### PR TITLE
Remove unnecessary `no-parallel` from 5 stateless tests

### DIFF
--- a/tests/queries/0_stateless/03737_ttl_delete_vertical_merge.sql
+++ b/tests/queries/0_stateless/03737_ttl_delete_vertical_merge.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 SET alter_sync = 2;
 SET optimize_throw_if_noop = 0;
 

--- a/tests/queries/0_stateless/03742_apply_row_policy_after_final.sql
+++ b/tests/queries/0_stateless/03742_apply_row_policy_after_final.sql
@@ -1,4 +1,3 @@
--- Tags: no-parallel
 -- Test for apply_row_policy_after_final setting with ReplacingMergeTree, https://github.com/ClickHouse/ClickHouse/issues/90986
 
 DROP TABLE IF EXISTS tab;

--- a/tests/queries/0_stateless/03913_jemalloc_cache_arena_metrics.sql
+++ b/tests/queries/0_stateless/03913_jemalloc_cache_arena_metrics.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 -- Verify dedicated cache arena metrics exist in system.asynchronous_metrics.
 -- When jemalloc is enabled, the dedicated cache arena metrics should be present.
 WITH

--- a/tests/queries/0_stateless/03980_datetime64_preepoch_partition_pruning_explain.sql
+++ b/tests/queries/0_stateless/03980_datetime64_preepoch_partition_pruning_explain.sql
@@ -1,4 +1,4 @@
--- Tags: no-replicated-database, no-parallel-replicas, no-parallel, no-random-merge-tree-settings
+-- Tags: no-replicated-database, no-parallel-replicas, no-random-merge-tree-settings
 -- EXPLAIN output may differ
 -- Verify that partition pruning is disabled when toDate() would overflow (pre-epoch / post-2149),
 -- but still works for normal in-range values

--- a/tests/queries/0_stateless/04049_with_func_alias_in_view.sql
+++ b/tests/queries/0_stateless/04049_with_func_alias_in_view.sql
@@ -1,4 +1,3 @@
--- Tags: no-parallel
 -- Test: WITH function-expression alias used in IN inside CREATE VIEW
 -- https://github.com/ClickHouse/ClickHouse/issues/99308
 


### PR DESCRIPTION
Remove `no-parallel` tag from 5 tests that don't modify any global state:

- **03737_ttl_delete_vertical_merge** — all tables in `currentDatabase()`, `part_log` queries filtered by database+table
- **03742_apply_row_policy_after_final** — row policies are scoped to `(name, database, table)`, no cross-database conflict
- **03913_jemalloc_cache_arena_metrics** — read-only query on `system.asynchronous_metrics`
- **03980_datetime64_preepoch_partition_pruning_explain** — only creates tables in `currentDatabase()`, checks EXPLAIN output
- **04049_with_func_alias_in_view** — only creates tables/views in `currentDatabase()`

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.437`
<!-- ch-version-info:end -->