### PR TITLE
Fix flaky 01926_order_by_desc_limit test timeout under MSan + S3

### DIFF
--- a/tests/queries/0_stateless/01926_order_by_desc_limit.sql
+++ b/tests/queries/0_stateless/01926_order_by_desc_limit.sql
@@ -9,7 +9,7 @@ CREATE TABLE order_by_desc (u UInt32, s String)
 ENGINE MergeTree ORDER BY u PARTITION BY u % 100
 SETTINGS index_granularity = 1024, index_granularity_bytes = '10Mi';
 
-INSERT INTO order_by_desc SELECT number, repeat('a', 1024) FROM numbers(1024 * 300);
+INSERT INTO order_by_desc SELECT number, repeat('a', 128) FROM numbers(1024 * 300);
 OPTIMIZE TABLE order_by_desc FINAL;
 
 SELECT s FROM order_by_desc ORDER BY u DESC LIMIT 10 FORMAT Null


### PR DESCRIPTION
The test `01926_order_by_desc_limit` consistently times out (600s) in the MSan + distributed cache + S3 storage CI configuration. The root cause is the ~300MB data volume (307,200 rows × `repeat('a', 1024)`) being too expensive to INSERT, OPTIMIZE FINAL, and SELECT under MSan's instrumentation overhead combined with S3 network I/O.

Reduce the string size from 1024 to 128 bytes, cutting total data from ~300MB to ~40MB. The test's primary assertion — `read_rows <= 1024 * 110` in `query_log` — is unaffected since it checks row counts, not byte volumes. The `max_memory_usage = '400M'` guard becomes more generous but remains as a safety net.


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Made with [Cursor](https://cursor.com)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.510`
<!-- ch-version-info:end -->