### PR TITLE
Fix random failure in 04011_explain_pretty_join due to setting randomization

### DIFF
--- a/tests/queries/0_stateless/04011_explain_pretty_join.sql
+++ b/tests/queries/0_stateless/04011_explain_pretty_join.sql
@@ -2,6 +2,7 @@ SET enable_analyzer = 1;
 SET parallel_hash_join_threshold = 0;
 SET enable_join_runtime_filters = 0;
 SET query_plan_join_swap_table = 0;
+SET query_plan_join_shard_by_pk_ranges = 0; -- adds 'Sharding:' lines to EXPLAIN output when enabled
 SET enable_parallel_replicas = 0;
 SET use_statistics = 0;
 


### PR DESCRIPTION
Fixing this:

```
2026-03-28 09:09:18 Reason: result differs with reference:  
2026-03-28 09:09:18 --- /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/tests/queries/0_stateless/04011_explain_pretty_join.reference	2026-03-28 09:02:02.344477332 +0900
2026-03-28 09:09:18 +++ /home/ubuntu/actions-runner/_work/ClickHouse/ClickHouse/tests/queries/0_stateless/04011_explain_pretty_join.5493.stdout	2026-03-28 09:09:18.780249483 +0900
2026-03-28 09:09:18 @@ -1,17 +1,18 @@
2026-03-28 09:09:18  Output: id, value, t2.id, t2.value
2026-03-28 09:09:18  
2026-03-28 09:09:18  Join (JOIN FillRightFirst)
2026-03-28 09:09:18  │  t1[100] ⋈ t2[100]
2026-03-28 09:09:18  │  Type: inner | Strictness: all | Algorithm: ConcurrentHashJoin
2026-03-28 09:09:18  │  Result rows: 100
2026-03-28 09:09:18  │  Join conditions: [(__table1.id) = (__table2.id)]
2026-03-28 09:09:18 +│  Sharding: [(id = id)]
2026-03-28 09:09:18  │  Output:
2026-03-28 09:09:18  │    Left:  id, value
2026-03-28 09:09:18  │    Right: id, value
2026-03-28 09:09:18  ├──ReadFromMergeTree (default.t1)
2026-03-28 09:09:18  │     Read type: Default
2026-03-28 09:09:18  │     Parts: 1 | Granules: 1
2026-03-28 09:09:18  │     Output: id, value
2026-03-28 09:09:18  └──ReadFromMergeTree (default.t2)
2026-03-28 09:09:18        Read type: Default
2026-03-28 09:09:18        Parts: 1 | Granules: 1
2026-03-28 09:09:18 @@ -24,20 +25,21 @@
2026-03-28 09:09:18  │  Result rows: 100
2026-03-28 09:09:18  │  Join conditions: [(__table2.id) = (__table3.id)]
2026-03-28 09:09:18  │  Output:
2026-03-28 09:09:18  │    Left:  id, id, value, value
2026-03-28 09:09:18  │    Right: id, value
2026-03-28 09:09:18  ├──Join (JOIN FillRightFirst)
2026-03-28 09:09:18  │  │  t1[100] ⋈ t2[100]
2026-03-28 09:09:18  │  │  Type: inner | Strictness: all | Algorithm: ConcurrentHashJoin
2026-03-28 09:09:18  │  │  Result rows: 100
2026-03-28 09:09:18  │  │  Join conditions: [(__table1.id) = (__table2.id)]
2026-03-28 09:09:18 +│  │  Sharding: [(id = id)]
2026-03-28 09:09:18  │  │  Output:
2026-03-28 09:09:18  │  │    Left:  id, value
2026-03-28 09:09:18  │  │    Right: id, value
2026-03-28 09:09:18  │  ├──ReadFromMergeTree (default.t1)
2026-03-28 09:09:18  │  │     Read type: Default
2026-03-28 09:09:18  │  │     Parts: 1 | Granules: 1
2026-03-28 09:09:18  │  │     Output: id, value
2026-03-28 09:09:18  │  └──ReadFromMergeTree (default.t2)
2026-03-28 09:09:18  │        Read type: Default
2026-03-28 09:09:18  │        Parts: 1 | Granules: 1
2026-03-28 09:09:18 
2026-03-28 09:09:18 
2026-03-28 09:09:18 Settings used in the test: --max_insert_threads 3 --group_by_two_level_threshold 282723 --group_by_two_level_threshold_bytes 44089920 --distributed_aggregation_memory_efficient 1 --fsync_metadata 0 --output_format_parallel_formatting 0 --input_format_parallel_parsing 0 --min_chunk_bytes_for_parallel_parsing 8894244 --max_read_buffer_size 728393 --prefer_localhost_replica 0 --max_block_size 65223 --max_joined_block_size_rows 37204 --joined_block_split_single_row 1 --join_output_by_rowlist_perkey_rows_threshold 549 --max_threads 3 --optimize_append_index 0 --use_hedged_requests 1 --optimize_if_chain_to_multiif 1 --optimize_if_transform_strings_to_enum 0 --optimize_read_in_order 1 --optimize_or_like_chain 0 --optimize_substitute_columns 1 --enable_multiple_prewhere_read_steps 1 --read_in_order_two_level_merge_threshold 57 --optimize_aggregation_in_order 0 --aggregation_in_order_max_block_bytes 4075040 --use_uncompressed_cache 1 --min_bytes_to_use_direct_io 8255060083 --min_bytes_to_use_mmap_io 10737418240 --local_filesystem_read_method mmap --remote_filesystem_read_method read --local_filesystem_read_prefetch 0 --filesystem_cache_segments_batch_size 3 --read_from_filesystem_cache_if_exists_otherwise_bypass_cache 0 --throw_on_error_from_cache_on_write_operations 0 --remote_filesystem_read_prefetch 1 --distributed_cache_discard_connection_if_unread_data 0 --distributed_cache_use_clients_cache_for_write 0 --distributed_cache_use_clients_cache_for_read 1 --allow_prefetched_read_pool_for_remote_filesystem 1 --filesystem_prefetch_max_memory_usage 32Mi --filesystem_prefetches_limit 0 --filesystem_prefetch_min_bytes_for_single_read_task 16Mi --filesystem_prefetch_step_marks 0 --filesystem_prefetch_step_bytes 100Mi --enable_filesystem_cache 1 --enable_filesystem_cache_on_write_operations 0 --compile_expressions 0 --compile_aggregate_expressions 1 --compile_sort_description 1 --merge_tree_coarse_index_granularity 14 --optimize_distinct_in_order 1 --max_bytes_before_remerge_sort 2994752336 --min_compress_block_size 1613357 --max_compress_block_size 2695277 --merge_tree_compact_parts_min_granules_to_multibuffer_read 113 --optimize_sorting_by_input_stream_properties 0 --http_response_buffer_size 2846428 --http_wait_end_of_query True --enable_memory_bound_merging_of_aggregation_results 0 --min_count_to_compile_expression 0 --min_count_to_compile_aggregate_expression 3 --min_count_to_compile_sort_description 0 --session_timezone America/Hermosillo --use_page_cache_for_disks_without_file_cache False --use_page_cache_for_local_disks False --use_page_cache_for_object_storage True --page_cache_inject_eviction False --merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability 0.48 --prefer_external_sort_block_bytes 1 --cross_join_min_rows_to_compress 100000000 --cross_join_min_bytes_to_compress 0 --min_external_table_block_size_bytes 100000000 --max_parsing_threads 10 --optimize_functions_to_subcolumns 0 --parallel_replicas_local_plan 0 --query_plan_join_swap_table auto --enable_vertical_final 1 --optimize_extract_common_expressions 1 --optimize_rewrite_array_exists_to_has False --optimize_skip_unused_shards False --optimize_trivial_approximate_count_query False --optimize_trivial_insert_select True --optimize_using_constraints False --optimize_syntax_fuse_functions True --optimize_aggregators_of_group_by_keys True --optimize_and_compare_chain True --optimize_arithmetic_operations_in_aggregate_functions True --optimize_count_from_files True --optimize_distributed_group_by_sharding_key True --optimize_empty_string_comparisons True --optimize_group_by_constant_keys True --optimize_group_by_function_keys True --optimize_injective_functions_in_group_by False --optimize_injective_functions_inside_uniq True --optimize_inverse_dictionary_lookup True --optimize_move_to_prewhere True --optimize_multiif_to_if True --optimize_normalize_count_variants True --optimize_on_insert True --optimize_redundant_functions_in_order_by True --optimize_respect_aliases False --optimize_rewrite_aggregate_function_with_if False --optimize_rewrite_regexp_functions True --optimize_rewrite_sum_if_to_count_if True --optimize_skip_unused_shards_rewrite_in True --optimize_time_filter_with_preimage True --optimize_trivial_count_query True --optimize_uniq_to_count True --optimize_use_projections True --optimize_use_implicit_projections True --optimize_use_projection_filtering True --query_plan_optimize_lazy_materialization True --query_plan_optimize_prewhere True --use_async_executor_for_materialized_views 0 --use_query_condition_cache 1 --secondary_indices_enable_bulk_filtering 1 --use_skip_indexes_if_final 1 --use_skip_indexes_on_data_read 0 --optimize_rewrite_like_perfect_affix 0 --input_format_parquet_use_native_reader_v3 1 --enable_lazy_columns_replication 1 --allow_special_serialization_kinds_in_output_formats 0 --use_skip_indexes_for_top_k 0 --use_top_k_dynamic_filtering False --query_plan_max_limit_for_top_k_optimization 0 --query_plan_read_in_order_through_join 0 --read_in_order_use_virtual_row 0 --short_circuit_function_evaluation_for_nulls_threshold 0.685560576088058 --automatic_parallel_replicas_mode 0 --temporary_files_buffer_size 1050695 --query_plan_optimize_join_order_algorithm greedy,dpsize --normalize_function_names True --enable_join_runtime_filters True --enable_parallel_blocks_marshalling True --query_plan_reuse_storage_ordering_for_window_functions False --query_plan_join_shard_by_pk_ranges True --count_distinct_optimization False --use_statistics False --use_statistics_cache False --max_bytes_before_external_sort 10737418240 --max_bytes_before_external_group_by 10737418240 --max_bytes_ratio_before_external_sort 0 --max_bytes_ratio_before_external_group_by 0 --use_skip_indexes_if_final_exact_mode 1
2026-03-28 09:09:18 
2026-03-28 09:09:18 MergeTree settings used in test: --ratio_of_defaults_for_sparse_serialization 0.7573281015807195 --prefer_fetch_merged_part_size_threshold 10737418240 --vertical_merge_algorithm_min_rows_to_activate 1000000 --vertical_merge_algorithm_min_columns_to_activate 100 --allow_vertical_merges_from_compact_to_wide_parts 1 --min_merge_bytes_to_use_direct_io 10633647306 --index_granularity_bytes 16713530 --merge_max_block_size 11031 --index_granularity 51547 --min_bytes_for_wide_part 283706792 --marks_compress_block_size 83794 --primary_key_compress_block_size 68854 --replace_long_file_name_to_hash 0 --max_file_name_length 0 --min_bytes_for_full_part_storage 536870912 --compact_parts_max_bytes_to_buffer 85233531 --compact_parts_max_granules_to_buffer 134 --compact_parts_merge_max_bytes_to_prefetch_part 9306335 --cache_populated_by_fetch 1 --concurrent_part_removal_threshold 100 --old_parts_lifetime 10 --prewarm_mark_cache 0 --use_const_adaptive_granularity 0 --enable_index_granularity_compression 1 --enable_block_number_column 1 --enable_block_offset_column 1 --use_primary_key_cache 0 --prewarm_primary_key_cache 0 --object_serialization_version v2 --object_shared_data_serialization_version map --object_shared_data_serialization_version_for_zero_level_parts advanced --object_shared_data_buckets_for_compact_part 3 --object_shared_data_buckets_for_wide_part 9 --dynamic_serialization_version v2 --auto_statistics_types minmax,countmin,uniq --serialization_info_version with_types --string_serialization_version with_size_stream --nullable_serialization_version basic --enable_shared_storage_snapshot_in_query 1 --min_columns_to_activate_adaptive_write_buffer 211 --reduce_blocking_parts_sleep_ms 1158 --shared_merge_tree_outdated_parts_group_size 2 --shared_merge_tree_max_outdated_parts_to_process_at_once 7 --map_serialization_version basic --map_serialization_version_for_zero_level_parts basic --max_buckets_in_map 81 --map_buckets_strategy constant --map_buckets_min_avg_size 291
2026-03-28 09:09:18 
2026-03-28 09:09:18 Database: test_z7kvh4ua
```

Similar to 4c7ec230f37d.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
