### PR TITLE
Temporarily disable server-side AST fuzzer in Stress Test and BuzzHouse [2]

### DIFF
--- a/ci/jobs/scripts/fuzzer/query-fuzzer-tweaks-users.xml
+++ b/ci/jobs/scripts/fuzzer/query-fuzzer-tweaks-users.xml
@@ -40,8 +40,6 @@
             </constraints>
 
             <!-- Allow all experimental features by default -->
-            <ast_fuzzer_runs>5</ast_fuzzer_runs>
-
             <allow_create_index_without_type>1</allow_create_index_without_type>
             <allow_custom_error_code_in_throwif>1</allow_custom_error_code_in_throwif>
             <allow_ddl>1</allow_ddl>

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -144,8 +144,6 @@ EOL
 
             <table_function_remote_max_addresses>200</table_function_remote_max_addresses>
 
-            <ast_fuzzer_runs>5</ast_fuzzer_runs>
-            <ast_fuzzer_any_query>true</ast_fuzzer_any_query>
 
             <constraints>
                 <max_execution_time>


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#100490

@groeneai This PR **doesn't fix** any of Stress tests failures. Just temporary disables it. 

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.440`
<!-- ch-version-info:end -->