### PR TITLE
Add unicode_word tokenizer

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/textindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/textindexes.md
@@ -170,6 +170,7 @@ ALTER TABLE table DROP INDEX text_idx;
   Compared to `ngrams(N)`, the `sparseGrams` tokenizer produces variable-length N-grams, allowing for a more flexible representation of the original text.
   For example, `tokenizer = sparseGrams(3, 5, 4)` internally generates 3-, 4-, 5-grams from the input string but only the 4- and 5-grams are returned.
 - `array` performs no tokenization, i.e. every row value is a token (see function [array](/sql-reference/functions/array-functions.md/#array)).
+- `unicode_word` splits strings into tokens using Unicode word boundary rules (similar to UAX #29). ASCII alphanumeric characters and underscores form tokens with connectors (`:` for letters, `.` and `'` for same-type characters). Non-ASCII Unicode characters become single-character tokens. Stop words (configurable, defaults to common CJK punctuation) are skipped. An optional parameter `stop_words` can be specified as an array of strings, for example, `tokenizer = unicode_word(['，', '。'])`.
 
 All available tokenizers are listed in [system.tokenizers](../../../operations/system-tables/tokenizers.md).
 

--- a/docs/en/operations/system-tables/tokenizers.md
+++ b/docs/en/operations/system-tables/tokenizers.md
@@ -36,5 +36,6 @@ SELECT * FROM system.tokenizers;
 │ array           │
 │ splitByString   │
 │ sparse_grams    │
+│ unicode_word    │
 └─────────────────┘
 ```

--- a/src/Functions/tokens.cpp
+++ b/src/Functions/tokens.cpp
@@ -253,6 +253,8 @@ public:
                     optional_args.emplace_back("ngrams", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isUInt8), isColumnConst, "const UInt8");
                 else if (tokenizer == SplitByStringTokenizer::getExternalName())
                     optional_args.emplace_back("separators", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isArray), isColumnConst, "const Array");
+                else if (tokenizer == UnicodeWordTokenizer::getExternalName())
+                    optional_args.emplace_back("stop_words", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isArray), isColumnConst, "const Array");
             }
             else if (arguments.size() == 4 || arguments.size() == 5)
             {
@@ -303,6 +305,7 @@ Available tokenizers:
 - `ngrams(N)` splits strings into equally large `N`-grams (also see function [ngrams](/sql-reference/functions/splitting-merging-functions.md/#ngrams)). The ngram length can be specified using an optional integer parameter between 1 and 8, for example, `tokens(value, 'ngrams', 3)`. The default ngram size, if not specified explicitly, is 3.
 - `sparseGrams(min_length, max_length, min_cutoff_length)` splits strings into variable-length n-grams of at least `min_length` and at most `max_length` (inclusive) characters (also see function [sparseGrams](/sql-reference/functions/string-functions#sparseGrams)). Unless specified explicitly, `min_length` and `max_length` default to 3 and 100. If parameter `min_cutoff_length` is provided, only n-grams with length greater or equal than `min_cutoff_length` are returned. Compared to `ngrams(N)`, the `sparseGrams` tokenizer produces variable-length N-grams, allowing for a more flexible representation of the original text. For example, `tokens(value, 'sparseGrams', 3, 5, 4)` internally generates 3-, 4-, 5-grams from the input string but only the 4- and 5-grams are returned.
 - `array` performs no tokenization, i.e. every row value is a token (also see function [array](/sql-reference/functions/array-functions.md/#array)).
+- `unicode_word` splits strings into tokens using Unicode word boundary rules (similar to UAX #29). ASCII alphanumeric characters and underscores form tokens with connectors (`:` for letters, `.` and `'` for same-type characters). Non-ASCII Unicode characters become single-character tokens. Stop words (configurable, defaults to common CJK punctuation) are skipped. An optional parameter `stop_words` can be specified as an array of strings, for example, `tokens(value, 'unicode_word', ['，', '。'])`.
 
 In case of the `splitByString` tokenizer, if the tokens do not form a [prefix code](https://en.wikipedia.org/wiki/Prefix_code), you likely want that the matching prefers longer separators first.
 To do so, pass the separators in order of descending length.
@@ -315,15 +318,17 @@ tokens(value, 'splitByString'[, separators])
 tokens(value, 'ngrams'[, n])
 tokens(value, 'sparseGrams'[, min_length, max_length[, min_cutoff_length]])
 tokens(value, 'array')
+tokens(value, 'unicode_word'[, stop_words])
 )";
     FunctionDocumentation::Arguments arguments = {
         {"value", "The input string.", {"String", "FixedString"}},
-        {"tokenizer", "The tokenizer to use. Valid arguments are `splitByNonAlpha`, `ngrams`, `splitByString`, `array`, and `sparseGrams`. Optional, if not set explicitly, defaults to `splitByNonAlpha`.", {"const String"}},
+        {"tokenizer", "The tokenizer to use. Valid arguments are `splitByNonAlpha`, `ngrams`, `splitByString`, `array`, `sparseGrams`, and `unicode_word`. Optional, if not set explicitly, defaults to `splitByNonAlpha`.", {"const String"}},
         {"n", "Only relevant if argument `tokenizer` is `ngrams`: An optional parameter which defines the length of the ngrams. If not set explicitly, defaults to `3`.", {"const UInt8"}},
         {"separators", "Only relevant if argument `tokenizer` is `split`: An optional parameter which defines the separator strings. If not set explicitly, defaults to `[' ']`.", {"const Array(String)"}},
         {"min_length", "Only relevant if argument `tokenizer` is `sparseGrams`: An optional parameter which defines the minimum gram length, defaults to 3.", {"const UInt8"}},
         {"max_length", "Only relevant if argument `tokenizer` is `sparseGrams`: An optional parameter which defines the maximum gram length, defaults to 100.", {"const UInt8"}},
-        {"min_cutoff_length", "Only relevant if argument `tokenizer` is `sparseGrams`: An optional parameter which defines the minimum cutoff length.", {"const UInt8"}}
+        {"min_cutoff_length", "Only relevant if argument `tokenizer` is `sparseGrams`: An optional parameter which defines the minimum cutoff length.", {"const UInt8"}},
+        {"stop_words", "Only relevant if argument `tokenizer` is `unicode_word`: An optional parameter which defines the stop words. If not set explicitly, defaults to common CJK punctuation marks.", {"const Array(String)"}},
     };
     FunctionDocumentation::ReturnedValue returned_value = {"Returns the resulting array of tokens from input string.", {"Array"}};
     FunctionDocumentation::Examples examples = {

--- a/src/Interpreters/ITokenizer.cpp
+++ b/src/Interpreters/ITokenizer.cpp
@@ -159,40 +159,46 @@ bool SplitByNonAlphaTokenizer::nextInStringLike(const char * data, size_t length
     return !bad_token && !token.empty();
 }
 
-void SplitByNonAlphaTokenizer::substringToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter, bool is_prefix, bool is_suffix) const
-{
-    size_t cur = 0;
-    size_t token_start = 0;
-    size_t token_len = 0;
-
-    while (cur < length && nextInString(data, length, cur, token_start, token_len))
-    {
-        /// In order to avoid filter updates with incomplete tokens, first token is ignored unless substring is prefix,
-        /// and last token is ignored, unless substring is suffix. See comment below for example
-        if ((token_start > 0 || is_prefix) && (token_start + token_len < length || is_suffix))
-            bloom_filter.add(data + token_start, token_len);
-    }
-}
-
-void SplitByNonAlphaTokenizer::substringToTokens(const char * data, size_t length, std::vector<String> & tokens, bool is_prefix, bool is_suffix) const
-{
-    size_t cur = 0;
-    size_t token_start = 0;
-    size_t token_len = 0;
-
-    while (cur < length && nextInString(data, length, cur, token_start, token_len))
-    {
-        /// In order to avoid adding incomplete tokens, first token is ignored unless substring is prefix and last token is ignored, unless substring is suffix.
-        /// Ex: If we want to match row "Service is not ready", and substring is "Serv" or "eady", we don't want to add either
-        /// of these substrings as tokens since they will not match any of the real tokens. However if our token string is
-        /// "Service " or " not ", we want to add these full tokens to our tokens vector.
-        if ((token_start > 0 || is_prefix) && (token_start + token_len < length || is_suffix))
-            tokens.push_back({data + token_start, token_len});
-    }
-}
-
 namespace
 {
+
+/// Shared implementation of `substringToBloomFilter` for word-boundary tokenizers
+/// (`SplitByNonAlphaTokenizer`, `UnicodeWordTokenizer`).
+///
+/// In order to avoid filter updates with incomplete tokens, the first token is
+/// ignored unless the substring is a prefix, and the last token is ignored unless
+/// the substring is a suffix.
+/// Ex: If we want to match row "Service is not ready", and substring is "Serv"
+/// or "eady", we don't want to add either of these substrings as tokens since
+/// they will not match any of the real tokens. However if our token string is
+/// "Service " or " not ", we want to add these full tokens to our bloom filter.
+template <typename Tokenizer>
+void wordBoundarySubstringToBloomFilter(
+    const Tokenizer & tokenizer, const char * data, size_t length, BloomFilter & bloom_filter, bool is_prefix, bool is_suffix)
+{
+    size_t cur = 0;
+    size_t token_start = 0;
+    size_t token_len = 0;
+
+    while (cur < length && tokenizer.nextInString(data, length, cur, token_start, token_len))
+        if ((token_start > 0 || is_prefix) && (token_start + token_len < length || is_suffix))
+            bloom_filter.add(data + token_start, token_len);
+}
+
+/// Shared implementation of `substringToTokens` for word-boundary tokenizers.
+/// Same boundary-filtering logic as `wordBoundarySubstringToBloomFilter`.
+template <typename Tokenizer>
+void wordBoundarySubstringToTokens(
+    const Tokenizer & tokenizer, const char * data, size_t length, std::vector<String> & tokens, bool is_prefix, bool is_suffix)
+{
+    size_t cur = 0;
+    size_t token_start = 0;
+    size_t token_len = 0;
+
+    while (cur < length && tokenizer.nextInString(data, length, cur, token_start, token_len))
+        if ((token_start > 0 || is_prefix) && (token_start + token_len < length || is_suffix))
+            tokens.push_back({data + token_start, token_len});
+}
 
 bool startsWithSeparator(const char * data, size_t length, size_t pos, const std::vector<String> & separators, std::string & matched_sep)
 {
@@ -208,6 +214,18 @@ bool startsWithSeparator(const char * data, size_t length, size_t pos, const std
     return false;
 }
 
+}
+
+void SplitByNonAlphaTokenizer::substringToBloomFilter(
+    const char * data, size_t length, BloomFilter & bloom_filter, bool is_prefix, bool is_suffix) const
+{
+    wordBoundarySubstringToBloomFilter(*this, data, length, bloom_filter, is_prefix, is_suffix);
+}
+
+void SplitByNonAlphaTokenizer::substringToTokens(
+    const char * data, size_t length, std::vector<String> & tokens, bool is_prefix, bool is_suffix) const
+{
+    wordBoundarySubstringToTokens(*this, data, length, tokens, is_prefix, is_suffix);
 }
 
 bool SplitByStringTokenizer::nextInString(const char * data, size_t length, size_t & pos, size_t & token_start, size_t & token_length) const
@@ -637,14 +655,18 @@ bool UnicodeWordTokenizer::nextInStringLike(const char * data, size_t length, si
             /// discarded, since their boundaries are ambiguous.
             if (token_alnum_count > 0 && (!last_glob_pos || (*last_glob_pos + 1 != pos && *last_glob_pos + 1 != token_start)))
             {
+                /// If we consumed a backslash but the escaped char didn't continue the token, back up so the next call
+                /// re-parses `\X` with proper escape context.
+                if (escaped)
+                {
+                    --pos;
+                    escaped = false;
+                }
+
                 /// Check if token is a stop word
                 if (stop_words.contains(token))
                     continue;
 
-                /// If we consumed a backslash but the escaped char didn't continue the token, back up so the next call
-                /// re-parses `\X` with proper escape context.
-                if (escaped)
-                    --pos;
                 return true;
             }
 
@@ -666,10 +688,10 @@ bool UnicodeWordTokenizer::nextInStringLike(const char * data, size_t length, si
         /// Unicode character
         size_t char_len = UTF8::seqLength(static_cast<UInt8>(c));
 
-        /// Prevent out-of-bounds
+        /// Truncated UTF-8 sequence at end of buffer
         if (pos + char_len > length)
         {
-            pos += char_len;
+            pos = length;
             escaped = false;
             continue;
         }
@@ -694,33 +716,13 @@ bool UnicodeWordTokenizer::nextInStringLike(const char * data, size_t length, si
 void UnicodeWordTokenizer::substringToBloomFilter(
     const char * data, size_t length, BloomFilter & bloom_filter, bool is_prefix, bool is_suffix) const
 {
-    size_t cur = 0;
-    size_t token_start = 0;
-    size_t token_len = 0;
-
-    while (cur < length && nextInString(data, length, cur, token_start, token_len))
-        /// In order to avoid filter updates with incomplete tokens,
-        /// first token is ignored, unless substring is prefix and
-        /// last token is ignored, unless substring is suffix
-        if ((token_start > 0 || is_prefix) && (token_start + token_len < length || is_suffix))
-            bloom_filter.add(data + token_start, token_len);
+    wordBoundarySubstringToBloomFilter(*this, data, length, bloom_filter, is_prefix, is_suffix);
 }
 
 void UnicodeWordTokenizer::substringToTokens(
     const char * data, size_t length, std::vector<String> & tokens, bool is_prefix, bool is_suffix) const
 {
-    size_t cur = 0;
-    size_t token_start = 0;
-    size_t token_len = 0;
-
-    while (cur < length && nextInString(data, length, cur, token_start, token_len))
-    {
-        /// In order to avoid filter updates with incomplete tokens,
-        /// first token is ignored, unless substring is prefix and
-        /// last token is ignored, unless substring is suffix
-        if ((token_start > 0 || is_prefix) && (token_start + token_len < length || is_suffix))
-            tokens.push_back({data + token_start, token_len});
-    }
+    wordBoundarySubstringToTokens(*this, data, length, tokens, is_prefix, is_suffix);
 }
 
 }

--- a/src/Interpreters/ITokenizer.cpp
+++ b/src/Interpreters/ITokenizer.cpp
@@ -409,4 +409,318 @@ void forEachTokenToBloomFilter(const ITokenizer & tokenizer, const char * data, 
         });
 }
 
+bool UnicodeWordTokenizer::nextInString(
+    const char * data, size_t length, size_t & __restrict pos, size_t & __restrict token_start, size_t & __restrict token_length) const
+{
+    token_length = 0;
+    while (pos < length)
+    {
+        token_start = pos;
+        char c = data[pos];
+
+        /// 1. ASCII fast path
+
+        if (isAlphaNumericASCII(c) || c == '_')
+        {
+            size_t token_alnum_count = 0;
+            token_length = 0;
+
+            while (pos < length)
+            {
+                char cur = data[pos];
+
+                /// 1a. ASCII letter or digit
+                if (isAlphaNumericASCII(cur))
+                {
+                    ++pos;
+                    ++token_length;
+                    ++token_alnum_count;
+                    continue;
+                }
+
+                /// 1b. Underscore
+                if (cur == '_')
+                {
+                    ++pos;
+                    ++token_length;
+                    continue;
+                }
+
+                /// Check if next character exists
+                if (pos + 1 >= length)
+                    break;
+
+                char next_c = data[pos + 1];
+                char prev_c = pos > 0 ? data[pos - 1] : '\0';
+
+                /// 1c. Colon: connects letters only
+                if (cur == ':' && isAlphaASCII(prev_c) && isAlphaASCII(next_c))
+                {
+                    ++pos;
+                    ++token_length;
+                    continue;
+                }
+
+                /// 1d. Dot or single quote: connects letter-letter or digit-digit
+                if ((cur == '.' || cur == '\'') &&
+                    ((isAlphaASCII(prev_c) && isAlphaASCII(next_c)) ||
+                     (isNumericASCII(prev_c) && isNumericASCII(next_c))))
+                {
+                    ++pos;
+                    ++token_length;
+                    continue;
+                }
+
+                /// Token ends
+                break;
+            }
+
+            /// Token must contain at least one alphanumeric character
+            if (token_alnum_count > 0)
+            {
+                /// Check if token is a stop word
+                std::string_view token_view(data + token_start, token_length);
+                if (stop_words.contains(token_view))
+                {
+                    token_length = 0;
+                    continue;
+                }
+                return true;
+            }
+
+            /// Invalid token (underscore only), continue searching
+            token_length = 0;
+            continue;
+        }
+
+        /// 2. ASCII non-alphanumeric: skip
+
+        if (isASCII(c))
+        {
+            ++pos;
+            continue;
+        }
+
+        /// 3. Unicode character handling
+
+        size_t char_len = UTF8::seqLength(static_cast<UInt8>(c));
+
+        /// Truncated UTF-8 sequence at end of buffer
+        if (pos + char_len > length)
+        {
+            pos = length;
+            return false;
+        }
+
+        std::string_view utf8_char(data + pos, char_len);
+
+        /// 3a. Stop words: skip
+        if (stop_words.contains(utf8_char))
+        {
+            pos += char_len;
+            continue;
+        }
+
+        token_start = pos;
+        token_length = char_len;
+        pos += char_len;
+
+        return true;
+    }
+
+    return false;
+}
+
+bool UnicodeWordTokenizer::nextInStringLike(const char * data, size_t length, size_t & __restrict pos, String & token) const
+{
+    token.clear();
+    size_t token_start;
+    std::optional<size_t> last_glob_pos;
+    bool escaped = false; /// Whether current char is an escaped char
+    while (pos < length)
+    {
+        token_start = pos;
+        char c = data[pos];
+
+        if (c == '\\' && !escaped)
+        {
+            if (pos + 1 >= length)
+                break;
+            ++pos;
+            c = data[pos];
+            escaped = true;
+        }
+
+        /// ASCII alphanumeric or escaped underscore
+        if (isAlphaNumericASCII(c) || (c == '_' && escaped))
+        {
+            size_t token_alnum_count = 0;
+            token.clear();
+
+            while (pos < length)
+            {
+                char cur = data[pos];
+                if (cur == '\\' && !escaped)
+                {
+                    if (pos + 1 >= length)
+                        break;
+                    ++pos;
+                    cur = data[pos];
+                    escaped = true;
+                }
+
+                /// 1a. ASCII letter or digit
+                if (isAlphaNumericASCII(cur))
+                {
+                    ++pos;
+                    escaped = false;
+                    token.push_back(cur);
+                    ++token_alnum_count;
+                    continue;
+                }
+
+                /// 1b. Underscore
+                if (cur == '_' && escaped)
+                {
+                    ++pos;
+                    escaped = false;
+                    token.push_back(cur);
+                    continue;
+                }
+
+                /// Wildcard
+                if (cur == '_' || (cur == '%' && !escaped))
+                {
+                    last_glob_pos = pos;
+                    ++pos;
+                    break;
+                }
+
+                /// Check if next character exists
+                if (pos + 1 >= length)
+                    break;
+
+                char next_c = data[pos + 1];
+                if (next_c == '\\')
+                {
+                    if (pos + 2 >= length)
+                        break;
+                    next_c = data[pos + 2];
+                }
+                char prev_c = token.empty() ? '\0' : token.back();
+
+                /// 1c. Colon: connects letters only
+                if (cur == ':' && isAlphaASCII(prev_c) && isAlphaASCII(next_c))
+                {
+                    ++pos;
+                    escaped = false;
+                    token.push_back(cur);
+                    continue;
+                }
+
+                /// 1d. Dot or single quote: connects letter-letter or digit-digit
+                if ((cur == '.' || cur == '\'') &&
+                    ((isAlphaASCII(prev_c) && isAlphaASCII(next_c)) ||
+                     (isNumericASCII(prev_c) && isNumericASCII(next_c))))
+                {
+                    ++pos;
+                    escaped = false;
+                    token.push_back(cur);
+                    continue;
+                }
+
+                /// Token ends
+                break;
+            }
+
+            /// Token must contain at least one alphanumeric character. Tokens adjacent to unescaped wildcards are
+            /// discarded, since their boundaries are ambiguous.
+            if (token_alnum_count > 0 && (!last_glob_pos || (*last_glob_pos + 1 != pos && *last_glob_pos + 1 != token_start)))
+            {
+                /// Check if token is a stop word
+                if (stop_words.contains(token))
+                    continue;
+
+                /// If we consumed a backslash but the escaped char didn't continue the token, back up so the next call
+                /// re-parses `\X` with proper escape context.
+                if (escaped)
+                    --pos;
+                return true;
+            }
+
+            /// Invalid token, continue searching
+            continue;
+        }
+
+        /// Skip ASCII non-alphanumeric
+        if (isASCII(c))
+        {
+            if (!escaped && (c == '_' || c == '%'))
+                last_glob_pos = pos;
+
+            ++pos;
+            escaped = false;
+            continue;
+        }
+
+        /// Unicode character
+        size_t char_len = UTF8::seqLength(static_cast<UInt8>(c));
+
+        /// Prevent out-of-bounds
+        if (pos + char_len > length)
+        {
+            pos += char_len;
+            escaped = false;
+            continue;
+        }
+
+        token = {data + pos, char_len};
+
+        /// 3a. Stop words: skip
+        if (stop_words.contains(token))
+        {
+            pos += char_len;
+            escaped = false;
+            continue;
+        }
+
+        pos += char_len;
+        return true;
+    }
+
+    return false;
+}
+
+void UnicodeWordTokenizer::substringToBloomFilter(
+    const char * data, size_t length, BloomFilter & bloom_filter, bool is_prefix, bool is_suffix) const
+{
+    size_t cur = 0;
+    size_t token_start = 0;
+    size_t token_len = 0;
+
+    while (cur < length && nextInString(data, length, cur, token_start, token_len))
+        /// In order to avoid filter updates with incomplete tokens,
+        /// first token is ignored, unless substring is prefix and
+        /// last token is ignored, unless substring is suffix
+        if ((token_start > 0 || is_prefix) && (token_start + token_len < length || is_suffix))
+            bloom_filter.add(data + token_start, token_len);
+}
+
+void UnicodeWordTokenizer::substringToTokens(
+    const char * data, size_t length, std::vector<String> & tokens, bool is_prefix, bool is_suffix) const
+{
+    size_t cur = 0;
+    size_t token_start = 0;
+    size_t token_len = 0;
+
+    while (cur < length && nextInString(data, length, cur, token_start, token_len))
+    {
+        /// In order to avoid filter updates with incomplete tokens,
+        /// first token is ignored, unless substring is prefix and
+        /// last token is ignored, unless substring is suffix
+        if ((token_start > 0 || is_prefix) && (token_start + token_len < length || is_suffix))
+            tokens.push_back({data + token_start, token_len});
+    }
+}
+
 }

--- a/src/Interpreters/ITokenizer.h
+++ b/src/Interpreters/ITokenizer.h
@@ -427,8 +427,7 @@ struct UnicodeWordTokenizer final : public ITokenizerHelper<UnicodeWordTokenizer
 
     bool nextInStringLike(const char * data, size_t length, size_t & pos, String & token) const override;
 
-    void
-    substringToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter, bool is_prefix, bool is_suffix) const override;
+    void substringToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter, bool is_prefix, bool is_suffix) const override;
 
     void substringToTokens(const char * data, size_t length, std::vector<String> & tokens, bool is_prefix, bool is_suffix) const override;
 

--- a/src/Interpreters/ITokenizer.h
+++ b/src/Interpreters/ITokenizer.h
@@ -8,6 +8,8 @@
 #include <base/types.h>
 #include <fmt/format.h>
 
+#include <absl/container/flat_hash_set.h>
+
 #if defined(__SSE2__)
 #  include <emmintrin.h>
 #  if defined(__SSE4_2__)
@@ -29,6 +31,7 @@ public:
         SplitByString,
         Array,
         SparseGrams,
+        UnicodeWord,
     };
 
     ITokenizer() = default;
@@ -359,6 +362,82 @@ private:
     mutable size_t previous_len = 0;
 };
 
+/// Split text into tokens using Unicode word boundary rules, similar to UAX #29.
+/// 1. ASCII Alphanumeric Tokens
+///
+/// * ASCII letters (`A-Z`, `a-z`) and digits (`0-9`) are accumulated into tokens.
+/// * `_` can appear at the **start, middle, or end** of a token, but a token cannot be **only `_` characters**.
+///
+///   * E.g., `a_b` -> token
+///   * `_a` -> token
+///   * `__` -> ignored (no alphanumeric)
+///
+/// 2. Connectors
+///
+/// * `:` connects **letters only**, not digits.
+/// * `.` and `'` connect **letters-letters** or **digits-digits**.
+/// * If the connector cannot connect both sides, it is treated as a **token boundary**.
+///
+/// 3. Unicode / Chinese
+///
+/// * Chinese characters are **always single-character tokens**.
+/// * Certain Unicode punctuation (Chinese punctuation) are **stop characters** and **break tokens**.
+///
+/// 4. Token Validity
+///
+/// * Tokens must contain at least **one ASCII letter or digit** to be valid.
+/// * Connectors `_`, `:`, `.`, `'` cannot form a token by themselves.
+/// * `_` can start or end the token but must **not be the only character**.
+///
+/// 5. Stream Processing
+///
+/// * Tokenization is **stream-based** -- return tokens as soon as they are complete.
+/// * ASCII fast path should be taken first for performance.
+/// * Only parse Unicode for **non-ASCII characters or stop characters**.
+///
+/// ---
+///
+/// Examples
+///
+/// | Input                    | Output Tokens                         |
+/// | ------------------------ | ------------------------------------- |
+/// | `a_b a_3 a_ _a __a_b_3_` | `['a_b','a_3','a_','_a','__a_b_3_']`  |
+/// | `3_b 3_3 3_ _3 __3_4_3_` | `['3_b','3_3','3_','_3','__3_4_3_']`  |
+/// | `a:b a:3 a: :a ::a:b:3:` | `['a:b','a','3','a','a','a:b','3']`   |
+/// | `a'b a'3 a' 'a ''a'b'3'` | `['a\'b','a','3','a','a','a\'b','3']` |
+/// | `a.b a.3 a. .a ..a.b.3.` | `['a.b','a','3','a','a','a.b','3']`   |
+struct UnicodeWordTokenizer final : public ITokenizerHelper<UnicodeWordTokenizer>
+{
+    explicit UnicodeWordTokenizer(const std::vector<String> & stop_words_)
+        : ITokenizerHelper(Type::UnicodeWord)
+        , stop_words(stop_words_.begin(), stop_words_.end())
+    {
+    }
+
+    static const char * getName() { return "unicode_word"; }
+    static const char * getExternalName() { return getName(); }
+    String getDescription() const override { return getName(); }
+
+    bool nextInString(
+        const char * data,
+        size_t length,
+        size_t & __restrict pos,
+        size_t & __restrict token_start,
+        size_t & __restrict token_length) const override;
+
+    bool nextInStringLike(const char * data, size_t length, size_t & pos, String & token) const override;
+
+    void
+    substringToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter, bool is_prefix, bool is_suffix) const override;
+
+    void substringToTokens(const char * data, size_t length, std::vector<String> & tokens, bool is_prefix, bool is_suffix) const override;
+
+    bool supportsStringLike() const override { return true; }
+
+private:
+    absl::flat_hash_set<String> stop_words;
+};
+
 namespace detail
 {
 
@@ -419,6 +498,12 @@ void forEachToken(const ITokenizer & tokenizer, const char * __restrict data, si
         {
             const auto & sparse_grams_tokenizer = assert_cast<const SparseGramsTokenizer &>(tokenizer);
             detail::forEachTokenImpl(sparse_grams_tokenizer, data, length, callback);
+            return;
+        }
+        case ITokenizer::Type::UnicodeWord:
+        {
+            const auto & unicode_word_tokenizer = assert_cast<const UnicodeWordTokenizer &>(tokenizer);
+            detail::forEachTokenImpl(unicode_word_tokenizer, data, length, callback);
             return;
         }
     }

--- a/src/Interpreters/TokenizerFactory.cpp
+++ b/src/Interpreters/TokenizerFactory.cpp
@@ -264,6 +264,29 @@ static void registerTokenizers(TokenizerFactory & factory)
 
     factory.registerTokenizer(SparseGramsTokenizer::getName(), ITokenizer::Type::SparseGrams, sparse_grams_creator);
     factory.registerTokenizer(SparseGramsTokenizer::getBloomFilterIndexName(), ITokenizer::Type::SparseGrams, sparse_grams_creator);
+
+    auto unicode_word_creator = [](const FieldVector & args) -> std::unique_ptr<ITokenizer>
+    {
+        const auto * tokenizer_name = UnicodeWordTokenizer::getExternalName();
+        assertParamsCount(args.size(), 1, tokenizer_name);
+
+        std::vector<String> stop_words;
+        if (args.empty())
+        {
+            /// Default stop words: common CJK punctuation marks
+            stop_words = {"，", "。", "！", "？", "；", "：", "、", "‘", "’", "“", "”"};
+        }
+        else
+        {
+            auto array = castAs<Array>(args[0], "stop_words");
+            for (const auto & value : array)
+                stop_words.emplace_back(castAs<String>(value, "stop_word"));
+        }
+
+        return std::make_unique<UnicodeWordTokenizer>(stop_words);
+    };
+
+    factory.registerTokenizer(UnicodeWordTokenizer::getName(), ITokenizer::Type::UnicodeWord, unicode_word_creator);
 }
 
 }

--- a/tests/performance/search_tokens.xml
+++ b/tests/performance/search_tokens.xml
@@ -3,6 +3,7 @@
     <query>SELECT tokens(URL, 'ngrams', 3) FROM hits_10m_single FORMAT Null</query>
     <query>SELECT tokens(URL, 'splitByString', ['/', '.', ':']) FROM hits_10m_single FORMAT Null</query>
     <query>SELECT tokens(URL, 'array') FROM hits_10m_single FORMAT Null</query>
+    <query>SELECT tokens(URL, 'unicode_word') FROM hits_10m_single FORMAT Null</query>
 
     <query>SELECT count() FROM hits_10m_single WHERE hasAllTokens(URL, ['market'])</query>
     <query>SELECT count() FROM hits_10m_single WHERE hasAllTokens(URL, ['market', 'video', 'com'])</query>

--- a/tests/queries/0_stateless/02346_system_tokenizers.reference
+++ b/tests/queries/0_stateless/02346_system_tokenizers.reference
@@ -6,3 +6,4 @@ sparse_grams
 splitByNonAlpha
 splitByString
 tokenbf_v1
+unicode_word

--- a/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.reference
+++ b/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.reference
@@ -72,3 +72,6 @@ SELECT tokens('测试数据', 'unicode_word'), tokensForLikePattern('%测试，�
 ['测','试','数','据']	['测','试','数','据']
 SELECT tokens('test_data', 'unicode_word'), tokensForLikePattern('test\_%data', 'unicode_word');
 ['test_data']	[]
+-- Stop word followed by escaped character in LIKE pattern (exercises escaped-state reset before stop word check)
+SELECT tokens('and%test', 'unicode_word', ['and']), tokensForLikePattern('and\%test', 'unicode_word', ['and']);
+['test']	['test']

--- a/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.reference
+++ b/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.reference
@@ -53,3 +53,22 @@ SELECT tokens('%%%%'), tokensForLikePattern('%%%%');
 []	[]
 SELECT tokens('____'), tokensForLikePattern('____');
 []	[]
+-- unicode_word tokenizer
+SELECT 'unicode_word:';
+unicode_word:
+SELECT tokens('hello', 'unicode_word'), tokensForLikePattern('hello', 'unicode_word');
+['hello']	['hello']
+SELECT tokens('你好世界', 'unicode_word'), tokensForLikePattern('你好世界', 'unicode_word');
+['你','好','世','界']	['你','好','世','界']
+SELECT tokens('hello', 'unicode_word'), tokensForLikePattern('%hello%', 'unicode_word');
+['hello']	[]
+SELECT tokens('hello_world', 'unicode_word'), tokensForLikePattern('hello\_world%', 'unicode_word');
+['hello_world']	[]
+SELECT tokens('你好世界', 'unicode_word'), tokensForLikePattern('%你好%世界%', 'unicode_word');
+['你','好','世','界']	['你','好','世','界']
+SELECT tokens('a:bc.d', 'unicode_word'), tokensForLikePattern('a:b%c.d', 'unicode_word');
+['a:bc.d']	[]
+SELECT tokens('测试数据', 'unicode_word'), tokensForLikePattern('%测试，数据%', 'unicode_word');
+['测','试','数','据']	['测','试','数','据']
+SELECT tokens('test_data', 'unicode_word'), tokensForLikePattern('test\_%data', 'unicode_word');
+['test_data']	[]

--- a/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.sql
+++ b/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.sql
@@ -34,3 +34,14 @@ SELECT tokens('\\\\%test'), tokensForLikePattern('\\\\%test');
 SELECT tokens('abc%d'), tokensForLikePattern('abc%d');
 SELECT tokens('%%%%'), tokensForLikePattern('%%%%');
 SELECT tokens('____'), tokensForLikePattern('____');
+
+-- unicode_word tokenizer
+SELECT 'unicode_word:';
+SELECT tokens('hello', 'unicode_word'), tokensForLikePattern('hello', 'unicode_word');
+SELECT tokens('你好世界', 'unicode_word'), tokensForLikePattern('你好世界', 'unicode_word');
+SELECT tokens('hello', 'unicode_word'), tokensForLikePattern('%hello%', 'unicode_word');
+SELECT tokens('hello_world', 'unicode_word'), tokensForLikePattern('hello\_world%', 'unicode_word');
+SELECT tokens('你好世界', 'unicode_word'), tokensForLikePattern('%你好%世界%', 'unicode_word');
+SELECT tokens('a:bc.d', 'unicode_word'), tokensForLikePattern('a:b%c.d', 'unicode_word');
+SELECT tokens('测试数据', 'unicode_word'), tokensForLikePattern('%测试，数据%', 'unicode_word');
+SELECT tokens('test_data', 'unicode_word'), tokensForLikePattern('test\_%data', 'unicode_word');

--- a/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.sql
+++ b/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.sql
@@ -45,3 +45,5 @@ SELECT tokens('你好世界', 'unicode_word'), tokensForLikePattern('%你好%世
 SELECT tokens('a:bc.d', 'unicode_word'), tokensForLikePattern('a:b%c.d', 'unicode_word');
 SELECT tokens('测试数据', 'unicode_word'), tokensForLikePattern('%测试，数据%', 'unicode_word');
 SELECT tokens('test_data', 'unicode_word'), tokensForLikePattern('test\_%data', 'unicode_word');
+-- Stop word followed by escaped character in LIKE pattern (exercises escaped-state reset before stop word check)
+SELECT tokens('and%test', 'unicode_word', ['and']), tokensForLikePattern('and\%test', 'unicode_word', ['and']);

--- a/tests/queries/0_stateless/04038_unicode_word_tokenizer.reference
+++ b/tests/queries/0_stateless/04038_unicode_word_tokenizer.reference
@@ -1,0 +1,76 @@
+-- { echoOn }
+-- ascii
+select tokens('a_b a_3 a_ _a __a_b_3_', 'unicode_word');
+['a_b','a_3','a_','_a','__a_b_3_']
+select tokens('3_b 3_3 3_ _3 __3_4_3_', 'unicode_word');
+['3_b','3_3','3_','_3','__3_4_3_']
+select tokens('___ _3___a_ _a__a_b_c_ ___', 'unicode_word');
+['_3___a_','_a__a_b_c_']
+select tokens('a:b a:3 a: :a ::a:b:3:', 'unicode_word');
+['a:b','a','3','a','a','a:b','3']
+select tokens('3:b 3:3 3: :3 ::3:4:3:', 'unicode_word');
+['3','b','3','3','3','3','3','4','3']
+select tokens('::: :3:::a: :a::a:b:c: :::', 'unicode_word');
+['3','a','a','a:b:c']
+select tokens($$a'b a'3 a' 'a ''a'b'3'$$, 'unicode_word');
+['a\'b','a','3','a','a','a\'b','3']
+select tokens($$3'b 3'3 3' '3 ''3'4'3'$$, 'unicode_word');
+['3','b','3\'3','3','3','3\'4\'3']
+select tokens($$''' '3'''a' 'a''a'b'c' '''$$, 'unicode_word');
+['3','a','a','a\'b\'c']
+select tokens($$a.b a.3 a. .a ..a.b.3.$$, 'unicode_word');
+['a.b','a','3','a','a','a.b','3']
+select tokens($$3.b 3.3 3. .3 ..3.4.3.$$, 'unicode_word');
+['3','b','3.3','3','3','3.4.3']
+select tokens($$... .3...a. .a..a.b.c. ...$$, 'unicode_word');
+['3','a','a','a.b.c']
+-- ascii and Chinese
+select tokens('错误503', 'unicode_word');
+['错','误','503']
+select tokens('taichi张三丰in the house', 'unicode_word');
+['taichi','张','三','丰','in','the','house']
+-- stop words
+select tokens('错误，503', 'unicode_word'); -- default stop words contains common full-width separators
+['错','误','503']
+select tokens('错误and 503', 'unicode_word', ['and']);
+['错','误','503']
+select tokensForLikePattern('%abc', 'unicode_word');            -- wildcard before token
+[]
+select tokensForLikePattern('abc%', 'unicode_word');            -- token before wildcard
+[]
+select tokensForLikePattern('a_b%c_d', 'unicode_word');         -- wildcard in between
+[]
+select tokensForLikePattern('a\%b a\_c', 'unicode_word');       -- escaped % breaks token (not alnum), escaped _ joins token
+['a','b','a_c']
+select tokensForLikePattern('a\_b%c', 'unicode_word');          -- mix escaped _ and unescaped %
+[]
+select tokensForLikePattern('a\_b\%c', 'unicode_word');         -- all escaped wildcards
+['a_b','c']
+select tokensForLikePattern('_a c%', 'unicode_word');           -- leading and trailing wildcards
+[]
+select tokensForLikePattern($$a:b%cd\_e.f'g$$, 'unicode_word'); -- mix colon, dot, single quote, wildcard, escaped _
+[]
+select tokensForLikePattern('%%__abc', 'unicode_word');         -- multiple leading wildcards
+[]
+select tokensForLikePattern('', 'unicode_word');                -- empty string
+[]
+select tokensForLikePattern('%%__', 'unicode_word');            -- only wildcards
+[]
+select tokensForLikePattern('你', 'unicode_word');              -- single Unicode char
+['你']
+select tokensForLikePattern('abc你好', 'unicode_word');         -- ASCII then Unicode
+['abc','你','好']
+select tokensForLikePattern('，。你好', 'unicode_word');        -- punctuation stop words skipped
+['你','好']
+select tokensForLikePattern('你好%世界', 'unicode_word');       -- Unicode token with wildcards
+['你','好','世','界']
+set enable_analyzer = 1;
+set enable_full_text_index = 1;
+drop table if exists tab;
+create table tab (key UInt64, str String, index text_idx(str) type text(tokenizer = unicode_word)) engine MergeTree order by key;
+insert into tab values (1, 'hello错误502需要处理kitty');
+explain estimate select * from tab where str like '%错误502需要%';
+default	tab	1	1	1
+explain estimate select * from tab where str like '%错误503需要%';
+default	tab	0	0	0
+drop table tab;

--- a/tests/queries/0_stateless/04038_unicode_word_tokenizer.reference
+++ b/tests/queries/0_stateless/04038_unicode_word_tokenizer.reference
@@ -34,6 +34,14 @@ select tokens('错误，503', 'unicode_word'); -- default stop words contains co
 ['错','误','503']
 select tokens('错误and 503', 'unicode_word', ['and']);
 ['错','误','503']
+-- edge cases
+select tokens('', 'unicode_word');                               -- empty string
+[]
+select tokens('a.b', 'unicode_word', ['.']);                     -- dot as stop word does not suppress connector
+['a.b']
+select tokens('a.b', 'unicode_word', ['a.b']);                   -- dot-connected token as stop word
+[]
+select tokens('test', 'unicode_word', 'not_an_array'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT } -- wrong stop_words type
 select tokensForLikePattern('%abc', 'unicode_word');            -- wildcard before token
 []
 select tokensForLikePattern('abc%', 'unicode_word');            -- token before wildcard

--- a/tests/queries/0_stateless/04038_unicode_word_tokenizer.sql
+++ b/tests/queries/0_stateless/04038_unicode_word_tokenizer.sql
@@ -24,6 +24,12 @@ select tokens('taichi张三丰in the house', 'unicode_word');
 select tokens('错误，503', 'unicode_word'); -- default stop words contains common full-width separators
 select tokens('错误and 503', 'unicode_word', ['and']);
 
+-- edge cases
+select tokens('', 'unicode_word');                               -- empty string
+select tokens('a.b', 'unicode_word', ['.']);                     -- dot as stop word does not suppress connector
+select tokens('a.b', 'unicode_word', ['a.b']);                   -- dot-connected token as stop word
+select tokens('test', 'unicode_word', 'not_an_array'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT } -- wrong stop_words type
+
 select tokensForLikePattern('%abc', 'unicode_word');            -- wildcard before token
 select tokensForLikePattern('abc%', 'unicode_word');            -- token before wildcard
 select tokensForLikePattern('a_b%c_d', 'unicode_word');         -- wildcard in between

--- a/tests/queries/0_stateless/04038_unicode_word_tokenizer.sql
+++ b/tests/queries/0_stateless/04038_unicode_word_tokenizer.sql
@@ -1,0 +1,57 @@
+-- { echoOn }
+-- ascii
+select tokens('a_b a_3 a_ _a __a_b_3_', 'unicode_word');
+select tokens('3_b 3_3 3_ _3 __3_4_3_', 'unicode_word');
+select tokens('___ _3___a_ _a__a_b_c_ ___', 'unicode_word');
+
+select tokens('a:b a:3 a: :a ::a:b:3:', 'unicode_word');
+select tokens('3:b 3:3 3: :3 ::3:4:3:', 'unicode_word');
+select tokens('::: :3:::a: :a::a:b:c: :::', 'unicode_word');
+
+select tokens($$a'b a'3 a' 'a ''a'b'3'$$, 'unicode_word');
+select tokens($$3'b 3'3 3' '3 ''3'4'3'$$, 'unicode_word');
+select tokens($$''' '3'''a' 'a''a'b'c' '''$$, 'unicode_word');
+
+select tokens($$a.b a.3 a. .a ..a.b.3.$$, 'unicode_word');
+select tokens($$3.b 3.3 3. .3 ..3.4.3.$$, 'unicode_word');
+select tokens($$... .3...a. .a..a.b.c. ...$$, 'unicode_word');
+
+-- ascii and Chinese
+select tokens('错误503', 'unicode_word');
+select tokens('taichi张三丰in the house', 'unicode_word');
+
+-- stop words
+select tokens('错误，503', 'unicode_word'); -- default stop words contains common full-width separators
+select tokens('错误and 503', 'unicode_word', ['and']);
+
+select tokensForLikePattern('%abc', 'unicode_word');            -- wildcard before token
+select tokensForLikePattern('abc%', 'unicode_word');            -- token before wildcard
+select tokensForLikePattern('a_b%c_d', 'unicode_word');         -- wildcard in between
+select tokensForLikePattern('a\%b a\_c', 'unicode_word');       -- escaped % breaks token (not alnum), escaped _ joins token
+select tokensForLikePattern('a\_b%c', 'unicode_word');          -- mix escaped _ and unescaped %
+select tokensForLikePattern('a\_b\%c', 'unicode_word');         -- all escaped wildcards
+select tokensForLikePattern('_a c%', 'unicode_word');           -- leading and trailing wildcards
+
+select tokensForLikePattern($$a:b%cd\_e.f'g$$, 'unicode_word'); -- mix colon, dot, single quote, wildcard, escaped _
+select tokensForLikePattern('%%__abc', 'unicode_word');         -- multiple leading wildcards
+select tokensForLikePattern('', 'unicode_word');                -- empty string
+select tokensForLikePattern('%%__', 'unicode_word');            -- only wildcards
+select tokensForLikePattern('你', 'unicode_word');              -- single Unicode char
+select tokensForLikePattern('abc你好', 'unicode_word');         -- ASCII then Unicode
+select tokensForLikePattern('，。你好', 'unicode_word');        -- punctuation stop words skipped
+select tokensForLikePattern('你好%世界', 'unicode_word');       -- Unicode token with wildcards
+
+set enable_analyzer = 1;
+set enable_full_text_index = 1;
+
+drop table if exists tab;
+
+create table tab (key UInt64, str String, index text_idx(str) type text(tokenizer = unicode_word)) engine MergeTree order by key;
+
+insert into tab values (1, 'hello错误502需要处理kitty');
+
+explain estimate select * from tab where str like '%错误502需要%';
+
+explain estimate select * from tab where str like '%错误503需要%';
+
+drop table tab;


### PR DESCRIPTION
Add a new `unicode_word` tokenizer that splits text using Unicode word boundary rules similar to UAX #29.

**Tokenization rules:**
- ASCII alphanumeric characters and underscores form tokens (underscore alone is not a valid token)
- Connectors: `:` connects letters only; `.` and `'` connect same-type characters (letter-letter or digit-digit)
- Non-ASCII Unicode characters become single-character tokens
- Stop words (configurable, defaults to common CJK punctuation) are filtered out

The tokenizer is registered in `TokenizerFactory` and automatically available for `text()` indexes and the `tokens`/`tokensForLikePattern` functions. It supports LIKE pattern matching via `nextInStringLike`.

This is the third and final PR split from #90268, following:
- #97871 — Refactor tokenization to `forEachToken` callback API
- #97872 — Add `tokensForLikePattern` function

### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Add `unicode_word` tokenizer for full-text indexes and the `tokens` function. It splits text using Unicode word boundary rules: ASCII words are formed with connector characters (underscore, colon, dot, single quote), while non-ASCII Unicode characters become single-character tokens. Configurable stop words default to common CJK punctuation.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new tokenizer used by full-text indexes and `tokens`/`tokensForLikePattern`, which can change query results and index behavior for users who opt into it; the LIKE-pattern parsing and UTF-8 handling paths increase surface area for edge-case bugs.
> 
> **Overview**
> **Adds a new `unicode_word` tokenizer** for text indexes and the `tokens`/`tokensForLikePattern` functions, providing Unicode-aware tokenization with ASCII connector rules and single-character non-ASCII tokens.
> 
> The tokenizer is **registered in `TokenizerFactory`** with configurable `stop_words` (defaulting to common CJK punctuation), wired into `forEachToken` dispatch, and exposed via updated docs and `system.tokenizers` output.
> 
> Extends function argument validation/docs for `tokens(...)` to accept `unicode_word` and its optional `stop_words`, and adds stateless tests covering tokenization, LIKE-pattern behavior, and text-index `LIKE` selectivity with the new tokenizer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 507d20690830a44d75e113c4441ebc1fd27a23d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.755`
<!-- ch-version-info:end -->