### PR TITLE
Pin map serialization settings in 03994_map_subcolumns_small_wide test

### DIFF
--- a/tests/queries/0_stateless/03994_map_subcolumns_small_wide.sql
+++ b/tests/queries/0_stateless/03994_map_subcolumns_small_wide.sql
@@ -23,6 +23,7 @@ create table t (id UInt64, m Map(String, UInt64))
 engine = MergeTree order by id
 settings
     map_serialization_version = 'basic',
+    map_serialization_version_for_zero_level_parts = 'basic',
     min_bytes_for_wide_part = 1,
     min_rows_for_wide_part = 1,
     serialization_info_version = 'with_types';
@@ -138,6 +139,7 @@ create table t (id UInt64, data Tuple(m Map(String, UInt64)))
 engine = MergeTree order by id
 settings
     map_serialization_version = 'basic',
+    map_serialization_version_for_zero_level_parts = 'basic',
     min_bytes_for_wide_part = 1,
     min_rows_for_wide_part = 1,
     serialization_info_version = 'with_types';


### PR DESCRIPTION
The "basic" serialization test sections pinned `map_serialization_version = 'basic'` but did not pin `map_serialization_version_for_zero_level_parts`. When the CI randomizer sets this to `with_buckets`, zero-level parts get written with bucket-based key ordering, causing the output to differ from the reference which expects insertion-order keys.

Add `map_serialization_version_for_zero_level_parts = 'basic'` to both basic table definitions to fully prevent bucketing in the basic serialization test sections.

Same root cause as #101024 (which fixes the compact variant `03993`).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- n/a

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.447`
<!-- ch-version-info:end -->