### PR TITLE
Fix shared cache issues between Protobuf and ProtobufList

### DIFF
--- a/docs/en/interfaces/formats/Protobuf/ProtobufList.md
+++ b/docs/en/interfaces/formats/Protobuf/ProtobufList.md
@@ -48,6 +48,6 @@ message Envelope {
 };
 ```
 
-If the schema does not contain an `Envelope` message, the top-level message type specified in `format_schema` is used directly.
+The message type specified in `format_schema` is resolved by first looking for it as a nested type inside a top-level `Envelope` message. If no match is found there — either because the schema has no `Envelope` message, or the `Envelope` does not contain a message with the requested name — the top-level message with that name is used directly.
 
 ## Format settings {#format-settings}

--- a/docs/en/interfaces/formats/Protobuf/ProtobufList.md
+++ b/docs/en/interfaces/formats/Protobuf/ProtobufList.md
@@ -48,4 +48,6 @@ message Envelope {
 };
 ```
 
+If the schema does not contain an `Envelope` message, the top-level message type specified in `format_schema` is used directly.
+
 ## Format settings {#format-settings}

--- a/src/Formats/ProtobufSchemas.cpp
+++ b/src/Formats/ProtobufSchemas.cpp
@@ -41,11 +41,6 @@ public:
 
     const google::protobuf::Descriptor * import(const String & schema_path, const String & message_name)
     {
-        // Search the message type among already imported ones.
-        const auto * descriptor = importer.pool()->FindMessageTypeByName(message_name);
-        if (descriptor)
-            return descriptor;
-
         const auto * file_descriptor = importer.Import(schema_path);
         if (error)
         {
@@ -60,7 +55,11 @@ public:
                 info.message);
         }
 
-        assert(file_descriptor);
+        if (!file_descriptor)
+            throw Exception(
+                ErrorCodes::CANNOT_PARSE_PROTOBUF_SCHEMA,
+                "Cannot parse '{}' file",
+                schema_path);
 
         if (with_envelope == WithEnvelope::Yes)
         {
@@ -125,7 +124,7 @@ ProtobufSchemas::getMessageTypeForFormatSchema(const FormatSchemaInfo & info, Wi
     }
 
     std::lock_guard lock(mutex);
-    auto key = ImporterKey{info.schemaDirectory(), with_envelope};
+    auto key = ImporterKey{info.schemaDirectory(), info.schemaPath(), with_envelope};
     auto it = importers.find(key);
     if (it == importers.end())
         it = importers

--- a/src/Formats/ProtobufSchemas.cpp
+++ b/src/Formats/ProtobufSchemas.cpp
@@ -62,25 +62,21 @@ public:
 
         assert(file_descriptor);
 
-        if (with_envelope == WithEnvelope::No)
+        if (with_envelope == WithEnvelope::Yes)
         {
-            const auto * message_descriptor = file_descriptor->FindMessageTypeByName(message_name);
-            if (!message_descriptor)
-                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Could not find a message named '{}' in the schema file '{}'",
-                    message_name, schema_path);
-
-            return message_descriptor;
+            const auto * envelope_descriptor = file_descriptor->FindMessageTypeByName("Envelope");
+            if (envelope_descriptor)
+            {
+                const auto * message_descriptor = envelope_descriptor->FindNestedTypeByName(message_name);
+                if (message_descriptor)
+                    return message_descriptor;
+            }
         }
 
-        const auto * envelope_descriptor = file_descriptor->FindMessageTypeByName("Envelope");
-        if (!envelope_descriptor)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Could not find a message named 'Envelope' in the schema file '{}'", schema_path);
-
-        const auto * message_descriptor = envelope_descriptor->FindNestedTypeByName(
-            message_name); // silly protobuf API disallows a restricting the field type to messages
+        const auto * message_descriptor = file_descriptor->FindMessageTypeByName(message_name);
         if (!message_descriptor)
-            throw Exception(
-                ErrorCodes::BAD_ARGUMENTS, "Could not find a message named '{}' in the schema file '{}'", message_name, schema_path);
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Could not find a message named '{}' in the schema file '{}'",
+                message_name, schema_path);
 
         return message_descriptor;
     }
@@ -129,11 +125,12 @@ ProtobufSchemas::getMessageTypeForFormatSchema(const FormatSchemaInfo & info, Wi
     }
 
     std::lock_guard lock(mutex);
-    auto it = importers.find(info.schemaDirectory());
+    auto key = ImporterKey{info.schemaDirectory(), with_envelope};
+    auto it = importers.find(key);
     if (it == importers.end())
         it = importers
                  .emplace(
-                     info.schemaDirectory(),
+                     key,
                      std::make_shared<ImporterWithSourceTree>(info.schemaDirectory(), google_protos_path, with_envelope))
                  .first;
     auto * importer = it->second.get();

--- a/src/Formats/ProtobufSchemas.h
+++ b/src/Formats/ProtobufSchemas.h
@@ -8,6 +8,7 @@
 #include <unordered_map>
 #include <base/types.h>
 #include <boost/noncopyable.hpp>
+#include <Common/SipHash.h>
 
 
 namespace google
@@ -92,14 +93,19 @@ private:
         bool operator==(const ImporterKey & other) const = default;
     };
 
-    std::unordered_map<ImporterKey,
-                       std::shared_ptr<ImporterWithSourceTree>,
-                       decltype([](const ImporterKey & key)
-                       {
-                           auto h1 = std::hash<String>{}(key.schema_directory);
-                           auto h2 = std::hash<String>{}(key.schema_path);
-                           return h1 ^ (h2 << 1) ^ (static_cast<uint8_t>(key.with_envelope) << 2);
-                       })> importers;
+    struct ImporterKeyHash
+    {
+        size_t operator()(const ImporterKey & key) const
+        {
+            SipHash hash;
+            hash.update(key.schema_directory);
+            hash.update(key.schema_path);
+            hash.update(key.with_envelope);
+            return hash.get64();
+        }
+    };
+
+    std::unordered_map<ImporterKey, std::shared_ptr<ImporterWithSourceTree>, ImporterKeyHash> importers;
     std::mutex mutex;
 };
 

--- a/src/Formats/ProtobufSchemas.h
+++ b/src/Formats/ProtobufSchemas.h
@@ -83,13 +83,22 @@ public:
     getMessageTypeForFormatSchema(const FormatSchemaInfo & info, WithEnvelope with_envelope, const String & google_protos_path);
 
 private:
-    using ImporterKey = std::pair<String, WithEnvelope>;
+    struct ImporterKey
+    {
+        String schema_directory;
+        String schema_path;
+        WithEnvelope with_envelope;
+
+        bool operator==(const ImporterKey & other) const = default;
+    };
+
     std::unordered_map<ImporterKey,
                        std::shared_ptr<ImporterWithSourceTree>,
                        decltype([](const ImporterKey & key)
                        {
-                           auto h = std::hash<String>{}(key.first);
-                           return h ^ (static_cast<uint8_t>(key.second));
+                           auto h1 = std::hash<String>{}(key.schema_directory);
+                           auto h2 = std::hash<String>{}(key.schema_path);
+                           return h1 ^ (h2 << 1) ^ (static_cast<uint8_t>(key.with_envelope) << 2);
                        })> importers;
     std::mutex mutex;
 };

--- a/src/Formats/ProtobufSchemas.h
+++ b/src/Formats/ProtobufSchemas.h
@@ -81,7 +81,17 @@ public:
     getMessageTypeForFormatSchema(const FormatSchemaInfo & info, WithEnvelope with_envelope, const String & google_protos_path);
 
 private:
-    std::unordered_map<String, std::shared_ptr<ImporterWithSourceTree>> importers;
+    using ImporterKey = std::pair<String, WithEnvelope>;
+    struct ImporterKeyHash
+    {
+        size_t operator()(const ImporterKey & key) const
+        {
+            auto h1 = std::hash<String>{}(key.first);
+            auto h2 = std::hash<uint8_t>{}(static_cast<uint8_t>(key.second));
+            return h1 ^ (h2 << 1);
+        }
+    };
+    std::unordered_map<ImporterKey, std::shared_ptr<ImporterWithSourceTree>, ImporterKeyHash> importers;
     std::mutex mutex;
 };
 

--- a/src/Formats/ProtobufSchemas.h
+++ b/src/Formats/ProtobufSchemas.h
@@ -41,6 +41,8 @@ public:
         No,
         // Return descriptor for a message with a user-provided name one level
         // below a top-level message with the hardcoded name "Envelope".
+        // If no "Envelope" message exists, the top-level message type
+        // specified in format_schema is used directly.
         // Example: In protobuf schema
         //   message Envelope {
         //     message MessageType {
@@ -82,16 +84,13 @@ public:
 
 private:
     using ImporterKey = std::pair<String, WithEnvelope>;
-    struct ImporterKeyHash
-    {
-        size_t operator()(const ImporterKey & key) const
-        {
-            auto h1 = std::hash<String>{}(key.first);
-            auto h2 = std::hash<uint8_t>{}(static_cast<uint8_t>(key.second));
-            return h1 ^ (h2 << 1);
-        }
-    };
-    std::unordered_map<ImporterKey, std::shared_ptr<ImporterWithSourceTree>, ImporterKeyHash> importers;
+    std::unordered_map<ImporterKey,
+                       std::shared_ptr<ImporterWithSourceTree>,
+                       decltype([](const ImporterKey & key)
+                       {
+                           auto h = std::hash<String>{}(key.first);
+                           return h ^ (static_cast<uint8_t>(key.second));
+                       })> importers;
     std::mutex mutex;
 };
 

--- a/tests/queries/0_stateless/04061_protobuf_cache_with_envelope.reference
+++ b/tests/queries/0_stateless/04061_protobuf_cache_with_envelope.reference
@@ -1,12 +1,16 @@
-ProtobufList before Protobuf (cold cache):
+Protobuf schema 1:
 0	0
 2	4
 3	9
-Protobuf:
+Protobuf schema 2 after schema 1:
 0	0
 2	4
 3	9
-ProtobufList after Protobuf (warm cache):
+ProtobufList schema 1:
+0	0
+2	4
+3	9
+ProtobufList schema 2 after schema 1:
 0	0
 2	4
 3	9

--- a/tests/queries/0_stateless/04061_protobuf_cache_with_envelope.reference
+++ b/tests/queries/0_stateless/04061_protobuf_cache_with_envelope.reference
@@ -1,0 +1,12 @@
+ProtobufList before Protobuf (cold cache):
+0	0
+2	4
+3	9
+Protobuf:
+0	0
+2	4
+3	9
+ProtobufList after Protobuf (warm cache):
+0	0
+2	4
+3	9

--- a/tests/queries/0_stateless/04061_protobuf_cache_with_envelope.sh
+++ b/tests/queries/0_stateless/04061_protobuf_cache_with_envelope.sh
@@ -10,7 +10,27 @@ SCHEMADIR=$CURDIR/format_schemas
 
 set -eo pipefail
 
-FORMAT_SCHEMA="$SCHEMADIR/04061_protobuf_cache_with_envelope:NumberAndSquare"
+FORMAT_SCHEMA_1="$SCHEMADIR/04061_protobuf_cache_with_envelope:NumberAndSquare"
+FORMAT_SCHEMA_2="$SCHEMADIR/04061_protobuf_cache_with_envelope_2:NumberAndSquare"
+
+roundtrip()
+{
+    local label="$1"
+    local format="$2"
+    local format_schema="$3"
+    local table_name="$4"
+
+    echo "$label"
+    local binary_file_path
+    binary_file_path=$(mktemp "$CURDIR/04061_protobuf_cache_with_envelope.XXXXXX.binary")
+
+    $CLICKHOUSE_CLIENT --query "SELECT * FROM squares_04061 ORDER BY number FORMAT $format SETTINGS format_schema = '$format_schema'" > "$binary_file_path"
+    $CLICKHOUSE_CLIENT --query "CREATE TABLE $table_name AS squares_04061"
+    $CLICKHOUSE_CLIENT --query "INSERT INTO $table_name SETTINGS format_schema = '$format_schema' FORMAT $format" < "$binary_file_path"
+    $CLICKHOUSE_CLIENT --query "SELECT * FROM $table_name ORDER BY number"
+
+    rm "$binary_file_path"
+}
 
 $CLICKHOUSE_CLIENT <<EOF
 DROP TABLE IF EXISTS squares_04061;
@@ -18,36 +38,19 @@ CREATE TABLE squares_04061 (number UInt32, square UInt64) ENGINE = MergeTree ORD
 INSERT INTO squares_04061 VALUES (2, 4), (0, 0), (3, 9);
 EOF
 
-# Use ProtobufList BEFORE Protobuf has cached anything.
-echo "ProtobufList before Protobuf (cold cache):"
-BINARY_FILE_PATH=$(mktemp "$CURDIR/04061_protobuf_cache_with_envelope.XXXXXX.binary")
-$CLICKHOUSE_CLIENT --query "SELECT * FROM squares_04061 ORDER BY number FORMAT ProtobufList SETTINGS format_schema = '$FORMAT_SCHEMA'" > "$BINARY_FILE_PATH"
-$CLICKHOUSE_CLIENT --query "CREATE TABLE roundtrip1_04061 AS squares_04061"
-$CLICKHOUSE_CLIENT --query "INSERT INTO roundtrip1_04061 SETTINGS format_schema = '$FORMAT_SCHEMA' FORMAT ProtobufList" < "$BINARY_FILE_PATH"
-$CLICKHOUSE_CLIENT --query "SELECT * FROM roundtrip1_04061 ORDER BY number"
-rm "$BINARY_FILE_PATH"
+# Use two different schema files with the same message name.
+roundtrip "Protobuf schema 1:" Protobuf "$FORMAT_SCHEMA_1" roundtrip1_04061
 
-# Use Protobuf format to populate the cache for this schema.
-echo "Protobuf:"
-BINARY_FILE_PATH=$(mktemp "$CURDIR/04061_protobuf_cache_with_envelope.XXXXXX.binary")
-$CLICKHOUSE_CLIENT --query "SELECT * FROM squares_04061 ORDER BY number FORMAT Protobuf SETTINGS format_schema = '$FORMAT_SCHEMA'" > "$BINARY_FILE_PATH"
-$CLICKHOUSE_CLIENT --query "CREATE TABLE roundtrip2_04061 AS squares_04061"
-$CLICKHOUSE_CLIENT --query "INSERT INTO roundtrip2_04061 SETTINGS format_schema = '$FORMAT_SCHEMA' FORMAT Protobuf" < "$BINARY_FILE_PATH"
-$CLICKHOUSE_CLIENT --query "SELECT * FROM roundtrip2_04061 ORDER BY number"
-rm "$BINARY_FILE_PATH"
+roundtrip "Protobuf schema 2 after schema 1:" Protobuf "$FORMAT_SCHEMA_2" roundtrip2_04061
 
-# Use ProtobufList AFTER Protobuf has populated the cache.
-echo "ProtobufList after Protobuf (warm cache):"
-BINARY_FILE_PATH=$(mktemp "$CURDIR/04061_protobuf_cache_with_envelope.XXXXXX.binary")
-$CLICKHOUSE_CLIENT --query "SELECT * FROM squares_04061 ORDER BY number FORMAT ProtobufList SETTINGS format_schema = '$FORMAT_SCHEMA'" > "$BINARY_FILE_PATH"
-$CLICKHOUSE_CLIENT --query "CREATE TABLE roundtrip3_04061 AS squares_04061"
-$CLICKHOUSE_CLIENT --query "INSERT INTO roundtrip3_04061 SETTINGS format_schema = '$FORMAT_SCHEMA' FORMAT ProtobufList" < "$BINARY_FILE_PATH"
-$CLICKHOUSE_CLIENT --query "SELECT * FROM roundtrip3_04061 ORDER BY number"
-rm "$BINARY_FILE_PATH"
+roundtrip "ProtobufList schema 1:" ProtobufList "$FORMAT_SCHEMA_1" roundtrip3_04061
+
+roundtrip "ProtobufList schema 2 after schema 1:" ProtobufList "$FORMAT_SCHEMA_2" roundtrip4_04061
 
 $CLICKHOUSE_CLIENT <<EOF
 DROP TABLE squares_04061;
 DROP TABLE roundtrip1_04061;
 DROP TABLE roundtrip2_04061;
 DROP TABLE roundtrip3_04061;
+DROP TABLE roundtrip4_04061;
 EOF

--- a/tests/queries/0_stateless/04061_protobuf_cache_with_envelope.sh
+++ b/tests/queries/0_stateless/04061_protobuf_cache_with_envelope.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+# Test that ProtobufList and Protobuf format behave nicely with their caches.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SCHEMADIR=$CURDIR/format_schemas
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+set -eo pipefail
+
+FORMAT_SCHEMA="$SCHEMADIR/04061_protobuf_cache_with_envelope:NumberAndSquare"
+
+$CLICKHOUSE_CLIENT <<EOF
+DROP TABLE IF EXISTS squares_04061;
+CREATE TABLE squares_04061 (number UInt32, square UInt64) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO squares_04061 VALUES (2, 4), (0, 0), (3, 9);
+EOF
+
+# Use ProtobufList BEFORE Protobuf has cached anything.
+echo "ProtobufList before Protobuf (cold cache):"
+BINARY_FILE_PATH=$(mktemp "$CURDIR/04061_protobuf_cache_with_envelope.XXXXXX.binary")
+$CLICKHOUSE_CLIENT --query "SELECT * FROM squares_04061 ORDER BY number FORMAT ProtobufList SETTINGS format_schema = '$FORMAT_SCHEMA'" > "$BINARY_FILE_PATH"
+$CLICKHOUSE_CLIENT --query "CREATE TABLE roundtrip1_04061 AS squares_04061"
+$CLICKHOUSE_CLIENT --query "INSERT INTO roundtrip1_04061 SETTINGS format_schema = '$FORMAT_SCHEMA' FORMAT ProtobufList" < "$BINARY_FILE_PATH"
+$CLICKHOUSE_CLIENT --query "SELECT * FROM roundtrip1_04061 ORDER BY number"
+rm "$BINARY_FILE_PATH"
+
+# Use Protobuf format to populate the cache for this schema.
+echo "Protobuf:"
+BINARY_FILE_PATH=$(mktemp "$CURDIR/04061_protobuf_cache_with_envelope.XXXXXX.binary")
+$CLICKHOUSE_CLIENT --query "SELECT * FROM squares_04061 ORDER BY number FORMAT Protobuf SETTINGS format_schema = '$FORMAT_SCHEMA'" > "$BINARY_FILE_PATH"
+$CLICKHOUSE_CLIENT --query "CREATE TABLE roundtrip2_04061 AS squares_04061"
+$CLICKHOUSE_CLIENT --query "INSERT INTO roundtrip2_04061 SETTINGS format_schema = '$FORMAT_SCHEMA' FORMAT Protobuf" < "$BINARY_FILE_PATH"
+$CLICKHOUSE_CLIENT --query "SELECT * FROM roundtrip2_04061 ORDER BY number"
+rm "$BINARY_FILE_PATH"
+
+# Use ProtobufList AFTER Protobuf has populated the cache.
+echo "ProtobufList after Protobuf (warm cache):"
+BINARY_FILE_PATH=$(mktemp "$CURDIR/04061_protobuf_cache_with_envelope.XXXXXX.binary")
+$CLICKHOUSE_CLIENT --query "SELECT * FROM squares_04061 ORDER BY number FORMAT ProtobufList SETTINGS format_schema = '$FORMAT_SCHEMA'" > "$BINARY_FILE_PATH"
+$CLICKHOUSE_CLIENT --query "CREATE TABLE roundtrip3_04061 AS squares_04061"
+$CLICKHOUSE_CLIENT --query "INSERT INTO roundtrip3_04061 SETTINGS format_schema = '$FORMAT_SCHEMA' FORMAT ProtobufList" < "$BINARY_FILE_PATH"
+$CLICKHOUSE_CLIENT --query "SELECT * FROM roundtrip3_04061 ORDER BY number"
+rm "$BINARY_FILE_PATH"
+
+$CLICKHOUSE_CLIENT <<EOF
+DROP TABLE squares_04061;
+DROP TABLE roundtrip1_04061;
+DROP TABLE roundtrip2_04061;
+DROP TABLE roundtrip3_04061;
+EOF

--- a/tests/queries/0_stateless/format_schemas/04061_protobuf_cache_with_envelope.proto
+++ b/tests/queries/0_stateless/format_schemas/04061_protobuf_cache_with_envelope.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+// This schema intentionally has NO Envelope message.
+// It is used to test that ProtobufList behaves consistently when also used with Protobuf format.
+
+message NumberAndSquare {
+  uint32 number = 1;
+  uint64 square = 2;
+};

--- a/tests/queries/0_stateless/format_schemas/04061_protobuf_cache_with_envelope_2.proto
+++ b/tests/queries/0_stateless/format_schemas/04061_protobuf_cache_with_envelope_2.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+// This schema intentionally has the same top-level message name as
+// 04061_protobuf_cache_with_envelope.proto to verify that schema caches are
+// isolated per file.
+
+message NumberAndSquare {
+  uint32 number = 1;
+  uint64 square = 2;
+};


### PR DESCRIPTION
This PR fixes a caching issue with protobuf format in which the WithEnvelope is not considered. This leads to misleading broken format parsing when first using FORMAT Protobuf in which both Protobuf and ProtobufList format are able to use the provided message type, however when the cache is reset, ProtobufList attempts to force the Envelope format which can lead to errors when not available. The Envelope specific format is not truly required - any Envelope will work and pointing to the original format is all thats required for the schema.

The secondary fix, allowing fallback from envelope may be undesirable, if so I can remove.
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

Fixes a protobuf cache entry issue and adds fallback to message type if Envelope schema not found

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.208` (included in `26.5` and later)
- Backported to: `26.4.5.137`
<!-- ch-version-info:end -->