### PR TITLE
Fix orphaned AST children when removing fields via direct nullptr assignment

### DIFF
--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -734,11 +734,11 @@ void QueryFuzzer::fuzzWindowFrame(ASTWindowDefinition & def)
             if (def.frame_begin_type == WindowFrame::BoundaryType::Offset)
             {
                 // The offsets are fuzzed normally through 'children'.
-                def.frame_begin_offset = make_intrusive<ASTLiteral>(getRandomField(0));
+                def.setOrReplace(def.frame_begin_offset, make_intrusive<ASTLiteral>(getRandomField(0)));
             }
             else
             {
-                def.frame_begin_offset = nullptr;
+                def.reset(def.frame_begin_offset);
             }
             break;
         }
@@ -750,11 +750,11 @@ void QueryFuzzer::fuzzWindowFrame(ASTWindowDefinition & def)
 
             if (def.frame_end_type == WindowFrame::BoundaryType::Offset)
             {
-                def.frame_end_offset = make_intrusive<ASTLiteral>(getRandomField(0));
+                def.setOrReplace(def.frame_end_offset, make_intrusive<ASTLiteral>(getRandomField(0)));
             }
             else
             {
-                def.frame_end_offset = nullptr;
+                def.reset(def.frame_end_offset);
             }
             break;
         }
@@ -843,13 +843,13 @@ void QueryFuzzer::fuzzCreateQuery(ASTCreateQuery & create)
             if (startsWith(engine_name, "Replicated"))
             {
                 engine_name = engine_name.substr(strlen("Replicated"));
-                if (auto & arguments = create.storage->engine->arguments)
+                auto * engine = create.storage->engine;
+                if (engine->arguments)
                 {
-                    auto & children = arguments->children;
-                    if (children.size() <= 2)
-                        arguments.reset();
+                    if (engine->arguments->children.size() <= 2)
+                        engine->reset(engine->arguments);
                     else
-                        children.erase(children.begin(), children.begin() + 2);
+                        engine->arguments->children.erase(engine->arguments->children.begin(), engine->arguments->children.begin() + 2);
                 }
             }
 

--- a/src/Databases/DatabaseOnDisk.cpp
+++ b/src/Databases/DatabaseOnDisk.cpp
@@ -164,7 +164,7 @@ String getObjectDefinitionFromCreateQuery(const ASTPtr & query)
 
     /// We remove everything that is not needed for ATTACH from the query.
     assert(!create->isTemporary());
-    create->database.reset();
+    create->reset(create->database);
 
     if (create->uuid != UUIDHelpers::Nil)
         create->setTable(TABLE_WITH_UUID_NAME_PLACEHOLDER);

--- a/src/Databases/DatabaseReplicated.cpp
+++ b/src/Databases/DatabaseReplicated.cpp
@@ -1336,7 +1336,7 @@ void DatabaseReplicated::checkQueryValid(const ASTPtr & query, ContextPtr query_
     {
         if (ddl_query->getDatabase() != getDatabaseName())
             throw Exception(ErrorCodes::UNKNOWN_DATABASE, "Database was renamed");
-        ddl_query->database.reset();
+        ddl_query->reset(ddl_query->database);
 
         if (auto * create = query->as<ASTCreateQuery>())
         {

--- a/src/Databases/DatabasesCommon.cpp
+++ b/src/Databases/DatabasesCommon.cpp
@@ -205,12 +205,12 @@ void applyMetadataChangesToCreateQuery(const ASTPtr & query, const StorageInMemo
             if (metadata.sampling_key.definition_ast)
                 storage_ast.set(storage_ast.sample_by, metadata.sampling_key.definition_ast);
             else if (storage_ast.sample_by != nullptr) /// SAMPLE BY was removed
-                storage_ast.sample_by = nullptr;
+                storage_ast.reset(storage_ast.sample_by);
 
             if (metadata.table_ttl.definition_ast)
                 storage_ast.set(storage_ast.ttl_table, metadata.table_ttl.definition_ast);
             else if (storage_ast.ttl_table != nullptr) /// TTL was removed
-                storage_ast.ttl_table = nullptr;
+                storage_ast.reset(storage_ast.ttl_table);
 
             if (metadata.settings_changes)
                 storage_ast.set(storage_ast.settings, metadata.settings_changes);
@@ -313,10 +313,10 @@ void cleanupObjectDefinitionFromTemporaryFlags(ASTCreateQuery & query)
 
     /// For views it is necessary to save the SELECT query itself, for the rest - on the contrary
     if (!query.isView())
-        query.select = nullptr;
+        query.reset(query.select);
 
-    query.format_ast = nullptr;
-    query.out_file = nullptr;
+    query.reset(query.format_ast);
+    query.reset(query.out_file);
 }
 
 String readMetadataFile(std::shared_ptr<IDisk> disk, const String & file_path)

--- a/src/Databases/MySQL/DatabaseMySQL.cpp
+++ b/src/Databases/MySQL/DatabaseMySQL.cpp
@@ -208,7 +208,6 @@ ASTPtr DatabaseMySQL::getCreateTableQueryImpl(const String & table_name, Context
     {
         ASTStorage * ast_storage = table_storage_define->as<ASTStorage>();
         ast_storage->engine->setKind(ASTFunction::Kind::TABLE_ENGINE);
-        ASTs storage_children = ast_storage->children;
         auto storage_engine_arguments = ast_storage->engine->arguments;
 
         /// Add table_name to engine arguments

--- a/src/Databases/MySQL/DatabaseMySQL.cpp
+++ b/src/Databases/MySQL/DatabaseMySQL.cpp
@@ -224,8 +224,7 @@ ASTPtr DatabaseMySQL::getCreateTableQueryImpl(const String & table_name, Context
         }
 
         /// Unset settings
-        std::erase_if(storage_children, [&](const ASTPtr & element) { return element.get() == ast_storage->settings; });
-        ast_storage->settings = nullptr;
+        ast_storage->reset(ast_storage->settings);
     }
 
     const Settings & settings = getContext()->getSettingsRef();

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -2360,8 +2360,8 @@ BlockIO InterpreterCreateQuery::fillTableIfNeeded(const ASTCreateQuery & create)
         command_list->children.push_back(command);
 
         auto query = make_intrusive<ASTAlterQuery>();
-        query->database = create.database;
-        query->table = create.table;
+        query->setDatabase(create.getDatabase());
+        query->setTable(create.getTable());
         query->uuid = create.uuid;
         auto * alter = query->as<ASTAlterQuery>();
 

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1255,7 +1255,7 @@ void InterpreterCreateQuery::setEngine(ASTCreateQuery & create) const
             }
             else
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "Storage should not be created yet, it's a bug.");
-            create.as_table_function = nullptr;
+            create.reset(create.as_table_function);
             setNullTableEngine(*create.storage);
         }
         return;

--- a/src/Interpreters/InterpreterSetQuery.cpp
+++ b/src/Interpreters/InterpreterSetQuery.cpp
@@ -122,7 +122,7 @@ void InterpreterSetQuery::applySettingsFromQuery(const ASTPtr & ast, ContextMuta
                 }
 
                 if (engine_settings->changes.empty())
-                    create_query->storage->settings = nullptr;
+                    create_query->storage->reset(create_query->storage->settings);
             }
         }
     }

--- a/src/Interpreters/NormalizeSelectWithUnionQueryVisitor.cpp
+++ b/src/Interpreters/NormalizeSelectWithUnionQueryVisitor.cpp
@@ -34,7 +34,8 @@ void NormalizeSelectWithUnionQueryMatcher::visit(ASTPtr & ast, Data & data)
         /// we need to keep and restore it.
         auto format = select_union->format_ast;
         visit(*select_union, data);
-        select_union->format_ast = format;
+        select_union->reset(select_union->format_ast);
+        select_union->set(select_union->format_ast, std::move(format));
     }
 }
 

--- a/src/Parsers/ASTAlterQuery.cpp
+++ b/src/Parsers/ASTAlterQuery.cpp
@@ -688,6 +688,9 @@ ASTPtr ASTAlterQuery::clone() const
     if (command_list)
         res->set(res->command_list, command_list->clone());
 
+    cloneOutputOptions(*res);
+    cloneTableOptions(*res);
+
     return res;
 }
 

--- a/src/Parsers/ASTInsertQuery.cpp
+++ b/src/Parsers/ASTInsertQuery.cpp
@@ -35,18 +35,16 @@ String ASTInsertQuery::getTable() const
 
 void ASTInsertQuery::setDatabase(const String & name)
 {
-    if (name.empty())
-        database.reset();
-    else
-        database = make_intrusive<ASTIdentifier>(name);
+    reset(database);
+    if (!name.empty())
+        set(database, make_intrusive<ASTIdentifier>(name));
 }
 
 void ASTInsertQuery::setTable(const String & name)
 {
-    if (name.empty())
-        table.reset();
-    else
-        table = make_intrusive<ASTIdentifier>(name);
+    reset(table);
+    if (!name.empty())
+        set(table, make_intrusive<ASTIdentifier>(name));
 }
 
 void ASTInsertQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const

--- a/src/Parsers/ASTKillQueryQuery.h
+++ b/src/Parsers/ASTKillQueryQuery.h
@@ -25,11 +25,12 @@ public:
     ASTPtr clone() const override
     {
         auto clone = make_intrusive<ASTKillQueryQuery>(*this);
+        clone->children.clear();
+
         if (where_expression)
-        {
-            clone->where_expression = where_expression->clone();
-            clone->children = {clone->where_expression};
-        }
+            clone->set(clone->where_expression, where_expression->clone());
+
+        cloneOutputOptions(*clone);
 
         return clone;
     }

--- a/src/Parsers/ASTOptimizeQuery.h
+++ b/src/Parsers/ASTOptimizeQuery.h
@@ -56,6 +56,9 @@ public:
             res->children.push_back(res->parts_list);
         }
 
+        cloneOutputOptions(*res);
+        cloneTableOptions(*res);
+
         return res;
     }
 

--- a/src/Parsers/ASTQueryWithOutput.cpp
+++ b/src/Parsers/ASTQueryWithOutput.cpp
@@ -94,22 +94,11 @@ bool ASTQueryWithOutput::resetOutputASTIfExist(IAST & ast)
     /// FIXME: try to prettify this cast using `as<>()`
     if (auto * ast_with_output = dynamic_cast<ASTQueryWithOutput *>(&ast))
     {
-        auto remove_if_exists = [&](ASTPtr & p)
-        {
-            if (p)
-            {
-                if (auto it = std::find(ast_with_output->children.begin(), ast_with_output->children.end(), p);
-                    it != ast_with_output->children.end())
-                    ast_with_output->children.erase(it);
-                p.reset();
-            }
-        };
-
-        remove_if_exists(ast_with_output->out_file);
-        remove_if_exists(ast_with_output->format_ast);
-        remove_if_exists(ast_with_output->settings_ast);
-        remove_if_exists(ast_with_output->compression);
-        remove_if_exists(ast_with_output->compression_level);
+        ast_with_output->reset(ast_with_output->out_file);
+        ast_with_output->reset(ast_with_output->format_ast);
+        ast_with_output->reset(ast_with_output->settings_ast);
+        ast_with_output->reset(ast_with_output->compression);
+        ast_with_output->reset(ast_with_output->compression_level);
 
         return true;
     }

--- a/src/Parsers/ASTQueryWithOutput.cpp
+++ b/src/Parsers/ASTQueryWithOutput.cpp
@@ -9,30 +9,15 @@ namespace DB
 void ASTQueryWithOutput::cloneOutputOptions(ASTQueryWithOutput & cloned) const
 {
     if (out_file)
-    {
-        cloned.out_file = out_file->clone();
-        cloned.children.push_back(cloned.out_file);
-    }
+        cloned.set(cloned.out_file, out_file->clone());
     if (format_ast)
-    {
-        cloned.format_ast = format_ast->clone();
-        cloned.children.push_back(cloned.format_ast);
-    }
+        cloned.set(cloned.format_ast, format_ast->clone());
     if (settings_ast)
-    {
-        cloned.settings_ast = settings_ast->clone();
-        cloned.children.push_back(cloned.settings_ast);
-    }
+        cloned.set(cloned.settings_ast, settings_ast->clone());
     if (compression)
-    {
-        cloned.compression = compression->clone();
-        cloned.children.push_back(cloned.compression);
-    }
+        cloned.set(cloned.compression, compression->clone());
     if (compression_level)
-    {
-        cloned.compression_level = compression_level->clone();
-        cloned.children.push_back(cloned.compression_level);
-    }
+        cloned.set(cloned.compression_level, compression_level->clone());
 }
 
 void ASTQueryWithOutput::formatImpl(WriteBuffer & ostr, const FormatSettings & s, FormatState & state, FormatStateStacked frame) const

--- a/src/Parsers/ASTQueryWithTableAndOutput.cpp
+++ b/src/Parsers/ASTQueryWithTableAndOutput.cpp
@@ -1,6 +1,5 @@
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTQueryWithTableAndOutput.h>
-#include <Parsers/IAST_erase.h>
 
 
 namespace DB
@@ -22,46 +21,24 @@ String ASTQueryWithTableAndOutput::getTable() const
 
 void ASTQueryWithTableAndOutput::setDatabase(const String & name)
 {
-    if (database)
-    {
-        std::erase(children, database);
-        database.reset();
-    }
-
+    reset(database);
     if (!name.empty())
-    {
-        database = make_intrusive<ASTIdentifier>(name);
-        children.push_back(database);
-    }
+        set(database, make_intrusive<ASTIdentifier>(name));
 }
 
 void ASTQueryWithTableAndOutput::setTable(const String & name)
 {
-    if (table)
-    {
-        std::erase(children, table);
-        table.reset();
-    }
-
+    reset(table);
     if (!name.empty())
-    {
-        table = make_intrusive<ASTIdentifier>(name);
-        children.push_back(table);
-    }
+        set(table, make_intrusive<ASTIdentifier>(name));
 }
 
 void ASTQueryWithTableAndOutput::cloneTableOptions(ASTQueryWithTableAndOutput & cloned) const
 {
     if (database)
-    {
-        cloned.database = database->clone();
-        cloned.children.push_back(cloned.database);
-    }
+        cloned.set(cloned.database, database->clone());
     if (table)
-    {
-        cloned.table = table->clone();
-        cloned.children.push_back(cloned.table);
-    }
+        cloned.set(cloned.table, table->clone());
 }
 
 }

--- a/src/Parsers/ASTSelectQuery.cpp
+++ b/src/Parsers/ASTSelectQuery.cpp
@@ -466,7 +466,7 @@ void ASTSelectQuery::replaceDatabaseAndTable(const StorageID & table_id)
     }
 
     String table_alias = getTableExpressionAlias(table_expression);
-    table_expression->database_and_table_name = make_intrusive<ASTTableIdentifier>(table_id);
+    table_expression->setOrReplace(table_expression->database_and_table_name, make_intrusive<ASTTableIdentifier>(table_id));
 
     if (!table_alias.empty())
         table_expression->database_and_table_name->setAlias(table_alias);
@@ -490,8 +490,8 @@ void ASTSelectQuery::addTableFunction(const ASTPtr & table_function_ptr)
 
     String table_alias = getTableExpressionAlias(table_expression);
     /// Maybe need to modify the alias, so we should clone new table_function node
-    table_expression->table_function = table_function_ptr->clone();
-    table_expression->database_and_table_name = nullptr;
+    table_expression->setOrReplace(table_expression->table_function, table_function_ptr->clone());
+    table_expression->reset(table_expression->database_and_table_name);
 
     if (table_alias.empty())
         table_expression->table_function->setAlias(table_alias);

--- a/src/Parsers/ASTSystemQuery.cpp
+++ b/src/Parsers/ASTSystemQuery.cpp
@@ -1,6 +1,5 @@
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/IAST.h>
-#include <Parsers/IAST_erase.h>
 #include <Parsers/ASTSystemQuery.h>
 #include <Poco/String.h>
 #include <Common/quoteString.h>
@@ -63,32 +62,16 @@ String ASTSystemQuery::getTable() const
 
 void ASTSystemQuery::setDatabase(const String & name)
 {
-    if (database)
-    {
-        std::erase(children, database);
-        database.reset();
-    }
-
+    reset(database);
     if (!name.empty())
-    {
-        database = make_intrusive<ASTIdentifier>(name);
-        children.push_back(database);
-    }
+        set(database, make_intrusive<ASTIdentifier>(name));
 }
 
 void ASTSystemQuery::setTable(const String & name)
 {
-    if (table)
-    {
-        std::erase(children, table);
-        table.reset();
-    }
-
+    reset(table);
     if (!name.empty())
-    {
-        table = make_intrusive<ASTIdentifier>(name);
-        children.push_back(table);
-    }
+        set(table, make_intrusive<ASTIdentifier>(name));
 }
 
 void ASTSystemQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & settings, FormatState & state, FormatStateStacked frame) const

--- a/src/Parsers/ASTViewTargets.cpp
+++ b/src/Parsers/ASTViewTargets.cpp
@@ -3,7 +3,6 @@
 #include <Common/quoteString.h>
 #include <Parsers/ASTCreateQuery.h>
 #include <Parsers/CommonParsers.h>
-#include <Parsers/IAST_erase.h>
 #include <IO/WriteHelpers.h>
 
 
@@ -153,18 +152,17 @@ void ASTViewTargets::setInnerEngine(ViewTarget::Kind kind, ASTPtr storage_def)
             if (target.inner_engine == new_inner_engine)
                 return;
             if (new_inner_engine)
-                children.push_back(new_inner_engine);
-            if (target.inner_engine)
-                std::erase(children, target.inner_engine);
-            target.inner_engine = new_inner_engine;
+                setOrReplace(target.inner_engine, std::move(new_inner_engine));
+            else
+                reset(target.inner_engine);
             return;
         }
     }
 
     if (new_inner_engine)
     {
-        targets.emplace_back(kind).inner_engine = new_inner_engine;
-        children.push_back(new_inner_engine);
+        auto & new_target = targets.emplace_back(kind);
+        set(new_target.inner_engine, std::move(new_inner_engine));
     }
 }
 
@@ -204,10 +202,7 @@ ASTPtr ASTViewTargets::clone() const
     for (auto & target : res->targets)
     {
         if (target.inner_engine)
-        {
-            target.inner_engine = boost::static_pointer_cast<ASTStorage>(target.inner_engine->clone());
-            res->children.push_back(target.inner_engine);
-        }
+            res->set(target.inner_engine, target.inner_engine->clone());
     }
     return res;
 }

--- a/src/Parsers/IAST.h
+++ b/src/Parsers/IAST.h
@@ -260,6 +260,41 @@ public:
         field.reset();
     }
 
+    void set(ASTPtr & field, ASTPtr child)
+    {
+        if (!child)
+            return;
+
+        children.push_back(child);
+        field = std::move(child);
+    }
+
+    void replace(ASTPtr & field, ASTPtr child)
+    {
+        if (!child)
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "Trying to replace AST subtree with nullptr");
+
+        for (ASTPtr & current_child : children)
+        {
+            if (current_child.get() == field.get())
+            {
+                current_child = child;
+                field = std::move(child);
+                return;
+            }
+        }
+
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "AST subtree not found in children");
+    }
+
+    void setOrReplace(ASTPtr & field, ASTPtr child)
+    {
+        if (field)
+            replace(field, std::move(child));
+        else
+            set(field, std::move(child));
+    }
+
     /// After changing one of `children` elements, update the corresponding member pointer if needed.
     void updatePointerToChild(const IAST * old_ptr, const ASTPtr & new_ptr)
     {

--- a/src/Parsers/IAST.h
+++ b/src/Parsers/IAST.h
@@ -239,6 +239,27 @@ public:
         field = nullptr;
     }
 
+    void reset(ASTPtr & field)
+    {
+        if (!field)
+            return;
+
+        auto child = children.begin();
+        while (child != children.end())
+        {
+            if (child->get() == field.get())
+                break;
+
+            child++;
+        }
+
+        if (child == children.end())
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "AST subtree not found in children");
+
+        children.erase(child);
+        field.reset();
+    }
+
     /// After changing one of `children` elements, update the corresponding member pointer if needed.
     void updatePointerToChild(const IAST * old_ptr, const ASTPtr & new_ptr)
     {

--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -1088,7 +1088,7 @@ std::optional<QueryPipeline> StorageDistributed::distributedWriteBetweenDistribu
             TableFunctionFactory::instance().get(src_distributed.remote_table_function_ptr, local_context);
         if (const TableFunctionView * view_function = typeid_cast<const TableFunctionView *>(src_table_function.get()))
         {
-            new_query->select = view_function->getSelectQuery().clone();
+            new_query->setOrReplace(new_query->select, view_function->getSelectQuery().clone());
         }
         else
         {
@@ -1104,7 +1104,7 @@ std::optional<QueryPipeline> StorageDistributed::distributedWriteBetweenDistribu
 
             select_with_union_query->list_of_selects->children.push_back(select->clone());
 
-            new_query->select = select_with_union_query;
+            new_query->setOrReplace(new_query->select, select_with_union_query);
         }
     }
     else
@@ -1118,7 +1118,7 @@ std::optional<QueryPipeline> StorageDistributed::distributedWriteBetweenDistribu
 
         new_select_query->replaceDatabaseAndTable(src_distributed.getRemoteDatabaseName(), src_distributed.getRemoteTableName());
 
-        new_query->select = select_with_union_query;
+        new_query->setOrReplace(new_query->select, select_with_union_query);
     }
 
     const auto src_cluster = src_distributed.getCluster();
@@ -1150,7 +1150,7 @@ std::optional<QueryPipeline> StorageDistributed::distributedWriteBetweenDistribu
     {
         new_query->table_id = StorageID(getRemoteDatabaseName(), getRemoteTableName());
         /// Reset table function for INSERT INTO remote()/cluster()
-        new_query->table_function.reset();
+        new_query->reset(new_query->table_function);
     }
 
     const auto & shards_info = dst_cluster->getShardsInfo();
@@ -1282,7 +1282,7 @@ std::optional<QueryPipeline> StorageDistributed::distributedWriteFromClusterStor
     {
         new_query->table_id = StorageID(getRemoteDatabaseName(), getRemoteTableName());
         /// Reset table function for INSERT INTO remote()/cluster()
-        new_query->table_function.reset();
+        new_query->reset(new_query->table_function);
     }
 
     String new_query_str;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add `IAST::reset(ASTPtr &)` overload and replace all bare `= nullptr` assignments on AST fields with `reset()` calls, so the children vector stays in sync with typed field pointers.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1030`
<!-- ch-version-info:end -->