### PR TITLE
tests: better fix for 03706_statistics_preserve_checksums_on_mutations

### DIFF
--- a/tests/queries/0_stateless/03706_statistics_preserve_checksums_on_mutations.sh
+++ b/tests/queries/0_stateless/03706_statistics_preserve_checksums_on_mutations.sh
@@ -14,11 +14,8 @@ create table mt (key Int, value String) engine=MergeTree() order by key settings
   min_bytes_for_wide_part=0,
   -- otherwise sparse info will be different, since for INSERTs the sparse ratio is calculated for the whole block, while for mutations for each granula (FIXME?)
   ratio_of_defaults_for_sparse_serialization=1,
-  -- Pin serialization_info_version to 'basic': with 'with_types' the INSERT and mutation
-  -- paths produce different serialization.json content (the mutation always uses the table's
-  -- stored settings while the INSERT path may produce different serialization info metadata),
-  -- causing checksum mismatches that are not actual data corruption.
-  serialization_info_version='basic',
+  map_serialization_version='basic',
+  map_serialization_version_for_zero_level_parts='basic',
   -- This uncovers the bug
   auto_statistics_types='uniq,minmax,countmin,tdigest'
 ;


### PR DESCRIPTION
The previous bot attempt (https://github.com/ClickHouse/ClickHouse/pull/100772) was to set serialization_info_version='basic', while this is OK, it is not transparent what was the problem.

Let's instead set map_serialization_version='basic', map_serialization_version_for_zero_level_parts='basic', since those was causes the difference:

    File: .server/data/default/mt/all_1_1_0_2/serialization.json
    {"columns":[],"propagate_types_serialization_versions_to_nested_types":true,"types_serialization_versions":{"nullable":1,"string":0},"version":1}

    File: .server/data/default/mt/all_1_1_0/serialization.json
    {"columns":[],"propagate_types_serialization_versions_to_nested_types":true,"types_serialization_versions":{"map":1,"nullable":1,"string":0},"version":1}

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.326`
<!-- ch-version-info:end -->