### PR TITLE
Fuzzy matching for PR changelog categories in CI checks

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/pr_body_check.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_body_check.py
@@ -2,10 +2,9 @@ import re
 import sys
 
 from ci.jobs.scripts.workflow_hooks.pr_labels_and_category import (
-    CATEGORIES_FOLD,
-    LABEL_CATEGORIES,
+    NO_CHANGELOG_REQUIRED_LABELS,
+    find_category,
     get_category,
-    normalize_category,
 )
 from ci.praktika.gh import GH
 from ci.praktika.info import Info
@@ -15,13 +14,10 @@ def check_changelog_entry(category, pr_body: str) -> str:
     lines = list(map(lambda x: x.strip(), pr_body.split("\n") if pr_body else []))
     lines = [re.sub(r"\s+", " ", line) for line in lines]
 
-    if category in LABEL_CATEGORIES["pr-not-for-changelog"]:
+    _matched, label = find_category(category)
+    if label in NO_CHANGELOG_REQUIRED_LABELS:
         return ""
-    if category in LABEL_CATEGORIES["pr-ci"]:
-        return ""
-    if category in LABEL_CATEGORIES["pr-documentation"]:
-        return ""
-    if normalize_category(category) not in CATEGORIES_FOLD:
+    if label is None:
         return f"Invalid category: [{category}]"
 
     entry = ""

--- a/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
@@ -1,6 +1,6 @@
 import re
 import sys
-from typing import Tuple
+from typing import Optional, Tuple
 
 from praktika.info import Info
 from praktika.utils import Shell
@@ -34,13 +34,19 @@ LABEL_CATEGORIES = {
         "Not for changelog",
     ],
     "pr-performance": ["Performance Improvement"],
-    "pr-ci": ["CI Fix or Improvement (changelog entry is not required)"],
+    "pr-ci": [
+        "CI Fix or Improvement (changelog entry is not required)",
+        "CI Fix or Improvement",
+    ],
     "pr-experimental": ["Experimental Feature"],
 }
 
 CATEGORY_TO_LABEL = {
     c: lb for lb, categories in LABEL_CATEGORIES.items() for c in categories
 }
+
+# Labels for categories that don't require a changelog entry
+NO_CHANGELOG_REQUIRED_LABELS = {"pr-not-for-changelog", "pr-ci", "pr-documentation"}
 
 
 class Labels:
@@ -82,19 +88,75 @@ class Labels:
     AUTO_BACKPORT = {"pr-critical-bugfix"}
 
 
-def normalize_category(cat: str) -> str:
-    """Drop everything after open parenthesis, drop leading/trailing whitespaces, normalize case"""
+def _levenshtein(s1: str, s2: str) -> int:
+    """Compute Levenshtein distance between two strings."""
+    if len(s1) < len(s2):
+        return _levenshtein(s2, s1)
+    if not s2:
+        return len(s1)
+    prev = list(range(len(s2) + 1))
+    for c1 in s1:
+        curr = [prev[0] + 1]
+        for j, c2 in enumerate(s2):
+            curr.append(min(prev[j + 1] + 1, curr[j] + 1, prev[j] + (c1 != c2)))
+        prev = curr
+    return prev[-1]
+
+
+def _normalize_for_matching(cat: str) -> str:
+    """Normalize category for matching: strip parenthetical suffix, collapse whitespace, casefold."""
     pos = cat.find("(")
-
     result = cat[:pos] if pos != -1 else cat
-    return result.strip().casefold()
+    return re.sub(r"\s+", " ", result.strip()).casefold()
 
 
-CATEGORIES_FOLD = [
-    normalize_category(c)
-    for lb, categories in LABEL_CATEGORIES.items()
-    for c in categories
-]
+def _normalized_distance(s1: str, s2: str) -> float:
+    """Compute normalized Levenshtein distance (0.0 = identical, 1.0 = completely different)."""
+    max_len = max(len(s1), len(s2))
+    if max_len == 0:
+        return 0.0
+    return _levenshtein(s1, s2) / max_len
+
+
+# Maximum normalized Levenshtein distance for fuzzy matching (20%)
+MAX_NORMALIZED_DISTANCE = 0.2
+
+
+def find_category(category: str) -> Tuple[Optional[str], Optional[str]]:
+    """Find matching category and label using fuzzy matching.
+
+    Matching is case-insensitive, whitespace-insensitive, ignores parenthetical
+    suffixes, and allows normalized Levenshtein distance up to 20%
+    (with whitespace removed for comparison).
+
+    Returns (matched_category, label) or (None, None).
+    """
+    # Exact match
+    if category in CATEGORY_TO_LABEL:
+        return category, CATEGORY_TO_LABEL[category]
+
+    # Normalized exact match
+    norm = _normalize_for_matching(category)
+    for known_cat, label in CATEGORY_TO_LABEL.items():
+        if _normalize_for_matching(known_cat) == norm:
+            return known_cat, label
+
+    # Fuzzy match with normalized Levenshtein distance <= 20% (whitespace removed)
+    compact = norm.replace(" ", "")
+    best_dist = MAX_NORMALIZED_DISTANCE + 1e-9
+    best_match = None
+    seen = set()
+    for known_cat, label in CATEGORY_TO_LABEL.items():
+        known_compact = _normalize_for_matching(known_cat).replace(" ", "")
+        if known_compact in seen:
+            continue
+        seen.add(known_compact)
+        dist = _normalized_distance(compact, known_compact)
+        if dist < best_dist:
+            best_dist = dist
+            best_match = (known_cat, label)
+
+    return best_match if best_match else (None, None)
 
 
 def get_category(pr_body: str) -> Tuple[str, str]:
@@ -128,11 +190,19 @@ def get_category(pr_body: str) -> Tuple[str, str]:
                 break
         else:
             i += 1
-    if not category or normalize_category(category) not in CATEGORIES_FOLD:
+
+    if not category:
         if "Reverts ClickHouse/" in pr_body:
             return "", LABEL_CATEGORIES["pr-not-for-changelog"][0]
-        error = "Change category is missing or invalid"
-    return error, category
+        return "Change category is missing or invalid", ""
+
+    matched, _label = find_category(category)
+    if matched is None:
+        if "Reverts ClickHouse/" in pr_body:
+            return "", LABEL_CATEGORIES["pr-not-for-changelog"][0]
+        return f"Change category is missing or invalid: '{category}'", ""
+
+    return error, matched
 
 
 def check_labels(category, info):

--- a/tests/ci/changelog.py
+++ b/tests/ci/changelog.py
@@ -51,6 +51,48 @@ def _normalize_for_matching(cat: str) -> str:
 MAX_NORMALIZED_DISTANCE = 0.2
 
 
+# Categories that should be skipped in the changelog, grouped by skip reason.
+# Uses the same canonical names as LABEL_CATEGORIES in pr_labels_and_category.py.
+_SKIP_CATEGORIES = {
+    "documentation": ["Documentation"],
+    "not-for-changelog": [
+        "Not for changelog",
+        "CI Fix or Improvement",
+    ],
+}
+
+# Also match historical/legacy category names not present in LABEL_CATEGORIES.
+_SKIP_LEGACY_PATTERN = re.compile(
+    r"(?i)((non|in|not|un)[-\s]*significant)"
+    r"|(changelog[ ]*entry[ ]*is[ ]*not[ ]*required)"
+)
+
+
+def _match_skip_category(category: str) -> Optional[str]:
+    """Check if a category should be skipped from the changelog.
+
+    Returns the skip reason ("documentation" or "not-for-changelog") or None.
+    Uses normalized Levenshtein matching with the same 20% threshold.
+    """
+    norm = _normalize_for_matching(category)
+    compact = norm.replace(" ", "")
+
+    for reason, names in _SKIP_CATEGORIES.items():
+        for name in names:
+            name_norm = _normalize_for_matching(name)
+            if name_norm == norm:
+                return reason
+            name_compact = name_norm.replace(" ", "")
+            if Levenshtein.normalized_distance(compact, name_compact) <= MAX_NORMALIZED_DISTANCE:
+                return reason
+
+    # Handle legacy names that don't match any current category
+    if _SKIP_LEGACY_PATTERN.search(category):
+        return "not-for-changelog"
+
+    return None
+
+
 def _match_changelog_category(category: str) -> Optional[str]:
     """Match a PR category to a preferred changelog category.
 
@@ -311,20 +353,12 @@ def generate_description(item: PullRequest, repo: Repository) -> Optional[Descri
         # Fall through, so that it shows up in output and the user can fix it.
         category = "NO CL CATEGORY"
 
-    # Filter out documentations changelog before not-for-changelog
-    if re.match(
-        r"(?i)doc",
-        category,
-    ):
+    # Filter out categories that are not for changelog, using the same
+    # fuzzy matching as the CI check.
+    skip_label = _match_skip_category(category)
+    if skip_label == "documentation":
         return None
-
-    # Filter out the PR categories that are not for changelog.
-    if re.search(
-        r"(?i)((non|in|not|un)[-\s]*significant)|"
-        r"(not[ ]*for[ ]*changelog)|"
-        r"(changelog[ ]*entry[ ]*is[ ]*not[ ]*required)",
-        category,
-    ):
+    if skip_label == "not-for-changelog":
         category = "NOT FOR CHANGELOG / INSIGNIFICANT"
         # Sometimes we declare not for changelog but still write a description. Keep it
         if len(entry) <= 4 or "Documentation entry" in entry:

--- a/tests/ci/changelog.py
+++ b/tests/ci/changelog.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, TextIO, Tuple
 import tqdm  # type: ignore
 from github.GithubException import RateLimitExceededException, UnknownObjectException
 from github.NamedUser import NamedUser
-from thefuzz.fuzz import ratio  # type: ignore
+from rapidfuzz.distance import Levenshtein  # type: ignore
 
 from ci_utils import Shell
 from git_helper import git_runner, is_shallow
@@ -38,6 +38,45 @@ categories_preferred_order = (
     "Build/Testing/Packaging Improvement",
     "Other",
 )
+
+
+def _normalize_for_matching(cat: str) -> str:
+    """Normalize category for matching: strip parenthetical suffix, collapse whitespace, casefold."""
+    pos = cat.find("(")
+    result = cat[:pos] if pos != -1 else cat
+    return re.sub(r"\s+", " ", result.strip()).casefold()
+
+
+# Maximum normalized Levenshtein distance for fuzzy matching (20%)
+MAX_NORMALIZED_DISTANCE = 0.2
+
+
+def _match_changelog_category(category: str) -> Optional[str]:
+    """Match a PR category to a preferred changelog category.
+
+    Uses the same rules as the CI check: case-insensitive, whitespace-insensitive,
+    normalized Levenshtein distance up to 20% (with whitespace removed for comparison).
+    """
+    norm = _normalize_for_matching(category)
+    compact = norm.replace(" ", "")
+
+    # Exact normalized match first
+    for pref in categories_preferred_order:
+        if _normalize_for_matching(pref) == norm:
+            return pref
+
+    # Fuzzy match with normalized Levenshtein distance <= 20%
+    best_dist = MAX_NORMALIZED_DISTANCE + 1e-9
+    best_match = None
+    for pref in categories_preferred_order:
+        pref_compact = _normalize_for_matching(pref).replace(" ", "")
+        dist = Levenshtein.normalized_distance(compact, pref_compact)
+        if dist < best_dist:
+            best_dist = dist
+            best_match = pref
+
+    return best_match
+
 
 FROM_REF = ""
 TO_REF = ""
@@ -314,10 +353,9 @@ def generate_description(item: PullRequest, repo: Repository) -> Optional[Descri
     if entry[-1] != ".":
         entry += "."
 
-    for c in categories_preferred_order:
-        if ratio(category.lower(), c.lower()) >= 90:
-            category = c
-            break
+    matched = _match_changelog_category(category)
+    if matched:
+        category = matched
 
     return Description(item.number, item.user, item.html_url, entry, category)
 

--- a/utils/changelog/requirements.txt
+++ b/utils/changelog/requirements.txt
@@ -1,4 +1,4 @@
-thefuzz
+rapidfuzz
 PyGitHub
 tqdm
 boto3


### PR DESCRIPTION
## Summary
- Define `NO_CHANGELOG_REQUIRED_LABELS` to explicitly track which categories don't require a changelog entry, replacing three separate hardcoded list-membership checks in `check_changelog_entry`
- Add `find_category` with fuzzy matching: case-insensitive, whitespace-insensitive, parenthetical-stripped, with normalized Levenshtein distance up to 20% — so minor typos in category names are accepted instead of failing the CI check
- `get_category` now returns the canonical category name so downstream label assignment and changelog checks work correctly even when the user writes a variant like `CI Fix or Improvement` (without the parenthetical)
- Update `changelog.py` to use the same normalization rules, replacing `thefuzz.fuzz.ratio` with `rapidfuzz.distance.Levenshtein`

## Test plan
- [ ] Verify existing PR body check still passes for standard categories
- [ ] Verify CI Fix or Improvement without "(changelog entry is not required)" suffix is accepted
- [ ] Verify minor typos (e.g. "New Feture") are fuzzy-matched to the correct category
- [ ] Verify completely invalid categories are still rejected

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.680`
<!-- ch-version-info:end -->