### PR TITLE
s3queue: fix cleanup of stale processing  nodes

### DIFF
--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.cpp
@@ -1514,7 +1514,7 @@ void ObjectStorageQueueMetadata::cleanupPersistentProcessingNodes()
     }
 
     auto current_time = getCurrentTime();
-    Strings nodes_to_remove;
+    std::vector<std::pair<String, int32_t>> nodes_to_remove;
     Strings get_batch;
     auto get_paths = [&]
     {
@@ -1538,7 +1538,7 @@ void ObjectStorageQueueMetadata::cleanupPersistentProcessingNodes()
                 get_batch[i], response[i].stat.mtime, persistent_processing_node_ttl_seconds.load(), current_time);
 
             if (response[i].stat.mtime / 1000 + persistent_processing_node_ttl_seconds < current_time)
-                nodes_to_remove.push_back(get_batch[i]);
+                nodes_to_remove.emplace_back(get_batch[i], response[i].stat.version);
         }
         get_batch.clear();
     };
@@ -1567,18 +1567,26 @@ void ObjectStorageQueueMetadata::cleanupPersistentProcessingNodes()
         return;
     }
 
-    for (const auto & node : nodes_to_remove)
+    size_t removed = 0;
+    for (const auto & node_with_version : nodes_to_remove)
     {
+        const auto & node = node_with_version.first;
+        const auto version = node_with_version.second;
+        LOG_TRACE(log, "Removing stale processing node: {}", node);
         zk_retries.resetFailures();
         zk_retries.retryLoop([&]
         {
-            code = getZooKeeper()->tryRemove(node);
+            code = getZooKeeper()->tryRemove(node, version);
         });
-        if (code != Coordination::Error::ZOK && code != Coordination::Error::ZNONODE)
+        if (code == Coordination::Error::ZOK)
+            ++removed;
+        else if (code == Coordination::Error::ZNONODE || code == Coordination::Error::ZBADVERSION)
+            LOG_TRACE(log, "Processing node {} was already removed or recreated, skipping", node);
+        else
             throw zkutil::KeeperException::fromPath(code, node);
     }
 
-    LOG_DEBUG(log, "Removed {} persistent processing nodes", nodes_to_remove.size());
+    LOG_DEBUG(log, "Removed {}/{} stale processing nodes", removed, nodes_to_remove.size());
 }
 
 }


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
<!-- End of fixes issue link part, do not remove -->

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.443`
- Backported to: `26.3.3.17`, `26.2.7.20`, `26.1.8.22`
<!-- ch-version-info:end -->