### PR TITLE
Fix flaky test 02111_function_mapExtractKeyLike

### DIFF
--- a/tests/queries/0_stateless/02111_function_mapExtractKeyLike.sql
+++ b/tests/queries/0_stateless/02111_function_mapExtractKeyLike.sql
@@ -1,6 +1,6 @@
 DROP TABLE IF EXISTS map_extractKeyLike_test;
 
-CREATE TABLE map_extractKeyLike_test (id UInt32, map Map(String, String)) Engine=MergeTree() ORDER BY id settings index_granularity=2;
+CREATE TABLE map_extractKeyLike_test (id UInt32, map Map(String, String)) Engine=MergeTree() ORDER BY id settings index_granularity=2, map_serialization_version_for_zero_level_parts='basic';
 
 INSERT INTO map_extractKeyLike_test VALUES (1, {'P1-K1':'1-V1','P2-K2':'1-V2'}),(2,{'P1-K1':'2-V1','P2-K2':'2-V2'});
 INSERT INTO map_extractKeyLike_test VALUES (3, {'P1-K1':'3-V1','P2-K2':'3-V2'}),(4,{'P1-K1':'4-V1','P2-K2':'4-V2'});


### PR DESCRIPTION
CI randomizes `map_serialization_version_for_zero_level_parts` between `basic` and `with_buckets` modes. When `with_buckets` is selected, map keys are stored in bucket (hash) order instead of insertion order. This test's reference file expects insertion-order keys, so the diff check fails when bucket mode is active.

The fix pins `map_serialization_version_for_zero_level_parts='basic'` in the `CREATE TABLE` settings, which takes priority over the randomized session-level setting. This is the same pattern used in PR #101024 (compact variant) and PR #101300 (wide variant) for the 03993/03994 map subcolumns tests.

Verified: 50/50 passes with full randomization after the fix. Deterministic reproduction confirmed: fails 100% without fix when bucket mode is forced, passes 100% with fix.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a]user-readable short description of the changes that goes to CHANGELOG.md):
Pin map serialization to basic mode in test 02111_function_mapExtractKeyLike to prevent flaky failures from CI randomization of map key ordering.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.448`
<!-- ch-version-info:end -->