### PR TITLE
Fix TSan data race in Keeper AuthID between preprocess and commit

### DIFF
--- a/src/Coordination/KeeperStorage.cpp
+++ b/src/Coordination/KeeperStorage.cpp
@@ -1370,7 +1370,10 @@ Coordination::Error KeeperStorage<Container>::commit(KeeperStorageBase::DeltaRan
                 else if constexpr (std::same_as<DeltaType, AddAuthDelta>)
                 {
                     std::lock_guard auth_lock{auth_mutex};
-                    committed_session_and_auth[operation.session_id].emplace_back(std::move(*operation.auth_id));
+                    /// We must copy here instead of move because the same AuthID object
+                    /// is referenced via shared_ptr from UncommittedState::session_and_auth,
+                    /// which can be read concurrently by preprocess on another thread.
+                    committed_session_and_auth[operation.session_id].emplace_back(*operation.auth_id);
                     return Coordination::Error::ZOK;
                 }
                 else if constexpr (std::same_as<DeltaType, CloseSessionDelta>)


### PR DESCRIPTION
Fix TSan data race in Keeper `AuthID` between `preprocess` and `commit`.

The `AddAuthDelta` holds a `shared_ptr<AuthID>` which is also referenced from `UncommittedState::session_and_auth`. When `commit` did `std::move(*operation.auth_id)`, it moved from the `AuthID` object while `preprocess` on another thread could concurrently read the same object via `hasACL`. Replace the move with a copy to keep the shared object valid for concurrent readers.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=3134af4b1eeebf8773015eb04eb1aa1a80bd2f17&name_0=MasterCI&name_1=Integration%20tests%20%28amd_tsan%2C%206%2F6%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)