### PR TITLE
CI: enable failpoint injection in stress tests

### DIFF
--- a/tests/config/config.d/fail_points_active.xml
+++ b/tests/config/config.d/fail_points_active.xml
@@ -1,0 +1,14 @@
+<clickhouse>
+    <!-- REGULAR failpoints enabled during stress tests.
+         Only REGULAR type is safe here: they fire-and-return on every trigger
+         with no synchronization. ONCE failpoints would fire once then vanish;
+         PAUSEABLE failpoints would deadlock the server because nothing calls
+         SYSTEM NOTIFY FAILPOINT to resume them. -->
+    <fail_points_active>
+        <replicated_merge_tree_commit_zk_fail_when_recovering_from_hw_fault/>
+        <use_delayed_remote_source/>
+        <cluster_discovery_faults/>
+        <check_table_query_delay_for_part/>
+        <remove_merge_tree_part_delay/>
+    </fail_points_active>
+</clickhouse>

--- a/tests/config/config.d/fail_points_active.xml
+++ b/tests/config/config.d/fail_points_active.xml
@@ -9,6 +9,5 @@
         <use_delayed_remote_source/>
         <cluster_discovery_faults/>
         <check_table_query_delay_for_part/>
-        <remove_merge_tree_part_delay/>
     </fail_points_active>
 </clickhouse>

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -251,6 +251,12 @@ else
     rm -f $DEST_SERVER_PATH/config.d/cannot_allocate_thread_injection.xml ||:
 fi
 
+if [[ -n "$CLICKHOUSE_FAILPOINTS_INJECTION" ]] && [[ "$CLICKHOUSE_FAILPOINTS_INJECTION" -eq 1 ]]; then
+    ln -sf $SRC_PATH/config.d/fail_points_active.xml $DEST_SERVER_PATH/config.d/
+else
+    rm -f $DEST_SERVER_PATH/config.d/fail_points_active.xml ||:
+fi
+
 # We randomize creating the snapshot on exit for Keeper to test out using older snapshots
 value=$((RANDOM % 2))
 echo "Replacing create_snapshot_on_exit with $value"

--- a/tests/docker_scripts/stress_runner.sh
+++ b/tests/docker_scripts/stress_runner.sh
@@ -241,6 +241,7 @@ stop_server
 export RANDOMIZE_OBJECT_KEY_TYPE=1
 export ZOOKEEPER_FAULT_INJECTION=1
 export THREAD_POOL_FAULT_INJECTION=1
+export CLICKHOUSE_FAILPOINTS_INJECTION=1
 configure
 
 if [[ "$USE_S3_STORAGE_FOR_MERGE_TREE" == "1" || "$USE_AZURE_STORAGE_FOR_MERGE_TREE" == "1" ]]; then
@@ -316,6 +317,7 @@ unset "${!THREAD_@}"
 # will not allow to load tables asynchronously. Anyway the stress tests was
 # running with fault injection.
 rm /etc/clickhouse-server/config.d/cannot_allocate_thread_injection.xml
+rm -f /etc/clickhouse-server/config.d/fail_points_active.xml
 
 start_server
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
## Summary

- Add `tests/config/config.d/fail_points_active.xml` with 5 `REGULAR` failpoints to activate during the stress test phase
- `install.sh`: conditionally links the config when `CLICKHOUSE_FAILPOINTS_INJECTION=1`
- `stress_runner.sh`: exports `CLICKHOUSE_FAILPOINTS_INJECTION=1` before the stress phase; removes the config before the clean-restart check

Only `REGULAR` failpoints are included — they fire-and-return on every trigger with no synchronization, making them safe for long-running stress runs. `ONCE` failpoints would fire once then auto-disable; `PAUSEABLE` failpoints would deadlock the server since nothing calls `SYSTEM NOTIFY FAILPOINT` to resume them.

**Failpoints enabled:**
| Failpoint | Purpose |
|-----------|---------|
| `replicated_merge_tree_commit_zk_fail_when_recovering_from_hw_fault` | Exercises ZK commit failure recovery path |
| `use_delayed_remote_source` | Adds latency to remote source reads |
| `cluster_discovery_faults` | Injects faults in cluster discovery |
| `check_table_query_delay_for_part` | Delays part-level table checks |
| `remove_merge_tree_part_delay` | Delays MergeTree part removal |

## Test plan

- [ ] Stress test run passes with `CLICKHOUSE_FAILPOINTS_INJECTION=1`
- [ ] Server starts cleanly after stress phase (config removed before clean-restart check)
- [ ] No regressions in existing stress test checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.381`
<!-- ch-version-info:end -->