### PR TITLE
Show downstream sync CI results inline in the report page

### DIFF
--- a/ci/praktika/downstream-reports.md
+++ b/ci/praktika/downstream-reports.md
@@ -1,0 +1,89 @@
+# Downstream (Sync) CI Reports
+
+## Overview
+
+When a PR is opened on the public repository, a sync PR may be created in a downstream
+repository. The downstream CI runs additional tests against the same code.
+
+The `json.html` report page can display these downstream results alongside the upstream
+results in a single merged table — for team members connected to a VPN with a configured
+proxy.
+
+## How It Works
+
+1. When a downstream sync PR starts, it uploads metadata to S3:
+   `<private-bucket>/sync_metadata/<upstream_sha>.json`
+   ```json
+   {
+       "private_pr_number": 55000,
+       "private_sha": "abc123...",
+       "upstream_pr_number": 102000
+   }
+   ```
+
+2. The public `json.html` page (at top level):
+   - Renders public results immediately
+   - If a proxy URL is configured, fetches the sync metadata via the proxy
+   - If metadata exists, fetches the downstream `result_pr.json`
+   - Merges downstream results into the table with a `Downstream:` name prefix
+   - Shows error messages if any step fails
+
+3. Clicking a downstream result name opens the downstream `json.html` served from the
+   proxy (in a new tab), where further drill-down works automatically.
+
+## Setup
+
+### Prerequisites
+
+- VPN connection (e.g. Tailscale)
+- An HTTPS reverse proxy with CORS headers that provides access to the private S3 bucket
+
+### Configure the Proxy URL
+
+**Option A: URL parameter** (one-time, gets persisted to localStorage):
+```
+https://s3.amazonaws.com/<bucket>/json.html?PR=123&sha=abc&name_0=PR&proxy=https://<proxy-host>/<private-bucket>
+```
+
+**Option B: Footer toggle** — click the link icon in the page footer and enter the
+proxy base URL.
+
+**Option C: Browser console**:
+```javascript
+localStorage.setItem('privateBaseUrl', 'https://<proxy-host>/<private-bucket>');
+location.reload();
+```
+
+To disable, clear the value via the footer toggle (enter empty string) or:
+```javascript
+localStorage.removeItem('privateBaseUrl');
+```
+
+## Error Messages
+
+| Message | Meaning |
+|---------|---------|
+| `Downstream: proxy unreachable` | Proxy URL is configured but the fetch failed (not on VPN, proxy down, or CORS issue) |
+| `Downstream: no sync metadata for this commit` | No downstream sync PR exists for this upstream commit SHA |
+| `Downstream: sync PR results not available yet` | Metadata exists but the downstream CI has not uploaded results yet |
+| `Downstream: invalid sync metadata` | Metadata JSON is malformed |
+
+## Architecture
+
+```
+Browser (json.html on S3)
+    |
+    |-- fetch result_pr.json from S3 (public, immediate)
+    |-- render public results
+    |
+    |-- fetch sync_metadata/<sha>.json via HTTPS proxy (async)
+    |-- fetch downstream result_pr.json via HTTPS proxy
+    |-- merge + re-render table with "Downstream:" prefix
+```
+
+The proxy must serve HTTPS and return CORS headers
+(`Access-Control-Allow-Origin: https://s3.amazonaws.com`) so the S3-hosted page can
+fetch from it.
+
+Links inside downstream results (logs, reports) are rewritten from the original
+domain to the proxy URL so they remain accessible.

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -1397,9 +1397,9 @@
         let displayResults = [...results];
         if (sortByStatus) {
             displayResults.sort((a, b) => {
-                const statusA = a.status || '';
-                const statusB = b.status || '';
-                return getStatusPriority(statusA) - getStatusPriority(statusB);
+                const statusDiff = getStatusPriority(a.status || '') - getStatusPriority(b.status || '');
+                if (statusDiff !== 0) return statusDiff;
+                return (a.name || '').localeCompare(b.name || '');
             });
         }
 

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -2178,6 +2178,16 @@
                                 clearPage();
                                 renderResults(PR, sha, nameParams);
                             }
+                        } else if (result.data && result.data.length === 0) {
+                            // Empty results — clear any stale cached downstream rows
+                            const hadDownstream = runtimeCache.downstreamResults !== null;
+                            runtimeCache.downstreamResults = null;
+                            runtimeCache.downstreamSha = null;
+                            runtimeCache.downstreamError = null;
+                            if (hadDownstream) {
+                                clearPage();
+                                renderResults(PR, sha, nameParams);
+                            }
                         }
                     });
                 }

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -2019,11 +2019,14 @@
             copy.name = originalName;
             copy._downstreamHref = `${privateBaseUrl}/json.html?PR=${encodeURIComponent(private_pr_number)}&sha=${encodeURIComponent(private_sha)}&name_0=PR&name_1=${encodeURIComponent(originalName)}`;
 
-            // Rewrite links: replace CloudFront/S3 private bucket prefix with proxy
+            // Rewrite links: replace origin+bucket prefix with proxy base URL.
+            // privateBaseUrl is e.g. https://proxy/bucket-name, extract /bucket-name
+            const bucketPath = new URL(privateBaseUrl).pathname;
             if (Array.isArray(copy.links)) {
-                copy.links = copy.links.map(link =>
-                    link.replace(/^https?:\/\/[^\/]+\/clickhouse-test-reports-private/, privateBaseUrl)
-                );
+                copy.links = copy.links.map(link => {
+                    const re = new RegExp('^https?://[^/]+' + bucketPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+                    return link.replace(re, privateBaseUrl);
+                });
             }
             return copy;
         });

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -1125,7 +1125,7 @@
             return;
         }
 
-        const lineWidth = 5;
+        const lineWidth = 1;
         const padding = 1;
         const totalHeight = (lineWidth + padding) * results.length;
 
@@ -1216,8 +1216,14 @@
 
             // Draw failure markers on top
             failedMarkers.forEach(({ x, y }) => {
-                ctx.font = "8px sans-serif";
-                ctx.fillText("❌", Math.max(x - 14, 0), y + 4);
+                ctx.fillStyle = "#ff3333";
+                ctx.beginPath();
+                const s = 3;
+                ctx.moveTo(x - s, y - s); ctx.lineTo(x + s, y + s);
+                ctx.moveTo(x + s, y - s); ctx.lineTo(x - s, y + s);
+                ctx.lineWidth = 1.5;
+                ctx.strokeStyle = "#ff3333";
+                ctx.stroke();
             });
         }
 
@@ -1438,7 +1444,7 @@
                         // Downstream result: link to private json.html via proxy
                         const link = document.createElement('a');
                         link.href = result._downstreamHref;
-                        link.textContent = value;
+                        link.textContent = '🔗 ' + value;
                         link.target = '_blank';
                         td.classList.add('name-column');
                         td.appendChild(link);
@@ -1671,7 +1677,8 @@
         runLink: null,
         sha: null,
         downstreamResults: null,
-        downstreamSha: null
+        downstreamSha: null,
+        downstreamError: null
     };
 
     function storeLink(link) {
@@ -1802,9 +1809,9 @@
             resultsDiv.appendChild(textDiv);
         }
 
-        // Merge cached downstream results if available for this SHA
+        // Merge cached downstream results if available
         let resultsData = result.results;
-        if (nameParams.length === 1 && runtimeCache.downstreamResults && runtimeCache.downstreamSha === sha) {
+        if (nameParams.length === 1 && runtimeCache.downstreamResults) {
             resultsData = [...resultsData, ...runtimeCache.downstreamResults];
         }
         if (Array.isArray(resultsData) && resultsData.length > 0) {
@@ -2092,26 +2099,10 @@
                 return;
             }
 
-            if (fetchResult) {
-                // Clear timers, event listeners, and DOM before refreshing content
-                clearPage();
-
-                // Rebuild the page with new data (public results render immediately).
-                // If we already have cached downstream results for this SHA, merge them
-                // into the initial render to avoid a visual jump.
-                await renderResults(PR, sha, nameParams);
-
-                // Restore scroll position
-                if (statusContainer) {
-                    statusContainer.scrollTop = scrollTop;
-                }
-
-                console.log(`Data refreshed at ${new Date().toLocaleTimeString()}`);
-            }
-
-            // Fetch downstream (private sync) results independently of upstream updates.
+            // Fetch downstream data into cache (no DOM changes here).
             // Only supported for PRs to main trunk (name_0=PR).
             // Runs on every tick so late-arriving downstream results are picked up.
+            let downstreamChanged = false;
             if (nameParams.length === 1 && nameParams[0] === 'PR' && privateBaseUrl) {
                 const resolvedSha = runtimeCache.commits
                     ? ((sha === 'latest')
@@ -2119,39 +2110,46 @@
                         : sha)
                     : sha;
                 if (resolvedSha) {
-                    fetchDownstreamData(resolvedSha, privateBaseUrl).then(result => {
-                        // Stale response guard: ignore if SHA changed since request started
-                        const currentSha = runtimeCache.commits
-                            ? runtimeCache.commits[runtimeCache.commits.length - 1]?.sha
-                            : sha;
-                        if (resolvedSha !== currentSha) return;
-
+                    const result = await fetchDownstreamData(resolvedSha, privateBaseUrl);
+                    // Stale response guard
+                    const currentSha = runtimeCache.commits
+                        ? runtimeCache.commits[runtimeCache.commits.length - 1]?.sha
+                        : sha;
+                    if (resolvedSha === currentSha) {
                         if (result.error) {
+                            if (runtimeCache.downstreamResults !== null || runtimeCache.downstreamError !== result.error) {
+                                downstreamChanged = true;
+                            }
                             runtimeCache.downstreamResults = null;
                             runtimeCache.downstreamSha = null;
-                            showDownstreamInfo(result.error);
+                            runtimeCache.downstreamError = result.error;
                         } else if (result.data && result.data.length > 0) {
+                            downstreamChanged = runtimeCache.downstreamSha !== resolvedSha
+                                || JSON.stringify(runtimeCache.downstreamResults?.map(r => r.status))
+                                   !== JSON.stringify(result.data.map(r => r.status));
                             runtimeCache.downstreamResults = result.data;
                             runtimeCache.downstreamSha = resolvedSha;
-                            // Clear any previous error banner
-                            const banner = document.querySelector('.downstream-info');
-                            if (banner) banner.remove();
-                            // Re-render just the results table with merged data
-                            const resultsDiv = document.getElementById('result-container');
-                            const oldTable = resultsDiv.querySelector('table');
-                            const target = getTargetResults(nameParams);
-                            if (target) {
-                                const merged = [...(target.results || []), ...result.data];
-                                const newTable = createResultsTable(merged, 1);
-                                if (newTable && oldTable) {
-                                    oldTable.replaceWith(newTable);
-                                } else if (newTable) {
-                                    resultsDiv.appendChild(newTable);
-                                }
-                            }
+                            runtimeCache.downstreamError = null;
                         }
-                    });
+                    }
                 }
+            }
+
+            // Single render pass with both upstream and downstream data
+            if (fetchResult || downstreamChanged) {
+                clearPage();
+                await renderResults(PR, sha, nameParams);
+
+                if (statusContainer) {
+                    statusContainer.scrollTop = scrollTop;
+                }
+
+                // Show downstream error if applicable
+                if (runtimeCache.downstreamError) {
+                    showDownstreamInfo(runtimeCache.downstreamError);
+                }
+
+                console.log(`Data refreshed at ${new Date().toLocaleTimeString()}`);
             }
         }
 

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -235,14 +235,24 @@
             color: #606060;
         }
 
-        #theme-toggle, #status-filter-toggle, #sort-toggle {
+        #theme-toggle, #status-filter-toggle, #sort-toggle, #proxy-toggle {
             cursor: pointer;
             color: var(--footer-text-color);
             margin-left: 10px;
         }
 
-        #theme-toggle:hover, #sort-toggle:hover {
+        #theme-toggle:hover, #sort-toggle:hover, #proxy-toggle:hover {
             color: #FAFF69;
+        }
+
+        .downstream-info {
+            padding: 8px 16px;
+            margin: 8px 0;
+            font-size: 13px;
+            border-radius: 4px;
+            background-color: var(--info-background);
+            color: var(--text-color);
+            opacity: 0.8;
         }
 
         #footer a:hover {
@@ -363,6 +373,7 @@
         <div class="left"></div>
         <div class="right"></div>
         <div class="settings">
+            <span id="proxy-toggle" title="Configure downstream proxy URL">🔗</span>
             <span id="status-filter-toggle"></span>
             <span id="sort-toggle">🔼</span>
             <span id="theme-toggle">🔆️</span>
@@ -509,6 +520,34 @@
     document.getElementById('status-filter-toggle').addEventListener('click', toggleStatusFilter);
     document.getElementById('sort-toggle').addEventListener('click', toggleSortByStatus);
     document.getElementById('toggle-status-bar').addEventListener('click', toggleStatusBar);
+    document.getElementById('proxy-toggle').addEventListener('click', toggleProxy);
+
+    function toggleProxy() {
+        const current = localStorage.getItem('privateBaseUrl') || '';
+        const value = prompt(
+            'Downstream proxy base URL\n(e.g. https://ci-reports.<tailnet>.ts.net/clickhouse-test-reports-private)\nLeave empty to disable:',
+            current
+        );
+        if (value === null) return; // cancelled
+        if (value.trim()) {
+            localStorage.setItem('privateBaseUrl', value.trim().replace(/\/+$/, ''));
+        } else {
+            localStorage.removeItem('privateBaseUrl');
+        }
+        updateProxyToggleIcon();
+        location.reload();
+    }
+
+    function updateProxyToggleIcon() {
+        const toggle = document.getElementById('proxy-toggle');
+        const hasProxy = !!localStorage.getItem('privateBaseUrl');
+        if (toggle) {
+            toggle.style.opacity = hasProxy ? '1' : '0.4';
+            toggle.title = hasProxy
+                ? 'Downstream proxy: ' + localStorage.getItem('privateBaseUrl')
+                : 'Configure downstream proxy URL';
+        }
+    }
 
     function toggleSortByStatus() {
         const current = localStorage.getItem('sortByStatus');
@@ -1384,7 +1423,15 @@
                 } else if (column === 'name') {
                     const statusValue = result["status"] ? result["status"].toLowerCase() : "";
 
-                    if (
+                    if (result._downstreamHref) {
+                        // Downstream result: link to private json.html via proxy
+                        const link = document.createElement('a');
+                        link.href = result._downstreamHref;
+                        link.textContent = value;
+                        link.target = '_blank';
+                        td.classList.add('name-column');
+                        td.appendChild(link);
+                    } else if (
                         (nest_level === 1 && ["pending", "skipped", "running"].includes(statusValue)) ||
                         (nest_level > 1 && (!Array.isArray(result.results) || result.results.length === 0) ||
                             nest_level === 0)
@@ -1611,7 +1658,8 @@
         prLink: null,
         commitLink: null,
         runLink: null,
-        sha: null
+        sha: null,
+        downstreamResults: null
     };
 
     function storeLink(link) {
@@ -1897,11 +1945,82 @@
         return hasNewData;
     }
 
+    // Fetch downstream (private sync) results via proxy.
+    // Returns { data: [...results], error: null } or { data: null, error: "message" }
+    async function fetchDownstreamData(sha, privateBaseUrl) {
+        // Step 1: Fetch sync metadata
+        let metaResult;
+        try {
+            metaResult = await fetchJson(`${privateBaseUrl}/sync_metadata/${sha}.json`);
+        } catch (e) {
+            return { data: null, error: 'Downstream: proxy unreachable' };
+        }
+        if (metaResult.status === 0) {
+            return { data: null, error: 'Downstream: proxy unreachable' };
+        }
+        if (metaResult.status === 403 || !metaResult.data) {
+            return { data: null, error: 'Downstream: no sync metadata for this commit' };
+        }
+
+        const { private_pr_number, private_sha } = metaResult.data;
+        if (!private_pr_number || !private_sha) {
+            return { data: null, error: 'Downstream: invalid sync metadata' };
+        }
+
+        // Step 2: Fetch private PR result
+        let resultResult;
+        try {
+            resultResult = await fetchJson(
+                `${privateBaseUrl}/PRs/${encodeURIComponent(private_pr_number)}/${encodeURIComponent(private_sha)}/result_pr.json`
+            );
+        } catch (e) {
+            return { data: null, error: 'Downstream: proxy unreachable' };
+        }
+        if (resultResult.status === 0) {
+            return { data: null, error: 'Downstream: proxy unreachable' };
+        }
+        if (resultResult.status === 403 || !resultResult.data) {
+            return { data: null, error: 'Downstream: sync PR results not available yet' };
+        }
+
+        const privateResults = resultResult.data.results || [];
+
+        // Step 3: Transform results — prefix names, add downstream href, rewrite links
+        const transformed = privateResults.map(r => {
+            const originalName = r.name;
+            const copy = Object.assign({}, r);
+            copy.name = 'Downstream: ' + originalName;
+            copy._downstreamHref = `${privateBaseUrl}/json.html?PR=${encodeURIComponent(private_pr_number)}&sha=${encodeURIComponent(private_sha)}&name_0=PR&name_1=${encodeURIComponent(originalName)}`;
+
+            // Rewrite links: replace CloudFront/S3 private bucket prefix with proxy
+            if (Array.isArray(copy.links)) {
+                copy.links = copy.links.map(link =>
+                    link.replace(/^https?:\/\/[^\/]+\/clickhouse-test-reports-private/, privateBaseUrl)
+                );
+            }
+            return copy;
+        });
+
+        return { data: transformed, error: null };
+    }
+
+    function showDownstreamInfo(message) {
+        const container = document.getElementById('result-container');
+        // Remove any existing downstream info bar
+        const existing = container.querySelector('.downstream-info');
+        if (existing) existing.remove();
+
+        const bar = document.createElement('div');
+        bar.className = 'downstream-info';
+        bar.textContent = message;
+        container.insertBefore(bar, container.firstChild);
+    }
+
     // Track for autorefresh toggle
     let openedInfoCnt = 0;
     let closedInfoCnt = 0;
 
-    async function renderResultsAuto(PR, REF, sha, nameParams, base_url) {
+    async function renderResultsAuto(PR, REF, sha, nameParams, base_url, privateBaseUrl) {
         function clearPage() {
             // First, clean up any existing timers and event listeners
             activeTimers.clearAll();
@@ -1961,7 +2080,7 @@
                 // Clear timers, event listeners, and DOM before refreshing content
                 clearPage();
 
-                // Rebuild the page with new data
+                // Rebuild the page with new data (public results render immediately)
                 await renderResults(PR, sha, nameParams);
 
                 // Restore scroll position
@@ -1970,6 +2089,39 @@
                 }
 
                 console.log(`Data refreshed at ${new Date().toLocaleTimeString()}`);
+
+                // Fetch downstream (private sync) results asynchronously
+                if (nameParams.length === 1 && privateBaseUrl) {
+                    const resolvedSha = runtimeCache.commits
+                        ? ((sha === 'latest')
+                            ? runtimeCache.commits[runtimeCache.commits.length - 1]?.sha
+                            : sha)
+                        : sha;
+                    if (resolvedSha) {
+                        fetchDownstreamData(resolvedSha, privateBaseUrl).then(result => {
+                            if (result.error) {
+                                runtimeCache.downstreamResults = null;
+                                showDownstreamInfo(result.error);
+                            } else if (result.data && result.data.length > 0) {
+                                runtimeCache.downstreamResults = result.data;
+                                // Re-render just the results table with merged data
+                                const resultsDiv = document.getElementById('result-container');
+                                const oldTable = resultsDiv.querySelector('table');
+                                const target = getTargetResults(nameParams);
+                                if (target) {
+                                    const merged = [...(target.results || []), ...result.data];
+                                    const nest_level = 1;
+                                    const newTable = createResultsTable(merged, nest_level);
+                                    if (newTable && oldTable) {
+                                        oldTable.replaceWith(newTable);
+                                    } else if (newTable) {
+                                        resultsDiv.appendChild(newTable);
+                                    }
+                                }
+                            }
+                        });
+                    }
+                }
             }
         }
 
@@ -2006,6 +2158,14 @@
         const REF = urlParams.get('REF');
         const sha = urlParams.get('sha');
         const base_url = urlParams.get('base_url');
+
+        // Proxy URL: from URL param (persisted) or localStorage
+        const proxyParam = urlParams.get('proxy');
+        if (proxyParam) {
+            localStorage.setItem('privateBaseUrl', proxyParam.replace(/\/+$/, ''));
+        }
+        const privateBaseUrl = localStorage.getItem('privateBaseUrl') || null;
+
         const nameParams = [];
         urlParams.forEach((value, key) => {
             if (key.startsWith('name_')) {
@@ -2013,7 +2173,7 @@
                 nameParams[index] = value;
             }
         });
-        await renderResultsAuto(PR, REF, sha, nameParams, base_url);
+        await renderResultsAuto(PR, REF, sha, nameParams, base_url, privateBaseUrl);
         renderFooter(nameParams)
         updatePageTitle(PR, REF, sha, nameParams)
         fetchStatistics(nameParams[0])
@@ -2031,6 +2191,7 @@
         await init();
         toggleStatusFilter(true);
         updateSortToggleIcon();
+        updateProxyToggleIcon();
     });
 
     function createFavicon() {

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -64,8 +64,8 @@
             --job-name-color: var(--text-color);
             --link-color: #FAFF69;
             --link-hover-color: #e6eb5e;
-            --file-link-color: #7ab3ff;
-            --file-link-hover-color: #a3cbff;
+            --file-link-color: #FAFF69;
+            --file-link-hover-color: #e6eb5e;
             --footer-background: #151515;
             --footer-text-color: #F9F9F9;
         }
@@ -131,7 +131,12 @@
             max-width: 100%;              /* make sure it doesn’t overflow parent */
         }
 
-        .file-link:hover {
+        .file-link a {
+            color: var(--file-link-color);
+            text-decoration: none;
+        }
+
+        .file-link a:hover, .file-link:hover {
             color: var(--file-link-hover-color);
             text-decoration: none;
         }
@@ -249,7 +254,7 @@
             background-color: color-mix(in srgb, var(--tile-background) 50%, #e0d8f0);
         }
         .night-theme tr.downstream-row {
-            background-color: color-mix(in srgb, var(--tile-background) 70%, #3a2d5c);
+            background-color: #2a2820;
         }
 
         .downstream-info {
@@ -531,10 +536,7 @@
 
     function toggleProxy() {
         const current = localStorage.getItem('privateBaseUrl') || '';
-        const value = prompt(
-            'Downstream proxy base URL\n(e.g. https://ci-reports.<tailnet>.ts.net/clickhouse-test-reports-private)\nLeave empty to disable:',
-            current
-        );
+        const value = prompt('Downstream proxy base URL (leave empty to disable):', current);
         if (value === null) return; // cancelled
         if (value.trim()) {
             localStorage.setItem('privateBaseUrl', value.trim().replace(/\/+$/, ''));
@@ -592,13 +594,14 @@
 
     function getStatusPriority(status) {
         const statusLower = (status || '').toLowerCase();
-        // Priority order: errors/failures first, then warnings, then success, then others
+        // Priority order: errors/failures, running, pending, success, then others
         if (statusLower === 'xpass') return 0;  // unexpected pass: treat as failure
-        if (statusLower === 'xfail') return 2;  // expected failure: treat as success
+        if (statusLower === 'xfail') return 3;  // expected failure: treat as success
         if (statusLower.includes('error') || statusLower.includes('fail') || statusLower.includes('dropped')) return 0;
-        if (statusLower.includes('pending') || statusLower.includes('running')) return 1;
-        if (statusLower.includes('success') || statusLower === 'ok') return 2;
-        return 3; // other statuses
+        if (statusLower.includes('running')) return 1;
+        if (statusLower.includes('pending')) return 2;
+        if (statusLower.includes('success') || statusLower === 'ok') return 3;
+        return 4; // other statuses
     }
 
     function formatTimestamp(timestamp, showDate = true) {
@@ -1997,7 +2000,7 @@
         const transformed = privateResults.map(r => {
             const originalName = r.name;
             const copy = Object.assign({}, r);
-            copy.name = 'Downstream: ' + originalName;
+            copy.name = originalName;
             copy._downstreamHref = `${privateBaseUrl}/json.html?PR=${encodeURIComponent(private_pr_number)}&sha=${encodeURIComponent(private_sha)}&name_0=PR&name_1=${encodeURIComponent(originalName)}`;
 
             // Rewrite links: replace CloudFront/S3 private bucket prefix with proxy
@@ -2098,8 +2101,9 @@
 
                 console.log(`Data refreshed at ${new Date().toLocaleTimeString()}`);
 
-                // Fetch downstream (private sync) results asynchronously
-                if (nameParams.length === 1 && privateBaseUrl) {
+                // Fetch downstream (private sync) results asynchronously.
+                // Only supported for PRs to main trunk (name_0=PR).
+                if (nameParams.length === 1 && nameParams[0] === 'PR' && privateBaseUrl) {
                     const resolvedSha = runtimeCache.commits
                         ? ((sha === 'latest')
                             ? runtimeCache.commits[runtimeCache.commits.length - 1]?.sha

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -2099,39 +2099,8 @@
                 return;
             }
 
-            // Fetch downstream data into cache (no DOM changes here).
-            // Only supported for PRs to main trunk (name_0=PR).
-            // Runs on every tick so late-arriving downstream results are picked up.
-            let downstreamChanged = false;
-            if (nameParams.length === 1 && nameParams[0] === 'PR' && privateBaseUrl) {
-                const resolvedSha = runtimeCache.commits
-                    ? ((sha === 'latest')
-                        ? runtimeCache.commits[runtimeCache.commits.length - 1]?.sha
-                        : sha)
-                    : sha;
-                console.log(`Downstream: resolvedSha=${resolvedSha}, cachedSha=${runtimeCache.downstreamSha}`);
-                if (resolvedSha) {
-                    const result = await fetchDownstreamData(resolvedSha, privateBaseUrl);
-                    console.log(`Downstream fetch: error=${result.error}, dataLen=${result.data?.length}`);
-                    if (result.error) {
-                        if (runtimeCache.downstreamResults !== null || runtimeCache.downstreamError !== result.error) {
-                            downstreamChanged = true;
-                        }
-                        runtimeCache.downstreamResults = null;
-                        runtimeCache.downstreamSha = null;
-                        runtimeCache.downstreamError = result.error;
-                    } else if (result.data && result.data.length > 0) {
-                        downstreamChanged = true;
-                        runtimeCache.downstreamResults = result.data;
-                        runtimeCache.downstreamSha = resolvedSha;
-                        runtimeCache.downstreamError = null;
-                    }
-                }
-            }
-            console.log(`Render decision: fetchResult=${fetchResult}, downstreamChanged=${downstreamChanged}, cachedDownstream=${runtimeCache.downstreamResults?.length}`);
-
-            // Single render pass with both upstream and downstream data
-            if (fetchResult || downstreamChanged) {
+            // Render upstream immediately (+ cached downstream if available)
+            if (fetchResult) {
                 clearPage();
                 await renderResults(PR, sha, nameParams);
 
@@ -2139,12 +2108,41 @@
                     statusContainer.scrollTop = scrollTop;
                 }
 
-                // Show downstream error if applicable
                 if (runtimeCache.downstreamError) {
                     showDownstreamInfo(runtimeCache.downstreamError);
                 }
 
                 console.log(`Data refreshed at ${new Date().toLocaleTimeString()}`);
+            }
+
+            // Fetch downstream asynchronously. Only for PRs to main trunk.
+            // On first load this adds downstream after a brief delay.
+            // On subsequent refreshes, cached data is already merged above.
+            if (nameParams.length === 1 && nameParams[0] === 'PR' && privateBaseUrl) {
+                const resolvedSha = runtimeCache.commits
+                    ? ((sha === 'latest')
+                        ? runtimeCache.commits[runtimeCache.commits.length - 1]?.sha
+                        : sha)
+                    : sha;
+                if (resolvedSha) {
+                    fetchDownstreamData(resolvedSha, privateBaseUrl).then(result => {
+                        if (result.error) {
+                            runtimeCache.downstreamResults = null;
+                            runtimeCache.downstreamSha = null;
+                            runtimeCache.downstreamError = result.error;
+                            showDownstreamInfo(result.error);
+                        } else if (result.data && result.data.length > 0) {
+                            runtimeCache.downstreamResults = result.data;
+                            runtimeCache.downstreamSha = resolvedSha;
+                            runtimeCache.downstreamError = null;
+                            // Re-render with merged data (only if not already merged)
+                            if (!document.querySelector('.downstream-row')) {
+                                clearPage();
+                                renderResults(PR, sha, nameParams);
+                            }
+                        }
+                    });
+                }
             }
         }
 

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -568,6 +568,7 @@
         const current = localStorage.getItem('sortByStatus');
         const newValue = current === 'true' ? 'false' : 'true';
         localStorage.setItem('sortByStatus', newValue);
+        columnSortActive = false;
 
         // Update the visual indicator
         updateSortToggleIcon();
@@ -600,14 +601,17 @@
 
     function getStatusPriority(status) {
         const statusLower = (status || '').toLowerCase();
-        // Priority order: errors/failures, running, pending, success, then others
-        if (statusLower === 'xpass') return 0;  // unexpected pass: treat as failure
-        if (statusLower === 'xfail') return 3;  // expected failure: treat as success
-        if (statusLower.includes('error') || statusLower.includes('fail') || statusLower.includes('dropped')) return 0;
-        if (statusLower.includes('running')) return 1;
-        if (statusLower.includes('pending')) return 2;
-        if (statusLower.includes('success') || statusLower === 'ok') return 3;
-        return 4; // other statuses
+        if (statusLower.includes('error')) return 0;
+        if (statusLower.includes('fail')) return 1;
+        if (statusLower === 'xpass') return 2;
+        if (statusLower.includes('running')) return 3;
+        if (statusLower.includes('dropped')) return 4;
+        if (statusLower.includes('pending')) return 5;
+        if (statusLower.includes('success')) return 6;
+        if (statusLower === 'ok') return 7;
+        if (statusLower === 'xfail') return 8;
+        if (statusLower.includes('skipped')) return 9;
+        return 10;
     }
 
     function formatTimestamp(timestamp, showDate = true) {
@@ -1405,16 +1409,17 @@
         const filter = localStorage.getItem('filter');
         const lastColumn = existingColumnsList[existingColumnsList.length - 1];
 
-        // Sort results by status if the feature is enabled
-        const sortByStatus = localStorage.getItem('sortByStatus') === 'true';
+        // Sort results by status if the feature is enabled.
+        // Skip if user clicked a column header (columnSortActive) — reset on next fresh render.
+        const sortByStatus = !columnSortActive && localStorage.getItem('sortByStatus') === 'true';
 
         // Work with a copy so we don't mutate the original
         let displayResults = [...results];
         if (sortByStatus) {
             displayResults.sort((a, b) => {
-                const statusDiff = getStatusPriority(a.status || '') - getStatusPriority(b.status || '');
-                if (statusDiff !== 0) return statusDiff;
-                return (a.name || '').localeCompare(b.name || '');
+                const statusA = a.status || '';
+                const statusB = b.status || '';
+                return getStatusPriority(statusA) - getStatusPriority(statusB);
             });
         }
 
@@ -1617,6 +1622,9 @@
         }
     }
 
+    // When true, populateTableRows skips its own sort-by-status (column header sort takes over)
+    let columnSortActive = false;
+
     function sortTable(results, column, key, tbody, nest_level, existingColumnsList) {
         // Find the table header element for the given key
         const tableHeaders = document.querySelectorAll('th');
@@ -1630,9 +1638,17 @@
         const ascending = th.getAttribute('data-sort-direction') === 'asc';
         th.setAttribute('data-sort-direction', ascending ? 'desc' : 'asc');
 
+        // Suppress populateTableRows auto-sort until next re-render
+        columnSortActive = true;
+
         results.sort((a, b) => {
-            if (a[column] < b[column]) return ascending ? -1 : 1;
-            if (a[column] > b[column]) return ascending ? 1 : -1;
+            let va = a[column], vb = b[column];
+            if (column === 'status') {
+                va = getStatusPriority(va);
+                vb = getStatusPriority(vb);
+            }
+            if (va < vb) return ascending ? -1 : 1;
+            if (va > vb) return ascending ? 1 : -1;
             return 0;
         });
 
@@ -2061,6 +2077,9 @@
             // First, clean up any existing timers and event listeners
             activeTimers.clearAll();
             activeListeners.removeAll();
+
+            // Reset column sort override so toggle takes effect again
+            columnSortActive = false;
 
             // Then clear the DOM content
             document.getElementById('result-container').innerHTML = '';

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -1670,7 +1670,8 @@
         commitLink: null,
         runLink: null,
         sha: null,
-        downstreamResults: null
+        downstreamResults: null,
+        downstreamSha: null
     };
 
     function storeLink(link) {
@@ -1801,11 +1802,15 @@
             resultsDiv.appendChild(textDiv);
         }
 
-        const resultsData = result.results;
+        // Merge cached downstream results if available for this SHA
+        let resultsData = result.results;
+        if (nameParams.length === 1 && runtimeCache.downstreamResults && runtimeCache.downstreamSha === sha) {
+            resultsData = [...resultsData, ...runtimeCache.downstreamResults];
+        }
         if (Array.isArray(resultsData) && resultsData.length > 0) {
             const table = createResultsTable(resultsData, i);
             if (table) {
-                resultsDiv.appendChild(table); // Appends table correctly
+                resultsDiv.appendChild(table);
             }
         }
         addDetailsWidget(runtimeCache, sha, PR)
@@ -2091,7 +2096,9 @@
                 // Clear timers, event listeners, and DOM before refreshing content
                 clearPage();
 
-                // Rebuild the page with new data (public results render immediately)
+                // Rebuild the page with new data (public results render immediately).
+                // If we already have cached downstream results for this SHA, merge them
+                // into the initial render to avoid a visual jump.
                 await renderResults(PR, sha, nameParams);
 
                 // Restore scroll position
@@ -2100,39 +2107,50 @@
                 }
 
                 console.log(`Data refreshed at ${new Date().toLocaleTimeString()}`);
+            }
 
-                // Fetch downstream (private sync) results asynchronously.
-                // Only supported for PRs to main trunk (name_0=PR).
-                if (nameParams.length === 1 && nameParams[0] === 'PR' && privateBaseUrl) {
-                    const resolvedSha = runtimeCache.commits
-                        ? ((sha === 'latest')
+            // Fetch downstream (private sync) results independently of upstream updates.
+            // Only supported for PRs to main trunk (name_0=PR).
+            // Runs on every tick so late-arriving downstream results are picked up.
+            if (nameParams.length === 1 && nameParams[0] === 'PR' && privateBaseUrl) {
+                const resolvedSha = runtimeCache.commits
+                    ? ((sha === 'latest')
+                        ? runtimeCache.commits[runtimeCache.commits.length - 1]?.sha
+                        : sha)
+                    : sha;
+                if (resolvedSha) {
+                    fetchDownstreamData(resolvedSha, privateBaseUrl).then(result => {
+                        // Stale response guard: ignore if SHA changed since request started
+                        const currentSha = runtimeCache.commits
                             ? runtimeCache.commits[runtimeCache.commits.length - 1]?.sha
-                            : sha)
-                        : sha;
-                    if (resolvedSha) {
-                        fetchDownstreamData(resolvedSha, privateBaseUrl).then(result => {
-                            if (result.error) {
-                                runtimeCache.downstreamResults = null;
-                                showDownstreamInfo(result.error);
-                            } else if (result.data && result.data.length > 0) {
-                                runtimeCache.downstreamResults = result.data;
-                                // Re-render just the results table with merged data
-                                const resultsDiv = document.getElementById('result-container');
-                                const oldTable = resultsDiv.querySelector('table');
-                                const target = getTargetResults(nameParams);
-                                if (target) {
-                                    const merged = [...(target.results || []), ...result.data];
-                                    const nest_level = 1;
-                                    const newTable = createResultsTable(merged, nest_level);
-                                    if (newTable && oldTable) {
-                                        oldTable.replaceWith(newTable);
-                                    } else if (newTable) {
-                                        resultsDiv.appendChild(newTable);
-                                    }
+                            : sha;
+                        if (resolvedSha !== currentSha) return;
+
+                        if (result.error) {
+                            runtimeCache.downstreamResults = null;
+                            runtimeCache.downstreamSha = null;
+                            showDownstreamInfo(result.error);
+                        } else if (result.data && result.data.length > 0) {
+                            runtimeCache.downstreamResults = result.data;
+                            runtimeCache.downstreamSha = resolvedSha;
+                            // Clear any previous error banner
+                            const banner = document.querySelector('.downstream-info');
+                            if (banner) banner.remove();
+                            // Re-render just the results table with merged data
+                            const resultsDiv = document.getElementById('result-container');
+                            const oldTable = resultsDiv.querySelector('table');
+                            const target = getTargetResults(nameParams);
+                            if (target) {
+                                const merged = [...(target.results || []), ...result.data];
+                                const newTable = createResultsTable(merged, 1);
+                                if (newTable && oldTable) {
+                                    oldTable.replaceWith(newTable);
+                                } else if (newTable) {
+                                    resultsDiv.appendChild(newTable);
                                 }
                             }
-                        });
-                    }
+                        }
+                    });
                 }
             }
         }

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -539,6 +539,12 @@
         const value = prompt('Downstream proxy base URL (leave empty to disable):', current);
         if (value === null) return; // cancelled
         if (value.trim()) {
+            try {
+                new URL(value.trim());
+            } catch {
+                alert('Invalid URL. Please enter a full URL starting with https://');
+                return;
+            }
             localStorage.setItem('privateBaseUrl', value.trim().replace(/\/+$/, ''));
         } else {
             localStorage.removeItem('privateBaseUrl');

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -245,6 +245,13 @@
             color: #FAFF69;
         }
 
+        tr.downstream-row {
+            background-color: color-mix(in srgb, var(--tile-background) 50%, #e0d8f0);
+        }
+        .night-theme tr.downstream-row {
+            background-color: color-mix(in srgb, var(--tile-background) 70%, #3a2d5c);
+        }
+
         .downstream-info {
             padding: 8px 16px;
             margin: 8px 0;
@@ -368,15 +375,15 @@
 <body>
     <div id="status-container"></div>
     <div id="result-container"></div>
-    <button id="toggle-status-bar">‖</button>
+    <button id="toggle-status-bar" title="Toggle sidebar">‖</button>
     <footer id="footer">
         <div class="left"></div>
         <div class="right"></div>
         <div class="settings">
             <span id="proxy-toggle" title="Configure downstream proxy URL">🔗</span>
-            <span id="status-filter-toggle"></span>
-            <span id="sort-toggle">🔼</span>
-            <span id="theme-toggle">🔆️</span>
+            <span id="status-filter-toggle" title="Filter by status"></span>
+            <span id="sort-toggle" title="Sort by status">🔼</span>
+            <span id="theme-toggle" title="Toggle day/night theme">🔆️</span>
         </div>
     </footer>
     <script>
@@ -1398,6 +1405,7 @@
 
         displayResults.forEach((result, _index) => {
             const row = document.createElement('tr');
+            if (result._downstreamHref) row.classList.add('downstream-row');
             const labels = result?.ext?.labels;
             const linklabels = result?.ext?.hlabels;
 

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -1809,9 +1809,13 @@
             resultsDiv.appendChild(textDiv);
         }
 
-        // Merge cached downstream results if available
+        // Merge cached downstream results if available and matching current SHA
         let resultsData = result.results;
-        if (nameParams.length === 1 && runtimeCache.downstreamResults) {
+        const resolvedSha = (sha === 'latest' && runtimeCache.commits)
+            ? runtimeCache.commits[runtimeCache.commits.length - 1]?.sha
+            : sha;
+        if (nameParams.length === 1 && runtimeCache.downstreamResults
+                && runtimeCache.downstreamSha === resolvedSha) {
             resultsData = [...resultsData, ...runtimeCache.downstreamResults];
         }
         if (Array.isArray(resultsData) && resultsData.length > 0) {
@@ -2127,9 +2131,15 @@
                 if (resolvedSha) {
                     fetchDownstreamData(resolvedSha, privateBaseUrl).then(result => {
                         if (result.error) {
+                            const hadDownstream = runtimeCache.downstreamResults !== null;
                             runtimeCache.downstreamResults = null;
                             runtimeCache.downstreamSha = null;
                             runtimeCache.downstreamError = result.error;
+                            // Re-render to clear stale downstream rows
+                            if (hadDownstream) {
+                                clearPage();
+                                renderResults(PR, sha, nameParams);
+                            }
                             showDownstreamInfo(result.error);
                         } else if (result.data && result.data.length > 0) {
                             runtimeCache.downstreamResults = result.data;

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -2109,31 +2109,26 @@
                         ? runtimeCache.commits[runtimeCache.commits.length - 1]?.sha
                         : sha)
                     : sha;
+                console.log(`Downstream: resolvedSha=${resolvedSha}, cachedSha=${runtimeCache.downstreamSha}`);
                 if (resolvedSha) {
                     const result = await fetchDownstreamData(resolvedSha, privateBaseUrl);
-                    // Stale response guard
-                    const currentSha = runtimeCache.commits
-                        ? runtimeCache.commits[runtimeCache.commits.length - 1]?.sha
-                        : sha;
-                    if (resolvedSha === currentSha) {
-                        if (result.error) {
-                            if (runtimeCache.downstreamResults !== null || runtimeCache.downstreamError !== result.error) {
-                                downstreamChanged = true;
-                            }
-                            runtimeCache.downstreamResults = null;
-                            runtimeCache.downstreamSha = null;
-                            runtimeCache.downstreamError = result.error;
-                        } else if (result.data && result.data.length > 0) {
-                            downstreamChanged = runtimeCache.downstreamSha !== resolvedSha
-                                || JSON.stringify(runtimeCache.downstreamResults?.map(r => r.status))
-                                   !== JSON.stringify(result.data.map(r => r.status));
-                            runtimeCache.downstreamResults = result.data;
-                            runtimeCache.downstreamSha = resolvedSha;
-                            runtimeCache.downstreamError = null;
+                    console.log(`Downstream fetch: error=${result.error}, dataLen=${result.data?.length}`);
+                    if (result.error) {
+                        if (runtimeCache.downstreamResults !== null || runtimeCache.downstreamError !== result.error) {
+                            downstreamChanged = true;
                         }
+                        runtimeCache.downstreamResults = null;
+                        runtimeCache.downstreamSha = null;
+                        runtimeCache.downstreamError = result.error;
+                    } else if (result.data && result.data.length > 0) {
+                        downstreamChanged = true;
+                        runtimeCache.downstreamResults = result.data;
+                        runtimeCache.downstreamSha = resolvedSha;
+                        runtimeCache.downstreamError = null;
                     }
                 }
             }
+            console.log(`Render decision: fetchResult=${fetchResult}, downstreamChanged=${downstreamChanged}, cachedDownstream=${runtimeCache.downstreamResults?.length}`);
 
             // Single render pass with both upstream and downstream data
             if (fetchResult || downstreamChanged) {


### PR DESCRIPTION
The CI report page (`json.html`) can now display results from a downstream sync
repository alongside the public CI results. When a proxy URL is configured (via
the footer link icon or `?proxy=` URL param), the page fetches sync metadata and
merges downstream results into the same table. Downstream rows are visually
distinguished by a different background color and a link emoji prefix.

Also includes minor UI improvements:
- Sort by status: running now ranks above pending, secondary sort by name
- Compact time trace widget (1px lines)
- Yellow file links in dark theme
- Tooltips on all footer toggles

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.893`
<!-- ch-version-info:end -->