### PR TITLE
Add EBS snapshot-based Docker image cache for CI runners

### DIFF
--- a/ci/docker/style-test/Dockerfile
+++ b/ci/docker/style-test/Dockerfile
@@ -1,5 +1,5 @@
 # docker build -t clickhouse/style-test .
-# EBS docker cache test
+# EBS docker cache test v4
 FROM ubuntu:22.04
 
 RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install --yes \

--- a/ci/docker/style-test/Dockerfile
+++ b/ci/docker/style-test/Dockerfile
@@ -1,4 +1,5 @@
 # docker build -t clickhouse/style-test .
+# EBS docker cache test
 FROM ubuntu:22.04
 
 RUN apt-get update && env DEBIAN_FRONTEND=noninteractive apt-get install --yes \

--- a/ci/praktika/ebs_docker_cache.py
+++ b/ci/praktika/ebs_docker_cache.py
@@ -1,0 +1,461 @@
+"""
+EBS Snapshot Docker Cache.
+
+Pre-populates Docker's image store from EBS snapshots so that CI runners
+do not need to pull images from the registry.  Docker build jobs create
+snapshots after building; runner jobs mount them before executing.
+
+Snapshots are tagged with a combined digest (derived from all per-image
+digests) and architecture so that runners can look them up with a single
+EC2 describe-snapshots call.
+"""
+
+import hashlib
+import os
+import signal
+import time
+import traceback
+from typing import Dict, List, Optional, Tuple
+
+from .settings import Settings
+from .utils import Shell, Utils
+
+# --- EBS snapshot tag keys ---
+TAG_NAME = "Name"
+TAG_NAME_VALUE = "praktika-docker-cache"
+TAG_DOCKER_CACHE_DIGEST = "docker-cache-digest"
+TAG_ARCH = "arch"
+
+# Mount points and device helpers
+_CACHE_MOUNT = "/mnt/docker-cache"
+_DOCKER_MOUNT = "/var/lib/docker"
+_CACHE_DOCKERD_SOCK = "/var/run/docker-cache.sock"
+_CACHE_DOCKERD_PID = "/var/run/docker-cache.pid"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_arch() -> str:
+    if Utils.is_arm():
+        return "arm"
+    elif Utils.is_amd():
+        return "amd"
+    raise RuntimeError("Unsupported CPU architecture for EBS docker cache")
+
+
+def _get_instance_metadata() -> Tuple[str, str, str]:
+    """Return (instance_id, availability_zone, region)."""
+    instance_id = (
+        os.environ.get("INSTANCE_ID")
+        or Shell.get_output("ec2metadata --instance-id")
+        or ""
+    )
+    az = Shell.get_output(
+        "ec2metadata --availability-zone"
+    ) or Shell.get_output(
+        "curl -s --fail http://169.254.169.254/latest/meta-data/placement/availability-zone"
+    )
+    region = Settings.AWS_REGION or (az[:-1] if az else "us-east-1")
+    if not instance_id or not az:
+        raise RuntimeError(
+            f"Cannot determine instance metadata: instance_id=[{instance_id}], az=[{az}]"
+        )
+    return instance_id, az, region
+
+
+def _ec2_client(region: str):
+    import boto3
+
+    return boto3.client("ec2", region_name=region)
+
+
+def _find_free_device() -> str:
+    """Return the first free /dev/xvd[f-z] device name."""
+    import string
+
+    for letter in string.ascii_lowercase[5:]:  # f..z
+        dev = f"/dev/xvd{letter}"
+        if not os.path.exists(dev):
+            return dev
+    raise RuntimeError("No free /dev/xvd* device found")
+
+
+def _resolve_device(requested_device: str) -> str:
+    """After attaching an EBS volume as e.g. /dev/xvdf, the kernel may
+    expose it as /dev/nvme*n1. Wait up to 30 s and return the actual path."""
+    for _ in range(30):
+        if os.path.exists(requested_device):
+            return requested_device
+        # On Nitro instances the device appears as /dev/nvme*n1 but we can
+        # find it via lsblk or by scanning /dev/disk/by-id/.
+        # Simple approach: look for a new block device that appeared.
+        time.sleep(1)
+    # Last resort: try lsblk
+    out = Shell.get_output("lsblk -dpno NAME,SERIAL 2>/dev/null") or ""
+    for line in out.strip().splitlines():
+        parts = line.split()
+        if len(parts) >= 2 and requested_device.replace("/dev/", "").replace(
+            "xvd", "vol"
+        ) in parts[1].replace("-", ""):
+            return parts[0]
+    raise RuntimeError(
+        f"Device {requested_device} did not appear within 30 seconds"
+    )
+
+
+def _wait_for_volume_status(ec2, volume_id: str, status: str, timeout: int = 120):
+    for _ in range(timeout):
+        resp = ec2.describe_volumes(VolumeIds=[volume_id])
+        vol = resp["Volumes"][0]
+        if vol["State"] == status:
+            return
+        time.sleep(1)
+    raise RuntimeError(
+        f"Volume {volume_id} did not reach state {status} within {timeout}s"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def calc_combined_digest(digest_dockers: Dict[str, str]) -> str:
+    """Combine per-image digests into a single cache key.
+
+    Uses sorted image names for determinism.
+    """
+    h = hashlib.sha256()
+    for name in sorted(digest_dockers.keys()):
+        h.update(f"{name}={digest_dockers[name]}".encode())
+    return h.hexdigest()[: Settings.CACHE_DIGEST_LEN]
+
+
+def find_snapshot(
+    combined_digest: str, arch: str, region: str
+) -> Optional[str]:
+    """Look up a completed EBS snapshot by digest and arch tags.
+
+    Returns snapshot_id if found, None otherwise.
+    """
+    ec2 = _ec2_client(region)
+    resp = ec2.describe_snapshots(
+        Filters=[
+            {"Name": f"tag:{TAG_DOCKER_CACHE_DIGEST}", "Values": [combined_digest]},
+            {"Name": f"tag:{TAG_ARCH}", "Values": [arch]},
+            {"Name": "status", "Values": ["completed"]},
+        ],
+        OwnerIds=["self"],
+    )
+    snapshots = resp.get("Snapshots", [])
+    if snapshots:
+        snapshots.sort(key=lambda s: s.get("StartTime", ""), reverse=True)
+        snap_id = snapshots[0]["SnapshotId"]
+        print(f"EBS docker cache: found snapshot [{snap_id}] for digest=[{combined_digest}] arch=[{arch}]")
+        return snap_id
+    return None
+
+
+def create_cache_snapshot(
+    docker_configs,
+    digests: Dict[str, str],
+    combined_digest: str,
+    arch: str,
+) -> Optional[str]:
+    """Create an EBS snapshot containing all Docker images pre-pulled.
+
+    1. Create a gp3 EBS volume in the same AZ as this instance
+    2. Attach, format (ext4), mount
+    3. Start a secondary dockerd with --data-root on the volume
+    4. Pull all images (arch-specific tags)
+    5. Stop dockerd, unmount, detach
+    6. Create snapshot with tags
+    7. Delete the temporary volume
+
+    Returns snapshot_id on success, None on failure.
+    """
+    instance_id, az, region = _get_instance_metadata()
+    ec2 = _ec2_client(region)
+
+    volume_id = None
+    device = None
+    mounted = False
+    dockerd_pid = None
+
+    try:
+        # 1. Create volume
+        print(f"EBS docker cache: creating {Settings.EBS_DOCKER_CACHE_VOLUME_SIZE_GB}GB {Settings.EBS_DOCKER_CACHE_VOLUME_TYPE} volume in {az}")
+        resp = ec2.create_volume(
+            AvailabilityZone=az,
+            Size=Settings.EBS_DOCKER_CACHE_VOLUME_SIZE_GB,
+            VolumeType=Settings.EBS_DOCKER_CACHE_VOLUME_TYPE,
+            TagSpecifications=[
+                {
+                    "ResourceType": "volume",
+                    "Tags": [
+                        {"Key": TAG_NAME, "Value": f"{TAG_NAME_VALUE}-builder"},
+                    ],
+                }
+            ],
+        )
+        volume_id = resp["VolumeId"]
+        print(f"EBS docker cache: created volume [{volume_id}]")
+        _wait_for_volume_status(ec2, volume_id, "available")
+
+        # 2. Attach
+        device = _find_free_device()
+        print(f"EBS docker cache: attaching [{volume_id}] as [{device}]")
+        ec2.attach_volume(
+            Device=device,
+            InstanceId=instance_id,
+            VolumeId=volume_id,
+        )
+        _wait_for_volume_status(ec2, volume_id, "in-use")
+        actual_device = _resolve_device(device)
+
+        # 3. Format and mount
+        Shell.check(f"sudo mkfs.ext4 -q {actual_device}", verbose=True, strict=True)
+        Shell.check(f"sudo mkdir -p {_CACHE_MOUNT}", verbose=True, strict=True)
+        Shell.check(
+            f"sudo mount -o noatime {actual_device} {_CACHE_MOUNT}",
+            verbose=True,
+            strict=True,
+        )
+        mounted = True
+
+        # 4. Start secondary dockerd
+        print("EBS docker cache: starting secondary dockerd")
+        Shell.check(
+            f"sudo dockerd"
+            f" --data-root {_CACHE_MOUNT}"
+            f" --host unix://{_CACHE_DOCKERD_SOCK}"
+            f" --pidfile {_CACHE_DOCKERD_PID}"
+            f" --exec-root /var/run/docker-cache"
+            f" >/dev/null 2>&1 &",
+            verbose=True,
+        )
+        # Wait for the socket to appear
+        for i in range(30):
+            if os.path.exists(_CACHE_DOCKERD_SOCK):
+                break
+            time.sleep(1)
+        else:
+            raise RuntimeError("Secondary dockerd did not start within 30s")
+
+        # Read the PID for cleanup
+        if os.path.exists(_CACHE_DOCKERD_PID):
+            with open(_CACHE_DOCKERD_PID, "r") as f:
+                dockerd_pid = int(f.read().strip())
+
+        # 5. Pull all images
+        docker_cmd = f"sudo docker -H unix://{_CACHE_DOCKERD_SOCK}"
+        for config in docker_configs:
+            tag = f"{digests[config.name]}_{arch}"
+            image_ref = f"{config.name}:{tag}"
+            print(f"EBS docker cache: pulling [{image_ref}]")
+            if not Shell.check(f"{docker_cmd} pull {image_ref}", verbose=True):
+                print(f"WARNING: EBS docker cache: failed to pull [{image_ref}], skipping")
+
+        # Show what we have
+        Shell.check(f"{docker_cmd} images", verbose=True)
+
+        # 6. Stop dockerd
+        if dockerd_pid:
+            print(f"EBS docker cache: stopping secondary dockerd (pid={dockerd_pid})")
+            try:
+                os.kill(dockerd_pid, signal.SIGTERM)
+                for _ in range(30):
+                    try:
+                        os.kill(dockerd_pid, 0)
+                        time.sleep(1)
+                    except OSError:
+                        break
+            except OSError:
+                pass
+            dockerd_pid = None
+
+        # 7. Unmount
+        Shell.check(f"sudo umount {_CACHE_MOUNT}", verbose=True, strict=True)
+        mounted = False
+
+        # 8. Detach volume
+        ec2.detach_volume(VolumeId=volume_id)
+        _wait_for_volume_status(ec2, volume_id, "available")
+
+        # 9. Create snapshot
+        print(f"EBS docker cache: creating snapshot from [{volume_id}]")
+        resp = ec2.create_snapshot(
+            VolumeId=volume_id,
+            Description=f"praktika-docker-cache {combined_digest} {arch}",
+            TagSpecifications=[
+                {
+                    "ResourceType": "snapshot",
+                    "Tags": [
+                        {"Key": TAG_NAME, "Value": TAG_NAME_VALUE},
+                        {"Key": TAG_DOCKER_CACHE_DIGEST, "Value": combined_digest},
+                        {"Key": TAG_ARCH, "Value": arch},
+                    ],
+                }
+            ],
+        )
+        snapshot_id = resp["SnapshotId"]
+        print(f"EBS docker cache: snapshot [{snapshot_id}] creation initiated (async)")
+
+        # 10. Delete the temporary volume (snapshot references S3 data, not the volume)
+        ec2.delete_volume(VolumeId=volume_id)
+        volume_id = None  # prevent double-delete in finally
+
+        return snapshot_id
+
+    except Exception as e:
+        print(f"ERROR: EBS docker cache snapshot creation failed: {e}")
+        traceback.print_exc()
+        return None
+
+    finally:
+        # Cleanup on failure
+        if dockerd_pid:
+            try:
+                os.kill(dockerd_pid, signal.SIGKILL)
+            except OSError:
+                pass
+        if mounted:
+            Shell.check(f"sudo umount {_CACHE_MOUNT}", verbose=True)
+        if volume_id:
+            try:
+                ec2.detach_volume(VolumeId=volume_id)
+                _wait_for_volume_status(ec2, volume_id, "available", timeout=60)
+                ec2.delete_volume(VolumeId=volume_id)
+            except Exception:
+                print(f"WARNING: EBS docker cache: failed to clean up volume [{volume_id}]")
+
+
+def mount_cache_volume(snapshot_id: str) -> Optional[str]:
+    """Create a volume from snapshot, attach, mount at /var/lib/docker.
+
+    Docker must be stopped before calling. Starts Docker after mounting.
+    Returns volume_id on success (for cleanup), None on failure.
+    """
+    instance_id, az, region = _get_instance_metadata()
+    ec2 = _ec2_client(region)
+
+    volume_id = None
+    device = None
+    mounted = False
+
+    try:
+        # Stop Docker
+        print("EBS docker cache: stopping Docker")
+        Shell.check("sudo systemctl stop docker docker.socket containerd", verbose=True)
+
+        # Create volume from snapshot
+        print(f"EBS docker cache: creating volume from snapshot [{snapshot_id}] in [{az}]")
+        resp = ec2.create_volume(
+            SnapshotId=snapshot_id,
+            AvailabilityZone=az,
+            VolumeType=Settings.EBS_DOCKER_CACHE_VOLUME_TYPE,
+            TagSpecifications=[
+                {
+                    "ResourceType": "volume",
+                    "Tags": [
+                        {"Key": TAG_NAME, "Value": f"{TAG_NAME_VALUE}-runner"},
+                        {"Key": "instance", "Value": instance_id},
+                    ],
+                }
+            ],
+        )
+        volume_id = resp["VolumeId"]
+        _wait_for_volume_status(ec2, volume_id, "available")
+
+        # Attach
+        device = _find_free_device()
+        print(f"EBS docker cache: attaching [{volume_id}] as [{device}]")
+        ec2.attach_volume(
+            Device=device,
+            InstanceId=instance_id,
+            VolumeId=volume_id,
+        )
+        _wait_for_volume_status(ec2, volume_id, "in-use")
+        actual_device = _resolve_device(device)
+
+        # Mount at /var/lib/docker
+        Shell.check(f"sudo mkdir -p {_DOCKER_MOUNT}", verbose=True, strict=True)
+        Shell.check(
+            f"sudo mount -o noatime {actual_device} {_DOCKER_MOUNT}",
+            verbose=True,
+            strict=True,
+        )
+        mounted = True
+
+        # Start Docker
+        print("EBS docker cache: starting Docker with cached images")
+        Shell.check("sudo systemctl start docker", verbose=True, strict=True)
+        Shell.check("docker images", verbose=True)
+
+        return volume_id
+
+    except Exception as e:
+        print(f"ERROR: EBS docker cache mount failed: {e}")
+        traceback.print_exc()
+        # Attempt recovery: unmount, restart Docker normally
+        if mounted:
+            Shell.check(f"sudo umount {_DOCKER_MOUNT}", verbose=True)
+        Shell.check("sudo systemctl start docker", verbose=True)
+        if volume_id:
+            try:
+                ec2.detach_volume(VolumeId=volume_id)
+                _wait_for_volume_status(ec2, volume_id, "available", timeout=60)
+                ec2.delete_volume(VolumeId=volume_id)
+            except Exception:
+                print(f"WARNING: EBS docker cache: failed to clean up volume [{volume_id}]")
+        return None
+
+
+def cleanup_cache_volume(volume_id: str) -> None:
+    """Stop Docker, unmount /var/lib/docker, detach and delete the cache volume."""
+    try:
+        _, _, region = _get_instance_metadata()
+    except Exception:
+        region = Settings.AWS_REGION or "us-east-1"
+    ec2 = _ec2_client(region)
+
+    print(f"EBS docker cache: cleaning up volume [{volume_id}]")
+    Shell.check("sudo systemctl stop docker docker.socket containerd", verbose=True)
+    Shell.check(f"sudo umount {_DOCKER_MOUNT}", verbose=True)
+
+    try:
+        ec2.detach_volume(VolumeId=volume_id)
+        _wait_for_volume_status(ec2, volume_id, "available", timeout=60)
+        ec2.delete_volume(VolumeId=volume_id)
+        print(f"EBS docker cache: volume [{volume_id}] deleted")
+    except Exception as e:
+        print(f"WARNING: EBS docker cache: cleanup failed for volume [{volume_id}]: {e}")
+
+
+def cleanup_old_snapshots(arch: str, region: str, keep: int) -> None:
+    """Delete old docker cache snapshots beyond the most recent `keep` per arch."""
+    ec2 = _ec2_client(region)
+    resp = ec2.describe_snapshots(
+        Filters=[
+            {"Name": f"tag:{TAG_NAME}", "Values": [TAG_NAME_VALUE]},
+            {"Name": f"tag:{TAG_ARCH}", "Values": [arch]},
+        ],
+        OwnerIds=["self"],
+    )
+    snapshots = resp.get("Snapshots", [])
+    if len(snapshots) <= keep:
+        return
+
+    # Sort newest first
+    snapshots.sort(key=lambda s: s.get("StartTime", ""), reverse=True)
+    to_delete = snapshots[keep:]
+    for snap in to_delete:
+        snap_id = snap["SnapshotId"]
+        try:
+            ec2.delete_snapshot(SnapshotId=snap_id)
+            print(f"EBS docker cache: deleted old snapshot [{snap_id}]")
+        except Exception as e:
+            print(f"WARNING: EBS docker cache: failed to delete snapshot [{snap_id}]: {e}")

--- a/ci/praktika/ebs_docker_cache.py
+++ b/ci/praktika/ebs_docker_cache.py
@@ -367,12 +367,12 @@ def mount_cache_volume(snapshot_id: str) -> Optional[str]:
     mounted = False
 
     try:
-        # Stop Docker
-        print("EBS docker cache: stopping Docker")
+        # 1. Stop Docker
+        print("EBS docker cache [mount]: stopping Docker")
         Shell.check("sudo systemctl stop docker docker.socket containerd", verbose=True)
 
-        # Create volume from snapshot
-        print(f"EBS docker cache: creating volume from snapshot [{snapshot_id}] in [{az}]")
+        # 2. Create volume from snapshot
+        print(f"EBS docker cache [mount]: creating volume from snapshot [{snapshot_id}] in [{az}]")
         resp = ec2.create_volume(
             SnapshotId=snapshot_id,
             AvailabilityZone=az,
@@ -388,12 +388,13 @@ def mount_cache_volume(snapshot_id: str) -> Optional[str]:
             ],
         )
         volume_id = resp["VolumeId"]
+        print(f"EBS docker cache [mount]: volume [{volume_id}] created, waiting for available...")
         _wait_for_volume_status(ec2, volume_id, "available")
 
-        # Attach
+        # 3. Attach
         devs_before = _get_block_devices()
         device = _find_free_device(instance_id, region)
-        print(f"EBS docker cache: attaching [{volume_id}] as [{device}]")
+        print(f"EBS docker cache [mount]: attaching [{volume_id}] as [{device}]")
         ec2.attach_volume(
             Device=device,
             InstanceId=instance_id,
@@ -401,8 +402,9 @@ def mount_cache_volume(snapshot_id: str) -> Optional[str]:
         )
         _wait_for_volume_status(ec2, volume_id, "in-use")
         actual_device = _wait_for_new_device(devs_before, volume_id)
+        print(f"EBS docker cache [mount]: attached as [{actual_device}]")
 
-        # Mount EBS and bind-mount docker + containerd subdirs
+        # 4. Mount EBS and bind-mount docker + containerd subdirs
         Shell.check(f"sudo mkdir -p {_CACHE_MOUNT}", verbose=True, strict=True)
         Shell.check(
             f"sudo mount -o noatime {actual_device} {_CACHE_MOUNT}",
@@ -413,10 +415,12 @@ def mount_cache_volume(snapshot_id: str) -> Optional[str]:
         Shell.check(f"sudo mount --bind {_CACHE_MOUNT}/docker {_DOCKER_MOUNT}", verbose=True, strict=True)
         Shell.check(f"sudo mount --bind {_CACHE_MOUNT}/containerd /var/lib/containerd", verbose=True, strict=True)
 
-        # Start Docker
-        print("EBS docker cache: starting Docker with cached images")
+        # 5. Start Docker and verify images
+        print("EBS docker cache [mount]: starting Docker with cached images")
         Shell.check("sudo systemctl start docker", verbose=True, strict=True)
         Shell.check("docker images", verbose=True)
+        image_count = Shell.get_output("docker images -q | wc -l") or "0"
+        print(f"EBS docker cache [mount]: Docker ready, {image_count.strip()} images available")
 
         return volume_id
 

--- a/ci/praktika/ebs_docker_cache.py
+++ b/ci/praktika/ebs_docker_cache.py
@@ -12,7 +12,6 @@ EC2 describe-snapshots call.
 
 import hashlib
 import os
-import signal
 import time
 import traceback
 from typing import Dict, List, Optional, Tuple
@@ -29,8 +28,6 @@ TAG_ARCH = "arch"
 # Mount points and device helpers
 _CACHE_MOUNT = "/mnt/docker-cache"
 _DOCKER_MOUNT = "/var/lib/docker"
-_CACHE_DOCKERD_SOCK = "/var/run/docker-cache.sock"
-_CACHE_DOCKERD_PID = "/var/run/docker-cache.pid"
 
 
 # ---------------------------------------------------------------------------
@@ -72,37 +69,63 @@ def _ec2_client(region: str):
     return boto3.client("ec2", region_name=region)
 
 
-def _find_free_device() -> str:
-    """Return the first free /dev/xvd[f-z] device name."""
+def _get_block_devices() -> set:
+    """Return the set of current block device paths."""
+    out = Shell.get_output("lsblk -dpno NAME 2>/dev/null") or ""
+    return {line.strip() for line in out.splitlines() if line.strip()}
+
+
+def _find_free_device(instance_id: str, region: str) -> str:
+    """Return a device name not already attached to this instance.
+
+    On Nitro instances /dev/xvd* files do not exist on the filesystem even
+    when the attachment point is in use, so we query the EC2 API instead.
+    """
     import string
+
+    ec2 = _ec2_client(region)
+    resp = ec2.describe_instances(InstanceIds=[instance_id])
+    used = set()
+    for res in resp.get("Reservations", []):
+        for inst in res.get("Instances", []):
+            for bdm in inst.get("BlockDeviceMappings", []):
+                used.add(bdm.get("DeviceName", ""))
 
     for letter in string.ascii_lowercase[5:]:  # f..z
         dev = f"/dev/xvd{letter}"
-        if not os.path.exists(dev):
+        if dev not in used:
             return dev
     raise RuntimeError("No free /dev/xvd* device found")
 
 
-def _resolve_device(requested_device: str) -> str:
-    """After attaching an EBS volume as e.g. /dev/xvdf, the kernel may
-    expose it as /dev/nvme*n1. Wait up to 30 s and return the actual path."""
-    for _ in range(30):
-        if os.path.exists(requested_device):
-            return requested_device
-        # On Nitro instances the device appears as /dev/nvme*n1 but we can
-        # find it via lsblk or by scanning /dev/disk/by-id/.
-        # Simple approach: look for a new block device that appeared.
+def _wait_for_new_device(
+    before: set, volume_id: str, timeout: int = 60
+) -> str:
+    """Wait for a new block device to appear after an EBS attach.
+
+    On Nitro instances the requested /dev/xvd* name is ignored and the volume
+    shows up as /dev/nvme*n1.  We detect it by diffing lsblk output before
+    and after the attach.  As a fallback, we also check the NVMe serial which
+    contains the volume-id (without the dash).
+    """
+    vol_serial = volume_id.replace("-", "").replace("vol", "vol")
+    for _ in range(timeout):
+        after = _get_block_devices()
+        new_devs = after - before
+        if new_devs:
+            dev = sorted(new_devs)[0]
+            print(f"EBS docker cache: new device [{dev}] appeared")
+            return dev
+        # Also try matching by NVMe serial (works even if lsblk diff missed it)
+        out = Shell.get_output("lsblk -dpno NAME,SERIAL 2>/dev/null") or ""
+        for line in out.splitlines():
+            parts = line.split()
+            if len(parts) >= 2 and vol_serial in parts[1].replace("-", ""):
+                print(f"EBS docker cache: matched device [{parts[0]}] by serial")
+                return parts[0]
         time.sleep(1)
-    # Last resort: try lsblk
-    out = Shell.get_output("lsblk -dpno NAME,SERIAL 2>/dev/null") or ""
-    for line in out.strip().splitlines():
-        parts = line.split()
-        if len(parts) >= 2 and requested_device.replace("/dev/", "").replace(
-            "xvd", "vol"
-        ) in parts[1].replace("-", ""):
-            return parts[0]
     raise RuntimeError(
-        f"Device {requested_device} did not appear within 30 seconds"
+        f"No new block device appeared for volume {volume_id} within {timeout}s"
     )
 
 
@@ -183,7 +206,6 @@ def create_cache_snapshot(
     volume_id = None
     device = None
     mounted = False
-    dockerd_pid = None
 
     try:
         # 1. Create volume
@@ -206,7 +228,8 @@ def create_cache_snapshot(
         _wait_for_volume_status(ec2, volume_id, "available")
 
         # 2. Attach
-        device = _find_free_device()
+        devs_before = _get_block_devices()
+        device = _find_free_device(instance_id, region)
         print(f"EBS docker cache: attaching [{volume_id}] as [{device}]")
         ec2.attach_volume(
             Device=device,
@@ -214,7 +237,7 @@ def create_cache_snapshot(
             VolumeId=volume_id,
         )
         _wait_for_volume_status(ec2, volume_id, "in-use")
-        actual_device = _resolve_device(device)
+        actual_device = _wait_for_new_device(devs_before, volume_id)
 
         # 3. Format and mount
         Shell.check(f"sudo mkfs.ext4 -q {actual_device}", verbose=True, strict=True)
@@ -226,59 +249,51 @@ def create_cache_snapshot(
         )
         mounted = True
 
-        # 4. Start secondary dockerd
-        print("EBS docker cache: starting secondary dockerd")
-        Shell.check(
-            f"sudo dockerd"
-            f" --data-root {_CACHE_MOUNT}"
-            f" --host unix://{_CACHE_DOCKERD_SOCK}"
-            f" --pidfile {_CACHE_DOCKERD_PID}"
-            f" --exec-root /var/run/docker-cache"
-            f" >/dev/null 2>&1 &",
-            verbose=True,
-        )
-        # Wait for the socket to appear
-        for i in range(30):
-            if os.path.exists(_CACHE_DOCKERD_SOCK):
-                break
-            time.sleep(1)
-        else:
-            raise RuntimeError("Secondary dockerd did not start within 30s")
+        # 4. Stop primary Docker, remount EBS as /var/lib/docker, pull images
+        # This is simpler and more reliable than running a secondary dockerd.
+        # At this point all images are already built and pushed to the registry,
+        # so we no longer need the primary Docker.
+        print("EBS docker cache: stopping primary Docker")
+        Shell.check("sudo systemctl stop docker docker.socket containerd", verbose=True)
 
-        # Read the PID for cleanup
-        if os.path.exists(_CACHE_DOCKERD_PID):
-            with open(_CACHE_DOCKERD_PID, "r") as f:
-                dockerd_pid = int(f.read().strip())
+        # Move current docker+containerd data aside
+        # EBS is already mounted at _CACHE_MOUNT from step 3
+        Shell.check("sudo mv /var/lib/docker /var/lib/docker.bak", verbose=True)
+        Shell.check("sudo mv /var/lib/containerd /var/lib/containerd.bak", verbose=True)
+        Shell.check(f"sudo mkdir -p {_DOCKER_MOUNT}", verbose=True, strict=True)
+        Shell.check("sudo mkdir -p /var/lib/containerd", verbose=True, strict=True)
+        # Create subdirs on the EBS for docker and containerd
+        Shell.check(f"sudo mkdir -p {_CACHE_MOUNT}/docker {_CACHE_MOUNT}/containerd", verbose=True, strict=True)
+        Shell.check(f"sudo mount --bind {_CACHE_MOUNT}/docker /var/lib/docker", verbose=True, strict=True)
+        Shell.check(f"sudo mount --bind {_CACHE_MOUNT}/containerd /var/lib/containerd", verbose=True, strict=True)
+
+        print("EBS docker cache: starting Docker with EBS data-root")
+        Shell.check("sudo systemctl start docker", verbose=True, strict=True)
 
         # 5. Pull all images
-        docker_cmd = f"sudo docker -H unix://{_CACHE_DOCKERD_SOCK}"
+        Shell.check("df -h", verbose=True)
         for config in docker_configs:
             tag = f"{digests[config.name]}_{arch}"
             image_ref = f"{config.name}:{tag}"
             print(f"EBS docker cache: pulling [{image_ref}]")
-            if not Shell.check(f"{docker_cmd} pull {image_ref}", verbose=True):
+            if not Shell.check(f"docker pull {image_ref}", verbose=True):
                 print(f"WARNING: EBS docker cache: failed to pull [{image_ref}], skipping")
 
         # Show what we have
-        Shell.check(f"{docker_cmd} images", verbose=True)
+        Shell.check("docker images", verbose=True)
+        Shell.check("df -h", verbose=True)
 
-        # 6. Stop dockerd
-        if dockerd_pid:
-            print(f"EBS docker cache: stopping secondary dockerd (pid={dockerd_pid})")
-            try:
-                os.kill(dockerd_pid, signal.SIGTERM)
-                for _ in range(30):
-                    try:
-                        os.kill(dockerd_pid, 0)
-                        time.sleep(1)
-                    except OSError:
-                        break
-            except OSError:
-                pass
-            dockerd_pid = None
-
-        # 7. Unmount
+        # 6. Stop Docker, unmount EBS, restore original docker/containerd data
+        print("EBS docker cache: stopping Docker, restoring original state")
+        Shell.check("sudo systemctl stop docker docker.socket containerd", verbose=True)
+        Shell.check(f"sudo umount /var/lib/docker", verbose=True, strict=True)
+        Shell.check(f"sudo umount /var/lib/containerd", verbose=True, strict=True)
         Shell.check(f"sudo umount {_CACHE_MOUNT}", verbose=True, strict=True)
+        Shell.check("sudo rm -rf /var/lib/docker /var/lib/containerd", verbose=True)
+        Shell.check("sudo mv /var/lib/docker.bak /var/lib/docker", verbose=True)
+        Shell.check("sudo mv /var/lib/containerd.bak /var/lib/containerd", verbose=True)
+        Shell.check("sudo systemctl start docker", verbose=True)
+
         mounted = False
 
         # 8. Detach volume
@@ -316,14 +331,19 @@ def create_cache_snapshot(
         return None
 
     finally:
-        # Cleanup on failure
-        if dockerd_pid:
-            try:
-                os.kill(dockerd_pid, signal.SIGKILL)
-            except OSError:
-                pass
+        # Cleanup on failure: restore original Docker/containerd state
         if mounted:
-            Shell.check(f"sudo umount {_CACHE_MOUNT}", verbose=True)
+            Shell.check("sudo systemctl stop docker docker.socket containerd 2>/dev/null", verbose=True)
+            Shell.check("sudo umount /var/lib/docker 2>/dev/null", verbose=True)
+            Shell.check("sudo umount /var/lib/containerd 2>/dev/null", verbose=True)
+            Shell.check(f"sudo umount {_CACHE_MOUNT} 2>/dev/null", verbose=True)
+            if os.path.exists("/var/lib/docker.bak"):
+                Shell.check("sudo rm -rf /var/lib/docker", verbose=True)
+                Shell.check("sudo mv /var/lib/docker.bak /var/lib/docker", verbose=True)
+            if os.path.exists("/var/lib/containerd.bak"):
+                Shell.check("sudo rm -rf /var/lib/containerd", verbose=True)
+                Shell.check("sudo mv /var/lib/containerd.bak /var/lib/containerd", verbose=True)
+            Shell.check("sudo systemctl start docker", verbose=True)
         if volume_id:
             try:
                 ec2.detach_volume(VolumeId=volume_id)
@@ -371,7 +391,8 @@ def mount_cache_volume(snapshot_id: str) -> Optional[str]:
         _wait_for_volume_status(ec2, volume_id, "available")
 
         # Attach
-        device = _find_free_device()
+        devs_before = _get_block_devices()
+        device = _find_free_device(instance_id, region)
         print(f"EBS docker cache: attaching [{volume_id}] as [{device}]")
         ec2.attach_volume(
             Device=device,
@@ -379,16 +400,18 @@ def mount_cache_volume(snapshot_id: str) -> Optional[str]:
             VolumeId=volume_id,
         )
         _wait_for_volume_status(ec2, volume_id, "in-use")
-        actual_device = _resolve_device(device)
+        actual_device = _wait_for_new_device(devs_before, volume_id)
 
-        # Mount at /var/lib/docker
-        Shell.check(f"sudo mkdir -p {_DOCKER_MOUNT}", verbose=True, strict=True)
+        # Mount EBS and bind-mount docker + containerd subdirs
+        Shell.check(f"sudo mkdir -p {_CACHE_MOUNT}", verbose=True, strict=True)
         Shell.check(
-            f"sudo mount -o noatime {actual_device} {_DOCKER_MOUNT}",
+            f"sudo mount -o noatime {actual_device} {_CACHE_MOUNT}",
             verbose=True,
             strict=True,
         )
         mounted = True
+        Shell.check(f"sudo mount --bind {_CACHE_MOUNT}/docker {_DOCKER_MOUNT}", verbose=True, strict=True)
+        Shell.check(f"sudo mount --bind {_CACHE_MOUNT}/containerd /var/lib/containerd", verbose=True, strict=True)
 
         # Start Docker
         print("EBS docker cache: starting Docker with cached images")
@@ -402,7 +425,9 @@ def mount_cache_volume(snapshot_id: str) -> Optional[str]:
         traceback.print_exc()
         # Attempt recovery: unmount, restart Docker normally
         if mounted:
-            Shell.check(f"sudo umount {_DOCKER_MOUNT}", verbose=True)
+            Shell.check("sudo umount /var/lib/docker 2>/dev/null", verbose=True)
+            Shell.check("sudo umount /var/lib/containerd 2>/dev/null", verbose=True)
+            Shell.check(f"sudo umount {_CACHE_MOUNT} 2>/dev/null", verbose=True)
         Shell.check("sudo systemctl start docker", verbose=True)
         if volume_id:
             try:
@@ -424,7 +449,9 @@ def cleanup_cache_volume(volume_id: str) -> None:
 
     print(f"EBS docker cache: cleaning up volume [{volume_id}]")
     Shell.check("sudo systemctl stop docker docker.socket containerd", verbose=True)
-    Shell.check(f"sudo umount {_DOCKER_MOUNT}", verbose=True)
+    Shell.check("sudo umount /var/lib/docker 2>/dev/null", verbose=True)
+    Shell.check("sudo umount /var/lib/containerd 2>/dev/null", verbose=True)
+    Shell.check(f"sudo umount {_CACHE_MOUNT}", verbose=True)
 
     try:
         ec2.detach_volume(VolumeId=volume_id)

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -206,6 +206,76 @@ def _build_dockers(workflow, job_name):
                 )
             )
 
+    # --- EBS Docker Cache: create snapshot if enabled ---
+    if (
+        Settings.ENABLE_EBS_DOCKER_CACHE
+        and job_status == Result.Status.SUCCESS
+        and job_name != Settings.DOCKER_BUILD_MANIFEST_JOB_NAME
+        and not Info().is_local_run
+    ):
+        from .ebs_docker_cache import (
+            _get_arch,
+            calc_combined_digest,
+            cleanup_old_snapshots,
+            create_cache_snapshot,
+            find_snapshot,
+        )
+
+        try:
+            combined = calc_combined_digest(docker_digests)
+            arch = _get_arch()
+            region = Settings.AWS_REGION
+            existing = find_snapshot(combined, arch, region)
+            if existing:
+                print(
+                    f"EBS docker cache: snapshot already exists [{existing}]"
+                    f" for digest=[{combined}], arch=[{arch}]"
+                )
+                results.append(
+                    Result.create_from(
+                        name="EBS Docker Cache",
+                        status=Result.Status.SKIPPED,
+                        info=f"snapshot exists: {existing}",
+                    )
+                )
+            else:
+                print(
+                    f"EBS docker cache: creating snapshot"
+                    f" for digest=[{combined}], arch=[{arch}]"
+                )
+                snap_id = create_cache_snapshot(
+                    docker_configs=dockers,
+                    digests=docker_digests,
+                    combined_digest=combined,
+                    arch=arch,
+                )
+                if snap_id:
+                    print(f"EBS docker cache: snapshot created [{snap_id}]")
+                    results.append(
+                        Result.create_from(
+                            name="EBS Docker Cache",
+                            status=Result.Status.SUCCESS,
+                            info=f"snapshot_id={snap_id}",
+                        )
+                    )
+                else:
+                    print("WARNING: EBS docker cache: snapshot creation failed")
+                    results.append(
+                        Result.create_from(
+                            name="EBS Docker Cache",
+                            status=Result.Status.SUCCESS,
+                            info="snapshot creation failed (non-fatal)",
+                        )
+                    )
+                cleanup_old_snapshots(
+                    arch=arch,
+                    region=region,
+                    keep=Settings.EBS_DOCKER_CACHE_MAX_SNAPSHOTS_PER_ARCH,
+                )
+        except Exception as e:
+            print(f"WARNING: EBS docker cache failed: {e}")
+            traceback.print_exc()
+
     return Result.create_from(results=results, info=job_info)
 
 
@@ -412,6 +482,15 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
         for docker in dockers:
             workflow_config.digest_dockers[docker.name] = Digest().calc_docker_digest(
                 docker, dockers
+            )
+        if Settings.ENABLE_EBS_DOCKER_CACHE and workflow_config.digest_dockers:
+            from .ebs_docker_cache import calc_combined_digest
+
+            workflow_config.docker_cache_digest = calc_combined_digest(
+                workflow_config.digest_dockers
+            )
+            print(
+                f"EBS docker cache: combined digest [{workflow_config.docker_cache_digest}]"
             )
         workflow_config.dump()
         results.append(

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -213,6 +213,10 @@ def _build_dockers(workflow, job_name):
         and job_name != Settings.DOCKER_BUILD_MANIFEST_JOB_NAME
         and not Info().is_local_run
     ):
+        # Free disk space from buildx before pulling images for the snapshot
+        _clean_buildx_volumes()
+        Shell.check("docker system prune -f", verbose=True)
+
         from .ebs_docker_cache import (
             _get_arch,
             calc_combined_digest,
@@ -263,8 +267,8 @@ def _build_dockers(workflow, job_name):
                     results.append(
                         Result.create_from(
                             name="EBS Docker Cache",
-                            status=Result.Status.SUCCESS,
-                            info="snapshot creation failed (non-fatal)",
+                            status=Result.Status.FAILED,
+                            info="snapshot creation failed",
                         )
                     )
                 cleanup_old_snapshots(

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -957,6 +957,50 @@ class Runner:
                 results_.append(Result.from_commands_run(name=name, command=check))
             prehook_result = Result.create_from(name="Pre Hooks", results=results_, stopwatch=sw_)
 
+        # --- EBS Docker Cache: mount before run ---
+        ebs_cache_volume_id = None
+        if (
+            res
+            and Settings.ENABLE_EBS_DOCKER_CACHE
+            and job.run_in_docker
+            and not no_docker
+            and not local_run
+        ):
+            try:
+                from .ebs_docker_cache import (
+                    calc_combined_digest,
+                    find_snapshot,
+                    mount_cache_volume,
+                )
+
+                run_config = RunConfig.from_workflow_data()
+                if run_config.digest_dockers:
+                    combined = (
+                        run_config.docker_cache_digest
+                        or calc_combined_digest(run_config.digest_dockers)
+                    )
+                    arch = "arm" if Utils.is_arm() else "amd"
+                    snapshot_id = find_snapshot(
+                        combined, arch, Settings.AWS_REGION
+                    )
+                    if snapshot_id:
+                        ebs_cache_volume_id = mount_cache_volume(snapshot_id)
+                        if ebs_cache_volume_id:
+                            print(
+                                f"EBS docker cache: volume [{ebs_cache_volume_id}] mounted"
+                            )
+                        else:
+                            print(
+                                "WARNING: EBS docker cache mount failed, falling back to pull"
+                            )
+                    else:
+                        print(
+                            f"EBS docker cache: no snapshot for digest=[{combined}] arch=[{arch}]"
+                        )
+            except Exception as e:
+                print(f"WARNING: EBS docker cache: {e}")
+                traceback.print_exc()
+
         if res:
             print(f"=== Run script [{job.name}], workflow [{workflow.name}] ===")
             run_code = None
@@ -991,6 +1035,15 @@ class Runner:
                 ).dump()
 
             print(f"=== Run script finished ===\n\n")
+
+        # --- EBS Docker Cache: cleanup after run ---
+        if ebs_cache_volume_id:
+            try:
+                from .ebs_docker_cache import cleanup_cache_volume
+
+                cleanup_cache_volume(ebs_cache_volume_id)
+            except Exception as e:
+                print(f"WARNING: EBS docker cache cleanup: {e}")
 
         if run_hooks:
             result = self._get_result_object(

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -966,6 +966,7 @@ class Runner:
             and not no_docker
             and not local_run
         ):
+            print("=== EBS Docker Cache: looking up snapshot ===")
             try:
                 from .ebs_docker_cache import (
                     calc_combined_digest,
@@ -980,26 +981,37 @@ class Runner:
                         or calc_combined_digest(run_config.digest_dockers)
                     )
                     arch = "arm" if Utils.is_arm() else "amd"
+                    print(
+                        f"EBS docker cache: digest=[{combined}] arch=[{arch}] region=[{Settings.AWS_REGION}]"
+                    )
                     snapshot_id = find_snapshot(
                         combined, arch, Settings.AWS_REGION
                     )
                     if snapshot_id:
+                        print(
+                            f"EBS docker cache: found snapshot [{snapshot_id}], mounting..."
+                        )
                         ebs_cache_volume_id = mount_cache_volume(snapshot_id)
                         if ebs_cache_volume_id:
                             print(
-                                f"EBS docker cache: volume [{ebs_cache_volume_id}] mounted"
+                                f"EBS docker cache: SUCCESS — volume [{ebs_cache_volume_id}] mounted, images ready"
                             )
                         else:
                             print(
-                                "WARNING: EBS docker cache mount failed, falling back to pull"
+                                "EBS docker cache: FAILED — mount returned None, falling back to docker pull"
                             )
                     else:
                         print(
-                            f"EBS docker cache: no snapshot for digest=[{combined}] arch=[{arch}]"
+                            f"EBS docker cache: NOT FOUND — no completed snapshot for digest=[{combined}] arch=[{arch}], falling back to docker pull"
                         )
+                else:
+                    print(
+                        "EBS docker cache: SKIPPED — no digest_dockers in RunConfig"
+                    )
             except Exception as e:
-                print(f"WARNING: EBS docker cache: {e}")
+                print(f"EBS docker cache: ERROR — {e}, falling back to docker pull")
                 traceback.print_exc()
+            print("=== EBS Docker Cache: done ===")
 
         if res:
             print(f"=== Run script [{job.name}], workflow [{workflow.name}] ===")

--- a/ci/praktika/runtime.py
+++ b/ci/praktika/runtime.py
@@ -21,6 +21,8 @@ class RunConfig(MetaClasses.Serializable):
     filtered_jobs: Dict[str, str]
     sha: str
     custom_data: Dict[str, Any]
+    # Combined digest of all Docker images, used as EBS snapshot cache key
+    docker_cache_digest: str = ""
 
     @classmethod
     def from_dict(cls, obj):
@@ -36,6 +38,7 @@ class RunConfig(MetaClasses.Serializable):
         for job_name, cache_jobs in cache_jobs.items():
             cache_jobs_deserialized[job_name] = Cache.CacheRecord.from_dict(cache_jobs)
         obj["cache_jobs"] = cache_artifacts_deserialized
+        obj.setdefault("docker_cache_digest", "")
         return RunConfig(**obj)
 
     @classmethod

--- a/ci/praktika/settings.py
+++ b/ci/praktika/settings.py
@@ -127,6 +127,13 @@ class _Settings:
     # Used by EventFeed and FeedSubscription for PR notification subscriptions
     EVENT_FEED_S3_PATH: str = ""
 
+    # EBS Docker Cache: pre-populate Docker's image store from EBS snapshots
+    # to eliminate image pull latency on CI runners
+    ENABLE_EBS_DOCKER_CACHE: bool = False
+    EBS_DOCKER_CACHE_VOLUME_SIZE_GB: int = 50
+    EBS_DOCKER_CACHE_VOLUME_TYPE: str = "gp3"
+    EBS_DOCKER_CACHE_MAX_SNAPSHOTS_PER_ARCH: int = 3
+
 
 _USER_DEFINED_SETTINGS = [
     "S3_ARTIFACT_PATH",
@@ -180,6 +187,10 @@ _USER_DEFINED_SETTINGS = [
     "CI_DB_READ_USER",
     "CI_DB_READ_URL",
     "TEST_FAILURE_PATTERNS",
+    "ENABLE_EBS_DOCKER_CACHE",
+    "EBS_DOCKER_CACHE_VOLUME_SIZE_GB",
+    "EBS_DOCKER_CACHE_VOLUME_TYPE",
+    "EBS_DOCKER_CACHE_MAX_SNAPSHOTS_PER_ARCH",
 ]
 
 

--- a/ci/praktika/settings.py
+++ b/ci/praktika/settings.py
@@ -130,7 +130,7 @@ class _Settings:
     # EBS Docker Cache: pre-populate Docker's image store from EBS snapshots
     # to eliminate image pull latency on CI runners
     ENABLE_EBS_DOCKER_CACHE: bool = False
-    EBS_DOCKER_CACHE_VOLUME_SIZE_GB: int = 50
+    EBS_DOCKER_CACHE_VOLUME_SIZE_GB: int = 100
     EBS_DOCKER_CACHE_VOLUME_TYPE: str = "gp3"
     EBS_DOCKER_CACHE_MAX_SNAPSHOTS_PER_ARCH: int = 3
 

--- a/ci/settings/settings.py
+++ b/ci/settings/settings.py
@@ -68,7 +68,7 @@ EVENT_FEED_S3_PATH = "clickhouse-test-reports-private/slack_feed"
 CLOUD_INFRASTRUCTURE_CONFIG_PATH = "./ci/infra/cloud.py"
 AWS_REGION = "us-east-1"
 
-ENABLE_EBS_DOCKER_CACHE = False
+ENABLE_EBS_DOCKER_CACHE = True
 
 # Substrings used to classify and categorize test failures based on error output.
 # Use the following query to find test failures NOT covered by current patterns:

--- a/ci/settings/settings.py
+++ b/ci/settings/settings.py
@@ -68,6 +68,8 @@ EVENT_FEED_S3_PATH = "clickhouse-test-reports-private/slack_feed"
 CLOUD_INFRASTRUCTURE_CONFIG_PATH = "./ci/infra/cloud.py"
 AWS_REGION = "us-east-1"
 
+ENABLE_EBS_DOCKER_CACHE = False
+
 # Substrings used to classify and categorize test failures based on error output.
 # Use the following query to find test failures NOT covered by current patterns:
 # WITH ['Timeout', 'AssertionError', 'E   assert', 'E   Exception', 'E   NameError', 'Connection refused', 'UnboundLocalError', 'AttributeError', 'Too many retry attempts', 'E   FileNotFoundError', 'E   RuntimeError', 'Connection has been closed', 'E   Failed', 'E   ValueError', 'E   KeyError', 'InternalError', 'syntax error', 'E   TypeError', 'E   OSError', 'Code:', 'ClientError', 'QueryRuntimeException', 'Max retries exceeded with url', 'UnicodeDecodeError', 'Py4JError', 'ConnectionLoss', 'Connection reset by peer', 'Exception:', 'Failure:', 'ExistsError', 'ConnectionError', 'Client Error', 'Errno']

--- a/rfc-ebs-docker-cache.md
+++ b/rfc-ebs-docker-cache.md
@@ -1,0 +1,131 @@
+# EBS Snapshot Docker Cache for CI Runners
+
+## How It Works
+
+### Snapshot Creation (in Docker build jobs)
+
+1. CI config job computes a combined SHA256 digest from all per-image digests → stored in `RunConfig.docker_cache_digest`
+2. ARM and AMD docker build jobs each build and push images to DockerHub as usual
+3. After building, if `ENABLE_EBS_DOCKER_CACHE` is set:
+   - Check if a snapshot with matching `docker-cache-digest` + `arch` tag already exists → skip if yes
+   - Clean up buildx cache to free disk space
+   - Create a 100 GB gp3 EBS volume, attach, format ext4
+   - Stop Docker, bind-mount EBS subdirs to `/var/lib/docker` and `/var/lib/containerd`
+   - Pull all just-built images from DockerHub into the EBS-backed Docker
+   - Stop Docker, unmount, detach, create EBS snapshot (async), delete volume
+4. Snapshot is tagged with `docker-cache-digest=<combined_digest>`, `arch=<amd|arm>`
+
+### Snapshot Consumption (on runners)
+
+1. Before running a Docker job, runner computes combined digest from `RunConfig`
+2. Calls `ec2:DescribeSnapshots` filtered by digest + arch + `status=completed`
+3. If found: creates volume from snapshot, attaches, bind-mounts `/var/lib/docker` and `/var/lib/containerd`, starts Docker → all images are present, zero pull
+4. If not found: falls back to normal Docker pull (transparent, non-fatal)
+5. After job: stops Docker, unmounts, detaches, deletes volume
+
+### First Run After Image Change
+
+The snapshot is created asynchronously (takes ~10-15 min). Jobs in the same CI run will still pull from DockerHub. The **next** CI run with the same images will find the completed snapshot and skip pulling.
+
+## Docker Images
+
+### CI-built images (in EBS snapshot, 34 images)
+
+```
+clickhouse/arrowflight-server-test   clickhouse/mysql-golang-client
+clickhouse/binary-builder            clickhouse/mysql-java-client
+clickhouse/cctools                   clickhouse/mysql-js-client
+clickhouse/docs-builder              clickhouse/mysql-php-client
+clickhouse/dotnet-client             clickhouse/mysql_dotnet_client
+clickhouse/fasttest                  clickhouse/nginx-dav
+clickhouse/fuzzer                    clickhouse/performance-comparison
+clickhouse/install-deb-test          clickhouse/postgresql-java-client
+clickhouse/install-rpm-test          clickhouse/python-bottle
+clickhouse/integration-helper        clickhouse/s3-proxy
+clickhouse/integration-test          clickhouse/server-jepsen-test
+clickhouse/integration-test-with-hms clickhouse/sqlancer-test
+clickhouse/integration-test-with-unity-catalog
+clickhouse/integration-tests-runner  clickhouse/stateless-test
+clickhouse/keeper-jepsen-test        clickhouse/stress-test
+clickhouse/kerberos-kdc              clickhouse/style-test
+clickhouse/test-base                 clickhouse/test-mysql57
+clickhouse/test-mysql80
+```
+
+### External images (NOT in EBS snapshot yet — TODO)
+
+These are pulled by integration tests at runtime. Adding them to the snapshot would eliminate all Docker pulls.
+
+```
+bitnamilegacy/openldap:2.6.8        mcr.microsoft.com/azure-storage/azurite:3.35.0
+cassandra:4.0                        minio/mc:RELEASE.2025-04-16T18-13-26Z
+confluentinc/cp-kafka:5.2.0         minio/minio:RELEASE.2024-07-31T05-46-26Z
+confluentinc/cp-kafka:7.9.0         minio/minio:RELEASE.2024-09-13T20-26-02Z
+confluentinc/cp-schema-registry:5.2.0  mongo:6.0
+confluentinc/cp-zookeeper:5.2.0     motoserver/moto:5.1.5
+coredns/coredns:1.9.3               mysql:8.0
+curlimages/curl                      nats
+dremio/dremio-oss:26.0              postgres:12.2-alpine
+ghcr.io/letsencrypt/pebble:2.9.0   postgres:16
+ghcr.io/letsencrypt/pebble-challtestsrv:2.9.0  prom/prometheus:v3.5.0
+ghcr.io/projectnessie/nessie:0.107.2  rabbitmq:4.2.1-management-alpine
+ghcr.io/ytsaurus/local:stable-24.2  redis
+lgboustc/hive_test:v2.0             tabulario/iceberg-rest:1.6.0
+tabulario/spark-iceberg:3.5.5_1.8.1 vakamo/lakekeeper:v0.9.4
+willfarrell/autoheal:1.2.0          zookeeper:3.4.9
+zookeeper:3.6.2
+```
+
+Note: `clickhouse/jdbc-bridge:2.1.0-dirty` is in compose files but not in `defs.py` (likely deprecated).
+
+## EBS Volume Size
+
+Current default: **100 GB gp3** per snapshot. 34 CI images compressed in overlay2 format. To be increased if external images are added (~30 more images). Volume size is the primary cost driver — reducing it to actual image footprint is the main optimization lever.
+
+## Snapshot Cleanup
+
+### Current implementation
+
+After creating a new snapshot, delete old ones beyond `EBS_DOCKER_CACHE_MAX_SNAPSHOTS_PER_ARCH` (default: 3) per architecture. This keeps the most recent 3 snapshots per arch.
+
+### TODO: time-based retention
+
+Ideal policy: delete snapshots not used for 1 month. AWS provides `DescribeSnapshotAttribute` and EBS Snapshots Archive tracks last access metadata (`LastAccessed` via CloudWatch `VolumeReadOps` on volumes created from a snapshot, or via `DescribeSnapshots` `StorageTier` / access tracking). Implementation:
+1. Enable EBS snapshot access tracking (if available in the region) or query CloudWatch for `CreateVolume` events referencing each snapshot
+2. Periodic cleanup (Lambda or cron): delete snapshots not accessed for 30 days
+3. Old release branch snapshots expire naturally without manual intervention
+
+## Configuration
+
+```python
+# ci/settings/settings.py
+ENABLE_EBS_DOCKER_CACHE = True
+```
+
+```python
+# ci/praktika/settings.py (defaults)
+EBS_DOCKER_CACHE_VOLUME_SIZE_GB = 100
+EBS_DOCKER_CACHE_VOLUME_TYPE = "gp3"
+EBS_DOCKER_CACHE_MAX_SNAPSHOTS_PER_ARCH = 3
+```
+
+### IAM permissions required
+
+`ec2:AttachVolume`, `ec2:CreateSnapshot`, `ec2:CreateVolume`, `ec2:DeleteSnapshot`, `ec2:DeleteVolume`, `ec2:DetachVolume`, `ec2:CreateTags`.
+
+## Files
+
+- `ci/praktika/ebs_docker_cache.py` — EBS snapshot operations (create, find, mount, cleanup)
+- `ci/praktika/settings.py` — settings
+- `ci/praktika/runtime.py` — `docker_cache_digest` field in `RunConfig`
+- `ci/praktika/native_jobs.py` — snapshot creation in docker build jobs
+- `ci/praktika/runner.py` — snapshot mount/cleanup on runners
+
+## TODO
+
+- **Per-image or per-group snapshots**: Instead of one large snapshot with all 34 images, create smaller snapshots per image or per job group (e.g., one for integration test images, one for build images). This reduces EBS volume size per runner and lowers cost significantly.
+- **Docker-in-Docker**: Integration tests run Docker inside Docker with a separate named volume (`clickhouse_integration_tests_volume:/var/lib/docker`). The inner Docker daemon does not see the host EBS cache, so all images are still pulled inside the container. Solving this requires either sharing the host Docker socket, using overlayfs layers, or pre-loading images into the inner daemon.
+- Add external Docker images to the snapshot (eliminates all pulls for integration tests)
+- Time-based snapshot retention (1 month TTL)
+- Monitor snapshot sizes and adjust volume size
+- Consider Fast Snapshot Restore (FSR) if lazy-load latency is a problem

--- a/tests/integration/test_logs_level/test.py
+++ b/tests/integration/test_logs_level/test.py
@@ -1,3 +1,4 @@
+# EBS docker cache test
 import pytest
 
 from helpers.cluster import ClickHouseCluster


### PR DESCRIPTION
Add EBS snapshot-based Docker image cache to eliminate Docker pull latency on CI runners.

When `ENABLE_EBS_DOCKER_CACHE` is enabled, Docker build jobs create EBS snapshots of Docker data-root after building images. Runners mount these snapshots as volumes instead of pulling from the registry - all images are available instantly. Transparent fallback to normal docker pull if no snapshot exists.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

