### PR TITLE
Fix `re.error` in `post_updateable_comment` when comment body contains backslash sequences

### DIFF
--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -324,7 +324,8 @@ class GH:
                     rex = re.compile(
                         f"{re.escape(start_tag)}.*{re.escape(end_tag)}", re.DOTALL
                     )
-                    body, _ = rex.subn(f"{start_tag}\n{tag_body}\n{end_tag}", body)
+                    replacement = f"{start_tag}\n{tag_body}\n{end_tag}"
+                    body, _ = rex.subn(lambda _: replacement, body)
                     if verbose:
                         print(
                             f"Updated existing comment [{id_to_update}] tag [{tag}] with [{tag_body}], new [{body}]"


### PR DESCRIPTION
`re.subn` interprets backslash sequences (like `\A`, `\1`, etc.) in the replacement string. When the copilot review generates markdown containing such sequences, the substitution fails with `re.error: bad escape \A`.

Using a lambda as the replacement argument avoids this — the return value is used literally.

https://github.com/ClickHouse/ClickHouse/actions/runs/24187019325/job/70594439021?pr=102120

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.710`
<!-- ch-version-info:end -->