### PR TITLE
CI: remove experimental result file mechanism from runner

### DIFF
--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -111,11 +111,8 @@ class Result(MetaClasses.Serializable):
                 "WARNING: No results and no status provided - setting status to error"
             )
             status = Result.Status.ERROR
-        # if not name:
-        #     name = _Environment.get().JOB_NAME
-        #     if not name:
-        #         print("ERROR: Failed to guess the .name")
-        #         raise
+        if not name:
+            name = _Environment.get().JOB_NAME
         start_time = None
         duration = None
         if not stopwatch:
@@ -318,26 +315,7 @@ class Result(MetaClasses.Serializable):
 
     @classmethod
     def file_name_static(cls, name):
-        if not name:
-            return cls.experimental_file_name_static()
-        else:
-            return f"{Settings.TEMP_DIR}/result_{Utils.normalize_string(name)}.json"
-
-    @classmethod
-    def experimental_file_name_static(cls):
-        return f"{Settings.TEMP_DIR}/result_job.json"
-
-    @classmethod
-    def experimental_from_fs(cls, name):
-        # experimental mode to let job write results into fixed result.json file instead of result_job_name.json
-        Shell.check(
-            f"cp {cls.experimental_file_name_static()} {cls.file_name_static(name)}",
-            verbose=True,
-        )
-        result = Result.from_fs(name)
-        result.name = name
-        result.dump()
-        return result
+        return f"{Settings.TEMP_DIR}/result_{Utils.normalize_string(name)}.json"
 
     @classmethod
     def from_dict(cls, obj: Dict[str, Any]) -> "Result":

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -442,15 +442,6 @@ class Runner:
             cmd += f" --workers {workers}"
         print(f"--- Run command [{cmd}]")
 
-        # Clean up stale experimental result file before starting the subprocess.
-        # This must happen before TeePopen.__enter__ which sleeps 1s after spawning
-        # the process — if the subprocess completes during that sleep (common for
-        # fast native jobs like Finish Workflow in backport PRs), deleting the file
-        # afterwards would remove the subprocess's own output, causing a spurious
-        # "Job killed or terminated" error.
-        if Path((Result.experimental_file_name_static())).exists():
-            Path(Result.experimental_file_name_static()).unlink()
-
         with TeePopen(
             cmd,
             timeout=job.timeout,
@@ -460,15 +451,6 @@ class Runner:
             start_time = Utils.timestamp()
 
             exit_code = process.wait()
-
-            if Path(Result.experimental_file_name_static()).exists():
-                result = Result.experimental_from_fs(job.name)
-                if not result.start_time:
-                    print(
-                        "WARNING: no start_time set by the job - set job start_time/duration"
-                    )
-                    result.start_time = start_time
-                    result.dump()
 
             result = Result.from_fs(job.name)
             if exit_code != 0:


### PR DESCRIPTION
The `experimental_file_name_static` / `experimental_from_fs` path in `Result` was designed to let a job write its result to a fixed `result_job.json` instead of the canonical `result_{job_name}.json`. No job in the codebase actually uses this path — it is dead code.

The runner code that checked for the experimental file after each job emitted a spurious warning on every run:

```
WARNING: no start_time set by the job - set job start_time/duration
```

Removing the entire mechanism eliminates the warning and simplifies both `runner.py` and `result.py`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)
