### PR TITLE
Fix flaky test 03742_nested_loop_join_long timeout under TSan

### DIFF
--- a/tests/queries/0_stateless/03742_nested_loop_join_long.sql
+++ b/tests/queries/0_stateless/03742_nested_loop_join_long.sql
@@ -10,7 +10,7 @@ CREATE TABLE events
 )
 ENGINE = MergeTree
 ORDER BY Time
-;
+SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
 
 INSERT INTO events SELECT number % 3 + 2, concat('Payload_', toString(number)), toDateTime('2024-01-01 00:00:00') + INTERVAL number MINUTES FROM numbers(100);
 INSERT INTO events SELECT NULL, concat('Payload_NULL', toString(number)), toDateTime('2024-01-01 00:00:00') + INTERVAL number MINUTES FROM numbers(10);
@@ -23,7 +23,7 @@ CREATE TABLE attributes
     `Attribute` String
 )
 ENGINE = MergeTree ORDER BY EventId
-;
+SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
 
 INSERT INTO attributes SELECT 1 AS EventId, 1 AS AnotherId, concat('A_', toString(number)) AS Attribute FROM numbers(100_000);
 INSERT INTO attributes SELECT 2 AS EventId, 2 AS AnotherId, concat('B_', toString(number)) AS Attribute FROM numbers(800_000);
@@ -40,7 +40,7 @@ CREATE TABLE events2
 )
 ENGINE = MergeTree
 ORDER BY Time
-;
+SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
 
 INSERT INTO events2 SELECT number, concat('Payload_', toString(number)), toDateTime('2024-01-01 00:00:00') + INTERVAL number MINUTES FROM numbers(1_000_000);
 
@@ -52,7 +52,8 @@ CREATE TABLE attributes2
     `Attribute` String
 )
 ENGINE = MergeTree
-ORDER BY EventId;
+ORDER BY EventId
+SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi';
 
 INSERT INTO attributes2 SELECT
     sipHash64(number, 1) % 10_000_000 AS EventId,


### PR DESCRIPTION
Fix timeout of `03742_nested_loop_join_long` on TSan + S3 storage. Randomized settings injected `index_granularity = 2`, creating ~500K marks for tables with 1M rows. Combined with TSan slowdown and S3 latency, this exceeded the 600s timeout.

Fix: explicitly set `index_granularity = 8192` and `index_granularity_bytes = '10Mi'` on all tables.

CI failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99658&sha=d17e968718f17a9de1bfc1b293be6e8c3ef4afeb&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%202%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/99658

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.27`
<!-- ch-version-info:end -->