### PR TITLE
Forbid reading google credentials from local file

### DIFF
--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -209,48 +209,9 @@ std::shared_ptr<DataLake::ICatalog> DatabaseDataLake::getCatalog() const
 
             if (settings[DatabaseDataLakeSetting::google_adc_credentials_file].changed)
             {
-                try
-                {
-                    const std::string & credentials_file_path = settings[DatabaseDataLakeSetting::google_adc_credentials_file].value;
-                    DB::ReadBufferFromFile file_buf(credentials_file_path);
-                    std::string json_str;
-                    DB::readStringUntilEOF(json_str, file_buf);
-
-                    Poco::JSON::Parser parser;
-                    Poco::Dynamic::Var json = parser.parse(json_str);
-                    const Poco::JSON::Object::Ptr & object = json.extract<Poco::JSON::Object::Ptr>();
-
-                    if (object->has("type"))
-                    {
-                        String type = object->get("type").extract<String>();
-                        if (type != "authorized_user")
-                        {
-                            throw DB::Exception(
-                                DB::ErrorCodes::BAD_ARGUMENTS,
-                                "Unsupported credentials type '{}' in Google ADC credentials file. Expected 'authorized_user'",
-                                type);
-                        }
-                    }
-
-                    if (google_adc_client_id.empty() && object->has("client_id"))
-                        google_adc_client_id = object->get("client_id").extract<String>();
-                    if (google_adc_client_secret.empty() && object->has("client_secret"))
-                        google_adc_client_secret = object->get("client_secret").extract<String>();
-                    if (google_adc_refresh_token.empty() && object->has("refresh_token"))
-                        google_adc_refresh_token = object->get("refresh_token").extract<String>();
-                    if (google_adc_quota_project_id.empty() && object->has("quota_project_id"))
-                        google_adc_quota_project_id = object->get("quota_project_id").extract<String>();
-                    if (google_project_id.empty() && object->has("project_id"))
-                        google_project_id = object->get("project_id").extract<String>();
-                }
-                catch (const DB::Exception & e)
-                {
-                    throw DB::Exception(
-                        DB::ErrorCodes::BAD_ARGUMENTS,
-                        "Failed to load Google ADC credentials from file '{}': {}",
-                        settings[DatabaseDataLakeSetting::google_adc_credentials_file].value,
-                        e.message());
-                }
+                throw DB::Exception(
+                    DB::ErrorCodes::BAD_ARGUMENTS,
+                    "reading google credentials from file is deprecated");
             }
 
             catalog_impl = std::make_shared<DataLake::BigLakeCatalog>(

--- a/src/Databases/DataLake/DatabaseDataLakeSettings.cpp
+++ b/src/Databases/DataLake/DatabaseDataLakeSettings.cpp
@@ -41,7 +41,7 @@ namespace ErrorCodes
     DECLARE(String, google_adc_client_secret, "", "Google Application Default Credentials client_secret for BigLake. Required if using ADC authentication instead of metadata service", 0) \
     DECLARE(String, google_adc_refresh_token, "", "Google Application Default Credentials refresh_token for BigLake. Required if using ADC authentication instead of metadata service", 0) \
     DECLARE(String, google_adc_quota_project_id, "", "Google Application Default Credentials quota_project_id for BigLake. Optional, used if google_project_id is not set", 0) \
-    DECLARE(String, google_adc_credentials_file, "", "Path to JSON file containing Google Application Default Credentials. If set, credentials will be loaded from this file. File should contain: type, client_id, client_secret, refresh_token, and optionally quota_project_id", 0) \
+    DECLARE(String, google_adc_credentials_file, "", "Deprecated setting. Path to JSON file containing Google Application Default Credentials. If set, credentials will be loaded from this file. File should contain: type, client_id, client_secret, refresh_token, and optionally quota_project_id", 0) \
     DECLARE(String, dlf_access_key_id, "", "Access id of DLF token for Paimon REST Catalog", 0) \
     DECLARE(String, dlf_access_key_secret, "", "Access secret of DLF token for Paimon REST Catalog", 0) \
 

--- a/src/Databases/DataLake/DatabaseDataLakeSettings.cpp
+++ b/src/Databases/DataLake/DatabaseDataLakeSettings.cpp
@@ -41,7 +41,7 @@ namespace ErrorCodes
     DECLARE(String, google_adc_client_secret, "", "Google Application Default Credentials client_secret for BigLake. Required if using ADC authentication instead of metadata service", 0) \
     DECLARE(String, google_adc_refresh_token, "", "Google Application Default Credentials refresh_token for BigLake. Required if using ADC authentication instead of metadata service", 0) \
     DECLARE(String, google_adc_quota_project_id, "", "Google Application Default Credentials quota_project_id for BigLake. Optional, used if google_project_id is not set", 0) \
-    DECLARE(String, google_adc_credentials_file, "", "Deprecated setting. Path to JSON file containing Google Application Default Credentials. If set, credentials will be loaded from this file. File should contain: type, client_id, client_secret, refresh_token, and optionally quota_project_id", 0) \
+    DECLARE(String, google_adc_credentials_file, "", "Deprecated setting, will throw an exception if used", 0) \
     DECLARE(String, dlf_access_key_id, "", "Access id of DLF token for Paimon REST Catalog", 0) \
     DECLARE(String, dlf_access_key_secret, "", "Access secret of DLF token for Paimon REST Catalog", 0) \
 


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/clickhouse-private/issues/52499

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Forbid reading Google credentials from a local file. This setting is insecure because it allows reading other credentials if the file path is known.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Backported to: `26.2.6.22`
<!-- ch-version-info:end -->