### PR TITLE
Make test_s3_aws_sdk_has_slightly_unreliable_behaviour idempotent

### DIFF
--- a/tests/integration/test_s3_aws_sdk_has_slightly_unreliable_behaviour/test.py
+++ b/tests/integration/test_s3_aws_sdk_has_slightly_unreliable_behaviour/test.py
@@ -71,6 +71,7 @@ def cluster():
 def test_dataloss(cluster):
     node = cluster.instances["node"]
 
+    node.query("DROP TABLE IF EXISTS s3_failover_test")
     node.query(
         """
         CREATE TABLE s3_failover_test (
@@ -83,5 +84,8 @@ def test_dataloss(cluster):
 
     # Must throw an exception because we use proxy which always fail
     # CompleteMultipartUpload requests
-    with pytest.raises(Exception):
-        node.query("INSERT INTO s3_failover_test VALUES (1, 'Hello')")
+    try:
+        with pytest.raises(Exception):
+            node.query("INSERT INTO s3_failover_test VALUES (1, 'Hello')")
+    finally:
+        node.query("DROP TABLE IF EXISTS s3_failover_test")


### PR DESCRIPTION
The test creates table `s3_failover_test` but never drops it. When the test is parametrized or retried within the same cluster, subsequent runs fail with `TABLE_ALREADY_EXISTS`.

Add `DROP TABLE IF EXISTS` before creating the table and in a `finally` block after the test body so the table is always cleaned up.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99495&sha=3f8f7655771a091216f7435f183b2d733c3ab62f&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20targeted%29
https://github.com/ClickHouse/ClickHouse/pull/99495

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.141`
<!-- ch-version-info:end -->