### PR TITLE
Add test: No test for merge handling in readonly MergeTree refresh (refreshDataParts covers parts by Transaction::commit)

### DIFF
--- a/tests/queries/0_stateless/04089_merge_tree_refresh_after_merge.reference
+++ b/tests/queries/0_stateless/04089_merge_tree_refresh_after_merge.reference
@@ -1,0 +1,4 @@
+3
+aaa
+bbb
+ccc

--- a/tests/queries/0_stateless/04089_merge_tree_refresh_after_merge.sh
+++ b/tests/queries/0_stateless/04089_merge_tree_refresh_after_merge.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Tags: no-random-settings, no-object-storage, no-replicated-database, no-shared-merge-tree, no-fasttest
+# Test: Verify that reader with refresh_parts_interval correctly handles merges done by writer
+# Covers: MergeTreeData::refreshDataParts at MergeTreeData.cpp:2620 - merge handling in readonly tables
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS writer_04089 SYNC"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS reader_04089 SYNC"
+
+${CLICKHOUSE_CLIENT} --query "
+CREATE TABLE writer_04089 (s String) ORDER BY ()
+SETTINGS table_disk = true,
+  disk = disk(
+      name = 04089_writer_${CLICKHOUSE_DATABASE},
+      type = object_storage,
+      object_storage_type = local,
+      metadata_type = plain_rewritable,
+      path = 'disks/04089/${CLICKHOUSE_DATABASE}/')
+"
+
+${CLICKHOUSE_CLIENT} --query "
+CREATE TABLE reader_04089 (s String) ORDER BY ()
+SETTINGS table_disk = true, refresh_parts_interval = 1,
+  disk = disk(
+      readonly = true,
+      name = 04089_reader_${CLICKHOUSE_DATABASE},
+      type = object_storage,
+      object_storage_type = local,
+      metadata_type = plain_rewritable,
+      path = 'disks/04089/${CLICKHOUSE_DATABASE}/')
+"
+
+# Insert 3 parts
+${CLICKHOUSE_CLIENT} --query "INSERT INTO writer_04089 VALUES ('aaa')"
+${CLICKHOUSE_CLIENT} --query "INSERT INTO writer_04089 VALUES ('bbb')"
+${CLICKHOUSE_CLIENT} --query "INSERT INTO writer_04089 VALUES ('ccc')"
+
+# Wait for reader to see all 3 rows
+for i in $(seq 1 30); do
+    result=$(${CLICKHOUSE_CLIENT} --query "SELECT count() FROM reader_04089")
+    if [ "$result" -eq 3 ]; then
+        break;
+    fi
+    sleep 0.5;
+done
+
+# Merge all parts in writer
+${CLICKHOUSE_CLIENT} --query "OPTIMIZE TABLE writer_04089 FINAL"
+
+# Wait for reader to refresh and verify no duplicate rows
+sleep 3
+
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM reader_04089"
+${CLICKHOUSE_CLIENT} --query "SELECT * FROM reader_04089 ORDER BY s"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE reader_04089 SYNC"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE writer_04089 SYNC"


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #79033](https://github.com/ClickHouse/ClickHouse/pull/79033) (merged 2025-04-11). Confirmed on current codebase — close with a note if already fixed._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #79033](https://github.com/ClickHouse/ClickHouse/pull/79033).

**1. No test for merge handling in readonly MergeTree refresh (refreshDataParts covers parts by Transaction::commit)**
  `src/Storages/MergeTree/MergeTreeData.cpp:2660`, `src/Storages/MergeTree/MergeTreeData.cpp:2688`
  **Why this test:** MergeTreeData::refreshDataParts (MergeTreeData.cpp:2620) loads new parts and adds them via Transaction::commit which calls getActivePartsToReplace to mark old covered parts as Outdated. This merge han
  **What's unique:** PR's test 03362 covers only basic single INSERT + read. This test covers the merge handling path: multiple inserts → writer merge → reader refresh correctly handling covered parts without duplicates.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---
_Found during review of [PR #79033](https://github.com/ClickHouse/ClickHouse/pull/79033)._