### PR TITLE
Respect detached data parts with invalid names for NumberOfDetachedParts

### DIFF
--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -416,13 +416,9 @@ void ServerAsynchronousMetrics::updateMutationAndDetachedPartsStats()
             {
                 for (const auto & detached_part: table_merge_tree->getDetachedParts())
                 {
-                    if (!detached_part.valid_name)
-                        continue;
-
-                    if (detached_part.prefix.empty())
-                        ++current_values.detached_by_user;
-
                     ++current_values.count;
+                    if (detached_part.valid_name && detached_part.prefix.empty())
+                        ++current_values.detached_by_user;
                 }
 
                 // mutation status


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Sometimes after a downgrade, detached parts appear with null reason, and they are not counted in NumberOfDetachedParts. Since users should not use CH-internal directories, I think we can assume that the parts are valid and not garbage.
Or we can make another metric.

Example (ver 24.8 is deprecated but still is possible I the future)
```

SELECT value
FROM system.asynchronous_metrics
WHERE metric = 'NumberOfDetachedParts'

Query id: dd445d18-43fc-4bd7-87c5-75011c737c0e

   ┌─value─┐
1. │ 12270 │
   └───────┘
SELECT
    reason,
    count()
FROM system.detached_parts
GROUP BY reason

Query id: bc241231-24ed-48df-98d8-09d339315096

   ┌─reason──────────┬─count()─┐
1. │ ᴺᵁᴸᴸ            │   31566 │
2. │                 │      30 │
3. │ ignored         │    9603 │
4. │ deleting        │       9 │
5. │ broken-on-start │    2625 │
6. │ unexpected      │       3 │
   └─────────────────┴─────────┘


SELECT *
FROM system.detached_parts
WHERE reason NOT IN ['ignored', 'deleting', 'broken-on-start', 'unexpected']
LIMIT 1

Query id: c61eaca0-99cc-43bb-abc6-e4c3816e7d1e

   ┌─database─┬─table─────────────┬─partition_id─┬─name─────────────────┬─bytes_on_disk─┬───modification_time─┬─disk───────────┬─path──────────────────────────────────────────────────────────────────────────────────────────────────────────────────┬─reason─┬─min_block_number─┬─max_block_number─┬─level─┐
1. │ ls       │ backend_log_shard │ 2025060219   │ 2025060219_846_853_1 │         68758 │ 2025-06-16 12:59:30 │ object_storage │ /var/lib/clickhouse/disks/object_storage/store/7d4/7d4a190a-18d2-4d63-8b4d-2f36d638428a/detached/2025060219_846_853_1 │        │              846 │              853 │     1 │
   └──────────┴───────────────────┴──────────────┴──────────────────────┴───────────────┴─────────────────────┴────────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴────────┴──────────────────┴──────────────────┴───────┘
```

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
