### PR TITLE
Add random projection functions for changing dimensionality of vector embeddings

### DIFF
--- a/src/Columns/benchmarks/benchmark_column_insert_many_from.cpp
+++ b/src/Columns/benchmarks/benchmark_column_insert_many_from.cpp
@@ -37,7 +37,7 @@ static ColumnPtr mockColumn(const DataTypePtr & type, size_t rows)
             column->insert(i);
         else if (isFloat(type_not_nullable))
         {
-            double d = i * 1.0;
+            double d = static_cast<double>(i);
             column->insert(d);
         }
         else if (isString(type_not_nullable))

--- a/src/Functions/array/CMakeLists.txt
+++ b/src/Functions/array/CMakeLists.txt
@@ -27,3 +27,7 @@ set_source_files_properties(array.cpp PROPERTIES COMPILE_FLAGS "-U_LIBCPP_HARDEN
 if (OMIT_HEAVY_DEBUG_SYMBOLS)
     target_compile_options(clickhouse_functions_array PRIVATE "-g1")
 endif()
+
+if (ENABLE_BENCHMARKS)
+    add_subdirectory(benchmarks)
+endif()

--- a/src/Functions/array/arrayRandomProjection.cpp
+++ b/src/Functions/array/arrayRandomProjection.cpp
@@ -1,0 +1,511 @@
+#include <Functions/array/arrayRandomProjection.h>
+
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnConst.h>
+#include <Columns/ColumnVector.h>
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/FunctionHelpers.h>
+#include <Functions/IFunction.h>
+#include <Common/FunctionDocumentation.h>
+
+#include <mutex>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+extern const int ILLEGAL_COLUMN;
+extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+extern const int BAD_ARGUMENTS;
+extern const int SIZES_OF_ARRAYS_DONT_MATCH;
+}
+
+struct NormalMethodTag
+{
+    static constexpr auto name = "randomProjectionNormal";
+};
+struct OrthogonalMethodTag
+{
+    static constexpr auto name = "randomProjectionOrthogonal";
+};
+struct SparseMethodTag
+{
+    static constexpr auto name = "randomProjectionSparse";
+};
+struct HadamardMethodTag
+{
+    static constexpr auto name = "randomProjectionHadamard";
+};
+
+/// Traits: maps MethodTag to the corresponding ProjectionState types.
+template <typename MethodTag>
+struct ProjectionStateTypes;
+
+template <>
+struct ProjectionStateTypes<NormalMethodTag>
+{
+    template <typename T>
+    using State = NormalProjectionState<T>;
+};
+template <>
+struct ProjectionStateTypes<OrthogonalMethodTag>
+{
+    template <typename T>
+    using State = OrthogonalProjectionState<T>;
+};
+template <>
+struct ProjectionStateTypes<SparseMethodTag>
+{
+    template <typename T>
+    using State = SparseProjectionState<T>;
+};
+template <>
+struct ProjectionStateTypes<HadamardMethodTag>
+{
+    template <typename T>
+    using State = HadamardProjectionState<T>;
+};
+
+/// Whether the method uses batched dense GEMM (Normal, Orthogonal) vs per-row apply (Sparse, Hadamard).
+template <typename MethodTag>
+struct UsesDenseGEMM : std::true_type
+{
+};
+template <>
+struct UsesDenseGEMM<SparseMethodTag> : std::false_type
+{
+};
+template <>
+struct UsesDenseGEMM<HadamardMethodTag> : std::false_type
+{
+};
+
+/// Per-row projection application for non-GEMM methods.
+template <typename T, typename MethodTag>
+void applyPerRow(const T * input, T * output, const typename ProjectionStateTypes<MethodTag>::template State<T> & state);
+
+template <>
+void applyPerRow<Float32, SparseMethodTag>(const Float32 * input, Float32 * output, const SparseProjectionState<Float32> & state)
+{
+    applySparseProjection<Float32>(input, output, state);
+}
+template <>
+void applyPerRow<Float64, SparseMethodTag>(const Float64 * input, Float64 * output, const SparseProjectionState<Float64> & state)
+{
+    applySparseProjection<Float64>(input, output, state);
+}
+template <>
+void applyPerRow<Float32, HadamardMethodTag>(const Float32 * input, Float32 * output, const HadamardProjectionState<Float32> & state)
+{
+    applyHadamardProjection<Float32>(input, output, state);
+}
+template <>
+void applyPerRow<Float64, HadamardMethodTag>(const Float64 * input, Float64 * output, const HadamardProjectionState<Float64> & state)
+{
+    applyHadamardProjection<Float64>(input, output, state);
+}
+
+template <typename MethodTag>
+class RandomProjectionExecutable;
+
+template <typename MethodTag>
+class RandomProjectionFunctionBase : public IFunctionBase
+{
+public:
+    RandomProjectionFunctionBase(size_t target_dim_, UInt64 seed_, DataTypes argument_types_, DataTypePtr result_type_)
+        : target_dim(target_dim_)
+        , seed(seed_)
+        , argument_types(std::move(argument_types_))
+        , result_type(std::move(result_type_))
+    {
+    }
+
+    String getName() const override { return MethodTag::name; }
+    const DataTypes & getArgumentTypes() const override { return argument_types; }
+    const DataTypePtr & getResultType() const override { return result_type; }
+    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo &) const override { return true; }
+    bool isStateful() const override { return true; }
+
+    ExecutableFunctionPtr prepare(const ColumnsWithTypeAndName &) const override
+    {
+        return std::make_unique<RandomProjectionExecutable<MethodTag>>(*this);
+    }
+
+private:
+    friend class RandomProjectionExecutable<MethodTag>;
+
+    using StateF32 = typename ProjectionStateTypes<MethodTag>::template State<Float32>;
+    using StateF64 = typename ProjectionStateTypes<MethodTag>::template State<Float64>;
+
+    size_t target_dim;
+    UInt64 seed;
+    DataTypes argument_types;
+    DataTypePtr result_type;
+
+    mutable std::once_flag init_flag_f32;
+    mutable std::once_flag init_flag_f64;
+    mutable StateF32 state_f32;
+    mutable StateF64 state_f64;
+
+    template <typename T>
+    void ensureInitialized(size_t input_dim) const
+    {
+        if constexpr (std::is_same_v<T, Float32>)
+        {
+            std::call_once(init_flag_f32, [&]() { state_f32.generate(input_dim, target_dim, seed); });
+            if (state_f32.input_dim != input_dim)
+                throw Exception(
+                    ErrorCodes::SIZES_OF_ARRAYS_DONT_MATCH,
+                    "All input arrays for {} must have the same dimension (expected {}, got {})",
+                    MethodTag::name,
+                    state_f32.input_dim,
+                    input_dim);
+        }
+        else
+        {
+            std::call_once(init_flag_f64, [&]() { state_f64.generate(input_dim, target_dim, seed); });
+            if (state_f64.input_dim != input_dim)
+                throw Exception(
+                    ErrorCodes::SIZES_OF_ARRAYS_DONT_MATCH,
+                    "All input arrays for {} must have the same dimension (expected {}, got {})",
+                    MethodTag::name,
+                    state_f64.input_dim,
+                    input_dim);
+        }
+    }
+
+    template <typename T>
+    const auto & getState() const
+    {
+        if constexpr (std::is_same_v<T, Float32>)
+            return state_f32;
+        else
+            return state_f64;
+    }
+};
+
+template <typename MethodTag>
+class RandomProjectionExecutable : public IExecutableFunction
+{
+public:
+    explicit RandomProjectionExecutable(const RandomProjectionFunctionBase<MethodTag> & base_)
+        : base(base_)
+    {
+    }
+
+    String getName() const override { return MethodTag::name; }
+    bool useDefaultImplementationForConstants() const override { return false; }
+
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & result_type, size_t input_rows_count) const override
+    {
+        const auto * array_type = checkAndGetDataType<DataTypeArray>(result_type.get());
+        if (!array_type)
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Result type must be Array");
+
+        const auto & nested = array_type->getNestedType();
+        WhichDataType nested_which(nested);
+
+        if (nested_which.isFloat32())
+            return executeTyped<Float32>(arguments, input_rows_count);
+        else if (nested_which.isFloat64())
+            return executeTyped<Float64>(arguments, input_rows_count);
+        else
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "Function {} only supports Float32 and Float64 element types", getName());
+    }
+
+private:
+    const RandomProjectionFunctionBase<MethodTag> & base;
+
+    template <typename T>
+    ColumnPtr executeTyped(const ColumnsWithTypeAndName & arguments, size_t input_rows_count) const
+    {
+        ColumnPtr col_input = arguments[0].column->convertToFullColumnIfConst();
+        const auto & col_array = assert_cast<const ColumnArray &>(*col_input);
+        const auto & data_in = typeid_cast<const ColumnVector<T> &>(col_array.getData()).getData();
+        const auto & offsets = col_array.getOffsets();
+
+        if (input_rows_count == 0)
+            return ColumnArray::create(ColumnVector<T>::create(), ColumnArray::ColumnOffsets::create());
+
+        size_t input_dim = offsets[0];
+        base.template ensureInitialized<T>(input_dim);
+
+        const auto & state = base.template getState<T>();
+        size_t target_dim = state.target_dim;
+
+        auto col_data_out = ColumnVector<T>::create(input_rows_count * target_dim);
+        auto & out = col_data_out->getData();
+
+        if constexpr (UsesDenseGEMM<MethodTag>::value)
+        {
+            /// Dense methods (Normal, Orthogonal): validate all rows first, then batch GEMM.
+            ColumnArray::Offset prev = 0;
+            for (size_t i = 0; i < input_rows_count; ++i)
+            {
+                size_t row_dim = offsets[i] - prev;
+                if (row_dim != input_dim)
+                    throw Exception(
+                        ErrorCodes::SIZES_OF_ARRAYS_DONT_MATCH,
+                        "All input arrays for {} must have the same dimension (expected {}, got {} at row {})",
+                        MethodTag::name,
+                        input_dim,
+                        row_dim,
+                        i);
+                prev = offsets[i];
+            }
+
+            applyDenseProjectionBatch<T>(data_in.data(), out.data(), input_rows_count, input_dim, target_dim, state.matrix.data());
+        }
+        else
+        {
+            /// Per-row methods (Sparse, Hadamard): validate and apply one row at a time.
+            ColumnArray::Offset prev = 0;
+            for (size_t i = 0; i < input_rows_count; ++i)
+            {
+                size_t row_dim = offsets[i] - prev;
+                if (row_dim != input_dim)
+                    throw Exception(
+                        ErrorCodes::SIZES_OF_ARRAYS_DONT_MATCH,
+                        "All input arrays for {} must have the same dimension (expected {}, got {} at row {})",
+                        MethodTag::name,
+                        input_dim,
+                        row_dim,
+                        i);
+
+                applyPerRow<T, MethodTag>(data_in.data() + prev, out.data() + i * target_dim, state);
+                prev = offsets[i];
+            }
+        }
+
+        auto col_offsets_out = ColumnArray::ColumnOffsets::create(input_rows_count);
+        auto & out_offsets = col_offsets_out->getData();
+        for (size_t i = 0; i < input_rows_count; ++i)
+            out_offsets[i] = (i + 1) * target_dim;
+
+        return ColumnArray::create(std::move(col_data_out), std::move(col_offsets_out));
+    }
+};
+
+template <typename MethodTag>
+class RandomProjectionOverloadResolver : public IFunctionOverloadResolver
+{
+public:
+    static constexpr auto name = MethodTag::name;
+
+    static FunctionOverloadResolverPtr create(ContextPtr) { return std::make_unique<RandomProjectionOverloadResolver<MethodTag>>(); }
+
+    String getName() const override { return name; }
+    size_t getNumberOfArguments() const override { return 3; }
+    ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {1, 2}; }
+    bool isVariadic() const override { return false; }
+
+    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
+    {
+        const auto * array_type = checkAndGetDataType<DataTypeArray>(arguments[0].type.get());
+        if (!array_type)
+            throw Exception(
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "First argument of function {} must be an Array, got {}",
+                getName(),
+                arguments[0].type->getName());
+
+        const auto & nested = array_type->getNestedType();
+        WhichDataType nested_which(nested);
+        if (!nested_which.isFloat32() && !nested_which.isFloat64())
+            throw Exception(
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "First argument of function {} must be Array(Float32) or Array(Float64), got Array({})",
+                getName(),
+                nested->getName());
+
+        if (!WhichDataType(arguments[1].type).isUInt())
+            throw Exception(
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "Second argument (target_dim) of function {} must be an unsigned integer, got {}",
+                getName(),
+                arguments[1].type->getName());
+
+        if (!WhichDataType(arguments[2].type).isUInt())
+            throw Exception(
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "Third argument (seed) of function {} must be an unsigned integer, got {}",
+                getName(),
+                arguments[2].type->getName());
+
+        return std::make_shared<DataTypeArray>(nested);
+    }
+
+    FunctionBasePtr buildImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & return_type) const override
+    {
+        if (!arguments[1].column || !isColumnConst(*arguments[1].column))
+            throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Second argument (target_dim) of function {} must be constant", getName());
+
+        size_t target_dim = arguments[1].column->getUInt(0);
+        if (target_dim == 0)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Second argument (target_dim) of function {} must be positive", getName());
+
+        if (!arguments[2].column || !isColumnConst(*arguments[2].column))
+            throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Third argument (seed) of function {} must be constant", getName());
+
+        UInt64 seed = arguments[2].column->getUInt(0);
+
+        DataTypes arg_types;
+        arg_types.reserve(arguments.size());
+        for (const auto & arg : arguments)
+            arg_types.push_back(arg.type);
+
+        return std::make_shared<RandomProjectionFunctionBase<MethodTag>>(target_dim, seed, std::move(arg_types), return_type);
+    }
+};
+
+REGISTER_FUNCTION(RandomProjectionNormal)
+{
+    FunctionDocumentation::Description description = R"(
+Applies a random projection to the input vector using a dense Gaussian random matrix.
+
+The projection matrix `P` of size (`target_dim` x `input_dim`) is filled with entries
+drawn from N(0, 1/`target_dim`). By the Johnson-Lindenstrauss lemma, pairwise distances
+are approximately preserved in the projected space.
+
+The matrix is generated once per query from the given seed, ensuring deterministic results
+across distributed nodes. Both downscaling (e.g. 1024 -> 256) and upscaling (e.g. 128 -> 512)
+are supported. The computation is SIMD-accelerated (AVX2/AVX-512) when available.
+)";
+
+    FunctionDocumentation::Syntax syntax = "randomProjectionNormal(vector, target_dim, seed)";
+
+    FunctionDocumentation::Arguments arguments = {
+        {"vector", "Input vector as an array of floating-point values.", {"Array(Float32)", "Array(Float64)"}},
+        {"target_dim", "Target dimensionality (must be a positive constant).", {"UInt*"}},
+        {"seed", "Random seed for deterministic projection (must be a constant).", {"UInt*"}},
+    };
+
+    FunctionDocumentation::ReturnedValue returned_value
+        = {"An array of the same element type with `target_dim` elements.", {"Array(Float32)", "Array(Float64)"}};
+
+    FunctionDocumentation::Examples examples = {
+        {"Downscale", "SELECT randomProjectionNormal([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 42);", ""},
+        {"Upscale", "SELECT randomProjectionNormal([1.0, 2.0]::Array(Float32), 4, 42);", ""},
+    };
+
+    FunctionDocumentation::IntroducedIn introduced_in = {25, 8};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Array;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<RandomProjectionOverloadResolver<NormalMethodTag>>(documentation);
+}
+
+REGISTER_FUNCTION(RandomProjectionOrthogonal)
+{
+    FunctionDocumentation::Description description = R"(
+Applies a random projection to the input vector using an orthogonal random matrix.
+
+A square Gaussian matrix of size `max(target_dim, input_dim)` is generated, then
+QR-decomposed via Householder reflections. The leading (`target_dim` x `input_dim`) block of the
+orthogonal factor `Q` is used as the projection matrix. Orthogonal projections preserve
+distances better than purely Gaussian projections for finite sample sizes.
+
+Both downscaling and upscaling are supported. The matrix is generated once per
+query from the given seed. The computation is SIMD-accelerated (AVX2/AVX-512) when available.
+)";
+
+    FunctionDocumentation::Syntax syntax = "randomProjectionOrthogonal(vector, target_dim, seed)";
+
+    FunctionDocumentation::Arguments arguments = {
+        {"vector", "Input vector as an array of floating-point values.", {"Array(Float32)", "Array(Float64)"}},
+        {"target_dim", "Target dimensionality (must be a positive constant).", {"UInt*"}},
+        {"seed", "Random seed for deterministic projection (must be a constant).", {"UInt*"}},
+    };
+
+    FunctionDocumentation::ReturnedValue returned_value
+        = {"An array of the same element type with `target_dim` elements.", {"Array(Float32)", "Array(Float64)"}};
+
+    FunctionDocumentation::Examples examples = {
+        {"Downscale", "SELECT randomProjectionOrthogonal([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 42);", ""},
+    };
+
+    FunctionDocumentation::IntroducedIn introduced_in = {25, 8};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Array;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<RandomProjectionOverloadResolver<OrthogonalMethodTag>>(documentation);
+}
+
+REGISTER_FUNCTION(RandomProjectionSparse)
+{
+    FunctionDocumentation::Description description = R"(
+Applies a random projection using a sparse Achlioptas matrix.
+
+Each entry of the projection matrix is independently `+1` (probability 1/6),
+`0` (probability 2/3), or `-1` (probability 1/6), scaled by `sqrt(3/target_dim)`.
+The sparsity makes this method approximately 3x faster than a dense Gaussian
+projection, as ~2/3 of entries require no computation.
+
+Both downscaling and upscaling are supported. The matrix is generated once per
+query from the given seed.
+)";
+
+    FunctionDocumentation::Syntax syntax = "randomProjectionSparse(vector, target_dim, seed)";
+
+    FunctionDocumentation::Arguments arguments = {
+        {"vector", "Input vector as an array of floating-point values.", {"Array(Float32)", "Array(Float64)"}},
+        {"target_dim", "Target dimensionality (must be a positive constant).", {"UInt*"}},
+        {"seed", "Random seed for deterministic projection (must be a constant).", {"UInt*"}},
+    };
+
+    FunctionDocumentation::ReturnedValue returned_value
+        = {"An array of the same element type with `target_dim` elements.", {"Array(Float32)", "Array(Float64)"}};
+
+    FunctionDocumentation::Examples examples = {
+        {"Downscale", "SELECT randomProjectionSparse([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 42);", ""},
+    };
+
+    FunctionDocumentation::IntroducedIn introduced_in = {25, 8};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Array;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<RandomProjectionOverloadResolver<SparseMethodTag>>(documentation);
+}
+
+REGISTER_FUNCTION(RandomProjectionHadamard)
+{
+    FunctionDocumentation::Description description = R"(
+Applies a random projection using the Subsampled Randomized Hadamard Transform (SRHT).
+
+The transform computes `y = S * H * D * x`, where `D` is a diagonal matrix of random
+signs, `H` is the Walsh-Hadamard transform (computed in O(n log n) via the Fast
+Walsh-Hadamard Transform), and `S` is a row-sampling operator. The input is
+zero-padded to the next power of 2 internally.
+
+For upscaling (`target_dim` > `input_dim`), multiple independent SRHT blocks are
+concatenated. Both downscaling and upscaling are supported. The matrix is
+generated once per query from the given seed.
+)";
+
+    FunctionDocumentation::Syntax syntax = "randomProjectionHadamard(vector, target_dim, seed)";
+
+    FunctionDocumentation::Arguments arguments = {
+        {"vector", "Input vector as an array of floating-point values.", {"Array(Float32)", "Array(Float64)"}},
+        {"target_dim", "Target dimensionality (must be a positive constant).", {"UInt*"}},
+        {"seed", "Random seed for deterministic projection (must be a constant).", {"UInt*"}},
+    };
+
+    FunctionDocumentation::ReturnedValue returned_value
+        = {"An array of the same element type with `target_dim` elements.", {"Array(Float32)", "Array(Float64)"}};
+
+    FunctionDocumentation::Examples examples = {
+        {"Downscale", "SELECT randomProjectionHadamard([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 42);", ""},
+    };
+
+    FunctionDocumentation::IntroducedIn introduced_in = {25, 8};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Array;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<RandomProjectionOverloadResolver<HadamardMethodTag>>(documentation);
+}
+
+}

--- a/src/Functions/array/arrayRandomProjection.cpp
+++ b/src/Functions/array/arrayRandomProjection.cpp
@@ -22,6 +22,7 @@ extern const int ILLEGAL_COLUMN;
 extern const int ILLEGAL_TYPE_OF_ARGUMENT;
 extern const int BAD_ARGUMENTS;
 extern const int SIZES_OF_ARRAYS_DONT_MATCH;
+extern const int TOO_LARGE_ARRAY_SIZE;
 }
 
 struct NormalMethodTag
@@ -241,7 +242,16 @@ private:
         const auto & state = base.template getState<T>();
         size_t target_dim = state.target_dim;
 
-        auto col_data_out = ColumnVector<T>::create(input_rows_count * target_dim);
+        size_t total_output_elements = input_rows_count * target_dim;
+        if (target_dim != 0 && total_output_elements / target_dim != input_rows_count)
+            throw Exception(
+                ErrorCodes::TOO_LARGE_ARRAY_SIZE,
+                "Output size overflow in {}: {} rows x {} target_dim exceeds size_t",
+                MethodTag::name,
+                input_rows_count,
+                target_dim);
+
+        auto col_data_out = ColumnVector<T>::create(total_output_elements);
         auto & out = col_data_out->getData();
 
         if constexpr (UsesDenseGEMM<MethodTag>::value)

--- a/src/Functions/array/arrayRandomProjection.cpp
+++ b/src/Functions/array/arrayRandomProjection.cpp
@@ -85,28 +85,32 @@ struct UsesDenseGEMM<HadamardMethodTag> : std::false_type
 };
 
 /// Per-row projection application for non-GEMM methods.
+/// `scratch` is a pre-allocated buffer (used by Hadamard, ignored by Sparse).
 template <typename T, typename MethodTag>
-void applyPerRow(const T * input, T * output, const typename ProjectionStateTypes<MethodTag>::template State<T> & state);
+void applyPerRow(
+    const T * input, T * output, const typename ProjectionStateTypes<MethodTag>::template State<T> & state, T * scratch);
 
 template <>
-void applyPerRow<Float32, SparseMethodTag>(const Float32 * input, Float32 * output, const SparseProjectionState<Float32> & state)
+void applyPerRow<Float32, SparseMethodTag>(const Float32 * input, Float32 * output, const SparseProjectionState<Float32> & state, Float32 *)
 {
     applySparseProjection<Float32>(input, output, state);
 }
 template <>
-void applyPerRow<Float64, SparseMethodTag>(const Float64 * input, Float64 * output, const SparseProjectionState<Float64> & state)
+void applyPerRow<Float64, SparseMethodTag>(const Float64 * input, Float64 * output, const SparseProjectionState<Float64> & state, Float64 *)
 {
     applySparseProjection<Float64>(input, output, state);
 }
 template <>
-void applyPerRow<Float32, HadamardMethodTag>(const Float32 * input, Float32 * output, const HadamardProjectionState<Float32> & state)
+void applyPerRow<Float32, HadamardMethodTag>(
+    const Float32 * input, Float32 * output, const HadamardProjectionState<Float32> & state, Float32 * scratch)
 {
-    applyHadamardProjection<Float32>(input, output, state);
+    applyHadamardProjection<Float32>(input, output, state, scratch);
 }
 template <>
-void applyPerRow<Float64, HadamardMethodTag>(const Float64 * input, Float64 * output, const HadamardProjectionState<Float64> & state)
+void applyPerRow<Float64, HadamardMethodTag>(
+    const Float64 * input, Float64 * output, const HadamardProjectionState<Float64> & state, Float64 * scratch)
 {
-    applyHadamardProjection<Float64>(input, output, state);
+    applyHadamardProjection<Float64>(input, output, state, scratch);
 }
 
 template <typename MethodTag>
@@ -263,6 +267,11 @@ private:
         else
         {
             /// Per-row methods (Sparse, Hadamard): validate and apply one row at a time.
+            /// Allocate scratch buffer once for Hadamard FWHT; Sparse ignores it.
+            std::vector<T> scratch;
+            if constexpr (std::is_same_v<MethodTag, HadamardMethodTag>)
+                scratch.resize(state.padded_dim);
+
             ColumnArray::Offset prev = 0;
             for (size_t i = 0; i < input_rows_count; ++i)
             {
@@ -276,7 +285,7 @@ private:
                         row_dim,
                         i);
 
-                applyPerRow<T, MethodTag>(data_in.data() + prev, out.data() + i * target_dim, state);
+                applyPerRow<T, MethodTag>(data_in.data() + prev, out.data() + i * target_dim, state, scratch.data());
                 prev = offsets[i];
             }
         }

--- a/src/Functions/array/arrayRandomProjection.h
+++ b/src/Functions/array/arrayRandomProjection.h
@@ -1,0 +1,902 @@
+#pragma once
+
+#include <Common/TargetSpecific.h>
+
+#include <pcg_random.hpp>
+
+#if USE_MULTITARGET_CODE
+#    include <immintrin.h>
+#endif
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <numbers>
+#include <numeric>
+#include <random>
+#include <vector>
+
+
+namespace DB
+{
+
+/// Own Box-Muller: `std::normal_distribution` is not guaranteed identical across libstdc++/libc++.
+template <typename T>
+T boxMullerNormal(pcg64 & rng)
+{
+    std::uniform_real_distribution<T> dist(std::numeric_limits<T>::min(), T(1));
+    T u1 = dist(rng);
+    T u2 = dist(rng);
+    return std::sqrt(T(-2) * std::log(u1)) * std::cos(T(2) * std::numbers::pi_v<T> * u2);
+}
+
+/// In-place fast Walsh–Hadamard transform; `n` must be a power of two.
+template <typename T>
+void fwht(T * data, size_t n)
+{
+    for (size_t len = 1; len < n; len <<= 1)
+    {
+        for (size_t i = 0; i < n; i += len << 1)
+        {
+            for (size_t j = 0; j < len; ++j)
+            {
+                T u = data[i + j];
+                T v = data[i + j + len];
+                data[i + j] = u + v;
+                data[i + j + len] = u - v;
+            }
+        }
+    }
+}
+
+inline size_t nextPowerOfTwo(size_t n)
+{
+    if (n == 0)
+        return 1;
+    --n;
+    n |= n >> 1;
+    n |= n >> 2;
+    n |= n >> 4;
+    n |= n >> 8;
+    n |= n >> 16;
+    n |= n >> 32;
+    return n + 1;
+}
+
+template <typename T>
+T dotProductScalar(const T * __restrict a, const T * __restrict b, size_t n)
+{
+    T sum = T(0);
+    for (size_t i = 0; i < n; ++i)
+        sum += a[i] * b[i];
+    return sum;
+}
+
+#if USE_MULTITARGET_CODE
+template <typename T>
+X86_64_V3_FUNCTION_SPECIFIC_ATTRIBUTE T dotProductAVX2(const T * __restrict a, const T * __restrict b, size_t n)
+{
+    size_t i = 0;
+    if constexpr (std::is_same_v<T, Float32>)
+    {
+        __m256 acc = _mm256_setzero_ps();
+        for (; i + 8 <= n; i += 8)
+        {
+            __m256 va = _mm256_loadu_ps(a + i);
+            __m256 vb = _mm256_loadu_ps(b + i);
+            acc = _mm256_fmadd_ps(va, vb, acc);
+        }
+        __m128 hi = _mm256_extractf128_ps(acc, 1);
+        __m128 lo = _mm256_castps256_ps128(acc);
+        __m128 sum128 = _mm_add_ps(lo, hi);
+        sum128 = _mm_hadd_ps(sum128, sum128);
+        sum128 = _mm_hadd_ps(sum128, sum128);
+        T result = _mm_cvtss_f32(sum128);
+        for (; i < n; ++i)
+            result += a[i] * b[i];
+        return result;
+    }
+    else
+    {
+        __m256d acc = _mm256_setzero_pd();
+        for (; i + 4 <= n; i += 4)
+        {
+            __m256d va = _mm256_loadu_pd(a + i);
+            __m256d vb = _mm256_loadu_pd(b + i);
+            acc = _mm256_fmadd_pd(va, vb, acc);
+        }
+        __m128d hi = _mm256_extractf128_pd(acc, 1);
+        __m128d lo = _mm256_castpd256_pd128(acc);
+        __m128d sum128 = _mm_add_pd(lo, hi);
+        T result = _mm_cvtsd_f64(sum128) + _mm_cvtsd_f64(_mm_unpackhi_pd(sum128, sum128));
+        for (; i < n; ++i)
+            result += a[i] * b[i];
+        return result;
+    }
+}
+
+template <typename T>
+X86_64_V4_FUNCTION_SPECIFIC_ATTRIBUTE T dotProductAVX512(const T * __restrict a, const T * __restrict b, size_t n)
+{
+    size_t i = 0;
+    if constexpr (std::is_same_v<T, Float32>)
+    {
+        __m512 acc = _mm512_setzero_ps();
+        for (; i + 16 <= n; i += 16)
+        {
+            __m512 va = _mm512_loadu_ps(a + i);
+            __m512 vb = _mm512_loadu_ps(b + i);
+            acc = _mm512_fmadd_ps(va, vb, acc);
+        }
+        T result = _mm512_reduce_add_ps(acc);
+        for (; i < n; ++i)
+            result += a[i] * b[i];
+        return result;
+    }
+    else
+    {
+        __m512d acc = _mm512_setzero_pd();
+        for (; i + 8 <= n; i += 8)
+        {
+            __m512d va = _mm512_loadu_pd(a + i);
+            __m512d vb = _mm512_loadu_pd(b + i);
+            acc = _mm512_fmadd_pd(va, vb, acc);
+        }
+        T result = _mm512_reduce_add_pd(acc);
+        for (; i < n; ++i)
+            result += a[i] * b[i];
+        return result;
+    }
+}
+#endif
+
+template <typename T>
+T dotProductDispatch(const T * __restrict a, const T * __restrict b, size_t n)
+{
+#if USE_MULTITARGET_CODE
+    if (isArchSupported(TargetArch::x86_64_v4))
+        return dotProductAVX512<T>(a, b, n);
+    if (isArchSupported(TargetArch::x86_64_v3))
+        return dotProductAVX2<T>(a, b, n);
+#endif
+    return dotProductScalar<T>(a, b, n);
+}
+
+template <typename T>
+void axpyScalar(T * __restrict y, const T * __restrict x, T alpha, size_t n)
+{
+    for (size_t i = 0; i < n; ++i)
+        y[i] += alpha * x[i];
+}
+
+#if USE_MULTITARGET_CODE
+template <typename T>
+X86_64_V3_FUNCTION_SPECIFIC_ATTRIBUTE void axpyAVX2(T * __restrict y, const T * __restrict x, T alpha, size_t n)
+{
+    size_t i = 0;
+    if constexpr (std::is_same_v<T, Float32>)
+    {
+        __m256 valpha = _mm256_set1_ps(alpha);
+        for (; i + 8 <= n; i += 8)
+        {
+            __m256 vy = _mm256_loadu_ps(y + i);
+            __m256 vx = _mm256_loadu_ps(x + i);
+            vy = _mm256_fmadd_ps(valpha, vx, vy);
+            _mm256_storeu_ps(y + i, vy);
+        }
+    }
+    else
+    {
+        __m256d valpha = _mm256_set1_pd(alpha);
+        for (; i + 4 <= n; i += 4)
+        {
+            __m256d vy = _mm256_loadu_pd(y + i);
+            __m256d vx = _mm256_loadu_pd(x + i);
+            vy = _mm256_fmadd_pd(valpha, vx, vy);
+            _mm256_storeu_pd(y + i, vy);
+        }
+    }
+    for (; i < n; ++i)
+        y[i] += alpha * x[i];
+}
+
+template <typename T>
+X86_64_V4_FUNCTION_SPECIFIC_ATTRIBUTE void axpyAVX512(T * __restrict y, const T * __restrict x, T alpha, size_t n)
+{
+    size_t i = 0;
+    if constexpr (std::is_same_v<T, Float32>)
+    {
+        __m512 valpha = _mm512_set1_ps(alpha);
+        for (; i + 16 <= n; i += 16)
+        {
+            __m512 vy = _mm512_loadu_ps(y + i);
+            __m512 vx = _mm512_loadu_ps(x + i);
+            vy = _mm512_fmadd_ps(valpha, vx, vy);
+            _mm512_storeu_ps(y + i, vy);
+        }
+    }
+    else
+    {
+        __m512d valpha = _mm512_set1_pd(alpha);
+        for (; i + 8 <= n; i += 8)
+        {
+            __m512d vy = _mm512_loadu_pd(y + i);
+            __m512d vx = _mm512_loadu_pd(x + i);
+            vy = _mm512_fmadd_pd(valpha, vx, vy);
+            _mm512_storeu_pd(y + i, vy);
+        }
+    }
+    for (; i < n; ++i)
+        y[i] += alpha * x[i];
+}
+#endif
+
+template <typename T>
+void axpyDispatch(T * __restrict y, const T * __restrict x, T alpha, size_t n)
+{
+#if USE_MULTITARGET_CODE
+    if (isArchSupported(TargetArch::x86_64_v4))
+    {
+        axpyAVX512<T>(y, x, alpha, n);
+        return;
+    }
+    if (isArchSupported(TargetArch::x86_64_v3))
+    {
+        axpyAVX2<T>(y, x, alpha, n);
+        return;
+    }
+#endif
+    axpyScalar<T>(y, x, alpha, n);
+}
+
+/// Column-major `n`×`n` Householder QR: upper triangle is `R`, subdiagonal holds normalized `v` (leading 1 implicit), `tau[k]` are scalars.
+template <typename T>
+void householderQR(T * __restrict A, T * __restrict tau, size_t n)
+{
+    for (size_t k = 0; k < n; ++k)
+    {
+        T * col_k = A + k * n;
+        size_t len = n - k;
+        T col_norm_sq = dotProductDispatch<T>(col_k + k, col_k + k, len);
+        T col_norm = std::sqrt(col_norm_sq);
+
+        if (col_norm < std::numeric_limits<T>::min())
+        {
+            tau[k] = T(0);
+            continue;
+        }
+
+        T sigma = (col_k[k] >= T(0)) ? col_norm : -col_norm;
+
+        col_k[k] += sigma;
+        T v0 = col_k[k];
+
+        tau[k] = v0 / sigma;
+
+        T inv_v0 = T(1) / v0;
+        for (size_t i = k + 1; i < n; ++i)
+            col_k[i] *= inv_v0;
+
+        for (size_t j = k + 1; j < n; ++j)
+        {
+            T * col_j = A + j * n;
+            T dot = col_j[k];
+            if (len > 1)
+                dot += dotProductDispatch<T>(col_k + k + 1, col_j + k + 1, len - 1);
+            T w = tau[k] * dot;
+            col_j[k] -= w;
+            if (len > 1)
+                axpyDispatch<T>(col_j + k + 1, col_k + k + 1, -w, len - 1);
+        }
+
+        col_k[k] = -sigma;
+    }
+}
+
+/// `Q` from packed Householder data: backward accumulation `H_0` ... `H_{n-1}`, column-major.
+template <typename T>
+void extractQ(const T * __restrict A_qr, const T * __restrict tau, T * __restrict Q, size_t n)
+{
+    std::memset(Q, 0, n * n * sizeof(T));
+    for (size_t i = 0; i < n; ++i)
+        Q[i + i * n] = T(1);
+
+    for (size_t k_rev = 0; k_rev < n; ++k_rev)
+    {
+        size_t k = n - 1 - k_rev;
+        if (std::abs(tau[k]) < std::numeric_limits<T>::min())
+            continue;
+
+        size_t len = n - k;
+        const T * v = A_qr + k * n;
+
+        for (size_t j = k; j < n; ++j)
+        {
+            T * q_col_j = Q + j * n;
+            T dot = q_col_j[k];
+            if (len > 1)
+                dot += dotProductDispatch<T>(v + k + 1, q_col_j + k + 1, len - 1);
+            T w = tau[k] * dot;
+            q_col_j[k] -= w;
+            if (len > 1)
+                axpyDispatch<T>(q_col_j + k + 1, v + k + 1, -w, len - 1);
+        }
+    }
+}
+
+/// `Y(N×D) = X(N×d) * P^T` with `P` row-major `D×d`, i.e. `Y[i,j] = dot(X_i, P_j)`.
+template <typename T>
+void gemmBatchScalar(const T * __restrict X, const T * __restrict P, T * __restrict Y, size_t N, size_t d, size_t D)
+{
+    std::memset(Y, 0, N * D * sizeof(T));
+
+    static constexpr size_t TILE_N = 32;
+    static constexpr size_t TILE_D = 32;
+    static constexpr size_t TILE_K = 64;
+
+    for (size_t i0 = 0; i0 < N; i0 += TILE_N)
+    {
+        const size_t i_end = std::min(i0 + TILE_N, N);
+        for (size_t j0 = 0; j0 < D; j0 += TILE_D)
+        {
+            const size_t j_end = std::min(j0 + TILE_D, D);
+            for (size_t k0 = 0; k0 < d; k0 += TILE_K)
+            {
+                const size_t k_end = std::min(k0 + TILE_K, d);
+                const size_t tile_k = k_end - k0;
+                for (size_t i = i0; i < i_end; ++i)
+                {
+                    for (size_t j = j0; j < j_end; ++j)
+                    {
+                        T acc = T(0);
+                        for (size_t k = 0; k < tile_k; ++k)
+                            acc += X[i * d + k0 + k] * P[j * d + k0 + k];
+                        Y[i * D + j] += acc;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#if USE_MULTITARGET_CODE
+template <typename T>
+X86_64_V3_FUNCTION_SPECIFIC_ATTRIBUTE void
+gemmBatchAVX2(const T * __restrict X, const T * __restrict P, T * __restrict Y, size_t N, size_t d, size_t D)
+{
+    std::memset(Y, 0, N * D * sizeof(T));
+
+    static constexpr size_t TILE_N = 16;
+    static constexpr size_t TILE_D = 16;
+    static constexpr size_t TILE_K = 64;
+    static constexpr size_t J_UNROLL = 4;
+
+    for (size_t i0 = 0; i0 < N; i0 += TILE_N)
+    {
+        const size_t i_end = std::min(i0 + TILE_N, N);
+        for (size_t j0 = 0; j0 < D; j0 += TILE_D)
+        {
+            const size_t j_end = std::min(j0 + TILE_D, D);
+            for (size_t k0 = 0; k0 < d; k0 += TILE_K)
+            {
+                const size_t k_end = std::min(k0 + TILE_K, d);
+                const size_t tile_k = k_end - k0;
+                for (size_t i = i0; i < i_end; ++i)
+                {
+                    const T * x_row = X + i * d + k0;
+                    T * y_row = Y + i * D;
+                    size_t j = j0;
+
+                    if constexpr (std::is_same_v<T, Float32>)
+                    {
+                        for (; j + J_UNROLL <= j_end; j += J_UNROLL)
+                        {
+                            const T * p0 = P + (j + 0) * d + k0;
+                            const T * p1 = P + (j + 1) * d + k0;
+                            const T * p2 = P + (j + 2) * d + k0;
+                            const T * p3 = P + (j + 3) * d + k0;
+
+                            __m256 acc0 = _mm256_setzero_ps();
+                            __m256 acc1 = _mm256_setzero_ps();
+                            __m256 acc2 = _mm256_setzero_ps();
+                            __m256 acc3 = _mm256_setzero_ps();
+
+                            size_t k = 0;
+                            for (; k + 8 <= tile_k; k += 8)
+                            {
+                                __m256 vx = _mm256_loadu_ps(x_row + k);
+                                acc0 = _mm256_fmadd_ps(vx, _mm256_loadu_ps(p0 + k), acc0);
+                                acc1 = _mm256_fmadd_ps(vx, _mm256_loadu_ps(p1 + k), acc1);
+                                acc2 = _mm256_fmadd_ps(vx, _mm256_loadu_ps(p2 + k), acc2);
+                                acc3 = _mm256_fmadd_ps(vx, _mm256_loadu_ps(p3 + k), acc3);
+                            }
+
+                            __m256 sum01 = _mm256_hadd_ps(acc0, acc1);
+                            __m256 sum23 = _mm256_hadd_ps(acc2, acc3);
+                            __m256 sum0123 = _mm256_hadd_ps(sum01, sum23);
+                            __m128 hi4 = _mm256_extractf128_ps(sum0123, 1);
+                            __m128 lo4 = _mm256_castps256_ps128(sum0123);
+                            __m128 dots128 = _mm_add_ps(lo4, hi4);
+
+                            alignas(16) float dots[4];
+                            _mm_store_ps(dots, dots128);
+                            T dot0 = dots[0];
+                            T dot1 = dots[1];
+                            T dot2 = dots[2];
+                            T dot3 = dots[3];
+
+                            for (; k < tile_k; ++k)
+                            {
+                                T xv = x_row[k];
+                                dot0 += xv * p0[k];
+                                dot1 += xv * p1[k];
+                                dot2 += xv * p2[k];
+                                dot3 += xv * p3[k];
+                            }
+
+                            y_row[j + 0] += dot0;
+                            y_row[j + 1] += dot1;
+                            y_row[j + 2] += dot2;
+                            y_row[j + 3] += dot3;
+                        }
+
+                        for (; j < j_end; ++j)
+                        {
+                            const T * p_row = P + j * d + k0;
+                            __m256 acc = _mm256_setzero_ps();
+                            size_t k = 0;
+                            for (; k + 8 <= tile_k; k += 8)
+                                acc = _mm256_fmadd_ps(_mm256_loadu_ps(x_row + k), _mm256_loadu_ps(p_row + k), acc);
+                            __m128 hi = _mm256_extractf128_ps(acc, 1);
+                            __m128 lo = _mm256_castps256_ps128(acc);
+                            __m128 s = _mm_add_ps(lo, hi);
+                            s = _mm_hadd_ps(s, s);
+                            s = _mm_hadd_ps(s, s);
+                            T dot = _mm_cvtss_f32(s);
+                            for (; k < tile_k; ++k)
+                                dot += x_row[k] * p_row[k];
+                            y_row[j] += dot;
+                        }
+                    }
+                    else
+                    {
+                        for (; j + J_UNROLL <= j_end; j += J_UNROLL)
+                        {
+                            const T * p0 = P + (j + 0) * d + k0;
+                            const T * p1 = P + (j + 1) * d + k0;
+                            const T * p2 = P + (j + 2) * d + k0;
+                            const T * p3 = P + (j + 3) * d + k0;
+
+                            __m256d acc0 = _mm256_setzero_pd();
+                            __m256d acc1 = _mm256_setzero_pd();
+                            __m256d acc2 = _mm256_setzero_pd();
+                            __m256d acc3 = _mm256_setzero_pd();
+
+                            size_t k = 0;
+                            for (; k + 4 <= tile_k; k += 4)
+                            {
+                                __m256d vx = _mm256_loadu_pd(x_row + k);
+                                acc0 = _mm256_fmadd_pd(vx, _mm256_loadu_pd(p0 + k), acc0);
+                                acc1 = _mm256_fmadd_pd(vx, _mm256_loadu_pd(p1 + k), acc1);
+                                acc2 = _mm256_fmadd_pd(vx, _mm256_loadu_pd(p2 + k), acc2);
+                                acc3 = _mm256_fmadd_pd(vx, _mm256_loadu_pd(p3 + k), acc3);
+                            }
+
+                            __m256d sum01 = _mm256_hadd_pd(acc0, acc1);
+                            __m256d sum23 = _mm256_hadd_pd(acc2, acc3);
+                            __m128d hi01 = _mm256_extractf128_pd(sum01, 1);
+                            __m128d lo01 = _mm256_castpd256_pd128(sum01);
+                            __m128d r01 = _mm_add_pd(lo01, hi01);
+                            __m128d hi23 = _mm256_extractf128_pd(sum23, 1);
+                            __m128d lo23 = _mm256_castpd256_pd128(sum23);
+                            __m128d r23 = _mm_add_pd(lo23, hi23);
+
+                            T dot0 = _mm_cvtsd_f64(r01);
+                            T dot1 = _mm_cvtsd_f64(_mm_unpackhi_pd(r01, r01));
+                            T dot2 = _mm_cvtsd_f64(r23);
+                            T dot3 = _mm_cvtsd_f64(_mm_unpackhi_pd(r23, r23));
+
+                            for (; k < tile_k; ++k)
+                            {
+                                T xv = x_row[k];
+                                dot0 += xv * p0[k];
+                                dot1 += xv * p1[k];
+                                dot2 += xv * p2[k];
+                                dot3 += xv * p3[k];
+                            }
+
+                            y_row[j + 0] += dot0;
+                            y_row[j + 1] += dot1;
+                            y_row[j + 2] += dot2;
+                            y_row[j + 3] += dot3;
+                        }
+
+                        for (; j < j_end; ++j)
+                        {
+                            const T * p_row = P + j * d + k0;
+                            __m256d acc = _mm256_setzero_pd();
+                            size_t k = 0;
+                            for (; k + 4 <= tile_k; k += 4)
+                                acc = _mm256_fmadd_pd(_mm256_loadu_pd(x_row + k), _mm256_loadu_pd(p_row + k), acc);
+                            __m128d hi = _mm256_extractf128_pd(acc, 1);
+                            __m128d lo = _mm256_castpd256_pd128(acc);
+                            __m128d s = _mm_add_pd(lo, hi);
+                            T dot = _mm_cvtsd_f64(s) + _mm_cvtsd_f64(_mm_unpackhi_pd(s, s));
+                            for (; k < tile_k; ++k)
+                                dot += x_row[k] * p_row[k];
+                            y_row[j] += dot;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+template <typename T>
+X86_64_V4_FUNCTION_SPECIFIC_ATTRIBUTE void
+gemmBatchAVX512(const T * __restrict X, const T * __restrict P, T * __restrict Y, size_t N, size_t d, size_t D)
+{
+    std::memset(Y, 0, N * D * sizeof(T));
+
+    static constexpr size_t TILE_N = 16;
+    static constexpr size_t TILE_D = 16;
+    static constexpr size_t TILE_K = 64;
+    static constexpr size_t J_UNROLL = 4;
+
+    for (size_t i0 = 0; i0 < N; i0 += TILE_N)
+    {
+        const size_t i_end = std::min(i0 + TILE_N, N);
+        for (size_t j0 = 0; j0 < D; j0 += TILE_D)
+        {
+            const size_t j_end = std::min(j0 + TILE_D, D);
+            for (size_t k0 = 0; k0 < d; k0 += TILE_K)
+            {
+                const size_t k_end = std::min(k0 + TILE_K, d);
+                const size_t tile_k = k_end - k0;
+                for (size_t i = i0; i < i_end; ++i)
+                {
+                    const T * x_row = X + i * d + k0;
+                    T * y_row = Y + i * D;
+                    size_t j = j0;
+
+                    if constexpr (std::is_same_v<T, Float32>)
+                    {
+                        for (; j + J_UNROLL <= j_end; j += J_UNROLL)
+                        {
+                            const T * p0 = P + (j + 0) * d + k0;
+                            const T * p1 = P + (j + 1) * d + k0;
+                            const T * p2 = P + (j + 2) * d + k0;
+                            const T * p3 = P + (j + 3) * d + k0;
+
+                            __m512 acc0 = _mm512_setzero_ps();
+                            __m512 acc1 = _mm512_setzero_ps();
+                            __m512 acc2 = _mm512_setzero_ps();
+                            __m512 acc3 = _mm512_setzero_ps();
+
+                            size_t k = 0;
+                            for (; k + 16 <= tile_k; k += 16)
+                            {
+                                __m512 vx = _mm512_loadu_ps(x_row + k);
+                                acc0 = _mm512_fmadd_ps(vx, _mm512_loadu_ps(p0 + k), acc0);
+                                acc1 = _mm512_fmadd_ps(vx, _mm512_loadu_ps(p1 + k), acc1);
+                                acc2 = _mm512_fmadd_ps(vx, _mm512_loadu_ps(p2 + k), acc2);
+                                acc3 = _mm512_fmadd_ps(vx, _mm512_loadu_ps(p3 + k), acc3);
+                            }
+
+                            T dot0 = _mm512_reduce_add_ps(acc0);
+                            T dot1 = _mm512_reduce_add_ps(acc1);
+                            T dot2 = _mm512_reduce_add_ps(acc2);
+                            T dot3 = _mm512_reduce_add_ps(acc3);
+
+                            for (; k < tile_k; ++k)
+                            {
+                                T xv = x_row[k];
+                                dot0 += xv * p0[k];
+                                dot1 += xv * p1[k];
+                                dot2 += xv * p2[k];
+                                dot3 += xv * p3[k];
+                            }
+
+                            y_row[j + 0] += dot0;
+                            y_row[j + 1] += dot1;
+                            y_row[j + 2] += dot2;
+                            y_row[j + 3] += dot3;
+                        }
+
+                        for (; j < j_end; ++j)
+                        {
+                            const T * p_row = P + j * d + k0;
+                            __m512 acc = _mm512_setzero_ps();
+                            size_t k = 0;
+                            for (; k + 16 <= tile_k; k += 16)
+                                acc = _mm512_fmadd_ps(_mm512_loadu_ps(x_row + k), _mm512_loadu_ps(p_row + k), acc);
+                            T dot = _mm512_reduce_add_ps(acc);
+                            for (; k < tile_k; ++k)
+                                dot += x_row[k] * p_row[k];
+                            y_row[j] += dot;
+                        }
+                    }
+                    else
+                    {
+                        for (; j + J_UNROLL <= j_end; j += J_UNROLL)
+                        {
+                            const T * p0 = P + (j + 0) * d + k0;
+                            const T * p1 = P + (j + 1) * d + k0;
+                            const T * p2 = P + (j + 2) * d + k0;
+                            const T * p3 = P + (j + 3) * d + k0;
+
+                            __m512d acc0 = _mm512_setzero_pd();
+                            __m512d acc1 = _mm512_setzero_pd();
+                            __m512d acc2 = _mm512_setzero_pd();
+                            __m512d acc3 = _mm512_setzero_pd();
+
+                            size_t k = 0;
+                            for (; k + 8 <= tile_k; k += 8)
+                            {
+                                __m512d vx = _mm512_loadu_pd(x_row + k);
+                                acc0 = _mm512_fmadd_pd(vx, _mm512_loadu_pd(p0 + k), acc0);
+                                acc1 = _mm512_fmadd_pd(vx, _mm512_loadu_pd(p1 + k), acc1);
+                                acc2 = _mm512_fmadd_pd(vx, _mm512_loadu_pd(p2 + k), acc2);
+                                acc3 = _mm512_fmadd_pd(vx, _mm512_loadu_pd(p3 + k), acc3);
+                            }
+
+                            T dot0 = _mm512_reduce_add_pd(acc0);
+                            T dot1 = _mm512_reduce_add_pd(acc1);
+                            T dot2 = _mm512_reduce_add_pd(acc2);
+                            T dot3 = _mm512_reduce_add_pd(acc3);
+
+                            for (; k < tile_k; ++k)
+                            {
+                                T xv = x_row[k];
+                                dot0 += xv * p0[k];
+                                dot1 += xv * p1[k];
+                                dot2 += xv * p2[k];
+                                dot3 += xv * p3[k];
+                            }
+
+                            y_row[j + 0] += dot0;
+                            y_row[j + 1] += dot1;
+                            y_row[j + 2] += dot2;
+                            y_row[j + 3] += dot3;
+                        }
+
+                        for (; j < j_end; ++j)
+                        {
+                            const T * p_row = P + j * d + k0;
+                            __m512d acc = _mm512_setzero_pd();
+                            size_t k = 0;
+                            for (; k + 8 <= tile_k; k += 8)
+                                acc = _mm512_fmadd_pd(_mm512_loadu_pd(x_row + k), _mm512_loadu_pd(p_row + k), acc);
+                            T dot = _mm512_reduce_add_pd(acc);
+                            for (; k < tile_k; ++k)
+                                dot += x_row[k] * p_row[k];
+                            y_row[j] += dot;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+#endif
+
+template <typename T>
+void applyDenseProjectionBatch(
+    const T * __restrict input_data,
+    T * __restrict output_data,
+    size_t num_rows,
+    size_t input_dim,
+    size_t target_dim,
+    const T * __restrict matrix)
+{
+#if USE_MULTITARGET_CODE
+    if (isArchSupported(TargetArch::x86_64_v4))
+    {
+        gemmBatchAVX512<T>(input_data, matrix, output_data, num_rows, input_dim, target_dim);
+        return;
+    }
+    if (isArchSupported(TargetArch::x86_64_v3))
+    {
+        gemmBatchAVX2<T>(input_data, matrix, output_data, num_rows, input_dim, target_dim);
+        return;
+    }
+#endif
+    gemmBatchScalar<T>(input_data, matrix, output_data, num_rows, input_dim, target_dim);
+}
+
+template <typename T>
+struct NormalProjectionState
+{
+    size_t input_dim = 0;
+    size_t target_dim = 0;
+    UInt64 seed = 0;
+    std::vector<T> matrix;
+
+    void generate(size_t d, size_t D, UInt64 s)
+    {
+        input_dim = d;
+        target_dim = D;
+        seed = s;
+
+        pcg64 rng(seed);
+        T scale = T(1) / std::sqrt(static_cast<T>(D));
+
+        matrix.resize(D * d);
+        for (size_t i = 0; i < D * d; ++i)
+            matrix[i] = boxMullerNormal<T>(rng) * scale;
+    }
+};
+
+template <typename T>
+struct OrthogonalProjectionState
+{
+    size_t input_dim = 0;
+    size_t target_dim = 0;
+    UInt64 seed = 0;
+    std::vector<T> matrix;
+
+    void generate(size_t d, size_t D, UInt64 s)
+    {
+        input_dim = d;
+        target_dim = D;
+        seed = s;
+
+        size_t n = std::max(d, D);
+        pcg64 rng(seed);
+
+        std::vector<T> gauss(n * n);
+        /// Column-major (i outer, j inner) matches Eigen ColMajor RNG consumption for the same seed.
+        for (size_t i = 0; i < n; ++i)
+            for (size_t j = 0; j < n; ++j)
+                gauss[i + j * n] = boxMullerNormal<T>(rng);
+
+        std::vector<T> tau(n);
+        householderQR<T>(gauss.data(), tau.data(), n);
+
+        std::vector<T> q_matrix(n * n);
+        extractQ<T>(gauss.data(), tau.data(), q_matrix.data(), n);
+
+        T scale = std::sqrt(static_cast<T>(n) / static_cast<T>(D));
+        matrix.resize(D * d);
+        for (size_t i = 0; i < D; ++i)
+            for (size_t j = 0; j < d; ++j)
+                matrix[i * d + j] = q_matrix[i + j * n] * scale;
+    }
+};
+
+template <typename T>
+struct SparseProjectionState
+{
+    size_t input_dim = 0;
+    size_t target_dim = 0;
+    UInt64 seed = 0;
+    T scale = 0;
+
+    /// Per input index `j`: pairs `(output row, ±1)` for Achlioptas nonzeros.
+    std::vector<std::vector<std::pair<UInt32, int8_t>>> columns;
+
+    void generate(size_t d, size_t D, UInt64 s)
+    {
+        input_dim = d;
+        target_dim = D;
+        seed = s;
+        scale = std::sqrt(T(3) / static_cast<T>(D));
+
+        pcg64 rng(seed);
+        std::uniform_int_distribution<int> dist6(0, 5);
+
+        columns.resize(d);
+        for (size_t j = 0; j < d; ++j)
+        {
+            columns[j].clear();
+            for (size_t i = 0; i < D; ++i)
+            {
+                int val = dist6(rng);
+                if (val == 0)
+                    columns[j].emplace_back(static_cast<UInt32>(i), int8_t(1));
+                else if (val == 5)
+                    columns[j].emplace_back(static_cast<UInt32>(i), int8_t(-1));
+            }
+        }
+    }
+};
+
+template <typename T>
+struct HadamardProjectionState
+{
+    size_t input_dim = 0;
+    size_t target_dim = 0;
+    UInt64 seed = 0;
+    size_t padded_dim = 0;
+    T scale_factor = 0;
+
+    struct Block
+    {
+        std::vector<int8_t> signs;
+        std::vector<UInt32> indices;
+    };
+    std::vector<Block> blocks;
+
+    void generate(size_t d, size_t D, UInt64 s)
+    {
+        input_dim = d;
+        target_dim = D;
+        seed = s;
+        padded_dim = nextPowerOfTwo(d);
+
+        pcg64 rng(seed);
+        std::uniform_int_distribution<int> sign_dist(0, 1);
+
+        size_t num_blocks = (D + padded_dim - 1) / padded_dim;
+        blocks.resize(num_blocks);
+
+        size_t remaining = D;
+        for (size_t b = 0; b < num_blocks; ++b)
+        {
+            auto & block = blocks[b];
+
+            block.signs.resize(padded_dim);
+            for (size_t i = 0; i < padded_dim; ++i)
+                block.signs[i] = sign_dist(rng) ? int8_t(1) : int8_t(-1);
+
+            size_t samples_this_block = std::min(remaining, padded_dim);
+            block.indices.resize(samples_this_block);
+
+            std::vector<UInt32> perm(padded_dim);
+            std::iota(perm.begin(), perm.end(), 0);
+            for (size_t i = 0; i < samples_this_block; ++i)
+            {
+                std::uniform_int_distribution<size_t> idx_dist(i, padded_dim - 1);
+                size_t j = idx_dist(rng);
+                std::swap(perm[i], perm[j]);
+            }
+            std::sort(perm.begin(), perm.begin() + samples_this_block);
+            for (size_t i = 0; i < samples_this_block; ++i)
+                block.indices[i] = perm[i];
+
+            remaining -= samples_this_block;
+        }
+
+        scale_factor = T(1) / std::sqrt(static_cast<T>(D));
+    }
+};
+
+/// Achlioptas: scale input once per column, scatter `±val` to listed rows (no multiply in inner loop).
+template <typename T>
+void applySparseProjection(const T * __restrict input, T * __restrict output, const SparseProjectionState<T> & state)
+{
+    std::memset(output, 0, state.target_dim * sizeof(T));
+
+    for (size_t j = 0; j < state.input_dim; ++j)
+    {
+        const T val = input[j] * state.scale;
+        for (const auto & [row_i, sign] : state.columns[j])
+            output[row_i] += sign * val;
+    }
+}
+
+/// SRHT: sign inputs, FWHT on padded power-of-two length, then subsample coefficients per block.
+template <typename T>
+void applyHadamardProjection(const T * __restrict input, T * __restrict output, const HadamardProjectionState<T> & state)
+{
+    std::vector<T> buf(state.padded_dim);
+
+    size_t out_offset = 0;
+    for (const auto & block : state.blocks)
+    {
+        for (size_t i = 0; i < state.input_dim; ++i)
+            buf[i] = input[i] * block.signs[i];
+        for (size_t i = state.input_dim; i < state.padded_dim; ++i)
+            buf[i] = T(0);
+
+        fwht(buf.data(), state.padded_dim);
+
+        for (size_t i = 0; i < block.indices.size(); ++i)
+            output[out_offset + i] = buf[block.indices[i]] * state.scale_factor;
+
+        out_offset += block.indices.size();
+    }
+}
+
+} // namespace DB

--- a/src/Functions/array/arrayRandomProjection.h
+++ b/src/Functions/array/arrayRandomProjection.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Common/TargetSpecific.h>
+#include <Core/Types.h>
 
 #include <pcg_random.hpp>
 
@@ -30,7 +31,7 @@ T boxMullerNormal(pcg64 & rng)
     return std::sqrt(T(-2) * std::log(u1)) * std::cos(T(2) * std::numbers::pi_v<T> * u2);
 }
 
-/// In-place fast Walsh–Hadamard transform; `n` must be a power of two.
+/// In-place fast Walsh-Hadamard transform; `n` must be a power of two.
 template <typename T>
 void fwht(T * data, size_t n)
 {
@@ -249,7 +250,7 @@ void axpyDispatch(T * __restrict y, const T * __restrict x, T alpha, size_t n)
     axpyScalar<T>(y, x, alpha, n);
 }
 
-/// Column-major `n`×`n` Householder QR: upper triangle is `R`, subdiagonal holds normalized `v` (leading 1 implicit), `tau[k]` are scalars.
+/// Column-major `n x n` Householder QR: upper triangle is `R`, subdiagonal holds normalized `v` (leading 1 implicit), `tau[k]` are scalars.
 template <typename T>
 void householderQR(T * __restrict A, T * __restrict tau, size_t n)
 {
@@ -324,7 +325,7 @@ void extractQ(const T * __restrict A_qr, const T * __restrict tau, T * __restric
     }
 }
 
-/// `Y(N×D) = X(N×d) * P^T` with `P` row-major `D×d`, i.e. `Y[i,j] = dot(X_i, P_j)`.
+/// `Y(N x D) = X(N x d) * P^T` with `P` row-major `D x d`, i.e. `Y[i,j] = dot(X_i, P_j)`.
 template <typename T>
 void gemmBatchScalar(const T * __restrict X, const T * __restrict P, T * __restrict Y, size_t N, size_t d, size_t D)
 {
@@ -773,7 +774,7 @@ struct SparseProjectionState
     UInt64 seed = 0;
     T scale = 0;
 
-    /// Per input index `j`: pairs `(output row, ±1)` for Achlioptas nonzeros.
+    /// Per input index `j`: pairs `(output row, +/-1)` for Achlioptas nonzeros.
     std::vector<std::vector<std::pair<UInt32, int8_t>>> columns;
 
     void generate(size_t d, size_t D, UInt64 s)
@@ -862,7 +863,7 @@ struct HadamardProjectionState
     }
 };
 
-/// Achlioptas: scale input once per column, scatter `±val` to listed rows (no multiply in inner loop).
+/// Achlioptas: scale input once per column, scatter `+/-val` to listed rows (no multiply in inner loop).
 template <typename T>
 void applySparseProjection(const T * __restrict input, T * __restrict output, const SparseProjectionState<T> & state)
 {
@@ -877,26 +878,33 @@ void applySparseProjection(const T * __restrict input, T * __restrict output, co
 }
 
 /// SRHT: sign inputs, FWHT on padded power-of-two length, then subsample coefficients per block.
+/// `scratch` must have at least `state.padded_dim` elements; avoids per-call heap allocation.
 template <typename T>
-void applyHadamardProjection(const T * __restrict input, T * __restrict output, const HadamardProjectionState<T> & state)
+void applyHadamardProjection(const T * __restrict input, T * __restrict output, const HadamardProjectionState<T> & state, T * __restrict scratch)
 {
-    std::vector<T> buf(state.padded_dim);
-
     size_t out_offset = 0;
     for (const auto & block : state.blocks)
     {
         for (size_t i = 0; i < state.input_dim; ++i)
-            buf[i] = input[i] * block.signs[i];
+            scratch[i] = input[i] * block.signs[i];
         for (size_t i = state.input_dim; i < state.padded_dim; ++i)
-            buf[i] = T(0);
+            scratch[i] = T(0);
 
-        fwht(buf.data(), state.padded_dim);
+        fwht(scratch, state.padded_dim);
 
         for (size_t i = 0; i < block.indices.size(); ++i)
-            output[out_offset + i] = buf[block.indices[i]] * state.scale_factor;
+            output[out_offset + i] = scratch[block.indices[i]] * state.scale_factor;
 
         out_offset += block.indices.size();
     }
+}
+
+/// Convenience overload that allocates the scratch buffer internally.
+template <typename T>
+void applyHadamardProjection(const T * __restrict input, T * __restrict output, const HadamardProjectionState<T> & state)
+{
+    std::vector<T> scratch(state.padded_dim);
+    applyHadamardProjection(input, output, state, scratch.data());
 }
 
 } // namespace DB

--- a/src/Functions/array/benchmarks/CMakeLists.txt
+++ b/src/Functions/array/benchmarks/CMakeLists.txt
@@ -1,0 +1,4 @@
+clickhouse_add_executable(benchmark_array_random_projection benchmark_array_random_projection.cpp)
+target_link_libraries(benchmark_array_random_projection PRIVATE
+    ch_contrib::gbenchmark_all
+    dbms)

--- a/src/Functions/array/benchmarks/benchmark_array_random_projection.cpp
+++ b/src/Functions/array/benchmarks/benchmark_array_random_projection.cpp
@@ -1,0 +1,155 @@
+#include <benchmark/benchmark.h>
+#include <Functions/array/arrayRandomProjection.h>
+
+
+template <typename T>
+static void BM_GemmScalar(benchmark::State & state)
+{
+    const size_t input_dim = state.range(0);
+    const size_t target_dim = state.range(1);
+    const size_t num_rows = state.range(2);
+
+    DB::NormalProjectionState<T> proj;
+    proj.generate(input_dim, target_dim, 42);
+
+    pcg64 rng(123);
+    std::vector<T> input(num_rows * input_dim);
+    for (auto & v : input)
+        v = DB::boxMullerNormal<T>(rng);
+    std::vector<T> output(num_rows * target_dim);
+
+    for (auto _ : state)
+    {
+        DB::gemmBatchScalar<T>(input.data(), proj.matrix.data(), output.data(), num_rows, input_dim, target_dim);
+        benchmark::DoNotOptimize(output.data());
+    }
+
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * num_rows);
+    state.SetBytesProcessed(
+        static_cast<int64_t>(state.iterations()) * num_rows * (input_dim + target_dim) * sizeof(T));
+}
+
+#if USE_MULTITARGET_CODE
+template <typename T>
+static void BM_GemmAVX2(benchmark::State & state)
+{
+    const size_t input_dim = state.range(0);
+    const size_t target_dim = state.range(1);
+    const size_t num_rows = state.range(2);
+
+    DB::NormalProjectionState<T> proj;
+    proj.generate(input_dim, target_dim, 42);
+
+    pcg64 rng(123);
+    std::vector<T> input(num_rows * input_dim);
+    for (auto & v : input)
+        v = DB::boxMullerNormal<T>(rng);
+    std::vector<T> output(num_rows * target_dim);
+
+    for (auto _ : state)
+    {
+        DB::gemmBatchAVX2<T>(input.data(), proj.matrix.data(), output.data(), num_rows, input_dim, target_dim);
+        benchmark::DoNotOptimize(output.data());
+    }
+
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * num_rows);
+    state.SetBytesProcessed(
+        static_cast<int64_t>(state.iterations()) * num_rows * (input_dim + target_dim) * sizeof(T));
+}
+
+template <typename T>
+static void BM_GemmAVX512(benchmark::State & state)
+{
+    const size_t input_dim = state.range(0);
+    const size_t target_dim = state.range(1);
+    const size_t num_rows = state.range(2);
+
+    DB::NormalProjectionState<T> proj;
+    proj.generate(input_dim, target_dim, 42);
+
+    pcg64 rng(123);
+    std::vector<T> input(num_rows * input_dim);
+    for (auto & v : input)
+        v = DB::boxMullerNormal<T>(rng);
+    std::vector<T> output(num_rows * target_dim);
+
+    for (auto _ : state)
+    {
+        DB::gemmBatchAVX512<T>(input.data(), proj.matrix.data(), output.data(), num_rows, input_dim, target_dim);
+        benchmark::DoNotOptimize(output.data());
+    }
+
+    state.SetItemsProcessed(static_cast<int64_t>(state.iterations()) * num_rows);
+    state.SetBytesProcessed(
+        static_cast<int64_t>(state.iterations()) * num_rows * (input_dim + target_dim) * sizeof(T));
+}
+#endif
+
+/// Args: {input_dim, target_dim, num_rows}
+
+BENCHMARK_TEMPLATE(BM_GemmScalar, Float32)
+    ->Args({128, 64, 1000})
+    ->Args({200, 100, 1000})
+    ->Args({256, 128, 1000})
+    ->Args({300, 150, 1000})
+    ->Args({512, 256, 1000})
+    ->Args({768, 256, 1000})
+    ->Args({1024, 256, 1000})
+    ->Args({1024, 512, 100})
+    ->Args({1536, 384, 100})
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(BM_GemmScalar, Float64)
+    ->Args({128, 64, 1000})
+    ->Args({200, 100, 1000})
+    ->Args({512, 256, 1000})
+    ->Args({768, 256, 1000})
+    ->Args({1024, 256, 1000})
+    ->Args({1536, 384, 100})
+    ->Unit(benchmark::kMicrosecond);
+
+#if USE_MULTITARGET_CODE
+BENCHMARK_TEMPLATE(BM_GemmAVX2, Float32)
+    ->Args({128, 64, 1000})
+    ->Args({200, 100, 1000})
+    ->Args({256, 128, 1000})
+    ->Args({300, 150, 1000})
+    ->Args({512, 256, 1000})
+    ->Args({768, 256, 1000})
+    ->Args({1024, 256, 1000})
+    ->Args({1024, 512, 100})
+    ->Args({1536, 384, 100})
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(BM_GemmAVX2, Float64)
+    ->Args({128, 64, 1000})
+    ->Args({200, 100, 1000})
+    ->Args({512, 256, 1000})
+    ->Args({768, 256, 1000})
+    ->Args({1024, 256, 1000})
+    ->Args({1536, 384, 100})
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(BM_GemmAVX512, Float32)
+    ->Args({128, 64, 1000})
+    ->Args({200, 100, 1000})
+    ->Args({256, 128, 1000})
+    ->Args({300, 150, 1000})
+    ->Args({512, 256, 1000})
+    ->Args({768, 256, 1000})
+    ->Args({1024, 256, 1000})
+    ->Args({1024, 512, 100})
+    ->Args({1536, 384, 100})
+    ->Unit(benchmark::kMicrosecond);
+
+BENCHMARK_TEMPLATE(BM_GemmAVX512, Float64)
+    ->Args({128, 64, 1000})
+    ->Args({200, 100, 1000})
+    ->Args({512, 256, 1000})
+    ->Args({768, 256, 1000})
+    ->Args({1024, 256, 1000})
+    ->Args({1536, 384, 100})
+    ->Unit(benchmark::kMicrosecond);
+#endif
+
+BENCHMARK_MAIN();

--- a/src/Functions/tests/gtest_array_random_projection.cpp
+++ b/src/Functions/tests/gtest_array_random_projection.cpp
@@ -4,7 +4,7 @@
 
 using namespace DB;
 
-// Row-major GEMM: Y(N x D) = X(N x d) * P^T; P is D x d row-major.
+/// Row-major GEMM: Y(N x D) = X(N x d) * P^T; P is D x d row-major.
 template <typename T>
 void gemmSimple(const T * X, const T * P, T * Y, size_t N, size_t d, size_t D)
 {
@@ -124,7 +124,7 @@ TEST(ArrayRandomProjection, AchlioptasSparsity)
     EXPECT_NEAR(sparsity, 2.0 / 3.0, 0.02);
 }
 
-// Householder QR: Q^T Q ~ I.
+/// Householder QR: Q^T Q ~ I.
 TEST(ArrayRandomProjection, HouseholderQROrthogonalityFloat)
 {
     const size_t n = 8;
@@ -187,7 +187,7 @@ TEST(ArrayRandomProjection, HouseholderQROrthogonalityDouble)
     EXPECT_LT(max_error, 1e-10);
 }
 
-// Reconstruction: A ~ Q * R.
+/// Reconstruction: A ~ Q * R.
 TEST(ArrayRandomProjection, HouseholderQRFactorizationCorrectness)
 {
     const size_t n = 8;
@@ -224,7 +224,7 @@ TEST(ArrayRandomProjection, HouseholderQRFactorizationCorrectness)
     EXPECT_LT(max_error, 1e-4f);
 }
 
-// Leading D x d block P: P P^T ~ I.
+/// Leading D x d block P: P P^T ~ I.
 TEST(ArrayRandomProjection, OrthogonalProjectionProperty)
 {
     const size_t d = 16;
@@ -264,7 +264,7 @@ TEST(ArrayRandomProjection, OrthogonalProjectionProperty)
     EXPECT_LT(max_error, 1e-4f);
 }
 
-// OrthogonalProjectionState: P P^T ~ scale^2 * I (sqrt(n/D) scaling in state).
+/// OrthogonalProjectionState: P P^T ~ scale^2 * I (sqrt(n/D) scaling in state).
 TEST(ArrayRandomProjection, OrthogonalProjectionStatePipeline)
 {
     OrthogonalProjectionState<float> state;
@@ -290,7 +290,7 @@ TEST(ArrayRandomProjection, OrthogonalProjectionStatePipeline)
     EXPECT_LT(max_error, 0.1f);
 }
 
-// Gaussian random projection: average ||y|| / ||x|| ~ 1 (JL-style).
+/// Gaussian random projection: average ||y|| / ||x|| ~ 1 (JL-style).
 TEST(ArrayRandomProjection, NormalProjectionNormPreservation)
 {
     const size_t d = 64;
@@ -326,7 +326,7 @@ TEST(ArrayRandomProjection, NormalProjectionNormPreservation)
     EXPECT_NEAR(avg_ratio, 1.0, 0.15);
 }
 
-// GEMM: tiled scalar and SIMD dispatch match reference; odd d exercises tails.
+/// GEMM: tiled scalar and SIMD dispatch match reference; odd d exercises tails.
 TEST(ArrayRandomProjection, GEMMCorrectness)
 {
     const size_t n = 5;
@@ -363,7 +363,7 @@ TEST(ArrayRandomProjection, GEMMCorrectness)
         EXPECT_NEAR(y_dispatch[i], y_ref[i], 1e-4f) << "dispatch mismatch at index " << i;
 }
 
-// Large GEMM: SIMD main loop vs reference.
+/// Large GEMM: SIMD main loop vs reference.
 TEST(ArrayRandomProjection, GEMMCorrectnessLarge)
 {
     const size_t n = 10;
@@ -443,7 +443,7 @@ TEST(ArrayRandomProjection, HadamardProjectionDeterminism)
         EXPECT_FLOAT_EQ(out1[i], out2[i]);
 }
 
-// dotProduct: scalar vs dispatch for various sizes including SIMD boundaries.
+/// dotProduct: scalar vs dispatch for various sizes including SIMD boundaries.
 TEST(ArrayRandomProjection, DotProductScalarVsDispatch)
 {
     pcg64 rng(42);
@@ -476,7 +476,7 @@ TEST(ArrayRandomProjection, DotProductScalarVsDispatch)
     }
 }
 
-// axpy: scalar vs dispatch for various sizes.
+/// axpy: scalar vs dispatch for various sizes.
 TEST(ArrayRandomProjection, AxpyScalarVsDispatch)
 {
     pcg64 rng(42);
@@ -498,7 +498,7 @@ TEST(ArrayRandomProjection, AxpyScalarVsDispatch)
     }
 }
 
-// nextPowerOfTwo: edge cases.
+/// nextPowerOfTwo: edge cases.
 TEST(ArrayRandomProjection, NextPowerOfTwo)
 {
     EXPECT_EQ(nextPowerOfTwo(0), 1u);
@@ -515,12 +515,12 @@ TEST(ArrayRandomProjection, NextPowerOfTwo)
     EXPECT_EQ(nextPowerOfTwo(1025), 2048u);
 }
 
-// GEMM corner cases: N=1, d=1, D=1.
+/// GEMM corner cases: N=1, d=1, D=1.
 TEST(ArrayRandomProjection, GEMMCornerCases)
 {
     pcg64 rng(42);
 
-    // Single element: 1x1 * 1x1
+        /// Single element: 1x1 * 1x1
     {
         float x[] = {3.0f};
         float p[] = {2.0f};
@@ -532,7 +532,7 @@ TEST(ArrayRandomProjection, GEMMCornerCases)
         EXPECT_NEAR(y_got[0], 6.0f, 1e-6f);
     }
 
-    // Single row, multiple columns
+        /// Single row, multiple columns
     {
         const size_t d = 33;
         const size_t dd = 17;
@@ -552,7 +552,7 @@ TEST(ArrayRandomProjection, GEMMCornerCases)
             EXPECT_NEAR(y_got[i], y_ref[i], 1e-4f);
     }
 
-    // D=1: single output per row
+        /// D=1: single output per row
     {
         const size_t n = 10;
         const size_t d = 64;
@@ -573,7 +573,7 @@ TEST(ArrayRandomProjection, GEMMCornerCases)
     }
 }
 
-// GEMM Float64: dispatch vs reference.
+/// GEMM Float64: dispatch vs reference.
 TEST(ArrayRandomProjection, GEMMCorrectnessFloat64)
 {
     const size_t n = 5;
@@ -599,7 +599,7 @@ TEST(ArrayRandomProjection, GEMMCorrectnessFloat64)
         EXPECT_NEAR(y_got[i], y_ref[i], std::abs(y_ref[i]) * 1e-10 + 1e-12) << "i=" << i;
 }
 
-// Sparse projection: output is non-zero and has correct dimension.
+/// Sparse projection: output is non-zero and has correct dimension.
 TEST(ArrayRandomProjection, SparseProjectionCorrectness)
 {
     SparseProjectionState<float> state;
@@ -614,7 +614,7 @@ TEST(ArrayRandomProjection, SparseProjectionCorrectness)
         sum += std::abs(v);
     EXPECT_GT(sum, 0.0f);
 
-    // Zero input -> zero output
+    /// Zero input -> zero output
     std::vector<float> zero_input(64, 0.0f);
     std::vector<float> zero_output(16, 999.0f);
     applySparseProjection<float>(zero_input.data(), zero_output.data(), state);
@@ -623,7 +623,7 @@ TEST(ArrayRandomProjection, SparseProjectionCorrectness)
         EXPECT_FLOAT_EQ(zero_output[i], 0.0f);
 }
 
-// Hadamard projection: output is non-zero and has correct dimension.
+/// Hadamard projection: output is non-zero and has correct dimension.
 TEST(ArrayRandomProjection, HadamardProjectionCorrectness)
 {
     HadamardProjectionState<float> state;
@@ -640,7 +640,7 @@ TEST(ArrayRandomProjection, HadamardProjectionCorrectness)
         sum += std::abs(v);
     EXPECT_GT(sum, 0.0f);
 
-    // Non-power-of-2 input
+    /// Non-power-of-2 input
     HadamardProjectionState<float> state2;
     state2.generate(50, 10, 42);
     EXPECT_EQ(state2.padded_dim, 64u);
@@ -657,4 +657,26 @@ TEST(ArrayRandomProjection, HadamardProjectionCorrectness)
     for (auto v : output2)
         sum2 += std::abs(v);
     EXPECT_GT(sum2, 0.0f);
+}
+
+/// Test that the scratch-buffer overload of `applyHadamardProjection` gives identical results to the convenience overload.
+TEST(ArrayRandomProjection, HadamardProjectionScratchBuffer)
+{
+    HadamardProjectionState<float> state;
+    state.generate(64, 16, 42);
+
+    std::vector<float> input(64);
+    pcg64 rng(77);
+    for (auto & v : input)
+        v = boxMullerNormal<float>(rng);
+
+    std::vector<float> out_convenience(16);
+    applyHadamardProjection<float>(input.data(), out_convenience.data(), state);
+
+    std::vector<float> out_scratch(16);
+    std::vector<float> scratch(state.padded_dim);
+    applyHadamardProjection<float>(input.data(), out_scratch.data(), state, scratch.data());
+
+    for (size_t i = 0; i < 16; ++i)
+        EXPECT_FLOAT_EQ(out_scratch[i], out_convenience[i]);
 }

--- a/src/Functions/tests/gtest_array_random_projection.cpp
+++ b/src/Functions/tests/gtest_array_random_projection.cpp
@@ -1,0 +1,660 @@
+#include <gtest/gtest.h>
+
+#include <Functions/array/arrayRandomProjection.h>
+
+using namespace DB;
+
+// Row-major GEMM: Y(N x D) = X(N x d) * P^T; P is D x d row-major.
+template <typename T>
+void gemmSimple(const T * X, const T * P, T * Y, size_t N, size_t d, size_t D)
+{
+    for (size_t i = 0; i < N; ++i)
+        for (size_t j = 0; j < D; ++j)
+        {
+            T sum = T(0);
+            for (size_t k = 0; k < d; ++k)
+                sum += X[i * d + k] * P[j * d + k];
+            Y[i * D + j] = sum;
+        }
+}
+
+TEST(ArrayRandomProjection, FWHT4)
+{
+    {
+        float data[] = {1.0f, 0.0f, 0.0f, 0.0f};
+        fwht(data, 4);
+        EXPECT_FLOAT_EQ(data[0], 1.0f);
+        EXPECT_FLOAT_EQ(data[1], 1.0f);
+        EXPECT_FLOAT_EQ(data[2], 1.0f);
+        EXPECT_FLOAT_EQ(data[3], 1.0f);
+    }
+    {
+        float data[] = {1.0f, 1.0f, 1.0f, 1.0f};
+        fwht(data, 4);
+        EXPECT_FLOAT_EQ(data[0], 4.0f);
+        EXPECT_FLOAT_EQ(data[1], 0.0f);
+        EXPECT_FLOAT_EQ(data[2], 0.0f);
+        EXPECT_FLOAT_EQ(data[3], 0.0f);
+    }
+    {
+        float data[] = {1.0f, 2.0f, 3.0f, 4.0f};
+        fwht(data, 4);
+        EXPECT_FLOAT_EQ(data[0], 10.0f);
+        EXPECT_FLOAT_EQ(data[1], -2.0f);
+        EXPECT_FLOAT_EQ(data[2], -4.0f);
+        EXPECT_FLOAT_EQ(data[3], 0.0f);
+    }
+}
+
+TEST(ArrayRandomProjection, FWHT8)
+{
+    float data[] = {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+    fwht(data, 8);
+    for (float i : data)
+        EXPECT_FLOAT_EQ(i, 1.0f);
+}
+
+TEST(ArrayRandomProjection, FWHTInverse)
+{
+    float original[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f};
+    float data[8];
+    std::memcpy(data, original, sizeof(data));
+
+    fwht(data, 8);
+    fwht(data, 8);
+
+    for (int i = 0; i < 8; ++i)
+        EXPECT_FLOAT_EQ(data[i], 8.0f * original[i]);
+}
+
+TEST(ArrayRandomProjection, BoxMullerDistribution)
+{
+    pcg64 rng(12345);
+    const size_t n = 100000;
+    double sum = 0;
+    double sum_sq = 0;
+
+    for (size_t i = 0; i < n; ++i)
+    {
+        double val = boxMullerNormal<double>(rng);
+        sum += val;
+        sum_sq += val * val;
+    }
+
+    double mean = sum / n;
+    double variance = sum_sq / n - mean * mean;
+
+    EXPECT_NEAR(mean, 0.0, 0.02);
+    EXPECT_NEAR(variance, 1.0, 0.05);
+}
+
+TEST(ArrayRandomProjection, BoxMullerDeterminism)
+{
+    const size_t n = 100;
+
+    pcg64 rng1(42);
+    pcg64 rng2(42);
+
+    for (size_t i = 0; i < n; ++i)
+    {
+        float v1 = boxMullerNormal<float>(rng1);
+        float v2 = boxMullerNormal<float>(rng2);
+        EXPECT_FLOAT_EQ(v1, v2);
+    }
+}
+
+TEST(ArrayRandomProjection, AchlioptasSparsity)
+{
+    pcg64 rng(42);
+    std::uniform_int_distribution<int> dist6(0, 5);
+
+    const size_t target_dim = 1000;
+    const size_t input_dim = 1000;
+    size_t total = target_dim * input_dim;
+    size_t nonzero = 0;
+
+    for (size_t i = 0; i < total; ++i)
+    {
+        int val = dist6(rng);
+        if (val == 0 || val == 5)
+            ++nonzero;
+    }
+
+    double sparsity = 1.0 - static_cast<double>(nonzero) / static_cast<double>(total);
+    EXPECT_NEAR(sparsity, 2.0 / 3.0, 0.02);
+}
+
+// Householder QR: Q^T Q ~ I.
+TEST(ArrayRandomProjection, HouseholderQROrthogonalityFloat)
+{
+    const size_t n = 8;
+    pcg64 rng(42);
+
+    std::vector<float> g(n * n);
+    for (size_t i = 0; i < n; ++i)
+        for (size_t j = 0; j < n; ++j)
+            g[i + j * n] = boxMullerNormal<float>(rng);
+
+    std::vector<float> tau(n);
+    householderQR<float>(g.data(), tau.data(), n);
+
+    std::vector<float> q(n * n);
+    extractQ<float>(g.data(), tau.data(), q.data(), n);
+
+    float max_error = 0;
+    for (size_t i = 0; i < n; ++i)
+    {
+        for (size_t j = 0; j < n; ++j)
+        {
+            float dot = 0;
+            for (size_t k = 0; k < n; ++k)
+                dot += q[k + i * n] * q[k + j * n];
+            float expected = (i == j) ? 1.0f : 0.0f;
+            max_error = std::max(max_error, std::abs(dot - expected));
+        }
+    }
+    EXPECT_LT(max_error, 1e-4f);
+}
+
+TEST(ArrayRandomProjection, HouseholderQROrthogonalityDouble)
+{
+    const size_t n = 32;
+    pcg64 rng(99);
+
+    std::vector<double> g(n * n);
+    for (size_t i = 0; i < n; ++i)
+        for (size_t j = 0; j < n; ++j)
+            g[i + j * n] = boxMullerNormal<double>(rng);
+
+    std::vector<double> tau(n);
+    householderQR<double>(g.data(), tau.data(), n);
+
+    std::vector<double> q(n * n);
+    extractQ<double>(g.data(), tau.data(), q.data(), n);
+
+    double max_error = 0;
+    for (size_t i = 0; i < n; ++i)
+    {
+        for (size_t j = 0; j < n; ++j)
+        {
+            double dot = 0;
+            for (size_t k = 0; k < n; ++k)
+                dot += q[k + i * n] * q[k + j * n];
+            double expected = (i == j) ? 1.0 : 0.0;
+            max_error = std::max(max_error, std::abs(dot - expected));
+        }
+    }
+    EXPECT_LT(max_error, 1e-10);
+}
+
+// Reconstruction: A ~ Q * R.
+TEST(ArrayRandomProjection, HouseholderQRFactorizationCorrectness)
+{
+    const size_t n = 8;
+    pcg64 rng(77);
+
+    std::vector<float> a_orig(n * n);
+    for (size_t i = 0; i < n; ++i)
+        for (size_t j = 0; j < n; ++j)
+            a_orig[i + j * n] = boxMullerNormal<float>(rng);
+
+    std::vector<float> a(a_orig);
+    std::vector<float> tau(n);
+    householderQR<float>(a.data(), tau.data(), n);
+
+    std::vector<float> r(n * n, 0.0f);
+    for (size_t j = 0; j < n; ++j)
+        for (size_t i = 0; i <= j; ++i)
+            r[i + j * n] = a[i + j * n];
+
+    std::vector<float> q(n * n);
+    extractQ<float>(a.data(), tau.data(), q.data(), n);
+
+    float max_error = 0;
+    for (size_t j = 0; j < n; ++j)
+    {
+        for (size_t i = 0; i < n; ++i)
+        {
+            float val = 0;
+            for (size_t k = 0; k < n; ++k)
+                val += q[i + k * n] * r[k + j * n];
+            max_error = std::max(max_error, std::abs(val - a_orig[i + j * n]));
+        }
+    }
+    EXPECT_LT(max_error, 1e-4f);
+}
+
+// Leading D x d block P: P P^T ~ I.
+TEST(ArrayRandomProjection, OrthogonalProjectionProperty)
+{
+    const size_t d = 16;
+    const size_t target_dim = 8;
+    const size_t n = std::max(d, target_dim);
+
+    pcg64 rng(42);
+
+    std::vector<float> g(n * n);
+    for (size_t i = 0; i < n; ++i)
+        for (size_t j = 0; j < n; ++j)
+            g[i + j * n] = boxMullerNormal<float>(rng);
+
+    std::vector<float> tau(n);
+    householderQR<float>(g.data(), tau.data(), n);
+
+    std::vector<float> q(n * n);
+    extractQ<float>(g.data(), tau.data(), q.data(), n);
+
+    std::vector<float> p(target_dim * d);
+    for (size_t i = 0; i < target_dim; ++i)
+        for (size_t j = 0; j < d; ++j)
+            p[i * d + j] = q[i + j * n];
+
+    float max_error = 0;
+    for (size_t i = 0; i < target_dim; ++i)
+    {
+        for (size_t j = 0; j < target_dim; ++j)
+        {
+            float dot = 0;
+            for (size_t k = 0; k < d; ++k)
+                dot += p[i * d + k] * p[j * d + k];
+            float expected = (i == j) ? 1.0f : 0.0f;
+            max_error = std::max(max_error, std::abs(dot - expected));
+        }
+    }
+    EXPECT_LT(max_error, 1e-4f);
+}
+
+// OrthogonalProjectionState: P P^T ~ scale^2 * I (sqrt(n/D) scaling in state).
+TEST(ArrayRandomProjection, OrthogonalProjectionStatePipeline)
+{
+    OrthogonalProjectionState<float> state;
+    state.generate(64, 16, 42);
+
+    EXPECT_EQ(state.input_dim, 64u);
+    EXPECT_EQ(state.target_dim, 16u);
+    EXPECT_EQ(state.matrix.size(), 16u * 64u);
+
+    float expected_scale_sq = static_cast<float>(std::max(64u, 16u)) / 16.0f;
+    float max_error = 0;
+    for (size_t i = 0; i < 16; ++i)
+    {
+        for (size_t j = 0; j < 16; ++j)
+        {
+            float dot = 0;
+            for (size_t k = 0; k < 64; ++k)
+                dot += state.matrix[i * 64 + k] * state.matrix[j * 64 + k];
+            float expected = (i == j) ? expected_scale_sq : 0.0f;
+            max_error = std::max(max_error, std::abs(dot - expected));
+        }
+    }
+    EXPECT_LT(max_error, 0.1f);
+}
+
+// Gaussian random projection: average ||y|| / ||x|| ~ 1 (JL-style).
+TEST(ArrayRandomProjection, NormalProjectionNormPreservation)
+{
+    const size_t d = 64;
+    const size_t target_dim = 32;
+    const int num_vectors = 100;
+
+    pcg64 rng(42);
+
+    float scale = 1.0f / std::sqrt(static_cast<float>(target_dim));
+    std::vector<float> p(target_dim * d);
+    for (size_t i = 0; i < target_dim * d; ++i)
+        p[i] = boxMullerNormal<float>(rng) * scale;
+
+    pcg64 vec_rng(123);
+    double total_ratio = 0;
+    for (int v = 0; v < num_vectors; ++v)
+    {
+        std::vector<float> x(d);
+        for (size_t i = 0; i < d; ++i)
+            x[i] = boxMullerNormal<float>(vec_rng);
+
+        std::vector<float> y(target_dim);
+        gemmSimple<float>(x.data(), p.data(), y.data(), 1, d, target_dim);
+
+        float orig_norm = std::sqrt(dotProductScalar<float>(x.data(), x.data(), d));
+        float proj_norm = std::sqrt(dotProductScalar<float>(y.data(), y.data(), target_dim));
+
+        if (orig_norm > 1e-6f)
+            total_ratio += proj_norm / orig_norm;
+    }
+
+    double avg_ratio = total_ratio / num_vectors;
+    EXPECT_NEAR(avg_ratio, 1.0, 0.15);
+}
+
+// GEMM: tiled scalar and SIMD dispatch match reference; odd d exercises tails.
+TEST(ArrayRandomProjection, GEMMCorrectness)
+{
+    const size_t n = 5;
+    const size_t d = 17;
+    const size_t dd = 7;
+
+    pcg64 rng(42);
+
+    std::vector<float> x(n * d);
+    std::vector<float> p(dd * d);
+    for (auto & v : x)
+        v = boxMullerNormal<float>(rng);
+    for (auto & v : p)
+        v = boxMullerNormal<float>(rng);
+
+    std::vector<float> y_ref(n * dd);
+    gemmSimple<float>(x.data(), p.data(), y_ref.data(), n, d, dd);
+
+    float sum = 0;
+    for (auto v : y_ref)
+        sum += std::abs(v);
+    EXPECT_GT(sum, 0.0f);
+
+    std::vector<float> y_scalar(n * dd);
+    gemmBatchScalar<float>(x.data(), p.data(), y_scalar.data(), n, d, dd);
+
+    for (size_t i = 0; i < n * dd; ++i)
+        EXPECT_NEAR(y_scalar[i], y_ref[i], 1e-4f) << "scalar mismatch at index " << i;
+
+    std::vector<float> y_dispatch(n * dd);
+    applyDenseProjectionBatch<float>(x.data(), y_dispatch.data(), n, d, dd, p.data());
+
+    for (size_t i = 0; i < n * dd; ++i)
+        EXPECT_NEAR(y_dispatch[i], y_ref[i], 1e-4f) << "dispatch mismatch at index " << i;
+}
+
+// Large GEMM: SIMD main loop vs reference.
+TEST(ArrayRandomProjection, GEMMCorrectnessLarge)
+{
+    const size_t n = 10;
+    const size_t d = 128;
+    const size_t dd = 64;
+
+    pcg64 rng(123);
+
+    std::vector<float> x(n * d);
+    std::vector<float> p(dd * d);
+    for (auto & v : x)
+        v = boxMullerNormal<float>(rng);
+    for (auto & v : p)
+        v = boxMullerNormal<float>(rng);
+
+    std::vector<float> y_ref(n * dd);
+    gemmSimple<float>(x.data(), p.data(), y_ref.data(), n, d, dd);
+
+    std::vector<float> y_dispatch(n * dd);
+    applyDenseProjectionBatch<float>(x.data(), y_dispatch.data(), n, d, dd, p.data());
+
+    for (size_t i = 0; i < n * dd; ++i)
+        EXPECT_NEAR(y_dispatch[i], y_ref[i], 1e-2f) << "large GEMM mismatch at index " << i;
+}
+
+TEST(ArrayRandomProjection, NormalProjectionStateDeterminism)
+{
+    NormalProjectionState<float> s1;
+    NormalProjectionState<float> s2;
+    s1.generate(128, 32, 42);
+    s2.generate(128, 32, 42);
+
+    ASSERT_EQ(s1.matrix.size(), s2.matrix.size());
+    for (size_t i = 0; i < s1.matrix.size(); ++i)
+        EXPECT_FLOAT_EQ(s1.matrix[i], s2.matrix[i]);
+}
+
+TEST(ArrayRandomProjection, SparseProjectionDeterminism)
+{
+    SparseProjectionState<float> s1;
+    SparseProjectionState<float> s2;
+    s1.generate(64, 16, 42);
+    s2.generate(64, 16, 42);
+
+    std::vector<float> input(64);
+    pcg64 rng(99);
+    for (auto & v : input)
+        v = boxMullerNormal<float>(rng);
+
+    std::vector<float> out1(16);
+    std::vector<float> out2(16);
+    applySparseProjection<float>(input.data(), out1.data(), s1);
+    applySparseProjection<float>(input.data(), out2.data(), s2);
+
+    for (size_t i = 0; i < 16; ++i)
+        EXPECT_FLOAT_EQ(out1[i], out2[i]);
+}
+
+TEST(ArrayRandomProjection, HadamardProjectionDeterminism)
+{
+    HadamardProjectionState<float> s1;
+    HadamardProjectionState<float> s2;
+    s1.generate(64, 16, 42);
+    s2.generate(64, 16, 42);
+
+    std::vector<float> input(64);
+    pcg64 rng(99);
+    for (auto & v : input)
+        v = boxMullerNormal<float>(rng);
+
+    std::vector<float> out1(16);
+    std::vector<float> out2(16);
+    applyHadamardProjection<float>(input.data(), out1.data(), s1);
+    applyHadamardProjection<float>(input.data(), out2.data(), s2);
+
+    for (size_t i = 0; i < 16; ++i)
+        EXPECT_FLOAT_EQ(out1[i], out2[i]);
+}
+
+// dotProduct: scalar vs dispatch for various sizes including SIMD boundaries.
+TEST(ArrayRandomProjection, DotProductScalarVsDispatch)
+{
+    pcg64 rng(42);
+    for (size_t n : {0, 1, 3, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 128, 255, 256, 257})
+    {
+        std::vector<float> a(n);
+        std::vector<float> b(n);
+        for (auto & v : a)
+            v = boxMullerNormal<float>(rng);
+        for (auto & v : b)
+            v = boxMullerNormal<float>(rng);
+
+        float ref = dotProductScalar<float>(a.data(), b.data(), n);
+        float got = dotProductDispatch<float>(a.data(), b.data(), n);
+        EXPECT_NEAR(got, ref, std::abs(ref) * 1e-5f + 1e-7f) << "n=" << n;
+    }
+
+    for (size_t n : {0, 1, 3, 4, 7, 8, 9, 15, 16, 64, 128})
+    {
+        std::vector<double> a(n);
+        std::vector<double> b(n);
+        for (auto & v : a)
+            v = boxMullerNormal<double>(rng);
+        for (auto & v : b)
+            v = boxMullerNormal<double>(rng);
+
+        double ref = dotProductScalar<double>(a.data(), b.data(), n);
+        double got = dotProductDispatch<double>(a.data(), b.data(), n);
+        EXPECT_NEAR(got, ref, std::abs(ref) * 1e-12 + 1e-15) << "n=" << n;
+    }
+}
+
+// axpy: scalar vs dispatch for various sizes.
+TEST(ArrayRandomProjection, AxpyScalarVsDispatch)
+{
+    pcg64 rng(42);
+    for (size_t n : {0, 1, 7, 8, 9, 15, 16, 17, 32, 64, 128, 255})
+    {
+        std::vector<float> x(n);
+        for (auto & v : x)
+            v = boxMullerNormal<float>(rng);
+        float alpha = boxMullerNormal<float>(rng);
+
+        std::vector<float> y_ref(n, 1.0f);
+        std::vector<float> y_got(n, 1.0f);
+
+        axpyScalar<float>(y_ref.data(), x.data(), alpha, n);
+        axpyDispatch<float>(y_got.data(), x.data(), alpha, n);
+
+        for (size_t i = 0; i < n; ++i)
+            EXPECT_NEAR(y_got[i], y_ref[i], std::abs(y_ref[i]) * 1e-5f + 1e-7f) << "n=" << n << " i=" << i;
+    }
+}
+
+// nextPowerOfTwo: edge cases.
+TEST(ArrayRandomProjection, NextPowerOfTwo)
+{
+    EXPECT_EQ(nextPowerOfTwo(0), 1u);
+    EXPECT_EQ(nextPowerOfTwo(1), 1u);
+    EXPECT_EQ(nextPowerOfTwo(2), 2u);
+    EXPECT_EQ(nextPowerOfTwo(3), 4u);
+    EXPECT_EQ(nextPowerOfTwo(4), 4u);
+    EXPECT_EQ(nextPowerOfTwo(5), 8u);
+    EXPECT_EQ(nextPowerOfTwo(7), 8u);
+    EXPECT_EQ(nextPowerOfTwo(8), 8u);
+    EXPECT_EQ(nextPowerOfTwo(9), 16u);
+    EXPECT_EQ(nextPowerOfTwo(1023), 1024u);
+    EXPECT_EQ(nextPowerOfTwo(1024), 1024u);
+    EXPECT_EQ(nextPowerOfTwo(1025), 2048u);
+}
+
+// GEMM corner cases: N=1, d=1, D=1.
+TEST(ArrayRandomProjection, GEMMCornerCases)
+{
+    pcg64 rng(42);
+
+    // Single element: 1x1 * 1x1
+    {
+        float x[] = {3.0f};
+        float p[] = {2.0f};
+        float y_ref[1];
+        float y_got[1];
+        gemmSimple<float>(x, p, y_ref, 1, 1, 1);
+        applyDenseProjectionBatch<float>(x, y_got, 1, 1, 1, p);
+        EXPECT_NEAR(y_got[0], y_ref[0], 1e-6f);
+        EXPECT_NEAR(y_got[0], 6.0f, 1e-6f);
+    }
+
+    // Single row, multiple columns
+    {
+        const size_t d = 33;
+        const size_t dd = 17;
+        std::vector<float> x(d);
+        std::vector<float> p(dd * d);
+        for (auto & v : x)
+            v = boxMullerNormal<float>(rng);
+        for (auto & v : p)
+            v = boxMullerNormal<float>(rng);
+
+        std::vector<float> y_ref(dd);
+        std::vector<float> y_got(dd);
+        gemmSimple<float>(x.data(), p.data(), y_ref.data(), 1, d, dd);
+        applyDenseProjectionBatch<float>(x.data(), y_got.data(), 1, d, dd, p.data());
+
+        for (size_t i = 0; i < dd; ++i)
+            EXPECT_NEAR(y_got[i], y_ref[i], 1e-4f);
+    }
+
+    // D=1: single output per row
+    {
+        const size_t n = 10;
+        const size_t d = 64;
+        std::vector<float> x(n * d);
+        std::vector<float> p(d);
+        for (auto & v : x)
+            v = boxMullerNormal<float>(rng);
+        for (auto & v : p)
+            v = boxMullerNormal<float>(rng);
+
+        std::vector<float> y_ref(n);
+        std::vector<float> y_got(n);
+        gemmSimple<float>(x.data(), p.data(), y_ref.data(), n, d, 1);
+        applyDenseProjectionBatch<float>(x.data(), y_got.data(), n, d, 1, p.data());
+
+        for (size_t i = 0; i < n; ++i)
+            EXPECT_NEAR(y_got[i], y_ref[i], 1e-4f);
+    }
+}
+
+// GEMM Float64: dispatch vs reference.
+TEST(ArrayRandomProjection, GEMMCorrectnessFloat64)
+{
+    const size_t n = 5;
+    const size_t d = 33;
+    const size_t dd = 17;
+
+    pcg64 rng(42);
+
+    std::vector<double> x(n * d);
+    std::vector<double> p(dd * d);
+    for (auto & v : x)
+        v = boxMullerNormal<double>(rng);
+    for (auto & v : p)
+        v = boxMullerNormal<double>(rng);
+
+    std::vector<double> y_ref(n * dd);
+    gemmSimple<double>(x.data(), p.data(), y_ref.data(), n, d, dd);
+
+    std::vector<double> y_got(n * dd);
+    applyDenseProjectionBatch<double>(x.data(), y_got.data(), n, d, dd, p.data());
+
+    for (size_t i = 0; i < n * dd; ++i)
+        EXPECT_NEAR(y_got[i], y_ref[i], std::abs(y_ref[i]) * 1e-10 + 1e-12) << "i=" << i;
+}
+
+// Sparse projection: output is non-zero and has correct dimension.
+TEST(ArrayRandomProjection, SparseProjectionCorrectness)
+{
+    SparseProjectionState<float> state;
+    state.generate(64, 16, 42);
+
+    std::vector<float> input(64, 1.0f);
+    std::vector<float> output(16, 0.0f);
+    applySparseProjection<float>(input.data(), output.data(), state);
+
+    float sum = 0;
+    for (auto v : output)
+        sum += std::abs(v);
+    EXPECT_GT(sum, 0.0f);
+
+    // Zero input -> zero output
+    std::vector<float> zero_input(64, 0.0f);
+    std::vector<float> zero_output(16, 999.0f);
+    applySparseProjection<float>(zero_input.data(), zero_output.data(), state);
+
+    for (size_t i = 0; i < 16; ++i)
+        EXPECT_FLOAT_EQ(zero_output[i], 0.0f);
+}
+
+// Hadamard projection: output is non-zero and has correct dimension.
+TEST(ArrayRandomProjection, HadamardProjectionCorrectness)
+{
+    HadamardProjectionState<float> state;
+    state.generate(64, 16, 42);
+
+    EXPECT_EQ(state.padded_dim, 64u);
+
+    std::vector<float> input(64, 1.0f);
+    std::vector<float> output(16, 0.0f);
+    applyHadamardProjection<float>(input.data(), output.data(), state);
+
+    float sum = 0;
+    for (auto v : output)
+        sum += std::abs(v);
+    EXPECT_GT(sum, 0.0f);
+
+    // Non-power-of-2 input
+    HadamardProjectionState<float> state2;
+    state2.generate(50, 10, 42);
+    EXPECT_EQ(state2.padded_dim, 64u);
+
+    std::vector<float> input2(50);
+    pcg64 rng(99);
+    for (auto & v : input2)
+        v = boxMullerNormal<float>(rng);
+
+    std::vector<float> output2(10, 0.0f);
+    applyHadamardProjection<float>(input2.data(), output2.data(), state2);
+
+    float sum2 = 0;
+    for (auto v : output2)
+        sum2 += std::abs(v);
+    EXPECT_GT(sum2, 0.0f);
+}

--- a/src/Functions/tests/gtest_array_random_projection.cpp
+++ b/src/Functions/tests/gtest_array_random_projection.cpp
@@ -680,3 +680,124 @@ TEST(ArrayRandomProjection, HadamardProjectionScratchBuffer)
     for (size_t i = 0; i < 16; ++i)
         EXPECT_FLOAT_EQ(out_scratch[i], out_convenience[i]);
 }
+
+/// Normal upscaling: input_dim=8 -> target_dim=32.
+TEST(ArrayRandomProjection, NormalProjectionUpscaling)
+{
+    NormalProjectionState<float> state;
+    state.generate(8, 32, 42);
+
+    EXPECT_EQ(state.input_dim, 8u);
+    EXPECT_EQ(state.target_dim, 32u);
+    EXPECT_EQ(state.matrix.size(), 32u * 8u);
+
+    std::vector<float> input(8);
+    pcg64 rng(99);
+    for (auto & v : input)
+        v = boxMullerNormal<float>(rng);
+
+    std::vector<float> output(32);
+    applyDenseProjectionBatch<float>(input.data(), output.data(), 1, 8, 32, state.matrix.data());
+
+    float sum = 0;
+    for (auto v : output)
+        sum += std::abs(v);
+    EXPECT_GT(sum, 0.0f);
+}
+
+/// Orthogonal upscaling: input_dim=8 -> target_dim=32.
+TEST(ArrayRandomProjection, OrthogonalProjectionUpscaling)
+{
+    OrthogonalProjectionState<float> state;
+    state.generate(8, 32, 42);
+
+    EXPECT_EQ(state.input_dim, 8u);
+    EXPECT_EQ(state.target_dim, 32u);
+
+    std::vector<float> input(8);
+    pcg64 rng(99);
+    for (auto & v : input)
+        v = boxMullerNormal<float>(rng);
+
+    std::vector<float> output(32);
+    applyDenseProjectionBatch<float>(input.data(), output.data(), 1, 8, 32, state.matrix.data());
+
+    float sum = 0;
+    for (auto v : output)
+        sum += std::abs(v);
+    EXPECT_GT(sum, 0.0f);
+}
+
+/// Sparse upscaling: input_dim=8 -> target_dim=32.
+TEST(ArrayRandomProjection, SparseProjectionUpscaling)
+{
+    SparseProjectionState<float> state;
+    state.generate(8, 32, 42);
+
+    EXPECT_EQ(state.input_dim, 8u);
+    EXPECT_EQ(state.target_dim, 32u);
+
+    std::vector<float> input(8);
+    pcg64 rng(99);
+    for (auto & v : input)
+        v = boxMullerNormal<float>(rng);
+
+    std::vector<float> output(32);
+    applySparseProjection<float>(input.data(), output.data(), state);
+
+    float sum = 0;
+    for (auto v : output)
+        sum += std::abs(v);
+    EXPECT_GT(sum, 0.0f);
+}
+
+/// Hadamard upscaling: input_dim=8 -> target_dim=32, multiple SRHT blocks.
+TEST(ArrayRandomProjection, HadamardProjectionUpscaling)
+{
+    HadamardProjectionState<float> state;
+    state.generate(8, 32, 42);
+
+    EXPECT_EQ(state.input_dim, 8u);
+    EXPECT_EQ(state.target_dim, 32u);
+    EXPECT_EQ(state.padded_dim, 8u);
+    EXPECT_GT(state.blocks.size(), 1u);
+
+    std::vector<float> input(8);
+    pcg64 rng(99);
+    for (auto & v : input)
+        v = boxMullerNormal<float>(rng);
+
+    std::vector<float> output(32);
+    applyHadamardProjection<float>(input.data(), output.data(), state);
+
+    float sum = 0;
+    for (auto v : output)
+        sum += std::abs(v);
+    EXPECT_GT(sum, 0.0f);
+}
+
+/// GEMM upscaling: reference vs dispatch for target_dim > input_dim.
+TEST(ArrayRandomProjection, GEMMUpscaling)
+{
+    const size_t n = 5;
+    const size_t d = 8;
+    const size_t dd = 32;
+
+    pcg64 rng(42);
+
+    std::vector<float> x(n * d);
+    std::vector<float> p(dd * d);
+    for (auto & v : x)
+        v = boxMullerNormal<float>(rng);
+    for (auto & v : p)
+        v = boxMullerNormal<float>(rng);
+
+    std::vector<float> y_ref(n * dd);
+    gemmSimple<float>(x.data(), p.data(), y_ref.data(), n, d, dd);
+
+    std::vector<float> y_dispatch(n * dd);
+    applyDenseProjectionBatch<float>(x.data(), y_dispatch.data(), n, d, dd, p.data());
+
+    for (size_t i = 0; i < n * dd; ++i)
+        EXPECT_NEAR(y_dispatch[i], y_ref[i], 1e-4f) << "upscaling GEMM mismatch at index " << i;
+}

--- a/tests/queries/0_stateless/04051_array_random_projection.reference
+++ b/tests/queries/0_stateless/04051_array_random_projection.reference
@@ -1,0 +1,71 @@
+Normal downscale dim
+2
+Orthogonal downscale dim
+2
+Sparse downscale dim
+2
+Hadamard downscale dim
+2
+Normal upscale dim
+4
+Orthogonal upscale dim
+4
+Sparse upscale dim
+4
+Hadamard upscale dim
+4
+Determinism Normal
+1
+Determinism Orthogonal
+1
+Determinism Sparse
+1
+Determinism Hadamard
+1
+Different seeds Normal
+1
+Different seeds Orthogonal
+1
+Different seeds Sparse
+1
+Different seeds Hadamard
+1
+Float64 Normal
+2
+Array(Float64)
+Array(Float32)
+Float64 Orthogonal
+Array(Float64)
+Float64 Sparse
+Array(Float64)
+Float64 Hadamard
+Array(Float64)
+Table scan
+1	2
+2	2
+3	2
+Same dim
+4
+Distance preservation Normal
+1
+Distance preservation Orthogonal
+1
+Distance preservation Sparse
+1
+Distance preservation Hadamard
+1
+Batch Orthogonal
+2
+2
+Batch Sparse
+2
+2
+Batch Hadamard
+2
+2
+Large dim Normal
+16
+Large dim Hadamard
+16
+Hadamard non-power-of-2
+3

--- a/tests/queries/0_stateless/04051_array_random_projection.sql
+++ b/tests/queries/0_stateless/04051_array_random_projection.sql
@@ -1,0 +1,145 @@
+-- Test basic output dimensions (downscaling)
+SELECT 'Normal downscale dim';
+SELECT length(randomProjectionNormal([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 42));
+SELECT 'Orthogonal downscale dim';
+SELECT length(randomProjectionOrthogonal([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 42));
+SELECT 'Sparse downscale dim';
+SELECT length(randomProjectionSparse([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 42));
+SELECT 'Hadamard downscale dim';
+SELECT length(randomProjectionHadamard([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 42));
+
+-- Test basic output dimensions (upscaling)
+SELECT 'Normal upscale dim';
+SELECT length(randomProjectionNormal([1.0, 2.0]::Array(Float32), 4, 42));
+SELECT 'Orthogonal upscale dim';
+SELECT length(randomProjectionOrthogonal([1.0, 2.0]::Array(Float32), 4, 42));
+SELECT 'Sparse upscale dim';
+SELECT length(randomProjectionSparse([1.0, 2.0]::Array(Float32), 4, 42));
+SELECT 'Hadamard upscale dim';
+SELECT length(randomProjectionHadamard([1.0, 2.0]::Array(Float32), 4, 42));
+
+-- Test determinism: same seed produces same result
+SELECT 'Determinism Normal';
+SELECT randomProjectionNormal([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 42)
+     = randomProjectionNormal([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 42);
+SELECT 'Determinism Orthogonal';
+SELECT randomProjectionOrthogonal([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 42)
+     = randomProjectionOrthogonal([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 42);
+SELECT 'Determinism Sparse';
+SELECT randomProjectionSparse([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 42)
+     = randomProjectionSparse([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 42);
+SELECT 'Determinism Hadamard';
+SELECT randomProjectionHadamard([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 42)
+     = randomProjectionHadamard([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 42);
+
+-- Test different seeds produce different results (extremely unlikely to be equal)
+SELECT 'Different seeds Normal';
+SELECT randomProjectionNormal([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 42)
+    != randomProjectionNormal([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 99);
+SELECT 'Different seeds Orthogonal';
+SELECT randomProjectionOrthogonal([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 42)
+    != randomProjectionOrthogonal([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 99);
+SELECT 'Different seeds Sparse';
+SELECT randomProjectionSparse([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 42)
+    != randomProjectionSparse([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 99);
+SELECT 'Different seeds Hadamard';
+SELECT randomProjectionHadamard([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 42)
+    != randomProjectionHadamard([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 99);
+
+-- Test Float64 support for all methods
+SELECT 'Float64 Normal';
+SELECT length(randomProjectionNormal([1.0, 2.0, 3.0, 4.0]::Array(Float64), 2, 42));
+SELECT toTypeName(randomProjectionNormal([1.0, 2.0, 3.0, 4.0]::Array(Float64), 2, 42));
+SELECT toTypeName(randomProjectionNormal([1.0, 2.0, 3.0, 4.0]::Array(Float32), 2, 42));
+SELECT 'Float64 Orthogonal';
+SELECT toTypeName(randomProjectionOrthogonal([1.0, 2.0, 3.0, 4.0]::Array(Float64), 2, 42));
+SELECT 'Float64 Sparse';
+SELECT toTypeName(randomProjectionSparse([1.0, 2.0, 3.0, 4.0]::Array(Float64), 2, 42));
+SELECT 'Float64 Hadamard';
+SELECT toTypeName(randomProjectionHadamard([1.0, 2.0, 3.0, 4.0]::Array(Float64), 2, 42));
+
+-- Test multi-row scan via subquery
+SELECT 'Table scan';
+SELECT id, length(randomProjectionNormal(embedding, 2, 42))
+FROM (SELECT 1 AS id, [1.0, 2.0, 3.0, 4.0]::Array(Float32) AS embedding
+      UNION ALL SELECT 2, [5.0, 6.0, 7.0, 8.0]
+      UNION ALL SELECT 3, [9.0, 10.0, 11.0, 12.0])
+ORDER BY id;
+
+-- Test identity-like dimension (same dim)
+SELECT 'Same dim';
+SELECT length(randomProjectionNormal([1.0, 2.0, 3.0, 4.0]::Array(Float32), 4, 42));
+
+-- Test distance preservation for all methods (downscaling 8 -> 4)
+SELECT 'Distance preservation Normal';
+SELECT abs(
+    L2Distance(
+        randomProjectionNormal([1,0,0,0,0,0,0,0]::Array(Float32), 4, 123),
+        randomProjectionNormal([0,0,0,0,0,0,0,1]::Array(Float32), 4, 123)
+    ) - L2Distance([1,0,0,0,0,0,0,0]::Array(Float32), [0,0,0,0,0,0,0,1]::Array(Float32))
+) < 2.0;
+SELECT 'Distance preservation Orthogonal';
+SELECT abs(
+    L2Distance(
+        randomProjectionOrthogonal([1,0,0,0,0,0,0,0]::Array(Float32), 4, 123),
+        randomProjectionOrthogonal([0,0,0,0,0,0,0,1]::Array(Float32), 4, 123)
+    ) - L2Distance([1,0,0,0,0,0,0,0]::Array(Float32), [0,0,0,0,0,0,0,1]::Array(Float32))
+) < 2.0;
+SELECT 'Distance preservation Sparse';
+SELECT abs(
+    L2Distance(
+        randomProjectionSparse([1,0,0,0,0,0,0,0]::Array(Float32), 4, 123),
+        randomProjectionSparse([0,0,0,0,0,0,0,1]::Array(Float32), 4, 123)
+    ) - L2Distance([1,0,0,0,0,0,0,0]::Array(Float32), [0,0,0,0,0,0,0,1]::Array(Float32))
+) < 2.0;
+SELECT 'Distance preservation Hadamard';
+SELECT abs(
+    L2Distance(
+        randomProjectionHadamard([1,0,0,0,0,0,0,0]::Array(Float32), 4, 123),
+        randomProjectionHadamard([0,0,0,0,0,0,0,1]::Array(Float32), 4, 123)
+    ) - L2Distance([1,0,0,0,0,0,0,0]::Array(Float32), [0,0,0,0,0,0,0,1]::Array(Float32))
+) < 2.0;
+
+-- Test multi-row batch for non-Normal methods
+SELECT 'Batch Orthogonal';
+SELECT length(randomProjectionOrthogonal(embedding, 2, 42))
+FROM (SELECT [1.0, 2.0, 3.0, 4.0]::Array(Float32) AS embedding
+      UNION ALL SELECT [5.0, 6.0, 7.0, 8.0]);
+SELECT 'Batch Sparse';
+SELECT length(randomProjectionSparse(embedding, 2, 42))
+FROM (SELECT [1.0, 2.0, 3.0, 4.0]::Array(Float32) AS embedding
+      UNION ALL SELECT [5.0, 6.0, 7.0, 8.0]);
+SELECT 'Batch Hadamard';
+SELECT length(randomProjectionHadamard(embedding, 2, 42))
+FROM (SELECT [1.0, 2.0, 3.0, 4.0]::Array(Float32) AS embedding
+      UNION ALL SELECT [5.0, 6.0, 7.0, 8.0]);
+
+-- Test larger dimensions (exercises SIMD main loops, d=64 > AVX512 width)
+SELECT 'Large dim Normal';
+SELECT length(randomProjectionNormal(arrayMap(x -> toFloat32(x), range(64)), 16, 42));
+SELECT 'Large dim Hadamard';
+SELECT length(randomProjectionHadamard(arrayMap(x -> toFloat32(x), range(64)), 16, 42));
+
+-- Test error: non-const target_dim
+SELECT randomProjectionNormal([1.0, 2.0]::Array(Float32), number, 42) FROM numbers(1); -- { serverError ILLEGAL_COLUMN }
+
+-- Test error: non-const seed
+SELECT randomProjectionNormal([1.0, 2.0]::Array(Float32), 2, number) FROM numbers(1); -- { serverError ILLEGAL_COLUMN }
+
+-- Test error: non-array input
+SELECT randomProjectionNormal(42, 2, 42); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+-- Test error: wrong array element type
+SELECT randomProjectionNormal([1, 2, 3]::Array(UInt8), 2, 42); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+-- Test error: target_dim = 0
+SELECT randomProjectionNormal([1.0, 2.0]::Array(Float32), 0, 42); -- { serverError BAD_ARGUMENTS }
+
+-- Test error: mismatched array dimensions in batch
+SELECT randomProjectionNormal(embedding, 2, 42)
+FROM (SELECT [1.0, 2.0, 3.0, 4.0]::Array(Float32) AS embedding
+      UNION ALL SELECT [1.0, 2.0, 3.0]); -- { serverError SIZES_OF_ARRAYS_DONT_MATCH }
+
+-- Test Hadamard with non-power-of-2 input dimension
+SELECT 'Hadamard non-power-of-2';
+SELECT length(randomProjectionHadamard([1.0, 2.0, 3.0, 4.0, 5.0]::Array(Float32), 3, 42));


### PR DESCRIPTION
### Functions for changing dimensionality #91169 

Add four SQL functions for random projections of vector embeddings:
- `randomProjectionNormal` — dense Gaussian random matrix
- `randomProjectionOrthogonal` — orthogonal matrix via Householder QR
- `randomProjectionSparse` — sparse Achlioptas matrix (+-1 with probability 1/6)
- `randomProjectionHadamard` — Subsampled Randomized Hadamard Transform (SRHT)

All functions support both downscaling and upscaling, Float32/Float64, and are deterministic given the same seed. Dense projections (Normal, Orthogonal) are SIMD-accelerated with hand-written AVX2/AVX-512 GEMM using j-unroll by 4 with independent FMA accumulators.

### Changelog category:
- New Feature