### PR TITLE
Fix flaky `03100_lwu_01_basics`

### DIFF
--- a/tests/queries/0_stateless/03100_lwu_01_basics.sql
+++ b/tests/queries/0_stateless/03100_lwu_01_basics.sql
@@ -12,7 +12,8 @@ ENGINE = ReplicatedMergeTree('/zookeeper/{database}/t_shared/', '1')
 ORDER BY id
 SETTINGS
     enable_block_number_column = true,
-    enable_block_offset_column = true;
+    enable_block_offset_column = true,
+    remove_unused_patch_parts = false;
 
 INSERT INTO t_shared SELECT number, number, number FROM numbers(20);
 INSERT INTO t_shared SELECT number, number, number FROM numbers(100, 10);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Test expects patch part `patch-4811bd937f1be8e9d5ec5374e149fefa-all_0_0_0_2` will be alive after `ALTER TABLE t_shared APPLY PATCHES` but there is a background process that will replace unused patch parts (that were applied to parts) with covering. 

So sometimes there can be this output https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100064&sha=4d7cfd8dc0a4b979804be98e83bb36ff338b29cc&name_0=PR&name_1=Stateless%20tests%20%28amd_asan_ubsan%2C%20distributed%20plan%2C%20parallel%2C%202%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/100064

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.86`
<!-- ch-version-info:end -->