### PR TITLE
Round Float64 results in test 02931_rewrite_sum_column_and_constant

### DIFF
--- a/tests/queries/0_stateless/02931_rewrite_sum_column_and_constant.reference
+++ b/tests/queries/0_stateless/02931_rewrite_sum_column_and_constant.reference
@@ -164,22 +164,22 @@ SELECT sum((1 AS m) - (uint64 AS n) AS i) AS j
 FROM test_table
 WHERE (m > 0) AND (n > 0) AND (i < 0)
 HAVING j < 0
-SELECT sum(uint64 + 2.11) From test_table;
-25.549999999999997
-SELECT sum(2.11 + uint64) From test_table;
-25.549999999999997
-SELECT sum(uint64 - 2.11) From test_table;
-4.450000000000001
-SELECT sum(2.11 - uint64) From test_table;
--4.450000000000001
-SELECT sum(uint64) + 2.11 * count(uint64) From test_table;
-25.549999999999997
-SELECT 2.11 * count(uint64) + sum(uint64) From test_table;
-25.549999999999997
-SELECT sum(uint64) - 2.11 * count(uint64) From test_table;
-4.450000000000001
-SELECT 2.11 * count(uint64) - sum(uint64) From test_table;
--4.450000000000001
+SELECT round(sum(uint64 + 2.11), 2) From test_table;
+25.55
+SELECT round(sum(2.11 + uint64), 2) From test_table;
+25.55
+SELECT round(sum(uint64 - 2.11), 2) From test_table;
+4.45
+SELECT round(sum(2.11 - uint64), 2) From test_table;
+-4.45
+SELECT round(sum(uint64) + 2.11 * count(uint64), 2) From test_table;
+25.55
+SELECT round(2.11 * count(uint64) + sum(uint64), 2) From test_table;
+25.55
+SELECT round(sum(uint64) - 2.11 * count(uint64), 2) From test_table;
+4.45
+SELECT round(2.11 * count(uint64) - sum(uint64), 2) From test_table;
+-4.45
 EXPLAIN SYNTAX (SELECT sum(uint64 + 2.11) From test_table);
 SELECT sum(uint64 + 2.11)
 FROM test_table

--- a/tests/queries/0_stateless/02931_rewrite_sum_column_and_constant.sql
+++ b/tests/queries/0_stateless/02931_rewrite_sum_column_and_constant.sql
@@ -76,14 +76,14 @@ EXPLAIN SYNTAX (SELECT sum(1 - uint64 AS i) j from test_table where i > 0 having
 EXPLAIN SYNTAX (SELECT sum((1 AS m) - (uint64 AS n)) j from test_table where m > 0 and n > 0 having j < 0);
 EXPLAIN SYNTAX (SELECT sum(((1 AS m) - (uint64 AS n)) AS i) j from test_table where m > 0 and n > 0 and i < 0 having j < 0);
 
-SELECT sum(uint64 + 2.11) From test_table;
-SELECT sum(2.11 + uint64) From test_table;
-SELECT sum(uint64 - 2.11) From test_table;
-SELECT sum(2.11 - uint64) From test_table;
-SELECT sum(uint64) + 2.11 * count(uint64) From test_table;
-SELECT 2.11 * count(uint64) + sum(uint64) From test_table;
-SELECT sum(uint64) - 2.11 * count(uint64) From test_table;
-SELECT 2.11 * count(uint64) - sum(uint64) From test_table;
+SELECT round(sum(uint64 + 2.11), 2) From test_table;
+SELECT round(sum(2.11 + uint64), 2) From test_table;
+SELECT round(sum(uint64 - 2.11), 2) From test_table;
+SELECT round(sum(2.11 - uint64), 2) From test_table;
+SELECT round(sum(uint64) + 2.11 * count(uint64), 2) From test_table;
+SELECT round(2.11 * count(uint64) + sum(uint64), 2) From test_table;
+SELECT round(sum(uint64) - 2.11 * count(uint64), 2) From test_table;
+SELECT round(2.11 * count(uint64) - sum(uint64), 2) From test_table;
 EXPLAIN SYNTAX (SELECT sum(uint64 + 2.11) From test_table);
 EXPLAIN SYNTAX (SELECT sum(2.11 + uint64) From test_table);
 EXPLAIN SYNTAX (SELECT sum(uint64 - 2.11) From test_table);


### PR DESCRIPTION
Test `02931_rewrite_sum_column_and_constant` fails under TSan with random settings due to floating-point precision differences. When `optimize_arithmetic_operations_in_aggregate_functions` is disabled, `sum(2.11 - uint64)` produces `-4.45` instead of `-4.450000000000001`. Both are valid results for the same mathematical value. Wrap Float64 arithmetic queries with `round(..., 2)` to avoid flaky results.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=98677&sha=c1d06924bbc951a62ad4a320efdcb22722d72d4b&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%202%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/98677

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)