### PR TITLE
Fix ArrowFlight integration test port conflict under pytest-xdist

### DIFF
--- a/tests/integration/compose/docker_compose_arrowflight.yml
+++ b/tests/integration/compose/docker_compose_arrowflight.yml
@@ -2,8 +2,8 @@ services:
   arrowflight1:
     image: clickhouse/arrowflight-server-test:${DOCKER_ARROWFLIGHT_SERVER_TAG:-latest}
     ports:
-      - "5005:5005"
-      - "5006:5006"
+      - "${ARROWFLIGHT_EXTERNAL_PORT:-5005}:5005"
+      - "${ARROWFLIGHT_AUTH_EXTERNAL_PORT:-5006}:5006"
     stop_signal: SIGINT
     stop_grace_period: 5s
     cpus: 3

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -636,6 +636,8 @@ class ClickHouseCluster:
         self.instances: dict[str, ClickHouseInstance] = {}
         self.with_arrowflight = False
         self.arrowflight_host = "arrowflight1"
+        self._arrowflight_port = 0
+        self._arrowflight_auth_port = 0
         self.with_zookeeper = False
         self.with_zookeeper_secure = False
         self.with_mysql_client = False
@@ -1054,6 +1056,20 @@ class ClickHouseCluster:
             return self._nats_port
         self._nats_port = self.port_pool.get_port()
         return self._nats_port
+
+    @property
+    def arrowflight_port(self):
+        if self._arrowflight_port:
+            return self._arrowflight_port
+        self._arrowflight_port = self.port_pool.get_port()
+        return self._arrowflight_port
+
+    @property
+    def arrowflight_auth_port(self):
+        if self._arrowflight_auth_port:
+            return self._arrowflight_auth_port
+        self._arrowflight_auth_port = self.port_pool.get_port()
+        return self._arrowflight_auth_port
 
     @property
     def ytsaurus_port(self):
@@ -1694,6 +1710,10 @@ class ClickHouseCluster:
 
     def setup_arrowflight_cmd(self, instance, env_variables, docker_compose_yml_dir):
         self.with_arrowflight = True
+        env_variables["ARROWFLIGHT_EXTERNAL_PORT"] = str(self.arrowflight_port)
+        env_variables["ARROWFLIGHT_AUTH_EXTERNAL_PORT"] = str(
+            self.arrowflight_auth_port
+        )
         self.base_cmd.extend(
             ["--file", p.join(docker_compose_yml_dir, "docker_compose_arrowflight.yml")]
         )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The ArrowFlight docker compose file (`docker_compose_arrowflight.yml`) uses hardcoded host port mappings (`5005:5005` and `5006:5006`). When pytest-xdist runs multiple workers — as happens in targeted and flaky CI checks with `--dist=each` — each worker tries to start its own ArrowFlight container binding the same host ports, causing:

```
Error response from daemon: driver failed programming external connectivity on endpoint
roottestarrowflightstorage-gw1-arrowflight1-1 (...):
Bind for 0.0.0.0:5005 failed: port is already allocated
```

This has been causing persistent `test_arrowflight_storage` failures in PR #91170's targeted integration test check:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=91170&sha=1e7eaf8dc3ae5fb55097ee49170c1e5e3a83191b&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20targeted%29
https://github.com/ClickHouse/ClickHouse/pull/91170

## Root cause analysis

Every other external service in the integration test framework (Mongo, Redis, Kafka, LDAP, etc.) uses dynamic port allocation from `PortPoolManager` to avoid host port conflicts between concurrent xdist workers. The ArrowFlight setup was missing this — `setup_arrowflight_cmd` did not allocate ports from the pool or set any port environment variables, and the compose file used literal port numbers.

In **regular** (non-targeted) integration test batches, `test_arrowflight_storage` works fine because `--dist=loadfile` assigns each test module to a single worker, so only one ArrowFlight container ever exists at a time. The bug only manifests under `--dist=each` with multiple workers, which is the mode used by targeted and flaky checks.

Once the test first failed in a targeted run (due to unlucky timing with port binding), it entered a self-perpetuating cycle: CIDB recorded the failure, which caused the targeted check to re-select `test_arrowflight_storage` on every subsequent commit, where it would fail again due to the port conflict, reinforcing the CIDB record.

## Fix

Use dynamic port allocation from the port pool, following the same pattern as every other external service:
- Added `arrowflight_port` and `arrowflight_auth_port` properties to `ClickHouseCluster` that allocate from `port_pool`
- `setup_arrowflight_cmd` now sets `ARROWFLIGHT_EXTERNAL_PORT` and `ARROWFLIGHT_AUTH_EXTERNAL_PORT` environment variables
- `docker_compose_arrowflight.yml` uses `${ARROWFLIGHT_EXTERNAL_PORT:-5005}:5005` and `${ARROWFLIGHT_AUTH_EXTERNAL_PORT:-5006}:5006`

The internal container ports (5005/5006) remain unchanged. Tests connect via Docker networking (`arrowflight1:5005`) and are unaffected — only the host-side port mapping becomes dynamic.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-008b877f-f06c-443a-bc52-8d701691610a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-008b877f-f06c-443a-bc52-8d701691610a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.504`
<!-- ch-version-info:end -->