### PR TITLE
Clear LLVM_PROFILE_FILE for manual clickhouse launches in test_server_reload

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -2135,8 +2135,11 @@ class ClickHouseCluster:
 
         # Code coverage files will be placed in database directory
         # (affect only WITH_COVERAGE=1 build)
+        # Use %p (PID) instead of %4m (merge-mode pool of 4) to avoid
+        # file-lock races between server and docker-exec'd client processes
+        # sharing the same container environment.
         env_variables["LLVM_PROFILE_FILE"] = (
-            "/debug/it-%4m.profraw"
+            "/debug/it-%p.profraw"
         )
 
         clickhouse_start_command = clickhouse_start_cmd

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -2135,11 +2135,8 @@ class ClickHouseCluster:
 
         # Code coverage files will be placed in database directory
         # (affect only WITH_COVERAGE=1 build)
-        # Use %p (PID) instead of %4m (merge-mode pool of 4) to avoid
-        # file-lock races between server and docker-exec'd client processes
-        # sharing the same container environment.
         env_variables["LLVM_PROFILE_FILE"] = (
-            "/debug/it-%p.profraw"
+            "/debug/it-%4m.profraw"
         )
 
         clickhouse_start_command = clickhouse_start_cmd

--- a/tests/integration/test_server_reload/test.py
+++ b/tests/integration/test_server_reload/test.py
@@ -309,10 +309,14 @@ def test_change_listen_host(cluster, zk):
     localhost_client = Client(
         host="127.0.0.1", port=9000, command="/usr/bin/clickhouse"
     )
+    # Clear LLVM_PROFILE_FILE so this manually-launched clickhouse process
+    # does not race with the server over the same profraw merge-pool slots.
     localhost_client.command = [
         "docker",
         "exec",
         "-i",
+        "-e",
+        "LLVM_PROFILE_FILE=",
         instance.docker_id,
     ] + localhost_client.command
     try:
@@ -338,10 +342,14 @@ def test_reload_via_client(cluster, zk):
     localhost_client = Client(
         host="127.0.0.1", port=9000, command="/usr/bin/clickhouse"
     )
+    # Clear LLVM_PROFILE_FILE so this manually-launched clickhouse process
+    # does not race with the server over the same profraw merge-pool slots.
     localhost_client.command = [
         "docker",
         "exec",
         "-i",
+        "-e",
+        "LLVM_PROFILE_FILE=",
         instance.docker_id,
     ] + localhost_client.command
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Not required

### What this PR does

In coverage builds (`amd_llvm_coverage`), `test_change_listen_host` and `test_reload_via_client` launch clickhouse inside a container via `docker exec`. These processes inherit `LLVM_PROFILE_FILE` from the container environment and can select the same merge-pool slot (`%4m`) as the running server, causing file-lock races that produce `LLVM Profile Error: Failed to write file...File exists` on stderr. The test helper then treats this non-empty stderr as a query failure.

**Fix:** Pass `-e LLVM_PROFILE_FILE=` to `docker exec` for these manual launches, clearing the variable so the profiler is disabled for the short-lived client processes. The server's profiling is unaffected.

**Root cause** (identified by @alexbakharew): The manually-launched clickhouse processes inside the container inherit the `LLVM_PROFILE_FILE=%4m` pattern. With only 4 hash slots, the client can select the same pool_id the server already holds, causing a file conflict.

**Scope:** Only the two affected tests are changed — the global `LLVM_PROFILE_FILE` setting in `cluster.py` is left at `%4m` as intended.

**CIDB data:** 29 failures in 30 days, exclusively on `Integration tests (amd_llvm_coverage, 5/5)`, affecting 27 distinct PRs and 3 master runs.