### PR TITLE
Add test: Zero-dimension shape (0,) path in readPrefix validation is u

### DIFF
--- a/tests/queries/0_stateless/04068_npy_zero_dimension_shape.sh
+++ b/tests/queries/0_stateless/04068_npy_zero_dimension_shape.sh
@@ -1,0 +1,4 @@
+--- shape (0,) count ---
+0
+--- shape (0,) describe ---
+array	Int32


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #100625](https://github.com/ClickHouse/ClickHouse/pull/100625).

**1. Zero-dimension shape (0,) path in readPrefix validation is untested**
  `src/Processors/Formats/Impl/NpyRowInputFormat.cpp:304`

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---
_Found during review of [PR #100625](https://github.com/ClickHouse/ClickHouse/pull/100625)._