### PR TITLE
Attempt to fix 99725

### DIFF
--- a/src/Functions/GatherUtils/Algorithms.h
+++ b/src/Functions/GatherUtils/Algorithms.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <base/arithmeticOverflow.h>
 #include <base/types.h>
 #include <Common/FieldVisitorConvertToNumber.h>
 #include <Functions/GatherUtils/Sources.h>
@@ -14,6 +15,7 @@ namespace DB::ErrorCodes
 {
     extern const int LOGICAL_ERROR;
     extern const int TOO_LARGE_ARRAY_SIZE;
+    extern const int ARGUMENT_OUT_OF_BOUND;
 }
 
 namespace DB::GatherUtils
@@ -381,7 +383,14 @@ static void sliceDynamicOffsetBoundedImpl(Source && src, Sink && sink, const ICo
         Int64 size = has_length ? length_nested_column->getInt(row_num) : static_cast<Int64>(src.getElementSize());
 
         if (size < 0)
-            size += offset > 0 ? static_cast<Int64>(src.getElementSize()) - (offset - 1) : -UInt64(offset);
+        {
+            Int64 abs_size;
+            if (common::subOverflow(Int64(0), size, abs_size))
+                throw Exception(DB::ErrorCodes::ARGUMENT_OUT_OF_BOUND,
+                    "Overflow in length argument of substring-like function: {}", size);
+            Int64 adjustment = offset > 0 ? static_cast<Int64>(src.getElementSize()) - (offset - 1) : static_cast<Int64>(-UInt64(offset));
+            size += adjustment;
+        }
 
         if (offset != 0 && size > 0)
         {

--- a/src/Functions/GatherUtils/Algorithms.h
+++ b/src/Functions/GatherUtils/Algorithms.h
@@ -388,8 +388,22 @@ static void sliceDynamicOffsetBoundedImpl(Source && src, Sink && sink, const ICo
             if (common::subOverflow(Int64(0), size, abs_size))
                 throw Exception(DB::ErrorCodes::ARGUMENT_OUT_OF_BOUND,
                     "Overflow in length argument of substring-like function: {}", size);
-            Int64 adjustment = offset > 0 ? static_cast<Int64>(src.getElementSize()) - (offset - 1) : static_cast<Int64>(-UInt64(offset));
-            size += adjustment;
+            Int64 adjustment;
+            if (offset > 0)
+            {
+                adjustment = static_cast<Int64>(src.getElementSize()) - (offset - 1);
+            }
+            else
+            {
+                if (common::subOverflow(Int64(0), offset, adjustment))
+                    throw Exception(DB::ErrorCodes::ARGUMENT_OUT_OF_BOUND,
+                        "Overflow in offset argument of substring-like function: {}", offset);
+            }
+            Int64 new_size;
+            if (common::addOverflow(size, adjustment, new_size))
+                throw Exception(DB::ErrorCodes::ARGUMENT_OUT_OF_BOUND,
+                    "Overflow when computing slice size in substring-like function: size={}, adjustment={}", size, adjustment);
+            size = new_size;
         }
 
         if (offset != 0 && size > 0)

--- a/src/Functions/LeftRight.h
+++ b/src/Functions/LeftRight.h
@@ -99,7 +99,7 @@ public:
                 // According to the docs, if length_value < 0, we need to take a suffix of the string starting from the position abs(length_value)
                 else
                 {
-                    sliceFromLeftConstantOffsetUnbounded(source, StringSink(*col_res, input_rows_count), -length_value);
+                    sliceFromLeftConstantOffsetUnbounded(source, StringSink(*col_res, input_rows_count), -static_cast<UInt64>(length_value));
                 }
             }
             else

--- a/src/Functions/LeftRight.h
+++ b/src/Functions/LeftRight.h
@@ -13,6 +13,7 @@
 #include <Functions/GatherUtils/Algorithms.h>
 #include <IO/WriteHelpers.h>
 #include <Interpreters/Context_fwd.h>
+#include <base/arithmeticOverflow.h>
 
 
 namespace DB
@@ -24,6 +25,7 @@ namespace ErrorCodes
 {
     extern const int ILLEGAL_COLUMN;
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int ARGUMENT_OUT_OF_BOUND;
 }
 
 enum class SubstringDirection : uint8_t
@@ -99,7 +101,11 @@ public:
                 // According to the docs, if length_value < 0, we need to take a suffix of the string starting from the position abs(length_value)
                 else
                 {
-                    sliceFromLeftConstantOffsetUnbounded(source, StringSink(*col_res, input_rows_count), -static_cast<UInt64>(length_value));
+                    Int64 abs_length_value;
+                    if (common::subOverflow(Int64(0), length_value, abs_length_value))
+                        throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND,
+                            "Argument of function {} is out of bound: {}", getName(), length_value);
+                    sliceFromLeftConstantOffsetUnbounded(source, StringSink(*col_res, input_rows_count), static_cast<size_t>(abs_length_value));
                 }
             }
             else

--- a/tests/queries/0_stateless/02159_left_right.reference
+++ b/tests/queries/0_stateless/02159_left_right.reference
@@ -256,3 +256,9 @@ o
 Привет
 
 \N
+
+-- Regression test: right() with INT64_MIN caused signed integer overflow (UBSan)
+SELECT right('Hello', -9223372036854775808);
+
+SELECT rightUTF8('Привет', -9223372036854775808);
+

--- a/tests/queries/0_stateless/02159_left_right.reference
+++ b/tests/queries/0_stateless/02159_left_right.reference
@@ -256,7 +256,6 @@ o
 Привет
 
 \N
-
 -- Regression test: right() with INT64_MIN caused signed integer overflow (UBSan)
 SELECT right('Hello', -9223372036854775808);
 

--- a/tests/queries/0_stateless/02159_left_right.reference
+++ b/tests/queries/0_stateless/02159_left_right.reference
@@ -264,3 +264,9 @@ SELECT rightUTF8(materialize('Привет'), -9223372036854775808); -- { server
 -- Dynamic-length path: bitNot(INT64_MAX) == INT64_MIN
 SELECT right('Hello', materialize(bitNot(toInt64(9223372036854775807)))); -- { serverError ARGUMENT_OUT_OF_BOUND }
 SELECT rightUTF8('Привет', materialize(bitNot(toInt64(9223372036854775807)))); -- { serverError ARGUMENT_OUT_OF_BOUND }
+-- substring with negative offset=INT64_MIN: abs(offset) overflows in sliceDynamicOffsetBoundedImpl
+-- materialize() prevents constant-folding so the dynamic code path is taken
+SELECT substring('Hello', materialize(bitNot(toInt64(9223372036854775807))), -1); -- { serverError ARGUMENT_OUT_OF_BOUND }
+-- substring with large positive offset: adjustment=element_size-(offset-1) is very negative,
+-- and size+adjustment underflows Int64
+SELECT substring('Hello', materialize(toInt64(9223372036854775807)), -8); -- { serverError ARGUMENT_OUT_OF_BOUND }

--- a/tests/queries/0_stateless/02159_left_right.reference
+++ b/tests/queries/0_stateless/02159_left_right.reference
@@ -256,8 +256,11 @@ o
 Привет
 
 \N
--- Regression test: right() with INT64_MIN caused signed integer overflow (UBSan)
-SELECT right('Hello', -9223372036854775808);
-
-SELECT rightUTF8('Привет', -9223372036854775808);
-
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/99725
+-- right() with INT64_MIN must raise an overflow exception
+-- Const-length path (string is non-const so useDefaultImplementationForConstants does not apply)
+SELECT right(materialize('Hello'), -9223372036854775808); -- { serverError ARGUMENT_OUT_OF_BOUND }
+SELECT rightUTF8(materialize('Привет'), -9223372036854775808); -- { serverError ARGUMENT_OUT_OF_BOUND }
+-- Dynamic-length path: bitNot(INT64_MAX) == INT64_MIN
+SELECT right('Hello', materialize(bitNot(toInt64(9223372036854775807)))); -- { serverError ARGUMENT_OUT_OF_BOUND }
+SELECT rightUTF8('Привет', materialize(bitNot(toInt64(9223372036854775807)))); -- { serverError ARGUMENT_OUT_OF_BOUND }

--- a/tests/queries/0_stateless/02159_left_right.sql
+++ b/tests/queries/0_stateless/02159_left_right.sql
@@ -93,3 +93,9 @@ SELECT rightUTF8(materialize('Привет'), -9223372036854775808); -- { server
 -- Dynamic-length path: bitNot(INT64_MAX) == INT64_MIN
 SELECT right('Hello', materialize(bitNot(toInt64(9223372036854775807)))); -- { serverError ARGUMENT_OUT_OF_BOUND }
 SELECT rightUTF8('Привет', materialize(bitNot(toInt64(9223372036854775807)))); -- { serverError ARGUMENT_OUT_OF_BOUND }
+-- substring with negative offset=INT64_MIN: abs(offset) overflows in sliceDynamicOffsetBoundedImpl
+-- materialize() prevents constant-folding so the dynamic code path is taken
+SELECT substring('Hello', materialize(bitNot(toInt64(9223372036854775807))), -1); -- { serverError ARGUMENT_OUT_OF_BOUND }
+-- substring with large positive offset: adjustment=element_size-(offset-1) is very negative,
+-- and size+adjustment underflows Int64
+SELECT substring('Hello', materialize(toInt64(9223372036854775807)), -8); -- { serverError ARGUMENT_OUT_OF_BOUND }

--- a/tests/queries/0_stateless/02159_left_right.sql
+++ b/tests/queries/0_stateless/02159_left_right.sql
@@ -84,3 +84,7 @@ SELECT rightUTF8('Привет', -number) FROM numbers(10);
 
 SELECT rightUTF8('Привет', number % 3 = 0 ? NULL : (number % 2 ? toInt64(number) : -number)) FROM numbers(10);
 SELECT rightUTF8(number < 5 ? 'Hello' : 'Привет', number % 3 = 0 ? NULL : (number % 2 ? toInt64(number) : -number)) FROM numbers(10);
+
+-- Regression test: right() with INT64_MIN caused signed integer overflow (UBSan)
+SELECT right('Hello', -9223372036854775808);
+SELECT rightUTF8('Привет', -9223372036854775808);

--- a/tests/queries/0_stateless/02159_left_right.sql
+++ b/tests/queries/0_stateless/02159_left_right.sql
@@ -85,6 +85,11 @@ SELECT rightUTF8('Привет', -number) FROM numbers(10);
 SELECT rightUTF8('Привет', number % 3 = 0 ? NULL : (number % 2 ? toInt64(number) : -number)) FROM numbers(10);
 SELECT rightUTF8(number < 5 ? 'Hello' : 'Привет', number % 3 = 0 ? NULL : (number % 2 ? toInt64(number) : -number)) FROM numbers(10);
 
--- Regression test: right() with INT64_MIN caused signed integer overflow (UBSan)
-SELECT right('Hello', -9223372036854775808);
-SELECT rightUTF8('Привет', -9223372036854775808);
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/99725
+-- right() with INT64_MIN must raise an overflow exception
+-- Const-length path (string is non-const so useDefaultImplementationForConstants does not apply)
+SELECT right(materialize('Hello'), -9223372036854775808); -- { serverError ARGUMENT_OUT_OF_BOUND }
+SELECT rightUTF8(materialize('Привет'), -9223372036854775808); -- { serverError ARGUMENT_OUT_OF_BOUND }
+-- Dynamic-length path: bitNot(INT64_MAX) == INT64_MIN
+SELECT right('Hello', materialize(bitNot(toInt64(9223372036854775807)))); -- { serverError ARGUMENT_OUT_OF_BOUND }
+SELECT rightUTF8('Привет', materialize(bitNot(toInt64(9223372036854775807)))); -- { serverError ARGUMENT_OUT_OF_BOUND }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes an exception when calling `right`, `rightUTF8`, or other substring functions with a length of INT64_MIN (-9223372036854775808), which previously caused undefined behavior due to integer overflow. The functions now correctly report an ARGUMENT_OUT_OF_BOUND error.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->


Fixes: #99725 

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.41`
<!-- ch-version-info:end -->