### PR TITLE
Fix flaky test 03545_analyzer_correlated_subquery_exists_asterisk

### DIFF
--- a/tests/queries/0_stateless/03545_analyzer_correlated_subquery_exists_asterisk.sql
+++ b/tests/queries/0_stateless/03545_analyzer_correlated_subquery_exists_asterisk.sql
@@ -4,8 +4,9 @@ SET enable_parallel_replicas = 0;
 SET correlated_subqueries_default_join_kind = 'left';
 SET correlated_subqueries_use_in_memory_buffer = 0;
 
--- Disable table swaps during query planning
+-- Pin query plan settings that affect EXPLAIN output structure
 SET query_plan_join_swap_table = false;
+SET query_plan_merge_expressions = 1;
 
 DROP TABLE IF EXISTS test;
 CREATE TABLE test(


### PR DESCRIPTION
Pin `query_plan_merge_expressions = 1` to stabilize EXPLAIN output.

When `query_plan_merge_expressions` is randomized to `0`, consecutive Expression steps in
the query plan are not merged together, changing the EXPLAIN output structure (e.g.,
`Expression ((Project names + (Projection + WHERE)))` becomes three separate steps:
`Expression (Project names)`, `Expression (Projection)`, `Expression (WHERE)`). This causes
a reference mismatch.

The test verifies correlated subquery EXISTS transformation into a SEMI JOIN — not expression
merging behavior. Pinning the setting preserves the test's intent while preventing false
failures under settings randomization.

**CIDB evidence:** 51 failures across 10 distinct PRs in 30 days, 0 master failures. Most hits are
from PRs that extend the settings randomizer (e.g., #100874, #99181, #100624).

**Local verification:** 100/100 passes with full randomization after the fix. Without fix,
`query_plan_merge_expressions = 0` deterministically changes EXPLAIN output.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)