### PR TITLE
Fix flaky test 03405_merge_filter_into_join

### DIFF
--- a/tests/queries/0_stateless/03405_merge_filter_into_join.sql
+++ b/tests/queries/0_stateless/03405_merge_filter_into_join.sql
@@ -10,6 +10,8 @@ set query_plan_join_swap_table = 0;
 set enable_analyzer = 1; -- Optimization requires LogicalJoinStep
 set enable_parallel_replicas = 0; -- Optimization requires LogicalJoinStep
 set parallel_hash_join_threshold = 0;
+set query_plan_merge_expressions = 1; -- Test checks merged expression step names in EXPLAIN
+set query_plan_merge_filter_into_join_condition = 1; -- Test verifies this optimization
 
 -- { echoOn }
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a]
- ~

### Description

Pin `query_plan_merge_expressions = 1` and `query_plan_merge_filter_into_join_condition = 1` in the test to prevent CI settings randomization from breaking the EXPLAIN output.

**Root cause:** The test checks that WHERE filters are merged into JOIN conditions via EXPLAIN PLAN output. When either of these settings is randomized to False:
- `query_plan_merge_expressions = 0` → Expression steps are not merged ("Before ORDER BY" and "Projection" appear as separate steps instead of a combined step), and the filter remains separate from the JOIN
- `query_plan_merge_filter_into_join_condition = 0` → The filter is not pushed into the JOIN condition at all, leaving a separate Filter step with `Clauses: [(__lhs_const) = (__rhs_const)]` instead of the expected `Clauses: [(__table2.age) = (__table3.age)]`

**Impact:** 53 failures across 7 PRs in 30 days. 33 of those from PR #100874 which adds these settings to the CI randomizer.

**Validation:**
- ❌ Without fix + `query_plan_merge_expressions=0`: test FAILS (EXPLAIN output differs)
- ❌ Without fix + `query_plan_merge_filter_into_join_condition=0`: test FAILS (filter not merged into JOIN)
- ✅ With fix + both bad settings from CLI: test PASSES (SQL SET overrides CLI)
- ✅ 50/50 passes with full randomization enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.523`
<!-- ch-version-info:end -->