### PR TITLE
Fix join runtime filter with Variant type

### DIFF
--- a/src/Processors/QueryPlan/RuntimeFilterLookup.h
+++ b/src/Processors/QueryPlan/RuntimeFilterLookup.h
@@ -107,7 +107,8 @@ public:
     )
         : IRuntimeFilter(filters_to_merge_, filter_column_target_type_, pass_ratio_threshold_for_disabling_, blocks_to_skip_before_reenabling_)
         , argument_can_have_nulls(hasNullable(filter_column_target_type) ||
-            WhichDataType(filter_column_target_type).isDynamic())
+            WhichDataType(filter_column_target_type).isDynamic() ||
+            WhichDataType(filter_column_target_type).isVariant())
         , bytes_limit(bytes_limit_)
         , exact_values_limit(exact_values_limit_)
         , exact_values(std::make_shared<Set>(SizeLimits{}, -1, argument_can_have_nulls))

--- a/tests/queries/0_stateless/04051_runtime_filter_variant_type.reference
+++ b/tests/queries/0_stateless/04051_runtime_filter_variant_type.reference
@@ -1,0 +1,2 @@
+true
+true

--- a/tests/queries/0_stateless/04051_runtime_filter_variant_type.sql
+++ b/tests/queries/0_stateless/04051_runtime_filter_variant_type.sql
@@ -1,0 +1,24 @@
+-- Reproducer for a bug where __applyFilter runtime filter returned Nullable(UInt8) instead of UInt8
+-- when joining on Variant columns. The Variant type can represent NULL, but `hasNullable` returns
+-- false for it, so the runtime filter incorrectly chose the single-element `equals` optimization
+-- (ValuesCount::ONE path) which produces Nullable(UInt8) via the Variant function adaptor.
+--
+-- The right side must have exactly 1 row to trigger the ONE code path.
+
+SET enable_analyzer = 1;
+
+-- Minimal reproducer: join on a Variant column with 1 row on the right side
+SELECT *
+FROM
+    (SELECT v FROM format(TSV, 'v Variant(String, Bool)', 'true\nfalse')) AS t1
+    JOIN
+    (SELECT v FROM format(TSV, 'v Variant(String, Bool)', 'true')) AS t2
+    USING (v);
+
+-- Same but with NULL values on the left side (NULL should not match)
+SELECT *
+FROM
+    (SELECT v FROM format(TSV, 'v Variant(String, Bool)', 'true\n\\N\nfalse')) AS t1
+    JOIN
+    (SELECT v FROM format(TSV, 'v Variant(String, Bool)', 'true')) AS t2
+    USING (v);


### PR DESCRIPTION
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=94849&sha=39d5e9127219f15622800caf07fd27eee52b9949&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%29
https://github.com/ClickHouse/ClickHouse/pull/94849

### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix join runtime filters on top of the Variant data type.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.65`
<!-- ch-version-info:end -->