### PR TITLE
Make version calcuation 2x faster in Config Workflow

### DIFF
--- a/ci/jobs/scripts/clickhouse_version.py
+++ b/ci/jobs/scripts/clickhouse_version.py
@@ -134,10 +134,9 @@ SET(VERSION_STRING {string})
         return cls.get_release_version_as_dict()["githash"]
 
     @classmethod
-    def store_version_data_in_ci_pipeline(cls):
-        version = cls.get_current_version_as_dict()
+    def store_version_data_in_ci_pipeline(cls, version):
         print(f"Store version in pipeline kv data: [version={version}]")
-        Info().store_kv_data("version", cls.get_current_version_as_dict())
+        Info().store_kv_data("version", version)
 
 
 if __name__ == "__main__":

--- a/ci/jobs/scripts/workflow_hooks/version_log.py
+++ b/ci/jobs/scripts/workflow_hooks/version_log.py
@@ -13,6 +13,7 @@ def _add_build_to_version_history():
         f"git rev-parse --is-shallow-repository | grep -q true && git fetch --unshallow --prune --no-recurse-submodules --filter=tree:0 origin {info.git_branch} ||:"
     )
     commit_parents = Shell.get_output("git log --format=%P -n 1").split(" ")
+    version = CHVersion.get_current_version_as_dict()
     data = {
         "check_start_time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         "pull_request_number": info.pr_number,
@@ -20,13 +21,13 @@ def _add_build_to_version_history():
         "commit_sha": info.sha,
         "commit_url": info.commit_url,
         "parent_commits_sha": commit_parents,
-        "version": CHVersion.get_version(),
+        "version": version["string"],
         "git_ref": info.git_branch,
     }
     print(f"Update version log: [{data}]")
     CIDBCluster().insert_json(table="version_history", json_str=data)
     # stores actual version data in pipline storage, to be used by jobs that need it
-    CHVersion.store_version_data_in_ci_pipeline()
+    CHVersion.store_version_data_in_ci_pipeline(version)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

If https://github.com/ClickHouse/ClickHouse/pull/100548 will not be merged, this is crucial

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.184`
- Backported to: `26.2.6.17`
<!-- ch-version-info:end -->