### PR TITLE
Fix flaky test 02572_query_views_log_background_thread

### DIFF
--- a/tests/queries/0_stateless/02572_query_views_log_background_thread.sh
+++ b/tests/queries/0_stateless/02572_query_views_log_background_thread.sh
@@ -33,6 +33,13 @@ for _ in {1..100}; do
     sleep 0.5
 done
 
+# Wait for the MV to finish writing to copy_02572 as well.
+# The buffer flush pipeline writes to data_02572 first (sink), then processes MVs (post-sink).
+# Data may appear in data_02572 before the MV completes writing to copy_02572.
+for _ in {1..100}; do
+    $CLICKHOUSE_CLIENT -q "select * from copy_02572;" | grep -q "1" && break
+    sleep 0.5
+done
 
 ${CLICKHOUSE_CLIENT} --ignore-error --query "select * from data_02572; select * from copy_02572;"
 


### PR DESCRIPTION
Fix race condition in test `02572_query_views_log_background_thread`.

The buffer flush pipeline writes to `data_02572` (sink) first, then processes materialized views (post-sink) which write to `copy_02572`. The test was only polling `data_02572` before asserting on both tables, so it could read `copy_02572` before the MV completed writing to it.

Added a second polling loop that waits for `copy_02572` to have data before the final assertion.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=bbc37a28a4ba68c6141991946718b6f4a4ac5755&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.865`
<!-- ch-version-info:end -->