### PR TITLE
Fix inject_random_order_for_select_without_order_by for multi-column SELECT

### DIFF
--- a/src/Analyzer/Passes/InjectRandomOrderIfNoOrderByPass.cpp
+++ b/src/Analyzer/Passes/InjectRandomOrderIfNoOrderByPass.cpp
@@ -39,20 +39,33 @@ void wrapWithSelectOrderBy(QueryTreeNodePtr & query_root, ContextPtr context)
 {
     auto * query_node = query_root->as<QueryNode>();
 
-    /// Re-resolve query_node columns setting the unique alias
-    String unique_column_name = "__subquery_column_" + toString(UUIDHelpers::generateV4());
+    /// Generate unique aliases for all projection columns
     auto subquery_projection_columns = query_node->getProjectionColumns();
+    Names unique_column_names;
+    unique_column_names.reserve(subquery_projection_columns.size());
+    String uuid_suffix = toString(UUIDHelpers::generateV4());
+    for (size_t i = 0; i < subquery_projection_columns.size(); ++i)
+        unique_column_names.push_back("__subquery_column_" + std::to_string(i) + "_" + uuid_suffix);
+
+    /// Re-resolve query_node columns setting the unique aliases
     query_node->clearProjectionColumns();
-    query_node->setProjectionAliasesToOverride({unique_column_name});
+    query_node->setProjectionAliasesToOverride(unique_column_names);
     query_node->resolveProjectionColumns(subquery_projection_columns);
     query_node->setIsSubquery(true);
 
-    /// SELECT unique_column_name FROM query_node order by rand()
+    /// SELECT all columns FROM query_node ORDER BY rand()
     auto new_root = std::make_shared<QueryNode>(Context::createCopy(context));
     new_root->getJoinTree() = query_root;
-    NameAndTypePair column{unique_column_name, subquery_projection_columns[0].type};
-    new_root->getProjection().getNodes().push_back(std::make_shared<ColumnNode>(column, query_root));
-    new_root->resolveProjectionColumns({column});
+
+    NamesAndTypes outer_columns;
+    outer_columns.reserve(subquery_projection_columns.size());
+    for (size_t i = 0; i < subquery_projection_columns.size(); ++i)
+    {
+        NameAndTypePair column{unique_column_names[i], subquery_projection_columns[i].type};
+        new_root->getProjection().getNodes().push_back(std::make_shared<ColumnNode>(column, query_root));
+        outer_columns.push_back(column);
+    }
+    new_root->resolveProjectionColumns(std::move(outer_columns));
     addRandomOrderBy(new_root->getOrderBy(), context);
 
     /// Replace old root with new wrapping query node

--- a/tests/queries/0_stateless/04076_inject_random_order_multicolumn.sql
+++ b/tests/queries/0_stateless/04076_inject_random_order_multicolumn.sql
@@ -1,0 +1,9 @@
+-- Verify that multi-column SELECT works with inject_random_order_for_select_without_order_by=1.
+-- Previously this crashed with BAD_ARGUMENTS because only a single alias was generated.
+SET inject_random_order_for_select_without_order_by = 1;
+
+-- Multi-column SELECT should succeed
+SELECT number, number + 1 FROM numbers(3) FORMAT Null;
+
+-- SELECT * from a table with multiple columns should succeed
+SELECT * FROM system.one FORMAT Null;


### PR DESCRIPTION
The wrapping logic in `InjectRandomOrderIfNoOrderByPass` only generated a single alias and selected a single column from the subquery, causing a `BAD_ARGUMENTS` exception for any SELECT with more than one projection column when `inject_random_order_for_select_without_order_by=1`.

Generate unique aliases for all projection columns and propagate all of them through the outer wrapping query.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix exception in multi-column SELECT queries when `inject_random_order_for_select_without_order_by` setting is enabled.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Closes #101107