### PR TITLE
Fix flaky test 02435_rollback_cancelled_queries timeout

### DIFF
--- a/tests/queries/0_stateless/02435_rollback_cancelled_queries.sh
+++ b/tests/queries/0_stateless/02435_rollback_cancelled_queries.sh
@@ -43,7 +43,7 @@ function insert_data
         $CLICKHOUSE_CURL -sS -F 'file=@-' "$CLICKHOUSE_URL&$TRASH_SETTINGS&file_format=TSV&file_types=UInt64" -X POST --form-string 'query=insert into dedup_test select * from file' < $DATA_FILE
     else
         # client will send 1000-rows blocks, server will squash them into 110000-rows blocks (more chances to catch a bug on query cancellation)
-        $CLICKHOUSE_CLIENT --stacktrace --query_id="$ID" --throw_on_unsupported_query_inside_transaction=0 --implicit_transaction="$IMPLICIT" \
+        timeout 120 $CLICKHOUSE_CLIENT --stacktrace --query_id="$ID" --throw_on_unsupported_query_inside_transaction=0 --implicit_transaction="$IMPLICIT" \
             --max_block_size=1000 --max_insert_block_size=1000 -q \
             "${BEGIN}insert into dedup_test settings max_insert_block_size=110000, min_insert_block_size_rows=110000 format TSV$COMMIT" < $DATA_FILE \
             | grep -Fv "Transaction is not in RUNNING state" | grep -Fv "There is no current transaction"
@@ -78,7 +78,7 @@ function thread_select
     local TIMELIMIT=$((SECONDS+TIMEOUT))
     while [ $SECONDS -lt "$TIMELIMIT" ]
     do
-        $CLICKHOUSE_CLIENT --implicit_transaction=1 -q "with (select count() from dedup_test) as c select throwIf(c % 1000000 != 0, 'Expected 1000000 * N rows, got ' || toString(c)) format Null"
+        timeout 120 $CLICKHOUSE_CLIENT --implicit_transaction=1 -q "with (select count() from dedup_test) as c select throwIf(c % 1000000 != 0, 'Expected 1000000 * N rows, got ' || toString(c)) format Null"
         sleep 0.$RANDOM;
     done
 }


### PR DESCRIPTION
## Summary
- Add `timeout 120` to `clickhouse-client` calls in `insert_data` and `thread_select` to prevent the test from hanging indefinitely when a client process gets stuck
- The `curl` calls already had `--max-time 120` but the `clickhouse-client` invocations had no timeout, allowing a single hung client to block the test until the 600s CI timeout
- Observed in ASan+distributed plan run: a client launched near the end of the 20s cancel window outlived the cancel thread and hung in startup (signal during `registerFunctions` under ASan)

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=744397212e4cfe2e1396ede6ef386c2c451c34fb&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_asan%2C%20distributed%20plan%2C%20parallel%2C%202%2F2%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that wraps `clickhouse-client` invocations with a hard timeout to prevent CI hangs; no production logic is affected.
> 
> **Overview**
> Prevents stateless test `02435_rollback_cancelled_queries.sh` from hanging indefinitely by wrapping the long-running `clickhouse-client` insert path and the `thread_select` validation query with `timeout 120`.
> 
> This makes the rollback/cancellation stress test fail fast if a client process gets stuck, aligning it with the existing curl request time limits and reducing CI flakiness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58b2ef15e4bbd15273d64e759a64ce315dd7d419. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.667`
<!-- ch-version-info:end -->