### PR TITLE
Add test: MergeTree deserialization of combined subcolumn with mixed l

### DIFF
--- a/tests/queries/0_stateless/04072_json_combined_subcolumn_mergetree_mixed.reference
+++ b/tests/queries/0_stateless/04072_json_combined_subcolumn_mergetree_mixed.reference
@@ -1,0 +1,12 @@
+1	42	Int64
+2	0	Int64
+3	{"x":1,"y":2}	JSON(max_dynamic_paths=10)
+4	{"x":3}	JSON(max_dynamic_paths=10)
+5	\N	None
+6	\N	None
+1	42	{}	42
+2	0	{}	0
+3	{"x":1,"y":2}	{"x":1,"y":2}	\N
+4	{"x":3}	{"x":3}	\N
+5	\N	{}	\N
+6	\N	{}	\N

--- a/tests/queries/0_stateless/04072_json_combined_subcolumn_mergetree_mixed.sql
+++ b/tests/queries/0_stateless/04072_json_combined_subcolumn_mergetree_mixed.sql
@@ -1,0 +1,22 @@
+-- Tags: no-fasttest
+SET enable_json_type = 1;
+SET allow_experimental_variant_type = 1;
+SET use_variant_as_common_type = 1;
+
+DROP TABLE IF EXISTS test_combined_mt_mixed;
+CREATE TABLE test_combined_mt_mixed (id UInt64, json JSON(max_dynamic_paths=10)) ENGINE = MergeTree ORDER BY id
+SETTINGS min_rows_for_wide_part=1, min_bytes_for_wide_part=1;
+
+INSERT INTO test_combined_mt_mixed VALUES (1, '{"a" : 42}');
+INSERT INTO test_combined_mt_mixed VALUES (2, '{"a" : 0}');
+INSERT INTO test_combined_mt_mixed VALUES (3, '{"a" : {"x" : 1, "y" : 2}}');
+INSERT INTO test_combined_mt_mixed VALUES (4, '{"a" : {"x" : 3}}');
+INSERT INTO test_combined_mt_mixed VALUES (5, '{"b" : 1}');
+INSERT INTO test_combined_mt_mixed VALUES (6, '{}');
+
+OPTIMIZE TABLE test_combined_mt_mixed FINAL;
+
+SELECT id, json.@a, dynamicType(json.@a) FROM test_combined_mt_mixed ORDER BY id;
+SELECT id, json.@a, json.^a, json.a FROM test_combined_mt_mixed ORDER BY id;
+
+DROP TABLE test_combined_mt_mixed;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #98788](https://github.com/ClickHouse/ClickHouse/pull/98788).

**1. MergeTree deserialization of combined subcolumn with mixed literal and sub-object values untested**
  `src/DataTypes/Serializations/SerializationObjectCombinedPath.cpp:186`

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---
_Found during review of [PR #98788](https://github.com/ClickHouse/ClickHouse/pull/98788)._