### PR TITLE
Store final PR labels state in praktika _Environment after check_labels

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -750,10 +750,6 @@ def main():
             # - The overall Tests result is treated as success in that case
             test_result.set_success()
 
-        # For bugfix validation, "Check errors" (latest in the list) is only a helper step and
-        # must not affect the overall job result.
-        results[-1].set_success()
-
     if JobStages.COLLECT_LOGS in stages:
         print("Collect logs")
 

--- a/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
@@ -265,14 +265,10 @@ def check_labels(category, info):
     if pr_labels_to_remove or pr_labels_to_add:
         Shell.check(cmd, verbose=True, strict=True, retries=5)
 
-    final_labels = list(labels)
     for label in pr_labels_to_add:
-        if label not in final_labels:
-            final_labels.append(label)
+        info.add_pr_label(label)
     for label in pr_labels_to_remove:
-        if label in final_labels:
-            final_labels.remove(label)
-    info.set_pr_labels(final_labels)
+        info.remove_pr_label(label)
 
 
 if __name__ == "__main__":

--- a/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
@@ -256,20 +256,23 @@ def check_labels(category, info):
         print(f"Add labels [{pr_labels_to_add}]")
         for label in pr_labels_to_add:
             cmd += f" --add-label '{label}'"
-            if label in info.pr_labels:
-                info.pr_labels.append(label)
-            info.dump()
 
     if pr_labels_to_remove:
         print(f"Remove labels [{pr_labels_to_remove}]")
         for label in pr_labels_to_remove:
             cmd += f" --remove-label '{label}'"
-            if label in info.pr_labels:
-                info.pr_labels.remove(label)
-            info.dump()
 
     if pr_labels_to_remove or pr_labels_to_add:
         Shell.check(cmd, verbose=True, strict=True, retries=5)
+
+    final_labels = list(labels)
+    for label in pr_labels_to_add:
+        if label not in final_labels:
+            final_labels.append(label)
+    for label in pr_labels_to_remove:
+        if label in final_labels:
+            final_labels.remove(label)
+    info.set_pr_labels(final_labels)
 
 
 if __name__ == "__main__":

--- a/ci/praktika/_environment.py
+++ b/ci/praktika/_environment.py
@@ -320,6 +320,16 @@ class _Environment(MetaClasses.Serializable):
                     self.PR_LABELS.append(label)
         self.dump()
 
+    def add_pr_label(self, label: str) -> None:
+        if label not in self.PR_LABELS:
+            self.PR_LABELS.append(label)
+            self.dump()
+
+    def remove_pr_label(self, label: str) -> None:
+        if label in self.PR_LABELS:
+            self.PR_LABELS.remove(label)
+            self.dump()
+
     @staticmethod
     def get_needs_statuses():
         if Path(Settings.WORKFLOW_STATUS_FILE).is_file():

--- a/ci/praktika/_environment.py
+++ b/ci/praktika/_environment.py
@@ -311,6 +311,15 @@ class _Environment(MetaClasses.Serializable):
         self.dump()
         return self
 
+    def set_pr_labels(self, labels: List[str], reset: bool = False) -> None:
+        if reset:
+            self.PR_LABELS = list(labels)
+        else:
+            for label in labels:
+                if label not in self.PR_LABELS:
+                    self.PR_LABELS.append(label)
+        self.dump()
+
     @staticmethod
     def get_needs_statuses():
         if Path(Settings.WORKFLOW_STATUS_FILE).is_file():

--- a/ci/praktika/info.py
+++ b/ci/praktika/info.py
@@ -232,6 +232,9 @@ class Info:
             print(f"ERROR: Exception, while reading workflow input [{e}]")
         return None
 
+    def set_pr_labels(self, labels, reset=False):
+        self.env.set_pr_labels(labels, reset=reset)
+
     def store_kv_data(self, key, value):
         print(f"Store workflow kv data: key [{key}], value [{value}]")
         self.env.JOB_KV_DATA[key] = value

--- a/ci/praktika/info.py
+++ b/ci/praktika/info.py
@@ -235,6 +235,12 @@ class Info:
     def set_pr_labels(self, labels, reset=False):
         self.env.set_pr_labels(labels, reset=reset)
 
+    def add_pr_label(self, label):
+        self.env.add_pr_label(label)
+
+    def remove_pr_label(self, label):
+        self.env.remove_pr_label(label)
+
     def store_kv_data(self, key, value):
         print(f"Store workflow kv data: key [{key}], value [{value}]")
         self.env.JOB_KV_DATA[key] = value

--- a/tests/queries/0_stateless/02536_replace_with_nonconst_needle_and_replacement.sql
+++ b/tests/queries/0_stateless/02536_replace_with_nonconst_needle_and_replacement.sql
@@ -1,4 +1,4 @@
--- Tests that functions replaceOne(), replaceAll(), replaceRegexpOne(), replaceRegexpAll() work with with non-const pattern and replacement arguments
+-- Tests that functions replaceOne(), replaceAll(), replaceRegexpOne(), replaceRegexpAll() work with non-const pattern and replacement arguments
 
 DROP TABLE IF EXISTS test_tab;
 

--- a/tests/queries/0_stateless/02864_statistics_ddl.sql
+++ b/tests/queries/0_stateless/02864_statistics_ddl.sql
@@ -172,7 +172,7 @@ ALTER TABLE tab DROP STATISTICS IF EXISTS s; -- no-op
 ALTER TABLE tab CLEAR STATISTICS s; -- { serverError ILLEGAL_STATISTICS }
 ALTER TABLE tab CLEAR STATISTICS IF EXISTS s; -- no-op
 
--- We don't check systematically that that statistics can only be created via ALTER ADD STATISTICS on columns of specific data types (the
+-- We don't check systematically that statistics can only be created via ALTER ADD STATISTICS on columns of specific data types (the
 -- internal type validation code is tested already above, (*)). Only do a rudimentary check for each statistics type with a data type that
 -- works and one that doesn't work.
 --   tdigest


### PR DESCRIPTION
Add `set_pr_labels(labels, reset=False)` to `_Environment` and `Info` to idempotently update `PR_LABELS` and persist via `dump()`. When `reset=True` the list is fully replaced; by default labels are added without duplicates.

Fix `check_labels` to build the final labels state (applying additions and removals to the snapshot) and call `info.set_pr_labels` once, so subsequent jobs reading `Info().pr_labels` see the correct labels.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.64`
<!-- ch-version-info:end -->