### PR TITLE
Cache permuted columns to avoid redundant permutations during part writing

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPartWriter.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPartWriter.cpp
@@ -22,38 +22,54 @@ namespace MergeTreeSetting
     extern const MergeTreeSettingsString default_compression_codec;
 }
 
-Block getIndexBlockAndPermute(const Block & block, const Names & names, const IColumnPermutation * permutation)
+Block getIndexBlockAndPermute(const Block & block, const Names & names, const IColumnPermutation * permutation, Block * permuted_columns_cache)
 {
     Block result;
     for (size_t i = 0, size = names.size(); i < size; ++i)
     {
+        if (permuted_columns_cache && permuted_columns_cache->has(names[i]))
+        {
+            result.insert(i, permuted_columns_cache->getByName(names[i]));
+            continue;
+        }
+
         auto src_column = block.getColumnOrSubcolumnByName(names[i]);
         src_column.column = removeSpecialRepresentations(src_column.column);
         src_column.column = src_column.column->convertToFullColumnIfConst();
-        result.insert(i, src_column);
 
         /// Reorder primary key columns in advance and add them to `primary_key_columns`.
         if (permutation)
-        {
-            auto & column = result.getByPosition(i);
-            column.column = column.column->permute(*permutation, 0);
-        }
+            src_column.column = src_column.column->permute(*permutation, 0);
+
+        if (permuted_columns_cache)
+            permuted_columns_cache->insert(src_column);
+
+        result.insert(i, src_column);
     }
 
     return result;
 }
 
-Block permuteBlockIfNeeded(const Block & block, const IColumnPermutation * permutation)
+Block permuteBlockIfNeeded(const Block & block, const IColumnPermutation * permutation, Block * permuted_columns_cache)
 {
     Block result;
     for (size_t i = 0; i < block.columns(); ++i)
     {
-        result.insert(i, block.getByPosition(i));
-        if (permutation)
+        const auto & col = block.getByPosition(i);
+        if (permuted_columns_cache && permuted_columns_cache->has(col.name))
         {
-            auto & column = result.getByPosition(i);
-            column.column = column.column->permute(*permutation, 0);
+            result.insert(i, permuted_columns_cache->getByName(col.name));
+            continue;
         }
+
+        auto column_with_type = col;
+        if (permutation)
+            column_with_type.column = column_with_type.column->permute(*permutation, 0);
+
+        if (permuted_columns_cache)
+            permuted_columns_cache->insert(column_with_type);
+
+        result.insert(i, column_with_type);
     }
     return result;
 }

--- a/src/Storages/MergeTree/IMergeTreeDataPartWriter.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPartWriter.cpp
@@ -24,12 +24,17 @@ namespace MergeTreeSetting
 
 Block getIndexBlockAndPermute(const Block & block, const Names & names, const IColumnPermutation * permutation, Block * permuted_columns_cache)
 {
+    /// The cache is meaningful only when a permutation is applied: it stores the result
+    /// of `permute()` so that subsequent lookups by name return the already-permuted column.
+    /// If `permutation == nullptr`, there is nothing to amortize, so we ignore the cache.
+    Block * cache = permutation ? permuted_columns_cache : nullptr;
+
     Block result;
     for (size_t i = 0, size = names.size(); i < size; ++i)
     {
-        if (permuted_columns_cache && permuted_columns_cache->has(names[i]))
+        if (cache && cache->has(names[i]))
         {
-            result.insert(i, permuted_columns_cache->getByName(names[i]));
+            result.insert(i, cache->getByName(names[i]));
             continue;
         }
 
@@ -41,8 +46,8 @@ Block getIndexBlockAndPermute(const Block & block, const Names & names, const IC
         if (permutation)
             src_column.column = src_column.column->permute(*permutation, 0);
 
-        if (permuted_columns_cache)
-            permuted_columns_cache->insert(src_column);
+        if (cache)
+            cache->insert(src_column);
 
         result.insert(i, src_column);
     }
@@ -52,13 +57,17 @@ Block getIndexBlockAndPermute(const Block & block, const Names & names, const IC
 
 Block permuteBlockIfNeeded(const Block & block, const IColumnPermutation * permutation, Block * permuted_columns_cache)
 {
+    /// See the comment in `getIndexBlockAndPermute`: the cache only stores genuinely
+    /// permuted columns, so it is ignored when `permutation == nullptr`.
+    Block * cache = permutation ? permuted_columns_cache : nullptr;
+
     Block result;
     for (size_t i = 0; i < block.columns(); ++i)
     {
         const auto & col = block.getByPosition(i);
-        if (permuted_columns_cache && permuted_columns_cache->has(col.name))
+        if (cache && cache->has(col.name))
         {
-            result.insert(i, permuted_columns_cache->getByName(col.name));
+            result.insert(i, cache->getByName(col.name));
             continue;
         }
 
@@ -66,8 +75,8 @@ Block permuteBlockIfNeeded(const Block & block, const IColumnPermutation * permu
         if (permutation)
             column_with_type.column = column_with_type.column->permute(*permutation, 0);
 
-        if (permuted_columns_cache)
-            permuted_columns_cache->insert(column_with_type);
+        if (cache)
+            cache->insert(column_with_type);
 
         result.insert(i, column_with_type);
     }

--- a/src/Storages/MergeTree/IMergeTreeDataPartWriter.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPartWriter.h
@@ -44,7 +44,7 @@ public:
 
     virtual ~IMergeTreeDataPartWriter();
 
-    virtual void write(const Block & block, const IColumnPermutation * permutation, Block * permuted_columns_cache = nullptr) = 0;
+    virtual void write(const Block & block, const IColumnPermutation * permutation, Block * permuted_columns_cache) = 0;
 
     virtual void finalizeIndexGranularity() = 0;
     virtual void fillChecksums(MergeTreeDataPartChecksums & checksums, NameSet & checksums_to_remove) = 0;

--- a/src/Storages/MergeTree/IMergeTreeDataPartWriter.h
+++ b/src/Storages/MergeTree/IMergeTreeDataPartWriter.h
@@ -22,9 +22,9 @@ using MergeTreeSettingsPtr = std::shared_ptr<const MergeTreeSettings>;
 
 using WrittenOffsetSubstreams = std::set<std::string>;
 
-Block getIndexBlockAndPermute(const Block & block, const Names & names, const IColumnPermutation * permutation);
+Block getIndexBlockAndPermute(const Block & block, const Names & names, const IColumnPermutation * permutation, Block * permuted_columns_cache = nullptr);
 
-Block permuteBlockIfNeeded(const Block & block, const IColumnPermutation * permutation);
+Block permuteBlockIfNeeded(const Block & block, const IColumnPermutation * permutation, Block * permuted_columns_cache = nullptr);
 
 /// Writes data part to disk in different formats.
 /// Calculates and serializes primary and skip indices if needed.
@@ -44,7 +44,7 @@ public:
 
     virtual ~IMergeTreeDataPartWriter();
 
-    virtual void write(const Block & block, const IColumnPermutation * permutation) = 0;
+    virtual void write(const Block & block, const IColumnPermutation * permutation, Block * permuted_columns_cache = nullptr) = 0;
 
     virtual void finalizeIndexGranularity() = 0;
     virtual void fillChecksums(MergeTreeDataPartChecksums & checksums, NameSet & checksums_to_remove) = 0;

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
@@ -277,6 +277,11 @@ void MergeTreeDataPartWriterCompact::writeDataBlockPrimaryIndexAndSkipIndices(co
 {
     writeDataBlock(block, granules_to_write);
 
+    /// `block` here is already fully permuted by `permuteBlockIfNeeded` in `write`,
+    /// so we pass `permutation = nullptr` and intentionally do not pass the permuted
+    /// columns cache: the columns in `block` are already permuted, so re-inserting
+    /// them via the cache would be pointless. The cache only helps when columns are
+    /// permuted on the fly (the Wide writer path).
     if (settings.rewrite_primary_key)
     {
         Block primary_key_block = getIndexBlockAndPermute(block, metadata_snapshot->getPrimaryKeyColumns(), nullptr);

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
@@ -223,8 +223,14 @@ ISerialization::SerializeBinaryBulkSettings MergeTreeDataPartWriterCompact::getS
     return serialize_settings;
 }
 
-void MergeTreeDataPartWriterCompact::write(const Block & block, const IColumnPermutation * permutation, Block * permuted_columns_cache)
+void MergeTreeDataPartWriterCompact::write(const Block & block, const IColumnPermutation * permutation, Block * /*permuted_columns_cache*/)
 {
+    /// The permuted columns cache is intentionally ignored in the Compact writer:
+    /// `permuteBlockIfNeeded` below permutes the whole block once, and the subsequent
+    /// `getIndexBlockAndPermute` calls in `writeDataBlockPrimaryIndexAndSkipIndices`
+    /// pass `permutation = nullptr` (they only re-pick columns by name from the
+    /// already-permuted block). So the cache would only ever be written to, never
+    /// read from — pure overhead.
     Block result_block = block;
 
     /// For some columns the set of streams may depend on the actual column data.
@@ -246,7 +252,7 @@ void MergeTreeDataPartWriterCompact::write(const Block & block, const IColumnPer
         fillIndexGranularity(index_granularity_for_block, result_block.rows());
     }
 
-    result_block = permuteBlockIfNeeded(result_block, permutation, permuted_columns_cache);
+    result_block = permuteBlockIfNeeded(result_block, permutation, nullptr);
 
     if (header.empty())
         header = result_block.cloneEmpty();
@@ -278,10 +284,8 @@ void MergeTreeDataPartWriterCompact::writeDataBlockPrimaryIndexAndSkipIndices(co
     writeDataBlock(block, granules_to_write);
 
     /// `block` here is already fully permuted by `permuteBlockIfNeeded` in `write`,
-    /// so we pass `permutation = nullptr` and intentionally do not pass the permuted
-    /// columns cache: the columns in `block` are already permuted, so re-inserting
-    /// them via the cache would be pointless. The cache only helps when columns are
-    /// permuted on the fly (the Wide writer path).
+    /// so we pass `permutation = nullptr` and no cache — only Wide writer benefits
+    /// from the permuted columns cache (see comment in `MergeTreeDataPartWriterCompact::write`).
     if (settings.rewrite_primary_key)
     {
         Block primary_key_block = getIndexBlockAndPermute(block, metadata_snapshot->getPrimaryKeyColumns(), nullptr);

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.cpp
@@ -223,7 +223,7 @@ ISerialization::SerializeBinaryBulkSettings MergeTreeDataPartWriterCompact::getS
     return serialize_settings;
 }
 
-void MergeTreeDataPartWriterCompact::write(const Block & block, const IColumnPermutation * permutation)
+void MergeTreeDataPartWriterCompact::write(const Block & block, const IColumnPermutation * permutation, Block * permuted_columns_cache)
 {
     Block result_block = block;
 
@@ -246,7 +246,7 @@ void MergeTreeDataPartWriterCompact::write(const Block & block, const IColumnPer
         fillIndexGranularity(index_granularity_for_block, result_block.rows());
     }
 
-    result_block = permuteBlockIfNeeded(result_block, permutation);
+    result_block = permuteBlockIfNeeded(result_block, permutation, permuted_columns_cache);
 
     if (header.empty())
         header = result_block.cloneEmpty();

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.h
@@ -30,7 +30,7 @@ public:
         const MergeTreeWriterSettings & settings,
         MergeTreeIndexGranularityPtr index_granularity_);
 
-    void write(const Block & block, const IColumnPermutation * permutation) override;
+    void write(const Block & block, const IColumnPermutation * permutation, Block * permuted_columns_cache = nullptr) override;
 
     void finalizeIndexGranularity() final;
     void fillChecksums(MergeTreeDataPartChecksums & checksums, NameSet & checksums_to_remove) final;

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterCompact.h
@@ -30,7 +30,7 @@ public:
         const MergeTreeWriterSettings & settings,
         MergeTreeIndexGranularityPtr index_granularity_);
 
-    void write(const Block & block, const IColumnPermutation * permutation, Block * permuted_columns_cache = nullptr) override;
+    void write(const Block & block, const IColumnPermutation * permutation, Block * permuted_columns_cache) override;
 
     void finalizeIndexGranularity() final;
     void fillChecksums(MergeTreeDataPartChecksums & checksums, NameSet & checksums_to_remove) final;

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
@@ -307,7 +307,7 @@ void MergeTreeDataPartWriterWide::shiftCurrentMark(const Granules & granules_wri
     }
 }
 
-void MergeTreeDataPartWriterWide::write(const Block & block, const IColumnPermutation * permutation)
+void MergeTreeDataPartWriterWide::write(const Block & block, const IColumnPermutation * permutation, Block * permuted_columns_cache)
 {
     Block block_to_write = block;
 
@@ -357,9 +357,9 @@ void MergeTreeDataPartWriterWide::write(const Block & block, const IColumnPermut
 
     Block primary_key_block;
     if (settings.rewrite_primary_key)
-        primary_key_block = getIndexBlockAndPermute(block, metadata_snapshot->getPrimaryKeyColumns(), permutation);
+        primary_key_block = getIndexBlockAndPermute(block, metadata_snapshot->getPrimaryKeyColumns(), permutation, permuted_columns_cache);
 
-    Block skip_indexes_block = getIndexBlockAndPermute(block, getSkipIndicesColumns(), permutation);
+    Block skip_indexes_block = getIndexBlockAndPermute(block, getSkipIndicesColumns(), permutation, permuted_columns_cache);
 
     auto it = columns_list.begin();
     for (size_t i = 0; i < columns_list.size(); ++i, ++it)
@@ -380,6 +380,11 @@ void MergeTreeDataPartWriterWide::write(const Block & block, const IColumnPermut
             {
                 const auto & index_column = *skip_indexes_block.getByName(it->name).column;
                 writeColumn(*it, index_column, offset_substreams, granules_to_write);
+            }
+            else if (permuted_columns_cache && permuted_columns_cache->has(it->name))
+            {
+                const auto & cached_column = *permuted_columns_cache->getByName(it->name).column;
+                writeColumn(*it, cached_column, offset_substreams, granules_to_write);
             }
             else
             {

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
@@ -381,14 +381,12 @@ void MergeTreeDataPartWriterWide::write(const Block & block, const IColumnPermut
                 const auto & index_column = *skip_indexes_block.getByName(it->name).column;
                 writeColumn(*it, index_column, offset_substreams, granules_to_write);
             }
-            else if (permuted_columns_cache && permuted_columns_cache->has(it->name))
-            {
-                const auto & cached_column = *permuted_columns_cache->getByName(it->name).column;
-                writeColumn(*it, cached_column, offset_substreams, granules_to_write);
-            }
             else
             {
                 /// We rearrange the columns that are not included in the primary key here; Then the result is released - to save RAM.
+                /// The permuted columns cache is populated above only with PK and skip-index columns
+                /// (via `getIndexBlockAndPermute`), so by construction it cannot contain this column,
+                /// and there is no point looking it up here.
                 ColumnPtr permuted_column = column.column->permute(*permutation, 0);
                 writeColumn(*it, *permuted_column, offset_substreams, granules_to_write);
             }

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterWide.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterWide.h
@@ -38,7 +38,7 @@ public:
         MergeTreeIndexGranularityPtr index_granularity_,
         WrittenOffsetSubstreams * written_offset_substreams_);
 
-    void write(const Block & block, const IColumnPermutation * permutation) override;
+    void write(const Block & block, const IColumnPermutation * permutation, Block * permuted_columns_cache = nullptr) override;
 
     void finalizeIndexGranularity() final;
     void fillChecksums(MergeTreeDataPartChecksums & checksums, NameSet & checksums_to_remove) final;

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterWide.h
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterWide.h
@@ -38,7 +38,7 @@ public:
         MergeTreeIndexGranularityPtr index_granularity_,
         WrittenOffsetSubstreams * written_offset_substreams_);
 
-    void write(const Block & block, const IColumnPermutation * permutation, Block * permuted_columns_cache = nullptr) override;
+    void write(const Block & block, const IColumnPermutation * permutation, Block * permuted_columns_cache) override;
 
     void finalizeIndexGranularity() final;
     void fillChecksums(MergeTreeDataPartChecksums & checksums, NameSet & checksums_to_remove) final;

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -944,7 +944,8 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeTempPartImpl(
         context->getWriteSettings(),
         static_cast<WrittenOffsetSubstreams *>(nullptr));
 
-    out->writeWithPermutation(block, perm_ptr);
+    Block permuted_columns_cache;
+    out->writeWithPermutation(block, perm_ptr, &permuted_columns_cache);
 
     for (const auto & projection : metadata_snapshot->getProjections())
     {
@@ -1140,7 +1141,8 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeProjectionPartImpl(
         data.getContext()->getWriteSettings(),
         static_cast<WrittenOffsetSubstreams *>(nullptr));
 
-    out->writeWithPermutation(block, perm_ptr);
+    Block permuted_columns_cache;
+    out->writeWithPermutation(block, perm_ptr, &permuted_columns_cache);
     out->finalizeIndexGranularity();
     auto finalizer = out->finalizePartAsync(new_data_part, IMergedBlockOutputStream::GatheredData{}, false);
     temp_part->part = new_data_part;

--- a/src/Storages/MergeTree/MergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.cpp
@@ -101,9 +101,9 @@ void MergedBlockOutputStream::cancel() noexcept
 /** If the data is not sorted, but we pre-calculated the permutation, after which they will be sorted.
     * This method is used to save RAM, since you do not need to keep two blocks at once - the source and the sorted.
     */
-void MergedBlockOutputStream::writeWithPermutation(const Block & block, const IColumn::Permutation * permutation)
+void MergedBlockOutputStream::writeWithPermutation(const Block & block, const IColumn::Permutation * permutation, Block * permuted_columns_cache)
 {
-    writeImpl(block, permutation);
+    writeImpl(block, permutation, permuted_columns_cache);
 }
 
 struct MergedBlockOutputStream::Finalizer::Impl
@@ -440,14 +440,14 @@ MergedBlockOutputStream::WrittenFiles MergedBlockOutputStream::finalizePartOnDis
     return written_files;
 }
 
-void MergedBlockOutputStream::writeImpl(const Block & block, const IColumn::Permutation * permutation)
+void MergedBlockOutputStream::writeImpl(const Block & block, const IColumn::Permutation * permutation, Block * permuted_columns_cache)
 {
     block.checkNumberOfRows();
     size_t rows = block.rows();
     if (!rows)
         return;
 
-    writer->write(block, permutation);
+    writer->write(block, permutation, permuted_columns_cache);
     if (reset_columns)
         new_serialization_infos.add(block);
 

--- a/src/Storages/MergeTree/MergedBlockOutputStream.h
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.h
@@ -39,7 +39,7 @@ public:
     /** If the data is not sorted, but we have previously calculated the permutation, that will sort it.
       * This method is used to save RAM, since you do not need to keep two blocks at once - the original one and the sorted one.
       */
-    void writeWithPermutation(const Block & block, const IColumn::Permutation * permutation);
+    void writeWithPermutation(const Block & block, const IColumn::Permutation * permutation, Block * permuted_columns_cache = nullptr);
 
     /// Finalizer is a structure which is returned from by finalizePart().
     /// Files from part may be written asynchronously, e.g. for blob storages.
@@ -78,7 +78,7 @@ private:
     /** If `permutation` is given, it rearranges the values in the columns when writing.
       * This is necessary to not keep the whole block in the RAM to sort it.
       */
-    void writeImpl(const Block & block, const IColumn::Permutation * permutation);
+    void writeImpl(const Block & block, const IColumn::Permutation * permutation, Block * permuted_columns_cache = nullptr);
 
     using WrittenFiles = std::vector<std::unique_ptr<WriteBufferFromFileBase>>;
     WrittenFiles finalizePartOnDisk(

--- a/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
@@ -64,7 +64,7 @@ void MergedColumnOnlyOutputStream::write(const Block & block)
     if (!block.rows())
         return;
 
-    writer->write(block, nullptr);
+    writer->write(block, nullptr, nullptr);
     new_serialization_infos.add(block);
 }
 

--- a/tests/performance/permuted_columns_cache.xml
+++ b/tests/performance/permuted_columns_cache.xml
@@ -1,58 +1,65 @@
 <test>
-    <!-- OpenTelemetry-style traces table: 3 String ORDER BY columns
-         (service, trace_id, span_id) plus a DateTime64 timestamp, with
-         bloom_filter skip indices for point lookups and a minmax index
-         on timestamp for range scans. Without the permuted columns cache,
-         each ORDER BY column with a skip index is permuted twice (primary
-         key + skip index). With the cache, only once. -->
+    <!-- Stresses the permuted columns cache: 5 String ORDER BY columns,
+         each with its own `bloom_filter` skip index, plus a `minmax` index
+         on a DateTime64 column that is also in the primary key.
+
+         Without the cache, every primary-key column is permuted twice
+         (once for the primary index, once for its skip index). With the
+         cache, each column is permuted only once. The more PK/skip-index
+         overlap, the bigger the win. -->
 
     <create_query>
         CREATE TABLE permute_cache_wide
         (
-            service String,
-            trace_id String,
-            span_id String,
-            timestamp DateTime64(6),
-            parent_span_id String,
-            operation String,
-            duration_us UInt64,
-            status_code UInt8,
-            INDEX idx_service (service) TYPE bloom_filter,
-            INDEX idx_trace (trace_id) TYPE bloom_filter,
-            INDEX idx_span (span_id) TYPE bloom_filter,
-            INDEX idx_ts (timestamp) TYPE minmax
+            c1 String,
+            c2 String,
+            c3 String,
+            c4 String,
+            c5 String,
+            ts DateTime64(6),
+            payload String,
+            value UInt64,
+            INDEX idx_c1 (c1) TYPE bloom_filter,
+            INDEX idx_c2 (c2) TYPE bloom_filter,
+            INDEX idx_c3 (c3) TYPE bloom_filter,
+            INDEX idx_c4 (c4) TYPE bloom_filter,
+            INDEX idx_c5 (c5) TYPE bloom_filter,
+            INDEX idx_ts (ts) TYPE minmax
         )
         ENGINE = MergeTree
-        ORDER BY (service, trace_id, span_id, timestamp)
+        ORDER BY (c1, c2, c3, c4, c5, ts)
         SETTINGS min_rows_for_wide_part = 0, min_bytes_for_wide_part = 0
     </create_query>
 
+    <!-- Pre-materialize the source data so the measured query only does
+         the part-writing work (which is what the cache affects). Use cheap
+         string generation (`toString(number)`) to keep the fill fast. -->
     <create_query>
         CREATE TABLE permute_cache_src
         (
-            service String,
-            trace_id String,
-            span_id String,
-            timestamp DateTime64(6),
-            parent_span_id String,
-            operation String,
-            duration_us UInt64,
-            status_code UInt8
+            c1 String,
+            c2 String,
+            c3 String,
+            c4 String,
+            c5 String,
+            ts DateTime64(6),
+            payload String,
+            value UInt64
         )
         ENGINE = Memory
     </create_query>
 
     <fill_query>
         INSERT INTO permute_cache_src SELECT
-            hex(sipHash128(number, 0)),
-            hex(sipHash128(number, 1)),
-            hex(sipHash128(number, 2)),
+            toString(number % 1000),
+            toString((number * 17) % 10000),
+            toString((number * 31) % 100000),
+            toString((number * 53) % 1000000),
+            toString(number),
             toDateTime64('2024-01-01', 6) + number / 1000000,
-            hex(sipHash128(number, 3)),
-            randomPrintableASCII(32),
-            rand64() % 10000000,
-            rand() % 3
-        FROM numbers(5000000)
+            toString(number),
+            number
+        FROM numbers(2000000)
     </fill_query>
 
     <query>INSERT INTO permute_cache_wide SELECT * FROM permute_cache_src</query>

--- a/tests/performance/permuted_columns_cache.xml
+++ b/tests/performance/permuted_columns_cache.xml
@@ -1,0 +1,60 @@
+<test>
+    <!-- Stress the permute path: 20 columns in ORDER BY, each with a minmax skip index.
+         Without the permuted columns cache, each column is permuted 3 times
+         (primary key + skip index + data column). With the cache, only once. -->
+
+    <create_query>
+        CREATE TABLE permute_cache_wide
+        (
+            c0 UInt64, c1 UInt64, c2 UInt64, c3 UInt64, c4 UInt64,
+            c5 UInt64, c6 UInt64, c7 UInt64, c8 UInt64, c9 UInt64,
+            c10 UInt64, c11 UInt64, c12 UInt64, c13 UInt64, c14 UInt64,
+            c15 UInt64, c16 UInt64, c17 UInt64, c18 UInt64, c19 UInt64,
+            INDEX idx0 (c0) TYPE minmax, INDEX idx1 (c1) TYPE minmax,
+            INDEX idx2 (c2) TYPE minmax, INDEX idx3 (c3) TYPE minmax,
+            INDEX idx4 (c4) TYPE minmax, INDEX idx5 (c5) TYPE minmax,
+            INDEX idx6 (c6) TYPE minmax, INDEX idx7 (c7) TYPE minmax,
+            INDEX idx8 (c8) TYPE minmax, INDEX idx9 (c9) TYPE minmax,
+            INDEX idx10 (c10) TYPE minmax, INDEX idx11 (c11) TYPE minmax,
+            INDEX idx12 (c12) TYPE minmax, INDEX idx13 (c13) TYPE minmax,
+            INDEX idx14 (c14) TYPE minmax, INDEX idx15 (c15) TYPE minmax,
+            INDEX idx16 (c16) TYPE minmax, INDEX idx17 (c17) TYPE minmax,
+            INDEX idx18 (c18) TYPE minmax, INDEX idx19 (c19) TYPE minmax
+        )
+        ENGINE = MergeTree
+        ORDER BY (c0, c1, c2, c3, c4, c5, c6, c7, c8, c9,
+                  c10, c11, c12, c13, c14, c15, c16, c17, c18, c19)
+        SETTINGS min_rows_for_wide_part = 0, min_bytes_for_wide_part = 0
+    </create_query>
+
+    <create_query>
+        CREATE TABLE permute_cache_src
+        (
+            c0 UInt64, c1 UInt64, c2 UInt64, c3 UInt64, c4 UInt64,
+            c5 UInt64, c6 UInt64, c7 UInt64, c8 UInt64, c9 UInt64,
+            c10 UInt64, c11 UInt64, c12 UInt64, c13 UInt64, c14 UInt64,
+            c15 UInt64, c16 UInt64, c17 UInt64, c18 UInt64, c19 UInt64
+        )
+        ENGINE = Memory
+    </create_query>
+
+    <fill_query>
+        INSERT INTO permute_cache_src SELECT
+            rand64(number * 20 + 0), rand64(number * 20 + 1),
+            rand64(number * 20 + 2), rand64(number * 20 + 3),
+            rand64(number * 20 + 4), rand64(number * 20 + 5),
+            rand64(number * 20 + 6), rand64(number * 20 + 7),
+            rand64(number * 20 + 8), rand64(number * 20 + 9),
+            rand64(number * 20 + 10), rand64(number * 20 + 11),
+            rand64(number * 20 + 12), rand64(number * 20 + 13),
+            rand64(number * 20 + 14), rand64(number * 20 + 15),
+            rand64(number * 20 + 16), rand64(number * 20 + 17),
+            rand64(number * 20 + 18), rand64(number * 20 + 19)
+        FROM numbers(5000000)
+    </fill_query>
+
+    <query>INSERT INTO permute_cache_wide SELECT * FROM permute_cache_src</query>
+
+    <drop_query>DROP TABLE IF EXISTS permute_cache_wide</drop_query>
+    <drop_query>DROP TABLE IF EXISTS permute_cache_src</drop_query>
+</test>

--- a/tests/performance/permuted_columns_cache.xml
+++ b/tests/performance/permuted_columns_cache.xml
@@ -1,6 +1,7 @@
 <test>
-    <!-- OpenTelemetry-style traces table: 4 String ORDER BY columns with
-         bloom_filter skip indices for point lookups, plus a minmax index
+    <!-- OpenTelemetry-style traces table: 3 String ORDER BY columns
+         (service, trace_id, span_id) plus a DateTime64 timestamp, with
+         bloom_filter skip indices for point lookups and a minmax index
          on timestamp for range scans. Without the permuted columns cache,
          each ORDER BY column with a skip index is permuted twice (primary
          key + skip index). With the cache, only once. -->

--- a/tests/performance/permuted_columns_cache.xml
+++ b/tests/performance/permuted_columns_cache.xml
@@ -1,55 +1,56 @@
 <test>
-    <!-- Stress the permute path: 20 columns in ORDER BY, each with a minmax skip index.
-         Without the permuted columns cache, each column is permuted 3 times
-         (primary key + skip index + data column). With the cache, only once. -->
+    <!-- OpenTelemetry-style traces table: 4 String ORDER BY columns with
+         bloom_filter skip indices for point lookups, plus a minmax index
+         on timestamp for range scans. Without the permuted columns cache,
+         each ORDER BY column with a skip index is permuted twice (primary
+         key + skip index). With the cache, only once. -->
 
     <create_query>
         CREATE TABLE permute_cache_wide
         (
-            c0 UInt64, c1 UInt64, c2 UInt64, c3 UInt64, c4 UInt64,
-            c5 UInt64, c6 UInt64, c7 UInt64, c8 UInt64, c9 UInt64,
-            c10 UInt64, c11 UInt64, c12 UInt64, c13 UInt64, c14 UInt64,
-            c15 UInt64, c16 UInt64, c17 UInt64, c18 UInt64, c19 UInt64,
-            INDEX idx0 (c0) TYPE minmax, INDEX idx1 (c1) TYPE minmax,
-            INDEX idx2 (c2) TYPE minmax, INDEX idx3 (c3) TYPE minmax,
-            INDEX idx4 (c4) TYPE minmax, INDEX idx5 (c5) TYPE minmax,
-            INDEX idx6 (c6) TYPE minmax, INDEX idx7 (c7) TYPE minmax,
-            INDEX idx8 (c8) TYPE minmax, INDEX idx9 (c9) TYPE minmax,
-            INDEX idx10 (c10) TYPE minmax, INDEX idx11 (c11) TYPE minmax,
-            INDEX idx12 (c12) TYPE minmax, INDEX idx13 (c13) TYPE minmax,
-            INDEX idx14 (c14) TYPE minmax, INDEX idx15 (c15) TYPE minmax,
-            INDEX idx16 (c16) TYPE minmax, INDEX idx17 (c17) TYPE minmax,
-            INDEX idx18 (c18) TYPE minmax, INDEX idx19 (c19) TYPE minmax
+            service String,
+            trace_id String,
+            span_id String,
+            timestamp DateTime64(6),
+            parent_span_id String,
+            operation String,
+            duration_us UInt64,
+            status_code UInt8,
+            INDEX idx_service (service) TYPE bloom_filter,
+            INDEX idx_trace (trace_id) TYPE bloom_filter,
+            INDEX idx_span (span_id) TYPE bloom_filter,
+            INDEX idx_ts (timestamp) TYPE minmax
         )
         ENGINE = MergeTree
-        ORDER BY (c0, c1, c2, c3, c4, c5, c6, c7, c8, c9,
-                  c10, c11, c12, c13, c14, c15, c16, c17, c18, c19)
+        ORDER BY (service, trace_id, span_id, timestamp)
         SETTINGS min_rows_for_wide_part = 0, min_bytes_for_wide_part = 0
     </create_query>
 
     <create_query>
         CREATE TABLE permute_cache_src
         (
-            c0 UInt64, c1 UInt64, c2 UInt64, c3 UInt64, c4 UInt64,
-            c5 UInt64, c6 UInt64, c7 UInt64, c8 UInt64, c9 UInt64,
-            c10 UInt64, c11 UInt64, c12 UInt64, c13 UInt64, c14 UInt64,
-            c15 UInt64, c16 UInt64, c17 UInt64, c18 UInt64, c19 UInt64
+            service String,
+            trace_id String,
+            span_id String,
+            timestamp DateTime64(6),
+            parent_span_id String,
+            operation String,
+            duration_us UInt64,
+            status_code UInt8
         )
         ENGINE = Memory
     </create_query>
 
     <fill_query>
         INSERT INTO permute_cache_src SELECT
-            rand64(number * 20 + 0), rand64(number * 20 + 1),
-            rand64(number * 20 + 2), rand64(number * 20 + 3),
-            rand64(number * 20 + 4), rand64(number * 20 + 5),
-            rand64(number * 20 + 6), rand64(number * 20 + 7),
-            rand64(number * 20 + 8), rand64(number * 20 + 9),
-            rand64(number * 20 + 10), rand64(number * 20 + 11),
-            rand64(number * 20 + 12), rand64(number * 20 + 13),
-            rand64(number * 20 + 14), rand64(number * 20 + 15),
-            rand64(number * 20 + 16), rand64(number * 20 + 17),
-            rand64(number * 20 + 18), rand64(number * 20 + 19)
+            hex(sipHash128(number, 0)),
+            hex(sipHash128(number, 1)),
+            hex(sipHash128(number, 2)),
+            toDateTime64('2024-01-01', 6) + number / 1000000,
+            hex(sipHash128(number, 3)),
+            randomPrintableASCII(32),
+            rand64() % 10000000,
+            rand() % 3
         FROM numbers(5000000)
     </fill_query>
 


### PR DESCRIPTION
When writing a MergeTree part, columns are permuted (reordered by sort key) independently for multiple consumers: primary key index, skip indices, and data columns. If a column appears in more than one of these, the same O(n) permute-and-copy operation is repeated.

This PR introduces a `Block`-based permuted columns cache that is threaded through `getIndexBlockAndPermute`, `permuteBlockIfNeeded`, and the writer's `write` method chain. Each column is permuted at most once; subsequent lookups by name return the already-permuted column from the cache.

The benefit is proportional to the number of overlapping columns between primary key, skip indices, and data columns — which is common in practice since primary key columns are always also data columns.

**Local benchmark** (OpenTelemetry-style traces table — 3 String ORDER BY columns with `bloom_filter` skip indices + `minmax` on timestamp, INSERT 5M rows):

| | Baseline | With cache | Improvement |
|---|---|---|---|
| Mean INSERT time | ~10.0s | ~8.3s | ~17% faster |

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Reduced INSERT latency for MergeTree tables with skip indices on ORDER BY columns by avoiding redundant column permutations during part writing (~17% on traces-shaped workloads)

#### Todo for @azat
- [ ] check private

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.929`
<!-- ch-version-info:end -->