### PR TITLE
Fix wrong node in test_jbod_ha_fetch_partition cleanup

### DIFF
--- a/tests/integration/test_jbod_ha/test.py
+++ b/tests/integration/test_jbod_ha/test.py
@@ -160,13 +160,13 @@ def test_jbod_ha_fetch_partition(start_cluster):
         assert int(node2.query("select count(p) from tbl")) == 10
 
         # Mimic disk recovery, just in case we add more tests later
-        node1.exec_in_container(
+        node2.exec_in_container(
             ["bash", "-c", "umount  /test_jbod_ha_jbod1"],
             privileged=True,
             user="root",
         )
 
-        node1.restart_clickhouse()
+        node2.restart_clickhouse()
 
     finally:
         for node in [node1, node2]:


### PR DESCRIPTION
## Summary
- Fix copy-paste bug in `test_jbod_ha_fetch_partition`: the test mounts proc on **node2** but the cleanup incorrectly unmounts and restarts **node1**, causing `umount: /test_jbod_ha_jbod1: target is busy` under TSan.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96130&sha=041d2e94874b0ca8cc527e2edec4f3e5daf012ee&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%201%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/96130

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.690`
<!-- ch-version-info:end -->