### PR TITLE
Reject ALTER TABLE that creates EPHEMERAL columns conflicting with virtual columns

### DIFF
--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1493,6 +1493,12 @@ void AlterCommands::validate(const StoragePtr & table, ContextPtr context) const
                 throw Exception(ErrorCodes::ILLEGAL_COLUMN,
                     "Cannot add column {}: this column name is reserved for persistent virtual column", backQuote(column_name));
 
+            if (command.default_kind == ColumnDefaultKind::Ephemeral
+                && virtuals->tryGet(column_name, VirtualsKind::Ephemeral))
+                throw Exception(ErrorCodes::ILLEGAL_COLUMN,
+                    "Cannot add ephemeral column {}: it conflicts with a virtual column of the same name",
+                    backQuote(column_name));
+
             if (command.codec)
             {
                 const auto & settings = context->getSettingsRef();
@@ -1520,6 +1526,12 @@ void AlterCommands::validate(const StoragePtr & table, ContextPtr context) const
             if (renamed_columns.contains(column_name))
                 throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Cannot rename and modify the same column {} "
                                                              "in a single ALTER query", backQuote(column_name));
+
+            if (command.default_kind == ColumnDefaultKind::Ephemeral
+                && virtuals->tryGet(column_name, VirtualsKind::Ephemeral))
+                throw Exception(ErrorCodes::ILLEGAL_COLUMN,
+                    "Cannot modify column {} to ephemeral: it conflicts with a virtual column of the same name",
+                    backQuote(column_name));
 
             if (command.codec)
             {
@@ -1733,6 +1745,12 @@ void AlterCommands::validate(const StoragePtr & table, ContextPtr context) const
             if (virtuals->tryGet(command.rename_to, VirtualsKind::Persistent))
                 throw Exception(ErrorCodes::ILLEGAL_COLUMN,
                     "Cannot rename to {}: this column name is reserved for persistent virtual column", backQuote(command.rename_to));
+
+            if (all_columns.get(command.column_name).default_desc.kind == ColumnDefaultKind::Ephemeral
+                && virtuals->tryGet(command.rename_to, VirtualsKind::Ephemeral))
+                throw Exception(ErrorCodes::ILLEGAL_COLUMN,
+                    "Cannot rename ephemeral column to {}: it conflicts with a virtual column of the same name",
+                    backQuote(command.rename_to));
 
             if (modified_columns.contains(column_name))
                 throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Cannot rename and modify the same column {} "

--- a/tests/queries/0_stateless/04040_alter_ephemeral_column_conflicts_with_virtual.sql
+++ b/tests/queries/0_stateless/04040_alter_ephemeral_column_conflicts_with_virtual.sql
@@ -1,0 +1,20 @@
+-- ALTER TABLE should not allow creating EPHEMERAL columns that conflict with virtual columns.
+-- This is the ALTER counterpart of the CREATE TABLE validation added in PR #99031.
+-- https://github.com/ClickHouse/ClickHouse/issues/99437
+
+DROP TABLE IF EXISTS t;
+
+CREATE TABLE t (key UInt32) ENGINE = MergeTree ORDER BY key;
+
+ALTER TABLE t ADD COLUMN `_part_offset` UInt8 EPHEMERAL 0; -- { serverError ILLEGAL_COLUMN }
+
+-- MODIFY COLUMN to EPHEMERAL should also be rejected
+ALTER TABLE t ADD COLUMN `_part_offset` UInt64;
+ALTER TABLE t MODIFY COLUMN `_part_offset` UInt8 EPHEMERAL 0; -- { serverError ILLEGAL_COLUMN }
+ALTER TABLE t DROP COLUMN `_part_offset`;
+
+-- DEFAULT columns with virtual column names should still work (they have physical storage)
+ALTER TABLE t ADD COLUMN `_part_offset` UInt64 DEFAULT 0;
+ALTER TABLE t DROP COLUMN `_part_offset`;
+
+DROP TABLE t;


### PR DESCRIPTION
## Summary
- PR #99031 fixed CREATE TABLE validation to reject EPHEMERAL columns that shadow virtual columns, but `AlterCommands::validate` was not updated
- `ALTER TABLE ADD COLUMN _part_offset UInt8 EPHEMERAL 0` could create an invalid state causing `LOGICAL_ERROR` on SELECT due to type mismatch between the Block header and virtual column data
- Added the same ephemeral-vs-virtual conflict check for ADD COLUMN, MODIFY COLUMN, and RENAME COLUMN in `AlterCommands::validate`

Fixes #99437

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `LOGICAL_ERROR` when using `ALTER TABLE ADD COLUMN` to create an `EPHEMERAL` column with the same name as a virtual column (e.g. `_part_offset`).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.726`
<!-- ch-version-info:end -->