### PR TITLE
CI: fix check_sync_pr_mergeable to use linked_pr_number

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/check_sync_pr_mergeable.py
+++ b/ci/jobs/scripts/workflow_hooks/check_sync_pr_mergeable.py
@@ -11,12 +11,12 @@ SYNC_REPO = "ClickHouse/clickhouse-private"
 def check():
     info = Info()
 
-    if not info.pr_number > 0:
-        print(f"WARNING: Invalid or unknown pr number: {info.pr_number}")
+    if not info.linked_pr_number > 0:
+        print(f"WARNING: Invalid or unknown pr number: {info.linked_pr_number}")
         return True
 
     raw = Shell.get_output(
-        f"gh pr list --state open --head sync-upstream/pr/{info.pr_number} --repo {SYNC_REPO} --json number --jq '.[].number'",
+        f"gh pr list --state open --head sync-upstream/pr/{info.linked_pr_number} --repo {SYNC_REPO} --json number --jq '.[].number'",
         verbose=True,
         retries=3,
     )
@@ -32,7 +32,7 @@ def check():
 
     if len(sync_pr_numbers) > 1:
         print(
-            f"ERROR: Expected at most one open Sync PR for branch sync-upstream/pr/{info.pr_number}, "
+            f"ERROR: Expected at most one open Sync PR for branch sync-upstream/pr/{info.linked_pr_number}, "
             f"found {len(sync_pr_numbers)}: {sync_pr_numbers}"
         )
         return False


### PR DESCRIPTION
In Push and Merge Queue workflows, `info.pr_number` is 0 because there is no open PR for the event. The sync PR branch is named `sync-upstream/pr/<N>` where `N` is the PR that was merged — this number is available via `info.linked_pr_number`. Using `pr_number` caused the check to always exit early with a WARNING and skip the actual mergeability check.

follow-up fix https://github.com/ClickHouse/ClickHouse/pull/100934

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.339`
<!-- ch-version-info:end -->