### PR TITLE
Use Settings for CIDB secrets in collect_statistics.py

### DIFF
--- a/ci/jobs/collect_statistics.py
+++ b/ci/jobs/collect_statistics.py
@@ -2,10 +2,11 @@ import json
 import sys
 from datetime import datetime
 
-from ci.praktika import Secret
 from ci.praktika.cidb import CIDB
+from ci.praktika.info import Info
 from ci.praktika.result import Result
 from ci.praktika.s3 import S3
+from ci.praktika.settings import Settings
 from ci.praktika.utils import Shell
 from ci.settings.settings import S3_REPORT_BUCKET_NAME
 
@@ -110,20 +111,14 @@ def get_job_stat_for_interval(name, interval_days, overall_statistics):
 
 if __name__ == "__main__":
 
-    cidb = CIDB(
-        url=Secret.Config(
-            name="clickhouse-test-stat-url",
-            type=Secret.Type.AWS_SSM_PARAMETER,
-        ).get_value(),
-        user=Secret.Config(
-            name="clickhouse-test-stat-login",
-            type=Secret.Type.AWS_SSM_PARAMETER,
-        ).get_value(),
-        passwd=Secret.Config(
-            name="clickhouse-test-stat-password",
-            type=Secret.Type.AWS_SSM_PARAMETER,
-        ).get_value(),
+    info = Info()
+    url_secret = info.get_secret(Settings.SECRET_CI_DB_URL)
+    user_secret = info.get_secret(Settings.SECRET_CI_DB_USER)
+    passwd_secret = info.get_secret(Settings.SECRET_CI_DB_PASSWORD)
+    url, user, pwd = (
+        url_secret.join_with(user_secret).join_with(passwd_secret).get_value()
     )
+    cidb = CIDB(url=url, user=user, passwd=pwd)
 
     BASE_REF = "master"
 


### PR DESCRIPTION
`collect_statistics.py` hardcoded public CIDB secret names (`clickhouse-test-stat-url`, etc.), so the NightlyStatistics job always queried the public CIDB — even in private forks that override `Settings.SECRET_CI_DB_*` via `private_settings_overrides.py`.

This replaces the hardcoded `Secret.Config` calls with `Info().get_secret(Settings.SECRET_CI_DB_URL)` / `SECRET_CI_DB_USER` / `SECRET_CI_DB_PASSWORD`, matching the pattern used in `runner.py` and `cidb_cluster.py`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.672`
<!-- ch-version-info:end -->