### PR TITLE
Fix system.stack_trace and global profiler for librdkafka threads

### DIFF
--- a/src/Common/QueryProfiler.cpp
+++ b/src/Common/QueryProfiler.cpp
@@ -310,7 +310,7 @@ template class QueryProfilerBase<QueryProfilerReal>;
 template class QueryProfilerBase<QueryProfilerCPU>;
 
 QueryProfilerReal::QueryProfilerReal(UInt64 thread_id, UInt64 period)
-    : QueryProfilerBase(thread_id, CLOCK_MONOTONIC, period, SIGUSR1)
+    : QueryProfilerBase(thread_id, CLOCK_MONOTONIC, period, PAUSE_SIGNAL)
 {}
 
 void QueryProfilerReal::signalHandler(int sig, siginfo_t * info, void * context)
@@ -323,7 +323,7 @@ void QueryProfilerReal::signalHandler(int sig, siginfo_t * info, void * context)
 }
 
 QueryProfilerCPU::QueryProfilerCPU(UInt64 thread_id, UInt64 period)
-    : QueryProfilerBase(thread_id, CLOCK_THREAD_CPUTIME_ID, period, SIGUSR2)
+    : QueryProfilerBase(thread_id, CLOCK_THREAD_CPUTIME_ID, period, PAUSE_SIGNAL)
 {}
 
 void QueryProfilerCPU::signalHandler(int sig, siginfo_t * info, void * context)

--- a/src/Common/QueryProfiler.h
+++ b/src/Common/QueryProfiler.h
@@ -81,6 +81,8 @@ public:
     QueryProfilerReal(UInt64 thread_id, UInt64 period); /// NOLINT
 
     static void signalHandler(int sig, siginfo_t * info, void * context);
+
+    static constexpr int PAUSE_SIGNAL = SIGUSR1;
 };
 
 /// Query profiler with timer based on CPU clock
@@ -90,6 +92,8 @@ public:
     QueryProfilerCPU(UInt64 thread_id, UInt64 period); /// NOLINT
 
     static void signalHandler(int sig, siginfo_t * info, void * context);
+
+    static constexpr int PAUSE_SIGNAL = SIGUSR2;
 };
 
 }

--- a/src/Storages/Kafka/KafkaConfigLoader.cpp
+++ b/src/Storages/Kafka/KafkaConfigLoader.cpp
@@ -5,6 +5,7 @@
 #include <Storages/Kafka/StorageKafka.h>
 #include <Storages/Kafka/StorageKafka2.h>
 #include <Storages/Kafka/parseSyslogLevel.h>
+#include <Storages/System/StorageSystemStackTrace.h>
 #include <boost/algorithm/string/replace.hpp>
 #include <Common/Exception.h>
 #include <Common/CurrentMetrics.h>
@@ -100,7 +101,7 @@ KafkaInterceptors<TStorageKafka>::rdKafkaOnThreadStart(rd_kafka_t *, rd_kafka_th
     sigset_t mask;
     sigemptyset(&mask);
 #ifdef OS_LINUX
-    sigaddset(&mask, SIGRTMIN);
+    sigaddset(&mask, STACK_TRACE_SERVICE_SIGNAL);
 #endif
     sigaddset(&mask, SIGUSR1);
     sigaddset(&mask, SIGUSR2);

--- a/src/Storages/Kafka/KafkaConfigLoader.cpp
+++ b/src/Storages/Kafka/KafkaConfigLoader.cpp
@@ -10,6 +10,7 @@
 #include <Common/Exception.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/NamedCollections/NamedCollectionsFactory.h>
+#include <Common/QueryProfiler.h>
 #include <Common/ThreadStatus.h>
 #include <Common/config_version.h>
 #include <Common/setThreadName.h>
@@ -103,8 +104,8 @@ KafkaInterceptors<TStorageKafka>::rdKafkaOnThreadStart(rd_kafka_t *, rd_kafka_th
 #ifdef OS_LINUX
     sigaddset(&mask, STACK_TRACE_SERVICE_SIGNAL);
 #endif
-    sigaddset(&mask, SIGUSR1);
-    sigaddset(&mask, SIGUSR2);
+    sigaddset(&mask, QueryProfilerReal::PAUSE_SIGNAL);
+    sigaddset(&mask, QueryProfilerCPU::PAUSE_SIGNAL);
     pthread_sigmask(SIG_UNBLOCK, &mask, nullptr);
 
     return RD_KAFKA_RESP_ERR_NO_ERROR;

--- a/src/Storages/Kafka/KafkaConfigLoader.cpp
+++ b/src/Storages/Kafka/KafkaConfigLoader.cpp
@@ -12,6 +12,7 @@
 #include <Common/ThreadStatus.h>
 #include <Common/config_version.h>
 #include <Common/setThreadName.h>
+#include <csignal>
 
 namespace CurrentMetrics
 {
@@ -86,6 +87,24 @@ KafkaInterceptors<TStorageKafka>::rdKafkaOnThreadStart(rd_kafka_t *, rd_kafka_th
     auto thread_status = std::make_shared<ThreadStatus>();
     std::lock_guard lock(self->thread_statuses_mutex);
     self->thread_statuses.emplace_back(std::move(thread_status));
+
+    /// Due to [1] librdkafka blocks all signals before creating threads,
+    /// and broker threads are created while signals are already all-blocked
+    /// (inside rd_kafka_new), so they inherit the all-blocked mask.
+    /// We unblock only the specific signals needed by `system.stack_trace`
+    /// (SIGRTMIN) and the query profiler (SIGUSR1/SIGUSR2), rather than
+    /// the full mask — otherwise we would also drop the process-wide
+    /// SIGPIPE block installed by the daemon.
+    ///
+    ///   [1]: https://github.com/confluentinc/librdkafka/issues/4571
+    sigset_t mask;
+    sigemptyset(&mask);
+#ifdef OS_LINUX
+    sigaddset(&mask, SIGRTMIN);
+#endif
+    sigaddset(&mask, SIGUSR1);
+    sigaddset(&mask, SIGUSR2);
+    pthread_sigmask(SIG_UNBLOCK, &mask, nullptr);
 
     return RD_KAFKA_RESP_ERR_NO_ERROR;
 }

--- a/src/Storages/System/StorageSystemStackTrace.cpp
+++ b/src/Storages/System/StorageSystemStackTrace.cpp
@@ -309,7 +309,7 @@ bool isSignalBlocked(UInt64 tid, int signal)
 
         UInt64 sig_blk;
         if (parseHexNumber(line, sig_blk))
-            return sig_blk & signal;
+            return sig_blk & (1ULL << (signal - 1));
     }
     catch (const Exception & e)
     {

--- a/src/Storages/System/StorageSystemStackTrace.cpp
+++ b/src/Storages/System/StorageSystemStackTrace.cpp
@@ -73,12 +73,6 @@ namespace
 // Initialized in StorageSystemStackTrace's ctor and used in signalHandler.
 std::atomic<pid_t> server_pid;
 
-#ifdef OS_LINUX
-const int STACK_TRACE_SERVICE_SIGNAL = SIGRTMIN;
-#else
-const int STACK_TRACE_SERVICE_SIGNAL = SIGUSR1;
-#endif
-
 std::atomic<int> sequence_num = 0;    /// For messages sent via pipe.
 std::atomic<int> data_ready_num = 0;
 std::atomic<bool> signal_latch = false;   /// Only need for thread sanitizer.

--- a/src/Storages/System/StorageSystemStackTrace.h
+++ b/src/Storages/System/StorageSystemStackTrace.h
@@ -3,6 +3,7 @@
 #if defined(OS_LINUX) || defined(OS_DARWIN)
 
 #include <Storages/IStorage.h>
+#include <csignal>
 
 namespace Poco
 {
@@ -14,6 +15,12 @@ namespace DB
 
 class Context;
 
+
+#ifdef OS_LINUX
+const int STACK_TRACE_SERVICE_SIGNAL = SIGRTMIN;
+#else
+const int STACK_TRACE_SERVICE_SIGNAL = SIGUSR1;
+#endif
 
 /// Allows to introspect stack trace of all server threads.
 /// It acts like an embedded debugger.


### PR DESCRIPTION
Can be useful for debugging problems, i.e. https://github.com/ClickHouse/ClickHouse/issues/100511

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Refs: https://github.com/confluentinc/librdkafka/issues/4571

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.221`
<!-- ch-version-info:end -->