### PR TITLE
Resubmit #98662: Add a setting to disallow settings profiles from config in sql

### DIFF
--- a/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
+++ b/docs/en/operations/server-configuration-parameters/_server_settings_outside_source.md
@@ -1833,6 +1833,7 @@ Settings for optional improvements in the access control system.
 | `table_engines_require_grant` | Sets whether creating a table with a specific table engine requires a grant.                                                                                                                                                                                                                                                                                                                                                                                                                                     | `false` |
 | `throw_on_unmatched_row_policies` | Sets whether reading from a table should throw an exception if the table has row policies, but none of them are for the current user | `false` |
 | `users_without_row_policies_can_read_rows` | Sets whether users without permissive row policies can still read rows using a `SELECT` query. For example, if there are two users A and B and a row policy is defined only for A, then if this setting is true, user B will see all rows. If this setting is false, user B will see no rows.                                                                                                                                                                                                                    | `true`  |
+| `disallow_config_defined_profiles_for_sql_defined_users` | When enabled, prevents config-defined settings profiles (those defined in XML configuration files such as `users.xml`), except for the default profile, from being applied to SQL-defined users. Profiles assigned to roles granted to a SQL-defined user are also checked. | `false` |
 
 Example:
 
@@ -1845,6 +1846,7 @@ Example:
     <select_from_information_schema_requires_grant>true</select_from_information_schema_requires_grant>
     <settings_constraints_replace_previous>true</settings_constraints_replace_previous>
     <table_engines_require_grant>false</table_engines_require_grant>
+    <disallow_config_defined_profiles_for_sql_defined_users>false</disallow_config_defined_profiles_for_sql_defined_users>
     <role_cache_expiration_time_seconds>600</role_cache_expiration_time_seconds>
 </access_control_improvements>
 ```

--- a/src/Access/AccessControl.cpp
+++ b/src/Access/AccessControl.cpp
@@ -311,6 +311,7 @@ void AccessControl::setupFromMainConfig(const Poco::Util::AbstractConfiguration 
     setEnableUserNameAccessType(config_.getBool("access_control_improvements.enable_user_name_access_type", true));
 
     setThrowOnInvalidReplicatedAccessEntities(config_.getBool("access_control_improvements.throw_on_invalid_replicated_access_entities", false));
+    setConfigDefinedProfilesForSQLUsersDisallowed(config_.getBool("access_control_improvements.disallow_config_defined_profiles_for_sql_defined_users", false));
 
     addStoragesFromMainConfig(config_, config_path_, get_zookeeper_function_);
 

--- a/src/Access/AccessControl.h
+++ b/src/Access/AccessControl.h
@@ -213,6 +213,9 @@ public:
     void setThrowOnInvalidReplicatedAccessEntities(bool enable) { throw_on_invalid_replicated_access_entities = enable; }
     bool shouldThrowOnInvalidReplicatedAccessEntities() const { return throw_on_invalid_replicated_access_entities; }
 
+    void setConfigDefinedProfilesForSQLUsersDisallowed(bool disallow) { disallow_config_defined_profiles_for_sql_defined_users = disallow; }
+    bool isConfigDefinedProfilesForSQLUsersDisallowed() const { return disallow_config_defined_profiles_for_sql_defined_users; }
+
     std::shared_ptr<const ContextAccess> getContextAccess(const ContextAccessParams & params) const;
 
     std::shared_ptr<const EnabledRoles> getEnabledRoles(
@@ -307,6 +310,7 @@ private:
     std::atomic_bool enable_user_name_access_type = true;
     std::atomic_bool enable_read_write_grants = false;
     std::atomic_bool allow_impersonate_user = false;
+    std::atomic_bool disallow_config_defined_profiles_for_sql_defined_users = false;
 };
 
 }

--- a/src/Access/ContextAccess.cpp
+++ b/src/Access/ContextAccess.cpp
@@ -441,8 +441,23 @@ void ContextAccess::setRolesInfo(const std::shared_ptr<const EnabledRolesInfo> &
 
     enabled_row_policies = access_control->getEnabledRowPolicies(*params.user_id, roles_info->enabled_roles);
 
-    enabled_settings = access_control->getEnabledSettings(
-        *params.user_id, user->settings, roles_info->enabled_roles, roles_info->settings_from_enabled_roles);
+    try
+    {
+        enabled_settings = access_control->getEnabledSettings(
+            *params.user_id, user->settings, roles_info->enabled_roles, roles_info->settings_from_enabled_roles);
+    }
+    catch (const Exception & e)
+    {
+        if (e.code() == ErrorCodes::ACCESS_DENIED)
+        {
+            /// A config-defined profile is blocked for this SQL user
+            /// (disallow_config_defined_profiles_for_sql_defined_users was enabled).
+            /// Keep the existing settings for this session; the user will be blocked on reconnect.
+            tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
+        else
+            throw;
+    }
 
     calculateAccessRights();
 }

--- a/src/Access/SettingsProfilesCache.cpp
+++ b/src/Access/SettingsProfilesCache.cpp
@@ -2,6 +2,7 @@
 #include <Access/AccessControl.h>
 #include <Access/SettingsProfile.h>
 #include <Access/SettingsProfilesInfo.h>
+#include <Access/UsersConfigAccessStorage.h>
 #include <Common/quoteString.h>
 
 
@@ -9,6 +10,7 @@ namespace DB
 {
 namespace ErrorCodes
 {
+    extern const int ACCESS_DENIED;
     extern const int THERE_IS_NO_PROFILE;
 }
 
@@ -110,7 +112,22 @@ void SettingsProfilesCache::mergeSettingsAndConstraints()
             i = enabled_settings.erase(i);
         else
         {
-            mergeSettingsAndConstraintsFor(*enabled);
+            try
+            {
+                mergeSettingsAndConstraintsFor(*enabled);
+            }
+            catch (const Exception & e)
+            {
+                if (e.code() == ErrorCodes::ACCESS_DENIED)
+                {
+                    /// A config-defined profile is now blocked for this SQL user
+                    /// (disallow_config_defined_profiles_for_sql_defined_users was enabled).
+                    /// Keep the existing settings for this session and continue with other entries.
+                    tryLogCurrentException(__PRETTY_FUNCTION__);
+                }
+                else
+                    throw;
+            }
             ++i;
         }
     }
@@ -137,6 +154,56 @@ void SettingsProfilesCache::mergeSettingsAndConstraintsFor(EnabledSettings & ena
 
     merged_settings.merge(enabled.params.settings_from_enabled_roles, /* normalize= */ false);
     merged_settings.merge(enabled.params.settings_from_user, /* normalize= */ false);
+
+    if (access_control.isConfigDefinedProfilesForSQLUsersDisallowed())
+    {
+        auto user_storage = access_control.findStorage(enabled.params.user_id);
+        bool is_sql_defined_user = user_storage
+            && strcmp(user_storage->getStorageType(), UsersConfigAccessStorage::STORAGE_TYPE) != 0;
+
+        if (is_sql_defined_user)
+        {
+            /// Recursively check profiles from user and role settings, including
+            /// indirect inheritance (e.g. SQL profile -> config profile).
+            /// Default profile and TO-clause profiles are exempt (admin-configured).
+            boost::container::flat_set<UUID> visited;
+            std::vector<UUID> stack;
+
+            auto collect_profile_ids = [](const SettingsProfileElements & elements, std::vector<UUID> & out)
+            {
+                for (const auto & elem : elements)
+                    if (elem.parent_profile)
+                        out.push_back(*elem.parent_profile);
+            };
+            collect_profile_ids(enabled.params.settings_from_user, stack);
+            collect_profile_ids(enabled.params.settings_from_enabled_roles, stack);
+
+            while (!stack.empty())
+            {
+                auto profile_id = stack.back();
+                stack.pop_back();
+                if (!visited.insert(profile_id).second)
+                    continue;
+                /// The server's default profile is always allowed.
+                if (default_profile_id && profile_id == *default_profile_id)
+                    continue;
+                auto profile_storage = access_control.findStorage(profile_id);
+                if (profile_storage
+                    && strcmp(profile_storage->getStorageType(), UsersConfigAccessStorage::STORAGE_TYPE) == 0)
+                {
+                    auto profile_name = access_control.tryReadName(profile_id);
+                    throw Exception(ErrorCodes::ACCESS_DENIED,
+                        "Cannot apply config-defined profile '{}' to SQL-defined user. "
+                        "Server setting `disallow_config_defined_profiles_for_sql_defined_users` is enabled",
+                        profile_name.value_or("unknown"));
+                }
+                /// Walk into child profiles.
+                auto it = all_profiles.find(profile_id);
+                if (it != all_profiles.end())
+                    collect_profile_ids(it->second->elements, stack);
+            }
+        }
+    }
 
     auto info = std::make_shared<SettingsProfilesInfo>(access_control);
 

--- a/tests/config/config.d/enable_access_control_improvements.xml
+++ b/tests/config/config.d/enable_access_control_improvements.xml
@@ -8,5 +8,6 @@
         <settings_constraints_replace_previous>true</settings_constraints_replace_previous>
         <table_engines_require_grant>true</table_engines_require_grant>
         <allow_impersonate_user>true</allow_impersonate_user>
+        <disallow_config_defined_profiles_for_sql_defined_users>true</disallow_config_defined_profiles_for_sql_defined_users>
     </access_control_improvements>
 </clickhouse>

--- a/tests/queries/0_stateless/04010_deny_config_profiles_for_sql_users.reference
+++ b/tests/queries/0_stateless/04010_deny_config_profiles_for_sql_users.reference
@@ -1,0 +1,6 @@
+no_profile_ok
+default_profile_ok
+ACCESS_DENIED
+sql_profile_ok
+ACCESS_DENIED
+ACCESS_DENIED

--- a/tests/queries/0_stateless/04010_deny_config_profiles_for_sql_users.reference
+++ b/tests/queries/0_stateless/04010_deny_config_profiles_for_sql_users.reference
@@ -4,3 +4,5 @@ ACCESS_DENIED
 sql_profile_ok
 ACCESS_DENIED
 ACCESS_DENIED
+before_role_change
+server_alive_after_role_change

--- a/tests/queries/0_stateless/04010_deny_config_profiles_for_sql_users.sh
+++ b/tests/queries/0_stateless/04010_deny_config_profiles_for_sql_users.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Test that config-defined profiles cannot be applied to SQL-defined users
+# when `disallow_config_defined_profiles_for_sql_defined_users` is enabled.
+# The default profile is always exempt from this restriction.
+# Indirect inheritance (SQL profile -> config profile) is also blocked.
+
+user_prefix="${CLICKHOUSE_TEST_UNIQUE_NAME}"
+
+# Cleanup
+${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS ${user_prefix}_u1, ${user_prefix}_u2, ${user_prefix}_u3, ${user_prefix}_u4, ${user_prefix}_u5"
+${CLICKHOUSE_CLIENT} --query "DROP SETTINGS PROFILE IF EXISTS ${user_prefix}_sql_profile, ${user_prefix}_inheriting_profile"
+${CLICKHOUSE_CLIENT} --query "DROP ROLE IF EXISTS ${user_prefix}_role_with_config_profile"
+
+# 1. SQL user with no explicit profile — should connect fine (global default profile is exempt)
+${CLICKHOUSE_CLIENT} --query "CREATE USER ${user_prefix}_u1 IDENTIFIED WITH no_password"
+${CLICKHOUSE_CLIENT} --user "${user_prefix}_u1" --query "SELECT 'no_profile_ok'"
+
+# 2. SQL user with config-defined 'default' profile — should succeed (default profile is always exempt)
+${CLICKHOUSE_CLIENT} --query "CREATE USER ${user_prefix}_u2 IDENTIFIED WITH no_password SETTINGS PROFILE 'default'"
+${CLICKHOUSE_CLIENT} --user "${user_prefix}_u2" --query "SELECT 'default_profile_ok'"
+
+# 3. SQL user with non-default config-defined profile 'readonly' — should fail on connect
+${CLICKHOUSE_CLIENT} --query "CREATE USER ${user_prefix}_u3 IDENTIFIED WITH no_password SETTINGS PROFILE 'readonly'"
+${CLICKHOUSE_CLIENT} --user "${user_prefix}_u3" --query "SELECT 'should_not_appear'" 2>&1 | grep -o 'ACCESS_DENIED'
+
+# 4. SQL user with SQL-defined profile — should succeed
+${CLICKHOUSE_CLIENT} --query "CREATE SETTINGS PROFILE ${user_prefix}_sql_profile SETTINGS max_threads = 4"
+${CLICKHOUSE_CLIENT} --query "CREATE USER ${user_prefix}_u4 IDENTIFIED WITH no_password SETTINGS PROFILE '${user_prefix}_sql_profile'"
+${CLICKHOUSE_CLIENT} --user "${user_prefix}_u4" --query "SELECT 'sql_profile_ok'"
+
+# 5. Role with non-default config-defined profile assigned to SQL user — should fail on connect
+${CLICKHOUSE_CLIENT} --query "CREATE ROLE ${user_prefix}_role_with_config_profile SETTINGS PROFILE 'readonly'"
+${CLICKHOUSE_CLIENT} --query "GRANT ${user_prefix}_role_with_config_profile TO ${user_prefix}_u1"
+${CLICKHOUSE_CLIENT} --query "ALTER USER ${user_prefix}_u1 DEFAULT ROLE ${user_prefix}_role_with_config_profile"
+${CLICKHOUSE_CLIENT} --user "${user_prefix}_u1" --query "SELECT 'should_not_appear'" 2>&1 | grep -o 'ACCESS_DENIED'
+
+# 6. SQL profile inheriting from config-defined profile — should fail on connect (indirect inheritance)
+${CLICKHOUSE_CLIENT} --query "CREATE SETTINGS PROFILE ${user_prefix}_inheriting_profile SETTINGS PROFILE 'readonly'"
+${CLICKHOUSE_CLIENT} --query "CREATE USER ${user_prefix}_u5 IDENTIFIED WITH no_password SETTINGS PROFILE '${user_prefix}_inheriting_profile'"
+${CLICKHOUSE_CLIENT} --user "${user_prefix}_u5" --query "SELECT 'should_not_appear'" 2>&1 | grep -o 'ACCESS_DENIED'
+
+# Cleanup
+${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS ${user_prefix}_u1, ${user_prefix}_u2, ${user_prefix}_u3, ${user_prefix}_u4, ${user_prefix}_u5"
+${CLICKHOUSE_CLIENT} --query "DROP SETTINGS PROFILE IF EXISTS ${user_prefix}_sql_profile, ${user_prefix}_inheriting_profile"
+${CLICKHOUSE_CLIENT} --query "DROP ROLE IF EXISTS ${user_prefix}_role_with_config_profile"

--- a/tests/queries/0_stateless/04010_deny_config_profiles_for_sql_users.sh
+++ b/tests/queries/0_stateless/04010_deny_config_profiles_for_sql_users.sh
@@ -13,9 +13,9 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 user_prefix="${CLICKHOUSE_TEST_UNIQUE_NAME}"
 
 # Cleanup
-${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS ${user_prefix}_u1, ${user_prefix}_u2, ${user_prefix}_u3, ${user_prefix}_u4, ${user_prefix}_u5"
+${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS ${user_prefix}_u1, ${user_prefix}_u2, ${user_prefix}_u3, ${user_prefix}_u4, ${user_prefix}_u5, ${user_prefix}_u6"
 ${CLICKHOUSE_CLIENT} --query "DROP SETTINGS PROFILE IF EXISTS ${user_prefix}_sql_profile, ${user_prefix}_inheriting_profile"
-${CLICKHOUSE_CLIENT} --query "DROP ROLE IF EXISTS ${user_prefix}_role_with_config_profile"
+${CLICKHOUSE_CLIENT} --query "DROP ROLE IF EXISTS ${user_prefix}_role_with_config_profile, ${user_prefix}_role_live"
 
 # 1. SQL user with no explicit profile — should connect fine (global default profile is exempt)
 ${CLICKHOUSE_CLIENT} --query "CREATE USER ${user_prefix}_u1 IDENTIFIED WITH no_password"
@@ -45,7 +45,21 @@ ${CLICKHOUSE_CLIENT} --query "CREATE SETTINGS PROFILE ${user_prefix}_inheriting_
 ${CLICKHOUSE_CLIENT} --query "CREATE USER ${user_prefix}_u5 IDENTIFIED WITH no_password SETTINGS PROFILE '${user_prefix}_inheriting_profile'"
 ${CLICKHOUSE_CLIENT} --user "${user_prefix}_u5" --query "SELECT 'should_not_appear'" 2>&1 | grep -o 'ACCESS_DENIED'
 
-# Cleanup
-${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS ${user_prefix}_u1, ${user_prefix}_u2, ${user_prefix}_u3, ${user_prefix}_u4, ${user_prefix}_u5"
+# 7. Modifying a role to add a config-defined profile while a SQL user is connected — should not crash the server
+${CLICKHOUSE_CLIENT} --query "DROP ROLE IF EXISTS ${user_prefix}_role_live"
+${CLICKHOUSE_CLIENT} --query "CREATE ROLE ${user_prefix}_role_live"
+${CLICKHOUSE_CLIENT} --query "CREATE USER ${user_prefix}_u6 IDENTIFIED WITH no_password"
+${CLICKHOUSE_CLIENT} --query "GRANT ${user_prefix}_role_live TO ${user_prefix}_u6"
+${CLICKHOUSE_CLIENT} --query "ALTER USER ${user_prefix}_u6 DEFAULT ROLE ${user_prefix}_role_live"
+# Open a session as u6, keep it alive in the background
+${CLICKHOUSE_CLIENT} --user "${user_prefix}_u6" --query "SELECT 'before_role_change'"
+# Now modify the role to reference a config-defined profile — must not crash the server.
+# The notification handler logs an expected ACCESS_DENIED error, suppress it.
+${CLICKHOUSE_CLIENT} --query "ALTER ROLE ${user_prefix}_role_live SETTINGS PROFILE 'readonly'" 2>/dev/null
+# Verify the server is still alive
+${CLICKHOUSE_CLIENT} --query "SELECT 'server_alive_after_role_change'"
+
+# Initial cleanup (also serves as final cleanup)
+${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS ${user_prefix}_u1, ${user_prefix}_u2, ${user_prefix}_u3, ${user_prefix}_u4, ${user_prefix}_u5, ${user_prefix}_u6"
 ${CLICKHOUSE_CLIENT} --query "DROP SETTINGS PROFILE IF EXISTS ${user_prefix}_sql_profile, ${user_prefix}_inheriting_profile"
-${CLICKHOUSE_CLIENT} --query "DROP ROLE IF EXISTS ${user_prefix}_role_with_config_profile"
+${CLICKHOUSE_CLIENT} --query "DROP ROLE IF EXISTS ${user_prefix}_role_with_config_profile, ${user_prefix}_role_live"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add a setting `access_control_improvements.disallow_config_defined_profiles_for_sql_defined_users` (disabled/allowed by default) that disallows using config-defined settings profiles (except for the `default` profile) for SQL-defined users

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
