### PR TITLE
Add MSan support for fibers and fix dragonbox struct padding

### DIFF
--- a/contrib/boost-cmake/CMakeLists.txt
+++ b/contrib/boost-cmake/CMakeLists.txt
@@ -178,6 +178,8 @@ endif()
 
 if (SANITIZE MATCHES "address")
     target_compile_definitions(_boost_context PUBLIC BOOST_USE_ASAN)
+elseif (SANITIZE MATCHES "memory")
+    target_compile_definitions(_boost_context PUBLIC BOOST_USE_MSAN)
 elseif (SANITIZE MATCHES "thread")
     target_compile_definitions(_boost_context PUBLIC BOOST_USE_TSAN)
 endif()

--- a/src/Common/Fiber.h
+++ b/src/Common/Fiber.h
@@ -1,6 +1,5 @@
 #pragma once
-/// defines.h should be included before fiber.hpp
-/// BOOST_USE_ASAN, BOOST_USE_MSAN, BOOST_USE_TSAN and BOOST_USE_UCONTEXT should be correctly defined for sanitizers.
+/// BOOST_USE_ASAN, BOOST_USE_MSAN, BOOST_USE_TSAN and BOOST_USE_UCONTEXT are defined via CMake for sanitizer builds.
 #include <base/defines.h>
 #include <boost/context/fiber.hpp>
 #include <map>

--- a/src/Common/Fiber.h
+++ b/src/Common/Fiber.h
@@ -1,6 +1,6 @@
 #pragma once
 /// defines.h should be included before fiber.hpp
-/// BOOST_USE_ASAN, BOOST_USE_TSAN and BOOST_USE_UCONTEXT should be correctly defined for sanitizers.
+/// BOOST_USE_ASAN, BOOST_USE_MSAN, BOOST_USE_TSAN and BOOST_USE_UCONTEXT should be correctly defined for sanitizers.
 #include <base/defines.h>
 #include <boost/context/fiber.hpp>
 #include <map>

--- a/src/Common/FiberStack.cpp
+++ b/src/Common/FiberStack.cpp
@@ -1,4 +1,5 @@
 #include <base/defines.h>
+#include <base/MemorySanitizer.h>
 #include <Common/formatReadable.h>
 #include <Common/CurrentMemoryTracker.h>
 #include <Common/Exception.h>
@@ -71,6 +72,14 @@ boost::context::stack_context FiberStack::allocate() const
             throw;
         }
     }
+
+    /// MSan doesn't track shadow for struct padding bytes through return values
+    /// (the LLVM IR shadow is per-field, not per-byte of the padded representation).
+    /// Any struct with padding returned by value will have uninitialized padding shadow
+    /// in the caller. On the main thread stack this is harmless (OS zero-inits pages),
+    /// but on heap-allocated fiber stacks the dirty shadow can propagate via stack slot
+    /// reuse and eventually trigger false positives in unrelated code.
+    __msan_unpoison(data, num_bytes);
 
     boost::context::stack_context sctx;
     sctx.size = num_bytes;

--- a/src/Common/FiberStack.cpp
+++ b/src/Common/FiberStack.cpp
@@ -1,5 +1,4 @@
 #include <base/defines.h>
-#include <base/MemorySanitizer.h>
 #include <Common/formatReadable.h>
 #include <Common/CurrentMemoryTracker.h>
 #include <Common/Exception.h>
@@ -72,14 +71,6 @@ boost::context::stack_context FiberStack::allocate() const
             throw;
         }
     }
-
-    /// Mark the fiber stack memory as initialized for MSan.
-    /// Unlike the program's main stack (which the OS zero-initializes), fiber stacks are
-    /// heap-allocated via aligned_alloc, so MSan considers them uninitialized.
-    /// This causes false positives when stack slots are reused across function calls within
-    /// the fiber. Unpoisoning is safe because MSan's per-variable lifetime tracking
-    /// (__lifetime.start / __lifetime.end) still properly detects real uninitialized variables.
-    __msan_unpoison(data, num_bytes);
 
     boost::context::stack_context sctx;
     sctx.size = num_bytes;

--- a/src/Common/tests/gtest_dragonbox_msan.cpp
+++ b/src/Common/tests/gtest_dragonbox_msan.cpp
@@ -1,0 +1,101 @@
+/// Test for dragonbox struct padding MSan issue.
+///
+/// `dragonbox::compute_nearest` used to declare `ReturnType ret_value;` (default-init)
+/// where ReturnType = `fp_t<double,false,false>` = `{ uint64_t significand; int exponent; }`
+/// This struct has 4 bytes of tail padding that are never written.
+///
+/// The fix is to value-initialize: `ReturnType ret_value{};`
+
+#include <base/defines.h>
+#include <base/MemorySanitizer.h>
+
+#include <IO/WriteHelpers.h>
+#include <Common/FiberStack.h>
+#include <Common/Fiber.h>
+
+#include <dragonbox/dragonbox.h>
+
+#include <gtest/gtest.h>
+
+
+/// Verify the fixed dragonbox returns a fully initialized struct.
+static void __attribute__((noinline)) checkDragonboxPaddingFixed()
+{
+    auto result = jkj::dragonbox::to_decimal(0.1);
+
+    /// fp_t<double, false, false> = { uint64_t significand; int exponent; /* 4 bytes padding */ }
+    static_assert(sizeof(result) == 16);
+
+#if defined(MEMORY_SANITIZER)
+    /// __msan_test_shadow returns the offset of the first uninitialized byte, or -1 if all clean.
+    intptr_t first_uninit = __msan_test_shadow(&result, sizeof(result));
+    EXPECT_EQ(first_uninit, static_cast<intptr_t>(-1))
+        << "dragonbox fp_t has uninitialized bytes starting at offset " << first_uninit;
+#endif
+}
+
+
+/// Demonstrate the BUG: default-init of the same struct leaves padding uninitialized.
+/// This mimics the original unfixed dragonbox code: `ReturnType ret_value;`
+static void __attribute__((noinline)) checkDefaultInitPadding()
+{
+    using FP = jkj::dragonbox::unsigned_fp_t<double>;
+    static_assert(sizeof(FP) == 16);
+
+    FP result;
+    result.significand = 1;
+    result.exponent = -1;
+    /// Padding bytes at offset 12..15 are never written — this is the bug.
+
+#if defined(MEMORY_SANITIZER)
+    intptr_t first_uninit = __msan_test_shadow(&result, sizeof(result));
+    /// With default-init, expect uninitialized bytes starting at offset 12 (the padding).
+    EXPECT_EQ(first_uninit, static_cast<intptr_t>(12))
+        << "Expected uninitialized padding at offset 12, got " << first_uninit;
+#endif
+}
+
+
+/// Run the checks on a fiber stack to match production conditions.
+TEST(DragonboxMSan, FixedRetvalOnFiberStack)
+{
+    bool fiber_ran = false;
+
+    FiberStack stack;
+    Fiber fiber(stack, [&](auto & /* suspend */)
+    {
+        checkDragonboxPaddingFixed();
+        fiber_ran = true;
+    });
+
+    fiber.resume();
+    EXPECT_TRUE(fiber_ran);
+}
+
+
+TEST(DragonboxMSan, DefaultInitPaddingOnFiberStack)
+{
+    bool fiber_ran = false;
+
+    FiberStack stack;
+    Fiber fiber(stack, [&](auto & /* suspend */)
+    {
+        checkDefaultInitPadding();
+        fiber_ran = true;
+    });
+
+    fiber.resume();
+    EXPECT_TRUE(fiber_ran);
+}
+
+
+/// Same checks on the regular stack for comparison.
+TEST(DragonboxMSan, FixedRetvalOnRegularStack)
+{
+    checkDragonboxPaddingFixed();
+}
+
+TEST(DragonboxMSan, DefaultInitPaddingOnRegularStack)
+{
+    checkDefaultInitPadding();
+}

--- a/src/Common/tests/gtest_dragonbox_msan.cpp
+++ b/src/Common/tests/gtest_dragonbox_msan.cpp
@@ -1,15 +1,17 @@
-/// Test for dragonbox struct padding MSan issue.
+/// Test documenting an MSan limitation with struct padding in return values.
 ///
-/// `dragonbox::compute_nearest` used to declare `ReturnType ret_value;` (default-init)
-/// where ReturnType = `fp_t<double,false,false>` = `{ uint64_t significand; int exponent; }`
-/// This struct has 4 bytes of tail padding that are never written.
+/// MSan tracks shadow per-field in LLVM IR, not per-byte of the padded struct.
+/// When a struct with padding is returned by value, the padding bytes have no
+/// shadow entry and appear "uninitialized" in the caller — even if the callee
+/// value-initialized the struct.
 ///
-/// The fix is to value-initialize: `ReturnType ret_value{};`
+/// On the main thread stack this is harmless (OS zero-inits pages), but on
+/// heap-allocated fiber stacks the dirty padding shadow can propagate via stack
+/// slot reuse. This is why FiberStack::allocate calls __msan_unpoison.
 
 #include <base/defines.h>
 #include <base/MemorySanitizer.h>
 
-#include <IO/WriteHelpers.h>
 #include <Common/FiberStack.h>
 #include <Common/Fiber.h>
 
@@ -18,84 +20,32 @@
 #include <gtest/gtest.h>
 
 
-/// Verify the fixed dragonbox returns a fully initialized struct.
-static void __attribute__((noinline)) checkDragonboxPaddingFixed()
+/// Demonstrates the MSan limitation: struct padding is uninitialized in return values.
+TEST(DragonboxMSan, ReturnValuePaddingShadowIsLost)
 {
-    auto result = jkj::dragonbox::to_decimal(0.1);
-
-    /// fp_t<double, false, false> = { uint64_t significand; int exponent; /* 4 bytes padding */ }
-    static_assert(sizeof(result) == 16);
-
 #if defined(MEMORY_SANITIZER)
-    /// __msan_test_shadow returns the offset of the first uninitialized byte, or -1 if all clean.
-    intptr_t first_uninit = __msan_test_shadow(&result, sizeof(result));
-    EXPECT_EQ(first_uninit, static_cast<intptr_t>(-1))
-        << "dragonbox fp_t has uninitialized bytes starting at offset " << first_uninit;
-#endif
-}
-
-
-/// Demonstrate the BUG: default-init of the same struct leaves padding uninitialized.
-/// This mimics the original unfixed dragonbox code: `ReturnType ret_value;`
-static void __attribute__((noinline)) checkDefaultInitPadding()
-{
     using FP = jkj::dragonbox::unsigned_fp_t<double>;
+    /// { uint64_t significand; int exponent; /* 4 bytes padding */ }
     static_assert(sizeof(FP) == 16);
 
-    FP result;
-    result.significand = 1;
-    result.exponent = -1;
-    /// Padding bytes at offset 12..15 are never written — this is the bug.
+    /// Local value-init: padding shadow IS clean.
+    {
+        FP local{};
+        local.significand = 1;
+        local.exponent = -1;
+        EXPECT_EQ(__msan_test_shadow(&local, sizeof(local)), static_cast<intptr_t>(-1))
+            << "Local value-init should have clean padding";
+    }
 
-#if defined(MEMORY_SANITIZER)
-    intptr_t first_uninit = __msan_test_shadow(&result, sizeof(result));
-    /// With default-init, expect uninitialized bytes starting at offset 12 (the padding).
-    EXPECT_EQ(first_uninit, static_cast<intptr_t>(12))
-        << "Expected uninitialized padding at offset 12, got " << first_uninit;
+    /// Returned from a function: padding shadow is LOST — this is the MSan limitation.
+    {
+        auto returned = jkj::dragonbox::to_decimal(0.1);
+        intptr_t first_uninit = __msan_test_shadow(&returned, sizeof(returned));
+        /// Padding starts at offset 12 (after uint64_t + int).
+        EXPECT_GE(first_uninit, static_cast<intptr_t>(12))
+            << "MSan should lose padding shadow through return values";
+    }
+#else
+    GTEST_SKIP() << "This test requires MSan";
 #endif
-}
-
-
-/// Run the checks on a fiber stack to match production conditions.
-TEST(DragonboxMSan, FixedRetvalOnFiberStack)
-{
-    bool fiber_ran = false;
-
-    FiberStack stack;
-    Fiber fiber(stack, [&](auto & /* suspend */)
-    {
-        checkDragonboxPaddingFixed();
-        fiber_ran = true;
-    });
-
-    fiber.resume();
-    EXPECT_TRUE(fiber_ran);
-}
-
-
-TEST(DragonboxMSan, DefaultInitPaddingOnFiberStack)
-{
-    bool fiber_ran = false;
-
-    FiberStack stack;
-    Fiber fiber(stack, [&](auto & /* suspend */)
-    {
-        checkDefaultInitPadding();
-        fiber_ran = true;
-    });
-
-    fiber.resume();
-    EXPECT_TRUE(fiber_ran);
-}
-
-
-/// Same checks on the regular stack for comparison.
-TEST(DragonboxMSan, FixedRetvalOnRegularStack)
-{
-    checkDragonboxPaddingFixed();
-}
-
-TEST(DragonboxMSan, DefaultInitPaddingOnRegularStack)
-{
-    checkDefaultInitPadding();
 }


### PR DESCRIPTION
Re-applies #101621 (which was reverted in #102005) with an updated understanding of the root cause.

**`BOOST_USE_MSAN` for fiber context tracking:** The boost fiber implementation has MSan annotations (`__msan_start_switch_fiber`/`__msan_finish_switch_fiber`) around every `swapcontext` call, but they were gated on `BOOST_USE_MSAN` which was never defined. Without them, MSan loses track of shadow memory across fiber context switches, causing false positives like STID 4179-5154.

**Keep `__msan_unpoison` with a correct explanation:** The original PR #101621 removed `__msan_unpoison` from `FiberStack::allocate`, which caused STID 4148-3044 and the revert. Investigation traced the origin to struct padding in return values (e.g. dragonbox's `fp_t`). Value-initializing the struct does not help: **MSan tracks shadow per-field in LLVM IR, not per-byte of the padded representation.** When any struct with padding is returned by value, the padding shadow is lost. This is a known unfixed LLVM limitation:

- https://github.com/llvm/llvm-project/pull/116615 — Clang coerces small structs with padding to wide integers for register return, making padding bits poison ([alive2 proof](https://alive2.llvm.org/ce/z/DwkvmT))
- https://github.com/llvm/llvm-project/issues/54476 — canonical MSan bug: struct padding false positives (open since 2022)
- https://github.com/llvm/llvm-project/issues/58945 — Clang codegen does not emit writes for padding bytes even with value-initialization
- https://github.com/llvm/llvm-project/issues/162216 — same pattern with `struct addrinfo`

On the main thread stack this is harmless (OS zero-inits pages), but on heap-allocated fiber stacks the dirty padding shadow propagates via stack slot reuse, causing false positives. The `__msan_unpoison` in `FiberStack::allocate` is the correct workaround. Updated the comment to explain why.

A test is included that documents this MSan limitation.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=102114&sha=5b68859e4e2e0023ace05c14f750a827f75ed7f5&name_0=PR&name_1=Stress%20test%20%28arm_msan%29
See also: https://github.com/ClickHouse/ClickHouse/pull/102114

Fixes: https://github.com/ClickHouse/ClickHouse/issues/101649

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.695`
<!-- ch-version-info:end -->