### PR TITLE
Persistent physical column names: part 1

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -159,7 +159,9 @@ static struct InitFiu
     PAUSEABLE(truncate_database_tables_pause) \
     REGULAR(datalake_try_get_table_return_nullptr) \
     PAUSEABLE_ONCE(drop_database_before_exclusive_ddl_lock) \
-    REGULAR(storage_merge_tree_background_schedule_merge_fail)
+    REGULAR(storage_merge_tree_background_schedule_merge_fail) \
+    PAUSEABLE_ONCE(physical_names_pause_after_metadata_alter) \
+    ONCE(physical_names_throw_before_mapping_persist)
 
 namespace FailPoints
 {

--- a/src/Core/MergeTreeSerializationEnums.h
+++ b/src/Core/MergeTreeSerializationEnums.h
@@ -9,6 +9,7 @@ enum class MergeTreeSerializationInfoVersion : uint8_t
 {
     BASIC = 0,
     WITH_TYPES = 1,
+    WITH_PHYSICAL_NAMES = 2,
 };
 
 enum class MergeTreeStringSerializationVersion : uint8_t

--- a/src/Core/NamesAndTypes.cpp
+++ b/src/Core/NamesAndTypes.cpp
@@ -41,6 +41,14 @@ String NameAndTypePair::getNameInStorage() const
     return name.substr(0, *subcolumn_delimiter_position);
 }
 
+String NameAndTypePair::getPhysicalNameInStorage() const
+{
+    if (physical_name.empty())
+        return getNameInStorage();
+
+    return physical_name;
+}
+
 bool NameAndTypePair::operator<(const NameAndTypePair & rhs) const
 {
     return std::forward_as_tuple(name, type->getName()) < std::forward_as_tuple(rhs.name, rhs.type->getName());
@@ -65,6 +73,7 @@ String NameAndTypePair::dump() const
     out << "name: " << name << "\n"
         << "type: " << type->getName() << "\n"
         << "name in storage: " << getNameInStorage() << "\n"
+        << "physical name in storage: " << getPhysicalNameInStorage() << "\n"
         << "type in storage: " << getTypeInStorage()->getName();
 
     return out.str();

--- a/src/Core/NamesAndTypes.h
+++ b/src/Core/NamesAndTypes.h
@@ -30,6 +30,7 @@ public:
         const DataTypePtr & type_in_storage_, const DataTypePtr & subcolumn_type_);
 
     String getNameInStorage() const;
+    String getPhysicalNameInStorage() const;
     String getSubcolumnName() const;
 
     bool isSubcolumn() const { return subcolumn_delimiter_position != std::nullopt; }
@@ -43,9 +44,11 @@ public:
     /// Can be used to convert "t.a.b.c" from meaning "column `t` in storage, subcolumn `a.b.c` inside it"
     /// to meaning "column `t.a.b` in storage, subcolumn `c` inside it".
     void setDelimiterAndTypeInStorage(const String & name_in_storage_, DataTypePtr type_in_storage_);
+    void setPhysicalName(const String & physical_name_) { physical_name = physical_name_; }
 
     String name;
     DataTypePtr type;
+    String physical_name;
 
 private:
     DataTypePtr type_in_storage;

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -1113,6 +1113,8 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
             {"merge_max_dynamic_subcolumns_in_compact_part", "auto", "auto", "Add a new setting to limit number of dynamic subcolumns in Compact part after merge regardless the parameters specified in the data type"},
             {"materialize_statistics_on_merge", true, true, "New setting"},
             {"escape_index_filenames", false, true, "Escape non-ascii characters in filenames created for indices"},
+            {"serialization_info_version", "with_types", "with_types", "Add `with_physical_names` option for persistent physical column names"},
+            {"activate_physical_names_for_existing_tables", false, false, "New setting"},
         });
         addSettingsChanges(merge_tree_settings_changes_history, "25.12",
         {

--- a/src/Core/SettingsEnums.cpp
+++ b/src/Core/SettingsEnums.cpp
@@ -372,7 +372,8 @@ IMPLEMENT_SETTING_ENUM(
     MergeTreeSerializationInfoVersion,
     ErrorCodes::BAD_ARGUMENTS,
     {{"basic", MergeTreeSerializationInfoVersion::BASIC},
-     {"with_types", MergeTreeSerializationInfoVersion::WITH_TYPES}})
+     {"with_types", MergeTreeSerializationInfoVersion::WITH_TYPES},
+     {"with_physical_names", MergeTreeSerializationInfoVersion::WITH_PHYSICAL_NAMES}})
 
 IMPLEMENT_SETTING_ENUM(
     MergeTreeStringSerializationVersion,

--- a/src/DataTypes/Serializations/ISerialization.cpp
+++ b/src/DataTypes/Serializations/ISerialization.cpp
@@ -387,6 +387,14 @@ String ISerialization::getFileNameForStream(const NameAndTypePair & column, cons
     return getFileNameForStream(column.getNameInStorage(), path, settings);
 }
 
+String ISerialization::getFileNameForStreamPhysical(const NameAndTypePair & column, const SubstreamPath & path, const StreamFileNameSettings & settings)
+{
+    if (column.physical_name.empty())
+        return getFileNameForStream(column, path, settings);
+
+    return getFileNameForStreamPhysical(column.getPhysicalNameInStorage(), column.getNameInStorage(), path, settings);
+}
+
 static bool isPossibleOffsetsOfNested(const ISerialization::SubstreamPath & path)
 {
     /// Arrays of Nested cannot be inside other types.
@@ -415,6 +423,22 @@ String ISerialization::getFileNameForStream(const String & name_in_storage, cons
         stream_name = escapeForFileName(nested_storage_name);
     else
         stream_name = escapeForFileName(name_in_storage);
+
+    return getNameForSubstreamPath(std::move(stream_name), path.begin(), path.end(), true, false, settings.escape_variant_substreams);
+}
+
+String ISerialization::getFileNameForStreamPhysical(
+    const String & physical_name_in_storage,
+    const String & logical_name_in_storage,
+    const SubstreamPath & path,
+    const StreamFileNameSettings & settings)
+{
+    String stream_name;
+    auto nested_storage_name = Nested::extractTableName(logical_name_in_storage);
+    if (logical_name_in_storage != nested_storage_name && isPossibleOffsetsOfNested(path))
+        stream_name = escapeForFileName(nested_storage_name);
+    else
+        stream_name = escapeForFileName(physical_name_in_storage);
 
     return getNameForSubstreamPath(std::move(stream_name), path.begin(), path.end(), true, false, settings.escape_variant_substreams);
 }

--- a/src/DataTypes/Serializations/ISerialization.h
+++ b/src/DataTypes/Serializations/ISerialization.h
@@ -613,6 +613,12 @@ public:
 
     static String getFileNameForStream(const NameAndTypePair & column, const SubstreamPath & path, const StreamFileNameSettings & settings);
     static String getFileNameForStream(const String & name_in_storage, const SubstreamPath & path, const StreamFileNameSettings & settings);
+    static String getFileNameForStreamPhysical(const NameAndTypePair & column, const SubstreamPath & path, const StreamFileNameSettings & settings);
+    static String getFileNameForStreamPhysical(
+        const String & physical_name_in_storage,
+        const String & logical_name_in_storage,
+        const SubstreamPath & path,
+        const StreamFileNameSettings & settings);
     static String getFileNameForRenamedColumnStream(const NameAndTypePair & column_from, const NameAndTypePair & column_to, const String & file_name);
     static String getFileNameForRenamedColumnStream(const String & name_from, const String & name_to, const String & file_name);
 

--- a/src/DataTypes/Serializations/SerializationInfo.cpp
+++ b/src/DataTypes/Serializations/SerializationInfo.cpp
@@ -6,6 +6,7 @@
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 #include <Core/Block.h>
+#include <Storages/MergeTree/PhysicalNameMapping.h>
 #include <base/EnumReflection.h>
 
 #include <Poco/JSON/JSON.h>
@@ -374,35 +375,36 @@ bool SerializationInfoByName::needsPersistence() const
     return !empty() || getVersion() > MergeTreeSerializationInfoVersion::BASIC;
 }
 
-void SerializationInfoByName::writeJSON(WriteBuffer & out) const
+template <typename NameMapper>
+static void writeJSONImpl(const SerializationInfoByName & infos, WriteBuffer & out, NameMapper && name_mapper)
 {
     Poco::JSON::Object object;
     Poco::JSON::Array column_infos;
 
-    for (const auto & [name, info] : *this)
+    for (const auto & [name, info] : infos)
     {
         Poco::JSON::Object info_json;
         info->toJSON(info_json);
-        info_json.set(KEY_NAME, name);
+        info_json.set(KEY_NAME, name_mapper(name));
         column_infos.add(std::move(info_json)); /// NOLINT
     }
 
-    auto version = getVersion();
+    auto version = infos.getVersion();
     object.set(KEY_VERSION, static_cast<uint8_t>(version));
     object.set(KEY_COLUMNS, std::move(column_infos)); /// NOLINT
 
     if (version >= MergeTreeSerializationInfoVersion::WITH_TYPES)
     {
         Poco::JSON::Object type_versions_obj;
-        type_versions_obj.set(KEY_STRING_SERIALIZATION_VERSION, static_cast<size_t>(settings.string_serialization_version));
-        if (settings.nullable_serialization_version != MergeTreeNullableSerializationVersion::BASIC)
-            type_versions_obj.set(KEY_NULLABLE_SERIALIZATION_VERSION, static_cast<size_t>(settings.nullable_serialization_version));
+        type_versions_obj.set(KEY_STRING_SERIALIZATION_VERSION, static_cast<size_t>(infos.getSettings().string_serialization_version));
+        if (infos.getSettings().nullable_serialization_version != MergeTreeNullableSerializationVersion::BASIC)
+            type_versions_obj.set(KEY_NULLABLE_SERIALIZATION_VERSION, static_cast<size_t>(infos.getSettings().nullable_serialization_version));
         object.set(KEY_TYPES_SERIALIZATION_VERSIONS, type_versions_obj);
 
         /// Write flag propagate_types_serialization_versions_to_nested_types only if it's set,
         /// so old versions can read this info if the flag is disabled.
-        if (settings.propagate_types_serialization_versions_to_nested_types)
-            object.set(KEY_PROPAGATE_DATA_TYPES_SERIALIZATION_VERSIONS_TO_NESTED_TYPES, settings.propagate_types_serialization_versions_to_nested_types);
+        if (infos.getSettings().propagate_types_serialization_versions_to_nested_types)
+            object.set(KEY_PROPAGATE_DATA_TYPES_SERIALIZATION_VERSIONS_TO_NESTED_TYPES, infos.getSettings().propagate_types_serialization_versions_to_nested_types);
     }
 
     std::ostringstream oss;     // STYLE_CHECK_ALLOW_STD_STRING_STREAM
@@ -410,6 +412,22 @@ void SerializationInfoByName::writeJSON(WriteBuffer & out) const
     Poco::JSON::Stringifier::stringify(object, oss);
 
     writeString(oss.str(), out);
+}
+
+void SerializationInfoByName::writeJSON(WriteBuffer & out) const
+{
+    writeJSONImpl(*this, out, [](const String & name) -> const String &
+    {
+        return name;
+    });
+}
+
+void SerializationInfoByName::writeJSONWithPhysicalNames(WriteBuffer & out, const PhysicalNameMapping & physical_name_mapping) const
+{
+    writeJSONImpl(*this, out, [&](const String & name)
+    {
+        return physical_name_mapping.getPhysicalNameOrDefault(name);
+    });
 }
 
 SerializationInfoByName SerializationInfoByName::clone() const
@@ -420,7 +438,16 @@ SerializationInfoByName SerializationInfoByName::clone() const
     return res;
 }
 
-SerializationInfoByName SerializationInfoByName::readJSONFromString(const NamesAndTypesList & columns, const std::string & json_str)
+namespace
+{
+
+struct ParsedJSON
+{
+    Poco::JSON::Array::Ptr columns_array;
+    SerializationInfoSettings settings;
+};
+
+ParsedJSON parseJSONEnvelope(const std::string & json_str)
 {
     Poco::JSON::Parser parser;
     auto object = parser.parse(json_str).extract<Poco::JSON::Object::Ptr>();
@@ -468,7 +495,6 @@ SerializationInfoByName SerializationInfoByName::readJSONFromString(const NamesA
     MergeTreeNullableSerializationVersion nullable_serialization_version = MergeTreeNullableSerializationVersion::BASIC;
     if (version >= MergeTreeSerializationInfoVersion::WITH_TYPES)
     {
-        /// types_serialization_versions is mandatory in WITH_TYPES mode
         if (!type_versions_obj)
         {
             throw Exception(
@@ -508,6 +534,15 @@ SerializationInfoByName SerializationInfoByName::readJSONFromString(const NamesA
         nullable_serialization_version,
         propagate_types_serialization_versions_to_nested_types);
 
+    return {std::move(columns_array), std::move(settings)};
+}
+
+} /// anonymous namespace
+
+SerializationInfoByName SerializationInfoByName::readJSONFromString(const NamesAndTypesList & columns, const std::string & json_str)
+{
+    auto [columns_array, settings] = parseJSONEnvelope(json_str);
+
     SerializationInfoByName infos(settings);
     if (columns_array)
     {
@@ -544,6 +579,52 @@ SerializationInfoByName SerializationInfoByName::readJSON(const NamesAndTypesLis
     String json_str;
     readString(json_str, in);
     return readJSONFromString(columns, json_str);
+}
+
+SerializationInfoByName SerializationInfoByName::readJSONWithPhysicalNames(
+    const NamesAndTypesList & columns,
+    const PhysicalNameMapping & physical_name_mapping,
+    ReadBuffer & in)
+{
+    String json_str;
+    readString(json_str, in);
+    auto [columns_array, settings] = parseJSONEnvelope(json_str);
+
+    SerializationInfoByName infos(settings);
+    if (!columns_array)
+        return infos;
+
+    std::unordered_map<std::string_view, const IDataType *> column_type_by_name;
+    for (const auto & [name, type] : columns)
+        column_type_by_name.emplace(name, type.get());
+
+    for (const auto & elem : *columns_array)
+    {
+        const auto & elem_object = elem.extract<Poco::JSON::Object::Ptr>();
+
+        if (!elem_object->has(KEY_NAME))
+            throw Exception(ErrorCodes::CORRUPTED_DATA, "Missed field '{}' in serialization infos", KEY_NAME);
+
+        auto stored_name = elem_object->getValue<String>(KEY_NAME);
+        String logical_name;
+
+        if (physical_name_mapping.hasPhysicalName(stored_name))
+            logical_name = physical_name_mapping.getLogicalName(stored_name);
+        else if (physical_name_mapping.getPhysicalNameOrDefault(stored_name) == stored_name && column_type_by_name.contains(stored_name))
+            logical_name = stored_name;
+        else
+            continue;
+
+        auto it = column_type_by_name.find(logical_name);
+        if (it == column_type_by_name.end())
+            continue;
+
+        auto info = it->second->createSerializationInfo(infos.getSettings());
+        info->fromJSON(*elem_object);
+        infos.emplace(logical_name, std::move(info));
+    }
+
+    return infos;
 }
 
 }

--- a/src/DataTypes/Serializations/SerializationInfo.h
+++ b/src/DataTypes/Serializations/SerializationInfo.h
@@ -20,6 +20,7 @@ class ReadBuffer;
 class WriteBuffer;
 class NamesAndTypesList;
 class Block;
+class PhysicalNameMapping;
 
 /** Contains information about kind of serialization of column and its subcolumns.
  *  Also contains information about content of columns,
@@ -120,6 +121,7 @@ public:
     void replaceData(const SerializationInfoByName & other);
 
     void writeJSON(WriteBuffer & out) const;
+    void writeJSONWithPhysicalNames(WriteBuffer & out, const PhysicalNameMapping & physical_name_mapping) const;
 
     SerializationInfoByName clone() const;
 
@@ -130,6 +132,7 @@ public:
     bool needsPersistence() const;
 
     static SerializationInfoByName readJSON(const NamesAndTypesList & columns, ReadBuffer & in);
+    static SerializationInfoByName readJSONWithPhysicalNames(const NamesAndTypesList & columns, const PhysicalNameMapping & physical_name_mapping, ReadBuffer & in);
 
     static SerializationInfoByName readJSONFromString(const NamesAndTypesList & columns, const std::string & str);
 

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -1126,13 +1126,19 @@ bool AlterCommand::isSettingsAlter() const
     return type == MODIFY_SETTING || type == RESET_SETTING;
 }
 
-bool AlterCommand::isRequireMutationStage(const StorageInMemoryMetadata & metadata, const ContextPtr & context) const
+bool AlterCommand::isRequireMutationStage(const StorageInMemoryMetadata & metadata, const ContextPtr & context, bool physical_names_active) const
 {
     if (ignore)
         return false;
 
     /// We remove properties on metadata level
     if (isRemovingProperty() || type == REMOVE_TTL || type == REMOVE_SAMPLE_BY)
+        return false;
+
+    if (physical_names_active && type == RENAME_COLUMN)
+        return false;
+
+    if (physical_names_active && type == DROP_COLUMN && !clear && !partition)
         return false;
 
     if (type == DROP_INDEX || type == DROP_PROJECTION || type == RENAME_COLUMN || type == DROP_STATISTICS)
@@ -1207,9 +1213,9 @@ bool AlterCommand::isDropOrRename() const
         || type == Type::RENAME_COLUMN;
 }
 
-std::optional<MutationCommand> AlterCommand::tryConvertToMutationCommand(StorageInMemoryMetadata & metadata, ContextPtr context) const
+std::optional<MutationCommand> AlterCommand::tryConvertToMutationCommand(StorageInMemoryMetadata & metadata, ContextPtr context, bool physical_names_active) const
 {
-    if (!isRequireMutationStage(metadata, context))
+    if (!isRequireMutationStage(metadata, context, physical_names_active))
         return {};
 
     MutationCommand result;
@@ -1866,12 +1872,12 @@ static MutationCommand createMaterializeTTLCommand()
     return command;
 }
 
-MutationCommands AlterCommands::getMutationCommands(StorageInMemoryMetadata metadata, bool materialize_ttl, ContextPtr context, bool with_alters) const
+MutationCommands AlterCommands::getMutationCommands(StorageInMemoryMetadata metadata, bool materialize_ttl, ContextPtr context, bool with_alters, bool physical_names_active) const
 {
     MutationCommands result;
     for (const auto & alter_cmd : *this)
     {
-        if (auto mutation_cmd = alter_cmd.tryConvertToMutationCommand(metadata, context); mutation_cmd)
+        if (auto mutation_cmd = alter_cmd.tryConvertToMutationCommand(metadata, context, physical_names_active); mutation_cmd)
         {
             result.push_back(*mutation_cmd);
         }

--- a/src/Storages/AlterCommands.h
+++ b/src/Storages/AlterCommands.h
@@ -173,7 +173,8 @@ struct AlterCommand
     /// executed. For example, cast from Date to UInt16 type can be executed
     /// without any data modifications. But column drop or modify from UInt16 to
     /// UInt32 require data modification.
-    bool isRequireMutationStage(const StorageInMemoryMetadata & metadata, const ContextPtr & context) const;
+    /// When physical_names_active is true, RENAME and DROP are metadata-only.
+    bool isRequireMutationStage(const StorageInMemoryMetadata & metadata, const ContextPtr & context, bool physical_names_active = false) const;
 
     /// Checks that only settings changed by alter
     bool isSettingsAlter() const;
@@ -193,7 +194,7 @@ struct AlterCommand
     /// If possible, convert alter command to mutation command. In other case
     /// return empty optional. Some storages may execute mutations after
     /// metadata changes.
-    std::optional<MutationCommand> tryConvertToMutationCommand(StorageInMemoryMetadata & metadata, ContextPtr context) const;
+    std::optional<MutationCommand> tryConvertToMutationCommand(StorageInMemoryMetadata & metadata, ContextPtr context, bool physical_names_active = false) const;
 };
 
 class Context;
@@ -235,7 +236,7 @@ public:
     /// alter. If alter can be performed as pure metadata update, than result is
     /// empty. If some TTL changes happened than, depending on materialize_ttl
     /// additional mutation command (MATERIALIZE_TTL) will be returned.
-    MutationCommands getMutationCommands(StorageInMemoryMetadata metadata, bool materialize_ttl, ContextPtr context, bool with_alters=false) const;
+    MutationCommands getMutationCommands(StorageInMemoryMetadata metadata, bool materialize_ttl, ContextPtr context, bool with_alters=false, bool physical_names_active=false) const;
 
     /// Check if commands have a text index
     static bool hasTextIndex(const StorageInMemoryMetadata & metadata);

--- a/src/Storages/MergeTree/IMergeTreeDataPartInfoForReader.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPartInfoForReader.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <memory>
 #include <Interpreters/Context_fwd.h>
 #include <Storages/MergeTree/RangesInDataPart.h>
 #include <Storages/MergeTree/ColumnsSubstreams.h>
@@ -13,6 +14,9 @@ namespace ErrorCodes
 {
 extern const int NOT_IMPLEMENTED;
 }
+
+class PhysicalNameMapping;
+using PhysicalNameMappingPtr = std::shared_ptr<const PhysicalNameMapping>;
 
 class IDataPartStorage;
 using DataPartStoragePtr = std::shared_ptr<const IDataPartStorage>;
@@ -109,6 +113,8 @@ public:
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "getReadHints not implemented for this reader");
     }
+
+    virtual PhysicalNameMappingPtr getPhysicalNameMapping() const { return nullptr; }
 };
 
 using MergeTreeDataPartInfoForReaderPtr = std::shared_ptr<IMergeTreeDataPartInfoForReader>;

--- a/src/Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h
+++ b/src/Storages/MergeTree/LoadedMergeTreeDataPartInfoForReader.h
@@ -94,6 +94,15 @@ public:
     const RangesInDataPartReadHints & getReadHints() const override { return read_hints; }
 
     size_t getRowCount() const override { return data_part->rows_count; }
+
+    PhysicalNameMappingPtr getPhysicalNameMapping() const override
+    {
+        auto mapping = data_part->storage.getPhysicalNameMapping();
+        if (mapping && mapping->isActive())
+            return mapping;
+        return nullptr;
+    }
+
 private:
     MergeTreeData::DataPartPtr data_part;
     AlterConversionsPtr alter_conversions;

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -42,6 +42,7 @@
 #include <Disks/TemporaryFileOnDisk.h>
 #include <Disks/createVolume.h>
 #include <IO/Operators.h>
+#include <IO/ReadHelpers.h>
 #include <IO/S3Common.h>
 #include <IO/SharedThreadPools.h>
 #include <IO/WriteBufferFromString.h>
@@ -215,6 +216,7 @@ namespace Setting
 
 namespace MergeTreeSetting
 {
+    extern const MergeTreeSettingsBool activate_physical_names_for_existing_tables;
     extern const MergeTreeSettingsBool allow_experimental_reverse_key;
     extern const MergeTreeSettingsBool allow_nullable_key;
     extern const MergeTreeSettingsBool allow_remote_fs_zero_copy_replication;
@@ -496,6 +498,51 @@ void MergeTreeData::initializeDirectoriesAndFormatVersion(const std::string & re
             throw Exception(ErrorCodes::METADATA_MISMATCH, "MergeTree data format version on disk doesn't support custom partitioning");
     }
 }
+
+void MergeTreeData::loadPhysicalNameMappingFromDisk()
+{
+    const auto physical_names_path = fs::path(relative_data_path) / PHYSICAL_NAMES_FILE_NAME;
+
+    for (const auto & disk : getDisks())
+    {
+        if (disk->isBroken())
+            continue;
+
+        if (auto buf = disk->readFileIfExists(physical_names_path, getReadSettings()))
+        {
+            setPhysicalNameMapping(PhysicalNameMapping::deserialize(*buf));
+            assertEOF(*buf);
+            return;
+        }
+    }
+}
+
+void MergeTreeData::writePhysicalNameMappingToDisk() const
+{
+    const auto physical_names_path = fs::path(relative_data_path) / PHYSICAL_NAMES_FILE_NAME;
+    auto mapping = getPhysicalNameMapping();
+    if (!mapping)
+        return;
+
+    for (const auto & disk : getStoragePolicy()->getDisks())
+    {
+        if (disk->isBroken())
+            continue;
+
+        if (!disk->isReadOnly() && !disk->isWriteOnce())
+        {
+            auto buf = disk->writeFile(physical_names_path, 4096, WriteMode::Rewrite, getContext()->getWriteSettings());
+            mapping->serialize(*buf);
+            buf->finalize();
+            if (getContext()->getSettingsRef()[Setting::fsync_metadata])
+                buf->sync();
+            return;
+        }
+    }
+
+    throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot write `{}` for table {}", PHYSICAL_NAMES_FILE_NAME, getStorageID().getNameForLogs());
+}
+
 DataPartsLock::DataPartsLock(SharedMutex & data_parts_mutex_, const MergeTreeData * data_)
     : wait_watch(Stopwatch(CLOCK_MONOTONIC))
     , lock(data_parts_mutex_)
@@ -4215,7 +4262,28 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
 
     if (!settings[Setting::allow_non_metadata_alters])
     {
-        auto mutation_commands = commands.getMutationCommands(new_metadata, settings[Setting::materialize_ttl_after_modify], local_context);
+        /// Evaluate activation against the post-MODIFY-SETTING state so that a
+        /// single ALTER mixing `MODIFY SETTING ... , RENAME COLUMN ...` activates
+        /// physical names and correctly takes the metadata-only path.
+        StorageInMemoryMetadata check_metadata = new_metadata;
+        commands.apply(check_metadata, local_context);
+
+        MergeTreeSettings effective_settings(*settings_from_storage);
+        if (check_metadata.settings_changes)
+            effective_settings.applyChanges(check_metadata.settings_changes->as<const ASTSetQuery &>().changes);
+
+        bool settings_enable_pn =
+            effective_settings[MergeTreeSetting::serialization_info_version] == MergeTreeSerializationInfoVersion::WITH_PHYSICAL_NAMES
+            && effective_settings[MergeTreeSetting::activate_physical_names_for_existing_tables];
+        bool has_compat_alter = std::any_of(commands.begin(), commands.end(), [](const auto & c)
+        {
+            return c.type == AlterCommand::RENAME_COLUMN || c.type == AlterCommand::DROP_COLUMN || c.type == AlterCommand::ADD_COLUMN;
+        });
+        bool pn_active = hasPhysicalNameMapping() || (settings_enable_pn && has_compat_alter);
+
+        auto mutation_commands = commands.getMutationCommands(
+            new_metadata, settings[Setting::materialize_ttl_after_modify], local_context,
+            /*with_alters=*/false, /*physical_names_active=*/pn_active);
 
         if (!mutation_commands.empty())
             throw Exception(ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
@@ -8955,6 +9023,10 @@ void MergeTreeData::checkColumnFilenamesForCollision(const ColumnsDescription & 
 {
     std::unordered_map<String, std::pair<String, String>> stream_name_to_full_name;
     auto columns_list = Nested::collect(columns.getAllPhysical());
+
+    if (auto mapping = getPhysicalNameMapping(); mapping && mapping->isActive())
+        populatePhysicalNames(columns_list, *mapping);
+
     SerializationInfo::Settings serialization_settings
     {
         settings[MergeTreeSetting::ratio_of_defaults_for_sparse_serialization],
@@ -8971,7 +9043,7 @@ void MergeTreeData::checkColumnFilenamesForCollision(const ColumnsDescription & 
 
         auto callback = [&](const auto & substream_path)
         {
-            auto full_stream_name = ISerialization::getFileNameForStream(column, substream_path, ISerialization::StreamFileNameSettings(settings));
+            auto full_stream_name = ISerialization::getFileNameForStreamPhysical(column, substream_path, ISerialization::StreamFileNameSettings(settings));
             String stream_name = replaceFileNameToHashIfNeeded(full_stream_name, settings, nullptr);
             column_streams.emplace(stream_name, full_stream_name);
         };

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -28,6 +28,7 @@
 #include <Storages/MergeTree/ZeroCopyLock.h>
 #include <Storages/MergeTree/TemporaryParts.h>
 #include <Storages/MergeTree/AlterConversions.h>
+#include <Storages/MergeTree/PhysicalNameMapping.h>
 #include <Storages/MergeTree/RangesInDataPart.h>
 #include <Storages/IndicesDescription.h>
 #include <Storages/DataDestinationType.h>
@@ -215,6 +216,7 @@ public:
     using PartitionIdToMinBlockPtr = std::shared_ptr<const PartitionIdToMinBlock>;
 
     constexpr static auto FORMAT_VERSION_FILE_NAME = "format_version.txt";
+    constexpr static auto PHYSICAL_NAMES_FILE_NAME = "physical_names.json";
     constexpr static auto DETACHED_DIR_NAME = "detached";
     constexpr static auto MOVING_DIR_NAME = "moving";
 
@@ -633,6 +635,25 @@ public:
 
     /// Load the set of data parts from disk. Call once - immediately after the object is created.
     void loadDataParts(bool skip_sanity_checks, std::optional<std::unordered_set<std::string>> expected_parts);
+
+    bool hasPhysicalNameMapping() const
+    {
+        auto mapping = physical_name_mapping.get();
+        return mapping && mapping->isActive();
+    }
+
+    PhysicalNameMappingPtr getPhysicalNameMapping() const
+    {
+        return physical_name_mapping.get();
+    }
+
+    void setPhysicalNameMapping(PhysicalNameMapping mapping_)
+    {
+        physical_name_mapping.set(std::make_unique<const PhysicalNameMapping>(std::move(mapping_)));
+    }
+
+    void loadPhysicalNameMappingFromDisk();
+    void writePhysicalNameMappingToDisk() const;
 
     /// Check the set of data parts on disk and load if needed, assuming the data on disk can change under the hood.
     /// This method allows read-only replicas of tables on a shared storage.
@@ -1521,6 +1542,8 @@ protected:
     /// It changes only when set of parts is changed and is
     /// protected by @data_parts_mutex.
     SerializationInfoByName serialization_hints{{}};
+
+    MultiVersion<PhysicalNameMapping> physical_name_mapping;
 
     /// A cache for metadata snapshots for patch parts.
     /// The key is a partition id of patch part.

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -273,16 +273,20 @@ namespace ErrorCodes
     Possible values:
     - `basic` - Basic format.
     - `with_types` - Format with additional `types_serialization_versions` field, allowing per-type serialization versions.
+    - `with_physical_names` - Format with additional support for persistent physical column names.
     This makes settings like `string_serialization_version` effective.
 
     During rolling upgrades, set this to `basic` so that new servers produce
     data parts compatible with old servers. After the upgrade completes,
     switch to `WITH_TYPES` to enable per-type serialization versions.
     )", 0) \
+    DECLARE(Bool, activate_physical_names_for_existing_tables, false, R"(
+    Enables activation of persistent physical column names for existing MergeTree-family tables.
+    )", 0) \
     DECLARE(MergeTreeStringSerializationVersion, string_serialization_version, "with_size_stream", R"(
     Controls the serialization format for top-level `String` columns.
 
-    This setting is only effective when `serialization_info_version` is set to "with_types".
+    This setting is only effective when `serialization_info_version` is set to "with_types" or "with_physical_names".
     When set to `with_size_stream`, top-level `String` columns are serialized with a separate
     `.size` subcolumn storing string lengths, rather than inline. This allows real `.size`
     subcolumns and can improve compression efficiency.

--- a/src/Storages/MergeTree/PhysicalNameMapping.cpp
+++ b/src/Storages/MergeTree/PhysicalNameMapping.cpp
@@ -1,0 +1,274 @@
+#include <Storages/MergeTree/PhysicalNameMapping.h>
+
+#include <Common/Exception.h>
+#include <IO/ReadBufferFromString.h>
+#include <IO/ReadHelpers.h>
+#include <IO/WriteHelpers.h>
+
+#include <Poco/JSON/Object.h>
+#include <Poco/JSON/Parser.h>
+#include <Poco/JSON/Stringifier.h>
+
+#include <algorithm>
+#include <charconv>
+#include <sstream>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+    extern const int LOGICAL_ERROR;
+}
+
+namespace
+{
+
+constexpr auto KEY_ACTIVE = "active";
+constexpr auto KEY_NEXT_PHYSICAL_COLUMN_ID = "next_physical_column_id";
+constexpr auto KEY_MAPPING = "mapping";
+
+/// Scans column names (or physical names) to find the highest value that
+/// parses as a valid UInt64, then returns max + 1.  This prevents collisions
+/// when a table already has numeric column names like "2" or "10" — the
+/// counter must start above them.
+UInt64 getNextPhysicalColumnId(const NamesAndTypesList & columns)
+{
+    UInt64 max_numeric_physical_name = 0;
+
+    for (const auto & column : columns)
+    {
+        const auto & name = column.name;
+        UInt64 value = 0;
+        auto * begin = name.data();
+        auto * end = begin + name.size();
+        auto [ptr, ec] = std::from_chars(begin, end, value);
+        if (ec == std::errc() && ptr == end)
+            max_numeric_physical_name = std::max(max_numeric_physical_name, value);
+    }
+
+    return max_numeric_physical_name + 1;
+}
+
+UInt64 getNextPhysicalColumnId(const std::unordered_map<String, String> & logical_to_physical)
+{
+    UInt64 max_numeric_physical_name = 0;
+
+    for (const auto & [_, physical_name] : logical_to_physical)
+    {
+        UInt64 value = 0;
+        auto * begin = physical_name.data();
+        auto * end = begin + physical_name.size();
+        auto [ptr, ec] = std::from_chars(begin, end, value);
+        if (ec == std::errc() && ptr == end)
+            max_numeric_physical_name = std::max(max_numeric_physical_name, value);
+    }
+
+    return max_numeric_physical_name + 1;
+}
+
+[[noreturn]] void throwMissingLogicalName(const String & logical_name)
+{
+    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Logical column name '{}' is not found in `PhysicalNameMapping`", logical_name);
+}
+
+[[noreturn]] void throwMissingPhysicalName(const String & physical_name)
+{
+    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Physical column name '{}' is not found in `PhysicalNameMapping`", physical_name);
+}
+
+}
+
+String PhysicalNameMapping::getPhysicalName(const String & logical_name) const
+{
+    auto it = logical_to_physical.find(logical_name);
+    if (it == logical_to_physical.end())
+        throwMissingLogicalName(logical_name);
+
+    return it->second;
+}
+
+String PhysicalNameMapping::getPhysicalNameOrDefault(const String & logical_name) const
+{
+    auto it = logical_to_physical.find(logical_name);
+    return it == logical_to_physical.end() ? logical_name : it->second;
+}
+
+String PhysicalNameMapping::getLogicalName(const String & physical_name) const
+{
+    auto it = physical_to_logical.find(physical_name);
+    if (it == physical_to_logical.end())
+        throwMissingPhysicalName(physical_name);
+
+    return it->second;
+}
+
+bool PhysicalNameMapping::hasLogicalName(const String & logical_name) const
+{
+    return logical_to_physical.contains(logical_name);
+}
+
+bool PhysicalNameMapping::hasPhysicalName(const String & physical_name) const
+{
+    return physical_to_logical.contains(physical_name);
+}
+
+String PhysicalNameMapping::allocatePhysicalName()
+{
+    /// The counter is monotonically increasing and never recycled.
+    /// This guarantees that DROP column "x" followed by ADD column "x"
+    /// always gets a different physical name, even if the logical name
+    /// is reused.  Old parts still reference the old physical name,
+    /// which is now orphaned — the reader's loadColumns remapping
+    /// (physical-name-first algorithm) will correctly skip it.
+    active = true;
+    return ::DB::toString(next_physical_column_id++);
+}
+
+void PhysicalNameMapping::addColumn(const String & logical_name, const String & physical_name)
+{
+    if (logical_to_physical.contains(logical_name))
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Logical column name '{}' is already registered in `PhysicalNameMapping`", logical_name);
+
+    if (physical_to_logical.contains(physical_name))
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Physical column name '{}' is already registered in `PhysicalNameMapping`", physical_name);
+
+    active = true;
+    logical_to_physical.emplace(logical_name, physical_name);
+    physical_to_logical.emplace(physical_name, logical_name);
+}
+
+void PhysicalNameMapping::removeColumn(const String & logical_name)
+{
+    auto it = logical_to_physical.find(logical_name);
+    if (it == logical_to_physical.end())
+        throwMissingLogicalName(logical_name);
+
+    physical_to_logical.erase(it->second);
+    logical_to_physical.erase(it);
+}
+
+void PhysicalNameMapping::renameColumn(const String & old_logical_name, const String & new_logical_name)
+{
+    auto it = logical_to_physical.find(old_logical_name);
+    if (it == logical_to_physical.end())
+        throwMissingLogicalName(old_logical_name);
+
+    if (logical_to_physical.contains(new_logical_name))
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Logical column name '{}' is already registered in `PhysicalNameMapping`", new_logical_name);
+
+    auto physical_name = it->second;
+    logical_to_physical.erase(it);
+    logical_to_physical.emplace(new_logical_name, physical_name);
+    physical_to_logical[physical_name] = new_logical_name;
+}
+
+Names PhysicalNameMapping::logicalNames() const
+{
+    Names names;
+    names.reserve(logical_to_physical.size());
+
+    for (const auto & [logical_name, _] : logical_to_physical)
+        names.push_back(logical_name);
+
+    return names;
+}
+
+PhysicalNameMapping PhysicalNameMapping::createForExistingTable(const NamesAndTypesList & columns)
+{
+    PhysicalNameMapping mapping;
+    mapping.active = true;
+    /// Identity mapping: physical_name == column_name for every existing column.
+    /// This is safe because files on disk were written using the column name,
+    /// so the identity mapping matches the actual file layout.
+    mapping.next_physical_column_id = getNextPhysicalColumnId(columns);
+
+    for (const auto & column : columns)
+        mapping.addColumn(column.name, column.name);
+
+    return mapping;
+}
+
+PhysicalNameMapping PhysicalNameMapping::createForNewTable(const NamesAndTypesList & columns)
+{
+    /// Same as existing-table activation: initial columns use identity mapping.
+    /// A separate entry point exists so that future work can diverge
+    /// (e.g. assign numeric names from the start for new tables).
+    return createForExistingTable(columns);
+}
+
+void PhysicalNameMapping::serialize(WriteBuffer & buf) const
+{
+    writeString(toString(), buf);
+}
+
+PhysicalNameMapping PhysicalNameMapping::deserialize(ReadBuffer & buf)
+{
+    String json;
+    readString(json, buf);
+    return fromString(json);
+}
+
+String PhysicalNameMapping::toString() const
+{
+    Poco::JSON::Object json;
+    Poco::JSON::Object mapping_json;
+
+    std::vector<std::pair<String, String>> mapping_entries(logical_to_physical.begin(), logical_to_physical.end());
+    std::sort(mapping_entries.begin(), mapping_entries.end(), [](const auto & lhs, const auto & rhs)
+    {
+        return lhs.first < rhs.first;
+    });
+
+    for (const auto & [logical_name, physical_name] : mapping_entries)
+        mapping_json.set(logical_name, physical_name);
+
+    json.set(KEY_ACTIVE, active);
+    json.set(KEY_NEXT_PHYSICAL_COLUMN_ID, next_physical_column_id);
+    json.set(KEY_MAPPING, mapping_json);
+
+    std::ostringstream oss; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    oss.exceptions(std::ios::failbit);
+    Poco::JSON::Stringifier::stringify(json, oss);
+    return oss.str();
+}
+
+PhysicalNameMapping PhysicalNameMapping::fromString(const String & str)
+{
+    Poco::JSON::Parser parser;
+    auto object = parser.parse(str).extract<Poco::JSON::Object::Ptr>();
+
+    PhysicalNameMapping mapping;
+
+    if (object->has(KEY_ACTIVE))
+        mapping.active = object->getValue<bool>(KEY_ACTIVE);
+
+    if (object->has(KEY_NEXT_PHYSICAL_COLUMN_ID))
+        mapping.next_physical_column_id = object->getValue<UInt64>(KEY_NEXT_PHYSICAL_COLUMN_ID);
+
+    if (!object->has(KEY_MAPPING))
+        return mapping;
+
+    auto mapping_object = object->getObject(KEY_MAPPING);
+    for (const auto & [logical_name, physical_name_value] : *mapping_object)
+        mapping.addColumn(logical_name, physical_name_value.convert<String>());
+
+    mapping.active = mapping.active || !mapping.logical_to_physical.empty();
+    if (mapping.next_physical_column_id == 1 && mapping.active)
+        mapping.next_physical_column_id = getNextPhysicalColumnId(mapping.logical_to_physical);
+
+    return mapping;
+}
+
+void populatePhysicalNames(NamesAndTypesList & columns, const PhysicalNameMapping & mapping)
+{
+    if (!mapping.isActive())
+        return;
+
+    for (auto & column : columns)
+        column.setPhysicalName(mapping.getPhysicalNameOrDefault(column.getNameInStorage()));
+}
+
+}

--- a/src/Storages/MergeTree/PhysicalNameMapping.h
+++ b/src/Storages/MergeTree/PhysicalNameMapping.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <Core/NamesAndTypes.h>
+
+#include <memory>
+#include <unordered_map>
+
+
+namespace DB
+{
+
+class ReadBuffer;
+class WriteBuffer;
+
+class PhysicalNameMapping;
+using PhysicalNameMappingPtr = std::shared_ptr<const PhysicalNameMapping>;
+
+/// Bidirectional map between logical SQL column names and stable on-disk physical names.
+///
+/// Existing columns get physical_name == column_name at activation time.
+/// New columns added after activation get monotonically increasing numeric
+/// physical names ("1", "2", ...) from a counter that never decreases.
+/// RENAME only updates the mapping; the physical name (and therefore all
+/// on-disk filenames) stays unchanged.  DROP removes the entry but the
+/// counter is never recycled, so a subsequent ADD of the same logical name
+/// gets a fresh physical name — this is the key invariant that makes
+/// DROP + re-ADD safe (old data files become orphans, not wrong-type reads).
+///
+/// Names not present in the mapping (virtual columns, `_row_exists`, etc.)
+/// pass through unchanged via `getPhysicalNameOrDefault`.
+///
+/// Thread safety: instances are immutable once published through
+/// `MultiVersion<PhysicalNameMapping>` in `MergeTreeData`.  Mutation methods
+/// (`addColumn`, `renameColumn`, ...) are only called on local copies
+/// inside engine `alter()` before atomic publication.
+class PhysicalNameMapping
+{
+public:
+    bool isActive() const
+    {
+        return active;
+    }
+
+    const std::unordered_map<String, String> & getLogicalToPhysical() const
+    {
+        return logical_to_physical;
+    }
+
+    /// Throws if `logical_name` is not in the mapping.
+    String getPhysicalName(const String & logical_name) const;
+
+    /// Returns `logical_name` itself when not in the mapping — safe default
+    /// for virtual columns, helper columns, and legacy (pre-activation) code paths.
+    String getPhysicalNameOrDefault(const String & logical_name) const;
+
+    /// Reverse lookup: physical -> logical.  Throws if not found.
+    String getLogicalName(const String & physical_name) const;
+
+    bool hasLogicalName(const String & logical_name) const;
+    bool hasPhysicalName(const String & physical_name) const;
+
+    /// Allocates the next numeric physical name and advances the counter.
+    /// Also sets `active = true` as a side effect (first allocation activates the mapping).
+    String allocatePhysicalName();
+
+    void addColumn(const String & logical_name, const String & physical_name);
+    void removeColumn(const String & logical_name);
+    void renameColumn(const String & old_logical_name, const String & new_logical_name);
+
+    Names logicalNames() const;
+
+    /// For existing tables: every column gets physical_name == column_name.
+    /// The counter is initialized past the highest numeric column name to
+    /// avoid collisions (e.g. a table with column "2" starts the counter at 3).
+    static PhysicalNameMapping createForExistingTable(const NamesAndTypesList & columns);
+
+    /// Currently identical to `createForExistingTable` — new tables also
+    /// start with identity mapping because the initial column set has no
+    /// reason to use counter-allocated names.  Kept as a separate entry
+    /// point for future divergence (e.g. new tables could start all columns
+    /// with numeric names).
+    static PhysicalNameMapping createForNewTable(const NamesAndTypesList & columns);
+
+    void serialize(WriteBuffer & buf) const;
+    static PhysicalNameMapping deserialize(ReadBuffer & buf);
+
+    String toString() const;
+    static PhysicalNameMapping fromString(const String & str);
+
+private:
+    bool active = false;
+    UInt64 next_physical_column_id = 1;
+    std::unordered_map<String, String> logical_to_physical;
+    std::unordered_map<String, String> physical_to_logical;
+};
+
+/// Sets `physical_name` on each `NameAndTypePair` by looking it up in the mapping.
+/// No-op when the mapping is inactive.  Columns not found in the mapping
+/// get their logical name as the physical name (passthrough).
+void populatePhysicalNames(NamesAndTypesList & columns, const PhysicalNameMapping & mapping);
+
+}

--- a/src/Storages/MergeTree/tests/gtest_physical_name_mapping.cpp
+++ b/src/Storages/MergeTree/tests/gtest_physical_name_mapping.cpp
@@ -1,0 +1,113 @@
+#include <gtest/gtest.h>
+
+#include <DataTypes/DataTypesNumber.h>
+#include <Storages/MergeTree/PhysicalNameMapping.h>
+
+
+using namespace DB;
+
+namespace
+{
+
+DataTypePtr uint64Type()
+{
+    static const auto type = std::make_shared<DataTypeUInt64>();
+    return type;
+}
+
+NamesAndTypesList makeColumns(std::initializer_list<String> names)
+{
+    NamesAndTypesList columns;
+    for (const auto & name : names)
+        columns.emplace_back(name, uint64Type());
+    return columns;
+}
+
+}
+
+TEST(PhysicalNameMapping, DropReAddSameName)
+{
+    auto mapping = PhysicalNameMapping::createForExistingTable(makeColumns({"a"}));
+
+    EXPECT_EQ(mapping.getPhysicalName("a"), "a");
+
+    mapping.removeColumn("a");
+    auto new_physical_name = mapping.allocatePhysicalName();
+    mapping.addColumn("a", new_physical_name);
+
+    EXPECT_EQ(mapping.getPhysicalName("a"), "1");
+    EXPECT_EQ(new_physical_name, "1");
+    EXPECT_NE(new_physical_name, "a");
+}
+
+TEST(PhysicalNameMapping, CounterWithNumericColumnNames)
+{
+    auto mapping = PhysicalNameMapping::createForExistingTable(makeColumns({"2", "a", "10"}));
+
+    EXPECT_EQ(mapping.allocatePhysicalName(), "11");
+}
+
+TEST(PhysicalNameMapping, RenamePreservesPhysical)
+{
+    auto mapping = PhysicalNameMapping::createForExistingTable(makeColumns({"a", "b"}));
+
+    mapping.renameColumn("a", "c");
+
+    EXPECT_FALSE(mapping.hasLogicalName("a"));
+    EXPECT_TRUE(mapping.hasLogicalName("c"));
+    EXPECT_EQ(mapping.getPhysicalName("c"), "a");
+    EXPECT_EQ(mapping.getLogicalName("a"), "c");
+}
+
+TEST(PhysicalNameMapping, SerializeDeserializeRoundTrip)
+{
+    auto mapping = PhysicalNameMapping::createForExistingTable(makeColumns({"10", "a"}));
+    auto new_physical_name = mapping.allocatePhysicalName();
+    mapping.addColumn("c", new_physical_name);
+    mapping.renameColumn("a", "b");
+
+    auto restored = PhysicalNameMapping::fromString(mapping.toString());
+
+    EXPECT_TRUE(restored.isActive());
+    EXPECT_EQ(restored.getPhysicalName("10"), "10");
+    EXPECT_EQ(restored.getPhysicalName("b"), "a");
+    EXPECT_EQ(restored.getPhysicalName("c"), "11");
+    EXPECT_EQ(restored.getLogicalName("a"), "b");
+    EXPECT_EQ(restored.allocatePhysicalName(), "12");
+}
+
+TEST(PhysicalNameMapping, UnmappedColumnsPassthrough)
+{
+    auto mapping = PhysicalNameMapping::createForExistingTable(makeColumns({"a"}));
+
+    EXPECT_EQ(mapping.getPhysicalNameOrDefault("_row_exists"), "_row_exists");
+
+    auto columns = makeColumns({"a", "_row_exists"});
+    populatePhysicalNames(columns, mapping);
+
+    auto a = columns.tryGetByName("a");
+    auto row_exists = columns.tryGetByName("_row_exists");
+
+    ASSERT_TRUE(a.has_value());
+    ASSERT_TRUE(row_exists.has_value());
+    EXPECT_EQ(a->getPhysicalNameInStorage(), "a");
+    EXPECT_EQ(row_exists->getPhysicalNameInStorage(), "_row_exists");
+}
+
+TEST(PhysicalNameMapping, ConcurrentDropAddCycle)
+{
+    auto mapping = PhysicalNameMapping::createForExistingTable(makeColumns({"a"}));
+
+    mapping.removeColumn("a");
+    auto b_physical_name = mapping.allocatePhysicalName();
+    mapping.addColumn("b", b_physical_name);
+
+    mapping.removeColumn("b");
+    auto a_physical_name = mapping.allocatePhysicalName();
+    mapping.addColumn("a", a_physical_name);
+
+    EXPECT_EQ(b_physical_name, "1");
+    EXPECT_EQ(a_physical_name, "2");
+    EXPECT_EQ(mapping.getPhysicalName("a"), "2");
+    EXPECT_NE(a_physical_name, b_physical_name);
+}


### PR DESCRIPTION
In the current implementation, `RENAME COLUMN` and `DROP + re-ADD COLUMN` operations in MergeTree require complete data mutations, necessitating the rewriting of every part stored on disk. To address this, a persistent bidirectional mapping is introduced between logical SQL column names and stable physical on-disk names, stored in a `physical_names.json` file at the table level. Once enabled, `RENAME COLUMN` becomes a metadata-only operation (leaving the physical file name unchanged), and `DROP COLUMN` bypasses the mutation stage entirely. 

For new columns added after activation, unique, incrementally increasing numeric physical names are assigned, ensuring that `DROP + re-ADD` of the same logical column name does not conflict with existing data files. 

This feature can be activated during table creation by setting `serialization_info_version = 'with_physical_names'`, or applied retroactively to existing tables by enabling `activate_physical_names_for_existing_tables = 1`. The first compatible `ALTER` operation triggers the activation of identity mapping. The functionality supports wide and compact parts, projections, Nested columns, and minmax indexes.

**This is the initial PR focusing on foundational changes that will not take immediate effect.**

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)