### PR TITLE
Add support to auto-detect region for s3express endpoint

### DIFF
--- a/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/S3/diskSettings.cpp
@@ -90,7 +90,6 @@ namespace S3RequestSetting
 
 namespace ErrorCodes
 {
-extern const int NO_ELEMENTS_IN_CONFIG;
 extern const int BAD_ARGUMENTS;
 }
 
@@ -117,12 +116,6 @@ getClient(const S3::URI & url, const S3Settings & settings, ContextPtr context, 
     const auto & request_settings = settings.request_settings;
 
     const bool is_s3_express_bucket = S3::isS3ExpressEndpoint(url.endpoint);
-    if (is_s3_express_bucket && auth_settings[S3AuthSetting::region].value.empty())
-    {
-        throw Exception(
-            ErrorCodes::NO_ELEMENTS_IN_CONFIG,
-            "Region should be explicitly specified for directory buckets");
-    }
 
     const Settings & local_settings = context->getSettingsRef();
 

--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -165,6 +165,7 @@ void PocoHTTPClientConfiguration::updateSchemeAndRegion()
     if (!endpointOverride.empty())
     {
         static const RE2 region_pattern(R"(^s3[.\-]([a-z0-9\-]+)\.amazonaws\.)");
+        static const RE2 s3express_region_pattern(R"(^s3express(?:-[a-z0-9\-]+)?(?:\.dualstack)?\.([a-z0-9\-]+)\.amazonaws\.)");
         Poco::URI uri(endpointOverride);
         if (uri.getScheme() == "http")
             scheme = Aws::Http::Scheme::HTTP;
@@ -172,7 +173,9 @@ void PocoHTTPClientConfiguration::updateSchemeAndRegion()
         if (force_region.empty())
         {
             String matched_region;
-            if (re2::RE2::PartialMatch(uri.getHost(), region_pattern, &matched_region))
+            if (
+                re2::RE2::PartialMatch(uri.getHost(), region_pattern, &matched_region)
+                || re2::RE2::PartialMatch(uri.getHost(), s3express_region_pattern, &matched_region))
             {
                 boost::algorithm::to_lower(matched_region);
                 region = matched_region;

--- a/src/IO/S3/tests/gtest_aws_s3_client.cpp
+++ b/src/IO/S3/tests/gtest_aws_s3_client.cpp
@@ -329,6 +329,53 @@ TEST(IOTestAwsS3Client, ChecksumHeaderIsPresentForS3Express)
         /*is_s3express_bucket=*/true);
 }
 
+TEST(IOTestAwsS3Client, DetectRegionFromS3ExpressEndpoint)
+{
+    DB::RemoteHostFilter remote_host_filter;
+    unsigned int s3_max_redirects = 100;
+    unsigned int s3_retry_attempts = 0;
+    bool s3_slow_all_threads_after_network_error = true;
+    bool s3_slow_all_threads_after_retryable_error = true;
+    bool enable_s3_requests_logging = false;
+    DB::S3::URI uri("https://test-perf-bucket--eun1-az1--x-s3.s3express-eun1-az1.eu-north-1.amazonaws.com/test.csv");
+
+    DB::S3::PocoHTTPClientConfiguration client_configuration = DB::S3::ClientFactory::instance().createClientConfiguration(
+        /*force_region=*/"",
+        remote_host_filter,
+        s3_max_redirects,
+        DB::S3::PocoHTTPClientConfiguration::RetryStrategy{.max_retries = s3_retry_attempts},
+        s3_slow_all_threads_after_network_error,
+        s3_slow_all_threads_after_retryable_error,
+        enable_s3_requests_logging,
+        /* for_disk_s3 = */ false,
+        /* opt_disk_name = */ {},
+        /* request_throttler = */ {},
+        "https");
+
+    client_configuration.endpointOverride = uri.endpoint;
+
+    DB::HTTPHeaderEntries headers;
+    DB::S3::ClientSettings client_settings{
+        .use_virtual_addressing = uri.is_virtual_hosted_style,
+        .disable_checksum = false,
+        .gcs_issue_compose_request = false,
+        .is_s3express_bucket = DB::S3::isS3ExpressEndpoint(uri.endpoint),
+    };
+
+    std::shared_ptr<DB::S3::Client> client = DB::S3::ClientFactory::instance().create(
+        client_configuration,
+        client_settings,
+        /*access_key_id=*/"ACCESS_KEY_ID",
+        /*secret_access_key=*/"SECRET_ACCESS_KEY",
+        /*server_side_encryption_customer_key_base64=*/"",
+        {},
+        headers,
+        DB::S3::CredentialsConfiguration{});
+
+    ASSERT_TRUE(client);
+    EXPECT_EQ(client->getRegion(), "eu-north-1");
+}
+
 namespace
 {
 


### PR DESCRIPTION
### Changelog category (leave one):

- Improvement



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add support to auto-detect region for s3express endpoint

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.220`
<!-- ch-version-info:end -->