### PR TITLE
Fix materialize_skip_indexes_on_merge not suppressing text indexes

### DIFF
--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -883,6 +883,7 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
     {
         global_ctx->merging_skip_indexes.clear();
         global_ctx->skip_indexes_by_column.clear();
+        global_ctx->text_indexes_to_merge.clear();
     }
 
     bool use_adaptive_granularity = global_ctx->new_data_part->index_granularity_info.mark_type.adaptive;

--- a/tests/queries/0_stateless/04082_materialize_skip_indexes_text_index.reference
+++ b/tests/queries/0_stateless/04082_materialize_skip_indexes_text_index.reference
@@ -1,0 +1,12 @@
+After merge with materialize_skip_indexes_on_merge=0
+idx_minmax	0
+idx_text	0
+After explicit MATERIALIZE INDEX
+idx_minmax	1
+idx_text	1
+After merge with materialize_skip_indexes_on_merge=1
+idx_minmax	1
+idx_text	1
+After merge with exclude idx_text
+idx_minmax	1
+idx_text	0

--- a/tests/queries/0_stateless/04082_materialize_skip_indexes_text_index.sql
+++ b/tests/queries/0_stateless/04082_materialize_skip_indexes_text_index.sql
@@ -1,0 +1,83 @@
+-- Tags: no-parallel
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/101666
+-- materialize_skip_indexes_on_merge=false must suppress text (full-text) indexes during merge,
+-- not only minmax/set/bloom_filter etc. Text indexes use a separate container
+-- (text_indexes_to_merge) which was previously not cleared by the setting.
+
+SET mutations_sync = 2;
+
+DROP TABLE IF EXISTS t_text_idx;
+
+CREATE TABLE t_text_idx
+(
+    id UInt64,
+    s String,
+    INDEX idx_text s TYPE text(tokenizer='splitByNonAlpha') GRANULARITY 1,
+    INDEX idx_minmax id TYPE minmax GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 4, materialize_skip_indexes_on_merge = 0;
+
+INSERT INTO t_text_idx SELECT number, 'hello world' FROM numbers(20);
+INSERT INTO t_text_idx SELECT number + 20, 'hello world' FROM numbers(20);
+
+OPTIMIZE TABLE t_text_idx FINAL;
+
+-- Both indexes should have no data after merge with materialize_skip_indexes_on_merge=0
+SELECT 'After merge with materialize_skip_indexes_on_merge=0';
+SELECT name, data_compressed_bytes > 0 AS has_data
+FROM system.data_skipping_indices
+WHERE database = currentDatabase() AND table = 't_text_idx'
+ORDER BY name;
+
+-- Explicit MATERIALIZE INDEX should still rebuild them
+ALTER TABLE t_text_idx MATERIALIZE INDEX idx_text;
+ALTER TABLE t_text_idx MATERIALIZE INDEX idx_minmax;
+
+SELECT 'After explicit MATERIALIZE INDEX';
+SELECT name, data_compressed_bytes > 0 AS has_data
+FROM system.data_skipping_indices
+WHERE database = currentDatabase() AND table = 't_text_idx'
+ORDER BY name;
+
+-- Reset setting and verify indexes are built during merge again
+ALTER TABLE t_text_idx MODIFY SETTING materialize_skip_indexes_on_merge = 1;
+
+TRUNCATE TABLE t_text_idx;
+INSERT INTO t_text_idx SELECT number, 'hello world' FROM numbers(20);
+INSERT INTO t_text_idx SELECT number + 20, 'hello world' FROM numbers(20);
+
+OPTIMIZE TABLE t_text_idx FINAL;
+
+SELECT 'After merge with materialize_skip_indexes_on_merge=1';
+SELECT name, data_compressed_bytes > 0 AS has_data
+FROM system.data_skipping_indices
+WHERE database = currentDatabase() AND table = 't_text_idx'
+ORDER BY name;
+
+DROP TABLE t_text_idx;
+
+-- Also test exclude_materialize_skip_indexes_on_merge with text indexes
+DROP TABLE IF EXISTS t_text_exclude;
+
+CREATE TABLE t_text_exclude
+(
+    id UInt64,
+    s String,
+    INDEX idx_text s TYPE text(tokenizer='splitByNonAlpha') GRANULARITY 1,
+    INDEX idx_minmax id TYPE minmax GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 4, exclude_materialize_skip_indexes_on_merge = 'idx_text';
+
+INSERT INTO t_text_exclude SELECT number, 'hello world' FROM numbers(20);
+INSERT INTO t_text_exclude SELECT number + 20, 'hello world' FROM numbers(20);
+
+OPTIMIZE TABLE t_text_exclude FINAL;
+
+-- Only idx_text should be excluded; idx_minmax should have data
+SELECT 'After merge with exclude idx_text';
+SELECT name, data_compressed_bytes > 0 AS has_data
+FROM system.data_skipping_indices
+WHERE database = currentDatabase() AND table = 't_text_exclude'
+ORDER BY name;
+
+DROP TABLE t_text_exclude;

--- a/tests/queries/0_stateless/04082_materialize_skip_indexes_text_index.sql
+++ b/tests/queries/0_stateless/04082_materialize_skip_indexes_text_index.sql
@@ -1,4 +1,3 @@
--- Tags: no-parallel
 -- Regression test for https://github.com/ClickHouse/ClickHouse/issues/101666
 -- materialize_skip_indexes_on_merge=false must suppress text (full-text) indexes during merge,
 -- not only minmax/set/bloom_filter etc. Text indexes use a separate container


### PR DESCRIPTION
When `materialize_skip_indexes_on_merge` is set to `false`, text (full-text) indexes were still built during merge operations. Other skip index types (minmax, set, bloom_filter) were correctly suppressed.

**Root cause:** In `MergeTask.cpp`, the check at line 881–886 that clears skip indexes when the setting is false only cleared `merging_skip_indexes` and `skip_indexes_by_column`, but missed the separate `text_indexes_to_merge` container. Text indexes use this separate container because they require special handling during vertical merges (introduced in PR #74401).

**Fix:** Add `text_indexes_to_merge.clear()` to the `materialize_skip_indexes_on_merge=false` branch so that text indexes are suppressed along with all other skip index types.

A regression test is included that verifies:
1. Text indexes are suppressed during merge when `materialize_skip_indexes_on_merge=0`
2. `ALTER TABLE MATERIALIZE INDEX` still rebuilds them explicitly
3. Text indexes are built normally when the setting is reset to `1`
4. `exclude_materialize_skip_indexes_on_merge` correctly excludes individual text indexes

Closes #101666

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `materialize_skip_indexes_on_merge=false` not suppressing text (full-text) indexes during merge. Previously, only non-text skip indexes (minmax, set, bloom_filter) were suppressed; text indexes continued to be built, wasting CPU and I/O.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.622`
- Backported to: `26.3.13.2`
<!-- ch-version-info:end -->