### PR TITLE
Fix broken docker pull retry in integration tests

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -42,7 +42,7 @@ INFRASTRUCTURE_ERROR_PATTERNS = [
     "OCI runtime create failed",
     "toomanyrequests",
     "pull access denied",
-    "logging_pulling_images",  # docker pull timeout during cluster.start()
+    "Got exception pulling images:",  # docker pull failure during cluster.start()
 ]
 
 

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -42,6 +42,7 @@ INFRASTRUCTURE_ERROR_PATTERNS = [
     "OCI runtime create failed",
     "toomanyrequests",
     "pull access denied",
+    "logging_pulling_images",  # docker pull timeout during cluster.start()
 ]
 
 

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3393,7 +3393,7 @@ class ClickHouseCluster:
                         "Got exception pulling images: %s", kwargs["exception"]
                     )
 
-            retry(log_function=logging_pulling_images, retries=3, delay=8, jitter=8)(run_and_check, images_pull_cmd, nothrow=True, timeout=600)
+            retry(log_function=logging_pulling_images, retries=3, delay=8, jitter=8)(run_and_check, images_pull_cmd, timeout=180)
 
             def logging_compose_up(**kwargs):
                 if "exception" in kwargs:

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3854,7 +3854,7 @@ class ClickHouseCluster:
             if self.with_letsencrypt_pebble and self.base_letsencrypt_pebble_cmd:
                 letsencrypt_pebble_pull_cmd = self.base_letsencrypt_pebble_cmd + ["pull"]
                 retry(log_function=logging_pulling_images, retries=3, delay=8, jitter=8)(
-                    run_and_check, letsencrypt_pebble_pull_cmd, nothrow=True, timeout=600
+                    run_and_check, letsencrypt_pebble_pull_cmd, timeout=180
                 )
                 letsencrypt_pebble_start_cmd = self.base_letsencrypt_pebble_cmd + common_opts
                 run_and_check(letsencrypt_pebble_start_cmd)


### PR DESCRIPTION
Fix docker pull retry in integration tests that was silently broken, causing all tests in a shard to fail on transient Docker Hub issues.

Two bugs fixed:

1. `nothrow=True` in the `docker compose pull` call prevented the retry decorator from seeing failures (non-zero exit codes were swallowed), so retries never happened for rate limiting or network errors.

2. Per-attempt timeout of 600s × 3 retries = 1800s exceeded the 900s pytest-timeout, so at most ~1.5 attempts could run before pytest killed everything. Reduced to 180s per attempt.

With `nothrow=True` removed, exhausted retries now propagate as exceptions to the pytest fixture, making pytest report `outcome="error"` (setup error) instead of `outcome="failed"`, which lets the existing `_is_infrastructure_error` detection correctly classify and skip these.

Also added `logging_pulling_images` to infrastructure error patterns as a safety net.

Example failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99567&sha=6ecd589a3551c7efc362c350c4cf2e08bbb0bdca&name_0=PR&name_1=Integration%20tests%20%28amd_binary%2C%201%2F5%29
https://github.com/ClickHouse/ClickHouse/pull/99567

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.782`
<!-- ch-version-info:end -->