### PR TITLE
Add tests for compareTrackAt coverage in partial_merge join (PR #99013)

### DIFF
--- a/tests/queries/0_stateless/04042_partial_merge_join_float_nan.reference
+++ b/tests/queries/0_stateless/04042_partial_merge_join_float_nan.reference
@@ -1,0 +1,12 @@
+3	L3	R3
+nan	Lnan	Rnan
+-inf	L-inf	
+1	L1	
+2	L2	
+3	L3	R3
+7	L7	
+8	L8	
+9	L9	
+inf	Linf	
+nan	Lnan	Rnan
+1

--- a/tests/queries/0_stateless/04042_partial_merge_join_float_nan.sql
+++ b/tests/queries/0_stateless/04042_partial_merge_join_float_nan.sql
@@ -1,0 +1,33 @@
+-- Test compareTrackAt with Float64/NaN/Inf keys in partial_merge join.
+-- ColumnVector<Float64>::compareTrackAt (ColumnVector.h:157) uses
+-- CompareHelper<Float64>::compare with NaN handling (nan_direction_hint).
+-- Exercises multi-row skipping on Float keys and NaN=NaN matching.
+
+SET join_algorithm = 'partial_merge';
+
+DROP TABLE IF EXISTS t_04042_left;
+DROP TABLE IF EXISTS t_04042_right;
+
+CREATE TABLE t_04042_left (key Float64, val String) ENGINE = MergeTree() ORDER BY key;
+CREATE TABLE t_04042_right (key Float64, val String) ENGINE = MergeTree() ORDER BY key;
+
+-- Left: -inf, 1, 2, 3, 7, 8, 9, inf, nan (sorted)
+-- Right: 0, 3, 5, 10, nan (sorted)
+INSERT INTO t_04042_left VALUES (-inf, 'L-inf'), (1, 'L1'), (2, 'L2'), (3, 'L3'), (7, 'L7'), (8, 'L8'), (9, 'L9'), (inf, 'Linf'), (nan, 'Lnan');
+INSERT INTO t_04042_right VALUES (0, 'R0'), (3, 'R3'), (5, 'R5'), (10, 'R10'), (nan, 'Rnan');
+
+-- INNER JOIN: matching keys 3 and NaN
+SELECT l.key, l.val, r.val
+FROM t_04042_left l INNER JOIN t_04042_right r ON l.key = r.key
+ORDER BY l.key;
+
+-- LEFT JOIN: all left rows, right values for matches
+SELECT l.key, l.val, r.val
+FROM t_04042_left l LEFT JOIN t_04042_right r ON l.key = r.key
+ORDER BY l.key;
+
+-- NaN matches NaN in merge join (compareAt returns 0 for NaN=NaN)
+SELECT count() FROM t_04042_left l INNER JOIN t_04042_right r ON l.key = r.key WHERE isNaN(l.key);
+
+DROP TABLE t_04042_left;
+DROP TABLE t_04042_right;

--- a/tests/queries/0_stateless/04043_partial_merge_join_multikey_track.reference
+++ b/tests/queries/0_stateless/04043_partial_merge_join_multikey_track.reference
@@ -1,0 +1,15 @@
+3	10	L3a	R3a
+5	20	L5b	R5b
+5	30	L5c	R5c
+10	10	L10a	R10a
+1	10	L1a	
+1	20	L1b	
+2	10	L2a	
+2	20	L2b	
+3	10	L3a	R3a
+5	10	L5a	
+5	20	L5b	R5b
+5	30	L5c	R5c
+10	10	L10a	R10a
+10	20	L10b	
+4

--- a/tests/queries/0_stateless/04043_partial_merge_join_multikey_track.sql
+++ b/tests/queries/0_stateless/04043_partial_merge_join_multikey_track.sql
@@ -1,0 +1,36 @@
+-- Test compareTrackAt multi-row skipping in partial_merge join with multi-key sort.
+-- MergeJoin.cpp:327 uses compareTrackAt on the first sort key to skip N rows at once
+-- (via nextN(-cmp) at MergeJoin.cpp:340), then falls back to regular compareAt for
+-- secondary keys when the first key is equal. Exercises the interaction between
+-- first-key track skipping and secondary-key matching.
+
+SET join_algorithm = 'partial_merge';
+
+DROP TABLE IF EXISTS t_04043_left;
+DROP TABLE IF EXISTS t_04043_right;
+
+-- Multi-key tables: (key1, key2)
+CREATE TABLE t_04043_left  (key1 UInt32, key2 UInt32, val String) ENGINE = MergeTree() ORDER BY (key1, key2);
+CREATE TABLE t_04043_right (key1 UInt32, key2 UInt32, val String) ENGINE = MergeTree() ORDER BY (key1, key2);
+
+-- Left key1:  1,1,2,2,3,5,5,5,10,10 — runs of key1 values less than right's key1
+-- force compareTrackAt to return track > 1 on the first key, then test secondary key
+INSERT INTO t_04043_left  VALUES (1,10,'L1a'), (1,20,'L1b'), (2,10,'L2a'), (2,20,'L2b'), (3,10,'L3a'), (5,10,'L5a'), (5,20,'L5b'), (5,30,'L5c'), (10,10,'L10a'), (10,20,'L10b');
+INSERT INTO t_04043_right VALUES (3,10,'R3a'), (5,20,'R5b'), (5,30,'R5c'), (10,10,'R10a');
+
+-- INNER JOIN on (key1, key2): verify multi-row skip on key1 does not miss key2 matches
+SELECT l.key1, l.key2, l.val, r.val
+FROM t_04043_left l INNER JOIN t_04043_right r ON l.key1 = r.key1 AND l.key2 = r.key2
+ORDER BY l.key1, l.key2;
+
+-- LEFT JOIN: all left rows present, right values only for exact (key1,key2) matches
+SELECT l.key1, l.key2, l.val, r.val
+FROM t_04043_left l LEFT JOIN t_04043_right r ON l.key1 = r.key1 AND l.key2 = r.key2
+ORDER BY l.key1, l.key2;
+
+-- Exact count of inner join matches
+SELECT count()
+FROM t_04043_left l INNER JOIN t_04043_right r ON l.key1 = r.key1 AND l.key2 = r.key2;
+
+DROP TABLE t_04043_left;
+DROP TABLE t_04043_right;


### PR DESCRIPTION
This PR adds tests for the coverage gaps identified in PR #99013, which introduced `IColumn::compareTrackAt` for devirtualized multi-row skipping in `partial_merge` join.

**`04042_partial_merge_join_float_nan`**
Exercises `ColumnVector<Float64>::compareTrackAt` (ColumnVector.h:157) with `Float64` join keys including `NaN`, `Inf`, and `-Inf`. No existing test in the suite used floating-point keys with `partial_merge` join. Verifies that `NaN` matches `NaN` under merge-join sort semantics and that track-skipping works correctly for all floating-point special values.

**`04043_partial_merge_join_multikey_track`**
Exercises MergeJoin.cpp:327-340: `compareTrackAt` on the first sort key returns `track > 1` for runs of left-side rows strictly less than the right cursor, then `nextN(-cmp)` skips them at once. Secondary keys fall back to regular `compareAt`. Verifies that multi-row first-key skipping does not accidentally miss valid `(key1, key2)` matches.

Created with Claude.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)