### PR TITLE
Revert "Skip merge selection when SYSTEM STOP MERGES is active for ReplicatedMergeTree"

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -4283,11 +4283,7 @@ void StorageReplicatedMergeTree::mergeSelectingTask()
         if ((*storage_settings.get())[MergeTreeSetting::assign_part_uuids])
             future_merged_part->uuid = UUIDHelpers::generateV4();
 
-        /// Skip merge selection when merges are stopped (e.g. SYSTEM STOP MERGES).
-        /// Without this check, merge entries are created in ZooKeeper even though they cannot be executed,
-        /// and the source parts become "virtual" in the queue, which blocks TTL moves.
-        bool can_assign_merge = max_source_parts_bytes_for_merge > 0
-            && !merger_mutator.merges_blocker.isCancelled();
+        bool can_assign_merge = max_source_parts_bytes_for_merge > 0;
         PartitionIdsHint partitions_to_merge_in;
         if (can_assign_merge)
         {

--- a/tests/integration/test_lost_part/test.py
+++ b/tests/integration/test_lost_part/test.py
@@ -48,7 +48,7 @@ def test_lost_part_same_replica(start_cluster):
                 "merge_selecting_sleep_ms=100, max_merge_selecting_sleep_ms=1000"
             )
 
-        node1.query("SYSTEM STOP REPLICATION QUEUES mt0")
+        node1.query("SYSTEM STOP MERGES mt0")
         node2.query("SYSTEM STOP REPLICATION QUEUES")
 
         for i in range(5):
@@ -117,7 +117,7 @@ def test_lost_part_other_replica(start_cluster):
                 "merge_selecting_sleep_ms=100, max_merge_selecting_sleep_ms=1000"
             )
 
-        node1.query("SYSTEM STOP REPLICATION QUEUES mt1")
+        node1.query("SYSTEM STOP MERGES mt1")
         node2.query("SYSTEM STOP REPLICATION QUEUES")
 
         for i in range(5):
@@ -144,7 +144,7 @@ def test_lost_part_other_replica(start_cluster):
         node1.query("CHECK TABLE mt1")
 
         node2.query("SYSTEM START REPLICATION QUEUES")
-        # Reduce timeout in sync replica since it might never finish with replication queue stopped and we don't want to wait 300s
+        # Reduce timeout in sync replica since it might never finish with merge stopped and we don't want to wait 300s
         res, err = node1.query_and_get_answer_with_error(
             "SYSTEM SYNC REPLICA mt1", settings={"receive_timeout": 30}
         )
@@ -170,7 +170,7 @@ def test_lost_part_other_replica(start_cluster):
         assert_eq_with_retry(node2, "SELECT COUNT() FROM mt1", "4")
         assert_eq_with_retry(node2, "SELECT COUNT() FROM system.replication_queue", "0")
 
-        node1.query("SYSTEM START REPLICATION QUEUES mt1")
+        node1.query("SYSTEM START MERGES mt1")
 
         assert_eq_with_retry(node1, "SELECT COUNT() FROM mt1", "4")
         assert_eq_with_retry(node1, "SELECT COUNT() FROM system.replication_queue", "0")


### PR DESCRIPTION
This PR is being reverted because it introduce very confusing logic for `SYSTEM STOP MERGES` for ReplicatedMergeTree. Before pr logic was following: "`SYSTEM STOP MERGES` stops merges and mutations execution, but doesn't stop merges and mutations assignment". Also we have non user-facing feature to stop merges in some partition. It works the same way.

 Now logic is the following for `SYSTEM STOP MERGES`.
1. Stops merges and mutations execution.
2. Stop only merges assignment.

It can fill replication queue with assigned mutations, because it doesn't stop mutation assignment. This likely will be very unexpected outcome for the user. Also behavior of `isCancelledForPartition` is not consistent, it doesn't stop assignment at all. Also it's inconsistent with SharedMergeTree logic. Also it's very weird way to fix test with TTL MOVE, there are multiple ways how to stop merges and mutations assignment.

I think it's better to introduce new type of query, or generalize the logic. However it's non that trivial and not compatible.

Reverts ClickHouse/ClickHouse#97426

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.763`
<!-- ch-version-info:end -->