### PR TITLE
Revert: Integrate jemalloc with je_ prefix and remove usage of linker's --wrap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,6 +544,29 @@ macro (clickhouse_add_executable target)
         add_executable (${ARGV} $<TARGET_OBJECTS:clickhouse_malloc>)
     endif ()
 
+    # Wrap the malloc/free and other C-style functions with our own ones
+    # to inject memory tracking mechanism into them.
+    # Sanitizers have their own way of intercepting the
+    # allocations and deallocations, so we skip this step for them.
+    if (NOT (SANITIZE OR SANITIZE_COVERAGE OR OS_DARWIN OR OS_FREEBSD OR OS_SUNOS))
+        target_link_options(${target} PRIVATE
+            "LINKER:--wrap=malloc"
+            "LINKER:--wrap=free"
+            "LINKER:--wrap=calloc"
+            "LINKER:--wrap=realloc"
+            "LINKER:--wrap=aligned_alloc"
+            "LINKER:--wrap=posix_memalign"
+            "LINKER:--wrap=valloc"
+            "LINKER:--wrap=memalign"
+            "LINKER:--wrap=reallocarray"
+        )
+        if (NOT USE_MUSL)
+            target_link_options(${target} PRIVATE
+                "LINKER:--wrap=pvalloc"
+            )
+        endif()
+    endif()
+
     get_target_property (type ${target} TYPE)
     if (${type} STREQUAL EXECUTABLE)
         target_link_libraries (${target} PUBLIC clickhouse_new_delete)

--- a/contrib/jemalloc-cmake/CMakeLists.txt
+++ b/contrib/jemalloc-cmake/CMakeLists.txt
@@ -186,10 +186,7 @@ configure_file(${JEMALLOC_INCLUDE_PREFIX}/jemalloc/internal/jemalloc_internal_de
 target_include_directories(_jemalloc SYSTEM PRIVATE
     "${CMAKE_CURRENT_BINARY_DIR}/${JEMALLOC_INCLUDE_PREFIX}/jemalloc/internal")
 
-# This is only about private functions, and we cannot use private namespace since we do not provide private_namespace.h
 target_compile_definitions(_jemalloc PRIVATE -DJEMALLOC_NO_PRIVATE_NAMESPACE)
-# Do not rename je_malloc to malloc (and friends)
-target_compile_definitions(_jemalloc INTERFACE -DJEMALLOC_NO_RENAME)
 
 # Because our coverage callbacks call malloc, and recursive call of malloc could not work.
 target_compile_options(_jemalloc PRIVATE ${WITHOUT_COVERAGE_FLAGS_LIST})

--- a/contrib/jemalloc-cmake/include/jemalloc/jemalloc_defs.h
+++ b/contrib/jemalloc-cmake/include/jemalloc/jemalloc_defs.h
@@ -24,10 +24,14 @@
  * Define overrides for non-standard allocator-related functions if they are
  * present on the system.
  */
-/* #undef JEMALLOC_OVERRIDE_MEMALIGN */
-/* #undef JEMALLOC_OVERRIDE_VALLOC */
-/* #undef JEMALLOC_OVERRIDE_PVALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_PVALLOC */
+#if !defined(USE_MUSL)
+    #define JEMALLOC_OVERRIDE_MEMALIGN
+    #define JEMALLOC_OVERRIDE_VALLOC
+    #if defined(__linux__)
+        #define JEMALLOC_OVERRIDE_PVALLOC
+        #define JEMALLOC_OVERRIDE___LIBC_PVALLOC
+    #endif
+#endif
 
 /*
  * At least Linux omits the "const" in:

--- a/contrib/jemalloc-cmake/include/jemalloc/jemalloc_rename.h
+++ b/contrib/jemalloc-cmake/include/jemalloc/jemalloc_rename.h
@@ -2,11 +2,8 @@
  * Name mangling for public symbols is controlled by --with-mangling and
  * --with-jemalloc-prefix.  With default settings the je_ prefix is stripped by
  * these macro definitions.
- *
- * When JEMALLOC_PREFIX is defined (i.e. jemalloc is built with je_ prefix),
- * no renaming is needed — je_malloc IS the canonical symbol name.
  */
-#if !defined(JEMALLOC_NO_RENAME) && !defined(JEMALLOC_PREFIX)
+#ifndef JEMALLOC_NO_RENAME
 #  define je_aligned_alloc aligned_alloc
 #  define je_calloc calloc
 #  define je_dallocx dallocx

--- a/contrib/jemalloc-cmake/include_darwin_aarch64/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/contrib/jemalloc-cmake/include_darwin_aarch64/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -7,7 +7,7 @@
  * multiple allocators simultaneously.
  */
 #define JEMALLOC_PREFIX "je_"
-#define JEMALLOC_CPREFIX ""
+#define JEMALLOC_CPREFIX "JE_"
 
 /*
  * Define overrides for non-standard allocator-related functions if they are

--- a/contrib/jemalloc-cmake/include_darwin_x86_64/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/contrib/jemalloc-cmake/include_darwin_x86_64/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -7,7 +7,7 @@
  * multiple allocators simultaneously.
  */
 #define JEMALLOC_PREFIX "je_"
-#define JEMALLOC_CPREFIX ""
+#define JEMALLOC_CPREFIX "JE_"
 
 /*
  * Define overrides for non-standard allocator-related functions if they are

--- a/contrib/jemalloc-cmake/include_freebsd_aarch64/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/contrib/jemalloc-cmake/include_freebsd_aarch64/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -6,8 +6,8 @@
  * public APIs to be prefixed.  This makes it possible, with some care, to use
  * multiple allocators simultaneously.
  */
-#define JEMALLOC_PREFIX "je_"
-#define JEMALLOC_CPREFIX ""
+/* #undef JEMALLOC_PREFIX */
+/* #undef JEMALLOC_CPREFIX */
 
 /*
  * Define overrides for non-standard allocator-related functions if they are
@@ -412,7 +412,7 @@
 #define JEMALLOC_CONFIG_MALLOC_CONF "@JEMALLOC_CONFIG_MALLOC_CONF@"
 
 /* If defined, jemalloc takes the malloc/free/etc. symbol names. */
-/* #undef JEMALLOC_IS_MALLOC */
+#define JEMALLOC_IS_MALLOC
 
 /*
  * Defined if strerror_r returns char * if _GNU_SOURCE is defined.

--- a/contrib/jemalloc-cmake/include_freebsd_ppc64le/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/contrib/jemalloc-cmake/include_freebsd_ppc64le/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -6,8 +6,8 @@
  * public APIs to be prefixed.  This makes it possible, with some care, to use
  * multiple allocators simultaneously.
  */
-#define JEMALLOC_PREFIX "je_"
-#define JEMALLOC_CPREFIX ""
+/* #undef JEMALLOC_PREFIX */
+/* #undef JEMALLOC_CPREFIX */
 
 /*
  * Define overrides for non-standard allocator-related functions if they are
@@ -410,7 +410,7 @@
 #define JEMALLOC_CONFIG_MALLOC_CONF ""
 
 /* If defined, jemalloc takes the malloc/free/etc. symbol names. */
-/* #undef JEMALLOC_IS_MALLOC */
+#define JEMALLOC_IS_MALLOC 
 
 /*
  * Defined if strerror_r returns char * if _GNU_SOURCE is defined.

--- a/contrib/jemalloc-cmake/include_freebsd_x86_64/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/contrib/jemalloc-cmake/include_freebsd_x86_64/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -6,8 +6,8 @@
  * public APIs to be prefixed.  This makes it possible, with some care, to use
  * multiple allocators simultaneously.
  */
-#define JEMALLOC_PREFIX "je_"
-#define JEMALLOC_CPREFIX ""
+/* #undef JEMALLOC_PREFIX */
+/* #undef JEMALLOC_CPREFIX */
 
 /*
  * Define overrides for non-standard allocator-related functions if they are
@@ -412,7 +412,7 @@
 #define JEMALLOC_CONFIG_MALLOC_CONF "@JEMALLOC_CONFIG_MALLOC_CONF@"
 
 /* If defined, jemalloc takes the malloc/free/etc. symbol names. */
-/* #undef JEMALLOC_IS_MALLOC */
+#define JEMALLOC_IS_MALLOC
 
 /*
  * Defined if strerror_r returns char * if _GNU_SOURCE is defined.

--- a/contrib/jemalloc-cmake/include_linux_aarch64/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/contrib/jemalloc-cmake/include_linux_aarch64/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -6,19 +6,21 @@
  * public APIs to be prefixed.  This makes it possible, with some care, to use
  * multiple allocators simultaneously.
  */
-#define JEMALLOC_PREFIX "je_"
-#define JEMALLOC_CPREFIX ""
+/* #undef JEMALLOC_PREFIX */
+/* #undef JEMALLOC_CPREFIX */
 
 /*
  * Define overrides for non-standard allocator-related functions if they are
  * present on the system.
  */
-/* #undef JEMALLOC_OVERRIDE___LIBC_CALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_FREE */
-/* #undef JEMALLOC_OVERRIDE___LIBC_MALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_MEMALIGN */
-/* #undef JEMALLOC_OVERRIDE___LIBC_REALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_VALLOC */
+#if !defined(USE_MUSL)
+    #define JEMALLOC_OVERRIDE___LIBC_CALLOC
+    #define JEMALLOC_OVERRIDE___LIBC_FREE
+    #define JEMALLOC_OVERRIDE___LIBC_MALLOC
+    #define JEMALLOC_OVERRIDE___LIBC_MEMALIGN
+    #define JEMALLOC_OVERRIDE___LIBC_REALLOC
+    #define JEMALLOC_OVERRIDE___LIBC_VALLOC
+#endif
 /* #undef JEMALLOC_OVERRIDE___POSIX_MEMALIGN */
 
 /*
@@ -410,7 +412,7 @@
 #define JEMALLOC_CONFIG_MALLOC_CONF "@JEMALLOC_CONFIG_MALLOC_CONF@"
 
 /* If defined, jemalloc takes the malloc/free/etc. symbol names. */
-/* #undef JEMALLOC_IS_MALLOC */
+#define JEMALLOC_IS_MALLOC
 
 /*
  * Defined if strerror_r returns char * if _GNU_SOURCE is defined.

--- a/contrib/jemalloc-cmake/include_linux_e2k/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/contrib/jemalloc-cmake/include_linux_e2k/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -5,19 +5,19 @@
  * public APIs to be prefixed.  This makes it possible, with some care, to use
  * multiple allocators simultaneously.
  */
-#define JEMALLOC_PREFIX "je_"
-#define JEMALLOC_CPREFIX ""
+#undef JEMALLOC_PREFIX
+#undef JEMALLOC_CPREFIX
 
 /*
  * Define overrides for non-standard allocator-related functions if they are
  * present on the system.
  */
-/* #undef JEMALLOC_OVERRIDE___LIBC_CALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_FREE */
-/* #undef JEMALLOC_OVERRIDE___LIBC_MALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_MEMALIGN */
-/* #undef JEMALLOC_OVERRIDE___LIBC_REALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_VALLOC */
+#undef JEMALLOC_OVERRIDE___LIBC_CALLOC
+#undef JEMALLOC_OVERRIDE___LIBC_FREE
+#undef JEMALLOC_OVERRIDE___LIBC_MALLOC
+#undef JEMALLOC_OVERRIDE___LIBC_MEMALIGN
+#undef JEMALLOC_OVERRIDE___LIBC_REALLOC
+#undef JEMALLOC_OVERRIDE___LIBC_VALLOC
 #undef JEMALLOC_OVERRIDE___POSIX_MEMALIGN
 
 /*
@@ -356,7 +356,7 @@
 #undef JEMALLOC_CONFIG_MALLOC_CONF
 
 /* If defined, jemalloc takes the malloc/free/etc. symbol names. */
-/* #undef JEMALLOC_IS_MALLOC */
+#undef JEMALLOC_IS_MALLOC
 
 /*
  * Defined if strerror_r returns char * if _GNU_SOURCE is defined.

--- a/contrib/jemalloc-cmake/include_linux_ppc64le/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/contrib/jemalloc-cmake/include_linux_ppc64le/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -6,19 +6,21 @@
  * public APIs to be prefixed.  This makes it possible, with some care, to use
  * multiple allocators simultaneously.
  */
-#define JEMALLOC_PREFIX "je_"
-#define JEMALLOC_CPREFIX ""
+/* #undef JEMALLOC_PREFIX */
+/* #undef JEMALLOC_CPREFIX */
 
 /*
  * Define overrides for non-standard allocator-related functions if they are
  * present on the system.
  */
-/* #undef JEMALLOC_OVERRIDE___LIBC_CALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_FREE */
-/* #undef JEMALLOC_OVERRIDE___LIBC_MALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_MEMALIGN */
-/* #undef JEMALLOC_OVERRIDE___LIBC_REALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_VALLOC */
+#if !defined(USE_MUSL)
+    #define JEMALLOC_OVERRIDE___LIBC_CALLOC
+    #define JEMALLOC_OVERRIDE___LIBC_FREE
+    #define JEMALLOC_OVERRIDE___LIBC_MALLOC
+    #define JEMALLOC_OVERRIDE___LIBC_MEMALIGN
+    #define JEMALLOC_OVERRIDE___LIBC_REALLOC
+    #define JEMALLOC_OVERRIDE___LIBC_VALLOC
+#endif
 /* #undef JEMALLOC_OVERRIDE___POSIX_MEMALIGN */
 
 /*
@@ -410,7 +412,7 @@
 #define JEMALLOC_CONFIG_MALLOC_CONF "@JEMALLOC_CONFIG_MALLOC_CONF@"
 
 /* If defined, jemalloc takes the malloc/free/etc. symbol names. */
-/* #undef JEMALLOC_IS_MALLOC */
+#define JEMALLOC_IS_MALLOC
 
 /*
  * Defined if strerror_r returns char * if _GNU_SOURCE is defined.

--- a/contrib/jemalloc-cmake/include_linux_riscv64/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/contrib/jemalloc-cmake/include_linux_riscv64/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -6,19 +6,21 @@
  * public APIs to be prefixed.  This makes it possible, with some care, to use
  * multiple allocators simultaneously.
  */
-#define JEMALLOC_PREFIX "je_"
-#define JEMALLOC_CPREFIX ""
+/* #undef JEMALLOC_PREFIX */
+/* #undef JEMALLOC_CPREFIX */
 
 /*
  * Define overrides for non-standard allocator-related functions if they are
  * present on the system.
  */
-/* #undef JEMALLOC_OVERRIDE___LIBC_CALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_FREE */
-/* #undef JEMALLOC_OVERRIDE___LIBC_MALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_MEMALIGN */
-/* #undef JEMALLOC_OVERRIDE___LIBC_REALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_VALLOC */
+#if !defined(USE_MUSL)
+    #define JEMALLOC_OVERRIDE___LIBC_CALLOC
+    #define JEMALLOC_OVERRIDE___LIBC_FREE
+    #define JEMALLOC_OVERRIDE___LIBC_MALLOC
+    #define JEMALLOC_OVERRIDE___LIBC_MEMALIGN
+    #define JEMALLOC_OVERRIDE___LIBC_REALLOC
+    #define JEMALLOC_OVERRIDE___LIBC_VALLOC
+#endif
 /* #undef JEMALLOC_OVERRIDE___POSIX_MEMALIGN */
 
 /*
@@ -410,7 +412,7 @@
 #define JEMALLOC_CONFIG_MALLOC_CONF "@JEMALLOC_CONFIG_MALLOC_CONF@"
 
 /* If defined, jemalloc takes the malloc/free/etc. symbol names. */
-/* #undef JEMALLOC_IS_MALLOC */
+#define JEMALLOC_IS_MALLOC
 
 /*
  * Defined if strerror_r returns char * if _GNU_SOURCE is defined.

--- a/contrib/jemalloc-cmake/include_linux_s390x/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/contrib/jemalloc-cmake/include_linux_s390x/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -6,20 +6,20 @@
  * public APIs to be prefixed.  This makes it possible, with some care, to use
  * multiple allocators simultaneously.
  */
-#define JEMALLOC_PREFIX "je_"
-#define JEMALLOC_CPREFIX ""
+/* #undef JEMALLOC_PREFIX */
+/* #undef JEMALLOC_CPREFIX */
 
 /*
  * Define overrides for non-standard allocator-related functions if they are
  * present on the system.
  */
-/* #undef JEMALLOC_OVERRIDE___LIBC_CALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_FREE */
-/* #undef JEMALLOC_OVERRIDE___LIBC_MALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_MEMALIGN */
-/* #undef JEMALLOC_OVERRIDE___LIBC_REALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_VALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_PVALLOC */
+#define JEMALLOC_OVERRIDE___LIBC_CALLOC 
+#define JEMALLOC_OVERRIDE___LIBC_FREE 
+#define JEMALLOC_OVERRIDE___LIBC_MALLOC 
+#define JEMALLOC_OVERRIDE___LIBC_MEMALIGN 
+#define JEMALLOC_OVERRIDE___LIBC_REALLOC 
+#define JEMALLOC_OVERRIDE___LIBC_VALLOC 
+#define JEMALLOC_OVERRIDE___LIBC_PVALLOC 
 /* #undef JEMALLOC_OVERRIDE___POSIX_MEMALIGN */
 
 /*
@@ -410,7 +410,7 @@
 #define JEMALLOC_CONFIG_MALLOC_CONF ""
 
 /* If defined, jemalloc takes the malloc/free/etc. symbol names. */
-/* #undef JEMALLOC_IS_MALLOC */
+#define JEMALLOC_IS_MALLOC 
 
 /*
  * Defined if strerror_r returns char * if _GNU_SOURCE is defined.

--- a/contrib/jemalloc-cmake/include_linux_x86_64/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/contrib/jemalloc-cmake/include_linux_x86_64/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -6,19 +6,21 @@
  * public APIs to be prefixed.  This makes it possible, with some care, to use
  * multiple allocators simultaneously.
  */
-#define JEMALLOC_PREFIX "je_"
-#define JEMALLOC_CPREFIX ""
+/* #undef JEMALLOC_PREFIX */
+/* #undef JEMALLOC_CPREFIX */
 
 /*
  * Define overrides for non-standard allocator-related functions if they are
  * present on the system.
  */
-/* #undef JEMALLOC_OVERRIDE___LIBC_CALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_FREE */
-/* #undef JEMALLOC_OVERRIDE___LIBC_MALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_MEMALIGN */
-/* #undef JEMALLOC_OVERRIDE___LIBC_REALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_VALLOC */
+#if !defined(USE_MUSL)
+    #define JEMALLOC_OVERRIDE___LIBC_CALLOC
+    #define JEMALLOC_OVERRIDE___LIBC_FREE
+    #define JEMALLOC_OVERRIDE___LIBC_MALLOC
+    #define JEMALLOC_OVERRIDE___LIBC_MEMALIGN
+    #define JEMALLOC_OVERRIDE___LIBC_REALLOC
+    #define JEMALLOC_OVERRIDE___LIBC_VALLOC
+#endif
 /* #undef JEMALLOC_OVERRIDE___POSIX_MEMALIGN */
 
 /*
@@ -410,7 +412,7 @@
 #define JEMALLOC_CONFIG_MALLOC_CONF "@JEMALLOC_CONFIG_MALLOC_CONF@"
 
 /* If defined, jemalloc takes the malloc/free/etc. symbol names. */
-/* #undef JEMALLOC_IS_MALLOC */
+#define JEMALLOC_IS_MALLOC
 
 /*
  * Defined if strerror_r returns char * if _GNU_SOURCE is defined.

--- a/contrib/jemalloc-cmake/include_linux_x86_64_musl/jemalloc/internal/jemalloc_internal_defs.h.in
+++ b/contrib/jemalloc-cmake/include_linux_x86_64_musl/jemalloc/internal/jemalloc_internal_defs.h.in
@@ -6,19 +6,21 @@
  * public APIs to be prefixed.  This makes it possible, with some care, to use
  * multiple allocators simultaneously.
  */
-#define JEMALLOC_PREFIX "je_"
-#define JEMALLOC_CPREFIX ""
+/* #undef JEMALLOC_PREFIX */
+/* #undef JEMALLOC_CPREFIX */
 
 /*
  * Define overrides for non-standard allocator-related functions if they are
  * present on the system.
  */
-/* #undef JEMALLOC_OVERRIDE___LIBC_CALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_FREE */
-/* #undef JEMALLOC_OVERRIDE___LIBC_MALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_MEMALIGN */
-/* #undef JEMALLOC_OVERRIDE___LIBC_REALLOC */
-/* #undef JEMALLOC_OVERRIDE___LIBC_VALLOC */
+#if !defined(USE_MUSL)
+    #define JEMALLOC_OVERRIDE___LIBC_CALLOC
+    #define JEMALLOC_OVERRIDE___LIBC_FREE
+    #define JEMALLOC_OVERRIDE___LIBC_MALLOC
+    #define JEMALLOC_OVERRIDE___LIBC_MEMALIGN
+    #define JEMALLOC_OVERRIDE___LIBC_REALLOC
+    #define JEMALLOC_OVERRIDE___LIBC_VALLOC
+#endif
 /* #undef JEMALLOC_OVERRIDE___POSIX_MEMALIGN */
 
 /*
@@ -411,7 +413,7 @@
 #define JEMALLOC_CONFIG_MALLOC_CONF "@JEMALLOC_CONFIG_MALLOC_CONF@"
 
 /* If defined, jemalloc takes the malloc/free/etc. symbol names. */
-/* #undef JEMALLOC_IS_MALLOC */
+#define JEMALLOC_IS_MALLOC
 
 /*
  * Defined if strerror_r returns char * if _GNU_SOURCE is defined.

--- a/programs/keeper/keeper_main.cpp
+++ b/programs/keeper/keeper_main.cpp
@@ -125,15 +125,15 @@ extern "C"
 /// Some of these messages are non-actionable for the users, such as:
 /// <jemalloc>: Number of CPUs detected is not deterministic. Per-CPU arena disabled.
 #if USE_JEMALLOC && defined(NDEBUG) && !defined(SANITIZER)
-extern "C" void (*je_malloc_message)(void *, const char *s);
-__attribute__((constructor(0))) void init_je_malloc_message() { je_malloc_message = [](void *, const char *){}; }
+extern "C" void (*malloc_message)(void *, const char *s);
+__attribute__((constructor(0))) void init_je_malloc_message() { malloc_message = [](void *, const char *){}; }
 #elif USE_JEMALLOC
 #include <unordered_set>
 /// Ignore messages which can be safely ignored, e.g. EAGAIN on pthread_create
-extern "C" void (*je_malloc_message)(void *, const char * s);
+extern "C" void (*malloc_message)(void *, const char * s);
 __attribute__((constructor(0))) void init_je_malloc_message()
 {
-    je_malloc_message = [](void *, const char * str)
+    malloc_message = [](void *, const char * str)
     {
         using namespace std::literals;
         static const std::unordered_set<std::string_view> ignore_messages{

--- a/programs/local/fuzzers/clickhouse_fuzzer.cpp
+++ b/programs/local/fuzzers/clickhouse_fuzzer.cpp
@@ -69,15 +69,15 @@ using MainFunc = int (*)(int, char**);
 /// Some of these messages are non-actionable for the users, such as:
 /// <jemalloc>: Number of CPUs detected is not deterministic. Per-CPU arena disabled.
 #if USE_JEMALLOC && defined(NDEBUG) && !defined(SANITIZER)
-extern "C" void (*je_malloc_message)(void *, const char *s);
-__attribute__((constructor(0))) void init_je_malloc_message() { je_malloc_message = [](void *, const char *){}; }
+extern "C" void (*malloc_message)(void *, const char *s);
+__attribute__((constructor(0))) void init_je_malloc_message() { malloc_message = [](void *, const char *){}; }
 #elif USE_JEMALLOC
 #include <unordered_set>
 /// Ignore messages which can be safely ignored, e.g. EAGAIN on pthread_create
-extern "C" void (*je_malloc_message)(void *, const char * s);
+extern "C" void (*malloc_message)(void *, const char * s);
 __attribute__((constructor(0))) void init_je_malloc_message()
 {
-    je_malloc_message = [](void *, const char * str)
+    malloc_message = [](void *, const char * str)
     {
         using namespace std::literals;
         static const std::unordered_set<std::string_view> ignore_messages{

--- a/programs/main.cpp
+++ b/programs/main.cpp
@@ -276,15 +276,15 @@ extern "C"
 /// Some of these messages are non-actionable for the users, such as:
 /// <jemalloc>: Number of CPUs detected is not deterministic. Per-CPU arena disabled.
 #if USE_JEMALLOC && defined(NDEBUG) && !defined(SANITIZER)
-extern "C" void (*je_malloc_message)(void *, const char *s);
-__attribute__((constructor(0))) void init_je_malloc_message() { je_malloc_message = [](void *, const char *){}; }
+extern "C" void (*malloc_message)(void *, const char *s);
+__attribute__((constructor(0))) void init_je_malloc_message() { malloc_message = [](void *, const char *){}; }
 #elif USE_JEMALLOC
 #include <unordered_set>
 /// Ignore messages which can be safely ignored, e.g. EAGAIN on pthread_create
-extern "C" void (*je_malloc_message)(void *, const char * s);
+extern "C" void (*malloc_message)(void *, const char * s);
 __attribute__((constructor(0))) void init_je_malloc_message()
 {
-    je_malloc_message = [](void *, const char * str)
+    malloc_message = [](void *, const char * str)
     {
         using namespace std::literals;
         static const std::unordered_set<std::string_view> ignore_messages{

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -246,9 +246,6 @@ endif ()
 
 add_library (clickhouse_malloc OBJECT Common/malloc.cpp)
 set_source_files_properties(Common/malloc.cpp PROPERTIES COMPILE_FLAGS "-fno-builtin")
-if (TARGET ch_contrib::jemalloc)
-    target_link_libraries (clickhouse_malloc PRIVATE ch_contrib::jemalloc clickhouse_common_io)
-endif()
 
 add_library (clickhouse_new_delete STATIC Common/AllocationInterceptors.cpp)
 target_link_libraries (clickhouse_new_delete PRIVATE clickhouse_common_io)

--- a/src/Common/AllocationInterceptors.cpp
+++ b/src/Common/AllocationInterceptors.cpp
@@ -3,6 +3,7 @@
 #include "config.h"
 
 #include <Common/memory.h>
+#include <Common/AllocationInterceptors.h>
 
 #if defined(OS_DARWIN) && (USE_JEMALLOC)
 /// In case of OSX jemalloc register itself as a default zone allocator.
@@ -234,3 +235,155 @@ void operator delete[](void * ptr, std::size_t size, std::align_val_t align) noe
     trace.onFree(ptr, actual_size);
     Memory::deleteSized(ptr, size, align);
 }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+
+extern "C" void * __wrap_malloc(size_t size) // NOLINT
+{
+    AllocationTrace trace;
+    std::size_t actual_size = Memory::trackMemoryFromC(size, trace);
+    void * ptr = __real_malloc(size);
+    if (unlikely(!ptr))
+    {
+        trace = CurrentMemoryTracker::free(actual_size);
+        return nullptr;
+    }
+    trace.onAlloc(ptr, actual_size);
+    return ptr;
+}
+
+extern "C" void * __wrap_calloc(size_t number_of_members, size_t size) // NOLINT
+{
+    size_t real_size = 0;
+    if (__builtin_mul_overflow(number_of_members, size, &real_size))
+        return nullptr;
+
+    AllocationTrace trace;
+    size_t actual_size = Memory::trackMemoryFromC(real_size, trace);
+    void * res = __real_calloc(number_of_members, size);
+    if (unlikely(!res))
+    {
+        trace = CurrentMemoryTracker::free(actual_size);
+        return nullptr;
+    }
+    trace.onAlloc(res, actual_size);
+    return res;
+}
+
+extern "C" void * __wrap_realloc(void * ptr, size_t size) // NOLINT
+{
+    size_t old_size = 0;
+    if (ptr)
+    {
+        AllocationTrace trace;
+        old_size = Memory::untrackMemory(ptr, trace);
+        trace.onFree(ptr, old_size);
+    }
+    AllocationTrace trace;
+    size_t actual_size = Memory::trackMemoryFromC(size, trace);
+    void * res = __real_realloc(ptr, size);
+    if (unlikely(!res))
+    {
+        trace = CurrentMemoryTracker::free(actual_size);
+        Memory::trackMemoryFromC(old_size, trace);
+        return nullptr;
+    }
+    trace.onAlloc(res, actual_size);
+    return res;
+}
+
+extern "C" int __wrap_posix_memalign(void ** memptr, size_t alignment, size_t size) // NOLINT
+{
+    AllocationTrace trace;
+    size_t actual_size = Memory::trackMemoryFromC(size, trace, static_cast<std::align_val_t>(alignment));
+    int res = __real_posix_memalign(memptr, alignment, size);
+    if (unlikely(res != 0))
+    {
+        trace = CurrentMemoryTracker::free(actual_size);
+        return res;
+    }
+    trace.onAlloc(*memptr, actual_size);
+    return res;
+}
+
+extern "C" void * __wrap_aligned_alloc(size_t alignment, size_t size) // NOLINT
+{
+    AllocationTrace trace;
+    size_t actual_size = Memory::trackMemoryFromC(size, trace, static_cast<std::align_val_t>(alignment));
+    void * res = __real_aligned_alloc(alignment, size);
+    if (unlikely(!res))
+    {
+        trace = CurrentMemoryTracker::free(actual_size);
+        return nullptr;
+    }
+    trace.onAlloc(res, actual_size);
+    return res;
+}
+
+#if !defined(OS_FREEBSD)
+extern "C" void * __wrap_valloc(size_t size) // NOLINT
+{
+    AllocationTrace trace;
+    size_t actual_size = Memory::trackMemoryFromC(size, trace);
+    void * res = __real_valloc(size);
+    if (unlikely(!res))
+    {
+        trace = CurrentMemoryTracker::free(actual_size);
+        return nullptr;
+    }
+    trace.onAlloc(res, actual_size);
+    return res;
+}
+#endif
+
+extern "C" void * __wrap_reallocarray(void * ptr, size_t number_of_members, size_t size) // NOLINT
+{
+    size_t real_size = 0;
+    if (__builtin_mul_overflow(number_of_members, size, &real_size))
+        return nullptr;
+
+    return __wrap_realloc(ptr, real_size);
+}
+
+extern "C" void __wrap_free(void * ptr) // NOLINT
+{
+    AllocationTrace trace;
+    size_t actual_size = Memory::untrackMemory(ptr, trace);
+    trace.onFree(ptr, actual_size);
+    __real_free(ptr);
+}
+
+#if !defined(OS_DARWIN) && !defined(OS_FREEBSD)
+extern "C" void * __wrap_memalign(size_t alignment, size_t size) // NOLINT
+{
+    AllocationTrace trace;
+    size_t actual_size = Memory::trackMemoryFromC(size, trace, static_cast<std::align_val_t>(alignment));
+    void * res = __real_memalign(alignment, size);
+    if (unlikely(!res))
+    {
+        trace = CurrentMemoryTracker::free(actual_size);
+        return nullptr;
+    }
+    trace.onAlloc(res, actual_size);
+    return res;
+}
+#endif
+
+#if !defined(USE_MUSL) && defined(OS_LINUX)
+extern "C" void * __wrap_pvalloc(size_t size) // NOLINT
+{
+    AllocationTrace trace;
+    size_t actual_size = Memory::trackMemoryFromC(size, trace);
+    void * res = __real_pvalloc(size);
+    if (unlikely(!res))
+    {
+        trace = CurrentMemoryTracker::free(actual_size);
+        return nullptr;
+    }
+    trace.onAlloc(res, actual_size);
+    return res;
+}
+#endif
+
+#pragma clang diagnostic pop

--- a/src/Common/AllocationInterceptors.h
+++ b/src/Common/AllocationInterceptors.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include "config.h"
-
+#include <base/defines.h>
 #include <cstddef>
 
 #pragma clang diagnostic push
@@ -9,30 +8,37 @@
 
 // NOLINTBEGIN
 
-/// These macros provide direct access to the underlying allocator,
-/// bypassing the tracking wrappers in malloc.cpp.
-/// Use them in code that does its own memory tracking (e.g. Allocator, AllocatorWithMemoryTracking)
-/// to avoid double-counting.
-
-#if USE_JEMALLOC
-
-#include <jemalloc/jemalloc.h>
-
-#define __real_malloc(size) je_malloc(size)
-#define __real_calloc(nmemb, size) je_calloc(nmemb, size)
-#define __real_realloc(ptr, size) je_realloc(ptr, size)
-#define __real_posix_memalign(memptr, alignment, size) je_posix_memalign(memptr, alignment, size)
-#define __real_aligned_alloc(alignment, size) je_aligned_alloc(alignment, size)
-#define __real_free je_free
-
-#else
+#if defined(SANITIZER) || defined(SANITIZE_COVERAGE) || defined(OS_DARWIN) || defined(OS_FREEBSD) || defined(OS_SUNOS)
 
 #define __real_malloc(size) ::malloc(size)
 #define __real_calloc(nmemb, size) ::calloc(nmemb, size)
 #define __real_realloc(ptr, size) ::realloc(ptr, size)
 #define __real_posix_memalign(memptr, alignment, size) ::posix_memalign(memptr, alignment, size)
 #define __real_aligned_alloc(alignment, size) ::aligned_alloc(alignment, size)
+#define __real_valloc(size) ::valloc(size)
 #define __real_free ::free
+
+#if !defined(OS_DARWIN)
+#define __real_memalign(alignment, size) ::memalign(alignment, size)
+#endif
+
+#if !defined(USE_MUSL) && defined(OS_LINUX)
+#define __real_pvalloc(size) ::pvalloc(size)
+#endif
+
+#else
+
+extern "C" void * __real_malloc(size_t size);
+extern "C" void * __real_calloc(size_t nmemb, size_t size);
+extern "C" void * __real_realloc(void * ptr, size_t size);
+extern "C" int    __real_posix_memalign(void ** memptr, size_t alignment, size_t size);
+extern "C" void * __real_aligned_alloc(size_t alignment, size_t size);
+extern "C" void * __real_valloc(size_t size);
+extern "C" void * __real_memalign(size_t alignment, size_t size);
+extern "C" void   __real_free(void * ptr);
+#if !defined(USE_MUSL) && defined(OS_LINUX)
+extern "C" void * __real_pvalloc(size_t size);
+#endif
 
 #endif
 

--- a/src/Common/AsynchronousMetrics.cpp
+++ b/src/Common/AsynchronousMetrics.cpp
@@ -472,7 +472,7 @@ uint64_t updateJemallocEpoch()
 {
     uint64_t value = 0;
     size_t size = sizeof(value);
-    je_mallctl("epoch", &value, &size, &value, size);
+    mallctl("epoch", &value, &size, &value, size);
     return value;
 }
 

--- a/src/Common/Jemalloc.cpp
+++ b/src/Common/Jemalloc.cpp
@@ -35,7 +35,7 @@ namespace Jemalloc
 void purgeArenas()
 {
     Stopwatch watch;
-    je_mallctl("arena." STRINGIFY(MALLCTL_ARENAS_ALL) ".purge", nullptr, nullptr, nullptr, 0);
+    mallctl("arena." STRINGIFY(MALLCTL_ARENAS_ALL) ".purge", nullptr, nullptr, nullptr, 0);
     ProfileEvents::increment(ProfileEvents::MemoryAllocatorPurge);
     ProfileEvents::increment(ProfileEvents::MemoryAllocatorPurgeTimeMicroseconds, watch.elapsedMicroseconds());
 }
@@ -44,7 +44,7 @@ void checkProfilingEnabled()
 {
     bool active = true;
     size_t active_size = sizeof(active);
-    je_mallctl("opt.prof", &active, &active_size, nullptr, 0);
+    mallctl("opt.prof", &active, &active_size, nullptr, 0);
 
     if (!active)
         throw Exception(
@@ -58,10 +58,10 @@ std::string_view flushProfile(const char * file_prefix)
     checkProfilingEnabled();
     char * prefix_buffer;
     size_t prefix_size = sizeof(prefix_buffer);
-    int n = je_mallctl("opt.prof_prefix", &prefix_buffer, &prefix_size, nullptr, 0); // NOLINT
+    int n = mallctl("opt.prof_prefix", &prefix_buffer, &prefix_size, nullptr, 0); // NOLINT
     if (!n && std::string_view(prefix_buffer) != "jeprof")
     {
-        je_mallctl("prof.dump", nullptr, nullptr, nullptr, 0);
+        mallctl("prof.dump", nullptr, nullptr, nullptr, 0);
         return getLastFlushProfileForThread();
     }
 
@@ -69,7 +69,7 @@ std::string_view flushProfile(const char * file_prefix)
     std::string profile_dump_path = fmt::format("{}.{}.{}.heap", file_prefix, getpid(), profile_counter.fetch_add(1));
     const auto * profile_dump_path_str = profile_dump_path.c_str();
 
-    je_mallctl("prof.dump", nullptr, nullptr, &profile_dump_path_str, sizeof(profile_dump_path_str)); // NOLINT
+    mallctl("prof.dump", nullptr, nullptr, &profile_dump_path_str, sizeof(profile_dump_path_str)); // NOLINT
     return getLastFlushProfileForThread();
 }
 
@@ -89,7 +89,7 @@ void setProfileSamplingRate(size_t lg_prof_sample)
     if (current == lg_prof_sample)
         return;
 
-    je_mallctl("prof.reset", nullptr, nullptr, &lg_prof_sample, sizeof(lg_prof_sample));
+    mallctl("prof.reset", nullptr, nullptr, &lg_prof_sample, sizeof(lg_prof_sample));
 }
 
 

--- a/src/Common/Jemalloc.h
+++ b/src/Common/Jemalloc.h
@@ -51,7 +51,7 @@ void setMaxBackgroundThreads(size_t max_threads);
 template <typename T>
 void setValue(const char * name, T value)
 {
-    je_mallctl(name, nullptr, nullptr, reinterpret_cast<void*>(&value), sizeof(T));
+    mallctl(name, nullptr, nullptr, reinterpret_cast<void*>(&value), sizeof(T));
 }
 
 template <typename T>
@@ -59,7 +59,7 @@ T getValue(const char * name)
 {
     T value;
     size_t value_size = sizeof(T);
-    je_mallctl(name, &value, &value_size, nullptr, 0);
+    mallctl(name, &value, &value_size, nullptr, 0);
     return value;
 }
 
@@ -88,25 +88,25 @@ struct MibCache
 {
     explicit MibCache(const char * name)
     {
-        je_mallctlnametomib(name, mib, &mib_length);
+        mallctlnametomib(name, mib, &mib_length);
     }
 
     void setValue(T value) const
     {
-        je_mallctlbymib(mib, mib_length, nullptr, nullptr, reinterpret_cast<void*>(&value), sizeof(T));
+        mallctlbymib(mib, mib_length, nullptr, nullptr, reinterpret_cast<void*>(&value), sizeof(T));
     }
 
     T getValue() const
     {
         T value;
         size_t value_size = sizeof(T);
-        je_mallctlbymib(mib, mib_length, &value, &value_size, nullptr, 0);
+        mallctlbymib(mib, mib_length, &value, &value_size, nullptr, 0);
         return value;
     }
 
     void run() const
     {
-        je_mallctlbymib(mib, mib_length, nullptr, nullptr, nullptr, 0);
+        mallctlbymib(mib, mib_length, nullptr, nullptr, nullptr, 0);
     }
 
 private:

--- a/src/Common/JemallocCacheAllocator.cpp
+++ b/src/Common/JemallocCacheAllocator.cpp
@@ -54,7 +54,7 @@ void * JemallocCacheAllocator::alloc(size_t size, size_t alignment)
     checkSize(size);
     auto trace = CurrentMemoryTracker::alloc(size);
 
-    void * ptr = je_mallocx(size, arenaFlags(alignment));
+    void * ptr = mallocx(size, arenaFlags(alignment));
     if (unlikely(!ptr))
     {
         [[maybe_unused]] auto trace_free = CurrentMemoryTracker::free(size);
@@ -70,7 +70,7 @@ void JemallocCacheAllocator::free(void * buf, size_t size)
     try
     {
         checkSize(size);
-        je_sdallocx(buf, size, freeFlags());
+        sdallocx(buf, size, freeFlags());
         auto trace = CurrentMemoryTracker::free(size);
         trace.onFree(buf, size);
     }
@@ -90,7 +90,7 @@ void * JemallocCacheAllocator::realloc(void * buf, size_t old_size, size_t new_s
 
     auto trace_alloc = CurrentMemoryTracker::alloc(new_size);
 
-    void * new_buf = je_rallocx(buf, new_size, arenaFlags(alignment));
+    void * new_buf = rallocx(buf, new_size, arenaFlags(alignment));
     if (unlikely(!new_buf))
     {
         [[maybe_unused]] auto trace_free = CurrentMemoryTracker::free(new_size);

--- a/src/Common/JemallocCacheArena.cpp
+++ b/src/Common/JemallocCacheArena.cpp
@@ -43,7 +43,7 @@ unsigned createArena()
 {
     unsigned arena_index = 0;
     size_t arena_index_size = sizeof(arena_index);
-    int err = je_mallctl("arenas.create", &arena_index, &arena_index_size, nullptr, 0);
+    int err = mallctl("arenas.create", &arena_index, &arena_index_size, nullptr, 0);
     if (err)
         throw DB::Exception(DB::ErrorCodes::CANNOT_ALLOCATE_MEMORY, "JemallocCacheArena: Failed to create jemalloc arena, error: {}", err);
     arena_created = true;

--- a/src/Common/malloc.cpp
+++ b/src/Common/malloc.cpp
@@ -1,242 +1,44 @@
-#include "config.h"
-
-#if USE_JEMALLOC && (defined(OS_LINUX) || defined(OS_FREEBSD))
-
-#include <cerrno>
+#if defined(OS_LINUX)
 #include <cstdlib>
-#include <cstddef>
 
-#include <jemalloc/jemalloc.h>
-
-#include <Common/memory.h>
-#include <base/getPageSize.h>
-
-/// Define standard allocation functions that perform memory tracking
-/// and delegate to jemalloc via je_* prefixed functions.
-///
-/// This replaces the previous --wrap linker approach with direct symbol
-/// interposition: malloc.cpp compiles to a dedicated object (clickhouse_malloc.o)
-/// that appears before libjemalloc.a in the link order.
-///
-/// jemalloc with je_ prefix does not export valloc/memalign/pvalloc,
-/// so we implement them via je_posix_memalign / je_aligned_alloc.
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wreserved-identifier"
+/// Interposing these symbols explicitly. The idea works like this: malloc.cpp compiles to a
+/// dedicated object (namely clickhouse_malloc.o), and it will show earlier in the link command
+/// than malloc libs like libjemalloc.a. As a result, these symbols get picked in time right after.
 
 extern "C"
 {
-
-void * malloc(size_t size)
-{
-    AllocationTrace trace;
-    size_t actual_size = Memory::trackMemoryFromC(size, trace);
-    void * ptr = je_malloc(size);
-    if (unlikely(!ptr))
-    {
-        trace = CurrentMemoryTracker::free(actual_size);
-        return nullptr;
-    }
-    trace.onAlloc(ptr, actual_size);
-    return ptr;
+    void *malloc(size_t size);
+    void free(void *ptr);
+    void *calloc(size_t nmemb, size_t size);
+    void *realloc(void *ptr, size_t size);
+    int posix_memalign(void **memptr, size_t alignment, size_t size);
+    void *aligned_alloc(size_t alignment, size_t size);
+    void *valloc(size_t size);
+    void *memalign(size_t alignment, size_t size);
+#if !defined(USE_MUSL)
+    void *pvalloc(size_t size);
+#endif
 }
 
-void free(void * ptr)
+template<typename T>
+inline void ignore(T x __attribute__((unused)))
 {
-    AllocationTrace trace;
-    size_t actual_size = Memory::untrackMemory(ptr, trace);
-    trace.onFree(ptr, actual_size);
-    je_free(ptr);
 }
 
-void * calloc(size_t nmemb, size_t size)
+static void dummyFunctionForInterposing() __attribute__((used));
+static void dummyFunctionForInterposing()
 {
-    size_t real_size = 0;
-    if (__builtin_mul_overflow(nmemb, size, &real_size))
-    {
-        errno = ENOMEM;
-        return nullptr;
-    }
-
-    AllocationTrace trace;
-    size_t actual_size = Memory::trackMemoryFromC(real_size, trace);
-    void * ptr = je_calloc(nmemb, size);
-    if (unlikely(!ptr))
-    {
-        trace = CurrentMemoryTracker::free(actual_size);
-        return nullptr;
-    }
-    trace.onAlloc(ptr, actual_size);
-    return ptr;
-}
-
-void * realloc(void * ptr, size_t size)
-{
-    size_t old_actual_size = 0;
-    if (ptr)
-        old_actual_size = je_sallocx(ptr, 0);
-
-    AllocationTrace trace;
-    size_t actual_size = Memory::trackMemoryFromC(size, trace);
-    void * res = je_realloc(ptr, size);
-    if (unlikely(!res))
-    {
-        trace = CurrentMemoryTracker::free(actual_size);
-        /// With jemalloc opt.zero_realloc:free (the default), realloc(ptr, 0)
-        /// frees ptr and returns nullptr. That is not a failure — untrack the old allocation.
-        if (size == 0 && ptr)
-        {
-            AllocationTrace free_trace = CurrentMemoryTracker::free(old_actual_size);
-            free_trace.onFree(ptr, old_actual_size);
-        }
-        return nullptr;
-    }
-
-    if (ptr)
-    {
-        AllocationTrace free_trace = CurrentMemoryTracker::free(old_actual_size);
-        free_trace.onFree(ptr, old_actual_size);
-    }
-    trace.onAlloc(res, actual_size);
-    return res;
-}
-
-int posix_memalign(void ** memptr, size_t alignment, size_t size)
-{
-    if (alignment < sizeof(void *) || (alignment & (alignment - 1)) != 0)
-        return EINVAL;
-    AllocationTrace trace;
-    size_t actual_size = Memory::trackMemoryFromC(size, trace, static_cast<std::align_val_t>(alignment));
-    int res = je_posix_memalign(memptr, alignment, size);
-    if (unlikely(res != 0))
-    {
-        trace = CurrentMemoryTracker::free(actual_size);
-        return res;
-    }
-    trace.onAlloc(*memptr, actual_size);
-    return res;
-}
-
-void * aligned_alloc(size_t alignment, size_t size)
-{
-    if (alignment == 0 || (alignment & (alignment - 1)) != 0 || (size % alignment) != 0)
-    {
-        errno = EINVAL;
-        return nullptr;
-    }
-    AllocationTrace trace;
-    size_t actual_size = Memory::trackMemoryFromC(size, trace, static_cast<std::align_val_t>(alignment));
-    void * res = je_aligned_alloc(alignment, size);
-    if (unlikely(!res))
-    {
-        trace = CurrentMemoryTracker::free(actual_size);
-        return nullptr;
-    }
-    trace.onAlloc(res, actual_size);
-    return res;
-}
-
-#if !defined(OS_FREEBSD)
-void * valloc(size_t size)
-{
-    void * res = nullptr;
-    size_t page_size = getPageSize();
-    AllocationTrace trace;
-    size_t actual_size = Memory::trackMemoryFromC(size, trace, static_cast<std::align_val_t>(page_size));
-    int err = je_posix_memalign(&res, page_size, size);
-    if (unlikely(err != 0))
-    {
-        trace = CurrentMemoryTracker::free(actual_size);
-        errno = err;
-        return nullptr;
-    }
-    trace.onAlloc(res, actual_size);
-    return res;
+    void* dummy;
+    free(nullptr); // NOLINT
+    ignore(malloc(0)); // NOLINT
+    ignore(calloc(0, 0)); // NOLINT
+    ignore(realloc(nullptr, 0)); // NOLINT
+    ignore(posix_memalign(&dummy, 0, 0)); // NOLINT
+    ignore(aligned_alloc(1, 0)); // NOLINT
+    ignore(valloc(0)); // NOLINT
+    ignore(memalign(0, 0)); // NOLINT
+#if !defined(USE_MUSL)
+    ignore(pvalloc(0)); // NOLINT
+#endif
 }
 #endif
-
-void * memalign(size_t alignment, size_t size)
-{
-    void * res = nullptr;
-    if (alignment == 0 || (alignment & (alignment - 1)) != 0)
-    {
-        errno = EINVAL;
-        return nullptr;
-    }
-    /// posix_memalign requires alignment >= sizeof(void*); widen valid small powers of two.
-    size_t effective_alignment = alignment < sizeof(void *) ? sizeof(void *) : alignment;
-    AllocationTrace trace;
-    size_t actual_size = Memory::trackMemoryFromC(size, trace, static_cast<std::align_val_t>(effective_alignment));
-    int err = je_posix_memalign(&res, effective_alignment, size);
-    if (unlikely(err != 0))
-    {
-        trace = CurrentMemoryTracker::free(actual_size);
-        errno = err;
-        return nullptr;
-    }
-    trace.onAlloc(res, actual_size);
-    return res;
-}
-
-#if !defined(USE_MUSL) && defined(OS_LINUX)
-void * pvalloc(size_t size)
-{
-    void * res = nullptr;
-    size_t page_size = getPageSize();
-    size_t rounded_size = size + page_size - 1;
-    if (unlikely(rounded_size < size))
-    {
-        errno = ENOMEM;
-        return nullptr;
-    }
-    rounded_size = rounded_size / page_size * page_size;
-    AllocationTrace trace;
-    size_t actual_size = Memory::trackMemoryFromC(rounded_size, trace, static_cast<std::align_val_t>(page_size));
-    int err = je_posix_memalign(&res, page_size, rounded_size);
-    if (unlikely(err != 0))
-    {
-        trace = CurrentMemoryTracker::free(actual_size);
-        errno = err;
-        return nullptr;
-    }
-    trace.onAlloc(res, actual_size);
-    return res;
-}
-#endif
-
-void * reallocarray(void * ptr, size_t nmemb, size_t size)
-{
-    size_t real_size = 0;
-    if (__builtin_mul_overflow(nmemb, size, &real_size))
-    {
-        errno = ENOMEM;
-        return nullptr;
-    }
-
-    return realloc(ptr, real_size);
-}
-
-size_t malloc_usable_size(void * ptr)
-{
-    return je_malloc_usable_size(ptr);
-}
-
-/// On Linux (non-musl), glibc internally calls __libc_malloc etc.
-/// We provide aliases so those internal calls also go through our wrappers.
-#if !defined(USE_MUSL) && defined(OS_LINUX)
-
-void * __libc_malloc(size_t size) __attribute__((alias("malloc"))); // NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
-void __libc_free(void * ptr) __attribute__((alias("free"))); // NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
-void * __libc_calloc(size_t nmemb, size_t size) __attribute__((alias("calloc"))); // NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
-void * __libc_realloc(void * ptr, size_t size) __attribute__((alias("realloc"))); // NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
-void * __libc_memalign(size_t alignment, size_t size) __attribute__((alias("memalign"))); // NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
-void * __libc_valloc(size_t size) __attribute__((alias("valloc"))); // NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
-void * __libc_pvalloc(size_t size) __attribute__((alias("pvalloc"))); // NOLINT(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
-
-#endif
-
-} // extern "C"
-
-#pragma clang diagnostic pop
-
-#endif // USE_JEMALLOC && (OS_LINUX || OS_FREEBSD)

--- a/src/Common/memory.h
+++ b/src/Common/memory.h
@@ -9,6 +9,16 @@
 #include <Common/MemoryTrackerDebugBlockerInThread.h>
 #include <Common/ProfileEvents.h>
 
+#include "config.h"
+
+#if USE_JEMALLOC
+#    include <jemalloc/jemalloc.h>
+#endif
+
+#if !USE_JEMALLOC
+#    include <cstdlib>
+#endif
+
 #if defined(OS_LINUX)
 #    include <malloc.h>
 #elif defined(OS_DARWIN)
@@ -63,9 +73,9 @@ inline ALWAYS_INLINE void deleteSized(void * ptr, std::size_t size, TAlign... al
         return;
 
     if constexpr (sizeof...(TAlign) == 1)
-        je_sdallocx(ptr, size, MALLOCX_ALIGN(alignToSizeT(align...)));
+        sdallocx(ptr, size, MALLOCX_ALIGN(alignToSizeT(align...)));
     else
-        je_sdallocx(ptr, size, 0);
+        sdallocx(ptr, size, 0);
 }
 
 #else
@@ -93,13 +103,9 @@ inline ALWAYS_INLINE size_t getActualAllocationSize(size_t size, TAlign... align
         size_for_nallocx = 1;
 
     if constexpr (sizeof...(TAlign) == 1)
-    {
-        actual_size = je_nallocx(size_for_nallocx, MALLOCX_ALIGN(alignToSizeT(align...)));
-    }
+        actual_size = nallocx(size_for_nallocx, MALLOCX_ALIGN(alignToSizeT(align...)));
     else
-    {
-        actual_size = je_nallocx(size_for_nallocx, 0);
-    }
+        actual_size = nallocx(size_for_nallocx, 0);
 #endif
 
     return actual_size;
@@ -139,9 +145,9 @@ inline ALWAYS_INLINE size_t untrackMemory(void * ptr [[maybe_unused]], Allocatio
         if (ptr != nullptr) [[likely]]
         {
             if constexpr (sizeof...(TAlign) == 1)
-                actual_size = je_sallocx(ptr, MALLOCX_ALIGN(alignToSizeT(align...)));
+                actual_size = sallocx(ptr, MALLOCX_ALIGN(alignToSizeT(align...)));
             else
-                actual_size = je_sallocx(ptr, 0);
+                actual_size = sallocx(ptr, 0);
         }
 #else
         if (size)

--- a/src/Coordination/FourLetterCommand.cpp
+++ b/src/Coordination/FourLetterCommand.cpp
@@ -665,7 +665,7 @@ void printToString(void * output, const char * data)
 String JemallocDumpStats::run()
 {
     std::string output;
-    je_malloc_stats_print(printToString, &output, nullptr);
+    malloc_stats_print(printToString, &output, nullptr);
     return output;
 }
 

--- a/src/Parsers/examples/parser_memory_profiler.cpp
+++ b/src/Parsers/examples/parser_memory_profiler.cpp
@@ -22,7 +22,12 @@
  * WITH HEAP PROFILING (generates .heap files for jeprof analysis)
  * ---------------------------------------------------------------
  *
- *   MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:0 \
+ *   # On macOS (jemalloc uses je_ prefix):
+ *   JE_MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:0 \
+ *       ./parser_memory_profiler --profile /tmp/query_ <<< 'SELECT 1;'
+ *
+ *   # On Linux:
+ *   MALLOC_CONF=prof:true,lg_prof_sample:0 \
  *       ./parser_memory_profiler --profile /tmp/query_ <<< 'SELECT 1;'
  *
  *   # This generates:
@@ -66,6 +71,7 @@
  */
 
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <cstdlib>
 #include <filesystem>
@@ -89,7 +95,7 @@ namespace
 /// Flush jemalloc thread cache to get accurate global stats
 void flushJemallocThreadCache()
 {
-    int ret = je_mallctl("thread.tcache.flush", nullptr, nullptr, nullptr, 0);
+    int ret = mallctl("thread.tcache.flush", nullptr, nullptr, nullptr, 0);
     if (ret != 0)
         std::cerr << "Warning: thread.tcache.flush failed: " << ret << "\n";
 }
@@ -99,7 +105,7 @@ void refreshJemallocEpoch()
 {
     uint64_t epoch = 1;
     size_t epoch_size = sizeof(epoch);
-    int ret = je_mallctl("epoch", &epoch, &epoch_size, &epoch, epoch_size);
+    int ret = mallctl("epoch", &epoch, &epoch_size, &epoch, epoch_size);
     if (ret != 0)
         std::cerr << "Warning: epoch refresh failed: " << ret << "\n";
 }
@@ -109,7 +115,7 @@ size_t getJemallocAllocated()
 {
     size_t allocated = 0;
     size_t allocated_size = sizeof(allocated);
-    int ret = je_mallctl("stats.allocated", &allocated, &allocated_size, nullptr, 0);
+    int ret = mallctl("stats.allocated", &allocated, &allocated_size, nullptr, 0);
     if (ret != 0)
         std::cerr << "Warning: stats.allocated failed: " << ret << "\n";
     return allocated;
@@ -120,7 +126,7 @@ bool isProfilingCompiled()
 {
     bool compiled = false;
     size_t sz = sizeof(compiled);
-    int ret = je_mallctl("config.prof", &compiled, &sz, nullptr, 0);
+    int ret = mallctl("config.prof", &compiled, &sz, nullptr, 0);
     return (ret == 0) && compiled;
 }
 
@@ -129,7 +135,7 @@ bool isProfilingEnabled()
 {
     bool enabled = false;
     size_t enabled_size = sizeof(enabled);
-    int ret = je_mallctl("opt.prof", &enabled, &enabled_size, nullptr, 0);
+    int ret = mallctl("opt.prof", &enabled, &enabled_size, nullptr, 0);
     if (ret != 0)
     {
         std::cerr << "Warning: opt.prof query failed: " << ret << "\n";
@@ -147,7 +153,7 @@ bool tryEnableProfiling()
 
     /// Try to enable prof.active
     bool active = true;
-    int ret = je_mallctl("prof.active", nullptr, nullptr, &active, sizeof(active));
+    int ret = mallctl("prof.active", nullptr, nullptr, &active, sizeof(active));
     if (ret != 0)
     {
         std::cerr << "Note: Cannot enable prof.active at runtime (ret=" << ret << ")\n";
@@ -161,7 +167,7 @@ bool tryEnableProfiling()
 /// Reset jemalloc profiler counters
 bool resetProfiler()
 {
-    int ret = je_mallctl("prof.reset", nullptr, nullptr, nullptr, 0);
+    int ret = mallctl("prof.reset", nullptr, nullptr, nullptr, 0);
     if (ret != 0)
     {
         std::cerr << "Warning: prof.reset failed: " << ret << "\n";
@@ -176,7 +182,7 @@ std::string dumpProfile(const std::string & prefix)
     static std::atomic<size_t> counter{0};
     std::string path = prefix + std::to_string(getpid()) + "." + std::to_string(counter.fetch_add(1)) + ".heap";
     const char * path_ptr = path.c_str();
-    int ret = je_mallctl("prof.dump", nullptr, nullptr, &path_ptr, sizeof(path_ptr));
+    int ret = mallctl("prof.dump", nullptr, nullptr, &path_ptr, sizeof(path_ptr));
     if (ret != 0)
     {
         std::cerr << "Error: prof.dump failed: " << ret << " (path: " << path << ")\n";
@@ -202,12 +208,12 @@ void printProfilingStatus()
 
     bool prof_compiled = false;
     size_t sz = sizeof(prof_compiled);
-    int ret = je_mallctl("config.prof", &prof_compiled, &sz, nullptr, 0);
+    int ret = mallctl("config.prof", &prof_compiled, &sz, nullptr, 0);
     std::cerr << "  config.prof (compiled with profiling): " << (ret == 0 ? (prof_compiled ? "yes" : "no") : "error") << "\n";
 
     bool prof_enabled = false;
     sz = sizeof(prof_enabled);
-    ret = je_mallctl("opt.prof", &prof_enabled, &sz, nullptr, 0);
+    ret = mallctl("opt.prof", &prof_enabled, &sz, nullptr, 0);
     std::cerr << "  opt.prof (profiling enabled at runtime): " << (ret == 0 ? (prof_enabled ? "yes" : "no") : "error") << "\n";
 
     if (!prof_compiled)
@@ -219,8 +225,10 @@ void printProfilingStatus()
     else if (!prof_enabled)
     {
         std::cerr << "\nProfiler is compiled but not enabled. This must be set at startup.\n";
-        std::cerr << "\nUse MALLOC_CONF to enable profiling:\n";
-        std::cerr << "  MALLOC_CONF=prof:true,prof_active:true <program> --profile <prefix>\n";
+        std::cerr << "\nOn macOS (jemalloc with je_ prefix), use JE_MALLOC_CONF:\n";
+        std::cerr << "  JE_MALLOC_CONF=prof:true,prof_active:true <program> --profile <prefix>\n";
+        std::cerr << "\nOn Linux (jemalloc without prefix), use MALLOC_CONF:\n";
+        std::cerr << "  MALLOC_CONF=prof:true <program> --profile <prefix>\n";
     }
 }
 
@@ -330,7 +338,7 @@ try
 
         /// Enable per-thread profiling (ClickHouse jemalloc defaults to prof_thread_active_init:false)
         bool thread_active = true;
-        je_mallctl("thread.prof.active", nullptr, nullptr, &thread_active, sizeof(thread_active));
+        mallctl("thread.prof.active", nullptr, nullptr, &thread_active, sizeof(thread_active));
 
         /// Reset profiler and dump initial state
         resetProfiler();

--- a/src/Storages/System/StorageSystemJemalloc.cpp
+++ b/src/Storages/System/StorageSystemJemalloc.cpp
@@ -25,7 +25,7 @@ UInt64 getJeMallocValue(const char * name)
 {
     UInt64 value{};
     size_t size = sizeof(value);
-    je_mallctl(name, &value, &size, nullptr, 0);
+    mallctl(name, &value, &size, nullptr, 0);
     /// mallctl() fills the value with 32 bit integer for some queries("arenas.nbins" for example).
     /// In this case variable 'size' will be changed from 8 to 4 and the 64 bit variable 'value' will hold the 32 bit actual value times 2^32 on big-endian machines.
     /// We should right shift the value by 32 on big-endian machines(which is unnecessary on little-endian machines).

--- a/src/Storages/System/StorageSystemJemallocStats.cpp
+++ b/src/Storages/System/StorageSystemJemallocStats.cpp
@@ -31,7 +31,7 @@ void StorageSystemJemallocStats::fillData(
     };
 
     std::string stats;
-    je_malloc_stats_print(print_to_string, &stats, nullptr);
+    malloc_stats_print(print_to_string, &stats, nullptr);
 
     res_columns[0]->insert(stats);
 #else

--- a/utils/parser-memory-profiler/README.md
+++ b/utils/parser-memory-profiler/README.md
@@ -173,7 +173,7 @@ Shows side-by-side comparison:
 
 2. **run_profiler.sh**:
    - Iterates through queries in the input file
-   - Runs `parser_memory_profiler` with `MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:0`
+   - Runs `parser_memory_profiler` with `JE_MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:0`
    - Uses `jeprof` to analyze heap profile diffs
    - Generates text reports, collapsed stacks, and SVGs
    - Collects everything into `results.json`
@@ -187,11 +187,12 @@ Shows side-by-side comparison:
 
 | Variable | Description |
 |----------|-------------|
-| `MALLOC_CONF` | jemalloc configuration |
+| `JE_MALLOC_CONF` | jemalloc configuration (macOS with `je_` prefix) |
+| `MALLOC_CONF` | jemalloc configuration (Linux) |
 
 Required settings for profiling:
 ```bash
-MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:0
+JE_MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:0
 ```
 
 - `prof:true` - Enable profiling support

--- a/utils/parser-memory-profiler/run_profiler.sh
+++ b/utils/parser-memory-profiler/run_profiler.sh
@@ -171,8 +171,10 @@ process_query() {
     echo -e "${GREEN}Processing query $id...${NC}" >&2
     
     # Run profiler with jemalloc profiling
+    # JE_MALLOC_CONF is used on macOS, MALLOC_CONF on Linux
     local output
-    output=$(MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:0 \
+    output=$(JE_MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:0 \
+        MALLOC_CONF=prof:true,prof_active:true,lg_prof_sample:0 \
         "$PROFILER" --profile "$profile_prefix" <<< "$query" 2>/dev/null)
     
     # Parse the output (format: length \t before \t after \t diff)


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Revert: Integrate jemalloc with je_ prefix and remove usage of linker's --wrap (it leads to crashes)

I'm working on a proper fix, but it will require sometime to understand what happens, while we have the problem in 26.3 release

Reverts: https://github.com/ClickHouse/ClickHouse/pull/99342
~~Reverts: https://github.com/ClickHouse/ClickHouse/pull/101626~~

Fixes: https://github.com/ClickHouse/ClickHouse/issues/101915