### PR TITLE
Exclude `slab_reclaimable` from cgroups v2 memory tracking

### DIFF
--- a/src/Common/MemoryWorker.cpp
+++ b/src/Common/MemoryWorker.cpp
@@ -112,6 +112,33 @@ uint64_t readMetricsFromStatFile(ReadBufferFromFile & buf, std::initializer_list
     return sum;
 }
 
+/// Read specific named metrics from a cgroups v2 memory.stat file into a map.
+/// Only reads keys present in the provided list, ignoring the rest.
+Metrics readNamedMetricsFromStatFile(ReadBufferFromFile & buf, std::initializer_list<std::string_view> keys)
+{
+    Metrics result;
+    while (!buf.eof())
+    {
+        std::string current_key;
+        readStringUntilWhitespace(current_key, buf);
+
+        if (std::find(keys.begin(), keys.end(), current_key) == keys.end())
+        {
+            std::string dummy;
+            readStringUntilNewlineInto(dummy, buf);
+            buf.tryIgnore(1);
+            continue;
+        }
+
+        assertChar(' ', buf);
+        uint64_t value = 0;
+        readIntText(value, buf);
+        result[std::move(current_key)] = value;
+        buf.tryIgnore(1);
+    }
+    return result;
+}
+
 struct CgroupsV1Reader : ICgroupsReader
 {
     explicit CgroupsV1Reader(const fs::path & stat_file_dir) : buf(stat_file_dir / "memory.stat") { }
@@ -144,7 +171,19 @@ struct CgroupsV2Reader : ICgroupsReader
     {
         std::lock_guard lock(mutex);
         stat_buf.rewind();
-        return readMetricsFromStatFile(stat_buf, {"anon", "sock", "kernel"}, {"kernel"}, &warnings_printed);
+        auto metrics = readNamedMetricsFromStatFile(stat_buf, {"anon", "sock", "kernel", "slab_reclaimable"});
+
+        uint64_t usage = metrics["anon"] + metrics["sock"];
+
+        /// `kernel` in cgroups v2 includes `slab_reclaimable` (dentry/inode cache),
+        /// which is a filesystem metadata cache the kernel drops under memory
+        /// pressure. Including it inflates `MemoryTracking` well above the actual
+        /// process RSS, leading to premature `MEMORY_LIMIT_EXCEEDED` errors.
+        uint64_t kernel = metrics["kernel"];
+        uint64_t slab_reclaimable = std::min(kernel, metrics["slab_reclaimable"]);
+        usage += kernel - slab_reclaimable;
+
+        return usage;
     }
 
     std::string dumpAllStats() override

--- a/src/Common/tests/gtest_cgroups_reader.cpp
+++ b/src/Common/tests/gtest_cgroups_reader.cpp
@@ -160,7 +160,7 @@ TEST_P(CgroupsMemoryUsageObserverFixture, ReadMemoryUsageTest)
     ASSERT_EQ(
         reader->readMemoryUsage(),
         version == ICgroupsReader::CgroupsVersion::V1 ? /* rss from memory.stat */ 2232029184
-                                                                  : /* anon+sock+kernel from memory.stat */ 11967193184);
+                                                                  : /* anon+sock+kernel-slab_reclaimable from memory.stat */ 10506210680);
 }
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Exclude `slab_reclaimable` from cgroups v2 memory tracking

The `CgroupsV2Reader` sums `anon + sock + kernel` from `memory.stat` to feed `MemoryTracking`. But `kernel` includes `slab_reclaimable` (dentry/inode cache) — a filesystem metadata cache the kernel drops under memory pressure, functionally equivalent to page cache.

On one of instances I can see that it can take significant portion of memory:

  Process RSS:      8.47 GiB
  anon:             7.75 GiB
  kernel:           4.22 GiB  (of which slab_reclaimable = 3.85 GiB)
  MemoryTracking:  11.99 GiB  (inflated ~42% vs real RSS)

The 3.85 GiB of reclaimable slab was dominated by `ext4_inode_cache` (with 56% usage only).

This inflated tracker causes premature `MEMORY_LIMIT_EXCEEDED` errors.

Cgroups v1 is not affected — its `rss` field excludes kernel memory.

Refs: #82036, #83981
