### PR TITLE
Revert "Fix `assertHasValidVersionMetadata` exception when part directory is externally removed"

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -2223,26 +2223,13 @@ bool IMergeTreeDataPart::assertHasValidVersionMetadata() const
         read_settings.local_fs_method = LocalFSReadMethod::pread;
         auto buf = getDataPartStorage().readFileIfExists(TXN_VERSION_METADATA_FILE_NAME, read_settings, small_file_size);
         if (!buf)
-        {
-            /// The part directory may have been removed externally (e.g., between
-            /// DETACH and ATTACH in an Ordinary database). If the directory is gone,
-            /// there is nothing to validate.
-            return !getDataPartStorage().exists();
-        }
+            return false;
 
         readStringUntilEOF(content, *buf);
         ReadBufferFromString str_buf{content};
         VersionMetadata file;
         file.read(str_buf);
         bool valid_creation_tid = version.creation_tid == file.creation_tid;
-
-        /// If the creation TID on disk doesn't match in-memory state, the file
-        /// belongs to a different incarnation of the part (e.g., an Ordinary database
-        /// reusing the same data directory path after DROP + CREATE). There is nothing
-        /// to validate in this case.
-        if (!valid_creation_tid)
-            return true;
-
         bool valid_removal_tid = version.removal_tid == file.removal_tid || version.removal_tid == Tx::PrehistoricTID;
         /// CSN may have been learned from the transaction log and cached in memory
         /// (e.g., by VersionMetadata::isVisible) but not yet appended to the on-disk file.
@@ -2254,7 +2241,7 @@ bool IMergeTreeDataPart::assertHasValidVersionMetadata() const
             || file.removal_csn == Tx::UnknownCSN;
         bool valid_removal_tid_lock = (version.removal_tid.isEmpty() && version.removal_tid_lock == 0)
             || (version.removal_tid_lock == version.removal_tid.getHash());
-        if (!valid_removal_tid || !valid_creation_csn || !valid_removal_csn || !valid_removal_tid_lock)
+        if (!valid_creation_tid || !valid_removal_tid || !valid_creation_csn || !valid_removal_csn || !valid_removal_tid_lock)
             throw Exception(ErrorCodes::CORRUPTED_DATA, "Invalid version metadata file");
         return true;
     }


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#99399

This change [isn't really necessary](https://github.com/ClickHouse/ClickHouse/pull/99399#discussion_r2955001570) since it was covering an external deletion of a file, and throwing a LOGICAL_ERROR in those cases is ok.

The tests (the one causing the error, and the one introduced in the PR) were already removed

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.51`
<!-- ch-version-info:end -->