### PR TITLE
Fix ReadBuffer is canceled exception in zip archive operations

### DIFF
--- a/src/IO/Archives/ZipArchiveReader.cpp
+++ b/src/IO/Archives/ZipArchiveReader.cpp
@@ -130,6 +130,8 @@ namespace
         static unsigned long readFileFunc(void *, void * stream, void * buf, unsigned long size) // NOLINT(google-runtime-int)
         {
             auto & strm = get(stream);
+            if (strm.stored_exception)
+                return 0;
             try
             {
                 if (strm.at_end)
@@ -146,6 +148,8 @@ namespace
         static ZPOS64_T tellFunc(void *, void * stream)
         {
             auto & strm = get(stream);
+            if (strm.stored_exception)
+                return static_cast<ZPOS64_T>(-1);
             try
             {
                 if (strm.at_end)
@@ -162,6 +166,8 @@ namespace
         static long seekFunc(void *, void * stream, ZPOS64_T offset, int origin) // NOLINT(google-runtime-int)
         {
             auto & strm = get(stream);
+            if (strm.stored_exception)
+                return -1;
             try
             {
                 if (origin == SEEK_END)

--- a/src/IO/Archives/ZipArchiveWriter.cpp
+++ b/src/IO/Archives/ZipArchiveWriter.cpp
@@ -220,6 +220,8 @@ private:
     static unsigned long writeFileFunc(void * opaque, void *, const void * buf, unsigned long size) // NOLINT(google-runtime-int)
     {
         auto * stream_info = reinterpret_cast<StreamInfo *>(opaque);
+        if (stream_info->stored_exception)
+            return 0;
         try
         {
             stream_info->write_buffer->write(reinterpret_cast<const char *>(buf), size);
@@ -241,6 +243,8 @@ private:
     static ZPOS64_T tellFunc(void * opaque, void *)
     {
         auto * stream_info = reinterpret_cast<StreamInfo *>(opaque);
+        if (stream_info->stored_exception)
+            return static_cast<ZPOS64_T>(-1);
         try
         {
             auto pos = stream_info->write_buffer->count() - stream_info->start_offset;


### PR DESCRIPTION
When a `ReadBuffer::nextImpl` throws, `ReadBuffer::next` calls `cancel()` and re-throws. The minizip library catches the exception via the C callback (`readFileFunc`) which stores it and returns 0. However, minizip may then call `readFileFunc` again before the stored exception is re-thrown via `rethrowStreamException`. At that point the underlying `ReadBuffer` is already canceled, and the `chassert(!isCanceled())` in `ReadBuffer::next` fires as a logical error.

The fix adds early-return checks for `stored_exception` in all minizip callback functions (`readFileFunc`, `tellFunc`, `seekFunc`, `writeFileFunc`) to avoid touching the buffer after a prior exception has already canceled it.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100395&sha=97c66cfd486cfc33344b02f7bf69a66ce1664104&name_0=PR&name_1=Stress%20test%20%28amd_msan%29
https://github.com/ClickHouse/ClickHouse/pull/100395

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `ReadBuffer is canceled. Can't read from it.` exception in backup/restore operations using zip archives.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.138`
<!-- ch-version-info:end -->