### PR TITLE
Fix segfault due to bad cast in `SerializationInfoTuple`

### DIFF
--- a/src/DataTypes/Serializations/SerializationInfoTuple.cpp
+++ b/src/DataTypes/Serializations/SerializationInfoTuple.cpp
@@ -61,14 +61,20 @@ void SerializationInfoTuple::add(const SerializationInfo & other)
 {
     SerializationInfo::add(other);
 
-    const auto & other_info = assert_cast<const SerializationInfoTuple &>(other);
+    const auto * other_info = typeid_cast<const SerializationInfoTuple *>(&other);
+    if (!other_info)
+    {
+        chassert(typeid(other) == typeid(SerializationInfo));
+        return;
+    }
+
     for (const auto & [name, elem] : name_to_elem)
     {
-        auto it = other_info.name_to_elem.find(name);
-        if (it != other_info.name_to_elem.end())
+        auto it = other_info->name_to_elem.find(name);
+        if (it != other_info->name_to_elem.end())
             elem->add(*it->second);
         else
-            elem->addDefaults(other_info.getData().num_rows);
+            elem->addDefaults(other_info->getData().num_rows);
     }
 }
 
@@ -97,11 +103,17 @@ void SerializationInfoTuple::replaceData(const SerializationInfo & other)
 {
     SerializationInfo::replaceData(other);
 
-    const auto & other_info = assert_cast<const SerializationInfoTuple &>(other);
+    const auto * other_info = typeid_cast<const SerializationInfoTuple *>(&other);
+    if (!other_info)
+    {
+        chassert(typeid(other) == typeid(SerializationInfo));
+        return;
+    }
+
     for (const auto & [name, elem] : name_to_elem)
     {
-        auto it = other_info.name_to_elem.find(name);
-        if (it != other_info.name_to_elem.end())
+        auto it = other_info->name_to_elem.find(name);
+        if (it != other_info->name_to_elem.end())
             elem->replaceData(*it->second);
     }
 }

--- a/src/DataTypes/Serializations/SerializationInfoTuple.cpp
+++ b/src/DataTypes/Serializations/SerializationInfoTuple.cpp
@@ -64,7 +64,6 @@ void SerializationInfoTuple::add(const SerializationInfo & other)
     const auto * other_info = typeid_cast<const SerializationInfoTuple *>(&other);
     if (!other_info)
     {
-        chassert(typeid(other) == typeid(SerializationInfo));
         return;
     }
 
@@ -106,7 +105,6 @@ void SerializationInfoTuple::replaceData(const SerializationInfo & other)
     const auto * other_info = typeid_cast<const SerializationInfoTuple *>(&other);
     if (!other_info)
     {
-        chassert(typeid(other) == typeid(SerializationInfo));
         return;
     }
 

--- a/tests/queries/0_stateless/04054_merge_after_alter_to_tuple.reference
+++ b/tests/queries/0_stateless/04054_merge_after_alter_to_tuple.reference
@@ -1,0 +1,3 @@
+1	1
+('foo','bar')
+('hello','world')

--- a/tests/queries/0_stateless/04054_merge_after_alter_to_tuple.sql
+++ b/tests/queries/0_stateless/04054_merge_after_alter_to_tuple.sql
@@ -1,4 +1,4 @@
--- Tags: no-random-merge-tree-settings
+-- Tags: no-parallel, no-random-merge-tree-settings
 
 -- Regression test: merging parts after ALTER MODIFY COLUMN changed a column
 -- from a non-Tuple type to a Tuple type used to crash with SIGSEGV because

--- a/tests/queries/0_stateless/04054_merge_after_alter_to_tuple.sql
+++ b/tests/queries/0_stateless/04054_merge_after_alter_to_tuple.sql
@@ -15,7 +15,7 @@ INSERT INTO t_alter_to_tuple VALUES ('(''foo'',''bar'')');
 -- Block mutations so the ALTER changes metadata but parts stay String-typed.
 SYSTEM ENABLE FAILPOINT mt_select_parts_to_mutate_max_part_size;
 
-ALTER TABLE t_alter_to_tuple MODIFY COLUMN col Tuple(String, String);
+ALTER TABLE t_alter_to_tuple MODIFY COLUMN col Tuple(String, String) SETTINGS alter_sync = 0;
 OPTIMIZE TABLE t_alter_to_tuple FINAL;
 
 SELECT level, count() FROM system.parts

--- a/tests/queries/0_stateless/04054_merge_after_alter_to_tuple.sql
+++ b/tests/queries/0_stateless/04054_merge_after_alter_to_tuple.sql
@@ -1,0 +1,31 @@
+-- Tags: no-random-merge-tree-settings
+
+-- Regression test: merging parts after ALTER MODIFY COLUMN changed a column
+-- from a non-Tuple type to a Tuple type used to crash with SIGSEGV because
+-- SerializationInfoTuple::add did assert_cast on a plain SerializationInfo
+
+DROP TABLE IF EXISTS t_alter_to_tuple;
+
+CREATE TABLE t_alter_to_tuple (col String)
+ENGINE = MergeTree ORDER BY tuple();
+
+INSERT INTO t_alter_to_tuple VALUES ('(''hello'',''world'')');
+INSERT INTO t_alter_to_tuple VALUES ('(''foo'',''bar'')');
+
+-- Block mutations so the ALTER changes metadata but parts stay String-typed.
+SYSTEM ENABLE FAILPOINT mt_select_parts_to_mutate_max_part_size;
+
+ALTER TABLE t_alter_to_tuple MODIFY COLUMN col Tuple(String, String);
+OPTIMIZE TABLE t_alter_to_tuple FINAL;
+
+SELECT level, count() FROM system.parts
+WHERE database = currentDatabase()
+  AND table = 't_alter_to_tuple'
+  AND active
+GROUP BY level;
+
+SELECT col FROM t_alter_to_tuple ORDER BY col;
+
+SYSTEM DISABLE FAILPOINT mt_select_parts_to_mutate_max_part_size;
+
+DROP TABLE t_alter_to_tuple;


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1494
<!-- End of fixes issue link part, do not remove -->

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes segfault where `SerializationInfoTuple::add` does `assert_cast` on a plain `SerializationInfo` reference while merging parts after `ALTER MODIFY COLUMN` changed a column from a non-Tuple type to a Tuple.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.212`
- Backported to: `26.3.1.892`, `26.2.6.20`
<!-- ch-version-info:end -->