### PR TITLE
Fix too strict validation of text index preprocessor

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -843,7 +843,10 @@ bool MergeTreeIndexConditionText::tryPrepareSetForTextSearch(
         /// The condition with such a predicate will be always true on granule.
         /// See MergeTreeIndexGranuleText::hasAllQueryTokensOrEmpty.
         if (ref.empty())
+        {
+            out.text_search_queries.clear();
             return false;
+        }
 
         std::vector<String> tokens;
         tokenizer->stringToTokens(ref.data(), ref.size(), tokens);

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -1411,6 +1411,23 @@ MergeTreeIndexConditionPtr MergeTreeIndexText::createIndexCondition(const Action
     return std::make_shared<MergeTreeIndexConditionText>(predicate, context, index.sample_block, tokenizer.get(), preprocessor);
 }
 
+DataTypePtr MergeTreeIndexText::getNestedDataType(const DataTypePtr & data_type)
+{
+    DataTypePtr nested_type = data_type;
+    while (true)
+    {
+        if (const auto * array_type = typeid_cast<const DataTypeArray *>(nested_type.get()))
+            nested_type = array_type->getNestedType();
+        else if (const auto * nullable_type = typeid_cast<const DataTypeNullable *>(nested_type.get()))
+            nested_type = nullable_type->getNestedType();
+        else if (const auto * lc_type = typeid_cast<const DataTypeLowCardinality *>(nested_type.get()))
+            nested_type = lc_type->getDictionaryType();
+        else
+            break;
+    }
+    return nested_type;
+}
+
 static const String ARGUMENT_TOKENIZER = "tokenizer";
 static const String ARGUMENT_PREPROCESSOR = "preprocessor";
 static const String ARGUMENT_DICTIONARY_BLOCK_SIZE = "dictionary_block_size";
@@ -1558,25 +1575,15 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
     if (index.column_names.size() != 1 || index.data_types.size() != 1)
         throw Exception(ErrorCodes::INCORRECT_NUMBER_OF_COLUMNS, "Text index must be created on a single column");
 
-    DataTypePtr nested_type = index.data_types[0];
-    while (true)
-    {
-        if (const auto * array_type = typeid_cast<const DataTypeArray *>(nested_type.get()))
-            nested_type = array_type->getNestedType();
-        else if (const auto * nullable_type = typeid_cast<const DataTypeNullable *>(nested_type.get()))
-            nested_type = nullable_type->getNestedType();
-        else if (const auto * lc_type = typeid_cast<const DataTypeLowCardinality *>(nested_type.get()))
-            nested_type = lc_type->getDictionaryType();
-        else
-            break;
-    }
+    DataTypePtr index_data_type = index.data_types[0];
+    WhichDataType which_data_type(MergeTreeIndexText::getNestedDataType(index_data_type));
 
-    WhichDataType data_type(nested_type);
-    if (!data_type.isString() && !data_type.isFixedString())
+    if (!which_data_type.isString() && !which_data_type.isFixedString())
     {
         throw Exception(
             ErrorCodes::BAD_ARGUMENTS,
-            "Text index must be created on columns of type `String` or `FixedString`");
+            "Text index must be created on columns of type with base type of String or FixedString, got: {}",
+            index_data_type->getName());
     }
 
     /// Create the preprocessor for validation.

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -458,6 +458,7 @@ public:
     MergeTreeIndexConditionPtr createIndexCondition(const ActionsDAG::Node * predicate, ContextPtr context) const override;
 
     PostingListCodecPtr getPostingListCodec() const { return posting_list_codec.get(); }
+    static DataTypePtr getNestedDataType(const DataTypePtr & data_type);
 
     MergeTreeIndexTextParams params;
     std::unique_ptr<ITokenizer> tokenizer;

--- a/src/Storages/MergeTree/MergeTreeIndexTextPreprocessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPreprocessor.cpp
@@ -109,6 +109,7 @@ ASTPtr convertASTForConstant(const IndexDescription & index, const ASTPtr & expr
 ActionsDAG createActionsDAGForPreprocessor(
     const NamesAndTypesList & source_columns,
     const String & source_name,
+    const DataTypePtr & source_type,
     ASTPtr expression_ast)
 {
     if (expression_ast == nullptr)
@@ -132,11 +133,22 @@ ActionsDAG createActionsDAGForPreprocessor(
     if (outputs.front()->result_name == source_name)
         throw Exception(ErrorCodes::INCORRECT_QUERY, "The preprocessor must have at least one expression on top of the source column. Got '{}'", outputs.front()->result_name);
 
-    auto nested_type = MergeTreeIndexText::getNestedDataType(outputs.front()->result_type);
+    auto output_type = outputs.front()->result_type;
+    auto nested_type = MergeTreeIndexText::getNestedDataType(output_type);
     WhichDataType which_data_type(nested_type);
 
     if (!which_data_type.isString() && !which_data_type.isFixedString())
-        throw Exception(ErrorCodes::INCORRECT_QUERY, "The preprocessor expression should return a column of type with base type of String or FixedString, got: {}", outputs.front()->result_type->getName());
+        throw Exception(ErrorCodes::INCORRECT_QUERY, "The preprocessor expression should return a column of type with base type of String or FixedString, got: {}", output_type->getName());
+
+    auto get_array_dimensions = [](const DataTypePtr & type) -> size_t
+    {
+        if (const auto * array_type = typeid_cast<const DataTypeArray *>(type.get()))
+            return array_type->getNumberOfDimensions();
+        return 0;
+    };
+
+    if (get_array_dimensions(source_type) != get_array_dimensions(output_type))
+        throw Exception(ErrorCodes::INCORRECT_QUERY, "The preprocessor expression must not change the array dimensions of the source column. Source type: '{}', preprocessor result type: '{}'", source_type->getName(), output_type->getName());
 
     if (actions_dag.hasNonDeterministic())
         throw Exception(ErrorCodes::INCORRECT_QUERY, "The preprocessor expression must not contain non-deterministic functions");
@@ -155,16 +167,19 @@ MergeTreeIndexTextPreprocessor::MergeTreeIndexTextPreprocessor(ASTPtr expression
     , original_actions(createActionsDAGForPreprocessor(
         index_description.expression->getRequiredColumnsWithTypes(),
         index_description.column_names.front(),
+        index_column_type,
         convertASTForIndexColumn(index_description, expression_ast, false)))
     /// Assume that index expression is already executed and use a placeholder column to execute preprocessor expression.
     , actions_for_index_column(createActionsDAGForPreprocessor(
         {{preprocessor_column_name, index_column_type}},
         preprocessor_column_name,
+        index_column_type,
         convertASTForIndexColumn(index_description, expression_ast, true)))
     /// Take constant string and execute preprocessor expression.
     , actions_for_constant(createActionsDAGForPreprocessor(
         {{preprocessor_column_name, std::make_shared<DataTypeString>()}},
         preprocessor_column_name,
+        std::make_shared<DataTypeString>(),
         convertASTForConstant(index_description, expression_ast)))
 {
 }

--- a/src/Storages/MergeTree/MergeTreeIndexTextPreprocessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPreprocessor.cpp
@@ -17,6 +17,7 @@
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ExpressionListParsers.h>
 #include <Storages/IndicesDescription.h>
+#include <Storages/MergeTree/MergeTreeIndexText.h>
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/TreeRewriter.h>
 
@@ -108,7 +109,6 @@ ASTPtr convertASTForConstant(const IndexDescription & index, const ASTPtr & expr
 ActionsDAG createActionsDAGForPreprocessor(
     const NamesAndTypesList & source_columns,
     const String & source_name,
-    const DataTypePtr & source_type,
     ASTPtr expression_ast)
 {
     if (expression_ast == nullptr)
@@ -132,8 +132,11 @@ ActionsDAG createActionsDAGForPreprocessor(
     if (outputs.front()->result_name == source_name)
         throw Exception(ErrorCodes::INCORRECT_QUERY, "The preprocessor must have at least one expression on top of the source column. Got '{}'", outputs.front()->result_name);
 
-    if (!outputs.front()->result_type->equals(*source_type))
-        throw Exception(ErrorCodes::INCORRECT_QUERY, "The preprocessor expression should return the same type as the source column. Got '{}', expected '{}'", outputs.front()->result_type->getName(), source_type->getName());
+    auto nested_type = MergeTreeIndexText::getNestedDataType(outputs.front()->result_type);
+    WhichDataType which_data_type(nested_type);
+
+    if (!which_data_type.isString() && !which_data_type.isFixedString())
+        throw Exception(ErrorCodes::INCORRECT_QUERY, "The preprocessor expression should return a column of type with base type of String or FixedString, got: {}", outputs.front()->result_type->getName());
 
     if (actions_dag.hasNonDeterministic())
         throw Exception(ErrorCodes::INCORRECT_QUERY, "The preprocessor expression must not contain non-deterministic functions");
@@ -152,19 +155,16 @@ MergeTreeIndexTextPreprocessor::MergeTreeIndexTextPreprocessor(ASTPtr expression
     , original_actions(createActionsDAGForPreprocessor(
         index_description.expression->getRequiredColumnsWithTypes(),
         index_description.column_names.front(),
-        index_column_type,
         convertASTForIndexColumn(index_description, expression_ast, false)))
     /// Assume that index expression is already executed and use a placeholder column to execute preprocessor expression.
     , actions_for_index_column(createActionsDAGForPreprocessor(
         {{preprocessor_column_name, index_column_type}},
         preprocessor_column_name,
-        index_column_type,
         convertASTForIndexColumn(index_description, expression_ast, true)))
     /// Take constant string and execute preprocessor expression.
     , actions_for_constant(createActionsDAGForPreprocessor(
         {{preprocessor_column_name, std::make_shared<DataTypeString>()}},
         preprocessor_column_name,
-        std::make_shared<DataTypeString>(),
         convertASTForConstant(index_description, expression_ast)))
 {
 }

--- a/tests/queries/0_stateless/04038_text_index_preprocessor_type_validation.reference
+++ b/tests/queries/0_stateless/04038_text_index_preprocessor_type_validation.reference
@@ -72,3 +72,6 @@ Type-preserving preprocessor (lower)
 Negative tests
 -- Preprocessor returning UInt64 should fail
 -- Preprocessor returning Array(UInt64) should fail
+-- Preprocessor wrapping scalar String in Array should fail
+-- Preprocessor wrapping scalar LowCardinality(String) in Array should fail
+-- Preprocessor adding extra array dimension to Array(String) should fail

--- a/tests/queries/0_stateless/04038_text_index_preprocessor_type_validation.reference
+++ b/tests/queries/0_stateless/04038_text_index_preprocessor_type_validation.reference
@@ -1,0 +1,74 @@
+CAST(val, String) on non-Nullable scalar types
+-- String
+1
+0
+-- FixedString
+1
+0
+-- LowCardinality(String)
+1
+0
+-- LowCardinality(FixedString)
+1
+0
+CAST(val, String) on Array types
+-- Array(String)
+1
+0
+-- Array(FixedString)
+1
+0
+-- Array(LowCardinality(String))
+1
+0
+CAST on Nullable types
+-- Nullable(String) + CAST to String (non-NULL data)
+1
+0
+-- Nullable(FixedString) + CAST to Nullable(String)
+1
+0
+-- LowCardinality(Nullable(String)) + CAST to String (non-NULL data)
+1
+0
+-- Array(Nullable(String)) + CAST to Nullable(String)
+1
+0
+Other CAST directions
+-- String + CAST to FixedString
+1
+0
+-- String + CAST to LowCardinality(String)
+1
+0
+-- String + CAST to Nullable(String)
+1
+0
+-- String + CAST to LowCardinality(Nullable(FixedString))
+1
+0
+-- LowCardinality(String) + CAST to Nullable(FixedString)
+1
+0
+Type-preserving preprocessor (lower)
+-- Nullable(String) + lower
+1
+0
+-- LowCardinality(String) + lower
+1
+0
+-- LowCardinality(Nullable(String)) + lower
+1
+0
+-- Array(String) + lower
+1
+0
+-- Array(Nullable(String)) + lower
+1
+0
+-- Array(LowCardinality(String)) + lower
+1
+0
+Negative tests
+-- Preprocessor returning UInt64 should fail
+-- Preprocessor returning Array(UInt64) should fail

--- a/tests/queries/0_stateless/04038_text_index_preprocessor_type_validation.sql
+++ b/tests/queries/0_stateless/04038_text_index_preprocessor_type_validation.sql
@@ -1,0 +1,184 @@
+-- Test text index preprocessor validation with various string-like column types.
+-- Before the fix, the preprocessor required exact type match between output and
+-- source column type. The fix relaxes this to check only that the base type
+-- (after unwrapping Array/Nullable/LowCardinality) is String or FixedString.
+
+DROP TABLE IF EXISTS tab;
+
+-- The main use case: CAST(val, 'String') as preprocessor normalizes any
+-- string-like column to plain String before tokenization.
+
+SELECT 'CAST(val, String) on non-Nullable scalar types';
+
+SELECT '-- String';
+CREATE TABLE tab (id UInt64, val String, INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'String'))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, 'foo'), (2, 'bar'), (3, 'baz');
+SELECT count() FROM tab WHERE hasToken(val, 'foo');
+SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+DROP TABLE tab;
+
+SELECT '-- FixedString';
+CREATE TABLE tab (id UInt64, val FixedString(3), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'String'))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, 'foo'), (2, 'bar'), (3, 'baz');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'xyz');
+DROP TABLE tab;
+
+SELECT '-- LowCardinality(String)';
+CREATE TABLE tab (id UInt64, val LowCardinality(String), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'String'))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, 'foo'), (2, 'bar'), (3, 'baz');
+SELECT count() FROM tab WHERE hasToken(val, 'foo');
+SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+DROP TABLE tab;
+
+SELECT '-- LowCardinality(FixedString)';
+CREATE TABLE tab (id UInt64, val LowCardinality(FixedString(3)), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'String'))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, 'foo'), (2, 'bar'), (3, 'baz');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'xyz');
+DROP TABLE tab;
+
+SELECT 'CAST(val, String) on Array types';
+
+SELECT '-- Array(String)';
+CREATE TABLE tab (id UInt64, val Array(String), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'String'))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, ['foo']), (2, ['bar']), (3, ['baz']);
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'xyz');
+DROP TABLE tab;
+
+SELECT '-- Array(FixedString)';
+CREATE TABLE tab (id UInt64, val Array(FixedString(3)), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'String'))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, ['foo']), (2, ['bar']), (3, ['baz']);
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'xyz');
+DROP TABLE tab;
+
+SELECT '-- Array(LowCardinality(String))';
+CREATE TABLE tab (id UInt64, val Array(LowCardinality(String)), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'String'))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, ['foo']), (2, ['bar']), (3, ['baz']);
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'xyz');
+DROP TABLE tab;
+
+-- For Nullable types, CAST(val, 'String') would fail at runtime when NULLs are present.
+-- Use type-appropriate CASTs that preserve the Nullable wrapper.
+
+SELECT 'CAST on Nullable types';
+
+SELECT '-- Nullable(String) + CAST to String (non-NULL data)';
+CREATE TABLE tab (id UInt64, val Nullable(String), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'String'))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, 'foo'), (2, 'bar'), (3, 'baz');
+SELECT count() FROM tab WHERE hasToken(val, 'foo');
+SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+DROP TABLE tab;
+
+SELECT '-- Nullable(FixedString) + CAST to Nullable(String)';
+CREATE TABLE tab (id UInt64, val Nullable(FixedString(3)), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'Nullable(String)'))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, 'foo'), (2, NULL), (3, 'bar');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'xyz');
+DROP TABLE tab;
+
+SELECT '-- LowCardinality(Nullable(String)) + CAST to String (non-NULL data)';
+CREATE TABLE tab (id UInt64, val LowCardinality(Nullable(String)), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'String'))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, 'foo'), (2, 'bar'), (3, 'baz');
+SELECT count() FROM tab WHERE hasToken(val, 'foo');
+SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+DROP TABLE tab;
+
+SELECT '-- Array(Nullable(String)) + CAST to Nullable(String)';
+CREATE TABLE tab (id UInt64, val Array(Nullable(String)), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'Nullable(String)'))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, ['foo']), (2, [NULL, 'bar']), (3, [NULL]);
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'xyz');
+DROP TABLE tab;
+
+SELECT 'Other CAST directions';
+
+SELECT '-- String + CAST to FixedString';
+CREATE TABLE tab (id UInt64, val String, INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'FixedString(3)'))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, 'foo'), (2, 'bar'), (3, 'baz');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'xyz');
+DROP TABLE tab;
+
+SELECT '-- String + CAST to LowCardinality(String)';
+CREATE TABLE tab (id UInt64, val String, INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'LowCardinality(String)'))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, 'foo'), (2, 'bar'), (3, 'baz');
+SELECT count() FROM tab WHERE hasToken(val, 'foo');
+SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+DROP TABLE tab;
+
+SELECT '-- String + CAST to Nullable(String)';
+CREATE TABLE tab (id UInt64, val String, INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'Nullable(String)'))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, 'foo'), (2, 'bar'), (3, 'baz');
+SELECT count() FROM tab WHERE hasToken(val, 'foo');
+SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+DROP TABLE tab;
+
+SELECT '-- String + CAST to LowCardinality(Nullable(FixedString))';
+CREATE TABLE tab (id UInt64, val String, INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'LowCardinality(Nullable(FixedString(3)))'))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, 'foo'), (2, 'bar'), (3, 'baz');
+SELECT count() FROM tab WHERE hasToken(val, 'foo');
+SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+DROP TABLE tab;
+
+SELECT '-- LowCardinality(String) + CAST to Nullable(FixedString)';
+CREATE TABLE tab (id UInt64, val LowCardinality(String), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'Nullable(FixedString(3))'))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, 'foo'), (2, 'bar'), (3, 'baz');
+SELECT count() FROM tab WHERE hasToken(val, 'foo');
+SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+DROP TABLE tab;
+
+SELECT 'Type-preserving preprocessor (lower)';
+
+SELECT '-- Nullable(String) + lower';
+CREATE TABLE tab (id UInt64, val Nullable(String), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, 'FOO'), (2, NULL), (3, 'BAR');
+SELECT count() FROM tab WHERE hasToken(val, 'foo');
+SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+DROP TABLE tab;
+
+SELECT '-- LowCardinality(String) + lower';
+CREATE TABLE tab (id UInt64, val LowCardinality(String), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, 'FOO'), (2, 'BAR'), (3, 'BAZ');
+SELECT count() FROM tab WHERE hasToken(val, 'foo');
+SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+DROP TABLE tab;
+
+SELECT '-- LowCardinality(Nullable(String)) + lower';
+CREATE TABLE tab (id UInt64, val LowCardinality(Nullable(String)), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, 'FOO'), (2, NULL), (3, 'BAR');
+SELECT count() FROM tab WHERE hasToken(val, 'foo');
+SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+DROP TABLE tab;
+
+SELECT '-- Array(String) + lower';
+CREATE TABLE tab (id UInt64, val Array(String), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, ['FOO']), (2, ['BAR']), (3, ['BAZ']);
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'xyz');
+DROP TABLE tab;
+
+SELECT '-- Array(Nullable(String)) + lower';
+CREATE TABLE tab (id UInt64, val Array(Nullable(String)), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, ['FOO']), (2, [NULL, 'BAR']), (3, [NULL]);
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'xyz');
+DROP TABLE tab;
+
+SELECT '-- Array(LowCardinality(String)) + lower';
+CREATE TABLE tab (id UInt64, val Array(LowCardinality(String)), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, ['FOO']), (2, ['BAR']), (3, ['BAZ']);
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAnyTokens(val, 'xyz');
+DROP TABLE tab;
+
+SELECT 'Negative tests';
+
+SELECT '-- Preprocessor returning UInt64 should fail';
+CREATE TABLE tab (id UInt64, val String, INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = length(val))) ENGINE = MergeTree ORDER BY id; -- { serverError INCORRECT_QUERY }
+
+SELECT '-- Preprocessor returning Array(UInt64) should fail';
+CREATE TABLE tab (id UInt64, val Array(String), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = length(val))) ENGINE = MergeTree ORDER BY id; -- { serverError INCORRECT_QUERY }

--- a/tests/queries/0_stateless/04038_text_index_preprocessor_type_validation.sql
+++ b/tests/queries/0_stateless/04038_text_index_preprocessor_type_validation.sql
@@ -182,3 +182,12 @@ CREATE TABLE tab (id UInt64, val String, INDEX idx(val) TYPE text(tokenizer = 's
 
 SELECT '-- Preprocessor returning Array(UInt64) should fail';
 CREATE TABLE tab (id UInt64, val Array(String), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = length(val))) ENGINE = MergeTree ORDER BY id; -- { serverError INCORRECT_QUERY }
+
+SELECT '-- Preprocessor wrapping scalar String in Array should fail';
+CREATE TABLE tab (id UInt64, val String, INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = array(val))) ENGINE = MergeTree ORDER BY id; -- { serverError INCORRECT_QUERY }
+
+SELECT '-- Preprocessor wrapping scalar LowCardinality(String) in Array should fail';
+CREATE TABLE tab (id UInt64, val LowCardinality(String), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = array(val))) ENGINE = MergeTree ORDER BY id; -- { serverError INCORRECT_QUERY }
+
+SELECT '-- Preprocessor adding extra array dimension to Array(String) should fail';
+CREATE TABLE tab (id UInt64, val Array(String), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = array(val))) ENGINE = MergeTree ORDER BY id; -- { serverError INCORRECT_QUERY }

--- a/tests/queries/0_stateless/04038_text_index_preprocessor_type_validation.sql
+++ b/tests/queries/0_stateless/04038_text_index_preprocessor_type_validation.sql
@@ -13,8 +13,8 @@ SELECT 'CAST(val, String) on non-Nullable scalar types';
 SELECT '-- String';
 CREATE TABLE tab (id UInt64, val String, INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'String'))) ENGINE = MergeTree ORDER BY id;
 INSERT INTO tab VALUES (1, 'foo'), (2, 'bar'), (3, 'baz');
-SELECT count() FROM tab WHERE hasToken(val, 'foo');
-SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'xyz');
 DROP TABLE tab;
 
 SELECT '-- FixedString';
@@ -27,8 +27,8 @@ DROP TABLE tab;
 SELECT '-- LowCardinality(String)';
 CREATE TABLE tab (id UInt64, val LowCardinality(String), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'String'))) ENGINE = MergeTree ORDER BY id;
 INSERT INTO tab VALUES (1, 'foo'), (2, 'bar'), (3, 'baz');
-SELECT count() FROM tab WHERE hasToken(val, 'foo');
-SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'xyz');
 DROP TABLE tab;
 
 SELECT '-- LowCardinality(FixedString)';
@@ -69,8 +69,8 @@ SELECT 'CAST on Nullable types';
 SELECT '-- Nullable(String) + CAST to String (non-NULL data)';
 CREATE TABLE tab (id UInt64, val Nullable(String), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'String'))) ENGINE = MergeTree ORDER BY id;
 INSERT INTO tab VALUES (1, 'foo'), (2, 'bar'), (3, 'baz');
-SELECT count() FROM tab WHERE hasToken(val, 'foo');
-SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'xyz');
 DROP TABLE tab;
 
 SELECT '-- Nullable(FixedString) + CAST to Nullable(String)';
@@ -83,8 +83,8 @@ DROP TABLE tab;
 SELECT '-- LowCardinality(Nullable(String)) + CAST to String (non-NULL data)';
 CREATE TABLE tab (id UInt64, val LowCardinality(Nullable(String)), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'String'))) ENGINE = MergeTree ORDER BY id;
 INSERT INTO tab VALUES (1, 'foo'), (2, 'bar'), (3, 'baz');
-SELECT count() FROM tab WHERE hasToken(val, 'foo');
-SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'xyz');
 DROP TABLE tab;
 
 SELECT '-- Array(Nullable(String)) + CAST to Nullable(String)';
@@ -106,29 +106,29 @@ DROP TABLE tab;
 SELECT '-- String + CAST to LowCardinality(String)';
 CREATE TABLE tab (id UInt64, val String, INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'LowCardinality(String)'))) ENGINE = MergeTree ORDER BY id;
 INSERT INTO tab VALUES (1, 'foo'), (2, 'bar'), (3, 'baz');
-SELECT count() FROM tab WHERE hasToken(val, 'foo');
-SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'xyz');
 DROP TABLE tab;
 
 SELECT '-- String + CAST to Nullable(String)';
 CREATE TABLE tab (id UInt64, val String, INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'Nullable(String)'))) ENGINE = MergeTree ORDER BY id;
 INSERT INTO tab VALUES (1, 'foo'), (2, 'bar'), (3, 'baz');
-SELECT count() FROM tab WHERE hasToken(val, 'foo');
-SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'xyz');
 DROP TABLE tab;
 
 SELECT '-- String + CAST to LowCardinality(Nullable(FixedString))';
 CREATE TABLE tab (id UInt64, val String, INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'LowCardinality(Nullable(FixedString(3)))'))) ENGINE = MergeTree ORDER BY id;
 INSERT INTO tab VALUES (1, 'foo'), (2, 'bar'), (3, 'baz');
-SELECT count() FROM tab WHERE hasToken(val, 'foo');
-SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'xyz');
 DROP TABLE tab;
 
 SELECT '-- LowCardinality(String) + CAST to Nullable(FixedString)';
 CREATE TABLE tab (id UInt64, val LowCardinality(String), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(val, 'Nullable(FixedString(3))'))) ENGINE = MergeTree ORDER BY id;
 INSERT INTO tab VALUES (1, 'foo'), (2, 'bar'), (3, 'baz');
-SELECT count() FROM tab WHERE hasToken(val, 'foo');
-SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'xyz');
 DROP TABLE tab;
 
 SELECT 'Type-preserving preprocessor (lower)';
@@ -136,22 +136,22 @@ SELECT 'Type-preserving preprocessor (lower)';
 SELECT '-- Nullable(String) + lower';
 CREATE TABLE tab (id UInt64, val Nullable(String), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))) ENGINE = MergeTree ORDER BY id;
 INSERT INTO tab VALUES (1, 'FOO'), (2, NULL), (3, 'BAR');
-SELECT count() FROM tab WHERE hasToken(val, 'foo');
-SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'xyz');
 DROP TABLE tab;
 
 SELECT '-- LowCardinality(String) + lower';
 CREATE TABLE tab (id UInt64, val LowCardinality(String), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))) ENGINE = MergeTree ORDER BY id;
 INSERT INTO tab VALUES (1, 'FOO'), (2, 'BAR'), (3, 'BAZ');
-SELECT count() FROM tab WHERE hasToken(val, 'foo');
-SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'xyz');
 DROP TABLE tab;
 
 SELECT '-- LowCardinality(Nullable(String)) + lower';
 CREATE TABLE tab (id UInt64, val LowCardinality(Nullable(String)), INDEX idx(val) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(val))) ENGINE = MergeTree ORDER BY id;
 INSERT INTO tab VALUES (1, 'FOO'), (2, NULL), (3, 'BAR');
-SELECT count() FROM tab WHERE hasToken(val, 'foo');
-SELECT count() FROM tab WHERE hasToken(val, 'xyz');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'foo');
+SELECT count() FROM tab WHERE hasAllTokens(val, 'xyz');
 DROP TABLE tab;
 
 SELECT '-- Array(String) + lower';


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed too strict validation of text index preprocessor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MergeTree text index validation paths used at table/index creation, which can change what schemas/expressions are accepted and when the index is used. The changes are localized but could affect query planning/index applicability for edge-case types.
> 
> **Overview**
> Fixes overly strict text index preprocessor validation by accepting preprocessors whose *base/nested* type (after unwrapping `Array`/`Nullable`/`LowCardinality`) is `String`/`FixedString`, rather than requiring exact type equality.
> 
> Adds shared `MergeTreeIndexText::getNestedDataType()` and uses it in both index creation validation and preprocessor validation; preprocessor checks now also enforce that array dimensionality is unchanged and provide clearer error messages including the actual type.
> 
> Additionally, prevents using the text index for `IN` predicates when the set contains an empty string by clearing any partially built `text_search_queries` before rejecting, and adds a stateless test suite covering the expanded type matrix and negative cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e85cf32ed019dc7bc5a8d351ffb9c50ac4d782f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.638`
- Backported to: `26.2.5.24`
<!-- ch-version-info:end -->