### PR TITLE
Fix logical error in ALTER TABLE DROP PART with non-literal AST

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -342,6 +342,14 @@ namespace ErrorCodes
     extern const int TOO_LARGE_LIGHTWEIGHT_UPDATES;
 }
 
+static String getPartNameFromAST(const ASTPtr & partition)
+{
+    const auto * literal = partition->as<ASTLiteral>();
+    if (!literal)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected a string literal for part name, got: {}", partition->formatForErrorMessage());
+    return literal->value.safeGet<String>();
+}
+
 static void checkSuspiciousIndices(const ASTFunction * index_function)
 {
     std::unordered_set<UInt64> unique_index_expression_hashes;
@@ -6312,7 +6320,7 @@ void MergeTreeData::checkAlterPartitionIsPossible(
         {
             if (command.part)
             {
-                auto part_name = command.partition->as<ASTLiteral &>().value.safeGet<String>();
+                auto part_name = getPartNameFromAST(command.partition);
                 /// We are able to parse it
                 MergeTreePartInfo::fromPartName(part_name, format_version);
             }
@@ -6400,7 +6408,7 @@ void MergeTreeData::movePartitionToDisk(const ASTPtr & partition, const String &
     String partition_id;
 
     if (moving_part)
-        partition_id = partition->as<ASTLiteral &>().value.safeGet<String>();
+        partition_id = getPartNameFromAST(partition);
     else
         partition_id = getPartitionIDFromQuery(partition, local_context);
 
@@ -6470,7 +6478,7 @@ void MergeTreeData::movePartitionToVolume(const ASTPtr & partition, const String
     String partition_id;
 
     if (moving_part)
-        partition_id = partition->as<ASTLiteral &>().value.safeGet<String>();
+        partition_id = getPartNameFromAST(partition);
     else
         partition_id = getPartitionIDFromQuery(partition, local_context);
 
@@ -6606,7 +6614,7 @@ Pipe MergeTreeData::alterPartition(
             {
                 if (command.part)
                 {
-                    auto part_name = command.partition->as<ASTLiteral &>().value.safeGet<String>();
+                    auto part_name = getPartNameFromAST(command.partition);
                     checkPartCanBeDropped(part_name, query_context);
                     dropPart(part_name, command.detach, query_context);
                 }
@@ -7698,7 +7706,7 @@ void MergeTreeData::dropDetached(const ASTPtr & partition, bool part, ContextPtr
 
     if (part)
     {
-        String part_name = partition->as<ASTLiteral &>().value.safeGet<String>();
+        String part_name = getPartNameFromAST(partition);
         validateDetachedPartName(part_name);
         auto disk = getDiskForDetachedPart(part_name);
         renamed_parts.addPart(part_name, part_name, "deleting_" + part_name, disk);
@@ -7860,7 +7868,7 @@ MergeTreeData::MutableDataPartsVector MergeTreeData::tryLoadPartsToAttach(const 
     /// Let's compose a list of parts that should be added.
     if (command.part)
     {
-        const String part_name = command.partition->as<ASTLiteral &>().value.safeGet<String>();
+        const String part_name = getPartNameFromAST(command.partition);
         const String part_directory = command.from_path.empty() ? part_name : command.from_path;
         validateDetachedPartName(part_name);
         validateDetachedPartName(part_directory);

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -7894,7 +7894,10 @@ void StorageReplicatedMergeTree::fetchPartition(
 
     if (fetch_part)
     {
-        String part_name = partition->as<ASTLiteral &>().value.safeGet<String>();
+        const auto * literal = partition->as<ASTLiteral>();
+        if (!literal)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected a string literal for part name, got: {}", partition->formatForErrorMessage());
+        String part_name = literal->value.safeGet<String>();
         auto part_path = findReplicaHavingPart(part_name, from, zookeeper);
 
         if (part_path.empty())
@@ -9446,7 +9449,10 @@ void StorageReplicatedMergeTree::movePartitionToShard(
 
     auto zookeeper = getZooKeeperAndAssertNotReadonly();
 
-    String part_name = partition->as<ASTLiteral &>().value.safeGet<String>();
+    const auto * literal = partition->as<ASTLiteral>();
+    if (!literal)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected a string literal for part name, got: {}", partition->formatForErrorMessage());
+    String part_name = literal->value.safeGet<String>();
     auto part_info = MergeTreePartInfo::fromPartName(part_name, format_version);
 
     auto part = getPartIfExists(part_info, {MergeTreeDataPartState::Active});

--- a/tests/queries/0_stateless/04039_alter_drop_part_non_literal.sql
+++ b/tests/queries/0_stateless/04039_alter_drop_part_non_literal.sql
@@ -1,0 +1,8 @@
+-- Verify that ALTER TABLE DROP PART with a query parameter of a non-String type
+-- throws a proper error instead of a logical error (bad cast).
+-- The server replaces typed query parameters with _CAST(...) which is an ASTFunction, not ASTLiteral.
+
+DROP TABLE IF EXISTS t;
+CREATE TABLE t (x UInt8) ENGINE = MergeTree ORDER BY x;
+ALTER TABLE t DROP PART {partition:Date}; -- { serverError BAD_ARGUMENTS }
+DROP TABLE t;

--- a/tests/queries/0_stateless/04040_alter_drop_part_non_literal.sql
+++ b/tests/queries/0_stateless/04040_alter_drop_part_non_literal.sql
@@ -4,5 +4,6 @@
 
 DROP TABLE IF EXISTS t;
 CREATE TABLE t (x UInt8) ENGINE = MergeTree ORDER BY x;
+SET param_partition = '2024-01-01';
 ALTER TABLE t DROP PART {partition:Date}; -- { serverError BAD_ARGUMENTS }
 DROP TABLE t;


### PR DESCRIPTION
## Summary

- Fix logical error (server abort in ASan builds) when `ALTER TABLE ... DROP PART` receives a non-literal AST node — e.g. via a typed query parameter like `{partition:Date}` which the server substitutes with `_CAST(value, 'Type')`
- Replace all 8 unsafe `as<ASTLiteral &>()` reference casts in part name extraction with safe pointer casts that throw `BAD_ARGUMENTS`
- Affects `MergeTreeData.cpp` (6 locations) and `StorageReplicatedMergeTree.cpp` (2 locations)

Closes https://github.com/ClickHouse/ClickHouse/issues/99401

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=bb7e748bbc81a5f9181f4fdb5f80aa1c6180c0a7&name_0=MasterCI&name_1=AST%20fuzzer%20%28arm_asan%29

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix logical error in `ALTER TABLE ... DROP PART` when a typed query parameter is used for the part name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.727`
<!-- ch-version-info:end -->