### PR TITLE
Filter LLVM Profile Error noise from test runner stderr

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2419,6 +2419,17 @@ class TestCase:
             with open(self.stderr_file, "rb") as stdfd:
                 stderr += str(stdfd.read(), errors="replace", encoding="utf-8")
 
+        # Filter out LLVM profiling runtime noise from stderr.
+        # In coverage builds, short-lived clickhouse-client processes contend over
+        # profraw merge pool files, producing "LLVM Profile Error:" messages that
+        # are not real test failures — the test output is correct. See #97020.
+        if stderr:
+            stderr = "\n".join(
+                line
+                for line in stderr.splitlines()
+                if not line.startswith("LLVM Profile Error:")
+            ).strip()
+
         if debug_log:
             debug_log = trim_for_log(debug_log, 100)
 


### PR DESCRIPTION
In coverage builds (`amd_llvm_coverage_per_test`), short-lived `clickhouse-client`
processes contend over profraw merge pool files (`%2m` pattern), producing
`LLVM Profile Error:` messages on stderr. The test runner treats any non-empty
stderr as a test failure (`if stderr: → FAIL`), even when the test output is
correct and exit code is 0.

This causes **~1160 false positives per month across 504+ distinct tests** on
master coverage runs (CIDB data, 30-day window). Example error:
```
LLVM Profile Error: Invalid profile data to merge
LLVM Profile Error: Profile Merging of file clickhouse-client-proc0-..._1.profraw failed: Success
LLVM Profile Error: Failed to write file "clickhouse-client-proc0-..._1.profraw": Success
```

The fix filters lines starting with `LLVM Profile Error:` from stderr before
the pass/fail decision point. This follows the same pattern as the existing
`IGNORED_SANITIZER_ERRORS` mechanism for known false positives. Real errors
(exceptions, crashes, Fatal messages) are completely unaffected.

Background: #97020 attempted to fix this via `%p` in the profraw pattern but was
closed because it creates too many files. #101912 fixed a specific integration
test. This PR addresses the root cause in the test runner itself.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Not required

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.824`
<!-- ch-version-info:end -->