### PR TITLE
Fix SIGSEGV in SortCursor JIT call under UBSan

### DIFF
--- a/src/Core/SortCursor.h
+++ b/src/Core/SortCursor.h
@@ -184,7 +184,7 @@ struct SortCursor : SortCursorHelper<SortCursor>
             assert(impl->raw_sort_columns_data.size() == rhs.impl->raw_sort_columns_data.size());
 
             auto sort_description_func_typed = reinterpret_cast<JITSortDescriptionFunc>(impl->desc.compiled_sort_description);
-            int res = sort_description_func_typed(lhs_pos, rhs_pos, impl->raw_sort_columns_data.data(), rhs.impl->raw_sort_columns_data.data()); /// NOLINT
+            int res = callJITFunction(sort_description_func_typed, lhs_pos, rhs_pos, impl->raw_sort_columns_data.data(), rhs.impl->raw_sort_columns_data.data());
 
             if (res > 0)
                 return true;
@@ -235,7 +235,7 @@ struct SimpleSortCursor : SortCursorHelper<SimpleSortCursor>
             assert(impl->raw_sort_columns_data.size() == rhs.impl->raw_sort_columns_data.size());
 
             auto sort_description_func_typed = reinterpret_cast<JITSortDescriptionFunc>(impl->desc.compiled_sort_description);
-            res = sort_description_func_typed(lhs_pos, rhs_pos, impl->raw_sort_columns_data.data(), rhs.impl->raw_sort_columns_data.data()); /// NOLINT
+            res = callJITFunction(sort_description_func_typed, lhs_pos, rhs_pos, impl->raw_sort_columns_data.data(), rhs.impl->raw_sort_columns_data.data());
         }
         else
 #endif

--- a/src/Core/SortCursor.h
+++ b/src/Core/SortCursor.h
@@ -184,7 +184,7 @@ struct SortCursor : SortCursorHelper<SortCursor>
             assert(impl->raw_sort_columns_data.size() == rhs.impl->raw_sort_columns_data.size());
 
             auto sort_description_func_typed = reinterpret_cast<JITSortDescriptionFunc>(impl->desc.compiled_sort_description);
-            int res = callJITFunction(sort_description_func_typed, lhs_pos, rhs_pos, impl->raw_sort_columns_data.data(), rhs.impl->raw_sort_columns_data.data());
+            int res = static_cast<int>(callJITFunction(sort_description_func_typed, lhs_pos, rhs_pos, impl->raw_sort_columns_data.data(), rhs.impl->raw_sort_columns_data.data()));
 
             if (res > 0)
                 return true;
@@ -235,7 +235,7 @@ struct SimpleSortCursor : SortCursorHelper<SimpleSortCursor>
             assert(impl->raw_sort_columns_data.size() == rhs.impl->raw_sort_columns_data.size());
 
             auto sort_description_func_typed = reinterpret_cast<JITSortDescriptionFunc>(impl->desc.compiled_sort_description);
-            res = callJITFunction(sort_description_func_typed, lhs_pos, rhs_pos, impl->raw_sort_columns_data.data(), rhs.impl->raw_sort_columns_data.data());
+            res = static_cast<int>(callJITFunction(sort_description_func_typed, lhs_pos, rhs_pos, impl->raw_sort_columns_data.data(), rhs.impl->raw_sort_columns_data.data()));
         }
         else
 #endif

--- a/src/Interpreters/JIT/compileFunction.h
+++ b/src/Interpreters/JIT/compileFunction.h
@@ -40,9 +40,9 @@ using JITCompiledFunction = void (*)(ColumnDataRowsSize, ColumnData *);
   * the read accesses unmapped memory, causing a SIGSEGV.
   */
 template <typename F, typename... Args>
-NO_SANITIZE_UNDEFINED inline void callJITFunction(F && f, Args &&... args)
+NO_SANITIZE_UNDEFINED inline decltype(auto) callJITFunction(F && f, Args &&... args)
 {
-    f(std::forward<Args>(args)...);
+    return f(std::forward<Args>(args)...);
 }
 
 struct CompiledFunction


### PR DESCRIPTION
### Changelog category (leave one):
  - CI Fix or Improvement (changelog entry is not required)


  ### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
  N/A

  ### Documentation entry for user-facing changes

  - [ ] Documentation is written (mandatory for new features)

  No user-facing changes.

  ---

  Fix SIGSEGV that occurs in CI UBSan tests when `SortCursor::greaterAt` or `SimpleSortCursor::greaterAt` calls a JIT-compiled sort description function.

  **Root cause**: UBSan's `-fsanitize=function` reads a type signature at `function_pointer - 8` before every indirect call. JIT-compiled functions don't have this prologue, and when JIT code is at a page boundary, the read
   accesses unmapped memory, causing a SIGSEGV.

  A `callJITFunction` wrapper with `NO_SANITIZE_UNDEFINED` already exists for this exact purpose (used by all aggregate function JIT calls), but the two sort description JIT call sites in `SortCursor.h` were calling the
  function pointer directly (with only a `/// NOLINT` to suppress the linter, not the sanitizer).

  **Fix**:
  1. Change `callJITFunction` return type from `void` to `decltype(auto)` so it can forward return values (sort comparators return `int8_t`, unlike aggregate functions which return `void`)
  2. Wrap both direct JIT calls in `SortCursor.h` with `callJITFunction`

  CI evidence: https://s3.amazonaws.com/clickhouse-test-reports/PRs/99390/a1c4213d5a228c06f1ea9865bccc910cbe16a4e0/stateless_tests_amd_ubsan_parallel/clickhouse-server.err.log

  Seen in: #98538, #99246, #99390, #98607

  Fixes: https://github.com/ClickHouse/ClickHouse/issues/99503