### PR TITLE
Fix signed integer overflow in `toStartOfInterval` for Week/Quarter/Year with origin

### DIFF
--- a/src/Functions/DateTimeTransforms.h
+++ b/src/Functions/DateTimeTransforms.h
@@ -735,7 +735,10 @@ struct ToStartOfInterval<IntervalKind::Kind::Week>
     {
         if (!origin.has_value())
             return time_zone.toStartOfWeekInterval(time_zone.toDayNum(t / scale_multiplier), weeks);
-        return ToStartOfInterval<IntervalKind::Kind::Day>::execute(t, weeks * 7, time_zone, scale_multiplier, origin);
+        Int64 days = 0;
+        if (common::mulOverflow(weeks, static_cast<Int64>(7), days))
+            throw DB::Exception(ErrorCodes::DECIMAL_OVERFLOW, "Numeric overflow");
+        return ToStartOfInterval<IntervalKind::Kind::Day>::execute(t, days, time_zone, scale_multiplier, origin);
     }
 };
 
@@ -791,7 +794,10 @@ struct ToStartOfInterval<IntervalKind::Kind::Quarter>
     {
         if (!origin.has_value())
             return time_zone.toStartOfQuarterInterval(time_zone.toDayNum(t / scale_multiplier), quarters);
-        return ToStartOfInterval<IntervalKind::Kind::Month>::execute(t, quarters * 3, time_zone, scale_multiplier, origin);
+        Int64 months = 0;
+        if (common::mulOverflow(quarters, static_cast<Int64>(3), months))
+            throw DB::Exception(ErrorCodes::DECIMAL_OVERFLOW, "Numeric overflow");
+        return ToStartOfInterval<IntervalKind::Kind::Month>::execute(t, months, time_zone, scale_multiplier, origin);
     }
 };
 
@@ -814,7 +820,10 @@ struct ToStartOfInterval<IntervalKind::Kind::Year>
     {
         if (!origin.has_value())
             return time_zone.toStartOfYearInterval(time_zone.toDayNum(t / scale_multiplier), years);
-        return ToStartOfInterval<IntervalKind::Kind::Month>::execute(t, years * 12, time_zone, scale_multiplier, origin);
+        Int64 months = 0;
+        if (common::mulOverflow(years, static_cast<Int64>(12), months))
+            throw DB::Exception(ErrorCodes::DECIMAL_OVERFLOW, "Numeric overflow");
+        return ToStartOfInterval<IntervalKind::Kind::Month>::execute(t, months, time_zone, scale_multiplier, origin);
     }
 };
 

--- a/tests/queries/0_stateless/04059_toStartOfInterval_weeks_overflow.sql
+++ b/tests/queries/0_stateless/04059_toStartOfInterval_weeks_overflow.sql
@@ -1,0 +1,11 @@
+-- Regression test: overflow in toStartOfInterval when converting between interval kinds with origin argument
+-- https://github.com/ClickHouse/ClickHouse/issues/100787
+
+-- weeks * 7 overflow
+SELECT toStartOfInterval(toDate32('2023-10-09'), toIntervalWeek(9223372036854775807), toDate32('2023-10-01')); -- { serverError DECIMAL_OVERFLOW }
+
+-- quarters * 3 overflow
+SELECT toStartOfInterval(toDate32('2023-10-09'), toIntervalQuarter(9223372036854775807), toDate32('2023-10-01')); -- { serverError DECIMAL_OVERFLOW }
+
+-- years * 12 overflow
+SELECT toStartOfInterval(toDate32('2023-10-09'), toIntervalYear(9223372036854775807), toDate32('2023-10-01')); -- { serverError DECIMAL_OVERFLOW }


### PR DESCRIPTION
When `toStartOfInterval` is called with an origin argument and a Week, Quarter, or Year interval, the interval value is multiplied by a constant (7, 3, or 12 respectively) to convert to a smaller unit before delegating. With extreme interval values like `INT64_MAX`, these multiplications overflow signed integers (undefined behavior), caught by UBSan.

Add `common::mulOverflow` checks before each multiplication, throwing `DECIMAL_OVERFLOW` on overflow, consistent with the existing pattern used for nanosecond/microsecond/millisecond conversions in the same file.

Closes #100787

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix undefined behavior (signed integer overflow) in `toStartOfInterval` when using Week, Quarter, or Year intervals with an origin argument and extreme interval values.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.297`
<!-- ch-version-info:end -->