### PR TITLE
Fix AST fuzzer old_compatibility mode conflicting with enable_analyzer constraint

### DIFF
--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -144,12 +144,15 @@ def run_fuzz_job(check_name: str):
     compatibility_setting: str | None = None
     if not buzzhouse:
         if is_old_compatibility:
-            compatibility_setting = "22.1"
+            # The minimum version is 24.3 because that's when enable_analyzer
+            # became enabled by default, and the fuzzer has a readonly constraint
+            # on enable_analyzer to avoid wasting cycles on the old interpreter.
+            compatibility_setting = "24.3"
         elif is_targeted:
             compatibility_setting = None
         else:
             compatibility_setting = (
-                f"{random.randint(22, 27)}.{random.randint(1, 12)}"
+                f"{random.randint(24, 27)}.{random.randint(1, 12)}"
             )
         if compatibility_setting:
             logging.info("AST fuzzer compatibility setting: %s", compatibility_setting)


### PR DESCRIPTION
The fuzzer config has a readonly constraint on `enable_analyzer` to avoid wasting cycles on the old interpreter. But `--compatibility=22.1` tries to set `allow_experimental_analyzer=0` (the analyzer didn't exist in 22.1), which hits that constraint and fails every run.

The analyzer was enabled by default in version 24.3, so use that as the minimum compatibility version. Also bump the random range for the regular (non-old_compatibility) fuzzer from 22-27 to 24-27 for the same reason.

Example failure: https://github.com/ClickHouse/ClickHouse/pull/100210 — the "AST fuzzer (amd_debug, targeted, old_compatibility)" check fails with `SETTING_CONSTRAINT_VIOLATION: Setting allow_experimental_analyzer should not be changed`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.107`
<!-- ch-version-info:end -->