### PR TITLE
Fix server shutdown deadlock

### DIFF
--- a/src/Storages/System/StatusRequestsPool.h
+++ b/src/Storages/System/StatusRequestsPool.h
@@ -96,8 +96,6 @@ public:
     };
 
 private:
-    ThreadPool thread_pool;
-
     std::mutex mutex;
     std::unordered_map<TBaseHolderPtr, RequestInfo> current_requests TSA_GUARDED_BY(mutex);
     std::deque<Request> requests_to_schedule TSA_GUARDED_BY(mutex);
@@ -105,16 +103,33 @@ private:
 
     LoggerPtr log;
 
+    /// thread_pool must be declared last so it is destroyed first.
+    /// ~ThreadPool calls finalize() which sets shutdown = true, wakes idle workers,
+    /// and joins them. By destroying thread_pool before other members, we guarantee
+    /// that worker threads (which access mutex, current_requests, and log) have all
+    /// exited before those members are destroyed.
+    ThreadPool thread_pool;
+
 public:
     explicit StatusRequestsPool(const size_t max_threads)
-        : thread_pool(create_pool(max_threads))
-        , log(getLogger("StatusRequestsPool"))
+        : log(getLogger("StatusRequestsPool"))
+        , thread_pool(create_pool(max_threads))
     {
     }
 
     ~StatusRequestsPool()
     {
-        thread_pool.wait();
+        /// Do not call thread_pool.wait() here:
+        /// wait() only waits for scheduled_jobs == 0 but does NOT set shutdown = true,
+        /// so idle worker threads remain blocked on the local pool's condition variable
+        /// (new_job_or_shutdown at ThreadPool.cpp:736) forever.
+        /// When GlobalThreadPool::shutdown() later tries to pthread_join the underlying
+        /// OS threads stuck in these worker loops, it deadlocks.
+        ///
+        /// The fix: thread_pool is declared as the last member, so ~ThreadPool runs first.
+        /// It calls finalize() which sets shutdown = true, wakes all workers, and joins
+        /// them while mutex, current_requests, and log are still alive.
+
         for (auto & request : requests_to_schedule)
             request.promise->set_exception(
                 std::make_exception_ptr(DB::Exception(ErrorCodes::QUERY_WAS_CANCELLED, "StatusRequestsPool is destroyed")));


### PR DESCRIPTION
StatusRequestsPool::~StatusRequestsPool() called thread_pool.wait() before the ThreadPool destructor ran. wait() only waits for scheduled_jobs == 0 — it does not set shutdown = true. Idle worker threads remain blocked on the condition variable at ThreadPool.cpp:736 forever. When GlobalThreadPool::shutdown() later tries to pthread_join these worker threads, it deadlocks.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=94140&sha=5d11770d7df6f28bdbf7e8f4f230ee266c6b3c2f&name_0=PR&name_1=Stress%20test%20%28amd_msan%29
https://github.com/ClickHouse/ClickHouse/pull/94140

Thread Stacks from GDB:

  Thread 1 (main, LWP 632570) — blocked joining Thread 2:

 ```
 #0  __futex_abstimed_wait_common64 (expected=633532, futex_word=0x7f34c9df6910)
  #3  __pthread_clockjoin_ex (threadid=139864701888064)
  #7  ThreadPoolImpl<std::thread>::ThreadFromThreadPool::join()         at ThreadPool.cpp:638
  #8  ThreadPoolImpl<std::thread>::finalize()                           at ThreadPool.cpp:564
  #9  DB::Server::main()::$_15::operator()()                           at Server.cpp:1414
        // GlobalThreadPool::instance().shutdown()
```

  Thread 2 (GlobalThreadPool worker, LWP 633532) — blocked waiting for shutdown=true:

```
  #3  __pthread_cond_wait_common (cond=0x712000057dd8)
  #7  std::condition_variable::wait<lambda>()                           at condition_variable.h:112
  #8  ThreadPoolImpl<ThreadFromGlobalPoolImpl<false,true>>::worker()    at ThreadPool.cpp:736
        // waiting on: shutdown || !jobs.empty() || ...
  #15 ThreadPoolImpl<std::thread>::worker()                             at ThreadPool.cpp:809
        // GlobalThreadPool worker executing the nested pool's work
```

Deadlock Timeline

  1. StatusRequestsPool owns a local ThreadPool whose workers run on GlobalThreadPool threads.

  2. Server shutdown begins. SCOPE_EXIT guards run in LIFO order:
     → global_context.reset() destroys StatusRequestsPool
     → ~StatusRequestsPool() calls thread_pool.wait()
     → wait() returns (no pending jobs), but does NOT set shutdown=true
     → Worker threads stay blocked at ThreadPool.cpp:736 waiting for shutdown flag

  3. Next SCOPE_EXIT runs:
     → GlobalThreadPool::shutdown() → finalize() → pthread_join(Thread 2)
     → Thread 2 is the worker still waiting for shutdown=true → DEADLOCK

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.93`
<!-- ch-version-info:end -->