### PR TITLE
Revert "Use memory tracking in hash table for patches"

### DIFF
--- a/src/Storages/MergeTree/PatchParts/PatchJoinCache.h
+++ b/src/Storages/MergeTree/PatchParts/PatchJoinCache.h
@@ -1,6 +1,5 @@
 #pragma once
 #include <future>
-#include <Common/AllocatorWithMemoryTracking.h>
 #include <Common/SharedMutex.h>
 #include <Common/ThreadPool_fwd.h>
 #include <Common/HashTable/Hash.h>
@@ -39,19 +38,8 @@ struct RangesInPatchParts;
   *  the emplace hint iterator, to make insertion complexity O(1) on average instead of O(log n).
   */
 
-using PatchOffsetsMap = absl::btree_map<
-    UInt64,
-    std::pair<UInt32, UInt32>,
-    std::less<>,
-    AllocatorWithMemoryTracking<std::pair<const UInt64, std::pair<UInt32, UInt32>>>>;
-
-using PatchHashMap = absl::node_hash_map<
-    UInt64,
-    PatchOffsetsMap,
-    HashCRC32<UInt64>,
-    std::equal_to<>,
-    AllocatorWithMemoryTracking<std::pair<const UInt64, PatchOffsetsMap>>>;
-
+using PatchOffsetsMap = absl::btree_map<UInt64, std::pair<UInt32, UInt32>>;
+using PatchHashMap = absl::node_hash_map<UInt64, PatchOffsetsMap, HashCRC32<UInt64>>;
 
 /**  A cache of maps and blocks for applying patch parts in Join mode.
   *  It avoids re-reading the same ranges of patch parts and rebuilding maps multiple times.


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#95231

Abseil hash maps are not exception-safe.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.446`
- Backported to: `26.3.3.18`, `26.2.7.21`, `26.1.8.14`
<!-- ch-version-info:end -->