### PR TITLE
add use_separate_cache_arena configuration parameter

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -130,6 +130,7 @@
 #include <unordered_set>
 
 #include <Common/Jemalloc.h>
+#include <Common/JemallocCacheArena.h>
 
 #include "config.h"
 #include <Common/config_version.h>
@@ -353,6 +354,7 @@ namespace ServerSetting
     extern const ServerSettingsString uncompressed_cache_policy;
     extern const ServerSettingsUInt64 uncompressed_cache_size;
     extern const ServerSettingsDouble uncompressed_cache_size_ratio;
+    extern const ServerSettingsBool use_separate_cache_arena;
     extern const ServerSettingsString primary_index_cache_policy;
     extern const ServerSettingsUInt64 primary_index_cache_size;
     extern const ServerSettingsDouble primary_index_cache_size_ratio;
@@ -1938,6 +1940,8 @@ try
     global_context->updateInterserverCredentials(config());
 
     /// Set up caches.
+
+    JemallocCacheArena::setEnabled(server_settings[ServerSetting::use_separate_cache_arena]);
 
     const size_t max_cache_size = static_cast<size_t>(static_cast<double>(physical_server_memory) * server_settings[ServerSetting::cache_size_to_ram_max_ratio]);
 

--- a/src/Common/AsynchronousMetrics.cpp
+++ b/src/Common/AsynchronousMetrics.cpp
@@ -1148,6 +1148,7 @@ void AsynchronousMetrics::update(TimePoint update_time, bool force_update)
     saveJemallocMetricImpl<size_t>(new_values, "arenas.dirty_decay_ms", "jemalloc.arenas.dirty_decay_ms");
 
     /// Per-arena metrics for the dedicated cache arena (mark cache, uncompressed cache).
+    if (JemallocCacheArena::isEnabled())
     {
         unsigned cache_arena = JemallocCacheArena::getArenaIndex();
         saveJemallocMetricImpl<size_t>(new_values,

--- a/src/Common/JemallocCacheArena.cpp
+++ b/src/Common/JemallocCacheArena.cpp
@@ -11,6 +11,7 @@
 
 #include <fmt/format.h>
 #include <string>
+#include <atomic>
 
 namespace ProfileEvents
 {
@@ -31,8 +32,12 @@ namespace ErrorCodes
 namespace DB::JemallocCacheArena
 {
 
+std::atomic<bool> enabled{true};
+
 namespace
 {
+
+bool arena_created = false;
 
 unsigned createArena()
 {
@@ -41,19 +46,37 @@ unsigned createArena()
     int err = je_mallctl("arenas.create", &arena_index, &arena_index_size, nullptr, 0);
     if (err)
         throw DB::Exception(DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY, "JemallocCacheArena: Failed to create jemalloc arena, error: {}", err);
+    arena_created = true;
     return arena_index;
 }
 
 }
 
+void setEnabled(bool value)
+{
+    chassert(!arena_created || value);
+    enabled.store(value, std::memory_order_relaxed);
+}
+
+bool isEnabled()
+{
+    return enabled.load(std::memory_order_relaxed);
+}
+
 unsigned getArenaIndex()
 {
+    if (!enabled.load(std::memory_order_relaxed))
+        return 0;
+
     static unsigned index = createArena();
     return index;
 }
 
 void purge()
 {
+    if (!enabled.load(std::memory_order_relaxed))
+        return;
+
     static Jemalloc::MibCache<unsigned> purge_mib(fmt::format("arena.{}.purge", getArenaIndex()).c_str());
 
     Stopwatch watch;
@@ -69,6 +92,8 @@ void purge()
 namespace DB::JemallocCacheArena
 {
 
+void setEnabled(bool) {}
+bool isEnabled() { return false; }
 unsigned getArenaIndex() { return 0; }
 void purge() {}
 

--- a/src/Common/JemallocCacheArena.h
+++ b/src/Common/JemallocCacheArena.h
@@ -1,19 +1,25 @@
 #pragma once
 
 #include "config.h"
-#include <cstddef>
 
 namespace DB::JemallocCacheArena
 {
 
+/// Enable or disable the dedicated cache arena. Must be called before any allocation.
+/// When disabled, getArenaIndex() returns 0 (default arena) and purge() is a no-op.
+void setEnabled(bool value);
+
+/// Whether the dedicated cache arena is enabled.
+bool isEnabled();
+
 /// Returns the jemalloc arena index dedicated to cache allocations
 /// (mark cache, uncompressed cache, etc.).
 /// Creates the arena on first call (thread-safe via Meyers singleton).
-/// Returns 0 (meaning "use default arena selection") if jemalloc is not available.
+/// Returns 0 (meaning "use default arena selection") if disabled or jemalloc is not available.
 unsigned getArenaIndex();
 
 /// Purge dirty pages only in the cache arena, returning memory to the OS.
-/// No-op if jemalloc is not available.
+/// No-op if disabled or jemalloc is not available.
 void purge();
 
 }

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -355,6 +355,10 @@ namespace
     - [merges_mutations_memory_usage_soft_limit](/operations/server-configuration-parameters/settings#merges_mutations_memory_usage_soft_limit)
     )", 0) \
     DECLARE(Bool, allow_use_jemalloc_memory, true, R"(Allows to use jemalloc memory.)", 0) \
+    DECLARE(Bool, use_separate_cache_arena, true, R"(
+    Enable a dedicated jemalloc arena for cache allocations (mark cache, uncompressed cache, page cache).
+    Isolates cache data from query-processing allocations, reducing memory fragmentation.
+    )", 0) \
     DECLARE(UInt64, cgroups_memory_usage_observer_wait_time, 15, R"(
     Interval in seconds during which the server's maximum allowed memory consumption is adjusted by the corresponding threshold in cgroups.
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
add use_separate_cache_arena configuration parameter to be able to control separation of cache arena

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.252`
<!-- ch-version-info:end -->