### PR TITLE
Fix inconsistent AST formatting for ALTER TABLE MODIFY QUERY with trailing SETTINGS

### DIFF
--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -505,9 +505,24 @@ void ASTAlterCommand::formatImpl(WriteBuffer & ostr, const FormatSettings & sett
     }
     else if (type == ASTAlterCommand::MODIFY_QUERY)
     {
-        ostr << "MODIFY QUERY" << settings.nl_or_ws
-                     ;
-        select->format(ostr, settings, state, frame);
+        ostr << "MODIFY QUERY" << settings.nl_or_ws;
+
+        /// When the ALTER query has trailing SETTINGS (inherited from ASTQueryWithOutput),
+        /// we must wrap the MODIFY QUERY select in parentheses. Otherwise the trailing
+        /// SETTINGS clause would be consumed by `ParserSelectQuery` as part of the
+        /// last SELECT during re-parsing, instead of remaining on the ALTER query.
+        /// Clear the flags to prevent inner nodes from adding redundant parentheses.
+        if (frame.parent_has_trailing_settings)
+        {
+            ostr << "(";
+            frame.parent_has_trailing_settings = false;
+            select->format(ostr, settings, state, frame);
+            ostr << ")";
+        }
+        else
+        {
+            select->format(ostr, settings, state, frame);
+        }
     }
     else if (type == ASTAlterCommand::MODIFY_REFRESH)
     {

--- a/tests/queries/0_stateless/04046_format_alter_modify_query_with_settings.reference
+++ b/tests/queries/0_stateless/04046_format_alter_modify_query_with_settings.reference
@@ -1,0 +1,7 @@
+ALTER TABLE v1\n    (MODIFY QUERY\n    SELECT 1\n    SETTINGS max_threads = 1)
+1
+ALTER TABLE v1\n    (MODIFY QUERY\n    SELECT 1)
+ALTER TABLE v1\n    (MODIFY QUERY\n    SELECT 1\n    UNION ALL\n    SELECT 2\n    SETTINGS max_threads = 1)
+1
+ALTER TABLE v1\n    (MODIFY QUERY\n(    SELECT c0\n    FROM\n    (\n        SELECT 1 AS c0\n        INTERSECT DISTINCT\n        SELECT 2 AS c0\n    )))\nSETTINGS max_threads = 1
+1

--- a/tests/queries/0_stateless/04046_format_alter_modify_query_with_settings.sql
+++ b/tests/queries/0_stateless/04046_format_alter_modify_query_with_settings.sql
@@ -1,0 +1,27 @@
+-- Verify that ALTER TABLE ... MODIFY QUERY round-trips correctly when trailing
+-- SETTINGS are present. The formatter must parenthesize the MODIFY QUERY select
+-- so that SETTINGS are not consumed by the inner SELECT during re-parsing,
+-- but must NOT propagate that flag into nested subqueries.
+
+-- Basic case: MODIFY QUERY with trailing SETTINGS
+SELECT formatQuery('ALTER TABLE v1 MODIFY QUERY SELECT 1 SETTINGS max_threads = 1');
+
+-- Round-trip: formatting twice must produce the same result
+SELECT formatQuery('ALTER TABLE v1 MODIFY QUERY SELECT 1 SETTINGS max_threads = 1')
+     = formatQuery(formatQuery('ALTER TABLE v1 MODIFY QUERY SELECT 1 SETTINGS max_threads = 1'));
+
+-- Without trailing SETTINGS: no parentheses needed
+SELECT formatQuery('ALTER TABLE v1 MODIFY QUERY SELECT 1');
+
+-- MODIFY QUERY with UNION and trailing SETTINGS
+SELECT formatQuery('ALTER TABLE v1 MODIFY QUERY SELECT 1 UNION ALL SELECT 2 SETTINGS max_threads = 1');
+
+SELECT formatQuery('ALTER TABLE v1 MODIFY QUERY SELECT 1 UNION ALL SELECT 2 SETTINGS max_threads = 1')
+     = formatQuery(formatQuery('ALTER TABLE v1 MODIFY QUERY SELECT 1 UNION ALL SELECT 2 SETTINGS max_threads = 1'));
+
+-- Nested subqueries with INTERSECT inside MODIFY QUERY with trailing SETTINGS:
+-- the parenthesization must not propagate into the nested subquery
+SELECT formatQuery('ALTER TABLE v1 (MODIFY QUERY SELECT c0 FROM ((SELECT 1 AS c0) INTERSECT DISTINCT (SELECT 2 AS c0))) SETTINGS max_threads = 1');
+
+SELECT formatQuery('ALTER TABLE v1 (MODIFY QUERY SELECT c0 FROM ((SELECT 1 AS c0) INTERSECT DISTINCT (SELECT 2 AS c0))) SETTINGS max_threads = 1')
+     = formatQuery(formatQuery('ALTER TABLE v1 (MODIFY QUERY SELECT c0 FROM ((SELECT 1 AS c0) INTERSECT DISTINCT (SELECT 2 AS c0))) SETTINGS max_threads = 1'));


### PR DESCRIPTION
When an ALTER TABLE query has trailing SETTINGS, the `parent_has_trailing_settings` flag was propagating into the MODIFY QUERY select and all nested subqueries, causing `ASTSelectWithUnionQuery` to wrap SELECT branches in unnecessary parentheses deep inside the query tree. This created structures that could not be parsed back, triggering "Inconsistent AST formatting" exceptions in debug builds.

The fix wraps the MODIFY QUERY select in parentheses at the `ASTAlterCommand` level (preventing SETTINGS from being consumed by the inner `ParserSelectQuery`) and clears the flag before formatting nested nodes, similar to how `ASTCreateQuery` handles the same issue for `CREATE TABLE AS SELECT`.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=98c6a9f57b5497e81d3aa7450f2a9d7f4703d233&name_0=MasterCI&name_1=BuzzHouse%20%28amd_debug%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.839`
<!-- ch-version-info:end -->