### PR TITLE
Add dynamic untracked memory limits for more precise memory tracking

### DIFF
--- a/src/Common/CurrentMemoryTracker.cpp
+++ b/src/Common/CurrentMemoryTracker.cpp
@@ -17,6 +17,14 @@ namespace ErrorCodes
 }
 }
 
+namespace ProfileEvents
+{
+    extern const Event MemoryTrackerAllocations;
+    extern const Event MemoryTrackerAllocationsBytes;
+    extern const Event MemoryTrackerDeallocations;
+    extern const Event MemoryTrackerDeallocationsBytes;
+}
+
 namespace
 {
 
@@ -52,6 +60,8 @@ AllocationTrace CurrentMemoryTracker::allocImpl(Int64 size, bool throw_if_memory
         if (!current_thread)
         {
             /// total_memory_tracker only, ignore untracked_memory
+            ProfileEvents::increment(ProfileEvents::MemoryTrackerAllocations);
+            ProfileEvents::increment(ProfileEvents::MemoryTrackerAllocationsBytes, size);
             return memory_tracker->allocImpl(size, throw_if_memory_exceeded);
         }
 
@@ -76,6 +86,8 @@ AllocationTrace CurrentMemoryTracker::allocImpl(Int64 size, bool throw_if_memory
 
             try
             {
+                ProfileEvents::increment(ProfileEvents::MemoryTrackerAllocations);
+                ProfileEvents::increment(ProfileEvents::MemoryTrackerAllocationsBytes, current_untracked_memory);
                 auto res = memory_tracker->allocImpl(current_untracked_memory, throw_if_memory_exceeded);
                 current_thread->updateUntrackedMemoryLimit(memory_tracker->get());
                 return res;
@@ -96,7 +108,10 @@ AllocationTrace CurrentMemoryTracker::allocImpl(Int64 size, bool throw_if_memory
 void CurrentMemoryTracker::check()
 {
     if (auto * memory_tracker = getMemoryTracker())
+    {
+        ProfileEvents::increment(ProfileEvents::MemoryTrackerAllocations);
         std::ignore = memory_tracker->allocImpl(0, true);
+    }
 }
 
 Int64 CurrentMemoryTracker::get()
@@ -122,6 +137,8 @@ AllocationTrace CurrentMemoryTracker::free(Int64 size)
     {
         if (!current_thread)
         {
+            ProfileEvents::increment(ProfileEvents::MemoryTrackerDeallocations);
+            ProfileEvents::increment(ProfileEvents::MemoryTrackerDeallocationsBytes, size);
             return memory_tracker->free(size);
         }
 
@@ -139,6 +156,9 @@ AllocationTrace CurrentMemoryTracker::free(Int64 size)
             Int64 untracked_memory = current_thread->untracked_memory;
             current_thread->untracked_memory = 0;
             current_thread->updateUntrackedMemoryLimit(memory_tracker->get() + untracked_memory);
+
+            ProfileEvents::increment(ProfileEvents::MemoryTrackerDeallocations);
+            ProfileEvents::increment(ProfileEvents::MemoryTrackerDeallocationsBytes, -untracked_memory);
             return memory_tracker->free(-untracked_memory);
         }
 

--- a/src/Common/CurrentMemoryTracker.cpp
+++ b/src/Common/CurrentMemoryTracker.cpp
@@ -150,8 +150,7 @@ AllocationTrace CurrentMemoryTracker::free(Int64 size)
         current_thread->untracked_memory_blocker_level = blocker_level;
 
         current_thread->untracked_memory -= size;
-        /// Use `max_untracked_memory` (not `untracked_memory_limit`) to create hysteresis and avoid track/untrack cycles
-        if (current_thread->untracked_memory < -current_thread->max_untracked_memory)
+        if (current_thread->untracked_memory < -current_thread->untracked_memory_limit)
         {
             Int64 untracked_memory = current_thread->untracked_memory;
             current_thread->untracked_memory = 0;

--- a/src/Common/CurrentMemoryTracker.cpp
+++ b/src/Common/CurrentMemoryTracker.cpp
@@ -76,7 +76,9 @@ AllocationTrace CurrentMemoryTracker::allocImpl(Int64 size, bool throw_if_memory
 
             try
             {
-                return memory_tracker->allocImpl(current_untracked_memory, throw_if_memory_exceeded);
+                auto res = memory_tracker->allocImpl(current_untracked_memory, throw_if_memory_exceeded);
+                current_thread->updateUntrackedMemoryLimit(memory_tracker->get());
+                return res;
             }
             catch (...)
             {
@@ -95,6 +97,13 @@ void CurrentMemoryTracker::check()
 {
     if (auto * memory_tracker = getMemoryTracker())
         std::ignore = memory_tracker->allocImpl(0, true);
+}
+
+Int64 CurrentMemoryTracker::get()
+{
+    if (auto * memory_tracker = getMemoryTracker())
+        return memory_tracker->get();
+    return 0;
 }
 
 AllocationTrace CurrentMemoryTracker::alloc(Int64 size)
@@ -124,10 +133,12 @@ AllocationTrace CurrentMemoryTracker::free(Int64 size)
         current_thread->untracked_memory_blocker_level = blocker_level;
 
         current_thread->untracked_memory -= size;
-        if (current_thread->untracked_memory < -current_thread->untracked_memory_limit)
+        /// Use `max_untracked_memory` (not `untracked_memory_limit`) to create hysteresis and avoid track/untrack cycles
+        if (current_thread->untracked_memory < -current_thread->max_untracked_memory)
         {
             Int64 untracked_memory = current_thread->untracked_memory;
             current_thread->untracked_memory = 0;
+            current_thread->updateUntrackedMemoryLimit(memory_tracker->get() + untracked_memory);
             return memory_tracker->free(-untracked_memory);
         }
 

--- a/src/Common/CurrentMemoryTracker.h
+++ b/src/Common/CurrentMemoryTracker.h
@@ -12,7 +12,9 @@ struct CurrentMemoryTracker
 
     /// This function should be called after memory deallocation.
     [[nodiscard]] static AllocationTrace free(Int64 size);
+
     static void check();
+    [[nodiscard]] static Int64 get();
 
     /// Throws MEMORY_LIMIT_EXCEEDED (if it's allowed to throw exceptions)
     static void injectFault();

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -745,6 +745,10 @@ The server successfully detected this situation and will download merged part fr
     M(QueryMemoryLimitExceeded, "Number of times when memory limit exceeded for query.", ValueType::Number) \
     M(MemoryAllocatedWithoutCheck, "Number of times memory has been allocated without checking for memory constraints.", ValueType::Number) \
     M(MemoryAllocatedWithoutCheckBytes, "Amount of bytes that has been allocated without checking for memory constraints.", ValueType::Number) \
+    M(MemoryTrackerAllocations, "Total number of allocations that were flushed to server/query levels (only these allocations can fail the query with MEMORY_LIMIT_EXCEEDED)", ValueType::Number) \
+    M(MemoryTrackerDeallocations, "Total number of deallocations that were flushed to server (MemoryTracking metric)/query levels", ValueType::Number) \
+    M(MemoryTrackerAllocationsBytes, "Total number of allocated bytes that were flushed to server/query levels (only these allocations can fail the query with MEMORY_LIMIT_EXCEEDED)", ValueType::Number) \
+    M(MemoryTrackerDeallocationsBytes, "Total number of deallocated bytes that were flushed to server (MemoryTracking metric)/query levels", ValueType::Number) \
     \
     M(AzureGetObject, "Number of Azure API GetObject calls.", ValueType::Number) \
     M(AzureUpload, "Number of Azure blob storage API Upload calls", ValueType::Number) \

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -254,6 +254,12 @@ bool ThreadStatus::isQueryCanceled() const
     return false;
 }
 
+void ThreadStatus::updateUntrackedMemoryLimit(Int64 current)
+{
+    constexpr Int64 untracked_memory_ratio_bits = 4; /// 1.0 / (1 << 4) = 1/16 = 6.25%
+    untracked_memory_limit = std::clamp<Int64>(current >> untracked_memory_ratio_bits, min_untracked_memory, max_untracked_memory);
+}
+
 size_t ThreadStatus::getNextPlanStepIndex() const
 {
     return local_data.plan_step_index->fetch_add(1);

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -221,6 +221,11 @@ public:
     VariableContext untracked_memory_blocker_level = VariableContext::Max;
     /// Each thread could new/delete memory in range of (-untracked_memory_limit, untracked_memory_limit) without access to common counters.
     Int64 untracked_memory_limit = 4 * 1024 * 1024;
+    /// To keep total untracked memory limited to `1/16 * RSS` we dynamically change `untracked_memory_limit` after every tracking event:
+    /// untracked_memory_limit = clamp(cur_memory_bytes / 16, min_untracked_memory, max_untracked_memory)
+    /// Note that these values are updated when the thread is attached to a group
+    Int64 min_untracked_memory = 4 * 1024 * 1024; /// Default is kept 4MB for tests and client; the setting default is 4KB
+    Int64 max_untracked_memory = 4 * 1024 * 1024;
 
     /// Statistics of read and write rows/bytes
     Progress progress_in;
@@ -338,6 +343,8 @@ public:
     void flushUntrackedMemory();
 
     void initGlobalProfiler(UInt64 global_profiler_real_time_period, UInt64 global_profiler_cpu_time_period);
+
+    void updateUntrackedMemoryLimit(Int64 current);
 
     size_t getNextPlanStepIndex() const;
     size_t getNextPipelineProcessorIndex() const;

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -3552,6 +3552,9 @@ Read more about [memory overcommit](memory-overcommit.md).
     DECLARE(UInt64, max_untracked_memory, (4 * 1024 * 1024), R"(
 Small allocations and deallocations are grouped in thread local variable and tracked or profiled only when an amount (in absolute value) becomes larger than the specified value. If the value is higher than 'memory_profiler_step' it will be effectively lowered to 'memory_profiler_step'.
 )", 0) \
+    DECLARE(UInt64, min_untracked_memory, (4 * 1024), R"(
+Lower bound for the dynamic untracked memory limit. The per-thread untracked memory limit is computed as `thread_memory_usage / 16` and clamped between `min_untracked_memory` and `max_untracked_memory`. This guarantees that total untracked memory does not exceed ~6.25% of the current memory footprint regardless of thread count. Set to the value of `max_untracked_memory` to disable the dynamic limit.
+)", 0) \
     DECLARE(UInt64, max_reverse_dictionary_lookup_cache_size_bytes, (100 * 1024 * 1024), R"(
 Maximum size in bytes of the per-query reverse dictionary lookup cache used by the function `dictGetKeys`. The cache stores serialized key tuples per attribute value to avoid re-scanning the dictionary within the same query. When the limit is reached, entries are evicted using LRU. Set to 0 to disable caching.
 )", 0) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -42,6 +42,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         addSettingsChanges(settings_changes_history, "26.5",
         {
             {"predicate_statistics_sample_rate", 0, 0, "New setting to collect predicate selectivity statistics into system.predicate_statistics_log"},
+            {"min_untracked_memory", 4 * 1024 * 1024, 4 * 1024, "More accurate memory tracking by making untracked memory limit proportional to thread memory usage."},
         });
         addSettingsChanges(settings_changes_history, "26.4",
         {

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -13,6 +13,7 @@
 #include <Parsers/queryNormalization.h>
 #include <Common/MemoryTracker.h>
 #include <Common/VariableContext.h>
+#include <Common/CurrentMemoryTracker.h>
 #include <Common/CurrentThread.h>
 #include <Common/Exception.h>
 #include <Common/ProfileEvents.h>
@@ -48,6 +49,7 @@ namespace Setting
     extern const SettingsUInt64 log_queries_cut_to_length;
     extern const SettingsBool log_query_threads;
     extern const SettingsUInt64 max_untracked_memory;
+    extern const SettingsUInt64 min_untracked_memory;
     extern const SettingsUInt64 memory_overcommit_ratio_denominator;
     extern const SettingsFloat memory_profiler_sample_probability;
     extern const SettingsUInt64 memory_profiler_sample_min_allocation_size;
@@ -387,9 +389,12 @@ void ThreadStatus::applyQuerySettings()
     query_id = query_context_ptr->getCurrentQueryId();
     initQueryProfiler();
 
-    untracked_memory_limit = settings[Setting::max_untracked_memory];
-    if (settings[Setting::memory_profiler_step] && settings[Setting::memory_profiler_step] < static_cast<UInt64>(untracked_memory_limit))
-        untracked_memory_limit = settings[Setting::memory_profiler_step];
+    max_untracked_memory = settings[Setting::max_untracked_memory];
+    if (settings[Setting::memory_profiler_step] && settings[Setting::memory_profiler_step] < static_cast<UInt64>(max_untracked_memory))
+        max_untracked_memory = settings[Setting::memory_profiler_step];
+    min_untracked_memory = std::min<Int64>(settings[Setting::min_untracked_memory], max_untracked_memory);
+
+    updateUntrackedMemoryLimit(CurrentMemoryTracker::get());
 
     /// Populate the cache from authoritative query settings; on the initiator this runs before ProcessList::insert, on workers after (idempotent)
     /// (we cannot do this for all threads, even though it is no-op, since it is a data-race)

--- a/tests/integration/test_early_memory_limit_exception/configs/users_overrides.yaml
+++ b/tests/integration/test_early_memory_limit_exception/configs/users_overrides.yaml
@@ -1,0 +1,3 @@
+profiles:
+  default:
+    min_untracked_memory: 4Mi

--- a/tests/integration/test_early_memory_limit_exception/test.py
+++ b/tests/integration/test_early_memory_limit_exception/test.py
@@ -4,7 +4,9 @@ from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 instance = cluster.add_instance(
-    "instance", main_configs=["configs/users_to_ignore_early_memory_limit_check.xml"]
+    "instance",
+    main_configs=["configs/users_to_ignore_early_memory_limit_check.xml"],
+    user_configs=["configs/users_overrides.yaml"],
 )
 
 

--- a/tests/integration/test_failed_async_inserts/configs/users.yaml
+++ b/tests/integration/test_failed_async_inserts/configs/users.yaml
@@ -1,0 +1,3 @@
+profiles:
+  default:
+    min_untracked_memory: 4Mi

--- a/tests/integration/test_failed_async_inserts/test.py
+++ b/tests/integration/test_failed_async_inserts/test.py
@@ -7,7 +7,9 @@ from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 node = cluster.add_instance(
-    "node", main_configs=["configs/config.xml"],
+    "node",
+    main_configs=["configs/config.xml"],
+    user_configs=["configs/users.yaml"],
     with_zookeeper=True,
     # Server is very short on memory and may fail while initializing remote database disk
     with_remote_database_disk=False,

--- a/tests/integration/test_settings_constraints_distributed/configs/users.d/users.xml
+++ b/tests/integration/test_settings_constraints_distributed/configs/users.d/users.xml
@@ -8,4 +8,10 @@
             <show_named_collections_secrets>1</show_named_collections_secrets>
         </default>
     </users>
+
+    <profiles>
+        <default>
+            <min_untracked_memory>4Mi</min_untracked_memory>
+        </default>
+    </profiles>
 </clickhouse>

--- a/tests/integration/test_settings_constraints_distributed_ddl/test.py
+++ b/tests/integration/test_settings_constraints_distributed_ddl/test.py
@@ -73,6 +73,7 @@ def test_ddl_worker_clamps_settings_constraints():
         f"CREATE TABLE {table_name} ON CLUSTER test_cluster (x Int64) ENGINE = MergeTree ORDER BY x",
         settings={
             "max_memory_usage": "1",
+            "min_untracked_memory": "4Mi",
             "distributed_ddl_entry_format_version": "2",
             "distributed_ddl_task_timeout": "60",
         },

--- a/tests/queries/0_stateless/02818_memory_profiler_sample_min_max_allocation_size.sh
+++ b/tests/queries/0_stateless/02818_memory_profiler_sample_min_max_allocation_size.sh
@@ -21,7 +21,7 @@ ${CLICKHOUSE_CLIENT} "${trace_settings[@]}" --query_id="$query_id_flush" --max_u
 # Non-flush path: small allocations stay below max_untracked_memory and sample via the cached ThreadStatus::sample_* values,
 # which must be refreshed after ProcessList::insert applies query-level memory_profiler_sample_* settings.
 query_id_cached="${CLICKHOUSE_DATABASE}_min_max_allocation_size_cached"
-${CLICKHOUSE_CLIENT} "${trace_settings[@]}" --query_id="$query_id_cached" --max_untracked_memory=4Mi
+${CLICKHOUSE_CLIENT} "${trace_settings[@]}" --query_id="$query_id_cached" --max_untracked_memory=4Mi --min_untracked_memory=4Mi
 
 ${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS trace_log"
 


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add dynamic untracked memory limits for more precise memory tracking

Original comment from  @serxa:

The current memory tracker has an error of up to `untracked_memory_limit = 4MB` per thread. Consider a ClickHouse server running with 8GB RAM and a standard `max_server_memory_usage_to_ram_ratio = 0.9` server setting. If there are 1000 threads (and every thread has 800KB on average) OOM can happen before any query is stopped with `MEMORY_LIMIT_EXCEEDED`.

We need total untracked memory to be proportional to current memory usage regardless of the number of threads. To make it fit into 10% RAM we want an error to be less than e.g. 6%. To achieve it we need `untracked_memory_limit` to be updated dynamically and be proportional to current thread memory usage for threads with small memory footprint: `untracked_memory_limit = clamp(already_tracked / 16, 4KB, 4MB)`

Resubmit of: https://github.com/ClickHouse/ClickHouse/pull/64423 (by @serxa)

_Note: marked as `Performance Improvement` for run perf tests and memory accounting can be also "performance imporvement"_