### PR TITLE
[CI Proof] Missing 'throw' before Coordination::Exception::fromPath silently ignores ZK error on max_log_ptr

### DIFF
--- a/tests/queries/0_stateless/04090_qa_pr56862_missing_throw.reference
+++ b/tests/queries/0_stateless/04090_qa_pr56862_missing_throw.reference
@@ -1,0 +1,15 @@
+--- tables
+t1
+t2
+t3
+--- counts
+t1	2
+t2	2
+t3	2
+--- after alter
+1	alpha	x
+2	beta	x
+--- after drop
+t1
+t2
+--- done

--- a/tests/queries/0_stateless/04090_qa_pr56862_missing_throw.reference
+++ b/tests/queries/0_stateless/04090_qa_pr56862_missing_throw.reference
@@ -1,15 +1,19 @@
 --- tables
-t1
-t2
-t3
+t1_04090
+t2_04090
+t3_04090
 --- counts
-t1	2
-t2	2
-t3	2
+t1_04090	2
+t2_04090	2
+t3_04090	2
 --- after alter
 1	alpha	x
 2	beta	x
+--- tables after alter
+t1_04090
+t2_04090
+t3_04090
 --- after drop
-t1
-t2
+t1_04090
+t2_04090
 --- done

--- a/tests/queries/0_stateless/04090_qa_pr56862_missing_throw.sql
+++ b/tests/queries/0_stateless/04090_qa_pr56862_missing_throw.sql
@@ -9,8 +9,6 @@
 -- metadata snapshots through the affected path. Under sanitizers this gives
 -- CI the best chance to detect issues from the silently ignored ZK error.
 
-SET max_execution_time = 30;
-
 DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier} SYNC;
 
 CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier}
@@ -21,13 +19,13 @@ USE {CLICKHOUSE_DATABASE_1:Identifier};
 SET distributed_ddl_output_mode = 'none';
 
 -- Create several tables so the metadata snapshot has content to iterate.
-CREATE TABLE t1 (id UInt32, data String) ENGINE = ReplicatedMergeTree ORDER BY id;
-CREATE TABLE t2 (id UInt32, value UInt64) ENGINE = ReplicatedMergeTree ORDER BY id;
-CREATE TABLE t3 (id UInt32, ts DateTime DEFAULT now()) ENGINE = ReplicatedMergeTree ORDER BY id;
+CREATE TABLE t1_04090 (id UInt32, data String) ENGINE = ReplicatedMergeTree ORDER BY id;
+CREATE TABLE t2_04090 (id UInt32, value UInt64) ENGINE = ReplicatedMergeTree ORDER BY id;
+CREATE TABLE t3_04090 (id UInt32, ts DateTime DEFAULT now()) ENGINE = ReplicatedMergeTree ORDER BY id;
 
-INSERT INTO t1 VALUES (1, 'alpha'), (2, 'beta');
-INSERT INTO t2 VALUES (1, 100), (2, 200);
-INSERT INTO t3 (id) VALUES (1), (2);
+INSERT INTO t1_04090 VALUES (1, 'alpha'), (2, 'beta');
+INSERT INTO t2_04090 VALUES (1, 100), (2, 200);
+INSERT INTO t3_04090 (id) VALUES (1), (2);
 
 -- system.tables reads replicated DB metadata via tryGetConsistentMetadataSnapshot.
 SELECT '--- tables';
@@ -35,24 +33,28 @@ SELECT name FROM system.tables WHERE database = currentDatabase() ORDER BY name;
 
 -- Row counts confirm data is accessible after metadata snapshot.
 SELECT '--- counts';
-SELECT 't1', count() FROM t1;
-SELECT 't2', count() FROM t2;
-SELECT 't3', count() FROM t3;
+SELECT 't1_04090', count() FROM t1_04090;
+SELECT 't2_04090', count() FROM t2_04090;
+SELECT 't3_04090', count() FROM t3_04090;
 
 -- SYSTEM SYNC DATABASE REPLICA exercises getConsistentMetadataSnapshotImpl.
 SYSTEM SYNC DATABASE REPLICA {CLICKHOUSE_DATABASE_1:Identifier};
 
 -- ALTER adds a DDL log entry, bumping max_log_ptr and causing the next
 -- metadata snapshot to re-read it via tryGet (the buggy path).
-ALTER TABLE t1 ADD COLUMN extra String DEFAULT 'x';
+ALTER TABLE t1_04090 ADD COLUMN extra String DEFAULT 'x';
 SELECT '--- after alter';
-SELECT id, data, extra FROM t1 ORDER BY id;
+SELECT id, data, extra FROM t1_04090 ORDER BY id;
 
 -- Another sync after ALTER to re-exercise the snapshot with new max_log_ptr.
 SYSTEM SYNC DATABASE REPLICA {CLICKHOUSE_DATABASE_1:Identifier};
 
+-- system.tables again to force another metadata snapshot read after ALTER.
+SELECT '--- tables after alter';
+SELECT name FROM system.tables WHERE database = currentDatabase() ORDER BY name;
+
 -- DROP TABLE also bumps the log pointer then snapshots metadata.
-DROP TABLE t3 SYNC;
+DROP TABLE t3_04090 SYNC;
 SELECT '--- after drop';
 SELECT name FROM system.tables WHERE database = currentDatabase() ORDER BY name;
 

--- a/tests/queries/0_stateless/04090_qa_pr56862_missing_throw.sql
+++ b/tests/queries/0_stateless/04090_qa_pr56862_missing_throw.sql
@@ -1,0 +1,64 @@
+-- Tags: zookeeper, no-replicated-database, no-ordinary-database
+-- no-replicated-database: we explicitly create a replicated database
+-- no-ordinary-database: requires Replicated engine
+
+-- Exercises DatabaseReplicated::getConsistentMetadataSnapshotImpl to expose a
+-- missing 'throw' before Coordination::Exception::fromPath on max_log_ptr
+-- (line ~1950 of DatabaseReplicated.cpp). Each DDL bumps max_log_ptr;
+-- SYSTEM SYNC DATABASE REPLICA and system.tables queries force re-reads of
+-- metadata snapshots through the affected path. Under sanitizers this gives
+-- CI the best chance to detect issues from the silently ignored ZK error.
+
+SET max_execution_time = 30;
+
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE:Identifier} SYNC;
+
+CREATE DATABASE {CLICKHOUSE_DATABASE:Identifier}
+    ENGINE = Replicated('/clickhouse/databases/{database}', 'shard1', 'replica1');
+
+USE {CLICKHOUSE_DATABASE:Identifier};
+
+SET distributed_ddl_output_mode = 'none';
+
+-- Create several tables so the metadata snapshot has content to iterate.
+CREATE TABLE t1 (id UInt32, data String) ENGINE = ReplicatedMergeTree ORDER BY id;
+CREATE TABLE t2 (id UInt32, value UInt64) ENGINE = ReplicatedMergeTree ORDER BY id;
+CREATE TABLE t3 (id UInt32, ts DateTime DEFAULT now()) ENGINE = ReplicatedMergeTree ORDER BY id;
+
+INSERT INTO t1 VALUES (1, 'alpha'), (2, 'beta');
+INSERT INTO t2 VALUES (1, 100), (2, 200);
+INSERT INTO t3 (id) VALUES (1), (2);
+
+-- system.tables reads replicated DB metadata via tryGetConsistentMetadataSnapshot.
+SELECT '--- tables';
+SELECT name FROM system.tables WHERE database = currentDatabase() ORDER BY name;
+
+-- Row counts confirm data is accessible after metadata snapshot.
+SELECT '--- counts';
+SELECT 't1', count() FROM t1;
+SELECT 't2', count() FROM t2;
+SELECT 't3', count() FROM t3;
+
+-- SYSTEM SYNC DATABASE REPLICA exercises getConsistentMetadataSnapshotImpl.
+SYSTEM SYNC DATABASE REPLICA {CLICKHOUSE_DATABASE:Identifier};
+
+-- ALTER adds a DDL log entry, bumping max_log_ptr and causing the next
+-- metadata snapshot to re-read it via tryGet (the buggy path).
+ALTER TABLE t1 ADD COLUMN extra String DEFAULT 'x';
+SELECT '--- after alter';
+SELECT id, data, extra FROM t1 ORDER BY id;
+
+-- Another sync after ALTER to re-exercise the snapshot with new max_log_ptr.
+SYSTEM SYNC DATABASE REPLICA {CLICKHOUSE_DATABASE:Identifier};
+
+-- DROP TABLE also bumps the log pointer then snapshots metadata.
+DROP TABLE t3 SYNC;
+SELECT '--- after drop';
+SELECT name FROM system.tables WHERE database = currentDatabase() ORDER BY name;
+
+-- Final sync to exercise snapshot after DROP changed max_log_ptr.
+SYSTEM SYNC DATABASE REPLICA {CLICKHOUSE_DATABASE:Identifier};
+
+-- Cleanup
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE:Identifier} SYNC;
+SELECT '--- done';

--- a/tests/queries/0_stateless/04090_qa_pr56862_missing_throw.sql
+++ b/tests/queries/0_stateless/04090_qa_pr56862_missing_throw.sql
@@ -11,12 +11,12 @@
 
 SET max_execution_time = 30;
 
-DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE:Identifier} SYNC;
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier} SYNC;
 
-CREATE DATABASE {CLICKHOUSE_DATABASE:Identifier}
-    ENGINE = Replicated('/clickhouse/databases/{database}', 'shard1', 'replica1');
+CREATE DATABASE {CLICKHOUSE_DATABASE_1:Identifier}
+    ENGINE = Replicated('/clickhouse/databases/{database}_04090', 'shard1', 'replica1');
 
-USE {CLICKHOUSE_DATABASE:Identifier};
+USE {CLICKHOUSE_DATABASE_1:Identifier};
 
 SET distributed_ddl_output_mode = 'none';
 
@@ -40,7 +40,7 @@ SELECT 't2', count() FROM t2;
 SELECT 't3', count() FROM t3;
 
 -- SYSTEM SYNC DATABASE REPLICA exercises getConsistentMetadataSnapshotImpl.
-SYSTEM SYNC DATABASE REPLICA {CLICKHOUSE_DATABASE:Identifier};
+SYSTEM SYNC DATABASE REPLICA {CLICKHOUSE_DATABASE_1:Identifier};
 
 -- ALTER adds a DDL log entry, bumping max_log_ptr and causing the next
 -- metadata snapshot to re-read it via tryGet (the buggy path).
@@ -49,7 +49,7 @@ SELECT '--- after alter';
 SELECT id, data, extra FROM t1 ORDER BY id;
 
 -- Another sync after ALTER to re-exercise the snapshot with new max_log_ptr.
-SYSTEM SYNC DATABASE REPLICA {CLICKHOUSE_DATABASE:Identifier};
+SYSTEM SYNC DATABASE REPLICA {CLICKHOUSE_DATABASE_1:Identifier};
 
 -- DROP TABLE also bumps the log pointer then snapshots metadata.
 DROP TABLE t3 SYNC;
@@ -57,8 +57,8 @@ SELECT '--- after drop';
 SELECT name FROM system.tables WHERE database = currentDatabase() ORDER BY name;
 
 -- Final sync to exercise snapshot after DROP changed max_log_ptr.
-SYSTEM SYNC DATABASE REPLICA {CLICKHOUSE_DATABASE:Identifier};
+SYSTEM SYNC DATABASE REPLICA {CLICKHOUSE_DATABASE_1:Identifier};
 
 -- Cleanup
-DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE:Identifier} SYNC;
+DROP DATABASE IF EXISTS {CLICKHOUSE_DATABASE_1:Identifier} SYNC;
 SELECT '--- done';


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

> ⚠️ **This is a CI proof PR — not a fix and not intended for merge.** It submits a test that could not be confirmed locally (code analysis strongly suggests a bug but local test did not trigger it — CI sanitizers and stress runs may catch it). **This PR will be closed automatically** once CI completes. If CI confirms the bug (TSAN/ASAN/cluster failure), a bug Issue will be filed separately.

**Suspected bug:** Missing 'throw' before Coordination::Exception::fromPath silently ignores ZK error on max_log_ptr

**Root cause:** Line 1950 calls 'Coordination::Exception::fromPath(current_max_log_ptr.error, ...)' without the 'throw' keyword. The old code used zookeeper->get() which throws internally on error. The refactored code uses tryGet() and must throw manually, but the throw was omitted.

**Affected locations:**
- `src/Databases/DatabaseReplicated.cpp:1950` — getConsistentMetadataSnapshotImpl - error handling for max_log_ptr ZK read

**Why CI is needed:** If max_log_ptr ZK node is temporarily unavailable or returns an error, the exception is silently swallowed. parse<UInt32> then runs on empty/garbage data, which could either crash or produce a wrong log pointer value. A wrong max_log_ptr could cause recoverLostReplica to use incorrect metadata, potentially leading to data inconsistency during database replica recovery.

**Suggested fix:** Add 'throw' keyword: 'throw Coordination::Exception::fromPath(current_max_log_ptr.error, zookeeper_path + "/max_log_ptr");'

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — temporary CI proof PR, will be closed automatically.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---
_Confidence: HIGH | Severity: P1 | Found during review of [PR #56862](https://github.com/ClickHouse/ClickHouse/pull/56862)._
