### PR TITLE
Fix cross-user data leak in `system.asynchronous_inserts`

### DIFF
--- a/src/Storages/System/StorageSystemAsynchronousInserts.cpp
+++ b/src/Storages/System/StorageSystemAsynchronousInserts.cpp
@@ -8,6 +8,8 @@
 #include <Interpreters/Context.h>
 #include <Core/DecimalFunctions.h>
 #include <Parsers/ASTInsertQuery.h>
+#include <Access/Common/AccessType.h>
+#include <Access/ContextAccess.h>
 
 namespace DB
 {
@@ -37,6 +39,9 @@ void StorageSystemAsynchronousInserts::fillData(MutableColumns & res_columns, Co
     if (!insert_queue)
         return;
 
+    const auto current_user_id = context->getUserID();
+    const bool show_all = context->getAccess()->isGranted(AccessType::SHOW_USERS);
+
     for (size_t shard_num = 0; shard_num < insert_queue->getPoolSize(); ++shard_num)
     {
         auto [queue, queue_lock] = insert_queue->getQueueLocked(shard_num);
@@ -44,6 +49,9 @@ void StorageSystemAsynchronousInserts::fillData(MutableColumns & res_columns, Co
         for (const auto & [first_update, elem] : queue)
         {
             const auto & [key, data] = elem;
+
+            if (!show_all && key.user_id != current_user_id)
+                continue;
 
             auto time_in_microseconds = [](const time_point<steady_clock> & timestamp)
             {

--- a/tests/queries/0_stateless/04043_system_asynchronous_inserts_user_filter.reference
+++ b/tests/queries/0_stateless/04043_system_asynchronous_inserts_user_filter.reference
@@ -1,0 +1,6 @@
+restricted_user sees:
+0
+secret_user sees:
+1
+admin sees:
+1

--- a/tests/queries/0_stateless/04043_system_asynchronous_inserts_user_filter.sh
+++ b/tests/queries/0_stateless/04043_system_asynchronous_inserts_user_filter.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+# Regression test: system.asynchronous_inserts must not leak cross-user insert metadata.
+# A user without SHOW_USERS privilege must only see their own pending inserts.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} -q "
+    DROP USER IF EXISTS secret_user_${CLICKHOUSE_DATABASE};
+    DROP USER IF EXISTS restricted_user_${CLICKHOUSE_DATABASE};
+    CREATE USER secret_user_${CLICKHOUSE_DATABASE};
+    CREATE USER restricted_user_${CLICKHOUSE_DATABASE};
+    DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.async_insert_test;
+    CREATE TABLE ${CLICKHOUSE_DATABASE}.async_insert_test (x UInt64) ENGINE=MergeTree ORDER BY x;
+    GRANT INSERT ON ${CLICKHOUSE_DATABASE}.async_insert_test TO secret_user_${CLICKHOUSE_DATABASE};
+    GRANT SELECT ON system.asynchronous_inserts TO secret_user_${CLICKHOUSE_DATABASE};
+    GRANT SELECT ON system.asynchronous_inserts TO restricted_user_${CLICKHOUSE_DATABASE};
+"
+
+# secret_user inserts with async_insert enabled and a very long flush timeout so the entry stays in the queue.
+${CLICKHOUSE_CLIENT} \
+    --user "secret_user_${CLICKHOUSE_DATABASE}" \
+    --async_insert 1 \
+    --async_insert_busy_timeout_max_ms 600000 \
+    --async_insert_busy_timeout_min_ms 600000 \
+    --wait_for_async_insert 0 \
+    -q "INSERT INTO ${CLICKHOUSE_DATABASE}.async_insert_test VALUES (42)"
+
+# restricted_user must see 0 rows (no cross-user visibility).
+echo "restricted_user sees:"
+${CLICKHOUSE_CLIENT} \
+    --user "restricted_user_${CLICKHOUSE_DATABASE}" \
+    -q "SELECT count() FROM system.asynchronous_inserts WHERE table = 'async_insert_test' AND database = '${CLICKHOUSE_DATABASE}'"
+
+# secret_user must see their own row.
+echo "secret_user sees:"
+${CLICKHOUSE_CLIENT} \
+    --user "secret_user_${CLICKHOUSE_DATABASE}" \
+    -q "SELECT count() FROM system.asynchronous_inserts WHERE table = 'async_insert_test' AND database = '${CLICKHOUSE_DATABASE}'"
+
+# Admin (current session) must see all rows.
+echo "admin sees:"
+${CLICKHOUSE_CLIENT} \
+    -q "SELECT count() FROM system.asynchronous_inserts WHERE table = 'async_insert_test' AND database = '${CLICKHOUSE_DATABASE}'"
+
+${CLICKHOUSE_CLIENT} -q "
+    DROP USER IF EXISTS secret_user_${CLICKHOUSE_DATABASE};
+    DROP USER IF EXISTS restricted_user_${CLICKHOUSE_DATABASE};
+    DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.async_insert_test;
+"


### PR DESCRIPTION
`StorageSystemAsynchronousInserts::fillData` iterated over all async
insert queue entries with no user filtering, allowing any user with
`SELECT ON system.asynchronous_inserts` to see pending inserts belonging
to other users (`query`, `database`, `table`, `entries.query_id`, etc.).

Fix: filter queue entries in `fillData` so that only the current user's
own entries are returned, unless the user has the `SHOW_USERS` privilege
(which represents elevated visibility over user-related data).

The `InsertQuery` struct already carries a `user_id` field populated
from `query_context->getUserID()` at push time; this fix simply
consults it during read.

just like system.query_cache (which has an [explicit design comment](https://github.com/ClickHouse/ClickHouse/blob/53a39f1a94f789a34f50f6491cb7ec5d386cbbfd/src/Storages/System/StorageSystemQueryResultCache.cpp#L55-L59) justifying cross-user visibility)
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.38`
- Backported to: `26.3.1.881`, `26.2.7.17`, `26.1.6.7`, `25.12.9.55`, `25.8.20.6`
<!-- ch-version-info:end -->