### PR TITLE
Flaky `02125_many_mutations_2`

### DIFF
--- a/tests/queries/0_stateless/02125_many_mutations_2.sh
+++ b/tests/queries/0_stateless/02125_many_mutations_2.sh
@@ -11,7 +11,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 $CLICKHOUSE_CLIENT -q "
 drop table if exists many_mutations;
-create table many_mutations (x UInt32, y UInt32) engine = MergeTree order by x settings number_of_mutations_to_delay = 0, number_of_mutations_to_throw = 0, max_parts_to_merge_at_once = 1;
+create table many_mutations (x UInt32, y UInt32) engine = MergeTree order by x settings number_of_mutations_to_delay = 0, number_of_mutations_to_throw = 0, max_parts_to_merge_at_once = 1, lock_acquire_timeout_for_background_operations=600;
 insert into many_mutations select number, number + 1 from numbers(2000);
 system stop merges many_mutations;
 "


### PR DESCRIPTION
### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

[Test failed here with a Timeout](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99462&sha=6af0a2208647e5333981cb8f9b185142f02988e1&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20sequential%29&name_1=Stateless%20tests%20%28arm_binary%2C%20sequential%29
https://github.com/ClickHouse/ClickHouse/pull/99462)

The place where the error message is coming from suggests, that the timeout fired due the value `lock_acquire_timeout_for_background_operations`. The following is likely to happen: 
1. We have a lot of mutatuions pending on a part 
2. They all start being executed at once
3. OPTIMIZE TABLE many_mutations FINAL gets executed right after that
4. Optimize table waits with a 120-second timeout
5. Due to randomized settings, heavy CI load etc, we hit the timeout

In order to fix this, the first solution for me was to increase timeout up to the upper bound for a test execution time.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.208`
<!-- ch-version-info:end -->