### PR TITLE
Add used index types column to system query log

### DIFF
--- a/docs/en/operations/system-tables/query_log.md
+++ b/docs/en/operations/system-tables/query_log.md
@@ -125,6 +125,7 @@ You can use the [log_formatted_queries](/operations/settings/settings#log_format
 - `used_table_functions` ([Array(String)](../../sql-reference/data-types/array.md)) — Canonical names of `table functions`, which were used during query execution.
 - `used_executable_user_defined_functions` ([Array(String)](../../sql-reference/data-types/array.md)) — Canonical names of `executable user defined functions`, which were used during query execution.
 - `used_sql_user_defined_functions` ([Array(String)](../../sql-reference/data-types/array.md)) — Canonical names of `sql user defined functions`, which were used during query execution.
+- `used_index_types` ([Array(String)](../../sql-reference/data-types/array.md)) — Canonical names of data-skipping index types (e.g., `minmax`, `set`, `bloom_filter`, `ngrambf_v1`, `tokenbf_v1`), which were used during query execution.
 - `used_privileges` ([Array(String)](../../sql-reference/data-types/array.md)) - Privileges which were successfully checked during query execution.
 - `missing_privileges` ([Array(String)](../../sql-reference/data-types/array.md)) - Privileges that are missing during query execution.
 - `query_cache_usage` ([Enum8](../../sql-reference/data-types/enum.md)) — Usage of the [query cache](../query-cache.md) during query execution. Values:
@@ -212,6 +213,7 @@ used_storages:                         []
 used_table_functions:                  []
 used_executable_user_defined_functions:[]
 used_sql_user_defined_functions:       []
+used_skip_index_types:                 []
 used_privileges:                       []
 missing_privileges:                    []
 query_cache_usage:                     None

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -2652,6 +2652,10 @@ void Context::addQueryFactoriesInfo(QueryLogFactories factory_type, const String
             break;
         case QueryLogFactories::SQLUserDefinedFunction:
             query_factories_info.sql_user_defined_functions.emplace(created_object);
+            break;
+        case QueryLogFactories::SkipIndexType:
+            query_factories_info.skip_index_types.emplace(created_object);
+            break;
     }
 }
 

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -498,6 +498,7 @@ public:
             table_functions = rhs.table_functions;
             executable_user_defined_functions = rhs.executable_user_defined_functions;
             sql_user_defined_functions = rhs.sql_user_defined_functions;
+            skip_index_types = rhs.skip_index_types;
         }
 
         QueryFactoriesInfo(QueryFactoriesInfo && rhs) = delete;
@@ -513,6 +514,7 @@ public:
         std::unordered_set<std::string> table_functions TSA_GUARDED_BY(mutex);
         std::unordered_set<std::string> executable_user_defined_functions TSA_GUARDED_BY(mutex);
         std::unordered_set<std::string> sql_user_defined_functions TSA_GUARDED_BY(mutex);
+        std::unordered_set<std::string> skip_index_types TSA_GUARDED_BY(mutex);
 
         mutable std::mutex mutex;
     };
@@ -1017,7 +1019,8 @@ public:
         Storage,
         TableFunction,
         ExecutableUserDefinedFunction,
-        SQLUserDefinedFunction
+        SQLUserDefinedFunction,
+        SkipIndexType
     };
 
     QueryFactoriesInfo getQueryFactoriesInfo() const;

--- a/src/Interpreters/QueryLog.cpp
+++ b/src/Interpreters/QueryLog.cpp
@@ -147,6 +147,7 @@ ColumnsDescription QueryLogElement::getColumnsDescription()
         {"used_table_functions", array_low_cardinality_string, "Canonical names of table functions, which were used during query execution."},
         {"used_executable_user_defined_functions", array_low_cardinality_string, "Canonical names of executable user defined functions, which were used during query execution."},
         {"used_sql_user_defined_functions", array_low_cardinality_string, "Canonical names of sql user defined functions, which were used during query execution."},
+        {"used_index_types", array_low_cardinality_string, "Canonical names of data-skipping index types, which were used during query execution."},
 
         {"used_row_policies", array_low_cardinality_string, "The list of row policies names that were used during query execution."},
 
@@ -293,6 +294,7 @@ void QueryLogElement::appendToBlock(MutableColumns & columns) const
         auto & column_table_function_factory_objects = typeid_cast<ColumnArray &>(*columns[i++]);
         auto & column_executable_user_defined_function_factory_objects = typeid_cast<ColumnArray &>(*columns[i++]);
         auto & column_sql_user_defined_function_factory_objects = typeid_cast<ColumnArray &>(*columns[i++]);
+        auto & column_skip_index_type_objects = typeid_cast<ColumnArray &>(*columns[i++]);
         auto & column_row_policies_names = typeid_cast<ColumnArray &>(*columns[i++]);
         auto & column_used_privileges = typeid_cast<ColumnArray &>(*columns[i++]);
         auto & column_missing_privileges = typeid_cast<ColumnArray &>(*columns[i++]);
@@ -322,6 +324,7 @@ void QueryLogElement::appendToBlock(MutableColumns & columns) const
         fill_column(used_table_functions, column_table_function_factory_objects);
         fill_column(used_executable_user_defined_functions, column_executable_user_defined_function_factory_objects);
         fill_column(used_sql_user_defined_functions, column_sql_user_defined_function_factory_objects);
+        fill_column(used_index_types, column_skip_index_type_objects);
         fill_column(used_row_policies, column_row_policies_names);
         fill_column(used_privileges, column_used_privileges);
         fill_column(missing_privileges, column_missing_privileges);

--- a/src/Interpreters/QueryLogElement.h
+++ b/src/Interpreters/QueryLogElement.h
@@ -83,6 +83,7 @@ struct QueryLogElement
     std::unordered_set<String> used_table_functions;
     std::unordered_set<String> used_executable_user_defined_functions;
     std::unordered_set<String> used_sql_user_defined_functions;
+    std::unordered_set<String> used_index_types;
     std::set<String> used_row_policies;
     std::unordered_set<String> used_privileges;
     std::unordered_set<String> missing_privileges;

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -405,6 +405,7 @@ addStatusInfoToQueryLogElement(QueryLogElement & element, const QueryStatusInfo 
         element.used_table_functions = factories_info.table_functions;
         element.used_executable_user_defined_functions = factories_info.executable_user_defined_functions;
         element.used_sql_user_defined_functions = factories_info.sql_user_defined_functions;
+        element.used_index_types = factories_info.skip_index_types;
     }
 
     element.async_read_counters = context_ptr->getAsyncReadCounters();

--- a/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataSelectExecutor.cpp
@@ -78,6 +78,7 @@ namespace Setting
     extern const SettingsString force_data_skipping_indices;
     extern const SettingsBool force_index_by_date;
     extern const SettingsSeconds lock_acquire_timeout;
+    extern const SettingsBool log_queries;
     extern const SettingsUInt64 max_rows_to_read;
     extern const SettingsUInt64 max_threads_for_indexes;
     extern const SettingsNonZeroUInt64 max_parallel_replicas;
@@ -1238,6 +1239,18 @@ RangesInDataParts MergeTreeDataSelectExecutor::filterPartsByPrimaryKeyAndSkipInd
             top_k_elapsed_us.load() / 1000,
             num_threads);
     }
+    /// Record used skip index types in the query log.
+    if (context->hasQueryContext() && settings[Setting::log_queries])
+    {
+        for (const auto & index_and_condition : skip_indexes.useful_indices)
+            context->getQueryContext()->addQueryFactoriesInfo(
+                Context::QueryLogFactories::SkipIndexType, index_and_condition.index->index.type);
+
+        if (skip_indexes.skip_index_for_top_k_filtering)
+            context->getQueryContext()->addQueryFactoriesInfo(
+                Context::QueryLogFactories::SkipIndexType, skip_indexes.skip_index_for_top_k_filtering->index.type);
+    }
+
     /// Skip empty ranges.
     std::erase_if(
         parts_with_ranges,

--- a/tests/queries/0_stateless/04077_query_log_used_skip_index_types.reference
+++ b/tests/queries/0_stateless/04077_query_log_used_skip_index_types.reference
@@ -1,0 +1,5 @@
+['minmax','set']
+['bloom_filter','ngrambf_v1']
+[]
+['minmax']
+[]

--- a/tests/queries/0_stateless/04077_query_log_used_skip_index_types.sql
+++ b/tests/queries/0_stateless/04077_query_log_used_skip_index_types.sql
@@ -1,0 +1,124 @@
+-- Tags: no-parallel
+
+DROP TABLE IF EXISTS test_skip_index_log;
+
+CREATE TABLE test_skip_index_log
+(
+    id UInt32,
+    value String,
+    num UInt32,
+    INDEX idx_minmax num TYPE minmax GRANULARITY 1,
+    INDEX idx_set num TYPE set(100) GRANULARITY 1,
+    INDEX idx_bf value TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_ngram value TYPE ngrambf_v1(3, 256, 2, 0) GRANULARITY 1
+)
+ENGINE = MergeTree()
+ORDER BY id;
+
+INSERT INTO test_skip_index_log SELECT number, toString(number), number FROM numbers(1000);
+
+-- Query that uses minmax and set indexes (numeric condition)
+SELECT count() FROM test_skip_index_log WHERE num > 500 FORMAT Null;
+
+SYSTEM FLUSH LOGS;
+
+SELECT arraySort(used_index_types)
+FROM system.query_log
+WHERE current_database = currentDatabase()
+    AND query LIKE '%FROM test_skip_index_log WHERE num > 500%'
+    AND type = 'QueryFinish'
+    AND query NOT LIKE '%system.query_log%'
+ORDER BY event_time_microseconds DESC
+LIMIT 1;
+
+-- Query that uses bloom_filter and ngrambf_v1 indexes (string condition)
+SELECT count() FROM test_skip_index_log WHERE value = '42' FORMAT Null;
+
+SYSTEM FLUSH LOGS;
+
+SELECT arraySort(used_index_types)
+FROM system.query_log
+WHERE current_database = currentDatabase()
+    AND query LIKE '%FROM test_skip_index_log WHERE value = %'
+    AND type = 'QueryFinish'
+    AND query NOT LIKE '%system.query_log%'
+ORDER BY event_time_microseconds DESC
+LIMIT 1;
+
+-- Query without skip indexes has empty array
+SELECT count() FROM test_skip_index_log FORMAT Null;
+
+SYSTEM FLUSH LOGS;
+
+SELECT used_index_types
+FROM system.query_log
+WHERE current_database = currentDatabase()
+    AND query LIKE '%count() FROM test_skip_index_log FORMAT Null%'
+    AND type = 'QueryFinish'
+    AND query NOT LIKE '%system.query_log%'
+ORDER BY event_time_microseconds DESC
+LIMIT 1;
+
+DROP TABLE test_skip_index_log;
+
+-- Test deduplication: two minmax indexes on different columns should produce a single 'minmax' entry
+DROP TABLE IF EXISTS test_skip_index_dedup;
+
+CREATE TABLE test_skip_index_dedup
+(
+    id UInt32,
+    a UInt32,
+    b UInt32,
+    INDEX idx_mm_a a TYPE minmax GRANULARITY 1,
+    INDEX idx_mm_b b TYPE minmax GRANULARITY 1
+)
+ENGINE = MergeTree()
+ORDER BY id;
+
+INSERT INTO test_skip_index_dedup SELECT number, number, number FROM numbers(1000);
+
+SELECT count() FROM test_skip_index_dedup WHERE a > 500 AND b < 200 FORMAT Null;
+
+SYSTEM FLUSH LOGS;
+
+SELECT arraySort(used_index_types)
+FROM system.query_log
+WHERE current_database = currentDatabase()
+    AND query LIKE '%FROM test_skip_index_dedup WHERE a > 500 AND b < 200%'
+    AND type = 'QueryFinish'
+    AND query NOT LIKE '%system.query_log%'
+ORDER BY event_time_microseconds DESC
+LIMIT 1;
+
+DROP TABLE test_skip_index_dedup;
+
+-- Test that indexes defined on columns not referenced in WHERE are not recorded
+DROP TABLE IF EXISTS test_skip_index_not_useful;
+
+CREATE TABLE test_skip_index_not_useful
+(
+    id UInt32,
+    indexed_col String,
+    other_col UInt32,
+    INDEX idx_bf indexed_col TYPE bloom_filter GRANULARITY 1
+)
+ENGINE = MergeTree()
+ORDER BY id;
+
+INSERT INTO test_skip_index_not_useful SELECT number, toString(number), number FROM numbers(1000);
+
+-- Filter on other_col which has no skip index; bloom_filter on indexed_col should not be useful
+SELECT count() FROM test_skip_index_not_useful WHERE other_col > 500 FORMAT Null;
+
+SYSTEM FLUSH LOGS;
+
+SELECT used_index_types
+FROM system.query_log
+WHERE current_database = currentDatabase()
+    AND query LIKE '%FROM test_skip_index_not_useful WHERE other_col%'
+    AND type = 'QueryFinish'
+    AND query NOT LIKE '%system.query_log%'
+ORDER BY event_time_microseconds DESC
+LIMIT 1;
+
+DROP TABLE test_skip_index_not_useful;


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature
### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
- Showing index usage by type . Close #101673 

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
