### PR TITLE
Fix TPC-H Q11 fraction parameter for SF=10 performance test

### DIFF
--- a/tests/benchmarks/tpc-h/README.md
+++ b/tests/benchmarks/tpc-h/README.md
@@ -1,7 +1,7 @@
 # Notes
 
 ## Q11
-The `FRACTION` parameter in the `HAVING` clause is defined as `0.0001 / SF` (spec section 2.4.11.3). The current query uses `0.0001`, which is correct for SF = 1. For other scale factors, adjust accordingly, e.g. `0.00001` for SF = 10, `0.000001` for SF = 100.
+The `FRACTION` parameter in the `HAVING` clause is defined as `0.0001 / SF` (spec section 2.4.11.3). `query_11.sql` uses `0.0001` (SF = 1), `query_11_sf10.sql` uses `0.00001` (SF = 10). For other scale factors, adjust accordingly.
 
 # List of known problems
 ## Q6

--- a/tests/benchmarks/tpc-h/queries/query_11_sf10.sql
+++ b/tests/benchmarks/tpc-h/queries/query_11_sf10.sql
@@ -1,5 +1,5 @@
 -- The FRACTION parameter in the HAVING clause is 0.0001 / SF (spec section 2.4.11.3).
--- Current value 0.0001 is for SF = 1. See query_11_sf10.sql for the SF = 10 variant.
+-- Current value 0.00001 is for SF = 10. See query_11.sql for the SF = 1 variant.
 
 SELECT
     ps_partkey,
@@ -10,7 +10,7 @@ WHERE (ps_suppkey = s_suppkey)
     AND (n_name = 'GERMANY')
 GROUP BY ps_partkey
 HAVING sum(ps_supplycost * ps_availqty) > (
-    SELECT sum(ps_supplycost * ps_availqty) * 0.0001
+    SELECT sum(ps_supplycost * ps_availqty) * 0.00001
     FROM partsupp, supplier, nation
     WHERE (ps_suppkey = s_suppkey)
         AND (s_nationkey = n_nationkey)

--- a/tests/performance/tpch.xml
+++ b/tests/performance/tpch.xml
@@ -25,7 +25,7 @@
 <!-- Q8 -->  <query file="../benchmarks/tpc-h/queries/query_08.sql"/>
 <!-- Q9 -->  <query file="../benchmarks/tpc-h/queries/query_09.sql"/>
 <!-- Q10 --> <query file="../benchmarks/tpc-h/queries/query_10.sql"/>
-<!-- Q11 --> <query file="../benchmarks/tpc-h/queries/query_11.sql"/>
+<!-- Q11 --> <query file="../benchmarks/tpc-h/queries/query_11_sf10.sql"/>
 <!-- Q12 --> <query file="../benchmarks/tpc-h/queries/query_12.sql"/>
 <!-- Q13 --> <query file="../benchmarks/tpc-h/queries/query_13.sql"/>
 <!-- Q14 --> <query file="../benchmarks/tpc-h/queries/query_14.sql"/>


### PR DESCRIPTION
Q11's `HAVING` clause uses a scale-factor-dependent threshold `0.0001 / SF` ([TPC-H spec section 2.4.11.3](https://www.tpc.org/TPC_Documents_Current_Versions/pdf/TPC-H_v3.0.1.pdf)). The performance test runs on SF=10 but was using `0.0001` (correct for SF=1). This PR adds `query_11_sf10.sql` with the correct value `0.00001` and points `tpch.xml` at it. The original `query_11.sql` (SF=1) stays untouched for correctness tests.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix TPC-H Q11 fraction parameter in performance test to match SF=10.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.789`
<!-- ch-version-info:end -->