### PR TITLE
Fix fork deadlock in uexpect causing test_interactive_totp_authentication timeout

### DIFF
--- a/tests/integration/helpers/uexpect.py
+++ b/tests/integration/helpers/uexpect.py
@@ -109,6 +109,7 @@ class IO(object):
             self.process.terminate()
         self.process.wait()
         os.close(self.master)
+        self.reader["thread"].join(timeout=5)
         if self._logger:
             self._logger.write("\n")
             self._logger.flush()
@@ -189,7 +190,7 @@ def spawn(command):
     master, slave = pty.openpty()
     process = Popen(
         command,
-        preexec_fn=os.setsid,
+        start_new_session=True,
         stdout=slave,
         stdin=slave,
         stderr=slave,


### PR DESCRIPTION
Fix fork deadlock in `uexpect` that caused `test_interactive_totp_authentication` to hang for 900s under MSan.

The test spawns 10 sequential interactive client sessions via pty. After 4 sessions completed, the 5th hung at `Popen` (stuck at `os.read(errpipe_read)`) because `preexec_fn=os.setsid` forces Python to use fork+exec, and leftover reader daemon threads (never joined) caused a multi-threaded fork deadlock.

Two fixes:
1. Replace `preexec_fn=os.setsid` with `start_new_session=True` — avoids forcing the slow fork path
2. Join the reader thread in `IO.close` to ensure cleanup before the next session

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100290&sha=55b637c00a57c55412341f944e3d40154b1d635f&name_0=PR&name_1=Integration%20tests%20%28amd_msan%2C%203%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/100290

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.112`
<!-- ch-version-info:end -->