### PR TITLE
Add a test for ambiguous column alias with VALUES

### DIFF
--- a/tests/queries/0_stateless/04045_ambiguous_column_alias_values.reference
+++ b/tests/queries/0_stateless/04045_ambiguous_column_alias_values.reference
@@ -1,0 +1,3 @@
+orig	redefined
+redefined	redefined
+orig	redefined

--- a/tests/queries/0_stateless/04045_ambiguous_column_alias_values.sql
+++ b/tests/queries/0_stateless/04045_ambiguous_column_alias_values.sql
@@ -1,3 +1,5 @@
+SET enable_analyzer = 1;
+
 -- https://github.com/ClickHouse/ClickHouse/issues/62566
 SELECT
     *,

--- a/tests/queries/0_stateless/04045_ambiguous_column_alias_values.sql
+++ b/tests/queries/0_stateless/04045_ambiguous_column_alias_values.sql
@@ -1,0 +1,15 @@
+-- https://github.com/ClickHouse/ClickHouse/issues/62566
+SELECT
+    *,
+    'redefined' AS my_field
+FROM VALUES('my_field String', 'orig');
+
+SELECT
+    my_field,
+    'redefined' AS my_field
+FROM VALUES('my_field String', 'orig');
+
+SELECT
+    t.my_field,
+    'redefined' AS my_field
+FROM VALUES('my_field String', 'orig') AS t;


### PR DESCRIPTION
Add a regression test for the issue where `SELECT *, 'redefined' AS my_field FROM VALUES('my_field String', 'orig')` failed with a block structure mismatch error with the analyzer.

Closes https://github.com/ClickHouse/ClickHouse/issues/62566

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.816`
<!-- ch-version-info:end -->