### PR TITLE
Fix missing `global SANITIZED` declaration in `collect_build_flags`

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -3811,6 +3811,7 @@ SANITIZED = False
 
 def collect_build_flags(args):
     global RELEASE_NON_SANITIZED
+    global SANITIZED
 
     result = []
 


### PR DESCRIPTION
`collect_build_flags` in `tests/clickhouse-test` declared `global RELEASE_NON_SANITIZED` but not `global SANITIZED`. In Python, any assignment to a name inside a function without a `global` declaration creates a local variable — the module-level `SANITIZED` (initialized to `False`) was never updated.

This meant the guard at line 583:

```python
if SANITIZED:
    print("Wait 60 seconds to let sanitizers print the report...")
    sleep(60)
```

never fired in sanitizer builds. Without this wait, the process group can be killed before the sanitizer runtime has flushed its full report to stderr, potentially causing truncated or missing sanitizer output on hung tests.

The bug was introduced before PR #99657 and remained unfixed when that PR refactored this block. Fix is one line: add `global SANITIZED` alongside the existing `global RELEASE_NON_SANITIZED`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.56`
<!-- ch-version-info:end -->