### PR TITLE
Fix flaky test 04004_integral_col_comparison_with_float_key_condition

### DIFF
--- a/tests/queries/0_stateless/04004_integral_col_comparison_with_float_key_condition.reference
+++ b/tests/queries/0_stateless/04004_integral_col_comparison_with_float_key_condition.reference
@@ -1,7 +1,7 @@
 -- { echo }
 
 DROP TABLE IF EXISTS test_int64;
-CREATE TABLE test_int64 (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192;
+CREATE TABLE test_int64 (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192, index_granularity_bytes = 10485760;
 INSERT INTO test_int64 SELECT number FROM numbers(200000);
 SELECT count() FROM test_int64 WHERE uid < 100000.5 SETTINGS force_primary_key = 1, max_rows_to_read = 106496;
 100001
@@ -78,7 +78,7 @@ SELECT count() FROM test_int64 WHERE uid = (-1.0 / 0.0) SETTINGS force_primary_k
 SELECT count() FROM test_int64 WHERE uid != (-1.0 / 0.0);
 200000
 DROP TABLE IF EXISTS test_uint64;
-CREATE TABLE test_uint64 (uid UInt64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192;
+CREATE TABLE test_uint64 (uid UInt64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192, index_granularity_bytes = 10485760;
 INSERT INTO test_uint64 SELECT number FROM numbers(200000);
 -- UInt64 fractional
 SELECT count() FROM test_uint64 WHERE uid < 100000.5 SETTINGS force_primary_key = 1, max_rows_to_read = 106496;
@@ -142,7 +142,7 @@ SELECT count() FROM test_uint64 WHERE uid = +0.0 SETTINGS force_primary_key = 1,
 SELECT count() FROM test_uint64 WHERE uid != +0.0 SETTINGS force_primary_key = 1, max_rows_to_read = 204800;
 199999
 DROP TABLE IF EXISTS test_int32;
-CREATE TABLE test_int32 (uid Int32) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192;
+CREATE TABLE test_int32 (uid Int32) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192, index_granularity_bytes = 10485760;
 INSERT INTO test_int32 SELECT number FROM numbers(200000);
 -- Int32 fractional
 SELECT count() FROM test_int32 WHERE uid < 100000.5 SETTINGS force_primary_key = 1, max_rows_to_read = 106496;
@@ -150,7 +150,7 @@ SELECT count() FROM test_int32 WHERE uid < 100000.5 SETTINGS force_primary_key =
 SELECT count() FROM test_int32 WHERE uid > 100000.5 SETTINGS force_primary_key = 1, max_rows_to_read = 106496;
 99999
 DROP TABLE IF EXISTS test_int8;
-CREATE TABLE test_int8 (uid Int8) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192;
+CREATE TABLE test_int8 (uid Int8) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192, index_granularity_bytes = 10485760;
 INSERT INTO test_int8 SELECT toInt8(number - 128) FROM numbers(256);
 -- Int8 above max
 SELECT count() FROM test_int8 WHERE uid < 200.5;
@@ -184,7 +184,7 @@ SELECT count() FROM test_int8 WHERE uid < 50.5 SETTINGS force_primary_key = 1, m
 SELECT count() FROM test_int8 WHERE uid > 50.5 SETTINGS force_primary_key = 1, max_rows_to_read = 256;
 77
 DROP TABLE IF EXISTS test_uint8;
-CREATE TABLE test_uint8 (uid UInt8) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192;
+CREATE TABLE test_uint8 (uid UInt8) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192, index_granularity_bytes = 10485760;
 INSERT INTO test_uint8 SELECT number FROM numbers(256);
 -- UInt8 above max
 SELECT count() FROM test_uint8 WHERE uid < 300.5;
@@ -199,7 +199,7 @@ SELECT count() FROM test_uint8 WHERE uid < 100.5 SETTINGS force_primary_key = 1,
 SELECT count() FROM test_uint8 WHERE uid > 100.5 SETTINGS force_primary_key = 1, max_rows_to_read = 256;
 155
 DROP TABLE IF EXISTS test_negation;
-CREATE TABLE test_negation (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192;
+CREATE TABLE test_negation (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192, index_granularity_bytes = 10485760;
 INSERT INTO test_negation SELECT number FROM numbers(200000);
 -- Negation
 SELECT count() FROM test_negation WHERE NOT (uid < 100000.5) SETTINGS force_primary_key = 1, max_rows_to_read = 106496;
@@ -211,7 +211,7 @@ SELECT count() FROM test_negation WHERE NOT (uid = 100000.5);
 SELECT count() FROM test_negation WHERE NOT (uid != 100000.5) SETTINGS force_primary_key = 1, max_rows_to_read = 1;
 0
 DROP TABLE IF EXISTS test_int64_boundary;
-CREATE TABLE test_int64_boundary (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1;
+CREATE TABLE test_int64_boundary (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_int64_boundary VALUES (-1), (0), (9223372036854775807);
 -- Int64 max boundary
 SELECT count() FROM test_int64_boundary WHERE uid < 9223372036854775808.0;
@@ -219,7 +219,7 @@ SELECT count() FROM test_int64_boundary WHERE uid < 9223372036854775808.0;
 SELECT count() FROM test_int64_boundary WHERE uid >= 9223372036854775808.0 SETTINGS force_primary_key = 1, max_rows_to_read = 1;
 0
 DROP TABLE IF EXISTS test_uint64_boundary;
-CREATE TABLE test_uint64_boundary (uid UInt64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1;
+CREATE TABLE test_uint64_boundary (uid UInt64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_uint64_boundary VALUES (0), (9223372036854775808), (18446744073709551615);
 -- UInt64 max boundary
 SELECT count() FROM test_uint64_boundary WHERE uid < 18446744073709551616.0;
@@ -227,7 +227,7 @@ SELECT count() FROM test_uint64_boundary WHERE uid < 18446744073709551616.0;
 SELECT count() FROM test_uint64_boundary WHERE uid >= 18446744073709551616.0 SETTINGS force_primary_key = 1, max_rows_to_read = 1;
 0
 DROP TABLE IF EXISTS test_int64_boundary;
-CREATE TABLE test_int64_boundary (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1;
+CREATE TABLE test_int64_boundary (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_int64_boundary VALUES (-9223372036854775808), (-1), (0), (9223372036854775807);
 -- Int64 above max
 SELECT count() FROM test_int64_boundary WHERE uid < 9223372036854775808.0;
@@ -256,7 +256,7 @@ SELECT count() FROM test_int64_boundary WHERE uid = -9223372036854777856.0 SETTI
 SELECT count() FROM test_int64_boundary WHERE uid != -9223372036854777856.0;
 4
 DROP TABLE IF EXISTS test_uint64_boundary;
-CREATE TABLE test_uint64_boundary (uid UInt64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1;
+CREATE TABLE test_uint64_boundary (uid UInt64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_uint64_boundary VALUES (0), (1), (9223372036854775808), (18446744073709551615);
 -- UInt64 above max
 SELECT count() FROM test_uint64_boundary WHERE uid < 18446744073709551616.0;
@@ -272,7 +272,7 @@ SELECT count() FROM test_uint64_boundary WHERE uid = 18446744073709551616.0 SETT
 SELECT count() FROM test_uint64_boundary WHERE uid != 18446744073709551616.0;
 4
 DROP TABLE IF EXISTS test_constest_left;
-CREATE TABLE test_constest_left (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192;
+CREATE TABLE test_constest_left (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192, index_granularity_bytes = 10485760;
 INSERT INTO test_constest_left SELECT number FROM numbers(200000);
 -- Const left Int64
 SELECT count() FROM test_constest_left WHERE 100000.5 > uid SETTINGS force_primary_key = 1, max_rows_to_read = 106496;
@@ -288,7 +288,7 @@ SELECT count() FROM test_constest_left WHERE 100000.5 = uid SETTINGS force_prima
 SELECT count() FROM test_constest_left WHERE 100000.5 != uid;
 200000
 DROP TABLE IF EXISTS test_nullable_int64;
-CREATE TABLE test_nullable_int64 (uid Nullable(Int64)) ENGINE = MergeTree ORDER BY uid SETTINGS allow_nullable_key = 1, index_granularity = 1;
+CREATE TABLE test_nullable_int64 (uid Nullable(Int64)) ENGINE = MergeTree ORDER BY uid SETTINGS allow_nullable_key = 1, index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_nullable_int64 VALUES (NULL), (-1), (0), (100000), (100001), (9223372036854775807);
 -- Nullable Int64
 SELECT count() FROM test_nullable_int64 WHERE uid < 100000.5 SETTINGS force_primary_key = 1, max_rows_to_read = 3;
@@ -312,7 +312,7 @@ SELECT count() FROM test_nullable_int64 WHERE uid < 9223372036854775808.0;
 SELECT count() FROM test_nullable_int64 WHERE uid >= 9223372036854775808.0 SETTINGS force_primary_key = 1, max_rows_to_read = 1;
 0
 DROP TABLE IF EXISTS test_int64_2pow53;
-CREATE TABLE test_int64_2pow53 (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1;
+CREATE TABLE test_int64_2pow53 (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_int64_2pow53 VALUES (9007199254740991), (9007199254740992), (9007199254740993), (9007199254740994);
 -- Int64 2^53 rounding
 SELECT count() FROM test_int64_2pow53 WHERE uid = 9007199254740993.0 SETTINGS force_primary_key = 1, max_rows_to_read = 2;
@@ -324,7 +324,7 @@ SELECT count() FROM test_int64_2pow53 WHERE uid < 9007199254740993.0 SETTINGS fo
 SELECT count() FROM test_int64_2pow53 WHERE uid >= 9007199254740993.0 SETTINGS force_primary_key = 1, max_rows_to_read = 4;
 3
 DROP TABLE IF EXISTS test_int64_2pow52_fractional;
-CREATE TABLE test_int64_2pow52_fractional (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1;
+CREATE TABLE test_int64_2pow52_fractional (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_int64_2pow52_fractional VALUES (4503599627370494), (4503599627370495), (4503599627370496), (4503599627370497);
 -- Int64 2^52 fractional
 SELECT count() FROM test_int64_2pow52_fractional WHERE uid = 4503599627370495.5 SETTINGS force_primary_key = 1, max_rows_to_read = 1;
@@ -336,7 +336,7 @@ SELECT count() FROM test_int64_2pow52_fractional WHERE uid < 4503599627370495.5 
 SELECT count() FROM test_int64_2pow52_fractional WHERE uid >= 4503599627370495.5 SETTINGS force_primary_key = 1, max_rows_to_read = 3;
 2
 DROP TABLE IF EXISTS test_int32_boundary;
-CREATE TABLE test_int32_boundary (uid Int32) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1;
+CREATE TABLE test_int32_boundary (uid Int32) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_int32_boundary VALUES (-2147483648), (-1), (0), (2147483647);
 -- Int32 above max
 SELECT count() FROM test_int32_boundary WHERE uid < 2147483648.0;
@@ -365,7 +365,7 @@ SELECT count() FROM test_int32_boundary WHERE uid = -2147483649.0 SETTINGS force
 SELECT count() FROM test_int32_boundary WHERE uid != -2147483649.0;
 4
 DROP TABLE IF EXISTS test_int16_boundary;
-CREATE TABLE test_int16_boundary (uid Int16) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1;
+CREATE TABLE test_int16_boundary (uid Int16) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_int16_boundary VALUES (-32768), (-1), (0), (32767);
 -- Int16 above max
 SELECT count() FROM test_int16_boundary WHERE uid < 32768.0;
@@ -394,7 +394,7 @@ SELECT count() FROM test_int16_boundary WHERE uid = -32769.0 SETTINGS force_prim
 SELECT count() FROM test_int16_boundary WHERE uid != -32769.0;
 4
 DROP TABLE IF EXISTS test_uint16_boundary;
-CREATE TABLE test_uint16_boundary (uid UInt16) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1;
+CREATE TABLE test_uint16_boundary (uid UInt16) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_uint16_boundary VALUES (0), (1), (65535);
 -- UInt16 above max
 SELECT count() FROM test_uint16_boundary WHERE uid < 65536.0;
@@ -423,7 +423,7 @@ SELECT count() FROM test_uint16_boundary WHERE uid = -1.0 SETTINGS force_primary
 SELECT count() FROM test_uint16_boundary WHERE uid != -1.0;
 3
 DROP TABLE IF EXISTS test_uint32_boundary;
-CREATE TABLE test_uint32_boundary (uid UInt32) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1;
+CREATE TABLE test_uint32_boundary (uid UInt32) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_uint32_boundary VALUES (0), (1), (4294967295);
 -- UInt32 above max
 SELECT count() FROM test_uint32_boundary WHERE uid < 4294967296.0;

--- a/tests/queries/0_stateless/04004_integral_col_comparison_with_float_key_condition.sql
+++ b/tests/queries/0_stateless/04004_integral_col_comparison_with_float_key_condition.sql
@@ -1,7 +1,7 @@
 -- { echo }
 
 DROP TABLE IF EXISTS test_int64;
-CREATE TABLE test_int64 (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192;
+CREATE TABLE test_int64 (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192, index_granularity_bytes = 10485760;
 INSERT INTO test_int64 SELECT number FROM numbers(200000);
 
 SELECT count() FROM test_int64 WHERE uid < 100000.5 SETTINGS force_primary_key = 1, max_rows_to_read = 106496;
@@ -50,7 +50,7 @@ SELECT count() FROM test_int64 WHERE uid = (-1.0 / 0.0) SETTINGS force_primary_k
 SELECT count() FROM test_int64 WHERE uid != (-1.0 / 0.0);
 
 DROP TABLE IF EXISTS test_uint64;
-CREATE TABLE test_uint64 (uid UInt64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192;
+CREATE TABLE test_uint64 (uid UInt64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192, index_granularity_bytes = 10485760;
 INSERT INTO test_uint64 SELECT number FROM numbers(200000);
 
 -- UInt64 fractional
@@ -91,7 +91,7 @@ SELECT count() FROM test_uint64 WHERE uid = +0.0 SETTINGS force_primary_key = 1,
 SELECT count() FROM test_uint64 WHERE uid != +0.0 SETTINGS force_primary_key = 1, max_rows_to_read = 204800;
 
 DROP TABLE IF EXISTS test_int32;
-CREATE TABLE test_int32 (uid Int32) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192;
+CREATE TABLE test_int32 (uid Int32) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192, index_granularity_bytes = 10485760;
 INSERT INTO test_int32 SELECT number FROM numbers(200000);
 
 -- Int32 fractional
@@ -99,7 +99,7 @@ SELECT count() FROM test_int32 WHERE uid < 100000.5 SETTINGS force_primary_key =
 SELECT count() FROM test_int32 WHERE uid > 100000.5 SETTINGS force_primary_key = 1, max_rows_to_read = 106496;
 
 DROP TABLE IF EXISTS test_int8;
-CREATE TABLE test_int8 (uid Int8) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192;
+CREATE TABLE test_int8 (uid Int8) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192, index_granularity_bytes = 10485760;
 INSERT INTO test_int8 SELECT toInt8(number - 128) FROM numbers(256);
 
 -- Int8 above max
@@ -123,7 +123,7 @@ SELECT count() FROM test_int8 WHERE uid < 50.5 SETTINGS force_primary_key = 1, m
 SELECT count() FROM test_int8 WHERE uid > 50.5 SETTINGS force_primary_key = 1, max_rows_to_read = 256;
 
 DROP TABLE IF EXISTS test_uint8;
-CREATE TABLE test_uint8 (uid UInt8) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192;
+CREATE TABLE test_uint8 (uid UInt8) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192, index_granularity_bytes = 10485760;
 INSERT INTO test_uint8 SELECT number FROM numbers(256);
 
 -- UInt8 above max
@@ -136,7 +136,7 @@ SELECT count() FROM test_uint8 WHERE uid < 100.5 SETTINGS force_primary_key = 1,
 SELECT count() FROM test_uint8 WHERE uid > 100.5 SETTINGS force_primary_key = 1, max_rows_to_read = 256;
 
 DROP TABLE IF EXISTS test_negation;
-CREATE TABLE test_negation (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192;
+CREATE TABLE test_negation (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192, index_granularity_bytes = 10485760;
 INSERT INTO test_negation SELECT number FROM numbers(200000);
 
 -- Negation
@@ -146,7 +146,7 @@ SELECT count() FROM test_negation WHERE NOT (uid = 100000.5);
 SELECT count() FROM test_negation WHERE NOT (uid != 100000.5) SETTINGS force_primary_key = 1, max_rows_to_read = 1;
 
 DROP TABLE IF EXISTS test_int64_boundary;
-CREATE TABLE test_int64_boundary (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1;
+CREATE TABLE test_int64_boundary (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_int64_boundary VALUES (-1), (0), (9223372036854775807);
 
 -- Int64 max boundary
@@ -154,7 +154,7 @@ SELECT count() FROM test_int64_boundary WHERE uid < 9223372036854775808.0;
 SELECT count() FROM test_int64_boundary WHERE uid >= 9223372036854775808.0 SETTINGS force_primary_key = 1, max_rows_to_read = 1;
 
 DROP TABLE IF EXISTS test_uint64_boundary;
-CREATE TABLE test_uint64_boundary (uid UInt64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1;
+CREATE TABLE test_uint64_boundary (uid UInt64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_uint64_boundary VALUES (0), (9223372036854775808), (18446744073709551615);
 
 -- UInt64 max boundary
@@ -162,7 +162,7 @@ SELECT count() FROM test_uint64_boundary WHERE uid < 18446744073709551616.0;
 SELECT count() FROM test_uint64_boundary WHERE uid >= 18446744073709551616.0 SETTINGS force_primary_key = 1, max_rows_to_read = 1;
 
 DROP TABLE IF EXISTS test_int64_boundary;
-CREATE TABLE test_int64_boundary (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1;
+CREATE TABLE test_int64_boundary (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_int64_boundary VALUES (-9223372036854775808), (-1), (0), (9223372036854775807);
 
 -- Int64 above max
@@ -182,7 +182,7 @@ SELECT count() FROM test_int64_boundary WHERE uid = -9223372036854777856.0 SETTI
 SELECT count() FROM test_int64_boundary WHERE uid != -9223372036854777856.0;
 
 DROP TABLE IF EXISTS test_uint64_boundary;
-CREATE TABLE test_uint64_boundary (uid UInt64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1;
+CREATE TABLE test_uint64_boundary (uid UInt64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_uint64_boundary VALUES (0), (1), (9223372036854775808), (18446744073709551615);
 
 -- UInt64 above max
@@ -194,7 +194,7 @@ SELECT count() FROM test_uint64_boundary WHERE uid = 18446744073709551616.0 SETT
 SELECT count() FROM test_uint64_boundary WHERE uid != 18446744073709551616.0;
 
 DROP TABLE IF EXISTS test_constest_left;
-CREATE TABLE test_constest_left (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192;
+CREATE TABLE test_constest_left (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192, index_granularity_bytes = 10485760;
 INSERT INTO test_constest_left SELECT number FROM numbers(200000);
 
 -- Const left Int64
@@ -206,7 +206,7 @@ SELECT count() FROM test_constest_left WHERE 100000.5 = uid SETTINGS force_prima
 SELECT count() FROM test_constest_left WHERE 100000.5 != uid;
 
 DROP TABLE IF EXISTS test_nullable_int64;
-CREATE TABLE test_nullable_int64 (uid Nullable(Int64)) ENGINE = MergeTree ORDER BY uid SETTINGS allow_nullable_key = 1, index_granularity = 1;
+CREATE TABLE test_nullable_int64 (uid Nullable(Int64)) ENGINE = MergeTree ORDER BY uid SETTINGS allow_nullable_key = 1, index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_nullable_int64 VALUES (NULL), (-1), (0), (100000), (100001), (9223372036854775807);
 
 -- Nullable Int64
@@ -222,7 +222,7 @@ SELECT count() FROM test_nullable_int64 WHERE uid < 9223372036854775808.0;
 SELECT count() FROM test_nullable_int64 WHERE uid >= 9223372036854775808.0 SETTINGS force_primary_key = 1, max_rows_to_read = 1;
 
 DROP TABLE IF EXISTS test_int64_2pow53;
-CREATE TABLE test_int64_2pow53 (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1;
+CREATE TABLE test_int64_2pow53 (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_int64_2pow53 VALUES (9007199254740991), (9007199254740992), (9007199254740993), (9007199254740994);
 
 -- Int64 2^53 rounding
@@ -232,7 +232,7 @@ SELECT count() FROM test_int64_2pow53 WHERE uid < 9007199254740993.0 SETTINGS fo
 SELECT count() FROM test_int64_2pow53 WHERE uid >= 9007199254740993.0 SETTINGS force_primary_key = 1, max_rows_to_read = 4;
 
 DROP TABLE IF EXISTS test_int64_2pow52_fractional;
-CREATE TABLE test_int64_2pow52_fractional (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1;
+CREATE TABLE test_int64_2pow52_fractional (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_int64_2pow52_fractional VALUES (4503599627370494), (4503599627370495), (4503599627370496), (4503599627370497);
 
 -- Int64 2^52 fractional
@@ -242,7 +242,7 @@ SELECT count() FROM test_int64_2pow52_fractional WHERE uid < 4503599627370495.5 
 SELECT count() FROM test_int64_2pow52_fractional WHERE uid >= 4503599627370495.5 SETTINGS force_primary_key = 1, max_rows_to_read = 3;
 
 DROP TABLE IF EXISTS test_int32_boundary;
-CREATE TABLE test_int32_boundary (uid Int32) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1;
+CREATE TABLE test_int32_boundary (uid Int32) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_int32_boundary VALUES (-2147483648), (-1), (0), (2147483647);
 
 -- Int32 above max
@@ -262,7 +262,7 @@ SELECT count() FROM test_int32_boundary WHERE uid = -2147483649.0 SETTINGS force
 SELECT count() FROM test_int32_boundary WHERE uid != -2147483649.0;
 
 DROP TABLE IF EXISTS test_int16_boundary;
-CREATE TABLE test_int16_boundary (uid Int16) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1;
+CREATE TABLE test_int16_boundary (uid Int16) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_int16_boundary VALUES (-32768), (-1), (0), (32767);
 
 -- Int16 above max
@@ -283,7 +283,7 @@ SELECT count() FROM test_int16_boundary WHERE uid != -32769.0;
 
 
 DROP TABLE IF EXISTS test_uint16_boundary;
-CREATE TABLE test_uint16_boundary (uid UInt16) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1;
+CREATE TABLE test_uint16_boundary (uid UInt16) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_uint16_boundary VALUES (0), (1), (65535);
 
 -- UInt16 above max
@@ -303,7 +303,7 @@ SELECT count() FROM test_uint16_boundary WHERE uid = -1.0 SETTINGS force_primary
 SELECT count() FROM test_uint16_boundary WHERE uid != -1.0;
 
 DROP TABLE IF EXISTS test_uint32_boundary;
-CREATE TABLE test_uint32_boundary (uid UInt32) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1;
+CREATE TABLE test_uint32_boundary (uid UInt32) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 1, index_granularity_bytes = 10485760;
 INSERT INTO test_uint32_boundary VALUES (0), (1), (4294967295);
 
 -- UInt32 above max


### PR DESCRIPTION
The issue was that some low value of `index_granularity_bytes` lowered the size of granules, causing the queries fail. The test depends on exact granularity.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Closes https://github.com/ClickHouse/ClickHouse/issues/100129

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.62`
<!-- ch-version-info:end -->