### PR TITLE
Fix flaky test 04039_prune_array_join_columns

### DIFF
--- a/tests/queries/0_stateless/04039_prune_array_join_columns.sql
+++ b/tests/queries/0_stateless/04039_prune_array_join_columns.sql
@@ -1,5 +1,7 @@
 SET enable_analyzer = 1;
 SET enable_parallel_replicas = 0;
+SET query_plan_enable_optimizations = 1; -- EXPLAIN output depends on expression step merging
+SET query_plan_merge_expressions = 1;
 
 DROP TABLE IF EXISTS t_nested;
 CREATE TABLE t_nested (`n.a` Array(Int64), `n.b` Array(Int64), `n.c` Array(Int64)) ENGINE = MergeTree ORDER BY tuple();


### PR DESCRIPTION
The test uses `EXPLAIN header=1` which produces output that depends on query plan expression step merging. When CI randomizes `query_plan_merge_expressions` to 0 (or `query_plan_enable_optimizations` to 0), Expression steps that are normally merged (e.g. `Before ORDER BY + Projection`) appear as separate steps, causing the output to differ from the reference file.

Pin `query_plan_enable_optimizations=1` and `query_plan_merge_expressions=1` to ensure stable EXPLAIN output regardless of CI setting randomization.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)