### PR TITLE
Use HTTP interface in test 03251_insert_sparse_all_formats to fix TSan timeout

### DIFF
--- a/tests/queries/0_stateless/03251_insert_sparse_all_formats.sh
+++ b/tests/queries/0_stateless/03251_insert_sparse_all_formats.sh
@@ -22,16 +22,14 @@ $CLICKHOUSE_CLIENT --query "
 
 for format in $formats; do
     echo $format
-    $CLICKHOUSE_CLIENT --query "INSERT INTO t_sparse_all_formats(a) SELECT number FROM numbers(1000)"
+    ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "INSERT INTO t_sparse_all_formats(a) SELECT number FROM numbers(1000)"
 
-    $CLICKHOUSE_CLIENT --query "SELECT number AS a, 0::UInt64 AS b, '' AS c FROM numbers(1000) FORMAT $format" \
+    ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "SELECT number AS a, 0::UInt64 AS b, '' AS c FROM numbers(1000) FORMAT $format" \
         | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query=INSERT+INTO+t_sparse_all_formats+FORMAT+$format&enable_parsing_to_custom_serialization=1" --data-binary @-
 
-    $CLICKHOUSE_CLIENT --query "SELECT number AS a FROM numbers(1000) FORMAT $format" \
+    ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "SELECT number AS a FROM numbers(1000) FORMAT $format" \
         | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query=INSERT+INTO+t_sparse_all_formats(a)+FORMAT+$format&enable_parsing_to_custom_serialization=1" --data-binary @-
 
-    $CLICKHOUSE_CLIENT --query "
-        SELECT sum(sipHash64(*)) FROM t_sparse_all_formats;
-        TRUNCATE TABLE t_sparse_all_formats;
-    "
+    ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "SELECT sum(sipHash64(*)) FROM t_sparse_all_formats"
+    ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "TRUNCATE TABLE t_sparse_all_formats"
 done

--- a/tests/queries/0_stateless/03251_insert_sparse_all_formats.sh
+++ b/tests/queries/0_stateless/03251_insert_sparse_all_formats.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, long, no-msan, no-azure-blob-storage, no-parallel-replicas
+# Tags: no-fasttest, long, no-msan, no-azure-blob-storage
 # no-azure-blob-storage: too slow
 # no-msan: it is too slow
-# no-parallel-replicas: the SELECT queries piped to INSERT hang with parallel replicas under TSan
 
 set -e
 

--- a/tests/queries/0_stateless/03251_insert_sparse_all_formats.sh
+++ b/tests/queries/0_stateless/03251_insert_sparse_all_formats.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, long, no-msan, no-azure-blob-storage
+# Tags: no-fasttest, long, no-msan, no-azure-blob-storage, no-parallel-replicas
 # no-azure-blob-storage: too slow
 # no-msan: it is too slow
+# no-parallel-replicas: the SELECT queries piped to INSERT hang with parallel replicas under TSan
 
 set -e
 


### PR DESCRIPTION
The test `03251_insert_sparse_all_formats` times out under TSan (600s limit) because it starts the ClickHouse binary ~208 times (52 formats × 4 `clickhouse-client` invocations per format). Each binary startup under TSan has significant overhead due to TSan initialization and memory operation interception on the large binary. The curl binary is not TSan-instrumented, so HTTP calls avoid this overhead entirely.

Replace per-format `$CLICKHOUSE_CLIENT` calls with `$CLICKHOUSE_CURL` HTTP calls. The test semantics are identical — randomized settings are applied server-side via URL parameters in both cases.

Observed in https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=101892&sha=633508e66d8356bbaa20a2af613a540aecbe96e9&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20s3%20storage%2C%20parallel%2C%202%2F2%29
https://github.com/ClickHouse/ClickHouse/pull/101892

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)