### PR TITLE
Fix flaky test 04051_top_k_dynamic_filter_read_in_order

### DIFF
--- a/tests/queries/0_stateless/04051_top_k_dynamic_filter_read_in_order.sql
+++ b/tests/queries/0_stateless/04051_top_k_dynamic_filter_read_in_order.sql
@@ -13,7 +13,7 @@ INSERT INTO t_topk_rio SELECT number, toString(number) FROM numbers(1000000);
 
 -- Correctness: results must match regardless of dynamic filtering.
 SELECT x FROM t_topk_rio ORDER BY x LIMIT 5
-SETTINGS optimize_read_in_order = 1, use_top_k_dynamic_filtering = 1;
+SETTINGS optimize_read_in_order = 1, use_top_k_dynamic_filtering = 1, query_plan_max_limit_for_top_k_optimization = 100;
 
 -- The query plan should NOT contain __topKFilter when read-in-order is active
 -- on the sorting key prefix.
@@ -21,7 +21,7 @@ SELECT explain LIKE '%__topKFilter%' AS has_topk_filter
 FROM (
     EXPLAIN actions = 1
     SELECT x FROM t_topk_rio ORDER BY x LIMIT 5
-    SETTINGS optimize_read_in_order = 1, use_top_k_dynamic_filtering = 1
+    SETTINGS optimize_read_in_order = 1, use_top_k_dynamic_filtering = 1, query_plan_max_limit_for_top_k_optimization = 100
 )
 WHERE has_topk_filter;
 
@@ -33,7 +33,7 @@ SELECT read_rows < 100000
 FROM system.query_log
 WHERE
     current_database = currentDatabase()
-    AND query LIKE '%SELECT x FROM t_topk_rio ORDER BY x LIMIT 5%'
+    AND query LIKE 'SELECT x FROM t_topk_rio ORDER BY x LIMIT 5%'
     AND query NOT LIKE '%system.query_log%'
     AND type = 'QueryFinish'
 ORDER BY event_time_microseconds DESC
@@ -45,7 +45,7 @@ SELECT count() > 0 AS has_topk_filter
 FROM (
     EXPLAIN actions = 1
     SELECT y FROM t_topk_rio ORDER BY y LIMIT 5
-    SETTINGS optimize_read_in_order = 1, use_top_k_dynamic_filtering = 1
+    SETTINGS optimize_read_in_order = 1, use_top_k_dynamic_filtering = 1, query_plan_max_limit_for_top_k_optimization = 100
 )
 WHERE explain LIKE '%__topKFilter%';
 

--- a/tests/queries/0_stateless/04051_top_k_dynamic_filter_read_in_order.sql
+++ b/tests/queries/0_stateless/04051_top_k_dynamic_filter_read_in_order.sql
@@ -33,8 +33,9 @@ SELECT read_rows < 100000
 FROM system.query_log
 WHERE
     current_database = currentDatabase()
-    AND query LIKE 'SELECT x FROM t_topk_rio ORDER BY x LIMIT 5%'
+    AND query LIKE '%SELECT x FROM t_topk_rio ORDER BY x LIMIT 5%'
     AND query NOT LIKE '%system.query_log%'
+    AND query NOT LIKE '%EXPLAIN%'
     AND type = 'QueryFinish'
 ORDER BY event_time_microseconds DESC
 LIMIT 1;


### PR DESCRIPTION
The test was sensitive to randomized `query_plan_max_limit_for_top_k_optimization` setting. When the fuzzer set it to `1`, the TopK optimization was skipped entirely (`LIMIT 5 > 1`), causing the last check (`__topKFilter` present for non-key `ORDER BY`) to fail.

Pin `query_plan_max_limit_for_top_k_optimization = 100` in all queries that depend on TopK behavior.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100177&sha=f5fa99b4c1cf1987201784ccbe12b8147bc25c8b&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/100177

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.113`
<!-- ch-version-info:end -->