### PR TITLE
Throw SUPPORT_IS_DISABLED for SHOW MASKING POLICIES in OSS builds

### DIFF
--- a/src/Interpreters/Access/InterpreterShowAccessEntitiesQuery.cpp
+++ b/src/Interpreters/Access/InterpreterShowAccessEntitiesQuery.cpp
@@ -12,6 +12,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int NOT_IMPLEMENTED;
+    extern const int SUPPORT_IS_DISABLED;
 }
 
 
@@ -116,24 +117,7 @@ String InterpreterShowAccessEntitiesQuery::getRewrittenQuery() const
 
         case AccessEntityType::MASKING_POLICY:
         {
-            origin = "masking_policies";
-            expr = "name";
-
-            if (!query.short_name.empty())
-                filter = "short_name = " + quoteString(query.short_name);
-
-            if (query.database_and_table_name)
-            {
-                const String & database = query.database_and_table_name->first;
-                const String & table_name = query.database_and_table_name->second;
-                if (!database.empty())
-                    filter += String{filter.empty() ? "" : " AND "} + "database = " + quoteString(database);
-                if (!table_name.empty())
-                    filter += String{filter.empty() ? "" : " AND "} + "table = " + quoteString(table_name);
-                if (!database.empty() && !table_name.empty())
-                    expr = "short_name";
-            }
-            break;
+            throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "Masking Policies are available only in ClickHouse Cloud");
         }
 
         case AccessEntityType::MAX:

--- a/tests/queries/0_stateless/04076_show_masking_policies_error_code.sql
+++ b/tests/queries/0_stateless/04076_show_masking_policies_error_code.sql
@@ -1,0 +1,3 @@
+-- Verify that SHOW MASKING POLICIES returns SUPPORT_IS_DISABLED (344)
+-- instead of UNKNOWN_TABLE (60) in OSS builds.
+SHOW MASKING POLICIES; -- { serverError SUPPORT_IS_DISABLED }


### PR DESCRIPTION
`SHOW MASKING POLICIES` generated a query against `system.masking_policies`, which does not exist in OSS builds, resulting in a confusing `UNKNOWN_TABLE` error. Other masking policy commands (`SHOW CREATE MASKING POLICY`, `CREATE MASKING POLICY`) already correctly throw `SUPPORT_IS_DISABLED`.

This aligns `SHOW MASKING POLICIES` with the same behavior.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `SHOW MASKING POLICIES` returning `UNKNOWN_TABLE` instead of `SUPPORT_IS_DISABLED` in OSS builds.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Closes #101116