### PR TITLE
Fix flaky test_polymorphic_parts repeated run failures

### DIFF
--- a/tests/integration/test_polymorphic_parts/test.py
+++ b/tests/integration/test_polymorphic_parts/test.py
@@ -193,12 +193,16 @@ def start_cluster():
     ],
 )
 def test_polymorphic_parts_basics(start_cluster, first_node, second_node):
+    # Clean up data from potential previous runs (pytest-repeat with --count)
+    first_node.query("TRUNCATE TABLE polymorphic_table")
+    second_node.query("SYSTEM SYNC REPLICA polymorphic_table", timeout=60)
+
     first_node.query("SYSTEM STOP MERGES")
     second_node.query("SYSTEM STOP MERGES")
 
     for size in [300, 300, 600]:
         insert_random_data("polymorphic_table", first_node, size)
-    second_node.query("SYSTEM SYNC REPLICA polymorphic_table", timeout=20)
+    second_node.query("SYSTEM SYNC REPLICA polymorphic_table", timeout=60)
 
     assert first_node.query("SELECT count() FROM polymorphic_table") == "1200\n"
     assert second_node.query("SELECT count() FROM polymorphic_table") == "1200\n"
@@ -225,14 +229,14 @@ def test_polymorphic_parts_basics(start_cluster, first_node, second_node):
         insert_random_data("polymorphic_table", first_node, 10)
         insert_random_data("polymorphic_table", second_node, 10)
 
-    first_node.query("SYSTEM SYNC REPLICA polymorphic_table", timeout=20)
-    second_node.query("SYSTEM SYNC REPLICA polymorphic_table", timeout=20)
+    first_node.query("SYSTEM SYNC REPLICA polymorphic_table", timeout=60)
+    second_node.query("SYSTEM SYNC REPLICA polymorphic_table", timeout=60)
 
     assert first_node.query("SELECT count() FROM polymorphic_table") == "2000\n"
     assert second_node.query("SELECT count() FROM polymorphic_table") == "2000\n"
 
     first_node.query("OPTIMIZE TABLE polymorphic_table FINAL")
-    second_node.query("SYSTEM SYNC REPLICA polymorphic_table", timeout=20)
+    second_node.query("SYSTEM SYNC REPLICA polymorphic_table", timeout=60)
 
     assert first_node.query("SELECT count() FROM polymorphic_table") == "2000\n"
     assert second_node.query("SELECT count() FROM polymorphic_table") == "2000\n"
@@ -251,10 +255,10 @@ def test_polymorphic_parts_basics(start_cluster, first_node, second_node):
     )
 
     # Check alters and mutations also work
-    first_node.query("ALTER TABLE polymorphic_table ADD COLUMN ss String")
+    first_node.query("ALTER TABLE polymorphic_table ADD COLUMN IF NOT EXISTS ss String")
     first_node.query("ALTER TABLE polymorphic_table UPDATE ss = toString(id) WHERE 1")
 
-    second_node.query("SYSTEM SYNC REPLICA polymorphic_table", timeout=20)
+    second_node.query("SYSTEM SYNC REPLICA polymorphic_table", timeout=60)
 
     first_node.query("SELECT count(ss) FROM polymorphic_table") == "2000\n"
     first_node.query("SELECT uniqExact(ss) FROM polymorphic_table") == "600\n"
@@ -265,12 +269,16 @@ def test_polymorphic_parts_basics(start_cluster, first_node, second_node):
 
 # Checks mostly that merge from compact part to compact part works.
 def test_compact_parts_only(start_cluster):
+    # Clean up data from potential previous runs (pytest-repeat with --count)
+    node1.query("TRUNCATE TABLE compact_parts_only")
+    node2.query("SYSTEM SYNC REPLICA compact_parts_only", timeout=60)
+
     for i in range(20):
         insert_random_data("compact_parts_only", node1, 100)
         insert_random_data("compact_parts_only", node2, 100)
 
-    node1.query("SYSTEM SYNC REPLICA compact_parts_only", timeout=20)
-    node2.query("SYSTEM SYNC REPLICA compact_parts_only", timeout=20)
+    node1.query("SYSTEM SYNC REPLICA compact_parts_only", timeout=60)
+    node2.query("SYSTEM SYNC REPLICA compact_parts_only", timeout=60)
 
     assert node1.query("SELECT count() FROM compact_parts_only") == "4000\n"
     assert node2.query("SELECT count() FROM compact_parts_only") == "4000\n"
@@ -289,7 +297,7 @@ def test_compact_parts_only(start_cluster):
     )
 
     node1.query("OPTIMIZE TABLE compact_parts_only FINAL")
-    node2.query("SYSTEM SYNC REPLICA compact_parts_only", timeout=20)
+    node2.query("SYSTEM SYNC REPLICA compact_parts_only", timeout=60)
     assert node2.query("SELECT count() FROM compact_parts_only") == "4000\n"
 
     expected = "Compact\t1\n"
@@ -316,6 +324,10 @@ def test_different_part_types_on_replicas(start_cluster, table, part_type):
     leader = node3
     follower = node4
 
+    # Clean up data from potential previous runs (pytest-repeat with --count)
+    leader.query("TRUNCATE TABLE {}".format(table))
+    follower.query("SYSTEM SYNC REPLICA {}".format(table), timeout=60)
+
     assert (
         leader.query(
             "SELECT is_leader FROM system.replicas WHERE table = '{}'".format(table)
@@ -339,7 +351,7 @@ def test_different_part_types_on_replicas(start_cluster, table, part_type):
         silent=True,
     )
 
-    follower.query("SYSTEM SYNC REPLICA {}".format(table), timeout=20)
+    follower.query("SYSTEM SYNC REPLICA {}".format(table), timeout=60)
 
     expected = "{}\t1\n".format(part_type)
 
@@ -420,14 +432,18 @@ def start_cluster_diff_versions():
 
 
 def test_polymorphic_parts_non_adaptive(start_cluster):
+    # Clean up data from potential previous runs (pytest-repeat with --count)
+    node1.query("TRUNCATE TABLE non_adaptive_table")
+    node2.query("SYSTEM SYNC REPLICA non_adaptive_table", timeout=60)
+
     node1.query("SYSTEM STOP MERGES")
     node2.query("SYSTEM STOP MERGES")
 
     insert_random_data("non_adaptive_table", node1, 100)
-    node2.query("SYSTEM SYNC REPLICA non_adaptive_table", timeout=20)
+    node2.query("SYSTEM SYNC REPLICA non_adaptive_table", timeout=60)
 
     insert_random_data("non_adaptive_table", node2, 100)
-    node1.query("SYSTEM SYNC REPLICA non_adaptive_table", timeout=20)
+    node1.query("SYSTEM SYNC REPLICA non_adaptive_table", timeout=60)
 
     assert TSV(
         node1.query(
@@ -449,9 +465,10 @@ def test_polymorphic_parts_non_adaptive(start_cluster):
 
 def test_polymorphic_parts_index(start_cluster):
     node1.query(
-        "CREATE DATABASE test_index ENGINE=Ordinary",
+        "CREATE DATABASE IF NOT EXISTS test_index ENGINE=Ordinary",
         settings={"allow_deprecated_database_ordinary": 1},
     )  # Different paths with Atomic
+    node1.query("DROP TABLE IF EXISTS test_index.index_compact SYNC")
     node1.query(
         """
         CREATE TABLE test_index.index_compact(a UInt32, s String)


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Not required

### Description

The `test_polymorphic_parts` integration test suite is chronically flaky — 21 distinct PRs affected in 30 days, with 3 master failures. The failures appear primarily in the CI `targeted` job (which uses `--count 10` via pytest-repeat) and in sanitizer builds (`amd_asan_ubsan, amd_asan`).

**Root causes identified:**

1. **Data accumulates across repeated test runs.** The `start_cluster` fixture is module-scoped: it creates tables once, but test functions run N times with `--count N`. Without cleanup between iterations, row counts grow (e.g., 4000 → 8000 → 12000) and assertions like `count() == '4000\n'` fail. In sanitizer CI builds, the accumulated data also amplifies replication load, causing `SYSTEM SYNC REPLICA` to timeout.

2. **`SYSTEM SYNC REPLICA` timeout of 20s is too tight for sanitizer builds.** ASAN/UBSAN builds run 2-5x slower. With 40 parts to replicate (20 INSERTs × 2 nodes), 20 seconds is insufficient even on a single run.

3. **`ALTER TABLE ADD COLUMN` and `CREATE DATABASE` fail on repeated runs** without idempotent syntax.

**Fix:**
- Add `TRUNCATE TABLE` at the start of each test function to ensure a clean state
- Increase `SYSTEM SYNC REPLICA` timeout from 20s to 60s (3x margin for sanitizer overhead)
- Use `IF NOT EXISTS` for `CREATE DATABASE` and `ADD COLUMN IF NOT EXISTS`
- Use `DROP TABLE IF EXISTS` before `CREATE TABLE` for non-replicated tables

**Verification:**
- Without fix: `test_compact_parts_only --count 3` → 2/3 fail (`assert '8000\n' == '4000\n'`)
- With fix: `test_compact_parts_only --count 5` → 5/5 pass
- Full suite single run: 7/7 pass

**Note:** A separate pre-existing ValuesBlockInputFormat parsing bug (306 CIDB hits in 30 days, `Cannot parse expression of type Array(Int32)`) also affects this test intermittently. That is a server-side issue affecting many integration tests, not specific to test_polymorphic_parts, and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.403`
<!-- ch-version-info:end -->