### PR TITLE
Pin sqllogictest repo to a specific commit and bump threshold

### DIFF
--- a/ci/jobs/sqllogic_test.py
+++ b/ci/jobs/sqllogic_test.py
@@ -318,7 +318,7 @@ def main():
 
         # Pin to a specific commit to avoid non-deterministic test results
         # when the upstream repo updates (e.g., SQLite version bumps).
-        sqllogictest_commit = "634e46492bff"
+        sqllogictest_commit = "634e46492bff5c206a6eb9ba934f2cd411c74bf0"
 
         def clone():
             if not Path(sqllogictest_repo).is_dir():

--- a/ci/jobs/sqllogic_test.py
+++ b/ci/jobs/sqllogic_test.py
@@ -321,11 +321,14 @@ def main():
         sqllogictest_commit = "634e46492bff"
 
         def clone():
-            if Path(sqllogictest_repo).is_dir():
-                return True
+            if not Path(sqllogictest_repo).is_dir():
+                if not Shell.check(
+                    f"git clone https://github.com/gregrahn/sqllogictest.git {sqllogictest_repo}",
+                    verbose=True,
+                ):
+                    return False
             return Shell.check(
-                f"git clone https://github.com/gregrahn/sqllogictest.git {sqllogictest_repo}"
-                f" && git -C {sqllogictest_repo} checkout {sqllogictest_commit}",
+                f"git -C {sqllogictest_repo} checkout {sqllogictest_commit}",
                 verbose=True,
             )
 

--- a/ci/jobs/sqllogic_test.py
+++ b/ci/jobs/sqllogic_test.py
@@ -327,11 +327,14 @@ def main():
                     verbose=True,
                 ):
                     return False
-            if not Shell.check(
-                f"git -C {sqllogictest_repo} fetch --depth 1 origin {sqllogictest_commit}",
-                verbose=True,
-            ):
-                return False
+            else:
+                # On reused workspaces, fetch latest refs so the pinned
+                # commit is available even if it was not in the original clone.
+                if not Shell.check(
+                    f"git -C {sqllogictest_repo} fetch origin",
+                    verbose=True,
+                ):
+                    return False
             return Shell.check(
                 f"git -C {sqllogictest_repo} checkout {sqllogictest_commit}",
                 verbose=True,

--- a/ci/jobs/sqllogic_test.py
+++ b/ci/jobs/sqllogic_test.py
@@ -327,6 +327,11 @@ def main():
                     verbose=True,
                 ):
                     return False
+            if not Shell.check(
+                f"git -C {sqllogictest_repo} fetch --depth 1 origin {sqllogictest_commit}",
+                verbose=True,
+            ):
+                return False
             return Shell.check(
                 f"git -C {sqllogictest_repo} checkout {sqllogictest_commit}",
                 verbose=True,

--- a/ci/jobs/sqllogic_test.py
+++ b/ci/jobs/sqllogic_test.py
@@ -13,7 +13,7 @@ from praktika.utils import Shell, Utils
 temp_dir = f"{Utils.cwd()}/ci/tmp/"
 
 MIN_TOTAL_TESTS = 5_939_581
-MAX_FAILED_TESTS = 173_986
+MAX_FAILED_TESTS = 174_004
 
 
 # Reuse the same ClickHouseBinary helper from sqltest_job.py
@@ -316,9 +316,16 @@ def main():
     if results[-1].is_ok():
         print("Clone sqllogictest repo")
 
+        # Pin to a specific commit to avoid non-deterministic test results
+        # when the upstream repo updates (e.g., SQLite version bumps).
+        sqllogictest_commit = "634e46492bff"
+
         def clone():
-            return Path(sqllogictest_repo).is_dir() or Shell.check(
-                f"git clone --depth 1 https://github.com/gregrahn/sqllogictest.git {sqllogictest_repo}",
+            if Path(sqllogictest_repo).is_dir():
+                return True
+            return Shell.check(
+                f"git clone https://github.com/gregrahn/sqllogictest.git {sqllogictest_repo}"
+                f" && git -C {sqllogictest_repo} checkout {sqllogictest_commit}",
                 verbose=True,
             )
 


### PR DESCRIPTION
## Summary

- Pin the `sqllogictest` repo clone to commit `634e46492bff` instead of using unpinned `--depth 1` clone, to prevent non-deterministic CI results when the upstream repo updates (e.g., SQLite version bumps).
- Bump `MAX_FAILED_TESTS` from 173,986 to 174,004 to account for 18 additional "Unexpected exception" failures introduced by the `LimitTransform` simplification in #99245.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.687`
<!-- ch-version-info:end -->