### PR TITLE
Restore allow_statistics check for ADD/DROP/MODIFY STATISTICS

### DIFF
--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -60,6 +60,7 @@ namespace Setting
     extern const SettingsBool allow_experimental_analyzer;
     extern const SettingsBool allow_experimental_codecs;
     extern const SettingsBool allow_experimental_json_lazy_type_hints;
+    extern const SettingsBool allow_statistics;
     extern const SettingsBool allow_suspicious_codecs;
     extern const SettingsBool allow_suspicious_ttl_expressions;
     extern const SettingsBool flatten_nested;
@@ -69,6 +70,7 @@ namespace ErrorCodes
 {
     extern const int ILLEGAL_COLUMN;
     extern const int ILLEGAL_STATISTICS;
+    extern const int INCORRECT_QUERY;
     extern const int BAD_ARGUMENTS;
     extern const int NOT_FOUND_COLUMN_IN_BLOCK;
     extern const int LOGICAL_ERROR;
@@ -1469,6 +1471,11 @@ void AlterCommands::validate(const StoragePtr & table, ContextPtr context) const
 
         if (command.ttl && !table->supportsTTL())
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Engine {} doesn't support TTL clause", table->getName());
+
+        if ((command.type == AlterCommand::ADD_STATISTICS || command.type == AlterCommand::DROP_STATISTICS
+             || command.type == AlterCommand::MODIFY_STATISTICS)
+            && !context->getSettingsRef()[Setting::allow_statistics])
+            throw Exception(ErrorCodes::INCORRECT_QUERY, "Alter table with statistics is disabled. Turn on allow_statistics");
 
         const auto & column_name = command.column_name;
         if (command.type == AlterCommand::ADD_COLUMN)

--- a/tests/queries/0_stateless/04076_allow_statistics_blocks_add_drop.sql
+++ b/tests/queries/0_stateless/04076_allow_statistics_blocks_add_drop.sql
@@ -1,0 +1,19 @@
+-- Verify that allow_statistics=0 blocks ADD, DROP, and MATERIALIZE STATISTICS.
+SET allow_statistics = 1;
+
+DROP TABLE IF EXISTS t_allow_statistics_check;
+CREATE TABLE t_allow_statistics_check (x UInt32) ENGINE = MergeTree ORDER BY x;
+
+SET allow_statistics = 0;
+
+ALTER TABLE t_allow_statistics_check ADD STATISTICS x TYPE tdigest; -- { serverError INCORRECT_QUERY }
+ALTER TABLE t_allow_statistics_check MODIFY STATISTICS x TYPE tdigest; -- { serverError INCORRECT_QUERY }
+
+SET allow_statistics = 1;
+ALTER TABLE t_allow_statistics_check ADD STATISTICS x TYPE tdigest;
+SET allow_statistics = 0;
+
+ALTER TABLE t_allow_statistics_check DROP STATISTICS x; -- { serverError INCORRECT_QUERY }
+ALTER TABLE t_allow_statistics_check MATERIALIZE STATISTICS x; -- { serverError INCORRECT_QUERY }
+
+DROP TABLE IF EXISTS t_allow_statistics_check;


### PR DESCRIPTION
After the refactor in PR #100288, the `allow_statistics` enforcement was moved to `MutationsInterpreter::prepare()`. However, `ADD STATISTICS` and `DROP STATISTICS` are routed as `AlterCommands`, not `MutationCommands`, so they never reached the new check.

Re-add the check in `AlterCommands::validate()` so that all three ALTER STATISTICS commands respect `allow_statistics=0`.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `allow_statistics=0` not blocking `ALTER TABLE ADD STATISTICS` and `ALTER TABLE DROP STATISTICS` after refactoring in #100288.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Closes #101082

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.878`
<!-- ch-version-info:end -->