### PR TITLE
Fix ignoring of TABLE_UUID_MISMATCH for non analyzer

### DIFF
--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -401,7 +401,7 @@ DatabaseAndTable DatabaseCatalog::getTableImpl(
             return {};
         }
         /// In old analyzer resolving done in multiple places, so we ignore TABLE_UUID_MISMATCH error.
-        else if (!analyzer)
+        else if (analyzer)
         {
             const auto & table_storage_id = db_and_table.second->getStorageID();
             if (db_and_table.first->getDatabaseName() != table_id.database_name ||


### PR DESCRIPTION
Fixes: https://github.com/ClickHouse/ClickHouse/pull/97323/ (cc @yakov-olkhovskiy )

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix ignoring of TABLE_UUID_MISMATCH for non analyzer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes table lookup error behavior for UUID-addressed tables, which can alter which queries fail (or succeed) depending on `allow_experimental_analyzer` and may affect edge cases around renamed/mismatched tables.
> 
> **Overview**
> Fixes `DatabaseCatalog::getTableImpl` UUID-resolution logic so `TABLE_UUID_MISMATCH` is **no longer checked/raised when the experimental analyzer is disabled** (old analyzer), and is instead validated only when `allow_experimental_analyzer` is enabled.
> 
> This aligns the behavior with the comment intention to *ignore* UUID mismatch errors in the old analyzer resolution path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63c00635111caa638074608aed4d08507238b3da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.879`
- Backported to: `26.3.1.891`, `26.2.6.4`, `26.1.7.4`, `25.12.9.59`, `25.8.21.4`
<!-- ch-version-info:end -->