### PR TITLE
Ignore changed files in contrib folder from differential coverage extraction

### DIFF
--- a/ci/jobs/scripts/generate_diff_coverage_report.sh
+++ b/ci/jobs/scripts/generate_diff_coverage_report.sh
@@ -61,14 +61,16 @@ fi
 
 patterns=()
 while IFS= read -r f; do
-  # Only include C/C++ source files that can appear in lcov coverage data
-  if [[ "$f" =~ \.(cpp|cc|cxx|c|h|hpp|hxx|hh)$ ]]; then
+  # Only include C/C++ source files that can appear in lcov coverage data.
+  # Skip contrib/ files — coverage is disabled for third-party code, so they
+  # produce no records in the tracefile and cause lcov to fail with "(empty)".
+  if [[ "$f" =~ \.(cpp|cc|cxx|c|h|hpp|hxx|hh)$ ]] && [[ ! "$f" =~ ^contrib/ ]]; then
     patterns+=("*$f")
   fi
 done < <(echo "$changed_files")
 
 if [ ${#patterns[@]} -eq 0 ]; then
-  echo "No C/C++ source files changed, skipping differential coverage report"
+  echo "No coverable C/C++ source files changed (contrib/ is excluded from coverage), skipping differential coverage report"
   exit 0
 fi
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.710`
<!-- ch-version-info:end -->