### PR TITLE
Close TCP connection on query parse errors to prevent stream desynchronization

### DIFF
--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -978,9 +978,9 @@ void TCPHandler::runImpl()
                     std::lock_guard lock(*callback_mutex);
                     sendException(*exception, send_exception_with_stack_trace);
                 }
-                catch (...)
+                catch (...) // NOLINT(bugprone-empty-catch)
                 {
-                    /// Failed to send the exception, but we're closing anyway.
+                    /// Ok: failed to send the exception, but we're closing anyway.
                 }
                 query_state->cancelOut(out);
                 return;

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -965,6 +965,27 @@ void TCPHandler::runImpl()
                 return;
             }
 
+            /// If the exception happened during initial query parsing (before
+            /// `query_context` was created at the end of `processQuery`), the
+            /// input buffer is in an unknown state: the failing read may have
+            /// consumed only part of the packet, leaving trailing bytes that
+            /// will be misinterpreted as the next packet on this connection.
+            /// The only safe option is to close the connection.
+            if (!query_state->query_context)
+            {
+                try
+                {
+                    std::lock_guard lock(*callback_mutex);
+                    sendException(*exception, send_exception_with_stack_trace);
+                }
+                catch (...)
+                {
+                    /// Failed to send the exception, but we're closing anyway.
+                }
+                query_state->cancelOut(out);
+                return;
+            }
+
             if (thread_trace_context)
                 thread_trace_context->root_span.addAttribute(*exception);
 

--- a/tests/queries/0_stateless/04092_tcp_settings_parse_error_closes_connection.py
+++ b/tests/queries/0_stateless/04092_tcp_settings_parse_error_closes_connection.py
@@ -165,9 +165,11 @@ def test_connection_closed_after_bad_settings():
     """After a settings parse error, the server must close the connection
     rather than trying to preserve it for reuse.
 
-    We verify this both from the client side (socket must be closed) and
-    from the server side (system.text_log must not show additional errors
-    from reading a desynchronized buffer).
+    We verify this from both sides:
+    - Client side: after consuming the Exception packet, recv() must return
+      EOF or a connection error — not another valid server packet.
+    - Server side: system.text_log must not show additional TCPHandler errors
+      from reading a desynchronized buffer after the UNKNOWN_SETTING error.
     """
     setting_name = f"NONEXISTENT_{os.getpid()}_{random.randint(0, 2**31)}"
 
@@ -195,8 +197,18 @@ def test_connection_closed_after_bad_settings():
         code, message = read_exception(sock)
         assert setting_name in message, f"Unexpected error: {code}: {message}"
 
-    except Exception:
-        raise
+        # The server should close the connection after the parse error.
+        # Verify we get EOF — not another valid server packet.
+        sock.settimeout(5)
+        try:
+            data = sock.recv(1)
+            assert not data, (
+                f"Expected EOF after settings parse error, "
+                f"but got data (first byte={data[0]})"
+            )
+        except (ConnectionResetError, ConnectionError, OSError):
+            pass  # Also acceptable — server reset the connection.
+
     finally:
         sock.close()
 

--- a/tests/queries/0_stateless/04092_tcp_settings_parse_error_closes_connection.py
+++ b/tests/queries/0_stateless/04092_tcp_settings_parse_error_closes_connection.py
@@ -73,10 +73,12 @@ def recv_exact(sock, n):
 # (interserver secret) to keep the packet format simple.
 CLIENT_REVISION = 54440
 
+CLIENT_NAME = "ClickHouse test"
+
 def send_hello(sock):
     pkt = bytearray()
     pkt += write_varuint(0)  # Client Hello
-    pkt += write_string("ClickHouse test")
+    pkt += write_string(CLIENT_NAME)
     pkt += write_varuint(25)  # major
     pkt += write_varuint(1)   # minor
     pkt += write_varuint(CLIENT_REVISION)
@@ -112,8 +114,8 @@ def build_client_info():
     buf += write_string("[::ffff:127.0.0.1]:0")  # initial_address
     buf += struct.pack("B", 1)  # TCP interface
     buf += write_string("")     # os_user
-    buf += write_string("test") # client_hostname
-    buf += write_string("test") # client_name
+    buf += write_string("test")        # client_hostname
+    buf += write_string(CLIENT_NAME)  # client_name (must match Hello)
     buf += write_varuint(25)    # major
     buf += write_varuint(1)     # minor
     buf += write_varuint(CLIENT_REVISION)

--- a/tests/queries/0_stateless/04092_tcp_settings_parse_error_closes_connection.py
+++ b/tests/queries/0_stateless/04092_tcp_settings_parse_error_closes_connection.py
@@ -224,29 +224,31 @@ def test_connection_closed_after_bad_settings():
     # We use the unique setting name to find the exact thread, then count
     # Error-level TCPHandler messages between our error and the next
     # "Done processing connection" on that thread.
-    error_count = clickhouse_query(
-        f"WITH anchor AS ("
-        f"  SELECT thread_id, event_time_microseconds AS t"
-        f"  FROM system.text_log"
-        f"  WHERE event_date >= yesterday()"
-        f"  AND message LIKE '%{setting_name}%'"
-        f"  LIMIT 1"
-        f") "
-        f"SELECT count() FROM system.text_log, anchor "
-        f"WHERE event_date >= yesterday() "
-        f"AND system.text_log.thread_id = anchor.thread_id "
-        f"AND level = 'Error' "
-        f"AND logger_name = 'TCPHandler' "
-        f"AND event_time_microseconds > anchor.t "
-        f"AND event_time_microseconds <= ("
-        f"  SELECT min(event_time_microseconds)"
-        f"  FROM system.text_log, anchor"
-        f"  WHERE event_date >= yesterday()"
-        f"  AND system.text_log.thread_id = anchor.thread_id"
-        f"  AND message LIKE '%Done processing connection%'"
-        f"  AND event_time_microseconds > anchor.t"
-        f")"
-    )
+    recent = "event_date >= yesterday() AND event_time >= now() - INTERVAL 10 MINUTE"
+    error_count = clickhouse_query(f"""
+        WITH anchor AS (
+            SELECT thread_id, event_time_microseconds AS t
+            FROM system.text_log
+            WHERE {recent}
+            AND message LIKE '%{setting_name}%'
+            ORDER BY event_time_microseconds DESC
+            LIMIT 1
+        )
+        SELECT count() FROM system.text_log, anchor
+        WHERE {recent}
+        AND system.text_log.thread_id = anchor.thread_id
+        AND level = 'Error'
+        AND logger_name = 'TCPHandler'
+        AND event_time_microseconds > anchor.t
+        AND event_time_microseconds <= (
+            SELECT min(event_time_microseconds)
+            FROM system.text_log, anchor
+            WHERE {recent}
+            AND system.text_log.thread_id = anchor.thread_id
+            AND message LIKE '%Done processing connection%'
+            AND event_time_microseconds > anchor.t
+        )
+    """)
 
     if int(error_count) > 0:
         print(f"FAIL: {error_count} extra error(s) — server read from desync'd buffer")

--- a/tests/queries/0_stateless/04092_tcp_settings_parse_error_closes_connection.py
+++ b/tests/queries/0_stateless/04092_tcp_settings_parse_error_closes_connection.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Test that a settings parsing error during query processing closes the
+connection instead of leaving the TCP stream desynchronized.
+
+When `BaseSettings::read` encounters an unknown setting with the IMPORTANT
+flag, it throws without consuming the setting value from the buffer. This
+leaves the read buffer in an inconsistent state. If the server tried to
+reuse the connection, subsequent reads would misinterpret leftover bytes as
+new packets — the specific null-dereference path this caused was fixed in
+https://github.com/ClickHouse/ClickHouse/pull/94434, but the underlying
+buffer desynchronization remained.
+
+This fix makes `TCPHandler` detect that `query_context` was never created
+(the exception happened during initial parsing) and close the connection,
+which is the only safe option when the input buffer state is unknown.
+"""
+
+import os
+import socket
+import struct
+import sys
+import time
+
+CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "127.0.0.1")
+CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT_TCP", 9000))
+
+# -- Minimal native protocol helpers -----------------------------------------
+
+def write_varuint(value):
+    result = bytearray()
+    while value > 0x7F:
+        result.append(0x80 | (value & 0x7F))
+        value >>= 7
+    result.append(value & 0x7F)
+    return bytes(result)
+
+def write_string(s):
+    if isinstance(s, str):
+        s = s.encode()
+    return write_varuint(len(s)) + s
+
+def read_varuint(sock):
+    result, shift = 0, 0
+    while True:
+        b = sock.recv(1)
+        if not b:
+            raise ConnectionError("Connection closed")
+        result |= (b[0] & 0x7F) << shift
+        if not (b[0] & 0x80):
+            return result
+        shift += 7
+
+def read_string(sock):
+    n = read_varuint(sock)
+    data = b""
+    while len(data) < n:
+        chunk = sock.recv(n - len(data))
+        if not chunk:
+            raise ConnectionError
+        data += chunk
+    return data.decode("utf-8", errors="replace")
+
+def recv_exact(sock, n):
+    data = b""
+    while len(data) < n:
+        chunk = sock.recv(n - len(data))
+        if not chunk:
+            raise ConnectionError
+        data += chunk
+    return data
+
+# Protocol version: above 54429 (STRINGS_WITH_FLAGS) but below 54441
+# (interserver secret) to keep the packet format simple.
+CLIENT_REVISION = 54440
+
+def send_hello(sock):
+    pkt = bytearray()
+    pkt += write_varuint(0)  # Client Hello
+    pkt += write_string("ClickHouse test")
+    pkt += write_varuint(25)  # major
+    pkt += write_varuint(1)   # minor
+    pkt += write_varuint(CLIENT_REVISION)
+    pkt += write_string("")        # default database
+    pkt += write_string("default") # user
+    pkt += write_string("")        # password
+    sock.sendall(pkt)
+
+def recv_hello(sock):
+    pkt_type = read_varuint(sock)
+    if pkt_type == 2:  # Exception
+        code = struct.unpack("<I", recv_exact(sock, 4))[0]
+        name = read_string(sock)
+        message = read_string(sock)
+        raise Exception(f"Server exception {code}: {name}: {message}")
+    assert pkt_type == 0, f"Expected Hello, got {pkt_type}"
+    read_string(sock)    # server name
+    read_varuint(sock)   # major
+    read_varuint(sock)   # minor
+    read_varuint(sock)   # revision
+    if CLIENT_REVISION >= 54058:
+        read_string(sock)  # timezone
+    if CLIENT_REVISION >= 54372:
+        read_string(sock)  # display name
+    if CLIENT_REVISION >= 54401:
+        read_varuint(sock) # patch
+
+def build_client_info():
+    buf = bytearray()
+    buf += struct.pack("B", 1)  # INITIAL_QUERY
+    buf += write_string("")     # initial_user
+    buf += write_string("")     # initial_query_id
+    buf += write_string("[::ffff:127.0.0.1]:0")  # initial_address
+    buf += struct.pack("B", 1)  # TCP interface
+    buf += write_string("")     # os_user
+    buf += write_string("test") # client_hostname
+    buf += write_string("test") # client_name
+    buf += write_varuint(25)    # major
+    buf += write_varuint(1)     # minor
+    buf += write_varuint(CLIENT_REVISION)
+    buf += write_string("")     # quota_key
+    buf += write_varuint(0)     # version_patch
+    return bytes(buf)
+
+def build_settings_with_unknown_important():
+    """Build settings block with an unknown IMPORTANT setting.
+
+    The server will throw UNKNOWN_SETTING when reading this, without consuming
+    the value — leaving the rest of the settings block in the read buffer.
+    """
+    buf = bytearray()
+    # Unknown setting with IMPORTANT flag
+    buf += write_string("NONEXISTENT_IMPORTANT_SETTING")
+    buf += write_varuint(0x01)  # Flags: IMPORTANT
+    buf += write_string("1")   # Value (not consumed by the server!)
+    # A known setting after the unknown one (left unread in the buffer)
+    buf += write_string("max_threads")
+    buf += write_varuint(0x01)  # Flags: IMPORTANT
+    buf += write_string("4")
+    # End marker
+    buf += write_string("")
+    return bytes(buf)
+
+def build_normal_settings():
+    """Valid empty settings block."""
+    return write_string("")
+
+def send_query(sock, settings_block, query_text="SELECT 1"):
+    pkt = bytearray()
+    pkt += write_varuint(1)  # Client Query
+    pkt += write_string("test-query")
+    pkt += build_client_info()
+    pkt += settings_block
+    pkt += write_varuint(2)  # stage = Complete
+    pkt += write_varuint(0)  # compression = disabled
+    pkt += write_string(query_text)
+    sock.sendall(pkt)
+
+def send_empty_block(sock):
+    pkt = bytearray()
+    pkt += write_varuint(2)  # Client Data
+    pkt += write_string("")  # temp table name
+    pkt += write_varuint(0)  # block info end
+    pkt += write_varuint(0)  # columns
+    pkt += write_varuint(0)  # rows
+    sock.sendall(pkt)
+
+def get_response(sock, timeout=5.0):
+    """Read server response. Returns (is_exception, message)."""
+    sock.settimeout(timeout)
+    try:
+        pkt_type = read_varuint(sock)
+        if pkt_type == 2:  # Exception
+            code = struct.unpack("<I", recv_exact(sock, 4))[0]
+            name = read_string(sock)
+            message = read_string(sock)
+            return True, f"{code}:{message}"
+        return False, f"pkt_type={pkt_type}"
+    except (socket.timeout, ConnectionError) as e:
+        return True, f"connection_error:{e}"
+
+
+# -- Tests -------------------------------------------------------------------
+
+def test_connection_closed_after_bad_settings():
+    """After a settings parse error, the server must close the connection.
+
+    Before the fix, the server would try to reuse the connection, reading
+    from a desynchronized buffer and potentially crashing.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(10)
+    sock.connect((CLICKHOUSE_HOST, CLICKHOUSE_PORT))
+
+    try:
+        send_hello(sock)
+        recv_hello(sock)
+
+        # Send a query with an unknown IMPORTANT setting.
+        send_query(sock, build_settings_with_unknown_important())
+        send_empty_block(sock)
+
+        # Server should respond with an exception for the unknown setting.
+        is_err, msg = get_response(sock)
+        assert is_err, f"Expected exception, got: {msg}"
+        assert "NONEXISTENT_IMPORTANT_SETTING" in msg, f"Unexpected error: {msg}"
+
+        # Now try to send a second query on the same connection.
+        # The server should have closed the connection, so this should fail.
+        try:
+            send_query(sock, build_normal_settings(), "SELECT 2")
+            send_empty_block(sock)
+
+            # Try to read the response — should get connection closed/reset.
+            sock.settimeout(3)
+            is_err, msg = get_response(sock)
+            if not is_err:
+                # If we got a successful response, the connection was reused
+                # despite the desync — this is the bug.
+                print("FAIL: connection was reused after settings parse error")
+                sys.exit(1)
+
+            # An exception here is acceptable — the important thing is that
+            # the server didn't crash or send garbage.
+            if "connection_error" in msg:
+                print("connection closed after settings parse error")
+            else:
+                # Server sent an exception for the second query. This could
+                # happen if it tried to parse the desync'd buffer. As long as
+                # the server is still alive, we'll check that separately.
+                print("connection closed after settings parse error")
+
+        except (BrokenPipeError, ConnectionResetError, ConnectionError, OSError):
+            print("connection closed after settings parse error")
+
+    finally:
+        sock.close()
+
+
+def test_server_still_alive_after_bad_settings():
+    """Verify the server is still accepting new connections after the bad one."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(10)
+    sock.connect((CLICKHOUSE_HOST, CLICKHOUSE_PORT))
+
+    try:
+        send_hello(sock)
+        recv_hello(sock)
+        send_query(sock, build_normal_settings(), "SELECT 'ok'")
+        send_empty_block(sock)
+
+        is_err, msg = get_response(sock)
+        assert not is_err, f"Expected success, got error: {msg}"
+        print("server alive after bad settings connection")
+    finally:
+        sock.close()
+
+
+def main():
+    test_connection_closed_after_bad_settings()
+    test_server_still_alive_after_bad_settings()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/queries/0_stateless/04092_tcp_settings_parse_error_closes_connection.py
+++ b/tests/queries/0_stateless/04092_tcp_settings_parse_error_closes_connection.py
@@ -18,11 +18,12 @@ which is the only safe option when the input buffer state is unknown.
 import os
 import socket
 import struct
+import subprocess
 import sys
-import time
 
 CLICKHOUSE_HOST = os.environ.get("CLICKHOUSE_HOST", "127.0.0.1")
 CLICKHOUSE_PORT = int(os.environ.get("CLICKHOUSE_PORT_TCP", 9000))
+CLICKHOUSE_CLIENT = os.environ.get("CLICKHOUSE_CLIENT", "clickhouse-client")
 
 # -- Minimal native protocol helpers -----------------------------------------
 
@@ -69,101 +70,75 @@ def recv_exact(sock, n):
         data += chunk
     return data
 
-# Protocol version: above 54429 (STRINGS_WITH_FLAGS) but below 54441
-# (interserver secret) to keep the packet format simple.
 CLIENT_REVISION = 54440
-
 CLIENT_NAME = "ClickHouse test"
 
 def send_hello(sock):
     pkt = bytearray()
-    pkt += write_varuint(0)  # Client Hello
+    pkt += write_varuint(0)
     pkt += write_string(CLIENT_NAME)
-    pkt += write_varuint(25)  # major
-    pkt += write_varuint(1)   # minor
+    pkt += write_varuint(25)
+    pkt += write_varuint(1)
     pkt += write_varuint(CLIENT_REVISION)
-    pkt += write_string("")        # default database
-    pkt += write_string("default") # user
-    pkt += write_string("")        # password
+    pkt += write_string("")
+    pkt += write_string("default")
+    pkt += write_string("")
     sock.sendall(pkt)
 
 def recv_hello(sock):
     pkt_type = read_varuint(sock)
-    if pkt_type == 2:  # Exception
+    if pkt_type == 2:
         code = struct.unpack("<I", recv_exact(sock, 4))[0]
         name = read_string(sock)
         message = read_string(sock)
         raise Exception(f"Server exception {code}: {name}: {message}")
     assert pkt_type == 0, f"Expected Hello, got {pkt_type}"
-    read_string(sock)    # server name
-    read_varuint(sock)   # major
-    read_varuint(sock)   # minor
-    read_varuint(sock)   # revision
+    read_string(sock)
+    read_varuint(sock)
+    read_varuint(sock)
+    read_varuint(sock)
     if CLIENT_REVISION >= 54058:
-        read_string(sock)  # timezone
+        read_string(sock)
     if CLIENT_REVISION >= 54372:
-        read_string(sock)  # display name
+        read_string(sock)
     if CLIENT_REVISION >= 54401:
-        read_varuint(sock) # patch
+        read_varuint(sock)
 
 def build_client_info():
     buf = bytearray()
-    buf += struct.pack("B", 1)  # INITIAL_QUERY
-    buf += write_string("")     # initial_user
-    buf += write_string("")     # initial_query_id
-    buf += write_string("[::ffff:127.0.0.1]:0")  # initial_address
-    buf += struct.pack("B", 1)  # TCP interface
-    buf += write_string("")     # os_user
-    buf += write_string("test")        # client_hostname
-    buf += write_string(CLIENT_NAME)  # client_name (must match Hello)
-    buf += write_varuint(25)    # major
-    buf += write_varuint(1)     # minor
-    buf += write_varuint(CLIENT_REVISION)
-    buf += write_string("")     # quota_key
-    buf += write_varuint(0)     # version_patch
-    return bytes(buf)
-
-def build_settings_with_unknown_important():
-    """Build settings block with an unknown IMPORTANT setting.
-
-    The server will throw UNKNOWN_SETTING when reading this, without consuming
-    the value — leaving the rest of the settings block in the read buffer.
-    """
-    buf = bytearray()
-    # Unknown setting with IMPORTANT flag
-    buf += write_string("NONEXISTENT_IMPORTANT_SETTING")
-    buf += write_varuint(0x01)  # Flags: IMPORTANT
-    buf += write_string("1")   # Value (not consumed by the server!)
-    # A known setting after the unknown one (left unread in the buffer)
-    buf += write_string("max_threads")
-    buf += write_varuint(0x01)  # Flags: IMPORTANT
-    buf += write_string("4")
-    # End marker
+    buf += struct.pack("B", 1)
     buf += write_string("")
+    buf += write_string("")
+    buf += write_string("[::ffff:127.0.0.1]:0")
+    buf += struct.pack("B", 1)
+    buf += write_string("")
+    buf += write_string("test")
+    buf += write_string(CLIENT_NAME)
+    buf += write_varuint(25)
+    buf += write_varuint(1)
+    buf += write_varuint(CLIENT_REVISION)
+    buf += write_string("")
+    buf += write_varuint(0)
     return bytes(buf)
-
-def build_normal_settings():
-    """Valid empty settings block."""
-    return write_string("")
 
 def send_query(sock, settings_block, query_text="SELECT 1"):
     pkt = bytearray()
-    pkt += write_varuint(1)  # Client Query
-    pkt += write_string("test-query")
+    pkt += write_varuint(1)
+    pkt += write_string("")
     pkt += build_client_info()
     pkt += settings_block
-    pkt += write_varuint(2)  # stage = Complete
-    pkt += write_varuint(0)  # compression = disabled
+    pkt += write_varuint(2)
+    pkt += write_varuint(0)
     pkt += write_string(query_text)
     sock.sendall(pkt)
 
 def send_empty_block(sock):
     pkt = bytearray()
-    pkt += write_varuint(2)  # Client Data
-    pkt += write_string("")  # temp table name
-    pkt += write_varuint(0)  # block info end
-    pkt += write_varuint(0)  # columns
-    pkt += write_varuint(0)  # rows
+    pkt += write_varuint(2)
+    pkt += write_string("")
+    pkt += write_varuint(0)
+    pkt += write_varuint(0)
+    pkt += write_varuint(0)
     sock.sendall(pkt)
 
 def read_exception(sock):
@@ -190,14 +165,25 @@ def get_response(sock, timeout=5.0):
         return True, f"connection_error:{e}"
 
 
+def clickhouse_query(query):
+    cmd = CLICKHOUSE_CLIENT.split() + ["--query", query]
+    return subprocess.run(cmd, capture_output=True, text=True, check=True).stdout.strip()
+
+
 # -- Tests -------------------------------------------------------------------
 
 def test_connection_closed_after_bad_settings():
-    """After a settings parse error, the server must close the connection.
+    """After a settings parse error, the server must close the connection
+    rather than trying to preserve it for reuse.
 
-    Before the fix, the server would try to reuse the connection, reading
-    from a desynchronized buffer and potentially crashing.
+    We verify this by checking `system.text_log` for the message
+    "The connection is preserved" — which `TCPHandler` logs when it decides
+    to keep a connection alive after an exception. With the fix, the
+    connection is closed before that point, so the message must not appear.
     """
+    # Use a unique setting name per run so we can find our exact error in text_log.
+    setting_name = f"NONEXISTENT_{os.getpid()}"
+
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.settimeout(10)
     sock.connect((CLICKHOUSE_HOST, CLICKHOUSE_PORT))
@@ -206,64 +192,57 @@ def test_connection_closed_after_bad_settings():
         send_hello(sock)
         recv_hello(sock)
 
-        # Send a query with an unknown IMPORTANT setting.
-        send_query(sock, build_settings_with_unknown_important())
+        # Build settings block with our unique unknown IMPORTANT setting.
+        settings = bytearray()
+        settings += write_string(setting_name)
+        settings += write_varuint(0x01)  # Flags: IMPORTANT
+        settings += write_string("1")
+        settings += write_string("")     # End marker
+
+        send_query(sock, bytes(settings))
         send_empty_block(sock)
 
         # Server should respond with an exception for the unknown setting.
         is_err, msg = get_response(sock)
         assert is_err, f"Expected exception, got: {msg}"
-        assert "NONEXISTENT_IMPORTANT_SETTING" in msg, f"Unexpected error: {msg}"
-
-        # Now try to send a second query on the same connection.
-        # The server should have closed the connection, so this should fail.
-        try:
-            send_query(sock, build_normal_settings(), "SELECT 2")
-            send_empty_block(sock)
-
-            # Try to read the response — should get connection closed/reset.
-            sock.settimeout(3)
-            is_err, msg = get_response(sock)
-            if not is_err:
-                # If we got a successful response, the connection was reused
-                # despite the desync — this is the bug.
-                print("FAIL: connection was reused after settings parse error")
-                sys.exit(1)
-
-            # An exception here is acceptable — the important thing is that
-            # the server didn't crash or send garbage.
-            if "connection_error" in msg:
-                print("connection closed after settings parse error")
-            else:
-                # Server sent an exception for the second query. This could
-                # happen if it tried to parse the desync'd buffer. As long as
-                # the server is still alive, we'll check that separately.
-                print("connection closed after settings parse error")
-
-        except (BrokenPipeError, ConnectionResetError, ConnectionError, OSError):
-            print("connection closed after settings parse error")
-
+        assert setting_name in msg, f"Unexpected error: {msg}"
     finally:
         sock.close()
+
+    clickhouse_query("SYSTEM FLUSH LOGS")
+
+    # On the unfixed server, after the UNKNOWN_SETTING error the server
+    # attempts to continue reading from the desync'd buffer (skipData, next
+    # loop iteration), producing additional errors like CANNOT_READ_ALL_DATA
+    # or UNEXPECTED_PACKET_FROM_CLIENT on the same thread.
+    # With the fix, the connection is closed immediately — only the single
+    # UNKNOWN_SETTING error appears.
+    error_count = clickhouse_query(
+        f"SELECT count() FROM system.text_log "
+        f"WHERE thread_id IN ("
+        f"  SELECT thread_id FROM system.text_log"
+        f"  WHERE message LIKE '%{setting_name}%'"
+        f") "
+        f"AND level = 'Error' "
+        f"AND logger_name = 'TCPHandler' "
+        f"AND event_time_microseconds >= ("
+        f"  SELECT min(event_time_microseconds) FROM system.text_log"
+        f"  WHERE message LIKE '%{setting_name}%'"
+        f")"
+    )
+
+    if int(error_count) > 1:
+        print(f"FAIL: {error_count} errors logged — server tried to read from desync'd buffer")
+        sys.exit(1)
+
+    print("connection closed after settings parse error")
 
 
 def test_server_still_alive_after_bad_settings():
     """Verify the server is still accepting new connections after the bad one."""
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.settimeout(10)
-    sock.connect((CLICKHOUSE_HOST, CLICKHOUSE_PORT))
-
-    try:
-        send_hello(sock)
-        recv_hello(sock)
-        send_query(sock, build_normal_settings(), "SELECT 'ok'")
-        send_empty_block(sock)
-
-        is_err, msg = get_response(sock)
-        assert not is_err, f"Expected success, got error: {msg}"
-        print("server alive after bad settings connection")
-    finally:
-        sock.close()
+    result = clickhouse_query("SELECT 'ok'")
+    assert result == "ok", f"Expected 'ok', got: {result}"
+    print("server alive after bad settings connection")
 
 
 def main():

--- a/tests/queries/0_stateless/04092_tcp_settings_parse_error_closes_connection.py
+++ b/tests/queries/0_stateless/04092_tcp_settings_parse_error_closes_connection.py
@@ -16,6 +16,7 @@ which is the only safe option when the input buffer state is unknown.
 """
 
 import os
+import random
 import socket
 import struct
 import subprocess
@@ -152,37 +153,23 @@ def read_exception(sock):
         read_exception(sock)
     return code, message
 
-def get_response(sock, timeout=5.0):
-    """Read server response. Returns (is_exception, message)."""
-    sock.settimeout(timeout)
-    try:
-        pkt_type = read_varuint(sock)
-        if pkt_type == 2:  # Exception
-            code, message = read_exception(sock)
-            return True, f"{code}:{message}"
-        return False, f"pkt_type={pkt_type}"
-    except (socket.timeout, ConnectionError) as e:
-        return True, f"connection_error:{e}"
-
 
 def clickhouse_query(query):
     cmd = CLICKHOUSE_CLIENT.split() + ["--query", query]
     return subprocess.run(cmd, capture_output=True, text=True, check=True).stdout.strip()
 
 
-# -- Tests -------------------------------------------------------------------
+# -- Test --------------------------------------------------------------------
 
 def test_connection_closed_after_bad_settings():
     """After a settings parse error, the server must close the connection
     rather than trying to preserve it for reuse.
 
-    We verify this by checking `system.text_log` for the message
-    "The connection is preserved" — which `TCPHandler` logs when it decides
-    to keep a connection alive after an exception. With the fix, the
-    connection is closed before that point, so the message must not appear.
+    We verify this both from the client side (socket must be closed) and
+    from the server side (system.text_log must not show additional errors
+    from reading a desynchronized buffer).
     """
-    # Use a unique setting name per run so we can find our exact error in text_log.
-    setting_name = f"NONEXISTENT_{os.getpid()}"
+    setting_name = f"NONEXISTENT_{os.getpid()}_{random.randint(0, 2**31)}"
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.settimeout(10)
@@ -203,42 +190,60 @@ def test_connection_closed_after_bad_settings():
         send_empty_block(sock)
 
         # Server should respond with an exception for the unknown setting.
-        is_err, msg = get_response(sock)
-        assert is_err, f"Expected exception, got: {msg}"
-        assert setting_name in msg, f"Unexpected error: {msg}"
+        pkt_type = read_varuint(sock)
+        assert pkt_type == 2, f"Expected Exception packet (2), got {pkt_type}"
+        code, message = read_exception(sock)
+        assert setting_name in message, f"Unexpected error: {code}: {message}"
+
+    except Exception:
+        raise
     finally:
         sock.close()
 
-    clickhouse_query("SYSTEM FLUSH LOGS")
+    clickhouse_query("SYSTEM FLUSH LOGS text_log")
 
     # On the unfixed server, after the UNKNOWN_SETTING error the server
     # attempts to continue reading from the desync'd buffer (skipData, next
     # loop iteration), producing additional errors like CANNOT_READ_ALL_DATA
-    # or UNEXPECTED_PACKET_FROM_CLIENT on the same thread.
-    # With the fix, the connection is closed immediately — only the single
-    # UNKNOWN_SETTING error appears.
+    # or UNEXPECTED_PACKET_FROM_CLIENT before closing the connection.
+    # With the fix, the connection is closed immediately — no additional
+    # errors appear between UNKNOWN_SETTING and "Done processing connection".
+    #
+    # We use the unique setting name to find the exact thread, then count
+    # Error-level TCPHandler messages between our error and the next
+    # "Done processing connection" on that thread.
     error_count = clickhouse_query(
-        f"SELECT count() FROM system.text_log "
-        f"WHERE thread_id IN ("
-        f"  SELECT thread_id FROM system.text_log"
-        f"  WHERE message LIKE '%{setting_name}%'"
+        f"WITH anchor AS ("
+        f"  SELECT thread_id, event_time_microseconds AS t"
+        f"  FROM system.text_log"
+        f"  WHERE event_date >= yesterday()"
+        f"  AND message LIKE '%{setting_name}%'"
+        f"  LIMIT 1"
         f") "
+        f"SELECT count() FROM system.text_log, anchor "
+        f"WHERE event_date >= yesterday() "
+        f"AND system.text_log.thread_id = anchor.thread_id "
         f"AND level = 'Error' "
         f"AND logger_name = 'TCPHandler' "
-        f"AND event_time_microseconds >= ("
-        f"  SELECT min(event_time_microseconds) FROM system.text_log"
-        f"  WHERE message LIKE '%{setting_name}%'"
+        f"AND event_time_microseconds > anchor.t "
+        f"AND event_time_microseconds <= ("
+        f"  SELECT min(event_time_microseconds)"
+        f"  FROM system.text_log, anchor"
+        f"  WHERE event_date >= yesterday()"
+        f"  AND system.text_log.thread_id = anchor.thread_id"
+        f"  AND message LIKE '%Done processing connection%'"
+        f"  AND event_time_microseconds > anchor.t"
         f")"
     )
 
-    if int(error_count) > 1:
-        print(f"FAIL: {error_count} errors logged — server tried to read from desync'd buffer")
+    if int(error_count) > 0:
+        print(f"FAIL: {error_count} extra error(s) — server read from desync'd buffer")
         sys.exit(1)
 
     print("connection closed after settings parse error")
 
 
-def test_server_still_alive_after_bad_settings():
+def test_server_still_alive():
     """Verify the server is still accepting new connections after the bad one."""
     result = clickhouse_query("SELECT 'ok'")
     assert result == "ok", f"Expected 'ok', got: {result}"
@@ -247,7 +252,7 @@ def test_server_still_alive_after_bad_settings():
 
 def main():
     test_connection_closed_after_bad_settings()
-    test_server_still_alive_after_bad_settings()
+    test_server_still_alive()
 
 
 if __name__ == "__main__":

--- a/tests/queries/0_stateless/04092_tcp_settings_parse_error_closes_connection.py
+++ b/tests/queries/0_stateless/04092_tcp_settings_parse_error_closes_connection.py
@@ -166,15 +166,24 @@ def send_empty_block(sock):
     pkt += write_varuint(0)  # rows
     sock.sendall(pkt)
 
+def read_exception(sock):
+    """Fully consume an Exception packet (after packet type is already read)."""
+    code = struct.unpack("<I", recv_exact(sock, 4))[0]
+    name = read_string(sock)
+    message = read_string(sock)
+    _stack_trace = read_string(sock)
+    has_nested = recv_exact(sock, 1)[0]
+    if has_nested:
+        read_exception(sock)
+    return code, message
+
 def get_response(sock, timeout=5.0):
     """Read server response. Returns (is_exception, message)."""
     sock.settimeout(timeout)
     try:
         pkt_type = read_varuint(sock)
         if pkt_type == 2:  # Exception
-            code = struct.unpack("<I", recv_exact(sock, 4))[0]
-            name = read_string(sock)
-            message = read_string(sock)
+            code, message = read_exception(sock)
             return True, f"{code}:{message}"
         return False, f"pkt_type={pkt_type}"
     except (socket.timeout, ConnectionError) as e:

--- a/tests/queries/0_stateless/04092_tcp_settings_parse_error_closes_connection.reference
+++ b/tests/queries/0_stateless/04092_tcp_settings_parse_error_closes_connection.reference
@@ -1,0 +1,2 @@
+connection closed after settings parse error
+server alive after bad settings connection


### PR DESCRIPTION
When an exception occurs during initial query parsing in `processQuery` (e.g., `BaseSettings::read` throwing for an unknown IMPORTANT setting without consuming its value from the buffer), the input stream is left in an inconsistent state. The server previously tried to reuse the connection, misinterpreting leftover bytes as new packets.

The null-dereference that this originally caused was fixed in https://github.com/ClickHouse/ClickHouse/pull/94434, but the underlying buffer desynchronization remained — the server would still read garbage from the stream, producing spurious "Unknown packet" errors before eventually closing the connection.

This PR detects that `query_context` was never created (the exception happened before `processQuery` finished parsing) and closes the connection immediately after sending the exception to the client.

Closes https://github.com/ClickHouse/clickhouse-private/issues/43810

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Close TCP connection when an exception occurs during initial query parsing to prevent reading garbage from a desynchronized stream.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.716`
<!-- ch-version-info:end -->