### PR TITLE
Fix false LOGICAL_ERROR in filesystem cache dynamic resize

### DIFF
--- a/src/Interpreters/Cache/LRUFileCachePriority.cpp
+++ b/src/Interpreters/Cache/LRUFileCachePriority.cpp
@@ -28,6 +28,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+    extern const int NOT_ENOUGH_SPACE;
 }
 
 void LRUFileCachePriority::State::add(uint64_t size_, uint64_t elements_, const CacheStateGuard::Lock &)
@@ -551,7 +552,12 @@ bool LRUFileCachePriority::modifySizeLimits(
 
     if (state->getSize(lock) > max_size_ || state->getElementsCount(lock) > max_elements_)
     {
-        throw Exception(ErrorCodes::LOGICAL_ERROR,
+        /// This is not a logical error: during dynamic cache resize with SLRU,
+        /// concurrent `tryIncreasePriority` can promote entries from probationary
+        /// to protected queue between eviction candidate collection and this call,
+        /// causing a sub-queue to temporarily exceed its new limit.
+        /// The caller catches this and retries on the next config reload.
+        throw Exception(ErrorCodes::NOT_ENOUGH_SPACE,
                         "Cannot modify size limits to {} in size and {} in elements: "
                         "not enough space freed. Current size: {}/{}, elements: {}/{} ({})",
                         max_size_, max_elements_, state->getSize(lock), max_size.load(),


### PR DESCRIPTION
During SLRU dynamic resize, concurrent `tryIncreasePriority` can promote entries from probationary to protected queue between eviction candidate collection and `modifySizeLimits` call. This causes a sub-queue to temporarily exceed its new limit, triggering a `LOGICAL_ERROR` exception.

Change the error code to `NOT_ENOUGH_SPACE` since this is an expected race condition, not a logic bug. The caller already catches exceptions and the resize will be retried on the next config reload.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99014&sha=28ffe4d83ba90c515fa8c6cf7e4f41e6088b60b3&name_0=PR&name_1=Stress%20test%20%28amd_debug%29
https://github.com/ClickHouse/ClickHouse/pull/99014

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix false `LOGICAL_ERROR` exception during filesystem cache dynamic resize due to a race condition in SLRU sub-queue promotion.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.70`
<!-- ch-version-info:end -->