### PR TITLE
Add style check for large files in git, remove unused 14 MB parquet

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -172,11 +172,20 @@ When reading diffs, scan for these classes of bugs:
 - Watch for file paths that surface contents in error messages on parse failure — even a "read then validate" pattern can leak file contents through exceptions.
 - This applies to all code paths that use `ReadBufferFromFile`, `WriteBufferToFile`, `std::ifstream`, or similar with user-controlled paths.
 
-**9) Semantic correctness & fix completeness**
+**9) Repository bloat — large & binary files**
+- ClickHouse is a huge monorepo; every byte committed to git is cloned by every contributor forever and can never be fully removed without history rewriting.
+- **Binary blobs** (JARs, compiled executables, archives, images, dataset files, model weights) must **never** be committed directly. Flag any new binary file larger than ~100 KB as a blocker. Check `file` type and size for any non-text addition.
+- **Chunked / split binaries** are a red flag — they indicate someone tried to work around size limits while still committing the same blob.
+- **Fat dependency bundles** (uber-JARs, vendored node_modules, bundled `.so`/.`dylib` files) are never acceptable in-tree.
+- **Acceptable alternatives:** download at test time from CI artifact storage / S3 / Maven Central; build from source inside the test container; use a Docker image that already contains the dependency; use git-lfs if the project supports it (ClickHouse does not).
+- **Test data** (Parquet files, Avro files, small JSON fixtures) under ~1 MB total is usually fine, but anything larger should be generated at test time or downloaded.
+- When a PR adds new files under `tests/integration/`, `tests/queries/`, or any other directory, always scan for unexpectedly large or binary additions — contributors sometimes commit build artifacts or data files without realizing the permanent cost.
+
+**10) Semantic correctness & fix completeness**
 - **Partial / asymmetric fixes:** when a behavior is changed in one code path, check whether symmetric paths need the same change. Examples: fixing `SYSTEM STOP MERGES` for merge selection but not mutation selection; fixing `ReplicatedMergeTree` but not `SharedMergeTree`. Use `grep` to find all related call sites.
 - **Multi-instance resource selection:** when a PR adds support for multiple instances of a resource (e.g. auxiliary ZooKeeper clusters, secondary storage backends), grep for every place that accesses the resource and verify the correct instance is selected — not just in the newly added code paths.
 
-**10) Trust boundary expansion — looking beyond the diff**
+**11) Trust boundary expansion — looking beyond the diff**
 
 Trigger: a PR wraps existing internal code for a wider audience (library function → SQL function, CLI tool → server endpoint, internal reader → table function, background-only path → user-reachable query). The wrapper diff may look fine, but the callee was written with assumptions about its original callers that no longer hold.
 
@@ -217,6 +226,8 @@ CLICKHOUSE RULES (MANDATORY)
   Ensure incremental rollout is feasible in both OSS and Cloud (feature flags, safe defaults, non-disruptive changes).
 - **Compilation time**
   Follow checklist **7) Compilation time & build impact**. Treat violations there as ClickHouse-rule issues.
+- **No large / binary files in git**
+  Binary blobs (JARs, archives, compiled artifacts, datasets >1 MB, fat dependency bundles) must never be committed. They permanently bloat the repository for every clone and cannot be removed without history rewriting. Test dependencies should be downloaded at test time, built from source inside the test container, or pulled from Docker images. Follow checklist **9) Repository bloat**. Any violation is a blocker.
 - **PR metadata quality**
   For PR-number reviews, verify PR template metadata against `.github/PULL_REQUEST_TEMPLATE.md`: `Changelog category` correctness, required `Changelog entry` quality, and alignment with `clickhouse-pr-description` changelog guidance (specificity, user impact, and migration details for backward-incompatible changes).
 
@@ -232,6 +243,7 @@ SEVERITY MODEL – WHAT DESERVES A COMMENT
 - Significant performance regression in a hot path.
 - Security or privilege issues, or license incompatibility.
 - Server-side file access with user-controlled paths that bypass `user_files_path` or equivalent restrictions.
+- Large binary files (JARs, archives, datasets, compiled artifacts) committed to git — permanent, irreversible repo bloat.
 
 **Majors** – serious but not catastrophic
 - Under-tested important edge cases or error paths.
@@ -296,6 +308,7 @@ Example:
 | PR metadata quality | ⚠️ | `Changelog category` does not match change type; `Changelog entry` is too vague for users |
 | Safe rollout | ➖ | |
 | Compilation time | ✅ | |
+| No large/binary files | ✅ | |
 
 **Performance & Safety** (omit if no concerns)
 - Only include this section if there are actual concerns about hot-path regressions, memory, concurrency, or failure modes.

--- a/ci/jobs/scripts/check_style/various_checks.sh
+++ b/ci/jobs/scripts/check_style/various_checks.sh
@@ -246,3 +246,47 @@ done
 
 # CLICKHOUSE_URL already includes "?"
 git grep -P 'CLICKHOUSE_URL(|_HTTPS)(}|}/|/|)\?' $ROOT_PATH/tests/queries/0_stateless/*.sh && echo "CLICKHOUSE_URL already includes '?', use '&' to append query parameters"
+
+# Large files checked into git.
+# Every byte committed is cloned by every contributor forever and cannot be removed without history rewriting.
+# Binary blobs (JARs, archives, .so, datasets) should be downloaded at test time or built from source.
+MAX_FILE_SIZE=$((5 * 1024 * 1024))  # 5 MB
+LARGE_FILE_WHITELIST=(
+    # Legitimate test data that is hard to generate at runtime
+    tests/queries/0_stateless/data_parquet/multi_column_bf.gz.parquet
+    tests/queries/0_stateless/data_json/ghdata_sample.json
+    tests/stress/keeper/workloads/zookeeper_log.parquet
+    tests/integration/test_catboost_evaluate/model/libcatboostmodel.so_aarch64
+    tests/integration/test_catboost_evaluate/model/libcatboostmodel.so_x86_64
+    tests/queries/0_stateless/data_zstd/test_01946.zstd
+    contrib/google-cloud-cpp-cmake/googleapis/e60db19f11f94175ac682c5898cce0f77cc508ea.tar.gz
+    tests/queries/0_stateless/data_npy/npy_big.npy
+    tests/queries/0_stateless/data_parquet/string_int_list_inconsistent_offset_multiple_batches.parquet
+    tests/sqllogic/known_failures.txt
+    tests/integration/test_keeper_java_client/java_client/keeper-java-client-test.jar
+    tests/integration/test_catboost_evaluate/model/amazon_model.bin
+    tests/queries/0_stateless/data_json/nbagames_sample.json
+    tests/queries/0_stateless/data_minio/02731.arrow
+    contrib/openssl-cmake/asm/crypto/modes/aes-gcm-avx512.s
+    # TODO: these should be removed and the test should build the JAR from source at runtime
+    tests/integration/test_paimon_rest_catalog/paimon-rest-catalog/chunk_00
+    tests/integration/test_paimon_rest_catalog/paimon-rest-catalog/chunk_01
+    tests/integration/test_paimon_rest_catalog/paimon-rest-catalog/chunk_02
+)
+large_file_whitelist_pattern=$(printf '%s\n' "${LARGE_FILE_WHITELIST[@]}" | paste -sd'|' -)
+# GNU stat (Linux) uses -c, BSD stat (macOS) uses -f — detect once instead of failing per file.
+if stat -c '%s %n' /dev/null >/dev/null 2>&1; then
+    STAT_FMT_FLAG='-c'
+    STAT_FMT='%s %n'
+else
+    STAT_FMT_FLAG='-f'
+    STAT_FMT='%z %N'
+fi
+# Bulk stat all tracked files via xargs (avoids fork-per-file which takes minutes on large repos).
+git ls-files -z "$ROOT_PATH" | xargs -0 stat "$STAT_FMT_FLAG" "$STAT_FMT" 2>/dev/null \
+    | awk -v limit="$MAX_FILE_SIZE" '$1 > limit { print substr($0, index($0, $2)) }' \
+    | while IFS= read -r file; do
+        if ! echo "$file" | grep -qE "^($large_file_whitelist_pattern)$"; then
+            echo "File $file is larger than 5 MB. Large files should not be committed to git — download them at test time or build from source instead."
+        fi
+    done

--- a/ci/jobs/scripts/check_style/various_checks.sh
+++ b/ci/jobs/scripts/check_style/various_checks.sh
@@ -253,26 +253,23 @@ git grep -P 'CLICKHOUSE_URL(|_HTTPS)(}|}/|/|)\?' $ROOT_PATH/tests/queries/0_stat
 MAX_FILE_SIZE=$((5 * 1024 * 1024))  # 5 MB
 LARGE_FILE_WHITELIST=(
     # Legitimate test data that is hard to generate at runtime
-    tests/queries/0_stateless/data_parquet/multi_column_bf.gz.parquet
-    tests/queries/0_stateless/data_json/ghdata_sample.json
-    tests/integration/test_catboost_evaluate/model/libcatboostmodel.so_aarch64
-    tests/integration/test_catboost_evaluate/model/libcatboostmodel.so_x86_64
-    tests/queries/0_stateless/data_zstd/test_01946.zstd
-    contrib/google-cloud-cpp-cmake/googleapis/e60db19f11f94175ac682c5898cce0f77cc508ea.tar.gz
-    tests/queries/0_stateless/data_npy/npy_big.npy
-    tests/queries/0_stateless/data_parquet/string_int_list_inconsistent_offset_multiple_batches.parquet
-    tests/sqllogic/known_failures.txt
-    tests/integration/test_keeper_java_client/java_client/keeper-java-client-test.jar
-    tests/integration/test_catboost_evaluate/model/amazon_model.bin
-    tests/queries/0_stateless/data_json/nbagames_sample.json
-    tests/queries/0_stateless/data_minio/02731.arrow
-    contrib/openssl-cmake/asm/crypto/modes/aes-gcm-avx512.s
+    -e multi_column_bf.gz.parquet
+    -e ghdata_sample.json
+    -e libcatboostmodel.so_aarch64
+    -e libcatboostmodel.so_x86_64
+    -e test_01946.zstd
+    -e e60db19f11f94175ac682c5898cce0f77cc508ea.tar.gz
+    -e npy_big.npy
+    -e string_int_list_inconsistent_offset_multiple_batches.parquet
+    -e known_failures.txt
+    -e keeper-java-client-test.jar
+    -e amazon_model.bin
+    -e nbagames_sample.json
+    -e 02731.arrow
+    -e aes-gcm-avx512.s
     # TODO: these should be removed and the test should build the JAR from source at runtime
-    tests/integration/test_paimon_rest_catalog/paimon-rest-catalog/chunk_00
-    tests/integration/test_paimon_rest_catalog/paimon-rest-catalog/chunk_01
-    tests/integration/test_paimon_rest_catalog/paimon-rest-catalog/chunk_02
+    -e paimon-rest-catalog/chunk_
 )
-large_file_whitelist_pattern=$(printf '%s\n' "${LARGE_FILE_WHITELIST[@]}" | paste -sd'|' -)
 # GNU stat (Linux) uses -c, BSD stat (macOS) uses -f — detect once instead of failing per file.
 if stat -c '%s %n' /dev/null >/dev/null 2>&1; then
     STAT_FMT_FLAG='-c'
@@ -284,8 +281,7 @@ fi
 # Bulk stat all tracked files via xargs (avoids fork-per-file which takes minutes on large repos).
 git ls-files -z "$ROOT_PATH" | xargs -0 stat "$STAT_FMT_FLAG" "$STAT_FMT" 2>/dev/null \
     | awk -v limit="$MAX_FILE_SIZE" '$1 > limit { print substr($0, index($0, $2)) }' \
+    | grep -v "${LARGE_FILE_WHITELIST[@]}" \
     | while IFS= read -r file; do
-        if ! echo "$file" | grep -qE "^($large_file_whitelist_pattern)$"; then
-            echo "File $file is larger than 5 MB. Large files should not be committed to git — download them at test time or build from source instead."
-        fi
+        echo "File $file is larger than 5 MB. Large files should not be committed to git — download them at test time or build from source instead."
     done

--- a/ci/jobs/scripts/check_style/various_checks.sh
+++ b/ci/jobs/scripts/check_style/various_checks.sh
@@ -255,7 +255,6 @@ LARGE_FILE_WHITELIST=(
     # Legitimate test data that is hard to generate at runtime
     tests/queries/0_stateless/data_parquet/multi_column_bf.gz.parquet
     tests/queries/0_stateless/data_json/ghdata_sample.json
-    tests/stress/keeper/workloads/zookeeper_log.parquet
     tests/integration/test_catboost_evaluate/model/libcatboostmodel.so_aarch64
     tests/integration/test_catboost_evaluate/model/libcatboostmodel.so_x86_64
     tests/queries/0_stateless/data_zstd/test_01946.zstd


### PR DESCRIPTION
Add a style check in `various_checks.sh` that flags any git-tracked file larger than 5 MB
unless it is explicitly whitelisted. This prevents accidentally committing binary blobs
(JARs, archives, `.so` files, large datasets) that permanently bloat the repository.

Also removes `tests/stress/keeper/workloads/zookeeper_log.parquet` (14 MB) which is unused —
the only reference is a commented-out line in a scenario file that points to a different filename.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Add a CI style check that rejects files larger than 5 MB committed to the repository, with a whitelist for existing legitimate test data. Remove unused 14 MB `zookeeper_log.parquet`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.674`
<!-- ch-version-info:end -->