### PR TITLE
Add missing keeper_response_time_ms and keeper_batch_size_elements histograms to Keeper metrics export

### DIFF
--- a/src/Coordination/KeeperConstants.cpp
+++ b/src/Coordination/KeeperConstants.cpp
@@ -417,6 +417,7 @@ extern const std::vector<Metric> keeper_metrics
 }
 
 #define APPLY_FOR_KEEPER_HISTOGRAMS(M) \
+    M(KeeperResponseTime) \
     M(KeeperReceiveRequestTimeMetricFamily) \
     M(KeeperDispatcherRequestsQueueTimeMetricFamily) \
     M(KeeperWritePreCommitTimeMetricFamily) \
@@ -425,6 +426,7 @@ extern const std::vector<Metric> keeper_metrics
     M(KeeperSendResponseTimeMetricFamily) \
     M(KeeperReadWaitForWriteTimeMetricFamily) \
     M(KeeperReadProcessTimeMetricFamily) \
+    M(KeeperBatchSizeElementsMetricFamily) \
     M(KeeperBatchSizeBytesMetricFamily) \
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description]
Seems like we lost 2 histograms in APPLY_FOR_KEEPER_HISTOGRAMS in KeeperConstants.cpp. Put them back.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.921`
<!-- ch-version-info:end -->