### PR TITLE
Allow materialized_views_ignore_errors to be set in the MV

### DIFF
--- a/docs/en/sql-reference/statements/create/view.md
+++ b/docs/en/sql-reference/statements/create/view.md
@@ -86,9 +86,14 @@ Materialized views in ClickHouse are implemented more like insert triggers. If t
 
 Materialized views in ClickHouse do not have deterministic behaviour in case of errors. This means that blocks that had been already written will be preserved in the destination table, but all blocks after error will not.
 
-By default if pushing to one of views fails, then the INSERT query will fail too, and some blocks may not be written to the destination table. This can be changed using `materialized_views_ignore_errors` setting (you should set it for `INSERT` query), if you will set `materialized_views_ignore_errors=true`, then any errors while pushing to views will be ignored and all blocks will be written to the destination table.
+By default if pushing to one of views fails, then the INSERT query will fail too, and some blocks may not be written to the destination table. This can be changed using `materialized_views_ignore_errors` setting in two ways:
 
-Also note, that `materialized_views_ignore_errors` set to `true` by default for `system.*_log` tables.
+- **Per-INSERT**: set it on the `INSERT` query (e.g. `INSERT INTO table SETTINGS materialized_views_ignore_errors=1 ...`). This ignores errors for **all** materialized views attached to the source table.
+- **Per-MV**: set it in the `SETTINGS` clause of the materialized view's `SELECT` query (e.g. `CREATE MATERIALIZED VIEW ... AS SELECT ... SETTINGS materialized_views_ignore_errors=1`). This ignores errors only for that specific materialized view, while other views on the same source table will still cause the INSERT to fail if they error.
+
+If the INSERT-level setting is `true`, it overrides all per-MV settings (errors are ignored for all views). If the INSERT-level setting is `false` (the default), the per-MV setting is checked for each view individually.
+
+Also note, that `materialized_views_ignore_errors` is set to `true` by default for `system.*_log` tables.
 :::
 
 If you specify `POPULATE`, the existing table data is inserted into the view when creating it, as if making a `CREATE TABLE ... AS SELECT ...` . Otherwise, the query contains only the data inserted in the table after creating the view. We **do not recommend** using `POPULATE`, since data inserted in the table during the view creation will not be inserted in it.

--- a/src/Interpreters/InsertDependenciesBuilder.cpp
+++ b/src/Interpreters/InsertDependenciesBuilder.cpp
@@ -17,6 +17,9 @@
 #include <Interpreters/ExpressionActions.h>
 #include <Interpreters/InterpreterSelectQuery.h>
 #include <Interpreters/InterpreterSelectQueryAnalyzer.h>
+#include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
+#include <Parsers/ASTSetQuery.h>
 #include <Interpreters/QueryViewsLog.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/StorageID.h>
@@ -414,7 +417,7 @@ public:
             if (!view_errors.current_exception.set(exception_with_storage))
                 continue;
 
-            if (!insert_dependencies->materialized_views_ignore_errors)
+            if (!insert_dependencies->shouldIgnoreErrorsForView(status.view_id))
             {
                 output.pushException(exception_with_storage);
                 return Status::PortFull;
@@ -448,7 +451,7 @@ public:
             if (!errors.needLogQueryView())
                 continue;
 
-            if (insert_dependencies->materialized_views_ignore_errors)
+            if (insert_dependencies->shouldIgnoreErrorsForView(status.view_id))
             {
                 if (status.is_finished)
                 {
@@ -836,6 +839,30 @@ std::pair<ContextPtr, ContextPtr> InsertDependenciesBuilder::createSelectInsertC
     return {select_context, insert_context};
 }
 
+bool InsertDependenciesBuilder::shouldIgnoreErrorsForView(const StorageID & view_id) const
+{
+    if (materialized_views_ignore_errors)
+        return true;
+
+    auto it = select_queries.find(view_id);
+    if (it != select_queries.end())
+    {
+        if (const auto * select = it->second->as<ASTSelectQuery>())
+        {
+            if (auto settings_ast = select->settings())
+            {
+                if (const auto * set_query = settings_ast->as<ASTSetQuery>())
+                {
+                    if (const Field * value = set_query->changes.tryGet("materialized_views_ignore_errors"))
+                        return value->safeGet<bool>();
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
 String InsertDependenciesBuilder::debugTree() const
 {
     WriteBufferFromOwnString output_buffer;
@@ -1127,15 +1154,15 @@ void InsertDependenciesBuilder::collectAllDependencies()
         }
         catch (...)
         {
-            if (!materialized_views_ignore_errors)
-                throw;
-
             if (id == init_table_id)
                 throw;
 
             auto view_id = isView(id) ? id : path.parent(1);
 
             if (view_id == init_table_id)
+                throw;
+
+            if (!shouldIgnoreErrorsForView(view_id))
                 throw;
 
             auto exception = addStorageToException(std::current_exception(), view_id);

--- a/src/Interpreters/InsertDependenciesBuilder.h
+++ b/src/Interpreters/InsertDependenciesBuilder.h
@@ -149,11 +149,15 @@ private:
     LoggerPtr logger;
 
 public:
-    // expose settings value into public
     bool deduplicate_blocks_in_dependent_materialized_views = false;
     bool insert_null_as_default = false;
     bool materialized_views_ignore_errors = false;
     bool ignore_materialized_views_with_dropped_target_table = false;
+
+    /// Returns true if errors should be ignored for the given view.
+    /// INSERT-level materialized_views_ignore_errors overrides all views;
+    /// otherwise checks the per-MV setting from the view's SELECT definition.
+    bool shouldIgnoreErrorsForView(const StorageID & view_id) const;
 };
 
 }

--- a/tests/queries/0_stateless/03595_per_mv_materialized_views_ignore_errors.reference
+++ b/tests/queries/0_stateless/03595_per_mv_materialized_views_ignore_errors.reference
@@ -1,0 +1,40 @@
+-- { echoOn }
+
+-- Case 1: Insert with no error — all MVs receive data
+insert into source_03595 values (1, 100), (2, 200);
+select 'source after insert 1', count() from source_03595;
+source after insert 1	2
+select 'target_ok1 after insert 1', count() from target_ok1_03595;
+target_ok1 after insert 1	2
+select 'target_fail after insert 1', count() from target_fail_03595;
+target_fail after insert 1	2
+select 'target_ok2 after insert 1', count() from target_ok2_03595;
+target_ok2 after insert 1	2
+-- Case 2: Insert that triggers mv_fail error (id=0).
+-- Because mv_fail has per-MV materialized_views_ignore_errors=1,
+-- the INSERT should succeed and data should reach source and the OK MVs.
+-- mv_fail's error is ignored; it may receive partial data.
+insert into source_03595 values (3, 300), (0, 400);
+select 'source after insert 2', count() from source_03595;
+source after insert 2	4
+select 'target_ok1 after insert 2', count() from target_ok1_03595;
+target_ok1 after insert 2	4
+select 'target_ok2 after insert 2', count() from target_ok2_03595;
+target_ok2 after insert 2	4
+-- Case 3: Verify that without the per-MV setting, errors still propagate.
+drop view mv_fail_03595;
+create materialized view mv_fail_03595 to target_fail_03595 as
+    select id, toUInt64(throwIf(id = 0, 'deliberate error in mv_fail')) as bad_val
+    from source_03595;
+insert into source_03595 values (4, 500), (0, 600); -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
+-- Source may have the new rows (blocks written before MV error)
+select 'source after insert 3 (failed)', count() from source_03595;
+source after insert 3 (failed)	6
+-- Case 4: INSERT-level setting still overrides everything
+insert into source_03595 settings materialized_views_ignore_errors = 1 values (5, 700), (0, 800);
+select 'source after insert 4', count() from source_03595;
+source after insert 4	8
+select 'target_ok1 after insert 4', count() from target_ok1_03595;
+target_ok1 after insert 4	6
+select 'target_ok2 after insert 4', count() from target_ok2_03595;
+target_ok2 after insert 4	6

--- a/tests/queries/0_stateless/03595_per_mv_materialized_views_ignore_errors.sql
+++ b/tests/queries/0_stateless/03595_per_mv_materialized_views_ignore_errors.sql
@@ -1,0 +1,73 @@
+-- Test per-MV materialized_views_ignore_errors setting.
+-- The setting can be specified in the MV definition (SETTINGS clause of SELECT)
+-- to ignore errors only for that specific MV, without requiring it on the INSERT.
+
+drop table if exists source_03595;
+drop table if exists target_ok1_03595;
+drop table if exists target_fail_03595;
+drop table if exists target_ok2_03595;
+drop view if exists mv_ok1_03595;
+drop view if exists mv_fail_03595;
+drop view if exists mv_ok2_03595;
+
+create table source_03595 (id UInt64, val Int64) engine = MergeTree() order by id;
+create table target_ok1_03595 (id UInt64, val Int64) engine = MergeTree() order by id;
+create table target_fail_03595 (id UInt64, bad_val UInt64) engine = MergeTree() order by id;
+create table target_ok2_03595 (id UInt64, val Int64) engine = MergeTree() order by id;
+
+-- mv_ok1: always succeeds
+create materialized view mv_ok1_03595 to target_ok1_03595 as select id, val from source_03595;
+
+-- mv_fail: fails when id = 0, but has per-MV ignore errors
+create materialized view mv_fail_03595 to target_fail_03595 as
+    select id, toUInt64(throwIf(id = 0, 'deliberate error in mv_fail')) as bad_val
+    from source_03595
+    settings materialized_views_ignore_errors = 1;
+
+-- mv_ok2: always succeeds
+create materialized view mv_ok2_03595 to target_ok2_03595 as select id, val from source_03595;
+
+-- { echoOn }
+
+-- Case 1: Insert with no error — all MVs receive data
+insert into source_03595 values (1, 100), (2, 200);
+select 'source after insert 1', count() from source_03595;
+select 'target_ok1 after insert 1', count() from target_ok1_03595;
+select 'target_fail after insert 1', count() from target_fail_03595;
+select 'target_ok2 after insert 1', count() from target_ok2_03595;
+
+-- Case 2: Insert that triggers mv_fail error (id=0).
+-- Because mv_fail has per-MV materialized_views_ignore_errors=1,
+-- the INSERT should succeed and data should reach source and the OK MVs.
+-- mv_fail's error is ignored; it may receive partial data.
+insert into source_03595 values (3, 300), (0, 400);
+select 'source after insert 2', count() from source_03595;
+select 'target_ok1 after insert 2', count() from target_ok1_03595;
+select 'target_ok2 after insert 2', count() from target_ok2_03595;
+
+-- Case 3: Verify that without the per-MV setting, errors still propagate.
+drop view mv_fail_03595;
+create materialized view mv_fail_03595 to target_fail_03595 as
+    select id, toUInt64(throwIf(id = 0, 'deliberate error in mv_fail')) as bad_val
+    from source_03595;
+
+insert into source_03595 values (4, 500), (0, 600); -- { serverError FUNCTION_THROW_IF_VALUE_IS_NON_ZERO }
+
+-- Source may have the new rows (blocks written before MV error)
+select 'source after insert 3 (failed)', count() from source_03595;
+
+-- Case 4: INSERT-level setting still overrides everything
+insert into source_03595 settings materialized_views_ignore_errors = 1 values (5, 700), (0, 800);
+select 'source after insert 4', count() from source_03595;
+select 'target_ok1 after insert 4', count() from target_ok1_03595;
+select 'target_ok2 after insert 4', count() from target_ok2_03595;
+
+-- { echoOff }
+
+drop view mv_ok1_03595;
+drop view mv_fail_03595;
+drop view mv_ok2_03595;
+drop table source_03595;
+drop table target_ok1_03595;
+drop table target_fail_03595;
+drop table target_ok2_03595;


### PR DESCRIPTION
Previously, materialized_views_ignore_errors could only be set at the INSERT query level. This is limiting because it means user are required to know the logic behind each table and materialized view. 

This should help by defining it directly inside the MV. Alternatively we can eventually set it at the 

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add support for materialized_views_ignore_errors in the MV definition

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)
