### PR TITLE
tests: fix test_server_reload/test.py::test_change_listen_host flakiness

### DIFF
--- a/tests/integration/test_server_reload/test.py
+++ b/tests/integration/test_server_reload/test.py
@@ -323,8 +323,7 @@ def test_change_listen_host(cluster, zk):
             client.query("SELECT 1")
         assert localhost_client.query("SELECT 1") == "1\n"
     finally:
-        with sync_loaded_config(localhost_client.query):
-            configure_from_zk(zk)
+        configure_from_zk(zk, localhost_client.query)
 
 
 # This is a regression test for the case when the clickhouse-server was waiting


### PR DESCRIPTION
Previously sync_loaded_config() updates loads_before, but the config can be already reloaded and MainConfigLoads updated, and then configure_from_zk() will wait for MainConfigLoads update and will timeout.

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=101092&sha=246d165cac385dac5d10b74e71cddf422fec5a5e&name_0=PR&name_1=Integration%20tests%20%28amd_llvm_coverage%2C%205%2F5%29
https://github.com/ClickHouse/ClickHouse/pull/101092

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.426`
<!-- ch-version-info:end -->