### PR TITLE
Fix flaky test `test_refreshable_mv/test.py::test_backup_outer_table`

### DIFF
--- a/tests/integration/test_refreshable_mv/test.py
+++ b/tests/integration/test_refreshable_mv/test.py
@@ -507,26 +507,24 @@ def do_test_backup(to_table):
         node1.query(f"SYSTEM WAIT VIEW re.{target}")
         node2.query(f"SYSTEM WAIT VIEW re.{target}")
     else:
-        # After restore, the refresh task resumes immediately (REFRESH EVERY 1 second).
-        # A refresh may EXCHANGE the target table via the DDL log. The EXCHANGE propagates
-        # asynchronously; SYNC REPLICA may run against the pre-EXCHANGE table, then the
-        # EXCHANGE swaps in the new table whose data hasn't replicated yet → empty SELECT.
-        # Fix: stop the view, wait for any in-flight refresh to fully complete (including
-        # the EXCHANGE DDL), sync DDL, sync data.
-        for node in nodes:
-            node.query("SYSTEM STOP VIEW re.rmv")
-        # WAIT VIEW ensures any in-flight refresh finishes, including the EXCHANGE DDL.
-        # For coordinated views it also waits for the EXCHANGE to be visible locally.
-        # If the refresh was cancelled by STOP VIEW, WAIT VIEW throws — that's expected.
-        for node in nodes:
-            try:
-                node.query("SYSTEM WAIT VIEW re.rmv")
-            except Exception:
-                pass
+        # After restore, target table data is not included in backup
+        # (`backup_data_from_refreshable_materialized_view_targets` is off by default).
+        # The refresh task resumes immediately (REFRESH EVERY 1 second) and must complete
+        # at least once to populate `re.tgt`.
+        # Ensure source data is replicated on all nodes before the refresh reads it.
         for node in nodes:
             node.query("SYSTEM SYNC DATABASE REPLICA re")
-        node1.query_with_retry(f"SYSTEM SYNC REPLICA re.{target}")
-        node2.query_with_retry(f"SYSTEM SYNC REPLICA re.{target}")
+            node.query_with_retry("SYSTEM SYNC REPLICA re.src")
+        # Wait for a refresh to complete *before* stopping the view. Stopping first
+        # can cancel the only in-flight refresh (interrupt_execution races with the
+        # EXCHANGE DDL), leaving `re.tgt` empty.
+        node1.query("SYSTEM WAIT VIEW re.rmv")
+        for node in nodes:
+            node.query("SYSTEM STOP VIEW re.rmv")
+        # Ensure the EXCHANGE DDL has propagated, then sync replica data.
+        for node in nodes:
+            node.query("SYSTEM SYNC DATABASE REPLICA re")
+            node.query_with_retry(f"SYSTEM SYNC REPLICA re.{target}")
     assert node1.query(f"SELECT * FROM re.{target}") == "1\n"
     assert node2.query(f"SELECT * FROM re.{target}") == "1\n"
 


### PR DESCRIPTION
After `RESTORE ALL ON CLUSTER`, the target table `re.tgt` is empty because `backup_data_from_refreshable_materialized_view_targets` defaults to false. The test relies on a post-restore refresh to populate it.

The old code called `SYSTEM STOP VIEW` before `SYSTEM WAIT VIEW`. `STOP VIEW` sets `interrupt_execution` which can cancel the in-flight refresh between the INSERT and the EXCHANGE DDL submission in `exchangeTargetTable`, leaving `re.tgt` permanently empty. The exception from `WAIT VIEW` was caught but the empty target was not handled.

Fix: sync `re.src` replicas after restore so the refresh reads correct data, then call `SYSTEM WAIT VIEW` *before* `SYSTEM STOP VIEW` to guarantee at least one full refresh cycle completes.

Closes #100184

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)