### PR TITLE
docs: Add beeterty/clickhouse-php-client to PHP third-party client libraries

### DIFF
--- a/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
+++ b/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3602
+personal_ws-1.1 en 3603
 AArch
 ABIs
 ACLs
@@ -1529,6 +1529,7 @@ bcrypt's
 bech
 benchmarked
 benchmarking
+beeterty
 bfloat
 bigrams
 binlog

--- a/docs/en/interfaces/third-party/client-libraries.md
+++ b/docs/en/interfaces/third-party/client-libraries.md
@@ -33,6 +33,7 @@ ClickHouse Inc does **not** maintain the libraries listed below and hasn't done 
 - [glushkovds/php-clickhouse-schema-builder](https://packagist.org/packages/glushkovds/php-clickhouse-schema-builder)
 - [kolya7k ClickHouse PHP extension](https://github.com//kolya7k/clickhouse-php)
 - [hyvor/clickhouse-php](https://github.com/hyvor/clickhouse-php)
+- [beeterty/clickhouse-php-client](https://packagist.org/packages/beeterty/clickhouse-php-client)
 ### Go {#go}
 - [clickhouse](https://github.com/kshvakov/clickhouse/)
 - [go-clickhouse](https://github.com/roistat/go-clickhouse)

--- a/docs/en/interfaces/third-party/client-libraries.md
+++ b/docs/en/interfaces/third-party/client-libraries.md
@@ -33,7 +33,7 @@ ClickHouse Inc does **not** maintain the libraries listed below and hasn't done 
 - [glushkovds/php-clickhouse-schema-builder](https://packagist.org/packages/glushkovds/php-clickhouse-schema-builder)
 - [kolya7k ClickHouse PHP extension](https://github.com//kolya7k/clickhouse-php)
 - [hyvor/clickhouse-php](https://github.com/hyvor/clickhouse-php)
-- [beeterty/clickhouse-php-client](https://packagist.org/packages/beeterty/clickhouse-php-client)
+- [beeterty/clickhouse-php-client](https://github.com/beeterty-technologies/clickhouse-php-client) 
 ### Go {#go}
 - [clickhouse](https://github.com/kshvakov/clickhouse/)
 - [go-clickhouse](https://github.com/roistat/go-clickhouse)


### PR DESCRIPTION
Adding beeterty/clickhouse-php-client to the PHP section of the third-party client libraries list.

Package: https://packagist.org/packages/beeterty/clickhouse-php-client
Source: https://github.com/beeterty-technologies/clickhouse-php-client

A lightweight, zero-dependency PHP client for ClickHouse over its native HTTP interface. Features include fluent query building, JSONEachRow streaming inserts, parameterized queries, and support for PHP 8.2+.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry:
...

### Documentation entry for user-facing changes
- [x] Documentation is written (mandatory for new features)

Added `beeterty/clickhouse-php-client` to the PHP section of `docs/en/interfaces/third-party/client-libraries.md`.

**Motivation:** PHP developers now have a lightweight, zero-dependency option for connecting to ClickHouse over its native HTTP interface, without pulling in heavy dependencies. It supports fluent query building, streaming inserts via JSONEachRow, parameterized queries, and requires PHP 8.2+.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.416`
<!-- ch-version-info:end -->