### PR TITLE
Added fix `input_format_connection_handling`

### DIFF
--- a/src/Processors/Formats/IRowInputFormat.cpp
+++ b/src/Processors/Formats/IRowInputFormat.cpp
@@ -322,6 +322,7 @@ void IRowInputFormat::resetParser()
     IInputFormat::resetParser();
     total_rows = 0;
     num_errors = 0;
+    got_connection_exception = false;
     block_missing_values.clear();
 }
 


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Continues https://github.com/ClickHouse/ClickHouse/pull/94509.

The current change affect `input_format_connection_handling`.  It resets the variable `got_connection_error` in `IRowInputFormat::resetParser()`. This would allow to use the same format even after a connection error has happened. This is relevant mostly for `StreamingFormatExecutor`. However, the current code in  `StreamingFormatExecutor` does not allow setting `got_connection_error` to true, since in case of streaming engines and async inserts (the cases when we reuse the same parser) it uses `ReadBuffer*` which do not throw connection errors. 

However, for the future, if the implementation changes, this might fire, so we fix this error at the early stage.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.746`
<!-- ch-version-info:end -->