### PR TITLE
Fix MSAN use-of-uninitialized-value in TextLogElement::appendToBlock

### DIFF
--- a/src/Interpreters/TextLog.h
+++ b/src/Interpreters/TextLog.h
@@ -29,7 +29,7 @@ struct TextLogElement
     String source_file;
     UInt64 source_line{};
 
-    std::string_view message_format_string;
+    String message_format_string;
     String value1;
     String value2;
     String value3;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the change):
Fix MemorySanitizer use-of-uninitialized-value finding in `system.text_log` flushing by making `TextLogElement::message_format_string` own its data.

### Description

**Problem:** ARM64 MSAN (`Stress test (arm_msan)`) reports `use-of-uninitialized-value` (STID 1478-2063) when the `SystemLog` flushing thread calls `TextLogElement::appendToBlock()` and converts `message_format_string` from `std::string_view` → `Field(string_view)` → `std::string(data, size)`.

**Stats:** 35 hits across 32 distinct PRs and 3 master failures since April 1, 2026. Accelerating — 18 hits on April 9 alone. All exclusively on `arm_msan` (check first added March 4, 2026).

**Root cause:** `TextLogElement::message_format_string` was the only field in the struct using `std::string_view` instead of `String`. The `string_view` stores a pointer to format string data from `Poco::Message._fmt_str`, which is set in `OwnSplitChannel.cpp:logToSystemTextLogQueue()` and later read asynchronously by the `SystemLog` flushing thread. While the data typically points to static string literals (from `LOG_*` macros), ARM64 MSAN does not correctly track the initialization status across this async boundary.

**Fix:** Change `std::string_view message_format_string` → `String message_format_string` in `TextLogElement`. This makes the field own its data (via copy at assignment time), consistent with all other string fields in the struct (`query_id`, `logger_name`, `message`, `source_file`, `value1`–`value10` are all `String`). The copy cost is negligible — format strings are short (~50–100 chars) and copied once per log message flush.

### Testing
- Debug build compiles cleanly
- Server starts, `system.text_log` populates correctly with 38K+ rows including proper `message_format_string` values