### PR TITLE
Use resize_exact for string function output buffers with pre-computed sizes

### DIFF
--- a/src/Functions/formatString.h
+++ b/src/Functions/formatString.h
@@ -77,8 +77,8 @@ struct FormatStringImpl
         for (size_t i = 1; i < substrings.size(); ++i)
             final_size += data[index_positions[i - 1]]->size();
 
-        res_data.resize(final_size);
-        res_offsets.resize(input_rows_count);
+        res_data.resize_exact(final_size);
+        res_offsets.resize_exact(input_rows_count);
 
         UInt64 offset = 0;
         for (UInt64 i = 0; i < input_rows_count; ++i)

--- a/src/Functions/soundex.cpp
+++ b/src/Functions/soundex.cpp
@@ -82,8 +82,8 @@ struct SoundexImpl
         ColumnString::Offsets & res_offsets,
         size_t input_rows_count)
     {
-        res_data.resize(input_rows_count * length);
-        res_offsets.resize(input_rows_count);
+        res_data.resize_exact(input_rows_count * length);
+        res_offsets.resize_exact(input_rows_count);
 
         size_t prev_offset = 0;
         for (size_t i = 0; i < input_rows_count; ++i)


### PR DESCRIPTION
Several string functions pre-calculate the exact output buffer size but then call `resize()`, which internally uses `reallocPowerOfTwoElements` and rounds up to the next power of two. This wastes memory when the exact size is already known.

This PR switches to `resize_exact()` (which uses `reserve_exact`) in two places where the total output size is computed before the allocation:

- `FormatStringImpl::format` (line 80-81) — used by `concat`, `format`
- `SoundexImpl` (line 85-86) — used by `soundex`

Note: `LowerUpperUTF8Impl` was intentionally NOT changed. UTF-8 case conversion can produce longer output (e.g., `ß` → `SS`), so the existing power-of-two headroom is valuable there — without it, the `U_BUFFER_OVERFLOW_ERROR` retry path would trigger more frequently.

### Why this matters

`PODArray::resize(n)` calls `reserve(n)` → `reallocPowerOfTwoElements(n)`, which rounds up to the next power of two. For large string columns, this can waste significant memory. For example, a 125 MB concat result may get a 256 MB allocation.

`PODArray::resize_exact(n)` calls `reserve_exact(n)` → `realloc(minimum_memory_for_elements(n))`, which allocates only what is needed. The SIMD padding (`pad_right`) is still included, so `memcpySmallAllowReadWriteOverflow15` remains safe.

In `FormatStringImpl::format`, the `final_size` computation is provably exact — verified by the existing `chassert(offset == final_size)` at line 125.

### Benchmark

Same-version A/B test, ClickHouse deployed in Kubernetes (kind cluster), 5M rows in a `String` column table.

Query: `SELECT concat(short_str, '_', toString(id), '_', category) FROM string_data FORMAT Null`

| Metric | Control (`resize`) | Experiment (`resize_exact`) | Change |
|--------|---------|------------|--------|
| FormatString alloc count (trace_log) | 34 | 30 | -12% |
| FormatString alloc MB (trace_log) | 155.7 | 125.0 | **-20%** |
| concat query peak memory | 16.1 MB avg | 13.1 MB avg | **-19%** |
| concat latency | 66 ms | 63 ms | neutral |

Profiled via `system.trace_log` with `trace_type='Memory'`, filtering stacks containing `FormatStringImpl`. Three iterations per query, both builds from the same commit.

### How to reproduce

```sql
CREATE TABLE string_data (
    id UInt64, short_str String, medium_str String,
    category LowCardinality(String), value Float64, ts DateTime
) ENGINE = MergeTree() ORDER BY (category, ts);

INSERT INTO string_data
SELECT number,
       concat('prefix_', toString(rand()%10000), '_suffix'),
       repeat(concat('word', toString(rand()%100), ' '), 15),
       arrayElement(['electronics','clothing','food','automotive','software'], (number%5)+1),
       rand()/4294967295.0*1000,
       toDateTime('2024-01-01') + toIntervalSecond(number)
FROM numbers(5000000);

-- Run this query and check memory_usage in system.query_log:
SELECT concat(short_str, '_', toString(id), '_', category)
FROM string_data FORMAT Null;

-- Check FormatString allocations:
SELECT count(), round(sum(abs(size))/1048576, 1) AS total_mb
FROM system.trace_log
WHERE trace_type = 'Memory'
  AND arrayStringConcat(arrayMap(x -> demangle(addressToSymbol(x)), trace), ' ')
      LIKE '%FormatStringImpl%'
SETTINGS allow_introspection_functions=1;
```

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduced memory usage by ~20% for `concat`, `format`, and `soundex` functions by using exact-size buffer allocation instead of power-of-two rounding when the output size is pre-computed.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

No documentation needed — internal allocation optimization, no user-visible API change.