### PR TITLE
Fix flaky test `test_kafka_commit_on_block_write`

### DIFF
--- a/tests/integration/test_storage_kafka/test_batch_fast.py
+++ b/tests/integration/test_storage_kafka/test_batch_fast.py
@@ -1579,27 +1579,56 @@ def test_kafka_commit_on_block_write(kafka_cluster, create_query_generator):
         check_callback=lambda res: int(res) >= 100,
     )
 
+    # Stop the producer and wait for it to finish.
+    # This finalizes i[0] to the exact number of produced messages.
     cancel.set()
-
-    instance.query(f"DROP TABLE test.{kafka_table} SYNC")
-
-    instance.query(create_query)
     kafka_thread.join()
 
+    # Wait for ALL produced messages to be consumed.
     instance.query_with_retry(
         f"SELECT uniqExact(key) FROM test.{kafka_table}_view",
         sleep_time=1,
+        retry_count=60,
         check_callback=lambda res: int(res) >= i[0],
     )
 
-    result = int(instance.query(f"SELECT count() == uniqExact(key) FROM test.{kafka_table}_view"))
+    # Wait for the streaming cycle to complete and commit offsets.
+    # "Stream(s) stalled. Rescheduling" is logged by threadFunc AFTER
+    # streamToViews returns (which includes the offset commit).
+    stalled_re_count = int(
+        instance.count_in_log(f"{kafka_table}.*stalled.*Rescheduling").strip()
+    )
+    instance.wait_for_log_line(
+        f"{kafka_table}.*stalled.*Rescheduling",
+        timeout=60,
+        repetitions=stalled_re_count + 1,
+    )
+
+    # Now offsets are committed. Drop and recreate the table.
+    instance.query(f"DROP TABLE test.{kafka_table} SYNC")
+    instance.query(create_query)
+
+    # Wait for the recreated consumer to poll and find no new messages.
+    stalled_re_count2 = int(
+        instance.count_in_log(f"{kafka_table}.*stalled.*Rescheduling").strip()
+    )
+    instance.wait_for_log_line(
+        f"{kafka_table}.*stalled.*Rescheduling",
+        timeout=60,
+        repetitions=stalled_re_count2 + 1,
+    )
+
+    # Verify no duplicates.
+    result = int(
+        instance.query(
+            f"SELECT count() == uniqExact(key) FROM test.{kafka_table}_view"
+        )
+    )
 
     instance.query(f"""
         DROP TABLE test.{kafka_table}_consumer;
         DROP TABLE test.{kafka_table}_view;
     """)
-
-    kafka_thread.join()
 
     assert result == 1, "Messages from kafka get duplicated!"
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Details:

The test was made flaky by c964e8ef07b which added pipeline cancellation during `DROP TABLE` and skips offset commits when `shutdown_called` is set. Under TSan, the pipeline is slower, so `DROP TABLE SYNC` frequently cancels the pipeline before the offset commit, causing messages to be re-consumed after table recreation.

Fix by ensuring all messages are consumed and offsets committed before dropping:

1. Join the producer thread before `DROP TABLE` (finalizes message count and eliminates race on `i[0]`).
2. Wait for all produced messages to appear in the view.
3. Wait for the streaming cycle to complete (confirmed by the `"stalled.*Rescheduling"` log line, which is emitted after `streamToViews` returns including the offset commit).
4. After drop/recreate, wait for the new consumer to poll and stall, confirming it had a chance to re-consume (if offsets were wrong).
5. Remove redundant second `kafka_thread.join`.

closes https://github.com/ClickHouse/ClickHouse/issues/101463
