### PR TITLE
Update ctcache to avoid stale cache due to redundant includes

### DIFF
--- a/ci/docker/binary-builder/Dockerfile
+++ b/ci/docker/binary-builder/Dockerfile
@@ -89,7 +89,7 @@ RUN curl -sL -O https://github.com/phracker/MacOSX-SDKs/releases/download/11.3/M
   && ln -sf darwin-x86_64 /build/cmake/toolchain/darwin-aarch64 \
   && rm /MacOSX11.0.sdk.tar.xz
 
-ARG CLANG_TIDY_SHA1=e33c063ca6e52b48bcefbc45d46d8c150ffa81ca
+ARG CLANG_TIDY_SHA1=3880541496c7ce0d2e2830d2f525375078fe0b1f
 RUN curl -Lo /usr/bin/clang-tidy-cache.py \
         "https://raw.githubusercontent.com/matus-chochlik/ctcache/$CLANG_TIDY_SHA1/src/ctcache/clang_tidy_cache.py" \
     && chmod +x /usr/bin/clang-tidy-cache.py


### PR DESCRIPTION
https://github.com/matus-chochlik/ctcache/pull/102 fixes the issue.

Turns out that including a header that was already included didn't change the hash because ctcache was using just the preprocessor output and the include guards made sure no new code was added. As a result, including an already-included header used a stale cache result.

Example:

```bash
/ClickHouse/src/Common/EnvironmentChecks.cpp:12:10: error: inclusion of deprecated C++ header 'stdlib.h'; consider using 'cstdlib' instead [hicpp-deprecated-headers,modernize-deprecated-headers,-warnings-as-errors]
   12 | #include <stdlib.h>
      |          ^~~~~~~~~~
      |          <cstdlib>
```

But then the ctcache log for the CI job that included such a change:

```bash
clang-tidy-cache output for "/ClickHouse/src/Common/EnvironmentChecks.cpp":
	DEBUG:clang-tidy-cache.py:Digest b768045a040372cf7b928f3226b7b6a19135d2ff exists in cache
```

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.808`
<!-- ch-version-info:end -->