### PR TITLE
Properly recalculate locations after config reload 

### DIFF
--- a/src/Disks/DiskObjectStorage/DiskObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/DiskObjectStorage.cpp
@@ -196,6 +196,7 @@ DiskObjectStorage::DiskObjectStorage(
             if (old_write_resource != new_write_resource)
                 LOG_INFO(log, "Using resource '{}' instead of '{}' for WRITE", new_write_resource, old_write_resource);
         });
+    cluster->applyNewSettings(config, config_prefix);
     blob_killer->applyNewSettings(config, config_prefix + ".data_background_cleanup");
     blob_copier->applyNewSettings(config, config_prefix + ".data_background_replication");
 }

--- a/src/Disks/DiskObjectStorage/DiskObjectStorageCache.cpp
+++ b/src/Disks/DiskObjectStorage/DiskObjectStorageCache.cpp
@@ -20,7 +20,7 @@ DiskObjectStoragePtr DiskObjectStorage::wrapWithCache(FileCachePtr cache, const 
 
     auto cache_disk = std::make_shared<DiskObjectStorage>(
         layer_name,
-        std::make_shared<ClusterConfiguration>(cluster->getConfiguration()),
+        std::make_shared<ClusterConfiguration>(layer_name, cluster->getConfiguration()),
         std::make_shared<MetadataStorageFromCacheObjectStorage>(metadata_storage),
         std::make_shared<ObjectStorageRouter>(std::move(registry)),
         std::dynamic_pointer_cast<const DiskObjectStorage>(shared_from_this()),

--- a/src/Disks/DiskObjectStorage/DiskObjectStorageTransaction.cpp
+++ b/src/Disks/DiskObjectStorage/DiskObjectStorageTransaction.cpp
@@ -324,7 +324,7 @@ std::unique_ptr<WriteBufferFromFileBase> DiskObjectStorageTransaction::writeFile
     {
         object.bytes_size = count;
 
-        /// Locations to which blocks were not originally copied should be marked as missing.
+        /// Locations to which blobs were not originally copied should be marked as missing.
         auto missing_locations = disk_tx->cluster->findComplement(replicated_locations);
         disk_tx->operations_to_execute.push_back([object, mode, create_blob_if_empty, blob_replication = std::move(missing_locations)](MetadataTransactionPtr tx)
         {

--- a/src/Disks/DiskObjectStorage/DiskObjectStorageTransaction.cpp
+++ b/src/Disks/DiskObjectStorage/DiskObjectStorageTransaction.cpp
@@ -260,7 +260,8 @@ std::unique_ptr<WriteBufferFromFileBase> DiskObjectStorageTransaction::writeFile
 
     StoredObject object(metadata_transaction->generateObjectKeyForPath(path).serialize(), path);
     std::vector<WriteBufferPtr> writers;
-    for (const auto & location : cluster->getEnabledLocations())
+    auto enabled_locations = cluster->getEnabledLocations();
+    for (const auto & location : enabled_locations)
     {
         size_t use_buffer_size = buf_size;
         std::unique_ptr<WriteBufferFromFileBase> writer;
@@ -319,11 +320,11 @@ std::unique_ptr<WriteBufferFromFileBase> DiskObjectStorageTransaction::writeFile
     /// ...
     /// buf1->finalize() // shouldn't do anything with metadata operations, just memorize what to do
     /// tx->commit()
-    const auto create_metadata_callback = [disk_tx = shared_from_this(), mode, object, autocommit, create_blob_if_empty](size_t count) mutable
+    const auto create_metadata_callback = [disk_tx = shared_from_this(), replicated_locations = std::move(enabled_locations), mode, object, autocommit, create_blob_if_empty](size_t count) mutable
     {
         object.bytes_size = count;
 
-        auto missing_locations = disk_tx->cluster->findComplement(disk_tx->cluster->getEnabledLocations());
+        auto missing_locations = disk_tx->cluster->findComplement(replicated_locations);
         disk_tx->operations_to_execute.push_back([object, mode, create_blob_if_empty, blob_replication = std::move(missing_locations)](MetadataTransactionPtr tx)
         {
             if (mode == WriteMode::Rewrite)

--- a/src/Disks/DiskObjectStorage/DiskObjectStorageTransaction.cpp
+++ b/src/Disks/DiskObjectStorage/DiskObjectStorageTransaction.cpp
@@ -324,6 +324,7 @@ std::unique_ptr<WriteBufferFromFileBase> DiskObjectStorageTransaction::writeFile
     {
         object.bytes_size = count;
 
+        /// Locations to which blocks were not originally copied should be marked as missing.
         auto missing_locations = disk_tx->cluster->findComplement(replicated_locations);
         disk_tx->operations_to_execute.push_back([object, mode, create_blob_if_empty, blob_replication = std::move(missing_locations)](MetadataTransactionPtr tx)
         {

--- a/src/Disks/DiskObjectStorage/RegisterDiskObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/RegisterDiskObjectStorage.cpp
@@ -55,7 +55,7 @@ void registerDiskObjectStorage(DiskFactory & factory, bool global_skip_access_ch
             cluster_registry["main"] = { .enabled = true, .local = true, .config_prefix = config_prefix };
         }
 
-        ClusterConfigurationPtr cluster = std::make_shared<ClusterConfiguration>(std::move(cluster_registry));
+        ClusterConfigurationPtr cluster = std::make_shared<ClusterConfiguration>(name, std::move(cluster_registry));
         ObjectStorageRouterPtr object_storages = std::make_shared<ObjectStorageRouter>(std::move(object_storage_registry));
 
         std::string compatibility_metadata_type_hint;

--- a/src/Disks/DiskObjectStorage/Replication/ClusterConfiguration.cpp
+++ b/src/Disks/DiskObjectStorage/Replication/ClusterConfiguration.cpp
@@ -3,6 +3,7 @@
 #include <Disks/DiskObjectStorage/ObjectStorages/StoredObject.h>
 
 #include <Common/Exception.h>
+#include <Common/Logger.h>
 #include <Common/UniqueLock.h>
 #include <Common/logger_useful.h>
 
@@ -18,10 +19,11 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
-ClusterConfiguration::ClusterConfiguration(std::unordered_map<Location, LocationInfo> locations_)
-    : locations(std::move(locations_))
+ClusterConfiguration::ClusterConfiguration(const std::string & disk_name, std::unordered_map<Location, LocationInfo> locations_)
+    : log(getLogger(fmt::format("{}::ClusterConfiguration", disk_name)))
+    , locations(std::move(locations_))
 {
-    LOG_DEBUG(getLogger("ClusterConfiguration"), "Cluster Configuration: {}", locations | std::views::keys | std::ranges::to<std::vector<std::string>>());
+    LOG_DEBUG(log, "Cluster Configuration: {}", locations | std::views::keys | std::ranges::to<std::vector<std::string>>());
 }
 
 void ClusterConfiguration::applyNewSettings(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix)
@@ -31,11 +33,13 @@ void ClusterConfiguration::applyNewSettings(const Poco::Util::AbstractConfigurat
     Locations updated_locations;
     config.keys(config_prefix + ".locations", updated_locations);
 
+    LOG_INFO(log, "Applying new settings");
     for (const auto & location : updated_locations)
     {
         auto & info = locations.at(location);
         info.local = config.getBool(config_prefix + ".locations." + location + ".local");
         info.enabled = config.getBool(config_prefix + ".locations." + location + ".enabled");
+        LOG_INFO(log, "Location '{}' - Local: {}, Enabled: {}", location, info.local, info.enabled);
     }
 }
 

--- a/src/Disks/DiskObjectStorage/Replication/ClusterConfiguration.h
+++ b/src/Disks/DiskObjectStorage/Replication/ClusterConfiguration.h
@@ -3,6 +3,7 @@
 #include <Disks/DiskObjectStorage/Replication/Location.h>
 
 #include <Common/SharedMutex.h>
+#include <Common/Logger.h>
 
 #include <base/defines.h>
 
@@ -23,7 +24,7 @@ struct LocationInfo
 class ClusterConfiguration
 {
 public:
-    explicit ClusterConfiguration(std::unordered_map<Location, LocationInfo> locations_);
+    explicit ClusterConfiguration(const std::string & disk_name, std::unordered_map<Location, LocationInfo> locations_);
 
     void applyNewSettings(const Poco::Util::AbstractConfiguration & config, const std::string & config_prefix);
 
@@ -39,6 +40,8 @@ public:
     Location getLocalLocation() const;
 
 private:
+    const LoggerPtr log;
+
     mutable SharedMutex mutex;
     std::unordered_map<Location, LocationInfo> locations TSA_GUARDED_BY(mutex);
 };

--- a/src/Disks/tests/gtest_disk_encrypted.cpp
+++ b/src/Disks/tests/gtest_disk_encrypted.cpp
@@ -458,7 +458,7 @@ TEST_F(DiskEncryptedTest, LocalBlobs)
     std::unordered_map<Location, LocationInfo> cluster_registry = {{"main", {true, true, ""}}};
     std::unordered_map<Location, ObjectStoragePtr> object_storage_registry = {{"main", object_storage}};
 
-    ClusterConfigurationPtr cluster = std::make_shared<ClusterConfiguration>(std::move(cluster_registry));
+    ClusterConfigurationPtr cluster = std::make_shared<ClusterConfiguration>("local_blobs", std::move(cluster_registry));
     ObjectStorageRouterPtr object_storages = std::make_shared<ObjectStorageRouter>(std::move(object_storage_registry));
 
     Poco::AutoPtr<Poco::Util::XMLConfiguration> config(new Poco::Util::XMLConfiguration());

--- a/src/Disks/tests/gtest_metadata_local_disk.cpp
+++ b/src/Disks/tests/gtest_metadata_local_disk.cpp
@@ -76,7 +76,7 @@ private:
 void verifyBlobsToRemove(const DB::MetadataStoragePtr & metadata, std::set<std::string> expected_blobs)
 {
     std::unordered_map<DB::Location, DB::LocationInfo> cluster_registry = {{"main", {true, true, ""}}};
-    DB::ClusterConfigurationPtr cluster = std::make_shared<DB::ClusterConfiguration>(std::move(cluster_registry));
+    DB::ClusterConfigurationPtr cluster = std::make_shared<DB::ClusterConfiguration>("disk", std::move(cluster_registry));
     auto blobs_to_remove = metadata->getBlobsToRemove(cluster, 10000);
 
     std::set<std::string> remote_paths;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.349`
- Backported to: `26.3.3.5`, `26.2.7.3`
<!-- ch-version-info:end -->