### PR TITLE
Add direct include for getenv usages

### DIFF
--- a/src/Common/EnvironmentChecks.cpp
+++ b/src/Common/EnvironmentChecks.cpp
@@ -9,6 +9,7 @@
 
 #include <tuple>
 
+#include <stdlib.h>
 #include <unistd.h>
 
 namespace


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Trying to build a project with libсxx version between 21st and 22nd leads to an error
```
${root}/clickhouse/src/Common/EnvironmentChecks.cpp:204:34: error: use of undeclared identifier 'getenv'
  204 |         if (const char * value = getenv(var); value && value[0]) // NOLINT(concurrency-mt-unsafe)
      |                                  ^
${root}/clickhouse/src/Common/EnvironmentChecks.cpp:207:17: error: use of undeclared identifier 'setenv'
  207 |             if (setenv(var, "", true)) // NOLINT(concurrency-mt-unsafe) // this is safe if not called concurrently
```

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.644`
<!-- ch-version-info:end -->