### PR TITLE
Fix chart duplication in play.html on theme switch

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -1844,6 +1844,12 @@ class QueryResultElement extends HTMLElement
     {
         await this._loadUplot();
 
+        if (this._uplot)
+        {
+            this._uplot.destroy();
+            this._uplot = null;
+        }
+
         let chart = this._chart;
         chart.style.display = 'block';
 


### PR DESCRIPTION
`renderChart` creates a new `uPlot` instance and appends it to the chart container, but never destroys the previous one. When switching between light/dark themes, `redrawChart` calls `renderChart`, which adds another chart without removing the old one — resulting in duplicated charts.

The fix calls `uPlot.destroy()` on the existing instance before creating a new one.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix chart duplication in Play UI when switching between light and dark themes.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.367`
<!-- ch-version-info:end -->