### PR TITLE
Fix timeout in 01731_async_task_queue_wait test

### DIFF
--- a/ci/jobs/scripts/check_style/various_checks.sh
+++ b/ci/jobs/scripts/check_style/various_checks.sh
@@ -191,10 +191,14 @@ find $ROOT_PATH/tests/queries -name '*.sh' |
 # Check for timeout with --signal but without --kill-after in .sh tests.
 # Without --kill-after, if the process ignores the signal, timeout hangs
 # indefinitely, causing the test to hit the hard timeout limit.
-find $ROOT_PATH/tests/queries -name '*.sh' -print0 |
-    xargs -0 grep -l -P 'timeout\s+.*(-s|--signal)[\s=]' |
-    xargs grep -LP 'kill-after' &&
-    echo "Tests using 'timeout --signal' must also use '--kill-after' to ensure the process is killed if it ignores the signal"
+tests_with_timeout_signal=( $(
+    find $ROOT_PATH/tests/queries -name '*.sh' -print0 |
+        xargs -0 grep -lP 'timeout\s+.*(-s|--signal)[\s=]' |
+        sort -u
+) )
+for test_case in "${tests_with_timeout_signal[@]}"; do
+    grep -qP 'kill-after' "$test_case" || echo "Test using 'timeout --signal' without '--kill-after' will hang if the process ignores the signal: $test_case"
+done
 
 find $ROOT_PATH/tests/queries -iname '*.sql' -or -iname '*.sh' -or -iname '*.py' -or -iname '*.j2' | xargs grep --with-filename -i -E -e 'system\s*flush\s*logs\s*(;|$|")' && echo "Please use SYSTEM FLUSH LOGS log_name over global SYSTEM FLUSH LOGS"
 

--- a/ci/jobs/scripts/check_style/various_checks.sh
+++ b/ci/jobs/scripts/check_style/various_checks.sh
@@ -188,6 +188,14 @@ find $ROOT_PATH/tests/queries -name '*.sh' |
     xargs grep -l -F 'timeout' &&
     echo ".sh tests cannot use the 'timeout' command, because it leads to race conditions, when the timeout is expired, and waiting for the command is done, but the server still runs some queries"
 
+# Check for timeout with --signal but without --kill-after in .sh tests.
+# Without --kill-after, if the process ignores the signal, timeout hangs
+# indefinitely, causing the test to hit the hard timeout limit.
+find $ROOT_PATH/tests/queries -name '*.sh' -print0 |
+    xargs -0 grep -l -P 'timeout\s+.*(-s|--signal)[\s=]' |
+    xargs grep -LP 'kill-after' &&
+    echo "Tests using 'timeout --signal' must also use '--kill-after' to ensure the process is killed if it ignores the signal"
+
 find $ROOT_PATH/tests/queries -iname '*.sql' -or -iname '*.sh' -or -iname '*.py' -or -iname '*.j2' | xargs grep --with-filename -i -E -e 'system\s*flush\s*logs\s*(;|$|")' && echo "Please use SYSTEM FLUSH LOGS log_name over global SYSTEM FLUSH LOGS"
 
 # Tests with SYSTEM DROP should have no-parallel tag, because SYSTEM DROP commands

--- a/tests/queries/0_stateless/01731_async_task_queue_wait.sh
+++ b/tests/queries/0_stateless/01731_async_task_queue_wait.sh
@@ -7,4 +7,4 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # regression for 'Empty task was returned from async task queue' during query
 # cancellation with async_socket_for_remote=1 (that ignores
 # max_distributed_connections)
-timeout --signal=SIGINT 1 ${CLICKHOUSE_CLIENT} --max_distributed_connections=1 --max_block_size=2  --interactive_delay=900000 -q "select number + sleep(0.3) as x from remote('127.{2,3}', system.numbers) settings max_block_size = 2" 2>&1 | grep "Empty task was returned from async task queue" || true
+timeout --signal=SIGINT --kill-after=5 1 ${CLICKHOUSE_CLIENT} --max_distributed_connections=1 --max_block_size=2  --interactive_delay=900000 -q "select number + sleep(0.3) as x from remote('127.{2,3}', system.numbers) settings max_block_size = 2" 2>&1 | grep "Empty task was returned from async task queue" || true

--- a/tests/queries/0_stateless/02357_query_cancellation_race.sh
+++ b/tests/queries/0_stateless/02357_query_cancellation_race.sh
@@ -6,4 +6,4 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CURDIR"/../shell_config.sh
 
 $CLICKHOUSE_CLIENT -q "create table tab (x UInt64, y String) engine = MergeTree order by x"
-for _ in $(seq 1 100); do timeout -s 2 0.05 $CLICKHOUSE_CLIENT --interactive_delay 1000 -q "insert into tab select number, toString(number) from system.numbers" || true; done
+for _ in $(seq 1 100); do timeout -s 2 --kill-after=5 0.05 $CLICKHOUSE_CLIENT --interactive_delay 1000 -q "insert into tab select number, toString(number) from system.numbers" || true; done


### PR DESCRIPTION
The test `01731_async_task_queue_wait` uses `timeout --signal=SIGINT 1` to cancel a `clickhouse-client` query after 1 second. In `parallel_replicas_local_plan` mode, the client doesn't terminate promptly after SIGINT. Without `--kill-after`, `timeout` waits indefinitely for the child to exit, keeping the pipe open, so the downstream `grep` also hangs until the 600s hard timeout.

Add `--kill-after=5` so the client receives SIGKILL if it doesn't exit within 5 seconds of SIGINT.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=419710e57d5762ef5612720949ca432415cef444&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_asan_ubsan%2C%20distributed%20plan%2C%20parallel%2C%201%2F2%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.89`
<!-- ch-version-info:end -->