### PR TITLE
Add test: No test for minIf/maxIf/argMinIf/argMaxIf with Decimal32/64/DateTime64 types

### DIFF
--- a/tests/queries/0_stateless/04089_decimal_datetime64_minmax_if.reference
+++ b/tests/queries/0_stateless/04089_decimal_datetime64_minmax_if.reference
@@ -1,0 +1,20 @@
+Decimal32 minIf/maxIf
+1	49
+Decimal64 minIf/maxIf
+1	49
+DateTime64 minIf/maxIf
+1970-01-01 00:00:11.000000	1970-01-01 00:00:49.000000
+Nullable Decimal32 min/max
+-49	50
+Nullable Decimal64 min/max
+-49	50
+Nullable DateTime64 min/max
+1970-01-01 00:00:01.000000	1970-01-01 00:01:38.000000
+Decimal32 argMinIf/argMaxIf
+51	99
+Decimal64 argMinIf/argMaxIf
+51	99
+DateTime64 argMinIf/argMaxIf
+11	49
+Nullable Decimal32 argMin/argMax
+1	100

--- a/tests/queries/0_stateless/04089_decimal_datetime64_minmax_if.sql
+++ b/tests/queries/0_stateless/04089_decimal_datetime64_minmax_if.sql
@@ -2,6 +2,7 @@
 -- Covers: src/Common/findExtreme.cpp:160-171 (optimized SIMD path for Decimal types via reinterpret_cast)
 -- These types now use the findExtreme* optimized path; no existing test covers -If/-NotNull combinators.
 
+SET session_timezone = 'UTC';
 
 -- Use small block size to exercise the cross-block merge path in SingleValueData
 SET max_threads = 1, max_block_size = 10;

--- a/tests/queries/0_stateless/04089_decimal_datetime64_minmax_if.sql
+++ b/tests/queries/0_stateless/04089_decimal_datetime64_minmax_if.sql
@@ -1,0 +1,81 @@
+-- Test: Verify correctness of min/max/argMin/argMax with -If combinators for Decimal32/64 and DateTime64
+-- Covers: src/Common/findExtreme.cpp:160-171 (optimized SIMD path for Decimal types via reinterpret_cast)
+-- These types now use the findExtreme* optimized path; no existing test covers -If/-NotNull combinators.
+
+
+-- Use small block size to exercise the cross-block merge path in SingleValueData
+SET max_threads = 1, max_block_size = 10;
+
+-- Decimal32 minIf/maxIf
+SELECT 'Decimal32 minIf/maxIf';
+SELECT
+    minIf(d, d > toDecimal32(0, 2)),
+    maxIf(d, d < toDecimal32(50, 2))
+FROM (SELECT toDecimal32(number - 50, 2) AS d FROM numbers(101))
+ORDER BY 1;
+
+-- Decimal64 minIf/maxIf
+SELECT 'Decimal64 minIf/maxIf';
+SELECT
+    minIf(d, d > toDecimal64(0, 6)),
+    maxIf(d, d < toDecimal64(50, 6))
+FROM (SELECT toDecimal64(number - 50, 6) AS d FROM numbers(101))
+ORDER BY 1;
+
+-- DateTime64 minIf/maxIf
+SELECT 'DateTime64 minIf/maxIf';
+SELECT
+    minIf(d, d > toDateTime64('1970-01-01 00:00:10', 6)),
+    maxIf(d, d < toDateTime64('1970-01-01 00:00:50', 6))
+FROM (SELECT toDateTime64(number, 6) AS d FROM numbers(100))
+ORDER BY 1;
+
+-- Nullable Decimal32 min/max (exercises setSmallestNotNullIf)
+SELECT 'Nullable Decimal32 min/max';
+SELECT min(d), max(d)
+FROM (SELECT if(number % 3 = 0, NULL, toDecimal32(number - 50, 2)) AS d FROM numbers(101))
+ORDER BY 1;
+
+-- Nullable Decimal64 min/max
+SELECT 'Nullable Decimal64 min/max';
+SELECT min(d), max(d)
+FROM (SELECT if(number % 3 = 0, NULL, toDecimal64(number - 50, 6)) AS d FROM numbers(101))
+ORDER BY 1;
+
+-- Nullable DateTime64 min/max
+SELECT 'Nullable DateTime64 min/max';
+SELECT min(d), max(d)
+FROM (SELECT if(number % 3 = 0, NULL, toDateTime64(number, 6)) AS d FROM numbers(100))
+ORDER BY 1;
+
+-- argMinIf/argMaxIf with Decimal32 (exercises getSmallestIndexNotNullIf)
+SELECT 'Decimal32 argMinIf/argMaxIf';
+SELECT
+    argMinIf(x, d, d > toDecimal32(0, 2)),
+    argMaxIf(x, d, d < toDecimal32(50, 2))
+FROM (SELECT number AS x, toDecimal32(number - 50, 2) AS d FROM numbers(101))
+ORDER BY 1;
+
+-- argMinIf/argMaxIf with Decimal64
+SELECT 'Decimal64 argMinIf/argMaxIf';
+SELECT
+    argMinIf(x, d, d > toDecimal64(0, 6)),
+    argMaxIf(x, d, d < toDecimal64(50, 6))
+FROM (SELECT number AS x, toDecimal64(number - 50, 6) AS d FROM numbers(101))
+ORDER BY 1;
+
+-- argMinIf/argMaxIf with DateTime64
+SELECT 'DateTime64 argMinIf/argMaxIf';
+SELECT
+    argMinIf(x, d, d > toDateTime64('1970-01-01 00:00:10', 6)),
+    argMaxIf(x, d, d < toDateTime64('1970-01-01 00:00:50', 6))
+FROM (SELECT number AS x, toDateTime64(number, 6) AS d FROM numbers(100))
+ORDER BY 1;
+
+-- argMin/argMax with Nullable Decimal32 (exercises getSmallestIndexNotNullIf with null_map)
+SELECT 'Nullable Decimal32 argMin/argMax';
+SELECT
+    argMin(x, d),
+    argMax(x, d)
+FROM (SELECT number AS x, if(number % 3 = 0, NULL, toDecimal32(number - 50, 2)) AS d FROM numbers(101))
+ORDER BY 1;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #76570](https://github.com/ClickHouse/ClickHouse/pull/76570) (merged 2025-03-10). Confirmed on current codebase — close with a note if already fixed._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #76570](https://github.com/ClickHouse/ClickHouse/pull/76570).

**1. No test for minIf/maxIf/argMinIf/argMaxIf with Decimal32/64/DateTime64 types**
  `src/Common/findExtreme.cpp:160`, `src/AggregateFunctions/SingleValueData.cpp:415`
  **Why this test:** SingleValueData.cpp:415 (setSmallestNotNullIf) and :457 (getSmallestIndexNotNullIf) now enter the findExtreme optimized path for Decimal types via the new underlying_has_find_extreme_implementation co
  **What's unique:** PR only includes a performance test (tests/performance/opt_max_min.xml) which tests basic min/max and argMin/argMax. This test covers minIf/maxIf/argMinIf/argMaxIf with condition filtering and Nullabl

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---
_Found during review of [PR #76570](https://github.com/ClickHouse/ClickHouse/pull/76570)._

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1048`
<!-- ch-version-info:end -->