### PR TITLE
Improve Arrow Parquet writer to include UUID logical type

### DIFF
--- a/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
+++ b/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
@@ -29,6 +29,7 @@
 #include <arrow/builder.h>
 #include <arrow/type.h>
 #include <arrow/util/decimal.h>
+#include <arrow/extension_type.h>
 
 #define FOR_INTERNAL_NUMERIC_TYPES(M) \
         M(Int8, arrow::Int8Builder) \
@@ -68,6 +69,33 @@ namespace DB
         extern const int DECIMAL_OVERFLOW;
         extern const int ILLEGAL_COLUMN;
     }
+
+    class ArrowUUIDExtensionType : public arrow::ExtensionType
+    {
+    public:
+        ArrowUUIDExtensionType() : arrow::ExtensionType(arrow::fixed_size_binary(16)) {}
+
+        std::string extension_name() const override { return "arrow.uuid"; }
+
+        bool ExtensionEquals(const arrow::ExtensionType& other) const override
+        {
+            return other.extension_name() == this->extension_name();
+        }
+
+        std::shared_ptr<arrow::Array> MakeArray(std::shared_ptr<arrow::ArrayData> data) const override
+        {
+            return std::make_shared<arrow::ExtensionArray>(data);
+        }
+
+        arrow::Result<std::shared_ptr<arrow::DataType>> Deserialize(
+            std::shared_ptr<arrow::DataType> /* storage_type */,
+            const std::string& /* serialized_data */) const override
+        {
+            return std::make_shared<ArrowUUIDExtensionType>();
+        }
+
+        std::string Serialize() const override { return ""; }
+    };
 
     static const std::initializer_list<std::pair<String, std::shared_ptr<arrow::DataType>>> internal_type_to_arrow_type =
     {
@@ -1015,13 +1043,13 @@ namespace DB
     }
 
     static std::shared_ptr<arrow::DataType> getArrowType(
-        DataTypePtr column_type, ColumnPtr column, const std::string & column_name, const std::string & format_name, const CHColumnToArrowColumn::Settings & settings, bool * out_is_column_nullable)
+        DataTypePtr column_type, ColumnPtr column, const std::string & column_name, const std::string & format_name, const CHColumnToArrowColumn::Settings & settings, bool * out_is_column_nullable, bool for_builder = false)
     {
         if (column_type->isNullable())
         {
             DataTypePtr nested_type = assert_cast<const DataTypeNullable *>(column_type.get())->getNestedType();
             ColumnPtr nested_column = assert_cast<const ColumnNullable *>(column.get())->getNestedColumnPtr();
-            auto arrow_type = getArrowType(nested_type, nested_column, column_name, format_name, settings, out_is_column_nullable);
+            auto arrow_type = getArrowType(nested_type, nested_column, column_name, format_name, settings, out_is_column_nullable, for_builder);
             *out_is_column_nullable = true;
             return arrow_type;
         }
@@ -1056,7 +1084,7 @@ namespace DB
             auto nested_type = assert_cast<const DataTypeArray *>(column_type.get())->getNestedType();
             auto nested_column = assert_cast<const ColumnArray *>(column.get())->getDataPtr();
             bool is_item_nullable = false;
-            auto nested_arrow_type = getArrowType(nested_type, nested_column, column_name, format_name, settings, &is_item_nullable);
+            auto nested_arrow_type = getArrowType(nested_type, nested_column, column_name, format_name, settings, &is_item_nullable, for_builder);
             return arrow::list(std::make_shared<arrow::Field>("item", nested_arrow_type, is_item_nullable));
         }
 
@@ -1070,7 +1098,7 @@ namespace DB
             for (size_t i = 0; i != nested_types.size(); ++i)
             {
                 bool is_field_nullable = false;
-                auto nested_arrow_type = getArrowType(nested_types[i], tuple_column->getColumnPtr(i), nested_names[i], format_name, settings, &is_field_nullable);
+                auto nested_arrow_type = getArrowType(nested_types[i], tuple_column->getColumnPtr(i), nested_names[i], format_name, settings, &is_field_nullable, for_builder);
                 nested_fields.push_back(std::make_shared<arrow::Field>(nested_names[i], nested_arrow_type, is_field_nullable));
             }
             return arrow::struct_(nested_fields);
@@ -1084,7 +1112,7 @@ namespace DB
             const auto & indexes_column = lc_column->getIndexesPtr();
             return arrow::dictionary(
                 getArrowTypeForLowCardinalityIndexes(indexes_column, settings),
-                getArrowType(nested_type, nested_column, column_name, format_name, settings, out_is_column_nullable));
+                getArrowType(nested_type, nested_column, column_name, format_name, settings, out_is_column_nullable, for_builder));
         }
 
         if (isMap(column_type))
@@ -1095,9 +1123,9 @@ namespace DB
             const auto & columns =  assert_cast<const ColumnMap *>(column.get())->getNestedData().getColumns();
 
             bool _is_key_nullable = false;
-            auto key_arrow_type = getArrowType(key_type, columns[0], column_name, format_name, settings, &_is_key_nullable);
+            auto key_arrow_type = getArrowType(key_type, columns[0], column_name, format_name, settings, &_is_key_nullable, for_builder);
             bool is_val_nullable = false;
-            auto val_arrow_type = getArrowType(val_type, columns[1], column_name, format_name, settings, &is_val_nullable);
+            auto val_arrow_type = getArrowType(val_type, columns[1], column_name, format_name, settings, &is_val_nullable, for_builder);
 
             return arrow::map(
                 key_arrow_type,
@@ -1129,7 +1157,7 @@ namespace DB
             return arrow::uint32();
 
         if (isUUID(column_type))
-            return arrow::fixed_size_binary(sizeof(UUID));
+            return for_builder ? arrow::fixed_size_binary(sizeof(UUID)) : std::make_shared<ArrowUUIDExtensionType>();
 
         if (isDate(column_type) && settings.output_date_as_uint16)
             return arrow::uint16();
@@ -1267,8 +1295,13 @@ namespace DB
                 if (!settings.low_cardinality_as_dictionary)
                     column = recursiveRemoveLowCardinality(column);
 
+                // Generate the unwrapped builder schema (safe for MakeBuilder)
+                bool is_column_nullable = false;
+                auto builder_type = getArrowType(
+                    header_column.type, column, header_column.name, format_name, settings, &is_column_nullable, true /* for_builder */);
+
                 std::unique_ptr<arrow::ArrayBuilder> array_builder;
-                arrow::Status status = MakeBuilder(arrow::default_memory_pool(), arrow_schema->field(static_cast<int>(column_i))->type(), &array_builder);
+                arrow::Status status = MakeBuilder(arrow::default_memory_pool(), builder_type, &array_builder);
                 checkStatus(status, column->getName(), format_name);
 
                 fillArrowArray(
@@ -1286,6 +1319,15 @@ namespace DB
                 std::shared_ptr<arrow::Array> arrow_array;
                 status = array_builder->Finish(&arrow_array);
                 checkStatus(status, column->getName(), format_name);
+
+                // Zero-copy cast to the extension-rich schema (handles infinite nesting)
+                auto target_type = arrow_schema->field(static_cast<int>(column_i))->type();
+                if (!arrow_array->type()->Equals(*target_type))
+                {
+                    auto view_result = arrow_array->View(target_type);
+                    checkStatus(view_result.status(), column->getName(), format_name);
+                    arrow_array = view_result.ValueOrDie();
+                }
 
                 table_data.at(column_i).emplace_back(std::move(arrow_array));
             }

--- a/tests/queries/0_stateless/04049_arrow_parquet_writer_uuid.reference
+++ b/tests/queries/0_stateless/04049_arrow_parquet_writer_uuid.reference
@@ -1,0 +1,1 @@
+UUID	4dfdc6b0-e3f2-4649-ad36-6598aff9c482

--- a/tests/queries/0_stateless/04049_arrow_parquet_writer_uuid.sh
+++ b/tests/queries/0_stateless/04049_arrow_parquet_writer_uuid.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+DATA_FILE="${CLICKHOUSE_TEST_UNIQUE_NAME}.parquet"
+
+$CLICKHOUSE_LOCAL --output_format_parquet_use_custom_encoder=0 -q "
+    SELECT toUUID('4dfdc6b0-e3f2-4649-ad36-6598aff9c482') AS id
+    INTO OUTFILE '${DATA_FILE}' FORMAT Parquet;
+"
+
+$CLICKHOUSE_LOCAL -q "
+    SELECT toTypeName(id), id
+    FROM file('${DATA_FILE}', Parquet);
+"
+
+rm -f "${DATA_FILE}"


### PR DESCRIPTION
Closes #100119 

### Changelog category:
- Improvement

### Changelog entry:
Exporting UUIDs to Parquet via the Arrow encoder now includes the correct UUID type annotation, eliminating the need to manually cast `FixedString(16)` data when reading the files back into ClickHouse or other systems.

## Motivation

When exporting to Parquet using the Arrow-based writer, UUID columns were previously written as raw `FIXED_LEN_BYTE_ARRAY(16)` without the `logicalType.UUID` annotation. This caused downstream systems (and ClickHouse's own Parquet reader) to infer the column as `FixedString(16)` rather than a proper UUID.

Ensures full data interoperability for UUIDs when exporting to Parquet via Arrow, so downstream tools read the type correctly out of the box without requiring manual schema hints.

## Parameters

`output_format_parquet_use_custom_encoder=0`: Applies specifically when this setting is explicitly set to 0 (which routes Parquet generation through the Arrow subsystem). The native Parquet encoder (1, the default) is unaffected and already handles UUIDs correctly.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.66`
<!-- ch-version-info:end -->