### PR TITLE
Fix segfault due to calling `StorageRabbitMQ::shutdown` twice

### DIFF
--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -902,6 +902,9 @@ void StorageRabbitMQ::shutdown(bool)
     if (shutdown_called.exchange(true))
         return;
 
+    LOG_TRACE(log, "Deactivating init task");
+    deactivateTask(init_task, true, false);
+
     for (auto & consumer_weak : consumers_ref)
     {
         auto consumer = consumer_weak.lock();
@@ -910,14 +913,11 @@ void StorageRabbitMQ::shutdown(bool)
         consumer->stop();
     }
 
-    LOG_TRACE(log, "Deactivating background tasks");
-
-    /// In case it has not yet been able to setup connection;
-    deactivateTask(init_task, true, false);
-
     /// The order of deactivating tasks is important: wait for streamingToViews() func to finish and
     /// then wait for background event loop to finish.
+    LOG_TRACE(log, "Deactivating streaming task");
     deactivateTask(streaming_task, true, false);
+    LOG_TRACE(log, "Deactivating looping task");
     deactivateTask(looping_task, true, true);
 
     LOG_TRACE(log, "Cleaning up RabbitMQ after table usage");
@@ -942,6 +942,8 @@ void StorageRabbitMQ::shutdown(bool)
 
         for (size_t i = 0; i < num_created_consumers; ++i)
             popConsumer();
+
+        consumers_ref.clear();
     }
     catch (...)
     {

--- a/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
+++ b/src/Storages/RabbitMQ/StorageRabbitMQ.cpp
@@ -898,10 +898,17 @@ void StorageRabbitMQ::startup()
 
 void StorageRabbitMQ::shutdown(bool)
 {
-    shutdown_called = true;
+    /// Needed to make this method idempotent
+    if (shutdown_called.exchange(true))
+        return;
 
-    for (auto & consumer : consumers_ref)
-        consumer.lock()->stop();
+    for (auto & consumer_weak : consumers_ref)
+    {
+        auto consumer = consumer_weak.lock();
+        if (!consumer)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "RabbitMQ consumer has been unexpectedly destroyed");
+        consumer->stop();
+    }
 
     LOG_TRACE(log, "Deactivating background tasks");
 
@@ -918,8 +925,13 @@ void StorageRabbitMQ::shutdown(bool)
     /// Just a paranoid try catch, it is not actually needed.
     try
     {
-        for (auto & consumer : consumers_ref)
-            consumer.lock()->closeConnections();
+        for (auto & consumer_weak : consumers_ref)
+        {
+            auto consumer = consumer_weak.lock();
+            if (!consumer)
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "RabbitMQ consumer has been unexpectedly destroyed");
+            consumer->closeConnections();
+        }
 
         if (drop_table)
             cleanupRabbitMQ();

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -41,7 +41,6 @@ def get_last_event_time(logger_name, message):
     return datetime.datetime.fromisoformat(ts)
 
 
-@pytest.mark.skip(reason="There is data race in Rabbit MQ storage when shutting down")
 def test_shutdown_rabbitmq_with_materialized_view(started_cluster):
     """
     Test that restarting server during active RabbitMQ consumption


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1500
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1487
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1511
<!-- End of fixes issue link part, do not remove -->

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`StorageRabbitMQ::shutdown` is not idempotent (it unconditionally accesses weak pointers and then destroys the corresponding shared pointers), but is now called twice: once in `StreamingStorageRegistry` and then in `DatabaseCatalog`. This fix makes the method idempotent and adds defensive null checks. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.183`
- Backported to: `26.3.1.890`
<!-- ch-version-info:end -->