### PR TITLE
Improve resilience of submodule checkout in CI

### DIFF
--- a/.github/workflows/retry_infra_failures.yml
+++ b/.github/workflows/retry_infra_failures.yml
@@ -87,7 +87,56 @@ jobs:
               :
             else
               should_rerun=true
-              echo "  Infrastructure failure detected."
+              echo "  Infrastructure failure detected (job-level heuristic)."
+            fi
+
+            # Fetch run metadata once for all checks below
+            run_data=$(gh api "repos/$GH_REPO/actions/runs/$run_id" \
+              --jq '{pr: .pull_requests[0].number, sha: .head_sha}')
+            pr_number=$(echo "$run_data" | jq -r '.pr // empty')
+            run_sha=$(echo "$run_data" | jq -r '.sha')
+
+            # If the job-level heuristic didn't trigger, check Praktika result JSONs
+            # on S3 for failures at the "Checkout Submodules" sub-step (e.g. transient
+            # DNS failures cloning git submodules).
+            if [ "$should_rerun" = "false" ] && [ -n "$verdicts" ] && [ -n "$pr_number" ] && [ -n "$run_sha" ]; then
+              # Get names of failed jobs (excluding pipeline plumbing)
+              failed_job_names=$(echo "$jobs_raw" | jq -r '
+                .jobs[] | select(.conclusion == "failure") |
+                select(.name != "Config Workflow" and .name != "Finish Workflow") |
+                .name
+              ')
+
+              all_checkout_failures=true
+              while IFS= read -r job_name; do
+                [ -z "$job_name" ] && continue
+                # Normalize job name to match Praktika result file naming:
+                # lowercase, replace non-alphanumeric chars with underscore, collapse runs
+                normalized=$(echo "$job_name" | tr '[:upper:]' '[:lower:]' | \
+                  sed 's/[^a-z0-9_]/_/g; s/__*/_/g')
+                result_url="https://s3.amazonaws.com/clickhouse-test-reports/PRs/${pr_number}/${run_sha}/result_${normalized}.json"
+
+                result_json=$(curl -sf --compressed "$result_url" 2>/dev/null || true)
+                if [ -z "$result_json" ]; then
+                  all_checkout_failures=false
+                  break
+                fi
+
+                # Check: all failed sub-results must be "Checkout Submodules"
+                has_non_checkout_failure=$(echo "$result_json" | jq -r '
+                  [.results[] | select(.status == "failure" or .status == "error") |
+                   .name] | map(select(. != "Checkout Submodules")) | length > 0
+                ')
+                if [ "$has_non_checkout_failure" = "true" ]; then
+                  all_checkout_failures=false
+                  break
+                fi
+              done <<< "$failed_job_names"
+
+              if [ "$all_checkout_failures" = "true" ] && [ -n "$failed_job_names" ]; then
+                should_rerun=true
+                echo "  Infrastructure failure detected (submodule checkout failure in Praktika results)."
+              fi
             fi
 
             # Check if "Config Workflow" failed in its "Run" step (e.g. due to
@@ -103,22 +152,15 @@ jobs:
                 ] | first // empty
               ')
 
-              if [ -n "$config_failed_at" ]; then
-                run_data=$(gh api "repos/$GH_REPO/actions/runs/$run_id" \
-                  --jq '{pr: .pull_requests[0].number, sha: .head_sha}')
-                pr_number=$(echo "$run_data" | jq -r '.pr // empty')
-                run_sha=$(echo "$run_data" | jq -r '.sha')
+              if [ -n "$config_failed_at" ] && [ -n "$pr_number" ]; then
+                pr_data=$(gh api "repos/$GH_REPO/pulls/$pr_number" \
+                  --jq '{sha: .head.sha, updated: .updated_at}')
+                pr_sha=$(echo "$pr_data" | jq -r '.sha')
+                pr_updated=$(echo "$pr_data" | jq -r '.updated')
 
-                if [ -n "$pr_number" ]; then
-                  pr_data=$(gh api "repos/$GH_REPO/pulls/$pr_number" \
-                    --jq '{sha: .head.sha, updated: .updated_at}')
-                  pr_sha=$(echo "$pr_data" | jq -r '.sha')
-                  pr_updated=$(echo "$pr_data" | jq -r '.updated')
-
-                  if [ "$run_sha" = "$pr_sha" ] && [[ "$pr_updated" > "$config_failed_at" ]]; then
-                    should_rerun=true
-                    echo "  Config Workflow failed but PR #$pr_number was updated after — rerunning."
-                  fi
+                if [ "$run_sha" = "$pr_sha" ] && [[ "$pr_updated" > "$config_failed_at" ]]; then
+                  should_rerun=true
+                  echo "  Config Workflow failed but PR #$pr_number was updated after — rerunning."
                 fi
               fi
             fi

--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -69,8 +69,8 @@ def clone_submodules():
         # Roll back to 10 if this starts hitting GitHub rate limits.
         command=f"xargs --max-procs={min([Utils.cpu_count(), 20])} --null --no-run-if-empty --max-args=1 git submodule update --depth 1 --single-branch",
         stdin_str="\0".join(submodules_to_update) + "\0",
-        timeout=240,
-        retries=2,
+        timeout=300,
+        retries=3,
         verbose=True,
     )
     # NOTE: the three "git submodule foreach" cleanup commands (reset --hard,


### PR DESCRIPTION
Improve resilience of submodule checkout in CI:

1. Increase retries from 2 to 3 and timeout from 240s to 300s for submodule checkout in the fast test job, matching what build jobs use.

2. Teach the `retry_infra_failures` workflow to detect failures at the `Checkout Submodules` Praktika sub-step by fetching result JSONs from S3. Previously, the workflow only used a job-level heuristic ("Run" step failed in under 2 minutes), which could miss submodule checkout failures that take longer due to retries and DNS timeouts.

Example of the failure: https://github.com/ClickHouse/ClickHouse/pull/99684

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.794`
<!-- ch-version-info:end -->