### PR TITLE
Add tests for niladic functions in subquery, GROUP BY, ORDER BY, HAVING, CASE, and JOIN contexts

### DIFF
--- a/tests/queries/0_stateless/03800_functions_without_parentheses.reference
+++ b/tests/queries/0_stateless/03800_functions_without_parentheses.reference
@@ -29,3 +29,11 @@ currentUser
 Date
 DateTime	1
 1
+1
+1	1
+1
+1
+1
+ok
+1
+1	1	1

--- a/tests/queries/0_stateless/03800_functions_without_parentheses.sql
+++ b/tests/queries/0_stateless/03800_functions_without_parentheses.sql
@@ -95,8 +95,10 @@ SELECT 1 AS x ORDER BY NOW;
 -- Niladic function in HAVING
 SELECT 1 AS x HAVING NOW > '2000-01-01';
 
--- Chained alias: niladic feeds into another expression alias
-WITH NOW AS ts, toDate(ts) AS d SELECT d = today();
+-- Niladic function directly inside a function alias body: most targeted test for the PR #98941 fix.
+-- Before the fix, allow_niladic_functions was inadvertently false when resolving the FUNCTION-type
+-- alias node at QueryAnalyzer.cpp:1084, so TODAY inside toDate(TODAY) would fail to resolve.
+WITH toDate(TODAY) AS d SELECT d = today();
 
 -- Niladic in CASE expression
 SELECT CASE WHEN DATABASE = currentDatabase() THEN 'ok' ELSE 'fail' END;

--- a/tests/queries/0_stateless/03800_functions_without_parentheses.sql
+++ b/tests/queries/0_stateless/03800_functions_without_parentheses.sql
@@ -82,3 +82,27 @@ SELECT concat; -- { serverError UNKNOWN_IDENTIFIER }
 
 -- Aggregate functions require parentheses
 SELECT count; -- { serverError UNKNOWN_IDENTIFIER }
+
+-- Niladic function in scalar subquery (PR #98941)
+SELECT (SELECT DATABASE) = currentDatabase();
+
+-- Niladic function in GROUP BY
+SELECT DATABASE = currentDatabase(), count() FROM system.one GROUP BY DATABASE ORDER BY DATABASE;
+
+-- Niladic function in ORDER BY
+SELECT 1 AS x ORDER BY NOW;
+
+-- Niladic function in HAVING
+SELECT 1 AS x HAVING NOW > '2000-01-01';
+
+-- Chained alias: niladic feeds into another expression alias
+WITH NOW AS ts, toDate(ts) AS d SELECT d = today();
+
+-- Niladic in CASE expression
+SELECT CASE WHEN DATABASE = currentDatabase() THEN 'ok' ELSE 'fail' END;
+
+-- Niladic in JOIN condition
+SELECT a.x FROM (SELECT 1 AS x, DATABASE AS db) a INNER JOIN (SELECT currentDatabase() AS db) b ON a.db = b.db;
+
+-- Multiple niladic functions in single SELECT
+SELECT DATABASE = currentDatabase(), USER = currentUser(), TODAY = today();


### PR DESCRIPTION
This PR extends the test for niladic SQL functions (functions without parentheses) added in #95949 and fixed in #98941.

PR #98941 fixed a bug where `allow_to_resolve_niladic_functions` was incorrectly passed as `ignore_alias` in `QueryAnalyzer.cpp:1083`. The existing test `03800_functions_without_parentheses` only covered niladic functions in `SELECT` expressions, `WHERE`, `DEFAULT`, and `INSERT SELECT`. This extends it to cover the additional SQL contexts where `tryResolveIdentifier` is called with this flag: scalar subqueries, `GROUP BY`, `ORDER BY`, `HAVING`, `CASE` expressions, and `JOIN` conditions.

Created with Claude.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.789`
<!-- ch-version-info:end -->