### PR TITLE
Challenge the statement in CMakeLists: Build libunwind with sanitizer instrumentation to fix ASan false positive on fiber stacks

### DIFF
--- a/contrib/libunwind-cmake/CMakeLists.txt
+++ b/contrib/libunwind-cmake/CMakeLists.txt
@@ -33,9 +33,8 @@ target_compile_definitions(unwind PRIVATE -D_LIBUNWIND_REMEMBER_STACK_ALLOC=1)
 # NOTE: from this macros sizeof(unw_context_t)/sizeof(unw_cursor_t) is depends, so it should be set always
 target_compile_definitions(unwind PUBLIC -D_LIBUNWIND_IS_NATIVE_ONLY)
 
-# We should enable optimizations (otherwise it will be too slow in debug)
-# and disable sanitizers (otherwise infinite loop may happen)
-target_compile_options(unwind PRIVATE -O3 -fno-exceptions -funwind-tables -fno-sanitize=all $<$<COMPILE_LANGUAGE:CXX>:-nostdinc++ -fno-rtti>)
+# We should enable optimizations (otherwise it will be too slow in debug).
+target_compile_options(unwind PRIVATE -O3 -fno-exceptions -funwind-tables $<$<COMPILE_LANGUAGE:CXX>:-nostdinc++ -fno-rtti>)
 
 target_compile_options(unwind PRIVATE -Wno-unused-but-set-variable)
 


### PR DESCRIPTION
Remove `-fno-sanitize=all` from libunwind build flags. This allows ASan to properly track the `unw_context_t` buffers in `_Unwind_Resume` and related functions, preventing false positive "stack-use-after-scope" reports during exception unwinding on fiber/coroutine stacks.

The root cause: `__unw_getcontext` saves registers via raw assembly (e.g., `stp` on AArch64) that bypasses ASan shadow tracking. On fiber stacks, `__asan_handle_no_return` cannot determine the correct stack boundaries and skips unpoisoning. When `unw_init_local` later reads the context via `memcpy` (globally intercepted by ASan), stale use-after-scope poisoning from the caller's stack frame causes a false positive.

With sanitizer instrumentation enabled, the compiler's ASan-aware memory operations properly maintain the shadow state for libunwind's stack variables, and `__asan_handle_no_return` within `__unw_resume` can function correctly.

Example failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100404&sha=4e239671fdc3523725369f5ad6028b4a52c43b45&name_0=PR&name_1=AST%20fuzzer%20%28arm_asan_ubsan%29
https://github.com/ClickHouse/ClickHouse/pull/100404

Closes #100442

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)