### PR TITLE
Fix default_normal_view_sql_security not applied on CREATE VIEW

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1529,7 +1529,7 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
     bool is_secondary_query = getContext()->getZooKeeperMetadataTransaction() && !getContext()->getZooKeeperMetadataTransaction()->isInitialQuery();
     auto mode = getLoadingStrictnessLevel(create.attach, /*force_attach*/ false, /*has_force_restore_data_flag*/ false, is_secondary_query || is_restore_from_backup);
 
-    if (!create.sql_security && create.supportSQLSecurity() && (create.refresh_strategy || !getContext()->getServerSettings()[ServerSetting::ignore_empty_sql_security_in_create_view_query]))
+    if (!create.sql_security && create.supportSQLSecurity() && (!create.attach || create.refresh_strategy || !getContext()->getServerSettings()[ServerSetting::ignore_empty_sql_security_in_create_view_query]))
         create.set(create.sql_security, make_intrusive<ASTSQLSecurity>());
 
     if (create.sql_security)

--- a/tests/queries/0_stateless/04097_default_normal_view_sql_security.reference
+++ b/tests/queries/0_stateless/04097_default_normal_view_sql_security.reference
@@ -1,0 +1,11 @@
+default_normal_view_sql_security = DEFINER
+1
+1
+default_normal_view_sql_security = INVOKER
+1
+default_normal_view_sql_security = NONE
+1
+functional check
+2
+2
+2

--- a/tests/queries/0_stateless/04097_default_normal_view_sql_security.sql
+++ b/tests/queries/0_stateless/04097_default_normal_view_sql_security.sql
@@ -1,0 +1,46 @@
+-- Tags: no-parallel
+
+DROP TABLE IF EXISTS test_table;
+DROP VIEW IF EXISTS test_view_default;
+DROP VIEW IF EXISTS test_view_definer;
+DROP VIEW IF EXISTS test_view_invoker;
+DROP VIEW IF EXISTS test_view_none;
+
+CREATE TABLE test_table (s String) ENGINE = MergeTree ORDER BY s;
+INSERT INTO test_table VALUES ('hello'), ('world');
+
+-- Test 1: default_normal_view_sql_security = DEFINER should be applied on CREATE VIEW
+SELECT 'default_normal_view_sql_security = DEFINER';
+
+SET default_normal_view_sql_security = 'DEFINER';
+CREATE VIEW test_view_definer AS SELECT * FROM test_table;
+
+SELECT create_table_query LIKE '%SQL SECURITY DEFINER%' AS has_definer FROM system.tables WHERE database = currentDatabase() AND name = 'test_view_definer';
+SELECT definer != '' AS has_definer_user FROM system.tables WHERE database = currentDatabase() AND name = 'test_view_definer';
+
+-- Test 2: default_normal_view_sql_security = INVOKER should be applied on CREATE VIEW
+SELECT 'default_normal_view_sql_security = INVOKER';
+
+SET default_normal_view_sql_security = 'INVOKER';
+CREATE VIEW test_view_invoker AS SELECT * FROM test_table;
+
+SELECT create_table_query LIKE '%SQL SECURITY INVOKER%' AS has_invoker FROM system.tables WHERE database = currentDatabase() AND name = 'test_view_invoker';
+
+-- Test 3: default_normal_view_sql_security = NONE should be applied on CREATE VIEW
+SELECT 'default_normal_view_sql_security = NONE';
+
+SET default_normal_view_sql_security = 'NONE';
+CREATE VIEW test_view_none AS SELECT * FROM test_table;
+
+SELECT create_table_query LIKE '%SQL SECURITY NONE%' AS has_none FROM system.tables WHERE database = currentDatabase() AND name = 'test_view_none';
+
+-- Test 4: Views created with defaults should work correctly
+SELECT 'functional check';
+SELECT count() FROM test_view_definer;
+SELECT count() FROM test_view_invoker;
+SELECT count() FROM test_view_none;
+
+DROP VIEW test_view_definer;
+DROP VIEW test_view_invoker;
+DROP VIEW test_view_none;
+DROP TABLE test_table;

--- a/tests/queries/0_stateless/04097_default_normal_view_sql_security.sql
+++ b/tests/queries/0_stateless/04097_default_normal_view_sql_security.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 DROP TABLE IF EXISTS test_table;
 DROP VIEW IF EXISTS test_view_default;
 DROP VIEW IF EXISTS test_view_definer;


### PR DESCRIPTION
The `default_normal_view_sql_security` setting was silently ignored during `CREATE VIEW` because the server setting `ignore_empty_sql_security_in_create_view_query` (defaults to `true`) gates the entire SQL security default application path. This meant `processSQLSecurityOption()` was never called for non-refreshable views, and the user-level setting had no effect.

The `ignore_empty_sql_security_in_create_view_query` setting was introduced as a migration compatibility measure to avoid retroactively adding SQL security clauses to existing views during `ATTACH`. However, it also blocked the defaults for new `CREATE` queries — which is a bug.

The fix adds `!create.attach` to the condition, so new `CREATE VIEW` statements always apply the configured defaults from `default_normal_view_sql_security` / `default_materialized_view_sql_security`, while `ATTACH` queries still respect the server setting for migration compatibility.

Closes #102199

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a]
`default_normal_view_sql_security` setting is now correctly applied when creating a normal view. Previously it was silently ignored due to the `ignore_empty_sql_security_in_create_view_query` server setting gating the defaults for new `CREATE VIEW` statements.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

> *Generated by [Nerve](https://github.com/nicholasgasior/nerve)*