### PR TITLE
Deflaking 02435_rollback_cancelled_queries

### DIFF
--- a/tests/queries/0_stateless/02435_rollback_cancelled_queries.sh
+++ b/tests/queries/0_stateless/02435_rollback_cancelled_queries.sh
@@ -92,8 +92,14 @@ function thread_cancel
         if (( RANDOM % 2 )); then
             SIGNAL="KILL"
         fi
-        PID=$(grep -Fa "$TEST_MARK" /proc/*/cmdline | grep -Fav grep | grep -Eoa "/proc/[0-9]*/cmdline:" | grep -Eo "[0-9]*" | head -1)
-        if [ ! -z "$PID" ]; then kill -s "$SIGNAL" "$PID"; fi
+        # Kill all matching processes, not just the first one. The TYPE=4 insert path wraps clickhouse-client
+        # in `timeout 120`, which forks a child: both the timeout wrapper (lower PID) and the clickhouse-client
+        # (higher PID) contain $TEST_MARK in their cmdlines. Killing only the wrapper (head -1 picks the lower
+        # PID) orphans the client, leaving the pipe write end open and blocking all downstream grep processes
+        # indefinitely.
+        for PID in $(grep -Fa "$TEST_MARK" /proc/*/cmdline 2>/dev/null | grep -Fav grep | grep -Eoa "/proc/[0-9]*/cmdline:" | grep -Eo "[0-9]*"); do
+            kill -s "$SIGNAL" "$PID" 2>/dev/null || true
+        done
         sleep 0.$RANDOM;
     done
 }

--- a/tests/queries/0_stateless/02435_rollback_cancelled_queries.sh
+++ b/tests/queries/0_stateless/02435_rollback_cancelled_queries.sh
@@ -43,7 +43,11 @@ function insert_data
         $CLICKHOUSE_CURL -sS -F 'file=@-' "$CLICKHOUSE_URL&$TRASH_SETTINGS&file_format=TSV&file_types=UInt64" -X POST --form-string 'query=insert into dedup_test select * from file' < $DATA_FILE
     else
         # client will send 1000-rows blocks, server will squash them into 110000-rows blocks (more chances to catch a bug on query cancellation)
-        timeout 120 $CLICKHOUSE_CLIENT --stacktrace --query_id="$ID" --throw_on_unsupported_query_inside_transaction=0 --implicit_transaction="$IMPLICIT" \
+        # Use -k 5s so that SIGKILL is sent 5 seconds after SIGTERM if the client does not exit.
+        # Under ASan, receiving SIGINT while the allocator lock is held causes DoLeakCheck (called from
+        # safeExit via interruptSignalHandler) to deadlock acquiring the same lock. The client then ignores
+        # SIGTERM too, so without -k the timeout wrapper waits forever, keeping the pipe open.
+        timeout -k 5s 120 $CLICKHOUSE_CLIENT --stacktrace --query_id="$ID" --throw_on_unsupported_query_inside_transaction=0 --implicit_transaction="$IMPLICIT" \
             --max_block_size=1000 --max_insert_block_size=1000 -q \
             "${BEGIN}insert into dedup_test settings max_insert_block_size=110000, min_insert_block_size_rows=110000 format TSV$COMMIT" < $DATA_FILE \
             | grep -Fv "Transaction is not in RUNNING state" | grep -Fv "There is no current transaction"


### PR DESCRIPTION
### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

Failure seen here: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99629&sha=latest&name_0=PR&name_1=Stateless+tests+%28amd_asan%2C+distributed+plan%2C+parallel%2C+2%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/99629 

cc @alexey-milovidov you did a fix on it recently, but it is still failing. Hopefully this fixes it.

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.798`
<!-- ch-version-info:end -->