### PR TITLE
Handle MEMORY_LIMIT_EXCEEDED gracefully in AST fuzzer

### DIFF
--- a/ci/jobs/scripts/fuzzer/run-fuzzer.sh
+++ b/ci/jobs/scripts/fuzzer/run-fuzzer.sh
@@ -282,6 +282,10 @@ function fuzz
                 # Give it some time to cool down
                 clickhouse-client --query "SHOW PROCESSLIST"
                 sleep 1
+            elif grep -F 'MEMORY_LIMIT_EXCEEDED' err
+            then
+                # Server is alive but at memory limit, give it time to reclaim
+                sleep 1
             else
                 echo "Server live check returns $?"
                 cat err

--- a/programs/client/FuzzLoop.cpp
+++ b/programs/client/FuzzLoop.cpp
@@ -46,6 +46,7 @@ namespace ErrorCodes
 extern const int CANNOT_PARSE_TEXT;
 extern const int NOT_IMPLEMENTED;
 extern const int SYNTAX_ERROR;
+extern const int MEMORY_LIMIT_EXCEEDED;
 extern const int TOO_DEEP_RECURSION;
 extern const int BUZZHOUSE;
 using ErrorCode = int;
@@ -112,7 +113,11 @@ bool Client::processASTFuzzerStep(const String & query_to_execute, const ASTPtr 
     const auto * exception = server_exception ? server_exception.get() : client_exception.get();
     // Sometimes you may get TOO_DEEP_RECURSION from the server,
     // and TOO_DEEP_RECURSION should not fail the fuzzer check.
-    if (have_error && exception->code() == ErrorCodes::TOO_DEEP_RECURSION)
+    // Similarly, MEMORY_LIMIT_EXCEEDED means the server correctly
+    // rejected an expensive query, not that it died.
+    if (have_error
+        && (exception->code() == ErrorCodes::TOO_DEEP_RECURSION
+            || exception->code() == ErrorCodes::MEMORY_LIMIT_EXCEEDED))
     {
         have_error = false;
         server_exception.reset();


### PR DESCRIPTION
The AST fuzzer reports false failures when the server hits its memory limit during fuzzing. This is especially common on ARM ASan+UBSan builds due to ~3x memory overhead.

When a fuzzed query triggers `MEMORY_LIMIT_EXCEEDED`, the fuzzer client treats it as a fatal error: it tries to reconnect, the reconnection also fails with `MEMORY_LIMIT_EXCEEDED`, and it exits with code 241. The post-run liveness check then also gets `MEMORY_LIMIT_EXCEEDED` and declares the server dead. The result is reported as "Received signal 15" — which is just the normal SIGTERM from shutdown.

Two fixes:
- In `FuzzLoop.cpp`, treat `MEMORY_LIMIT_EXCEEDED` like `TOO_DEEP_RECURSION`: clear the error and continue fuzzing.
- In `run-fuzzer.sh`, treat `MEMORY_LIMIT_EXCEEDED` during the liveness check as transient (like `TOO_MANY_SIMULTANEOUS_QUERIES`).

Example failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=102000&sha=latest&name_0=PR&name_1=AST+fuzzer+%28arm_asan_ubsan%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.712`
<!-- ch-version-info:end -->