### PR TITLE
Fix flaky test 03634_autopr_input_bytes_estimation

### DIFF
--- a/tests/queries/0_stateless/03634_autopr_input_bytes_estimation.sql
+++ b/tests/queries/0_stateless/03634_autopr_input_bytes_estimation.sql
@@ -8,8 +8,18 @@ SET enable_parallel_replicas=1, automatic_parallel_replicas_mode=2, parallel_rep
 -- Reading of aggregation states from disk will affect `ReadCompressedBytes`
 SET max_bytes_before_external_group_by=0, max_bytes_ratio_before_external_group_by=0;
 
+-- External sort spills data to disk and reads it back, which inflates `ReadCompressedBytes`
+-- and breaks the estimation accuracy check. Keep sorting fully in-memory.
+SET max_bytes_before_external_sort=0, max_bytes_ratio_before_external_sort=0;
+
 -- Override randomized max_threads to avoid timeout on slow builds (ASan)
 SET max_threads=0;
+
+-- query_23 does SELECT * with ORDER BY on the full hits table, which needs significant
+-- memory for in-memory sorting. CI environments have a ~4.66 GiB limit that is too tight
+-- when external sort is disabled. Remove the memory cap since this test measures byte
+-- estimation accuracy, not memory consumption.
+SET max_memory_usage=0;
 
 -- settings override: while the total amount of data to be read is small (in order of 100KB), with different settings we may wastefully overread much more data
 SELECT COUNT(*) FROM test.hits WHERE AdvEngineID <> 0 FORMAT Null SETTINGS log_comment='query_1',


### PR DESCRIPTION
The test sporadically fails with `MEMORY_LIMIT_EXCEEDED` (code 241) on `query_23`
(`SELECT * FROM test.hits WHERE URL LIKE '%google%' ORDER BY EventTime LIMIT 10`).

All 6 failures in the last 30 days show the same pattern: when CI randomizes
`max_bytes_before_external_sort=0` (disabling external sort), the full ORDER BY
sort happens in-memory and needs >4.66 GiB — exceeding the CI environment's memory
cap. The test already pins `max_bytes_before_external_group_by=0` to keep GROUP BY
in-memory (external spills inflate `ReadCompressedBytes` and break the estimation
check). This applies the same treatment to external sort and removes the memory cap
since the test measures byte estimation accuracy, not memory consumption.

Affected checks: arm_binary, amd_msan, amd_tsan — 10 distinct PRs in 30 days, never
on master.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.425`
<!-- ch-version-info:end -->