### PR TITLE
[WIP] Add hasPhrase function with TextIndex phrase query support

### DIFF
--- a/src/Functions/hasPhrase.cpp
+++ b/src/Functions/hasPhrase.cpp
@@ -1,0 +1,227 @@
+#include <Functions/FunctionFactory.h>
+#include <Functions/FunctionHelpers.h>
+
+#include <Columns/ColumnString.h>
+#include <Common/FunctionDocumentation.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/ITokenizer.h>
+#include <Interpreters/TokenizerFactory.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+    extern const int FUNCTION_NOT_ALLOWED;
+}
+
+namespace
+{
+
+/// Tokenize a phrase string into an ordered list of tokens.
+std::vector<String> tokenizePhrase(const String & phrase, const ITokenizer & tokenizer)
+{
+    std::vector<String> tokens;
+    tokenizer.stringToTokens(phrase.data(), phrase.size(), tokens);
+    return tokens;
+}
+
+/// Check if `phrase_tokens` appear adjacently in order within the haystack.
+/// Scans the haystack token stream, tracking consecutive phrase token matches.
+bool hasPhraseInString(std::string_view haystack, const std::vector<String> & phrase_tokens, const ITokenizer & tokenizer)
+{
+    if (phrase_tokens.empty())
+        return true;
+
+    if (phrase_tokens.size() == 1)
+    {
+        /// Single token: just check existence.
+        bool found = false;
+        forEachToken(tokenizer, haystack.data(), haystack.size(),
+            [&](const char * token_start, size_t token_len)
+            {
+                if (std::string_view(token_start, token_len) == phrase_tokens[0])
+                {
+                    found = true;
+                    return true;
+                }
+                return false;
+            });
+        return found;
+    }
+
+    /// Multi-token phrase: scan and track consecutive matches.
+    size_t match_idx = 0;
+    bool found = false;
+
+    forEachToken(tokenizer, haystack.data(), haystack.size(),
+        [&](const char * token_start, size_t token_len)
+        {
+            std::string_view token(token_start, token_len);
+
+            if (token == phrase_tokens[match_idx])
+            {
+                ++match_idx;
+                if (match_idx == phrase_tokens.size())
+                {
+                    found = true;
+                    return true;
+                }
+            }
+            else
+            {
+                /// Reset, but check if current token matches the first phrase token.
+                match_idx = (token == phrase_tokens[0]) ? 1 : 0;
+            }
+            return false;
+        });
+
+    return found;
+}
+
+} /// anonymous namespace
+
+/// hasPhrase(haystack, phrase [, tokenizer]) -> UInt8
+/// Returns 1 if the phrase (all tokens in order, adjacent) is found in the haystack.
+class FunctionHasPhrase : public IFunction
+{
+public:
+    static constexpr auto name = "hasPhrase";
+    static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionHasPhrase>(); }
+
+    String getName() const override { return name; }
+    size_t getNumberOfArguments() const override { return 0; }
+    bool isVariadic() const override { return true; }
+    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo &) const override { return true; }
+    bool useDefaultImplementationForConstants() const override { return true; }
+    ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {1, 2}; }
+
+    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
+    {
+        if (arguments.size() < 2 || arguments.size() > 3)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "Function {} requires 2 or 3 arguments, got {}", getName(), arguments.size());
+
+        FunctionArgumentDescriptors mandatory_args
+        {
+            {"haystack", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isStringOrFixedString), nullptr, "String or FixedString"},
+            {"phrase", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), isColumnConst, "const String"}
+        };
+
+        FunctionArgumentDescriptors optional_args
+        {
+            {"tokenizer", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), isColumnConst, "const String"}
+        };
+
+        validateFunctionArguments(name, arguments, mandatory_args, optional_args);
+
+        DataTypePtr return_type = std::make_shared<DataTypeNumber<UInt8>>();
+        if (arguments[0].type->isNullable())
+            return_type = std::make_shared<DataTypeNullable>(std::make_shared<DataTypeNumber<UInt8>>());
+        return return_type;
+    }
+
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
+    {
+        if (input_rows_count == 0)
+            return ColumnVector<UInt8>::create();
+
+        /// Resolve tokenizer.
+        const auto tokenizer_name = arguments.size() < 3 || !arguments[2].column
+            ? SplitByNonAlphaTokenizer::getExternalName()
+            : arguments[2].column->getDataAt(0);
+
+        auto tokenizer = TokenizerFactory::instance().get(tokenizer_name);
+
+        /// Check tokenizer supports phrase queries. [D-04]
+        if (!tokenizer->supportsPhraseQuery())
+            throw Exception(ErrorCodes::FUNCTION_NOT_ALLOWED,
+                "Function {} does not support tokenizer '{}' because it produces overlapping tokens. "
+                "Use a word-level tokenizer (splitByNonAlpha, unicodeWord, or splitByString).",
+                getName(), String(tokenizer_name));
+
+        /// Extract phrase tokens.
+        auto phrase_column = arguments[1].column;
+        String phrase_str = (*phrase_column)[0].safeGet<String>();
+        auto phrase_tokens = tokenizePhrase(phrase_str, *tokenizer);
+
+        /// Empty phrase matches everything. [D-13]
+        if (phrase_tokens.empty())
+        {
+            auto col_result = ColumnVector<UInt8>::create();
+            col_result->getData().assign(input_rows_count, UInt8(1));
+            return col_result;
+        }
+
+        auto col_result = ColumnVector<UInt8>::create();
+        auto & result_data = col_result->getData();
+        result_data.resize(input_rows_count);
+
+        ColumnPtr col_input = arguments[0].column;
+        const auto * col_string = checkAndGetColumn<ColumnString>(col_input.get());
+        if (!col_string)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "Function {} requires String column as first argument", getName());
+
+        for (size_t i = 0; i < input_rows_count; ++i)
+        {
+            std::string_view input = col_string->getDataAt(i);
+            result_data[i] = hasPhraseInString(input, phrase_tokens, *tokenizer) ? 1 : 0;
+        }
+
+        return col_result;
+    }
+};
+
+REGISTER_FUNCTION(HasPhrase)
+{
+    FunctionDocumentation::Description description = R"(
+Checks if a phrase (sequence of adjacent tokens) is present in the haystack string.
+
+The phrase is tokenized and the function checks if all tokens appear consecutively
+and in order in the haystack.
+
+:::note
+Column `haystack` should have a [text index](../../engines/table-engines/mergetree-family/textindexes)
+for optimal performance. If no text index is defined, the function performs a brute-force scan.
+:::
+    )";
+    FunctionDocumentation::Syntax syntax = "hasPhrase(haystack, phrase [, tokenizer])";
+    FunctionDocumentation::Arguments doc_arguments = {
+        {"haystack", "String to be searched.", {"String"}},
+        {"phrase", "Phrase to search for. Will be tokenized.", {"const String"}},
+        {"tokenizer", "Tokenizer to use. Optional, defaults to splitByNonAlpha. "
+                      "Only word-level tokenizers are supported (splitByNonAlpha, unicodeWord, splitByString).", {"const String"}},
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {"Returns 1 if the phrase is found, 0 otherwise.", {"UInt8"}};
+    FunctionDocumentation::Examples examples = {
+    {
+        "Phrase search",
+        "SELECT hasPhrase('the quick brown fox', 'quick brown')",
+        R"(
+┌─hasPhrase('the quick brown fox', 'quick brown')─┐
+│                                                1 │
+└──────────────────────────────────────────────────┘
+        )"
+    },
+    {
+        "Order matters",
+        "SELECT hasPhrase('the quick brown fox', 'brown quick')",
+        R"(
+┌─hasPhrase('the quick brown fox', 'brown quick')─┐
+│                                                0 │
+└──────────────────────────────────────────────────┘
+        )"
+    }
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {26, 4};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::StringSearch;
+    FunctionDocumentation documentation = {description, syntax, doc_arguments, {}, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionHasPhrase>(documentation);
+}
+
+}

--- a/src/Functions/hasPhrase.cpp
+++ b/src/Functions/hasPhrase.cpp
@@ -7,7 +7,6 @@
 #include <DataTypes/DataTypeNullable.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/ITokenizer.h>
-#include <Interpreters/TokenizerFactory.h>
 
 namespace DB
 {
@@ -15,7 +14,6 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
-    extern const int FUNCTION_NOT_ALLOWED;
 }
 
 namespace
@@ -84,8 +82,9 @@ bool hasPhraseInString(std::string_view haystack, const std::vector<String> & ph
 
 } /// anonymous namespace
 
-/// hasPhrase(haystack, phrase [, tokenizer]) -> UInt8
+/// hasPhrase(haystack, phrase) -> UInt8
 /// Returns 1 if the phrase (all tokens in order, adjacent) is found in the haystack.
+/// Always uses splitByNonAlpha tokenizer, consistent with hasToken.
 class FunctionHasPhrase : public IFunction
 {
 public:
@@ -93,30 +92,20 @@ public:
     static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionHasPhrase>(); }
 
     String getName() const override { return name; }
-    size_t getNumberOfArguments() const override { return 0; }
-    bool isVariadic() const override { return true; }
+    size_t getNumberOfArguments() const override { return 2; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo &) const override { return true; }
     bool useDefaultImplementationForConstants() const override { return true; }
-    ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {1, 2}; }
+    ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {1}; }
 
     DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
     {
-        if (arguments.size() < 2 || arguments.size() > 3)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                "Function {} requires 2 or 3 arguments, got {}", getName(), arguments.size());
-
         FunctionArgumentDescriptors mandatory_args
         {
             {"haystack", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isStringOrFixedString), nullptr, "String or FixedString"},
             {"phrase", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), isColumnConst, "const String"}
         };
 
-        FunctionArgumentDescriptors optional_args
-        {
-            {"tokenizer", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), isColumnConst, "const String"}
-        };
-
-        validateFunctionArguments(name, arguments, mandatory_args, optional_args);
+        validateFunctionArguments(name, arguments, mandatory_args);
 
         DataTypePtr return_type = std::make_shared<DataTypeNumber<UInt8>>();
         if (arguments[0].type->isNullable())
@@ -129,26 +118,14 @@ public:
         if (input_rows_count == 0)
             return ColumnVector<UInt8>::create();
 
-        /// Resolve tokenizer.
-        const auto tokenizer_name = arguments.size() < 3 || !arguments[2].column
-            ? SplitByNonAlphaTokenizer::getExternalName()
-            : arguments[2].column->getDataAt(0);
-
-        auto tokenizer = TokenizerFactory::instance().get(tokenizer_name);
-
-        /// Check tokenizer supports phrase queries. [D-04]
-        if (!tokenizer->supportsPhraseQuery())
-            throw Exception(ErrorCodes::FUNCTION_NOT_ALLOWED,
-                "Function {} does not support tokenizer '{}' because it produces overlapping tokens. "
-                "Use a word-level tokenizer (splitByNonAlpha, unicodeWord, or splitByString).",
-                getName(), String(tokenizer_name));
+        SplitByNonAlphaTokenizer tokenizer;
 
         /// Extract phrase tokens.
         auto phrase_column = arguments[1].column;
         String phrase_str = (*phrase_column)[0].safeGet<String>();
-        auto phrase_tokens = tokenizePhrase(phrase_str, *tokenizer);
+        auto phrase_tokens = tokenizePhrase(phrase_str, tokenizer);
 
-        /// Empty phrase matches everything. [D-13]
+        /// Empty phrase matches everything.
         if (phrase_tokens.empty())
         {
             auto col_result = ColumnVector<UInt8>::create();
@@ -169,7 +146,7 @@ public:
         for (size_t i = 0; i < input_rows_count; ++i)
         {
             std::string_view input = col_string->getDataAt(i);
-            result_data[i] = hasPhraseInString(input, phrase_tokens, *tokenizer) ? 1 : 0;
+            result_data[i] = hasPhraseInString(input, phrase_tokens, tokenizer) ? 1 : 0;
         }
 
         return col_result;
@@ -189,12 +166,10 @@ Column `haystack` should have a [text index](../../engines/table-engines/mergetr
 for optimal performance. If no text index is defined, the function performs a brute-force scan.
 :::
     )";
-    FunctionDocumentation::Syntax syntax = "hasPhrase(haystack, phrase [, tokenizer])";
+    FunctionDocumentation::Syntax syntax = "hasPhrase(haystack, phrase)";
     FunctionDocumentation::Arguments doc_arguments = {
         {"haystack", "String to be searched.", {"String"}},
-        {"phrase", "Phrase to search for. Will be tokenized.", {"const String"}},
-        {"tokenizer", "Tokenizer to use. Optional, defaults to splitByNonAlpha. "
-                      "Only word-level tokenizers are supported (splitByNonAlpha, unicodeWord, splitByString).", {"const String"}},
+        {"phrase", "Phrase to search for. Will be tokenized using splitByNonAlpha.", {"const String"}},
     };
     FunctionDocumentation::ReturnedValue returned_value = {"Returns 1 if the phrase is found, 0 otherwise.", {"UInt8"}};
     FunctionDocumentation::Examples examples = {

--- a/src/Interpreters/ITokenizer.h
+++ b/src/Interpreters/ITokenizer.h
@@ -93,6 +93,24 @@ public:
     virtual void stringLikeToTokens(const char * data, size_t length, std::vector<String> & tokens) const = 0;
     virtual bool supportsStringLike() const = 0;
 
+    /// Whether this tokenizer supports phrase queries (positional matching).
+    /// Only word-level tokenizers produce meaningful token positions for phrase search.
+    /// Ngram, SparseGrams, and Array tokenizers do not support phrase queries. [D-04]
+    virtual bool supportsPhraseQuery() const
+    {
+        switch (type)
+        {
+            case Type::SplitByNonAlpha:
+            case Type::UnicodeWord:
+            case Type::SplitByString:
+                return true;
+            case Type::Ngrams:
+            case Type::SparseGrams:
+            case Type::Array:
+                return false;
+        }
+    }
+
 private:
     Type type;
 };

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -136,6 +136,7 @@ bool MergeTreeIndexConditionText::requiresReadingAllTokens(const RPNElement & el
         case RPNElement::FUNCTION_AND:
         case RPNElement::FUNCTION_EQUALS:
         case RPNElement::FUNCTION_HAS_ALL_TOKENS:
+        case RPNElement::FUNCTION_HAS_PHRASE:
         case RPNElement::FUNCTION_UNKNOWN:
         case RPNElement::ALWAYS_TRUE:
         case RPNElement::ALWAYS_FALSE:
@@ -155,6 +156,7 @@ bool MergeTreeIndexConditionText::isSupportedFunction(const String & function_na
     return function_name == "hasToken"
         || function_name == "hasAnyTokens"
         || function_name == "hasAllTokens"
+        || function_name == "hasPhrase"
         || function_name == "equals"
         || function_name == "mapContainsKey"
         || function_name == "mapContainsKeyLike"
@@ -181,6 +183,13 @@ TextIndexDirectReadMode MergeTreeIndexConditionText::getDirectReadMode(const Str
         || function_name == "hasAllTokens")
     {
         return TextIndexDirectReadMode::Exact;
+    }
+
+    if (function_name == "hasPhrase")
+    {
+        /// hasPhrase needs row-level post-filtering to verify token adjacency,
+        /// so it cannot use Exact mode (which skips the row-level filter).
+        return getHintOrNoneMode();
     }
 
     if (function_name == "equals"
@@ -258,8 +267,17 @@ bool MergeTreeIndexConditionText::alwaysUnknownOrTrue() const
         {RPNElement::FUNCTION_EQUALS,
          RPNElement::FUNCTION_HAS_ANY_TOKENS,
          RPNElement::FUNCTION_HAS_ALL_TOKENS,
+         RPNElement::FUNCTION_HAS_PHRASE,
          RPNElement::FUNCTION_IN,
          RPNElement::FUNCTION_MATCH});
+}
+
+bool MergeTreeIndexConditionText::hasPhraseQuery() const
+{
+    return std::any_of(rpn.begin(), rpn.end(), [](const RPNElement & element)
+    {
+        return element.function == RPNElement::FUNCTION_HAS_PHRASE;
+    });
 }
 
 bool MergeTreeIndexConditionText::mayBeTrueOnGranule(MergeTreeIndexGranulePtr idx_granule, const UpdatePartialDisjunctionResultFn & update_partial_disjunction_result_fn) const
@@ -289,6 +307,13 @@ bool MergeTreeIndexConditionText::mayBeTrueOnGranule(MergeTreeIndexGranulePtr id
             chassert(element.text_search_queries.size() == 1);
             const auto & text_search_query = element.text_search_queries.front();
             bool exists_in_granule = granule->hasAllQueryTokens(*text_search_query);
+            rpn_stack.emplace_back(exists_in_granule, true);
+        }
+        else if (element.function == RPNElement::FUNCTION_HAS_PHRASE)
+        {
+            chassert(element.text_search_queries.size() == 1);
+            const auto & text_search_query = element.text_search_queries.front();
+            bool exists_in_granule = granule->hasPhraseQueryTokens(*text_search_query);
             rpn_stack.emplace_back(exists_in_granule, true);
         }
         else if (element.function == RPNElement::FUNCTION_EQUALS)
@@ -593,6 +618,21 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
             out.text_search_queries.emplace_back(std::make_shared<TextSearchQuery>(function_name, TextSearchMode::All, direct_read_mode, search_tokens));
         }
 
+        return true;
+    }
+    if (function_name == "hasPhrase")
+    {
+        if (!value_data_type.isString())
+            return false;
+
+        /// For hasPhrase, we need to preserve token order for phrase semantics.
+        /// Store original ordered tokens separately; the sorted tokens in TextSearchQuery
+        /// are used for index lookups, while ordered_tokens are used for positional verification.
+        auto search_tokens = stringToTokens(value_field);
+        auto query = std::make_shared<TextSearchQuery>(function_name, TextSearchMode::All, direct_read_mode, search_tokens);
+        query->ordered_tokens = std::move(search_tokens);
+        out.function = RPNElement::FUNCTION_HAS_PHRASE;
+        out.text_search_queries.emplace_back(std::move(query));
         return true;
     }
     if (function_name == "hasToken" || function_name == "hasTokenOrNull")

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.h
@@ -42,7 +42,11 @@ struct TextSearchQuery
     String function_name;
     TextSearchMode search_mode;
     TextIndexDirectReadMode direct_read_mode;
+    /// Sorted unique tokens for index lookups and hashing.
     std::vector<String> tokens;
+    /// Original ordered tokens for phrase queries (preserves duplicates and order).
+    /// Empty for non-phrase queries.
+    std::vector<String> ordered_tokens;
 
     SipHash getHash() const;
 };
@@ -83,6 +87,9 @@ public:
     std::optional<String> replaceToVirtualColumn(const TextSearchQuery & query, const String & index_name);
     TextSearchQueryPtr getSearchQueryForVirtualColumn(const String & column_name) const;
 
+    /// Whether any RPN element uses FUNCTION_HAS_PHRASE.
+    bool hasPhraseQuery() const;
+
     TextIndexTokensCachePtr tokensCache() const { return tokens_cache; }
     TextIndexHeaderCachePtr headerCache() const { return header_cache; }
     TextIndexPostingsCachePtr postingsCache() const { return postings_cache; }
@@ -102,6 +109,7 @@ private:
             FUNCTION_MATCH,
             FUNCTION_HAS_ANY_TOKENS,
             FUNCTION_HAS_ALL_TOKENS,
+            FUNCTION_HAS_PHRASE,
             /// Can take any value
             FUNCTION_UNKNOWN,
             /// Operators

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -338,6 +338,10 @@ void MergeTreeIndexGranuleText::deserializeBinaryWithMultipleStreams(MergeTreeIn
     if (!index_stream || !dictionary_stream || !postings_stream)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Index with type 'text' must be deserialized with 3 streams: index, dictionary, postings. One of the streams is missing");
 
+    /// The .pos stream is optional — old parts may not have it. [D-08]
+    auto positions_it = streams.find(MergeTreeIndexSubstream::Type::TextIndexPositions);
+    auto * positions_stream = (positions_it != streams.end()) ? positions_it->second : nullptr;
+
     if (index_id_for_caches.empty())
     {
         const auto & part_storage = state.part.getDataPartStorage();
@@ -346,16 +350,50 @@ void MergeTreeIndexGranuleText::deserializeBinaryWithMultipleStreams(MergeTreeIn
 
     is_empty = false;
     remaining_tokens.clear();
+    token_positions.clear();
 
-    analyzeDictionary(*index_stream, *dictionary_stream, state);
+    analyzeDictionary(*index_stream, *dictionary_stream, state, positions_stream);
     readPostingsForRareTokens(*postings_stream, state);
+}
+
+/// Skip one token's position data in the .pos stream without storing it.
+/// Reads [num_rows] then per-row [row_id] [count] [count positions], discarding all values.
+static void skipOneTokenPositions(ReadBuffer & istr)
+{
+    UInt64 num_rows;
+    readVarUInt(num_rows, istr);
+
+    for (UInt64 r = 0; r < num_rows; ++r)
+    {
+        UInt64 row_id;
+        readVarUInt(row_id, istr);
+        UNUSED(row_id);
+
+        UInt64 count;
+        readVarUInt(count, istr);
+
+        for (UInt64 j = 0; j < count; ++j)
+        {
+            UInt64 val;
+            readVarUInt(val, istr);
+        }
+    }
 }
 
 void MergeTreeIndexGranuleText::analyzeDictionary(
     MergeTreeIndexReaderStream & header_stream,
     MergeTreeIndexReaderStream & dictionary_stream,
-    MergeTreeIndexDeserializationState & state)
+    MergeTreeIndexDeserializationState & state,
+    MergeTreeIndexReaderStream * positions_stream)
 {
+    /// Determine whether we need to read position data for phrase queries.
+    const auto & condition_text_ref = typeid_cast<const MergeTreeIndexConditionText &>(*state.condition);
+    const bool need_positions = positions_stream != nullptr && condition_text_ref.hasPhraseQuery();
+
+    ReadBuffer * pos_buffer = nullptr;
+    if (need_positions)
+        pos_buffer = positions_stream->getDataBuffer();
+
     auto tokens_to_read = fillTokensFromCache(state);
     if (tokens_to_read.empty())
         return;
@@ -385,6 +423,9 @@ void MergeTreeIndexGranuleText::analyzeDictionary(
 
         blocks_to_read.back().second.emplace_back(token);
     }
+
+    /// Track how many tokens' position data we've consumed from the .pos stream.
+    size_t pos_tokens_consumed = 0;
 
     for (const auto & [block_idx, needed_tokens] : blocks_to_read)
     {
@@ -427,7 +468,18 @@ void MergeTreeIndexGranuleText::analyzeDictionary(
         }
 
         if (matched_indices.empty())
+        {
+            /// Skip position data for all tokens in this block if we need positions.
+            if (pos_buffer)
+            {
+                size_t tokens_before_block = block_idx * params.dictionary_block_size;
+                size_t tokens_to_skip = tokens_before_block - pos_tokens_consumed + num_tokens;
+                for (size_t s = 0; s < tokens_to_skip && !pos_buffer->eof(); ++s)
+                    skipOneTokenPositions(*pos_buffer);
+                pos_tokens_consumed = tokens_before_block + num_tokens;
+            }
             continue;
+        }
 
         /// Deserialize only the token infos for matched tokens.
         auto infos = TextIndexSerialization::deserializeTokenInfos(
@@ -435,6 +487,35 @@ void MergeTreeIndexGranuleText::analyzeDictionary(
             num_tokens,
             matched_indices,
             postings_serialization);
+
+        /// Read position data from the .pos stream, synchronized with dictionary blocks.
+        if (pos_buffer)
+        {
+            /// Skip position data for all blocks/tokens between the last consumed position and this block.
+            size_t tokens_before_block = block_idx * params.dictionary_block_size;
+            size_t tokens_to_skip = tokens_before_block - pos_tokens_consumed;
+            for (size_t s = 0; s < tokens_to_skip && !pos_buffer->eof(); ++s)
+                skipOneTokenPositions(*pos_buffer);
+
+            /// Read position data for all tokens in this block.
+            /// Matched tokens get stored in token_positions; others are skipped.
+            size_t match_ptr = 0;
+            for (size_t i = 0; i < num_tokens && !pos_buffer->eof(); ++i)
+            {
+                if (match_ptr < matched_indices.size() && i == matched_indices[match_ptr])
+                {
+                    String token_name(block_tokens.getDataAt(i));
+                    token_positions[token_name] = TextIndexSerialization::deserializePositions(*pos_buffer);
+                    ++match_ptr;
+                }
+                else
+                {
+                    skipOneTokenPositions(*pos_buffer);
+                }
+            }
+
+            pos_tokens_consumed = tokens_before_block + num_tokens;
+        }
 
         for (size_t i = 0; i < matched_indices.size(); ++i)
         {
@@ -538,9 +619,18 @@ void MergeTreeIndexGranuleText::readPostingsForRareTokens(MergeTreeIndexReaderSt
 
 size_t MergeTreeIndexGranuleText::memoryUsageBytes() const
 {
+    size_t positions_size = 0;
+    for (const auto & [token, pos_data] : token_positions)
+    {
+        positions_size += token.capacity();
+        for (const auto & [row_id, positions] : pos_data.row_positions)
+            positions_size += sizeof(row_id) + positions.capacity() * sizeof(UInt32);
+    }
+
     return sizeof(*this)
         + remaining_tokens.capacity() * sizeof(*remaining_tokens.begin())
-        + rare_tokens_postings.capacity() * sizeof(*rare_tokens_postings.begin());
+        + rare_tokens_postings.capacity() * sizeof(*rare_tokens_postings.begin())
+        + positions_size;
 }
 
 bool MergeTreeIndexGranuleText::hasAnyQueryTokens(const TextSearchQuery & query) const
@@ -634,6 +724,98 @@ bool MergeTreeIndexGranuleText::hasAllQueryTokensOrEmpty(const TextSearchQuery &
     return true;
 }
 
+bool MergeTreeIndexGranuleText::hasPhraseQueryTokens(const TextSearchQuery & query) const
+{
+    /// Empty phrase always matches [D-13].
+    if (query.tokens.empty())
+        return true;
+
+    /// First, check that all tokens exist in the granule (same as hasAllQueryTokens).
+    if (!hasAllQueryTokens(query))
+        return false;
+
+    /// If no position data is available (old parts without .pos file), degrade
+    /// to hasAllQueryTokens result (conservative, may have false positives) [D-08].
+    if (!hasPositionData())
+        return true;
+
+    /// Perform positional verification using the two-pointer algorithm [D-12].
+    /// For each row that contains all tokens, verify that ordered_tokens[i+1]
+    /// appears at position == ordered_tokens[i].position + 1.
+    const auto & ordered = query.ordered_tokens;
+    if (ordered.empty())
+        return true;
+
+    /// Collect position data for each ordered token.
+    std::vector<const TokenPositionsData *> token_pos_data;
+    token_pos_data.reserve(ordered.size());
+    for (const auto & token : ordered)
+    {
+        auto it = token_positions.find(token);
+        if (it == token_positions.end() || !it->second.hasPositions())
+            return true; /// No position data for this token — conservatively return true.
+        token_pos_data.push_back(&it->second);
+    }
+
+    /// For single-token phrases, all tokens exist so any row with the token matches.
+    if (ordered.size() == 1)
+        return true;
+
+    /// Collect the set of row IDs that appear in ALL ordered tokens' position data.
+    /// Build a map from row_id to an index into each token's row_positions vector.
+    /// We iterate over the first token's rows and check if all other tokens have the same row.
+    const auto & first_token_positions = token_pos_data[0]->getPositions();
+
+    for (const auto & [row_id, positions_in_row] : first_token_positions)
+    {
+        /// For this row_id, gather position lists from each ordered token.
+        std::vector<const std::vector<UInt32> *> row_position_lists;
+        row_position_lists.reserve(ordered.size());
+        row_position_lists.push_back(&positions_in_row);
+
+        bool all_tokens_in_row = true;
+        for (size_t t = 1; t < ordered.size(); ++t)
+        {
+            const auto & tp = token_pos_data[t]->getPositions();
+            /// Binary search for this row_id in the sorted row_positions.
+            auto it = std::lower_bound(tp.begin(), tp.end(), row_id,
+                [](const RowPositions & rp, UInt32 rid) { return rp.first < rid; });
+
+            if (it == tp.end() || it->first != row_id)
+            {
+                all_tokens_in_row = false;
+                break;
+            }
+            row_position_lists.push_back(&it->second);
+        }
+
+        if (!all_tokens_in_row)
+            continue;
+
+        /// Two-pointer algorithm: for each position of the first token,
+        /// check if token[1] has position+1, token[2] has position+2, etc.
+        for (UInt32 start_pos : *row_position_lists[0])
+        {
+            bool phrase_match = true;
+            for (size_t t = 1; t < ordered.size(); ++t)
+            {
+                UInt32 expected_pos = start_pos + static_cast<UInt32>(t);
+                const auto & pos_list = *row_position_lists[t];
+                /// Binary search for expected_pos in the sorted position list.
+                if (!std::binary_search(pos_list.begin(), pos_list.end(), expected_pos))
+                {
+                    phrase_match = false;
+                    break;
+                }
+            }
+            if (phrase_match)
+                return true;
+        }
+    }
+
+    return false;
+}
+
 PostingListPtr MergeTreeIndexGranuleText::getPostingsForRareToken(std::string_view token) const
 {
     auto it = rare_tokens_postings.find(token);
@@ -646,13 +828,15 @@ MergeTreeIndexGranuleTextWritable::MergeTreeIndexGranuleTextWritable(
     SortedTokensAndPostings && tokens_and_postings_,
     TokenToPostingsBuilderMap && tokens_map_,
     std::list<PostingList> && posting_lists_,
-    std::unique_ptr<Arena> && arena_)
+    std::unique_ptr<Arena> && arena_,
+    TokenPositionsBuilder && positions_builder_)
     : params(std::move(params_))
     , posting_list_codec(posting_list_codec_)
     , tokens_and_postings(std::move(tokens_and_postings_))
     , tokens_map(std::move(tokens_map_))
     , posting_lists(std::move(posting_lists_))
     , arena(std::move(arena_))
+    , positions_builder(std::move(positions_builder_))
     , logger(getLogger("TextIndexGranuleWriter"))
 {
 }
@@ -907,6 +1091,107 @@ void TextIndexSerialization::serializeSparseIndex(const DictionarySparseIndex & 
     serialization_number->serializeBinaryBulk(*sparse_index.offsets_in_file, ostr, 0, sparse_index.offsets_in_file->size());
 }
 
+void TextIndexSerialization::serializePositions(
+    const SortedTokensAndPostings & tokens_and_postings,
+    const TokenPositionsBuilder & positions_builder,
+    WriteBuffer & ostr,
+    size_t block_begin,
+    size_t block_end)
+{
+    /// Serialize position data for each token in the dictionary block,
+    /// in the same sorted order as posting lists. [D-03, D-07, D-15]
+    for (size_t i = block_begin; i < block_end; ++i)
+    {
+        const auto & token_view = tokens_and_postings[i].first;
+        auto sorted_positions = positions_builder.getSortedPositions(token_view);
+
+        /// Write row count for this token.
+        writeVarUInt(sorted_positions.size(), ostr);
+
+        for (const auto & [row_id, positions] : sorted_positions)
+        {
+            /// Write row ID.
+            writeVarUInt(row_id, ostr);
+
+            /// Write position count for this row.
+            writeVarUInt(positions.size(), ostr);
+
+            if (positions.empty())
+                continue;
+
+            /// Write first position as-is, then deltas. [D-07]
+            writeVarUInt(positions[0], ostr);
+            for (size_t j = 1; j < positions.size(); ++j)
+            {
+                chassert(positions[j] >= positions[j - 1]);
+                writeVarUInt(positions[j] - positions[j - 1], ostr);
+            }
+        }
+    }
+}
+
+void TextIndexSerialization::serializePositions(const TokenPositionsData & positions, WriteBuffer & ostr)
+{
+    /// Serialize position data for a single token (used in merge path). [D-07, D-09]
+    /// Format: [num_rows (VarUInt)] then per-row: [row_id (VarUInt)] [count (VarUInt)] [first_pos (VarUInt)] [deltas...]
+    writeVarUInt(positions.row_positions.size(), ostr);
+
+    for (const auto & [row_id, pos_list] : positions.row_positions)
+    {
+        writeVarUInt(row_id, ostr);
+        writeVarUInt(pos_list.size(), ostr);
+
+        if (pos_list.empty())
+            continue;
+
+        writeVarUInt(pos_list[0], ostr);
+        for (size_t j = 1; j < pos_list.size(); ++j)
+        {
+            chassert(pos_list[j] >= pos_list[j - 1]);
+            writeVarUInt(pos_list[j] - pos_list[j - 1], ostr);
+        }
+    }
+}
+
+TokenPositionsData TextIndexSerialization::deserializePositions(ReadBuffer & istr)
+{
+    /// Deserialize position data for a single token. [D-07]
+    /// Symmetric to serializePositions.
+    TokenPositionsData result;
+
+    UInt64 num_rows;
+    readVarUInt(num_rows, istr);
+    result.row_positions.reserve(num_rows);
+
+    for (UInt64 r = 0; r < num_rows; ++r)
+    {
+        UInt64 row_id;
+        readVarUInt(row_id, istr);
+
+        UInt64 count;
+        readVarUInt(count, istr);
+
+        std::vector<UInt32> positions(count);
+        if (count > 0)
+        {
+            UInt64 first_pos;
+            readVarUInt(first_pos, istr);
+            positions[0] = static_cast<UInt32>(first_pos);
+
+            for (UInt64 j = 1; j < count; ++j)
+            {
+                UInt64 delta;
+                readVarUInt(delta, istr);
+                positions[j] = positions[j - 1] + static_cast<UInt32>(delta);
+            }
+        }
+
+        result.row_positions.emplace_back(static_cast<UInt32>(row_id), std::move(positions));
+    }
+
+    return result;
+}
+
 DictionarySparseIndex TextIndexSerialization::deserializeSparseIndex(ReadBuffer & istr)
 {
     ProfileEvents::increment(ProfileEvents::TextIndexReadSparseIndexBlocks);
@@ -1136,7 +1421,7 @@ DictionarySparseIndex serializeTokensAndPostings(
 
 void MergeTreeIndexGranuleTextWritable::serializeBinary(WriteBuffer &) const
 {
-    throw Exception(ErrorCodes::LOGICAL_ERROR, "Index with type 'text' must be serialized with 3 streams: index, dictionary, postings");
+    throw Exception(ErrorCodes::LOGICAL_ERROR, "Index with type 'text' must be serialized with 4 streams: index, dictionary, postings, positions");
 }
 
 void MergeTreeIndexGranuleTextWritable::serializeBinaryWithMultipleStreams(MergeTreeIndexOutputStreams & streams) const
@@ -1144,18 +1429,72 @@ void MergeTreeIndexGranuleTextWritable::serializeBinaryWithMultipleStreams(Merge
     auto * index_stream = streams.at(MergeTreeIndexSubstream::Type::Regular);
     auto * dictionary_stream = streams.at(MergeTreeIndexSubstream::Type::TextIndexDictionary);
     auto * postings_stream = streams.at(MergeTreeIndexSubstream::Type::TextIndexPostings);
+    auto * positions_stream = streams.at(MergeTreeIndexSubstream::Type::TextIndexPositions);
 
-    if (!index_stream || !dictionary_stream || !postings_stream)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Index with type 'text' must be serialized with 3 streams: index, dictionary, postings. One of the streams is missing");
+    if (!index_stream || !dictionary_stream || !postings_stream || !positions_stream)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Index with type 'text' must be serialized with 4 streams: index, dictionary, postings, positions. One of the streams is missing");
 
     PostingsSerialization postings_serialization(posting_list_codec);
-    auto sparse_index_block = serializeTokensAndPostings(
-        tokens_and_postings,
-        *dictionary_stream,
-        *postings_stream,
-        params,
-        postings_serialization);
 
+    /// Serialize tokens, postings, and positions aligned by dictionary block. [D-15]
+    size_t num_tokens = tokens_and_postings.size();
+    size_t num_blocks = (num_tokens + params.dictionary_block_size - 1) / params.dictionary_block_size;
+
+    auto sparse_index_tokens = ColumnString::create();
+    auto & sparse_index_str = assert_cast<ColumnString &>(*sparse_index_tokens);
+    sparse_index_str.reserve(num_blocks);
+
+    auto sparse_index_offsets = ColumnUInt64::create();
+    auto & sparse_index_offsets_data = sparse_index_offsets->getData();
+    sparse_index_offsets_data.reserve(num_blocks);
+
+    auto tokens_format = params.dictionary_block_frontcoding_compression
+        ? TextIndexSerialization::TokensFormat::FrontCodedStrings
+        : TextIndexSerialization::TokensFormat::RawStrings;
+
+    for (size_t block_idx = 0; block_idx < num_blocks; ++block_idx)
+    {
+        size_t block_begin = block_idx * params.dictionary_block_size;
+        size_t block_end = std::min(block_begin + params.dictionary_block_size, num_tokens);
+
+        /// Start a new compressed block because the dictionary blocks
+        /// are usually read with random reads and it is more efficient
+        /// to decompress only the needed data.
+        dictionary_stream->compressed_hashing.next();
+        auto dictionary_mark = dictionary_stream->getCurrentMark();
+        chassert(dictionary_mark.offset_in_decompressed_block == 0);
+
+        const auto & first_token = tokens_and_postings[block_begin].first;
+        sparse_index_offsets_data.emplace_back(dictionary_mark.offset_in_compressed_file);
+        sparse_index_str.insertData(first_token.data(), first_token.size());
+
+        serializeTokensImpl(
+            [&](size_t i) { return tokens_and_postings[i].first; },
+            dictionary_stream->compressed_hashing,
+            tokens_format,
+            block_begin,
+            block_end);
+
+        for (size_t i = block_begin; i < block_end; ++i)
+        {
+            auto & postings = *tokens_and_postings[i].second;
+            auto token_info = TextIndexSerialization::serializePostings(postings, *postings_stream, params, postings_serialization);
+            TextIndexSerialization::serializeTokenInfo(dictionary_stream->compressed_hashing, token_info);
+
+            if (token_info.header & PostingsSerialization::Flags::EmbeddedPostings)
+                postings_serialization.serialize(postings, token_info, params.posting_list_block_size, dictionary_stream->compressed_hashing);
+        }
+
+        /// Serialize position data aligned with this dictionary block. [D-03, D-15]
+        TextIndexSerialization::serializePositions(
+            tokens_and_postings,
+            positions_builder,
+            positions_stream->plain_hashing,
+            block_begin,
+            block_end);
+    }
+
+    auto sparse_index_block = DictionarySparseIndex(std::move(sparse_index_tokens), std::move(sparse_index_offsets));
     TextIndexSerialization::serializeSparseIndex(sparse_index_block, index_stream->compressed_hashing);
 }
 
@@ -1228,6 +1567,9 @@ void PostingListBuilder::add(UInt32 value, PostingListsHolder & postings_holder)
 
 void MergeTreeIndexTextGranuleBuilder::addDocument(std::string_view document)
 {
+    const bool capture_positions = tokenizer->supportsPhraseQuery();
+    UInt32 token_position = 0;
+
     forEachToken(
         *tokenizer,
         document.data(),
@@ -1242,6 +1584,16 @@ void MergeTreeIndexTextGranuleBuilder::addDocument(std::string_view document)
 
             auto & posting_list_builder = it->getMapped();
             posting_list_builder.add(static_cast<UInt32>(current_row), posting_lists);
+
+            /// Capture token position for phrase query support. [D-02, D-04]
+            /// Copy token to arena for stable string_view lifetime in positions_builder.
+            if (capture_positions)
+            {
+                const char * persisted = arena->insert(token_start, token_length);
+                positions_builder.add(std::string_view(persisted, token_length), static_cast<UInt32>(current_row), token_position);
+            }
+
+            ++token_position;
             ++num_processed_tokens;
             return false;
         });
@@ -1271,7 +1623,8 @@ std::unique_ptr<MergeTreeIndexGranuleTextWritable> MergeTreeIndexTextGranuleBuil
         std::move(sorted_values),
         std::move(tokens_map),
         std::move(posting_lists),
-        std::move(arena));
+        std::move(arena),
+        std::move(positions_builder));
 }
 
 void MergeTreeIndexTextGranuleBuilder::reset()
@@ -1281,6 +1634,7 @@ void MergeTreeIndexTextGranuleBuilder::reset()
     num_processed_tokens = 0;
     tokens_map = {};
     posting_lists.clear();
+    positions_builder.clear();
     arena = std::make_unique<Arena>();
 }
 
@@ -1388,14 +1742,26 @@ MergeTreeIndexSubstreams MergeTreeIndexText::getSubstreams() const
     {
         {MergeTreeIndexSubstream::Type::Regular, "", ".idx"},
         {MergeTreeIndexSubstream::Type::TextIndexDictionary, ".dct", ".idx"},
-        {MergeTreeIndexSubstream::Type::TextIndexPostings, ".pst", ".idx"}
+        {MergeTreeIndexSubstream::Type::TextIndexPostings, ".pst", ".idx"},
+        {MergeTreeIndexSubstream::Type::TextIndexPositions, ".pos", ".idx"}
     };
 }
 
 MergeTreeIndexFormat MergeTreeIndexText::getDeserializedFormat(const MergeTreeDataPartChecksums & checksums, const std::string & path_prefix) const
 {
     if (indexFileExistsInChecksums(checksums, path_prefix, ".idx"))
-        return {1, getSubstreams()};
+    {
+        /// Check if the positions substream exists. Old parts may not have it. [D-08]
+        if (indexFileExistsInChecksums(checksums, path_prefix + ".pos", ".idx"))
+            return {1, getSubstreams()};
+
+        /// Fallback to 3-stream format (without positions) for backward compatibility.
+        return {1, {
+            {MergeTreeIndexSubstream::Type::Regular, "", ".idx"},
+            {MergeTreeIndexSubstream::Type::TextIndexDictionary, ".dct", ".idx"},
+            {MergeTreeIndexSubstream::Type::TextIndexPostings, ".pst", ".idx"}
+        }};
+    }
 
     return {0, {}};
 }

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -201,6 +201,64 @@ struct TokenPostingsInfo
 using TokenPostingsInfoPtr = std::shared_ptr<TokenPostingsInfo>;
 using TokenToPostingsInfosMap = absl::flat_hash_map<String, TokenPostingsInfoPtr>;
 
+/// Map from row ID to sorted token positions (0-based token sequence numbers) within that row.
+using RowPositionsMap = absl::flat_hash_map<UInt32, std::vector<UInt32>>;
+
+/// Builder for token position data during index writing.
+/// Accumulates per-token, per-row position lists that correspond 1:1 with posting list entries.
+/// Uses token sequence numbers (0-based) rather than byte offsets. [D-02, D-03]
+struct TokenPositionsBuilder
+{
+    /// Add a token position: the token at `token_view` appeared at position `position` in row `row_id`.
+    void add(std::string_view token_view, UInt32 row_id, UInt32 position)
+    {
+        data[token_view][row_id].push_back(position);
+    }
+
+    /// Get sorted positions for a given token across all rows.
+    /// Returns a vector of (row_id, sorted positions) pairs, sorted by row_id.
+    std::vector<std::pair<UInt32, std::vector<UInt32>>> getSortedPositions(std::string_view token_view) const
+    {
+        auto it = data.find(token_view);
+        if (it == data.end())
+            return {};
+
+        std::vector<std::pair<UInt32, std::vector<UInt32>>> result;
+        result.reserve(it->second.size());
+        for (const auto & [row_id, positions] : it->second)
+        {
+            auto sorted_positions = positions;
+            std::sort(sorted_positions.begin(), sorted_positions.end());
+            result.emplace_back(row_id, std::move(sorted_positions));
+        }
+        std::sort(result.begin(), result.end(), [](const auto & a, const auto & b) { return a.first < b.first; });
+        return result;
+    }
+
+    void clear() { data.clear(); }
+    bool empty() const { return data.empty(); }
+
+private:
+    /// token -> (row_id -> positions)
+    absl::flat_hash_map<std::string_view, RowPositionsMap> data;
+};
+
+/// A single row's position data: row ID and its sorted token positions.
+using RowPositions = std::pair<UInt32, std::vector<UInt32>>;
+
+/// Read-path data structure holding deserialized token position information.
+/// Corresponds 1:1 with posting list data for a given token. [D-03]
+struct TokenPositionsData
+{
+    /// Check if position data is available (non-empty).
+    bool hasPositions() const { return !row_positions.empty(); }
+
+    /// Get the position entries (row_id, positions) for this token.
+    const std::vector<RowPositions> & getPositions() const { return row_positions; }
+
+    std::vector<RowPositions> row_positions;
+};
+
 struct DictionaryBlockBase
 {
     ColumnPtr tokens;
@@ -257,6 +315,23 @@ struct TextIndexSerialization
     static void serializeTokenInfo(WriteBuffer & ostr, const TokenPostingsInfo & token_info);
     static void serializeSparseIndex(const DictionarySparseIndex & sparse_index, WriteBuffer & ostr);
 
+    /// Serializes token position data for a dictionary block of tokens. [D-07, D-15]
+    /// Positions are written in the same token order as the posting lists (sorted alphabetically).
+    /// Format per token per row: [count (VarUInt)] [first_pos (VarUInt)] [delta_1 (VarUInt)] ...
+    static void serializePositions(
+        const SortedTokensAndPostings & tokens_and_postings,
+        const TokenPositionsBuilder & positions_builder,
+        WriteBuffer & ostr,
+        size_t block_begin,
+        size_t block_end);
+
+    /// Serializes position data for a single token. Used by the merge path. [D-07, D-09]
+    static void serializePositions(const TokenPositionsData & positions, WriteBuffer & ostr);
+
+    /// Deserializes position data for a single token from the .pos stream. [D-07]
+    /// Symmetric to serializePositions: reads [num_rows] then per-row [row_id] [count] [first_pos] [deltas...].
+    static TokenPositionsData deserializePositions(ReadBuffer & istr);
+
     static DictionarySparseIndex deserializeSparseIndex(ReadBuffer & istr);
     /// If postings_serialization is null, embedded postings are skipped.
     static TokenPostingsInfo deserializeTokenInfo(ReadBuffer & istr, PostingsSerialization * postings_serialization);
@@ -301,11 +376,17 @@ public:
     bool hasAnyQueryTokens(const TextSearchQuery & query) const;
     bool hasAllQueryTokens(const TextSearchQuery & query) const;
     bool hasAllQueryTokensOrEmpty(const TextSearchQuery & query) const;
+    bool hasPhraseQueryTokens(const TextSearchQuery & query) const;
 
     const TokenToPostingsInfosMap & getRemainingTokens() const { return remaining_tokens; }
     PostingListPtr getPostingsForRareToken(std::string_view token) const;
     void setCurrentRange(RowsRange range) { current_range = std::move(range); }
     const String & getIndexIdForCaches() const { return index_id_for_caches; }
+
+    /// Returns true if position data was loaded from the .pos stream. [D-08]
+    bool hasPositionData() const { return !token_positions.empty(); }
+    /// Position data deserialized from the .pos stream, keyed by token string. [D-03]
+    const absl::flat_hash_map<String, TokenPositionsData> & getTokenPositions() const { return token_positions; }
 
     static PostingListPtr readPostingsBlock(
         MergeTreeIndexReaderStream & stream,
@@ -317,7 +398,8 @@ public:
 
 private:
     /// Reads dictionary blocks and analyzes them for tokens.
-    void analyzeDictionary(MergeTreeIndexReaderStream & header_stream, MergeTreeIndexReaderStream & dictionary_stream, MergeTreeIndexDeserializationState & state);
+    /// If positions_stream is non-null, also reads position data from the .pos stream. [D-08]
+    void analyzeDictionary(MergeTreeIndexReaderStream & header_stream, MergeTreeIndexReaderStream & dictionary_stream, MergeTreeIndexDeserializationState & state, MergeTreeIndexReaderStream * positions_stream = nullptr);
     /// Fills tokens and their infos from the cache.
     /// Returns tokens that are not in the cache and need to be read from the dictionary file.
     std::vector<String> fillTokensFromCache(MergeTreeIndexDeserializationState & state);
@@ -338,6 +420,9 @@ private:
     String index_id_for_caches;
     /// Serialization for the posting lists.
     PostingsSerialization postings_serialization;
+    /// Deserialized token position data from the .pos stream. [D-03, D-08]
+    /// Empty when the .pos stream is not present (old parts).
+    absl::flat_hash_map<String, TokenPositionsData> token_positions;
 };
 
 /// Text index granule created on writing of the index.
@@ -351,7 +436,8 @@ struct MergeTreeIndexGranuleTextWritable : public IMergeTreeIndexGranule
         SortedTokensAndPostings && tokens_and_postings_,
         TokenToPostingsBuilderMap && tokens_map_,
         std::list<PostingList> && posting_lists_,
-        std::unique_ptr<Arena> && arena_);
+        std::unique_ptr<Arena> && arena_,
+        TokenPositionsBuilder && positions_builder_);
 
     ~MergeTreeIndexGranuleTextWritable() override = default;
 
@@ -371,6 +457,8 @@ struct MergeTreeIndexGranuleTextWritable : public IMergeTreeIndexGranule
     TokenToPostingsBuilderMap tokens_map;
     std::list<PostingList> posting_lists;
     std::unique_ptr<Arena> arena;
+    /// Token position data for phrase query support. [D-03]
+    TokenPositionsBuilder positions_builder;
     LoggerPtr logger;
 };
 
@@ -406,6 +494,8 @@ struct MergeTreeIndexTextGranuleBuilder
     std::list<PostingList> posting_lists;
     /// Keys may be serialized into arena (see ArenaKeyHolder).
     std::unique_ptr<Arena> arena;
+    /// Token position builder for phrase query support. [D-02, D-03, D-04]
+    TokenPositionsBuilder positions_builder;
 };
 
 class MergeTreeIndexTextPreprocessor;

--- a/src/Storages/MergeTree/MergeTreeIndicesSerialization.h
+++ b/src/Storages/MergeTree/MergeTreeIndicesSerialization.h
@@ -22,6 +22,7 @@ struct MergeTreeIndexSubstream
         Regular,
         TextIndexDictionary,
         TextIndexPostings,
+        TextIndexPositions,
     };
 
     Type type;
@@ -32,9 +33,9 @@ struct MergeTreeIndexSubstream
 
     static bool isCompressed(Type type)
     {
-        /// Text index postings are not compressed by write buffer,
+        /// Text index postings and positions are not compressed by write buffer,
         /// because the compression is implicitly applied during building them.
-        return type != Type::TextIndexPostings;
+        return type != Type::TextIndexPostings && type != Type::TextIndexPositions;
     }
 };
 

--- a/src/Storages/MergeTree/TextIndexUtils.cpp
+++ b/src/Storages/MergeTree/TextIndexUtils.cpp
@@ -238,10 +238,26 @@ MergeTextIndexesTask::MergeTextIndexesTask(
 
     auto substreams = index_ptr->getSubstreams();
 
+    /// Try to open .pos input streams if available. [D-08, D-09]
+    /// Position data is only carried during merge if ALL source segments have .pos streams.
+    has_position_streams = true;
+
     for (size_t i = 0; i < segments.size(); ++i)
     {
         for (const auto & substream : substreams)
         {
+            /// For .pos streams, check existence first - old parts may not have them.
+            if (substream.type == MergeTreeIndexSubstream::Type::TextIndexPositions)
+            {
+                auto pos_stream_name = segments[i].index_file_name + substream.suffix;
+                auto actual_name = IMergeTreeDataPart::getStreamNameOrHash(pos_stream_name, substream.extension, *segments[i].part_storage);
+                if (!actual_name)
+                {
+                    has_position_streams = false;
+                    continue;
+                }
+            }
+
             auto stream = makeTextIndexInputStream(
                 segments[i].part_storage,
                 segments[i].index_file_name + substream.suffix,
@@ -326,6 +342,32 @@ PostingListPtr MergeTextIndexesTask::adjustPartOffsets(size_t source_num, Postin
     return std::make_shared<PostingList>(offsets.size(), offsets.data());
 }
 
+TokenPositionsData MergeTextIndexesTask::readPositions(size_t source_num)
+{
+    if (!has_position_streams)
+        return {};
+
+    auto it = input_streams[source_num].find(MergeTreeIndexSubstream::Type::TextIndexPositions);
+    if (it == input_streams[source_num].end())
+        return {};
+
+    auto * data_buffer = it->second->getDataBuffer();
+    return TextIndexSerialization::deserializePositions(*data_buffer);
+}
+
+TokenPositionsData MergeTextIndexesTask::adjustPositionRowIDs(size_t source_num, TokenPositionsData positions)
+{
+    if (!merged_part_offsets || positions.row_positions.empty())
+        return positions;
+
+    size_t part_index = segments[source_num].part_index;
+
+    for (auto & [row_id, pos_list] : positions.row_positions)
+        row_id = static_cast<UInt32>((*merged_part_offsets)[part_index, row_id]);
+
+    return positions;
+}
+
 void MergeTextIndexesTask::flushPostingList()
 {
     auto * postings_stream = output_streams.at(MergeTreeIndexSubstream::Type::TextIndexPostings);
@@ -336,6 +378,11 @@ void MergeTextIndexesTask::flushPostingList()
         token_info.embedded_postings = std::make_shared<PostingList>(output_postings);
 
     output_infos.push_back(token_info);
+    /// Sort accumulated position rows by row_id for deterministic output. [D-09]
+    std::sort(output_positions.row_positions.begin(), output_positions.row_positions.end(),
+        [](const auto & a, const auto & b) { return a.first < b.first; });
+    output_block_positions.push_back(std::move(output_positions));
+    output_positions = {};
     output_postings.clear();
 }
 
@@ -377,9 +424,16 @@ void MergeTextIndexesTask::flushDictionaryBlock()
         }
     }
 
+    /// Write position data for this dictionary block to the .pos stream. [D-03, D-09]
+    auto * positions_stream = output_streams.at(MergeTreeIndexSubstream::Type::TextIndexPositions);
+    auto & pos_ostr = positions_stream->plain_hashing;
+    for (size_t i = 0; i < num_tokens; ++i)
+        TextIndexSerialization::serializePositions(output_block_positions[i], pos_ostr);
+
     output_tokens = ColumnString::create();
     output_postings.clear();
     output_infos.clear();
+    output_block_positions.clear();
 }
 
 bool MergeTextIndexesTask::isNewToken(const SortCursor & cursor) const
@@ -423,6 +477,7 @@ bool MergeTextIndexesTask::executeStep()
                 flushDictionaryBlock();
 
             output_tokens->insertFrom(*inputs[current->order].tokens, current->getRow());
+            output_positions = {};
         }
 
         auto read_postings = readPostingLists(current->order);
@@ -432,6 +487,12 @@ bool MergeTextIndexesTask::executeStep()
             posting = adjustPartOffsets(current->order, posting);
             output_postings |= *posting;
         }
+
+        /// Read and accumulate position data for the current token. [D-09]
+        auto positions = readPositions(current->order);
+        positions = adjustPositionRowIDs(current->order, std::move(positions));
+        for (auto & row_pos : positions.row_positions)
+            output_positions.row_positions.push_back(std::move(row_pos));
 
         if (!current->isLast())
         {

--- a/src/Storages/MergeTree/TextIndexUtils.h
+++ b/src/Storages/MergeTree/TextIndexUtils.h
@@ -99,8 +99,13 @@ private:
     void readDictionaryBlock(size_t source_num);
     /// Reads the next posting lists for the next token in the given source index.
     std::vector<PostingListPtr> readPostingLists(size_t source_num);
+    /// Reads position data for the current token from the given source.
+    /// Returns empty data if .pos stream is not available. [D-08, D-09]
+    TokenPositionsData readPositions(size_t source_num);
     /// Adjusts row numbers in the postings list according to merged part offsets.
     PostingListPtr adjustPartOffsets(size_t source_num, PostingListPtr posting_list);
+    /// Adjusts row IDs in position data according to merged part offsets. [D-09]
+    TokenPositionsData adjustPositionRowIDs(size_t source_num, TokenPositionsData positions);
 
     void flushPostingList();
     void flushDictionaryBlock();
@@ -129,6 +134,8 @@ private:
     MutableColumnPtr output_tokens;
     /// Tokens infos accumulated for the current dictionary block.
     std::vector<TokenPostingsInfo> output_infos;
+    /// Position data accumulated for the current dictionary block (parallel to output_infos).
+    std::vector<TokenPositionsData> output_block_positions;
     /// Postings accumulated for the current token.
     PostingList output_postings;
     /// Sparse index accumulated for the task. Flushed only once in the end of the task.
@@ -136,6 +143,11 @@ private:
     MutableColumnPtr sparse_index_offsets;
 
     PostingsSerialization postings_serialization;
+
+    /// Whether input segments have .pos streams available.
+    bool has_position_streams = false;
+    /// Accumulated position data for the current token across all source segments.
+    TokenPositionsData output_positions;
 
     bool is_initialized = false;
 };

--- a/tests/queries/0_stateless/04061_text_index_hasPhrase.reference
+++ b/tests/queries/0_stateless/04061_text_index_hasPhrase.reference
@@ -22,9 +22,6 @@
 1
 0
 1
--- Section 1c: Explicit tokenizer
-1
-1
 -- Section 2: Text index integration
 -- Basic phrase query
 1	the quick brown fox
@@ -61,14 +58,10 @@ Parts: 0/1
 -- Consistency: empty phrase
 8
 8
--- Section 5: Ngram tokenizer rejection
--- Section 6: Merge correctness
+-- Section 5: Merge correctness
 -- Before merge
 1
 5
 -- After merge
 1
 5
--- Section 7: Multiple tokenizers
--- splitByString tokenizer: quick brown
-1

--- a/tests/queries/0_stateless/04061_text_index_hasPhrase.reference
+++ b/tests/queries/0_stateless/04061_text_index_hasPhrase.reference
@@ -1,0 +1,74 @@
+-- Section 1: Pure function correctness
+1
+1
+1
+1
+1
+0
+0
+0
+0
+1
+1
+1
+1
+-- Section 1b: Edge cases
+0
+1
+1
+1
+1
+1
+1
+0
+1
+-- Section 1c: Explicit tokenizer
+1
+1
+-- Section 2: Text index integration
+-- Basic phrase query
+1	the quick brown fox
+-- 3-token phrase
+1	the quick brown fox
+-- Phrase: quick fox
+3	quick fox is not brown fox
+-- Phrase: brown quick
+4	brown quick reverse order
+-- Single token
+5	segmentation fault core dumped
+6	no fault here at all
+-- Empty phrase
+8
+-- Phrase not present
+-- Repeated tokens: to be
+7	to be or not to be
+-- Section 3: EXPLAIN indexes verification
+-- Skip index name in EXPLAIN
+1
+-- Non-matching phrase skips parts
+Parts: 0/1
+-- Section 4: Index vs no-index consistency
+-- Consistency: quick brown
+1
+1
+-- Consistency: segmentation fault
+5
+5
+-- Consistency: to be
+7
+7
+-- Consistency: not present
+-- Consistency: empty phrase
+8
+8
+-- Section 5: Ngram tokenizer rejection
+-- Section 6: Merge correctness
+-- Before merge
+1
+5
+-- After merge
+1
+5
+-- Section 7: Multiple tokenizers
+-- splitByString tokenizer: quick brown
+1

--- a/tests/queries/0_stateless/04061_text_index_hasPhrase.sql
+++ b/tests/queries/0_stateless/04061_text_index_hasPhrase.sql
@@ -1,0 +1,269 @@
+-- Tags: no-fasttest, no-parallel-replicas
+
+-- Ensure text index is always used (use_skip_indexes_on_data_read=0 has a known
+-- incompatibility with text index direct read and can cause hangs).
+SET use_skip_indexes_on_data_read = 1;
+
+-- ============================================================
+-- Section 1: Pure function correctness (no index)
+-- ============================================================
+
+SELECT '-- Section 1: Pure function correctness';
+
+-- Basic 2-token phrase
+SELECT hasPhrase('the quick brown fox', 'quick brown');
+-- Basic 3-token phrase
+SELECT hasPhrase('the quick brown fox', 'quick brown fox');
+-- Full match
+SELECT hasPhrase('the quick brown fox', 'the quick brown fox');
+-- Single token (equivalent to hasToken)
+SELECT hasPhrase('the quick brown fox', 'quick');
+-- Empty phrase -> always 1
+SELECT hasPhrase('the quick brown fox', '');
+-- Tokens present but not adjacent -> 0
+SELECT hasPhrase('the quick brown fox', 'quick fox');
+-- Tokens present but wrong order -> 0
+SELECT hasPhrase('the quick brown fox', 'brown quick');
+-- Phrase not in text at all
+SELECT hasPhrase('the quick brown fox', 'lazy dog');
+-- Single word not present
+SELECT hasPhrase('the quick brown fox', 'cat');
+-- Repeated tokens in phrase
+SELECT hasPhrase('to be or not to be that is the question', 'to be');
+SELECT hasPhrase('to be or not to be that is the question', 'not to be');
+-- Phrase at start
+SELECT hasPhrase('hello world foo bar', 'hello world');
+-- Phrase at end
+SELECT hasPhrase('hello world foo bar', 'foo bar');
+
+SELECT '-- Section 1b: Edge cases';
+
+-- Empty haystack
+SELECT hasPhrase('', 'hello');
+SELECT hasPhrase('', '');
+-- Special characters as separators
+SELECT hasPhrase('error: segmentation fault (core dumped)', 'segmentation fault');
+SELECT hasPhrase('path/to/file.txt contains data', 'to file');
+-- Numeric tokens
+SELECT hasPhrase('error 404 not found', '404 not');
+SELECT hasPhrase('version 1 2 3', '1 2 3');
+-- Long text
+SELECT hasPhrase(
+    'Lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua',
+    'sed do eiusmod'
+);
+-- Case sensitive
+SELECT hasPhrase('The Quick Brown Fox', 'the quick');
+SELECT hasPhrase('The Quick Brown Fox', 'The Quick');
+
+SELECT '-- Section 1c: Explicit tokenizer';
+
+SELECT hasPhrase('hello world test', 'hello world', 'splitByNonAlpha');
+SELECT hasPhrase('hello world test', 'world test', 'splitByNonAlpha');
+
+-- ============================================================
+-- Section 2: Text index integration (with text index)
+-- ============================================================
+
+SELECT '-- Section 2: Text index integration';
+
+DROP TABLE IF EXISTS test_phrase_idx;
+
+CREATE TABLE test_phrase_idx
+(
+    id UInt64,
+    content String,
+    INDEX idx content TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi';
+
+INSERT INTO test_phrase_idx VALUES
+    (1, 'the quick brown fox'),
+    (2, 'jumps over the lazy dog'),
+    (3, 'quick fox is not brown fox'),
+    (4, 'brown quick reverse order'),
+    (5, 'segmentation fault core dumped'),
+    (6, 'no fault here at all'),
+    (7, 'to be or not to be'),
+    (8, 'that is the question');
+
+-- Basic phrase query
+SELECT '-- Basic phrase query';
+SELECT id, content FROM test_phrase_idx WHERE hasPhrase(content, 'quick brown') ORDER BY id;
+
+-- 3-token phrase
+SELECT '-- 3-token phrase';
+SELECT id, content FROM test_phrase_idx WHERE hasPhrase(content, 'quick brown fox') ORDER BY id;
+
+-- Tokens not adjacent in row 1 (quick _ _ fox), but adjacent in row 3 (quick fox ...)
+SELECT '-- Phrase: quick fox';
+SELECT id, content FROM test_phrase_idx WHERE hasPhrase(content, 'quick fox') ORDER BY id;
+
+-- 'brown quick' appears in row 4 as adjacent tokens in that order
+SELECT '-- Phrase: brown quick';
+SELECT id, content FROM test_phrase_idx WHERE hasPhrase(content, 'brown quick') ORDER BY id;
+
+-- Single token phrase
+SELECT '-- Single token';
+SELECT id, content FROM test_phrase_idx WHERE hasPhrase(content, 'fault') ORDER BY id;
+
+-- Empty phrase matches all
+SELECT '-- Empty phrase';
+SELECT count() FROM test_phrase_idx WHERE hasPhrase(content, '');
+
+-- Phrase not present at all
+SELECT '-- Phrase not present';
+SELECT id, content FROM test_phrase_idx WHERE hasPhrase(content, 'hello world') ORDER BY id;
+
+-- Repeated tokens
+SELECT '-- Repeated tokens: to be';
+SELECT id, content FROM test_phrase_idx WHERE hasPhrase(content, 'to be') ORDER BY id;
+
+-- ============================================================
+-- Section 3: EXPLAIN indexes=1 verification
+-- ============================================================
+
+SELECT '-- Section 3: EXPLAIN indexes verification';
+
+-- Verify that hasPhrase uses skip index (Name: idx should appear in EXPLAIN output)
+SELECT '-- Skip index name in EXPLAIN';
+SELECT count() > 0
+FROM (
+    EXPLAIN indexes = 1 SELECT * FROM test_phrase_idx WHERE hasPhrase(content, 'quick brown')
+)
+WHERE explain LIKE '%Name:%idx%';
+
+-- Non-matching phrase should skip all parts (Parts: 0/1)
+SELECT '-- Non-matching phrase skips parts';
+SELECT trim(explain)
+FROM (
+    EXPLAIN indexes = 1 SELECT * FROM test_phrase_idx WHERE hasPhrase(content, 'nonexistent phrase here')
+)
+WHERE explain LIKE '%Parts: 0/1%';
+
+-- ============================================================
+-- Section 4: Consistency between indexed and non-indexed tables
+-- ============================================================
+
+SELECT '-- Section 4: Index vs no-index consistency';
+
+DROP TABLE IF EXISTS test_phrase_noidx;
+
+CREATE TABLE test_phrase_noidx
+(
+    id UInt64,
+    content String
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+INSERT INTO test_phrase_noidx VALUES
+    (1, 'the quick brown fox'),
+    (2, 'jumps over the lazy dog'),
+    (3, 'quick fox is not brown fox'),
+    (4, 'brown quick reverse order'),
+    (5, 'segmentation fault core dumped'),
+    (6, 'no fault here at all'),
+    (7, 'to be or not to be'),
+    (8, 'that is the question');
+
+-- Compare results: indexed vs non-indexed should be identical
+SELECT '-- Consistency: quick brown';
+SELECT id FROM test_phrase_idx WHERE hasPhrase(content, 'quick brown') ORDER BY id;
+SELECT id FROM test_phrase_noidx WHERE hasPhrase(content, 'quick brown') ORDER BY id;
+
+SELECT '-- Consistency: segmentation fault';
+SELECT id FROM test_phrase_idx WHERE hasPhrase(content, 'segmentation fault') ORDER BY id;
+SELECT id FROM test_phrase_noidx WHERE hasPhrase(content, 'segmentation fault') ORDER BY id;
+
+SELECT '-- Consistency: to be';
+SELECT id FROM test_phrase_idx WHERE hasPhrase(content, 'to be') ORDER BY id;
+SELECT id FROM test_phrase_noidx WHERE hasPhrase(content, 'to be') ORDER BY id;
+
+SELECT '-- Consistency: not present';
+SELECT id FROM test_phrase_idx WHERE hasPhrase(content, 'hello world') ORDER BY id;
+SELECT id FROM test_phrase_noidx WHERE hasPhrase(content, 'hello world') ORDER BY id;
+
+SELECT '-- Consistency: empty phrase';
+SELECT count() FROM test_phrase_idx WHERE hasPhrase(content, '');
+SELECT count() FROM test_phrase_noidx WHERE hasPhrase(content, '');
+
+DROP TABLE IF EXISTS test_phrase_idx;
+DROP TABLE IF EXISTS test_phrase_noidx;
+
+-- ============================================================
+-- Section 5: Ngram tokenizer rejection (FC-5)
+-- ============================================================
+
+SELECT '-- Section 5: Ngram tokenizer rejection';
+
+-- hasPhrase should reject ngram tokenizer with an exception
+SELECT hasPhrase('hello world', 'hello world', 'ngram(3)'); -- { serverError BAD_ARGUMENTS }
+
+-- ============================================================
+-- Section 6: OPTIMIZE TABLE merge correctness (FC-3)
+-- ============================================================
+
+SELECT '-- Section 6: Merge correctness';
+
+DROP TABLE IF EXISTS test_phrase_merge;
+
+CREATE TABLE test_phrase_merge
+(
+    id UInt64,
+    content String,
+    INDEX idx content TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi';
+
+-- Insert multiple batches to create multiple parts
+INSERT INTO test_phrase_merge VALUES (1, 'the quick brown fox'), (2, 'jumps over the lazy dog');
+INSERT INTO test_phrase_merge VALUES (3, 'quick fox is not brown fox'), (4, 'brown quick reverse order');
+INSERT INTO test_phrase_merge VALUES (5, 'to be or not to be'), (6, 'that is the question');
+
+-- Query before merge
+SELECT '-- Before merge';
+SELECT id FROM test_phrase_merge WHERE hasPhrase(content, 'quick brown') ORDER BY id;
+SELECT id FROM test_phrase_merge WHERE hasPhrase(content, 'to be') ORDER BY id;
+
+OPTIMIZE TABLE test_phrase_merge FINAL;
+
+-- Query after merge — results must be identical
+SELECT '-- After merge';
+SELECT id FROM test_phrase_merge WHERE hasPhrase(content, 'quick brown') ORDER BY id;
+SELECT id FROM test_phrase_merge WHERE hasPhrase(content, 'to be') ORDER BY id;
+
+DROP TABLE IF EXISTS test_phrase_merge;
+
+-- ============================================================
+-- Section 7: Multiple tokenizers (FC-4)
+-- ============================================================
+
+SELECT '-- Section 7: Multiple tokenizers';
+
+-- Test with splitByString tokenizer
+DROP TABLE IF EXISTS test_phrase_split;
+
+CREATE TABLE test_phrase_split
+(
+    id UInt64,
+    content String,
+    INDEX idx content TYPE text(tokenizer = 'splitByString') GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi';
+
+INSERT INTO test_phrase_split VALUES
+    (1, 'the quick brown fox'),
+    (2, 'quick fox is not brown'),
+    (3, 'brown quick reverse');
+
+SELECT '-- splitByString tokenizer: quick brown';
+SELECT id FROM test_phrase_split WHERE hasPhrase(content, 'quick brown') ORDER BY id;
+
+DROP TABLE IF EXISTS test_phrase_split;

--- a/tests/queries/0_stateless/04061_text_index_hasPhrase.sql
+++ b/tests/queries/0_stateless/04061_text_index_hasPhrase.sql
@@ -56,11 +56,6 @@ SELECT hasPhrase(
 SELECT hasPhrase('The Quick Brown Fox', 'the quick');
 SELECT hasPhrase('The Quick Brown Fox', 'The Quick');
 
-SELECT '-- Section 1c: Explicit tokenizer';
-
-SELECT hasPhrase('hello world test', 'hello world', 'splitByNonAlpha');
-SELECT hasPhrase('hello world test', 'world test', 'splitByNonAlpha');
-
 -- ============================================================
 -- Section 2: Text index integration (with text index)
 -- ============================================================
@@ -194,19 +189,10 @@ DROP TABLE IF EXISTS test_phrase_idx;
 DROP TABLE IF EXISTS test_phrase_noidx;
 
 -- ============================================================
--- Section 5: Ngram tokenizer rejection (FC-5)
+-- Section 5: OPTIMIZE TABLE merge correctness (FC-3)
 -- ============================================================
 
-SELECT '-- Section 5: Ngram tokenizer rejection';
-
--- hasPhrase should reject ngram tokenizer with an exception
-SELECT hasPhrase('hello world', 'hello world', 'ngram(3)'); -- { serverError BAD_ARGUMENTS }
-
--- ============================================================
--- Section 6: OPTIMIZE TABLE merge correctness (FC-3)
--- ============================================================
-
-SELECT '-- Section 6: Merge correctness';
+SELECT '-- Section 5: Merge correctness';
 
 DROP TABLE IF EXISTS test_phrase_merge;
 
@@ -238,32 +224,3 @@ SELECT id FROM test_phrase_merge WHERE hasPhrase(content, 'quick brown') ORDER B
 SELECT id FROM test_phrase_merge WHERE hasPhrase(content, 'to be') ORDER BY id;
 
 DROP TABLE IF EXISTS test_phrase_merge;
-
--- ============================================================
--- Section 7: Multiple tokenizers (FC-4)
--- ============================================================
-
-SELECT '-- Section 7: Multiple tokenizers';
-
--- Test with splitByString tokenizer
-DROP TABLE IF EXISTS test_phrase_split;
-
-CREATE TABLE test_phrase_split
-(
-    id UInt64,
-    content String,
-    INDEX idx content TYPE text(tokenizer = 'splitByString') GRANULARITY 1
-)
-ENGINE = MergeTree
-ORDER BY id
-SETTINGS index_granularity = 2, index_granularity_bytes = '10Mi';
-
-INSERT INTO test_phrase_split VALUES
-    (1, 'the quick brown fox'),
-    (2, 'quick fox is not brown'),
-    (3, 'brown quick reverse');
-
-SELECT '-- splitByString tokenizer: quick brown';
-SELECT id FROM test_phrase_split WHERE hasPhrase(content, 'quick brown') ORDER BY id;
-
-DROP TABLE IF EXISTS test_phrase_split;


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature


### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Add `hasPhrase` function for exact phrase matching with TextIndex acceleration. The function tokenizes a phrase and checks if all tokens appear adjacently and in order in the haystack. A new `.pos` position data stream is added to the TextIndex to enable granule-level phrase filtering.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

**Motivation**: Current TextIndex supports token-level matching (`hasToken`, `hasAllTokens`) but cannot verify token adjacency. Searching for "segmentation fault" matches any row containing both words regardless of their position. `hasPhrase` fills this gap by supporting exact phrase matching.

**Syntax**: `hasPhrase(haystack, phrase)`

**Parameters**:
- `haystack` — String column to search in
- `phrase` — Constant phrase string to search for (will be tokenized)

**Example**:
```sql
SELECT hasPhrase('the quick brown fox', 'quick brown'); -- 1
SELECT hasPhrase('the quick brown fox', 'brown quick'); -- 0 (order matters)

-- With TextIndex acceleration:
CREATE TABLE t (content String, INDEX idx content TYPE text) ENGINE = MergeTree ORDER BY tuple();
INSERT INTO t VALUES ('segmentation fault occurred');
SELECT * FROM t WHERE hasPhrase(content, 'segmentation fault');
```

**Implementation details**:
- New `.pos.idx` substream stores token position data (delta-encoded VarUInt)
- Position data enables granule-level phrase filtering in the TextIndex
- Old parts without `.pos` files gracefully degrade to `hasAllTokens`-level filtering with row-level string verification
- Non-phrase queries (`hasToken`, `hasAllTokens`) have zero overhead — `.pos` stream is not opened