### PR TITLE
Prevent server termination when unregistering S3 client fails

### DIFF
--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -339,7 +339,6 @@ Client::~Client()
     catch (...)
     {
         tryLogCurrentException(log);
-        throw;
     }
 }
 


### PR DESCRIPTION
Prevents the server from terminating (`std::terminate`) when an exception is thrown during S3 client cache unregistration. The `throw;` statement was erroneously placed within the `catch` block of `Client::~Client()`, which is a `noexcept` destructor.
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)
### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix exception escaping from S3 `Client::~Client` destructor causing server termination.

StackOverflow similar issue link: https://stackoverflow.com/questions/40455741/why-c11-mark-destructors-as-nothrow-and-is-it-possible-to-override-it
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
