### PR TITLE
Add diagnostic counters to adjustLastGranule assertion

### DIFF
--- a/src/Storages/MergeTree/MergeTreeRangeReader.cpp
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.cpp
@@ -388,8 +388,15 @@ void MergeTreeRangeReader::ReadResult::adjustLastGranule()
     if (num_rows_to_subtract > rows_per_granule.back())
     {
         throw Exception(ErrorCodes::LOGICAL_ERROR,
-                        "Can't adjust last granule because it has {} rows, but try to subtract {} rows (num_read_rows = {}, rows_per_granule = [{}])",
-                        rows_per_granule.back(), num_rows_to_subtract, num_read_rows, fmt::join(rows_per_granule, ", "));
+                        "Can't adjust last granule because it has {} rows, but try to subtract {} rows "
+                        "(num_read_rows = {}, total_rows_per_granule = {}, rows_per_granule = [{}], "
+                        "debug: max_rows={}, rows_from_read={}, rows_from_finalize_loop={}, rows_from_finalize_post={}, "
+                        "ranges_processed={}, skipped_marks={}, use_query_condition_cache={}, can_read_incomplete_granules={})",
+                        rows_per_granule.back(), num_rows_to_subtract, num_read_rows, total_rows_per_granule,
+                        fmt::join(rows_per_granule, ", "),
+                        debug_max_rows, debug_rows_from_read_in_loop, debug_rows_from_finalize_in_loop,
+                        debug_rows_from_finalize_post_loop, debug_num_ranges_processed, debug_skipped_marks,
+                        debug_use_query_condition_cache, debug_can_read_incomplete_granules);
     }
 
     rows_per_granule.back() -= num_rows_to_subtract;
@@ -1049,12 +1056,17 @@ MergeTreeRangeReader::ReadResult MergeTreeRangeReader::startReadingChain(size_t 
     /// result.num_rows_read if the last granule in range also the last in part (so we have to adjust last granule).
     {
         bool use_query_condition_cache = merge_tree_reader->getMergeTreeReaderSettings().use_query_condition_cache;
+        result.debug_max_rows = max_rows;
+        result.debug_use_query_condition_cache = use_query_condition_cache;
+        result.debug_can_read_incomplete_granules = can_read_incomplete_granules;
         size_t space_left = max_rows;
         while (space_left && (!stream.isFinished() || !ranges.empty()))
         {
             if (stream.isFinished())
             {
-                result.addRows(stream.finalize(result.columns));
+                size_t finalized = stream.finalize(result.columns);
+                result.debug_rows_from_finalize_in_loop += finalized;
+                result.addRows(finalized);
                 if (current_mark && *current_mark < stream.last_mark)
                     result.addReadRange(MarkRange(*current_mark, stream.last_mark));
 
@@ -1062,12 +1074,14 @@ MergeTreeRangeReader::ReadResult MergeTreeRangeReader::startReadingChain(size_t 
                 result.addRange(ranges.front());
                 ranges.pop_front();
                 current_mark = stream.current_mark;
+                ++result.debug_num_ranges_processed;
             }
 
             if (merge_tree_reader->canSkipMark(currentMark(), stream.stream.currentTaskLastMark()))
             {
                 result.addGranule(0, {0, 0} /* unused when granule has no rows to read */);
                 stream.toNextMark();
+                ++result.debug_skipped_marks;
                 continue;
             }
 
@@ -1084,13 +1098,19 @@ MergeTreeRangeReader::ReadResult MergeTreeRangeReader::startReadingChain(size_t 
             bool last = rows_to_read == space_left;
             UInt64 starting_offset = stream.currentPartOffset();
             UInt64 granule_offset = stream.current_mark;
-            result.addRows(stream.read(result.columns, rows_to_read, !last));
+            size_t read_rows = stream.read(result.columns, rows_to_read, !last);
+            result.debug_rows_from_read_in_loop += read_rows;
+            result.addRows(read_rows);
             result.addGranule(rows_to_read, {starting_offset, granule_offset});
             space_left = (rows_to_read > space_left ? 0 : space_left - rows_to_read);
         }
     }
 
-    result.addRows(stream.finalize(result.columns));
+    {
+        size_t finalized = stream.finalize(result.columns);
+        result.debug_rows_from_finalize_post_loop += finalized;
+        result.addRows(finalized);
+    }
     size_t last_mark = stream.isFinished() ? stream.last_mark : stream.current_mark;
     if (current_mark && current_mark < last_mark)
         result.addReadRange(MarkRange{*current_mark, last_mark});

--- a/src/Storages/MergeTree/MergeTreeRangeReader.h
+++ b/src/Storages/MergeTree/MergeTreeRangeReader.h
@@ -387,6 +387,17 @@ public:
         size_t total_rows_per_granule = 0;
         /// The number of rows was read at first step. May be zero if no read columns present in part.
         size_t num_read_rows = 0;
+
+        /// Diagnostic counters for debugging adjustLastGranule assertions.
+        /// These track where addRows() increments came from in startReadingChain().
+        size_t debug_rows_from_read_in_loop = 0;       /// rows from stream.read() inside the loop
+        size_t debug_rows_from_finalize_in_loop = 0;    /// rows from stream.finalize() at range boundaries
+        size_t debug_rows_from_finalize_post_loop = 0;  /// rows from stream.finalize() after the loop
+        size_t debug_max_rows = 0;                      /// max_rows parameter passed to startReadingChain
+        size_t debug_num_ranges_processed = 0;          /// number of ranges processed
+        size_t debug_skipped_marks = 0;                 /// marks skipped via canSkipMark
+        bool debug_use_query_condition_cache = false;
+        bool debug_can_read_incomplete_granules = false;
         /// The number of rows was removed from last granule after clear or optimize.
         size_t num_rows_to_skip_in_last_granule = 0;
         /// Without any filtration.


### PR DESCRIPTION
The `adjustLastGranule()` assertion (STID 5258-4b5f) fires with exactly +2 granules worth of extra rows. This is extremely rare — 3 hits in 90 days, all on TSAN builds with S3 storage — and has resisted reproduction attempts across multiple sessions totaling 12,000+ targeted queries under TSAN + MinIO S3.

The current error message shows `num_read_rows` and `rows_per_granule` but not enough context to identify which code path produces the extra rows. This PR adds diagnostic counters to `ReadResult` that track the source of every `addRows()` increment in `startReadingChain()`:

- `rows_from_read`: rows returned by `stream.read()` (usually 0 for lazy reads, non-zero on position mismatches)
- `rows_from_finalize_loop`: rows from `stream.finalize()` at range boundaries inside the loop
- `rows_from_finalize_post`: rows from the post-loop `stream.finalize()`
- `max_rows`, `ranges_processed`, `skipped_marks`
- `use_query_condition_cache`, `can_read_incomplete_granules`

No behavior change — only the assertion error message gains additional context. When the bug next triggers in CI, the message will reveal whether the extra rows come from an unexpected finalize, a position mismatch in `stream.read()`, or a mark-skipping interaction.

Related issue: #100769

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.320`
<!-- ch-version-info:end -->