### PR TITLE
Fix flaky test_storage_dict when run multiple times

### DIFF
--- a/tests/integration/test_storage_dict/test.py
+++ b/tests/integration/test_storage_dict/test.py
@@ -26,6 +26,15 @@ def cluster():
 def test_storage_dict(cluster):
     node1 = cluster.instances["node1"]
 
+    cluster.exec_in_container(
+        cluster.nginx_id,
+        ["rm", "-f", "/usr/share/nginx/files/test_dict"],
+    )
+
+    node1.query("DROP DICTIONARY IF EXISTS dict")
+    node1.query("DROP DICTIONARY IF EXISTS dict1")
+    node1.query("DROP DICTIONARY IF EXISTS dict2")
+
     node1.query(f"insert into table function url(urldb) values ('foo', 'bar')")
     result = node1.query(f"select * from url(urldb)")
     assert result.strip() == "foo\tbar"


### PR DESCRIPTION
Fix flaky `test_storage_dict` integration test when run multiple times in the same cluster (e.g. targeted CI with `--count 10`).

The second PUT to nginx returns HTTP 204 (file already exists) which `assertResponseIsOk` rejects, and `CREATE DICTIONARY` fails with `DICTIONARY_ALREADY_EXISTS`. Clean up the nginx file and dictionaries at the start of each test run.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99751&sha=8ba3760a0d291cbfb672edbdf9ee6d6e817fad96&name_0=PR&name_1=Integration%20tests%20%28amd_asan%2C%20targeted%29
https://github.com/ClickHouse/ClickHouse/pull/99751

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.866`
<!-- ch-version-info:end -->