### PR TITLE
Use shared_mutex for KeeperLogStore to reduce changelog lock contention

### DIFF
--- a/src/Coordination/KeeperLogStore.cpp
+++ b/src/Coordination/KeeperLogStore.cpp
@@ -23,31 +23,32 @@ KeeperLogStore::KeeperLogStore(LogFileSettings log_file_settings, FlushSettings 
 
 uint64_t KeeperLogStore::start_index() const
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    ProfiledSharedLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.getStartIndex();
 }
 
 void KeeperLogStore::init(uint64_t last_commited_log_index, uint64_t logs_to_keep)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    ProfiledExclusiveLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     changelog.readChangelogAndInitWriter(last_commited_log_index, logs_to_keep);
 }
 
 uint64_t KeeperLogStore::next_slot() const
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    ProfiledSharedLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.getNextEntryIndex();
 }
 
 nuraft::ptr<nuraft::log_entry> KeeperLogStore::last_entry() const
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    /// Exclusive: getLastEntry -> getEntry may mutate LogEntryStorage::first_log_entry.
+    ProfiledExclusiveLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.getLastEntry();
 }
 
 uint64_t KeeperLogStore::append(nuraft::ptr<nuraft::log_entry> & entry)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    ProfiledExclusiveLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     uint64_t idx = changelog.getNextEntryIndex();
     changelog.appendEntry(idx, entry);
     return idx;
@@ -56,93 +57,95 @@ uint64_t KeeperLogStore::append(nuraft::ptr<nuraft::log_entry> & entry)
 
 void KeeperLogStore::write_at(uint64_t index, nuraft::ptr<nuraft::log_entry> & entry)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    ProfiledExclusiveLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     changelog.writeAt(index, entry);
 }
 
 nuraft::ptr<std::vector<nuraft::ptr<nuraft::log_entry>>> KeeperLogStore::log_entries(uint64_t start, uint64_t end)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    ProfiledSharedLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.getLogEntriesBetween(start, end);
 }
 
 nuraft::ptr<std::vector<nuraft::ptr<nuraft::log_entry>>>
 KeeperLogStore::log_entries_ext(uint64_t start, uint64_t end, int64_t batch_size_hint_in_bytes)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    ProfiledSharedLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.getLogEntriesBetween(start, end, batch_size_hint_in_bytes);
 }
 
 nuraft::ptr<nuraft::log_entry> KeeperLogStore::entry_at(uint64_t index)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    /// Exclusive: entryAt -> getEntry may mutate LogEntryStorage::first_log_entry.
+    ProfiledExclusiveLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.entryAt(index);
 }
 
 bool KeeperLogStore::is_conf(uint64_t index)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    ProfiledSharedLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.isConfigLog(index);
 }
 
 uint64_t KeeperLogStore::term_at(uint64_t index)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    ProfiledSharedLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.termAt(index);
 }
 
 nuraft::ptr<nuraft::buffer> KeeperLogStore::pack(uint64_t index, int32_t cnt)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    /// Exclusive: serializeEntriesToBuffer -> getEntry may mutate LogEntryStorage::first_log_entry.
+    ProfiledExclusiveLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.serializeEntriesToBuffer(index, cnt);
 }
 
 bool KeeperLogStore::compact(uint64_t last_log_index)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    ProfiledExclusiveLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     changelog.compact(last_log_index);
     return true;
 }
 
 bool KeeperLogStore::flush()
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    ProfiledExclusiveLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.flush();
 }
 
 void KeeperLogStore::apply_pack(uint64_t index, nuraft::buffer & pack)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    ProfiledExclusiveLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     changelog.applyEntriesFromBuffer(index, pack);
 }
 
 uint64_t KeeperLogStore::size() const
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    ProfiledSharedLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.size();
 }
 
 void KeeperLogStore::end_of_append_batch(uint64_t /*start_index*/, uint64_t /*count*/)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    ProfiledExclusiveLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     changelog.flushAsync();
 }
 
 nuraft::ptr<nuraft::log_entry> KeeperLogStore::getLatestConfigChange() const
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    ProfiledSharedLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.getLatestConfigChange();
 }
 
 void KeeperLogStore::shutdownChangelog()
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    ProfiledExclusiveLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     changelog.shutdown();
 }
 
 bool KeeperLogStore::flushChangelogAndShutdown()
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    ProfiledExclusiveLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     if (changelog.isInitialized())
         changelog.flush();
     changelog.shutdown();
@@ -151,19 +154,19 @@ bool KeeperLogStore::flushChangelogAndShutdown()
 
 uint64_t KeeperLogStore::last_durable_index()
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    ProfiledSharedLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.lastDurableIndex();
 }
 
 void KeeperLogStore::setRaftServer(const nuraft::ptr<nuraft::raft_server> & raft_server)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    ProfiledExclusiveLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     changelog.setRaftServer(raft_server);
 }
 
 void KeeperLogStore::getKeeperLogInfo(KeeperLogInfo & log_info) const
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
+    ProfiledSharedLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     changelog.getKeeperLogInfo(log_info);
 }
 

--- a/src/Coordination/KeeperLogStore.h
+++ b/src/Coordination/KeeperLogStore.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <libnuraft/log_store.hxx>
-#include <mutex>
 #include <Core/Types.h>
+#include <Common/SharedMutex.h>
 #include <Coordination/Changelog.h>
 #include <Coordination/KeeperContext.h>
 #include <Coordination/Keeper4LWInfo.h>
@@ -81,7 +81,7 @@ public:
     void getKeeperLogInfo(KeeperLogInfo & log_info) const;
 
 private:
-    mutable std::mutex changelog_lock;
+    mutable SharedMutex changelog_lock;
     LoggerPtr log;
     Changelog changelog TSA_GUARDED_BY(changelog_lock);
 };


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Change `changelog_lock` from `std::mutex` to `SharedMutex` with `ProfiledSharedLock` for read-only methods and `ProfiledExclusiveLock` for mutating methods.

### Documentation entry for user-facing changes
Profiling Keeper lock contention with bpftrace (tracing mutex acquisitions longer than 20ms) revealed that `KeeperLogStore::next_slot` (a read-only method returning `max_log_id + 1`) was contending with `KeeperLogStore::append` on the same exclusive `std::mutex`, with contention events reaching 30-33ms.

<details>
  <summary>Callstacks recorded by bpftrace (contention events >20ms)</summary>
  
`next_slot` blocked by `append`:
```
[contended 33 ms] tid=2849559 addr=0x71c6ed269e20
    std::__1::mutex::lock()
    DB::ProfiledMutexLock::ProfiledMutexLock(...)
    DB::KeeperLogStore::next_slot() const
    nuraft::raft_server::snapshot_and_compact(unsigned long, bool)
    nuraft::raft_server::commit_in_bg_exec(unsigned long, bool)
    nuraft::raft_server::commit_in_bg()
    DB::KeeperServer::KeeperRaftServer::commit_in_bg()
```

`append` blocked by `next_slot`:
```
[contended 33 ms] tid=2849534 addr=0x71c6ed269e20
    std::__1::mutex::lock()
    DB::ProfiledMutexLock::ProfiledMutexLock(...)
    DB::KeeperLogStore::append(std::__1::shared_ptr<nuraft::log_entry>&)
    nuraft::raft_server::store_log_entry(...)
    nuraft::raft_server::handle_cli_req(...)
    nuraft::raft_server::handle_cli_req_prelock(...)
    nuraft::raft_server::process_req(...)
    nuraft::rpc_session::read_complete(...)
```

Both contend on the same lock address (`0x71c6ed269e20`), which is the `KeeperLogStore::changelog_lock` mutex.
</details>

Since `next_slot` and other read-only methods only read changelog state, they can safely use shared locks. This change replaces the `std::mutex` with `SharedMutex` and uses `ProfiledSharedLock` for read-only methods, `ProfiledExclusiveLock` for mutating methods.

Aggregate `KeeperChangelogLockWaitMicroseconds` drops from ~3500μs/s to ~400μs/s in steady state (~9x reduction).

<details>
  <summary>Measured results (aggregate `KeeperChangelogLockWaitMicroseconds` and `KeeperChangelogLockHoldMicroseconds` per second on the leader):</summary>

Before:
```
--- 10:28:40 ---
  KeeperChangelogLockWaitMicroseconds                      3273 /s
  KeeperChangelogLockHoldMicroseconds                      7645 /s
  KeeperCommits                                           12271 /s
  FileSync                                                  258 /s
  KeeperRequestTotal                                      48886 /s
--- 10:28:41 ---
  KeeperChangelogLockWaitMicroseconds                      3819 /s
  KeeperChangelogLockHoldMicroseconds                      7427 /s
  KeeperCommits                                           12204 /s
  FileSync                                                  263 /s
  KeeperRequestTotal                                      48574 /s
--- 10:28:42 ---
  KeeperChangelogLockWaitMicroseconds                     38107 /s
  KeeperChangelogLockHoldMicroseconds                     42093 /s
  KeeperCommits                                           11382 /s
  FileSync                                                  242 /s
  KeeperRequestTotal                                      45508 /s
```

After:
```
--- 10:25:48 ---
  KeeperChangelogLockWaitMicroseconds                       526 /s
  KeeperChangelogLockHoldMicroseconds                      3423 /s
  KeeperCommits                                           11948 /s
  FileSync                                                  376 /s
  KeeperRequestTotal                                      47942 /s
--- 10:25:49 ---
  KeeperChangelogLockWaitMicroseconds                       329 /s
  KeeperChangelogLockHoldMicroseconds                      2982 /s
  KeeperCommits                                           10886 /s
  FileSync                                                  336 /s
  KeeperRequestTotal                                      43518 /s
--- 10:25:50 ---
  KeeperChangelogLockWaitMicroseconds                     77607 /s
  KeeperChangelogLockHoldMicroseconds                     41785 /s
  KeeperCommits                                           10446 /s
  FileSync                                                  325 /s
  KeeperRequestTotal                                      41210 /s
```
</details>

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.718`
<!-- ch-version-info:end -->