### PR TITLE
Fix flaky test 03801_materialized_cte

### DIFF
--- a/tests/queries/0_stateless/03801_materialized_cte.sql
+++ b/tests/queries/0_stateless/03801_materialized_cte.sql
@@ -6,6 +6,7 @@ SET enable_materialized_cte = 1;
 SET optimize_group_by_function_keys = 1;
 SET query_plan_use_logical_join_step = 1; -- canonical name; runner may inject 0 via alias, breaking Post Join Actions in second EXPLAIN
 SET enable_join_runtime_filters = 1; -- reference includes BuildRuntimeFilter node in first EXPLAIN
+SET query_plan_merge_expressions = 1; -- EXPLAIN output changes when adjacent Expression steps are not merged
 
 CREATE TABLE users (uid Int16, name String, age Int16) ENGINE=Memory;
 


### PR DESCRIPTION
Pin `query_plan_merge_expressions = 1` because this test uses EXPLAIN which
outputs different Expression step descriptions depending on whether adjacent
expression steps are merged. When randomized to 0 by the CI test runner,
merged descriptions like `(Project names + Projection)` split into separate
steps, causing a reference file mismatch.

The test verifies materialized CTE functionality (query tree structure,
plan layout, execution results), not expression merging behavior — so
pinning this setting preserves the test's intent.

57 failures across 23 PRs in 30 days. Previous fix PR #100384 (by
@alexey-milovidov) addressed node ID instability and `optimize_group_by_function_keys`
but did not pin `query_plan_merge_expressions`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)