### PR TITLE
Fix macOS build with ld64.lld

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,8 +195,9 @@ option(BUILD_STANDALONE_KEEPER "Build keeper as small standalone binary" OFF)
 
 # Create BuildID when using lld. For other linkers it is created by default.
 # (NOTE: LINKER_NAME can be either path or name, and in different variants)
-if (LINKER_NAME MATCHES "lld")
+if (LINKER_NAME MATCHES "lld" AND NOT LINKER_NAME MATCHES "ld64")
     # SHA1 is not cryptographically secure but it is the best what lld is offering.
+    # ld64.lld (MachO linker) does not support --build-id.
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--build-id=sha1")
 endif ()
 

--- a/src/Common/SharedMutex.h
+++ b/src/Common/SharedMutex.h
@@ -62,18 +62,18 @@ public:
     SharedMutex & operator=(SharedMutex &&) = delete;
 
     // Exclusive ownership
-    void lock() TSA_ACQUIRE() { WriterLock(); }
+    void lock() TSA_ACQUIRE() { absl::Mutex::lock(); }
 
-    bool try_lock() TSA_TRY_ACQUIRE(true) { return WriterTryLock(); }
+    bool try_lock() TSA_TRY_ACQUIRE(true) { return absl::Mutex::try_lock(); }
 
-    void unlock() TSA_RELEASE() { WriterUnlock(); }
+    void unlock() TSA_RELEASE() { absl::Mutex::unlock(); }
 
     // Shared ownership
-    void lock_shared() TSA_ACQUIRE_SHARED() { ReaderLock(); }
+    void lock_shared() TSA_ACQUIRE_SHARED() { absl::Mutex::lock_shared(); }
 
-    bool try_lock_shared() TSA_TRY_ACQUIRE_SHARED(true) { return ReaderTryLock(); }
+    bool try_lock_shared() TSA_TRY_ACQUIRE_SHARED(true) { return absl::Mutex::try_lock_shared(); }
 
-    void unlock_shared() TSA_RELEASE_SHARED() { ReaderUnlock(); }
+    void unlock_shared() TSA_RELEASE_SHARED() { absl::Mutex::unlock_shared(); }
 };
 }
 


### PR DESCRIPTION
Fix two issues when building on macOS with `ld64.lld` (introduced by https://github.com/ClickHouse/ClickHouse/pull/100275):

1. Skip `--build-id=sha1` linker flag for `ld64.lld` — it's an ELF-only flag not supported by the MachO linker.
2. Replace deprecated `absl::Mutex` method calls (`WriterLock`, `ReaderLock`, etc.) with the non-deprecated lowercase equivalents in the `SharedMutex` non-Linux fallback.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix macOS build with `ld64.lld`: skip unsupported `--build-id` flag and fix deprecated `absl::Mutex` calls.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.728`
<!-- ch-version-info:end -->