### PR TITLE
Add QueryBatchingQueue for batching identical concurrent SELECT queries

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -1073,6 +1073,9 @@ void LocalServer::processConfig()
     /// Initialize a dummy query result cache.
     global_context->setQueryResultCache(0, 0, 0, 0);
 
+    /// Initialize query batching queue.
+    global_context->setQueryBatchingQueue();
+
     /// Initialize allowed tiers
     global_context->getAccessControl().setAllowTierSettings(server_settings[ServerSetting::allow_feature_tier]);
 

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -2099,6 +2099,9 @@ try
     }
     global_context->setQueryResultCache(query_result_cache_max_size_in_bytes, query_result_cache_max_entries, query_result_cache_max_entry_size_in_bytes, query_result_cache_max_entry_size_in_rows);
 
+    /// Initialize query batching queue for batching identical concurrent SELECT queries.
+    global_context->setQueryBatchingQueue();
+
 #if USE_EMBEDDED_COMPILER
     size_t compiled_expression_cache_max_size_in_bytes = server_settings[ServerSetting::compiled_expression_cache_size];
     size_t compiled_expression_cache_max_elements = server_settings[ServerSetting::compiled_expression_cache_elements_size];

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -5426,6 +5426,34 @@ Possible values:
 
 - Any string
 )", 0) \
+    DECLARE(Bool, use_query_batching, false, R"(
+If turned on, identical concurrent `SELECT` queries from the same user will be batched together.
+The first query in the batch executes and writes its result into the query result cache.
+Subsequent queries in the batch read from the cache, avoiding redundant computation.
+
+Requires the query result cache to be enabled at the server level.
+
+Possible values:
+
+- 0 - Disabled
+- 1 - Enabled
+)", 0) \
+    DECLARE(Milliseconds, query_batching_max_wait_ms, 100, R"(
+Maximum time in milliseconds to wait for additional queries to join a batch before executing it.
+Only relevant when `use_query_batching` is enabled.
+
+Possible values:
+
+- Positive integer >= 0.
+)", 0) \
+    DECLARE(UInt64, query_batching_max_batch_size, 100, R"(
+Maximum number of queries to collect in a single batch before executing it.
+Only relevant when `use_query_batching` is enabled.
+
+Possible values:
+
+- Positive integer >= 1.
+)", 0) \
     DECLARE(Bool, enable_sharing_sets_for_mutations, true, R"(
 Allow sharing set objects build for IN subqueries between different tasks of the same mutation. This reduces memory usage and CPU consumption
 )", 0) \

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -72,6 +72,7 @@
 #include <Interpreters/Cache/FileCache.h>
 #include <Interpreters/Cache/QueryConditionCache.h>
 #include <Interpreters/Cache/QueryResultCache.h>
+#include <Interpreters/QueryBatchingQueue.h>
 #include <Interpreters/Cache/ReverseLookupCache.h>
 #include <Interpreters/ContextTimeSeriesTagsCollector.h>
 #include <Interpreters/SessionTracker.h>
@@ -555,6 +556,7 @@ struct ContextSharedPart : boost::noncopyable
     mutable TextIndexPostingsCachePtr text_index_postings_cache TSA_GUARDED_BY(mutex);  /// Cache of deserialized text index posting lists.
     mutable QueryConditionCachePtr query_condition_cache TSA_GUARDED_BY(mutex);       /// Cache of matching marks for predicates
     mutable QueryResultCachePtr query_result_cache TSA_GUARDED_BY(mutex);             /// Cache of query results.
+    mutable QueryBatchingQueuePtr query_batching_queue TSA_GUARDED_BY(mutex);        /// Queue for batching identical concurrent queries.
     mutable MarkCachePtr index_mark_cache TSA_GUARDED_BY(mutex);                      /// Cache of marks in compressed files of MergeTree indices.
     mutable MMappedFileCachePtr mmap_cache TSA_GUARDED_BY(mutex);                     /// Cache of mmapped files to avoid frequent open/map/unmap/close and to reuse from several threads.
 #if USE_AVRO
@@ -871,6 +873,17 @@ struct ContextSharedPart : boost::noncopyable
         bool is_shutdown_called = shutdown_called.exchange(true);
         if (is_shutdown_called)
             return;
+
+        /// Shut down the query batching queue before the database catalog goes away.
+        {
+            QueryBatchingQueuePtr queue;
+            {
+                std::lock_guard lock(mutex);
+                queue = std::move(query_batching_queue);
+            }
+            if (queue)
+                queue->shutdown();
+        }
 
         /// Need to flush the async insert queue before shutting down the database catalog
         std::shared_ptr<AsynchronousInsertQueue> delete_async_insert_queue;
@@ -4522,6 +4535,22 @@ void Context::clearQueryResultCache(const std::optional<String> & tag) const
     /// Clear the cache without holding context mutex to avoid blocking context for a long time
     if (cache)
         cache->clear(tag);
+}
+
+void Context::setQueryBatchingQueue()
+{
+    std::lock_guard lock(shared->mutex);
+
+    if (shared->query_batching_queue)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Query batching queue has been already created.");
+
+    shared->query_batching_queue = std::make_shared<QueryBatchingQueue>(shared_from_this());
+}
+
+QueryBatchingQueuePtr Context::getQueryBatchingQueue() const
+{
+    SharedLockGuard lock(shared->mutex);
+    return shared->query_batching_queue;
 }
 
 void Context::clearCaches() const

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -119,6 +119,7 @@ struct Progress;
 struct FileProgress;
 class Clusters;
 class QueryResultCache;
+class QueryBatchingQueue;
 class QueryConditionCache;
 class ISystemLog;
 class QueryLog;
@@ -1411,6 +1412,9 @@ public:
     void updateQueryResultCacheConfiguration(const Poco::Util::AbstractConfiguration & config, size_t max_cache_size);
     std::shared_ptr<QueryResultCache> getQueryResultCache() const;
     void clearQueryResultCache(const std::optional<String> & tag) const;
+
+    void setQueryBatchingQueue();
+    std::shared_ptr<QueryBatchingQueue> getQueryBatchingQueue() const;
 
 #if USE_AVRO
     void setIcebergMetadataFilesCache(const String & cache_policy, size_t max_size_in_bytes, size_t max_entries, double size_ratio);

--- a/src/Interpreters/QueryBatchingQueue.cpp
+++ b/src/Interpreters/QueryBatchingQueue.cpp
@@ -1,0 +1,235 @@
+#include <Interpreters/QueryBatchingQueue.h>
+
+#include <Common/SipHash.h>
+#include <Common/logger_useful.h>
+#include <Common/setThreadName.h>
+#include <Core/Settings.h>
+#include <Interpreters/Context.h>
+#include <Parsers/IAST.h>
+#include <Parsers/ASTSelectQuery.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
+
+namespace DB
+{
+
+namespace Setting
+{
+    extern const SettingsBool use_query_batching;
+    extern const SettingsMilliseconds query_batching_max_wait_ms;
+    extern const SettingsUInt64 query_batching_max_batch_size;
+}
+
+QueryBatchingQueue::QueryBatchingQueue(ContextPtr context_)
+    : WithContext(context_)
+{
+    flush_thread = ThreadFromGlobalPool([this] { processExpiredBatches(); });
+}
+
+QueryBatchingQueue::~QueryBatchingQueue()
+{
+    shutdown();
+}
+
+void QueryBatchingQueue::shutdown()
+{
+    bool expected = false;
+    if (!is_shutdown.compare_exchange_strong(expected, true))
+        return;
+
+    {
+        std::lock_guard lock(mutex);
+        /// Notify all waiting batches that we are shutting down.
+        for (auto & [_, batch] : active_batches)
+        {
+            try
+            {
+                batch->leader_done_promise.set_value();
+            }
+            catch (const std::future_error &)
+            {
+                /// Promise already satisfied — that's fine.
+            }
+        }
+        active_batches.clear();
+    }
+
+    cv.notify_all();
+
+    if (flush_thread.joinable())
+        flush_thread.join();
+
+    LOG_DEBUG(log, "QueryBatchingQueue shut down");
+}
+
+bool QueryBatchingQueue::BatchKey::operator==(const BatchKey & other) const
+{
+    return ast_hash == other.ast_hash && user_id == other.user_id;
+}
+
+UInt128 QueryBatchingQueue::computeBatchKeyHash(const BatchKey & key)
+{
+    SipHash hasher;
+    hasher.update(key.ast_hash.low64);
+    hasher.update(key.ast_hash.high64);
+    if (key.user_id)
+        hasher.update(key.user_id->toUnderType());
+    return hasher.get128();
+}
+
+std::optional<QueryBatchingQueue::BatchResult> QueryBatchingQueue::tryBatchQuery(
+    const ASTPtr & ast,
+    const ContextPtr & query_context)
+{
+    if (is_shutdown)
+        return std::nullopt;
+
+    /// Only batch SELECT queries.
+    if (!ast->as<ASTSelectQuery>() && !ast->as<ASTSelectWithUnionQuery>())
+        return std::nullopt;
+
+    const auto & settings = query_context->getSettingsRef();
+    if (!settings[Setting::use_query_batching])
+        return std::nullopt;
+
+    /// Compute the batch key from the AST hash and user ID.
+    BatchKey key;
+    key.ast_hash = ast->getTreeHash(/*ignore_aliases=*/false);
+    key.user_id = query_context->getUserID();
+
+    UInt128 key_hash = computeBatchKeyHash(key);
+
+    std::lock_guard lock(mutex);
+
+    auto it = active_batches.find(key_hash);
+    if (it != active_batches.end())
+    {
+        /// A batch already exists for this key — this query is a follower.
+        auto & batch = it->second;
+
+        /// If the batch has reached its maximum size, don't join it — execute independently.
+        if (batch->query_count >= batch->max_batch_size)
+        {
+            LOG_TRACE(log, "Batch full (key_hash={}, count={}), query will execute independently",
+                key_hash, batch->query_count);
+            return std::nullopt;
+        }
+
+        batch->query_count++;
+
+        LOG_TRACE(log, "Query joined existing batch (key_hash={}, count={})", key_hash, batch->query_count);
+
+        return BatchResult{
+            .role = BatchResult::Role::Follower,
+            .batch_key_hash = key_hash,
+            .leader_done = batch->leader_done_future,
+        };
+    }
+
+    /// No existing batch — this query becomes the leader.
+    auto batch = std::make_shared<Batch>();
+    batch->key = key;
+    batch->key_hash = key_hash;
+    batch->query_count = 1;
+    batch->max_batch_size = settings[Setting::query_batching_max_batch_size];
+    batch->created_at = std::chrono::steady_clock::now();
+
+    active_batches[key_hash] = batch;
+
+    LOG_TRACE(log, "Query started new batch as leader (key_hash={})", key_hash);
+
+    cv.notify_one();
+
+    return BatchResult{
+        .role = BatchResult::Role::Leader,
+        .batch_key_hash = key_hash,
+        .leader_done = {},
+    };
+}
+
+void QueryBatchingQueue::notifyBatchComplete(UInt128 batch_key_hash)
+{
+    std::lock_guard lock(mutex);
+
+    auto it = active_batches.find(batch_key_hash);
+    if (it == active_batches.end())
+        return;
+
+    auto & batch = it->second;
+
+    LOG_TRACE(log, "Batch complete (key_hash={}, served {} queries)", batch_key_hash, batch->query_count);
+
+    try
+    {
+        batch->leader_done_promise.set_value();
+    }
+    catch (const std::future_error &)
+    {
+        /// Promise already satisfied.
+    }
+
+    active_batches.erase(it);
+}
+
+void QueryBatchingQueue::processExpiredBatches()
+{
+    setThreadName("QryBatchFlush");
+
+    while (!is_shutdown)
+    {
+        std::vector<BatchPtr> expired_batches;
+
+        {
+            std::unique_lock lock(mutex);
+
+            /// Wait for either new batches or a short polling interval.
+            cv.wait_for(lock, std::chrono::milliseconds(50), [this]
+            {
+                return is_shutdown.load() || !active_batches.empty();
+            });
+
+            if (is_shutdown)
+                return;
+
+            auto now = std::chrono::steady_clock::now();
+
+            /// Get the max wait from the global context settings.
+            auto max_wait_ms = Milliseconds(getContext()->getSettingsRef()[Setting::query_batching_max_wait_ms].totalMilliseconds());
+            if (max_wait_ms == Milliseconds::zero())
+                max_wait_ms = Milliseconds(100); /// Fallback default.
+
+            for (auto it = active_batches.begin(); it != active_batches.end();)
+            {
+                auto & batch = it->second;
+                auto elapsed = std::chrono::duration_cast<Milliseconds>(now - batch->created_at);
+
+                if (elapsed >= max_wait_ms)
+                {
+                    LOG_TRACE(log, "Batch expired (key_hash={}, age={}ms, count={})",
+                        batch->key_hash, elapsed.count(), batch->query_count);
+
+                    expired_batches.push_back(batch);
+                    it = active_batches.erase(it);
+                }
+                else
+                {
+                    ++it;
+                }
+            }
+        }
+
+        /// Notify expired batches outside the lock.
+        for (auto & batch : expired_batches)
+        {
+            try
+            {
+                batch->leader_done_promise.set_value();
+            }
+            catch (const std::future_error &)
+            {
+                /// Already satisfied.
+            }
+        }
+    }
+}
+
+}

--- a/src/Interpreters/QueryBatchingQueue.h
+++ b/src/Interpreters/QueryBatchingQueue.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <Common/Logger.h>
+#include <Common/ThreadPool.h>
+#include <Interpreters/Context_fwd.h>
+#include <Parsers/IAST_fwd.h>
+#include <Parsers/IASTHash.h>
+#include <base/UUID.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <future>
+#include <mutex>
+#include <optional>
+#include <unordered_map>
+
+namespace DB
+{
+
+/// A queue that collects identical concurrent SELECT queries and batches them together.
+///
+/// When multiple queries with the same normalized AST arrive within a short time window,
+/// only the first ("leader") query is executed. The leader writes its result into the
+/// query result cache. Subsequent ("follower") queries in the batch wait for the leader
+/// to finish and then read from the cache.
+///
+/// Batching is per-user: queries from different users are never mixed into the same batch.
+///
+/// The design is inspired by AsynchronousInsertQueue but for SELECT queries.
+class QueryBatchingQueue : public WithContext
+{
+public:
+    using Milliseconds = std::chrono::milliseconds;
+
+    explicit QueryBatchingQueue(ContextPtr context_);
+    ~QueryBatchingQueue();
+
+    /// Returned by tryBatchQuery to indicate the query's role in a batch.
+    struct BatchResult
+    {
+        enum class Role : uint8_t
+        {
+            /// This query is the leader — it should execute normally with cache write enabled.
+            Leader,
+            /// This query is a follower — it should read from cache after the leader finishes.
+            Follower,
+        };
+
+        Role role;
+
+        /// The hash identifying this batch. The leader must pass this back to notifyBatchComplete.
+        UInt128 batch_key_hash;
+
+        /// For followers: a future that becomes ready when the leader has finished.
+        /// For leaders: empty.
+        std::shared_future<void> leader_done;
+    };
+
+    /// Try to batch this query. Returns a BatchResult indicating the query's role.
+    /// If batching is not applicable (e.g., non-SELECT), returns std::nullopt.
+    std::optional<BatchResult> tryBatchQuery(
+        const ASTPtr & ast,
+        const ContextPtr & query_context);
+
+    /// Called by the leader after it has finished executing (successfully or not).
+    void notifyBatchComplete(UInt128 batch_key_hash);
+
+    void shutdown();
+
+private:
+    /// A batch key identifies a group of queries that can be batched together.
+    struct BatchKey
+    {
+        IASTHash ast_hash;
+        std::optional<UUID> user_id;
+
+        bool operator==(const BatchKey & other) const;
+    };
+
+    /// An active batch collecting queries.
+    struct Batch
+    {
+        BatchKey key;
+        UInt128 key_hash;
+        size_t query_count = 0;
+        size_t max_batch_size = 100;
+        std::chrono::steady_clock::time_point created_at;
+        std::promise<void> leader_done_promise;
+        std::shared_future<void> leader_done_future;
+
+        Batch()
+            : leader_done_future(leader_done_promise.get_future().share())
+        {
+        }
+    };
+
+    using BatchPtr = std::shared_ptr<Batch>;
+    using BatchMap = std::unordered_map<UInt128, BatchPtr>;
+
+    mutable std::mutex mutex;
+    std::condition_variable cv;
+    BatchMap active_batches;
+
+    std::atomic<bool> is_shutdown{false};
+    ThreadFromGlobalPool flush_thread;
+
+    LoggerPtr log = getLogger("QueryBatchingQueue");
+
+    /// Background thread that flushes expired batches.
+    void processExpiredBatches();
+
+    /// Compute a combined hash for the batch key.
+    static UInt128 computeBatchKeyHash(const BatchKey & key);
+};
+
+using QueryBatchingQueuePtr = std::shared_ptr<QueryBatchingQueue>;
+
+}

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -14,6 +14,7 @@
 
 #include <Interpreters/AsynchronousInsertQueue.h>
 #include <Interpreters/Cache/QueryResultCache.h>
+#include <Interpreters/QueryBatchingQueue.h>
 #include <IO/WriteBufferFromVector.h>
 #include <IO/LimitReadBuffer.h>
 #include <IO/ReadBuffer.h>
@@ -160,6 +161,8 @@ namespace Setting
     extern const SettingsString polyglot_dialect;
     extern const SettingsUInt64 output_format_compression_zstd_window_log;
     extern const SettingsBool query_cache_compress_entries;
+    extern const SettingsBool use_query_batching;
+    extern const SettingsMilliseconds query_batching_max_wait_ms;
     extern const SettingsUInt64 query_cache_max_entries;
     extern const SettingsUInt64 query_cache_max_size_in_bytes;
     extern const SettingsMilliseconds query_cache_min_query_duration;
@@ -1655,6 +1658,54 @@ static BlockIO executeQueryImpl(
                 http_continue_callback();
         }
 
+        /// Query batching: if enabled, try to batch this query with other identical concurrent queries.
+        /// The leader executes with query cache enabled; followers wait and read from cache.
+        std::optional<QueryBatchingQueue::BatchResult> batch_result;
+        UInt128 batch_key_hash = 0;
+        bool batching_leader = false;
+
+        if (settings[Setting::use_query_batching] && !internal
+            && client_info.query_kind == ClientInfo::QueryKind::INITIAL_QUERY
+            && out_ast
+            && (out_ast->as<ASTSelectQuery>() || out_ast->as<ASTSelectWithUnionQuery>()))
+        {
+            if (auto batching_queue = context->getQueryBatchingQueue())
+            {
+                batch_result = batching_queue->tryBatchQuery(out_ast, context);
+                if (batch_result)
+                {
+                    if (batch_result->role == QueryBatchingQueue::BatchResult::Role::Leader)
+                    {
+                        /// Leader: enable query cache so the result is cached for followers.
+                        batching_leader = true;
+                        batch_key_hash = batch_result->batch_key_hash;
+
+                        context->setSetting("use_query_cache", Field(true));
+                        context->setSetting("query_cache_ttl", Field(UInt64(2)));
+                    }
+                    else
+                    {
+                        /// Follower: wait for the leader to finish, then read from cache.
+                        if (batch_result->leader_done.valid())
+                        {
+                            auto wait_ms = settings[Setting::query_batching_max_wait_ms].totalMilliseconds();
+                            auto status = batch_result->leader_done.wait_for(std::chrono::milliseconds(wait_ms));
+                            if (status == std::future_status::timeout)
+                            {
+                                LOG_TRACE(getLogger("executeQuery"), "Query batching: follower timed out waiting for leader, executing independently");
+                                batch_result.reset();
+                            }
+                            else
+                            {
+                                /// Leader is done — enable query cache reads so we can fetch from cache.
+                                context->setSetting("use_query_cache", Field(true));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         QueryResultCachePtr query_result_cache = context->getQueryResultCache();
         const bool can_use_query_result_cache = query_result_cache != nullptr && settings[Setting::use_query_cache] && !internal
             && client_info.query_kind == ClientInfo::QueryKind::INITIAL_QUERY
@@ -1965,7 +2016,9 @@ static BlockIO executeQueryImpl(
                                     implicit_tcl_executor,
                                     // Need to be cached, since will be changed after complete()
                                     pulling_pipeline = pipeline.pulling(),
-                                    query_span](const QueryPipelineFinalizedInfo & query_pipeline_finalized_info, std::chrono::system_clock::time_point finish_time) mutable
+                                    query_span,
+                                    batching_leader,
+                                    batch_key_hash](const QueryPipelineFinalizedInfo & query_pipeline_finalized_info, std::chrono::system_clock::time_point finish_time) mutable
             {
                 logQueryFinishImpl(elem, context, out_ast, query_pipeline_finalized_info, pulling_pipeline, query_span, query_result_cache_usage, internal, finish_time);
 
@@ -1973,10 +2026,17 @@ static BlockIO executeQueryImpl(
                 {
                     implicit_tcl_executor->commit(context);
                 }
+
+                /// Notify batched followers that the leader query has completed.
+                if (batching_leader)
+                {
+                    if (auto batching_queue = context->getQueryBatchingQueue())
+                        batching_queue->notifyBatchComplete(batch_key_hash);
+                }
             };
 
             auto exception_callback =
-                [start_watch, elem, context, out_ast, internal, my_quota(quota), implicit_tcl_executor, query_span](bool log_error) mutable
+                [start_watch, elem, context, out_ast, internal, my_quota(quota), implicit_tcl_executor, query_span, batching_leader, batch_key_hash](bool log_error) mutable
             {
                 if (implicit_tcl_executor->transactionRunning())
                 {
@@ -1995,6 +2055,13 @@ static BlockIO executeQueryImpl(
                 }
 
                 logQueryException(elem, context, start_watch, out_ast, query_span, internal, log_error);
+
+                /// Notify batched followers even on exception so they don't wait forever.
+                if (batching_leader)
+                {
+                    if (auto batching_queue = context->getQueryBatchingQueue())
+                        batching_queue->notifyBatchComplete(batch_key_hash);
+                }
             };
 
             res.finalize_query_pipeline = std::move(finish_callback_finalize_pipeline);

--- a/tests/queries/0_stateless/04093_query_batching_basic.reference
+++ b/tests/queries/0_stateless/04093_query_batching_basic.reference
@@ -1,0 +1,17 @@
+Test 1: Basic query batching enabled - query executes correctly
+1	hello
+2	world
+3	foo
+Test 2: Query batching writes to query result cache
+3
+3
+1
+Test 3: Query batching is disabled by default
+3
+0
+Test 4: Different queries are not batched together
+1
+1
+1
+Test 5: Non-SELECT queries are not affected
+4

--- a/tests/queries/0_stateless/04093_query_batching_basic.sql
+++ b/tests/queries/0_stateless/04093_query_batching_basic.sql
@@ -1,0 +1,57 @@
+-- Tags: no-parallel
+-- Tag no-parallel: Messes with internal cache
+
+-- Tests basic query batching functionality.
+-- When use_query_batching is enabled, identical concurrent queries should be
+-- batched together, with the leader writing to the query result cache and
+-- followers reading from it.
+
+SYSTEM CLEAR QUERY CACHE;
+
+SELECT 'Test 1: Basic query batching enabled - query executes correctly';
+
+DROP TABLE IF EXISTS test_batching;
+CREATE TABLE test_batching (id UInt64, value String) ENGINE = MergeTree() ORDER BY id;
+INSERT INTO test_batching VALUES (1, 'hello'), (2, 'world'), (3, 'foo');
+
+-- With batching enabled, a simple SELECT should still return correct results.
+SELECT id, value FROM test_batching ORDER BY id SETTINGS use_query_batching = 1;
+
+SELECT 'Test 2: Query batching writes to query result cache';
+
+SYSTEM CLEAR QUERY CACHE;
+
+-- Run the same query twice with batching. The first execution should populate the cache.
+SELECT count() FROM test_batching SETTINGS use_query_batching = 1;
+SELECT count() FROM test_batching SETTINGS use_query_batching = 1;
+
+-- The query result cache should have an entry now.
+SELECT count() >= 1 FROM system.query_cache;
+
+SELECT 'Test 3: Query batching is disabled by default';
+
+SYSTEM CLEAR QUERY CACHE;
+
+-- Without use_query_batching, the cache should not be populated by the batching mechanism.
+SELECT count() FROM test_batching;
+SELECT count() FROM system.query_cache;
+
+SELECT 'Test 4: Different queries are not batched together';
+
+SYSTEM CLEAR QUERY CACHE;
+
+SELECT count() FROM test_batching WHERE id = 1 SETTINGS use_query_batching = 1;
+SELECT count() FROM test_batching WHERE id = 2 SETTINGS use_query_batching = 1;
+
+-- Two different queries should create two separate cache entries.
+SELECT count() >= 2 FROM system.query_cache;
+
+SELECT 'Test 5: Non-SELECT queries are not affected';
+
+-- INSERT should work normally with batching enabled.
+INSERT INTO test_batching VALUES (4, 'bar') SETTINGS use_query_batching = 1;
+SELECT count() FROM test_batching SETTINGS use_query_batching = 1;
+
+DROP TABLE test_batching;
+
+SYSTEM CLEAR QUERY CACHE;

--- a/tests/queries/0_stateless/04093_query_batching_concurrent.reference
+++ b/tests/queries/0_stateless/04093_query_batching_concurrent.reference
@@ -1,0 +1,10 @@
+Test 1: Concurrent identical queries all return correct results
+1000
+1000
+1000
+1000
+1000
+Test 2: Concurrent different queries return correct results
+100
+500
+1000

--- a/tests/queries/0_stateless/04093_query_batching_concurrent.sh
+++ b/tests/queries/0_stateless/04093_query_batching_concurrent.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Tags: no-parallel
+# Tag no-parallel: Messes with internal cache
+
+# Tests concurrent query batching: multiple identical queries are sent
+# simultaneously and should be batched together.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "SYSTEM CLEAR QUERY CACHE"
+$CLICKHOUSE_CLIENT -q "DROP TABLE IF EXISTS test_batching_concurrent"
+$CLICKHOUSE_CLIENT -q "CREATE TABLE test_batching_concurrent (id UInt64, value UInt64) ENGINE = MergeTree() ORDER BY id"
+$CLICKHOUSE_CLIENT -q "INSERT INTO test_batching_concurrent SELECT number, number * 10 FROM numbers(1000)"
+
+echo "Test 1: Concurrent identical queries all return correct results"
+
+# Launch 5 identical queries concurrently with batching enabled.
+# Collect outputs and sort to avoid non-deterministic ordering.
+for i in $(seq 1 5); do
+    $CLICKHOUSE_CLIENT -q "SELECT count() FROM test_batching_concurrent SETTINGS use_query_batching = 1, query_batching_max_wait_ms = 500" &
+done
+
+# Wait for all background queries to complete.
+wait
+
+echo "Test 2: Concurrent different queries return correct results"
+
+# Launch queries with different WHERE clauses — these should NOT be batched together.
+# Collect and sort results to avoid non-deterministic output ordering from background jobs.
+{
+    $CLICKHOUSE_CLIENT -q "SELECT count() FROM test_batching_concurrent WHERE id < 100 SETTINGS use_query_batching = 1" &
+    $CLICKHOUSE_CLIENT -q "SELECT count() FROM test_batching_concurrent WHERE id < 500 SETTINGS use_query_batching = 1" &
+    $CLICKHOUSE_CLIENT -q "SELECT count() FROM test_batching_concurrent WHERE id < 1000 SETTINGS use_query_batching = 1" &
+    wait
+} | sort -n
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE test_batching_concurrent"
+$CLICKHOUSE_CLIENT -q "SYSTEM CLEAR QUERY CACHE"

--- a/tests/queries/0_stateless/04093_query_batching_settings.reference
+++ b/tests/queries/0_stateless/04093_query_batching_settings.reference
@@ -1,0 +1,7 @@
+Test 1: query_batching_max_wait_ms setting is accepted
+100
+Test 2: query_batching_max_batch_size setting is accepted
+100
+Test 3: Batching with query cache coexistence
+100
+1

--- a/tests/queries/0_stateless/04093_query_batching_settings.sql
+++ b/tests/queries/0_stateless/04093_query_batching_settings.sql
@@ -1,0 +1,37 @@
+-- Tags: no-parallel
+-- Tag no-parallel: Messes with internal cache
+
+-- Tests query batching settings validation and behavior.
+
+SYSTEM CLEAR QUERY CACHE;
+
+SELECT 'Test 1: query_batching_max_wait_ms setting is accepted';
+
+DROP TABLE IF EXISTS test_batching_settings;
+CREATE TABLE test_batching_settings (id UInt64) ENGINE = MergeTree() ORDER BY id;
+INSERT INTO test_batching_settings SELECT number FROM numbers(100);
+
+-- Setting a custom max wait time should work without errors.
+SELECT count() FROM test_batching_settings
+    SETTINGS use_query_batching = 1, query_batching_max_wait_ms = 50;
+
+SELECT 'Test 2: query_batching_max_batch_size setting is accepted';
+
+-- Setting a custom batch size should work without errors.
+SELECT count() FROM test_batching_settings
+    SETTINGS use_query_batching = 1, query_batching_max_batch_size = 10;
+
+SELECT 'Test 3: Batching with query cache coexistence';
+
+SYSTEM CLEAR QUERY CACHE;
+
+-- Both settings can be used together.
+SELECT count() FROM test_batching_settings
+    SETTINGS use_query_batching = 1, use_query_cache = 1, query_cache_ttl = 5;
+
+-- The cache should have an entry.
+SELECT count() >= 1 FROM system.query_cache;
+
+DROP TABLE test_batching_settings;
+
+SYSTEM CLEAR QUERY CACHE;


### PR DESCRIPTION
Add a `QueryBatchingQueue` that deduplicates identical concurrent SELECT queries using a leader/follower pattern built on the existing `QueryResultCache`.

When `use_query_batching = 1`, concurrent identical queries (same full AST + user ID) are grouped:
- The first query ("leader") executes normally with `use_query_cache = 1`, writing its result to the query result cache
- Subsequent queries ("followers") wait on a `std::shared_future<void>` for the leader to finish, then read the result from the query result cache
- Batches are flushed after `query_batching_max_wait_ms` (default 100ms) or `query_batching_max_batch_size` (default 100 queries)

Closes #102306

### Changelog category (leave one):
- Experimental Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add `use_query_batching` setting to deduplicate identical concurrent SELECT queries. The first query executes and caches its result; subsequent identical queries read from the query result cache instead of re-executing.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

New settings:
- `use_query_batching` (Bool, default `false`) — enable query batching for SELECT queries
- `query_batching_max_wait_ms` (Milliseconds, default `100`) — maximum time a follower waits for the leader to finish
- `query_batching_max_batch_size` (UInt64, default `100`) — maximum queries per batch before flushing

Example:
```sql
SELECT count() FROM large_table SETTINGS use_query_batching = 1;
```

When multiple clients issue this same query concurrently, only one execution occurs — the rest read from the query result cache.