### PR TITLE
Fix usage of text index with functions `startsWith` and `endsWith`

### DIFF
--- a/src/Interpreters/ITokenizer.cpp
+++ b/src/Interpreters/ITokenizer.cpp
@@ -85,6 +85,16 @@ bool NgramsTokenizer::nextInStringLike(const char * data, size_t length, size_t 
     return false;
 }
 
+void NgramsTokenizer::substringToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter, bool, bool) const
+{
+    stringToBloomFilter(data, length, bloom_filter);
+}
+
+void NgramsTokenizer::substringToTokens(const char * data, size_t length, std::vector<String> & tokens, bool, bool) const
+{
+    stringToTokens(data, length, tokens);
+}
+
 bool SplitByNonAlphaTokenizer::nextInString(const char * data, size_t length, size_t & __restrict pos, size_t & __restrict token_start, size_t & __restrict token_length) const
 {
     token_start = pos;
@@ -260,6 +270,16 @@ bool SplitByStringTokenizer::nextInStringLike(const char * /*data*/, size_t /*le
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "StringTokenExtractor::nextInStringLike is not implemented");
 }
 
+void SplitByStringTokenizer::substringToBloomFilter(const char *, size_t, BloomFilter &, bool, bool) const
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "SplitByStringTokenizer::substringToBloomFilter is not implemented");
+}
+
+void SplitByStringTokenizer::substringToTokens(const char *, size_t, std::vector<String> &, bool, bool) const
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "SplitByStringTokenizer::substringToTokens is not implemented");
+}
+
 String SplitByStringTokenizer::getDescription() const
 {
     String result = fmt::format("{}([", getName());
@@ -289,6 +309,16 @@ bool ArrayTokenizer::nextInString(const char * /*data*/, size_t length, size_t &
 bool ArrayTokenizer::nextInStringLike(const char * /*data*/, size_t /*length*/, size_t & /*pos*/, String & /*token*/) const
 {
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "ArrayTokenizer::nextInStringLike is not implemented");
+}
+
+void ArrayTokenizer::substringToBloomFilter(const char *, size_t, BloomFilter &, bool, bool) const
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "ArrayTokenizer::substringToBloomFilter is not implemented");
+}
+
+void ArrayTokenizer::substringToTokens(const char *, size_t, std::vector<String> &, bool, bool) const
+{
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "ArrayTokenizer::substringToTokens is not implemented");
 }
 
 SparseGramsTokenizer::SparseGramsTokenizer(size_t min_length, size_t max_length, std::optional<size_t> min_cutoff_length_)
@@ -372,6 +402,16 @@ bool SparseGramsTokenizer::nextInStringLike(const char * data, size_t length, si
             return true;
         }
     }
+}
+
+void SparseGramsTokenizer::substringToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter, bool /*is_prefix*/, bool /*is_suffix*/) const
+{
+    stringToBloomFilter(data, length, bloom_filter);
+}
+
+void SparseGramsTokenizer::substringToTokens(const char * data, size_t length, std::vector<String> & tokens, bool /*is_prefix*/, bool /*is_suffix*/) const
+{
+    stringToTokens(data, length, tokens);
 }
 
 std::vector<String> SparseGramsTokenizer::compactTokens(const std::vector<String> & tokens) const

--- a/src/Interpreters/ITokenizer.h
+++ b/src/Interpreters/ITokenizer.h
@@ -73,11 +73,8 @@ public:
         const char * data,
         size_t length,
         BloomFilter & bloom_filter,
-        bool /*is_prefix*/,
-        bool /*is_suffix*/) const
-    {
-        stringToBloomFilter(data, length, bloom_filter);
-    }
+        bool is_prefix,
+        bool is_suffix) const = 0;
 
     virtual void stringLikeToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter) const = 0;
 
@@ -92,11 +89,8 @@ public:
         const char * data,
         size_t length,
         std::vector<String> & tokens,
-        bool /*is_prefix*/,
-        bool /*is_suffix*/) const
-    {
-        stringToTokens(data, length, tokens);
-    }
+        bool is_prefix,
+        bool is_suffix) const = 0;
 
     virtual void stringLikeToTokens(const char * data, size_t length, std::vector<String> & tokens) const = 0;
     virtual bool supportsStringLike() const = 0;
@@ -116,7 +110,6 @@ protected:
     const char * getTokenizerName() const override { return Derived::getName(); }
     const char * getTokenizerExternalName() const override { return Derived::getExternalName(); }
 
-private:
     std::unique_ptr<ITokenizer> clone() const override
     {
         return std::make_unique<Derived>(*static_cast<const Derived *>(this));
@@ -182,6 +175,9 @@ struct NgramsTokenizer final : public ITokenizerHelper<NgramsTokenizer>
     size_t getN() const { return n; }
 
     bool supportsStringLike() const override { return true; }
+    void substringToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter, bool is_prefix, bool is_suffix) const override;
+    void substringToTokens(const char * data, size_t length, std::vector<String> & tokens, bool is_prefix, bool is_suffix) const override;
+
 private:
     size_t n;
 };
@@ -318,6 +314,8 @@ struct SplitByStringTokenizer final : public ITokenizerHelper<SplitByStringToken
     bool nextInStringLike(const char * data, size_t length, size_t & pos, String & token) const override;
 
     bool supportsStringLike() const override { return false; }
+    void substringToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter, bool is_prefix, bool is_suffix) const override;
+    void substringToTokens(const char * data, size_t length, std::vector<String> & tokens, bool is_prefix, bool is_suffix) const override;
 private:
     std::vector<String> separators;
 };
@@ -335,6 +333,8 @@ struct ArrayTokenizer final : public ITokenizerHelper<ArrayTokenizer>
     bool nextInStringLike(const char * data, size_t length, size_t & pos, String & token) const override;
 
     bool supportsStringLike() const override { return false; }
+    void substringToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter, bool is_prefix, bool is_suffix) const override;
+    void substringToTokens(const char * data, size_t length, std::vector<String> & tokens, bool is_prefix, bool is_suffix) const override;
 };
 
 /// Parser extracting sparse grams (the same as function sparseGrams).
@@ -353,6 +353,8 @@ struct SparseGramsTokenizer final : public ITokenizerHelper<SparseGramsTokenizer
 
     bool nextInStringLike(const char * data, size_t length, size_t & pos, String & token) const override;
     bool supportsStringLike() const override { return true; }
+    void substringToBloomFilter(const char * data, size_t length, BloomFilter & bloom_filter, bool is_prefix, bool is_suffix) const override;
+    void substringToTokens(const char * data, size_t length, std::vector<String> & tokens, bool is_prefix, bool is_suffix) const override;
 private:
     size_t min_gram_length;
     size_t max_gram_length;

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -587,14 +587,14 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
         out.text_search_queries.emplace_back(std::make_shared<TextSearchQuery>(function_name, TextSearchMode::All, direct_read_mode, std::move(tokens)));
         return true;
     }
-    if (function_name == "startsWith")
+    if (function_name == "startsWith" && tokenizer->supportsStringLike())
     {
         auto tokens = substringToTokens(value_field, true, false);
         out.function = RPNElement::FUNCTION_EQUALS;
         out.text_search_queries.emplace_back(std::make_shared<TextSearchQuery>(function_name, TextSearchMode::All, direct_read_mode, std::move(tokens)));
         return true;
     }
-    if (function_name == "endsWith")
+    if (function_name == "endsWith" && tokenizer->supportsStringLike())
     {
         auto tokens = substringToTokens(value_field, false, true);
         out.function = RPNElement::FUNCTION_EQUALS;

--- a/tests/queries/0_stateless/04050_text_index_starts_ends_with.reference
+++ b/tests/queries/0_stateless/04050_text_index_starts_ends_with.reference
@@ -1,0 +1,160 @@
+tokenizer: array
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_fts)
+    Indexes:
+      PrimaryKey
+        Condition: true
+        Parts: 3/3
+        Granules: 3/3
+      Ranges: 3
+2	Full-text search is now generally available
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_fts)
+    Indexes:
+      PrimaryKey
+        Condition: true
+        Parts: 3/3
+        Granules: 3/3
+      Ranges: 3
+2	Full-text search is now generally available
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_fts)
+    Indexes:
+      PrimaryKey
+        Condition: true
+        Parts: 3/3
+        Granules: 3/3
+      Ranges: 3
+1	ClickHouse is a fast analytical database
+tokenizer: splitByString
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_fts)
+    Indexes:
+      PrimaryKey
+        Condition: true
+        Parts: 3/3
+        Granules: 3/3
+      Ranges: 3
+2	Full-text search is now generally available
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_fts)
+    Indexes:
+      PrimaryKey
+        Condition: true
+        Parts: 3/3
+        Granules: 3/3
+      Ranges: 3
+2	Full-text search is now generally available
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_fts)
+    Indexes:
+      PrimaryKey
+        Condition: true
+        Parts: 3/3
+        Granules: 3/3
+      Ranges: 3
+1	ClickHouse is a fast analytical database
+tokenizer: ngrams(3)
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_fts)
+    Indexes:
+      PrimaryKey
+        Condition: true
+        Parts: 3/3
+        Granules: 3/3
+      Skip
+        Name: idx_name_fts
+        Description: text GRANULARITY 100000000
+        Condition: (mode: All; tokens: ["Ful", "ull"])
+        Parts: 1/3
+        Granules: 1/3
+      Ranges: 1
+2	Full-text search is now generally available
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_fts)
+    Indexes:
+      PrimaryKey
+        Condition: true
+        Parts: 3/3
+        Granules: 3/3
+      Skip
+        Name: idx_name_fts
+        Description: text GRANULARITY 100000000
+        Condition: (mode: All; tokens: ["Ful", "ull"])
+        Parts: 1/3
+        Granules: 1/3
+      Ranges: 1
+2	Full-text search is now generally available
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_fts)
+    Indexes:
+      PrimaryKey
+        Condition: true
+        Parts: 3/3
+        Granules: 3/3
+      Skip
+        Name: idx_name_fts
+        Description: text GRANULARITY 100000000
+        Condition: (mode: All; tokens: [" da", "aba", "al ", "aly", "ana", "ase", "ata", "bas", "cal", "dat", "ica", "l d", "lyt", "nal", "tab", "tic", "yti"])
+        Parts: 1/3
+        Granules: 1/3
+      Ranges: 1
+1	ClickHouse is a fast analytical database
+tokenizer: splitByNonAlpha
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_fts)
+    Indexes:
+      PrimaryKey
+        Condition: true
+        Parts: 3/3
+        Granules: 3/3
+      Skip
+        Name: idx_name_fts
+        Description: text GRANULARITY 100000000
+        Condition: (mode: All; tokens: [])
+        Parts: 3/3
+        Granules: 3/3
+      Ranges: 3
+2	Full-text search is now generally available
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_fts)
+    Indexes:
+      PrimaryKey
+        Condition: true
+        Parts: 3/3
+        Granules: 3/3
+      Skip
+        Name: idx_name_fts
+        Description: text GRANULARITY 100000000
+        Condition: (mode: All; tokens: [])
+        Parts: 3/3
+        Granules: 3/3
+      Ranges: 3
+2	Full-text search is now generally available
+Expression ((Project names + Projection))
+  Expression ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_fts)
+    Indexes:
+      PrimaryKey
+        Condition: true
+        Parts: 3/3
+        Granules: 3/3
+      Skip
+        Name: idx_name_fts
+        Description: text GRANULARITY 100000000
+        Condition: (mode: All; tokens: ["database"])
+        Parts: 1/3
+        Granules: 1/3
+      Ranges: 1
+1	ClickHouse is a fast analytical database

--- a/tests/queries/0_stateless/04050_text_index_starts_ends_with.sql.j2
+++ b/tests/queries/0_stateless/04050_text_index_starts_ends_with.sql.j2
@@ -1,0 +1,59 @@
+{% for tokenizer in ['array', 'splitByString', 'ngrams(3)', 'splitByNonAlpha'] -%}
+
+DROP TABLE IF EXISTS test_fts;
+
+SELECT 'tokenizer: {{ tokenizer }}';
+
+CREATE TABLE test_fts
+(
+    id UInt64,
+    name String,
+    INDEX idx_name_fts name TYPE text(tokenizer = {{ tokenizer }})
+)
+ENGINE = MergeTree
+ORDER BY id SETTINGS index_granularity = 1024;
+
+SYSTEM STOP MERGES test_fts;
+
+INSERT INTO test_fts VALUES
+    (1, 'ClickHouse is a fast analytical database');
+
+INSERT INTO test_fts VALUES
+    (2, 'Full-text search is now generally available');
+
+INSERT INTO test_fts VALUES
+    (3, 'The quick brown fox jumps over the lazy dog'),
+    (4, 'ClickHouse supports inverted text indexes');
+
+SET optimize_rewrite_like_perfect_affix = 1;
+
+EXPLAIN indexes = 1
+SELECT id, name
+FROM test_fts
+WHERE name LIKE 'Full%';
+
+SELECT id, name
+FROM test_fts
+WHERE name LIKE 'Full%';
+
+EXPLAIN indexes = 1
+SELECT id, name
+FROM test_fts
+WHERE startsWith(name, 'Full');
+
+SELECT id, name
+FROM test_fts
+WHERE startsWith(name, 'Full');
+
+EXPLAIN indexes = 1
+SELECT id, name
+FROM test_fts
+WHERE endsWith(name, 'analytical database');
+
+SELECT id, name
+FROM test_fts
+WHERE endsWith(name, 'analytical database');
+
+DROP TABLE test_fts;
+
+{% endfor -%}

--- a/tests/queries/0_stateless/04050_text_index_starts_ends_with.sql.j2
+++ b/tests/queries/0_stateless/04050_text_index_starts_ends_with.sql.j2
@@ -1,4 +1,8 @@
+-- Tags: no-parallel-replicas
+
 {% for tokenizer in ['array', 'splitByString', 'ngrams(3)', 'splitByNonAlpha'] -%}
+
+SET enable_analyzer = 1;
 
 DROP TABLE IF EXISTS test_fts;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed incorrect usage of text index with `startsWith` and `endsWith` functions for tokenizers that do not support substring matching (`array`, `splitByString`). Previously, these tokenizers would silently produce wrong results, potentially causing the index to skip granules containing matching rows. 


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.76`
- Backported to: `26.3.1.883`, `26.2.6.10`
<!-- ch-version-info:end -->