### PR TITLE
Split `parallel_replicas_parallel_distributed_insert_select` from `parallel_distributed_insert_select`

### DIFF
--- a/src/Client/BuzzHouse/Generator/SessionSettings.cpp
+++ b/src/Client/BuzzHouse/Generator/SessionSettings.cpp
@@ -1151,6 +1151,7 @@ static std::unordered_map<String, CHSetting> serverSettings2 = {
     {"parallel_replicas_index_analysis_only_on_coordinator", trueOrFalseSetting},
     {"parallel_replicas_insert_select_local_pipeline", trueOrFalseSettingNoOracle},
     {"parallel_replicas_local_plan", trueOrFalseSetting},
+    {"parallel_replicas_parallel_distributed_insert_select", trueOrFalseSettingNoOracle},
     {"parallel_replicas_mark_segment_size", CHSetting(highRange, {}, false)},
     {"parallel_replicas_min_number_of_rows_per_replica", CHSetting(highRange, {}, false)},
     {"parallel_replicas_mode",

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -1244,7 +1244,7 @@ If the ratio of unavailable shards to total shards exceeds this value, an except
 A value of 0 means no limit (default behavior — all unavailable shards can be skipped).
 )", 0) \
     \
-    DECLARE(UInt64, parallel_distributed_insert_select, 2, R"(
+    DECLARE(UInt64, parallel_distributed_insert_select, 0, R"(
 Enables parallel distributed `INSERT ... SELECT` query.
 
 If we execute `INSERT INTO distributed_table_a SELECT ... FROM distributed_table_b` queries and both tables use the same cluster, and both tables are either [replicated](../../engines/table-engines/mergetree-family/replication.md) or non-replicated, then this query is processed locally on every shard.
@@ -1255,7 +1255,32 @@ Possible values:
 - `1` — `SELECT` will be executed on each shard from the underlying table of the distributed engine.
 - `2` — `SELECT` and `INSERT` will be executed on each shard from/to the underlying table of the distributed engine.
 
-Setting `enable_parallel_replicas = 1` is needed when using this setting.
+**Example with Distributed tables**
+
+With `parallel_distributed_insert_select = 1`, the `SELECT` is rewritten to read from the local (underlying) table, while the `INSERT` still goes through the Distributed table:
+
+```sql
+-- Original query:
+INSERT INTO dist_dst SELECT * FROM dist_src
+SETTINGS parallel_distributed_insert_select = 1, optimize_skip_unused_shards = 1;
+-- Each shard executes:
+--   INSERT INTO dist_dst SELECT * FROM local_src
+```
+
+With `parallel_distributed_insert_select = 2`, both the `SELECT` and `INSERT` are rewritten to use local tables on each shard, bypassing Distributed sends entirely:
+
+```sql
+-- Original query:
+INSERT INTO dist_dst SELECT * FROM dist_src
+SETTINGS parallel_distributed_insert_select = 2, optimize_skip_unused_shards = 1;
+-- Each shard executes:
+--   INSERT INTO local_dst SELECT * FROM local_src
+```
+)", 0) \
+    DECLARE(Bool, parallel_replicas_parallel_distributed_insert_select, 1, R"(
+Enables parallel distributed `INSERT ... SELECT` query for parallel replicas.
+
+Requires `enable_parallel_replicas = 1` (and `max_parallel_replicas > 1`). Each replica reads a coordinated portion of the source table and inserts into the local table:
 )", 0) \
     DECLARE(UInt64, distributed_group_by_no_merge, 0, R"(
 Do not merge aggregation states from different servers for distributed query processing, you can use this in case it is for certain that there are different keys on different shards

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -47,6 +47,8 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"enable_materialized_cte", false, false, "New setting"},
             {"finalize_projection_parts_synchronously", false, false, "New setting to finalize projection parts synchronously during INSERT to reduce peak memory usage."},
             {"highlight_max_matches_per_row", 10000, 10000, "New setting to limit the number of highlight matches per row to protect against excessive memory usage."},
+            {"parallel_distributed_insert_select", 2, 0, "Disable parallel distributed insert select by default"},
+            {"parallel_replicas_parallel_distributed_insert_select", 1, 1, "Enable parallel distributed INSERT SELECT for parallel replicas only by default"},
         });
         addSettingsChanges(settings_changes_history, "26.3",
         {

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -72,6 +72,7 @@ namespace Setting
     extern const SettingsBool use_concurrency_control;
     extern const SettingsSeconds lock_acquire_timeout;
     extern const SettingsUInt64 parallel_distributed_insert_select;
+    extern const SettingsBool parallel_replicas_parallel_distributed_insert_select;
     extern const SettingsBool enable_parsing_to_custom_serialization;
     extern const SettingsUInt64 allow_experimental_parallel_reading_from_replicas;
     extern const SettingsBool parallel_replicas_local_plan;
@@ -657,9 +658,6 @@ std::optional<QueryPipeline> InterpreterInsertQuery::buildInsertSelectPipelinePa
     if (!settings[Setting::allow_experimental_analyzer])
         return {};
 
-    if (settings[Setting::parallel_distributed_insert_select] != 2)
-        return {};
-
     /// Create a context with automatic_parallel_replicas_mode disabled upfront.
     /// INSERT SELECT should use parallel replicas regardless of automatic mode,
     /// and followers need automatic_parallel_replicas_mode == 0 to participate in coordinated reading.
@@ -943,12 +941,17 @@ BlockIO InterpreterInsertQuery::execute()
                 if (auto pipeline = distributedWriteIntoReplicatedMergeTreeOrDataLakeFromClusterStorage(query, context); pipeline)
                     res.pipeline = std::move(*pipeline);
             }
-            if (!res.pipeline.initialized())
-            {
-                auto pipeline = buildInsertSelectPipelineParallelReplicas(query, table);
-                if (pipeline)
-                    res.pipeline = std::move(*pipeline);
-            }
+
+            query.select = std::move(saved_select);
+        }
+        if (!res.pipeline.initialized())
+        {
+            /// parallel replicas path also mutates the SELECT AST, so keep a backup
+            auto saved_select = query.select->clone();
+
+            auto pipeline = buildInsertSelectPipelineParallelReplicas(query, table);
+            if (pipeline)
+                res.pipeline = std::move(*pipeline);
 
             query.select = std::move(saved_select);
         }

--- a/tests/integration/test_parallel_replicas_insert_select/test.py
+++ b/tests/integration/test_parallel_replicas_insert_select/test.py
@@ -83,7 +83,7 @@ def test_insert_select(start_cluster, cluster_name, max_parallel_replicas, local
     node1.query(
         f"INSERT INTO {target_table} SELECT * FROM {source_table}",
         settings={
-            "parallel_distributed_insert_select": 2,
+            "parallel_replicas_parallel_distributed_insert_select": 1,
             "enable_parallel_replicas": 2,
             "max_parallel_replicas": max_parallel_replicas,
             "cluster_for_parallel_replicas": cluster_name,
@@ -144,7 +144,7 @@ def test_insert_select_no_table(start_cluster, cluster_name, max_parallel_replic
         node1.query(
             f"INSERT INTO {target_table} SELECT * FROM {source_table}",
             settings={
-                "parallel_distributed_insert_select": 2,
+                "parallel_replicas_parallel_distributed_insert_select": 1,
                 "enable_parallel_replicas": 2,
                 "max_parallel_replicas": max_parallel_replicas,
                 "cluster_for_parallel_replicas": cluster_name,
@@ -174,7 +174,7 @@ def test_insert_select_no_target_table(start_cluster, cluster_name, max_parallel
         node1.query(
             f"INSERT INTO {target_table} SELECT * FROM {source_table}",
             settings={
-                "parallel_distributed_insert_select": 2,
+                "parallel_replicas_parallel_distributed_insert_select": 1,
                 "enable_parallel_replicas": 2,
                 "max_parallel_replicas": max_parallel_replicas,
                 "cluster_for_parallel_replicas": cluster_name,
@@ -213,7 +213,7 @@ def test_insert_select_limit(start_cluster, max_parallel_replicas, parallel_repl
     node1.query(
         f"INSERT INTO {target_table} SELECT * FROM {source_table} LIMIT {limit}",
         settings={
-            "parallel_distributed_insert_select": 2,
+            "parallel_replicas_parallel_distributed_insert_select": 1,
             "enable_parallel_replicas": 2,
             "max_parallel_replicas": max_parallel_replicas,
             "cluster_for_parallel_replicas": cluster_name,
@@ -258,7 +258,7 @@ def test_insert_select_with_constant(start_cluster, max_parallel_replicas, paral
     node1.query(
         f"INSERT INTO {target_table} WITH 1 + 1 as two SELECT key + (select sum(number) from numbers(10) where number < two), value FROM {source_table}",
         settings={
-            "parallel_distributed_insert_select": 2,
+            "parallel_replicas_parallel_distributed_insert_select": 1,
             "enable_parallel_replicas": 2,
             "max_parallel_replicas": max_parallel_replicas,
             "cluster_for_parallel_replicas": cluster_name,
@@ -304,7 +304,7 @@ def test_insert_select_where(start_cluster, max_parallel_replicas, parallel_repl
     node1.query(
         f"INSERT INTO {target_table} SELECT * FROM {source_table} WHERE key % 10 = 0",
         settings={
-            "parallel_distributed_insert_select": 2,
+            "parallel_replicas_parallel_distributed_insert_select": 1,
             "enable_parallel_replicas": 2,
             "max_parallel_replicas": max_parallel_replicas,
             "cluster_for_parallel_replicas": cluster_name,

--- a/tests/queries/0_stateless/03394_pr_insert_select.sql
+++ b/tests/queries/0_stateless/03394_pr_insert_select.sql
@@ -1,5 +1,5 @@
 SET enable_analyzer=1; -- parallel distributed insert select for replicated tables works only with analyzer
-SET parallel_distributed_insert_select=2;
+SET parallel_replicas_parallel_distributed_insert_select=1;
 
 DROP TABLE IF EXISTS t_mt_source;
 DROP TABLE IF EXISTS t_rmt_target SYNC;

--- a/tests/queries/0_stateless/03394_pr_insert_select_local_pipeline.sql
+++ b/tests/queries/0_stateless/03394_pr_insert_select_local_pipeline.sql
@@ -1,5 +1,5 @@
 SET enable_analyzer=1; -- parallel distributed insert select for replicated tables works only with analyzer
-SET parallel_distributed_insert_select=2;
+SET parallel_replicas_parallel_distributed_insert_select=1;
 
 DROP TABLE IF EXISTS t_mt_source;
 DROP TABLE IF EXISTS t_rmt_target SYNC;

--- a/tests/queries/0_stateless/03394_pr_insert_select_threads.sql
+++ b/tests/queries/0_stateless/03394_pr_insert_select_threads.sql
@@ -1,7 +1,7 @@
 -- Tags: long, no-parallel, no-object-storage, no-msan, no-tsan
 
 SET enable_analyzer=1; -- parallel distributed insert select for replicated tables works only with analyzer
-SET parallel_distributed_insert_select=2;
+SET parallel_replicas_parallel_distributed_insert_select=1;
 
 DROP TABLE IF EXISTS t_mt_source;
 DROP TABLE IF EXISTS t_rmt_target SYNC;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Split `parallel_replicas_parallel_distributed_insert_select` from `parallel_distributed_insert_select`

For distributed tables, parallel_distributed_insert_select, cannot be enabled by default, since we cannot be sure that the data is shared correctly.

The purpose of enabling parallel_distributed_insert_select=2, was for parallel replicas, so let's split this into a separate function.

Fixes: https://github.com/ClickHouse/ClickHouse/issues/100788