### PR TITLE
ci: prefer the last failed query in case of identical query_id

### DIFF
--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -499,7 +499,7 @@ class FuzzerLogParser:
             return None
         print(f"Query id: {query_id}")
         query_command = Shell.get_output(
-            f"grep -a '{query_id}' {self.server_log} | head -n1"
+            f"grep -a '{query_id}.* executeQuery:' {self.server_log} | tail -n1"
         )
         if not query_command:
             print("Query not found in server log by query id")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.512`
<!-- ch-version-info:end -->