### PR TITLE
Speed up LLVM coverage HTML report upload to S3

### DIFF
--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -1186,12 +1186,20 @@ class _ResultS3:
                 print(
                     f"INFO: Uploading {len(asset_paths)} assets to {base_s3_prefix} in parallel"
                 )
-                print(asset_paths)
-                with ThreadPoolExecutor(max_workers=10) as executor:
-                    for asset in asset_paths:
-                        rel_path = asset.relative_to(common_root)
-                        s3_path = f"{base_s3_prefix}/{rel_path}"
-                        executor.submit(S3.upload_asset_streaming, asset, s3_path)
+                with ThreadPoolExecutor(max_workers=50) as executor:
+                    futures = {
+                        executor.submit(
+                            S3.upload_asset_streaming,
+                            asset,
+                            f"{base_s3_prefix}/{asset.relative_to(common_root)}",
+                        ): asset
+                        for asset in asset_paths
+                    }
+                for future, asset in futures.items():
+                    try:
+                        future.result()
+                    except Exception as e:
+                        print(f"ERROR: Failed to upload asset [{asset}]: {e}")
         result.assets = []
 
         if result.results:

--- a/ci/praktika/s3.py
+++ b/ci/praktika/s3.py
@@ -451,22 +451,48 @@ class S3:
     @classmethod
     def upload_asset_streaming(cls, local_path: Path, s3_path: str):
         """
-        Uploads assets using streaming gzip to AWS S3. Detects mimetypes automatically.
+        Uploads a single asset to S3 with optional gzip compression.
+
+        Uses boto3 in-memory gzip when available (no subprocess overhead).
+        Falls back to piped `gzip | aws s3 cp` when boto3 is not available.
         """
+        import gzip as _gzip
+
         assert isinstance(local_path, Path)
         content_type, _ = mimetypes.guess_type(local_path)
         content_type = content_type or "application/octet-stream"
 
-        compressible = [".html", ".css", ".js", ".json", ".svg", ".txt"]
+        compressible = {".html", ".css", ".js", ".json", ".svg", ".txt"}
         use_gzip = local_path.suffix.lower() in compressible
 
-        if use_gzip:
-            cmd = f'gzip -8c {local_path} | aws s3 cp - s3://{s3_path} --content-type {content_type} --content-encoding gzip --cache-control "max-age=604800, public"'
-        else:
-            cmd = f'aws s3 cp {local_path} s3://{s3_path} --content-type {content_type} --cache-control "max-age=604800, public"'
+        if BOTO3_AVAILABLE and cls._get_boto3_client():
+            s3_path_clean = str(s3_path).removeprefix("s3://")
+            bucket, key = s3_path_clean.split("/", maxsplit=1)
+            extra_args = {
+                "ContentType": content_type,
+                "CacheControl": "max-age=604800, public",
+            }
+            if use_gzip:
+                data = _gzip.compress(local_path.read_bytes(), compresslevel=8)
+                extra_args["ContentEncoding"] = "gzip"
 
-        print("Execute:", cmd)
-        cls.run_command_with_retries(cmd, retries=3)
+                def _upload():
+                    cls._get_boto3_client().put_object(
+                        Bucket=bucket, Key=key, Body=data, **extra_args
+                    )
+            else:
+                def _upload():
+                    cls._get_boto3_client().upload_file(
+                        str(local_path), bucket, key, ExtraArgs=extra_args
+                    )
+
+            cls._retry_on_no_credentials(_upload)
+        else:
+            if use_gzip:
+                cmd = f'gzip -8c {local_path} | aws s3 cp - s3://{s3_path} --content-type {content_type} --content-encoding gzip --cache-control "max-age=604800, public"'
+            else:
+                cmd = f'aws s3 cp {local_path} s3://{s3_path} --content-type {content_type} --cache-control "max-age=604800, public"'
+            cls.run_command_with_retries(cmd, retries=3)
 
     @classmethod
     def copy_file_from_s3_with_version(cls, s3_path, local_path):

--- a/src/Common/thread_local_rng.cpp
+++ b/src/Common/thread_local_rng.cpp
@@ -1,4 +1,5 @@
 #include <Common/thread_local_rng.h>
 #include <Common/randomSeed.h>
 
+// Trigger coverage collection.
 thread_local pcg64 thread_local_rng{randomSeed()};

--- a/src/Common/thread_local_rng.cpp
+++ b/src/Common/thread_local_rng.cpp
@@ -1,5 +1,4 @@
 #include <Common/thread_local_rng.h>
 #include <Common/randomSeed.h>
 
-// Trigger coverage collection.
 thread_local pcg64 thread_local_rng{randomSeed()};


### PR DESCRIPTION
## Motivation

The LLVM coverage job uploads the genhtml HTML report to S3. A ClickHouse
coverage report contains ~50 000 files. The old code uploaded each file by
spawning a separate subprocess:

```
gzip -8c <file> | aws s3 cp - s3://...
```

With `max_workers=10` this serialized ~5 000 process-forks at a time, each
incurring AWS CLI startup, pipe setup, and an HTTP handshake. Upload time was
in the range of tens of minutes.

## Changes

**`ci/praktika/s3.py` — `upload_asset_streaming`**

When boto3 is available (which it is on all CI runners), compress the file
in-memory with `gzip.compress()` and call `put_object` directly. No subprocess,
no pipe, no CLI startup. Falls back to the original `gzip | aws s3 cp` path
when boto3 is not available.

**`ci/praktika/result.py` — `upload_result_files_to_s3`**

- `max_workers` raised from 10 → 50.
- Removed the `print(asset_paths)` line that was dumping all 50 000 paths into
  the build log on every run.
- Added error collection from futures (`future.result()` in a loop) so upload
  failures are surfaced instead of being silently swallowed.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.283`
<!-- ch-version-info:end -->