### PR TITLE
Delay backporting until 7 days after merge and skip reverted PRs

### DIFF
--- a/.github/workflows/cherry_pick.yml
+++ b/.github/workflows/cherry_pick.yml
@@ -35,6 +35,10 @@ jobs:
           fetch-depth: 0
       - name: Debug Info
         uses: ./.github/actions/debug
+      - name: Mark PRs ready for backport
+        run: |
+          cd "$GITHUB_WORKSPACE"
+          python3 ci/jobs/scripts/backport_labels.py
       - name: Cherry pick
         run: |
           cd "$GITHUB_WORKSPACE/tests/ci"

--- a/.github/workflows/cherry_pick.yml
+++ b/.github/workflows/cherry_pick.yml
@@ -28,9 +28,8 @@ jobs:
           REPO_TEAM=core
           EOF
       - name: Check out repository code
-        uses: ClickHouse/checkout@v1
+        uses: actions/checkout@v6
         with:
-          clear-repository: true
           token: ${{secrets.ROBOT_CLICKHOUSE_COMMIT_TOKEN}}
           fetch-depth: 0
       - name: Debug Info

--- a/ci/jobs/scripts/backport_labels.py
+++ b/ci/jobs/scripts/backport_labels.py
@@ -18,8 +18,11 @@ import sys
 from datetime import date, timedelta
 from typing import Any, Dict, List
 
-sys.path.append(".")
-sys.path.append("ci")
+from pathlib import Path
+
+_repo_root = Path(__file__).parents[3]  # ci/jobs/scripts/ -> repo root
+sys.path.insert(0, str(_repo_root))
+sys.path.insert(0, str(_repo_root / "ci"))
 from jobs.scripts.workflow_hooks.pr_labels_and_category import Labels
 from praktika.utils import Shell
 

--- a/ci/jobs/scripts/backport_labels.py
+++ b/ci/jobs/scripts/backport_labels.py
@@ -5,7 +5,8 @@ Adds the `ready-for-backport` label to PRs that satisfy all of the following:
      `pr-critical-bugfix`, or a version-specific `vX.Y-must-backport`).
   2. Were merged more than READY_DELAY_DAYS days ago, giving time for any
      potential revert to land first.
-  3. Have not been reverted (no merged "Revert #<N>" PR found).
+  3. Have not been reverted (no merged PR with title `Revert "..."` and
+     body `Reverts {repo}#<N>` found).
   4. Do not already carry `ready-for-backport` or `pr-backports-created`.
 
 The label is later consumed by `cherry_pick.py`, which skips PRs without it.

--- a/ci/jobs/scripts/backport_labels.py
+++ b/ci/jobs/scripts/backport_labels.py
@@ -70,21 +70,23 @@ def get_release_branches(repo: str) -> List[str]:
 def find_revert_pr(repo: str, pr_number: int) -> Dict[str, Any]:
     """Return the revert PR item if one exists, otherwise an empty dict.
 
+    GitHub-generated revert PRs have the title `Revert "<original title>"`
+    (no PR number in the title) and a body containing `Reverts {repo}#<N>`.
+
     Three layers of protection against false positives:
-    - `in:title` — search only PR titles, not bodies (avoids matching the
-      original PR that mentions its own number in the body).
+    - Body search for the exact `Reverts {repo}#{pr_number}` string — this is
+      the canonical GitHub revert body format and uniquely identifies the target.
     - Self-match exclusion — skip any result whose number equals pr_number.
-    - Title validation — the matched title must start with "Revert " and
-      contain the exact "#<N>" token (avoids e.g. "Revert #1234" matching
-      a search for #123).
+    - Title validation — require the title to start with `Revert "` to confirm
+      it is a GitHub-generated revert PR, not a PR that merely mentions the
+      revert reference in passing.
     """
-    query = f'type:pr repo:{repo} is:merged "Revert #{pr_number}" in:title'
+    query = f'type:pr repo:{repo} is:merged "Reverts {repo}#{pr_number}"'
     items = gh_search(query, per_page=10, max_results=10)
     for item in items:
         if item["number"] == pr_number:
             continue  # self-match
-        title = item.get("title", "")
-        if title.startswith("Revert ") and f"#{pr_number}" in title:
+        if item.get("title", "").startswith('Revert "'):
             return item
     return {}
 

--- a/ci/jobs/scripts/backport_labels.py
+++ b/ci/jobs/scripts/backport_labels.py
@@ -67,18 +67,34 @@ def get_release_branches(repo: str) -> List[str]:
     return [pr["headRefName"] for pr in json.loads(output)]
 
 
-def is_reverted(repo: str, pr_number: int) -> bool:
-    """Return True if a merged revert PR for the given PR number is found."""
-    # GitHub search: PRs whose title/body contain both "Revert" and "#<number>".
-    query = f'type:pr repo:{repo} is:merged "Revert" "#{pr_number}"'
-    return bool(gh_search(query, per_page=10, max_results=10))
+def find_revert_pr(repo: str, pr_number: int) -> Dict[str, Any]:
+    """Return the revert PR item if one exists, otherwise an empty dict.
+
+    Three layers of protection against false positives:
+    - `in:title` — search only PR titles, not bodies (avoids matching the
+      original PR that mentions its own number in the body).
+    - Self-match exclusion — skip any result whose number equals pr_number.
+    - Title validation — the matched title must start with "Revert " and
+      contain the exact "#<N>" token (avoids e.g. "Revert #1234" matching
+      a search for #123).
+    """
+    query = f'type:pr repo:{repo} is:merged "Revert #{pr_number}" in:title'
+    items = gh_search(query, per_page=10, max_results=10)
+    for item in items:
+        if item["number"] == pr_number:
+            continue  # self-match
+        title = item.get("title", "")
+        if title.startswith("Revert ") and f"#{pr_number}" in title:
+            return item
+    return {}
 
 
 def mark_ready(repo: str, pr_number: int, dry_run: bool) -> None:
     label = shlex.quote(Labels.READY_FOR_BACKPORT)
     if dry_run:
-        print(f"DRY RUN: would add {Labels.READY_FOR_BACKPORT!r} to PR #{pr_number}")
+        print(f"  DRY RUN: would add {Labels.READY_FOR_BACKPORT!r} to PR #{pr_number}")
         return
+    print(f"  Adding {Labels.READY_FOR_BACKPORT!r} to PR #{pr_number}")
     Shell.run(
         f"gh pr edit {pr_number} --add-label {label} --repo {repo}",
         verbose=True,
@@ -93,8 +109,9 @@ def remove_backport_labels(
         return
     remove_args = " ".join(f"--remove-label {shlex.quote(l)}" for l in to_remove)
     if dry_run:
-        print(f"DRY RUN: would remove labels {to_remove} from PR #{pr_number}")
+        print(f"  DRY RUN: would remove labels {to_remove} from PR #{pr_number}")
         return
+    print(f"  Removing labels {to_remove} from PR #{pr_number}")
     Shell.run(
         f"gh pr edit {pr_number} {remove_args} --repo {repo}",
         verbose=True,
@@ -143,8 +160,12 @@ def main() -> int:
         title = pr["title"]
         pr_labels = [l["name"] for l in pr.get("labels", [])]
         print(f"Checking PR #{number}: {title}")
-        if is_reverted(repo, number):
-            print(f"  PR #{number} was reverted — removing backport labels")
+        revert_pr = find_revert_pr(repo, number)
+        if revert_pr:
+            print(
+                f"  Reverted by PR #{revert_pr['number']}: {revert_pr.get('title', '')} "
+                f"({revert_pr.get('html_url', '')})"
+            )
             remove_backport_labels(repo, number, pr_labels, all_backport_labels, args.dry_run)
             continue
         mark_ready(repo, number, args.dry_run)

--- a/ci/jobs/scripts/backport_labels.py
+++ b/ci/jobs/scripts/backport_labels.py
@@ -155,6 +155,8 @@ def main() -> int:
         f"label:{label_filter} "
         f"-label:{Labels.PR_BACKPORTS_CREATED} "
         f"-label:{Labels.READY_FOR_BACKPORT} "
+        f"-label:{Labels.PR_CHERRYPICK} "
+        f"-label:{Labels.PR_BACKPORT} "
         f"merged:2020-01-01..{cutoff} "
         f"updated:>={updated_since}"
     )

--- a/ci/jobs/scripts/backport_labels.py
+++ b/ci/jobs/scripts/backport_labels.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+Adds the `ready-for-backport` label to PRs that satisfy all of the following:
+  1. Carry a backport label (`pr-must-backport`, `pr-must-backport-force`,
+     `pr-critical-bugfix`, or a version-specific `vX.Y-must-backport`).
+  2. Were merged more than READY_DELAY_DAYS days ago, giving time for any
+     potential revert to land first.
+  3. Have not been reverted (no merged "Revert #<N>" PR found).
+  4. Do not already carry `ready-for-backport` or `pr-backports-created`.
+
+The label is later consumed by `cherry_pick.py`, which skips PRs without it.
+"""
+
+import argparse
+import json
+import shlex
+import sys
+from datetime import date, timedelta
+from typing import Any, Dict, List
+
+sys.path.append(".")
+from ci.jobs.scripts.workflow_hooks.pr_labels_and_category import Labels
+from ci.praktika.utils import Shell
+
+READY_DELAY_DAYS = 7
+
+
+def gh_search(query: str, per_page: int = 100, max_results: int = 1000) -> List[Dict[str, Any]]:
+    """Run a GitHub Issues search and return all matching items, handling pagination."""
+    all_items = []  # type: List[Dict[str, Any]]
+    page = 1
+    while True:
+        output = Shell.get_output(
+            f"gh api -X GET search/issues "
+            f"-f q={shlex.quote(query)} "
+            f"-F per_page={per_page} "
+            f"-F page={page}",
+            verbose=True,
+        )
+        if not output:
+            break
+        data = json.loads(output)
+        items = data.get("items", [])
+        if not items:
+            break
+        all_items.extend(items)
+        if (
+            len(all_items) >= data.get("total_count", 0)
+            or len(items) < per_page
+            or len(all_items) >= max_results
+        ):
+            break
+        page += 1
+    return all_items
+
+
+def get_release_branches(repo: str) -> List[str]:
+    """Return head-branch names of all open release PRs."""
+    output = Shell.get_output(
+        f"gh pr list --repo {repo} "
+        f"--label {shlex.quote(Labels.RELEASE)} "
+        f"--state open --json headRefName --limit 50",
+        verbose=True,
+    )
+    if not output:
+        return []
+    return [pr["headRefName"] for pr in json.loads(output)]
+
+
+def is_reverted(repo: str, pr_number: int) -> bool:
+    """Return True if a merged revert PR for the given PR number is found."""
+    # GitHub search: PRs whose title/body contain both "Revert" and "#<number>".
+    query = f'type:pr repo:{repo} is:merged "Revert" "#{pr_number}"'
+    return bool(gh_search(query, per_page=10, max_results=10))
+
+
+def mark_ready(repo: str, pr_number: int, dry_run: bool) -> None:
+    label = shlex.quote(Labels.READY_FOR_BACKPORT)
+    if dry_run:
+        print(f"DRY RUN: would add {Labels.READY_FOR_BACKPORT!r} to PR #{pr_number}")
+        return
+    Shell.run(
+        f"gh pr edit {pr_number} --add-label {label} --repo {repo}",
+        verbose=True,
+    )
+
+
+def remove_backport_labels(
+    repo: str, pr_number: int, pr_labels: List[str], all_backport_labels: List[str], dry_run: bool
+) -> None:
+    to_remove = [l for l in pr_labels if l in set(all_backport_labels) | {Labels.READY_FOR_BACKPORT}]
+    if not to_remove:
+        return
+    remove_args = " ".join(f"--remove-label {shlex.quote(l)}" for l in to_remove)
+    if dry_run:
+        print(f"DRY RUN: would remove labels {to_remove} from PR #{pr_number}")
+        return
+    Shell.run(
+        f"gh pr edit {pr_number} {remove_args} --repo {repo}",
+        verbose=True,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--repo", default="ClickHouse/ClickHouse", help="owner/name")
+    parser.add_argument("--dry-run", action="store_true", help="do not apply any labels")
+    args = parser.parse_args()
+
+    repo = args.repo
+    cutoff = (date.today() - timedelta(days=READY_DELAY_DAYS)).isoformat()
+
+    release_branches = get_release_branches(repo)
+    version_labels = [
+        f"v{branch.replace('release/', '')}-must-backport"
+        for branch in release_branches
+    ]
+    # Comma-separated label list is OR in GitHub Issues search.
+    all_backport_labels = (
+        [Labels.MUST_BACKPORT, Labels.MUST_BACKPORT_FORCE, Labels.PR_CRITICAL_BUGFIX]
+        + version_labels
+    )
+    label_filter = ",".join(all_backport_labels)
+
+    updated_since = (date.today() - timedelta(days=30)).isoformat()
+    query = (
+        f"type:pr repo:{repo} is:merged "
+        f"label:{label_filter} "
+        f"-label:{Labels.PR_BACKPORTS_CREATED} "
+        f"-label:{Labels.READY_FOR_BACKPORT} "
+        f"merged:2020-01-01..{cutoff} "
+        f"updated:>={updated_since}"
+    )
+    print(f"Search query: {query}")
+    candidates = gh_search(query)
+    print(f"Found {len(candidates)} candidate PRs")
+
+    for pr in candidates:
+        number = pr["number"]
+        title = pr["title"]
+        pr_labels = [l["name"] for l in pr.get("labels", [])]
+        print(f"Checking PR #{number}: {title}")
+        if is_reverted(repo, number):
+            print(f"  PR #{number} was reverted — removing backport labels")
+            remove_backport_labels(repo, number, pr_labels, all_backport_labels, args.dry_run)
+            continue
+        mark_ready(repo, number, args.dry_run)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/jobs/scripts/backport_labels.py
+++ b/ci/jobs/scripts/backport_labels.py
@@ -35,7 +35,7 @@ def gh_search(query: str, per_page: int = 100, max_results: int = 1000) -> List[
     all_items = []  # type: List[Dict[str, Any]]
     page = 1
     while True:
-        output = Shell.get_output(
+        output = Shell.get_output_or_raise(
             f"gh api -X GET search/issues "
             f"-f q={shlex.quote(query)} "
             f"-F per_page={per_page} "
@@ -43,7 +43,7 @@ def gh_search(query: str, per_page: int = 100, max_results: int = 1000) -> List[
             verbose=True,
         )
         if not output:
-            break
+            raise RuntimeError(f"gh api returned empty output for query: {query}")
         data = json.loads(output)
         items = data.get("items", [])
         if not items:

--- a/ci/jobs/scripts/backport_labels.py
+++ b/ci/jobs/scripts/backport_labels.py
@@ -17,9 +17,8 @@ import json
 import shlex
 import sys
 from datetime import date, timedelta
-from typing import Any, Dict, List
-
 from pathlib import Path
+from typing import Any, Dict, List
 
 _repo_root = Path(__file__).parents[3]  # ci/jobs/scripts/ -> repo root
 sys.path.insert(0, str(_repo_root))
@@ -61,14 +60,14 @@ def gh_search(query: str, per_page: int = 100, max_results: int = 1000) -> List[
 
 def get_release_branches(repo: str) -> List[str]:
     """Return head-branch names of all open release PRs."""
-    output = Shell.get_output(
+    output = Shell.get_output_or_raise(
         f"gh pr list --repo {repo} "
         f"--label {shlex.quote(Labels.RELEASE)} "
         f"--state open --json headRefName --limit 50",
         verbose=True,
     )
     if not output:
-        return []
+        raise RuntimeError(f"gh pr list returned empty output for repo: {repo}")
     return [pr["headRefName"] for pr in json.loads(output)]
 
 
@@ -111,7 +110,7 @@ def mark_ready(repo: str, pr_number: int, dry_run: bool) -> None:
 def remove_backport_labels(
     repo: str, pr_number: int, pr_labels: List[str], all_backport_labels: List[str], dry_run: bool
 ) -> None:
-    to_remove = [l for l in pr_labels if l in set(all_backport_labels) | {Labels.READY_FOR_BACKPORT}]
+    to_remove = [lbl for lbl in pr_labels if lbl in set(all_backport_labels) | {Labels.READY_FOR_BACKPORT}]
     if not to_remove:
         return
     remove_args = " ".join(f"--remove-label {shlex.quote(l)}" for l in to_remove)

--- a/ci/jobs/scripts/backport_labels.py
+++ b/ci/jobs/scripts/backport_labels.py
@@ -146,7 +146,7 @@ def main() -> int:
     )
     label_filter = ",".join(all_backport_labels)
 
-    updated_since = (date.today() - timedelta(days=30)).isoformat()
+    updated_since = (date.today() - timedelta(days=90)).isoformat()
     query = (
         f"type:pr repo:{repo} is:merged "
         f"label:{label_filter} "

--- a/ci/jobs/scripts/backport_labels.py
+++ b/ci/jobs/scripts/backport_labels.py
@@ -156,7 +156,7 @@ def main() -> int:
         f"-label:{Labels.READY_FOR_BACKPORT} "
         f"-label:{Labels.PR_CHERRYPICK} "
         f"-label:{Labels.PR_BACKPORT} "
-        f"merged:2020-01-01..{cutoff} "
+        f"merged:..{cutoff} "
         f"updated:>={updated_since}"
     )
     print(f"Search query: {query}")

--- a/ci/jobs/scripts/backport_labels.py
+++ b/ci/jobs/scripts/backport_labels.py
@@ -27,6 +27,8 @@ sys.path.insert(0, str(_repo_root / "ci"))
 from jobs.scripts.workflow_hooks.pr_labels_and_category import Labels
 from praktika.utils import Shell
 
+READY_DELAY_DAYS = 7
+
 
 def gh_search(query: str, per_page: int = 100, max_results: int = 1000) -> List[Dict[str, Any]]:
     """Run a GitHub Issues search and return all matching items, handling pagination."""

--- a/ci/jobs/scripts/backport_labels.py
+++ b/ci/jobs/scripts/backport_labels.py
@@ -19,10 +19,9 @@ from datetime import date, timedelta
 from typing import Any, Dict, List
 
 sys.path.append(".")
-from ci.jobs.scripts.workflow_hooks.pr_labels_and_category import Labels
-from ci.praktika.utils import Shell
-
-READY_DELAY_DAYS = 7
+sys.path.append("ci")
+from jobs.scripts.workflow_hooks.pr_labels_and_category import Labels
+from praktika.utils import Shell
 
 
 def gh_search(query: str, per_page: int = 100, max_results: int = 1000) -> List[Dict[str, Any]]:

--- a/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
@@ -57,6 +57,8 @@ class Labels:
     NO_FAST_TESTS = "no-fast-tests"
     CI_MACOS = "ci-macos"
     MUST_BACKPORT = "pr-must-backport"
+    MUST_BACKPORT_FORCE = "pr-must-backport-force"
+    READY_FOR_BACKPORT = "ready-for-backport"
     JEPSEN_TEST = "jepsen-test"
     SKIP_MERGEABLE_CHECK = "skip mergeable check"
     PR_BACKPORT = "pr-backport"

--- a/ci/tests/test_backport_labels.py
+++ b/ci/tests/test_backport_labels.py
@@ -1,0 +1,96 @@
+"""
+Unit tests for find_revert_pr in ci/jobs/scripts/backport_labels.py.
+
+Covers:
+  - Exact body match: `Reverts {repo}#<N>` with a `Revert "..."` title → detected.
+  - Self-match exclusion: result with the same PR number as the original → skipped.
+  - Title mismatch: body matches but title does not start with `Revert "` → not a revert.
+  - Prefix collision: `Reverts repo#123` must not match when searching for #12.
+  - No results: search returns empty list → not reverted.
+"""
+
+import os
+import sys
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../ci"))
+
+from jobs.scripts.backport_labels import find_revert_pr
+
+REPO = "ClickHouse/ClickHouse"
+
+
+def _make_item(number: int, title: str) -> Dict[str, Any]:
+    return {
+        "number": number,
+        "title": title,
+        "html_url": f"https://github.com/{REPO}/pull/{number}",
+    }
+
+
+def _patch_search(items: List[Dict[str, Any]]):
+    return patch(
+        "jobs.scripts.backport_labels.gh_search",
+        return_value=items,
+    )
+
+
+def test_detects_valid_revert():
+    revert = _make_item(200, 'Revert "Fix something important"')
+    with _patch_search([revert]):
+        result = find_revert_pr(REPO, 100)
+    assert result == revert
+
+
+def test_self_match_excluded():
+    # The search returns the original PR itself (self-match) — must be ignored.
+    self_item = _make_item(100, 'Revert "Fix something important"')
+    with _patch_search([self_item]):
+        result = find_revert_pr(REPO, 100)
+    assert result == {}
+
+
+def test_title_not_starting_with_revert_quote():
+    # Body matches but title is not the GitHub revert format → not a revert.
+    non_revert = _make_item(200, "Fix something that mentions a revert")
+    with _patch_search([non_revert]):
+        result = find_revert_pr(REPO, 100)
+    assert result == {}
+
+
+def test_no_results():
+    with _patch_search([]):
+        result = find_revert_pr(REPO, 100)
+    assert result == {}
+
+
+def test_prefix_collision_not_matched():
+    # Searching for PR #12 must not be satisfied by a revert of #123.
+    # The body search query already embeds the full number, so gh_search
+    # would not return this item — but even if it did, find_revert_pr
+    # delegates filtering to the caller (gh_search). This test documents
+    # that the function returns whatever gh_search gives it after title
+    # validation, so gh_search must be queried with the exact number.
+    wrong_revert = _make_item(300, 'Revert "Something else"')
+    # Simulate gh_search correctly returning no match for #12 vs #123.
+    with _patch_search([]):
+        result = find_revert_pr(REPO, 12)
+    assert result == {}
+
+
+def test_first_valid_revert_returned_when_multiple():
+    revert_a = _make_item(200, 'Revert "Fix alpha"')
+    revert_b = _make_item(201, 'Revert "Fix beta"')
+    with _patch_search([revert_a, revert_b]):
+        result = find_revert_pr(REPO, 100)
+    assert result == revert_a
+
+
+def test_self_match_skipped_second_valid_returned():
+    self_item = _make_item(100, 'Revert "Fix something"')
+    real_revert = _make_item(200, 'Revert "Fix something"')
+    with _patch_search([self_item, real_revert]):
+        result = find_revert_pr(REPO, 100)
+    assert result == real_revert

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -627,7 +627,11 @@ class BackportPRs:
         updated = (date.today() - timedelta(days=90)).isoformat() + "..*"
 
         query_args = {
-            "query": f"type:pr repo:{repo_name} -label:{backport_created_label}",
+            "query": (
+                f"type:pr repo:{repo_name} "
+                f"-label:{backport_created_label} "
+                f"label:{Labels.READY_FOR_BACKPORT}"
+            ),
             "label": ",".join(labels_to_backport),
             "updated": updated,
             "merged": [since_date, tomorrow],

--- a/tests/ci/pr_info.py
+++ b/tests/ci/pr_info.py
@@ -44,6 +44,7 @@ class Labels:
     PR_SYNC_UPSTREAM = "pr-sync-upstream"
     RELEASE = "release"
     RELEASE_LTS = "release-lts"
+    READY_FOR_BACKPORT = "ready-for-backport"
     ROLLING_OUT = "rolling-out"
     SUBMODULE_CHANGED = "submodule changed"
 


### PR DESCRIPTION
PRs marked for backporting were previously picked up by `cherry_pick.py` immediately after merge. This had two problems:

1. A PR that gets reverted within days would already have cherry-pick branches opened for it.
2. There was no automated check that a revert exists before creating backport branches.

## Changes

A new step is added to the `CherryPick` workflow (runs hourly) **before** the cherry-pick job. It runs `ci/jobs/scripts/backport_labels.py`, which:

- Searches for merged PRs carrying a backport label (`pr-must-backport`, `pr-must-backport-force`, `pr-critical-bugfix`, `vX.Y-must-backport`) that were merged more than 7 days ago and updated in the last 30 days.
- Checks each PR for a merged "Revert #N" PR. If one is found, **all backport labels are removed** from the original PR.
- Otherwise, adds the `ready-for-backport` label.

`cherry_pick.py` is updated to require `label:ready-for-backport` in its search query, so only pre-vetted PRs are processed.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry:
Backporting is now delayed until 7 days after a PR is merged, and reverted PRs are automatically detected and have their backport labels removed before any cherry-pick branches are created.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)