### PR TITLE
Avoid lock contention from background fetch threads in getMutationsSnapshot

### DIFF
--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -48,6 +48,14 @@ namespace ErrorCodes
     extern const int BAD_ARGUMENTS;
 }
 
+static bool hasSupportedMetadataMutation(const MutationCommands & commands)
+{
+    for (const auto & cmd : commands)
+        if (AlterConversions::isSupportedMetadataMutation(cmd.type))
+            return true;
+    return false;
+}
+
 
 ReplicatedMergeTreeQueue::ReplicatedMergeTreeQueue(StorageReplicatedMergeTree & storage_, ReplicatedMergeTreeMergeStrategyPicker & merge_strategy_picker_)
     : storage(storage_)
@@ -75,6 +83,7 @@ void ReplicatedMergeTreeQueue::clear()
     mutations_by_partition.clear();
     mutation_pointer.clear();
     mutation_counters = {};
+    num_metadata_mutations_in_map.store(0, std::memory_order_release);
 }
 
 void ReplicatedMergeTreeQueue::setBrokenPartsToEnqueueFetchesOnLoading(Strings && parts_to_fetch)
@@ -1172,6 +1181,9 @@ int32_t ReplicatedMergeTreeQueue::updateMutations(zkutil::ZooKeeperPtr zookeeper
                         mutations_by_partition.erase(partition_and_block_num.first);
                 }
 
+                if (hasSupportedMetadataMutation(entry.commands))
+                    num_metadata_mutations_in_map.fetch_sub(1, std::memory_order_release);
+
                 if (!it->second.is_done)
                 {
                     const auto commands = entry.commands;
@@ -1231,6 +1243,8 @@ int32_t ReplicatedMergeTreeQueue::updateMutations(zkutil::ZooKeeperPtr zookeeper
             {
                 auto & mutation = mutations_by_znode.emplace(entry->znode_name, MutationStatus(entry, format_version)).first->second;
                 incrementMutationsCounters(mutation_counters, entry->commands);
+                if (hasSupportedMetadataMutation(entry->commands))
+                    num_metadata_mutations_in_map.fetch_add(1, std::memory_order_release);
 
                 NOEXCEPT_SCOPE({
                     for (const auto & pair : entry->block_numbers)
@@ -1308,6 +1322,9 @@ ReplicatedMergeTreeMutationEntryPtr ReplicatedMergeTreeQueue::removeMutation(
         {
             decrementMutationsCounters(mutation_counters, entry->commands);
         }
+
+        if (hasSupportedMetadataMutation(entry->commands))
+            num_metadata_mutations_in_map.fetch_sub(1, std::memory_order_release);
 
         mutations_by_znode.erase(it);
         LOG_DEBUG(log, "Removed mutation {} from local state.", entry->znode_name);
@@ -2317,9 +2334,13 @@ MergeTreeData::MutationsSnapshotPtr ReplicatedMergeTreeQueue::getMutationsSnapsh
     if (params.need_patch_parts)
         patch_parts = storage.getPatchPartsVectorForInternalUsage();
 
-    std::shared_lock lock(state_mutex);
-    if (!params.need_data_mutations && !params.need_alter_mutations && params.min_part_metadata_version >= params.metadata_version)
+    const bool need_metadata_mutations = params.min_part_metadata_version < params.metadata_version
+        && num_metadata_mutations_in_map.load(std::memory_order_acquire) > 0;
+
+    if (!params.need_data_mutations && !params.need_alter_mutations && !need_metadata_mutations)
         return std::make_shared<MutationsSnapshot>(params, std::move(mutations_snapshot_counters), std::move(mutations_snapshot), std::move(patch_parts));
+
+    std::shared_lock lock(state_mutex);
 
     for (const auto & [partition_id, mutations] : mutations_by_partition)
     {

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.h
@@ -173,6 +173,10 @@ private:
     /// Unfinished mutations that are required for AlterConversions.
     MutationCounters mutation_counters;
 
+    /// Total number of mutations in mutations_by_znode that contain supported metadata mutations.
+    /// Atomic so getMutationsSnapshot can check it without acquiring state_mutex.
+    std::atomic<Int64> num_metadata_mutations_in_map{0};
+
     /// Partition -> (block_number -> MutationStatus)
     std::unordered_map<String, std::map<Int64, MutationStatus *>> mutations_by_partition;
     /// Znode ID of the latest mutation that is done.


### PR DESCRIPTION
We observed a significant increase in SELECT duration (>10x) when there are a lot of background fetches running. The flamegraph indicated lock contention in `ReplicatedMergeTreeQueue::getMutationsSnapshot`. This happened for tables that had no pending data or metadata mutations. It looks like the method could just exit early without acquiring `state_mutex` in this case (with `apply_mutations_on_fly` and `apply_patch_parts` both disabled). We should even be able to exit early if there are parts with an older metadata version by tracking if there are any supported metadata mutations with an atomic counter. The shared lock introduced in https://github.com/ClickHouse/ClickHouse/pull/95771 doesn't seem to avoid this because fetches frequently acquire exclusive locks.

### Changelog category (leave one):

- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Improve SELECT performance by avoiding lock contention when getting mutation snapshots with many concurrent background fetches.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
