### PR TITLE
Add log_first test coverage for executable UDF stderr_reaction

### DIFF
--- a/tests/integration/test_executable_user_defined_function/functions/test_function_config.xml
+++ b/tests/integration/test_executable_user_defined_function/functions/test_function_config.xml
@@ -422,17 +422,43 @@
         <stderr_reaction>log_last</stderr_reaction>
     </function>
 
-    <!-- default stderr_reaction (log_last): stderr with exit 0 should not throw -->
+    <!-- log_first mode: stderr should appear in exception when exit code != 0 -->
     <function>
         <type>executable</type>
-        <name>test_function_stderr_default_reaction</name>
+        <name>test_function_python_exception_log_first</name>
+        <return_type>String</return_type>
+        <argument>
+            <type>UInt64</type>
+        </argument>
+        <format>TabSeparated</format>
+        <command>input_python_exception.py</command>
+        <stderr_reaction>log_first</stderr_reaction>
+    </function>
+
+    <!-- log_first mode: stderr with exit 0 should not throw -->
+    <function>
+        <type>executable</type>
+        <name>test_function_stderr_log_first_reaction</name>
         <return_type>String</return_type>
         <argument>
             <type>String</type>
         </argument>
         <format>TabSeparated</format>
         <command>input_always_error.py</command>
-        <!-- no stderr_reaction: relies on default (log_last) -->
+        <stderr_reaction>log_first</stderr_reaction>
+    </function>
+
+    <!-- log_last mode: stderr with exit 0 should not throw -->
+    <function>
+        <type>executable</type>
+        <name>test_function_stderr_log_last_reaction</name>
+        <return_type>String</return_type>
+        <argument>
+            <type>String</type>
+        </argument>
+        <format>TabSeparated</format>
+        <command>input_always_error.py</command>
+        <stderr_reaction>log_last</stderr_reaction>
     </function>
 
     <!-- The next two UDFs have an explicit 'deterministic' tag defined -->

--- a/tests/integration/test_executable_user_defined_function/functions/test_function_config.xml
+++ b/tests/integration/test_executable_user_defined_function/functions/test_function_config.xml
@@ -461,6 +461,19 @@
         <stderr_reaction>log_last</stderr_reaction>
     </function>
 
+    <!-- none mode: stderr should be completely ignored -->
+    <function>
+        <type>executable</type>
+        <name>test_function_stderr_none_reaction</name>
+        <return_type>String</return_type>
+        <argument>
+            <type>String</type>
+        </argument>
+        <format>TabSeparated</format>
+        <command>input_always_error.py</command>
+        <stderr_reaction>none</stderr_reaction>
+    </function>
+
     <!-- The next two UDFs have an explicit 'deterministic' tag defined -->
     <function>
         <type>executable</type>

--- a/tests/integration/test_executable_user_defined_function/test.py
+++ b/tests/integration/test_executable_user_defined_function/test.py
@@ -442,17 +442,23 @@ def test_executable_function_python_exception_in_query_log(started_cluster):
         assert component in exception_text, f"Missing required component: {component}"
 
 
-def test_executable_function_default_stderr_reaction(started_cluster):
-    '''Test that UDFs writing to stderr succeed under default stderr_reaction (log_last) when exit code is 0'''
+@pytest.mark.parametrize("func_name", [
+    "test_function_stderr_log_last_reaction",
+    "test_function_stderr_log_first_reaction",
+])
+def test_executable_function_stderr_no_throw_on_success(started_cluster, func_name):
+    '''Test that UDFs writing to stderr succeed under log_last/log_first when exit code is 0'''
     skip_test_msan(node)
 
-    # input_always_error.py writes "Fake error" to stderr but exits 0
-    # With default stderr_reaction (log_last), this should NOT throw
-    assert node.query("SELECT test_function_stderr_default_reaction('abc')") == "Key abc\n"
+    assert node.query(f"SELECT {func_name}('abc')") == "Key abc\n"
 
 
-def test_executable_function_python_exception_log_last_in_query_log(started_cluster):
-    '''Test that stderr content appears in exception when exit code != 0 under log_last mode'''
+@pytest.mark.parametrize("func_name,mode", [
+    ("test_function_python_exception_log_last", "log_last"),
+    ("test_function_python_exception_log_first", "log_first"),
+])
+def test_executable_function_stderr_in_exception_on_failure(started_cluster, func_name, mode):
+    '''Test that stderr content appears in exception when exit code != 0 under log_last/log_first'''
     skip_test_msan(node)
 
     node.query("SYSTEM FLUSH LOGS")
@@ -460,11 +466,10 @@ def test_executable_function_python_exception_log_last_in_query_log(started_clus
     query_id = uuid.uuid4().hex
 
     try:
-        node.query("SELECT test_function_python_exception_log_last(1)", query_id=query_id)
+        node.query(f"SELECT {func_name}(1)", query_id=query_id)
         assert False, "Exception should have been thrown"
     except Exception as ex:
         assert "DB::Exception" in str(ex)
-        # Under log_last mode, exit code exception is enriched with stderr
         assert "Child process was exited with return code 1" in str(ex)
 
     node.query("SYSTEM FLUSH LOGS")
@@ -479,7 +484,6 @@ def test_executable_function_python_exception_log_last_in_query_log(started_clus
 
     exception_text = TSV(result).lines[0]
 
-    # Verify stderr content is included in the exit code exception
     required_components = [
         "Stderr:",
         "in process_data",
@@ -488,4 +492,4 @@ def test_executable_function_python_exception_log_last_in_query_log(started_clus
     ]
 
     for component in required_components:
-        assert component in exception_text, f"Missing required component: {component}"
+        assert component in exception_text, f"Missing required component in {mode}: {component}"

--- a/tests/integration/test_executable_user_defined_function/test.py
+++ b/tests/integration/test_executable_user_defined_function/test.py
@@ -445,9 +445,10 @@ def test_executable_function_python_exception_in_query_log(started_cluster):
 @pytest.mark.parametrize("func_name", [
     "test_function_stderr_log_last_reaction",
     "test_function_stderr_log_first_reaction",
+    "test_function_stderr_none_reaction",
 ])
 def test_executable_function_stderr_no_throw_on_success(started_cluster, func_name):
-    '''Test that UDFs writing to stderr succeed under log_last/log_first when exit code is 0'''
+    '''Test that UDFs writing to stderr succeed under log_last/log_first/none when exit code is 0'''
     skip_test_msan(node)
 
     assert node.query(f"SELECT {func_name}('abc')") == "Key abc\n"


### PR DESCRIPTION
QA requested symmetric test coverage for `log_first` mode since #99232 changed
its stderr drain logic. Existing tests only covered `log_last` and `throw`.
Also replaced the implicit default-reaction test with explicit mode configs
and parametrized the log_last/log_first tests.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.496`
<!-- ch-version-info:end -->