### PR TITLE
Validate Iceberg metadata file path for null bytes

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -1143,6 +1143,8 @@ MetadataFileWithInfo getLatestOrExplicitMetadataFileAndVersion(
     if (data_lake_settings[DataLakeStorageSetting::iceberg_metadata_file_path].changed)
     {
         auto explicit_metadata_path = data_lake_settings[DataLakeStorageSetting::iceberg_metadata_file_path].value;
+        if (explicit_metadata_path.find('\0') != String::npos)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Iceberg metadata file path contains a null byte");
         LOG_TEST(log, "Explicit metadata file path is specified {}, will read from this metadata file", explicit_metadata_path);
         std::filesystem::path p(explicit_metadata_path);
         auto it = p.begin();

--- a/tests/integration/test_storage_iceberg_with_spark/test_metadata_file_path_security.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_metadata_file_path_security.py
@@ -50,7 +50,7 @@ def test_metadata_file_path_security(started_cluster_iceberg_with_spark):
         )
 
     # Test 2: Null byte injection should be rejected
-    with pytest.raises(Exception, match = "ICEBERG_SPECIFICATION_VIOLATION"):
+    with pytest.raises(Exception, match = "BAD_ARGUMENTS"):
         create_iceberg_table(
             "local",
             instance,
@@ -60,7 +60,7 @@ def test_metadata_file_path_security(started_cluster_iceberg_with_spark):
         )
 
     # Test 3: Null byte in middle of path should be rejected
-    with pytest.raises(Exception, match = "PATH_ACCESS_DENIED"):
+    with pytest.raises(Exception, match = "BAD_ARGUMENTS"):
         create_iceberg_table(
             "local",
             instance,


### PR DESCRIPTION
A null byte in the `iceberg_metadata_file_path` setting causes `std::length_error` in filesystem path operations. Since `std::length_error` is a `std::logic_error`, the exception handler in `executeQuery.cpp` treats it as a logical error and aborts the server in debug/sanitizer builds.

Reject paths containing null bytes with a proper `BAD_ARGUMENTS` exception instead.

Closes https://github.com/ClickHouse/ClickHouse/issues/96811
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100176&sha=32a8de2243259ca5c69f22e0599aa41189972a69&name_0=PR&name_1=AST%20fuzzer%20%28amd_tsan%29
https://github.com/ClickHouse/ClickHouse/pull/100176

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix exception when Iceberg metadata file path setting contains a null byte.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.110` (included in `26.4` and later)
- Backported to: `26.3.21.5`, `25.8.33.4`
<!-- ch-version-info:end -->