### PR TITLE
Fix lost logic of 00156_max_execution_speed_sample_merge

### DIFF
--- a/tests/queries/0_stateless/00156_max_execution_speed_sample_merge.sql
+++ b/tests/queries/0_stateless/00156_max_execution_speed_sample_merge.sql
@@ -5,11 +5,12 @@
 -- NOTE: This test uses simple synthetic data to validate the fact throttling was applied.
 -- If throttling works as expected - each execution will take >= 1 second, as we allow not more than {max_execution_speed} records/sec
 -- If it doesn't - each select will finish immediately, and the test will fail
--- NOTE: fuzzer and parallelism are disabled as it can fiddle behaviour of merge and cause the flakiness - we're checking the functional correctness here
+-- NOTE: randomizer and parallelism are disabled as they can fiddle behaviour of merge and cause flakiness - we're checking functional correctness here
+-- NOTE: sleep(0.001) per block ensures CLOCK_MONOTONIC_COARSE (ReadProgressCallback) ticks between reads - otherwise entire data can be read within a single ~10ms clock tick and skipping throttling
 
 SET max_execution_speed = 2;                      -- this is the parameter we're testing - execution to be throttled down to 2 records/sec
 SET timeout_before_checking_execution_speed = 0;  -- and to apply it immediately
-SET max_block_size = 1;                           -- this one needs to be tweaked to ensure only 1 record per block is written; otherwise we'll read everything at once, and throttling won't work
+SET max_block_size = 1;                           -- this one needs to be tweaked to ensure only 1 record per block is read; otherwise we'll read everything at once, and throttling won't work
 
 CREATE TEMPORARY TABLE times (t DateTime);
 
@@ -25,14 +26,14 @@ CREATE
 INSERT INTO t00156_max_execution_speed_sample_merge SELECT number FROM numbers(30);
 
 INSERT INTO times SELECT now();
-SELECT * FROM t00156_max_execution_speed_sample_merge SAMPLE 1/2 FORMAT Null;
+SELECT *, sleep(0.001) FROM t00156_max_execution_speed_sample_merge SAMPLE 1/2 FORMAT Null;
 INSERT INTO times SELECT now();
 
 SELECT max(t) - min(t) >= 1 FROM times;
 TRUNCATE TABLE times;
 
 INSERT INTO times SELECT now();
-SELECT * FROM merge('t00156_max_execution_speed_sample_merge') SAMPLE 1/2 FORMAT Null;
+SELECT *, sleep(0.001) FROM merge('t00156_max_execution_speed_sample_merge') SAMPLE 1/2 FORMAT Null;
 INSERT INTO times SELECT now();
 
 SELECT max(t) - min(t) >= 1 FROM times;

--- a/tests/queries/0_stateless/00156_max_execution_speed_sample_merge.sql
+++ b/tests/queries/0_stateless/00156_max_execution_speed_sample_merge.sql
@@ -1,7 +1,6 @@
--- Tags: stateful
 -- This test validates that max_execution_speed & timeout_before_checking_execution_speed works with:
 --      a) regular query
---      b) temp merge query
+--      b) merge query
 -- NOTE: This test uses simple synthetic data to validate the fact throttling was applied.
 -- If throttling works as expected - each execution will take >= 1 second, as we allow not more than {max_execution_speed} records/seconds
 -- If it doesn't - each select will finish immediately, and the test will fail
@@ -14,18 +13,26 @@ SET max_block_size = 1;
 CREATE TEMPORARY TABLE times (t DateTime);
 
 DROP TABLE IF EXISTS t00156_max_execution_speed_sample_merge;
-CREATE TABLE t00156_max_execution_speed_sample_merge (v UInt64);
-INSERT INTO t00156_max_execution_speed_sample_merge SELECT number FROM numbers(28);
+CREATE 
+  TABLE t00156_max_execution_speed_sample_merge
+    (v UInt64)
+  ENGINE = MergeTree
+  ORDER BY intHash32(v)
+  SAMPLE BY intHash32(v);
+
+INSERT INTO t00156_max_execution_speed_sample_merge SELECT number FROM numbers(4);
 
 INSERT INTO times SELECT now();
-SELECT * FROM t00156_max_execution_speed_sample_merge WHERE sleepEachRow(0.1) == 0 FORMAT Null;
+SELECT * FROM t00156_max_execution_speed_sample_merge SAMPLE 1/2 WHERE sleepEachRow(1) == 0 FORMAT Null;
 INSERT INTO times SELECT now();
 
-SELECT max(t) - min(t) >= 1 FROM times;
+SELECT max(t) - min(t) >= 2 FROM times;
 TRUNCATE TABLE times;
 
 INSERT INTO times SELECT now();
-SELECT * FROM t00156_max_execution_speed_sample_merge WHERE sleepEachRow(0.1) == 0 FORMAT Null;
+SELECT * FROM merge('t00156_max_execution_speed_sample_merge') SAMPLE 1/2 WHERE sleepEachRow(1) == 0 FORMAT Null;
 INSERT INTO times SELECT now();
 
-SELECT max(t) - min(t) >= 1 FROM times;
+SELECT max(t) - min(t) >= 2 FROM times;
+
+DROP TABLE IF EXISTS t00156_max_execution_speed_sample_merge;

--- a/tests/queries/0_stateless/00156_max_execution_speed_sample_merge.sql
+++ b/tests/queries/0_stateless/00156_max_execution_speed_sample_merge.sql
@@ -4,7 +4,6 @@
 -- NOTE: This test uses simple synthetic data to validate the fact throttling was applied.
 -- If throttling works as expected - each execution will take >= 1 second, as we allow not more than {max_execution_speed} records/sec
 -- If it doesn't - each select will finish immediately, and the test will fail
--- NOTE: Setting max_block_size=1 to ensure sleepEachRow(..) applies per each row guaranteed and the resulting timing is predictable [2-3] seconds
 
 SET max_execution_speed = 5;                      -- this is parameter we're testing - to throttle execution down to 5 records/sec
 SET timeout_before_checking_execution_speed = 0;  -- and to start throttling immediately

--- a/tests/queries/0_stateless/00156_max_execution_speed_sample_merge.sql
+++ b/tests/queries/0_stateless/00156_max_execution_speed_sample_merge.sql
@@ -1,24 +1,26 @@
+-- Tags: no-random-settings, no-random-merge-tree-settings, no-parallel
 -- This test validates that max_execution_speed & timeout_before_checking_execution_speed works with:
 --      a) regular query
 --      b) merge query
 -- NOTE: This test uses simple synthetic data to validate the fact throttling was applied.
 -- If throttling works as expected - each execution will take >= 1 second, as we allow not more than {max_execution_speed} records/sec
 -- If it doesn't - each select will finish immediately, and the test will fail
+-- NOTE: fuzzer and parallelism are disabled as it can fiddle behaviour of merge and cause the flakiness - we're checking the functional correctness here
 
-SET max_execution_speed = 5;                      -- this is parameter we're testing - to throttle execution down to 5 records/sec
-SET timeout_before_checking_execution_speed = 0;  -- and to start throttling immediately
-SET max_block_size = 1;                           -- needs to be tweaked to make sure we write only 1 record per block; otherwise we'll read everything at once, and throttling won't work
+SET max_execution_speed = 2;                      -- this is the parameter we're testing - execution to be throttled down to 2 records/sec
+SET timeout_before_checking_execution_speed = 0;  -- and to apply it immediately
+SET max_block_size = 1;                           -- this one needs to be tweaked to ensure only 1 record per block is written; otherwise we'll read everything at once, and throttling won't work
 
 CREATE TEMPORARY TABLE times (t DateTime);
 
 DROP TABLE IF EXISTS t00156_max_execution_speed_sample_merge;
-CREATE 
+CREATE
   TABLE t00156_max_execution_speed_sample_merge
     (v UInt64)
   ENGINE = MergeTree
   ORDER BY intHash32(v)
   SAMPLE BY intHash32(v)
-  SETTINGS min_bytes_for_wide_part = 0;           -- another tweak to make sure all records don't end up in the same granule
+  SETTINGS min_bytes_for_wide_part = 0;           -- another tweak to force Wide parts so that max_block_size is respected within granules
 
 INSERT INTO t00156_max_execution_speed_sample_merge SELECT number FROM numbers(30);
 
@@ -26,13 +28,13 @@ INSERT INTO times SELECT now();
 SELECT * FROM t00156_max_execution_speed_sample_merge SAMPLE 1/2 FORMAT Null;
 INSERT INTO times SELECT now();
 
-SELECT max(t) - min(t) >= 2 FROM times;
+SELECT max(t) - min(t) >= 1 FROM times;
 TRUNCATE TABLE times;
 
 INSERT INTO times SELECT now();
 SELECT * FROM merge('t00156_max_execution_speed_sample_merge') SAMPLE 1/2 FORMAT Null;
 INSERT INTO times SELECT now();
 
-SELECT max(t) - min(t) >= 2 FROM times;
+SELECT max(t) - min(t) >= 1 FROM times;
 
 DROP TABLE IF EXISTS t00156_max_execution_speed_sample_merge;

--- a/tests/queries/0_stateless/00156_max_execution_speed_sample_merge.sql
+++ b/tests/queries/0_stateless/00156_max_execution_speed_sample_merge.sql
@@ -2,13 +2,13 @@
 --      a) regular query
 --      b) merge query
 -- NOTE: This test uses simple synthetic data to validate the fact throttling was applied.
--- If throttling works as expected - each execution will take >= 1 second, as we allow not more than {max_execution_speed} records/seconds
+-- If throttling works as expected - each execution will take >= 1 second, as we allow not more than {max_execution_speed} records/sec
 -- If it doesn't - each select will finish immediately, and the test will fail
 -- NOTE: Setting max_block_size=1 to ensure sleepEachRow(..) applies per each row guaranteed and the resulting timing is predictable [2-3] seconds
 
-SET max_execution_speed = 10;
-SET timeout_before_checking_execution_speed = 0;
-SET max_block_size = 1;
+SET max_execution_speed = 5;                      -- this is parameter we're testing - to throttle execution down to 5 records/sec
+SET timeout_before_checking_execution_speed = 0;  -- and to start throttling immediately
+SET max_block_size = 1;                           -- needs to be tweaked to make sure we write only 1 record per block; otherwise we'll read everything at once, and throttling won't work
 
 CREATE TEMPORARY TABLE times (t DateTime);
 
@@ -18,19 +18,20 @@ CREATE
     (v UInt64)
   ENGINE = MergeTree
   ORDER BY intHash32(v)
-  SAMPLE BY intHash32(v);
+  SAMPLE BY intHash32(v)
+  SETTINGS min_bytes_for_wide_part = 0;           -- another tweak to make sure all records don't end up in the same granule
 
-INSERT INTO t00156_max_execution_speed_sample_merge SELECT number FROM numbers(4);
+INSERT INTO t00156_max_execution_speed_sample_merge SELECT number FROM numbers(30);
 
 INSERT INTO times SELECT now();
-SELECT * FROM t00156_max_execution_speed_sample_merge SAMPLE 1/2 WHERE sleepEachRow(1) == 0 FORMAT Null;
+SELECT * FROM t00156_max_execution_speed_sample_merge SAMPLE 1/2 FORMAT Null;
 INSERT INTO times SELECT now();
 
 SELECT max(t) - min(t) >= 2 FROM times;
 TRUNCATE TABLE times;
 
 INSERT INTO times SELECT now();
-SELECT * FROM merge('t00156_max_execution_speed_sample_merge') SAMPLE 1/2 WHERE sleepEachRow(1) == 0 FORMAT Null;
+SELECT * FROM merge('t00156_max_execution_speed_sample_merge') SAMPLE 1/2 FORMAT Null;
 INSERT INTO times SELECT now();
 
 SELECT max(t) - min(t) >= 2 FROM times;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Some crucial logic has been lost at #94379 while fixing #92641.
The purpose of this PR is to bring it back and to handle the test properly. 
Modifications:
- fixed misleading comment
- added sampling back (not critical, more nice-to-have)
- added back check at 'merge' operation (second case)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.218`
<!-- ch-version-info:end -->