### PR TITLE
Disable coverage for 00746_sql_fuzzy test

### DIFF
--- a/tests/queries/0_stateless/00746_sql_fuzzy.sh
+++ b/tests/queries/0_stateless/00746_sql_fuzzy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-coverage
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
Disable coverage for `00746_sql_fuzzy` test. The fuzzy SQL test generates random queries that are not meaningful for code coverage analysis, similar to #101692.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.600`
<!-- ch-version-info:end -->