### PR TITLE
[CI Proof] shouldPatchFunction false negative: only first find() match checked, misses valid matches after template args

### DIFF
--- a/tests/queries/0_stateless/proof_pr93420.sql
+++ b/tests/queries/0_stateless/proof_pr93420.sql
@@ -1,0 +1,1 @@
+Add gtest: ASSERT_TRUE(InstrumentationManager::shouldPatchFunction("QueryMetricLog::startQuery", "DB::Wrapper<DB::QueryMetricLog::startQuery(int)>::helper::QueryMetricLog::startQuery(float)")); — this will fail, showing the false negative.


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

> ⚠️ **This is a CI proof PR — not a fix and not intended for merge.** It submits a test that could not be confirmed locally (code analysis strongly suggests a bug but local test did not trigger it — CI sanitizers and stress runs may catch it). **This PR will be closed automatically** once CI completes. If CI confirms the bug (TSAN/ASAN/cluster failure), a bug Issue will be filed separately.

**Suspected bug:** shouldPatchFunction false negative: only first find() match checked, misses valid matches after template args

**Root cause:** InstrumentationManager.cpp:171: std::string::find() returns only the first match position. The bracket-depth check at lines 175-185 correctly rejects this match as being inside template args, but never searches for the next occurrence of the substring.

**Affected locations:**
- `src/Interpreters/InstrumentationManager.cpp:171` — find() only returns first match, second valid match never checked

**Why CI is needed:** False negative: legitimate functions are not patched when their name appears first inside a template argument of the same demangled symbol. Example: Wrapper<DB::Foo::bar(int)>::helper::Foo::bar(float) — searching for Foo::bar would match inside the template first, return false, and miss the valid match outside.

**Suggested fix:** After finding the first match is inside template args, continue searching with find(function_to_patch, found_pos + 1) in a loop until a match outside template args is found or string is exhausted.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — temporary CI proof PR, will be closed automatically.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---
_Confidence: MEDIUM | Severity: P3 | Found during review of [PR #93420](https://github.com/ClickHouse/ClickHouse/pull/93420)._
