### PR TITLE
fix flaky test 03706_statistics_preserve_checksums_on_mutations

### DIFF
--- a/tests/queries/0_stateless/03706_statistics_preserve_checksums_on_mutations.sh
+++ b/tests/queries/0_stateless/03706_statistics_preserve_checksums_on_mutations.sh
@@ -15,7 +15,7 @@ create table mt (key Int, value String) engine=MergeTree() order by key settings
   -- otherwise sparse info will be different, since for INSERTs the sparse ratio is calculated for the whole block, while for mutations for each granula (FIXME?)
   ratio_of_defaults_for_sparse_serialization=1,
   -- This uncovers the bug
-  auto_statistics_types='uniq,minmax,countmin,tdigest'
+  auto_statistics_types='uniq,minmax,countmin'
 ;
 insert into mt select number, repeat('a', number) from numbers(10e3) settings max_block_size=1e6;
 -- { echo }


### PR DESCRIPTION
fix https://github.com/ClickHouse/ClickHouse/issues/100786

TDigest will differ due to the size of block during building. For simplicity, we will skip this type of statisitics.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
