### PR TITLE
Revert #97114 Move join step row estimation before check for 1 child"

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -305,14 +305,6 @@ RelationStats estimateReadRowsCount(QueryPlan::Node & node, const ActionsDAG::No
         return estimateReadRowsCount(*reading->getSubplanReferenceRoot(), filter);
     }
 
-    if (const auto * join_step = typeid_cast<const JoinStepLogical *>(step); join_step && join_step->isOptimized())
-    {
-        return RelationStats{
-            .estimated_rows = join_step->getResultRowsEstimation(),
-            .column_stats = join_step->getResultColumnStats(),
-            .table_name = join_step->getReadableRelationName()};
-    }
-
     if (node.children.size() != 1)
         return {};
 
@@ -346,6 +338,14 @@ RelationStats estimateReadRowsCount(QueryPlan::Node & node, const ActionsDAG::No
         auto stats = estimateReadRowsCount(*node.children.front(), filter);
         auto aggregation_stats = estimateAggregatingStepStats(*aggregating_step, stats);
         return aggregation_stats;
+    }
+
+    if (const auto * join_step = typeid_cast<const JoinStepLogical *>(step); join_step && join_step->isOptimized())
+    {
+        return RelationStats{
+            .estimated_rows = join_step->getResultRowsEstimation(),
+            .column_stats = join_step->getResultColumnStats(),
+            .table_name = join_step->getReadableRelationName()};
     }
 
     if (const auto * sorting_step = typeid_cast<const SortingStep *>(step))

--- a/tests/queries/0_stateless/03545_analyzer_correlated_subquery_exists_asterisk.reference
+++ b/tests/queries/0_stateless/03545_analyzer_correlated_subquery_exists_asterisk.reference
@@ -10,7 +10,7 @@ Positions: 2
     Join (JOIN FillRightFirst)
     Type: LEFT
     Strictness: SEMI
-    Algorithm: HashJoin
+    Algorithm: ConcurrentHashJoin
     Clauses: [(__table1.i1) = (exists(__table2).__table1.i1)]
       Expression (Left Pre Join Actions)
       Actions: INPUT :: 0 -> __table1.i1 Int64 : 0

--- a/tests/queries/0_stateless/03837_subquery_ndv_propagation_join_order.reference
+++ b/tests/queries/0_stateless/03837_subquery_ndv_propagation_join_order.reference
@@ -1,14 +1,14 @@
   JoinLogical
-  Join: sq[50000] ⋈ pc[300] ⋈ rs[200]
-  ResultRows: 60000
+  Join: sq ⋈ rs[200] ⋈ pc[300]
+  ResultRows: unknown
     JoinLogical
-    Join: sq[50000] ⋈ pc[300]
-    ResultRows: 1500
+    Join: sq ⋈ rs[200]
+    ResultRows: unknown
         Aggregating
             JoinLogical
             Join: s[50000] ⋈ p[10000]
             ResultRows: 50000
                 ReadFromMergeTree (default.test_sales)
                 ReadFromMergeTree (default.test_partners)
-        ReadFromMergeTree (default.test_product_catalog)
-      ReadFromMergeTree (default.test_region_subsidies)
+        ReadFromMergeTree (default.test_region_subsidies)
+      ReadFromMergeTree (default.test_product_catalog)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Revert #97114 "Move join step row estimation before check for 1 child" due to suspected performance regression.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.40`
- Backported to: `26.3.10.16`, `26.2.17.11`
<!-- ch-version-info:end -->