### PR TITLE
Add timeout to SYSTEM STOP DISTRIBUTED SENDS in stop_server

### DIFF
--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -225,7 +225,7 @@ function stop_server()
     #
     # Refs: https://github.com/ClickHouse/ClickHouse/issues/72557
     for i in {1..30}; do
-        if clickhouse client -q "SYSTEM STOP DISTRIBUTED SENDS"; then
+        if clickhouse client --receive_timeout=10 -q "SYSTEM STOP DISTRIBUTED SENDS"; then
             break
         fi
     done


### PR DESCRIPTION
The `stop_server` function in `stress_tests.lib` retries `SYSTEM STOP DISTRIBUTED SENDS` up to 30 times before calling `clickhouse stop`. When the server is unresponsive (e.g. after a stress test under TSan), each attempt waits for the default `receive_timeout` of 300 seconds. This means the loop burns 30 × 300 = 9000 seconds (2.5 hours) before proceeding to actually stop the server, consuming the entire CI job timeout and preventing any diagnostics (gdb stack traces, log collection, etc.).

Add `--receive_timeout=10` so each attempt fails within 10 seconds when the server is unresponsive. Worst case the loop now takes 300 seconds instead of 9000.

Found in: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=102011&sha=8ed7fb8bcfdac4af8d2a062200b104281178981b&name_0=PR&name_1=Stress%20test%20%28arm_tsan%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.734`
<!-- ch-version-info:end -->