### PR TITLE
Docs: document projection limitation

### DIFF
--- a/docs/en/sql-reference/statements/alter/projection.md
+++ b/docs/en/sql-reference/statements/alter/projection.md
@@ -292,6 +292,48 @@ Below are the possible values for both `deduplicate_merge_projection_mode` and `
 - `drop`: Affected projection table parts are dropped. Queries will fall back to the original table part for affected projection parts.
 - `rebuild`: The affected projection part is rebuilt to stay consistent with data in the original table part.
 
+## Limitations {#limitations}
+
+It is not possible to use an `ALIAS` column in a projection's `ORDER BY` clause. For example:
+
+```sql
+CREATE TABLE t
+(
+    id UInt64,
+    a UInt32,
+    ab_sum UInt64 ALIAS a + 1,
+--highlight-next-line
+    PROJECTION p (SELECT a ORDER BY ab_sum)
+)
+ENGINE = MergeTree ORDER BY id;
+-- Fails with UNKNOWN_IDENTIFIER
+```
+
+`ALIAS` columns are not physically stored and are computed on-the-fly at query time, so they are unavailable during the projection part write path when the sorting expression is evaluated.
+
+Instead, use `MATERIALIZED` columns or inline the expression directly:
+
+```sql
+-- using MATERIALIZED column
+CREATE TABLE t
+(
+    id UInt64,
+    a UInt32,
+    ab_sum UInt64 MATERIALIZED a + 1,
+    PROJECTION p (SELECT a ORDER BY ab_sum)
+)
+ENGINE = MergeTree ORDER BY id;
+
+-- using an inline expression
+CREATE TABLE t
+(
+    id UInt64,
+    a UInt32,
+    PROJECTION p (SELECT a ORDER BY a + 1)
+)
+ENGINE = MergeTree ORDER BY id;
+```
+
 ## See also {#see-also}
 - ["Control Of Projections During Merges" (blog post)](https://clickhouse.com/blog/clickhouse-release-24-08#control-of-projections-during-merges)
 - ["Projections" (guide)](/data-modeling/projections#using-projections-to-speed-up-UK-price-paid)


### PR DESCRIPTION
Closes https://github.com/ClickHouse/ClickHouse/issues/99861. Documents the mentioned limitation that you cannot use an ALIAS column in the projection ORDER BY.

Once this is merged will update https://clickhouse.com/docs/data-modeling/projections to link to the limitations section so we only need to maintain in a single place.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.800`
<!-- ch-version-info:end -->