### PR TITLE
Subtract slab_reclaimable from kernel memory in cgroupv2 reader

### DIFF
--- a/src/Common/MemoryWorker.cpp
+++ b/src/Common/MemoryWorker.cpp
@@ -116,7 +116,7 @@ void readMetricsFromStatFile(
 
     if (print_warnings)
     {
-        for (auto it = keys.begin(); it != keys.end(); ++it)
+        for (const auto * it = keys.begin(); it != keys.end(); ++it)
         {
             uint64_t key_bit = 1ull << (it - keys.begin());
             if (!(seen_mask & key_bit) && std::find(optional_keys.begin(), optional_keys.end(), *it) == optional_keys.end())

--- a/src/Common/MemoryWorker.cpp
+++ b/src/Common/MemoryWorker.cpp
@@ -39,15 +39,13 @@ namespace ErrorCodes
 namespace
 {
 
-using Metrics = std::map<std::string, uint64_t>;
-
 /// Format is
 ///   kernel 5
 ///   rss 15
 ///   [...]
-Metrics readAllMetricsFromStatFile(ReadBufferFromFile & buf)
+std::map<std::string, uint64_t> readAllMetricsFromStatFile(ReadBufferFromFile & buf)
 {
-    Metrics metrics;
+    std::map<std::string, uint64_t> metrics;
     while (!buf.eof())
     {
         std::string current_key;
@@ -65,10 +63,22 @@ Metrics readAllMetricsFromStatFile(ReadBufferFromFile & buf)
     return metrics;
 }
 
-uint64_t readMetricsFromStatFile(ReadBufferFromFile & buf, std::initializer_list<std::string_view> keys, std::initializer_list<std::string_view> optional_keys, bool * warnings_printed)
+using Metrics = std::map<std::string_view, uint64_t>;
+
+void readMetricsFromStatFile(
+    ReadBufferFromFile & buf,
+    Metrics & metrics,
+    std::initializer_list<std::string_view> keys,
+    std::initializer_list<std::string_view> optional_keys,
+    bool * warnings_printed)
 {
-    uint64_t sum = 0;
-    uint64_t found_mask = 0;
+    /// Zero out existing values; keeps map nodes allocated for reuse.
+    for (auto & [_, v] : metrics)
+        v = 0;
+
+    /// Track which keys were actually seen in this pass.
+    uint64_t seen_mask = 0;
+
     bool print_warnings = !*warnings_printed;
     while (!buf.eof())
     {
@@ -80,36 +90,42 @@ uint64_t readMetricsFromStatFile(ReadBufferFromFile & buf, std::initializer_list
         {
             std::string dummy;
             readStringUntilNewlineInto(dummy, buf);
-            buf.tryIgnore(1); /// skip EOL (if not EOF)
+            buf.tryIgnore(1);
             continue;
         }
-
-        if (print_warnings && (found_mask & (1l << (it - keys.begin()))))
-        {
-            *warnings_printed = true;
-            LOG_ERROR(getLogger("CgroupsReader"), "Duplicate key '{}' in '{}'", current_key, buf.getFileName());
-        }
-        found_mask |= 1ll << (it - keys.begin());
 
         assertChar(' ', buf);
         uint64_t value = 0;
         readIntText(value, buf);
-        sum += value;
-        buf.tryIgnore(1); /// skip EOL (if not EOF)
+        buf.tryIgnore(1);
+
+        uint64_t key_bit = 1ull << (it - keys.begin());
+        if (seen_mask & key_bit)
+        {
+            if (print_warnings)
+            {
+                *warnings_printed = true;
+                LOG_ERROR(getLogger("CgroupsReader"), "Duplicate key '{}' in '{}'", current_key, buf.getFileName());
+            }
+        }
+        seen_mask |= key_bit;
+
+        /// Use the string_view from keys (string literals) as map key.
+        metrics[*it] = value;
     }
 
-    /// Did we see all keys?
-    for (const auto * it = keys.begin(); it != keys.end(); ++it)
+    if (print_warnings)
     {
-        if (print_warnings
-                && !(found_mask & (1l << (it - keys.begin())))
-                && std::find(optional_keys.begin(), optional_keys.end(), *it) == optional_keys.end())
+        for (auto it = keys.begin(); it != keys.end(); ++it)
         {
-            *warnings_printed = true;
-            LOG_ERROR(getLogger("CgroupsReader"), "Cannot find '{}' in '{}'", *it, buf.getFileName());
+            uint64_t key_bit = 1ull << (it - keys.begin());
+            if (!(seen_mask & key_bit) && std::find(optional_keys.begin(), optional_keys.end(), *it) == optional_keys.end())
+            {
+                *warnings_printed = true;
+                LOG_ERROR(getLogger("CgroupsReader"), "Cannot find '{}' in '{}'", *it, buf.getFileName());
+            }
         }
     }
-    return sum;
 }
 
 struct CgroupsV1Reader : ICgroupsReader
@@ -120,7 +136,9 @@ struct CgroupsV1Reader : ICgroupsReader
     {
         std::lock_guard lock(mutex);
         buf.rewind();
-        return readMetricsFromStatFile(buf, {"rss"}, {}, &warnings_printed);
+        readMetricsFromStatFile(buf, metrics, {"rss"}, {}, &warnings_printed);
+        auto it = metrics.find("rss");
+        return it != metrics.end() ? it->second : 0;
     }
 
     std::string dumpAllStats() override
@@ -133,6 +151,7 @@ struct CgroupsV1Reader : ICgroupsReader
 private:
     std::mutex mutex;
     ReadBufferFromFile buf TSA_GUARDED_BY(mutex);
+    Metrics metrics TSA_GUARDED_BY(mutex);
     bool warnings_printed TSA_GUARDED_BY(mutex) = false;
 };
 
@@ -144,7 +163,25 @@ struct CgroupsV2Reader : ICgroupsReader
     {
         std::lock_guard lock(mutex);
         stat_buf.rewind();
-        return readMetricsFromStatFile(stat_buf, {"anon", "sock", "kernel"}, {"kernel"}, &warnings_printed);
+        readMetricsFromStatFile(
+            stat_buf, metrics, {"anon", "sock", "kernel", "slab_reclaimable"}, {"kernel", "slab_reclaimable"}, &warnings_printed);
+
+        auto get = [](const Metrics & m, std::string_view key) -> uint64_t
+        {
+            auto it = m.find(key);
+            return it != m.end() ? it->second : 0;
+        };
+
+        /// anon + sock: actual process memory.
+        /// kernel - slab_reclaimable: non-reclaimable kernel memory (pagetables, kernel_stack, slab_unreclaimable).
+        /// slab_reclaimable is excluded because the kernel reclaims it synchronously under memory pressure
+        /// before invoking the OOM killer, so it should not count against the application's memory budget.
+        uint64_t usage = get(metrics, "anon") + get(metrics, "sock");
+        uint64_t kernel = get(metrics, "kernel");
+        uint64_t slab_reclaimable = get(metrics, "slab_reclaimable");
+        if (kernel > slab_reclaimable)
+            usage += kernel - slab_reclaimable;
+        return usage;
     }
 
     std::string dumpAllStats() override
@@ -157,6 +194,7 @@ struct CgroupsV2Reader : ICgroupsReader
 private:
     std::mutex mutex;
     ReadBufferFromFile stat_buf TSA_GUARDED_BY(mutex);
+    Metrics metrics TSA_GUARDED_BY(mutex);
     bool warnings_printed TSA_GUARDED_BY(mutex) = false;
 };
 

--- a/src/Common/MemoryWorker.cpp
+++ b/src/Common/MemoryWorker.cpp
@@ -69,7 +69,6 @@ void readMetricsFromStatFile(
     ReadBufferFromFile & buf,
     Metrics & metrics,
     std::initializer_list<std::string_view> keys,
-    std::initializer_list<std::string_view> optional_keys,
     bool * warnings_printed)
 {
     /// Zero out existing values; keeps map nodes allocated for reuse.
@@ -119,7 +118,7 @@ void readMetricsFromStatFile(
         for (const auto * it = keys.begin(); it != keys.end(); ++it)
         {
             uint64_t key_bit = 1ull << (it - keys.begin());
-            if (!(seen_mask & key_bit) && std::find(optional_keys.begin(), optional_keys.end(), *it) == optional_keys.end())
+            if (!(seen_mask & key_bit))
             {
                 *warnings_printed = true;
                 LOG_ERROR(getLogger("CgroupsReader"), "Cannot find '{}' in '{}'", *it, buf.getFileName());
@@ -136,7 +135,7 @@ struct CgroupsV1Reader : ICgroupsReader
     {
         std::lock_guard lock(mutex);
         buf.rewind();
-        readMetricsFromStatFile(buf, metrics, {"rss"}, {}, &warnings_printed);
+        readMetricsFromStatFile(buf, metrics, {"rss"}, &warnings_printed);
         auto it = metrics.find("rss");
         return it != metrics.end() ? it->second : 0;
     }
@@ -164,7 +163,7 @@ struct CgroupsV2Reader : ICgroupsReader
         std::lock_guard lock(mutex);
         stat_buf.rewind();
         readMetricsFromStatFile(
-            stat_buf, metrics, {"anon", "sock", "kernel", "slab_reclaimable"}, {"kernel", "slab_reclaimable"}, &warnings_printed);
+            stat_buf, metrics, {"anon", "sock", "kernel", "slab_reclaimable"}, &warnings_printed);
 
         auto get = [](const Metrics & m, std::string_view key) -> uint64_t
         {

--- a/src/Common/tests/gtest_cgroups_reader.cpp
+++ b/src/Common/tests/gtest_cgroups_reader.cpp
@@ -160,7 +160,7 @@ TEST_P(CgroupsMemoryUsageObserverFixture, ReadMemoryUsageTest)
     ASSERT_EQ(
         reader->readMemoryUsage(),
         version == ICgroupsReader::CgroupsVersion::V1 ? /* rss from memory.stat */ 2232029184
-                                                                  : /* anon+sock+kernel from memory.stat */ 11967193184);
+                                                                  : /* anon+sock+kernel-slab_reclaimable from memory.stat */ 10506210680);
 }
 
 
@@ -176,5 +176,30 @@ INSTANTIATE_TEST_SUITE_P(
     CgroupsMemoryUsageObserverTests,
     CgroupsMemoryUsageObserverFixture,
     ::testing::Values(ICgroupsReader::CgroupsVersion::V1, ICgroupsReader::CgroupsVersion::V2));
+
+
+/// Test cgroupv2 memory.stat without kernel/slab_reclaimable (older kernels).
+/// Result should be just anon + sock.
+TEST(CgroupsV2NoKernel, ReadMemoryUsageTest)
+{
+    std::string tmp_dir = "./test_cgroups_v2_no_kernel";
+    fs::create_directories(tmp_dir);
+
+    auto stat_file = WriteBufferFromFile(tmp_dir + "/memory.stat");
+    std::string content = R"(anon 5000000000
+file 1000000000
+sock 1000
+inactive_anon 0
+active_anon 5000000000
+)";
+    stat_file.write(content.data(), content.size());
+    stat_file.finalize();
+    stat_file.sync();
+
+    auto reader = ICgroupsReader::createCgroupsReader(ICgroupsReader::CgroupsVersion::V2, tmp_dir);
+    ASSERT_EQ(reader->readMemoryUsage(), /* anon + sock */ 5000001000);
+
+    fs::remove_all(tmp_dir);
+}
 
 #endif


### PR DESCRIPTION
The cgroupv2 memory usage calculation now uses `anon + sock + (kernel - slab_reclaimable)` instead of `anon + sock + kernel`. The `slab_reclaimable` portion is reclaimed synchronously by the kernel under memory pressure before invoking the OOM killer, so it should not count against the application's memory budget. This gives a more accurate picture of actual memory pressure.

On one of instances @azat saw that it can take significant portion of memory:

Process RSS: 8.47 GiB
anon: 7.75 GiB
kernel: 4.22 GiB (of which slab_reclaimable = 3.85 GiB)
MemoryTracking: 11.99 GiB (inflated ~42% vs real RSS)

The 3.85 GiB of reclaimable slab was dominated by ext4_inode_cache (with 56% usage only).

This inflated tracker causes premature `MEMORY_LIMIT_EXCEEDED` errors.

Cgroups v1 is not affected — its rss field excludes kernel memory.

Refs: https://github.com/ClickHouse/ClickHouse/issues/82036, https://github.com/ClickHouse/ClickHouse/pull/83981

Also refactors `readMetricsFromStatFile` to populate a caller-owned map of individual metric values instead of returning a sum, allowing callers to apply their own aggregation logic.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Cgroupv2 memory tracking now excludes `slab_reclaimable` from kernel memory, giving a more accurate measure of non-reclaimable memory usage.

cc @al13n321 as you added kernel for page cache.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.513`
- Backported to: `26.3.4.4`, `26.2.8.17`, `26.1.8.20`, `25.8.22.15`
<!-- ch-version-info:end -->