### PR TITLE
Pin `merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability` in 03668_shard_join_in_reverse_order

### DIFF
--- a/tests/queries/0_stateless/03668_shard_join_in_reverse_order.reference
+++ b/tests/queries/0_stateless/03668_shard_join_in_reverse_order.reference
@@ -3,7 +3,7 @@
 DROP TABLE IF EXISTS t0;
 CREATE TABLE t0 (c0 Int) ENGINE = MergeTree() ORDER BY (c0 DESC) SETTINGS index_granularity = 1, allow_experimental_reverse_key = 1;
 INSERT INTO TABLE t0 (c0) SELECT number FROM numbers(10);
-SELECT c0 FROM t0 JOIN t0 tx USING (c0) ORDER BY c0 SETTINGS query_plan_join_shard_by_pk_ranges = 1, max_threads = 2, query_plan_read_in_order_through_join = 1;
+SELECT c0 FROM t0 JOIN t0 tx USING (c0) ORDER BY c0 SETTINGS query_plan_join_shard_by_pk_ranges = 1, max_threads = 2, query_plan_read_in_order_through_join = 1, merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0;
 0
 1
 2

--- a/tests/queries/0_stateless/03668_shard_join_in_reverse_order.sql
+++ b/tests/queries/0_stateless/03668_shard_join_in_reverse_order.sql
@@ -6,6 +6,6 @@ CREATE TABLE t0 (c0 Int) ENGINE = MergeTree() ORDER BY (c0 DESC) SETTINGS index_
 
 INSERT INTO TABLE t0 (c0) SELECT number FROM numbers(10);
 
-SELECT c0 FROM t0 JOIN t0 tx USING (c0) ORDER BY c0 SETTINGS query_plan_join_shard_by_pk_ranges = 1, max_threads = 2, query_plan_read_in_order_through_join = 1;
+SELECT c0 FROM t0 JOIN t0 tx USING (c0) ORDER BY c0 SETTINGS query_plan_join_shard_by_pk_ranges = 1, max_threads = 2, query_plan_read_in_order_through_join = 1, merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0;
 
 DROP TABLE t0;


### PR DESCRIPTION
The CI randomizes `merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability` to a random value in [0, 1) (drawn uniformly, rounded to 2 decimal places) via `clickhouse-test`. When non-zero, it fires a Bernoulli trial per read and artificially promotes some mark ranges from "non-intersecting" to "intersecting", routing them through the merge-read pipeline.

This breaks `query_plan_read_in_order_through_join = 1` in combination with `query_plan_join_shard_by_pk_ranges = 1`: the shard-join optimization relies on each shard reading a non-overlapping PK range in order, so that the final `ORDER BY` can be replaced with a cheap merge-sort. The injection creates overlapping ranges, violating that invariant and producing unsorted output (e.g. `4, 3, 2, 1, 0, 9, 8, 7, 6, 5` instead of `0..9`).

Pin the setting to `0` in the query so the injection does not interfere with the test.

Closes https://github.com/ClickHouse/ClickHouse/issues/100870

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Pin `merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability` in 03668_shard_join_in_reverse_order

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
