### PR TITLE
Do not ignore DROP for refreshable materialized views in stress tests

### DIFF
--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -199,7 +199,15 @@ BlockIO InterpreterDropQuery::executeToTableImpl(const ContextPtr & context_, AS
                 table_id.getNameForLogs());
 
         bool secondary_query = getContext()->getClientInfo().query_kind == ClientInfo::QueryKind::SECONDARY_QUERY;
-        if (!secondary_query && settings[Setting::ignore_drop_queries_probability] != 0 && ast_drop_query.kind == ASTDropQuery::Kind::Drop
+
+        /// Don't ignore DROP for refreshable materialized views: TRUNCATE doesn't stop
+        /// the periodic refresh task, so the orphaned view would keep refreshing indefinitely,
+        /// consuming background pool threads and potentially overwhelming the server.
+        auto * materialized_view = dynamic_cast<StorageMaterializedView *>(table.get());
+        bool is_refreshable_view = materialized_view && materialized_view->isRefreshable();
+
+        if (!secondary_query && !is_refreshable_view
+            && settings[Setting::ignore_drop_queries_probability] != 0 && ast_drop_query.kind == ASTDropQuery::Kind::Drop
             && std::uniform_real_distribution<>(0.0, 1.0)(thread_local_rng) <= settings[Setting::ignore_drop_queries_probability])
         {
             ast_drop_query.sync = false;


### PR DESCRIPTION
The `ignore_drop_queries_probability` setting (used in stress tests) converts `DROP TABLE` to `TRUNCATE TABLE`, but `TRUNCATE` does not stop the periodic refresh task of a refreshable materialized view. This causes the orphaned view to keep refreshing indefinitely, consuming background pool threads and progressively overwhelming the server — especially under TSan where each operation is 5–15x slower.

**Root cause analysis** of the "Hung check failed, possible deadlock found" flake in `Stress test (arm_tsan)`:

1. Test `03221_refreshable_matview_progress.sql` creates an MV with `REFRESH AFTER 10 SECOND`
2. The stress test's `ignore_drop_queries_probability=0.2` converts the final `DROP TABLE` to `TRUNCATE TABLE`
3. The view survives and keeps refreshing every 10 seconds for the rest of the stress test
4. 48 refreshes observed, each getting progressively slower under TSan (from sub-second to 59 minutes)
5. The server becomes completely unresponsive, failing the hung check

Fix: skip the DROP-to-TRUNCATE conversion for refreshable materialized views, since `TRUNCATE` doesn't stop their periodic refresh task.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99997&sha=355f90c5ba8982dc501d353f211c43350cfbc20e&name_0=PR&name_1=Stress%20test%20%28arm_tsan%29
https://github.com/ClickHouse/ClickHouse/pull/99997

Relates to #101383

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.676`
<!-- ch-version-info:end -->