### PR TITLE
Fix passing multiple --test selectors in praktika run

### DIFF
--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -303,7 +303,8 @@ def main():
 
         fast_test_command = f"cd {temp_dir} && clickhouse-test --hung-check --trace --capture-client-stacktrace --no-random-settings --no-random-merge-tree-settings --no-long --testname --shard --check-zookeeper-session --order random --report-logs-stats --fast-tests-only --no-stateful --jobs {nproc_fast}"
         if args.test:
-            fast_test_command += f" -- '{args.test}'"
+            test_pattern = "|".join(args.test.split())
+            fast_test_command += f" -- '{test_pattern}'"
 
         res = CH.run_test(fast_test_command)
 

--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -120,7 +120,12 @@ class JobStages(metaclass=MetaClasses.WithIter):
 
 def parse_args():
     parser = argparse.ArgumentParser(description="ClickHouse Fast Test Job")
-    parser.add_argument("--test", help="Optional test_case name to run", default="")
+    parser.add_argument(
+        "--test",
+        help="Optional. Space-separated test name patterns",
+        default=[],
+        nargs="+",
+        action="extend")
     parser.add_argument("--param", help="Optional custom job start stage", default=None)
     parser.add_argument("--set-status-success", help="Forcefully set a green status", action="store_true")
     return parser.parse_args()
@@ -303,7 +308,7 @@ def main():
 
         fast_test_command = f"cd {temp_dir} && clickhouse-test --hung-check --trace --capture-client-stacktrace --no-random-settings --no-random-merge-tree-settings --no-long --testname --shard --check-zookeeper-session --order random --report-logs-stats --fast-tests-only --no-stateful --jobs {nproc_fast}"
         if args.test:
-            test_pattern = "|".join(args.test.split())
+            test_pattern = "|".join(args.test)
             fast_test_command += f" -- '{test_pattern}'"
 
         res = CH.run_test(fast_test_command)

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -421,7 +421,7 @@ class Runner:
             cmd += f" --param {param}"
         if test:
             print(f"Custom --test [{test}] will be passed to job's script")
-            cmd += f" --test {test}"
+            cmd += f" --test '{test}'"
         if count is not None:
             print(f"Custom --count [{count}] will be passed to job's script")
             cmd += f" --count {count}"

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -421,7 +421,7 @@ class Runner:
             cmd += f" --param {param}"
         if test:
             print(f"Custom --test [{test}] will be passed to job's script")
-            cmd += f" --test '{test}'"
+            cmd += f" --test {test}"
         if count is not None:
             print(f"Custom --count [{count}] will be passed to job's script")
             cmd += f" --count {count}"


### PR DESCRIPTION
When passing multiple test names to `praktika run --test A B`, the runner
appended them unquoted to the shell command, causing job scripts (e.g.
`fast_test.py`) to reject the extra positional arguments as unrecognized.

Quote the `--test` value in `runner.py` so it arrives as a single argument,
and in `fast_test.py` join space-separated test names with `|` to form a
regex pattern for `clickhouse-test`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.263`
<!-- ch-version-info:end -->