### PR TITLE
Fix signed integer overflow in WITH FILL step calculation

### DIFF
--- a/src/Processors/Transforms/FillingTransform.cpp
+++ b/src/Processors/Transforms/FillingTransform.cpp
@@ -14,6 +14,7 @@
 #include <Common/FieldVisitorToString.h>
 #include <Common/logger_useful.h>
 #include <IO/Operators.h>
+#include <base/arithmeticOverflow.h>
 
 
 namespace DB
@@ -81,7 +82,11 @@ static FillColumnDescription::StepFunction getStepFunction(const Field & step, c
     {
         if (which.isDate() || which.isDate32())
         {
-            Int64 avg_seconds = step.safeGet<Int64>() * step_kind->toAvgSeconds();
+            Int64 step_value = step.safeGet<Int64>();
+            Int64 avg_seconds = 0;
+            if (common::mulOverflow(step_value, static_cast<Int64>(step_kind->toAvgSeconds()), avg_seconds))
+                throw Exception(ErrorCodes::INVALID_WITH_FILL_EXPRESSION,
+                                "Overflow in WITH FILL step value");
             if (std::abs(avg_seconds) < 86400)
                 throw Exception(ErrorCodes::INVALID_WITH_FILL_EXPRESSION,
                                 "Value of step is to low ({} seconds). Must be >= 1 day", std::abs(avg_seconds));

--- a/tests/queries/0_stateless/04046_filling_step_overflow.sql
+++ b/tests/queries/0_stateless/04046_filling_step_overflow.sql
@@ -1,0 +1,2 @@
+-- Verify that extreme WITH FILL step values don't cause signed integer overflow (UBSan)
+SELECT toDate('2020-01-01') AS d ORDER BY d DESC WITH FILL STEP INTERVAL -9223372036854775808 MONTH; -- { serverError INVALID_WITH_FILL_EXPRESSION }


### PR DESCRIPTION
Fix signed integer overflow in `getStepFunction` when computing average seconds for a WITH FILL step on Date/Date32 columns. The multiplication `step * toAvgSeconds()` can overflow with extreme step values (e.g. `INT64_MIN`), triggering undefined behavior caught by UBSan.

Use `common::mulOverflow` to detect the overflow and throw a meaningful `INVALID_WITH_FILL_EXPRESSION` exception instead.

Fixes https://github.com/ClickHouse/ClickHouse/issues/99849

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98138&sha=a349e29ce98d34354439478bec564adb7d5b66c9&name_0=PR&name_1=Stress%20test%20%28amd_ubsan%29
https://github.com/ClickHouse/ClickHouse/pull/98138

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.820`
<!-- ch-version-info:end -->