### PR TITLE
Add replacing_merge_cleanup_period_seconds experimental setting for ReplacingMergeTree

### DIFF
--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -1090,6 +1090,7 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
     {
         addSettingsChanges(merge_tree_settings_changes_history, "26.3",
         {
+            {"replacing_merge_cleanup_period_seconds", 0, 0, "New setting to periodically trigger FINAL CLEANUP merges for ReplacingMergeTree with is_deleted"},
             {"vertical_merge_optimize_ttl_delete", false, true, "Allow vertical merge algorithm for merges that need to remove rows expired by TTL"},
             {"shared_merge_tree_replica_set_max_lifetime_seconds", 300, 300, "New setting"},
             {"table_readonly", false, false, "New setting to mark table as read-only, preventing inserts and modifications"},

--- a/src/Storages/MergeTree/Compaction/MergeSelectorApplier.h
+++ b/src/Storages/MergeTree/Compaction/MergeSelectorApplier.h
@@ -21,6 +21,9 @@ struct MergeSelectorChoice
 
     /// If this merges down to a single part in a partition
     bool final = false;
+
+    /// If this merge was triggered by the periodic cleanup timer (replacing_merge_cleanup_period_seconds)
+    bool is_periodic_cleanup = false;
 };
 using MergeSelectorChoices = std::vector<MergeSelectorChoice>;
 

--- a/src/Storages/MergeTree/MergeMutateSelectedEntry.h
+++ b/src/Storages/MergeTree/MergeMutateSelectedEntry.h
@@ -47,6 +47,10 @@ struct MergeMutateSelectedEntry
     MergeTreeTransactionPtr txn;
     Strings mutation_ids; /// List of mutation version strings being applied
     bool finalized{false};
+
+    /// True if this merge was triggered by the periodic cleanup timer (replacing_merge_cleanup_period_seconds)
+    bool is_periodic_cleanup{false};
+
     MergeMutateSelectedEntry(FutureMergedMutatedPartPtr future_part_, CurrentlyMergingPartsTaggerPtr tagger_,
                              MutationCommandsConstPtr commands_, const MergeTreeTransactionPtr & txn_ = NO_TRANSACTION_PTR,
                              Strings mutation_ids_ = {})

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp
@@ -42,6 +42,8 @@ namespace MergeTreeSetting
     extern const MergeTreeSettingsBool enable_max_bytes_limit_for_min_age_to_force_merge;
     extern const MergeTreeSettingsUInt64 number_of_free_entries_in_pool_to_execute_optimize_entire_partition;
     extern const MergeTreeSettingsBool apply_patches_on_merge;
+    extern const MergeTreeSettingsUInt64 replacing_merge_cleanup_period_seconds;
+    extern const MergeTreeSettingsBool allow_experimental_replacing_merge_with_cleanup;
 }
 
 namespace
@@ -214,6 +216,63 @@ String getBestPartitionToOptimizeEntire(
     return best_partition_it->first;
 }
 
+} // anonymous namespace
+
+String MergeTreeDataMergerMutator::getBestPartitionForPeriodicCleanup(
+    const PartitionsStatistics & stats,
+    time_t current_time) const
+{
+    const auto settings = data.getSettings();
+
+    if (!(*settings)[MergeTreeSetting::replacing_merge_cleanup_period_seconds])
+        return {};
+
+    /// Cleanup merges are only meaningful for ReplacingMergeTree with is_deleted support.
+    /// Skip if the prerequisite experimental flag is not enabled or the table has no is_deleted column.
+    if (!(*settings)[MergeTreeSetting::allow_experimental_replacing_merge_with_cleanup]
+        || data.merging_params.is_deleted_column.empty())
+        return {};
+
+    Int64 occupied = CurrentMetrics::values[CurrentMetrics::BackgroundMergesAndMutationsPoolTask].load(std::memory_order_relaxed);
+    Int64 max_tasks_count = data.getContext()->getMergeMutateExecutor()->getMaxTasksCount();
+    Int64 optimize_entire_partition_threshold = (*settings)[MergeTreeSetting::number_of_free_entries_in_pool_to_execute_optimize_entire_partition];
+    if (occupied > 1 && max_tasks_count - occupied < optimize_entire_partition_threshold)
+    {
+        LOG_INFO(log,
+            "Not enough idle threads to execute periodic cleanup merge. See settings "
+            "'number_of_free_entries_in_pool_to_execute_optimize_entire_partition' and 'background_pool_size'");
+        return {};
+    }
+
+    String best_partition;
+    time_t best_next_time = std::numeric_limits<time_t>::max();
+
+    for (const auto & [partition_id, partition_stats] : stats)
+    {
+        /// Skip empty partitions — nothing to clean up
+        if (partition_stats.part_count == 0)
+            continue;
+
+        auto it = next_cleanup_merge_time_by_partition.find(partition_id);
+        const time_t next_time = (it != next_cleanup_merge_time_by_partition.end()) ? it->second : 0;
+
+        if (current_time < next_time)
+            continue;
+
+        /// Among all ready partitions, pick the one whose cleanup is most overdue
+        if (next_time < best_next_time)
+        {
+            best_next_time = next_time;
+            best_partition = partition_id;
+        }
+    }
+
+    return best_partition;
+}
+
+namespace
+{
+
 CollectedPartsRanges grabAllPossibleRanges(
     const PartsCollectorPtr & parts_collector,
     const StorageMetadataPtr & metadata_snapshot,
@@ -380,6 +439,9 @@ PartitionIdsHint MergeTreeDataMergerMutator::getPartitionsThatMayBeMerged(
     if (auto best = getBestPartitionToOptimizeEntire(selector.merge_constraints[0].max_size_bytes, context, settings, partitions_stats, log); !best.empty())
         partitions_hint.insert(std::move(best));
 
+    if (auto best = getBestPartitionForPeriodicCleanup(partitions_stats, current_time); !best.empty())
+        partitions_hint.insert(std::move(best));
+
     LOG_TRACE(log,
             "Checked {} partitions, found {} partitions with parts that may be merged: [{}] "
             "(max_total_size_to_merge={}, merge_with_ttl_allowed={}, can_use_ttl_merges={})",
@@ -443,6 +505,39 @@ std::expected<MergeSelectorChoices, SelectMergeFailure> MergeTreeDataMergerMutat
             /*partition_id=*/best,
             /*final=*/true,
             /*optimize_skip_merged_partitions=*/true);
+    }
+
+    if (auto best = getBestPartitionForPeriodicCleanup(partitions_stats, current_time); !best.empty())
+    {
+        auto result = selectAllPartsToMergeWithinPartition(
+            metadata_snapshot,
+            parts_collector,
+            merge_predicate,
+            /*partition_id=*/best,
+            /*final=*/true,
+            /*optimize_skip_merged_partitions=*/false);
+
+        /// Always advance the cooldown timer, whether selection succeeded or not.
+        /// Without this, a partition that fails selection (e.g. because the merge predicate
+        /// blocks it) would be picked again on every scheduler cycle with no backoff,
+        /// causing repeated failed attempts and noisy logs.
+        next_cleanup_merge_time_by_partition[best] = current_time + (*settings)[MergeTreeSetting::replacing_merge_cleanup_period_seconds];
+
+        if (result.has_value())
+        {
+            chassert(!result->empty());
+            result->front().is_periodic_cleanup = true;
+
+            const auto & storage = data.getStorageID();
+            LOG_DEBUG(log, "Scheduled periodic cleanup merge for table {}.{}, partition '{}'. "
+                           "Next cleanup for this partition allowed after: {}.",
+                           backQuote(storage.database_name),
+                           backQuote(storage.table_name),
+                           best,
+                           toString(next_cleanup_merge_time_by_partition[best]));
+        }
+
+        return result;
     }
 
     return std::unexpected(SelectMergeFailure{

--- a/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
+++ b/src/Storages/MergeTree/MergeTreeDataMergerMutator.h
@@ -134,6 +134,18 @@ private:
     PartitionIdToTTLs next_recompress_ttl_merge_times_by_partition;
     /// Performing TTL merges independently for each partition guarantees that
     /// there is only a limited number of TTL merges and no partition stores data, that is too stale
+
+    /// Stores the next allowed periodic cleanup merge time for each partition.
+    /// Used when `replacing_merge_cleanup_period_seconds` is set on a ReplacingMergeTree with `is_deleted`.
+    PartitionIdToTTLs next_cleanup_merge_time_by_partition;
+
+    /// Returns the partition ID ready for a periodic cleanup merge, or an empty string if none qualifies.
+    /// A partition qualifies when `now >= next_cleanup_merge_time_by_partition[partition]`
+    /// and the partition is non-empty. Single-part partitions are included because a cleanup
+    /// rewrite is still needed to physically remove `is_deleted = 1` rows.
+    String getBestPartitionForPeriodicCleanup(
+        const PartitionsStatistics & stats,
+        time_t current_time) const;
 };
 
 std::string convertMergeConstraintsToString(const MergeConstraints & constraints);

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -1912,6 +1912,20 @@ namespace ErrorCodes
     - `true`
     - `false`
     )", EXPERIMENTAL) \
+    DECLARE(UInt64, replacing_merge_cleanup_period_seconds, 0, R"(
+    When set to a non-zero value and `allow_experimental_replacing_merge_with_cleanup`
+    is enabled, the background merge thread will periodically schedule a
+    `FINAL CLEANUP` merge for each partition of a `ReplacingMergeTree` table with
+    an `is_deleted` column. The cleanup merge runs at most once per
+    `replacing_merge_cleanup_period_seconds` seconds per partition, removing rows
+    where `is_deleted = 1` and keeping only the latest version of each key.
+
+    This setting is intended for tables with continuous inserts where
+    `min_age_to_force_merge_on_partition_only` cannot trigger because fresh parts
+    are always present. Set to 0 (default) to disable.
+
+    Requires `allow_experimental_replacing_merge_with_cleanup = 1`.
+    )", EXPERIMENTAL) \
     DECLARE(Bool, allow_experimental_reverse_key, false, R"(
     Enables support for descending sort order in MergeTree sorting keys. This
     setting is particularly useful for time series analysis and Top-N queries,

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -102,6 +102,7 @@ namespace MergeTreeSetting
     extern const MergeTreeSettingsBool assign_part_uuids;
     extern const MergeTreeSettingsDeduplicateMergeProjectionMode deduplicate_merge_projection_mode;
     extern const MergeTreeSettingsBool enable_replacing_merge_with_cleanup_for_min_age_to_force_merge;
+    extern const MergeTreeSettingsUInt64 replacing_merge_cleanup_period_seconds;
     extern const MergeTreeSettingsUInt64 finished_mutations_to_keep;
     extern const MergeTreeSettingsSeconds lock_acquire_timeout_for_background_operations;
     extern const MergeTreeSettingsBool min_age_to_force_merge_on_partition_only;
@@ -1262,6 +1263,10 @@ std::expected<MergeMutateSelectedEntryPtr, SelectMergeFailure> StorageMergeTree:
                 formatReadableSizeWithBinarySuffix(background_memory_tracker.getSoftLimit())));
     };
 
+    /// Captured by select_without_hint and read by construct_merge_select_entry to
+    /// propagate the periodic cleanup flag from MergeSelectorChoice to MergeMutateSelectedEntry.
+    bool is_periodic_cleanup = false;
+
     const auto construct_future_part = [&](MergeSelectorChoices choices) -> std::expected<FutureMergedMutatedPartPtr, SelectMergeFailure>
     {
         chassert(choices.size() == 1);
@@ -1322,7 +1327,10 @@ std::expected<MergeMutateSelectedEntryPtr, SelectMergeFailure> StorageMergeTree:
             ),
             /*partitions_hint=*/std::nullopt);
 
-        return select_result.and_then(construct_future_part);
+        if (select_result.has_value())
+            is_periodic_cleanup = select_result->front().is_periodic_cleanup;
+
+        return std::move(select_result).and_then(construct_future_part);
     };
 
     const auto select_in_partition = [&]() -> std::expected<FutureMergedMutatedPartPtr, SelectMergeFailure>
@@ -1396,7 +1404,9 @@ std::expected<MergeMutateSelectedEntryPtr, SelectMergeFailure> StorageMergeTree:
             uint64_t needed_disk_space = CompactionStatistics::estimateNeededDiskSpace(future_part->parts, true);
             auto tagger = std::make_unique<CurrentlyMergingPartsTagger>(future_part, needed_disk_space, *this, metadata_snapshot, false);
 
-            return std::make_shared<MergeMutateSelectedEntry>(future_part, std::move(tagger), std::make_shared<MutationCommands>());
+            auto entry = std::make_shared<MergeMutateSelectedEntry>(future_part, std::move(tagger), std::make_shared<MutationCommands>());
+            entry->is_periodic_cleanup = is_periodic_cleanup;
+            return entry;
         }
         catch (...)
         {
@@ -1780,9 +1790,13 @@ bool StorageMergeTree::scheduleDataProcessingJob(BackgroundJobsAssignee & assign
 
         bool cleanup = merge_entry->future_part->final
             && (*getSettings())[MergeTreeSetting::allow_experimental_replacing_merge_with_cleanup]
-            && (*getSettings())[MergeTreeSetting::enable_replacing_merge_with_cleanup_for_min_age_to_force_merge]
-            && (*getSettings())[MergeTreeSetting::min_age_to_force_merge_seconds]
-            && (*getSettings())[MergeTreeSetting::min_age_to_force_merge_on_partition_only];
+            && (
+                ((*getSettings())[MergeTreeSetting::enable_replacing_merge_with_cleanup_for_min_age_to_force_merge]
+                    && (*getSettings())[MergeTreeSetting::min_age_to_force_merge_seconds]
+                    && (*getSettings())[MergeTreeSetting::min_age_to_force_merge_on_partition_only])
+                || (merge_entry->is_periodic_cleanup
+                    && (*getSettings())[MergeTreeSetting::replacing_merge_cleanup_period_seconds])
+            );
 
         auto task = std::make_shared<MergePlainMergeTreeTask>(*this, metadata_snapshot, /* deduplicate */ false, Names{}, cleanup, merge_entry, shared_lock, common_assignee_trigger);
         task->setCurrentTransaction(std::move(transaction_for_merge), std::move(txn));

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -201,6 +201,7 @@ namespace MergeTreeSetting
     extern const MergeTreeSettingsBool disable_fetch_partition_for_zero_copy_replication;
     extern const MergeTreeSettingsBool enable_mixed_granularity_parts;
     extern const MergeTreeSettingsBool enable_replacing_merge_with_cleanup_for_min_age_to_force_merge;
+    extern const MergeTreeSettingsUInt64 replacing_merge_cleanup_period_seconds;
     extern const MergeTreeSettingsBool enable_the_endpoint_id_with_zookeeper_name_prefix;
     extern const MergeTreeSettingsFloat fault_probability_after_part_commit;
     extern const MergeTreeSettingsFloat fault_probability_before_part_commit;
@@ -4337,9 +4338,13 @@ void StorageReplicatedMergeTree::mergeSelectingTask()
 
                 bool cleanup = future_merged_part->final
                     && (*storage_settings_ptr)[MergeTreeSetting::allow_experimental_replacing_merge_with_cleanup]
-                    && (*storage_settings_ptr)[MergeTreeSetting::enable_replacing_merge_with_cleanup_for_min_age_to_force_merge]
-                    && (*storage_settings_ptr)[MergeTreeSetting::min_age_to_force_merge_seconds]
-                    && (*storage_settings_ptr)[MergeTreeSetting::min_age_to_force_merge_on_partition_only];
+                    && (
+                        ((*storage_settings_ptr)[MergeTreeSetting::enable_replacing_merge_with_cleanup_for_min_age_to_force_merge]
+                            && (*storage_settings_ptr)[MergeTreeSetting::min_age_to_force_merge_seconds]
+                            && (*storage_settings_ptr)[MergeTreeSetting::min_age_to_force_merge_on_partition_only])
+                        || (select_merge_result.value()[0].is_periodic_cleanup
+                            && (*storage_settings_ptr)[MergeTreeSetting::replacing_merge_cleanup_period_seconds])
+                    );
 
                 create_result = createLogEntryToMergeParts(
                     zookeeper,

--- a/tests/queries/0_stateless/04004_alter_modify_column_ttl_without_type.sql
+++ b/tests/queries/0_stateless/04004_alter_modify_column_ttl_without_type.sql
@@ -11,7 +11,7 @@ CREATE TABLE alter_modify_column_ttl_without_type
 ENGINE = MergeTree
 ORDER BY uid;
 
-INSERT INTO alter_modify_column_ttl_without_type VALUES (1, 'expired', '2000-01-01'), (2, 'valid', today());
+INSERT INTO alter_modify_column_ttl_without_type VALUES (1, 'expired', '2000-01-01'), (2, 'valid', '2099-01-01');
 
 ALTER TABLE alter_modify_column_ttl_without_type MODIFY COLUMN name TTL age + INTERVAL 1 DAY;
 SHOW CREATE TABLE alter_modify_column_ttl_without_type FORMAT TSVRaw;

--- a/tests/queries/0_stateless/04036_replacing_cleanup_period.reference
+++ b/tests/queries/0_stateless/04036_replacing_cleanup_period.reference
@@ -1,0 +1,9 @@
+Cleanup OK
+1	2	0
+3	1	0
+Second cleanup OK
+1	4	0
+3	1	0
+Replicated cleanup OK
+1	2	0
+3	1	0

--- a/tests/queries/0_stateless/04036_replacing_cleanup_period.sh
+++ b/tests/queries/0_stateless/04036_replacing_cleanup_period.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Tags: long
+#
+# Tests for replacing_merge_cleanup_period_seconds setting.
+# Verifies that the background merge thread automatically triggers a FINAL CLEANUP
+# merge after the configured period, physically removing is_deleted=1 rows and
+# deduplicating updates without requiring an explicit OPTIMIZE command.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Wait for deleted rows to be physically absent from $1 (timeout in seconds).
+# Returns 0 if cleanup succeeded, 1 if timed out.
+wait_for_cleanup()
+{
+    local table=$1
+    local timeout=$2
+    local res
+    for _ in $(seq "$timeout")
+    do
+        sleep 1
+        res=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM $table WHERE deleted = 1")
+        if [ "$res" -eq 0 ]
+        then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Wait until the row count for $2 (WHERE clause) in $1 equals $3 (timeout in seconds).
+# Used to confirm deduplication has occurred, not just deletion.
+wait_for_row_count()
+{
+    local table=$1
+    local condition=$2
+    local expected=$3
+    local timeout=$4
+    local res
+    for _ in $(seq "$timeout")
+    do
+        sleep 1
+        res=$($CLICKHOUSE_CLIENT -q "SELECT count() FROM $table WHERE $condition")
+        if [ "$res" -eq "$expected" ]
+        then
+            return 0
+        fi
+    done
+    return 1
+}
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t04036_cleanup_period"
+
+# Create table with a 1-second cleanup period so the background thread fires quickly.
+# merge_selecting_sleep_ms=500 makes the background scheduler wake up every 0.5s.
+$CLICKHOUSE_CLIENT -q "
+CREATE TABLE t04036_cleanup_period
+(
+    id      UInt64,
+    ver     UInt64,
+    deleted UInt8
+)
+ENGINE = ReplacingMergeTree(ver, deleted)
+ORDER BY id
+SETTINGS
+    allow_experimental_replacing_merge_with_cleanup = 1,
+    replacing_merge_cleanup_period_seconds = 1,
+    merge_selecting_sleep_ms = 500"
+
+# Insert multiple versions of the same key including a deletion.
+# Each INSERT creates a separate part (5 parts total).
+$CLICKHOUSE_CLIENT -q "INSERT INTO t04036_cleanup_period VALUES (1, 1, 0)" # insert key=1 ver=1
+$CLICKHOUSE_CLIENT -q "INSERT INTO t04036_cleanup_period VALUES (1, 2, 0)" # update key=1 to ver=2
+$CLICKHOUSE_CLIENT -q "INSERT INTO t04036_cleanup_period VALUES (2, 1, 0)" # insert key=2 ver=1
+$CLICKHOUSE_CLIENT -q "INSERT INTO t04036_cleanup_period VALUES (2, 2, 1)" # delete key=2 at ver=2
+$CLICKHOUSE_CLIENT -q "INSERT INTO t04036_cleanup_period VALUES (3, 1, 0)" # insert key=3 (never updated)
+
+# Wait for the periodic cleanup merge to physically remove the deleted row.
+# The timer fires after 1s regardless of whether a regular merge ran first, because
+# the cleanup check allows single-part rewrites to remove is_deleted=1 rows.
+if wait_for_cleanup 't04036_cleanup_period' 60
+then
+    echo "Cleanup OK"
+else
+    echo "Cleanup FAILED (timeout)"
+fi
+
+# After cleanup: key=2 is physically gone, key=1 is at ver=2, key=3 is at ver=1.
+$CLICKHOUSE_CLIENT -q "SELECT id, ver, deleted FROM t04036_cleanup_period ORDER BY id"
+
+# Insert more versions to verify that updates are also deduplicated by the timer.
+$CLICKHOUSE_CLIENT -q "INSERT INTO t04036_cleanup_period VALUES (1, 3, 0)" # update key=1 to ver=3
+$CLICKHOUSE_CLIENT -q "INSERT INTO t04036_cleanup_period VALUES (1, 4, 0)" # update key=1 to ver=4
+
+# Cannot use wait_for_cleanup here: there are no deleted=1 rows after these inserts,
+# so it would return immediately before deduplication has happened.
+# Instead wait until key=1 has been deduplicated to exactly 1 row (the latest version).
+if wait_for_row_count 't04036_cleanup_period' 'id = 1' 1 60
+then
+    echo "Second cleanup OK"
+else
+    echo "Second cleanup FAILED (timeout)"
+fi
+
+# Only ver=4 of key=1 should survive alongside key=3.
+$CLICKHOUSE_CLIENT -q "SELECT id, ver, deleted FROM t04036_cleanup_period ORDER BY id"
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE t04036_cleanup_period"
+
+# --- Replicated table test ---
+# Verifies that periodic cleanup is scheduled via ZooKeeper on replicated tables.
+# Uses wait_for_cleanup to confirm is_deleted=1 rows are physically removed.
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS t04036_cleanup_period_replicated"
+
+$CLICKHOUSE_CLIENT -q "
+CREATE TABLE t04036_cleanup_period_replicated
+(
+    id      UInt64,
+    ver     UInt64,
+    deleted UInt8
+)
+ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/{database}/t04036_cleanup_period_replicated', 'node', ver, deleted)
+ORDER BY id
+SETTINGS
+    allow_experimental_replacing_merge_with_cleanup = 1,
+    replacing_merge_cleanup_period_seconds = 1,
+    merge_selecting_sleep_ms = 500,
+    cleanup_delay_period = 1,
+    max_cleanup_delay_period = 1,
+    cleanup_delay_period_random_add = 0"
+
+$CLICKHOUSE_CLIENT -q "INSERT INTO t04036_cleanup_period_replicated VALUES (1, 1, 0)"
+$CLICKHOUSE_CLIENT -q "INSERT INTO t04036_cleanup_period_replicated VALUES (1, 2, 0)"
+$CLICKHOUSE_CLIENT -q "INSERT INTO t04036_cleanup_period_replicated VALUES (2, 1, 0)"
+$CLICKHOUSE_CLIENT -q "INSERT INTO t04036_cleanup_period_replicated VALUES (2, 2, 1)"
+$CLICKHOUSE_CLIENT -q "INSERT INTO t04036_cleanup_period_replicated VALUES (3, 1, 0)"
+
+# After periodic cleanup, the deleted row for key=2 is physically removed.
+# wait_for_number_of_parts is not used here: a regular merge can produce 1 part
+# without cleanup, leaving is_deleted=1 rows intact. We wait for the actual
+# data condition instead.
+if wait_for_cleanup 't04036_cleanup_period_replicated' 60
+then
+    echo "Replicated cleanup OK"
+else
+    echo "Replicated cleanup FAILED (timeout)"
+fi
+
+$CLICKHOUSE_CLIENT -q "SELECT id, ver, deleted FROM t04036_cleanup_period_replicated ORDER BY id"
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE t04036_cleanup_period_replicated"


### PR DESCRIPTION
## Summary

Adds a new experimental setting `replacing_merge_cleanup_period_seconds` to `ReplacingMergeTree`. When set to a non-zero value, the background merge thread automatically schedules a `FINAL CLEANUP` merge for each partition on a time-based schedule — without requiring manual `OPTIMIZE TABLE ... FINAL CLEANUP`.

This solves the gap where `enable_replacing_merge_with_cleanup_for_min_age_to_force_merge` is unusable for tables with continuous inserts (the `min_age` condition is never satisfied because fresh parts are always present).

Closes #99348

Related docs PR: DanLaav/clickhouse-docs#1

---

## Overview

**Problem:** Tables with continuous inserts always have fresh parts, so `min_age_to_force_merge_seconds` never fires. Deleted rows (via `is_deleted = 1`) accumulate forever and are only hidden by `FINAL`, not physically removed.

**Solution:** A per-partition timer. When `now >= last_cleanup + period`, the background merge scheduler runs a full-partition `FINAL CLEANUP` merge automatically.

---

## End-to-End Flow

```
Background scheduler wakes up (every merge_selecting_sleep_ms)
│
└─► StorageMergeTree::selectPartsToMerge()
    │
    └─► MergeTreeDataMergerMutator::selectPartsToMerge()
        │
        ├─► [existing] TTL merge check
        ├─► [existing] min_age_to_force_merge check
        │
        └─► [NEW] getBestPartitionForPeriodicCleanup()
                │
                ├─ setting == 0?       → skip (fast path, no overhead)
                ├─ pool too busy?      → skip (respect background_pool_size)
                ├─ loop partitions:
                │     ├─ empty?                    → skip
                │     └─ now >= next_cleanup_time? → candidate
                │
                └─ best partition found?
                    │
                    Yes ──► selectAllPartsToMergeWithinPartition(final=true)
                            │
                            ├─ set is_periodic_cleanup = true on MergeSelectorChoice
                            ├─ update next_cleanup_time[partition] = now + period
                            │
                            └─► StorageMergeTree::scheduleDataProcessingJob()
                                │
                                ├─ propagate is_periodic_cleanup → MergeMutateSelectedEntry
                                │
                                └─ cleanup = final
                                       && allow_experimental_replacing_merge_with_cleanup
                                       && (
                                           [existing] min_age path
                                           OR
                                           [NEW] is_periodic_cleanup && period > 0
                                          )
                                   │
                                   └─► MergePlainMergeTreeTask(cleanup=true)
                                           │
                                           └─ physical removal of is_deleted=1 rows
                                              deduplication to latest version per key
```

---

## File-by-File Changes

### 1. `src/Storages/MergeTree/MergeTreeSettings.cpp`

Declares the new setting as `UInt64`, default `0` (disabled), `EXPERIMENTAL` tier. Zero-cost when unused.

### 2. `src/Core/SettingsChangesHistory.cpp`

Registers the setting in the version history for 26.3, required for rolling upgrades in replicated clusters.

### 3. `src/Storages/MergeTree/MergeTreeDataMergerMutator.h`

Adds `next_cleanup_merge_time_by_partition` (reuses `PartitionIdToTTLs`, same type as TTL merge tracking) and declares `getBestPartitionForPeriodicCleanup`.

### 4. `src/Storages/MergeTree/MergeTreeDataMergerMutator.cpp`

Implements `getBestPartitionForPeriodicCleanup`:
- Fast exit when setting is 0
- Reuses existing pool throttle check (`number_of_free_entries_in_pool_to_execute_optimize_entire_partition`)
- Picks the most overdue partition to prevent starvation
- Timer updated immediately on scheduling (not on completion) to prevent re-selection on next tick

### 5. `src/Storages/MergeTree/Compaction/MergeSelectorApplier.h`

Adds `is_periodic_cleanup` flag to `MergeSelectorChoice` to carry the trigger type from selector to storage layer.

### 6. `src/Storages/MergeTree/MergeMutateSelectedEntry.h`

Adds `is_periodic_cleanup` flag to `MergeMutateSelectedEntry` so it survives until `scheduleDataProcessingJob` runs.

### 7. `src/Storages/StorageMergeTree.cpp`

Propagates the flag from `MergeSelectorChoice` → `MergeMutateSelectedEntry` and adds the new OR-branch to the `cleanup` condition alongside the existing `min_age` path.

### 8. `src/Storages/StorageReplicatedMergeTree.cpp`

Same `cleanup` condition change as `StorageMergeTree.cpp`. For replicated tables the merge is coordinated through ZooKeeper by the leader replica and executed on all replicas.

### 9. `tests/queries/0_stateless/04036_replacing_cleanup_period.sh`

Shell test (polling loop requires `sleep`). Uses `replacing_merge_cleanup_period_seconds = 1` and `merge_selecting_sleep_ms = 500` for fast CI execution. Verifies both physical deletion of `is_deleted=1` rows and deduplication of updates, across two cleanup cycles.

---

### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Added experimental setting `replacing_merge_cleanup_period_seconds` for `ReplacingMergeTree`. When set to a non-zero value (requires `allow_experimental_replacing_merge_with_cleanup = 1`), the background merge thread automatically runs a `FINAL CLEANUP` merge for each partition at most once per configured period, physically removing deleted rows without manual intervention.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

Documentation added in DanLaav/clickhouse-docs#1 — new section "Automatic periodic cleanup for tables with continuous inserts" in the ReplacingMergeTree guide.