### PR TITLE
Fix flaky test_kafka_formats_with_broken_message integration test

### DIFF
--- a/tests/integration/test_storage_kafka/test_batch_slow_0.py
+++ b/tests/integration/test_storage_kafka/test_batch_slow_0.py
@@ -383,13 +383,16 @@ def test_kafka_formats_with_broken_message(kafka_cluster, create_query_generator
         assert TSV(result) == TSV(expected), "Proper result for format: {}".format(
             format_name
         )
-        errors_result = json.loads(
-            instance.query(
-                "SELECT raw_message, error FROM test.kafka_errors_{format_name}_mv format JSONEachRow".format(
-                    format_name=format_name
-                )
-            )
+        errors_query = "SELECT raw_message, error FROM test.kafka_errors_{format_name}_mv FORMAT JSONEachRow".format(
+            format_name=format_name
         )
+        errors_text = instance.query_with_retry(
+            errors_query,
+            retry_count=30,
+            sleep_time=1,
+            check_callback=lambda res: len(res) > 0,
+        )
+        errors_result = json.loads(errors_text)
         # print(errors_result.strip())
         # print(errors_expected.strip())
         assert (


### PR DESCRIPTION
Fix flaky `test_kafka_formats_with_broken_message` by waiting for the error row to appear in the materialized view before querying it.

The test waited for data rows via `query_with_retry`, but then queried `kafka_errors_*_mv` directly without retry. If the error row hadn't been flushed yet, the query returned an empty string, causing `json.loads("")` to throw `JSONDecodeError`.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100115&sha=bc88afbf7346646c37befae5ead1fe4c906f33e1&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%201%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/100115

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.94`
<!-- ch-version-info:end -->