### PR TITLE
Fix MSan false positive: unpoison TryResult at fiber boundary

### DIFF
--- a/src/Client/ConnectionEstablisher.h
+++ b/src/Client/ConnectionEstablisher.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <base/MemorySanitizer.h>
 #include <Common/AsyncTaskExecutor.h>
 #include <Common/Epoll.h>
 #include <Common/Fiber.h>
@@ -72,7 +73,15 @@ public:
     /// The process is considered finished if connection is ready,
     /// some exception occurred or timeout exceeded.
     bool isFinished() const { return is_finished; }
-    TryResult getResult() const { return result; }
+    TryResult getResult() const
+    {
+        /// The result is populated inside a fiber whose stack is allocated via aligned_alloc.
+        /// MSan treats such memory as uninitialized and cannot track writes through
+        /// boost::context's uninstrumented assembly for fiber switches.
+        /// Unpoison the result at this fiber boundary to suppress false positives.
+        __msan_unpoison(&result, sizeof(result));
+        return result;
+    }
 
     const std::string & getFailMessage() const { return fail_message; }
 

--- a/src/Client/ConnectionEstablisher.h
+++ b/src/Client/ConnectionEstablisher.h
@@ -75,10 +75,11 @@ public:
     bool isFinished() const { return is_finished; }
     TryResult getResult() const
     {
-        /// The result is populated inside a fiber whose stack is allocated via aligned_alloc.
-        /// MSan treats such memory as uninitialized and cannot track writes through
-        /// boost::context's uninstrumented assembly for fiber switches.
-        /// Unpoison the result at this fiber boundary to suppress false positives.
+        /// TryResult has struct padding bytes that are never explicitly initialized
+        /// (neither by the defaulted constructor nor by ConnectionEstablisher::run()).
+        /// When vector operations in getMany() move TryResult objects, MSan can flag
+        /// reads of these uninitialized padding bytes. Unpoison the entire struct
+        /// (including padding) to suppress this false positive.
         __msan_unpoison(&result, sizeof(result));
         return result;
     }


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

*This is an internal MSan false positive fix, not user-visible.*

### Description

**Problem:** `MemorySanitizer: use-of-uninitialized-value` (STID 4179-5154) in `PoolWithFailoverBase::getMany()` → `std::erase_if` → `vector::erase`, exclusively on `Stress test (arm_msan)`. After PR #98677 expanded ARM64 CI coverage, the failure rate spiked from ~4 hits/month to 15+ hits/day (19 hits in 30 days across 15 distinct PRs + master).

**Root cause:** `TryResult` has struct padding bytes (between `is_up_to_date`/`delay` and after `is_readonly`) that are never explicitly initialized — neither by the defaulted constructor (in-class initializers only set named fields) nor by `ConnectionEstablisher::run()` (which writes individual fields through a reference). When `erase_if` in `getMany()` moves `TryResult` objects in the vector, the compiler-generated move can read these uninitialized padding bytes, and MSan flags them.

Note: `result` is a class member of `ConnectionEstablisherAsync`, not on the fiber stack. Writes to it in `ConnectionEstablisher::run()` go through an instrumented reference and ARE tracked by MSan. The previous blanket `__msan_unpoison` in `FiberStack::allocate()` was insufficient precisely because it targets the fiber stack, not the class member.

**Fix:** Restore `__msan_unpoison(&result, sizeof(result))` in `ConnectionEstablisherAsync::getResult()` to unpoison the entire struct including padding before returning. This exact fix was originally introduced in commit 262fbda7d44 and later removed in 31e498011ed.

**Evidence:**
- 19/19 hits are exclusively on `Stress test (arm_msan)` — zero x86_64 MSAN hits
- Spike correlates with PR #98677 (merged March 30) expanding arm_msan test volume from ~1 test/day to 920 tests/day
- The original fix (commit 262fbda7d44) eliminated the issue for 10 days (March 22-31) before being removed

**Stack trace:**
\`\`\`
#0 vector::erase (vector.h:1172)
#1 erase_if → getMany lambda (PoolWithFailoverBase.h:349)
#2 getMany (PoolWithFailoverBase.h:349)
#3 getManyImpl (ConnectionPoolWithFailover.cpp:237)
#4 getMany (ConnectionPoolWithFailover.cpp:135)
#5-#12 RemoteQueryExecutor → sendQueryUnlocked
#13-#19 AsyncTaskExecutor → Fiber → boost::context::fiber_ucontext
\`\`\`