### PR TITLE
Fix race condition in `IPartitionStrategy::computePartitionKey` (used by object storage sinks)

### DIFF
--- a/src/Storages/IPartitionStrategy.cpp
+++ b/src/Storages/IPartitionStrategy.cpp
@@ -199,9 +199,6 @@ const KeyDescription & IPartitionStrategy::getPartitionKeyDescription() const
 IPartitionStrategy::PartitionExpressionActionsAndColumnName
 IPartitionStrategy::getPartitionExpressionActions(ASTPtr & expression_ast)
 {
-    if (cached_result)
-        return *cached_result;
-
     auto syntax_result = TreeRewriter(context).analyze(expression_ast, sample_block.getNamesAndTypesList());
     auto actions_dag = ExpressionAnalyzer(expression_ast, syntax_result, context).getActionsDAG(false);
 
@@ -209,9 +206,6 @@ IPartitionStrategy::getPartitionExpressionActions(ASTPtr & expression_ast)
     result.actions = std::make_shared<ExpressionActions>(
         std::move(actions_dag), ExpressionActionsSettings(context), false);
     result.column_name = expression_ast->getColumnName();
-
-    if (!result.actions->getActionsDAG().hasNonDeterministic())
-        cached_result = result;
 
     return result;
 }
@@ -266,13 +260,21 @@ std::shared_ptr<IPartitionStrategy> PartitionStrategyFactory::get(StrategyType s
 WildcardPartitionStrategy::WildcardPartitionStrategy(KeyDescription partition_key_description_, const Block & sample_block_, ContextPtr context_)
     : IPartitionStrategy(partition_key_description_, sample_block_, context_)
 {
+    ASTs arguments(1, partition_key_description.definition_ast);
+    ASTPtr partition_by_string = makeASTFunction("toString", std::move(arguments));
+    auto actions_with_column = getPartitionExpressionActions(partition_by_string);
+
+    if (!actions_with_column.actions->getActionsDAG().hasNonDeterministic())
+    {
+        cached_result = actions_with_column;
+    }
 }
 
 ColumnPtr WildcardPartitionStrategy::computePartitionKey(const Chunk & chunk)
 {
     ASTs arguments(1, partition_key_description.definition_ast);
     ASTPtr partition_by_string = makeASTFunction("toString", std::move(arguments));
-    auto actions_with_column = getPartitionExpressionActions(partition_by_string);
+    auto actions_with_column = cached_result.value_or(getPartitionExpressionActions(partition_by_string));
 
     Block block_with_partition_by_expr = sample_block.cloneWithoutColumns();
     block_with_partition_by_expr.setColumns(chunk.getColumns());
@@ -311,6 +313,15 @@ HiveStylePartitionStrategy::HiveStylePartitionStrategy(
     }
 
     block_without_partition_columns = buildBlockWithoutPartitionColumns(sample_block, partition_columns_name_set);
+
+    ASTs arguments(1, partition_key_description.definition_ast);
+    ASTPtr partition_by_string = makeASTFunction("toString", std::move(arguments));
+    auto actions_with_column = getPartitionExpressionActions(partition_by_string);
+
+    if (!actions_with_column.actions->getActionsDAG().hasNonDeterministic())
+    {
+        cached_result = actions_with_column;
+    }
 }
 
 std::string HiveStylePartitionStrategy::getPathForRead(const std::string & prefix)

--- a/src/Storages/IPartitionStrategy.cpp
+++ b/src/Storages/IPartitionStrategy.cpp
@@ -296,7 +296,7 @@ WildcardPartitionStrategy::WildcardPartitionStrategy(KeyDescription partition_ke
     cacheDeterministicActions(cached_result, actions_with_column);
 }
 
-ColumnPtr WildcardPartitionStrategy::computePartitionKey(const Chunk & chunk)
+ColumnPtr WildcardPartitionStrategy::computePartitionKey(const Chunk & chunk) const
 {
     auto actions_with_column = getCachedOrBuildActions(
         cached_result,

--- a/src/Storages/IPartitionStrategy.cpp
+++ b/src/Storages/IPartitionStrategy.cpp
@@ -22,6 +22,8 @@ extern const int BAD_ARGUMENTS;
 
 namespace
 {
+    using PartitionExpressionActionsAndColumnName = IPartitionStrategy::PartitionExpressionActionsAndColumnName;
+
     /// Builds AST for hive partition path format
     ///  `partition_column_1=toString(partition_value_expr_1)/ ... /partition_column_N=toString(partition_value_expr_N)/`
     /// for given partition columns list and a partition by AST.
@@ -87,6 +89,33 @@ namespace
         }
 
         return result;
+    }
+
+    ASTPtr buildToStringPartitionAST(ASTPtr partition_by)
+    {
+        ASTs arguments(1, partition_by);
+        return makeASTFunction("toString", std::move(arguments));
+    }
+
+    template <typename BuildAST>
+    PartitionExpressionActionsAndColumnName getCachedOrBuildActions(
+        const std::optional<PartitionExpressionActionsAndColumnName> & cached_result,
+        const IPartitionStrategy & partition_strategy,
+        BuildAST && build_ast)
+    {
+        if (cached_result)
+            return *cached_result;
+
+        auto expression_ast = build_ast();
+        return partition_strategy.getPartitionExpressionActions(expression_ast);
+    }
+
+    void cacheDeterministicActions(
+        std::optional<PartitionExpressionActionsAndColumnName> & cached_result,
+        const PartitionExpressionActionsAndColumnName & actions_with_column)
+    {
+        if (!actions_with_column.actions->getActionsDAG().hasNonDeterministic())
+            cached_result = actions_with_column;
     }
 
     std::shared_ptr<IPartitionStrategy> createHivePartitionStrategy(
@@ -197,7 +226,7 @@ const KeyDescription & IPartitionStrategy::getPartitionKeyDescription() const
 }
 
 IPartitionStrategy::PartitionExpressionActionsAndColumnName
-IPartitionStrategy::getPartitionExpressionActions(ASTPtr & expression_ast)
+IPartitionStrategy::getPartitionExpressionActions(ASTPtr & expression_ast) const
 {
     auto syntax_result = TreeRewriter(context).analyze(expression_ast, sample_block.getNamesAndTypesList());
     auto actions_dag = ExpressionAnalyzer(expression_ast, syntax_result, context).getActionsDAG(false);
@@ -260,21 +289,19 @@ std::shared_ptr<IPartitionStrategy> PartitionStrategyFactory::get(StrategyType s
 WildcardPartitionStrategy::WildcardPartitionStrategy(KeyDescription partition_key_description_, const Block & sample_block_, ContextPtr context_)
     : IPartitionStrategy(partition_key_description_, sample_block_, context_)
 {
-    ASTs arguments(1, partition_key_description.definition_ast);
-    ASTPtr partition_by_string = makeASTFunction("toString", std::move(arguments));
-    auto actions_with_column = getPartitionExpressionActions(partition_by_string);
-
-    if (!actions_with_column.actions->getActionsDAG().hasNonDeterministic())
-    {
-        cached_result = actions_with_column;
-    }
+    auto actions_with_column = getCachedOrBuildActions(
+        cached_result,
+        *this,
+        [&] { return buildToStringPartitionAST(partition_key_description.definition_ast); });
+    cacheDeterministicActions(cached_result, actions_with_column);
 }
 
 ColumnPtr WildcardPartitionStrategy::computePartitionKey(const Chunk & chunk)
 {
-    ASTs arguments(1, partition_key_description.definition_ast);
-    ASTPtr partition_by_string = makeASTFunction("toString", std::move(arguments));
-    auto actions_with_column = cached_result.value_or(getPartitionExpressionActions(partition_by_string));
+    auto actions_with_column = getCachedOrBuildActions(
+        cached_result,
+        *this,
+        [&] { return buildToStringPartitionAST(partition_key_description.definition_ast); });
 
     Block block_with_partition_by_expr = sample_block.cloneWithoutColumns();
     block_with_partition_by_expr.setColumns(chunk.getColumns());
@@ -314,14 +341,11 @@ HiveStylePartitionStrategy::HiveStylePartitionStrategy(
 
     block_without_partition_columns = buildBlockWithoutPartitionColumns(sample_block, partition_columns_name_set);
 
-    ASTs arguments(1, partition_key_description.definition_ast);
-    ASTPtr partition_by_string = makeASTFunction("toString", std::move(arguments));
-    auto actions_with_column = getPartitionExpressionActions(partition_by_string);
-
-    if (!actions_with_column.actions->getActionsDAG().hasNonDeterministic())
-    {
-        cached_result = actions_with_column;
-    }
+    auto actions_with_column = getCachedOrBuildActions(
+        cached_result,
+        *this,
+        [&] { return buildHivePartitionAST(partition_key_description.definition_ast, getPartitionColumns()); });
+    cacheDeterministicActions(cached_result, actions_with_column);
 }
 
 std::string HiveStylePartitionStrategy::getPathForRead(const std::string & prefix)
@@ -359,10 +383,13 @@ std::string HiveStylePartitionStrategy::getPathForWrite(
     return path;
 }
 
-ColumnPtr HiveStylePartitionStrategy::computePartitionKey(const Chunk & chunk)
+ColumnPtr HiveStylePartitionStrategy::computePartitionKey(const Chunk & chunk) const
 {
-    auto hive_ast = buildHivePartitionAST(partition_key_description.definition_ast, getPartitionColumns());
-    auto actions_with_column = getPartitionExpressionActions(hive_ast);
+    auto actions_with_column = getCachedOrBuildActions(
+        cached_result,
+        *this,
+        [&] { return buildHivePartitionAST(partition_key_description.definition_ast, getPartitionColumns()); });
+    cacheDeterministicActions(cached_result, actions_with_column);
 
     Block block_with_partition_by_expr = sample_block.cloneWithoutColumns();
     block_with_partition_by_expr.setColumns(chunk.getColumns());

--- a/src/Storages/IPartitionStrategy.cpp
+++ b/src/Storages/IPartitionStrategy.cpp
@@ -389,7 +389,6 @@ ColumnPtr HiveStylePartitionStrategy::computePartitionKey(const Chunk & chunk) c
         cached_result,
         *this,
         [&] { return buildHivePartitionAST(partition_key_description.definition_ast, getPartitionColumns()); });
-    cacheDeterministicActions(cached_result, actions_with_column);
 
     Block block_with_partition_by_expr = sample_block.cloneWithoutColumns();
     block_with_partition_by_expr.setColumns(chunk.getColumns());

--- a/src/Storages/IPartitionStrategy.cpp
+++ b/src/Storages/IPartitionStrategy.cpp
@@ -103,6 +103,8 @@ namespace
         const IPartitionStrategy & partition_strategy,
         BuildAST && build_ast)
     {
+        /// The cache write happens in the cacheDeterministicActions function, which is called from the constructor of the partition strategy.
+        /// If the actions are not deterministic, it will not be cached.
         if (cached_result)
             return *cached_result;
 

--- a/src/Storages/IPartitionStrategy.h
+++ b/src/Storages/IPartitionStrategy.h
@@ -27,7 +27,7 @@ struct IPartitionStrategy
 
     virtual ~IPartitionStrategy() = default;
 
-    virtual ColumnPtr computePartitionKey(const Chunk & chunk) = 0;
+    virtual ColumnPtr computePartitionKey(const Chunk & chunk) const = 0;
 
     virtual std::string getPathForRead(const std::string & prefix) = 0;
     virtual std::string getPathForWrite(const std::string & prefix, const std::string & partition_key) = 0;
@@ -49,7 +49,7 @@ struct IPartitionStrategy
     NamesAndTypesList getPartitionColumns() const;
     const KeyDescription & getPartitionKeyDescription() const;
 
-    PartitionExpressionActionsAndColumnName getPartitionExpressionActions(ASTPtr & expression_ast);
+    PartitionExpressionActionsAndColumnName getPartitionExpressionActions(ASTPtr & expression_ast) const;
 
 protected:
     const KeyDescription partition_key_description;
@@ -92,7 +92,7 @@ struct WildcardPartitionStrategy : IPartitionStrategy
 {
     WildcardPartitionStrategy(KeyDescription partition_key_description_, const Block & sample_block_, ContextPtr context_);
 
-    ColumnPtr computePartitionKey(const Chunk & chunk) override;
+    ColumnPtr computePartitionKey(const Chunk & chunk) const override;
     std::string getPathForRead(const std::string & prefix) override;
     std::string getPathForWrite(const std::string & prefix, const std::string & partition_key) override;
 };
@@ -111,7 +111,7 @@ struct HiveStylePartitionStrategy : IPartitionStrategy
         const std::string & file_format_,
         bool partition_columns_in_data_file_);
 
-    ColumnPtr computePartitionKey(const Chunk & chunk) override;
+    ColumnPtr computePartitionKey(const Chunk & chunk) const override;
     std::string getPathForRead(const std::string & prefix) override;
     std::string getPathForWrite(const std::string & prefix, const std::string & partition_key) override;
 


### PR DESCRIPTION
`IPartitionStrategy::computePartitionKey` might be called from different threads, and it writes to `cached_result` concurrently without any sort of protection. It would be easier to add a mutex around it, but we can actually make it lock-free by moving the cache write to the constructor.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix possible race condition in `IPartitionStrategy::cached_result` introduced in https://github.com/ClickHouse/ClickHouse/pull/92844

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches object-storage partition key computation and caching; while intended to be behavior-preserving, it changes when expression actions are built/cached and could impact partitioning/perf under concurrency.
> 
> **Overview**
> Fixes a potential race on `IPartitionStrategy::cached_result` by **removing cache writes during `computePartitionKey`/`getPartitionExpressionActions`** and instead precomputing and caching deterministic expression actions in the `WildcardPartitionStrategy` and `HiveStylePartitionStrategy` constructors.
> 
> Refactors action creation into small helpers (`buildToStringPartitionAST`, `getCachedOrBuildActions`, `cacheDeterministicActions`) and makes `computePartitionKey`/`getPartitionExpressionActions` `const` to reflect thread-safe usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb89e896748b2b70c73bfcd7638c538db1b47429. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.259`
<!-- ch-version-info:end -->