### PR TITLE
Add 'watch' command to keeper-client

### DIFF
--- a/docs/en/operations/utilities/clickhouse-keeper-client.md
+++ b/docs/en/operations/utilities/clickhouse-keeper-client.md
@@ -79,17 +79,18 @@ keeper foo bar
 
 ## Commands {#clickhouse-keeper-client-commands}
 
--   `ls '[path]'` -- Lists the nodes for the given path (default: cwd)
+-   `ls '[path]' [watch_id]` -- Lists the nodes for the given path (default: cwd). Optionally sets a children watch identified by `watch_id`
 -   `cd '[path]'` -- Changes the working path (default `.`)
 -   `cp '<src>' '<dest>'`  -- Copies 'src' node to 'dest' path
 -   `cpr '<src>' '<dest>'`  -- Copies 'src' node subtree to 'dest' path
 -   `mv '<src>' '<dest>'`  -- Moves 'src' node to the 'dest' path
 -   `mvr '<src>' '<dest>'`  -- Moves 'src' node subtree to 'dest' path
--   `exists '<path>'` -- Returns `1` if node exists, `0` otherwise
+-   `exists '<path>' [watch_id]` -- Returns `1` if node exists, `0` otherwise. Optionally sets a watch identified by `watch_id`
 -   `set '<path>' <value> [version]` -- Updates the node's value. Only updates if version matches (default: -1)
 -   `create '<path>' <value> [mode]` -- Creates new node with the set value
 -   `touch '<path>'` -- Creates new node with an empty string as value. Doesn't throw an exception if the node already exists
--   `get '<path>'` -- Returns the node's value
+-   `get '<path>' [watch_id]` -- Returns the node's value. Optionally sets a data watch identified by `watch_id`
+-   `watch <watch_id> [timeout_seconds]` -- Waits for the watch event identified by `watch_id` and prints the event type and path. If `timeout_seconds` is specified, returns an error after the given timeout
 -   `rm '<path>' [version]` -- Removes the node only if version matches (default: -1)
 -   `rmr '<path>' [limit]` -- Recursively deletes path if the subtree size is smaller than the limit. Confirmation required (default limit = 100)
 -   `flwc <command>` -- Executes four-letter-word command

--- a/src/Common/ZooKeeper/KeeperClientCLI/Commands.cpp
+++ b/src/Common/ZooKeeper/KeeperClientCLI/Commands.cpp
@@ -1,10 +1,14 @@
 
 #include <algorithm>
+#include <chrono>
 #include <Common/StringUtils.h>
 #include <Common/ZooKeeper/KeeperClientCLI/Commands.h>
 #include <Common/ZooKeeper/KeeperClientCLI/KeeperClient.h>
+#include <future>
 #include <queue>
+#include <expected>
 
+#include <Common/FieldVisitorConvertToNumber.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/ExpressionElementParsers.h>
@@ -25,7 +29,30 @@ bool LSCommand::parse(IParser::Pos & pos, boost::intrusive_ptr<ASTKeeperQuery> &
         return true;
 
     node->args.push_back(std::move(path));
+
+    String watch_id;
+    if (parseKeeperArg(pos, expected, watch_id))
+        node->args.push_back(std::move(watch_id));
+
     return true;
+}
+
+namespace
+{
+template <typename Result, typename Callback>
+std::expected<Result, String> withWatch(const String & watch_id, KeeperClientBase * client, Callback && call)
+{
+    if (client->watches.contains(watch_id))
+        return std::unexpected(fmt::format("Watch '{}' already exists", watch_id));
+
+    auto promise = std::make_shared<std::promise<Coordination::WatchResponse>>();
+    auto fut = promise->get_future();
+    auto res
+        = call(std::make_shared<Coordination::WatchCallback>([p = std::move(promise)](const auto & response) { p->set_value(response); }));
+
+    client->watches.emplace(watch_id, std::move(fut));
+    return res;
+}
 }
 
 void LSCommand::execute(const ASTKeeperQuery * query, KeeperClientBase * client) const
@@ -36,7 +63,24 @@ void LSCommand::execute(const ASTKeeperQuery * query, KeeperClientBase * client)
     else
         path = client->cwd;
 
-    auto children = client->zookeeper->getChildren(path);
+    Strings children;
+    if (query->args.size() == 2)
+    {
+        auto watch_id = query->args[1].safeGet<String>();
+        auto res = withWatch<Strings>(
+            watch_id, client, [&](auto watch) { return client->zookeeper->getChildrenWatch(path, nullptr, std::move(watch)); });
+
+        if (!res)
+        {
+            client->cout << res.error() << "\n";
+            return;
+        }
+
+        children = res.value();
+    }
+    else
+        children = client->zookeeper->getChildren(path);
+
     std::sort(children.begin(), children.end());
 
     bool need_space = false;
@@ -169,12 +213,34 @@ bool GetCommand::parse(IParser::Pos & pos, boost::intrusive_ptr<ASTKeeperQuery> 
         return false;
     node->args.push_back(std::move(path));
 
+    String watch_id;
+    if (parseKeeperArg(pos, expected, watch_id))
+        node->args.push_back(std::move(watch_id));
+
     return true;
 }
 
 void GetCommand::execute(const ASTKeeperQuery * query, KeeperClientBase * client) const
 {
-    client->cout << client->zookeeper->get(client->getAbsolutePath(query->args[0].safeGet<String>())) << "\n";
+    auto path = client->getAbsolutePath(query->args[0].safeGet<String>());
+    String value;
+    if (query->args.size() == 2)
+    {
+        auto watch_id = query->args[1].safeGet<String>();
+        auto res
+            = withWatch<String>(watch_id, client, [&](auto watch) { return client->zookeeper->getWatch(path, nullptr, std::move(watch)); });
+
+        if (!res)
+        {
+            client->cout << res.error() << "\n";
+            return;
+        }
+
+        value = res.value();
+    }
+    else
+        value = client->zookeeper->get(path);
+    client->cout << value << "\n";
 }
 
 bool ExistsCommand::parse(IParser::Pos & pos, boost::intrusive_ptr<ASTKeeperQuery> & node, DB::Expected & expected) const
@@ -184,12 +250,100 @@ bool ExistsCommand::parse(IParser::Pos & pos, boost::intrusive_ptr<ASTKeeperQuer
         return false;
     node->args.push_back(std::move(path));
 
+    String watch_id;
+    if (parseKeeperArg(pos, expected, watch_id))
+        node->args.push_back(std::move(watch_id));
+
     return true;
 }
 
 void ExistsCommand::execute(const DB::ASTKeeperQuery * query, DB::KeeperClientBase * client) const
 {
-    client->cout << client->zookeeper->exists(client->getAbsolutePath(query->args[0].safeGet<String>())) << "\n";
+    auto path = client->getAbsolutePath(query->args[0].safeGet<String>());
+    bool result;
+    if (query->args.size() == 2)
+    {
+        auto watch_id = query->args[1].safeGet<String>();
+        auto res = withWatch<bool>(
+            watch_id, client, [&](auto watch) { return client->zookeeper->existsWatch(path, nullptr, std::move(watch)); });
+
+        if (!res)
+        {
+            client->cout << res.error() << "\n";
+            return;
+        }
+
+        result = res.value();
+    }
+    else
+        result = client->zookeeper->exists(path);
+    client->cout << result << "\n";
+}
+
+namespace
+{
+
+String watchEventTypeToString(int32_t type)
+{
+    switch (type)
+    {
+        case Coordination::CREATED: return "CREATED";
+        case Coordination::DELETED: return "DELETED";
+        case Coordination::CHANGED: return "CHANGED";
+        case Coordination::CHILD: return "CHILD";
+        case Coordination::SESSION: return "SESSION";
+        case Coordination::NOTWATCHING: return "NOTWATCHING";
+        default: return "UNKNOWN(" + std::to_string(type) + ")";
+    }
+}
+
+}
+
+bool WaitWatchCommand::parse(IParser::Pos & pos, boost::intrusive_ptr<ASTKeeperQuery> & node, Expected & expected) const
+{
+    String watch_id;
+    if (!parseKeeperArg(pos, expected, watch_id))
+        return false;
+    node->args.push_back(std::move(watch_id));
+
+    ASTPtr timeout;
+    if (ParserNumber{}.parse(pos, timeout, expected))
+        node->args.push_back(timeout->as<ASTLiteral &>().value);
+
+    return true;
+}
+
+void WaitWatchCommand::execute(const ASTKeeperQuery * query, KeeperClientBase * client) const
+{
+    auto watch_id = query->args[0].safeGet<String>();
+    auto it = client->watches.find(watch_id);
+    if (it == client->watches.end())
+    {
+        client->cerr << "No watch with id '" << watch_id << "'\n";
+        return;
+    }
+
+    if (!it->second.valid())
+        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Stale future for watch '{}'", watch_id);
+
+    if (query->args.size() == 2)
+    {
+        double timeout_seconds = applyVisitor(FieldVisitorConvertToNumber<Float64>(), query->args[1]);
+        auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::duration<double>(timeout_seconds));
+        if (it->second.wait_for(duration) == std::future_status::timeout)
+        {
+            client->cerr << "Watch '" << watch_id << "' timed out\n";
+            return; /// watch stays in the map and can be checked by the command later
+        }
+    }
+
+    auto fut = std::move(it->second);
+    client->watches.erase(it);
+
+    auto response = fut.get();
+
+    client->cout << "path: " << response.path << "\n";
+    client->cout << "type: " << watchEventTypeToString(response.type) << "\n";
 }
 
 bool GetStatCommand::parse(IParser::Pos & pos, boost::intrusive_ptr<ASTKeeperQuery> & node, Expected & expected) const

--- a/src/Common/ZooKeeper/KeeperClientCLI/Commands.h
+++ b/src/Common/ZooKeeper/KeeperClientCLI/Commands.h
@@ -41,7 +41,7 @@ class LSCommand : public IKeeperClientCommand
 
     void execute(const ASTKeeperQuery * query, KeeperClientBase * client) const override;
 
-    String getHelpMessage() const override { return "{} [path] -- Lists the nodes for the given path (default: cwd)"; }
+    String getHelpMessage() const override { return "{} [path] [watch_id] -- Lists the nodes for the given path (default: cwd). Optionally sets a watch"; }
 };
 
 class CDCommand : public IKeeperClientCommand
@@ -99,7 +99,7 @@ class GetCommand : public IKeeperClientCommand
 
     void execute(const ASTKeeperQuery * query, KeeperClientBase * client) const override;
 
-    String getHelpMessage() const override { return "{} <path> -- Returns the node's value"; }
+    String getHelpMessage() const override { return "{} <path> [watch_id] -- Returns the node's value. Optionally sets a watch"; }
 };
 
 class ExistsCommand : public IKeeperClientCommand
@@ -110,7 +110,7 @@ class ExistsCommand : public IKeeperClientCommand
 
     void execute(const ASTKeeperQuery * query, KeeperClientBase * client) const override;
 
-    String getHelpMessage() const override { return "{} <path> -- Returns `1` if node exists, `0` otherwise"; }
+    String getHelpMessage() const override { return "{} <path> [watch_id] -- Returns `1` if node exists, `0` otherwise. Optionally sets a watch"; }
 };
 
 class GetStatCommand : public IKeeperClientCommand
@@ -321,6 +321,17 @@ class MVRCommand : public IKeeperClientCommand
     {
         return "{} <src> <dest> -- Moves 'src' node subtree to 'dest' path.";
     }
+};
+
+class WaitWatchCommand : public IKeeperClientCommand
+{
+    String getName() const override { return "watch"; }
+
+    bool parse(IParser::Pos & pos, boost::intrusive_ptr<ASTKeeperQuery> & node, Expected & expected) const override;
+
+    void execute(const ASTKeeperQuery * query, KeeperClientBase * client) const override;
+
+    String getHelpMessage() const override { return "{} <watch_id> [timeout_seconds] -- Waits for watch event and prints the response"; }
 };
 
 class GetAclCommand : public IKeeperClientCommand

--- a/src/Common/ZooKeeper/KeeperClientCLI/KeeperClient.cpp
+++ b/src/Common/ZooKeeper/KeeperClientCLI/KeeperClient.cpp
@@ -195,6 +195,7 @@ KeeperClientBase::KeeperClientBase(std::ostream & cout_, std::ostream & cerr_)
         std::make_shared<MVCommand>(),
         std::make_shared<MVRCommand>(),
         std::make_shared<GetAclCommand>(),
+        std::make_shared<WaitWatchCommand>(),
     });
 }
 

--- a/src/Common/ZooKeeper/KeeperClientCLI/KeeperClient.h
+++ b/src/Common/ZooKeeper/KeeperClientCLI/KeeperClient.h
@@ -4,6 +4,8 @@
 #include <Common/ZooKeeper/ZooKeeper.h>
 #include <Core/Names.h>
 #include <filesystem>
+#include <future>
+#include <unordered_map>
 
 
 namespace fs = std::filesystem;
@@ -45,6 +47,8 @@ public:
     bool ask_confirmation = true;
 
     inline static std::map<String, Command> commands;
+
+    std::unordered_map<String, std::future<Coordination::WatchResponse>> watches;
 
     std::ostream & cout;
     std::ostream & cerr;

--- a/tests/queries/0_stateless/04061_keeper_client_watch_commands.reference
+++ b/tests/queries/0_stateless/04061_keeper_client_watch_commands.reference
@@ -24,4 +24,4 @@ Watch 'wtimeout' timed out
 No watch with id 'no_such_watch'
 -- duplicate watches
 child1 child2 will_appear
-Watch 'wdup' already exists
+Watch 'wexists_ls' already exists

--- a/tests/queries/0_stateless/04061_keeper_client_watch_commands.reference
+++ b/tests/queries/0_stateless/04061_keeper_client_watch_commands.reference
@@ -1,0 +1,27 @@
+-- get with watch_id
+initial
+-- exists with watch_id
+1
+0
+-- ls with watch_id
+child1
+-- watch data change
+initial
+path: /test-keeper-watch-default
+type: CHANGED
+-- watch child event
+child1
+path: /test-keeper-watch-default
+type: CHILD
+-- watch exists created
+0
+path: /test-keeper-watch-default/will_appear
+type: CREATED
+-- watch timeout
+updated
+Watch 'wtimeout' timed out
+-- watch unknown id
+No watch with id 'no_such_watch'
+-- duplicate watches
+child1 child2 will_appear
+Watch 'wdup' already exists

--- a/tests/queries/0_stateless/04061_keeper_client_watch_commands.sh
+++ b/tests/queries/0_stateless/04061_keeper_client_watch_commands.sh
@@ -46,7 +46,7 @@ $CLICKHOUSE_KEEPER_CLIENT -q "watch no_such_watch 1" 2>&1
 
 # -- duplicate watches --
 echo '-- duplicate watches' 2>&1
-$CLICKHOUSE_KEEPER_CLIENT -q "ls '$path' wdup; get '$path' wdup" 2>&1
+$CLICKHOUSE_KEEPER_CLIENT -q "ls '$path' wexists_ls; get '$path' wexists_ls" 2>&1
 
 # Cleanup
 $CLICKHOUSE_KEEPER_CLIENT -q "rmr '$path'"

--- a/tests/queries/0_stateless/04061_keeper_client_watch_commands.sh
+++ b/tests/queries/0_stateless/04061_keeper_client_watch_commands.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+path="/test-keeper-watch-$CLICKHOUSE_DATABASE"
+
+$CLICKHOUSE_KEEPER_CLIENT -q "rmr '$path'" >& /dev/null
+
+$CLICKHOUSE_KEEPER_CLIENT -q "create '$path' 'initial'"
+$CLICKHOUSE_KEEPER_CLIENT -q "create '$path/child1' 'c1'"
+
+# -- get with watch: compatible output (prints value as before) --
+echo '-- get with watch_id'
+$CLICKHOUSE_KEEPER_CLIENT -q "get '$path' w1"
+
+# -- exists with watch: compatible output (prints 1/0 as before) --
+echo '-- exists with watch_id'
+$CLICKHOUSE_KEEPER_CLIENT -q "exists '$path' w2"
+$CLICKHOUSE_KEEPER_CLIENT -q "exists '$path/nonexistent' w3"
+
+# -- ls with watch: compatible output (prints children as before) --
+echo '-- ls with watch_id'
+$CLICKHOUSE_KEEPER_CLIENT -q "ls '$path' w4"
+
+# -- watch with data change (CHANGED event via get watch) --
+echo '-- watch data change'
+$CLICKHOUSE_KEEPER_CLIENT -q "get '$path' wdata; set '$path' 'updated'; watch wdata 10"
+
+# -- watch child event (CHILD event via ls watch) --
+echo '-- watch child event'
+$CLICKHOUSE_KEEPER_CLIENT -q "ls '$path' wchild; create '$path/child2' 'c2'; watch wchild 10"
+
+# -- watch exists on non-existent node (CREATED event) --
+echo '-- watch exists created'
+$CLICKHOUSE_KEEPER_CLIENT -q "exists '$path/will_appear' wexist; create '$path/will_appear' 'hi'; watch wexist 10"
+
+# -- watch timeout --
+echo '-- watch timeout'
+$CLICKHOUSE_KEEPER_CLIENT -q "get '$path' wtimeout; watch wtimeout 0.5" 2>&1
+
+# -- watch with unknown id --
+echo '-- watch unknown id'
+$CLICKHOUSE_KEEPER_CLIENT -q "watch no_such_watch 1" 2>&1
+
+# -- duplicate watches --
+echo '-- duplicate watches' 2>&1
+$CLICKHOUSE_KEEPER_CLIENT -q "ls '$path' wdup; get '$path' wdup" 2>&1
+
+# Cleanup
+$CLICKHOUSE_KEEPER_CLIENT -q "rmr '$path'"


### PR DESCRIPTION
Add `watch_id` parameter to `get`, `exists`, and `ls` commands in `clickhouse-keeper-client`. When specified, the command registers a ZooKeeper watch and stores it under the given id. A new `watch` command lets the user wait for the event (with optional timeout) and prints the event type and path. Duplicate watch ids are rejected with an error.

### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add `watch` command to `clickhouse-keeper-client` with watch support in `get`, `exists`, and `ls` commands.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.311`
<!-- ch-version-info:end -->