### PR TITLE
Retry CIDB queries with backoff on timeout

### DIFF
--- a/ci/praktika/cidb.py
+++ b/ci/praktika/cidb.py
@@ -1,6 +1,7 @@
 import copy
 import dataclasses
 import json
+import time
 import urllib
 from typing import List, Optional
 
@@ -214,7 +215,7 @@ ORDER BY day DESC
                 record.test_context_raw = result_.info
                 yield json.dumps(dataclasses.asdict(record))
 
-    def query(self, query: str, retries: int = 1, log_level="warning"):
+    def query(self, query: str, retries: int = 5, log_level="warning"):
         """
         Executes a SELECT query on CI DB with retry support.
 
@@ -236,7 +237,7 @@ ORDER BY day DESC
                     url=self.url,
                     params=params,
                     headers=self.auth,
-                    timeout=Settings.CI_DB_INSERT_TIMEOUT_SEC,
+                    timeout=Settings.CI_DB_QUERY_TIMEOUT_SEC,
                 )
 
                 if response.ok:
@@ -254,6 +255,7 @@ ORDER BY day DESC
                 print(f"ERROR: Exception during CI DB query attempt {attempt}: {ex}")
                 if attempt == retries:
                     raise ex
+                time.sleep(2**attempt)
 
     def insert_rows(self, jsons, retries=3):
         params = {

--- a/ci/praktika/settings.py
+++ b/ci/praktika/settings.py
@@ -102,6 +102,7 @@ class _Settings:
     CI_DB_DB_NAME = ""
     CI_DB_TABLE_NAME = ""
     CI_DB_INSERT_TIMEOUT_SEC = 20
+    CI_DB_QUERY_TIMEOUT_SEC = 60
 
     # to post links for reading statistics in html report (with read-only user)
     CI_DB_READ_USER: str = ""


### PR DESCRIPTION
The targeted fuzzer/stateless/integration jobs query `play.clickhouse.com` at startup to fetch previously-failed tests. With a 20s read timeout and no retries, a slow response kills the whole job before any testing happens.

Increase the read timeout to 60s (`CI_DB_QUERY_TIMEOUT_SEC`) and retry up to 5 times with exponential backoff (2, 4, 8, 16s between attempts).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to CI DB read/query behavior, mainly increasing timeouts and adding retries; primary impact is potentially longer waits on persistent CIDB outages.
> 
> **Overview**
> **CIDB SELECT queries are now more resilient to slow/unstable responses.** `CIDB.query()` increases default retries from 1 to 5, switches to a dedicated `CI_DB_QUERY_TIMEOUT_SEC` (60s) instead of the insert timeout, and adds exponential backoff (`time.sleep(2**attempt)`) between failed attempts.
> 
> `Settings` adds `CI_DB_QUERY_TIMEOUT_SEC` to separate query/read timeouts from insert/write timeouts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f542e7e3204d988b48611094566b4f4b8166b409. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.657`
<!-- ch-version-info:end -->