### PR TITLE
Fix a case of having zero bytes cache logical error

### DIFF
--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -1351,7 +1351,8 @@ size_t CachedOnDiskReadBufferFromFile::readFromFileSegment(
                 "Actual object size: {}, expected size: {}, stop reason: {}. Treating as EOF.",
                 offset, info.read_until_position, *object_size, file_size_,
                 impl_read_stop_reason ? *impl_read_stop_reason : "None");
-            file_segment.setDownloadFinishedWithoutContinuation();
+            if (file_segment.isDownloader())
+                file_segment.setDownloadFinishedWithoutContinuation();
             info.read_until_position = offset;
             return 0;
         }

--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -1329,14 +1329,31 @@ size_t CachedOnDiskReadBufferFromFile::readFromFileSegment(
         std::optional<std::string> impl_read_stop_reason;
         if (state.read_type != ReadType::CACHED)
         {
+            object_size = state.buf->getRemoteFileSize();
+
 #if USE_AWS_S3
             if (const auto * s3_buf = dynamic_cast<const ReadBufferFromS3 *>(state.buf.get()))
             {
                 impl_read_until_position = s3_buf->getReadUntilPosition();
                 impl_read_stop_reason = s3_buf->getStopReason();
-                object_size = s3_buf->getObjectSizeFromS3();
             }
 #endif
+        }
+
+        if (object_size.has_value() && *object_size == offset)
+        {
+            /// The remote object is smaller than file_size_ indicated, e.g. the object was
+            /// overwritten with shorter content between listing and reading.
+            /// Treat this as a legitimate EOF rather than a logic error.
+            LOG_WARNING(
+                log,
+                "Remote object is smaller than expected: read {} bytes but expected to read until position {}. "
+                "Actual object size: {}, expected size: {}, stop reason: {}. Treating as EOF.",
+                offset, info.read_until_position, *object_size, file_size_,
+                impl_read_stop_reason ? *impl_read_stop_reason : "None");
+            file_segment.setDownloadFinishedWithoutContinuation();
+            info.read_until_position = offset;
+            return 0;
         }
 
         throw Exception(

--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
@@ -304,6 +304,11 @@ std::optional<size_t> ReadBufferFromAzureBlobStorage::tryGetFileSize()
     return file_size;
 }
 
+std::optional<size_t> ReadBufferFromAzureBlobStorage::getRemoteFileSize() const
+{
+    return static_cast<size_t>(blob_container_client->GetBlobClient(path).GetProperties().Value.BlobSize);
+}
+
 size_t ReadBufferFromAzureBlobStorage::readBigAt(char * to, size_t n, size_t range_begin, const std::function<bool(size_t)> & /*progress_callback*/) const
 {
     size_t initial_n = n;

--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.h
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.h
@@ -48,6 +48,8 @@ public:
 
     std::optional<size_t> tryGetFileSize() override;
 
+    std::optional<size_t> getRemoteFileSize() const override;
+
     size_t readBigAt(char * to, size_t n, size_t range_begin, const std::function<bool(size_t)> & progress_callback) const override;
 
     bool supportsReadAt() override { return true; }

--- a/src/IO/ReadBufferFromFileBase.h
+++ b/src/IO/ReadBufferFromFileBase.h
@@ -62,6 +62,13 @@ public:
 
     virtual bool isCached() const { return false; }
 
+    /// Query the actual object size directly from remote storage.
+    /// Unlike tryGetFileSize(), which typically returns a pre-known cached value passed at construction time,
+    /// this method issues a real metadata request (e.g. S3 HeadObject, Azure GetProperties) and reflects
+    /// the current state of the object. Useful for detecting mismatches between the expected and actual size.
+    /// Returns std::nullopt for non-remote or local file buffers.
+    virtual std::optional<size_t> getRemoteFileSize() const { return std::nullopt; }
+
 protected:
     std::optional<size_t> file_size;
     ProfileCallback profile_callback;

--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -400,6 +400,11 @@ size_t ReadBufferFromS3::getObjectSizeFromS3() const
     return S3::getObjectSize(*client_ptr, bucket, key, version_id);
 }
 
+std::optional<size_t> ReadBufferFromS3::getRemoteFileSize() const
+{
+    return getObjectSizeFromS3();
+}
+
 off_t ReadBufferFromS3::getPosition()
 {
     return offset - available();

--- a/src/IO/ReadBufferFromS3.h
+++ b/src/IO/ReadBufferFromS3.h
@@ -90,7 +90,7 @@ public:
 
     std::string getStopReason() const { return stop_reason; }
 
-    size_t getObjectSizeFromS3() const;
+    std::optional<size_t> getRemoteFileSize() const override;
 
 private:
     std::unique_ptr<S3::ReadBufferFromGetObjectResult> initialize(size_t attempt);
@@ -101,6 +101,8 @@ private:
     /// Call inside catch() block if GetObject fails. Bumps metrics, logs the error.
     /// Returns true if the error looks retriable.
     bool processException(size_t read_offset, size_t attempt) const;
+
+    size_t getObjectSizeFromS3() const;
 
     Aws::S3::Model::GetObjectResult sendRequest(size_t attempt, size_t range_begin, std::optional<size_t> range_end_incl) const;
 

--- a/src/Interpreters/Cache/FileSegment.cpp
+++ b/src/Interpreters/Cache/FileSegment.cpp
@@ -638,6 +638,14 @@ void FileSegment::setDownloadFailed()
     setDownloadFailedUnlocked(lk);
 }
 
+void FileSegment::setDownloadFinishedWithoutContinuation()
+{
+    auto lk = lock();
+    assertIsDownloaderUnlocked("setDownloadFinishedWithoutContinuation", lk);
+    setDownloadState(State::PARTIALLY_DOWNLOADED_NO_CONTINUATION, lk);
+    cv.notify_all();
+}
+
 void FileSegment::setDownloadFailedUnlocked(const FileSegmentGuard::Lock & lock)
 {
     LOG_INFO(log, "Setting download as failed: {}", getInfoForLogUnlocked(lock));

--- a/src/Interpreters/Cache/FileSegment.h
+++ b/src/Interpreters/Cache/FileSegment.h
@@ -231,6 +231,11 @@ public:
 
     void setDownloadFailed();
 
+    /// Mark that no more data will be written to this segment (e.g. the remote object turned out
+    /// to be smaller than expected), without treating it as a failure.
+    /// The segment will be shrunk to the actually downloaded size during completion.
+    void setDownloadFinishedWithoutContinuation();
+
     bool isBackgroundDownloadEnabled() const { return background_download_enabled; }
 
 private:


### PR DESCRIPTION

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a case which can lead to `Having zero bytes, ...` logical error from cache arising from a remote object being overwritten in between `list` and `read` which previously resulted in a stale object metadata.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.435`
- Backported to: `26.3.3.15`, `26.2.7.16`
<!-- ch-version-info:end -->