### PR TITLE
Disable 01169_alter_partition_isolation_stress for S3 storage

### DIFF
--- a/tests/queries/0_stateless/01169_alter_partition_isolation_stress.sh
+++ b/tests/queries/0_stateless/01169_alter_partition_isolation_stress.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-replicated-database, no-ordinary-database, no-encrypted-storage, no-azure-blob-storage
+# Tags: long, no-replicated-database, no-ordinary-database, no-encrypted-storage, no-azure-blob-storage, no-s3-storage
 
 # shellcheck disable=SC2015
 # shellcheck disable=SC2119


### PR DESCRIPTION
## Summary
- The `01169_alter_partition_isolation_stress` test times out (242s) in the debug build with S3 storage configuration
- S3 latency makes the many transactional I/O operations (ALTER TABLE DROP PARTITION, INSERT, SELECT across 20 iterations) too slow
- Added `no-s3-storage` tag since S3 adds no testing value for partition isolation correctness

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99028&sha=88f672395ea772d1c6050078ab389c00bda9d188&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20distributed%20plan%2C%20s3%20storage%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/99028

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)