### PR TITLE
Allow creating table as table function with another engine

### DIFF
--- a/docs/en/sql-reference/statements/create/table.md
+++ b/docs/en/sql-reference/statements/create/table.md
@@ -73,10 +73,10 @@ For both features, you can specify a different engine for the table. If the engi
 ### From a Table Function {#from-a-table-function}
 
 ```sql
-CREATE TABLE [IF NOT EXISTS] [db.]table_name AS table_function()
+CREATE TABLE [IF NOT EXISTS] [db.]table_name AS table_function() [ENGINE = engine]
 ```
 
-Creates a table with the same result as that of the [table function](/sql-reference/table-functions) specified. The created table will also work in the same way as the corresponding table function that was specified.
+If an engine is not specified, creates a table with the same structure and behavior as the specified [table function](/sql-reference/table-functions). Otherwise, the table function's engine is overridden, and only the table structure is inferred from the table function.
 
 ### From SELECT query {#from-select-query}
 

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -184,6 +184,7 @@ namespace ErrorCodes
     extern const int TOO_MANY_DATABASES;
     extern const int THERE_IS_NO_COLUMN;
     extern const int CANNOT_RESTORE_TABLE;
+    extern const int INCOMPATIBLE_COLUMNS;
 }
 
 namespace fs = std::filesystem;
@@ -729,7 +730,6 @@ ConstraintsDescription InterpreterCreateQuery::getConstraintsDescription(
     return ConstraintsDescription{constraints_data};
 }
 
-
 InterpreterCreateQuery::TableProperties InterpreterCreateQuery::getTablePropertiesAndNormalizeCreateQuery(
     ASTCreateQuery & create, LoadingStrictnessLevel mode)
 {
@@ -757,6 +757,16 @@ InterpreterCreateQuery::TableProperties InterpreterCreateQuery::getTableProperti
 
         if (create.columns_list->columns)
         {
+            if (create.as_table_function && create.storage && create.storage->engine)
+            {
+                /// 1. In CREATE ... AS table_function() ENGINE = ... queries table_function should be used
+                /// only for table structure inference, so the after the structure is inferred the
+                /// table_function should not be used.
+                /// 2. ATTACH ... ENGINE = ... AS table_function() queries are not allowed.
+                assert(!create.attach);
+                throw Exception(ErrorCodes::INCOMPATIBLE_COLUMNS, "Columns should be inferred from the table function.");
+            }
+
             properties.columns = getColumnsDescription(*create.columns_list->columns, getContext(), mode, is_restore_from_backup);
         }
 
@@ -1269,20 +1279,31 @@ void InterpreterCreateQuery::setEngine(ASTCreateQuery & create) const
 {
     if (create.as_table_function)
     {
+        if (create.storage && !create.storage->engine)
+        {
+            /// Engine should either be explicitly specified or completely inferred from the table function
+            throw Exception(ErrorCodes::ENGINE_REQUIRED, "Engine required to be specified to override table function's engine");
+        }
+
         if (getContext()->getSettingsRef()[Setting::restore_replace_external_table_functions_to_null])
         {
             const auto & factory = TableFunctionFactory::instance();
 
             auto properties = factory.tryGetProperties(create.as_table_function->as<ASTFunction>()->name);
             if (properties && properties->allow_readonly)
+            {
+                if (create.storage && StorageFactory::instance().getStorageFeatures(create.storage->engine->name).source_access_type)
+                {
+                    setNullTableEngine(*create.storage);
+                }
                 return;
+            }
+
             if (!create.storage)
             {
                 auto storage_ast = make_intrusive<ASTStorage>();
                 create.set(create.storage, storage_ast);
             }
-            else
-                throw Exception(ErrorCodes::LOGICAL_ERROR, "Storage should not be created yet, it's a bug.");
             create.as_table_function = nullptr;
             setNullTableEngine(*create.storage);
         }
@@ -2051,19 +2072,29 @@ bool InterpreterCreateQuery::doCreateTable(ASTCreateQuery & create,
     /// NOTE: CREATE query may be rewritten by Storage creator or table function
     if (create.as_table_function)
     {
-        auto table_function_ast = create.as_table_function->ptr();
-        auto table_function = TableFunctionFactory::instance().get(table_function_ast, getContext());
+        if (create.storage)
+        {
+            /// When a specific engine is specified, the table function is used only to infer the table structure.
+            /// Hereafter, this table should not be treated as built from a table function.
+            create.reset(create.as_table_function);
+        }
+        else
+        {
+            /// In case of CREATE AS table_function() query we should use global context
+            /// in storage creation because there will be no query context on server startup
+            /// and because storage lifetime is bigger than query context lifetime.
+            auto table_function_ast = create.as_table_function->ptr();
+            auto table_function = TableFunctionFactory::instance().get(table_function_ast, getContext());
 
-        if (!table_function->canBeUsedToCreateTable())
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Table function '{}' cannot be used to create a table", table_function->getName());
+            if (!table_function->canBeUsedToCreateTable())
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Table function '{}' cannot be used to create a table", table_function->getName());
 
-        /// In case of CREATE AS table_function() query we should use global context
-        /// in storage creation because there will be no query context on server startup
-        /// and because storage lifetime is bigger than query context lifetime.
-        res = table_function->execute(table_function_ast, getContext(), create.getTable(), properties.columns, /*use_global_context=*/true, /*is_insert_query=*/true);
-        res->renameInMemory({create.getDatabase(), create.getTable(), create.uuid});
+            res = table_function->execute(table_function_ast, getContext(), create.getTable(), properties.columns, /*use_global_context=*/true, /*is_insert_query=*/true);
+            res->renameInMemory({create.getDatabase(), create.getTable(), create.uuid});
+        }
     }
-    else
+
+    if (!res)
     {
         res = StorageFactory::instance().get(create,
             data_path,

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -900,7 +900,7 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
         if (!s_rparen.ignore(pos, expected))
             return false;
 
-        auto storage_parse_result = parse_storage();
+        parse_storage();
 
         /// Accept both "EMPTY COMMENT ... AS" and "COMMENT ... EMPTY AS" orderings.
         try_parse_empty_or_clone();
@@ -908,26 +908,30 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
         try_parse_empty_or_clone();
 
         /// When EMPTY or CLONE was parsed, AS is required; otherwise AS is optional.
-        bool has_as = false;
-        if (is_create_empty || is_clone_as)
+        bool has_as = ParserKeyword{Keyword::AS}.ignore(pos, expected);
+        if ((is_create_empty || is_clone_as) && !has_as)
         {
-            if (!ParserKeyword{Keyword::AS}.ignore(pos, expected))
-                return false;
-            has_as = true;
+            return false;
         }
-        else
-            has_as = ParserKeyword{Keyword::AS}.ignore(pos, expected);
 
-        if ((storage_parse_result || is_temporary) && has_as)
+        if (is_temporary && has_as)
         {
             if (!select_p.parse(pos, select, expected))
                 return false;
         }
 
-        if (!storage_parse_result && !is_temporary && has_as)
+        if (!is_temporary && has_as)
         {
-            if (!table_function_p.parse(pos, as_table_function, expected))
-                return false;
+            if (!select_p.parse(pos, select, expected))
+            {
+                // ATTACH ... ENGINE = ... AS table_function() queries not allowed
+                if ((!attach || !storage) && !table_function_p.parse(pos, as_table_function, expected))
+                    return false;
+
+                /// Optional - ENGINE can be specified.
+                if (!attach && !storage)
+                    parse_storage();
+            }
         }
 
         /// Will set default table engine if Storage clause was not parsed
@@ -961,8 +965,8 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
         {
             if (!select_p.parse(pos, select, expected)) /// AS SELECT ...
             {
-                /// ENGINE can not be specified for table functions.
-                if (storage || !table_function_p.parse(pos, as_table_function, expected))
+                // ATTACH ... ENGINE = ... AS table_function() queries not allowed
+                if ((!attach || !storage) && !table_function_p.parse(pos, as_table_function, expected))
                 {
                     /// AS [db.]table
                     if (!name_p.parse(pos, as_table, expected))
@@ -974,11 +978,11 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
                         if (!name_p.parse(pos, as_table, expected))
                             return false;
                     }
-
-                    /// Optional - ENGINE can be specified.
-                    if (!storage)
-                        parse_storage();
                 }
+
+                /// Optional - ENGINE can be specified for CREATE queries.
+                if (!attach && !storage)
+                    parse_storage();
             }
         }
     }

--- a/src/Parsers/tests/gtest_Parser.cpp
+++ b/src/Parsers/tests/gtest_Parser.cpp
@@ -269,6 +269,32 @@ INSTANTIATE_TEST_SUITE_P(ParserCreateDatabaseQuery, ParserTest,
         }
 })));
 
+INSTANTIATE_TEST_SUITE_P(ParserCreateTableQuery, ParserTest,
+    ::testing::Combine(
+        ::testing::Values(std::make_shared<ParserCreateQuery>()),
+        ::testing::ValuesIn(std::initializer_list<ParserTestCase>{
+        {
+            "CREATE TABLE Foo ENGINE = MergeTree AS file('foo') ORDER BY name",
+            "throws Syntax error"
+        },
+        {
+            "ATTACH TABLE foo (f Int64) Engine = MergeTree AS file('test.csv')",
+            "throws Syntax error"
+        },
+        {
+            "ATTACH TABLE foo (f Int64) AS file('test.csv') Engine = MergeTree",
+            "throws Syntax error"
+        },
+        {
+            "ATTACH TABLE foo Engine = MergeTree AS file('test.csv')",
+            "throws Syntax error"
+        },
+        {
+            "ATTACH TABLE foo AS file('test.csv') Engine = MergeTree",
+            "throws Syntax error"
+        }
+})));
+
 INSTANTIATE_TEST_SUITE_P(ParserCreateUserQuery, ParserTest,
     ::testing::Combine(
         ::testing::Values(std::make_shared<ParserCreateUserQuery>()),

--- a/tests/queries/0_stateless/00973_create_table_as_table_function.reference
+++ b/tests/queries/0_stateless/00973_create_table_as_table_function.reference
@@ -25,3 +25,7 @@
 23
 24
 25
+0
+MergeTree	CREATE TABLE default.t5 (`number` UInt64) ENGINE = MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192
+0
+Memory	CREATE TABLE default.t6 (`number` UInt64) ENGINE = Memory

--- a/tests/queries/0_stateless/00973_create_table_as_table_function.sql
+++ b/tests/queries/0_stateless/00973_create_table_as_table_function.sql
@@ -2,6 +2,9 @@ DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t2;
 DROP TABLE IF EXISTS t3;
 DROP TABLE IF EXISTS t4;
+DROP TABLE IF EXISTS t5;
+DROP TABLE IF EXISTS t6;
+DROP TABLE IF EXISTS t7;
 
 CREATE TABLE t1 AS remote('127.0.0.1', system.one);
 SELECT count() FROM t1;
@@ -15,7 +18,22 @@ SELECT * FROM t3 where number > 17 and number < 25;
 CREATE TABLE t4 AS numbers(100);
 SELECT count() FROM t4 where number > 74;
 
+CREATE TABLE t5 ENGINE = MergeTree AS numbers(100);
+SELECT count() FROM t5;
+SELECT engine, create_table_query FROM system.tables WHERE name = 't5' AND database = currentDatabase();
+
+CREATE TABLE t6 AS numbers(100) ENGINE = Memory;
+SELECT count() FROM t6;
+SELECT engine, create_table_query FROM system.tables WHERE name = 't6' AND database = currentDatabase();
+
+CREATE TABLE t7 AS numbers(10) ORDER BY number; -- { serverError 119 }
+CREATE TABLE t7 ORDER BY number AS numbers(10); -- { serverError 119 }
+CREATE TABLE t7 (number UInt64) AS numbers(10) ENGINE = Memory; -- { serverError 122 }
+CREATE TABLE t7 (number UInt64) ENGINE = Memory AS numbers(10); -- { serverError 122 }
+
 DROP TABLE t1;
 DROP TABLE t2;
 DROP TABLE t3;
 DROP TABLE t4;
+DROP TABLE t5;
+DROP TABLE t6;

--- a/tests/queries/0_stateless/01445_create_table_as_table_function.sh
+++ b/tests/queries/0_stateless/01445_create_table_as_table_function.sh
@@ -8,5 +8,5 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 # NOTE: database = $CLICKHOUSE_DATABASE is unwanted
 ${CLICKHOUSE_CLIENT} --query "CREATE TABLE system.columns AS numbers(10);" 2>&1 | grep -F "Code: 57" > /dev/null && echo 'OK' || echo 'FAIL'
-${CLICKHOUSE_CLIENT} --query "CREATE TABLE system.columns engine=Memory AS numbers(10);" 2>&1 | grep -F "Code: 62" > /dev/null && echo 'OK' || echo 'FAIL'
-${CLICKHOUSE_CLIENT} --query "CREATE TABLE system.columns AS numbers(10) engine=Memory;" 2>&1 | grep -F "Code: 62" > /dev/null && echo 'OK' || echo 'FAIL'
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE system.columns engine=Memory AS numbers(10);" 2>&1 | grep -F "Code: 57" > /dev/null && echo 'OK' || echo 'FAIL'
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE system.columns AS numbers(10) engine=Memory;" 2>&1 | grep -F "Code: 57" > /dev/null && echo 'OK' || echo 'FAIL'


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry:

Users can create a table with structure inferred from a table function, but with a different engine. The table function's engine is ignored.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

Fixes https://github.com/ClickHouse/ClickHouse/issues/50571.

This PR allows users to specify engine for CREATE TABLE AS table_function() queries.
The table function is used to infer table structure, i.e. the list of columns with names and types, and the new table is created with the specified engine. The table function's engine is ignored.


Example:


```
CREATE TABLE test ENGINE = MergeTree ORDER BY coalesce(name, '') AS file('test.csv')
```
where test.csv is the following:
```
name,age
'John',29
```

creates the table equivalent to the following query:
```
CREATE TABLE test (`name` Nullable(String), `age` Nullable(Int64)) ENGINE = MergeTree ORDER BY coalesce(name, '')
```

