### PR TITLE
Allow PR body checks to parse inline changelog category and entry

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/pr_body_check.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_body_check.py
@@ -34,6 +34,9 @@ def check_changelog_entry(category, pr_body: str) -> str:
         if m:
             # Check if the entry is on the same line (e.g. "Changelog entry: Fix something")
             inline = (m.group(2) or "").strip()
+            # Strip markdown formatting markers (e.g. "**Changelog entry:**" yields "**")
+            inline = re.sub(r"^[-*_\s]*", "", inline)
+            inline = re.sub(r"[-*_\s]*$", "", inline)
             if inline:
                 entry_lines = [inline]
                 i += 1

--- a/ci/jobs/scripts/workflow_hooks/pr_body_check.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_body_check.py
@@ -27,16 +27,24 @@ def check_changelog_entry(category, pr_body: str) -> str:
     entry = ""
     i = 0
     while i < len(lines):
-        if re.match(
-            r"(?i)^[#>*_ ]*(short\s*description|change\s*log\s*entry)", lines[i]
-        ):
-            i += 1
-            # Can have one empty line between header and the entry itself.
-            # Filter it out.
-            if i < len(lines) and not lines[i]:
+        m = re.match(
+            r"(?i)^[#>*_ ]*(short\s*description|change\s*log\s*entry)(?:[^:]*:\s*(.*))?$",
+            lines[i],
+        )
+        if m:
+            # Check if the entry is on the same line (e.g. "Changelog entry: Fix something")
+            inline = (m.group(2) or "").strip()
+            if inline:
+                entry_lines = [inline]
                 i += 1
+            else:
+                i += 1
+                # Can have one empty line between header and the entry itself.
+                # Filter it out.
+                if i < len(lines) and not lines[i]:
+                    i += 1
+                entry_lines = []
             # All following lines until empty one are the changelog entry.
-            entry_lines = []
             while i < len(lines) and lines[i]:
                 entry_lines.append(lines[i])
                 i += 1

--- a/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
@@ -105,27 +105,38 @@ def get_category(pr_body: str) -> Tuple[str, str]:
     error = ""
     i = 0
     while i < len(lines):
-        if re.match(r"(?i)^[#>*_ ]*change\s*log\s*category", lines[i]):
-            i += 1
-            if i >= len(lines):
-                break
-            # Can have one empty line between header and the category
-            # itself. Filter it out.
-            if not lines[i]:
+        m = re.match(
+            r"(?i)^[#>*_ ]*change\s*log\s*category(?:[^:]*:\s*(.*))?$", lines[i]
+        )
+        if m:
+            # Check if the category is on the same line (e.g. "Changelog category: Bug Fix")
+            inline = (m.group(1) or "").strip()
+            inline = re.sub(r"^[-*_\s]*", "", inline)
+            inline = re.sub(r"[-*_\s]*$", "", inline)
+            if inline:
+                category = inline
+                i += 1
+            else:
                 i += 1
                 if i >= len(lines):
                     break
-            category = re.sub(r"^[-*\s]*", "", lines[i])
-            i += 1
+                # Can have one empty line between header and the category
+                # itself. Filter it out.
+                if not lines[i]:
+                    i += 1
+                    if i >= len(lines):
+                        break
+                category = re.sub(r"^[-*\s]*", "", lines[i])
+                i += 1
 
-            # Should not have more than one category. Require empty line
-            # after the first found category.
-            if i >= len(lines):
-                break
-            if lines[i]:
-                second_category = re.sub(r"^[-*\s]*", "", lines[i])
-                error = f"More than one changelog category specified: '{category}', '{second_category}'"
-                break
+                # Should not have more than one category. Require empty line
+                # after the first found category.
+                if i >= len(lines):
+                    break
+                if lines[i]:
+                    second_category = re.sub(r"^[-*\s]*", "", lines[i])
+                    error = f"More than one changelog category specified: '{category}', '{second_category}'"
+                    break
         else:
             i += 1
     if not category or normalize_category(category) not in CATEGORIES_FOLD:

--- a/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
@@ -114,7 +114,7 @@ def get_category(pr_body: str) -> Tuple[str, str]:
             inline = re.sub(r"^[-*_\s]*", "", inline)
             inline = re.sub(r"[-*_\s]*$", "", inline)
             if inline:
-                category = inline
+                new_category = inline
                 i += 1
             else:
                 i += 1
@@ -126,17 +126,20 @@ def get_category(pr_body: str) -> Tuple[str, str]:
                     i += 1
                     if i >= len(lines):
                         break
-                category = re.sub(r"^[-*\s]*", "", lines[i])
+                new_category = re.sub(r"^[-*\s]*", "", lines[i])
                 i += 1
 
                 # Should not have more than one category. Require empty line
                 # after the first found category.
-                if i >= len(lines):
-                    break
-                if lines[i]:
+                if i < len(lines) and lines[i]:
                     second_category = re.sub(r"^[-*\s]*", "", lines[i])
-                    error = f"More than one changelog category specified: '{category}', '{second_category}'"
+                    error = f"More than one changelog category specified: '{new_category}', '{second_category}'"
                     break
+
+            if category:
+                error = f"More than one changelog category specified: '{category}', '{new_category}'"
+                break
+            category = new_category
         else:
             i += 1
     if not category or normalize_category(category) not in CATEGORIES_FOLD:

--- a/tests/ci/changelog.py
+++ b/tests/ci/changelog.py
@@ -230,28 +230,48 @@ def generate_description(item: PullRequest, repo: Repository) -> Optional[Descri
     if lines:
         i = 0
         while i < len(lines):
-            if re.match(r"(?i)^[#>*_ ]*change\s*log\s*category", lines[i]):
-                i += 1
-                if i >= len(lines):
-                    break
-                # Can have one empty line between header and the category itself.
-                # Filter it out.
-                if not lines[i]:
+            m_cat = re.match(
+                r"(?i)^[#>*_ ]*change\s*log\s*category(?:[^:]*:\s*(.*))?$",
+                lines[i],
+            )
+            m_entry = re.match(
+                r"(?i)^[#>*_ ]*(short\s*description|change\s*log\s*entry)(?:[^:]*:\s*(.*))?$",
+                lines[i],
+            )
+            if m_cat:
+                # Check if the category is on the same line
+                inline = (m_cat.group(1) or "").strip()
+                inline = re.sub(r"^[-*_\s]*", "", inline)
+                inline = re.sub(r"[-*_\s]*$", "", inline)
+                if inline:
+                    category = inline
+                    i += 1
+                else:
                     i += 1
                     if i >= len(lines):
                         break
-                category = re.sub(r"^[-*\s]*", "", lines[i])
-                i += 1
-            elif re.match(
-                r"(?i)^[#>*_ ]*(short\s*description|change\s*log\s*entry)", lines[i]
-            ):
-                i += 1
-                # Can have one empty line between header and the entry itself.
-                # Filter it out.
-                if i < len(lines) and not lines[i]:
+                    # Can have one empty line between header and the category itself.
+                    # Filter it out.
+                    if not lines[i]:
+                        i += 1
+                        if i >= len(lines):
+                            break
+                    category = re.sub(r"^[-*\s]*", "", lines[i])
                     i += 1
+            elif m_entry:
+                # Check if the entry is on the same line
+                inline = (m_entry.group(2) or "").strip()
+                if inline:
+                    entry_lines = [inline]
+                    i += 1
+                else:
+                    i += 1
+                    # Can have one empty line between header and the entry itself.
+                    # Filter it out.
+                    if i < len(lines) and not lines[i]:
+                        i += 1
+                    entry_lines = []
                 # All following lines until empty one are the changelog entry.
-                entry_lines = []
                 while i < len(lines) and lines[i]:
                     entry_lines.append(lines[i])
                     i += 1

--- a/tests/ci/changelog.py
+++ b/tests/ci/changelog.py
@@ -244,7 +244,7 @@ def generate_description(item: PullRequest, repo: Repository) -> Optional[Descri
                 inline = re.sub(r"^[-*_\s]*", "", inline)
                 inline = re.sub(r"[-*_\s]*$", "", inline)
                 if inline:
-                    category = inline
+                    new_category = inline
                     i += 1
                 else:
                     i += 1
@@ -256,8 +256,12 @@ def generate_description(item: PullRequest, repo: Repository) -> Optional[Descri
                         i += 1
                         if i >= len(lines):
                             break
-                    category = re.sub(r"^[-*\s]*", "", lines[i])
+                    new_category = re.sub(r"^[-*\s]*", "", lines[i])
                     i += 1
+                # If we already found a category, this is a duplicate — skip
+                # silently (changelog.py doesn't report errors, just picks the first).
+                if not category:
+                    category = new_category
             elif m_entry:
                 # Check if the entry is on the same line
                 inline = (m_entry.group(2) or "").strip()

--- a/tests/ci/changelog.py
+++ b/tests/ci/changelog.py
@@ -265,6 +265,9 @@ def generate_description(item: PullRequest, repo: Repository) -> Optional[Descri
             elif m_entry:
                 # Check if the entry is on the same line
                 inline = (m_entry.group(2) or "").strip()
+                # Strip markdown formatting markers (e.g. "**Changelog entry:**" yields "**")
+                inline = re.sub(r"^[-*_\s]*", "", inline)
+                inline = re.sub(r"[-*_\s]*$", "", inline)
                 if inline:
                     entry_lines = [inline]
                     i += 1


### PR DESCRIPTION
## Summary
- PR body check scripts now accept changelog category and entry on the same line as the header (e.g., `Changelog category: <category>` instead of requiring them on the next line)
- Also handles bold/italic markdown formatting around headers (e.g., `**Changelog category:** <category>`)
- Updated all three parsing locations: `pr_labels_and_category.py`, `pr_body_check.py`, and `changelog.py`

Example of a PR that was broken: https://github.com/ClickHouse/ClickHouse/pull/99532

## Test plan
- [x] Tested with standard template format (value on next line)
- [x] Tested with inline format (`Changelog category: <category>`)
- [x] Tested with bold formatting (`**Changelog category:** <category>`)
- [x] Tested with italic formatting (`_Changelog category_: Improvement`)
- [x] Tested with no colon (header only, value on next line)
- [x] Tested multiple categories still produce error
- [x] Tested with full PR body from #99532

Changelog category: CI Fix or Improvement (changelog entry is not required)
Changelog entry: Allow PR body checks to parse inline changelog category and entry, and handle bold/italic formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.689`
<!-- ch-version-info:end -->