### PR TITLE
Re-add {database} macro support in clickhouse-client prompt

### DIFF
--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -707,6 +707,11 @@ void Client::connect()
 
     prompt = appendSmileyIfNeeded(prompt);
 
+    // Sync the true current database from the server after handshake.
+    // This handles the case where default_database is set server-side
+    // without a client --database flag. Called once at connect time;
+    // server config reloads (SYSTEM RELOAD CONFIG) cannot change the
+    // current database for an already-established session.
     syncDefaultDatabase();
 }
 

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -707,12 +707,17 @@ void Client::connect()
 
     prompt = appendSmileyIfNeeded(prompt);
 
-    // Sync the true current database from the server after handshake.
-    // This handles the case where default_database is set server-side
-    // without a client --database flag. Called once at connect time;
-    // server config reloads (SYSTEM RELOAD CONFIG) cannot change the
-    // current database for an already-established session.
-    syncDefaultDatabase();
+    /// Sync the current database from the server after the handshake, but only when all
+    /// three conditions hold:
+    ///  - interactive: in batch mode the prompt is never displayed, so the extra
+    ///    round-trip to the server would add latency with no visible benefit;
+    ///  - no explicit --database flag: if the user passed --database, default_database
+    ///    is already set to the correct value and must not be overridden by whatever
+    ///    the server considers the current database;
+    ///  - {database} appears in the prompt string: querying the server is pointless
+    ///    when the macro is absent and the result would never be shown.
+    if (is_interactive && default_database.empty() && prompt.find("{database}") != String::npos)
+        syncDefaultDatabase();
 }
 
 // Prints changed settings to stderr. Useful for debugging fuzzing failures.

--- a/programs/client/Client.cpp
+++ b/programs/client/Client.cpp
@@ -706,6 +706,8 @@ void Client::connect()
         boost::replace_all(prompt, "{" + key + "}", value);
 
     prompt = appendSmileyIfNeeded(prompt);
+
+    syncDefaultDatabase();
 }
 
 // Prints changed settings to stderr. Useful for debugging fuzzing failures.

--- a/programs/client/clickhouse-client.xml
+++ b/programs/client/clickhouse-client.xml
@@ -23,6 +23,7 @@
             {port}
             {user}
             {display_name}
+            {database}
 
         You can also use colored prompt, like in [1].
           [1]: https://misc.flogisoft.com/bash/tip_colors_and_formatting

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -12,6 +12,7 @@
 #include <Core/UUID.h>
 #include <Interpreters/sortBlock.h>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/replace.hpp>
 
 #if USE_CLIENT_AI
 #include <Client/AI/AISQLGenerator.h>
@@ -3393,7 +3394,9 @@ bool ClientBase::processQueryText(const String & text)
 
 String ClientBase::getPrompt() const
 {
-    return prompt;
+    String result = prompt;
+    boost::replace_all(result, "{database}", default_database.empty() ? "default" : default_database);
+    return result;
 }
 
 

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -3808,6 +3808,22 @@ bool ClientBase::processHelpCommand(const String & word_arg)
 }
 
 #if USE_CLIENT_AI
+void ClientBase::syncDefaultDatabase()
+{
+    try
+    {
+        const auto db = executeQueryForSingleString("SELECT currentDatabase()");
+        if (!db.empty())
+            default_database = db;
+        else
+            LOG_WARNING(getLogger("ClientBase"), "syncDefaultDatabase: server returned empty result for SELECT currentDatabase()");
+    }
+    catch (...)
+    {
+        LOG_WARNING(getLogger("ClientBase"), "syncDefaultDatabase: failed to query current database from server: {}", getCurrentExceptionMessage(false));
+    }
+}
+
 bool ClientBase::checkAIProviderAcknowledgment()
 {
     // If API key came from environment and user hasn't acknowledged yet, ask for confirmation

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -330,6 +330,11 @@ protected:
 
     String appendSmileyIfNeeded(const String & prompt);
 
+    /// Query the server for the current database and update default_database.
+    /// Called after the connection handshake so that the prompt reflects the
+    /// server-side default when no --database flag was passed.
+    void syncDefaultDatabase();
+
     /// Should be one of the first, to be destroyed the last,
     /// since other members can use them.
     /// This holder may not be initialized in case if we run the client in the embedded mode (SSH).

--- a/tests/queries/0_stateless/04056_client_prompt_database.expect
+++ b/tests/queries/0_stateless/04056_client_prompt_database.expect
@@ -42,7 +42,7 @@ expect eof
 # syncDefaultDatabase() fires SELECT currentDatabase() after the handshake and writes
 # the result into default_database, so the prompt reflects the server-side default.
 spawn bash -c "source $basedir/../shell_config.sh ; opts=\$(echo \"\$CLICKHOUSE_CLIENT_EXPECT_OPT\" | sed 's/--database=\[^ \]*//g') ; \$CLICKHOUSE_CLIENT_BINARY \$opts --prompt '{database}' --history_file=$history_file"
-expect -re "\n\[a-z_\]+ :) $"
+expect -re "\ndefault :) $"
 
 send -- "\4"
 expect eof

--- a/tests/queries/0_stateless/04056_client_prompt_database.expect
+++ b/tests/queries/0_stateless/04056_client_prompt_database.expect
@@ -37,3 +37,12 @@ expect -re "\nsystem :) $"
 
 send -- "\4"
 expect eof
+
+# Test 3: {database} shows the server's current database when --database flag is not passed.
+# syncDefaultDatabase() fires SELECT currentDatabase() after the handshake and writes
+# the result into default_database, so the prompt reflects the server-side default.
+spawn bash -c "source $basedir/../shell_config.sh ; opts=\$(echo \"\$CLICKHOUSE_CLIENT_EXPECT_OPT\" | sed 's/--database=\[^ \]*//g') ; \$CLICKHOUSE_CLIENT_BINARY \$opts --prompt '{database}' --history_file=$history_file"
+expect -re "\n\[a-z_\]+ :) $"
+
+send -- "\4"
+expect eof

--- a/tests/queries/0_stateless/04056_client_prompt_database.expect
+++ b/tests/queries/0_stateless/04056_client_prompt_database.expect
@@ -1,0 +1,39 @@
+#!/usr/bin/expect -f
+
+# Test that {database} macro in the clickhouse-client prompt reflects the current database
+# and updates dynamically after USE statements.
+# https://github.com/ClickHouse/ClickHouse/issues/49118
+
+set basedir [file dirname $argv0]
+set basename [file tail $argv0]
+if {[info exists env(CLICKHOUSE_TMP)]} {
+    set CLICKHOUSE_TMP $env(CLICKHOUSE_TMP)
+} else {
+    set CLICKHOUSE_TMP "."
+}
+exp_internal -f $CLICKHOUSE_TMP/$basename.debuglog 0
+set history_file $CLICKHOUSE_TMP/$basename.history
+
+log_user 0
+set timeout 60
+match_max 100000
+
+expect_after {
+    # Do not ignore eof from expect
+    -i $any_spawn_id eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    -i $any_spawn_id timeout { exit 1 }
+}
+
+# Test 1: {database} in prompt shows the database set via --database flag.
+# CLICKHOUSE_CLIENT_EXPECT_OPT includes --database=test (CLICKHOUSE_DATABASE).
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_EXPECT_OPT --prompt '{database}' --history_file=$history_file"
+expect -re "\ntest :) $"
+
+# Test 2: {database} updates in the prompt after a USE statement.
+send -- "USE system;\r"
+expect "\nOk."
+expect -re "\nsystem :) $"
+
+send -- "\4"
+expect eof

--- a/tests/queries/0_stateless/04057_local_prompt_database.expect
+++ b/tests/queries/0_stateless/04057_local_prompt_database.expect
@@ -1,0 +1,40 @@
+#!/usr/bin/expect -f
+
+# Test that {database} macro in the clickhouse-local prompt reflects the current database
+# and updates dynamically after USE statements.
+# https://github.com/ClickHouse/ClickHouse/issues/49118
+
+set basedir [file dirname $argv0]
+set basename [file tail $argv0]
+if {[info exists env(CLICKHOUSE_TMP)]} {
+    set CLICKHOUSE_TMP $env(CLICKHOUSE_TMP)
+} else {
+    set CLICKHOUSE_TMP "."
+}
+exp_internal -f $CLICKHOUSE_TMP/$basename.debuglog 0
+set history_file $CLICKHOUSE_TMP/$basename.history
+
+log_user 0
+set timeout 60
+match_max 100000
+
+expect_after {
+    # Do not ignore eof from expect
+    -i $any_spawn_id eof { exp_continue }
+    # A default timeout action is to do nothing, change it to fail
+    -i $any_spawn_id timeout { exit 1 }
+}
+
+# Test 1: {database} in prompt shows "default" when --database flag is not passed.
+# default_database is empty in that case; getPrompt() falls back to the literal
+# string "default" so no server round-trip is needed.
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_LOCAL --disable_suggestion --enable-progress-table-toggle=0 --prompt '{database}' --history_file=$history_file"
+expect -re "\ndefault :) $"
+
+# Test 2: {database} updates in the prompt after a USE statement.
+send -- "USE system;\r"
+expect "\nOk."
+expect -re "\nsystem :) $"
+
+send -- "\4"
+expect eof


### PR DESCRIPTION
**Re-add `{database}` macro support in clickhouse-client prompt**

- The `{database}` macro was removed in PR #42508 because it read from static config and did not update after `USE` statements. This re-adds the macro by substituting it dynamically from the `default_database` member variable, which is updated on `USE` and `--database` flag.

Closes #49118

**Changelog category (leave one):**

- Improvement

**Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):**

- Re-add support for the `{database}` macro in the client prompt (`prompt_by_server_display_name`). Unlike the previous implementation removed in #42508, the database name now updates dynamically after `USE` statements and correctly reflects the `--database` CLI flag.

**Documentation entry for user-facing changes**

- [x] Documentation is written (mandatory for new features)

- The `{database}` macro is now available again in the `prompt_by_server_display_name` client configuration setting, alongside `{host}`, `{port}`, `{user}`, and `{display_name}`. It displays the current database and updates dynamically when switching databases via `USE`.

Example configuration:
```xml
<prompt_by_server_display_name>
    <default>{database}@{host} :) </default>
</prompt_by_server_display_name>
```