### PR TITLE
Fix null pointer dereference in `TableFunctionMergeTreeAnalyzeIndexes::parseArgumentsForOptimizations`

### DIFF
--- a/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
+++ b/src/TableFunctions/TableFunctionMergeTreeAnalyzeIndexes.cpp
@@ -194,7 +194,11 @@ void TableFunctionMergeTreeAnalyzeIndexes::parseArgumentsForOptimizations(const 
         if (optimization == "vector_search_index_analysis")
         {
             auto cast_node = args[4]->children.at(0);
-            auto vector_search_args = cast_node->children.at(0)->as<ASTLiteral>()->value.safeGet<Array>();
+            const auto * literal = cast_node->children.at(0)->as<ASTLiteral>();
+            if (!literal)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "vector_search_index_analysis expects a literal tuple argument");
+            auto vector_search_args = literal->value.safeGet<Array>();
             if (vector_search_args.size() != 6)
                 throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
                     "vector_search_index_analysis requires 6 arguments");


### PR DESCRIPTION
The `as<ASTLiteral>()` call can return nullptr when the AST fuzzer generates non-literal arguments for `vector_search_index_analysis`. Add a null check to throw a proper exception instead.

Found in: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100941&sha=9b5c05a71c343cc54616570d969b14b555b83f79&name_0=PR&name_1=Stress%20test%20%28arm_asan_ubsan%2C%20s3%29
https://github.com/ClickHouse/ClickHouse/pull/100941

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)
