### PR TITLE
Revert "AST Fuzz projection definitions "

### DIFF
--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -509,33 +509,6 @@ NullsAction QueryFuzzer::fuzzNullsAction(NullsAction action)
     return action;
 }
 
-void QueryFuzzer::fuzzWindowDefinition(ASTWindowDefinition & def)
-{
-    auto removeChild = [](ASTWindowDefinition & wdef, ASTPtr & member)
-    {
-        auto & ch = wdef.children;
-        member->children.clear();
-        ch.erase(std::remove(ch.begin(), ch.end(), member), ch.end());
-        member = nullptr;
-    };
-
-    if (def.partition_by)
-    {
-        if (fuzz_rand() % 50 == 0)
-            removeChild(def, def.partition_by);
-        else
-            fuzzColumnLikeExpressionList(def.partition_by.get());
-    }
-    if (def.order_by)
-    {
-        if (fuzz_rand() % 50 == 0)
-            removeChild(def, def.order_by);
-        else
-            fuzzOrderByList(def.order_by.get(), 0);
-    }
-    fuzzWindowFrame(def);
-}
-
 void QueryFuzzer::fuzzWindowFrame(ASTWindowDefinition & def)
 {
     checkIterationLimit();
@@ -1103,54 +1076,9 @@ void QueryFuzzer::fuzzIndexDeclaration(ASTIndexDeclaration & index)
 
 void QueryFuzzer::fuzzProjectionDeclaration(ASTProjectionDeclaration & projection)
 {
-    if (!projection.query)
-        return;
-    auto * select = typeid_cast<ASTProjectionSelectQuery *>(projection.query);
-    if (!select || !select->select())
-        return;
+    UNUSED(projection);
 
-    /// Occasionally add _part_offset to SELECT before fuzzing,
-    /// so the fuzz passes can move/replace it along with other expressions.
-    /// _part_offset is valid in projection SELECT and GROUP BY, but NOT in ORDER BY.
-    if (fuzz_rand() % 20 == 0)
-    {
-        select->select()->children.emplace_back(make_intrusive<ASTIdentifier>("_part_offset"));
-    }
-    fuzzColumnLikeExpressionList(select->select().get());
-    /// GROUP BY — ASTProjectionSelectQuery has no ROLLUP/CUBE/GROUPING SETS/TOTALS/HAVING/WHERE
-    if (select->groupBy().get())
-    {
-        if (fuzz_rand() % 50 == 0)
-        {
-            select->groupBy()->children.clear();
-            select->setExpression(ASTProjectionSelectQuery::Expression::GROUP_BY, {});
-        }
-        else
-        {
-            if (fuzz_rand() % 20 == 0)
-            {
-                /// Occasionally add _part_offset to GROUP BY,
-                select->groupBy()->children.emplace_back(make_intrusive<ASTIdentifier>("_part_offset"));
-            }
-            fuzzColumnLikeExpressionList(select->groupBy().get());
-        }
-    }
-    else if (fuzz_rand() % 50 == 0)
-    {
-        select->setExpression(ASTProjectionSelectQuery::Expression::GROUP_BY, getRandomExpressionList(select->select()->children.size()));
-    }
-    if (select->orderBy().get())
-    {
-        if (fuzz_rand() % 50 == 0)
-        {
-            select->orderBy()->children.clear();
-            select->setExpression(ASTProjectionSelectQuery::Expression::ORDER_BY, {});
-        }
-        else
-        {
-            fuzz(select->orderBy()->children);
-        }
-    }
+    /// TODO finish this soon
 }
 
 DataTypePtr QueryFuzzer::fuzzDataType(DataTypePtr type)
@@ -2589,7 +2517,9 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
         if (fn->isWindowFunction() && fn->window_definition)
         {
             auto & def = fn->window_definition->as<ASTWindowDefinition &>();
-            fuzzWindowDefinition(def);
+            fuzzColumnLikeExpressionList(def.partition_by.get());
+            fuzzOrderByList(def.order_by.get(), 0);
+            fuzzWindowFrame(def);
         }
 
         fuzz(fn->children);
@@ -2792,22 +2722,10 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
             addOrReplacePredicate(select, ASTSelectQuery::Expression::QUALIFY);
         }
 
-        if (select->orderBy().get())
+        fuzzOrderByList(select->orderBy().get(), select->select()->children.size());
+        if (select->orderBy().get() && fuzz_rand() % 50 == 0)
         {
-            if (fuzz_rand() % 50 == 0)
-            {
-                select->orderBy()->children.clear();
-                select->setExpression(ASTSelectQuery::Expression::ORDER_BY, {});
-                select->order_by_all = false;
-            }
-            else
-            {
-                if (fuzz_rand() % 50 == 0)
-                {
-                    select->order_by_all = !select->order_by_all;
-                }
-                fuzzOrderByList(select->orderBy().get(), select->select()->children.size());
-            }
+            select->order_by_all = !select->order_by_all;
         }
         if (select->limitLength())
         {
@@ -3211,7 +3129,9 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
     }
     else if (auto * wdef = typeid_cast<ASTWindowDefinition *>(ast.get()))
     {
-        fuzzWindowDefinition(*wdef);
+        fuzzColumnLikeExpressionList(wdef->partition_by.get());
+        fuzzOrderByList(wdef->order_by.get(), 0);
+        fuzzWindowFrame(*wdef);
         fuzz(wdef->children);
     }
     else if (auto * with_elem = typeid_cast<ASTWithElement *>(ast.get()))

--- a/src/Common/QueryFuzzer.h
+++ b/src/Common/QueryFuzzer.h
@@ -215,7 +215,6 @@ private:
     void fuzzColumnLikeExpressionList(IAST * ast);
     NullsAction fuzzNullsAction(NullsAction action);
     void fuzzWindowFrame(ASTWindowDefinition & def);
-    void fuzzWindowDefinition(ASTWindowDefinition & def);
     void fuzzCreateQuery(ASTCreateQuery & create);
     void fuzzExplainQuery(ASTExplainQuery & explain);
     ASTExplainQuery::ExplainKind fuzzExplainKind(ASTExplainQuery::ExplainKind kind = ASTExplainQuery::ExplainKind::QueryPipeline);


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#99331

It causes the fuzzer to crash: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99392&sha=79675d11551f5921deb17e5300ed823c30d98968&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%29
https://github.com/ClickHouse/ClickHouse/pull/99392


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.658`
<!-- ch-version-info:end -->