### PR TITLE
Fix parser position leak in `ParserSetQuery` for `disk()` function check

### DIFF
--- a/src/Parsers/ParserSetQuery.cpp
+++ b/src/Parsers/ParserSetQuery.cpp
@@ -212,12 +212,16 @@ bool ParserSetQuery::parseNameValuePair(SettingChange & change, IParser::Pos & p
         return false;
 
     /// for SETTINGS disk=disk(type='s3', path='', ...)
-    if (function_p.parse(pos, function_ast, expected) && function_ast->as<ASTFunction>()->name == "disk")
     {
-        tryGetIdentifierNameInto(name, change.name);
-        change.value = createFieldFromAST(function_ast);
+        auto pos_before_func = pos;
+        if (function_p.parse(pos, function_ast, expected) && function_ast->as<ASTFunction>()->name == "disk")
+        {
+            tryGetIdentifierNameInto(name, change.name);
+            change.value = createFieldFromAST(function_ast);
 
-        return true;
+            return true;
+        }
+        pos = pos_before_func;
     }
     if (!literal_or_map_p.parse(pos, value, expected))
         return false;
@@ -281,12 +285,16 @@ bool ParserSetQuery::parseNameValuePairWithParameterOrDefault(
         }
 
         /// Setting
-        if (function_p.parse(pos, function_ast, expected) && function_ast->as<ASTFunction>()->name == "disk")
         {
-            change.name = name;
-            change.value = createFieldFromAST(function_ast);
+            auto pos_before_func = pos;
+            if (function_p.parse(pos, function_ast, expected) && function_ast->as<ASTFunction>()->name == "disk")
+            {
+                change.name = name;
+                change.value = createFieldFromAST(function_ast);
 
-            return true;
+                return true;
+            }
+            pos = pos_before_func;
         }
 
         if (!value_p.parse(pos, node, expected))

--- a/tests/queries/0_stateless/04057_explain_except_ast_formatting.reference
+++ b/tests/queries/0_stateless/04057_explain_except_ast_formatting.reference
@@ -1,0 +1,5 @@
+EXPLAIN PIPELINE header = 1, compact = 1\n(\n    SELECT -2\n)\nEXCEPT ALL\n(\n    SELECT 1\n)
+EXPLAIN PIPELINE header = 1, compact = 1\n(\n    SELECT -2\n)\nEXCEPT ALL\n(\n    SELECT 1\n)
+EXPLAIN PIPELINE header = 1, compact = 1\n(\n    SELECT -2\n)\nEXCEPT ALL\n(\n    SELECT 1\n)
+EXPLAIN PIPELINE header = 1, compact = 1\nSELECT -2\nINTERSECT ALL\nSELECT 1
+EXPLAIN PIPELINE header = 1, compact = 1\nSELECT -2\nINTERSECT ALL\nSELECT 1

--- a/tests/queries/0_stateless/04057_explain_except_ast_formatting.sql
+++ b/tests/queries/0_stateless/04057_explain_except_ast_formatting.sql
@@ -1,0 +1,20 @@
+-- Regression test: EXPLAIN with settings followed by parenthesized
+-- EXCEPT/INTERSECT operands must parse correctly.
+--
+-- The formatter wraps EXCEPT operands in parens (to disambiguate
+-- SELECT * EXCEPT col). When a setting value like `1` is immediately
+-- followed by `(SELECT ...`, ParserFunction used to greedily parse
+-- `1(SELECT ...)` as a function call, corrupting the parser position.
+
+-- Without parentheses (always worked, but verify roundtrip).
+SELECT formatQuery('EXPLAIN PIPELINE header = 1, compact = 1 SELECT -2 EXCEPT ALL SELECT 1');
+
+-- With explicit parentheses — this is the form the formatter produces.
+SELECT formatQuery('EXPLAIN PIPELINE header = 1, compact = 1 (SELECT -2) EXCEPT ALL (SELECT 1)');
+
+-- Nested formatQuery proves parse → format → re-parse → re-format is stable.
+SELECT formatQuery(formatQuery('EXPLAIN PIPELINE header = 1, compact = 1 (SELECT -2) EXCEPT ALL (SELECT 1)'));
+
+-- Same for INTERSECT.
+SELECT formatQuery('EXPLAIN PIPELINE header = 1, compact = 1 (SELECT -2) INTERSECT ALL (SELECT 1)');
+SELECT formatQuery(formatQuery('EXPLAIN PIPELINE header = 1, compact = 1 (SELECT -2) INTERSECT ALL (SELECT 1)'));


### PR DESCRIPTION
`parseNameValuePair` and `parseNameValuePairWithParameterOrDefault` try `ParserFunction` to detect `disk(...)` syntax. When the parse succeeds but the name is not `disk`, `pos` is left advanced by the successful parse and never restored. Save and restore `pos` around the check.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.253`
<!-- ch-version-info:end -->