### PR TITLE
ci: use test-base image for unit tests to fix sanitizers symbolization

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -109,7 +109,7 @@ common_unit_test_job_config = Job.Config(
     name=JobNames.UNITTEST,
     runs_on=[],  # from parametrize()
     command=f"python3 ./ci/jobs/unit_tests_job.py",
-    run_in_docker="clickhouse/fasttest+--privileged",
+    run_in_docker="clickhouse/test-base+--privileged",
     digest_config=Job.CacheDigestConfig(
         include_paths=["./ci/jobs/unit_tests_job.py"],
     ),


### PR DESCRIPTION
fasttest does not have llvm package, while test-base does

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100702&sha=latest&name_0=PR&name_1=Unit+tests+%28asan_ubsan%29
https://github.com/ClickHouse/ClickHouse/pull/100702

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.274`
<!-- ch-version-info:end -->