### PR TITLE
Skip removed `users` entries in the main YAML config parser

### DIFF
--- a/src/Access/UsersConfigParser.cpp
+++ b/src/Access/UsersConfigParser.cpp
@@ -48,6 +48,11 @@ namespace ErrorCodes
 
 namespace
 {
+    bool isRemovedConfigEntry(const Poco::Util::AbstractConfiguration & config, const String & entry_path)
+    {
+        return config.has(entry_path + "[@remove]") || config.has(entry_path + ".@remove");
+    }
+
     template <typename T>
     void parseGrant(T & entity, const String & string_query, const std::unordered_set<UUID> & role_ids_from_users_config, const AccessControl & access_control, LoggerPtr log)
     {
@@ -681,12 +686,20 @@ std::vector<AccessEntityPtr> UsersConfigParser::parseUsers(
     Poco::Util::AbstractConfiguration::Keys user_names;
     config.keys("users", user_names);
 
+    Poco::Util::AbstractConfiguration::Keys filtered_user_names;
+    filtered_user_names.reserve(user_names.size());
+    for (const auto & user_name : user_names)
+    {
+        if (!isRemovedConfigEntry(config, "users." + user_name))
+            filtered_user_names.push_back(user_name);
+    }
+
     bool no_password_allowed = access_control.isNoPasswordAllowed();
     bool plaintext_password_allowed = access_control.isPlaintextPasswordAllowed();
 
     std::vector<AccessEntityPtr> users;
-    users.reserve(user_names.size());
-    for (const auto & user_name : user_names)
+    users.reserve(filtered_user_names.size());
+    for (const auto & user_name : filtered_user_names)
     {
         try
         {

--- a/src/Access/tests/gtest_users_config_parser.cpp
+++ b/src/Access/tests/gtest_users_config_parser.cpp
@@ -1,0 +1,56 @@
+#include <gtest/gtest.h>
+
+#include <Access/AccessControl.h>
+#include <Access/User.h>
+#include <Common/Config/ConfigProcessor.h>
+#include <IO/WriteBufferFromFile.h>
+#include <IO/WriteHelpers.h>
+#include <Poco/Util/XMLConfiguration.h>
+#include <base/scope_guard.h>
+
+#include <algorithm>
+#include <filesystem>
+
+using namespace DB;
+
+TEST(UsersConfigParser, SkipsRemovedUsersFromYamlMainConfig)
+{
+    namespace fs = std::filesystem;
+
+    auto path = fs::temp_directory_path() / "test_users_config_parser_remove_default";
+    auto config_path = path / "config.yaml";
+
+    fs::create_directories(path);
+    SCOPE_EXIT({ fs::remove_all(path); });
+
+    {
+        WriteBufferFromFile out(config_path.string());
+        std::string data = R"YAML(
+users:
+    default:
+        "@remove": remove
+    anotheruser:
+        password: ''
+)YAML";
+        writeString(data, out);
+        out.finalize();
+    }
+
+    ConfigProcessor processor(config_path.string(), /* throw_on_bad_incl = */ false, /* log_to_console = */ false);
+    bool has_zk_includes = false;
+    XMLDocumentPtr config_xml = processor.processConfig(&has_zk_includes);
+    ConfigurationPtr configuration(new Poco::Util::XMLConfiguration(config_xml));
+
+    Poco::Util::AbstractConfiguration::Keys user_names;
+    configuration->keys("users", user_names);
+    std::sort(user_names.begin(), user_names.end());
+    ASSERT_EQ(user_names.size(), 2);
+    EXPECT_EQ(user_names[0], "anotheruser");
+    EXPECT_EQ(user_names[1], "default");
+
+    AccessControl access_control;
+    ASSERT_NO_THROW(access_control.setUsersConfig(*configuration));
+    EXPECT_FALSE(access_control.find<User>("default").has_value());
+    EXPECT_TRUE(access_control.find<User>("anotheruser").has_value());
+    access_control.shutdown();
+}


### PR DESCRIPTION
Fixes #84208

Skip removed `users` entries before authentication validation when access entities are parsed directly from the main YAML config.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Skip authentication validation for users removed with `@remove` when `users` are configured directly in the main YAML config.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
