### PR TITLE
validate column structure before applying patches

### DIFF
--- a/src/Storages/MergeTree/PatchParts/applyPatches.cpp
+++ b/src/Storages/MergeTree/PatchParts/applyPatches.cpp
@@ -8,6 +8,7 @@
 #include <DataTypes/DataTypesNumber.h>
 #include <Common/ProfileEvents.h>
 #include <Common/ElapsedTimeProfileEventIncrement.h>
+#include <Common/logger_useful.h>
 #include <shared_mutex>
 
 namespace ProfileEvents
@@ -69,7 +70,10 @@ public:
         build();
     }
 
-    IColumn::Patch createPatchForColumn(const String & column_name, IColumn::Versions & dst_versions) const;
+    /// When @p result_type is provided, sources with a different type are
+    /// filtered out per-source so compatible updates survive schema transitions.
+    IColumn::Patch createPatchForColumn(const String & column_name, IColumn::Versions & dst_versions,
+                                        const DataTypePtr & result_type = nullptr) const;
 
 private:
     void build();
@@ -98,6 +102,11 @@ private:
     IColumn::Offsets src_row_indices;
     /// Index of row in the result block.
     IColumn::Offsets dst_row_indices;
+
+    /// Scratch space for type-filtering path in createPatchForColumn.
+    mutable IColumn::Offsets filtered_src_col_indices;
+    mutable IColumn::Offsets filtered_src_row_indices;
+    mutable IColumn::Offsets filtered_dst_row_indices;
 };
 
 void CombinedPatchBuilder::build()
@@ -224,33 +233,58 @@ void CombinedPatchBuilder::build()
     }
 }
 
-IColumn::Patch CombinedPatchBuilder::createPatchForColumn(const String & column_name, IColumn::Versions & dst_versions) const
+IColumn::Patch CombinedPatchBuilder::createPatchForColumn(
+    const String & column_name, IColumn::Versions & dst_versions, const DataTypePtr & result_type) const
 {
     std::vector<IColumn::Patch::Source> sources;
+    std::vector<bool> source_ok(all_patch_blocks.size(), true);
+    std::vector<size_t> remap(all_patch_blocks.size());
+    bool need_filter = false;
 
-    for (const auto & patch_block : all_patch_blocks)
+    for (size_t i = 0; i < all_patch_blocks.size(); ++i)
     {
-        const auto & patch_column = patch_block.getByName(column_name).column;
-        if (!patch_column)
+        const auto & pcol = all_patch_blocks[i].getByName(column_name);
+        if (!pcol.column)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "Column {} has null data in patch block", column_name);
 
-        IColumn::Patch::Source source =
+        if (result_type && !result_type->equals(*pcol.type))
         {
-            .column = *patch_column,
-            .versions = getColumnUInt64Data(patch_block, PartDataVersionColumn::name),
-        };
+            source_ok[i] = false;
+            need_filter = true;
+            continue;
+        }
 
-        sources.push_back(std::move(source));
+        remap[i] = sources.size();
+        sources.push_back({.column = *pcol.column,
+                           .versions = getColumnUInt64Data(all_patch_blocks[i], PartDataVersionColumn::name)});
     }
 
-    return IColumn::Patch
+    if (!need_filter)
+        return IColumn::Patch{
+            .sources = std::move(sources), .src_col_indices = &src_block_indices,
+            .src_row_indices = src_row_indices, .dst_row_indices = dst_row_indices,
+            .dst_versions = dst_versions};
+
+    filtered_src_col_indices.clear();
+    filtered_src_row_indices.clear();
+    filtered_dst_row_indices.clear();
+
+    for (size_t j = 0; j < dst_row_indices.size(); ++j)
     {
+        if (!source_ok[src_block_indices[j]])
+            continue;
+        filtered_src_col_indices.push_back(remap[src_block_indices[j]]);
+        filtered_src_row_indices.push_back(src_row_indices[j]);
+        filtered_dst_row_indices.push_back(dst_row_indices[j]);
+    }
+
+    bool single_source = sources.size() == 1;
+    return IColumn::Patch{
         .sources = std::move(sources),
-        .src_col_indices = &src_block_indices,
-        .src_row_indices = src_row_indices,
-        .dst_row_indices = dst_row_indices,
-        .dst_versions = dst_versions,
-    };
+        .src_col_indices = single_source ? nullptr : &filtered_src_col_indices,
+        .src_row_indices = filtered_src_row_indices,
+        .dst_row_indices = filtered_dst_row_indices,
+        .dst_versions = dst_versions};
 }
 
 Block getUpdatedHeader(const PatchesToApply & patches, const NameSet & updated_columns)
@@ -278,10 +312,19 @@ Block getUpdatedHeader(const PatchesToApply & patches, const NameSet & updated_c
         headers.push_back(std::move(header));
     }
 
+    if (headers.empty())
+        return {};
+
+    /// Schema evolution may cause type mismatches across patch headers.
+    /// Skip assertion in that case — createPatchForColumn handles filtering.
+    for (size_t i = 1; i < headers.size(); ++i)
+        if (!isCompatibleHeader(headers[i], headers[0]))
+            return headers.front();
+
     for (size_t i = 1; i < headers.size(); ++i)
         assertCompatibleHeader(headers[i], headers[0], "patch parts");
 
-    return headers.empty() ? Block{} : headers.front();
+    return headers.front();
 }
 
 bool canApplyPatchesRaw(const PatchesToApply & patches)
@@ -332,9 +375,23 @@ void applyPatchesToBlockRaw(
             if (!patch_block.has(result_column.name))
                 continue;
 
-            const auto & patch_column = patch_block.getByName(result_column.name).column;
-            if (!patch_column)
+            const auto & patch_col_with_type = patch_block.getByName(result_column.name);
+            if (!patch_col_with_type.column)
                 continue;
+
+            /// If the column type in the patch part doesn't match the result column
+            /// (e.g., due to schema evolution changing a column's type), skip the patch
+            /// for this column. Applying a patch with mismatched types would cause
+            /// undefined behavior in insertFrom (SIGSEGV in release builds).
+            if (!result_column.type->equals(*patch_col_with_type.type))
+            {
+                LOG_WARNING(getLogger("applyPatches"),
+                    "Skipping patch for column {} because column type has changed ({} -> {})",
+                    result_column.name, patch_col_with_type.type->getName(), result_column.type->getName());
+                continue;
+            }
+
+            const auto & patch_column = patch_col_with_type.column;
 
             IColumn::Patch::Source source =
             {
@@ -377,7 +434,7 @@ void applyPatchesToBlockCombined(
             continue;
 
         auto & result_versions = addDataVersionForColumn(versions_block, result_column.name, result_block.rows(), source_data_version);
-        auto multi_patch = builder.createPatchForColumn(result_column.name, result_versions);
+        auto multi_patch = builder.createPatchForColumn(result_column.name, result_versions, result_column.type);
         result_column.column = removeSpecialRepresentations(result_column.column);
 
         if (canApplyPatchInplace(*result_column.column))

--- a/src/Storages/MergeTree/PatchParts/tests/gtest_apply_patches_type_mismatch.cpp
+++ b/src/Storages/MergeTree/PatchParts/tests/gtest_apply_patches_type_mismatch.cpp
@@ -1,0 +1,178 @@
+#include <gtest/gtest.h>
+
+#include <Storages/MergeTree/PatchParts/applyPatches.h>
+#include <Storages/MergeTree/MergeTreeVirtualColumns.h>
+#include <Columns/ColumnsNumber.h>
+#include <Columns/ColumnString.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/DataTypeString.h>
+
+using namespace DB;
+
+/// Regression test for a SIGSEGV that occurred in production when
+/// applyPatchesToBlock was called with a patch part whose column type
+/// had diverged from the result block type due to schema evolution.
+///
+/// Without the type->equals() guard the patch was applied blindly,
+/// causing insertFrom to reinterpret ColumnString memory as
+/// ColumnVector (or vice-versa) → SIGSEGV at a garbage pointer.
+///
+/// With the guard the mismatched patch is skipped and the result
+/// block retains its original data for that column.
+TEST(ApplyPatches, TypeMismatchSkipsPatch)
+{
+    /// ---------- result block (current schema: String column) ----------
+    auto result_col = ColumnString::create();
+    result_col->insert("aaa");
+    result_col->insert("bbb");
+    result_col->insert("ccc");
+
+    auto version_col = ColumnUInt64::create();
+    version_col->insert(1u);
+    version_col->insert(1u);
+    version_col->insert(1u);
+
+    Block result_block;
+    result_block.insert({result_col->getPtr(), std::make_shared<DataTypeString>(), "value"});
+    result_block.insert({version_col->getPtr(), std::make_shared<DataTypeUInt64>(), PartDataVersionColumn::name});
+
+    /// ---------- patch block (old schema: UInt64 column) ----------
+    auto patch_value_col = ColumnUInt64::create();
+    patch_value_col->insert(42u);
+
+    auto patch_version_col = ColumnUInt64::create();
+    patch_version_col->insert(2u);     /// higher version → patch wins if applied
+
+    Block patch_block;
+    patch_block.insert({patch_value_col->getPtr(), std::make_shared<DataTypeUInt64>(), "value"});
+    patch_block.insert({patch_version_col->getPtr(), std::make_shared<DataTypeUInt64>(), PartDataVersionColumn::name});
+
+    /// ---------- build PatchToApply ----------
+    auto patch = std::make_shared<PatchToApply>();
+    patch->patch_blocks.push_back(std::move(patch_block));
+    patch->result_row_indices.push_back(1);  /// update row 1
+    patch->patch_row_indices.push_back(0);   /// from patch row 0
+
+    PatchesToApply patches{std::move(patch)};
+    Block versions_block;
+
+    /// ---------- apply ----------
+    applyPatchesToBlock(result_block, versions_block, patches, {"value"}, /*source_data_version=*/ 1);
+
+    /// ---------- verify ----------
+    /// The patch has UInt64 type while the result has String type.
+    /// The guard must skip the patch, so row 1 keeps its original value.
+    const auto & col = result_block.getByName("value").column;
+    ASSERT_EQ(col->size(), 3u);
+    EXPECT_EQ((*col)[0].safeGet<String>(), "aaa");
+    EXPECT_EQ((*col)[1].safeGet<String>(), "bbb");   /// NOT "42" or garbled
+    EXPECT_EQ((*col)[2].safeGet<String>(), "ccc");
+}
+
+/// Sanity check: when types match the patch IS applied normally.
+TEST(ApplyPatches, SameTypeAppliesPatch)
+{
+    auto result_col = ColumnUInt64::create();
+    result_col->insert(100u);
+    result_col->insert(200u);
+    result_col->insert(300u);
+
+    auto version_col = ColumnUInt64::create();
+    version_col->insert(1u);
+    version_col->insert(1u);
+    version_col->insert(1u);
+
+    Block result_block;
+    result_block.insert({result_col->getPtr(), std::make_shared<DataTypeUInt64>(), "value"});
+    result_block.insert({version_col->getPtr(), std::make_shared<DataTypeUInt64>(), PartDataVersionColumn::name});
+
+    auto patch_value_col = ColumnUInt64::create();
+    patch_value_col->insert(999u);
+
+    auto patch_version_col = ColumnUInt64::create();
+    patch_version_col->insert(2u);
+
+    Block patch_block;
+    patch_block.insert({patch_value_col->getPtr(), std::make_shared<DataTypeUInt64>(), "value"});
+    patch_block.insert({patch_version_col->getPtr(), std::make_shared<DataTypeUInt64>(), PartDataVersionColumn::name});
+
+    auto patch = std::make_shared<PatchToApply>();
+    patch->patch_blocks.push_back(std::move(patch_block));
+    patch->result_row_indices.push_back(1);
+    patch->patch_row_indices.push_back(0);
+
+    PatchesToApply patches{std::move(patch)};
+    Block versions_block;
+
+    applyPatchesToBlock(result_block, versions_block, patches, {"value"}, /*source_data_version=*/ 1);
+
+    const auto & col = result_block.getByName("value").column;
+    ASSERT_EQ(col->size(), 3u);
+    EXPECT_EQ((*col)[0].safeGet<UInt64>(), 100u);
+    EXPECT_EQ((*col)[1].safeGet<UInt64>(), 999u);   /// patch applied
+    EXPECT_EQ((*col)[2].safeGet<UInt64>(), 300u);
+}
+
+/// When multiple patch sources exist and only some have mismatched types,
+/// the compatible sources must still be applied (per-source filtering).
+TEST(ApplyPatches, MixedTypeSourcesAppliesCompatibleOnes)
+{
+    /// Result block: String column with 4 rows.
+    auto result_col = ColumnString::create();
+    result_col->insert("a");
+    result_col->insert("b");
+    result_col->insert("c");
+    result_col->insert("d");
+
+    auto version_col = ColumnUInt64::create();
+    version_col->insert(1u);
+    version_col->insert(1u);
+    version_col->insert(1u);
+    version_col->insert(1u);
+
+    Block result_block;
+    result_block.insert({result_col->getPtr(), std::make_shared<DataTypeString>(), "value"});
+    result_block.insert({version_col->getPtr(), std::make_shared<DataTypeUInt64>(), PartDataVersionColumn::name});
+
+    /// Patch 1: INCOMPATIBLE — UInt64 type, wants to update row 1.
+    auto p1_value = ColumnUInt64::create();
+    p1_value->insert(42u);
+    auto p1_version = ColumnUInt64::create();
+    p1_version->insert(2u);
+
+    Block p1_block;
+    p1_block.insert({p1_value->getPtr(), std::make_shared<DataTypeUInt64>(), "value"});
+    p1_block.insert({p1_version->getPtr(), std::make_shared<DataTypeUInt64>(), PartDataVersionColumn::name});
+
+    auto patch1 = std::make_shared<PatchToApply>();
+    patch1->patch_blocks.push_back(std::move(p1_block));
+    patch1->result_row_indices.push_back(1);
+    patch1->patch_row_indices.push_back(0);
+
+    /// Patch 2: COMPATIBLE — String type, wants to update row 2.
+    auto p2_value = ColumnString::create();
+    p2_value->insert("updated");
+    auto p2_version = ColumnUInt64::create();
+    p2_version->insert(3u);
+
+    Block p2_block;
+    p2_block.insert({p2_value->getPtr(), std::make_shared<DataTypeString>(), "value"});
+    p2_block.insert({p2_version->getPtr(), std::make_shared<DataTypeUInt64>(), PartDataVersionColumn::name});
+
+    auto patch2 = std::make_shared<PatchToApply>();
+    patch2->patch_blocks.push_back(std::move(p2_block));
+    patch2->result_row_indices.push_back(2);
+    patch2->patch_row_indices.push_back(0);
+
+    PatchesToApply patches{std::move(patch1), std::move(patch2)};
+    Block versions_block;
+
+    applyPatchesToBlock(result_block, versions_block, patches, {"value"}, /*source_data_version=*/ 1);
+
+    const auto & col = result_block.getByName("value").column;
+    ASSERT_EQ(col->size(), 4u);
+    EXPECT_EQ((*col)[0].safeGet<String>(), "a");
+    EXPECT_EQ((*col)[1].safeGet<String>(), "b");        /// incompatible patch skipped
+    EXPECT_EQ((*col)[2].safeGet<String>(), "updated");   /// compatible patch applied
+    EXPECT_EQ((*col)[3].safeGet<String>(), "d");
+}


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
validate column structure before applying patches

### Details:
`applyPatchesToBlockRaw` matches patch columns to result columns by name only, without type validation. When schema evolution changes a column type (e.g., `UInt32` change to `String`), the patch column has a different type than the result column that results in crash.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.45` (included in `26.4` and later)
- Backported to: `26.3.17.13`
<!-- ch-version-info:end -->