### PR TITLE
Fix logical error in ObjectStorageQueueIFileMetadata ownership check

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
@@ -184,8 +184,8 @@ ObjectStorageQueueIFileMetadata::~ObjectStorageQueueIFileMetadata()
                 /// e.g. we successfully removed the node, but did not get confirmation,
                 /// but then if we retry - we can remove a newly recreated node,
                 /// therefore avoid this with this check.
-                /// On the first attempt, this can also fail for ephemeral processing nodes
-                /// if the ZooKeeper session expired before the destructor runs.
+                /// On the first attempt, this can also fail if the cleanup thread
+                /// removed the processing node by TTL before the destructor runs.
                 if (!checkProcessingOwnership(zk_client))
                 {
                     LOG_TEST(log, "Will not remove processing node, ownership changed");
@@ -397,8 +397,8 @@ void ObjectStorageQueueIFileMetadata::resetProcessing()
         /// e.g. we successfully removed the node, but did not get confirmation,
         /// but then if we retry - we can remove a newly recreated node,
         /// therefore avoid this with this check.
-        /// On the first attempt, this can also fail for ephemeral processing nodes
-        /// if the ZooKeeper session expired before resetProcessing runs.
+        /// On the first attempt, this can also fail if the cleanup thread
+        /// removed the processing node by TTL before `resetProcessing` runs.
         if (!checkProcessingOwnership(zk_client))
         {
             LOG_TEST(log, "Will not remove processing node, ownership changed");

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
@@ -180,22 +180,17 @@ ObjectStorageQueueIFileMetadata::~ObjectStorageQueueIFileMetadata()
             zk_retry.retryLoop([&]
             {
                 auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log, zookeeper_name);
-                if (zk_retry.isRetry())
+                /// It is possible that we fail "after operation",
+                /// e.g. we successfully removed the node, but did not get confirmation,
+                /// but then if we retry - we can remove a newly recreated node,
+                /// therefore avoid this with this check.
+                /// On the first attempt, this can also fail for ephemeral processing nodes
+                /// if the ZooKeeper session expired before the destructor runs.
+                if (!checkProcessingOwnership(zk_client))
                 {
-                    /// It is possible that we fail "after operation",
-                    /// e.g. we successfully removed the node, but did not get confirmation,
-                    /// but then if we retry - we can remove a newly recreated node,
-                    /// therefore avoid this with this check.
-                    if (!checkProcessingOwnership(zk_client))
-                    {
-                        LOG_TEST(log, "Will not remove processing node, ownership changed");
-                        code = Coordination::Error::ZOK;
-                        return;
-                    }
-                }
-                else
-                {
-                    chassert(checkProcessingOwnership(zk_client));
+                    LOG_TEST(log, "Will not remove processing node, ownership changed");
+                    code = Coordination::Error::ZOK;
+                    return;
                 }
                 code = zk_client->tryRemove(processing_node_path);
             });
@@ -398,22 +393,17 @@ void ObjectStorageQueueIFileMetadata::resetProcessing()
     zk_retry.retryLoop([&]
     {
         auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log, zookeeper_name);
-        if (zk_retry.isRetry())
+        /// It is possible that we fail "after operation",
+        /// e.g. we successfully removed the node, but did not get confirmation,
+        /// but then if we retry - we can remove a newly recreated node,
+        /// therefore avoid this with this check.
+        /// On the first attempt, this can also fail for ephemeral processing nodes
+        /// if the ZooKeeper session expired before resetProcessing runs.
+        if (!checkProcessingOwnership(zk_client))
         {
-            /// It is possible that we fail "after operation",
-            /// e.g. we successfully removed the node, but did not get confirmation,
-            /// but then if we retry - we can remove a newly recreated node,
-            /// therefore avoid this with this check.
-            if (!checkProcessingOwnership(zk_client))
-            {
-                LOG_TEST(log, "Will not remove processing node, ownership changed");
-                code = Coordination::Error::ZOK;
-                return;
-            }
-        }
-        else
-        {
-            chassert(checkProcessingOwnership(zk_client));
+            LOG_TEST(log, "Will not remove processing node, ownership changed");
+            code = Coordination::Error::ZOK;
+            return;
         }
         code = zk_client->tryMulti(requests, responses);
     });


### PR DESCRIPTION
The `chassert(checkProcessingOwnership(zk_client))` on the first (non-retry)
attempt in the destructor and `resetProcessing` assumed the processing node
always exists at that point. However, the cleanup thread
(`cleanupPersistentProcessingNodes`) can remove persistent processing nodes
by TTL before the destructor or `resetProcessing` runs, causing the assertion
to fail.

The fix handles the first attempt the same way as retries: check ownership
and gracefully skip removal if the node is already gone.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=6b6f08f7f3280b9a79bdc23722219aad089be269&name_0=MasterCI&name_1=Stress%20test%20%28arm_asan%2C%20s3%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)