### PR TITLE
Add missing `hostname` column to `DeltaMetadataLog` and `IcebergMetadataLog`

### DIFF
--- a/src/Interpreters/DeltaMetadataLog.cpp
+++ b/src/Interpreters/DeltaMetadataLog.cpp
@@ -25,6 +25,8 @@
 #include <Common/DateLUTImpl.h>
 #include <Common/typeid_cast.h>
 #include <Common/ErrnoException.h>
+#include <base/getFQDNOrHostName.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 
 namespace DB
 {
@@ -50,6 +52,7 @@ const DataTypePtr rowType = makeNullable(std::make_shared<DataTypeUInt64>());
 ColumnsDescription DeltaMetadataLogElement::getColumnsDescription()
 {
     return ColumnsDescription{
+        {"hostname", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "Hostname of the server executing the query."},
         {"event_date", std::make_shared<DataTypeDate>(), "Date of the entry."},
         {"event_time", std::make_shared<DataTypeDateTime>(), "Event time."},
         {"query_id", std::make_shared<DataTypeString>(), "Query id."},
@@ -61,6 +64,7 @@ ColumnsDescription DeltaMetadataLogElement::getColumnsDescription()
 void DeltaMetadataLogElement::appendToBlock(MutableColumns & columns) const
 {
     size_t column_index = 0;
+    columns[column_index++]->insert(getFQDNOrHostName());
     columns[column_index++]->insert(DateLUT::instance().toDayNum(current_time).toUnderType());
     columns[column_index++]->insert(current_time);
     columns[column_index++]->insert(query_id);

--- a/src/Interpreters/IcebergMetadataLog.cpp
+++ b/src/Interpreters/IcebergMetadataLog.cpp
@@ -14,6 +14,8 @@
 #include <Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h>
 #include <Common/DateLUTImpl.h>
 #include <Common/ErrnoException.h>
+#include <base/getFQDNOrHostName.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 
 namespace DB
 {
@@ -53,6 +55,7 @@ ColumnsDescription IcebergMetadataLogElement::getColumnsDescription()
         {"ManifestFileEntry", static_cast<Int8>(IcebergMetadataLogLevel::ManifestFileEntry)}});
 
     return ColumnsDescription{
+        {"hostname", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "Hostname of the server executing the query."},
         {"event_date", std::make_shared<DataTypeDate>(), "Date of the entry."},
         {"event_time", std::make_shared<DataTypeDateTime>(), "Event time."},
         {"query_id", std::make_shared<DataTypeString>(), "Query id."},
@@ -67,6 +70,7 @@ ColumnsDescription IcebergMetadataLogElement::getColumnsDescription()
 void IcebergMetadataLogElement::appendToBlock(MutableColumns & columns) const
 {
     size_t column_index = 0;
+    columns[column_index++]->insert(getFQDNOrHostName());
     columns[column_index++]->insert(DateLUT::instance().toDayNum(current_time).toUnderType());
     columns[column_index++]->insert(current_time);
     columns[column_index++]->insert(query_id);

--- a/tests/queries/0_stateless/04092_delta_iceberg_metadata_log_hostname.reference
+++ b/tests/queries/0_stateless/04092_delta_iceberg_metadata_log_hostname.reference
@@ -1,0 +1,2 @@
+hostname	LowCardinality(String)
+hostname	LowCardinality(String)

--- a/tests/queries/0_stateless/04092_delta_iceberg_metadata_log_hostname.sql
+++ b/tests/queries/0_stateless/04092_delta_iceberg_metadata_log_hostname.sql
@@ -1,0 +1,12 @@
+-- Verify that system.delta_lake_metadata_log and system.iceberg_metadata_log
+-- have the hostname column as the first column with type LowCardinality(String).
+
+SELECT name, type FROM system.columns
+WHERE table = 'delta_lake_metadata_log' AND database = 'system' AND name = 'hostname';
+
+SELECT name, type FROM system.columns
+WHERE table = 'iceberg_metadata_log' AND database = 'system' AND name = 'hostname';
+
+-- Verify SELECT hostname does not throw UNKNOWN_IDENTIFIER
+SELECT hostname FROM system.delta_lake_metadata_log LIMIT 0;
+SELECT hostname FROM system.iceberg_metadata_log LIMIT 0;


### PR DESCRIPTION
`system.delta_lake_metadata_log` and `system.iceberg_metadata_log` are the only two `SystemLog`-derived tables that don't have a `hostname` column. Every other system log table (25+) includes it.

The `SystemLog` base class does not inject `hostname` automatically -- each `LogElement` subclass must declare it in `getColumnsDescription` and write it in `appendToBlock`. Both tables were introduced in 25.10 (#86152 and #87263) by copying from each other but neither included it.

This is the same class of bug that was previously fixed for `blob_storage_log` in #62456. The original bulk addition of `hostname` to all system log tables was #55894.

Any tooling that queries `SELECT hostname FROM system.<table>` across all system log tables will get `UNKNOWN_IDENTIFIER` errors on these two tables. The tables are always created by the `SystemLog` infrastructure regardless of whether the `delta_lake_log_metadata` / `iceberg_log_metadata` settings are enabled.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md): Add missing `hostname` column to `system.delta_lake_metadata_log` and `system.iceberg_metadata_log`. These were the only system log tables without it, causing `UNKNOWN_IDENTIFIER` errors when querying the column.

### Documentation entry for user-facing changes

- [x] Documentation is not required (no user-facing changes beyond the bug fix)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.700`
<!-- ch-version-info:end -->