### PR TITLE
Restore `fatal.log` artifact in stress test CI reports

### DIFF
--- a/ci/jobs/stress_job.py
+++ b/ci/jobs/stress_job.py
@@ -212,6 +212,13 @@ def run_stress_test(upgrade_check: bool = False) -> None:
         )
         is_oom = is_oom or server_log_oom
 
+    # Generate fatal.log from all server logs
+    fatal_log = result_path / "fatal.log"
+    if server_log_path.exists():
+        Shell.check(
+            f"rg --text '\\s<Fatal>\\s' {server_log_path}/clickhouse-server*.log > {fatal_log}"
+        )
+
     test_results, additional_logs = process_results(result_path, server_log_path)
 
     server_died = False

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -332,9 +332,6 @@ function check_logs_for_critical_errors()
     # Remove file no_such_key_errors.txt if it's empty
     [ -s /test_output/no_such_key_errors.txt ] || rm -f /test_output/no_such_key_errors.txt
 
-    # Remove file fatal_messages.txt if it's empty
-    [ -s /test_output/fatal_messages.txt ] || rm -f /test_output/fatal_messages.txt
-
     dmesg -T > /test_output/dmesg.log
 }
 


### PR DESCRIPTION
The refactoring in 85deff32971 ("CI: Stress tests refactor errors check") moved error checking from shell (`stress_tests.lib`) to Python (`FuzzerLogParser` in `stress_job.py`) but dropped the generation of `fatal.log` (previously `fatal_messages.txt`) — a dedicated artifact file containing all `<Fatal>` level messages extracted from server logs.

This restores it by generating `fatal.log` in `stress_job.py` before `process_results` collects artifacts, matching how `ast_fuzzer_job.py` already does it. Also removes dead `fatal_messages.txt` cleanup code left behind in `stress_tests.lib`.

Example report missing `fatal.log`: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=95997&sha=991a8e611e7ce62b999bbb39343bb46d574b6e31&name_0=PR&name_1=Stress%20test%20%28amd_msan%29
https://github.com/ClickHouse/ClickHouse/pull/95997

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.182`
<!-- ch-version-info:end -->