### PR TITLE
Bump rocksdb submodule version to v10.10.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -139,7 +139,7 @@
 	url = https://github.com/danlark1/miniselect
 [submodule "contrib/rocksdb"]
 	path = contrib/rocksdb
-	url = https://github.com/ClickHouse/rocksdb
+	url = https://github.com/facebook/rocksdb
 [submodule "contrib/xz"]
 	path = contrib/xz
 	url = https://github.com/xz-mirror/xz

--- a/contrib/rocksdb-cmake/CMakeLists.txt
+++ b/contrib/rocksdb-cmake/CMakeLists.txt
@@ -73,6 +73,7 @@ set(SOURCES
     ${ROCKSDB_SOURCE_DIR}/db/db_impl/db_impl_files.cc
     ${ROCKSDB_SOURCE_DIR}/db/db_impl/db_impl_follower.cc
     ${ROCKSDB_SOURCE_DIR}/db/db_impl/db_impl_open.cc
+    ${ROCKSDB_SOURCE_DIR}/db/db_impl/db_impl_debug.cc
     ${ROCKSDB_SOURCE_DIR}/db/db_impl/db_impl_experimental.cc
     ${ROCKSDB_SOURCE_DIR}/db/db_impl/db_impl_readonly.cc
     ${ROCKSDB_SOURCE_DIR}/db/db_impl/db_impl_secondary.cc
@@ -92,10 +93,12 @@ set(SOURCES
     ${ROCKSDB_SOURCE_DIR}/db/log_reader.cc
     ${ROCKSDB_SOURCE_DIR}/db/log_writer.cc
     ${ROCKSDB_SOURCE_DIR}/db/malloc_stats.cc
+    ${ROCKSDB_SOURCE_DIR}/db/manifest_ops.cc
     ${ROCKSDB_SOURCE_DIR}/db/memtable.cc
     ${ROCKSDB_SOURCE_DIR}/db/memtable_list.cc
     ${ROCKSDB_SOURCE_DIR}/db/merge_helper.cc
     ${ROCKSDB_SOURCE_DIR}/db/merge_operator.cc
+    ${ROCKSDB_SOURCE_DIR}/db/multi_scan.cc
     ${ROCKSDB_SOURCE_DIR}/db/output_validator.cc
     ${ROCKSDB_SOURCE_DIR}/db/periodic_task_scheduler.cc
     ${ROCKSDB_SOURCE_DIR}/db/range_del_aggregator.cc
@@ -155,6 +158,7 @@ set(SOURCES
     ${ROCKSDB_SOURCE_DIR}/memtable/hash_skiplist_rep.cc
     ${ROCKSDB_SOURCE_DIR}/memtable/skiplistrep.cc
     ${ROCKSDB_SOURCE_DIR}/memtable/vectorrep.cc
+    ${ROCKSDB_SOURCE_DIR}/memtable/wbwi_memtable.cc
     ${ROCKSDB_SOURCE_DIR}/memtable/write_buffer_manager.cc
     ${ROCKSDB_SOURCE_DIR}/monitoring/histogram.cc
     ${ROCKSDB_SOURCE_DIR}/monitoring/histogram_windowing.cc


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Upgrade the bundled RocksDB from a stale ClickHouse-maintained fork at v9.4 to upstream `facebook/rocksdb` v10.10.1.

### Motivation
ClickHouse has been using a stale fork (`ClickHouse/rocksdb`) pinned at v9.4.0 with a single custom patch
for LLVM v16 build compatibility. The fork has fallen behind upstream by ~790 commits spanning 13 minor
releases (9.5 through 10.10). Carrying a divergent fork creates maintenance burden, delays security and
bug fixes, and misses significant performance work.

### Key improvements in the new version
**Performance:** async I/O prefetching for `MultiGet`/multi-scan iterators, production-ready parallel
compression, LZ4/LZ4HC efficiency improvements, and buffered I/O optimizations.

**Stability:** fixes for use-after-free in best-efforts recovery, `GetSortedWalFiles` hanging,
`SetOptions` silently reverting changes, compaction incorrectly dropping keys, FIFO compaction race
conditions, WAL corruption, and various file/blob leak issues.

**New capabilities:** `HyperClockCache` as the default block cache (better scalability than `LRUCache`),
auto-tuning manifest file size, resumable compaction, experimental secondary indices, per-CF
`allow_ingest_behind`, and `IngestWriteBatchWithIndex` for bypassing memtable.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.215`
<!-- ch-version-info:end -->