### PR TITLE
Add backport system documentation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,6 +4,8 @@ Do not commit to the master branch. Create a new branch for every task.
 
 When writing text such as documentation, comments, or commit messages, wrap literal names from ClickHouse SQL language, classes and functions, or literal excerpts from log messages inside inline code blocks, such as: `MergeTree`.
 
+When adding headers to documentation files under `docs/`, every header must include an explicit anchor in the form `{#kebab-case-anchor}` at the end of the header line, e.g. `## My Section {#my-section}`. This is mandatory for all heading levels.
+
 When writing text such as documentation, comments, or commit messages, write names of functions and methods as `f` instead of `f()` - we prefer it for mathematical purity when it refers a function itself rather than its application.
 
 When mentioning logical errors, say "exception" instead of "crash", because they don't crash the server in the release build.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,7 +4,7 @@ Do not commit to the master branch. Create a new branch for every task.
 
 When writing text such as documentation, comments, or commit messages, wrap literal names from ClickHouse SQL language, classes and functions, or literal excerpts from log messages inside inline code blocks, such as: `MergeTree`.
 
-When adding headers to documentation files under `docs/`, every header must include an explicit anchor in the form `{#kebab-case-anchor}` at the end of the header line, e.g. `## My Section {#my-section}`. This is mandatory for all heading levels.
+When adding headers to documentation files under `docs/`, every header must include an explicit anchor in the form `{#kebab-case-anchor}` at the end of the header line, e.g. `## My Section {#my-section}`. This is mandatory for all heading levels. New documentation files must also include a frontmatter block at the top (before the first heading) with `description`, `sidebar_label`, `sidebar_position`, `slug`, `title`, and `doc_type` fields, modelled on existing files such as `docs/en/development/continuous-integration.md`.
 
 When writing text such as documentation, comments, or commit messages, write names of functions and methods as `f` instead of `f()` - we prefer it for mathematical purity when it refers a function itself rather than its application.
 

--- a/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
+++ b/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
@@ -3617,7 +3617,7 @@ hardcoded
 kiegroup
 Lodash
 OpenJDK
-PR
+PR's
 PyGithub
 PyPI
 rollout

--- a/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
+++ b/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3606 
+personal_ws-1.1 en 3625
 AArch
 ABIs
 ACLs

--- a/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
+++ b/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
@@ -3617,7 +3617,7 @@ hardcoded
 kiegroup
 Lodash
 OpenJDK
-PR's
+PR
 PyGithub
 PyPI
 rollout

--- a/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
+++ b/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3603
+personal_ws-1.1 en 3606 
 AArch
 ABIs
 ACLs
@@ -1280,6 +1280,7 @@ VIEWs
 Vadim
 Valgrind
 ValueType
+VarUInt
 VectorScan
 Vectorized
 VersionBadge
@@ -1527,9 +1528,9 @@ basename
 bcrypt
 bcrypt's
 bech
+beeterty
 benchmarked
 benchmarking
-beeterty
 bfloat
 bigrams
 binlog
@@ -2946,8 +2947,8 @@ reinterpretAsString
 reinterpretAsUInt
 reinterpretAsUUID
 remerge
-removeDiacriticsUTF
 remoteSecure
+removeDiacriticsUTF
 repivot
 replaceAll
 replaceOne
@@ -3533,7 +3534,6 @@ varpop
 varpopstable
 varsamp
 varsampstable
-VarUInt
 vectorized
 vectorscan
 vendoring
@@ -3605,3 +3605,22 @@ znodes
 zookeeperSessionUptime
 zstd
 zxid
+assignees
+Assignees
+backport
+Backport
+backporting
+backports
+Codeberg
+Distributable
+hardcoded
+kiegroup
+Lodash
+OpenJDK
+PR's
+PyGithub
+PyPI
+rollout
+Skara
+sorenlouv
+tibdex

--- a/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
+++ b/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 3625
+personal_ws-1.1 en 3617
 AArch
 ABIs
 ACLs
@@ -3611,16 +3611,8 @@ backport
 Backport
 backporting
 backports
-Codeberg
 Distributable
-hardcoded
-kiegroup
-Lodash
-OpenJDK
 PR's
 PyGithub
 PyPI
 rollout
-Skara
-sorenlouv
-tibdex

--- a/docs/en/development/backports.md
+++ b/docs/en/development/backports.md
@@ -1,0 +1,178 @@
+# Backport System
+
+This document describes the ClickHouse backport policy and the automated sistem that implements it.
+
+## Release Model
+
+ClickHouse versions follow the scheme `YY.M.patch.build-type`, where `YY` is the two-digit year, `M` is the release month (no leading zero), `patch` is the patch number within the branch, and `type` is either `stable` or `lts`.
+
+Example: `25.3.8.23-lts` — March 2025 LTS, eighth patch.
+
+There are two release tracks:
+
+- **Stable** releases are published roughly monthly. The three most recent stable releases receive patches, giving approximately three months of active support per release.
+- **LTS (Long-Term Support)** releases are published in March and August each year. Two LTS versions are supported simultaneously, each for at least 12 months.
+
+Users running production workloads are encouraged to use either the latest stable or an LTS release, and to upgrade to new patch versions promptly, as patch releses do not introduce breaking changes.
+
+## Backport Policy
+
+Not all changes are backported. The goal is to keep releese branches stable, so the scope of backports is intentionally narrow:
+
+- **Security fixes** — always backported.
+- **Critical bug fixes** (crashes, data loss, wrong results, RBAC issues) — always backported; identified by the `pr-critical-bugfix` label, which triggers backporting automatically.
+- **Stability and regression fixes** — backported when the risk of the change is low relative to the risk of leaving the bug in place; identified by `pr-must-backport` added manually by maintainers.
+- **Minor bug fixes with an available workaround** — generally not backported to avoid destabilising release branches.
+- **New features, improvements, performance work** — not backported.
+
+The label `pr-must-backport` is the manual override used by maintainers to mark a PR for backporting. The label `pr-critical-bugfix` causes `pr-must-backport` to be added automatically by the CI hook (see `pr_labels_and_category.py`).
+
+**Conflict escalation.** When automatic backporting cannot resolve merge conflicts, a cherry-pick PR must still be created and assigned to the author, merger, and existing assignees of the original PR so that a human can resolve the conflicts and complete the backport.
+
+**Delay policy.** By default, a merged PR is not backported immediately. The automation waits 7 days after the merge before creating backport branches. This grace period allows a bad commit to be reverted on the master branch before the backport machinery engages, avoiding the extra work of backporting a change that will be reverted anyway.
+
+## Backport Tool
+
+The backport policy described above is implemented by the automated tool in `tests/ci/cherry_pick.py`. The tool runs as a GitHub Actions workflow on ClickHouse infrastucture and covers all the requirements: discovering active release branches, selecting PRs that qualify for backporting, performing the two-stage cherry-pick and backport procedure, managing conflicts, enforcing the delay policy, and keeping labels in sync.
+
+The long-term goal is to extract this implementation into a standalone open-source Python tool that other projects can adopt. The target design is:
+
+- **Configurable** — all policy parameters (qualifying labels, delay window, stale PR thresholds, rolling-out behaviour, etc.) expressed as a configuration file so the tool can be adapted to match any project's backport requirements without code changes.
+- **Distributable** — packaged as a self-contained Python wheel installable from PyPI, with no dependency on ClickHouse's CI infrastructure.
+- **Programmable** — exposing a clean object model for pull requests, labels, and release branches so that users can script custom workflows on top of the core engine.
+
+## Active Release Branches
+
+An active release brunch is any branch whose corresponding release PR (carrying the `release` label) is still open on GitHub. The backport automation discovers these dynamically on each run, so no configuration changes are needed when a new release is cut or an old one reaches end-of-life.
+
+A release branch can be in a **rolling-out** state (its release PR carries the `rolling-out` label) during the period when a new release is being deployed. General backports are paused for rolling-out branches to avoid complicating the rollout. Version-specific labels (e.g. `v25.3-must-backport`) override this and force backporting even during a rollout.
+
+## Implementation
+
+### Overview
+
+The backport automation runs hourly as the `CherryPick` GitHub Actions workflow (`.github/workflows/cherry_pick.yml`), implemented in `tests/ci/cherry_pick.py`. It operates through the GitHub API and local git operations on a self-hosted `style-checker-aarch64` runner.
+
+The process is two-staged for each (original PR, release branch) pair:
+
+1. A **cherry-pick PR** is created to isolate conflict resolution from the actual merge target. If there are no conflicts, it is merged automatically.
+2. A **backport PR** is created against the real release branch, with the cherry-picked changes squashed into a single commit.
+
+### Labels
+
+Labels on the original PR control whether and where backporting happens.
+
+| Label | Effect |
+|---|---|
+| `pr-must-backport` | Backport to all active release branches (skipping branches marked `rolling-out`) |
+| `pr-must-backport-force` | Backport to all active release branches, ignoring `rolling-out` restrictions |
+| `pr-critical-bugfix` | Triggers `pr-must-backport` automatically (via `AUTO_BACKPORT` in `pr_labels_and_category.py`) |
+| `v{VER}-must-backport` (e.g. `v25.3-must-backport`) | Backport only to that specific release branch; overrides `rolling-out` skip for that branch |
+| `pr-backports-created` | Set by the bot when all required backport PRs have been created; cleared if a cherry-pick PR is reopened |
+| `pr-cherrypick` | Applied to cherry-pick PRs created by the bot |
+| `pr-backport` | Applied to backport PRs created by the bot |
+| `do not test` | Applied to cherry-pick PRs so CI does not run on them |
+| `rolling-out` | Set on a **release PR** to indicate its branch is currently being rolled out; general backports skip it |
+
+### Branch and PR Naming
+
+For each original PR number `N` and release branch `release/X.Y`:
+
+- Cherry-pick branch: `cherrypick/release/X.Y/N`
+- Backport branch: `backport/release/X.Y/N`
+- Cherry-pick PR title: `Cherry pick #N to release/X.Y: <original title>`
+- Backport PR title: `Backport #N to release/X.Y: <original title>`
+
+### Step-by-Step Process
+
+#### 1. Discover active releases
+
+`BackportPRs.receive_release_prs` queries GitHub for all open PRs with the `release` label. The head refs of these PRs are the release branch names (e.g. `release/25.3`). A compatibility label set is derived from them: `v25.3-must-backport`, etc.
+
+#### 2. Find PRs to backport
+
+`BackportPRs.receive_prs_for_backport` uses the GitHub search API to find merged PRs that:
+- carry at least one backport label (`pr-must-backport`, `pr-must-backport-force`, `pr-critical-bugfix`, or a version-specific label), and
+- do **not** already have `pr-backports-created`, and
+- were merged after the oldest commit date found on any release branch, and
+- were updated within the last 90 days (to keep the search query efficient).
+
+#### 3. Rolling-out branch handling
+
+When a release PR carries the `rolling-out` label, general backport labels (`pr-must-backport`, `pr-critical-bugfix`) skip that branch. The bot closes any previously created cherry-pick or backport PRs for that branch with an explanatory comment. A version-specific label (e.g. `v25.3-must-backport`) always overrides this. `pr-must-backport-force` bypasses the `rolling-out` check for all branches.
+
+#### 4. Cherry-pick stage (`ReleaseBranch.create_cherrypick`)
+
+For each (original PR, release branch) pair where no cherry-pick PR exists yet:
+
+1. Check out the release branch and create a **backport branch** (`backport/release/X.Y/N`) from it.
+2. Perform `git merge -s ours` against the first parent of the merge commit to create a synthetic merge base with no content changes.
+3. Force-create a **cherry-pick branch** (`cherrypick/release/X.Y/N`) pointing directly at the merge commit of the original PR.
+4. Attempt `git merge --no-commit --no-ff` of the cherry-pick branch into the backport branch:
+   - If already up-to-date, the change is already present in the release branch — mark as done and skip.
+   - Otherwise (with or without conflicts) reset and push both branches.
+5. Create the cherry-pick PR targeting `backport/release/X.Y/N` from `cherrypick/release/X.Y/N`, labelled `pr-cherrypick` and `do not test`.
+6. Propagate `pr-bugfix` or `pr-critical-bugfix` from the original PR if applicable.
+7. Assignees are **not** set at this point; they are only added when conflicts are detected.
+
+#### 5. Auto-merge of conflict-free cherry-pick PRs
+
+If the cherry-pick PR is mergeable (no conflicts), the bot merges it automatically via the GitHub API and proceeds immediately to the backport stage.
+
+#### 6. Backport stage (`ReleaseBranch.create_backport`)
+
+After the cherry-pick PR is merged:
+
+1. Check out and pull the backport branch.
+2. Find the merge-base between the release branch and the backport branch.
+3. `git reset --soft` to the merge-base, squashing all cherry-picked commits into one.
+4. Commit with the backport PR title as the message.
+5. Force-push the backport branch and open a backport PR targeting the real release branch.
+6. Label the PR `pr-backport` (and `pr-bugfix` / `pr-critical-bugfix` if applicable).
+7. Assign the PR to the original PR's author, merger, and existing assignees (excluding robot accounts).
+
+#### 7. Completion
+
+When all release branches for a given original PR are backported, the bot adds `pr-backports-created` to the original PR.
+
+#### 8. Pre-check
+
+Before starting any work on a PR, `ReleaseBranch.pre_check` runs `git merge-base --is-ancestor` to verify the merge commit is not already reachable from the release branch. If it is, the PR is considered already backported and skipped.
+
+### Stale Cherry-pick PR Handling
+
+The `CherryPickPRs` class runs at the start of each hourly execution and handles two scenarios:
+
+- **Orphaned cherry-pick PRs**: If a cherry-pick PR's release branch no longer has an open release PR (i.e. the release is closed), the cherry-pick PR is closed automatically.
+- **Reopened cherry-pick PRs**: If an original PR already has `pr-backports-created` but a cherry-pick PR for it is still open, the `pr-backports-created` label is removed from the original PR so it can be reprocessed.
+
+For cherry-pick PRs waiting for manual conflict resolution:
+- After **3 days** of no updates, the bot posts a ping comment mentioning the assignees.
+- After **7 days** of no updates, the bot posts a closing comment and closes the PR.
+
+### Conflict Resolution
+
+When a cherry-pick has conflicts, the cherry-pick PR is left open for a human to resolve. The bot assigns it to the original PR's author, merger, and assignees. After the conflicts are resolved and the cherry-pick PR is merged, the bot creates the backport PR on the next hourly run.
+
+To discard a backport entirely, close the cherry-pick PR. The bot will treat it as intentionally skipped.
+
+To recreate a broken cherry-pick PR from scratch:
+1. Remove the `pr-cherrypick` label from the cherry-pick PR.
+2. Delete the `cherrypick/...` branch.
+3. Remove `pr-backports-created` from the original PR if present.
+
+### CI for Backport PRs
+
+Backport PRs target release branches, so they use a dedicated CI workflow (`BackportPR`, defined in `ci/workflows/backport_branches.py`) rather than the standard pull request workflow. This workflow runs a representative subset of CI: ASan/UBSan and TSan builds, release builds, macOS builds, functional tests under ASan, stress tests under TSan, and integration tests. It validates that the backport branch has between 1 and 50 commits and at least one changed file (enforced by `check_backport_branch.py`).
+
+### Authentication
+
+The workflow authenticates with an SSH key (`ROBOT_CLICKHOUSE_SSH_KEY`) for git push operations and a GitHub token (`ROBOT_CLICKHOUSE_COMMIT_TOKEN`) for API calls. The `get_best_robot_token` helper selects the token with the most remaining API quota. Robot accounts (`robot-clickhouse`, `clickhouse-gh`) are excluded when assigning reviewers.
+
+### GitHub API Cache
+
+`GitHubCache` (from `cache_utils.py`) persists the PyGithub object cache to S3, reducing API calls across hourly runs. The cache is downloaded at the start and uploaded at the end of each run.
+
+### Error Handling
+
+Errors during individual PR processing are caught and logged but do not stop the run. After all PRs are processed, if any errors occurred, a `BackportException` is raised. In CI, this triggers a notification via `CIBuddy` to the team chat.

--- a/docs/en/development/backports.md
+++ b/docs/en/development/backports.md
@@ -184,7 +184,7 @@ Backport PRs target release branches, so they use a dedicated CI workflow (`Back
 
 ### Authentication {#authentication}
 
-The workflow authenticates with an SSH key (`ROBOT_CLICKHOUSE_SSH_KEY`) for git push operations and a GitHub token (`ROBOT_CLICKHOUSE_COMMIT_TOKEN`) for API calls. The `get_best_robot_token` helper selects the token with the most remaining API quota. Robot accounts (`robot-clickhouse`, `clickhouse-gh`) are excluded when assigning a responsible person.
+The workflow uses an SSH key (`ROBOT_CLICKHOUSE_SSH_KEY`) for git push operations. GitHub API calls are authenticated via `get_best_robot_token`, which selects the token with the most remaining quota from a pool stored in SSM (`/github-tokens`). `ROBOT_CLICKHOUSE_COMMIT_TOKEN` is used by the checkout step in the Actions workflow, not for API calls. Robot accounts (`robot-clickhouse`, `clickhouse-gh`) are excluded when assigning a responsible person.
 
 ### GitHub API Cache {#github-api-cache}
 

--- a/docs/en/development/backports.md
+++ b/docs/en/development/backports.md
@@ -38,8 +38,6 @@ The label `pr-must-backport` is the manual override used by maintainers to mark 
 
 **Conflict escalation.** When automatic backporting cannot resolve merge conflicts, a cherry-pick PR must still be created and assigned to the author, merger, and existing assignees of the original PR so that a human can resolve the conflicts and complete the backport.
 
-**Delay policy.** By default, a merged PR is not backported immediately. The automation waits 7 days after the merge before creating backport branches. This grace period allows a bad commit to be reverted on the master branch before the backport machinery engages, avoiding the extra work of backporting a change that will be reverted anyway. The delay window is configurable and can be set to zero to backport immediately.
-
 ## Backport Tool {#backport-tool}
 
 The backport policy described above is implemented by the automated tool in `tests/ci/cherry_pick.py`. The tool runs as a GitHub Actions workflow on ClickHouse infrastructure and covers all the requirements: discovering active release branches, selecting PRs that qualify for backporting, performing the two-stage cherry-pick and backport procedure, managing conflicts, enforcing the delay policy, and keeping labels in sync.
@@ -49,28 +47,6 @@ The long-term goal is to extract this implementation into a standalone open-sour
 - **Configurable** — all policy parameters (qualifying labels, delay window, stale PR thresholds, rolling-out behaviour, etc.) expressed as a configuration file so the tool can be adapted to match any project's backport requirements without code changes.
 - **Distributable** — packaged as a self-contained Python wheel installable from PyPI, with no dependency on ClickHouse's CI infrastructure.
 - **Programmable** — exposing a clean object model for pull requests, labels, and release branches so that users can script custom workflows on top of the core engine.
-
-### Gaps Compared to Popular Backport Tools {#gaps-compared-to-popular-backport-tools}
-
-Surveying widely-used backport tools (sorenlouv/backport, OpenJDK Skara `git-backport`, kiegroup/git-backporting, tibdex/backport) reveals the following capabilities they provide that the current ClickHouse implementation does not cover and that the standalone tool should address:
-
-- **Project-level configuration file.** All popular tools ship a per-repository config file (`.backportrc.json` or equivalent) that encodes which labels trigger backporting, target branch patterns, PR title and body templates, assignee rules, and so on. The ClickHouse tool has this logic hardcoded and cannot be adopted by other projects without code changes.
-
-- **Configurable label-to-branch mapping.** sorenlouv and kiegroup both use a configurable regex (`branchLabelMapping`, `--target-branch-pattern`) to extract the target release branch from a label name. The ClickHouse tool relies on a fixed naming convention (`v{VER}-must-backport`) and cannot be reconfigured for different label schemes.
-
-- **Configurable PR title and body templates.** Popular tools allow Handlebars or Lodash templates for the backport PR title, body, and branch name, so teams can match their own conventions. The ClickHouse tool produces fixed-format titles (`Backport #N to release/X.Y: …`) with no customisation point.
-
-- **Configurable conflict resolution strategy.** kiegroup exposes `--strategy` and `--strategy-option` for the underlying cherry-pick, allowing auto-resolution with `theirs` as a team policy. The ClickHouse tool always stops at a conflict and waits for a human; there is no option to resolve automatically in favour of the incoming change.
-
-- **Success and failure comments on the original PR.** sorenlouv and kiegroup post a status comment directly on the source PR when a backport succeeds or fails. The ClickHouse tool only pings assignees on stale cherry-pick PRs and posts no feedback on the original PR.
-
-- **Multi-platform support.** kiegroup supports GitHub, GitLab, and Codeberg. The ClickHouse tool is tightly coupled to GitHub's API and branch model.
-
-- **Backport by commit SHA.** sorenlouv and `git-backport` can cherry-pick a specific commit hash rather than a whole merged PR. The ClickHouse tool operates exclusively at the PR level.
-
-- **Forward-porting.** sorenlouv supports porting changes from an older branch to a newer one (e.g. from a release branch back to master). The ClickHouse tool only backports from master to release branches.
-
-- **GitHub Enterprise / self-hosted support.** sorenlouv exposes configurable API base URLs for GitHub Enterprise instances. The ClickHouse tool assumes `github.com`.
 
 ### Testing {#testing}
 

--- a/docs/en/development/backports.md
+++ b/docs/en/development/backports.md
@@ -29,7 +29,7 @@ Users running production workloads are encouraged to use either the latest stabl
 Not all changes are backported. The goal is to keep release branches stable, so the scope of backports is intentionally narrow:
 
 - **Security fixes** — always backported.
-- **Critical bug fixes** (crashes, data loss, wrong results, RBAC issues) — always backported; identified by the `pr-critical-bugfix` label, which triggers backporting automatically.
+- **Critical bug fixes** (exceptions (logical errors), data loss, wrong results, RBAC issues) — always backported; identified by the `pr-critical-bugfix` label, which triggers backporting automatically.
 - **Stability and regression fixes** — backported when the risk of the change is low relative to the risk of leaving the bug in place; identified by `pr-must-backport` added manually by maintainers.
 - **Minor bug fixes with an available workaround** — generally not backported to avoid destabilising release branches.
 - **New features, improvements, performance work** — not backported.

--- a/docs/en/development/backports.md
+++ b/docs/en/development/backports.md
@@ -1,3 +1,12 @@
+---
+description: 'Overview of the ClickHouse backport policy and automation'
+sidebar_label: 'Backport System'
+sidebar_position: 56
+slug: /development/backports
+title: 'Backport System'
+doc_type: 'reference'
+---
+
 # Backport System {#backport-system}
 
 This document describes the ClickHouse backport policy and the automated system that implements it.

--- a/docs/en/development/backports.md
+++ b/docs/en/development/backports.md
@@ -29,7 +29,7 @@ Users running production workloads are encouraged to use either the latest stabl
 Not all changes are backported. The goal is to keep release branches stable, so the scope of backports is intentionally narrow:
 
 - **Security fixes** — always backported.
-- **Critical bug fixes** (exceptions (logical errors), data loss, wrong results, RBAC issues) — always backported; identified by the `pr-critical-bugfix` label, which triggers backporting automatically.
+- **Critical bug fixes** (exceptions (logical errors), data loss, wrong results, RBAC issues) — automatically selected for backporting under the general backport rules; identified by the `pr-critical-bugfix` label, which causes `pr-must-backport` to be added automatically.
 - **Stability and regression fixes** — backported when the risk of the change is low relative to the risk of leaving the bug in place; identified by `pr-must-backport` added manually by maintainers.
 - **Minor bug fixes with an available workaround** — generally not backported to avoid destabilising release branches.
 - **New features, improvements, performance work** — not backported.

--- a/docs/en/development/backports.md
+++ b/docs/en/development/backports.md
@@ -1,12 +1,12 @@
-# Backport System
+# Backport System {#backport-system}
 
 This document describes the ClickHouse backport policy and the automated system that implements it.
 
-## Release Model
+## Release Model {#release-model}
 
-ClickHouse versions follow the scheme `YY.M.patch.build-type`, where `YY` is the two-digit year, `M` is the release month (no leading zero), `patch` is the patch number within the branch, and `type` is either `stable` or `lts`.
+ClickHouse versions follow the scheme `YY.M.patch.build-type`, where `YY` is the two-digit year, `M` is the release month (no leading zero), `patch` is the patch number within the branch, `build` is a monotonically increasing build number, and `type` is either `stable` or `lts`.
 
-Example: `25.3.8.23-lts` — March 2025 LTS, eighth patch.
+Example: `25.3.8.23-lts` — March 2025 LTS, patch 8, build 23.
 
 There are two release tracks:
 
@@ -15,7 +15,7 @@ There are two release tracks:
 
 Users running production workloads are encouraged to use either the latest stable or an LTS release, and to upgrade to new patch versions promptly, as patch releases do not introduce breaking changes.
 
-## Backport Policy
+## Backport Policy {#backport-policy}
 
 Not all changes are backported. The goal is to keep release branches stable, so the scope of backports is intentionally narrow:
 
@@ -29,9 +29,9 @@ The label `pr-must-backport` is the manual override used by maintainers to mark 
 
 **Conflict escalation.** When automatic backporting cannot resolve merge conflicts, a cherry-pick PR must still be created and assigned to the author, merger, and existing assignees of the original PR so that a human can resolve the conflicts and complete the backport.
 
-**Delay policy.** By default, a merged PR is not backported immediately. The automation waits 7 days after the merge before creating backport branches. This grace period allows a bad commit to be reverted on the master branch before the backport machinery engages, avoiding the extra work of backporting a change that will be reverted anyway.
+**Delay policy (optional).** By default, a merged PR is not backported immediately. The automation waits 7 days after the merge before creating backport branches. This grace period allows a bad commit to be reverted on the master branch before the backport machinery engages, avoiding the extra work of backporting a change that will be reverted anyway.
 
-## Backport Tool
+## Backport Tool {#backport-tool}
 
 The backport policy described above is implemented by the automated tool in `tests/ci/cherry_pick.py`. The tool runs as a GitHub Actions workflow on ClickHouse infrastructure and covers all the requirements: discovering active release branches, selecting PRs that qualify for backporting, performing the two-stage cherry-pick and backport procedure, managing conflicts, enforcing the delay policy, and keeping labels in sync.
 
@@ -41,7 +41,7 @@ The long-term goal is to extract this implementation into a standalone open-sour
 - **Distributable** — packaged as a self-contained Python wheel installable from PyPI, with no dependency on ClickHouse's CI infrastructure.
 - **Programmable** — exposing a clean object model for pull requests, labels, and release branches so that users can script custom workflows on top of the core engine.
 
-### Gaps Compared to Popular Backport Tools
+### Gaps Compared to Popular Backport Tools {#gaps-compared-to-popular-backport-tools}
 
 Surveying widely-used backport tools (sorenlouv/backport, OpenJDK Skara `git-backport`, kiegroup/git-backporting, tibdex/backport) reveals the following capabilities they provide that the current ClickHouse implementation does not cover and that the standalone tool should address:
 
@@ -63,7 +63,7 @@ Surveying widely-used backport tools (sorenlouv/backport, OpenJDK Skara `git-bac
 
 - **GitHub Enterprise / self-hosted support.** sorenlouv exposes configurable API base URLs for GitHub Enterprise instances. The ClickHouse tool assumes `github.com`.
 
-### Testing
+### Testing {#testing}
 
 A planned part of the standalone tool is a dedicated test suite together with a lightweight testing infrastructure. The infrastructure will be able to spin up temporary GitHub repositories (or local equivalents) pre-populated with:
 
@@ -73,15 +73,15 @@ A planned part of the standalone tool is a dedicated test suite together with a 
 
 This lets tests exercise the full automation loop — label detection, cherry-pick branch creation, conflict handling, backport PR creation, assignee logic, rolling-out skip, and delay policy — against a real but disposable repository, without touching production state. The same infrastructure can be reused to regression-test policy changes before they are deployed.
 
-## Active Release Branches
+## Active Release Branches {#active-release-branches}
 
 An active release branch is any branch whose corresponding release PR (carrying the `release` label) is still open on GitHub. The backport automation discovers these dynamically on each run, so no configuration changes are needed when a new release is cut or an old one reaches end-of-life.
 
 A release branch can be in a **rolling-out** state (its release PR carries the `rolling-out` label) during the period when a new release is being deployed. General backports are paused for rolling-out branches to avoid complicating the rollout. Version-specific labels (e.g. `v25.3-must-backport`) override this and force backporting even during a rollout.
 
-## Implementation
+## Implementation {#implementation}
 
-### Overview
+### Overview {#overview}
 
 The backport automation runs hourly as the `CherryPick` GitHub Actions workflow (`.github/workflows/cherry_pick.yml`), implemented in `tests/ci/cherry_pick.py`. It operates through the GitHub API and local git operations on a self-hosted `style-checker-aarch64` runner.
 
@@ -90,7 +90,7 @@ The process is two-staged for each (original PR, release branch) pair:
 1. A **cherry-pick PR** is created to isolate conflict resolution from the actual merge target. If there are no conflicts, it is merged automatically.
 2. A **backport PR** is created against the real release branch, with the cherry-picked changes squashed into a single commit.
 
-### Labels
+### Labels {#labels}
 
 Labels on the original PR control whether and where backporting happens.
 
@@ -106,7 +106,7 @@ Labels on the original PR control whether and where backporting happens.
 | `do not test` | Applied to cherry-pick PRs so CI does not run on them |
 | `rolling-out` | Set on a **release PR** to indicate its branch is currently being rolled out; general backports skip it |
 
-### Branch and PR Naming
+### Branch and PR Naming {#branch-and-pr-naming}
 
 For each original PR number `N` and release branch `release/X.Y`:
 
@@ -115,13 +115,13 @@ For each original PR number `N` and release branch `release/X.Y`:
 - Cherry-pick PR title: `Cherry pick #N to release/X.Y: <original title>`
 - Backport PR title: `Backport #N to release/X.Y: <original title>`
 
-### Step-by-Step Process
+### Step-by-Step Process {#step-by-step-process}
 
-#### 1. Discover active releases
+#### 1. Discover active releases {#discover-active-releases}
 
 `BackportPRs.receive_release_prs` queries GitHub for all open PRs with the `release` label. The head refs of these PRs are the release branch names (e.g. `release/25.3`). A compatibility label set is derived from them: `v25.3-must-backport`, etc.
 
-#### 2. Find PRs to backport
+#### 2. Find PRs to backport {#find-prs-to-backport}
 
 `BackportPRs.receive_prs_for_backport` uses the GitHub search API to find merged PRs that:
 - carry at least one backport label (`pr-must-backport`, `pr-must-backport-force`, `pr-critical-bugfix`, or a version-specific label), and
@@ -129,11 +129,11 @@ For each original PR number `N` and release branch `release/X.Y`:
 - were merged after the oldest commit date found on any release branch, and
 - were updated within the last 90 days (to keep the search query efficient).
 
-#### 3. Rolling-out branch handling
+#### 3. Rolling-out branch handling {#rolling-out-branch-handling}
 
 When a release PR carries the `rolling-out` label, general backport labels (`pr-must-backport`, `pr-critical-bugfix`) skip that branch. The bot closes any previously created cherry-pick or backport PRs for that branch with an explanatory comment. A version-specific label (e.g. `v25.3-must-backport`) always overrides this. `pr-must-backport-force` bypasses the `rolling-out` check for all branches.
 
-#### 4. Cherry-pick stage (`ReleaseBranch.create_cherrypick`)
+#### 4. Cherry-pick stage (`ReleaseBranch.create_cherrypick`) {#cherry-pick-stage}
 
 For each (original PR, release branch) pair where no cherry-pick PR exists yet:
 
@@ -147,11 +147,11 @@ For each (original PR, release branch) pair where no cherry-pick PR exists yet:
 6. Propagate `pr-bugfix` or `pr-critical-bugfix` from the original PR if applicable.
 7. Assignees are **not** set at this point; they are only added when conflicts are detected.
 
-#### 5. Auto-merge of conflict-free cherry-pick PRs
+#### 5. Auto-merge of conflict-free cherry-pick PRs {#auto-merge-conflict-free-cherry-pick-prs}
 
 If the cherry-pick PR is mergeable (no conflicts), the bot merges it automatically via the GitHub API and proceeds immediately to the backport stage.
 
-#### 6. Backport stage (`ReleaseBranch.create_backport`)
+#### 6. Backport stage (`ReleaseBranch.create_backport`) {#backport-stage}
 
 After the cherry-pick PR is merged:
 
@@ -163,15 +163,15 @@ After the cherry-pick PR is merged:
 6. Label the PR `pr-backport` (and `pr-bugfix` / `pr-critical-bugfix` if applicable).
 7. Assign the PR to the original PR's author, merger, and existing assignees (excluding robot accounts).
 
-#### 7. Completion
+#### 7. Completion {#completion}
 
 When all release branches for a given original PR are backported, the bot adds `pr-backports-created` to the original PR.
 
-#### 8. Pre-check
+#### 8. Pre-check {#pre-check}
 
 Before starting any work on a PR, `ReleaseBranch.pre_check` runs `git merge-base --is-ancestor` to verify the merge commit is not already reachable from the release branch. If it is, the PR is considered already backported and skipped.
 
-### Stale Cherry-pick PR Handling
+### Stale Cherry-pick PR Handling {#stale-cherry-pick-pr-handling}
 
 The `CherryPickPRs` class runs at the start of each hourly execution and handles two scenarios:
 
@@ -182,7 +182,7 @@ For cherry-pick PRs waiting for manual conflict resolution:
 - After **3 days** of no updates, the bot posts a ping comment mentioning the assignees.
 - After **7 days** of no updates, the bot posts a closing comment and closes the PR.
 
-### Conflict Resolution
+### Conflict Resolution {#conflict-resolution}
 
 When a cherry-pick has conflicts, the cherry-pick PR is left open for a human to resolve. The bot assigns it to the original PR's author, merger, and assignees. After the conflicts are resolved and the cherry-pick PR is merged, the bot creates the backport PR on the next hourly run.
 
@@ -193,18 +193,18 @@ To recreate a broken cherry-pick PR from scratch:
 2. Delete the `cherrypick/...` branch.
 3. Remove `pr-backports-created` from the original PR if present.
 
-### CI for Backport PRs
+### CI for Backport PRs {#ci-for-backport-prs}
 
 Backport PRs target release branches, so they use a dedicated CI workflow (`BackportPR`, defined in `ci/workflows/backport_branches.py`) rather than the standard pull request workflow. This workflow runs a representative subset of CI: ASan/UBSan and TSan builds, release builds, macOS builds, functional tests under ASan, stress tests under TSan, and integration tests. It validates that the backport branch has between 1 and 50 commits and at least one changed file (enforced by `check_backport_branch.py`).
 
-### Authentication
+### Authentication {#authentication}
 
-The workflow authenticates with an SSH key (`ROBOT_CLICKHOUSE_SSH_KEY`) for git push operations and a GitHub token (`ROBOT_CLICKHOUSE_COMMIT_TOKEN`) for API calls. The `get_best_robot_token` helper selects the token with the most remaining API quota. Robot accounts (`robot-clickhouse`, `clickhouse-gh`) are excluded when assigning reviewers.
+The workflow authenticates with an SSH key (`ROBOT_CLICKHOUSE_SSH_KEY`) for git push operations and a GitHub token (`ROBOT_CLICKHOUSE_COMMIT_TOKEN`) for API calls. The `get_best_robot_token` helper selects the token with the most remaining API quota. Robot accounts (`robot-clickhouse`, `clickhouse-gh`) are excluded when assigning a responsible person.
 
-### GitHub API Cache
+### GitHub API Cache {#github-api-cache}
 
 `GitHubCache` (from `cache_utils.py`) persists the PyGithub object cache to S3, reducing API calls across hourly runs. The cache is downloaded at the start and uploaded at the end of each run.
 
-### Error Handling
+### Error Handling {#error-handling}
 
 Errors during individual PR processing are caught and logged but do not stop the run. After all PRs are processed, if any errors occurred, a `BackportException` is raised. In CI, this triggers a notification via `CIBuddy` to the team chat.

--- a/docs/en/development/backports.md
+++ b/docs/en/development/backports.md
@@ -41,6 +41,16 @@ The long-term goal is to extract this implementation into a standalone open-sour
 - **Distributable** — packaged as a self-contained Python wheel installable from PyPI, with no dependency on ClickHouse's CI infrastructure.
 - **Programmable** — exposing a clean object model for pull requests, labels, and release branches so that users can script custom workflows on top of the core engine.
 
+### Testing
+
+A planned part of the standalone tool is a dedicated test suite together with a lightweight testing infrastructure. The infrastructure will be able to spin up temporary GitHub repositories (or local equivalents) pre-populated with:
+
+- a configurable set of branches representing release lines,
+- pull requests carrying various combinations of backport labels,
+- release PRs with the `release` label pointing at the release branches.
+
+This lets tests exercise the full automation loop — label detection, cherry-pick branch creation, conflict handling, backport PR creation, assignee logic, rolling-out skip, and delay policy — against a real but disposable repository, without touching production state. The same infrastructure can be reused to regression-test policy changes before they are deployed.
+
 ## Active Release Branches
 
 An active release brunch is any branch whose corresponding release PR (carrying the `release` label) is still open on GitHub. The backport automation discovers these dynamically on each run, so no configuration changes are needed when a new release is cut or an old one reaches end-of-life.

--- a/docs/en/development/backports.md
+++ b/docs/en/development/backports.md
@@ -1,6 +1,6 @@
 # Backport System
 
-This document describes the ClickHouse backport policy and the automated sistem that implements it.
+This document describes the ClickHouse backport policy and the automated system that implements it.
 
 ## Release Model
 
@@ -13,11 +13,11 @@ There are two release tracks:
 - **Stable** releases are published roughly monthly. The three most recent stable releases receive patches, giving approximately three months of active support per release.
 - **LTS (Long-Term Support)** releases are published in March and August each year. Two LTS versions are supported simultaneously, each for at least 12 months.
 
-Users running production workloads are encouraged to use either the latest stable or an LTS release, and to upgrade to new patch versions promptly, as patch releses do not introduce breaking changes.
+Users running production workloads are encouraged to use either the latest stable or an LTS release, and to upgrade to new patch versions promptly, as patch releases do not introduce breaking changes.
 
 ## Backport Policy
 
-Not all changes are backported. The goal is to keep releese branches stable, so the scope of backports is intentionally narrow:
+Not all changes are backported. The goal is to keep release branches stable, so the scope of backports is intentionally narrow:
 
 - **Security fixes** — always backported.
 - **Critical bug fixes** (crashes, data loss, wrong results, RBAC issues) — always backported; identified by the `pr-critical-bugfix` label, which triggers backporting automatically.
@@ -33,13 +33,35 @@ The label `pr-must-backport` is the manual override used by maintainers to mark 
 
 ## Backport Tool
 
-The backport policy described above is implemented by the automated tool in `tests/ci/cherry_pick.py`. The tool runs as a GitHub Actions workflow on ClickHouse infrastucture and covers all the requirements: discovering active release branches, selecting PRs that qualify for backporting, performing the two-stage cherry-pick and backport procedure, managing conflicts, enforcing the delay policy, and keeping labels in sync.
+The backport policy described above is implemented by the automated tool in `tests/ci/cherry_pick.py`. The tool runs as a GitHub Actions workflow on ClickHouse infrastructure and covers all the requirements: discovering active release branches, selecting PRs that qualify for backporting, performing the two-stage cherry-pick and backport procedure, managing conflicts, enforcing the delay policy, and keeping labels in sync.
 
 The long-term goal is to extract this implementation into a standalone open-source Python tool that other projects can adopt. The target design is:
 
 - **Configurable** — all policy parameters (qualifying labels, delay window, stale PR thresholds, rolling-out behaviour, etc.) expressed as a configuration file so the tool can be adapted to match any project's backport requirements without code changes.
 - **Distributable** — packaged as a self-contained Python wheel installable from PyPI, with no dependency on ClickHouse's CI infrastructure.
 - **Programmable** — exposing a clean object model for pull requests, labels, and release branches so that users can script custom workflows on top of the core engine.
+
+### Gaps Compared to Popular Backport Tools
+
+Surveying widely-used backport tools (sorenlouv/backport, OpenJDK Skara `git-backport`, kiegroup/git-backporting, tibdex/backport) reveals the following capabilities they provide that the current ClickHouse implementation does not cover and that the standalone tool should address:
+
+- **Project-level configuration file.** All popular tools ship a per-repository config file (`.backportrc.json` or equivalent) that encodes which labels trigger backporting, target branch patterns, PR title and body templates, assignee rules, and so on. The ClickHouse tool has this logic hardcoded and cannot be adopted by other projects without code changes.
+
+- **Configurable label-to-branch mapping.** sorenlouv and kiegroup both use a configurable regex (`branchLabelMapping`, `--target-branch-pattern`) to extract the target release branch from a label name. The ClickHouse tool relies on a fixed naming convention (`v{VER}-must-backport`) and cannot be reconfigured for different label schemes.
+
+- **Configurable PR title and body templates.** Popular tools allow Handlebars or Lodash templates for the backport PR title, body, and branch name, so teams can match their own conventions. The ClickHouse tool produces fixed-format titles (`Backport #N to release/X.Y: …`) with no customisation point.
+
+- **Configurable conflict resolution strategy.** kiegroup exposes `--strategy` and `--strategy-option` for the underlying cherry-pick, allowing auto-resolution with `theirs` as a team policy. The ClickHouse tool always stops at a conflict and waits for a human; there is no option to resolve automatically in favour of the incoming change.
+
+- **Success and failure comments on the original PR.** sorenlouv and kiegroup post a status comment directly on the source PR when a backport succeeds or fails. The ClickHouse tool only pings assignees on stale cherry-pick PRs and posts no feedback on the original PR.
+
+- **Multi-platform support.** kiegroup supports GitHub, GitLab, and Codeberg. The ClickHouse tool is tightly coupled to GitHub's API and branch model.
+
+- **Backport by commit SHA.** sorenlouv and `git-backport` can cherry-pick a specific commit hash rather than a whole merged PR. The ClickHouse tool operates exclusively at the PR level.
+
+- **Forward-porting.** sorenlouv supports porting changes from an older branch to a newer one (e.g. from a release branch back to master). The ClickHouse tool only backports from master to release branches.
+
+- **GitHub Enterprise / self-hosted support.** sorenlouv exposes configurable API base URLs for GitHub Enterprise instances. The ClickHouse tool assumes `github.com`.
 
 ### Testing
 
@@ -53,7 +75,7 @@ This lets tests exercise the full automation loop — label detection, cherry-pi
 
 ## Active Release Branches
 
-An active release brunch is any branch whose corresponding release PR (carrying the `release` label) is still open on GitHub. The backport automation discovers these dynamically on each run, so no configuration changes are needed when a new release is cut or an old one reaches end-of-life.
+An active release branch is any branch whose corresponding release PR (carrying the `release` label) is still open on GitHub. The backport automation discovers these dynamically on each run, so no configuration changes are needed when a new release is cut or an old one reaches end-of-life.
 
 A release branch can be in a **rolling-out** state (its release PR carries the `rolling-out` label) during the period when a new release is being deployed. General backports are paused for rolling-out branches to avoid complicating the rollout. Version-specific labels (e.g. `v25.3-must-backport`) override this and force backporting even during a rollout.
 

--- a/docs/en/development/backports.md
+++ b/docs/en/development/backports.md
@@ -29,7 +29,7 @@ The label `pr-must-backport` is the manual override used by maintainers to mark 
 
 **Conflict escalation.** When automatic backporting cannot resolve merge conflicts, a cherry-pick PR must still be created and assigned to the author, merger, and existing assignees of the original PR so that a human can resolve the conflicts and complete the backport.
 
-**Delay policy (optional).** By default, a merged PR is not backported immediately. The automation waits 7 days after the merge before creating backport branches. This grace period allows a bad commit to be reverted on the master branch before the backport machinery engages, avoiding the extra work of backporting a change that will be reverted anyway.
+**Delay policy.** By default, a merged PR is not backported immediately. The automation waits 7 days after the merge before creating backport branches. This grace period allows a bad commit to be reverted on the master branch before the backport machinery engages, avoiding the extra work of backporting a change that will be reverted anyway. The delay window is configurable and can be set to zero to backport immediately.
 
 ## Backport Tool {#backport-tool}
 

--- a/docs/en/development/backports.md
+++ b/docs/en/development/backports.md
@@ -70,7 +70,7 @@ A release branch can be in a **rolling-out** state (its release PR carries the `
 
 The backport automation runs hourly as the `CherryPick` GitHub Actions workflow (`.github/workflows/cherry_pick.yml`), implemented in `tests/ci/cherry_pick.py`. It operates through the GitHub API and local git operations on a self-hosted `style-checker-aarch64` runner.
 
-The process is two-staged for each (original PR, release branch) pair:
+The process is two-stage for each (original PR, release branch) pair:
 
 1. A **cherry-pick PR** is created to isolate conflict resolution from the actual merge target. If there are no conflicts, it is merged automatically.
 2. A **backport PR** is created against the real release branch, with the cherry-picked changes squashed into a single commit.


### PR DESCRIPTION
Add `docs/en/development/backports.md` documenting the ClickHouse backport policy and the automated `cherry_pick.py` tool. Covers the release model, backport eligibility rules, the two-stage cherry-pick/backport procedure, label semantics, stale PR handling, conflict resolution, and CI workflow. Also extends the aspell ignore dictionary with terms used in the new document and adds a CLAUDE.md rule requiring explicit anchors and frontmatter on all documentation headers.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.607`
<!-- ch-version-info:end -->