### PR TITLE
Allow parenthesized queries in EXPLAIN

### DIFF
--- a/src/Parsers/Access/ASTCreateMaskingPolicyQuery.cpp
+++ b/src/Parsers/Access/ASTCreateMaskingPolicyQuery.cpp
@@ -10,7 +10,7 @@ namespace
 {
     void formatRenameTo(const String & new_name, WriteBuffer & ostr, const IAST::FormatSettings &)
     {
-        ostr << " RENAME TO " << backQuote(new_name);
+        ostr << " RENAME TO " << backQuoteIfNeed(new_name);
     }
 
     void formatUpdateExpression(const ASTPtr & expr, WriteBuffer & ostr, const IAST::FormatSettings & settings)

--- a/src/Parsers/Access/ASTCreateQuotaQuery.cpp
+++ b/src/Parsers/Access/ASTCreateQuotaQuery.cpp
@@ -52,7 +52,7 @@ namespace
 
     void formatRenameTo(const String & new_name, WriteBuffer & ostr, const IAST::FormatSettings &)
     {
-        ostr << " RENAME TO " << backQuote(new_name);
+        ostr << " RENAME TO " << backQuoteIfNeed(new_name);
     }
 
 

--- a/src/Parsers/Access/ASTCreateRowPolicyQuery.cpp
+++ b/src/Parsers/Access/ASTCreateRowPolicyQuery.cpp
@@ -12,7 +12,7 @@ namespace
 {
     void formatRenameTo(const String & new_short_name, WriteBuffer & ostr, const IAST::FormatSettings &)
     {
-        ostr << " RENAME TO " << backQuote(new_short_name);
+        ostr << " RENAME TO " << backQuoteIfNeed(new_short_name);
     }
 
 

--- a/src/Parsers/ParserExplainQuery.cpp
+++ b/src/Parsers/ParserExplainQuery.cpp
@@ -71,10 +71,30 @@ bool ParserExplainQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
     if (kind == ASTExplainQuery::ExplainKind::ParsedAST)
     {
         ParserQuery p(end, allow_settings_after_format_in_insert);
-        if (p.parse(pos, query, expected))
-            explain_query->setExplainedQuery(std::move(query));
-        else
-            return false;
+        bool parsed_query = false;
+        /// Allow parentheses around inner EXPLAIN queries
+        if (pos->type == TokenType::OpeningRoundBracket)
+        {
+            auto saved = pos;
+            ++pos;
+            if (p.parse(pos, query, expected) && pos->type == TokenType::ClosingRoundBracket)
+            {
+                ++pos;
+                explain_query->setExplainedQuery(std::move(query));
+                parsed_query = true;
+            }
+            else
+            {
+                pos = saved;
+            }
+        }
+        if (!parsed_query)
+        {
+            if (p.parse(pos, query, expected))
+                explain_query->setExplainedQuery(std::move(query));
+            else
+                return false;
+        }
     }
     else if (kind == ASTExplainQuery::ExplainKind::TableOverride)
     {

--- a/src/Parsers/ParserExplainQuery.cpp
+++ b/src/Parsers/ParserExplainQuery.cpp
@@ -72,8 +72,13 @@ bool ParserExplainQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
     {
         ParserQuery p(end, allow_settings_after_format_in_insert);
         bool parsed_query = false;
+        if (p.parse(pos, query, expected))
+        {
+            explain_query->setExplainedQuery(std::move(query));
+            parsed_query = true;
+        }
         /// Allow parentheses around inner EXPLAIN queries
-        if (pos->type == TokenType::OpeningRoundBracket)
+        if (!parsed_query && pos->type == TokenType::OpeningRoundBracket)
         {
             auto saved = pos;
             ++pos;
@@ -89,12 +94,7 @@ bool ParserExplainQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
             }
         }
         if (!parsed_query)
-        {
-            if (p.parse(pos, query, expected))
-                explain_query->setExplainedQuery(std::move(query));
-            else
-                return false;
-        }
+            return false;
     }
     else if (kind == ASTExplainQuery::ExplainKind::TableOverride)
     {

--- a/tests/queries/0_stateless/04049_explain_ast_parenthesized_access_queries.reference
+++ b/tests/queries/0_stateless/04049_explain_ast_parenthesized_access_queries.reference
@@ -1,0 +1,2 @@
+EXPLAIN AST graph = 1, optimize = 0\n(ALTER ROW POLICY p1 ON d0.t57 RENAME TO p7)\nSETTINGS schema_inference_use_cache_for_s3 = 0
+EXPLAIN AST graph = 1, optimize = 0\n(ALTER ROW POLICY p1 ON d0.t57 RENAME TO p7)\nSETTINGS schema_inference_use_cache_for_s3 = 0

--- a/tests/queries/0_stateless/04049_explain_ast_parenthesized_access_queries.sql
+++ b/tests/queries/0_stateless/04049_explain_ast_parenthesized_access_queries.sql
@@ -1,0 +1,9 @@
+-- Regression test: EXPLAIN AST with trailing SETTINGS must not produce
+-- unparseable parenthesized output for access control queries.
+
+-- The formatter wraps non-ASTQueryWithOutput inner queries in parens when
+-- trailing output options exist. The parser must accept that form back.
+SELECT formatQuery('EXPLAIN AST graph = 1, optimize = 0 ALTER ROW POLICY p1 ON d0.`t57` RENAME TO p7 SETTINGS schema_inference_use_cache_for_s3 = 0');
+
+-- Verify the parenthesized form can also be parsed directly.
+SELECT formatQuery('EXPLAIN AST graph = 1, optimize = 0 (ALTER ROW POLICY p1 ON d0.t57 RENAME TO p7) SETTINGS schema_inference_use_cache_for_s3 = 0');


### PR DESCRIPTION
Queries like the following were failing the double parse/format check (see f.e. [here](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=f2358d518323578bdf7e97f847b18c8a9dbff43d&name_0=MasterCI&name_1=BuzzHouse%20%28amd_debug%29&name_1=BuzzHouse%20%28amd_debug%29)):

```
EXPLAIN AST graph = 1, optimize = 0 
        ALTER ROW POLICY p1 ON d0.`t57` RENAME TO p7 
SETTINGS schema_inference_use_cache_for_s3 = 0;
```

because the parsed/formatted query would add parentheses around the inner query (because of https://github.com/ClickHouse/ClickHouse/pull/99545). I think there is no reason to forbid parenthesized queries in EXPLAIN.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.61`
<!-- ch-version-info:end -->