### PR TITLE
Fix Parquet metadata cache key collision for files in tar archives on S3

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -697,14 +697,14 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
             && (object_info->getFileFormat().value_or(configuration->format) == "Parquet")
             && !object_info->getObjectMetadata()->etag.empty())
         {
-            /// For files inside archives, relative_path_with_metadata has an empty path
-            /// (since ObjectInfoInArchive doesn't initialize the base ObjectInfo path).
+            /// For files inside archives, ObjectInfoInArchive doesn't initialize the
+            /// base ObjectInfo::relative_path_with_metadata path, leaving it empty.
             /// We must use object_info->getPath() which returns the correct unique path
             /// (e.g. "archive.tar::file.parquet"), otherwise all files in the same archive
             /// would share the same Parquet metadata cache key, causing wrong metadata
             /// to be used and silent data corruption.
             std::optional<RelativePathWithMetadata> object_with_metadata = object_info->relative_path_with_metadata;
-            if (object_with_metadata.has_value() && object_with_metadata->relative_path.empty())
+            if (object_info->isArchive())
                 object_with_metadata->relative_path = object_info->getPath();
             input_format = FormatFactory::instance().getInputWithMetadata(
                 object_info->getFileFormat().value_or(configuration->format),

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -697,7 +697,15 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
             && (object_info->getFileFormat().value_or(configuration->format) == "Parquet")
             && !object_info->getObjectMetadata()->etag.empty())
         {
-            const std::optional<RelativePathWithMetadata> object_with_metadata = object_info->relative_path_with_metadata;
+            /// For files inside archives, relative_path_with_metadata has an empty path
+            /// (since ObjectInfoInArchive doesn't initialize the base ObjectInfo path).
+            /// We must use object_info->getPath() which returns the correct unique path
+            /// (e.g. "archive.tar::file.parquet"), otherwise all files in the same archive
+            /// would share the same Parquet metadata cache key, causing wrong metadata
+            /// to be used and silent data corruption.
+            std::optional<RelativePathWithMetadata> object_with_metadata = object_info->relative_path_with_metadata;
+            if (object_with_metadata.has_value() && object_with_metadata->relative_path.empty())
+                object_with_metadata->relative_path = object_info->getPath();
             input_format = FormatFactory::instance().getInputWithMetadata(
                 object_info->getFileFormat().value_or(configuration->format),
                 *read_buf,

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -697,12 +697,6 @@ StorageObjectStorageSource::ReaderHolder StorageObjectStorageSource::createReade
             && (object_info->getFileFormat().value_or(configuration->format) == "Parquet")
             && !object_info->getObjectMetadata()->etag.empty())
         {
-            /// For files inside archives, ObjectInfoInArchive doesn't initialize the
-            /// base ObjectInfo::relative_path_with_metadata path, leaving it empty.
-            /// We must use object_info->getPath() which returns the correct unique path
-            /// (e.g. "archive.tar::file.parquet"), otherwise all files in the same archive
-            /// would share the same Parquet metadata cache key, causing wrong metadata
-            /// to be used and silent data corruption.
             std::optional<RelativePathWithMetadata> object_with_metadata = object_info->relative_path_with_metadata;
             if (object_info->isArchive())
                 object_with_metadata->relative_path = object_info->getPath();

--- a/tests/queries/0_stateless/04092_s3_tar_archive_union_schema.reference
+++ b/tests/queries/0_stateless/04092_s3_tar_archive_union_schema.reference
@@ -1,0 +1,6 @@
+1	1	\N
+2	2	\N
+3	3	\N
+4	4	hello
+5	5	world
+6	6	foo

--- a/tests/queries/0_stateless/04092_s3_tar_archive_union_schema.sh
+++ b/tests/queries/0_stateless/04092_s3_tar_archive_union_schema.sh
@@ -26,7 +26,7 @@ $CLICKHOUSE_CLIENT -q "
 
 $CLICKHOUSE_CLIENT -q "
     INSERT INTO FUNCTION s3(s3_conn, url='http://localhost:11111/${S3_PATH}/test_2.parquet', format=Parquet)
-    SELECT number + 4 AS timestamp, number + 4.0 AS a, ['hello', 'world', 'foo'][number + 1] AS b
+    SELECT number + 4 AS timestamp, number + 4.0 AS a, toNullable(['hello', 'world', 'foo'][number + 1]) AS b
     FROM numbers(3)
     SETTINGS s3_truncate_on_insert=1
 "

--- a/tests/queries/0_stateless/04092_s3_tar_archive_union_schema.sh
+++ b/tests/queries/0_stateless/04092_s3_tar_archive_union_schema.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# Tag no-fasttest: Depends on S3
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/101544
+# When reading a tar archive from S3 containing parquet files with different
+# schemas using schema_inference_mode=union, columns present only in some
+# files were silently returned as all-null due to Parquet metadata cache
+# key collision: all files in the same archive shared the same cache key.
+
+set -e
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+S3_PATH="test/${CLICKHOUSE_DATABASE}_04092"
+
+# Create two parquet files with different schemas on S3
+$CLICKHOUSE_CLIENT -q "
+    INSERT INTO FUNCTION s3(s3_conn, url='http://localhost:11111/${S3_PATH}/test_1.parquet', format=Parquet)
+    SELECT number + 1 AS timestamp, number + 1.0 AS a
+    FROM numbers(3)
+    SETTINGS s3_truncate_on_insert=1
+"
+
+$CLICKHOUSE_CLIENT -q "
+    INSERT INTO FUNCTION s3(s3_conn, url='http://localhost:11111/${S3_PATH}/test_2.parquet', format=Parquet)
+    SELECT number + 4 AS timestamp, number + 4.0 AS a, ['hello', 'world', 'foo'][number + 1] AS b
+    FROM numbers(3)
+    SETTINGS s3_truncate_on_insert=1
+"
+
+# Download the parquet files, create a tar archive, and upload it
+TMP_DIR=$(mktemp -d)
+trap "rm -rf $TMP_DIR" EXIT
+
+curl -s "http://localhost:11111/${S3_PATH}/test_1.parquet" -o "${TMP_DIR}/test_1.parquet"
+curl -s "http://localhost:11111/${S3_PATH}/test_2.parquet" -o "${TMP_DIR}/test_2.parquet"
+tar cf "${TMP_DIR}/test.parquet.tar" -C "${TMP_DIR}" test_1.parquet test_2.parquet
+curl -s -X PUT "http://localhost:11111/${S3_PATH}/test.parquet.tar" --upload-file "${TMP_DIR}/test.parquet.tar"
+
+# Query with union mode — column b should have real values from test_2.parquet
+$CLICKHOUSE_CLIENT -q "
+    SET schema_inference_mode = 'union';
+    SET schema_inference_use_cache_for_s3 = 0;
+    SELECT *
+    FROM s3(s3_conn, url='http://localhost:11111/${S3_PATH}/test.parquet.tar :: *.parquet')
+    ORDER BY timestamp
+"


### PR DESCRIPTION
Fix silent data loss when reading a tar archive from S3 containing multiple Parquet files with different schemas using `schema_inference_mode=union`.

`ObjectInfoInArchive` does not initialize the base `ObjectInfo::relative_path_with_metadata` path, leaving it empty. When the Parquet metadata cache constructs a cache key from this field, all files within the same archive get the same key (empty path + same etag). The first file's metadata is cached and then incorrectly reused for subsequent files, causing the reader to use the wrong schema and either silently fill columns with nulls or throw `TProtocolException` errors on `OffsetIndex` data.

The fix ensures that when `relative_path_with_metadata` has an empty path, we fall back to `object_info->getPath()` which returns the correct unique path (e.g. `archive.tar::file.parquet`) for archive entries.

Fixes https://github.com/ClickHouse/ClickHouse/issues/101544

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix silent data loss when reading tar archives from S3 with `schema_inference_mode=union` and heterogeneous Parquet schemas — the Parquet metadata cache incorrectly reused the first file's metadata for all subsequent files in the archive.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.209`
- Backported to: `26.4.1.1130`, `26.3.10.49`
<!-- ch-version-info:end -->