### PR TITLE
Fix flaky test 03706_statistics_preserve_checksums_on_mutations

### DIFF
--- a/tests/queries/0_stateless/03706_statistics_preserve_checksums_on_mutations.sh
+++ b/tests/queries/0_stateless/03706_statistics_preserve_checksums_on_mutations.sh
@@ -14,6 +14,11 @@ create table mt (key Int, value String) engine=MergeTree() order by key settings
   min_bytes_for_wide_part=0,
   -- otherwise sparse info will be different, since for INSERTs the sparse ratio is calculated for the whole block, while for mutations for each granula (FIXME?)
   ratio_of_defaults_for_sparse_serialization=1,
+  -- Pin serialization_info_version to 'basic': with 'with_types' the INSERT and mutation
+  -- paths produce different serialization.json content (the mutation always uses the table's
+  -- stored settings while the INSERT path may produce different serialization info metadata),
+  -- causing checksum mismatches that are not actual data corruption.
+  serialization_info_version='basic',
   -- This uncovers the bug
   auto_statistics_types='uniq,minmax,countmin,tdigest'
 ;


### PR DESCRIPTION
Pin `serialization_info_version='basic'` in the test's CREATE TABLE to fix
~30% failure rate under CI's MergeTree setting randomization.

When `serialization_info_version=with_types` is randomized, the INSERT and
mutation (ALTER TABLE REWRITE PARTS) code paths produce different
`serialization.json` metadata content. The INSERT path constructs
SerializationInfo from the data write, while the full-column mutation path
reads settings from `source_part->storage.getSettings()` (MutateTask.cpp:642-653).
This causes a mismatch in the serialization metadata format — the actual
column data is identical (verified: `uncompressed_hash_of_compressed_files`
matches in all failures).

Investigation: out of 30 test runs with MergeTree randomization, 9 failed.
All 9 failures (100%) had `serialization_info_version=with_types` — probability
of this being random is (0.5)^9 = 0.2%. With the pin to `basic`, 50/50 passes
under full randomization (both query and MergeTree settings).

Closes https://github.com/ClickHouse/ClickHouse/issues/100786

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.290`
<!-- ch-version-info:end -->