### PR TITLE
Fix two latent defects: nullable flag in parallel merge and FixedString in JIT getColumnData

### DIFF
--- a/src/AggregateFunctions/Combinators/AggregateFunctionNull.h
+++ b/src/AggregateFunctions/Combinators/AggregateFunctionNull.h
@@ -169,6 +169,10 @@ public:
 
     void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs, ThreadPool & thread_pool, std::atomic<bool> & is_cancelled, Arena * arena) const override
     {
+        if constexpr (result_is_nullable)
+            if (getFlag(rhs))
+                setFlag(place);
+
         nested_function->merge(nestedPlace(place), nestedPlace(rhs), thread_pool, is_cancelled, arena);
     }
 

--- a/src/Interpreters/JIT/compileFunction.cpp
+++ b/src/Interpreters/JIT/compileFunction.cpp
@@ -4,6 +4,7 @@
 
 #    include <AggregateFunctions/IAggregateFunction.h>
 #    include <Columns/ColumnNullable.h>
+#    include <Columns/ColumnFixedString.h>
 #    include <Columns/ColumnString.h>
 #    include <DataTypes/DataTypeNullable.h>
 #    include <DataTypes/Native.h>
@@ -68,6 +69,13 @@ ColumnData getColumnData(const IColumn * column, size_t skip_rows)
         const auto * string_column = assert_cast<const ColumnString *>(column);
         result.data = reinterpret_cast<const char *>(string_column->getChars().data());
         result.offset_data = reinterpret_cast<const char *>(string_column->getOffsets().data());
+    }
+    else if (WhichDataType(column->getDataType()).isFixedString())
+    {
+        /// Same as String: the JIT comparator computes byte offsets as row_index * n,
+        /// so the data pointer must be to the start of the chars array regardless of skip_rows.
+        const auto * fixed_string_column = assert_cast<const ColumnFixedString *>(column);
+        result.data = reinterpret_cast<const char *>(fixed_string_column->getChars().data());
     }
     else
     {


### PR DESCRIPTION
Two latent defects found during code review of #100687 and #100577. Neither is currently triggerable — both are defensive fixes for consistency and correctness.

**1. Missing nullable flag propagation in `AggregateFunctionNullBase` parallel merge**

The thread-pool-aware `merge` in `AggregateFunctionNullBase` does not propagate the nullable flag from the source state to the destination, unlike the non-thread-pool `merge` which does. This was introduced when the thread-pool merge was first added and would cause incorrect NULL results if a future aggregate function both supports parallelized merge (`isAbleToParallelizeMerge`) and has `returns_default_when_only_null = false`. Currently all parallelizable functions (`uniqExact`, `uniqHLL12`) have `returns_default_when_only_null = true`, making `result_is_nullable` always false — so this path is compiled out.

Related: #100687

**2. Missing `ColumnFixedString` handling in JIT `getColumnData`**

When #100577 added JIT sort support for `ColumnString` and `ColumnFixedString`, it added a special case in `getColumnData` for `ColumnString` to always use the base chars pointer regardless of `skip_rows`. The matching `ColumnFixedString` case was missed. Currently no call site combines FixedString with `skip_rows > 0`, so the fallback `getDataAt(skip_rows)` always receives 0 and returns the correct pointer.

Related: #100577

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.412`
<!-- ch-version-info:end -->