### PR TITLE
Enable logging in FunctionsStress unit test

### DIFF
--- a/src/Functions/tests/gtest_functions_stress.cpp
+++ b/src/Functions/tests/gtest_functions_stress.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <Poco/ConsoleChannel.h>
 #include <absl/log/globals.h>
 #include <boost/program_options.hpp>
 #include <fmt/ranges.h>
@@ -2103,6 +2104,13 @@ TEST(FunctionsStress, stress)
 #endif
 
     chassert(!logger);
+
+    /// Set up console logging so that LOG_ERROR output is visible in the test log.
+    /// Without this, the root logger has a nullptr channel and all messages are silently discarded.
+    Poco::AutoPtr<Poco::ConsoleChannel> channel(new Poco::ConsoleChannel(std::cerr));
+    Poco::Logger::root().setChannel(channel);
+    Poco::Logger::root().setLevel("information");
+
     logger = getLogger("stress");
 
     /// (This makes exception stack traces much faster, and this test spends a lot of time throwing and catching exceptions.)


### PR DESCRIPTION
`FunctionsStress.stress` uses `LOG_ERROR` to report which functions failed and why, but the root Poco logger has no channel configured — all messages are silently discarded. The "see log above" assertion message refers to output that was never produced, making CI failures impossible to diagnose.

Set up a `ConsoleChannel` on stderr before creating the logger, following the same pattern used by other unit tests.

Example failure with no useful output: https://s3.amazonaws.com/clickhouse-test-reports/PRs/100230/fd4001476012b7f2827bdaebc87f146ed62f0d4b/unit_tests_tsan/job.log

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.839`
<!-- ch-version-info:end -->