### PR TITLE
ci: ignore ASan warning about __asan_handle_no_return in clickhouse-test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -78,6 +78,9 @@ MESSAGES_TO_RETRY = [
 
 IGNORED_SANITIZER_ERRORS = [
     "ASan doesn't fully support makecontext/swapcontext functions and may produce false positives in some cases!",
+    # This warning appears when the virtual stack size is too large for ASan to track __asan_handle_no_return.
+    # It is a known limitation (https://github.com/google/sanitizers/issues/189) and not a real error.
+    "ASan is ignoring requested __asan_handle_no_return",
     # Note, usually such error means that sanitizer has found something but failed to print, so it should not be ignored
     # "LLVM ERROR: IO failure on output stream: Broken pipe",
 ]


### PR DESCRIPTION
Ignore the `ASan is ignoring requested __asan_handle_no_return` warning in `clickhouse-test`. This warning appears when the virtual stack size is too large for ASan to track `__asan_handle_no_return`. It is a known limitation (https://github.com/google/sanitizers/issues/189) and not a real error.

Close: https://github.com/ClickHouse/clickhouse-private/issues/53120#issuecomment-4099612841

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.78`
<!-- ch-version-info:end -->