### PR TITLE
Add JIT support to `ColumnString` and `ColumnFixedString` comparison for ORDER BY

### DIFF
--- a/base/base/memcmpSmall.h
+++ b/base/base/memcmpSmall.h
@@ -840,3 +840,8 @@ inline bool memequalSmallLikeZeroPaddedAllowOverflow15(const Char * a, size_t a_
 {
     return 0 == memcmpSmallLikeZeroPaddedAllowOverflow15(a, a_size, b, b_size);
 }
+
+inline int memcmpSmallCharsAllowOverflow15(const UInt8* a, size_t a_size, const UInt8* b, size_t b_size)
+{
+    return memcmpSmallAllowOverflow15(a, a_size, b, b_size);
+}

--- a/base/base/memcmpSmall.h
+++ b/base/base/memcmpSmall.h
@@ -841,7 +841,10 @@ inline bool memequalSmallLikeZeroPaddedAllowOverflow15(const Char * a, size_t a_
     return 0 == memcmpSmallLikeZeroPaddedAllowOverflow15(a, a_size, b, b_size);
 }
 
-inline int memcmpSmallCharsAllowOverflow15(const UInt8* a, size_t a_size, const UInt8* b, size_t b_size)
+inline int memcmpSmallCharsAllowOverflow15(const UInt8 * a, size_t a_size, const UInt8 * b, size_t b_size)
 {
-    return memcmpSmallAllowOverflow15(a, a_size, b, b_size);
+    /// Normalize to -1/0/1 because the JIT caller truncates i32 to i8,
+    /// and the generic (memcmp-based) fallback may return arbitrary magnitude.
+    const int res = memcmpSmallAllowOverflow15(a, a_size, b, b_size);
+    return (res > 0) - (res < 0);
 }

--- a/src/Columns/ColumnFixedString.cpp
+++ b/src/Columns/ColumnFixedString.cpp
@@ -16,6 +16,12 @@
 #    include <emmintrin.h>
 #endif
 
+#if USE_EMBEDDED_COMPILER
+#    include <llvm/IR/Function.h>
+#    include <llvm/IR/IRBuilder.h>
+#    include <llvm/IR/Module.h>
+#endif
+
 
 namespace DB
 {
@@ -165,6 +171,41 @@ void ColumnFixedString::updateHashFast(SipHash & hash) const
     hash.update(n);
     hash.update(reinterpret_cast<const char *>(chars.data()), size() * n);
 }
+
+#if USE_EMBEDDED_COMPILER
+bool ColumnFixedString::isComparatorCompilable() const { return true; }
+llvm::Value * ColumnFixedString::compileComparator(llvm::IRBuilderBase & b, llvm::Value * lhs, llvm::Value * rhs, llvm::Value * /*nan_direction_hint*/) const
+{
+    llvm::Value * lhs_chars_ptr = b.CreateExtractValue(lhs, {0});
+    llvm::Value * lhs_row_index = b.CreateExtractValue(lhs, {1});
+    llvm::Value * rhs_chars_ptr = b.CreateExtractValue(rhs, {0});
+    llvm::Value * rhs_row_index = b.CreateExtractValue(rhs, {1});
+
+    auto * size_type = b.getInt64Ty();
+    auto * n_value = llvm::ConstantInt::get(size_type, n);
+
+    auto * lhs_current_ptr = b.CreateInBoundsGEP(b.getInt8Ty(), lhs_chars_ptr, b.CreateMul(lhs_row_index, n_value));
+    auto * rhs_current_ptr = b.CreateInBoundsGEP(b.getInt8Ty(), rhs_chars_ptr, b.CreateMul(rhs_row_index, n_value));
+
+    llvm::Module * module = b.GetInsertBlock()->getModule();
+    auto * memcmp_func_type = llvm::FunctionType::get(b.getInt32Ty(),
+        {lhs_current_ptr->getType(), n_value->getType(), rhs_current_ptr->getType(), n_value->getType()}, false);
+    llvm::Function * memcmp_func = llvm::dyn_cast<llvm::Function>(
+        module->getOrInsertFunction("memcmpSmallCharsAllowOverflow15", memcmp_func_type).getCallee()
+    );
+    auto * compare_result = b.CreateCall(memcmp_func, {lhs_current_ptr, n_value, rhs_current_ptr, n_value});
+
+    auto * lhs_greater_than_rhs_result = llvm::ConstantInt::getSigned(b.getInt8Ty(), 1);
+    auto * lhs_less_than_rhs_result = llvm::ConstantInt::getSigned(b.getInt8Ty(), -1);
+    auto * lhs_equals_rhs_result = llvm::ConstantInt::getSigned(b.getInt8Ty(), 0);
+
+    auto * is_greater = b.CreateICmpSGT(compare_result, b.getInt32(0));  // compare_result > 0
+    auto * is_less = b.CreateICmpSLT(compare_result, b.getInt32(0));     // compare_result < 0
+    auto * result_if_not_greater = b.CreateSelect(is_less, lhs_less_than_rhs_result, lhs_equals_rhs_result);
+    auto * final_result = b.CreateSelect(is_greater, lhs_greater_than_rhs_result, result_if_not_greater);
+    return final_result;
+}
+#endif
 
 struct ColumnFixedString::ComparatorBase
 {

--- a/src/Columns/ColumnFixedString.cpp
+++ b/src/Columns/ColumnFixedString.cpp
@@ -195,15 +195,8 @@ llvm::Value * ColumnFixedString::compileComparator(llvm::IRBuilderBase & b, llvm
     );
     auto * compare_result = b.CreateCall(memcmp_func, {lhs_current_ptr, n_value, rhs_current_ptr, n_value});
 
-    auto * lhs_greater_than_rhs_result = llvm::ConstantInt::getSigned(b.getInt8Ty(), 1);
-    auto * lhs_less_than_rhs_result = llvm::ConstantInt::getSigned(b.getInt8Ty(), -1);
-    auto * lhs_equals_rhs_result = llvm::ConstantInt::getSigned(b.getInt8Ty(), 0);
-
-    auto * is_greater = b.CreateICmpSGT(compare_result, b.getInt32(0));  // compare_result > 0
-    auto * is_less = b.CreateICmpSLT(compare_result, b.getInt32(0));     // compare_result < 0
-    auto * result_if_not_greater = b.CreateSelect(is_less, lhs_less_than_rhs_result, lhs_equals_rhs_result);
-    auto * final_result = b.CreateSelect(is_greater, lhs_greater_than_rhs_result, result_if_not_greater);
-    return final_result;
+    /// memcmpSmallAllowOverflow15 returns -1/0/1, so truncating i32 to i8 is safe
+    return b.CreateTrunc(compare_result, b.getInt8Ty());
 }
 #endif
 

--- a/src/Columns/ColumnFixedString.h
+++ b/src/Columns/ColumnFixedString.h
@@ -154,6 +154,11 @@ public:
         return memcmpSmallAllowOverflow15(chars.data() + p1 * n, rhs.chars.data() + p2 * n, n);
     }
 
+#if USE_EMBEDDED_COMPILER
+    bool isComparatorCompilable() const override;
+    llvm::Value * compileComparator(llvm::IRBuilderBase & b, llvm::Value * lhs, llvm::Value * rhs, llvm::Value * /*nan_direction_hint*/) const override;
+#endif
+
     void getPermutation(IColumn::PermutationSortDirection direction, IColumn::PermutationSortStability stability,
                     size_t limit, int nan_direction_hint, Permutation & res) const override;
 

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -743,17 +743,10 @@ llvm::Value * ColumnString::compileComparator(llvm::IRBuilderBase & b, llvm::Val
         module->getOrInsertFunction("memcmpSmallCharsAllowOverflow15", memcmp_func_type).getCallee()
     );
 
-    auto * compare_result =  b.CreateCall(memcmp_func, {lhs_current_ptr, lhs_current_size, rhs_current_ptr, rhs_current_size});
+    auto * compare_result = b.CreateCall(memcmp_func, {lhs_current_ptr, lhs_current_size, rhs_current_ptr, rhs_current_size});
 
-    auto * lhs_greater_than_rhs_result = llvm::ConstantInt::getSigned(b.getInt8Ty(), 1);
-    auto * lhs_less_than_rhs_result = llvm::ConstantInt::getSigned(b.getInt8Ty(), -1);
-    auto * lhs_equals_rhs_result = llvm::ConstantInt::getSigned(b.getInt8Ty(), 0);
-
-    auto * is_greater = b.CreateICmpSGT(compare_result, b.getInt32(0));  // compare_result > 0
-    auto * is_less = b.CreateICmpSLT(compare_result, b.getInt32(0));     // compare_result < 0
-    auto * result_if_not_greater = b.CreateSelect(is_less, lhs_less_than_rhs_result, lhs_equals_rhs_result);
-    auto * final_result = b.CreateSelect(is_greater, lhs_greater_than_rhs_result, result_if_not_greater);
-    return final_result;
+    /// memcmpSmallAllowOverflow15 returns -1/0/1, so truncating i32 to i8 is safe
+    return b.CreateTrunc(compare_result, b.getInt8Ty());
 }
 #endif
 

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -714,9 +714,9 @@ llvm::Value * ColumnString::compileComparator(llvm::IRBuilderBase & b, llvm::Val
 
     llvm::Value * const_one = llvm::ConstantInt::get(size_type, 1);
 
-    auto load_offset = [&](llvm::Value * offset_aray, llvm::Value * index)
+    auto load_offset = [&](llvm::Value * offset_array, llvm::Value * index)
     {
-        auto * element_ptr = b.CreateInBoundsGEP(size_type, offset_aray, index);
+        auto * element_ptr = b.CreateInBoundsGEP(size_type, offset_array, index);
         return b.CreateLoad(size_type, element_ptr);
     };
     auto * lhs_prev_index = b.CreateSub(lhs_index, const_one);

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -716,7 +716,9 @@ llvm::Value * ColumnString::compileComparator(llvm::IRBuilderBase & b, llvm::Val
 
     auto load_offset = [&](llvm::Value * offset_array, llvm::Value * index)
     {
-        auto * element_ptr = b.CreateInBoundsGEP(size_type, offset_array, index);
+        /// Not inbounds: for row 0 the index is -1 (wrapped unsigned), accessing
+        /// the PaddedPODArray padding element before the start of the array.
+        auto * element_ptr = b.CreateGEP(size_type, offset_array, index);
         return b.CreateLoad(size_type, element_ptr);
     };
     auto * lhs_prev_index = b.CreateSub(lhs_index, const_one);

--- a/src/Columns/ColumnString.cpp
+++ b/src/Columns/ColumnString.cpp
@@ -11,6 +11,11 @@
 #include <Common/WeakHash.h>
 #include <Common/assert_cast.h>
 
+#if USE_EMBEDDED_COMPILER
+#    include <llvm/IR/Function.h>
+#    include <llvm/IR/IRBuilder.h>
+#    include <llvm/IR/Module.h>
+#endif
 
 namespace DB
 {
@@ -689,6 +694,68 @@ ColumnPtr ColumnString::compress(bool force_compression) const
         });
 }
 
+#if USE_EMBEDDED_COMPILER
+bool ColumnString::isComparatorCompilable() const
+{
+    return true;
+}
+
+llvm::Value * ColumnString::compileComparator(llvm::IRBuilderBase & b, llvm::Value * lhs, llvm::Value * rhs, llvm::Value * /*nan_direction_hint*/) const
+{
+    llvm::Value * lhs_chars_ptr = b.CreateExtractValue(lhs, {0});
+    llvm::Value * lhs_offset_ptr = b.CreateExtractValue(lhs, {1});
+    llvm::Value * lhs_index = b.CreateExtractValue(lhs, {2});
+
+    llvm::Value * rhs_chars_ptr = b.CreateExtractValue(rhs, {0});
+    llvm::Value * rhs_offset_ptr = b.CreateExtractValue(rhs, {1});
+    llvm::Value * rhs_index = b.CreateExtractValue(rhs, {2});
+
+    auto * size_type = b.getInt64Ty();
+
+    llvm::Value * const_one = llvm::ConstantInt::get(size_type, 1);
+
+    auto load_offset = [&](llvm::Value * offset_aray, llvm::Value * index)
+    {
+        auto * element_ptr = b.CreateInBoundsGEP(size_type, offset_aray, index);
+        return b.CreateLoad(size_type, element_ptr);
+    };
+    auto * lhs_prev_index = b.CreateSub(lhs_index, const_one);
+    auto * lhs_current_start_offset = load_offset(lhs_offset_ptr, lhs_prev_index);
+    auto * lhs_current_end_offset = load_offset(lhs_offset_ptr, lhs_index);
+    auto * lhs_current_size = b.CreateSub(lhs_current_end_offset, lhs_current_start_offset);
+    auto * lhs_current_ptr = b.CreateInBoundsGEP(b.getInt8Ty(), lhs_chars_ptr, lhs_current_start_offset);
+
+    auto * rhs_prev_index = b.CreateSub(rhs_index, const_one);
+    auto * rhs_current_start_offset = load_offset(rhs_offset_ptr, rhs_prev_index);
+    auto * rhs_current_end_offset = load_offset(rhs_offset_ptr, rhs_index);
+    auto * rhs_current_size = b.CreateSub(rhs_current_end_offset, rhs_current_start_offset);
+    auto * rhs_current_ptr = b.CreateInBoundsGEP(b.getInt8Ty(), rhs_chars_ptr, rhs_current_start_offset);
+
+    // Call memcmpSmallAllowOverflow15, same as in ColumnString::compareAt
+    llvm::Module * module = b.GetInsertBlock()->getModule();
+    llvm::FunctionType * memcmp_func_type = llvm::FunctionType::get(
+        b.getInt32Ty(),
+        {b.getInt8Ty()->getPointerTo(), b.getInt64Ty(), b.getInt8Ty()->getPointerTo(), b.getInt64Ty()},
+        false
+    );
+
+    llvm::Function * memcmp_func = llvm::dyn_cast<llvm::Function>(
+        module->getOrInsertFunction("memcmpSmallCharsAllowOverflow15", memcmp_func_type).getCallee()
+    );
+
+    auto * compare_result =  b.CreateCall(memcmp_func, {lhs_current_ptr, lhs_current_size, rhs_current_ptr, rhs_current_size});
+
+    auto * lhs_greater_than_rhs_result = llvm::ConstantInt::getSigned(b.getInt8Ty(), 1);
+    auto * lhs_less_than_rhs_result = llvm::ConstantInt::getSigned(b.getInt8Ty(), -1);
+    auto * lhs_equals_rhs_result = llvm::ConstantInt::getSigned(b.getInt8Ty(), 0);
+
+    auto * is_greater = b.CreateICmpSGT(compare_result, b.getInt32(0));  // compare_result > 0
+    auto * is_less = b.CreateICmpSLT(compare_result, b.getInt32(0));     // compare_result < 0
+    auto * result_if_not_greater = b.CreateSelect(is_less, lhs_less_than_rhs_result, lhs_equals_rhs_result);
+    auto * final_result = b.CreateSelect(is_greater, lhs_greater_than_rhs_result, result_if_not_greater);
+    return final_result;
+}
+#endif
 
 int ColumnString::compareAtWithCollation(size_t n, size_t m, const IColumn & rhs_, int, const Collator & collator) const
 {

--- a/src/Columns/ColumnString.h
+++ b/src/Columns/ColumnString.h
@@ -267,6 +267,11 @@ public:
         return memcmpSmallAllowOverflow15(chars.data() + offsetAt(n), sizeAt(n), rhs.chars.data() + rhs.offsetAt(m), rhs.sizeAt(m));
     }
 
+#if USE_EMBEDDED_COMPILER
+    bool isComparatorCompilable() const override;
+    llvm::Value * compileComparator(llvm::IRBuilderBase & b, llvm::Value * lhs, llvm::Value * rhs, llvm::Value * /*nan_direction_hint*/) const override;
+#endif
+
     /// Variant of compareAt for string comparison with respect of collation.
     int compareAtWithCollation(size_t n, size_t m, const IColumn & rhs_, int, const Collator & collator) const override;
 

--- a/src/Core/SortDescription.cpp
+++ b/src/Core/SortDescription.cpp
@@ -7,6 +7,7 @@
 #include <Common/SipHash.h>
 #include <Common/typeid_cast.h>
 #include <Common/logger_useful.h>
+#include <DataTypes/DataTypeNullable.h>
 
 #include "config.h"
 
@@ -156,9 +157,12 @@ void compileSortDescriptionIfNeeded(SortDescription & description, const DataTyp
 
     for (const auto & type : sort_description_types)
     {
-        if (!type->createColumn()->isComparatorCompilable() || !canBeNativeType(*type))
+        auto nested_type = removeNullable(type);
+        if (!type->createColumn()->isComparatorCompilable() ||
+            (!canBeNativeType(*type) && !WhichDataType(nested_type).isString() && !WhichDataType(nested_type).isFixedString()))
             return;
     }
+
 
     auto description_dump = getSortDescriptionDump(description, sort_description_types);
 

--- a/src/Core/SortDescription.cpp
+++ b/src/Core/SortDescription.cpp
@@ -155,11 +155,15 @@ void compileSortDescriptionIfNeeded(SortDescription & description, const DataTyp
     if (!description.compile_sort_description || sort_description_types.empty())
         return;
 
-    for (const auto & type : sort_description_types)
+    for (size_t i = 0; i < description.size(); ++i)
     {
-        auto nested_type = removeNullable(type);
-        if (!type->createColumn()->isComparatorCompilable() ||
-            (!canBeNativeType(*type) && !WhichDataType(nested_type).isString() && !WhichDataType(nested_type).isFixedString()))
+        auto nested_type = removeNullable(sort_description_types[i]);
+        if (!sort_description_types[i]->createColumn()->isComparatorCompilable() ||
+            (!canBeNativeType(*sort_description_types[i]) && !WhichDataType(nested_type).isString() && !WhichDataType(nested_type).isFixedString()))
+            return;
+
+        /// JIT comparator does not support collation-aware comparison
+        if (description[i].collator)
             return;
     }
 

--- a/src/Interpreters/JIT/CHJIT.cpp
+++ b/src/Interpreters/JIT/CHJIT.cpp
@@ -22,6 +22,7 @@
 #include <llvm/Support/SmallVectorMemoryBuffer.h>
 
 #include <base/getPageSize.h>
+#include <base/memcmpSmall.h>
 #include <Common/Exception.h>
 #include <Common/ErrnoException.h>
 #include <Common/formatReadable.h>
@@ -392,6 +393,7 @@ CHJIT::CHJIT()
     symbol_resolver->registerSymbol("memset", reinterpret_cast<void *>(&memset));
     symbol_resolver->registerSymbol("memcpy", reinterpret_cast<void *>(&memcpy));
     symbol_resolver->registerSymbol("memcmp", reinterpret_cast<void *>(&memcmp));
+    symbol_resolver->registerSymbol("memcmpSmallCharsAllowOverflow15", reinterpret_cast<void *>(&memcmpSmallCharsAllowOverflow15));
 
     symbol_resolver->registerSymbol("fmod", reinterpret_cast<void *>(static_cast<double (*)(double, double)>(&fmod)));
     symbol_resolver->registerSymbol("__divti3", reinterpret_cast<void *>(&__divti3));

--- a/src/Interpreters/JIT/compileFunction.cpp
+++ b/src/Interpreters/JIT/compileFunction.cpp
@@ -4,6 +4,7 @@
 
 #    include <AggregateFunctions/IAggregateFunction.h>
 #    include <Columns/ColumnNullable.h>
+#    include <Columns/ColumnString.h>
 #    include <DataTypes/DataTypeNullable.h>
 #    include <DataTypes/Native.h>
 #    include <Interpreters/JIT/CHJIT.h>
@@ -60,8 +61,33 @@ ColumnData getColumnData(const IColumn * column, size_t skip_rows)
     }
     /// skip null key data for one nullable key optimization
     result.data = column->getDataAt(skip_rows).data();
+    if (WhichDataType(column->getDataType()).isString())
+    {
+        const auto * string_column = assert_cast<const ColumnString *>(column);
+        result.offset_data = reinterpret_cast<const char *>(&string_column->getOffsets()[skip_rows]);
+    }
 
     return result;
+}
+
+llvm::StructType * buildColumnDataStruct(llvm::IRBuilderBase & b)
+{
+    auto * char_ptr_type = b.getInt8Ty()->getPointerTo();
+    return llvm::StructType::get(char_ptr_type, char_ptr_type, char_ptr_type);
+}
+
+llvm::StructType * buildStringRefType(llvm::IRBuilderBase &b)
+{
+    auto * data_ptr_type = b.getInt8Ty()->getPointerTo();
+    auto * offset_ptr_type = b.getInt8Ty()->getPointerTo();
+    auto * index_type = b.getInt64Ty();
+    return llvm::StructType::get(data_ptr_type, offset_ptr_type, index_type);
+}
+
+llvm::StructType * buildFixedStringType(llvm::IRBuilderBase &b)
+{
+    auto * data_ptr_type = b.getInt8Ty()->getPointerTo();
+    return llvm::StructType::get(data_ptr_type, b.getInt64Ty());
 }
 
 static void compileFunction(llvm::Module & module, const IFunctionBase & function)
@@ -70,7 +96,7 @@ static void compileFunction(llvm::Module & module, const IFunctionBase & functio
 
     llvm::IRBuilder<> b(module.getContext());
     auto * size_type = b.getIntNTy(sizeof(size_t) * 8);
-    auto * data_type = llvm::StructType::get(b.getInt8Ty()->getPointerTo(), b.getInt8Ty()->getPointerTo());
+    auto * data_type = buildColumnDataStruct(b);
     auto * func_type = llvm::FunctionType::get(b.getVoidTy(), { size_type, data_type->getPointerTo() }, /*isVarArg=*/false);
 
     /// Create function in module
@@ -241,7 +267,7 @@ static void compileAddIntoAggregateStatesFunctions(llvm::Module & module,
     else
         places_type = b.getInt8Ty()->getPointerTo();
 
-    auto * column_type = llvm::StructType::get(b.getInt8Ty()->getPointerTo(), b.getInt8Ty()->getPointerTo());
+    auto * column_type = buildColumnDataStruct(b);
 
     auto * add_into_aggregate_states_func_declaration = llvm::FunctionType::get(b.getVoidTy(), { size_type, size_type, column_type->getPointerTo(), places_type }, false);
     auto * add_into_aggregate_states_func = llvm::Function::Create(add_into_aggregate_states_func_declaration, llvm::Function::ExternalLinkage, name, module);
@@ -426,7 +452,7 @@ static void compileInsertAggregatesIntoResultColumns(llvm::Module & module, cons
 
     auto * size_type = b.getIntNTy(sizeof(size_t) * 8);
 
-    auto * column_type = llvm::StructType::get(b.getInt8Ty()->getPointerTo(), b.getInt8Ty()->getPointerTo());
+    auto * column_type = buildColumnDataStruct(b);
     auto * aggregate_data_places_type = b.getInt8Ty()->getPointerTo()->getPointerTo();
     auto * insert_aggregates_into_result_func_declaration = llvm::FunctionType::get(b.getVoidTy(), { size_type, size_type, column_type->getPointerTo(), aggregate_data_places_type }, false);
     auto * insert_aggregates_into_result_func = llvm::Function::Create(insert_aggregates_into_result_func_declaration, llvm::Function::ExternalLinkage, name, module);
@@ -559,7 +585,7 @@ static void compileSortDescription(llvm::Module & module,
 
     auto * size_type = b.getIntNTy(sizeof(size_t) * 8);
 
-    auto * column_data_type = llvm::StructType::get(b.getInt8Ty()->getPointerTo(), b.getInt8Ty()->getPointerTo());
+    auto * column_data_type = buildColumnDataStruct(b);
 
     std::vector<llvm::Type *> function_argument_types = {size_type, size_type, column_data_type->getPointerTo(), column_data_type->getPointerTo()};
     auto * comparator_func_declaration = llvm::FunctionType::get(b.getInt8Ty(), function_argument_types, false);
@@ -590,46 +616,97 @@ static void compileSortDescription(llvm::Module & module,
 
         const auto & sort_description = description[i];
         const auto & column_type = sort_description_types[i];
+        auto nested_column_type = removeNullable(column_type);
 
         auto dummy_column = column_type->createColumn();
 
-        auto * column_native_type = toNativeType(b, removeNullable(column_type));
-        if (!column_native_type)
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "No native type for column type {}", column_type->getName());
-
-        bool column_type_is_nullable = column_type->isNullable();
-
-        auto * nullable_unitialized = llvm::Constant::getNullValue(toNullableType(b, column_native_type));
-
-        auto * lhs_column = b.CreateLoad(column_data_type, b.CreateConstInBoundsGEP1_64(column_data_type, columns_lhs_arg, i));
-        auto * lhs_column_data = b.CreateExtractValue(lhs_column, {0});
-        auto * lhs_column_null_data = column_type_is_nullable ? b.CreateExtractValue(lhs_column, {1}) : nullptr;
-
-        llvm::Value * lhs_column_element_offset = b.CreateInBoundsGEP(column_native_type, lhs_column_data, lhs_index_arg);
-        llvm::Value * lhs_value = b.CreateLoad(column_native_type, lhs_column_element_offset);
-
-        if (lhs_column_null_data)
+        auto try_load_nullable_value = [&](llvm::Value * value, llvm::Value * nullable_uninitialized, llvm::Value * column_null_data, llvm::Value * index_arg) -> llvm::Value *
         {
-            auto * is_null_value_pointer = b.CreateInBoundsGEP(b.getInt8Ty(), lhs_column_null_data, lhs_index_arg);
-            auto * is_null = b.CreateICmpNE(b.CreateLoad(b.getInt8Ty(), is_null_value_pointer), b.getInt8(0));
-            auto * lhs_nullable_value = b.CreateInsertValue(b.CreateInsertValue(nullable_unitialized, lhs_value, {0}), is_null, {1});
-            lhs_value = lhs_nullable_value;
-        }
+            if (column_null_data)
+            {
+                auto * is_null_value_pointer = b.CreateInBoundsGEP(b.getInt8Ty(), column_null_data, index_arg);
+                auto * is_null = b.CreateICmpNE(b.CreateLoad(b.getInt8Ty(), is_null_value_pointer), b.getInt8(0));
+                auto * nullable_value = b.CreateInsertValue(b.CreateInsertValue(nullable_uninitialized, value, {0}), is_null, {1});
+                value = nullable_value;
+            }
+            return value;
+        };
 
-        auto * rhs_column = b.CreateLoad(column_data_type, b.CreateConstInBoundsGEP1_64(column_data_type, columns_rhs_arg, i));
-        auto * rhs_column_data = b.CreateExtractValue(rhs_column, {0});
-        auto * rhs_column_null_data = column_type_is_nullable ? b.CreateExtractValue(rhs_column, {1}) : nullptr;
-
-        llvm::Value * rhs_column_element_offset = b.CreateInBoundsGEP(column_native_type, rhs_column_data, rhs_index_arg);
-        llvm::Value * rhs_value = b.CreateLoad(column_native_type, rhs_column_element_offset);
-
-        if (rhs_column_null_data)
+        auto load_column_string_value = [&](llvm::Value * column_arg, llvm::Value * index_arg, bool is_nullable)
         {
-            auto * is_null_value_pointer = b.CreateInBoundsGEP(b.getInt8Ty(), rhs_column_null_data, rhs_index_arg);
-            auto * is_null = b.CreateICmpNE(b.CreateLoad(b.getInt8Ty(), is_null_value_pointer), b.getInt8(0));
-            auto * rhs_nullable_value = b.CreateInsertValue(b.CreateInsertValue(nullable_unitialized, rhs_value, {0}), is_null, {1});
-            rhs_value = rhs_nullable_value;
+            auto * string_ref_type = buildStringRefType(b);
+            auto * nullable_uninitialized = llvm::Constant::getNullValue(toNullableType(b, string_ref_type));
+
+            auto * column = b.CreateLoad(column_data_type, b.CreateConstInBoundsGEP1_64(column_data_type, column_arg, i));
+            auto * column_data = b.CreateExtractValue(column, {0});
+            auto * column_null_data = is_nullable ? b.CreateExtractValue(column, {1}) : nullptr;
+            auto * column_offset_data = b.CreateExtractValue(column, {2});
+
+            /// build struct : {chars ptr, offset ptr, index}
+            /// The string comparison logic is relatively complex, so here we only pass the raw memory pointers and the row index.
+            /// The specific implementation will be completed in ColumnString::compileComparator
+            llvm::Value * value = llvm::UndefValue::get(string_ref_type);
+            value = b.CreateInsertValue(value, column_data, {0});
+            value = b.CreateInsertValue(value, column_offset_data, {1});
+            value = b.CreateInsertValue(value, index_arg, {2});
+
+            return try_load_nullable_value(value, nullable_uninitialized, column_null_data, index_arg);
+        };
+
+        auto load_column_fixed_string_value = [&](llvm::Value * column_arg, llvm::Value * index_arg, bool is_nullable)
+        {
+            auto * fixed_string_type = buildFixedStringType(b);
+
+            auto * nullable_uninitialized = llvm::Constant::getNullValue(toNullableType(b, fixed_string_type));
+
+            auto * column = b.CreateLoad(column_data_type, b.CreateConstInBoundsGEP1_64(column_data_type, column_arg, i));
+            auto * column_data = b.CreateExtractValue(column, {0});
+            auto * column_null_data = is_nullable ? b.CreateExtractValue(column, {1}) : nullptr;
+
+            llvm::Value * value = llvm::UndefValue::get(fixed_string_type);
+            value = b.CreateInsertValue(value, column_data, {0});
+            value = b.CreateInsertValue(value, index_arg, {1});
+
+            return try_load_nullable_value(value, nullable_uninitialized, column_null_data, index_arg);
+        };
+
+        auto load_column_native_value = [&](llvm::Value * column_arg, llvm::Value * index_arg, bool is_nullable)
+        {
+            auto * column_native_type = toNativeType(b, nested_column_type);
+            if (!column_native_type)
+                throw Exception(ErrorCodes::LOGICAL_ERROR, "No native type for column type {}", column_type->getName());
+
+            auto * nullable_uninitialized = llvm::Constant::getNullValue(toNullableType(b, column_native_type));
+
+            auto * column = b.CreateLoad(column_data_type, b.CreateConstInBoundsGEP1_64(column_data_type, column_arg, i));
+            auto * column_data = b.CreateExtractValue(column, {0});
+            auto * column_null_data = is_nullable ? b.CreateExtractValue(column, {1}) : nullptr;
+
+            llvm::Value * column_element_offset = b.CreateInBoundsGEP(column_native_type, column_data, index_arg);
+            llvm::Value * value = b.CreateLoad(column_native_type, column_element_offset);
+
+            return try_load_nullable_value(value, nullable_uninitialized, column_null_data, index_arg);
+        };
+
+        llvm::Value * lhs_value = nullptr;
+        llvm::Value * rhs_value = nullptr;
+        if (WhichDataType(nested_column_type).isString())
+        {
+            lhs_value = load_column_string_value(columns_lhs_arg, lhs_index_arg, column_type->isNullable());
+            rhs_value = load_column_string_value(columns_rhs_arg, rhs_index_arg, column_type->isNullable());
         }
+        else if (WhichDataType(nested_column_type).isFixedString())
+        {
+            lhs_value = load_column_fixed_string_value(columns_lhs_arg, lhs_index_arg, column_type->isNullable());
+            rhs_value = load_column_fixed_string_value(columns_rhs_arg, rhs_index_arg, column_type->isNullable());
+        }
+        else if (canBeNativeType(column_type))
+        {
+            lhs_value = load_column_native_value(columns_lhs_arg, lhs_index_arg, column_type->isNullable());
+            rhs_value = load_column_native_value(columns_rhs_arg, rhs_index_arg, column_type->isNullable());
+        }
+        else
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Not supported type for column type {}", column_type->getName());
 
         llvm::Value * direction = llvm::ConstantInt::getSigned(b.getInt8Ty(), sort_description.direction);
         llvm::Value * nan_direction_hint = llvm::ConstantInt::getSigned(b.getInt8Ty(), sort_description.nulls_direction);

--- a/src/Interpreters/JIT/compileFunction.cpp
+++ b/src/Interpreters/JIT/compileFunction.cpp
@@ -60,11 +60,18 @@ ColumnData getColumnData(const IColumn * column, size_t skip_rows)
         column = &nullable->getNestedColumn();
     }
     /// skip null key data for one nullable key optimization
-    result.data = column->getDataAt(skip_rows).data();
     if (WhichDataType(column->getDataType()).isString())
     {
+        /// For String columns, use base pointers to chars and offsets arrays directly.
+        /// The JIT comparator uses absolute row indices into these arrays, so both
+        /// pointers must be to the start of their respective arrays regardless of skip_rows.
         const auto * string_column = assert_cast<const ColumnString *>(column);
-        result.offset_data = reinterpret_cast<const char *>(&string_column->getOffsets()[skip_rows]);
+        result.data = reinterpret_cast<const char *>(string_column->getChars().data());
+        result.offset_data = reinterpret_cast<const char *>(string_column->getOffsets().data());
+    }
+    else
+    {
+        result.data = column->getDataAt(skip_rows).data();
     }
 
     return result;

--- a/src/Interpreters/JIT/compileFunction.h
+++ b/src/Interpreters/JIT/compileFunction.h
@@ -22,6 +22,7 @@ struct ColumnData
 {
     const char * data = nullptr;
     const char * null_data = nullptr;
+    const char * offset_data = nullptr; // For String type, points to offsets data
 };
 
 /** Returns ColumnData for column.

--- a/tests/performance/string_order_by.xml
+++ b/tests/performance/string_order_by.xml
@@ -1,0 +1,23 @@
+<test>
+    <settings>
+        <max_threads>8</max_threads>
+        <min_count_to_compile_sort_description>0</min_count_to_compile_sort_description>
+    </settings>
+    <create_query>CREATE TABLE str_sort (a String, b UInt64, c FixedString(5), d String, e UInt32, f UInt32) ENGINE = Memory</create_query>
+    <fill_query>
+        INSERT INTO str_sort
+        SELECT 
+            randomString(4) AS a,
+            rand()  AS b, cast(randomString(5) AS FixedString(5)) as c,
+            toString(rand() % 100000) as d,
+            rand() % 1000 as e,
+            rand() % 1000 as f
+        FROM numbers(1e7)
+    </fill_query>
+
+    <query>SELECT a, b FROM str_sort ORDER BY a, b, e, f FORMAT Null</query>
+    <query>SELECT b, c FROM str_sort ORDER BY b, c, e, f FORMAT Null</query>
+    <query>SELECT a, d FROM str_sort ORDER BY c, d, e, f FORMAT Null</query>
+
+    <drop_query>DROP TABLE IF EXISTS str_sort</drop_query>
+</test>

--- a/tests/performance/string_order_by.xml
+++ b/tests/performance/string_order_by.xml
@@ -1,6 +1,7 @@
 <test>
     <settings>
         <max_threads>8</max_threads>
+        <compile_sort_description>1</compile_sort_description>
         <min_count_to_compile_sort_description>0</min_count_to_compile_sort_description>
     </settings>
     <create_query>CREATE TABLE str_sort (a String, b UInt64, c FixedString(5), d String, e UInt32, f UInt32) ENGINE = Memory</create_query>
@@ -19,5 +20,22 @@
     <query>SELECT b, c FROM str_sort ORDER BY b, c, e, f FORMAT Null</query>
     <query>SELECT a, d FROM str_sort ORDER BY c, d, e, f FORMAT Null</query>
 
+    <create_query>CREATE TABLE str_sort_long (a String, b UInt64, c FixedString(128), d String, e UInt32, f UInt32) ENGINE = Memory</create_query>
+    <fill_query>
+        INSERT INTO str_sort_long
+        SELECT
+            randomString(64) AS a,
+            rand() AS b, cast(randomString(128) AS FixedString(128)) as c,
+            randomString(256) as d,
+            rand() % 1000 as e,
+            rand() % 1000 as f
+        FROM numbers(5e6)
+    </fill_query>
+
+    <query>SELECT a, b FROM str_sort_long ORDER BY a, b, e, f FORMAT Null</query>
+    <query>SELECT b, c FROM str_sort_long ORDER BY b, c, e, f FORMAT Null</query>
+    <query>SELECT a, d FROM str_sort_long ORDER BY c, d, e, f FORMAT Null</query>
+
     <drop_query>DROP TABLE IF EXISTS str_sort</drop_query>
+    <drop_query>DROP TABLE IF EXISTS str_sort_long</drop_query>
 </test>

--- a/tests/queries/0_stateless/04056_jit_sort_string_columns.reference
+++ b/tests/queries/0_stateless/04056_jit_sort_string_columns.reference
@@ -1,0 +1,104 @@
+--- String ASC ---
+	6
+apple	1
+apple	4
+apple	8
+banana	3
+banana	5
+cherry	2
+cherry	7
+--- String DESC ---
+cherry	2
+cherry	7
+banana	3
+banana	5
+apple	1
+apple	4
+apple	8
+	6
+--- FixedString ASC ---
+aaaa	6
+appl	1
+appl	4
+bana	3
+bana	5
+bana	8
+cher	2
+cher	7
+--- FixedString DESC ---
+cher	2
+cher	7
+bana	3
+bana	5
+bana	8
+appl	1
+appl	4
+aaaa	6
+--- Nullable(String) ASC NULLS FIRST ---
+\N	4
+\N	5
+	6
+apple	1
+apple	8
+banana	3
+cherry	2
+cherry	7
+--- Nullable(String) ASC NULLS LAST ---
+	6
+apple	1
+apple	8
+banana	3
+cherry	2
+cherry	7
+\N	4
+\N	5
+--- Nullable(FixedString) ASC NULLS FIRST ---
+\N	4
+\N	5
+aaaa	6
+appl	1
+bana	3
+bana	8
+cher	2
+cher	7
+--- Nullable(FixedString) ASC NULLS LAST ---
+aaaa	6
+appl	1
+bana	3
+bana	8
+cher	2
+cher	7
+\N	4
+\N	5
+--- Mixed: String + UInt32 ---
+	6
+apple	8
+apple	4
+apple	1
+banana	5
+banana	3
+cherry	7
+cherry	2
+--- Mixed: UInt32 + FixedString ---
+1	appl
+2	cher
+3	bana
+4	appl
+5	bana
+6	aaaa
+7	cher
+8	bana
+--- Mixed: Nullable(String) + FixedString ---
+	aaaa	6
+apple	appl	1
+apple	bana	8
+banana	bana	3
+cherry	cher	2
+cherry	cher	7
+\N	appl	4
+\N	bana	5
+--- Empty string edge case ---
+	6
+apple	1
+apple	4
+apple	8

--- a/tests/queries/0_stateless/04056_jit_sort_string_columns.sql
+++ b/tests/queries/0_stateless/04056_jit_sort_string_columns.sql
@@ -1,0 +1,63 @@
+-- Tags: no-fasttest
+-- no-fasttest: JIT compilation is not available in fasttest
+
+SET compile_sort_description = 1;
+SET min_count_to_compile_sort_description = 0;
+
+DROP TABLE IF EXISTS t_jit_sort_str;
+
+CREATE TABLE t_jit_sort_str
+(
+    s String,
+    fs FixedString(4),
+    ns Nullable(String),
+    nfs Nullable(FixedString(4)),
+    x UInt32
+) ENGINE = Memory;
+
+INSERT INTO t_jit_sort_str VALUES ('banana', 'bana', 'banana', 'bana', 3);
+INSERT INTO t_jit_sort_str VALUES ('apple', 'appl', 'apple', 'appl', 1);
+INSERT INTO t_jit_sort_str VALUES ('cherry', 'cher', 'cherry', 'cher', 2);
+INSERT INTO t_jit_sort_str VALUES ('apple', 'appl', NULL, NULL, 4);
+INSERT INTO t_jit_sort_str VALUES ('banana', 'bana', NULL, NULL, 5);
+INSERT INTO t_jit_sort_str VALUES ('', 'aaaa', '', 'aaaa', 6);
+INSERT INTO t_jit_sort_str VALUES ('cherry', 'cher', 'cherry', 'cher', 7);
+INSERT INTO t_jit_sort_str VALUES ('apple', 'bana', 'apple', 'bana', 8);
+
+SELECT '--- String ASC ---';
+SELECT s, x FROM t_jit_sort_str ORDER BY s, x;
+
+SELECT '--- String DESC ---';
+SELECT s, x FROM t_jit_sort_str ORDER BY s DESC, x;
+
+SELECT '--- FixedString ASC ---';
+SELECT fs, x FROM t_jit_sort_str ORDER BY fs, x;
+
+SELECT '--- FixedString DESC ---';
+SELECT fs, x FROM t_jit_sort_str ORDER BY fs DESC, x;
+
+SELECT '--- Nullable(String) ASC NULLS FIRST ---';
+SELECT ns, x FROM t_jit_sort_str ORDER BY ns ASC NULLS FIRST, x;
+
+SELECT '--- Nullable(String) ASC NULLS LAST ---';
+SELECT ns, x FROM t_jit_sort_str ORDER BY ns ASC NULLS LAST, x;
+
+SELECT '--- Nullable(FixedString) ASC NULLS FIRST ---';
+SELECT nfs, x FROM t_jit_sort_str ORDER BY nfs ASC NULLS FIRST, x;
+
+SELECT '--- Nullable(FixedString) ASC NULLS LAST ---';
+SELECT nfs, x FROM t_jit_sort_str ORDER BY nfs ASC NULLS LAST, x;
+
+SELECT '--- Mixed: String + UInt32 ---';
+SELECT s, x FROM t_jit_sort_str ORDER BY s, x DESC;
+
+SELECT '--- Mixed: UInt32 + FixedString ---';
+SELECT x, fs FROM t_jit_sort_str ORDER BY x, fs;
+
+SELECT '--- Mixed: Nullable(String) + FixedString ---';
+SELECT ns, fs, x FROM t_jit_sort_str ORDER BY ns ASC NULLS LAST, fs, x;
+
+SELECT '--- Empty string edge case ---';
+SELECT s, x FROM t_jit_sort_str WHERE s = '' OR s = 'apple' ORDER BY s, x;
+
+DROP TABLE t_jit_sort_str;


### PR DESCRIPTION
Supersedes and closes #86014.

Co-authored with @lgbo-ustc, based on https://github.com/ClickHouse/ClickHouse/pull/86014.

Add JIT compilation support for `ColumnString` and `ColumnFixedString` comparisons in sort descriptions, including their `Nullable` variants. This extends the existing JIT sort infrastructure (which previously only supported native numeric types) to string columns, reducing virtual dispatch overhead in the merge-sort comparator hot path.

Key changes:
- Add `offset_data` field to `ColumnData` struct for string offset array access in JIT
- Register `memcmpSmallCharsAllowOverflow15` as a JIT-resolvable symbol (with result normalization for portability across `memcmp` implementations)
- Implement `compileComparator` for `ColumnString` and `ColumnFixedString`
- Extend `compileSortDescription` to handle string/fixed-string value loading
- Relax `canBeNativeType` gate in `compileSortDescriptionIfNeeded` for string types

Note: the JIT comparator is used in the merge phase (`SortCursor::greaterAt`), not in the per-chunk pdqsort which already uses devirtualized template-instantiated comparators. The improvement is therefore proportional to the fraction of time spent in merging.

#### Local benchmark results (`max_threads=2`, 10s per run via `clickhouse benchmark`)

| Query | No JIT (QPS) | JIT (QPS) | Change |
|---|---|---|---|
| Short strings: `ORDER BY String, Int, Int, Int` | 0.798 | 0.868 | +8.8% |
| Short strings: `ORDER BY Int, FixedStr, Int, Int` | 1.422 | 1.603 | +12.7% |
| Short strings: `ORDER BY FixedStr, String, Int, Int` | 0.770 | 0.817 | +6.1% |
| Long strings: `ORDER BY String, Int, Int, Int` | 1.561 | 1.554 | -0.4% |
| Long strings: `ORDER BY Int, FixedStr, Int, Int` | 1.730 | 1.940 | +12.1% |
| Long strings: `ORDER BY FixedStr, String, Int, Int` | 0.621 | 0.729 | +17.4% |

Short strings: `String` = `randomString(4)`, `FixedString(5)`, 10M rows.
Long strings: `String` = `randomString(64)` / `randomString(256)`, `FixedString(128)`, 5M rows.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add JIT compilation support for `String` and `FixedString` column comparisons in ORDER BY, improving merge-phase sort performance by 6–17% for string-heavy sort keys. Co-authored with @lgbo-ustc.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.232`
<!-- ch-version-info:end -->