### PR TITLE
Fix flaky test `04043_system_asynchronous_inserts_user_filter`

### DIFF
--- a/tests/queries/0_stateless/04043_system_asynchronous_inserts_user_filter.sh
+++ b/tests/queries/0_stateless/04043_system_asynchronous_inserts_user_filter.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-parallel
+# no-parallel: concurrent SYSTEM FLUSH ASYNC INSERT QUEUE from other tests drains the pending queue
 
 # Regression test: system.asynchronous_inserts must not leak cross-user insert metadata.
 # A user without SHOW_USERS privilege must only see their own pending inserts.


### PR DESCRIPTION
Resolves https://github.com/ClickHouse/ClickHouse/issues/100231

Add `no-parallel` tag because the test relies on a pending async insert remaining in the queue. Concurrent tests that run
`SYSTEM FLUSH ASYNC INSERT QUEUE` drain all shards globally, removing the entry before the subsequent SELECT queries can observe it.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.75`
<!-- ch-version-info:end -->