### PR TITLE
Fix not ready set in text index analysis

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -11,6 +11,7 @@
 #include <Storages/MergeTree/MergeTreeIndexTextPreprocessor.h>
 #include <Storages/MergeTree/TextIndexCache.h>
 #include <Common/OptimizedRegularExpression.h>
+#include <Columns/ColumnSet.h>
 #include <Interpreters/ExpressionActions.h>
 
 namespace DB
@@ -707,6 +708,26 @@ bool MergeTreeIndexConditionText::traverseMapElementKeyNode(const RPNBuilderFunc
 
     if (!key_const_value.has_value())
         return false;
+
+    /// If the DAG contains a Set (e.g. from an IN subquery), try to build it before execution.
+    /// The Set may not be ready yet because it is built later during query execution.
+    for (const auto & node : subdag.getNodes())
+    {
+        if (node.type != ActionsDAG::ActionType::COLUMN)
+            continue;
+
+        const auto * column_set = checkAndGetColumn<ColumnSet>(node.column.get());
+        if (!column_set)
+            continue;
+
+        auto future_set = column_set->getData();
+        if (!future_set)
+            return false;
+
+        auto prepared_set = future_set->buildOrderedSetInplace(getContext());
+        if (!prepared_set || !prepared_set->hasExplicitSetElements())
+            return false;
+    }
 
     /// Evaluate function on the empty map. Empty map will return default value for any key.
     Block block{{required_column.type->createColumnConstWithDefaultValue(1), required_column.type, required_column.name}};

--- a/tests/queries/0_stateless/04050_text_index_map_keys_in_subquery.reference
+++ b/tests/queries/0_stateless/04050_text_index_map_keys_in_subquery.reference
@@ -1,0 +1,30 @@
+0
+1
+4
+CreatingSets (Create sets before main query execution)
+  Expression (Project names)
+    Sorting (Sorting for ORDER BY)
+      Expression ((Before ORDER BY + Projection))
+        Expression ((WHERE + Change column names to column identifiers))
+          ReadFromMergeTree (default.tab)
+          Indexes:
+            PrimaryKey
+              Keys:
+                name
+              Condition: (name in [\'name-a\', \'name-a\'])
+              Parts: 1/1
+              Granules: 5/6
+              Search Algorithm: binary search
+            Skip
+              Name: idx_attrs_keys
+              Description: text GRANULARITY 100000000
+              Condition: (mode: All; tokens: ["entity"])
+              Parts: 1/1
+              Granules: 5/5
+            Skip
+              Name: idx_attrs_values
+              Description: text GRANULARITY 100000000
+              Condition: (mode: Any; tokens: ["e1", "e2"])
+              Parts: 1/1
+              Granules: 3/5
+            Ranges: 2

--- a/tests/queries/0_stateless/04050_text_index_map_keys_in_subquery.sql
+++ b/tests/queries/0_stateless/04050_text_index_map_keys_in_subquery.sql
@@ -1,0 +1,59 @@
+-- Tags: no-parallel-replicas
+
+-- Test that text indexes on mapKeys(m) do not cause "Not-ready Set" exception
+-- when a query uses map_column['key'] IN (SELECT ... subquery).
+-- The bug: traverseMapElementKeyNode clones the IN expression DAG and tries
+-- to execute it, but the Set from the subquery is not built yet at that point.
+
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab
+(
+    id UInt32,
+    name LowCardinality(String),
+    attrs Map(LowCardinality(String), String),
+    INDEX idx_attrs_keys mapKeys(attrs) TYPE text(tokenizer = 'array'),
+    INDEX idx_attrs_values mapValues(attrs) TYPE text(tokenizer = 'array')
+)
+ENGINE = MergeTree
+ORDER BY (name, id)
+SETTINGS index_granularity = 1;
+
+INSERT INTO tab VALUES
+    (0, 'name-a', {'entity':'e1', 'reason':'OK'}),
+    (1, 'name-a', {'entity':'e2', 'reason':'TooManyRequests'}),
+    (2, 'name-a', {'entity':'e3', 'reason':'OK'}),
+    (3, 'name-b', {'entity':'e4', 'reason':'Timeout'}),
+    (4, 'name-a', {'entity':'e1', 'reason':'TooManyRequests'}),
+    (5, 'name-a', {'entity':'e3', 'reason':'Unknown Error'});
+
+SELECT id
+FROM tab
+WHERE name = 'name-a'
+    AND mapContains(attrs, 'entity')
+    AND attrs['entity'] IN (
+        SELECT DISTINCT attrs['entity']
+        FROM tab
+        WHERE name = 'name-a'
+            AND mapContains(attrs, 'reason')
+            AND attrs['reason'] LIKE '%TooMany%'
+    )
+ORDER BY id;
+
+EXPLAIN indexes = 1
+SELECT id
+FROM tab
+WHERE name = 'name-a'
+    AND mapContains(attrs, 'entity')
+    AND attrs['entity'] IN (
+        SELECT DISTINCT attrs['entity']
+        FROM tab
+        WHERE name = 'name-a'
+            AND mapContains(attrs, 'reason')
+            AND attrs['reason'] LIKE '%TooMany%'
+    )
+ORDER BY id;
+
+DROP TABLE tab;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed "Not-ready Set is passed as the second argument" errors during analysis of text index built on top of `mapValues` for predicates that contain `IN` clause.

In addition to #99286.

<!-- ch-version-info:start -->
### Version info
- Backported to: `26.2.6.8`
<!-- ch-version-info:end -->