### PR TITLE
Add ability limit amount of jemalloc profile flushes on MEMORY_LIMIT_EXCEEDED per time interval

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -380,6 +380,7 @@ namespace ServerSetting
     extern const ServerSettingsBool abort_on_logical_error;
     extern const ServerSettingsUInt64 jemalloc_flush_profile_interval_bytes;
     extern const ServerSettingsBool jemalloc_flush_profile_on_memory_exceeded;
+    extern const ServerSettingsUInt64 jemalloc_flush_profile_on_memory_exceeded_interval;
     extern const ServerSettingsString allowed_disks_for_table_engines;
     extern const ServerSettingsUInt64 s3_credentials_provider_max_cache_size;
     extern const ServerSettingsUInt64 max_open_files;
@@ -1400,6 +1401,7 @@ try
 
     total_memory_tracker.setJemallocFlushProfileInterval(server_settings[ServerSetting::jemalloc_flush_profile_interval_bytes]);
     total_memory_tracker.setJemallocFlushProfileOnMemoryExceeded(server_settings[ServerSetting::jemalloc_flush_profile_on_memory_exceeded]);
+    total_memory_tracker.setJemallocFlushProfileOnMemoryExceededSeconds(server_settings[ServerSetting::jemalloc_flush_profile_on_memory_exceeded_interval]);
 
     Poco::ThreadPool server_pool(
         /* minCapacity */3,

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -370,23 +370,39 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceed
             current_hard_limit && (will_be > current_hard_limit || (level == VariableContext::Global && will_be_rss > current_hard_limit))))
     {
 #if USE_JEMALLOC
-        if (level == VariableContext::Global && jemalloc_flush_profile_on_memory_exceeded)
+        if (level == VariableContext::Global && (jemalloc_flush_profile_on_memory_exceeded_interval_s || jemalloc_flush_profile_on_memory_exceeded))
         {
             MemoryTrackerBlockerInThread untrack_lock(VariableContext::Global);
             if (DB::Jemalloc::getValue<bool>("prof.active"))
             {
-                static std::atomic<uint64_t> flush_count = 0;
                 auto * flush_prefix = DB::Jemalloc::getValue<char *>("opt.prof_prefix");
                 if (!flush_prefix)
                 {
                     if (throw_if_memory_exceeded)
                         LOG_WARNING(getLogger("MemoryTracker"), "Cannot flush memory profile, empty prefix");
                 }
-                else if (flush_count.fetch_add(1, std::memory_order_relaxed) < 100) // so we don't flush too many profiles
+                else if (jemalloc_flush_profile_on_memory_exceeded_interval_s)
                 {
-                    auto flushed_profile = DB::Jemalloc::flushProfile(flush_prefix);
-                    if (throw_if_memory_exceeded)
-                        LOG_INFO(getLogger("MemoryTracker"), "Flushed memory profile to {} after total memory exceeded", flushed_profile);
+                    static std::atomic<time_t> last_flush_time{0};
+                    time_t now = time(nullptr);
+                    time_t last = last_flush_time.load(std::memory_order_relaxed);
+                    if (now - last >= static_cast<time_t>(jemalloc_flush_profile_on_memory_exceeded_interval_s)
+                        && last_flush_time.compare_exchange_strong(last, now, std::memory_order_relaxed))
+                    {
+                        auto flushed_profile = DB::Jemalloc::flushProfile(flush_prefix);
+                        if (throw_if_memory_exceeded)
+                            LOG_INFO(getLogger("MemoryTracker"), "Flushed memory profile to {} after total memory exceeded", flushed_profile);
+                    }
+                }
+                else
+                {
+                    static std::atomic<uint64_t> flush_count = 0;
+                    if (flush_count.fetch_add(1, std::memory_order_relaxed) < 100)
+                    {
+                        auto flushed_profile = DB::Jemalloc::flushProfile(flush_prefix);
+                        if (throw_if_memory_exceeded)
+                            LOG_INFO(getLogger("MemoryTracker"), "Flushed memory profile to {} after total memory exceeded", flushed_profile);
+                    }
                 }
             }
         }

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -383,10 +383,10 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceed
                 }
                 else if (jemalloc_flush_profile_on_memory_exceeded_interval_s)
                 {
-                    static std::atomic<time_t> last_flush_time{0};
-                    time_t now = time(nullptr);
-                    time_t last = last_flush_time.load(std::memory_order_relaxed);
-                    if (now - last >= static_cast<time_t>(jemalloc_flush_profile_on_memory_exceeded_interval_s)
+                    static std::atomic<UInt64> last_flush_time{0};
+                    UInt64 now = static_cast<UInt64>(time(nullptr));
+                    UInt64 last = last_flush_time.load(std::memory_order_relaxed);
+                    if (now - last >= jemalloc_flush_profile_on_memory_exceeded_interval_s
                         && last_flush_time.compare_exchange_strong(last, now, std::memory_order_relaxed))
                     {
                         auto flushed_profile = DB::Jemalloc::flushProfile(flush_prefix);

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -81,6 +81,7 @@ private:
 
     UInt64 jemalloc_flush_profile_interval_bytes = 0;
     bool jemalloc_flush_profile_on_memory_exceeded = false;
+    UInt64 jemalloc_flush_profile_on_memory_exceeded_interval_s = 0;
 
     /// Singly-linked list. All information will be passed to subsequent memory trackers also (it allows to implement trackers hierarchy).
     /// In terms of tree nodes it is the list of parents. Lifetime of these trackers should "include" lifetime of current tracker.
@@ -200,6 +201,11 @@ public:
     void setJemallocFlushProfileOnMemoryExceeded(bool flush)
     {
         jemalloc_flush_profile_on_memory_exceeded = flush;
+    }
+
+    void setJemallocFlushProfileOnMemoryExceededSeconds(UInt64 interval_s)
+    {
+        jemalloc_flush_profile_on_memory_exceeded_interval_s = interval_s;
     }
 
     void setSampleMaxAllocationSize(UInt64 value)

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -1258,6 +1258,7 @@ The policy on how to perform a scheduling of CPU slots specified by `concurrent_
     DECLARE(Bool, abort_on_logical_error, false, R"(Crash the server on LOGICAL_ERROR exceptions. Only for experts.)", 0) \
     DECLARE(UInt64, jemalloc_flush_profile_interval_bytes, 0, R"(Flushing jemalloc profile will be done after global peak memory usage increased by jemalloc_flush_profile_interval_bytes)", 0) \
     DECLARE(Bool, jemalloc_flush_profile_on_memory_exceeded, 0, R"(Flushing jemalloc profile will be done on total memory exceeded errors)", 0) \
+    DECLARE(UInt64, jemalloc_flush_profile_on_memory_exceeded_interval, 0, R"(If non-zero, sets the minimum interval in seconds between flushing jemalloc profiles on total memory exceeded errors. For example, 5 means at most one profile flush every 5 seconds. Takes priority over `jemalloc_flush_profile_on_memory_exceeded`.)", 0) \
     DECLARE(Bool, jemalloc_enable_global_profiler, Jemalloc::default_enable_global_profiler, R"(Enable jemalloc's allocation profiler for all threads. Jemalloc will sample allocations and all deallocations for sampled allocations.
     Profiles can be flushed using SYSTEM JEMALLOC FLUSH PROFILE which can be used for allocation analysis.
     Samples can also be stored in system.trace_log using config jemalloc_collect_global_profile_samples_in_trace_log or with query setting jemalloc_collect_profile_samples_in_trace_log.


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add ability limit amount of jemalloc profile flushes on MEMORY_LIMIT_EXCEEDED per time interval

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.538`
<!-- ch-version-info:end -->