### PR TITLE
Fix flaky test 03801_materialized_cte

### DIFF
--- a/tests/queries/0_stateless/03801_materialized_cte.reference
+++ b/tests/queries/0_stateless/03801_materialized_cte.reference
@@ -1,108 +1,108 @@
-QUERY id: 0
+QUERY id: N
   PROJECTION COLUMNS
     name String
   PROJECTION
-    LIST id: 1, nodes: 1
-      COLUMN id: 2, column_name: name, result_type: String, source_id: 3
+    LIST id: N, nodes: 1
+      COLUMN id: N, column_name: name, result_type: String, source_id: N
   JOIN TREE
-    QUERY id: 3, alias: __table1, is_subquery: 1, is_cte: 1, is_materialized: 1, cte_name: a
+    QUERY id: N, alias: __table1, is_subquery: 1, is_cte: 1, is_materialized: 1, cte_name: a
       PROJECTION COLUMNS
         name String
       PROJECTION
-        LIST id: 4, nodes: 1
-          COLUMN id: 5, column_name: name, result_type: String, source_id: 6
+        LIST id: N, nodes: 1
+          COLUMN id: N, column_name: name, result_type: String, source_id: N
       JOIN TREE
-        TABLE id: 6, alias: __table2, table_name: default.users
-QUERY id: 0
+        TABLE id: N, alias: __table2, table_name: default.users
+QUERY id: N
   PROJECTION COLUMNS
     count() UInt64
   PROJECTION
-    LIST id: 1, nodes: 1
-      FUNCTION id: 2, function_name: count, function_type: aggregate, result_type: UInt64
+    LIST id: N, nodes: 1
+      FUNCTION id: N, function_name: count, function_type: aggregate, result_type: UInt64
   JOIN TREE
-    JOIN id: 3, strictness: ALL, kind: INNER
+    JOIN id: N, strictness: ALL, kind: INNER
       LEFT TABLE EXPRESSION
-        TABLE id: 4, alias: __table1, table_name: _temporary_and_external_tables._tmp_UNIQ_ID, temporary_table_name: _materialized_cte_UNIQ_ID
+        TABLE id: N, alias: __table1, table_name: _temporary_and_external_tables._tmp_UNIQ_ID, temporary_table_name: _materialized_cte_UNIQ_ID
           MATERIALIZED CTE SUBQUERY
-            QUERY id: 5, alias: __table2, is_subquery: 1, is_cte: 1, is_materialized: 1, cte_name: a
+            QUERY id: N, alias: __table2, is_subquery: 1, is_cte: 1, is_materialized: 1, cte_name: a
               PROJECTION COLUMNS
                 uid Int16
                 name String
                 age Int16
               PROJECTION
-                LIST id: 6, nodes: 3
-                  COLUMN id: 7, column_name: uid, result_type: Int16, source_id: 8
-                  COLUMN id: 9, column_name: name, result_type: String, source_id: 8
-                  COLUMN id: 10, column_name: age, result_type: Int16, source_id: 8
+                LIST id: N, nodes: 3
+                  COLUMN id: N, column_name: uid, result_type: Int16, source_id: N
+                  COLUMN id: N, column_name: name, result_type: String, source_id: N
+                  COLUMN id: N, column_name: age, result_type: Int16, source_id: N
               JOIN TREE
-                TABLE id: 8, alias: __table3, table_name: default.users
+                TABLE id: N, alias: __table3, table_name: default.users
       RIGHT TABLE EXPRESSION
-        TABLE id: 11, alias: __table4, table_name: _temporary_and_external_tables._tmp_UNIQ_ID, temporary_table_name: _materialized_cte_UNIQ_ID
+        TABLE id: N, alias: __table4, table_name: _temporary_and_external_tables._tmp_UNIQ_ID, temporary_table_name: _materialized_cte_UNIQ_ID
           MATERIALIZED CTE SUBQUERY
-            QUERY id: 12, alias: __table5, is_subquery: 1, is_cte: 1, is_materialized: 1, cte_name: a
+            QUERY id: N, alias: __table5, is_subquery: 1, is_cte: 1, is_materialized: 1, cte_name: a
               PROJECTION COLUMNS
                 uid Int16
                 name String
                 age Int16
               PROJECTION
-                LIST id: 13, nodes: 3
-                  COLUMN id: 14, column_name: uid, result_type: Int16, source_id: 15
-                  COLUMN id: 16, column_name: name, result_type: String, source_id: 15
-                  COLUMN id: 17, column_name: age, result_type: Int16, source_id: 15
+                LIST id: N, nodes: 3
+                  COLUMN id: N, column_name: uid, result_type: Int16, source_id: N
+                  COLUMN id: N, column_name: name, result_type: String, source_id: N
+                  COLUMN id: N, column_name: age, result_type: Int16, source_id: N
               JOIN TREE
-                TABLE id: 15, alias: __table6, table_name: default.users
+                TABLE id: N, alias: __table6, table_name: default.users
       JOIN EXPRESSION
-        FUNCTION id: 18, function_name: equals, function_type: ordinary, result_type: UInt8
+        FUNCTION id: N, function_name: equals, function_type: ordinary, result_type: UInt8
           ARGUMENTS
-            LIST id: 19, nodes: 2
-              COLUMN id: 20, column_name: uid, result_type: Int16, source_id: 4
-              COLUMN id: 21, column_name: uid, result_type: Int16, source_id: 11
-QUERY id: 0
+            LIST id: N, nodes: 2
+              COLUMN id: N, column_name: uid, result_type: Int16, source_id: N
+              COLUMN id: N, column_name: uid, result_type: Int16, source_id: N
+QUERY id: N
   PROJECTION COLUMNS
     count() UInt64
   PROJECTION
-    LIST id: 1, nodes: 1
-      FUNCTION id: 2, function_name: count, function_type: aggregate, result_type: UInt64
+    LIST id: N, nodes: 1
+      FUNCTION id: N, function_name: count, function_type: aggregate, result_type: UInt64
   JOIN TREE
-    JOIN id: 3, strictness: ALL, kind: INNER
+    JOIN id: N, strictness: ALL, kind: INNER
       LEFT TABLE EXPRESSION
-        TABLE id: 4, alias: __table1, table_name: _temporary_and_external_tables._tmp_UNIQ_ID, temporary_table_name: _materialized_cte_UNIQ_ID
+        TABLE id: N, alias: __table1, table_name: _temporary_and_external_tables._tmp_UNIQ_ID, temporary_table_name: _materialized_cte_UNIQ_ID
           MATERIALIZED CTE SUBQUERY
-            QUERY id: 5, alias: __table2, is_subquery: 1, is_cte: 1, is_materialized: 1, cte_name: a
+            QUERY id: N, alias: __table2, is_subquery: 1, is_cte: 1, is_materialized: 1, cte_name: a
               PROJECTION COLUMNS
                 uid Int16
                 count() UInt64
               PROJECTION
-                LIST id: 6, nodes: 2
-                  COLUMN id: 7, column_name: uid, result_type: Int16, source_id: 8
-                  FUNCTION id: 9, function_name: count, function_type: aggregate, result_type: UInt64
+                LIST id: N, nodes: 2
+                  COLUMN id: N, column_name: uid, result_type: Int16, source_id: N
+                  FUNCTION id: N, function_name: count, function_type: aggregate, result_type: UInt64
               JOIN TREE
-                TABLE id: 8, alias: __table3, table_name: default.users
+                TABLE id: N, alias: __table3, table_name: default.users
               GROUP BY
-                LIST id: 10, nodes: 1
-                  COLUMN id: 11, column_name: uid, result_type: Int16, source_id: 8
+                LIST id: N, nodes: 1
+                  COLUMN id: N, column_name: uid, result_type: Int16, source_id: N
       RIGHT TABLE EXPRESSION
-        TABLE id: 12, alias: __table4, table_name: _temporary_and_external_tables._tmp_UNIQ_ID, temporary_table_name: _materialized_cte_UNIQ_ID
+        TABLE id: N, alias: __table4, table_name: _temporary_and_external_tables._tmp_UNIQ_ID, temporary_table_name: _materialized_cte_UNIQ_ID
           MATERIALIZED CTE SUBQUERY
-            QUERY id: 13, alias: __table5, is_subquery: 1, is_cte: 1, is_materialized: 1, cte_name: a
+            QUERY id: N, alias: __table5, is_subquery: 1, is_cte: 1, is_materialized: 1, cte_name: a
               PROJECTION COLUMNS
                 uid Int16
                 count() UInt64
               PROJECTION
-                LIST id: 14, nodes: 2
-                  COLUMN id: 15, column_name: uid, result_type: Int16, source_id: 16
-                  FUNCTION id: 17, function_name: count, function_type: aggregate, result_type: UInt64
+                LIST id: N, nodes: 2
+                  COLUMN id: N, column_name: uid, result_type: Int16, source_id: N
+                  FUNCTION id: N, function_name: count, function_type: aggregate, result_type: UInt64
               JOIN TREE
-                TABLE id: 16, alias: __table6, table_name: default.users
+                TABLE id: N, alias: __table6, table_name: default.users
               GROUP BY
-                LIST id: 18, nodes: 1
-                  COLUMN id: 19, column_name: uid, result_type: Int16, source_id: 16
+                LIST id: N, nodes: 1
+                  COLUMN id: N, column_name: uid, result_type: Int16, source_id: N
       JOIN EXPRESSION
-        FUNCTION id: 20, function_name: equals, function_type: ordinary, result_type: UInt8
+        FUNCTION id: N, function_name: equals, function_type: ordinary, result_type: UInt8
           ARGUMENTS
-            LIST id: 21, nodes: 2
-              COLUMN id: 22, column_name: uid, result_type: Int16, source_id: 4
-              COLUMN id: 23, column_name: uid, result_type: Int16, source_id: 12
+            LIST id: N, nodes: 2
+              COLUMN id: N, column_name: uid, result_type: Int16, source_id: N
+              COLUMN id: N, column_name: uid, result_type: Int16, source_id: N
 MaterializingCTEs (Materialize CTEs before main query execution)
 Header: count() UInt64
   Expression ((Project names + Projection))

--- a/tests/queries/0_stateless/03801_materialized_cte.sql
+++ b/tests/queries/0_stateless/03801_materialized_cte.sql
@@ -10,12 +10,16 @@ INSERT INTO users VALUES (8888, 'Alice', 50);
 SELECT
     REGEXP_REPLACE(
         REGEXP_REPLACE(
-            explain,
-            '_temporary_and_external_tables._tmp_\\w+\\-\\w+\\-\\w+\\-\\w+\\-\\w+',
-            '_temporary_and_external_tables._tmp_UNIQ_ID'
+            REGEXP_REPLACE(
+                explain,
+                '_temporary_and_external_tables._tmp_\\w+\\-\\w+\\-\\w+\\-\\w+\\-\\w+',
+                '_temporary_and_external_tables._tmp_UNIQ_ID'
+            ),
+            '_materialized_cte_\\w+\\_\\w+',
+            '_materialized_cte_UNIQ_ID'
         ),
-        '_materialized_cte_\\w+\\_\\w+',
-        '_materialized_cte_UNIQ_ID'
+        '(\\bid|source_id): \\d+',
+        '\\1: N'
     )
 FROM
 (
@@ -29,12 +33,16 @@ FROM
 SELECT
     REGEXP_REPLACE(
         REGEXP_REPLACE(
-            explain,
-            '_temporary_and_external_tables._tmp_\\w+\\-\\w+\\-\\w+\\-\\w+\\-\\w+',
-            '_temporary_and_external_tables._tmp_UNIQ_ID'
+            REGEXP_REPLACE(
+                explain,
+                '_temporary_and_external_tables._tmp_\\w+\\-\\w+\\-\\w+\\-\\w+\\-\\w+',
+                '_temporary_and_external_tables._tmp_UNIQ_ID'
+            ),
+            '_materialized_cte_\\w+\\_\\w+',
+            '_materialized_cte_UNIQ_ID'
         ),
-        '_materialized_cte_\\w+\\_\\w+',
-        '_materialized_cte_UNIQ_ID'
+        '(\\bid|source_id): \\d+',
+        '\\1: N'
     )
 FROM
 (
@@ -47,12 +55,16 @@ FROM
 SELECT
     REGEXP_REPLACE(
         REGEXP_REPLACE(
-            explain,
-            '_temporary_and_external_tables._tmp_\\w+\\-\\w+\\-\\w+\\-\\w+\\-\\w+',
-            '_temporary_and_external_tables._tmp_UNIQ_ID'
+            REGEXP_REPLACE(
+                explain,
+                '_temporary_and_external_tables._tmp_\\w+\\-\\w+\\-\\w+\\-\\w+\\-\\w+',
+                '_temporary_and_external_tables._tmp_UNIQ_ID'
+            ),
+            '_materialized_cte_\\w+\\_\\w+',
+            '_materialized_cte_UNIQ_ID'
         ),
-        '_materialized_cte_\\w+\\_\\w+',
-        '_materialized_cte_UNIQ_ID'
+        '(\\bid|source_id): \\d+',
+        '\\1: N'
     )
 FROM
 (

--- a/tests/queries/0_stateless/03801_materialized_cte.sql
+++ b/tests/queries/0_stateless/03801_materialized_cte.sql
@@ -1,5 +1,6 @@
 SET enable_analyzer = 1;
 SET enable_materialized_cte = 1;
+SET optimize_group_by_function_keys = 1;
 
 CREATE TABLE users (uid Int16, name String, age Int16) ENGINE=Memory;
 


### PR DESCRIPTION
Fix flaky test `03801_materialized_cte` by normalizing non-deterministic node IDs in `EXPLAIN QUERY TREE` output.

The `EXPLAIN QUERY TREE` output contains node IDs (`id: N`, `source_id: N`) from a global counter that shifts when other queries run in parallel. The test already normalized UUIDs in temporary table and CTE names but did not normalize these node IDs.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100373&sha=4717161518a29a179c942d56728f7220300024d6&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%201%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/100373

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.135`
<!-- ch-version-info:end -->