### PR TITLE
Fix filesystem cache race in incrementSize after eviction

### DIFF
--- a/src/Interpreters/Cache/FileCache.cpp
+++ b/src/Interpreters/Cache/FileCache.cpp
@@ -1232,7 +1232,20 @@ bool FileCache::doTryReserve(
 
         main_priority_iterator->check(lock);
         eviction_candidates.afterEvictState(lock);
-        main_priority_iterator->incrementSize(size, lock);
+
+        /// Between `collectEvictionInfo` (which computed how much to evict under the
+        /// state lock) and here, the state lock was dropped for eviction I/O. During
+        /// that gap other threads may have acquired hold spaces or completed reserve
+        /// cycles that consumed the freed space in a sub-queue, so `incrementSize`
+        /// can legitimately find that there is no longer enough room.
+        /// Use `tryIncrementSize` to treat this as a transient reservation failure.
+        if (!main_priority_iterator->tryIncrementSize(size, lock))
+        {
+            if (main_priority_iterator && added_new_main_entry)
+                main_priority_iterator->invalidate();
+            failure_reason = "not enough space after eviction due to concurrent reservations";
+            return false;
+        }
 
         if (query_priority_iterator)
             query_priority_iterator->incrementSize(size, lock);

--- a/src/Interpreters/Cache/FileCache.cpp
+++ b/src/Interpreters/Cache/FileCache.cpp
@@ -1247,8 +1247,14 @@ bool FileCache::doTryReserve(
             return false;
         }
 
-        if (query_priority_iterator)
-            query_priority_iterator->incrementSize(size, lock);
+        if (query_priority_iterator && !query_priority_iterator->tryIncrementSize(size, lock))
+        {
+            main_priority_iterator->decrementSize(size);
+            if (main_priority_iterator && added_new_main_entry)
+                main_priority_iterator->invalidate();
+            failure_reason = "not enough space after eviction due to concurrent reservations (query limit)";
+            return false;
+        }
     }
     catch (...)
     {

--- a/src/Interpreters/Cache/IFileCachePriority.h
+++ b/src/Interpreters/Cache/IFileCachePriority.h
@@ -129,6 +129,11 @@ public:
 
         virtual void incrementSize(size_t size, const CacheStateGuard::Lock &) = 0;
 
+        /// Like `incrementSize`, but returns false instead of throwing when
+        /// the sub-queue cannot fit the requested size (e.g. because concurrent
+        /// reservations consumed the freed space between eviction and this call).
+        virtual bool tryIncrementSize(size_t size, const CacheStateGuard::Lock &) = 0;
+
         virtual void decrementSize(size_t size) = 0;
 
         virtual bool isValid(const CachePriorityGuard::WriteLock &) const = 0;

--- a/src/Interpreters/Cache/LRUFileCachePriority.cpp
+++ b/src/Interpreters/Cache/LRUFileCachePriority.cpp
@@ -640,6 +640,19 @@ void LRUFileCachePriority::LRUIterator::incrementSize(
     size_t size,
     const CacheStateGuard::Lock & lock)
 {
+    if (!tryIncrementSize(size, lock))
+    {
+        auto entry_ptr = entry.lock();
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+                        "Cannot increment size by {} for entry {}. Current state: {}",
+                        size, entry_ptr->toString(), cache_priority->getStateInfoForLog(lock));
+    }
+}
+
+bool LRUFileCachePriority::LRUIterator::tryIncrementSize(
+    size_t size,
+    const CacheStateGuard::Lock & lock)
+{
     chassert(size);
     assertValid();
 
@@ -649,11 +662,7 @@ void LRUFileCachePriority::LRUIterator::incrementSize(
     size_t elements = entry_ptr->size > 0 ? 0 : 1;
 
     if (!cache_priority->canFit(size, elements, lock))
-    {
-        throw Exception(ErrorCodes::LOGICAL_ERROR,
-                        "Cannot increment size by {} for entry {}. Current state: {}",
-                        size, entry_ptr->toString(), cache_priority->getStateInfoForLog(lock));
-    }
+        return false;
 
     LOG_TEST(
         cache_priority->log,
@@ -664,6 +673,7 @@ void LRUFileCachePriority::LRUIterator::incrementSize(
     entry_ptr->size += size;
 
     cache_priority->check(lock);
+    return true;
 }
 
 void LRUFileCachePriority::LRUIterator::decrementSize(size_t size)
@@ -715,8 +725,8 @@ std::string LRUFileCachePriority::getStateInfoForLog(const CacheStateGuard::Lock
 {
     return fmt::format(
         "size: {}/{}, elements: {}/{}, hold size: {}, hold elements: {}, description: {}",
-        getSize(lock), max_size.load(), getElementsCount(lock),
-        total_hold_size.load(), total_hold_elements.load(), max_elements.load(), description);
+        getSize(lock), max_size.load(), getElementsCount(lock), max_elements.load(),
+        total_hold_size.load(), total_hold_elements.load(), description);
 }
 
 std::string LRUFileCachePriority::getApproxStateInfoForLog() const

--- a/src/Interpreters/Cache/LRUFileCachePriority.h
+++ b/src/Interpreters/Cache/LRUFileCachePriority.h
@@ -251,6 +251,8 @@ public:
 
     void incrementSize(size_t size, const CacheStateGuard::Lock &) override;
 
+    bool tryIncrementSize(size_t size, const CacheStateGuard::Lock &) override;
+
     void decrementSize(size_t size) override;
 
     QueueEntryType getType() const override { return QueueEntryType::LRU; }

--- a/src/Interpreters/Cache/SLRUFileCachePriority.cpp
+++ b/src/Interpreters/Cache/SLRUFileCachePriority.cpp
@@ -827,6 +827,15 @@ void SLRUFileCachePriority::SLRUIterator::incrementSize(size_t size, const Cache
     check(lock);
 }
 
+bool SLRUFileCachePriority::SLRUIterator::tryIncrementSize(size_t size, const CacheStateGuard::Lock & lock)
+{
+    assertValid();
+    if (!lru_iterator.tryIncrementSize(size, lock))
+        return false;
+    check(lock);
+    return true;
+}
+
 void SLRUFileCachePriority::SLRUIterator::decrementSize(size_t size)
 {
     assertValid();

--- a/src/Interpreters/Cache/SLRUFileCachePriority.h
+++ b/src/Interpreters/Cache/SLRUFileCachePriority.h
@@ -169,6 +169,8 @@ public:
 
     void incrementSize(size_t size, const CacheStateGuard::Lock &) override;
 
+    bool tryIncrementSize(size_t size, const CacheStateGuard::Lock &) override;
+
     void decrementSize(size_t size) override;
 
 private:

--- a/src/Interpreters/Cache/SplitFileCachePriority.cpp
+++ b/src/Interpreters/Cache/SplitFileCachePriority.cpp
@@ -294,6 +294,13 @@ void SplitFileCachePriority::SplitIterator::incrementSize(
     iterator->incrementSize(size, lock);
 }
 
+bool SplitFileCachePriority::SplitIterator::tryIncrementSize(
+    size_t size,
+    const CacheStateGuard::Lock & lock)
+{
+    return iterator->tryIncrementSize(size, lock);
+}
+
 void SplitFileCachePriority::SplitIterator::decrementSize(size_t size)
 {
     iterator->decrementSize(size);

--- a/src/Interpreters/Cache/SplitFileCachePriority.h
+++ b/src/Interpreters/Cache/SplitFileCachePriority.h
@@ -149,6 +149,8 @@ public:
 
     void incrementSize(size_t size, const CacheStateGuard::Lock &) override;
 
+    bool tryIncrementSize(size_t size, const CacheStateGuard::Lock &) override;
+
     void decrementSize(size_t size) override;
 
     QueueEntryType getType() const override


### PR DESCRIPTION
Between `collectEvictionInfo` and `incrementSize`, the state lock is dropped for eviction I/O. During that gap other threads may complete reserve cycles that change the sub-queue state, so `incrementSize` can legitimately find that a sub-queue no longer has room. This manifests as a `LOGICAL_ERROR` exception "Cannot increment size".

Example failure: https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?PR=52290&sha=c7313ec1fda3fdda8147d312f770824667ffe879&name_0=PR&name_1=Stateless%20tests%20%28amd_release%2C%20meta%20storage%20in%20keeper%2C%20s3%20storage%2C%20sequential%29

Add `tryIncrementSize` (returns false instead of throwing) to the `Iterator` interface and use it in `doTryReserve` to treat the condition as a transient reservation failure. Also fix argument order in `LRUFileCachePriority::getStateInfoForLog` which swapped `max_elements` with `hold size` / `hold elements`.

cc @kssenii

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a race condition in the filesystem cache that could cause a `LOGICAL_ERROR` "Cannot increment size" when multiple threads compete for cache space.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)