### PR TITLE
Fix flaky test 04002_cast_nullable_read_in_order

### DIFF
--- a/tests/queries/0_stateless/04002_cast_nullable_read_in_order.reference
+++ b/tests/queries/0_stateless/04002_cast_nullable_read_in_order.reference
@@ -3,17 +3,17 @@
 SET optimize_read_in_order = 1;
 DROP TABLE IF EXISTS test_nullable_order_by;
 CREATE TABLE test_nullable_order_by (x UInt32, y UInt32) ENGINE=MergeTree ORDER BY x;
-INSERT INTO test_nullable_order_by SELECT number, number FROM numbers(1e6);
+INSERT INTO test_nullable_order_by SELECT number, number FROM numbers(1e5);
 SELECT sum(y) FROM
 (
     SELECT y FROM test_nullable_order_by ORDER BY x::UInt64 LIMIT 1000000000
 );
-499999500000
+4999950000
 SELECT sum(y) FROM
 (
     SELECT y FROM test_nullable_order_by ORDER BY x::Nullable(UInt64) LIMIT 1000000000
 );
-499999500000
+4999950000
 DROP TABLE IF EXISTS test_accurate_cast_or_null;
 CREATE TABLE test_accurate_cast_or_null (x Date32, y UInt32) ENGINE=MergeTree ORDER BY x;
 INSERT INTO test_accurate_cast_or_null SELECT toDate32('1969-12-29') + number, number FROM numbers(6);
@@ -53,14 +53,14 @@ LIMIT 10;
 1.3	\N
 DROP TABLE IF EXISTS test_nullable_sorting_key_order_by;
 CREATE TABLE test_nullable_sorting_key_order_by (x UInt32, y UInt32) ENGINE=MergeTree ORDER BY x::Nullable(UInt32) SETTINGS allow_nullable_key = 1;
-INSERT INTO test_nullable_sorting_key_order_by SELECT number, number FROM numbers(1e6);
+INSERT INTO test_nullable_sorting_key_order_by SELECT number, number FROM numbers(1e5);
 SELECT sum(y) FROM
 (
     SELECT y FROM test_nullable_sorting_key_order_by ORDER BY x::UInt32 LIMIT 1000000000
 );
-499999500000
+4999950000
 SELECT sum(y) FROM
 (
     SELECT y FROM test_nullable_sorting_key_order_by ORDER BY x::Nullable(UInt32) LIMIT 1000000000
 );
-499999500000
+4999950000

--- a/tests/queries/0_stateless/04002_cast_nullable_read_in_order.sql
+++ b/tests/queries/0_stateless/04002_cast_nullable_read_in_order.sql
@@ -4,7 +4,7 @@ SET optimize_read_in_order = 1;
 
 DROP TABLE IF EXISTS test_nullable_order_by;
 CREATE TABLE test_nullable_order_by (x UInt32, y UInt32) ENGINE=MergeTree ORDER BY x;
-INSERT INTO test_nullable_order_by SELECT number, number FROM numbers(1e6);
+INSERT INTO test_nullable_order_by SELECT number, number FROM numbers(1e5);
 
 SELECT sum(y) FROM
 (
@@ -46,7 +46,7 @@ LIMIT 10;
 
 DROP TABLE IF EXISTS test_nullable_sorting_key_order_by;
 CREATE TABLE test_nullable_sorting_key_order_by (x UInt32, y UInt32) ENGINE=MergeTree ORDER BY x::Nullable(UInt32) SETTINGS allow_nullable_key = 1;
-INSERT INTO test_nullable_sorting_key_order_by SELECT number, number FROM numbers(1e6);
+INSERT INTO test_nullable_sorting_key_order_by SELECT number, number FROM numbers(1e5);
 
 SELECT sum(y) FROM
 (


### PR DESCRIPTION
Since the tables are bit big, if we get low index granularity via randomize setting, then it can become very slow. So, we keep the runtime bounded by making the size of the table smaller.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Closes https://github.com/ClickHouse/ClickHouse/issues/100221.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.84`
<!-- ch-version-info:end -->