### PR TITLE
Fix `copy_file_from_s3_with_version` not recording download usage in `StorageUsage`

### DIFF
--- a/ci/praktika/s3.py
+++ b/ci/praktika/s3.py
@@ -494,6 +494,7 @@ class S3:
 
             # Retry on transient credential failures (IMDS temporarily unreachable)
             version = cls._retry_on_no_credentials(_download)
+            StorageUsage.add_downloaded(local_path)
             print(f"Downloaded file from S3 with version {version} using boto3")
             return version
 
@@ -511,7 +512,7 @@ class S3:
         )
         metadata = json.loads(output)
         version = int(metadata.get("Metadata", {}).get("version", "0"))
-
+        StorageUsage.add_downloaded(local_path)
         print(f"Downloaded file from S3 with version {version} using AWS CLI")
         return version
 


### PR DESCRIPTION
Both the boto3 and AWS CLI branches were missing a call to `StorageUsage.add_downloaded` after a successful download, causing `storage_usage` to underreport downloaded bytes in CIDB metrics.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.845`
<!-- ch-version-info:end -->