### PR TITLE
Add comments in wide integer ARM rounding emulation

### DIFF
--- a/base/base/wide_integer_impl.h
+++ b/base/base/wide_integer_impl.h
@@ -58,9 +58,12 @@ constexpr long double round_to_64bit_mantissa(long double value) noexcept
     // Scale to extract exactly 64 bits of precision
     constexpr long double scale = static_cast<long double>(1ULL << 63) * 2.0L; // 2^64
 
-    // Use rint (round-to-nearest-even) to match x86 FPU default rounding mode,
-    // rather than std::round which uses ties-away-from-zero.
-    long double scaled = std::rint(mantissa * scale);
+    // N.B. std::round (ties away from zero) is used intentionally, NOT std::rint (ties to even).
+    // On ARM, division by max_int can produce results with an exact .5 fractional part
+    // (e.g., 9223372036854775808.5) because the 113-bit mantissa preserves it. On x86,
+    // the 64-bit mantissa truncates the same division to 9223372036854775809.0 directly.
+    // std::round matches x86's truncation direction for these tie cases; std::rint does not.
+    long double scaled = std::round(mantissa * scale);
 
     // Convert back to normalized mantissa with 64-bit precision
     long double rounded_mantissa = scaled / scale;

--- a/base/base/wide_integer_impl.h
+++ b/base/base/wide_integer_impl.h
@@ -57,7 +57,10 @@ constexpr long double round_to_64bit_mantissa(long double value) noexcept
     // mantissa is now in range [0.5, 1.0) or (-1.0, -0.5]
     // Scale to extract exactly 64 bits of precision
     constexpr long double scale = static_cast<long double>(1ULL << 63) * 2.0L; // 2^64
-    long double scaled = std::round(mantissa * scale);
+
+    // Use rint (round-to-nearest-even) to match x86 FPU default rounding mode,
+    // rather than std::round which uses ties-away-from-zero.
+    long double scaled = std::rint(mantissa * scale);
 
     // Convert back to normalized mantissa with 64-bit precision
     long double rounded_mantissa = scaled / scale;


### PR DESCRIPTION
## Summary
- `round_to_64bit_mantissa` in `wide_integer_impl.h` used `std::round` (ties away from zero), but x86 FPU defaults to round-to-nearest-even
- Replace with `std::rint` which respects the current rounding mode (round-to-nearest-even by default), correctly matching x86 80-bit extended precision tie-breaking behavior

Followup to #96633.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.737`
<!-- ch-version-info:end -->