### PR TITLE
Fix flaky test 02377_extend_protocol_with_query_parameters

### DIFF
--- a/tests/queries/0_stateless/02377_extend_protocol_with_query_parameters.sh
+++ b/tests/queries/0_stateless/02377_extend_protocol_with_query_parameters.sh
@@ -33,7 +33,10 @@ $CLICKHOUSE_CLIENT -q "
     map_arr Map(UInt8, Array(UInt8)),
     map_map_arr Map(String, Map(String, Array(UInt8))))
   engine = MergeTree
-  order by (id)"
+  order by (id)
+  -- Pin map serialization to 'basic' so Map key order is deterministic regardless
+  -- of randomized map_serialization_version / map_serialization_version_for_zero_level_parts
+  SETTINGS map_serialization_version = 'basic', map_serialization_version_for_zero_level_parts = 'basic'"
 
 
 $CLICKHOUSE_CLIENT \


### PR DESCRIPTION
When CI randomizes `map_serialization_version` and/or `map_serialization_version_for_zero_level_parts` to `with_buckets`, Map keys get distributed into hash buckets which changes their iteration order on readback. The test inserts data into a MergeTree table with Map columns and expects a specific key order in the output — but bucketed serialization doesn't preserve insertion order.

This caused 10 failures across 7 unrelated PRs in the last 30 days (amd_tsan, amd_asan_ubsan, amd_msan, amd_debug, arm_binary, amd_llvm_coverage).

The fix pins `map_serialization_version = 'basic'` and `map_serialization_version_for_zero_level_parts = 'basic'` in the test's CREATE TABLE SETTINGS. This is a targeted pin — the test validates query parameter passing with complex types, not Map serialization behavior.

Verified: 50/50 passes with full randomization.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.524`
<!-- ch-version-info:end -->