### PR TITLE
Fix flaky test 02346_text_index_prewhere_support

### DIFF
--- a/tests/queries/0_stateless/02346_text_index_prewhere_support.sh
+++ b/tests/queries/0_stateless/02346_text_index_prewhere_support.sh
@@ -167,7 +167,7 @@ function run()
     $MY_CLICKHOUSE_CLIENT --query "
         SELECT trim(explain) FROM
         (
-            EXPLAIN actions = 1, indexes = 1 $query SETTINGS use_skip_indexes_on_data_read = 1
+            EXPLAIN actions = 1, indexes = 1 $query SETTINGS use_skip_indexes_on_data_read = 1, query_plan_remove_unused_columns = 1
         )
         WHERE explain LIKE '%INPUT%\_\_text_index%' OR explain ILIKE '%name: inv_idx%'
     "

--- a/tests/queries/0_stateless/02346_text_index_prewhere_support.sh
+++ b/tests/queries/0_stateless/02346_text_index_prewhere_support.sh
@@ -7,7 +7,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 set -e
 
-MY_CLICKHOUSE_CLIENT="$CLICKHOUSE_CLIENT --enable_analyzer 1 --use_skip_indexes_on_data_read 1"
+MY_CLICKHOUSE_CLIENT="$CLICKHOUSE_CLIENT --enable_analyzer 1 --use_skip_indexes_on_data_read 1 --query_plan_remove_unused_columns 1"
 
 $MY_CLICKHOUSE_CLIENT --query "
     DROP TABLE IF EXISTS tab;
@@ -167,7 +167,7 @@ function run()
     $MY_CLICKHOUSE_CLIENT --query "
         SELECT trim(explain) FROM
         (
-            EXPLAIN actions = 1, indexes = 1 $query SETTINGS use_skip_indexes_on_data_read = 1, query_plan_remove_unused_columns = 1
+            EXPLAIN actions = 1, indexes = 1 $query SETTINGS use_skip_indexes_on_data_read = 1
         )
         WHERE explain LIKE '%INPUT%\_\_text_index%' OR explain ILIKE '%name: inv_idx%'
     "


### PR DESCRIPTION
Pin `query_plan_remove_unused_columns = 1` in the EXPLAIN query to stabilize skip index
EXPLAIN output when the setting is randomized to False.

When `query_plan_remove_unused_columns` is False (newly randomized by #100874), unused
columns stay in the query plan. This shifts text index INPUT node positions from 0 to 1+
and drops the `Actions:` prefix, causing the reference file comparison to fail. The setting
is pinned only in the EXPLAIN subquery (query-level SETTINGS) — actual query execution and
data correctness checks are unaffected.

17 failures across 7 unrelated PRs in 30 days.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.549`
<!-- ch-version-info:end -->