### PR TITLE
Fix flaky vector search tests by pinning query_plan_merge_expressions

### DIFF
--- a/tests/queries/0_stateless/02354_vector_search_binary_quantization.sql
+++ b/tests/queries/0_stateless/02354_vector_search_binary_quantization.sql
@@ -7,6 +7,7 @@
 -- Also has good number of calls to reinterpret() to test conversion of native floats to Array(Float32)
 
 SET enable_analyzer = 1;
+SET query_plan_merge_expressions = 1; -- vector search optimizer requires merged expression steps to recognize the plan pattern
 
 DROP TABLE IF EXISTS dbpedia;
 

--- a/tests/queries/0_stateless/02354_vector_search_choose_correct_index.sql
+++ b/tests/queries/0_stateless/02354_vector_search_choose_correct_index.sql
@@ -1,6 +1,7 @@
 -- Tags: no-fasttest, no-ordinary-database
 
 SET parallel_replicas_local_plan = 1; -- this setting is randomized, set it explicitly to have local plan for parallel replicas
+SET query_plan_merge_expressions = 1; -- vector search optimizer requires merged expression steps to recognize the plan pattern
 
 -- Test for issue #77978
 

--- a/tests/queries/0_stateless/02354_vector_search_distributed_index_analysis.sql
+++ b/tests/queries/0_stateless/02354_vector_search_distributed_index_analysis.sql
@@ -2,6 +2,7 @@
 
 set allow_experimental_parallel_reading_from_replicas=0;
 set enable_analyzer = 1;
+set query_plan_merge_expressions = 1; -- vector search optimizer requires merged expression steps to recognize the plan pattern
 --- Ignore warnings when replica does not respond, and analysis is done on initiator
 set send_logs_level='error';
 

--- a/tests/queries/0_stateless/02354_vector_search_drop_table_clear_cache.sql
+++ b/tests/queries/0_stateless/02354_vector_search_drop_table_clear_cache.sql
@@ -7,6 +7,7 @@
 SET enable_analyzer = 1;
 SET parallel_replicas_local_plan = 1; -- this setting is randomized, set it explicitly to force local plan for parallel replicas
 SET query_plan_optimize_lazy_materialization = 1;
+SET query_plan_merge_expressions = 1; -- vector search optimizer requires merged expression steps to recognize the plan pattern
 
 DROP TABLE IF EXISTS tab;
 

--- a/tests/queries/0_stateless/02354_vector_search_nonindexed_columns.sql
+++ b/tests/queries/0_stateless/02354_vector_search_nonindexed_columns.sql
@@ -8,6 +8,7 @@
 SET enable_analyzer = 1;
 SET parallel_replicas_local_plan = 1;
 SET optimize_move_to_prewhere = 1, query_plan_optimize_prewhere = 1;
+SET query_plan_merge_expressions = 1; -- vector search optimizer requires merged expression steps to recognize the plan pattern
 
 DROP TABLE IF EXISTS tab;
 

--- a/tests/queries/0_stateless/02354_vector_search_part_format.sql
+++ b/tests/queries/0_stateless/02354_vector_search_part_format.sql
@@ -4,6 +4,7 @@
 -- Basic tests for vector similarity index stored in compact vs. wide format, respectively full vs. packed parts
 
 SET parallel_replicas_local_plan = 1; -- this setting is randomized, set it explicitly to have local plan for parallel replicas
+SET query_plan_merge_expressions = 1; -- vector search optimizer requires merged expression steps to recognize the plan pattern
 
 DROP TABLE IF EXISTS tab_compact_full;
 DROP TABLE IF EXISTS tab_wide_full;

--- a/tests/queries/0_stateless/02354_vector_search_pre_and_post_filtering.sql
+++ b/tests/queries/0_stateless/02354_vector_search_pre_and_post_filtering.sql
@@ -4,6 +4,7 @@
 
 SET enable_analyzer = 1;
 SET parallel_replicas_local_plan = 1; -- this setting is randomized, set it explicitly to have local plan for parallel replicas
+SET query_plan_merge_expressions = 1; -- vector search optimizer requires merged expression steps to recognize the plan pattern
 
 DROP TABLE IF EXISTS tab;
 

--- a/tests/queries/0_stateless/02354_vector_search_queries.sql
+++ b/tests/queries/0_stateless/02354_vector_search_queries.sql
@@ -5,6 +5,7 @@
 -- Test runs with analyzer enabled
 SET enable_analyzer = 1;
 SET query_plan_optimize_lazy_materialization = 1;
+SET query_plan_merge_expressions = 1; -- vector search optimizer requires merged expression steps to recognize the plan pattern
 
 SELECT '10 rows, index_granularity = 8192, GRANULARITY = 1 million --> 1 granule, 1 indexed block';
 

--- a/tests/queries/0_stateless/02354_vector_search_reference_vector_types.sql
+++ b/tests/queries/0_stateless/02354_vector_search_reference_vector_types.sql
@@ -5,6 +5,7 @@
 
 SET enable_analyzer = 1;
 SET parallel_replicas_local_plan = 1; -- this setting is randomized, set it explicitly to force local plan for parallel replicas
+SET query_plan_merge_expressions = 1; -- vector search optimizer requires merged expression steps to recognize the plan pattern
 
 DROP TABLE IF EXISTS tab_f64;
 DROP TABLE IF EXISTS tab_f32;

--- a/tests/queries/0_stateless/02354_vector_search_rescoring.sql
+++ b/tests/queries/0_stateless/02354_vector_search_rescoring.sql
@@ -5,6 +5,7 @@
 
 SET enable_analyzer = 1;
 SET parallel_replicas_local_plan = 1; -- this setting is randomized, set it explicitly to force local plan for parallel replicas
+SET query_plan_merge_expressions = 1; -- vector search optimizer requires merged expression steps to recognize the plan pattern
 
 DROP TABLE IF EXISTS tab;
 

--- a/tests/queries/0_stateless/02354_vector_search_rescoring_distance_in_select_list.sql
+++ b/tests/queries/0_stateless/02354_vector_search_rescoring_distance_in_select_list.sql
@@ -11,6 +11,7 @@
 
 SET enable_analyzer = 1;
 SET vector_search_with_rescoring = 0;
+SET query_plan_merge_expressions = 1; -- vector search optimizer requires merged expression steps to recognize the plan pattern
 
 SELECT 'Create tables with Array(Float32) and Array(BFloat16) column';
 

--- a/tests/queries/0_stateless/02354_vector_search_subquery.sql
+++ b/tests/queries/0_stateless/02354_vector_search_subquery.sql
@@ -4,6 +4,7 @@ SET enable_analyzer = 1; -- analyzer vs. non-analyzer produce slightly different
 SET query_plan_optimize_prewhere = 1;
 SET optimize_move_to_prewhere = 1;
 SET query_plan_optimize_lazy_materialization = 1;
+SET query_plan_merge_expressions = 1; -- vector search optimizer requires merged expression steps to recognize the plan pattern
 
 -- Reference vector for vector search is computed by a subquery (issue #69085)
 

--- a/tests/queries/0_stateless/02354_vector_search_vector_similarity_index_cache.sql
+++ b/tests/queries/0_stateless/02354_vector_search_vector_similarity_index_cache.sql
@@ -4,6 +4,7 @@
 -- Tests the vector index cache.
 
 SET parallel_replicas_local_plan = 1;
+SET query_plan_merge_expressions = 1; -- vector search optimizer requires merged expression steps to recognize the plan pattern
 
 SYSTEM CLEAR VECTOR SIMILARITY INDEX CACHE;
 SELECT metric, value FROM system.metrics WHERE metric = 'VectorSimilarityIndexCacheBytes';

--- a/tests/queries/0_stateless/02354_vector_search_with_huge_dimension.sql
+++ b/tests/queries/0_stateless/02354_vector_search_with_huge_dimension.sql
@@ -3,6 +3,7 @@
 -- Tests vector search over vectors with a huge dimension (32k)
 
 SET parallel_replicas_local_plan = 1;
+SET query_plan_merge_expressions = 1; -- vector search optimizer requires merged expression steps to recognize the plan pattern
 
 DROP TABLE IF EXISTS tab;
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Not required

### What's changed

Pin `query_plan_merge_expressions = 1` in 14 vector search tests that depend on the vector similarity index being used.

**Root cause:** The vector search optimizer (`tryUseVectorSearch()` in `useVectorSearch.cpp`) requires a specific merged expression step sequence: `LimitStep → SortingStep → ExpressionStep → ReadFromMergeTree`. When `query_plan_merge_expressions` is randomized to `0` by the CI test runner, expressions are not merged, the optimizer fails to detect the pattern, and falls back to brute-force scan — producing different (exact) results instead of the approximate index results the tests expect.

**Evidence:** CIDB shows 20+ distinct PRs affected across 14 tests in the last 30 days:

| Test | PRs affected (30d) | Total hits |
|------|-------------------|------------|
| `pre_and_post_filtering` | 6 | 17 |
| `nonindexed_columns` | 5 | 9 |
| `rescoring` | 5 | 9 |
| `choose_correct_index` | 4 | 30 |
| `with_huge_dimension` | 4 | 33 |
| `rescoring_distance_in_select_list` | 4 | 11 |
| `binary_quantization` | 3 | 9 |
| `queries` | 3 | 8 |
| `distributed_index_analysis` | 3 | 7 |
| ... and 5 more | 2-3 each | |

**Reproduction:** Deterministic — `CLICKHOUSE_CLIENT_OPT="--query_plan_merge_expressions 0"` triggers the failure in every affected test. Fix (query-level SET) overrides the CLI setting.

**Verification:** All 12 locally-verifiable tests pass 20/20 with full randomization after the fix. (2 tests — `distributed_index_analysis` and `rescoring_and_prewhere` — require parallel replicas infrastructure not available locally; `rescoring_and_prewhere` was already fixed in #101573.)

This extends #101573 which applied the same fix to `rescoring_and_prewhere` only.

**Tests changed:**
1. `02354_vector_search_binary_quantization`
2. `02354_vector_search_choose_correct_index`
3. `02354_vector_search_distributed_index_analysis`
4. `02354_vector_search_drop_table_clear_cache`
5. `02354_vector_search_nonindexed_columns`
6. `02354_vector_search_part_format`
7. `02354_vector_search_pre_and_post_filtering`
8. `02354_vector_search_queries`
9. `02354_vector_search_reference_vector_types`
10. `02354_vector_search_rescoring`
11. `02354_vector_search_rescoring_distance_in_select_list`
12. `02354_vector_search_subquery`
13. `02354_vector_search_vector_similarity_index_cache`
14. `02354_vector_search_with_huge_dimension`