### PR TITLE
Show WASM UDFs in system.functions with arguments and return type

### DIFF
--- a/src/Functions/UserDefined/UserDefinedWebAssembly.cpp
+++ b/src/Functions/UserDefined/UserDefinedWebAssembly.cpp
@@ -694,11 +694,11 @@ UserDefinedWebAssemblyFunctionFactory::addOrReplace(ASTPtr create_function_query
         function_def.settings);
 
     std::unique_lock lock(registry_mutex);
-    registry[function_def.function_name] = wasm_func;
+    registry[function_def.function_name] = RegistryEntry{wasm_func, create_function_query};
     return wasm_func;
 }
 
-bool UserDefinedWebAssemblyFunctionFactory::has(const String & function_name)
+bool UserDefinedWebAssemblyFunctionFactory::has(const String & function_name) const
 {
     std::shared_lock lock(registry_mutex);
     return registry.contains(function_name);
@@ -718,7 +718,7 @@ FunctionOverloadResolverPtr UserDefinedWebAssemblyFunctionFactory::get(const Str
                 function_name,
                 fmt::join(registry | std::views::transform([](const auto & pair) { return pair.first; }), ", "));
         }
-        wasm_func = it->second;
+        wasm_func = it->second.function;
     }
 
     auto executable_function = std::make_shared<FunctionUserDefinedWasm>(function_name, std::move(wasm_func), std::move(context));
@@ -729,6 +729,16 @@ bool UserDefinedWebAssemblyFunctionFactory::dropIfExists(const String & function
 {
     std::unique_lock lock(registry_mutex);
     return registry.erase(function_name) > 0;
+}
+
+std::vector<UserDefinedWebAssemblyFunctionFactory::RegisteredFunction> UserDefinedWebAssemblyFunctionFactory::getAllFunctions() const
+{
+    std::shared_lock lock(registry_mutex);
+    std::vector<RegisteredFunction> result;
+    result.reserve(registry.size());
+    for (const auto & [sql_name, entry] : registry)
+        result.push_back(RegisteredFunction{sql_name, entry.function, entry.create_query});
+    return result;
 }
 
 UserDefinedWebAssemblyFunctionFactory & UserDefinedWebAssemblyFunctionFactory::instance()

--- a/src/Functions/UserDefined/UserDefinedWebAssembly.h
+++ b/src/Functions/UserDefined/UserDefinedWebAssembly.h
@@ -84,18 +84,34 @@ class WasmModuleManager;
 class UserDefinedWebAssemblyFunctionFactory
 {
 public:
+    struct RegisteredFunction
+    {
+        String sql_name;
+        std::shared_ptr<UserDefinedWebAssemblyFunction> function;
+        ASTPtr create_query;
+    };
+
     std::shared_ptr<UserDefinedWebAssemblyFunction> addOrReplace(ASTPtr create_function_query, WasmModuleManager & module_manager);
 
-    bool has(const String & function_name);
+    bool has(const String & function_name) const;
     FunctionOverloadResolverPtr get(const String & function_name, ContextPtr context);
 
     /// Returns true if function was removed
     bool dropIfExists(const String & function_name);
 
+    /// Returns all registered WASM functions with their metadata for introspection (e.g. system.functions).
+    std::vector<RegisteredFunction> getAllFunctions() const;
+
     static UserDefinedWebAssemblyFunctionFactory & instance();
 private:
-    DB::SharedMutex registry_mutex;
-    std::unordered_map<String, std::shared_ptr<UserDefinedWebAssemblyFunction>> registry;
+    struct RegistryEntry
+    {
+        std::shared_ptr<UserDefinedWebAssemblyFunction> function;
+        ASTPtr create_query;
+    };
+
+    mutable DB::SharedMutex registry_mutex;
+    std::unordered_map<String, RegistryEntry> registry;
 };
 
 }

--- a/src/Storages/System/StorageSystemFunctions.cpp
+++ b/src/Storages/System/StorageSystemFunctions.cpp
@@ -8,6 +8,8 @@
 #include <Interpreters/formatWithPossiblyHidingSecrets.h>
 #include <Functions/UserDefined/UserDefinedSQLFunctionFactory.h>
 #include <Functions/UserDefined/UserDefinedExecutableFunctionFactory.h>
+#include <Functions/UserDefined/UserDefinedWebAssembly.h>
+#include <Parsers/ASTCreateWasmFunctionQuery.h>
 #include <Storages/System/StorageSystemFunctions.h>
 #include <Common/Exception.h>
 #include <Common/Logger.h>
@@ -106,7 +108,8 @@ std::vector<std::pair<String, Int8>> getOriginEnumsValues()
     return std::vector<std::pair<String, Int8>>{
         {"System", static_cast<Int8>(FunctionOrigin::SYSTEM)},
         {"SQLUserDefined", static_cast<Int8>(FunctionOrigin::SQL_USER_DEFINED)},
-        {"ExecutableUserDefined", static_cast<Int8>(FunctionOrigin::EXECUTABLE_USER_DEFINED)}
+        {"ExecutableUserDefined", static_cast<Int8>(FunctionOrigin::EXECUTABLE_USER_DEFINED)},
+        {"WasmUserDefined", static_cast<Int8>(FunctionOrigin::WASM_USER_DEFINED)},
     };
 }
 
@@ -163,6 +166,11 @@ void StorageSystemFunctions::fillData(MutableColumns & res_columns, ContextPtr c
             else
                 throw;
         }
+        /// WASM functions are stored in the same SQL objects storage but have their own origin.
+        /// They are emitted separately below; skip them here to avoid duplicates.
+        if (ast && ast->as<ASTCreateWasmFunctionQuery>())
+            continue;
+
         String create_query;
         if (ast)
             create_query = format({context, *ast});
@@ -174,6 +182,54 @@ void StorageSystemFunctions::fillData(MutableColumns & res_columns, ContextPtr c
     for (const auto & function_name : user_defined_executable_functions_names)
     {
         fillRow(res_columns, function_name, 0, "", FunctionOrigin::EXECUTABLE_USER_DEFINED, user_defined_executable_functions_factory);
+    }
+
+    const auto & wasm_functions_factory = UserDefinedWebAssemblyFunctionFactory::instance();
+    for (const auto & registered : wasm_functions_factory.getAllFunctions())
+    {
+        const auto & func = *registered.function;
+        const auto & arg_names = func.getArgumentNames();
+        const auto & arg_types = func.getArguments();
+        const auto & result_type = func.getResultType();
+
+        String create_query;
+        if (registered.create_query)
+            create_query = format({context, *registered.create_query});
+
+        String syntax = registered.sql_name + "(";
+        String arguments_str;
+        for (size_t i = 0; i < arg_types.size(); ++i)
+        {
+            if (i > 0)
+                syntax += ", ";
+            const String & arg_name = i < arg_names.size() ? arg_names[i] : ("arg" + std::to_string(i + 1));
+            const String type_name = arg_types[i]->getName();
+            syntax += arg_name + " " + type_name;
+            arguments_str += "- `" + arg_name + "` — " + type_name + "\n";
+        }
+        syntax += ")";
+
+        String returned_value_str;
+        if (result_type)
+        {
+            syntax += " -> " + result_type->getName();
+            returned_value_str = result_type->getName();
+        }
+
+        res_columns[0]->insert(registered.sql_name);
+        res_columns[1]->insert(UInt64(0)); // is_aggregate
+        res_columns[2]->insert(false); // case_insensitive
+        res_columns[3]->insertDefault(); // alias_to
+        res_columns[4]->insert(create_query);
+        res_columns[5]->insert(static_cast<Int8>(FunctionOrigin::WASM_USER_DEFINED));
+        res_columns[6]->insertDefault(); // description
+        res_columns[7]->insert(syntax);
+        res_columns[8]->insert(arguments_str);
+        res_columns[9]->insertDefault(); // parameters
+        res_columns[10]->insert(returned_value_str);
+        res_columns[11]->insertDefault(); // examples
+        res_columns[12]->insertDefault(); // introduced_in
+        res_columns[13]->insertDefault(); // categories
     }
 }
 

--- a/tests/queries/0_stateless/02117_show_create_table_system.reference
+++ b/tests/queries/0_stateless/02117_show_create_table_system.reference
@@ -311,7 +311,7 @@ CREATE TABLE system.functions
     `case_insensitive` UInt8,
     `alias_to` String,
     `create_query` String,
-    `origin` Enum8('System' = 0, 'SQLUserDefined' = 1, 'ExecutableUserDefined' = 2),
+    `origin` Enum8('System' = 0, 'SQLUserDefined' = 1, 'ExecutableUserDefined' = 2, 'WasmUserDefined' = 3),
     `description` String,
     `syntax` String,
     `arguments` String,

--- a/tests/queries/0_stateless/03215_udf_with_union.sql
+++ b/tests/queries/0_stateless/03215_udf_with_union.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 DROP FUNCTION IF EXISTS 03215_udf_with_union;
 CREATE FUNCTION 03215_udf_with_union AS () -> (
     SELECT sum(s)

--- a/tests/queries/0_stateless/03215_udf_with_union.sql
+++ b/tests/queries/0_stateless/03215_udf_with_union.sql
@@ -1,3 +1,5 @@
+-- Tags: no-parallel
+
 DROP FUNCTION IF EXISTS 03215_udf_with_union;
 CREATE FUNCTION 03215_udf_with_union AS () -> (
     SELECT sum(s)

--- a/tests/queries/0_stateless/04064_wasm_system_functions.reference
+++ b/tests/queries/0_stateless/04064_wasm_system_functions.reference
@@ -1,0 +1,2 @@
+wasm_sf_buffered	0	0	WasmUserDefined	wasm_sf_buffered(x Int32) -> Int32	- `x` — Int32\n	Int32
+wasm_sf_simple	0	0	WasmUserDefined	wasm_sf_simple(x Int32) -> Int32	- `x` — Int32\n	Int32

--- a/tests/queries/0_stateless/04064_wasm_system_functions.sh
+++ b/tests/queries/0_stateless/04064_wasm_system_functions.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-parallel, no-msan
+# Test that WASM UDFs appear correctly in system.functions with proper metadata.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} << 'EOF'
+DROP FUNCTION IF EXISTS wasm_sf_simple;
+DROP FUNCTION IF EXISTS wasm_sf_buffered;
+DELETE FROM system.webassembly_modules WHERE name = 'wasm_sf_test';
+EOF
+
+cat "${CUR_DIR}/wasm/identity_int.wasm" | ${CLICKHOUSE_CLIENT} \
+    --query "INSERT INTO system.webassembly_modules (name, code) SELECT 'wasm_sf_test', code FROM input('code String') FORMAT RawBlob"
+
+${CLICKHOUSE_CLIENT} << 'EOF'
+-- RowDirect ABI function with a named argument
+CREATE OR REPLACE FUNCTION wasm_sf_simple
+    LANGUAGE WASM ABI ROW_DIRECT FROM 'wasm_sf_test' :: 'identity_raw'
+    ARGUMENTS (x Int32) RETURNS Int32;
+
+-- BufferedV1 ABI function
+CREATE OR REPLACE FUNCTION wasm_sf_buffered
+    LANGUAGE WASM ABI BUFFERED_V1 FROM 'wasm_sf_test' :: 'identity_msgpack_i32'
+    ARGUMENTS (x Int32) RETURNS Int32;
+
+-- Both functions must appear in system.functions with origin WasmUserDefined
+SELECT name, is_aggregate, case_insensitive, origin, syntax, arguments, returned_value
+FROM system.functions
+WHERE name IN ('wasm_sf_simple', 'wasm_sf_buffered')
+ORDER BY name;
+
+-- Each function must appear exactly once (no duplicates from the SQL UDF storage)
+SELECT name, count() AS cnt
+FROM system.functions
+WHERE name IN ('wasm_sf_simple', 'wasm_sf_buffered')
+GROUP BY name
+HAVING cnt > 1;
+
+DROP FUNCTION IF EXISTS wasm_sf_simple;
+DROP FUNCTION IF EXISTS wasm_sf_buffered;
+DELETE FROM system.webassembly_modules WHERE name = 'wasm_sf_test';
+EOF


### PR DESCRIPTION
WASM UDFs were invisible in `system.functions`: they were neither listed with                                                                   
  their own `WasmUserDefined` origin, nor did the `syntax`, `arguments`, or                                                                       
  `returned_value` columns carry any data. In addition, functions appeared twice —                                                                
  once as `SQLUserDefined` (because WASM definitions are stored in the SQL objects                                                                
  storage) and once in the WASM-specific iteration.                                                                                               
                                                                                                                                                  
  This PR fixes all three issues:                                                                                                                 
                                                                                                                                                  
  - `WasmUserDefined` was defined in the `FunctionOrigin` enum but missing from
    `getOriginEnumsValues()`, so it was never a legal value in the `origin` column.                                                               
    It is now registered.                                   
  - WASM functions stored in `UserDefinedSQLObjectsStorage` are skipped in the                                                                    
    `SQLUserDefined` loop (detected via `ASTCreateWasmFunctionQuery`) to prevent
    duplicates.                                                                                                                                   
  - `UserDefinedWebAssemblyFunctionFactory` gains a `getAllFunctions() const` method
    that returns a snapshot of the registry with SQL name, function metadata, and
    the original `CREATE FUNCTION` AST. `StorageSystemFunctions::fillData` uses this                                                              
    to populate `syntax`, `arguments`, and `returned_value` from the `DataType`
    metadata.                                                                                                                                     
  - A new stateless test `04064_wasm_system_functions` covers both a `ROW_DIRECT`                                                                 
    and a `BUFFERED_V1` function and asserts correct origin, syntax, arguments,
    returned value, and no duplicates.                                                                                                            
                                                            
  ### Changelog category (leave one):                                                                                                             
  - Improvement
                                                                                                                                                  
  ### Changelog entry (a [user-readable short  description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into   CHANGELOG.md):                                            
                                                                                                                                                  
  WASM UDFs now appear in `system.functions` with correct `origin` (`WasmUserDefined`),
  `syntax`, `arguments`, and `returned_value` columns populated from their ClickHouse                                                             
  type metadata. Previously they were either missing or listed with the wrong origin
  as duplicates.                              
                                          
  ### Documentation entry for user-facing changes
                                                                                                                                                  
  - [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.509`
<!-- ch-version-info:end -->