### PR TITLE
Fix exception when finding common supertype for tuples of different arities

### DIFF
--- a/src/DataTypes/getLeastSupertype.cpp
+++ b/src/DataTypes/getLeastSupertype.cpp
@@ -281,6 +281,7 @@ DataTypePtr getLeastSuperTypeForTuple(const DataTypes & types)
     Strings element_names;
     size_t element_size = 0;
     std::vector<DataTypes> element_types;
+    bool initialized = false;
 
     bool have_nullable = false;
 
@@ -298,7 +299,7 @@ DataTypePtr getLeastSuperTypeForTuple(const DataTypes & types)
         if (const auto * type_tuple = typeid_cast<const DataTypeTuple *>(unwrapped_type))
         {
             const auto & current_elements = type_tuple->getElements();
-            if (element_types.empty())
+            if (!initialized)
             {
                 element_size = current_elements.size();
                 element_types.resize(element_size);
@@ -306,6 +307,7 @@ DataTypePtr getLeastSuperTypeForTuple(const DataTypes & types)
                     element_types[i].reserve(types.size());
                 if (type_tuple->hasExplicitNames())
                     element_names = type_tuple->getElementNames();
+                initialized = true;
             }
 
             if (element_size != type_tuple->getElements().size())

--- a/src/Functions/if.cpp
+++ b/src/Functions/if.cpp
@@ -678,7 +678,14 @@ private:
         ColumnsWithTypeAndName temporary_columns(3);
         temporary_columns[0] = arguments[0];
 
-        size_t tuple_size = type1.getElements().size();
+        const size_t tuple_size = tuple_result.getElements().size();
+
+        if (type1.getElements().size() != tuple_size
+            || type2.getElements().size() != tuple_size
+            || col1_contents.size() != tuple_size
+            || col2_contents.size() != tuple_size)
+            return nullptr;
+
         if (tuple_size == 0)
             return ColumnTuple::create(input_rows_count);
 

--- a/tests/queries/0_stateless/04057_tuple_empty_supertype.reference
+++ b/tests/queries/0_stateless/04057_tuple_empty_supertype.reference
@@ -1,0 +1,5 @@
+0
+Variant(Tuple(), Tuple(Nullable(Nothing), UInt32, UInt8, UInt8))
+()
+Tuple(UInt8, UInt8)
+Array(Variant(Tuple(), Tuple(UInt8, UInt8)))

--- a/tests/queries/0_stateless/04057_tuple_empty_supertype.sql
+++ b/tests/queries/0_stateless/04057_tuple_empty_supertype.sql
@@ -1,0 +1,28 @@
+SET enable_analyzer = 1;
+SET use_variant_as_common_type = 1;
+
+-- Reproducer: empty tuple vs non-empty tuple in INTERSECT ALL
+SELECT count() FROM
+(
+    SELECT if(1, tuple(), (NULL, 2147483647, 1, 10)) AS k
+    INTERSECT ALL
+    SELECT if(0, (-2147483648, -1), toNullable((NULL, NULL, 2147483646, 0))) AS k
+);
+
+-- Direct if() with empty tuple vs non-empty tuple (Variant result)
+SELECT toTypeName(if(1, tuple(), (NULL, CAST(2147483647, 'UInt32'), CAST(1, 'UInt8'), CAST(10, 'UInt8'))));
+
+-- Empty tuple vs empty tuple (should still work)
+SELECT if(1, tuple(), tuple());
+
+-- Same-arity tuples (regression guard)
+SELECT toTypeName(if(1, CAST((1, 2), 'Tuple(UInt8, UInt8)'), CAST((3, 4), 'Tuple(UInt8, UInt8)')));
+
+-- Array containing empty and non-empty tuples (Variant)
+SELECT toTypeName([tuple(), CAST((1, 2), 'Tuple(UInt8, UInt8)')]);
+
+-- Without Variant: should error on incompatible tuple arities
+SELECT [tuple(), (1, 2)] SETTINGS use_variant_as_common_type = 0; -- { serverError NO_COMMON_TYPE }
+
+-- Legacy path: should error on incompatible tuple arities (no Variant in legacy INTERSECT)
+SELECT 1 FROM (SELECT tuple() AS k INTERSECT ALL SELECT (1, 2) AS k) SETTINGS enable_analyzer = 0, use_variant_as_common_type = 0; -- { serverError NO_COMMON_TYPE }


### PR DESCRIPTION
When `use_variant_as_common_type` is enabled, `getLeastSuperTypeForTuple` treats an empty tuple the same as "not yet initialized" because it checks `element_types.empty()` to detect the first tuple. An empty tuple legitimately has zero elements, so initialization is skipped and the next (non-empty) tuple silently overwrites the state.

This introduces an explicit `initialized` flag so that an empty tuple is correctly recorded.

In `FunctionIf::executeTuple`, the result type may now be `Variant` (wrapping tuples of different arities). The per-element loop must not run in that case because the branches have different numbers of elements. A guard is added that returns `nullptr` (falling back to the generic `Variant` path) when element counts disagree.

Closes https://github.com/ClickHouse/ClickHouse/issues/100691

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix exception when computing common supertype for empty and non-empty tuples with `use_variant_as_common_type` enabled.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.280`
<!-- ch-version-info:end -->