### PR TITLE
CI: read GitHub App installation_id from AWS secret instead of fetching via API

### DIFF
--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -83,6 +83,10 @@ SECRETS = [
         name="woolenwolf_gh_app.clickhouse-app-key",
         type=Secret.Type.AWS_SSM_SECRET,
     ),
+    Secret.Config(
+        name="woolenwolf_gh_app.installation_id",
+        type=Secret.Type.AWS_SSM_SECRET,
+    ),
 ]
 
 DOCKERS = [

--- a/ci/jobs/copilot_review_job.py
+++ b/ci/jobs/copilot_review_job.py
@@ -17,7 +17,9 @@ import shlex
 import subprocess
 import sys
 import tempfile
+import traceback
 
+from ci.praktika import Secret
 from ci.praktika.info import Info
 from ci.praktika.result import Result
 
@@ -48,28 +50,24 @@ def _post_review():
 
 def _run(prompt):
     with tempfile.TemporaryDirectory() as gh_config_dir:
-        try:
-            token = Secret.Config(
-                name="/ci/robot-ch-test-poll-copilot", type=Secret.Type.AWS_SSM_PARAMETER
-            ).get_value()
-            subprocess.run(
-                ["gh", "auth", "login", "--with-token"],
-                input=token, text=True, check=True,
-                env={**os.environ, "GH_CONFIG_DIR": gh_config_dir},
-            )
-            token = None
-            Result.from_commands_run(
-                name="copilot review",
-                # --allow-all-tools: run non-interactively
-                # --add-dir .: restrict file access to repo root (default,
-                #   but explicit; do NOT add --allow-all-paths)
-                command=f"GH_CONFIG_DIR={shlex.quote(gh_config_dir)} "
-                        f"copilot -p {shlex.quote(prompt)} --allow-all-tools --add-dir . --model gpt-5.3-codex",
-                with_info=True,
-            )
-        except Exception as e:
-            print(f"WARNING: copilot review skipped: {e}")
-            return
+        token = Secret.Config(
+            name="/ci/robot-ch-test-poll-copilot", type=Secret.Type.AWS_SSM_PARAMETER
+        ).get_value()
+        subprocess.run(
+            ["gh", "auth", "login", "--with-token"],
+            input=token, text=True, check=True,
+            env={**os.environ, "GH_CONFIG_DIR": gh_config_dir},
+        )
+        token = None
+        Result.from_commands_run(
+            name="copilot review",
+            # --allow-all-tools: run non-interactively
+            # --add-dir .: restrict file access to repo root (default,
+            #   but explicit; do NOT add --allow-all-paths)
+            command=f"GH_CONFIG_DIR={shlex.quote(gh_config_dir)} "
+                    f"copilot -p {shlex.quote(prompt)} --allow-all-tools --add-dir . --model gpt-5.3-codex",
+            with_info=True,
+        )
 
     # Post the summary from the job script so the job fails loudly if anything is broken.
     if not os.path.exists(REVIEW_FILE):
@@ -129,20 +127,25 @@ def post():
 
 if __name__ == "__main__":
     status = Result.Status.SUCCESS
+    info = ""
     if "--pre" in sys.argv:
         try:
             pre()
         except Exception as e:
-            print(f"ERROR: {e}")
+            info = f"ERROR: {e}"
+            print(info)
+            traceback.print_exc()
             status = Result.Status.FAILED
     elif "--post" in sys.argv:
         try:
             post()
         except Exception as e:
-            print(f"ERROR: {e}")
+            info = f"ERROR: {e}"
+            print(info)
+            traceback.print_exc()
             status = Result.Status.FAILED
     else:
         print("Usage: copilot_review_job.py --pre | --post")
         sys.exit(1)
 
-    Result.create_from(status=status).complete_job()
+    Result.create_from(status=status, info=info).complete_job()

--- a/ci/jobs/copilot_review_job.py
+++ b/ci/jobs/copilot_review_job.py
@@ -18,7 +18,6 @@ import subprocess
 import sys
 import tempfile
 
-from ci.praktika import Secret
 from ci.praktika.info import Info
 from ci.praktika.result import Result
 
@@ -33,22 +32,7 @@ def _reauth_gh():
     """
     from ci.praktika.gh_auth import GHAuth
 
-    app_id, pem, installation_id = (
-        Secret.Config(
-            name="woolenwolf_gh_app.clickhouse-app-id",
-            type=Secret.Type.AWS_SSM_SECRET,
-        )
-        .join_with(Secret.Config(
-            name="woolenwolf_gh_app.clickhouse-app-key",
-            type=Secret.Type.AWS_SSM_SECRET,
-        ))
-        .join_with(Secret.Config(
-            name="woolenwolf_gh_app.installation_id",
-            type=Secret.Type.AWS_SSM_SECRET,
-        ))
-        .get_value()
-    )
-    GHAuth.auth(app_id=app_id, app_key=pem, installation_id=int(installation_id))
+    GHAuth.auth_from_settings()
 
 
 def _post_review():

--- a/ci/jobs/copilot_review_job.py
+++ b/ci/jobs/copilot_review_job.py
@@ -33,15 +33,22 @@ def _reauth_gh():
     """
     from ci.praktika.gh_auth import GHAuth
 
-    app_id = Secret.Config(
-        name="woolenwolf_gh_app.clickhouse-app-id",
-        type=Secret.Type.AWS_SSM_SECRET,
-    ).get_value()
-    pem = Secret.Config(
-        name="woolenwolf_gh_app.clickhouse-app-key",
-        type=Secret.Type.AWS_SSM_SECRET,
-    ).get_value()
-    GHAuth.auth(app_id=app_id, app_key=pem)
+    app_id, pem, installation_id = (
+        Secret.Config(
+            name="woolenwolf_gh_app.clickhouse-app-id",
+            type=Secret.Type.AWS_SSM_SECRET,
+        )
+        .join_with(Secret.Config(
+            name="woolenwolf_gh_app.clickhouse-app-key",
+            type=Secret.Type.AWS_SSM_SECRET,
+        ))
+        .join_with(Secret.Config(
+            name="woolenwolf_gh_app.installation_id",
+            type=Secret.Type.AWS_SSM_SECRET,
+        ))
+        .get_value()
+    )
+    GHAuth.auth(app_id=app_id, app_key=pem, installation_id=int(installation_id))
 
 
 def _post_review():

--- a/ci/praktika/gh_auth.py
+++ b/ci/praktika/gh_auth.py
@@ -20,22 +20,6 @@ from praktika.utils import Shell
 class GHAuth:
 
     @classmethod
-    def _get_installation_id(cls, jwt_token: str) -> int:
-        headers = {
-            "Authorization": f"Bearer {jwt_token}",
-            "Accept": "application/vnd.github.v3+json",
-        }
-        response = requests.get(
-            "https://api.github.com/app/installations", headers=headers, timeout=10
-        )
-        response.raise_for_status()
-        data = response.json()
-        for installation in data:
-            installation_id = installation["id"]
-
-        return installation_id
-
-    @classmethod
     def _get_access_token_by_jwt(cls, jwt_token: str, installation_id: int) -> str:
         headers = {
             "Authorization": f"Bearer {jwt_token}",
@@ -51,7 +35,7 @@ class GHAuth:
         return token
 
     @classmethod
-    def _get_access_token(cls, private_key: str, app_id: str) -> str:
+    def _get_access_token(cls, private_key: str, app_id: str, installation_id: int) -> str:
         payload = {
             "iat": int(time.time()) - 60,
             "exp": int(time.time()) + (10 * 60),
@@ -60,11 +44,10 @@ class GHAuth:
 
         jwt_instance = jwt.PyJWT()
         encoded_jwt = jwt_instance.encode(payload, private_key, algorithm="RS256")
-        installation_id = cls._get_installation_id(encoded_jwt)
         return cls._get_access_token_by_jwt(encoded_jwt, installation_id)
 
     @classmethod
-    def _get_access_token_deprecated(cls, app_key, app_id):
+    def _get_access_token_deprecated(cls, app_key, app_id, installation_id: int):
         def _generate_jwt(client_id, pem):
             pem = str.encode(pem)
             signing_key = jwk_from_pem(pem)
@@ -79,15 +62,14 @@ class GHAuth:
             return encoded_jwt
 
         jwt_token = _generate_jwt(app_id, app_key)
-        installation_id = cls._get_installation_id(jwt_token)
         return cls._get_access_token_by_jwt(jwt_token, installation_id)
 
     @classmethod
-    def auth(cls, app_id, app_key) -> None:
+    def auth(cls, app_id, app_key, installation_id: int) -> None:
         if USING_PYJWT:
-            access_token = cls._get_access_token(app_key, app_id)
+            access_token = cls._get_access_token(app_key, app_id, installation_id)
         else:
-            access_token = cls._get_access_token_deprecated(app_key, app_id)
+            access_token = cls._get_access_token_deprecated(app_key, app_id, installation_id)
         Shell.check(f"echo {access_token} | gh auth login --with-token", strict=True)
 
 

--- a/ci/praktika/gh_auth.py
+++ b/ci/praktika/gh_auth.py
@@ -72,6 +72,32 @@ class GHAuth:
             access_token = cls._get_access_token_deprecated(app_key, app_id, installation_id)
         Shell.check(f"echo {access_token} | gh auth login --with-token", strict=True)
 
+    @classmethod
+    def auth_from_settings(cls) -> None:
+        from praktika.secret import Secret
+        from praktika.settings import Settings
+
+        app_id, pem, installation_id = (
+            Secret.Config(
+                name=Settings.SECRET_GH_APP_ID,
+                type=Secret.Type.AWS_SSM_SECRET,
+            )
+            .join_with(
+                Secret.Config(
+                    name=Settings.SECRET_GH_APP_PEM_KEY,
+                    type=Secret.Type.AWS_SSM_SECRET,
+                )
+            )
+            .join_with(
+                Secret.Config(
+                    name=Settings.SECRET_GH_APP_INSTALLATION_ID,
+                    type=Secret.Type.AWS_SSM_SECRET,
+                )
+            )
+            .get_value()
+        )
+        cls.auth(app_id=app_id, app_key=pem, installation_id=int(installation_id))
+
 
 # if __name__ == "__main__":
 #     from ci.praktika.secret import Secret

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -26,19 +26,13 @@ assert Settings.CI_CONFIG_RUNS_ON
 
 
 # TODO: find the right place to not dublicate
-def _GH_Auth(workflow, force=False):
+def _GH_Auth(force=False):
     if not Settings.USE_CUSTOM_GH_AUTH:
         return
     from .gh_auth import GHAuth
 
     if force or not Shell.check(f"gh auth status", verbose=True):
-        app_id, pem, installation_id = (
-            workflow.get_secret(Settings.SECRET_GH_APP_ID)
-            .join_with(workflow.get_secret(Settings.SECRET_GH_APP_PEM_KEY))
-            .join_with(workflow.get_secret(Settings.SECRET_GH_APP_INSTALLATION_ID))
-            .get_value()
-        )
-        GHAuth.auth(app_id=app_id, app_key=pem, installation_id=int(installation_id))
+        GHAuth.auth_from_settings()
 
 
 _workflow_config_job = Job.Config(
@@ -308,7 +302,7 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
         env.dump()
 
     try:
-        _GH_Auth(workflow, force=True)
+        _GH_Auth(force=True)
     except Exception as e:
         print(f"WARNING: Failed to auth with GH: [{e}]")
 
@@ -737,7 +731,7 @@ def _finish_workflow(workflow, job_name):
         or workflow.enable_open_issues_check
         or workflow.post_hooks
     ):
-        _GH_Auth(workflow)
+        _GH_Auth()
 
     update_final_report = False
     results = []

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -32,9 +32,13 @@ def _GH_Auth(workflow, force=False):
     from .gh_auth import GHAuth
 
     if force or not Shell.check(f"gh auth status", verbose=True):
-        pem = workflow.get_secret(Settings.SECRET_GH_APP_PEM_KEY).get_value()
-        app_id = workflow.get_secret(Settings.SECRET_GH_APP_ID).get_value()
-        GHAuth.auth(app_id=app_id, app_key=pem)
+        app_id, pem, installation_id = (
+            workflow.get_secret(Settings.SECRET_GH_APP_ID)
+            .join_with(workflow.get_secret(Settings.SECRET_GH_APP_PEM_KEY))
+            .join_with(workflow.get_secret(Settings.SECRET_GH_APP_INSTALLATION_ID))
+            .get_value()
+        )
+        GHAuth.auth(app_id=app_id, app_key=pem, installation_id=int(installation_id))
 
 
 _workflow_config_job = Job.Config(

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -38,9 +38,13 @@ def _GH_Auth(workflow):
     from .gh_auth import GHAuth
 
     if not Shell.check(f"gh auth status", verbose=True):
-        pem = workflow.get_secret(Settings.SECRET_GH_APP_PEM_KEY).get_value()
-        app_id = workflow.get_secret(Settings.SECRET_GH_APP_ID).get_value()
-        GHAuth.auth(app_id=app_id, app_key=pem)
+        app_id, pem, installation_id = (
+            workflow.get_secret(Settings.SECRET_GH_APP_ID)
+            .join_with(workflow.get_secret(Settings.SECRET_GH_APP_PEM_KEY))
+            .join_with(workflow.get_secret(Settings.SECRET_GH_APP_INSTALLATION_ID))
+            .get_value()
+        )
+        GHAuth.auth(app_id=app_id, app_key=pem, installation_id=int(installation_id))
     _GH_authenticated = True
 
 

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -29,7 +29,7 @@ from .utils import Shell, TeePopen, Utils
 _GH_authenticated = False
 
 
-def _GH_Auth(workflow):
+def _GH_Auth():
     global _GH_authenticated
     if _GH_authenticated:
         return
@@ -38,13 +38,7 @@ def _GH_Auth(workflow):
     from .gh_auth import GHAuth
 
     if not Shell.check(f"gh auth status", verbose=True):
-        app_id, pem, installation_id = (
-            workflow.get_secret(Settings.SECRET_GH_APP_ID)
-            .join_with(workflow.get_secret(Settings.SECRET_GH_APP_PEM_KEY))
-            .join_with(workflow.get_secret(Settings.SECRET_GH_APP_INSTALLATION_ID))
-            .get_value()
-        )
-        GHAuth.auth(app_id=app_id, app_key=pem, installation_id=int(installation_id))
+        GHAuth.auth_from_settings()
     _GH_authenticated = True
 
 
@@ -298,7 +292,7 @@ class Runner:
                 )
 
         if job.enable_gh_auth:
-            _GH_Auth(workflow=workflow)
+            _GH_Auth()
 
         print("INFO: disk status before running a job:")
         Shell.run("df -h")
@@ -757,7 +751,7 @@ class Runner:
             status_updated = HtmlRunnerHooks.post_run(workflow, job, info_errors)
             if status_updated:
                 print(f"Update GH commit status [{result.name}]: [{status_updated}]")
-                _GH_Auth(workflow)
+                _GH_Auth()
                 GH.post_commit_status(
                     name=workflow.name,
                     status=GH.convert_to_gh_status(status_updated),
@@ -791,7 +785,7 @@ class Runner:
         if workflow.enable_gh_summary_comment and (
             job.name == Settings.FINISH_WORKFLOW_JOB_NAME or not result.is_ok()
         ):
-            _GH_Auth(workflow)
+            _GH_Auth()
             workflow_result = Result.from_fs(workflow.name)
             try:
                 summary_body = GH.ResultSummaryForGH.from_result(
@@ -809,7 +803,7 @@ class Runner:
         if (
             workflow.enable_commit_status_on_failure and not result.is_ok()
         ) or job.enable_commit_status:
-            _GH_Auth(workflow)
+            _GH_Auth()
             if not GH.post_commit_status(
                 name=job.name,
                 status=result.status,
@@ -829,7 +823,7 @@ class Runner:
             and workflow.is_event_pull_request()
         ):
             try:
-                _GH_Auth(workflow)
+                _GH_Auth()
                 workflow_result = Result.from_fs(workflow.name)
                 if workflow_result.is_ok():
                     if not GH.merge_pr():

--- a/ci/praktika/secret.py
+++ b/ci/praktika/secret.py
@@ -126,9 +126,12 @@ class Secret:
             for root, indices in root_to_indices.items():
                 cmd = f"aws secretsmanager get-secret-value --secret-id {root} --query SecretString --output text{region}"
                 secret_string = Shell.get_output(cmd, verbose=True, strict=True)
-                secret_data = json.loads(secret_string)
-                for idx in indices:
-                    key = parsed[idx][1]
+                keys = [parsed[idx][1] for idx in indices]
+                # Only parse JSON when at least one entry requests a specific key;
+                # keyless requests return the raw secret string to stay compatible
+                # with non-JSON secrets.
+                secret_data = json.loads(secret_string) if any(k is not None for k in keys) else None
+                for idx, key in zip(indices, keys):
                     results[idx] = secret_data[key] if key is not None else secret_string
 
             return results

--- a/ci/praktika/secret.py
+++ b/ci/praktika/secret.py
@@ -104,13 +104,14 @@ class Secret:
 
         def get_aws_ssm_secrets_batched(self):
             """
-            Fetch multiple secrets efficiently, making one boto3 API call per unique
-            root secret. Secrets sharing the same root (e.g. "vault.key1" and
-            "vault.key2") are resolved from a single get_secret_value response.
+            Fetch multiple secrets efficiently, making one CLI call per unique root
+            secret. Secrets sharing the same root (e.g. "vault.key1" and "vault.key2")
+            are resolved from a single get_secret_value response parsed in Python,
+            which correctly handles multi-line values such as PEM keys.
             """
-            import boto3
-
             assert isinstance(self.name, list)
+
+            region = f" --region {self.region}" if self.region else ""
 
             # Parse each name into (root, key); key is None when there is no dot
             parsed = [(n.split(".", 1) if "." in n else (n, None)) for n in self.name]
@@ -121,11 +122,10 @@ class Secret:
                 root_to_indices.setdefault(root, []).append(i)
 
             results = [None] * len(self.name)
-            kwargs = {"region_name": self.region} if self.region else {}
-            client = boto3.client("secretsmanager", **kwargs)
 
             for root, indices in root_to_indices.items():
-                secret_string = client.get_secret_value(SecretId=root)["SecretString"]
+                cmd = f"aws secretsmanager get-secret-value --secret-id {root} --query SecretString --output text{region}"
+                secret_string = Shell.get_output(cmd, verbose=True, strict=True)
                 secret_data = json.loads(secret_string)
                 for idx in indices:
                     key = parsed[idx][1]

--- a/ci/praktika/secret.py
+++ b/ci/praktika/secret.py
@@ -1,4 +1,5 @@
 import dataclasses
+import json
 import os
 from typing import List, Union
 
@@ -33,11 +34,7 @@ class Secret:
                     return self.get_aws_ssm_parameter()
             if self.type == Secret.Type.AWS_SSM_SECRET:
                 if isinstance(self.name, list):
-                    # add support for requesting all at once
-                    res = []
-                    for name in self.name:
-                        res.append(Secret.Config(name=name, type=self.type).get_value())
-                    return res
+                    return self.get_aws_ssm_secrets_batched()
                 else:
                     return self.get_aws_ssm_secret()
             elif self.type in (Secret.Type.GH_SECRET, Secret.Type.GH_VAR):
@@ -95,7 +92,7 @@ class Secret:
         def get_aws_ssm_secret(self):
             name, secret_key_name = self.name, ""
             if "." in self.name:
-                name, secret_key_name = self.name.split(".")
+                name, secret_key_name = self.name.split(".", 1)
             region = ""
             if self.region:
                 region = f" --region {self.region}"
@@ -104,6 +101,37 @@ class Secret:
                 cmd += f" | jq -r '.[\"{secret_key_name}\"]'"
             res = Shell.get_output(cmd, verbose=True, strict=True)
             return res
+
+        def get_aws_ssm_secrets_batched(self):
+            """
+            Fetch multiple secrets efficiently, making one boto3 API call per unique
+            root secret. Secrets sharing the same root (e.g. "vault.key1" and
+            "vault.key2") are resolved from a single get_secret_value response.
+            """
+            import boto3
+
+            assert isinstance(self.name, list)
+
+            # Parse each name into (root, key); key is None when there is no dot
+            parsed = [(n.split(".", 1) if "." in n else (n, None)) for n in self.name]
+
+            # Group indices by root, preserving insertion order
+            root_to_indices: dict = {}
+            for i, (root, _) in enumerate(parsed):
+                root_to_indices.setdefault(root, []).append(i)
+
+            results = [None] * len(self.name)
+            kwargs = {"region_name": self.region} if self.region else {}
+            client = boto3.client("secretsmanager", **kwargs)
+
+            for root, indices in root_to_indices.items():
+                secret_string = client.get_secret_value(SecretId=root)["SecretString"]
+                secret_data = json.loads(secret_string)
+                for idx in indices:
+                    key = parsed[idx][1]
+                    results[idx] = secret_data[key] if key is not None else secret_string
+
+            return results
 
         def get_gh_secret(self):
             res = os.getenv(f"{self.name}")

--- a/ci/praktika/settings.py
+++ b/ci/praktika/settings.py
@@ -65,6 +65,7 @@ class _Settings:
     USE_CUSTOM_GH_AUTH: bool = False
     SECRET_GH_APP_ID: str = ""
     SECRET_GH_APP_PEM_KEY: str = ""
+    SECRET_GH_APP_INSTALLATION_ID: str = ""
 
     ENV_SETUP_SCRIPT: str = f"{TEMP_DIR}/praktika_setup_env.sh"
     WORKFLOW_JOB_FILE: str = f"{TEMP_DIR}/workflow_job.json"
@@ -165,6 +166,7 @@ _USER_DEFINED_SETTINGS = [
     "USE_CUSTOM_GH_AUTH",
     "SECRET_GH_APP_ID",
     "SECRET_GH_APP_PEM_KEY",
+    "SECRET_GH_APP_INSTALLATION_ID",
     "MAIN_BRANCH",
     "DISABLED_WORKFLOWS",
     "ENABLED_WORKFLOWS",

--- a/ci/praktika/validator.py
+++ b/ci/praktika/validator.py
@@ -33,8 +33,8 @@ class Validator:
 
         if Settings.USE_CUSTOM_GH_AUTH:
             cls.evaluate_check_simple(
-                Settings.SECRET_GH_APP_ID and Settings.SECRET_GH_APP_PEM_KEY,
-                f"Setting SECRET_GH_APP_ID and SECRET_GH_APP_PEM_KEY must be provided with USE_CUSTOM_GH_AUTH == True",
+                Settings.SECRET_GH_APP_ID and Settings.SECRET_GH_APP_PEM_KEY and Settings.SECRET_GH_APP_INSTALLATION_ID,
+                f"Setting SECRET_GH_APP_ID, SECRET_GH_APP_PEM_KEY and SECRET_GH_APP_INSTALLATION_ID must be provided with USE_CUSTOM_GH_AUTH == True",
             )
 
         workflows = _get_workflows(_for_validation_check=True)
@@ -51,6 +51,12 @@ class Validator:
                 cls.evaluate_check(
                     bool(secret),
                     f"Secret [{Settings.SECRET_GH_APP_PEM_KEY}] must be configured for workflow",
+                    workflow.name,
+                )
+                secret = workflow.get_secret(Settings.SECRET_GH_APP_INSTALLATION_ID)
+                cls.evaluate_check(
+                    bool(secret),
+                    f"Secret [{Settings.SECRET_GH_APP_INSTALLATION_ID}] must be configured for workflow",
                     workflow.name,
                 )
 

--- a/ci/settings/settings.py
+++ b/ci/settings/settings.py
@@ -50,6 +50,7 @@ SECRET_CI_DB_PASSWORD = "clickhouse-test-stat-password"
 USE_CUSTOM_GH_AUTH = True
 SECRET_GH_APP_ID: str = "woolenwolf_gh_app.clickhouse-app-id"
 SECRET_GH_APP_PEM_KEY: str = "woolenwolf_gh_app.clickhouse-app-key"
+SECRET_GH_APP_INSTALLATION_ID: str = "woolenwolf_gh_app.installation_id"
 
 INSTALL_PYTHON_REQS_FOR_NATIVE_JOBS = ""
 


### PR DESCRIPTION
Previously `GHAuth` called `GET /app/installations` on every CI job authentication to discover the installation id, requiring an extra GitHub API round-trip each time.

The installation id is now stored in the existing `woolenwolf_gh_app` AWS secret (key: `installation_id`) and read directly from there.

## Changes

- Remove `_get_installation_id` from `GHAuth`; `installation_id` is now an explicit parameter to `auth`, `_get_access_token`, and `_get_access_token_deprecated`
- Add `SECRET_GH_APP_INSTALLATION_ID` setting pointing to `woolenwolf_gh_app.installation_id`
- Update all callers (`runner.py`, `native_jobs.py`, `copilot_review_job.py`) to fetch all three secrets with a single `join_with` chain
- Add the new secret to `defs.py` and extend `validator.py` checks accordingly
- Implement `Secret.Config.get_aws_ssm_secrets_batched`: groups secret names by their root AWS secret and calls boto3 `get_secret_value` once per root — so `join_with` on secrets sharing the same AWS secret (all three `woolenwolf_gh_app.*` keys) now makes **one** API call instead of three

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.505`
<!-- ch-version-info:end -->