### PR TITLE
April 1: Improve query waiting experience with built-in Tetris

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -5,6 +5,7 @@
 #include <Client/InternalTextLogs.h>
 #include <Client/LineReader.h>
 #include <Client/TerminalKeystrokeInterceptor.h>
+#include <Client/ClientTetris.h>
 #include <Client/TestHint.h>
 #include <Client/TestTags.h>
 #include <Core/SortDescription.h>
@@ -550,12 +551,12 @@ void ClientBase::onData(Block & block, ASTPtr parsed_query)
         return;
 
     /// If results are written INTO OUTFILE, we can avoid clearing progress to avoid flicker.
-    if (need_render_progress && tty_buf && (!select_into_file || select_into_file_and_stdout))
+    if (need_render_progress && tty_buf && !clientTetrisObscuresProgress() && (!select_into_file || select_into_file_and_stdout))
     {
         std::unique_lock lock(tty_mutex);
         progress_indication.clearProgressOutput(*tty_buf, lock);
     }
-    if (need_render_progress_table && tty_buf && (!select_into_file || select_into_file_and_stdout))
+    if (need_render_progress_table && tty_buf && !clientTetrisObscuresProgress() && (!select_into_file || select_into_file_and_stdout))
     {
         std::unique_lock lock(tty_mutex);
         progress_table.clearTableOutput(*tty_buf, lock);
@@ -587,14 +588,14 @@ void ClientBase::onData(Block & block, ASTPtr parsed_query)
     output_format->flush();
 
     /// Restore progress bar and progress table after data block.
-    if (need_render_progress && tty_buf)
+    if (need_render_progress && tty_buf && !clientTetrisObscuresProgress())
     {
         if (select_into_file && !select_into_file_and_stdout)
             error_stream << "\r";
         std::unique_lock lock(tty_mutex);
         progress_indication.writeProgress(*tty_buf, lock);
     }
-    if (need_render_progress_table && tty_buf && !cancelled)
+    if (need_render_progress_table && tty_buf && !clientTetrisObscuresProgress() && !cancelled)
     {
         if (!need_render_progress && select_into_file && !select_into_file_and_stdout)
             error_stream << "\r";
@@ -607,12 +608,12 @@ void ClientBase::onData(Block & block, ASTPtr parsed_query)
 void ClientBase::onLogData(Block & block)
 {
     initLogsOutputStream();
-    if (need_render_progress && tty_buf)
+    if (need_render_progress && tty_buf && !clientTetrisObscuresProgress())
     {
         std::unique_lock lock(tty_mutex);
         progress_indication.clearProgressOutput(*tty_buf, lock);
     }
-    if (need_render_progress_table && tty_buf)
+    if (need_render_progress_table && tty_buf && !clientTetrisObscuresProgress())
     {
         std::unique_lock lock(tty_mutex);
         progress_table.clearTableOutput(*tty_buf, lock);
@@ -991,21 +992,35 @@ void ClientBase::initTTYBuffer(ProgressOption progress_option, ProgressOption pr
     if (tty_buf)
         return;
 
+    const bool allow_client_tetris = is_interactive && getClientConfiguration().getBool("enable-client-tetris", true);
+
     if (progress_option == ProgressOption::OFF || (!is_interactive && progress_option == ProgressOption::DEFAULT))
         need_render_progress = false;
 
     if (progress_table_option == ProgressOption::OFF || (!is_interactive && progress_table_option == ProgressOption::DEFAULT))
         need_render_progress_table = false;
 
-    if (!need_render_progress && !need_render_progress_table)
+    if (!need_render_progress && !need_render_progress_table && !allow_client_tetris)
         return;
 
-    progress_table_toggle_enabled = getClientConfiguration().getBool("enable-progress-table-toggle");
-    progress_table_toggle_on = !progress_table_toggle_enabled;
+    if (need_render_progress_table)
+    {
+        progress_table_toggle_enabled = getClientConfiguration().getBool("enable-progress-table-toggle");
+        progress_table_toggle_on = !progress_table_toggle_enabled;
+    }
+    else
+    {
+        progress_table_toggle_enabled = false;
+        progress_table_toggle_on = false;
+    }
+
+    enable_client_tetris = allow_client_tetris;
 
     /// If need_render_progress and need_render_progress_table are enabled,
     /// use ProgressOption that was set for the progress bar for progress table as well.
     ProgressOption progress = progress_option ? progress_option : progress_table_option;
+    if (!need_render_progress && !need_render_progress_table)
+        progress = ProgressOption::TTY;
 
     /// Output all progress bar commands to terminal at once to avoid flicker.
     /// This size is usually greater than the window size.
@@ -1079,14 +1094,41 @@ void ClientBase::initTTYBuffer(ProgressOption progress_option, ProgressOption pr
 
 void ClientBase::initKeystrokeInterceptor()
 {
-    if (is_interactive && need_render_progress_table && progress_table_toggle_enabled)
-    {
-        keystroke_interceptor = std::make_unique<TerminalKeystrokeInterceptor>(stdin_fd, error_stream);
-        keystroke_interceptor->registerCallback(' ', [this]() { progress_table_toggle_on = !progress_table_toggle_on; });
+    const bool progress_keys = need_render_progress_table && progress_table_toggle_enabled;
+    if (!is_interactive || !tty_buf || (!progress_keys && !enable_client_tetris))
+        return;
 
-        if (isEmbeeddedClient())
-            keystroke_interceptor->registerCallback(0x03, [this]() { tryStopQuery(); });
+    keystroke_interceptor = std::make_unique<TerminalKeystrokeInterceptor>(stdin_fd, error_stream);
+
+    if (enable_client_tetris && !client_tetris)
+        client_tetris = std::make_unique<ClientTetris>(*this);
+
+    if (progress_keys || enable_client_tetris)
+    {
+        keystroke_interceptor->registerCallback(' ', [this, progress_keys]()
+        {
+            if (client_tetris && client_tetris->isActive())
+                client_tetris->handleKey(' ');
+            else if (progress_keys)
+                progress_table_toggle_on = !progress_table_toggle_on;
+        });
     }
+
+    if (enable_client_tetris)
+    {
+        keystroke_interceptor->registerCallback('t', [this]() { client_tetris->toggle(); });
+        keystroke_interceptor->registerCallback('T', [this]() { client_tetris->toggle(); });
+        for (char key : {'h', 'j', 'k', 'l', 'r', 'R'})
+            keystroke_interceptor->registerCallback(key, [this, key]() { client_tetris->handleKey(key); });
+    }
+
+    if (isEmbeeddedClient())
+        keystroke_interceptor->registerCallback(0x03, [this]() { tryStopQuery(); });
+}
+
+bool ClientBase::clientTetrisObscuresProgress() const
+{
+    return client_tetris && client_tetris->isActive();
 }
 
 
@@ -1543,7 +1585,7 @@ void ClientBase::onProgress(const Progress & value)
     if (output_format)
         output_format->onProgress(value);
 
-    if (need_render_progress && tty_buf)
+    if (need_render_progress && tty_buf && !clientTetrisObscuresProgress())
     {
         std::unique_lock lock(tty_mutex);
         progress_indication.writeProgress(*tty_buf, lock);
@@ -1558,12 +1600,12 @@ void ClientBase::onTimezoneUpdate(const String & tz)
 
 void ClientBase::onEndOfStream()
 {
-    if (need_render_progress && tty_buf)
+    if (need_render_progress && tty_buf && !clientTetrisObscuresProgress())
     {
         std::unique_lock lock(tty_mutex);
         progress_indication.clearProgressOutput(*tty_buf, lock);
     }
-    if (need_render_progress_table && tty_buf)
+    if (need_render_progress_table && tty_buf && !clientTetrisObscuresProgress())
     {
         std::unique_lock lock(tty_mutex);
         progress_table.clearTableOutput(*tty_buf, lock);
@@ -1648,12 +1690,12 @@ void ClientBase::onProfileEvents(Block & block)
         progress_indication.updateThreadEventData(thread_times);
         progress_table.updateTable(block);
 
-        if (need_render_progress && tty_buf)
+        if (need_render_progress && tty_buf && !clientTetrisObscuresProgress())
         {
             std::unique_lock lock(tty_mutex);
             progress_indication.writeProgress(*tty_buf, lock);
         }
-        if (need_render_progress_table && tty_buf && !cancelled)
+        if (need_render_progress_table && tty_buf && !clientTetrisObscuresProgress() && !cancelled)
         {
             bool toggle_enabled = getClientConfiguration().getBool("enable-progress-table-toggle", true);
             std::unique_lock lock(tty_mutex);
@@ -1667,12 +1709,12 @@ void ClientBase::onProfileEvents(Block & block)
                 /// We need to restart the watch each time we flushed these events
                 profile_events.watch.restart();
                 initLogsOutputStream();
-                if (need_render_progress && tty_buf)
+                if (need_render_progress && tty_buf && !clientTetrisObscuresProgress())
                 {
                     std::unique_lock lock(tty_mutex);
                     progress_indication.clearProgressOutput(*tty_buf, lock);
                 }
-                if (need_render_progress_table && tty_buf)
+                if (need_render_progress_table && tty_buf && !clientTetrisObscuresProgress())
                 {
                     std::unique_lock lock(tty_mutex);
                     progress_table.clearTableOutput(*tty_buf, lock);
@@ -1694,7 +1736,7 @@ void ClientBase::onProfileEvents(Block & block)
 /// Flush all buffers.
 void ClientBase::resetOutput()
 {
-    if (need_render_progress_table && tty_buf)
+    if (need_render_progress_table && tty_buf && !clientTetrisObscuresProgress())
     {
         std::unique_lock lock(tty_mutex);
         progress_table.clearTableOutput(*tty_buf, lock);
@@ -2274,12 +2316,12 @@ void ClientBase::cancelQuery()
 
     stopKeystrokeInterceptorIfExists();
 
-    if (need_render_progress && tty_buf)
+    if (need_render_progress && tty_buf && !clientTetrisObscuresProgress())
     {
         std::unique_lock lock(tty_mutex);
         progress_indication.clearProgressOutput(*tty_buf, lock);
     }
-    if (need_render_progress_table && tty_buf)
+    if (need_render_progress_table && tty_buf && !clientTetrisObscuresProgress())
     {
         std::unique_lock lock(tty_mutex);
         progress_table.clearTableOutput(*tty_buf, lock);
@@ -2447,12 +2489,12 @@ void ClientBase::processParsedSingleQuery(
     if (!profile_events.last_block.empty())
     {
         initLogsOutputStream();
-        if (need_render_progress && tty_buf)
+        if (need_render_progress && tty_buf && !clientTetrisObscuresProgress())
         {
             std::unique_lock lock(tty_mutex);
             progress_indication.clearProgressOutput(*tty_buf, lock);
         }
-        if (need_render_progress_table && tty_buf)
+        if (need_render_progress_table && tty_buf && !clientTetrisObscuresProgress())
         {
             std::unique_lock lock(tty_mutex);
             progress_table.clearTableOutput(*tty_buf, lock);
@@ -2474,7 +2516,7 @@ void ClientBase::processParsedSingleQuery(
         progress_indication.writeFinalProgress();
         bool toggle_enabled = getClientConfiguration().getBool("enable-progress-table-toggle", true);
         bool show_progress_table = !toggle_enabled || progress_table_toggle_on;
-        if (need_render_progress_table && show_progress_table)
+        if (need_render_progress_table && show_progress_table && !clientTetrisObscuresProgress())
         {
             std::unique_lock lock(tty_mutex);
             progress_table.writeFinalTable(*tty_buf, lock);
@@ -3136,6 +3178,9 @@ void ClientBase::startKeystrokeInterceptorIfExists()
 
 void ClientBase::stopKeystrokeInterceptorIfExists()
 {
+    if (client_tetris)
+        client_tetris->onInterceptorStop();
+
     if (keystroke_interceptor)
     {
         try
@@ -3261,7 +3306,7 @@ bool ClientBase::checkAIProviderAcknowledgment()
     if (ai_inferred_from_env && !ai_provider_acknowledged && is_interactive)
     {
         // Clear any progress display
-        if (need_render_progress && tty_buf)
+        if (need_render_progress && tty_buf && !clientTetrisObscuresProgress())
         {
             std::unique_lock lock(tty_mutex);
             progress_indication.clearProgressOutput(*tty_buf, lock);
@@ -3320,6 +3365,7 @@ void ClientBase::addCommonOptions(OptionsDescription & options_description)
         ("progress", po::value<ProgressOption>()->implicit_value(ProgressOption::TTY, "tty")->default_value(ProgressOption::DEFAULT, "default"), "Print progress of queries execution - to TTY: tty|on|1|true|yes; to STDERR non-interactive mode: err; OFF: off|0|false|no; DEFAULT - interactive to TTY, non-interactive is off")
         ("progress-table", po::value<ProgressOption>()->implicit_value(ProgressOption::TTY, "tty")->default_value(ProgressOption::DEFAULT, "default"), "Print a progress table with changing metrics during query execution - to TTY: tty|on|1|true|yes; to STDERR non-interactive mode: err; OFF: off|0|false|no; DEFAULT - interactive to TTY, non-interactive is off")
         ("enable-progress-table-toggle", po::value<bool>()->default_value(true), "Enable toggling of the progress table by pressing the control key (Space). Only applicable in interactive mode with the progress table enabled.")
+        ("enable-client-tetris", po::value<bool>()->default_value(true), "Enable the terminal Tetris mini-game during long queries (press `t` to toggle). Interactive mode with a TTY only.")
 
         ("disable_suggestion,A", "Disable loading suggestions. Note that suggestions are loaded asynchronously through a second connection to ClickHouse server. Recommended when pasting queries with TAB characters.") /// Shorthand -A like in MySQL client
         ("wait_for_suggestions_to_load", "Load suggestion data synchonously")
@@ -3458,6 +3504,8 @@ void ClientBase::addOptionsToTheClientConfiguration(const CommandLineOptions & o
     }
     if (options.contains("enable-progress-table-toggle"))
         getClientConfiguration().setBool("enable-progress-table-toggle", options["enable-progress-table-toggle"].as<bool>());
+    if (options.contains("enable-client-tetris"))
+        getClientConfiguration().setBool("enable-client-tetris", options["enable-client-tetris"].as<bool>());
     if (options.contains("echo"))
         getClientConfiguration().setBool("echo", true);
     if (options.contains("disable_suggestion"))

--- a/src/Client/ClientBase.h
+++ b/src/Client/ClientBase.h
@@ -76,6 +76,7 @@ std::istream& operator>> (std::istream & in, ProgressOption & progress);
 
 class InternalTextLogs;
 class TerminalKeystrokeInterceptor;
+class ClientTetris;
 class WriteBufferFromFileDescriptor;
 struct Settings;
 struct MergeTreeSettings;
@@ -90,6 +91,8 @@ struct MergeTreeSettings;
  */
 class ClientBase
 {
+    friend class ClientTetris;
+
 public:
     using Arguments = std::vector<String>;
 
@@ -260,6 +263,8 @@ private:
     void startKeystrokeInterceptorIfExists();
     void stopKeystrokeInterceptorIfExists();
 
+    bool clientTetrisObscuresProgress() const;
+
     /// Execute a query and collect all results as a single string (rows separated by newlines)
     /// Returns empty string on exception
     std::string executeQueryForSingleString(const std::string & query);
@@ -323,6 +328,8 @@ protected:
     bool multiline = false;
 
     std::unique_ptr<TerminalKeystrokeInterceptor> keystroke_interceptor;
+    std::unique_ptr<ClientTetris> client_tetris;
+    bool enable_client_tetris = false;
 
     bool is_interactive = false; /// Use either interactive line editing interface or batch mode.
     bool delayed_interactive = false;

--- a/src/Client/ClientTetris.cpp
+++ b/src/Client/ClientTetris.cpp
@@ -1,0 +1,365 @@
+#include <Client/ClientTetris.h>
+#include <Client/ClientBase.h>
+#include <Common/TerminalSize.h>
+#include <base/types.h>
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <cstring>
+#include <thread>
+
+
+namespace DB
+{
+
+namespace
+{
+
+int8_t g_shapes[7][4][4][4];
+
+struct ShapesInit
+{
+    ShapesInit()
+    {
+        static const int8_t BASE[7][4][4] = {
+            {{0, 0, 0, 0}, {1, 1, 1, 1}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+            {{0, 1, 1, 0}, {0, 1, 1, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+            {{0, 1, 0, 0}, {1, 1, 1, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+            {{0, 1, 1, 0}, {1, 1, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+            {{1, 1, 0, 0}, {0, 1, 1, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+            {{1, 0, 0, 0}, {1, 1, 1, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+            {{0, 0, 1, 0}, {1, 1, 1, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}},
+        };
+
+        auto rotate = [](const int8_t in[4][4], int8_t out[4][4])
+        {
+            for (int y = 0; y < 4; ++y)
+                for (int x = 0; x < 4; ++x)
+                    out[x][3 - y] = in[y][x];
+        };
+
+        int8_t cur[4][4];
+        int8_t nxt[4][4];
+        for (int p = 0; p < 7; ++p)
+        {
+            memcpy(cur, BASE[p], sizeof(cur));
+            for (int r = 0; r < 4; ++r)
+            {
+                memcpy(g_shapes[p][r], cur, sizeof(cur));
+                rotate(cur, nxt);
+                memcpy(cur, nxt, sizeof(cur));
+            }
+        }
+    }
+};
+
+const ShapesInit shapes_init;
+
+}
+
+ClientTetris::ClientTetris(ClientBase & client_) : client(client_)
+{
+}
+
+ClientTetris::~ClientTetris()
+{
+    onInterceptorStop();
+}
+
+void ClientTetris::onInterceptorStop()
+{
+    active = false;
+    if (loop_thread.joinable())
+        loop_thread.join();
+    std::lock_guard lock(game_mutex);
+    clearOverlayLocked();
+}
+
+void ClientTetris::toggle()
+{
+    bool start = false;
+    bool stop = false;
+    {
+        std::lock_guard lock(game_mutex);
+        if (!active.load())
+        {
+            active = true;
+            resetGameLocked();
+            start = true;
+        }
+        else
+        {
+            active = false;
+            stop = true;
+        }
+    }
+    if (stop)
+    {
+        if (loop_thread.joinable())
+            loop_thread.join();
+        std::lock_guard lock(game_mutex);
+        clearOverlayLocked();
+        return;
+    }
+    if (start)
+    {
+        if (loop_thread.joinable())
+            loop_thread.join();
+        loop_thread = std::thread([this] { runLoop(); });
+        std::lock_guard lock(game_mutex);
+        renderLocked();
+    }
+}
+
+void ClientTetris::runLoop()
+{
+    while (active.load())
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(450));
+        if (!active.load())
+            break;
+        std::lock_guard lock(game_mutex);
+        if (!active.load())
+            break;
+        if (!game_over)
+            tickGravity();
+        renderLocked();
+    }
+}
+
+bool ClientTetris::collidesLocked(int px, int py, int rot, int type) const
+{
+    const int r = (type == 1) ? 0 : rot;
+    for (int y = 0; y < 4; ++y)
+    {
+        for (int x = 0; x < 4; ++x)
+        {
+            if (!g_shapes[type][r][y][x])
+                continue;
+            const int bx = px + x;
+            const int by = py + y;
+            if (bx < 0 || bx >= board_w || by >= board_h)
+                return true;
+            if (by >= 0 && board[by][bx])
+                return true;
+        }
+    }
+    return false;
+}
+
+void ClientTetris::resetGameLocked()
+{
+    memset(board, 0, sizeof(board));
+    game_over = false;
+    spawnPieceLocked();
+}
+
+void ClientTetris::spawnPieceLocked()
+{
+    rng = rng * 6364136223846793005ULL + 1;
+    piece_type = static_cast<int>((rng >> 32) % 7);
+    rotation = 0;
+    piece_x = 3;
+    piece_y = 0;
+    if (collidesLocked(piece_x, piece_y, rotation, piece_type))
+        game_over = true;
+}
+
+void ClientTetris::mergePieceLocked()
+{
+    const int r = (piece_type == 1) ? 0 : rotation;
+    for (int y = 0; y < 4; ++y)
+    {
+        for (int x = 0; x < 4; ++x)
+        {
+            if (!g_shapes[piece_type][r][y][x])
+                continue;
+            const int bx = piece_x + x;
+            const int by = piece_y + y;
+            if (by >= 0 && by < board_h && bx >= 0 && bx < board_w)
+                board[by][bx] = 1;
+        }
+    }
+}
+
+void ClientTetris::clearLinesLocked()
+{
+    for (int y = board_h - 1; y >= 0; --y)
+    {
+        bool full = true;
+        for (int x = 0; x < board_w; ++x)
+        {
+            if (!board[y][x])
+            {
+                full = false;
+                break;
+            }
+        }
+        if (full)
+        {
+            for (int y2 = y; y2 > 0; --y2)
+                memcpy(board[y2], board[y2 - 1], board_w);
+            memset(board[0], 0, board_w);
+            ++y;
+        }
+    }
+}
+
+void ClientTetris::tickGravity()
+{
+    if (collidesLocked(piece_x, piece_y + 1, rotation, piece_type))
+    {
+        mergePieceLocked();
+        clearLinesLocked();
+        spawnPieceLocked();
+    }
+    else
+        ++piece_y;
+}
+
+void ClientTetris::hardDropLocked()
+{
+    if (game_over)
+        return;
+    while (!collidesLocked(piece_x, piece_y + 1, rotation, piece_type))
+        ++piece_y;
+    mergePieceLocked();
+    clearLinesLocked();
+    spawnPieceLocked();
+}
+
+void ClientTetris::renderLocked()
+{
+    if (!client.tty_buf)
+        return;
+
+    String frame;
+    frame.reserve(4096);
+    fmt::format_to(std::back_inserter(frame), "\033[s\033[1;1H");
+
+    fmt::format_to(std::back_inserter(frame), "Tetris  t:exit  h/l:move  j:down  k:rotate  space:drop  r:restart\r\n");
+
+    if (game_over)
+        fmt::format_to(std::back_inserter(frame), "GAME OVER\r\n");
+
+    const int r = (piece_type == 1) ? 0 : rotation;
+    for (int row = 0; row < board_h; ++row)
+    {
+        fmt::format_to(std::back_inserter(frame), "|");
+        for (int col = 0; col < board_w; ++col)
+        {
+            char c = board[row][col] ? '#' : ' ';
+            if (!board[row][col])
+            {
+                for (int py = 0; py < 4; ++py)
+                {
+                    for (int px = 0; px < 4; ++px)
+                    {
+                        if (g_shapes[piece_type][r][py][px] && piece_x + px == col && piece_y + py == row)
+                        {
+                            c = '@';
+                            break;
+                        }
+                    }
+                    if (c == '@')
+                        break;
+                }
+            }
+            fmt::format_to(std::back_inserter(frame), "{}", c);
+        }
+        fmt::format_to(std::back_inserter(frame), "|\r\n");
+    }
+    fmt::format_to(std::back_inserter(frame), "+");
+    for (int i = 0; i < board_w; ++i)
+        fmt::format_to(std::back_inserter(frame), "-");
+    fmt::format_to(std::back_inserter(frame), "+\033[u");
+
+    client.tty_buf->write(frame.data(), frame.size());
+    client.tty_buf->next();
+}
+
+void ClientTetris::clearOverlayLocked()
+{
+    if (!client.tty_buf)
+        return;
+
+    uint16_t term_w = 80;
+    uint16_t term_h = 28;
+    try
+    {
+        const auto sz = getTerminalSize(client.stdin_fd, client.stderr_fd);
+        term_w = std::max<uint16_t>(sz.first, 40);
+        term_h = std::min<uint16_t>(std::max<uint16_t>(sz.second, 24), 200);
+    }
+    catch (...)
+    {
+    }
+
+    const size_t w = term_w;
+    const size_t h = term_h;
+    String blank(w, ' ');
+    String s;
+    s.reserve(h * (w + 32));
+    fmt::format_to(std::back_inserter(s), "\033[s");
+    for (size_t row = 0; row < h; ++row)
+        fmt::format_to(std::back_inserter(s), "\033[{};1H\033[K{}", row + 1, blank);
+    fmt::format_to(std::back_inserter(s), "\033[u");
+
+    client.tty_buf->write(s.data(), s.size());
+    client.tty_buf->next();
+}
+
+void ClientTetris::handleKey(char c)
+{
+    std::lock_guard lock(game_mutex);
+    if (!active.load())
+        return;
+
+    if (c == 'r' || c == 'R')
+    {
+        resetGameLocked();
+        renderLocked();
+        return;
+    }
+
+    if (game_over)
+        return;
+
+    switch (c)
+    {
+        case 'h':
+            if (!collidesLocked(piece_x - 1, piece_y, rotation, piece_type))
+                --piece_x;
+            break;
+        case 'l':
+            if (!collidesLocked(piece_x + 1, piece_y, rotation, piece_type))
+                ++piece_x;
+            break;
+        case 'j':
+            if (!collidesLocked(piece_x, piece_y + 1, rotation, piece_type))
+                ++piece_y;
+            else
+            {
+                mergePieceLocked();
+                clearLinesLocked();
+                spawnPieceLocked();
+            }
+            break;
+        case 'k':
+        {
+            const int nr = (rotation + 1) % 4;
+            if (!collidesLocked(piece_x, piece_y, nr, piece_type))
+                rotation = nr;
+            break;
+        }
+        case ' ':
+            hardDropLocked();
+            break;
+        default:
+            break;
+    }
+    renderLocked();
+}
+
+}

--- a/src/Client/ClientTetris.h
+++ b/src/Client/ClientTetris.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+
+namespace DB
+{
+
+class ClientBase;
+
+/// Minimal terminal Tetris overlay while a query runs (easter egg). Toggled with `t`.
+class ClientTetris
+{
+public:
+    explicit ClientTetris(ClientBase & client_);
+    ~ClientTetris();
+
+    void toggle();
+    void handleKey(char c);
+    /// Called when the keystroke interceptor stops (query finished or cancelled).
+    void onInterceptorStop();
+
+    bool isActive() const { return active.load(); }
+
+private:
+    void runLoop();
+    void tickGravity();
+    void renderLocked();
+    void clearOverlayLocked();
+    void resetGameLocked();
+    void spawnPieceLocked();
+    void mergePieceLocked();
+    void clearLinesLocked();
+    void hardDropLocked();
+    bool collidesLocked(int px, int py, int rot, int type) const;
+
+    ClientBase & client;
+
+    std::atomic<bool> active{false};
+    std::thread loop_thread;
+    std::mutex game_mutex;
+
+    static constexpr int board_w = 10;
+    static constexpr int board_h = 20;
+
+    int8_t board[board_h][board_w]{};
+    int piece_type = 0;
+    int rotation = 0;
+    int piece_x = 0;
+    int piece_y = 0;
+    bool game_over = false;
+    uint64_t rng = 1;
+};
+
+}


### PR DESCRIPTION
Users are sometimes dissatisfied with long-running queries. This PR improves their experience by adding a small Tetris game to clickhouse client to play while waiting. The game can be toggled on/off during query execution by pressing `t`. Happy April Fools’ Day!

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improve query waiting experience with built-in Tetris

