### PR TITLE
Fix missing stream exception for nested JSON in wide parts

### DIFF
--- a/src/Columns/ColumnDynamic.h
+++ b/src/Columns/ColumnDynamic.h
@@ -214,7 +214,7 @@ public:
 
     ColumnPtr filter(const Filter & filt, ssize_t result_size_hint) const override
     {
-        return create(variant_column_ptr->filter(filt, result_size_hint), variant_info, max_dynamic_types, global_max_dynamic_types);
+        return create(variant_column_ptr->filter(filt, result_size_hint), variant_info, max_dynamic_types, global_max_dynamic_types, statistics);
     }
 
     void filter(const Filter & filt) override
@@ -235,12 +235,12 @@ public:
 
     ColumnPtr index(const IColumn & indexes, size_t limit) const override
     {
-        return create(variant_column_ptr->index(indexes, limit), variant_info, max_dynamic_types, global_max_dynamic_types);
+        return create(variant_column_ptr->index(indexes, limit), variant_info, max_dynamic_types, global_max_dynamic_types, statistics);
     }
 
     ColumnPtr replicate(const Offsets & replicate_offsets) const override
     {
-        return create(variant_column_ptr->replicate(replicate_offsets), variant_info, max_dynamic_types, global_max_dynamic_types);
+        return create(variant_column_ptr->replicate(replicate_offsets), variant_info, max_dynamic_types, global_max_dynamic_types, statistics);
     }
 
     VectorWithMemoryTracking<MutableColumnPtr> scatter(size_t num_columns, const Selector & selector) const override
@@ -249,7 +249,7 @@ public:
         VectorWithMemoryTracking<MutableColumnPtr> scattered_columns;
         scattered_columns.reserve(num_columns);
         for (auto & scattered_variant_column : scattered_variant_columns)
-            scattered_columns.emplace_back(create(std::move(scattered_variant_column), variant_info, max_dynamic_types, global_max_dynamic_types));
+            scattered_columns.emplace_back(create(std::move(scattered_variant_column), variant_info, max_dynamic_types, global_max_dynamic_types, statistics));
 
         return scattered_columns;
     }

--- a/src/Columns/ColumnObject.cpp
+++ b/src/Columns/ColumnObject.cpp
@@ -1173,7 +1173,7 @@ ColumnPtr ColumnObject::filter(const Filter & filt, ssize_t result_size_hint) co
         filtered_dynamic_paths[path] = column->filter(filt, result_size_hint);
 
     auto filtered_shared_data = shared_data->filter(filt, result_size_hint);
-    return ColumnObject::create(filtered_typed_paths, filtered_dynamic_paths, filtered_shared_data, max_dynamic_paths, global_max_dynamic_paths, max_dynamic_types);
+    return ColumnObject::create(filtered_typed_paths, filtered_dynamic_paths, filtered_shared_data, max_dynamic_paths, global_max_dynamic_paths, max_dynamic_types, statistics);
 }
 
 void ColumnObject::filter(const Filter & filt)
@@ -1227,7 +1227,7 @@ ColumnPtr ColumnObject::index(const IColumn & indexes, size_t limit) const
         indexed_dynamic_paths[path] = column->index(indexes, limit);
 
     auto indexed_shared_data = shared_data->index(indexes, limit);
-    return ColumnObject::create(indexed_typed_paths, indexed_dynamic_paths, indexed_shared_data, max_dynamic_paths, global_max_dynamic_paths, max_dynamic_types);
+    return ColumnObject::create(indexed_typed_paths, indexed_dynamic_paths, indexed_shared_data, max_dynamic_paths, global_max_dynamic_paths, max_dynamic_types, statistics);
 }
 
 ColumnPtr ColumnObject::replicate(const Offsets & replicate_offsets) const
@@ -1243,7 +1243,7 @@ ColumnPtr ColumnObject::replicate(const Offsets & replicate_offsets) const
         replicated_dynamic_paths[path] = column->replicate(replicate_offsets);
 
     auto replicated_shared_data = shared_data->replicate(replicate_offsets);
-    return ColumnObject::create(replicated_typed_paths, replicated_dynamic_paths, replicated_shared_data, max_dynamic_paths, global_max_dynamic_paths, max_dynamic_types);
+    return ColumnObject::create(replicated_typed_paths, replicated_dynamic_paths, replicated_shared_data, max_dynamic_paths, global_max_dynamic_paths, max_dynamic_types, statistics);
 }
 
 VectorWithMemoryTracking<MutableColumnPtr> ColumnObject::scatter(size_t num_columns, const Selector & selector) const
@@ -1274,7 +1274,7 @@ VectorWithMemoryTracking<MutableColumnPtr> ColumnObject::scatter(size_t num_colu
     VectorWithMemoryTracking<MutableColumnPtr> result_columns;
     result_columns.reserve(num_columns);
     for (size_t i = 0; i != num_columns; ++i)
-        result_columns.emplace_back(ColumnObject::create(std::move(scattered_typed_paths[i]), std::move(scattered_dynamic_paths[i]), std::move(scattered_shared_data_columns[i]), max_dynamic_paths, global_max_dynamic_paths, max_dynamic_types));
+        result_columns.emplace_back(ColumnObject::create(std::move(scattered_typed_paths[i]), std::move(scattered_dynamic_paths[i]), std::move(scattered_shared_data_columns[i]), max_dynamic_paths, global_max_dynamic_paths, max_dynamic_types, statistics));
     return result_columns;
 }
 

--- a/tests/queries/0_stateless/04054_json_nested_shared_data_buckets_missing_stream_bug.reference
+++ b/tests/queries/0_stateless/04054_json_nested_shared_data_buckets_missing_stream_bug.reference
@@ -1,0 +1,3 @@
+1	{"images":[{"url":"c","width":300}]}
+2	{"images":[{"url":"d","width":400}]}
+3	{"images":[{"url":"a","width":100}]}

--- a/tests/queries/0_stateless/04054_json_nested_shared_data_buckets_missing_stream_bug.sql
+++ b/tests/queries/0_stateless/04054_json_nested_shared_data_buckets_missing_stream_bug.sql
@@ -1,0 +1,42 @@
+-- Tags: long
+
+SET allow_experimental_json_type = 1;
+
+-- Regression test for a bug where ColumnObject::index (and filter/replicate/scatter)
+-- did not propagate statistics, causing a mismatch between the number of shared data
+-- buckets chosen during stream creation vs serialization state creation for nested JSON
+-- columns inside Array(JSON). This resulted in:
+-- "Stream ... object_shared_data.1.size1 not found" (LOGICAL_ERROR)
+--
+-- The bug requires: Wide parts, nested JSON with empty shared data, a non-trivial
+-- permutation applied during INSERT, and optimize_on_insert=0 to prevent mergeBlock
+-- from pre-sorting the block and nullifying the permutation.
+
+DROP TABLE IF EXISTS src;
+DROP TABLE IF EXISTS dst;
+
+CREATE TABLE src (id UInt64, data JSON(max_dynamic_paths=256))
+ENGINE = MergeTree ORDER BY tuple()
+SETTINGS min_bytes_for_wide_part=0;
+
+INSERT INTO src VALUES
+    (3, '{"images": [{"url": "a", "width": 100}]}'),
+    (2, '{"images": [{"url": "d", "width": 400}]}'),
+    (1, '{"images": [{"url": "c", "width": 300}]}');
+
+CREATE TABLE dst (id UInt64, data JSON(max_dynamic_paths=256))
+ENGINE = MergeTree ORDER BY id
+SETTINGS min_bytes_for_wide_part=0;
+
+-- Data arrives at the MergeTree sink with statistics intact from reading the source part.
+-- The sink applies a permutation to sort by id. With optimize_on_insert=0, the raw
+-- permutation is passed to the writer. The inner JSON (inside Array) goes through
+-- ColumnArray::permute -> ColumnArray::indexImpl -> ColumnObject::index.
+-- Before the fix, ColumnObject::index dropped statistics, causing a bucket count mismatch.
+INSERT INTO dst SELECT * FROM src
+SETTINGS max_insert_threads=1, optimize_on_insert=0;
+
+SELECT id, data FROM dst ORDER BY id;
+
+DROP TABLE src;
+DROP TABLE dst;


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1717
<!-- End of fixes issue link part, do not remove -->

PR #97523 fixed `ColumnObject::permute` and `ColumnDynamic::permute` to propagate `statistics`, but left the same bug in `filter`, `index`, `replicate`, and `scatter` for both `ColumnObject` and `ColumnDynamic`.

When a top-level JSON column containing `Array(JSON)` is permuted during INSERT (e.g. MergeTree sorting with `optimize_on_insert=0`), the chain `ColumnObject::permute` → `ColumnArray::permute` → `indexImpl` → `ColumnObject::index` drops statistics on the inner JSON column. This causes a mismatch: `enumerateStreams` (stream creation) uses the `block_sample` column which retains statistics via `cloneEmpty` and chooses 1 bucket (empty shared data optimization), while `serializeBinaryBulkStatePrefix` (serialization) uses the permuted column without statistics and chooses N buckets. The subsequent write to bucket 1 fails with "Stream ... not found" (LOGICAL_ERROR).

Reported by customer on version 25.12.1.1459:
```
Code: 49. DB::Exception: Stream light_images.images.Array(JSON(max_dynamic_types=16, max_dynamic_paths=256)).object_shared_data.1.size1 not found. (LOGICAL_ERROR)
```

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix LOGICAL_ERROR exception "Stream ... not found" when inserting into a table with nested `Array(JSON)` columns in wide parts with `optimize_on_insert=0`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.201`
- Backported to: `26.3.1.893`, `26.2.6.19`, `26.1.7.8`, `25.12.9.63`, `25.8.21.6`, `25.3.15.24`
<!-- ch-version-info:end -->