### PR TITLE
Fix watches triggering in ZK client

### DIFF
--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -1011,31 +1011,54 @@ void ZooKeeper::receiveEvent()
         {
             const WatchResponse & watch_response = dynamic_cast<const WatchResponse &>(response_);
 
+            auto event_type = watch_response.type;
+            auto trigger_watches = [&watch_response](Watches & watches_container)
+            {
+                auto it = watches_container.find(watch_response.path);
+                if (it == watches_container.end())
+                {
+                    /// This is Ok.
+                    /// Because watches are identified by path.
+                    /// And there may exist many watches for single path.
+                    /// And watch is added to the list of watches on client side
+                    ///  slightly before than it is registered by the server.
+                    /// And that's why new watch may be already fired by old event,
+                    ///  but then the server will actually register new watch
+                    ///  and will send event again later.
+                }
+                else
+                {
+                    /// NOTE We may process callbacks not under mutex.
+                    for (const auto & event_or_callback : it->second)
+                    {
+                        if (event_or_callback)
+                            event_or_callback(watch_response);
+                    }
+
+                    CurrentMetrics::sub(CurrentMetrics::ZooKeeperWatch, it->second.size());
+                    watches_container.erase(it);
+                }
+            };
+
             std::lock_guard lock(watches_mutex);
 
-            auto it = watches.find(watch_response.path);
-            if (it == watches.end())
+            switch (event_type)
             {
-                /// This is Ok.
-                /// Because watches are identified by path.
-                /// And there may exist many watches for single path.
-                /// And watch is added to the list of watches on client side
-                ///  slightly before than it is registered by the server.
-                /// And that's why new watch may be already fired by old event,
-                ///  but then the server will actually register new watch
-                ///  and will send event again later.
-            }
-            else
-            {
-                /// NOTE We may process callbacks not under mutex.
-                for (const auto & event_or_callback : it->second)
-                {
-                    if (event_or_callback)
-                        event_or_callback(watch_response);
-                }
-
-                CurrentMetrics::sub(CurrentMetrics::ZooKeeperWatch, it->second.size());
-                watches.erase(it);
+                case Coordination::Event::CREATED:
+                case Coordination::Event::CHANGED:
+                    trigger_watches(watches);
+                    break;
+                case Coordination::Event::DELETED:
+                case Coordination::Event::SESSION:
+                    /// client will handle disconnection but lets trigger callbacks as soon as possible
+                    trigger_watches(watches);
+                    trigger_watches(list_watches);
+                    break;
+                case Coordination::Event::CHILD:
+                    trigger_watches(list_watches);
+                    break;
+                default:
+                    throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Unexpected watch event type {}", event_type);
             }
         };
     }
@@ -1085,47 +1108,74 @@ void ZooKeeper::receiveEvent()
         }
 
         /// Just helper for watch callbacks update. The main logic is below.
-        const auto update_watch_callbacks = [this](const Coordination::ZooKeeperRequestPtr & req, const Coordination::ResponsePtr & resp, const Coordination::WatchCallbackPtrOrEventPtr & watch)
+        const auto update_watch_callbacks = [this](
+                                                const Coordination::ZooKeeperRequestPtr & req,
+                                                const Coordination::ResponsePtr & resp,
+                                                const Coordination::WatchCallbackPtrOrEventPtr & watch)
         {
             bool add_watch = false;
+            auto op_num = req->getOpNum();
             /// 3 indicates the ZooKeeperExistsRequest.
             // For exists, we set the watch on both node exist and nonexist case.
             // For other case like getData, we only set the watch when node exists.
-            if (req->getOpNum() == OpNum::Exists)
+            if (op_num == OpNum::Exists)
                 add_watch = (resp->error == Error::ZOK || resp->error == Error::ZNONODE);
             else
                 add_watch = resp->error == Error::ZOK;
 
-            if (add_watch)
-            {
+            if (!add_watch || !watch)
+                return;
 
-                /// The key of watches should exclude the args.chroot
-                String req_path = req->getPath();
-                removeRootPath(req_path, args.chroot);
-                std::lock_guard lock(watches_mutex);
-                auto & callbacks = watches[req_path];
-                if (watch)
-                {
-                    if (callbacks.insert(watch).second)
-                    {
-                        /// Warn only for debug or sanitizers builds (i.e. CI), since it is OK to have 100 replicas,
-                        /// but if we will log only if the number of watches > 1000..10000, then, CI will not capture anything.
-                        ///
-                        /// And we do have tests that create > 100 replicas, so we cannot assert for 100 watches here
-                        /// (since all replicas shares some paths in ZooKeeper)
-#if defined(DEBUG_OR_SANITIZER_BUILD)
-                        static constexpr size_t WATCHES_CALLBACK_SANITY_LIMIT = 10000;
-                        chassert(callbacks.size() <= WATCHES_CALLBACK_SANITY_LIMIT);
-                        if (callbacks.size() > 100)
-                            LOG_WARNING(log, "Too many watches for path {}: {} (This is likely an error)", req_path, callbacks.size());
-#endif
-                        /// It is unlikely that 10K watches is OK, let's warn even in release builds.
-                        if (callbacks.size() > 10000)
-                            LOG_WARNING(log, "Too many watches for path {}: {} (This is likely an error)", req_path, callbacks.size());
-                        CurrentMetrics::add(CurrentMetrics::ZooKeeperWatch);
-                    }
-                }
+            bool is_list_request = false;
+
+            switch (op_num)
+            {
+                case OpNum::SimpleList:
+                case OpNum::List:
+                case OpNum::FilteredList:
+                case OpNum::FilteredListWithStatsAndData:
+                    is_list_request = true;
+                    break;
+                default:
+                    break;
             }
+
+            /// The key of watches should exclude the args.chroot
+            String req_path = req->getPath();
+            removeRootPath(req_path, args.chroot);
+
+            std::lock_guard lock(watches_mutex);
+            auto & callbacks = is_list_request ? list_watches[req_path] : watches[req_path];
+
+            if (!callbacks.insert(watch).second)
+                return;
+
+            /// Warn only for debug or sanitizers builds (i.e. CI), since it is OK to have 100 replicas,
+            /// but if we will log only if the number of watches > 1000..10000, then, CI will not capture anything.
+            ///
+            /// And we do have tests that create > 100 replicas, so we cannot assert for 100 watches here
+            /// (since all replicas shares some paths in ZooKeeper)
+#if defined(DEBUG_OR_SANITIZER_BUILD)
+            static constexpr size_t WATCHES_CALLBACK_SANITY_LIMIT = 10000;
+            chassert(callbacks.size() <= WATCHES_CALLBACK_SANITY_LIMIT);
+            if (callbacks.size() > 100)
+                LOG_WARNING(
+                    log,
+                    "Too many {} for path {}: {} (This is likely an error)",
+                    is_list_request ? "list_watches" : "watches",
+                    req_path,
+                    callbacks.size());
+#endif
+            /// It is unlikely that 10K watches is OK, let's warn even in release builds.
+            if (callbacks.size() > 10000)
+                LOG_WARNING(
+                    log,
+                    "Too many {} for path {}: {} (This is likely an error)",
+                    is_list_request ? "list_watches" : "watches",
+                    req_path,
+                    callbacks.size());
+
+            CurrentMetrics::add(CurrentMetrics::ZooKeeperWatch);
         };
 
         /// Instead of setting the watch in sendEvent, set it in receiveEvent because need to check the response.
@@ -1319,33 +1369,43 @@ void ZooKeeper::finalize(bool error_send, bool error_receive, const String & rea
         {
             std::lock_guard lock(watches_mutex);
 
-            Int64 watch_callback_count = 0;
-            for (auto & path_watches : watches)
+            auto trigger_watches = [this](Watches & watches_container)
             {
                 WatchResponse response;
                 response.type = SESSION;
                 response.state = EXPIRED_SESSION;
                 response.error = Error::ZSESSIONEXPIRED;
 
-                for (const auto & event_or_callback : path_watches.second)
+                Int64 watch_callback_count = 0;
+                for (auto & path_watches : watches_container)
                 {
-                    watch_callback_count += 1;
-                    if (event_or_callback)
+                    for (const auto & event_or_callback : path_watches.second)
                     {
-                        try
+                        watch_callback_count += 1;
+                        // TODO: there is impossible to have watch which will be "nullptr"
+                        if (event_or_callback)
                         {
-                            event_or_callback(response);
-                        }
-                        catch (...)
-                        {
-                            tryLogCurrentException(log);
+                            try
+                            {
+                                event_or_callback(response);
+                            }
+                            catch (...)
+                            {
+                                tryLogCurrentException(log);
+                            }
                         }
                     }
                 }
-            }
+
+                return watch_callback_count;
+            };
+
+            auto watch_callback_count = trigger_watches(watches);
+            watch_callback_count += trigger_watches(list_watches);
 
             CurrentMetrics::sub(CurrentMetrics::ZooKeeperWatch, watch_callback_count);
             watches.clear();
+            list_watches.clear();
         }
 
         /// Drain queue

--- a/src/Common/ZooKeeper/ZooKeeperImpl.h
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.h
@@ -297,6 +297,7 @@ private:
     std::mutex operations_mutex;
 
     Watches watches TSA_GUARDED_BY(watches_mutex);
+    Watches list_watches TSA_GUARDED_BY(watches_mutex);
 
     /// A wrapper around ThreadFromGlobalPool that allows to call join() on it from multiple threads.
     class ThreadReference

--- a/tests/queries/0_stateless/04061_keeper_client_watch_commands.reference
+++ b/tests/queries/0_stateless/04061_keeper_client_watch_commands.reference
@@ -22,6 +22,29 @@ updated
 Watch 'wtimeout' timed out
 -- watch unknown id
 No watch with id 'no_such_watch'
--- duplicate watches
+-- data change does not trigger children watch
+updated
 child1 child2 will_appear
+path: /test-keeper-watch-default
+type: CHANGED
+Watch 'w_ls' timed out
+child1 child2 child3 will_appear
+path: /test-keeper-watch-default
+type: CHILD
+-- child change does not trigger data watch
+child1 child2 child3 will_appear
+v2
+path: /test-keeper-watch-default
+type: CHANGED
+path: /test-keeper-watch-default
+type: CHILD
+-- child change does not trigger exists watch
+child1 child2 child3 child4 will_appear
+1
+path: /test-keeper-watch-default
+type: CHANGED
+path: /test-keeper-watch-default
+type: CHILD
+-- duplicate watches
+child1 child2 child3 child4 child5 will_appear
 Watch 'wexists_ls' already exists

--- a/tests/queries/0_stateless/04061_keeper_client_watch_commands.sh
+++ b/tests/queries/0_stateless/04061_keeper_client_watch_commands.sh
@@ -44,7 +44,22 @@ $CLICKHOUSE_KEEPER_CLIENT -q "get '$path' wtimeout; watch wtimeout 0.5" 2>&1
 echo '-- watch unknown id'
 $CLICKHOUSE_KEEPER_CLIENT -q "watch no_such_watch 1" 2>&1
 
-# -- duplicate watches --
+# -- data change must NOT trigger children watch --
+# Set ls (children) watch, change data (should not trigger it),
+# then add a child (should trigger it). If dispatch is correct the
+# watch fires with CHILD, not CHANGED.
+echo '-- data change does not trigger children watch'
+$CLICKHOUSE_KEEPER_CLIENT -q "get '$path' w_get; ls '$path' w_ls; set '$path' 'v2'; set '$path/child1' 'change'; watch w_get 5; watch w_ls 1; create '$path/child3' 'c3'; ls '$path'; watch w_ls 10" 2>&1
+
+# -- child change must NOT trigger data or exists watches --
+# Set get (data) and exists watches, add a child (should not trigger them),
+# then change data (should trigger them). If dispatch is correct the
+# watches fire with CHANGED, not CHILD.
+echo '-- child change does not trigger data watch'
+$CLICKHOUSE_KEEPER_CLIENT -q "ls '$path' wget_ls; get '$path' w_data; create '$path/child4' 'c4'; set '$path' 'v3'; watch w_data 10; watch wget_ls 10"
+echo '-- child change does not trigger exists watch' 2>&1
+$CLICKHOUSE_KEEPER_CLIENT -q "ls '$path' wexists_ls; exists '$path' w_exists; create '$path/child5' 'c5'; set '$path' 'v4'; watch w_exists 10; watch wexists_ls 10" 2>&1
+
 echo '-- duplicate watches' 2>&1
 $CLICKHOUSE_KEEPER_CLIENT -q "ls '$path' wexists_ls; get '$path' wexists_ls" 2>&1
 


### PR DESCRIPTION
Separate watches into `watches` (data/exists) and `list_watches` (children) maps in `ZooKeeperImpl` so that events are dispatched to the correct watch type: CREATED/CHANGED fire data watches, CHILD fires list watches, and DELETED/SESSION fire both. Previously all watches shared a single map, so a data change could incorrectly trigger a children watch and vice versa.

Depends on #100834.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix incorrect watch event dispatch in ZooKeeper client: data changes no longer trigger children watches and child changes no longer trigger data/exists watches.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)