### PR TITLE
Fix flaky test_keeper_reconfig_remove_many

### DIFF
--- a/tests/integration/test_keeper_reconfig_remove_many/test.py
+++ b/tests/integration/test_keeper_reconfig_remove_many/test.py
@@ -119,6 +119,11 @@ def test_reconfig_remove_2_and_leader(started_cluster):
 
     ku.wait_configs_equal(config, zk1)
 
+    zk2.stop()
+    zk2 = create_client(node2)
+    zk2.sync("/test_two_0")
+    ku.wait_configs_equal(config, zk2)
+
     for i in range(200):
         assert zk1.exists(f"test_two_{i}")
         assert zk2.exists(f"test_two_{i}")


### PR DESCRIPTION
After removing nodes 4 and 5 via `reconfig`, the `zk2` client (connected to node2) may lose its session during the cluster reconfiguration. Under TSan the window is wide enough for the keeper to reject the handshake on reconnect with "Possibly it's overloaded, doesn't see leader or stale".

Recreate `zk2` with a fresh connection and sync+wait for config propagation before verifying data, matching what was already done for `zk1`.

Found by https://github.com/ClickHouse/clickhouse-private/pull/54238

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.634`
<!-- ch-version-info:end -->