### PR TITLE
Support query parameters in clickhouse-benchmark

### DIFF
--- a/docs/en/operations/utilities/clickhouse-benchmark.md
+++ b/docs/en/operations/utilities/clickhouse-benchmark.md
@@ -75,6 +75,45 @@ clickhouse-benchmark [keys] < queries_file;
 
 If you want to apply some [settings](/operations/settings/overview) for queries, pass them as a key `--<session setting name>= SETTING_VALUE`. For example, `--max_memory_usage=1048576`.
 
+## Query Parameters {#clickhouse-benchmark-query-parameters}
+
+`clickhouse-benchmark` supports parameterized queries similar to `clickhouse-client`. You can specify parameters using `--param_<name>=<value>` command-line options and reference them in queries using the `{name:Type}` syntax.
+
+**Syntax:**
+
+```bash
+clickhouse-benchmark --param_<name>=<value> [--param_<name2>=<value2> ...] --query "SELECT {name:Type}"
+```
+
+**Examples:**
+
+```bash
+# String parameter
+clickhouse-benchmark --iterations 10 --param_user 'alice' \
+    --query "SELECT * FROM users WHERE name = {user:String}"
+
+# Numeric parameter
+clickhouse-benchmark --iterations 100 --param_limit 1000 \
+    --query "SELECT * FROM table LIMIT {limit:UInt32}"
+
+# Array parameter
+clickhouse-benchmark --iterations 50 --param_ids '[1,2,3,4,5]' \
+    --query "SELECT * FROM table WHERE id IN {ids:Array(UInt32)}"
+
+# Multiple parameters
+clickhouse-benchmark --concurrency 10 --iterations 1000 \
+    --param_min_val 100 --param_max_val 200 \
+    --query "SELECT count() FROM table WHERE value BETWEEN {min_val:UInt32} AND {max_val:UInt32}"
+
+# Identifier parameter (for table/column names)
+clickhouse-benchmark --param_table 'system.numbers' \
+    --query "SELECT count() FROM {table:Identifier} LIMIT 1000000"
+```
+
+**Supported types:** All ClickHouse data types are supported. See the [data types reference](/sql-reference/data-types/index.md) for details.
+
+**Protocol compatibility:** Query parameters are sent via the network protocol and substituted on the server side. Servers older than version 21.12 do not support query parameters and will return an error.
+
 ## Environment variable options {#clickhouse-benchmark-environment-variable-options}
 
 The user name, password and host can be set via environment variables `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD` and `CLICKHOUSE_HOST`.  

--- a/programs/benchmark/Benchmark.cpp
+++ b/programs/benchmark/Benchmark.cpp
@@ -40,6 +40,8 @@
 #include <Common/CurrentMetrics.h>
 #include <IO/WriteBuffer.h>
 #include <Client/ClientApplicationBaseParser.h>
+#include <Core/ProtocolDefines.h>
+#include <Core/Protocol.h>
 
 /** A tool for evaluating ClickHouse performance.
   * The tool emulates a case with fixed amount of simultaneously executing queries.
@@ -64,6 +66,7 @@ namespace ErrorCodes
     extern const int CANNOT_BLOCK_SIGNAL;
     extern const int EMPTY_DATA_PASSED;
     extern const int UNRECOGNIZED_ARGUMENTS;
+    extern const int NOT_IMPLEMENTED;
 }
 
 class Benchmark : public Poco::Util::Application
@@ -74,7 +77,8 @@ public:
         String && proto_send_chunked,
         String && proto_recv_chunked,
         bool print_stacktrace_,
-        Settings && settings_)
+        Settings && settings_,
+        NameToNameMap && query_parameters_)
         : connection_arguments(ConnectionArguments{
             .hosts = options.contains("host") ? std::make_optional(options["host"].as<Strings>()) : std::nullopt,
             .ports = options.contains("port") ? std::make_optional(options["port"].as<Ports>()) : std::nullopt,
@@ -109,6 +113,7 @@ public:
         display_client_side_time(options.contains("client-side-time")),
         print_stacktrace(print_stacktrace_),
         settings(std::move(settings_)),
+        query_parameters(std::move(query_parameters_)),
         shared_context(Context::createShared()),
         global_context(Context::createGlobal(shared_context.get())),
         pool(CurrentMetrics::LocalThread, CurrentMetrics::LocalThreadActive, CurrentMetrics::LocalThreadScheduled, max_concurrency)
@@ -117,6 +122,10 @@ public:
         global_context->setSettings(settings);
         global_context->setClientName(std::string(DEFAULT_CLIENT_NAME));
         global_context->setQueryKindInitial();
+
+        /// Set query parameters in context
+        if (!query_parameters.empty())
+            global_context->setQueryParameters(query_parameters);
 
         /// This is needed to receive blocks with columns of AggregateFunction data type
         /// (example: when using stage = 'with_mergeable_state')
@@ -257,7 +266,8 @@ private:
     size_t reconnect;
     bool display_client_side_time;
     bool print_stacktrace;
-    const Settings & settings;
+    Settings settings;
+    NameToNameMap query_parameters;  /// Parameterized query values
     SharedContextHolder shared_context;
     ContextMutablePtr global_context;
     QueryProcessingStage::Enum query_processing_stage;
@@ -269,6 +279,8 @@ private:
 
     /// Don't execute new queries after timelimit or SIGINT or exception
     std::atomic<bool> shutdown{false};
+    /// Whether server version has been checked for query parameter support
+    std::atomic<bool> server_version_checked{false};
 
     std::atomic<size_t> queries_executed{0};
 
@@ -670,6 +682,22 @@ private:
 
         ConnectionPool::Entry entry = connections[connection_index]->get(ConnectionTimeouts::getTCPTimeoutsWithoutFailover(settings));
 
+        /// Check server version for query parameter support on the first query execution,
+        /// reusing the connection already obtained from the pool.
+        if (!query_parameters.empty() && !server_version_checked.load(std::memory_order_relaxed))
+        {
+            UInt64 server_revision = entry->getServerRevision(
+                ConnectionTimeouts::getTCPTimeoutsWithoutFailover(settings));
+
+            if (server_revision < DBMS_MIN_PROTOCOL_VERSION_WITH_PARAMETERS)
+                throw Exception(ErrorCodes::NOT_IMPLEMENTED,
+                    "Query parameters are not supported by the server (revision {}). "
+                    "Minimum required revision is {}.",
+                    server_revision, DBMS_MIN_PROTOCOL_VERSION_WITH_PARAMETERS);
+
+            server_version_checked.store(true, std::memory_order_relaxed);
+        }
+
         bool should_reconnect = false;
         {
             std::lock_guard lock(queries_per_connection_mutex);
@@ -882,11 +910,58 @@ int mainEntryClickHouseBenchmark(int argc, char ** argv)
             ("proto_caps", value<std::string>(), "Enable/disable chunked protocol (comma-separated): chunked_optional, notchunked, notchunked_optional, send_chunked, send_chunked_optional, send_notchunked, send_notchunked_optional, recv_chunked, recv_chunked_optional, recv_notchunked, recv_notchunked_optional")
         ;
 
+        /// Parse query parameters manually and filter them out from arguments
+        /// (same approach as clickhouse-client)
+        NameToNameMap query_parameters;
+        std::vector<String> filtered_arguments;
+
+        /// skip program name
+        for (int arg_num = 1; arg_num < argc; ++arg_num)
+        {
+            std::string_view arg = argv[arg_num];
+
+            if (arg.starts_with("--param_") || arg.starts_with("--param-"))
+            {
+                auto param_continuation = arg.substr(strlen("--param_"));
+                auto equal_pos = param_continuation.find_first_of('=');
+
+                if (equal_pos == std::string::npos)
+                {
+                    /// param_name value
+                    ++arg_num;
+                    if (arg_num >= argc)
+                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Parameter requires value");
+                    arg = argv[arg_num];
+                    if (arg.starts_with("--") || arg.starts_with("-"))
+                        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                            "Parameter `{}` requires a value, but got `{}` which looks like a flag. "
+                            "Use --param_{}=<value> syntax instead.",
+                            param_continuation, arg, param_continuation);
+                    query_parameters.emplace(String(param_continuation), String(arg));
+                    /// Skip both --param_name and value from filtered arguments
+                }
+                else
+                {
+                    if (equal_pos == 0)
+                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Parameter name cannot be empty");
+
+                    /// param_name=value
+                    query_parameters.emplace(param_continuation.substr(0, equal_pos), param_continuation.substr(equal_pos + 1));
+                    /// Skip --param_name=value from filtered arguments
+                }
+            }
+            else
+            {
+                /// Add non-parameter arguments to filtered list
+                filtered_arguments.emplace_back(argv[arg_num]);
+            }
+        }
+
         Settings settings;
         auto options_description_non_verbose = options_description;
         settings.addToProgramOptions(options_description);
 
-        auto parser = po::command_line_parser(argc, argv)
+        auto parser = po::command_line_parser(filtered_arguments)
                           .options(options_description)
                           .extra_parser(OptionsAliasParser(options_description))
                           .allow_unregistered();
@@ -896,7 +971,8 @@ int mainEntryClickHouseBenchmark(int argc, char ** argv)
         auto unrecognized_options = po::collect_unrecognized(parsed.options, po::collect_unrecognized_mode::exclude_positional);
         if (!unrecognized_options.empty())
         {
-            throw Exception(ErrorCodes::UNRECOGNIZED_ARGUMENTS, "Unrecognized option '{}'", unrecognized_options[0]);
+            throw Exception(ErrorCodes::UNRECOGNIZED_ARGUMENTS,
+                "Unrecognized option '{}'", unrecognized_options[0]);
         }
 
         /// Check positional options.
@@ -926,6 +1002,10 @@ int mainEntryClickHouseBenchmark(int argc, char ** argv)
                 std::cout << options_description << "\n";
             else
                 std::cout << options_description_non_verbose << "\n";
+            std::cout << "\nQuery parameters:\n"
+                         "  --param_<name>=<value>      Set query parameter (can also use --param-<name>).\n"
+                         "                              Multiple parameters can be specified.\n"
+                         "                              Example: --param_id=42 --query \"SELECT {id:UInt32}\"\n";
             std::cout << "\nSee also: https://clickhouse.com/docs/operations/utilities/clickhouse-benchmark/\n";
             return 0;
         }
@@ -982,7 +1062,8 @@ int mainEntryClickHouseBenchmark(int argc, char ** argv)
             std::move(proto_send_chunked),
             std::move(proto_recv_chunked),
             print_stacktrace,
-            std::move(settings));
+            std::move(settings),
+            std::move(query_parameters));
         return benchmark.run();
     }
     catch (const po::error & e)

--- a/src/Client/HedgedConnections.cpp
+++ b/src/Client/HedgedConnections.cpp
@@ -177,6 +177,7 @@ void HedgedConnections::sendIgnoredPartUUIDs(const std::vector<UUID> & uuids)
 void HedgedConnections::sendQuery(
     const ConnectionTimeouts & timeouts,
     const String & query,
+    const NameToNameMap & query_parameters,
     const String & query_id,
     UInt64 stage,
     ClientInfo & client_info,
@@ -208,7 +209,7 @@ void HedgedConnections::sendQuery(
         hedged_connections_factory.skipReplicasWithTwoLevelAggregationIncompatibility();
     }
 
-    auto send_query = [this, timeouts, query, query_id, stage, client_info, with_pending_data, external_roles](ReplicaState & replica)
+    auto send_query = [this, timeouts, query, query_parameters, query_id, stage, client_info, with_pending_data, external_roles](ReplicaState & replica)
     {
         Settings modified_settings = settings;
 
@@ -238,7 +239,7 @@ void HedgedConnections::sendQuery(
         modified_settings.set("allow_experimental_analyzer", static_cast<bool>(modified_settings[Setting::allow_experimental_analyzer]));
 
         replica.connection->sendQuery(
-            timeouts, query, /* query_parameters */ {}, query_id, stage, &modified_settings, &client_info, with_pending_data, external_roles, {});
+            timeouts, query, query_parameters, query_id, stage, &modified_settings, &client_info, with_pending_data, external_roles, {});
 
         replica.change_replica_timeout.setRelative(timeouts.receive_data_timeout);
         replica.packet_receiver->setTimeout(hedged_connections_factory.getConnectionTimeouts().receive_timeout);

--- a/src/Client/HedgedConnections.h
+++ b/src/Client/HedgedConnections.h
@@ -87,6 +87,7 @@ public:
     void sendQuery(
         const ConnectionTimeouts & timeouts,
         const String & query,
+        const NameToNameMap & query_parameters,
         const String & query_id,
         UInt64 stage,
         ClientInfo & client_info,

--- a/src/Client/IConnections.h
+++ b/src/Client/IConnections.h
@@ -21,6 +21,7 @@ public:
     virtual void sendQuery(
         const ConnectionTimeouts & timeouts,
         const String & query,
+        const NameToNameMap & query_parameters,
         const String & query_id,
         UInt64 stage,
         ClientInfo & client_info,

--- a/src/Client/MultiplexedConnections.cpp
+++ b/src/Client/MultiplexedConnections.cpp
@@ -141,6 +141,7 @@ void MultiplexedConnections::sendExternalTablesData(std::vector<ExternalTablesDa
 void MultiplexedConnections::sendQuery(
     const ConnectionTimeouts & timeouts,
     const String & query,
+    const NameToNameMap & query_parameters,
     const String & query_id,
     UInt64 stage,
     ClientInfo & client_info,
@@ -199,14 +200,14 @@ void MultiplexedConnections::sendQuery(
                 modified_settings[Setting::parallel_replica_offset] = i;
 
             replica_states[i].connection->sendQuery(
-                timeouts, query, /* query_parameters */ {}, query_id, stage, &modified_settings, &client_info, with_pending_data, external_roles, {});
+                timeouts, query, query_parameters, query_id, stage, &modified_settings, &client_info, with_pending_data, external_roles, {});
         }
     }
     else
     {
         /// Use single replica.
         replica_states[0].connection->sendQuery(
-            timeouts, query, /* query_parameters */ {}, query_id, stage, &modified_settings, &client_info, with_pending_data, external_roles, {});
+            timeouts, query, query_parameters, query_id, stage, &modified_settings, &client_info, with_pending_data, external_roles, {});
     }
 
     sent_query = true;

--- a/src/Client/MultiplexedConnections.h
+++ b/src/Client/MultiplexedConnections.h
@@ -33,6 +33,7 @@ public:
     void sendQuery(
         const ConnectionTimeouts & timeouts,
         const String & query,
+        const NameToNameMap & query_parameters,
         const String & query_id,
         UInt64 stage,
         ClientInfo & client_info,

--- a/src/QueryPipeline/RemoteQueryExecutor.cpp
+++ b/src/QueryPipeline/RemoteQueryExecutor.cpp
@@ -434,7 +434,10 @@ void RemoteQueryExecutor::sendQueryUnlocked(ClientInfo::QueryKind query_kind, As
         local_granted_roles.insert(local_granted_roles.end(), granted_roles.begin(), granted_roles.end());
     }
 
-    connections->sendQuery(timeouts, query, query_id, stage, modified_client_info, true, local_granted_roles);
+    /// Extract query parameters from context
+    const auto & query_parameters = context->getQueryParameters();
+
+    connections->sendQuery(timeouts, query, query_parameters, query_id, stage, modified_client_info, true, local_granted_roles);
 
     established = false;
     sent_query = true;

--- a/tests/queries/0_stateless/03400_benchmark_query_parameters.reference
+++ b/tests/queries/0_stateless/03400_benchmark_query_parameters.reference
@@ -1,0 +1,8 @@
+OK: Basic string parameter
+OK: Numeric parameter
+OK: Array parameter
+OK: Multiple parameters
+OK: Identifier parameter
+OK: Space-separated parameter
+OK: Hyphen variant parameter
+All tests passed

--- a/tests/queries/0_stateless/03400_benchmark_query_parameters.sh
+++ b/tests/queries/0_stateless/03400_benchmark_query_parameters.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Test basic string parameter
+${CLICKHOUSE_BENCHMARK} --iterations 1 --concurrency 1 \
+    --param_name 'test_value' \
+    --query "SELECT {name:String} AS result" \
+    2>&1 | grep -q "Queries executed: 1" && echo "OK: Basic string parameter"
+
+# Test numeric parameter
+${CLICKHOUSE_BENCHMARK} --iterations 1 --concurrency 1 \
+    --param_id 42 \
+    --query "SELECT {id:UInt32} AS result" \
+    2>&1 | grep -q "Queries executed: 1" && echo "OK: Numeric parameter"
+
+# Test array parameter
+${CLICKHOUSE_BENCHMARK} --iterations 1 --concurrency 1 \
+    --param_arr '[1,2,3]' \
+    --query "SELECT {arr:Array(UInt32)} AS result" \
+    2>&1 | grep -q "Queries executed: 1" && echo "OK: Array parameter"
+
+# Test multiple parameters
+${CLICKHOUSE_BENCHMARK} --iterations 1 --concurrency 1 \
+    --param_str 'hello' \
+    --param_num 123 \
+    --query "SELECT {str:String} AS s, {num:UInt32} AS n" \
+    2>&1 | grep -q "Queries executed: 1" && echo "OK: Multiple parameters"
+
+# Test identifier parameter (table name)
+${CLICKHOUSE_BENCHMARK} --iterations 1 --concurrency 1 \
+    --param_tbl 'one' \
+    --query "SELECT * FROM system.{tbl:Identifier}" \
+    2>&1 | grep -q "Queries executed: 1" && echo "OK: Identifier parameter"
+
+# Test space-separated parameter form (--param_name value)
+${CLICKHOUSE_BENCHMARK} --iterations 1 --concurrency 1 \
+    --param_val test_space \
+    --query "SELECT {val:String} AS result" \
+    2>&1 | grep -q "Queries executed: 1" && echo "OK: Space-separated parameter"
+
+# Test hyphen variant (--param-name)
+${CLICKHOUSE_BENCHMARK} --iterations 1 --concurrency 1 \
+    --param-hyphen 'hyphen_test' \
+    --query "SELECT {hyphen:String} AS result" \
+    2>&1 | grep -q "Queries executed: 1" && echo "OK: Hyphen variant parameter"
+
+echo "All tests passed"

--- a/tests/queries/0_stateless/03401_benchmark_query_parameters_errors.reference
+++ b/tests/queries/0_stateless/03401_benchmark_query_parameters_errors.reference
@@ -1,0 +1,4 @@
+OK: Missing parameter value detected
+OK: Flag-like parameter value detected
+OK: Undefined parameter detected
+Error handling tests passed

--- a/tests/queries/0_stateless/03401_benchmark_query_parameters_errors.sh
+++ b/tests/queries/0_stateless/03401_benchmark_query_parameters_errors.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-parallel
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Test missing parameter value (param as last argument)
+${CLICKHOUSE_BENCHMARK} --iterations 1 --concurrency 1 \
+    --query "SELECT 1" \
+    --param_missing \
+    2>&1 | grep -q "Parameter requires value" && echo "OK: Missing parameter value detected"
+
+# Test parameter value that looks like a flag (--param_name --query should error, not consume --query)
+${CLICKHOUSE_BENCHMARK} --iterations 1 --concurrency 1 \
+    --param_test --query "SELECT 1" \
+    2>&1 | grep -q "looks like a flag" && echo "OK: Flag-like parameter value detected"
+
+# Test query with undefined parameter (should fail gracefully)
+${CLICKHOUSE_BENCHMARK} --iterations 1 --concurrency 1 \
+    --query "SELECT {undefined:String}" \
+    2>&1 | grep -qi "error\|exception" && echo "OK: Undefined parameter detected"
+
+echo "Error handling tests passed"

--- a/tests/queries/0_stateless/03402_benchmark_query_parameters_integration.reference
+++ b/tests/queries/0_stateless/03402_benchmark_query_parameters_integration.reference
@@ -1,0 +1,4 @@
+OK: Parameterized SELECT
+OK: Parameterized IN clause
+OK: Parameterized aggregation
+Integration tests passed

--- a/tests/queries/0_stateless/03402_benchmark_query_parameters_integration.sh
+++ b/tests/queries/0_stateless/03402_benchmark_query_parameters_integration.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Create a temporary table for testing
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE IF NOT EXISTS ${CLICKHOUSE_DATABASE}.test_benchmark_params (
+    id UInt32,
+    name String,
+    value Float64
+) ENGINE = Memory"
+
+# Insert test data
+${CLICKHOUSE_CLIENT} --query "INSERT INTO ${CLICKHOUSE_DATABASE}.test_benchmark_params VALUES
+    (1, 'test1', 10.5),
+    (2, 'test2', 20.5),
+    (3, 'test3', 30.5)"
+
+# Test SELECT with parameter
+${CLICKHOUSE_BENCHMARK} --iterations 5 --concurrency 2 \
+    --param_target_id 2 \
+    --query "SELECT * FROM ${CLICKHOUSE_DATABASE}.test_benchmark_params WHERE id = {target_id:UInt32}" \
+    2>&1 | grep -q "Queries executed: 5" && echo "OK: Parameterized SELECT"
+
+# Test with IN clause and array parameter
+${CLICKHOUSE_BENCHMARK} --iterations 3 --concurrency 1 \
+    --param_ids '[1,3]' \
+    --query "SELECT count() FROM ${CLICKHOUSE_DATABASE}.test_benchmark_params WHERE id IN {ids:Array(UInt32)}" \
+    2>&1 | grep -q "Queries executed: 3" && echo "OK: Parameterized IN clause"
+
+# Test aggregation with parameter
+${CLICKHOUSE_BENCHMARK} --iterations 2 --concurrency 1 \
+    --param_threshold 15.0 \
+    --query "SELECT count() FROM ${CLICKHOUSE_DATABASE}.test_benchmark_params WHERE value > {threshold:Float64}" \
+    2>&1 | grep -q "Queries executed: 2" && echo "OK: Parameterized aggregation"
+
+# Cleanup
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${CLICKHOUSE_DATABASE}.test_benchmark_params"
+
+echo "Integration tests passed"

--- a/tests/queries/0_stateless/03403_benchmark_query_parameters_concurrency.reference
+++ b/tests/queries/0_stateless/03403_benchmark_query_parameters_concurrency.reference
@@ -1,0 +1,3 @@
+OK: High concurrency with parameters
+OK: Randomized execution with parameters
+Concurrency tests passed

--- a/tests/queries/0_stateless/03403_benchmark_query_parameters_concurrency.sh
+++ b/tests/queries/0_stateless/03403_benchmark_query_parameters_concurrency.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-parallel
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Test with high concurrency to ensure thread safety
+${CLICKHOUSE_BENCHMARK} --iterations 100 --concurrency 10 \
+    --param_value 'concurrent_test' \
+    --query "SELECT {value:String}, sleep(0.001)" \
+    2>&1 | grep -q "Queries executed: 100" && echo "OK: High concurrency with parameters"
+
+# Test with randomize option
+${CLICKHOUSE_BENCHMARK} --iterations 50 --concurrency 5 --randomize \
+    --param_num 42 \
+    --query "SELECT {num:UInt32} * number FROM system.numbers LIMIT 10" \
+    2>&1 | grep -q "Queries executed: 50" && echo "OK: Randomized execution with parameters"
+
+echo "Concurrency tests passed"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Support query parameters in clickhouse-benchmark

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)


Continues https://github.com/ClickHouse/ClickHouse/pull/99972 to improve clickhouse-benchmark.

```
clickhouse-benchmark --param_<name>=<value> [--param_<name2>=<value2> ...] --query "SELECT {name:Type}"
```