### PR TITLE
Disable FIPS provider for sanitizer unit tests

### DIFF
--- a/ci/jobs/unit_tests_job.py
+++ b/ci/jobs/unit_tests_job.py
@@ -1,10 +1,20 @@
+import os
+
 from ci.praktika.info import Info
 from ci.praktika.result import Result
 from ci.praktika.utils import Shell
 
 if __name__ == "__main__":
+    # The CI Docker image installs an uninstrumented FIPS provider (`fips.so`) for OpenSSL.
+    # Sanitizers cannot track writes from uninstrumented shared libraries, causing false
+    # positives during OpenSSL global initialization (e.g. "use-of-uninitialized-value"
+    # in MSan). Disable FIPS provider loading for sanitizer builds.
+    job_name = Info().job_name
+    if any(san in job_name for san in ("msan", "asan", "tsan", "ubsan")):
+        os.environ["OPENSSL_CONF"] = "/dev/null"
+
     # Note, LSan does not compatible with debugger
-    if "asan" not in Info().job_name:
+    if "asan" not in job_name:
         # With gdb we will capture stacktrace in case of abnormal termination and timeout (45 mins)
         command_launcher = f"timeout -s INT -v 45m gdb -batch -ex 'handle all nostop' -ex 'set print thread-events off' -ex run -ex bt -ex 'thread apply all bt' -arg"
     else:


### PR DESCRIPTION
The CI Docker image installs an uninstrumented `fips.so` (built from stock OpenSSL 3.1.2) that gets loaded during OpenSSL global initialization. Sanitizers cannot track writes from uninstrumented shared libraries, causing false positives — currently MSan reports "use-of-uninitialized-value" in `OPENSSL_LH_retrieve` inside `fips.so`, crashing the unit test binary before any tests run.

This has been a latent issue since FIPS was added to the Docker image (June 2025), but only manifested now due to a link order change from #100348 (H3 library upgrade) which shifted global constructor ordering so that `sqid.cpp`'s `DEFAULT_BLOCKLIST` initialization poisons stack memory before `curl.cpp`'s global constructor loads the FIPS provider.

All `Unit tests (msan)` runs have been failing since ~00:49 UTC March 26: https://s3.amazonaws.com/clickhouse-test-reports/PRs/100798/f39aa9f209bb3760611b2bcb6eff737dad3b6f21/unit_tests_msan/job.log

Set `OPENSSL_CONF=/dev/null` for all sanitizer builds to prevent loading the uninstrumented FIPS provider.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.294`
<!-- ch-version-info:end -->