### PR TITLE
Revert "Add direct include for getenv usages"

### DIFF
--- a/src/Common/EnvironmentChecks.cpp
+++ b/src/Common/EnvironmentChecks.cpp
@@ -9,7 +9,6 @@
 
 #include <tuple>
 
-#include <stdlib.h>
 #include <unistd.h>
 
 namespace


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#99856

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.679`
<!-- ch-version-info:end -->