### PR TITLE
Test: raise `max_memory_usage` for TPC-H Q05 to 6 GB

### DIFF
--- a/tests/queries/0_stateless/04040_tpc_h_q05.sh
+++ b/tests/queries/0_stateless/04040_tpc_h_q05.sh
@@ -12,4 +12,4 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=./04040_tpc_h.lib
 . "$CURDIR"/04040_tpc_h.lib
 
-{ echo "USE tpch;"; cat "$CURDIR/../../benchmarks/tpc-h/queries/query_05.sql"; } | $CLICKHOUSE_CLIENT "${SETTINGS[@]}"
+{ echo "USE tpch;"; cat "$CURDIR/../../benchmarks/tpc-h/queries/query_05.sql"; } | $CLICKHOUSE_CLIENT "${SETTINGS[@]}" --max_memory_usage 6000000000


### PR DESCRIPTION
The query needs ~4.72 GiB for the hash join, which can exceed the default 5 GB limit from limits.yaml. Example of failing CI [here](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=7904ee0aa343a6ea2976fe7b0c7d0cd3fa777bb3&name_0=NightlyCoverage&name_1=Stateless%20tests%20%28amd_coverage%2C%205%2F8%29&name_1=Stateless%20tests%20%28amd_coverage%2C%205%2F8%29)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.545`
<!-- ch-version-info:end -->