### PR TITLE
Backport #101295 to 26.2: Fix column resize in play.html after web component refactoring

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -884,6 +884,11 @@ class QueryResultElement extends HTMLElement
         this.attachShadow({ mode: 'open' });
         this.shadowRoot.innerHTML = `
             <style>
+                *
+                {
+                    box-sizing: border-box;
+                }
+
                 :host
                 {
                     display: block;


### PR DESCRIPTION
Backport of #101295 to 26.2.

Fix column resize in `play.html` web UI after the result table was refactored into a web component. Shadow DOM does not inherit `box-sizing: border-box` from the outer document.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix column resize in play.html web UI after the result table was refactored into a web component.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.2.10.10`
<!-- ch-version-info:end -->