### PR TITLE
Fix flaky test 02967_parallel_replicas_joins_and_analyzer

### DIFF
--- a/tests/queries/0_stateless/02967_parallel_replicas_joins_and_analyzer.sql.j2
+++ b/tests/queries/0_stateless/02967_parallel_replicas_joins_and_analyzer.sql.j2
@@ -20,6 +20,7 @@ set enable_parallel_replicas = 2, max_parallel_replicas = 2, cluster_for_paralle
 SET optimize_read_in_order = 1, optimize_sorting_by_input_stream_properties = 1;
 SET query_plan_optimize_join_order_algorithm = 'greedy';
 SET optimize_move_to_prewhere = 1, query_plan_optimize_prewhere = 1;
+SET enable_join_runtime_filters = 1; -- Changes the plan (BuildRuntimeFilter node)
 
 {% for use_global_in in [0, 1] -%}
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- none

### What this PR does

Pin `enable_join_runtime_filters = 1` in the test setup to prevent the CI test randomizer from disabling runtime filters (~5% probability), which removes `BuildRuntimeFilter` nodes from the EXPLAIN output and restructures the join plan, causing a reference mismatch.

### Root cause

The CI test runner randomizes `enable_join_runtime_filters` with a 5% probability of `False` (line 1406 of `tests/clickhouse-test`). When disabled, the query planner omits the `BuildRuntimeFilter` optimization step, restructuring the entire join tree in the EXPLAIN output. Since this test verifies EXPLAIN plans that include `BuildRuntimeFilter`, the output no longer matches the `.reference` file.

**CIDB evidence:** All 36 failures in the last 30 days (across 9+ unrelated PRs and 2 master hits) had `--enable_join_runtime_filters False` in their randomized settings — 100% correlation.

### How the fix works

Adding `SET enable_join_runtime_filters = 1` before `-- { echoOn }` ensures the plan always includes `BuildRuntimeFilter` nodes regardless of CI randomization. The test-level SET takes precedence over CLI settings injected by the runner.

### Verification

- **Deterministic reproduction:** `CLICKHOUSE_CLIENT_OPT="--enable_join_runtime_filters 0"` causes 100% failure rate without the fix
- **Fix validation:** Same injection → 100% pass rate with the fix
- **Stress test:** 50/50 passes with full randomization enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.318`
<!-- ch-version-info:end -->