### PR TITLE
Add DNS_ERROR to upgrade check ignored errors

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -329,6 +329,7 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "RaftInstance: failed to accept a rpc connection due to error 125" \
            -e "UNKNOWN_DATABASE" \
            -e "NETWORK_ERROR" \
+           -e "DNS_ERROR" \
            -e "UNKNOWN_TABLE" \
            -e "ZooKeeperClient" \
            -e "KEEPER_EXCEPTION" \


### PR DESCRIPTION
Transient DNS resolution failures (e.g. for Azure Blob Storage hosts like `openbucketforpublicci.blob.core.windows.net`) are the same class of network issue as the already-ignored `NETWORK_ERROR` and `Connection refused` patterns in the upgrade check. Without this, flaky DNS in CI causes spurious upgrade check failures.

Example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=102162&sha=e82cf187c7c5dd7b4acbc89006206c76188a8dd2&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is not required (no user-facing changes)