### PR TITLE
Improve Claude AI tools: CI docs, test naming, review checklist, PR description skill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8,23 +8,33 @@ When writing text such as documentation, comments, or commit messages, write nam
 
 When mentioning logical errors, say "exception" instead of "crash", because they don't crash the server in the release build.
 
-Links to ClickHouse CI, such as `https://s3.amazonaws.com/clickhouse-test-reports/json.html?...` should be analyzed using the tool at `.claude/tools/fetch_ci_report.js`, which directly fetches the underlying JSON data without requiring a browser:
+Links to ClickHouse CI should be analyzed using the tool at `.claude/tools/fetch_ci_report.js`, which directly fetches the underlying JSON data without requiring a browser. It accepts GitHub PR URLs (fetches all CI reports) or direct S3/CI HTML URLs.
 
 ```bash
-# Fetch and analyze CI report
-node /path/to/ClickHouse/.claude/tools/fetch_ci_report.js "<ci-url>" [options]
+# Fetch all CI reports for a PR
+node .claude/tools/fetch_ci_report.js "https://github.com/ClickHouse/ClickHouse/pull/12345"
+
+# Show only failed tests with CIDB links
+node .claude/tools/fetch_ci_report.js "https://github.com/ClickHouse/ClickHouse/pull/12345" --failed --cidb
+
+# Fetch only a specific report from a PR (by index)
+node .claude/tools/fetch_ci_report.js "https://github.com/ClickHouse/ClickHouse/pull/12345" --report 2
+
+# Filter by test name, show artifact links
+node .claude/tools/fetch_ci_report.js "<url>" --test peak_memory --links
+
+# Download logs and show failed tests
+node .claude/tools/fetch_ci_report.js "<url>" --failed --download-logs
 
 # Options:
-#   --test <name>    Filter tests by name
-#   --failed         Show only failed tests
-#   --all            Show all test results
-#   --links          Show artifact links (logs.tar.gz, etc.)
-#   --download-logs  Download logs.tar.gz to /tmp/ci_logs.tar.gz
+#   --test <name>               Filter tests by name
+#   --failed                    Show only failed tests
+#   --all                       Show all test results
+#   --links                     Show artifact links (logs.tar.gz, etc.)
+#   --cidb                      Show CIDB links for failed tests
+#   --report <number>           For PR URLs: fetch only one specific report
+#   --download-logs             Download logs.tar.gz to /tmp/ci_logs.tar.gz
 #   --credentials <user,password>  HTTP Basic Auth for private repositories
-
-# Examples:
-node .claude/tools/fetch_ci_report.js "https://s3.amazonaws.com/..." --failed --links
-node .claude/tools/fetch_ci_report.js "https://s3.amazonaws.com/..." --test peak_memory --download-logs
 ```
 
 After downloading logs, extract specific test logs:
@@ -128,10 +138,7 @@ When writing tests, do not add "no-*" tags (like "no-parallel") unless strictly 
 
 When writing tests in tests/queries, prefer adding a new test instead of extending existing ones.
 
-When adding a new test, first run the following command to find the current test with the last prefix index, then increment the resulting index by 1, and use this as the prefix for the new test name:
-```
-ls tests/queries/0_stateless/[0-9]*.reference | tail -n 1
-```
+When adding a new test, consult `./tests/queries/0_stateless/add-test` to determine the correct name prefix for the new test.
 
 When writing C++ code, always use Allman-style braces (opening brace on a new line). This is enforced by the style check in CI.
 
@@ -155,11 +162,3 @@ ARM machines in CI are not slow. They are similar to x86 in performance.
 
 Use `tmp` subdirectory in the current directory for temporary files (logs, downloads, scripts, etc.), do not use `/tmp`. Create the directory if needed.
 
-When there are crucial findings (when I corrected your behavior, you when you found a crucial insight about the code), append them to `.claude/learnings.md`, but be concise. You can commit the changes in learnings.md along with the other changes. Read this file at start.
-
-Always load and apply the following skills:
-
-- .claude/skills/fix-sync
-- .claude/skills/alloc-profile
-- .claude/skills/bisect
-- .claude/skills/create-worktree

--- a/.claude/skills/clickhouse-pr-description/SKILL.md
+++ b/.claude/skills/clickhouse-pr-description/SKILL.md
@@ -1,121 +1,125 @@
 ---
 name: clickhouse-pr-description
-description: Generate PR descriptions for ClickHouse/ClickHouse that match maintainer expectations. Strips AI slop automatically. Use when creating or updating PR descriptions.
+description: Generate PR descriptions for ClickHouse/ClickHouse that match maintainer expectations. Use when creating or updating PR descriptions.
 argument-hint: "[PR-number or branch-name]"
 disable-model-invocation: false
-allowed-tools: Task, Bash(gh:*), Bash(git:*), Read, Glob, Grep
+allowed-tools: Task, Bash(gh:*), Bash(git:*), Read, Glob, Grep, AskUserQuestion
 ---
 
 # ClickHouse PR Description Skill
 
-Generate PR descriptions that look like a human wrote them in 30 seconds. ClickHouse maintainers hate AI slop.
-
-## Arguments
-
-- `$0` (optional): PR number or branch name. If omitted, uses the current branch.
-
-## Obtaining the Diff
-
-**If a PR number is given:**
-- Fetch the PR info: `gh pr view $0 --json title,body,baseRefName,headRefName,files`
-- Get the diff: `gh pr diff $0`
-
-**If a branch name is given:**
-- Get the diff against master: `git diff master...$0`
-
-**If nothing is given:**
-- Use current branch: `git diff master...HEAD`
-- Get commit messages: `git log --oneline master..HEAD`
+Generate a good PR description and apply it, with optional confirmation based on user preference.
 
 ## Title
 
-Plain description. No prefix conventions.
+Plain description of what changed. No prefix conventions like `fix():` or `feat():`.
 
 - Good: `Change default stderr_reaction to log_last for executable UDFs`
-- Good: `Fix crash when inserting NULL into non-nullable column`
-- Good: `Fuzzer fixes`
-- Bad: `fix(udf): Change default stderr_reaction to log_last` -- conventional commits = instant AI tell
-- Bad: `Improve error handling and enrich exit code exceptions with stderr context` -- too polished
-
-Keep it under 80 chars. Lowercase after first word is fine.
+- Good: `Fix exception when inserting NULL into non-nullable column via CAST`
+- Bad: `fix(udf): Change default stderr_reaction` — conventional commits, ClickHouse doesn't use them
+- Bad: `Fuzzer fixes` — too vague, tells the reviewer nothing
+- Bad: `Improve error handling and enrich exit code exceptions with stderr context` — too vague, doesn't say what was actually changed
 
 ## Body
 
-**Only the official template from `.github/PULL_REQUEST_TEMPLATE.md`. Nothing else above or below unless you have a genuine reason.**
+Read `.github/PULL_REQUEST_TEMPLATE.md` for the exact template structure.
 
-Read `.github/PULL_REQUEST_TEMPLATE.md` for the exact template. Fill in the changelog category (delete the rest), write the changelog entry, and keep the documentation checkbox.
+A good PR description has two parts:
 
-**If context is needed** (complex bug fix, behavioral change), add 1-3 paragraphs of plain text ABOVE the template. Free-form, no headers, no formatting. Like explaining to a colleague:
+**1. Free-form context (above the template, optional but encouraged for non-trivial changes)**
+
+Explain to a future reader: what was the problem, why did it need fixing, what approach was taken, what were the results or trade-offs. This is the right place for:
+- Motivation and background
+- Description of the approach and why it was chosen over alternatives
+- Benchmark results or measurements
+- Links to related issues, discussions, or previous attempts
+- Any caveats or known limitations
+
+Use plain paragraphs. Headers like `## Motivation`, `## Changes`, `## Results` are fine and helpful — they make the PR easier to navigate for reviewers. Bullet lists are fine. Be as detailed as needed.
+
+**2. Template section (mandatory)**
+
+Fill in the changelog category (delete the rest of the list), write the changelog entry, and keep the documentation checkbox.
+
+### Example of a well-written body
+
+From [#96110](https://github.com/ClickHouse/ClickHouse/pull/96110):
 
 ```
-The previous default `throw` for stderr_reaction caused confusing errors when
-UDFs wrote warnings to stderr but exited 0. Changed to `log_last` which matches
-what most users expect. The `throw` behavior is still available via config.
-
 ### Changelog category (leave one):
-- Bug Fix (user-visible misbehavior in an official stable release)
+- Backward Incompatible Change
 
 ### Changelog entry:
-Change default `stderr_reaction` from `throw` to `log_last` for executable UDFs.
-Previously, UDFs that wrote warnings to stderr would fail even with exit code 0.
-Fixes #XXXXX.
+The semantics of the `do_not_merge_across_partitions_select_final` setting were
+made more obvious. Previously, the feature could be automatically enabled when
+the setting was not explicitly set in the configs. It caused confusion repeatedly
+and, unfortunately, led to some issues in production. Now, the rules are simpler:
+`do_not_merge_across_partitions_select_final=1` enables the functionality
+unconditionally. If `do_not_merge_across_partitions_select_final=0`, then automatic
+is used only if the new setting
+`enable_automatic_decision_for_merging_across_partitions_for_final=1` and not used
+otherwise. To preserve the old behaviour as much as possible, the defaults were set
+to `do_not_merge_across_partitions_select_final=0` and
+`enable_automatic_decision_for_merging_across_partitions_for_final=1`.
 
 ### Documentation entry for user-facing changes
 - [ ] Documentation is written (mandatory for new features)
+
+---
+
+The backward-incompatible part is that if someone has
+`do_not_merge_across_partitions_select_final=0` explicitly set in the configs,
+it no longer protects against the use of automatics. I'm open to discussion on
+whether we should conservatively default to disabled automatics.
 ```
+
+Note: extra context after `---` is fine — reviewers see it, but only the changelog entry above the blank line goes into the CHANGELOG.
 
 ## Changelog entry guidelines
 
-- Written for **users**, not developers
-- Present tense: "Fix" not "Fixed"
-- Say what changed AND why it matters to users
-- Code elements in backticks
-- Reference issue: `Fixes #XXXXX`
-- 1-3 sentences max
+The entry is what ends up in the published CHANGELOG. Write it for a user who is upgrading and scanning for what affects them. The PR link and author attribution are appended automatically by tooling — do not include them.
 
-## AI Slop Blacklist
+**Format:** the changelog script (`tests/ci/changelog.py`) collects all lines after the `### Changelog entry:` header up to the first blank line, then joins them with spaces into a single string. This means:
+- The entry can span multiple lines in the template — they become one paragraph
+- A blank line terminates collection — anything after it is ignored
+- Write it as a single paragraph (no bullet lists, no blank lines within)
 
-These patterns are **never allowed** in ClickHouse PRs:
+**Tense:** mixed is fine and natural. "Added X", "Fix a case where...", "The `X` setting is now Y" are all real examples from the CHANGELOG. Don't force everything into present tense.
 
-| Pattern | Why it's slop |
-|---------|---------------|
-| `fix(scope):` / `feat():` / `chore():` | Conventional commits -- ClickHouse doesn't use them |
-| `## Summary` | Not in template, screams AI |
-| `## Test plan` / `## Testing` | Tests speak for themselves |
-| `## Changes` / `## What changed` | Not in template |
-| `## Behavior after this change` | Not a ClickHouse convention |
-| Markdown tables comparing behavior | Over-engineered, nobody does this |
-| Checkbox lists `- [ ] tested X` | Not a ClickHouse convention |
-| `This PR ...` to start the description | AI opener. Just describe the change directly |
-| Bullet lists of file-by-file changes | Implementation details don't belong here |
-| `## Motivation` as a header | If needed, just write it as plain text |
-| Emojis in any form | No |
-| `Co-Authored-By: Claude/Cursor/...` in PR descriptions | AI attribution in PR body is noise; commit trailers are a separate policy |
-| Perfectly parallel sentence structures | Vary your phrasing |
-| Words: "enhance", "streamline", "leverage", "robust", "comprehensive" | Classic AI vocabulary |
+**Length:** match the impact. A small new function can be one sentence. A changed default or backward-incompatible behavior warrants as many sentences as needed, including what users must do to adapt.
 
-## For CI/not-for-changelog PRs
+**Specificity:** always name the exact thing that changed. Never write "Fix a bug" or "Improve performance" without saying what specifically.
 
-Minimal is best:
+**For backward-incompatible changes:** always explain the old behavior, the new behavior, and how to restore the old one if possible.
 
-```
-### Changelog category (leave one):
-- Not for changelog (changelog entry is not required)
+**Real examples from the ClickHouse CHANGELOG:**
 
-### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
+One sentence, sufficient for a focused addition:
+> Add `xxh3_128` hashing function.
 
-...
+One sentence with enough context:
+> `DATE` columns from PostgreSQL are now inferred as `Date32` in ClickHouse (in previous versions they were inferred as `Date`, which led to overflow of values outside a narrow range). Allow inserting `Date32` values back to PostgreSQL.
 
-### Documentation entry for user-facing changes
+Full migration instructions for a default change:
+> Deduplication is turned ON for all inserts by default. It was OFF before for async inserts and for MV's, but it was ON for sync inserts. The goal is to have the same defaults for both ways of inserts. If you have deduplication explicitly disabled on your cluster, you have to explicitly set `deduplicate_insert='backward_compatible_choice'` to keep the old behavior.
 
-- [ ] Documentation is written (mandatory for new features)
-```
+Describes new capability with enough detail to understand when to use it:
+> Added `OPTIMIZE <table> DRY RUN PARTS <part names>` query to simulate merges without committing the result part. It may be useful for testing purposes: verifying merge correctness in the new version, deterministically reproducing merge-related bugs, and reliably benchmarking merge performance.
 
-## Process
+Reference the issue if one exists: `Closes #XXXXX` or `Fixes #XXXXX` at the end.
 
-1. Read the diff to understand the change
-2. Pick the right changelog category
-3. Write a changelog entry for users (not developers)
-4. Only add free-form context above template if the change is non-obvious
-5. Re-read the body -- delete anything that a ClickHouse maintainer would call slop
-6. Check title -- no conventional commit prefix, no AI-polished phrasing
+## What to avoid
+
+These patterns make PRs harder to read or signal low effort:
+
+- `fix(scope):` / `feat():` / `chore():` — ClickHouse doesn't use conventional commits
+- `This PR ...` to start any section — just describe the change
+- Vague titles like `Fuzzer fixes`, `Fix bug`, `Improvements` — always say what specifically
+- Markdown tables comparing "before/after behavior" unless genuinely useful
+- Perfectly parallel sentence structure throughout — vary phrasing naturally
+
+## AI co-authorship
+
+It's fine to mention AI assistance openly. `Co-Authored-By:` in commits or acknowledgements in the PR description are acceptable — ClickHouse is open about AI-assisted development.
+
+Before creating or updating the PR, check user memory for a confirmation preference. If no preference is stored, ask once: "Should I always show you the description for approval before applying it, or just go ahead every time?" Save the answer to memory and apply it from then on.

--- a/.claude/skills/clickhouse-pr-description/SKILL.md
+++ b/.claude/skills/clickhouse-pr-description/SKILL.md
@@ -122,4 +122,4 @@ These patterns make PRs harder to read or signal low effort:
 
 It's fine to mention AI assistance openly. `Co-Authored-By:` in commits or acknowledgements in the PR description are acceptable — ClickHouse is open about AI-assisted development.
 
-Before creating or updating the PR, check user memory for a confirmation preference. If no preference is stored, ask once: "Should I always show you the description for approval before applying it, or just go ahead every time?" Save the answer to memory and apply it from then on.
+Before creating or updating the PR, check user memory for a confirmation preference. If no preference is stored and the session is interactive, ask once: "Should I always show you the description for approval before applying it, or just go ahead every time?" Save the answer to memory and apply it from then on. If the session is non-interactive, proceed directly without asking.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -15,17 +15,17 @@ allowed-tools: Task, Bash, Read, Glob, Grep, WebFetch, AskUserQuestion
 ## Obtaining the Diff
 
 **If a PR number is given:**
-- Fetch the PR info: `gh pr view $0 --json title,body,baseRefName,headRefName,files`
-- Get the diff: `gh pr diff $0`
+- Fetch PR metadata (title, description, base/head refs, changed files).
+- Fetch the full PR diff.
 - Note the PR title, description, and linked issues
 
 **If a branch name is given:**
-- Get the diff against master: `git diff master...$0`
+- Get the diff against `master`.
 - Use the branch name as context
 
 **If a diff spec is given (e.g., `HEAD~3..HEAD`):**
-- Get the diff: `git diff $0`
-- Get commit messages: `git log --oneline $0`
+- Get the diff for the specified range.
+- Get commit messages for the same range.
 
 Store the diff for analysis. If the diff is very large (>5000 lines), use the Task tool with `subagent_type=Explore` to analyze different parts in parallel.
 
@@ -45,6 +45,7 @@ SCOPE & LANGUAGE
 
 INPUTS YOU WILL RECEIVE
 - PR title, description, motivation
+- PR template fields (`Changelog category`, `Changelog entry`)
 - Diff (file paths, added/removed lines)
 - Linked issues / discussions
 - CI status and logs (if available)
@@ -92,6 +93,7 @@ WHAT TO REVIEW VS WHAT TO IGNORE
 - Scan all changed lines for typos in comments, variable names, string literals, log messages, error messages, and documentation.
 - Report all typos found with suggested corrections.
 - Check that error messages are clear, informative, and help the user understand what went wrong and how to fix it.
+- Review PR template changelog quality: `Changelog category` must match the change, and `Changelog entry` (when required by the PR template) must be present and user-readable.
 
 **Explicitly ignore (do not comment on these unless they indicate a bug):**
 - Commented debugging code (completely ignore for draft PR, no more than one message in total)
@@ -120,14 +122,18 @@ When reading diffs, scan for these classes of bugs:
 - Misuse of `std::unique_ptr` / `std::shared_ptr` / intrusive refcounts: cycles, double ownership, or forgotten release.
 
 **3) Concurrency & threading**
-- Access to shared state without appropriate locking/atomics.
-- Lock ordering changes that could introduce ABBA deadlocks.
-- Using non-thread-safe data structures from multiple threads.
-- Mutable globals or singletons accessed from many places.
+- Access to shared state without a lock or atomic: look for member variable reads/writes that happen outside the guarded region, especially on fast paths that skip locking as an optimization.
+- Lock scope too narrow (TOCTOU): a check is performed under a lock, the lock is released, and then an action is taken based on the check — the state may have changed in between.
+- Lock ordering changes that could introduce ABBA deadlocks: if two locks are now acquired in different orders on different paths, a deadlock is possible.
+- `std::atomic` with wrong memory ordering: `relaxed` is rarely correct for anything beyond counters; loads/stores that must synchronize with other threads need at least `acquire`/`release`.
+- Condition variable misuse: `wait` without a predicate loop (vulnerable to spurious wakeups), or notifying while the lock is still held.
+- Using non-thread-safe containers (e.g. `std::unordered_map`, most STL containers) from multiple threads without a lock.
+- Mutable globals or singletons modified from multiple threads.
 
 **4) Error handling & observability**
 - Ignored return values of functions that can fail (IO, network, syscalls).
-- Exceptions that cross module boundaries in unexpected ways.
+- Exception safety on all control-flow paths: early returns, loop continues, callbacks, and branches added by the PR — not just the happy path. Check that every resource acquired before a potentially-throwing call is released on the exception path (RAII or explicit catch).
+- **Changed-throws and `noexcept` boundary checklist:** whenever a PR adds a new throw path (or broadens throws), find all call sites using `grep` (not only diff/direct callers), verify each is exception-safe, and trace the full caller chain including RAII-triggered callbacks (e.g. `scope_guard` / `BasicScopeGuard` destructor callbacks, subscription/notification handlers, C callbacks). Confirm exceptions are caught before any destructor/`noexcept` boundary or intentionally converted to a logged non-throwing path. Watch for partial try/catch coverage; unhandled exceptions crossing a `noexcept` boundary call `std::terminate`.
 - Inconsistent error codes or messages that make debugging impossible.
 - Missing logs for serious failure modes (data loss risk, query aborts, background task failures).
 
@@ -146,8 +152,9 @@ When reading diffs, scan for these classes of bugs:
 - Extra syscalls, unnecessary fsyncs, sleeps, or polling in hot paths.
 
 **7) Compilation time & build impact**
+- ClickHouse has ~10k translation units; compilation time is a key developer productivity concern.
 - Adding non-trivial code (function bodies, method implementations, template definitions) to widely-included headers instead of moving it to `.cpp` files. Large function bodies in headers force recompilation of every translation unit that includes them. Prefer keeping only declarations, forward declarations, and truly trivial inline functions in `.h` files.
-- Adding or pulling heavy transitive includes into high-fan-out headers. When a header is included by hundreds or thousands of translation units, every extra `#include` it carries multiplies across the entire build. Watch for headers like `Exception.h`, `IColumn.h`, `IDataType.h`, and other foundational headers gaining new includes. Prefer forward declarations, dedicated lightweight `_fwd.h` headers, or moving the dependency into `.cpp` files.
+- Adding or pulling heavy transitive includes into high-fan-out headers. When a header is included by hundreds or thousands of translation units, every extra `#include` it carries multiplies across the entire build. Watch for foundational headers like `Exception.h`, `IColumn.h`, `IDataType.h`, `typeid_cast.h`, `assert_cast.h`, and `Context_fwd.h` gaining new includes. Prefer forward declarations, dedicated lightweight `_fwd.h` headers, or moving the dependency into `.cpp` files.
 - Unnecessary template instantiations: template code that unconditionally instantiates specializations for cases that are statically known to be unreachable. Use `if constexpr` to prune template variants that do not apply (e.g., instantiating a `division_by_nullable=true` variant for non-division operations). Each unnecessary instantiation multiplies compile time and binary size.
 - Large `constexpr` evaluation in headers: complex `constexpr` loops or recursive `constexpr` functions in headers that the compiler must evaluate in every translation unit. Extract them into `.cpp` files or break them into smaller units.
 
@@ -160,13 +167,18 @@ When reading diffs, scan for these classes of bugs:
 - Watch for file paths that surface contents in error messages on parse failure — even a "read then validate" pattern can leak file contents through exceptions.
 - This applies to all code paths that use `ReadBufferFromFile`, `WriteBufferToFile`, `std::ifstream`, or similar with user-controlled paths.
 
+**9) Semantic correctness & fix completeness**
+- **Partial / asymmetric fixes:** when a behavior is changed in one code path, check whether symmetric paths need the same change. Examples: fixing `SYSTEM STOP MERGES` for merge selection but not mutation selection; fixing `ReplicatedMergeTree` but not `SharedMergeTree`. Use `grep` to find all related call sites.
+- **Multi-instance resource selection:** when a PR adds support for multiple instances of a resource (e.g. auxiliary ZooKeeper clusters, secondary storage backends), grep for every place that accesses the resource and verify the correct instance is selected — not just in the newly added code paths.
+
+
 CLICKHOUSE RULES (MANDATORY)
 - **Deletion logging**
   All data deletion events (files, parts, metadata, ZooKeeper/Keeper entries, etc.) must be logged at an appropriate level.
 - **Serialization versioning**
   Any format (columns, aggregates, protocol, settings serialization, replication metadata) must be versioned. Check upgrade/downgrade resilience and the impact on existing clusters.
 - **Core-area scrutiny**
-  Apply stricter scrutiny to query execution, storage engines, replication, Keeper/coordination, system tables, and MergeTree internals.
+  For changes in query execution, storage engines, replication, Keeper/coordination, system tables, and MergeTree internals: read the full modified file (not just the diff context); verify invariants hold under concurrent background operations (merges, mutations, replication); check all error paths including those not touched by the diff; and confirm the change is consistent with symmetric subsystems — e.g. if fixing `ReplicatedMergeTree`, check `SharedMergeTree` and partition-level variants for the same issue.
 - **No test removal**
   Do **not** delete or relax existing tests. New behavior requires **new tests**.
   Tests replace random database names with `default` in output normalization. Do **not** flag hardcoded `default.` or `default_` prefixes in expected test output as incorrect or suggest using `${CLICKHOUSE_DATABASE}` – this is by design.
@@ -175,11 +187,11 @@ CLICKHOUSE RULES (MANDATORY)
 - **No magic constants**
   Avoid magic constants; represent important thresholds or alternative behaviors as settings with sensible defaults.
 - **Backward compatibility**
-  New versions must be configurable to behave like older versions via `compatibility` settings. Ensure `SettingsHistory.cpp` is updated when settings change.
+  New versions must be configurable to behave like older versions via `compatibility` settings. Ensure `SettingsHistory.cpp` is updated when settings change. **New validation / enforcement on existing data:** if a PR adds a check that throws at `CREATE TABLE`, query execution, or server startup, and that check applies to objects created before the PR, it is a backward-incompatibility — the constraint may be violated by legitimate existing setups. It should either be gated behind a setting or applied only to newly created objects.
 - **Safe rollout**
   Ensure incremental rollout is feasible in both OSS and Cloud (feature flags, safe defaults, non-disruptive changes).
 - **Compilation time**
-  ClickHouse has ~10k translation units; compilation time is a key developer productivity concern. Non-trivial function bodies, template definitions, and `constexpr` logic should live in `.cpp` files, not in headers. Do not add heavy `#include` directives to foundational headers (e.g. `Exception.h`, `IColumn.h`, `IDataType.h`, `typeid_cast.h`, `assert_cast.h`, `Context_fwd.h`); prefer forward declarations or `_fwd.h` headers. Use `if constexpr` to avoid instantiating template specializations that are statically unreachable.
+  Follow checklist **7) Compilation time & build impact**. Treat violations there as ClickHouse-rule issues.
 
 SEVERITY MODEL – WHAT DESERVES A COMMENT
 
@@ -216,6 +228,7 @@ Focus on problems — do not describe what was checked and found to be fine. Use
 
 **Missing context** (omit if none)
 - Bullet list of critical info you lacked. Prefix each item with ⚠️ (e.g., ⚠️ No CI logs available, ⚠️ No benchmarks provided).
+- If PR motivation/reason is not clear from the title and description, add a ⚠️ item explicitly stating that motivation is unclear.
 
 **Findings** (omit if no findings)
 - **❌ Blockers**
@@ -226,6 +239,7 @@ Focus on problems — do not describe what was checked and found to be fine. Use
   - Suggested fix.
 - **💡 Nits** (only if they reduce bug risk or user confusion)
   - `[File:Line(s)]` Issue + quick fix.
+  - Use this section for changelog-template quality issues (`Changelog category` mismatch, missing/unclear required `Changelog entry`).
 
 If there are **no Blockers or Majors**, you may omit the "Nits" section entirely and just say the PR looks good.
 
@@ -267,15 +281,3 @@ STYLE & CONDUCT
 - Avoid changing scope: review what's in the PR; suggest follow-ups separately.
 - If you are not reasonably confident a finding is a real issue or meaningful risk, **do not mention it**.
 - When performing a code review, **ignore `/.github/workflows/*` files**.
-
-## Examples
-
-- `/review 98239` — Review PR #98239
-- `/review my-feature-branch` — Review changes on branch vs master
-- `/review HEAD~3..HEAD` — Review the last 3 commits
-
-## Notes
-
-- For large PRs, use Task tool with `subagent_type=Explore` to analyze different subsystems in parallel
-- Read full files when diff context is insufficient to judge correctness
-- Include code suggestions as minimal diffs where helpful

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -187,7 +187,7 @@ CLICKHOUSE RULES (MANDATORY)
 - **No magic constants**
   Avoid magic constants; represent important thresholds or alternative behaviors as settings with sensible defaults.
 - **Backward compatibility**
-  New versions must be configurable to behave like older versions via `compatibility` settings. Ensure `SettingsHistory.cpp` is updated when settings change. **New validation / enforcement on existing data:** if a PR adds a check that throws at `CREATE TABLE`, query execution, or server startup, and that check applies to objects created before the PR, it is a backward-incompatibility — the constraint may be violated by legitimate existing setups. It should either be gated behind a setting or applied only to newly created objects.
+  New versions must be configurable to behave like older versions via `compatibility` settings. Ensure `SettingsChangesHistory.cpp` is updated when settings change. **New validation / enforcement on existing data:** if a PR adds a check that throws at `CREATE TABLE`, query execution, or server startup, and that check applies to objects created before the PR, it is a backward-incompatibility — the constraint may be violated by legitimate existing setups. It should either be gated behind a setting or applied only to newly created objects.
 - **Safe rollout**
   Ensure incremental rollout is feasible in both OSS and Cloud (feature flags, safe defaults, non-disruptive changes).
 - **Compilation time**
@@ -259,8 +259,8 @@ Example:
 | No test removal | ✅ | |
 | Experimental gate | ❌ | New feature `X` has no gate |
 | No magic constants | ✅ | |
-| Backward compatibility | ⚠️ | Default changed without `SettingsHistory.cpp` update |
-| `SettingsHistory.cpp` | ❌ | Not updated |
+| Backward compatibility | ⚠️ | Default changed without `SettingsChangesHistory.cpp` update |
+| `SettingsChangesHistory.cpp` | ❌ | Not updated |
 | Safe rollout | ➖ | |
 | Compilation time | ✅ | |
 


### PR DESCRIPTION
Three independent improvements to the `.claude/` tooling:

**CLAUDE.md:** `fetch_ci_report.js` now accepts GitHub PR URLs directly (not just S3 URLs), with examples for the `--cidb` and `--report` flags. The manual test-prefix detection command is replaced with a reference to the `add-test` script. Stale `learnings.md` instruction and explicit skill-loading list removed.

**review skill:** Expanded concurrency section (TOCTOU, wrong `std::atomic` memory ordering, condition variable misuse); exception safety now covers all control-flow paths and adds a checklist for new throw paths crossing `noexcept` boundaries or destructor callbacks — a pattern that caused silent `std::terminate` in practice (e.g. https://github.com/ClickHouse/ClickHouse/issues/99810). New section on semantic correctness: partial/asymmetric fixes and multi-instance resource selection (e.g. https://github.com/ClickHouse/ClickHouse/issues/99523). Backward compatibility rule extended to cover new validation on existing data. Core-area scrutiny expanded.

**clickhouse-pr-description skill:** Rewrote guidance based on real CHANGELOG entries from 2025-2026 releases. Removed opinionated rules that aren't universal (80-char title limit, anti-AI framing, "minimal is best" for CI PRs, prohibition on `## Motivation`/`## Results` sections). Added note that tooling appends attribution automatically. Confirmation before applying is now opt-in via user memory.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.774`
<!-- ch-version-info:end -->