### PR TITLE
Keep GH Comments as before, add more context about LLVM Coverage in log

### DIFF
--- a/ci/jobs/llvm_coverage_job.py
+++ b/ci/jobs/llvm_coverage_job.py
@@ -296,6 +296,22 @@ if __name__ == "__main__":
                 info=msg,
             )
             print_res.set_comment(msg)
+        # Append high-precision hit/total counts to the log so they are visible
+        # in the artifact without cluttering the GitHub comment.
+        if _diff_ran:
+            with open(_print_log, "a") as _f:
+                _f.write(
+                    f"\n--- Coverage counts ---\n"
+                    f"Lines     : baseline {b_line_hit:,}/{b_line_total:,}"
+                    f"  →  current {c_line_hit:,}/{c_line_total:,}"
+                    f"  (Δ {c_line_hit - b_line_hit:+,} / {c_line_total - b_line_total:+,})\n"
+                    f"Functions : baseline {b_func_hit:,}/{b_func_total:,}"
+                    f"  →  current {c_func_hit:,}/{c_func_total:,}"
+                    f"  (Δ {c_func_hit - b_func_hit:+,} / {c_func_total - b_func_total:+,})\n"
+                    f"Branches  : baseline {b_branch_hit:,}/{b_branch_total:,}"
+                    f"  →  current {c_branch_hit:,}/{c_branch_total:,}"
+                    f"  (Δ {c_branch_hit - b_branch_hit:+,} / {c_branch_total - b_branch_total:+,})\n"
+                )
         print_res.files.append(_print_log)
         results.append(print_res)
 

--- a/ci/jobs/scripts/job_hooks/llvm_coverage_hook.py
+++ b/ci/jobs/scripts/job_hooks/llvm_coverage_hook.py
@@ -41,24 +41,14 @@ def check():
         diff_url = d.get("diff_url", "")
         uncovered_code_url = d.get("uncovered_code_url", "")
 
-        def fmt_cov(pct: float, hit: int, total: int) -> str:
-            if total > 0:
-                return f"{pct:.2f}% ({hit:,}/{total:,})"
-            return f"{pct:.2f}%"
-
-        def fmt_delta(pct_delta: float, hit_delta: int) -> str:
-            if hit_delta != 0:
-                return f"{pct_delta:+.2f}% ({hit_delta:+,})"
-            return f"{pct_delta:+.2f}%"
-
         if info.pr_number > 0:
             body = (
                 f"### LLVM Coverage Report\n\n"
                 f"| Metric | Baseline | Current | Δ |\n"
                 f"|--------|----------|---------|---|\n"
-                f"| Lines | {fmt_cov(b_line_cov, b_line_hit, b_line_total)} | {fmt_cov(c_line_cov, c_line_hit, c_line_total)} | {fmt_delta(c_line_cov - b_line_cov, c_line_hit - b_line_hit)} |\n"
-                f"| Functions | {fmt_cov(b_function_cov, b_func_hit, b_func_total)} | {fmt_cov(c_function_cov, c_func_hit, c_func_total)} | {fmt_delta(c_function_cov - b_function_cov, c_func_hit - b_func_hit)} |\n"
-                f"| Branches | {fmt_cov(b_branch_cov, b_branch_hit, b_branch_total)} | {fmt_cov(c_branch_cov, c_branch_hit, c_branch_total)} | {fmt_delta(c_branch_cov - b_branch_cov, c_branch_hit - b_branch_hit)} |\n"
+                f"| Lines | {b_line_cov:.2f}% | {c_line_cov:.2f}% | {c_line_cov - b_line_cov:+.2f}% |\n"
+                f"| Functions | {b_function_cov:.2f}% | {c_function_cov:.2f}% | {c_function_cov - b_function_cov:+.2f}% |\n"
+                f"| Branches | {b_branch_cov:.2f}% | {c_branch_cov:.2f}% | {c_branch_cov - b_branch_cov:+.2f}% |\n"
             )
             if pr_changed_lines_info:
                 changed_line = f"\n**Changed lines:** {pr_changed_lines_info}"


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Follow-up of https://github.com/ClickHouse/ClickHouse/pull/101590

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.577`
<!-- ch-version-info:end -->