### PR TITLE
Move projection virtuals into `ProjectionDescription`

### DIFF
--- a/src/Databases/DatabasesCommon.cpp
+++ b/src/Databases/DatabasesCommon.cpp
@@ -117,7 +117,7 @@ void validateCreateQuery(const ASTCreateQuery & query, ContextPtr context)
     if (columns.projections)
     {
         for (const auto & child : columns.projections->children)
-            ProjectionDescription::getProjectionFromAST(child, columns_desc, context);
+            ProjectionDescription::getProjectionFromAST(child, columns_desc, nullptr, context);
     }
     if (!new_query.storage)
         return;

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -777,7 +777,7 @@ InterpreterCreateQuery::TableProperties InterpreterCreateQuery::getTableProperti
         if (create.columns_list->projections)
             for (const auto & projection_ast : create.columns_list->projections->children)
             {
-                auto projection = ProjectionDescription::getProjectionFromAST(projection_ast, properties.columns, getContext());
+                auto projection = ProjectionDescription::getProjectionFromAST(projection_ast, properties.columns, nullptr, getContext());
                 properties.projections.add(std::move(projection));
             }
 

--- a/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
@@ -19,12 +19,14 @@
 
 namespace DB
 {
+
 namespace Setting
 {
     extern const SettingsString preferred_optimize_projection_name;
     extern const SettingsBool force_optimize_projection;
     extern const SettingsBool optimize_use_projection_filtering;
 }
+
 }
 
 namespace DB::QueryPlanOptimizations
@@ -226,12 +228,11 @@ std::optional<String> optimizeUseNormalProjections(
 
     auto logger = getLogger("optimizeUseNormalProjections");
 
-    auto projection_virtuals = reading->getMergeTreeData().getProjectionVirtualsPtr();
     auto has_all_required_columns = [&](const ProjectionDescription * projection)
     {
         for (const auto & col : required_columns)
         {
-            if (!projection->sample_block.findColumnOrSubcolumnByName(col) && !projection_virtuals->has(col))
+            if (!projection->sample_block.findColumnOrSubcolumnByName(col) && !projection->virtuals->has(col))
                 return false;
         }
 

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -859,7 +859,7 @@ void AlterCommand::apply(StorageInMemoryMetadata & metadata, ContextPtr context)
     }
     else if (type == ADD_PROJECTION)
     {
-        auto projection = ProjectionDescription::getProjectionFromAST(projection_decl, metadata.columns, context);
+        auto projection = ProjectionDescription::getProjectionFromAST(projection_decl, metadata.columns, &metadata.partition_key, context);
         metadata.projections.add(std::move(projection), after_projection_name, first, if_not_exists);
     }
     else if (type == DROP_PROJECTION)
@@ -1332,7 +1332,7 @@ void AlterCommands::apply(StorageInMemoryMetadata & metadata, ContextPtr context
             auto partition_key = metadata_copy.partition_key.expression_list_ast->clone();
             FunctionNameNormalizer::visit(partition_key.get());
             metadata_copy.minmax_count_projection.emplace(ProjectionDescription::getMinMaxCountProjection(
-                metadata_copy.columns, partition_key, minmax_columns, metadata_copy.primary_key, context));
+                metadata_copy.columns, partition_key, minmax_columns, metadata_copy.primary_key, &metadata_copy.partition_key, context));
         }
     }
 
@@ -1361,7 +1361,7 @@ void AlterCommands::apply(StorageInMemoryMetadata & metadata, ContextPtr context
         try
         {
             /// Check if we can still build projection from new metadata.
-            auto new_projection = ProjectionDescription::getProjectionFromAST(projection.definition_ast, metadata_copy.columns, context);
+            auto new_projection = ProjectionDescription::getProjectionFromAST(projection.definition_ast, metadata_copy.columns, &metadata_copy.partition_key, context);
             /// Check if new metadata has the same keys as the old one.
             if (!blocksHaveEqualStructure(projection.sample_block_for_keys, new_projection.sample_block_for_keys))
                 throw Exception(ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN, "Cannot ALTER column");

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -780,27 +780,6 @@ VirtualColumnsDescription MergeTreeData::createVirtuals(const StorageInMemoryMet
     return desc;
 }
 
-VirtualColumnsDescription MergeTreeData::createProjectionVirtuals(const StorageInMemoryMetadata & metadata)
-{
-    VirtualColumnsDescription desc;
-
-    desc.addEphemeral("_part", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "Name of part");
-    desc.addEphemeral("_part_index", std::make_shared<DataTypeUInt64>(), "Sequential index of the part in the query result");
-    desc.addEphemeral("_part_starting_offset", std::make_shared<DataTypeUInt64>(), "Cumulative starting row of the part in the query result");
-    desc.addEphemeral("_part_uuid", std::make_shared<DataTypeUUID>(), "Unique part identifier (if enabled MergeTree setting assign_part_uuids)");
-    desc.addEphemeral("_partition_id", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "Name of partition");
-    desc.addEphemeral("_part_data_version", std::make_shared<DataTypeUInt64>(), "Data version of part (either min block number or mutation version)");
-    desc.addEphemeral("_disk_name", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "Disk name");
-
-    if (metadata.hasPartitionKey())
-    {
-        auto partition_types = metadata.partition_key.sample_block.getDataTypes();
-        desc.addEphemeral("_partition_value", std::make_shared<DataTypeTuple>(std::move(partition_types)), "Value (a tuple) of a PARTITION BY expression");
-    }
-
-    return desc;
-}
-
 StoragePolicyPtr MergeTreeData::getStoragePolicy() const
 {
     auto settings = getSettings();
@@ -1210,7 +1189,6 @@ void MergeTreeData::setProperties(
 
     setInMemoryMetadata(new_metadata);
     setVirtuals(createVirtuals(new_metadata));
-    projection_virtuals.set(std::make_unique<VirtualColumnsDescription>(createProjectionVirtuals(new_metadata)));
 
     std::lock_guard lock(patch_parts_metadata_mutex);
     patch_parts_metadata_cache.clear();

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1374,10 +1374,6 @@ public:
     bool initializeDiskOnConfigChange(const std::set<String> & /*new_added_disks*/) override;
 
     static VirtualColumnsDescription createVirtuals(const StorageInMemoryMetadata & metadata);
-    static VirtualColumnsDescription createProjectionVirtuals(const StorageInMemoryMetadata & metadata);
-
-    /// Similar to IStorage::getVirtuals but returns only virtual columns valid in projection.
-    VirtualsDescriptionPtr getProjectionVirtualsPtr() const { return projection_virtuals.get(); }
 
     /// Load/unload primary keys of all data parts
     void loadPrimaryKeys() const;
@@ -1984,8 +1980,6 @@ private:
     void clearPartsFromFilesystemImpl(const DataPartsVector & parts, NameSet * part_names_succeed);
 
     mutable TemporaryParts temporary_parts;
-
-    MultiVersionVirtualsDescriptionPtr projection_virtuals;
 
     /// A regexp for files that should be prewarmed in the cache if cache_populated_by_fetch is enabled.
     MultiVersion<re2::RE2> filename_regexp_for_cache_prewarming;

--- a/src/Storages/MergeTree/ProjectionIndex/IProjectionIndex.h
+++ b/src/Storages/MergeTree/ProjectionIndex/IProjectionIndex.h
@@ -11,6 +11,7 @@ namespace DB
 
 class ColumnsDescription;
 
+struct KeyDescription;
 struct ProjectionDescription;
 
 using IColumnPermutation = PaddedPODArray<size_t>;
@@ -26,7 +27,11 @@ public:
     virtual String getName() const = 0;
 
     virtual void fillProjectionDescription(
-        ProjectionDescription & result, const IAST * index_expr, const ColumnsDescription & columns, ContextPtr query_context) const
+        ProjectionDescription & result,
+        const IAST * index_expr,
+        const ColumnsDescription & columns,
+        const KeyDescription * partition_key,
+        const ContextPtr & query_context) const
         = 0;
 
     virtual Block calculate(

--- a/src/Storages/MergeTree/ProjectionIndex/ProjectionIndexBasic.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/ProjectionIndexBasic.cpp
@@ -37,7 +37,11 @@ static ASTPtr wrapInTupleIfNeeded(ASTPtr expr_list)
 }
 
 void ProjectionIndexBasic::fillProjectionDescription(
-    ProjectionDescription & result, const IAST * index_expr, const ColumnsDescription & columns, ContextPtr query_context) const
+    ProjectionDescription & result,
+    const IAST * index_expr,
+    const ColumnsDescription & columns,
+    const KeyDescription * partition_key,
+    const ContextPtr & query_context) const
 {
     auto select_query = make_intrusive<ASTProjectionSelectQuery>();
     auto select_expr_list = make_intrusive<ASTExpressionList>();
@@ -45,7 +49,7 @@ void ProjectionIndexBasic::fillProjectionDescription(
     select_query->setExpression(ASTProjectionSelectQuery::Expression::SELECT, std::move(select_expr_list));
     select_query->setExpression(ASTProjectionSelectQuery::Expression::ORDER_BY, wrapInTupleIfNeeded(index_expr->clone()));
 
-    ProjectionDescription::fillProjectionDescriptionByQuery(result, *select_query, columns, query_context);
+    ProjectionDescription::fillProjectionDescriptionByQuery(result, *select_query, columns, partition_key, query_context);
 }
 
 Block ProjectionIndexBasic::calculate(

--- a/src/Storages/MergeTree/ProjectionIndex/ProjectionIndexBasic.h
+++ b/src/Storages/MergeTree/ProjectionIndex/ProjectionIndexBasic.h
@@ -21,7 +21,8 @@ public:
         ProjectionDescription & result,
         const IAST * index_expr,
         const ColumnsDescription & columns,
-        ContextPtr query_context) const override;
+        const KeyDescription * partition_key,
+        const ContextPtr & query_context) const override;
 
     Block calculate(
         const ProjectionDescription & projection_desc,

--- a/src/Storages/MergeTree/ProjectionIndex/ProjectionIndexCommitOrder.cpp
+++ b/src/Storages/MergeTree/ProjectionIndex/ProjectionIndexCommitOrder.cpp
@@ -13,7 +13,11 @@ namespace DB
 {
 
 void ProjectionIndexCommitOrder::fillProjectionDescription(
-    ProjectionDescription & result, const IAST * index_expr, const ColumnsDescription & columns, ContextPtr query_context) const
+    ProjectionDescription & result,
+    const IAST * index_expr,
+    const ColumnsDescription & columns,
+    const KeyDescription * partition_key,
+    const ContextPtr & query_context) const
 {
     auto select_query = make_intrusive<ASTProjectionSelectQuery>();
 
@@ -33,7 +37,7 @@ void ProjectionIndexCommitOrder::fillProjectionDescription(
     order_expr_list->children.push_back(order_expr_list->arguments);
     select_query->setExpression(ASTProjectionSelectQuery::Expression::ORDER_BY, std::move(order_expr_list));
 
-    ProjectionDescription::fillProjectionDescriptionByQuery(result, *select_query, columns, query_context);
+    ProjectionDescription::fillProjectionDescriptionByQuery(result, *select_query, columns, partition_key, query_context);
 }
 
 Block ProjectionIndexCommitOrder::calculate(

--- a/src/Storages/MergeTree/ProjectionIndex/ProjectionIndexCommitOrder.h
+++ b/src/Storages/MergeTree/ProjectionIndex/ProjectionIndexCommitOrder.h
@@ -32,7 +32,8 @@ public:
         ProjectionDescription & result,
         const IAST * index_expr,
         const ColumnsDescription & columns,
-        ContextPtr query_context) const override;
+        const KeyDescription * partition_key,
+        const ContextPtr & query_context) const override;
 
     Block calculate(
         const ProjectionDescription & projection_desc,

--- a/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeTableMetadata.cpp
@@ -431,7 +431,7 @@ bool ReplicatedMergeTreeTableMetadata::checkEquals(
         is_equal = false;
     }
 
-    String parsed_zk_projections = ProjectionsDescription::parse(from_zk.projections, columns, context).toString();
+    String parsed_zk_projections = ProjectionsDescription::parse(from_zk.projections, columns, nullptr, context).toString();
     if (projections != parsed_zk_projections)
     {
         handleTableMetadataMismatch(table_name_for_error_message, "projections", from_zk.projections, parsed_zk_projections, projections, strict_check, logger);
@@ -565,7 +565,7 @@ StorageInMemoryMetadata ReplicatedMergeTreeTableMetadata::Diff::getNewMetadata(c
             new_metadata.constraints = ConstraintsDescription::parse(new_constraints);
 
         if (projections_changed)
-            new_metadata.projections = ProjectionsDescription::parse(new_projections, new_columns, context);
+            new_metadata.projections = ProjectionsDescription::parse(new_projections, new_columns, &new_metadata.partition_key, context);
 
         if (ttl_table_changed)
         {
@@ -642,7 +642,7 @@ StorageInMemoryMetadata ReplicatedMergeTreeTableMetadata::Diff::getNewMetadata(c
     {
         ProjectionsDescription recalculated_projections;
         for (const auto & projection : new_metadata.projections)
-            recalculated_projections.add(ProjectionDescription::getProjectionFromAST(projection.definition_ast, new_metadata.columns, context));
+            recalculated_projections.add(ProjectionDescription::getProjectionFromAST(projection.definition_ast, new_metadata.columns, &new_metadata.partition_key, context));
         new_metadata.projections = std::move(recalculated_projections);
     }
 

--- a/src/Storages/MergeTree/registerStorageMergeTree.cpp
+++ b/src/Storages/MergeTree/registerStorageMergeTree.cpp
@@ -699,7 +699,7 @@ static StoragePtr create(const StorageFactory::Arguments & args)
         auto partition_key = metadata.partition_key.expression_list_ast->clone();
         FunctionNameNormalizer::visit(partition_key.get());
         metadata.minmax_count_projection.emplace(ProjectionDescription::getMinMaxCountProjection(
-            columns, partition_key, minmax_columns, metadata.primary_key, context));
+            columns, partition_key, minmax_columns, metadata.primary_key, &metadata.partition_key, context));
 
         if (args.storage_def->sample_by)
             metadata.sampling_key = KeyDescription::getKeyFromAST(args.storage_def->sample_by->ptr(), metadata.columns, context);
@@ -776,7 +776,7 @@ static StoragePtr create(const StorageFactory::Arguments & args)
             {
                 try
                 {
-                    auto projection = ProjectionDescription::getProjectionFromAST(projection_ast, columns, context);
+                    auto projection = ProjectionDescription::getProjectionFromAST(projection_ast, columns, &metadata.partition_key, context);
                     metadata.projections.add(std::move(projection));
                 }
                 catch (...)
@@ -848,7 +848,7 @@ static StoragePtr create(const StorageFactory::Arguments & args)
         auto partition_key = metadata.partition_key.expression_list_ast->clone();
         FunctionNameNormalizer::visit(partition_key.get());
         metadata.minmax_count_projection.emplace(ProjectionDescription::getMinMaxCountProjection(
-            columns, partition_key, minmax_columns, metadata.primary_key, context));
+            columns, partition_key, minmax_columns, metadata.primary_key, &metadata.partition_key, context));
 
         const auto * ast = engine_args[arg_num]->as<ASTLiteral>();
         if (ast && ast->value.getType() == Field::Types::UInt64)

--- a/src/Storages/MergeTree/tests/gtest_trivial_count_null_snapshot.cpp
+++ b/src/Storages/MergeTree/tests/gtest_trivial_count_null_snapshot.cpp
@@ -63,7 +63,7 @@ TEST(SupportsTrivialCountOptimization, NullMutationsSnapshot)
     auto minmax_columns = metadata.getColumnsRequiredForPartitionKey();
     auto partition_key = metadata.partition_key.expression_list_ast->clone();
     metadata.minmax_count_projection.emplace(
-        ProjectionDescription::getMinMaxCountProjection(columns, partition_key, minmax_columns, metadata.primary_key, context));
+        ProjectionDescription::getMinMaxCountProjection(columns, partition_key, minmax_columns, metadata.primary_key, &metadata.partition_key, context));
 
     auto storage_settings = std::make_unique<MergeTreeSettings>(context->getMergeTreeSettings());
 

--- a/src/Storages/ProjectionsDescription.cpp
+++ b/src/Storages/ProjectionsDescription.cpp
@@ -4,7 +4,10 @@
 #include <Common/iota.h>
 #include <Core/Defines.h>
 #include <Core/Settings.h>
+#include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/DataTypeTuple.h>
+#include <DataTypes/DataTypeUUID.h>
 #include <DataTypes/NestedUtils.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
@@ -58,6 +61,31 @@ extern const SettingsBool enable_positional_arguments_for_projections;
 
 }
 
+namespace
+{
+
+VirtualsDescriptionPtr createProjectionVirtuals(const KeyDescription * partition_key)
+{
+    auto desc = std::make_shared<VirtualColumnsDescription>();
+
+    desc->addEphemeral("_part", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "Name of part");
+    desc->addEphemeral("_part_index", std::make_shared<DataTypeUInt64>(), "Sequential index of the part in the query result");
+    desc->addEphemeral("_part_starting_offset", std::make_shared<DataTypeUInt64>(), "Cumulative starting row of the part in the query result");
+    desc->addEphemeral("_part_uuid", std::make_shared<DataTypeUUID>(), "Unique part identifier (if enabled MergeTree setting assign_part_uuids)");
+    desc->addEphemeral("_partition_id", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "Name of partition");
+    desc->addEphemeral("_part_data_version", std::make_shared<DataTypeUInt64>(), "Data version of part (either min block number or mutation version)");
+    desc->addEphemeral("_disk_name", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), "Disk name");
+
+    if (partition_key && partition_key->sample_block.columns() > 0)
+    {
+        auto partition_types = partition_key->sample_block.getDataTypes();
+        desc->addEphemeral("_partition_value", std::make_shared<DataTypeTuple>(std::move(partition_types)), "Value (a tuple) of a PARTITION BY expression");
+    }
+
+    return desc;
+}
+
+}
 
 bool ProjectionDescription::isPrimaryKeyColumnPossiblyWrappedInFunctions(const ASTPtr & node) const
 {
@@ -98,6 +126,7 @@ ProjectionDescription ProjectionDescription::clone() const
     other.index = index;
     other.index_granularity = index_granularity;
     other.index_granularity_bytes = index_granularity_bytes;
+    other.virtuals = virtuals;
 
     return other;
 }
@@ -251,8 +280,11 @@ void ProjectionDescription::loadSettings(const SettingsChanges & changes)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "projection index_granularity_bytes cannot be 0, which leads to fixed granularity");
 }
 
-ProjectionDescription
-ProjectionDescription::getProjectionFromAST(const ASTPtr & definition_ast, const ColumnsDescription & columns, ContextPtr query_context)
+ProjectionDescription ProjectionDescription::getProjectionFromAST(
+    const ASTPtr & definition_ast,
+    const ColumnsDescription & columns,
+    const KeyDescription * partition_key,
+    const ContextPtr & query_context)
 {
     const auto * projection_definition = definition_ast->as<ASTProjectionDeclaration>();
 
@@ -270,7 +302,7 @@ ProjectionDescription::getProjectionFromAST(const ASTPtr & definition_ast, const
     {
         chassert(projection_definition->type);
         result.index = ProjectionIndexFactory::instance().get(*projection_definition);
-        result.index->fillProjectionDescription(result, projection_definition->index, columns, query_context);
+        result.index->fillProjectionDescription(result, projection_definition->index, columns, partition_key, query_context);
         if (projection_definition->with_settings)
             result.loadSettings(projection_definition->with_settings->changes);
         return result;
@@ -279,12 +311,16 @@ ProjectionDescription::getProjectionFromAST(const ASTPtr & definition_ast, const
     if (projection_definition->with_settings)
         result.loadSettings(projection_definition->with_settings->changes);
 
-    fillProjectionDescriptionByQuery(result, projection_definition->query->as<ASTProjectionSelectQuery &>(), columns, query_context);
+    fillProjectionDescriptionByQuery(result, projection_definition->query->as<ASTProjectionSelectQuery &>(), columns, partition_key, query_context);
     return result;
 }
 
 void ProjectionDescription::fillProjectionDescriptionByQuery(
-    ProjectionDescription & result, const ASTProjectionSelectQuery & query, const ColumnsDescription & columns, ContextPtr query_context)
+    ProjectionDescription & result,
+    const ASTProjectionSelectQuery & query,
+    const ColumnsDescription & columns,
+    const KeyDescription * partition_key,
+    const ContextPtr & query_context)
 {
     auto projection_order_by = query.orderBy();
     result.query_ast = query.cloneToASTSelect();
@@ -450,14 +486,16 @@ void ProjectionDescription::fillProjectionDescriptionByQuery(
 
     metadata.setColumns(ColumnsDescription(metadata_columns));
     result.metadata = std::make_shared<StorageInMemoryMetadata>(metadata);
+    result.virtuals = createProjectionVirtuals(partition_key);
 }
 
 ProjectionDescription ProjectionDescription::getMinMaxCountProjection(
     const ColumnsDescription & columns,
-    ASTPtr partition_columns,
+    const ASTPtr & partition_columns,
     const Names & minmax_columns,
     const KeyDescription & primary_key,
-    ContextPtr query_context)
+    const KeyDescription * partition_key,
+    const ContextPtr & query_context)
 {
     ProjectionDescription result;
 
@@ -488,10 +526,10 @@ ProjectionDescription ProjectionDescription::getMinMaxCountProjection(
 
     if (partition_columns && !partition_columns->children.empty())
     {
-        partition_columns = partition_columns->clone();
-        for (const auto & partition_column : partition_columns->children)
+        auto partition_columns_copy = partition_columns->clone();
+        for (const auto & partition_column : partition_columns_copy->children)
             KeyDescription::moduloToModuloLegacyRecursive(partition_column);
-        select_query->setExpression(ASTProjectionSelectQuery::Expression::GROUP_BY, partition_columns->clone());
+        select_query->setExpression(ASTProjectionSelectQuery::Expression::GROUP_BY, std::move(partition_columns_copy));
     }
 
     result.definition_ast = select_query;
@@ -552,12 +590,8 @@ ProjectionDescription ProjectionDescription::getMinMaxCountProjection(
     metadata.sorting_key = KeyDescription::buildEmptyKey();
     metadata.primary_key = KeyDescription::buildEmptyKey();
     result.metadata = std::make_shared<StorageInMemoryMetadata>(metadata);
+    result.virtuals = createProjectionVirtuals(partition_key);
     return result;
-}
-
-void ProjectionDescription::recalculateWithNewColumns(const ColumnsDescription & new_columns, ContextPtr query_context)
-{
-    *this = getProjectionFromAST(definition_ast, new_columns, query_context);
 }
 
 Block ProjectionDescription::calculate(
@@ -691,7 +725,11 @@ String ProjectionsDescription::toString() const
     return list.formatWithSecretsOneLine();
 }
 
-ProjectionsDescription ProjectionsDescription::parse(const String & str, const ColumnsDescription & columns, ContextPtr query_context)
+ProjectionsDescription ProjectionsDescription::parse(
+    const String & str,
+    const ColumnsDescription & columns,
+    const KeyDescription * parent_partition_key,
+    const ContextPtr & query_context)
 {
     ProjectionsDescription result;
     if (str.empty())
@@ -702,7 +740,7 @@ ProjectionsDescription ProjectionsDescription::parse(const String & str, const C
 
     for (const auto & projection_ast : list->children)
     {
-        auto projection = ProjectionDescription::getProjectionFromAST(projection_ast, columns, query_context);
+        auto projection = ProjectionDescription::getProjectionFromAST(projection_ast, columns, parent_partition_key, query_context);
         result.add(std::move(projection));
     }
 

--- a/src/Storages/ProjectionsDescription.h
+++ b/src/Storages/ProjectionsDescription.h
@@ -5,6 +5,7 @@
 #include <Parsers/IAST_fwd.h>
 #include <Storages/ColumnsDescription.h>
 #include <Storages/MergeTree/ProjectionIndex/IProjectionIndex.h>
+#include <Storages/VirtualColumnsDescription.h>
 #include <Common/PODArray_fwd.h>
 
 #include <memory>
@@ -59,6 +60,7 @@ struct ProjectionDescription
     Block sample_block_for_keys;
 
     StorageMetadataPtr metadata;
+    VirtualsDescriptionPtr virtuals;
 
     size_t key_size = 0;
 
@@ -81,21 +83,26 @@ struct ProjectionDescription
     std::optional<UInt64> index_granularity_bytes;
 
     /// Parse projection from definition AST
-    static ProjectionDescription
-    getProjectionFromAST(const ASTPtr & definition_ast, const ColumnsDescription & columns, ContextPtr query_context);
+    static ProjectionDescription getProjectionFromAST(
+        const ASTPtr & definition_ast,
+        const ColumnsDescription & columns,
+        const KeyDescription * partition_key,
+        const ContextPtr & query_context);
 
     static void fillProjectionDescriptionByQuery(
         ProjectionDescription & result,
         const ASTProjectionSelectQuery & query,
         const ColumnsDescription & columns,
-        ContextPtr query_context);
+        const KeyDescription * partition_key,
+        const ContextPtr & query_context);
 
     static ProjectionDescription getMinMaxCountProjection(
         const ColumnsDescription & columns,
-        ASTPtr partition_columns,
+        const ASTPtr & partition_columns,
         const Names & minmax_columns,
         const KeyDescription & primary_key,
-        ContextPtr query_context);
+        const KeyDescription * partition_key,
+        const ContextPtr & query_context);
 
     ProjectionDescription() = default;
 
@@ -112,10 +119,6 @@ struct ProjectionDescription
 
     bool operator==(const ProjectionDescription & other) const;
     bool operator!=(const ProjectionDescription & other) const { return !(*this == other); }
-
-    /// Recalculate projection with new columns because projection expression may change
-    /// if something change in columns.
-    void recalculateWithNewColumns(const ColumnsDescription & new_columns, ContextPtr query_context);
 
     bool isPrimaryKeyColumnPossiblyWrappedInFunctions(const ASTPtr & node) const;
 
@@ -159,7 +162,11 @@ struct ProjectionsDescription : public IHints<>
     /// Convert description to string
     String toString() const;
     /// Parse description from string
-    static ProjectionsDescription parse(const String & str, const ColumnsDescription & columns, ContextPtr query_context);
+    static ProjectionsDescription parse(
+        const String & str,
+        const ColumnsDescription & columns,
+        const KeyDescription * parent_partition_key,
+        const ContextPtr & query_context);
 
     /// Return common expression for all stored projections
     ExpressionActionsPtr getSingleExpressionForProjections(const ColumnsDescription & columns, ContextPtr query_context) const;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Needed for the unification of virtual columns and in-memory storage metadata.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.745`
<!-- ch-version-info:end -->