### PR TITLE
delay processing until server has finished loading all the tables

### DIFF
--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -19,6 +19,7 @@
 #include <Storages/MemorySettings.h>
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
+#include <Storages/StorageMaterializedView.h>
 #include <Storages/StorageMemory.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/Exception.h>
@@ -1019,6 +1020,35 @@ std::vector<StorageID> DatabaseCatalog::getDependentViews(const StorageID & sour
 {
     std::lock_guard lock{databases_mutex};
     return view_dependencies.getDependencies(source_table_id);
+}
+
+std::vector<StorageID> DatabaseCatalog::getReadyDependentViews(const StorageID & source_table_id, const ContextPtr & query_context) const
+{
+    /// During server startup, not all dependent views may be registered yet.
+    /// Return empty to prevent streaming engines from processing with a
+    /// partial dependency graph, which would permanently lose data for
+    /// views not yet loaded.
+    auto global_context = Context::getGlobalContextInstance();
+    if (global_context->getApplicationType() == Context::ApplicationType::SERVER
+        && !global_context->isServerCompletelyStarted())
+        return {};
+
+    auto view_ids = getDependentViews(source_table_id);
+    if (view_ids.empty())
+        return {};
+
+    for (const auto & view_id : view_ids)
+    {
+        auto view = tryGetTable(view_id, query_context);
+        if (!view)
+            return {};
+
+        auto * materialized_view = dynamic_cast<StorageMaterializedView *>(view.get());
+        if (materialized_view && !materialized_view->tryGetTargetTable())
+            return {};
+    }
+
+    return view_ids;
 }
 
 DDLGuardPtr DatabaseCatalog::getDDLGuard(const String & database, const String & table, const IDatabase * expected_database)

--- a/src/Interpreters/DatabaseCatalog.h
+++ b/src/Interpreters/DatabaseCatalog.h
@@ -186,6 +186,12 @@ public:
     void removeViewDependency(const StorageID & source_table_id, const StorageID & view_id);
     std::vector<StorageID> getDependentViews(const StorageID & source_table_id) const;
 
+    /// Check that all dependent views of a streaming source table are ready.
+    /// Returns the list of ready views, or empty if not all are ready yet.
+    /// During server startup, returns empty to prevent streaming engines from
+    /// processing data before all MV dependencies are registered.
+    std::vector<StorageID> getReadyDependentViews(const StorageID & source_table_id, const ContextPtr & query_context) const;
+
     /// If table has UUID, addUUIDMapping(...) must be called when table attached to some database
     /// removeUUIDMapping(...) must be called when it detached,
     /// and removeUUIDMappingFinally(...) must be called when table is dropped and its data removed from disk.

--- a/src/Storages/FileLog/StorageFileLog.cpp
+++ b/src/Storages/FileLog/StorageFileLog.cpp
@@ -636,24 +636,7 @@ size_t StorageFileLog::getPollTimeoutMillisecond() const
 
 bool StorageFileLog::checkDependencies(const StorageID & table_id)
 {
-    // Check if all dependencies are attached
-    auto view_ids = DatabaseCatalog::instance().getDependentViews(table_id);
-    if (view_ids.empty())
-        return false;
-
-    for (const auto & view_id : view_ids)
-    {
-        auto view = DatabaseCatalog::instance().tryGetTable(view_id, getContext());
-        if (!view)
-            return false;
-
-        // If it materialized view, check it's target table
-        auto * materialized_view = dynamic_cast<StorageMaterializedView *>(view.get());
-        if (materialized_view && !materialized_view->tryGetTargetTable())
-            return false;
-    }
-
-    return true;
+    return !DatabaseCatalog::instance().getReadyDependentViews(table_id, getContext()).empty();
 }
 
 size_t StorageFileLog::getTableDependentCount() const

--- a/src/Storages/Kafka/StorageKafkaUtils.cpp
+++ b/src/Storages/Kafka/StorageKafkaUtils.cpp
@@ -538,27 +538,9 @@ SettingsChanges createSettingsAdjustments(KafkaSettings & kafka_settings, const 
     return result;
 }
 
-bool checkDependencies(const StorageID & table_id, const ContextPtr& context)
+bool checkDependencies(const StorageID & table_id, const ContextPtr & context)
 {
-    // Check if all dependencies are attached
-    auto view_ids = DatabaseCatalog::instance().getDependentViews(table_id);
-    if (view_ids.empty())
-        return false;
-
-    // Check the dependencies are ready?
-    for (const auto & view_id : view_ids)
-    {
-        auto view = DatabaseCatalog::instance().tryGetTable(view_id, context);
-        if (!view)
-            return false;
-
-        // If it materialized view, check it's target table
-        auto * materialized_view = dynamic_cast<StorageMaterializedView *>(view.get());
-        if (materialized_view && !materialized_view->tryGetTargetTable())
-            return false;
-    }
-
-    return true;
+    return !DatabaseCatalog::instance().getReadyDependentViews(table_id, context).empty();
 }
 
 VirtualColumnsDescription createVirtuals(StreamingHandleErrorMode handle_error_mode)

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -711,29 +711,7 @@ std::shared_ptr<ObjectStorageQueueSource> StorageObjectStorageQueue::createSourc
 
 size_t StorageObjectStorageQueue::getDependencies() const
 {
-    auto table_id = getStorageID();
-
-    // Check if all dependencies are attached
-    auto view_ids = DatabaseCatalog::instance().getDependentViews(table_id);
-    LOG_TEST(log, "Number of attached views {} for {}", view_ids.size(), table_id.getNameForLogs());
-
-    if (view_ids.empty())
-        return 0;
-
-    // Check the dependencies are ready?
-    for (const auto & view_id : view_ids)
-    {
-        auto view = DatabaseCatalog::instance().tryGetTable(view_id, getContext());
-        if (!view)
-            return 0;
-
-        // If it materialized view, check it's target table
-        auto * materialized_view = dynamic_cast<StorageMaterializedView *>(view.get());
-        if (materialized_view && !materialized_view->tryGetTargetTable())
-            return 0;
-    }
-
-    return view_ids.size();
+    return DatabaseCatalog::instance().getReadyDependentViews(getStorageID(), getContext()).size();
 }
 
 void StorageObjectStorageQueue::threadFunc(size_t streaming_tasks_index)

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -1041,27 +1041,7 @@ RabbitMQConsumerPtr StorageRabbitMQ::createConsumer()
 
 bool StorageRabbitMQ::hasDependencies(const StorageID & table_id)
 {
-    // Check if all dependencies are attached
-    auto view_ids = DatabaseCatalog::instance().getDependentViews(table_id);
-    LOG_TEST(log, "Number of attached views {} for {}", view_ids.size(), table_id.getNameForLogs());
-
-    if (view_ids.empty())
-        return false;
-
-    // Check the dependencies are ready?
-    for (const auto & view_id : view_ids)
-    {
-        auto view = DatabaseCatalog::instance().tryGetTable(view_id, getContext());
-        if (!view)
-            return false;
-
-        // If it materialized view, check it's target table
-        auto * materialized_view = dynamic_cast<StorageMaterializedView *>(view.get());
-        if (materialized_view && !materialized_view->tryGetTargetTable())
-            return false;
-    }
-
-    return true;
+    return !DatabaseCatalog::instance().getReadyDependentViews(table_id, getContext()).empty();
 }
 
 void StorageRabbitMQ::streamingToViewsFunc()

--- a/tests/integration/test_kafka_bad_messages/test_mv_target_missing.py
+++ b/tests/integration/test_kafka_bad_messages/test_mv_target_missing.py
@@ -13,6 +13,7 @@ instance = cluster.add_instance(
     main_configs=["configs/kafka.xml"],
     with_kafka=True,
     with_zookeeper=True,
+    stay_alive=True,
     macros={
         "kafka_broker": "kafka1",
         "kafka_format_json_each_row": "JSONEachRow",
@@ -325,6 +326,101 @@ missing_dependencies: []
             DROP TABLE test.target1;
             DROP TABLE test.target2;
             DROP TABLE test.tkafkamiss;
+            DROP DATABASE test;
+            """
+        )
+
+
+@pytest.mark.parametrize(
+    "create_query_generator",
+    [k.generate_old_create_table_query, k.generate_new_create_table_query],
+)
+def test_no_data_loss_on_restart(kafka_cluster, create_query_generator):
+    """Verify no data is lost in materialized views during server restart.
+
+    Regression test for a startup race condition where Kafka consumers could
+    process batches before all MV dependencies were registered, causing
+    permanent data loss for unloaded MVs.
+    """
+    admin = k.get_admin_client(kafka_cluster)
+    topic = "no_data_loss_restart" + k.get_topic_postfix(create_query_generator)
+
+    with k.kafka_topic(admin, topic):
+
+        settings = {
+            "kafka_flush_interval_ms": 1000,
+        }
+        if create_query_generator == k.generate_old_create_table_query:
+            settings["kafka_commit_on_select"] = 1
+
+        create_query = create_query_generator(
+            "kafka_restart",
+            "a UInt64, b String",
+            topic_list=topic,
+            consumer_group=topic,
+            format="JSONEachRow",
+            settings=settings,
+        )
+
+        instance.query(
+            f"""
+            DROP DATABASE IF EXISTS test;
+            CREATE DATABASE test;
+
+            {create_query};
+
+            CREATE TABLE test.target1 (a UInt64, b String)
+                ENGINE = MergeTree() ORDER BY a;
+            CREATE TABLE test.target2 (a UInt64, b String)
+                ENGINE = MergeTree() ORDER BY a;
+
+            CREATE MATERIALIZED VIEW test.mv1 TO test.target1
+                AS SELECT * FROM test.kafka_restart;
+            CREATE MATERIALIZED VIEW test.mv2 TO test.target2
+                AS SELECT * FROM test.kafka_restart;
+            """
+        )
+
+        # Pre-restart: produce and verify both targets receive data
+        messages_before = [
+            f'{{"a": {i}, "b": "before"}}' for i in range(10)
+        ]
+        k.kafka_produce(kafka_cluster, topic, messages_before)
+
+        for target in ["test.target1", "test.target2"]:
+            instance.query_with_retry(
+                f"SELECT count() FROM {target}",
+                retry_count=100,
+                check_callback=lambda x: int(x) == 10,
+            )
+
+        # Restart server
+        instance.restart_clickhouse()
+
+        # Post-restart: produce and verify ALL messages arrive in BOTH targets
+        messages_after = [
+            f'{{"a": {i}, "b": "after"}}' for i in range(100, 110)
+        ]
+        k.kafka_produce(kafka_cluster, topic, messages_after)
+
+        for target in ["test.target1", "test.target2"]:
+            result = instance.query_with_retry(
+                f"SELECT count() FROM {target} WHERE b = 'after'",
+                retry_count=100,
+                check_callback=lambda x: int(x) == 10,
+            )
+            assert int(result) == 10, (
+                f"Expected 10 post-restart rows in {target}, got {result}. "
+                "Possible data loss during restart due to partial MV dependency loading."
+            )
+
+        instance.query(
+            """
+            DROP TABLE test.mv1;
+            DROP TABLE test.mv2;
+            DROP TABLE test.target1;
+            DROP TABLE test.target2;
+            DROP TABLE test.kafka_restart;
             DROP DATABASE test;
             """
         )


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
delay processing until server has finished loading all the tables

### Details:

During server startup, four streaming engines including Kafka start processing batches before all MV dependencies have finished registering in `DatabaseCatalog`. This results in data loss, when only registered MVs are updated. Proposed change delays processing until server has completed start up.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.817`
<!-- ch-version-info:end -->