### PR TITLE
Fix exception in ObjectStorageQueueIFileMetadata when processing ownership is lost

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueIFileMetadata.cpp
@@ -180,22 +180,17 @@ ObjectStorageQueueIFileMetadata::~ObjectStorageQueueIFileMetadata()
             zk_retry.retryLoop([&]
             {
                 auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log, zookeeper_name);
-                if (zk_retry.isRetry())
+                /// It is possible that we fail "after operation",
+                /// e.g. we successfully removed the node, but did not get confirmation,
+                /// but then if we retry - we can remove a newly recreated node,
+                /// therefore avoid this with this check.
+                /// On the first attempt, ownership can also be lost if the ZooKeeper
+                /// session expired and another processor took over.
+                if (!checkProcessingOwnership(zk_client))
                 {
-                    /// It is possible that we fail "after operation",
-                    /// e.g. we successfully removed the node, but did not get confirmation,
-                    /// but then if we retry - we can remove a newly recreated node,
-                    /// therefore avoid this with this check.
-                    if (!checkProcessingOwnership(zk_client))
-                    {
-                        LOG_TEST(log, "Will not remove processing node, ownership changed");
-                        code = Coordination::Error::ZOK;
-                        return;
-                    }
-                }
-                else
-                {
-                    chassert(checkProcessingOwnership(zk_client));
+                    LOG_TEST(log, "Will not remove processing node, ownership changed");
+                    code = Coordination::Error::ZOK;
+                    return;
                 }
                 code = zk_client->tryRemove(processing_node_path);
             });
@@ -398,22 +393,17 @@ void ObjectStorageQueueIFileMetadata::resetProcessing()
     zk_retry.retryLoop([&]
     {
         auto zk_client = ObjectStorageQueueMetadata::getZooKeeper(log, zookeeper_name);
-        if (zk_retry.isRetry())
+        /// It is possible that we fail "after operation",
+        /// e.g. we successfully removed the node, but did not get confirmation,
+        /// but then if we retry - we can remove a newly recreated node,
+        /// therefore avoid this with this check.
+        /// On the first attempt, ownership can also be lost if the ZooKeeper
+        /// session expired and another processor took over.
+        if (!checkProcessingOwnership(zk_client))
         {
-            /// It is possible that we fail "after operation",
-            /// e.g. we successfully removed the node, but did not get confirmation,
-            /// but then if we retry - we can remove a newly recreated node,
-            /// therefore avoid this with this check.
-            if (!checkProcessingOwnership(zk_client))
-            {
-                LOG_TEST(log, "Will not remove processing node, ownership changed");
-                code = Coordination::Error::ZOK;
-                return;
-            }
-        }
-        else
-        {
-            chassert(checkProcessingOwnership(zk_client));
+            LOG_TEST(log, "Will not remove processing node, ownership changed");
+            code = Coordination::Error::ZOK;
+            return;
         }
         code = zk_client->tryMulti(requests, responses);
     });


### PR DESCRIPTION
The `chassert(checkProcessingOwnership(zk_client))` in the destructor and `resetProcessing` of `ObjectStorageQueueIFileMetadata` can fire when ZooKeeper session expires between creating the processing node and attempting to remove it, allowing another processor to take over. This is a legitimate scenario under stress, not a logic bug.

Replace the assertion with the same graceful handling already used on retry: check ownership and skip removal if it changed.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=d370916dc6c37021dcc9c7dd6f327cfc8b1198fd&name_0=MasterCI&name_1=Stress%20test%20%28arm_asan_ubsan%2C%20s3%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)