### PR TITLE
Fix undefined behavior in `MergeTreeWhereOptimizer` iterator dereference

### DIFF
--- a/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
+++ b/src/Storages/MergeTree/MergeTreeWhereOptimizer.cpp
@@ -459,7 +459,7 @@ std::optional<MergeTreeWhereOptimizer::OptimizeResult> MergeTreeWhereOptimizer::
             /// Keep the original order of conditions in prewhere_conditions.
             position = condition_positions[&(*cond_it)];
             auto prewhere_it = prewhere_conditions.begin();
-            while (condition_positions[&(*prewhere_it)] < position && prewhere_it != prewhere_conditions.end())
+            while (prewhere_it != prewhere_conditions.end() && condition_positions[&(*prewhere_it)] < position)
                 ++prewhere_it;
             prewhere_conditions.splice(prewhere_it, where_conditions, cond_it);
         }


### PR DESCRIPTION
The while loop in `move_to_prewhere_conditions` dereferenced the iterator before checking it against `end()`, causing undefined behavior when the `prewhere_conditions` list was empty. Swap the condition order so the iterator validity check short-circuits before dereferencing.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.370`
<!-- ch-version-info:end -->