### PR TITLE
Fix flaky `test_user_overcommit` integration test

### DIFF
--- a/tests/integration/test_overcommit_tracker/test.py
+++ b/tests/integration/test_overcommit_tracker/test.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 from helpers.cluster import ClickHouseCluster
@@ -41,7 +43,7 @@ def test_user_overcommit():
     finished = False
     last_error = ""
 
-    for attempt in range(3):
+    for attempt in range(5):
         responses_A = list()
         responses_B = list()
         for i in range(100):
@@ -71,6 +73,9 @@ def test_user_overcommit():
         last_error = (
             f"attempt {attempt + 1}: overcommitted_killed={overcommitted_killed}, finished={finished}"
         )
+
+        # Wait for ProcessList and MemoryTracker state to clear before the next attempt.
+        time.sleep(2)
 
     assert overcommitted_killed, f"overcommitted query is not killed ({last_error})"
     assert finished, f"all tasks are killed ({last_error})"


### PR DESCRIPTION
Increase retry attempts from 3 to 5 and add a 2-second delay between attempts to let ProcessList and MemoryTracker state clear. Without the delay, leftover state from the previous attempt's 100 concurrent queries can prevent sufficient memory pressure in subsequent attempts.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)
