### PR TITLE
Fix `Nullable(Tuple)` not working with `CSV`, `MsgPack` format properly

### DIFF
--- a/src/Processors/Formats/Impl/ArrowColumnToCHColumn.cpp
+++ b/src/Processors/Formats/Impl/ArrowColumnToCHColumn.cpp
@@ -1408,7 +1408,7 @@ static ColumnWithTypeAndName readColumnFromArrowColumn(
         arrow_column->type()->id() != arrow::Type::LARGE_LIST &&
         arrow_column->type()->id() != arrow::Type::FIXED_SIZE_LIST &&
         arrow_column->type()->id() != arrow::Type::MAP &&
-        arrow_column->type()->id() != arrow::Type::STRUCT &&
+        arrow_column->type()->id() != arrow::Type::STRUCT && /// TODO: support Nullable(Tuple(...)) for Arrow/ORC
         arrow_column->type()->id() != arrow::Type::DICTIONARY)
     {
         DataTypePtr nested_type_hint;

--- a/src/Processors/Formats/Impl/CSVRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/CSVRowInputFormat.cpp
@@ -15,6 +15,7 @@
 #include <DataTypes/Serializations/SerializationNullable.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeTuple.h>
 
 
 namespace DB
@@ -377,8 +378,23 @@ bool CSVFormatReader::readField(
         /// commas, which might be also used as delimiters. However,
         /// they do not contain empty unquoted fields, so this check
         /// works for tuples as well.
-        column.insertDefault();
-        return false;
+        ///
+        /// Exception: `Nullable(Tuple())` with zero elements serializes to
+        /// an empty field in CSV, so an empty value is its only valid
+        /// representation. Let it fall through to normal deserialization
+        /// instead of inserting NULL as the default.
+        bool is_nullable_empty_tuple = false;
+        if (type->isNullable())
+        {
+            if (const auto * tuple_type = typeid_cast<const DataTypeTuple *>(removeNullable(type).get()))
+                is_nullable_empty_tuple = tuple_type->getElements().empty();
+        }
+
+        if (!is_nullable_empty_tuple)
+        {
+            column.insertDefault();
+            return false;
+        }
     }
 
     if (format_settings.csv.use_default_on_bad_values)

--- a/src/Processors/Formats/Impl/MsgPackRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/MsgPackRowInputFormat.cpp
@@ -398,14 +398,26 @@ bool MsgPackVisitor::start_array(size_t size) // NOLINT
         if (size > 0)
             info_stack.push(Info{nested_column, nested_type, false, size, nullptr});
     }
-    else if (isTuple(info_stack.top().type))
+    else if (isTuple(removeNullable(info_stack.top().type)))
     {
-        const auto & tuple_type = assert_cast<const DataTypeTuple &>(*info_stack.top().type);
+        /// If the type is Nullable, reaching start_array means the value
+        /// is non-null (for nulls, the parser calls visit_nil instead).
+        /// So we can safely unwrap the Nullable to work with the inner
+        /// ColumnTuple directly.
+        IColumn * column_ptr = &info_stack.top().column;
+        if (info_stack.top().type->isNullable())
+        {
+            auto & nullable_column = assert_cast<ColumnNullable &>(*column_ptr);
+            nullable_column.getNullMapColumn().insertValue(0);
+            column_ptr = &nullable_column.getNestedColumn();
+        }
+
+        const auto & tuple_type = assert_cast<const DataTypeTuple &>(*removeNullable(info_stack.top().type));
         const auto & nested_types = tuple_type.getElements();
         if (size != nested_types.size())
             throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Cannot insert MessagePack array with size {} into Tuple column with {} elements", size, nested_types.size());
 
-        ColumnTuple & column_tuple = assert_cast<ColumnTuple &>(info_stack.top().column);
+        ColumnTuple & column_tuple = assert_cast<ColumnTuple &>(*column_ptr);
         /// Push nested columns into stack in reverse order.
         for (ssize_t i = static_cast<ssize_t>(nested_types.size()) - 1; i >= 0; --i)
             info_stack.push(Info{column_tuple.getColumn(i), nested_types[i], true, std::nullopt, nullptr});

--- a/src/Processors/Formats/Impl/MsgPackRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/MsgPackRowInputFormat.cpp
@@ -400,6 +400,11 @@ bool MsgPackVisitor::start_array(size_t size) // NOLINT
     }
     else if (isTuple(removeNullable(info_stack.top().type)))
     {
+        const auto & tuple_type = assert_cast<const DataTypeTuple &>(*removeNullable(info_stack.top().type));
+        const auto & nested_types = tuple_type.getElements();
+        if (size != nested_types.size())
+            throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Cannot insert MessagePack array with size {} into Tuple column with {} elements", size, nested_types.size());
+
         /// If the type is Nullable, reaching start_array means the value
         /// is non-null (for nulls, the parser calls visit_nil instead).
         /// So we can safely unwrap the Nullable to work with the inner
@@ -411,11 +416,6 @@ bool MsgPackVisitor::start_array(size_t size) // NOLINT
             nullable_column.getNullMapColumn().insertValue(0);
             column_ptr = &nullable_column.getNestedColumn();
         }
-
-        const auto & tuple_type = assert_cast<const DataTypeTuple &>(*removeNullable(info_stack.top().type));
-        const auto & nested_types = tuple_type.getElements();
-        if (size != nested_types.size())
-            throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Cannot insert MessagePack array with size {} into Tuple column with {} elements", size, nested_types.size());
 
         ColumnTuple & column_tuple = assert_cast<ColumnTuple &>(*column_ptr);
         /// Push nested columns into stack in reverse order.

--- a/src/Processors/Formats/Impl/MsgPackRowInputFormat.h
+++ b/src/Processors/Formats/Impl/MsgPackRowInputFormat.h
@@ -65,7 +65,7 @@ class MsgPackRowInputFormat : public IRowInputFormat
 public:
     MsgPackRowInputFormat(SharedHeader header_, ReadBuffer & in_, Params params_, const FormatSettings & settings);
 
-    String getName() const override { return "MagPackRowInputFormat"; }
+    String getName() const override { return "MsgPackRowInputFormat"; }
     void resetParser() override;
     void setReadBuffer(ReadBuffer & in_) override;
     void resetReadBuffer() override;

--- a/tests/queries/0_stateless/04019_formats_nullable_empty_tuple_roundtrip.reference
+++ b/tests/queries/0_stateless/04019_formats_nullable_empty_tuple_roundtrip.reference
@@ -1,0 +1,187 @@
+-- { echo }
+
+SET allow_experimental_nullable_tuple_type = 1;
+SET engine_file_truncate_on_insert = 1;
+DROP TABLE IF EXISTS test_nullable_empty_tuple;
+CREATE TABLE test_nullable_empty_tuple (c0 Nullable(Tuple())) ENGINE = Memory;
+INSERT INTO TABLE test_nullable_empty_tuple (c0) VALUES (()), (NULL), (());
+SELECT 'CSV';
+CSV
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.csv', 'CSV', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.csv', 'CSV', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'TabSeparated';
+TabSeparated
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.tsv', 'TabSeparated', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.tsv', 'TabSeparated', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'TabSeparatedRaw';
+TabSeparatedRaw
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.tsvraw', 'TabSeparatedRaw', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.tsvraw', 'TabSeparatedRaw', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'JSONEachRow';
+JSONEachRow
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.json', 'JSONEachRow', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.json', 'JSONEachRow', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'JSONCompactEachRow';
+JSONCompactEachRow
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.jsoncompact', 'JSONCompactEachRow', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.jsoncompact', 'JSONCompactEachRow', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'JSONStringsEachRow';
+JSONStringsEachRow
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.jsonstr', 'JSONStringsEachRow', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.jsonstr', 'JSONStringsEachRow', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'JSONCompactStringsEachRow';
+JSONCompactStringsEachRow
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.jsoncstr', 'JSONCompactStringsEachRow', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.jsoncstr', 'JSONCompactStringsEachRow', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'Values';
+Values
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.values', 'Values', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.values', 'Values', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'TSKV';
+TSKV
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.tskv', 'TSKV', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.tskv', 'TSKV', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'CustomSeparated';
+CustomSeparated
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.custom', 'CustomSeparated', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.custom', 'CustomSeparated', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'Native';
+Native
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.native', 'Native', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.native', 'Native', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'RowBinary';
+RowBinary
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.rowbin', 'RowBinary', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.rowbin', 'RowBinary', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'Avro';
+Avro
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.avro', 'Avro', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.avro', 'Avro', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'MsgPack';
+MsgPack
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.msgpack', 'MsgPack', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.msgpack', 'MsgPack', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'BSONEachRow';
+BSONEachRow
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.bson', 'BSONEachRow', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.bson', 'BSONEachRow', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'JSON';
+JSON
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.jsonall', 'JSON', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.jsonall', 'JSON', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'JSONCompact';
+JSONCompact
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.jsoncompactall', 'JSONCompact', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.jsoncompactall', 'JSONCompact', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'JSONColumns';
+JSONColumns
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.jsoncols', 'JSONColumns', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.jsoncols', 'JSONColumns', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'JSONCompactColumns';
+JSONCompactColumns
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.jsonccols', 'JSONCompactColumns', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.jsonccols', 'JSONCompactColumns', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'JSONColumnsWithMetadata';
+JSONColumnsWithMetadata
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.jsoncolsmeta', 'JSONColumnsWithMetadata', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.jsoncolsmeta', 'JSONColumnsWithMetadata', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'JSONObjectEachRow';
+JSONObjectEachRow
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.jsonobj', 'JSONObjectEachRow', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.jsonobj', 'JSONObjectEachRow', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'Buffers';
+Buffers
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.buf', 'Buffers', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.buf', 'Buffers', 'c0 Nullable(Tuple())');
+()
+\N
+()
+-- Parquet doesn't support empty tuples by design
+SELECT 'Parquet';
+Parquet
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.parquet', 'Parquet', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple; -- { serverError BAD_ARGUMENTS }
+-- TODO: Does not work for Arrow, ArrowStream, and ORC but should
+SELECT 'Arrow';
+Arrow
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.arrow', 'Arrow', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.arrow', 'Arrow', 'c0 Nullable(Tuple())');
+()
+()
+()
+SELECT 'ArrowStream';
+ArrowStream
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.arrowstream', 'ArrowStream', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.arrowstream', 'ArrowStream', 'c0 Nullable(Tuple())');
+()
+()
+()
+SELECT 'ORC';
+ORC
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.orc', 'ORC', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.orc', 'ORC', 'c0 Nullable(Tuple())');
+()
+()
+()

--- a/tests/queries/0_stateless/04019_formats_nullable_empty_tuple_roundtrip.sql
+++ b/tests/queries/0_stateless/04019_formats_nullable_empty_tuple_roundtrip.sql
@@ -1,0 +1,113 @@
+-- { echo }
+
+SET allow_experimental_nullable_tuple_type = 1;
+SET engine_file_truncate_on_insert = 1;
+
+DROP TABLE IF EXISTS test_nullable_empty_tuple;
+CREATE TABLE test_nullable_empty_tuple (c0 Nullable(Tuple())) ENGINE = Memory;
+INSERT INTO TABLE test_nullable_empty_tuple (c0) VALUES (()), (NULL), (());
+
+SELECT 'CSV';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.csv', 'CSV', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.csv', 'CSV', 'c0 Nullable(Tuple())');
+
+SELECT 'TabSeparated';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.tsv', 'TabSeparated', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.tsv', 'TabSeparated', 'c0 Nullable(Tuple())');
+
+SELECT 'TabSeparatedRaw';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.tsvraw', 'TabSeparatedRaw', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.tsvraw', 'TabSeparatedRaw', 'c0 Nullable(Tuple())');
+
+SELECT 'JSONEachRow';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.json', 'JSONEachRow', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.json', 'JSONEachRow', 'c0 Nullable(Tuple())');
+
+SELECT 'JSONCompactEachRow';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.jsoncompact', 'JSONCompactEachRow', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.jsoncompact', 'JSONCompactEachRow', 'c0 Nullable(Tuple())');
+
+SELECT 'JSONStringsEachRow';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.jsonstr', 'JSONStringsEachRow', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.jsonstr', 'JSONStringsEachRow', 'c0 Nullable(Tuple())');
+
+SELECT 'JSONCompactStringsEachRow';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.jsoncstr', 'JSONCompactStringsEachRow', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.jsoncstr', 'JSONCompactStringsEachRow', 'c0 Nullable(Tuple())');
+
+SELECT 'Values';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.values', 'Values', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.values', 'Values', 'c0 Nullable(Tuple())');
+
+SELECT 'TSKV';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.tskv', 'TSKV', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.tskv', 'TSKV', 'c0 Nullable(Tuple())');
+
+SELECT 'CustomSeparated';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.custom', 'CustomSeparated', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.custom', 'CustomSeparated', 'c0 Nullable(Tuple())');
+
+SELECT 'Native';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.native', 'Native', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.native', 'Native', 'c0 Nullable(Tuple())');
+
+SELECT 'RowBinary';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.rowbin', 'RowBinary', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.rowbin', 'RowBinary', 'c0 Nullable(Tuple())');
+
+SELECT 'Avro';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.avro', 'Avro', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.avro', 'Avro', 'c0 Nullable(Tuple())');
+
+SELECT 'MsgPack';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.msgpack', 'MsgPack', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.msgpack', 'MsgPack', 'c0 Nullable(Tuple())');
+
+SELECT 'BSONEachRow';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.bson', 'BSONEachRow', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.bson', 'BSONEachRow', 'c0 Nullable(Tuple())');
+
+SELECT 'JSON';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.jsonall', 'JSON', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.jsonall', 'JSON', 'c0 Nullable(Tuple())');
+
+SELECT 'JSONCompact';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.jsoncompactall', 'JSONCompact', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.jsoncompactall', 'JSONCompact', 'c0 Nullable(Tuple())');
+
+SELECT 'JSONColumns';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.jsoncols', 'JSONColumns', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.jsoncols', 'JSONColumns', 'c0 Nullable(Tuple())');
+
+SELECT 'JSONCompactColumns';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.jsonccols', 'JSONCompactColumns', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.jsonccols', 'JSONCompactColumns', 'c0 Nullable(Tuple())');
+
+SELECT 'JSONColumnsWithMetadata';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.jsoncolsmeta', 'JSONColumnsWithMetadata', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.jsoncolsmeta', 'JSONColumnsWithMetadata', 'c0 Nullable(Tuple())');
+
+SELECT 'JSONObjectEachRow';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.jsonobj', 'JSONObjectEachRow', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.jsonobj', 'JSONObjectEachRow', 'c0 Nullable(Tuple())');
+
+SELECT 'Buffers';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.buf', 'Buffers', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.buf', 'Buffers', 'c0 Nullable(Tuple())');
+
+-- Parquet doesn't support empty tuples by design
+SELECT 'Parquet';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.parquet', 'Parquet', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple; -- { serverError BAD_ARGUMENTS }
+
+-- TODO: Does not work for Arrow, ArrowStream, and ORC but should
+SELECT 'Arrow';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.arrow', 'Arrow', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.arrow', 'Arrow', 'c0 Nullable(Tuple())');
+
+SELECT 'ArrowStream';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.arrowstream', 'ArrowStream', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.arrowstream', 'ArrowStream', 'c0 Nullable(Tuple())');
+
+SELECT 'ORC';
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.orc', 'ORC', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
+SELECT c0 FROM file(currentDatabase() || '_04019.orc', 'ORC', 'c0 Nullable(Tuple())');

--- a/tests/queries/0_stateless/04019_formats_nullable_empty_tuple_roundtrip.sql
+++ b/tests/queries/0_stateless/04019_formats_nullable_empty_tuple_roundtrip.sql
@@ -1,3 +1,6 @@
+-- Tags: no-fasttest
+-- no-fasttest: Some formats not available in fasttest enviroment
+
 -- { echo }
 
 SET allow_experimental_nullable_tuple_type = 1;

--- a/tests/queries/0_stateless/04029_msgpack_nullable_empty_tuple_roundtrip.reference
+++ b/tests/queries/0_stateless/04029_msgpack_nullable_empty_tuple_roundtrip.reference
@@ -1,0 +1,75 @@
+-- { echo }
+
+SET allow_experimental_nullable_tuple_type = 1;
+SET engine_file_truncate_on_insert = 1;
+SELECT 'empty tuple';
+empty tuple
+DROP TABLE IF EXISTS test_empty;
+CREATE TABLE test_empty (c0 Nullable(Tuple())) ENGINE = Memory;
+INSERT INTO test_empty VALUES (()), (NULL), (());
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_empty.msgpack', 'MsgPack', 'c0 Nullable(Tuple())') SELECT c0 FROM test_empty;
+SELECT c0 FROM file(currentDatabase() || '_04029_empty.msgpack', 'MsgPack', 'c0 Nullable(Tuple())');
+()
+\N
+()
+SELECT 'single element';
+single element
+DROP TABLE IF EXISTS test_single;
+CREATE TABLE test_single (c0 Nullable(Tuple(Int32))) ENGINE = Memory;
+INSERT INTO test_single VALUES ((1)), (NULL), ((3));
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_single.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32))') SELECT c0 FROM test_single;
+SELECT c0 FROM file(currentDatabase() || '_04029_single.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32))');
+(1)
+\N
+(3)
+SELECT 'multiple elements';
+multiple elements
+DROP TABLE IF EXISTS test_multi;
+CREATE TABLE test_multi (c0 Nullable(Tuple(Int32, String, Float64))) ENGINE = Memory;
+INSERT INTO test_multi VALUES ((1, 'hello', 3.14)), (NULL), ((42, 'world', 2.72));
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_multi.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, String, Float64))') SELECT c0 FROM test_multi;
+SELECT c0 FROM file(currentDatabase() || '_04029_multi.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, String, Float64))');
+(1,'hello',3.14)
+\N
+(42,'world',2.7199999999999998)
+SELECT 'nested tuple';
+nested tuple
+DROP TABLE IF EXISTS test_nested;
+CREATE TABLE test_nested (c0 Nullable(Tuple(Int32, Tuple(String, Float64)))) ENGINE = Memory;
+INSERT INTO test_nested VALUES ((1, ('a', 0.1))), (NULL), ((2, ('b', 0.2)));
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_nested.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, Tuple(String, Float64)))') SELECT c0 FROM test_nested;
+SELECT c0 FROM file(currentDatabase() || '_04029_nested.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, Tuple(String, Float64)))');
+(1,('a',0.1))
+\N
+(2,('b',0.2))
+SELECT 'all nulls';
+all nulls
+DROP TABLE IF EXISTS test_allnull;
+CREATE TABLE test_allnull (c0 Nullable(Tuple(Int32))) ENGINE = Memory;
+INSERT INTO test_allnull VALUES (NULL), (NULL), (NULL);
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_allnull.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32))') SELECT c0 FROM test_allnull;
+SELECT c0 FROM file(currentDatabase() || '_04029_allnull.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32))');
+\N
+\N
+\N
+SELECT 'nested nullable tuple';
+nested nullable tuple
+DROP TABLE IF EXISTS test_nested_nullable;
+CREATE TABLE test_nested_nullable (c0 Nullable(Tuple(Int32, Nullable(Tuple(String, Int32))))) ENGINE = Memory;
+INSERT INTO test_nested_nullable VALUES ((1, ('a', 10))), (NULL), ((2, NULL)), ((3, ('b', 30)));
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_nested_nullable.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, Nullable(Tuple(String, Int32))))') SELECT c0 FROM test_nested_nullable;
+SELECT c0 FROM file(currentDatabase() || '_04029_nested_nullable.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, Nullable(Tuple(String, Int32))))');
+(1,('a',10))
+\N
+(2,NULL)
+(3,('b',30))
+SELECT 'multiple nullable tuple columns';
+multiple nullable tuple columns
+DROP TABLE IF EXISTS test_multicol;
+CREATE TABLE test_multicol (a Nullable(Tuple(Int32)), b Nullable(Tuple(String, String))) ENGINE = Memory;
+INSERT INTO test_multicol VALUES ((1), ('x', 'y')), (NULL, ('a', 'b')), ((3), NULL);
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_multicol.msgpack', 'MsgPack', 'a Nullable(Tuple(Int32)), b Nullable(Tuple(String, String))') SELECT a, b FROM test_multicol;
+SELECT a, b FROM file(currentDatabase() || '_04029_multicol.msgpack', 'MsgPack', 'a Nullable(Tuple(Int32)), b Nullable(Tuple(String, String))');
+(1)	('x','y')
+\N	('a','b')
+(3)	\N

--- a/tests/queries/0_stateless/04029_msgpack_nullable_empty_tuple_roundtrip.reference
+++ b/tests/queries/0_stateless/04029_msgpack_nullable_empty_tuple_roundtrip.reference
@@ -25,23 +25,23 @@ SELECT c0 FROM file(currentDatabase() || '_04029_single.msgpack', 'MsgPack', 'c0
 SELECT 'multiple elements';
 multiple elements
 DROP TABLE IF EXISTS test_multi;
-CREATE TABLE test_multi (c0 Nullable(Tuple(Int32, String, Float64))) ENGINE = Memory;
-INSERT INTO test_multi VALUES ((1, 'hello', 3.14)), (NULL), ((42, 'world', 2.72));
-INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_multi.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, String, Float64))') SELECT c0 FROM test_multi;
-SELECT c0 FROM file(currentDatabase() || '_04029_multi.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, String, Float64))');
-(1,'hello',3.14)
+CREATE TABLE test_multi (c0 Nullable(Tuple(Int32, String, Int64))) ENGINE = Memory;
+INSERT INTO test_multi VALUES ((1, 'hello', 314)), (NULL), ((42, 'world', 272));
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_multi.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, String, Int64))') SELECT c0 FROM test_multi;
+SELECT c0 FROM file(currentDatabase() || '_04029_multi.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, String, Int64))');
+(1,'hello',314)
 \N
-(42,'world',2.7199999999999998)
+(42,'world',272)
 SELECT 'nested tuple';
 nested tuple
 DROP TABLE IF EXISTS test_nested;
-CREATE TABLE test_nested (c0 Nullable(Tuple(Int32, Tuple(String, Float64)))) ENGINE = Memory;
-INSERT INTO test_nested VALUES ((1, ('a', 0.1))), (NULL), ((2, ('b', 0.2)));
-INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_nested.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, Tuple(String, Float64)))') SELECT c0 FROM test_nested;
-SELECT c0 FROM file(currentDatabase() || '_04029_nested.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, Tuple(String, Float64)))');
-(1,('a',0.1))
+CREATE TABLE test_nested (c0 Nullable(Tuple(Int32, Tuple(String, Int32)))) ENGINE = Memory;
+INSERT INTO test_nested VALUES ((1, ('a', 10))), (NULL), ((2, ('b', 20)));
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_nested.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, Tuple(String, Int32)))') SELECT c0 FROM test_nested;
+SELECT c0 FROM file(currentDatabase() || '_04029_nested.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, Tuple(String, Int32)))');
+(1,('a',10))
 \N
-(2,('b',0.2))
+(2,('b',20))
 SELECT 'all nulls';
 all nulls
 DROP TABLE IF EXISTS test_allnull;

--- a/tests/queries/0_stateless/04029_msgpack_nullable_empty_tuple_roundtrip.sql
+++ b/tests/queries/0_stateless/04029_msgpack_nullable_empty_tuple_roundtrip.sql
@@ -1,3 +1,6 @@
+-- Tags: no-fasttest
+-- no-fasttest: MsgPack format not available in fasttest enviroment
+
 -- { echo }
 
 SET allow_experimental_nullable_tuple_type = 1;

--- a/tests/queries/0_stateless/04029_msgpack_nullable_empty_tuple_roundtrip.sql
+++ b/tests/queries/0_stateless/04029_msgpack_nullable_empty_tuple_roundtrip.sql
@@ -1,0 +1,53 @@
+-- { echo }
+
+SET allow_experimental_nullable_tuple_type = 1;
+SET engine_file_truncate_on_insert = 1;
+
+SELECT 'empty tuple';
+DROP TABLE IF EXISTS test_empty;
+CREATE TABLE test_empty (c0 Nullable(Tuple())) ENGINE = Memory;
+INSERT INTO test_empty VALUES (()), (NULL), (());
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_empty.msgpack', 'MsgPack', 'c0 Nullable(Tuple())') SELECT c0 FROM test_empty;
+SELECT c0 FROM file(currentDatabase() || '_04029_empty.msgpack', 'MsgPack', 'c0 Nullable(Tuple())');
+
+SELECT 'single element';
+DROP TABLE IF EXISTS test_single;
+CREATE TABLE test_single (c0 Nullable(Tuple(Int32))) ENGINE = Memory;
+INSERT INTO test_single VALUES ((1)), (NULL), ((3));
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_single.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32))') SELECT c0 FROM test_single;
+SELECT c0 FROM file(currentDatabase() || '_04029_single.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32))');
+
+SELECT 'multiple elements';
+DROP TABLE IF EXISTS test_multi;
+CREATE TABLE test_multi (c0 Nullable(Tuple(Int32, String, Float64))) ENGINE = Memory;
+INSERT INTO test_multi VALUES ((1, 'hello', 3.14)), (NULL), ((42, 'world', 2.72));
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_multi.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, String, Float64))') SELECT c0 FROM test_multi;
+SELECT c0 FROM file(currentDatabase() || '_04029_multi.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, String, Float64))');
+
+SELECT 'nested tuple';
+DROP TABLE IF EXISTS test_nested;
+CREATE TABLE test_nested (c0 Nullable(Tuple(Int32, Tuple(String, Float64)))) ENGINE = Memory;
+INSERT INTO test_nested VALUES ((1, ('a', 0.1))), (NULL), ((2, ('b', 0.2)));
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_nested.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, Tuple(String, Float64)))') SELECT c0 FROM test_nested;
+SELECT c0 FROM file(currentDatabase() || '_04029_nested.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, Tuple(String, Float64)))');
+
+SELECT 'all nulls';
+DROP TABLE IF EXISTS test_allnull;
+CREATE TABLE test_allnull (c0 Nullable(Tuple(Int32))) ENGINE = Memory;
+INSERT INTO test_allnull VALUES (NULL), (NULL), (NULL);
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_allnull.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32))') SELECT c0 FROM test_allnull;
+SELECT c0 FROM file(currentDatabase() || '_04029_allnull.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32))');
+
+SELECT 'nested nullable tuple';
+DROP TABLE IF EXISTS test_nested_nullable;
+CREATE TABLE test_nested_nullable (c0 Nullable(Tuple(Int32, Nullable(Tuple(String, Int32))))) ENGINE = Memory;
+INSERT INTO test_nested_nullable VALUES ((1, ('a', 10))), (NULL), ((2, NULL)), ((3, ('b', 30)));
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_nested_nullable.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, Nullable(Tuple(String, Int32))))') SELECT c0 FROM test_nested_nullable;
+SELECT c0 FROM file(currentDatabase() || '_04029_nested_nullable.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, Nullable(Tuple(String, Int32))))');
+
+SELECT 'multiple nullable tuple columns';
+DROP TABLE IF EXISTS test_multicol;
+CREATE TABLE test_multicol (a Nullable(Tuple(Int32)), b Nullable(Tuple(String, String))) ENGINE = Memory;
+INSERT INTO test_multicol VALUES ((1), ('x', 'y')), (NULL, ('a', 'b')), ((3), NULL);
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_multicol.msgpack', 'MsgPack', 'a Nullable(Tuple(Int32)), b Nullable(Tuple(String, String))') SELECT a, b FROM test_multicol;
+SELECT a, b FROM file(currentDatabase() || '_04029_multicol.msgpack', 'MsgPack', 'a Nullable(Tuple(Int32)), b Nullable(Tuple(String, String))');

--- a/tests/queries/0_stateless/04029_msgpack_nullable_empty_tuple_roundtrip.sql
+++ b/tests/queries/0_stateless/04029_msgpack_nullable_empty_tuple_roundtrip.sql
@@ -19,17 +19,17 @@ SELECT c0 FROM file(currentDatabase() || '_04029_single.msgpack', 'MsgPack', 'c0
 
 SELECT 'multiple elements';
 DROP TABLE IF EXISTS test_multi;
-CREATE TABLE test_multi (c0 Nullable(Tuple(Int32, String, Float64))) ENGINE = Memory;
-INSERT INTO test_multi VALUES ((1, 'hello', 3.14)), (NULL), ((42, 'world', 2.72));
-INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_multi.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, String, Float64))') SELECT c0 FROM test_multi;
-SELECT c0 FROM file(currentDatabase() || '_04029_multi.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, String, Float64))');
+CREATE TABLE test_multi (c0 Nullable(Tuple(Int32, String, Int64))) ENGINE = Memory;
+INSERT INTO test_multi VALUES ((1, 'hello', 314)), (NULL), ((42, 'world', 272));
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_multi.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, String, Int64))') SELECT c0 FROM test_multi;
+SELECT c0 FROM file(currentDatabase() || '_04029_multi.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, String, Int64))');
 
 SELECT 'nested tuple';
 DROP TABLE IF EXISTS test_nested;
-CREATE TABLE test_nested (c0 Nullable(Tuple(Int32, Tuple(String, Float64)))) ENGINE = Memory;
-INSERT INTO test_nested VALUES ((1, ('a', 0.1))), (NULL), ((2, ('b', 0.2)));
-INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_nested.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, Tuple(String, Float64)))') SELECT c0 FROM test_nested;
-SELECT c0 FROM file(currentDatabase() || '_04029_nested.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, Tuple(String, Float64)))');
+CREATE TABLE test_nested (c0 Nullable(Tuple(Int32, Tuple(String, Int32)))) ENGINE = Memory;
+INSERT INTO test_nested VALUES ((1, ('a', 10))), (NULL), ((2, ('b', 20)));
+INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_nested.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, Tuple(String, Int32)))') SELECT c0 FROM test_nested;
+SELECT c0 FROM file(currentDatabase() || '_04029_nested.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32, Tuple(String, Int32)))');
 
 SELECT 'all nulls';
 DROP TABLE IF EXISTS test_allnull;


### PR DESCRIPTION
Given,

```sql
SET allow_experimental_nullable_tuple_type = 1;
SET engine_file_truncate_on_insert = 1;

CREATE TABLE test_nullable_empty_tuple (c0 Nullable(Tuple())) ENGINE = Memory;
INSERT INTO TABLE test_nullable_empty_tuple (c0) VALUES (()), (NULL), (());
```

CSV:
```sql
INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04019.csv', 'CSV', 'c0 Nullable(Tuple())') SELECT c0 FROM test_nullable_empty_tuple;
-- returns \N \N \N. Should be () \N ()
SELECT c0 FROM file(currentDatabase() || '_04019.csv', 'CSV', 'c0 Nullable(Tuple())');
```

MsgPack:
```sql
SET allow_experimental_nullable_tuple_type = 1;
SET engine_file_truncate_on_insert = 1;

CREATE TABLE test_single (c0 Nullable(Tuple(Int32))) ENGINE = Memory;
INSERT INTO test_single VALUES ((1)), (NULL), ((3));
INSERT INTO TABLE FUNCTION file(currentDatabase() || '_04029_single.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32))') SELECT c0 FROM test_single;

-- Throws error but should work
SELECT c0 FROM file(currentDatabase() || '_04029_single.msgpack', 'MsgPack', 'c0 Nullable(Tuple(Int32))');
```


This PR contains test for other formats as well to make sure they work with empty `Nullable(Tuple)`.

TODO: Currently, Arrow, ArrowStream, and ORC still have problem with `Nullable(Tuple)` which I will fix later in subsequent PR.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `CSV`, `MsgPack` format not being able to parse `Nullable(Tuple)` properly. Closes https://github.com/ClickHouse/ClickHouse/issues/99753.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.890`
<!-- ch-version-info:end -->