### PR TITLE
Make clickhouse-client's progress bar less jittery when working from a hotel with clusters with a very large number of replicas: Increase interactive_delay by sqrt(fanout) for distributed queries

### DIFF
--- a/src/Client/HedgedConnections.cpp
+++ b/src/Client/HedgedConnections.cpp
@@ -1,8 +1,10 @@
 #include <Core/Protocol.h>
 #if defined(OS_LINUX)
 
+#include <cmath>
 #include <Client/HedgedConnections.h>
 #include <Common/ProfileEvents.h>
+#include <Common/thread_local_rng.h>
 #include <Core/Settings.h>
 #include <Core/ProtocolDefines.h>
 #include <Interpreters/ClientInfo.h>
@@ -24,6 +26,7 @@ namespace Setting
     extern const SettingsBool fallback_to_stale_replicas_for_distributed_queries;
     extern const SettingsUInt64 group_by_two_level_threshold;
     extern const SettingsUInt64 group_by_two_level_threshold_bytes;
+    extern const SettingsUInt64 interactive_delay;
     extern const SettingsNonZeroUInt64 max_parallel_replicas;
     extern const SettingsUInt64 parallel_replicas_count;
     extern const SettingsUInt64 parallel_replica_offset;
@@ -215,6 +218,19 @@ void HedgedConnections::sendQuery(
         /// Queries in foreign languages are transformed to ClickHouse-SQL. Ensure the setting before sending.
         modified_settings[Setting::dialect] = Dialect::clickhouse;
         modified_settings[Setting::dialect].changed = false;
+
+        /// Scale interactive_delay by sqrt(fanout) with jitter, same as in MultiplexedConnections.
+        {
+            size_t total_fanout = distributed_fanout * offset_states.size();
+            if (total_fanout > 1)
+            {
+                UInt64 delay = modified_settings[Setting::interactive_delay];
+                double scale = std::sqrt(static_cast<double>(total_fanout));
+                double jitter = 1.0 + (thread_local_rng() % 1000) / 1000.0;
+                delay = static_cast<UInt64>(std::ceil(static_cast<double>(delay) * scale * jitter));
+                modified_settings[Setting::interactive_delay] = delay;
+            }
+        }
 
         if (disable_two_level_aggregation)
         {

--- a/src/Client/HedgedConnections.h
+++ b/src/Client/HedgedConnections.h
@@ -127,6 +127,8 @@ public:
 
     void setReplicaInfo(ReplicaInfo value) override { replica_info = value; }
 
+    void setDistributedFanout(size_t total_connections) override { distributed_fanout = total_connections; }
+
     void setAsyncCallback(AsyncCallback async_callback) override;
 
 private:
@@ -195,6 +197,9 @@ private:
     /// New replica may not support two-level aggregation due to version incompatibility.
     /// If we didn't disabled it, we need to skip this replica.
     bool disable_two_level_aggregation = false;
+
+    /// Total number of remote connections across all shards in the distributed query.
+    size_t distributed_fanout = 0;
 
     /// We will save replica with last received packet
     /// (except cases when packet type is EndOfStream or Exception)

--- a/src/Client/IConnections.h
+++ b/src/Client/IConnections.h
@@ -67,6 +67,11 @@ public:
     /// We create a RemoteQueryExecutor for each replica
     virtual void setReplicaInfo(ReplicaInfo value) = 0;
 
+    /// Set the total number of remote connections across all shards in a distributed query.
+    /// Used to scale `interactive_delay` by sqrt(fanout) to reduce progress/profile event traffic.
+    virtual void setDistributedFanout(size_t /*total_connections*/) {}
+
+
     /// Returns the number of replicas.
     virtual size_t size() const = 0;
 

--- a/src/Client/MultiplexedConnections.cpp
+++ b/src/Client/MultiplexedConnections.cpp
@@ -1,5 +1,6 @@
 #include <Client/MultiplexedConnections.h>
 
+#include <cmath>
 #include <Common/thread_local_rng.h>
 #include <Core/Protocol.h>
 #include <Core/ProtocolDefines.h>
@@ -19,6 +20,7 @@ namespace Setting
     extern const SettingsDialect dialect;
     extern const SettingsUInt64 group_by_two_level_threshold;
     extern const SettingsUInt64 group_by_two_level_threshold_bytes;
+    extern const SettingsUInt64 interactive_delay;
     extern const SettingsUInt64 parallel_replicas_count;
     extern const SettingsUInt64 parallel_replica_offset;
     extern const SettingsSeconds receive_timeout;
@@ -157,6 +159,24 @@ void MultiplexedConnections::sendQuery(
     /// Queries in foreign languages are transformed to ClickHouse-SQL. Ensure the setting before sending.
     modified_settings[Setting::dialect] = Dialect::clickhouse;
     modified_settings[Setting::dialect].changed = false;
+
+    /// Scale interactive_delay by sqrt(fanout) to reduce progress/profile event traffic
+    /// from distributed queries. Each remote server will send updates less frequently,
+    /// proportional to the square root of the total number of remote connections.
+    /// Also add per-connection jitter to avoid TCP incast and make the progress bar smooth.
+    {
+        size_t total_fanout = distributed_fanout * replica_states.size();
+        if (total_fanout > 1)
+        {
+            UInt64 delay = modified_settings[Setting::interactive_delay];
+            double scale = std::sqrt(static_cast<double>(total_fanout));
+            /// Add random jitter in range [1.0, 2.0) to desynchronize progress reports
+            /// across connections, avoiding TCP incast and making the progress bar smooth.
+            double jitter = 1.0 + (thread_local_rng() % 1000) / 1000.0;
+            delay = static_cast<UInt64>(std::ceil(static_cast<double>(delay) * scale * jitter));
+            modified_settings[Setting::interactive_delay] = delay;
+        }
+    }
 
     for (auto & replica : replica_states)
     {

--- a/src/Client/MultiplexedConnections.h
+++ b/src/Client/MultiplexedConnections.h
@@ -65,6 +65,8 @@ public:
 
     void setReplicaInfo(ReplicaInfo value) override { replica_info = value; }
 
+    void setDistributedFanout(size_t total_connections) override { distributed_fanout = total_connections; }
+
     void setAsyncCallback(AsyncCallback async_callback) override;
 
 private:
@@ -107,6 +109,10 @@ private:
 
     /// std::nullopt if parallel reading from replicas is not used
     std::optional<ReplicaInfo> replica_info;
+
+    /// Total number of remote connections across all shards in the distributed query.
+    /// Used to scale interactive_delay to reduce progress/profile event traffic.
+    size_t distributed_fanout = 0;
 
     /// A mutex for the sendCancel function to execute safely in separate thread.
     mutable std::mutex cancel_mutex;

--- a/src/Processors/QueryPlan/ReadFromRemote.cpp
+++ b/src/Processors/QueryPlan/ReadFromRemote.cpp
@@ -726,7 +726,7 @@ void ReadFromRemote::addPipe(
                 priority_func);
             remote_query_executor->setLogger(log);
             remote_query_executor->setPoolMode(PoolMode::GET_ONE);
-            remote_query_executor->setDistributedFanout(shards.size());
+            remote_query_executor->setDistributedFanout(shards.size() * shard.shard_info.per_replica_pools.size());
             remote_query_executor->setUnavailableShardTracker(unavailable_shard_tracker);
 
             if (!table_func_ptr)
@@ -1056,7 +1056,7 @@ Pipe ReadFromParallelRemoteReplicasStep::createPipeForSingeReplica(
 
     remote_query_executor->setLogger(log);
     remote_query_executor->setMainTable(storage_id);
-    remote_query_executor->setDistributedFanout(pools_to_use.size());
+    remote_query_executor->setDistributedFanout(pools_to_use.size() - (exclude_pool_index.has_value() ? 1 : 0));
 
     Pipe pipe
         = createRemoteSourcePipe(std::move(remote_query_executor), add_agg_info, add_totals, add_extremes, async_read, async_query_sending, parallel_marshalling_threads);

--- a/src/Processors/QueryPlan/ReadFromRemote.cpp
+++ b/src/Processors/QueryPlan/ReadFromRemote.cpp
@@ -529,7 +529,8 @@ void ReadFromRemote::addLazyPipe(
     }
 
     auto lazily_create_stream = [
-            my_shard = shard, my_shard_count = shard_count, query = shard.query, header = shard.header,
+            my_shard = shard, my_shard_count = shard_count, my_distributed_fanout = shards.size(),
+            query = shard.query, header = shard.header,
             my_context = context, my_throttler = throttler,
             my_main_table = main_table, my_table_func_ptr = table_func_ptr,
             my_scalars = scalars, my_external_tables = external_tables,
@@ -632,6 +633,7 @@ void ReadFromRemote::addLazyPipe(
             {DataTypeUInt32().createColumnConst(1, my_shard.shard_info.shard_num), std::make_shared<DataTypeUInt32>(), "_shard_num"}};
         auto remote_query_executor = std::make_shared<RemoteQueryExecutor>(
             std::move(connections), query_string, header, my_context, my_throttler, my_scalars, my_external_tables, stage_to_use, my_shard.query_plan);
+        remote_query_executor->setDistributedFanout(my_distributed_fanout);
 
         auto pipe = createRemoteSourcePipe(
             remote_query_executor, add_agg_info, add_totals, add_extremes, async_read, async_query_sending, parallel_marshalling_threads);
@@ -724,6 +726,7 @@ void ReadFromRemote::addPipe(
                 priority_func);
             remote_query_executor->setLogger(log);
             remote_query_executor->setPoolMode(PoolMode::GET_ONE);
+            remote_query_executor->setDistributedFanout(shards.size());
             remote_query_executor->setUnavailableShardTracker(unavailable_shard_tracker);
 
             if (!table_func_ptr)
@@ -753,6 +756,7 @@ void ReadFromRemote::addPipe(
             stage_to_use,
             shard.query_plan);
         remote_query_executor->setLogger(log);
+        remote_query_executor->setDistributedFanout(shards.size());
         remote_query_executor->setUnavailableShardTracker(unavailable_shard_tracker);
 
         if (context->canUseTaskBasedParallelReplicas() || parallel_replicas_disabled)
@@ -1052,6 +1056,7 @@ Pipe ReadFromParallelRemoteReplicasStep::createPipeForSingeReplica(
 
     remote_query_executor->setLogger(log);
     remote_query_executor->setMainTable(storage_id);
+    remote_query_executor->setDistributedFanout(pools_to_use.size());
 
     Pipe pipe
         = createRemoteSourcePipe(std::move(remote_query_executor), add_agg_info, add_totals, add_extremes, async_read, async_query_sending, parallel_marshalling_threads);

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -434,6 +434,9 @@ void RemoteQueryExecutor::sendQueryUnlocked(ClientInfo::QueryKind query_kind, As
         local_granted_roles.insert(local_granted_roles.end(), granted_roles.begin(), granted_roles.end());
     }
 
+    if (distributed_fanout > 0)
+        connections->setDistributedFanout(distributed_fanout);
+
     connections->sendQuery(timeouts, query, query_id, stage, modified_client_info, true, local_granted_roles);
 
     established = false;

--- a/src/QueryPipeline/RemoteQueryExecutor.h
+++ b/src/QueryPipeline/RemoteQueryExecutor.h
@@ -215,6 +215,8 @@ public:
 
     void setUnavailableShardTracker(UnavailableShardTrackerPtr tracker) { unavailable_shard_tracker = std::move(tracker); }
 
+    void setDistributedFanout(size_t total_connections) { distributed_fanout = total_connections; }
+
     const Block & getHeader() const { return *header; }
     const SharedHeader & getSharedHeader() const { return header; }
 
@@ -321,6 +323,9 @@ private:
 
     UnavailableShardTrackerPtr unavailable_shard_tracker;
     bool shard_skip_reported = false;
+
+    /// Total number of remote connections across all shards, used to scale interactive_delay.
+    size_t distributed_fanout = 0;
 
     GetPriorityForLoadBalancing::Func priority_func;
 


### PR DESCRIPTION
When a distributed query fans out to many remote servers, each server sends progress and profile event packets every `interactive_delay` microseconds. On clusters with 100+ shards, this creates excessive network traffic (1-10 MB/sec of progress data).

Scale the `interactive_delay` sent to remote servers by `sqrt(total_fanout)` where `total_fanout = number_of_shards * replicas_per_shard`. For example, with 100 remote servers and a default `interactive_delay` of 100ms, each server receives ~1000ms delay, reducing aggregate progress traffic by ~10x while keeping updates frequent enough for a responsive progress bar.

Add per-connection random jitter in range [1.0, 2.0) to desynchronize progress reports across connections, avoiding TCP incast bursts and making the progress bar smoother.

Closes https://github.com/ClickHouse/ClickHouse/issues/82626

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Make clickhouse-client's progress bar less jittery when working from a hotel with clusters with a very large number of replicas.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.83`
<!-- ch-version-info:end -->