### PR TITLE
Cancel write buffers in IcebergStorageSink destructor

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -712,6 +712,11 @@ IcebergStorageSink::IcebergStorageSink(
     }
 }
 
+IcebergStorageSink::~IcebergStorageSink()
+{
+    cancelBuffers();
+}
+
 void IcebergStorageSink::consume(Chunk & chunk)
 {
     if (isCancelled())

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.h
@@ -85,7 +85,8 @@ public:
         const Iceberg::PersistentTableComponents & persistent_table_components_,
         const StorageID & table_id_);
 
-    ~IcebergStorageSink() override = default;
+    ~IcebergStorageSink() override;
+
 
     String getName() const override { return "IcebergStorageSink"; }
 


### PR DESCRIPTION
## Summary
- `IcebergStorageSink::~IcebergStorageSink()` was `= default`, but the `writer_per_partition_key` map holds `MultipleFileWriter` objects containing `WriteBuffer`s. If the sink is destroyed without `onFinish` or `onException` being called (e.g., when the pipeline is reset early), those buffers aren't finalized or canceled, triggering a `LOGICAL_ERROR` assertion: "WriteBuffer is neither finalized nor canceled in destructor."
- The fix adds a destructor that calls `cancelBuffers()`, which is safe to call even after finalize/release since `WriteBuffer::cancel` is a no-op on already finalized or canceled buffers.

Stress test (arm_asan) failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99366&sha=740fb11832c55538d991cd1e82170a10729c64b4&name_0=PR&name_1=Stress%20test%20%28arm_asan%29
https://github.com/ClickHouse/ClickHouse/pull/99366

### Changelog category (leave one):
- CI Fix or improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Cancel write buffers in `IcebergStorageSink` destructor to prevent LOGICAL_ERROR exception when the pipeline is reset before the sink finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.719`
<!-- ch-version-info:end -->