### PR TITLE
Fix flaky test 01583_const_column_in_set_index

### DIFF
--- a/tests/queries/0_stateless/01583_const_column_in_set_index.sql
+++ b/tests/queries/0_stateless/01583_const_column_in_set_index.sql
@@ -1,4 +1,7 @@
 SET query_plan_optimize_prewhere = 1;
+-- Parallel replicas with local plan execute the IN subquery in both local and remote
+-- contexts, doubling the rows read from numbers(10) and exceeding max_rows_to_read.
+SET enable_parallel_replicas = 0;
 
 drop table if exists insub;
 


### PR DESCRIPTION
When CI randomizes `enable_parallel_replicas=1` with `parallel_replicas_local_plan=1`,
the query planner creates both local and remote execution plans that independently
execute the `IN (SELECT toInt32(3) FROM numbers(10))` subquery, doubling the rows
read (20 instead of 10) and exceeding the tight `max_rows_to_read=12` limit.

Pin `enable_parallel_replicas=0` since this test verifies primary key condition
behavior with IN subquery, not parallel replicas.

21 failures across 8 distinct PRs + 4 master hits in the last 30 days.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)