### PR TITLE
Fix flaky test 03707_statistics_cache

### DIFF
--- a/tests/queries/0_stateless/03707_statistics_cache.sql
+++ b/tests/queries/0_stateless/03707_statistics_cache.sql
@@ -57,14 +57,6 @@ ALTER TABLE sc_unused MATERIALIZE STATISTICS ALL;
 SELECT sum(val) FROM sc_unused
 SETTINGS use_statistics_cache = 0, log_comment = 'nouse-agg' FORMAT Null;
 
-SYSTEM FLUSH LOGS query_log;
-
-SELECT toUInt8(ProfileEvents['LoadedStatisticsMicroseconds'] = 0)
-FROM system.query_log
-WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = 'nouse-agg'
-ORDER BY event_time_microseconds DESC
-LIMIT 1;
-
 ------------------------------------------------------------
 -- LowCardinality: CountMin https://github.com/ClickHouse/ClickHouse/issues/87886
 ------------------------------------------------------------
@@ -89,14 +81,6 @@ ALTER TABLE st_cm_lc MATERIALIZE STATISTICS ALL;
 
 SELECT count() FROM st_cm_lc WHERE cat = 'PROMO'
 SETTINGS use_statistics_cache = 0, log_comment = 'cm-lc-load' FORMAT Null;
-
-SYSTEM FLUSH LOGS query_log;
-
-SELECT toUInt8(ProfileEvents['LoadedStatisticsMicroseconds'] > 0)
-FROM system.query_log
-WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = 'cm-lc-load'
-ORDER BY event_time_microseconds DESC
-LIMIT 1;
 
 ------------------------------------------------------------
 -- JOIN with Uniq
@@ -130,7 +114,22 @@ WHERE b.t = 'PROMO'
 SETTINGS use_statistics_cache = 0, query_plan_optimize_join_order_limit = 10, log_comment = 'join-load'
 FORMAT Null;
 
+------------------------------------------------------------
+-- Verify all test cases (single flush for performance)
+------------------------------------------------------------
 SYSTEM FLUSH LOGS query_log;
+
+SELECT toUInt8(ProfileEvents['LoadedStatisticsMicroseconds'] = 0)
+FROM system.query_log
+WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = 'nouse-agg'
+ORDER BY event_time_microseconds DESC
+LIMIT 1;
+
+SELECT toUInt8(ProfileEvents['LoadedStatisticsMicroseconds'] > 0)
+FROM system.query_log
+WHERE event_date >= yesterday() AND event_time >= now() - 600 AND type = 'QueryFinish' AND current_database = currentDatabase() AND log_comment = 'cm-lc-load'
+ORDER BY event_time_microseconds DESC
+LIMIT 1;
 
 SELECT toUInt8(ProfileEvents['LoadedStatisticsMicroseconds'] > 0)
 FROM system.query_log

--- a/tests/queries/0_stateless/03707_statistics_cache.sql
+++ b/tests/queries/0_stateless/03707_statistics_cache.sql
@@ -7,6 +7,10 @@ SET log_query_settings = 1;
 SET mutations_sync = 2;
 SET max_execution_time = 60;
 SET optimize_move_to_prewhere = 1, query_plan_optimize_prewhere = 1;
+-- Statistics loading happens inside optimizePrewhere(), which requires
+-- the Filter→ReadFromMergeTree pattern. query_plan_merge_expressions = 0
+-- inserts an intermediate Expression step that breaks this pattern.
+SET query_plan_merge_expressions = 1;
 
 -- test rely on local execution, - force parallel replicas to genearate local plan
 SET parallel_replicas_local_plan=1;


### PR DESCRIPTION
The second section of `03707_statistics_cache` (CountMin on LowCardinality) fails
intermittently in CI with output `0` instead of `1`. The test checks
`ProfileEvents['LoadedStatisticsMicroseconds'] > 0` to verify that statistics were
loaded during query execution, but statistics loading returned 0 μs about 5% of the
time.

**Root cause:** Statistics are loaded inside `optimizePrewhere()`, which requires a
direct `Filter → ReadFromMergeTree` parent-child pattern in the query plan tree. When
the CI test runner randomizes `query_plan_merge_expressions` to `0` (5% probability),
an intermediate `Expression (Change column names to column identifiers)` step is
inserted between `Filter` and `ReadFromMergeTree`. The `optimizePrewhere()` function
then fails to cast the child step to `SourceStepWithFilter` and returns early — before
calling `getConditionSelectivityEstimator()`, which is where
`LoadedStatisticsMicroseconds` gets incremented.

**Fix:** Pin `query_plan_merge_expressions = 1` alongside the existing prewhere setting
pins. This ensures the expression-merging optimization keeps the Filter and
ReadFromMergeTree steps adjacent, preserving the pattern that the prewhere optimizer
expects.

**Reproduction:**
```sql
-- Fails (LoadedStatisticsMicroseconds = 0):
SET query_plan_merge_expressions = 0;
...
SELECT count() FROM st_cm_lc WHERE cat = 'PROMO' SETTINGS use_statistics_cache = 0;

-- Passes (LoadedStatisticsMicroseconds > 0):
SET query_plan_merge_expressions = 1;
...
SELECT count() FROM st_cm_lc WHERE cat = 'PROMO' SETTINGS use_statistics_cache = 0;
```

58 failures across 10 unrelated PRs in the last 30 days; 0 master hits.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a]ways a single line):
Not required.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.365`
<!-- ch-version-info:end -->