### PR TITLE
Fix flaky 02223_insert_select_schema_inference

### DIFF
--- a/tests/queries/0_stateless/02223_insert_select_schema_inference.sql
+++ b/tests/queries/0_stateless/02223_insert_select_schema_inference.sql
@@ -1,5 +1,5 @@
 drop table if exists test;
 create table test (x UInt32, y String, d Date) engine=Memory() as select number as x, toString(number) as y, toDate(number) as d from numbers(10);
-insert into table function file('data.native.zst') select * from test settings engine_file_truncate_on_insert=1;
-desc file('data.native.zst');
-select * from file('data.native.zst');
+insert into table function file(currentDatabase() || '_02223_insert_select_schema_inference.native.zst') select * from test settings engine_file_truncate_on_insert=1;
+desc file(currentDatabase() || '_02223_insert_select_schema_inference.native.zst');
+select * from file(currentDatabase() || '_02223_insert_select_schema_inference.native.zst');


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

It used a fixed filename but didn't have no-parallel, so concurrent runs could race for accessing the same file.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.869`
<!-- ch-version-info:end -->