### PR TITLE
Fix crash in Iceberg getMetadataFileAndVersion on malformed metadata paths

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Utils.cpp
@@ -142,12 +142,26 @@ static MetadataFileWithInfo getMetadataFileAndVersion(const std::string & path)
     String version_str;
     /// v<V>.metadata.json
     if (file_name.starts_with('v'))
-        version_str = String(file_name.begin() + 1, file_name.begin() + file_name.find_first_of('.'));
+    {
+        auto dot_pos = file_name.find_first_of('.');
+        if (dot_pos == String::npos || dot_pos <= 1)
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Bad metadata file name: '{}'. Expected vN.metadata.json or NNNNN-uuid.metadata.json", file_name);
+        version_str = String(file_name.begin() + 1, file_name.begin() + dot_pos);
+    }
     /// <V>-<random-uuid>.metadata.json
     else
-        version_str = String(file_name.begin(), file_name.begin() + file_name.find_first_of('-'));
+    {
+        auto dash_pos = file_name.find_first_of('-');
+        if (dash_pos == String::npos || dash_pos == 0)
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Bad metadata file name: '{}'. Expected vN.metadata.json or NNNNN-uuid.metadata.json", file_name);
+        version_str = String(file_name.begin(), file_name.begin() + dash_pos);
+    }
 
-    if (!std::all_of(version_str.begin(), version_str.end(), isdigit))
+    if (version_str.empty() || !std::all_of(version_str.begin(), version_str.end(), isdigit))
         throw Exception(
             ErrorCodes::BAD_ARGUMENTS, "Bad metadata file name: '{}'. Expected vN.metadata.json where N is a number", file_name);
 

--- a/tests/queries/0_stateless/04065_iceberg_metadata_file_path_validation.sql
+++ b/tests/queries/0_stateless/04065_iceberg_metadata_file_path_validation.sql
@@ -1,0 +1,18 @@
+-- Tags: no-fasttest
+-- Verify that invalid iceberg_metadata_file_path values produce proper errors
+-- instead of crashing the server (std::stoi, std::length_error, etc.).
+-- See: https://github.com/ClickHouse/ClickHouse/issues/100473
+
+-- Filename starting with dash: find_first_of('-') returns 0, empty version_str passes
+-- vacuous all_of check, then stoi("") throws std::invalid_argument.
+SELECT * FROM icebergS3('http://localhost:11111/test/est', 'clickhouse', 'clickhouse', SETTINGS iceberg_metadata_file_path = '-21474836.47'); -- { serverError BAD_ARGUMENTS }
+
+-- Filename with no dash: find_first_of('-') returns npos, string constructor with npos
+-- offset causes std::length_error.
+SELECT * FROM icebergS3('http://localhost:11111/test/est', 'clickhouse', 'clickhouse', SETTINGS iceberg_metadata_file_path = '.*'); -- { serverError BAD_ARGUMENTS }
+
+-- Another dash-prefixed variant from AST fuzzer.
+SELECT * FROM icebergS3('http://localhost:11111/test/est', 'clickhouse', 'clickhouse', SETTINGS iceberg_metadata_file_path = '-838:59:59.999999999'); -- { serverError BAD_ARGUMENTS }
+
+-- Non-numeric version after v prefix.
+SELECT * FROM icebergS3('http://localhost:11111/test/est', 'clickhouse', 'clickhouse', SETTINGS iceberg_metadata_file_path = 'vABC.metadata.json'); -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
`getMetadataFileAndVersion()` in `Utils.cpp` used `find_first_of('-')` and `find_first_of('.')` without checking for `npos` before using the result to construct a substring. When the AST fuzzer passes arbitrary `iceberg_metadata_file_path` values (e.g. `'-21474836.47'`, `'.*'`, `'-838:59:59.999999999'`), this causes two crash modes:

1. **`npos` offset → UB**: When the delimiter is missing entirely (e.g. `'.*'` has no `-`), `find_first_of` returns `npos`. The string constructor `String(begin, begin + npos)` attempts to create a string of size ~2^64, throwing `std::length_error`.

2. **Empty version string → `stoi("")`**: When the delimiter is at position 0 (e.g. `-21474836.47` starts with `-`), `find_first_of('-')` returns 0, creating an empty `version_str`. The existing `std::all_of(version_str.begin(), version_str.end(), isdigit)` check returns `true` for empty ranges (vacuously true), so validation passes. Then `std::stoi("")` throws `std::invalid_argument`.

Both exceptions are caught by the generic `std::exception` handler and wrapped as a `Logical error`, which aborts the server via `abortOnFailedAssertion`.

The fix stores the `find_first_of` result in a variable and checks for `npos` (delimiter not found) and position 0 (empty version string) before constructing the substring. Invalid filenames now throw `BAD_ARGUMENTS` — a normal user-facing error that doesn't crash the server.

**CIDB evidence**: 19 hits across 17 PRs + 1 master hit in 30 days (STID: 2508-3132), mostly from AST fuzzer and stress tests.

Closes https://github.com/ClickHouse/ClickHouse/issues/100473

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix server crash when reading Iceberg tables with malformed `iceberg_metadata_file_path` values that don't match the expected `vN.metadata.json` or `NNNNN-uuid.metadata.json` naming pattern.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)