### PR TITLE
Fix flaky test 01655_plan_optimizations (all variants)

### DIFF
--- a/tests/queries/0_stateless/01655_plan_optimizations.sh
+++ b/tests/queries/0_stateless/01655_plan_optimizations.sh
@@ -4,6 +4,11 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+# Pin query plan settings that affect EXPLAIN output structure.
+# CI randomizes these (especially after PR #100874 adds them to SettingsRandomizer),
+# which changes step ordering/merging and breaks the grep-based assertions.
+export CLICKHOUSE_CLIENT="$CLICKHOUSE_CLIENT --query_plan_filter_push_down=1 --query_plan_merge_expressions=1 --query_plan_execute_functions_after_sorting=1 --query_plan_split_filter=1"
+
 $CLICKHOUSE_CLIENT -q "select x + 1 from (select y + 2 as x from (select dummy + 3 as y)) settings query_plan_max_optimizations_to_apply = 1" 2>&1 |
      grep -o "Too many optimizations applied to query plan"
 

--- a/tests/queries/0_stateless/01655_plan_optimizations_merge_filters.sql
+++ b/tests/queries/0_stateless/01655_plan_optimizations_merge_filters.sql
@@ -1,5 +1,7 @@
 set optimize_syntax_fuse_functions = 0;
 set query_plan_merge_filters=1;
+set query_plan_filter_push_down=1;
+set query_plan_merge_expressions=1;
 set optimize_respect_aliases = 1;
 set query_plan_optimize_prewhere = 1;
 

--- a/tests/queries/0_stateless/01655_plan_optimizations_optimize_read_in_window_order.sh
+++ b/tests/queries/0_stateless/01655_plan_optimizations_optimize_read_in_window_order.sh
@@ -4,6 +4,10 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+# Pin query_plan_merge_expressions to avoid Expression step changes in EXPLAIN output
+# when CI randomizes this setting (especially after PR #100874).
+export CLICKHOUSE_CLIENT="$CLICKHOUSE_CLIENT --query_plan_merge_expressions=1"
+
 name=test_01655_plan_optimizations_optimize_read_in_window_order
 
 $CLICKHOUSE_CLIENT -q "drop table if exists ${name}"


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a]user-readable short description of the changes that goes to CHANGELOG.md):
- Not required

### What is the problem?

The `01655_plan_optimizations` test family (4 test files, 549 failures across 25 PRs in 30 days) is chronically flaky due to CI settings randomization. Four `query_plan_*` settings control optimizations that the tests verify via EXPLAIN output, but their randomized values disable those optimizations, changing the step ordering:

| Setting | Effect when disabled | Tests affected |
|---------|---------------------|----------------|
| `query_plan_filter_push_down` | Filter stays above Aggregation/Sort/Distinct | main, merge_filters |
| `query_plan_merge_expressions` | Expression steps not merged | main, merge_filters, window_order |
| `query_plan_execute_functions_after_sorting` | Functions not lifted after sorting | main |
| `query_plan_split_filter` | Filter expressions not split for partial push-down | main |

### How was it tested?

**Deterministic reproduction**: each setting set to 0 individually fails the corresponding test 100% of the time.

**Fix verification**: all 4 settings disabled simultaneously → all tests pass.

**Stress test**: 50 iterations × 4 tests = 200 runs with full randomization → **0 failures** (155 counted by test runner including `_long` variant).

### What was changed?

- `01655_plan_optimizations.sh`: pin `query_plan_filter_push_down=1`, `query_plan_merge_expressions=1`, `query_plan_execute_functions_after_sorting=1`, `query_plan_split_filter=1` via `CLICKHOUSE_CLIENT` export
- `01655_plan_optimizations_merge_filters.sql`: pin `query_plan_filter_push_down=1`, `query_plan_merge_expressions=1` via SET
- `01655_plan_optimizations_optimize_read_in_window_order.sh`: pin `query_plan_merge_expressions=1` via `CLICKHOUSE_CLIENT` export

Each test pins **only** the settings that control the specific optimizations it verifies. No broad `no-random-*` tags.

Note: PR #100874 ("Next batch of settings to randomize during tests runs") has a partial fix for these tests but misses `query_plan_filter_push_down=1` for the main `.sh` test. This PR provides the complete fix.