### PR TITLE
Keeper: fix write of snapshot via temporary file

### DIFF
--- a/src/Coordination/KeeperSnapshotManager.cpp
+++ b/src/Coordination/KeeperSnapshotManager.cpp
@@ -726,12 +726,7 @@ SnapshotFileInfoPtr KeeperSnapshotManager<Storage>::serializeSnapshotBufferToDis
 
     auto disk = getLatestSnapshotDisk();
 
-    {
-        auto buf = disk->writeFile(tmp_snapshot_file_name);
-        buf->finalize();
-    }
-
-    auto plain_buf = disk->writeFile(snapshot_file_name);
+    auto plain_buf = disk->writeFile(tmp_snapshot_file_name);
     copyData(reader, *plain_buf);
 
     const size_t bytes_written = plain_buf->count();
@@ -743,7 +738,7 @@ SnapshotFileInfoPtr KeeperSnapshotManager<Storage>::serializeSnapshotBufferToDis
 
     plain_buf->finalize();
 
-    disk->removeFile(tmp_snapshot_file_name);
+    disk->moveFile(tmp_snapshot_file_name, snapshot_file_name);
 
     auto snapshot_file_info = std::make_shared<SnapshotFileInfo>(snapshot_file_name, disk);
     existing_snapshots.emplace(up_to_log_idx, snapshot_file_info);
@@ -915,12 +910,8 @@ SnapshotFileInfoPtr KeeperSnapshotManager<Storage>::serializeSnapshotToDisk(cons
     auto tmp_snapshot_file_name = "tmp_" + snapshot_file_name;
 
     auto disk = getLatestSnapshotDisk();
-    {
-        auto buf = disk->writeFile(tmp_snapshot_file_name);
-        buf->finalize();
-    }
 
-    auto writer = disk->writeFile(snapshot_file_name);
+    auto writer = disk->writeFile(tmp_snapshot_file_name);
     std::unique_ptr<WriteBuffer> compressed_writer;
     if (compress_snapshots_zstd)
         compressed_writer = wrapWriteBufferWithCompressionMethod(std::move(writer), CompressionMethod::Zstd, 3);
@@ -938,7 +929,7 @@ SnapshotFileInfoPtr KeeperSnapshotManager<Storage>::serializeSnapshotToDisk(cons
     compressed_writer->sync();
     ProfileEvents::increment(ProfileEvents::KeeperSnapshotFileSyncMicroseconds, watch.elapsedMicroseconds());
 
-    disk->removeFile(tmp_snapshot_file_name);
+    disk->moveFile(tmp_snapshot_file_name, snapshot_file_name);
 
     auto snapshot_file_info = std::make_shared<SnapshotFileInfo>(snapshot_file_name, disk);
     existing_snapshots.emplace(up_to_log_idx, snapshot_file_info);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Keeper: Fix write of snapshot via temporary file

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
