### PR TITLE
introduce ISystemLogFlushPolicy interface in SystemLog

### DIFF
--- a/src/Common/SystemLogBase.h
+++ b/src/Common/SystemLogBase.h
@@ -76,6 +76,9 @@ public:
     /// The flashed index is the index of the last log element which has been flushed successfully.
     /// Thereby all the records whose index is less than the flashed index are flushed already.
     virtual Index getLastLogIndex() = 0;
+    /// Notifies the implementation that a manual flush up to `target_index` was requested.
+    virtual void setManualFlushTargetIndex(Index /* target_index */) {}
+
     /// Call this method to wake up the flush thread and flush the data in the background. It is non blocking call
     virtual void notifyFlush(Index expected_flushed_index, bool should_prepare_tables_anyway) = 0;
     /// Call this method to wait until the logs are flushed up to expected_flushed_index. It is blocking call.

--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -59,6 +59,7 @@
 #include <Processors/Executors/PushingPipelineExecutor.h>
 #include <Storages/IStorage.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
+#include <Interpreters/SystemLogDefaultFlushPolicy.h>
 
 #if CLICKHOUSE_CLOUD
 #include <Interpreters/DistributedCacheLog.h>
@@ -528,8 +529,9 @@ SystemLog<LogElement>::SystemLog(
     , log(getLogger("SystemLog (" + settings_.queue_settings.database + "." + settings_.queue_settings.table + ")"))
     , table_id(settings_.queue_settings.database, settings_.queue_settings.table)
     , storage_def(settings_.engine)
-    , create_query(getCreateTableQuery()->formatWithSecretsOneLine())
+    , flush_policy(std::make_unique<DefaultSystemLogFlushPolicy>())
 {
+    create_query = getCreateTableQuery()->formatWithSecretsOneLine();
     assert(settings_.queue_settings.database == DatabaseCatalog::SYSTEM_DATABASE);
 }
 
@@ -589,6 +591,7 @@ void SystemLog<LogElement>::flushImpl(const std::vector<LogElement> & to_flush, 
     UInt64 execute_insert_time = 0;
     UInt64 confirm_time = 0;
     size_t flush_size = to_flush.size();
+    bool is_manual_flush = flush_policy->isManualFlush(to_flush_end);
 
     try
     {
@@ -654,11 +657,15 @@ void SystemLog<LogElement>::flushImpl(const std::vector<LogElement> & to_flush, 
         executor.start();
         executor.push(block);
         executor.finish();
+
+        flush_policy->afterFlush(io, is_manual_flush, flush_size);
         execute_insert_time = stopwatch.elapsedMilliseconds();
         stopwatch.restart();
     }
     catch (...)
     {
+        if (is_manual_flush)
+            flush_policy->cancelManualFlush();
         ProfileEvents::increment(ProfileEvents::SystemLogErrorOnFlush);
         tryLogCurrentException(__PRETTY_FUNCTION__, fmt::format("Failed to flush system log {} with {} entries up to offset {}",
             table_id.getNameForLogs(), to_flush.size(), to_flush_end));
@@ -784,6 +791,7 @@ void SystemLog<LogElement>::addSettingsForQuery(ContextMutablePtr & mutable_cont
     {
         /// We always want to deliver the data to the original table regardless of the MVs
         mutable_context->setSetting("materialized_views_ignore_errors", true);
+        flush_policy->addInsertSettings(mutable_context);
     }
     else if (query_kind == IAST::QueryKind::Rename)
     {
@@ -804,7 +812,10 @@ ASTPtr SystemLog<LogElement>::getCreateTableQuery()
     auto new_columns_list = make_intrusive<ASTColumns>();
     auto ordinary_columns = LogElement::getColumnsDescription();
     auto alias_columns = LogElement::getNamesAndAliases();
-    ordinary_columns.setAliases(alias_columns);
+    /// S3-backed engines do not support alias columns; `shouldSkipAliasColumns` returns
+    /// `true` for `SharedSystemLogFlushPolicy` and `false` for `DefaultSystemLogFlushPolicy`.
+    if (!flush_policy->shouldSkipAliasColumns())
+        ordinary_columns.setAliases(alias_columns);
 
     new_columns_list->set(new_columns_list->columns, InterpreterCreateQuery::formatColumns(ordinary_columns));
 

--- a/src/Interpreters/SystemLog.h
+++ b/src/Interpreters/SystemLog.h
@@ -10,6 +10,7 @@
 #include <Parsers/ParserCreateQuery.h>
 #include <Parsers/CommonParsers.h>
 
+#include <Interpreters/SystemLogFlushPolicy.h>
 #include <boost/noncopyable.hpp>
 
 #define LIST_OF_ALL_SYSTEM_LOGS(M) \
@@ -211,7 +212,12 @@ public:
       */
     void prepareTable() override;
 
-    const StorageID & getTableID() { return table_id; }
+    const StorageID & getTableID() const { return table_id; }
+
+    void setManualFlushTargetIndex(ISystemLog::Index target_index) override
+    {
+        flush_policy->prepareManualFlush(target_index);
+    }
 
 protected:
     LoggerPtr log;
@@ -227,7 +233,8 @@ private:
     /* Saving thread data */
     const StorageID table_id;
     const String storage_def;
-    const String create_query;
+    std::unique_ptr<ISystemLogFlushPolicy> flush_policy;
+    String create_query;
     String old_create_query;
     bool is_prepared = false;
 

--- a/src/Interpreters/SystemLogDefaultFlushPolicy.h
+++ b/src/Interpreters/SystemLogDefaultFlushPolicy.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <Interpreters/SystemLogFlushPolicy.h>
+
+namespace DB
+{
+
+/// Default implementation of `ISystemLogFlushPolicy`.
+class DefaultSystemLogFlushPolicy : public ISystemLogFlushPolicy
+{
+public:
+    bool isManualFlush(uint64_t /*to_flush_end*/) override { return false; }
+    void prepareManualFlush(uint64_t /*target_index*/) override {}
+    void afterFlush(const BlockIO & /*io*/, bool /*is_manual_flush*/, size_t /*flush_size*/) override {}
+    void addInsertSettings(ContextMutablePtr & /*context*/) override {}
+    bool shouldSkipAliasColumns() override { return false; }
+};
+
+}

--- a/src/Interpreters/SystemLogFlushPolicy.h
+++ b/src/Interpreters/SystemLogFlushPolicy.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <Interpreters/Context_fwd.h>
+#include <QueryPipeline/BlockIO.h>
+#include <base/types.h>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace DB
+{
+
+/// Interface that defines the flush behavior for system log tables.
+class ISystemLogFlushPolicy
+{
+public:
+    virtual ~ISystemLogFlushPolicy() = default;
+
+    /// Returns `true` when the flush at `to_flush_end` corresponds to an explicit
+    /// `SYSTEM FLUSH LOGS` command rather than a background periodic flush.
+    virtual bool isManualFlush(uint64_t to_flush_end) = 0;
+
+    /// Arms the engine for the next manual flush up to `target_index`.
+    virtual void prepareManualFlush(uint64_t target_index) = 0;
+
+    /// Called after the pipeline executor finishes writing `flush_size` rows.
+    /// `is_manual_flush` is true when triggered by `SYSTEM FLUSH LOGS`.
+    /// Implementations use this hook to track or wait for delivery.
+    virtual void afterFlush(const BlockIO & io, bool is_manual_flush, size_t flush_size) = 0;
+
+    /// Called when a flush fails with an exception before `afterFlush` could run.
+    /// Implementations should reset any state set by `prepareManualFlush`.
+    virtual void cancelManualFlush() {}
+
+    /// Injects engine-specific settings into the query context used for `INSERT` queries.
+    virtual void addInsertSettings(ContextMutablePtr & context) = 0;
+
+    /// Returns `true` when alias columns must be omitted from `CREATE TABLE` queries.
+    /// S3-backed engines do not support alias columns.
+    virtual bool shouldSkipAliasColumns() = 0;
+};
+
+}

--- a/src/Interpreters/SystemLogFlushPolicy.h
+++ b/src/Interpreters/SystemLogFlushPolicy.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <Interpreters/Context_fwd.h>
-#include <QueryPipeline/BlockIO.h>
 #include <base/types.h>
 
 #include <cstddef>
@@ -9,6 +8,8 @@
 
 namespace DB
 {
+
+struct BlockIO;
 
 /// Interface that defines the flush behavior for system log tables.
 class ISystemLogFlushPolicy


### PR DESCRIPTION
This PR is required for internal logging use case. It introduces `ISystemLogFlushPolicy`, an interface that abstracts flush behavior in `SystemLog`. This provides a clean extension point for future implementations without modifying SystemLog directly. `DefaultSystemLogFlushPolicy` is included as the base implementation (it preserves the current flush behavior).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.144`
<!-- ch-version-info:end -->