### PR TITLE
Revert "Preserve original parameter types in timeseries aggregate functions"

### DIFF
--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesBase.h
@@ -62,11 +62,17 @@ public:
         UnorderedMapWithMemoryTracking<size_t, Bucket> buckets;
     };
 
-    explicit AggregateFunctionTimeseriesBase(const DataTypes & argument_types_, const Array & parameters_,
+    explicit AggregateFunctionTimeseriesBase(const DataTypes & argument_types_,
         TimestampType start_timestamp_, TimestampType end_timestamp_, IntervalType step_, IntervalType window_, UInt32 timestamp_scale_)
         : Base(
             argument_types_,
-            parameters_,
+            {
+                /// Normalize all parameters to decimals with the same scale as the scale of timestamp argument
+                DecimalField<Decimal64>(start_timestamp_, timestamp_scale_),
+                DecimalField<Decimal64>(end_timestamp_, timestamp_scale_),
+                DecimalField<Decimal64>(step_, timestamp_scale_),
+                DecimalField<Decimal64>(window_, timestamp_scale_)
+            },
             createResultType())
         , bucket_count(bucketCount(start_timestamp_, end_timestamp_, step_))
         , start_timestamp(start_timestamp_)

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesHelpers.cpp
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesHelpers.cpp
@@ -207,12 +207,12 @@ AggregateFunctionPtr createWithValueType(const std::string & name, const DataTyp
         {
             Float64 predict_offset = extractFloatParameter(name, "predict_offset", predict_offset_param) * static_cast<Float64>(DecimalUtils::scaleMultiplier<Int64>(target_scale));
             res = std::make_shared<Function<FunctionTraits<array_arguments, DateTime64, Int64, ValueType, is_predict>>>
-                (argument_types, parameters, start_timestamp, end_timestamp, step, window, target_scale, predict_offset);
+                (argument_types, start_timestamp, end_timestamp, step, window, target_scale, predict_offset);
         }
         else
         {
             res = std::make_shared<Function<FunctionTraits<array_arguments, DateTime64, Int64, ValueType, is_rate_or_resets>>>
-                (argument_types, parameters, start_timestamp, end_timestamp, step, window, target_scale);
+                (argument_types, start_timestamp, end_timestamp, step, window, target_scale);
         }
     }
     else if (isDateTime(timestamp_type) || isUInt32(timestamp_type))
@@ -226,12 +226,12 @@ AggregateFunctionPtr createWithValueType(const std::string & name, const DataTyp
         {
             Float64 predict_offset = extractFloatParameter(name, "predict_offset", predict_offset_param);
             res = std::make_shared<Function<FunctionTraits<array_arguments, UInt32, Int32, ValueType, is_predict>>>
-                (argument_types, parameters, start_timestamp, end_timestamp, step, window, 0, predict_offset);
+                (argument_types, start_timestamp, end_timestamp, step, window, 0, predict_offset);
         }
         else
         {
             res = std::make_shared<Function<FunctionTraits<array_arguments, UInt32, Int32, ValueType, is_rate_or_resets>>>
-                (argument_types, parameters, start_timestamp, end_timestamp, step, window, 0);
+                (argument_types, start_timestamp, end_timestamp, step, window, 0);
         }
     }
 

--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesLinearRegression.h
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeseriesLinearRegression.h
@@ -81,9 +81,9 @@ public:
 
     using Bucket = typename Base::Bucket;
 
-    explicit AggregateFunctionTimeseriesLinearRegression(const DataTypes & argument_types_, const Array & parameters_,
+    explicit AggregateFunctionTimeseriesLinearRegression(const DataTypes & argument_types_,
         TimestampType start_timestamp_, TimestampType end_timestamp_, IntervalType step_, IntervalType window_, UInt32 timestamp_scale_, Float64 predict_offset_ = 0)
-        : Base(argument_types_, parameters_, start_timestamp_, end_timestamp_, step_, window_, timestamp_scale_)
+        : Base(argument_types_, start_timestamp_, end_timestamp_, step_, window_, timestamp_scale_)
         , predict_offset(predict_offset_)
     {
     }

--- a/tests/queries/0_stateless/03254_timeseries_instant_value_aggregate_functions.reference
+++ b/tests/queries/0_stateless/03254_timeseries_instant_value_aggregate_functions.reference
@@ -15,15 +15,15 @@ idelta	[10,10,10,-30,60,20,20,20,20,20,20,20,20,20,20,20,20,20,20,20,20,20,20,20
 Row 1:
 ──────
 metric_id: 142
-c1:        AggregateFunction(timeSeriesInstantRateToGrid('1734004810', '1734004860', 10, 60), Array(DateTime64(3, 'UTC')), Array(Float64))
-c2:        AggregateFunction(timeSeriesInstantRateToGrid('1734004810', '1734004860', 10, 60), Array(DateTime64(3, 'UTC')), Array(Float64))
-c3:        AggregateFunction(timeSeriesInstantRateToGrid('1734004810', '1734004860', 10, 60), Array(DateTime64(3, 'UTC')), Array(Float64))
-c4:        AggregateFunction(timeSeriesInstantRateToGrid('1734004810.123', '1734004861', 10, 60), Array(DateTime64(3, 'UTC')), Array(Float64))
-c5:        AggregateFunction(timeSeriesInstantRateToGrid('1734004810.1234', '1734004860.123', 10, 60), Array(DateTime64(3, 'UTC')), Array(Float64))
-c6:        AggregateFunction(timeSeriesInstantRateToGrid('1734004810.1', '1734004860.123', 10, 60), Array(DateTime64(3, 'UTC')), Array(Float64))
-c7:        AggregateFunction(timeSeriesInstantRateToGrid('1734004810', '1734004860', 10, 60), Array(DateTime64(3, 'UTC')), Array(Float64))
-c8:        AggregateFunction(timeSeriesInstantRateToGrid(1734004810, '1734004860', 10, 60), Array(DateTime64(3, 'UTC')), Array(Float64))
-c9:        AggregateFunction(timeSeriesInstantRateToGrid('1734004810.12', 1734004861, 10, 60), Array(DateTime64(3, 'UTC')), Array(Float64))
+c1:        AggregateFunction(timeSeriesInstantRateToGrid('1734004810', '1734004860', '10', '60'), Array(DateTime64(3, 'UTC')), Array(Float64))
+c2:        AggregateFunction(timeSeriesInstantRateToGrid('1734004810', '1734004860', '10', '60'), Array(DateTime64(3, 'UTC')), Array(Float64))
+c3:        AggregateFunction(timeSeriesInstantRateToGrid('1734004810', '1734004860', '10', '60'), Array(DateTime64(3, 'UTC')), Array(Float64))
+c4:        AggregateFunction(timeSeriesInstantRateToGrid('1734004810.123', '1734004861', '10', '60'), Array(DateTime64(3, 'UTC')), Array(Float64))
+c5:        AggregateFunction(timeSeriesInstantRateToGrid('1734004810.123', '1734004860.123', '10', '60'), Array(DateTime64(3, 'UTC')), Array(Float64))
+c6:        AggregateFunction(timeSeriesInstantRateToGrid('1734004810.1', '1734004860.123', '10', '60'), Array(DateTime64(3, 'UTC')), Array(Float64))
+c7:        AggregateFunction(timeSeriesInstantRateToGrid('1734004810', '1734004860', '10', '60'), Array(DateTime64(3, 'UTC')), Array(Float64))
+c8:        AggregateFunction(timeSeriesInstantRateToGrid('1734004810', '1734004860', '10', '60'), Array(DateTime64(3, 'UTC')), Array(Float64))
+c9:        AggregateFunction(timeSeriesInstantRateToGrid('1734004810.12', '1734004861', '10', '60'), Array(DateTime64(3, 'UTC')), Array(Float64))
 Row 1:
 ──────
 metric_id: 142

--- a/tests/queries/0_stateless/03254_timeseries_instant_value_aggregate_functions.sql
+++ b/tests/queries/0_stateless/03254_timeseries_instant_value_aggregate_functions.sql
@@ -1,7 +1,6 @@
 SET allow_experimental_ts_to_grid_aggregate_function=1;
 
 SET cluster_for_parallel_replicas = 'test_shard_localhost';
-SET enable_parallel_replicas = 0; -- Prevent randomized parallel replicas from interfering; queries that need it set it explicitly via SETTINGS
 
 
 CREATE TABLE t_resampled_timeseries
@@ -41,7 +40,7 @@ FROM (
     GROUP BY metric_id
 )
 ORDER BY metric_id
-SETTINGS enable_parallel_replicas=1, max_parallel_replicas=3, parallel_replicas_for_non_replicated_merge_tree=1, enable_analyzer=1, prefer_localhost_replica=1;
+SETTINGS enable_parallel_replicas=1, max_parallel_replicas=3, parallel_replicas_for_non_replicated_merge_tree=1, enable_analyzer=1;
 
 -- Test with DateTime64
 
@@ -79,7 +78,7 @@ FROM (
     GROUP BY metric_id
 )
 ORDER BY metric_id
-SETTINGS enable_parallel_replicas=1, max_parallel_replicas=3, parallel_replicas_for_non_replicated_merge_tree=1, enable_analyzer=1, prefer_localhost_replica=1;
+SETTINGS enable_parallel_replicas=1, max_parallel_replicas=3, parallel_replicas_for_non_replicated_merge_tree=1, enable_analyzer=1;
 
 -- Another test with a reset
 WITH [
@@ -101,7 +100,7 @@ SELECT * FROM (
 
 
 -- Tests to validate block header compatibility in queries with parallel replicas
-SET serialize_query_plan=1, prefer_localhost_replica = false, enable_parallel_replicas = 0;
+SET serialize_query_plan=1, prefer_localhost_replica = false;
 
 SELECT
     metric_id,

--- a/tests/queries/0_stateless/03254_timeseries_to_grid_aggregate_function_sparse.sql
+++ b/tests/queries/0_stateless/03254_timeseries_to_grid_aggregate_function_sparse.sql
@@ -7,8 +7,6 @@ WITH [102, 104, 112, 113, 120] as timestamps
 INSERT INTO ts_data SELECT ts::DateTime64 as timestamp, ts + 10000 as value FROM (SELECT arrayJoin(timestamps) as ts);
 
 SET allow_experimental_ts_to_grid_aggregate_function = 1;
-SET enable_parallel_replicas = 0; -- Prevent randomized parallel replicas from interfering with aggregate function type comparison; the explicit clusterAllReplicas section uses query-level SETTINGS to enable it.
-SET prefer_localhost_replica = 1;
 
 SELECT 'Original data (ts, val):';
 SELECT groupArraySorted(30)((toUnixTimestamp(timestamp), value)) FROM ts_data;


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#101083

cc @alexey-milovidov 