### PR TITLE
Detect docker compose/pull infrastructure failures with FAIL status

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -47,12 +47,23 @@ INFRASTRUCTURE_ERROR_PATTERNS = [
 
 
 def _is_infrastructure_error(result: Result) -> bool:
-    """Returns True if the result is an ERROR caused by infrastructure issues."""
-    if result.status not in (Result.Status.ERROR, Result.StatusExtended.ERROR):
-        return False
+    """Returns True if the result is a failure caused by infrastructure issues."""
     if not result.info:
         return False
-    return any(pattern in result.info for pattern in INFRASTRUCTURE_ERROR_PATTERNS)
+    if result.status in (Result.Status.ERROR, Result.StatusExtended.ERROR):
+        return any(pattern in result.info for pattern in INFRASTRUCTURE_ERROR_PATTERNS)
+    # Docker compose/pull infrastructure failures may appear with FAIL status
+    # when pytest reports fixture (setup phase) errors as test failures.
+    # Require both docker context and an infrastructure pattern to avoid
+    # false positives on genuine test failures.
+    if result.status in (Result.Status.FAILED, Result.StatusExtended.FAIL):
+        has_docker_context = (
+            "'docker'" in result.info or "images_pull_cmd" in result.info
+        )
+        return has_docker_context and any(
+            p in result.info for p in INFRASTRUCTURE_ERROR_PATTERNS
+        )
+    return False
 
 
 def _mark_infrastructure_errors(results: list) -> int:


### PR DESCRIPTION
When `docker compose pull` times out during `start_cluster` fixture, pytest may report the outcome as `failed` instead of `error`, resulting in FAIL status. The `_is_infrastructure_error` function previously only checked ERROR status, so these docker infrastructure failures were not detected and could not be retried.

Now for FAIL status, we also check for infrastructure patterns when the traceback indicates a docker operation (subprocess command containing `'docker'` or cluster.py `images_pull_cmd` in the traceback). This avoids false positives on genuine test failures that happen to mention timeouts.

Example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99918&sha=be5a382e49024e28389510f230e6c39ce12c50f7&name_0=PR&name_1=Integration%20tests%20%28amd_llvm_coverage%2C%202%2F5%29
https://github.com/ClickHouse/ClickHouse/pull/99918 — all 200 failures are `docker compose pull` timing out at 180 seconds, but reported as FAIL instead of being detected as infrastructure errors.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.843`
<!-- ch-version-info:end -->