### PR TITLE
Tag `03642_system_instrument_stress` as long

### DIFF
--- a/tests/queries/0_stateless/03642_system_instrument_stress.sh
+++ b/tests/queries/0_stateless/03642_system_instrument_stress.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: use-xray, no-parallel, no-fasttest, no-llvm-coverage
+# Tags: use-xray, no-parallel, no-fasttest, no-llvm-coverage, long
 # no-parallel: avoid other tests interfering with the global system.instrumentation table
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)


### PR DESCRIPTION
Tag `03642_system_instrument_stress` as `long`. The test spawns `nproc` parallel workers each running 100 sequential `clickhouse-client` calls. In debug builds on CI machines this consistently takes ~270s, exceeding the 180s flaky-check limit for non-`long` tests.

[Flaky check report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=102391&sha=f9e7727745c52b516a482598b741a086e97b9ba2&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20flaky%20check%29) | [PR #102391](https://github.com/ClickHouse/ClickHouse/pull/102391)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.817`
<!-- ch-version-info:end -->