### PR TITLE
Fix copy-paste bug in `buildRangeConfiguration`: use `max_attr_name` for max attribute lookup

### DIFF
--- a/src/Dictionaries/DictionaryStructure.cpp
+++ b/src/Dictionaries/DictionaryStructure.cpp
@@ -401,18 +401,21 @@ void DictionaryStructure::parseRangeConfiguration(const Poco::Util::AbstractConf
     if (!range_min)
         return;
 
-    range_min->type = removeNullable(range_min->type);
-    range_max->type = removeNullable(range_max->type);
+    auto range_min_type = removeNullable(range_min->type);
+    auto range_max_type = removeNullable(range_max->type);
 
-    if (!range_min->type->equals(*range_max->type))
+    if (!range_min_type->equals(*range_max_type))
     {
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
             "Dictionary structure 'range_min' and 'range_max' should have same type, "
             "'range_min' type: {},"
             "'range_max' type: {}",
-            range_min->type->getName(),
-            range_max->type->getName());
+            range_min_type->getName(),
+            range_max_type->getName());
     }
+
+    range_min.emplace(DictionaryTypedSpecialAttribute{range_min->name, range_min->expression, range_min_type});
+    range_max.emplace(DictionaryTypedSpecialAttribute{range_max->name, range_max->expression, range_max_type});
 
     WhichDataType range_type(range_min->type);
 

--- a/src/Dictionaries/DictionaryStructure.cpp
+++ b/src/Dictionaries/DictionaryStructure.cpp
@@ -401,6 +401,9 @@ void DictionaryStructure::parseRangeConfiguration(const Poco::Util::AbstractConf
     if (!range_min)
         return;
 
+    range_min->type = removeNullable(range_min->type);
+    range_max->type = removeNullable(range_max->type);
+
     if (!range_min->type->equals(*range_max->type))
     {
         throw Exception(ErrorCodes::BAD_ARGUMENTS,

--- a/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
+++ b/src/Dictionaries/getDictionaryConfigurationFromAST.cpp
@@ -234,7 +234,7 @@ void buildRangeConfiguration(AutoPtr<Document> doc, AutoPtr<Element> root, const
         throw Exception(ErrorCodes::INCORRECT_DICTIONARY_DEFINITION,
             "MIN {} attribute is not defined in the dictionary attributes", range->min_attr_name);
 
-    auto range_max_attribute_it = all_attrs.find(range->min_attr_name);
+    auto range_max_attribute_it = all_attrs.find(range->max_attr_name);
     if (range_max_attribute_it == all_attrs.end())
         throw Exception(ErrorCodes::INCORRECT_DICTIONARY_DEFINITION,
             "MAX {} attribute is not defined in the dictionary attributes", range->max_attr_name);

--- a/tests/queries/0_stateless/04077_range_hashed_dictionary_validate_max_attribute.reference
+++ b/tests/queries/0_stateless/04077_range_hashed_dictionary_validate_max_attribute.reference
@@ -1,1 +1,2 @@
+hello
 dict_04077_good	RangeHashed

--- a/tests/queries/0_stateless/04077_range_hashed_dictionary_validate_max_attribute.reference
+++ b/tests/queries/0_stateless/04077_range_hashed_dictionary_validate_max_attribute.reference
@@ -1,0 +1,1 @@
+dict_04077_good	RangeHashed

--- a/tests/queries/0_stateless/04077_range_hashed_dictionary_validate_max_attribute.sql
+++ b/tests/queries/0_stateless/04077_range_hashed_dictionary_validate_max_attribute.sql
@@ -35,7 +35,29 @@ LIFETIME(MIN 0 MAX 100)
 LAYOUT(RANGE_HASHED())
 RANGE(MIN nonexistent_col MAX end_date); -- { serverError INCORRECT_DICTIONARY_DEFINITION }
 
--- Test 3: Valid dictionary with matching min/max attributes must succeed.
+-- Test 3: Different types for MIN and MAX must be rejected at dictionary creation.
+-- Previously, the bug caused both range_min and range_max to get the MIN attribute's
+-- type, so this type mismatch was silently masked and the dictionary was created.
+DROP TABLE IF EXISTS source_04077_types;
+CREATE TABLE source_04077_types (id UInt64, start_date Date, end_ts DateTime, value String) ENGINE = Memory;
+
+DROP DICTIONARY IF EXISTS dict_04077_type_mismatch;
+CREATE DICTIONARY dict_04077_type_mismatch
+(
+    id UInt64,
+    start_date Date,
+    end_ts DateTime,
+    value String DEFAULT ''
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 'source_04077_types'))
+LIFETIME(MIN 0 MAX 100)
+LAYOUT(RANGE_HASHED())
+RANGE(MIN start_date MAX end_ts); -- { serverError BAD_ARGUMENTS }
+
+DROP TABLE IF EXISTS source_04077_types;
+
+-- Test 4: Valid dictionary with matching min/max attributes must succeed.
 DROP DICTIONARY IF EXISTS dict_04077_good;
 CREATE DICTIONARY dict_04077_good
 (

--- a/tests/queries/0_stateless/04077_range_hashed_dictionary_validate_max_attribute.sql
+++ b/tests/queries/0_stateless/04077_range_hashed_dictionary_validate_max_attribute.sql
@@ -35,9 +35,7 @@ LIFETIME(MIN 0 MAX 100)
 LAYOUT(RANGE_HASHED())
 RANGE(MIN nonexistent_col MAX end_date); -- { serverError INCORRECT_DICTIONARY_DEFINITION }
 
--- Test 3: Different types for MIN and MAX must be rejected at dictionary creation.
--- Previously, the bug caused both range_min and range_max to get the MIN attribute's
--- type, so this type mismatch was silently masked and the dictionary was created.
+-- Test 3: Different underlying types for MIN and MAX must be rejected at dictionary creation.
 DROP TABLE IF EXISTS source_04077_types;
 CREATE TABLE source_04077_types (id UInt64, start_date Date, end_ts DateTime, value String) ENGINE = Memory;
 
@@ -57,7 +55,33 @@ RANGE(MIN start_date MAX end_ts); -- { serverError BAD_ARGUMENTS }
 
 DROP TABLE IF EXISTS source_04077_types;
 
--- Test 4: Valid dictionary with matching min/max attributes must succeed.
+-- Test 4: Nullable types for range attributes are accepted when underlying types match.
+-- Previously, the bug caused both range_min and range_max to get the MIN attribute's
+-- type, so the Nullable on the max attribute was silently lost.
+DROP TABLE IF EXISTS source_04077_nullable;
+CREATE TABLE source_04077_nullable (id UInt64, start_date Date, end_date Nullable(Date), value String) ENGINE = Memory;
+INSERT INTO source_04077_nullable VALUES (1, '2023-01-01', '2023-12-31', 'hello');
+
+DROP DICTIONARY IF EXISTS dict_04077_nullable;
+CREATE DICTIONARY dict_04077_nullable
+(
+    id UInt64,
+    start_date Date,
+    end_date Nullable(Date),
+    value String DEFAULT ''
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 'source_04077_nullable'))
+LIFETIME(MIN 0 MAX 100)
+LAYOUT(RANGE_HASHED())
+RANGE(MIN start_date MAX end_date);
+
+SELECT dictGet('dict_04077_nullable', 'value', toUInt64(1), toDate('2023-06-15'));
+
+DROP DICTIONARY IF EXISTS dict_04077_nullable;
+DROP TABLE IF EXISTS source_04077_nullable;
+
+-- Test 5: Valid dictionary with matching non-nullable min/max attributes must succeed.
 DROP DICTIONARY IF EXISTS dict_04077_good;
 CREATE DICTIONARY dict_04077_good
 (
@@ -72,6 +96,7 @@ LIFETIME(MIN 0 MAX 100)
 LAYOUT(RANGE_HASHED())
 RANGE(MIN start_date MAX end_date);
 
+SYSTEM RELOAD DICTIONARY dict_04077_good;
 SELECT name, type FROM system.dictionaries WHERE name = 'dict_04077_good' AND database = currentDatabase();
 
 DROP DICTIONARY IF EXISTS dict_04077_good;

--- a/tests/queries/0_stateless/04077_range_hashed_dictionary_validate_max_attribute.sql
+++ b/tests/queries/0_stateless/04077_range_hashed_dictionary_validate_max_attribute.sql
@@ -1,0 +1,56 @@
+-- Verify that RANGE(MIN ... MAX ...) correctly validates and configures the max attribute.
+-- Previously, buildRangeConfiguration used range->min_attr_name for both min and max lookups
+-- (copy-paste bug), so a non-existent max attribute was silently accepted.
+
+DROP TABLE IF EXISTS source_04077;
+CREATE TABLE source_04077 (id UInt64, start_date Date, end_date Date, value String) ENGINE = Memory;
+
+-- Test 1: Non-existent MAX attribute must be rejected.
+DROP DICTIONARY IF EXISTS dict_04077_bad;
+CREATE DICTIONARY dict_04077_bad
+(
+    id UInt64,
+    start_date Date,
+    end_date Date,
+    value String DEFAULT ''
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 'source_04077'))
+LIFETIME(MIN 0 MAX 100)
+LAYOUT(RANGE_HASHED())
+RANGE(MIN start_date MAX nonexistent_col); -- { serverError INCORRECT_DICTIONARY_DEFINITION }
+
+-- Test 2: Non-existent MIN attribute must still be rejected (regression guard).
+DROP DICTIONARY IF EXISTS dict_04077_bad2;
+CREATE DICTIONARY dict_04077_bad2
+(
+    id UInt64,
+    start_date Date,
+    end_date Date,
+    value String DEFAULT ''
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 'source_04077'))
+LIFETIME(MIN 0 MAX 100)
+LAYOUT(RANGE_HASHED())
+RANGE(MIN nonexistent_col MAX end_date); -- { serverError INCORRECT_DICTIONARY_DEFINITION }
+
+-- Test 3: Valid dictionary with matching min/max attributes must succeed.
+DROP DICTIONARY IF EXISTS dict_04077_good;
+CREATE DICTIONARY dict_04077_good
+(
+    id UInt64,
+    start_date Date,
+    end_date Date,
+    value String DEFAULT ''
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 'source_04077'))
+LIFETIME(MIN 0 MAX 100)
+LAYOUT(RANGE_HASHED())
+RANGE(MIN start_date MAX end_date);
+
+SELECT name, type FROM system.dictionaries WHERE name = 'dict_04077_good' AND database = currentDatabase();
+
+DROP DICTIONARY IF EXISTS dict_04077_good;
+DROP TABLE IF EXISTS source_04077;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`buildRangeConfiguration` in `getDictionaryConfigurationFromAST.cpp` used `range->min_attr_name` for both the min and max attribute lookups. This is a copy-paste error from commit ff53466db65c (2022-01-09). As a result:

1. A dictionary with a non-existent max range attribute could be created without error, only failing later at query time with a confusing `UNKNOWN_IDENTIFIER` exception.
2. When min and max range attributes had different types, the `range_max` XML element got the min attribute's type configuration instead of the max attribute's. This silently bypassed the downstream type-equality check in `parseRangeConfiguration`, allowing an invalid dictionary to be created.

The fix has two parts:

1. **`buildRangeConfiguration`**: Change `all_attrs.find(range->min_attr_name)` to `all_attrs.find(range->max_attr_name)` on the max attribute lookup line, so the correct type is propagated to the XML config.

2. **`parseRangeConfiguration`**: Strip `Nullable` from range_min and range_max types before comparing them for equality. `RangeHashedDictionary` already handles nullable range columns at the data level (unwrapping `ColumnNullable`), and `callOnRangeType` dispatches on the non-nullable underlying type. Without this, the fix in (1) would break existing dictionaries that use `Date` for MIN and `Nullable(Date)` for MAX — they previously only worked because the bug gave both the min attribute's non-nullable type.

The test covers five cases:
- Non-existent MAX attribute is rejected (`INCORRECT_DICTIONARY_DEFINITION`)
- Non-existent MIN attribute is still rejected (regression guard)
- Different underlying types for MIN (`Date`) and MAX (`DateTime`) are rejected (`BAD_ARGUMENTS`)
- `Date`/`Nullable(Date)` range attributes work correctly (nullable stripped before comparison)
- Valid dictionary with matching non-nullable attributes succeeds

Closes #101672

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `RANGE_HASHED` dictionary creation silently accepting a non-existent `MAX` range attribute and using the wrong type configuration when min and max range attributes had different types. The bug was a copy-paste error in `buildRangeConfiguration` that looked up `min_attr_name` instead of `max_attr_name` for the max attribute.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c44c1f3f-a77e-4bc3-82b9-a8958630476a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c44c1f3f-a77e-4bc3-82b9-a8958630476a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.576`
<!-- ch-version-info:end -->