### PR TITLE
Unflake 02346_text_index_prefetch

### DIFF
--- a/tests/queries/0_stateless/02346_text_index_prefetch.sql
+++ b/tests/queries/0_stateless/02346_text_index_prefetch.sql
@@ -9,6 +9,12 @@ SET filesystem_prefetch_step_bytes = 0;
 SET filesystem_prefetch_step_marks = 0;
 SET enable_filesystem_cache = 1;
 SET read_from_filesystem_cache_if_exists_otherwise_bypass_cache = 0;
+-- When merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability is on splitPartsRanges
+-- skips extracting non-intersecting ranges from level-0 parts (which all 3 parts are, since each has a single INSERT).
+-- All parts end up in the "intersecting" bucket, read via MergeTreeReadPoolInOrder which never calls
+-- prefetchBeginOfRange — so zero prefetched reads. Fixed by setting the injection probability to 0.
+SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0;
+
 
 DROP TABLE IF EXISTS tab;
 

--- a/tests/queries/0_stateless/02346_text_index_prefetch.sql
+++ b/tests/queries/0_stateless/02346_text_index_prefetch.sql
@@ -5,6 +5,9 @@ SET allow_prefetched_read_pool_for_remote_filesystem = 1;
 SET remote_filesystem_read_prefetch = 1;
 SET remote_filesystem_read_method = 'threadpool';
 SET max_rows_to_read = 0;
+SET filesystem_prefetch_step_bytes = 0;
+SET filesystem_prefetch_step_marks = 0;
+SET read_from_filesystem_cache_if_exists_otherwise_bypass_cache = 0;
 
 DROP TABLE IF EXISTS tab;
 

--- a/tests/queries/0_stateless/02346_text_index_prefetch.sql
+++ b/tests/queries/0_stateless/02346_text_index_prefetch.sql
@@ -7,6 +7,7 @@ SET remote_filesystem_read_method = 'threadpool';
 SET max_rows_to_read = 0;
 SET filesystem_prefetch_step_bytes = 0;
 SET filesystem_prefetch_step_marks = 0;
+SET enable_filesystem_cache = 1;
 SET read_from_filesystem_cache_if_exists_otherwise_bypass_cache = 0;
 
 DROP TABLE IF EXISTS tab;


### PR DESCRIPTION
### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

Failure seen here: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100467&sha=fa5fc4aa74f152c3c608648284fd035e2dfd84a4&name_0=PR&name_1=Stateless+tests+%28amd_asan_ubsan%2C+distributed+plan%2C+parallel%2C+1%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/100467 Set additional filesystem_prefetch settings to force it.

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.199`
<!-- ch-version-info:end -->