### PR TITLE
Reduce Keeper memory usage with compact children set

### DIFF
--- a/src/Coordination/CompactChildrenSet.cpp
+++ b/src/Coordination/CompactChildrenSet.cpp
@@ -2,6 +2,7 @@
 
 #include <Common/Exception.h>
 
+#include <base/defines.h>
 #include <memory>
 
 namespace DB
@@ -187,6 +188,7 @@ void CompactChildrenSet::erase(std::string_view child)
         /// The string_view points to arena-owned keys in SnapshotableHashTable
         /// that outlive this set, so it's safe to keep the pointer.
         std::string_view remaining = *set->begin();
+        chassert(!remaining.empty());
         delete set;
         ptr = remaining.data();
         name_size = remaining.size();
@@ -276,7 +278,7 @@ CompactChildrenSet::ConstIterator CompactChildrenSet::end() const
 size_t CompactChildrenSet::heapSizeInBytes() const
 {
     if (isSet())
-        return sizeof(ChildrenSet) + asSet()->size() * sizeof(std::string_view);
+        return sizeof(ChildrenSet) + asSet()->capacity() * sizeof(std::string_view);
     return 0;
 }
 

--- a/src/Coordination/CompactChildrenSet.cpp
+++ b/src/Coordination/CompactChildrenSet.cpp
@@ -1,0 +1,292 @@
+#include <Coordination/CompactChildrenSet.h>
+
+#include <Common/Exception.h>
+
+#include <memory>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
+// --- Iterator implementation ---
+
+CompactChildrenSet::ConstIterator::ConstIterator(std::string_view sv_, bool done_)
+    : set_mode(false), done(done_), sv(sv_)
+{
+}
+
+CompactChildrenSet::ConstIterator::ConstIterator(ChildrenSet::const_iterator set_it_)
+    : set_mode(true), done(false), set_it(set_it_)
+{
+}
+
+CompactChildrenSet::ConstIterator::reference CompactChildrenSet::ConstIterator::operator*() const
+{
+    if (set_mode)
+        return *set_it;
+    return sv;
+}
+
+CompactChildrenSet::ConstIterator::pointer CompactChildrenSet::ConstIterator::operator->() const
+{
+    if (set_mode)
+        return &*set_it;
+    return &sv;
+}
+
+CompactChildrenSet::ConstIterator & CompactChildrenSet::ConstIterator::operator++()
+{
+    if (set_mode)
+        ++set_it;
+    else
+        done = true;
+    return *this;
+}
+
+CompactChildrenSet::ConstIterator CompactChildrenSet::ConstIterator::operator++(int)
+{
+    auto tmp = *this;
+    ++(*this);
+    return tmp;
+}
+
+bool CompactChildrenSet::ConstIterator::operator==(const ConstIterator & other) const
+{
+    if (set_mode != other.set_mode)
+        return false;
+    if (set_mode)
+        return set_it == other.set_it;
+    return done == other.done;
+}
+
+bool CompactChildrenSet::ConstIterator::operator!=(const ConstIterator & other) const
+{
+    return !(*this == other);
+}
+
+// --- CompactChildrenSet implementation ---
+
+CompactChildrenSet::~CompactChildrenSet()
+{
+    if (isSet())
+        delete asSet();
+}
+
+CompactChildrenSet::CompactChildrenSet(const CompactChildrenSet & other)
+{
+    if (other.isSet())
+    {
+        auto * new_set = new ChildrenSet(*other.asSet());
+        ptr = reinterpret_cast<const char *>(new_set);
+        name_size = 0;
+    }
+    else
+    {
+        ptr = other.ptr;
+        name_size = other.name_size;
+    }
+}
+
+CompactChildrenSet & CompactChildrenSet::operator=(const CompactChildrenSet & other)
+{
+    if (this == &other)
+        return *this;
+
+    /// Allocate-then-swap for exception safety (§4.2)
+    if (other.isSet())
+    {
+        auto * new_set = new ChildrenSet(*other.asSet());
+        if (isSet())
+            delete asSet();
+        ptr = reinterpret_cast<const char *>(new_set);
+        name_size = 0;
+    }
+    else
+    {
+        if (isSet())
+            delete asSet();
+        ptr = other.ptr;
+        name_size = other.name_size;
+    }
+    return *this;
+}
+
+CompactChildrenSet::CompactChildrenSet(CompactChildrenSet && other) noexcept
+    : ptr(other.ptr), name_size(other.name_size)
+{
+    other.ptr = nullptr;
+    other.name_size = 0;
+}
+
+CompactChildrenSet & CompactChildrenSet::operator=(CompactChildrenSet && other) noexcept
+{
+    if (this == &other)
+        return *this;
+
+    if (isSet())
+        delete asSet();
+
+    ptr = other.ptr;
+    name_size = other.name_size;
+    other.ptr = nullptr;
+    other.name_size = 0;
+    return *this;
+}
+
+void CompactChildrenSet::insert(std::string_view child)
+{
+    if (child.empty())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Empty child names are not allowed in CompactChildrenSet");
+
+    if (isEmpty())
+    {
+        ptr = child.data();
+        name_size = child.size();
+        return;
+    }
+
+    if (isSingle())
+    {
+        std::string_view existing = asSingle();
+        if (existing == child)
+            return;
+        promoteToSet(existing, child);
+        return;
+    }
+
+    /// Set mode
+    asSet()->insert(child);
+}
+
+void CompactChildrenSet::erase(std::string_view child)
+{
+    if (isEmpty())
+        return;
+
+    if (isSingle())
+    {
+        if (asSingle() == child)
+        {
+            ptr = nullptr;
+            name_size = 0;
+        }
+        return;
+    }
+
+    /// Set mode
+    auto * set = asSet();
+    set->erase(child);
+
+    if (set->size() == 1)
+    {
+        /// Demote to single mode.
+        /// The string_view points to arena-owned keys in SnapshotableHashTable
+        /// that outlive this set, so it's safe to keep the pointer.
+        std::string_view remaining = *set->begin();
+        delete set;
+        ptr = remaining.data();
+        name_size = remaining.size();
+    }
+    else if (set->empty())
+    {
+        delete set;
+        ptr = nullptr;
+        name_size = 0;
+    }
+}
+
+size_t CompactChildrenSet::size() const
+{
+    if (isEmpty())
+        return 0;
+    if (isSingle())
+        return 1;
+    return asSet()->size();
+}
+
+bool CompactChildrenSet::empty() const
+{
+    if (isSet())
+        /// `reserve(n>=2)` on an empty container promotes to set mode with zero elements.
+        /// This is the only way to reach a zero-element set.
+        return asSet()->empty();
+    return isEmpty();
+}
+
+bool CompactChildrenSet::contains(std::string_view child) const
+{
+    if (isEmpty())
+        return false;
+    if (isSingle())
+        return asSingle() == child;
+    return asSet()->contains(child);
+}
+
+void CompactChildrenSet::clear()
+{
+    if (isSet())
+        delete asSet();
+    ptr = nullptr;
+    name_size = 0;
+}
+
+void CompactChildrenSet::reserve(size_t n)
+{
+    if (n <= 1)
+        return;
+
+    if (isSet())
+    {
+        asSet()->reserve(n);
+        return;
+    }
+
+    /// Need to promote to set mode (§4.6)
+    auto set = std::make_unique<ChildrenSet>();
+    if (isSingle())
+        set->insert(asSingle());
+    set->reserve(n);
+    ptr = reinterpret_cast<const char *>(set.release());
+    name_size = 0;
+}
+
+CompactChildrenSet::ConstIterator CompactChildrenSet::begin() const
+{
+    if (isEmpty())
+        return ConstIterator({}, true);
+
+    if (isSingle())
+        return ConstIterator(asSingle(), false);
+
+    return ConstIterator(asSet()->begin());
+}
+
+CompactChildrenSet::ConstIterator CompactChildrenSet::end() const
+{
+    if (isSet())
+        return ConstIterator(asSet()->end());
+
+    return ConstIterator({}, true);
+}
+
+size_t CompactChildrenSet::heapSizeInBytes() const
+{
+    if (isSet())
+        return sizeof(ChildrenSet) + asSet()->size() * sizeof(std::string_view);
+    return 0;
+}
+
+void CompactChildrenSet::promoteToSet(std::string_view existing, std::string_view new_child)
+{
+    auto set = std::make_unique<ChildrenSet>();
+    set->insert(existing);
+    set->insert(new_child);
+    ptr = reinterpret_cast<const char *>(set.release());
+    name_size = 0;
+}
+
+}

--- a/src/Coordination/CompactChildrenSet.h
+++ b/src/Coordination/CompactChildrenSet.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <absl/container/flat_hash_set.h>
+#include <base/StringViewHash.h>
+
+#include <cstddef>
+#include <string_view>
+
+namespace DB
+{
+
+using ChildrenSet = absl::flat_hash_set<std::string_view, StringViewHash>;
+
+/// A compact representation of a set of children for Keeper nodes.
+/// Uses a tagged-pointer scheme to avoid the 32-byte overhead of
+/// absl::flat_hash_set for the common cases of 0 or 1 children.
+///
+/// Three states discriminated by ptr and name_size:
+///   Empty:  ptr == nullptr, name_size == 0
+///   Single: ptr != nullptr, name_size > 0  → string_view{ptr, name_size}
+///   Set:    ptr != nullptr, name_size == 0  → heap-allocated ChildrenSet*
+///
+/// Invariant: ZooKeeper child names are always non-empty,
+/// so (ptr != nullptr, name_size == 0) unambiguously identifies the set state.
+///
+/// Callers must guarantee that all string_view data outlives the container.
+/// In single mode the pointer is stored directly; in set mode, demotion on
+/// erase extracts a string_view before deleting the set. Both cases require
+/// stable underlying storage (e.g. arena-owned keys in SnapshotableHashTable).
+class CompactChildrenSet
+{
+public:
+    class ConstIterator
+    {
+    public:
+        using value_type = std::string_view;
+        using reference = const std::string_view &;
+        using pointer = const std::string_view *;
+        using difference_type = std::ptrdiff_t;
+        using iterator_category = std::forward_iterator_tag;
+
+        ConstIterator() = default;
+
+        reference operator*() const;
+        pointer operator->() const;
+
+        ConstIterator & operator++();
+        ConstIterator operator++(int);
+
+        bool operator==(const ConstIterator & other) const;
+        bool operator!=(const ConstIterator & other) const;
+
+    private:
+        friend class CompactChildrenSet;
+
+        /// Constructor for single/empty mode
+        ConstIterator(std::string_view sv_, bool done_);
+
+        /// Constructor for set mode
+        explicit ConstIterator(ChildrenSet::const_iterator set_it_);
+
+        bool set_mode = false;
+        bool done = true;
+
+        /// Used in single mode: holds its own copy of the string_view
+        std::string_view sv;
+
+        /// Used in set mode
+        ChildrenSet::const_iterator set_it;
+    };
+
+    CompactChildrenSet() = default;
+    ~CompactChildrenSet();
+
+    CompactChildrenSet(const CompactChildrenSet & other);
+    CompactChildrenSet & operator=(const CompactChildrenSet & other);
+
+    CompactChildrenSet(CompactChildrenSet && other) noexcept;
+    CompactChildrenSet & operator=(CompactChildrenSet && other) noexcept;
+
+    void insert(std::string_view child);
+    void erase(std::string_view child);
+    size_t size() const;
+    bool empty() const;
+    bool contains(std::string_view child) const;
+    void clear();
+    void reserve(size_t n);
+
+    ConstIterator begin() const;
+    ConstIterator end() const;
+
+    /// Returns the number of bytes allocated on the heap for this container.
+    /// Zero for empty/single states (inline storage), approximate for set mode.
+    size_t heapSizeInBytes() const;
+
+private:
+    bool isSet() const { return ptr != nullptr && name_size == 0; }
+    bool isSingle() const { return ptr != nullptr && name_size != 0; }
+    bool isEmpty() const { return ptr == nullptr; }
+
+    std::string_view asSingle() const { return {ptr, name_size}; }
+
+    const ChildrenSet * asSet() const
+    {
+        return reinterpret_cast<const ChildrenSet *>(ptr);
+    }
+
+    ChildrenSet * asSet()
+    {
+        return reinterpret_cast<ChildrenSet *>(const_cast<char *>(ptr));
+    }
+
+    void promoteToSet(std::string_view existing, std::string_view new_child);
+
+    const char * ptr = nullptr;
+    size_t name_size = 0;
+};
+
+}

--- a/src/Coordination/CompactChildrenSet.h
+++ b/src/Coordination/CompactChildrenSet.h
@@ -39,7 +39,7 @@ public:
         using difference_type = std::ptrdiff_t;
         using iterator_category = std::forward_iterator_tag;
 
-        ConstIterator() = default;
+        ConstIterator() : sv() {}
 
         reference operator*() const;
         pointer operator->() const;
@@ -62,11 +62,14 @@ public:
         bool set_mode = false;
         bool done = true;
 
-        /// Used in single mode: holds its own copy of the string_view
-        std::string_view sv;
+        union
+        {
+            /// Used in single mode: holds its own copy of the string_view
+            std::string_view sv;
 
-        /// Used in set mode
-        ChildrenSet::const_iterator set_it;
+            /// Used in set mode
+            ChildrenSet::const_iterator set_it;
+        };
     };
 
     CompactChildrenSet() = default;

--- a/src/Coordination/KeeperStorage.cpp
+++ b/src/Coordination/KeeperStorage.cpp
@@ -428,7 +428,7 @@ KeeperMemNode & KeeperMemNode::operator=(KeeperMemNode && other) noexcept
 
     other.stats.data_size = 0;
 
-    static_assert(std::is_nothrow_move_assignable_v<ChildrenSet>);
+    static_assert(std::is_nothrow_move_assignable_v<CompactChildrenSet>);
     children = std::move(other.children);
 
     return *this;
@@ -466,7 +466,7 @@ void KeeperMemNode::setResponseStat(Coordination::Stat & response_stat) const
 
 uint64_t KeeperMemNode::sizeInBytes() const
 {
-    return sizeof(KeeperMemNode) + children.size() * sizeof(std::string_view) + stats.data_size;
+    return sizeof(KeeperMemNode) + children.heapSizeInBytes() + stats.data_size;
 }
 
 void KeeperMemNode::setData(const String & new_data)

--- a/src/Coordination/KeeperStorage.h
+++ b/src/Coordination/KeeperStorage.h
@@ -13,7 +13,7 @@
 
 #include <base/defines.h>
 
-#include <absl/container/flat_hash_set.h>
+#include <Coordination/CompactChildrenSet.h>
 
 #include "config.h"
 #if USE_ROCKSDB
@@ -27,8 +27,6 @@ class KeeperContext;
 using KeeperContextPtr = std::shared_ptr<KeeperContext>;
 
 using ResponseCallback = std::function<void(const Coordination::ZooKeeperResponsePtr &)>;
-using ChildrenSet = absl::flat_hash_set<std::string_view, StringViewHash>;
-
 struct NodeStats
 {
     int64_t czxid{0};
@@ -273,7 +271,7 @@ struct KeeperMemNode
     // move it to the new copy of node
     KeeperMemNode copyFromSnapshotNode();
 private:
-    ChildrenSet children{};
+    CompactChildrenSet children{};
 };
 
 struct KeeperStorageStats
@@ -490,10 +488,14 @@ public:
     using Node = Container::Node;
 
 #if !defined(ADDRESS_SANITIZER) && !defined(MEMORY_SANITIZER)
+    static_assert(sizeof(CompactChildrenSet) == 16);
+    static_assert(sizeof(KeeperMemNode) == 104);
     static_assert(
-        sizeof(ListNode<Node>) <= 144,
-        "std::list node containing ListNode<Node> is > 160 bytes (sizeof(ListNode<Node>) + 16 bytes for pointers) which will increase "
+        sizeof(ListNode<Node>) <= 128,
+        "std::list node containing ListNode<Node> is > 144 bytes (sizeof(ListNode<Node>) + 16 bytes for pointers) which will increase "
         "memory consumption");
+    static_assert(std::is_nothrow_move_assignable_v<CompactChildrenSet>);
+    static_assert(std::is_nothrow_move_constructible_v<CompactChildrenSet>);
 #endif
 
 

--- a/src/Coordination/tests/gtest_compact_children_set.cpp
+++ b/src/Coordination/tests/gtest_compact_children_set.cpp
@@ -334,6 +334,9 @@ TEST(CompactChildrenSet, IteratorPostIncrement)
 
 TEST(CompactChildrenSet, RejectsEmptyChildName)
 {
+#ifndef DEBUG_OR_SANITIZER_BUILD
+    /// `LOGICAL_ERROR` aborts in debug/sanitizer builds, so we can only test
+    /// the throwing path in release builds.
     CompactChildrenSet cs;
     EXPECT_THROW(cs.insert(""), Exception);
 
@@ -347,6 +350,7 @@ TEST(CompactChildrenSet, RejectsEmptyChildName)
 
     /// Container unchanged after rejected inserts
     EXPECT_EQ(cs.size(), 2);
+#endif
 }
 
 TEST(CompactChildrenSet, CopyAssignmentSetToSingle)

--- a/src/Coordination/tests/gtest_compact_children_set.cpp
+++ b/src/Coordination/tests/gtest_compact_children_set.cpp
@@ -199,7 +199,7 @@ TEST(CompactChildrenSet, Clear)
 TEST(CompactChildrenSet, CopyFromEmpty)
 {
     CompactChildrenSet cs;
-    CompactChildrenSet copy(cs);
+    const CompactChildrenSet copy(cs); // NOLINT(performance-unnecessary-copy-initialization) - intentionally testing copy constructor
     EXPECT_TRUE(copy.empty());
 }
 
@@ -208,7 +208,7 @@ TEST(CompactChildrenSet, CopyFromSingle)
     CompactChildrenSet cs;
     cs.insert(CHILD_A);
 
-    CompactChildrenSet copy(cs);
+    const CompactChildrenSet copy(cs);
     EXPECT_EQ(copy.size(), 1);
     EXPECT_TRUE(copy.contains(CHILD_A));
 
@@ -305,7 +305,9 @@ TEST(CompactChildrenSet, IteratorSetMode)
     cs.insert(CHILD_C);
 
     size_t count = 0;
-    bool found_a = false, found_b = false, found_c = false;
+    bool found_a = false;
+    bool found_b = false;
+    bool found_c = false;
     for (const auto & child : cs)
     {
         if (child == CHILD_A) found_a = true;

--- a/src/Coordination/tests/gtest_compact_children_set.cpp
+++ b/src/Coordination/tests/gtest_compact_children_set.cpp
@@ -1,0 +1,481 @@
+#include <gtest/gtest.h>
+#include <Common/Exception.h>
+#include <Coordination/CompactChildrenSet.h>
+#include <string_view>
+
+using namespace DB;
+
+/// We need stable string data that outlives insert/erase operations,
+/// similar to how SnapshotableHashTable's GlobalArena works in production.
+static constexpr std::string_view CHILD_A = "child_a";
+static constexpr std::string_view CHILD_B = "child_b";
+static constexpr std::string_view CHILD_C = "child_c";
+
+TEST(CompactChildrenSet, EmptyState)
+{
+    CompactChildrenSet cs;
+    EXPECT_TRUE(cs.empty());
+    EXPECT_EQ(cs.size(), 0);
+    EXPECT_FALSE(cs.contains(CHILD_A));
+    EXPECT_EQ(cs.begin(), cs.end());
+    EXPECT_EQ(cs.heapSizeInBytes(), 0);
+}
+
+TEST(CompactChildrenSet, EmptyToSingleTransition)
+{
+    CompactChildrenSet cs;
+    cs.insert(CHILD_A);
+    EXPECT_FALSE(cs.empty());
+    EXPECT_EQ(cs.size(), 1);
+    EXPECT_TRUE(cs.contains(CHILD_A));
+    EXPECT_FALSE(cs.contains(CHILD_B));
+    EXPECT_EQ(cs.heapSizeInBytes(), 0);
+
+    /// Iterator should yield exactly one element
+    auto it = cs.begin();
+    EXPECT_NE(it, cs.end());
+    EXPECT_EQ(*it, CHILD_A);
+    ++it;
+    EXPECT_EQ(it, cs.end());
+}
+
+TEST(CompactChildrenSet, SingleToSetPromotion)
+{
+    CompactChildrenSet cs;
+    cs.insert(CHILD_A);
+    cs.insert(CHILD_B);
+    EXPECT_FALSE(cs.empty());
+    EXPECT_EQ(cs.size(), 2);
+    EXPECT_TRUE(cs.contains(CHILD_A));
+    EXPECT_TRUE(cs.contains(CHILD_B));
+    EXPECT_GT(cs.heapSizeInBytes(), 0);
+}
+
+TEST(CompactChildrenSet, DuplicateInsertInSingleMode)
+{
+    CompactChildrenSet cs;
+    cs.insert(CHILD_A);
+    cs.insert(CHILD_A);
+    EXPECT_EQ(cs.size(), 1);
+    EXPECT_EQ(cs.heapSizeInBytes(), 0);
+}
+
+TEST(CompactChildrenSet, DuplicateInsertInSetMode)
+{
+    CompactChildrenSet cs;
+    cs.insert(CHILD_A);
+    cs.insert(CHILD_B);
+    cs.insert(CHILD_A);
+    EXPECT_EQ(cs.size(), 2);
+}
+
+TEST(CompactChildrenSet, SetToSingleDemotion)
+{
+    CompactChildrenSet cs;
+    cs.insert(CHILD_A);
+    cs.insert(CHILD_B);
+    EXPECT_EQ(cs.size(), 2);
+
+    cs.erase(CHILD_A);
+    EXPECT_EQ(cs.size(), 1);
+    EXPECT_FALSE(cs.contains(CHILD_A));
+    EXPECT_TRUE(cs.contains(CHILD_B));
+    /// After demotion, heap allocation is freed
+    EXPECT_EQ(cs.heapSizeInBytes(), 0);
+}
+
+TEST(CompactChildrenSet, SetToEmptyDemotion)
+{
+    CompactChildrenSet cs;
+    cs.insert(CHILD_A);
+    cs.insert(CHILD_B);
+
+    cs.erase(CHILD_A);
+    cs.erase(CHILD_B);
+    EXPECT_TRUE(cs.empty());
+    EXPECT_EQ(cs.size(), 0);
+    EXPECT_EQ(cs.begin(), cs.end());
+}
+
+TEST(CompactChildrenSet, SingleToEmpty)
+{
+    CompactChildrenSet cs;
+    cs.insert(CHILD_A);
+    cs.erase(CHILD_A);
+    EXPECT_TRUE(cs.empty());
+    EXPECT_EQ(cs.size(), 0);
+}
+
+TEST(CompactChildrenSet, EraseNonExistent)
+{
+    CompactChildrenSet cs;
+    /// Erase on empty — no-op
+    cs.erase(CHILD_A);
+    EXPECT_TRUE(cs.empty());
+
+    /// Erase non-matching in single mode — no-op
+    cs.insert(CHILD_A);
+    cs.erase(CHILD_B);
+    EXPECT_EQ(cs.size(), 1);
+    EXPECT_TRUE(cs.contains(CHILD_A));
+
+    /// Erase non-matching in set mode — no-op
+    cs.insert(CHILD_B);
+    cs.erase(CHILD_C);
+    EXPECT_EQ(cs.size(), 2);
+}
+
+TEST(CompactChildrenSet, FullCycle)
+{
+    /// Empty → single → set → single → empty
+    CompactChildrenSet cs;
+    EXPECT_TRUE(cs.empty());
+
+    cs.insert(CHILD_A);
+    EXPECT_EQ(cs.size(), 1);
+
+    cs.insert(CHILD_B);
+    EXPECT_EQ(cs.size(), 2);
+
+    cs.erase(CHILD_A);
+    EXPECT_EQ(cs.size(), 1);
+    EXPECT_TRUE(cs.contains(CHILD_B));
+
+    cs.erase(CHILD_B);
+    EXPECT_TRUE(cs.empty());
+}
+
+TEST(CompactChildrenSet, ReserveOnEmpty)
+{
+    CompactChildrenSet cs;
+    cs.reserve(10);
+    /// Must still be logically empty after reserve
+    EXPECT_TRUE(cs.empty());
+    EXPECT_EQ(cs.size(), 0);
+    EXPECT_EQ(cs.begin(), cs.end());
+
+    /// Subsequent insert should work
+    cs.insert(CHILD_A);
+    EXPECT_EQ(cs.size(), 1);
+    EXPECT_TRUE(cs.contains(CHILD_A));
+}
+
+TEST(CompactChildrenSet, ReserveOnSingle)
+{
+    CompactChildrenSet cs;
+    cs.insert(CHILD_A);
+    cs.reserve(10);
+    /// Should preserve the existing child
+    EXPECT_EQ(cs.size(), 1);
+    EXPECT_TRUE(cs.contains(CHILD_A));
+}
+
+TEST(CompactChildrenSet, ReserveSmallIsNoOp)
+{
+    CompactChildrenSet cs;
+    cs.reserve(0);
+    EXPECT_TRUE(cs.empty());
+    EXPECT_EQ(cs.heapSizeInBytes(), 0);
+
+    cs.reserve(1);
+    EXPECT_TRUE(cs.empty());
+    EXPECT_EQ(cs.heapSizeInBytes(), 0);
+}
+
+TEST(CompactChildrenSet, Clear)
+{
+    CompactChildrenSet cs;
+    cs.insert(CHILD_A);
+    cs.insert(CHILD_B);
+    cs.clear();
+    EXPECT_TRUE(cs.empty());
+    EXPECT_EQ(cs.size(), 0);
+
+    /// Clear on empty — no-op
+    cs.clear();
+    EXPECT_TRUE(cs.empty());
+}
+
+TEST(CompactChildrenSet, CopyFromEmpty)
+{
+    CompactChildrenSet cs;
+    CompactChildrenSet copy(cs);
+    EXPECT_TRUE(copy.empty());
+}
+
+TEST(CompactChildrenSet, CopyFromSingle)
+{
+    CompactChildrenSet cs;
+    cs.insert(CHILD_A);
+
+    CompactChildrenSet copy(cs);
+    EXPECT_EQ(copy.size(), 1);
+    EXPECT_TRUE(copy.contains(CHILD_A));
+
+    /// Original unchanged
+    EXPECT_EQ(cs.size(), 1);
+}
+
+TEST(CompactChildrenSet, CopyFromSet)
+{
+    CompactChildrenSet cs;
+    cs.insert(CHILD_A);
+    cs.insert(CHILD_B);
+
+    CompactChildrenSet copy(cs);
+    EXPECT_EQ(copy.size(), 2);
+    EXPECT_TRUE(copy.contains(CHILD_A));
+    EXPECT_TRUE(copy.contains(CHILD_B));
+
+    /// Mutating copy doesn't affect original
+    copy.erase(CHILD_A);
+    EXPECT_EQ(copy.size(), 1);
+    EXPECT_EQ(cs.size(), 2);
+}
+
+TEST(CompactChildrenSet, CopyAssignmentFromSetToSet)
+{
+    CompactChildrenSet cs1;
+    cs1.insert(CHILD_A);
+    cs1.insert(CHILD_B);
+
+    CompactChildrenSet cs2;
+    cs2.insert(CHILD_C);
+    cs2.insert(CHILD_A);
+
+    cs2 = cs1;
+    EXPECT_EQ(cs2.size(), 2);
+    EXPECT_TRUE(cs2.contains(CHILD_A));
+    EXPECT_TRUE(cs2.contains(CHILD_B));
+}
+
+TEST(CompactChildrenSet, CopyAssignmentSelfAssign)
+{
+    CompactChildrenSet cs;
+    cs.insert(CHILD_A);
+    cs.insert(CHILD_B);
+
+    auto & ref = cs;
+    cs = ref;  // NOLINT: intentional self-assignment test
+    EXPECT_EQ(cs.size(), 2);
+}
+
+TEST(CompactChildrenSet, MoveFromSingle)
+{
+    CompactChildrenSet cs;
+    cs.insert(CHILD_A);
+
+    CompactChildrenSet moved(std::move(cs));
+    EXPECT_EQ(moved.size(), 1);
+    EXPECT_TRUE(moved.contains(CHILD_A));
+    EXPECT_TRUE(cs.empty());  // NOLINT: testing moved-from state
+}
+
+TEST(CompactChildrenSet, MoveFromSet)
+{
+    CompactChildrenSet cs;
+    cs.insert(CHILD_A);
+    cs.insert(CHILD_B);
+
+    CompactChildrenSet moved(std::move(cs));
+    EXPECT_EQ(moved.size(), 2);
+    EXPECT_TRUE(cs.empty());  // NOLINT: testing moved-from state
+}
+
+TEST(CompactChildrenSet, MoveAssignment)
+{
+    CompactChildrenSet cs1;
+    cs1.insert(CHILD_A);
+    cs1.insert(CHILD_B);
+
+    CompactChildrenSet cs2;
+    cs2.insert(CHILD_C);
+
+    cs2 = std::move(cs1);
+    EXPECT_EQ(cs2.size(), 2);
+    EXPECT_TRUE(cs2.contains(CHILD_A));
+    EXPECT_TRUE(cs1.empty());  // NOLINT: testing moved-from state
+}
+
+TEST(CompactChildrenSet, IteratorSetMode)
+{
+    CompactChildrenSet cs;
+    cs.insert(CHILD_A);
+    cs.insert(CHILD_B);
+    cs.insert(CHILD_C);
+
+    size_t count = 0;
+    bool found_a = false, found_b = false, found_c = false;
+    for (const auto & child : cs)
+    {
+        if (child == CHILD_A) found_a = true;
+        if (child == CHILD_B) found_b = true;
+        if (child == CHILD_C) found_c = true;
+        ++count;
+    }
+    EXPECT_EQ(count, 3);
+    EXPECT_TRUE(found_a);
+    EXPECT_TRUE(found_b);
+    EXPECT_TRUE(found_c);
+}
+
+TEST(CompactChildrenSet, IteratorPostIncrement)
+{
+    CompactChildrenSet cs;
+    cs.insert(CHILD_A);
+
+    auto it = cs.begin();
+    auto prev = it++;
+    EXPECT_EQ(*prev, CHILD_A);
+    EXPECT_EQ(it, cs.end());
+}
+
+TEST(CompactChildrenSet, RejectsEmptyChildName)
+{
+    CompactChildrenSet cs;
+    EXPECT_THROW(cs.insert(""), Exception);
+
+    /// Also in single mode
+    cs.insert(CHILD_A);
+    EXPECT_THROW(cs.insert(""), Exception);
+
+    /// Also in set mode
+    cs.insert(CHILD_B);
+    EXPECT_THROW(cs.insert(""), Exception);
+
+    /// Container unchanged after rejected inserts
+    EXPECT_EQ(cs.size(), 2);
+}
+
+TEST(CompactChildrenSet, CopyAssignmentSetToSingle)
+{
+    CompactChildrenSet cs_set;
+    cs_set.insert(CHILD_A);
+    cs_set.insert(CHILD_B);
+
+    CompactChildrenSet cs_single;
+    cs_single.insert(CHILD_C);
+
+    cs_single = cs_set;
+    EXPECT_EQ(cs_single.size(), 2);
+    EXPECT_TRUE(cs_single.contains(CHILD_A));
+    EXPECT_TRUE(cs_single.contains(CHILD_B));
+}
+
+TEST(CompactChildrenSet, CopyAssignmentSetToEmpty)
+{
+    CompactChildrenSet cs_set;
+    cs_set.insert(CHILD_A);
+    cs_set.insert(CHILD_B);
+
+    CompactChildrenSet cs_empty;
+    cs_empty = cs_set;
+    EXPECT_EQ(cs_empty.size(), 2);
+    EXPECT_TRUE(cs_empty.contains(CHILD_A));
+    EXPECT_TRUE(cs_empty.contains(CHILD_B));
+}
+
+TEST(CompactChildrenSet, CopyAssignmentSingleToSet)
+{
+    CompactChildrenSet cs_single;
+    cs_single.insert(CHILD_A);
+
+    CompactChildrenSet cs_set;
+    cs_set.insert(CHILD_B);
+    cs_set.insert(CHILD_C);
+
+    cs_set = cs_single;
+    EXPECT_EQ(cs_set.size(), 1);
+    EXPECT_TRUE(cs_set.contains(CHILD_A));
+    EXPECT_FALSE(cs_set.contains(CHILD_B));
+}
+
+TEST(CompactChildrenSet, MoveAssignmentToSetTarget)
+{
+    CompactChildrenSet src;
+    src.insert(CHILD_A);
+
+    CompactChildrenSet tgt;
+    tgt.insert(CHILD_B);
+    tgt.insert(CHILD_C);
+
+    tgt = std::move(src);
+    EXPECT_EQ(tgt.size(), 1);
+    EXPECT_TRUE(tgt.contains(CHILD_A));
+    EXPECT_TRUE(src.empty());  // NOLINT: testing moved-from state
+}
+
+TEST(CompactChildrenSet, MoveAssignmentSetToSet)
+{
+    CompactChildrenSet src;
+    src.insert(CHILD_A);
+    src.insert(CHILD_B);
+
+    CompactChildrenSet tgt;
+    tgt.insert(CHILD_C);
+    tgt.insert(CHILD_A);
+
+    tgt = std::move(src);
+    EXPECT_EQ(tgt.size(), 2);
+    EXPECT_TRUE(tgt.contains(CHILD_A));
+    EXPECT_TRUE(tgt.contains(CHILD_B));
+    EXPECT_TRUE(src.empty());  // NOLINT: testing moved-from state
+}
+
+TEST(CompactChildrenSet, ReserveOnSetMode)
+{
+    CompactChildrenSet cs;
+    cs.insert(CHILD_A);
+    cs.insert(CHILD_B);
+
+    /// Reserve on already-set-mode container should just forward to the set
+    cs.reserve(100);
+    EXPECT_EQ(cs.size(), 2);
+    EXPECT_TRUE(cs.contains(CHILD_A));
+    EXPECT_TRUE(cs.contains(CHILD_B));
+}
+
+TEST(CompactChildrenSet, CopyAssignmentEmptyToSet)
+{
+    CompactChildrenSet cs_empty;
+
+    CompactChildrenSet cs_set;
+    cs_set.insert(CHILD_A);
+    cs_set.insert(CHILD_B);
+
+    /// Overwrite set-mode target with empty source
+    cs_set = cs_empty;
+    EXPECT_TRUE(cs_set.empty());
+    EXPECT_EQ(cs_set.size(), 0);
+}
+
+TEST(CompactChildrenSet, MoveAssignmentFromEmpty)
+{
+    CompactChildrenSet src;
+
+    CompactChildrenSet tgt;
+    tgt.insert(CHILD_A);
+    tgt.insert(CHILD_B);
+
+    /// Move empty into set-mode target
+    tgt = std::move(src);
+    EXPECT_TRUE(tgt.empty());
+    EXPECT_TRUE(src.empty());  // NOLINT: testing moved-from state
+}
+
+TEST(CompactChildrenSet, ReserveOnSingleThenEraseToZero)
+{
+    CompactChildrenSet cs;
+    cs.insert(CHILD_A);
+
+    /// Promote single to set via reserve
+    cs.reserve(10);
+    EXPECT_EQ(cs.size(), 1);
+    EXPECT_TRUE(cs.contains(CHILD_A));
+
+    /// Erase the only element — should clean up the set
+    cs.erase(CHILD_A);
+    EXPECT_TRUE(cs.empty());
+    EXPECT_EQ(cs.size(), 0);
+    EXPECT_EQ(cs.heapSizeInBytes(), 0);
+}

--- a/src/Coordination/tests/gtest_coordination_snapshot.cpp
+++ b/src/Coordination/tests/gtest_coordination_snapshot.cpp
@@ -160,13 +160,13 @@ TYPED_TEST(CoordinationTest, SnapshotableHashMapDataSize)
     n1.setData("1234");
     Node n2;
     n2.setData("123456");
-    n2.addChild("");
+    n2.addChild("c");
 
     /// Note: Below, we check in many cases only that getApproximateDataSize() > 0. This is because
-    ///       the SnapshotableHashTable's approximate data size includes Node's sizeInBytes(). The
-    ///       latter includes sizeof(absl::flat_hash_set) which is surprisingly not constant across
-    ///       different runs. The approximate size is only used for statistics accounting, so this
-    ///       should be okay.
+    ///       the SnapshotableHashTable's approximate data size includes Node's `sizeInBytes`, which
+    ///       includes `CompactChildrenSet::heapSizeInBytes` (0 for nodes with 0-1 children,
+    ///       approximate for nodes with 2+ children). The approximate size is only used for
+    ///       statistics accounting, so this should be okay.
 
     world.disableSnapshotMode();
     world.insert("world", n1);


### PR DESCRIPTION
Reduce memory consumption of Keeper by replacing `absl::flat_hash_set` with `CompactChildrenSet` for storing node children. The new container stores 0–1 children inline without heap allocation, which covers the majority of Keeper nodes. This reduces `KeeperMemNode` size from 144 to 128 bytes.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduce memory consumption of Keeper by replacing `absl::flat_hash_set` with `CompactChildrenSet` for storing node children. The new container stores 0–1 children inline without heap allocation, which covers the majority of Keeper nodes. This reduces `KeeperMemNode` size from 144 to 128 bytes.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.846`
<!-- ch-version-info:end -->