### PR TITLE
Fix segfault in dictionary internal query

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -3157,9 +3157,10 @@ try
             global_context->getExternalDictionariesLoader().enablePeriodicUpdates(false);
 
             if (!server_settings[ServerSetting::shutdown_wait_unfinished_queries])
+            {
                 global_context->getProcessList().killAllQueries();
-
-            global_context->getExternalDictionariesLoader().joinLoadingThreads();
+                global_context->getExternalDictionariesLoader().joinLoadingThreads();
+            }
 
             size_t wait_limit_seconds = server_settings[ServerSetting::shutdown_wait_unfinished];
             auto wait_start = std::chrono::steady_clock::now();

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -3154,13 +3154,9 @@ try
             else
                 global_context->cancelAllBackupsAndRestores();
 
-            global_context->getExternalDictionariesLoader().enablePeriodicUpdates(false);
-
+            /// Killing remaining queries.
             if (!server_settings[ServerSetting::shutdown_wait_unfinished_queries])
-            {
                 global_context->getProcessList().killAllQueries();
-                global_context->getExternalDictionariesLoader().joinLoadingThreads();
-            }
 
             size_t wait_limit_seconds = server_settings[ServerSetting::shutdown_wait_unfinished];
             auto wait_start = std::chrono::steady_clock::now();

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -3154,9 +3154,12 @@ try
             else
                 global_context->cancelAllBackupsAndRestores();
 
-            /// Killing remaining queries.
+            global_context->getExternalDictionariesLoader().enablePeriodicUpdates(false);
+
             if (!server_settings[ServerSetting::shutdown_wait_unfinished_queries])
                 global_context->getProcessList().killAllQueries();
+
+            global_context->getExternalDictionariesLoader().waitForCurrentLoadingThreadsToFinish();
 
             size_t wait_limit_seconds = server_settings[ServerSetting::shutdown_wait_unfinished];
             auto wait_start = std::chrono::steady_clock::now();

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -3159,7 +3159,7 @@ try
             if (!server_settings[ServerSetting::shutdown_wait_unfinished_queries])
                 global_context->getProcessList().killAllQueries();
 
-            global_context->getExternalDictionariesLoader().waitForCurrentLoadingThreadsToFinish();
+            global_context->getExternalDictionariesLoader().joinLoadingThreads();
 
             size_t wait_limit_seconds = server_settings[ServerSetting::shutdown_wait_unfinished];
             auto wait_start = std::chrono::steady_clock::now();

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -885,11 +885,14 @@ struct ContextSharedPart : boost::noncopyable
         /// This must be done first because otherwise the reloading may pass a changed config
         /// to some destroyed parts of ContextSharedPart.
 
-        /// Disable future dictionary queries
+        /// We need to make sure no dictionary queries are concurrent with the further shutdown logic
+        /// because it sets various fields to null and those fields are unconditionally dereferenced by queries.
+        /// So we need to:
+        /// (1) Disable future dictionary queries.
+        /// (2) Make sure all the currently running dictionary queries are killed.
+        /// (3) Join the dictionary queries' threads.
         SHUTDOWN(log, "dictionaries loader", external_dictionaries_loader, enablePeriodicUpdates(false));
-        /// Make sure all the currently running dictionary queries are killed
         process_list.killAllQueries();
-        /// Join the dictionary queries' threads
         SHUTDOWN(log, "dictionaries loader threads", external_dictionaries_loader, joinLoadingThreads());
 
         SHUTDOWN(log, "UDFs loader", external_user_defined_executable_functions_loader, enablePeriodicUpdates(false));

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -375,6 +375,7 @@ namespace ServerSetting
     extern const ServerSettingsUInt64 max_replicated_fetches_network_bandwidth_for_server;
     extern const ServerSettingsUInt64 max_replicated_sends_network_bandwidth_for_server;
     extern const ServerSettingsBool s3queue_disable_streaming;
+    extern const ServerSettingsBool shutdown_wait_unfinished_queries;
     extern const ServerSettingsUInt64 tables_loader_background_pool_size;
     extern const ServerSettingsUInt64 tables_loader_foreground_pool_size;
     extern const ServerSettingsNonZeroUInt64 prefetch_threadpool_pool_size;
@@ -886,6 +887,10 @@ struct ContextSharedPart : boost::noncopyable
         /// to some destroyed parts of ContextSharedPart.
 
         SHUTDOWN(log, "dictionaries loader", external_dictionaries_loader, enablePeriodicUpdates(false));
+        if (!server_settings[ServerSetting::shutdown_wait_unfinished_queries])
+            process_list.killAllQueries();
+        SHUTDOWN(log, "dictionaries loader threads", external_dictionaries_loader, joinLoadingThreads());
+
         SHUTDOWN(log, "UDFs loader", external_user_defined_executable_functions_loader, enablePeriodicUpdates(false));
         SHUTDOWN(log, "another UDFs storage", user_defined_sql_objects_storage, stopWatching());
 

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -375,7 +375,6 @@ namespace ServerSetting
     extern const ServerSettingsUInt64 max_replicated_fetches_network_bandwidth_for_server;
     extern const ServerSettingsUInt64 max_replicated_sends_network_bandwidth_for_server;
     extern const ServerSettingsBool s3queue_disable_streaming;
-    extern const ServerSettingsBool shutdown_wait_unfinished_queries;
     extern const ServerSettingsUInt64 tables_loader_background_pool_size;
     extern const ServerSettingsUInt64 tables_loader_foreground_pool_size;
     extern const ServerSettingsNonZeroUInt64 prefetch_threadpool_pool_size;
@@ -886,9 +885,11 @@ struct ContextSharedPart : boost::noncopyable
         /// This must be done first because otherwise the reloading may pass a changed config
         /// to some destroyed parts of ContextSharedPart.
 
+        /// Disable future dictionary queries
         SHUTDOWN(log, "dictionaries loader", external_dictionaries_loader, enablePeriodicUpdates(false));
-        if (!server_settings[ServerSetting::shutdown_wait_unfinished_queries])
-            process_list.killAllQueries();
+        /// Make sure all the currently running dictionary queries are killed
+        process_list.killAllQueries();
+        /// Join the dictionary queries' threads
         SHUTDOWN(log, "dictionaries loader threads", external_dictionaries_loader, joinLoadingThreads());
 
         SHUTDOWN(log, "UDFs loader", external_user_defined_executable_functions_loader, enablePeriodicUpdates(false));

--- a/src/Interpreters/ExternalLoader.cpp
+++ b/src/Interpreters/ExternalLoader.cpp
@@ -405,7 +405,7 @@ public:
         joinLoadingThreads(lock);
     }
 
-    void waitForCurrentLoadingThreadsToFinish()
+    void joinLoadingThreads()
     {
         std::unique_lock lock{mutex};
         joinLoadingThreads(lock);
@@ -1389,9 +1389,9 @@ void ExternalLoader::enablePeriodicUpdates(bool enable_)
     periodic_updater->enable(enable_);
 }
 
-void ExternalLoader::waitForCurrentLoadingThreadsToFinish()
+void ExternalLoader::joinLoadingThreads()
 {
-    loading_dispatcher->waitForCurrentLoadingThreadsToFinish();
+    loading_dispatcher->joinLoadingThreads();
 }
 
 bool ExternalLoader::hasLoadedObjects() const

--- a/src/Interpreters/ExternalLoader.cpp
+++ b/src/Interpreters/ExternalLoader.cpp
@@ -402,8 +402,18 @@ public:
     {
         std::unique_lock lock{mutex};
         infos.clear(); /// We clear this map to tell the threads that we don't want any load results anymore.
+        joinLoadingThreads(lock);
+    }
 
-        /// Wait for all the threads to finish.
+    void waitForCurrentLoadingThreadsToFinish()
+    {
+        std::unique_lock lock{mutex};
+        joinLoadingThreads(lock);
+    }
+
+private:
+    void joinLoadingThreads(std::unique_lock<std::mutex> & lock)
+    {
         while (!loading_threads.empty())
         {
             auto it = loading_threads.begin();
@@ -415,6 +425,8 @@ public:
             lock.lock();
         }
     }
+
+public:
 
     using ObjectConfigsPtr = LoadablesConfigReader::ObjectConfigsPtr;
 
@@ -1375,6 +1387,11 @@ void ExternalLoader::enableAsyncLoading(bool enable)
 void ExternalLoader::enablePeriodicUpdates(bool enable_)
 {
     periodic_updater->enable(enable_);
+}
+
+void ExternalLoader::waitForCurrentLoadingThreadsToFinish()
+{
+    loading_dispatcher->waitForCurrentLoadingThreadsToFinish();
 }
 
 bool ExternalLoader::hasLoadedObjects() const

--- a/src/Interpreters/ExternalLoader.h
+++ b/src/Interpreters/ExternalLoader.h
@@ -105,7 +105,7 @@ public:
     /// Sets settings for periodic updates.
     void enablePeriodicUpdates(bool enable);
 
-    void waitForCurrentLoadingThreadsToFinish();
+    void joinLoadingThreads();
 
     /// Returns the status of the object.
     /// If the object has not been loaded yet then the function returns Status::NOT_LOADED.

--- a/src/Interpreters/ExternalLoader.h
+++ b/src/Interpreters/ExternalLoader.h
@@ -105,6 +105,8 @@ public:
     /// Sets settings for periodic updates.
     void enablePeriodicUpdates(bool enable);
 
+    void waitForCurrentLoadingThreadsToFinish();
+
     /// Returns the status of the object.
     /// If the object has not been loaded yet then the function returns Status::NOT_LOADED.
     /// If the specified name isn't found in the configuration then the function returns Status::NOT_EXIST.


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1464
<!-- End of fixes issue link part, do not remove -->

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix null pointer dereference segfault when loading dictionaries during server shutdown. `Context::getUserDefinedSQLObjectsStorage` (dereferences `user_defined_sql_objects_storage`) is called by dictionary threads concurrently with the main thread calling `Context::shutdown` (sets `user_defined_sql_objects_storage` to null). We need to make sure we disable future updates in the dictionaries loader, kill the currently running dictionary queries and join the dictionary loading threads - all before running `Context::shutdown`. Similar to what we do with normal queries.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.410`
- Backported to: `26.3.3.13`, `26.2.7.8`, `26.1.8.6`
<!-- ch-version-info:end -->