### PR TITLE
tests: avoid throw from finally block in test_s3_cluster

### DIFF
--- a/tests/integration/test_s3_cluster/test.py
+++ b/tests/integration/test_s3_cluster/test.py
@@ -103,7 +103,7 @@ def started_cluster():
 
         yield cluster
     finally:
-        shutil.rmtree(os.path.join(SCRIPT_DIR, "data/generated/"))
+        shutil.rmtree(os.path.join(SCRIPT_DIR, "data/generated/"), ignore_errors=True)
         cluster.shutdown()
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=101646&sha=e74e13691ce79fa334f0c9985f4f5a49f514705d&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%204%2F6%29

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.704`
<!-- ch-version-info:end -->