### PR TITLE
fix convert exception when ConditionSelectivityEstimator process invalid enum string

### DIFF
--- a/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
@@ -15,6 +15,8 @@
 #include <Storages/StorageInMemoryMetadata.h>
 #include <Storages/MergeTree/RPNBuilder.h>
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
+#include <Processors/Formats/IRowInputFormat.h>
+
 
 namespace DB
 {
@@ -290,8 +292,11 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
                     {
                         const_value = convertFieldToType(const_value, *column_type);
                     }
-                    catch (...)
+                    catch (const Exception & e)
                     {
+                        if (!isParseError(e.code()))
+                            throw;
+
                         /// The string value is not valid for the column type (e.g. unknown enum element).
                         /// For equality, the condition can never match, so selectivity is 0.
                         /// For other operators, fall back to default unknown selectivity.

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
@@ -286,7 +286,25 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
             {
                 if (const_value.getType() == Field::Types::String)
                 {
-                    const_value = convertFieldToType(const_value, *column_type);
+                    try
+                    {
+                        const_value = convertFieldToType(const_value, *column_type);
+                    }
+                    catch (...)
+                    {
+                        /// The string value is not valid for the column type (e.g. unknown enum element).
+                        /// For equality, the condition can never match, so selectivity is 0.
+                        /// For other operators, fall back to default unknown selectivity.
+                        LOG_DEBUG(getLogger("ConditionSelectivityEstimator"),
+                            "Cannot convert value to column type, skipping statistics estimation. The exception is : {}",
+                            getCurrentExceptionMessage(false));
+                        if (func_name == "equals")
+                        {
+                            out.function = RPNElement::ALWAYS_FALSE;
+                            return true;
+                        }
+                        return false;
+                    }
                     if (const_value.isNull())
                         return false;
                 }

--- a/tests/queries/0_stateless/04049_statistics_enum_invalid_value.sql
+++ b/tests/queries/0_stateless/04049_statistics_enum_invalid_value.sql
@@ -1,0 +1,16 @@
+DROP TABLE IF EXISTS t_enum_stats;
+
+CREATE TABLE t_enum_stats
+(
+    a Int64,
+    x Enum('hello' = 1, 'world' = 2)
+)
+ENGINE = MergeTree
+ORDER BY tuple()
+SETTINGS auto_statistics_types = 'minmax';
+
+INSERT INTO t_enum_stats VALUES (1, 'hello');
+
+SELECT * FROM t_enum_stats WHERE a = 1 AND x = '';
+
+DROP TABLE t_enum_stats;


### PR DESCRIPTION

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
When ConditionSelectivityEstimator process condition like `enum_column = ''` which the string constant is invalid, we should ignore the exception and use fake selectivity or treat it as always false

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.36`
<!-- ch-version-info:end -->