### PR TITLE
Fix integration tests to be idempotent when re-run with --count

### DIFF
--- a/tests/integration/test_block_structure_mismatch/test.py
+++ b/tests/integration/test_block_structure_mismatch/test.py
@@ -49,6 +49,8 @@ CREATE TABLE dist_test (
 
 
 def test(started_cluster):
+    node1.query("TRUNCATE TABLE local_test")
+    node2.query("TRUNCATE TABLE local_test")
     node1.query(
         "INSERT INTO local_test (t, shard, col1, col2) VALUES (1000, 0, 'x', 'y')"
     )

--- a/tests/integration/test_group_array_element_size/test.py
+++ b/tests/integration/test_group_array_element_size/test.py
@@ -3,6 +3,11 @@ import pytest
 
 from helpers.cluster import ClickHouseCluster
 
+ORIGINAL_CONFIG = """<clickhouse>
+    <aggregate_function_group_array_max_element_size>10</aggregate_function_group_array_max_element_size>
+    <aggregate_function_group_array_action_when_limit_is_reached>throw</aggregate_function_group_array_action_when_limit_is_reached>
+</clickhouse>"""
+
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance(
     "node1",
@@ -29,6 +34,12 @@ def started_cluster():
 
 
 def test_max_exement_size(started_cluster):
+    # Restore original config in case a previous run left it modified.
+    node1.replace_config(
+        "/etc/clickhouse-server/config.d/group_array_max_element_size.xml",
+        ORIGINAL_CONFIG,
+    )
+    node1.restart_clickhouse()
     node1.query("DROP TABLE IF EXISTS tab3")
     node1.query(
         "CREATE TABLE tab3 (x AggregateFunction(groupArray, Array(UInt8))) ENGINE = MergeTree ORDER BY tuple()"
@@ -74,6 +85,12 @@ def test_max_exement_size(started_cluster):
 
 
 def test_limit_size(started_cluster):
+    # Restore original config in case a previous run left it modified.
+    node2.replace_config(
+        "/etc/clickhouse-server/config.d/group_array_max_element_size.xml",
+        ORIGINAL_CONFIG,
+    )
+    node2.restart_clickhouse()
     node2.query("DROP TABLE IF EXISTS tab4")
     node2.query(
         "CREATE TABLE tab4 (x AggregateFunction(groupArray, Array(UInt8))) ENGINE = MergeTree ORDER BY tuple()"

--- a/tests/integration/test_group_array_element_size/test.py
+++ b/tests/integration/test_group_array_element_size/test.py
@@ -29,6 +29,7 @@ def started_cluster():
 
 
 def test_max_exement_size(started_cluster):
+    node1.query("DROP TABLE IF EXISTS tab3")
     node1.query(
         "CREATE TABLE tab3 (x AggregateFunction(groupArray, Array(UInt8))) ENGINE = MergeTree ORDER BY tuple()"
     )
@@ -73,6 +74,7 @@ def test_max_exement_size(started_cluster):
 
 
 def test_limit_size(started_cluster):
+    node2.query("DROP TABLE IF EXISTS tab4")
     node2.query(
         "CREATE TABLE tab4 (x AggregateFunction(groupArray, Array(UInt8))) ENGINE = MergeTree ORDER BY tuple()"
     )

--- a/tests/integration/test_replication_credentials/test.py
+++ b/tests/integration/test_replication_credentials/test.py
@@ -45,6 +45,8 @@ def same_credentials_cluster():
 
 
 def test_same_credentials(same_credentials_cluster):
+    node1.query("TRUNCATE TABLE test_table")
+    node2.query("SYSTEM SYNC REPLICA test_table", timeout=10)
     node1.query("insert into test_table values ('2017-06-16', 111, 0)")
     time.sleep(1)
 
@@ -84,6 +86,8 @@ def no_credentials_cluster():
 
 
 def test_no_credentials(no_credentials_cluster):
+    node3.query("TRUNCATE TABLE test_table")
+    node4.query("SYSTEM SYNC REPLICA test_table", timeout=10)
     node3.query("insert into test_table values ('2017-06-18', 111, 0)")
     time.sleep(1)
 
@@ -123,6 +127,8 @@ def different_credentials_cluster():
 
 
 def test_different_credentials(different_credentials_cluster):
+    node5.query("TRUNCATE TABLE test_table")
+    node6.query("TRUNCATE TABLE test_table")
     node5.query("insert into test_table values ('2017-06-20', 111, 0)")
     time.sleep(1)
 
@@ -188,6 +194,8 @@ def credentials_and_no_credentials_cluster():
 
 
 def test_credentials_and_no_credentials(credentials_and_no_credentials_cluster):
+    node7.query("TRUNCATE TABLE test_table")
+    node8.query("TRUNCATE TABLE test_table")
     node7.query("insert into test_table values ('2017-06-21', 111, 0)")
     time.sleep(1)
 

--- a/tests/integration/test_replication_credentials/test.py
+++ b/tests/integration/test_replication_credentials/test.py
@@ -4,13 +4,23 @@ import pytest
 
 from helpers.cluster import ClickHouseCluster
 
+ORIGINAL_CREDENTIALS1 = """
+<clickhouse>
+    <interserver_http_port>9009</interserver_http_port>
+    <interserver_http_credentials>
+        <user>admin</user>
+        <password>222</password>
+    </interserver_http_credentials>
+</clickhouse>
+"""
+
 
 def _fill_nodes(nodes, shard):
     for node in nodes:
         node.query(
             """
-                CREATE DATABASE test;
-                CREATE TABLE test_table(date Date, id UInt32, dummy UInt32)
+                CREATE DATABASE IF NOT EXISTS test;
+                CREATE TABLE IF NOT EXISTS test_table(date Date, id UInt32, dummy UInt32)
                 ENGINE = ReplicatedMergeTree('/clickhouse/tables/test{shard}/replicated', '{replica}') PARTITION BY toYYYYMM(date) ORDER BY id;
             """.format(
                 shard=shard, replica=node.name
@@ -127,6 +137,11 @@ def different_credentials_cluster():
 
 
 def test_different_credentials(different_credentials_cluster):
+    # Restore original credentials config in case a previous run modified it.
+    node5.replace_config(
+        "/etc/clickhouse-server/config.d/credentials1.xml", ORIGINAL_CREDENTIALS1
+    )
+    node5.query("SYSTEM RELOAD CONFIG")
     node5.query("TRUNCATE TABLE test_table")
     node6.query("TRUNCATE TABLE test_table")
     node5.query("insert into test_table values ('2017-06-20', 111, 0)")
@@ -194,6 +209,11 @@ def credentials_and_no_credentials_cluster():
 
 
 def test_credentials_and_no_credentials(credentials_and_no_credentials_cluster):
+    # Restore original credentials config in case a previous run modified it.
+    node7.replace_config(
+        "/etc/clickhouse-server/config.d/credentials1.xml", ORIGINAL_CREDENTIALS1
+    )
+    node7.query("SYSTEM RELOAD CONFIG")
     node7.query("TRUNCATE TABLE test_table")
     node8.query("TRUNCATE TABLE test_table")
     node7.query("insert into test_table values ('2017-06-21', 111, 0)")

--- a/tests/integration/test_version_update/test.py
+++ b/tests/integration/test_version_update/test.py
@@ -68,6 +68,7 @@ def start_cluster():
 
 
 def test_modulo_partition_key_issue_23508(start_cluster):
+    node2.query("DROP TABLE IF EXISTS test")
     node2.query(
         "CREATE TABLE test (id Int64, v UInt64, value String) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/table1', '1', v) PARTITION BY id % 20 ORDER BY (id, v)"
     )

--- a/tests/integration/test_version_update/test.py
+++ b/tests/integration/test_version_update/test.py
@@ -68,7 +68,7 @@ def start_cluster():
 
 
 def test_modulo_partition_key_issue_23508(start_cluster):
-    node2.query("DROP TABLE IF EXISTS test")
+    node2.query("DROP TABLE IF EXISTS test SYNC")
     node2.query(
         "CREATE TABLE test (id Int64, v UInt64, value String) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/tables/table1', '1', v) PARTITION BY id % 20 ORDER BY (id, v)"
     )


### PR DESCRIPTION
The targeted CI job re-runs previously failed tests with `--count 10`. These tests were not idempotent:

- `test_replication_credentials`: data accumulated across re-runs because tables were never truncated. Add `TRUNCATE TABLE` at the start of each test function.

- `test_block_structure_mismatch`: same issue — duplicate rows from repeated inserts. Add `TRUNCATE TABLE` before inserting.

- `test_version_update`: `CREATE TABLE test` failed with "Table already exists" on the second run. Add `DROP TABLE IF EXISTS` before creating.

- `test_group_array_element_size`: same — `tab3` and `tab4` not dropped between runs. Add `DROP TABLE IF EXISTS` before creating.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.85`
<!-- ch-version-info:end -->