### PR TITLE
[WIP] Add backup engine URL()

### DIFF
--- a/src/Backups/BackupFactory.cpp
+++ b/src/Backups/BackupFactory.cpp
@@ -56,6 +56,7 @@ void registerBackupEngineMemory(BackupFactory &);
 void registerBackupEngineNull(BackupFactory &);
 void registerBackupEngineS3(BackupFactory &);
 void registerBackupEngineAzureBlobStorage(BackupFactory &);
+void registerBackupEngineURL(BackupFactory &);
 
 void registerBackupEngines(BackupFactory & factory)
 {
@@ -64,6 +65,7 @@ void registerBackupEngines(BackupFactory & factory)
     registerBackupEngineNull(factory);
     registerBackupEngineS3(factory);
     registerBackupEngineAzureBlobStorage(factory);
+    registerBackupEngineURL(factory);
 }
 
 BackupFactory::BackupFactory()

--- a/src/Backups/BackupIO_URL.cpp
+++ b/src/Backups/BackupIO_URL.cpp
@@ -1,0 +1,273 @@
+#include <Backups/BackupIO_URL.h>
+
+#include <Core/ServerSettings.h>
+#include <Core/Settings.h>
+#include <IO/ConnectionTimeouts.h>
+#include <IO/HTTPCommon.h>
+#include <IO/ReadBufferFromFileDecorator.h>
+#include <IO/ReadWriteBufferFromHTTP.h>
+#include <IO/WriteBufferFromHTTP.h>
+#include <IO/copyData.h>
+#include <Interpreters/Context.h>
+
+#include <Poco/Net/HTTPRequest.h>
+#include <Poco/Net/HTTPResponse.h>
+#include <Poco/StreamCopier.h>
+
+
+namespace DB
+{
+
+namespace Setting
+{
+    extern const SettingsUInt64 max_http_get_redirects;
+}
+
+namespace ErrorCodes
+{
+    extern const int NETWORK_ERROR;
+}
+
+namespace
+{
+    HTTPHeaderEntries makeAuthHeaders(const Poco::Net::HTTPBasicCredentials & credentials)
+    {
+        if (credentials.getUsername().empty())
+            return {};
+        Poco::Net::HTTPRequest tmp_request;
+        credentials.authenticate(tmp_request);
+        String auth = tmp_request.get("Authorization", "");
+        if (auth.empty())
+            return {};
+        return {{"Authorization", auth}};
+    }
+}
+
+
+BackupReaderURL::BackupReaderURL(
+    const Poco::URI & uri_,
+    const String & http_user_name,
+    const String & http_password,
+    const ReadSettings & read_settings_,
+    const WriteSettings & write_settings_,
+    const ContextPtr & context_)
+    : BackupReaderDefault(read_settings_, write_settings_, getLogger("BackupReaderURL"))
+    , base_uri(uri_)
+    , credentials(http_user_name, http_password)
+    , timeouts(ConnectionTimeouts::getHTTPTimeouts(context_->getSettingsRef(), context_->getServerSettings()))
+    , max_redirects(context_->getSettingsRef()[Setting::max_http_get_redirects])
+    , context(context_)
+{
+}
+
+BackupReaderURL::~BackupReaderURL() = default;
+
+Poco::URI BackupReaderURL::getURIForFile(const String & file_name) const
+{
+    Poco::URI uri = base_uri;
+    String path = uri.getPath();
+    if (!path.empty() && path.back() != '/')
+        path += '/';
+    path += file_name;
+    uri.setPath(path);
+    return uri;
+}
+
+bool BackupReaderURL::fileExists(const String & file_name)
+{
+    auto file_uri = getURIForFile(file_name);
+    try
+    {
+        auto buf = BuilderRWBufferFromHTTP(file_uri)
+                       .withConnectionGroup(HTTPConnectionGroupType::HTTP)
+                       .withSettings(read_settings)
+                       .withTimeouts(timeouts)
+                       .withHostFilter(&context->getRemoteHostFilter())
+                       .withRedirects(max_redirects)
+                       .create(credentials);
+        buf->getFileInfo();
+        return true;
+    }
+    catch (const HTTPException & e)
+    {
+        if (e.getHTTPStatus() == Poco::Net::HTTPResponse::HTTP_NOT_FOUND)
+            return false;
+        throw;
+    }
+}
+
+UInt64 BackupReaderURL::getFileSize(const String & file_name)
+{
+    auto file_uri = getURIForFile(file_name);
+    auto buf = BuilderRWBufferFromHTTP(file_uri)
+                   .withConnectionGroup(HTTPConnectionGroupType::HTTP)
+                   .withSettings(read_settings)
+                   .withTimeouts(timeouts)
+                   .withHostFilter(&context->getRemoteHostFilter())
+                   .withRedirects(max_redirects)
+                   .create(credentials);
+    auto info = buf->getFileInfo();
+    if (!info.file_size)
+        throw Exception(ErrorCodes::NETWORK_ERROR, "Cannot get file size from URL: {}", file_uri.toString());
+    return *info.file_size;
+}
+
+std::unique_ptr<ReadBufferFromFileBase> BackupReaderURL::readFile(const String & file_name)
+{
+    auto file_uri = getURIForFile(file_name);
+    auto buf = BuilderRWBufferFromHTTP(file_uri)
+                   .withConnectionGroup(HTTPConnectionGroupType::HTTP)
+                   .withSettings(read_settings)
+                   .withTimeouts(timeouts)
+                   .withHostFilter(&context->getRemoteHostFilter())
+                   .withRedirects(max_redirects)
+                   .withDelayInit(false)
+                   .create(credentials);
+    return std::make_unique<ReadBufferFromFileDecorator>(std::move(buf), file_uri.toString());
+}
+
+
+BackupWriterURL::BackupWriterURL(
+    const Poco::URI & uri_,
+    const String & http_user_name,
+    const String & http_password,
+    const String & http_method_,
+    const ReadSettings & read_settings_,
+    const WriteSettings & write_settings_,
+    const ContextPtr & context_)
+    : BackupWriterDefault(read_settings_, write_settings_, getLogger("BackupWriterURL"))
+    , base_uri(uri_)
+    , credentials(http_user_name, http_password)
+    , http_method(http_method_.empty() ? Poco::Net::HTTPRequest::HTTP_PUT : http_method_)
+    , timeouts(ConnectionTimeouts::getHTTPTimeouts(context_->getSettingsRef(), context_->getServerSettings()))
+    , max_redirects(context_->getSettingsRef()[Setting::max_http_get_redirects])
+    , context(context_)
+{
+}
+
+BackupWriterURL::~BackupWriterURL() = default;
+
+Poco::URI BackupWriterURL::getURIForFile(const String & file_name) const
+{
+    Poco::URI uri = base_uri;
+    String path = uri.getPath();
+    if (!path.empty() && path.back() != '/')
+        path += '/';
+    path += file_name;
+    uri.setPath(path);
+    return uri;
+}
+
+bool BackupWriterURL::fileExists(const String & file_name)
+{
+    auto file_uri = getURIForFile(file_name);
+    try
+    {
+        auto buf = BuilderRWBufferFromHTTP(file_uri)
+                       .withConnectionGroup(HTTPConnectionGroupType::HTTP)
+                       .withSettings(read_settings)
+                       .withTimeouts(timeouts)
+                       .withHostFilter(&context->getRemoteHostFilter())
+                       .withRedirects(max_redirects)
+                       .create(credentials);
+        buf->getFileInfo();
+        return true;
+    }
+    catch (const HTTPException & e)
+    {
+        if (e.getHTTPStatus() == Poco::Net::HTTPResponse::HTTP_NOT_FOUND)
+            return false;
+        throw;
+    }
+}
+
+UInt64 BackupWriterURL::getFileSize(const String & file_name)
+{
+    auto file_uri = getURIForFile(file_name);
+    auto buf = BuilderRWBufferFromHTTP(file_uri)
+                   .withConnectionGroup(HTTPConnectionGroupType::HTTP)
+                   .withSettings(read_settings)
+                   .withTimeouts(timeouts)
+                   .withHostFilter(&context->getRemoteHostFilter())
+                   .withRedirects(max_redirects)
+                   .create(credentials);
+    auto info = buf->getFileInfo();
+    if (!info.file_size)
+        throw Exception(ErrorCodes::NETWORK_ERROR, "Cannot get file size from URL: {}", file_uri.toString());
+    return *info.file_size;
+}
+
+std::unique_ptr<ReadBuffer> BackupWriterURL::readFile(const String & file_name, size_t /*expected_file_size*/)
+{
+    auto file_uri = getURIForFile(file_name);
+    return BuilderRWBufferFromHTTP(file_uri)
+               .withConnectionGroup(HTTPConnectionGroupType::HTTP)
+               .withSettings(read_settings)
+               .withTimeouts(timeouts)
+               .withHostFilter(&context->getRemoteHostFilter())
+               .withRedirects(max_redirects)
+               .withDelayInit(false)
+               .create(credentials);
+}
+
+std::unique_ptr<WriteBuffer> BackupWriterURL::writeFile(const String & file_name)
+{
+    auto file_uri = getURIForFile(file_name);
+    return BuilderWriteBufferFromHTTP(file_uri)
+               .withConnectionGroup(HTTPConnectionGroupType::HTTP)
+               .withMethod(http_method)
+               .withTimeouts(timeouts)
+               .withAdditionalHeaders(makeAuthHeaders(credentials))
+               .create();
+}
+
+void BackupWriterURL::copyFile(const String & destination, const String & source, size_t size)
+{
+    LOG_TRACE(log, "Copying file inside backup from {} to {}", source, destination);
+    auto in = readFile(source, size);
+    auto out = writeFile(destination);
+    copyData(*in, *out, size);
+    out->finalize();
+}
+
+void BackupWriterURL::removeFile(const String & file_name)
+{
+    auto file_uri = getURIForFile(file_name);
+    try
+    {
+        auto session = makeHTTPSession(HTTPConnectionGroupType::HTTP, file_uri, timeouts);
+        Poco::Net::HTTPRequest request(
+            Poco::Net::HTTPRequest::HTTP_DELETE,
+            file_uri.getPathAndQuery(),
+            Poco::Net::HTTPMessage::HTTP_1_1);
+        if (file_uri.getPort())
+            request.setHost(file_uri.getHost(), file_uri.getPort());
+        else
+            request.setHost(file_uri.getHost());
+        if (!credentials.getUsername().empty())
+            credentials.authenticate(request);
+        session->sendRequest(request);
+        Poco::Net::HTTPResponse response;
+        auto & response_stream = session->receiveResponse(response);
+        std::string ignored_body;
+        Poco::StreamCopier::copyToString(response_stream, ignored_body);  /// Drain response body.
+        auto status = response.getStatus();
+        if (status != Poco::Net::HTTPResponse::HTTP_OK
+            && status != Poco::Net::HTTPResponse::HTTP_NO_CONTENT
+            && status != Poco::Net::HTTPResponse::HTTP_NOT_FOUND)
+        {
+            LOG_WARNING(
+                log,
+                "HTTP DELETE returned unexpected status {} {} for URL {}",
+                static_cast<int>(status),
+                response.getReason(),
+                file_uri.toString());
+        }
+    }
+    catch (...)
+    {
+        LOG_WARNING(log, "Failed to remove file {} via HTTP DELETE: {}", file_name, getCurrentExceptionMessage(false));
+    }
+}
+
+}

--- a/src/Backups/BackupIO_URL.h
+++ b/src/Backups/BackupIO_URL.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <Backups/BackupIO_Default.h>
+#include <IO/ConnectionTimeouts.h>
+#include <IO/HTTPHeaderEntries.h>
+#include <Interpreters/Context_fwd.h>
+#include <Poco/Net/HTTPBasicCredentials.h>
+#include <Poco/URI.h>
+
+
+namespace DB
+{
+
+/// Represents a backup stored at HTTP(S) URL.
+class BackupReaderURL : public BackupReaderDefault
+{
+public:
+    BackupReaderURL(
+        const Poco::URI & uri_,
+        const String & http_user_name,
+        const String & http_password,
+        const ReadSettings & read_settings_,
+        const WriteSettings & write_settings_,
+        const ContextPtr & context_);
+
+    ~BackupReaderURL() override;
+
+    bool fileExists(const String & file_name) override;
+    UInt64 getFileSize(const String & file_name) override;
+
+    std::unique_ptr<ReadBufferFromFileBase> readFile(const String & file_name) override;
+
+private:
+    Poco::URI getURIForFile(const String & file_name) const;
+
+    const Poco::URI base_uri;
+    const Poco::Net::HTTPBasicCredentials credentials;
+    const ConnectionTimeouts timeouts;
+    const size_t max_redirects;
+    const ContextPtr context;
+};
+
+
+class BackupWriterURL : public BackupWriterDefault
+{
+public:
+    BackupWriterURL(
+        const Poco::URI & uri_,
+        const String & http_user_name,
+        const String & http_password,
+        const String & http_method_,
+        const ReadSettings & read_settings_,
+        const WriteSettings & write_settings_,
+        const ContextPtr & context_);
+
+    ~BackupWriterURL() override;
+
+    bool fileExists(const String & file_name) override;
+    UInt64 getFileSize(const String & file_name) override;
+    std::unique_ptr<WriteBuffer> writeFile(const String & file_name) override;
+
+    void copyFile(const String & destination, const String & source, size_t size) override;
+    void removeFile(const String & file_name) override;
+
+private:
+    std::unique_ptr<ReadBuffer> readFile(const String & file_name, size_t expected_file_size) override;
+    Poco::URI getURIForFile(const String & file_name) const;
+
+    const Poco::URI base_uri;
+    const Poco::Net::HTTPBasicCredentials credentials;
+    const String http_method;
+    const ConnectionTimeouts timeouts;
+    const size_t max_redirects;
+    const ContextPtr context;
+};
+
+}

--- a/src/Backups/registerBackupEngineURL.cpp
+++ b/src/Backups/registerBackupEngineURL.cpp
@@ -1,0 +1,151 @@
+#include <Backups/BackupFactory.h>
+#include <Backups/BackupIO_URL.h>
+#include <Backups/BackupImpl.h>
+#include <Backups/BackupInfo.h>
+#include <Common/NamedCollections/NamedCollections.h>
+#include <Core/Settings.h>
+#include <IO/Archives/hasRegisteredArchiveFileExtension.h>
+#include <Interpreters/Context.h>
+#include <Access/Common/AccessFlags.h>
+
+#include <Poco/URI.h>
+
+#include <filesystem>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+}
+
+namespace Setting
+{
+    extern const SettingsUInt64 archive_adaptive_buffer_max_size_bytes;
+}
+
+namespace
+{
+    String removeFileNameFromURL(String & url)
+    {
+        Poco::URI uri{url};
+        String path = uri.getPath();
+        size_t slash_pos = path.find_last_of('/');
+        String file_name = path.substr(slash_pos + 1);
+        path.resize(slash_pos + 1);
+        uri.setPath(path);
+        url = uri.toString();
+        return file_name;
+    }
+}
+
+
+void registerBackupEngineURL(BackupFactory & factory)
+{
+    auto creator_fn = [](const BackupFactory::CreateParams & params) -> std::unique_ptr<IBackup>
+    {
+        const auto & args = params.backup_info.args;
+
+        String url;
+        String http_user_name;
+        String http_password;
+        String http_method;
+
+        if (auto collection = params.backup_info.getNamedCollection(params.context))
+        {
+            url = collection->get<String>("url");
+            http_user_name = collection->getOrDefault<String>("user", "");
+            http_password = collection->getOrDefault<String>("password", "");
+            http_method = collection->getOrDefault<String>("http_method", collection->getOrDefault<String>("method", ""));
+            if (!http_method.empty() && http_method != "POST" && http_method != "PUT")
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS,
+                    "HTTP method must be POST or PUT (got: {}). Default is PUT",
+                    http_method);
+
+            if (collection->has("filename"))
+                url = std::filesystem::path(url) / collection->get<String>("filename");
+
+            if (args.size() > 1)
+                throw Exception(
+                    ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
+                    "Backup URL requires 1 or 2 arguments: named_collection, [filename]");
+
+            if (args.size() == 1)
+                url = std::filesystem::path(url) / args[0].safeGet<String>();
+        }
+        else
+        {
+            if (args.empty() || args.size() > 3)
+                throw Exception(
+                    ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
+                    "Backup URL requires 1 to 3 arguments: url, [http_user_name, http_password]");
+
+            url = args[0].safeGet<String>();
+
+            if (args.size() >= 3)
+            {
+                http_user_name = args[1].safeGet<String>();
+                http_password = args[2].safeGet<String>();
+            }
+        }
+
+        BackupImpl::ArchiveParams archive_params;
+        if (hasRegisteredArchiveFileExtension(url))
+        {
+            if (params.is_internal_backup)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Using archives with backups on clusters is disabled");
+
+            archive_params.archive_name = removeFileNameFromURL(url);
+            archive_params.compression_method = params.compression_method;
+            archive_params.compression_level = params.compression_level;
+            archive_params.password = params.password;
+            archive_params.adaptive_buffer_max_size = params.context->getSettingsRef()[Setting::archive_adaptive_buffer_max_size_bytes];
+        }
+        else
+        {
+            if (!params.password.empty())
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Password is not applicable, backup cannot be encrypted");
+        }
+
+        const Poco::URI uri{url};
+
+        const std::string_view source_name = toStringSource(AccessTypeObjects::Source::URL);
+        if (params.open_mode == IBackup::OpenMode::READ)
+        {
+            params.context->checkAccess(AccessType::READ, source_name);
+
+            auto reader = std::make_shared<BackupReaderURL>(
+                uri,
+                http_user_name,
+                http_password,
+                params.read_settings,
+                params.write_settings,
+                params.context);
+
+            return std::make_unique<BackupImpl>(params, archive_params, reader);
+        }
+        else
+        {
+            params.context->checkAccess(AccessType::WRITE, source_name);
+
+            auto writer = std::make_shared<BackupWriterURL>(
+                uri,
+                http_user_name,
+                http_password,
+                http_method,
+                params.read_settings,
+                params.write_settings,
+                params.context);
+
+            return std::make_unique<BackupImpl>(params, archive_params, writer);
+        }
+    };
+
+    factory.registerBackupEngine("URL", creator_fn);
+}
+
+}


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add backup engine URL().
Uploads and downloads files similar to table function `url()`:

```
BACKUP ... TO URL(url)
RESTORE ... FROM URL(url)
```

(the implementation is incomplete, don't review yet)