### PR TITLE
Support running targeted jobs locally in `ci/jobs/integration_test_job.py`

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -435,7 +435,7 @@ tar -czf ./ci/tmp/logs.tar.gz \
             os.environ[key] = value.strip()
 
     java_path = Shell.get_output(
-        "update-alternatives --config java | sed -n 's/.*(providing \/usr\/bin\/java): //p'",
+        r"update-alternatives --config java | sed -n 's/.*(providing \/usr\/bin\/java): //p'",
         verbose=True,
     )
     repeat_option = ""
@@ -512,7 +512,7 @@ tar -czf ./ci/tmp/logs.tar.gz \
     print(f"Using ClickHouse binary at [{clickhouse_path}]")
 
     changed_test_modules = []
-    if is_bugfix_validation or is_flaky_check or is_targeted_check:
+    if is_bugfix_validation or is_flaky_check:
         if info.is_local_run:
             assert (
                 args.test
@@ -562,28 +562,41 @@ tar -czf ./ci/tmp/logs.tar.gz \
 
     targeted_tests = []
     if is_targeted_check:
-        assert not args.test, "--test not supposed to be used for targeted check ???"
-        targeter = Targeting(info=info)
-        tests, results_with_info = targeter.get_all_relevant_tests_with_info(
-            clickhouse_path
-        )
-        # no subtask level for integration tests - cannot add this info to the report now
-        # results.append(results_with_info)
-        if not tests:
-            # early exit
-            Result.create_from(
-                status=Result.Status.SKIPPED,
-                info="No failed tests found from previous runs",
-            ).complete_job()
+        if info.is_local_run:
+            assert (
+                args.test
+            ), (
+                "Local run of targeted integration job requires --test "
+                "(CIDB-based test selection is unavailable). "
+                "Example: --test test_polymorphic_parts"
+            )
+            print(
+                "NOTE: local targeted run: using explicit --test selectors instead of CIDB",
+                flush=True,
+            )
+        else:
+            assert not args.test, "--test not supposed to be used for targeted check ???"
+            targeter = Targeting(info=info)
+            tests, results_with_info = targeter.get_all_relevant_tests_with_info(
+                clickhouse_path
+            )
+            # no subtask level for integration tests - cannot add this info to the report now
+            # results.append(results_with_info)
+            if not tests:
+                # early exit
+                Result.create_from(
+                    status=Result.Status.SKIPPED,
+                    info="No failed tests found from previous runs",
+                ).complete_job()
 
-        # Parse test names from the query result
-        for test_ in tests:
-            if test_.strip():
-                test_name = test_.strip()
-                targeted_tests.append(
-                    test_name.split("[")[0]
-                )  # remove parametrization - does not work with test repeat with --count
-        print(f"Parsed {len(targeted_tests)} test names: {targeted_tests}")
+            # Parse test names from the query result
+            for test_ in tests:
+                if test_.strip():
+                    test_name = test_.strip()
+                    targeted_tests.append(
+                        test_name.split("[")[0]
+                    )  # remove parametrization - does not work with test repeat with --count
+            print(f"Parsed {len(targeted_tests)} test names: {targeted_tests}")
 
     if not Shell.check("docker info > /dev/null 2>&1", verbose=True):
         _start_docker_in_docker()


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

There are also two other nit fixes, though they shouldn't make a real difference.

### Documentation entry for user-facing changes

N/A

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

### Explanation
Previously, it wasn't possible to run a `targeted` CI check on local mode because of a bug in the logic. There were conflicting checks in this file where one condition requires the use of `--test` and another one bans it. Effectively, the script prevented users from running targeted_checks manually entirely because you would hit one of the assertions. This PR updates it so the `assert not args.test` statement is avoided on local mode, so that the script now allows (and requires) the user to specify `--test`, similar to other CI check types.
