### PR TITLE
fix: align curl password with docker run example in networking docs

### DIFF
--- a/docker/server/README.src/content.md
+++ b/docker/server/README.src/content.md
@@ -72,8 +72,8 @@ docker rm some-clickhouse-server
 You can expose your ClickHouse running in docker by [mapping a particular port](https://docs.docker.com/config/containers/container-networking/) from inside the container using host ports:
 
 ```bash
-docker run -d -p 18123:8123 -p 19000:9000 -e CLICKHOUSE_PASSWORD=changeme --name some-clickhouse-server --ulimit nofile=262144:262144 %%IMAGE%%
-echo 'SELECT version()' | curl 'http://localhost:18123/?password=changeme' --data-binary @-
+docker run -d -p 18123:8123 -p 19000:9000 -e CLICKHOUSE_PASSWORD=yourpassword --name some-clickhouse-server --ulimit nofile=262144:262144 %%IMAGE%%
+echo 'SELECT version()' | curl 'http://localhost:18123/?password=yourpassword' --data-binary @-
 ```
 
 `22.6.3.35`


### PR DESCRIPTION
Closes #102315

## Problem

In `docker/server/README.src/content.md`, the networking example has **mismatched passwords**:

```bash
docker run -d -p 18123:8123 -p 19000:9000 -e CLICKHOUSE_PASSWORD=*** --name some-clickhouse-server ...
echo 'SELECT version()' | curl 'http://localhost:18123/?password=changeme' --data-binary @-
```

The server sets password `***` but the curl command uses `changeme` — these do not match, so the example will always fail with an authentication error.

## Fix

Changed both the `CLICKHOUSE_PASSWORD` env var and the curl `?password` parameter to use the consistent placeholder `yourpassword`, making the example self-consistent and functional.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed mismatched passwords in the Docker networking example in the ClickHouse server README documentation.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)