### PR TITLE
Fix use-after-free in Parquet ReadManager shutdown path

### DIFF
--- a/src/Processors/Formats/Impl/Parquet/ReadManager.cpp
+++ b/src/Processors/Formats/Impl/Parquet/ReadManager.cpp
@@ -657,14 +657,18 @@ void ReadManager::scheduleTasksIfNeeded(ReadStage stage_idx)
                 n += 1;
                 ++i;
             }
-            funcs.push_back([this, _batch = std::move(batch), _shutdown = shutdown, _stage_idx = stage_idx]
+            funcs.push_back([this, _batch = std::move(batch), _shutdown = shutdown]
             {
                 std::shared_lock shutdown_lock(*_shutdown, std::try_to_lock);
                 if (!shutdown_lock.owns_lock())
-                {
-                    stages.at(size_t(_stage_idx)).batches_in_progress.fetch_sub(1, std::memory_order_relaxed);
+                    /// ReadManager may already be destroyed at this point — the destructor
+                    /// calls shutdown->shutdown() which only waits for in-flight tasks (shared
+                    /// lock holders), not for queued tasks. Accessing `this` here would be a
+                    /// use-after-free. The batches_in_progress decrement is unnecessary because:
+                    /// - In normal completion (read() calls shutdown), no tasks are queued
+                    ///   (all row groups reached Deallocated before shutdown was called).
+                    /// - In abnormal destruction (~ReadManager), nobody checks the counter.
                     return;
-                }
                 runBatchOfTasks(_batch);
             });
         }


### PR DESCRIPTION
## Root cause

In `ReadManager::scheduleTasksIfNeeded()`, the lambda scheduled for thread pool execution captures `this` (the ReadManager) and, when the shutdown lock fails to acquire, accessed `this->stages` to decrement `batches_in_progress`. However, the ReadManager destructor (`~ReadManager()`) only calls `shutdown->shutdown()` which waits for **in-flight** tasks (shared lock holders), not for tasks still **queued** in the thread pool.

Race condition timeline:
1. An in-flight task (holding the shared lock) calls `scheduleTasksIfNeeded()` which queues new lambdas via `bulkSchedule()`
2. The in-flight task completes and releases the shared lock
3. `~ReadManager()` calls `shutdown->shutdown()`, which returns immediately (no shared lock holders)
4. ReadManager is destroyed — `stages` memory is freed
5. Queued lambda starts, `try_lock_shared()` fails (shutdown was called)
6. Lambda accesses `this->stages.at(...)` — **heap-use-after-free**

## Fix

Remove the `batches_in_progress.fetch_sub(1)` from the shutdown early-return path in the lambda. This is safe because:

- **Normal completion path** (`read()` calls `shutdown` at line 1031): All row groups have reached `Deallocated` before `shutdown()` is called, meaning all thread pool tasks have already completed. No tasks remain queued, so the early-return path is never hit.
- **Abnormal destruction** (`~ReadManager()`): Nobody checks `batches_in_progress` after the destructor runs.

This matches the pattern already used in `Prefetcher.cpp` (line 412), where the shutdown early-return path correctly avoids accessing `this`.

Also removed the now-unused `_stage_idx` capture from the lambda.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry:
Fix heap-use-after-free in Parquet reader thread pool shutdown path, where a queued task could access the destroyed ReadManager object. The crash manifested as an AddressSanitizer finding in stress tests with S3 storage.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.358`
<!-- ch-version-info:end -->