### PR TITLE
Docs: add missing `ReplicatedCoalescingMergeTree` to list

### DIFF
--- a/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
+++ b/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
@@ -1009,6 +1009,7 @@ ReferenceKeyed
 Refreshable
 RegexpTree
 RemoteRead
+ReplicatedCoalescingMergeTree
 ReplacingMergeTree
 ReplicasMaxAbsoluteDelay
 ReplicasMaxInsertsInQueue

--- a/docs/en/engines/table-engines/mergetree-family/replication.md
+++ b/docs/en/engines/table-engines/mergetree-family/replication.md
@@ -26,15 +26,16 @@ ENGINE = ReplicatedMergeTree
 ```
 :::
 
-Replication is only supported for tables in the MergeTree family:
+Replication is only supported for tables in the MergeTree family
 
-- ReplicatedMergeTree
 - ReplicatedSummingMergeTree
+- ReplicatedCoalescingMergeTree
+- ReplicatedVersionedCollapsingMergeTree
+- ReplicatedCollapsingMergeTree
+- ReplicatedGraphiteMergeTree
+- ReplicatedMergeTree
 - ReplicatedReplacingMergeTree
 - ReplicatedAggregatingMergeTree
-- ReplicatedCollapsingMergeTree
-- ReplicatedVersionedCollapsingMergeTree
-- ReplicatedGraphiteMergeTree
 
 Replication works at the level of an individual table, not the entire server. A server can store both replicated and non-replicated tables at the same time.
 


### PR DESCRIPTION
Community member flagged that `ReplicatedCoalescingMergeTree` is missing from the list.
Updated the list with all from `SELECT name FROM system.table_engines WHERE name LIKE 'Replicated%' `
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.649`
<!-- ch-version-info:end -->