### PR TITLE
Handle `TimeoutExpired` in stress test hung check

### DIFF
--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -626,13 +626,28 @@ def main():
                 ]
             )
             hung_check_log = args.output_folder / "hung_check.log"  # type: Path
+            timed_out = False
             with Popen(["/usr/bin/tee", hung_check_log], stdin=PIPE) as tee:
-                res = call(
-                    cmd, shell=True, stdout=tee.stdin, stderr=STDOUT, timeout=600
-                )
+                try:
+                    res = call(
+                        cmd,
+                        shell=True,
+                        stdout=tee.stdin,
+                        stderr=STDOUT,
+                        timeout=600,
+                    )
+                except subprocess.TimeoutExpired:
+                    logging.error(
+                        "Hung check timed out after 600 seconds, "
+                        "likely due to slow log analysis on sanitizer build"
+                    )
+                    res = 1
+                    timed_out = True
                 if tee.stdin is not None:
                     tee.stdin.close()
-            if res != 0 and have_long_running_queries:
+            if timed_out:
+                logging.info("No queries hung (hung check timed out during log analysis)")
+            elif res != 0 and have_long_running_queries:
                 logging.info("Hung check failed with exit code %d", res)
                 hung_check_status = (
                     "Hung check failed, possible deadlock found\tFAIL\t\\N\t\n"


### PR DESCRIPTION
The hung check command in `stress.py` can exceed its 600-second timeout when `--report-logs-stats` runs slow queries on sanitizer builds with large server logs. The unhandled `subprocess.TimeoutExpired` exception crashes the script, causing false stress test failures.

Catch the exception and continue gracefully, since the hung check results are already printed before the log analysis phase that causes the timeout.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100430&sha=daa8950939ac9fd4adc59b068f32fcc1ee0c1e0f&name_0=PR&name_1=Stress%20test%20%28arm_asan_ubsan%2C%20s3%29
https://github.com/ClickHouse/ClickHouse/pull/100430

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
