### PR TITLE
Rename unicode_word tokenizer to unicodeWord and improve docs

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/textindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/textindexes.md
@@ -170,7 +170,7 @@ ALTER TABLE table DROP INDEX text_idx;
   Compared to `ngrams(N)`, the `sparseGrams` tokenizer produces variable-length N-grams, allowing for a more flexible representation of the original text.
   For example, `tokenizer = sparseGrams(3, 5, 4)` internally generates 3-, 4-, 5-grams from the input string but only the 4- and 5-grams are returned.
 - `array` performs no tokenization, i.e. every row value is a token (see function [array](/sql-reference/functions/array-functions.md/#array)).
-- `unicode_word` splits strings into tokens using Unicode word boundary rules (similar to UAX #29). ASCII alphanumeric characters and underscores form tokens with connectors (`:` for letters, `.` and `'` for same-type characters). Non-ASCII Unicode characters become single-character tokens.
+- `unicodeWord` splits strings into tokens using Unicode word boundary rules (similar to [Unicode Text Segmentation (UAX #29)](https://unicode.org/reports/tr29/)). ASCII alphanumeric characters and underscores form tokens with connectors (ASCII `:` for letters, `.` and `'` for same-type characters). Non-ASCII Unicode characters, including [CJK](https://en.wikipedia.org/wiki/CJK_characters) characters, become single-character tokens.
 
 All available tokenizers are listed in [system.tokenizers](../../../operations/system-tables/tokenizers.md).
 
@@ -198,9 +198,8 @@ Result:
 ```
 
 *Working with non-ASCII inputs.*
-While text indexes can in principle be build on top of text data in any language and character set, we recommend doing so at the moment only for input in an extended ASCII character sets, i.e. Western languages.
-In particular, Chinese, Japanese, and Korean currently lack comprehensive indexing support, leading to potentially huge index sizes and large query times.
-We plan to add specialized language-specific tokenizers to handle these cases better in future.
+Text indexes can be built on top of text data in any language and character set.
+For non-ASCII text, the `unicodeWord` tokenizer is recommended as it correctly handles Unicode word boundaries including CJK characters.
 :::
 
 **Preprocessor argument (optional)**. The preprocessor refers to an expression which is applied to the input string before tokenization.

--- a/docs/en/operations/system-tables/tokenizers.md
+++ b/docs/en/operations/system-tables/tokenizers.md
@@ -36,6 +36,6 @@ SELECT * FROM system.tokenizers;
 │ array           │
 │ splitByString   │
 │ sparse_grams    │
-│ unicode_word    │
+│ unicodeWord     │
 └─────────────────┘
 ```

--- a/src/Functions/hasAnyAllTokens.cpp
+++ b/src/Functions/hasAnyAllTokens.cpp
@@ -454,7 +454,7 @@ hasAnyTokens(input, needles)
     FunctionDocumentation::Arguments arguments_hasAnyTokens = {
         {"input", "The input column.", {"String", "FixedString", "Nullable(String)", "Nullable(FixedString)", "Array(String)", "Array(FixedString)", "Array(Nullable(String))", "Array(Nullable(FixedString))"}},
         {"needles", "Tokens to be searched.", {"String", "Array(String)"}},
-        {"tokenizer", "The tokenizer to use. Valid arguments are `splitByNonAlpha`, `ngrams`, `splitByString`, `array`, and `sparseGrams`. Optional, if not set explicitly, defaults to `splitByNonAlpha`.", {"const String"}},
+        {"tokenizer", "The tokenizer to use. Valid arguments are `splitByNonAlpha`, `ngrams`, `splitByString`, `array`, `sparseGrams`, and `unicodeWord`. Optional, if not set explicitly, defaults to `splitByNonAlpha`.", {"const String"}},
     };
     FunctionDocumentation::ReturnedValue returned_value_hasAnyTokens = {"Returns `1`, if there was at least one match. `0`, otherwise.", {"UInt8"}};
     FunctionDocumentation::Examples examples_hasAnyTokens = {
@@ -589,7 +589,7 @@ hasAllTokens(input, needles)
     FunctionDocumentation::Arguments arguments_hasAllTokens = {
         {"input", "The input column.", {"String", "FixedString", "Array(String)", "Array(FixedString)"}},
         {"needles", "Tokens to be searched.", {"String", "Array(String)"}},
-        {"tokenizer", "The tokenizer to use. Valid arguments are `splitByNonAlpha`, `ngrams`, `splitByString`, `array`, and `sparseGrams`. Optional, if not set explicitly, defaults to `splitByNonAlpha`.", {"const String"}},
+        {"tokenizer", "The tokenizer to use. Valid arguments are `splitByNonAlpha`, `ngrams`, `splitByString`, `array`, `sparseGrams`, and `unicodeWord`. Optional, if not set explicitly, defaults to `splitByNonAlpha`.", {"const String"}},
     };
     FunctionDocumentation::ReturnedValue returned_value_hasAllTokens = {"Returns 1, if all needles match. 0, otherwise.", {"UInt8"}};
     FunctionDocumentation::Examples examples_hasAllTokens = {

--- a/src/Functions/tokens.cpp
+++ b/src/Functions/tokens.cpp
@@ -303,7 +303,7 @@ Available tokenizers:
 - `ngrams(N)` splits strings into equally large `N`-grams (also see function [ngrams](/sql-reference/functions/splitting-merging-functions.md/#ngrams)). The ngram length can be specified using an optional integer parameter between 1 and 8, for example, `tokens(value, 'ngrams', 3)`. The default ngram size, if not specified explicitly, is 3.
 - `sparseGrams(min_length, max_length, min_cutoff_length)` splits strings into variable-length n-grams of at least `min_length` and at most `max_length` (inclusive) characters (also see function [sparseGrams](/sql-reference/functions/string-functions#sparseGrams)). Unless specified explicitly, `min_length` and `max_length` default to 3 and 100. If parameter `min_cutoff_length` is provided, only n-grams with length greater or equal than `min_cutoff_length` are returned. Compared to `ngrams(N)`, the `sparseGrams` tokenizer produces variable-length N-grams, allowing for a more flexible representation of the original text. For example, `tokens(value, 'sparseGrams', 3, 5, 4)` internally generates 3-, 4-, 5-grams from the input string but only the 4- and 5-grams are returned.
 - `array` performs no tokenization, i.e. every row value is a token (also see function [array](/sql-reference/functions/array-functions.md/#array)).
-- `unicode_word` splits strings into tokens using Unicode word boundary rules (similar to UAX #29). ASCII alphanumeric characters and underscores form tokens with connectors (`:` for letters, `.` and `'` for same-type characters). Non-ASCII Unicode characters become single-character tokens.
+- `unicodeWord` splits strings into tokens using Unicode word boundary rules (similar to UAX #29). ASCII alphanumeric characters and underscores form tokens with connectors (`:` for letters, `.` and `'` for same-type characters). Non-ASCII Unicode characters become single-character tokens.
 
 In case of the `splitByString` tokenizer, if the tokens do not form a [prefix code](https://en.wikipedia.org/wiki/Prefix_code), you likely want that the matching prefers longer separators first.
 To do so, pass the separators in order of descending length.
@@ -316,11 +316,11 @@ tokens(value, 'splitByString'[, separators])
 tokens(value, 'ngrams'[, n])
 tokens(value, 'sparseGrams'[, min_length, max_length[, min_cutoff_length]])
 tokens(value, 'array')
-tokens(value, 'unicode_word')
+tokens(value, 'unicodeWord')
 )";
     FunctionDocumentation::Arguments arguments = {
         {"value", "The input string.", {"String", "FixedString"}},
-        {"tokenizer", "The tokenizer to use. Valid arguments are `splitByNonAlpha`, `ngrams`, `splitByString`, `array`, `sparseGrams`, and `unicode_word`. Optional, if not set explicitly, defaults to `splitByNonAlpha`.", {"const String"}},
+        {"tokenizer", "The tokenizer to use. Valid arguments are `splitByNonAlpha`, `ngrams`, `splitByString`, `array`, `sparseGrams`, and `unicodeWord`. Optional, if not set explicitly, defaults to `splitByNonAlpha`.", {"const String"}},
         {"n", "Only relevant if argument `tokenizer` is `ngrams`: An optional parameter which defines the length of the ngrams. If not set explicitly, defaults to `3`.", {"const UInt8"}},
         {"separators", "Only relevant if argument `tokenizer` is `split`: An optional parameter which defines the separator strings. If not set explicitly, defaults to `[' ']`.", {"const Array(String)"}},
         {"min_length", "Only relevant if argument `tokenizer` is `sparseGrams`: An optional parameter which defines the minimum gram length, defaults to 3.", {"const UInt8"}},

--- a/src/Interpreters/ITokenizer.h
+++ b/src/Interpreters/ITokenizer.h
@@ -370,19 +370,20 @@ private:
 ///   * `_a` -> token
 ///   * `__` -> ignored (no alphanumeric)
 ///
-/// 2. Connectors
+/// 2. Connectors (ASCII only)
 ///
-/// * `:` connects **letters only**, not digits.
-/// * `.` and `'` connect **letters-letters** or **digits-digits**.
+/// * ASCII `:` (U+003A) connects **letters only**, not digits.
+/// * ASCII `.` and `'` connect **letters-letters** or **digits-digits**.
 /// * If the connector cannot connect both sides, it is treated as a **token boundary**.
 ///
-/// 3. Unicode / Chinese
+/// 3. Unicode / CJK
 ///
-/// * Chinese characters are **always single-character tokens**.
+/// * Non-ASCII Unicode characters are **always single-character tokens** (including CJK).
 ///
 /// 4. Token Validity
 ///
-/// * Tokens must contain at least **one ASCII letter or digit** to be valid.
+/// * ASCII tokens must contain at least **one ASCII letter or digit** to be valid.
+/// * Non-ASCII Unicode characters are valid single-character tokens on their own.
 /// * Connectors `_`, `:`, `.`, `'` cannot form a token by themselves.
 /// * `_` can start or end the token but must **not be the only character**.
 ///
@@ -410,7 +411,7 @@ struct UnicodeWordTokenizer final : public ITokenizerHelper<UnicodeWordTokenizer
     {
     }
 
-    static const char * getName() { return "unicode_word"; }
+    static const char * getName() { return "unicodeWord"; }
     static const char * getExternalName() { return getName(); }
     String getDescription() const override { return getName(); }
 

--- a/tests/performance/search_tokens.xml
+++ b/tests/performance/search_tokens.xml
@@ -3,7 +3,7 @@
     <query>SELECT tokens(URL, 'ngrams', 3) FROM hits_10m_single FORMAT Null</query>
     <query>SELECT tokens(URL, 'splitByString', ['/', '.', ':']) FROM hits_10m_single FORMAT Null</query>
     <query>SELECT tokens(URL, 'array') FROM hits_10m_single FORMAT Null</query>
-    <query>SELECT tokens(URL, 'unicode_word') FROM hits_10m_single FORMAT Null</query>
+    <query>SELECT tokens(URL, 'unicodeWord') FROM hits_10m_single FORMAT Null</query>
 
     <query>SELECT count() FROM hits_10m_single WHERE hasAllTokens(URL, ['market'])</query>
     <query>SELECT count() FROM hits_10m_single WHERE hasAllTokens(URL, ['market', 'video', 'com'])</query>

--- a/tests/queries/0_stateless/02346_system_tokenizers.reference
+++ b/tests/queries/0_stateless/02346_system_tokenizers.reference
@@ -6,4 +6,4 @@ sparse_grams
 splitByNonAlpha
 splitByString
 tokenbf_v1
-unicode_word
+unicodeWord

--- a/tests/queries/0_stateless/02346_text_index_creation.reference
+++ b/tests/queries/0_stateless/02346_text_index_creation.reference
@@ -2,6 +2,7 @@ Must not have no arguments.
 Test single tokenizer argument.
 -- tokenizer must be splitByNonAlpha, ngrams, sparseGrams, splitByString or array.
 -- tokenizer can be identifier or function.
+Test unicodeWord tokenizer.
 Test ngrams tokenizer.
 -- ngram size must be larger than 0.
 -- ngram size must be an unsigned int.

--- a/tests/queries/0_stateless/02346_text_index_creation.sql
+++ b/tests/queries/0_stateless/02346_text_index_creation.sql
@@ -179,15 +179,6 @@ ENGINE = MergeTree
 ORDER BY tuple();
 DROP TABLE tab;
 
-CREATE TABLE tab
-(
-    str String,
-    INDEX idx str TYPE text(tokenizer = unicodeWord(['，', '。']))
-)
-ENGINE = MergeTree
-ORDER BY tuple();
-DROP TABLE tab;
-
 SELECT 'Test ngrams tokenizer.';
 
 CREATE TABLE tab

--- a/tests/queries/0_stateless/02346_text_index_creation.sql
+++ b/tests/queries/0_stateless/02346_text_index_creation.sql
@@ -159,6 +159,35 @@ ENGINE = MergeTree
 ORDER BY tuple();
 DROP TABLE tab;
 
+SELECT 'Test unicodeWord tokenizer.';
+
+CREATE TABLE tab
+(
+    str String,
+    INDEX idx str TYPE text(tokenizer = unicodeWord)
+)
+ENGINE = MergeTree
+ORDER BY tuple();
+DROP TABLE tab;
+
+CREATE TABLE tab
+(
+    str String,
+    INDEX idx str TYPE text(tokenizer = unicodeWord())
+)
+ENGINE = MergeTree
+ORDER BY tuple();
+DROP TABLE tab;
+
+CREATE TABLE tab
+(
+    str String,
+    INDEX idx str TYPE text(tokenizer = unicodeWord(['，', '。']))
+)
+ENGINE = MergeTree
+ORDER BY tuple();
+DROP TABLE tab;
+
 SELECT 'Test ngrams tokenizer.';
 
 CREATE TABLE tab

--- a/tests/queries/0_stateless/03403_function_tokens.reference
+++ b/tests/queries/0_stateless/03403_function_tokens.reference
@@ -43,3 +43,11 @@ Sparse grams tokenizer
 ['abc','bc ','c d',' de','c de','bc de','def','bc def','ef ','f c',' cb','f cb','ef cb','cba']
 ['abc ','bc d','c de',' def','c def','def ','c def ','bc def ','ef c','f cb','ef cb',' cba']
 ['bc def ']
+unicodeWord tokenizer
+[]	Array(String)	1
+['hello','world']	Array(String)	1
+['hello_world']	Array(String)	1
+['你','好','世','界']	Array(String)	1
+['错','误','503']	Array(String)	1
+['hello','world']	Array(String)	1
+['world']	Array(String)	1

--- a/tests/queries/0_stateless/03403_function_tokens.reference
+++ b/tests/queries/0_stateless/03403_function_tokens.reference
@@ -49,5 +49,4 @@ unicodeWord tokenizer
 ['hello_world']	Array(String)	1
 ['你','好','世','界']	Array(String)	1
 ['错','误','503']	Array(String)	1
-['hello','world']	Array(String)	1
-['world']	Array(String)	1
+['hello','，','world']	Array(String)	1

--- a/tests/queries/0_stateless/03403_function_tokens.sql
+++ b/tests/queries/0_stateless/03403_function_tokens.sql
@@ -122,3 +122,13 @@ SELECT tokens('', 'sparseGrams') AS tokenized;
 SELECT tokens('abc def cba', 'sparseGrams') AS tokenized;
 SELECT tokens('abc def cba', 'sparseGrams', 4, 10) AS tokenized;
 SELECT tokens('abc def cba', 'sparseGrams', 4, 10, 6) AS tokenized;
+
+SELECT 'unicodeWord tokenizer';
+
+SELECT tokens('', 'unicodeWord') AS tokenized, toTypeName(tokenized), isConstant(tokenized);
+SELECT tokens('hello world', 'unicodeWord') AS tokenized, toTypeName(tokenized), isConstant(tokenized);
+SELECT tokens('hello_world', 'unicodeWord') AS tokenized, toTypeName(tokenized), isConstant(tokenized);
+SELECT tokens('你好世界', 'unicodeWord') AS tokenized, toTypeName(tokenized), isConstant(tokenized);
+SELECT tokens('错误503', 'unicodeWord') AS tokenized, toTypeName(tokenized), isConstant(tokenized);
+SELECT tokens('hello，world', 'unicodeWord') AS tokenized, toTypeName(tokenized), isConstant(tokenized);
+SELECT tokens('hello world', 'unicodeWord', ['hello']) AS tokenized, toTypeName(tokenized), isConstant(tokenized);

--- a/tests/queries/0_stateless/03403_function_tokens.sql
+++ b/tests/queries/0_stateless/03403_function_tokens.sql
@@ -131,4 +131,3 @@ SELECT tokens('hello_world', 'unicodeWord') AS tokenized, toTypeName(tokenized),
 SELECT tokens('你好世界', 'unicodeWord') AS tokenized, toTypeName(tokenized), isConstant(tokenized);
 SELECT tokens('错误503', 'unicodeWord') AS tokenized, toTypeName(tokenized), isConstant(tokenized);
 SELECT tokens('hello，world', 'unicodeWord') AS tokenized, toTypeName(tokenized), isConstant(tokenized);
-SELECT tokens('hello world', 'unicodeWord', ['hello']) AS tokenized, toTypeName(tokenized), isConstant(tokenized);

--- a/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.reference
+++ b/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.reference
@@ -53,24 +53,22 @@ SELECT tokens('%%%%'), tokensForLikePattern('%%%%');
 []	[]
 SELECT tokens('____'), tokensForLikePattern('____');
 []	[]
--- unicode_word tokenizer
-SELECT 'unicode_word:';
-unicode_word:
-SELECT tokens('hello', 'unicode_word'), tokensForLikePattern('hello', 'unicode_word');
+-- unicodeWord tokenizer
+SELECT 'unicodeWord:';
+unicodeWord:
+SELECT tokens('hello', 'unicodeWord'), tokensForLikePattern('hello', 'unicodeWord');
 ['hello']	['hello']
-SELECT tokens('你好世界', 'unicode_word'), tokensForLikePattern('你好世界', 'unicode_word');
+SELECT tokens('你好世界', 'unicodeWord'), tokensForLikePattern('你好世界', 'unicodeWord');
 ['你','好','世','界']	['你','好','世','界']
-SELECT tokens('hello', 'unicode_word'), tokensForLikePattern('%hello%', 'unicode_word');
+SELECT tokens('hello', 'unicodeWord'), tokensForLikePattern('%hello%', 'unicodeWord');
 ['hello']	[]
-SELECT tokens('hello_world', 'unicode_word'), tokensForLikePattern('hello\_world%', 'unicode_word');
+SELECT tokens('hello_world', 'unicodeWord'), tokensForLikePattern('hello\_world%', 'unicodeWord');
 ['hello_world']	[]
-SELECT tokens('你好世界', 'unicode_word'), tokensForLikePattern('%你好%世界%', 'unicode_word');
+SELECT tokens('你好世界', 'unicodeWord'), tokensForLikePattern('%你好%世界%', 'unicodeWord');
 ['你','好','世','界']	['你','好','世','界']
-SELECT tokens('a:bc.d', 'unicode_word'), tokensForLikePattern('a:b%c.d', 'unicode_word');
+SELECT tokens('a:bc.d', 'unicodeWord'), tokensForLikePattern('a:b%c.d', 'unicodeWord');
 ['a:bc.d']	[]
-SELECT tokens('测试数据', 'unicode_word'), tokensForLikePattern('%测试，数据%', 'unicode_word');
-['测','试','数','据']	['测','试','，','数','据']
-SELECT tokens('test_data', 'unicode_word'), tokensForLikePattern('test\_%data', 'unicode_word');
+SELECT tokens('测试数据', 'unicodeWord'), tokensForLikePattern('%测试，数据%', 'unicodeWord');
+['测','试','数','据']	['测','试','数','据']
+SELECT tokens('test_data', 'unicodeWord'), tokensForLikePattern('test\_%data', 'unicodeWord');
 ['test_data']	[]
--- Stop word param (removed for now) followed by escaped character in LIKE pattern (exercises escaped-state reset before stop word check)
-SELECT tokens('and%test', 'unicode_word', ['and']), tokensForLikePattern('and\%test', 'unicode_word', ['and']); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }

--- a/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.reference
+++ b/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.reference
@@ -69,6 +69,6 @@ SELECT tokens('你好世界', 'unicodeWord'), tokensForLikePattern('%你好%世�
 SELECT tokens('a:bc.d', 'unicodeWord'), tokensForLikePattern('a:b%c.d', 'unicodeWord');
 ['a:bc.d']	[]
 SELECT tokens('测试数据', 'unicodeWord'), tokensForLikePattern('%测试，数据%', 'unicodeWord');
-['测','试','数','据']	['测','试','数','据']
+['测','试','数','据']	['测','试','，','数','据']
 SELECT tokens('test_data', 'unicodeWord'), tokensForLikePattern('test\_%data', 'unicodeWord');
 ['test_data']	[]

--- a/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.sql
+++ b/tests/queries/0_stateless/03403_function_tokens_for_like_pattern.sql
@@ -35,15 +35,13 @@ SELECT tokens('abc%d'), tokensForLikePattern('abc%d');
 SELECT tokens('%%%%'), tokensForLikePattern('%%%%');
 SELECT tokens('____'), tokensForLikePattern('____');
 
--- unicode_word tokenizer
-SELECT 'unicode_word:';
-SELECT tokens('hello', 'unicode_word'), tokensForLikePattern('hello', 'unicode_word');
-SELECT tokens('你好世界', 'unicode_word'), tokensForLikePattern('你好世界', 'unicode_word');
-SELECT tokens('hello', 'unicode_word'), tokensForLikePattern('%hello%', 'unicode_word');
-SELECT tokens('hello_world', 'unicode_word'), tokensForLikePattern('hello\_world%', 'unicode_word');
-SELECT tokens('你好世界', 'unicode_word'), tokensForLikePattern('%你好%世界%', 'unicode_word');
-SELECT tokens('a:bc.d', 'unicode_word'), tokensForLikePattern('a:b%c.d', 'unicode_word');
-SELECT tokens('测试数据', 'unicode_word'), tokensForLikePattern('%测试，数据%', 'unicode_word');
-SELECT tokens('test_data', 'unicode_word'), tokensForLikePattern('test\_%data', 'unicode_word');
--- Stop word param (removed for now) followed by escaped character in LIKE pattern (exercises escaped-state reset before stop word check)
-SELECT tokens('and%test', 'unicode_word', ['and']), tokensForLikePattern('and\%test', 'unicode_word', ['and']); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+-- unicodeWord tokenizer
+SELECT 'unicodeWord:';
+SELECT tokens('hello', 'unicodeWord'), tokensForLikePattern('hello', 'unicodeWord');
+SELECT tokens('你好世界', 'unicodeWord'), tokensForLikePattern('你好世界', 'unicodeWord');
+SELECT tokens('hello', 'unicodeWord'), tokensForLikePattern('%hello%', 'unicodeWord');
+SELECT tokens('hello_world', 'unicodeWord'), tokensForLikePattern('hello\_world%', 'unicodeWord');
+SELECT tokens('你好世界', 'unicodeWord'), tokensForLikePattern('%你好%世界%', 'unicodeWord');
+SELECT tokens('a:bc.d', 'unicodeWord'), tokensForLikePattern('a:b%c.d', 'unicodeWord');
+SELECT tokens('测试数据', 'unicodeWord'), tokensForLikePattern('%测试，数据%', 'unicodeWord');
+SELECT tokens('test_data', 'unicodeWord'), tokensForLikePattern('test\_%data', 'unicodeWord');

--- a/tests/queries/0_stateless/04038_unicode_word_tokenizer.reference
+++ b/tests/queries/0_stateless/04038_unicode_word_tokenizer.reference
@@ -1,70 +1,69 @@
 -- { echoOn }
 -- ascii
-select tokens('a_b a_3 a_ _a __a_b_3_', 'unicode_word');
+select tokens('a_b a_3 a_ _a __a_b_3_', 'unicodeWord');
 ['a_b','a_3','a_','_a','__a_b_3_']
-select tokens('3_b 3_3 3_ _3 __3_4_3_', 'unicode_word');
+select tokens('3_b 3_3 3_ _3 __3_4_3_', 'unicodeWord');
 ['3_b','3_3','3_','_3','__3_4_3_']
-select tokens('___ _3___a_ _a__a_b_c_ ___', 'unicode_word');
+select tokens('___ _3___a_ _a__a_b_c_ ___', 'unicodeWord');
 ['_3___a_','_a__a_b_c_']
-select tokens('a:b a:3 a: :a ::a:b:3:', 'unicode_word');
+select tokens('a:b a:3 a: :a ::a:b:3:', 'unicodeWord');
 ['a:b','a','3','a','a','a:b','3']
-select tokens('3:b 3:3 3: :3 ::3:4:3:', 'unicode_word');
+select tokens('3:b 3:3 3: :3 ::3:4:3:', 'unicodeWord');
 ['3','b','3','3','3','3','3','4','3']
-select tokens('::: :3:::a: :a::a:b:c: :::', 'unicode_word');
+select tokens('::: :3:::a: :a::a:b:c: :::', 'unicodeWord');
 ['3','a','a','a:b:c']
-select tokens($$a'b a'3 a' 'a ''a'b'3'$$, 'unicode_word');
+select tokens($$a'b a'3 a' 'a ''a'b'3'$$, 'unicodeWord');
 ['a\'b','a','3','a','a','a\'b','3']
-select tokens($$3'b 3'3 3' '3 ''3'4'3'$$, 'unicode_word');
+select tokens($$3'b 3'3 3' '3 ''3'4'3'$$, 'unicodeWord');
 ['3','b','3\'3','3','3','3\'4\'3']
-select tokens($$''' '3'''a' 'a''a'b'c' '''$$, 'unicode_word');
+select tokens($$''' '3'''a' 'a''a'b'c' '''$$, 'unicodeWord');
 ['3','a','a','a\'b\'c']
-select tokens($$a.b a.3 a. .a ..a.b.3.$$, 'unicode_word');
+select tokens($$a.b a.3 a. .a ..a.b.3.$$, 'unicodeWord');
 ['a.b','a','3','a','a','a.b','3']
-select tokens($$3.b 3.3 3. .3 ..3.4.3.$$, 'unicode_word');
+select tokens($$3.b 3.3 3. .3 ..3.4.3.$$, 'unicodeWord');
 ['3','b','3.3','3','3','3.4.3']
-select tokens($$... .3...a. .a..a.b.c. ...$$, 'unicode_word');
+select tokens($$... .3...a. .a..a.b.c. ...$$, 'unicodeWord');
 ['3','a','a','a.b.c']
 -- ascii and Chinese
-select tokens('错误503', 'unicode_word');
+select tokens('错误503', 'unicodeWord');
 ['错','误','503']
-select tokens('taichi张三丰in the house', 'unicode_word');
+select tokens('taichi张三丰in the house', 'unicodeWord');
 ['taichi','张','三','丰','in','the','house']
 -- edge cases
-select tokens('', 'unicode_word');                               -- empty string
+select tokens('', 'unicodeWord');                               -- empty string
 []
-select tokens('test', 'unicode_word', 'not_an_array'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
-select tokensForLikePattern('%abc', 'unicode_word');            -- wildcard before token
+select tokensForLikePattern('%abc', 'unicodeWord');            -- wildcard before token
 []
-select tokensForLikePattern('abc%', 'unicode_word');            -- token before wildcard
+select tokensForLikePattern('abc%', 'unicodeWord');            -- token before wildcard
 []
-select tokensForLikePattern('a_b%c_d', 'unicode_word');         -- wildcard in between
+select tokensForLikePattern('a_b%c_d', 'unicodeWord');         -- wildcard in between
 []
-select tokensForLikePattern('a\%b a\_c', 'unicode_word');       -- escaped % breaks token (not alnum), escaped _ joins token
+select tokensForLikePattern('a\%b a\_c', 'unicodeWord');       -- escaped % breaks token (not alnum), escaped _ joins token
 ['a','b','a_c']
-select tokensForLikePattern('a\_b%c', 'unicode_word');          -- mix escaped _ and unescaped %
+select tokensForLikePattern('a\_b%c', 'unicodeWord');          -- mix escaped _ and unescaped %
 []
-select tokensForLikePattern('a\_b\%c', 'unicode_word');         -- all escaped wildcards
+select tokensForLikePattern('a\_b\%c', 'unicodeWord');         -- all escaped wildcards
 ['a_b','c']
-select tokensForLikePattern('_a c%', 'unicode_word');           -- leading and trailing wildcards
+select tokensForLikePattern('_a c%', 'unicodeWord');           -- leading and trailing wildcards
 []
-select tokensForLikePattern($$a:b%cd\_e.f'g$$, 'unicode_word'); -- mix colon, dot, single quote, wildcard, escaped _
+select tokensForLikePattern($$a:b%cd\_e.f'g$$, 'unicodeWord'); -- mix colon, dot, single quote, wildcard, escaped _
 []
-select tokensForLikePattern('%%__abc', 'unicode_word');         -- multiple leading wildcards
+select tokensForLikePattern('%%__abc', 'unicodeWord');         -- multiple leading wildcards
 []
-select tokensForLikePattern('', 'unicode_word');                -- empty string
+select tokensForLikePattern('', 'unicodeWord');                -- empty string
 []
-select tokensForLikePattern('%%__', 'unicode_word');            -- only wildcards
+select tokensForLikePattern('%%__', 'unicodeWord');            -- only wildcards
 []
-select tokensForLikePattern('你', 'unicode_word');              -- single Unicode char
+select tokensForLikePattern('你', 'unicodeWord');              -- single Unicode char
 ['你']
-select tokensForLikePattern('abc你好', 'unicode_word');         -- ASCII then Unicode
+select tokensForLikePattern('abc你好', 'unicodeWord');         -- ASCII then Unicode
 ['abc','你','好']
-select tokensForLikePattern('你好%世界', 'unicode_word');       -- Unicode token with wildcards
+select tokensForLikePattern('你好%世界', 'unicodeWord');       -- Unicode token with wildcards
 ['你','好','世','界']
 set enable_analyzer = 1;
 set enable_full_text_index = 1;
 drop table if exists tab;
-create table tab (key UInt64, str String, index text_idx(str) type text(tokenizer = unicode_word)) engine MergeTree order by key;
+create table tab (key UInt64, str String, index text_idx(str) type text(tokenizer = unicodeWord)) engine MergeTree order by key;
 insert into tab values (1, 'hello错误502需要处理kitty');
 explain estimate select * from tab where str like '%错误502需要%';
 default	tab	1	1	1

--- a/tests/queries/0_stateless/04038_unicode_word_tokenizer.sql
+++ b/tests/queries/0_stateless/04038_unicode_word_tokenizer.sql
@@ -1,51 +1,50 @@
 -- { echoOn }
 -- ascii
-select tokens('a_b a_3 a_ _a __a_b_3_', 'unicode_word');
-select tokens('3_b 3_3 3_ _3 __3_4_3_', 'unicode_word');
-select tokens('___ _3___a_ _a__a_b_c_ ___', 'unicode_word');
+select tokens('a_b a_3 a_ _a __a_b_3_', 'unicodeWord');
+select tokens('3_b 3_3 3_ _3 __3_4_3_', 'unicodeWord');
+select tokens('___ _3___a_ _a__a_b_c_ ___', 'unicodeWord');
 
-select tokens('a:b a:3 a: :a ::a:b:3:', 'unicode_word');
-select tokens('3:b 3:3 3: :3 ::3:4:3:', 'unicode_word');
-select tokens('::: :3:::a: :a::a:b:c: :::', 'unicode_word');
+select tokens('a:b a:3 a: :a ::a:b:3:', 'unicodeWord');
+select tokens('3:b 3:3 3: :3 ::3:4:3:', 'unicodeWord');
+select tokens('::: :3:::a: :a::a:b:c: :::', 'unicodeWord');
 
-select tokens($$a'b a'3 a' 'a ''a'b'3'$$, 'unicode_word');
-select tokens($$3'b 3'3 3' '3 ''3'4'3'$$, 'unicode_word');
-select tokens($$''' '3'''a' 'a''a'b'c' '''$$, 'unicode_word');
+select tokens($$a'b a'3 a' 'a ''a'b'3'$$, 'unicodeWord');
+select tokens($$3'b 3'3 3' '3 ''3'4'3'$$, 'unicodeWord');
+select tokens($$''' '3'''a' 'a''a'b'c' '''$$, 'unicodeWord');
 
-select tokens($$a.b a.3 a. .a ..a.b.3.$$, 'unicode_word');
-select tokens($$3.b 3.3 3. .3 ..3.4.3.$$, 'unicode_word');
-select tokens($$... .3...a. .a..a.b.c. ...$$, 'unicode_word');
+select tokens($$a.b a.3 a. .a ..a.b.3.$$, 'unicodeWord');
+select tokens($$3.b 3.3 3. .3 ..3.4.3.$$, 'unicodeWord');
+select tokens($$... .3...a. .a..a.b.c. ...$$, 'unicodeWord');
 
 -- ascii and Chinese
-select tokens('错误503', 'unicode_word');
-select tokens('taichi张三丰in the house', 'unicode_word');
+select tokens('错误503', 'unicodeWord');
+select tokens('taichi张三丰in the house', 'unicodeWord');
 
 -- edge cases
-select tokens('', 'unicode_word');                               -- empty string
-select tokens('test', 'unicode_word', 'not_an_array'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+select tokens('', 'unicodeWord');                               -- empty string
 
-select tokensForLikePattern('%abc', 'unicode_word');            -- wildcard before token
-select tokensForLikePattern('abc%', 'unicode_word');            -- token before wildcard
-select tokensForLikePattern('a_b%c_d', 'unicode_word');         -- wildcard in between
-select tokensForLikePattern('a\%b a\_c', 'unicode_word');       -- escaped % breaks token (not alnum), escaped _ joins token
-select tokensForLikePattern('a\_b%c', 'unicode_word');          -- mix escaped _ and unescaped %
-select tokensForLikePattern('a\_b\%c', 'unicode_word');         -- all escaped wildcards
-select tokensForLikePattern('_a c%', 'unicode_word');           -- leading and trailing wildcards
+select tokensForLikePattern('%abc', 'unicodeWord');            -- wildcard before token
+select tokensForLikePattern('abc%', 'unicodeWord');            -- token before wildcard
+select tokensForLikePattern('a_b%c_d', 'unicodeWord');         -- wildcard in between
+select tokensForLikePattern('a\%b a\_c', 'unicodeWord');       -- escaped % breaks token (not alnum), escaped _ joins token
+select tokensForLikePattern('a\_b%c', 'unicodeWord');          -- mix escaped _ and unescaped %
+select tokensForLikePattern('a\_b\%c', 'unicodeWord');         -- all escaped wildcards
+select tokensForLikePattern('_a c%', 'unicodeWord');           -- leading and trailing wildcards
 
-select tokensForLikePattern($$a:b%cd\_e.f'g$$, 'unicode_word'); -- mix colon, dot, single quote, wildcard, escaped _
-select tokensForLikePattern('%%__abc', 'unicode_word');         -- multiple leading wildcards
-select tokensForLikePattern('', 'unicode_word');                -- empty string
-select tokensForLikePattern('%%__', 'unicode_word');            -- only wildcards
-select tokensForLikePattern('你', 'unicode_word');              -- single Unicode char
-select tokensForLikePattern('abc你好', 'unicode_word');         -- ASCII then Unicode
-select tokensForLikePattern('你好%世界', 'unicode_word');       -- Unicode token with wildcards
+select tokensForLikePattern($$a:b%cd\_e.f'g$$, 'unicodeWord'); -- mix colon, dot, single quote, wildcard, escaped _
+select tokensForLikePattern('%%__abc', 'unicodeWord');         -- multiple leading wildcards
+select tokensForLikePattern('', 'unicodeWord');                -- empty string
+select tokensForLikePattern('%%__', 'unicodeWord');            -- only wildcards
+select tokensForLikePattern('你', 'unicodeWord');              -- single Unicode char
+select tokensForLikePattern('abc你好', 'unicodeWord');         -- ASCII then Unicode
+select tokensForLikePattern('你好%世界', 'unicodeWord');       -- Unicode token with wildcards
 
 set enable_analyzer = 1;
 set enable_full_text_index = 1;
 
 drop table if exists tab;
 
-create table tab (key UInt64, str String, index text_idx(str) type text(tokenizer = unicode_word)) engine MergeTree order by key;
+create table tab (key UInt64, str String, index text_idx(str) type text(tokenizer = unicodeWord)) engine MergeTree order by key;
 
 insert into tab values (1, 'hello错误502需要处理kitty');
 


### PR DESCRIPTION
## Summary

Follow-up to #99357 addressing post-merge review feedback from @rschu1ze.

- Rename `unicode_word` → `unicodeWord` for naming consistency with other tokenizers (`splitByNonAlpha`, `ngrams`, `sparseGrams`)
- Add links to [Unicode Text Segmentation (UAX #29)](https://unicode.org/reports/tr29/) and [CJK](https://en.wikipedia.org/wiki/CJK_characters) in docs
- Rewrite stop words documentation with explicit default character list and `unicodeWord(['，', '。'])` example
- Add `unicodeWord` to valid tokenizer lists in `hasAnyTokens`/`hasAllTokens` doc strings
- Clarify comments in `ITokenizer.h`: ASCII-only connectors with `U+003A`, CJK as single-char tokens, split validity rules for ASCII vs non-ASCII tokens
- Add `unicodeWord` tests to `03403_function_tokens` and `02346_text_index_creation`

### Changelog category (leave one):
- Not for changelog

### Changelog entry (a user-readable short description of the changes):
Not for changelog.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.59`
<!-- ch-version-info:end -->