### PR TITLE
Fix possible deadlock on shutdown in BlobKillerThread

### DIFF
--- a/src/Disks/DiskObjectStorage/Replication/BlobKillerThread.cpp
+++ b/src/Disks/DiskObjectStorage/Replication/BlobKillerThread.cpp
@@ -267,6 +267,13 @@ void BlobKillerThread::shutdown()
     auto component_guard = Coordination::setCurrentComponent("BlobKillerThread::shutdown");
     LOG_INFO(log, "Shutting down Blob Killer thread");
 
+    /// Signal shutdown to unblock any threads waiting in waitRound().
+    /// This must happen before task->deactivate() because deactivate() cancels
+    /// any pending scheduled task, which means run() will never execute and
+    /// finished_rounds will never be incremented — leaving waiters stuck forever.
+    is_shutdown = true;
+    finished_rounds.notify_all();
+
     task->deactivate();
 
     /// We need to execute it here explicitly because some blobs may be in the metadata storage queue.
@@ -291,6 +298,8 @@ void BlobKillerThread::waitRound(int64_t expected_round)
     int64_t current_round = finished_rounds.load();
     while (current_round < expected_round)
     {
+        if (is_shutdown)
+            return;
         finished_rounds.wait(current_round);
         current_round = finished_rounds.load();
     }
@@ -298,6 +307,9 @@ void BlobKillerThread::waitRound(int64_t expected_round)
 
 void BlobKillerThread::triggerAndWait()
 {
+    if (is_shutdown)
+        return;
+
     int64_t expected_round = trigger();
 
     if (wrapped_blob_killer)

--- a/src/Disks/DiskObjectStorage/Replication/BlobKillerThread.h
+++ b/src/Disks/DiskObjectStorage/Replication/BlobKillerThread.h
@@ -40,6 +40,7 @@ private:
 
     std::atomic<bool> started{false};
     std::atomic<bool> enabled{true};
+    std::atomic<bool> is_shutdown{false};
     std::atomic<int64_t> finished_rounds{0};
     std::atomic<int64_t> reschedule_interval_sec{0};
     std::atomic<int64_t> metadata_request_batch{0};


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix possible deadlock on server shutdown when BlobKillerThread cleanup is in progress.

### What this PR does

`BlobKillerThread::waitRound()` uses `std::atomic::wait()` with **no timeout and no shutdown check**. When `shutdown()` calls `task->deactivate()`, the background task (`run()`) never executes again — so `finished_rounds` is never incremented, and any thread blocked in `waitRound()` hangs **forever**.

This causes the "Possible deadlock on shutdown (see gdb.log)" failure seen massively in stress tests across all sanitizer and debug builds.

### Root cause analysis

**The deadlock scenario:**
1. `MergeTreeCleanupThread::iterate()` calls `clearOldPartsFromFilesystem()`
2. This calls `DiskObjectStorageTransaction::commit()` → `waitBlobRemoval()` → `BlobKillerThread::triggerAndWait()`
3. `triggerAndWait()` calls `trigger()` (schedules the background task) then `waitRound(N+1)` — blocks on `finished_rounds.wait(N)`
4. Server receives SIGTERM → `DiskObjectStorage::shutdown()` → `BlobKillerThread::shutdown()` → `task->deactivate()`
5. `deactivate()` cancels the pending scheduled task, so `run()` never executes
6. `finished_rounds` stays at N forever, `waitRound()` blocks forever
7. Server cannot shut down

**Evidence from CI gdb.logs:**
- **amd_msan** (master, April 1): Thread 443 "BgSchPool" blocked in `BlobKillerThread::triggerAndWait()` → `waitRound()`, called from `MergeTreeCleanupThread::iterate()` → `clearOldPartsFromFilesystem()`. 416 other threads idle waiting for the pool to shut down.
- **arm_tsan** (master, March 31): 32 threads blocked on `Poco::FileChannel::log()` mutex — cascade from a BgSchPool thread that acquired the FileChannel lock while logging from `BlobKillerThread::run()`, then got stuck in TSAN's internal `SlotLock`.

### The fix

1. Add `std::atomic<bool> is_shutdown{false}` flag
2. In `shutdown()`, set `is_shutdown = true` **before** `task->deactivate()`, and call `finished_rounds.notify_all()` to wake up any existing waiters
3. In `waitRound()`, check `is_shutdown` in the loop — return immediately if shutting down
4. In `triggerAndWait()`, check `is_shutdown` to avoid scheduling new work during shutdown

### CIDB data

```sql
-- 45+ hits in 30 days, 30+ distinct PRs, 7 master failures
SELECT pull_request_number, count() as cnt
FROM default.checks
WHERE test_name = 'Possible deadlock on shutdown (see gdb.log)'
  AND test_status IN ('FAIL', 'ERROR')
  AND check_start_time > now() - INTERVAL 30 DAY
GROUP BY pull_request_number ORDER BY cnt DESC
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)