### PR TITLE
Fix flaky test 03652_explain_input_header

### DIFF
--- a/tests/queries/0_stateless/03652_explain_input_header.sql
+++ b/tests/queries/0_stateless/03652_explain_input_header.sql
@@ -1,6 +1,7 @@
 SET enable_analyzer = 1;
 SET enable_parallel_replicas = 0;
 SET enable_join_runtime_filters = 0;
+SET query_plan_merge_expressions = 1; -- EXPLAIN output depends on merged Expression steps
 DROP TABLE IF EXISTS t1;
 DROP TABLE IF EXISTS t2;
 


### PR DESCRIPTION
Pin `query_plan_merge_expressions = 1` to stabilize EXPLAIN PLAN output in the test.

When CI randomizes `query_plan_merge_expressions` to 0, adjacent Expression steps
like `(Project names + Projection)` split into separate nodes, causing the reference
output to mismatch. The test verifies EXPLAIN PLAN `header`/`input_headers` display
features, not the expression merging optimization itself, so pinning this setting
preserves the test's intent.

**CIDB evidence:** 27 failures across 7 distinct PRs in 30 days, 0 master failures —
all triggered by settings randomization.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)