### PR TITLE
Add test: No test for insert_deduplication_token + INSERT SELECT witho

### DIFF
--- a/tests/queries/0_stateless/04070_dedup_token_insert_select_mv.reference
+++ b/tests/queries/0_stateless/04070_dedup_token_insert_select_mv.reference
@@ -1,0 +1,6 @@
+MV dedup with token, no ORDER BY ALL
+10
+10
+Different token inserts into MV
+20
+20

--- a/tests/queries/0_stateless/04070_dedup_token_insert_select_mv.sql
+++ b/tests/queries/0_stateless/04070_dedup_token_insert_select_mv.sql
@@ -1,0 +1,38 @@
+-- Tags: replica
+
+-- Test: dedup token with INSERT SELECT (no ORDER BY ALL) + materialized views
+-- This covers the interaction between insert_deduplication_token and
+-- deduplicate_blocks_in_dependent_materialized_views for unsorted INSERT SELECT
+
+
+DROP TABLE IF EXISTS t_src_04070 SYNC;
+DROP TABLE IF EXISTS t_mv_dst_04070 SYNC;
+DROP VIEW IF EXISTS mv_04070;
+
+CREATE TABLE t_src_04070 (k UInt64, v String)
+ENGINE = ReplicatedMergeTree('/clickhouse/test/t_src_04070_99206/r1', 'r1')
+ORDER BY k;
+
+CREATE TABLE t_mv_dst_04070 (k UInt64, cnt UInt64)
+ENGINE = ReplicatedMergeTree('/clickhouse/test/t_mv_dst_04070_99206/r1', 'r1')
+ORDER BY k;
+
+CREATE MATERIALIZED VIEW mv_04070 TO t_mv_dst_04070 AS
+SELECT k, count() as cnt FROM t_src_04070 GROUP BY k;
+
+-- Insert with dedup token, no ORDER BY ALL, with MV dedup enabled
+SELECT 'MV dedup with token, no ORDER BY ALL';
+INSERT INTO t_src_04070 SELECT number, 'a' FROM numbers(10) SETTINGS insert_deduplication_token = 'mv_token1', deduplicate_blocks_in_dependent_materialized_views = 1;
+INSERT INTO t_src_04070 SELECT number, 'a' FROM numbers(10) SETTINGS insert_deduplication_token = 'mv_token1', deduplicate_blocks_in_dependent_materialized_views = 1;
+SELECT count() FROM t_src_04070 ORDER BY 1;
+SELECT count() FROM t_mv_dst_04070 ORDER BY 1;
+
+-- Different token inserts new data into both source and MV
+SELECT 'Different token inserts into MV';
+INSERT INTO t_src_04070 SELECT number, 'b' FROM numbers(10) SETTINGS insert_deduplication_token = 'mv_token2', deduplicate_blocks_in_dependent_materialized_views = 1;
+SELECT count() FROM t_src_04070 ORDER BY 1;
+SELECT count() FROM t_mv_dst_04070 ORDER BY 1;
+
+DROP VIEW mv_04070;
+DROP TABLE t_mv_dst_04070 SYNC;
+DROP TABLE t_src_04070 SYNC;

--- a/tests/queries/0_stateless/04070_dedup_token_insert_select_mv.sql
+++ b/tests/queries/0_stateless/04070_dedup_token_insert_select_mv.sql
@@ -23,13 +23,13 @@ SELECT k, count() as cnt FROM t_src_04070 GROUP BY k;
 -- Insert with dedup token, no ORDER BY ALL, with MV dedup enabled
 SELECT 'MV dedup with token, no ORDER BY ALL';
 INSERT INTO t_src_04070 SELECT number, 'a' FROM numbers(10) SETTINGS insert_deduplication_token = 'mv_token1', deduplicate_blocks_in_dependent_materialized_views = 1;
-INSERT INTO t_src_04070 SELECT number, 'a' FROM numbers(10) SETTINGS insert_deduplication_token = 'mv_token1', deduplicate_blocks_in_dependent_materialized_views = 1;
+INSERT INTO t_src_04070 SELECT number, 'b' FROM numbers(10) SETTINGS insert_deduplication_token = 'mv_token1', deduplicate_blocks_in_dependent_materialized_views = 1;
 SELECT count() FROM t_src_04070 ORDER BY 1;
 SELECT count() FROM t_mv_dst_04070 ORDER BY 1;
 
 -- Different token inserts new data into both source and MV
 SELECT 'Different token inserts into MV';
-INSERT INTO t_src_04070 SELECT number, 'b' FROM numbers(10) SETTINGS insert_deduplication_token = 'mv_token2', deduplicate_blocks_in_dependent_materialized_views = 1;
+INSERT INTO t_src_04070 SELECT number, 'c' FROM numbers(10) SETTINGS insert_deduplication_token = 'mv_token2', deduplicate_blocks_in_dependent_materialized_views = 1;
 SELECT count() FROM t_src_04070 ORDER BY 1;
 SELECT count() FROM t_mv_dst_04070 ORDER BY 1;
 

--- a/tests/queries/0_stateless/04070_dedup_token_insert_select_mv.sql
+++ b/tests/queries/0_stateless/04070_dedup_token_insert_select_mv.sql
@@ -1,4 +1,4 @@
--- Tags: replica
+-- Tags: replica, no-replicated-database
 
 -- Test: dedup token with INSERT SELECT (no ORDER BY ALL) + materialized views
 -- This covers the interaction between insert_deduplication_token and
@@ -10,11 +10,11 @@ DROP TABLE IF EXISTS t_mv_dst_04070 SYNC;
 DROP VIEW IF EXISTS mv_04070;
 
 CREATE TABLE t_src_04070 (k UInt64, v String)
-ENGINE = ReplicatedMergeTree('/clickhouse/test/t_src_04070_99206/r1', 'r1')
+ENGINE = ReplicatedMergeTree('/clickhouse/{database}/t_src_04070_99206/r1', 'r1')
 ORDER BY k;
 
 CREATE TABLE t_mv_dst_04070 (k UInt64, cnt UInt64)
-ENGINE = ReplicatedMergeTree('/clickhouse/test/t_mv_dst_04070_99206/r1', 'r1')
+ENGINE = ReplicatedMergeTree('/clickhouse/{database}/t_mv_dst_04070_99206/r1', 'r1')
 ORDER BY k;
 
 CREATE MATERIALIZED VIEW mv_04070 TO t_mv_dst_04070 AS


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #99206](https://github.com/ClickHouse/ClickHouse/pull/99206) (merged 2026-03-12). Confirmed on current codebase — close with a note if already fixed._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #99206](https://github.com/ClickHouse/ClickHouse/pull/99206).

**1. No test for insert_deduplication_token + INSERT SELECT without ORDER BY ALL + materialized views**
  `src/Interpreters/InterpreterInsertQuery.cpp:435`, `src/Core/DeduplicateInsert.cpp:77`

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---
_Found during review of [PR #99206](https://github.com/ClickHouse/ClickHouse/pull/99206)._

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.465`
<!-- ch-version-info:end -->