### PR TITLE
DataLakeCatalog: avoid full catalog read for `UNKNOWN_TABLE` typo hints

### DIFF
--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -87,6 +87,7 @@ namespace Setting
 {
     extern const SettingsBool fsync_metadata;
     extern const SettingsBool allow_experimental_analyzer;
+    extern const SettingsBool show_data_lake_catalogs_in_system_tables;
 }
 
 namespace MergeTreeSetting
@@ -2236,9 +2237,12 @@ std::pair<String, String> TableNameHints::getExtendedHintForTable(const String &
 
 Names TableNameHints::getAllRegisteredNames() const
 {
-    if (database)
-        return database->getAllTableNames(context);
-    return {};
+    if (!database)
+        return {};
+    /// DataLakeCatalog::getAllTableNames lists all tables from remote catalog - expensive. Skip when user opted out.
+    if (database->isDatalakeCatalog() && context && !context->getSettingsRef()[Setting::show_data_lake_catalogs_in_system_tables])
+        return {};
+    return database->getAllTableNames(context);
 }
 
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Avoid scanning the whole remote data lake catalog for “Maybe you meant …” table hints when `show_data_lake_catalogs_in_system_tables` is disabled.

### Documentation entry for user-facing changes

When `show_data_lake_catalogs_in_system_tables = 0`, the server must not implicitly scan the whole remote data lake catalog.  
Previously, building the **“Maybe you meant …”** hint for a missing table in a `DataLakeCatalog` database still called `getAllTableNames()` → `DatabaseDataLake::getTablesIterator()`, which lists the entire catalog and loads per-table metadata—heavy work and can **OOM** on large catalogs, only to enrich an error message.

This change makes **`TableNameHints::getAllRegisteredNames()`** return an empty name list for data lake catalogs when that setting is off, so hint generation does not trigger a full catalog listing.


#### Query examples


```sql
SET show_data_lake_catalogs_in_system_tables = 0;
```

Drop non-existent table:

```sql
DROP TABLE datalake.`schema1.table1`;
```

Previously (undesired): server could answer with `UNKNOWN_TABLE` and a **“Maybe you meant …”** suggestion after scanning catalog names:
```
Received exception from server (version 26.3.1):
Code: 60. DB::Exception: Received from localhost:9000. DB::Exception: Table datalake.`schema1.table1` does not exist. Maybe you meant datalake.`schema1.table`?. (UNKNOWN_TABLE)
```
After the fix: `UNKNOWN_TABLE` without hint when the setting is `0`:
```
Received exception from server (version 26.4.1):
Code: 60. DB::Exception: Received from localhost:9000. DB::Exception: Table datalake.`schema1.table1` does not exist. (UNKNOWN_TABLE)
```


#### Optional follow-up

If local hints are skipped for data lake + setting `0`, **`getHintForTable`** can still fall back to **`getExtendedHintForTable`**, which only scans **non–data-lake** databases. In edge cases a suggestion could point at another database’s table. If that is undesirable, a follow-up could skip extended hints under the same condition as local enumeration.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.807`
<!-- ch-version-info:end -->