### PR TITLE
ci: support Docker-in-Docker for praktika job

### DIFF
--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -374,7 +374,34 @@ class Runner:
             for p_ in [path, path_1]:
                 if p_ and Path(p_).exists() and p_.startswith("/"):
                     extra_mounts += f" --volume {p_}:{p_}"
-            cmd = f"docker run {tty} --rm --name {container_name} {'--user $(id -u):$(id -g)' if not from_root else ''} -e PYTHONUNBUFFERED=1 -e PYTHONPATH='.:./ci' --volume ./:{current_dir} {extra_mounts} {gh_mount} {workdir} {' '.join(settings)} {docker} {job.command}"
+
+            # PRAKTIKA_HOST_WORKDIR overrides the host-side path used in
+            # --volume for the working directory mount.  Two main use cases:
+            #   1. Point the mount at an arbitrary host directory.
+            #   2. Docker-in-Docker: the inner Docker daemon needs the real
+            #      host path (not the outer container's CWD) for volume mounts.
+            #      This variable make it more flexible to set the real host path.
+            # When unset, defaults to "./" (current directory).
+            host_dir = os.environ.get("PRAKTIKA_HOST_WORKDIR", "./")
+
+            # Rewrite relative host paths in user-supplied --volume settings
+            # so that they resolve correctly when PRAKTIKA_HOST_WORKDIR is set
+            # (e.g. in Docker-in-Docker scenarios).
+            if host_dir != "./":
+                rewritten_settings = []
+                for s in settings:
+                    if s.startswith("--volume="):
+                        vol_arg = s.removeprefix("--volume=")
+                        src, sep, rest = vol_arg.partition(":")
+                        if src == ".":
+                            src = host_dir.rstrip("/")
+                        elif src.startswith("./"):
+                            src = host_dir.rstrip("/") + src[1:]
+                        s = f"--volume={src}{sep}{rest}"
+                    rewritten_settings.append(s)
+                settings = rewritten_settings
+
+            cmd = f"docker run {tty} --rm --name {container_name} {'--user $(id -u):$(id -g)' if not from_root else ''} -e PYTHONUNBUFFERED=1 -e PYTHONPATH='.:./ci' --volume {host_dir}:{current_dir} {extra_mounts} {gh_mount} {workdir} {' '.join(settings)} {docker} {job.command}"
         else:
             cmd = job.command
             python_path = os.getenv("PYTHONPATH", ":")
@@ -462,7 +489,7 @@ class Runner:
             # Get host user's UID and GID (not from inside the container)
             uid = os.getuid()
             gid = os.getgid()
-            chown_cmd = f"docker run --rm --user root --volume ./:{current_dir} --workdir={current_dir} {docker} chown -R {uid}:{gid} {Settings.TEMP_DIR}"
+            chown_cmd = f"docker run --rm --user root --volume {host_dir}:{current_dir} --workdir={current_dir} {docker} chown -R {uid}:{gid} {Settings.TEMP_DIR}"
             Shell.run(chown_cmd)
 
         return exit_code

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import os
 import re
+import shlex
 import sys
 import traceback
 from pathlib import Path
@@ -380,9 +381,10 @@ class Runner:
             #   1. Point the mount at an arbitrary host directory.
             #   2. Docker-in-Docker: the inner Docker daemon needs the real
             #      host path (not the outer container's CWD) for volume mounts.
-            #      This variable make it more flexible to set the real host path.
+            #      This variable makes it more flexible to set the real host path.
             # When unset, defaults to "./" (current directory).
             host_dir = os.environ.get("PRAKTIKA_HOST_WORKDIR", "./")
+            host_dir_q = shlex.quote(host_dir)
 
             # Rewrite relative host paths in user-supplied --volume settings
             # so that they resolve correctly when PRAKTIKA_HOST_WORKDIR is set
@@ -401,7 +403,7 @@ class Runner:
                     rewritten_settings.append(s)
                 settings = rewritten_settings
 
-            cmd = f"docker run {tty} --rm --name {container_name} {'--user $(id -u):$(id -g)' if not from_root else ''} -e PYTHONUNBUFFERED=1 -e PYTHONPATH='.:./ci' --volume {host_dir}:{current_dir} {extra_mounts} {gh_mount} {workdir} {' '.join(settings)} {docker} {job.command}"
+            cmd = f"docker run {tty} --rm --name {container_name} {'--user $(id -u):$(id -g)' if not from_root else ''} -e PYTHONUNBUFFERED=1 -e PYTHONPATH='.:./ci' --volume {host_dir_q}:{current_dir} {extra_mounts} {gh_mount} {workdir} {' '.join(settings)} {docker} {job.command}"
         else:
             cmd = job.command
             python_path = os.getenv("PYTHONPATH", ":")
@@ -489,7 +491,7 @@ class Runner:
             # Get host user's UID and GID (not from inside the container)
             uid = os.getuid()
             gid = os.getgid()
-            chown_cmd = f"docker run --rm --user root --volume {host_dir}:{current_dir} --workdir={current_dir} {docker} chown -R {uid}:{gid} {Settings.TEMP_DIR}"
+            chown_cmd = f"docker run --rm --user root --volume {host_dir_q}:{current_dir} --workdir={current_dir} {docker} chown -R {uid}:{gid} {Settings.TEMP_DIR}"
             Shell.run(chown_cmd)
 
         return exit_code

--- a/tests/integration/test_intersecting_parts/test.py
+++ b/tests/integration/test_intersecting_parts/test.py
@@ -22,6 +22,7 @@ def started_cluster():
 # This test constructs intersecting parts intentionally. It's not an elegant test.
 # TODO(hanfei): write a test which select part 1_1 merging with part 2_2 and drop range.
 def test_intersect_parts_when_restart(started_cluster):
+    node.query("DROP TABLE IF EXISTS data SYNC")
     node.query(
         """
          CREATE TABLE data (

--- a/tests/integration/test_intersecting_parts/test.py
+++ b/tests/integration/test_intersecting_parts/test.py
@@ -19,7 +19,7 @@ def started_cluster():
         cluster.shutdown()
 
 
-# This test construct intersecting parts intentially. It's not a elegent test.
+# This test constructs intersecting parts intentionally. It's not an elegant test.
 # TODO(hanfei): write a test which select part 1_1 merging with part 2_2 and drop range.
 def test_intersect_parts_when_restart(started_cluster):
     node.query(


### PR DESCRIPTION
Introduce env `PRAKTIKA_HOST_WORKDIR` to override the default host directory `./`.

`PRAKTIKA_HOST_WORKDIR` overrides the host-side path used in --volume for the working directory mount.  Two main use cases:
1. Point the mount at an arbitrary host directory.
2. Docker-in-Docker: the inner Docker daemon needs the real host path (not the outer container's CWD) for volume mounts.  This variable make it more flexible to set the real host path. 

When unset, defaults to "./" (current directory).

### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

ci: support Docker-in-Docker for praktika job

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.47`
<!-- ch-version-info:end -->