### PR TITLE
Fix stress test CI report dropping Server died and passing results

### DIFF
--- a/ci/jobs/stress_job.py
+++ b/ci/jobs/stress_job.py
@@ -225,11 +225,8 @@ def run_stress_test(upgrade_check: bool = False) -> None:
     failed_results = []
     for test_result in test_results:
         if test_result.name == "Server died":
-            # This result from stress.py indicates a server crash - we use it as a flag
-            # to trigger detailed log parsing below, but don't include it in the CI report
-            # since we'll create a more informative result from the parsed logs
             server_died = True
-        elif not test_result.is_ok():
+        if not test_result.is_ok():
             failed_results.append(test_result)
 
     if server_died:
@@ -322,8 +319,9 @@ def run_stress_test(upgrade_check: bool = False) -> None:
             )
         )
 
+    all_results = failed_results + [r for r in test_results if r.is_ok()]
     r = Result.create_from(
-        results=failed_results,
+        results=all_results,
         status=Result.Status.SUCCESS if not failed_results else "",
         stopwatch=stopwatch,
     )


### PR DESCRIPTION
When the stress test server dies, `stress_job.py` was filtering out the "Server died" result from `test_results.tsv` and replacing it with a parsed error from the server logs. When the log parser couldn't find a specific cause (e.g. silent OOM kill), it fell back to "Unknown error" — which is less informative than the original "Server died".

This also dropped all passing results ("Server successfully started", "No lost s3 keys", etc.) from the CI report, making it harder to understand what checks passed.

The fix:
- Always include "Server died" in the report (the log parser still adds a more specific result alongside it when it finds one)
- Include passing results from `test_results.tsv` in the CI report

Closes #101335

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.449`
<!-- ch-version-info:end -->