### PR TITLE
Fix flaky test_backup_outer_table in test_refreshable_mv

### DIFF
--- a/tests/integration/test_refreshable_mv/test.py
+++ b/tests/integration/test_refreshable_mv/test.py
@@ -507,22 +507,15 @@ def do_test_backup(to_table):
         node1.query(f"SYSTEM WAIT VIEW re.{target}")
         node2.query(f"SYSTEM WAIT VIEW re.{target}")
     else:
-        # After restore, the refresh task resumes immediately (REFRESH EVERY 1 second).
-        # A refresh may EXCHANGE the target table via the DDL log. The EXCHANGE propagates
-        # asynchronously; SYNC REPLICA may run against the pre-EXCHANGE table, then the
-        # EXCHANGE swaps in the new table whose data hasn't replicated yet → empty SELECT.
-        # Fix: stop the view, wait for any in-flight refresh to fully complete (including
-        # the EXCHANGE DDL), sync DDL, sync data.
+        # After restore, target table data is not included in backup
+        # (backup_data_from_refreshable_materialized_view_targets is off by default).
+        # A refresh must complete to populate it. Wait for the first refresh to
+        # finish *before* stopping the view — otherwise STOP VIEW can cancel the
+        # only in-flight refresh, leaving the target empty.
+        node1.query("SYSTEM WAIT VIEW re.rmv")
         for node in nodes:
             node.query("SYSTEM STOP VIEW re.rmv")
-        # WAIT VIEW ensures any in-flight refresh finishes, including the EXCHANGE DDL.
-        # For coordinated views it also waits for the EXCHANGE to be visible locally.
-        # If the refresh was cancelled by STOP VIEW, WAIT VIEW throws — that's expected.
-        for node in nodes:
-            try:
-                node.query("SYSTEM WAIT VIEW re.rmv")
-            except Exception:
-                pass
+        # Ensure the EXCHANGE DDL has propagated, then sync replica data.
         for node in nodes:
             node.query("SYSTEM SYNC DATABASE REPLICA re")
         node1.query_with_retry(f"SYSTEM SYNC REPLICA re.{target}")


### PR DESCRIPTION
After RESTORE, `re.tgt` is empty because backup skips refreshable MV target data by default. The refresh task starts immediately (REFRESH EVERY 1 SECOND), but the test called `SYSTEM STOP VIEW` first, which could cancel the only in-flight refresh before it completed the EXCHANGE — leaving the table permanently empty.

Fix: call `SYSTEM WAIT VIEW` before `SYSTEM STOP VIEW`, ensuring at least one refresh completes and populates the target table.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99539&sha=a82ffdfade32d4ed3b9def1491ffb2f92385dc7f&name_0=PR&name_1=Integration%20tests%20%28amd_binary%2C%203%2F5%29
https://github.com/ClickHouse/ClickHouse/pull/99539

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.893`
<!-- ch-version-info:end -->