### PR TITLE
Fix debug assertion in DDLWorker::scheduleTasks during reinitialization

### DIFF
--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -331,6 +331,10 @@ void DDLWorker::scheduleTasks(bool reinitialized)
     /// NOTE: It does not protect from all cases of query duplication, see also comments in processTask(...)
     if (reinitialized)
     {
+        /// We are reloading the queue after connection loss, so reset the flag.
+        /// It will be set back to true once we successfully initialize a new task.
+        queue_fully_loaded_after_initialization_debug_helper = false;
+
         if (current_tasks.empty())
             LOG_TRACE(log, "Don't have unfinished tasks after restarting");
         else
@@ -466,6 +470,14 @@ void DDLWorker::scheduleTasks(bool reinitialized)
         {
             /// If connection was lost during queue loading
             /// we may start processing from finished task (because we don't know yet that it's finished) and it's ok.
+            return false;
+        }
+
+        if (first_failed_task_name.has_value())
+        {
+            /// During reinitialization, begin_node is moved back to first_failed_task_name.
+            /// With parallel execution, tasks after first_failed_task_name may already be
+            /// completed or still in current_tasks — that's expected, not a violation.
             return false;
         }
 


### PR DESCRIPTION
Fix debug assertion in `DDLWorker::scheduleTasks` during reinitialization with parallel DDL execution.

When DDLWorker reinitializes after ZooKeeper connection loss, `first_failed_task_name` moves `begin_node` back to an earlier queue position. With parallel execution, tasks after that point may already be completed or still in `current_tasks` from the previous session. The debug assertion flags these as violations because it expects entries >= `begin_node` to be neither processed nor in-progress.

Two fixes:
- Reset `queue_fully_loaded_after_initialization_debug_helper` on reinitialization so the existing relaxation for connection-loss scenarios applies correctly.
- Add explicit relaxation for entries >= `begin_node` when `first_failed_task_name` is set, since we deliberately moved the start position backward and completed/in-progress entries are expected.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=fabf54f4172f1c410ef70a7a69641e578f4a422d&name_0=MasterCI&name_1=BuzzHouse%20%28amd_msan%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.96`
<!-- ch-version-info:end -->