### PR TITLE
Refactor projection settings: replace optional fields with generic SettingsChanges

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -784,7 +784,7 @@ InterpreterCreateQuery::TableProperties InterpreterCreateQuery::getTableProperti
         if (create.columns_list->projections)
             for (const auto & projection_ast : create.columns_list->projections->children)
             {
-                auto projection = ProjectionDescription::getProjectionFromAST(projection_ast, properties.columns, nullptr, getContext());
+                auto projection = ProjectionDescription::getProjectionFromAST(projection_ast, properties.columns, nullptr, getContext(), mode);
                 properties.projections.add(std::move(projection));
             }
 

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -878,7 +878,8 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context)
     }
     else if (type == ADD_PROJECTION)
     {
-        auto projection = ProjectionDescription::getProjectionFromAST(projection_decl, metadata.columns, &metadata.partition_key, context);
+        auto projection = ProjectionDescription::getProjectionFromAST(
+            projection_decl, metadata.columns, &metadata.partition_key, context, LoadingStrictnessLevel::CREATE);
         metadata.projections.add(std::move(projection), after_projection_name, first, if_not_exists);
     }
     else if (type == DROP_PROJECTION)

--- a/src/Storages/MergeTree/MergeTask.h
+++ b/src/Storages/MergeTree/MergeTask.h
@@ -138,7 +138,8 @@ public:
             global_ctx->suffix = std::move(suffix_);
             global_ctx->merging_params = std::move(merging_params_);
 
-            global_ctx->data_settings = global_ctx->data->getSettings(global_ctx->projection);
+            global_ctx->data_settings
+                = global_ctx->data->getSettings(global_ctx->projection ? &global_ctx->projection->settings_changes : nullptr);
 
             auto prepare_stage_ctx = std::make_shared<ExecuteAndFinalizeHorizontalPartRuntimeContext>();
             (*stages.begin())->setRuntimeContext(std::move(prepare_stage_ctx), global_ctx);

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1121,16 +1121,13 @@ void MergeTreeData::checkProperties(
                 true /* allow_nullable_key */,
                 local_context);
 
-            if (projection.index_granularity || projection.index_granularity_bytes)
+            if (!canUseAdaptiveGranularity() && projection.has_index_granularity_overrides)
             {
-                if (!canUseAdaptiveGranularity())
-                {
-                    throw Exception(
-                        ErrorCodes::SUPPORT_IS_DISABLED,
-                        "Projection {} specifies index_granularity-related overrides, but the parent table uses fixed granularity. "
-                        "Such overrides are supported with adaptive granularity (e.g. index_granularity_bytes > 0)",
-                        projection.name);
-                }
+                throw Exception(
+                    ErrorCodes::SUPPORT_IS_DISABLED,
+                    "Projection {} specifies index_granularity-related overrides, but the parent table uses fixed granularity. "
+                    "Such overrides are supported with adaptive granularity (e.g. index_granularity_bytes > 0)",
+                    projection.name);
             }
             projections_names.insert(projection.name);
         }
@@ -4971,7 +4968,7 @@ MergeTreeDataPartFormat MergeTreeData::choosePartFormat(
     using PartStorageType = MergeTreeDataPartStorageType;
 
     String out_reason;
-    const auto settings = getSettings(projection);
+    const auto settings = getSettings(projection ? &projection->settings_changes : nullptr);
     if (!canUsePolymorphicParts(*settings, out_reason))
         return {PartType::Wide, PartStorageType::Full};
 
@@ -10697,23 +10694,17 @@ MergeTreeData::PartsSnapshotInfo MergeTreeData::getPartsSnapshotInfo(const DataP
     return info;
 }
 
-MergeTreeSettingsPtr MergeTreeData::getSettings(ProjectionDescriptionRawPtr projection) const
+MergeTreeSettingsPtr MergeTreeData::getSettings(const SettingsChanges * settings_changes) const
 {
     auto data_settings = storage_settings.get();
-    if (projection)
+
+    if (settings_changes && !settings_changes->empty())
     {
-        if ((projection->index_granularity && (*projection->index_granularity != (*data_settings)[MergeTreeSetting::index_granularity]))
-            || (projection->index_granularity_bytes
-                && (*projection->index_granularity_bytes != (*data_settings)[MergeTreeSetting::index_granularity_bytes])))
-        {
-            auto new_data_settings = std::make_shared<MergeTreeSettings>(*data_settings);
-            if (projection->index_granularity)
-                (*new_data_settings)[MergeTreeSetting::index_granularity] = *projection->index_granularity;
-            if (projection->index_granularity_bytes)
-                (*new_data_settings)[MergeTreeSetting::index_granularity_bytes] = *projection->index_granularity_bytes;
-            data_settings = new_data_settings;
-        }
+        auto new_data_settings = std::make_shared<MergeTreeSettings>(*data_settings);
+        new_data_settings->applyChanges(*settings_changes);
+        return new_data_settings;
     }
+
     return data_settings;
 }
 

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1135,8 +1135,8 @@ public:
 
     /// Get constant pointer to storage settings.
     /// Copy this pointer into your scope and you will get consistent settings.
-    /// When `projection` is provided, apply projection-level overrides on top of the table settings.
-    MergeTreeSettingsPtr getSettings(ProjectionDescriptionRawPtr projection = nullptr) const;
+    /// When `settings_changes` is provided, apply the overrides on top of the table settings.
+    MergeTreeSettingsPtr getSettings(const SettingsChanges * settings_changes = nullptr) const;
 
     StorageMetadataPtr getInMemoryMetadataPtr(ContextPtr query_context, bool bypass_metadata_cache) const override;
 

--- a/src/Storages/MergeTree/MergeTreeDataPartBuilder.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartBuilder.cpp
@@ -71,7 +71,7 @@ std::shared_ptr<IMergeTreeDataPart> MergeTreeDataPartBuilder::build()
     if (!part_info)
         part_info = MergeTreePartInfo::fromPartName(name, data.format_version);
 
-    auto data_settings = data.getSettings(projection);
+    auto data_settings = data.getSettings(projection ? &projection->settings_changes : nullptr);
 
     switch (part_type->getValue())
     {

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -118,7 +118,7 @@ namespace ErrorCodes
 
 MergeTreeDataSelectExecutor::MergeTreeDataSelectExecutor(const MergeTreeData & data_, ProjectionDescriptionRawPtr projection)
     : data(data_)
-    , data_settings(data.getSettings(projection))
+    , data_settings(data.getSettings(projection ? &projection->settings_changes : nullptr))
     , log(getLogger(data.getLogName() + " (SelectExecutor)"))
 {
 }

--- a/src/Storages/MergeTree/MergeTreeDataWriter.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataWriter.cpp
@@ -1025,7 +1025,7 @@ MergeTreeTemporaryPartPtr MergeTreeDataWriter::writeProjectionPartImpl(
 
     auto new_data_part = parent_part->getProjectionPartBuilder(part_name, &projection, is_temp).withPartType(part_type).build();
     auto projection_part_storage = new_data_part->getDataPartStoragePtr();
-    auto data_settings = data.getSettings(&projection);
+    auto data_settings = data.getSettings(&projection.settings_changes);
 
     if (is_temp)
         projection_part_storage->beginTransaction();

--- a/src/Storages/MergeTree/ProjectionIndex/IProjectionIndex.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/IProjectionIndex.cpp
@@ -3,6 +3,7 @@
 #include <numeric>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTProjectionDeclaration.h>
+#include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/MergeTree/ProjectionIndex/ProjectionIndexBasic.h>
 #include <Storages/MergeTree/ProjectionIndex/ProjectionIndexCommitOrder.h>
 
@@ -12,6 +13,11 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int INCORRECT_QUERY;
+}
+
+std::shared_ptr<MergeTreeSettings> IProjectionIndex::getDefaultSettings() const
+{
+    return std::make_shared<MergeTreeSettings>();
 }
 
 IProjectionIndex::~IProjectionIndex() = default;

--- a/src/Storages/MergeTree/ProjectionIndex/IProjectionIndex.h
+++ b/src/Storages/MergeTree/ProjectionIndex/IProjectionIndex.h
@@ -18,6 +18,8 @@ using IColumnPermutation = PaddedPODArray<size_t>;
 
 class ASTProjectionDeclaration;
 
+struct MergeTreeSettings;
+
 /// Base interface for projection index implementations.
 class IProjectionIndex
 {
@@ -41,6 +43,15 @@ public:
         ContextPtr context,
         const IColumnPermutation * perm_ptr) const
         = 0;
+
+    /// Returns default MergeTreeSettings for this projection index type.
+    /// These defaults are applied before any user-specified SETTINGS overrides.
+    virtual std::shared_ptr<MergeTreeSettings> getDefaultSettings() const;
+
+    /// Returns the maximum number of rows supported by this index.
+    /// Some indices are limited to 32-bit row counts (approx. 4.29 billion).
+    /// Defaults to the maximum possible value if no specific limit exists.
+    virtual UInt64 getMaxRows() const { return std::numeric_limits<UInt64>::max(); }
 };
 
 using ProjectionIndexPtr = std::shared_ptr<IProjectionIndex>;

--- a/src/Storages/MergeTree/ProjectionIndex/IProjectionIndex.h
+++ b/src/Storages/MergeTree/ProjectionIndex/IProjectionIndex.h
@@ -33,7 +33,8 @@ public:
         const IAST * index_expr,
         const ColumnsDescription & columns,
         const KeyDescription * partition_key,
-        const ContextPtr & query_context) const
+        const ContextPtr & query_context,
+        const MergeTreeSettings & projection_settings) const
         = 0;
 
     virtual Block calculate(

--- a/src/Storages/MergeTree/ProjectionIndex/ProjectionIndexBasic.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/ProjectionIndexBasic.cpp
@@ -41,7 +41,8 @@ void ProjectionIndexBasic::fillProjectionDescription(
     const IAST * index_expr,
     const ColumnsDescription & columns,
     const KeyDescription * partition_key,
-    const ContextPtr & query_context) const
+    const ContextPtr & query_context,
+    const MergeTreeSettings & projection_settings) const
 {
     auto select_query = make_intrusive<ASTProjectionSelectQuery>();
     auto select_expr_list = make_intrusive<ASTExpressionList>();
@@ -49,7 +50,7 @@ void ProjectionIndexBasic::fillProjectionDescription(
     select_query->setExpression(ASTProjectionSelectQuery::Expression::SELECT, std::move(select_expr_list));
     select_query->setExpression(ASTProjectionSelectQuery::Expression::ORDER_BY, wrapInTupleIfNeeded(index_expr->clone()));
 
-    ProjectionDescription::fillProjectionDescriptionByQuery(result, *select_query, columns, partition_key, query_context);
+    ProjectionDescription::fillProjectionDescriptionByQuery(result, *select_query, columns, partition_key, query_context, projection_settings);
 }
 
 Block ProjectionIndexBasic::calculate(

--- a/src/Storages/MergeTree/ProjectionIndex/ProjectionIndexBasic.h
+++ b/src/Storages/MergeTree/ProjectionIndex/ProjectionIndexBasic.h
@@ -22,7 +22,8 @@ public:
         const IAST * index_expr,
         const ColumnsDescription & columns,
         const KeyDescription * partition_key,
-        const ContextPtr & query_context) const override;
+        const ContextPtr & query_context,
+        const MergeTreeSettings & projection_settings) const override;
 
     Block calculate(
         const ProjectionDescription & projection_desc,

--- a/src/Storages/MergeTree/ProjectionIndex/ProjectionIndexCommitOrder.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/ProjectionIndexCommitOrder.cpp
@@ -17,7 +17,8 @@ void ProjectionIndexCommitOrder::fillProjectionDescription(
     const IAST * index_expr,
     const ColumnsDescription & columns,
     const KeyDescription * partition_key,
-    const ContextPtr & query_context) const
+    const ContextPtr & query_context,
+    const MergeTreeSettings & projection_settings) const
 {
     auto select_query = make_intrusive<ASTProjectionSelectQuery>();
 
@@ -37,7 +38,7 @@ void ProjectionIndexCommitOrder::fillProjectionDescription(
     order_expr_list->children.push_back(order_expr_list->arguments);
     select_query->setExpression(ASTProjectionSelectQuery::Expression::ORDER_BY, std::move(order_expr_list));
 
-    ProjectionDescription::fillProjectionDescriptionByQuery(result, *select_query, columns, partition_key, query_context);
+    ProjectionDescription::fillProjectionDescriptionByQuery(result, *select_query, columns, partition_key, query_context, projection_settings);
 }
 
 Block ProjectionIndexCommitOrder::calculate(

--- a/src/Storages/MergeTree/ProjectionIndex/ProjectionIndexCommitOrder.h
+++ b/src/Storages/MergeTree/ProjectionIndex/ProjectionIndexCommitOrder.h
@@ -33,7 +33,8 @@ public:
         const IAST * index_expr,
         const ColumnsDescription & columns,
         const KeyDescription * partition_key,
-        const ContextPtr & query_context) const override;
+        const ContextPtr & query_context,
+        const MergeTreeSettings & projection_settings) const override;
 
     Block calculate(
         const ProjectionDescription & projection_desc,

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -914,7 +914,7 @@ static StoragePtr create(const StorageFactory::Arguments & args)
             {
                 try
                 {
-                    auto projection = ProjectionDescription::getProjectionFromAST(projection_ast, columns, &metadata.partition_key, context);
+                    auto projection = ProjectionDescription::getProjectionFromAST(projection_ast, columns, &metadata.partition_key, context, args.mode);
                     metadata.projections.add(std::move(projection));
                 }
                 catch (...)

--- a/src/Storages/ProjectionsDescription.cpp
+++ b/src/Storages/ProjectionsDescription.cpp
@@ -1,6 +1,7 @@
 #include <Storages/ProjectionsDescription.h>
 #include <DataTypes/DataTypeString.h>
 
+#include <Access/AccessControl.h>
 #include <Columns/ColumnConst.h>
 #include <Common/iota.h>
 #include <Core/Defines.h>
@@ -38,7 +39,9 @@
 #include <QueryPipeline/Pipe.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Storages/IStorage.h>
+#include <Storages/MergeTree/MergeTreeBackgroundExecutor.h>
 #include <Storages/MergeTree/MergeTreeData.h>
+#include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/MergeTree/MergeTreeVirtualColumns.h>
 #include <Storages/StorageInMemoryMetadata.h>
 
@@ -52,14 +55,21 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
     extern const int NOT_IMPLEMENTED;
     extern const int NO_SUCH_PROJECTION_IN_TABLE;
-    extern const int UNKNOWN_SETTING;
     extern const int BAD_ARGUMENTS;
+    extern const int SUPPORT_IS_DISABLED;
 }
 
 namespace Setting
 {
 
 extern const SettingsBool enable_positional_arguments_for_projections;
+
+}
+
+namespace MergeTreeSetting
+{
+
+extern const MergeTreeSettingsUInt64 index_granularity_bytes;
 
 }
 
@@ -100,13 +110,13 @@ ProjectionDescription ProjectionDescription::clone() const
     other.with_block_number = with_block_number;
     other.with_block_offset = with_block_offset;
     other.index = index;
-    other.index_granularity = index_granularity;
-    other.index_granularity_bytes = index_granularity_bytes;
     other.add_minmax_index_for_numeric_columns = add_minmax_index_for_numeric_columns;
     other.add_minmax_index_for_string_columns = add_minmax_index_for_string_columns;
     other.add_minmax_index_for_temporal_columns = add_minmax_index_for_temporal_columns;
     other.add_minmax_index_for_block_number_column = add_minmax_index_for_block_number_column;
     other.add_minmax_index_for_block_offset_column = add_minmax_index_for_block_offset_column;
+    other.settings_changes = settings_changes;
+    other.has_index_granularity_overrides = has_index_granularity_overrides;
 
     return other;
 }
@@ -231,46 +241,12 @@ private:
 
 }
 
-void ProjectionDescription::loadSettings(const SettingsChanges & changes)
-{
-    for (const auto & [setting, value] : changes)
-    {
-        if (setting == "index_granularity")
-            index_granularity = value.safeGet<UInt64>();
-        else if (setting == "index_granularity_bytes")
-            index_granularity_bytes = value.safeGet<UInt64>();
-        else if (setting == "add_minmax_index_for_numeric_columns")
-            add_minmax_index_for_numeric_columns = value.safeGet<UInt64>() != 0;
-        else if (setting == "add_minmax_index_for_string_columns")
-            add_minmax_index_for_string_columns = value.safeGet<UInt64>() != 0;
-        else if (setting == "add_minmax_index_for_temporal_columns")
-            add_minmax_index_for_temporal_columns = value.safeGet<UInt64>() != 0;
-        else if (setting == "add_minmax_index_for_block_number_column")
-            add_minmax_index_for_block_number_column = value.safeGet<UInt64>() != 0;
-        else if (setting == "add_minmax_index_for_block_offset_column")
-            add_minmax_index_for_block_offset_column = value.safeGet<UInt64>() != 0;
-        else
-            throw Exception(ErrorCodes::UNKNOWN_SETTING, "Unknown setting '{}' for projections", setting);
-    }
-
-    /// These checks are permanent sensible safeguards: they apply both to projection creation and projection loading,
-    /// and are not expected to change in the future. Keeping them unconditional simplifies the implementation.
-
-    if (index_granularity && *index_granularity < 1)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "projection index_granularity: value {} makes no sense", *index_granularity);
-
-    if (index_granularity_bytes && *index_granularity_bytes > 0 && *index_granularity_bytes < 1024)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "projection index_granularity_bytes: {} is lower than 1024", *index_granularity_bytes);
-
-    if (index_granularity_bytes && *index_granularity_bytes == 0)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "projection index_granularity_bytes cannot be 0, which leads to fixed granularity");
-}
-
 ProjectionDescription ProjectionDescription::getProjectionFromAST(
     const ASTPtr & definition_ast,
     const ColumnsDescription & columns,
     const KeyDescription * partition_key,
-    const ContextPtr & query_context)
+    const ContextPtr & query_context,
+    LoadingStrictnessLevel mode)
 {
     const auto * projection_definition = definition_ast->as<ASTProjectionDeclaration>();
 
@@ -287,20 +263,72 @@ ProjectionDescription ProjectionDescription::getProjectionFromAST(
     if (projection_definition->index)
     {
         chassert(projection_definition->type);
-
-        if (projection_definition->with_settings)
-            result.loadSettings(projection_definition->with_settings->changes);
-
         result.index = ProjectionIndexFactory::instance().get(*projection_definition);
         result.index->fillProjectionDescription(result, projection_definition->index, columns, partition_key, query_context);
-
-        return result;
+    }
+    else
+    {
+        fillProjectionDescriptionByQuery(result, projection_definition->query->as<ASTProjectionSelectQuery &>(), columns, partition_key, query_context);
     }
 
+    auto merge_tree_settings = result.index ? result.index->getDefaultSettings() : std::make_shared<MergeTreeSettings>();
     if (projection_definition->with_settings)
-        result.loadSettings(projection_definition->with_settings->changes);
+        merge_tree_settings->applyChanges(projection_definition->with_settings->changes);
+    result.settings_changes = merge_tree_settings->changes();
 
-    fillProjectionDescriptionByQuery(result, projection_definition->query->as<ASTProjectionSelectQuery &>(), columns, partition_key, query_context);
+    /// Track whether the effective settings include index_granularity or index_granularity_bytes overrides
+    /// (from either the projection index's getDefaultSettings() or the user's explicit SETTINGS clause),
+    /// so that checkProperties can reject projections with granularity overrides on non-adaptive tables.
+    for (const auto & change : result.settings_changes)
+    {
+        if (change.name == "index_granularity" || change.name == "index_granularity_bytes")
+        {
+            result.has_index_granularity_overrides = true;
+            break;
+        }
+    }
+
+    if (mode <= LoadingStrictnessLevel::CREATE)
+    {
+        static const std::unordered_set<std::string_view> ALLOWED_PROJECTION_SETTINGS = {
+            "index_granularity",
+            "index_granularity_bytes",
+            "min_compress_block_size",
+            "max_compress_block_size",
+            "min_bytes_for_wide_part",
+            "min_level_for_wide_part",
+            "min_rows_for_wide_part",
+            "ratio_of_defaults_for_sparse_serialization",
+            "write_marks_for_substreams_in_compact_parts",
+            "serialization_info_version",
+            "nullable_serialization_version",
+            "string_serialization_version",
+            "replace_long_file_name_to_hash",
+            "map_serialization_version",
+            "map_serialization_version_for_zero_level_parts",
+            "propagate_types_serialization_versions_to_nested_types",
+        };
+
+        for (const auto & change : result.settings_changes)
+        {
+            if (!ALLOWED_PROJECTION_SETTINGS.contains(change.name))
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Setting {} is not allowed for projections", change.name);
+        }
+
+        const auto & ac = query_context->getAccessControl();
+        bool allow_experimental = ac.getAllowExperimentalTierSettings();
+        bool allow_beta = ac.getAllowBetaTierSettings();
+        merge_tree_settings->sanityCheck(query_context->getMergeMutateExecutor()->getMaxTasksCount(), allow_experimental, allow_beta);
+    }
+
+    /// Ensure index_granularity_bytes is non-zero to prevent the projection from falling back
+    /// to fixed granularity. Enforced unconditionally (both CREATE and ATTACH paths).
+    if ((*merge_tree_settings)[MergeTreeSetting::index_granularity_bytes] == 0)
+    {
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS, "projection index_granularity_bytes cannot be 0, which leads to fixed granularity");
+    }
+
     return result;
 }
 
@@ -592,7 +620,20 @@ Block ProjectionDescription::calculate(
     const Block & block, UInt64 starting_offset, ContextPtr context, const IColumnPermutation * perm_ptr) const
 {
     if (index)
+    {
+        if (block.rows() > index->getMaxRows())
+        {
+            throw Exception(
+                ErrorCodes::SUPPORT_IS_DISABLED,
+                "Cannot calculate projection index with {} rows, which exceeds the limit ({}) "
+                "for projection index '{}' (Type: {}).",
+                block.rows(),
+                index->getMaxRows(),
+                name,
+                index->getName());
+        }
         return index->calculate(*this, block, starting_offset, context, perm_ptr);
+    }
 
     return calculateByQuery(block, starting_offset, context, perm_ptr);
 }

--- a/src/Storages/ProjectionsDescription.cpp
+++ b/src/Storages/ProjectionsDescription.cpp
@@ -70,6 +70,11 @@ namespace MergeTreeSetting
 {
 
 extern const MergeTreeSettingsUInt64 index_granularity_bytes;
+extern const MergeTreeSettingsBool add_minmax_index_for_numeric_columns;
+extern const MergeTreeSettingsBool add_minmax_index_for_string_columns;
+extern const MergeTreeSettingsBool add_minmax_index_for_temporal_columns;
+extern const MergeTreeSettingsBool add_minmax_index_for_block_number_column;
+extern const MergeTreeSettingsBool add_minmax_index_for_block_offset_column;
 
 }
 
@@ -110,11 +115,6 @@ ProjectionDescription ProjectionDescription::clone() const
     other.with_block_number = with_block_number;
     other.with_block_offset = with_block_offset;
     other.index = index;
-    other.add_minmax_index_for_numeric_columns = add_minmax_index_for_numeric_columns;
-    other.add_minmax_index_for_string_columns = add_minmax_index_for_string_columns;
-    other.add_minmax_index_for_temporal_columns = add_minmax_index_for_temporal_columns;
-    other.add_minmax_index_for_block_number_column = add_minmax_index_for_block_number_column;
-    other.add_minmax_index_for_block_offset_column = add_minmax_index_for_block_offset_column;
     other.settings_changes = settings_changes;
     other.has_index_granularity_overrides = has_index_granularity_overrides;
 
@@ -264,13 +264,12 @@ ProjectionDescription ProjectionDescription::getProjectionFromAST(
     {
         chassert(projection_definition->type);
         result.index = ProjectionIndexFactory::instance().get(*projection_definition);
-        result.index->fillProjectionDescription(result, projection_definition->index, columns, partition_key, query_context);
-    }
-    else
-    {
-        fillProjectionDescriptionByQuery(result, projection_definition->query->as<ASTProjectionSelectQuery &>(), columns, partition_key, query_context);
     }
 
+    /// Compute effective MergeTree settings for the projection (defaults possibly contributed by
+    /// the projection index, with user-supplied WITH SETTINGS overrides applied on top). This must
+    /// happen before fillProjectionDescription[ByQuery] because the latter reconstructs settings
+    /// from result.settings_changes to drive implicit-minmax skip-index creation.
     auto merge_tree_settings = result.index ? result.index->getDefaultSettings() : std::make_shared<MergeTreeSettings>();
     if (projection_definition->with_settings)
         merge_tree_settings->applyChanges(projection_definition->with_settings->changes);
@@ -288,11 +287,25 @@ ProjectionDescription ProjectionDescription::getProjectionFromAST(
         }
     }
 
+    if (result.index)
+    {
+        result.index->fillProjectionDescription(result, projection_definition->index, columns, partition_key, query_context, *merge_tree_settings);
+    }
+    else
+    {
+        fillProjectionDescriptionByQuery(result, projection_definition->query->as<ASTProjectionSelectQuery &>(), columns, partition_key, query_context, *merge_tree_settings);
+    }
+
     if (mode <= LoadingStrictnessLevel::CREATE)
     {
         static const std::unordered_set<std::string_view> ALLOWED_PROJECTION_SETTINGS = {
             "index_granularity",
             "index_granularity_bytes",
+            "add_minmax_index_for_numeric_columns",
+            "add_minmax_index_for_string_columns",
+            "add_minmax_index_for_temporal_columns",
+            "add_minmax_index_for_block_number_column",
+            "add_minmax_index_for_block_offset_column",
             "min_compress_block_size",
             "max_compress_block_size",
             "min_bytes_for_wide_part",
@@ -318,7 +331,11 @@ ProjectionDescription ProjectionDescription::getProjectionFromAST(
         const auto & ac = query_context->getAccessControl();
         bool allow_experimental = ac.getAllowExperimentalTierSettings();
         bool allow_beta = ac.getAllowBetaTierSettings();
-        merge_tree_settings->sanityCheck(query_context->getMergeMutateExecutor()->getMaxTasksCount(), allow_experimental, allow_beta);
+        merge_tree_settings->sanityCheck(
+            query_context->getMergeMutateExecutor()->getMaxTasksCount(),
+            allow_experimental,
+            allow_beta,
+            query_context->wasBackgroundPoolAutoLowered());
     }
 
     /// Ensure index_granularity_bytes is non-zero to prevent the projection from falling back
@@ -337,7 +354,8 @@ void ProjectionDescription::fillProjectionDescriptionByQuery(
     const ASTProjectionSelectQuery & query,
     const ColumnsDescription & columns,
     const KeyDescription * partition_key,
-    const ContextPtr & query_context)
+    const ContextPtr & query_context,
+    const MergeTreeSettings & projection_settings)
 {
     auto projection_order_by = query.orderBy();
     result.query_ast = query.cloneToASTSelect();
@@ -498,12 +516,13 @@ void ProjectionDescription::fillProjectionDescriptionByQuery(
     metadata.setColumns(ColumnsDescription(metadata_columns));
     metadata.setVirtuals(MergeTreeData::createVirtuals(partition_key));
 
-    /// Initialize implicit-minmax skip indices from projection-level settings.
-    metadata.add_minmax_index_for_numeric_columns = result.add_minmax_index_for_numeric_columns;
-    metadata.add_minmax_index_for_string_columns = result.add_minmax_index_for_string_columns;
-    metadata.add_minmax_index_for_temporal_columns = result.add_minmax_index_for_temporal_columns;
-    metadata.add_minmax_index_for_block_number_column = result.add_minmax_index_for_block_number_column;
-    metadata.add_minmax_index_for_block_offset_column = result.add_minmax_index_for_block_offset_column;
+    /// Initialize implicit-minmax skip indices from the effective projection-level MergeTree settings
+    /// (defaults from the projection index plus any user-supplied WITH SETTINGS overrides).
+    metadata.add_minmax_index_for_numeric_columns = projection_settings[MergeTreeSetting::add_minmax_index_for_numeric_columns];
+    metadata.add_minmax_index_for_string_columns = projection_settings[MergeTreeSetting::add_minmax_index_for_string_columns];
+    metadata.add_minmax_index_for_temporal_columns = projection_settings[MergeTreeSetting::add_minmax_index_for_temporal_columns];
+    metadata.add_minmax_index_for_block_number_column = projection_settings[MergeTreeSetting::add_minmax_index_for_block_number_column];
+    metadata.add_minmax_index_for_block_offset_column = projection_settings[MergeTreeSetting::add_minmax_index_for_block_offset_column];
     metadata.addImplicitIndicesForVirtualColumns(query_context);
     for (const auto & column : metadata.columns)
         metadata.addImplicitIndicesForColumn(column, query_context);

--- a/src/Storages/ProjectionsDescription.h
+++ b/src/Storages/ProjectionsDescription.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Core/Types.h>
+#include <Databases/LoadingStrictnessLevel.h>
 #include <Interpreters/AggregateDescription.h>
 #include <Parsers/IAST_fwd.h>
 #include <Storages/ColumnsDescription.h>
@@ -76,23 +77,30 @@ struct ProjectionDescription
     bool with_block_number = false;
     bool with_block_offset = false;
 
+    /// If not null, this projection is treated as a specialized index. It triggers specific calculation and application
+    /// logic during query execution to optimize data access paths.
     ProjectionIndexPtr index;
 
-    /// Settings (configurable via WITH SETTINGS clause of the projection declaration)
-    std::optional<UInt64> index_granularity = {};
-    std::optional<UInt64> index_granularity_bytes = {};
     bool add_minmax_index_for_numeric_columns = false;
     bool add_minmax_index_for_string_columns = false;
     bool add_minmax_index_for_temporal_columns = false;
     bool add_minmax_index_for_block_number_column = false;
     bool add_minmax_index_for_block_offset_column = false;
 
+    /// Optional SETTINGS overrides for the projection.
+    SettingsChanges settings_changes;
+
+    /// Cache whether index_granularity or index_granularity_bytes is overridden to avoid re-scanning the changes list
+    /// during data writing.
+    bool has_index_granularity_overrides = false;
+
     /// Parse projection from definition AST
     static ProjectionDescription getProjectionFromAST(
         const ASTPtr & definition_ast,
         const ColumnsDescription & columns,
         const KeyDescription * partition_key,
-        const ContextPtr & query_context);
+        const ContextPtr & query_context,
+        LoadingStrictnessLevel mode = LoadingStrictnessLevel::ATTACH);
 
     static void fillProjectionDescriptionByQuery(
         ProjectionDescription & result,
@@ -119,8 +127,6 @@ struct ProjectionDescription
     ProjectionDescription & operator=(ProjectionDescription && other) = default;
 
     ProjectionDescription clone() const;
-
-    void loadSettings(const SettingsChanges & changes);
 
     bool operator==(const ProjectionDescription & other) const;
     bool operator!=(const ProjectionDescription & other) const { return !(*this == other); }

--- a/src/Storages/ProjectionsDescription.h
+++ b/src/Storages/ProjectionsDescription.h
@@ -27,6 +27,8 @@ struct KeyDescription;
 
 class ASTProjectionSelectQuery;
 
+struct MergeTreeSettings;
+
 /// Description of projections for Storage
 struct ProjectionDescription
 {
@@ -81,12 +83,6 @@ struct ProjectionDescription
     /// logic during query execution to optimize data access paths.
     ProjectionIndexPtr index;
 
-    bool add_minmax_index_for_numeric_columns = false;
-    bool add_minmax_index_for_string_columns = false;
-    bool add_minmax_index_for_temporal_columns = false;
-    bool add_minmax_index_for_block_number_column = false;
-    bool add_minmax_index_for_block_offset_column = false;
-
     /// Optional SETTINGS overrides for the projection.
     SettingsChanges settings_changes;
 
@@ -107,7 +103,8 @@ struct ProjectionDescription
         const ASTProjectionSelectQuery & query,
         const ColumnsDescription & columns,
         const KeyDescription * partition_key,
-        const ContextPtr & query_context);
+        const ContextPtr & query_context,
+        const MergeTreeSettings & projection_settings);
 
     static ProjectionDescription getMinMaxCountProjection(
         const ColumnsDescription & columns,

--- a/tests/queries/0_stateless/04068_projection_index_settings.reference
+++ b/tests/queries/0_stateless/04068_projection_index_settings.reference
@@ -1,0 +1,9 @@
+p_gran2 marks:	51
+projections after create:	p_gran2	{'index_granularity':'2','index_granularity_bytes':'999999999'}
+p_gran10 marks:	11
+projections after alter:	p_gran10	{'index_granularity':'10','index_granularity_bytes':'999999999'}
+projections after alter:	p_gran2	{'index_granularity':'2','index_granularity_bytes':'999999999'}
+projections after reattach:	p_gran10	{'index_granularity':'10','index_granularity_bytes':'999999999'}
+projections after reattach:	p_gran2	{'index_granularity':'2','index_granularity_bytes':'999999999'}
+projection part_type:	Compact
+compress settings:	p_compress	1234567

--- a/tests/queries/0_stateless/04068_projection_index_settings.sql
+++ b/tests/queries/0_stateless/04068_projection_index_settings.sql
@@ -1,0 +1,137 @@
+----------------------------------------------------------------------
+-- 1. Basic INDEX projection with index_granularity override
+----------------------------------------------------------------------
+
+DROP TABLE IF EXISTS t_proj_settings;
+
+CREATE TABLE t_proj_settings
+(
+    id UInt64,
+    region String,
+    PROJECTION p_gran2 INDEX region TYPE basic WITH SETTINGS (index_granularity = 2, index_granularity_bytes = 999999999)
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity = 8192, min_bytes_for_wide_part = 0,
+         min_bytes_for_full_part_storage = 0, enable_vertical_merge_algorithm = 0;
+
+INSERT INTO t_proj_settings SELECT number, toString(number % 100) FROM numbers(100);
+
+-- With index_granularity = 2, we expect 51 marks (100 rows / 2 + 1)
+SELECT 'p_gran2 marks:', marks FROM system.projection_parts
+WHERE active AND database = currentDatabase() AND table = 't_proj_settings' AND name = 'p_gran2';
+
+-- Verify system.projections shows the user-specified settings
+SELECT 'projections after create:', name, settings FROM system.projections
+WHERE database = currentDatabase() AND table = 't_proj_settings' ORDER BY name;
+
+----------------------------------------------------------------------
+-- 2. ALTER ADD projection with settings override + MATERIALIZE
+----------------------------------------------------------------------
+
+ALTER TABLE t_proj_settings ADD PROJECTION p_gran10 INDEX region TYPE basic WITH SETTINGS (index_granularity = 10, index_granularity_bytes = 999999999);
+
+ALTER TABLE t_proj_settings MATERIALIZE PROJECTION p_gran10 SETTINGS mutations_sync = 1;
+
+-- With index_granularity = 10, we expect 11 marks (100 rows / 10 + 1)
+SELECT 'p_gran10 marks:', marks FROM system.projection_parts
+WHERE active AND database = currentDatabase() AND table = 't_proj_settings' AND name = 'p_gran10';
+
+SELECT 'projections after alter:', name, settings FROM system.projections
+WHERE database = currentDatabase() AND table = 't_proj_settings' ORDER BY name;
+
+----------------------------------------------------------------------
+-- 3. DETACH/ATTACH preserves projection settings
+----------------------------------------------------------------------
+
+DETACH TABLE t_proj_settings SYNC;
+ATTACH TABLE t_proj_settings;
+
+SELECT 'projections after reattach:', name, settings FROM system.projections
+WHERE database = currentDatabase() AND table = 't_proj_settings' ORDER BY name;
+
+DROP TABLE t_proj_settings;
+
+----------------------------------------------------------------------
+-- 4. Projection-level min_bytes_for_wide_part overrides parent table
+----------------------------------------------------------------------
+
+DROP TABLE IF EXISTS t_proj_wide;
+
+-- Parent table forces Wide format (min_bytes_for_wide_part = 0).
+-- Projection overrides to force Compact format (min_bytes_for_wide_part = very large).
+CREATE TABLE t_proj_wide
+(
+    id UInt64,
+    region String,
+    PROJECTION p_compact INDEX region TYPE basic WITH SETTINGS (min_bytes_for_wide_part = 1000000000)
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS min_bytes_for_wide_part = 0, min_bytes_for_full_part_storage = 0;
+
+INSERT INTO t_proj_wide SELECT number, toString(number % 100) FROM numbers(100);
+
+-- Projection has min_bytes_for_wide_part = 1000000000, so for 100 rows it should be Compact
+-- (regardless of what the parent table's random settings may be).
+SELECT 'projection part_type:', part_type FROM system.projection_parts
+WHERE active AND database = currentDatabase() AND table = 't_proj_wide' AND name = 'p_compact';
+
+DROP TABLE t_proj_wide;
+
+----------------------------------------------------------------------
+-- 5. Projection-level min_compress_block_size overrides parent table
+----------------------------------------------------------------------
+
+DROP TABLE IF EXISTS t_proj_compress;
+
+-- Parent table uses default min_compress_block_size (65536).
+-- Projection overrides to a different value. Verify via system.projections settings map.
+CREATE TABLE t_proj_compress
+(
+    id UInt64,
+    region String,
+    PROJECTION p_compress INDEX region TYPE basic WITH SETTINGS (min_compress_block_size = 1234567)
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS min_bytes_for_full_part_storage = 0;
+
+SELECT 'compress settings:', name, settings['min_compress_block_size'] FROM system.projections
+WHERE database = currentDatabase() AND table = 't_proj_compress' ORDER BY name;
+
+DROP TABLE t_proj_compress;
+
+----------------------------------------------------------------------
+-- 6. Disallowed settings are rejected for INDEX projections
+----------------------------------------------------------------------
+
+DROP TABLE IF EXISTS t_bad_settings;
+
+CREATE TABLE t_bad_settings (id UInt64, region String)
+ENGINE = MergeTree ORDER BY id;
+
+-- Unknown/disallowed setting
+ALTER TABLE t_bad_settings ADD PROJECTION p_bad INDEX region TYPE basic WITH SETTINGS (max_parts_to_merge_at_once = 5); -- { serverError BAD_ARGUMENTS }
+
+-- index_granularity = 0 should fail sanity check
+ALTER TABLE t_bad_settings ADD PROJECTION p_bad INDEX region TYPE basic WITH SETTINGS (index_granularity = 0); -- { serverError BAD_ARGUMENTS }
+
+-- index_granularity_bytes = 0 forces non-adaptive granularity which is disallowed
+ALTER TABLE t_bad_settings ADD PROJECTION p_bad INDEX region TYPE basic WITH SETTINGS (index_granularity_bytes = 0); -- { serverError BAD_ARGUMENTS }
+
+DROP TABLE t_bad_settings;
+
+----------------------------------------------------------------------
+-- 7. Non-adaptive table rejects INDEX projections with granularity overrides
+----------------------------------------------------------------------
+
+DROP TABLE IF EXISTS t_fixed_gran;
+
+CREATE TABLE t_fixed_gran (id UInt64, region String)
+ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity_bytes = 0;
+
+ALTER TABLE t_fixed_gran ADD PROJECTION p_bad INDEX region TYPE basic WITH SETTINGS (index_granularity = 2); -- { serverError SUPPORT_IS_DISABLED }
+
+DROP TABLE t_fixed_gran;


### PR DESCRIPTION
Replace per-projection optional `index_granularity`/`index_granularity_bytes` fields with a generic `SettingsChanges` map and a `has_index_granularity_overrides` flag. This enables projections to override any allowed `MergeTreeSettings`, not just granularity.

**Changes:**
- `ProjectionDescription`: replace `optional<UInt64> index_granularity/index_granularity_bytes` with `SettingsChanges settings_changes` and `bool has_index_granularity_overrides`. Remove `loadSettings`; validation now happens in `getProjectionFromAST`.
- `MergeTreeData::getSettings`: accept `const SettingsChanges *` instead of `ProjectionDescriptionRawPtr`. Skip copy when `settings_changes` is empty.
- `IProjectionIndex`: add `getDefaultSettings` and `getMaxRows` virtual methods.
- `getProjectionFromAST`: accept `LoadingStrictnessLevel`. On `CREATE`, enforce an `ALLOWED_PROJECTION_SETTINGS` whitelist covering part format, granularity, compression, serialization, and related settings. Run `sanityCheck` and reject `index_granularity_bytes = 0`.
- Add test `04068_projection_index_settings` covering granularity overrides, ALTER+MATERIALIZE, DETACH/ATTACH persistence, `min_bytes_for_wide_part` override (Compact vs parent), `min_compress_block_size` override, disallowed settings rejection, and non-adaptive table rejection.

### Changelog category (leave one):
- Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

Allow projections to override additional MergeTree settings (compression, part format, serialization) beyond just `index_granularity`, with a whitelist of allowed settings and validation.

### Documentation entry for user-facing changes

- [x] Documentation is not required (internal refactor, no new user-facing syntax)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.898`
<!-- ch-version-info:end -->