### PR TITLE
Fix SIGSEGV in ColumnMap::calculateStatisticsForRange on empty columns

### DIFF
--- a/src/Columns/ColumnMap.cpp
+++ b/src/Columns/ColumnMap.cpp
@@ -468,9 +468,14 @@ void ColumnMap::takeExactDynamicStructureFrom(const IColumn & source)
 
 ColumnMap::StatisticsPtr ColumnMap::calculateStatisticsForRange(size_t start, size_t end) const
 {
+    if (start == end)
+        return std::make_shared<Statistics>(0, 0);
+
     const auto & offsets = getNestedColumn().getOffsets();
-    size_t total_maps_size = offsets[ssize_t(end) - 1] - offsets[ssize_t(start) - 1];
-    return std::make_shared<Statistics>(start == end ? 0 : static_cast<Float64>(total_maps_size) / static_cast<Float64>(end - start), end - start);
+    size_t nested_start = start == 0 ? 0 : offsets[start - 1];
+    size_t nested_end = offsets[end - 1];
+    size_t total_maps_size = nested_end - nested_start;
+    return std::make_shared<Statistics>(static_cast<Float64>(total_maps_size) / static_cast<Float64>(end - start), end - start);
 }
 
 ColumnMap::StatisticsPtr ColumnMap::getOrCalculateStatistics() const

--- a/src/Columns/tests/gtest_column_map.cpp
+++ b/src/Columns/tests/gtest_column_map.cpp
@@ -1,0 +1,111 @@
+#include <Columns/ColumnMap.h>
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnTuple.h>
+#include <Columns/ColumnString.h>
+#include <Columns/ColumnsNumber.h>
+
+#include <gtest/gtest.h>
+
+
+using namespace DB;
+
+static MutableColumnPtr createEmptyMapColumn()
+{
+    auto key_col = ColumnString::create();
+    auto val_col = ColumnFloat64::create();
+    auto tuple_col = ColumnTuple::create(Columns{std::move(key_col), std::move(val_col)});
+    auto array_col = ColumnArray::create(std::move(tuple_col));
+    return ColumnMap::create(std::move(array_col));
+}
+
+static MutableColumnPtr createMapColumnWithRows(size_t num_rows, size_t entries_per_row)
+{
+    auto key_col = ColumnString::create();
+    auto val_col = ColumnFloat64::create();
+    auto offsets_col = ColumnArray::ColumnOffsets::create();
+    auto & offsets_data = offsets_col->getData();
+
+    size_t current_offset = 0;
+    for (size_t i = 0; i < num_rows; ++i)
+    {
+        for (size_t j = 0; j < entries_per_row; ++j)
+        {
+            key_col->insert("key_" + std::to_string(i) + "_" + std::to_string(j));
+            val_col->insert(static_cast<Float64>(i * 100 + j));
+        }
+        current_offset += entries_per_row;
+        offsets_data.push_back(current_offset);
+    }
+
+    auto tuple_col = ColumnTuple::create(Columns{std::move(key_col), std::move(val_col)});
+    auto array_col = ColumnArray::create(std::move(tuple_col), std::move(offsets_col));
+    return ColumnMap::create(std::move(array_col));
+}
+
+/// Regression test: `calculateStatisticsForRange(0, 0)` on an empty ColumnMap
+/// used to access `offsets[-1]` (out-of-bounds) before checking `start == end`.
+/// This caused a SIGSEGV when `MergedData::insertChunk` processed an empty
+/// ColumnMap chunk during `MergingSortedAlgorithm` execution.
+TEST(ColumnMap, CalculateStatisticsForEmptyRange)
+{
+    auto map_col = createEmptyMapColumn();
+    ASSERT_EQ(map_col->size(), 0u);
+    ASSERT_TRUE(map_col->hasStatistics());
+
+    auto stats = assert_cast<const ColumnMap &>(*map_col).calculateStatisticsForRange(0, 0);
+    ASSERT_NE(stats, nullptr);
+    ASSERT_EQ(stats->avg, 0);
+    ASSERT_EQ(stats->count, 0u);
+}
+
+/// Verify `getOrCalculateStatistics` does not crash on an empty column.
+TEST(ColumnMap, GetOrCalculateStatisticsEmpty)
+{
+    auto map_col = createEmptyMapColumn();
+    auto stats = assert_cast<const ColumnMap &>(*map_col).getOrCalculateStatistics();
+    ASSERT_NE(stats, nullptr);
+    ASSERT_EQ(stats->avg, 0);
+    ASSERT_EQ(stats->count, 0u);
+}
+
+/// Verify `takeOrCalculateStatisticsFrom` handles a mix of empty and
+/// non-empty source columns without crashing.
+TEST(ColumnMap, TakeOrCalculateStatisticsFromMixedSources)
+{
+    auto empty_col = createEmptyMapColumn();
+    auto populated_col = createMapColumnWithRows(10, 3);
+
+    VectorWithMemoryTracking<ColumnPtr> sources;
+    sources.push_back(empty_col->getPtr());
+    sources.push_back(populated_col->getPtr());
+    sources.push_back(empty_col->getPtr());
+
+    auto target = createEmptyMapColumn();
+    assert_cast<ColumnMap &>(*target).takeOrCalculateStatisticsFrom(sources);
+
+    auto stats = assert_cast<const ColumnMap &>(*target).getStatistics();
+    ASSERT_NE(stats, nullptr);
+    /// Only the populated column contributes: 10 rows, 3 entries each -> avg = 3.0
+    ASSERT_DOUBLE_EQ(stats->avg, 3.0);
+    ASSERT_EQ(stats->count, 10u);
+}
+
+/// Verify statistics are correct for a non-trivial range.
+TEST(ColumnMap, CalculateStatisticsForNonEmptyRange)
+{
+    auto map_col = createMapColumnWithRows(5, 4);
+    auto stats = assert_cast<const ColumnMap &>(*map_col).calculateStatisticsForRange(0, 5);
+    ASSERT_NE(stats, nullptr);
+    ASSERT_DOUBLE_EQ(stats->avg, 4.0);
+    ASSERT_EQ(stats->count, 5u);
+}
+
+/// Verify statistics for a sub-range starting from a non-zero offset.
+TEST(ColumnMap, CalculateStatisticsForSubRange)
+{
+    auto map_col = createMapColumnWithRows(10, 2);
+    auto stats = assert_cast<const ColumnMap &>(*map_col).calculateStatisticsForRange(3, 7);
+    ASSERT_NE(stats, nullptr);
+    ASSERT_DOUBLE_EQ(stats->avg, 2.0);
+    ASSERT_EQ(stats->count, 4u);
+}


### PR DESCRIPTION
`ColumnMap::calculateStatisticsForRange(0, 0)` accessed `offsets[ssize_t(0) - 1]` (out-of-bounds read at `offsets[-1]`) before the `start == end` guard on the return line. This caused a segfault when `MergedData::insertChunk` processed an empty `ColumnMap` chunk during `MergingSortedAlgorithm` execution.

The bug was introduced by #99200 ("Implement automatic buckets in Map data type MergeTree serialization"), backported to 26.3 via #100900.

**Root cause:**

```cpp
// src/Columns/ColumnMap.cpp — before fix
ColumnMap::StatisticsPtr ColumnMap::calculateStatisticsForRange(size_t start, size_t end) const
{
    const auto & offsets = getNestedColumn().getOffsets();
    size_t total_maps_size = offsets[ssize_t(end) - 1] - offsets[ssize_t(start) - 1]; // BUG: offsets[-1]
    return std::make_shared<Statistics>(start == end ? 0 : ...);  // guard is too late
}
```

When called with `start=0, end=0` (empty column), `offsets[ssize_t(0) - 1]` wraps to `offsets[SIZE_MAX]` — UB / segfault. The `start == end` ternary on the return line is a dead guard since the OOB access already occurred.

**Call chain:**
1. `MergedData::insertChunk` checks `columns[i]->hasStatistics()`
2. `ColumnMap::hasStatistics` unconditionally returns `true`
3. `takeOrCalculateStatisticsFrom` → `getOrCalculateStatistics` → `calculateStatisticsForRange(0, size())`
4. When the source `ColumnMap` is empty (`size() == 0`) → `calculateStatisticsForRange(0, 0)` → crash

**Trigger:** `ORDER BY ... LIMIT N BY` on tables with Map columns, when multi-threaded execution produces chunks where some threads yield zero rows.

**Fix:** Early return for the empty range case before accessing `offsets`, and fix the non-empty path to correctly handle `start == 0` without the `ssize_t` cast.

**Stack trace from production crash (v26.3.5.12):**

```
Signal: Segmentation fault (11). Address: 0x10. Access: read.

 2. DB::ColumnMap::takeOrCalculateStatisticsFrom(...) @ 0x1d15156c
 3. DB::MergedData::insertChunk(DB::Chunk&&, unsigned long) @ 0x1eac418d
 4. DB::MergingSortedAlgorithm::insertChunk(unsigned long) @ 0x1eac67e8
 5. DB::MergingSortedAlgorithm::mergeImpl(...) @ 0x1eb3b4ed
 6. DB::IMergingTransform<DB::MergingSortedAlgorithm>::work() @ 0x1ca7de4c
 7. DB::ExecutionThreadContext::executeTask() @ 0x1e65edbd
 8. DB::PipelineExecutor::executeStepImpl(...) @ 0x1e650364
```

**Related issues:** #101667, #101848

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix segfault in `ColumnMap::calculateStatisticsForRange` when processing empty Map columns during merge-sorted query execution (e.g. `ORDER BY ... LIMIT N BY` on tables with Map columns).

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)