### PR TITLE
Fix flaky tests 03926_semi_join_swap_tables and 03927_anti_join_swap_tables

### DIFF
--- a/tests/queries/0_stateless/03926_semi_join_swap_tables.reference
+++ b/tests/queries/0_stateless/03926_semi_join_swap_tables.reference
@@ -1,12 +1,12 @@
-  Type: RIGHT
-  Strictness: SEMI
-    Type: LEFT
-    Strictness: SEMI
-    Type: LEFT
-    Strictness: SEMI
-    Type: LEFT
-    Strictness: SEMI
+Type: RIGHT
+Strictness: SEMI
+Type: LEFT
+Strictness: SEMI
+Type: LEFT
+Strictness: SEMI
+Type: LEFT
+Strictness: SEMI
 3
-  Type: LEFT
-  Strictness: SEMI
+Type: LEFT
+Strictness: SEMI
 3

--- a/tests/queries/0_stateless/03926_semi_join_swap_tables.sql
+++ b/tests/queries/0_stateless/03926_semi_join_swap_tables.sql
@@ -16,7 +16,7 @@ SET enable_analyzer = 1, query_plan_join_swap_table = 'auto';
 SET join_algorithm='hash';
 
 -- swap LEFT SEMI join to RIGHT SEMI join
-SELECT *
+SELECT trimLeft(explain)
 FROM (
     EXPLAIN actions=1
     SELECT *
@@ -27,7 +27,7 @@ FROM (
 WHERE (explain LIKE '% Type:%') OR (explain LIKE '% Strictness:%');
 
 -- no swapping for PARTIAL_MERGE join
-SELECT *
+SELECT trimLeft(explain)
 FROM (
     EXPLAIN actions=1
     SELECT *
@@ -39,7 +39,7 @@ FROM (
 WHERE (explain LIKE '% Type:%') OR (explain LIKE '% Strictness:%');
 
 -- no swapping for PREFER_PARTIAL_MERGE join
-SELECT *
+SELECT trimLeft(explain)
 FROM (
     EXPLAIN actions=1
     SELECT *
@@ -51,11 +51,11 @@ FROM (
 WHERE (explain LIKE '% Type:%') OR (explain LIKE '% Strictness:%');
 
 -- no swapping for AUTO join
-SELECT *
+SELECT trimLeft(explain)
 FROM (
     EXPLAIN actions=1
     SELECT *
-    FROM lhs 
+    FROM lhs
     LEFT SEMI JOIN rhs
     ON lhs.a = rhs.a
     SETTINGS join_algorithm='auto'
@@ -76,7 +76,7 @@ FROM system.query_log
 WHERE log_comment = '03926_left_semi_join_swap_tables' AND current_database = currentDatabase() AND type = 'QueryFinish' AND event_date >= yesterday() AND event_time >= NOW() - INTERVAL '10 MINUTE';
 
 -- swap RIGHT SEMI join to LEFT SEMI join
-SELECT *
+SELECT trimLeft(explain)
 FROM (
     EXPLAIN actions=1
     SELECT *

--- a/tests/queries/0_stateless/03927_anti_join_swap_tables.reference
+++ b/tests/queries/0_stateless/03927_anti_join_swap_tables.reference
@@ -1,6 +1,6 @@
-  Type: RIGHT
-  Strictness: ANTI
+Type: RIGHT
+Strictness: ANTI
 3
-  Type: LEFT
-  Strictness: ANTI
+Type: LEFT
+Strictness: ANTI
 3

--- a/tests/queries/0_stateless/03927_anti_join_swap_tables.sql
+++ b/tests/queries/0_stateless/03927_anti_join_swap_tables.sql
@@ -16,7 +16,7 @@ SET enable_analyzer = 1, query_plan_join_swap_table = 'auto';
 SET join_algorithm='hash';
 
 -- swap LEFT ANTI join to RIGHT ANTI join
-SELECT *
+SELECT trimLeft(explain)
 FROM (
     EXPLAIN actions=1
     SELECT *
@@ -40,7 +40,7 @@ FROM system.query_log
 WHERE log_comment = '03927_left_anti_join_swap_tables' AND current_database = currentDatabase() AND type = 'QueryFinish' AND event_date >= yesterday() AND event_time >= NOW() - INTERVAL '10 MINUTE';
 
 -- swap RIGHT ANTI join to LEFT ANTI join
-SELECT *
+SELECT trimLeft(explain)
 FROM (
     EXPLAIN actions=1
     SELECT *


### PR DESCRIPTION
Both tests compare EXPLAIN output to check that the query planner correctly swaps
SEMI/ANTI join sides. The tests filter for `Type:` and `Strictness:` lines from
EXPLAIN actions=1, but the output includes leading whitespace reflecting the plan
tree depth.

When `enable_join_runtime_filters` is randomized to `false` by CI, the plan tree
gains an extra `Expression (Post Join Actions)` node between the top-level
Expression and the Join node. This pushes the join's Type/Strictness lines one
level deeper (from 2-space to 4-space indent), causing the reference diff to fail
even though the join type values are correct.

The fix uses `trimLeft(explain)` to strip leading whitespace from the EXPLAIN output,
making the comparison insensitive to plan tree depth. All original assertions (swap
type, strictness, build table row count) are preserved — the tests still fully verify
the join swap optimization.

CIDB data: 03926 had 16 failures across 5 unrelated PRs, 03927 had 37 failures
across 6 unrelated PRs in the last 30 days.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.303`
<!-- ch-version-info:end -->