### PR TITLE
Fix incorrect pool reuse across MySQL dictionaries

### DIFF
--- a/src/Common/mysqlxx/PoolFactory.cpp
+++ b/src/Common/mysqlxx/PoolFactory.cpp
@@ -7,11 +7,8 @@ namespace mysqlxx
 
 struct PoolFactory::Impl
 {
-    // Cache of already affected pools identified by their config name
-    std::map<std::string, std::shared_ptr<PoolWithFailover>> pools;
-
     // Cache of Pool ID (host + port + user +...) cibling already established shareable pool
-    std::map<std::string, std::string> pools_by_ids;
+    std::map<std::string, std::shared_ptr<PoolWithFailover>> shared_pools_by_id;
 
     /// Protect pools and pools_by_ids caches
     std::mutex mutex;
@@ -68,39 +65,26 @@ static std::string getPoolEntryName(const Poco::Util::AbstractConfiguration & co
 PoolWithFailover PoolFactory::get(const Poco::Util::AbstractConfiguration & config,
         const std::string & config_name, unsigned default_connections, unsigned max_connections, size_t max_tries)
 {
-
     std::lock_guard lock(impl->mutex);
-    auto entry = impl->pools.find(config_name);
-    if (entry != impl->pools.end())
-    {
-        return *(entry->second);
-    }
 
-    std::string entry_name = getPoolEntryName(config, config_name);
-    if (auto id = impl->pools_by_ids.find(entry_name); id != impl->pools_by_ids.end())
-    {
-        entry = impl->pools.find(id->second);
-        std::shared_ptr<PoolWithFailover> pool = entry->second;
-        impl->pools.insert_or_assign(config_name, pool);
-        return *pool;
-    }
+    const std::string entry_name = getPoolEntryName(config, config_name);
+
+    if (entry_name.empty())
+        return PoolWithFailover(config, config_name, default_connections, max_connections, max_tries);
+
+    if (auto it = impl->shared_pools_by_id.find(entry_name); it != impl->shared_pools_by_id.end())
+        return *(it->second);
 
     auto pool = std::make_shared<PoolWithFailover>(config, config_name, default_connections, max_connections, max_tries);
-    // Check the pool will be shared
-    if (!entry_name.empty())
-    {
-        // Store shared pool
-        impl->pools.insert_or_assign(config_name, pool);
-        impl->pools_by_ids.insert_or_assign(entry_name, config_name);
-    }
+    impl->shared_pools_by_id.emplace(entry_name, pool);
+
     return *pool;
 }
 
 void PoolFactory::reset()
 {
     std::lock_guard lock(impl->mutex);
-    impl->pools.clear();
-    impl->pools_by_ids.clear();
+    impl->shared_pools_by_id.clear();
 }
 
 PoolFactory::PoolFactory() : impl(std::make_unique<PoolFactory::Impl>()) {}

--- a/tests/integration/test_dictionaries_mysql/test.py
+++ b/tests/integration/test_dictionaries_mysql/test.py
@@ -373,6 +373,65 @@ def test_predefined_connection_configuration(started_cluster):
     assert int(result) == 200
 
 
+def test_mysql_share_connection_dictionaries(started_cluster):
+    try:
+        instance.query("DROP DICTIONARY IF EXISTS mysql_shared_dict")
+        instance.query("DROP DICTIONARY IF EXISTS mysql_non_shared_dict")
+
+        instance.query(
+            f"""
+        CREATE DICTIONARY mysql_shared_dict
+        (
+            id UInt64,
+            value UInt32
+        )
+        PRIMARY KEY id
+        SOURCE(MYSQL(
+            HOST '123.456.78.9'
+            PORT 3306
+            USER 'user_1'
+            PASSWORD 'xxx'
+            DB 'db_1'
+            TABLE 'tbl_1'
+            SHARE_CONNECTION 1))
+        LAYOUT(DIRECT())
+        """
+        )
+
+        instance.query(
+            f"""
+        CREATE DICTIONARY mysql_non_shared_dict
+        (
+            id UInt64,
+            value UInt32
+        )
+        PRIMARY KEY id
+        SOURCE(MYSQL(
+            HOST '456.78.9.123'
+            PORT 3306
+            USER 'user_2'
+            PASSWORD 'xxx'
+            DB 'db_2'
+            TABLE 'tbl_2'))
+        LAYOUT(DIRECT())
+        """
+        )
+
+        result = instance.query_and_get_error(
+            "SELECT count() from mysql_shared_dict"
+        )
+        assert ("db_1@123.456.78.9:3306" in result)
+
+        result = instance.query_and_get_error(
+            "SELECT count() from mysql_non_shared_dict"
+        )
+        assert ("db_2@456.78.9.123:3306" in result)
+
+    finally:
+        instance.query("DROP DICTIONARY IF EXISTS mysql_non_shared_dict")
+        instance.query("DROP DICTIONARY IF EXISTS mysql_shared_dict")
+
+
 def create_mysql_db(mysql_connection, name):
     with mysql_connection.cursor() as cursor:
         cursor.execute("DROP DATABASE IF EXISTS {}".format(name))


### PR DESCRIPTION
Fixes: #101578


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix incorrect pool reuse across MySQL dictionaries, because they have same config_name `dictionary.source.mysql`


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
