### PR TITLE
Fix stress test post-restart timeout for sanitizer builds

### DIFF
--- a/tests/docker_scripts/stress_runner.sh
+++ b/tests/docker_scripts/stress_runner.sh
@@ -265,7 +265,7 @@ if [ "$cache_policy" = "SLRU" ]; then
 fi
 
 # Randomize async_load_databases
-if [ $(( $(date +%-d) % 2 )) -eq 0 ]; then
+if [ $((RANDOM % 2)) -eq 0 ]; then
     sudo echo "<clickhouse><async_load_databases>false</async_load_databases></clickhouse>" \
         > /etc/clickhouse-server/config.d/enable_async_load_databases.xml
 fi

--- a/tests/docker_scripts/stress_runner.sh
+++ b/tests/docker_scripts/stress_runner.sh
@@ -294,7 +294,9 @@ unset "${!THREAD_@}"
 # running with fault injection.
 rm /etc/clickhouse-server/config.d/cannot_allocate_thread_injection.xml
 
-start_server || { echo "Failed to start server"; exit 1; }
+# Use a larger timeout for the post-stress restart: under sanitizers with
+# async_load_databases=false the server may need minutes to load all tables.
+start_server 30 || { echo "Failed to start server"; exit 1; }
 
 check_server_start
 


### PR DESCRIPTION
Fix spurious "Cannot start clickhouse-server" failure in stress tests under TSan.

After the stress test, the server is restarted to verify data integrity. On some runs, `async_load_databases` is set to `false`, requiring synchronous table loading. Under TSan, loading all tables created during the stress test takes longer than the default 140-second timeout (6 attempts × 20s), causing a false failure.

Changes:
- Increase `start_server` timeout from 6 to 30 attempts (~10 min) for the post-stress restart
- Replace day-of-month-based randomization of `async_load_databases` with `$RANDOM` for proper per-run randomization

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=101445&sha=67faa9d714c5f795f00216c9a979fecbc1bde18d&name_0=PR&name_1=Stress%20test%20%28arm_tsan%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.654`
<!-- ch-version-info:end -->