### PR TITLE
Add tag `long` to 01037_polygon_dicts_correctness_fast so it doesn't fail with timeout in asan flaky check

### DIFF
--- a/tests/queries/0_stateless/01037_polygon_dicts_correctness_fast.sh
+++ b/tests/queries/0_stateless/01037_polygon_dicts_correctness_fast.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-debug
+# Tags: no-debug, long
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
