### PR TITLE
Add failing test for parallel_distributed_insert_select=2 with different sharding keys

### DIFF
--- a/tests/queries/0_stateless/04062_parallel_distributed_insert_select_different_sharding_keys.reference
+++ b/tests/queries/0_stateless/04062_parallel_distributed_insert_select_different_sharding_keys.reference
@@ -1,4 +1,3 @@
-parallel_distributed_insert_select=2
 2
 300
 3	2	200

--- a/tests/queries/0_stateless/04062_parallel_distributed_insert_select_different_sharding_keys.reference
+++ b/tests/queries/0_stateless/04062_parallel_distributed_insert_select_different_sharding_keys.reference
@@ -1,0 +1,10 @@
+parallel_distributed_insert_select=2
+2
+300
+3	2	200
+2	3	100
+parallel_distributed_insert_select=0
+2
+300
+3	2	200
+2	3	100

--- a/tests/queries/0_stateless/04062_parallel_distributed_insert_select_different_sharding_keys.sql
+++ b/tests/queries/0_stateless/04062_parallel_distributed_insert_select_different_sharding_keys.sql
@@ -1,4 +1,6 @@
--- Tags: shard
+-- Tags: distributed, no-replicated-database, no-parallel-replicas
+-- Tag no-replicated-database: ON CLUSTER is not allowed
+-- Tag no-parallel-replicas: adjust_settings_for_autopr(args, tags, random_settings) forces random_settings["parallel_distributed_insert_select"] = 0
 -- https://github.com/ClickHouse/ClickHouse/issues/100788
 -- parallel_distributed_insert_select=2 does not reshard data when source
 -- and target distributed tables have different sharding keys.
@@ -6,9 +8,9 @@
 SET distributed_ddl_output_mode = 'none';
 
 DROP DATABASE IF EXISTS 04062_test ON CLUSTER test_cluster_two_shards SYNC;
-
 CREATE DATABASE 04062_test ON CLUSTER test_cluster_two_shards;
-USE DATABASE 04062_test;
+
+USE 04062_test;
 
 DROP TABLE IF EXISTS dist_tgt_04062;
 DROP TABLE IF EXISTS dist_src_04062;
@@ -38,6 +40,7 @@ SYSTEM FLUSH DISTRIBUTED dist_src_04062;
 -- Test 1: parallel_distributed_insert_select=2 (default).
 -- Each shard copies local_src to local_tgt without resharding by SecondaryId.
 INSERT INTO dist_tgt_04062 SELECT * FROM dist_src_04062;
+SYSTEM FLUSH DISTRIBUTED dist_tgt_04062;
 
 SELECT count() FROM dist_tgt_04062;
 SELECT sum(Value) FROM dist_tgt_04062;

--- a/tests/queries/0_stateless/04062_parallel_distributed_insert_select_different_sharding_keys.sql
+++ b/tests/queries/0_stateless/04062_parallel_distributed_insert_select_different_sharding_keys.sql
@@ -1,0 +1,73 @@
+-- Tags: shard
+-- https://github.com/ClickHouse/ClickHouse/issues/100788
+-- parallel_distributed_insert_select=2 does not reshard data when source
+-- and target distributed tables have different sharding keys.
+
+SET distributed_ddl_output_mode = 'none';
+
+DROP TABLE IF EXISTS dist_tgt_04062;
+DROP TABLE IF EXISTS dist_src_04062;
+DROP TABLE IF EXISTS local_tgt_04062 ON CLUSTER test_cluster_two_shards SYNC;
+DROP TABLE IF EXISTS local_src_04062 ON CLUSTER test_cluster_two_shards SYNC;
+
+CREATE TABLE local_src_04062 ON CLUSTER test_cluster_two_shards
+(PrimaryId UInt64, SecondaryId UInt64, Value UInt64)
+ENGINE = MergeTree() ORDER BY PrimaryId;
+
+CREATE TABLE local_tgt_04062 ON CLUSTER test_cluster_two_shards
+(PrimaryId UInt64, SecondaryId UInt64, Value UInt64)
+ENGINE = MergeTree() ORDER BY SecondaryId;
+
+CREATE TABLE dist_src_04062 AS local_src_04062
+ENGINE = Distributed(test_cluster_two_shards, currentDatabase(), local_src_04062, PrimaryId);
+
+CREATE TABLE dist_tgt_04062 AS local_tgt_04062
+ENGINE = Distributed(test_cluster_two_shards, currentDatabase(), local_tgt_04062, SecondaryId);
+
+-- Two rows where PrimaryId and SecondaryId route to opposite shards (modulo 2):
+--   PrimaryId=2 -> shard 1, SecondaryId=3 -> shard 2
+--   PrimaryId=3 -> shard 2, SecondaryId=2 -> shard 1
+INSERT INTO dist_src_04062 VALUES (2, 3, 100), (3, 2, 200);
+SYSTEM FLUSH DISTRIBUTED dist_src_04062;
+
+-- Test 1: parallel_distributed_insert_select=2 (default).
+-- Each shard copies local_src to local_tgt without resharding by SecondaryId.
+SELECT 'parallel_distributed_insert_select=2';
+INSERT INTO dist_tgt_04062 SELECT * FROM dist_src_04062
+    SETTINGS parallel_distributed_insert_select = 2;
+
+SELECT count() FROM dist_tgt_04062;
+SELECT sum(Value) FROM dist_tgt_04062;
+
+-- With optimize_skip_unused_shards, queries route by SecondaryId.
+-- If data was correctly resharded, these find the expected rows.
+SELECT PrimaryId, SecondaryId, Value FROM dist_tgt_04062
+    WHERE SecondaryId = 2
+    SETTINGS optimize_skip_unused_shards = 1;
+SELECT PrimaryId, SecondaryId, Value FROM dist_tgt_04062
+    WHERE SecondaryId = 3
+    SETTINGS optimize_skip_unused_shards = 1;
+
+-- Reset target for next test.
+TRUNCATE TABLE local_tgt_04062 ON CLUSTER test_cluster_two_shards;
+
+-- Test 2: parallel_distributed_insert_select=0 (workaround, reshards correctly).
+SELECT 'parallel_distributed_insert_select=0';
+INSERT INTO dist_tgt_04062 SELECT * FROM dist_src_04062
+    SETTINGS parallel_distributed_insert_select = 0;
+SYSTEM FLUSH DISTRIBUTED dist_tgt_04062;
+
+SELECT count() FROM dist_tgt_04062;
+SELECT sum(Value) FROM dist_tgt_04062;
+
+SELECT PrimaryId, SecondaryId, Value FROM dist_tgt_04062
+    WHERE SecondaryId = 2
+    SETTINGS optimize_skip_unused_shards = 1;
+SELECT PrimaryId, SecondaryId, Value FROM dist_tgt_04062
+    WHERE SecondaryId = 3
+    SETTINGS optimize_skip_unused_shards = 1;
+
+DROP TABLE dist_tgt_04062;
+DROP TABLE dist_src_04062;
+DROP TABLE local_tgt_04062 ON CLUSTER test_cluster_two_shards SYNC;
+DROP TABLE local_src_04062 ON CLUSTER test_cluster_two_shards SYNC;

--- a/tests/queries/0_stateless/04062_parallel_distributed_insert_select_different_sharding_keys.sql
+++ b/tests/queries/0_stateless/04062_parallel_distributed_insert_select_different_sharding_keys.sql
@@ -36,9 +36,7 @@ SYSTEM FLUSH DISTRIBUTED dist_src_04062;
 
 -- Test 1: parallel_distributed_insert_select=2 (default).
 -- Each shard copies local_src to local_tgt without resharding by SecondaryId.
-SELECT 'parallel_distributed_insert_select=2';
-INSERT INTO dist_tgt_04062 SELECT * FROM dist_src_04062
-    SETTINGS parallel_distributed_insert_select = 2;
+INSERT INTO dist_tgt_04062 SELECT * FROM dist_src_04062;
 
 SELECT count() FROM dist_tgt_04062;
 SELECT sum(Value) FROM dist_tgt_04062;
@@ -53,7 +51,7 @@ SELECT PrimaryId, SecondaryId, Value FROM dist_tgt_04062
     SETTINGS optimize_skip_unused_shards = 1;
 
 -- Reset target for next test.
-TRUNCATE TABLE local_tgt_04062 ON CLUSTER test_cluster_two_shards;
+TRUNCATE TABLE local_tgt_04062 ON CLUSTER test_cluster_two_shards SYNC;
 
 -- Test 2: parallel_distributed_insert_select=0 (workaround, reshards correctly).
 SELECT 'parallel_distributed_insert_select=0';
@@ -75,3 +73,4 @@ DROP TABLE dist_tgt_04062;
 DROP TABLE dist_src_04062;
 DROP TABLE local_tgt_04062 ON CLUSTER test_cluster_two_shards SYNC;
 DROP TABLE local_src_04062 ON CLUSTER test_cluster_two_shards SYNC;
+DROP DATABASE 04062_test ON CLUSTER test_cluster_two_shards;

--- a/tests/queries/0_stateless/04062_parallel_distributed_insert_select_different_sharding_keys.sql
+++ b/tests/queries/0_stateless/04062_parallel_distributed_insert_select_different_sharding_keys.sql
@@ -5,7 +5,8 @@
 
 SET distributed_ddl_output_mode = 'none';
 
-DROP DATABASE IF EXISTS 04062_test ON CLUSTER test_cluster_two_shards;
+DROP DATABASE IF EXISTS 04062_test ON CLUSTER test_cluster_two_shards SYNC;
+
 CREATE DATABASE 04062_test ON CLUSTER test_cluster_two_shards;
 USE DATABASE 04062_test;
 
@@ -73,4 +74,4 @@ DROP TABLE dist_tgt_04062;
 DROP TABLE dist_src_04062;
 DROP TABLE local_tgt_04062 ON CLUSTER test_cluster_two_shards SYNC;
 DROP TABLE local_src_04062 ON CLUSTER test_cluster_two_shards SYNC;
-DROP DATABASE 04062_test ON CLUSTER test_cluster_two_shards;
+DROP DATABASE 04062_test ON CLUSTER test_cluster_two_shards SYNC;

--- a/tests/queries/0_stateless/04062_parallel_distributed_insert_select_different_sharding_keys.sql
+++ b/tests/queries/0_stateless/04062_parallel_distributed_insert_select_different_sharding_keys.sql
@@ -5,6 +5,10 @@
 
 SET distributed_ddl_output_mode = 'none';
 
+DROP DATABASE IF EXISTS 04062_test ON CLUSTER test_cluster_two_shards;
+CREATE DATABASE 04062_test ON CLUSTER test_cluster_two_shards;
+USE DATABASE 04062_test;
+
 DROP TABLE IF EXISTS dist_tgt_04062;
 DROP TABLE IF EXISTS dist_src_04062;
 DROP TABLE IF EXISTS local_tgt_04062 ON CLUSTER test_cluster_two_shards SYNC;


### PR DESCRIPTION
Reproduces https://github.com/ClickHouse/ClickHouse/issues/100788: when source and target distributed tables have different sharding keys, `parallel_distributed_insert_select=2` (the current default) does not reshard data according to the target's sharding key. Each shard copies its local data directly, so `optimize_skip_unused_shards` queries on the target return wrong results.

The test has two parts:
- **`parallel_distributed_insert_select=2`**: demonstrates the bug — data stays sharded by the source key, and shard-pruned queries return empty results
- **`parallel_distributed_insert_select=0`**: shows the workaround works correctly — data is resharded by the target key

This PR intentionally contains only the failing test. The fix will follow separately.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)