### PR TITLE
Add distroless images to the release workflow

### DIFF
--- a/.github/workflows/backfill_distroless.yml
+++ b/.github/workflows/backfill_distroless.yml
@@ -1,0 +1,98 @@
+name: BackfillDistroless
+
+"on":
+  workflow_dispatch:
+    inputs:
+      versions:
+        description: 'Space-separated list of versions to build (e.g. "25.3.3.42 25.8.2.100 25.10.1.7525")'
+        required: true
+        type: string
+      dry-run:
+        description: 'Build but do not push to Docker Hub'
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: backfill-distroless
+
+env:
+  PYTHONUNBUFFERED: 1
+
+jobs:
+  BackfillDistroless:
+    runs-on: [self-hosted, style-checker-aarch64]
+    steps:
+      - name: Check out repository code
+        uses: ClickHouse/checkout@v1
+        with:
+          clear-repository: true
+      - name: Debug Info
+        uses: ./.github/actions/debug
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        if: ${{ inputs.dry-run != true }}
+        uses: docker/login-action@v3
+        with:
+          username: robotclickhouse
+          password: ${{ secrets.DOCKERHUB_ROBOT_PASSWORD }}
+      - name: Build and push distroless images
+        shell: bash
+        run: |
+          set -e
+
+          PUSH_FLAG=""
+          OUTPUT_FLAG="--output=type=docker"
+          if [ "${{ inputs.dry-run }}" != "true" ]; then
+            PUSH_FLAG="--push"
+            OUTPUT_FLAG="--output=type=registry"
+          fi
+
+          GITHUB_RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          SHA=$(git rev-parse HEAD)
+
+          for VERSION in ${{ inputs.versions }}; do
+            echo "============================================"
+            echo "Building distroless images for ${VERSION}"
+            echo "============================================"
+
+            # Validate version format
+            if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "ERROR: Invalid version format: ${VERSION}"
+              exit 1
+            fi
+
+            VERSION_MINOR=${VERSION%.*}
+            VERSION_MAJOR=${VERSION_MINOR%.*}
+
+            for image_config in \
+              "clickhouse/clickhouse-server:docker/server/Dockerfile.distroless:docker/server" \
+              "clickhouse/clickhouse-keeper:docker/keeper/Dockerfile.distroless:docker/keeper"
+            do
+              IMAGE_NAME=${image_config%%:*}
+              rest=${image_config#*:}
+              DOCKERFILE=${rest%%:*}
+              CONTEXT=${rest#*:}
+
+              echo "--- ${IMAGE_NAME}:${VERSION}-distroless ---"
+
+              docker buildx build \
+                --platform=linux/amd64,linux/arm64 \
+                --provenance=true \
+                --sbom=true \
+                ${PUSH_FLAG:-$OUTPUT_FLAG} \
+                --label="build-url=${GITHUB_RUN_URL}" \
+                --label="com.clickhouse.build.githash=${SHA}" \
+                --label="com.clickhouse.build.version=${VERSION}-distroless" \
+                --tag="${IMAGE_NAME}:${VERSION}-distroless" \
+                --build-arg=VERSION="${VERSION}" \
+                --progress=plain \
+                --file="${DOCKERFILE}" \
+                "${CONTEXT}"
+
+              echo "Done: ${IMAGE_NAME}:${VERSION}-distroless"
+            done
+          done
+
+          echo "All versions built successfully."

--- a/.github/workflows/backfill_distroless.yml
+++ b/.github/workflows/backfill_distroless.yml
@@ -39,12 +39,15 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ROBOT_PASSWORD }}
       - name: Build and push distroless images
         shell: bash
+        env:
+          INPUT_VERSIONS: ${{ inputs.versions }}
+          INPUT_DRY_RUN: ${{ inputs.dry-run }}
         run: |
           set -e
 
           PUSH_FLAG=""
           OUTPUT_FLAG="--output=type=docker"
-          if [ "${{ inputs.dry-run }}" != "true" ]; then
+          if [ "$INPUT_DRY_RUN" != "true" ]; then
             PUSH_FLAG="--push"
             OUTPUT_FLAG="--output=type=registry"
           fi
@@ -52,7 +55,7 @@ jobs:
           GITHUB_RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           SHA=$(git rev-parse HEAD)
 
-          for VERSION in ${{ inputs.versions }}; do
+          for VERSION in $INPUT_VERSIONS; do
             echo "============================================"
             echo "Building distroless images for ${VERSION}"
             echo "============================================"

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -241,6 +241,11 @@ jobs:
             variant=${config%%:*}
             dockerfile=${config##*:}
 
+            if [ ! -f "$dockerfile" ]; then
+              echo "Skipping $variant: $dockerfile not found at this tag"
+              continue
+            fi
+
             VERSION_SUFFIX=$([ "$variant" = "ubuntu" ] && echo "" || echo "-$variant")
             LABEL_VERSION="${CLICKHOUSE_VERSION_STRING}${VERSION_SUFFIX}"
             TAGS=(
@@ -305,6 +310,11 @@ jobs:
             # Split the config into variant and Dockerfile path
             variant=${config%%:*}
             dockerfile=${config##*:}
+
+            if [ ! -f "$dockerfile" ]; then
+              echo "Skipping $variant: $dockerfile not found at this tag"
+              continue
+            fi
 
             VERSION_SUFFIX=$([ "$variant" = "ubuntu" ] && echo "" || echo "-$variant")
             LABEL_VERSION="${CLICKHOUSE_VERSION_STRING}${VERSION_SUFFIX}"

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -233,6 +233,7 @@ jobs:
           configs=(
             "ubuntu:../../docker/server/Dockerfile.ubuntu"
             "alpine:../../docker/server/Dockerfile.alpine"
+            "distroless:../../docker/server/Dockerfile.distroless"
           )
 
           for config in "${configs[@]}"; do
@@ -297,6 +298,7 @@ jobs:
           configs=(
             "ubuntu:../../docker/keeper/Dockerfile.ubuntu"
             "alpine:../../docker/keeper/Dockerfile.alpine"
+            "distroless:../../docker/keeper/Dockerfile.distroless"
           )
 
           for config in "${configs[@]}"; do


### PR DESCRIPTION
The CI pipeline already builds and pushes distroless images on every master merge (`head-distroless` tag), but the `create_release.yml` workflow only produces ubuntu and alpine variants for tagged releases.

This adds `Dockerfile.distroless` to the server and keeper build configs in the release workflow, so tagged releases will also get distroless images (e.g. `clickhouse-server:24.8.1.1234-distroless`, `clickhouse-keeper:24.8.1.1234-distroless`).

The distroless images use a Debian 13 base (`gcr.io/distroless/cc-debian13:nonroot`) — glibc 2.41, OpenSSL 3.5.5, no shell, no package manager, 0 reachable CVEs (Mend).

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Distroless Docker images are now published with ubuntu and alpine variants for tagged releases.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.617`
<!-- ch-version-info:end -->