### PR TITLE
Docs: add warning about use of cache dictionary layouts in Cloud

### DIFF
--- a/docs/en/sql-reference/statements/create/dictionary/layouts/cache.md
+++ b/docs/en/sql-reference/statements/create/dictionary/layouts/cache.md
@@ -13,6 +13,12 @@ import TabItem from '@theme/TabItem';
 The `cached` dictionary layout type is stores the dictionary in a cache that has a fixed number of cells.
 These cells contain frequently used elements.
 
+:::warning ClickHouse Cloud
+In ClickHouse Cloud, nodes can be replaced at any time due to autoscaling. When a node is replaced, the `cache` dictionary is wiped clean and must be re-warmed by incoming queries. Until re-warmed, lookups for keys not yet in the cache return default values, which can cause **data quality issues** — especially when the dictionary is used to denormalize data inside a [materialized view](/sql-reference/statements/create/view#materialized-view).
+
+Use a layout that fully loads dictionary data on startup, such as [`hashed`](./hashed.md), [`complex_key_hashed`](./hashed.md#complex_key_hashed), or [`flat`](./flat.md), so the dictionary is immediately available after a node replacement. See [Dictionary Best Practices](/dictionary/best-practices) for guidance on choosing a layout.
+:::
+
 The dictionary key has the [UInt64](/sql-reference/data-types/int-uint.md) type.
 
 When searching for a dictionary, the cache is searched first. For each block of data, all keys that are not found in the cache or are outdated are requested from the source using `SELECT attrs... FROM db.table WHERE id IN (k1, k2, ...)`. The received data is then written to the cache.

--- a/docs/en/sql-reference/statements/create/dictionary/layouts/cache.md
+++ b/docs/en/sql-reference/statements/create/dictionary/layouts/cache.md
@@ -17,6 +17,10 @@ These cells contain frequently used elements.
 In ClickHouse Cloud, nodes can be replaced at any time due to autoscaling. When a node is replaced, the `cache` dictionary is wiped clean and must be re-warmed by incoming queries. Until re-warmed, lookups for keys not yet in the cache return default values, which can cause **data quality issues** — especially when the dictionary is used to denormalize data inside a [materialized view](/sql-reference/statements/create/view#materialized-view).
 
 Use a layout that fully loads dictionary data on startup, such as [`hashed`](./hashed.md), [`complex_key_hashed`](./hashed.md#complex_key_hashed), or [`flat`](./flat.md), so the dictionary is immediately available after a node replacement. See [Dictionary Best Practices](/dictionary/best-practices) for guidance on choosing a layout.
+:::warning[Avoid cache layouts when using ClickHouse Cloud]
+In ClickHouse Cloud, nodes can be replaced at any time due to autoscaling. When a node is replaced, the `cache` dictionary is wiped clean and must be re-warmed by incoming queries. Until re-warmed, lookups for keys not yet in the cache return default values, which can cause **data quality issues** — especially when the dictionary is used to denormalize data inside a [materialized view](/sql-reference/statements/create/view#materialized-view).
+
+Use a layout that fully loads dictionary data on startup, such as [`hashed`](./hashed.md), [`complex_key_hashed`](./hashed.md#complex_key_hashed), or [`flat`](./flat.md), so the dictionary is immediately available after a node replacement. See [Dictionary Best Practices](/dictionary/best-practices) for guidance on choosing a layout.
 :::
 
 The dictionary key has the [UInt64](/sql-reference/data-types/int-uint.md) type.

--- a/docs/en/sql-reference/statements/create/dictionary/layouts/overview.md
+++ b/docs/en/sql-reference/statements/create/dictionary/layouts/overview.md
@@ -37,6 +37,8 @@ There are a variety of ways to store dictionaries in memory, each with CPU and R
 :::tip Recommended layouts
 [flat](./flat.md), [hashed](./hashed.md), and [complex_key_hashed](./hashed.md#complex_key_hashed) provide the best query performance.
 Caching layouts are not recommended due to potentially poor performance and difficulty tuning parameters — see [cache](./cache.md) for details.
+
+**ClickHouse Cloud:** Caching layouts (`cache`, `complex_key_cache`, `ssd_cache`, `complex_key_ssd_cache`) are not recommended for use in ClickHouse Cloud. Nodes can be replaced at any time due to autoscaling, which wipes the cache clean. Until re-warmed, dictionary lookups return default values, which can cause data quality issues in downstream [materialized views](/sql-reference/statements/create/view#materialized-view). Always use a fully-loaded layout in Cloud environments. See [Dictionary Best Practices](/dictionary/best-practices) for more details.
 :::
 
 ## Specify dictionary layout {#specify-dictionary-layout}

--- a/docs/en/sql-reference/statements/create/dictionary/layouts/ssd-cache.md
+++ b/docs/en/sql-reference/statements/create/dictionary/layouts/ssd-cache.md
@@ -10,7 +10,7 @@ doc_type: 'reference'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-:::warning ClickHouse Cloud
+:::warning[Avoid cache layouts when using ClickHouse Cloud]
 In ClickHouse Cloud, nodes can be replaced at any time due to autoscaling. When a node is replaced, the `ssd_cache` dictionary is wiped clean and must be re-warmed by incoming queries. Until re-warmed, lookups for keys not yet in the cache return default values, which can cause **data quality issues** — especially when the dictionary is used to denormalize data inside a [materialized view](/sql-reference/statements/create/view#materialized-view).
 
 Use a layout that fully loads dictionary data on startup, such as [`hashed`](./hashed.md), [`complex_key_hashed`](./hashed.md#complex_key_hashed), or [`flat`](./flat.md), so the dictionary is immediately available after a node replacement. See [Dictionary Best Practices](/dictionary/best-practices) for guidance on choosing a layout.

--- a/docs/en/sql-reference/statements/create/dictionary/layouts/ssd-cache.md
+++ b/docs/en/sql-reference/statements/create/dictionary/layouts/ssd-cache.md
@@ -10,6 +10,12 @@ doc_type: 'reference'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+:::warning ClickHouse Cloud
+In ClickHouse Cloud, nodes can be replaced at any time due to autoscaling. When a node is replaced, the `ssd_cache` dictionary is wiped clean and must be re-warmed by incoming queries. Until re-warmed, lookups for keys not yet in the cache return default values, which can cause **data quality issues** — especially when the dictionary is used to denormalize data inside a [materialized view](/sql-reference/statements/create/view#materialized-view).
+
+Use a layout that fully loads dictionary data on startup, such as [`hashed`](./hashed.md), [`complex_key_hashed`](./hashed.md#complex_key_hashed), or [`flat`](./flat.md), so the dictionary is immediately available after a node replacement. See [Dictionary Best Practices](/dictionary/best-practices) for guidance on choosing a layout.
+:::
+
 ## ssd_cache {#ssd_cache}
 
 Similar to `cache`, but stores data on SSD and index in RAM. All cache dictionary settings related to update queue can also be applied to SSD cache dictionaries.


### PR DESCRIPTION
Together with https://github.com/ClickHouse/clickhouse-docs/pull/5999 closes https://github.com/ClickHouse/ClickHouse/issues/113305

> Since we use autoscaling in cloud, nodes can be replaced at any moment and if a node is replaced the dictionary is wiped clean.  This can result in ingestion issues if they are using a dictionary to denormalize data in an MV.  tl;dr only use complex key hashed or another dictionary lay out that prepopulates dictionaries, instead of populating them via caching mechanisms.  See https://clickhouse.com/docs/dictionary/best-practices for more info on choosing dicationary cache layouts.
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
