### PR TITLE
Allow zero-size string types |S0 and <U0 in Npy format

### DIFF
--- a/src/Processors/Formats/Impl/NpyRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/NpyRowInputFormat.cpp
@@ -267,9 +267,10 @@ void NpyRowInputFormat::readPrefix()
     /// Validate that the product of all shape dimensions does not overflow
     /// and is consistent with the available data size.
     size_t element_size = header.numpy_type->getSize();
-    if (element_size == 0)
-        throw Exception(ErrorCodes::INCORRECT_DATA, "Npy element size is zero");
 
+    /// element_size == 0 is valid for |S0 and <U0 (zero-length string types).
+    /// Total data is 0 bytes, so all overflow and size checks are trivially satisfied.
+    /// Skip directly to the file-size check (which will also pass: 0 <= available).
     static constexpr size_t max_bytes_per_row = 2ULL * 1024 * 1024 * 1024; /// 2 GiB
     if (element_size > max_bytes_per_row)
         throw Exception(
@@ -288,7 +289,7 @@ void NpyRowInputFormat::readPrefix()
         total_elements *= dim;
     }
 
-    if (total_elements > std::numeric_limits<size_t>::max() / element_size)
+    if (element_size != 0 && total_elements > std::numeric_limits<size_t>::max() / element_size)
         throw Exception(
             ErrorCodes::INCORRECT_DATA,
             "Npy shape overflow: total data size exceeds the maximum value");
@@ -481,8 +482,16 @@ void NpyRowInputFormat::readValue(IColumn * column)
 
 bool NpyRowInputFormat::readRow(MutableColumns & columns, RowReadExtension &  /*ext*/)
 {
-    if (in->eof())
+    if (read_rows >= header.shape[0])
         return false;
+
+    /// For non-zero element sizes, check eof to detect truncated files.
+    /// For zero-size elements (|S0, <U0), the data section is empty and
+    /// eof is expected — rows are produced based on the row counter alone.
+    if (header.numpy_type->getSize() != 0 && in->eof())
+        return false;
+
+    ++read_rows;
 
     auto & column = columns[0];
     IColumn * current_column = column.get();

--- a/src/Processors/Formats/Impl/NpyRowInputFormat.h
+++ b/src/Processors/Formats/Impl/NpyRowInputFormat.h
@@ -54,6 +54,7 @@ private:
     DataTypePtr nested_type;
     NumpyHeader header;
     size_t counted_rows = 0;
+    size_t read_rows = 0;
 };
 
 class NpySchemaReader : public ISchemaReader

--- a/tests/queries/0_stateless/04056_npy_large_shape_validation.reference
+++ b/tests/queries/0_stateless/04056_npy_large_shape_validation.reference
@@ -5,5 +5,13 @@ INCORRECT_DATA
 BAD_ARGUMENTS
 INCORRECT_DATA
 INCORRECT_DATA
+3
+0
+0
+0
+0
+0
+['','','']
+['','','']
 [1,2,3]
 [4,5,6]

--- a/tests/queries/0_stateless/04056_npy_large_shape_validation.sh
+++ b/tests/queries/0_stateless/04056_npy_large_shape_validation.sh
@@ -124,7 +124,33 @@ sys.stdout.buffer.write(magic + version + header_len + header)
 
 ${CLICKHOUSE_CLIENT} --query "SELECT * FROM file('${CLICKHOUSE_TEST_UNIQUE_NAME}/offset_amplification.npy', 'Npy') LIMIT 1" 2>&1 | grep -m1 -o 'INCORRECT_DATA'
 
-# Test 8: Valid file still works
+# Test 8: Zero-size string dtype |S0 — valid NumPy type, must not be rejected
+# Verify both count() (uses countRows fast path) and SELECT * (uses readRow)
+python3 -c "
+import numpy as np
+np.save('${USER_FILES_PATH}/${CLICKHOUSE_TEST_UNIQUE_NAME}/s0.npy', np.ndarray(shape=(3,), dtype='|S0'))
+"
+
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM file('${CLICKHOUSE_TEST_UNIQUE_NAME}/s0.npy', 'Npy')"
+${CLICKHOUSE_CLIENT} --query "SELECT length(array) FROM file('${CLICKHOUSE_TEST_UNIQUE_NAME}/s0.npy', 'Npy')"
+
+# Test 9: Zero-size Unicode dtype <U0
+python3 -c "
+import numpy as np
+np.save('${USER_FILES_PATH}/${CLICKHOUSE_TEST_UNIQUE_NAME}/u0.npy', np.ndarray(shape=(2,), dtype='<U0'))
+"
+
+${CLICKHOUSE_CLIENT} --query "SELECT length(array) FROM file('${CLICKHOUSE_TEST_UNIQUE_NAME}/u0.npy', 'Npy')"
+
+# Test 10: Multi-dimensional zero-size string: shape=(2, 3) with |S0
+python3 -c "
+import numpy as np
+np.save('${USER_FILES_PATH}/${CLICKHOUSE_TEST_UNIQUE_NAME}/s0_2d.npy', np.ndarray(shape=(2, 3), dtype='|S0'))
+"
+
+${CLICKHOUSE_CLIENT} --query "SELECT * FROM file('${CLICKHOUSE_TEST_UNIQUE_NAME}/s0_2d.npy', 'Npy')"
+
+# Test 11: Valid file still works
 python3 -c "
 import numpy as np
 np.save('${USER_FILES_PATH}/${CLICKHOUSE_TEST_UNIQUE_NAME}/valid_shape.npy', np.array([[1, 2, 3], [4, 5, 6]], dtype=np.int32))


### PR DESCRIPTION
Follow-up to #100625. The blanket `element_size == 0` rejection was incorrect:
`np.ndarray(shape=(3,), dtype='|S0')` produces a valid `.npy` file with
zero-length string elements and zero data bytes, and NumPy loads it back fine.

Two fixes:
- Remove the `element_size == 0` rejection; guard the overflow division instead.
- Fix `readRow` to use a row counter instead of relying solely on `eof()`.
  For zero-size elements the data section is empty, so EOF is reached
  immediately despite rows remaining. This caused `SELECT count()` (which
  uses `countRows` from shape metadata) and `SELECT *` (which uses `readRow`)
  to disagree.

Closes #101133

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not for changelog — the regression was introduced in #100625 which has not been included in any release.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.521`
<!-- ch-version-info:end -->