### PR TITLE
Set ZooKeeper component in unfreezePartitionsByMatcher

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -9454,6 +9454,7 @@ bool MergeTreeData::removeDetachedPart(DiskPtr disk, const String & path, const 
 
 PartitionCommandsResultInfo MergeTreeData::unfreezePartitionsByMatcher(MatcherFn matcher, const String & backup_name, ContextPtr local_context)
 {
+    auto component_guard = Coordination::setCurrentComponent("MergeTreeData::unfreezePartitionsByMatcher");
     auto backup_path = fs::path("shadow") / escapeForFileName(backup_name) / relative_data_path;
 
     LOG_DEBUG(log, "Unfreezing parts by path {}", backup_path.generic_string());


### PR DESCRIPTION
Follow-up to https://github.com/ClickHouse/ClickHouse/pull/96051 — `MergeTreeData::unfreezePartitionsByMatcher` was missing a `Coordination::setCurrentComponent` guard, causing a LOGICAL_ERROR exception when `enforce_component_tracking` is enabled (SharedCatalog with meta storage in keeper).

Failed report: https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?PR=52290&sha=c7313ec1fda3fdda8147d312f770824667ffe879&name_0=PR&name_1=Stress%20test%20%28arm_asan%2C%20SharedCatalog%2C%20meta%20storage%20in%20keeper%29

CC @antonio2368

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.747`
<!-- ch-version-info:end -->