### PR TITLE
Fix AST fuzzer crash on ATTACH TABLE ... FROM toggled to CREATE

### DIFF
--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -2848,7 +2848,15 @@ void QueryFuzzer::fuzz(ASTPtr & ast)
     {
         /// Toggle CREATE ↔ ATTACH to exercise the attach path with the same schema
         if (fuzz_rand() % 100 == 0)
+        {
             create_query->attach = !create_query->attach;
+            /// `FROM 'path'` is only valid for ATTACH, not CREATE
+            if (!create_query->attach)
+            {
+                create_query->has_attach_from_path = false;
+                create_query->attach_from_path.clear();
+            }
+        }
         fuzzCreateQuery(*create_query);
     }
     else if (auto * drop_query = typeid_cast<ASTDropQuery *>(ast.get()))

--- a/src/Parsers/ASTCreateQuery.cpp
+++ b/src/Parsers/ASTCreateQuery.cpp
@@ -394,7 +394,7 @@ void ASTCreateQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & 
         if (uuid != UUIDHelpers::Nil)
             ostr << " UUID " << quoteString(toString(uuid));
 
-        assert(attach || !has_attach_from_path);
+        chassert(attach || !has_attach_from_path);
         if (has_attach_from_path)
             ostr << " FROM " << quoteString(attach_from_path);
 


### PR DESCRIPTION
## Summary

- The AST fuzzer toggles `CREATE` ↔ `ATTACH` ([introduced in #98914](https://github.com/ClickHouse/ClickHouse/pull/98914)) but didn't clear `has_attach_from_path` when flipping to `CREATE`, producing an invalid AST that hit `assert(attach || !has_attach_from_path)` in `ASTCreateQuery::formatQueryImpl`.
- Clear the attach-from-path fields when toggling `ATTACH` → `CREATE`, and downgrade the assertion to `chassert`.

Fuzzer crash: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98230&sha=c5b06b3aa454794ea987219951b34959135f47fb&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%29
https://github.com/ClickHouse/ClickHouse/pull/98230

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.743`
<!-- ch-version-info:end -->