### PR TITLE
Add wget retry logic to Alpine Docker image build

### DIFF
--- a/docker/server/Dockerfile.alpine
+++ b/docker/server/Dockerfile.alpine
@@ -50,19 +50,32 @@ ARG DEFAULT_GID="101"
 RUN addgroup -S -g "${DEFAULT_GID}" clickhouse && \
     adduser -S -h "/var/lib/clickhouse" -s /bin/bash -G clickhouse -g "ClickHouse server" -u "${DEFAULT_UID}" clickhouse
 
+ARG WGET_RETRIES=5
+ARG WGET_RETRY_DELAY=1
+
 RUN arch=${TARGETARCH:-amd64} \
     && cd /tmp \
+    && wget_with_retry() { \
+        local url="$1"; local attempt=1; \
+        while [ "$attempt" -le "${WGET_RETRIES}" ]; do \
+            if wget -c -q "$url"; then return 0; fi; \
+            echo "Attempt $attempt/${WGET_RETRIES} failed for $url, retrying in ${WGET_RETRY_DELAY}s..."; \
+            sleep "${WGET_RETRY_DELAY}"; \
+            attempt=$((attempt + 1)); \
+        done; \
+        echo "ERROR: Failed to download $url after ${WGET_RETRIES} attempts"; return 1; \
+    } \
     && if [ -n "${DIRECT_DOWNLOAD_URLS}" ]; then \
         echo "installing from provided urls with tgz packages: ${DIRECT_DOWNLOAD_URLS}" \
         && for url in $DIRECT_DOWNLOAD_URLS; do \
             echo "Get ${url}" \
-            && wget -c -q "$url" \
+            && wget_with_retry "$url" \
         ; done \
     else \
         for package in ${PACKAGES}; do \
             echo "Get ${REPOSITORY}/${package}-${VERSION}-${arch}.tgz" \
-            && wget -c -q "${REPOSITORY}/${package}-${VERSION}-${arch}.tgz" \
-            && wget -c -q "${REPOSITORY}/${package}-${VERSION}-${arch}.tgz.sha512" \
+            && wget_with_retry "${REPOSITORY}/${package}-${VERSION}-${arch}.tgz" \
+            && wget_with_retry "${REPOSITORY}/${package}-${VERSION}-${arch}.tgz.sha512" \
         ; done \
     fi \
     && cat *.tgz.sha512 | sed 's:/output/:/tmp/:' | sha512sum -c \


### PR DESCRIPTION
The `clickhouse/clickhouse-server:head-alpine-arm64` Docker image build fails intermittently with `wget: bad address` DNS resolution errors during cross-architecture builds via QEMU. BusyBox `wget` (used in Alpine) has no built-in retry support, so this adds a `wget_with_retry` wrapper that retries up to 5 times with a 1-second delay.

Observed in https://github.com/ClickHouse/ClickHouse/pull/100363

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.134`
<!-- ch-version-info:end -->