### PR TITLE
Fix flaky test 02126_dist_desc by using case-insensitive LIKE

### DIFF
--- a/tests/queries/0_stateless/02126_dist_desc.sql.j2
+++ b/tests/queries/0_stateless/02126_dist_desc.sql.j2
@@ -14,7 +14,7 @@ select anyIf(query, is_initial_query), groupArrayIf(query, query_kind = 'Describ
 where
     event_date >= yesterday() AND event_time >= now() - 600 AND
     type = 'QueryFinish' and
-    query not like '%FLUSH LOGS%' and
+    query not ilike '%FLUSH LOGS%' and
     -- current_database is not set for queries on shards
     -- (so 'current_database = currentDatabase()' will not show DESC queries)
     log_comment like '%' || currentDatabase() || '%'


### PR DESCRIPTION
The test uses lowercase `system flush logs query_log` but filters results with `query not like '%FLUSH LOGS%'` (uppercase). Since `LIKE` is case-sensitive, the flush query can appear in the output. Changed to `ilike` for case-insensitive matching.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=a66451e5f46d8594270bdc6ee8cfd3025428f954&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.813`
<!-- ch-version-info:end -->