### PR TITLE
Fix false-positive hung check failure caused by server-side AST fuzzer

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -503,6 +503,12 @@ def clickhouse_execute_http(
         "http_send_timeout": timeout,
         "output_format_parallel_formatting": 0,
         "max_rows_to_read": 0,  # Some queries read from system.text_log which might get too big
+        # Disable server-side AST fuzzer for infrastructure queries (hung
+        # check, log analysis, etc.).  The stress test profile sets
+        # ast_fuzzer_runs=5, and without this override the fuzzer mutates
+        # the hung-check processlist query, spawning new queries that then
+        # appear in the processlist — causing a false-positive hung check.
+        "ast_fuzzer_runs": 0,
     }
     if settings is not None:
         params.update(settings)
@@ -4660,16 +4666,29 @@ def main(args):
             try:
                 processlist = get_processlist_with_stacktraces(args)
             except Exception as e:
-                print(
-                    colored(
-                        "\nHung check failed. Failed to get processlist with stacktraces: "
-                        + str(e),
-                        args,
-                        "red",
-                        attrs=["bold"],
+                # The stacktrace query is expensive (JOIN + symbolization) and
+                # can time out under sanitizers.  Re-check whether the queries
+                # are still running — if they finished in the meantime, it was
+                # not a real hang.
+                try:
+                    hung_count = get_processlist_size(args)
+                except Exception:
+                    hung_count = -1
+                if hung_count != 0:
+                    print(
+                        colored(
+                            "\nHung check failed. Failed to get processlist with stacktraces: "
+                            + str(e),
+                            args,
+                            "red",
+                            attrs=["bold"],
+                        )
                     )
-                )
-                exit_code.value = 1
+                    exit_code.value = 1
+                else:
+                    print(
+                        " queries finished while collecting stacktraces, not a hang"
+                    )
 
         if processlist:
             print(

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -4662,6 +4662,7 @@ def main(args):
             exit_code.value = 1
 
         processlist = ""
+        hung_check_failed = False
         if hung_count > 0:
             try:
                 processlist = get_processlist_with_stacktraces(args)
@@ -4685,6 +4686,7 @@ def main(args):
                         )
                     )
                     exit_code.value = 1
+                    hung_check_failed = True
                 else:
                     print(
                         " queries finished while collecting stacktraces, not a hang"
@@ -4701,7 +4703,7 @@ def main(args):
 
             print_stacktraces()
             exit_code.value = 1
-        else:
+        elif not hung_check_failed:
             print(colored("\nNo queries hung.", args, "green", attrs=["bold"]))
 
     if len(restarted_tests) > 0:


### PR DESCRIPTION
The stress test profile sets `ast_fuzzer_runs=5` in the server config, enabling server-side AST fuzzing for all queries. When the hung check runs its `SELECT count() FROM system.processes` query via HTTP, the fuzzer mutates it and spawns additional queries that themselves appear in the processlist — creating a self-referential loop where the hung check always sees > 0 queries. After 90 seconds of polling, it attempts `get_processlist_with_stacktraces` (a heavy JOIN with symbolization, also fuzzed), which times out. By then the original queries have finished, but `exit_code=1` is already set.

Two fixes:
1. Add `ast_fuzzer_runs=0` to the default HTTP params in `clickhouse_execute_http`, so all infrastructure queries (hung check, log analysis) are not fuzzed.
2. When `get_processlist_with_stacktraces` times out, re-check `get_processlist_size` — if queries have finished during the timeout, don't treat it as a failure.

References: https://github.com/ClickHouse/ClickHouse/pull/100439
Closes https://github.com/ClickHouse/ClickHouse/issues/100445

### Changelog category:
- CI Fix or Improvement

### Changelog entry:
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.181`
<!-- ch-version-info:end -->