### PR TITLE
Fix flaky test `03640_skip_indexes_with_or_and_not`

### DIFF
--- a/tests/queries/0_stateless/03640_skip_indexes_with_or_and_not.sql
+++ b/tests/queries/0_stateless/03640_skip_indexes_with_or_and_not.sql
@@ -25,7 +25,7 @@ INSERT INTO tab VALUES
   (5, {'key1':'1'}, {'key3':'3'}),
   (6, {'key1':'1'}, {'key1':'1'});
 
-SELECT *
+SELECT id, mapSort(map1), mapSort(map2)
 FROM tab
 WHERE (mapContains(map1, 'key2') OR mapContains(map2, 'key2')) AND (NOT mapContains(map2, 'key3'))
 ORDER BY id;


### PR DESCRIPTION
The test [was flaky](https://play.clickhouse.com/play?user=play&run=1#V0lUSAogICAgOTAgQVMgaW50ZXJ2YWxfZGF5cwpTRUxFQ1QKICAgIHRvU3RhcnRPZkRheShjaGVja19zdGFydF90aW1lKSBBUyBkYXksCiAgICBjb3VudCgpIEFTIGZhaWx1cmVzLAogICAgZ3JvdXBVbmlxQXJyYXkocHVsbF9yZXF1ZXN0X251bWJlcikgQVMgcHJzLAogICAgYW55KHJlcG9ydF91cmwpIEFTIHJlcG9ydF91cmwKRlJPTSBjaGVja3MKV0hFUkUgKG5vdygpIC0gdG9JbnRlcnZhbERheShpbnRlcnZhbF9kYXlzKSkgPD0gY2hlY2tfc3RhcnRfdGltZQogICAgQU5EIHRlc3RfbmFtZSA9ICcwMzY0MF9za2lwX2luZGV4ZXNfd2l0aF9vcl9hbmRfbm90JwogICAgLS0gQU5EIGNoZWNrX25hbWUgPSAnU3RhdGVsZXNzIHRlc3RzIChhbWRfdHNhbiwgczMgc3RvcmFnZSwgcGFyYWxsZWwsIDEvMiknCiAgICBBTkQgdGVzdF9zdGF0dXMgSU4gKCdGQUlMJywgJ0VSUk9SJykKICAgIEFORCAocHVsbF9yZXF1ZXN0X251bWJlciA9IDAgT1IgYmFzZV9yZWYgSU4gKCdtYXN0ZXInKSkKICAgIEFORCB0ZXN0X2NvbnRleHRfcmF3IExJS0UgJyVyZXN1bHQgZGlmZmVycyB3aXRoIHJlZmVyZW5jZSUnCkdST1VQIEJZIGRheQpPUkRFUiBCWSBkYXkgREVTQwo=) because `Map` key ordering is non-deterministic.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix flaky test `03640_skip_indexes_with_or_and_not`

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.746`
<!-- ch-version-info:end -->