### PR TITLE
Fix flaky test_server_reload/test_change_listen_host under coverage

### DIFF
--- a/tests/integration/test_server_reload/test.py
+++ b/tests/integration/test_server_reload/test.py
@@ -167,7 +167,7 @@ def sync_loaded_config(querier):
 def wait_loaded_config_changed(loads_before, querier):
     loads_after = None
     start_time = time.monotonic()
-    while time.monotonic() - start_time < 10:
+    while time.monotonic() - start_time < 60:
         try:
             loads_after = querier(LOADS_QUERY)
             if loads_after != loads_before:


### PR DESCRIPTION
Increase the timeout in `wait_loaded_config_changed` from 10 to 60 seconds.

The ZK-based config reload path relies entirely on ZK watches — the periodic 2-second file check does not cover ZK-only changes. Under coverage builds, the end-to-end latency (ZK watch delivery, background thread scheduling, config reload with socket rebinding) can exceed 10 seconds, causing the test to flake.

The polling loop exits immediately once the counter changes, so the increased timeout has no impact on the happy path.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=101092&sha=246d165cac385dac5d10b74e71cddf422fec5a5e&name_0=PR&name_1=Integration%20tests%20%28amd_llvm_coverage%2C%205%2F5%29
https://github.com/ClickHouse/ClickHouse/pull/101092

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.400`
<!-- ch-version-info:end -->