### PR TITLE
Fix `If`, `Distinct`, `DistinctIf`, `IfState ` aggregate function combinators with `Tuple` return type not being able to read older serialized states after introduction of `Nullable(Tuple)`

### DIFF
--- a/src/AggregateFunctions/Combinators/AggregateFunctionDistinct.h
+++ b/src/AggregateFunctions/Combinators/AggregateFunctionDistinct.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <AggregateFunctions/IAggregateFunction.h>
+#include <AggregateFunctions/Combinators/AggregateFunctionNull.h>
 #include <AggregateFunctions/KeyHolderHelpers.h>
 #include <DataTypes/DataTypeArray.h>
 #include <IO/ReadHelpersArena.h>
@@ -302,6 +303,27 @@ public:
     }
 
     AggregateFunctionPtr getNestedFunction() const override { return nested_func; }
+
+    AggregateFunctionPtr getOwnNullAdapter(
+        const AggregateFunctionPtr & nested_function,
+        const DataTypes & arguments,
+        const Array & params,
+        const AggregateFunctionProperties & /*properties*/) const override
+    {
+        /// After `Nullable(Tuple)` was introduced, Tuple's `canBeInsideNullable` now returns true,
+        /// which changed the default null adapter for Tuple-returning functions:
+        ///   - single-arg: from `<false, false>` to `<true, true>` (flag byte added to serialization).
+        ///   - multi-arg: from `<false, true>` to `<true, true>` (flag byte was already present).
+        /// Only single-arg functions are affected because the multi-arg (variadic) Null combinator
+        /// always serialized the flag byte unconditionally, so its serialization format did not change.
+        /// Currently, the only single-arg Tuple-returning aggregate function is `sumCount`.
+        /// We hardcode the check for `sumCount` rather than matching all single-arg Tuple-returning
+        /// functions, so that future functions with the same shape get the correct new behavior
+        /// (`<true, true>`) by default and are not silently forced into the legacy adapter.
+        if (nested_func->getName() == "sumCount")
+            return std::make_shared<AggregateFunctionNullUnary<false, false>>(nested_function, arguments, params);
+        return nullptr;
+    }
 };
 
 }

--- a/src/AggregateFunctions/Combinators/AggregateFunctionIf.cpp
+++ b/src/AggregateFunctions/Combinators/AggregateFunctionIf.cpp
@@ -3,6 +3,7 @@
 #include <AggregateFunctions/Combinators/AggregateFunctionNull.h>
 
 #include <Common/VectorWithMemoryTracking.h>
+#include <DataTypes/DataTypeTuple.h>
 
 #include <absl/container/inlined_vector.h>
 
@@ -471,6 +472,19 @@ AggregateFunctionPtr AggregateFunctionIf::getOwnNullAdapter(
     /// For other arguments it is as usual (at least one is NULL then the result is NULL if possible).
     bool return_type_is_nullable = !properties.returns_default_when_only_null && getResultType()->canBeInsideNullable()
         && std::any_of(arguments.begin(), arguments.end() - 1, [](const auto & element) { return element->isNullable(); });
+
+    /// After `Nullable(Tuple)` was introduced, Tuple's `canBeInsideNullable` now returns
+    /// true, which changed the If-combinator null adapter for Tuple-returning functions:
+    ///   - single-arg (IfNullUnary): from `<false, false>` to `<true, true>` (flag byte added).
+    ///   - multi-arg (IfNullVariadic): from `<false, false>` to `<true, true>` (flag byte added).
+    /// The change below will make sure that the null adapter for Tuple remains `<false, false>` keeping backward compatibility.
+    /// This can lead to some inconsistency because now for Tuple-returning aggregate functions we never
+    /// serialize the flag byte. But the base variadic Null combinator (applied to multi-argument functions
+    /// with at least one Nullable argument) always serializes the flag byte unconditionally.
+    /// For example, `simpleLinearRegressionState` will write the flag byte but `simpleLinearRegressionIfState` will not.
+    /// This inconsistency predates the introduction of `Nullable(Tuple)`.
+    if (return_type_is_nullable && typeid_cast<const DataTypeTuple *>(getResultType().get()))
+        return_type_is_nullable = false;
 
     bool need_to_serialize_flag = return_type_is_nullable || properties.returns_default_when_only_null;
 

--- a/tests/integration/test_backward_compatibility/test_aggregate_function_state_tuple_return_type.py
+++ b/tests/integration/test_backward_compatibility/test_aggregate_function_state_tuple_return_type.py
@@ -345,71 +345,88 @@ def test_backward_compatibility_for_tuple_return_type(start_cluster):
             ("sumCountResample_empty", f"SELECT sumCountResample(0, 2, 1)(x, g) FROM {remote_tab} WHERE 0"),
         ]
 
+    def batch_query(checks):
+        """Combine individual checks into a single multi-statement query.
+
+        Each check's SELECT is wrapped as ``SELECT 'name', (original_select)``
+        so that the output contains one labeled row per check.
+        """
+        parts = []
+        for name, query in checks:
+            # Strip trailing semicolons/whitespace from the original query.
+            q = query.rstrip().rstrip(";")
+            parts.append(f"SELECT '{name}', ({q})")
+        return ";\n".join(parts)
+
+    def parse_batch_result(result, checks):
+        """Parse the labeled output back into a ``{name: value}`` dict."""
+        lines = result.strip().split("\n")
+        assert len(lines) == len(checks), (
+            f"Expected {len(checks)} result lines, got {len(lines)}"
+        )
+        parsed = {}
+        for line, (name, _) in zip(lines, checks):
+            parts = line.split("\t", 1)
+            assert parts[0] == name, f"Expected label '{name}', got '{parts[0]}'"
+            parsed[name] = parts[1] if len(parts) > 1 else ""
+        return parsed
+
+    def run_checks(node, checks):
+        """Run all checks on a node in a single round-trip and return results dict."""
+        return parse_batch_result(node.query(batch_query(checks)), checks)
+
     mixed_checks = build_checks(mixed_remote_tab)
     pre_nullable_only_checks = build_checks(pre_nullable_only_remote_tab)
-
-    mixed_baseline_results = {}
-    for name, query in mixed_checks:
-        mixed_baseline_results[name] = pre_nullable_tuple_node_1.query(query)
-
-    assert mixed_baseline_results["sumCount"] == "(48,16)\n"
-
-    for name, query in mixed_checks:
-        assert pre_nullable_tuple_node_2.query(query) == mixed_baseline_results[name], name
-        assert node3.query(query) == mixed_baseline_results[name], name
-        assert node4.query(query) == mixed_baseline_results[name], name
-
-    # Extra baseline with 4x pre-26.1 nodes.
-    pre_nullable_only_baseline_results = {}
-    for name, query in pre_nullable_only_checks:
-        pre_nullable_only_baseline_results[name] = pre_nullable_tuple_node_1.query(query)
-
-    for name, _ in mixed_checks:
-        assert pre_nullable_only_baseline_results[name] == mixed_baseline_results[name], name
-
-    # Cover empty aggregate states with deterministic tuple-return functions.
     mixed_empty_checks = build_empty_checks(mixed_remote_tab)
     pre_nullable_only_empty_checks = build_empty_checks(pre_nullable_only_remote_tab)
 
-    mixed_empty_baseline_results = {}
-    for name, query in mixed_empty_checks:
-        mixed_empty_baseline_results[name] = pre_nullable_tuple_node_1.query(query)
+    # Baseline: run all checks from the first pre-26.1 node.
+    mixed_baseline = run_checks(pre_nullable_tuple_node_1, mixed_checks)
+    assert mixed_baseline["sumCount"] == "(48,16)"
 
-    assert mixed_empty_baseline_results["sumCount_empty"] == "(0,0)\n"
+    # Verify all other nodes produce the same results (one round-trip per node).
+    for node in [pre_nullable_tuple_node_2, node3, node4]:
+        results = run_checks(node, mixed_checks)
+        for name in mixed_baseline:
+            assert results[name] == mixed_baseline[name], f"{name} on {node.name}"
 
-    for name, query in mixed_empty_checks:
-        assert pre_nullable_tuple_node_2.query(query) == mixed_empty_baseline_results[name], name
-        assert node3.query(query) == mixed_empty_baseline_results[name], name
-        assert node4.query(query) == mixed_empty_baseline_results[name], name
+    # Extra baseline with 4x pre-26.1 nodes — must match mixed baseline.
+    pre_nullable_only_baseline = run_checks(
+        pre_nullable_tuple_node_1, pre_nullable_only_checks
+    )
+    for name in mixed_baseline:
+        assert pre_nullable_only_baseline[name] == mixed_baseline[name], name
 
-    pre_nullable_only_empty_baseline_results = {}
-    for name, query in pre_nullable_only_empty_checks:
-        pre_nullable_only_empty_baseline_results[name] = pre_nullable_tuple_node_1.query(query)
+    # Cover empty aggregate states.
+    mixed_empty_baseline = run_checks(pre_nullable_tuple_node_1, mixed_empty_checks)
+    assert mixed_empty_baseline["sumCount_empty"] == "(0,0)"
 
-    for name, _ in mixed_empty_checks:
+    for node in [pre_nullable_tuple_node_2, node3, node4]:
+        results = run_checks(node, mixed_empty_checks)
+        for name in mixed_empty_baseline:
+            assert results[name] == mixed_empty_baseline[name], f"{name} on {node.name}"
+
+    pre_nullable_only_empty_baseline = run_checks(
+        pre_nullable_tuple_node_1, pre_nullable_only_empty_checks
+    )
+    for name in mixed_empty_baseline:
         assert (
-            pre_nullable_only_empty_baseline_results[name]
-            == mixed_empty_baseline_results[name]
+            pre_nullable_only_empty_baseline[name] == mixed_empty_baseline[name]
         ), name
 
     # Upgrade one pre-26.1 node to latest and re-check compatibility from all coordinators.
     pre_nullable_tuple_node_1.restart_with_latest_version(fix_metadata=True)
 
-    for name, query in mixed_checks:
-        assert pre_nullable_tuple_node_1.query(query) == mixed_baseline_results[name], name
-        assert pre_nullable_tuple_node_2.query(query) == mixed_baseline_results[name], name
-        assert node3.query(query) == mixed_baseline_results[name], name
-        assert node4.query(query) == mixed_baseline_results[name], name
+    for node in [pre_nullable_tuple_node_1, pre_nullable_tuple_node_2, node3, node4]:
+        results = run_checks(node, mixed_checks)
+        for name in mixed_baseline:
+            assert results[name] == mixed_baseline[name], f"{name} on {node.name}"
 
-    for name, query in mixed_empty_checks:
-        assert (
-            pre_nullable_tuple_node_1.query(query) == mixed_empty_baseline_results[name]
-        ), name
-        assert (
-            pre_nullable_tuple_node_2.query(query) == mixed_empty_baseline_results[name]
-        ), name
-        assert node3.query(query) == mixed_empty_baseline_results[name], name
-        assert node4.query(query) == mixed_empty_baseline_results[name], name
+        results = run_checks(node, mixed_empty_checks)
+        for name in mixed_empty_baseline:
+            assert (
+                results[name] == mixed_empty_baseline[name]
+            ), f"{name} on {node.name}"
 
     for node in test_nodes:
         node.query("DROP TABLE IF EXISTS tab_tuple_return")

--- a/tests/integration/test_backward_compatibility/test_aggregate_function_state_tuple_return_type.py
+++ b/tests/integration/test_backward_compatibility/test_aggregate_function_state_tuple_return_type.py
@@ -183,6 +183,142 @@ def test_backward_compatibility_for_tuple_return_type(start_cluster):
                 "sumCount",
                 f"SELECT sumCount(x) FROM {remote_tab}",
             ),
+            # -If combinator
+            (
+                "sumCountIf",
+                f"SELECT sumCountIf(x, x > 2) FROM {remote_tab}",
+            ),
+            (
+                "simpleLinearRegressionIf",
+                f"SELECT tuple("
+                f"roundBankers(tupleElement(simpleLinearRegressionIf(x, y, x > 1), 1), 4), "
+                f"roundBankers(tupleElement(simpleLinearRegressionIf(x, y, x > 1), 2), 4)) "
+                f"FROM {remote_tab}",
+            ),
+            (
+                "studentTTestIf",
+                f"SELECT tuple("
+                f"roundBankers(tupleElement(studentTTestIf(x, g, x > 1), 1), 4), "
+                f"roundBankers(tupleElement(studentTTestIf(x, g, x > 1), 2), 4)) "
+                f"FROM {remote_tab}",
+            ),
+            (
+                "argAndMinIf",
+                f"SELECT argAndMinIf(a, b, a > 0) FROM {remote_tab}",
+            ),
+            (
+                "argAndMaxIf",
+                f"SELECT argAndMaxIf(a, b, a > 0) FROM {remote_tab}",
+            ),
+            # -Distinct combinator
+            (
+                "sumCountDistinct",
+                f"SELECT sumCountDistinct(x) FROM {remote_tab}",
+            ),
+            (
+                "simpleLinearRegressionDistinct",
+                f"SELECT tuple("
+                f"roundBankers(tupleElement(simpleLinearRegressionDistinct(x, y), 1), 4), "
+                f"roundBankers(tupleElement(simpleLinearRegressionDistinct(x, y), 2), 4)) "
+                f"FROM {remote_tab}",
+            ),
+            (
+                "studentTTestDistinct",
+                f"SELECT tuple("
+                f"roundBankers(tupleElement(studentTTestDistinct(x, g), 1), 4), "
+                f"roundBankers(tupleElement(studentTTestDistinct(x, g), 2), 4)) "
+                f"FROM {remote_tab}",
+            ),
+            (
+                "argAndMinDistinct",
+                f"SELECT argAndMinDistinct(a, b) FROM {remote_tab}",
+            ),
+            (
+                "argAndMaxDistinct",
+                f"SELECT argAndMaxDistinct(a, b) FROM {remote_tab}",
+            ),
+            # -DistinctIf combinator
+            (
+                "sumCountDistinctIf",
+                f"SELECT sumCountDistinctIf(x, x > 2) FROM {remote_tab}",
+            ),
+            (
+                "simpleLinearRegressionDistinctIf",
+                f"SELECT tuple("
+                f"roundBankers(tupleElement(simpleLinearRegressionDistinctIf(x, y, x > 1), 1), 4), "
+                f"roundBankers(tupleElement(simpleLinearRegressionDistinctIf(x, y, x > 1), 2), 4)) "
+                f"FROM {remote_tab}",
+            ),
+            (
+                "argAndMinDistinctIf",
+                f"SELECT argAndMinDistinctIf(a, b, a > 0) FROM {remote_tab}",
+            ),
+            # -Array combinator
+            (
+                "sumCountArray",
+                f"SELECT sumCountArray([x]) FROM {remote_tab}",
+            ),
+            (
+                "simpleLinearRegressionArray",
+                f"SELECT tuple("
+                f"roundBankers(tupleElement(simpleLinearRegressionArray([x], [y]), 1), 4), "
+                f"roundBankers(tupleElement(simpleLinearRegressionArray([x], [y]), 2), 4)) "
+                f"FROM {remote_tab}",
+            ),
+            (
+                "argAndMinArray",
+                f"SELECT argAndMinArray([a], [b]) FROM {remote_tab}",
+            ),
+            # -Merge combinator
+            (
+                "sumCountMerge",
+                f"SELECT sumCountMerge(s) FROM (SELECT sumCountState(x) AS s FROM {remote_tab})",
+            ),
+            (
+                "simpleLinearRegressionMerge",
+                f"SELECT tuple("
+                f"roundBankers(tupleElement(simpleLinearRegressionMerge(s), 1), 4), "
+                f"roundBankers(tupleElement(simpleLinearRegressionMerge(s), 2), 4)) "
+                f"FROM (SELECT simpleLinearRegressionState(x, y) AS s FROM {remote_tab})",
+            ),
+            (
+                "argAndMinMerge",
+                f"SELECT argAndMinMerge(s) FROM (SELECT argAndMinState(a, b) AS s FROM {remote_tab})",
+            ),
+            # -ForEach combinator
+            (
+                "sumCountForEach",
+                f"SELECT sumCountForEach([x]) FROM {remote_tab}",
+            ),
+            (
+                "simpleLinearRegressionForEach",
+                f"SELECT arrayMap(t -> tuple("
+                f"roundBankers(tupleElement(t, 1), 4), "
+                f"roundBankers(tupleElement(t, 2), 4)), "
+                f"simpleLinearRegressionForEach([x], [y])) "
+                f"FROM {remote_tab}",
+            ),
+            (
+                "argAndMinForEach",
+                f"SELECT argAndMinForEach([a], [b]) FROM {remote_tab}",
+            ),
+            # -Resample combinator
+            (
+                "sumCountResample",
+                f"SELECT sumCountResample(0, 2, 1)(x, g) FROM {remote_tab}",
+            ),
+            (
+                "simpleLinearRegressionResample",
+                f"SELECT arrayMap(t -> tuple("
+                f"roundBankers(tupleElement(t, 1), 4), "
+                f"roundBankers(tupleElement(t, 2), 4)), "
+                f"simpleLinearRegressionResample(0, 2, 1)(x, y, g)) "
+                f"FROM {remote_tab}",
+            ),
+            (
+                "argAndMinResample",
+                f"SELECT argAndMinResample(0, 2, 1)(a, b, g) FROM {remote_tab}",
+            ),
         ]
 
     def build_empty_checks(remote_tab):
@@ -197,6 +333,16 @@ def test_backward_compatibility_for_tuple_return_type(start_cluster):
                 "sumMapWithOverflow_empty",
                 f"SELECT sumMapWithOverflow(tuple(keys, vals8)) FROM {remote_tab} WHERE 0",
             ),
+            ("sumCountIf_empty", f"SELECT sumCountIf(x, x > 2) FROM {remote_tab} WHERE 0"),
+            ("sumCountDistinct_empty", f"SELECT sumCountDistinct(x) FROM {remote_tab} WHERE 0"),
+            ("sumCountArray_empty", f"SELECT sumCountArray([x]) FROM {remote_tab} WHERE 0"),
+            (
+                "simpleLinearRegressionIf_empty",
+                f"SELECT simpleLinearRegressionIf(x, y, x > 1) FROM {remote_tab} WHERE 0",
+            ),
+            ("argAndMinIf_empty", f"SELECT argAndMinIf(a, b, a > 0) FROM {remote_tab} WHERE 0"),
+            ("sumCountForEach_empty", f"SELECT sumCountForEach([x]) FROM {remote_tab} WHERE 0"),
+            ("sumCountResample_empty", f"SELECT sumCountResample(0, 2, 1)(x, g) FROM {remote_tab} WHERE 0"),
         ]
 
     mixed_checks = build_checks(mixed_remote_tab)

--- a/tests/queries/0_stateless/02406_minmax_behaviour.reference
+++ b/tests/queries/0_stateless/02406_minmax_behaviour.reference
@@ -135,15 +135,15 @@ SELECT argMinIf(number, -number::Float64, number > 2030) from numbers(2032);
 Select argMax((n, n), n) t, toTypeName(t) FROM (Select if(number % 3 == 0, NULL, number) as n from numbers(10));
 (8,8)	Nullable(Tuple(Nullable(UInt64), Nullable(UInt64)))
 Select argMaxIf((n, n), n, n < 5) t, toTypeName(t) FROM (Select if(number % 3 == 0, NULL, number) as n from numbers(10));
-(4,4)	Nullable(Tuple(Nullable(UInt64), Nullable(UInt64)))
+(4,4)	Tuple(Nullable(UInt64), Nullable(UInt64))
 Select argMaxIf((n, n), n, n > 5) t, toTypeName(t) FROM (Select if(number % 3 == 0, NULL, number) as n from numbers(10));
-(8,8)	Nullable(Tuple(Nullable(UInt64), Nullable(UInt64)))
+(8,8)	Tuple(Nullable(UInt64), Nullable(UInt64))
 Select argMin((n, n), n) t, toTypeName(t) FROM (Select if(number % 3 == 0, NULL, number) as n from numbers(10));
 (1,1)	Nullable(Tuple(Nullable(UInt64), Nullable(UInt64)))
 Select argMinIf((n, n), n, n < 5) t, toTypeName(t) FROM (Select if(number % 3 == 0, NULL, number) as n from numbers(10));
-(1,1)	Nullable(Tuple(Nullable(UInt64), Nullable(UInt64)))
+(1,1)	Tuple(Nullable(UInt64), Nullable(UInt64))
 Select argMinIf((n, n), n, n > 5) t, toTypeName(t) FROM (Select if(number % 3 == 0, NULL, number) as n from numbers(10));
-(7,7)	Nullable(Tuple(Nullable(UInt64), Nullable(UInt64)))
+(7,7)	Tuple(Nullable(UInt64), Nullable(UInt64))
 SET compile_aggregate_expressions=1;
 SET min_count_to_compile_aggregate_expression=0;
 WITH

--- a/tests/queries/0_stateless/02451_variadic_null_garbage_data.reference
+++ b/tests/queries/0_stateless/02451_variadic_null_garbage_data.reference
@@ -24,8 +24,8 @@ SELECT argMin((n, n), n) t, toTypeName(t) FROM (SELECT if(number <= 100, NULL, n
 SELECT argMin((n, n), n) t, toTypeName(t) FROM (SELECT if(number % 5 == 0, NULL, number::Int32) as n from numbers(5, 10));
 (6,6)	Nullable(Tuple(Nullable(Int32), Nullable(Int32)))
 SELECT argMaxIf((n, n), n, n > 100) t, toTypeName(t) FROM (SELECT if(number % 3 = 0, NULL, number) AS n from numbers(50));
-\N	Nullable(Tuple(Nullable(UInt64), Nullable(UInt64)))
+(NULL,NULL)	Tuple(Nullable(UInt64), Nullable(UInt64))
 SELECT argMaxIf((n, n), n, n < 100) t, toTypeName(t) FROM (SELECT if(number % 3 = 0, NULL, number) AS n from numbers(50));
-(49,49)	Nullable(Tuple(Nullable(UInt64), Nullable(UInt64)))
+(49,49)	Tuple(Nullable(UInt64), Nullable(UInt64))
 SELECT argMaxIf((n, n), n, n % 5 == 0) t, toTypeName(t) FROM (SELECT if(number % 3 = 0, NULL, number) AS n from numbers(50));
-(40,40)	Nullable(Tuple(Nullable(UInt64), Nullable(UInt64)))
+(40,40)	Tuple(Nullable(UInt64), Nullable(UInt64))

--- a/tests/queries/0_stateless/04048_sumcountif_nullable_backward_compat.reference
+++ b/tests/queries/0_stateless/04048_sumcountif_nullable_backward_compat.reference
@@ -1,5 +1,5 @@
 non_nullable_hex	0A0000000000000004
-nullable_hex	010A0000000000000004
-new_format_works	(10,4)
-return_type	Nullable(Tuple(UInt64, UInt64))
+nullable_hex	0A0000000000000004
+old_format_works	(10,4)
+return_type	Tuple(UInt64, UInt64)
 sumcount_fixed	(10,4)

--- a/tests/queries/0_stateless/04048_sumcountif_nullable_backward_compat.sql
+++ b/tests/queries/0_stateless/04048_sumcountif_nullable_backward_compat.sql
@@ -1,27 +1,28 @@
--- Bug test for PR #97502 (Fix sumCount aggregate backward compat with Nullable args).
--- PR #97502 adds getOwnNullAdapter to sumCount fixing its backward compat, but
--- sumCountIf (via AggregateFunctionIf) still wraps in NullAdapter producing a
--- leading flag byte, so old serialized states (no flag byte) fail to deserialize.
--- sumCountDistinct has the same issue.
+-- Regression test for sumCountIf backward compat with Nullable args.
+-- Originally this test documented the broken behavior after Nullable(Tuple) was introduced.
+-- Now it verifies the fix: the If and Distinct combinators preserve the old state layout.
 
 -- sumCountIf with non-nullable args: state has no flag byte (9 bytes)
 SELECT 'non_nullable_hex', hex(sumCountIfState(x, x > 0))
 FROM (SELECT CAST(number, 'UInt8') AS x FROM numbers(5));
 
--- sumCountIf with Nullable args: state gains a leading flag byte (10 bytes)
+-- sumCountIf with Nullable args: previously gained a leading flag byte (10 bytes),
+-- now fixed to produce the same 9-byte format as non-nullable.
 SELECT 'nullable_hex', hex(sumCountIfState(x, x > 0))
 FROM (SELECT CAST(number, 'Nullable(UInt8)') AS x FROM numbers(5));
 
--- Old 9-byte state (written before the flag byte was added) fails to deserialize
--- as AggregateFunction(sumCountIf, Nullable(UInt8), UInt8) — backward compat break
-SELECT finalizeAggregation(CAST(unhex('0A0000000000000004'), 'AggregateFunction(sumCountIf, Nullable(UInt8), UInt8)')); -- { serverError ATTEMPT_TO_READ_AFTER_EOF }
+-- Old 9-byte state (written before Nullable(Tuple) was introduced): previously failed
+-- with ATTEMPT_TO_READ_AFTER_EOF, now deserializes correctly.
+SELECT 'old_format_works', finalizeAggregation(CAST(unhex('0A0000000000000004'), 'AggregateFunction(sumCountIf, Nullable(UInt8), UInt8)'));
 
--- New 10-byte state (with flag byte) deserializes correctly
-SELECT 'new_format_works', finalizeAggregation(CAST(unhex('010A0000000000000004'), 'AggregateFunction(sumCountIf, Nullable(UInt8), UInt8)'));
+-- 10-byte state with flag byte (produced by the broken intermediate version): now rejected
+-- because the fixed serialization no longer expects the flag byte.
+SELECT finalizeAggregation(CAST(unhex('010A0000000000000004'), 'AggregateFunction(sumCountIf, Nullable(UInt8), UInt8)')); -- { serverError BAD_ARGUMENTS }
 
--- Return type for sumCountIf with Nullable args is Nullable(Tuple(UInt64, UInt64))
+-- Return type: previously Nullable(Tuple(UInt64, UInt64)), now Tuple(UInt64, UInt64)
+-- because the legacy no-flag adapter does not wrap the result in Nullable.
 SELECT 'return_type', toTypeName(sumCountIf(x, x > 0))
 FROM (SELECT CAST(number, 'Nullable(UInt8)') AS x FROM numbers(5));
 
--- Contrast: sumCount itself is fixed by PR #97502 (old format still deserializes)
+-- Contrast: sumCount itself is also fixed (old format still deserializes).
 SELECT 'sumcount_fixed', finalizeAggregation(CAST(unhex('0A0000000000000004'), 'AggregateFunction(sumCount, Nullable(UInt8))'));

--- a/tests/queries/0_stateless/04054_sumcount_combinator_compatibility.reference
+++ b/tests/queries/0_stateless/04054_sumcount_combinator_compatibility.reference
@@ -1,0 +1,85 @@
+-- { echo }
+
+-- Backward compatibility test for sumCount with all combinators and Nullable arguments.
+-- After Nullable(Tuple) was introduced, the Null/If combinators changed serialization for
+-- Tuple-returning functions. These tests verify that old states (from v25.11, pre-Nullable(Tuple))
+-- can still be deserialized, and that new states match the old format byte-for-byte.
+
+SET allow_suspicious_low_cardinality_types = 1;
+-- sumCountIf: Nullable and non-Nullable produce the same state format (no flag byte).
+SELECT hex(sumCountIfState(x, x > 0)) FROM (SELECT CAST(number, 'UInt8') AS x FROM numbers(5));
+0A0000000000000004
+SELECT hex(sumCountIfState(x, x > 0)) FROM (SELECT CAST(number, 'Nullable(UInt8)') AS x FROM numbers(5));
+0A0000000000000004
+-- sumCountIf: return type is Tuple, not Nullable(Tuple).
+SELECT toTypeName(sumCountIf(x, x > 0)) FROM (SELECT CAST(number, 'Nullable(UInt8)') AS x FROM numbers(5));
+Tuple(UInt64, UInt64)
+-- sumCountIf: deserialize old states.
+SELECT finalizeAggregation(CAST(unhex('070000000000000002'), 'AggregateFunction(sumCountIf, Nullable(UInt8), UInt8)'));
+(7,2)
+SELECT finalizeAggregation(CAST(unhex('000000000000000000'), 'AggregateFunction(sumCountIf, Nullable(UInt8), UInt8)'));
+(0,0)
+-- sumCountIf: round-trip produces identical bytes.
+SELECT hex(sumCountIfState(x, x > 2)) FROM (SELECT number::Nullable(UInt8) AS x FROM numbers(5));
+070000000000000002
+SELECT hex(sumCountIfState(x, 0)) FROM (SELECT CAST(NULL, 'Nullable(UInt8)') AS x);
+000000000000000000
+SELECT hex(sumCountIfState(x, 1)) FROM (SELECT CAST(NULL, 'Nullable(UInt8)') AS x);
+000000000000000000
+-- sumCountIf: LowCardinality(Nullable) same format.
+SELECT hex(sumCountIfState(x, x > 2)) FROM (SELECT CAST(number, 'LowCardinality(Nullable(UInt8))') AS x FROM numbers(5));
+070000000000000002
+-- sumCountIf: merge old states.
+SELECT sumCountIfMerge(st) FROM
+(
+    SELECT CAST(unhex('070000000000000002'), 'AggregateFunction(sumCountIf, Nullable(UInt8), UInt8)') AS st
+    UNION ALL
+    SELECT CAST(unhex('070000000000000002'), 'AggregateFunction(sumCountIf, Nullable(UInt8), UInt8)') AS st
+);
+(14,4)
+-- sumCountDistinct: deserialize old states.
+SELECT finalizeAggregation(CAST(unhex('0404020103'), 'AggregateFunction(sumCountDistinct, Nullable(UInt8))'));
+(10,4)
+SELECT finalizeAggregation(CAST(unhex('00'), 'AggregateFunction(sumCountDistinct, Nullable(UInt8))'));
+(0,0)
+-- sumCountDistinct: round-trip.
+SELECT hex(sumCountDistinctState(x)) FROM (SELECT number::Nullable(UInt8) AS x FROM numbers(5) WHERE x > 0);
+0404020103
+SELECT hex(sumCountDistinctState(x)) FROM (SELECT CAST(1, 'Nullable(UInt8)') AS x WHERE 0);
+00
+SELECT hex(sumCountDistinctState(x)) FROM (SELECT CAST(NULL, 'Nullable(UInt8)') AS x);
+00
+-- sumCountDistinct: LowCardinality(Nullable) same format.
+SELECT hex(sumCountDistinctState(x)) FROM (SELECT CAST(number, 'LowCardinality(Nullable(UInt8))') AS x FROM numbers(5) WHERE x > 0);
+0404020103
+-- sumCountDistinctIf: deserialize old state and round-trip.
+SELECT finalizeAggregation(CAST(unhex('03040203'), 'AggregateFunction(sumCountDistinctIf, Nullable(UInt8), UInt8)'));
+(9,3)
+SELECT hex(sumCountDistinctIfState(x, x > 1)) FROM (SELECT number::Nullable(UInt8) AS x FROM numbers(5));
+03040203
+-- sumCountArray: deserialize old state and round-trip.
+SELECT finalizeAggregation(CAST(unhex('0A0000000000000004'), 'AggregateFunction(sumCountArray, Array(Nullable(UInt8)))'));
+(10,4)
+SELECT hex(sumCountArrayState(x)) FROM (SELECT [number::Nullable(UInt8)] AS x FROM numbers(5) WHERE number > 0);
+0A0000000000000004
+SELECT finalizeAggregation(CAST(unhex('000000000000000000'), 'AggregateFunction(sumCountArray, Array(Nullable(UInt8)))'));
+(0,0)
+-- sumCountForEach: deserialize old state and round-trip.
+SELECT finalizeAggregation(CAST(unhex('01000000000000000A0000000000000004'), 'AggregateFunction(sumCountForEach, Array(Nullable(UInt8)))'));
+[(10,4)]
+SELECT hex(sumCountForEachState(x)) FROM (SELECT [number::Nullable(UInt8)] AS x FROM numbers(5) WHERE number > 0);
+01000000000000000A0000000000000004
+-- sumCountMerge: deserialize old state and round-trip.
+SELECT finalizeAggregation(CAST(unhex('0A0000000000000004'), 'AggregateFunction(sumCountMerge, AggregateFunction(sumCount, Nullable(UInt8)))'));
+(10,4)
+SELECT hex(sumCountMergeState(s)) FROM (SELECT sumCountState(number::Nullable(UInt8)) AS s FROM numbers(5) WHERE number > 0);
+0A0000000000000004
+-- sumCountResample: deserialize old state and round-trip.
+SELECT finalizeAggregation(CAST(unhex('01000000000000000001010000000000000001020000000000000001030000000000000001040000000000000001'), 'AggregateFunction(sumCountResample(0, 5, 1), Nullable(UInt8), UInt8)'));
+[(0,1),(1,1),(2,1),(3,1),(4,1)]
+SELECT hex(sumCountResampleState(0, 5, 1)(x, y)) FROM (SELECT number::Nullable(UInt8) AS x, number::UInt8 AS y FROM numbers(5));
+01000000000000000001010000000000000001020000000000000001030000000000000001040000000000000001
+SELECT sumCountOrNull(x) FROM (SELECT number::Nullable(UInt8) AS x FROM numbers(5) WHERE x > 0);
+(10,4)
+SELECT sumCountOrDefault(x) FROM (SELECT number::Nullable(UInt8) AS x FROM numbers(5) WHERE x > 0);
+(10,4)

--- a/tests/queries/0_stateless/04054_sumcount_combinator_compatibility.sql
+++ b/tests/queries/0_stateless/04054_sumcount_combinator_compatibility.sql
@@ -1,0 +1,71 @@
+-- { echo }
+
+-- Backward compatibility test for sumCount with all combinators and Nullable arguments.
+-- After Nullable(Tuple) was introduced, the Null/If combinators changed serialization for
+-- Tuple-returning functions. These tests verify that old states (from v25.11, pre-Nullable(Tuple))
+-- can still be deserialized, and that new states match the old format byte-for-byte.
+
+SET allow_suspicious_low_cardinality_types = 1;
+
+-- sumCountIf: Nullable and non-Nullable produce the same state format (no flag byte).
+SELECT hex(sumCountIfState(x, x > 0)) FROM (SELECT CAST(number, 'UInt8') AS x FROM numbers(5));
+SELECT hex(sumCountIfState(x, x > 0)) FROM (SELECT CAST(number, 'Nullable(UInt8)') AS x FROM numbers(5));
+
+-- sumCountIf: return type is Tuple, not Nullable(Tuple).
+SELECT toTypeName(sumCountIf(x, x > 0)) FROM (SELECT CAST(number, 'Nullable(UInt8)') AS x FROM numbers(5));
+
+-- sumCountIf: deserialize old states.
+SELECT finalizeAggregation(CAST(unhex('070000000000000002'), 'AggregateFunction(sumCountIf, Nullable(UInt8), UInt8)'));
+SELECT finalizeAggregation(CAST(unhex('000000000000000000'), 'AggregateFunction(sumCountIf, Nullable(UInt8), UInt8)'));
+
+-- sumCountIf: round-trip produces identical bytes.
+SELECT hex(sumCountIfState(x, x > 2)) FROM (SELECT number::Nullable(UInt8) AS x FROM numbers(5));
+SELECT hex(sumCountIfState(x, 0)) FROM (SELECT CAST(NULL, 'Nullable(UInt8)') AS x);
+SELECT hex(sumCountIfState(x, 1)) FROM (SELECT CAST(NULL, 'Nullable(UInt8)') AS x);
+
+-- sumCountIf: LowCardinality(Nullable) same format.
+SELECT hex(sumCountIfState(x, x > 2)) FROM (SELECT CAST(number, 'LowCardinality(Nullable(UInt8))') AS x FROM numbers(5));
+
+-- sumCountIf: merge old states.
+SELECT sumCountIfMerge(st) FROM
+(
+    SELECT CAST(unhex('070000000000000002'), 'AggregateFunction(sumCountIf, Nullable(UInt8), UInt8)') AS st
+    UNION ALL
+    SELECT CAST(unhex('070000000000000002'), 'AggregateFunction(sumCountIf, Nullable(UInt8), UInt8)') AS st
+);
+
+-- sumCountDistinct: deserialize old states.
+SELECT finalizeAggregation(CAST(unhex('0404020103'), 'AggregateFunction(sumCountDistinct, Nullable(UInt8))'));
+SELECT finalizeAggregation(CAST(unhex('00'), 'AggregateFunction(sumCountDistinct, Nullable(UInt8))'));
+
+-- sumCountDistinct: round-trip.
+SELECT hex(sumCountDistinctState(x)) FROM (SELECT number::Nullable(UInt8) AS x FROM numbers(5) WHERE x > 0);
+SELECT hex(sumCountDistinctState(x)) FROM (SELECT CAST(1, 'Nullable(UInt8)') AS x WHERE 0);
+SELECT hex(sumCountDistinctState(x)) FROM (SELECT CAST(NULL, 'Nullable(UInt8)') AS x);
+
+-- sumCountDistinct: LowCardinality(Nullable) same format.
+SELECT hex(sumCountDistinctState(x)) FROM (SELECT CAST(number, 'LowCardinality(Nullable(UInt8))') AS x FROM numbers(5) WHERE x > 0);
+
+-- sumCountDistinctIf: deserialize old state and round-trip.
+SELECT finalizeAggregation(CAST(unhex('03040203'), 'AggregateFunction(sumCountDistinctIf, Nullable(UInt8), UInt8)'));
+SELECT hex(sumCountDistinctIfState(x, x > 1)) FROM (SELECT number::Nullable(UInt8) AS x FROM numbers(5));
+
+-- sumCountArray: deserialize old state and round-trip.
+SELECT finalizeAggregation(CAST(unhex('0A0000000000000004'), 'AggregateFunction(sumCountArray, Array(Nullable(UInt8)))'));
+SELECT hex(sumCountArrayState(x)) FROM (SELECT [number::Nullable(UInt8)] AS x FROM numbers(5) WHERE number > 0);
+SELECT finalizeAggregation(CAST(unhex('000000000000000000'), 'AggregateFunction(sumCountArray, Array(Nullable(UInt8)))'));
+
+-- sumCountForEach: deserialize old state and round-trip.
+SELECT finalizeAggregation(CAST(unhex('01000000000000000A0000000000000004'), 'AggregateFunction(sumCountForEach, Array(Nullable(UInt8)))'));
+SELECT hex(sumCountForEachState(x)) FROM (SELECT [number::Nullable(UInt8)] AS x FROM numbers(5) WHERE number > 0);
+
+-- sumCountMerge: deserialize old state and round-trip.
+SELECT finalizeAggregation(CAST(unhex('0A0000000000000004'), 'AggregateFunction(sumCountMerge, AggregateFunction(sumCount, Nullable(UInt8)))'));
+SELECT hex(sumCountMergeState(s)) FROM (SELECT sumCountState(number::Nullable(UInt8)) AS s FROM numbers(5) WHERE number > 0);
+
+-- sumCountResample: deserialize old state and round-trip.
+SELECT finalizeAggregation(CAST(unhex('01000000000000000001010000000000000001020000000000000001030000000000000001040000000000000001'), 'AggregateFunction(sumCountResample(0, 5, 1), Nullable(UInt8), UInt8)'));
+SELECT hex(sumCountResampleState(0, 5, 1)(x, y)) FROM (SELECT number::Nullable(UInt8) AS x, number::UInt8 AS y FROM numbers(5));
+
+SELECT sumCountOrNull(x) FROM (SELECT number::Nullable(UInt8) AS x FROM numbers(5) WHERE x > 0);
+SELECT sumCountOrDefault(x) FROM (SELECT number::Nullable(UInt8) AS x FROM numbers(5) WHERE x > 0);

--- a/tests/queries/0_stateless/04055_aggregate_function_tuple_return_type_combinator_compatibility.reference
+++ b/tests/queries/0_stateless/04055_aggregate_function_tuple_return_type_combinator_compatibility.reference
@@ -1,0 +1,75 @@
+-- { echo }
+
+-- Backward compatibility test for Tuple-returning aggregate functions with combinators and Nullable arguments.
+-- These tests verify that old states (from v25.11, pre-Nullable(Tuple)) can still be deserialized.
+
+-- 1. simpleLinearRegressionIf(Nullable(Float64), Nullable(Float64), cond)
+SELECT finalizeAggregation(CAST(unhex('03000000000000000000000000002640000000000000394000000000008046400000000000405940'), 'AggregateFunction(simpleLinearRegressionIf, Nullable(Float64), Nullable(Float64), UInt8)'));
+(2,1)
+SELECT hex(simpleLinearRegressionIfState(x, y, x > 1))
+FROM values('x Nullable(Float64), y Nullable(Float64)', (1, 3), (2, 5), (NULL, 7), (4, 9), (5, 11));
+03000000000000000000000000002640000000000000394000000000008046400000000000405940
+-- 2. studentTTestIf(Nullable(Float64), Nullable(UInt8), cond)
+SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
+FROM (SELECT finalizeAggregation(CAST(unhex('000000000000004000000000000000400000000000002040000000000000284000000000000041400000000000005A40'), 'AggregateFunction(studentTTestIf, Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
+(-0.4851,0.6756)
+SELECT hex(studentTTestIfState(v, g, v > 1))
+FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
+000000000000004000000000000000400000000000002040000000000000284000000000000041400000000000005A40
+-- 3. welchTTestIf(Nullable(Float64), Nullable(UInt8), cond)
+SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
+FROM (SELECT finalizeAggregation(CAST(unhex('000000000000004000000000000000400000000000002040000000000000284000000000000041400000000000005A40'), 'AggregateFunction(welchTTestIf, Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
+(-0.4851,0.7051)
+SELECT hex(welchTTestIfState(v, g, v > 1))
+FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
+000000000000004000000000000000400000000000002040000000000000284000000000000041400000000000005A40
+-- 4. meanZTestIf(1., 1., 0.95)(Nullable(Float64), Nullable(UInt8), cond)
+SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4), roundBankers(res.3, 4), roundBankers(res.4, 4))
+FROM (SELECT finalizeAggregation(CAST(unhex('0000000000000040000000000000004000000000000020400000000000002840'), 'AggregateFunction(meanZTestIf(1., 1., 0.95), Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
+(-2,0.0455,-3.96,-0.04)
+SELECT hex(meanZTestIfState(1., 1., 0.95)(v, g, v > 1))
+FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
+0000000000000040000000000000004000000000000020400000000000002840
+-- 5. argAndMinIf(Nullable(Int32), Nullable(Int32), cond)
+SELECT finalizeAggregation(CAST(unhex('01030000000100000000'), 'AggregateFunction(argAndMinIf, Nullable(Int32), Nullable(Int32), UInt8)'));
+(3,0)
+SELECT hex(argAndMinIfState(a, b, a > 0))
+FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (NULL, 1), (3, 0));
+01030000000100000000
+-- 6. argAndMaxIf(Nullable(Int32), Nullable(Int32), cond)
+SELECT finalizeAggregation(CAST(unhex('01010000000102000000'), 'AggregateFunction(argAndMaxIf, Nullable(Int32), Nullable(Int32), UInt8)'));
+(1,2)
+SELECT hex(argAndMaxIfState(a, b, a > 0))
+FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (NULL, 1), (3, 0));
+01010000000102000000
+-- 7. kolmogorovSmirnovTestIf('two-sided')(Nullable(Float64), Nullable(UInt8), cond)
+SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
+FROM (SELECT finalizeAggregation(CAST(unhex('02020000000000000840000000000000144000000000000000400000000000002440'), 'AggregateFunction(kolmogorovSmirnovTestIf(''two-sided''), Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
+(0.5,1)
+SELECT hex(kolmogorovSmirnovTestIfState('two-sided')(v, g, v > 1))
+FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
+02020000000000000840000000000000144000000000000000400000000000002440
+-- Distinct combinator: verify round-trip for a subset.
+
+-- simpleLinearRegressionDistinct: round-trip.
+SELECT hex(simpleLinearRegressionDistinctState(x, y))
+FROM values('x Nullable(Float64), y Nullable(Float64)', (1, 3), (2, 5), (NULL, 7), (4, 9), (5, 11));
+01041000000000000010400000000000002240100000000000000040000000000000144010000000000000F03F00000000000008401000000000000014400000000000002640
+-- studentTTestDistinct: round-trip.
+SELECT hex(studentTTestDistinctState(v, g))
+FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
+010509000000000000F03F0009000000000000244001090000000000000840000900000000000014400009000000000000004001
+-- argAndMinDistinct: round-trip.
+SELECT hex(argAndMinDistinctState(a, b))
+FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (NULL, 1), (3, 0));
+0102080100000002000000080300000000000000
+-- Merge combinator: verify round-trip for a subset.
+
+-- simpleLinearRegressionMerge: round-trip.
+SELECT hex(simpleLinearRegressionMergeState(s))
+FROM (SELECT simpleLinearRegressionState(x, y) AS s FROM values('x Nullable(Float64), y Nullable(Float64)', (1, 3), (2, 5), (4, 9), (5, 11)));
+01040000000000000000000000000028400000000000003C4000000000000047400000000000005A40
+-- argAndMinMerge: round-trip.
+SELECT hex(argAndMinMergeState(s))
+FROM (SELECT argAndMinState(a, b) AS s FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (3, 0)));
+0101030000000100000000

--- a/tests/queries/0_stateless/04055_aggregate_function_tuple_return_type_combinator_compatibility.sql
+++ b/tests/queries/0_stateless/04055_aggregate_function_tuple_return_type_combinator_compatibility.sql
@@ -1,0 +1,74 @@
+-- { echo }
+
+-- Backward compatibility test for Tuple-returning aggregate functions with combinators and Nullable arguments.
+-- These tests verify that old states (from v25.11, pre-Nullable(Tuple)) can still be deserialized.
+
+-- 1. simpleLinearRegressionIf(Nullable(Float64), Nullable(Float64), cond)
+SELECT finalizeAggregation(CAST(unhex('03000000000000000000000000002640000000000000394000000000008046400000000000405940'), 'AggregateFunction(simpleLinearRegressionIf, Nullable(Float64), Nullable(Float64), UInt8)'));
+
+SELECT hex(simpleLinearRegressionIfState(x, y, x > 1))
+FROM values('x Nullable(Float64), y Nullable(Float64)', (1, 3), (2, 5), (NULL, 7), (4, 9), (5, 11));
+
+-- 2. studentTTestIf(Nullable(Float64), Nullable(UInt8), cond)
+SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
+FROM (SELECT finalizeAggregation(CAST(unhex('000000000000004000000000000000400000000000002040000000000000284000000000000041400000000000005A40'), 'AggregateFunction(studentTTestIf, Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
+
+SELECT hex(studentTTestIfState(v, g, v > 1))
+FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
+
+-- 3. welchTTestIf(Nullable(Float64), Nullable(UInt8), cond)
+SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
+FROM (SELECT finalizeAggregation(CAST(unhex('000000000000004000000000000000400000000000002040000000000000284000000000000041400000000000005A40'), 'AggregateFunction(welchTTestIf, Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
+
+SELECT hex(welchTTestIfState(v, g, v > 1))
+FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
+
+-- 4. meanZTestIf(1., 1., 0.95)(Nullable(Float64), Nullable(UInt8), cond)
+SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4), roundBankers(res.3, 4), roundBankers(res.4, 4))
+FROM (SELECT finalizeAggregation(CAST(unhex('0000000000000040000000000000004000000000000020400000000000002840'), 'AggregateFunction(meanZTestIf(1., 1., 0.95), Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
+
+SELECT hex(meanZTestIfState(1., 1., 0.95)(v, g, v > 1))
+FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
+
+-- 5. argAndMinIf(Nullable(Int32), Nullable(Int32), cond)
+SELECT finalizeAggregation(CAST(unhex('01030000000100000000'), 'AggregateFunction(argAndMinIf, Nullable(Int32), Nullable(Int32), UInt8)'));
+
+SELECT hex(argAndMinIfState(a, b, a > 0))
+FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (NULL, 1), (3, 0));
+
+-- 6. argAndMaxIf(Nullable(Int32), Nullable(Int32), cond)
+SELECT finalizeAggregation(CAST(unhex('01010000000102000000'), 'AggregateFunction(argAndMaxIf, Nullable(Int32), Nullable(Int32), UInt8)'));
+
+SELECT hex(argAndMaxIfState(a, b, a > 0))
+FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (NULL, 1), (3, 0));
+
+-- 7. kolmogorovSmirnovTestIf('two-sided')(Nullable(Float64), Nullable(UInt8), cond)
+SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
+FROM (SELECT finalizeAggregation(CAST(unhex('02020000000000000840000000000000144000000000000000400000000000002440'), 'AggregateFunction(kolmogorovSmirnovTestIf(''two-sided''), Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
+
+SELECT hex(kolmogorovSmirnovTestIfState('two-sided')(v, g, v > 1))
+FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
+
+-- Distinct combinator: verify round-trip for a subset.
+
+-- simpleLinearRegressionDistinct: round-trip.
+SELECT hex(simpleLinearRegressionDistinctState(x, y))
+FROM values('x Nullable(Float64), y Nullable(Float64)', (1, 3), (2, 5), (NULL, 7), (4, 9), (5, 11));
+
+-- studentTTestDistinct: round-trip.
+SELECT hex(studentTTestDistinctState(v, g))
+FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
+
+-- argAndMinDistinct: round-trip.
+SELECT hex(argAndMinDistinctState(a, b))
+FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (NULL, 1), (3, 0));
+
+-- Merge combinator: verify round-trip for a subset.
+
+-- simpleLinearRegressionMerge: round-trip.
+SELECT hex(simpleLinearRegressionMergeState(s))
+FROM (SELECT simpleLinearRegressionState(x, y) AS s FROM values('x Nullable(Float64), y Nullable(Float64)', (1, 3), (2, 5), (4, 9), (5, 11)));
+
+-- argAndMinMerge: round-trip.
+SELECT hex(argAndMinMergeState(s))
+FROM (SELECT argAndMinState(a, b) AS s FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (3, 0)));


### PR DESCRIPTION
### `If` combinator:
All `Tuple` returning aggregate functions are affected.

Single-arg aggregate function, `sumCount`:
```sql
SELECT finalizeAggregation(CAST(
      unhex('0A0000000000000004'),
      'AggregateFunction(sumCountIf, Nullable(UInt8), UInt8)'
  )); -- throws error
```

Variadic aggregate functions:
```sql
SELECT finalizeAggregation(CAST(  unhex('03000000000000000000000000002640000000000000394000000000008046400000000000405940'),
    'AggregateFunction(simpleLinearRegressionIf, Nullable(Float64), Nullable(Float64), UInt8)')); -- throws error
```

This affected all tuple returning functions because `if` combinator never wrote the flag byte (for both single and variadic aggregate function) even if the base function wrote the flag byte (base function always wrote the flag if it were variadic); with `Nullable(Tuple)`, we unlocked some path that made `if` combinator write the flag byte for all tuple returning aggregate if any of the argument if `Nullable`.

### `Distinct` combinator:

Only single-argument aggregate function, `sumCount` is affected:

```sql
SELECT finalizeAggregation(CAST(
      unhex('03000201'),
      'AggregateFunction(sumCountDistinct, Nullable(UInt8))'
  )); -- throws error
```

Other combinators are not affected because either the return type is not `Nullable` (e.g. `Array`, `AggregateFunction`) or not existed before pre-nullable `Tuple`.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `If`, `Distinct`, `DistinctIf`, `IfState ` aggregate function combinators with `Tuple` return type and one or more `Nullable` argument not being able to read older serialized states after introduction of `Nullable(Tuple)`. Closes https://github.com/ClickHouse/ClickHouse/issues/98917.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.299`
- Backported to: `26.3.2.2`, `26.2.6.25`, `26.1.7.11`
<!-- ch-version-info:end -->