### PR TITLE
Mark getClientHTTPHeader as non-deterministic

### DIFF
--- a/src/Functions/getClientHTTPHeader.cpp
+++ b/src/Functions/getClientHTTPHeader.cpp
@@ -36,6 +36,8 @@ public:
 
     String getName() const override { return "getClientHTTPHeader"; }
 
+    bool isDeterministic() const override { return false; }
+
     bool useDefaultImplementationForConstants() const override { return true; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo &) const override { return false; }
 

--- a/tests/queries/0_stateless/04076_getClientHTTPHeader_nondeterministic.sql
+++ b/tests/queries/0_stateless/04076_getClientHTTPHeader_nondeterministic.sql
@@ -1,0 +1,5 @@
+-- Verify that getClientHTTPHeader is treated as non-deterministic and
+-- cannot be used together with the query cache.
+SYSTEM DROP QUERY CACHE;
+SELECT getClientHTTPHeader('X-Test') SETTINGS allow_get_client_http_header = 1, use_query_cache = 1; -- { serverError QUERY_CACHE_USED_WITH_NONDETERMINISTIC_FUNCTIONS }
+SYSTEM DROP QUERY CACHE;


### PR DESCRIPTION
`getClientHTTPHeader` reads per-connection HTTP headers, so its result can differ between connections with the same arguments. Without the `isDeterministic()=false` override, the query cache incorrectly caches results of queries using this function, returning stale header values on subsequent requests.

This is the same class of bug that was fixed for `connectionId` in PR #92174.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Mark `getClientHTTPHeader` as non-deterministic so the query cache does not incorrectly cache its results.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Closes #101120