### PR TITLE
Fix entrypoint error messages in case log files are disabled

### DIFF
--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -30,10 +30,10 @@ CLICKHOUSE_CONFIG="${CLICKHOUSE_CONFIG:-/etc/clickhouse-server/config.xml}"
 DATA_DIR="$(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key=path || true)"
 TMP_DIR="$(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key=tmp_path || true)"
 USER_PATH="$(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key=user_files_path || true)"
-LOG_PATH="$(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key=logger.log || true)"
+LOG_PATH="$(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key=logger.log --try || true)"
 LOG_DIR=""
 if [ -n "$LOG_PATH" ]; then LOG_DIR="$(dirname "$LOG_PATH")"; fi
-ERROR_LOG_PATH="$(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key=logger.errorlog || true)"
+ERROR_LOG_PATH="$(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key=logger.errorlog --try || true)"
 ERROR_LOG_DIR=""
 if [ -n "$ERROR_LOG_PATH" ]; then ERROR_LOG_DIR="$(dirname "$ERROR_LOG_PATH")"; fi
 FORMAT_SCHEMA_PATH="$(clickhouse extract-from-config --config-file "$CLICKHOUSE_CONFIG" --key=format_schema_path || true)"


### PR DESCRIPTION
It is quite common to run ClickHouse in Docker with enabled console logging. If the logger.log and logger.errorlog settings are removed from the configuration, the entrypoint script currently produces two messages on startup:

```
Poco::Exception. Code: 1000, e.code() = 0, Not found: logger.log (version 26.2.5.45 (official build))
Poco::Exception. Code: 1000, e.code() = 0, Not found: logger.errorlog (version 26.2.5.45 (official build))
```

This commit fixes this behavior by adding the `--try` flag to the relevant `extract-from-config` invocations.

Related: https://github.com/ClickHouse/ClickHouse/issues/69551

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

> Fixed two error messages on container startup in case the configuration did not contain the `logger.log` and `logger.errorlog` settings (e.g. when all log messages are supposed to go to STDOUT/STDERR).

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.79`
<!-- ch-version-info:end -->