### PR TITLE
Fix undefined behavior in Avro reader

### DIFF
--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -3,6 +3,7 @@
 
 #include <numeric>
 
+#include <Core/AccurateComparison.h>
 #include <Core/Field.h>
 
 #include <Common/CacheBase.h>
@@ -111,6 +112,23 @@ size_t AvroInputStreamReadBufferAdapter::byteCount() const
     return in.count();
 }
 
+/// Helper to convert and insert a numeric value with overflow detection.
+template <typename Source, typename Target, typename Column>
+static void convertAndInsert(Column & column, Source value)
+{
+    Target converted;
+    if (!accurate::convertNumeric<Source, Target, /* strict= */ false>(value, converted))
+    {
+        throw Exception(
+            ErrorCodes::VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE,
+            "Cannot convert Avro value {} to {}",
+            // Convert char types to int for logging
+            +value,
+            demangle(typeid(Target).name()));
+    }
+    column.insertValue(converted);
+}
+
 /// Insert value with conversion to the column of target type.
 template <typename T>
 static void insertNumber(IColumn & column, WhichDataType type, T value)
@@ -118,50 +136,62 @@ static void insertNumber(IColumn & column, WhichDataType type, T value)
     switch (type.idx)
     {
         case TypeIndex::UInt8:
-            assert_cast<ColumnUInt8 &>(column).insertValue(static_cast<UInt8>(value));
+            convertAndInsert<T, UInt8>(assert_cast<ColumnUInt8 &>(column), value);
             break;
-        case TypeIndex::Date: [[fallthrough]];
+        case TypeIndex::Date:
+            [[fallthrough]];
         case TypeIndex::UInt16:
-            assert_cast<ColumnUInt16 &>(column).insertValue(static_cast<UInt16>(value));
+            convertAndInsert<T, UInt16>(assert_cast<ColumnUInt16 &>(column), value);
             break;
-        case TypeIndex::DateTime: [[fallthrough]];
+        case TypeIndex::DateTime:
+            [[fallthrough]];
         case TypeIndex::UInt32:
-            assert_cast<ColumnUInt32 &>(column).insertValue(static_cast<UInt32>(value));
+            convertAndInsert<T, UInt32>(assert_cast<ColumnUInt32 &>(column), value);
             break;
         case TypeIndex::UInt64:
-            assert_cast<ColumnUInt64 &>(column).insertValue(static_cast<UInt64>(value));
+            convertAndInsert<T, UInt64>(assert_cast<ColumnUInt64 &>(column), value);
             break;
         case TypeIndex::Int8:
-            assert_cast<ColumnInt8 &>(column).insertValue(static_cast<Int8>(value));
+            convertAndInsert<T, Int8>(assert_cast<ColumnInt8 &>(column), value);
             break;
         case TypeIndex::Int16:
-            assert_cast<ColumnInt16 &>(column).insertValue(static_cast<Int16>(value));
+            convertAndInsert<T, Int16>(assert_cast<ColumnInt16 &>(column), value);
             break;
-        case TypeIndex::Date32: [[fallthrough]];
+        case TypeIndex::Date32:
+            [[fallthrough]];
         case TypeIndex::Int32:
-            assert_cast<ColumnInt32 &>(column).insertValue(static_cast<Int32>(value));
+            convertAndInsert<T, Int32>(assert_cast<ColumnInt32 &>(column), value);
             break;
         case TypeIndex::Int64:
-            assert_cast<ColumnInt64 &>(column).insertValue(static_cast<Int64>(value));
+            convertAndInsert<T, Int64>(assert_cast<ColumnInt64 &>(column), value);
             break;
         case TypeIndex::Float32:
-            assert_cast<ColumnFloat32 &>(column).insertValue(static_cast<Float32>(value));
+            convertAndInsert<T, Float32>(assert_cast<ColumnFloat32 &>(column), value);
             break;
         case TypeIndex::Float64:
-            assert_cast<ColumnFloat64 &>(column).insertValue(static_cast<Float64>(value));
+            convertAndInsert<T, Float64>(assert_cast<ColumnFloat64 &>(column), value);
             break;
         case TypeIndex::Decimal32:
-            assert_cast<ColumnDecimal<Decimal32> &>(column).insertValue(static_cast<Int32>(value));
+            convertAndInsert<T, Int32>(assert_cast<ColumnDecimal<Decimal32> &>(column), value);
             break;
         case TypeIndex::Decimal64:
-            assert_cast<ColumnDecimal<Decimal64> &>(column).insertValue(static_cast<Int64>(value));
+            convertAndInsert<T, Int64>(assert_cast<ColumnDecimal<Decimal64> &>(column), value);
             break;
         case TypeIndex::DateTime64:
-            assert_cast<ColumnDecimal<DateTime64> &>(column).insertValue(static_cast<Int64>(value));
+            convertAndInsert<T, Int64>(assert_cast<ColumnDecimal<DateTime64> &>(column), value);
             break;
         case TypeIndex::IPv4:
-            assert_cast<ColumnIPv4 &>(column).insertValue(IPv4(static_cast<UInt32>(value)));
+        {
+            UInt32 converted;
+            // Can't use convertAndInsert here because we want to call IPv4 on
+            // the result below before inserting it into the column.
+            if (!accurate::convertNumeric<T, UInt32, /* strict= */ false>(value, converted))
+            {
+                throw Exception(ErrorCodes::VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE, "Cannot convert Avro value {} to UInt32", +value);
+            }
+            assert_cast<ColumnIPv4 &>(column).insertValue(IPv4(converted));
             break;
+        }
         default:
             throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Type is not compatible with Avro");
     }
@@ -353,7 +383,8 @@ AvroDeserializer::DeserializeFn AvroDeserializer::createDeserializeFn(const avro
             {
                 return [target](IColumn & column, avro::Decoder & decoder)
                 {
-                    insertNumber(column, target, decoder.decodeBool());
+                    // Cast bool to UInt8 since accurate::convertNumeric doesn't support bool
+                    insertNumber(column, target, static_cast<UInt8>(decoder.decodeBool()));
                     return true;
                 };
             }

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -131,15 +131,14 @@ static void convertAndInsert(Column & column, Source value, TypeIndex type_index
 
     if constexpr (std::is_floating_point_v<Source>)
     {
-        // Float-to-integer and float-to-float overflow are UB - must check
+        // Float-to-integer, float-to-float overflow, and casting NaN to integer are UB - must check
         Target converted;
-        if (!accurate::convertNumeric<Source, Target, /* strict= */ false>(value, converted))
+        if ((!std::is_floating_point_v<Target> && isNaN(value)) ||
+         !accurate::convertNumeric<Source, Target, /* strict= */ false>(value, converted))
         {
             throw Exception(
                 ErrorCodes::VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE,
-                "Cannot convert Avro value {} to {}",
-                value,
-                magic_enum::enum_name(type_index));
+                "Cannot convert Avro value {} to {}", value, magic_enum::enum_name(type_index));
         }
         insert(converted);
     }

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -58,6 +58,8 @@
 #include <Poco/Net/HTTPResponse.h>
 #include <Poco/URI.h>
 
+#include <magic_enum.hpp>
+
 
 namespace CurrentMetrics
 {
@@ -112,21 +114,39 @@ size_t AvroInputStreamReadBufferAdapter::byteCount() const
     return in.count();
 }
 
-/// Helper to convert and insert a numeric value with overflow detection.
-template <typename Source, typename Target, typename Column>
-static void convertAndInsert(Column & column, Source value)
+/// Helper to convert and insert a numeric value.
+/// Only floating-point to integer/float conversions can cause undefined behavior,
+/// so we only apply range checks for floating-point source types.
+/// Integer-to-integer conversions are always defined (may truncate/wrap).
+template <typename Source, typename Target, typename Column, bool is_ipv4 = false>
+static void convertAndInsert(Column & column, Source value, TypeIndex type_index)
 {
-    Target converted;
-    if (!accurate::convertNumeric<Source, Target, /* strict= */ false>(value, converted))
+    auto insert = [&](Target value_to_insert) {
+        if constexpr (is_ipv4)
+            column.insertValue(IPv4(value_to_insert));
+        else
+            column.insertValue(value_to_insert);
+    };
+
+    if constexpr (std::is_floating_point_v<Source>)
     {
-        throw Exception(
-            ErrorCodes::VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE,
-            "Cannot convert Avro value {} to {}",
-            // Convert char types to int for logging
-            +value,
-            demangle(typeid(Target).name()));
+        // Float-to-integer and float-to-float overflow are UB - must check
+        Target converted;
+        if (!accurate::convertNumeric<Source, Target, /* strict= */ false>(value, converted))
+        {
+            throw Exception(
+                ErrorCodes::VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE,
+                "Cannot convert Avro value {} to {}",
+                value,
+                magic_enum::enum_name(type_index));
+        }
+        insert(converted);
     }
-    column.insertValue(converted);
+    else
+    {
+        // Integer-to-integer conversions are always defined (may truncate/wrap)
+        insert(static_cast<Target>(value));
+    }
 }
 
 /// Insert value with conversion to the column of target type.
@@ -136,62 +156,53 @@ static void insertNumber(IColumn & column, WhichDataType type, T value)
     switch (type.idx)
     {
         case TypeIndex::UInt8:
-            convertAndInsert<T, UInt8>(assert_cast<ColumnUInt8 &>(column), value);
+            convertAndInsert<T, UInt8>(assert_cast<ColumnUInt8 &>(column), value, type.idx);
             break;
         case TypeIndex::Date:
             [[fallthrough]];
         case TypeIndex::UInt16:
-            convertAndInsert<T, UInt16>(assert_cast<ColumnUInt16 &>(column), value);
+            convertAndInsert<T, UInt16>(assert_cast<ColumnUInt16 &>(column), value, type.idx);
             break;
         case TypeIndex::DateTime:
             [[fallthrough]];
         case TypeIndex::UInt32:
-            convertAndInsert<T, UInt32>(assert_cast<ColumnUInt32 &>(column), value);
+            convertAndInsert<T, UInt32>(assert_cast<ColumnUInt32 &>(column), value, type.idx);
             break;
         case TypeIndex::UInt64:
-            convertAndInsert<T, UInt64>(assert_cast<ColumnUInt64 &>(column), value);
+            convertAndInsert<T, UInt64>(assert_cast<ColumnUInt64 &>(column), value, type.idx);
             break;
         case TypeIndex::Int8:
-            convertAndInsert<T, Int8>(assert_cast<ColumnInt8 &>(column), value);
+            convertAndInsert<T, Int8>(assert_cast<ColumnInt8 &>(column), value, type.idx);
             break;
         case TypeIndex::Int16:
-            convertAndInsert<T, Int16>(assert_cast<ColumnInt16 &>(column), value);
+            convertAndInsert<T, Int16>(assert_cast<ColumnInt16 &>(column), value, type.idx);
             break;
         case TypeIndex::Date32:
             [[fallthrough]];
         case TypeIndex::Int32:
-            convertAndInsert<T, Int32>(assert_cast<ColumnInt32 &>(column), value);
+            convertAndInsert<T, Int32>(assert_cast<ColumnInt32 &>(column), value, type.idx);
             break;
         case TypeIndex::Int64:
-            convertAndInsert<T, Int64>(assert_cast<ColumnInt64 &>(column), value);
+            convertAndInsert<T, Int64>(assert_cast<ColumnInt64 &>(column), value, type.idx);
             break;
         case TypeIndex::Float32:
-            convertAndInsert<T, Float32>(assert_cast<ColumnFloat32 &>(column), value);
+            convertAndInsert<T, Float32>(assert_cast<ColumnFloat32 &>(column), value, type.idx);
             break;
         case TypeIndex::Float64:
-            convertAndInsert<T, Float64>(assert_cast<ColumnFloat64 &>(column), value);
+            convertAndInsert<T, Float64>(assert_cast<ColumnFloat64 &>(column), value, type.idx);
             break;
         case TypeIndex::Decimal32:
-            convertAndInsert<T, Int32>(assert_cast<ColumnDecimal<Decimal32> &>(column), value);
+            convertAndInsert<T, Int32>(assert_cast<ColumnDecimal<Decimal32> &>(column), value, type.idx);
             break;
         case TypeIndex::Decimal64:
-            convertAndInsert<T, Int64>(assert_cast<ColumnDecimal<Decimal64> &>(column), value);
+            convertAndInsert<T, Int64>(assert_cast<ColumnDecimal<Decimal64> &>(column), value, type.idx);
             break;
         case TypeIndex::DateTime64:
-            convertAndInsert<T, Int64>(assert_cast<ColumnDecimal<DateTime64> &>(column), value);
+            convertAndInsert<T, Int64>(assert_cast<ColumnDecimal<DateTime64> &>(column), value, type.idx);
             break;
         case TypeIndex::IPv4:
-        {
-            UInt32 converted;
-            // Can't use convertAndInsert here because we want to call IPv4 on
-            // the result below before inserting it into the column.
-            if (!accurate::convertNumeric<T, UInt32, /* strict= */ false>(value, converted))
-            {
-                throw Exception(ErrorCodes::VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE, "Cannot convert Avro value {} to UInt32", +value);
-            }
-            assert_cast<ColumnIPv4 &>(column).insertValue(IPv4(converted));
+            convertAndInsert<T, UInt32, ColumnIPv4, true>(assert_cast<ColumnIPv4 &>(column), value, type.idx);
             break;
-        }
         default:
             throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Type is not compatible with Avro");
     }

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -121,7 +121,8 @@ size_t AvroInputStreamReadBufferAdapter::byteCount() const
 template <typename Source, typename Target, typename Column, bool is_ipv4 = false>
 static void convertAndInsert(Column & column, Source value, TypeIndex type_index)
 {
-    auto insert = [&](Target value_to_insert) {
+    auto insert = [&](Target value_to_insert)
+    {
         if constexpr (is_ipv4)
             column.insertValue(IPv4(value_to_insert));
         else

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -58,7 +58,7 @@
 #include <Poco/Net/HTTPResponse.h>
 #include <Poco/URI.h>
 
-#include <magic_enum.hpp>
+#include <base/EnumReflection.h>
 
 
 namespace CurrentMetrics

--- a/tests/queries/0_stateless/04035_avro_overflow_detection.reference
+++ b/tests/queries/0_stateless/04035_avro_overflow_detection.reference
@@ -22,8 +22,8 @@ Test 11: Zero float to int (should succeed)
 0
 Test 12: Negative whole float to int (should succeed)
 -50
-Test 13: NaN to int (converts to INT32_MIN)
--2147483648
+Test 13: NaN to int
+OK
 Test 14: Infinity to int
 OK
 Test 15: Int 1 to Bool (should succeed)

--- a/tests/queries/0_stateless/04035_avro_overflow_detection.reference
+++ b/tests/queries/0_stateless/04035_avro_overflow_detection.reference
@@ -1,0 +1,48 @@
+Test 1: Long to UInt8 overflow
+OK
+Test 2: Negative to UInt8 overflow
+OK
+Test 3: Large Int64 to Int8 overflow
+OK
+Test 4: Negative Int64 to UInt64 overflow
+OK
+Test 5: Value within range (should succeed)
+100
+Test 6: Large double to Float32 overflow
+OK
+Test 7: Fractional float to int (truncates)
+1
+Test 8: Negative fractional float to int (truncates)
+-2
+Test 9: Large float outside int range
+OK
+Test 10: Whole number float to int (should succeed)
+100
+Test 11: Zero float to int (should succeed)
+0
+Test 12: Negative whole float to int (should succeed)
+-50
+Test 13: NaN to int (converts to INT32_MIN)
+-2147483648
+Test 14: Infinity to int
+OK
+Test 15: Int 1 to Bool (should succeed)
+true
+Test 16: Int 0 to Bool (should succeed)
+false
+Test 17: Int 2 to Bool (converts to true)
+true
+Test 18: Negative int to Bool
+OK
+Test 19: Negative to IPv4
+OK
+Test 20: Value exceeding UInt32 max to IPv4
+OK
+Test 21: Fractional float to IPv4 (truncates)
+0.0.0.192
+Test 22: Valid UInt32 to IPv4 (should succeed)
+192.168.1.1
+Test 23: Zero to IPv4 (should succeed)
+0.0.0.0
+Test 24: Max IPv4 (should succeed)
+255.255.255.255

--- a/tests/queries/0_stateless/04035_avro_overflow_detection.reference
+++ b/tests/queries/0_stateless/04035_avro_overflow_detection.reference
@@ -1,11 +1,11 @@
-Test 1: Long to UInt8 overflow
-OK
-Test 2: Negative to UInt8 overflow
-OK
-Test 3: Large Int64 to Int8 overflow
-OK
-Test 4: Negative Int64 to UInt64 overflow
-OK
+Test 1: Long to UInt8 narrowing (300 mod 256 = 44)
+44
+Test 2: Negative to UInt8 (wraps to 255)
+255
+Test 3: Large Int64 to Int8 (200 truncates to -56)
+-56
+Test 4: Negative Int64 to UInt64 (wraps)
+18446744073709551516
 Test 5: Value within range (should succeed)
 100
 Test 6: Large double to Float32 overflow
@@ -32,12 +32,12 @@ Test 16: Int 0 to Bool (should succeed)
 false
 Test 17: Int 2 to Bool (converts to true)
 true
-Test 18: Negative int to Bool
-OK
-Test 19: Negative to IPv4
-OK
-Test 20: Value exceeding UInt32 max to IPv4
-OK
+Test 18: Negative int to Bool (wraps to true)
+true
+Test 19: Negative to IPv4 (wraps to 255.255.255.255)
+255.255.255.255
+Test 20: Value exceeding UInt32 max to IPv4 (truncates)
+42.5.242.0
 Test 21: Fractional float to IPv4 (truncates)
 0.0.0.192
 Test 22: Valid UInt32 to IPv4 (should succeed)

--- a/tests/queries/0_stateless/04035_avro_overflow_detection.sh
+++ b/tests/queries/0_stateless/04035_avro_overflow_detection.sh
@@ -81,7 +81,7 @@ ${CLICKHOUSE_LOCAL} -q "SELECT -50.0::Float64 AS x FORMAT Avro" | \
 
 echo "Test 13: NaN to int"
 ${CLICKHOUSE_LOCAL} -q "SELECT nan::Float64 AS x FORMAT Avro" | \
-    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Int32' -q "SELECT * FROM table"
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Int32' -q "SELECT * FROM table" 2>&1 | \
     expect_error "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE"
 
 echo "Test 14: Infinity to int"

--- a/tests/queries/0_stateless/04035_avro_overflow_detection.sh
+++ b/tests/queries/0_stateless/04035_avro_overflow_detection.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+# Test that Avro format properly detects numeric overflow and type conversion errors
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+#
+# Integer overflow tests
+#
+
+echo "Test 1: Long to UInt8 overflow"
+${CLICKHOUSE_LOCAL} -q "SELECT toInt64(300) AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x UInt8' -q "SELECT * FROM table" 2>&1 | \
+    grep -q "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE" && echo "OK" || echo "FAIL"
+
+echo "Test 2: Negative to UInt8 overflow"
+${CLICKHOUSE_LOCAL} -q "SELECT toInt64(-1) AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x UInt8' -q "SELECT * FROM table" 2>&1 | \
+    grep -q "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE" && echo "OK" || echo "FAIL"
+
+echo "Test 3: Large Int64 to Int8 overflow"
+${CLICKHOUSE_LOCAL} -q "SELECT toInt64(200) AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Int8' -q "SELECT * FROM table" 2>&1 | \
+    grep -q "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE" && echo "OK" || echo "FAIL"
+
+echo "Test 4: Negative Int64 to UInt64 overflow"
+${CLICKHOUSE_LOCAL} -q "SELECT toInt64(-100) AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x UInt64' -q "SELECT * FROM table" 2>&1 | \
+    grep -q "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE" && echo "OK" || echo "FAIL"
+
+echo "Test 5: Value within range (should succeed)"
+${CLICKHOUSE_LOCAL} -q "SELECT toInt64(100) AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x UInt8' -q "SELECT * FROM table"
+
+#
+# Float to float overflow tests
+#
+
+echo "Test 6: Large double to Float32 overflow"
+${CLICKHOUSE_LOCAL} -q "SELECT toFloat64(1e300) AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Float32' -q "SELECT * FROM table" 2>&1 | \
+    grep -q "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE" && echo "OK" || echo "FAIL"
+
+#
+# Float to integer conversion tests
+#
+
+echo "Test 7: Fractional float to int (truncates)"
+${CLICKHOUSE_LOCAL} -q "SELECT 1.5::Float64 AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Int32' -q "SELECT * FROM table"
+
+echo "Test 8: Negative fractional float to int (truncates)"
+${CLICKHOUSE_LOCAL} -q "SELECT -2.7::Float64 AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Int32' -q "SELECT * FROM table"
+
+echo "Test 9: Large float outside int range"
+${CLICKHOUSE_LOCAL} -q "SELECT 1e20::Float64 AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Int32' -q "SELECT * FROM table" 2>&1 | \
+    grep -q "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE" && echo "OK" || echo "FAIL"
+
+echo "Test 10: Whole number float to int (should succeed)"
+${CLICKHOUSE_LOCAL} -q "SELECT 100.0::Float64 AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Int32' -q "SELECT * FROM table"
+
+echo "Test 11: Zero float to int (should succeed)"
+${CLICKHOUSE_LOCAL} -q "SELECT 0.0::Float64 AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Int32' -q "SELECT * FROM table"
+
+echo "Test 12: Negative whole float to int (should succeed)"
+${CLICKHOUSE_LOCAL} -q "SELECT -50.0::Float64 AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Int32' -q "SELECT * FROM table"
+
+echo "Test 13: NaN to int (converts to INT32_MIN)"
+${CLICKHOUSE_LOCAL} -q "SELECT nan::Float64 AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Int32' -q "SELECT * FROM table"
+
+echo "Test 14: Infinity to int"
+${CLICKHOUSE_LOCAL} -q "SELECT inf::Float64 AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Int32' -q "SELECT * FROM table" 2>&1 | \
+    grep -q "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE" && echo "OK" || echo "FAIL"
+
+#
+# Bool conversion tests
+#
+
+echo "Test 15: Int 1 to Bool (should succeed)"
+${CLICKHOUSE_LOCAL} -q "SELECT 1::Int64 AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Bool' -q "SELECT * FROM table"
+
+echo "Test 16: Int 0 to Bool (should succeed)"
+${CLICKHOUSE_LOCAL} -q "SELECT 0::Int64 AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Bool' -q "SELECT * FROM table"
+
+echo "Test 17: Int 2 to Bool (converts to true)"
+${CLICKHOUSE_LOCAL} -q "SELECT 2::Int64 AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Bool' -q "SELECT * FROM table"
+
+echo "Test 18: Negative int to Bool"
+${CLICKHOUSE_LOCAL} -q "SELECT -1::Int64 AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Bool' -q "SELECT * FROM table" 2>&1 | \
+    grep -q "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE" && echo "OK" || echo "FAIL"
+
+#
+# IPv4 conversion tests
+#
+
+echo "Test 19: Negative to IPv4"
+${CLICKHOUSE_LOCAL} -q "SELECT -1::Int64 AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x IPv4' -q "SELECT * FROM table" 2>&1 | \
+    grep -q "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE" && echo "OK" || echo "FAIL"
+
+echo "Test 20: Value exceeding UInt32 max to IPv4"
+${CLICKHOUSE_LOCAL} -q "SELECT 5000000000::Int64 AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x IPv4' -q "SELECT * FROM table" 2>&1 | \
+    grep -q "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE" && echo "OK" || echo "FAIL"
+
+echo "Test 21: Fractional float to IPv4 (truncates)"
+${CLICKHOUSE_LOCAL} -q "SELECT 192.5::Float64 AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x IPv4' -q "SELECT * FROM table"
+
+echo "Test 22: Valid UInt32 to IPv4 (should succeed)"
+${CLICKHOUSE_LOCAL} -q "SELECT 3232235777::UInt64 AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x IPv4' -q "SELECT * FROM table"
+
+echo "Test 23: Zero to IPv4 (should succeed)"
+${CLICKHOUSE_LOCAL} -q "SELECT 0::Int64 AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x IPv4' -q "SELECT * FROM table"
+
+echo "Test 24: Max IPv4 (should succeed)"
+${CLICKHOUSE_LOCAL} -q "SELECT 4294967295::UInt64 AS x FORMAT Avro" | \
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x IPv4' -q "SELECT * FROM table"

--- a/tests/queries/0_stateless/04035_avro_overflow_detection.sh
+++ b/tests/queries/0_stateless/04035_avro_overflow_detection.sh
@@ -1,35 +1,41 @@
 #!/usr/bin/env bash
 # Tags: no-fasttest
 
-# Test that Avro format properly detects numeric overflow and type conversion errors
+# Test that Avro format properly handles numeric conversions:
+# - Float-to-integer and float-to-float overflow are undefined behavior and must be detected
+# - Integer-to-integer conversions use defined C++ behavior (truncation/wrapping)
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
+ expect_error() {
+     if grep -q "$1"; then
+         echo "OK"
+     else
+         echo "FAIL"
+     fi
+ }
+
 #
-# Integer overflow tests
+# Integer narrowing tests (defined behavior - truncation/wrapping)
 #
 
-echo "Test 1: Long to UInt8 overflow"
+echo "Test 1: Long to UInt8 narrowing (300 mod 256 = 44)"
 ${CLICKHOUSE_LOCAL} -q "SELECT toInt64(300) AS x FORMAT Avro" | \
-    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x UInt8' -q "SELECT * FROM table" 2>&1 | \
-    grep -q "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE" && echo "OK" || echo "FAIL"
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x UInt8' -q "SELECT * FROM table"
 
-echo "Test 2: Negative to UInt8 overflow"
+echo "Test 2: Negative to UInt8 (wraps to 255)"
 ${CLICKHOUSE_LOCAL} -q "SELECT toInt64(-1) AS x FORMAT Avro" | \
-    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x UInt8' -q "SELECT * FROM table" 2>&1 | \
-    grep -q "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE" && echo "OK" || echo "FAIL"
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x UInt8' -q "SELECT * FROM table"
 
-echo "Test 3: Large Int64 to Int8 overflow"
+echo "Test 3: Large Int64 to Int8 (200 truncates to -56)"
 ${CLICKHOUSE_LOCAL} -q "SELECT toInt64(200) AS x FORMAT Avro" | \
-    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Int8' -q "SELECT * FROM table" 2>&1 | \
-    grep -q "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE" && echo "OK" || echo "FAIL"
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Int8' -q "SELECT * FROM table"
 
-echo "Test 4: Negative Int64 to UInt64 overflow"
+echo "Test 4: Negative Int64 to UInt64 (wraps)"
 ${CLICKHOUSE_LOCAL} -q "SELECT toInt64(-100) AS x FORMAT Avro" | \
-    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x UInt64' -q "SELECT * FROM table" 2>&1 | \
-    grep -q "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE" && echo "OK" || echo "FAIL"
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x UInt64' -q "SELECT * FROM table"
 
 echo "Test 5: Value within range (should succeed)"
 ${CLICKHOUSE_LOCAL} -q "SELECT toInt64(100) AS x FORMAT Avro" | \
@@ -42,7 +48,7 @@ ${CLICKHOUSE_LOCAL} -q "SELECT toInt64(100) AS x FORMAT Avro" | \
 echo "Test 6: Large double to Float32 overflow"
 ${CLICKHOUSE_LOCAL} -q "SELECT toFloat64(1e300) AS x FORMAT Avro" | \
     ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Float32' -q "SELECT * FROM table" 2>&1 | \
-    grep -q "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE" && echo "OK" || echo "FAIL"
+    expect_error "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE"
 
 #
 # Float to integer conversion tests
@@ -59,7 +65,7 @@ ${CLICKHOUSE_LOCAL} -q "SELECT -2.7::Float64 AS x FORMAT Avro" | \
 echo "Test 9: Large float outside int range"
 ${CLICKHOUSE_LOCAL} -q "SELECT 1e20::Float64 AS x FORMAT Avro" | \
     ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Int32' -q "SELECT * FROM table" 2>&1 | \
-    grep -q "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE" && echo "OK" || echo "FAIL"
+    expect_error "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE"
 
 echo "Test 10: Whole number float to int (should succeed)"
 ${CLICKHOUSE_LOCAL} -q "SELECT 100.0::Float64 AS x FORMAT Avro" | \
@@ -80,7 +86,7 @@ ${CLICKHOUSE_LOCAL} -q "SELECT nan::Float64 AS x FORMAT Avro" | \
 echo "Test 14: Infinity to int"
 ${CLICKHOUSE_LOCAL} -q "SELECT inf::Float64 AS x FORMAT Avro" | \
     ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Int32' -q "SELECT * FROM table" 2>&1 | \
-    grep -q "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE" && echo "OK" || echo "FAIL"
+    expect_error "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE"
 
 #
 # Bool conversion tests
@@ -98,24 +104,21 @@ echo "Test 17: Int 2 to Bool (converts to true)"
 ${CLICKHOUSE_LOCAL} -q "SELECT 2::Int64 AS x FORMAT Avro" | \
     ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Bool' -q "SELECT * FROM table"
 
-echo "Test 18: Negative int to Bool"
+echo "Test 18: Negative int to Bool (wraps to true)"
 ${CLICKHOUSE_LOCAL} -q "SELECT -1::Int64 AS x FORMAT Avro" | \
-    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Bool' -q "SELECT * FROM table" 2>&1 | \
-    grep -q "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE" && echo "OK" || echo "FAIL"
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Bool' -q "SELECT * FROM table"
 
 #
-# IPv4 conversion tests
+# IPv4 conversion tests (integer narrowing - defined behavior)
 #
 
-echo "Test 19: Negative to IPv4"
+echo "Test 19: Negative to IPv4 (wraps to 255.255.255.255)"
 ${CLICKHOUSE_LOCAL} -q "SELECT -1::Int64 AS x FORMAT Avro" | \
-    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x IPv4' -q "SELECT * FROM table" 2>&1 | \
-    grep -q "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE" && echo "OK" || echo "FAIL"
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x IPv4' -q "SELECT * FROM table"
 
-echo "Test 20: Value exceeding UInt32 max to IPv4"
+echo "Test 20: Value exceeding UInt32 max to IPv4 (truncates)"
 ${CLICKHOUSE_LOCAL} -q "SELECT 5000000000::Int64 AS x FORMAT Avro" | \
-    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x IPv4' -q "SELECT * FROM table" 2>&1 | \
-    grep -q "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE" && echo "OK" || echo "FAIL"
+    ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x IPv4' -q "SELECT * FROM table"
 
 echo "Test 21: Fractional float to IPv4 (truncates)"
 ${CLICKHOUSE_LOCAL} -q "SELECT 192.5::Float64 AS x FORMAT Avro" | \

--- a/tests/queries/0_stateless/04035_avro_overflow_detection.sh
+++ b/tests/queries/0_stateless/04035_avro_overflow_detection.sh
@@ -79,9 +79,10 @@ echo "Test 12: Negative whole float to int (should succeed)"
 ${CLICKHOUSE_LOCAL} -q "SELECT -50.0::Float64 AS x FORMAT Avro" | \
     ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Int32' -q "SELECT * FROM table"
 
-echo "Test 13: NaN to int (converts to INT32_MIN)"
+echo "Test 13: NaN to int"
 ${CLICKHOUSE_LOCAL} -q "SELECT nan::Float64 AS x FORMAT Avro" | \
     ${CLICKHOUSE_LOCAL} --input-format Avro -S 'x Int32' -q "SELECT * FROM table"
+    expect_error "VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE"
 
 echo "Test 14: Infinity to int"
 ${CLICKHOUSE_LOCAL} -q "SELECT inf::Float64 AS x FORMAT Avro" | \


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix undefined behavior in Avro format reader when reading numeric values that overflow the target column type. Now queries fail on overflows instead of silently producing incorrect values.

Fixes: https://github.com/ClickHouse/ClickHouse/issues/85077.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.72`
<!-- ch-version-info:end -->