### PR TITLE
Fix flaky tests 01585_use_index_for_global_in and _with_null

### DIFF
--- a/tests/queries/0_stateless/01585_use_index_for_global_in.sql
+++ b/tests/queries/0_stateless/01585_use_index_for_global_in.sql
@@ -2,6 +2,7 @@
 
 SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0.0;
 SET use_statistics = 0; -- auto_statistics_types causes extra rows to be read
+SET enable_parallel_replicas = 0; -- parallel replicas execute IN subquery on each replica, inflating max_rows_to_read count
 
 drop table if exists xp;
 drop table if exists xp_d;

--- a/tests/queries/0_stateless/01585_use_index_for_global_in_with_null.sql
+++ b/tests/queries/0_stateless/01585_use_index_for_global_in_with_null.sql
@@ -1,6 +1,7 @@
 -- Tags: global
 
 SET use_statistics = 0; -- auto_statistics_types causes extra rows to be read
+SET enable_parallel_replicas = 0; -- parallel replicas execute IN subquery on each replica, inflating max_rows_to_read count
 
 drop table if exists xp;
 drop table if exists xp_d;


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- n/a

### What this PR does

Pins `enable_parallel_replicas = 0` at session level in both
`01585_use_index_for_global_in` and `01585_use_index_for_global_in_with_null`
test files.

### Root cause

When CI randomizes `enable_parallel_replicas = 1` with
`parallel_replicas_for_non_replicated_merge_tree = 1` and
`parallel_replicas_local_plan = 1`, the system creates both a local plan
and a remote plan for the query. Each plan independently executes the IN
subquery (`numbers(2)`), causing the row count seen by `max_rows_to_read`
to double:

- Expected: 2 (numbers) + 2 (table scan) = **4 rows**
- Actual: 2 (local subquery) + 2 (remote subquery) + 2 (table scan) = **6 rows**

This triggers `TOO_MANY_ROWS` (error code 158).

The test already protected GLOBAL IN queries with per-query
`SETTINGS enable_parallel_replicas=0` (added in PR #97517), but regular
IN queries were left unprotected.

### CIDB evidence

21 failures across 6 distinct unrelated PRs in 30 days
(`01585_use_index_for_global_in`), plus 20+ failures across 7+ PRs for the
`_with_null` variant. All recent failures show
`enable_parallel_replicas = 1` in the randomized settings and the error
`max rows: 4.00, current rows: 6.00`.

### Verification

Deterministic reproduction:
```sql
-- FAILS (exit code 158):
SELECT * FROM xp WHERE i IN (SELECT * FROM numbers(2))
SETTINGS max_rows_to_read=4, enable_parallel_replicas=1,
  parallel_replicas_for_non_replicated_merge_tree=1,
  cluster_for_parallel_replicas='parallel_replicas',
  parallel_replicas_local_plan=1,
  parallel_replicas_min_number_of_rows_per_replica=1;
-- max rows: 4.00, current rows: 6.00

-- PASSES with fix:
SET enable_parallel_replicas = 0;
SELECT * FROM xp WHERE i IN (SELECT * FROM numbers(2))
SETTINGS max_rows_to_read=4, ...;
-- Returns correct results
```

Both tests pass 50/50 and 100/100 with full randomization after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)