### PR TITLE
Add test for DROP DETACHED PART with non-String typed query parameter (PR #99489)

### DIFF
--- a/tests/queries/0_stateless/04042_drop_detached_part_non_literal.sql
+++ b/tests/queries/0_stateless/04042_drop_detached_part_non_literal.sql
@@ -1,0 +1,15 @@
+-- Tags: no-fasttest
+-- PR #99489 added a test for `ALTER TABLE DROP PART` with a non-String typed
+-- query parameter. This test covers the same fix in `dropDetached`, which uses
+-- `getPartNameFromAST` at `MergeTreeData.cpp` line 7706. A non-String typed
+-- parameter (`{partition:Date}`) is replaced by `_CAST(...)` — an `ASTFunction`,
+-- not `ASTLiteral` — so the old code threw `LOGICAL_ERROR`. The fix throws
+-- `BAD_ARGUMENTS` instead.
+
+DROP TABLE IF EXISTS t_04042_dda;
+CREATE TABLE t_04042_dda (x UInt8) ENGINE = MergeTree ORDER BY x;
+
+SET param_partition = '2024-01-01';
+ALTER TABLE t_04042_dda DROP DETACHED PART {partition:Date} SETTINGS allow_drop_detached = 1; -- { serverError BAD_ARGUMENTS }
+
+DROP TABLE t_04042_dda;

--- a/tests/queries/0_stateless/04042_drop_detached_part_non_literal.sql
+++ b/tests/queries/0_stateless/04042_drop_detached_part_non_literal.sql
@@ -1,4 +1,3 @@
--- Tags: no-fasttest
 -- PR #99489 added a test for `ALTER TABLE DROP PART` with a non-String typed
 -- query parameter. This test covers the same fix in `dropDetached`, which uses
 -- `getPartNameFromAST` at `MergeTreeData.cpp` line 7706. A non-String typed


### PR DESCRIPTION
Add a test for the `DROP DETACHED PART` code path in PR #99489. The PR's own test (`04040`) covers `DROP PART`; `dropDetached` at `MergeTreeData.cpp:7706` uses the same `getPartNameFromAST` fix but had no test. A non-`String`-typed query parameter (`{partition:Date}`) must throw `BAD_ARGUMENTS` instead of `LOGICAL_ERROR`.

Created with Claude.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
