### PR TITLE
Throw if privileges for 'SHOW COLUMNS' are missing

### DIFF
--- a/src/Interpreters/InterpreterShowColumnsQuery.cpp
+++ b/src/Interpreters/InterpreterShowColumnsQuery.cpp
@@ -45,7 +45,7 @@ String InterpreterShowColumnsQuery::getRewrittenQuery()
     String database = escapeString(resolved_database);
     String table = escapeString(query.table);
 
-    getContext()->getAccess()->checkAccess(AccessType::SHOW_COLUMNS, database, table);
+    getContext()->getAccess()->checkAccess(AccessType::SHOW_COLUMNS, query.database, query.table);
 
     String rewritten_query;
     if (use_mysql_types)

--- a/src/Interpreters/InterpreterShowColumnsQuery.cpp
+++ b/src/Interpreters/InterpreterShowColumnsQuery.cpp
@@ -9,8 +9,9 @@
 #include <Parsers/ASTShowColumnsQuery.h>
 #include <Interpreters/ClientInfo.h>
 #include <Interpreters/Context.h>
+#include <Access/ContextAccess.h>
 #include <Interpreters/executeQuery.h>
-
+#include <Access/Common/AccessType.h>
 
 namespace DB
 {
@@ -43,6 +44,8 @@ String InterpreterShowColumnsQuery::getRewrittenQuery()
     String resolved_database = getContext()->resolveDatabase(query.database);
     String database = escapeString(resolved_database);
     String table = escapeString(query.table);
+
+    getContext()->getAccess()->checkAccess(AccessType::SHOW_COLUMNS, database, table);
 
     String rewritten_query;
     if (use_mysql_types)

--- a/tests/queries/0_stateless/02184_table_engine_access.sh
+++ b/tests/queries/0_stateless/02184_table_engine_access.sh
@@ -16,6 +16,9 @@ $CLICKHOUSE_CLIENT --query "GRANT SHOW COLUMNS ON *.* TO user_test_02184;"
 $CLICKHOUSE_CLIENT --query "CREATE TABLE url ENGINE=URL('https://clickhouse.com', LineAsString)"
 
 $CLICKHOUSE_CLIENT  --user=user_test_02184 --password=user_test_02184  --query "CREATE TABLE t AS url" 2>&1| grep -Fo "ACCESS_DENIED" | uniq
+$CLICKHOUSE_CLIENT  --user=user_test_02184 --password=user_test_02184  --query "SHOW COLUMNS FROM t" 2>&1| grep -Fo "ACCESS_DENIED" | uniq
+$CLICKHOUSE_CLIENT  --user=user_test_02184 --password=user_test_02184  --query "SHOW CREATE t" 2>&1| grep -Fo "ACCESS_DENIED" | uniq
+
 
 $CLICKHOUSE_CLIENT --query "GRANT READ, WRITE ON URL TO user_test_02184;"
 $CLICKHOUSE_CLIENT --user=user_test_02184 --password=user_test_02184  --query "CREATE TABLE t AS url"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Check `SHOW COLUMNS` for `SHOW COLUMNS from  <table>` queries.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authorization behavior for `SHOW COLUMNS`, which can affect users/roles and error paths if access rights are misconfigured. Scope is small but touches access control enforcement.
> 
> **Overview**
> **Enforces privilege checks for `SHOW COLUMNS FROM <table>` queries.** `InterpreterShowColumnsQuery` now calls `checkAccess(AccessType::SHOW_COLUMNS, database, table)` before rewriting/executing the underlying `system.columns` query.
> 
> Updates the `02184_table_engine_access` stateless test to assert `ACCESS_DENIED` for `SHOW COLUMNS` (and `SHOW CREATE`) when the user lacks required table-engine privileges, and to pass once `READ/WRITE` on the `URL` engine is granted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4afc8cae1fbbc519c5f83462a5a31e25919c0cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->