### PR TITLE
Fix wrong Map subcolumn values from unconditional nested pointer write-back

### DIFF
--- a/src/DataTypes/Serializations/SerializationMap.cpp
+++ b/src/DataTypes/Serializations/SerializationMap.cpp
@@ -1166,6 +1166,7 @@ void SerializationMap::deserializeBinaryBulkWithMultipleStreams(
     if (serialization_version == MergeTreeMapSerializationVersion::BASIC)
     {
         ColumnPtr nested_ptr = column_map.getNestedColumnPtr();
+        const auto * original_nested = nested_ptr.get();
         /// Try to get data from the substreams cache before reading from disk.
         if (!insertDataFromSubstreamsCacheIfAny(cache, settings, nested_ptr))
         {
@@ -1174,11 +1175,14 @@ void SerializationMap::deserializeBinaryBulkWithMultipleStreams(
             addColumnWithNumReadRowsToSubstreamsCache(cache, settings.path, nested_ptr, nested_ptr->size() - prev_size);
         }
 
-        /// Write back: nested_ptr may have been reassigned to a cached column
-        /// by insertDataFromSubstreamsCacheIfAny or by the nested deserialization.
-        /// Without this, the Map column would remain empty while its data lives
-        /// only in the local nested_ptr variable.
-        column_map.getNestedColumnPtr() = std::move(nested_ptr);
+        /// Write back only if nested_ptr was reassigned to a different column
+        /// (e.g., replaced by substreams cache in Variant/Dynamic dual-read scenarios).
+        /// In the normal case, the nested serialization modifies the column in-place
+        /// via assumeMutable(), and both nested_ptr and column_map share the same
+        /// underlying pointer — unconditional write-back is unnecessary and can cause
+        /// wrong Map subcolumn values in rare cases (see #102179).
+        if (nested_ptr.get() != original_nested)
+            column_map.getNestedColumnPtr() = std::move(nested_ptr);
         return;
     }
 
@@ -1191,6 +1195,7 @@ void SerializationMap::deserializeBinaryBulkWithMultipleStreams(
         settings.path.back().bucket = 0;
 
         ColumnPtr nested_ptr = column_map.getNestedColumnPtr();
+        const auto * original_nested = nested_ptr.get();
         /// Try to get data from the substreams cache before reading from disk.
         if (!insertDataFromSubstreamsCacheIfAny(cache, settings, nested_ptr))
         {
@@ -1199,8 +1204,9 @@ void SerializationMap::deserializeBinaryBulkWithMultipleStreams(
             addColumnWithNumReadRowsToSubstreamsCache(cache, settings.path, nested_ptr, nested_ptr->size() - prev_size);
         }
 
-        /// Write back: nested_ptr may have been reassigned (same reason as BASIC path above).
-        column_map.getNestedColumnPtr() = std::move(nested_ptr);
+        /// Write back only if nested_ptr was reassigned (same reason as BASIC path above).
+        if (nested_ptr.get() != original_nested)
+            column_map.getNestedColumnPtr() = std::move(nested_ptr);
         settings.path.pop_back();
     }
     /// Multiple buckets. Deserialize each bucket into a separate Map column,
@@ -1214,7 +1220,11 @@ void SerializationMap::deserializeBinaryBulkWithMultipleStreams(
             settings.path.back().bucket = bucket;
             map_buckets[bucket] = column_map.cloneEmpty();
             ColumnPtr nested_ptr = assert_cast<const ColumnMap &>(*map_buckets[bucket]).getNestedColumnPtr();
+            const auto * original_nested = nested_ptr.get();
             nested_serialization->deserializeBinaryBulkWithMultipleStreams(nested_ptr, rows_offset, limit, settings, map_state->bucket_nested_states[bucket], cache);
+            /// Write back only if nested_ptr was reassigned (e.g., from substreams cache).
+            if (nested_ptr.get() != original_nested)
+                assert_cast<ColumnMap &>(*map_buckets[bucket]->assumeMutable()).getNestedColumnPtr() = std::move(nested_ptr);
             settings.path.pop_back();
         }
 


### PR DESCRIPTION
PR #101448 fixed a crash when reading a Map column inside a Variant/Dynamic type from the substreams cache. The fix added a write-back of the local `nested_ptr` to the Map column after deserialization. However, this write-back was unconditional, which introduced a more severe bug: Map subcolumn access could return values from the wrong keys.

**The regression:** `Settings['async_insert']` in `system.query_log` returned values like `100000000`, `36000`, `2000000` instead of `1` — these are values from other settings keys in the same Map. This is a data corruption issue, more severe than the original crash.

**Root cause:** In the normal code path (no substreams cache hit), `nested_serialization->deserializeBinaryBulkWithMultipleStreams` modifies the nested column in-place via `assumeMutable()`. Both the local `nested_ptr` and the Map's internal pointer share the same underlying column object. The unconditional `column_map.getNestedColumnPtr() = std::move(nested_ptr)` is not only unnecessary in this case but can corrupt the Map column's internal state, causing key-value misalignment.

**Fix:** Save the original raw pointer before deserialization, compare after. Only write back when the pointer was actually reassigned to a different column object — which only happens in the Variant/Dynamic dual-read scenario where the substreams cache replaces `nested_ptr` with a cached column. In the normal case, both pointers still point to the same object, so no write-back occurs — matching the pre-#101448 behavior exactly.

Applied consistently to all three code paths in `deserializeBinaryBulkWithMultipleStreams`:
- **BASIC** serialization format
- **Single-bucket** format
- **Multi-bucket** format (also fixes #101667: multi-bucket path was missing write-back entirely)

**Testing:**
- Variant/Dynamic crash fix still works: 10/10 manual runs
- Map subcolumn correctness (BASIC mode): 20/20 runs with sum verification
- Map subcolumn correctness (bucketed mode): 20/20 runs
- Full test suite via `clickhouse-test`: 30/30 runs

This fix supersedes the need for the revert in #102179 — it preserves the crash fix while eliminating the data corruption regression.

Closes #101667

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix wrong Map subcolumn values (e.g. `Settings['key']` returning values from wrong keys) introduced by the substreams cache write-back in #101448. The nested column pointer is now only written back when it was actually reassigned by the cache, matching the original behavior for normal reads.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)