### PR TITLE
doc: clarify not enforcing data types settings in INSERT statement

### DIFF
--- a/docs/en/sql-reference/statements/insert-into.md
+++ b/docs/en/sql-reference/statements/insert-into.md
@@ -106,6 +106,45 @@ INSERT INTO table SETTINGS ... FORMAT format_name data_set
 
 If a table has [constraints](../../sql-reference/statements/create/table.md#constraints), their expressions will be checked for each row of inserted data. If any of those constraints is not satisfied — the server will raise an exception containing the constraint name and expression, and the query will be stopped.
 
+## Data Type Validation {#data-type-validation}
+
+ClickHouse validates experimental and suspicious data types (controlled by settings like `allow_experimental_time_time64_type`, `allow_experimental_nullable_tuple_type`, `allow_suspicious_low_cardinality_types`, `allow_suspicious_fixed_string_types`, etc.) only during table creation (`CREATE TABLE`) and schema modification (`ALTER TABLE`), not during `INSERT`.
+
+This means that if a table with an experimental data type already exists, data can be inserted into it even when the corresponding setting is disabled on the server. This is by design — once a table is created, inserts should not be blocked by settings that control type creation.
+
+For example:
+
+```sql
+SET allow_experimental_time_time64_type = 1;
+
+CREATE TABLE events
+(
+    `id` UInt64,
+    `event_time` Time
+)
+ENGINE = MergeTree()
+ORDER BY id;
+
+SET allow_experimental_time_time64_type = 0;
+
+-- This works even though the setting is now disabled.
+-- The table already exists, so inserts are not blocked.
+INSERT INTO events VALUES (1, '14:30:25');
+
+-- But creating a new table with the Time type will fail.
+CREATE TABLE events_new
+(
+    `id` UInt64,
+    `event_time` Time
+)
+ENGINE = MergeTree()
+ORDER BY id; -- ERR: TYPE_TIME_TIME64_IS_NOT_ENABLED
+```
+
+:::note
+As a consequence, a client with a newer version (where a setting is enabled by default) can insert data with experimental types into a server with an older version (where the setting is disabled), as long as the target table already has the corresponding column types. The validation is enforced at the DDL level, not at the DML level.
+:::
+
 ## Inserting the Results of SELECT {#inserting-the-results-of-select}
 
 **Syntax**

--- a/docs/en/sql-reference/statements/insert-into.md
+++ b/docs/en/sql-reference/statements/insert-into.md
@@ -110,12 +110,12 @@ If a table has [constraints](../../sql-reference/statements/create/table.md#cons
 
 ClickHouse validates allowed data types (controlled by settings like `enable_time_time64_type`, `allow_suspicious_low_cardinality_types`, `allow_suspicious_fixed_string_types`, etc.) only during table creation (`CREATE TABLE`) and schema modification (`ALTER TABLE`), not during `INSERT`.
 
-This means that if a table with not allowed data type already exists, data can be inserted into it even when the corresponding setting is disabled on the server. This is by design — once a table is created, inserts should not be blocked by settings that control type creation.
+This means that if a table with a disallowed data type already exists, data can be inserted into it even when the corresponding setting is disabled on the server. This is by design — once a table is created, inserts should not be blocked by settings that control type creation.
 
 For example:
 
 ```sql
-SET allow_experimental_time_time64_type = 1;
+SET enable_time_time64_type = 1;
 
 CREATE TABLE events
 (
@@ -125,7 +125,7 @@ CREATE TABLE events
 ENGINE = MergeTree()
 ORDER BY id;
 
-SET allow_experimental_time_time64_type = 0;
+SET enable_time_time64_type = 0;
 
 -- This works even though the setting is now disabled.
 -- The table already exists, so inserts are not blocked.
@@ -142,7 +142,7 @@ ORDER BY id; -- ERR: TYPE_TIME_TIME64_IS_NOT_ENABLED
 ```
 
 :::note
-As a consequence, a client with a newer version (where a setting is enabled by default) can insert data with experimental types into a server with an older version (where the setting is disabled), as long as the target table already has the corresponding column types. The validation is enforced at the DDL level, not at the DML level.
+As a consequence, a client with a newer version (where a setting is enabled by default) can insert data with disallowed data types into a server with an older version (where the setting is disabled), as long as the target table already has the corresponding column types. The validation is enforced at the DDL level, not at the DML level.
 :::
 
 ## Inserting the Results of SELECT {#inserting-the-results-of-select}

--- a/docs/en/sql-reference/statements/insert-into.md
+++ b/docs/en/sql-reference/statements/insert-into.md
@@ -108,9 +108,9 @@ If a table has [constraints](../../sql-reference/statements/create/table.md#cons
 
 ## Data Type Validation {#data-type-validation}
 
-ClickHouse validates experimental and suspicious data types (controlled by settings like `allow_experimental_time_time64_type`, `allow_experimental_nullable_tuple_type`, `allow_suspicious_low_cardinality_types`, `allow_suspicious_fixed_string_types`, etc.) only during table creation (`CREATE TABLE`) and schema modification (`ALTER TABLE`), not during `INSERT`.
+ClickHouse validates allowed data types (controlled by settings like `enable_time_time64_type`, `allow_suspicious_low_cardinality_types`, `allow_suspicious_fixed_string_types`, etc.) only during table creation (`CREATE TABLE`) and schema modification (`ALTER TABLE`), not during `INSERT`.
 
-This means that if a table with an experimental data type already exists, data can be inserted into it even when the corresponding setting is disabled on the server. This is by design — once a table is created, inserts should not be blocked by settings that control type creation.
+This means that if a table with not allowed data type already exists, data can be inserted into it even when the corresponding setting is disabled on the server. This is by design — once a table is created, inserts should not be blocked by settings that control type creation.
 
 For example:
 


### PR DESCRIPTION


### Changelog category (leave one):
- Documentation (changelog entry is not required)

Documentation: clarify not enforcing data types settings in `INSERT` statement

### Summary of change
<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
This is a outcome of validation bug found on this PR https://github.com/ClickHouse/ClickHouse/pull/99353

We end up not adding that validation because that complicates the UX. So just decided to document it.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.516`
<!-- ch-version-info:end -->