### PR TITLE
Remove flaky text_log assertions from test 03312_line_numbers

### DIFF
--- a/tests/queries/0_stateless/03312_line_numbers.reference
+++ b/tests/queries/0_stateless/03312_line_numbers.reference
@@ -4,5 +4,3 @@ QueryStart	1	4	SELECT \'This is the first query, and it is located on line 4\',\
 QueryFinish	1	4	SELECT \'This is the first query, and it is located on line 4\',\n1, -- Just random stuff to ensure proper counting of lines.\n2, 3;
 QueryStart	2	8	SELECT \'This is the second query, and it is located on line 8\';
 QueryFinish	2	8	SELECT \'This is the second query, and it is located on line 8\';
-Ok
-Ok

--- a/tests/queries/0_stateless/03312_line_numbers.sql
+++ b/tests/queries/0_stateless/03312_line_numbers.sql
@@ -7,8 +7,5 @@ SELECT 'This is the first query, and it is located on line 4',
 
 SELECT 'This is the second query, and it is located on line 8';
 
-SYSTEM FLUSH LOGS query_log, text_log;
+SYSTEM FLUSH LOGS query_log;
 SELECT type, script_query_number, script_line_number, query FROM system.query_log WHERE current_database = currentDatabase() AND event_date >= yesterday() AND event_time >= now() - 600 ORDER BY event_time_microseconds, type;
-
-SELECT 'Ok' FROM system.text_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND message LIKE '%(query 1, line 4)%' AND message LIKE '%This is the first query%' LIMIT 1;
-SELECT 'Ok' FROM system.text_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND message LIKE '%(query 2, line 8)%' AND message LIKE '%This is the second query%' LIMIT 1;


### PR DESCRIPTION
Remove two flaky `system.text_log` assertions from test `03312_line_numbers`. The `text_log` checks were non-deterministic because text log ingestion is asynchronous and `SYSTEM FLUSH LOGS` does not guarantee all entries are materialized. The remaining `query_log` assertions are deterministic and fully cover `script_query_number` / `script_line_number` tracking.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100699&sha=d3364a856816a3c582441841e5a85806271c9a6f&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%201%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/100699

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is not required for this change.