### PR TITLE
Disable per-query memory limit for TPC-H/TPC-DS correctness tests

### DIFF
--- a/tests/queries/0_stateless/04033_tpc_ds.lib
+++ b/tests/queries/0_stateless/04033_tpc_ds.lib
@@ -6,7 +6,11 @@ TPCDS_SETTINGS_JSON="$CURDIR/../../benchmarks/tpc-ds/settings.json"
 
 # 1. --max_rows_to_read 0 because of https://github.com/ClickHouse/ClickHouse/issues/99937. Can be removed after the issue is closed.
 # 2. TPC-DS tables use S3 web disk. Increase HTTP retries to avoid transient `No message received` errors (default is 10).
-SETTINGS=(-m --max_rows_to_read 0 --http_max_tries 100)
+# 3. --max_memory_usage 0: The default `parallel_hash` join algorithm causes the greedy join
+#    order optimizer to choose a high-memory join order for multi-table TPC queries (4-5 GiB
+#    vs ~850 MiB with `hash`). This exceeds the CI profile's 5G limit on coverage builds.
+#    These tests verify correctness, not memory usage — disable the per-query memory limit.
+SETTINGS=(-m --max_rows_to_read 0 --http_max_tries 100 --max_memory_usage 0)
 _tpcds_output=$(jq -e -r '
     "--format", .format,
     (.settings | to_entries[] | "--\(.key)", (.value | tostring))

--- a/tests/queries/0_stateless/04040_tpc_h.lib
+++ b/tests/queries/0_stateless/04040_tpc_h.lib
@@ -5,7 +5,11 @@
 TPCH_SETTINGS_JSON="$CURDIR/../../benchmarks/tpc-h/settings.json"
 
 # --max_rows_to_read 0 because of https://github.com/ClickHouse/ClickHouse/issues/99937. Can be removed after the issue is closed.
-SETTINGS=(-m --max_rows_to_read 0)
+# --max_memory_usage 0: The default `parallel_hash` join algorithm causes the greedy join
+# order optimizer to choose a high-memory join order for multi-table TPC queries (4-5 GiB
+# vs ~850 MiB with `hash`). This exceeds the CI profile's 5G limit on coverage builds.
+# These tests verify correctness, not memory usage — disable the per-query memory limit.
+SETTINGS=(-m --max_rows_to_read 0 --max_memory_usage 0)
 _tpch_output=$(jq -e -r '
     (.settings | to_entries[] | "--\(.key)", (.value | tostring))
 ' "$TPCH_SETTINGS_JSON")


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
N/A

### What the bug is

TPC-H correctness tests (04040_tpc_h_q05 in particular) intermittently fail with `MEMORY_LIMIT_EXCEEDED` on `amd_coverage` builds (~33% failure rate, 2 master failures in 14 days).

The CI profile (`tests/config/users.d/limits.yaml`) sets `max_memory_usage: 5G` (= 4.66 GiB). The TPC-H Q05 query peaks at 4.06–4.72 GiB depending on hash table sizing, right at the edge of this limit.

### Root cause analysis

**This is NOT coverage-specific.** The root cause is the `parallel_hash` join algorithm causing the greedy join order optimizer to choose a dramatically worse join order.

For TPC-H Q05 (6-table join: customer, orders, lineitem, supplier, nation, region with `join_use_nulls=1`):

| Algorithm | Build rows | Peak memory | Join order |
|-----------|-----------|-------------|------------|
| `hash` | 6.2M | 854 MiB | Optimal — lineitem on build side |
| `parallel_hash` | **30.5M** | **4.06–4.72 GiB** | Bad — creates many-to-many customer⋈supplier intermediate (5x larger) |

The `parallel_hash` order joins customer with supplier on `nationkey=nationkey` before joining with orders. This creates a many-to-many product: each of ~6K customers per Asian nation matches EVERY ~400 supplier per nation → ~12M intermediate rows. The `hash` order avoids this by joining customer with orders first on `custkey` (one-to-many).

**Reproduction:**
```bash
# With hash (good order, ~850 MiB):
clickhouse-client --join_use_nulls 1 --max_rows_to_read 0 --join_algorithm hash \
  -q "USE tpch; SELECT n_name, ... FROM customer, orders, lineitem, supplier, nation, region WHERE ... GROUP BY n_name"

# With parallel_hash (bad order, ~4.7 GiB):
clickhouse-client --join_use_nulls 1 --max_rows_to_read 0 --join_algorithm parallel_hash \
  -q "USE tpch; SELECT n_name, ... FROM customer, orders, lineitem, supplier, nation, region WHERE ... GROUP BY n_name"
```

The default `join_algorithm` is `direct,parallel_hash,hash` — `parallel_hash` is tried first.

**Why only `amd_coverage` fails:** The peak memory (4.06–4.72 GiB) is right at the CI limit (4.66 GiB). Whether it fits depends on exact hash table sizing, which varies slightly between runs and builds. The `amd_coverage` build happens to hit conditions (possibly ThinLTO disabled, different cost estimates) where `parallel_hash` is consistently selected with a large enough hash table to exceed the limit ~33% of the time.

### The fix

Set `max_memory_usage=0` (unlimited) in both TPC-H and TPC-DS `.lib` files. This matches the existing `max_rows_to_read=0` pattern already present for the same tests (see [#99937](https://github.com/ClickHouse/ClickHouse/issues/99937)). These tests verify query **correctness** against reference files, not memory behavior.

**Note:** The underlying optimizer behavior (different join orders for `parallel_hash` vs `hash`) may warrant a separate investigation in the join order optimizer.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)