### PR TITLE
Check for query cancellation during vector similarity index building

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.cpp
@@ -6,6 +6,7 @@
 #include <Columns/ColumnArray.h>
 #include <Columns/ColumnsNumber.h>
 #include <Common/BitHelpers.h>
+#include <Common/CurrentThread.h>
 #include <Common/setThreadName.h>
 #include <Common/formatReadable.h>
 #include <Common/getNumberOfCPUCoresToUse.h>
@@ -20,6 +21,7 @@
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/ProcessList.h>
 #include <Interpreters/castColumn.h>
 
 #include <ranges>
@@ -329,6 +331,14 @@ void updateImpl(const ColumnArray * column_array, const ColumnArray::Offsets & c
     /// the runner is destroyed first (waits for all tasks) and the lambda is destroyed second.
     auto add_vector_to_index = [&](USearchIndex::vector_key_t key, size_t row)
     {
+        /// Periodically check if the query has been cancelled. USearch internally does not check for cancellation,
+        /// and a single `add` call can take a very long time under sanitizers. Without this check, KILL QUERY
+        /// cannot stop the index building.
+        if (row % 128 == 0)
+            if (auto query_context = CurrentThread::tryGetQueryContext())
+                if (auto query_status = query_context->getProcessListElementSafe())
+                    query_status->throwIfKilled();
+
         const typename Column::ValueType & value = column_array_data_float_data[column_array_offsets[row - 1]];
         unum::usearch::index_dense_t::add_result_t result;
 

--- a/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.cpp
@@ -331,13 +331,12 @@ void updateImpl(const ColumnArray * column_array, const ColumnArray::Offsets & c
     /// the runner is destroyed first (waits for all tasks) and the lambda is destroyed second.
     auto add_vector_to_index = [&](USearchIndex::vector_key_t key, size_t row)
     {
-        /// Periodically check if the query has been cancelled. USearch internally does not check for cancellation,
+        /// Check if the query has been cancelled. USearch internally does not check for cancellation,
         /// and a single `add` call can take a very long time under sanitizers. Without this check, KILL QUERY
-        /// cannot stop the index building.
-        if (row % 128 == 0)
-            if (auto query_context = CurrentThread::tryGetQueryContext())
-                if (auto query_status = query_context->getProcessListElementSafe())
-                    query_status->throwIfKilled();
+        /// cannot stop the index building. The check is cheap (reads an atomic flag).
+        if (auto query_context = CurrentThread::tryGetQueryContext())
+            if (auto query_status = query_context->getProcessListElementSafe())
+                query_status->throwIfKilled();
 
         const typename Column::ValueType & value = column_array_data_float_data[column_array_offsets[row - 1]];
         unum::usearch::index_dense_t::add_result_t result;


### PR DESCRIPTION
The stress test (arm_tsan) hits a hung check failure because USearch's HNSW graph construction does not respect query cancellation. When `KILL QUERY` is issued, threads stuck inside USearch `add` keep running indefinitely, especially under TSan where each operation is very slow.

Add a cancellation check before calling USearch `add`. This lets `KILL QUERY` interrupt index building.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=102000&sha=9190a5549402d12fff136f61209c5405f2aa896c&name_0=PR&name_1=Stress%20test%20%28arm_tsan%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.742`
<!-- ch-version-info:end -->