### PR TITLE
Add test with virtual columns pruning for delta lake

### DIFF
--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -5025,3 +5025,14 @@ def test_insert_select_from_cluster_with_partition_pruning(started_cluster, allo
     )
     assert result == 0
     node.query(f"DROP TABLE IF EXISTS {table_name2}_dst ON CLUSTER cluster")
+    node.query("SYSTEM FLUSH LOGS ON CLUSTER 'cluster'")
+    filtered = int(
+        node.query(
+            f"""
+            SELECT ProfileEvents['ObjectStoragePredicateFilteredObjects']
+            FROM system.query_log
+            WHERE query_id = '{query_id}' AND type = 'QueryFinish' AND is_initial_query = 1
+            """
+        )
+    )
+    assert filtered >= 2


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Delta lake pruner with virtual columns. This closes https://github.com/ClickHouse/ClickHouse/issues/101515

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.546`
<!-- ch-version-info:end -->