### PR TITLE
Fix flaky test_database_iceberg_lakekeeper_catalog port conflict in parallel CI

### DIFF
--- a/tests/integration/compose/docker_compose_iceberg_lakekeeper_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_lakekeeper_catalog.yml
@@ -8,7 +8,7 @@ services:
       - RUST_LOG=info
     command: ["serve"]
     ports:
-      - 8181:8181
+      - "${ICEBERG_REST_CATALOG_PORT}:8181"
     healthcheck:
       test: ["CMD", "/home/nonroot/lakekeeper", "healthcheck"]
       interval: 1s

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1762,8 +1762,7 @@ class ClickHouseCluster:
         file_name = "docker_compose_iceberg_rest_catalog.yml"
         if extra_parameters is not None and extra_parameters["docker_compose_file_name"] != "":
             file_name = extra_parameters["docker_compose_file_name"]
-        if file_name == "docker_compose_iceberg_rest_catalog.yml":
-            env_variables["ICEBERG_REST_CATALOG_PORT"] = str(self.iceberg_rest_catalog_port)
+        env_variables["ICEBERG_REST_CATALOG_PORT"] = str(self.iceberg_rest_catalog_port)
         self.base_cmd.extend(
             [
                 "--file",

--- a/tests/integration/test_database_iceberg_lakekeeper_catalog/test.py
+++ b/tests/integration/test_database_iceberg_lakekeeper_catalog/test.py
@@ -20,15 +20,18 @@ from helpers.cluster import ClickHouseCluster
 from helpers.config_cluster import minio_secret_key, minio_access_key
 from helpers.test_tools import TSV, csv_compare
 
-BASE_URL_LOCAL = "http://localhost:8181/catalog"
 BASE_URL = "http://lakekeeper:8181/catalog"
 CATALOG_NAME = "demo"
 WAREHOUSE_NAME = "demo"
 
+
+def get_lakekeeper_local_url(cluster):
+    return f"http://localhost:{cluster.iceberg_rest_catalog_port}"
+
 DEFAULT_CREATE_TABLE = "CREATE TABLE {}.`{}.{}`\n(\n    `id` Nullable(Float64),\n    `data` Nullable(String)\n)\nENGINE = Iceberg('http://minio:9000/warehouse-rest/data/', 'minio', '[HIDDEN]')\n"
 
 
-def create_warehouse(minio_ip):
+def create_warehouse(cluster, minio_ip):
     minio_endpoint = f"http://{minio_ip}:9000"
 
     warehouse_data = {
@@ -55,7 +58,7 @@ def create_warehouse(minio_ip):
 
     try:
         response = requests.post(
-            "http://localhost:8181/management/v1/warehouse",
+            f"{get_lakekeeper_local_url(cluster)}/management/v1/warehouse",
             headers={"Content-Type": "application/json"},
             json=warehouse_data,
             timeout=30
@@ -79,7 +82,7 @@ def load_catalog_impl(started_cluster):
     return RestCatalog(
         name="my_catalog",
         warehouse=WAREHOUSE_NAME,
-        uri=BASE_URL_LOCAL,
+        uri=f"{get_lakekeeper_local_url(started_cluster)}/catalog",
         token="dummy",
         **{
             "s3.endpoint": s3_endpoint,
@@ -109,7 +112,7 @@ def started_cluster():
         time.sleep(15)
 
         minio_ip = cluster.get_instance_ip('minio')
-        create_warehouse(minio_ip)
+        create_warehouse(cluster, minio_ip)
 
         yield cluster
 


### PR DESCRIPTION
The `test_database_iceberg_lakekeeper_catalog` integration tests fail intermittently in CI with:
```
Error response from daemon: Bind for 0.0.0.0:8181 failed: port is already allocated
```

This happens because `docker_compose_iceberg_lakekeeper_catalog.yml` hardcodes the host port mapping `8181:8181` for the Lakekeeper service. When multiple CI workers (e.g., gw0, gw1) run in parallel on the same host, they compete for the same port.

The fix uses the existing `ICEBERG_REST_CATALOG_PORT` dynamic port allocation from `PortPoolManager`, which was already implemented for the REST catalog compose file but was gated behind a filename check that excluded custom catalog compose files like Lakekeeper.

Changes:
- `cluster.py`: Set `ICEBERG_REST_CATALOG_PORT` for all iceberg catalog compose files, not just the REST one
- `docker_compose_iceberg_lakekeeper_catalog.yml`: Use `${ICEBERG_REST_CATALOG_PORT}:8181` instead of `8181:8181`
- `test.py`: Replace hardcoded `localhost:8181` with dynamic port from `cluster.iceberg_rest_catalog_port`

Verified locally: all 4 Lakekeeper catalog tests pass (test_list_tables, test_select, test_hide_sensitive_info, test_tables_with_same_location). Also verified the existing REST catalog test (test_database_iceberg) still passes.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.323`
<!-- ch-version-info:end -->