### PR TITLE
auto-bisect: use portable base64 encoding for private CI credentials

### DIFF
--- a/utils/auto-bisect/helpers/download.sh
+++ b/utils/auto-bisect/helpers/download.sh
@@ -31,7 +31,7 @@ fi
 # Build Basic Auth header from CH_CI_USER + CH_CI_PASSWORD (validated in bisect.sh)
 BASIC_AUTH_HEADER=""
 if [[ "${PRIVATE:-false}" == "true" ]]; then
-  BASIC_AUTH_HEADER="Authorization: Basic $(echo -n "${CH_CI_USER}:${CH_CI_PASSWORD}" | base64 -w0)"
+  BASIC_AUTH_HEADER="Authorization: Basic $(printf '%s' "${CH_CI_USER}:${CH_CI_PASSWORD}" | base64 | tr -d '\n')"
 fi
 
 function try_download() {


### PR DESCRIPTION
`base64 -w0` is GNU coreutils-specific. BSD/macOS `base64` does not accept `-w`, so `--private` mode fails on macOS with a cryptic error.

Switch to `printf '%s' ... | base64 | tr -d '\n'` which is POSIX-portable across Linux and macOS.

Followup to #100989.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.409`
<!-- ch-version-info:end -->