### PR TITLE
Fix flaky test 02918_optimize_count_for_merge_tables

### DIFF
--- a/tests/queries/0_stateless/02918_optimize_count_for_merge_tables.sql
+++ b/tests/queries/0_stateless/02918_optimize_count_for_merge_tables.sql
@@ -20,7 +20,9 @@ SET apply_patch_parts = 0;
 SELECT count() FROM merge;
 
 -- can use the trivial count optimization
-EXPLAIN SELECT count() FROM merge settings enable_analyzer=0;
+-- Pin query_plan_merge_expressions: when disabled (randomized by CI), Expression steps
+-- are shown separately ("Projection" + "Before ORDER BY") instead of merged, breaking the reference.
+EXPLAIN SELECT count() FROM merge settings enable_analyzer=0, query_plan_merge_expressions=1;
 
 CREATE TABLE mt3 (id UInt64) ENGINE = TinyLog;
 
@@ -29,7 +31,7 @@ INSERT INTO mt2 VALUES (2);
 SELECT count() FROM merge;
 
 -- can't use the trivial count optimization as TinyLog doesn't support it
-EXPLAIN SELECT count() FROM merge settings enable_analyzer=0;
+EXPLAIN SELECT count() FROM merge settings enable_analyzer=0, query_plan_merge_expressions=1;
 
 DROP TABLE IF EXISTS mt1;
 DROP TABLE IF EXISTS mt2;


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Not required

### What this PR does

Pin `query_plan_merge_expressions=1` in the EXPLAIN query-level SETTINGS for test `02918_optimize_count_for_merge_tables`.

When CI randomizes `query_plan_merge_expressions` to `False`, the two Expression steps (`Projection` + `Before ORDER BY`) are shown separately instead of merged into one line, causing the EXPLAIN output to diverge from the reference file.

**Root cause:** `query_plan_merge_expressions` controls whether adjacent Expression steps in the query plan are merged into a single step. When disabled, `Expression ((Projection + Before ORDER BY))` becomes two steps: `Expression (Projection)` → `Expression (Before ORDER BY)`.

**Evidence:** 3 of the 14 failures in 30 days (all from PR #100874's settings randomization runs on `arm_asan_ubsan`, `amd_debug`, `amd_asan_ubsan`) had `query_plan_merge_expressions=False` in the randomized settings.

**Fix:** Query-level `SETTINGS query_plan_merge_expressions=1` overrides the session-level randomized value, ensuring deterministic EXPLAIN output. The test's purpose (verifying trivial count optimization for Merge-engine tables) is fully preserved.

**Verified:** 100/100 passes with full randomization locally.