### PR TITLE
distroless: security hardening for docker-init

### DIFF
--- a/docker/keeper/Dockerfile.distroless
+++ b/docker/keeper/Dockerfile.distroless
@@ -136,7 +136,8 @@ RUN mkdir -p \
 # ──────────────────────────────────────────────────────────────────────────────
 # Stage 2: Production distroless image.
 # ──────────────────────────────────────────────────────────────────────────────
-FROM gcr.io/distroless/cc-debian12:nonroot AS production
+# Pinned 2026-03-17
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:7e5b8df2f4d36f5599ef4ab856d7d444922531709becb03f3368c6d797d0a5eb AS production
 
 COPY --from=ch-builder /output/ /
 
@@ -157,7 +158,8 @@ ENTRYPOINT ["/usr/bin/clickhouse", "docker-init", "--keeper"]
 # Stage 3: Debug image — same as production but includes the busybox shell
 #           at /busybox/sh for interactive troubleshooting.
 # ──────────────────────────────────────────────────────────────────────────────
-FROM gcr.io/distroless/cc-debian12:debug-nonroot AS debug
+# Pinned 2026-03-17
+FROM gcr.io/distroless/cc-debian12:debug-nonroot@sha256:641f055b21555d5e4f77b7f1f3caca80840a76c4f7ae5df36a159a436941d2c2 AS debug
 
 COPY --from=ch-builder /output/ /
 

--- a/docker/server/Dockerfile.distroless
+++ b/docker/server/Dockerfile.distroless
@@ -154,7 +154,8 @@ RUN printf '%b' \
 # ──────────────────────────────────────────────────────────────────────────────
 # Stage 2: Production distroless image.
 # ──────────────────────────────────────────────────────────────────────────────
-FROM gcr.io/distroless/cc-debian12:nonroot AS production
+# Pinned 2026-03-17
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:7e5b8df2f4d36f5599ef4ab856d7d444922531709becb03f3368c6d797d0a5eb AS production
 
 COPY --from=ch-builder /output/ /
 
@@ -175,7 +176,8 @@ ENTRYPOINT ["/usr/bin/clickhouse", "docker-init"]
 # Stage 3: Debug image — same as production but includes the busybox shell
 #           at /busybox/sh for interactive troubleshooting.
 # ──────────────────────────────────────────────────────────────────────────────
-FROM gcr.io/distroless/cc-debian12:debug-nonroot AS debug
+# Pinned 2026-03-17
+FROM gcr.io/distroless/cc-debian12:debug-nonroot@sha256:641f055b21555d5e4f77b7f1f3caca80840a76c4f7ae5df36a159a436941d2c2 AS debug
 
 COPY --from=ch-builder /output/ /
 

--- a/programs/docker-init/docker-init.cpp
+++ b/programs/docker-init/docker-init.cpp
@@ -25,6 +25,7 @@
 #include <fcntl.h>
 #include <grp.h>
 #include <pwd.h>
+#include <sys/prctl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -38,6 +39,16 @@ namespace
 /// Path to the clickhouse multi-tool binary, derived from argv[0].
 /// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 std::string g_clickhouse_binary;
+
+/// Remove dynamic linker injection variables from the environment before exec.
+/// Defense in depth: prevents a malicious LD_PRELOAD mounted via a volume from
+/// injecting code into ClickHouse subprocesses.
+void sanitizeEnvironment()
+{
+    for (const char * var : {"LD_PRELOAD", "LD_LIBRARY_PATH", "GLIBC_TUNABLES",
+                              "LD_AUDIT", "LD_DEBUG", "DYLD_INSERT_LIBRARIES"})
+        unsetenv(var); // NOLINT(concurrency-mt-unsafe)
+}
 
 /// Get an environment variable value, returning default_value if not set.
 std::string getEnv(const char * name, const std::string & default_value = "")
@@ -66,6 +77,9 @@ int runCommand(const std::vector<std::string> & args)
 
     if (pid == 0)
     {
+        signal(SIGTERM, SIG_DFL);
+        signal(SIGINT, SIG_DFL);
+        sanitizeEnvironment();
         auto argv = buildArgv(args);
         execvp(argv[0], argv.data());
         _exit(127);
@@ -93,6 +107,9 @@ std::pair<int, std::vector<std::string>> captureCommand(const std::vector<std::s
 
     if (pid == 0)
     {
+        signal(SIGTERM, SIG_DFL);
+        signal(SIGINT, SIG_DFL);
+        sanitizeEnvironment();
         (void)close(pipefd[0]);
         if (dup2(pipefd[1], STDOUT_FILENO) < 0)
             _exit(127);
@@ -161,6 +178,9 @@ int runPipeline(const std::vector<std::string> & lhs, const std::vector<std::str
     }
     if (lhs_pid == 0)
     {
+        signal(SIGTERM, SIG_DFL);
+        signal(SIGINT, SIG_DFL);
+        sanitizeEnvironment();
         (void)close(pipefd[0]);
         (void)dup2(pipefd[1], STDOUT_FILENO);
         (void)close(pipefd[1]);
@@ -180,6 +200,9 @@ int runPipeline(const std::vector<std::string> & lhs, const std::vector<std::str
     }
     if (rhs_pid == 0)
     {
+        signal(SIGTERM, SIG_DFL);
+        signal(SIGINT, SIG_DFL);
+        sanitizeEnvironment();
         (void)close(pipefd[1]);
         (void)dup2(pipefd[0], STDIN_FILENO);
         (void)close(pipefd[0]);
@@ -493,6 +516,9 @@ void initClickHouseDB(
 
     if (server_pid == 0)
     {
+        signal(SIGTERM, SIG_DFL);
+        signal(SIGINT, SIG_DFL);
+        sanitizeEnvironment();
         auto argv = buildArgv(server_args);
         execvp(argv[0], argv.data());
         _exit(127);
@@ -520,6 +546,9 @@ void initClickHouseDB(
         pid_t check_pid = fork();
         if (check_pid == 0)
         {
+            signal(SIGTERM, SIG_DFL);
+            signal(SIGINT, SIG_DFL);
+            sanitizeEnvironment();
             int devnull = open("/dev/null", O_WRONLY);
             if (devnull >= 0)
             {
@@ -744,6 +773,7 @@ int mainEntryClickHouseDockerInit(int argc, char ** argv)
         for (std::size_t i = 1; i < extra_args.size(); ++i)
             exec_cmd.push_back(extra_args[i]);
 
+        sanitizeEnvironment();
         auto exec_argv = buildArgv(exec_cmd);
         execvp(exec_argv[0], exec_argv.data());
         std::cerr << "docker-init: failed to exec '" << extra_args[0] << "': " << strerror(errno) << "\n"; // NOLINT(concurrency-mt-unsafe)
@@ -837,6 +867,8 @@ int mainEntryClickHouseDockerInit(int argc, char ** argv)
         for (const auto & arg : extra_args)
             exec_args.push_back(arg);
 
+        sanitizeEnvironment();
+        prctl(PR_SET_DUMPABLE, 0, 0, 0, 0);
         auto exec_argv = buildArgv(exec_args);
         execvp(exec_argv[0], exec_argv.data());
         std::cerr << "docker-init: failed to exec clickhouse keeper: " << strerror(errno) << "\n"; // NOLINT(concurrency-mt-unsafe)
@@ -916,6 +948,8 @@ int mainEntryClickHouseDockerInit(int argc, char ** argv)
     for (const auto & arg : extra_args)
         exec_args.push_back(arg);
 
+    sanitizeEnvironment();
+    prctl(PR_SET_DUMPABLE, 0, 0, 0, 0);
     auto exec_argv = buildArgv(exec_args);
     execvp(exec_argv[0], exec_argv.data());
     std::cerr << "docker-init: failed to exec clickhouse server: " << strerror(errno) << "\n"; // NOLINT(concurrency-mt-unsafe)


### PR DESCRIPTION
Four defense-in-depth hardening changes for `docker-init` (PID 1 in the distroless image):

**LD_PRELOAD sanitization**: added `sanitizeEnvironment()` that strips `LD_PRELOAD`, `LD_LIBRARY_PATH`, `GLIBC_TUNABLES`, `LD_AUDIT`, `LD_DEBUG`, `DYLD_INSERT_LIBRARIES` before every `execvp` call (all 9 exec sites). Without this, a mounted volume with a malicious `.so` + `LD_PRELOAD` injects code into ClickHouse subprocesses.

**Signal reset in forked children**: added `signal(SIGTERM, SIG_DFL)` and `signal(SIGINT, SIG_DFL)` in the child branch of every fork+exec path (6 sites). Prevents stale parent signal state from misfiring in the narrow fork→exec window.

**prctl(PR_SET_DUMPABLE, 0)** before keeper and server exec. Disables core dumps for docker-init itself before replacing its image.

**Distroless image digest pinning**: both `docker/server/Dockerfile.distroless` and `docker/keeper/Dockerfile.distroless` now pin `gcr.io/distroless/cc-debian12` to SHA256 digests (fetched 2026-03-17) instead of mutable tags.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)