### PR TITLE
Revert "Experiment: use azurite-rs instead of azurite for functional tests"

### DIFF
--- a/ci/docker/stateless-test/Dockerfile
+++ b/ci/docker/stateless-test/Dockerfile
@@ -61,6 +61,12 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "aws
     && ./aws/install \
     && rm awscliv2.zip
 
+# Install Node.js 20 from NodeSource (azurite 3.34 fails with 24)
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
+
 ARG PROTOC_VERSION=25.1
 RUN curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip \
     && unzip protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /usr/local \
@@ -100,13 +106,8 @@ ENV MINIO_ROOT_PASSWORD="clickhouse"
 RUN chmod 777 /home
 ENV HOME="/home"
 
-# Download azurite-rs (Azure Blob Storage emulator in Rust)
-# https://github.com/ClickHouse/azurite-rs
-ARG AZURITE_RS_VERSION=v0.1.0-28a2afc
-RUN arch=${TARGETARCH:-amd64} \
-    && curl -fsSL "https://github.com/ClickHouse/azurite-rs/releases/download/${AZURITE_RS_VERSION}/azurite-rs-linux-${arch}.tar.gz" | tar -xz -C /usr/local/bin/ \
-    && mv /usr/local/bin/azurite-rs-linux-${arch} /usr/local/bin/azurite-rs \
-    && chmod +x /usr/local/bin/azurite-rs
+RUN npm install -g azurite@3.34.0 \
+    && npm install -g tslib
 
 # Install Redpanda (Kafka-compatible broker, no JVM required)
 COPY --from=redpanda /opt/redpanda /opt/redpanda

--- a/ci/docker/stateless-test/Dockerfile
+++ b/ci/docker/stateless-test/Dockerfile
@@ -61,7 +61,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "aws
     && ./aws/install \
     && rm awscliv2.zip
 
-# Install Node.js 20 from NodeSource (azurite 3.34 fails with 24)
+# Install Node.js 20 from NodeSource (azurite 3.35 fails with 24)
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && apt-get clean \
@@ -106,7 +106,7 @@ ENV MINIO_ROOT_PASSWORD="clickhouse"
 RUN chmod 777 /home
 ENV HOME="/home"
 
-RUN npm install -g azurite@3.34.0 \
+RUN npm install -g azurite@3.35.0 \
     && npm install -g tslib
 
 # Install Redpanda (Kafka-compatible broker, no JVM required)

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -164,13 +164,13 @@ class ClickHouseProc:
 
     def start_azurite(self):
         command = (
-            f"cd {temp_dir} && azurite-rs --host 0.0.0.0 --blob-port 10000 --silent --in-memory",
+            f"cd {temp_dir} && azurite-blob --blobHost 0.0.0.0 --blobPort 10000 --silent --inMemoryPersistence",
         )
         with open(self.AZURITE_LOG, "w") as log_file:
             self.azurite_proc = subprocess.Popen(
                 command, stdout=log_file, stderr=subprocess.STDOUT, shell=True
             )
-        print(f"Started azurite-rs asynchronously with PID {self.azurite_proc.pid}")
+        print(f"Started azurite asynchronously with PID {self.azurite_proc.pid}")
         return True
 
     def start_kafka(self):

--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -21,7 +21,7 @@ source /repo/tests/docker_scripts/attach_gdb.lib
 # shellcheck source=../stateless/stress_tests.lib
 source /repo/tests/docker_scripts/stress_tests.lib
 
-azurite-rs --host 0.0.0.0 --blob-port 10000 --debug > /azurite_log 2>&1 &
+azurite-blob --blobHost 0.0.0.0 --blobPort 10000 --debug /azurite_log &
 cd /repo && python3 /repo/ci/jobs/scripts/clickhouse_proc.py start_minio stateless || ( echo "Failed to start minio" && exit 1 ) # to have a proper environment
 
 echo "Get previous release tag"


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#95967

https://github.com/ClickHouse/azurite-rs is broken in multiple places, and it is not possible to maintain all features of Azure Blob Storage in a vibe-coded project.

Examples of broken protocol: 
1. https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100522&sha=8d49d3d67bf37f03859d5255253256493e28a45b&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/100522
2. https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100522&sha=685910a56c81a98c6e22587eb626f1f2893d96de&name_0=PR&name_1=Stateless%20tests%20%28arm_asan_ubsan%2C%20targeted%29

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.231`
- Backported to: `26.3.1.895`, `26.2.6.24`
<!-- ch-version-info:end -->