### PR TITLE
Fix http_handlers example in config.yaml.example to include defaults

### DIFF
--- a/programs/server/config.yaml.example
+++ b/programs/server/config.yaml.example
@@ -904,28 +904,23 @@ query_masking_rules:
 # status - use with static type, response status code
 # content_type - use with static type, response content-type
 # response_content - use with static type, Response content sent to client, when using the prefix 'file://' or 'config://', find the content from the file or configuration send to client.
+# defaults - include an empty string value at the bottom to preserve default handlers (e.g. /ping, /health)
 
 # http_handlers:
-#     - rule:
-#         url: /
+#     rule:
+#       - url: /
 #         methods: POST,GET
 #         headers:
 #           pragma: no-cache
 #         handler:
 #           type: dynamic_query_handler
 #           query_param_name: query
-#     - rule:
-#         url: /predefined_query
+#       - url: /predefined_query
 #         methods: POST,GET
 #         handler:
 #           type: predefined_query_handler
 #           query: 'SELECT * FROM system.settings'
-#     - rule:
-#         handler:
-#           type: static
-#           status: 200
-#           content_type: 'text/plain; charset=UTF-8'
-#           response_content: config://http_server_default_response
+#     defaults: ""
 
 send_crash_reports:
     enabled: true


### PR DESCRIPTION
The yaml example that existed did work but was not compatible with the
defaults setting which includes the default routes such as /ping and
/health.

The syntax is actually different and it was frustrating to find the
correct way to add default http_handlers into custom configuration.

I also needed to remove the catchall handler since it interfered with
the defaults.

Relates to #99432
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

- Motivation: The current example in the config.yaml.example file was incorrect if users needed to keep default handlers


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.168`
<!-- ch-version-info:end -->