### PR TITLE
Fix flaky test `test_keeper_remove_rejoin_leader`

### DIFF
--- a/tests/integration/test_keeper_remove_rejoin_leader/test.py
+++ b/tests/integration/test_keeper_remove_rejoin_leader/test.py
@@ -242,6 +242,9 @@ def test_leader_election_after_rolling_membership_change(started_cluster):
     for n in remaining:
         keeper_utils.wait_until_connected(cluster, n, timeout=60.0)
 
+    # Re-discover the leader after the membership change.
+    leader = keeper_utils.get_leader(cluster, remaining)
+
     # Step 3: Add node5 to the cluster.  node1/3/4 are active at this point,
     # so node5 can connect to them during startup (async Keeper init).
     cfg5 = _get_generated_cfg(node_names, 5)
@@ -281,8 +284,12 @@ def test_leader_election_after_rolling_membership_change(started_cluster):
 
     time.sleep(2)
 
-    for n in [leader, node4, node5]:
+    active_nodes = [leader, node4, node5]
+    for n in active_nodes:
         keeper_utils.wait_until_connected(cluster, n, timeout=60.0)
+
+    # Re-discover the leader after the membership change.
+    leader = keeper_utils.get_leader(cluster, active_nodes)
 
     # Step 5: Add node6 to the cluster.  node1/4/5 are active at this point,
     # so node6 can connect to them during startup (async Keeper init).


### PR DESCRIPTION
Re-discover the Keeper leader after each membership change (remove member) before sending subsequent `rcfg` commands. After removing a follower, leadership can transfer to another node, causing `rcfg` sent to the old leader to fail with "Cannot reconfigure cluster because there is no active leader."

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100277&sha=2ababdf2356bd9024610826832bb5427b9a0c0e8&name_0=PR&name_1=Integration%20tests%20%28amd_msan%2C%203%2F6%29
https://github.com/ClickHouse/ClickHouse/pull/100277

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.129` (included in `26.4` and later)
- Backported to: `26.3.33.109`
<!-- ch-version-info:end -->