### PR TITLE
Fix signed integer overflow in timeseries normalizeParameter

### DIFF
--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesHelpers.cpp
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesHelpers.cpp
@@ -40,15 +40,15 @@ Decimal64 normalizeParameter(const std::string & function_name, const std::strin
     {
         auto value = parameter_field.safeGet<DecimalField<Decimal32>>();
         auto value_scale_multiplier = value.getScaleMultiplier();
-        return Decimal64(value.getValue()) / value_scale_multiplier * target_scale_multiplier;
+        return (Decimal128(value.getValue()) / Decimal128(value_scale_multiplier)) * Decimal128(target_scale_multiplier);
     }
     else if (Int64 int_value = 0; parameter_field.tryGet(int_value))
     {
-        return Decimal64(int_value) * target_scale_multiplier;
+        return Decimal128(int_value) * Decimal128(target_scale_multiplier);
     }
     else if (UInt64 uint_value = 0; parameter_field.tryGet(uint_value))
     {
-        return Decimal64(uint_value) * target_scale_multiplier;
+        return Decimal128(uint_value) * Decimal128(target_scale_multiplier);
     }
     else if (String string_value; parameter_field.tryGet(string_value))
     {
@@ -56,7 +56,7 @@ Decimal64 normalizeParameter(const std::string & function_name, const std::strin
         UInt32 scale = target_scale;
         ReadBufferFromString buf(string_value);
         if (tryReadDecimalText(buf, value, 20, scale))
-            return value * DecimalUtils::scaleMultiplier<Decimal64>(scale);
+            return Decimal128(value) * Decimal128(DecimalUtils::scaleMultiplier<Decimal64>(scale));
         else
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
                 "Cannot parse {} parameter for aggregate function {}", parameter_name, function_name);

--- a/tests/queries/0_stateless/04046_fix_timeseries_parameter_overflow.sql
+++ b/tests/queries/0_stateless/04046_fix_timeseries_parameter_overflow.sql
@@ -7,6 +7,6 @@ SET allow_experimental_ts_to_grid_aggregate_function = 1;
 CREATE TABLE ts_data_overflow (timestamp DateTime64(3, 'UTC'), value Float64) ENGINE=MergeTree() ORDER BY tuple();
 INSERT INTO ts_data_overflow VALUES ('2020-01-01 00:00:00.000', 1.0), ('2020-01-01 00:00:01.000', 2.0);
 
-SELECT timeSeriesResampleToGridWithStaleness(100, 150, 9223372036854775806, 50)(timestamp, value) AS res FROM ts_data_overflow FORMAT Null;
+SELECT timeSeriesResampleToGridWithStaleness(100, 150, 9223372036854775806, 50)(timestamp, value) AS res FROM ts_data_overflow FORMAT Null; -- { serverError BAD_ARGUMENTS }
 
 DROP TABLE ts_data_overflow;

--- a/tests/queries/0_stateless/04046_fix_timeseries_parameter_overflow.sql
+++ b/tests/queries/0_stateless/04046_fix_timeseries_parameter_overflow.sql
@@ -1,0 +1,12 @@
+-- Test that extreme parameter values don't cause signed integer overflow in normalizeParameter
+-- Previously, large Int64 values multiplied by the scale multiplier would overflow Decimal64.
+-- https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99724&sha=465742228dbb9152c5c3f98cc28f5249b27f98ab&name_0=PR&name_1=AST%20fuzzer%20%28amd_ubsan%29
+
+SET allow_experimental_ts_to_grid_aggregate_function = 1;
+
+CREATE TABLE ts_data_overflow (timestamp DateTime64(3, 'UTC'), value Float64) ENGINE=MergeTree() ORDER BY tuple();
+INSERT INTO ts_data_overflow VALUES ('2020-01-01 00:00:00.000', 1.0), ('2020-01-01 00:00:01.000', 2.0);
+
+SELECT timeSeriesResampleToGridWithStaleness(100, 150, 9223372036854775806, 50)(timestamp, value) AS res FROM ts_data_overflow FORMAT Null;
+
+DROP TABLE ts_data_overflow;


### PR DESCRIPTION
Fix signed integer overflow in `normalizeParameter` for timeseries aggregate functions. When large parameter values (e.g. `9223372036854775806`) are multiplied by the scale multiplier, the result overflows `Decimal64`. Use `Decimal128` for intermediate computation, matching the approach already used for the `Decimal64` parameter branch.

Found by AST fuzzer (UBSan): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99724&sha=465742228dbb9152c5c3f98cc28f5249b27f98ab&name_0=PR&name_1=AST%20fuzzer%20%28amd_ubsan%29
https://github.com/ClickHouse/ClickHouse/pull/99724

Closes #99878.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.814`
<!-- ch-version-info:end -->