### PR TITLE
Fix flaky test 02354_vector_search_rescoring_and_prewhere

### DIFF
--- a/tests/queries/0_stateless/02354_vector_search_rescoring_and_prewhere.sql
+++ b/tests/queries/0_stateless/02354_vector_search_rescoring_and_prewhere.sql
@@ -4,6 +4,7 @@
 
 SET enable_analyzer = 1;
 SET parallel_replicas_local_plan = 1; -- this setting is randomized, set it explicitly to force local plan for parallel replicas
+SET query_plan_merge_expressions = 1; -- vector search optimizer requires merged expression steps to recognize the plan pattern
 
 DROP TABLE IF EXISTS tab;
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Not required

### What this PR does

Pin `query_plan_merge_expressions = 1` to fix a chronic flaky test.

**Root cause:** The vector search query plan optimizer (`tryUseVectorSearch` in `useVectorSearch.cpp`) requires a specific plan structure: `LimitStep → SortingStep → ExpressionStep → [FilterStep] → ReadFromMergeTree`. When `query_plan_merge_expressions` is randomized to `0`, extra unmerged `ExpressionStep`s appear between `SortingStep` and `ReadFromMergeTree`, breaking the optimizer's pattern matching. It silently falls back to brute-force scan, producing different (L2Distance-sorted full scan) results instead of HNSW index-based results.

**Reproduction:** `SET query_plan_merge_expressions = 0` deterministically triggers the failure — all queries in the test return brute-force results (e.g., `16, 19, 12, 11` instead of index-filtered `16, 19`).

**CIDB evidence:** 34 failures in 30 days — 30 from PR #100874 flaky check (which adds `query_plan_merge_expressions` to the SettingsRandomizer), plus historical hits in PRs #96130, #99181, and 1 master failure.

**Verification:** 50/50 passes with full randomization after the fix.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.520`
<!-- ch-version-info:end -->