### PR TITLE
Fix checkDataPart failing with NO_FILE_IN_DATA_PART for fetched parts with unknown projections

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1664,6 +1664,38 @@ void IMergeTreeDataPart::loadChecksums(bool require)
             assertEOF(*buf);
             bytes_on_disk = checksums.getTotalSizeOnDisk();
             bytes_uncompressed_on_disk = checksums.getTotalSizeUncompressedOnDisk();
+
+            /// Strip .proj entries from checksums whose directories do not actually
+            /// exist on disk.  This can only happen for top-level parts, not for
+            /// projection sub-parts (which never contain .proj entries themselves).
+            /// The typical scenario: a part is fetched from a replica whose
+            /// checksums.txt references a projection that was dropped from the table
+            /// metadata -- the .proj directory is never transferred but checksums.txt
+            /// is copied verbatim from the sender.
+            /// Without this cleanup, checkDataPart would throw NO_FILE_IN_DATA_PART
+            /// and the part would be marked broken, causing an infinite re-fetch loop.
+            if (!parent_part)
+            {
+                bool has_phantom_projections = false;
+                for (auto it = checksums.files.begin(); it != checksums.files.end();)
+                {
+                    if (it->first.ends_with(".proj") && !getDataPartStorage().existsDirectory(it->first))
+                    {
+                        LOG_DEBUG(storage.log, "Part {}: ignoring phantom projection entry '{}' in checksums "
+                            "(directory does not exist on disk)", name, it->first);
+                        it = checksums.files.erase(it);
+                        has_phantom_projections = true;
+                    }
+                    else
+                        ++it;
+                }
+
+                if (has_phantom_projections)
+                {
+                    bytes_on_disk = checksums.getTotalSizeOnDisk();
+                    bytes_uncompressed_on_disk = checksums.getTotalSizeUncompressedOnDisk();
+                }
+            }
         }
         else
             bytes_on_disk = getDataPartStorage().calculateTotalSizeOnDisk();

--- a/src/Storages/MergeTree/checkDataPart.cpp
+++ b/src/Storages/MergeTree/checkDataPart.cpp
@@ -384,6 +384,22 @@ static IMergeTreeDataPart::Checksums checkDataPart(
         }
     }
 
+    /// Strip .proj entries from checksums_txt whose directories were never
+    /// present on disk (e.g. a replica that fetched the part after its
+    /// projection was dropped -- checksums.txt was copied verbatim from the
+    /// sender but the .proj directory was not transferred).  Without this,
+    /// checkEqual below would throw NO_FILE_IN_DATA_PART.
+    for (auto it = checksums_txt.files.begin(); it != checksums_txt.files.end();)
+    {
+        if (it->first.ends_with(".proj") && !checksums_data.has(it->first))
+        {
+            is_broken_projection = true;
+            it = checksums_txt.files.erase(it);
+        }
+        else
+            ++it;
+    }
+
     if (is_cancelled())
         return {};
 

--- a/tests/queries/0_stateless/03822_attach_with_unknown_projection.reference
+++ b/tests/queries/0_stateless/03822_attach_with_unknown_projection.reference
@@ -1,0 +1,12 @@
+=== Replicated MergeTree ===
+7
+Found unexpected projection directories: pp.proj
+21	21
+7
+21	21
+7
+21	21
+=== MergeTree ===
+7
+Found unexpected projection directories: pp.proj
+7

--- a/tests/queries/0_stateless/03822_attach_with_unknown_projection.reference
+++ b/tests/queries/0_stateless/03822_attach_with_unknown_projection.reference
@@ -4,6 +4,7 @@ Found unexpected projection directories: pp.proj
 21	21
 7
 21	21
+1
 7
 21	21
 === MergeTree ===

--- a/tests/queries/0_stateless/03822_attach_with_unknown_projection.sh
+++ b/tests/queries/0_stateless/03822_attach_with_unknown_projection.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Tags: replica, no-shared-merge-tree
+# Tag no-shared-merge-tree because detaching a partition on one replica should not affect the other replica, so the test relies on the fact that the detached part is still present on disk and can be re-attached.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Test: attaching a partition whose parts contain a projection that has since
+# been dropped from the table metadata must not mark the part as broken or
+# lost.  Covers two code-paths:
+#   1) checkDataPart  (ReplicatedMergeTreePartCheckThread)
+#   2) sendPartFromDisk (DataPartsExchange -- inter-replica fetches)
+
+run() { ${CLICKHOUSE_CLIENT} --query "$@"; }
+
+# ── ReplicatedMergeTree test ────────────────────────────────────────────────
+
+REPLICAS=2
+for i in $(seq $REPLICAS);
+do
+     run "DROP TABLE IF EXISTS t_unknown_proj_$i SYNC"
+
+     run "CREATE TABLE t_unknown_proj_$i (x Int32, y Int32, PROJECTION p (SELECT x, y ORDER BY x))
+          ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/t_unknown_proj', '$i')
+          PARTITION BY intDiv(y, 100) ORDER BY y
+          SETTINGS max_parts_to_merge_at_once = 1"
+done
+
+run "INSERT INTO t_unknown_proj_1 SELECT number, number FROM numbers(7)"
+
+run "ALTER TABLE t_unknown_proj_1 ADD PROJECTION pp (SELECT x, count() GROUP BY x) SETTINGS mutations_sync=2, alter_sync=2"
+run "ALTER TABLE t_unknown_proj_1 MATERIALIZE PROJECTION pp SETTINGS mutations_sync=2, alter_sync=2"
+
+# Detach the partition so that parts with pp.proj are moved to detached/.
+run "ALTER TABLE t_unknown_proj_1 DETACH PARTITION 0 SETTINGS mutations_sync=2, alter_sync=2"
+
+# Drop projection pp from the table metadata while the partition is detached.
+run "ALTER TABLE t_unknown_proj_1 CLEAR PROJECTION pp SETTINGS mutations_sync=2, alter_sync=2"
+run "ALTER TABLE t_unknown_proj_1 DROP PROJECTION pp SETTINGS mutations_sync=2, alter_sync=2"
+
+# Drop the detached part from replica 2 to force it to fetch the part with the unknown projection from replica 1.
+run "ALTER TABLE t_unknown_proj_2 DROP DETACHED PARTITION 0 SETTINGS allow_drop_detached=1"
+
+# Re-attach: the part still has pp.proj on disk, but the table no longer
+# knows about projection pp.
+run "ALTER TABLE t_unknown_proj_1 ATTACH PARTITION 0 SETTINGS mutations_sync=2"
+
+# The part must be usable: CHECK TABLE should pass and data should be intact.
+echo "=== Replicated MergeTree ==="
+run "SELECT count() FROM t_unknown_proj_1"
+run "CHECK TABLE t_unknown_proj_1" 2>&1 | grep -o "Found unexpected projection directories: pp.proj" | uniq
+
+run "SELECT sum(x), sum(y) FROM t_unknown_proj_1"
+
+# Replica 2 must fetch the part with the unknown projection from replica 1
+# via downloadPartToDisk on a local disk.  This exercises the receiver-side
+# checkEqual that compares checksums.txt against actually transferred files.
+run "SYSTEM SYNC REPLICA t_unknown_proj_2"
+run "SELECT count() FROM t_unknown_proj_2"
+run "SELECT sum(x), sum(y) FROM t_unknown_proj_2"
+
+# Force a merge to make sure the part with the unknown projection can merge.
+run "ALTER TABLE t_unknown_proj_1 MODIFY SETTING max_parts_to_merge_at_once = 100"
+run "OPTIMIZE TABLE t_unknown_proj_1 FINAL"
+run "SELECT count() FROM t_unknown_proj_1"
+run "SELECT sum(x), sum(y) FROM t_unknown_proj_1"
+
+for i in $(seq $REPLICAS);
+do
+     run "DROP TABLE IF EXISTS t_unknown_proj_$i SYNC"
+done
+
+# ── Plain MergeTree test ────────────────────────────────────────────────────
+run "DROP TABLE IF EXISTS t_unknown_proj_mt SYNC"
+run "CREATE TABLE t_unknown_proj_mt (x Int32, y Int32, PROJECTION p (SELECT x, y ORDER BY x))
+     ENGINE = MergeTree()
+     PARTITION BY intDiv(y, 100) ORDER BY y
+     SETTINGS max_parts_to_merge_at_once = 1"
+
+run "INSERT INTO t_unknown_proj_mt SELECT number, number FROM numbers(7)"
+
+run "ALTER TABLE t_unknown_proj_mt ADD PROJECTION pp (SELECT x, count() GROUP BY x) SETTINGS mutations_sync=2"
+run "ALTER TABLE t_unknown_proj_mt MATERIALIZE PROJECTION pp SETTINGS mutations_sync=2, alter_sync=2"
+
+run "ALTER TABLE t_unknown_proj_mt DETACH PARTITION 0 SETTINGS mutations_sync=2, alter_sync=2"
+
+run "ALTER TABLE t_unknown_proj_mt CLEAR PROJECTION pp SETTINGS mutations_sync=2, alter_sync=2"
+run "ALTER TABLE t_unknown_proj_mt DROP PROJECTION pp SETTINGS mutations_sync=2, alter_sync=2"
+
+run "ALTER TABLE t_unknown_proj_mt ATTACH PARTITION 0 SETTINGS mutations_sync=2, alter_sync=2"
+
+echo "=== MergeTree ==="
+run "SELECT count() FROM t_unknown_proj_mt"
+run "CHECK TABLE t_unknown_proj_mt" 2>&1 | grep -o "Found unexpected projection directories: pp.proj" | uniq
+
+# Force a merge.
+run "ALTER TABLE t_unknown_proj_mt MODIFY SETTING max_parts_to_merge_at_once = 100"
+run "OPTIMIZE TABLE t_unknown_proj_mt FINAL"
+run "SELECT count() FROM t_unknown_proj_mt"
+
+run "DROP TABLE t_unknown_proj_mt SYNC"

--- a/tests/queries/0_stateless/03822_attach_with_unknown_projection.sh
+++ b/tests/queries/0_stateless/03822_attach_with_unknown_projection.sh
@@ -61,9 +61,9 @@ run "SELECT count() FROM t_unknown_proj_2"
 run "SELECT sum(x), sum(y) FROM t_unknown_proj_2"
 
 # CHECK TABLE on replica 2 must not fail with NO_FILE_IN_DATA_PART:
-# checksums.txt references pp.proj but the directory was never transferred,
-# so loadChecksums must strip it before checkDataPart runs.
-run "CHECK TABLE t_unknown_proj_2" 2>&1 | grep -o "NO_FILE_IN_DATA_PART\|BROKEN_PROJECTION" | uniq
+# checksums.txt references pp.proj but the directory was never transferred.
+# checkDataPart must strip phantom .proj entries before the checkEqual comparison.
+run "CHECK TABLE t_unknown_proj_2"
 
 # Force a merge to make sure the part with the unknown projection can merge.
 run "ALTER TABLE t_unknown_proj_1 MODIFY SETTING max_parts_to_merge_at_once = 100"

--- a/tests/queries/0_stateless/03822_attach_with_unknown_projection.sh
+++ b/tests/queries/0_stateless/03822_attach_with_unknown_projection.sh
@@ -60,6 +60,11 @@ run "SYSTEM SYNC REPLICA t_unknown_proj_2"
 run "SELECT count() FROM t_unknown_proj_2"
 run "SELECT sum(x), sum(y) FROM t_unknown_proj_2"
 
+# CHECK TABLE on replica 2 must not fail with NO_FILE_IN_DATA_PART:
+# checksums.txt references pp.proj but the directory was never transferred,
+# so loadChecksums must strip it before checkDataPart runs.
+run "CHECK TABLE t_unknown_proj_2" 2>&1 | grep -o "NO_FILE_IN_DATA_PART\|BROKEN_PROJECTION" | uniq
+
 # Force a merge to make sure the part with the unknown projection can merge.
 run "ALTER TABLE t_unknown_proj_1 MODIFY SETTING max_parts_to_merge_at_once = 100"
 run "OPTIMIZE TABLE t_unknown_proj_1 FINAL"


### PR DESCRIPTION
When a part is fetched from a replica whose `checksums.txt` references a `.proj` that was dropped from the table metadata, the `.proj` directory is never transferred but `checksums.txt` is copied verbatim from the sender. This causes two problems:

1. The in-memory `checksums` object (loaded by `loadChecksums`) contains phantom `.proj` entries, affecting metrics and removal.
2. `checkDataPart` (called by `CHECK TABLE` and `ReplicatedMergeTreePartCheckThread`) re-reads `checksums.txt` from disk and throws `NO_FILE_IN_DATA_PART`, marking the part broken and triggering an infinite re-fetch loop.

Fix: strip phantom `.proj` entries (whose directories do not exist on disk) in two places:
- `loadChecksums`: cleans the in-memory view after reading the file (parts are immutable, on-disk file is not modified).
- `checkDataPart`: strips entries from `checksums_txt` before `checkEqual`, since it reads the file independently from disk.

Fixes https://github.com/ClickHouse/ClickHouse/issues/100413
Related: #99623

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed an infinite re-fetch loop on a replica that fetched a part containing an unknown projection: `checkDataPart` was throwing `NO_FILE_IN_DATA_PART` because `checksums.txt` referenced a `.proj` entry whose directory was never transferred.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)