### PR TITLE
Added `max_replicated_table_num_to_warn` similar to `max_table_num_to…

### DIFF
--- a/docs/en/operations/system-tables/system_warnings.md
+++ b/docs/en/operations/system-tables/system_warnings.md
@@ -20,6 +20,7 @@ If current value drops below the threshold, the entry is removed from the table.
 The table can be configured with these settings:
 
 - [max_table_num_to_warn](../server-configuration-parameters/settings.md#max_table_num_to_warn)
+- [max_replicated_table_num_to_warn](../server-configuration-parameters/settings.md#max_replicated_table_num_to_warn)
 - [max_database_num_to_warn](../server-configuration-parameters/settings.md#max_database_num_to_warn)
 - [max_dictionary_num_to_warn](../server-configuration-parameters/settings.md#max_dictionary_num_to_warn)
 - [max_view_num_to_warn](../server-configuration-parameters/settings.md#max_view_num_to_warn)

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -308,6 +308,7 @@ namespace ServerSetting
     extern const ServerSettingsUInt64 max_server_memory_usage;
     extern const ServerSettingsDouble max_server_memory_usage_to_ram_ratio;
     extern const ServerSettingsUInt64 max_table_num_to_warn;
+    extern const ServerSettingsUInt64 max_replicated_table_num_to_warn;
     extern const ServerSettingsUInt64 max_table_size_to_drop;
     extern const ServerSettingsUInt64 max_temporary_data_on_disk_size;
     extern const ServerSettingsUInt64 max_thread_pool_free_size;
@@ -2272,6 +2273,7 @@ try
             global_context->setMaxPartitionSizeToDrop(new_server_settings[ServerSetting::max_partition_size_to_drop]);
             global_context->setMaxNamedCollectionNumToWarn(new_server_settings[ServerSetting::max_named_collection_num_to_warn]);
             global_context->setMaxTableNumToWarn(new_server_settings[ServerSetting::max_table_num_to_warn]);
+            global_context->setMaxReplicatedTableNumToWarn(new_server_settings[ServerSetting::max_replicated_table_num_to_warn]);
             global_context->setMaxViewNumToWarn(new_server_settings[ServerSetting::max_view_num_to_warn]);
             global_context->setMaxDictionaryNumToWarn(new_server_settings[ServerSetting::max_dictionary_num_to_warn]);
             global_context->setMaxDatabaseNumToWarn(new_server_settings[ServerSetting::max_database_num_to_warn]);

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -684,6 +684,15 @@ namespace
     <max_table_num_to_warn>400</max_table_num_to_warn>
     ```
     )", 0) \
+    DECLARE(UInt64, max_replicated_table_num_to_warn, 3000lu, R"(
+    If the number of attached replicated tables exceeds the specified value, clickhouse server will add warning messages to `system.warnings` table.
+
+    **Example**
+
+    ```xml
+    <max_replicated_table_num_to_warn>400</max_replicated_table_num_to_warn>
+    ```
+    )", 0) \
     DECLARE(UInt64, max_pending_mutations_to_warn, 500lu, R"(
     If the number of pending mutations exceeds the specified value, clickhouse server will add warning messages to `system.warnings` table.
 
@@ -1718,6 +1727,7 @@ void ServerSettings::dumpToSystemServerSettingsColumns(ServerSettingColumnsParam
             {"max_table_size_to_drop", {std::to_string(context->getMaxTableSizeToDrop()), ChangeableWithoutRestart::Yes}},
             {"max_named_collection_num_to_warn", {std::to_string(context->getMaxNamedCollectionNumToWarn()), ChangeableWithoutRestart::Yes}},
             {"max_table_num_to_warn", {std::to_string(context->getMaxTableNumToWarn()), ChangeableWithoutRestart::Yes}},
+            {"max_replicated_table_num_to_warn", {std::to_string(context->getMaxReplicatedTableNumToWarn()), ChangeableWithoutRestart::Yes}},
             {"max_view_num_to_warn", {std::to_string(context->getMaxViewNumToWarn()), ChangeableWithoutRestart::Yes}},
             {"max_dictionary_num_to_warn", {std::to_string(context->getMaxDictionaryNumToWarn()), ChangeableWithoutRestart::Yes}},
             {"max_database_num_to_warn", {std::to_string(context->getMaxDatabaseNumToWarn()), ChangeableWithoutRestart::Yes}},

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -244,6 +244,7 @@ namespace CurrentMetrics
     extern const Metric BuildVectorSimilarityIndexThreadsActive;
     extern const Metric BuildVectorSimilarityIndexThreadsScheduled;
     extern const Metric AttachedTable;
+    extern const Metric AttachedReplicatedTable;
     extern const Metric AttachedView;
     extern const Metric AttachedDictionary;
     extern const Metric AttachedDatabase;
@@ -389,6 +390,7 @@ namespace ServerSetting
     extern const ServerSettingsInt32 os_threads_nice_value_zookeeper_client_send_receive;
     extern const ServerSettingsBool enforce_keeper_component_tracking;
     extern const ServerSettingsUInt64 max_table_num_to_throw;
+    extern const ServerSettingsUInt64 max_replicated_table_num_to_throw;
     extern const ServerSettingsUInt64 max_view_num_to_throw;
     extern const ServerSettingsUInt64 max_dictionary_num_to_throw;
     extern const ServerSettingsUInt64 max_database_num_to_throw;
@@ -638,6 +640,7 @@ struct ContextSharedPart : boost::noncopyable
     std::atomic_size_t max_database_num_to_warn = 1000lu;
     std::atomic_size_t max_named_collection_num_to_warn = 1000lu;
     std::atomic_size_t max_table_num_to_warn = 5000lu;
+    std::atomic_size_t max_replicated_table_num_to_warn = 3000lu;
     std::atomic_size_t max_view_num_to_warn = 10000lu;
     std::atomic_size_t max_dictionary_num_to_warn = 1000lu;
     std::atomic_size_t max_part_num_to_warn = 100000lu;
@@ -1446,6 +1449,7 @@ std::unordered_map<Context::WarningType, PreformattedMessage> Context::getWarnin
         common_warnings = shared->warnings;
 
         auto attached_tables = CurrentMetrics::get(CurrentMetrics::AttachedTable);
+        auto attached_replicated_tables = CurrentMetrics::get(CurrentMetrics::AttachedReplicatedTable);
         auto attached_views = CurrentMetrics::get(CurrentMetrics::AttachedView);
         auto attached_dictionaries = CurrentMetrics::get(CurrentMetrics::AttachedDictionary);
         auto attached_databases = CurrentMetrics::get(CurrentMetrics::AttachedDatabase);
@@ -1462,6 +1466,18 @@ std::unordered_map<Context::WarningType, PreformattedMessage> Context::getWarnin
                 common_warnings[Context::WarningType::MAX_ATTACHED_TABLES] = PreformattedMessage::create(
                     "The number of attached tables ({}) exceeds the warning limit of {}.",
                     attached_tables, shared->max_table_num_to_warn.load());
+        }
+
+        if (attached_replicated_tables > static_cast<Int64>(shared->max_replicated_table_num_to_warn))
+        {
+            if (auto limit = shared->server_settings[ServerSetting::max_replicated_table_num_to_throw]; limit > shared->max_replicated_table_num_to_warn.load())
+                common_warnings[Context::WarningType::MAX_ATTACHED_REPLICATED_TABLES] = PreformattedMessage::create(
+                    "The number of attached replicated tables ({}) exceeds the warning limit of {}. You will not be able to create new replicated tables once the limit of {} is reached.",
+                    attached_tables, shared->max_replicated_table_num_to_warn.load(), limit.value);
+            else
+                common_warnings[Context::WarningType::MAX_ATTACHED_REPLICATED_TABLES] = PreformattedMessage::create(
+                    "The number of attached replicated tables ({}) exceeds the warning limit of {}.",
+                    attached_tables, shared->max_replicated_table_num_to_warn.load());
         }
 
         if (attached_views > static_cast<Int64>(shared->max_view_num_to_warn))
@@ -5527,6 +5543,12 @@ size_t Context::getMaxTableNumToWarn() const
     return shared->max_table_num_to_warn;
 }
 
+size_t Context::getMaxReplicatedTableNumToWarn() const
+{
+    SharedLockGuard lock(shared->mutex);
+    return shared->max_replicated_table_num_to_warn;
+}
+
 size_t Context::getMaxViewNumToWarn() const
 {
     SharedLockGuard lock(shared->mutex);
@@ -5573,6 +5595,12 @@ void Context::setMaxTableNumToWarn(size_t max_table_to_warn)
 {
     std::lock_guard lock(shared->mutex);
     shared->max_table_num_to_warn = max_table_to_warn;
+}
+
+void Context::setMaxReplicatedTableNumToWarn(size_t max_replicated_table_to_warn)
+{
+    std::lock_guard lock(shared->mutex);
+    shared->max_replicated_table_num_to_warn = max_replicated_table_to_warn;
 }
 
 void Context::setMaxViewNumToWarn(size_t max_view_to_warn)

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -752,6 +752,7 @@ public:
         MAX_ATTACHED_DATABASES,
         MAX_ATTACHED_DICTIONARIES,
         MAX_ATTACHED_TABLES,
+        MAX_ATTACHED_REPLICATED_TABLES,
         MAX_ATTACHED_VIEWS,
         MAX_NAMED_COLLECTIONS,
         MAX_NUM_THREADS_LOWER_THAN_LIMIT,
@@ -1183,6 +1184,7 @@ public:
 
     size_t getMaxNamedCollectionNumToWarn() const;
     size_t getMaxTableNumToWarn() const;
+    size_t getMaxReplicatedTableNumToWarn() const;
     size_t getMaxViewNumToWarn() const;
     size_t getMaxDictionaryNumToWarn() const;
     size_t getMaxDatabaseNumToWarn() const;
@@ -1192,6 +1194,7 @@ public:
 
     void setMaxNamedCollectionNumToWarn(size_t max_named_collection_to_warn);
     void setMaxTableNumToWarn(size_t max_table_to_warn);
+    void setMaxReplicatedTableNumToWarn(size_t max_replicated_table_to_warn);
     void setMaxViewNumToWarn(size_t max_view_to_warn);
     void setMaxDictionaryNumToWarn(size_t max_dictionary_to_warn);
     void setMaxDatabaseNumToWarn(size_t max_database_to_warn);

--- a/tests/config/config.d/max_num_to_warn.xml
+++ b/tests/config/config.d/max_num_to_warn.xml
@@ -1,5 +1,6 @@
 <clickhouse>
     <max_table_num_to_warn>5</max_table_num_to_warn>
+    <max_replicated_table_num_to_warn>3</max_replicated_table_num_to_warn>
     <max_view_num_to_warn>5</max_view_num_to_warn>
     <max_dictionary_num_to_warn>5</max_dictionary_num_to_warn>
     <max_database_num_to_warn>2</max_database_num_to_warn>

--- a/tests/integration/test_table_db_num_limit/config/config.xml
+++ b/tests/integration/test_table_db_num_limit/config/config.xml
@@ -20,6 +20,9 @@
     <max_table_num_to_warn>5</max_table_num_to_warn>
     <max_table_num_to_throw>10</max_table_num_to_throw>
 
+    <max_replicated_table_num_to_warn>3</max_replicated_table_num_to_warn>
+    <max_replicated_table_num_to_throw>5</max_replicated_table_num_to_throw>
+
     <max_view_num_to_warn>5</max_view_num_to_warn>
     <max_view_num_to_throw>10</max_view_num_to_throw>
 

--- a/tests/queries/0_stateless/02931_max_num_to_warn.reference
+++ b/tests/queries/0_stateless/02931_max_num_to_warn.reference
@@ -2,4 +2,5 @@ The number of active parts _ exceeds the warning limit of 10.	The number of acti
 The number of attached databases _ exceeds the warning limit of 2.	The number of attached databases ({}) exceeds the warning limit of {}.
 The number of attached dictionaries _ exceeds the warning limit of 5.	The number of attached dictionaries ({}) exceeds the warning limit of {}.
 The number of attached tables _ exceeds the warning limit of 5.	The number of attached tables ({}) exceeds the warning limit of {}.
+The number of attached replicated tables _ exceeds the warning limit of 5.	The number of attached replicated tables ({}) exceeds the warning limit of {}.
 The number of attached views _ exceeds the warning limit of 5.	The number of attached views ({}) exceeds the warning limit of {}.

--- a/tests/queries/0_stateless/02931_max_num_to_warn.sql
+++ b/tests/queries/0_stateless/02931_max_num_to_warn.sql
@@ -1,4 +1,4 @@
--- Tags: no-parallel
+-- Tags: no-parallel, zookeeper
 
 CREATE DATABASE IF NOT EXISTS test_max_num_to_warn_02931;
 CREATE TABLE IF NOT EXISTS test_max_num_to_warn_02931.test_max_num_to_warn_1 (id Int32, str String) Engine=Memory;
@@ -12,6 +12,18 @@ CREATE TABLE IF NOT EXISTS test_max_num_to_warn_02931.test_max_num_to_warn_8 (id
 CREATE TABLE IF NOT EXISTS test_max_num_to_warn_02931.test_max_num_to_warn_9 (id Int32, str String) Engine=Memory;
 CREATE TABLE IF NOT EXISTS test_max_num_to_warn_02931.test_max_num_to_warn_10 (id Int32, str String) Engine=Memory;
 CREATE TABLE IF NOT EXISTS test_max_num_to_warn_02931.test_max_num_to_warn_11 (id Int32, str String) Engine=Memory;
+
+CREATE TABLE IF NOT EXISTS test_max_num_to_warn_02931.test_max_num_to_warn_1 (id Int32, str String) Engine=ReplicatedMergeTree('/clickhouse/test_max_num_to_warn_02931/{database}/{table}', '1') ORDER BY id;
+CREATE TABLE IF NOT EXISTS test_max_num_to_warn_02931.test_max_num_to_warn_2 (id Int32, str String) Engine=ReplicatedMergeTree('/clickhouse/test_max_num_to_warn_02931/{database}/{table}', '1') ORDER BY id;
+CREATE TABLE IF NOT EXISTS test_max_num_to_warn_02931.test_max_num_to_warn_3 (id Int32, str String) Engine=ReplicatedMergeTree('/clickhouse/test_max_num_to_warn_02931/{database}/{table}', '1') ORDER BY id;
+CREATE TABLE IF NOT EXISTS test_max_num_to_warn_02931.test_max_num_to_warn_4 (id Int32, str String) Engine=ReplicatedMergeTree('/clickhouse/test_max_num_to_warn_02931/{database}/{table}', '1') ORDER BY id;
+CREATE TABLE IF NOT EXISTS test_max_num_to_warn_02931.test_max_num_to_warn_5 (id Int32, str String) Engine=ReplicatedMergeTree('/clickhouse/test_max_num_to_warn_02931/{database}/{table}', '1') ORDER BY id;
+CREATE TABLE IF NOT EXISTS test_max_num_to_warn_02931.test_max_num_to_warn_6 (id Int32, str String) Engine=ReplicatedMergeTree('/clickhouse/test_max_num_to_warn_02931/{database}/{table}', '1') ORDER BY id;
+CREATE TABLE IF NOT EXISTS test_max_num_to_warn_02931.test_max_num_to_warn_7 (id Int32, str String) Engine=ReplicatedMergeTree('/clickhouse/test_max_num_to_warn_02931/{database}/{table}', '1') ORDER BY id;
+CREATE TABLE IF NOT EXISTS test_max_num_to_warn_02931.test_max_num_to_warn_8 (id Int32, str String) Engine=ReplicatedMergeTree('/clickhouse/test_max_num_to_warn_02931/{database}/{table}', '1') ORDER BY id;
+CREATE TABLE IF NOT EXISTS test_max_num_to_warn_02931.test_max_num_to_warn_9 (id Int32, str String) Engine=ReplicatedMergeTree('/clickhouse/test_max_num_to_warn_02931/{database}/{table}', '1') ORDER BY id;
+CREATE TABLE IF NOT EXISTS test_max_num_to_warn_02931.test_max_num_to_warn_10 (id Int32, str String) Engine=ReplicatedMergeTree('/clickhouse/test_max_num_to_warn_02931/{database}/{table}', '1') ORDER BY id;
+CREATE TABLE IF NOT EXISTS test_max_num_to_warn_02931.test_max_num_to_warn_11 (id Int32, str String) Engine=ReplicatedMergeTree('/clickhouse/test_max_num_to_warn_02931/{database}/{table}', '1') ORDER BY id;
 
 CREATE VIEW IF NOT EXISTS test_max_num_to_warn_02931.test_max_num_to_warn_view_1 AS SELECT * FROM test_max_num_to_warn_02931.test_max_num_to_warn_1;
 CREATE VIEW IF NOT EXISTS test_max_num_to_warn_02931.test_max_num_to_warn_view_2 AS SELECT * FROM test_max_num_to_warn_02931.test_max_num_to_warn_2;


### PR DESCRIPTION
…_warn` / `max_table_num_to_throw`.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
