### PR TITLE
Fix access check logic in `StorageSystemCompletions`

### DIFF
--- a/src/Storages/System/StorageSystemCompletions.cpp
+++ b/src/Storages/System/StorageSystemCompletions.cpp
@@ -127,12 +127,17 @@ void fillDataWithDatabasesTablesColumns(MutableColumns & res_columns, const Cont
         res_columns[1]->insert(DATABASE_CONTEXT);
         res_columns[2]->insertDefault();
 
+        const bool check_access_for_tables_in_db = check_access_for_tables
+            && !access->isGranted(AccessType::SHOW_TABLES, database_name);
+        const bool check_access_for_columns_in_db = check_access_for_columns
+            && !access->isGranted(AccessType::SHOW_COLUMNS, database_name);
+
         for (auto iterator = database_ptr->getTablesIterator(context); iterator->isValid(); iterator->next())
         {
             const auto & table_name = iterator->name();
             const auto & table = iterator->table();
             fillDataWithTableColumns(database_name, table_name, table, res_columns, context,
-                check_access_for_tables, check_access_for_columns);
+                check_access_for_tables_in_db, check_access_for_columns_in_db);
         }
     }
 

--- a/src/Storages/System/StorageSystemCompletions.cpp
+++ b/src/Storages/System/StorageSystemCompletions.cpp
@@ -68,11 +68,12 @@ void fillDataWithTableColumns(
     const String & table_name,
     const StoragePtr & table,
     MutableColumns & res_columns,
-    const ContextPtr & context)
+    const ContextPtr & context,
+    bool check_access_for_tables,
+    bool check_access_for_columns)
 {
     const auto & access = context->getAccess();
-    if (!access->isGranted(AccessType::SHOW_TABLES) || !access->isGranted(AccessType::SHOW_TABLES, database_name)
-        || !access->isGranted(AccessType::SHOW_TABLES, database_name, table_name))
+    if (check_access_for_tables && !access->isGranted(AccessType::SHOW_TABLES, database_name, table_name))
         return;
 
     if (!table)
@@ -82,7 +83,7 @@ void fillDataWithTableColumns(
     res_columns[1]->insert(TABLE_CONTEXT);
     res_columns[2]->insert(database_name);
 
-    if (!access->isGranted(AccessType::SHOW_COLUMNS) || !access->isGranted(AccessType::SHOW_COLUMNS, database_name, table_name))
+    if (check_access_for_columns && !access->isGranted(AccessType::SHOW_COLUMNS, database_name, table_name))
         return;
 
     auto table_lock = table->tryLockForShare(context->getCurrentQueryId(), context->getSettingsRef()[Setting::lock_acquire_timeout]);
@@ -96,7 +97,7 @@ void fillDataWithTableColumns(
     const auto & columns = (*snapshot)->getColumns();
     for (const auto & column : columns)
     {
-        if (!access->isGranted(AccessType::SHOW_COLUMNS, database_name, table_name, column.name))
+        if (check_access_for_columns && !access->isGranted(AccessType::SHOW_COLUMNS, database_name, table_name, column.name))
             continue;
 
         res_columns[0]->insert(column.name);
@@ -108,11 +109,15 @@ void fillDataWithTableColumns(
 void fillDataWithDatabasesTablesColumns(MutableColumns & res_columns, const ContextPtr & context)
 {
     const auto & access = context->getAccess();
+    const bool check_access_for_databases = !access->isGranted(AccessType::SHOW_DATABASES);
+    const bool check_access_for_tables = !access->isGranted(AccessType::SHOW_TABLES);
+    const bool check_access_for_columns = !access->isGranted(AccessType::SHOW_COLUMNS);
+
     const auto & settings = context->getSettingsRef();
     const auto & databases = DatabaseCatalog::instance().getDatabases(GetDatabasesOptions{.with_datalake_catalogs = settings[Setting::show_data_lake_catalogs_in_system_tables]});
     for (const auto & [database_name, database_ptr] : databases)
     {
-        if (!access->isGranted(AccessType::SHOW_DATABASES) || !access->isGranted(AccessType::SHOW_DATABASES, database_name))
+        if (check_access_for_databases && !access->isGranted(AccessType::SHOW_DATABASES, database_name))
             continue;
 
         if (database_name == DatabaseCatalog::TEMPORARY_DATABASE)
@@ -126,7 +131,8 @@ void fillDataWithDatabasesTablesColumns(MutableColumns & res_columns, const Cont
         {
             const auto & table_name = iterator->name();
             const auto & table = iterator->table();
-            fillDataWithTableColumns(database_name, table_name, table, res_columns, context);
+            fillDataWithTableColumns(database_name, table_name, table, res_columns, context,
+                check_access_for_tables, check_access_for_columns);
         }
     }
 
@@ -136,7 +142,8 @@ void fillDataWithDatabasesTablesColumns(MutableColumns & res_columns, const Cont
         for (auto & [table_name, table] : external_tables)
         {
             const String database_name(1, '\0');
-            fillDataWithTableColumns(database_name, table_name, table, res_columns, context);
+            fillDataWithTableColumns(database_name, table_name, table, res_columns, context,
+                check_access_for_tables, check_access_for_columns);
         }
     }
 }

--- a/src/Storages/System/StorageSystemCompletions.cpp
+++ b/src/Storages/System/StorageSystemCompletions.cpp
@@ -83,9 +83,6 @@ void fillDataWithTableColumns(
     res_columns[1]->insert(TABLE_CONTEXT);
     res_columns[2]->insert(database_name);
 
-    if (check_access_for_columns && !access->isGranted(AccessType::SHOW_COLUMNS, database_name, table_name))
-        return;
-
     auto table_lock = table->tryLockForShare(context->getCurrentQueryId(), context->getSettingsRef()[Setting::lock_acquire_timeout]);
     if (table_lock == nullptr)
         return; // table was dropped while acquiring the lock

--- a/tests/queries/0_stateless/04054_completions_access.reference
+++ b/tests/queries/0_stateless/04054_completions_access.reference
@@ -1,0 +1,13 @@
+=== Per-table grant user sees the permitted table ===
+visible_table
+=== Per-table grant user sees columns of the permitted table ===
+id
+name
+=== Per-table grant user does NOT see the hidden table ===
+0
+=== Per-db grant user sees the permitted database ===
+completions_access_db_04054
+=== Per-db grant user does NOT see other databases ===
+0
+=== Temporary table appears in completions ===
+tmp_completions_04054

--- a/tests/queries/0_stateless/04054_completions_access.reference
+++ b/tests/queries/0_stateless/04054_completions_access.reference
@@ -6,8 +6,20 @@ name
 === Per-table grant user does NOT see the hidden table ===
 0
 === Per-db grant user sees the permitted database ===
-completions_access_db_04054
+default
 === Per-db grant user does NOT see other databases ===
 0
+=== Per-db SHOW TABLES grant user sees all tables in the database ===
+hidden_table
+visible_table
+=== Per-db SHOW COLUMNS grant user sees columns of all tables ===
+id
+name
+=== SHOW TABLES only: table is visible ===
+visible_table
+=== SHOW TABLES only: columns are NOT visible ===
+0
+=== Per-column revoke: non-revoked column is visible ===
+name
 === Temporary table appears in completions ===
 tmp_completions_04054

--- a/tests/queries/0_stateless/04054_completions_access.sh
+++ b/tests/queries/0_stateless/04054_completions_access.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Tags: no-parallel
+# Tag no-parallel: create user
+
+# Test that system.completions respects per-table grants correctly.
+# A user with only per-table SHOW TABLES/SHOW COLUMNS grants (no global grant)
+# should see completions for their permitted tables, not others.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --query "DROP DATABASE IF EXISTS completions_access_db_04054;"
+$CLICKHOUSE_CLIENT --query "CREATE DATABASE completions_access_db_04054;"
+$CLICKHOUSE_CLIENT --query "CREATE TABLE completions_access_db_04054.visible_table (id UInt32, name String) ENGINE = Memory;"
+$CLICKHOUSE_CLIENT --query "CREATE TABLE completions_access_db_04054.hidden_table (id UInt32, value Float64) ENGINE = Memory;"
+
+$CLICKHOUSE_CLIENT --query "DROP USER IF EXISTS completions_access_user_04054;"
+$CLICKHOUSE_CLIENT --query "CREATE USER completions_access_user_04054 IDENTIFIED WITH no_password;"
+# Grant only per-table access (no global SHOW TABLES/SHOW COLUMNS grant)
+$CLICKHOUSE_CLIENT --query "GRANT SHOW TABLES ON completions_access_db_04054.visible_table TO completions_access_user_04054;"
+$CLICKHOUSE_CLIENT --query "GRANT SHOW COLUMNS ON completions_access_db_04054.visible_table TO completions_access_user_04054;"
+
+echo "=== Per-table grant user sees the permitted table ==="
+$CLICKHOUSE_CLIENT --user=completions_access_user_04054 \
+    --query "SELECT word FROM system.completions WHERE context = 'table' AND belongs = 'completions_access_db_04054' ORDER BY word;"
+
+echo "=== Per-table grant user sees columns of the permitted table ==="
+$CLICKHOUSE_CLIENT --user=completions_access_user_04054 \
+    --query "SELECT word FROM system.completions WHERE context = 'column' AND belongs = 'visible_table' ORDER BY word;"
+
+echo "=== Per-table grant user does NOT see the hidden table ==="
+$CLICKHOUSE_CLIENT --user=completions_access_user_04054 \
+    --query "SELECT count() FROM system.completions WHERE context = 'table' AND word = 'hidden_table';"
+
+$CLICKHOUSE_CLIENT --query "DROP USER IF EXISTS completions_access_user_04054;"
+
+# Case A: per-db SHOW DATABASES grant controls context = 'database' rows
+$CLICKHOUSE_CLIENT --query "DROP USER IF EXISTS completions_db_user_04054;"
+$CLICKHOUSE_CLIENT --query "CREATE USER completions_db_user_04054 IDENTIFIED WITH no_password;"
+$CLICKHOUSE_CLIENT --query "GRANT SHOW DATABASES ON completions_access_db_04054.* TO completions_db_user_04054;"
+
+echo "=== Per-db grant user sees the permitted database ==="
+$CLICKHOUSE_CLIENT --user=completions_db_user_04054 \
+    --query "SELECT word FROM system.completions WHERE context = 'database' AND word = 'completions_access_db_04054';"
+
+echo "=== Per-db grant user does NOT see other databases ==="
+$CLICKHOUSE_CLIENT --user=completions_db_user_04054 \
+    --query "SELECT count() FROM system.completions WHERE context = 'database' AND word = 'default';"
+
+$CLICKHOUSE_CLIENT --query "DROP USER IF EXISTS completions_db_user_04054;"
+
+# Case B: external tables (session temporary tables) branch
+echo "=== Temporary table appears in completions ==="
+$CLICKHOUSE_CLIENT -nm --query "
+CREATE TEMPORARY TABLE tmp_completions_04054 (x UInt32, y String);
+SELECT word FROM system.completions WHERE context = 'table' AND word = 'tmp_completions_04054';
+"
+
+$CLICKHOUSE_CLIENT --query "DROP DATABASE IF EXISTS completions_access_db_04054;"

--- a/tests/queries/0_stateless/04054_completions_access.sh
+++ b/tests/queries/0_stateless/04054_completions_access.sh
@@ -8,51 +8,96 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-$CLICKHOUSE_CLIENT --query "DROP DATABASE IF EXISTS completions_access_db_04054;"
-$CLICKHOUSE_CLIENT --query "CREATE DATABASE completions_access_db_04054;"
-$CLICKHOUSE_CLIENT --query "CREATE TABLE completions_access_db_04054.visible_table (id UInt32, name String) ENGINE = Memory;"
-$CLICKHOUSE_CLIENT --query "CREATE TABLE completions_access_db_04054.hidden_table (id UInt32, value Float64) ENGINE = Memory;"
+$CLICKHOUSE_CLIENT --query "CREATE TABLE ${CLICKHOUSE_DATABASE}.visible_table (id UInt32, name String) ENGINE = Memory;"
+$CLICKHOUSE_CLIENT --query "CREATE TABLE ${CLICKHOUSE_DATABASE}.hidden_table (id UInt32, value Float64) ENGINE = Memory;"
 
-$CLICKHOUSE_CLIENT --query "DROP USER IF EXISTS completions_access_user_04054;"
-$CLICKHOUSE_CLIENT --query "CREATE USER completions_access_user_04054 IDENTIFIED WITH no_password;"
+$CLICKHOUSE_CLIENT --query "DROP USER IF EXISTS ${CLICKHOUSE_DATABASE}_user;"
+$CLICKHOUSE_CLIENT --query "CREATE USER ${CLICKHOUSE_DATABASE}_user IDENTIFIED WITH no_password;"
 # Grant only per-table access (no global SHOW TABLES/SHOW COLUMNS grant)
-$CLICKHOUSE_CLIENT --query "GRANT SHOW TABLES ON completions_access_db_04054.visible_table TO completions_access_user_04054;"
-$CLICKHOUSE_CLIENT --query "GRANT SHOW COLUMNS ON completions_access_db_04054.visible_table TO completions_access_user_04054;"
+$CLICKHOUSE_CLIENT --query "GRANT SHOW TABLES ON ${CLICKHOUSE_DATABASE}.visible_table TO ${CLICKHOUSE_DATABASE}_user;"
+$CLICKHOUSE_CLIENT --query "GRANT SHOW COLUMNS ON ${CLICKHOUSE_DATABASE}.visible_table TO ${CLICKHOUSE_DATABASE}_user;"
 
 echo "=== Per-table grant user sees the permitted table ==="
-$CLICKHOUSE_CLIENT --user=completions_access_user_04054 \
-    --query "SELECT word FROM system.completions WHERE context = 'table' AND belongs = 'completions_access_db_04054' ORDER BY word;"
+$CLICKHOUSE_CLIENT --user="${CLICKHOUSE_DATABASE}_user" \
+    --query "SELECT word FROM system.completions WHERE context = 'table' AND belongs = '${CLICKHOUSE_DATABASE}' ORDER BY word;"
 
 echo "=== Per-table grant user sees columns of the permitted table ==="
-$CLICKHOUSE_CLIENT --user=completions_access_user_04054 \
+$CLICKHOUSE_CLIENT --user="${CLICKHOUSE_DATABASE}_user" \
     --query "SELECT word FROM system.completions WHERE context = 'column' AND belongs = 'visible_table' ORDER BY word;"
 
 echo "=== Per-table grant user does NOT see the hidden table ==="
-$CLICKHOUSE_CLIENT --user=completions_access_user_04054 \
+$CLICKHOUSE_CLIENT --user="${CLICKHOUSE_DATABASE}_user" \
     --query "SELECT count() FROM system.completions WHERE context = 'table' AND word = 'hidden_table';"
 
-$CLICKHOUSE_CLIENT --query "DROP USER IF EXISTS completions_access_user_04054;"
+$CLICKHOUSE_CLIENT --query "DROP USER IF EXISTS ${CLICKHOUSE_DATABASE}_user;"
 
 # Case A: per-db SHOW DATABASES grant controls context = 'database' rows
-$CLICKHOUSE_CLIENT --query "DROP USER IF EXISTS completions_db_user_04054;"
-$CLICKHOUSE_CLIENT --query "CREATE USER completions_db_user_04054 IDENTIFIED WITH no_password;"
-$CLICKHOUSE_CLIENT --query "GRANT SHOW DATABASES ON completions_access_db_04054.* TO completions_db_user_04054;"
+$CLICKHOUSE_CLIENT --query "DROP USER IF EXISTS ${CLICKHOUSE_DATABASE}_db_user;"
+$CLICKHOUSE_CLIENT --query "CREATE USER ${CLICKHOUSE_DATABASE}_db_user IDENTIFIED WITH no_password;"
+$CLICKHOUSE_CLIENT --query "GRANT SHOW DATABASES ON ${CLICKHOUSE_DATABASE}.* TO ${CLICKHOUSE_DATABASE}_db_user;"
 
 echo "=== Per-db grant user sees the permitted database ==="
-$CLICKHOUSE_CLIENT --user=completions_db_user_04054 \
-    --query "SELECT word FROM system.completions WHERE context = 'database' AND word = 'completions_access_db_04054';"
+$CLICKHOUSE_CLIENT --user="${CLICKHOUSE_DATABASE}_db_user" \
+    --query "SELECT word FROM system.completions WHERE context = 'database' AND word = '${CLICKHOUSE_DATABASE}';"
 
 echo "=== Per-db grant user does NOT see other databases ==="
-$CLICKHOUSE_CLIENT --user=completions_db_user_04054 \
+$CLICKHOUSE_CLIENT --user="${CLICKHOUSE_DATABASE}_db_user" \
     --query "SELECT count() FROM system.completions WHERE context = 'database' AND word = 'default';"
 
-$CLICKHOUSE_CLIENT --query "DROP USER IF EXISTS completions_db_user_04054;"
+$CLICKHOUSE_CLIENT --query "DROP USER IF EXISTS ${CLICKHOUSE_DATABASE}_db_user;"
 
-# Case B: external tables (session temporary tables) branch
+# Case B: per-db SHOW TABLES/SHOW COLUMNS grant controls table and column rows
+$CLICKHOUSE_CLIENT --query "DROP USER IF EXISTS ${CLICKHOUSE_DATABASE}_dbtables_user;"
+$CLICKHOUSE_CLIENT --query "CREATE USER ${CLICKHOUSE_DATABASE}_dbtables_user IDENTIFIED WITH no_password;"
+$CLICKHOUSE_CLIENT --query "GRANT SHOW DATABASES ON ${CLICKHOUSE_DATABASE}.* TO ${CLICKHOUSE_DATABASE}_dbtables_user;"
+$CLICKHOUSE_CLIENT --query "GRANT SHOW TABLES ON ${CLICKHOUSE_DATABASE}.* TO ${CLICKHOUSE_DATABASE}_dbtables_user;"
+$CLICKHOUSE_CLIENT --query "GRANT SHOW COLUMNS ON ${CLICKHOUSE_DATABASE}.* TO ${CLICKHOUSE_DATABASE}_dbtables_user;"
+
+echo "=== Per-db SHOW TABLES grant user sees all tables in the database ==="
+$CLICKHOUSE_CLIENT --user="${CLICKHOUSE_DATABASE}_dbtables_user" \
+    --query "SELECT word FROM system.completions WHERE context = 'table' AND belongs = '${CLICKHOUSE_DATABASE}' ORDER BY word;"
+
+echo "=== Per-db SHOW COLUMNS grant user sees columns of all tables ==="
+$CLICKHOUSE_CLIENT --user="${CLICKHOUSE_DATABASE}_dbtables_user" \
+    --query "SELECT word FROM system.completions WHERE context = 'column' AND belongs = 'visible_table' ORDER BY word;"
+
+$CLICKHOUSE_CLIENT --query "DROP USER IF EXISTS ${CLICKHOUSE_DATABASE}_dbtables_user;"
+
+# Case C: SHOW TABLES granted but SHOW COLUMNS not granted — table visible, columns hidden
+$CLICKHOUSE_CLIENT --query "DROP USER IF EXISTS ${CLICKHOUSE_DATABASE}_notcols_user;"
+$CLICKHOUSE_CLIENT --query "CREATE USER ${CLICKHOUSE_DATABASE}_notcols_user IDENTIFIED WITH no_password;"
+$CLICKHOUSE_CLIENT --query "GRANT SHOW DATABASES ON ${CLICKHOUSE_DATABASE}.* TO ${CLICKHOUSE_DATABASE}_notcols_user;"
+$CLICKHOUSE_CLIENT --query "GRANT SHOW TABLES ON ${CLICKHOUSE_DATABASE}.visible_table TO ${CLICKHOUSE_DATABASE}_notcols_user;"
+# No SHOW COLUMNS grant at all
+
+echo "=== SHOW TABLES only: table is visible ==="
+$CLICKHOUSE_CLIENT --user="${CLICKHOUSE_DATABASE}_notcols_user" \
+    --query "SELECT word FROM system.completions WHERE context = 'table' AND belongs = '${CLICKHOUSE_DATABASE}' ORDER BY word;"
+
+echo "=== SHOW TABLES only: columns are NOT visible ==="
+$CLICKHOUSE_CLIENT --user="${CLICKHOUSE_DATABASE}_notcols_user" \
+    --query "SELECT count() FROM system.completions WHERE context = 'column' AND belongs = 'visible_table';"
+
+$CLICKHOUSE_CLIENT --query "DROP USER IF EXISTS ${CLICKHOUSE_DATABASE}_notcols_user;"
+
+# Case D: per-column SHOW COLUMNS revoke — revoked column is hidden, others visible
+$CLICKHOUSE_CLIENT --query "DROP USER IF EXISTS ${CLICKHOUSE_DATABASE}_percol_user;"
+$CLICKHOUSE_CLIENT --query "CREATE USER ${CLICKHOUSE_DATABASE}_percol_user IDENTIFIED WITH no_password;"
+$CLICKHOUSE_CLIENT --query "GRANT SHOW DATABASES ON ${CLICKHOUSE_DATABASE}.* TO ${CLICKHOUSE_DATABASE}_percol_user;"
+$CLICKHOUSE_CLIENT --query "GRANT SHOW TABLES ON ${CLICKHOUSE_DATABASE}.visible_table TO ${CLICKHOUSE_DATABASE}_percol_user;"
+$CLICKHOUSE_CLIENT --query "GRANT SHOW COLUMNS ON ${CLICKHOUSE_DATABASE}.visible_table TO ${CLICKHOUSE_DATABASE}_percol_user;"
+$CLICKHOUSE_CLIENT --query "REVOKE SHOW COLUMNS(id) ON ${CLICKHOUSE_DATABASE}.visible_table FROM ${CLICKHOUSE_DATABASE}_percol_user;"
+# 'id' column is revoked, 'name' should still be visible
+
+echo "=== Per-column revoke: non-revoked column is visible ==="
+$CLICKHOUSE_CLIENT --user="${CLICKHOUSE_DATABASE}_percol_user" \
+    --query "SELECT word FROM system.completions WHERE context = 'column' AND belongs = 'visible_table' ORDER BY word;"
+
+$CLICKHOUSE_CLIENT --query "DROP USER IF EXISTS ${CLICKHOUSE_DATABASE}_percol_user;"
+
+# Case E: external tables (session temporary tables) branch
 echo "=== Temporary table appears in completions ==="
 $CLICKHOUSE_CLIENT -nm --query "
 CREATE TEMPORARY TABLE tmp_completions_04054 (x UInt32, y String);
 SELECT word FROM system.completions WHERE context = 'table' AND word = 'tmp_completions_04054';
 "
-
-$CLICKHOUSE_CLIENT --query "DROP DATABASE IF EXISTS completions_access_db_04054;"

--- a/tests/queries/0_stateless/04054_completions_access.sh
+++ b/tests/queries/0_stateless/04054_completions_access.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
-# Tag no-parallel: create user
 
 # Test that system.completions respects per-table grants correctly.
 # A user with only per-table SHOW TABLES/SHOW COLUMNS grants (no global grant)


### PR DESCRIPTION
Fix two bugs and one performance issue in `StorageSystemCompletions`.

**Bug 1:** `fillDataWithTableColumns` used `||` to chain three levels of
`isGranted` (global / per-db / per-table), so a user who had only a per-table
`SHOW TABLES` grant would always get an early `return` on the global check —
making `system.completions` return no rows for them.

**Bug 2:** `fillDataWithTableColumns` had a table-level short-circuit for
`SHOW_COLUMNS` — it called `isGranted(SHOW_COLUMNS, db, table)` without a
column name to decide whether to skip all columns for a table. When a user held
`GRANT SHOW COLUMNS ON table` combined with `REVOKE SHOW COLUMNS(col)`, this
call returned `false` and caused all columns to be hidden — inconsistent with
`SHOW COLUMNS` and `system.columns`.

**Performance:** the global-level `isGranted` calls were repeated on every
per-table iteration, wasting CPU for large catalogs.

Fix all three issues following the pattern used in `StorageSystemPartsBase`:
- Compute `check_access_for_databases/tables/columns` flags once per query in
  `fillDataWithDatabasesTablesColumns`.
- Refine the flags at database level (`check_access_for_tables_in_db` /
  `check_access_for_columns_in_db`) to skip redundant per-table `isGranted`
  calls when a database-level grant already covers all tables.
- Pass the flags into `fillDataWithTableColumns`, remove the table-level
  `SHOW_COLUMNS` short-circuit, and let all cases fall through to the
  per-column `isGranted(SHOW_COLUMNS, db, table, col)` check.

Add test `04054_completions_access` covering all access control paths:
- Per-table `SHOW TABLES`/`SHOW COLUMNS` grant — permitted table and its
  columns are visible; others are not.
- Per-db `SHOW DATABASES` grant — only the permitted database is visible.
- Per-db `SHOW TABLES`/`SHOW COLUMNS` grant — all tables and columns in the
  database are visible.
- `SHOW TABLES` without `SHOW COLUMNS` — table name is visible but columns
  are hidden.
- Per-column `REVOKE` — revoked column is hidden while other columns remain
  visible.
- Session temporary tables — appear in completions regardless of grants.


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `system.completions` to correctly filter databases, tables, and columns by access rights in all grant combinations: per-table, per-db, and per-column revoke.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.247`
<!-- ch-version-info:end -->