### PR TITLE
Fix UBSan: float-to-Int64 overflow in NumericIndexedVector

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionGroupNumericIndexedVectorDataBSI.h
+++ b/src/AggregateFunctions/AggregateFunctionGroupNumericIndexedVectorDataBSI.h
@@ -298,8 +298,31 @@ public:
           * - When value is a Float32/Float64, fraction_bit_num indicates how many bits are used to represent the decimal, Because the
           *   maximum value of total_bit_num(integer_bit_num + fraction_bit_num) is 64, overflow may occur.
           */
-        using ScaledValueType = std::conditional_t<std::is_floating_point_v<ValueType>, ValueType, UInt64>;
-        Int64 scaled_value = Int64(value * static_cast<ScaledValueType>(1ULL << fraction_bit_num));
+        Int64 scaled_value = 0;
+        UInt64 scaling = 1ULL << fraction_bit_num;
+
+        if constexpr (std::is_same_v<ValueType, UInt64>)
+        {
+            if (value > static_cast<UInt64>(std::numeric_limits<Int64>::max()))
+                throw Exception(ErrorCodes::INCORRECT_DATA, "Value {} does not fit in Int64. It should, even when using UInt64.", value);
+            scaled_value = static_cast<Int64>(value);
+        }
+        else if constexpr (std::is_same_v<ValueType, Float32> || std::is_same_v<ValueType, Float64>)
+        {
+            constexpr Float64 lim = static_cast<Float64>(std::numeric_limits<Int64>::max());
+            if (fabs(value) > lim / static_cast<Float64>(scaling))
+                throw Exception(
+                    ErrorCodes::INCORRECT_DATA,
+                    "Value {} is out of range for BSI with integer_bit_num={} and fraction_bit_num={}",
+                    Float64(value),
+                    integer_bit_num,
+                    fraction_bit_num);
+            scaled_value = static_cast<Int64>(value * static_cast<ValueType>(scaling));
+        }
+        else
+        {
+            scaled_value = static_cast<Int64>(value);
+        }
         for (size_t i = 0; i < total_bit_num; ++i)
         {
             if (scaled_value & (1ULL << i))

--- a/tests/queries/0_stateless/04092_numeric_indexed_vector_overflow.sql
+++ b/tests/queries/0_stateless/04092_numeric_indexed_vector_overflow.sql
@@ -1,0 +1,22 @@
+-- Regression test for UBSan: float-to-Int64 overflow in initializeFromVectorAndValue
+-- https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100881&sha=341df970a65dbe1925c658ad88c44e9fe1a3f005&name_0=PR&name_1=AST%20fuzzer%20%28arm_asan_ubsan%29
+
+DROP TABLE IF EXISTS uin_value_details;
+
+CREATE TABLE uin_value_details (uin UInt8, value Float64) ENGINE = MergeTree() ORDER BY uin;
+
+INSERT INTO uin_value_details (uin, value) VALUES (1, 7.3), (2, 8.3);
+
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_details) AS vec
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseAdd(vec, 1e26)); -- { serverError INCORRECT_DATA }
+
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_details) AS vec
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseAdd(vec, -1e26)); -- { serverError INCORRECT_DATA }
+
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_details) AS vec
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseSubtract(vec, 1e26)); -- { serverError INCORRECT_DATA }
+
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_details) AS vec
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseMultiply(vec, 1e26)); -- { serverError INCORRECT_DATA }
+
+DROP TABLE uin_value_details;

--- a/tests/queries/0_stateless/04092_numeric_indexed_vector_overflow.sql
+++ b/tests/queries/0_stateless/04092_numeric_indexed_vector_overflow.sql
@@ -1,3 +1,5 @@
+-- Tags: no-fasttest
+
 -- Regression test for UBSan: float-to-Int64 overflow in initializeFromVectorAndValue
 -- https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100881&sha=341df970a65dbe1925c658ad88c44e9fe1a3f005&name_0=PR&name_1=AST%20fuzzer%20%28arm_asan_ubsan%29
 


### PR DESCRIPTION
`initializeFromVectorAndValue` was missing overflow checks when converting a scaled floating-point value to `Int64`. When the AST fuzzer produced a query like `numericIndexedVectorPointwiseAdd(vec, 1e26)`, the value `1.54743e+26` overflowed `Int64`, triggering undefined behavior detected by UBSan.

The `addValue` method in the same file already had the proper range check. This PR applies the same pattern to `initializeFromVectorAndValue`.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100881&sha=341df970a65dbe1925c658ad88c44e9fe1a3f005&name_0=PR&name_1=AST%20fuzzer%20%28arm_asan_ubsan%29
https://github.com/ClickHouse/ClickHouse/pull/100881

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix undefined behavior (float-to-integer overflow) in `NumericIndexedVector` pointwise operations when the scalar value is too large.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)