### PR TITLE
Fix `tryGetTableMetadata` to catch all exception types

### DIFF
--- a/src/Databases/DataLake/RestCatalog.cpp
+++ b/src/Databases/DataLake/RestCatalog.cpp
@@ -824,6 +824,16 @@ bool RestCatalog::tryGetTableMetadata(
         LOG_DEBUG(log, "tryGetTableMetadata response: {}", ex.what());
         return false;
     }
+    catch (const std::exception & ex)
+    {
+        LOG_DEBUG(log, "tryGetTableMetadata response: {}", ex.what());
+        return false;
+    }
+    catch (...)
+    {
+        DB::tryLogCurrentException(log);
+        return false;
+    }
 }
 
 void RestCatalog::getTableMetadata(


### PR DESCRIPTION
Previously only `DB::Exception` was caught, allowing `Poco::Exception` and `std::exception` thrown by `Poco::JSON::Parser` or other code inside `getTableMetadataImpl` to propagate unexpectedly from a `try*` API that is supposed to return `false` on failure.

Major issue of https://github.com/ClickHouse/ClickHouse/pull/92993

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
