### PR TITLE
Propagate case sensitivity from parent disk to cache wrapper

### DIFF
--- a/src/Disks/DiskObjectStorage/DiskObjectStorageCache.cpp
+++ b/src/Disks/DiskObjectStorage/DiskObjectStorageCache.cpp
@@ -30,6 +30,12 @@ DiskObjectStoragePtr DiskObjectStorage::wrapWithCache(FileCachePtr cache, const 
     /// Link with target disk.
     cache_disk->wrapped_disk = std::dynamic_pointer_cast<const DiskObjectStorage>(shared_from_this());
 
+    /// Inherit case sensitivity from the parent disk to avoid a redundant
+    /// lazy probe on the cache wrapper. The underlying storage is the same,
+    /// so case sensitivity is invariant between parent and wrapper.
+    if (auto cs = getCachedCaseSensitivity())
+        cache_disk->setCaseSensitivityChecked(*cs);
+
     return cache_disk;
 }
 

--- a/src/Disks/IDisk.h
+++ b/src/Disks/IDisk.h
@@ -578,6 +578,28 @@ public:
     bool isCaseInsensitive();
 
 protected:
+    /// Returns the cached case sensitivity result if already computed, or nullopt.
+    /// Used to propagate case sensitivity to wrapper disks without triggering
+    /// a lazy probe.
+    std::optional<bool> getCachedCaseSensitivity() const
+    {
+        if (is_case_sensitivity_checked.load())
+            return is_case_insensitive.load();
+        return std::nullopt;
+    }
+
+    /// Set the case sensitivity flag directly, bypassing the lazy probe.
+    /// Used when wrapping a disk (e.g., cache layer) that shares the same
+    /// underlying storage and thus the same case sensitivity property.
+    /// No lock needed: called on a freshly created disk before it is shared
+    /// between threads. The seq_cst stores ensure any later reader of
+    /// `isCaseInsensitive` sees the updated flags via the fast-path check.
+    void setCaseSensitivityChecked(bool case_insensitive)
+    {
+        is_case_insensitive = case_insensitive;
+        is_case_sensitivity_checked = true;
+    }
+
     const String name;
 
     /// Base implementation of the function copy().


### PR DESCRIPTION
When `DiskObjectStorage` is wrapped with a cache layer via `wrapWithCache`, the cache wrapper previously had to perform its own lazy probe to determine case sensitivity, even though the underlying storage is identical. This adds `getCachedCaseSensitivity` and `setCaseSensitivityChecked` helpers to `IDisk` so the parent can propagate its already-computed result to the wrapper, avoiding the redundant filesystem probe.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Fix redundant case-sensitivity filesystem probe on cache-wrapped `DiskObjectStorage` by propagating the already-computed result from the parent disk.

CI report: https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?PR=52438&sha=c5d57d81acfe4e943b1b0fccc8e84b02050adfd4&name_0=PR&name_1=Stateless%20tests%20%28amd_asan%2C%20db%20disk%2C%20distributed%20cache%2C%20meta%20storage%20in%20keeper%2C%20s3%20storage%2C%20sequential%2C%202%2F2%29
### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
