### PR TITLE
Deepen return type validation for function results

### DIFF
--- a/src/Analyzer/Resolve/resolveFunction.cpp
+++ b/src/Analyzer/Resolve/resolveFunction.cpp
@@ -28,6 +28,7 @@
 #include <DataTypes/DataTypeSet.h>
 #include <DataTypes/DataTypeTuple.h>
 #include <Functions/exists.h>
+#include <Columns/validateColumnType.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ExternalDictionariesLoader.h>
 #include <Interpreters/misc.h>
@@ -1551,13 +1552,13 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
                 column = function_base->getConstantResultForNonConstArguments(argument_columns, result_type);
             }
 
-            if (column && column->getDataType() != result_type->getColumnType())
+            if (column && !columnMatchesType(*column, *result_type))
                 throw Exception(
                     ErrorCodes::LOGICAL_ERROR,
                     "Unexpected return type from {}. Expected {}. Got {}",
                     function->getName(),
-                    result_type->getColumnType(),
-                    column->getDataType());
+                    result_type->getName(),
+                    column->getName());
 
             const bool is_deterministic = all_arguments_are_deterministic && function->isDeterministic();
 

--- a/src/Columns/ColumnFunction.cpp
+++ b/src/Columns/ColumnFunction.cpp
@@ -1,6 +1,7 @@
 #include <Interpreters/ExpressionActions.h>
 #include <Columns/ColumnFunction.h>
 #include <Columns/ColumnsCommon.h>
+#include <Columns/validateColumnType.h>
 #include <Common/PODArray.h>
 #include <Common/SipHash.h>
 #include <Common/ProfileEvents.h>
@@ -409,13 +410,13 @@ ColumnWithTypeAndName ColumnFunction::reduce() const
         ProfileEvents::increment(ProfileEvents::CompiledFunctionExecute);
 
     res.column = function->execute(columns, res.type, elements_size, /* dry_run = */ false);
-    if (res.column->getDataType() != res.type->getColumnType())
+    if (!columnMatchesType(*res.column, *res.type))
         throw Exception(
             ErrorCodes::LOGICAL_ERROR,
             "Unexpected return type from {}. Expected {}. Got {}",
             function->getName(),
-            res.type->getColumnType(),
-            res.column->getDataType());
+            res.type->getName(),
+            res.column->getName());
     if (recursively_convert_result_to_full_column_if_low_cardinality)
     {
         res.column = recursiveRemoveLowCardinality(res.column);

--- a/src/Columns/validateColumnType.cpp
+++ b/src/Columns/validateColumnType.cpp
@@ -1,0 +1,68 @@
+#include <Columns/validateColumnType.h>
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnConst.h>
+#include <Columns/ColumnMap.h>
+#include <Columns/ColumnNullable.h>
+#include <Columns/ColumnSparse.h>
+#include <Columns/ColumnTuple.h>
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeMap.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeTuple.h>
+
+namespace DB
+{
+
+bool columnMatchesType(const IColumn & column, const IDataType & type)
+{
+    const IColumn * col = &column;
+
+    /// Strip wrappers that don't change the logical type.
+    if (const auto * col_const = typeid_cast<const ColumnConst *>(col))
+        col = &col_const->getDataColumn();
+    if (const auto * col_sparse = typeid_cast<const ColumnSparse *>(col))
+        col = &col_sparse->getValuesColumn();
+
+    if (col->getDataType() != type.getColumnType())
+        return false;
+
+    if (const auto * col_array = typeid_cast<const ColumnArray *>(col))
+    {
+        if (const auto * type_array = typeid_cast<const DataTypeArray *>(&type))
+            return columnMatchesType(col_array->getData(), *type_array->getNestedType());
+        return false;
+    }
+
+    if (const auto * col_nullable = typeid_cast<const ColumnNullable *>(col))
+    {
+        if (const auto * type_nullable = typeid_cast<const DataTypeNullable *>(&type))
+            return columnMatchesType(col_nullable->getNestedColumn(), *type_nullable->getNestedType());
+        return false;
+    }
+
+    if (const auto * col_tuple = typeid_cast<const ColumnTuple *>(col))
+    {
+        if (const auto * type_tuple = typeid_cast<const DataTypeTuple *>(&type))
+        {
+            const auto & type_elements = type_tuple->getElements();
+            if (col_tuple->tupleSize() != type_elements.size())
+                return false;
+            for (size_t i = 0; i < col_tuple->tupleSize(); ++i)
+                if (!columnMatchesType(col_tuple->getColumn(i), *type_elements[i]))
+                    return false;
+            return true;
+        }
+        return false;
+    }
+
+    if (const auto * col_map = typeid_cast<const ColumnMap *>(col))
+    {
+        if (const auto * type_map = typeid_cast<const DataTypeMap *>(&type))
+            return columnMatchesType(col_map->getNestedColumn(), *type_map->getNestedType());
+        return false;
+    }
+
+    return true;
+}
+
+}

--- a/src/Columns/validateColumnType.cpp
+++ b/src/Columns/validateColumnType.cpp
@@ -1,14 +1,18 @@
 #include <Columns/validateColumnType.h>
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnConst.h>
+#include <Columns/ColumnLowCardinality.h>
 #include <Columns/ColumnMap.h>
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnSparse.h>
 #include <Columns/ColumnTuple.h>
+#include <Columns/ColumnVariant.h>
 #include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeMap.h>
 #include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeTuple.h>
+#include <DataTypes/DataTypeVariant.h>
 
 namespace DB
 {
@@ -59,6 +63,28 @@ bool columnMatchesType(const IColumn & column, const IDataType & type)
     {
         if (const auto * type_map = typeid_cast<const DataTypeMap *>(&type))
             return columnMatchesType(col_map->getNestedColumn(), *type_map->getNestedType());
+        return false;
+    }
+
+    if (const auto * col_lc = typeid_cast<const ColumnLowCardinality *>(col))
+    {
+        if (const auto * type_lc = typeid_cast<const DataTypeLowCardinality *>(&type))
+            return columnMatchesType(*col_lc->getDictionary().getNestedColumn(), *type_lc->getDictionaryType());
+        return false;
+    }
+
+    if (const auto * col_variant = typeid_cast<const ColumnVariant *>(col))
+    {
+        if (const auto * type_variant = typeid_cast<const DataTypeVariant *>(&type))
+        {
+            const auto & type_variants = type_variant->getVariants();
+            if (col_variant->getVariants().size() != type_variants.size())
+                return false;
+            for (size_t i = 0; i < type_variants.size(); ++i)
+                if (!columnMatchesType(col_variant->getVariantByGlobalDiscriminator(i), *type_variants[i]))
+                    return false;
+            return true;
+        }
         return false;
     }
 

--- a/src/Columns/validateColumnType.h
+++ b/src/Columns/validateColumnType.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <Columns/IColumn.h>
+#include <DataTypes/IDataType.h>
+
+namespace DB
+{
+
+/// Recursively checks that a column's structure matches its declared DataType.
+/// Returns true if the column is compatible with the type, false otherwise.
+/// This goes deeper than comparing top-level TypeIndex values: it recurses
+/// into Array, Nullable, Tuple, and Map to verify nested element types.
+bool columnMatchesType(const IColumn & column, const IDataType & type);
+
+}

--- a/src/Functions/tests/gtest_functions_stress.cpp
+++ b/src/Functions/tests/gtest_functions_stress.cpp
@@ -9,6 +9,7 @@
 #include <base/scope_guard.h>
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnConst.h>
+#include <Columns/validateColumnType.h>
 #include <Columns/ColumnLowCardinality.h>
 #include <Columns/ColumnNothing.h>
 #include <Columns/ColumnNullable.h>
@@ -1536,8 +1537,8 @@ struct FunctionsStressTestThread
             throw Exception(ErrorCodes::INCORRECT_DATA, "function returned nullptr column");
         if (column->size() != expected_rows)
             throw Exception(ErrorCodes::INCORRECT_DATA, "function returned unexpected number of rows: {} instead of {}", column->size(), expected_rows);
-        if (column->getDataType() != data_type->getColumnType())
-            throw Exception(ErrorCodes::INCORRECT_DATA, "function returned column of unexpected type: {} instead of {}", magic_enum::enum_name<TypeIndex>(column->getDataType()), magic_enum::enum_name<TypeIndex>(data_type->getColumnType()));
+        if (!columnMatchesType(*column, *data_type))
+            throw Exception(ErrorCodes::INCORRECT_DATA, "function returned column of unexpected type: {} instead of {}", column->getName(), data_type->getName());
 
         auto apply = [&](IColumn & col)
         {

--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -9,6 +9,7 @@
 #include <DataTypes/DataTypesBinaryEncoding.h>
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnSet.h>
+#include <Columns/validateColumnType.h>
 #include <Functions/IFunction.h>
 #include <Functions/IFunctionAdaptors.h>
 #include <Functions/materialize.h>
@@ -447,13 +448,13 @@ const ActionsDAG::Node & ActionsDAG::addFunctionImpl(
         {
             size_t num_rows = arguments.empty() ? 0 : arguments.front().column->size();
             column = node.function->execute(arguments, node.result_type, num_rows, true);
-            if (column->getDataType() != node.result_type->getColumnType())
+            if (!columnMatchesType(*column, *node.result_type))
                 throw Exception(
                     ErrorCodes::LOGICAL_ERROR,
                     "Unexpected return type from {}. Expected {}. Got {}",
                     node.function->getName(),
-                    node.result_type->getColumnType(),
-                    column->getDataType());
+                    node.result_type->getName(),
+                    column->getName());
         }
         else
         {
@@ -916,7 +917,16 @@ static ColumnWithTypeAndName executeActionForPartialResult(
             try
             {
                 if (only_constant_arguments)
+                {
                     res_column.column = node->function->execute(arguments, res_column.type, input_rows_count, true);
+                    if (res_column.column && !columnMatchesType(*res_column.column, *res_column.type))
+                        throw Exception(
+                            ErrorCodes::LOGICAL_ERROR,
+                            "Unexpected return type from {}. Expected {}. Got {}",
+                            node->function->getName(),
+                            res_column.type->getName(),
+                            res_column.column->getName());
+                }
                 else
                     res_column.column = node->function_base->getConstantResultForNonConstArguments(arguments, res_column.type);
             }

--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -448,18 +448,19 @@ const ActionsDAG::Node & ActionsDAG::addFunctionImpl(
         {
             size_t num_rows = arguments.empty() ? 0 : arguments.front().column->size();
             column = node.function->execute(arguments, node.result_type, num_rows, true);
-            if (!columnMatchesType(*column, *node.result_type))
-                throw Exception(
-                    ErrorCodes::LOGICAL_ERROR,
-                    "Unexpected return type from {}. Expected {}. Got {}",
-                    node.function->getName(),
-                    node.result_type->getName(),
-                    column->getName());
         }
         else
         {
             column = node.function_base->getConstantResultForNonConstArguments(arguments, node.result_type);
         }
+
+        if (column && !columnMatchesType(*column, *node.result_type))
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR,
+                "Unexpected return type from {}. Expected {}. Got {}",
+                node.function->getName(),
+                node.result_type->getName(),
+                column->getName());
 
         /// If the result is not a constant, just in case, we will consider the result as unknown.
         if (column && isColumnConst(*column))
@@ -917,18 +918,17 @@ static ColumnWithTypeAndName executeActionForPartialResult(
             try
             {
                 if (only_constant_arguments)
-                {
                     res_column.column = node->function->execute(arguments, res_column.type, input_rows_count, true);
-                    if (res_column.column && !columnMatchesType(*res_column.column, *res_column.type))
-                        throw Exception(
-                            ErrorCodes::LOGICAL_ERROR,
-                            "Unexpected return type from {}. Expected {}. Got {}",
-                            node->function->getName(),
-                            res_column.type->getName(),
-                            res_column.column->getName());
-                }
                 else
                     res_column.column = node->function_base->getConstantResultForNonConstArguments(arguments, res_column.type);
+
+                if (res_column.column && !columnMatchesType(*res_column.column, *res_column.type))
+                    throw Exception(
+                        ErrorCodes::LOGICAL_ERROR,
+                        "Unexpected return type from {}. Expected {}. Got {}",
+                        node->function->getName(),
+                        res_column.type->getName(),
+                        res_column.column->getName());
             }
             catch (Exception & e)
             {

--- a/src/Interpreters/ExpressionActions.cpp
+++ b/src/Interpreters/ExpressionActions.cpp
@@ -7,6 +7,7 @@
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnFunction.h>
 #include <Columns/ColumnReplicated.h>
+#include <Columns/validateColumnType.h>
 #include <Common/typeid_cast.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypesNumber.h>
@@ -690,7 +691,7 @@ static void executeAction(const ExpressionActions::Action & action, ExecutionCon
                     ProfileEvents::increment(ProfileEvents::CompiledFunctionExecute);
 
                 res_column.column = action.node->function->execute(arguments, res_column.type, num_rows, dry_run);
-                if (res_column.column->getDataType() != res_column.type->getColumnType())
+                if (!columnMatchesType(*res_column.column, *res_column.type))
                 {
                     throw Exception(
                         ErrorCodes::LOGICAL_ERROR,


### PR DESCRIPTION
Replace the shallow `getDataType() != getColumnType()` check with a recursive `columnMatchesType` that validates nested types inside Array, Nullable, Tuple, and Map.

The existing check only compared top-level `TypeIndex` values (e.g. `Array == Array`), so it missed mismatches in nested element types like `Array(Nullable(Tuple(Int64, Int64)))` vs `Array(Nullable(Tuple(Float64, Float64)))`. The new check recurses into container types and would have caught the bug fixed in #100895, producing a clear error:

```
Unexpected return type from intDiv. Expected Array(Nullable(Tuple(Int64, Int64))). Got Const(Array(Nullable(Tuple(Float64, Float64))))
```

instead of the cryptic `Bad cast from type ColumnVector<double> to ColumnVector<long>` deep in serialization.

The check is applied at all entry points where function results are validated:
- `ExpressionActions::executeImpl`
- `ActionsDAG::addFunctionImpl`
- `ActionsDAG::executeActionForPartialResult`
- `ColumnFunction::reduce`
- `resolveFunction` (Analyzer)
- `gtest_functions_stress` (stress test)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.356`
<!-- ch-version-info:end -->