### PR TITLE
Fix copilot review job: force gh re-auth and post comment from job script

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -166,8 +166,6 @@ class JobConfigs:
         name=JobNames.CODE_REVIEW,
         runs_on=RunnerLabels.STYLE_CHECK_ARM,
         command="python3 ./ci/jobs/copilot_review_job.py --pre",
-        allow_merge_on_failure=True,
-        enable_gh_auth=True,
     )
     ci_results_review = Job.Config(
         name=JobNames.CI_RESULTS_REVIEW,

--- a/ci/jobs/copilot_review_job.py
+++ b/ci/jobs/copilot_review_job.py
@@ -4,11 +4,12 @@ Copilot-based automated PR code review job.
 --pre: review code only (Code Review job, runs at start of CI)
 --post: review CI failures (CI Results Review job, runs at end of CI)
 
-Always succeeds — copilot errors are logged as warnings only.
+Copilot errors are logged as warnings only. Posting the review comment is
+done by the job script itself (not copilot) and fails the job if it does not work.
 
-Copilot writes the review to REVIEW_FILE and posts it via
-`ci/praktika/gh.py post-or-update --tag review` using `env -u GH_CONFIG_DIR`
-so the comment is posted as the pre-authenticated app, not the Copilot robot.
+Copilot writes the review to REVIEW_FILE; the job script then posts it via
+`ci/praktika/gh.py post-or-update --tag review` so the comment is always posted
+as the pre-authenticated app, not the Copilot robot.
 """
 
 import os
@@ -22,6 +23,36 @@ from ci.praktika.info import Info
 from ci.praktika.result import Result
 
 REVIEW_FILE = "./ci/tmp/copilot_review.md"
+
+
+def _reauth_gh():
+    """Force re-auth of the main gh context (outside any GH_CONFIG_DIR override).
+
+    Called at job start regardless of current auth status, so the token is
+    always fresh when copilot invokes `env -u GH_CONFIG_DIR`.
+    """
+    from ci.praktika.gh_auth import GHAuth
+
+    app_id = Secret.Config(
+        name="woolenwolf_gh_app.clickhouse-app-id",
+        type=Secret.Type.AWS_SSM_SECRET,
+    ).get_value()
+    pem = Secret.Config(
+        name="woolenwolf_gh_app.clickhouse-app-key",
+        type=Secret.Type.AWS_SSM_SECRET,
+    ).get_value()
+    GHAuth.auth(app_id=app_id, app_key=pem)
+
+
+def _post_review():
+    """Post REVIEW_FILE as a PR comment. Raises on failure, failing the job."""
+    subprocess.run(
+        [
+            "python", "ci/praktika/gh.py",
+            "post-or-update", "--tag", "review", "--file", REVIEW_FILE,
+        ],
+        check=True,
+    )
 
 
 def _run(prompt):
@@ -49,7 +80,12 @@ def _run(prompt):
             print(f"WARNING: copilot review skipped: {e}")
             return
 
-    # Copilot posts the summary itself via ci/praktika/gh.py post-or-update
+    # Post the summary from the job script so the job fails loudly if anything is broken.
+    if not os.path.exists(REVIEW_FILE):
+        raise RuntimeError(f"Copilot did not write {REVIEW_FILE}")
+    if os.path.getsize(REVIEW_FILE) == 0:
+        raise RuntimeError(f"{REVIEW_FILE} is empty")
+    _post_review()
 
 
 def pre():
@@ -58,6 +94,7 @@ def pre():
         print("Not a PR, skipping")
         return
 
+    _reauth_gh()
     os.makedirs("./ci/tmp", exist_ok=True)
     prompt = (
         f"Follow the Review Instructions in .claude/skills/review/SKILL.md. "
@@ -70,8 +107,8 @@ def pre():
         f"Read inline comments already posted by clickhouse-gh[bot]; do not post a new comment if a similar one already exists. "
         f"Write a self-contained summary of ALL findings (regardless of previous summaries) "
         f"as plain Markdown to {REVIEW_FILE} using the REQUESTED OUTPUT FORMAT from .claude/skills/review/SKILL.md — "
-        f"start with `---\n### AI Review`, then use #### for section headers. "
-        f"Post it with: env -u GH_CONFIG_DIR python ci/praktika/gh.py post-or-update --tag review --file {REVIEW_FILE}"
+        f"start with `---\n#### AI Review`, then use ##### for section headers. "
+        f"Do NOT post the summary yourself — the job script will post it after you finish."
     )
     _run(prompt)
 
@@ -82,6 +119,7 @@ def post():
         print("Not a PR, skipping")
         return
 
+    _reauth_gh()
     os.makedirs("./ci/tmp", exist_ok=True)
     ci_report_url = info.get_report_url()
 
@@ -92,19 +130,28 @@ def post():
         f"Otherwise review the PR {info.pr_url} diff and match each failure to the code changes. "
         f"Write a self-contained summary as plain Markdown to {REVIEW_FILE} — "
         f"start with `---\n### AI Review`, then use #### headers for sections only if needed. "
-        f"Post it with: env -u GH_CONFIG_DIR python ci/praktika/gh.py post-or-update --tag review --file {REVIEW_FILE} "
+        f"Do NOT post the summary yourself — the job script will post it after you finish. "
         f"Do not post inline comments."
     )
     _run(prompt)
 
 
 if __name__ == "__main__":
+    status = Result.Status.SUCCESS
     if "--pre" in sys.argv:
-        pre()
+        try:
+            pre()
+        except Exception as e:
+            print(f"ERROR: {e}")
+            status = Result.Status.FAILED
     elif "--post" in sys.argv:
-        post()
+        try:
+            post()
+        except Exception as e:
+            print(f"ERROR: {e}")
+            status = Result.Status.FAILED
     else:
         print("Usage: copilot_review_job.py --pre | --post")
         sys.exit(1)
 
-    Result.create_from(status=Result.Status.SUCCESS).complete_job()
+    Result.create_from(status=status).complete_job()

--- a/ci/jobs/copilot_review_job.py
+++ b/ci/jobs/copilot_review_job.py
@@ -48,7 +48,7 @@ def _post_review():
     """Post REVIEW_FILE as a PR comment. Raises on failure, failing the job."""
     subprocess.run(
         [
-            "python", "ci/praktika/gh.py",
+            sys.executable, "ci/praktika/gh.py",
             "post-or-update", "--tag", "review", "--file", REVIEW_FILE,
         ],
         check=True,


### PR DESCRIPTION
The copilot review job was silently failing to post its review comment with
`permission denied` because the main gh context token (mounted from the host
into the Docker container at `GH_CONFIG_DIR=/ghconfig`) had expired. The runner
only re-authenticates if `gh auth status` fails, but an expired token can pass
that check.

Additionally, the comment was being posted by copilot itself via a shell command
in the prompt, making failures invisible — the job always reported success.

## Changes

- Add `_reauth_gh()`: force-refreshes the main gh context token at job start
  using the app credentials from AWS SSM, regardless of current auth status.
  This ensures the token is fresh when copilot invokes `env -u GH_CONFIG_DIR`.
- Move `post-or-update` posting from the copilot prompt into `_run()` in the
  job script itself — the job now owns posting and raises on failure.
- Fail the job (via `Result.Status.FAILED`) if `REVIEW_FILE` is missing, empty,
  or the comment post command fails.
- Update prompts to tell copilot not to post the summary (the job script handles it).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.192`
<!-- ch-version-info:end -->