### PR TITLE
Catch exceptions in MergeTreeTransaction::afterCommit to prevent std::terminate

### DIFF
--- a/src/Interpreters/MergeTreeTransaction.cpp
+++ b/src/Interpreters/MergeTreeTransaction.cpp
@@ -3,6 +3,7 @@
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Interpreters/TransactionLog.h>
 #include <Interpreters/TransactionsInfoLog.h>
+#include <Common/Exception.h>
 #include <Common/noexcept_scope.h>
 
 #include <fmt/ranges.h>
@@ -238,7 +239,14 @@ void MergeTreeTransaction::afterCommit(CSN assigned_csn) noexcept
     for (const auto & part : created_parts)
     {
         part->version.creation_csn.store(csn);
-        part->appendCSNToVersionMetadata(VersionMetadata::WhichCSN::CREATION);
+        try
+        {
+            part->appendCSNToVersionMetadata(VersionMetadata::WhichCSN::CREATION);
+        }
+        catch (...)
+        {
+            tryLogCurrentException("MergeTreeTransaction", "Failed to write creation CSN to version metadata");
+        }
     }
 
     for (const auto & part : removed_parts)
@@ -255,11 +263,27 @@ void MergeTreeTransaction::afterCommit(CSN assigned_csn) noexcept
         }
 
         part->version.removal_csn.store(csn);
-        part->appendCSNToVersionMetadata(VersionMetadata::WhichCSN::REMOVAL);
+        try
+        {
+            part->appendCSNToVersionMetadata(VersionMetadata::WhichCSN::REMOVAL);
+        }
+        catch (...)
+        {
+            tryLogCurrentException("MergeTreeTransaction", "Failed to write removal CSN to version metadata");
+        }
     }
 
     for (const auto & storage_and_mutation : committed_mutations)
-        storage_and_mutation.first->setMutationCSN(storage_and_mutation.second, csn);
+    {
+        try
+        {
+            storage_and_mutation.first->setMutationCSN(storage_and_mutation.second, csn);
+        }
+        catch (...)
+        {
+            tryLogCurrentException("MergeTreeTransaction", "Failed to set mutation CSN");
+        }
+    }
 }
 
 bool MergeTreeTransaction::rollback() noexcept


### PR DESCRIPTION
## Summary

- Wrap `appendCSNToVersionMetadata` and `setMutationCSN` calls in `afterCommit` with try-catch blocks to prevent `std::terminate` when disk write fault injection triggers an exception in a `noexcept` function
- Writing CSN to version metadata is an optimization - the CSN can be recovered from the transaction log in ZooKeeper on restart

Fixes #85468

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=9f55e660b5a692bc6a65ecb1935bf81ea840dfeb&name_0=MasterCI&name_1=BuzzHouse%20%28arm_asan%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)