### PR TITLE
Docs: update example to reflect Cloud default

### DIFF
--- a/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
+++ b/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
@@ -323,12 +323,13 @@ To disable `error_log` setting, you should create the following file `/etc/click
 
 ## custom_settings_prefixes {#custom_settings_prefixes}
 
-List of prefixes for [custom settings](/operations/settings/query-level#custom_settings). The prefixes must be separated with commas.
+List of prefixes used for [custom settings](/operations/settings/query-level#custom_settings).
+Multiple prefixes should be separated by commas.
 
 **Example**
 
 ```xml
-<custom_settings_prefixes>custom_</custom_settings_prefixes>
+<custom_settings_prefixes>SQL_</custom_settings_prefixes>
 ```
 
 **See Also**

--- a/docs/en/operations/settings/settings-query-level.md
+++ b/docs/en/operations/settings/settings-query-level.md
@@ -86,13 +86,18 @@ Custom settings enable you to pass **session-specific parameters** that can be r
 - Maintain stateful information across queries in a session
 
 A custom setting name must begin with one of a number of predefined prefixes from a list you define.
-The list of prefixes can be declared using the [`custom_settings_prefixes`](../../operations/server-configuration-parameters/settings.md#custom_settings_prefixes) setting, defined in your server configuration file.
+The list of prefixes can be specified using the [`custom_settings_prefixes`](../../operations/server-configuration-parameters/settings.md#custom_settings_prefixes) server setting, defined in your server configuration file.
 
 In the example below, `SQL_` is chosen as the custom prefix:
 
 ```xml
 <custom_settings_prefixes>SQL_</custom_settings_prefixes>
 ```
+
+:::note
+In ClickHouse Cloud it is not possible to specify a custom prefix.
+All user settings begin with prefix `SQL_`.
+:::
 
 To define a custom setting use the `SET` command:
 

--- a/docs/en/operations/settings/settings-query-level.md
+++ b/docs/en/operations/settings/settings-query-level.md
@@ -80,14 +80,21 @@ The setting is now back to its default:
 ## Custom settings {#custom_settings}
 
 In addition to the common [settings](/operations/settings/settings.md), users can define custom settings.
+Custom settings enable you to pass **session-specific parameters** that can be referenced within queries, policies, or functions. This is useful when you need to:
+- Filter data based on user identity or organization
+- Apply different business logic based on context
+- Maintain stateful information across queries in a session
 
-A custom setting name must begin with one of predefined prefixes. The list of these prefixes must be declared in the [custom_settings_prefixes](../../operations/server-configuration-parameters/settings.md#custom_settings_prefixes) parameter in the server configuration file.
+A custom setting name must begin with one of a number of predefined prefixes from a list you define.
+The list of prefixes can be declared using the [`custom_settings_prefixes`](../../operations/server-configuration-parameters/settings.md#custom_settings_prefixes) setting, defined in your server configuration file.
+
+In the example below, `SQL_` is chosen as the custom prefix:
 
 ```xml
 <custom_settings_prefixes>SQL_</custom_settings_prefixes>
 ```
 
-To define a custom setting use `SET` command:
+To define a custom setting use the `SET` command:
 
 ```sql
 SET SQL_a = 123;

--- a/docs/en/operations/settings/settings-query-level.md
+++ b/docs/en/operations/settings/settings-query-level.md
@@ -84,19 +84,19 @@ In addition to the common [settings](/operations/settings/settings.md), users ca
 A custom setting name must begin with one of predefined prefixes. The list of these prefixes must be declared in the [custom_settings_prefixes](../../operations/server-configuration-parameters/settings.md#custom_settings_prefixes) parameter in the server configuration file.
 
 ```xml
-<custom_settings_prefixes>custom_</custom_settings_prefixes>
+<custom_settings_prefixes>SQL_</custom_settings_prefixes>
 ```
 
 To define a custom setting use `SET` command:
 
 ```sql
-SET custom_a = 123;
+SET SQL_a = 123;
 ```
 
 To get the current value of a custom setting use `getSetting()` function:
 
 ```sql
-SELECT getSetting('custom_a');
+SELECT getSetting('SQL_a');
 ```
 
 ## Examples {#examples}

--- a/docs/en/operations/settings/settings-query-level.md
+++ b/docs/en/operations/settings/settings-query-level.md
@@ -96,7 +96,7 @@ In the example below, `SQL_` is chosen as the custom prefix:
 
 :::note
 In ClickHouse Cloud it is not possible to specify a custom prefix.
-All user settings begin with prefix `SQL_`.
+All custom user settings begin with prefix `SQL_`.
 :::
 
 To define a custom setting use the `SET` command:


### PR DESCRIPTION
In Cloud config we set `SQL_` as the custom setting prefix. Updating the docs to reflect this so it's consistent between OSS and Cloud.
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.772`
<!-- ch-version-info:end -->