### PR TITLE
Fix yellow highlight covering the green bar on table rows in Play UI

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -257,6 +257,11 @@
             background-repeat: no-repeat;
         }
 
+        .table button:hover
+        {
+            background-color: transparent;
+        }
+
         .table-addendum
         {
             position: absolute;


### PR DESCRIPTION
The `.database button:hover` style applied an opaque yellow `background-color` to table name buttons, which covered the green progress bar (showing relative table size) on the parent `.table` div. This adds a `.table button:hover` override with `background-color: transparent` so the bar remains visible on hover.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix yellow highlight covering the green progress bar on table rows in Play UI.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)