### PR TITLE
Add test coverage for ALTER TABLE bypassing EPHEMERAL virtual column validation

### DIFF
--- a/tests/queries/0_stateless/04033_ephemeral_column_conflicts_with_virtual.sql
+++ b/tests/queries/0_stateless/04033_ephemeral_column_conflicts_with_virtual.sql
@@ -25,3 +25,14 @@ INSERT INTO test_default_virtual_override (key) SELECT number FROM numbers(10);
 SELECT key, _part_offset FROM test_default_virtual_override ORDER BY key;
 
 DROP TABLE test_default_virtual_override;
+
+-- ALTER TABLE ADD COLUMN must also reject EPHEMERAL columns conflicting with virtual column names.
+-- The CREATE TABLE path is validated, but the ALTER path must be too.
+CREATE TABLE test_alter_add_ephemeral_virtual (key UInt32) ENGINE = MergeTree ORDER BY key;
+ALTER TABLE test_alter_add_ephemeral_virtual ADD COLUMN `_part_offset` UInt8 EPHEMERAL 0; -- { serverError ILLEGAL_COLUMN }
+DROP TABLE test_alter_add_ephemeral_virtual;
+
+-- ALTER TABLE MODIFY COLUMN must also reject changing a column to EPHEMERAL if it conflicts.
+CREATE TABLE test_alter_modify_ephemeral_virtual (key UInt32, `_part_offset` UInt8 DEFAULT 0) ENGINE = MergeTree ORDER BY key;
+ALTER TABLE test_alter_modify_ephemeral_virtual MODIFY COLUMN `_part_offset` UInt8 EPHEMERAL 0; -- { serverError ILLEGAL_COLUMN }
+DROP TABLE test_alter_modify_ephemeral_virtual;


### PR DESCRIPTION
PR #99031 added validation in InterpreterCreateQuery::validateVirtualColumns to reject EPHEMERAL columns that conflict with ephemeral virtual column names at CREATE TABLE time. However, the same validation is missing from the ALTER TABLE path in AlterCommands.cpp.

AlterCommands.cpp line 1492 only checks VirtualsKind::Persistent:
if (virtuals->tryGet(column_name, VirtualsKind::Persistent))
      throw Exception(ErrorCodes::ILLEGAL_COLUMN, ...);

There is no equivalent check for VirtualsKind::Ephemeral, so this currently succeeds without error:
ALTER TABLE t ADD COLUMN `_part_offset` UInt8 EPHEMERAL 0;

Subsequent SELECT on the table throws:
LOGICAL_ERROR: Bad cast from type DB::ColumnVector<unsigned long> to DB::ColumnVector<char8_t>

This PR
Adds two failing test cases to 04033_ephemeral_column_conflicts_with_virtual covering:
  1. ALTER TABLE ADD COLUMN with an EPHEMERAL virtual column name
  2. ALTER TABLE MODIFY COLUMN changing an existing column to EPHEMERAL with a virtual column name

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
