### PR TITLE
Add test: No test covers ALTER UPDATE on common virtual column _table 

### DIFF
--- a/tests/queries/0_stateless/04071_common_virtual_column_coverage.reference
+++ b/tests/queries/0_stateless/04071_common_virtual_column_coverage.reference
@@ -1,0 +1,21 @@
+1	t_04071
+2	t_04071
+3	t_04071
+number	UInt64						0
+_table	LowCardinality(String)			The name of table which the row comes from			1
+x	UInt32	0
+_part	LowCardinality(String)	1
+_part_index	UInt64	1
+_part_starting_offset	UInt64	1
+_part_uuid	UUID	1
+_partition_id	LowCardinality(String)	1
+_sample_factor	Float64	1
+_part_offset	UInt64	1
+_part_granule_offset	UInt64	1
+_part_data_version	UInt64	1
+_disk_name	LowCardinality(String)	1
+_distance	Float32	1
+_row_exists	UInt8	1
+_block_number	UInt64	1
+_block_offset	UInt64	1
+_table	LowCardinality(String)	1

--- a/tests/queries/0_stateless/04071_common_virtual_column_coverage.sql
+++ b/tests/queries/0_stateless/04071_common_virtual_column_coverage.sql
@@ -1,0 +1,18 @@
+
+DROP TABLE IF EXISTS test.t_04071;
+CREATE TABLE test.t_04071 (x UInt32) ENGINE = MergeTree ORDER BY x;
+INSERT INTO test.t_04071 VALUES (1), (2), (3);
+
+-- Verify _table works as virtual column
+SELECT x, _table FROM test.t_04071 ORDER BY x;
+
+-- Attempting to UPDATE common virtual column _table should fail with NOT_IMPLEMENTED
+ALTER TABLE test.t_04071 UPDATE _table = 'foo' WHERE 1; -- { serverError NOT_IMPLEMENTED }
+
+-- DESCRIBE on a table function should include _table in virtual columns
+DESCRIBE TABLE numbers(10) SETTINGS describe_include_virtual_columns=1;
+
+-- DESCRIBE on a regular table should also include _table
+DESCRIBE TABLE test.t_04071 SETTINGS describe_include_virtual_columns=1, describe_compact_output=1;
+
+DROP TABLE IF EXISTS test.t_04071;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #101006](https://github.com/ClickHouse/ClickHouse/pull/101006).

**1. No test covers ALTER UPDATE on common virtual column _table or DESCRIBE table function with common virtuals**
  `src/Interpreters/MutationsInterpreter.cpp:549`, `src/Interpreters/InterpreterDescribeQuery.cpp:181`

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---
_Found during review of [PR #101006](https://github.com/ClickHouse/ClickHouse/pull/101006)._