### PR TITLE
CI: Fix related PR info lookup in Slack feed

### DIFF
--- a/ci/praktika/infrastructure/native/lambda_slack_worker.py
+++ b/ci/praktika/infrastructure/native/lambda_slack_worker.py
@@ -215,7 +215,7 @@ def _post_dm(user_id: str, user_email: str, s3_path: str, text: str) -> None:
         print(f"chat.postMessage error: {e}")
 
 
-def format_event_text(event, pr_status, indent="", include_related_prs: bool = True):
+def format_event_text(event, pr_status, indent="", include_related_prs: bool = True, pr_to_event=None):
     """Format event text with optional indentation for linked events."""
     # PR status emoji
     pr_status_emoji = ":pr_open:" if pr_status == "open" else ":pr_merged:"
@@ -334,14 +334,25 @@ def format_event_text(event, pr_status, indent="", include_related_prs: bool = T
         # Add related PRs if available (only for parent events)
         if include_related_prs and not indent:
             related_prs = event.ext.get("related_prs", [])
+            # For merge commits (pr_number == 0), derive related_prs from linked_pr_number
+            if not related_prs and event.ext.get("pr_number", 0) == 0:
+                linked_pr_number = event.ext.get("linked_pr_number", 0)
+                if linked_pr_number:
+                    related_prs = [linked_pr_number]
             if related_prs:
                 event_text += "\n\n*Related PRs:*"
                 for pr_num in related_prs:
+                    # Look up related PR info: prefer live data from the feed, fall back to pre-stored ext
                     pr_info = {}
-                    if hasattr(event, "result") and event.result:
-                        result_ext = event.result.get("ext", {})
-                        related_pr_info = result_ext.get("related_pr_info", {})
-                        pr_info = related_pr_info.get(pr_num, {})
+                    if pr_to_event and pr_num in pr_to_event:
+                        related_event = pr_to_event[pr_num]
+                        pr_info = {
+                            "pr_title": related_event.ext.get("pr_title", ""),
+                            "change_url": related_event.ext.get("change_url", ""),
+                            "report_url": related_event.ext.get("report_url", ""),
+                        }
+                    else:
+                        pr_info = event.ext.get("related_pr_info", {}).get(pr_num, {})
 
                     pr_title = pr_info.get("pr_title", "")
                     pr_change_url = pr_info.get("change_url", "")
@@ -625,7 +636,7 @@ def publish_home_view(
                     break
 
             # Format parent event
-            event_text = format_event_text(root_event, pr_status, indent="")
+            event_text = format_event_text(root_event, pr_status, indent="", pr_to_event=pr_to_event)
 
             # Add parent event section
             blocks.append(

--- a/ci/praktika/infrastructure/native/lambda_slack_worker.py
+++ b/ci/praktika/infrastructure/native/lambda_slack_worker.py
@@ -215,7 +215,7 @@ def _post_dm(user_id: str, user_email: str, s3_path: str, text: str) -> None:
         print(f"chat.postMessage error: {e}")
 
 
-def format_event_text(event, pr_status, indent="", include_related_prs: bool = True, pr_to_event=None):
+def format_event_text(event, pr_status, indent="", include_related_prs: bool = True):
     """Format event text with optional indentation for linked events."""
     # PR status emoji
     pr_status_emoji = ":pr_open:" if pr_status == "open" else ":pr_merged:"
@@ -322,40 +322,14 @@ def format_event_text(event, pr_status, indent="", include_related_prs: bool = T
         if skipped_cnt:
             parts.append(f"{skipped_cnt} skipped")
 
-        # Build related PR links to append inline (only for parent events, merge commits)
-        related_pr_links = ""
-        if include_related_prs and not indent:
-            related_prs = event.ext.get("related_prs", [])
-            # For merge commits (pr_number == 0), derive related_prs from linked_pr_number
-            if not related_prs and event.ext.get("pr_number", 0) == 0:
-                linked_pr_number = event.ext.get("linked_pr_number", 0)
-                if linked_pr_number:
-                    related_prs = [linked_pr_number]
-            for pr_num in related_prs:
-                pr_info = {}
-                if pr_to_event and pr_num in pr_to_event:
-                    related_event = pr_to_event[pr_num]
-                    pr_info = {
-                        "change_url": related_event.ext.get("change_url", ""),
-                    }
-                else:
-                    pr_info = event.ext.get("related_pr_info", {}).get(pr_num, {})
-                pr_change_url = pr_info.get("change_url", "")
-                if pr_change_url:
-                    related_pr_links += f" · <{pr_change_url}|#{pr_num}>"
-                else:
-                    related_pr_links += f" · #{pr_num}"
-
         if parts:
             summary = " · ".join(parts)
             if report_url_text:
-                event_text += f"\n{indent}{summary} · {report_url_text}{related_pr_links}"
+                event_text += f"\n{indent}{summary} · {report_url_text}"
             else:
-                event_text += f"\n{indent}{summary}{related_pr_links}"
+                event_text += f"\n{indent}{summary}"
         elif report_url_text:
-            event_text += f"\n{indent}{report_url_text}{related_pr_links}"
-        elif related_pr_links:
-            event_text += f"\n{indent}{related_pr_links.lstrip(' · ')}"
+            event_text += f"\n{indent}{report_url_text}"
 
     return event_text
 
@@ -622,7 +596,7 @@ def publish_home_view(
                     break
 
             # Format parent event
-            event_text = format_event_text(root_event, pr_status, indent="", pr_to_event=pr_to_event)
+            event_text = format_event_text(root_event, pr_status, indent="")
 
             # Add parent event section
             blocks.append(

--- a/ci/praktika/infrastructure/native/lambda_slack_worker.py
+++ b/ci/praktika/infrastructure/native/lambda_slack_worker.py
@@ -322,16 +322,8 @@ def format_event_text(event, pr_status, indent="", include_related_prs: bool = T
         if skipped_cnt:
             parts.append(f"{skipped_cnt} skipped")
 
-        if parts:
-            summary = " · ".join(parts)
-            if report_url_text:
-                event_text += f"\n{indent}{summary} · {report_url_text}"
-            else:
-                event_text += f"\n{indent}{summary}"
-        elif report_url_text:
-            event_text += f"\n{indent}{report_url_text}"
-
-        # Add related PRs if available (only for parent events)
+        # Build related PR links to append inline (only for parent events, merge commits)
+        related_pr_links = ""
         if include_related_prs and not indent:
             related_prs = event.ext.get("related_prs", [])
             # For merge commits (pr_number == 0), derive related_prs from linked_pr_number
@@ -339,37 +331,31 @@ def format_event_text(event, pr_status, indent="", include_related_prs: bool = T
                 linked_pr_number = event.ext.get("linked_pr_number", 0)
                 if linked_pr_number:
                     related_prs = [linked_pr_number]
-            if related_prs:
-                event_text += "\n\n*Related PRs:*"
-                for pr_num in related_prs:
-                    # Look up related PR info: prefer live data from the feed, fall back to pre-stored ext
-                    pr_info = {}
-                    if pr_to_event and pr_num in pr_to_event:
-                        related_event = pr_to_event[pr_num]
-                        pr_info = {
-                            "pr_title": related_event.ext.get("pr_title", ""),
-                            "change_url": related_event.ext.get("change_url", ""),
-                            "report_url": related_event.ext.get("report_url", ""),
-                        }
-                    else:
-                        pr_info = event.ext.get("related_pr_info", {}).get(pr_num, {})
+            for pr_num in related_prs:
+                pr_info = {}
+                if pr_to_event and pr_num in pr_to_event:
+                    related_event = pr_to_event[pr_num]
+                    pr_info = {
+                        "change_url": related_event.ext.get("change_url", ""),
+                    }
+                else:
+                    pr_info = event.ext.get("related_pr_info", {}).get(pr_num, {})
+                pr_change_url = pr_info.get("change_url", "")
+                if pr_change_url:
+                    related_pr_links += f" · <{pr_change_url}|#{pr_num}>"
+                else:
+                    related_pr_links += f" · #{pr_num}"
 
-                    pr_title = pr_info.get("pr_title", "")
-                    pr_change_url = pr_info.get("change_url", "")
-                    pr_report_url = pr_info.get("report_url", "")
-
-                    if pr_change_url:
-                        pr_link_text = f"<{pr_change_url}|#{pr_num}>"
-                    else:
-                        pr_link_text = f"#{pr_num}"
-
-                    pr_line = f"\n  • {pr_link_text}"
-                    if pr_title:
-                        pr_line += f" - {pr_title}"
-                    if pr_report_url:
-                        pr_line += f" (<{pr_report_url}|report>)"
-
-                    event_text += pr_line
+        if parts:
+            summary = " · ".join(parts)
+            if report_url_text:
+                event_text += f"\n{indent}{summary} · {report_url_text}{related_pr_links}"
+            else:
+                event_text += f"\n{indent}{summary}{related_pr_links}"
+        elif report_url_text:
+            event_text += f"\n{indent}{report_url_text}{related_pr_links}"
+        elif related_pr_links:
+            event_text += f"\n{indent}{related_pr_links.lstrip(' · ')}"
 
     return event_text
 

--- a/ci/praktika/infrastructure/native/lambda_slack_worker.py
+++ b/ci/praktika/infrastructure/native/lambda_slack_worker.py
@@ -215,7 +215,7 @@ def _post_dm(user_id: str, user_email: str, s3_path: str, text: str) -> None:
         print(f"chat.postMessage error: {e}")
 
 
-def format_event_text(event, pr_status, indent="", include_related_prs: bool = True):
+def format_event_text(event, pr_status, indent=""):
     """Format event text with optional indentation for linked events."""
     # PR status emoji
     pr_status_emoji = ":pr_open:" if pr_status == "open" else ":pr_merged:"
@@ -340,7 +340,7 @@ def _format_notification_text(event, notify_type: str) -> str:
     ext = getattr(event, "ext", {}) or {}
     pr_status = (ext.get("pr_status") or "").lower()
 
-    base = format_event_text(event, pr_status, indent="", include_related_prs=False)
+    base = format_event_text(event, pr_status, indent="")
 
     failed_names = []
     result = getattr(event, "result", None)


### PR DESCRIPTION
Fixes two bugs introduced by #93939, identified in review by @SmitaRKulkarni and @Ergus.

two bugs prevented related pr info to be printed in slack feed, i made a fix and decided to just remove this functionality as this information looks redundant in slack app home view.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.282`
<!-- ch-version-info:end -->