### PR TITLE
Fix changelog script parsing template boilerplate as entry text

### DIFF
--- a/tests/ci/changelog.py
+++ b/tests/ci/changelog.py
@@ -316,7 +316,7 @@ def generate_description(item: PullRequest, repo: Repository) -> Optional[Descri
                 lines[i],
             )
             m_entry = re.match(
-                r"(?i)^[#>*_ ]*(short\s*description|change\s*log\s*entry)(?:[^:]*:\s*(.*))?$",
+                r"(?i)^[#>*_ ]*(short\s*description|change\s*log\s*entry)(?:\s*\(.*\))?(?:[^:]*:\s*(.*))?$",
                 lines[i],
             )
             if m_cat:


### PR DESCRIPTION
The regex for matching the `Changelog entry` header used `[^:]*:` to find the trailing colon separator. However, the PR template header contains a URL with colons inside parentheses:

```
### Changelog entry (a [user-readable short description](https://...changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
```

The `[^:]*:` matched the first colon (from `https:`), capturing the URL fragment as the changelog entry instead of looking at subsequent lines. This produced broken entries like:

```
* //github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):. [#91352](...) ([Amos Bird](...)).
```

Fix by adding `(?:\s*\(.*\))?` to skip the parenthetical description before searching for the trailing colon.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.3.1.887`
<!-- ch-version-info:end -->