### PR TITLE
Add TPC-DS as a performance test

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -613,7 +613,7 @@ def main():
 
         def run_tests():
             # Run 10 random queries per test by default, but all queries for benchmarks
-            benchmarks = {"clickbench.xml", "tpch.xml"}
+            benchmarks = {"clickbench.xml", "tpch.xml", "tpcds.xml"}
             for test in test_files:
                 max_queries = 0 if test in benchmarks else 10
                 CHServer.run_test(

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -494,6 +494,7 @@ def main():
                 "hits1": "https://clickhouse-datasets.s3.amazonaws.com/hits/partitions/hits_v1.tar",
                 "values": "https://clickhouse-datasets.s3.amazonaws.com/values_with_expressions/partitions/test_values.tar",
                 "tpch10": "https://clickhouse-datasets.s3.amazonaws.com/h/10/tpch.tar",
+                "tpcds1": "https://clickhouse-datasets.s3.amazonaws.com/ds/scale_1/tpcds.tar",
             }
             cmds = []
             for dataset_path in dataset_paths.values():

--- a/ci/jobs/scripts/perf/download.sh
+++ b/ci/jobs/scripts/perf/download.sh
@@ -18,7 +18,7 @@ mkdir left ||:
 ## right_pr=$3 not used for now
 #right_sha=$4
 
-datasets=${CHPC_DATASETS-"hits1 hits10 hits100 values tpch10"}
+datasets=${CHPC_DATASETS-"hits1 hits10 hits100 values tpch10 tpcds1"}
 
 declare -A dataset_paths
 dataset_paths["hits10"]="https://clickhouse-private-datasets.s3.amazonaws.com/hits_10m_single/partitions/hits_10m_single.tar"
@@ -26,6 +26,7 @@ dataset_paths["hits100"]="https://clickhouse-private-datasets.s3.amazonaws.com/h
 dataset_paths["hits1"]="https://clickhouse-datasets.s3.amazonaws.com/hits/partitions/hits_v1.tar"
 dataset_paths["values"]="https://clickhouse-datasets.s3.amazonaws.com/values_with_expressions/partitions/test_values.tar"
 dataset_paths["tpch10"]="https://clickhouse-datasets.s3.amazonaws.com/h/10/tpch.tar"
+dataset_paths["tpcds1"]="https://clickhouse-datasets.s3.amazonaws.com/ds/scale_1/tpcds.tar"
 
 
 function download

--- a/ci/jobs/scripts/perf/report.py
+++ b/ci/jobs/scripts/perf/report.py
@@ -32,7 +32,7 @@ slower_queries = 0
 unstable_queries = 0
 very_unstable_queries = 0
 unstable_backward_incompatible_queries = 0
-benchmarks = {"clickbench", "tpch"}  # already fast enough, here for consistency
+benchmarks = {"clickbench", "tpch", "tpcds"}
 
 # max seconds to run one query by itself, not counting preparation
 # by default it's 2 seconds, but for benchmarks it's 8 seconds

--- a/tests/performance/scripts/perf.py
+++ b/tests/performance/scripts/perf.py
@@ -277,6 +277,19 @@ def first_keyword(sql):
     return ""
 
 
+def execute_query_group(connection, q_list, query_id, settings):
+    """
+    Execute a group of SQL statements sequentially and return the total server-side elapsed time.
+    Some benchmark queries (e.g. TPC-DS Q14) consist of multiple SELECT statements in one file.
+    We run them together and sum the elapsed time so that they appear as a single entry in the performance report.
+    """
+    total = 0
+    for q in q_list:
+        connection.execute(q, query_id=query_id, settings=settings)
+        total += connection.last_query.elapsed
+    return total
+
+
 def load_settings_file(xml_root, base_dir):
     """Load settings from a JSON file referenced by <settings file="..."/> attribute."""
     elem = xml_root.find("settings")
@@ -296,13 +309,14 @@ def load_settings_file(xml_root, base_dir):
 # Not worth fixing properly unless we have such scenario, the whole perf test suite needs a rewrite.
 extra_create_queries = []
 extra_drop_queries = []
-test_queries = []
+test_queries = []  # list[list[str]]: each entry is a group of SQL statements to execute and time together
 for e in root.findall("query"):
     if "file" in e.attrib:
         query_path = os.path.join(xml_dir, e.attrib["file"])
         with open(query_path, "r", encoding="utf-8") as f:
             full_text = f.read().strip()
         statements = split_sql_statements(full_text)
+        select_stmts = []
         for stmt in statements:
             keyword = first_keyword(stmt)
             if keyword in ("CREATE", "ALTER"):
@@ -310,9 +324,14 @@ for e in root.findall("query"):
             elif keyword in ("DROP", "TRUNCATE"):
                 extra_drop_queries.append(stmt)
             else:
-                test_queries += substitute_parameters([stmt])
+                select_stmts.append(stmt)
+        # Multi-SELECT files (e.g. TPC-DS Q14) are grouped into one timed entry.
+        if len(select_stmts) > 1:
+            test_queries.append(substitute_parameters(select_stmts))
+        else:
+            test_queries += [[s] for s in substitute_parameters(select_stmts)]
     else:
-        test_queries += substitute_parameters([e.text])
+        test_queries += [[s] for s in substitute_parameters([e.text])]
 
 # If we're given a list of queries to run, check that it makes sense.
 for i in args.queries_to_run or []:
@@ -325,7 +344,7 @@ for i in args.queries_to_run or []:
 # If we're only asked to print the queries, do that and exit.
 if args.print_queries:
     for i in args.queries_to_run or range(0, len(test_queries)):
-        print(test_queries[i])
+        print(";\n".join(test_queries[i]))
     exit(0)
 
 # If we're only asked to print the settings, do that and exit. These are settings
@@ -465,13 +484,13 @@ if args.queries_to_run:
 # Run test queries.
 profile_total_seconds = 0
 for query_index in queries_to_run:
-    q = test_queries[query_index]
+    q_list = test_queries[query_index]
     query_prefix = f"{test_name}.query{query_index}"
 
     # We have some crazy long queries (about 100kB), so trim them to a sane
     # length. This means we can't use query text as an identifier and have to
     # use the test name + the test-wide query index.
-    query_display_name = q
+    query_display_name = ";\n".join(q_list)
     if len(query_display_name) > 1000:
         query_display_name = f"{query_display_name[:1000]}...({query_index})"
 
@@ -504,10 +523,11 @@ for query_index in queries_to_run:
                 # * collect profiler traces, which might be helpful for analyzing
                 #   test coverage. We disable profiler for normal runs because
                 #   it makes the results unstable.
-                res = c.execute(
-                    q,
-                    query_id=prewarm_id,
-                    settings={
+                prewarm_elapsed = execute_query_group(
+                    c,
+                    q_list,
+                    prewarm_id,
+                    {
                         "max_execution_time": args.prewarm_max_query_seconds,
                         "query_profiler_real_time_period_ns": 10000000,
                         "query_profiler_cpu_time_period_ns": 10000000,
@@ -522,7 +542,7 @@ for query_index in queries_to_run:
                 raise
 
             print(
-                f"prewarm\t{query_index}\t{prewarm_id}\t{conn_index}\t{c.last_query.elapsed}"
+                f"prewarm\t{query_index}\t{prewarm_id}\t{conn_index}\t{prewarm_elapsed}"
             )
         except KeyboardInterrupt:
             raise
@@ -569,10 +589,8 @@ for query_index in queries_to_run:
 
         for conn_index, c in enumerate(this_query_connections):
             try:
-                res = c.execute(
-                    q,
-                    query_id=run_id,
-                    settings={"max_execution_time": args.max_query_seconds},
+                elapsed = execute_query_group(
+                    c, q_list, run_id, {"max_execution_time": args.max_query_seconds}
                 )
             except clickhouse_driver.errors.Error as e:
                 # Add query id to the exception to make debugging easier.
@@ -580,7 +598,6 @@ for query_index in queries_to_run:
                 e.message = run_id + ": " + e.message
                 raise
 
-            elapsed = c.last_query.elapsed
             all_server_times[conn_index].append(elapsed)
 
             server_seconds += elapsed
@@ -641,17 +658,18 @@ for query_index in queries_to_run:
 
         for conn_index, c in enumerate(this_query_connections):
             try:
-                res = c.execute(
-                    q,
-                    query_id=run_id,
-                    settings={
+                profile_elapsed = execute_query_group(
+                    c,
+                    q_list,
+                    run_id,
+                    {
                         "query_profiler_real_time_period_ns": 10000000,
                         "query_profiler_cpu_time_period_ns": 10000000,
                         "metrics_perf_events_enabled": 1,
                     },
                 )
                 print(
-                    f"profile\t{query_index}\t{run_id}\t{conn_index}\t{c.last_query.elapsed}"
+                    f"profile\t{query_index}\t{run_id}\t{conn_index}\t{profile_elapsed}"
                 )
             except clickhouse_driver.errors.Error as e:
                 # Add query id to the exception to make debugging easier.

--- a/tests/performance/scripts/perf.py
+++ b/tests/performance/scripts/perf.py
@@ -325,11 +325,16 @@ for e in root.findall("query"):
                 extra_drop_queries.append(stmt)
             else:
                 select_stmts.append(stmt)
-        # Multi-SELECT files (e.g. TPC-DS Q14) are grouped into one timed entry.
-        if len(select_stmts) > 1:
-            test_queries.append(substitute_parameters(select_stmts))
-        else:
-            test_queries += [[s] for s in substitute_parameters(select_stmts)]
+        # Some benchmark queries (e.g. TPC-DS Q14) have multiple SELECTs in one file.
+        # They are executed together and timed as a single entry in the report.
+        # Substitution parameters are expanded per-statement and then zipped, so that each group contains statements with same parameters.
+        # Example:
+        #   select_stmts = ["SELECT FROM {t}.x", "SELECT FROM {t}.y"], {t} = [a, b]
+        #   expanded = [["SELECT FROM a.x", "SELECT FROM b.x"], ["SELECT FROM a.y", "SELECT FROM b.y"]]
+        #   zip(*expanded) -> ("SELECT FROM a.x", "SELECT FROM a.y"), ("SELECT FROM b.x", "SELECT FROM b.y")
+        expanded = [substitute_parameters([s]) for s in select_stmts]
+        for group in zip(*expanded):
+            test_queries.append(list(group))
     else:
         test_queries += [[s] for s in substitute_parameters([e.text])]
 

--- a/tests/performance/tpcds.xml
+++ b/tests/performance/tpcds.xml
@@ -49,7 +49,7 @@
 <!-- Q32 --> <query file="../benchmarks/tpc-ds/queries/query_32.sql"/>
 <!-- Q33 --> <query file="../benchmarks/tpc-ds/queries/query_33.sql"/>
 <!-- Q34 --> <query file="../benchmarks/tpc-ds/queries/query_34.sql"/>
-<!-- Q35 --> <query file="../benchmarks/tpc-ds/queries/query_35.sql"/>
+<!-- Q35 excluded: problematic, see tests/benchmarks/tpc-ds/README.md  --> <query>SELECT 'Q35 skipped'</query>
 <!-- Q36 --> <query file="../benchmarks/tpc-ds/queries/query_36.sql"/>
 <!-- Q37 --> <query file="../benchmarks/tpc-ds/queries/query_37.sql"/>
 <!-- Q38 --> <query file="../benchmarks/tpc-ds/queries/query_38.sql"/>

--- a/tests/performance/tpcds.xml
+++ b/tests/performance/tpcds.xml
@@ -1,4 +1,5 @@
 <!-- https://clickhouse.com/docs/getting-started/example-datasets/tpcds -->
+<!-- Scale factor: 1 -->
 <test>
 
 <settings file="../benchmarks/tpc-ds/settings.json"/>

--- a/tests/performance/tpcds.xml
+++ b/tests/performance/tpcds.xml
@@ -1,0 +1,117 @@
+<!-- https://clickhouse.com/docs/getting-started/example-datasets/tpcds -->
+<test>
+
+<settings file="../benchmarks/tpc-ds/settings.json"/>
+
+<substitutions>
+    <substitution>
+        <name>table</name>
+        <values>
+            <value>tpcds</value>
+        </values>
+    </substitution>
+</substitutions>
+
+<fill_query>USE {table}</fill_query>
+
+<!-- Q1 -->  <query file="../benchmarks/tpc-ds/queries/query_01.sql"/>
+<!-- Q2 -->  <query file="../benchmarks/tpc-ds/queries/query_02.sql"/>
+<!-- Q3 -->  <query file="../benchmarks/tpc-ds/queries/query_03.sql"/>
+<!-- Q4 -->  <query file="../benchmarks/tpc-ds/queries/query_04.sql"/>
+<!-- Q5 -->  <query file="../benchmarks/tpc-ds/queries/query_05.sql"/>
+<!-- Q6 -->  <query file="../benchmarks/tpc-ds/queries/query_06.sql"/>
+<!-- Q7 -->  <query file="../benchmarks/tpc-ds/queries/query_07.sql"/>
+<!-- Q8 -->  <query file="../benchmarks/tpc-ds/queries/query_08.sql"/>
+<!-- Q9 -->  <query file="../benchmarks/tpc-ds/queries/query_09.sql"/>
+<!-- Q10 --> <query file="../benchmarks/tpc-ds/queries/query_10.sql"/>
+<!-- Q11 --> <query file="../benchmarks/tpc-ds/queries/query_11.sql"/>
+<!-- Q12 --> <query file="../benchmarks/tpc-ds/queries/query_12.sql"/>
+<!-- Q13 --> <query file="../benchmarks/tpc-ds/queries/query_13.sql"/>
+<!-- Q14 --> <query file="../benchmarks/tpc-ds/queries/query_14.sql"/>
+<!-- Q15 --> <query file="../benchmarks/tpc-ds/queries/query_15.sql"/>
+<!-- Q16 --> <query file="../benchmarks/tpc-ds/queries/query_16.sql"/>
+<!-- Q17 --> <query file="../benchmarks/tpc-ds/queries/query_17.sql"/>
+<!-- Q18 --> <query file="../benchmarks/tpc-ds/queries/query_18.sql"/>
+<!-- Q19 --> <query file="../benchmarks/tpc-ds/queries/query_19.sql"/>
+<!-- Q20 --> <query file="../benchmarks/tpc-ds/queries/query_20.sql"/>
+<!-- Q21 --> <query file="../benchmarks/tpc-ds/queries/query_21.sql"/>
+<!-- Q22 --> <query file="../benchmarks/tpc-ds/queries/query_22.sql"/>
+<!-- Q23 --> <query file="../benchmarks/tpc-ds/queries/query_23.sql"/>
+<!-- Q24 --> <query file="../benchmarks/tpc-ds/queries/query_24.sql"/>
+<!-- Q25 --> <query file="../benchmarks/tpc-ds/queries/query_25.sql"/>
+<!-- Q26 --> <query file="../benchmarks/tpc-ds/queries/query_26.sql"/>
+<!-- Q27 --> <query file="../benchmarks/tpc-ds/queries/query_27.sql"/>
+<!-- Q28 --> <query file="../benchmarks/tpc-ds/queries/query_28.sql"/>
+<!-- Q29 --> <query file="../benchmarks/tpc-ds/queries/query_29.sql"/>
+<!-- Q30 --> <query file="../benchmarks/tpc-ds/queries/query_30.sql"/>
+<!-- Q31 --> <query file="../benchmarks/tpc-ds/queries/query_31.sql"/>
+<!-- Q32 --> <query file="../benchmarks/tpc-ds/queries/query_32.sql"/>
+<!-- Q33 --> <query file="../benchmarks/tpc-ds/queries/query_33.sql"/>
+<!-- Q34 --> <query file="../benchmarks/tpc-ds/queries/query_34.sql"/>
+<!-- Q35 --> <query file="../benchmarks/tpc-ds/queries/query_35.sql"/>
+<!-- Q36 --> <query file="../benchmarks/tpc-ds/queries/query_36.sql"/>
+<!-- Q37 --> <query file="../benchmarks/tpc-ds/queries/query_37.sql"/>
+<!-- Q38 --> <query file="../benchmarks/tpc-ds/queries/query_38.sql"/>
+<!-- Q39 --> <query file="../benchmarks/tpc-ds/queries/query_39.sql"/>
+<!-- Q40 --> <query file="../benchmarks/tpc-ds/queries/query_40.sql"/>
+<!-- Q41 --> <query file="../benchmarks/tpc-ds/queries/query_41.sql"/>
+<!-- Q42 --> <query file="../benchmarks/tpc-ds/queries/query_42.sql"/>
+<!-- Q43 --> <query file="../benchmarks/tpc-ds/queries/query_43.sql"/>
+<!-- Q44 --> <query file="../benchmarks/tpc-ds/queries/query_44.sql"/>
+<!-- Q45 --> <query file="../benchmarks/tpc-ds/queries/query_45.sql"/>
+<!-- Q46 --> <query file="../benchmarks/tpc-ds/queries/query_46.sql"/>
+<!-- Q47 --> <query file="../benchmarks/tpc-ds/queries/query_47.sql"/>
+<!-- Q48 --> <query file="../benchmarks/tpc-ds/queries/query_48.sql"/>
+<!-- Q49 --> <query file="../benchmarks/tpc-ds/queries/query_49.sql"/>
+<!-- Q50 --> <query file="../benchmarks/tpc-ds/queries/query_50.sql"/>
+<!-- Q51 --> <query file="../benchmarks/tpc-ds/queries/query_51.sql"/>
+<!-- Q52 --> <query file="../benchmarks/tpc-ds/queries/query_52.sql"/>
+<!-- Q53 --> <query file="../benchmarks/tpc-ds/queries/query_53.sql"/>
+<!-- Q54 --> <query file="../benchmarks/tpc-ds/queries/query_54.sql"/>
+<!-- Q55 --> <query file="../benchmarks/tpc-ds/queries/query_55.sql"/>
+<!-- Q56 --> <query file="../benchmarks/tpc-ds/queries/query_56.sql"/>
+<!-- Q57 --> <query file="../benchmarks/tpc-ds/queries/query_57.sql"/>
+<!-- Q58 --> <query file="../benchmarks/tpc-ds/queries/query_58.sql"/>
+<!-- Q59 --> <query file="../benchmarks/tpc-ds/queries/query_59.sql"/>
+<!-- Q60 --> <query file="../benchmarks/tpc-ds/queries/query_60.sql"/>
+<!-- Q61 --> <query file="../benchmarks/tpc-ds/queries/query_61.sql"/>
+<!-- Q62 --> <query file="../benchmarks/tpc-ds/queries/query_62.sql"/>
+<!-- Q63 --> <query file="../benchmarks/tpc-ds/queries/query_63.sql"/>
+<!-- Q64 --> <query file="../benchmarks/tpc-ds/queries/query_64.sql"/>
+<!-- Q65 --> <query file="../benchmarks/tpc-ds/queries/query_65.sql"/>
+<!-- Q66 --> <query file="../benchmarks/tpc-ds/queries/query_66.sql"/>
+<!-- Q67 --> <query file="../benchmarks/tpc-ds/queries/query_67.sql"/>
+<!-- Q68 --> <query file="../benchmarks/tpc-ds/queries/query_68.sql"/>
+<!-- Q69 --> <query file="../benchmarks/tpc-ds/queries/query_69.sql"/>
+<!-- Q70 --> <query file="../benchmarks/tpc-ds/queries/query_70.sql"/>
+<!-- Q71 --> <query file="../benchmarks/tpc-ds/queries/query_71.sql"/>
+<!-- Q72 --> <query file="../benchmarks/tpc-ds/queries/query_72.sql"/>
+<!-- Q73 --> <query file="../benchmarks/tpc-ds/queries/query_73.sql"/>
+<!-- Q74 --> <query file="../benchmarks/tpc-ds/queries/query_74.sql"/>
+<!-- Q75 --> <query file="../benchmarks/tpc-ds/queries/query_75.sql"/>
+<!-- Q76 --> <query file="../benchmarks/tpc-ds/queries/query_76.sql"/>
+<!-- Q77 --> <query file="../benchmarks/tpc-ds/queries/query_77.sql"/>
+<!-- Q78 --> <query file="../benchmarks/tpc-ds/queries/query_78.sql"/>
+<!-- Q79 --> <query file="../benchmarks/tpc-ds/queries/query_79.sql"/>
+<!-- Q80 --> <query file="../benchmarks/tpc-ds/queries/query_80.sql"/>
+<!-- Q81 --> <query file="../benchmarks/tpc-ds/queries/query_81.sql"/>
+<!-- Q82 --> <query file="../benchmarks/tpc-ds/queries/query_82.sql"/>
+<!-- Q83 --> <query file="../benchmarks/tpc-ds/queries/query_83.sql"/>
+<!-- Q84 --> <query file="../benchmarks/tpc-ds/queries/query_84.sql"/>
+<!-- Q85 --> <query file="../benchmarks/tpc-ds/queries/query_85.sql"/>
+<!-- Q86 --> <query file="../benchmarks/tpc-ds/queries/query_86.sql"/>
+<!-- Q87 --> <query file="../benchmarks/tpc-ds/queries/query_87.sql"/>
+<!-- Q88 --> <query file="../benchmarks/tpc-ds/queries/query_88.sql"/>
+<!-- Q89 --> <query file="../benchmarks/tpc-ds/queries/query_89.sql"/>
+<!-- Q90 --> <query file="../benchmarks/tpc-ds/queries/query_90.sql"/>
+<!-- Q91 --> <query file="../benchmarks/tpc-ds/queries/query_91.sql"/>
+<!-- Q92 --> <query file="../benchmarks/tpc-ds/queries/query_92.sql"/>
+<!-- Q93 --> <query file="../benchmarks/tpc-ds/queries/query_93.sql"/>
+<!-- Q94 --> <query file="../benchmarks/tpc-ds/queries/query_94.sql"/>
+<!-- Q95 --> <query file="../benchmarks/tpc-ds/queries/query_95.sql"/>
+<!-- Q96 --> <query file="../benchmarks/tpc-ds/queries/query_96.sql"/>
+<!-- Q97 --> <query file="../benchmarks/tpc-ds/queries/query_97.sql"/>
+<!-- Q98 --> <query file="../benchmarks/tpc-ds/queries/query_98.sql"/>
+<!-- Q99 --> <query file="../benchmarks/tpc-ds/queries/query_99.sql"/>
+
+</test>

--- a/tests/performance/tpch.xml
+++ b/tests/performance/tpch.xml
@@ -1,4 +1,5 @@
 <!-- https://clickhouse.com/docs/getting-started/example-datasets/tpch -->
+<!-- Scale factor: 10 -->
 <test>
 
 <settings file="../benchmarks/tpc-h/settings.json"/>


### PR DESCRIPTION
Add TPC-DS SF1 as a performance benchmark, similar to the existing TPC-H SF10 benchmark (https://github.com/ClickHouse/ClickHouse/pull/94410).

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add TPC-DS SF1 benchmark to performance tests


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.525`
<!-- ch-version-info:end -->