### PR TITLE
CI: check sync PR is mergeable before entering merge queue

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/check_sync_pr_mergeable.py
+++ b/ci/jobs/scripts/workflow_hooks/check_sync_pr_mergeable.py
@@ -1,0 +1,58 @@
+import sys
+import traceback
+
+from praktika.info import Info
+from praktika.utils import Shell
+
+SYNC_REPO = "ClickHouse/clickhouse-private"
+
+
+def check():
+    info = Info()
+
+    if not info.pr_number > 0:
+        print(f"WARNING: Invalid or unknown pr number: {info.pr_number}")
+        return True
+
+    sync_pr_numbers = Shell.get_output(
+        f"gh pr list --state open --head sync-upstream/pr/{info.pr_number} --repo {SYNC_REPO} --json number --jq '.[].number'",
+        verbose=True,
+    ).splitlines()
+    sync_pr_numbers = [n for n in sync_pr_numbers if n.strip()]
+
+    if len(sync_pr_numbers) == 0:
+        print("WARNING: No open Sync PR found - skipping check")
+        return True
+
+    if len(sync_pr_numbers) > 1:
+        print(
+            f"ERROR: Expected at most one open Sync PR for branch sync-upstream/pr/{info.pr_number}, "
+            f"found {len(sync_pr_numbers)}: {sync_pr_numbers}"
+        )
+        return False
+
+    sync_pr_number = sync_pr_numbers[0]
+
+    mergeable = Shell.get_output(
+        f"gh pr view {sync_pr_number} --repo {SYNC_REPO} --json mergeable --jq .mergeable",
+        verbose=True,
+    ).strip()
+
+    if mergeable == "CONFLICTING":
+        print(
+            f"ERROR: Sync PR #{sync_pr_number} in {SYNC_REPO} has conflicts and cannot be merged"
+        )
+        return False
+
+    print(
+        f"Sync PR #{sync_pr_number} in {SYNC_REPO} is mergeable (state: {mergeable})"
+    )
+    return True
+
+
+if __name__ == "__main__":
+    try:
+        if not check():
+            sys.exit(1)
+    except Exception:
+        traceback.print_exc()

--- a/ci/jobs/scripts/workflow_hooks/check_sync_pr_mergeable.py
+++ b/ci/jobs/scripts/workflow_hooks/check_sync_pr_mergeable.py
@@ -1,4 +1,5 @@
 import sys
+import time
 import traceback
 
 from praktika.info import Info
@@ -14,11 +15,16 @@ def check():
         print(f"WARNING: Invalid or unknown pr number: {info.pr_number}")
         return True
 
-    sync_pr_numbers = Shell.get_output(
+    raw = Shell.get_output(
         f"gh pr list --state open --head sync-upstream/pr/{info.pr_number} --repo {SYNC_REPO} --json number --jq '.[].number'",
         verbose=True,
-    ).splitlines()
-    sync_pr_numbers = [n for n in sync_pr_numbers if n.strip()]
+        retries=3,
+    )
+    if not raw:
+        print("WARNING: Failed to retrieve Sync PR list after retries - skipping check")
+        return True
+
+    sync_pr_numbers = [n for n in raw.splitlines() if n.strip()]
 
     if len(sync_pr_numbers) == 0:
         print("WARNING: No open Sync PR found - skipping check")
@@ -36,7 +42,21 @@ def check():
     mergeable = Shell.get_output(
         f"gh pr view {sync_pr_number} --repo {SYNC_REPO} --json mergeable --jq .mergeable",
         verbose=True,
-    ).strip()
+    )
+    if not mergeable or mergeable == "UNKNOWN":
+        print(
+            f"WARNING: Sync PR #{sync_pr_number} mergeable state is '{mergeable}', retrying in 5s..."
+        )
+        time.sleep(5)
+        mergeable = Shell.get_output(
+            f"gh pr view {sync_pr_number} --repo {SYNC_REPO} --json mergeable --jq .mergeable",
+            verbose=True,
+        )
+    if not mergeable or mergeable == "UNKNOWN":
+        print(
+            f"WARNING: Sync PR #{sync_pr_number} mergeable state is still '{mergeable}' - skipping check"
+        )
+        return True
 
     if mergeable == "CONFLICTING":
         print(

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -334,7 +334,12 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
         report_url_current_sha = info.get_report_url(latest=False)
         body = f"Workflow [[{workflow.name}]({report_url_latest_sha})], commit [{env.SHA[:8]}]"
         res2 = not bool(env.PR_NUMBER) or GH.post_updateable_comment(
-            comment_tags_and_bodies={"report": body, "summary": "", "review": ""},
+            comment_tags_and_bodies={
+                "report": body,
+                "param_1": "",
+                "summary": "",
+                "review": "",
+            },
         )
         res1 = GH.post_commit_status(
             name=workflow.name,

--- a/ci/praktika/utils.py
+++ b/ci/praktika/utils.py
@@ -175,24 +175,31 @@ class Shell:
         return cls.get_output(command, verbose=verbose, strict=True).strip()
 
     @classmethod
-    def get_output(cls, command, strict=False, verbose=False):
+    def get_output(cls, command, strict=False, verbose=False, retries=1, delay=2):
         if verbose:
             print(f"Run command [{command}]")
-        res = subprocess.run(
-            command,
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            executable="/bin/bash",
-            errors="ignore",
-        )
-        if res.stderr:
-            print(f"WARNING: stderr: {res.stderr.strip()}")
-        if strict and res.returncode != 0:
-            raise RuntimeError(
-                f"command failed with, exit_code {res.returncode}, stderr:\n>>>\n{res.stderr.strip()}\n<<<"
+        for attempt in range(retries):
+            res = subprocess.run(
+                command,
+                shell=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                executable="/bin/bash",
+                errors="ignore",
             )
+            if res.stderr:
+                print(f"WARNING: stderr: {res.stderr.strip()}")
+            if strict and res.returncode != 0:
+                raise RuntimeError(
+                    f"command failed with, exit_code {res.returncode}, stderr:\n>>>\n{res.stderr.strip()}\n<<<"
+                )
+            if res.returncode == 0:
+                return res.stdout.strip()
+            if attempt < retries - 1:
+                print(f"WARNING: command failed (attempt {attempt + 1}/{retries}), retrying in {delay}s...")
+                time.sleep(delay)
+                delay = min(2 * delay, 60)
         return res.stdout.strip()
 
     @classmethod

--- a/ci/workflows/merge_queue.py
+++ b/ci/workflows/merge_queue.py
@@ -28,6 +28,7 @@ workflow = Workflow.Config(
     pre_hooks=[
         "python3 ./ci/jobs/scripts/workflow_hooks/store_data.py",
         "python3 ./ci/jobs/scripts/workflow_hooks/set_dummy_sync_commit_status.py",
+        "python3 ./ci/jobs/scripts/workflow_hooks/check_sync_pr_mergeable.py",
     ],
 )
 


### PR DESCRIPTION
Before a PR enters the merge queue, verify that the corresponding sync PR in
`ClickHouse/clickhouse-private` (branch `sync-upstream/pr/<PR_NUM>`) has no
merge conflicts. This prevents a situation where the upstream PR merges but
the sync PR cannot be merged due to conflicts, breaking the sync pipeline.

The new `check_sync_pr_mergeable.py` pre-hook in `MergeQueueCI`:
- Looks up the open sync PR by branch name via `gh pr list`
- Fails if more than one open sync PR is found (ambiguous state)
- Skips silently if no sync PR exists (not every PR requires one)
- Checks `mergeable` state via `gh pr view --json mergeable`; exits with
  code 1 when the state is `CONFLICTING`, blocking the merge queue entry

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.338`
<!-- ch-version-info:end -->