### PR TITLE
tests: attempt to fix test_overcommit_tracker flakiness under amd_llvm_coverage

### DIFF
--- a/tests/integration/test_overcommit_tracker/configs/config.d/config.xml
+++ b/tests/integration/test_overcommit_tracker/configs/config.d/config.xml
@@ -1,4 +1,0 @@
-<clickhouse>
-    <!-- Keep the number of threads consistent across queries in the test -->
-    <concurrent_threads_soft_limit_ratio_to_cores>0</concurrent_threads_soft_limit_ratio_to_cores>
-</clickhouse>

--- a/tests/integration/test_overcommit_tracker/test.py
+++ b/tests/integration/test_overcommit_tracker/test.py
@@ -6,7 +6,6 @@ cluster = ClickHouseCluster(__file__)
 
 node = cluster.add_instance(
     "node",
-    main_configs=["configs/config.d/config.xml"],
     user_configs=[
         "configs/users.d/users.xml",
     ],
@@ -22,8 +21,8 @@ def start_cluster():
         cluster.shutdown()
 
 
-USER_TEST_QUERY_A = "SELECT groupArray(number) FROM numbers(2500000) SETTINGS max_memory_usage_for_user=2000000000,memory_overcommit_ratio_denominator=1"
-USER_TEST_QUERY_B = "SELECT groupArray(number) FROM numbers(2500000) SETTINGS max_memory_usage_for_user=2000000000,memory_overcommit_ratio_denominator=80000000"
+USER_TEST_QUERY_A = "SELECT groupArray(number) FROM numbers(2500000) SETTINGS max_threads=1, max_memory_usage_for_user=2000000000, memory_overcommit_ratio_denominator=1"
+USER_TEST_QUERY_B = "SELECT groupArray(number) FROM numbers(2500000) SETTINGS max_threads=1, max_memory_usage_for_user=2000000000, memory_overcommit_ratio_denominator=80000000"
 
 
 def test_user_overcommit():


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

With new proper asserition added in https://github.com/ClickHouse/ClickHouse/pull/100621 the test [fails for amd_llvm_coverage](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=1433e4028149234da6c75198739f4b65d6533d7d&name_0=MasterCI&name_1=Integration%20tests%20%28amd_llvm_coverage%2C%202%2F5%29&name_1=Integration%20tests%20%28amd_llvm_coverage%2C%202%2F5%29), let's try something obvious - `FORMAT Null`, if this won't help, we can play with settings/parallelism

Fixes: https://github.com/ClickHouse/ClickHouse/issues/101318

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.464`
<!-- ch-version-info:end -->