### PR TITLE
Fix SLRU race bug in fs cache 26.1+

### DIFF
--- a/src/Interpreters/Cache/IFileCachePriority.cpp
+++ b/src/Interpreters/Cache/IFileCachePriority.cpp
@@ -22,11 +22,13 @@ IFileCachePriority::Entry::Entry(
     const Key & key_,
     size_t offset_,
     size_t size_,
-    KeyMetadataPtr key_metadata_)
+    KeyMetadataPtr key_metadata_,
+    State initial_state)
     : key(key_)
     , offset(offset_)
     , key_metadata(key_metadata_)
     , size(size_)
+    , state(initial_state)
 {
 }
 

--- a/src/Interpreters/Cache/IFileCachePriority.h
+++ b/src/Interpreters/Cache/IFileCachePriority.h
@@ -30,9 +30,6 @@ public:
 
     struct Entry
     {
-        Entry(const Key & key_, size_t offset_, size_t size_, KeyMetadataPtr key_metadata_);
-        Entry(const Entry & other);
-
         const Key key;
         const size_t offset;
         const KeyMetadataPtr key_metadata;
@@ -45,6 +42,15 @@ public:
         enum class State
         {
             Active,
+            /// Temporary state used only in SLRU during queue transitions (downgrade from
+            /// protected to probationary, or upgrade from probationary to protected).
+            /// The new entry is added to the destination queue with this state and transitions
+            /// to Active atomically together with the SLRUIterator's inner pointer update in
+            /// `SLRUIterator::setIterator`. This ensures that `iterateImpl`, which checks entry
+            /// state before evicting, never sees the entry as evictable until the SLRUIterator
+            /// already points to it: a concurrent iteration that observes Active state will
+            /// always find this entry (not the previous queue entry) when it calls getEntry().
+            PreActive,
             /// Entry is collected for eviction via IFileCachePriority::collectEvictionCandidates
             /// and is being or soon will be removed from filesystem.
             Evicting,
@@ -57,13 +63,24 @@ public:
             Removed,
         };
 
-        /// Be aware that by default this method has relaxed guarantees.
-        /// See which locks are used in setter methods below if stronger guarantees are needed.
-        State getState() const { return state.load(std::memory_order_relaxed); }
+        Entry(const Key & key_, size_t offset_, size_t size_, KeyMetadataPtr key_metadata_, State initial_state = State::Active);
+        Entry(const Entry & other);
+
+        State getState() const { return state.load(); }
+
+        /// Transitions PreActive → Active. Must be called inside `SLRUIterator::entry_mutex`
+        /// together with the pointer update so that `getEntry()` and state visibility are atomic.
+        void setActiveFlag(const CacheStateGuard::Lock &)
+        {
+            [[maybe_unused]] auto prev = state.exchange(State::Active);
+            chassert(
+                prev == State::PreActive,
+                printUnexpectedState(prev, "PreActive", "Active"));
+        }
 
         void setEvictingFlag(const LockedKey &)
         {
-            [[maybe_unused]] auto prev = state.exchange(State::Evicting, std::memory_order_relaxed);
+            [[maybe_unused]] auto prev = state.exchange(State::Evicting);
             chassert(
                 prev == State::Active,
                 printUnexpectedState(prev, "Active", "Evicting"));
@@ -71,7 +88,7 @@ public:
 
         void setMovingFlag(const LockedKey &)
         {
-            [[maybe_unused]] auto prev = state.exchange(State::Moving, std::memory_order_relaxed);
+            [[maybe_unused]] auto prev = state.exchange(State::Moving);
             chassert(
                 prev == State::Active,
                 printUnexpectedState(prev, "Active", "Moving"));
@@ -79,7 +96,7 @@ public:
 
         void setRemoved(const CachePriorityGuard::WriteLock &)
         {
-            [[maybe_unused]] auto prev = state.exchange(State::Removed, std::memory_order_relaxed);
+            [[maybe_unused]] auto prev = state.exchange(State::Removed);
             chassert(
                 prev == State::Active || prev == State::Evicting || prev == State::Invalidated,
                 printUnexpectedState(prev, "Active or Evicting or Invalidated", "Removed"));
@@ -91,14 +108,15 @@ public:
             /// Active in case of FileCache::remove
             /// Evicting in case of FileCache::tryReserve
             /// Moving in case of SLRU queue moves
+            /// PreActive in case of exception during SLRU queue transition
             chassert(
-                prev == State::Active || prev == State::Evicting || prev == State::Moving,
-                printUnexpectedState(prev, "Active or Moving or Evicting", "Invalidated"));
+                prev == State::Active || prev == State::Evicting || prev == State::Moving || prev == State::PreActive,
+                printUnexpectedState(prev, "Active or Moving or Evicting or PreActive", "Invalidated"));
         }
 
         void resetFlag(State from_state, State to_state = State::Active)
         {
-            [[maybe_unused]] auto prev = state.exchange(to_state, std::memory_order_relaxed);
+            [[maybe_unused]] auto prev = state.exchange(to_state);
             chassert(
                 prev == from_state,
                 printUnexpectedState(prev, magic_enum::enum_name(from_state), fmt::format("{}", magic_enum::enum_name(to_state))));

--- a/src/Interpreters/Cache/LRUFileCachePriority.cpp
+++ b/src/Interpreters/Cache/LRUFileCachePriority.cpp
@@ -232,8 +232,18 @@ LRUFileCachePriority::iterateImpl(
             {
                 case Entry::State::Active:
                 {
-                    /// TODO: Inroduce a separate pre-Active state for zero size valid entries
+                    /// A newly added entry may have size 0 before the first
+                    /// space reservation completes. It is not yet evictable.
                     return entry.size > 0;
+                }
+                case Entry::State::PreActive:
+                {
+                    /// Entry is being moved between SLRU queues. Size may already be
+                    /// non-zero, but the entry is not evictable until `SLRUIterator::setIterator`
+                    /// transitions it to Active atomically with the iterator pointer update.
+                    /// For SLRU transitions `size > 0` alone is not a sufficient guard, because
+                    /// the SLRUIterator might still point to the old entry.
+                    return false;
                 }
                 case Entry::State::Invalidated:
                 {

--- a/src/Interpreters/Cache/SLRUFileCachePriority.cpp
+++ b/src/Interpreters/Cache/SLRUFileCachePriority.cpp
@@ -496,7 +496,8 @@ bool SLRUFileCachePriority::collectCandidatesForEvictionInProtected(
                 /// Once we have state lock, we will increment size for new entry
                 /// and reset size for the old entry,
                 /// thus size will be transferred from one entry to another.
-                auto empty_entry = std::make_shared<Entry>(entry->key, entry->offset, /* size */0, entry->key_metadata);
+                /// PreActive: iterateImpl skips this entry until setIterator atomically transitions it to Active.
+                auto empty_entry = std::make_shared<Entry>(entry->key, entry->offset, /* size */0, entry->key_metadata, Entry::State::PreActive);
                 auto new_iterator = probationary_queue.add(std::move(empty_entry), lk, /* state_lock */nullptr);
                 downgraded_entries->add(DowngradedEntryInfo{
                     .slru_iterator = iterator,
@@ -658,11 +659,13 @@ bool SLRUFileCachePriority::tryIncreasePriority(
         downgrade_candidates.afterEvictWrite(lock);
         removeEntries(invalidated_entries, lock);
 
+        /// PreActive: iterateImpl skips this entry until setIterator atomically transitions it to Active.
         auto empty_entry = std::make_shared<Entry>(
             prev_entry->key,
             prev_entry->offset,
             /* size */0,
-            prev_entry->key_metadata);
+            prev_entry->key_metadata,
+            Entry::State::PreActive);
 
         return protected_queue.add(
             std::move(empty_entry), lock, /* state_lock */nullptr);
@@ -808,7 +811,7 @@ SLRUFileCachePriority::EntryPtr SLRUFileCachePriority::SLRUIterator::getEntry() 
 void SLRUFileCachePriority::SLRUIterator::setIterator(
     LRUIterator && iterator_,
     bool is_protected_,
-    const CacheStateGuard::Lock &)
+    const CacheStateGuard::Lock & state_lock)
 {
     auto new_entry = iterator_.getEntry();
     chassert(new_entry->size > 0);
@@ -818,6 +821,14 @@ void SLRUFileCachePriority::SLRUIterator::setIterator(
 
     std::lock_guard lock(entry_mutex);
     entry = new_entry;
+    /// Atomically activate the new entry together with the pointer update.
+    /// `iterateImpl` reads entry state without holding `entry_mutex`, so it sees either:
+    ///   - PreActive  → skips the entry (not evictable yet), or
+    ///   - Active     → calls getEntry() under entry_mutex and is guaranteed to see new_entry.
+    /// This eliminates the race where iterateImpl finds new_entry as evictable but
+    /// getEntry() still returns the previous queue entry, causing setEvictingFlag
+    /// to be called on an entry that is not in Active state.
+    new_entry->setActiveFlag(state_lock);
 }
 
 void SLRUFileCachePriority::SLRUIterator::incrementSize(size_t size, const CacheStateGuard::Lock & lock)

--- a/tests/integration/test_filesystem_cache/test.py
+++ b/tests/integration/test_filesystem_cache/test.py
@@ -966,4 +966,69 @@ def test_finished_download_time(cluster):
     )
     assert len(elapsed_time) > 0
     assert int(elapsed_time) > 1
-    assert int(elapsed_time) < 5
+
+
+@pytest.mark.parametrize("cache_policy", ["lru", "slru"])
+def test_concurrent_eviction(cluster, cache_policy):
+    """Stress-test concurrent eviction in filesystem cache with multiple readers."""
+    import threading
+
+    node = cluster.instances["node"]
+    cache_name = f"bench_small_{cache_policy}_{uuid.uuid4().hex[:8]}"
+    table_name = f"bench_eviction_{uuid.uuid4().hex[:8]}"
+    try:
+        node.query(
+            f"""
+            DROP TABLE IF EXISTS {table_name} SYNC;
+            CREATE TABLE {table_name} (key UInt32, value String)
+            ENGINE = MergeTree() ORDER BY key
+            SETTINGS disk = disk(
+                type = cache,
+                name = '{cache_name}',
+                path = '{cache_name}/',
+                max_size = '1Mi',
+                max_file_segment_size = 32768,
+                boundary_alignment = 32768,
+                cache_policy = '{cache_policy}',
+                disk = 'hdd_blob'
+            );
+            INSERT INTO {table_name} SELECT number, randomString(100) FROM numbers(100000);
+            """
+        )
+
+        test_start = node.query("SELECT now()").strip()
+
+        stop_event = threading.Event()
+
+        def drop_cache_loop():
+            while not stop_event.is_set():
+                node.query(f"SYSTEM CLEAR FILESYSTEM CACHE '{cache_name}'")
+
+        drop_thread = threading.Thread(target=drop_cache_loop, daemon=True)
+        drop_thread.start()
+
+        try:
+            node.exec_in_container(
+                [
+                    "/usr/bin/clickhouse",
+                    "benchmark",
+                    "--iterations",
+                    "200",
+                    "--concurrency",
+                    "100",
+                    "--query",
+                    f"SELECT count() FROM {table_name} WHERE key < (randConstant() % 100000) OR key > (randConstant() % 100000) FORMAT Null",
+                ]
+            )
+        finally:
+            stop_event.set()
+            drop_thread.join()
+
+        errors = int(
+            node.query(
+                f"SELECT count() FROM system.errors WHERE name = 'LOGICAL_ERROR' AND last_error_time >= '{test_start}'"
+            ).strip()
+        )
+        assert errors == 0, f"LOGICAL_ERROR occurred on {node.name}"
+    finally:
+        node.query(f"DROP TABLE IF EXISTS {table_name} SYNC")

--- a/tests/integration/test_filesystem_cache/test.py
+++ b/tests/integration/test_filesystem_cache/test.py
@@ -971,13 +971,9 @@ def test_finished_download_time(cluster):
 
 @pytest.mark.parametrize("cache_policy", ["lru", "slru"])
 def test_concurrent_eviction(cluster, cache_policy):
-    """Stress-test concurrent eviction in filesystem cache with multiple readers.
+    """Stress-test concurrent eviction in filesystem cache with multiple readers."""
+    import threading
 
-    The dataset (~50 MB) is intentionally much larger than the cache (1 MB) so
-    that every benchmark iteration evicts entries and causes continuous
-    probationary ↔ protected queue transitions in SLRU.  This widens the race
-    window that the fix for the SLRU downgrade bug closes.
-    """
     node = cluster.instances["node"]
     cache_name = f"bench_small_{cache_policy}_{uuid.uuid4().hex[:8]}"
     table_name = f"bench_eviction_{uuid.uuid4().hex[:8]}"
@@ -997,27 +993,43 @@ def test_concurrent_eviction(cluster, cache_policy):
                 cache_policy = '{cache_policy}',
                 disk = 'hdd_blob'
             );
-            INSERT INTO {table_name} SELECT number, randomString(500) FROM numbers(100000);
+            INSERT INTO {table_name} SELECT number, randomString(100) FROM numbers(100000);
             """
         )
 
-        node.exec_in_container(
-            [
-                "/usr/bin/clickhouse",
-                "benchmark",
-                "--iterations",
-                "300",
-                "--concurrency",
-                "50",
-                "--query",
-                f"SELECT sum(key) FROM {table_name} FORMAT Null",
-            ]
-        )
+        test_start = node.query("SELECT now()").strip()
 
-        # chassert failures abort the server without updating system.errors,
-        # so check the server log directly.
-        assert not node.contains_in_log(
-            "LOGICAL_ERROR"
-        ), f"LOGICAL_ERROR occurred on {node.name}"
+        stop_event = threading.Event()
+
+        def drop_cache_loop():
+            while not stop_event.is_set():
+                node.query(f"SYSTEM CLEAR FILESYSTEM CACHE '{cache_name}'")
+
+        drop_thread = threading.Thread(target=drop_cache_loop, daemon=True)
+        drop_thread.start()
+
+        try:
+            node.exec_in_container(
+                [
+                    "/usr/bin/clickhouse",
+                    "benchmark",
+                    "--iterations",
+                    "200",
+                    "--concurrency",
+                    "100",
+                    "--query",
+                    f"SELECT count() FROM {table_name} WHERE key < (randConstant() % 100000) OR key > (randConstant() % 100000) FORMAT Null",
+                ]
+            )
+        finally:
+            stop_event.set()
+            drop_thread.join()
+
+        errors = int(
+            node.query(
+                f"SELECT count() FROM system.errors WHERE name = 'LOGICAL_ERROR' AND last_error_time >= '{test_start}'"
+            ).strip()
+        )
+        assert errors == 0, f"LOGICAL_ERROR occurred on {node.name}"
     finally:
         node.query(f"DROP TABLE IF EXISTS {table_name} SYNC")

--- a/tests/integration/test_filesystem_cache/test.py
+++ b/tests/integration/test_filesystem_cache/test.py
@@ -970,9 +970,13 @@ def test_finished_download_time(cluster):
 
 @pytest.mark.parametrize("cache_policy", ["lru", "slru"])
 def test_concurrent_eviction(cluster, cache_policy):
-    """Stress-test concurrent eviction in filesystem cache with multiple readers."""
-    import threading
+    """Stress-test concurrent eviction in filesystem cache with multiple readers.
 
+    The dataset (~50 MB) is intentionally much larger than the cache (1 MB) so
+    that every benchmark iteration evicts entries and causes continuous
+    probationary ↔ protected queue transitions in SLRU.  This widens the race
+    window that the fix for the SLRU downgrade bug closes.
+    """
     node = cluster.instances["node"]
     cache_name = f"bench_small_{cache_policy}_{uuid.uuid4().hex[:8]}"
     table_name = f"bench_eviction_{uuid.uuid4().hex[:8]}"
@@ -992,43 +996,27 @@ def test_concurrent_eviction(cluster, cache_policy):
                 cache_policy = '{cache_policy}',
                 disk = 'hdd_blob'
             );
-            INSERT INTO {table_name} SELECT number, randomString(100) FROM numbers(100000);
+            INSERT INTO {table_name} SELECT number, randomString(500) FROM numbers(100000);
             """
         )
 
-        test_start = node.query("SELECT now()").strip()
-
-        stop_event = threading.Event()
-
-        def drop_cache_loop():
-            while not stop_event.is_set():
-                node.query(f"SYSTEM CLEAR FILESYSTEM CACHE '{cache_name}'")
-
-        drop_thread = threading.Thread(target=drop_cache_loop, daemon=True)
-        drop_thread.start()
-
-        try:
-            node.exec_in_container(
-                [
-                    "/usr/bin/clickhouse",
-                    "benchmark",
-                    "--iterations",
-                    "200",
-                    "--concurrency",
-                    "100",
-                    "--query",
-                    f"SELECT count() FROM {table_name} WHERE key < (randConstant() % 100000) OR key > (randConstant() % 100000) FORMAT Null",
-                ]
-            )
-        finally:
-            stop_event.set()
-            drop_thread.join()
-
-        errors = int(
-            node.query(
-                f"SELECT count() FROM system.errors WHERE name = 'LOGICAL_ERROR' AND last_error_time >= '{test_start}'"
-            ).strip()
+        node.exec_in_container(
+            [
+                "/usr/bin/clickhouse",
+                "benchmark",
+                "--iterations",
+                "300",
+                "--concurrency",
+                "50",
+                "--query",
+                f"SELECT sum(key) FROM {table_name} FORMAT Null",
+            ]
         )
-        assert errors == 0, f"LOGICAL_ERROR occurred on {node.name}"
+
+        # chassert failures abort the server without updating system.errors,
+        # so check the server log directly.
+        assert not node.contains_in_log(
+            "LOGICAL_ERROR"
+        ), f"LOGICAL_ERROR occurred on {node.name}"
     finally:
         node.query(f"DROP TABLE IF EXISTS {table_name} SYNC")

--- a/tests/integration/test_filesystem_cache/test.py
+++ b/tests/integration/test_filesystem_cache/test.py
@@ -966,6 +966,7 @@ def test_finished_download_time(cluster):
     )
     assert len(elapsed_time) > 0
     assert int(elapsed_time) > 1
+    assert int(elapsed_time) < 5
 
 
 @pytest.mark.parametrize("cache_policy", ["lru", "slru"])


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix SLRU race bug in filesystem cache 26.1+, which can lead to space reservation logical error. In debug build it can also lead to failed assert: `'Previous state is Evicting, but expected state to be Active while setting Evicting flag for 2c1e3484ecdc6b78a8978fa5b17c5097:0:339 (state: Evicting)'.`

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.722`
- Backported to: `26.3.6.4`, `26.2.10.7`, `26.1.10.8`
<!-- ch-version-info:end -->