### PR TITLE
Improve error message when text index preprocessor references wrong column

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -57,6 +57,7 @@ namespace ErrorCodes
     extern const int INCORRECT_NUMBER_OF_COLUMNS;
     extern const int CORRUPTED_DATA;
     extern const int SUPPORT_IS_DISABLED;
+    extern const int UNKNOWN_IDENTIFIER;
 }
 
 static constexpr UInt64 MAX_CARDINALITY_FOR_RAW_POSTINGS = 12;
@@ -1594,7 +1595,21 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
     /// For very strict validation of the expression we fully parse it here.
     /// However it will be parsed again for index construction, generally immediately after this call.
     /// This is a bit redundant but that doesn't impact performance anyhow because the expression is intended to be simple enough.
-    MergeTreeIndexTextPreprocessor preprocessor(preprocessor_ast, index);
+    try
+    {
+        MergeTreeIndexTextPreprocessor preprocessor(preprocessor_ast, index);
+    }
+    catch (Exception & e)
+    {
+        if (e.code() == ErrorCodes::UNKNOWN_IDENTIFIER && preprocessor_ast)
+        {
+            e.addMessage(
+                "The preprocessor expression '{}' must use the index column expression '{}' as its input, not the underlying table column",
+                preprocessor_ast->formatForErrorMessage(),
+                index.column_names.front());
+        }
+        throw;
+    }
 }
 
 }


### PR DESCRIPTION
When a text index preprocessor expression references the underlying table column instead of the index column expression, the error message was confusing, mentioning internal placeholder `__text_index_column`. Now the error clearly states that the preprocessor must use the index column expression as its input.

Example:

```
CREATE TABLE tab
(
    `key` UInt64,
    `str` String,
    INDEX text_idx upper(str) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(str)) GRANULARITY 100000000
)
ENGINE = MergeTree
ORDER BY key

Query id: 25a016d3-53a2-450f-b491-270198dfe364


Elapsed: 0.136 sec.

Received exception from server (version 26.3.1):
Code: 47. DB::Exception: Received from localhost:9000. DB::Exception: Missing columns: 'str' while processing: 'lower(str)', required columns: 'str', available columns: '__text_index_column': The preprocessor expression 'lower(str)' must use the index column expression 'upper(str)' as its input, not the underlying table column: When validating secondary index `text_idx`. (UNKNOWN_IDENTIFIER)
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

