### PR TITLE
Fix flaky test_multiple_schemes_tables by reducing Spark JVM startups

### DIFF
--- a/tests/integration/test_database_delta/test.py
+++ b/tests/integration/test_database_delta/test.py
@@ -7,7 +7,6 @@ import os
 import re
 import random
 import time
-import subprocess
 import uuid
 from datetime import datetime, timedelta
 from helpers.cluster import ClickHouseCluster
@@ -23,6 +22,8 @@ import uuid
 
 from helpers.test_tools import TSV
 
+UC_LOG = "/var/lib/clickhouse/user_files/unitycatalog/uc.log"
+
 
 def start_unity_catalog(node):
     node.exec_in_container(
@@ -32,6 +33,26 @@ def start_unity_catalog(node):
             f"""cp -r /unitycatalog /var/lib/clickhouse/user_files/ && cd /var/lib/clickhouse/user_files/unitycatalog && nohup bin/start-uc-server > uc.log 2>&1 &""",
         ]
     )
+    # Wait for Unity Catalog to accept connections on port 8080 before returning.
+    # The 120s timeout matches the UC startup wait in tests/casa_del_dolor/catalogs/datalakes.py.
+    try:
+        node.exec_in_container(
+            [
+                "bash",
+                "-c",
+                """for i in $(seq 1 120); do (echo > /dev/tcp/localhost/8080) 2>/dev/null && exit 0; sleep 1; done; echo 'Unity Catalog did not start within 120s' >&2; exit 1""",
+            ]
+        )
+    except Exception as e:
+        print("UC health check failed:", str(e))
+        try:
+            logs = node.exec_in_container(
+                ["tail", "-n", "50", UC_LOG]
+            )
+            print("Last 50 lines of UC log:\n", logs)
+        except Exception as log_e:
+            print(f"Cannot read UC log: {str(log_e)}")
+        raise
 
 
 @pytest.fixture(scope="module")
@@ -102,26 +123,30 @@ def execute_spark_query(node, query_text):
             ],
             timeout=600,
         )
-    except subprocess.CalledProcessError as e:
-        print("Command failed with exit code:", e.returncode)
-        print("Command:", e.cmd)
+    except Exception as e:
+        returncode = getattr(e, "returncode", None)
+        cmd = getattr(e, "cmd", None)
+        if returncode is not None:
+            print("Command failed with exit code:", returncode)
+        if cmd is not None:
+            print("Command:", cmd)
 
-        stdout = e.stdout.decode() if e.stdout else "<no stdout>"
-        stderr = e.stderr.decode() if e.stderr else "<no stderr>"
-        print("STDOUT:\n", stdout)
-        print("STDERR:\n", stderr)
+        stdout_bytes = getattr(e, "stdout", None)
+        stderr_bytes = getattr(e, "stderr", None)
+        if stdout_bytes is not None or stderr_bytes is not None:
+            stdout = stdout_bytes.decode() if stdout_bytes else "<no stdout>"
+            stderr = stderr_bytes.decode() if stderr_bytes else "<no stderr>"
+            print("STDOUT:\n", stdout)
+            print("STDERR:\n", stderr)
+        else:
+            print("Command failed with exception:", str(e))
 
         try:
             logs = node.exec_in_container(
-                [
-                    "tail",
-                    "-n",
-                    "50",
-                    "/var/lib/clickhouse/user_files/unitycatalog/uc.log",
-                ]
+                ["tail", "-n", "50", UC_LOG]
             )
             print("Last 50 lines of UC log:\n", logs)
-        except subprocess.CalledProcessError as log_e:
+        except Exception as log_e:
             print(f"Cannot read log file: {str(log_e)}")
 
         raise
@@ -191,23 +216,16 @@ def test_embedded_database_and_tables(started_cluster, use_delta_kernel):
 def test_multiple_schemes_tables(started_cluster):
     test_uuid = str(uuid.uuid4()).replace("-", "_")
     node1 = started_cluster.instances["node1"]
-    execute_multiple_spark_queries(
-        node1, [f"CREATE SCHEMA test_schema{test_uuid}{i}" for i in range(10)]
-    )
-    execute_multiple_spark_queries(
-        node1,
-        [
-            f"CREATE TABLE test_schema{test_uuid}{i}.test_table{test_uuid}{i} (col1 int, col2 double) using Delta location '/var/lib/clickhouse/user_files/tmp/test_schema{test_uuid}{i}/test_table{test_uuid}{i}'"
-            for i in range(10)
-        ],
-    )
-    execute_multiple_spark_queries(
-        node1,
-        [
-            f"INSERT INTO test_schema{test_uuid}{i}.test_table{test_uuid}{i} VALUES ({i}, {i}.0)"
-            for i in range(10)
-        ],
-    )
+    # Combine schema creation, table creation and inserts into a single
+    # Spark invocation to avoid multiple slow JVM startups.
+    queries = []
+    for i in range(10):
+        queries.extend([
+            f"CREATE SCHEMA test_schema{test_uuid}{i}",
+            f"CREATE TABLE test_schema{test_uuid}{i}.test_table{test_uuid}{i} (col1 int, col2 double) using Delta location '/var/lib/clickhouse/user_files/tmp/test_schema{test_uuid}{i}/test_table{test_uuid}{i}'",
+            f"INSERT INTO test_schema{test_uuid}{i}.test_table{test_uuid}{i} VALUES ({i}, {i}.0)",
+        ])
+    execute_multiple_spark_queries(node1, queries)
 
     node1.query(
         f"create database multi_schema_test{test_uuid} engine DataLakeCatalog('http://localhost:8080/api/2.1/unity-catalog') settings warehouse = 'unity', catalog_type='unity', vended_credentials=false",


### PR DESCRIPTION
Fix flaky `test_multiple_schemes_tables` by combining three separate `execute_multiple_spark_queries` calls (CREATE SCHEMA, CREATE TABLE, INSERT) into a single call with all 30 statements. This avoids launching three separate Spark JVM processes, which was the root cause of the 600s timeout flakiness.

This is the same fix pattern already applied to sibling tests (`test_complex_table_schema`, `test_timestamp_ntz`, `test_snapshot_version`) in #96962, but `test_multiple_schemes_tables` was missed.

Additionally:
- Added a startup health-check to `start_unity_catalog` that waits for port 8080 before returning, with diagnostic UC log output on failure.
- Improved error handling in `execute_spark_query` to catch generic exceptions (not just `subprocess.CalledProcessError`), since `exec_in_container` raises its own exception type.

CI report example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=cb384bf1df419569d1adb624e6da348725b81b44&name_0=MasterCI&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%206%2F6%29

Closes #100708

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.314`
<!-- ch-version-info:end -->