### PR TITLE
Fix flaky test 03800_assume_not_null_coalesce_if_null_monotonicity_key_condition

### DIFF
--- a/tests/queries/0_stateless/03800_assume_not_null_coalesce_if_null_monotonicity_key_condition.reference
+++ b/tests/queries/0_stateless/03800_assume_not_null_coalesce_if_null_monotonicity_key_condition.reference
@@ -5,6 +5,7 @@ DROP VIEW IF EXISTS view_coalesce;
 DROP VIEW IF EXISTS view_assume;
 DROP TABLE IF EXISTS test;
 SET session_timezone = 'UTC';
+SET query_plan_merge_expressions = 1; -- pin to avoid EXPLAIN output changes from randomization
 CREATE TABLE test
 (
     id UInt64,

--- a/tests/queries/0_stateless/03800_assume_not_null_coalesce_if_null_monotonicity_key_condition.sql
+++ b/tests/queries/0_stateless/03800_assume_not_null_coalesce_if_null_monotonicity_key_condition.sql
@@ -10,6 +10,7 @@ DROP VIEW IF EXISTS view_assume;
 DROP TABLE IF EXISTS test;
 
 SET session_timezone = 'UTC';
+SET query_plan_merge_expressions = 1; -- pin to avoid EXPLAIN output changes from randomization
 
 CREATE TABLE test
 (


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a]notation for the changelog):
- none

---

## Summary

Pin `query_plan_merge_expressions = 1` in the test to prevent EXPLAIN output mismatches when CI randomizes this setting to 0.

- The test verifies that `assumeNotNull`/`coalesce`/`ifNull` monotonicity is correctly used by KeyCondition for MinMax index and primary key condition optimization
- `query_plan_merge_expressions` only controls cosmetic merging of adjacent expression steps in the query plan — it does not affect index analysis or granule pruning
- When randomized to 0, all 10+ EXPLAIN blocks produce structurally different output (unmerged expression nodes), breaking the reference comparison

## CIDB evidence

13 failures across 6 unrelated PRs in 30 days (zero master failures — only triggered by CI randomization in PR runs):
- PR #100874 (settings randomization PR), PR #99513, PR #96130, PR #99181, PR #94017, PR #98500

## Reproduction

Deterministic reproduction:
```
CLICKHOUSE_CLIENT_OPT="--query_plan_merge_expressions 0" \
  tests/clickhouse-test --no-random-settings --no-random-merge-tree-settings \
  03800_assume_not_null_coalesce_if_null_monotonicity_key_condition
# → FAIL every time without fix
# → OK every time with fix
```

Verified 50/50 passes with full randomization after fix.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.457`
<!-- ch-version-info:end -->