### PR TITLE
Add bug test for correlated EXISTS with LIMIT/OFFSET regression (PR #99005)

### DIFF
--- a/tests/queries/0_stateless/04048_correlated_exists_limit_offset.sql
+++ b/tests/queries/0_stateless/04048_correlated_exists_limit_offset.sql
@@ -1,0 +1,32 @@
+-- Bug test for PR #99005 (Fix EXISTS not respecting LIMIT and OFFSET in subqueries).
+-- PR #99005 correctly fixes non-correlated EXISTS with LIMIT/OFFSET, but correlated
+-- EXISTS with LIMIT offset>0 or limit=0 now throws NOT_IMPLEMENTED because
+-- optimizePlanForExists preserves the LimitStep while decorrelateQueryPlan cannot
+-- handle it.
+
+DROP TABLE IF EXISTS t_04048_outer;
+DROP TABLE IF EXISTS t_04048_inner;
+
+CREATE TABLE t_04048_outer (x UInt64) ENGINE = MergeTree() ORDER BY x;
+CREATE TABLE t_04048_inner (x UInt64) ENGINE = MergeTree() ORDER BY x;
+
+INSERT INTO t_04048_outer VALUES (1), (2), (3);
+INSERT INTO t_04048_inner VALUES (1), (1), (1), (2), (2);
+
+-- Correlated EXISTS with OFFSET that skips all matching rows → NOT_IMPLEMENTED
+SELECT x, EXISTS (
+    SELECT 1 FROM t_04048_inner
+    WHERE t_04048_inner.x = t_04048_outer.x
+    LIMIT 3 OFFSET 10
+) AS e FROM t_04048_outer ORDER BY x; -- { serverError NOT_IMPLEMENTED, UNKNOWN_IDENTIFIER }
+
+-- Correlated EXISTS with LIMIT 0 → NOT_IMPLEMENTED
+SELECT x, EXISTS (
+    SELECT 1 FROM t_04048_inner
+    WHERE t_04048_inner.x = t_04048_outer.x
+    LIMIT 0
+) AS e FROM t_04048_outer ORDER BY x; -- { serverError NOT_IMPLEMENTED, UNKNOWN_IDENTIFIER }
+
+
+DROP TABLE t_04048_outer;
+DROP TABLE t_04048_inner;


### PR DESCRIPTION
PR #99005 correctly fixes non-correlated `EXISTS` with `LIMIT`/`OFFSET`. However, it introduces a regression for **correlated** `EXISTS` subqueries: `optimizePlanForExists` now preserves the `LimitStep` when `limit=0` or `offset>0`, but `decorrelateQueryPlan` does not support `LimitStep` and throws `NOT_IMPLEMENTED`.

### Repro (`04048`)

```sql
-- Both throw NOT_IMPLEMENTED after PR #99005:
SELECT x, EXISTS (SELECT 1 FROM inner WHERE inner.x = outer.x LIMIT 3 OFFSET 10) FROM outer;
SELECT x, EXISTS (SELECT 1 FROM inner WHERE inner.x = outer.x LIMIT 0) FROM outer;

-- This still works (offset=0, limit>0):
SELECT x, EXISTS (SELECT 1 FROM inner WHERE inner.x = outer.x LIMIT 3) FROM outer;
```

The fix should add `LimitStep` support to `decorrelateQueryPlan`, or handle the correlated EXISTS case specially in `optimizePlanForExists` before creating the `LimitStep`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.71`
<!-- ch-version-info:end -->