### PR TITLE
Use f-strings in kill query integration tests

### DIFF
--- a/tests/integration/test_mongodb_kill_query/test.py
+++ b/tests/integration/test_mongodb_kill_query/test.py
@@ -105,7 +105,7 @@ def test_kill_query(setup_mongodb_users):
     query_thread.join()
 
     result = node1.query(
-        "SELECT count(*) FROM system.processes WHERE query_id='{query_id}'"
+        f"SELECT count(*) FROM system.processes WHERE query_id='{query_id}'"
     )
     assert int(result.strip()) == 0
 

--- a/tests/integration/test_mysql_kill_query/test.py
+++ b/tests/integration/test_mysql_kill_query/test.py
@@ -132,7 +132,7 @@ def test_kill_infinite_query(setup_infinite_query):
 
     # Verify that query was successfully cancelled in ClickHouse server
     result = node1.query(
-        "SELECT count(*) FROM system.processes WHERE query_id='{query_id}'"
+        f"SELECT count(*) FROM system.processes WHERE query_id='{query_id}'"
     )
     assert int(result.strip()) == 0
 
@@ -178,7 +178,7 @@ SETTINGS max_block_size = 10000""",
 
     # Verify that query was successfully cancelled in ClickHouse server
     result = node1.query(
-        "SELECT count(*) FROM system.processes WHERE query_id='{query_id}'"
+        f"SELECT count(*) FROM system.processes WHERE query_id='{query_id}'"
     )
     assert int(result.strip()) == 0
 

--- a/tests/integration/test_postgresql_kill_query/test.py
+++ b/tests/integration/test_postgresql_kill_query/test.py
@@ -126,7 +126,7 @@ def test_kill_infinite_query(setup_infinite_query):
 
     # Verify that query was successfully cancelled in ClickHouse server
     result = node1.query(
-        "SELECT count(*) FROM system.processes WHERE query_id='{query_id}'"
+        f"SELECT count(*) FROM system.processes WHERE query_id='{query_id}'"
     )
     assert int(result.strip()) == 0
 
@@ -172,7 +172,7 @@ SETTINGS max_block_size = 10000""",
 
     # Verify that query was successfully cancelled in ClickHouse server
     result = node1.query(
-        "SELECT count(*) FROM system.processes WHERE query_id='{query_id}'"
+        f"SELECT count(*) FROM system.processes WHERE query_id='{query_id}'"
     )
     assert int(result.strip()) == 0
 

--- a/tests/integration/test_sqlite_kill_query/test.py
+++ b/tests/integration/test_sqlite_kill_query/test.py
@@ -103,7 +103,7 @@ def test_kill_query(started_cluster):
 
     # Verify that query was successfully cancelled in ClickHouse server
     result = node1.query(
-        "SELECT count(*) FROM system.processes WHERE query_id='{query_id}'"
+        f"SELECT count(*) FROM system.processes WHERE query_id='{query_id}'"
     )
     assert int(result.strip()) == 0
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Use f-strings in *_kill_query integration tests for query string formatting.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.498`
<!-- ch-version-info:end -->