### PR TITLE
Docs: remove unneeded experimental setting for SQL standard VALUES clause as a table expression

### DIFF
--- a/docs/en/sql-reference/table-functions/values.md
+++ b/docs/en/sql-reference/table-functions/values.md
@@ -193,16 +193,11 @@ FROM VALUES(
 
 ## SQL Standard VALUES Clause {#sql-standard-values-clause}
 
-ClickHouse also supports the SQL standard `VALUES` clause as a table expression
+From version 26.3, ClickHouse also supports the SQL standard `VALUES` clause as a table expression
 in `FROM`, as used in PostgreSQL, MySQL, DuckDB, and SQL Server. This syntax is
 rewritten internally to use the `values` table function described above.
 
-:::note
-This feature is experimental. To enable it, set `allow_experimental_sql_standard_values_clause = 1`.
-:::
-
 ```sql title="Query"
-SET allow_experimental_sql_standard_values_clause = 1;
 SELECT * FROM (VALUES (1, 'a'), (2, 'b'), (3, 'c')) AS t(id, val);
 ```
 


### PR DESCRIPTION
Closes https://github.com/ClickHouse/ClickHouse/issues/100791
In https://github.com/ClickHouse/ClickHouse/pull/100143 the experimental setting was removed, but the documentation wasn't updated. Furthermore this will only work from 26.3 and documentation omits this.
### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.288`
<!-- ch-version-info:end -->