### PR TITLE
Fix parsing of shell-style quotes in arguments for the executable table function

### DIFF
--- a/src/TableFunctions/TableFunctionExecutable.cpp
+++ b/src/TableFunctions/TableFunctionExecutable.cpp
@@ -15,7 +15,7 @@
 #include <Storages/checkAndGetLiteralArgument.h>
 #include <TableFunctions/TableFunctionFactory.h>
 #include <TableFunctions/registerTableFunctions.h>
-#include <boost/algorithm/string.hpp>
+#include <boost/program_options/parsers.hpp>
 #include <Common/Exception.h>
 #include <Common/VectorWithMemoryTracking.h>
 
@@ -122,13 +122,11 @@ void TableFunctionExecutable::parseArguments(const ASTPtr & ast_function, Contex
         args[i] = evaluateConstantExpressionOrIdentifierAsLiteral(args[i], context);
 
     auto script_name_with_arguments_value = checkAndGetLiteralArgument<String>(args[0], "script_name_with_arguments_value");
-
-    VectorWithMemoryTracking<String> script_name_with_arguments;
-    boost::split(script_name_with_arguments, script_name_with_arguments_value, [](char c){ return c == ' '; });
+    auto script_name_with_arguments = boost::program_options::split_unix(script_name_with_arguments_value);
 
     script_name = std::move(script_name_with_arguments[0]);
     script_name_with_arguments.erase(script_name_with_arguments.begin());
-    arguments = std::move(script_name_with_arguments);
+    arguments.assign(script_name_with_arguments.begin(), script_name_with_arguments.end());
     format = checkAndGetLiteralArgument<String>(args[1], "format");
     structure = checkAndGetLiteralArgument<String>(args[2], "structure");
 

--- a/src/TableFunctions/TableFunctionExecutable.cpp
+++ b/src/TableFunctions/TableFunctionExecutable.cpp
@@ -123,6 +123,8 @@ void TableFunctionExecutable::parseArguments(const ASTPtr & ast_function, Contex
 
     auto script_name_with_arguments_value = checkAndGetLiteralArgument<String>(args[0], "script_name_with_arguments_value");
     auto script_name_with_arguments = boost::program_options::split_unix(script_name_with_arguments_value);
+    if (script_name_with_arguments.empty())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Script name cannot be empty");
 
     script_name = std::move(script_name_with_arguments[0]);
     script_name_with_arguments.erase(script_name_with_arguments.begin());

--- a/tests/integration/test_executable_table_function/test.py
+++ b/tests/integration/test_executable_table_function/test.py
@@ -49,6 +49,9 @@ def started_cluster():
 
 def test_executable_function_echo_arguments_bash(started_cluster):
     skip_test_msan(node)
+    assert node.query_and_get_error(
+            "SELECT * FROM executable('', 'LineAsString', 'value String')"
+    )
     assert (
         node.query(
             r"""SELECT * FROM executable('echo_arguments.sh \'Key 1\' \'Key 2\'', 'LineAsString', 'value String')"""

--- a/tests/integration/test_executable_table_function/test.py
+++ b/tests/integration/test_executable_table_function/test.py
@@ -47,6 +47,34 @@ def started_cluster():
         cluster.shutdown()
 
 
+def test_executable_function_echo_arguments_bash(started_cluster):
+    skip_test_msan(node)
+    assert (
+        node.query(
+            r"""SELECT * FROM executable('echo_arguments.sh \'Key 1\' \'Key 2\'', 'LineAsString', 'value String')"""
+        )
+        == "Key 1\nKey 2\n"
+    )
+    assert (
+        node.query(
+            r"""SELECT * FROM executable('echo_arguments.sh ''Key 1'' ''Key 2''', 'LineAsString', 'value String')"""
+        )
+        == "Key 1\nKey 2\n"
+    )
+    assert (
+        node.query(
+            r"""SELECT * FROM executable('echo_arguments.sh "Key 1" "Key 2"', 'LineAsString', 'value String')"""
+        )
+        == "Key 1\nKey 2\n"
+    )
+    assert (
+        node.query(
+            r"""SELECT * FROM executable('echo_arguments.sh Key 1 Key 2 Key 3', 'LineAsString', 'value String')"""
+        )
+        == "Key\n1\nKey\n2\nKey\n3\n"
+    )
+
+
 def test_executable_function_no_input_bash(started_cluster):
     skip_test_msan(node)
     assert (

--- a/tests/integration/test_executable_table_function/user_scripts/echo_arguments.sh
+++ b/tests/integration/test_executable_table_function/user_scripts/echo_arguments.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+for arg in "$@"; do
+    echo $arg
+done

--- a/tests/queries/0_stateless/02377_executable_function_settings.oldanalyzer.reference
+++ b/tests/queries/0_stateless/02377_executable_function_settings.oldanalyzer.reference
@@ -1,9 +1,0 @@
-SELECT data
-FROM executable(\'\', \'JSON\', \'data String\')
---------------------
-SELECT data
-FROM executable(\'\', \'JSON\', \'data String\', SETTINGS max_command_execution_time = 100)
---------------------
-SELECT data
-FROM executable(\'\', \'JSON\', \'data String\', SETTINGS max_command_execution_time = 100, command_read_timeout = 1)
---------------------

--- a/tests/queries/0_stateless/02377_executable_function_settings.sql
+++ b/tests/queries/0_stateless/02377_executable_function_settings.sql
@@ -1,3 +1,14 @@
+SET enable_analyzer = 0;
+
+-- EXPLAIN SYNTAX with the old analyzer calls parseArguments, which rejects empty script_name
+EXPLAIN SYNTAX SELECT * from executable('', 'JSON', 'data String'); -- { serverError BAD_ARGUMENTS }
+EXPLAIN SYNTAX SELECT * from executable('', 'JSON', 'data String', SETTINGS max_command_execution_time=100); -- { serverError BAD_ARGUMENTS }
+EXPLAIN SYNTAX SELECT * from executable('', 'JSON', 'data String', SETTINGS max_command_execution_time=100, command_read_timeout=1); -- { serverError BAD_ARGUMENTS }
+
+
+SET enable_analyzer = 1;
+
+-- EXPLAIN SYNTAX with the new analyzer does not call parseArguments
 EXPLAIN SYNTAX SELECT * from executable('', 'JSON', 'data String');
 SELECT '--------------------';
 EXPLAIN SYNTAX SELECT * from executable('', 'JSON', 'data String', SETTINGS max_command_execution_time=100);


### PR DESCRIPTION
Fixes #66634.

Currently, the executable table function fails to handle quoted arguments because it relies on `boost::split`, so this PR replaces it with `boost::program_options::split_unix` to support proper shell-style quoting instead of simple space-based splitting

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix parsing of shell-style quotes in arguments for the `executable` table function.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
N/A. Just a bug fix, no new features

### Details

Working example from the issue #66634:
```
│:) select * from executable('argument_test.sh "a b"', LineAsString, 'value String')                                                                                                                                                                                                    │
│                                                                                                                                                                                                                                                                                       │
│SELECT *                                                                                                                                                                                                                                                                               │
│FROM executable('argument_test.sh "a b"', LineAsString, 'value String')                                                                                                                                                                                                                │
│                                                                                                                                                                                                                                                                                       │
│Query id: 1c712b2d-673e-49a2-965c-24378db6f99a                                                                                                                                                                                                                                         │
│                                                                                                                                                                                                                                                                                       │
│   ┌─value─┐                                                                                                                                                                                                                                                                           │
│1. │ a b   │                                                                                                                                                                                                                                                                           │
│   └───────┘
```