### PR TITLE
Reduce profiled lock overhead in Keeper

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -537,9 +537,7 @@
     M(DictCacheRequestTimeNs, "Number of nanoseconds spend in querying the external data sources for the dictionaries of 'cache' types.", ValueType::Nanoseconds) \
     M(DictCacheRequests, "Number of bulk requests to the external data sources for the dictionaries of 'cache' types.", ValueType::Number) \
     M(DictCacheLockWriteNs, "Number of nanoseconds spend in waiting for write lock to update the data for the dictionaries of 'cache' types.", ValueType::Nanoseconds) \
-    M(DictCacheLockWriteHoldNs, "Number of nanoseconds spent holding write lock for the dictionaries of 'cache' types.", ValueType::Nanoseconds) \
     M(DictCacheLockReadNs, "Number of nanoseconds spend in waiting for read lock to lookup the data for the dictionaries of 'cache' types.", ValueType::Nanoseconds) \
-    M(DictCacheLockReadHoldNs, "Number of nanoseconds spent holding read lock for the dictionaries of 'cache' types.", ValueType::Nanoseconds) \
     \
     M(DistributedSyncInsertionTimeoutExceeded, "A timeout has exceeded while waiting for shards during synchronous insertion into a Distributed table (with 'distributed_foreground_insert' = 1)", ValueType::Number) \
     M(DistributedAsyncInsertionFailures, "Number of failures for asynchronous insertion into a Distributed table (with 'distributed_foreground_insert' = 0)", ValueType::Number) \
@@ -952,19 +950,12 @@ The server successfully detected this situation and will download merged part fr
     M(KeeperProcessElapsedMicroseconds, "Keeper commit latency for a single request", ValueType::Microseconds) \
     M(KeeperPreprocessElapsedMicroseconds, "Keeper preprocessing latency for a single request", ValueType::Microseconds) \
     M(KeeperStorageLockWaitMicroseconds, "Time spent waiting for acquiring Keeper storage lock", ValueType::Microseconds) \
-    M(KeeperStorageLockHoldMicroseconds, "Time spent holding Keeper storage lock", ValueType::Microseconds) \
     M(KeeperStorageSharedLockWaitMicroseconds, "Time spent waiting for acquiring Keeper storage shared lock", ValueType::Microseconds) \
-    M(KeeperStorageSharedLockHoldMicroseconds, "Time spent holding Keeper storage shared lock", ValueType::Microseconds) \
     M(KeeperChangelogLockWaitMicroseconds, "Time spent waiting for acquiring Keeper changelog lock", ValueType::Microseconds) \
-    M(KeeperChangelogLockHoldMicroseconds, "Time spent holding Keeper changelog lock", ValueType::Microseconds) \
     M(KeeperServerWriteLockWaitMicroseconds, "Time spent waiting for acquiring Keeper server write lock", ValueType::Microseconds) \
-    M(KeeperServerWriteLockHoldMicroseconds, "Time spent holding Keeper server write lock", ValueType::Microseconds) \
     M(KeeperSessionCallbackLockWaitMicroseconds, "Time spent waiting for acquiring Keeper session callback lock", ValueType::Microseconds) \
-    M(KeeperSessionCallbackLockHoldMicroseconds, "Time spent holding Keeper session callback lock", ValueType::Microseconds) \
     M(KeeperReadRequestQueueLockWaitMicroseconds, "Time spent waiting for acquiring Keeper read request queue lock", ValueType::Microseconds) \
-    M(KeeperReadRequestQueueLockHoldMicroseconds, "Time spent holding Keeper read request queue lock", ValueType::Microseconds) \
     M(KeeperProcessAndResponsesLockWaitMicroseconds, "Time spent waiting for acquiring Keeper process and responses lock", ValueType::Microseconds) \
-    M(KeeperProcessAndResponsesLockHoldMicroseconds, "Time spent holding Keeper process and responses lock", ValueType::Microseconds) \
     M(KeeperCommitWaitElapsedMicroseconds, "Time spent waiting for certain log to be committed", ValueType::Microseconds) \
     M(KeeperBatchMaxCount, "Number of times the size of batch was limited by the amount", ValueType::Number) \
     M(KeeperBatchMaxTotalSize, "Number of times the size of batch was limited by the total bytes size", ValueType::Number) \
@@ -993,7 +984,6 @@ The server successfully detected this situation and will download merged part fr
     M(KeeperRequestRejectedDueToSoftMemoryLimitCount, "Number requests that have been rejected due to soft memory limit exceeded", ValueType::Number) \
     M(KeeperStaleRequestsSkipped, "Number of Keeper requests skipped because the session is no longer live", ValueType::Number) \
     M(KeeperLiveSessionsLockWaitMicroseconds, "Time spent waiting to acquire Keeper live sessions lock", ValueType::Microseconds) \
-    M(KeeperLiveSessionsLockHoldMicroseconds, "Time spent holding Keeper live sessions lock", ValueType::Microseconds) \
     \
     M(OverflowBreak, "Number of times, data processing was cancelled by query complexity limitation with setting '*_overflow_mode' = 'break' and the result is incomplete.", ValueType::Number) \
     M(OverflowThrow, "Number of times, data processing was cancelled by query complexity limitation with setting '*_overflow_mode' = 'throw' and exception was thrown.", ValueType::Number) \

--- a/src/Common/ProfiledLocks.h
+++ b/src/Common/ProfiledLocks.h
@@ -14,148 +14,145 @@
 namespace DB
 {
 
-/// RAII lock guard that measures both wait-time and hold-time for std::mutex.
-/// Increments the wait-event after the lock is acquired, and the hold-event when the guard is destroyed.
+/// RAII lock guard that measures wait-time on contention only for std::mutex.
+/// Uses try_lock to detect contention: uncontended acquisitions have zero timing overhead.
+/// Only increments the wait-event when the lock was actually contended (try_lock failed).
 class TSA_SCOPED_LOCKABLE ProfiledMutexLock final : private boost::noncopyable
 {
 public:
-    ProfiledMutexLock(std::mutex & mutex, ProfileEvents::Event wait_event_, ProfileEvents::Event hold_event_) TSA_ACQUIRE(mutex)
+    ProfiledMutexLock(std::mutex & mutex, ProfileEvents::Event wait_event_) TSA_ACQUIRE(mutex)
         : wait_event(wait_event_)
-        , hold_event(hold_event_)
     {
-        Stopwatch wait_watch;
-        std::unique_lock<std::mutex> l(mutex);
-        ProfileEvents::increment(wait_event, wait_watch.elapsedMicroseconds());
-        underlying_lock = std::move(l);
-        hold_watch.restart();
+        if (mutex.try_lock())
+        {
+            underlying_lock = std::unique_lock<std::mutex>(mutex, std::adopt_lock);
+        }
+        else
+        {
+            Stopwatch wait_watch;
+            std::unique_lock<std::mutex> l(mutex);
+            ProfileEvents::increment(wait_event, wait_watch.elapsedMicroseconds());
+            underlying_lock = std::move(l);
+        }
     }
 
     ~ProfiledMutexLock() TSA_RELEASE()
     {
         if (underlying_lock.owns_lock())
-        {
-            UInt64 elapsed = hold_watch.elapsedMicroseconds();
             underlying_lock.unlock();
-            ProfileEvents::increment(hold_event, elapsed);
-        }
     }
 
     void unlock() TSA_RELEASE()
     {
-        UInt64 elapsed = hold_watch.elapsedMicroseconds();
         underlying_lock.unlock();
-        ProfileEvents::increment(hold_event, elapsed);
     }
 
     void lock() TSA_ACQUIRE()
     {
+        if (underlying_lock.try_lock())
+            return;
+
         Stopwatch wait_watch;
         underlying_lock.lock();
         ProfileEvents::increment(wait_event, wait_watch.elapsedMicroseconds());
-        hold_watch.restart();
     }
 
 private:
     std::unique_lock<std::mutex> underlying_lock;
     ProfileEvents::Event wait_event;
-    ProfileEvents::Event hold_event;
-    Stopwatch hold_watch;
 };
 
-/// RAII lock guard that measures both wait-time and hold-time for exclusive (write) locks on SharedMutex.
-/// Increments the wait-event after the lock is acquired, and the hold-event when the guard is destroyed.
+/// RAII lock guard that measures wait-time on contention only for exclusive (write) locks on SharedMutex.
 class TSA_SCOPED_LOCKABLE ProfiledExclusiveLock final : private boost::noncopyable
 {
 public:
-    ProfiledExclusiveLock(SharedMutex & mutex, ProfileEvents::Event wait_event_, ProfileEvents::Event hold_event_) TSA_ACQUIRE(mutex)
+    ProfiledExclusiveLock(SharedMutex & mutex, ProfileEvents::Event wait_event_) TSA_ACQUIRE(mutex)
         : wait_event(wait_event_)
-        , hold_event(hold_event_)
     {
-        Stopwatch wait_watch;
-        std::unique_lock<SharedMutex> l(mutex);
-        ProfileEvents::increment(wait_event, wait_watch.elapsedMicroseconds());
-        underlying_lock = std::move(l);
-        hold_watch.restart();
+        if (mutex.try_lock())
+        {
+            underlying_lock = std::unique_lock<SharedMutex>(mutex, std::adopt_lock);
+        }
+        else
+        {
+            Stopwatch wait_watch;
+            std::unique_lock<SharedMutex> l(mutex);
+            ProfileEvents::increment(wait_event, wait_watch.elapsedMicroseconds());
+            underlying_lock = std::move(l);
+        }
     }
 
     ~ProfiledExclusiveLock() TSA_RELEASE()
     {
         if (underlying_lock.owns_lock())
-        {
-            UInt64 elapsed = hold_watch.elapsedMicroseconds();
             underlying_lock.unlock();
-            ProfileEvents::increment(hold_event, elapsed);
-        }
     }
 
     void unlock() TSA_RELEASE()
     {
-        UInt64 elapsed = hold_watch.elapsedMicroseconds();
         underlying_lock.unlock();
-        ProfileEvents::increment(hold_event, elapsed);
     }
 
     void lock() TSA_ACQUIRE()
     {
+        if (underlying_lock.try_lock())
+            return;
+
         Stopwatch wait_watch;
         underlying_lock.lock();
         ProfileEvents::increment(wait_event, wait_watch.elapsedMicroseconds());
-        hold_watch.restart();
     }
 
 private:
     std::unique_lock<SharedMutex> underlying_lock;
     ProfileEvents::Event wait_event;
-    ProfileEvents::Event hold_event;
-    Stopwatch hold_watch;
 };
 
 
-/// RAII lock guard that measures both wait-time and hold-time for shared (read) locks on SharedMutex.
+/// RAII lock guard that measures wait-time on contention only for shared (read) locks on SharedMutex.
 class TSA_SCOPED_LOCKABLE ProfiledSharedLock final : private boost::noncopyable
 {
 public:
-    ProfiledSharedLock(SharedMutex & mutex, ProfileEvents::Event wait_event_, ProfileEvents::Event hold_event_) TSA_ACQUIRE_SHARED(mutex)
+    ProfiledSharedLock(SharedMutex & mutex, ProfileEvents::Event wait_event_) TSA_ACQUIRE_SHARED(mutex)
         : wait_event(wait_event_)
-        , hold_event(hold_event_)
     {
-        Stopwatch wait_watch;
-        std::shared_lock<SharedMutex> l(mutex);
-        ProfileEvents::increment(wait_event, wait_watch.elapsedMicroseconds());
-        underlying_lock = std::move(l);
-        hold_watch.restart();
+        if (mutex.try_lock_shared())
+        {
+            underlying_lock = std::shared_lock<SharedMutex>(mutex, std::adopt_lock);
+        }
+        else
+        {
+            Stopwatch wait_watch;
+            std::shared_lock<SharedMutex> l(mutex);
+            ProfileEvents::increment(wait_event, wait_watch.elapsedMicroseconds());
+            underlying_lock = std::move(l);
+        }
     }
 
     ~ProfiledSharedLock() TSA_RELEASE()
     {
         if (underlying_lock.owns_lock())
-        {
-            UInt64 elapsed = hold_watch.elapsedMicroseconds();
             underlying_lock.unlock();
-            ProfileEvents::increment(hold_event, elapsed);
-        }
     }
 
     void unlock() TSA_RELEASE()
     {
-        UInt64 elapsed = hold_watch.elapsedMicroseconds();
         underlying_lock.unlock();
-        ProfileEvents::increment(hold_event, elapsed);
     }
 
-    void lock() TSA_ACQUIRE()
+    void lock() TSA_ACQUIRE_SHARED()
     {
+        if (underlying_lock.try_lock())
+            return;
+
         Stopwatch wait_watch;
         underlying_lock.lock();
         ProfileEvents::increment(wait_event, wait_watch.elapsedMicroseconds());
-        hold_watch.restart();
     }
 
 private:
     std::shared_lock<SharedMutex> underlying_lock;
     ProfileEvents::Event wait_event;
-    ProfileEvents::Event hold_event;
-    Stopwatch hold_watch;
 };
 
 }

--- a/src/Coordination/KeeperConstants.cpp
+++ b/src/Coordination/KeeperConstants.cpp
@@ -243,19 +243,12 @@
     M(KeeperProcessElapsedMicroseconds) \
     M(KeeperPreprocessElapsedMicroseconds) \
     M(KeeperStorageLockWaitMicroseconds) \
-    M(KeeperStorageLockHoldMicroseconds) \
     M(KeeperStorageSharedLockWaitMicroseconds) \
-    M(KeeperStorageSharedLockHoldMicroseconds) \
     M(KeeperChangelogLockWaitMicroseconds) \
-    M(KeeperChangelogLockHoldMicroseconds) \
     M(KeeperServerWriteLockWaitMicroseconds) \
-    M(KeeperServerWriteLockHoldMicroseconds) \
     M(KeeperSessionCallbackLockWaitMicroseconds) \
-    M(KeeperSessionCallbackLockHoldMicroseconds) \
     M(KeeperReadRequestQueueLockWaitMicroseconds) \
-    M(KeeperReadRequestQueueLockHoldMicroseconds) \
     M(KeeperProcessAndResponsesLockWaitMicroseconds) \
-    M(KeeperProcessAndResponsesLockHoldMicroseconds) \
     M(KeeperCommitWaitElapsedMicroseconds) \
     M(KeeperBatchMaxCount) \
     M(KeeperBatchMaxTotalSize) \
@@ -325,7 +318,6 @@
     M(KeeperRequestRejectedDueToSoftMemoryLimitCount) \
     M(KeeperStaleRequestsSkipped) \
     M(KeeperLiveSessionsLockWaitMicroseconds) \
-    M(KeeperLiveSessionsLockHoldMicroseconds) \
 
 namespace ProfileEvents
 {

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -55,11 +55,8 @@ namespace ProfileEvents
     extern const Event KeeperRequestRejectedDueToSoftMemoryLimitCount;
     extern const Event KeeperStaleRequestsSkipped;
     extern const Event KeeperLiveSessionsLockWaitMicroseconds;
-    extern const Event KeeperLiveSessionsLockHoldMicroseconds;
     extern const Event KeeperSessionCallbackLockWaitMicroseconds;
-    extern const Event KeeperSessionCallbackLockHoldMicroseconds;
     extern const Event KeeperReadRequestQueueLockWaitMicroseconds;
-    extern const Event KeeperReadRequestQueueLockHoldMicroseconds;
 }
 
 namespace HistogramMetrics
@@ -218,7 +215,7 @@ void KeeperDispatcher::requestThread()
                     if (req.request->getOpNum() != Coordination::OpNum::Close
                         && req.request->getOpNum() != Coordination::OpNum::SessionID)
                     {
-                        ProfiledMutexLock lock(live_sessions_mutex, ProfileEvents::KeeperLiveSessionsLockWaitMicroseconds, ProfileEvents::KeeperLiveSessionsLockHoldMicroseconds);
+                        ProfiledMutexLock lock(live_sessions_mutex, ProfileEvents::KeeperLiveSessionsLockWaitMicroseconds);
                         if (!live_sessions.contains(req.session_id))
                         {
                             ProfileEvents::increment(ProfileEvents::KeeperStaleRequestsSkipped);
@@ -300,7 +297,7 @@ void KeeperDispatcher::requestThread()
                             {
                                 const auto & last_request = current_batch.back();
                                 ZooKeeperOpentelemetrySpans::maybeInitialize(request.request->spans.read_wait_for_write, request.request->tracing_context);
-                                ProfiledMutexLock lock(read_request_queue_mutex, ProfileEvents::KeeperReadRequestQueueLockWaitMicroseconds, ProfileEvents::KeeperReadRequestQueueLockHoldMicroseconds);
+                                ProfiledMutexLock lock(read_request_queue_mutex, ProfileEvents::KeeperReadRequestQueueLockWaitMicroseconds);
                                 read_request_queue[{last_request.session_id, last_request.request->xid}].push_back(request);
                             }
                             else if (request.request->getOpNum() == Coordination::OpNum::Reconfig)
@@ -433,7 +430,7 @@ void KeeperDispatcher::requestThread()
                 {
                     bool is_live;
                     {
-                        ProfiledMutexLock lock(live_sessions_mutex, ProfileEvents::KeeperLiveSessionsLockWaitMicroseconds, ProfileEvents::KeeperLiveSessionsLockHoldMicroseconds);
+                        ProfiledMutexLock lock(live_sessions_mutex, ProfileEvents::KeeperLiveSessionsLockWaitMicroseconds);
                         is_live = live_sessions.contains(request.session_id);
                     }
                     if (is_live)
@@ -552,7 +549,7 @@ bool KeeperDispatcher::setResponse(int64_t session_id, const Coordination::ZooKe
     /// KeeperOverDispatcher's CallbackState is protected by its own mutex.
     ZooKeeperResponseCallback callback;
     {
-        ProfiledMutexLock lock(session_to_response_callback_mutex, ProfileEvents::KeeperSessionCallbackLockWaitMicroseconds, ProfileEvents::KeeperSessionCallbackLockHoldMicroseconds);
+        ProfiledMutexLock lock(session_to_response_callback_mutex, ProfileEvents::KeeperSessionCallbackLockWaitMicroseconds);
 
         /// Special new session response.
         if (response->xid != Coordination::WATCH_XID && response->getOpNum() == Coordination::OpNum::SessionID)
@@ -598,7 +595,7 @@ bool KeeperDispatcher::putRequest(const Coordination::ZooKeeperRequestPtr & requ
 {
     {
         /// If session was already disconnected than we will ignore requests
-        ProfiledMutexLock lock(session_to_response_callback_mutex, ProfileEvents::KeeperSessionCallbackLockWaitMicroseconds, ProfileEvents::KeeperSessionCallbackLockHoldMicroseconds);
+        ProfiledMutexLock lock(session_to_response_callback_mutex, ProfileEvents::KeeperSessionCallbackLockWaitMicroseconds);
         if (!session_to_response_callback.contains(session_id))
             return false;
     }
@@ -632,7 +629,7 @@ bool KeeperDispatcher::putRequest(const Coordination::ZooKeeperRequestPtr & requ
 bool KeeperDispatcher::putLocalReadRequest(const Coordination::ZooKeeperRequestPtr & request, int64_t session_id)
 {
     {
-        ProfiledMutexLock lock(live_sessions_mutex, ProfileEvents::KeeperLiveSessionsLockWaitMicroseconds, ProfileEvents::KeeperLiveSessionsLockHoldMicroseconds);
+        ProfiledMutexLock lock(live_sessions_mutex, ProfileEvents::KeeperLiveSessionsLockWaitMicroseconds);
         if (!live_sessions.contains(session_id))
         {
             ProfileEvents::increment(ProfileEvents::KeeperStaleRequestsSkipped);
@@ -642,7 +639,7 @@ bool KeeperDispatcher::putLocalReadRequest(const Coordination::ZooKeeperRequestP
 
     {
         /// If session was already disconnected than we will ignore requests
-        ProfiledMutexLock lock(session_to_response_callback_mutex, ProfileEvents::KeeperSessionCallbackLockWaitMicroseconds, ProfileEvents::KeeperSessionCallbackLockHoldMicroseconds);
+        ProfiledMutexLock lock(session_to_response_callback_mutex, ProfileEvents::KeeperSessionCallbackLockWaitMicroseconds);
         if (!session_to_response_callback.contains(session_id))
             return false;
     }
@@ -689,7 +686,7 @@ void KeeperDispatcher::initialize(const Poco::Util::AbstractConfiguration & conf
             {
                 /// check if we have queue of read requests depending on this request to be committed
                 SessionAndXID key(request_for_session.session_id, request_for_session.request->xid);
-                ProfiledMutexLock lock(read_request_queue_mutex, ProfileEvents::KeeperReadRequestQueueLockWaitMicroseconds, ProfileEvents::KeeperReadRequestQueueLockHoldMicroseconds);
+                ProfiledMutexLock lock(read_request_queue_mutex, ProfileEvents::KeeperReadRequestQueueLockWaitMicroseconds);
                 if (auto it = read_request_queue.find(key); it != read_request_queue.end())
                 {
                     pending_reads = std::move(it->second);
@@ -703,7 +700,7 @@ void KeeperDispatcher::initialize(const Poco::Util::AbstractConfiguration & conf
             {
                 /// Skip reads whose session is no longer live
                 {
-                    ProfiledMutexLock lock(live_sessions_mutex, ProfileEvents::KeeperLiveSessionsLockWaitMicroseconds, ProfileEvents::KeeperLiveSessionsLockHoldMicroseconds);
+                    ProfiledMutexLock lock(live_sessions_mutex, ProfileEvents::KeeperLiveSessionsLockWaitMicroseconds);
                     if (!live_sessions.contains(read_request.session_id))
                     {
                         ProfileEvents::increment(ProfileEvents::KeeperStaleRequestsSkipped);
@@ -754,7 +751,7 @@ void KeeperDispatcher::initialize(const Poco::Util::AbstractConfiguration & conf
             /// how followers learn about closed sessions.
             if (request_for_session.request->getOpNum() == Coordination::OpNum::Close)
             {
-                ProfiledMutexLock lock(live_sessions_mutex, ProfileEvents::KeeperLiveSessionsLockWaitMicroseconds, ProfileEvents::KeeperLiveSessionsLockHoldMicroseconds);
+                ProfiledMutexLock lock(live_sessions_mutex, ProfileEvents::KeeperLiveSessionsLockWaitMicroseconds);
                 live_sessions.erase(request_for_session.session_id);
             }
         });
@@ -839,7 +836,7 @@ void KeeperDispatcher::shutdown()
         KeeperRequestsForSessions close_requests;
         {
             /// Clear all registered sessions
-            ProfiledMutexLock lock(session_to_response_callback_mutex, ProfileEvents::KeeperSessionCallbackLockWaitMicroseconds, ProfileEvents::KeeperSessionCallbackLockHoldMicroseconds);
+            ProfiledMutexLock lock(session_to_response_callback_mutex, ProfileEvents::KeeperSessionCallbackLockWaitMicroseconds);
 
             if (server && hasLeader())
             {
@@ -921,13 +918,13 @@ void KeeperDispatcher::registerSession(int64_t session_id, ZooKeeperResponseCall
 {
     bool inserted = false;
     {
-        ProfiledMutexLock lock(live_sessions_mutex, ProfileEvents::KeeperLiveSessionsLockWaitMicroseconds, ProfileEvents::KeeperLiveSessionsLockHoldMicroseconds);
+        ProfiledMutexLock lock(live_sessions_mutex, ProfileEvents::KeeperLiveSessionsLockWaitMicroseconds);
         inserted = live_sessions.insert(session_id).second;
     }
 
     try
     {
-        ProfiledMutexLock lock(session_to_response_callback_mutex, ProfileEvents::KeeperSessionCallbackLockWaitMicroseconds, ProfileEvents::KeeperSessionCallbackLockHoldMicroseconds);
+        ProfiledMutexLock lock(session_to_response_callback_mutex, ProfileEvents::KeeperSessionCallbackLockWaitMicroseconds);
         if (!session_to_response_callback.try_emplace(session_id, callback).second)
             throw Exception(DB::ErrorCodes::LOGICAL_ERROR, "Session with id {} already registered in dispatcher", session_id);
         CurrentMetrics::add(CurrentMetrics::KeeperAliveConnections);
@@ -936,7 +933,7 @@ void KeeperDispatcher::registerSession(int64_t session_id, ZooKeeperResponseCall
     {
         if (inserted)
         {
-            ProfiledMutexLock lock(live_sessions_mutex, ProfileEvents::KeeperLiveSessionsLockWaitMicroseconds, ProfileEvents::KeeperLiveSessionsLockHoldMicroseconds);
+            ProfiledMutexLock lock(live_sessions_mutex, ProfileEvents::KeeperLiveSessionsLockWaitMicroseconds);
             live_sessions.erase(session_id);
         }
         throw;
@@ -1009,7 +1006,7 @@ void KeeperDispatcher::finishSession(int64_t session_id)
 
     ZooKeeperResponseCallback callback;
     {
-        ProfiledMutexLock lock(session_to_response_callback_mutex, ProfileEvents::KeeperSessionCallbackLockWaitMicroseconds, ProfileEvents::KeeperSessionCallbackLockHoldMicroseconds);
+        ProfiledMutexLock lock(session_to_response_callback_mutex, ProfileEvents::KeeperSessionCallbackLockWaitMicroseconds);
         auto session_it = session_to_response_callback.find(session_id);
         if (session_it != session_to_response_callback.end())
         {
@@ -1029,7 +1026,7 @@ void KeeperDispatcher::finishSession(int64_t session_id)
     /// Remove from live_sessions so `requestThread` can skip stale requests
     /// still sitting in the queue for this session.
     {
-        ProfiledMutexLock lock(live_sessions_mutex, ProfileEvents::KeeperLiveSessionsLockWaitMicroseconds, ProfileEvents::KeeperLiveSessionsLockHoldMicroseconds);
+        ProfiledMutexLock lock(live_sessions_mutex, ProfileEvents::KeeperLiveSessionsLockWaitMicroseconds);
         live_sessions.erase(session_id);
     }
 
@@ -1065,7 +1062,7 @@ void KeeperDispatcher::addErrorResponses(const KeeperRequestsForSessions & reque
         if (may_have_dependent_reads)
         {
             SessionAndXID key(request_for_session.session_id, request_for_session.request->xid);
-            ProfiledMutexLock lock(read_request_queue_mutex, ProfileEvents::KeeperReadRequestQueueLockWaitMicroseconds, ProfileEvents::KeeperReadRequestQueueLockHoldMicroseconds);
+            ProfiledMutexLock lock(read_request_queue_mutex, ProfileEvents::KeeperReadRequestQueueLockWaitMicroseconds);
             if (auto it = read_request_queue.find(key); it != read_request_queue.end())
             {
                 dependent_reads.insert(dependent_reads.end(), std::move_iterator(it->second.begin()), std::move_iterator(it->second.end()));
@@ -1125,7 +1122,7 @@ int64_t KeeperDispatcher::getSessionID(int64_t session_timeout_ms)
     auto future = promise->get_future();
 
     {
-        ProfiledMutexLock lock(session_to_response_callback_mutex, ProfileEvents::KeeperSessionCallbackLockWaitMicroseconds, ProfileEvents::KeeperSessionCallbackLockHoldMicroseconds);
+        ProfiledMutexLock lock(session_to_response_callback_mutex, ProfileEvents::KeeperSessionCallbackLockWaitMicroseconds);
         new_session_id_response_callback[request->internal_id]
             = [promise, internal_id = request->internal_id](
                   const Coordination::ZooKeeperResponsePtr & response, Coordination::ZooKeeperRequestPtr /*request*/)

--- a/src/Coordination/KeeperLogStore.cpp
+++ b/src/Coordination/KeeperLogStore.cpp
@@ -7,7 +7,6 @@
 namespace ProfileEvents
 {
     extern const Event KeeperChangelogLockWaitMicroseconds;
-    extern const Event KeeperChangelogLockHoldMicroseconds;
 }
 
 namespace DB
@@ -24,31 +23,31 @@ KeeperLogStore::KeeperLogStore(LogFileSettings log_file_settings, FlushSettings 
 
 uint64_t KeeperLogStore::start_index() const
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.getStartIndex();
 }
 
 void KeeperLogStore::init(uint64_t last_commited_log_index, uint64_t logs_to_keep)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     changelog.readChangelogAndInitWriter(last_commited_log_index, logs_to_keep);
 }
 
 uint64_t KeeperLogStore::next_slot() const
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.getNextEntryIndex();
 }
 
 nuraft::ptr<nuraft::log_entry> KeeperLogStore::last_entry() const
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.getLastEntry();
 }
 
 uint64_t KeeperLogStore::append(nuraft::ptr<nuraft::log_entry> & entry)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     uint64_t idx = changelog.getNextEntryIndex();
     changelog.appendEntry(idx, entry);
     return idx;
@@ -57,93 +56,93 @@ uint64_t KeeperLogStore::append(nuraft::ptr<nuraft::log_entry> & entry)
 
 void KeeperLogStore::write_at(uint64_t index, nuraft::ptr<nuraft::log_entry> & entry)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     changelog.writeAt(index, entry);
 }
 
 nuraft::ptr<std::vector<nuraft::ptr<nuraft::log_entry>>> KeeperLogStore::log_entries(uint64_t start, uint64_t end)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.getLogEntriesBetween(start, end);
 }
 
 nuraft::ptr<std::vector<nuraft::ptr<nuraft::log_entry>>>
 KeeperLogStore::log_entries_ext(uint64_t start, uint64_t end, int64_t batch_size_hint_in_bytes)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.getLogEntriesBetween(start, end, batch_size_hint_in_bytes);
 }
 
 nuraft::ptr<nuraft::log_entry> KeeperLogStore::entry_at(uint64_t index)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.entryAt(index);
 }
 
 bool KeeperLogStore::is_conf(uint64_t index)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.isConfigLog(index);
 }
 
 uint64_t KeeperLogStore::term_at(uint64_t index)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.termAt(index);
 }
 
 nuraft::ptr<nuraft::buffer> KeeperLogStore::pack(uint64_t index, int32_t cnt)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.serializeEntriesToBuffer(index, cnt);
 }
 
 bool KeeperLogStore::compact(uint64_t last_log_index)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     changelog.compact(last_log_index);
     return true;
 }
 
 bool KeeperLogStore::flush()
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.flush();
 }
 
 void KeeperLogStore::apply_pack(uint64_t index, nuraft::buffer & pack)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     changelog.applyEntriesFromBuffer(index, pack);
 }
 
 uint64_t KeeperLogStore::size() const
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.size();
 }
 
 void KeeperLogStore::end_of_append_batch(uint64_t /*start_index*/, uint64_t /*count*/)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     changelog.flushAsync();
 }
 
 nuraft::ptr<nuraft::log_entry> KeeperLogStore::getLatestConfigChange() const
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.getLatestConfigChange();
 }
 
 void KeeperLogStore::shutdownChangelog()
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     changelog.shutdown();
 }
 
 bool KeeperLogStore::flushChangelogAndShutdown()
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     if (changelog.isInitialized())
         changelog.flush();
     changelog.shutdown();
@@ -152,19 +151,19 @@ bool KeeperLogStore::flushChangelogAndShutdown()
 
 uint64_t KeeperLogStore::last_durable_index()
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     return changelog.lastDurableIndex();
 }
 
 void KeeperLogStore::setRaftServer(const nuraft::ptr<nuraft::raft_server> & raft_server)
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     changelog.setRaftServer(raft_server);
 }
 
 void KeeperLogStore::getKeeperLogInfo(KeeperLogInfo & log_info) const
 {
-    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds, ProfileEvents::KeeperChangelogLockHoldMicroseconds);
+    ProfiledMutexLock lock(changelog_lock, ProfileEvents::KeeperChangelogLockWaitMicroseconds);
     changelog.getKeeperLogInfo(log_info);
 }
 

--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -53,7 +53,6 @@
 namespace ProfileEvents
 {
     extern const Event KeeperServerWriteLockWaitMicroseconds;
-    extern const Event KeeperServerWriteLockHoldMicroseconds;
 }
 
 namespace DB
@@ -480,7 +479,7 @@ void KeeperServer::forceRecovery()
 {
     // notify threads containing the lock that we want to enter recovery mode
     is_recovering = true;
-    ProfiledMutexLock lock(server_write_mutex, ProfileEvents::KeeperServerWriteLockWaitMicroseconds, ProfileEvents::KeeperServerWriteLockHoldMicroseconds);
+    ProfiledMutexLock lock(server_write_mutex, ProfileEvents::KeeperServerWriteLockWaitMicroseconds);
     auto params = raft_instance->get_current_params();
     enterRecoveryMode(params);
     raft_instance->setConfig(state_manager->load_config());
@@ -738,7 +737,7 @@ RaftAppendResult KeeperServer::putRequestBatch(const KeeperRequestsForSessions &
     for (const auto & request_for_session : requests_for_sessions)
         entries.push_back(IKeeperStateMachine::getZooKeeperLogEntry(request_for_session));
 
-    ProfiledMutexLock lock(server_write_mutex, ProfileEvents::KeeperServerWriteLockWaitMicroseconds, ProfileEvents::KeeperServerWriteLockHoldMicroseconds);
+    ProfiledMutexLock lock(server_write_mutex, ProfileEvents::KeeperServerWriteLockWaitMicroseconds);
     if (is_recovering)
         return nullptr;
 
@@ -1140,7 +1139,7 @@ KeeperServer::ConfigUpdateState KeeperServer::applyConfigUpdate(
     const ClusterUpdateAction & action, bool last_command_was_leader_change)
 {
     using enum ConfigUpdateState;
-    ProfiledMutexLock _(server_write_mutex, ProfileEvents::KeeperServerWriteLockWaitMicroseconds, ProfileEvents::KeeperServerWriteLockHoldMicroseconds);
+    ProfiledMutexLock _(server_write_mutex, ProfileEvents::KeeperServerWriteLockWaitMicroseconds);
 
     if (const auto * add = std::get_if<AddRaftServer>(&action))
     {
@@ -1210,7 +1209,7 @@ ClusterUpdateActions KeeperServer::getRaftConfigurationDiff(const Poco::Util::Ab
 
     if (!diff.empty())
     {
-        ProfiledMutexLock lock(server_write_mutex, ProfileEvents::KeeperServerWriteLockWaitMicroseconds, ProfileEvents::KeeperServerWriteLockHoldMicroseconds);
+        ProfiledMutexLock lock(server_write_mutex, ProfileEvents::KeeperServerWriteLockWaitMicroseconds);
         last_local_config = state_manager->parseServersConfiguration(config, true, coordination_settings[CoordinationSetting::async_replication]).cluster_config;
     }
 
@@ -1219,8 +1218,7 @@ ClusterUpdateActions KeeperServer::getRaftConfigurationDiff(const Poco::Util::Ab
 
 void KeeperServer::applyConfigUpdateWithReconfigDisabled(const ClusterUpdateAction& action)
 {
-    ProfiledMutexLock server_write_lock(
-        server_write_mutex, ProfileEvents::KeeperServerWriteLockWaitMicroseconds, ProfileEvents::KeeperServerWriteLockHoldMicroseconds);
+    ProfiledMutexLock server_write_lock(server_write_mutex, ProfileEvents::KeeperServerWriteLockWaitMicroseconds);
     if (is_recovering) return;
     constexpr auto sleep_time = 500ms;
 

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -42,11 +42,8 @@ namespace ProfileEvents
     extern const Event KeeperReadSnapshot;
     extern const Event KeeperSaveSnapshot;
     extern const Event KeeperStorageLockWaitMicroseconds;
-    extern const Event KeeperStorageLockHoldMicroseconds;
     extern const Event KeeperStorageSharedLockWaitMicroseconds;
-    extern const Event KeeperStorageSharedLockHoldMicroseconds;
     extern const Event KeeperProcessAndResponsesLockWaitMicroseconds;
-    extern const Event KeeperProcessAndResponsesLockHoldMicroseconds;
 }
 
 namespace CurrentMetrics
@@ -220,10 +217,10 @@ void assertDigest(
 /// Macros to construct timed lock guards for storage_mutex with appropriate ProfileEvents.
 /// We cannot use a factory function because TSA does not track lock ownership across function boundaries.
 #define KEEPER_STORAGE_LOCK_EXCLUSIVE(name) \
-    ProfiledExclusiveLock name(storage_mutex, ProfileEvents::KeeperStorageLockWaitMicroseconds, ProfileEvents::KeeperStorageLockHoldMicroseconds)
+    ProfiledExclusiveLock name(storage_mutex, ProfileEvents::KeeperStorageLockWaitMicroseconds)
 
 #define KEEPER_STORAGE_LOCK_SHARED(name) \
-    ProfiledSharedLock name(storage_mutex, ProfileEvents::KeeperStorageSharedLockWaitMicroseconds, ProfileEvents::KeeperStorageSharedLockHoldMicroseconds)
+    ProfiledSharedLock name(storage_mutex, ProfileEvents::KeeperStorageSharedLockWaitMicroseconds)
 
 union XidHelper
 {
@@ -686,7 +683,7 @@ nuraft::ptr<nuraft::buffer> KeeperStateMachine<Storage>::commit(const uint64_t l
 
             {
                 KEEPER_STORAGE_LOCK_SHARED(lock);
-                ProfiledMutexLock response_lock(process_and_responses_lock, ProfileEvents::KeeperProcessAndResponsesLockWaitMicroseconds, ProfileEvents::KeeperProcessAndResponsesLockHoldMicroseconds);
+                ProfiledMutexLock response_lock(process_and_responses_lock, ProfileEvents::KeeperProcessAndResponsesLockWaitMicroseconds);
                 KeeperResponsesForSessions responses_for_sessions
                     = storage->processRequest(request_for_session->request, request_for_session->session_id, request_for_session->zxid);
                 for (auto & response_for_session : responses_for_sessions)
@@ -1064,7 +1061,7 @@ void KeeperStateMachine<Storage>::processReadRequest(const KeeperRequestForSessi
     /// Pure local request, just process it with storage
     {
         KEEPER_STORAGE_LOCK_SHARED(storage_lock);
-        ProfiledMutexLock response_lock(process_and_responses_lock, ProfileEvents::KeeperProcessAndResponsesLockWaitMicroseconds, ProfileEvents::KeeperProcessAndResponsesLockHoldMicroseconds);
+        ProfiledMutexLock response_lock(process_and_responses_lock, ProfileEvents::KeeperProcessAndResponsesLockWaitMicroseconds);
         auto responses = storage->processRequest(
             request_for_session.request, request_for_session.session_id, std::nullopt, true /*check_acl*/, true /*is_local*/);
         for (auto & response_for_session : responses)

--- a/src/Dictionaries/CacheDictionary.cpp
+++ b/src/Dictionaries/CacheDictionary.cpp
@@ -25,9 +25,7 @@ namespace ProfileEvents
     extern const Event DictCacheRequestTimeNs;
     extern const Event DictCacheRequests;
     extern const Event DictCacheLockWriteNs;
-    extern const Event DictCacheLockWriteHoldNs;
     extern const Event DictCacheLockReadNs;
-    extern const Event DictCacheLockReadHoldNs;
 }
 
 namespace CurrentMetrics
@@ -79,7 +77,7 @@ CacheDictionary<dictionary_key_type>::~CacheDictionary()
 template <DictionaryKeyType dictionary_key_type>
 size_t CacheDictionary<dictionary_key_type>::getElementCount() const
 {
-    const ProfiledSharedLock read_lock{rw_lock, ProfileEvents::DictCacheLockReadNs, ProfileEvents::DictCacheLockReadHoldNs};
+    const ProfiledSharedLock read_lock{rw_lock, ProfileEvents::DictCacheLockReadNs};
     return cache_storage_ptr->getSize();
 }
 
@@ -89,21 +87,21 @@ size_t CacheDictionary<dictionary_key_type>::getBytesAllocated() const
     /// In case of existing string arena we check the size of it.
     /// But the same appears in setAttributeValue() function, which is called from update() function
     /// which in turn is called from another thread.
-    const ProfiledSharedLock read_lock{rw_lock, ProfileEvents::DictCacheLockReadNs, ProfileEvents::DictCacheLockReadHoldNs};
+    const ProfiledSharedLock read_lock{rw_lock, ProfileEvents::DictCacheLockReadNs};
     return cache_storage_ptr->getBytesAllocated();
 }
 
 template <DictionaryKeyType dictionary_key_type>
 double CacheDictionary<dictionary_key_type>::getLoadFactor() const
 {
-    const ProfiledSharedLock read_lock{rw_lock, ProfileEvents::DictCacheLockReadNs, ProfileEvents::DictCacheLockReadHoldNs};
+    const ProfiledSharedLock read_lock{rw_lock, ProfileEvents::DictCacheLockReadNs};
     return cache_storage_ptr->getLoadFactor();
 }
 
 template <DictionaryKeyType dictionary_key_type>
 std::exception_ptr CacheDictionary<dictionary_key_type>::getLastException() const
 {
-    const ProfiledSharedLock read_lock{rw_lock, ProfileEvents::DictCacheLockReadNs, ProfileEvents::DictCacheLockReadHoldNs};
+    const ProfiledSharedLock read_lock{rw_lock, ProfileEvents::DictCacheLockReadNs};
     return last_exception;
 }
 
@@ -180,7 +178,7 @@ Columns CacheDictionary<dictionary_key_type>::getColumns(
         default_mask= &std::get<RefFilter>(defaults_or_filter).get();
 
     {
-        const ProfiledSharedLock read_lock{rw_lock, ProfileEvents::DictCacheLockReadNs, ProfileEvents::DictCacheLockReadHoldNs};
+        const ProfiledSharedLock read_lock{rw_lock, ProfileEvents::DictCacheLockReadNs};
         result_of_fetch_from_storage = cache_storage_ptr->fetchColumnsForKeys(keys, request, default_mask);
     }
 
@@ -291,7 +289,7 @@ ColumnUInt8::Ptr CacheDictionary<dictionary_key_type>::hasKeys(const Columns & k
     FetchResult result_of_fetch_from_storage;
 
     {
-        const ProfiledSharedLock read_lock{rw_lock, ProfileEvents::DictCacheLockReadNs, ProfileEvents::DictCacheLockReadHoldNs};
+        const ProfiledSharedLock read_lock{rw_lock, ProfileEvents::DictCacheLockReadNs};
         result_of_fetch_from_storage = cache_storage_ptr->fetchColumnsForKeys(keys, request, /*default_mask*/ nullptr);
     }
 
@@ -547,7 +545,7 @@ Pipe CacheDictionary<dictionary_key_type>::read(const Names & column_names, size
 
     {
         /// Write lock on storage
-        const ProfiledExclusiveLock write_lock{rw_lock, ProfileEvents::DictCacheLockWriteNs, ProfileEvents::DictCacheLockWriteHoldNs};
+        const ProfiledExclusiveLock write_lock{rw_lock, ProfileEvents::DictCacheLockWriteNs};
         if constexpr (dictionary_key_type == DictionaryKeyType::Simple)
         {
             auto keys = cache_storage_ptr->getCachedSimpleKeys();
@@ -700,7 +698,7 @@ void CacheDictionary<dictionary_key_type>::update(CacheDictionaryUpdateUnitPtr<d
 
             {
                 /// Lock for cache modification
-                ProfiledExclusiveLock write_lock{rw_lock, ProfileEvents::DictCacheLockWriteNs, ProfileEvents::DictCacheLockWriteHoldNs};
+                ProfiledExclusiveLock write_lock{rw_lock, ProfileEvents::DictCacheLockWriteNs};
                 cache_storage_ptr->insertColumnsForKeys(found_keys_in_source, fetched_columns_during_update);
                 cache_storage_ptr->insertDefaultKeys(not_found_keys_in_source);
 
@@ -714,7 +712,7 @@ void CacheDictionary<dictionary_key_type>::update(CacheDictionaryUpdateUnitPtr<d
         catch (...)
         {
             /// Lock just for last_exception safety
-            ProfiledExclusiveLock write_lock{rw_lock, ProfileEvents::DictCacheLockWriteNs, ProfileEvents::DictCacheLockWriteHoldNs};
+            ProfiledExclusiveLock write_lock{rw_lock, ProfileEvents::DictCacheLockWriteNs};
             ++error_count;
             last_exception = std::current_exception();
             backoff_end_time = now + std::chrono::seconds(calculateDurationWithBackoff(rnd_engine, error_count));


### PR DESCRIPTION
Reduce the overhead of `ProfiledMutexLock`, `ProfiledExclusiveLock`, and `ProfiledSharedLock` by eliminating hold-time measurement and only timing contention when it actually occurs.

Previously, every lock acquisition created a `Stopwatch`, measured wait-time unconditionally, and then tracked hold-time with a second `Stopwatch` until unlock. This added overhead even when locks were uncontended (the common case).

Now the guards use `try_lock` first: if the lock is acquired immediately (no contention), no timing is performed at all — zero overhead on the fast path. Only when `try_lock` fails does a `Stopwatch` measure the actual contention wait-time. Hold-time tracking is removed entirely.

This reduces the per-lock overhead from two `Stopwatch` instances + two `ProfileEvents::increment` calls to zero in the uncontended case, and one `Stopwatch` + one `increment` in the contended case.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduce profiled lock overhead by using `try_lock` to avoid timing uncontended acquisitions and removing hold-time measurement.

cc @filimonov 

Ref https://github.com/ClickHouse/ClickHouse/pull/99751#issuecomment-4144173145

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.534`
<!-- ch-version-info:end -->