### PR TITLE
Fix cache config leftover in test_storage_iceberg_with_spark

### DIFF
--- a/tests/integration/test_storage_iceberg_with_spark/conftest.py
+++ b/tests/integration/test_storage_iceberg_with_spark/conftest.py
@@ -1,3 +1,4 @@
+import os
 import os.path as p
 import random
 
@@ -141,3 +142,5 @@ def started_cluster_iceberg_with_spark():
 
     finally:
         cluster.shutdown()
+        if p.exists(filesystem_cache_config_path):
+            os.remove(filesystem_cache_config_path)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Fixes #99568


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.744`
<!-- ch-version-info:end -->