### PR TITLE
Fix mutation UPDATE SET DateTime literal not rewritten with session_t…

### DIFF
--- a/src/Interpreters/MutationsDateTimeLiteralVisitor.cpp
+++ b/src/Interpreters/MutationsDateTimeLiteralVisitor.cpp
@@ -1,6 +1,7 @@
 #include <Interpreters/MutationsDateTimeLiteralVisitor.h>
 #include <Interpreters/InDepthNodeVisitor.h>
 #include <Parsers/ASTAlterQuery.h>
+#include <Parsers/ASTAssignment.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
@@ -163,6 +164,23 @@ public:
     {
         if (auto * function = ast->as<ASTFunction>())
             visit(*function, data);
+        else if (auto * assignment = ast->as<ASTAssignment>())
+            visit(*assignment, data);
+    }
+
+    /// Wrap string literal in UPDATE SET when the target column is DateTime without explicit timezone
+    static void visit(ASTAssignment & assignment, Data & data)
+    {
+        auto dt = getDateTimeColumnType(assignment.column_name, data.columns);
+        if (!dt)
+            return;
+
+        auto & expr = assignment.children.at(0);
+        if (const auto * lit = expr->as<ASTLiteral>(); lit && lit->value.getType() == Field::Types::String)
+        {
+            expr = wrapWithTimezone(expr, dt, data.session_timezone);
+            data.modified = true;
+        }
     }
 
     static void visit(ASTFunction & function, Data & data)

--- a/tests/queries/0_stateless/04056_mutation_session_timezone_datetime_literals.reference
+++ b/tests/queries/0_stateless/04056_mutation_session_timezone_datetime_literals.reference
@@ -15,4 +15,8 @@ after delete lc	1	2000-01-01 01:02:03
 before delete nullable dt64	1	2000-01-01 01:02:03.123
 before delete nullable dt64	2	2000-01-01 04:05:06.456
 after delete nullable dt64	1	2000-01-01 01:02:03.123
+update set dt	1	946735200
+update set dt	2	946735200
+update set dt64	1	946735200
+update set dt64	2	946735200
 explicit tz	1	2000-01-01 01:02:03

--- a/tests/queries/0_stateless/04056_mutation_session_timezone_datetime_literals.sql
+++ b/tests/queries/0_stateless/04056_mutation_session_timezone_datetime_literals.sql
@@ -66,6 +66,26 @@ SELECT 'before delete nullable dt64', id, time FROM test_mutation_tz64_nullable 
 ALTER TABLE test_mutation_tz64_nullable DELETE WHERE time >= '2000-01-01 02:00:00';
 SELECT 'after delete nullable dt64', id, time FROM test_mutation_tz64_nullable ORDER BY id;
 
+-- ALTER UPDATE SET DateTime column to a string literal — the literal must be
+-- interpreted in session timezone, not server timezone
+DROP TABLE IF EXISTS test_mutation_tz_set SYNC;
+CREATE TABLE test_mutation_tz_set (id UInt32, time DateTime) ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO test_mutation_tz_set VALUES (1, '2000-01-01 00:00:00');
+ALTER TABLE test_mutation_tz_set UPDATE time = '2000-01-01 07:00:00' WHERE id = 1;
+-- Verify UPDATE SET used session timezone: insert the same literal and compare unix timestamps
+INSERT INTO test_mutation_tz_set VALUES (2, '2000-01-01 07:00:00');
+SELECT 'update set dt', id, toUnixTimestamp(time) FROM test_mutation_tz_set ORDER BY id;
+
+-- Same for DateTime64
+DROP TABLE IF EXISTS test_mutation_tz64_set SYNC;
+CREATE TABLE test_mutation_tz64_set (id UInt32, time DateTime64(3)) ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO test_mutation_tz64_set VALUES (1, '2000-01-01 00:00:00.000');
+ALTER TABLE test_mutation_tz64_set UPDATE time = '2000-01-01 07:00:00.123' WHERE id = 1;
+INSERT INTO test_mutation_tz64_set VALUES (2, '2000-01-01 07:00:00.123');
+SELECT 'update set dt64', id, toUnixTimestamp(time) FROM test_mutation_tz64_set ORDER BY id;
+
 -- DateTime with explicit timezone should NOT be rewritten (timezone is already determined)
 DROP TABLE IF EXISTS test_mutation_tz_explicit SYNC;
 CREATE TABLE test_mutation_tz_explicit (id UInt32, time DateTime('UTC')) ENGINE = MergeTree ORDER BY id;
@@ -80,4 +100,6 @@ DROP TABLE test_mutation_tz_upd SYNC;
 DROP TABLE test_mutation_tz_nullable SYNC;
 DROP TABLE test_mutation_tz_lc SYNC;
 DROP TABLE test_mutation_tz64_nullable SYNC;
+DROP TABLE test_mutation_tz_set SYNC;
+DROP TABLE test_mutation_tz64_set SYNC;
 DROP TABLE test_mutation_tz_explicit SYNC;


### PR DESCRIPTION
…imezone

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes a case where timezone was not included during the assignment in the ALTER statement. Closes https://github.com/ClickHouse/ClickHouse/issues/101328. Related https://github.com/ClickHouse/ClickHouse/pull/100647.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.16`
- Backported to: `26.3.13.30`, `26.2.19.24`
<!-- ch-version-info:end -->