### PR TITLE
Fix incorrect WHERE pushdown into JOIN with USING type coercion

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/mergeFilterIntoJoinCondition.cpp
+++ b/src/Processors/QueryPlan/Optimizations/mergeFilterIntoJoinCondition.cpp
@@ -97,23 +97,19 @@ ExpressionSide getExpressionSide(
     auto inputs = getExpressionInputs(expr);
 
     bool has_left = false;
-    for (const auto * input : inputs)
-    {
-        if (left_allowed_inputs.contains(input))
-        {
-            has_left = true;
-            break;
-        }
-    }
-
     bool has_right = false;
     for (const auto * input : inputs)
     {
-        if (right_allowed_inputs.contains(input))
-        {
+        bool in_left = left_allowed_inputs.contains(input);
+        bool in_right = right_allowed_inputs.contains(input);
+        if (in_left)
+            has_left = true;
+        if (in_right)
             has_right = true;
-            break;
-        }
+        if (!in_left && !in_right)
+            /// Input not from either side (e.g. a column whose type was changed by USING coercion).
+            /// The expression cannot be safely pushed to either side.
+            return ExpressionSide::UNKNOWN;
     }
 
     if (has_left && !has_right)

--- a/tests/queries/0_stateless/04071_join_runtime_filter_using_type_coercion.sql
+++ b/tests/queries/0_stateless/04071_join_runtime_filter_using_type_coercion.sql
@@ -1,0 +1,7 @@
+-- Regression test: `mergeFilterIntoJoinCondition` must not push a WHERE
+-- equality into a JOIN condition when an input column's type was changed by
+-- USING coercion. Previously, `getExpressionSide` ignored inputs not in
+-- either allowed set, misclassifying the expression and causing a
+-- LOGICAL_ERROR: "Unexpected return type from round. Expected UInt16. Got Const(UInt8)".
+
+SELECT 1 FROM (SELECT 1 AS x, 1 AS y) AS a INNER JOIN (SELECT 1023 AS y) AS b USING (y) WHERE round(*) = b.y;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix incorrect WHERE pushdown into JOIN with USING type coercion (previously leads to `LOGICAL_ERROR`)

Consider the following query:

    SELECT 1 FROM (SELECT 1 AS x, 1 AS y) AS a
    INNER JOIN (SELECT 1023 AS y) AS b
    USING (y) WHERE round(*) = b.y

The left side has `y UInt8`, the right side has `y UInt16`. `USING (y)` coerces both to the common supertype `UInt16`. The WHERE clause is analyzed against this post-join schema, so `round(y, x)` is resolved with `y:UInt16` and returns `UInt16`.

`tryMergeFilterIntoJoinCondition` tries to push `round(y, x) = b.y` into the join condition. It classifies each operand's side by checking which input columns it references. The coerced `y:UInt16` does not match the left stream's `y:UInt8`, so it is correctly excluded from both allowed input sets. However, `getExpressionSide` silently skipped inputs not in either set, so `round(y, x)` was misclassified as LEFT-only (only `x` was counted).

After push-down, `mergeNodes` matched `y:UInt16` by name to the pre-join `y:UInt8`. The `round` node kept `result_type = UInt16` but now operated on `UInt8` inputs, causing a LOGICAL_ERROR during header evaluation.

Fix: if any input of an expression is not in either the left or right allowed set, classify the expression as UNKNOWN to prevent push-down.

Fixes: https://github.com/ClickHouse/ClickHouse/issues/101306