### PR TITLE
Docs: clarify that `GLOBAL JOIN` subquery side depends on join kind

### DIFF
--- a/docs/en/sql-reference/operators/in.md
+++ b/docs/en/sql-reference/operators/in.md
@@ -141,6 +141,8 @@ When using the regular `IN`, the query is sent to remote servers, and each of th
 
 When using `GLOBAL IN` / `GLOBAL JOIN`, first all the subqueries are run for `GLOBAL IN` / `GLOBAL JOIN`, and the results are collected in temporary tables. Then the temporary tables are sent to each remote server, where the queries are run using this temporary data.
 
+For `GLOBAL ... JOIN`, which side of the join is calculated as the subquery depends on the join kind: for `LEFT` and `INNER` joins, the right table is calculated; for `RIGHT` joins, the left table is calculated instead, since the right table is the preserved side and should be read from shards.
+
 For a non-distributed query, use the regular `IN` / `JOIN`.
 
 Be careful when using subqueries in the `IN` / `JOIN` clauses for distributed query processing.

--- a/docs/en/sql-reference/statements/select/join.md
+++ b/docs/en/sql-reference/statements/select/join.md
@@ -400,7 +400,7 @@ SETTINGS max_block_size = 2;
 There are two ways to execute a JOIN involving distributed tables:
 
 - When using a normal `JOIN`, the query is sent to remote servers. Subqueries are run on each of them in order to make the right table, and the join is performed with this table. In other words, the right table is formed on each server separately.
-- When using `GLOBAL ... JOIN`, first the requestor server runs a subquery to calculate the right table. This temporary table is passed to each remote server, and queries are run on them using the temporary data that was transmitted.
+- When using `GLOBAL ... JOIN`, first the requestor server runs a subquery to calculate one side of the join and collects the result into a temporary table. This temporary table is then passed to each remote server, and queries are run on them using the temporary data that was transmitted. For `LEFT` and `INNER` joins, the right table is calculated as the subquery. For `RIGHT` joins, the left table is calculated instead, since the right table is the one being preserved and should be read from shards.
 
 Be careful when using `GLOBAL`. For more information, see the [Distributed subqueries](/sql-reference/operators/in#distributed-subqueries) section.
 


### PR DESCRIPTION
Clarify that `GLOBAL ... JOIN` does not always calculate the right table as a subquery first. Since #71162, the behavior depends on the join kind:
- `LEFT`/`INNER` joins: the right table is calculated as the subquery
- `RIGHT` joins: the left table is calculated instead (since the right table is the preserved side and should be read from shards)

Updated both `docs/en/sql-reference/statements/select/join.md` and `docs/en/sql-reference/operators/in.md`.

Closes https://github.com/ClickHouse/ClickHouse/issues/88012

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.624`
<!-- ch-version-info:end -->