### PR TITLE
Add test for compact MergeTree deduplication with multiple distinct codecs (PR #97522)

### DIFF
--- a/tests/queries/0_stateless/04042_compact_multi_codec_dedup.reference
+++ b/tests/queries/0_stateless/04042_compact_multi_codec_dedup.reference
@@ -1,0 +1,4 @@
+1
+1	hello	1.5
+2	world	2.5
+3	foo	3.5

--- a/tests/queries/0_stateless/04042_compact_multi_codec_dedup.sql
+++ b/tests/queries/0_stateless/04042_compact_multi_codec_dedup.sql
@@ -1,0 +1,42 @@
+-- Tags: no-fasttest
+-- Regression test for PR #97522: non-deterministic `uncompressed_hash` in
+-- compact `MergeTree` parts with multiple distinct compression codecs.
+--
+-- `MergeTreeWriterCompact` groups substreams by codec in a `streams_by_codec`
+-- map. Before the fix, this was `std::unordered_map`, whose iteration order is
+-- non-deterministic, so the same data could produce different `uncompressed_hash`
+-- values across inserts, breaking deduplication. The fix uses `std::map`.
+--
+-- This test uses columns with three distinct codecs (LZ4, ZSTD, DoubleDelta+LZ4)
+-- to ensure multiple entries in `streams_by_codec`. Forcing compact parts via
+-- `min_bytes_for_wide_part = 10485760`. Two identical inserts must be deduplicated
+-- to exactly one active part.
+
+DROP TABLE IF EXISTS t_04042_mc_dedup;
+
+CREATE TABLE t_04042_mc_dedup
+(
+    id    UInt64   CODEC(LZ4),
+    val1  String   CODEC(ZSTD(1)),
+    val2  Float64  CODEC(DoubleDelta, LZ4)
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS
+    non_replicated_deduplication_window = 1000,
+    min_bytes_for_wide_part = 10485760,
+    min_rows_for_wide_part  = 10485760;
+
+SYSTEM STOP MERGES t_04042_mc_dedup;
+
+INSERT INTO t_04042_mc_dedup VALUES (1, 'hello', 1.5), (2, 'world', 2.5), (3, 'foo', 3.5);
+-- Identical insert: must be deduplicated (uncompressed_hash must be deterministic)
+INSERT INTO t_04042_mc_dedup VALUES (1, 'hello', 1.5), (2, 'world', 2.5), (3, 'foo', 3.5);
+
+-- Exactly one active part after two identical inserts
+SELECT count() FROM system.parts WHERE database = currentDatabase() AND table = 't_04042_mc_dedup' AND active;
+
+-- Data is intact
+SELECT id, val1, val2 FROM t_04042_mc_dedup ORDER BY id;
+
+DROP TABLE t_04042_mc_dedup;

--- a/tests/queries/0_stateless/04042_compact_multi_codec_dedup.sql
+++ b/tests/queries/0_stateless/04042_compact_multi_codec_dedup.sql
@@ -1,4 +1,3 @@
--- Tags: no-fasttest
 -- Regression test for PR #97522: non-deterministic `uncompressed_hash` in
 -- compact `MergeTree` parts with multiple distinct compression codecs.
 --


### PR DESCRIPTION
Add a stateless regression test covering the fix from PR #97522, which made `uncompressed_hash` deterministic for compact `MergeTree` parts by changing `streams_by_codec` from `std::unordered_map` to `std::map` in `MergeTreeWriterCompact`.

The existing deduplication test (`03711_deduplication_blocks_part_log`) uses only default-codec columns, which produces a single entry in `streams_by_codec` and never exercises the multi-codec iteration order that was the root cause of the bug.

This test uses three columns with distinct codecs (`LZ4`, `ZSTD(1)`, `DoubleDelta+LZ4`) in a compact part, inserts the same data twice, and asserts exactly one active part remains — directly verifying deterministic hashing and correct deduplication.

Created with Claude.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)