### PR TITLE
Add LowCardinality(FixedString) key tests for startsWith/LIKE/match pruning

### DIFF
--- a/tests/queries/0_stateless/04032_fixedstring_prefix_key_condition.reference
+++ b/tests/queries/0_stateless/04032_fixedstring_prefix_key_condition.reference
@@ -324,4 +324,37 @@ ORDER BY text
 SETTINGS force_primary_key = 1, max_rows_to_read = 3;
 plain-110
 plain-11z
+SELECT text
+FROM test_lc_fixedstring
+WHERE startsWith(CAST(lc_fs_col, 'LowCardinality(String)'), '11')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+plain-11
+plain-110
+plain-11z
+SELECT text
+FROM test_lc_fixedstring
+WHERE CAST(lc_fs_col, 'LowCardinality(String)') LIKE '11%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+plain-11
+plain-110
+plain-11z
+SELECT text
+FROM test_lc_fixedstring
+WHERE CAST(lc_fs_col, 'LowCardinality(String)') NOT LIKE '99%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+plain-11
+plain-110
+plain-11z
+plain-12
+plain-21
+SELECT text
+FROM test_lc_fixedstring
+WHERE match(CAST(lc_fs_col, 'LowCardinality(String)'), '^11.')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+plain-110
+plain-11z
 DROP TABLE IF EXISTS test_lc_fixedstring;

--- a/tests/queries/0_stateless/04032_fixedstring_prefix_key_condition.reference
+++ b/tests/queries/0_stateless/04032_fixedstring_prefix_key_condition.reference
@@ -245,3 +245,83 @@ FROM test_string
 WHERE match(CAST(string_col, 'FixedString(40)'), toFixedString('^11.', 4)) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 ORDER BY text
 SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+DROP TABLE IF EXISTS test_lc_fixedstring;
+CREATE TABLE test_lc_fixedstring
+(
+    lc_fs_col LowCardinality(FixedString(40)),
+    text String
+)
+ENGINE = MergeTree
+ORDER BY lc_fs_col
+SETTINGS index_granularity = 1;
+INSERT INTO test_lc_fixedstring SELECT fixed_string_col, text FROM test;
+-- LowCardinality(FixedString) key tests (PR #99001)
+
+SELECT text
+FROM test_lc_fixedstring
+WHERE startsWith(lc_fs_col, '11')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+plain-11
+plain-110
+plain-11z
+SELECT text
+FROM test_lc_fixedstring
+WHERE startsWith(CAST(lc_fs_col, 'String'), '11')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+plain-11
+plain-110
+plain-11z
+SELECT text
+FROM test_lc_fixedstring
+WHERE lc_fs_col LIKE '11%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+plain-11
+plain-110
+plain-11z
+SELECT text
+FROM test_lc_fixedstring
+WHERE CAST(lc_fs_col, 'String') LIKE '11%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+plain-11
+plain-110
+plain-11z
+SELECT text
+FROM test_lc_fixedstring
+WHERE lc_fs_col NOT LIKE '99%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+plain-11
+plain-110
+plain-11z
+plain-12
+plain-21
+SELECT text
+FROM test_lc_fixedstring
+WHERE CAST(lc_fs_col, 'String') NOT LIKE '99%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+plain-11
+plain-110
+plain-11z
+plain-12
+plain-21
+SELECT text
+FROM test_lc_fixedstring
+WHERE match(lc_fs_col, '^11.')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+plain-11
+plain-110
+plain-11z
+SELECT text
+FROM test_lc_fixedstring
+WHERE match(CAST(lc_fs_col, 'String'), '^11.')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+plain-110
+plain-11z
+DROP TABLE IF EXISTS test_lc_fixedstring;

--- a/tests/queries/0_stateless/04032_fixedstring_prefix_key_condition.sql
+++ b/tests/queries/0_stateless/04032_fixedstring_prefix_key_condition.sql
@@ -298,4 +298,28 @@ WHERE match(CAST(lc_fs_col, 'String'), '^11.')
 ORDER BY text
 SETTINGS force_primary_key = 1, max_rows_to_read = 3;
 
+SELECT text
+FROM test_lc_fixedstring
+WHERE startsWith(CAST(lc_fs_col, 'LowCardinality(String)'), '11')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test_lc_fixedstring
+WHERE CAST(lc_fs_col, 'LowCardinality(String)') LIKE '11%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test_lc_fixedstring
+WHERE CAST(lc_fs_col, 'LowCardinality(String)') NOT LIKE '99%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+
+SELECT text
+FROM test_lc_fixedstring
+WHERE match(CAST(lc_fs_col, 'LowCardinality(String)'), '^11.')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
 DROP TABLE IF EXISTS test_lc_fixedstring;

--- a/tests/queries/0_stateless/04032_fixedstring_prefix_key_condition.sql
+++ b/tests/queries/0_stateless/04032_fixedstring_prefix_key_condition.sql
@@ -234,3 +234,68 @@ FROM test_string
 WHERE match(CAST(string_col, 'FixedString(40)'), toFixedString('^11.', 4)) -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 ORDER BY text
 SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+DROP TABLE IF EXISTS test_lc_fixedstring;
+
+CREATE TABLE test_lc_fixedstring
+(
+    lc_fs_col LowCardinality(FixedString(40)),
+    text String
+)
+ENGINE = MergeTree
+ORDER BY lc_fs_col
+SETTINGS index_granularity = 1;
+
+INSERT INTO test_lc_fixedstring SELECT fixed_string_col, text FROM test;
+
+-- LowCardinality(FixedString) key tests (PR #99001)
+
+SELECT text
+FROM test_lc_fixedstring
+WHERE startsWith(lc_fs_col, '11')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test_lc_fixedstring
+WHERE startsWith(CAST(lc_fs_col, 'String'), '11')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test_lc_fixedstring
+WHERE lc_fs_col LIKE '11%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test_lc_fixedstring
+WHERE CAST(lc_fs_col, 'String') LIKE '11%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test_lc_fixedstring
+WHERE lc_fs_col NOT LIKE '99%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+
+SELECT text
+FROM test_lc_fixedstring
+WHERE CAST(lc_fs_col, 'String') NOT LIKE '99%'
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+
+SELECT text
+FROM test_lc_fixedstring
+WHERE match(lc_fs_col, '^11.')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+SELECT text
+FROM test_lc_fixedstring
+WHERE match(CAST(lc_fs_col, 'String'), '^11.')
+ORDER BY text
+SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+DROP TABLE IF EXISTS test_lc_fixedstring;


### PR DESCRIPTION
PR #99001 fixed prefix-range pruning for `FixedString` primary keys: when the key type after `LowCardinality` stripping is `FixedString` or `LowCardinality(FixedString)`, the string constant must be kept as-is rather than truncated, otherwise the key condition silently produces wrong bounds and skips rows it should read.

The existing test in `04032` covers plain `FixedString` and `String` keys. `LowCardinality(FixedString)` is a distinct reachable code path through the same fix but had no coverage. This PR extends `04032` with a `LowCardinality(FixedString(40))` key table and exercises `startsWith`, `LIKE`, `NOT LIKE`, `match`, and their `CAST(..., 'String')` variants — all with `force_primary_key = 1` to assert pruning is used and row-read counts are tight.

Created with Claude.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.788`
<!-- ch-version-info:end -->