### PR TITLE
Optimize Keeper span instrumentation hot path

### DIFF
--- a/src/Common/ZooKeeper/KeeperSpans.cpp
+++ b/src/Common/ZooKeeper/KeeperSpans.cpp
@@ -1,5 +1,7 @@
 #include <Common/ZooKeeper/KeeperSpans.h>
+#include <Common/thread_local_rng.h>
 #include <Coordination/KeeperDispatcher.h>
+#include <Interpreters/OpenTelemetrySpanLog.h>
 #include <Interpreters/Context.h>
 #include <optional>
 

--- a/src/Common/ZooKeeper/KeeperSpans.cpp
+++ b/src/Common/ZooKeeper/KeeperSpans.cpp
@@ -45,19 +45,19 @@ void ZooKeeperOpentelemetrySpans::maybeInitialize(
     UInt64 start_time_us)
 {
     chassert(maybe_span.start_time_us == 0);
-    chassert(maybe_span.span == std::nullopt);
+    chassert(!maybe_span.span);
 
     maybe_span.start_time_us = start_time_us;
 
     if (!parent_context)
         return;
 
-    maybe_span.span.emplace(OpenTelemetry::Span{
+    maybe_span.span = std::make_unique<OpenTelemetry::Span>(OpenTelemetry::Span{
         .trace_id = parent_context->trace_id,
         .span_id = thread_local_rng(),
         .parent_span_id = parent_context->span_id,
         .operation_name = String(maybe_span.operation_name),
-        .start_time_us = start_time_us,
+        .start_time_us = maybe_span.start_time_us,
         .kind = maybe_span.kind,
     });
 }

--- a/src/Common/ZooKeeper/KeeperSpans.cpp
+++ b/src/Common/ZooKeeper/KeeperSpans.cpp
@@ -73,6 +73,7 @@ void ZooKeeperOpentelemetrySpans::maybeFinalizeImpl(
 
     maybe_span.histogram.observe((finish_time_us - maybe_span.start_time_us) / 1000);
 
+    /// Defensive branch: `maybeFinalize` handles the no-span case before calling `maybeFinalizeImpl`.
     if (!maybe_span.span)
         return;
 

--- a/src/Common/ZooKeeper/KeeperSpans.h
+++ b/src/Common/ZooKeeper/KeeperSpans.h
@@ -2,10 +2,7 @@
 
 #include <Common/HistogramMetrics.h>
 #include <Common/OpenTelemetryTraceContext.h>
-#include <Common/thread_local_rng.h>
 #include <Core/Types.h>
-#include <Interpreters/OpenTelemetrySpanLog.h>
-#include <unordered_map>
 #include <string>
 #include <chrono>
 #include <optional>

--- a/src/Common/ZooKeeper/KeeperSpans.h
+++ b/src/Common/ZooKeeper/KeeperSpans.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <chrono>
 #include <optional>
+#include <memory>
 
 namespace HistogramMetrics
 {
@@ -36,11 +37,40 @@ struct MaybeSpan
     const std::string_view operation_name;
     const OpenTelemetry::SpanKind kind;
     HistogramMetrics::Metric & histogram;
-    std::optional<OpenTelemetry::Span> span;
+    std::unique_ptr<OpenTelemetry::Span> span;
     UInt64 start_time_us = 0;
 
     MaybeSpan(const std::string_view operation_name_, OpenTelemetry::SpanKind kind_, HistogramMetrics::Metric & histogram_)
         : operation_name(operation_name_), kind(kind_), histogram(histogram_) {}
+
+    MaybeSpan(const MaybeSpan & other)
+        : operation_name(other.operation_name)
+        , kind(other.kind)
+        , histogram(other.histogram)
+        , span(other.span ? std::make_unique<OpenTelemetry::Span>(*other.span) : nullptr)
+        , start_time_us(other.start_time_us)
+    {
+    }
+
+    MaybeSpan & operator=(const MaybeSpan & other)
+    {
+        if (this == &other)
+            return *this;
+
+        chassert(operation_name == other.operation_name);
+        chassert(kind == other.kind);
+        chassert(&histogram == &other.histogram);
+
+        start_time_us = other.start_time_us;
+        if (other.span)
+            span = std::make_unique<OpenTelemetry::Span>(*other.span);
+        else
+            span.reset();
+
+        return *this;
+    }
+
+    MaybeSpan(MaybeSpan &&) noexcept = default;
 };
 
 struct ZooKeeperOpentelemetrySpans

--- a/src/Common/ZooKeeper/KeeperSpans.h
+++ b/src/Common/ZooKeeper/KeeperSpans.h
@@ -32,6 +32,7 @@ namespace Coordination
 namespace DB
 {
 
+/// `MaybeSpan` tracks an interval for histogram metrics and, optionally, for an OpenTelemetry span.
 struct MaybeSpan
 {
     const std::string_view operation_name;
@@ -103,6 +104,7 @@ struct ZooKeeperOpentelemetrySpans
     MaybeSpan pre_commit{"keeper.write.pre_commit", OpenTelemetry::SpanKind::INTERNAL, HistogramMetrics::KeeperWritePreCommitTime};
     MaybeSpan commit{"keeper.write.commit", OpenTelemetry::SpanKind::INTERNAL, HistogramMetrics::KeeperWriteCommitTime};
 
+    /// Wall-clock microseconds since epoch (`std::chrono::system_clock`).
     static UInt64 now()
     {
         return std::chrono::duration_cast<std::chrono::microseconds>(

--- a/src/Common/ZooKeeper/KeeperSpans.h
+++ b/src/Common/ZooKeeper/KeeperSpans.h
@@ -71,6 +71,21 @@ struct MaybeSpan
     }
 
     MaybeSpan(MaybeSpan &&) noexcept = default;
+
+    MaybeSpan & operator=(MaybeSpan && other) noexcept
+    {
+        if (this == &other)
+            return *this;
+
+        chassert(operation_name == other.operation_name);
+        chassert(kind == other.kind);
+        chassert(&histogram == &other.histogram);
+
+        start_time_us = other.start_time_us;
+        span = std::move(other.span);
+
+        return *this;
+    }
 };
 
 struct ZooKeeperOpentelemetrySpans
@@ -119,10 +134,10 @@ struct ZooKeeperOpentelemetrySpans
 
     static void maybeFinalizeImpl(
         MaybeSpan & maybe_span,
-        std::vector<OpenTelemetry::SpanAttribute> attributes = {},
-        OpenTelemetry::SpanStatus status = OpenTelemetry::SpanStatus::OK,
-        const String & error_message = {},
-        UInt64 finish_time_us = now());
+        std::vector<OpenTelemetry::SpanAttribute> attributes,
+        OpenTelemetry::SpanStatus status,
+        const String & error_message,
+        UInt64 finish_time_us);
 };
 
 }

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -603,14 +603,14 @@ bool KeeperDispatcher::putRequest(const Coordination::ZooKeeperRequestPtr & requ
     KeeperRequestForSession request_info;
     request_info.use_xid_64 = use_xid_64;
     request_info.request = request;
-    using namespace std::chrono;
-    request_info.time = duration_cast<milliseconds>(system_clock::now().time_since_epoch()).count();
+    const UInt64 enqueue_time_us = ZooKeeperOpentelemetrySpans::now();
+    request_info.time = enqueue_time_us / 1000;
     request_info.session_id = session_id;
 
     if (keeper_context->isShutdownCalled())
         return false;
 
-    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans.dispatcher_requests_queue, request->tracing_context);
+    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans.dispatcher_requests_queue, request->tracing_context, enqueue_time_us);
 
     /// Put close requests without timeouts
     if (request->getOpNum() == Coordination::OpNum::Close)

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -628,7 +628,13 @@ nuraft::ptr<nuraft::buffer> KeeperStateMachine<Storage>::commit(const uint64_t l
     {
         response.response->enqueue_ts = std::chrono::steady_clock::now();
         if (response.request)
-            ZooKeeperOpentelemetrySpans::maybeInitialize(response.request->spans.dispatcher_responses_queue, response.request->tracing_context);
+        {
+            const UInt64 enqueue_time_us = ZooKeeperOpentelemetrySpans::now();
+            ZooKeeperOpentelemetrySpans::maybeInitialize(
+                response.request->spans.dispatcher_responses_queue,
+                response.request->tracing_context,
+                enqueue_time_us);
+        }
         if (!responses_queue.push(response))
         {
             ProfileEvents::increment(ProfileEvents::KeeperCommitsFailed);
@@ -1480,7 +1486,13 @@ void KeeperStateMachine<Storage>::processReadRequest(const KeeperRequestForSessi
                 response_for_session.request = request_for_session.request;
             response_for_session.response->enqueue_ts = std::chrono::steady_clock::now();
             if (response_for_session.request)
-                ZooKeeperOpentelemetrySpans::maybeInitialize(response_for_session.request->spans.dispatcher_responses_queue, response_for_session.request->tracing_context);
+            {
+                const UInt64 enqueue_time_us = ZooKeeperOpentelemetrySpans::now();
+                ZooKeeperOpentelemetrySpans::maybeInitialize(
+                    response_for_session.request->spans.dispatcher_responses_queue,
+                    response_for_session.request->tracing_context,
+                    enqueue_time_us);
+            }
             if (!responses_queue.push(response_for_session))
                 LOG_WARNING(log, "Failed to push response with session id {} to the queue, probably because of shutdown", response_for_session.session_id);
         }

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -26,6 +26,7 @@
 #include <Common/OpenTelemetryTraceContext.h>
 #include <Common/Exception.h>
 #include <Common/ProfileEvents.h>
+#include <Common/thread_local_rng.h>
 #include <Common/ZooKeeper/ZooKeeperCommon.h>
 #include <Common/ZooKeeper/ZooKeeperConstants.h>
 #include <Common/ZooKeeper/ZooKeeperIO.h>


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Keeper processes requests faster by reducing internal instrumentation overhead on hot paths, improving throughput by ~15% and lowering latency at high QPS.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Reduce per-request instrumentation overhead in Keeper hot paths. At high QPS the cost of `ZooKeeperOpentelemetrySpans` becomes visible: every request eagerly evaluates wall-clock timestamps in default arguments and carries a full `OpenTelemetry::Span` object inline (`std::optional`) even when tracing is disabled.

This PR switches `MaybeSpan::span` to `std::unique_ptr` (heap-allocated only when tracing is active, saving ~1 KB per request), replaces eager default-argument timestamp reads with lazy resolution inside the function body, and uses `CLOCK_MONOTONIC_COARSE` for histogram-only durations while keeping wall-clock microseconds for real OpenTelemetry spans. Enqueue timestamps in `KeeperDispatcher::putRequest` and `KeeperStateMachine` are computed once and reused for both `request_info.time` and span initialization. No protocol, settings, or user-visible semantic changes.

Benchmarked with `force_sync` disabled (to measure CPU overhead, not `fsync`): **+15% RPS, -13% p50 latency, -15% p99 latency** across read/write workloads.

<details>
<summary>Benchmark results (upstream/master vs this branch, force_sync disabled)</summary>

| Metric | `upstream/master` | this branch | Delta |
|---|---:|---:|---:|
| Read RPS | 162752 | 187804 | +15.4% |
| Write RPS | 32536.7 | 37541.3 | +15.4% |
| Read p50 | 3.366 ms | 2.948 ms | -12.4% |
| Read p99 | 6.019 ms | 5.122 ms | -14.9% |
| Write p50 | 3.491 ms | 3.052 ms | -12.6% |
| Write p99 | 6.027 ms | 5.128 ms | -14.9% |

**Per-operation:**

| Operation | master RPS | branch RPS | Delta |
|---|---:|---:|---:|
| `Create` | 8139.7 | 9411.0 | +15.6% |
| `Remove` | 8134.6 | 9378.2 | +15.3% |
| `Get` | 162752 | 187804 | +15.4% |
| `Multi` | 16262.5 | 18752.1 | +15.3% |

<details>
<summary>Raw output: upstream/master</summary>

```text
read requests 7816938, write requests 1562728, Read RPS: 162752, Read MiB/s: 19.2852, Write RPS: 32536.7, Write MiB/s: 36.321.

Read sampler:
0%      0.105 msec.
10%     1.971 msec.
20%     2.394 msec.
30%     2.743 msec.
40%     3.046 msec.
50%     3.366 msec.
60%     3.687 msec.
70%     4.025 msec.
80%     4.414 msec.
90%     4.926 msec.
95%     5.316 msec.
99%     6.019 msec.
99.9%   13.206 msec.
99.99%  40.801 msec.

Write sampler:
0%      0.538 msec.
10%     2.074 msec.
20%     2.495 msec.
30%     2.838 msec.
40%     3.165 msec.
50%     3.491 msec.
60%     3.795 msec.
70%     4.122 msec.
80%     4.49 msec.
90%     4.986 msec.
95%     5.378 msec.
99%     6.027 msec.
99.9%   12.386 msec.
99.99%  37.904 msec.

Per-operation breakdown:
  Create: 390947 requests, 8139.7 RPS, p50 3.45 ms, p99 6.12 ms
  Remove: 390700 requests, 8134.56 RPS, p50 3.452 ms, p99 6.114 ms
  Get: 7816938 requests, 162752 RPS, p50 3.366 ms, p99 6.019 ms
  Multi: 781081 requests, 16262.5 RPS, p50 3.469 ms, p99 6.103 ms
```

</details>

<details>
<summary>Raw output: this branch</summary>

```text
Requests executed: 6313169.

read requests 5261432, write requests 1051744, Read RPS: 187804, Read MiB/s: 22.2537, Write RPS: 37541.3, Write MiB/s: 41.8878.

Read sampler:
0%      0.149 msec.
10%     1.808 msec.
20%     2.143 msec.
30%     2.43 msec.
40%     2.686 msec.
50%     2.948 msec.
60%     3.223 msec.
70%     3.502 msec.
80%     3.794 msec.
90%     4.19 msec.
95%     4.498 msec.
99%     5.122 msec.
99.9%   14.656 msec.
99.99%  42.606 msec.

Write sampler:
0%      0.634 msec.
10%     1.898 msec.
20%     2.224 msec.
30%     2.512 msec.
40%     2.773 msec.
50%     3.052 msec.
60%     3.313 msec.
70%     3.581 msec.
80%     3.878 msec.
90%     4.25 msec.
95%     4.53 msec.
99%     5.128 msec.
99.9%   37.163 msec.
99.99%  43.96 msec.

Per-operation breakdown:
  Create: 263656 requests, 9411.04 RPS, p50 3.013 ms, p99 5.174 ms
  Remove: 262737 requests, 9378.23 RPS, p50 3.033 ms, p99 5.171 ms
  Get: 5261432 requests, 187804 RPS, p50 2.948 ms, p99 5.122 ms
  Multi: 525351 requests, 18752.1 RPS, p50 3.068 ms, p99 5.156 ms
```

</details></details>