### PR TITLE
Unpoison fiber stack before each resume to fix ASan false positives

### DIFF
--- a/src/Common/AsyncTaskExecutor.cpp
+++ b/src/Common/AsyncTaskExecutor.cpp
@@ -42,6 +42,9 @@ void AsyncTaskExecutor::resume()
 
 void AsyncTaskExecutor::resumeUnlocked()
 {
+    /// Clear stale use-after-scope poisoning on the fiber stack before switching to it.
+    /// See FiberStack::beforeResume() for details.
+    fiber_stack.beforeResume();
     fiber.resume();
 }
 

--- a/src/Common/FiberStack.cpp
+++ b/src/Common/FiberStack.cpp
@@ -43,7 +43,7 @@ FiberStack::FiberStack(size_t stack_size_)
 {
 }
 
-boost::context::stack_context FiberStack::allocate() const
+boost::context::stack_context FiberStack::allocate()
 {
     size_t num_pages = 1 + (stack_size - 1) / page_size;
 
@@ -71,6 +71,10 @@ boost::context::stack_context FiberStack::allocate() const
             throw;
         }
     }
+
+    /// Remember the allocation for ASan unpoisoning in beforeResume().
+    stack_base = data;
+    stack_allocation_size = num_bytes;
 
     boost::context::stack_context sctx;
     sctx.size = num_bytes;

--- a/src/Common/FiberStack.h
+++ b/src/Common/FiberStack.h
@@ -1,5 +1,11 @@
 #pragma once
 #include <boost/context/stack_context.hpp>
+#include <base/sanitizer_defs.h>
+#include <cstddef>
+
+#if __has_include(<sanitizer/asan_interface.h>) && defined(ADDRESS_SANITIZER)
+#   include <sanitizer/asan_interface.h>
+#endif
 
 /// This is an implementation of allocator for fiber stack.
 /// The reference implementation is protected_fixedsize_stack from boost::context.
@@ -16,10 +22,31 @@ public:
 
     explicit FiberStack(size_t stack_size_ = default_stack_size);
 
-    boost::context::stack_context allocate() const;
+    boost::context::stack_context allocate();
     void deallocate(boost::context::stack_context & sctx) const;
+
+    /// Unpoison the fiber stack memory for ASan.
+    ///
+    /// ASan's use-after-scope detection poisons stack memory when local variables
+    /// go out of scope. On fiber stacks, this poisoning persists across context
+    /// switches (yield/resume), causing false positives when the same stack addresses
+    /// are reused by new frames in subsequent fiber resumes.
+    ///
+    /// This must be called before each fiber resume to clear stale scope poisoning.
+    /// See https://github.com/google/sanitizers/issues/189
+    void beforeResume() const
+    {
+#if defined(ADDRESS_SANITIZER)
+        if (stack_base)
+            ASAN_UNPOISON_MEMORY_REGION(stack_base, stack_allocation_size);
+#endif
+    }
 
 private:
     const size_t stack_size;
     const size_t page_size;
+
+    /// Tracked allocation for ASan unpoisoning.
+    void * stack_base = nullptr;
+    size_t stack_allocation_size = 0;
 };


### PR DESCRIPTION
ASan's `use-after-scope` detection poisons real stack memory when local variables go out of scope. On fiber stacks managed by `makecontext`/`swapcontext`, this poisoning persists across context switches (yield/resume), causing false positives when the same stack addresses are reused by new frames in subsequent fiber resumes — notably during exception unwinding in `_Unwind_Resume`.

The fix: call `ASAN_UNPOISON_MEMORY_REGION` on the entire fiber stack before each `Fiber::resume`, clearing any stale scope poisoning. This is complementary to the `__sanitizer_start_switch_fiber` / `__sanitizer_finish_switch_fiber` annotations in boost::context, which only manage the fake stack (for use-after-return), not real stack poisoning (for use-after-scope).

See https://github.com/google/sanitizers/issues/189

Example failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100041&sha=e3d5fc0647f84f316414376a48aa9ffbf8565b07&name_0=PR&name_1=AST%20fuzzer%20%28arm_asan_ubsan%29
https://github.com/ClickHouse/ClickHouse/pull/100041

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.95`
<!-- ch-version-info:end -->