### PR TITLE
Remove `stop_words` param for unicode tokenizer

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/textindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/textindexes.md
@@ -170,7 +170,7 @@ ALTER TABLE table DROP INDEX text_idx;
   Compared to `ngrams(N)`, the `sparseGrams` tokenizer produces variable-length N-grams, allowing for a more flexible representation of the original text.
   For example, `tokenizer = sparseGrams(3, 5, 4)` internally generates 3-, 4-, 5-grams from the input string but only the 4- and 5-grams are returned.
 - `array` performs no tokenization, i.e. every row value is a token (see function [array](/sql-reference/functions/array-functions.md/#array)).
-- `unicode_word` splits strings into tokens using Unicode word boundary rules (similar to UAX #29). ASCII alphanumeric characters and underscores form tokens with connectors (`:` for letters, `.` and `'` for same-type characters). Non-ASCII Unicode characters become single-character tokens. Stop words (configurable, defaults to common CJK punctuation) are skipped. An optional parameter `stop_words` can be specified as an array of strings, for example, `tokenizer = unicode_word(['，', '。'])`.
+- `unicode_word` splits strings into tokens using Unicode word boundary rules (similar to UAX #29). ASCII alphanumeric characters and underscores form tokens with connectors (`:` for letters, `.` and `'` for same-type characters). Non-ASCII Unicode characters become single-character tokens.
 
 All available tokenizers are listed in [system.tokenizers](../../../operations/system-tables/tokenizers.md).
 

--- a/src/Functions/tokens.cpp
+++ b/src/Functions/tokens.cpp
@@ -253,8 +253,6 @@ public:
                     optional_args.emplace_back("ngrams", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isUInt8), isColumnConst, "const UInt8");
                 else if (tokenizer == SplitByStringTokenizer::getExternalName())
                     optional_args.emplace_back("separators", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isArray), isColumnConst, "const Array");
-                else if (tokenizer == UnicodeWordTokenizer::getExternalName())
-                    optional_args.emplace_back("stop_words", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isArray), isColumnConst, "const Array");
             }
             else if (arguments.size() == 4 || arguments.size() == 5)
             {
@@ -305,7 +303,7 @@ Available tokenizers:
 - `ngrams(N)` splits strings into equally large `N`-grams (also see function [ngrams](/sql-reference/functions/splitting-merging-functions.md/#ngrams)). The ngram length can be specified using an optional integer parameter between 1 and 8, for example, `tokens(value, 'ngrams', 3)`. The default ngram size, if not specified explicitly, is 3.
 - `sparseGrams(min_length, max_length, min_cutoff_length)` splits strings into variable-length n-grams of at least `min_length` and at most `max_length` (inclusive) characters (also see function [sparseGrams](/sql-reference/functions/string-functions#sparseGrams)). Unless specified explicitly, `min_length` and `max_length` default to 3 and 100. If parameter `min_cutoff_length` is provided, only n-grams with length greater or equal than `min_cutoff_length` are returned. Compared to `ngrams(N)`, the `sparseGrams` tokenizer produces variable-length N-grams, allowing for a more flexible representation of the original text. For example, `tokens(value, 'sparseGrams', 3, 5, 4)` internally generates 3-, 4-, 5-grams from the input string but only the 4- and 5-grams are returned.
 - `array` performs no tokenization, i.e. every row value is a token (also see function [array](/sql-reference/functions/array-functions.md/#array)).
-- `unicode_word` splits strings into tokens using Unicode word boundary rules (similar to UAX #29). ASCII alphanumeric characters and underscores form tokens with connectors (`:` for letters, `.` and `'` for same-type characters). Non-ASCII Unicode characters become single-character tokens. Stop words (configurable, defaults to common CJK punctuation) are skipped. An optional parameter `stop_words` can be specified as an array of strings, for example, `tokens(value, 'unicode_word', ['，', '。'])`.
+- `unicode_word` splits strings into tokens using Unicode word boundary rules (similar to UAX #29). ASCII alphanumeric characters and underscores form tokens with connectors (`:` for letters, `.` and `'` for same-type characters). Non-ASCII Unicode characters become single-character tokens.
 
 In case of the `splitByString` tokenizer, if the tokens do not form a [prefix code](https://en.wikipedia.org/wiki/Prefix_code), you likely want that the matching prefers longer separators first.
 To do so, pass the separators in order of descending length.
@@ -318,7 +316,6 @@ tokens(value, 'splitByString'[, separators])
 tokens(value, 'ngrams'[, n])
 tokens(value, 'sparseGrams'[, min_length, max_length[, min_cutoff_length]])
 tokens(value, 'array')
-tokens(value, 'unicode_word'[, stop_words])
 )";
     FunctionDocumentation::Arguments arguments = {
         {"value", "The input string.", {"String", "FixedString"}},
@@ -328,7 +325,6 @@ tokens(value, 'unicode_word'[, stop_words])
         {"min_length", "Only relevant if argument `tokenizer` is `sparseGrams`: An optional parameter which defines the minimum gram length, defaults to 3.", {"const UInt8"}},
         {"max_length", "Only relevant if argument `tokenizer` is `sparseGrams`: An optional parameter which defines the maximum gram length, defaults to 100.", {"const UInt8"}},
         {"min_cutoff_length", "Only relevant if argument `tokenizer` is `sparseGrams`: An optional parameter which defines the minimum cutoff length.", {"const UInt8"}},
-        {"stop_words", "Only relevant if argument `tokenizer` is `unicode_word`: An optional parameter which defines the stop words. If not set explicitly, defaults to common CJK punctuation marks.", {"const Array(String)"}},
     };
     FunctionDocumentation::ReturnedValue returned_value = {"Returns the resulting array of tokens from input string.", {"Array"}};
     FunctionDocumentation::Examples examples = {

--- a/src/Functions/tokens.cpp
+++ b/src/Functions/tokens.cpp
@@ -316,6 +316,7 @@ tokens(value, 'splitByString'[, separators])
 tokens(value, 'ngrams'[, n])
 tokens(value, 'sparseGrams'[, min_length, max_length[, min_cutoff_length]])
 tokens(value, 'array')
+tokens(value, 'unicode_word')
 )";
     FunctionDocumentation::Arguments arguments = {
         {"value", "The input string.", {"String", "FixedString"}},

--- a/src/Interpreters/ITokenizer.cpp
+++ b/src/Interpreters/ITokenizer.cpp
@@ -642,10 +642,7 @@ bool UnicodeWordTokenizer::nextInStringLike(const char * data, size_t length, si
                 /// If we consumed a backslash but the escaped char didn't continue the token, back up so the next call
                 /// re-parses `\X` with proper escape context.
                 if (escaped)
-                {
                     --pos;
-                    escaped = false;
-                }
 
                 return true;
             }

--- a/src/Interpreters/ITokenizer.cpp
+++ b/src/Interpreters/ITokenizer.cpp
@@ -496,13 +496,6 @@ bool UnicodeWordTokenizer::nextInString(
             /// Token must contain at least one alphanumeric character
             if (token_alnum_count > 0)
             {
-                /// Check if token is a stop word
-                std::string_view token_view(data + token_start, token_length);
-                if (stop_words.contains(token_view))
-                {
-                    token_length = 0;
-                    continue;
-                }
                 return true;
             }
 
@@ -528,15 +521,6 @@ bool UnicodeWordTokenizer::nextInString(
         {
             pos = length;
             return false;
-        }
-
-        std::string_view utf8_char(data + pos, char_len);
-
-        /// 3a. Stop words: skip
-        if (stop_words.contains(utf8_char))
-        {
-            pos += char_len;
-            continue;
         }
 
         token_start = pos;
@@ -663,10 +647,6 @@ bool UnicodeWordTokenizer::nextInStringLike(const char * data, size_t length, si
                     escaped = false;
                 }
 
-                /// Check if token is a stop word
-                if (stop_words.contains(token))
-                    continue;
-
                 return true;
             }
 
@@ -697,14 +677,6 @@ bool UnicodeWordTokenizer::nextInStringLike(const char * data, size_t length, si
         }
 
         token = {data + pos, char_len};
-
-        /// 3a. Stop words: skip
-        if (stop_words.contains(token))
-        {
-            pos += char_len;
-            escaped = false;
-            continue;
-        }
 
         pos += char_len;
         return true;

--- a/src/Interpreters/ITokenizer.h
+++ b/src/Interpreters/ITokenizer.h
@@ -8,8 +8,6 @@
 #include <base/types.h>
 #include <fmt/format.h>
 
-#include <absl/container/flat_hash_set.h>
-
 #if defined(__SSE2__)
 #  include <emmintrin.h>
 #  if defined(__SSE4_2__)
@@ -381,7 +379,6 @@ private:
 /// 3. Unicode / Chinese
 ///
 /// * Chinese characters are **always single-character tokens**.
-/// * Certain Unicode punctuation (Chinese punctuation) are **stop characters** and **break tokens**.
 ///
 /// 4. Token Validity
 ///
@@ -408,9 +405,8 @@ private:
 /// | `a.b a.3 a. .a ..a.b.3.` | `['a.b','a','3','a','a','a.b','3']`   |
 struct UnicodeWordTokenizer final : public ITokenizerHelper<UnicodeWordTokenizer>
 {
-    explicit UnicodeWordTokenizer(const std::vector<String> & stop_words_)
+    explicit UnicodeWordTokenizer()
         : ITokenizerHelper(Type::UnicodeWord)
-        , stop_words(stop_words_.begin(), stop_words_.end())
     {
     }
 
@@ -432,9 +428,6 @@ struct UnicodeWordTokenizer final : public ITokenizerHelper<UnicodeWordTokenizer
     void substringToTokens(const char * data, size_t length, std::vector<String> & tokens, bool is_prefix, bool is_suffix) const override;
 
     bool supportsStringLike() const override { return true; }
-
-private:
-    absl::flat_hash_set<String> stop_words;
 };
 
 namespace detail

--- a/src/Interpreters/TokenizerFactory.cpp
+++ b/src/Interpreters/TokenizerFactory.cpp
@@ -267,23 +267,8 @@ static void registerTokenizers(TokenizerFactory & factory)
 
     auto unicode_word_creator = [](const FieldVector & args) -> std::unique_ptr<ITokenizer>
     {
-        const auto * tokenizer_name = UnicodeWordTokenizer::getExternalName();
-        assertParamsCount(args.size(), 1, tokenizer_name);
-
-        std::vector<String> stop_words;
-        if (args.empty())
-        {
-            /// Default stop words: common CJK punctuation marks
-            stop_words = {"，", "。", "！", "？", "；", "：", "、", "‘", "’", "“", "”"};
-        }
-        else
-        {
-            auto array = castAs<Array>(args[0], "stop_words");
-            for (const auto & value : array)
-                stop_words.emplace_back(castAs<String>(value, "stop_word"));
-        }
-
-        return std::make_unique<UnicodeWordTokenizer>(stop_words);
+        assertParamsCount(args.size(), 0, UnicodeWordTokenizer::getExternalName());
+        return std::make_unique<UnicodeWordTokenizer>();
     };
 
     factory.registerTokenizer(UnicodeWordTokenizer::getName(), ITokenizer::Type::UnicodeWord, unicode_word_creator);

--- a/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.reference
+++ b/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.reference
@@ -72,3 +72,5 @@ SELECT tokens('测试数据', 'unicode_word'), tokensForLikePattern('%测试，�
 ['测','试','数','据']	['测','试','，','数','据']
 SELECT tokens('test_data', 'unicode_word'), tokensForLikePattern('test\_%data', 'unicode_word');
 ['test_data']	[]
+-- Stop word param (removed for now) followed by escaped character in LIKE pattern (exercises escaped-state reset before stop word check)
+SELECT tokens('and%test', 'unicode_word', ['and']), tokensForLikePattern('and\%test', 'unicode_word', ['and']); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }

--- a/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.reference
+++ b/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.reference
@@ -69,9 +69,6 @@ SELECT tokens('你好世界', 'unicode_word'), tokensForLikePattern('%你好%世
 SELECT tokens('a:bc.d', 'unicode_word'), tokensForLikePattern('a:b%c.d', 'unicode_word');
 ['a:bc.d']	[]
 SELECT tokens('测试数据', 'unicode_word'), tokensForLikePattern('%测试，数据%', 'unicode_word');
-['测','试','数','据']	['测','试','数','据']
+['测','试','数','据']	['测','试','，','数','据']
 SELECT tokens('test_data', 'unicode_word'), tokensForLikePattern('test\_%data', 'unicode_word');
 ['test_data']	[]
--- Stop word followed by escaped character in LIKE pattern (exercises escaped-state reset before stop word check)
-SELECT tokens('and%test', 'unicode_word', ['and']), tokensForLikePattern('and\%test', 'unicode_word', ['and']);
-['test']	['test']

--- a/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.sql
+++ b/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.sql
@@ -45,5 +45,3 @@ SELECT tokens('你好世界', 'unicode_word'), tokensForLikePattern('%你好%世
 SELECT tokens('a:bc.d', 'unicode_word'), tokensForLikePattern('a:b%c.d', 'unicode_word');
 SELECT tokens('测试数据', 'unicode_word'), tokensForLikePattern('%测试，数据%', 'unicode_word');
 SELECT tokens('test_data', 'unicode_word'), tokensForLikePattern('test\_%data', 'unicode_word');
--- Stop word followed by escaped character in LIKE pattern (exercises escaped-state reset before stop word check)
-SELECT tokens('and%test', 'unicode_word', ['and']), tokensForLikePattern('and\%test', 'unicode_word', ['and']);

--- a/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.sql
+++ b/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.sql
@@ -45,3 +45,5 @@ SELECT tokens('你好世界', 'unicode_word'), tokensForLikePattern('%你好%世
 SELECT tokens('a:bc.d', 'unicode_word'), tokensForLikePattern('a:b%c.d', 'unicode_word');
 SELECT tokens('测试数据', 'unicode_word'), tokensForLikePattern('%测试，数据%', 'unicode_word');
 SELECT tokens('test_data', 'unicode_word'), tokensForLikePattern('test\_%data', 'unicode_word');
+-- Stop word param (removed for now) followed by escaped character in LIKE pattern (exercises escaped-state reset before stop word check)
+SELECT tokens('and%test', 'unicode_word', ['and']), tokensForLikePattern('and\%test', 'unicode_word', ['and']); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }

--- a/tests/queries/0_stateless/04038_unicode_word_tokenizer.reference
+++ b/tests/queries/0_stateless/04038_unicode_word_tokenizer.reference
@@ -29,19 +29,10 @@ select tokens('错误503', 'unicode_word');
 ['错','误','503']
 select tokens('taichi张三丰in the house', 'unicode_word');
 ['taichi','张','三','丰','in','the','house']
--- stop words
-select tokens('错误，503', 'unicode_word'); -- default stop words contains common full-width separators
-['错','误','503']
-select tokens('错误and 503', 'unicode_word', ['and']);
-['错','误','503']
 -- edge cases
 select tokens('', 'unicode_word');                               -- empty string
 []
-select tokens('a.b', 'unicode_word', ['.']);                     -- dot as stop word does not suppress connector
-['a.b']
-select tokens('a.b', 'unicode_word', ['a.b']);                   -- dot-connected token as stop word
-[]
-select tokens('test', 'unicode_word', 'not_an_array'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT } -- wrong stop_words type
+select tokens('test', 'unicode_word', 'not_an_array'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 select tokensForLikePattern('%abc', 'unicode_word');            -- wildcard before token
 []
 select tokensForLikePattern('abc%', 'unicode_word');            -- token before wildcard
@@ -68,8 +59,6 @@ select tokensForLikePattern('你', 'unicode_word');              -- single Unico
 ['你']
 select tokensForLikePattern('abc你好', 'unicode_word');         -- ASCII then Unicode
 ['abc','你','好']
-select tokensForLikePattern('，。你好', 'unicode_word');        -- punctuation stop words skipped
-['你','好']
 select tokensForLikePattern('你好%世界', 'unicode_word');       -- Unicode token with wildcards
 ['你','好','世','界']
 set enable_analyzer = 1;

--- a/tests/queries/0_stateless/04038_unicode_word_tokenizer.sql
+++ b/tests/queries/0_stateless/04038_unicode_word_tokenizer.sql
@@ -20,15 +20,9 @@ select tokens($$... .3...a. .a..a.b.c. ...$$, 'unicode_word');
 select tokens('错误503', 'unicode_word');
 select tokens('taichi张三丰in the house', 'unicode_word');
 
--- stop words
-select tokens('错误，503', 'unicode_word'); -- default stop words contains common full-width separators
-select tokens('错误and 503', 'unicode_word', ['and']);
-
 -- edge cases
 select tokens('', 'unicode_word');                               -- empty string
-select tokens('a.b', 'unicode_word', ['.']);                     -- dot as stop word does not suppress connector
-select tokens('a.b', 'unicode_word', ['a.b']);                   -- dot-connected token as stop word
-select tokens('test', 'unicode_word', 'not_an_array'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT } -- wrong stop_words type
+select tokens('test', 'unicode_word', 'not_an_array'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 
 select tokensForLikePattern('%abc', 'unicode_word');            -- wildcard before token
 select tokensForLikePattern('abc%', 'unicode_word');            -- token before wildcard
@@ -44,7 +38,6 @@ select tokensForLikePattern('', 'unicode_word');                -- empty string
 select tokensForLikePattern('%%__', 'unicode_word');            -- only wildcards
 select tokensForLikePattern('你', 'unicode_word');              -- single Unicode char
 select tokensForLikePattern('abc你好', 'unicode_word');         -- ASCII then Unicode
-select tokensForLikePattern('，。你好', 'unicode_word');        -- punctuation stop words skipped
 select tokensForLikePattern('你好%世界', 'unicode_word');       -- Unicode token with wildcards
 
 set enable_analyzer = 1;


### PR DESCRIPTION
Removing stop words parameter of unicode tokenizer. It was decided that we should add it back in as a index-level parameter later. See the PR where it was added: https://github.com/ClickHouse/ClickHouse/pull/99357

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
