### PR TITLE
Fix flaky test_reload_cluster_config_if_host_address_change

### DIFF
--- a/tests/integration/test_dns_cache/test.py
+++ b/tests/integration/test_dns_cache/test.py
@@ -62,7 +62,8 @@ node8 = cluster.add_instance(
     "node8",
     main_configs=[
         "configs/remote_servers_with_disable_dns_setting.xml",
-        "configs/listen_host.xml"
+        "configs/listen_host.xml",
+        "configs/dns_update_short.xml",
     ],
     # Disable `with_remote_database_disk` as the `test_reload_cluster_config_if_host_address_change` may simulate DNS service outage, causing it to fail to start.
     with_remote_database_disk=False,
@@ -520,8 +521,8 @@ def test_reload_cluster_config_if_host_address_change(cluster_ready):
     # Restore the original DNS configuration to simulate DNS service recovery
     node.exec_in_container(["bash", "-c", f"echo '{resolv_conf_bak}' > /etc/resolv.conf"], privileged=True, user="root")
     node.exec_in_container(["bash", "-c", f"echo '{hosts_bak}' > /etc/hosts"], privileged=True, user="root")
-    # Wait a bit until dns cache will be updated
-    assert_eq_with_retry(node, "SELECT is_local FROM system.clusters WHERE cluster='test_cluster' AND host_name='node8'", "1")
+    # Wait until dns cache will be updated (dns_cache_update_period is 10s, so we need enough retries)
+    assert_eq_with_retry(node, "SELECT is_local FROM system.clusters WHERE cluster='test_cluster' AND host_name='node8'", "1", retry_count=40)
 
     # Change the resolved IPs of node8
     node.exec_in_container(["bash", "-c", f"echo -e '127.0.0.1 node8\n192.168.1.1 node8\n192.168.1.2 node8' > /etc/hosts"], privileged=True, user="root")


### PR DESCRIPTION
Node8 was missing `dns_update_short.xml`, so it used the default 15-second DNS cache update period. The `assert_eq_with_retry` with default parameters (20 retries × 0.5s = 10s) would time out before the DNS cache had a chance to refresh.

Add `dns_update_short.xml` to node8 config (10s update period) and increase retry count to 40 (20s window) for comfortable margin.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=101042&sha=6bce0d39d7fb522ace5a37cb78c047754d7f0a09&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%204%2F4%29
https://github.com/ClickHouse/ClickHouse/pull/101042

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.395`
<!-- ch-version-info:end -->