### PR TITLE
Follow-up to #95127: add trace logging to Throttler, fix flaky test 02844_max_backup_bandwidth_s3

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -546,7 +546,7 @@ void Client::connect()
 
             if (max_client_network_bandwidth)
             {
-                ThrottlerPtr throttler = std::make_shared<Throttler>(max_client_network_bandwidth, 0, "");
+                ThrottlerPtr throttler = std::make_shared<Throttler>("client_network", max_client_network_bandwidth, 0, "");
                 connection->setThrottler(throttler);
             }
 

--- a/src/Common/Throttler.cpp
+++ b/src/Common/Throttler.cpp
@@ -27,7 +27,7 @@ namespace ErrorCodes
 /// Just 10^9.
 static constexpr auto NS = 1000000000UL;
 
-Throttler::Throttler(std::string_view throttler_name_, size_t max_speed_, const ThrottlerPtr & parent_,
+Throttler::Throttler(const char * throttler_name_, size_t max_speed_, const ThrottlerPtr & parent_,
         ProfileEvents::Event event_amount_,
         ProfileEvents::Event event_sleep_us_)
     : throttler_name(throttler_name_)
@@ -40,13 +40,13 @@ Throttler::Throttler(std::string_view throttler_name_, size_t max_speed_, const 
     , event_sleep_us(event_sleep_us_)
 {}
 
-Throttler::Throttler(std::string_view throttler_name_, size_t max_speed_,
+Throttler::Throttler(const char * throttler_name_, size_t max_speed_,
         ProfileEvents::Event event_amount_,
         ProfileEvents::Event event_sleep_us_)
     : Throttler(throttler_name_, max_speed_, nullptr, event_amount_, event_sleep_us_)
 {}
 
-Throttler::Throttler(std::string_view throttler_name_, size_t max_speed_, size_t limit_, const char * limit_exceeded_exception_message_, const ThrottlerPtr & parent_)
+Throttler::Throttler(const char * throttler_name_, size_t max_speed_, size_t limit_, const char * limit_exceeded_exception_message_, const ThrottlerPtr & parent_)
     : throttler_name(throttler_name_)
     , max_speed(max_speed_)
     , max_burst(max_speed_ * default_burst_seconds)

--- a/src/Common/Throttler.cpp
+++ b/src/Common/Throttler.cpp
@@ -3,6 +3,7 @@
 #include <Common/Exception.h>
 #include <Common/Stopwatch.h>
 #include <Common/CurrentThread.h>
+#include <Common/logger_useful.h>
 #include <IO/WriteHelpers.h>
 
 #include <base/scope_guard.h>
@@ -26,10 +27,11 @@ namespace ErrorCodes
 /// Just 10^9.
 static constexpr auto NS = 1000000000UL;
 
-Throttler::Throttler(size_t max_speed_, const ThrottlerPtr & parent_,
+Throttler::Throttler(std::string_view throttler_name_, size_t max_speed_, const ThrottlerPtr & parent_,
         ProfileEvents::Event event_amount_,
         ProfileEvents::Event event_sleep_us_)
-    : max_speed(max_speed_)
+    : throttler_name(throttler_name_)
+    , max_speed(max_speed_)
     , max_burst(max_speed_ * default_burst_seconds)
     , limit_exceeded_exception_message("")
     , tokens(static_cast<double>(max_burst))
@@ -38,14 +40,15 @@ Throttler::Throttler(size_t max_speed_, const ThrottlerPtr & parent_,
     , event_sleep_us(event_sleep_us_)
 {}
 
-Throttler::Throttler(size_t max_speed_,
+Throttler::Throttler(std::string_view throttler_name_, size_t max_speed_,
         ProfileEvents::Event event_amount_,
         ProfileEvents::Event event_sleep_us_)
-    : Throttler(max_speed_, nullptr, event_amount_, event_sleep_us_)
+    : Throttler(throttler_name_, max_speed_, nullptr, event_amount_, event_sleep_us_)
 {}
 
-Throttler::Throttler(size_t max_speed_, size_t limit_, const char * limit_exceeded_exception_message_, const ThrottlerPtr & parent_)
-    : max_speed(max_speed_)
+Throttler::Throttler(std::string_view throttler_name_, size_t max_speed_, size_t limit_, const char * limit_exceeded_exception_message_, const ThrottlerPtr & parent_)
+    : throttler_name(throttler_name_)
+    , max_speed(max_speed_)
     , max_burst(max_speed_ * default_burst_seconds)
     , limit(limit_)
     , limit_exceeded_exception_message(limit_exceeded_exception_message_)
@@ -90,8 +93,15 @@ bool Throttler::throttle(size_t amount, size_t max_block_ns)
             ? std::numeric_limits<UInt64>::max()
             : static_cast<UInt64>(block_ns_double);
 
+        UInt64 sleep_ns = std::min<UInt64>(max_block_ns, block_ns);
+        LOG_TRACE(log, "Sleeping: throttler_name={}, amount={}, count={}, tokens={}, max_speed={}, block_ns={}, max_block_ns={}, sleep_ns={}", throttler_name, amount, count_value, tokens_value, max_speed_value, block_ns, max_block_ns, sleep_ns);
+
         // Note that throwing exception from the following blocking call is safe. It is important for query cancellation.
-        sleepForNanoseconds(std::min<UInt64>(max_block_ns, block_ns));
+        sleepForNanoseconds(sleep_ns);
+    }
+    else if (max_speed_value > 0)
+    {
+        LOG_TRACE(log, "Not sleeping: throttler_name={}, amount={}, count={}, tokens={}, max_speed={}", throttler_name, amount, count_value, tokens_value, max_speed_value);
     }
 
     bool parent_block = false;
@@ -127,6 +137,8 @@ void Throttler::throttleImpl(size_t amount, size_t & count_value, double & token
 void Throttler::reset()
 {
     std::lock_guard lock(mutex);
+
+    LOG_TRACE(log, "Reset: throttler_name={}, count={}, tokens={}, max_burst={}", throttler_name, count, tokens, max_burst);
 
     count = 0;
     tokens = static_cast<double>(max_burst);
@@ -164,6 +176,8 @@ UInt64 Throttler::getMaxBurst() const
 void Throttler::setMaxSpeed(size_t max_speed_)
 {
     std::lock_guard lock(mutex);
+
+    LOG_TRACE(log, "setMaxSpeed: throttler_name={}, {} -> {}, tokens={}", throttler_name, max_speed, max_speed_, tokens);
 
     max_speed = max_speed_;
     max_burst = max_speed_ * default_burst_seconds;

--- a/src/Common/Throttler.h
+++ b/src/Common/Throttler.h
@@ -4,7 +4,6 @@
 #include <Common/Logger.h>
 #include <Common/ProfileEvents.h>
 #include <mutex>
-#include <string_view>
 #include <base/sleep.h>
 #include <base/types.h>
 #include <atomic>
@@ -21,33 +20,33 @@ class Throttler : public IThrottler
 public:
     static const size_t default_burst_seconds = 1;
 
-    Throttler(std::string_view throttler_name_, size_t max_speed_, size_t max_burst_, const ThrottlerPtr & parent_ = nullptr,
+    Throttler(const char * throttler_name_, size_t max_speed_, size_t max_burst_, const ThrottlerPtr & parent_ = nullptr,
             ProfileEvents::Event event_amount_ = ProfileEvents::end(),
             ProfileEvents::Event event_sleep_us_ = ProfileEvents::end())
         : throttler_name(throttler_name_), max_speed(max_speed_), max_burst(max_burst_), limit_exceeded_exception_message(""), tokens(static_cast<double>(max_burst)), parent(parent_)
         , event_amount(event_amount_), event_sleep_us(event_sleep_us_)
     {}
 
-    Throttler(std::string_view throttler_name_, size_t max_speed_, size_t max_burst_,
+    Throttler(const char * throttler_name_, size_t max_speed_, size_t max_burst_,
             ProfileEvents::Event event_amount_ = ProfileEvents::end(),
             ProfileEvents::Event event_sleep_us_ = ProfileEvents::end())
         : throttler_name(throttler_name_), max_speed(max_speed_), max_burst(max_burst_), limit_exceeded_exception_message(""), tokens(static_cast<double>(max_burst))
         , event_amount(event_amount_), event_sleep_us(event_sleep_us_)
     {}
 
-    explicit Throttler(std::string_view throttler_name_, size_t max_speed_, const ThrottlerPtr & parent_ = nullptr,
+    explicit Throttler(const char * throttler_name_, size_t max_speed_, const ThrottlerPtr & parent_ = nullptr,
         ProfileEvents::Event event_amount_ = ProfileEvents::end(),
         ProfileEvents::Event event_sleep_us_ = ProfileEvents::end());
 
-    Throttler(std::string_view throttler_name_, size_t max_speed_,
+    Throttler(const char * throttler_name_, size_t max_speed_,
         ProfileEvents::Event event_amount_,
         ProfileEvents::Event event_sleep_us_);
 
-    Throttler(std::string_view throttler_name_, size_t max_speed_, size_t max_burst_, size_t limit_, const char * limit_exceeded_exception_message_,
+    Throttler(const char * throttler_name_, size_t max_speed_, size_t max_burst_, size_t limit_, const char * limit_exceeded_exception_message_,
               const ThrottlerPtr & parent_ = nullptr)
         : throttler_name(throttler_name_), max_speed(max_speed_), max_burst(max_burst_), limit(limit_), limit_exceeded_exception_message(limit_exceeded_exception_message_), tokens(static_cast<double>(max_burst)), parent(parent_) {}
 
-    Throttler(std::string_view throttler_name_, size_t max_speed_, size_t limit_, const char * limit_exceeded_exception_message_,
+    Throttler(const char * throttler_name_, size_t max_speed_, size_t limit_, const char * limit_exceeded_exception_message_,
               const ThrottlerPtr & parent_ = nullptr);
 
     /// Use `amount` tokens, sleeps if required or throws exception on limit overflow.
@@ -77,7 +76,7 @@ private:
     void throttleImpl(size_t amount, size_t & count_value, double & tokens_value, size_t & max_speed_value);
 
     /// Human-readable name for logging (e.g. "backups_query", "remote_read_server")
-    std::string_view throttler_name;
+    const char * throttler_name;
     LoggerPtr log = getLogger("Throttler");
 
     size_t count{0};

--- a/src/Common/Throttler.h
+++ b/src/Common/Throttler.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <Common/IThrottler.h>
+#include <Common/Logger.h>
 #include <Common/ProfileEvents.h>
-
 #include <mutex>
+#include <string_view>
 #include <base/sleep.h>
 #include <base/types.h>
 #include <atomic>
@@ -20,33 +21,33 @@ class Throttler : public IThrottler
 public:
     static const size_t default_burst_seconds = 1;
 
-    Throttler(size_t max_speed_, size_t max_burst_, const ThrottlerPtr & parent_ = nullptr,
+    Throttler(std::string_view throttler_name_, size_t max_speed_, size_t max_burst_, const ThrottlerPtr & parent_ = nullptr,
             ProfileEvents::Event event_amount_ = ProfileEvents::end(),
             ProfileEvents::Event event_sleep_us_ = ProfileEvents::end())
-        : max_speed(max_speed_), max_burst(max_burst_), limit_exceeded_exception_message(""), tokens(static_cast<double>(max_burst)), parent(parent_)
+        : throttler_name(throttler_name_), max_speed(max_speed_), max_burst(max_burst_), limit_exceeded_exception_message(""), tokens(static_cast<double>(max_burst)), parent(parent_)
         , event_amount(event_amount_), event_sleep_us(event_sleep_us_)
     {}
 
-    Throttler(size_t max_speed_, size_t max_burst_,
+    Throttler(std::string_view throttler_name_, size_t max_speed_, size_t max_burst_,
             ProfileEvents::Event event_amount_ = ProfileEvents::end(),
             ProfileEvents::Event event_sleep_us_ = ProfileEvents::end())
-        : max_speed(max_speed_), max_burst(max_burst_), limit_exceeded_exception_message(""), tokens(static_cast<double>(max_burst))
+        : throttler_name(throttler_name_), max_speed(max_speed_), max_burst(max_burst_), limit_exceeded_exception_message(""), tokens(static_cast<double>(max_burst))
         , event_amount(event_amount_), event_sleep_us(event_sleep_us_)
     {}
 
-    explicit Throttler(size_t max_speed_, const ThrottlerPtr & parent_ = nullptr,
+    explicit Throttler(std::string_view throttler_name_, size_t max_speed_, const ThrottlerPtr & parent_ = nullptr,
         ProfileEvents::Event event_amount_ = ProfileEvents::end(),
         ProfileEvents::Event event_sleep_us_ = ProfileEvents::end());
 
-    Throttler(size_t max_speed_,
+    Throttler(std::string_view throttler_name_, size_t max_speed_,
         ProfileEvents::Event event_amount_,
         ProfileEvents::Event event_sleep_us_);
 
-    Throttler(size_t max_speed_, size_t max_burst_, size_t limit_, const char * limit_exceeded_exception_message_,
+    Throttler(std::string_view throttler_name_, size_t max_speed_, size_t max_burst_, size_t limit_, const char * limit_exceeded_exception_message_,
               const ThrottlerPtr & parent_ = nullptr)
-        : max_speed(max_speed_), max_burst(max_burst_), limit(limit_), limit_exceeded_exception_message(limit_exceeded_exception_message_), tokens(static_cast<double>(max_burst)), parent(parent_) {}
+        : throttler_name(throttler_name_), max_speed(max_speed_), max_burst(max_burst_), limit(limit_), limit_exceeded_exception_message(limit_exceeded_exception_message_), tokens(static_cast<double>(max_burst)), parent(parent_) {}
 
-    Throttler(size_t max_speed_, size_t limit_, const char * limit_exceeded_exception_message_,
+    Throttler(std::string_view throttler_name_, size_t max_speed_, size_t limit_, const char * limit_exceeded_exception_message_,
               const ThrottlerPtr & parent_ = nullptr);
 
     /// Use `amount` tokens, sleeps if required or throws exception on limit overflow.
@@ -74,6 +75,10 @@ public:
 private:
     void throttleImpl(size_t amount, size_t & count_value, double & tokens_value);
     void throttleImpl(size_t amount, size_t & count_value, double & tokens_value, size_t & max_speed_value);
+
+    /// Human-readable name for logging (e.g. "backups_query", "remote_read_server")
+    std::string_view throttler_name;
+    LoggerPtr log = getLogger("Throttler");
 
     size_t count{0};
     size_t max_speed TSA_GUARDED_BY(mutex){0}; /// in tokens per second.

--- a/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/AzureBlobStorage/AzureBlobStorageCommon.cpp
@@ -349,6 +349,7 @@ BlobClientOptions getClientOptions(
     if (settings[Setting::azure_max_get_rps] > 0 || settings[Setting::azure_max_get_burst] > 0)
     {
         request_throttler.get_throttler = std::make_shared<Throttler>(
+            "azure_get_rps",
             settings[Setting::azure_max_get_rps],
             settings[Setting::azure_max_get_burst],
             ProfileEvents::AzureGetRequestThrottlerCount,
@@ -367,6 +368,7 @@ BlobClientOptions getClientOptions(
     if (settings[Setting::azure_max_put_rps] > 0 || settings[Setting::azure_max_put_burst] > 0)
     {
         request_throttler.put_throttler = std::make_shared<Throttler>(
+            "azure_put_rps",
             settings[Setting::azure_max_put_rps],
             settings[Setting::azure_max_put_burst],
             ProfileEvents::AzurePutRequestThrottlerCount,

--- a/src/IO/S3RequestSettings.cpp
+++ b/src/IO/S3RequestSettings.cpp
@@ -301,6 +301,7 @@ void S3RequestSettings::finishInit(const DB::Settings & settings, bool validate_
             : default_max_get_burst;
 
         request_throttler.get_throttler = std::make_shared<Throttler>(
+            "s3_get_rps",
             max_get_rps,
             max_get_burst,
             ProfileEvents::S3GetRequestThrottlerCount,
@@ -321,6 +322,7 @@ void S3RequestSettings::finishInit(const DB::Settings & settings, bool validate_
             : default_max_put_burst;
 
         request_throttler.put_throttler = std::make_shared<Throttler>(
+            "s3_put_rps",
             max_put_rps,
             max_put_burst,
             ProfileEvents::S3PutRequestThrottlerCount,

--- a/src/Interpreters/ClusterProxy/executeQuery.cpp
+++ b/src/Interpreters/ClusterProxy/executeQuery.cpp
@@ -285,6 +285,7 @@ static ThrottlerPtr getThrottler(const ContextPtr & context)
     if (settings[Setting::max_network_bandwidth] || settings[Setting::max_network_bytes])
     {
         throttler = std::make_shared<Throttler>(
+            "network_cluster_query",
             settings[Setting::max_network_bandwidth],
             settings[Setting::max_network_bytes],
             "Limit for bytes to send or receive over network exceeded.",

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1130,31 +1130,31 @@ struct ContextSharedPart : boost::noncopyable
     void configureServerWideThrottling()
     {
         if (auto bandwidth = server_settings[ServerSetting::max_replicated_fetches_network_bandwidth_for_server])
-            replicated_fetches_throttler = std::make_shared<Throttler>(bandwidth);
+            replicated_fetches_throttler = std::make_shared<Throttler>("replicated_fetches_server", bandwidth);
 
         if (auto bandwidth = server_settings[ServerSetting::max_replicated_sends_network_bandwidth_for_server])
-            replicated_sends_throttler = std::make_shared<Throttler>(bandwidth);
+            replicated_sends_throttler = std::make_shared<Throttler>("replicated_sends_server", bandwidth);
 
         if (auto bandwidth = server_settings[ServerSetting::max_remote_read_network_bandwidth_for_server])
-            remote_read_throttler = std::make_shared<Throttler>(bandwidth, ProfileEvents::RemoteReadThrottlerBytes, ProfileEvents::RemoteReadThrottlerSleepMicroseconds);
+            remote_read_throttler = std::make_shared<Throttler>("remote_read_server", bandwidth, ProfileEvents::RemoteReadThrottlerBytes, ProfileEvents::RemoteReadThrottlerSleepMicroseconds);
 
         if (auto bandwidth = server_settings[ServerSetting::max_remote_write_network_bandwidth_for_server])
-            remote_write_throttler = std::make_shared<Throttler>(bandwidth, ProfileEvents::RemoteWriteThrottlerBytes, ProfileEvents::RemoteWriteThrottlerSleepMicroseconds);
+            remote_write_throttler = std::make_shared<Throttler>("remote_write_server", bandwidth, ProfileEvents::RemoteWriteThrottlerBytes, ProfileEvents::RemoteWriteThrottlerSleepMicroseconds);
 
         if (auto bandwidth = server_settings[ServerSetting::max_local_read_bandwidth_for_server])
-            local_read_throttler = std::make_shared<Throttler>(bandwidth, ProfileEvents::LocalReadThrottlerBytes, ProfileEvents::LocalReadThrottlerSleepMicroseconds);
+            local_read_throttler = std::make_shared<Throttler>("local_read_server", bandwidth, ProfileEvents::LocalReadThrottlerBytes, ProfileEvents::LocalReadThrottlerSleepMicroseconds);
 
         if (auto bandwidth = server_settings[ServerSetting::max_local_write_bandwidth_for_server])
-            local_write_throttler = std::make_shared<Throttler>(bandwidth, ProfileEvents::LocalWriteThrottlerBytes, ProfileEvents::LocalWriteThrottlerSleepMicroseconds);
+            local_write_throttler = std::make_shared<Throttler>("local_write_server", bandwidth, ProfileEvents::LocalWriteThrottlerBytes, ProfileEvents::LocalWriteThrottlerSleepMicroseconds);
 
         if (auto bandwidth = server_settings[ServerSetting::max_backup_bandwidth_for_server])
-            backups_server_throttler = std::make_shared<Throttler>(bandwidth, ProfileEvents::BackupThrottlerBytes, ProfileEvents::BackupThrottlerSleepMicroseconds);
+            backups_server_throttler = std::make_shared<Throttler>("backups_server", bandwidth, ProfileEvents::BackupThrottlerBytes, ProfileEvents::BackupThrottlerSleepMicroseconds);
 
         if (auto bandwidth = server_settings[ServerSetting::max_mutations_bandwidth_for_server])
-            mutations_throttler = std::make_shared<Throttler>(bandwidth, ProfileEvents::MutationsThrottlerBytes, ProfileEvents::MutationsThrottlerSleepMicroseconds);
+            mutations_throttler = std::make_shared<Throttler>("mutations_server", bandwidth, ProfileEvents::MutationsThrottlerBytes, ProfileEvents::MutationsThrottlerSleepMicroseconds);
 
         if (auto bandwidth = server_settings[ServerSetting::max_merges_bandwidth_for_server])
-            merges_throttler = std::make_shared<Throttler>(bandwidth, ProfileEvents::MergesThrottlerBytes, ProfileEvents::MergesThrottlerSleepMicroseconds);
+            merges_throttler = std::make_shared<Throttler>("merges_server", bandwidth, ProfileEvents::MergesThrottlerBytes, ProfileEvents::MergesThrottlerSleepMicroseconds);
     }
 };
 
@@ -4675,7 +4675,7 @@ ThrottlerPtr Context::getRemoteReadThrottler() const
     {
         std::lock_guard lock(mutex);
         if (!remote_read_query_throttler)
-            remote_read_query_throttler = std::make_shared<Throttler>(bandwidth, throttler, ProfileEvents::QueryRemoteReadThrottlerBytes, ProfileEvents::QueryRemoteReadThrottlerSleepMicroseconds);
+            remote_read_query_throttler = std::make_shared<Throttler>("remote_read_query", bandwidth, throttler, ProfileEvents::QueryRemoteReadThrottlerBytes, ProfileEvents::QueryRemoteReadThrottlerSleepMicroseconds);
         throttler = remote_read_query_throttler;
     }
     return throttler;
@@ -4693,7 +4693,7 @@ ThrottlerPtr Context::getRemoteWriteThrottler() const
     {
         std::lock_guard lock(mutex);
         if (!remote_write_query_throttler)
-            remote_write_query_throttler = std::make_shared<Throttler>(bandwidth, throttler, ProfileEvents::QueryRemoteWriteThrottlerBytes, ProfileEvents::QueryRemoteWriteThrottlerSleepMicroseconds);
+            remote_write_query_throttler = std::make_shared<Throttler>("remote_write_query", bandwidth, throttler, ProfileEvents::QueryRemoteWriteThrottlerBytes, ProfileEvents::QueryRemoteWriteThrottlerSleepMicroseconds);
         throttler = remote_write_query_throttler;
     }
     return throttler;
@@ -4711,7 +4711,7 @@ ThrottlerPtr Context::getLocalReadThrottler() const
     {
         std::lock_guard lock(mutex);
         if (!local_read_query_throttler)
-            local_read_query_throttler = std::make_shared<Throttler>(bandwidth, throttler, ProfileEvents::QueryLocalReadThrottlerBytes, ProfileEvents::QueryLocalReadThrottlerSleepMicroseconds);
+            local_read_query_throttler = std::make_shared<Throttler>("local_read_query", bandwidth, throttler, ProfileEvents::QueryLocalReadThrottlerBytes, ProfileEvents::QueryLocalReadThrottlerSleepMicroseconds);
         throttler = local_read_query_throttler;
     }
     return throttler;
@@ -4729,7 +4729,7 @@ ThrottlerPtr Context::getLocalWriteThrottler() const
     {
         std::lock_guard lock(mutex);
         if (!local_write_query_throttler)
-            local_write_query_throttler = std::make_shared<Throttler>(bandwidth, throttler, ProfileEvents::QueryLocalWriteThrottlerBytes, ProfileEvents::QueryLocalWriteThrottlerSleepMicroseconds);
+            local_write_query_throttler = std::make_shared<Throttler>("local_write_query", bandwidth, throttler, ProfileEvents::QueryLocalWriteThrottlerBytes, ProfileEvents::QueryLocalWriteThrottlerSleepMicroseconds);
         throttler = local_write_query_throttler;
     }
     return throttler;
@@ -4742,7 +4742,7 @@ ThrottlerPtr Context::getBackupsThrottler() const
     {
         std::lock_guard lock(mutex);
          if (!backups_query_throttler)
-            backups_query_throttler = std::make_shared<Throttler>(bandwidth, throttler, ProfileEvents::QueryBackupThrottlerBytes, ProfileEvents::QueryBackupThrottlerSleepMicroseconds);
+            backups_query_throttler = std::make_shared<Throttler>("backups_query", bandwidth, throttler, ProfileEvents::QueryBackupThrottlerBytes, ProfileEvents::QueryBackupThrottlerSleepMicroseconds);
         throttler = backups_query_throttler;
     }
     return throttler;
@@ -4774,7 +4774,7 @@ void Context::reloadRemoteThrottlerConfig(size_t read_bandwidth, size_t write_ba
     {
         std::lock_guard lock(shared->mutex);
         if (!shared->remote_read_throttler)
-            shared->remote_read_throttler = std::make_shared<Throttler>(read_bandwidth, ProfileEvents::RemoteReadThrottlerBytes, ProfileEvents::RemoteReadThrottlerSleepMicroseconds);
+            shared->remote_read_throttler = std::make_shared<Throttler>("remote_read_server", read_bandwidth, ProfileEvents::RemoteReadThrottlerBytes, ProfileEvents::RemoteReadThrottlerSleepMicroseconds);
     }
 
     if (shared->remote_read_throttler)
@@ -4784,7 +4784,7 @@ void Context::reloadRemoteThrottlerConfig(size_t read_bandwidth, size_t write_ba
     {
         std::lock_guard lock(shared->mutex);
         if (!shared->remote_write_throttler)
-            shared->remote_write_throttler = std::make_shared<Throttler>(write_bandwidth, ProfileEvents::RemoteWriteThrottlerBytes, ProfileEvents::RemoteWriteThrottlerSleepMicroseconds);
+            shared->remote_write_throttler = std::make_shared<Throttler>("remote_write_server", write_bandwidth, ProfileEvents::RemoteWriteThrottlerBytes, ProfileEvents::RemoteWriteThrottlerSleepMicroseconds);
     }
 
     if (shared->remote_write_throttler)
@@ -4797,7 +4797,7 @@ void Context::reloadLocalThrottlerConfig(size_t read_bandwidth, size_t write_ban
     {
         std::lock_guard lock(shared->mutex);
         if (!shared->local_read_throttler)
-            shared->local_read_throttler = std::make_shared<Throttler>(read_bandwidth);
+            shared->local_read_throttler = std::make_shared<Throttler>("local_read_server", read_bandwidth);
     }
 
     if (shared->local_read_throttler)
@@ -4807,7 +4807,7 @@ void Context::reloadLocalThrottlerConfig(size_t read_bandwidth, size_t write_ban
     {
         std::lock_guard lock(shared->mutex);
         if (!shared->local_write_throttler)
-            shared->local_write_throttler = std::make_shared<Throttler>(write_bandwidth);
+            shared->local_write_throttler = std::make_shared<Throttler>("local_write_server", write_bandwidth);
     }
 
     if (shared->local_write_throttler)

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -379,14 +379,16 @@ ProcessList::EntryPtr ProcessList::insert(
 
         if (!total_network_throttler && settings[Setting::max_network_bandwidth_for_all_users])
         {
-            total_network_throttler = std::make_shared<Throttler>(settings[Setting::max_network_bandwidth_for_all_users]);
+            total_network_throttler = std::make_shared<Throttler>("network_all_users", settings[Setting::max_network_bandwidth_for_all_users]);
         }
 
         if (!user_process_list.user_throttler)
         {
             if (settings[Setting::max_network_bandwidth_for_user])
+            {
                 user_process_list.user_throttler
-                    = std::make_shared<Throttler>(settings[Setting::max_network_bandwidth_for_user], total_network_throttler);
+                    = std::make_shared<Throttler>("network_user", settings[Setting::max_network_bandwidth_for_user], total_network_throttler);
+            }
             else if (settings[Setting::max_network_bandwidth_for_all_users])
                 user_process_list.user_throttler = total_network_throttler;
         }

--- a/src/Storages/Distributed/DistributedSink.cpp
+++ b/src/Storages/Distributed/DistributedSink.cpp
@@ -506,7 +506,7 @@ void DistributedSink::writeSync(const Block & block)
         if (!throttler && (settings[Setting::max_network_bandwidth] || settings[Setting::max_network_bytes]))
         {
             throttler = std::make_shared<Throttler>(
-                settings[Setting::max_network_bandwidth], settings[Setting::max_network_bytes], "Network bandwidth limit for a query exceeded.");
+                "network_distributed_query", settings[Setting::max_network_bandwidth], settings[Setting::max_network_bytes], "Network bandwidth limit for a query exceeded.");
         }
 
         watch.restart();

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -429,8 +429,8 @@ StorageReplicatedMergeTree::StorageReplicatedMergeTree(
     , part_check_thread(*this)
     , restarting_thread(*this)
     , part_moves_between_shards_orchestrator(*this)
-    , replicated_fetches_throttler(std::make_shared<Throttler>((*getSettings())[MergeTreeSetting::max_replicated_fetches_network_bandwidth], getContext()->getReplicatedFetchesThrottler()))
-    , replicated_sends_throttler(std::make_shared<Throttler>((*getSettings())[MergeTreeSetting::max_replicated_sends_network_bandwidth], getContext()->getReplicatedSendsThrottler()))
+    , replicated_fetches_throttler(std::make_shared<Throttler>("replicated_fetches_table", (*getSettings())[MergeTreeSetting::max_replicated_fetches_network_bandwidth], getContext()->getReplicatedFetchesThrottler()))
+    , replicated_sends_throttler(std::make_shared<Throttler>("replicated_sends_table", (*getSettings())[MergeTreeSetting::max_replicated_sends_network_bandwidth], getContext()->getReplicatedSendsThrottler()))
 {
     auto table_disks = getDisks();
     for (const auto & disk : table_disks)

--- a/tests/queries/0_stateless/02844_max_backup_bandwidth_s3.reference
+++ b/tests/queries/0_stateless/02844_max_backup_bandwidth_s3.reference
@@ -1,1 +1,2 @@
-1
+native_copy	0
+no_native_copy	1

--- a/tests/queries/0_stateless/02844_max_backup_bandwidth_s3.reference
+++ b/tests/queries/0_stateless/02844_max_backup_bandwidth_s3.reference
@@ -1,2 +1,1 @@
-native_copy	0
 no_native_copy	1

--- a/tests/queries/0_stateless/02844_max_backup_bandwidth_s3.sh
+++ b/tests/queries/0_stateless/02844_max_backup_bandwidth_s3.sh
@@ -14,29 +14,28 @@ client_opts=(
 $CLICKHOUSE_CLIENT "${client_opts[@]}" -m -q "
     drop table if exists data;
     create table data (key UInt64 CODEC(NONE)) engine=MergeTree() order by tuple() settings min_bytes_for_wide_part=1e9, disk='s3_disk';
-    -- 2e6*8 bytes = 16MB, with 1MB/s bandwidth it should take ~16 seconds for non-native copy
-    insert into data select * from numbers(2e6);
+    -- reading 1e6*8 bytes with 1M bandwith it should take (8-1)/1=7 seconds
+    insert into data select * from numbers(1e6);
 "
 
-query_id_native=$(random_str 10)
-$CLICKHOUSE_CLIENT "${client_opts[@]}" --query_id "$query_id_native" -q "backup table data to S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data/backup2') SETTINGS allow_s3_native_copy=1" --max_backup_bandwidth=1M > /dev/null
-
-query_id_no_native=$(random_str 10)
-$CLICKHOUSE_CLIENT "${client_opts[@]}" --query_id "$query_id_no_native" -q "backup table data to S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data/backup3') SETTINGS allow_s3_native_copy=0" --max_backup_bandwidth=1M > /dev/null
-
-# Check that non-native copy with bandwidth limiting takes significantly longer than native copy.
-# Native copy uses S3 server-side copy which bypasses client bandwidth limiting.
-# We check that non-native copy is at least 10 seconds longer than native copy,
-# which verifies that bandwidth limiting is being applied.
+query_id=$(random_str 10)
+$CLICKHOUSE_CLIENT "${client_opts[@]}" --query_id "$query_id" -q "backup table data to S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data/backup2') SETTINGS allow_s3_native_copy=1" --max_backup_bandwidth=1M > /dev/null
 $CLICKHOUSE_CLIENT "${client_opts[@]}" -m -q "
     SYSTEM FLUSH LOGS query_log;
     SELECT
-        (no_native_duration_ms - native_duration_ms) >= 10000 AS bandwidth_limiting_works
-    FROM (
-        SELECT
-            (SELECT query_duration_ms FROM system.query_log
-             WHERE event_date >= yesterday() AND event_time >= now() - 600 AND current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id_native' AND type != 'QueryStart') AS native_duration_ms,
-            (SELECT query_duration_ms FROM system.query_log
-             WHERE event_date >= yesterday() AND event_time >= now() - 600 AND current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id_no_native' AND type != 'QueryStart') AS no_native_duration_ms
-    )
+        'native_copy',
+        query_duration_ms >= 7e3
+    FROM system.query_log
+    WHERE event_date >= yesterday() AND event_time >= now() - 600 AND current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id' AND type != 'QueryStart'
+"
+
+query_id=$(random_str 10)
+$CLICKHOUSE_CLIENT "${client_opts[@]}" --query_id "$query_id" -q "backup table data to S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data/backup3') SETTINGS allow_s3_native_copy=0" --max_backup_bandwidth=1M > /dev/null
+$CLICKHOUSE_CLIENT "${client_opts[@]}" -m -q "
+    SYSTEM FLUSH LOGS query_log;
+    SELECT
+        'no_native_copy',
+        query_duration_ms >= 7e3
+    FROM system.query_log
+    WHERE event_date >= yesterday() AND event_time >= now() - 600 AND current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id' AND type != 'QueryStart'
 "

--- a/tests/queries/0_stateless/02844_max_backup_bandwidth_s3.sh
+++ b/tests/queries/0_stateless/02844_max_backup_bandwidth_s3.sh
@@ -14,21 +14,14 @@ client_opts=(
 $CLICKHOUSE_CLIENT "${client_opts[@]}" -m -q "
     drop table if exists data;
     create table data (key UInt64 CODEC(NONE)) engine=MergeTree() order by tuple() settings min_bytes_for_wide_part=1e9, disk='s3_disk';
-    -- reading 1e6*8 bytes with 1M bandwith it should take (8-1)/1=7 seconds
+    -- reading 1e6*8 bytes with 1M bandwidth it should take (8-1)/1=7 seconds
     insert into data select * from numbers(1e6);
 "
 
-query_id=$(random_str 10)
-$CLICKHOUSE_CLIENT "${client_opts[@]}" --query_id "$query_id" -q "backup table data to S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data/backup2') SETTINGS allow_s3_native_copy=1" --max_backup_bandwidth=1M > /dev/null
-$CLICKHOUSE_CLIENT "${client_opts[@]}" -m -q "
-    SYSTEM FLUSH LOGS query_log;
-    SELECT
-        'native_copy',
-        query_duration_ms >= 7e3
-    FROM system.query_log
-    WHERE event_date >= yesterday() AND event_time >= now() - 600 AND current_database = '$CLICKHOUSE_DATABASE' AND query_id = '$query_id' AND type != 'QueryStart'
-"
-
+# We only test no_native_copy because with native copy S3 performs a server-side copy
+# and ClickHouse never reads/writes the data, so throttling cannot apply.
+# Checking wall clock time for native copy is unreliable — S3 server-side copy latency is unpredictable.
+#
 query_id=$(random_str 10)
 $CLICKHOUSE_CLIENT "${client_opts[@]}" --query_id "$query_id" -q "backup table data to S3(s3_conn, 'backups/$CLICKHOUSE_DATABASE/data/backup3') SETTINGS allow_s3_native_copy=0" --max_backup_bandwidth=1M > /dev/null
 $CLICKHOUSE_CLIENT "${client_opts[@]}" -m -q "


### PR DESCRIPTION
Follow-up to #95127 (which was reverted). Addresses flaky test `02844_max_backup_bandwidth_s3` (issue #85084).

**`Throttler` trace logging:** All `Throttler` instances are now named (e.g. `backups_query`, `remote_read_server`, `s3_get_rps`). The name is the first constructor parameter (`std::string_view`, immutable). `LOG_TRACE` covers all state mutations: `throttle` (sleeping and not-sleeping paths), `reset`, `setMaxSpeed`. The sleeping path logs `block_ns`, `max_block_ns`, and `sleep_ns` to detect clamping. Disabled throttlers (`max_speed == 0`) are silent. The logger is cached as a member to avoid repeated `getLogger` lookups.

**Test fix:** Removed the `native_copy` case — with `allow_s3_native_copy=1`, S3 performs a server-side copy and ClickHouse never reads/writes the data, so the `Throttler` is never invoked. The previous assertion that native copy finishes in < 7s was wrong: it relied on an upper bound on S3 server-side copy latency, which is unpredictable and caused flaky failures on ARM CI.

CI failure example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95118&sha=ab1adaa5d88f38a4934fac9fc8ffb91e97ef5a6f&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/95118

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.116`
<!-- ch-version-info:end -->