### PR TITLE
Treat dependabot PRs as not for changelog

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/pr_body_check.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_body_check.py
@@ -2,6 +2,7 @@ import re
 import sys
 
 from ci.jobs.scripts.workflow_hooks.pr_labels_and_category import (
+    BOT_AUTHORS,
     NO_CHANGELOG_REQUIRED_LABELS,
     find_category,
     get_category,
@@ -71,6 +72,12 @@ if __name__ == "__main__":
 
     if "release" in labels or "release-lts" in labels:
         print("NOTE: Release PR detected, skipping changelog entry check")
+        sys.exit(0)
+
+    if Info().user_name in BOT_AUTHORS:
+        print(
+            f"NOTE: PR by bot author '{Info().user_name}', skipping changelog entry check"
+        )
         sys.exit(0)
 
     error, category = get_category(body)

--- a/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
@@ -271,13 +271,22 @@ def check_labels(category, info):
         info.remove_pr_label(label)
 
 
+BOT_AUTHORS = {"dependabot[bot]"}
+
+
 if __name__ == "__main__":
     info = Info()
     if Labels.RELEASE in info.pr_labels or Labels.RELEASE_LTS in info.pr_labels:
         print("NOTE: Release PR detected, skipping changelog category check")
         sys.exit(0)
-    error, category = get_category(info.pr_body)
-    if not category or error:
-        print(f"ERROR: {error}")
-        sys.exit(1)
+    if info.user_name in BOT_AUTHORS:
+        print(
+            f"NOTE: PR by bot author '{info.user_name}', treating as 'Not for changelog'"
+        )
+        category = LABEL_CATEGORIES["pr-not-for-changelog"][0]
+    else:
+        error, category = get_category(info.pr_body)
+        if not category or error:
+            print(f"ERROR: {error}")
+            sys.exit(1)
     check_labels(category, info)

--- a/tests/ci/changelog.py
+++ b/tests/ci/changelog.py
@@ -120,6 +120,8 @@ def _match_changelog_category(category: str) -> Optional[str]:
     return best_match
 
 
+BOT_AUTHORS = {"dependabot[bot]"}
+
 FROM_REF = ""
 TO_REF = ""
 SHA_IN_CHANGELOG = []  # type: List[str]
@@ -300,6 +302,14 @@ def generate_description(item: PullRequest, repo: Repository) -> Optional[Descri
                 item.head.ref,
                 item.number,
             )
+    # Skip PRs by bot authors (e.g., dependabot)
+    # pylint: disable=protected-access
+    user_login = item.user._rawData["login"]
+    # pylint: enable=protected-access
+    if user_login in BOT_AUTHORS:
+        logging.info("Skipping PR %s by bot author '%s'", item.number, user_login)
+        return None
+
     description = item.body
     # Don't skip empty lines because they delimit parts of description
     lines = [x.strip() for x in (description.split("\n") if description else [])]


### PR DESCRIPTION
Dependabot PRs (like https://github.com/ClickHouse/ClickHouse/pull/100254) don't follow the PR template and lack a changelog category, causing CI checks to fail. This PR detects `dependabot[bot]` as the PR author and automatically treats these PRs as "Not for changelog" in three places:

- `pr_labels_and_category` — assigns `pr-not-for-changelog` label instead of parsing the PR body
- `pr_body_check` — skips changelog entry validation
- `tests/ci/changelog.py` — excludes from generated changelog

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.105`
<!-- ch-version-info:end -->