### PR TITLE
Check `isCanceled` before calling `eof` on the input `ReadBuffer` in `TCPHandler`

### DIFF
--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -492,9 +492,11 @@ void TCPHandler::runImpl()
             }
 
             /// If we need to shut down, or client disconnects.
-            if (!tcp_server.isOpen() || server.isCancelled() || in->eof())
+            if (!tcp_server.isOpen() || server.isCancelled() || in->isCanceled() || in->eof())
             {
-                LOG_TEST(log, "Closing connection (open: {}, cancelled: {}, eof: {})", tcp_server.isOpen(), server.isCancelled(), in->eof());
+                LOG_TEST(log, "Closing connection (open: {}, cancelled: {}, in_canceled: {}, eof: {})",
+                    tcp_server.isOpen(), server.isCancelled(), in->isCanceled(),
+                    !in->isCanceled() && in->eof());
                 return;
             }
         }


### PR DESCRIPTION
When waiting for a new query between requests, `TCPHandler::runImpl` calls `in->eof()` to detect client disconnection. If the `ReadBuffer` was previously canceled (due to a failed read during a prior query's callback), calling `eof()` triggers `next()`, which hits `chassert(!isCanceled())` and aborts the server.

Add an `in->isCanceled()` check before `in->eof()` in the condition, matching the pattern already used in `receivePacketsExpectCancel`. Also guard the `in->eof()` call in the `LOG_TEST` message to avoid evaluating it on a canceled buffer (function arguments are not short-circuit evaluated unlike `||`).

This is a follow-up to #98955 and #99272 which fixed similar race conditions in callback paths.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99537&sha=7338429ff8d3349ba147f9ba05558bbd6b84e4b2&name_0=PR&name_1=Stress%20test%20%28amd_tsan%29
https://github.com/ClickHouse/ClickHouse/pull/99537

Closes #100581

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.334`
<!-- ch-version-info:end -->