### PR TITLE
Downgrade S3 PreconditionFailed log level from Error to Info

### DIFF
--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -644,6 +644,12 @@ void PocoHTTPClient::makeRequestInternalImpl(
                 if (enable_s3_requests_logging)
                     LOG_TEST(log, "Response status: {}, {}", status_code, poco_response.getReason());
             }
+            else if (Poco::Net::HTTPResponse::HTTP_PRECONDITION_FAILED == status_code)
+            {
+                /// PreconditionFailed (412) is an expected response for conditional writes
+                /// (e.g. If-None-Match: *), not a genuine error.
+                LOG_INFO(log, "Response status: {}, {}", status_code, poco_response.getReason());
+            }
             else if (Poco::Net::HTTPResponse::HTTP_NOT_FOUND != status_code || !Expect404ResponseScope::is404Expected())
             {
                 /// Error statuses are more important so we show them even if `enable_s3_requests_logging == false`.

--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -781,8 +781,14 @@ void WriteBufferFromS3::makeSinglepartUpload(WriteBufferFromS3::PartData && data
             }
             else
             {
-                LOG_ERROR(log, "S3Exception name {}, Message: {}, bucket {}, key {}, object size {}",
-                          outcome.GetError().GetExceptionName(), outcome.GetError().GetMessage(), bucket, key, content_length);
+                /// PreconditionFailed is an expected response for conditional writes (e.g. If-None-Match: *),
+                /// not a genuine error — the caller handles it.
+                if (outcome.GetError().GetExceptionName() == "PreconditionFailed")
+                    LOG_INFO(log, "S3Exception name {}, Message: {}, bucket {}, key {}, object size {}",
+                              outcome.GetError().GetExceptionName(), outcome.GetError().GetMessage(), bucket, key, content_length);
+                else
+                    LOG_ERROR(log, "S3Exception name {}, Message: {}, bucket {}, key {}, object size {}",
+                              outcome.GetError().GetExceptionName(), outcome.GetError().GetMessage(), bucket, key, content_length);
                 throw S3Exception(
                     outcome.GetError().GetErrorType(),
                     "Message: {}, bucket {}, key {}, object size {}",


### PR DESCRIPTION
## Summary
- Downgrade `PreconditionFailed` (HTTP 412) S3 response log level from Error to Info in both `PocoHTTPClient` and `WriteBufferFromS3`
- 412 is an expected outcome of conditional writes (`If-None-Match: *`) used by Iceberg metadata commits — it should not be logged at Error level
- Fixes flaky test `03800_mv_from_iceberg` which failed because Error-level logs leaked to stderr via `--send_logs_level=warning`

The root cause: during `CREATE TABLE IF NOT EXISTS` for an Iceberg table, the first S3 PUT for `v1.metadata.json` timed out but actually succeeded on MinIO. The S3 SDK retried and got 412 PreconditionFailed. The Error-level log was forwarded to the client's stderr, causing the test to fail.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=a5483cedba19a14e57f9c27fe76b707f5a1a45bb&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_asan%2C%20distributed%20plan%2C%20parallel%2C%202%2F2%29

## Test plan
- [x] Build succeeds locally (release build)
- [ ] Existing `03800_mv_from_iceberg` test should no longer fail due to `PreconditionFailed` stderr output
- [ ] Other S3 error scenarios (non-PreconditionFailed) still log at Error level

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts logging severity for expected S3 conditional-write failures (HTTP 412 / `PreconditionFailed`) while keeping other error handling unchanged.
> 
> **Overview**
> Reduces noise from expected S3 conditional-write failures by downgrading `HTTP 412 PreconditionFailed` responses from error to info logs.
> 
> This is applied in both the low-level `PocoHTTPClient` HTTP status logging and the `WriteBufferFromS3` single-part `PutObject` failure path, while preserving error-level logging for other non-expected failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5143bbfa8ef56fcdda5a3d5800c248a01f85006. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->