### PR TITLE
Fix exception in DDLWorker::cleanupQueue on ZNOTEMPTY

### DIFF
--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -1021,6 +1021,13 @@ void DDLWorker::cleanupQueue(Int64, const ZooKeeperPtr & zookeeper)
             /// Now we can safely delete entry
             LOG_INFO(log, "Task {} is outdated, deleting it", node_name);
 
+            /// Ensure node_path/finished exists to prevent staled hosts from processing this entry.
+            /// If a host calls createStatusDirs and finds that it created node_path/active
+            /// but node_path/finished already exists, it will detect concurrent deletion and back off.
+            /// This also handles the rare case when the initiator lost connection after enqueueing the entry
+            /// and never created status dirs (node_path/finished didn't exist).
+            zookeeper->tryCreate(fs::path(node_path) / "finished", {}, zkutil::CreateMode::Persistent);
+
             /// We recursively delete all nodes except node_path/finished to prevent staled hosts from
             /// creating node_path/active node (see createStatusDirs(...))
             zookeeper->tryRemoveChildrenRecursive(node_path, /* probably_flat */ false, zkutil::RemoveException{"finished"});
@@ -1036,16 +1043,6 @@ void DDLWorker::cleanupQueue(Int64, const ZooKeeperPtr & zookeeper)
             if (rm_entry_res == Coordination::Error::ZNONODE)
             {
                 /// Most likely both node_path/finished and node_path were removed concurrently.
-                bool entry_removed_concurrently = res[0]->error == Coordination::Error::ZNONODE;
-                if (entry_removed_concurrently)
-                    continue;
-
-                /// Possible rare case: initiator node has lost connection after enqueueing entry and failed to create status dirs.
-                /// No one has started to process the entry, so node_path/active and node_path/finished nodes were never created, node_path has no children.
-                /// Entry became outdated, but we cannot remove remove it in a transaction with node_path/finished.
-                chassert(res[0]->error == Coordination::Error::ZOK && res[1]->error == Coordination::Error::ZNONODE);
-                rm_entry_res = zookeeper->tryRemove(node_path);  /// NOLINT(clang-analyzer-deadcode.DeadStores)
-                chassert(rm_entry_res != Coordination::Error::ZNOTEMPTY);
                 continue;
             }
             zkutil::KeeperMultiException::check(rm_entry_res, ops, res);


### PR DESCRIPTION
When the DDL entry initiator loses connection after creating the entry but before calling `createStatusDirs`, the `finished` child node is never created. During cleanup, the code relied on `finished` existing to signal concurrent deletion to other hosts. Without it, a concurrent host could call `createStatusDirs`, successfully create both `active` and `finished`, and start processing the entry being deleted. The subsequent `tryRemove` of the entry node would then fail with `ZNOTEMPTY`, triggering a `chassert` failure.

Fix by creating the `finished` node before removing children during cleanup. This restores the protection signal so that concurrent hosts detect deletion in progress and back off via the `is_currently_deleting` check in `createStatusDirs`.

Closes https://github.com/ClickHouse/ClickHouse/issues/88191

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix exception `rm_entry_res != Coordination::Error::ZNOTEMPTY` in `DDLWorker::cleanupQueue` that could happen when the DDL entry initiator lost Keeper connection before creating status directories.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.119`
<!-- ch-version-info:end -->