### PR TITLE
Use `ld64.lld` (LLVM's Mach-O linker) for Darwin builds

### DIFF
--- a/cmake/tools.cmake
+++ b/cmake/tools.cmake
@@ -41,7 +41,7 @@ if (NOT LINKER_NAME)
     if (OS_LINUX AND NOT ARCH_S390X)
         ch_find_program (LLD_PATH NAMES "ld.lld-${COMPILER_VERSION_MAJOR}" "ld.lld")
     elseif (OS_DARWIN)
-        ch_find_program (LLD_PATH NAMES "ld")
+        ch_find_program (LLD_PATH NAMES "ld64.lld-${COMPILER_VERSION_MAJOR}" "ld64.lld" "ld")
         # Duplicate libraries passed to the linker is not a problem.
         set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-no_warn_duplicate_libraries")
     endif ()


### PR DESCRIPTION
Prefer `ld64.lld` over Apple's `ld` (cctools-port ld64) for macOS builds. This should significantly reduce Darwin link times, as cctools-port's ld64 is very slow with `-ffunction-sections` and `-dead_strip`. Falls back to `ld` if `ld64.lld` is not available.

Works for both native macOS builds and cross-compiled builds from Linux.

https://github.com/ClickHouse/ClickHouse/pull/99474#issuecomment-4090210166

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Prefer `ld64.lld` over Apple's `ld` (cctools-port ld64) for macOS builds. This should significantly reduce Darwin link times, as cctools-port's ld64 is very slow with `-ffunction-sections` and `-dead_strip`. Falls back to `ld` if `ld64.lld` is not available.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.87`
<!-- ch-version-info:end -->