### PR TITLE
Fix Alias tables without a target table with Database Replicated

### DIFF
--- a/src/Storages/StorageAlias.h
+++ b/src/Storages/StorageAlias.h
@@ -105,8 +105,20 @@ public:
 
     void updateExternalDynamicMetadataIfExists(ContextPtr local_context) override;
     void checkTableCanBeDropped(ContextPtr /*query_context*/) const override {}
-    StorageInMemoryMetadata getInMemoryMetadata() const override { return getTargetTable()->getInMemoryMetadata(); }
-    StorageMetadataPtr getInMemoryMetadataPtr(bool bypass_metadata_cache) const override { return getTargetTable()->getInMemoryMetadataPtr(bypass_metadata_cache); }
+    StorageInMemoryMetadata getInMemoryMetadata() const override
+    {
+        auto target = tryGetTargetTable();
+        if (!target)
+            return IStorage::getInMemoryMetadata();
+        return target->getInMemoryMetadata();
+    }
+    StorageMetadataPtr getInMemoryMetadataPtr(bool bypass_metadata_cache) const override
+    {
+        auto target = tryGetTargetTable();
+        if (!target)
+            return IStorage::getInMemoryMetadataPtr(bypass_metadata_cache);
+        return target->getInMemoryMetadataPtr(bypass_metadata_cache);
+    }
     std::optional<StorageMetadataPtr> tryGetInMemoryMetadataPtr() const override
     {
         auto target = tryGetTargetTable();
@@ -188,7 +200,13 @@ public:
         return target->getSerializationHints();
     }
 
-    ActionLock getActionLock(StorageActionBlockType type) override { return getTargetTable()->getActionLock(type); }
+    ActionLock getActionLock(StorageActionBlockType type) override
+    {
+        auto target = tryGetTargetTable();
+        if (!target)
+            return {};
+        return target->getActionLock(type);
+    }
 
     TableLockHolder lockForShare(const String & query_id, const std::chrono::milliseconds & acquire_timeout) const { return getTargetTable()->lockForShare(query_id, Poco::Timespan(acquire_timeout.count() * 1000)); }
     TableLockHolder tryLockForShare(const String & query_id, const std::chrono::milliseconds & acquire_timeout) const

--- a/tests/integration/test_replicated_database/test.py
+++ b/tests/integration/test_replicated_database/test.py
@@ -2015,3 +2015,32 @@ def test_ignore_cluster_name_setting(started_cluster):
     # Cleanup
     for node in [main_node, dummy_node]:
         node.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")
+
+
+def test_alias_with_dropped_target(started_cluster):
+    db_name = "test_alias_dropped"
+
+    main_node.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")
+    dummy_node.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")
+
+    main_node.query(
+        f"""
+        CREATE DATABASE {db_name} ENGINE = Replicated('/clickhouse/databases/{db_name}', '{{shard}}', '{{replica}}');
+        SET allow_experimental_alias_table_engine = 1;
+        CREATE TABLE {db_name}.base_table (id UInt32, value String) ENGINE = MergeTree ORDER BY id;
+        CREATE TABLE {db_name}.alias_table ENGINE = Alias('{db_name}', 'base_table');
+        DROP TABLE {db_name}.base_table;
+        """
+    )
+
+    dummy_node.query(
+        f"""
+        DROP DATABASE IF EXISTS {db_name} SYNC;
+        CREATE DATABASE {db_name} ENGINE = Replicated('/clickhouse/databases/{db_name}', '{{shard}}', '{{replica}}');
+        SYSTEM SYNC DATABASE REPLICA {db_name};
+        """
+    )
+
+    # Cleanup
+    for node in [main_node, dummy_node]:
+        node.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix failure to initialize on a fresh replica Alias tables without a target table in the Database Replicated. Closes https://github.com/ClickHouse/ClickHouse/issues/101320

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.870`
- Backported to: `26.3.9.6`, `26.2.14.4`, `26.1.9.4`
<!-- ch-version-info:end -->