### PR TITLE
Fix VectorSimilarityIndexCache entries never evicted after part removal

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -485,6 +485,9 @@ void IMergeTreeDataPart::removeIndexFromCache(PrimaryIndexCache * index_cache) c
     index_cache->remove(key);
 }
 
+/// Remove all vector similarity index cache entries for this part.
+/// The cache key must use `getRelativePathOfActivePart` (not `getFullPath`) to match
+/// the key used during insertion in `MergeTreeIndexReader::read`.
 void IMergeTreeDataPart::removeFromVectorIndexCache(VectorSimilarityIndexCache * vector_similarity_index_cache) const
 {
     if (!vector_similarity_index_cache)

--- a/src/Storages/MergeTree/MergeTreeIndexReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexReader.cpp
@@ -146,7 +146,11 @@ void MergeTreeIndexReader::read(size_t mark, const IMergeTreeIndexCondition * co
     ///
     /// The same cannot be done for other skip indexes. Because their GRANULARITY is small (e.g. 1), the sheer number of skip index granules
     /// would create too much lock contention in the cache (this was learned the hard way).
-    if (index->isVectorSimilarityIndex())
+    /// Don't populate the cache for parts which are not Active (e.g. Outdated after a mutation).
+    /// Such parts will be removed soon and caching them is wasteful.
+    /// Also note that the cache key must use `getRelativePathOfActivePart` (not `getFullPath`) to match
+    /// the key used during eviction in `IMergeTreeDataPart::removeFromVectorIndexCache`.
+    if (index->isVectorSimilarityIndex() && part->getState() == MergeTreeDataPartState::Active)
     {
         VectorSimilarityIndexCacheKey key{part->getDataPartStorage().getDiskName() + ":" + part->getRelativePathOfActivePart(),
                                           index->getFileName(),

--- a/src/Storages/MergeTree/MergeTreeIndexReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexReader.cpp
@@ -148,7 +148,7 @@ void MergeTreeIndexReader::read(size_t mark, const IMergeTreeIndexCondition * co
     /// would create too much lock contention in the cache (this was learned the hard way).
     if (index->isVectorSimilarityIndex())
     {
-        VectorSimilarityIndexCacheKey key{part->getDataPartStorage().getDiskName() + ":" + part->getDataPartStorage().getFullPath(),
+        VectorSimilarityIndexCacheKey key{part->getDataPartStorage().getDiskName() + ":" + part->getRelativePathOfActivePart(),
                                           index->getFileName(),
                                           mark};
 

--- a/tests/queries/0_stateless/04040_vector_search_cache_eviction_on_mutation.reference
+++ b/tests/queries/0_stateless/04040_vector_search_cache_eviction_on_mutation.reference
@@ -1,0 +1,6 @@
+VectorSimilarityIndexCacheBytes	0
+5
+6
+7
+VectorSimilarityIndexCacheBytes	Good
+VectorSimilarityIndexCacheBytes	0

--- a/tests/queries/0_stateless/04040_vector_search_cache_eviction_on_mutation.sh
+++ b/tests/queries/0_stateless/04040_vector_search_cache_eviction_on_mutation.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-ordinary-database, no-parallel
+# no-parallel: checks server-wide VectorSimilarityIndexCacheBytes metric
+
+# Regression test: verify that VectorSimilarityIndexCache entries are evicted
+# when old parts are removed after a mutation (not only on DROP TABLE).
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS tab"
+$CLICKHOUSE_CLIENT --query "SYSTEM DROP VECTOR SIMILARITY INDEX CACHE"
+
+# Cache must be empty
+$CLICKHOUSE_CLIENT --query "SELECT metric, value FROM system.metrics WHERE metric = 'VectorSimilarityIndexCacheBytes'"
+
+$CLICKHOUSE_CLIENT --query "
+    CREATE TABLE tab (
+        id Int32,
+        vec Array(Float32),
+        INDEX idx vec TYPE vector_similarity('hnsw', 'L2Distance', 2)
+    )
+    ENGINE = MergeTree ORDER BY id
+    SETTINGS index_granularity = 8192, old_parts_lifetime = 0, merge_tree_clear_old_parts_interval_seconds = 1, cleanup_delay_period = 0, cleanup_delay_period_random_add = 0, cleanup_thread_preferred_points_per_iteration = 0
+"
+
+$CLICKHOUSE_CLIENT --query "
+    INSERT INTO tab VALUES
+        (0, [1.0, 0.0]), (1, [1.1, 0.0]), (2, [1.2, 0.0]), (3, [1.3, 0.0]), (4, [1.4, 0.0]),
+        (5, [0.0, 2.0]), (6, [0.0, 2.1]), (7, [0.0, 2.2]), (8, [0.0, 2.3]), (9, [0.0, 2.4])
+"
+
+# Populate vector similarity index cache
+$CLICKHOUSE_CLIENT --query "
+    WITH [0.0, 2.0] AS reference_vec
+    SELECT id FROM tab ORDER BY L2Distance(vec, reference_vec) LIMIT 3
+"
+
+# Cache must be non-empty now
+$CLICKHOUSE_CLIENT --query "SELECT metric, IF(value > 0, 'Good', 'Zero') FROM system.metrics WHERE metric = 'VectorSimilarityIndexCacheBytes'"
+
+# Mutation replaces the part; the old part becomes Outdated
+$CLICKHOUSE_CLIENT --query "ALTER TABLE tab DELETE WHERE id = 0 SETTINGS mutations_sync = 2"
+
+# Wait until the old part is cleaned up (removed from disk and caches cleared)
+for _ in $(seq 1 60); do
+    cnt=$($CLICKHOUSE_CLIENT --query "SELECT count() FROM system.parts WHERE database = currentDatabase() AND table = 'tab'")
+    if [ "$cnt" -eq 1 ]; then
+        break
+    fi
+    sleep 1
+done
+
+# The old part's cache entries must have been evicted.
+# The new (mutated) part has not been queried yet, so cache must be empty.
+$CLICKHOUSE_CLIENT --query "SELECT metric, value FROM system.metrics WHERE metric = 'VectorSimilarityIndexCacheBytes'"
+
+$CLICKHOUSE_CLIENT --query "DROP TABLE tab SYNC"


### PR DESCRIPTION
## Summary

The `VectorSimilarityIndexCache` key was constructed using `getFullPath` which returns an absolute path. This path changes when a part is moved between disks or detached. The eviction code in `IMergeTreeDataPart::remove` constructs the key using a different path, so the lookup never matches and cache entries are never freed.

Use `getRelativePathOfActivePart` instead so that the key used during eviction matches the key used during insertion.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `VectorSimilarityIndexCache` entries never being evicted after part removal due to mismatched cache keys.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.874`
<!-- ch-version-info:end -->