### PR TITLE
Fix flaky test 03800_use_const_adaptive_granularity_vertical_merge

### DIFF
--- a/tests/queries/0_stateless/03800_use_const_adaptive_granularity_vertical_merge.reference
+++ b/tests/queries/0_stateless/03800_use_const_adaptive_granularity_vertical_merge.reference
@@ -3,7 +3,7 @@ insert into tab select 1, if(number < 4096, 'foo', repeat('b', 1000)) from numbe
 select name, rows, marks, index_granularity_bytes_in_memory_allocated from system.parts where database = currentDatabase() and table = 'tab' and active;
 1_1_1_0	327675	3278	25
 1_2_2_0	72325	740	25
-optimize table tab;
+optimize table tab FINAL;
 select name, rows, marks, index_granularity_bytes_in_memory_allocated from system.parts where database = currentDatabase() and table = 'tab' and active;
 1_1_2_1	400000	4001	25
 select * from tab format Null;

--- a/tests/queries/0_stateless/03800_use_const_adaptive_granularity_vertical_merge.sql
+++ b/tests/queries/0_stateless/03800_use_const_adaptive_granularity_vertical_merge.sql
@@ -25,7 +25,7 @@ SETTINGS
 -- { echo }
 insert into tab select 1, if(number < 4096, 'foo', repeat('b', 1000)) from numbers(400e3) settings max_block_size=65535, max_insert_threads=1;
 select name, rows, marks, index_granularity_bytes_in_memory_allocated from system.parts where database = currentDatabase() and table = 'tab' and active;
-optimize table tab;
+optimize table tab FINAL;
 select name, rows, marks, index_granularity_bytes_in_memory_allocated from system.parts where database = currentDatabase() and table = 'tab' and active;
 select * from tab format Null;
 check table tab;


### PR DESCRIPTION
Use `OPTIMIZE TABLE ... FINAL` to force the merge instead of relying on merge selector heuristics. Without `FINAL`, the merge selector may decide not to merge parts (e.g., due to memory limits from `CompactionStatistics::getMaxSourcePartsBytesForMerge`), causing the test to fail because the parts remain unmerged.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100157&sha=6a8f4bf7d23b1337c4c93a7730b597ba68dafaff&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/100157

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)