### PR TITLE
Fix `file_offset_of_buffer_end <= getFileSize()` assertion in `Log`/`StripeLog` on S3

### DIFF
--- a/src/Storages/StorageLog.cpp
+++ b/src/Storages/StorageLog.cpp
@@ -140,6 +140,11 @@ private:
         {
             plain = disk->readFile(data_path, read_settings_.adjustBufferSize(file_size));
 
+            /// Limit reads to the file size that was snapshotted under the read lock.
+            /// The file may have grown since (due to concurrent inserts after lock release),
+            /// but we must not read beyond the snapshotted range.
+            plain->setReadUntilPosition(file_size);
+
             if (offset)
                 plain->seek(offset, SEEK_SET);
 

--- a/src/Storages/StorageStripeLog.cpp
+++ b/src/Storages/StorageStripeLog.cpp
@@ -170,6 +170,12 @@ private:
 
             String data_file_path = storage->table_path + "data.bin";
             data_in.emplace(storage->disk->readFile(data_file_path, read_settings.adjustBufferSize(file_size)));
+
+            /// Limit reads to the file size that was snapshotted under the read lock.
+            /// The file may have grown since (due to concurrent inserts after lock release),
+            /// but we must not read beyond the snapshotted range that the index covers.
+            data_in->setReadUntilPosition(file_size);
+
             block_in.emplace(*data_in, 0, index_begin, index_end);
         }
     }


### PR DESCRIPTION
The `StripeLogSource` and `LogSource` release the read lock before lazily opening the data file. On S3 object storage, the `AsynchronousBoundedReadBuffer` caches file size from metadata at open time, which may differ from the snapshotted size the index was built against if concurrent writes modified the file metadata between lock release and file open.

Fix by calling `setReadUntilPosition(file_size)` after opening the file, bounding reads to the snapshotted file size. This is a no-op on local disk and only takes effect on object storage where `AsynchronousBoundedReadBuffer` is used.

Found by BuzzHouse (amd_msan): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99537&sha=7338429ff8d3349ba147f9ba05558bbd6b84e4b2&name_0=PR&name_1=BuzzHouse%20%28amd_msan%29
https://github.com/ClickHouse/ClickHouse/pull/99537

Fixes https://github.com/ClickHouse/ClickHouse/issues/82555

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `file_offset_of_buffer_end <= getFileSize()` assertion failure (exception in debug builds) when reading from `Log` or `StripeLog` tables on S3 object storage with concurrent writes.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.344`
<!-- ch-version-info:end -->