### PR TITLE
Fix TPC-H and TPC-DS correctness tests OOM on heavy builds

### DIFF
--- a/tests/benchmarks/tpc-ds/settings.json
+++ b/tests/benchmarks/tpc-ds/settings.json
@@ -7,6 +7,7 @@
         "intersect_default_mode": "DISTINCT",
         "joined_subquery_requires_alias": 0,
         "join_use_nulls": 1,
+        "max_memory_usage": 0,
         "union_default_mode": "DISTINCT"
     }
 }

--- a/tests/benchmarks/tpc-h/settings.json
+++ b/tests/benchmarks/tpc-h/settings.json
@@ -1,5 +1,6 @@
 {
     "settings": {
-        "join_use_nulls": 1
+        "join_use_nulls": 1,
+        "max_memory_usage": 0
     }
 }


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- ...

### Summary

TPC-H and TPC-DS correctness tests use complex multi-table joins with `join_use_nulls=1`. Several queries (TPC-H q05/q08, TPC-DS q06) peak near the CI default `max_memory_usage` of 5G (~4.66 GiB).

**Problem:** On coverage and ASAN builds (instrumentation overhead), and when optimizer PRs change join ordering, these queries exceed the memory limit and fail with `MEMORY_LIMIT_EXCEEDED`. This causes spurious CI failures unrelated to the PR's changes.

**Evidence from CIDB:**
- TPC-H q05: 2 master failures on `amd_coverage` in 30 days (genuine trunk issue)
- TPC-H q08: 24 failures across 4 PRs (optimizer PRs #98479, #101398 change join order → OOM)
- TPC-DS q06: 12 failures across 3 PRs (same OOM pattern)

**Fix:** Set `max_memory_usage: 0` (unlimited per-query memory) in both `tpc-h/settings.json` and `tpc-ds/settings.json`. This matches the existing `max_rows_to_read: 0` pattern already used in these test libs. The CI still has process-level memory limits as a safety net.

**What this does NOT change:** The tests still run full TPC queries and validate results against reference files. Test correctness checking is fully preserved.