### PR TITLE
CI: avoid OSError for long result filenames by not dumping sub-results

### DIFF
--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -321,7 +321,19 @@ class Result(MetaClasses.Serializable):
         if not name:
             return cls.experimental_file_name_static()
         else:
-            return f"{Settings.TEMP_DIR}/result_{Utils.normalize_string(name)}.json"
+            normalized = Utils.normalize_string(name)
+            # Linux filesystems limit filenames to 255 bytes.
+            # prefix "result_" (7) + suffix ".json" (5) = 12, leaving 243 for the name.
+            # Reserve 9 chars for a uniqueness hash when truncating.
+            max_len = 243
+            if len(normalized) > max_len:
+                import hashlib
+
+                digest = hashlib.md5(
+                    normalized.encode(), usedforsecurity=False
+                ).hexdigest()[:8]
+                normalized = f"{normalized[:max_len - 9]}_{digest}"
+            return f"{Settings.TEMP_DIR}/result_{normalized}.json"
 
     @classmethod
     def experimental_file_name_static(cls):

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -336,22 +336,7 @@ class Result(MetaClasses.Serializable):
         if not name:
             return cls.experimental_file_name_static()
         else:
-            normalized = Utils.normalize_string(name)
-            # Linux filesystems limit filenames to 255 bytes.
-            # prefix "result_" (7) + suffix ".json" (5) = 12, leaving 243 for the name.
-            # Reserve 9 bytes for a uniqueness hash suffix when truncating.
-            max_bytes = 243
-            encoded = normalized.encode("utf-8")
-            if len(encoded) > max_bytes:
-                import hashlib
-
-                digest = hashlib.md5(
-                    encoded, usedforsecurity=False
-                ).hexdigest()[:8]
-                # Truncate bytes and decode safely to avoid splitting a multibyte char
-                truncated = encoded[: max_bytes - 9].decode("utf-8", errors="ignore")
-                normalized = f"{truncated}_{digest}"
-            return f"{Settings.TEMP_DIR}/result_{normalized}.json"
+            return f"{Settings.TEMP_DIR}/result_{Utils.normalize_string(name)}.json"
 
     @classmethod
     def experimental_file_name_static(cls):

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -324,15 +324,18 @@ class Result(MetaClasses.Serializable):
             normalized = Utils.normalize_string(name)
             # Linux filesystems limit filenames to 255 bytes.
             # prefix "result_" (7) + suffix ".json" (5) = 12, leaving 243 for the name.
-            # Reserve 9 chars for a uniqueness hash when truncating.
-            max_len = 243
-            if len(normalized) > max_len:
+            # Reserve 9 bytes for a uniqueness hash suffix when truncating.
+            max_bytes = 243
+            encoded = normalized.encode("utf-8")
+            if len(encoded) > max_bytes:
                 import hashlib
 
                 digest = hashlib.md5(
-                    normalized.encode(), usedforsecurity=False
+                    encoded, usedforsecurity=False
                 ).hexdigest()[:8]
-                normalized = f"{normalized[:max_len - 9]}_{digest}"
+                # Truncate bytes and decode safely to avoid splitting a multibyte char
+                truncated = encoded[: max_bytes - 9].decode("utf-8", errors="ignore")
+                normalized = f"{truncated}_{digest}"
             return f"{Settings.TEMP_DIR}/result_{normalized}.json"
 
     @classmethod

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -1,6 +1,7 @@
 import copy
 import dataclasses
 import datetime
+import errno
 import io
 import json
 import os
@@ -238,10 +239,13 @@ class Result(MetaClasses.Serializable):
         name is derived from a long error message.
         """
         try:
-            if Path(self.file_name()).is_file():
-                self.dump()
-        except OSError:
-            pass
+            exists = Path(self.file_name()).is_file()
+        except OSError as e:
+            if e.errno == errno.ENAMETOOLONG:
+                return self
+            raise
+        if exists:
+            self.dump()
         return self
 
     def set_status(self, status) -> "Result":

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -229,9 +229,24 @@ class Result(MetaClasses.Serializable):
     def is_dropped(self):
         return self.status in (Result.Status.DROPPED,)
 
+    def _dump_if_persisted(self) -> "Result":
+        """Dump only if a result file already exists on disk.
+
+        Setters use this so that job-level results (already dumped by `complete_job`
+        or `copy_result_to_s3`) are kept up-to-date, while sub-results (tasks) never
+        create their own files — avoiding `OSError: File name too long` when a result
+        name is derived from a long error message.
+        """
+        try:
+            if Path(self.file_name()).is_file():
+                self.dump()
+        except OSError:
+            pass
+        return self
+
     def set_status(self, status) -> "Result":
         self.status = status
-        self.dump()
+        self._dump_if_persisted()
         return self
 
     def set_success(self) -> "Result":
@@ -245,7 +260,7 @@ class Result(MetaClasses.Serializable):
 
     def set_results(self, results: List["Result"]) -> "Result":
         self.results = results
-        self.dump()
+        self._dump_if_persisted()
         return self
 
     def set_files(self, files, strict=True) -> "Result":
@@ -265,7 +280,7 @@ class Result(MetaClasses.Serializable):
                 )
                 files.remove(file)
         self.files += files
-        self.dump()
+        self._dump_if_persisted()
         return self
 
     def set_on_error_hook(self, hook: str) -> "Result":
@@ -296,12 +311,12 @@ class Result(MetaClasses.Serializable):
         if self.info:
             self.info += "\n"
         self.info += info
-        self.dump()
+        self._dump_if_persisted()
         return self
 
     def set_link(self, link) -> "Result":
         self.links.append(link)
-        self.dump()
+        self._dump_if_persisted()
         return self
 
     def _add_job_summary_to_info(self):


### PR DESCRIPTION
When a job produces sub-results (tasks) whose names are derived from error
messages — for example the `adjustLastGranule` error from #100769 — the name
can exceed the 255-byte Linux filesystem limit. All setter methods
(`set_status`, `set_results`, `set_files`, `set_info`, `set_link`) on `Result`
unconditionally called `dump()`, which tried to open a JSON file named after
the result. This caused `OSError: [Errno 36] File name too long`, crashing the
CI harness entirely before it could upload or report any results.

Example failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=101315&sha=d65b7bf56cf5118ae84a6e2cf21759a9ad11bf7d&name_0=PR&name_1=Stateless+tests+%28amd_tsan%2C+s3+storage%2C+parallel%2C+1%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/101315

**Fix:** sub-result files should never be created in the first place — only
job-level and workflow-level results need to be persisted to disk. A new
`_dump_if_persisted()` helper replaces the unconditional `self.dump()` in all
setters: it only writes to disk when a result file already exists. Sub-results
(tasks) are never explicitly dumped first, so they have no file on disk and the
setters are no-ops for them regardless of name length. Job-level results are
created explicitly by `complete_job`, `copy_result_to_s3`, or a direct
`dump()` call, and continue to be updated on every setter call as before. The
helper also catches `OSError` as a safety net.

cc @maxknv

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.507`
<!-- ch-version-info:end -->