### PR TITLE
Fix filter push-down changing column constness after partial AND extraction

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
@@ -177,26 +177,6 @@ static std::optional<ActionsDAG::ActionsForFilterPushDown> splitFilter(QueryPlan
         {
             materializeFilterColumnIfNeededAfterPushDown(*filter, is_filter_column_const_before, result->is_filter_const_after_push_down);
         }
-
-        /// After partial push-down, the remaining expression may evaluate to a constant
-        /// on 0-row header input, even though it has non-const DAG inputs.
-        /// Example: `plus(X, NULL)` folds to const NULL regardless of X.
-        /// The `is_filter_const_after_push_down` flag only captures the case where ALL
-        /// conjunctions are pushed down, not this "runtime folding" case.
-        /// If the filter column was non-const before and becomes const after header
-        /// recomputation, parent steps holding the old non-const header will see a
-        /// "Block structure mismatch". Prevent this by wrapping in `materialize`.
-        if (!is_filter_column_const_before && !removes_filter && !result->is_filter_const_after_push_down)
-        {
-            auto updated_header = expression.updateHeader(*filter->getInputHeaders().front());
-            const auto & col = updated_header.getByName(filter_column_name);
-            if (col.column && col.column->isConst())
-            {
-                const auto & filter_node = expression.findInOutputs(filter_column_name);
-                const auto & non_const_node = expression.materializeNode(filter_node, false);
-                expression.addOrReplaceInOutputs(non_const_node);
-            }
-        }
     }
     return result;
 }

--- a/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/filterPushDown.cpp
@@ -177,6 +177,26 @@ static std::optional<ActionsDAG::ActionsForFilterPushDown> splitFilter(QueryPlan
         {
             materializeFilterColumnIfNeededAfterPushDown(*filter, is_filter_column_const_before, result->is_filter_const_after_push_down);
         }
+
+        /// After partial push-down, the remaining expression may evaluate to a constant
+        /// on 0-row header input, even though it has non-const DAG inputs.
+        /// Example: `plus(X, NULL)` folds to const NULL regardless of X.
+        /// The `is_filter_const_after_push_down` flag only captures the case where ALL
+        /// conjunctions are pushed down, not this "runtime folding" case.
+        /// If the filter column was non-const before and becomes const after header
+        /// recomputation, parent steps holding the old non-const header will see a
+        /// "Block structure mismatch". Prevent this by wrapping in `materialize`.
+        if (!is_filter_column_const_before && !removes_filter && !result->is_filter_const_after_push_down)
+        {
+            auto updated_header = expression.updateHeader(*filter->getInputHeaders().front());
+            const auto & col = updated_header.getByName(filter_column_name);
+            if (col.column && col.column->isConst())
+            {
+                const auto & filter_node = expression.findInOutputs(filter_column_name);
+                const auto & non_const_node = expression.materializeNode(filter_node, false);
+                expression.addOrReplaceInOutputs(non_const_node);
+            }
+        }
     }
     return result;
 }

--- a/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
@@ -106,6 +106,18 @@ void optimizeTreeFirstPass(const QueryPlanOptimizationSettings & optimization_se
             }
         }
 
+        /// An optimization applied to a child node may have changed a grandchild's
+        /// output header (e.g., filter push-down modifies a filter step's DAG, which
+        /// changes its output constness). The intermediate child step's cached input
+        /// header becomes stale. Refresh it before running optimizations on this node,
+        /// so that steps like mergeExpressions see consistent headers.
+        for (size_t i = 0; i < frame.node->children.size(); ++i)
+        {
+            auto child_output = frame.node->children[i]->step->getOutputHeader();
+            if (!blocksHaveEqualStructure(*frame.node->step->getInputHeaders()[i], *child_output))
+                frame.node->step->updateInputHeader(std::move(child_output), i);
+        }
+
         size_t max_update_depth = 0;
 
         /// Apply all optimizations.

--- a/tests/queries/0_stateless/04032_filter_push_down_const_having.sql
+++ b/tests/queries/0_stateless/04032_filter_push_down_const_having.sql
@@ -28,4 +28,15 @@ GROUP BY GROUPING SETS ((g))
 HAVING h
 ORDER BY g DESC;
 
+-- After partial push-down of AND, the remaining expression may fold to a constant
+-- on 0-row header input (e.g., plus(X, NULL) → const NULL), even though the DAG
+-- node has non-const inputs. This caused "Block structure mismatch" when
+-- mergeExpressions used a stale non-const header from the parent step.
+SELECT
+    (MAX(c0) + NULL) AND materialize(0) AS h,
+    -c0 AS g
+FROM t_const_having
+GROUP BY g
+HAVING h;
+
 DROP TABLE t_const_having;


### PR DESCRIPTION
After partial push-down extracts some conjunctions from a HAVING filter (e.g., `materialize(0)` from `(MAX(c0) + NULL) AND materialize(0)`), the remaining expression may evaluate to a constant on 0-row header input (e.g., `plus(X, NULL)` folds to const NULL regardless of X).

The existing `is_filter_const_after_push_down` flag only captures the case where ALL conjunctions are pushed down, missing this "runtime folding" case. When the `FilterStep` header is recomputed, the filter column becomes const, but parent steps still hold the old non-const header, causing "Block structure mismatch" when `mergeExpressions` later uses the stale header.

Fix: after modifying the DAG, recompute the header and wrap the remaining predicate in `materialize` if it became const.

Found via AST fuzzer: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99539&sha=4d694d72dadaddbf43066e6a7132370f5c379ab8&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%29
https://github.com/ClickHouse/ClickHouse/pull/99539

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix "Block structure mismatch" exception in queries with HAVING clause where the filter expression contains both an aggregate wrapped in a NULL-producing function and `materialize(0)`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.854`
<!-- ch-version-info:end -->