### PR TITLE
Add missing Keeper component tracking guard to no-arg loadStatistics

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -1106,6 +1106,8 @@ ColumnsStatistics IMergeTreeDataPart::loadStatisticsWide(const NameSet & require
 
 ColumnsStatistics IMergeTreeDataPart::loadStatistics() const
 {
+    auto component_guard = Coordination::setCurrentComponent("IMergeTreeDataPart::loadStatistics");
+
     if (auto * reader = getStatisticsPackedReader())
         return loadStatisticsPacked(*reader, {});
 


### PR DESCRIPTION
The no-arg `IMergeTreeDataPart::loadStatistics` overload was missing the
`Coordination::setCurrentComponent` guard. Its sibling overload
`loadStatistics(const Names &)` already had one.

When `getEstimates` calls the no-arg overload during query planning (via
`filterPartsByStatistics` in `ReadFromMergeTree::selectRangesToRead`), it
accesses Keeper metadata storage without a component set, causing a server
exception on configurations with "meta in keeper" + "s3 storage":

```
Logical error: Current component is empty, please set it for your scope
using Coordination::setCurrentComponent (STID: 2884-4370)
```


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Made with [Cursor](https://cursor.com)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.509`
- Backported to: `26.3.11.20`, `26.2.19.28`
<!-- ch-version-info:end -->