### PR TITLE
Fix inconsistent AST formatting for SAMPLE with query-level OFFSET

### DIFF
--- a/src/Parsers/ASTSelectQuery.cpp
+++ b/src/Parsers/ASTSelectQuery.cpp
@@ -77,13 +77,29 @@ void ASTSelectQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & s, Fo
         ostr << s.nl_or_ws;
     }
 
-    ostr << indent_str << "SELECT" << (distinct ? " DISTINCT" : "");
+    /// When the table has a SAMPLE clause and the query has a standalone OFFSET
+    /// (without LIMIT), use FROM-first syntax so that SELECT separates SAMPLE
+    /// from OFFSET.  Otherwise, the formatted "... SAMPLE r OFFSET n ..." is
+    /// ambiguous: the parser would consume OFFSET as the SAMPLE offset instead
+    /// of a query-level OFFSET.
+    bool format_from_first = sampleSize() && limitOffset() && !limitLength();
+
+    if (format_from_first && tables())
+    {
+        ostr << indent_str << "FROM";
+        tables()->format(ostr, s, state, frame);
+        ostr << s.nl_or_ws << indent_str << "SELECT" << (distinct ? " DISTINCT" : "");
+    }
+    else
+    {
+        ostr << indent_str << "SELECT" << (distinct ? " DISTINCT" : "");
+    }
 
     s.one_line
         ? select()->format(ostr, s, state, frame)
         : select()->as<ASTExpressionList &>().formatImplMultiline(ostr, s, state, frame);
 
-    if (tables())
+    if (!format_from_first && tables())
     {
         ostr << s.nl_or_ws << indent_str << "FROM";
         tables()->format(ostr, s, state, frame);

--- a/tests/queries/0_stateless/04054_sample_offset_formatting_ambiguity.reference
+++ b/tests/queries/0_stateless/04054_sample_offset_formatting_ambiguity.reference
@@ -1,0 +1,13 @@
+SelectWithUnionQuery (children 1)
+ ExpressionList (children 1)
+  SelectQuery (children 3)
+   ExpressionList (children 1)
+    Literal UInt64_1
+   TablesInSelectQuery (children 1)
+    TablesInSelectQueryElement (children 1)
+     TableExpression (children 2)
+      TableIdentifier system.one
+      SampleRatio 5 / 10
+   Literal UInt64_10
+FROM system.one\nSAMPLE 5 / 10\nSELECT 1\nOFFSET 10
+SELECT 1\nFROM system.one\nSAMPLE 5 / 10 OFFSET 10

--- a/tests/queries/0_stateless/04054_sample_offset_formatting_ambiguity.sql
+++ b/tests/queries/0_stateless/04054_sample_offset_formatting_ambiguity.sql
@@ -1,0 +1,14 @@
+-- Verify that a query with both SAMPLE and a query-level OFFSET roundtrips
+-- through formatting without the OFFSET being confused with SAMPLE OFFSET.
+
+-- FROM-first: OFFSET is after SELECT, so it is a query-level OFFSET.
+-- The AST must show Literal UInt64_10 as a child of SelectQuery (query-level offset),
+-- NOT as a child of TableExpression (which would mean SAMPLE offset).
+EXPLAIN AST FROM system.one SAMPLE 0.5 SELECT 1 OFFSET 10;
+
+-- Verify `formatQuery` produces FROM-first syntax when SAMPLE + query-level OFFSET
+-- coexist, so that re-parsing is unambiguous.
+SELECT formatQuery('FROM system.one SAMPLE 0.5 SELECT 1 OFFSET 10');
+
+-- When the OFFSET is a SAMPLE offset (SELECT-first), formatting should stay SELECT-first.
+SELECT formatQuery('SELECT 1 FROM system.one SAMPLE 0.5 OFFSET 10');


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix inconsistent AST formatting for SAMPLE with query-level OFFSET. Closes https://github.com/ClickHouse/ClickHouse/issues/100576

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
