### PR TITLE
Retry docker compose up for ZooKeeper in integration tests

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3395,6 +3395,12 @@ class ClickHouseCluster:
 
             retry(log_function=logging_pulling_images, retries=3, delay=8, jitter=8)(run_and_check, images_pull_cmd, nothrow=True, timeout=600)
 
+            def logging_compose_up(**kwargs):
+                if "exception" in kwargs:
+                    logging.info(
+                        "Got exception in docker compose up: %s", kwargs["exception"]
+                    )
+
             if self.with_zookeeper_secure and self.base_zookeeper_cmd:
                 logging.debug("Setup ZooKeeper Secure")
                 logging.debug(
@@ -3405,7 +3411,9 @@ class ClickHouseCluster:
                         shutil.rmtree(self.zookeeper_instance_dir_prefix + f"{i}", ignore_errors=True)
                 for dir in self.zookeeper_dirs_to_create:
                     os.makedirs(dir)
-                run_and_check(self.base_zookeeper_cmd + common_opts, env=self.env)
+                retry(log_function=logging_compose_up, retries=3, delay=3, jitter=2)(
+                    run_and_check, self.base_zookeeper_cmd + common_opts, env=self.env
+                )
                 self.up_called = True
 
                 self.wait_zookeeper_secure_to_start()
@@ -3495,7 +3503,9 @@ class ClickHouseCluster:
                                 ),
                             )
 
-                run_and_check(self.base_zookeeper_cmd + common_opts, env=self.env)
+                retry(log_function=logging_compose_up, retries=3, delay=3, jitter=2)(
+                    run_and_check, self.base_zookeeper_cmd + common_opts, env=self.env
+                )
                 self.up_called = True
 
                 self.wait_zookeeper_to_start()


### PR DESCRIPTION
Wrap `docker compose up -d` for ZooKeeper/Keeper containers in integration tests with the existing `retry()` decorator (3 retries, 3s base delay).

Currently, a transient Docker-in-Docker networking race — where the daemon reports ready via `docker info` but the network subsystem hasn't fully initialized — causes `network ... not found` errors that immediately fail all tests in the shard with no recovery. Image pulls already have retry logic (line 3396 of `cluster.py`), but compose-up did not.

Seen in #98230: [Integration tests (amd_binary, 1/5)](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98230&sha=3a1a2a77d4ecaffb47629f3d75243946e1c36100&name_0=PR&name_1=Integration%20tests%20%28amd_binary%2C%201%2F5%29
https://github.com/ClickHouse/ClickHouse/pull/98230) — all 29 tests failed identically with `Error response from daemon: network roottestdistributedinterserversecret-gw1_default not found`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.683`
<!-- ch-version-info:end -->