### PR TITLE
Fix "Cannot start clickhouse-server" caused by StorageAlias validation in SharedCatalog

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1791,10 +1791,27 @@ void checkForUnsupportedColumns(IStorage & storage, LoadingStrictnessLevel mode)
     }
 }
 
-void validateVirtualColumns(IStorage & storage)
+void validateVirtualColumns(IStorage & storage, LoadingStrictnessLevel mode)
 {
+    /// For non-strict modes (e.g. SECONDARY_CREATE during SharedCatalog state application),
+    /// use tryGetInMemoryMetadataPtr which returns nullopt when the target table of a
+    /// StorageAlias doesn't exist yet. The target may appear later or may have been dropped;
+    /// the validation will happen at query time instead.
+    StorageMetadataPtr metadata;
+    if (mode > LoadingStrictnessLevel::CREATE)
+    {
+        auto maybe_metadata = storage.tryGetInMemoryMetadataPtr();
+        if (!maybe_metadata)
+            return;
+        metadata = *maybe_metadata;
+    }
+    else
+    {
+        metadata = storage.getInMemoryMetadataPtr();
+    }
+
     auto virtual_columns = storage.getVirtualsPtr();
-    for (const auto & storage_column : storage.getInMemoryMetadataPtr()->getColumns())
+    for (const auto & storage_column : metadata->getColumns())
     {
         if (virtual_columns->tryGet(storage_column.name, VirtualsKind::Persistent))
         {
@@ -1821,7 +1838,7 @@ void validateVirtualColumns(IStorage & storage)
 void validateStorage(IStorage & storage, LoadingStrictnessLevel mode)
 try
 {
-    validateVirtualColumns(storage);
+    validateVirtualColumns(storage, mode);
     checkForUnsupportedColumns(storage, mode);
 }
 catch (...)


### PR DESCRIPTION
During `SharedDatabaseCatalog::applyState`, creating a `StorageAlias` table triggers `validateVirtualColumns` which calls `getInMemoryMetadataPtr`. For `StorageAlias`, this resolves the target table via `DatabaseCatalog::getTable`, throwing `UNKNOWN_TABLE` if the target doesn't exist yet (ordering issue) or was already dropped. After 10 retries the server gives up and exits with "Cannot start clickhouse-server".

Fix by making `validateVirtualColumns` mode-aware: for `SECONDARY_CREATE` and above (used by SharedCatalog state application), use `tryGetInMemoryMetadataPtr` which returns nullopt when the target table is missing, and skip validation. The virtual column check will happen at query time instead.

Found in https://github.com/ClickHouse/clickhouse-private/pull/54538

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Made with [Cursor](https://cursor.com)