### PR TITLE
Fix DeltaLake CDF copy-paste bug: second OR-branch of is_delta_lake_cdf checked wrong setting

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -136,7 +136,7 @@ StorageObjectStorage::StorageObjectStorage(
         is_datalake_query, columns_in_table_or_function_definition.toString(true));
 
     bool is_delta_lake_cdf = context->getSettingsRef()[Setting::delta_lake_snapshot_start_version] != -1
-            || context->getSettingsRef()[Setting::delta_lake_snapshot_start_version] != -1;
+            || context->getSettingsRef()[Setting::delta_lake_snapshot_end_version] != -1;
 
     if (!is_table_function && is_delta_lake_cdf)
     {
@@ -469,7 +469,7 @@ void StorageObjectStorage::read(
                 return;
             }
         }
-        else if (auto end_version = settings[Setting::delta_lake_snapshot_start_version].value;
+        else if (auto end_version = settings[Setting::delta_lake_snapshot_end_version].value;
                  end_version != DeltaLake::TableSnapshot::LATEST_SNAPSHOT_VERSION)
         {
             throw DB::Exception(

--- a/tests/integration/test_storage_delta/test_cdf.py
+++ b/tests/integration/test_storage_delta/test_cdf.py
@@ -228,10 +228,13 @@ SET TBLPROPERTIES ('delta.minReaderVersion'='1', 'delta.minWriterVersion'='2', d
     )
     # Regression for https://github.com/ClickHouse/ClickHouse/issues/100449:
     # using end_version on a table function without start_version must throw BAD_ARGUMENTS.
+    # Use plain non-CDF columns here: _change_type and _commit_version only exist in the
+    # schema when start_version is set (CDF mode), so selecting them without start_version
+    # causes UNKNOWN_IDENTIFIER before reaching the BAD_ARGUMENTS guard.
     assert (
         "Cannot use delta_lake_snapshot_end_version without delta_lake_snapshot_start_version"
         in instance.query_and_get_error(
-            f"SELECT {select_columns} FROM {table_function} ORDER BY all",
+            f"SELECT first_name, age FROM {table_function} ORDER BY all",
             settings={"delta_lake_snapshot_end_version": 3},
         )
     )

--- a/tests/integration/test_storage_delta/test_cdf.py
+++ b/tests/integration/test_storage_delta/test_cdf.py
@@ -216,6 +216,25 @@ SET TBLPROPERTIES ('delta.minReaderVersion'='1', 'delta.minWriterVersion'='2', d
             settings={"delta_lake_snapshot_start_version": 0},
         )
     )
+    # Regression for https://github.com/ClickHouse/ClickHouse/issues/100449:
+    # setting only end_version (without start_version) must also be detected as a
+    # CDF request and rejected for stored tables.
+    assert (
+        "Delta lake CDF is allowed only for deltaLake table function"
+        in instance.query_and_get_error(
+            f"CREATE TABLE a ENGINE = DeltaLake('http://{started_cluster.minio_ip}:{started_cluster.minio_port}/{bucket}/{table_name}/', 'minio', '{minio_secret_key}')",
+            settings={"delta_lake_snapshot_end_version": 3},
+        )
+    )
+    # Regression for https://github.com/ClickHouse/ClickHouse/issues/100449:
+    # using end_version on a table function without start_version must throw BAD_ARGUMENTS.
+    assert (
+        "Cannot use delta_lake_snapshot_end_version without delta_lake_snapshot_start_version"
+        in instance.query_and_get_error(
+            f"SELECT {select_columns} FROM {table_function} ORDER BY all",
+            settings={"delta_lake_snapshot_end_version": 3},
+        )
+    )
     # Data with CDF enabled starts from snapshot version 2.
     # Snapshot version 1 is just a metadata change. 
     # Reading from snapshot version 1 can sometimes fail with "cdf not enabled", because metadata is propagated asynchronously.

--- a/tests/queries/0_stateless/04054_deltalake_cdf_copy_paste_bug.sql
+++ b/tests/queries/0_stateless/04054_deltalake_cdf_copy_paste_bug.sql
@@ -1,0 +1,12 @@
+-- Tags: no-fasttest
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/100449
+--
+-- Copy-paste bug: both OR-branches of is_delta_lake_cdf checked
+-- delta_lake_snapshot_start_version.  Setting only delta_lake_snapshot_end_version
+-- must also be detected as a CDF request.
+--
+-- The constructor check in StorageObjectStorage fires before any network access,
+-- so a non-existent URL is sufficient to trigger it.
+
+SET delta_lake_snapshot_end_version = 1;
+CREATE TABLE t_cdf_bug (x UInt32) ENGINE = S3('http://nonexistent_host/bucket/file.parquet', 'Parquet'); -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
Fix two copy-paste bugs introduced with DeltaLake CDF (Change Data Feed) support in `StorageObjectStorage.cpp`.

**Bug 1 — `is_delta_lake_cdf` detection (constructor, line ~138):**
Both OR-branches checked `delta_lake_snapshot_start_version`. The second must check `delta_lake_snapshot_end_version`. Without the fix, setting only `end_version` leaves `is_delta_lake_cdf = false`, silently bypassing the stored-table guard.

**Bug 2 — guard against `end_version` without `start_version` (read path, line ~472):**
The variable is named `end_version` but was populated from `delta_lake_snapshot_start_version`. The condition always evaluated to false when `start_version == -1`, making the guard dead code.

Fixes https://github.com/ClickHouse/ClickHouse/issues/100449

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a copy-paste bug where `delta_lake_snapshot_end_version` set without `delta_lake_snapshot_start_version` was silently ignored instead of producing a `BAD_ARGUMENTS` error.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.154`
- Backported to: `26.2.6.16`
<!-- ch-version-info:end -->