### PR TITLE
Docs: correct introduced in version for cosineDistance

### DIFF
--- a/src/Functions/vectorFunctions.cpp
+++ b/src/Functions/vectorFunctions.cpp
@@ -2356,7 +2356,7 @@ SELECT cosineDistance((1, 2), (2, 3));
 └────────────────────────────────┘
             )"}
     };
-    FunctionDocumentation::IntroducedIn introduced_in_cosine_distance = {1, 1};
+    FunctionDocumentation::IntroducedIn introduced_in_cosine_distance = {21, 11};
     FunctionDocumentation::Category category_cosine_distance = FunctionDocumentation::Category::Distance;
     FunctionDocumentation documentation_cosine_distance = {description_cosine_distance, syntax_cosine_distance, arguments_cosine_distance, {}, returned_value_cosine_distance, examples_cosine_distance, introduced_in_cosine_distance, category_cosine_distance};
 


### PR DESCRIPTION
Corrects version for cosineDistance

Reference: https://pastila.nl/?00030e6c/a1384842f5e82e77ecfca2b55a98e03f#ELzAMSPTjypXVa87l3JuMw==
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.560`
<!-- ch-version-info:end -->