### PR TITLE
Fix timeout in `03781_json_max_dynamic_subcolumns_control_on_parsing`

### DIFF
--- a/tests/queries/0_stateless/03781_json_max_dynamic_subcolumns_control_on_parsing.sql
+++ b/tests/queries/0_stateless/03781_json_max_dynamic_subcolumns_control_on_parsing.sql
@@ -1,7 +1,7 @@
 -- Tags: no-msan, no-tsan
 
 drop table if exists test;
-create table test (json JSON) engine=MergeTree order by tuple();
+create table test (json JSON) engine=MergeTree order by tuple() settings index_granularity=8192;
 insert into test select toJSONString(arrayMap(x -> tuple('a' || x, x), range(20))::Map(String, UInt32)) from numbers(1000000) settings max_dynamic_subcolumns_in_json_type_parsing=10;
 select distinct(arrayJoin(JSONDynamicPaths(json))) as path from test order by path;
 drop table test;


### PR DESCRIPTION
Pin `index_granularity=8192` so that randomized MergeTree settings cannot pick a tiny value like 2, which produces 500K granules for the 1M-row insert and causes the test to exceed its 600-second timeout.

The test is about `max_dynamic_subcolumns_in_json_type_parsing`, not granularity behavior, so fixing the granularity is appropriate while still allowing other settings to be randomized.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99119&sha=c8afcf4ba46afd7dc41a6ae09a79127adbe98fca&name_0=PR
https://github.com/ClickHouse/ClickHouse/pull/99119

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
