### PR TITLE
Backport distroless Dockerfile updates to 25.8

### DIFF
--- a/docker/keeper/Dockerfile.distroless
+++ b/docker/keeper/Dockerfile.distroless
@@ -3,8 +3,8 @@
 # The entrypoint is the compiled `clickhouse docker-init --keeper` subcommand.
 #
 # Build targets:
-#   production  — gcr.io/distroless/cc-debian12:nonroot  (default)
-#   debug       — gcr.io/distroless/cc-debian12:debug-nonroot  (includes busybox shell)
+#   production  — gcr.io/distroless/cc-debian13:nonroot  (default)
+#   debug       — gcr.io/distroless/cc-debian13:debug-nonroot  (includes busybox shell)
 #
 # Usage:
 #   docker build -f Dockerfile.distroless --target production -t clickhouse/clickhouse-keeper:distroless .
@@ -31,7 +31,7 @@ RUN sed -i "s|http://archive.ubuntu.com|${apt_archive}|g" /etc/apt/sources.list 
 
 ARG REPO_CHANNEL="stable"
 ARG REPOSITORY="deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/deb ${REPO_CHANNEL} main"
-ARG VERSION="26.1.2.11"
+ARG VERSION="26.3.4.11"
 ARG PACKAGES="clickhouse-common-static clickhouse-keeper"
 
 ARG deb_location_url=""
@@ -138,8 +138,8 @@ RUN mkdir -p \
 # ──────────────────────────────────────────────────────────────────────────────
 # Stage 2: Production distroless image.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-03-10. Refresh: docker pull gcr.io/distroless/cc-debian12:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian12:nonroot
-FROM gcr.io/distroless/cc-debian12:nonroot@sha256:7e5b8df2f4d36f5599ef4ab856d7d444922531709becb03f3368c6d797d0a5eb AS production
+# Pinned 2026-04-02. Refresh: docker pull gcr.io/distroless/cc-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:nonroot
+FROM gcr.io/distroless/cc-debian13:nonroot@sha256:9c4fe2381c2e6d53c4cfdefeff6edbd2a67ec7713e2c3ca6653806cbdbf27a1e AS production
 
 COPY --from=ch-builder /output/ /
 
@@ -161,8 +161,8 @@ ENTRYPOINT ["/usr/bin/clickhouse", "docker-init", "--keeper"]
 # Stage 3: Debug image — same as production but includes the busybox shell
 #           at /busybox/sh for interactive troubleshooting.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-03-10. Refresh: docker pull gcr.io/distroless/cc-debian12:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian12:debug-nonroot
-FROM gcr.io/distroless/cc-debian12:debug-nonroot@sha256:641f055b21555d5e4f77b7f1f3caca80840a76c4f7ae5df36a159a436941d2c2 AS debug
+# Pinned 2026-04-02. Refresh: docker pull gcr.io/distroless/cc-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:debug-nonroot
+FROM gcr.io/distroless/cc-debian13:debug-nonroot@sha256:d47b319b1047dff7cdee335e3e61468f3610fac20060653aabe3786d6ecba621 AS debug
 
 COPY --from=ch-builder /output/ /
 

--- a/docker/server/Dockerfile.distroless
+++ b/docker/server/Dockerfile.distroless
@@ -3,8 +3,8 @@
 # The entrypoint is the compiled `clickhouse docker-init` subcommand.
 #
 # Build targets:
-#   production  — gcr.io/distroless/cc-debian12:nonroot  (default)
-#   debug       — gcr.io/distroless/cc-debian12:debug-nonroot  (includes busybox shell)
+#   production  — gcr.io/distroless/cc-debian13:nonroot  (default)
+#   debug       — gcr.io/distroless/cc-debian13:debug-nonroot  (includes busybox shell)
 #
 # Usage:
 #   docker build -f Dockerfile.distroless --target production -t clickhouse/clickhouse-server:distroless .
@@ -37,7 +37,7 @@ RUN sed -i "s|http://archive.ubuntu.com|${apt_archive}|g" /etc/apt/sources.list 
 
 ARG REPO_CHANNEL="stable"
 ARG REPOSITORY="deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/deb ${REPO_CHANNEL} main"
-ARG VERSION="26.1.2.11"
+ARG VERSION="26.3.4.11"
 ARG PACKAGES="clickhouse-client clickhouse-server clickhouse-common-static"
 
 #docker-official-library:off
@@ -156,8 +156,8 @@ RUN { \
 # ──────────────────────────────────────────────────────────────────────────────
 # Stage 2: Production distroless image.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-03-10. Refresh: docker pull gcr.io/distroless/cc-debian12:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian12:nonroot
-FROM gcr.io/distroless/cc-debian12:nonroot@sha256:7e5b8df2f4d36f5599ef4ab856d7d444922531709becb03f3368c6d797d0a5eb AS production
+# Pinned 2026-04-02. Refresh: docker pull gcr.io/distroless/cc-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:nonroot
+FROM gcr.io/distroless/cc-debian13:nonroot@sha256:9c4fe2381c2e6d53c4cfdefeff6edbd2a67ec7713e2c3ca6653806cbdbf27a1e AS production
 
 COPY --from=ch-builder /output/ /
 
@@ -179,8 +179,8 @@ ENTRYPOINT ["/usr/bin/clickhouse", "docker-init"]
 # Stage 3: Debug image — same as production but includes the busybox shell
 #           at /busybox/sh for interactive troubleshooting.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-03-10. Refresh: docker pull gcr.io/distroless/cc-debian12:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian12:debug-nonroot
-FROM gcr.io/distroless/cc-debian12:debug-nonroot@sha256:641f055b21555d5e4f77b7f1f3caca80840a76c4f7ae5df36a159a436941d2c2 AS debug
+# Pinned 2026-04-02. Refresh: docker pull gcr.io/distroless/cc-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:debug-nonroot
+FROM gcr.io/distroless/cc-debian13:debug-nonroot@sha256:d47b319b1047dff7cdee335e3e61468f3610fac20060653aabe3786d6ecba621 AS debug
 
 COPY --from=ch-builder /output/ /
 


### PR DESCRIPTION
Update distroless base images from Debian 12 to Debian 13 and refresh pinned digests, matching master. Without this, the release workflow skips distroless builds for 25.8 tags because `Dockerfile.distroless` at the tag has stale base image pins.

The next 25.8 patch release will include distroless images on Docker Hub.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Update distroless Docker base images from Debian 12 to Debian 13.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)