### PR TITLE
Fix possible buffer overflow in ConsoleChannel

### DIFF
--- a/base/poco/Foundation/include/Poco/ConsoleChannel.h
+++ b/base/poco/Foundation/include/Poco/ConsoleChannel.h
@@ -176,7 +176,7 @@ protected:
 private:
     std::ostream & _str;
     bool _enableColors;
-    Color _colors[9];
+    Color _colors[10];
     static FastMutex _mutex;
     static const std::string CSI;
 };


### PR DESCRIPTION
Enum ```Message::PRIO_TEST``` has value of 9 and is used as array index for ```_colors``` in ColorConsoleChannel::setProperty(). Therefore length of ```_colors``` array should be increased to 10.

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes possible buffer overflow that could occur while using ColorConsoleChannel.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
