### PR TITLE
Fix logical error in `optimize_functions_to_subcolumns` for `count()` function for `Nullable(Tuple)`

### DIFF
--- a/src/Analyzer/Passes/FunctionToSubcolumnsPass.cpp
+++ b/src/Analyzer/Passes/FunctionToSubcolumnsPass.cpp
@@ -356,6 +356,19 @@ std::map<std::pair<TypeIndex, String>, NodeToSubcolumnTransformer> node_transfor
             NameAndTypePair column{ctx.column.name + ".null", std::make_shared<DataTypeUInt8>()};
             if (sourceHasColumn(ctx.column_source, column.name) || !canOptimizeToSubcolumn(ctx.column_source, column.name))
                 return;
+
+            /// When the column is inside a Nullable(Tuple(...)), the .null subcolumn/nullmap
+            /// in storage is Nullable(UInt8), not UInt8, because the type system wraps all
+            /// subcolumns of a Nullable(Tuple(...)) with the outer nullability. Using it with
+            /// a hardcoded UInt8 type causes a type mismatch at runtime. Skip the optimization.
+            if (auto * table_node = ctx.column_source->as<TableNode>())
+            {
+                auto actual = table_node->getStorageSnapshot()->tryGetColumn(
+                    GetColumnsOptions(GetColumnsOptions::All).withRegularSubcolumns(), column.name);
+                if (actual && actual->type->isNullable())
+                    return;
+            }
+
             auto & function_arguments_nodes = function_node.getArguments().getNodes();
 
             auto new_column_node = std::make_shared<ColumnNode>(column, ctx.column_source);

--- a/tests/queries/0_stateless/04039_count_nullable_tuple_subcolumn.reference
+++ b/tests/queries/0_stateless/04039_count_nullable_tuple_subcolumn.reference
@@ -1,22 +1,23 @@
 -- { echo }
 
-SET enable_analyzer = 1;
 SET allow_experimental_nullable_tuple_type = 1;
 SET optimize_functions_to_subcolumns = 1;
 DROP TABLE IF EXISTS test;
 CREATE TABLE test (t Tuple(v Nullable(Tuple(w Nullable(UInt32))))) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO test VALUES (((1))), (((NULL))), ((NULL));
-EXPLAIN SYNTAX run_query_tree_passes = 1 SELECT count(t.v.w) FROM test;
+EXPLAIN SYNTAX run_query_tree_passes = 1 SELECT count(t.v.w) FROM test SETTINGS enable_analyzer = 1;
 SELECT count(__table1.`t.v.w`) AS `count(t.v.w)`
 FROM default.test AS __table1
+SETTINGS enable_analyzer = 1
 SELECT count(t.v.w) FROM test;
 1
 DROP TABLE IF EXISTS test2;
 CREATE TABLE test2 (t Nullable(Tuple(u Nullable(UInt32)))) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO test2 VALUES ((1)), ((NULL)), (NULL);
-EXPLAIN SYNTAX run_query_tree_passes = 1 SELECT count(t.u) FROM test2;
+EXPLAIN SYNTAX run_query_tree_passes = 1 SELECT count(t.u) FROM test2 SETTINGS enable_analyzer = 1;
 SELECT count(__table1.`t.u`) AS `count(t.u)`
 FROM default.test2 AS __table1
+SETTINGS enable_analyzer = 1
 SELECT count(t.u) FROM test2;
 1
 -- Test from https://github.com/ClickHouse/ClickHouse/pull/99490

--- a/tests/queries/0_stateless/04039_count_nullable_tuple_subcolumn.reference
+++ b/tests/queries/0_stateless/04039_count_nullable_tuple_subcolumn.reference
@@ -1,0 +1,37 @@
+-- { echo }
+
+SET enable_analyzer = 1;
+SET allow_experimental_nullable_tuple_type = 1;
+SET optimize_functions_to_subcolumns = 1;
+CREATE TABLE test (t Tuple(v Nullable(Tuple(w Nullable(UInt32))))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO test VALUES (((1))), (((NULL))), ((NULL));
+EXPLAIN SYNTAX run_query_tree_passes = 1 SELECT count(t.v.w) FROM test;
+SELECT count(__table1.`t.v.w`) AS `count(t.v.w)`
+FROM default.test AS __table1
+SELECT count(t.v.w) FROM test;
+1
+DROP TABLE IF EXISTS test2;
+CREATE TABLE test2 (t Nullable(Tuple(u Nullable(UInt32)))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO test2 VALUES ((1)), ((NULL)), (NULL);
+EXPLAIN SYNTAX run_query_tree_passes = 1 SELECT count(t.u) FROM test2;
+SELECT count(__table1.`t.u`) AS `count(t.u)`
+FROM default.test2 AS __table1
+SELECT count(t.u) FROM test2;
+1
+-- Test from https://github.com/ClickHouse/ClickHouse/pull/99490
+DROP TABLE IF EXISTS t_nullable_tuple;
+CREATE TABLE t_nullable_tuple
+(
+    `tup` Nullable(Tuple(u UInt64, s Nullable(String)))
+)
+ENGINE = MergeTree
+ORDER BY tuple()
+SETTINGS ratio_of_defaults_for_sparse_serialization = 0, nullable_serialization_version = 'allow_sparse', min_bytes_for_wide_part = 0;
+INSERT INTO t_nullable_tuple SELECT if((number % 5) = 0, (number, toString(number)), NULL) FROM numbers(1000);
+SELECT count(tup.u) FROM t_nullable_tuple SETTINGS optimize_functions_to_subcolumns = 1;
+200
+-- TODO: These output 1000 but should be 200. This is wrong but is a different bug.
+SELECT count(tup.s) FROM t_nullable_tuple SETTINGS optimize_functions_to_subcolumns = 1;
+1000
+SELECT DISTINCT count(tup.s) FROM t_nullable_tuple SETTINGS optimize_functions_to_subcolumns = 1;
+1000

--- a/tests/queries/0_stateless/04039_count_nullable_tuple_subcolumn.reference
+++ b/tests/queries/0_stateless/04039_count_nullable_tuple_subcolumn.reference
@@ -3,6 +3,7 @@
 SET enable_analyzer = 1;
 SET allow_experimental_nullable_tuple_type = 1;
 SET optimize_functions_to_subcolumns = 1;
+DROP TABLE IF EXISTS test;
 CREATE TABLE test (t Tuple(v Nullable(Tuple(w Nullable(UInt32))))) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO test VALUES (((1))), (((NULL))), ((NULL));
 EXPLAIN SYNTAX run_query_tree_passes = 1 SELECT count(t.v.w) FROM test;

--- a/tests/queries/0_stateless/04039_count_nullable_tuple_subcolumn.sql
+++ b/tests/queries/0_stateless/04039_count_nullable_tuple_subcolumn.sql
@@ -1,7 +1,5 @@
 -- { echo }
 
-SET enable_analyzer = 1;
-
 SET allow_experimental_nullable_tuple_type = 1;
 SET optimize_functions_to_subcolumns = 1;
 
@@ -9,14 +7,14 @@ DROP TABLE IF EXISTS test;
 CREATE TABLE test (t Tuple(v Nullable(Tuple(w Nullable(UInt32))))) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO test VALUES (((1))), (((NULL))), ((NULL));
 
-EXPLAIN SYNTAX run_query_tree_passes = 1 SELECT count(t.v.w) FROM test;
+EXPLAIN SYNTAX run_query_tree_passes = 1 SELECT count(t.v.w) FROM test SETTINGS enable_analyzer = 1;
 SELECT count(t.v.w) FROM test;
 
 DROP TABLE IF EXISTS test2;
 CREATE TABLE test2 (t Nullable(Tuple(u Nullable(UInt32)))) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO test2 VALUES ((1)), ((NULL)), (NULL);
 
-EXPLAIN SYNTAX run_query_tree_passes = 1 SELECT count(t.u) FROM test2;
+EXPLAIN SYNTAX run_query_tree_passes = 1 SELECT count(t.u) FROM test2 SETTINGS enable_analyzer = 1;
 SELECT count(t.u) FROM test2;
 
 -- Test from https://github.com/ClickHouse/ClickHouse/pull/99490

--- a/tests/queries/0_stateless/04039_count_nullable_tuple_subcolumn.sql
+++ b/tests/queries/0_stateless/04039_count_nullable_tuple_subcolumn.sql
@@ -5,6 +5,7 @@ SET enable_analyzer = 1;
 SET allow_experimental_nullable_tuple_type = 1;
 SET optimize_functions_to_subcolumns = 1;
 
+DROP TABLE IF EXISTS test;
 CREATE TABLE test (t Tuple(v Nullable(Tuple(w Nullable(UInt32))))) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO test VALUES (((1))), (((NULL))), ((NULL));
 

--- a/tests/queries/0_stateless/04039_count_nullable_tuple_subcolumn.sql
+++ b/tests/queries/0_stateless/04039_count_nullable_tuple_subcolumn.sql
@@ -1,0 +1,38 @@
+-- { echo }
+
+SET enable_analyzer = 1;
+
+SET allow_experimental_nullable_tuple_type = 1;
+SET optimize_functions_to_subcolumns = 1;
+
+CREATE TABLE test (t Tuple(v Nullable(Tuple(w Nullable(UInt32))))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO test VALUES (((1))), (((NULL))), ((NULL));
+
+EXPLAIN SYNTAX run_query_tree_passes = 1 SELECT count(t.v.w) FROM test;
+SELECT count(t.v.w) FROM test;
+
+DROP TABLE IF EXISTS test2;
+CREATE TABLE test2 (t Nullable(Tuple(u Nullable(UInt32)))) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO test2 VALUES ((1)), ((NULL)), (NULL);
+
+EXPLAIN SYNTAX run_query_tree_passes = 1 SELECT count(t.u) FROM test2;
+SELECT count(t.u) FROM test2;
+
+-- Test from https://github.com/ClickHouse/ClickHouse/pull/99490
+DROP TABLE IF EXISTS t_nullable_tuple;
+
+CREATE TABLE t_nullable_tuple
+(
+    `tup` Nullable(Tuple(u UInt64, s Nullable(String)))
+)
+ENGINE = MergeTree
+ORDER BY tuple()
+SETTINGS ratio_of_defaults_for_sparse_serialization = 0, nullable_serialization_version = 'allow_sparse', min_bytes_for_wide_part = 0;
+
+INSERT INTO t_nullable_tuple SELECT if((number % 5) = 0, (number, toString(number)), NULL) FROM numbers(1000);
+
+SELECT count(tup.u) FROM t_nullable_tuple SETTINGS optimize_functions_to_subcolumns = 1;
+
+-- TODO: These output 1000 but should be 200. This is wrong but is a different bug.
+SELECT count(tup.s) FROM t_nullable_tuple SETTINGS optimize_functions_to_subcolumns = 1;
+SELECT DISTINCT count(tup.s) FROM t_nullable_tuple SETTINGS optimize_functions_to_subcolumns = 1;


### PR DESCRIPTION
Logical error:

```sql
SET allow_experimental_nullable_tuple_type = 1;
SET optimize_functions_to_subcolumns = 1;

CREATE TABLE test (t Tuple(v Nullable(Tuple(w Nullable(UInt32))))) ENGINE = MergeTree ORDER BY tuple();
INSERT INTO test VALUES (((1))), (((NULL))), ((NULL));

SELECT count(t.v.w) FROM test;
```

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a logical error when `optimize_functions_to_subcolumns` rewrites `count()` on a field of a `Nullable(Tuple(...))` column.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.29`
<!-- ch-version-info:end -->