### PR TITLE
Pre-pull Docker images before integration tests start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /build
 /build_*
 /build-*
+/ci/tmp
 /tests/venv
 /obj-x86_64-linux-gnu/
 

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -1,9 +1,10 @@
 import argparse
 import os
+import re
 import subprocess
 import time
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from more_itertools import tail
 
@@ -101,6 +102,178 @@ def _start_docker_in_docker():
             )
         time.sleep(2)
     print(f"Started docker-in-docker asynchronously with PID {dockerd_proc.pid}")
+
+
+_COMPOSE_DIR = Path("./tests/integration/compose")
+
+# Explicit mapping for with_* flags whose compose file name cannot be derived
+# by simply prepending "docker_compose_" and appending ".yml".
+_WITH_FLAG_TO_COMPOSE: dict[str, List[str]] = {
+    "mysql57": ["docker_compose_mysql.yml"],
+    "mysql8": ["docker_compose_mysql_8_0.yml"],
+    "dremio26": ["docker_compose_dremio_26_0.yml"],
+    "kerberos_kdc": ["docker_compose_kerberos_kdc.yml"],
+    # with_iceberg_catalog can use any of the iceberg catalogs; include them all
+    "iceberg_catalog": [
+        "docker_compose_iceberg_rest_catalog.yml",
+        "docker_compose_iceberg_hms_catalog.yml",
+        "docker_compose_iceberg_lakekeeper_catalog.yml",
+        "docker_compose_iceberg_nessie_catalog.yml",
+    ],
+    "hms_catalog": ["docker_compose_iceberg_hms_catalog.yml"],
+    "glue_catalog": ["docker_compose_glue_catalog.yml"],
+    "prometheus_writer": ["docker_compose_prometheus.yml"],
+    "prometheus_reader": ["docker_compose_prometheus.yml"],
+    "prometheus_receiver": ["docker_compose_prometheus.yml"],
+    # with_odbc_drivers implicitly sets up mysql8 + postgres
+    "odbc_drivers": ["docker_compose_mysql_8_0.yml", "docker_compose_postgres.yml"],
+    # Flags with no separate compose file of their own
+    "jdbc_bridge": [],
+    "net_trics": [],
+}
+
+
+def get_compose_files_for_test_modules(test_modules: List[str]) -> List[Path]:
+    """Return compose files needed by the given test modules.
+
+    Grep every Python source file in each test suite directory for:
+    - `with_X=True` patterns (mapped via `_WITH_FLAG_TO_COMPOSE` or the obvious
+      `docker_compose_{X}.yml` naming convention), and
+    - explicit `docker_compose_*.yml` file name strings (used e.g. via
+      `extra_parameters={"docker_compose_file_name": "..."}` calls).
+    """
+    needed: set[Path] = set()
+    suite_dirs = {m.split("/")[0] for m in test_modules}
+
+    for suite_dir in suite_dirs:
+        suite_path = Path("./tests/integration/") / suite_dir
+        if not suite_path.is_dir():
+            continue
+        for py_file in suite_path.glob("**/*.py"):
+            try:
+                content = py_file.read_text(errors="replace")
+            except OSError:
+                continue
+
+            # 1. with_X=True → compose file via mapping or naming convention
+            for m in re.finditer(r"\bwith_(\w+)\s*=\s*True", content):
+                flag = m.group(1)
+                if flag in _WITH_FLAG_TO_COMPOSE:
+                    for fname in _WITH_FLAG_TO_COMPOSE[flag]:
+                        p = _COMPOSE_DIR / fname
+                        if p.exists():
+                            needed.add(p)
+                else:
+                    p = _COMPOSE_DIR / f"docker_compose_{flag}.yml"
+                    if p.exists():
+                        needed.add(p)
+
+            # 2. Directly named compose files (e.g. in extra_parameters dicts)
+            for m in re.finditer(r"(docker_compose_\w+\.yml)", content):
+                p = _COMPOSE_DIR / m.group(1)
+                if p.exists():
+                    needed.add(p)
+
+    return sorted(needed)
+
+
+def get_images_from_compose_files(compose_files: List[Path]) -> List[str]:
+    """Parse compose files and return a deduplicated list of image references.
+
+    Environment variable placeholders like `${DOCKER_NGINX_DAV_TAG:-latest}` are
+    resolved from `os.environ`.  For clickhouse images that appear without a tag
+    (e.g. `clickhouse/integration-test`) the tag is looked up from `IMAGES_ENV`.
+    Images with still-unresolvable variables are silently skipped.
+    """
+    known_image_tags: dict[str, str] = {}
+    for image_name, env_var in IMAGES_ENV.items():
+        tag = os.environ.get(env_var)
+        if tag:
+            known_image_tags[image_name] = tag
+
+    def resolve_image(raw: str) -> Optional[str]:
+        def replace_var(m: re.Match) -> str:
+            var_name = m.group(1)
+            default = m.group(2) if m.group(2) is not None else "latest"
+            return os.environ.get(var_name, default)
+
+        resolved = re.sub(r"\$\{(\w+)(?::-([^}]*))?\}", replace_var, raw)
+        if "${" in resolved:
+            return None  # Still-unresolvable variable — skip
+        # Append the correct tag for tagless known clickhouse images
+        if ":" not in resolved and resolved in known_image_tags:
+            resolved = f"{resolved}:{known_image_tags[resolved]}"
+        return resolved
+
+    images: set[str] = set()
+    for compose_file in compose_files:
+        try:
+            content = compose_file.read_text()
+        except OSError:
+            continue
+        for m in re.finditer(r"^\s+image:\s+(.+)$", content, re.MULTILINE):
+            resolved = resolve_image(m.group(1).strip())
+            if resolved:
+                images.add(resolved)
+
+    return sorted(images)
+
+
+def prefetch_images(
+    images: List[str], retries: int = 3, pull_timeout: int = 300
+) -> bool:
+    """Pull every image with up to `retries` attempts and a per-attempt `pull_timeout`.
+
+    Returns True if every image was pulled successfully, False otherwise.
+    """
+    if not images:
+        print("No images to pre-fetch.")
+        return True
+
+    print(f"Pre-fetching {len(images)} Docker image(s):")
+    for img in images:
+        print(f"  {img}")
+
+    failed: List[str] = []
+    total_start = time.perf_counter()
+    for image in images:
+        ok = False
+        for attempt in range(1, retries + 1):
+            print(
+                f"Pulling {image} (attempt {attempt}/{retries}, "
+                f"elapsed {time.perf_counter() - total_start:.1f}s) ...",
+                flush=True,
+            )
+            pull_start = time.perf_counter()
+            if Shell.check(
+                f"timeout {pull_timeout} docker pull {image}", verbose=True
+            ):
+                print(
+                    f"Pulled {image} in {time.perf_counter() - pull_start:.1f}s",
+                    flush=True,
+                )
+                ok = True
+                break
+            print(
+                f"Pull of {image} failed on attempt {attempt} "
+                f"({time.perf_counter() - pull_start:.1f}s elapsed)",
+                flush=True,
+            )
+            if attempt < retries:
+                time.sleep(5)
+        if not ok:
+            failed.append(image)
+
+    total_elapsed = time.perf_counter() - total_start
+    if failed:
+        print(
+            f"ERROR: Failed to pull the following image(s) after {retries} attempt(s) "
+            f"({total_elapsed:.1f}s total): {failed}"
+        )
+        return False
+
+    print(f"All images pre-fetched successfully in {total_elapsed:.1f}s.")
+    return True
 
 
 def parse_args():
@@ -616,6 +789,22 @@ tar -czf ./ci/tmp/logs.tar.gz \
             os.environ[env_name] = tag
         else:
             assert False, f"No tag found for image [{image_name}]"
+
+    # Pre-fetch all Docker images needed by the selected test suites.
+    # This is done after IMAGES_ENV vars are set so tag resolution works correctly.
+    # Fail fast here rather than discovering missing images mid-test-run.
+    all_test_modules = parallel_test_modules + sequential_test_modules
+    compose_files = get_compose_files_for_test_modules(all_test_modules)
+    print(
+        f"Compose files detected for this batch ({len(compose_files)}): "
+        + ", ".join(str(f.name) for f in compose_files)
+    )
+    images_to_prefetch = get_images_from_compose_files(compose_files)
+    if not prefetch_images(images_to_prefetch):
+        Result.create_from(
+            status=Result.Status.ERROR,
+            info="Failed to pre-pull Docker images needed by the test batch",
+        ).complete_job()
 
     test_env = {
         "CLICKHOUSE_TESTS_BASE_CONFIG_DIR": clickhouse_server_config_dir,

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -212,7 +212,10 @@ def get_images_from_compose_files(compose_files: List[Path]) -> List[str]:
         except OSError:
             continue
         for m in re.finditer(r"^\s+image:\s+(.+)$", content, re.MULTILINE):
-            resolved = resolve_image(m.group(1).strip())
+            # Strip inline YAML comments from unquoted values before resolving
+            # (e.g. `coredns/coredns:1.9.3 # :latest broke this test`).
+            raw = re.sub(r"\s+#.*$", "", m.group(1).strip())
+            resolved = resolve_image(raw)
             if resolved:
                 images.add(resolved)
 
@@ -222,58 +225,27 @@ def get_images_from_compose_files(compose_files: List[Path]) -> List[str]:
 def prefetch_images(
     images: List[str], retries: int = 3, pull_timeout: int = 300
 ) -> bool:
-    """Pull every image with up to `retries` attempts and a per-attempt `pull_timeout`.
+    """Pull every image in parallel using `ci/prefetch-integration-test-images`.
 
-    Returns True if every image was pulled successfully, False otherwise.
+    Images with no manifest for the current architecture (e.g. amd64-only images
+    on arm64 runners) are silently skipped.  Returns True on success, False if any
+    image fails to pull for a real reason.
     """
     if not images:
         print("No images to pre-fetch.")
         return True
 
-    print(f"Pre-fetching {len(images)} Docker image(s):")
-    for img in images:
-        print(f"  {img}")
-
-    failed: List[str] = []
-    total_start = time.perf_counter()
-    for image in images:
-        ok = False
-        for attempt in range(1, retries + 1):
-            print(
-                f"Pulling {image} (attempt {attempt}/{retries}, "
-                f"elapsed {time.perf_counter() - total_start:.1f}s) ...",
-                flush=True,
-            )
-            pull_start = time.perf_counter()
-            if Shell.check(
-                f"timeout {pull_timeout} docker pull {image}", verbose=True
-            ):
-                print(
-                    f"Pulled {image} in {time.perf_counter() - pull_start:.1f}s",
-                    flush=True,
-                )
-                ok = True
-                break
-            print(
-                f"Pull of {image} failed on attempt {attempt} "
-                f"({time.perf_counter() - pull_start:.1f}s elapsed)",
-                flush=True,
-            )
-            if attempt < retries:
-                time.sleep(5)
-        if not ok:
-            failed.append(image)
-
-    total_elapsed = time.perf_counter() - total_start
-    if failed:
-        print(
-            f"ERROR: Failed to pull the following image(s) after {retries} attempt(s) "
-            f"({total_elapsed:.1f}s total): {failed}"
-        )
-        return False
-
-    print(f"All images pre-fetched successfully in {total_elapsed:.1f}s.")
-    return True
+    script = f"{repo_dir}/ci/jobs/scripts/prefetch-integration-test-images"
+    env = {
+        **os.environ,
+        "PULL_RETRIES": str(retries),
+        "PULL_TIMEOUT": str(pull_timeout),
+    }
+    return Shell.check(
+        f"{script} {' '.join(images)}",
+        verbose=True,
+        env=env,
+    )
 
 
 def parse_args():

--- a/ci/jobs/scripts/prefetch-integration-test-images
+++ b/ci/jobs/scripts/prefetch-integration-test-images
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Pre-fetches Docker images in parallel before integration tests start.
+#
+# Images that are unavailable for the current architecture (e.g. amd64-only
+# images on arm64 runners) are silently skipped rather than failing the job.
+#
+# Usage:
+#   ci/prefetch-integration-test-images IMAGE [IMAGE ...]
+#
+# Environment variables:
+#   PULL_RETRIES   Number of pull attempts per image (default: 3)
+#   PULL_TIMEOUT   Per-attempt timeout in seconds (default: 300)
+
+set -uo pipefail
+
+PULL_RETRIES="${PULL_RETRIES:-3}"
+PULL_TIMEOUT="${PULL_TIMEOUT:-300}"
+
+images=("$@")
+if [[ ${#images[@]} -eq 0 ]]; then
+    echo "No images to pre-fetch."
+    exit 0
+fi
+
+echo "Pre-fetching ${#images[@]} Docker image(s) in parallel:"
+for img in "${images[@]}"; do
+    echo "  $img"
+done
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+
+pull_one()
+{
+    local image="$1"
+    local fail_file="$2"
+    local attempt out start elapsed
+
+    for ((attempt = 1; attempt <= PULL_RETRIES; attempt++)); do
+        echo "Pulling $image (attempt $attempt/$PULL_RETRIES) ..."
+        start=$SECONDS
+        if out=$(timeout "$PULL_TIMEOUT" docker pull "$image" 2>&1); then
+            elapsed=$((SECONDS - start))
+            echo "Pulled $image in ${elapsed}s"
+            return 0
+        fi
+        elapsed=$((SECONDS - start))
+        # Arch-specific image — not a real failure on this runner.
+        if echo "$out" | grep -q "no matching manifest"; then
+            echo "SKIP $image: no manifest for this architecture (${elapsed}s)"
+            return 0
+        fi
+        echo "Pull of $image failed on attempt $attempt (${elapsed}s elapsed):"
+        echo "$out"
+        if ((attempt < PULL_RETRIES)); then
+            sleep 5
+        fi
+    done
+
+    echo "FAILED to pull $image after $PULL_RETRIES attempt(s)"
+    echo "$image" > "$fail_file"
+    return 1
+}
+
+# Launch all pulls in parallel; each writes its image name to a unique file on failure.
+pids=()
+for image in "${images[@]}"; do
+    # Sanitize image name to a safe filename.
+    safe="${image//[^a-zA-Z0-9._-]/_}"
+    pull_one "$image" "$work_dir/fail_${safe}" &
+    pids+=($!)
+done
+
+# Collect exit statuses.
+any_fail=0
+for pid in "${pids[@]}"; do
+    wait "$pid" || any_fail=1
+done
+
+# Report failures.
+failed=()
+for f in "$work_dir"/fail_*; do
+    [[ -s "$f" ]] && failed+=("$(cat "$f")")
+done
+
+if [[ ${#failed[@]} -gt 0 ]]; then
+    echo "ERROR: Failed to pull the following image(s) after $PULL_RETRIES attempt(s): ${failed[*]}"
+    exit 1
+fi
+
+if [[ $any_fail -ne 0 ]]; then
+    # A pull_one returned non-zero without writing a fail file — shouldn't happen,
+    # but guard against it anyway.
+    echo "ERROR: One or more image pulls failed unexpectedly."
+    exit 1
+fi
+
+echo "All images pre-fetched successfully."

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -152,6 +152,13 @@ class Runner:
     def _pre_run(self, workflow, job, local_run=False):
         if job.name == Settings.CI_CONFIG_JOB_NAME:
             GH.print_actions_debug_info()
+        dirty = Shell.get_output("git status --short", verbose=False) or ""
+        if dirty:
+            print(f"NOTE: Dirty repo state before job start:\n{dirty}")
+            print("NOTE: Cleaning repo")
+            Shell.check("git clean -ffd", verbose=True)
+        else:
+            print("NOTE: Repo state is clean before job start")
         env = _Environment.get()
 
         result = Result(
@@ -835,6 +842,12 @@ class Runner:
                 except Exception as e:
                     traceback.print_exc()
                     print(f"ERROR: failed to notify Slack users: {e}")
+
+        dirty = Shell.get_output("git status --short", verbose=False) or ""
+        if dirty:
+            print(f"NOTE: Dirty repo state after job:\n{dirty}")
+        else:
+            print("NOTE: Repo state is clean after job")
 
         return is_ok
 


### PR DESCRIPTION
Integration tests pull Docker images on demand inside individual test fixtures.
When the registry is slow or flaky this causes mid-run failures that are
hard to distinguish from real test failures, and wastes time retrying inside
the already-running session.

This change adds a pre-fetch step that runs before any test is executed:

1. Grep every Python source file in the test suite directories selected for
   the current batch for `with_X=True` patterns and explicit
   `docker_compose_*.yml` filename strings.
2. Map the detected flags to the corresponding compose files in
   `tests/integration/compose/` using a small override table for non-obvious
   names (e.g. `with_mysql57` → `docker_compose_mysql.yml`) and the obvious
   `docker_compose_{flag}.yml` convention for everything else.
3. Parse `image:` entries from those compose files, resolving
   `${VAR:-default}` placeholders from the environment (tags for
   `clickhouse/*` images are already set from `IMAGES_ENV` at this point).
4. Pull every image with up to 3 attempts (300 s timeout per attempt, 5 s
   sleep between retries). Each pull line logs elapsed time. If any image
   cannot be pulled the job fails immediately with an `ERROR` status rather
   than letting the failure surface mid-test.

**Potential drawback:** many integration test jobs start simultaneously, so pre-fetching images up-front from all of them may put extra load on the registry proxy. To mitigate this, the pre-fetch step only pulls images required for the specific job batch rather than the full set. This change may still need to be reverted if the proxy turns out to be overloaded in practice.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.53`
<!-- ch-version-info:end -->