### PR TITLE
Fix: don't wipe LDAP user roles on interserver authentication

### DIFF
--- a/src/Access/LDAPAccessStorage.cpp
+++ b/src/Access/LDAPAccessStorage.cpp
@@ -485,8 +485,11 @@ std::optional<AuthResult> LDAPAccessStorage::authenticateImpl(
     }
     else
     {
-        // Just in case external_roles are changed. This will be no-op if they are not.
-        updateAssignedRolesNoLock(*id, user->getName(), external_roles);
+        // Don't update roles when authenticating via AlwaysAllowCredentials (interserver path),
+        // because we didn't contact LDAP and have no role information — updating with an empty
+        // set would wipe the user's existing mapped roles.
+        if (!typeid_cast<const AlwaysAllowCredentials *>(&credentials))
+            updateAssignedRolesNoLock(*id, user->getName(), external_roles);
     }
 
     if (id)


### PR DESCRIPTION
ClickHouse version: 25.8.20.4. The affected code is still present on current master.

## Problem

`LDAPAccessStorage::authenticateImpl` calls `updateAssignedRolesNoLock` with
empty `external_roles` when credentials are `AlwaysAllowCredentials`
(the trusted interserver authentication path).

In this path ClickHouse does not contact LDAP because no password is available,
so there is no LDAP role information to refresh. Updating the existing user with
this empty set removes the previously mapped LDAP roles from the in-memory user.

## User-visible impact

An LDAP user can successfully authenticate and execute queries, then lose
their mapped roles after an interserver request for the same user reaches a node.

This manifests as either:

- an already opened session losing its current roles and failing even local queries;
- a distributed child query failing with `Code: 497` on a physical shard table,
  for example `Not enough privileges ... ON <database>.<table>_SH`
  while executing a remote query.

The issue can be triggered by nested remote execution, for example a CTE/JOIN
over Distributed tables or `clusterAllReplicas()` applied to a Distributed table.

## Expected behavior

Trusted interserver authentication must not overwrite LDAP-mapped roles when
it has no role information from LDAP.

## Fix

Skip role updates for `AlwaysAllowCredentials`. Normal password authentication
with `BasicCredentials` is unchanged and continues to refresh LDAP-mapped roles.

Ref: #52035, #78791, #79099

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry:
Fix unintended removal of LDAP-mapped roles during trusted interserver authentication.
