### PR TITLE
Add Claude Code skill for PR descriptions

### DIFF
--- a/.claude/skills/clickhouse-pr-description/SKILL.md
+++ b/.claude/skills/clickhouse-pr-description/SKILL.md
@@ -37,24 +37,13 @@ Plain description. No prefix conventions.
 - Bad: `fix(udf): Change default stderr_reaction to log_last` -- conventional commits = instant AI tell
 - Bad: `Improve error handling and enrich exit code exceptions with stderr context` -- too polished
 
-Keep it under 80 chars. Lowercase after first word is fine. Typos are more human than perfection.
+Keep it under 80 chars. Lowercase after first word is fine.
 
 ## Body
 
-**Only the official template. Nothing else above or below unless you have a genuine reason.**
+**Only the official template from `.github/PULL_REQUEST_TEMPLATE.md`. Nothing else above or below unless you have a genuine reason.**
 
-```
-### Changelog category (leave one):
-- <one category>
-
-### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
-
-<1-3 sentences for the user. Present tense. Say what changed and why it matters.>
-
-### Documentation entry for user-facing changes
-
-- [ ] Documentation is written (mandatory for new features)
-```
+Read `.github/PULL_REQUEST_TEMPLATE.md` for the exact template. Fill in the changelog category (delete the rest), write the changelog entry, and keep the documentation checkbox.
 
 **If context is needed** (complex bug fix, behavioral change), add 1-3 paragraphs of plain text ABOVE the template. Free-form, no headers, no formatting. Like explaining to a colleague:
 
@@ -74,20 +63,6 @@ Fixes #XXXXX.
 ### Documentation entry for user-facing changes
 - [ ] Documentation is written (mandatory for new features)
 ```
-
-## Changelog categories (pick one, delete the rest)
-
-- New Feature
-- Experimental Feature
-- Improvement
-- Performance Improvement
-- Backward Incompatible Change
-- Build/Testing/Packaging Improvement
-- Documentation (changelog entry is not required)
-- Critical Bug Fix (crash, data loss, RBAC)
-- Bug Fix (user-visible misbehavior in an official stable release)
-- CI Fix or Improvement (changelog entry is not required)
-- Not for changelog (changelog entry is not required)
 
 ## Changelog entry guidelines
 
@@ -115,7 +90,7 @@ These patterns are **never allowed** in ClickHouse PRs:
 | Bullet lists of file-by-file changes | Implementation details don't belong here |
 | `## Motivation` as a header | If needed, just write it as plain text |
 | Emojis in any form | No |
-| `Co-Authored-By: Claude/Cursor/...` | Remove AI attribution from commits |
+| `Co-Authored-By: Claude/Cursor/...` in PR descriptions | AI attribution in PR body is noise; commit trailers are a separate policy |
 | Perfectly parallel sentence structures | Vary your phrasing |
 | Words: "enhance", "streamline", "leverage", "robust", "comprehensive" | Classic AI vocabulary |
 

--- a/.claude/skills/clickhouse-pr-description/SKILL.md
+++ b/.claude/skills/clickhouse-pr-description/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: clickhouse-pr-description
+description: Generate PR descriptions for ClickHouse/ClickHouse that match maintainer expectations. Strips AI slop automatically. Use when creating or updating PR descriptions.
+argument-hint: "[PR-number or branch-name]"
+disable-model-invocation: false
+allowed-tools: Task, Bash(gh:*), Bash(git:*), Read, Glob, Grep
+---
+
+# ClickHouse PR Description Skill
+
+Generate PR descriptions that look like a human wrote them in 30 seconds. ClickHouse maintainers hate AI slop.
+
+## Arguments
+
+- `$0` (optional): PR number or branch name. If omitted, uses the current branch.
+
+## Obtaining the Diff
+
+**If a PR number is given:**
+- Fetch the PR info: `gh pr view $0 --json title,body,baseRefName,headRefName,files`
+- Get the diff: `gh pr diff $0`
+
+**If a branch name is given:**
+- Get the diff against master: `git diff master...$0`
+
+**If nothing is given:**
+- Use current branch: `git diff master...HEAD`
+- Get commit messages: `git log --oneline master..HEAD`
+
+## Title
+
+Plain description. No prefix conventions.
+
+- Good: `Change default stderr_reaction to log_last for executable UDFs`
+- Good: `Fix crash when inserting NULL into non-nullable column`
+- Good: `Fuzzer fixes`
+- Bad: `fix(udf): Change default stderr_reaction to log_last` -- conventional commits = instant AI tell
+- Bad: `Improve error handling and enrich exit code exceptions with stderr context` -- too polished
+
+Keep it under 80 chars. Lowercase after first word is fine. Typos are more human than perfection.
+
+## Body
+
+**Only the official template. Nothing else above or below unless you have a genuine reason.**
+
+```
+### Changelog category (leave one):
+- <one category>
+
+### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
+
+<1-3 sentences for the user. Present tense. Say what changed and why it matters.>
+
+### Documentation entry for user-facing changes
+
+- [ ] Documentation is written (mandatory for new features)
+```
+
+**If context is needed** (complex bug fix, behavioral change), add 1-3 paragraphs of plain text ABOVE the template. Free-form, no headers, no formatting. Like explaining to a colleague:
+
+```
+The previous default `throw` for stderr_reaction caused confusing errors when
+UDFs wrote warnings to stderr but exited 0. Changed to `log_last` which matches
+what most users expect. The `throw` behavior is still available via config.
+
+### Changelog category (leave one):
+- Bug Fix (user-visible misbehavior in an official stable release)
+
+### Changelog entry:
+Change default `stderr_reaction` from `throw` to `log_last` for executable UDFs.
+Previously, UDFs that wrote warnings to stderr would fail even with exit code 0.
+Fixes #XXXXX.
+
+### Documentation entry for user-facing changes
+- [ ] Documentation is written (mandatory for new features)
+```
+
+## Changelog categories (pick one, delete the rest)
+
+- New Feature
+- Experimental Feature
+- Improvement
+- Performance Improvement
+- Backward Incompatible Change
+- Build/Testing/Packaging Improvement
+- Documentation (changelog entry is not required)
+- Critical Bug Fix (crash, data loss, RBAC)
+- Bug Fix (user-visible misbehavior in an official stable release)
+- CI Fix or Improvement (changelog entry is not required)
+- Not for changelog (changelog entry is not required)
+
+## Changelog entry guidelines
+
+- Written for **users**, not developers
+- Present tense: "Fix" not "Fixed"
+- Say what changed AND why it matters to users
+- Code elements in backticks
+- Reference issue: `Fixes #XXXXX`
+- 1-3 sentences max
+
+## AI Slop Blacklist
+
+These patterns are **never allowed** in ClickHouse PRs:
+
+| Pattern | Why it's slop |
+|---------|---------------|
+| `fix(scope):` / `feat():` / `chore():` | Conventional commits -- ClickHouse doesn't use them |
+| `## Summary` | Not in template, screams AI |
+| `## Test plan` / `## Testing` | Tests speak for themselves |
+| `## Changes` / `## What changed` | Not in template |
+| `## Behavior after this change` | Not a ClickHouse convention |
+| Markdown tables comparing behavior | Over-engineered, nobody does this |
+| Checkbox lists `- [ ] tested X` | Not a ClickHouse convention |
+| `This PR ...` to start the description | AI opener. Just describe the change directly |
+| Bullet lists of file-by-file changes | Implementation details don't belong here |
+| `## Motivation` as a header | If needed, just write it as plain text |
+| Emojis in any form | No |
+| `Co-Authored-By: Claude/Cursor/...` | Remove AI attribution from commits |
+| Perfectly parallel sentence structures | Vary your phrasing |
+| Words: "enhance", "streamline", "leverage", "robust", "comprehensive" | Classic AI vocabulary |
+
+## For CI/not-for-changelog PRs
+
+Minimal is best:
+
+```
+### Changelog category (leave one):
+- Not for changelog (changelog entry is not required)
+
+### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
+
+...
+
+### Documentation entry for user-facing changes
+
+- [ ] Documentation is written (mandatory for new features)
+```
+
+## Process
+
+1. Read the diff to understand the change
+2. Pick the right changelog category
+3. Write a changelog entry for users (not developers)
+4. Only add free-form context above template if the change is non-obvious
+5. Re-read the body -- delete anything that a ClickHouse maintainer would call slop
+6. Check title -- no conventional commit prefix, no AI-polished phrasing


### PR DESCRIPTION
Claude Code skill that teaches Claude to generate PR descriptions matching
ClickHouse maintainer expectations. Includes the official template, changelog
category guide, and an AI slop blacklist to catch common patterns.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds only a new documentation/skill markdown file with guidance text and no runtime code changes.
> 
> **Overview**
> Adds a new Claude skill definition at `.claude/skills/clickhouse-pr-description/SKILL.md` to guide generating ClickHouse PR titles/bodies.
> 
> The skill documents how to obtain diffs (via `gh`/`git`), enforces use of the upstream PR template, and includes a changelog-writing guide plus an *AI slop* blacklist to avoid common maintainer dislikes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b770676935e11cb95ff7b7325e243696ee5cb1c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.642`
<!-- ch-version-info:end -->