### PR TITLE
Implement index interpreters via alter interpreter

### DIFF
--- a/src/Interpreters/InterpreterCreateIndexQuery.cpp
+++ b/src/Interpreters/InterpreterCreateIndexQuery.cpp
@@ -1,22 +1,14 @@
-
-#include <Access/ContextAccess.h>
-#include <Core/Settings.h>
-#include <Databases/DatabaseReplicated.h>
-#include <Interpreters/Context.h>
-#include <Interpreters/DatabaseCatalog.h>
-#include <Interpreters/executeDDLQueryOnCluster.h>
-#include <Interpreters/InterpreterFactory.h>
 #include <Interpreters/InterpreterCreateIndexQuery.h>
-#include <Interpreters/FunctionNameNormalizer.h>
+#include <Interpreters/InterpreterAlterQuery.h>
+#include <Interpreters/InterpreterFactory.h>
+#include <Interpreters/Context.h>
+
+#include <Parsers/ASTAlterQuery.h>
 #include <Parsers/ASTCreateIndexQuery.h>
-#include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTIndexDeclaration.h>
 #include <Parsers/ASTFunction.h>
-#include <Storages/AlterCommands.h>
 
-#if CLICKHOUSE_CLOUD
-#include <Interpreters/SharedDatabaseCatalog.h>
-#endif
+#include <Core/Settings.h>
 
 namespace DB
 {
@@ -24,98 +16,74 @@ namespace Setting
 {
     extern const SettingsBool allow_create_index_without_type;
     extern const SettingsBool create_index_ignore_unique;
-    extern const SettingsSeconds lock_acquire_timeout;
 }
 
 namespace ErrorCodes
 {
-    extern const int TABLE_IS_READ_ONLY;
     extern const int INCORRECT_QUERY;
     extern const int NOT_IMPLEMENTED;
 }
 
-
-BlockIO InterpreterCreateIndexQuery::execute()
+namespace
 {
-    FunctionNameNormalizer::visit(query_ptr.get());
-    auto current_context = getContext();
-    const auto & create_index = query_ptr->as<ASTCreateIndexQuery &>();
 
-    if (create_index.unique)
+bool validateCreateIndexQuery(const ASTCreateIndexQuery & query, const ContextPtr & context)
+{
+    if (query.unique)
     {
-        if (!current_context->getSettingsRef()[Setting::create_index_ignore_unique])
+        if (!context->getSettingsRef()[Setting::create_index_ignore_unique])
         {
             throw Exception(ErrorCodes::NOT_IMPLEMENTED, "CREATE UNIQUE INDEX is not supported."
                 " SET create_index_ignore_unique=1 to ignore this UNIQUE keyword.");
         }
-
     }
+
     // Noop if allow_create_index_without_type = true. throw otherwise
-    if (!create_index.index_decl->as<ASTIndexDeclaration>()->getType())
+    if (!query.index_decl->as<ASTIndexDeclaration>()->getType())
     {
-        if (!current_context->getSettingsRef()[Setting::allow_create_index_without_type])
+        if (!context->getSettingsRef()[Setting::allow_create_index_without_type])
         {
             throw Exception(ErrorCodes::INCORRECT_QUERY, "CREATE INDEX without TYPE is forbidden."
                 " SET allow_create_index_without_type=1 to ignore this statements");
         }
 
         // Nothing to do
+        return false;
+    }
+
+    return true;
+}
+
+ASTPtr rewriteToAlterTable(const ASTCreateIndexQuery & query)
+{
+    auto alter = make_intrusive<ASTAlterQuery>();
+    alter->alter_object = ASTAlterQuery::AlterObjectType::TABLE;
+    alter->setDatabase(query.getDatabase());
+    alter->setTable(query.getTable());
+    alter->cluster = query.cluster;
+
+    auto command_list = make_intrusive<ASTExpressionList>();
+    command_list->children.push_back(query.convertToASTAlterCommand());
+
+    alter->command_list = command_list.get();
+    alter->children.push_back(std::move(command_list));
+
+    return alter;
+}
+
+}
+
+BlockIO InterpreterCreateIndexQuery::execute()
+{
+    const auto & create_index = query_ptr->as<ASTCreateIndexQuery &>();
+    const auto context = Context::createCopy(getContext());
+
+    bool need_proceed = validateCreateIndexQuery(create_index, context);
+    if (!need_proceed)
         return {};
-    }
 
-    AccessRightsElements required_access;
-    required_access.emplace_back(AccessType::ALTER_ADD_INDEX, create_index.getDatabase(), create_index.getTable());
-
-    if (!create_index.cluster.empty())
-    {
-        DDLQueryOnClusterParams params;
-        params.access_to_check = std::move(required_access);
-        return executeDDLQueryOnCluster(query_ptr, current_context, params);
-    }
-
-    current_context->checkAccess(required_access);
-    auto table_id = current_context->resolveStorageID(create_index, Context::ResolveOrdinary);
-    query_ptr->as<ASTCreateIndexQuery &>().setDatabase(table_id.database_name);
-
-    DatabasePtr database = DatabaseCatalog::instance().getDatabase(table_id.database_name);
-    if (database->shouldReplicateQuery(getContext(), query_ptr))
-    {
-        auto guard = DatabaseCatalog::instance().getDDLGuard(table_id.database_name, table_id.table_name, database.get());
-        guard->releaseTableLock();
-        return database->tryEnqueueReplicatedDDL(query_ptr, current_context, {}, std::move(guard));
-    }
-
-#if CLICKHOUSE_CLOUD
-    if (SharedDatabaseCatalog::shouldReplicateQuery(getContext(), query_ptr))
-    {
-        return SharedDatabaseCatalog::instance().tryExecuteDDLQuery(query_ptr, getContext());
-    }
-#endif
-
-    StoragePtr table = DatabaseCatalog::instance().getTable(table_id, current_context);
-    if (table->isStaticStorage())
-        throw Exception(ErrorCodes::TABLE_IS_READ_ONLY, "Table is read-only");
-
-    /// Convert ASTCreateIndexQuery to AlterCommand.
-    AlterCommands alter_commands;
-
-    AlterCommand command;
-    command.ast = create_index.convertToASTAlterCommand();
-    command.index_decl = create_index.index_decl;
-    command.type = AlterCommand::ADD_INDEX;
-    command.index_name = create_index.index_name->as<ASTIdentifier &>().name();
-    command.if_not_exists = create_index.if_not_exists;
-
-    alter_commands.emplace_back(std::move(command));
-
-    auto alter_lock = table->lockForAlter(current_context->getSettingsRef()[Setting::lock_acquire_timeout]);
-    StorageInMemoryMetadata metadata = table->getInMemoryMetadata();
-    alter_commands.validate(table, current_context);
-    alter_commands.prepare(metadata);
-    table->checkAlterIsPossible(alter_commands, current_context);
-    table->alter(alter_commands, current_context, alter_lock);
-
-    return {};
+    auto alter_query = rewriteToAlterTable(create_index);
+    return InterpreterAlterQuery(alter_query, context).execute();
 }
 
 void registerInterpreterCreateIndexQuery(InterpreterFactory & factory)

--- a/src/Interpreters/InterpreterDropIndexQuery.cpp
+++ b/src/Interpreters/InterpreterDropIndexQuery.cpp
@@ -1,89 +1,43 @@
-#include <Access/ContextAccess.h>
-#include <Core/Settings.h>
-#include <Databases/DatabaseReplicated.h>
-#include <Interpreters/Context.h>
-#include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/InterpreterDropIndexQuery.h>
+#include <Interpreters/InterpreterAlterQuery.h>
 #include <Interpreters/InterpreterFactory.h>
-#include <Interpreters/executeDDLQueryOnCluster.h>
-#include <Parsers/ASTDropIndexQuery.h>
-#include <Parsers/ASTIdentifier.h>
-#include <Storages/AlterCommands.h>
+#include <Interpreters/Context.h>
 
-#if CLICKHOUSE_CLOUD
-#include <Interpreters/SharedDatabaseCatalog.h>
-#endif
+#include <Parsers/ASTAlterQuery.h>
+#include <Parsers/ASTDropIndexQuery.h>
 
 namespace DB
 {
-namespace Setting
+
+namespace
 {
-    extern const SettingsSeconds lock_acquire_timeout;
+
+ASTPtr rewriteToAlterTable(const ASTDropIndexQuery & query)
+{
+    auto alter = make_intrusive<ASTAlterQuery>();
+    alter->alter_object = ASTAlterQuery::AlterObjectType::TABLE;
+    alter->setDatabase(query.getDatabase());
+    alter->setTable(query.getTable());
+    alter->cluster = query.cluster;
+
+    auto command_list = make_intrusive<ASTExpressionList>();
+    command_list->children.push_back(query.convertToASTAlterCommand());
+
+    alter->command_list = command_list.get();
+    alter->children.push_back(std::move(command_list));
+
+    return alter;
 }
 
-namespace ErrorCodes
-{
-    extern const int TABLE_IS_READ_ONLY;
 }
-
 
 BlockIO InterpreterDropIndexQuery::execute()
 {
-    auto current_context = getContext();
     const auto & drop_index = query_ptr->as<ASTDropIndexQuery &>();
+    const auto context = Context::createCopy(getContext());
 
-    AccessRightsElements required_access;
-    required_access.emplace_back(AccessType::ALTER_DROP_INDEX, drop_index.getDatabase(), drop_index.getTable());
-
-    if (!drop_index.cluster.empty())
-    {
-        DDLQueryOnClusterParams params;
-        params.access_to_check = std::move(required_access);
-        return executeDDLQueryOnCluster(query_ptr, current_context, params);
-    }
-
-    current_context->checkAccess(required_access);
-    auto table_id = current_context->resolveStorageID(drop_index, Context::ResolveOrdinary);
-    query_ptr->as<ASTDropIndexQuery &>().setDatabase(table_id.database_name);
-
-    DatabasePtr database = DatabaseCatalog::instance().getDatabase(table_id.database_name);
-    if (database->shouldReplicateQuery(getContext(), query_ptr))
-    {
-        auto guard = DatabaseCatalog::instance().getDDLGuard(table_id.database_name, table_id.table_name, database.get());
-        guard->releaseTableLock();
-        return database->tryEnqueueReplicatedDDL(query_ptr, current_context, {}, std::move(guard));
-    }
-
-#if CLICKHOUSE_CLOUD
-    if (SharedDatabaseCatalog::shouldReplicateQuery(getContext(), query_ptr))
-    {
-        return SharedDatabaseCatalog::instance().tryExecuteDDLQuery(query_ptr, getContext());
-    }
-#endif
-
-    StoragePtr table = DatabaseCatalog::instance().getTable(table_id, current_context);
-    if (table->isStaticStorage())
-        throw Exception(ErrorCodes::TABLE_IS_READ_ONLY, "Table is read-only");
-
-    /// Convert ASTDropIndexQuery to AlterCommand.
-    AlterCommands alter_commands;
-
-    AlterCommand command;
-    command.ast = drop_index.convertToASTAlterCommand();
-    command.type = AlterCommand::DROP_INDEX;
-    command.index_name = drop_index.index_name->as<ASTIdentifier &>().name();
-    command.if_exists = drop_index.if_exists;
-
-    alter_commands.emplace_back(std::move(command));
-
-    auto alter_lock = table->lockForAlter(current_context->getSettingsRef()[Setting::lock_acquire_timeout]);
-    StorageInMemoryMetadata metadata = table->getInMemoryMetadata();
-    alter_commands.validate(table, current_context);
-    alter_commands.prepare(metadata);
-    table->checkAlterIsPossible(alter_commands, current_context);
-    table->alter(alter_commands, current_context, alter_lock);
-
-    return {};
+    auto alter_query = rewriteToAlterTable(drop_index);
+    return InterpreterAlterQuery(alter_query, context).execute();
 }
 
 void registerInterpreterDropIndexQuery(InterpreterFactory & factory)

--- a/src/Parsers/ASTCreateIndexQuery.cpp
+++ b/src/Parsers/ASTCreateIndexQuery.cpp
@@ -68,7 +68,8 @@ ASTPtr ASTCreateIndexQuery::convertToASTAlterCommand() const
     command->type = ASTAlterCommand::ADD_INDEX;
     command->if_not_exists = if_not_exists;
 
-    command->index_decl = command->children.emplace_back(index_decl).get();
+    command->index_decl = command->children.emplace_back(index_decl->clone()).get();
+    command->index_decl->as<ASTIndexDeclaration &>().part_of_create_index_query = false;
 
     return command;
 }

--- a/src/Parsers/ASTCreateIndexQuery.cpp
+++ b/src/Parsers/ASTCreateIndexQuery.cpp
@@ -68,7 +68,6 @@ ASTPtr ASTCreateIndexQuery::convertToASTAlterCommand() const
     command->type = ASTAlterCommand::ADD_INDEX;
     command->if_not_exists = if_not_exists;
 
-    command->index = command->children.emplace_back(index_name).get();
     command->index_decl = command->children.emplace_back(index_decl).get();
 
     return command;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use InterpreterAlterQuery for `CREATE/DROP INDEX` queries

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.851`
<!-- ch-version-info:end -->