### PR TITLE
Fix very expensive version tweak calculation

### DIFF
--- a/ci/jobs/scripts/clickhouse_version.py
+++ b/ci/jobs/scripts/clickhouse_version.py
@@ -51,52 +51,12 @@ SET(VERSION_STRING {string})
         version = cls.get_release_version_as_dict()
         info = Info()
         try:
-            # Check if the commit is directly on the first-parent chain
-            is_on_first_parent = Shell.get_output(
-                f"git rev-list --first-parent HEAD | grep -q {version['githash']} && echo 'yes' || echo 'no'",
-                verbose=True,
-            ).strip()
-
-            if is_on_first_parent == "yes":
-                # Commit is directly on the first-parent chain (upstream scenario)
-                # Use simple first-parent counting
-                tweak = int(
-                    Shell.get_output(
-                        f"git rev-list --count --first-parent {version['githash']}..HEAD",
-                        verbose=True,
-                    )
-                )
-            else:
-                # Commit is not on first-parent chain (fork with sync scenario)
-                # Find the merge commit where this commit entered the first-parent chain
-                # Iterate backwards to find the last commit that has target as ancestor (the merge point)
-                merge_commit = Shell.get_output(
-                    f"commits=$(git rev-list --first-parent HEAD); "
-                    f"prev=''; "
-                    f"for commit in $commits; do "
-                    f"if git merge-base --is-ancestor {version['githash']} $commit 2>/dev/null; then "
-                    f"prev=$commit; "
-                    f"else "
-                    f"echo $prev; break; "
-                    f"fi; done",
+            tweak = int(
+                Shell.get_output(
+                    f"git rev-list --count --first-parent {version['githash']}..HEAD",
                     verbose=True,
-                ).strip()
-
-                if merge_commit:
-                    tweak = int(
-                        Shell.get_output(
-                            f"git rev-list --count --first-parent {merge_commit}..HEAD",
-                            verbose=True,
-                        )
-                    )
-                else:
-                    # Fallback if we can't find the merge point
-                    tweak = int(
-                        Shell.get_output(
-                            f"git rev-list --count --first-parent {version['githash']}..HEAD",
-                            verbose=True,
-                        )
-                    )
+                )
+            )
         except (ValueError, Exception):
             # Shallow checkout or other error
             tweak = 1


### PR DESCRIPTION
It can iterate over ~50K commits for backports, which takes ~5min, but, it does it 2x times, which eventually lead to job timeout.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.190`
- Backported to: `26.2.6.18`
<!-- ch-version-info:end -->