### PR TITLE
Add missing wait_for_query_to_start function to test (26.1)

### DIFF
--- a/tests/queries/0_stateless/04039_merge_tree_snapshot_teardown_race.sh
+++ b/tests/queries/0_stateless/04039_merge_tree_snapshot_teardown_race.sh
@@ -12,6 +12,19 @@ TABLE="test_04039_snapshot_teardown_${CLICKHOUSE_TEST_UNIQUE_NAME}"
 TABLE_PROJ="test_04039_proj_teardown_${CLICKHOUSE_TEST_UNIQUE_NAME}"
 ITERATIONS=20
 
+function wait_for_query_to_start()
+{
+    local timeout=30
+    local start=$EPOCHSECONDS
+    while [[ $($CLICKHOUSE_CLIENT --query "SELECT count() FROM system.processes WHERE query_id = '$1'" 2>/dev/null || echo "0") == 0 ]]; do
+        if ((EPOCHSECONDS - start > timeout)); then
+            echo "Timeout waiting for query $1 to start" >&2
+            return 1
+        fi
+        sleep 0.1
+    done
+}
+
 function cleanup()
 {
     $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS ${TABLE} SYNC" >/dev/null 2>&1 ||:


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Not for changelog

---

The test `04039_merge_tree_snapshot_teardown_race` calls `wait_for_query_to_start` but this function only exists in `shell_config.sh` on master (commit 62405eb3113). Branch 26.1 does not have it, causing 100% test failure on ReleaseBranchCI.

This adds the function definition directly in the test file, matching the fix already applied to branch 26.2 in commit 50164d2fe77.

**CIDB evidence — 26.1 failures (17 in last 14 days, all FAIL):**
```
head_ref  failures  latest
26.1      17        2026-04-09 12:23:14
```

**26.2 confirmed fixed** — 0 failures since the Apr 7 fix (20+ consecutive OK runs).