### PR TITLE
Mark `02346_text_index_mark_file_compatibility` as long, no-flaky-check

### DIFF
--- a/tests/queries/0_stateless/02346_text_index_mark_file_compatibility.sql
+++ b/tests/queries/0_stateless/02346_text_index_mark_file_compatibility.sql
@@ -1,3 +1,5 @@
+-- Tags: long, no-flaky-check
+
 -- For tables with a text index, the merge may produce a corrupt .mrk file format
 
 SET use_query_condition_cache = 0;


### PR DESCRIPTION
Mark `02346_text_index_mark_file_compatibility` as `long`, `no-flaky-check` — the test times out (300s on `OPTIMIZE TABLE tab FINAL`) in the flaky check under ASan.

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=102108&sha=3becb5581e58f157ba99a6618c3e46d6542c21b2&name_0=PR&name_1=Stateless%20tests%20%28arm_asan_ubsan%2C%20flaky%20check%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.693`
<!-- ch-version-info:end -->