### PR TITLE
Fix flaky test 03668_shard_join_in_reverse_order

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -960,14 +960,16 @@ Pipe ReadFromMergeTree::readByLayers(
                 sort_description.emplace_back(sorting_columns[i], input_order_info->direction);
         }
 
+        ReadType in_order_read_type = input_order_info->direction > 0 ? ReadType::InOrder : ReadType::InReverseOrder;
+
         reading_step_getter
-            = [this, &index_build_context, &in_order_column_names_to_read, &info, sorting_expr, &sort_description](auto parts)
+            = [this, &index_build_context, &in_order_column_names_to_read, &info, sorting_expr, &sort_description, in_order_read_type](auto parts)
         {
             auto pipe = this->read(
                 std::move(parts),
                 index_build_context,
                 in_order_column_names_to_read,
-                ReadType::InOrder,
+                in_order_read_type,
                 1 /* num_streams */,
                 0 /* min_marks_for_concurrent_read */,
                 info.use_uncompressed_cache);

--- a/tests/queries/0_stateless/03668_shard_join_in_reverse_order.reference
+++ b/tests/queries/0_stateless/03668_shard_join_in_reverse_order.reference
@@ -1,9 +1,3 @@
--- { echo ON }
-
-DROP TABLE IF EXISTS t0;
-CREATE TABLE t0 (c0 Int) ENGINE = MergeTree() ORDER BY (c0 DESC) SETTINGS index_granularity = 1, allow_experimental_reverse_key = 1;
-INSERT INTO TABLE t0 (c0) SELECT number FROM numbers(10);
-SELECT c0 FROM t0 JOIN t0 tx USING (c0) ORDER BY c0 SETTINGS query_plan_join_shard_by_pk_ranges = 1, max_threads = 2, query_plan_read_in_order_through_join = 1;
 0
 1
 2
@@ -14,4 +8,14 @@ SELECT c0 FROM t0 JOIN t0 tx USING (c0) ORDER BY c0 SETTINGS query_plan_join_sha
 7
 8
 9
-DROP TABLE t0;
+---
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9

--- a/tests/queries/0_stateless/03668_shard_join_in_reverse_order.sql
+++ b/tests/queries/0_stateless/03668_shard_join_in_reverse_order.sql
@@ -1,11 +1,17 @@
--- { echo ON }
-
 DROP TABLE IF EXISTS t0;
 
 CREATE TABLE t0 (c0 Int) ENGINE = MergeTree() ORDER BY (c0 DESC) SETTINGS index_granularity = 1, allow_experimental_reverse_key = 1;
 
 INSERT INTO TABLE t0 (c0) SELECT number FROM numbers(10);
 
-SELECT c0 FROM t0 JOIN t0 tx USING (c0) ORDER BY c0 SETTINGS query_plan_join_shard_by_pk_ranges = 1, max_threads = 2, query_plan_read_in_order_through_join = 1;
+SELECT c0 FROM t0 JOIN t0 tx USING (c0) ORDER BY c0 SETTINGS query_plan_join_shard_by_pk_ranges = 1, max_threads = 2;
+
+SELECT '---';
+
+-- Same query with three settings pinned to trigger the read-in-order path through join sharding:
+-- query_plan_read_in_order_through_join=1 lets optimizeReadInOrder traverse through the JOIN,
+-- read_in_order_use_virtual_row=1 enables read-in-order for INNER JOIN,
+-- enable_join_runtime_filters=0 lets optimizeJoinByShards see the right-side source.
+SELECT c0 FROM t0 JOIN t0 tx USING (c0) ORDER BY c0 SETTINGS query_plan_join_shard_by_pk_ranges = 1, max_threads = 2, query_plan_read_in_order_through_join = 1, read_in_order_use_virtual_row = 1, enable_join_runtime_filters = 0;
 
 DROP TABLE t0;


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix flaky test 03668_shard_join_in_reverse_order

Closes https://github.com/ClickHouse/ClickHouse/issues/100870

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.567`
<!-- ch-version-info:end -->