### PR TITLE
Add no-debug and no-flaky-check tags to 03211_nested_json_merges_small test

### DIFF
--- a/tests/queries/0_stateless/03211_nested_json_merges_small.sql.j2
+++ b/tests/queries/0_stateless/03211_nested_json_merges_small.sql.j2
@@ -1,4 +1,4 @@
--- Tags: no-fasttest, long, no-tsan, no-asan, no-msan, no-ubsan
+-- Tags: no-fasttest, long, no-debug, no-tsan, no-asan, no-msan, no-ubsan
 
 SET enable_json_type = 1;
 

--- a/tests/queries/0_stateless/03211_nested_json_merges_small.sql.j2
+++ b/tests/queries/0_stateless/03211_nested_json_merges_small.sql.j2
@@ -1,4 +1,4 @@
--- Tags: no-fasttest, long, no-debug, no-tsan, no-asan, no-msan, no-ubsan
+-- Tags: no-fasttest, long, no-debug, no-flaky-check, no-tsan, no-asan, no-msan, no-ubsan
 
 SET enable_json_type = 1;
 


### PR DESCRIPTION
Add `no-debug` and `no-flaky-check` tags to `03211_nested_json_merges_small` test.

The test times out (600s) in debug builds with S3 storage. The sibling test `03211_nested_json_merges` already has the `no-debug` tag.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99474&sha=8af813bfd7a739d91992fc063ad9726ec82b4d3f&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20distributed%20plan%2C%20s3%20storage%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/99474

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.834`
<!-- ch-version-info:end -->