### PR TITLE
Kill stale Redpanda before starting a new one in CI

### DIFF
--- a/ci/jobs/scripts/functional_tests/setup_kafka.sh
+++ b/ci/jobs/scripts/functional_tests/setup_kafka.sh
@@ -4,7 +4,21 @@ set -euxf -o pipefail
 
 KAFKA_BROKER=${KAFKA_BROKER:-127.0.0.1:9092}
 
+stop_redpanda() {
+    if pgrep -f redpanda > /dev/null 2>&1; then
+        echo "Stopping existing Redpanda process..."
+        pkill -f redpanda || true
+        sleep 2
+        # Force kill if still running
+        if pgrep -f redpanda > /dev/null 2>&1; then
+            pkill -9 -f redpanda || true
+            sleep 1
+        fi
+    fi
+}
+
 start_redpanda() {
+    stop_redpanda
     rm -rf /tmp/redpanda-data
 
     echo "Starting Redpanda broker..."


### PR DESCRIPTION
Redpanda startup in CI was [failing with "Address already in use" on port 33145](https://s3.amazonaws.com/clickhouse-test-reports/PRs/100966/2479ac072f9777de43d8152f9adf89f266224017/stateless_tests_amd_debug_distributed_plan_s3_storage_parallel/kafka.log) because a previous instance was still running. This caused all Kafka-related stateless tests to fail silently. 

Add a stop_redpanda step that kills any existing Redpanda process before attempting to start a fresh one.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

