### PR TITLE
Fix flaky test 02015_async_inserts_4

### DIFF
--- a/tests/queries/0_stateless/02015_async_inserts_4.sh
+++ b/tests/queries/0_stateless/02015_async_inserts_4.sh
@@ -5,35 +5,41 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+# Use unique names per test run to avoid conflicts when the flaky check
+# runs this test multiple times in parallel (users and roles are global objects).
+user_allowed="u_02015_allowed_${CLICKHOUSE_DATABASE}"
+user_denied="u_02015_denied_${CLICKHOUSE_DATABASE}"
+role_name="role_02015_${CLICKHOUSE_DATABASE}"
+
 url="${CLICKHOUSE_URL}&async_insert=1&wait_for_async_insert=1"
 
-${CLICKHOUSE_CLIENT} -q "DROP USER IF EXISTS u_02015_allowed"
-${CLICKHOUSE_CLIENT} -q "DROP USER IF EXISTS u_02015_denied"
-${CLICKHOUSE_CLIENT} -q "DROP ROLE IF EXISTS role_02015"
+${CLICKHOUSE_CLIENT} -q "DROP USER IF EXISTS ${user_allowed}"
+${CLICKHOUSE_CLIENT} -q "DROP USER IF EXISTS ${user_denied}"
+${CLICKHOUSE_CLIENT} -q "DROP ROLE IF EXISTS ${role_name}"
 
-${CLICKHOUSE_CLIENT} -q "CREATE ROLE role_02015"
-${CLICKHOUSE_CLIENT} -q "CREATE USER u_02015_allowed";
-${CLICKHOUSE_CLIENT} -q "CREATE USER u_02015_denied";
+${CLICKHOUSE_CLIENT} -q "CREATE ROLE ${role_name}"
+${CLICKHOUSE_CLIENT} -q "CREATE USER ${user_allowed}";
+${CLICKHOUSE_CLIENT} -q "CREATE USER ${user_denied}";
 
-${CLICKHOUSE_CLIENT} -q "REVOKE ALL ON *.* FROM u_02015_allowed"
-${CLICKHOUSE_CLIENT} -q "REVOKE ALL ON *.* FROM u_02015_denied"
+${CLICKHOUSE_CLIENT} -q "REVOKE ALL ON *.* FROM ${user_allowed}"
+${CLICKHOUSE_CLIENT} -q "REVOKE ALL ON *.* FROM ${user_denied}"
 
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS async_inserts"
 ${CLICKHOUSE_CLIENT} -q "CREATE TABLE async_inserts (id UInt32, s String) ENGINE = MergeTree ORDER BY id"
 
-${CLICKHOUSE_CLIENT} -q "GRANT INSERT ON async_inserts TO role_02015"
-${CLICKHOUSE_CLIENT} -q "GRANT role_02015 to u_02015_allowed"
+${CLICKHOUSE_CLIENT} -q "GRANT INSERT ON async_inserts TO ${role_name}"
+${CLICKHOUSE_CLIENT} -q "GRANT ${role_name} to ${user_allowed}"
 
-${CLICKHOUSE_CURL} -sS "$url&user=u_02015_denied" \
+${CLICKHOUSE_CURL} -sS "$url&user=${user_denied}" \
     -d 'INSERT INTO async_inserts FORMAT JSONEachRow {"id": 1, "s": "a"} {"id": 2, "s": "b"}' \
     | grep -o "Not enough privileges"
 
-${CLICKHOUSE_CURL} -sS "$url&user=u_02015_allowed" \
+${CLICKHOUSE_CURL} -sS "$url&user=${user_allowed}" \
     -d 'INSERT INTO async_inserts FORMAT JSONEachRow {"id": 1, "s": "a"} {"id": 2, "s": "b"}'
 
 ${CLICKHOUSE_CLIENT} -q "SELECT * FROM async_inserts ORDER BY id"
 
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE async_inserts"
-${CLICKHOUSE_CLIENT} -q "DROP USER u_02015_allowed"
-${CLICKHOUSE_CLIENT} -q "DROP USER u_02015_denied"
-${CLICKHOUSE_CLIENT} -q "DROP ROLE role_02015"
+${CLICKHOUSE_CLIENT} -q "DROP USER ${user_allowed}"
+${CLICKHOUSE_CLIENT} -q "DROP USER ${user_denied}"
+${CLICKHOUSE_CLIENT} -q "DROP ROLE ${role_name}"


### PR DESCRIPTION
The test creates users and roles with hardcoded global names (`u_02015_allowed`,
`u_02015_denied`, `role_02015`). When the flaky check runs this test multiple
times with parallel workers, one instance's `DROP USER IF EXISTS` races with
another instance's `REVOKE ALL` / `CREATE USER`, causing `UNKNOWN_ROLE` errors.

The fix suffixes all user and role names with `$CLICKHOUSE_DATABASE` (unique per
test invocation), so parallel instances operate on independent global objects.

**Reproduction:** `--test-runs 10 -j 4` — fails 6/10 without fix, passes 50/50
with fix at `--test-runs 50 -j 8`.

Ref: #101447

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.669`
<!-- ch-version-info:end -->