### PR TITLE
Fix MSan false positive in PoolWithFailoverBase::getMany

### DIFF
--- a/src/Common/PoolWithFailoverBase.h
+++ b/src/Common/PoolWithFailoverBase.h
@@ -8,6 +8,7 @@
 #include <base/types.h>
 #include <base/scope_guard.h>
 #include <base/sort.h>
+#include <base/MemorySanitizer.h>
 #include <Common/PoolBase.h>
 #include <Common/ProfileEvents.h>
 #include <Common/NetException.h>
@@ -308,6 +309,11 @@ PoolWithFailoverBase<TNestedPool>::getMany(
 
             std::string fail_message;
             result = try_get_entry(shuffled_pool.pool, fail_message);
+
+            /// MSan LLVM IR tracks shadow per-field, not per-byte, so struct
+            /// padding in return values inherits whatever shadow was in the
+            /// destination stack slot previously, which can be dirty.
+            __msan_unpoison(&result, sizeof(result));
 
             if (!fail_message.empty())
                 fail_messages += fail_message + '\n';


### PR DESCRIPTION
MSan LLVM IR tracks shadow per-field, not per-byte, so struct padding bytes in
return values inherit whatever shadow occupied the destination stack slot
previously. `TryResult` has 9 bytes of padding and is returned by value from
`try_get_entry`; the dirty padding shadow then propagates through vector
operations in `erase_if` and triggers a use-of-uninitialized-value report.

Unpoison the result after the call, matching the pattern already used elsewhere
in the codebase (e.g. `FiberStack.cpp`).

Closes #102395

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)