### PR TITLE
ci: add mac2-m2pro runners in ap-southeast-2

### DIFF
--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -29,7 +29,7 @@ class RunnerLabels:
     ARM_SMALL = ["self-hosted", "arm-small"]
     AMD_SMALL_MEM = ["self-hosted", "amd-small-mem"]
     ARM_SMALL_MEM = ["self-hosted", "arm-small-mem"]
-    MACOS_ARM_SMALL = ["self-hosted", "arm_macos_small"]
+    MACOS_ARM_SMALL = ["self-hosted", "macos_m2"]
     MACOS_AMD_SMALL = ["self-hosted", "amd_macos_m1"]
     STYLE_CHECK_AMD = ["self-hosted", "style-checker"]
     STYLE_CHECK_ARM = ["self-hosted", "style-checker-aarch64"]

--- a/ci/infra/cloud.py
+++ b/ci/infra/cloud.py
@@ -7,6 +7,8 @@ from ci.defs.defs import RunnerLabels
 
 MAC_OS_TAHOE_IMAGE_AMI = "ami-0f8ce53a93ab42329"
 MAC_OS_SEQUOIA_AMD_IMAGE_AMI = "ami-0d66088cfc49c54b0"
+MAC_OS_TAHOE_ARM_IMAGE_AMI = "ami-0cbd6d494543c15b3"
+
 MAC_VPC_NAME = "ci-cd"
 MAC_SECURITY_GROUP_IDS = ["sg-061fd9184274476c0"]
 
@@ -120,6 +122,24 @@ CLOUD = CloudInfrastructure.Config(
             praktika_resource_tag="mac",
             runner_type=RunnerLabels.MACOS_AMD_SMALL[1],
             quantity=3,
+        ),
+        EC2Instance.Config(
+            name=RunnerLabels.MACOS_ARM_SMALL[1],
+            image_id=MAC_OS_TAHOE_ARM_IMAGE_AMI,
+            instance_type="mac2-m2pro.metal",
+            region="ap-southeast-2",
+            subnet_id="subnet-09516f5db7b5bfac2",
+            security_group_ids=["sg-0f2c7852169121ec5"],
+            iam_instance_profile_name=PRAKTIKA_EC2_INSTANCE_PROFILE_NAME,
+            key_name="awswork",
+            user_data_file="./ci/infra/scripts/user_data_macos.txt",
+            root_volume_type="gp3",
+            root_volume_size=100,
+            root_volume_encrypted=True,
+            tenancy="host",
+            praktika_resource_tag="mac_m2_pro",
+            runner_type=RunnerLabels.MACOS_ARM_SMALL[1],
+            quantity=1,
         ),
     ],
     # TODO: add autoscaling and launch templates

--- a/ci/infra/cloud.py
+++ b/ci/infra/cloud.py
@@ -100,7 +100,7 @@ CLOUD = CloudInfrastructure.Config(
             instance_type="mac2-m2pro.metal",
             auto_placement="on",
             quantity_per_az=3,
-            praktika_resource_tag="mac",
+            praktika_resource_tag="mac_m2_pro",
         ),
     ],
     ec2_instances=[

--- a/ci/infra/cloud.py
+++ b/ci/infra/cloud.py
@@ -139,7 +139,7 @@ CLOUD = CloudInfrastructure.Config(
             tenancy="host",
             praktika_resource_tag="mac_m2_pro",
             runner_type=RunnerLabels.MACOS_ARM_SMALL[1],
-            quantity=1,
+            quantity=2,
         ),
     ],
     # TODO: add autoscaling and launch templates

--- a/ci/infra/cloud.py
+++ b/ci/infra/cloud.py
@@ -89,7 +89,17 @@ CLOUD = CloudInfrastructure.Config(
             ],
             instance_type="mac1.metal",
             auto_placement="on",
-            quantity_per_az=2,
+            quantity_per_az=3,
+            praktika_resource_tag="mac",
+        ),
+        DedicatedHost.Config(
+            name="mac2-m2pro.metal",
+            availability_zones=[
+                "ap-southeast-2b",
+            ],
+            instance_type="mac2-m2pro.metal",
+            auto_placement="on",
+            quantity_per_az=3,
             praktika_resource_tag="mac",
         ),
     ],
@@ -109,7 +119,7 @@ CLOUD = CloudInfrastructure.Config(
             tenancy="host",
             praktika_resource_tag="mac",
             runner_type=RunnerLabels.MACOS_AMD_SMALL[1],
-            quantity=2,
+            quantity=3,
         ),
     ],
     # TODO: add autoscaling and launch templates

--- a/ci/praktika/infrastructure/cloud.py
+++ b/ci/praktika/infrastructure/cloud.py
@@ -128,7 +128,7 @@ class CloudInfrastructure:
             # Deploy EC2 Instances
             if _wants("EC2Instance", "EC2Instances", "Instance", "Instances"):
                 for instance_config in self.ec2_instances:
-                    if self._settings and self._settings.AWS_REGION:
+                    if self._settings and self._settings.AWS_REGION and not instance_config.region:
                         instance_config.region = self._settings.AWS_REGION
 
                     print("\n" + "=" * 60)

--- a/ci/praktika/infrastructure/cloud.py
+++ b/ci/praktika/infrastructure/cloud.py
@@ -99,7 +99,14 @@ class CloudInfrastructure:
             # Deploy all Dedicated Hosts
             if _wants("DedicatedHost", "DedicatedHosts"):
                 for host_config in self.dedicated_hosts:
-                    if self._settings and self._settings.AWS_REGION:
+                    # Only fall back to the global region setting when no explicit AZs are
+                    # configured; otherwise _resolved_region() derives the correct region
+                    # from the AZ name and a single AWS_REGION would break multi-region setups.
+                    if (
+                        self._settings
+                        and self._settings.AWS_REGION
+                        and not host_config.availability_zones
+                    ):
                         host_config.region = self._settings.AWS_REGION
 
                     print("\n" + "=" * 60)

--- a/ci/praktika/infrastructure/dedicated_host.py
+++ b/ci/praktika/infrastructure/dedicated_host.py
@@ -48,6 +48,18 @@ class DedicatedHost:
         # Extra fetched/derived properties
         ext: Dict[str, Any] = field(default_factory=dict)
 
+        def _resolved_region(self) -> str:
+            """Return the region, auto-derived from availability_zones if not set explicitly."""
+            if self.region:
+                return self.region
+            if self.availability_zones:
+                # AZ name is region name + one letter suffix, e.g. "us-east-1a" -> "us-east-1"
+                return self.availability_zones[0][:-1]
+            raise ValueError(
+                f"Cannot determine region for DedicatedHost '{self.name}': "
+                f"neither 'region' nor 'availability_zones' is set"
+            )
+
         def _resolved_availability_zones(self) -> List[str]:
             if self.availability_zones:
                 return self.availability_zones
@@ -58,9 +70,10 @@ class DedicatedHost:
 
             import boto3
 
-            ec2 = boto3.client("ec2", region_name=self.region)
+            region = self._resolved_region()
+            ec2 = boto3.client("ec2", region_name=region)
             resp = ec2.describe_availability_zones(
-                Filters=[{"Name": "region-name", "Values": [self.region]}]
+                Filters=[{"Name": "region-name", "Values": [region]}]
             )
             zones = [
                 z["ZoneName"]
@@ -68,7 +81,7 @@ class DedicatedHost:
                 if z.get("State") == "available" and z.get("ZoneName")
             ]
             if not zones:
-                raise Exception(f"No available AZs found for region '{self.region}'")
+                raise Exception(f"No available AZs found for region '{region}'")
             return zones
 
         def _host_filters(self, az: str) -> List[Dict[str, Any]]:
@@ -97,7 +110,7 @@ class DedicatedHost:
         def fetch(self):
             import boto3
 
-            ec2 = boto3.client("ec2", region_name=self.region)
+            ec2 = boto3.client("ec2", region_name=self._resolved_region())
 
             # self._ensure_host_resource_group()
 
@@ -155,7 +168,7 @@ class DedicatedHost:
                 "Query": json.dumps(query_obj),
             }
 
-            rg = boto3.client("resource-groups", region_name=self.region)
+            rg = boto3.client("resource-groups", region_name=self._resolved_region())
 
             exists = False
             try:
@@ -214,7 +227,7 @@ class DedicatedHost:
                     f"placed on these dedicated hosts. Currently set to: '{self.auto_placement}'"
                 )
 
-            ec2 = boto3.client("ec2", region_name=self.region)
+            ec2 = boto3.client("ec2", region_name=self._resolved_region())
 
             azs = self._resolved_availability_zones()
 
@@ -361,7 +374,7 @@ class DedicatedHost:
 
             _ = force  # Unused, kept for API consistency
 
-            ec2 = boto3.client("ec2", region_name=self.region)
+            ec2 = boto3.client("ec2", region_name=self._resolved_region())
 
             # Fetch existing hosts
             self.fetch()


### PR DESCRIPTION
Adds infrastructure support for `mac2-m2pro.metal` runners in `ap-southeast-2`.

Changes:
- Rename `MACOS_ARM_SMALL` runner label from `arm_macos_small` to `macos_m2` in `defs.py`
- Add `praktika_resource_tag="mac_m2_pro"` to the `mac2-m2pro.metal` dedicated host config
- Add `EC2Instance.Config` for `mac2-m2pro.metal` in `ap-southeast-2` with the correct AMI (`ami-0cbd6d494543c15b3`, macOS 26.3.1 ARM), subnet, and security group
- Fix `CloudInfrastructure.deploy` to not overwrite an explicitly set `region` on `EC2Instance.Config` with the global `AWS_REGION` setting (same guard already existed for `DedicatedHost`)

**Changelog category:** CI Fix or improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.19`
<!-- ch-version-info:end -->