### PR TITLE
Mark `00534_functions_bad_arguments` tests as `long` and `no-flaky-check`

### DIFF
--- a/tests/queries/0_stateless/00534_functions_bad_arguments1.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments1.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-debug, no-msan
+# Tags: long, no-tsan, no-debug, no-msan, no-flaky-check
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016

--- a/tests/queries/0_stateless/00534_functions_bad_arguments10.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments10.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-debug, no-msan
+# Tags: long, no-tsan, no-debug, no-msan, no-flaky-check
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016

--- a/tests/queries/0_stateless/00534_functions_bad_arguments11.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments11.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-debug, no-msan
+# Tags: long, no-tsan, no-debug, no-msan, no-flaky-check
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016

--- a/tests/queries/0_stateless/00534_functions_bad_arguments12.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments12.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-debug, no-msan
+# Tags: long, no-tsan, no-debug, no-msan, no-flaky-check
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016

--- a/tests/queries/0_stateless/00534_functions_bad_arguments13.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments13.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-debug, no-msan
+# Tags: long, no-tsan, no-debug, no-msan, no-flaky-check
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016

--- a/tests/queries/0_stateless/00534_functions_bad_arguments2.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments2.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-debug, no-msan
+# Tags: long, no-tsan, no-debug, no-msan, no-flaky-check
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016

--- a/tests/queries/0_stateless/00534_functions_bad_arguments3.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments3.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-debug, no-msan
+# Tags: long, no-tsan, no-debug, no-msan, no-flaky-check
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016

--- a/tests/queries/0_stateless/00534_functions_bad_arguments4_long.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments4_long.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-tsan, no-debug, no-msan
+# Tags: long, no-tsan, no-debug, no-msan, no-flaky-check
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016

--- a/tests/queries/0_stateless/00534_functions_bad_arguments5.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments5.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-debug, no-fasttest, no-msan
+# Tags: long, no-tsan, no-debug, no-fasttest, no-msan, no-flaky-check
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016

--- a/tests/queries/0_stateless/00534_functions_bad_arguments6.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments6.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-debug, no-msan
+# Tags: long, no-tsan, no-debug, no-msan, no-flaky-check
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016

--- a/tests/queries/0_stateless/00534_functions_bad_arguments7.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments7.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-debug, no-fasttest, no-msan
+# Tags: long, no-tsan, no-debug, no-fasttest, no-msan, no-flaky-check
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016

--- a/tests/queries/0_stateless/00534_functions_bad_arguments8.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments8.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-debug, no-msan
+# Tags: long, no-tsan, no-debug, no-msan, no-flaky-check
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016

--- a/tests/queries/0_stateless/00534_functions_bad_arguments9.sh
+++ b/tests/queries/0_stateless/00534_functions_bad_arguments9.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-debug, no-msan
+# Tags: long, no-tsan, no-debug, no-msan, no-flaky-check
 # Tag no-tsan: Too long for TSan
 
 # shellcheck disable=SC2016


### PR DESCRIPTION
These tests enumerate all functions with bad arguments and are too slow
to run repeatedly in the combined flaky check (which now runs coverage-selected
tests with up to 50-100 repeats since the old targeted check was merged into it
in 9ac4dcf71eb).

Seen timing out in https://github.com/ClickHouse/ClickHouse/pull/101928

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.621`
<!-- ch-version-info:end -->