### PR TITLE
Disable bluetoothd and remove stale workspace on macOS runners

### DIFF
--- a/ci/infra/scripts/user_data_macos.txt
+++ b/ci/infra/scripts/user_data_macos.txt
@@ -136,5 +136,6 @@ fi
 # Download and execute cloud-init script
 INIT_ENVIRONMENT=${INIT_ENVIRONMENT:-macos}
 aws s3 cp "s3://github-runners-data/cloud-init/${INIT_ENVIRONMENT}.py" /tmp/runner-init.py
+sudo rm -rf /Users/ec2-user/actions-runner/_work
 sudo -u ec2-user -i bash -c "/Users/ec2-user/venv/bin/python /tmp/runner-init.py --environment \"$INIT_ENVIRONMENT\""
 reboot

--- a/ci/infra/scripts/user_data_macos.txt
+++ b/ci/infra/scripts/user_data_macos.txt
@@ -44,6 +44,9 @@ if [ -f /tmp/clickhouse-ci-macos-runner.success ]; then
 else
   echo "No success marker found - proceeding with installation"
 
+  # Disable greedy system service
+  launchctl disable system/com.apple.bluetoothd
+
   # Install Homebrew if not already installed
   if ! sudo -u "$USER" -i command -v brew &> /dev/null; then
     echo "Installing Homebrew..."


### PR DESCRIPTION
macOS EC2 runners include system services that are unnecessary in a CI context.
`bluetoothd` in particular consumes CPU and memory on machines where Bluetooth is
never used, so it is now disabled during initial runner setup.

Additionally, when a runner restarts, the `actions-runner/_work` directory may
contain leftover files from previous jobs that can cause `runner-init.py` to fail
or behave inconsistently. The directory is now cleaned before `runner-init.py` runs.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.736`
<!-- ch-version-info:end -->