### PR TITLE
Fix `test_keeper_remove_rejoin_leader` flakyness

### DIFF
--- a/tests/integration/test_keeper_remove_rejoin_leader/configs/enable_keeper1.xml
+++ b/tests/integration/test_keeper_remove_rejoin_leader/configs/enable_keeper1.xml
@@ -13,6 +13,7 @@
             <operation_timeout_ms>5000</operation_timeout_ms>
             <session_timeout_ms>30000</session_timeout_ms>
             <raft_logs_level>trace</raft_logs_level>
+            <heart_beat_interval_ms>250</heart_beat_interval_ms>
         </coordination_settings>
 
         <raft_configuration>

--- a/tests/integration/test_keeper_remove_rejoin_leader/configs/enable_keeper2.xml
+++ b/tests/integration/test_keeper_remove_rejoin_leader/configs/enable_keeper2.xml
@@ -13,6 +13,7 @@
             <operation_timeout_ms>5000</operation_timeout_ms>
             <session_timeout_ms>30000</session_timeout_ms>
             <raft_logs_level>trace</raft_logs_level>
+            <heart_beat_interval_ms>250</heart_beat_interval_ms>
         </coordination_settings>
 
         <raft_configuration>

--- a/tests/integration/test_keeper_remove_rejoin_leader/configs/enable_keeper3.xml
+++ b/tests/integration/test_keeper_remove_rejoin_leader/configs/enable_keeper3.xml
@@ -13,6 +13,7 @@
             <operation_timeout_ms>5000</operation_timeout_ms>
             <session_timeout_ms>30000</session_timeout_ms>
             <raft_logs_level>trace</raft_logs_level>
+            <heart_beat_interval_ms>250</heart_beat_interval_ms>
         </coordination_settings>
 
         <raft_configuration>

--- a/tests/integration/test_keeper_remove_rejoin_leader/configs/enable_keeper4.xml
+++ b/tests/integration/test_keeper_remove_rejoin_leader/configs/enable_keeper4.xml
@@ -11,6 +11,7 @@
             <operation_timeout_ms>5000</operation_timeout_ms>
             <session_timeout_ms>30000</session_timeout_ms>
             <raft_logs_level>trace</raft_logs_level>
+            <heart_beat_interval_ms>250</heart_beat_interval_ms>
             <election_timeout_lower_bound_ms>600</election_timeout_lower_bound_ms>
             <election_timeout_upper_bound_ms>800</election_timeout_upper_bound_ms>
         </coordination_settings>

--- a/tests/integration/test_keeper_remove_rejoin_leader/configs/enable_keeper5.xml
+++ b/tests/integration/test_keeper_remove_rejoin_leader/configs/enable_keeper5.xml
@@ -11,6 +11,7 @@
             <operation_timeout_ms>5000</operation_timeout_ms>
             <session_timeout_ms>30000</session_timeout_ms>
             <raft_logs_level>trace</raft_logs_level>
+            <heart_beat_interval_ms>250</heart_beat_interval_ms>
             <election_timeout_lower_bound_ms>600</election_timeout_lower_bound_ms>
             <election_timeout_upper_bound_ms>800</election_timeout_upper_bound_ms>
         </coordination_settings>

--- a/tests/integration/test_keeper_remove_rejoin_leader/configs/enable_keeper6.xml
+++ b/tests/integration/test_keeper_remove_rejoin_leader/configs/enable_keeper6.xml
@@ -11,6 +11,7 @@
             <operation_timeout_ms>5000</operation_timeout_ms>
             <session_timeout_ms>30000</session_timeout_ms>
             <raft_logs_level>trace</raft_logs_level>
+            <heart_beat_interval_ms>250</heart_beat_interval_ms>
             <election_timeout_lower_bound_ms>600</election_timeout_lower_bound_ms>
             <election_timeout_upper_bound_ms>800</election_timeout_upper_bound_ms>
         </coordination_settings>


### PR DESCRIPTION
Claude's finding:

> Now it's clear. Here's what happened:
>                                                                                                                                                                                                                                               
>   1. Node 2 was the original leader (term 1).                                                                                                                                                                                                 
>   2. Node 4 has a shorter election timeout range: 600-800ms (vs 1000-2000ms for nodes 1/2/3). This is because node 4 uses a different config.                                                                                                 
>   3. At 12:53:02.130 — node 4 hits an election timeout (while still a follower with hb alive), starts a pre-vote, wins, and at 12:53:02.580 becomes leader for term 2.                                                                        
>   4. Node 2 receives the config change from the new leader (node 4) at 12:53:02.623 and becomes a follower.                                                                                                                                   
>   5. At 12:53:10.703 the test sends the rcfg to add node6 to node 2 (the stale leader variable), but node 2 is no longer the leader → "no active leader".     

So I reduced the heartbeat interval to make this less likely to happen.

cc: @antonio2368, @JiaQiTang98 
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.49`
<!-- ch-version-info:end -->