### PR TITLE
Pin query_plan_join_shard_by_pk_ranges in EXPLAIN pretty tests

### DIFF
--- a/tests/queries/0_stateless/04011_explain_pretty_join.sql
+++ b/tests/queries/0_stateless/04011_explain_pretty_join.sql
@@ -4,6 +4,7 @@ SET enable_join_runtime_filters = 0;
 SET query_plan_join_swap_table = 0;
 SET enable_parallel_replicas = 0;
 SET use_statistics = 0;
+SET query_plan_join_shard_by_pk_ranges = 0;
 
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t2;

--- a/tests/queries/0_stateless/04012_explain_pretty_output.sql
+++ b/tests/queries/0_stateless/04012_explain_pretty_output.sql
@@ -4,6 +4,7 @@ SET enable_join_runtime_filters = 0;
 SET query_plan_join_swap_table = 0;
 SET enable_parallel_replicas = 0;
 SET use_statistics = 0;
+SET query_plan_join_shard_by_pk_ranges = 0;
 
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t2;


### PR DESCRIPTION
Pin `query_plan_join_shard_by_pk_ranges = 0` in tests `04011_explain_pretty_join` and `04012_explain_pretty_output` to fix intermittent failures.

The setting is randomized in CI with 30% probability of being `True`. When enabled, it adds an extra `Sharding: [(key = key)]` line to the join EXPLAIN output, which doesn't match the reference files.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


Broken in #100624

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.343`
<!-- ch-version-info:end -->