### PR TITLE
Skip external database engines during restore with restore_replace_external_engines_to_null

### DIFF
--- a/src/Backups/RestorerFromBackup.cpp
+++ b/src/Backups/RestorerFromBackup.cpp
@@ -14,6 +14,7 @@
 #include <Backups/RestorerFromBackup.h>
 #include <Core/Settings.h>
 #include <Databases/DDLDependencyVisitor.h>
+#include <Databases/DatabaseFactory.h>
 #include <Databases/IDatabase.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
@@ -54,6 +55,7 @@ namespace Setting
     extern const SettingsUInt64 backup_restore_keeper_max_retries;
     extern const SettingsSeconds lock_acquire_timeout;
     extern const SettingsBool restore_replicated_merge_tree_to_shared_merge_tree;
+    extern const SettingsBool restore_replace_external_engines_to_null;
 }
 
 namespace ErrorCodes
@@ -431,6 +433,28 @@ void RestorerFromBackup::createAndCheckDatabase(const String & database_name)
 void RestorerFromBackup::createAndCheckDatabaseImpl(const String & database_name)
 {
     checkIsQueryCancelled();
+
+    /// Skip external database engines (e.g. MySQL, PostgreSQL, S3, DataLakeCatalog) when
+    /// restore_replace_external_engines_to_null is set - there is no meaningful way to
+    /// replace a database engine with Null, so we skip both creation and verification.
+    if (context->getSettingsRef()[Setting::restore_replace_external_engines_to_null])
+    {
+        std::lock_guard lock{mutex};
+        const auto & database_info = database_infos.at(database_name);
+        if (database_info.create_database_query)
+        {
+            const auto & create = database_info.create_database_query->as<const ASTCreateQuery &>();
+            if (create.storage && create.storage->engine
+                && DatabaseFactory::instance().isDatabaseExternal(create.storage->engine->name))
+            {
+                LOG_TRACE(log, "Skipping external database {} with engine {} because restore_replace_external_engines_to_null is set",
+                    backQuoteIfNeed(database_name), create.storage->engine->name);
+                skipped_databases.emplace(database_name);
+                return;
+            }
+        }
+    }
+
     createDatabase(database_name);
     checkDatabase(database_name);
 }
@@ -669,6 +693,19 @@ void RestorerFromBackup::createAndCheckTable(const QualifiedTableName & table_na
 void RestorerFromBackup::createAndCheckTableImpl(const QualifiedTableName & table_name)
 {
     checkIsQueryCancelled();
+
+    /// Skip tables belonging to databases that were skipped during restore
+    /// (external database engines when restore_replace_external_engines_to_null is set).
+    {
+        std::lock_guard lock{mutex};
+        if (skipped_databases.contains(table_name.database))
+        {
+            LOG_TRACE(log, "Skipping table {}.{} because its database was skipped",
+                backQuoteIfNeed(table_name.database), backQuoteIfNeed(table_name.table));
+            return;
+        }
+    }
+
     createTable(table_name);
     checkTable(table_name);
 }
@@ -845,6 +882,12 @@ void RestorerFromBackup::insertDataToTable(const QualifiedTableName & table_name
     if (restore_settings.structure_only)
         return;
 
+    {
+        std::lock_guard lock{mutex};
+        if (skipped_databases.contains(table_name.database))
+            return;
+    }
+
     StoragePtr storage;
     String data_path_in_backup;
     std::optional<ASTs> partitions;
@@ -926,8 +969,11 @@ void RestorerFromBackup::finalizeTables()
     {
         std::lock_guard lock{mutex};
         tables.reserve(table_infos.size());
-        for (const auto & [_, info] : table_infos)
-            tables.push_back(info.storage);
+        for (const auto & [table_name, info] : table_infos)
+        {
+            if (!skipped_databases.contains(table_name.database) && info.storage)
+                tables.push_back(info.storage);
+        }
     }
 
     for (const auto & storage : tables)

--- a/src/Backups/RestorerFromBackup.h
+++ b/src/Backups/RestorerFromBackup.h
@@ -9,6 +9,7 @@
 #include <Common/ZooKeeper/ZooKeeperRetries.h>
 
 #include <filesystem>
+#include <unordered_set>
 
 
 namespace DB
@@ -120,6 +121,10 @@ private:
 
     std::vector<DataRestoreTask> data_restore_tasks TSA_GUARDED_BY(mutex);
     std::unique_ptr<AccessRestorerFromBackup> access_restorer TSA_GUARDED_BY(mutex);
+
+    /// Databases skipped during restore because they use external engines
+    /// and restore_replace_external_engines_to_null is set.
+    std::unordered_set<String> skipped_databases TSA_GUARDED_BY(mutex);
 };
 
 }

--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -1061,7 +1061,7 @@ void registerDatabaseDataLake(DatabaseFactory & factory)
             std::move(engine_for_tables),
             args.uuid);
     };
-    factory.registerDatabase("DataLakeCatalog", create_fn, { .supports_arguments = true, .supports_settings = true });
+    factory.registerDatabase("DataLakeCatalog", create_fn, { .supports_arguments = true, .supports_settings = true, .is_external = true });
 }
 
 }

--- a/src/Databases/DatabaseBackup.cpp
+++ b/src/Databases/DatabaseBackup.cpp
@@ -471,7 +471,7 @@ void registerDatabaseBackup(DatabaseFactory & factory)
         return std::make_shared<DatabaseBackup>(args.database_name, args.metadata_path, config, args.context);
     };
 
-    factory.registerDatabase("Backup", create_fn, {.supports_arguments = true});
+    factory.registerDatabase("Backup", create_fn, {.supports_arguments = true, .is_external = true});
 }
 
 }

--- a/src/Databases/DatabaseFactory.cpp
+++ b/src/Databases/DatabaseFactory.cpp
@@ -137,6 +137,14 @@ DatabaseFactory & DatabaseFactory::instance()
     return db_fact;
 }
 
+bool DatabaseFactory::isDatabaseExternal(const String & engine_name) const
+{
+    auto it = database_engines.find(engine_name);
+    if (it == database_engines.end())
+        return false;
+    return it->second.features.is_external;
+}
+
 DatabasePtr DatabaseFactory::getImpl(const ASTCreateQuery & create, const String & metadata_path, ContextPtr context)
 {
     auto * storage = create.storage;

--- a/src/Databases/DatabaseFactory.h
+++ b/src/Databases/DatabaseFactory.h
@@ -71,6 +71,7 @@ public:
         .supports_arguments = false,
         .supports_settings = false,
         .supports_table_overrides = false,
+        .is_external = false,
     });
 
     const DatabaseEngines & getDatabaseEngines() const { return database_engines; }

--- a/src/Databases/DatabaseFactory.h
+++ b/src/Databases/DatabaseFactory.h
@@ -48,6 +48,11 @@ public:
         bool supports_arguments = false;
         bool supports_settings = false;
         bool supports_table_overrides = false;
+        /// Whether this database engine accesses external data sources
+        /// (e.g. MySQL, PostgreSQL, S3, DataLakeCatalog).
+        /// Used by restore to skip external databases when
+        /// restore_replace_external_engines_to_null is set.
+        bool is_external = false;
     };
 
     using CreatorFn = std::function<DatabasePtr(const Arguments & arguments)>;
@@ -69,6 +74,9 @@ public:
     });
 
     const DatabaseEngines & getDatabaseEngines() const { return database_engines; }
+
+    /// Returns true if the given database engine accesses external data sources.
+    bool isDatabaseExternal(const String & engine_name) const;
 
     std::vector<String> getAllRegisteredNames() const override
     {

--- a/src/Databases/DatabaseFilesystem.cpp
+++ b/src/Databases/DatabaseFilesystem.cpp
@@ -263,6 +263,6 @@ void registerDatabaseFilesystem(DatabaseFactory & factory)
 
         return std::make_shared<DatabaseFilesystem>(args.database_name, init_path, args.context);
     };
-    factory.registerDatabase("Filesystem", create_fn, {.supports_arguments = true});
+    factory.registerDatabase("Filesystem", create_fn, {.supports_arguments = true, .is_external = true});
 }
 }

--- a/src/Databases/DatabaseHDFS.cpp
+++ b/src/Databases/DatabaseHDFS.cpp
@@ -262,7 +262,7 @@ void registerDatabaseHDFS(DatabaseFactory & factory)
 
         return std::make_shared<DatabaseHDFS>(args.database_name, source_url, args.context);
     };
-    factory.registerDatabase("HDFS", create_fn, {.supports_arguments = true});
+    factory.registerDatabase("HDFS", create_fn, {.supports_arguments = true, .is_external = true});
 }
 } // DB
 

--- a/src/Databases/DatabaseS3.cpp
+++ b/src/Databases/DatabaseS3.cpp
@@ -334,7 +334,7 @@ void registerDatabaseS3(DatabaseFactory & factory)
 
         return std::make_shared<DatabaseS3>(args.database_name, config, args.context);
     };
-    factory.registerDatabase("S3", create_fn, {.supports_arguments = true});
+    factory.registerDatabase("S3", create_fn, {.supports_arguments = true, .is_external = true});
 }
 }
 #endif

--- a/src/Databases/MySQL/DatabaseMySQL.cpp
+++ b/src/Databases/MySQL/DatabaseMySQL.cpp
@@ -662,7 +662,7 @@ void registerDatabaseMySQL(DatabaseFactory & factory)
             throw Exception(ErrorCodes::CANNOT_CREATE_DATABASE, "Cannot create MySQL database, because {}", exception_message);
         }
     };
-    factory.registerDatabase("MySQL", create_fn, {.supports_arguments = true, .supports_settings = true});
+    factory.registerDatabase("MySQL", create_fn, {.supports_arguments = true, .supports_settings = true, .is_external = true});
 }
 }
 

--- a/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabaseMaterializedPostgreSQL.cpp
@@ -564,6 +564,7 @@ void registerDatabaseMaterializedPostgreSQL(DatabaseFactory & factory)
         .supports_arguments = true,
         .supports_settings = true,
         .supports_table_overrides = true,
+        .is_external = true,
     });
 }
 }

--- a/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
+++ b/src/Databases/PostgreSQL/DatabasePostgreSQL.cpp
@@ -577,7 +577,7 @@ void registerDatabasePostgreSQL(DatabaseFactory & factory)
             use_table_cache,
             args.uuid);
     };
-    factory.registerDatabase("PostgreSQL", create_fn, {.supports_arguments = true});
+    factory.registerDatabase("PostgreSQL", create_fn, {.supports_arguments = true, .is_external = true});
 }
 }
 

--- a/src/Databases/SQLite/DatabaseSQLite.cpp
+++ b/src/Databases/SQLite/DatabaseSQLite.cpp
@@ -233,7 +233,7 @@ void registerDatabaseSQLite(DatabaseFactory & factory)
 
         return std::make_shared<DatabaseSQLite>(args.context, engine_define, args.create_query.attach, database_path);
     };
-    factory.registerDatabase("SQLite", create_fn, {.supports_arguments = true});
+    factory.registerDatabase("SQLite", create_fn, {.supports_arguments = true, .is_external = true});
 }
 }
 

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -608,6 +608,29 @@ def test_backup_database(started_cluster):
     )
 
 
+def test_restore_database_replace_external_to_null(started_cluster):
+    node = started_cluster.instances["node1"]
+    db_name = "backup_database_null"
+    create_clickhouse_iceberg_database(started_cluster, node, db_name)
+
+    backup_id = uuid.uuid4().hex
+    backup_name = f"File('/backups/test_backup_{backup_id}/')"
+
+    node.query(f"BACKUP DATABASE {db_name} TO {backup_name}")
+    node.query(f"DROP DATABASE {db_name} SYNC")
+    assert db_name not in node.query("SHOW DATABASES")
+
+    node.query(
+        f"RESTORE DATABASE {db_name} FROM {backup_name}",
+        settings={
+            "restore_replace_external_engines_to_null": 1,
+            "restore_replace_external_table_functions_to_null": 1,
+            "restore_replace_external_dictionary_source_to_null": 1,
+        },
+    )
+    assert db_name not in node.query("SHOW DATABASES")
+
+
 def test_non_existing_tables(started_cluster):
     node = started_cluster.instances["node1"]
 


### PR DESCRIPTION
When `restore_replace_external_engines_to_null` is set, external table engines are replaced with Null during restore. However, external **database** engines (e.g. `DataLakeCatalog`, `MySQL`, `PostgreSQL`, `S3`, `HDFS`, `SQLite`, `Filesystem`, `Backup`) were still being created, which could fail or initiate unwanted external connections.

This adds an `is_external` flag to `DatabaseFactory::EngineFeatures` (similar to `source_access_type` in `StorageFactory`) and uses it in `RestorerFromBackup` to skip creation of external databases — and any tables belonging to them — when the setting is active.

Required for chreplay

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The `restore_replace_external_engines_to_null` setting now also skips restoring databases with external engines (e.g. `DataLakeCatalog`, `MySQL`, `PostgreSQL`, `S3`) instead of failing or initiating external connections.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.908`
<!-- ch-version-info:end -->