### PR TITLE
Coalescing merge tree fix array

### DIFF
--- a/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
@@ -270,33 +270,40 @@ static SummingSortedAlgorithm::ColumnsDefinition defineColumns(
             /// if nested table name ends with `Map` it is a possible candidate for special handling
             if (map_name == column.name || !endsWith(map_name, "Map"))
             {
-                bool is_agg_func = WhichDataType(column.type).isAggregateFunction();
-
-                SummingSortedAlgorithm::AggregateDescription desc;
-                desc.remove_default_values = remove_default_values;
-                desc.aggregate_all_columns = aggregate_all_columns;
-                desc.sum_function_map_name = sum_function_map_name;
-                desc.is_agg_func_type = is_agg_func;
-                desc.column_numbers = {i};
-
-                desc.real_type = column.type;
-                desc.nested_type = recursiveRemoveLowCardinality(desc.real_type);
-                if (desc.real_type.get() == desc.nested_type.get())
-                    desc.nested_type = nullptr;
-
-                if (simple)
+                if (!column_names_to_sum.empty() && !isInNames(column.name, column_names_to_sum))
                 {
-                    // simple aggregate function
-                    desc.init(simple->getFunction(), true);
-                    if (desc.function->allocatesMemoryInArena())
-                        def.allocates_memory_in_arena = true;
+                    def.column_numbers_not_to_aggregate.push_back(i);
                 }
-                else if (!is_agg_func)
+                else
                 {
-                    desc.init(sum_function_name.c_str(), {column.type});
-                }
+                    bool is_agg_func = WhichDataType(column.type).isAggregateFunction();
 
-                def.columns_to_aggregate.emplace_back(std::move(desc));
+                    SummingSortedAlgorithm::AggregateDescription desc;
+                    desc.remove_default_values = remove_default_values;
+                    desc.aggregate_all_columns = aggregate_all_columns;
+                    desc.sum_function_map_name = sum_function_map_name;
+                    desc.is_agg_func_type = is_agg_func;
+                    desc.column_numbers = {i};
+
+                    desc.real_type = column.type;
+                    desc.nested_type = recursiveRemoveLowCardinality(desc.real_type);
+                    if (desc.real_type.get() == desc.nested_type.get())
+                        desc.nested_type = nullptr;
+
+                    if (simple)
+                    {
+                        // simple aggregate function
+                        desc.init(simple->getFunction(), true);
+                        if (desc.function->allocatesMemoryInArena())
+                            def.allocates_memory_in_arena = true;
+                    }
+                    else if (!is_agg_func)
+                    {
+                        desc.init(sum_function_name.c_str(), {column.type});
+                    }
+
+                    def.columns_to_aggregate.emplace_back(std::move(desc));
+                }
             }
 
             continue;

--- a/tests/queries/0_stateless/04060_coalescing_merge_tree_array_tuple_with_column_param.reference
+++ b/tests/queries/0_stateless/04060_coalescing_merge_tree_array_tuple_with_column_param.reference
@@ -1,2 +1,2 @@
-first	['a','b']	('hello',42)	v2
-first	['a','b']	('hello',42)	v2
+first	['a','b']	('hello',42)	{'x':1,'y':2}	v2
+first	['a','b']	('hello',42)	{'x':1,'y':2}	v2

--- a/tests/queries/0_stateless/04060_coalescing_merge_tree_array_tuple_with_column_param.reference
+++ b/tests/queries/0_stateless/04060_coalescing_merge_tree_array_tuple_with_column_param.reference
@@ -1,0 +1,2 @@
+first	['a','b']	('hello',42)	v2
+first	['a','b']	('hello',42)	v2

--- a/tests/queries/0_stateless/04060_coalescing_merge_tree_array_tuple_with_column_param.sql
+++ b/tests/queries/0_stateless/04060_coalescing_merge_tree_array_tuple_with_column_param.sql
@@ -1,0 +1,28 @@
+DROP TABLE IF EXISTS 04060_test;
+
+CREATE TABLE 04060_test
+(
+    key            String,
+    str_col        String,
+    arr_col        Array(String),
+    tuple_col      Tuple(x String, y UInt32),
+    update_column  Nullable(String)
+)
+ENGINE = CoalescingMergeTree(update_column)
+ORDER BY key;
+
+INSERT INTO 04060_test (key, str_col, arr_col, tuple_col)
+VALUES ('k', 'first', ['a', 'b'], ('hello', 42));
+
+INSERT INTO 04060_test (key, update_column)
+VALUES ('k', 'v2');
+
+SELECT str_col, arr_col, tuple_col, update_column
+FROM 04060_test FINAL;
+
+OPTIMIZE TABLE 04060_test FINAL;
+
+SELECT str_col, arr_col, tuple_col, update_column
+FROM 04060_test;
+
+DROP TABLE 04060_test;

--- a/tests/queries/0_stateless/04060_coalescing_merge_tree_array_tuple_with_column_param.sql
+++ b/tests/queries/0_stateless/04060_coalescing_merge_tree_array_tuple_with_column_param.sql
@@ -6,23 +6,24 @@ CREATE TABLE 04060_test
     str_col        String,
     arr_col        Array(String),
     tuple_col      Tuple(x String, y UInt32),
+    map_col        Map(String, UInt32),
     update_column  Nullable(String)
 )
 ENGINE = CoalescingMergeTree(update_column)
 ORDER BY key;
 
-INSERT INTO 04060_test (key, str_col, arr_col, tuple_col)
-VALUES ('k', 'first', ['a', 'b'], ('hello', 42));
+INSERT INTO 04060_test (key, str_col, arr_col, tuple_col, map_col)
+VALUES ('k', 'first', ['a', 'b'], ('hello', 42), {'x': 1, 'y': 2});
 
 INSERT INTO 04060_test (key, update_column)
 VALUES ('k', 'v2');
 
-SELECT str_col, arr_col, tuple_col, update_column
+SELECT str_col, arr_col, tuple_col, map_col, update_column
 FROM 04060_test FINAL;
 
 OPTIMIZE TABLE 04060_test FINAL;
 
-SELECT str_col, arr_col, tuple_col, update_column
+SELECT str_col, arr_col, tuple_col, map_col, update_column
 FROM 04060_test;
 
 DROP TABLE 04060_test;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Coalescing merge tree fix for array type. This closes https://github.com/ClickHouse/ClickHouse/issues/89509

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.829`
- Backported to: `26.3.7.9`, `26.2.11.6`, `26.1.8.36`, `25.8.24.11`
<!-- ch-version-info:end -->