### PR TITLE
Exclude cancelled queries from FailedQuery events

### DIFF
--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -834,7 +834,8 @@ void logQueryException(
     elem.event_time = timeInSeconds(time_now);
     elem.event_time_microseconds = timeInMicroseconds(time_now);
 
-    incrementFailedQueryProfileEvents(query_ast, context->getClientInfo(), internal);
+    if (log_error)
+        incrementFailedQueryProfileEvents(query_ast, context->getClientInfo(), internal);
 
     QueryStatusInfoPtr info;
     if (process_list_elem)
@@ -948,7 +949,8 @@ void logExceptionBeforeStart(
     /// Update performance counters before logging to query_log
     CurrentThread::finalizePerformanceCounters();
 
-    incrementFailedQueryProfileEvents(ast, context->getClientInfo(), internal);
+    if (log_error)
+        incrementFailedQueryProfileEvents(ast, context->getClientInfo(), internal);
 
     QueryStatusInfoPtr info;
     if (QueryStatusPtr process_list_elem = context->getProcessListElementSafe())

--- a/tests/queries/0_stateless/04054_query_events_on_query_cancel.reference
+++ b/tests/queries/0_stateless/04054_query_events_on_query_cancel.reference
@@ -1,0 +1,8 @@
+Row 1:
+──────
+type:                     ExceptionWhileProcessing
+exception_code:           735
+FailedQuery:              0
+FailedSelectQuery:        0
+FailedInitialQuery:       0
+FailedInitialSelectQuery: 0

--- a/tests/queries/0_stateless/04054_query_events_on_query_cancel.sh
+++ b/tests/queries/0_stateless/04054_query_events_on_query_cancel.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+QUERY_ID="${CLICKHOUSE_TEST_UNIQUE_NAME}_to_cancel"
+
+$CLICKHOUSE_CLIENT --query_id "$QUERY_ID" -q "
+    SELECT sleepEachRow(0.5), rand64() FROM numbers(1000)
+    FORMAT Null
+    SETTINGS max_block_size = 1,
+             function_sleep_max_microseconds_per_block = 1000000000
+" &
+CLIENT_PID=$!
+
+wait_for_query_to_start "$QUERY_ID"
+
+kill -INT "$CLIENT_PID"
+wait "$CLIENT_PID"
+
+$CLICKHOUSE_CLIENT -nm -q "
+    SYSTEM FLUSH LOGS query_log;
+
+    SELECT
+        type,
+        exception_code,
+        ProfileEvents['FailedQuery'] AS FailedQuery,
+        ProfileEvents['FailedSelectQuery'] AS FailedSelectQuery,
+        ProfileEvents['FailedInitialQuery'] AS FailedInitialQuery,
+        ProfileEvents['FailedInitialSelectQuery'] AS FailedInitialSelectQuery
+    FROM system.query_log
+    WHERE event_date >= yesterday()
+        AND event_time >= now() - 600
+        AND current_database = currentDatabase()
+        AND query_id = '${QUERY_ID}'
+        AND type != 'QueryStart'
+    ORDER BY event_time_microseconds DESC
+    LIMIT 1
+    FORMAT Vertical;
+"

--- a/tests/queries/0_stateless/04054_query_events_on_query_cancel_before_start.reference
+++ b/tests/queries/0_stateless/04054_query_events_on_query_cancel_before_start.reference
@@ -1,0 +1,8 @@
+Row 1:
+──────
+type:                     ExceptionBeforeStart
+exception_code:           394
+FailedQuery:              0
+FailedSelectQuery:        0
+FailedInitialQuery:       0
+FailedInitialSelectQuery: 0

--- a/tests/queries/0_stateless/04054_query_events_on_query_cancel_before_start.sh
+++ b/tests/queries/0_stateless/04054_query_events_on_query_cancel_before_start.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Tags: no-parallel
+# Tag no-parallel: uses a PAUSEABLE failpoint; concurrent test instances would share the
+# same global failpoint channel and interfere with each other's ENABLE/DISABLE sequence.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+set -e
+
+DB_NAME="${CLICKHOUSE_DATABASE}_cancel_before_start"
+QUERY_ID="${CLICKHOUSE_TEST_UNIQUE_NAME}_to_cancel_before_start"
+
+cleanup()
+{
+    $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT truncate_database_tables_pause" 2>/dev/null ||:
+    $CLICKHOUSE_CLIENT -q "KILL QUERY WHERE query_id = '${QUERY_ID}' FORMAT Null" 2>/dev/null ||:
+    wait 2>/dev/null ||:
+    $CLICKHOUSE_CLIENT -q "DROP DATABASE IF EXISTS ${DB_NAME} SYNC" 2>/dev/null ||:
+}
+trap cleanup EXIT
+
+$CLICKHOUSE_CLIENT -q "DROP DATABASE IF EXISTS ${DB_NAME} SYNC"
+$CLICKHOUSE_CLIENT -q "CREATE DATABASE ${DB_NAME} ENGINE = Atomic"
+
+for i in $(seq 1 5); do
+    $CLICKHOUSE_CLIENT -q "
+        CREATE TABLE ${DB_NAME}.t${i} (x UInt64) ENGINE = MergeTree ORDER BY x;
+        INSERT INTO ${DB_NAME}.t${i} SELECT number FROM numbers(100);
+    "
+done
+
+$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT truncate_database_tables_pause"
+
+$CLICKHOUSE_CLIENT --query_id "$QUERY_ID" -q "TRUNCATE TABLES FROM ${DB_NAME} LIKE '%'" 2>/dev/null &
+TRUNCATE_PID=$!
+
+$CLICKHOUSE_CLIENT -q "SYSTEM WAIT FAILPOINT truncate_database_tables_pause PAUSE"
+$CLICKHOUSE_CLIENT -q "KILL QUERY WHERE query_id = '${QUERY_ID}' FORMAT Null"
+$CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT truncate_database_tables_pause"
+
+wait "$TRUNCATE_PID" 2>/dev/null ||:
+
+$CLICKHOUSE_CLIENT -nm -q "
+    SYSTEM FLUSH LOGS query_log;
+
+    SELECT
+        type,
+        exception_code,
+        ProfileEvents['FailedQuery'] AS FailedQuery,
+        ProfileEvents['FailedSelectQuery'] AS FailedSelectQuery,
+        ProfileEvents['FailedInitialQuery'] AS FailedInitialQuery,
+        ProfileEvents['FailedInitialSelectQuery'] AS FailedInitialSelectQuery
+    FROM system.query_log
+    WHERE event_date >= yesterday()
+        AND event_time >= now() - 600
+        AND current_database = currentDatabase()
+        AND query_id = '${QUERY_ID}'
+        AND is_initial_query
+        AND type != 'QueryStart'
+    ORDER BY event_time_microseconds DESC
+    LIMIT 1
+    FORMAT Vertical;
+"


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Exclude cancelled queries from `Failed*Query` profile events to make it consistent with errors logging

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Details

Query cancellation exceptions may be treated as an expected cancellations and not an errors -- for example from the logging perspective (text_log). This behavior is controlled through `log_error` flag argument of `logQueryException` method.

This patch aligns FailedQuery events with logs, by excluding cancelled queries count from those events.
