### PR TITLE
Fix flaky test `00177_memory_bound_merging`

### DIFF
--- a/tests/queries/0_stateless/00177_memory_bound_merging.sh
+++ b/tests/queries/0_stateless/00177_memory_bound_merging.sh
@@ -31,7 +31,7 @@ test1() {
         GROUP BY CounterID, URL, EventDate
         ORDER BY URL, EventDate
         LIMIT 5 OFFSET 10
-        SETTINGS optimize_aggregation_in_order = 1, enable_memory_bound_merging_of_aggregation_results = 1, enable_parallel_replicas = 1, automatic_parallel_replicas_mode = 0, parallel_replicas_for_non_replicated_merge_tree = 1, max_parallel_replicas = 3, optimize_read_in_order = 1, max_rows_to_read = 0"
+        SETTINGS optimize_aggregation_in_order = 1, enable_memory_bound_merging_of_aggregation_results = 1, enable_parallel_replicas = 1, automatic_parallel_replicas_mode = 0, parallel_replicas_for_non_replicated_merge_tree = 1, max_parallel_replicas = 3, query_plan_aggregation_in_order = 1, optimize_read_in_order = 1, optimize_group_by_constant_keys = 1, max_rows_to_read = 0"
     check_replicas_read_in_order $query_id
 }
 
@@ -62,7 +62,7 @@ test3() {
             FROM test.hits
             WHERE CounterID = 1704509 AND UserID = 4322253409885123546
             GROUP BY URL, EventDate
-            SETTINGS optimize_aggregation_in_order = 1, enable_memory_bound_merging_of_aggregation_results = 1, enable_parallel_replicas = 1, automatic_parallel_replicas_mode = 0, parallel_replicas_for_non_replicated_merge_tree = 1, max_parallel_replicas = 3, parallel_replicas_local_plan=1, optimize_read_in_order = 1
+            SETTINGS optimize_aggregation_in_order = 1, enable_memory_bound_merging_of_aggregation_results = 1, enable_parallel_replicas = 1, automatic_parallel_replicas_mode = 0, parallel_replicas_for_non_replicated_merge_tree = 1, max_parallel_replicas = 3, parallel_replicas_local_plan=1, query_plan_aggregation_in_order = 1, optimize_read_in_order = 1
         )
         WHERE explain LIKE '%Aggr%Transform%' OR explain LIKE '%InOrder%'"
 }


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

None

### Description

The test `00177_memory_bound_merging` is flaky — 18 failures across 7 unrelated PRs in the last 30 days. A previous fix (PR #96261, merged Feb 7) pinned `optimize_read_in_order=1` and `max_rows_to_read=0`, but failures continue due to two additional randomized settings.

**Root cause:** The test verifies that replicas use `AggregatingInOrderTransform` (in-order aggregation with memory-bound merging). The `aggregation_in_order` query plan optimization requires **both** `optimize_aggregation_in_order=1` **and** `query_plan_aggregation_in_order=1` (see `QueryPlanOptimizationSettings.cpp:157`). The test only pinned the first setting, leaving it vulnerable to CI randomization of the second.

Two failure modes confirmed via CIDB analysis:
1. **`query_plan_aggregation_in_order` randomized to `False`** — directly disables the optimization at the query plan level, switching the pipeline from `AggregatingInOrderTransform` to plain `AggregatingTransform`. Replicas then don't read in order, and `check_replicas_read_in_order` returns 0 instead of 1. (Confirmed in PR #100624 failure on `amd_asan_ubsan, distributed plan`)
2. **`optimize_group_by_constant_keys` randomized to `False`** (5% probability, added by PR #97547 on Mar 22) — keeps constant `CounterID` in the GROUP BY clause, breaking the primary key prefix match needed for aggregation-in-order in test1 which uses `GROUP BY CounterID, URL, EventDate`. (Confirmed in PR #100762 failure on `arm_binary`)

**Fix:** Pin `query_plan_aggregation_in_order=1` in test1 and test3, and `optimize_group_by_constant_keys=1` in test1. This matches the pattern already used by test2 (which pins `query_plan_aggregation_in_order=1` and was not affected).

**Verification:** Local EXPLAIN PIPELINE confirms:
- Without fix: `query_plan_aggregation_in_order=0` → `AggregatingTransform` (no in-order aggregation)
- With fix: `query_plan_aggregation_in_order=1` → `AggregatingInOrderTransform` + `FinalizeAggregatedTransform` (correct in-order aggregation path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.298`
<!-- ch-version-info:end -->