### PR TITLE
Implement Sparkbar aggregation combinator

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/combinators.md
+++ b/docs/en/sql-reference/aggregate-functions/combinators.md
@@ -331,6 +331,75 @@ Examples: `sumArgMin(column, expr)`, `countArgMin(expr)`, `avgArgMin(x, expr)` a
 
 Similar to suffix -ArgMin but processes only the rows that have the maximum value for the specified extra expression.
 
+## -Sparkbar {#-sparkbar}
+
+The -Sparkbar suffix can be appended to the name of any aggregate function that returns a numeric type. This combinator divides the input data into buckets based on a key column, applies the aggregate function to each bucket, and renders the results as a [sparkbar](reference/sparkbar.md) visualization (a string of Unicode bar characters).
+
+**Syntax**
+
+```sql
+<aggFunction>Sparkbar(width, min, max)(bucket_key, [aggFunction_params...])
+```
+
+**Arguments**
+
+- `width` — Number of buckets (segments) in the sparkbar. Must be in range [2, 1024]. [UInt8/16/32/64](../../sql-reference/data-types/int-uint.md).
+- `min` — Minimum value of the bucket key range (inclusive). Type must match `bucket_key`.
+- `max` — Maximum value of the bucket key range (inclusive). Type must match `bucket_key`.
+- `bucket_key` — Column used for bucketing. Must be an integer type, [Date](../../sql-reference/data-types/date.md), or [DateTime](../../sql-reference/data-types/datetime.md).
+- `aggFunction_params` — Parameters passed to the nested aggregate function.
+
+**Returned value**
+
+A sparkbar string visualizing the aggregated values across buckets. Values outside the `[min, max]` range are ignored.
+
+Type: [String](../../sql-reference/data-types/string.md).
+
+**Example**
+
+```sql
+SELECT sumSparkbar(10, 0, 9)(number, number + 1) FROM numbers(10);
+```
+
+```text
+┌─sumSparkbar(10, 0, 9)(number, plus(number, 1))─┐
+│ ▁▂▃▃▄▅▅▆▇█                                     │
+└────────────────────────────────────────────────┘
+```
+
+Count occurrences per bucket:
+
+```sql
+SELECT countSparkbar(5, toDate('2024-01-01'), toDate('2024-01-05'))(date)
+FROM (SELECT toDate('2024-01-01') + number % 5 AS date FROM numbers(20));
+```
+
+```text
+┌─countSparkbar(5, toDate('2024-01-01'), toDate('2024-01-05'))(date)─┐
+│ █████                                                              │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+With GROUP BY:
+
+```sql
+SELECT
+    category,
+    sumSparkbar(12, toDate('2024-01-01'), toDate('2024-12-01'))(month, revenue)
+FROM sales
+GROUP BY category;
+```
+
+The `-Sparkbar` combinator can be combined with `-State` and `-Merge` for use with [AggregatingMergeTree](../../engines/table-engines/mergetree-family/aggregatingmergetree.md):
+
+```sql
+-- Store intermediate state
+SELECT sumSparkbarState(10, 0, 9)(number, 1) AS state FROM numbers(10);
+
+-- Merge states and get final result
+SELECT sumSparkbarMerge(10, 0, 9)(state) FROM aggregated_table;
+```
+
 ## Related Content {#related-content}
 
 - Blog: [Using Aggregate Combinators in ClickHouse](https://clickhouse.com/blog/aggregate-functions-combinators-in-clickhouse-for-arrays-maps-and-states)

--- a/src/AggregateFunctions/Combinators/AggregateFunctionSparkbar.cpp
+++ b/src/AggregateFunctions/Combinators/AggregateFunctionSparkbar.cpp
@@ -1,0 +1,140 @@
+#include <AggregateFunctions/Combinators/AggregateFunctionCombinatorFactory.h>
+#include <AggregateFunctions/Combinators/AggregateFunctionSparkbar.h>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
+    extern const int BAD_ARGUMENTS;
+}
+
+namespace
+{
+
+class AggregateFunctionCombinatorSparkbar final : public IAggregateFunctionCombinator
+{
+public:
+    String getName() const override
+    {
+        return "Sparkbar";
+    }
+
+    DataTypes transformArguments(const DataTypes & arguments) const override
+    {
+        if (arguments.empty())
+            throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
+                "Incorrect number of arguments for aggregate function with {} suffix. "
+                "At least one argument (bucket key) is required", getName());
+
+        /// Remove the first argument (bucket key), pass the rest to nested function
+        return DataTypes(arguments.begin() + 1, arguments.end());
+    }
+
+    Array transformParameters(const Array & params) const override
+    {
+        /// Sparkbar combinator requires exactly 3 parameters: width, min_x, max_x
+        /// These are consumed by the combinator, not passed to nested function
+        if (params.size() != 3)
+            throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
+                "Aggregate function with {} suffix requires exactly 3 parameters (width, min_x, max_x), got {}",
+                getName(), params.size());
+
+        /// Return empty array - all parameters are consumed by the combinator
+        return Array();
+    }
+
+    AggregateFunctionPtr transformAggregateFunction(
+        const AggregateFunctionPtr & nested_function,
+        const AggregateFunctionProperties &,
+        const DataTypes & arguments,
+        const Array & params) const override
+    {
+        if (arguments.empty())
+            throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
+                "Incorrect number of arguments for aggregate function with {} suffix. "
+                "At least one argument (bucket key) is required", getName());
+
+        if (params.size() != 3)
+            throw Exception(ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
+                "Aggregate function with {} suffix requires exactly 3 parameters (width, min_x, max_x), got {}", getName(), params.size());
+
+        UInt64 width = params[0].safeGet<UInt64>();
+
+        WhichDataType which{arguments[0]};
+
+        if (which.isNativeUInt() || which.isDate() || which.isDateTime())
+        {
+            UInt64 begin_x = params[1].safeGet<UInt64>();
+            UInt64 end_x = params[2].safeGet<UInt64>();
+
+            return std::make_shared<AggregateFunctionSparkbar<UInt64>>(
+                nested_function,
+                static_cast<size_t>(width),
+                begin_x,
+                end_x,
+                arguments,
+                params);
+        }
+
+        if (which.isNativeInt())
+        {
+            Int64 begin_x;
+            Int64 end_x;
+
+            if (!params[1].tryGet<Int64>(begin_x))
+                begin_x = static_cast<Int64>(params[1].safeGet<UInt64>());
+            if (!params[2].tryGet<Int64>(end_x))
+                end_x = static_cast<Int64>(params[2].safeGet<UInt64>());
+
+            return std::make_shared<AggregateFunctionSparkbar<Int64>>(
+                nested_function,
+                static_cast<size_t>(width),
+                begin_x,
+                end_x,
+                arguments,
+                params);
+        }
+
+        if (which.isDate32())
+        {
+            Int32 begin_x;
+            Int32 end_x;
+
+            Int64 tmp;
+            if (params[1].tryGet<Int64>(tmp))
+                begin_x = static_cast<Int32>(tmp);
+            else
+                begin_x = static_cast<Int32>(params[1].safeGet<UInt64>());
+            if (params[2].tryGet<Int64>(tmp))
+                end_x = static_cast<Int32>(tmp);
+            else
+                end_x = static_cast<Int32>(params[2].safeGet<UInt64>());
+
+            return std::make_shared<AggregateFunctionSparkbar<Int32>>(
+                nested_function,
+                static_cast<size_t>(width),
+                begin_x,
+                end_x,
+                arguments,
+                params);
+        }
+
+        throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+            "Illegal type {} of the first argument for aggregate function with {} suffix. "
+            "The type should be native integer, Date, Date32 or DateTime",
+            arguments[0]->getName(), getName());
+    }
+};
+
+}
+
+void registerAggregateFunctionCombinatorSparkbar(AggregateFunctionCombinatorFactory & factory)
+{
+    factory.registerCombinator(std::make_shared<AggregateFunctionCombinatorSparkbar>());
+}
+
+}

--- a/src/AggregateFunctions/Combinators/AggregateFunctionSparkbar.cpp
+++ b/src/AggregateFunctions/Combinators/AggregateFunctionSparkbar.cpp
@@ -15,6 +15,22 @@ namespace ErrorCodes
 namespace
 {
 
+template <typename T>
+T getParam(const Field & field)
+{
+    if constexpr (std::is_signed_v<T>)
+    {
+        Int64 value;
+        if (field.tryGet<Int64>(value))
+            return static_cast<T>(value);
+        return static_cast<T>(field.safeGet<UInt64>());
+    }
+    else
+    {
+        return static_cast<T>(field.safeGet<UInt64>());
+    }
+}
+
 class AggregateFunctionCombinatorSparkbar final : public IAggregateFunctionCombinator
 {
 public:
@@ -67,61 +83,16 @@ public:
         WhichDataType which{arguments[0]};
 
         if (which.isNativeUInt() || which.isDate() || which.isDateTime())
-        {
-            UInt64 begin_x = params[1].safeGet<UInt64>();
-            UInt64 end_x = params[2].safeGet<UInt64>();
-
             return std::make_shared<AggregateFunctionSparkbar<UInt64>>(
-                nested_function,
-                static_cast<size_t>(width),
-                begin_x,
-                end_x,
-                arguments,
-                params);
-        }
+                nested_function, width, getParam<UInt64>(params[1]), getParam<UInt64>(params[2]), arguments, params);
 
         if (which.isNativeInt())
-        {
-            Int64 begin_x;
-            Int64 end_x;
-
-            if (!params[1].tryGet<Int64>(begin_x))
-                begin_x = static_cast<Int64>(params[1].safeGet<UInt64>());
-            if (!params[2].tryGet<Int64>(end_x))
-                end_x = static_cast<Int64>(params[2].safeGet<UInt64>());
-
             return std::make_shared<AggregateFunctionSparkbar<Int64>>(
-                nested_function,
-                static_cast<size_t>(width),
-                begin_x,
-                end_x,
-                arguments,
-                params);
-        }
+                nested_function, width, getParam<Int64>(params[1]), getParam<Int64>(params[2]), arguments, params);
 
         if (which.isDate32())
-        {
-            Int32 begin_x;
-            Int32 end_x;
-
-            Int64 tmp;
-            if (params[1].tryGet<Int64>(tmp))
-                begin_x = static_cast<Int32>(tmp);
-            else
-                begin_x = static_cast<Int32>(params[1].safeGet<UInt64>());
-            if (params[2].tryGet<Int64>(tmp))
-                end_x = static_cast<Int32>(tmp);
-            else
-                end_x = static_cast<Int32>(params[2].safeGet<UInt64>());
-
             return std::make_shared<AggregateFunctionSparkbar<Int32>>(
-                nested_function,
-                static_cast<size_t>(width),
-                begin_x,
-                end_x,
-                arguments,
-                params);
-        }
+                nested_function, width, getParam<Int32>(params[1]), getParam<Int32>(params[2]), arguments, params);
 
         throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
             "Illegal type {} of the first argument for aggregate function with {} suffix. "

--- a/src/AggregateFunctions/Combinators/AggregateFunctionSparkbar.h
+++ b/src/AggregateFunctions/Combinators/AggregateFunctionSparkbar.h
@@ -1,0 +1,272 @@
+#pragma once
+
+#include <array>
+#include <string_view>
+
+#include <AggregateFunctions/IAggregateFunction.h>
+#include <Columns/ColumnNullable.h>
+#include <Columns/ColumnString.h>
+#include <Common/PODArray.h>
+#include <Common/assert_cast.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeString.h>
+#include <DataTypes/IDataType.h>
+#include <IO/ReadHelpers.h>
+#include <IO/WriteHelpers.h>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+}
+
+/** Aggregate function combinator -Sparkbar applies another aggregate function to values
+  * falling into buckets by the first argument, and then renders the results as a sparkbar string.
+  *
+  * Example: sumSparkbar(10, 0, 100)(x, amount) - sums amounts for each bucket and renders as sparkbar
+  *          countSparkbar(10, 0, 100)(x) - counts values in each bucket and renders as sparkbar
+  */
+template <typename Key>
+class AggregateFunctionSparkbar final : public IAggregateFunctionHelper<AggregateFunctionSparkbar<Key>>
+{
+private:
+    static constexpr size_t BAR_LEVELS = 8;
+    static constexpr size_t MAX_WIDTH = 1024;
+
+    AggregateFunctionPtr nested_function;
+
+    size_t width;
+    Key begin_x;
+    Key end_x;
+
+    size_t align_of_data;
+    size_t size_of_data;
+
+    size_t updateFrame(ColumnString::Chars & frame, Float64 value) const
+    {
+        static constexpr std::array<std::string_view, BAR_LEVELS + 1> bars{" ", "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"};
+        const auto & bar = (std::isnan(value) || value < 1 || value > BAR_LEVELS) ? bars[0] : bars[static_cast<UInt8>(value)];
+        frame.insert(bar.begin(), bar.end());
+        return bar.size();
+    }
+
+    void render(ColumnString & to_column, const PaddedPODArray<Float64> & values) const
+    {
+        auto & chars = to_column.getChars();
+        auto & offsets = to_column.getOffsets();
+
+        Float64 max_value = 0;
+        for (const auto & v : values)
+        {
+            if (!std::isnan(v) && v > 0)
+                max_value = std::max(max_value, v);
+        }
+
+        if (max_value == 0)
+        {
+            offsets.push_back(chars.size());
+            return;
+        }
+
+        for (auto v : values)
+        {
+            Float64 scaled = 0;
+            if (!std::isnan(v) && v > 0)
+                scaled = v / max_value * (BAR_LEVELS - 1) + 1;
+            updateFrame(chars, scaled);
+        }
+
+        offsets.push_back(chars.size());
+    }
+
+public:
+    AggregateFunctionSparkbar(
+        AggregateFunctionPtr nested_function_,
+        size_t width_,
+        Key begin_x_,
+        Key end_x_,
+        const DataTypes & arguments,
+        const Array & params)
+        : IAggregateFunctionHelper<AggregateFunctionSparkbar<Key>>{arguments, params, std::make_shared<DataTypeString>()}
+        , nested_function{nested_function_}
+        , width{width_}
+        , begin_x{begin_x_}
+        , end_x{end_x_}
+        , align_of_data{nested_function->alignOfData()}
+        , size_of_data{(nested_function->sizeOfData() + align_of_data - 1) / align_of_data * align_of_data}
+    {
+        if (width < 2 || width > MAX_WIDTH)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Parameter width must be in range [2, {}]", MAX_WIDTH);
+
+        if (begin_x >= end_x)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Parameter min_x must be less than max_x");
+
+        auto result_type = removeNullable(nested_function->getResultType());
+        if (!isNumber(result_type) && !isDecimal(result_type))
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "Aggregate function {} requires nested function with numeric result type, got {}",
+                getName(), nested_function->getResultType()->getName());
+    }
+
+    String getName() const override
+    {
+        return nested_function->getName() + "Sparkbar";
+    }
+
+    bool isState() const override
+    {
+        return nested_function->isState();
+    }
+
+    bool isVersioned() const override
+    {
+        return nested_function->isVersioned();
+    }
+
+    size_t getVersionFromRevision(size_t revision) const override
+    {
+        return nested_function->getVersionFromRevision(revision);
+    }
+
+    size_t getDefaultVersion() const override
+    {
+        return nested_function->getDefaultVersion();
+    }
+
+    bool allocatesMemoryInArena() const override
+    {
+        return nested_function->allocatesMemoryInArena();
+    }
+
+    bool hasTrivialDestructor() const override
+    {
+        return nested_function->hasTrivialDestructor();
+    }
+
+    size_t sizeOfData() const override
+    {
+        /// We store `width` instances of the nested function state
+        return width * size_of_data;
+    }
+
+    size_t alignOfData() const override
+    {
+        return align_of_data;
+    }
+
+    AggregateDataPtr getNestedPlace(AggregateDataPtr __restrict place, size_t bucket) const
+    {
+        return place + bucket * size_of_data;
+    }
+
+    void create(AggregateDataPtr __restrict place) const override
+    {
+        for (size_t i = 0; i < width; ++i)
+        {
+            try
+            {
+                nested_function->create(getNestedPlace(place, i));
+            }
+            catch (...)
+            {
+                for (size_t j = 0; j < i; ++j)
+                    nested_function->destroy(getNestedPlace(place, j));
+                throw;
+            }
+        }
+    }
+
+    void destroy(AggregateDataPtr __restrict place) const noexcept override
+    {
+        for (size_t i = 0; i < width; ++i)
+            nested_function->destroy(getNestedPlace(place, i));
+    }
+
+    void destroyUpToState(AggregateDataPtr __restrict place) const noexcept override
+    {
+        for (size_t i = 0; i < width; ++i)
+            nested_function->destroyUpToState(getNestedPlace(place, i));
+    }
+
+    void add(AggregateDataPtr __restrict place, const IColumn ** columns, size_t row_num, Arena * arena) const override
+    {
+        Key key;
+
+        if constexpr (static_cast<Key>(-1) < 0)
+            key = static_cast<Key>(columns[0]->getInt(row_num));
+        else
+            key = static_cast<Key>(columns[0]->getUInt(row_num));
+
+        /// Skip out-of-range keys
+        if (key < begin_x || key > end_x)
+            return;
+
+        /// Calculate bucket index
+        size_t bucket = 0;
+        Key delta = end_x - begin_x;
+        if (delta < std::numeric_limits<Key>::max())
+            delta = delta + 1;
+        Float64 w = static_cast<Float64>(width);
+        bucket = std::min<size_t>(
+            static_cast<size_t>(w / static_cast<Float64>(delta) * static_cast<Float64>(key - begin_x)),
+            width - 1);
+
+        /// The nested function receives columns starting from index 1 (skip the key column)
+        nested_function->add(getNestedPlace(place, bucket), columns + 1, row_num, arena);
+    }
+
+    void merge(AggregateDataPtr __restrict place, ConstAggregateDataPtr rhs, Arena * arena) const override
+    {
+        for (size_t i = 0; i < width; ++i)
+            nested_function->merge(getNestedPlace(place, i), getNestedPlace(const_cast<AggregateDataPtr>(rhs), i), arena);
+    }
+
+    void serialize(ConstAggregateDataPtr __restrict place, WriteBuffer & buf, std::optional<size_t> version) const override
+    {
+        for (size_t i = 0; i < width; ++i)
+            nested_function->serialize(getNestedPlace(const_cast<AggregateDataPtr>(place), i), buf, version);
+    }
+
+    void deserialize(AggregateDataPtr __restrict place, ReadBuffer & buf, std::optional<size_t> version, Arena * arena) const override
+    {
+        for (size_t i = 0; i < width; ++i)
+            nested_function->deserialize(getNestedPlace(place, i), buf, version, arena);
+    }
+
+    void insertResultInto(AggregateDataPtr __restrict place, IColumn & to, Arena * arena) const override
+    {
+        auto & to_column = assert_cast<ColumnString &>(to);
+
+        /// Extract values from each bucket
+        PaddedPODArray<Float64> bucket_values(width, 0);
+
+        /// Create a temporary column to receive nested results
+        auto result_type = nested_function->getResultType();
+        auto temp_column = result_type->createColumn();
+
+        for (size_t i = 0; i < width; ++i)
+        {
+            nested_function->insertResultInto(getNestedPlace(place, i), *temp_column, arena);
+        }
+
+        /// Convert results to Float64 for rendering
+        bool is_nullable = nested_function->getResultType()->isNullable();
+        for (size_t i = 0; i < width; ++i)
+        {
+            if (is_nullable && temp_column->isNullAt(i))
+                bucket_values[i] = std::nan("");
+            else
+                bucket_values[i] = temp_column->getFloat64(i);
+        }
+
+        render(to_column, bucket_values);
+    }
+
+    AggregateFunctionPtr getNestedFunction() const override { return nested_function; }
+};
+
+}

--- a/src/AggregateFunctions/registerAggregateFunctions.cpp
+++ b/src/AggregateFunctions/registerAggregateFunctions.cpp
@@ -113,6 +113,7 @@ void registerAggregateFunctionCombinatorResample(AggregateFunctionCombinatorFact
 void registerAggregateFunctionCombinatorDistinct(AggregateFunctionCombinatorFactory &);
 void registerAggregateFunctionCombinatorMap(AggregateFunctionCombinatorFactory & factory);
 void registerAggregateFunctionCombinatorsArgMinArgMax(AggregateFunctionCombinatorFactory & factory);
+void registerAggregateFunctionCombinatorSparkbar(AggregateFunctionCombinatorFactory & factory);
 
 void registerWindowFunctions(AggregateFunctionFactory & factory);
 
@@ -229,6 +230,7 @@ void registerAggregateFunctions()
         registerAggregateFunctionCombinatorDistinct(factory);
         registerAggregateFunctionCombinatorMap(factory);
         registerAggregateFunctionCombinatorsArgMinArgMax(factory);
+        registerAggregateFunctionCombinatorSparkbar(factory);
     }
 }
 

--- a/tests/queries/0_stateless/4061_sparkbar_combinator.reference
+++ b/tests/queries/0_stateless/4061_sparkbar_combinator.reference
@@ -1,0 +1,35 @@
+sumSparkbar with range:
+▁▂▃▃▄▅▅▆▇█
+countSparkbar with range:
+██████████
+avgSparkbar with range:
+ ▂▄▆█
+minSparkbar with range:
+█▇▆▅▅
+maxSparkbar with range:
+ ▂▄▆█
+sumSparkbar with Date:
+▂▃▅▆█
+sumSparkbar multiple rows per bucket:
+█████
+sumSparkbar with GROUP BY:
+0	 ▂▄▆█
+1	▁▃▄▆█
+sumSparkbar empty (out of range):
+
+uniqSparkbar with range:
+█████
+anySparkbar with range:
+▂▃▅▆█
+State/Merge round-trip:
+▂▃▅▆█
+Merge from multiple sources:
+█████
+finalizeAggregation with State:
+▂▃▅▆█
+Negative range:
+█████
+Nullable key:
+█ █ █
+Boundary values:
+█ █ █

--- a/tests/queries/0_stateless/4061_sparkbar_combinator.sql
+++ b/tests/queries/0_stateless/4061_sparkbar_combinator.sql
@@ -1,0 +1,92 @@
+-- Test sumSparkbar combinator with specified range
+SELECT 'sumSparkbar with range:';
+SELECT sumSparkbar(10, 0, 9)(number, number + 1) FROM numbers(10);
+
+-- Test countSparkbar combinator with specified range
+SELECT 'countSparkbar with range:';
+SELECT countSparkbar(10, 0, 9)(number) FROM numbers(10);
+
+-- Test avgSparkbar combinator with specified range
+SELECT 'avgSparkbar with range:';
+SELECT avgSparkbar(5, 0, 4)(number, number * 2) FROM numbers(5);
+
+-- Test minSparkbar combinator
+SELECT 'minSparkbar with range:';
+SELECT minSparkbar(5, 0, 4)(number, 10 - number) FROM numbers(5);
+
+-- Test maxSparkbar combinator
+SELECT 'maxSparkbar with range:';
+SELECT maxSparkbar(5, 0, 4)(number, number) FROM numbers(5);
+
+-- Test with Date type
+SELECT 'sumSparkbar with Date:';
+SELECT sumSparkbar(5, toDate('2020-01-01'), toDate('2020-01-05'))(
+    toDate('2020-01-01') + number,
+    number + 1
+) FROM numbers(5);
+
+-- Test with multiple rows per bucket
+SELECT 'sumSparkbar multiple rows per bucket:';
+SELECT sumSparkbar(5, 0, 4)(number % 5, 1) FROM numbers(20);
+
+-- Test with GROUP BY
+SELECT 'sumSparkbar with GROUP BY:';
+SELECT
+    number % 2 AS grp,
+    sumSparkbar(5, 0, 4)(number DIV 2, number)
+FROM numbers(10)
+GROUP BY grp
+ORDER BY grp;
+
+-- Test empty result (all values out of range)
+SELECT 'sumSparkbar empty (out of range):';
+SELECT sumSparkbar(5, 100, 104)(number, 1) FROM numbers(10);
+
+-- Test with uniqSparkbar
+SELECT 'uniqSparkbar with range:';
+SELECT uniqSparkbar(5, 0, 4)(number, number % 3) FROM numbers(15);
+
+-- Test anySparkbar
+SELECT 'anySparkbar with range:';
+SELECT anySparkbar(5, 0, 4)(number, number + 1) FROM numbers(5);
+
+-- Test State/Merge round-trip (serialization/deserialization)
+SELECT 'State/Merge round-trip:';
+SELECT sumSparkbarMerge(5, 0, 4)(state)
+FROM (
+    SELECT sumSparkbarState(5, 0, 4)(number, number + 1) AS state
+    FROM numbers(5)
+);
+
+-- Test merging from multiple sources (distributed query simulation)
+SELECT 'Merge from multiple sources:';
+SELECT sumSparkbarMerge(5, 0, 9)(state)
+FROM (
+    SELECT sumSparkbarState(5, 0, 9)(number, 1) AS state FROM numbers(5)
+    UNION ALL
+    SELECT sumSparkbarState(5, 0, 9)(number + 5, 1) AS state FROM numbers(5)
+);
+
+-- Test finalizeAggregation with State (alternative to AggregatingMergeTree)
+SELECT 'finalizeAggregation with State:';
+SELECT finalizeAggregation(sumSparkbarState(5, 0, 4)(number, number + 1))
+FROM numbers(5);
+
+-- Test negative range with signed integers
+SELECT 'Negative range:';
+SELECT sumSparkbar(5, -5, -1)(toInt64(number) - 5, 1) FROM numbers(5);
+
+-- Test Nullable key handling
+SELECT 'Nullable key:';
+SELECT sumSparkbar(5, 0, 4)(
+    if(number % 2 = 0, number, NULL)::Nullable(UInt64),
+    1
+) FROM numbers(10);
+
+-- Test boundary values (keys at exact bucket boundaries)
+SELECT 'Boundary values:';
+SELECT sumSparkbar(5, 0, 4)(number, 1) FROM (
+    SELECT 0 AS number UNION ALL
+    SELECT 4 AS number UNION ALL
+    SELECT 2 AS number
+);


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
  Add -Sparkbar aggregate function combinator that applies any aggregate function to values within buckets and renders results as a sparkbar visualization. For example, sumSparkbar(10, min, max)(key, value) computes sums for each bucket and
  displays as a bar chart.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

### Details
issue: https://github.com/ClickHouse/ClickHouse/issues/59832
