### PR TITLE
Fix logical error: Unexpected return type from A. Expected B. Got C. Action: (STID: 1611-343c)

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/mergeFilterIntoJoinCondition.cpp
+++ b/src/Processors/QueryPlan/Optimizations/mergeFilterIntoJoinCondition.cpp
@@ -96,29 +96,26 @@ ExpressionSide getExpressionSide(
 {
     auto inputs = getExpressionInputs(expr);
 
+    /// Whether at least one input comes from the left/right stream with an unchanged type.
     bool has_left = false;
-    for (const auto * input : inputs)
-    {
-        if (left_allowed_inputs.contains(input))
-        {
-            has_left = true;
-            break;
-        }
-    }
-
     bool has_right = false;
+
+    /// Whether at least one input is not available from either side (e.g. a USING column whose
+    /// type was changed by the JOIN USING clause). We cannot safely assign this expression to one side.
+    bool has_unavailable = false;
+
     for (const auto * input : inputs)
     {
-        if (right_allowed_inputs.contains(input))
-        {
-            has_right = true;
-            break;
-        }
+        bool in_left = left_allowed_inputs.contains(input);
+        bool in_right = right_allowed_inputs.contains(input);
+        has_left |= in_left;
+        has_right |= in_right;
+        has_unavailable |= !in_left && !in_right;
     }
 
-    if (has_left && !has_right)
+    if (has_left && !has_right && !has_unavailable)
         return ExpressionSide::LEFT;
-    else if (!has_left && has_right)
+    else if (!has_left && has_right && !has_unavailable)
         return ExpressionSide::RIGHT;
 
     return ExpressionSide::UNKNOWN;

--- a/tests/queries/0_stateless/04070_join_using_type_coercion_round.sql
+++ b/tests/queries/0_stateless/04070_join_using_type_coercion_round.sql
@@ -1,0 +1,2 @@
+-- `round(y, x)` in WHERE on a `JOIN USING` column must not cause a type mismatch exception.
+SELECT * FROM (SELECT 1 AS x, 1 AS y) AS a JOIN (SELECT 65537 AS y) AS b USING (y) WHERE round(y, x) = b.y;


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix logical error: `Unexpected return type from A. Expected B. Got C. Action: (STID: 1611-343c)`

The following stress test failed because of this issue:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=91998&sha=4c8ce380f3b9349a0b65eceba07c71e6ff5215aa&name_0=PR&name_1=Stress+test+%28arm_asan_ubsan%2C+s3%29
https://github.com/ClickHouse/ClickHouse/pull/91998

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.488`
<!-- ch-version-info:end -->