### PR TITLE
Fix flaky test 02496_remove_redundant_sorting

### DIFF
--- a/tests/queries/0_stateless/02496_remove_redundant_sorting.sh
+++ b/tests/queries/0_stateless/02496_remove_redundant_sorting.sh
@@ -8,8 +8,8 @@ if [ -z ${ENABLE_ANALYZER+x} ]; then
     ENABLE_ANALYZER=0
 fi
 
-DISABLE_OPTIMIZATION="SET enable_analyzer=$ENABLE_ANALYZER;SET query_plan_remove_redundant_sorting=0;SET optimize_duplicate_order_by_and_distinct=0"
-ENABLE_OPTIMIZATION="SET enable_analyzer=$ENABLE_ANALYZER;SET query_plan_remove_redundant_sorting=1;SET optimize_duplicate_order_by_and_distinct=0"
+DISABLE_OPTIMIZATION="SET enable_analyzer=$ENABLE_ANALYZER;SET query_plan_enable_optimizations=1;SET query_plan_remove_redundant_sorting=0;SET optimize_duplicate_order_by_and_distinct=0;SET query_plan_merge_expressions=1;SET query_plan_merge_filters=1;SET query_plan_lift_up_union=1"
+ENABLE_OPTIMIZATION="SET enable_analyzer=$ENABLE_ANALYZER;SET query_plan_enable_optimizations=1;SET query_plan_remove_redundant_sorting=1;SET optimize_duplicate_order_by_and_distinct=0;SET query_plan_merge_expressions=1;SET query_plan_merge_filters=1;SET query_plan_lift_up_union=1"
 
 echo "-- Disabled query_plan_remove_redundant_sorting"
 echo "-- ORDER BY clauses in subqueries are untouched"
@@ -324,7 +324,7 @@ FROM (
 run_query "$query"
 
 echo "-- disable common optimization to avoid functions to be lifted up (liftUpFunctions optimization), needed for testing with stateful function"
-ENABLE_OPTIMIZATION="SET query_plan_enable_optimizations=0;$ENABLE_OPTIMIZATION"
+ENABLE_OPTIMIZATION="$ENABLE_OPTIMIZATION;SET query_plan_enable_optimizations=0"
 echo "-- neighbor() as stateful function prevents removing inner ORDER BY since its result depends on order"
 query="SELECT
     number,


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Description

Fix flaky test `02496_remove_redundant_sorting` (+ its `_analyzer` variant) which fails when CI randomizes query plan step-merging settings.

**Root cause:** The test's EXPLAIN output depends on Filter and Expression steps being merged (e.g., `Filter (((WHERE + ...) + HAVING))` as one step). When CI randomizes any of these settings to 0, steps are no longer merged and labels change:
- `query_plan_merge_filters=0` → WHERE and HAVING become separate Filter steps
- `query_plan_merge_expressions=0` → Expression steps are not combined
- `query_plan_lift_up_union=0` → Union lifting changes plan structure  
- `query_plan_enable_optimizations=0` → master switch disables all of the above

**Impact:** 114 PR failures across 7 PRs in 30 days (103 from PR #100874 which adds new settings to the randomizer).

**Fix:** Pin the 4 settings that control step merging in both `DISABLE_OPTIMIZATION` and `ENABLE_OPTIMIZATION` variables:
- `query_plan_enable_optimizations=1`
- `query_plan_merge_expressions=1`
- `query_plan_merge_filters=1`
- `query_plan_lift_up_union=1`

Also changes the end-section override from prepend to append (`$ENABLE_OPTIMIZATION;SET query_plan_enable_optimizations=0` instead of `SET query_plan_enable_optimizations=0;$ENABLE_OPTIMIZATION`), so the last SET wins and correctly disables `liftUpFunctions` for the stateful-function test while respecting the new pin.

**Verification:** All 4 trigger settings deterministically fail without the fix and pass with it. 100/100 runs passed with full CI randomization enabled.