### PR TITLE
compareTrackAt() in partial_merge_join for nullables

### DIFF
--- a/src/Columns/ColumnNullable.h
+++ b/src/Columns/ColumnNullable.h
@@ -52,7 +52,7 @@ public:
     std::string getName() const override { return "Nullable(" + nested_column->getName() + ")"; }
     TypeIndex getDataType() const override { return TypeIndex::Nullable; }
     MutableColumnPtr cloneResized(size_t size) const override;
-    size_t size() const override { return assert_cast<const ColumnUInt8 &>(*null_map).size(); }
+    size_t size() const final { return assert_cast<const ColumnUInt8 &>(*null_map).size(); }
     bool isNullAt(size_t n) const final { return assert_cast<const ColumnUInt8 &>(*null_map).getData()[n] != 0;}
     Field operator[](size_t n) const override;
     void get(size_t n, Field & res) const override;

--- a/src/Columns/ColumnNullable.h
+++ b/src/Columns/ColumnNullable.h
@@ -53,7 +53,7 @@ public:
     TypeIndex getDataType() const override { return TypeIndex::Nullable; }
     MutableColumnPtr cloneResized(size_t size) const override;
     size_t size() const override { return assert_cast<const ColumnUInt8 &>(*null_map).size(); }
-    bool isNullAt(size_t n) const override { return assert_cast<const ColumnUInt8 &>(*null_map).getData()[n] != 0;}
+    bool isNullAt(size_t n) const final { return assert_cast<const ColumnUInt8 &>(*null_map).getData()[n] != 0;}
     Field operator[](size_t n) const override;
     void get(size_t n, Field & res) const override;
     void getValueNameImpl(WriteBufferFromOwnString &, size_t n, const Options &) const override;

--- a/src/Interpreters/MergeJoin.cpp
+++ b/src/Interpreters/MergeJoin.cpp
@@ -81,8 +81,6 @@ ColumnWithTypeAndName condtitionColumnToJoinable(const Block & block, const Stri
 template <bool has_left_nulls, bool has_right_nulls, bool track = false>
 Int64 nullableCompareAt(const IColumn & left_column, const IColumn & right_column, size_t lhs_pos, size_t rhs_pos)
 {
-    static constexpr int null_direction_hint = 1;
-
     const IColumn * left_notnull = &left_column;
     const IColumn * right_notnull = &right_column;
     const ColumnNullable * left_nullable = nullptr;
@@ -95,7 +93,7 @@ Int64 nullableCompareAt(const IColumn & left_column, const IColumn & right_colum
         {
             /// NULL != NULL case
             if (left_nullable->isNullAt(lhs_pos))
-                return null_direction_hint;
+                return -1;
 
             left_notnull = &left_nullable->getNestedColumn();
         }
@@ -107,7 +105,7 @@ Int64 nullableCompareAt(const IColumn & left_column, const IColumn & right_colum
         if (right_nullable)
         {
             if (right_nullable->isNullAt(rhs_pos))
-                return -null_direction_hint;
+                return 1;
 
             right_notnull = &right_nullable->getNestedColumn();
         }
@@ -115,7 +113,7 @@ Int64 nullableCompareAt(const IColumn & left_column, const IColumn & right_colum
 
     if constexpr (track)
     {
-        Int64 res = left_notnull->compareTrackAt(lhs_pos, rhs_pos, *right_notnull, null_direction_hint);
+        Int64 res = left_notnull->compareTrackAt(lhs_pos, rhs_pos, *right_notnull, -1);
 
         if (left_nullable && res < 0)
         {
@@ -136,7 +134,7 @@ Int64 nullableCompareAt(const IColumn & left_column, const IColumn & right_colum
         return res;
     }
     else
-        return left_notnull->compareAt(lhs_pos, rhs_pos, *right_notnull, null_direction_hint);
+        return left_notnull->compareAt(lhs_pos, rhs_pos, *right_notnull, -1);
 }
 
 /// Get first and last row from sorted block

--- a/src/Interpreters/MergeJoin.cpp
+++ b/src/Interpreters/MergeJoin.cpp
@@ -78,7 +78,7 @@ ColumnWithTypeAndName condtitionColumnToJoinable(const Block & block, const Stri
     return {res_col, res_col_type, res_name};
 }
 
-template <bool has_left_nulls, bool has_right_nulls, bool track = false>
+template <bool has_left_nulls, bool has_right_nulls>
 Int64 nullableCompareAt(const IColumn & left_column, const IColumn & right_column, size_t lhs_pos, size_t rhs_pos)
 {
     const IColumn * left_notnull = &left_column;
@@ -111,30 +111,66 @@ Int64 nullableCompareAt(const IColumn & left_column, const IColumn & right_colum
         }
     }
 
-    if constexpr (track)
-    {
-        Int64 res = left_notnull->compareTrackAt(lhs_pos, rhs_pos, *right_notnull, -1);
+    return left_notnull->compareAt(lhs_pos, rhs_pos, *right_notnull, -1);
+}
 
-        if (left_nullable && res < 0)
+template <bool has_left_nulls, bool has_right_nulls>
+Int64 nullableCompareTrackAt(const IColumn & left_column, const IColumn & right_column, size_t lhs_pos, size_t rhs_pos)
+{
+    const IColumn * left_notnull = &left_column;
+    const IColumn * right_notnull = &right_column;
+    const ColumnNullable * left_nullable = nullptr;
+    const ColumnNullable * right_nullable = nullptr;
+
+    if constexpr (has_left_nulls)
+    {
+        left_nullable = checkAndGetColumn<ColumnNullable>(&left_column);
+        if (left_nullable)
         {
-            size_t pos = lhs_pos + 1;
-            size_t end = lhs_pos - res;
-            for (; pos < end; ++pos)
-                if (left_nullable->isNullAt(pos))
-                    return -static_cast<Int64>(pos - lhs_pos);
+            size_t null_pos = lhs_pos;
+            while (null_pos < left_nullable->size() && left_nullable->isNullAt(null_pos))
+                ++null_pos;
+            if (null_pos > lhs_pos)
+                return -static_cast<Int64>(null_pos - lhs_pos);
+
+            left_notnull = &left_nullable->getNestedColumn();
         }
-        if (right_nullable && res > 0)
-        {
-            size_t pos = rhs_pos + 1;
-            size_t end = rhs_pos + res;
-            for (; pos < end; ++pos)
-                if (right_nullable->isNullAt(pos))
-                    return pos - rhs_pos;
-        }
-        return res;
     }
-    else
-        return left_notnull->compareAt(lhs_pos, rhs_pos, *right_notnull, -1);
+
+    if constexpr (has_right_nulls)
+    {
+        right_nullable = checkAndGetColumn<ColumnNullable>(&right_column);
+        if (right_nullable)
+        {
+            size_t null_pos = rhs_pos;
+            while (null_pos < right_nullable->size() && right_nullable->isNullAt(null_pos))
+                ++null_pos;
+            if (null_pos > rhs_pos)
+                return null_pos - rhs_pos;
+
+            right_notnull = &right_nullable->getNestedColumn();
+        }
+    }
+
+    Int64 res = left_notnull->compareTrackAt(lhs_pos, rhs_pos, *right_notnull, -1);
+
+    if (left_nullable && res < 0)
+    {
+        size_t pos = lhs_pos + 1;
+        size_t end = lhs_pos - res;
+        for (; pos < end; ++pos)
+            if (left_nullable->isNullAt(pos))
+                return -static_cast<Int64>(pos - lhs_pos);
+    }
+    if (right_nullable && res > 0)
+    {
+        size_t pos = rhs_pos + 1;
+        size_t end = rhs_pos + res;
+        for (; pos < end; ++pos)
+            if (right_nullable->isNullAt(pos))
+                return pos - rhs_pos;
+    }
+    return res;
 }
 
 /// Get first and last row from sorted block
@@ -341,7 +377,7 @@ private:
 
         while (true)
         {
-            Int64 cmp = nullableCompareAt<left_nulls, right_nulls, true>(
+            Int64 cmp = nullableCompareTrackAt<left_nulls, right_nulls>(
                 *impl.sort_columns[0], *rhs.impl.sort_columns[0], position(), rhs.position());
 
             for (size_t i = 1; (!cmp) && i < impl.sort_columns_size; ++i)

--- a/src/Interpreters/MergeJoin.cpp
+++ b/src/Interpreters/MergeJoin.cpp
@@ -83,49 +83,60 @@ Int64 nullableCompareAt(const IColumn & left_column, const IColumn & right_colum
 {
     static constexpr int null_direction_hint = 1;
 
-    if constexpr (has_left_nulls && has_right_nulls)
-    {
-        const auto * left_nullable = checkAndGetColumn<ColumnNullable>(&left_column);
-        const auto * right_nullable = checkAndGetColumn<ColumnNullable>(&right_column);
-
-        if (left_nullable && right_nullable)
-        {
-            int res = left_column.compareAt(lhs_pos, rhs_pos, right_column, null_direction_hint);
-            if (res)
-                return res;
-
-            /// NULL != NULL case
-            if (left_column.isNullAt(lhs_pos))
-                return null_direction_hint;
-
-            return 0;
-        }
-    }
+    const IColumn * left_notnull = &left_column;
+    const IColumn * right_notnull = &right_column;
+    const ColumnNullable * left_nullable = nullptr;
+    const ColumnNullable * right_nullable = nullptr;
 
     if constexpr (has_left_nulls)
     {
-        if (const auto * left_nullable = checkAndGetColumn<ColumnNullable>(&left_column))
+        left_nullable = checkAndGetColumn<ColumnNullable>(&left_column);
+        if (left_nullable)
         {
-            if (left_column.isNullAt(lhs_pos))
+            /// NULL != NULL case
+            if (left_nullable->isNullAt(lhs_pos))
                 return null_direction_hint;
-            return left_nullable->getNestedColumn().compareAt(lhs_pos, rhs_pos, right_column, null_direction_hint);
+
+            left_notnull = &left_nullable->getNestedColumn();
         }
     }
 
     if constexpr (has_right_nulls)
     {
-        if (const auto * right_nullable = checkAndGetColumn<ColumnNullable>(&right_column))
+        right_nullable = checkAndGetColumn<ColumnNullable>(&right_column);
+        if (right_nullable)
         {
-            if (right_column.isNullAt(rhs_pos))
+            if (right_nullable->isNullAt(rhs_pos))
                 return -null_direction_hint;
-            return left_column.compareAt(lhs_pos, rhs_pos, right_nullable->getNestedColumn(), null_direction_hint);
+
+            right_notnull = &right_nullable->getNestedColumn();
         }
     }
 
     if constexpr (track)
-        return left_column.compareTrackAt(lhs_pos, rhs_pos, right_column, null_direction_hint);
+    {
+        Int64 res = left_notnull->compareTrackAt(lhs_pos, rhs_pos, *right_notnull, null_direction_hint);
+
+        if (left_nullable && res < 0)
+        {
+            size_t pos = lhs_pos + 1;
+            size_t end = lhs_pos - res;
+            for (; pos < end; ++pos)
+                if (left_nullable->isNullAt(pos))
+                    return -static_cast<Int64>(pos - lhs_pos);
+        }
+        if (right_nullable && res > 0)
+        {
+            size_t pos = rhs_pos + 1;
+            size_t end = rhs_pos + res;
+            for (; pos < end; ++pos)
+                if (right_nullable->isNullAt(pos))
+                    return pos - rhs_pos;
+        }
+        return res;
+    }
     else
-        return left_column.compareAt(lhs_pos, rhs_pos, right_column, null_direction_hint);
+        return left_notnull->compareAt(lhs_pos, rhs_pos, *right_notnull, null_direction_hint);
 }
 
 /// Get first and last row from sorted block

--- a/src/Interpreters/MergeJoin.cpp
+++ b/src/Interpreters/MergeJoin.cpp
@@ -163,6 +163,14 @@ Block extractMinMax(const Block & block, const Block & keys)
     return min_max;
 }
 
+std::vector<ColumnPtr> extractColumnsByNames(const Block & src, const Block & names)
+{
+    std::vector<ColumnPtr> columns;
+    columns.reserve(names.columns());
+    for (size_t i = 0; i < names.columns(); ++i)
+        columns.push_back(src.getByName(names.getByPosition(i).name).column);
+    return columns;
+}
 }
 
 
@@ -431,12 +439,11 @@ void copyLeftRange(const Block & block, MutableColumns & columns, size_t start, 
     }
 }
 
-void copyRightRange(const Block & right_block, const Block & right_columns_to_add, MutableColumns & columns,
-                    size_t row_position, size_t rows_to_add)
+void copyRightRange(const std::vector<ColumnPtr> & columns_to_add, MutableColumns & columns, size_t row_position, size_t rows_to_add)
 {
-    for (size_t i = 0; i < right_columns_to_add.columns(); ++i)
+    for (size_t i = 0; i < columns_to_add.size(); ++i)
     {
-        const auto & src_column = right_block.getByName(right_columns_to_add.getByPosition(i).name).column;
+        const auto & src_column = columns_to_add[i];
         auto & dst_column = columns[i];
         auto * dst_nullable = typeid_cast<ColumnNullable *>(dst_column.get());
 
@@ -447,14 +454,19 @@ void copyRightRange(const Block & right_block, const Block & right_columns_to_ad
     }
 }
 
-void joinEqualsAnyLeft(const Block & right_block, const Block & right_columns_to_add, MutableColumns & right_columns, const MergeJoinEqualRange & range)
+void joinEqualsAnyLeft(const std::vector<ColumnPtr> & columns_to_add, MutableColumns & right_columns, const MergeJoinEqualRange & range)
 {
-    copyRightRange(right_block, right_columns_to_add, right_columns, range.right_start, range.left_length);
+    copyRightRange(columns_to_add, right_columns, range.right_start, range.left_length);
 }
 
 template <bool is_all>
-bool joinEquals(const Block & left_block, const Block & right_block, const Block & right_columns_to_add,
-                MutableColumns & left_columns, MutableColumns & right_columns, MergeJoinEqualRange & range, size_t max_rows [[maybe_unused]])
+bool joinEquals(
+    const Block & left_block,
+    const std::vector<ColumnPtr> & columns_to_add,
+    MutableColumns & left_columns,
+    MutableColumns & right_columns,
+    MergeJoinEqualRange & range,
+    size_t max_rows [[maybe_unused]])
 {
     bool one_more = true;
 
@@ -475,14 +487,14 @@ bool joinEquals(const Block & left_block, const Block & right_block, const Block
         for (size_t right_row = 0; right_row < range.right_length; ++right_row, ++row_position)
         {
             copyLeftRange(left_block, left_columns, range.left_start, left_rows_to_add);
-            copyRightRange(right_block, right_columns_to_add, right_columns, row_position, left_rows_to_add);
+            copyRightRange(columns_to_add, right_columns, row_position, left_rows_to_add);
         }
     }
     else
     {
         size_t left_rows_to_add = range.left_length;
         copyLeftRange(left_block, left_columns, range.left_start, left_rows_to_add);
-        copyRightRange(right_block, right_columns_to_add, right_columns, range.right_start, left_rows_to_add);
+        copyRightRange(columns_to_add, right_columns, range.right_start, left_rows_to_add);
     }
 
     return one_more;
@@ -937,6 +949,8 @@ bool MergeJoin::leftJoin(MergeJoinCursor & left_cursor, const Block & left_block
     MergeJoinCursor right_cursor(right_block, right_merge_description);
     left_cursor.setCompareNullability(right_cursor);
 
+    auto r_columns_to_add = extractColumnsByNames(right_block, right_columns_to_add);
+
     /// Set right cursor position in first continuation right block
     if constexpr (is_all)
     {
@@ -964,7 +978,7 @@ bool MergeJoin::leftJoin(MergeJoinCursor & left_cursor, const Block & left_block
 
             size_t max_rows = maxRangeRows(left_columns[0]->size(), max_joined_block_rows);
 
-            if (!joinEquals<true>(left_block, right_block, right_columns_to_add, left_columns, right_columns, range, max_rows))
+            if (!joinEquals<true>(left_block, r_columns_to_add, left_columns, right_columns, range, max_rows))
             {
                 right_cursor.nextN(range.right_length);
                 right_block_info.skip = right_cursor.position();
@@ -973,7 +987,7 @@ bool MergeJoin::leftJoin(MergeJoinCursor & left_cursor, const Block & left_block
             }
         }
         else
-            joinEqualsAnyLeft(right_block, right_columns_to_add, right_columns, range);
+            joinEqualsAnyLeft(r_columns_to_add, right_columns, range);
 
         right_cursor.nextN(range.right_length);
 
@@ -999,6 +1013,8 @@ bool MergeJoin::allInnerJoin(MergeJoinCursor & left_cursor, const Block & left_b
     MergeJoinCursor right_cursor(right_block, right_merge_description);
     left_cursor.setCompareNullability(right_cursor);
 
+    auto r_columns_to_add = extractColumnsByNames(right_block, right_columns_to_add);
+
     /// Set right cursor position in first continuation right block
     right_cursor.nextN(right_block_info.skip);
     right_block_info.skip = 0;
@@ -1013,7 +1029,7 @@ bool MergeJoin::allInnerJoin(MergeJoinCursor & left_cursor, const Block & left_b
 
         size_t max_rows = maxRangeRows(left_columns[0]->size(), max_joined_block_rows);
 
-        if (!joinEquals<true>(left_block, right_block, right_columns_to_add, left_columns, right_columns, range, max_rows))
+        if (!joinEquals<true>(left_block, r_columns_to_add, left_columns, right_columns, range, max_rows))
         {
             right_cursor.nextN(range.right_length);
             right_block_info.skip = right_cursor.position();
@@ -1041,13 +1057,15 @@ bool MergeJoin::semiLeftJoin(MergeJoinCursor & left_cursor, const Block & left_b
     MergeJoinCursor right_cursor(right_block, right_merge_description);
     left_cursor.setCompareNullability(right_cursor);
 
+    auto r_columns_to_add = extractColumnsByNames(right_block, right_columns_to_add);
+
     while (!left_cursor.atEnd() && !right_cursor.atEnd())
     {
         MergeJoinEqualRange range = left_cursor.getNextEqualRange(right_cursor);
         if (range.empty())
             break;
 
-        joinEquals<false>(left_block, right_block, right_columns_to_add, left_columns, right_columns, range, 0);
+        joinEquals<false>(left_block, r_columns_to_add, left_columns, right_columns, range, 0);
 
         right_cursor.nextN(range.right_length);
         left_cursor.nextN(range.left_length);

--- a/src/Interpreters/MergeJoin.cpp
+++ b/src/Interpreters/MergeJoin.cpp
@@ -459,7 +459,7 @@ void makeSortAndMerge(const Names & keys, SortDescription & sort, SortDescriptio
         if (!unique_keys.contains(key_name))
         {
             unique_keys.insert(key_name);
-            sort.emplace_back(key_name);
+            sort.emplace_back(key_name, /*direction*/1, /*nulls_direction*/-1);
         }
     }
 }

--- a/src/Interpreters/MergeJoin.cpp
+++ b/src/Interpreters/MergeJoin.cpp
@@ -114,9 +114,12 @@ Int64 nullableCompareAt(const IColumn & left_column, const IColumn & right_colum
     return left_notnull->compareAt(lhs_pos, rhs_pos, *right_notnull, MergeJoin::nulls_direction);
 }
 
+// Compare first key column with (left NULL != right NULL) logic & track
 template <bool has_left_nulls, bool has_right_nulls>
 Int64 nullableCompareTrackAt(const IColumn & left_column, const IColumn & right_column, size_t lhs_pos, size_t rhs_pos)
 {
+    static_assert(MergeJoin::nulls_direction == -1); // NULLs are first
+
     const IColumn * left_notnull = &left_column;
     const IColumn * right_notnull = &right_column;
     const ColumnNullable * left_nullable = nullptr;
@@ -127,11 +130,15 @@ Int64 nullableCompareTrackAt(const IColumn & left_column, const IColumn & right_
         left_nullable = checkAndGetColumn<ColumnNullable>(&left_column);
         if (left_nullable)
         {
-            size_t null_pos = lhs_pos;
-            while (null_pos < left_nullable->size() && left_nullable->isNullAt(null_pos))
-                ++null_pos;
-            if (null_pos > lhs_pos)
-                return -static_cast<Int64>(null_pos - lhs_pos);
+            // Source block is sorted with 'NULLs are first' order. Check NULLs only for lhs_pos == 0.
+            if (!lhs_pos)
+            {
+                size_t null_pos = 0;
+                while (null_pos < left_nullable->size() && left_nullable->isNullAt(null_pos))
+                    ++null_pos;
+                if (null_pos)
+                    return -static_cast<Int64>(null_pos);
+            }
 
             left_notnull = &left_nullable->getNestedColumn();
         }
@@ -142,35 +149,23 @@ Int64 nullableCompareTrackAt(const IColumn & left_column, const IColumn & right_
         right_nullable = checkAndGetColumn<ColumnNullable>(&right_column);
         if (right_nullable)
         {
-            size_t null_pos = rhs_pos;
-            while (null_pos < right_nullable->size() && right_nullable->isNullAt(null_pos))
-                ++null_pos;
-            if (null_pos > rhs_pos)
-                return null_pos - rhs_pos;
+            // Source block is sorted with 'NULLs are first' order. Check NULLs only for rhs_pos == 0.
+            // It also known we've already skipped all left NULLs.
+            if (!rhs_pos)
+            {
+                size_t null_pos = 0;
+                while (null_pos < right_nullable->size() && right_nullable->isNullAt(null_pos))
+                    ++null_pos;
+                if (null_pos)
+                    return null_pos;
+            }
 
             right_notnull = &right_nullable->getNestedColumn();
         }
     }
 
-    Int64 res = left_notnull->compareTrackAt(lhs_pos, rhs_pos, *right_notnull, MergeJoin::nulls_direction);
-
-    if (left_nullable && res < 0)
-    {
-        size_t pos = lhs_pos + 1;
-        size_t end = lhs_pos - res;
-        for (; pos < end; ++pos)
-            if (left_nullable->isNullAt(pos))
-                return -static_cast<Int64>(pos - lhs_pos);
-    }
-    if (right_nullable && res > 0)
-    {
-        size_t pos = rhs_pos + 1;
-        size_t end = rhs_pos + res;
-        for (; pos < end; ++pos)
-            if (right_nullable->isNullAt(pos))
-                return pos - rhs_pos;
-    }
-    return res;
+    // No need to check if column values have NULLs inside the track. It's the first key column.
+    return left_notnull->compareTrackAt(lhs_pos, rhs_pos, *right_notnull, MergeJoin::nulls_direction);
 }
 
 /// Get first and last row from sorted block
@@ -304,6 +299,10 @@ public:
 
         if (impl.sort_columns_size == 0)
             throw Exception(ErrorCodes::LOGICAL_ERROR, "MergeJoinCursor requires sort_columns size greater then 0");
+
+        /// We use zero position as 'is first range in block' detector
+        if (position())
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "MergeJoinCursor is expected to have initial position 0");
     }
 
     size_t position() const { return impl.getPos(); }

--- a/src/Interpreters/MergeJoin.cpp
+++ b/src/Interpreters/MergeJoin.cpp
@@ -78,6 +78,7 @@ ColumnWithTypeAndName condtitionColumnToJoinable(const Block & block, const Stri
     return {res_col, res_col_type, res_name};
 }
 
+// Compare with (left NULL != right NULL) logic
 template <bool has_left_nulls, bool has_right_nulls>
 Int64 nullableCompareAt(const IColumn & left_column, const IColumn & right_column, size_t lhs_pos, size_t rhs_pos)
 {
@@ -91,9 +92,8 @@ Int64 nullableCompareAt(const IColumn & left_column, const IColumn & right_colum
         left_nullable = checkAndGetColumn<ColumnNullable>(&left_column);
         if (left_nullable)
         {
-            /// NULL != NULL case
             if (left_nullable->isNullAt(lhs_pos))
-                return -1;
+                return MergeJoin::nulls_direction;
 
             left_notnull = &left_nullable->getNestedColumn();
         }
@@ -105,13 +105,13 @@ Int64 nullableCompareAt(const IColumn & left_column, const IColumn & right_colum
         if (right_nullable)
         {
             if (right_nullable->isNullAt(rhs_pos))
-                return 1;
+                return -MergeJoin::nulls_direction;
 
             right_notnull = &right_nullable->getNestedColumn();
         }
     }
 
-    return left_notnull->compareAt(lhs_pos, rhs_pos, *right_notnull, -1);
+    return left_notnull->compareAt(lhs_pos, rhs_pos, *right_notnull, MergeJoin::nulls_direction);
 }
 
 template <bool has_left_nulls, bool has_right_nulls>
@@ -152,7 +152,7 @@ Int64 nullableCompareTrackAt(const IColumn & left_column, const IColumn & right_
         }
     }
 
-    Int64 res = left_notnull->compareTrackAt(lhs_pos, rhs_pos, *right_notnull, -1);
+    Int64 res = left_notnull->compareTrackAt(lhs_pos, rhs_pos, *right_notnull, MergeJoin::nulls_direction);
 
     if (left_nullable && res < 0)
     {
@@ -459,7 +459,7 @@ void makeSortAndMerge(const Names & keys, SortDescription & sort, SortDescriptio
         if (!unique_keys.contains(key_name))
         {
             unique_keys.insert(key_name);
-            sort.emplace_back(key_name, /*direction*/1, /*nulls_direction*/-1);
+            sort.emplace_back(key_name, /*direction*/1, MergeJoin::nulls_direction);
         }
     }
 }

--- a/src/Interpreters/MergeJoin.h
+++ b/src/Interpreters/MergeJoin.h
@@ -20,6 +20,8 @@ enum class JoinTableSide : uint8_t;
 class MergeJoin : public IJoin
 {
 public:
+    static constexpr Int32 nulls_direction = -1;
+
     MergeJoin(std::shared_ptr<TableJoin> table_join_, SharedHeader right_sample_block);
 
     struct NotProcessed


### PR DESCRIPTION
### Changelog category (leave one):
- performance improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
perf improvement in partial_merge_join

Missing part of #99013 

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.618`
<!-- ch-version-info:end -->