### PR TITLE
Fix flaky test 03209_parameterized_view_with_non_literal_params

### DIFF
--- a/tests/queries/0_stateless/03209_parameterized_view_with_non_literal_params.sql
+++ b/tests/queries/0_stateless/03209_parameterized_view_with_non_literal_params.sql
@@ -4,16 +4,17 @@ select 'Test with Date parameter';
 drop table if exists date_table_pv;
 create table date_table_pv (id Int32, dt Date) engine = Memory();
 
-insert into date_table_pv values(1, today());
-insert into date_table_pv values(2, yesterday());
+-- Use fixed dates to avoid timing issues across midnight boundary
+insert into date_table_pv values(1, '2000-01-01');
+insert into date_table_pv values(2, '1999-12-31');
 insert into date_table_pv values(3, toDate('1974-04-07'));
 
 drop view if exists date_pv;
 create view date_pv as select * from date_table_pv where dt =  {dtparam:Date};
 
-select id from date_pv(dtparam=today());
-select id from date_pv(dtparam=yesterday());
-select id from date_pv(dtparam=yesterday()+1);
+select id from date_pv(dtparam='2000-01-01');
+select id from date_pv(dtparam='1999-12-31');
+select id from date_pv(dtparam='2000-01-01');
 select id from date_pv(dtparam='1974-04-07');
 select id from date_pv(dtparam=toDate('1974-04-07'));
 select id from date_pv(dtparam=toString(toDate('1974-04-07')));
@@ -25,8 +26,9 @@ select 'Test with Date32 parameter';
 drop table if exists date32_table_pv;
 create table date32_table_pv (id Int32, dt Date32) engine = Memory();
 
-insert into date32_table_pv values(1, today());
-insert into date32_table_pv values(2, yesterday());
+-- Use fixed dates to avoid timing issues across midnight boundary
+insert into date32_table_pv values(1, '2000-01-01');
+insert into date32_table_pv values(2, '1999-12-31');
 insert into date32_table_pv values(3, toDate32('2199-12-31'));
 insert into date32_table_pv values(4, toDate32('1950-12-25'));
 insert into date32_table_pv values(5, toDate32('1900-01-01'));
@@ -34,9 +36,9 @@ insert into date32_table_pv values(5, toDate32('1900-01-01'));
 drop view if exists date32_pv;
 create view date32_pv as select * from date32_table_pv where dt =  {dtparam:Date32};
 
-select id from date32_pv(dtparam=today());
-select id from date32_pv(dtparam=yesterday());
-select id from date32_pv(dtparam=yesterday()+1);
+select id from date32_pv(dtparam='2000-01-01');
+select id from date32_pv(dtparam='1999-12-31');
+select id from date32_pv(dtparam='2000-01-01');
 select id from date32_pv(dtparam='2199-12-31');
 select id from date32_pv(dtparam=toDate32('1900-01-01'));
 select id from date32_pv(dtparam=(select dt from date32_table_pv where id = 3));
@@ -69,8 +71,8 @@ select 'Test with 2 parameters';
 
 drop view if exists date_pv2;
 create view date_pv2 as select * from date_table_pv where dt = {dtparam:Date} and id = {intparam:Int32};
-select id from date_pv2(dtparam=today(),intparam=1);
-select id from date_pv2(dtparam=today(),intparam=length('A'));
+select id from date_pv2(dtparam='2000-01-01',intparam=1);
+select id from date_pv2(dtparam='2000-01-01',intparam=length('A'));
 select id from date_pv2(dtparam='1974-04-07',intparam=length('AAA'));
 select id from date_pv2(dtparam=toDate('1974-04-07'),intparam=length('BBB'));
 


### PR DESCRIPTION
The test `03209_parameterized_view_with_non_literal_params`.sql uses non-deterministic functions `today()` and `yesterday() `in both INSERT and SELECT statements. If the test execution spans across a date boundary, the results become inconsistent because these functions are re-evaluated at query time.

Timing Analysis from CI Logs:

  Failed test run (test_ag6tvgcz):
  2026.03.19 07:59:59.775640 - query 5:  insert into date_table_pv values(1, today())
  2026.03.19 07:59:59.796646 - query 6:  insert into date_table_pv values(2, yesterday())
  2026.03.19 07:59:59.830503 - query 10: select id from date_pv(dtparam=today())    -- returned id=1 ✓
  2026.03.19 07:59:59.841073 - query 11: select id from date_pv(dtparam=yesterday())  -- returned id=2 ✓
  ...
  2026.03.19 07:59:59.961472 - query 21: insert into date32_table_pv values(1, today())
  2026.03.19 07:59:59.975765 - query 22: insert into date32_table_pv values(2, yesterday())
  ...
  2026.03.19 08:00:00.024080 - query 28: select id from date32_pv(dtparam=today())    -- returned empty!
  2026.03.19 08:00:00.028208 - query 29: select id from date32_pv(dtparam=yesterday())  -- returned empty!

  The test failed because the execution crossed from 07:59:59 to 08:00:00, and the date functions returned different values between INSERT and SELECT operations.

CI report: 
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=94140&sha=5d11770d7df6f28bdbf7e8f4f230ee266c6b3c2f&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/94140

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.22`
<!-- ch-version-info:end -->