### PR TITLE
Temporarily disable server-side AST fuzzer in Stress Test and BuzzHouse

### DIFF
--- a/ci/jobs/scripts/fuzzer/query-fuzzer-tweaks-users.xml
+++ b/ci/jobs/scripts/fuzzer/query-fuzzer-tweaks-users.xml
@@ -40,8 +40,6 @@
             </constraints>
 
             <!-- Allow all experimental features by default -->
-            <ast_fuzzer_runs>5</ast_fuzzer_runs>
-
             <allow_custom_error_code_in_throwif>1</allow_custom_error_code_in_throwif>
             <allow_ddl>1</allow_ddl>
             <allow_distributed_ddl>1</allow_distributed_ddl>

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -144,8 +144,6 @@ EOL
 
             <table_function_remote_max_addresses>200</table_function_remote_max_addresses>
 
-            <ast_fuzzer_runs>5</ast_fuzzer_runs>
-            <ast_fuzzer_any_query>true</ast_fuzzer_any_query>
 
             <constraints>
                 <max_execution_time>


### PR DESCRIPTION
Temporarily disable `ast_fuzzer_runs` in Stress Test and BuzzHouse CI configs while stability issues are being addressed.

Alternative to full revert in https://github.com/ClickHouse/ClickHouse/pull/100437 — this only removes the CI config settings without reverting the C++ code improvements.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.152`
<!-- ch-version-info:end -->