### PR TITLE
Don't assign new merges or mutations in replicated merge tree if SYSTEM STOP MERGES called

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -4283,11 +4283,13 @@ void StorageReplicatedMergeTree::mergeSelectingTask()
         if ((*storage_settings.get())[MergeTreeSetting::assign_part_uuids])
             future_merged_part->uuid = UUIDHelpers::generateV4();
 
-        /// Skip merge selection when merges are stopped (e.g. SYSTEM STOP MERGES).
-        /// Without this check, merge entries are created in ZooKeeper even though they cannot be executed,
-        /// and the source parts become "virtual" in the queue, which blocks TTL moves.
-        bool can_assign_merge = max_source_parts_bytes_for_merge > 0
-            && !merger_mutator.merges_blocker.isCancelled();
+        /// Skip merge/mutation assignment when merges are stopped globally (e.g. `SYSTEM STOP MERGES`)
+        /// or for specific partitions (e.g. internally during `REPLACE PARTITION`).
+        /// Without this check, merge/mutation entries are created in ZooKeeper even though they
+        /// cannot be executed, and the source parts become "virtual" in the queue, which blocks TTL moves.
+        const bool merges_stopped_globally = merger_mutator.merges_blocker.isCancelled();
+
+        bool can_assign_merge = max_source_parts_bytes_for_merge > 0 && !merges_stopped_globally;
         PartitionIdsHint partitions_to_merge_in;
         if (can_assign_merge)
         {
@@ -4301,6 +4303,12 @@ void StorageReplicatedMergeTree::mergeSelectingTask()
                     /*aggressive_=*/false,
                     /*range_filter_=*/nullptr
                 ));
+
+            /// Filter out partitions where merges are stopped (e.g. internally during `REPLACE PARTITION`).
+            std::erase_if(partitions_to_merge_in, [&](const String & partition_id)
+            {
+                return merger_mutator.merges_blocker.isCancelledForPartition(partition_id);
+            });
 
             if (partitions_to_merge_in.empty())
                 can_assign_merge = false;
@@ -4382,6 +4390,10 @@ void StorageReplicatedMergeTree::mergeSelectingTask()
             return AttemptStatus::Limited;
         }
 
+        /// Skip mutation assignment when merges are stopped globally.
+        if (merges_stopped_globally)
+            return AttemptStatus::CannotSelect;
+
         if (queue.countMutations() > 0)
         {
             /// We don't need the list of committing blocks to choose a part to mutate
@@ -4393,6 +4405,11 @@ void StorageReplicatedMergeTree::mergeSelectingTask()
             for (const auto & part : data_parts)
             {
                 fiu_do_on(FailPoints::rmt_merge_selecting_task_max_part_size, { max_source_part_bytes_for_mutation = 1; });
+
+                /// Skip parts in partitions where merges/mutations are stopped.
+                if (merger_mutator.merges_blocker.isCancelledForPartition(part->info.getPartitionId()))
+                    continue;
+
                 if (part->getBytesOnDisk() > max_source_part_bytes_for_mutation)
                 {
                     queue.addPartsPostponeReasons(part->name, PostponeReasons::EXCEED_MAX_PART_SIZE);

--- a/tests/integration/test_lost_part/test.py
+++ b/tests/integration/test_lost_part/test.py
@@ -191,7 +191,7 @@ def test_lost_part_mutation(start_cluster):
                 "merge_selecting_sleep_ms=100, max_merge_selecting_sleep_ms=1000, max_postpone_time_for_failed_mutations_ms = 0"
             )
 
-        node1.query("SYSTEM STOP MERGES mt2")
+        node1.query("SYSTEM STOP REPLICATION QUEUES mt2")
         node2.query("SYSTEM STOP REPLICATION QUEUES")
 
         for i in range(2):
@@ -215,7 +215,7 @@ def test_lost_part_mutation(start_cluster):
         # other way to detect broken parts
         node1.query("CHECK TABLE mt2")
 
-        node1.query("SYSTEM START MERGES mt2")
+        node1.query("SYSTEM START REPLICATION QUEUES mt2")
         res, err = node1.query_and_get_answer_with_error("SYSTEM SYNC REPLICA mt2")
         print("result: ", res)
         print("error: ", res)
@@ -256,7 +256,7 @@ def test_lost_last_part(start_cluster):
                 "merge_selecting_sleep_ms=100, max_merge_selecting_sleep_ms=1000"
             )
 
-        node1.query("SYSTEM STOP MERGES mt3")
+        node1.query("SYSTEM STOP REPLICATION QUEUES mt3")
         node2.query("SYSTEM STOP REPLICATION QUEUES")
 
         for i in range(1):
@@ -273,7 +273,7 @@ def test_lost_last_part(start_cluster):
         # other way to detect broken parts
         node1.query("CHECK TABLE mt3")
 
-        node1.query("SYSTEM START MERGES mt3")
+        node1.query("SYSTEM START REPLICATION QUEUES mt3")
 
         for i in range(100):
             result = node1.query(


### PR DESCRIPTION


### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Now replicated merge tree will assign new merges and mutations if `SYSTEM STOP MERGES` is called.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
