### PR TITLE
Fix inconsistent AST formatting for CREATE TABLE AS SELECT with SETTINGS

### DIFF
--- a/src/Parsers/ASTCreateQuery.cpp
+++ b/src/Parsers/ASTCreateQuery.cpp
@@ -601,7 +601,22 @@ void ASTCreateQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & 
     {
         ostr << settings.nl_or_ws;
         ostr << "AS ";
-        select->format(ostr, settings, state, frame);
+
+        /// When the CREATE query has SETTINGS (inherited from ASTQueryWithOutput),
+        /// we must wrap the AS-select in parentheses. Otherwise the trailing
+        /// SETTINGS clause would be consumed by ParserSelectQuery as part of the
+        /// last SELECT in the UNION/INTERSECT chain during re-parsing, instead of
+        /// remaining on the ASTCreateQuery — breaking the formatting roundtrip.
+        if (settings_ast)
+        {
+            ostr << "(";
+            select->format(ostr, settings, state, frame);
+            ostr << ")";
+        }
+        else
+        {
+            select->format(ostr, settings, state, frame);
+        }
     }
 }
 

--- a/tests/queries/0_stateless/04035_create_as_select_intersect_settings.reference
+++ b/tests/queries/0_stateless/04035_create_as_select_intersect_settings.reference
@@ -1,0 +1,3 @@
+CREATE TABLE t\nENGINE = `Null`\nAS (SELECT 1 AS x\nINTERSECT\nSELECT 1 AS x)\nSETTINGS enable_global_with_statement = 0
+1
+CREATE TABLE t\nENGINE = `Null`\nAS SELECT 1 AS x\nINTERSECT\nSELECT 1 AS x

--- a/tests/queries/0_stateless/04035_create_as_select_intersect_settings.sql
+++ b/tests/queries/0_stateless/04035_create_as_select_intersect_settings.sql
@@ -1,0 +1,29 @@
+-- Regression test: CREATE TABLE AS SELECT ... INTERSECT SELECT ... SETTINGS ...
+-- In debug builds, the AST formatting consistency check would trigger a
+-- "Logical error: Inconsistent AST formatting" exception because the trailing
+-- SETTINGS clause migrated from the ASTCreateQuery to the last ASTSelectQuery
+-- during a format-reparse roundtrip.
+
+DROP TABLE IF EXISTS t_intersect_settings;
+
+-- Parenthesized SELECTs with trailing SETTINGS on CREATE (this was the failing case)
+CREATE TABLE t_intersect_settings ENGINE = Null() AS (SELECT 1 AS x) INTERSECT (SELECT 1 AS x) SETTINGS enable_global_with_statement = 0;
+DROP TABLE IF EXISTS t_intersect_settings;
+
+-- Parenthesized SELECTs with both inner and outer SETTINGS
+CREATE TABLE t_intersect_settings ENGINE = Null() AS (SELECT 1 AS x SETTINGS max_threads = 1) INTERSECT (SELECT 1 AS x) SETTINGS enable_global_with_statement = 0;
+DROP TABLE IF EXISTS t_intersect_settings;
+
+-- UNION ALL with trailing SETTINGS
+CREATE TABLE t_intersect_settings ENGINE = Null() AS (SELECT 1 AS x) UNION ALL (SELECT 2 AS x) SETTINGS enable_global_with_statement = 0;
+DROP TABLE IF EXISTS t_intersect_settings;
+
+-- Verify formatting roundtrip preserves SETTINGS on the CREATE level
+SELECT formatQuery('CREATE TABLE t ENGINE = Null() AS (SELECT 1 AS x) INTERSECT (SELECT 1 AS x) SETTINGS enable_global_with_statement = 0');
+
+-- Verify formatting roundtrip is idempotent
+SELECT formatQuery('CREATE TABLE t ENGINE = Null() AS (SELECT 1 AS x) INTERSECT (SELECT 1 AS x) SETTINGS enable_global_with_statement = 0')
+     = formatQuery(formatQuery('CREATE TABLE t ENGINE = Null() AS (SELECT 1 AS x) INTERSECT (SELECT 1 AS x) SETTINGS enable_global_with_statement = 0'));
+
+-- Without trailing SETTINGS (should not add parens)
+SELECT formatQuery('CREATE TABLE t ENGINE = Null() AS SELECT 1 AS x INTERSECT SELECT 1 AS x');


### PR DESCRIPTION
## Summary
- Fix `Inconsistent AST formatting` exception in debug builds when `CREATE TABLE ... AS (SELECT ...) INTERSECT (SELECT ...) SETTINGS ...` is formatted and re-parsed
- The trailing `SETTINGS` clause (on `ASTCreateQuery`) was consumed by `ParserSelectQuery` during re-parsing, moving it to the inner `ASTSelectQuery` and changing the tree hash
- The fix wraps the AS-select in parentheses when `ASTCreateQuery` has `settings_ast`

Found by BuzzHouse (amd_debug): https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=05d3e661d04d044e56f740116b619b4038f69c98&name_0=MasterCI&name_1=BuzzHouse%20%28amd_debug%29

## Test plan
- [x] Added stateless test `04035_create_as_select_intersect_settings` covering:
  - Parenthesized SELECTs with trailing SETTINGS on CREATE
  - Both inner and outer SETTINGS
  - UNION ALL with trailing SETTINGS
  - `formatQuery` roundtrip verification
  - Idempotency check (`formatQuery(formatQuery(...))`)
  - Without trailing SETTINGS (no unnecessary parens)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to `ASTCreateQuery` formatting and only affects `CREATE ... AS SELECT` when a trailing `SETTINGS` clause exists; primary risk is minor SQL formatting output differences.
> 
> **Overview**
> Fixes a formatting roundtrip bug where `CREATE TABLE ... AS SELECT ... SETTINGS ...` could reparse with the trailing `SETTINGS` incorrectly attached to the last SELECT in a `UNION`/`INTERSECT` chain.
> 
> `ASTCreateQuery::formatQueryImpl` now wraps the `AS` select in parentheses when `settings_ast` is present, ensuring the `SETTINGS` clause stays on the `CREATE` node. Adds a stateless regression test (`04035_create_as_select_intersect_settings`) covering `INTERSECT`/`UNION ALL`, inner+outer `SETTINGS`, and `formatQuery` idempotency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d62246f35590038c2d12c45c6fb6e6947a58085. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.649`
<!-- ch-version-info:end -->