### PR TITLE
Evaluate engine arguments for StorageAlias before storing the definition

### DIFF
--- a/src/Storages/StorageAlias.cpp
+++ b/src/Storages/StorageAlias.cpp
@@ -327,8 +327,8 @@ void registerStorageAlias(StorageFactory & factory)
         else if (args.engine_args.size() == 1)
         {
             // Syntax: ENGINE = Alias(table_name) or ENGINE = Alias(db.table_name)
-            auto evaluated_arg = evaluateConstantExpressionOrIdentifierAsLiteral(args.engine_args[0], local_context);
-            String table_arg = checkAndGetLiteralArgument<String>(evaluated_arg, "table_name");
+            args.engine_args[0] = evaluateConstantExpressionOrIdentifierAsLiteral(args.engine_args[0], local_context);
+            String table_arg = checkAndGetLiteralArgument<String>(args.engine_args[0], "table_name");
 
             auto dot_pos = table_arg.find('.');
             if (dot_pos != String::npos)
@@ -345,10 +345,10 @@ void registerStorageAlias(StorageFactory & factory)
         else if (args.engine_args.size() == 2)
         {
             // Syntax: ENGINE = Alias(database_name, table_name)
-            auto evaluated_db = evaluateConstantExpressionOrIdentifierAsLiteral(args.engine_args[0], local_context);
-            auto evaluated_table = evaluateConstantExpressionOrIdentifierAsLiteral(args.engine_args[1], local_context);
-            target_database = checkAndGetLiteralArgument<String>(evaluated_db, "database_name");
-            target_table = checkAndGetLiteralArgument<String>(evaluated_table, "table_name");
+            args.engine_args[0] = evaluateConstantExpressionOrIdentifierAsLiteral(args.engine_args[0], local_context);
+            args.engine_args[1] = evaluateConstantExpressionOrIdentifierAsLiteral(args.engine_args[1], local_context);
+            target_database = checkAndGetLiteralArgument<String>(args.engine_args[0], "database_name");
+            target_table = checkAndGetLiteralArgument<String>(args.engine_args[1], "table_name");
         }
         else
         {

--- a/tests/queries/0_stateless/04055_storage_alias_bake_currentDatabase.reference
+++ b/tests/queries/0_stateless/04055_storage_alias_bake_currentDatabase.reference
@@ -1,0 +1,18 @@
+-- { echo }
+
+SET allow_experimental_alias_table_engine = 1;
+CREATE TABLE source_bake (id UInt32, value String) ENGINE = MergeTree ORDER BY id;
+-- Two-argument case: currentDatabase() should be baked to literal
+CREATE TABLE alias_bake_1 ENGINE = Alias(currentDatabase(), 'source_bake');
+SELECT create_table_query NOT LIKE '%currentDatabase()%' FROM system.tables WHERE database = currentDatabase() AND name = 'alias_bake_1';
+1
+-- Single-argument case: concat should be baked to literal
+CREATE TABLE alias_bake_2 ENGINE = Alias(concat(currentDatabase(), '.source_bake'));
+SELECT create_table_query NOT LIKE '%currentDatabase()%' FROM system.tables WHERE database = currentDatabase() AND name = 'alias_bake_2';
+1
+-- Verify both aliases still work
+INSERT INTO source_bake VALUES (1, 'hello');
+SELECT * FROM alias_bake_1;
+1	hello
+SELECT * FROM alias_bake_2;
+1	hello

--- a/tests/queries/0_stateless/04055_storage_alias_bake_currentDatabase.sql
+++ b/tests/queries/0_stateless/04055_storage_alias_bake_currentDatabase.sql
@@ -1,0 +1,18 @@
+-- { echo }
+
+SET allow_experimental_alias_table_engine = 1;
+
+CREATE TABLE source_bake (id UInt32, value String) ENGINE = MergeTree ORDER BY id;
+
+-- Two-argument case: currentDatabase() should be baked to literal
+CREATE TABLE alias_bake_1 ENGINE = Alias(currentDatabase(), 'source_bake');
+SELECT create_table_query NOT LIKE '%currentDatabase()%' FROM system.tables WHERE database = currentDatabase() AND name = 'alias_bake_1';
+
+-- Single-argument case: concat should be baked to literal
+CREATE TABLE alias_bake_2 ENGINE = Alias(concat(currentDatabase(), '.source_bake'));
+SELECT create_table_query NOT LIKE '%currentDatabase()%' FROM system.tables WHERE database = currentDatabase() AND name = 'alias_bake_2';
+
+-- Verify both aliases still work
+INSERT INTO source_bake VALUES (1, 'hello');
+SELECT * FROM alias_bake_1;
+SELECT * FROM alias_bake_2;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Evaluate engine arguments for `StorageAlias` before storing the definition, so that expressions like `currentDatabase()` are resolved to literals before being saved to the database.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.422`
- Backported to: `26.3.3.10`, `26.2.7.12`, `26.1.8.5`
<!-- ch-version-info:end -->