### PR TITLE
check_cpp.sh: use word boundaries for keyword detection in {$ check

### DIFF
--- a/ci/jobs/scripts/check_style/check_cpp.sh
+++ b/ci/jobs/scripts/check_style/check_cpp.sh
@@ -35,7 +35,7 @@ find $ROOT_PATH/{src,base,programs,utils} -name '*.h' -or -name '*.cpp' 2>/dev/n
     grep -vP $EXCLUDE |
     grep -v 'src/Storages/System/StorageSystemDashboards.cpp' |
     grep -vP $EXCLUDE_DOCS |
-    xargs grep $@ -n -P '((class|struct|namespace|enum|if|for|while|else|throw|switch).*|\)(\s*const)?(\s*override)?\s*)\{$|\s$|^ {1,3}[^\* ]\S|\t|^\s*(if|else if|if constexpr|else if constexpr|for|while|catch|switch)\(|\( [^\s\\]|\S \)' |
+    xargs grep $@ -n -P '((\b(class|struct|namespace|enum|if|for|while|else|throw|switch)\b.*|\)(\s*const)?(\s*override)?\s*))\{$|\s$|^ {1,3}[^\* ]\S|\t|^\s*\b(if|else if|if constexpr|else if constexpr|for|while|catch|switch)\b\(|\( [^\s\\]|\S \)' |
 # a curly brace not in a new line, but not for the case of C++11 init or agg. initialization | trailing whitespace | number of ws not a multiple of 4, but not in the case of comment continuation | missing whitespace after for/if/while... before opening brace | whitespaces inside braces
     grep -v -P '//|\s+\*|\$\(\(| \)"' && echo "^ style error on this line"
 # single-line comment | continuation of a multiline comment | a typical piece of embedded shell code | something like ending of raw string literal


### PR DESCRIPTION
Main reason: https://github.com/ClickHouse/ClickHouse/pull/99981/changes/57ea780f38d7383954935676eaee417b14d5fefe

Keywords like `if`, `for`, `while`, `else` were matched as bare substrings, causing false positives when they appear as part of identifiers (e.g. `DataLakeSpecific` contains `if`, `throwSomething` contains `throw`).

Add `\b` word boundaries around all keyword alternatives so only actual C++ keywords trigger the heuristic.



### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.860`
<!-- ch-version-info:end -->