### PR TITLE
Fix flaky 03591_optimize_prewhere_row_policy due to randomized index_granularity

### DIFF
--- a/tests/queries/0_stateless/03591_optimize_prewhere_row_policy.reference
+++ b/tests/queries/0_stateless/03591_optimize_prewhere_row_policy.reference
@@ -5,7 +5,7 @@ SET enable_parallel_replicas = 0;
 SET use_statistics = 0;
 DROP TABLE IF EXISTS 03591_test;
 DROP ROW POLICY IF EXISTS 03591_rp ON 03591_test;
-CREATE TABLE 03591_test (a Int32, b Int32) ENGINE=MergeTree ORDER BY tuple();
+CREATE TABLE 03591_test (a Int32, b Int32) ENGINE=MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
 INSERT INTO 03591_test VALUES (3, 1), (2, 2), (3, 2);
 SELECT * FROM 03591_test;
 3	1

--- a/tests/queries/0_stateless/03591_optimize_prewhere_row_policy.sql
+++ b/tests/queries/0_stateless/03591_optimize_prewhere_row_policy.sql
@@ -8,7 +8,7 @@ DROP TABLE IF EXISTS 03591_test;
 
 DROP ROW POLICY IF EXISTS 03591_rp ON 03591_test;
 
-CREATE TABLE 03591_test (a Int32, b Int32) ENGINE=MergeTree ORDER BY tuple();
+CREATE TABLE 03591_test (a Int32, b Int32) ENGINE=MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
 
 INSERT INTO 03591_test VALUES (3, 1), (2, 2), (3, 2);
 


### PR DESCRIPTION
The `EXPLAIN PLAN` output in `03591_optimize_prewhere_row_policy` expects `Granules: 1`, but with randomized `index_granularity = 1` (from the test fuzzer), 3 rows produce 3 granules instead. Fix by explicitly setting `index_granularity = 8192, index_granularity_bytes = '10Mi'` in the CREATE TABLE.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99594&sha=53fbf7907fe49da79d8d71cac0d4845ff54939cf&name_0=PR&name_1=Stateless%20tests%20%28amd_asan%2C%20distributed%20plan%2C%20parallel%2C%202%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/99594

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.892`
<!-- ch-version-info:end -->