### PR TITLE
Fix out-of-bounds access in lazy materialization with projection PREWHERE

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeLazyMaterialization.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeLazyMaterialization.cpp
@@ -70,13 +70,14 @@ std::pair<std::vector<size_t>, std::vector<size_t>> mapInputsToHeaderPositions(c
 
 /// Returns a boolean mask which indicate if the header column is required.
 /// The required_output_positions is the same mask for the output header.
-/// There may be less DAG outputs than required_output_positions.size().
+/// The number of DAG outputs may differ from required_output_positions.size().
 std::vector<bool> getRequiredHeaderPositions(const ActionsDAG & dag, const Block & header, std::vector<bool> required_output_positions)
 {
     std::unordered_set<const ActionsDAG::Node *> required_nodes;
     std::stack<const ActionsDAG::Node *> stack;
 
-    for (size_t i = 0; i < dag.getOutputs().size(); ++i)
+    size_t num_matched_outputs = std::min(dag.getOutputs().size(), required_output_positions.size());
+    for (size_t i = 0; i < num_matched_outputs; ++i)
     {
         if (required_output_positions[i])
             stack.push(dag.getOutputs()[i]);

--- a/tests/queries/0_stateless/04063_lazy_materialization_projection_prewhere_crash.reference
+++ b/tests/queries/0_stateless/04063_lazy_materialization_projection_prewhere_crash.reference
@@ -1,0 +1,1 @@
+https://example.com/page1

--- a/tests/queries/0_stateless/04063_lazy_materialization_projection_prewhere_crash.sql
+++ b/tests/queries/0_stateless/04063_lazy_materialization_projection_prewhere_crash.sql
@@ -1,0 +1,33 @@
+-- Regression test: out-of-bounds access in getRequiredHeaderPositions during
+-- optimizeLazyMaterialization2 when a projection with PREWHERE is used.
+-- The projection adds a _projection_filter column to the expression DAG,
+-- making dag.getOutputs() larger than the required_output_positions vector
+-- (sized from the sorting step's output header), causing an abort in debug builds.
+
+DROP TABLE IF EXISTS test_lazy_mat_proj;
+CREATE TABLE test_lazy_mat_proj
+(
+    id UInt64,
+    event_date Date,
+    url String,
+    region String,
+    PROJECTION region_url_proj
+    (
+        SELECT _part_offset ORDER BY region, url
+    )
+)
+ENGINE = MergeTree
+ORDER BY (event_date, id)
+SETTINGS index_granularity = 1, min_bytes_for_wide_part = 0;
+
+INSERT INTO test_lazy_mat_proj VALUES (1, '2023-01-01', 'https://example.com/page1', 'europe');
+INSERT INTO test_lazy_mat_proj VALUES (2, '2023-01-01', 'https://example.com/page2', 'us_west');
+
+OPTIMIZE TABLE test_lazy_mat_proj FINAL;
+
+-- The LIMIT triggers optimizeLazyMaterialization2, the projection provides
+-- _projection_filter in PREWHERE, and ORDER BY ALL triggers the sorting step.
+SELECT url FROM test_lazy_mat_proj WHERE region = 'europe' ORDER BY ALL LIMIT 10
+SETTINGS query_plan_remove_unused_columns = 0, enable_multiple_prewhere_read_steps = 0;
+
+DROP TABLE test_lazy_mat_proj;

--- a/tests/queries/0_stateless/04063_lazy_materialization_projection_prewhere_crash.sql
+++ b/tests/queries/0_stateless/04063_lazy_materialization_projection_prewhere_crash.sql
@@ -28,6 +28,7 @@ OPTIMIZE TABLE test_lazy_mat_proj FINAL;
 -- The LIMIT triggers optimizeLazyMaterialization2, the projection provides
 -- _projection_filter in PREWHERE, and ORDER BY ALL triggers the sorting step.
 SELECT url FROM test_lazy_mat_proj WHERE region = 'europe' ORDER BY ALL LIMIT 10
-SETTINGS query_plan_remove_unused_columns = 0, enable_multiple_prewhere_read_steps = 0;
+SETTINGS query_plan_remove_unused_columns = 0, enable_multiple_prewhere_read_steps = 0,
+    force_optimize_projection = 1, force_optimize_projection_name = 'region_url_proj';
 
 DROP TABLE test_lazy_mat_proj;


### PR DESCRIPTION
Fix out-of-bounds access in `getRequiredHeaderPositions` during `optimizeLazyMaterialization2` when a projection with PREWHERE is used.

When a projection adds `_projection_filter` to the expression DAG, `dag.getOutputs().size()` can exceed `required_output_positions.size()` (which is sized from the sorting step's output header). The loop at line 79 indexes into the `vector<bool>` without bounds checking, causing an abort in debug/sanitizer builds.

The fix caps the loop at `min(dag.getOutputs().size(), required_output_positions.size())`, so extra DAG outputs beyond the sorting header are safely ignored.

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix exception in `optimizeLazyMaterialization` when a projection with PREWHERE is used with `ORDER BY ... LIMIT`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.402`
- Backported to: `26.3.3.19`
<!-- ch-version-info:end -->