### PR TITLE
Fix `sumCountOrDefault` aggregate function with one or more `Nullable` argument not being able to read older serialized states after introduction of `Nullable(Tuple)`

### DIFF
--- a/src/AggregateFunctions/Combinators/AggregateFunctionOrFill.h
+++ b/src/AggregateFunctions/Combinators/AggregateFunctionOrFill.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <AggregateFunctions/IAggregateFunction.h>
+#include <AggregateFunctions/Combinators/AggregateFunctionNull.h>
 #include <Columns/ColumnNullable.h>
 #include <Columns/ColumnsCommon.h>
 #include <Common/typeid_cast.h>
@@ -324,6 +325,32 @@ public:
     }
 
     AggregateFunctionPtr getNestedFunction() const override { return nested_function; }
+
+    /// After `Nullable(Tuple)` was introduced, Tuple's `canBeInsideNullable` now returns true,
+    /// which changed the default null adapter for Tuple-returning functions:
+    ///   - single-arg: from `<false, false>` to `<true, true>` (flag byte added to serialization).
+    ///   - multi-arg: from `<false, true>` to `<true, true>` (flag byte was already present).
+    /// Only single-arg functions are affected because the multi-arg (variadic) Null combinator
+    /// always serialized the flag byte unconditionally, so its serialization format did not change.
+    /// Only OrDefault is affected. OrNull also has no backward compat concern since it
+    /// didn't work for Tuple-returning functions before `Nullable(Tuple)` was introduced.
+    /// Currently, the only single-arg Tuple-returning aggregate function is `sumCount`.
+    /// We hardcode the check for `sumCount` rather than matching all single-arg Tuple-returning
+    /// functions, so that future functions with the same shape get the correct new behavior
+    /// (`<true, true>`) by default and are not silently forced into the legacy adapter.
+    AggregateFunctionPtr getOwnNullAdapter(
+        const AggregateFunctionPtr & nested_function_,
+        const DataTypes & arguments,
+        const Array & params,
+        const AggregateFunctionProperties & /*properties*/) const override
+    {
+        if constexpr (!UseNull) /// OrDefault only
+        {
+            if (nested_function->getName() == "sumCount")
+                return std::make_shared<AggregateFunctionNullUnary<false, false>>(nested_function_, arguments, params);
+        }
+        return nullptr;
+    }
 };
 
 }

--- a/tests/integration/test_backward_compatibility/test_aggregate_function_state_tuple_return_type.py
+++ b/tests/integration/test_backward_compatibility/test_aggregate_function_state_tuple_return_type.py
@@ -319,6 +319,22 @@ def test_backward_compatibility_for_tuple_return_type(start_cluster):
                 "argAndMinResample",
                 f"SELECT argAndMinResample(0, 2, 1)(a, b, g) FROM {remote_tab}",
             ),
+            # -OrDefault combinator
+            (
+                "sumCountOrDefault",
+                f"SELECT sumCountOrDefault(x) FROM {remote_tab}",
+            ),
+            (
+                "simpleLinearRegressionOrDefault",
+                f"SELECT tuple("
+                f"roundBankers(tupleElement(simpleLinearRegressionOrDefault(x, y), 1), 4), "
+                f"roundBankers(tupleElement(simpleLinearRegressionOrDefault(x, y), 2), 4)) "
+                f"FROM {remote_tab}",
+            ),
+            (
+                "argAndMinOrDefault",
+                f"SELECT argAndMinOrDefault(a, b) FROM {remote_tab}",
+            ),
         ]
 
     def build_empty_checks(remote_tab):
@@ -343,6 +359,7 @@ def test_backward_compatibility_for_tuple_return_type(start_cluster):
             ("argAndMinIf_empty", f"SELECT argAndMinIf(a, b, a > 0) FROM {remote_tab} WHERE 0"),
             ("sumCountForEach_empty", f"SELECT sumCountForEach([x]) FROM {remote_tab} WHERE 0"),
             ("sumCountResample_empty", f"SELECT sumCountResample(0, 2, 1)(x, g) FROM {remote_tab} WHERE 0"),
+            ("sumCountOrDefault_empty", f"SELECT sumCountOrDefault(x) FROM {remote_tab} WHERE 0"),
         ]
 
     def batch_query(checks):

--- a/tests/queries/0_stateless/04054_sumcount_combinator_compatibility.reference
+++ b/tests/queries/0_stateless/04054_sumcount_combinator_compatibility.reference
@@ -79,6 +79,23 @@ SELECT finalizeAggregation(CAST(unhex('01000000000000000001010000000000000001020
 [(0,1),(1,1),(2,1),(3,1),(4,1)]
 SELECT hex(sumCountResampleState(0, 5, 1)(x, y)) FROM (SELECT number::Nullable(UInt8) AS x, number::UInt8 AS y FROM numbers(5));
 01000000000000000001010000000000000001020000000000000001030000000000000001040000000000000001
+-- sumCountOrDefault: deserialize old state and round-trip.
+SELECT finalizeAggregation(CAST(unhex('0A000000000000000501'), 'AggregateFunction(sumCountOrDefault, Nullable(UInt8))'));
+(10,5)
+SELECT hex(sumCountOrDefaultState(x)) FROM (SELECT number::Nullable(UInt8) AS x FROM numbers(5));
+0A000000000000000501
+SELECT finalizeAggregation(CAST(unhex('00000000000000000000'), 'AggregateFunction(sumCountOrDefault, Nullable(UInt8))'));
+(0,0)
+SELECT hex(sumCountOrDefaultState(x)) FROM (SELECT CAST(1, 'Nullable(UInt8)') AS x WHERE 0);
+00000000000000000000
+-- sumCountOrDefault: LowCardinality(Nullable) same format.
+SELECT hex(sumCountOrDefaultState(x)) FROM (SELECT CAST(number, 'LowCardinality(Nullable(UInt8))') AS x FROM numbers(5));
+0A000000000000000501
+-- sumCountOrNull: round-trip (no backward compat concern — didn't exist pre-Nullable(Tuple)).
+SELECT finalizeAggregation(CAST(unhex('0A000000000000000501'), 'AggregateFunction(sumCountOrNull, Nullable(UInt8))'));
+(10,5)
+SELECT hex(sumCountOrNullState(x)) FROM (SELECT number::Nullable(UInt8) AS x FROM numbers(5));
+0A000000000000000501
 SELECT sumCountOrNull(x) FROM (SELECT number::Nullable(UInt8) AS x FROM numbers(5) WHERE x > 0);
 (10,4)
 SELECT sumCountOrDefault(x) FROM (SELECT number::Nullable(UInt8) AS x FROM numbers(5) WHERE x > 0);

--- a/tests/queries/0_stateless/04054_sumcount_combinator_compatibility.sql
+++ b/tests/queries/0_stateless/04054_sumcount_combinator_compatibility.sql
@@ -67,5 +67,18 @@ SELECT hex(sumCountMergeState(s)) FROM (SELECT sumCountState(number::Nullable(UI
 SELECT finalizeAggregation(CAST(unhex('01000000000000000001010000000000000001020000000000000001030000000000000001040000000000000001'), 'AggregateFunction(sumCountResample(0, 5, 1), Nullable(UInt8), UInt8)'));
 SELECT hex(sumCountResampleState(0, 5, 1)(x, y)) FROM (SELECT number::Nullable(UInt8) AS x, number::UInt8 AS y FROM numbers(5));
 
+-- sumCountOrDefault: deserialize old state and round-trip.
+SELECT finalizeAggregation(CAST(unhex('0A000000000000000501'), 'AggregateFunction(sumCountOrDefault, Nullable(UInt8))'));
+SELECT hex(sumCountOrDefaultState(x)) FROM (SELECT number::Nullable(UInt8) AS x FROM numbers(5));
+SELECT finalizeAggregation(CAST(unhex('00000000000000000000'), 'AggregateFunction(sumCountOrDefault, Nullable(UInt8))'));
+SELECT hex(sumCountOrDefaultState(x)) FROM (SELECT CAST(1, 'Nullable(UInt8)') AS x WHERE 0);
+
+-- sumCountOrDefault: LowCardinality(Nullable) same format.
+SELECT hex(sumCountOrDefaultState(x)) FROM (SELECT CAST(number, 'LowCardinality(Nullable(UInt8))') AS x FROM numbers(5));
+
+-- sumCountOrNull: round-trip (no backward compat concern — didn't exist pre-Nullable(Tuple)).
+SELECT finalizeAggregation(CAST(unhex('0A000000000000000501'), 'AggregateFunction(sumCountOrNull, Nullable(UInt8))'));
+SELECT hex(sumCountOrNullState(x)) FROM (SELECT number::Nullable(UInt8) AS x FROM numbers(5));
+
 SELECT sumCountOrNull(x) FROM (SELECT number::Nullable(UInt8) AS x FROM numbers(5) WHERE x > 0);
 SELECT sumCountOrDefault(x) FROM (SELECT number::Nullable(UInt8) AS x FROM numbers(5) WHERE x > 0);

--- a/tests/queries/0_stateless/04055_aggregate_function_tuple_return_type_combinator_compatibility.reference
+++ b/tests/queries/0_stateless/04055_aggregate_function_tuple_return_type_combinator_compatibility.reference
@@ -3,73 +3,58 @@
 -- Backward compatibility test for Tuple-returning aggregate functions with combinators and Nullable arguments.
 -- These tests verify that old states (from v25.11, pre-Nullable(Tuple)) can still be deserialized.
 
+-- If combinator: deserialize old states.
+
 -- 1. simpleLinearRegressionIf(Nullable(Float64), Nullable(Float64), cond)
 SELECT finalizeAggregation(CAST(unhex('03000000000000000000000000002640000000000000394000000000008046400000000000405940'), 'AggregateFunction(simpleLinearRegressionIf, Nullable(Float64), Nullable(Float64), UInt8)'));
 (2,1)
-SELECT hex(simpleLinearRegressionIfState(x, y, x > 1))
-FROM values('x Nullable(Float64), y Nullable(Float64)', (1, 3), (2, 5), (NULL, 7), (4, 9), (5, 11));
-03000000000000000000000000002640000000000000394000000000008046400000000000405940
 -- 2. studentTTestIf(Nullable(Float64), Nullable(UInt8), cond)
 SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
 FROM (SELECT finalizeAggregation(CAST(unhex('000000000000004000000000000000400000000000002040000000000000284000000000000041400000000000005A40'), 'AggregateFunction(studentTTestIf, Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
 (-0.4851,0.6756)
-SELECT hex(studentTTestIfState(v, g, v > 1))
-FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
-000000000000004000000000000000400000000000002040000000000000284000000000000041400000000000005A40
 -- 3. welchTTestIf(Nullable(Float64), Nullable(UInt8), cond)
 SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
 FROM (SELECT finalizeAggregation(CAST(unhex('000000000000004000000000000000400000000000002040000000000000284000000000000041400000000000005A40'), 'AggregateFunction(welchTTestIf, Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
 (-0.4851,0.7051)
-SELECT hex(welchTTestIfState(v, g, v > 1))
-FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
-000000000000004000000000000000400000000000002040000000000000284000000000000041400000000000005A40
 -- 4. meanZTestIf(1., 1., 0.95)(Nullable(Float64), Nullable(UInt8), cond)
 SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4), roundBankers(res.3, 4), roundBankers(res.4, 4))
 FROM (SELECT finalizeAggregation(CAST(unhex('0000000000000040000000000000004000000000000020400000000000002840'), 'AggregateFunction(meanZTestIf(1., 1., 0.95), Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
 (-2,0.0455,-3.96,-0.04)
-SELECT hex(meanZTestIfState(1., 1., 0.95)(v, g, v > 1))
-FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
-0000000000000040000000000000004000000000000020400000000000002840
 -- 5. argAndMinIf(Nullable(Int32), Nullable(Int32), cond)
 SELECT finalizeAggregation(CAST(unhex('01030000000100000000'), 'AggregateFunction(argAndMinIf, Nullable(Int32), Nullable(Int32), UInt8)'));
 (3,0)
-SELECT hex(argAndMinIfState(a, b, a > 0))
-FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (NULL, 1), (3, 0));
-01030000000100000000
 -- 6. argAndMaxIf(Nullable(Int32), Nullable(Int32), cond)
 SELECT finalizeAggregation(CAST(unhex('01010000000102000000'), 'AggregateFunction(argAndMaxIf, Nullable(Int32), Nullable(Int32), UInt8)'));
 (1,2)
-SELECT hex(argAndMaxIfState(a, b, a > 0))
-FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (NULL, 1), (3, 0));
-01010000000102000000
 -- 7. kolmogorovSmirnovTestIf('two-sided')(Nullable(Float64), Nullable(UInt8), cond)
 SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
 FROM (SELECT finalizeAggregation(CAST(unhex('02020000000000000840000000000000144000000000000000400000000000002440'), 'AggregateFunction(kolmogorovSmirnovTestIf(''two-sided''), Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
 (0.5,1)
-SELECT hex(kolmogorovSmirnovTestIfState('two-sided')(v, g, v > 1))
-FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
-02020000000000000840000000000000144000000000000000400000000000002440
--- Distinct combinator: verify round-trip for a subset.
+-- Distinct combinator: deserialize old states.
 
--- simpleLinearRegressionDistinct: round-trip.
-SELECT hex(simpleLinearRegressionDistinctState(x, y))
-FROM values('x Nullable(Float64), y Nullable(Float64)', (1, 3), (2, 5), (NULL, 7), (4, 9), (5, 11));
-01041000000000000010400000000000002240100000000000000040000000000000144010000000000000F03F00000000000008401000000000000014400000000000002640
--- studentTTestDistinct: round-trip.
-SELECT hex(studentTTestDistinctState(v, g))
-FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
-010509000000000000F03F0009000000000000244001090000000000000840000900000000000014400009000000000000004001
--- argAndMinDistinct: round-trip.
-SELECT hex(argAndMinDistinctState(a, b))
-FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (NULL, 1), (3, 0));
-0102080100000002000000080300000000000000
--- Merge combinator: verify round-trip for a subset.
+-- simpleLinearRegressionDistinct
+SELECT finalizeAggregation(CAST(unhex('01041000000000000010400000000000002240100000000000000040000000000000144010000000000000F03F00000000000008401000000000000014400000000000002640'), 'AggregateFunction(simpleLinearRegressionDistinct, Nullable(Float64), Nullable(Float64))'));
+(2,1)
+-- studentTTestDistinct
+SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
+FROM (SELECT finalizeAggregation(CAST(unhex('010509000000000000F03F0009000000000000244001090000000000000840000900000000000014400009000000000000004001'), 'AggregateFunction(studentTTestDistinct, Nullable(Float64), Nullable(UInt8))')) AS res);
+(-0.9,0.4345)
+-- argAndMinDistinct
+SELECT finalizeAggregation(CAST(unhex('0102080100000002000000080300000000000000'), 'AggregateFunction(argAndMinDistinct, Nullable(Int32), Nullable(Int32))'));
+(3,0)
+-- Merge combinator: deserialize old states.
 
--- simpleLinearRegressionMerge: round-trip.
-SELECT hex(simpleLinearRegressionMergeState(s))
-FROM (SELECT simpleLinearRegressionState(x, y) AS s FROM values('x Nullable(Float64), y Nullable(Float64)', (1, 3), (2, 5), (4, 9), (5, 11)));
-01040000000000000000000000000028400000000000003C4000000000000047400000000000005A40
--- argAndMinMerge: round-trip.
-SELECT hex(argAndMinMergeState(s))
-FROM (SELECT argAndMinState(a, b) AS s FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (3, 0)));
-0101030000000100000000
+-- simpleLinearRegressionMerge
+SELECT finalizeAggregation(CAST(unhex('01040000000000000000000000000028400000000000003C4000000000000047400000000000005A40'), 'AggregateFunction(simpleLinearRegressionMerge, AggregateFunction(simpleLinearRegression, Nullable(Float64), Nullable(Float64)))'));
+(2,1)
+-- argAndMinMerge
+SELECT finalizeAggregation(CAST(unhex('0101030000000100000000'), 'AggregateFunction(argAndMinMerge, AggregateFunction(argAndMin, Nullable(Int32), Nullable(Int32)))'));
+(3,0)
+-- OrDefault combinator: deserialize old states.
+
+-- simpleLinearRegressionOrDefault
+SELECT finalizeAggregation(CAST(unhex('01040000000000000000000000000028400000000000003C4000000000000047400000000000005A4001'), 'AggregateFunction(simpleLinearRegressionOrDefault, Nullable(Float64), Nullable(Float64))'));
+(2,1)
+-- argAndMinOrDefault
+SELECT finalizeAggregation(CAST(unhex('010103000000010000000001'), 'AggregateFunction(argAndMinOrDefault, Nullable(Int32), Nullable(Int32))'));
+(3,0)

--- a/tests/queries/0_stateless/04055_aggregate_function_tuple_return_type_combinator_compatibility.reference
+++ b/tests/queries/0_stateless/04055_aggregate_function_tuple_return_type_combinator_compatibility.reference
@@ -1,60 +1,103 @@
 -- { echo }
 
 -- Backward compatibility test for Tuple-returning aggregate functions with combinators and Nullable arguments.
--- These tests verify that old states (from v25.11, pre-Nullable(Tuple)) can still be deserialized.
+-- These tests verify that old states (from v25.11, pre-Nullable(Tuple)) can still be deserialized,
+-- and that new states match the old format (round-trip).
 
--- If combinator: deserialize old states.
+-- If combinator: deserialize old states and round-trip.
 
 -- 1. simpleLinearRegressionIf(Nullable(Float64), Nullable(Float64), cond)
 SELECT finalizeAggregation(CAST(unhex('03000000000000000000000000002640000000000000394000000000008046400000000000405940'), 'AggregateFunction(simpleLinearRegressionIf, Nullable(Float64), Nullable(Float64), UInt8)'));
 (2,1)
+SELECT hex(simpleLinearRegressionIfState(x, y, x > 1))
+FROM values('x Nullable(Float64), y Nullable(Float64)', (1, 3), (2, 5), (NULL, 7), (4, 9), (5, 11));
+03000000000000000000000000002640000000000000394000000000008046400000000000405940
 -- 2. studentTTestIf(Nullable(Float64), Nullable(UInt8), cond)
 SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
 FROM (SELECT finalizeAggregation(CAST(unhex('000000000000004000000000000000400000000000002040000000000000284000000000000041400000000000005A40'), 'AggregateFunction(studentTTestIf, Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
 (-0.4851,0.6756)
+SELECT hex(studentTTestIfState(v, g, v > 1))
+FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
+000000000000004000000000000000400000000000002040000000000000284000000000000041400000000000005A40
 -- 3. welchTTestIf(Nullable(Float64), Nullable(UInt8), cond)
 SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
 FROM (SELECT finalizeAggregation(CAST(unhex('000000000000004000000000000000400000000000002040000000000000284000000000000041400000000000005A40'), 'AggregateFunction(welchTTestIf, Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
 (-0.4851,0.7051)
+SELECT hex(welchTTestIfState(v, g, v > 1))
+FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
+000000000000004000000000000000400000000000002040000000000000284000000000000041400000000000005A40
 -- 4. meanZTestIf(1., 1., 0.95)(Nullable(Float64), Nullable(UInt8), cond)
 SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4), roundBankers(res.3, 4), roundBankers(res.4, 4))
 FROM (SELECT finalizeAggregation(CAST(unhex('0000000000000040000000000000004000000000000020400000000000002840'), 'AggregateFunction(meanZTestIf(1., 1., 0.95), Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
 (-2,0.0455,-3.96,-0.04)
+SELECT hex(meanZTestIfState(1., 1., 0.95)(v, g, v > 1))
+FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
+0000000000000040000000000000004000000000000020400000000000002840
 -- 5. argAndMinIf(Nullable(Int32), Nullable(Int32), cond)
 SELECT finalizeAggregation(CAST(unhex('01030000000100000000'), 'AggregateFunction(argAndMinIf, Nullable(Int32), Nullable(Int32), UInt8)'));
 (3,0)
+SELECT hex(argAndMinIfState(a, b, a > 0))
+FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (NULL, 1), (3, 0));
+01030000000100000000
 -- 6. argAndMaxIf(Nullable(Int32), Nullable(Int32), cond)
 SELECT finalizeAggregation(CAST(unhex('01010000000102000000'), 'AggregateFunction(argAndMaxIf, Nullable(Int32), Nullable(Int32), UInt8)'));
 (1,2)
+SELECT hex(argAndMaxIfState(a, b, a > 0))
+FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (NULL, 1), (3, 0));
+01010000000102000000
 -- 7. kolmogorovSmirnovTestIf('two-sided')(Nullable(Float64), Nullable(UInt8), cond)
 SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
 FROM (SELECT finalizeAggregation(CAST(unhex('02020000000000000840000000000000144000000000000000400000000000002440'), 'AggregateFunction(kolmogorovSmirnovTestIf(''two-sided''), Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
 (0.5,1)
--- Distinct combinator: deserialize old states.
+SELECT hex(kolmogorovSmirnovTestIfState('two-sided')(v, g, v > 1))
+FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
+02020000000000000840000000000000144000000000000000400000000000002440
+-- Distinct combinator: deserialize old states and round-trip.
 
 -- simpleLinearRegressionDistinct
 SELECT finalizeAggregation(CAST(unhex('01041000000000000010400000000000002240100000000000000040000000000000144010000000000000F03F00000000000008401000000000000014400000000000002640'), 'AggregateFunction(simpleLinearRegressionDistinct, Nullable(Float64), Nullable(Float64))'));
 (2,1)
+SELECT hex(simpleLinearRegressionDistinctState(x, y))
+FROM values('x Nullable(Float64), y Nullable(Float64)', (1, 3), (2, 5), (NULL, 7), (4, 9), (5, 11));
+01041000000000000010400000000000002240100000000000000040000000000000144010000000000000F03F00000000000008401000000000000014400000000000002640
 -- studentTTestDistinct
 SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
 FROM (SELECT finalizeAggregation(CAST(unhex('010509000000000000F03F0009000000000000244001090000000000000840000900000000000014400009000000000000004001'), 'AggregateFunction(studentTTestDistinct, Nullable(Float64), Nullable(UInt8))')) AS res);
 (-0.9,0.4345)
+SELECT hex(studentTTestDistinctState(v, g))
+FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
+010509000000000000F03F0009000000000000244001090000000000000840000900000000000014400009000000000000004001
 -- argAndMinDistinct
 SELECT finalizeAggregation(CAST(unhex('0102080100000002000000080300000000000000'), 'AggregateFunction(argAndMinDistinct, Nullable(Int32), Nullable(Int32))'));
 (3,0)
--- Merge combinator: deserialize old states.
+SELECT hex(argAndMinDistinctState(a, b))
+FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (NULL, 1), (3, 0));
+0102080100000002000000080300000000000000
+-- Merge combinator: deserialize old states and round-trip.
 
 -- simpleLinearRegressionMerge
 SELECT finalizeAggregation(CAST(unhex('01040000000000000000000000000028400000000000003C4000000000000047400000000000005A40'), 'AggregateFunction(simpleLinearRegressionMerge, AggregateFunction(simpleLinearRegression, Nullable(Float64), Nullable(Float64)))'));
 (2,1)
+SELECT hex(simpleLinearRegressionMergeState(s))
+FROM (SELECT simpleLinearRegressionState(x, y) AS s FROM values('x Nullable(Float64), y Nullable(Float64)', (1, 3), (2, 5), (4, 9), (5, 11)));
+01040000000000000000000000000028400000000000003C4000000000000047400000000000005A40
 -- argAndMinMerge
 SELECT finalizeAggregation(CAST(unhex('0101030000000100000000'), 'AggregateFunction(argAndMinMerge, AggregateFunction(argAndMin, Nullable(Int32), Nullable(Int32)))'));
 (3,0)
--- OrDefault combinator: deserialize old states.
+SELECT hex(argAndMinMergeState(s))
+FROM (SELECT argAndMinState(a, b) AS s FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (3, 0)));
+0101030000000100000000
+-- OrDefault combinator: deserialize old states and round-trip.
 
 -- simpleLinearRegressionOrDefault
 SELECT finalizeAggregation(CAST(unhex('01040000000000000000000000000028400000000000003C4000000000000047400000000000005A4001'), 'AggregateFunction(simpleLinearRegressionOrDefault, Nullable(Float64), Nullable(Float64))'));
 (2,1)
+SELECT hex(simpleLinearRegressionOrDefaultState(x, y))
+FROM values('x Nullable(Float64), y Nullable(Float64)', (1, 3), (2, 5), (NULL, 7), (4, 9), (5, 11));
+01040000000000000000000000000028400000000000003C4000000000000047400000000000005A4001
 -- argAndMinOrDefault
 SELECT finalizeAggregation(CAST(unhex('010103000000010000000001'), 'AggregateFunction(argAndMinOrDefault, Nullable(Int32), Nullable(Int32))'));
 (3,0)
+SELECT hex(argAndMinOrDefaultState(a, b))
+FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (NULL, 1), (3, 0));
+010103000000010000000001

--- a/tests/queries/0_stateless/04055_aggregate_function_tuple_return_type_combinator_compatibility.sql
+++ b/tests/queries/0_stateless/04055_aggregate_function_tuple_return_type_combinator_compatibility.sql
@@ -1,59 +1,102 @@
 -- { echo }
 
 -- Backward compatibility test for Tuple-returning aggregate functions with combinators and Nullable arguments.
--- These tests verify that old states (from v25.11, pre-Nullable(Tuple)) can still be deserialized.
+-- These tests verify that old states (from v25.11, pre-Nullable(Tuple)) can still be deserialized,
+-- and that new states match the old format (round-trip).
 
--- If combinator: deserialize old states.
+-- If combinator: deserialize old states and round-trip.
 
 -- 1. simpleLinearRegressionIf(Nullable(Float64), Nullable(Float64), cond)
 SELECT finalizeAggregation(CAST(unhex('03000000000000000000000000002640000000000000394000000000008046400000000000405940'), 'AggregateFunction(simpleLinearRegressionIf, Nullable(Float64), Nullable(Float64), UInt8)'));
+
+SELECT hex(simpleLinearRegressionIfState(x, y, x > 1))
+FROM values('x Nullable(Float64), y Nullable(Float64)', (1, 3), (2, 5), (NULL, 7), (4, 9), (5, 11));
 
 -- 2. studentTTestIf(Nullable(Float64), Nullable(UInt8), cond)
 SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
 FROM (SELECT finalizeAggregation(CAST(unhex('000000000000004000000000000000400000000000002040000000000000284000000000000041400000000000005A40'), 'AggregateFunction(studentTTestIf, Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
 
+SELECT hex(studentTTestIfState(v, g, v > 1))
+FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
+
 -- 3. welchTTestIf(Nullable(Float64), Nullable(UInt8), cond)
 SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
 FROM (SELECT finalizeAggregation(CAST(unhex('000000000000004000000000000000400000000000002040000000000000284000000000000041400000000000005A40'), 'AggregateFunction(welchTTestIf, Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
+
+SELECT hex(welchTTestIfState(v, g, v > 1))
+FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
 
 -- 4. meanZTestIf(1., 1., 0.95)(Nullable(Float64), Nullable(UInt8), cond)
 SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4), roundBankers(res.3, 4), roundBankers(res.4, 4))
 FROM (SELECT finalizeAggregation(CAST(unhex('0000000000000040000000000000004000000000000020400000000000002840'), 'AggregateFunction(meanZTestIf(1., 1., 0.95), Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
 
+SELECT hex(meanZTestIfState(1., 1., 0.95)(v, g, v > 1))
+FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
+
 -- 5. argAndMinIf(Nullable(Int32), Nullable(Int32), cond)
 SELECT finalizeAggregation(CAST(unhex('01030000000100000000'), 'AggregateFunction(argAndMinIf, Nullable(Int32), Nullable(Int32), UInt8)'));
 
+SELECT hex(argAndMinIfState(a, b, a > 0))
+FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (NULL, 1), (3, 0));
+
 -- 6. argAndMaxIf(Nullable(Int32), Nullable(Int32), cond)
 SELECT finalizeAggregation(CAST(unhex('01010000000102000000'), 'AggregateFunction(argAndMaxIf, Nullable(Int32), Nullable(Int32), UInt8)'));
+
+SELECT hex(argAndMaxIfState(a, b, a > 0))
+FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (NULL, 1), (3, 0));
 
 -- 7. kolmogorovSmirnovTestIf('two-sided')(Nullable(Float64), Nullable(UInt8), cond)
 SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
 FROM (SELECT finalizeAggregation(CAST(unhex('02020000000000000840000000000000144000000000000000400000000000002440'), 'AggregateFunction(kolmogorovSmirnovTestIf(''two-sided''), Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
 
--- Distinct combinator: deserialize old states.
+SELECT hex(kolmogorovSmirnovTestIfState('two-sided')(v, g, v > 1))
+FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
+
+-- Distinct combinator: deserialize old states and round-trip.
 
 -- simpleLinearRegressionDistinct
 SELECT finalizeAggregation(CAST(unhex('01041000000000000010400000000000002240100000000000000040000000000000144010000000000000F03F00000000000008401000000000000014400000000000002640'), 'AggregateFunction(simpleLinearRegressionDistinct, Nullable(Float64), Nullable(Float64))'));
+
+SELECT hex(simpleLinearRegressionDistinctState(x, y))
+FROM values('x Nullable(Float64), y Nullable(Float64)', (1, 3), (2, 5), (NULL, 7), (4, 9), (5, 11));
 
 -- studentTTestDistinct
 SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
 FROM (SELECT finalizeAggregation(CAST(unhex('010509000000000000F03F0009000000000000244001090000000000000840000900000000000014400009000000000000004001'), 'AggregateFunction(studentTTestDistinct, Nullable(Float64), Nullable(UInt8))')) AS res);
 
+SELECT hex(studentTTestDistinctState(v, g))
+FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
+
 -- argAndMinDistinct
 SELECT finalizeAggregation(CAST(unhex('0102080100000002000000080300000000000000'), 'AggregateFunction(argAndMinDistinct, Nullable(Int32), Nullable(Int32))'));
 
--- Merge combinator: deserialize old states.
+SELECT hex(argAndMinDistinctState(a, b))
+FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (NULL, 1), (3, 0));
+
+-- Merge combinator: deserialize old states and round-trip.
 
 -- simpleLinearRegressionMerge
 SELECT finalizeAggregation(CAST(unhex('01040000000000000000000000000028400000000000003C4000000000000047400000000000005A40'), 'AggregateFunction(simpleLinearRegressionMerge, AggregateFunction(simpleLinearRegression, Nullable(Float64), Nullable(Float64)))'));
 
+SELECT hex(simpleLinearRegressionMergeState(s))
+FROM (SELECT simpleLinearRegressionState(x, y) AS s FROM values('x Nullable(Float64), y Nullable(Float64)', (1, 3), (2, 5), (4, 9), (5, 11)));
+
 -- argAndMinMerge
 SELECT finalizeAggregation(CAST(unhex('0101030000000100000000'), 'AggregateFunction(argAndMinMerge, AggregateFunction(argAndMin, Nullable(Int32), Nullable(Int32)))'));
 
--- OrDefault combinator: deserialize old states.
+SELECT hex(argAndMinMergeState(s))
+FROM (SELECT argAndMinState(a, b) AS s FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (3, 0)));
+
+-- OrDefault combinator: deserialize old states and round-trip.
 
 -- simpleLinearRegressionOrDefault
 SELECT finalizeAggregation(CAST(unhex('01040000000000000000000000000028400000000000003C4000000000000047400000000000005A4001'), 'AggregateFunction(simpleLinearRegressionOrDefault, Nullable(Float64), Nullable(Float64))'));
 
+SELECT hex(simpleLinearRegressionOrDefaultState(x, y))
+FROM values('x Nullable(Float64), y Nullable(Float64)', (1, 3), (2, 5), (NULL, 7), (4, 9), (5, 11));
+
 -- argAndMinOrDefault
 SELECT finalizeAggregation(CAST(unhex('010103000000010000000001'), 'AggregateFunction(argAndMinOrDefault, Nullable(Int32), Nullable(Int32))'));
+
+SELECT hex(argAndMinOrDefaultState(a, b))
+FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (NULL, 1), (3, 0));

--- a/tests/queries/0_stateless/04055_aggregate_function_tuple_return_type_combinator_compatibility.sql
+++ b/tests/queries/0_stateless/04055_aggregate_function_tuple_return_type_combinator_compatibility.sql
@@ -3,72 +3,57 @@
 -- Backward compatibility test for Tuple-returning aggregate functions with combinators and Nullable arguments.
 -- These tests verify that old states (from v25.11, pre-Nullable(Tuple)) can still be deserialized.
 
+-- If combinator: deserialize old states.
+
 -- 1. simpleLinearRegressionIf(Nullable(Float64), Nullable(Float64), cond)
 SELECT finalizeAggregation(CAST(unhex('03000000000000000000000000002640000000000000394000000000008046400000000000405940'), 'AggregateFunction(simpleLinearRegressionIf, Nullable(Float64), Nullable(Float64), UInt8)'));
-
-SELECT hex(simpleLinearRegressionIfState(x, y, x > 1))
-FROM values('x Nullable(Float64), y Nullable(Float64)', (1, 3), (2, 5), (NULL, 7), (4, 9), (5, 11));
 
 -- 2. studentTTestIf(Nullable(Float64), Nullable(UInt8), cond)
 SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
 FROM (SELECT finalizeAggregation(CAST(unhex('000000000000004000000000000000400000000000002040000000000000284000000000000041400000000000005A40'), 'AggregateFunction(studentTTestIf, Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
 
-SELECT hex(studentTTestIfState(v, g, v > 1))
-FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
-
 -- 3. welchTTestIf(Nullable(Float64), Nullable(UInt8), cond)
 SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
 FROM (SELECT finalizeAggregation(CAST(unhex('000000000000004000000000000000400000000000002040000000000000284000000000000041400000000000005A40'), 'AggregateFunction(welchTTestIf, Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
-
-SELECT hex(welchTTestIfState(v, g, v > 1))
-FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
 
 -- 4. meanZTestIf(1., 1., 0.95)(Nullable(Float64), Nullable(UInt8), cond)
 SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4), roundBankers(res.3, 4), roundBankers(res.4, 4))
 FROM (SELECT finalizeAggregation(CAST(unhex('0000000000000040000000000000004000000000000020400000000000002840'), 'AggregateFunction(meanZTestIf(1., 1., 0.95), Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
 
-SELECT hex(meanZTestIfState(1., 1., 0.95)(v, g, v > 1))
-FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
-
 -- 5. argAndMinIf(Nullable(Int32), Nullable(Int32), cond)
 SELECT finalizeAggregation(CAST(unhex('01030000000100000000'), 'AggregateFunction(argAndMinIf, Nullable(Int32), Nullable(Int32), UInt8)'));
 
-SELECT hex(argAndMinIfState(a, b, a > 0))
-FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (NULL, 1), (3, 0));
-
 -- 6. argAndMaxIf(Nullable(Int32), Nullable(Int32), cond)
 SELECT finalizeAggregation(CAST(unhex('01010000000102000000'), 'AggregateFunction(argAndMaxIf, Nullable(Int32), Nullable(Int32), UInt8)'));
-
-SELECT hex(argAndMaxIfState(a, b, a > 0))
-FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (NULL, 1), (3, 0));
 
 -- 7. kolmogorovSmirnovTestIf('two-sided')(Nullable(Float64), Nullable(UInt8), cond)
 SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
 FROM (SELECT finalizeAggregation(CAST(unhex('02020000000000000840000000000000144000000000000000400000000000002440'), 'AggregateFunction(kolmogorovSmirnovTestIf(''two-sided''), Nullable(Float64), Nullable(UInt8), UInt8)')) AS res);
 
-SELECT hex(kolmogorovSmirnovTestIfState('two-sided')(v, g, v > 1))
-FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
+-- Distinct combinator: deserialize old states.
 
--- Distinct combinator: verify round-trip for a subset.
+-- simpleLinearRegressionDistinct
+SELECT finalizeAggregation(CAST(unhex('01041000000000000010400000000000002240100000000000000040000000000000144010000000000000F03F00000000000008401000000000000014400000000000002640'), 'AggregateFunction(simpleLinearRegressionDistinct, Nullable(Float64), Nullable(Float64))'));
 
--- simpleLinearRegressionDistinct: round-trip.
-SELECT hex(simpleLinearRegressionDistinctState(x, y))
-FROM values('x Nullable(Float64), y Nullable(Float64)', (1, 3), (2, 5), (NULL, 7), (4, 9), (5, 11));
+-- studentTTestDistinct
+SELECT tuple(roundBankers(res.1, 4), roundBankers(res.2, 4))
+FROM (SELECT finalizeAggregation(CAST(unhex('010509000000000000F03F0009000000000000244001090000000000000840000900000000000014400009000000000000004001'), 'AggregateFunction(studentTTestDistinct, Nullable(Float64), Nullable(UInt8))')) AS res);
 
--- studentTTestDistinct: round-trip.
-SELECT hex(studentTTestDistinctState(v, g))
-FROM values('v Nullable(Float64), g Nullable(UInt8)', (1, 0), (3, 0), (5, 0), (2, 1), (10, 1), (NULL, 1));
+-- argAndMinDistinct
+SELECT finalizeAggregation(CAST(unhex('0102080100000002000000080300000000000000'), 'AggregateFunction(argAndMinDistinct, Nullable(Int32), Nullable(Int32))'));
 
--- argAndMinDistinct: round-trip.
-SELECT hex(argAndMinDistinctState(a, b))
-FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (NULL, 1), (3, 0));
+-- Merge combinator: deserialize old states.
 
--- Merge combinator: verify round-trip for a subset.
+-- simpleLinearRegressionMerge
+SELECT finalizeAggregation(CAST(unhex('01040000000000000000000000000028400000000000003C4000000000000047400000000000005A40'), 'AggregateFunction(simpleLinearRegressionMerge, AggregateFunction(simpleLinearRegression, Nullable(Float64), Nullable(Float64)))'));
 
--- simpleLinearRegressionMerge: round-trip.
-SELECT hex(simpleLinearRegressionMergeState(s))
-FROM (SELECT simpleLinearRegressionState(x, y) AS s FROM values('x Nullable(Float64), y Nullable(Float64)', (1, 3), (2, 5), (4, 9), (5, 11)));
+-- argAndMinMerge
+SELECT finalizeAggregation(CAST(unhex('0101030000000100000000'), 'AggregateFunction(argAndMinMerge, AggregateFunction(argAndMin, Nullable(Int32), Nullable(Int32)))'));
 
--- argAndMinMerge: round-trip.
-SELECT hex(argAndMinMergeState(s))
-FROM (SELECT argAndMinState(a, b) AS s FROM values('a Nullable(Int32), b Nullable(Int32)', (1, 2), (3, 0)));
+-- OrDefault combinator: deserialize old states.
+
+-- simpleLinearRegressionOrDefault
+SELECT finalizeAggregation(CAST(unhex('01040000000000000000000000000028400000000000003C4000000000000047400000000000005A4001'), 'AggregateFunction(simpleLinearRegressionOrDefault, Nullable(Float64), Nullable(Float64))'));
+
+-- argAndMinOrDefault
+SELECT finalizeAggregation(CAST(unhex('010103000000010000000001'), 'AggregateFunction(argAndMinOrDefault, Nullable(Int32), Nullable(Int32))'));


### PR DESCRIPTION
### `OrDefault` combinator:

Only single-argument aggregate function, `sumCount` is affected:

```sql
SELECT finalizeAggregation(CAST(unhex('0A000000000000000501'), 
'AggregateFunction(sumCountOrDefault, Nullable(UInt8))'));  -- throws error
```


`OrNull` is not affected because `sumCountOrNull` was not even possible before introduction of `Nullable(Tuple)` so no backward compatibility to preserve.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `sumCountOrDefault` aggregate function with one or more `Nullable` argument not being able to read older serialized states after introduction of `Nullable(Tuple)`. Closes https://github.com/ClickHouse/ClickHouse/issues/100882.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.363`
- Backported to: `26.3.3.6`, `26.2.7.5`, `26.1.8.3`
<!-- ch-version-info:end -->