### PR TITLE
Fix flaky test 03734_has_function_key_condition_skip_index_explain

### DIFF
--- a/tests/queries/0_stateless/03734_has_function_key_condition_skip_index_explain.sql
+++ b/tests/queries/0_stateless/03734_has_function_key_condition_skip_index_explain.sql
@@ -2,6 +2,8 @@
 -- add_minmax_index_for_numeric_columns=0: Changes plan
 -- EXPLAIN output may differ
 
+SET query_plan_merge_expressions = 1;
+
 -- { echoOn }
 
 DROP TABLE IF EXISTS test_has_skip_minmax;


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- none

### What this PR does

Pin `query_plan_merge_expressions = 1` in test `03734_has_function_key_condition_skip_index_explain` to fix flaky failures caused by the CI settings randomizer.

**Root cause:** When `query_plan_merge_expressions` randomizes to 0, the query planner does not merge consecutive Expression/Filter steps. This changes EXPLAIN output structure:
- `Expression ((Project names + Projection))` splits into `Expression (Project names)` → `Expression (Projection)`
- `Filter ((WHERE + Change column names to column identifiers))` splits into `Filter (WHERE)` → `Expression (Change column names to column identifiers)`

The test verifies that `has()` function correctly triggers KeyCondition and skip index pruning (minmax, set, bloom_filter) — expression step merging is irrelevant to this verification.

**CIDB evidence:** 17 failures across 6 unrelated PRs in 30 days, 0 master hits.

**Reproduction:** `CLICKHOUSE_CLIENT_OPT="--query_plan_merge_expressions 0"` deterministically triggers the failure.

**Validation:** 50/50 passes with full randomization after the fix.