### PR TITLE
Unpoison fiber stack after context switch on AArch64 to fix MSan false positives

### DIFF
--- a/src/Common/FiberStack.cpp
+++ b/src/Common/FiberStack.cpp
@@ -79,6 +79,8 @@ boost::context::stack_context FiberStack::allocate() const
     /// in the caller. On the main thread stack this is harmless (OS zero-inits pages),
     /// but on heap-allocated fiber stacks the dirty shadow can propagate via stack slot
     /// reuse and eventually trigger false positives in unrelated code.
+    /// This unpoison provides a clean initial state; on AArch64, dirty shadow also
+    /// accumulates across context switches and is re-cleaned in fiber_ucontext.hpp.
     __msan_unpoison(data, num_bytes);
 
     boost::context::stack_context sctx;


### PR DESCRIPTION
On AArch64, LLVM loses MSan shadow for struct-padding bytes in return values ([llvm/llvm-project#54476](https://github.com/llvm/llvm-project/issues/54476)). On heap-allocated fiber stacks the dirty shadow accumulates across context switches and propagates via stack-slot reuse, triggering false positives in unrelated code.

The one-time `__msan_unpoison` at fiber allocation (in `FiberStack::allocate`) is insufficient because `BOOST_USE_MSAN` (added in #102158) now properly preserves shadow across context switches — including the dirty padding shadow. This caused a spike from ~1-5 failures/day to 81 failures on April 9 for STID 1478-2063.

Fix by calling `__msan_unpoison` on the whole fiber stack after every `__msan_finish_switch_fiber` on AArch64 in `fiber_ucontext.hpp`. This clears accumulated dirty padding without affecting the main thread stack.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97744&sha=aa7dccac1cbacd8009ec368bdbf6045ff7bc3c29&name_0=PR&name_1=Stress%20test%20%28arm_msan%29

Fixes: https://github.com/ClickHouse/ClickHouse/issues/102241

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)