### PR TITLE
Sync private changes

### DIFF
--- a/src/Storages/MutationCommands.cpp
+++ b/src/Storages/MutationCommands.cpp
@@ -149,13 +149,24 @@ std::optional<MutationCommand> MutationCommand::parse(const ASTAlterCommand & co
     if (parse_alter_commands && command.type == ASTAlterCommand::MODIFY_COLUMN && command.remove_property.empty()
         && nullptr == command.settings_changes && nullptr == command.settings_resets)
     {
-        res.type = MutationCommand::Type::READ_COLUMN;
         const auto & ast_col_decl = command.col_decl->as<ASTColumnDeclaration &>();
-        if (nullptr == ast_col_decl.getType())
+
+        if (ast_col_decl.getType() != nullptr)
+        {
+            res.type = MutationCommand::Type::READ_COLUMN;
+            res.column_name = ast_col_decl.name;
+            res.data_type = DataTypeFactory::instance().get(ast_col_decl.getType());
+            return res;
+        }
+
+        const bool metadata_only_modification
+            = ast_col_decl.getDefaultExpression() != nullptr
+            || ast_col_decl.getComment() != nullptr
+            || ast_col_decl.getCodec() != nullptr
+            || ast_col_decl.getTTL() != nullptr;
+
+        if (!metadata_only_modification)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "MODIFY COLUMN mutation command doesn't specify type: {}", command.formatForErrorMessage());
-        res.column_name = ast_col_decl.name;
-        res.data_type = DataTypeFactory::instance().get(ast_col_decl.getType());
-        return res;
     }
     if (parse_alter_commands && command.type == ASTAlterCommand::DROP_COLUMN)
     {


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.54`
<!-- ch-version-info:end -->