### PR TITLE
Add JOIN path test for filter push-down const column fix

### DIFF
--- a/tests/queries/0_stateless/04032_filter_push_down_const_having.sql
+++ b/tests/queries/0_stateless/04032_filter_push_down_const_having.sql
@@ -29,3 +29,36 @@ HAVING h
 ORDER BY g DESC;
 
 DROP TABLE t_const_having;
+
+-- Regression test for the JOIN path of the same fix (filterPushDown.cpp:711-714).
+-- constifyFilterColumnAfterPushDown must also be called after splitActionsForJOINFilterPushDown
+-- when the filter was const before push-down but is non-const after (same bug, JOIN code path).
+DROP TABLE IF EXISTS t_const_join_left;
+DROP TABLE IF EXISTS t_const_join_right;
+CREATE TABLE t_const_join_left (a Int32, b Int32) ENGINE = MergeTree ORDER BY a;
+CREATE TABLE t_const_join_right (a Int32, b Int32) ENGINE = MergeTree ORDER BY a;
+INSERT INTO t_const_join_left VALUES (1, 10), (2, 20), (3, 30);
+INSERT INTO t_const_join_right VALUES (1, 100), (2, 200), (3, 300);
+
+-- AND short-circuits to const(0); cross-side expression cannot be pushed to either side.
+SELECT l.a, l.b, r.b
+FROM t_const_join_left AS l
+INNER JOIN t_const_join_right AS r ON l.a = r.a
+WHERE toLowCardinality(toUInt8(0)) AND 1 AND (l.b + r.b > 0)
+ORDER BY l.a;
+
+SELECT l.a, l.b, r.b
+FROM t_const_join_left AS l
+LEFT JOIN t_const_join_right AS r ON l.a = r.a
+WHERE toLowCardinality(toUInt8(0)) AND 1 AND (l.b + r.b > 0)
+ORDER BY l.a;
+
+-- AND short-circuits to const(0); single-side expression can be pushed to left.
+SELECT l.a, l.b, r.b
+FROM t_const_join_left AS l
+INNER JOIN t_const_join_right AS r ON l.a = r.a
+WHERE toLowCardinality(toUInt8(0)) AND 1 AND l.b > 5
+ORDER BY l.a;
+
+DROP TABLE t_const_join_left;
+DROP TABLE t_const_join_right;


### PR DESCRIPTION
This PR adds a regression test for the JOIN code path of the fix in #99010.

PR #99010 calls constifyFilterColumnAfterPushDown in two places: the aggregation path (line 174, tested by the PR own test) and the JOIN path (line 714, untested). When a WHERE clause over a JOIN short-circuits to a constant via AND (e.g., toLowCardinality(0) AND 1 AND cross-side-expr), the JOIN push-down can leave an expression whose constness is not restored, causing a Block structure mismatch exception.

Created with Claude.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry:
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
