### PR TITLE
Fix flaky test 02859_replicated_db_name_zookeeper

### DIFF
--- a/tests/queries/0_stateless/02859_replicated_db_name_zookeeper.sh
+++ b/tests/queries/0_stateless/02859_replicated_db_name_zookeeper.sh
@@ -16,7 +16,7 @@ FROM
 (
     WITH '/clickhouse/databases/' AS prefix
     SELECT
-        toUUID(substr(path, length(prefix) + 1)) AS uuid,
+        toUUIDOrNull(substr(path, length(prefix) + 1)) AS uuid,
         value AS db_name
     FROM system.zookeeper
     WHERE (path IN (
@@ -24,6 +24,7 @@ FROM
         FROM system.zookeeper
         WHERE path = prefix
     )) AND (name = 'first_replica_database_name')
+    HAVING uuid IS NOT NULL
 ) AS t1
 INNER JOIN system.databases AS t2 USING (uuid)
 WHERE db_name like '%$CLICKHOUSE_DATABASE%'


### PR DESCRIPTION
The test scans all entries under `/clickhouse/databases/` in ZooKeeper and calls `toUUID` on each path suffix. When other parallel tests create entries with non-UUID names (e.g. `d2_test_8e50qzr4`), the parse fails with `CANNOT_PARSE_UUID`.

Fix: use `toUUIDOrNull` instead and filter out NULL results.

Failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=101892&sha=633508e66d8356bbaa20a2af613a540aecbe96e9&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29
https://github.com/ClickHouse/ClickHouse/pull/101892

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.632`
<!-- ch-version-info:end -->