### PR TITLE
CI: suppress ASan false positives from libunwind in fiber stacks

### DIFF
--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -43,7 +43,9 @@ const char * __asan_default_suppressions()
            /// → PlatformUnpoisonStacks() → sigaltstack. The sigaltstack interceptor writes
            /// a stack_t result onto the fiber's heap-allocated stack, which has bytes
            /// already poisoned as stack redzones from previous fiber frames — a false positive.
-           "interceptor_via_fun:__asan_handle_no_return\n";
+           /// Suppress via the internal ASan helper rather than __asan_handle_no_return to
+           /// avoid masking real bugs in ordinary (non-fiber) exception paths.
+           "interceptor_via_fun:PlatformUnpoisonStacks\n";
 }
 const char * __lsan_default_options()
 {

--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -34,6 +34,12 @@ const char * __asan_default_options()
 {
     return "halt_on_error=1 abort_on_error=1";
 }
+const char * __asan_default_suppressions()
+{
+    /// libunwind is compiled without sanitizers (-fno-sanitize=all) and triggers false
+    /// positives during C++ exception unwinding in fibers. See #100442.
+    return "interceptor_via_lib:libunwind\n";
+}
 const char * __lsan_default_options()
 {
     return "max_allocation_size_mb=32768";

--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -38,7 +38,12 @@ const char * __asan_default_suppressions()
 {
     /// libunwind is compiled without sanitizers (-fno-sanitize=all) and triggers false
     /// positives during C++ exception unwinding in fibers. See #100442.
-    return "interceptor_via_lib:libunwind\n";
+    return "interceptor_via_lib:libunwind\n"
+           /// When an exception is thrown inside a fiber, ASan calls __asan_handle_no_return
+           /// → PlatformUnpoisonStacks() → sigaltstack. The sigaltstack interceptor writes
+           /// a stack_t result onto the fiber's heap-allocated stack, which has bytes
+           /// already poisoned as stack redzones from previous fiber frames — a false positive.
+           "interceptor_via_fun:__asan_handle_no_return\n";
 }
 const char * __lsan_default_options()
 {


### PR DESCRIPTION
`libunwind` is compiled with `-fno-sanitize=all`, so it does not unpoison its own stack frames. During C++ exception unwinding inside fibers, `_Unwind_Resume` reuses fiber stack slots previously poisoned by scope-exit instrumentation in user code, causing the ASan `memcpy` interceptor to report spurious `stack-use-after-scope` errors.

Add `__asan_default_suppressions` returning `interceptor_via_lib:libunwind` to suppress all ASan interceptor errors originating from `libunwind`.


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)