### PR TITLE
Support `Unit tests` job type in `check_ci.py` issue creation

### DIFF
--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -51,6 +51,7 @@ class JobTypes:
     BUGFIX_VALIDATION_FUNCTIONAL = "Bugfix validation functional"
     BUGFIX_VALIDATION_INTEGRATION = "Bugfix validation integration"
     CLICKBENCH = "ClickBench"
+    UNIT_TESTS = "Unit tests"
 
 
 class CreateIssue:
@@ -149,6 +150,28 @@ Test output:
         return cls.create_and_link_gh_issue(title, body, labels)
 
     @classmethod
+    def extract_unit_test_title(cls, result):
+        """
+        Extract a meaningful issue title from unit test output.
+        Looks for sanitizer summaries or gtest failure markers.
+        Falls back to the result name if nothing is found.
+        """
+        info = result.info or ""
+        # Look for sanitizer SUMMARY line, e.g.:
+        #   SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /path/File.h:229:25
+        m = re.search(
+            r"SUMMARY:\s+(\w+):\s+\S+\s+\S*/([^/\s]+:\d+)", info
+        )
+        if m:
+            return f"{m.group(1)} in {m.group(2)}"
+        # Look for gtest FAILED marker, e.g.:
+        #   [  FAILED  ] TestSuite.TestName (123 ms)
+        m = re.search(r"\[\s+FAILED\s+\]\s+(\S+)", info)
+        if m:
+            return m.group(1)
+        return result.name
+
+    @classmethod
     def create_gh_issue_on_fuzzer_or_stress_finding(cls, result, job_name):
         title = result.name
         body = f"""\
@@ -195,7 +218,7 @@ Test output:
             print("Cannot handle OOM errors - skip")
             return False
         if (
-            any(key in job_result.name for key in ("Buzz", "AST"))
+            any(key in job_result.name for key in ("Buzz", "AST", "Unit tests"))
             and job_result.results
         ):
             return True
@@ -236,7 +259,9 @@ Test output:
                 issue_url = cls.create_gh_issue_on_fuzzer_or_stress_finding(
                     result, job_name
                 )
-        elif any(key in job_name for key in ("Buzz", "AST", "Stress")):
+        elif any(key in job_name for key in ("Buzz", "AST", "Stress", "Unit tests")):
+            if "Unit tests" in job_name and result.name == job_name:
+                result.name = cls.extract_unit_test_title(result)
             issue_url = cls.create_gh_issue_on_fuzzer_or_stress_finding(
                 result, job_name
             )


### PR DESCRIPTION
`check_ci.py` crashed with `Unsupported job type: Unit tests (asan_ubsan)` when trying to create a GitHub issue for a unit test failure. This adds `Unit tests` as a recognized job type in `can_process` and `create_issue`, routing failures to `create_gh_issue_on_fuzzer_or_stress_finding`.

When unit tests fail at the job level (no individual gtest results), the issue title is extracted from the log output — matching sanitizer SUMMARY lines or gtest `[ FAILED ]` markers — instead of using the generic job name.

Example: `"UndefinedBehaviorSanitizer in DivisionUtils.h:229"` instead of `"Unit tests (asan_ubsan)"`.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100625&sha=7e052e83f96c5aa3ba38e19abec6dfcda753a4c5&name_0=PR&name_1=Unit%20tests%20%28asan_ubsan%29
https://github.com/ClickHouse/ClickHouse/pull/100625

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.308`
<!-- ch-version-info:end -->