### PR TITLE
[DOCS] - clarify what linux version should have THP set to madvise

### DIFF
--- a/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
+++ b/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
@@ -1833,6 +1833,7 @@ defaultProfiles
 defaultRoles
 defaultValueOfArgumentType
 defaultValueOfTypeName
+defragmentation
 delim
 deltaLake
 deltaLakeCluster

--- a/docs/en/operations/tips.md
+++ b/docs/en/operations/tips.md
@@ -123,8 +123,7 @@ Use at least a 10 GB network, if possible. 1 Gb will also work, but it will be m
 
 ## Huge Pages {#huge-pages}
 
-If you are using old Linux kernel, disable transparent huge pages. It interferes with memory allocator, which leads to significant performance degradation.
-On newer Linux kernels transparent huge pages are alright.
+Always set transparent huge pages to `madvise`. On older kernels (before 5.9), THP set to `always` can cause significant performance degradation — the kernel spends excessive time on memory defragmentation, especially on systems with 64 GB+ of RAM. Kernel 5.9 introduced proactive compaction, which handles THP much better, but ClickHouse still warns at startup if THP is set to `always`, so `madvise` is the recommended setting regardless of kernel version.
 
 ```bash
 $ echo 'madvise' | sudo tee /sys/kernel/mm/transparent_hugepage/enabled


### PR DESCRIPTION
Resolving https://github.com/ClickHouse/clickhouse-docs/issues/2997

Updating Transparent Huge Pages guide to recommend madvise and flagging specific Kernel Version (5.9)

### Changelog category (leave one):
- Documentation (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.214`
<!-- ch-version-info:end -->