### PR TITLE
Fix crash on invalid `format_regexp` in `Regexp` format

### DIFF
--- a/src/Processors/Formats/Impl/RegexpRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/RegexpRowInputFormat.cpp
@@ -22,6 +22,9 @@ RegexpFieldExtractor::RegexpFieldExtractor(const FormatSettings & format_setting
     if (regexp_str.empty())
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "The regular expression is not set for the `Regexp` format. It requires setting the value of the `format_regexp` setting.");
 
+    if (!regexp.ok())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Invalid regular expression '{}' for the `Regexp` format: {}", regexp_str, regexp.error());
+
     size_t fields_count = regexp.NumberOfCapturingGroups();
     matched_fields.resize(fields_count);
     re2_arguments.resize(fields_count);

--- a/tests/queries/0_stateless/04067_regexp_invalid_pattern.sql
+++ b/tests/queries/0_stateless/04067_regexp_invalid_pattern.sql
@@ -1,0 +1,6 @@
+SET engine_file_truncate_on_insert = 1;
+
+INSERT INTO FUNCTION file(currentDatabase() || '_04067_regexp.data', 'CSV', 'x UInt64') VALUES (1);
+
+SELECT * FROM file(currentDatabase() || '_04067_regexp.data', 'Regexp') SETTINGS format_regexp = '\\'; -- { serverError CANNOT_EXTRACT_TABLE_STRUCTURE }
+SELECT * FROM file(currentDatabase() || '_04067_regexp.data', 'Regexp', 'x String') SETTINGS format_regexp = '\\'; -- { serverError BAD_ARGUMENTS }


### PR DESCRIPTION
The following query gives `std::exception` due to lack of invalidation of regexp.

```sql
SET engine_file_truncate_on_insert = 1;

INSERT INTO FUNCTION file(currentDatabase() || '_04067_regexp.data', 'CSV', 'x UInt64') VALUES (1);

SELECT * FROM file(currentDatabase() || '_04067_regexp.data', 'Regexp') SETTINGS format_regexp = '\\';
```

The bug was that `RegexpFieldExtractor` did not validate the regex before calling `NumberOfCapturingGroups()`, which returns `-1` for invalid patterns, leading to `vector::resize` with a huge size.

From PR (https://github.com/ClickHouse/ClickHouse/pull/101021) CI:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=101021&sha=a4a2b1f22c80e4fc911cc2c1cf2bb873ea62c27f&name_0=PR&name_1=Stress%20test%20%28amd_debug%29

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix crash when using the `Regexp` format with an invalid regular expression in `format_regexp` setting.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.394`
<!-- ch-version-info:end -->