### PR TITLE
Add tests for Time/Time64 supertype resolution with DateTime/DateTime64 (PR #99267)

### DIFF
--- a/tests/queries/0_stateless/04042_time_datetime_supertype.reference
+++ b/tests/queries/0_stateless/04042_time_datetime_supertype.reference
@@ -1,0 +1,18 @@
+Time + DateTime supertype
+DateTime
+Time + DateTime64 supertype
+DateTime64(3)
+DateTime64(6)
+Time + DateTime64 tz preservation
+DateTime64(3, \'America/New_York\')
+Date + Time incompatible
+Time64 higher scale + DateTime64 tz
+DateTime64(6, \'Europe/Berlin\')
+Three-way supertype
+Array(DateTime64(6))
+Time64 to DateTime64 CAST
+1970-01-01 14:45:40.123000
+1970-01-01 14:45:40.123
+Value correctness after promotion
+1970-01-01 14:45:40
+1970-01-01 14:45:40.000

--- a/tests/queries/0_stateless/04042_time_datetime_supertype.sql
+++ b/tests/queries/0_stateless/04042_time_datetime_supertype.sql
@@ -1,4 +1,3 @@
--- Tags: no-fasttest
 -- Test `getLeastSupertype` for `Time`/`Time64` mixed with `DateTime`/`DateTime64`
 -- (PR #99267). The existing test 04037 covers `Time` vs `DateTime64` comparisons;
 -- this test covers the explicit supertype resolution paths added to

--- a/tests/queries/0_stateless/04042_time_datetime_supertype.sql
+++ b/tests/queries/0_stateless/04042_time_datetime_supertype.sql
@@ -1,0 +1,47 @@
+-- Tags: no-fasttest
+-- Test `getLeastSupertype` for `Time`/`Time64` mixed with `DateTime`/`DateTime64`
+-- (PR #99267). The existing test 04037 covers `Time` vs `DateTime64` comparisons;
+-- this test covers the explicit supertype resolution paths added to
+-- `getLeastSupertype.cpp`, including timezone preservation and scale selection.
+
+SET session_timezone = 'UTC';
+SET enable_analyzer = 1;
+SET use_variant_as_common_type = 0;
+
+-- Time + DateTime → DateTime
+SELECT 'Time + DateTime supertype';
+SELECT toTypeName(if(1, CAST('10:00:00', 'Time'), toDateTime('2025-01-01 00:00:00')));
+
+-- Time + DateTime64 → DateTime64 with the DateTime64 scale
+SELECT 'Time + DateTime64 supertype';
+SELECT toTypeName(if(1, CAST('10:00:00', 'Time'), toDateTime64('2025-01-01 00:00:00', 3)));
+SELECT toTypeName(if(1, CAST('10:00:00', 'Time'), toDateTime64('2025-01-01 00:00:00', 6)));
+
+-- Time + DateTime64 with timezone → DateTime64 preserves timezone
+SELECT 'Time + DateTime64 tz preservation';
+SELECT toTypeName(if(1, CAST('10:00:00', 'Time'), toDateTime64('2025-01-01 00:00:00', 3, 'America/New_York')));
+
+-- Date + Time → NO_COMMON_TYPE (incompatible)
+SELECT 'Date + Time incompatible';
+SELECT if(1, toDate('2025-01-01'), CAST('10:00:00', 'Time')); -- { serverError NO_COMMON_TYPE }
+SELECT if(1, toDate32('2025-01-01'), CAST('10:00:00', 'Time')); -- { serverError NO_COMMON_TYPE }
+SELECT if(1, toDate('2025-01-01'), CAST('10:00:00.123', 'Time64(3)')); -- { serverError NO_COMMON_TYPE }
+SELECT if(1, toDate32('2025-01-01'), CAST('10:00:00.123', 'Time64(3)')); -- { serverError NO_COMMON_TYPE }
+
+-- Time64 with higher scale + DateTime64 with timezone → DateTime64(max_scale, tz)
+SELECT 'Time64 higher scale + DateTime64 tz';
+SELECT toTypeName(if(1, CAST('10:00:00.123456', 'Time64(6)'), toDateTime64('2025-01-01 00:00:00', 3, 'Europe/Berlin')));
+
+-- Three-way: Time + Time64 + DateTime64 → DateTime64 with maximum scale
+SELECT 'Three-way supertype';
+SELECT toTypeName([CAST('10:00:00', 'Time'), CAST('10:00:00.123', 'Time64(3)'), toDateTime64('2025-01-01 00:00:00', 6)]);
+
+-- Explicit CAST: Time64 → DateTime64 with scale change
+SELECT 'Time64 to DateTime64 CAST';
+SELECT CAST(CAST('14:45:40.123', 'Time64(3)'), 'DateTime64(6)');
+SELECT CAST(CAST('14:45:40.123456', 'Time64(6)'), 'DateTime64(3)');
+
+-- Value correctness after promotion
+SELECT 'Value correctness after promotion';
+SELECT if(1, CAST('14:45:40', 'Time'), toDateTime('2025-01-01 00:00:00'));
+SELECT if(1, CAST('14:45:40', 'Time'), toDateTime64('2025-01-01 00:00:00', 3));

--- a/tests/queries/0_stateless/04043_time_datetime_tz_comparison.reference
+++ b/tests/queries/0_stateless/04043_time_datetime_tz_comparison.reference
@@ -1,0 +1,20 @@
+Time vs DateTime with Europe/Moscow timezone
+1
+0
+1
+Time64 vs DateTime with Europe/Moscow timezone
+1
+0
+1
+Time64 to DateTime64 CAST with scale change
+1970-01-01 14:45:40.123
+1970-01-01 14:45:40.123456000
+1970-01-01 14:45:40.123000
+1970-01-01 00:00:00.000
+1970-01-01 23:59:59.999
+Supertype preserves DateTime timezone when mixed with Time
+DateTime(\'Europe/Moscow\')
+DateTime64(3, \'Europe/Moscow\')
+accurateCast Time64 to DateTime64
+1970-01-01 14:45:40.123000
+1970-01-01 14:45:40.123000

--- a/tests/queries/0_stateless/04043_time_datetime_tz_comparison.sql
+++ b/tests/queries/0_stateless/04043_time_datetime_tz_comparison.sql
@@ -1,4 +1,3 @@
--- Tags: no-fasttest
 -- Test `Time`/`Time64` vs `DateTime` comparison with non-UTC timezones, and
 -- `Time64` → `DateTime64` explicit CAST with scale changes (PR #99267).
 -- The PR's own test (04037) covers UTC and DateTime64 with non-UTC timezone;

--- a/tests/queries/0_stateless/04043_time_datetime_tz_comparison.sql
+++ b/tests/queries/0_stateless/04043_time_datetime_tz_comparison.sql
@@ -1,0 +1,41 @@
+-- Tags: no-fasttest
+-- Test `Time`/`Time64` vs `DateTime` comparison with non-UTC timezones, and
+-- `Time64` → `DateTime64` explicit CAST with scale changes (PR #99267).
+-- The PR's own test (04037) covers UTC and DateTime64 with non-UTC timezone;
+-- this test covers plain `DateTime` with non-UTC timezone and verifies UTC
+-- normalisation semantics.
+
+SET allow_experimental_time_time64_type = 1;
+SET session_timezone = 'UTC';
+SET enable_analyzer = 1;
+
+-- Europe/Moscow is UTC+3 at Unix epoch; toDateTime('1970-01-01 15:45:40', 'Europe/Moscow')
+-- = 15:45:40 − 3h = 12:45:40 UTC = 45940s.  Time('12:45:40') = 45940s → equal.
+SELECT 'Time vs DateTime with Europe/Moscow timezone';
+SELECT CAST('12:45:40', 'Time') = toDateTime('1970-01-01 15:45:40', 'Europe/Moscow');
+SELECT CAST('15:45:40', 'Time') = toDateTime('1970-01-01 15:45:40', 'Europe/Moscow');
+SELECT CAST('15:45:40', 'Time') > toDateTime('1970-01-01 15:45:40', 'Europe/Moscow');
+
+-- Time64(3) vs DateTime using UTC normalisation
+SELECT 'Time64 vs DateTime with Europe/Moscow timezone';
+SELECT CAST('12:45:40.000', 'Time64(3)') = toDateTime('1970-01-01 15:45:40', 'Europe/Moscow');
+SELECT CAST('12:45:40.001', 'Time64(3)') = toDateTime('1970-01-01 15:45:40', 'Europe/Moscow');
+SELECT CAST('12:45:40.001', 'Time64(3)') > toDateTime('1970-01-01 15:45:40', 'Europe/Moscow');
+
+-- Time64 → DateTime64 CAST with different scales
+SELECT 'Time64 to DateTime64 CAST with scale change';
+SELECT CAST(CAST('14:45:40.123456', 'Time64(6)'), 'DateTime64(3)');
+SELECT CAST(CAST('14:45:40.123456', 'Time64(6)'), 'DateTime64(9)');
+SELECT CAST(CAST('14:45:40.123', 'Time64(3)'), 'DateTime64(6)');
+SELECT CAST(CAST('00:00:00.000', 'Time64(3)'), 'DateTime64(3)');
+SELECT CAST(CAST('23:59:59.999', 'Time64(3)'), 'DateTime64(3)');
+
+-- Supertype preserves DateTime timezone when mixed with Time
+SELECT 'Supertype preserves DateTime timezone when mixed with Time';
+SELECT toTypeName(if(1, CAST('10:00:00', 'Time'), toDateTime('2020-01-01 10:00:00', 'Europe/Moscow')));
+SELECT toTypeName(if(1, CAST('10:00:00.000', 'Time64(3)'), toDateTime('2020-01-01 10:00:00', 'Europe/Moscow')));
+
+-- accurateCast: Time64 → DateTime64
+SELECT 'accurateCast Time64 to DateTime64';
+SELECT accurateCast(CAST('14:45:40.123', 'Time64(3)'), 'DateTime64(6)');
+SELECT accurateCastOrNull(CAST('14:45:40.123', 'Time64(3)'), 'DateTime64(6)');


### PR DESCRIPTION
Add two tests covering coverage gaps in PR #99267 (`Time`/`Time64` supertype resolution with `DateTime`/`DateTime64`):

1. `04042_time_datetime_supertype.sql` — explicitly exercises `getLeastSupertype` paths: `Time + DateTime → DateTime`, `Time + DateTime64 → DateTime64` with scale/timezone preservation, `Date + Time → NO_COMMON_TYPE`, `Time64 + DateTime64 → DateTime64(max_scale, tz)`, three-way supertype, and value correctness after promotion.

2. `04043_time_datetime_tz_comparison.sql` — exercises `Time`/`Time64` vs `DateTime` comparisons with a non-UTC timezone (`Europe/Moscow`), verifying UTC normalisation semantics, and covers `accurateCast`/`accurateCastOrNull` for `Time64 → DateTime64`.

Created with Claude.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.786`
<!-- ch-version-info:end -->