### PR TITLE
Fix flaky test 04004_integral_col_comparison_with_float_key_condition

### DIFF
--- a/tests/queries/0_stateless/04004_integral_col_comparison_with_float_key_condition.reference
+++ b/tests/queries/0_stateless/04004_integral_col_comparison_with_float_key_condition.reference
@@ -2,6 +2,8 @@
 SET optimize_move_to_prewhere = 1;
 SET query_plan_optimize_prewhere = 1;
 SET optimize_trivial_approximate_count_query = 0;
+SET max_insert_threads = 1;
+SET enable_parallel_replicas = 0;
 DROP TABLE IF EXISTS test_int64;
 CREATE TABLE test_int64 (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192, index_granularity_bytes = 10485760;
 INSERT INTO test_int64 SELECT number FROM numbers(200000);

--- a/tests/queries/0_stateless/04004_integral_col_comparison_with_float_key_condition.sql
+++ b/tests/queries/0_stateless/04004_integral_col_comparison_with_float_key_condition.sql
@@ -1,4 +1,5 @@
 -- Tags: no-random-settings
+
 -- { echo }
 SET optimize_move_to_prewhere = 1;
 SET query_plan_optimize_prewhere = 1;

--- a/tests/queries/0_stateless/04004_integral_col_comparison_with_float_key_condition.sql
+++ b/tests/queries/0_stateless/04004_integral_col_comparison_with_float_key_condition.sql
@@ -2,6 +2,8 @@
 SET optimize_move_to_prewhere = 1;
 SET query_plan_optimize_prewhere = 1;
 SET optimize_trivial_approximate_count_query = 0;
+SET max_insert_threads = 1;
+SET enable_parallel_replicas = 0;
 
 DROP TABLE IF EXISTS test_int64;
 CREATE TABLE test_int64 (uid Int64) ENGINE = MergeTree ORDER BY uid SETTINGS index_granularity = 8192, index_granularity_bytes = 10485760;

--- a/tests/queries/0_stateless/04004_integral_col_comparison_with_float_key_condition.sql
+++ b/tests/queries/0_stateless/04004_integral_col_comparison_with_float_key_condition.sql
@@ -1,3 +1,4 @@
+-- Tags: no-random-settings
 -- { echo }
 SET optimize_move_to_prewhere = 1;
 SET query_plan_optimize_prewhere = 1;


### PR DESCRIPTION
Pin `max_insert_threads` and `enable_parallel_replicas` in the test to prevent flakiness caused by randomized settings.

The test verifies primary key index pruning with float literals by setting tight `max_rows_to_read` limits (e.g., 106496 = exactly 13 granules). With randomized `max_insert_threads = 2`, the INSERT creates two parts with non-aligned granule boundaries, requiring 14 granules (114688 rows) instead of 13, exceeding the limit.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100210&sha=258375acfa8710bf850499904e8186c66232066c&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%201%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/100210

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.224` (included in `26.4` and later)
- Backported to: `26.3.33.91`
<!-- ch-version-info:end -->