### PR TITLE
Fix interrupted Kafka shell-test cleanup for upgrade check

### DIFF
--- a/tests/queries/0_stateless/03918_kafka_produce_consume.sh
+++ b/tests/queries/0_stateless/03918_kafka_produce_consume.sh
@@ -11,6 +11,25 @@ KAFKA_TOPIC=$(echo "${CLICKHOUSE_TEST_UNIQUE_NAME}" | tr '_' '-')
 KAFKA_GROUP="${CLICKHOUSE_TEST_UNIQUE_NAME}_group"
 KAFKA_BROKER="127.0.0.1:9092"
 
+cleanup()
+{
+    local exit_code=$?
+
+    trap - EXIT INT TERM
+    set +e
+
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_mv" 2>/dev/null
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_dst" 2>/dev/null
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_kafka" 2>/dev/null
+    timeout 10 rpk topic delete $KAFKA_TOPIC --brokers $KAFKA_BROKER > /dev/null 2>&1
+
+    exit $exit_code
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 # Create topic
 rpk topic create $KAFKA_TOPIC -p 1 --brokers $KAFKA_BROKER > /dev/null 2>&1 && echo "Created topic."
 
@@ -52,9 +71,3 @@ for i in $(seq 1 120); do
 done
 
 $CLICKHOUSE_CLIENT -q "SELECT key, value FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_dst ORDER BY key"
-
-# Cleanup
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_mv" 2>/dev/null
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_dst" 2>/dev/null
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_kafka" 2>/dev/null
-timeout 10 rpk topic delete $KAFKA_TOPIC --brokers $KAFKA_BROKER > /dev/null 2>&1

--- a/tests/queries/0_stateless/03919_kafka_virtual_columns.sh
+++ b/tests/queries/0_stateless/03919_kafka_virtual_columns.sh
@@ -11,6 +11,25 @@ KAFKA_TOPIC=$(echo "${CLICKHOUSE_TEST_UNIQUE_NAME}" | tr '_' '-')
 KAFKA_GROUP="${CLICKHOUSE_TEST_UNIQUE_NAME}_group"
 KAFKA_BROKER="127.0.0.1:9092"
 
+cleanup()
+{
+    local exit_code=$?
+
+    trap - EXIT INT TERM
+    set +e
+
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_mv" 2>/dev/null
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_dst" 2>/dev/null
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_kafka" 2>/dev/null
+    timeout 10 rpk topic delete $KAFKA_TOPIC --brokers $KAFKA_BROKER > /dev/null 2>&1
+
+    exit $exit_code
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 # Create topic
 rpk topic create $KAFKA_TOPIC -p 1 --brokers $KAFKA_BROKER > /dev/null 2>&1 && echo "Created topic."
 
@@ -68,9 +87,3 @@ $CLICKHOUSE_CLIENT -q "SELECT id, data, kafka_key, kafka_offset, kafka_partition
 
 # Verify topic name
 $CLICKHOUSE_CLIENT -q "SELECT kafka_topic = '$KAFKA_TOPIC' AS topic_matches FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_dst LIMIT 1"
-
-# Cleanup
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_mv" 2>/dev/null
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_dst" 2>/dev/null
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_kafka" 2>/dev/null
-timeout 10 rpk topic delete $KAFKA_TOPIC --brokers $KAFKA_BROKER > /dev/null 2>&1

--- a/tests/queries/0_stateless/03920_kafka_insert.sh
+++ b/tests/queries/0_stateless/03920_kafka_insert.sh
@@ -10,6 +10,26 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 KAFKA_TOPIC=$(echo "${CLICKHOUSE_TEST_UNIQUE_NAME}" | tr '_' '-')
 KAFKA_BROKER="127.0.0.1:9092"
 
+cleanup()
+{
+    local exit_code=$?
+
+    trap - EXIT INT TERM
+    set +e
+
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_mv" 2>/dev/null
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_dst" 2>/dev/null
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_consumer" 2>/dev/null
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_producer" 2>/dev/null
+    timeout 10 rpk topic delete $KAFKA_TOPIC --brokers $KAFKA_BROKER > /dev/null 2>&1
+
+    exit $exit_code
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 # Create topic
 rpk topic create $KAFKA_TOPIC -p 1 --brokers $KAFKA_BROKER > /dev/null 2>&1 && echo "Created topic."
 
@@ -62,10 +82,3 @@ for i in $(seq 1 120); do
 done
 
 $CLICKHOUSE_CLIENT -q "SELECT key, value FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_dst ORDER BY key"
-
-# Cleanup
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_mv" 2>/dev/null
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_dst" 2>/dev/null
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_consumer" 2>/dev/null
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_producer" 2>/dev/null
-timeout 10 rpk topic delete $KAFKA_TOPIC --brokers $KAFKA_BROKER > /dev/null 2>&1

--- a/tests/queries/0_stateless/03921_kafka_formats.sh
+++ b/tests/queries/0_stateless/03921_kafka_formats.sh
@@ -9,20 +9,45 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 KAFKA_BROKER="127.0.0.1:9092"
 KAFKA_BASE=$(echo "${CLICKHOUSE_TEST_UNIQUE_NAME}" | tr '_' '-')
+KAFKA_TOPIC_JSON="${KAFKA_BASE}-json"
+KAFKA_TOPIC_CSV="${KAFKA_BASE}-csv"
+KAFKA_TOPIC_TSV="${KAFKA_BASE}-tsv"
+
+cleanup()
+{
+    local exit_code=$?
+
+    trap - EXIT INT TERM
+    set +e
+
+    for fmt in json csv tsv; do
+        $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_${fmt}_mv" 2>/dev/null
+        $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_${fmt}_dst" 2>/dev/null
+        $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_${fmt}_kafka" 2>/dev/null
+    done
+    timeout 10 rpk topic delete $KAFKA_TOPIC_JSON --brokers $KAFKA_BROKER > /dev/null 2>&1
+    timeout 10 rpk topic delete $KAFKA_TOPIC_CSV --brokers $KAFKA_BROKER > /dev/null 2>&1
+    timeout 10 rpk topic delete $KAFKA_TOPIC_TSV --brokers $KAFKA_BROKER > /dev/null 2>&1
+
+    exit $exit_code
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # Test JSONEachRow format
-KAFKA_TOPIC="${KAFKA_BASE}-json"
-rpk topic create $KAFKA_TOPIC -p 1 --brokers $KAFKA_BROKER > /dev/null 2>&1 && echo "Created topic."
+rpk topic create $KAFKA_TOPIC_JSON -p 1 --brokers $KAFKA_BROKER > /dev/null 2>&1 && echo "Created topic."
 
 for i in $(seq 1 3); do
     echo "{\"a\": $i, \"b\": \"json_$i\"}"
-done | timeout 30 rpk topic produce $KAFKA_TOPIC --brokers $KAFKA_BROKER > /dev/null 2>&1
+done | timeout 30 rpk topic produce $KAFKA_TOPIC_JSON --brokers $KAFKA_BROKER > /dev/null 2>&1
 
 $CLICKHOUSE_CLIENT -q "
     CREATE TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_json_kafka (a UInt64, b String)
     ENGINE = Kafka
     SETTINGS kafka_broker_list = '$KAFKA_BROKER',
-             kafka_topic_list = '$KAFKA_TOPIC',
+             kafka_topic_list = '$KAFKA_TOPIC_JSON',
              kafka_group_name = '${CLICKHOUSE_TEST_UNIQUE_NAME}_json_group',
              kafka_format = 'JSONEachRow',
              kafka_max_block_size = 100;
@@ -37,7 +62,6 @@ $CLICKHOUSE_CLIENT -q "
 "
 
 # Test CSV format
-KAFKA_TOPIC_CSV="${KAFKA_BASE}-csv"
 rpk topic create $KAFKA_TOPIC_CSV -p 1 --brokers $KAFKA_BROKER > /dev/null 2>&1 && echo "Created topic."
 
 for i in $(seq 1 3); do
@@ -63,7 +87,6 @@ $CLICKHOUSE_CLIENT -q "
 "
 
 # Test TSV format
-KAFKA_TOPIC_TSV="${KAFKA_BASE}-tsv"
 rpk topic create $KAFKA_TOPIC_TSV -p 1 --brokers $KAFKA_BROKER > /dev/null 2>&1 && echo "Created topic."
 
 for i in $(seq 1 3); do
@@ -107,13 +130,3 @@ $CLICKHOUSE_CLIENT -q "SELECT a, b FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_csv_dst O
 
 echo "--- TSV ---"
 $CLICKHOUSE_CLIENT -q "SELECT a, b FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_tsv_dst ORDER BY a"
-
-# Cleanup
-for fmt in json csv tsv; do
-    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_${fmt}_mv" 2>/dev/null
-    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_${fmt}_dst" 2>/dev/null
-    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_${fmt}_kafka" 2>/dev/null
-done
-timeout 10 rpk topic delete $KAFKA_TOPIC --brokers $KAFKA_BROKER > /dev/null 2>&1
-timeout 10 rpk topic delete $KAFKA_TOPIC_CSV --brokers $KAFKA_BROKER > /dev/null 2>&1
-timeout 10 rpk topic delete $KAFKA_TOPIC_TSV --brokers $KAFKA_BROKER > /dev/null 2>&1

--- a/tests/queries/0_stateless/03922_kafka_skip_broken_messages.sh
+++ b/tests/queries/0_stateless/03922_kafka_skip_broken_messages.sh
@@ -11,6 +11,25 @@ KAFKA_TOPIC=$(echo "${CLICKHOUSE_TEST_UNIQUE_NAME}" | tr '_' '-')
 KAFKA_GROUP="${CLICKHOUSE_TEST_UNIQUE_NAME}_group"
 KAFKA_BROKER="127.0.0.1:9092"
 
+cleanup()
+{
+    local exit_code=$?
+
+    trap - EXIT INT TERM
+    set +e
+
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_mv" 2>/dev/null
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_dst" 2>/dev/null
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_kafka" 2>/dev/null
+    timeout 10 rpk topic delete $KAFKA_TOPIC --brokers $KAFKA_BROKER > /dev/null 2>&1
+
+    exit $exit_code
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 # Create topic
 rpk topic create $KAFKA_TOPIC -p 1 --brokers $KAFKA_BROKER > /dev/null 2>&1 && echo "Created topic."
 
@@ -58,9 +77,3 @@ done
 
 # Only valid messages should be in the destination table
 $CLICKHOUSE_CLIENT -q "SELECT id, value FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_dst ORDER BY id"
-
-# Cleanup
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_mv" 2>/dev/null
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_dst" 2>/dev/null
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_kafka" 2>/dev/null
-timeout 10 rpk topic delete $KAFKA_TOPIC --brokers $KAFKA_BROKER > /dev/null 2>&1

--- a/tests/queries/0_stateless/03923_kafka2_keeper_offsets.sh
+++ b/tests/queries/0_stateless/03923_kafka2_keeper_offsets.sh
@@ -12,6 +12,25 @@ KAFKA_GROUP="${CLICKHOUSE_TEST_UNIQUE_NAME}_group"
 KAFKA_BROKER="127.0.0.1:9092"
 KEEPER_PATH="/clickhouse/test/${CLICKHOUSE_TEST_UNIQUE_NAME}"
 
+cleanup()
+{
+    local exit_code=$?
+
+    trap - EXIT INT TERM
+    set +e
+
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_mv" 2>/dev/null
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_dst" 2>/dev/null
+    $CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_kafka" 2>/dev/null
+    timeout 10 rpk topic delete $KAFKA_TOPIC --brokers $KAFKA_BROKER > /dev/null 2>&1
+
+    exit $exit_code
+}
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 # Create topic
 rpk topic create $KAFKA_TOPIC -p 1 --brokers $KAFKA_BROKER > /dev/null 2>&1 && echo "Created topic."
 
@@ -73,9 +92,3 @@ done
 
 echo "--- After second batch ---"
 $CLICKHOUSE_CLIENT -q "SELECT id, data FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_dst ORDER BY id"
-
-# Cleanup
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_mv" 2>/dev/null
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_dst" 2>/dev/null
-$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_kafka" 2>/dev/null
-timeout 10 rpk topic delete $KAFKA_TOPIC --brokers $KAFKA_BROKER > /dev/null 2>&1


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
- N/A

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

## Summary
- Add signal-safe cleanup to the server-based `Kafka` shell tests so interrupted runs drop their tables, materialized views, and topics on `EXIT`/`TERM`.
- This avoids leaving restorable `StorageKafka` metadata behind for `Upgrade check`, which can then restart with broker connection errors when no `Kafka` service is started by the upgrade runner.

## Issue
- Closes #100554
- Original issue: https://github.com/ClickHouse/ClickHouse/issues/100554

## CI report
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99240&sha=43693454dbac75af4e1d56d409aee687eef729ba&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29
https://github.com/ClickHouse/ClickHouse/pull/99240

## Testing
- `bash -n` on the six modified shell scripts
- `git diff --check`
- Local runs of:
  - `tests/queries/0_stateless/03918_kafka_produce_consume.sh`
  - `tests/queries/0_stateless/03919_kafka_virtual_columns.sh`
  - `tests/queries/0_stateless/03921_kafka_formats.sh`
  - `tests/queries/0_stateless/03922_kafka_skip_broken_messages.sh`
  - isolated `tests/queries/0_stateless/03920_kafka_insert.sh`
- Local `timeout -s TERM 2` run of isolated `tests/queries/0_stateless/03920_kafka_insert.sh` left no `ClickHouse` tables and no `Kafka` topics behind
- `tests/queries/0_stateless/03923_kafka2_keeper_offsets.sh` was not run locally because the local server did not expose `Keeper` on `9181`

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.250`
<!-- ch-version-info:end -->