### PR TITLE
Add perf-report Claude skill and fix CI report artifact links

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -33,7 +33,7 @@ node .claude/tools/fetch_ci_report.js "<url>" --failed --download-logs
 #   --links                     Show artifact links (logs.tar.gz, etc.)
 #   --cidb                      Show CIDB links for failed tests
 #   --report <number>           For PR URLs: fetch only one specific report
-#   --download-logs             Download logs.tar.gz to /tmp/ci_logs.tar.gz
+#   --download-logs [path]      Download logs to path (default: /tmp/ci_logs.tar.{gz,zst})
 #   --credentials <user,password>  HTTP Basic Auth for private repositories
 ```
 

--- a/.claude/skills/perf-report/SKILL.md
+++ b/.claude/skills/perf-report/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: perf-report
+description: Analyze CI performance comparison reports for a ClickHouse PR. Lists all regressions and improvements, cross-references with master history to distinguish real changes from flaky tests.
+argument-hint: "<PR-number or CI-report-URL>"
+disable-model-invocation: false
+allowed-tools: Bash, Read, Grep, Glob, WebFetch
+---
+
+# Performance Report Analysis Skill
+
+## Arguments
+
+- `$0` (required): PR number (e.g. `99474`) or a CI report URL
+
+## Steps
+
+### 1. Fetch performance data
+
+Use the `fetch_perf_report.py` tool to get TSV data for both architectures:
+
+```bash
+python3 .claude/tools/fetch_perf_report.py "https://github.com/ClickHouse/ClickHouse/pull/$PR" --arch amd --tsv
+python3 .claude/tools/fetch_perf_report.py "https://github.com/ClickHouse/ClickHouse/pull/$PR" --arch arm --tsv
+```
+
+If a direct CI report URL is given instead of a PR number, use it directly.
+
+Extract all changed queries (column 10 == 1 means the change exceeds the threshold):
+- Column 1: test name
+- Column 2: query index
+- Column 4: shard
+- Column 5: old time
+- Column 6: new time
+- Column 8: ratio (e.g. 1.5 = 1.5x)
+- Column 10: 1 if changed, 0 if within threshold
+- Column 12: "slower" or "faster"
+- Column 13: query text
+
+### 2. List ALL changes
+
+Present the **complete, unfiltered** list of all changes above 1.10x, sorted by magnitude, for both architectures separately. Use tables with columns: Magnitude, Direction, Test, Query#, Shard.
+
+Do NOT summarize, collapse, or hide entries. Do NOT dismiss anything as "noise" or "not actionable" without evidence. Every entry must be visible.
+
+### 3. Cross-reference with master history
+
+For every test that shows as slower or faster above 1.10x, check the public CI database to determine if this is a known flaky test or a genuine change introduced by the PR.
+
+Query the public CI database:
+
+```bash
+clickhouse client --host play.clickhouse.com --user explorer --secure -q "
+SELECT
+    replaceRegexpOne(test_name, '::(new|old)$', '') AS test,
+    countIf(test_status = 'slower') AS slower_count,
+    countIf(test_status = 'faster') AS faster_count,
+    countIf(test_status = 'unstable') AS unstable_count,
+    count() AS total_runs
+FROM default.checks
+WHERE pull_request_number = 0
+  AND check_name LIKE '%Performance%amd%'  -- or arm
+  AND check_start_time >= now() - INTERVAL 30 DAY
+  AND test_name IN (
+    'test_name #N::new',
+    ...
+  )
+GROUP BY test
+ORDER BY slower_count DESC, test
+"
+```
+
+**Important:**
+- `pull_request_number = 0` means master commits
+- Test names in the DB have `::new` and `::old` suffixes — query with `::new`
+- Use `%amd%` for AMD results and `%arm%` for ARM results
+- Query both architectures separately
+
+### 4. Classify each change
+
+For each test, classify based on the master history:
+
+- **Flaky on master**: appears as slower in >1% of master runs, or has many unstable entries. Note the ratio (e.g. "8/685 runs, flaky").
+- **Never on master**: 0 slower appearances in the last 30 days with a meaningful number of total runs (>50). This is likely a genuine regression introduced by the PR.
+- **Rarely on master**: 1-2 appearances out of hundreds. Treat as borderline — note it but don't dismiss.
+- For "faster" results: check if the test was previously *slower* on master (meaning this PR fixes it) or if it was never faster before (genuine improvement).
+
+### 5. Present the verdict
+
+Present the final classification in a table per architecture:
+
+| Magnitude | Test | Master slower/total (30d) | Verdict |
+|---|---|---|---|
+
+Classify as:
+- **Flaky** — frequently appears on master, dismiss
+- **Unstable** — high unstable count on master, dismiss
+- **Never on master — investigate** — genuine regression
+- **Rarely on master** — borderline, note it
+- **Real improvement** — never faster on master before, or fixes a previously-slower test
+
+### 6. Summary
+
+After the tables, provide a brief summary:
+- Count of genuine regressions (never on master) per architecture
+- Count of genuine improvements per architecture
+- Count of flaky/dismissed entries
+- Call out any extreme outliers (>2x) explicitly regardless of flaky status
+
+### 7. Deep-dive: accessing CI logs (when asked)
+
+When the user asks to investigate a specific regression further, download and analyze the CI artifacts.
+
+**Get artifact links** using the `fetch_ci_report.js` tool with `--links`:
+
+```bash
+node .claude/tools/fetch_ci_report.js "<CI-report-URL-for-specific-shard>" --links
+```
+
+This will show `logs.tar.zst`, `job.log.zst`, `all-query-metrics.tsv`, `report.html`, etc.
+
+**Download and extract server logs:**
+
+```bash
+curl -sS "<logs.tar.zst-URL>" -o tmp/perf_logs.tar.zst
+tar -I zstd -tf tmp/perf_logs.tar.zst  # list contents
+tar -I zstd -xf tmp/perf_logs.tar.zst -C tmp/ ./right/server.log  # PR binary
+tar -I zstd -xf tmp/perf_logs.tar.zst -C tmp/ ./left/server.log   # master binary
+```
+
+- `right/server.log` = PR binary (the "new" version)
+- `left/server.log` = master binary (the "old" version)
+
+**Analyze the query execution** by finding the query ID in the server log:
+
+```bash
+# Find the query and its timing
+grep "math.query2" tmp/right/server.log | grep -E "Aggregated|Read.*rows.*sec"
+```
+
+The perf framework uses query IDs like `{test_name.query{N}.run{M}}` (e.g. `math.query2.run0`). Look at:
+- `Aggregated ... in X sec` — actual compute time
+- `executeQuery: Read N rows ... in X sec` — total query time
+- `TCPHandler: Processed in X sec` — wall clock including network
+
+**Compare both servers** during the same time window to see if the machine was under load or if only the PR binary was slow. Check for:
+- Background activity (merges, flushes, system log writes)
+- Errors or warnings
+- Whether the slowdown is in UserTime (CPU-bound) or wall clock (I/O/contention)
+
+**Check the git hash** of the binary that actually ran:
+
+```bash
+grep "Starting ClickHouse" tmp/right/server.log | head -1
+```
+
+This shows the exact revision, build ID, and PID. Compare with what you expect — the CI perf test may use a different binary than the latest commit if the build was cached.
+
+## Rules
+
+- **Never dismiss a regression without checking master history first.** Do not call anything "noise" or "not actionable" based on intuition alone.
+- **Show all data.** The user wants the full picture, not a filtered summary.
+- **Both architectures matter.** AMD runs on Intel Sapphire Rapids (m7i.4xlarge), ARM runs on Graviton 4 (m8g.4xlarge). Regressions on one but not the other are still real.
+- **A test appearing in multiple CI runs of the same PR is a strong signal** even if it also occasionally appears on master.
+- **Do not look at the PR code or run local benchmarks** unless explicitly asked. This skill is purely about CI report analysis.

--- a/.claude/skills/perf-report/SKILL.md
+++ b/.claude/skills/perf-report/SKILL.md
@@ -28,7 +28,7 @@ If a direct CI report URL is given instead of a PR number, use it directly.
 Extract all changed queries (column 10 == 1 means the change exceeds the threshold):
 - Column 1: test name
 - Column 2: query index
-- Column 4: shard
+- Column 4: batch
 - Column 5: old time
 - Column 6: new time
 - Column 8: ratio (e.g. 1.5 = 1.5x)
@@ -38,7 +38,7 @@ Extract all changed queries (column 10 == 1 means the change exceeds the thresho
 
 ### 2. List ALL changes
 
-Present the **complete, unfiltered** list of all changes above 1.10x, sorted by magnitude, for both architectures separately. Use tables with columns: Magnitude, Direction, Test, Query#, Shard.
+Present the **complete, unfiltered** list of all changes above 1.10x, sorted by magnitude, for both architectures separately. Use tables with columns: Magnitude, Direction, Test, Query#, Batch.
 
 Do NOT summarize, collapse, or hide entries. Do NOT dismiss anything as "noise" or "not actionable" without evidence. Every entry must be visible.
 
@@ -79,10 +79,10 @@ ORDER BY slower_count DESC, test
 
 For each test, classify based on the master history:
 
-- **Flaky on master**: appears as slower in >1% of master runs, or has many unstable entries. Note the ratio (e.g. "8/685 runs, flaky").
-- **Never on master**: 0 slower appearances in the last 30 days with a meaningful number of total runs (>50). This is likely a genuine regression introduced by the PR.
+- **Flaky on master**: appears as slower in >1% of master runs, or has many unstable entries. Note the count (e.g. "8/685 runs").
+- **New in this PR**: 0 slower (or faster) appearances on master in the last 30 days with a meaningful number of total runs (>50). This change was first observed in this PR.
 - **Rarely on master**: 1-2 appearances out of hundreds. Treat as borderline — note it but don't dismiss.
-- For "faster" results: check if the test was previously *slower* on master (meaning this PR fixes it) or if it was never faster before (genuine improvement).
+- For "faster" results: check if the test was previously *slower* on master (meaning this PR fixes it).
 
 ### 5. Present the verdict
 
@@ -94,9 +94,9 @@ Present the final classification in a table per architecture:
 Classify as:
 - **Flaky** — frequently appears on master, dismiss
 - **Unstable** — high unstable count on master, dismiss
-- **Never on master — investigate** — genuine regression
+- **New in this PR — investigate** — regression not seen on master before
+- **New in this PR — improvement** — speedup not seen on master before, or fixes a previously-slower test
 - **Rarely on master** — borderline, note it
-- **Real improvement** — never faster on master before, or fixes a previously-slower test
 
 ### 6. Summary
 
@@ -113,7 +113,7 @@ When the user asks to investigate a specific regression further, download and an
 **Get artifact links** using the `fetch_ci_report.js` tool with `--links`:
 
 ```bash
-node .claude/tools/fetch_ci_report.js "<CI-report-URL-for-specific-shard>" --links
+node .claude/tools/fetch_ci_report.js "<CI-report-URL-for-specific-batch>" --links
 ```
 
 This will show `logs.tar.zst`, `job.log.zst`, `all-query-metrics.tsv`, `report.html`, etc.
@@ -213,13 +213,13 @@ The `all-query-metrics.tsv` file (linked from `--links` output) contains the pro
 
 ### Important: use unique download paths
 
-When analyzing multiple shards or PRs, use unique directory names to avoid overwriting:
+When analyzing multiple batches or PRs, use unique directory names to avoid overwriting:
 
 ```bash
-mkdir -p tmp/shard1_amd tmp/shard5_amd
-curl -sS "<shard1-logs-url>" -o tmp/shard1_amd/logs.tar.zst
-curl -sS "<shard5-logs-url>" -o tmp/shard5_amd/logs.tar.zst
-tar -I zstd -xf tmp/shard1_amd/logs.tar.zst -C tmp/shard1_amd/
+mkdir -p tmp/batch1_amd tmp/batch5_amd
+curl -sS "<batch1-logs-url>" -o tmp/batch1_amd/logs.tar.zst
+curl -sS "<batch5-logs-url>" -o tmp/batch5_amd/logs.tar.zst
+tar -I zstd -xf tmp/batch1_amd/logs.tar.zst -C tmp/batch1_amd/
 ```
 
 ## Rules

--- a/.claude/skills/perf-report/SKILL.md
+++ b/.claude/skills/perf-report/SKILL.md
@@ -155,6 +155,73 @@ grep "Starting ClickHouse" tmp/right/server.log | head -1
 
 This shows the exact revision, build ID, and PID. Compare with what you expect — the CI perf test may use a different binary than the latest commit if the build was cached.
 
+### 8. Deep-dive: trace log profiling (flamegraphs)
+
+The `logs.tar.zst` archive contains `right-trace-log.tsv` and `left-trace-log.tsv` — these are exports of `system.trace_log` from each server, containing CPU and real-time stack samples for every query.
+
+**Extract trace logs:**
+
+```bash
+tar -I zstd -xf tmp/perf_logs.tar.zst -C tmp/ ./right-trace-log.tsv ./left-trace-log.tsv
+```
+
+**Key columns** (TSV format, header in row 1, types in row 2, data from row 3):
+- Column 7: `trace_type` — `CPU` (sampled CPU time), `Real` (wall clock), `Memory`, etc.
+- Column 11: `query_id` — matches the `{test.queryN.runM}` pattern from server logs
+- Column 19: `symbols` — comma-separated list of function names (leaf first), wrapped in `['...']`
+
+**Find the hotspot for a specific query** — extract CPU traces and count leaf functions:
+
+```bash
+grep "math.query2" tmp/right-trace-log.tsv | awk -F'\t' '$7 == "CPU" {print $19}' | \
+  sed "s/\[//g; s/\]//g; s/'//g" | \
+  awk -F',' '{print $1}' | \
+  sort | uniq -c | sort -rn | head -20
+```
+
+This gives a flat profile of where CPU time is spent, similar to `perf report`. Compare left (master) vs right (PR) to see what changed.
+
+**Build collapsed stacks for flamegraph visualization:**
+
+```bash
+grep "math.query2" tmp/right-trace-log.tsv | awk -F'\t' '$7 == "CPU" {print $19}' | \
+  sed "s/\[//g; s/\]//g; s/','/;/g; s/'//g" | \
+  sort | uniq -c | awk '{print $2, $1}' > tmp/math2_right.collapsed
+```
+
+The resulting `.collapsed` file can be processed with `flamegraph.pl` or the `analyze-assembly.py --perf-map` tool.
+
+**This is the fastest way to identify the root cause of a regression.** Example: for a 31x `exp10` regression, the trace log immediately showed `modf` consuming 577/1200 CPU samples on the PR binary vs 28/60 on master — pinpointing the exact function responsible without needing to reproduce locally.
+
+**The archive also contains pre-built SVG flamegraphs** for queries the framework selected for detailed analysis:
+
+```bash
+tar -I zstd -tf tmp/perf_logs.tar.zst | grep "\.svg"
+```
+
+These come in `.left.svg` (master), `.right.svg` (PR), and `.diff.svg` (differential) variants, for both `CPU` and `Real` time. Not all queries get flamegraphs — only those the framework considers interesting.
+
+### 9. Deep-dive: profile events from raw TSV
+
+The archive contains per-query raw metric data in `analyze/tmp/{test}_{queryN}.tsv`. Each row is one run, with an array of all ProfileEvents (counters like `UserTimeMicroseconds`, `OSCPUVirtualTimeMicroseconds`, `RealTimeMicroseconds`, etc.).
+
+```bash
+tar -I zstd -xf tmp/perf_logs.tar.zst -C tmp/ ./analyze/tmp/math_2.tsv
+```
+
+The `all-query-metrics.tsv` file (linked from `--links` output) contains the processed comparison data with old/new values, ratios, and thresholds for every metric of every query. The `fetch_perf_report.py` tool already parses this, but the raw file has all metrics, not just `client_time`.
+
+### Important: use unique download paths
+
+When analyzing multiple shards or PRs, use unique directory names to avoid overwriting:
+
+```bash
+mkdir -p tmp/shard1_amd tmp/shard5_amd
+curl -sS "<shard1-logs-url>" -o tmp/shard1_amd/logs.tar.zst
+curl -sS "<shard5-logs-url>" -o tmp/shard5_amd/logs.tar.zst
+tar -I zstd -xf tmp/shard1_amd/logs.tar.zst -C tmp/shard1_amd/
+```
+
 ## Rules
 
 - **Never dismiss a regression without checking master history first.** Do not call anything "noise" or "not actionable" based on intuition alone.

--- a/.claude/tools/fetch_ci_report.js
+++ b/.claude/tools/fetch_ci_report.js
@@ -16,7 +16,7 @@
  *   --all            Show all test results (not just summary)
  *   --links          Show artifact links
  *   --cidb           Show CIDB links for failed tests
- *   --download-logs  Download logs.tar.gz to /tmp/ci_logs.tar.gz
+ *   --download-logs [path]  Download logs to given path (default: /tmp/ci_logs.tar.gz or .tar.zst)
  *   --report <number> For PR URLs: fetch only one specific report (default: fetch all)
  *   --credentials <user,password>  HTTP Basic Auth credentials (comma-separated). Only for ClickHouse_private repository
  *
@@ -631,7 +631,7 @@ async function fetchReport(inputUrl, options = {}) {
       if (logsLink) {
         console.log(`\nDownloading logs from: ${logsLink.href}`);
         const ext = logsLink.href.endsWith('.zst') ? '.tar.zst' : '.tar.gz';
-        const logsPath = `/tmp/ci_logs${ext}`;
+        const logsPath = options.downloadLogs !== true ? options.downloadLogs : `/tmp/ci_logs${ext}`;
         execSync(`curl -sL "${logsLink.href}" -o ${logsPath}`);
         console.log(`Logs saved to: ${logsPath}`);
 
@@ -674,7 +674,7 @@ Options:
   --all            Show all test results (not just summary)
   --links          Show artifact links
   --cidb           Show CIDB links for failed tests
-  --download-logs  Download logs.tar.gz to /tmp/ci_logs.tar.gz
+  --download-logs [path]  Download logs to path (default: /tmp/ci_logs.tar.{gz,zst})
   --report <number> For PR URLs: fetch only one specific report (default: fetch all)
   --credentials <user,password>  HTTP Basic Auth credentials
 
@@ -719,7 +719,12 @@ Examples:
         options.showCidb = true;
         break;
       case '--download-logs':
-        options.downloadLogs = true;
+        // Optional path argument: if next arg doesn't start with -- and isn't a URL, use it as path
+        if (i + 1 < args.length && !args[i + 1].startsWith('--') && !args[i + 1].startsWith('http')) {
+          options.downloadLogs = args[++i];
+        } else {
+          options.downloadLogs = true;
+        }
         break;
       case '--report':
         options.reportIndex = args[++i];

--- a/.claude/tools/fetch_ci_report.js
+++ b/.claude/tools/fetch_ci_report.js
@@ -278,12 +278,21 @@ function extractArtifactLinks(jsonData) {
 
   extractFromResults(jsonData.results);
 
-  // Filter to only artifact links
-  return links.filter(link =>
-    link.href.includes('.tar.gz') ||
-    link.href.includes('.log') ||
-    link.href.includes('configs')
-  );
+  // Filter to artifact/log links; exclude json.html navigation links and raw binaries
+  return links.filter(link => {
+    const h = link.href;
+    // Exclude CI navigation/report links
+    if (h.includes('json.html')) return false;
+    // Include all log and archive formats
+    if (h.includes('.log') || h.includes('.log.zst')) return true;
+    if (h.includes('.tar.gz') || h.includes('.tar.zst') || h.includes('.tgz')) return true;
+    if (h.includes('.zst')) return true;
+    if (h.includes('.html') && !h.includes('json.html')) return true;
+    if (h.includes('.tsv')) return true;
+    if (h.includes('configs')) return true;
+    if (h.includes('artifact_report')) return true;
+    return false;
+  });
 }
 
 /**
@@ -618,10 +627,11 @@ async function fetchReport(inputUrl, options = {}) {
 
     // Download logs if requested
     if (options.downloadLogs) {
-      const logsLink = artifactLinks.find(l => l.href.includes('logs.tar.gz'));
+      const logsLink = artifactLinks.find(l => l.href.includes('logs.tar.gz') || l.href.includes('logs.tar.zst'));
       if (logsLink) {
         console.log(`\nDownloading logs from: ${logsLink.href}`);
-        const logsPath = '/tmp/ci_logs.tar.gz';
+        const ext = logsLink.href.endsWith('.zst') ? '.tar.zst' : '.tar.gz';
+        const logsPath = `/tmp/ci_logs${ext}`;
         execSync(`curl -sL "${logsLink.href}" -o ${logsPath}`);
         console.log(`Logs saved to: ${logsPath}`);
 

--- a/.claude/tools/fetch_ci_report.js
+++ b/.claude/tools/fetch_ci_report.js
@@ -635,10 +635,10 @@ async function fetchReport(inputUrl, options = {}) {
         execSync(`curl -sL "${logsLink.href}" -o ${logsPath}`);
         console.log(`Logs saved to: ${logsPath}`);
 
-        // List contents
+        // List contents (tar auto-detects compression format with -tf)
         try {
           console.log('\nLogs archive contents (pytest logs):');
-          const contents = execSync(`tar -tzf ${logsPath} | grep -E "pytest.*\\.log$|pytest.*\\.jsonl$" | head -20`).toString();
+          const contents = execSync(`tar -tf ${logsPath} | grep -E "pytest.*\\.log$|pytest.*\\.jsonl$" | head -20`).toString();
           console.log(contents || '(no pytest logs found)');
         } catch (e) {
           // Ignore errors from grep/head

--- a/.claude/tools/fetch_ci_report.js
+++ b/.claude/tools/fetch_ci_report.js
@@ -34,7 +34,7 @@ const https = require('https');
 const http = require('http');
 const { URL } = require('url');
 const fs = require('fs');
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 const zlib = require('zlib');
 
 /**
@@ -632,13 +632,14 @@ async function fetchReport(inputUrl, options = {}) {
         console.log(`\nDownloading logs from: ${logsLink.href}`);
         const ext = logsLink.href.endsWith('.zst') ? '.tar.zst' : '.tar.gz';
         const logsPath = options.downloadLogs !== true ? options.downloadLogs : `/tmp/ci_logs${ext}`;
-        execSync(`curl -sL "${logsLink.href}" -o ${logsPath}`);
+        execFileSync('curl', ['-sL', logsLink.href, '-o', logsPath]);
         console.log(`Logs saved to: ${logsPath}`);
 
         // List contents (tar auto-detects compression format with -tf)
         try {
           console.log('\nLogs archive contents (pytest logs):');
-          const contents = execSync(`tar -tf ${logsPath} | grep -E "pytest.*\\.log$|pytest.*\\.jsonl$" | head -20`).toString();
+          const listing = execFileSync('tar', ['-tf', logsPath]).toString();
+          const contents = listing.split('\n').filter(l => /pytest.*\.(log|jsonl)$/.test(l)).slice(0, 20).join('\n');
           console.log(contents || '(no pytest logs found)');
         } catch (e) {
           // Ignore errors from grep/head


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---

Two changes:

1. **Fix `fetch_ci_report.js` artifact link filtering** — the tool was only matching `.tar.gz` and `.log` extensions, missing `.tar.zst`, `.log.zst`, `.html`, and `.tsv` artifacts that CI now uses. This made it impossible to discover server logs and performance reports from the tool output.

2. **Add `perf-report` Claude skill** (`.claude/skills/perf-report/SKILL.md`) — a structured workflow for analyzing CI performance comparison reports. It:
   - Fetches perf data for both AMD and ARM using `fetch_perf_report.py`
   - Lists all changes above 1.10x, unfiltered
   - Cross-references every regression/improvement against master history in the public CIDB (`play.clickhouse.com`, `default.checks` table) to distinguish genuine changes from flaky tests
   - Classifies each as flaky, never-on-master (investigate), or real improvement
   - Includes guidance on downloading and analyzing server logs from CI artifacts for deep-dives

Example output from using the skill: https://pastila.nl/?00039a88/142244239e4bfc9912c4b3ea9d692655#iVm8J545eVpG8P3zVgT1Bg==GCM

cc @nickitat @thevar1able @rschu1ze

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.254`
<!-- ch-version-info:end -->