### PR TITLE
Storage `merge` always proxy virtuals to underlying storages

### DIFF
--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -111,22 +111,6 @@ bool columnDefaultKindHasSameType(ColumnDefaultKind lhs, ColumnDefaultKind rhs)
     return false;
 }
 
-/// Adds to the select query section `WITH value AS column_name`
-///
-/// For example:
-/// - `WITH 9000 as _port`.
-void rewriteEntityInAst(ASTPtr ast, const String & column_name, const Field & value)
-{
-    auto & select = ast->as<ASTSelectQuery &>();
-    if (!select.with())
-        select.setExpression(ASTSelectQuery::Expression::WITH, make_intrusive<ASTExpressionList>());
-
-    auto literal = make_intrusive<ASTLiteral>(value);
-    literal->alias = column_name;
-    literal->setPreferAliasToColumnName(true);
-    select.with()->children.push_back(literal);
-}
-
 }
 
 StorageMerge::DatabaseNameOrRegexp::DatabaseNameOrRegexp(
@@ -615,22 +599,7 @@ void ReadFromMerge::filterTablesAndCreateChildrenPlans()
     if (child_plans)
         return;
 
-    has_database_virtual_column = false;
-    has_table_virtual_column = false;
-    column_names.clear();
-    column_names.reserve(all_column_names.size());
-
-    for (const auto & column_name : all_column_names)
-    {
-        if (column_name == "_database" && storage_merge->isVirtualColumn(column_name, merge_storage_snapshot->metadata))
-            has_database_virtual_column = true;
-        else if (column_name == "_table" && storage_merge->isVirtualColumn(column_name, merge_storage_snapshot->metadata))
-            has_table_virtual_column = true;
-        else
-            column_names.push_back(column_name);
-    }
-
-    selected_tables = getSelectedTables(context, has_database_virtual_column, has_table_virtual_column);
+    selected_tables = getSelectedTables(context);
     child_plans = createChildrenPlans(query_info);
 }
 
@@ -714,14 +683,7 @@ std::vector<ReadFromMerge::ChildPlan> ReadFromMerge::createChildrenPlans(SelectQ
             auto nested_storage_snapshot = storage->getStorageSnapshot(storage_metadata_snapshot, modified_context);
 
             Names column_names_as_aliases;
-            Names real_column_names = column_names;
-            {
-                if (has_table_virtual_column && (nested_storage_snapshot->metadata->columns.hasColumnOrSubcolumn(GetColumnsOptions::All, "_table") || nested_storage_snapshot->virtual_columns->has("_table")))
-                    real_column_names.emplace_back("_table");
-
-                if (has_database_virtual_column && (nested_storage_snapshot->metadata->columns.hasColumnOrSubcolumn(GetColumnsOptions::All, "_database") || nested_storage_snapshot->virtual_columns->has("_database")))
-                    real_column_names.emplace_back("_database");
-            }
+            Names real_column_names = all_column_names;
 
             /// If there are no real columns requested from this table, we will read the smallest column.
             /// We should remember it to not include this column in the result.
@@ -818,8 +780,6 @@ std::vector<ReadFromMerge::ChildPlan> ReadFromMerge::createChildrenPlans(SelectQ
 
             if (child.plan.isInitialized())
             {
-                addVirtualColumns(child, modified_query_info, common_processed_stage, table);
-
                 /// Source tables could have different but convertible types, like numeric types of different width.
                 /// We must return streams with structure equals to structure of Merge table.
                 convertAndFilterSourceStream(*common_header, modified_query_info, nested_storage_snapshot, aliases, row_policy_data_opt, context, child, is_smallest_column_requested);
@@ -1000,46 +960,14 @@ SelectQueryInfo ReadFromMerge::getModifiedQueryInfo(const ContextMutablePtr & mo
 
         auto get_column_options = GetColumnsOptions(GetColumnsOptions::All).withSubcolumns(storage_snapshot_->storage.supportsSubcolumns()).withVirtuals(VirtualsKind::All, VirtualsMaterializationPlace::All);
 
-        std::unordered_map<std::string, QueryTreeNodePtr> column_name_to_node;
-        if (!storage_snapshot_->metadata->columns.hasColumnOrSubcolumn(GetColumnsOptions::All, "_table") && !storage_snapshot_->virtual_columns->has("_table"))
-        {
-            auto table_name_node = std::make_shared<ConstantNode>(current_storage_id.table_name);
-            auto table_name_alias = std::make_shared<ConstantNode>("__table1._table");
-
-            auto function_node = std::make_shared<FunctionNode>("__actionName");
-            function_node->getArguments().getNodes().push_back(std::move(table_name_node));
-            function_node->getArguments().getNodes().push_back(std::move(table_name_alias));
-            function_node->resolveAsFunction(FunctionFactory::instance().get("__actionName", context));
-
-            column_name_to_node.emplace("_table", function_node);
-        }
-
-        if (!storage_snapshot_->metadata->columns.hasColumnOrSubcolumn(GetColumnsOptions::All, "_database") && !storage_snapshot_->virtual_columns->has("_database"))
-        {
-            auto database_name_node = std::make_shared<ConstantNode>(current_storage_id.database_name);
-            auto database_name_alias = std::make_shared<ConstantNode>("__table1._database");
-
-            auto function_node = std::make_shared<FunctionNode>("__actionName");
-            function_node->getArguments().getNodes().push_back(std::move(database_name_node));
-            function_node->getArguments().getNodes().push_back(std::move(database_name_alias));
-            function_node->resolveAsFunction(FunctionFactory::instance().get("__actionName", context));
-
-            column_name_to_node.emplace("_database", function_node);
-        }
-
         /// Replace references to columns that don't exist in this child table with default values.
         /// This happens when merge() is used over tables with different schemas and the processing
         /// stage is above FetchColumns (e.g., for distributed/remote tables where the full query
         /// is sent to the child for processing).
+        std::unordered_map<std::string, QueryTreeNodePtr> column_name_to_node;
         for (const auto & column_name : required_column_names)
         {
             if (column_name_to_node.contains(column_name))
-                continue;
-
-            /// Virtual columns like `_table` are handled separately by the Merge engine
-            /// (added as plan steps after the child query executes), so they should not be
-            /// replaced with default values here.
-            if (column_name == "_table" || column_name == "_database")
                 continue;
 
             if (storage_snapshot_->tryGetColumn(get_column_options, column_name))
@@ -1131,12 +1059,6 @@ SelectQueryInfo ReadFromMerge::getModifiedQueryInfo(const ContextMutablePtr & mo
         TreeRewriterResult new_analyzer_res = *modified_query_info.syntax_analyzer_result;
         removeJoin(modified_select, new_analyzer_res, modified_context);
         modified_query_info.syntax_analyzer_result = std::make_shared<TreeRewriterResult>(std::move(new_analyzer_res));
-
-        if (!storage_snapshot_->metadata->columns.hasColumnOrSubcolumn(GetColumnsOptions::All, "_table") && !storage_snapshot_->virtual_columns->has("_table"))
-            rewriteEntityInAst(modified_query_info.query, "_table", current_storage_id.table_name);
-
-        if (!storage_snapshot_->metadata->columns.hasColumnOrSubcolumn(GetColumnsOptions::All, "_database") && !storage_snapshot_->virtual_columns->has("_database"))
-            rewriteEntityInAst(modified_query_info.query, "_database", current_storage_id.database_name);
     }
 
     return modified_query_info;
@@ -1158,38 +1080,6 @@ bool recursivelyApplyToReadingSteps(QueryPlan::Node * node, const std::function<
         ok &= func(*read_from_merge_tree);
 
     return ok;
-}
-
-void ReadFromMerge::addVirtualColumns(
-    ChildPlan & child,
-    SelectQueryInfo & /* modified_query_info */,
-    QueryProcessingStage::Enum processed_stage,
-    const StorageWithLockAndName & storage_with_lock) const
-{
-    const auto & [database_name, storage, lock, table_name] = storage_with_lock;
-    const auto plan_header = child.plan.getCurrentHeader();
-
-    if (processed_stage > QueryProcessingStage::FetchColumns)
-        return;
-
-    if (std::dynamic_pointer_cast<StorageDistributed>(storage))
-        return;
-
-    if (has_database_virtual_column && !plan_header->has("_database"))
-    {
-        auto adding_column_dag = ActionsDAG::makeAddingConstantColumnActions("_database", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), database_name);
-        auto expression_step = std::make_unique<ExpressionStep>(child.plan.getCurrentHeader(), std::move(adding_column_dag));
-        expression_step->setStepDescription("Add virtual column _database for Merge");
-        child.plan.addStep(std::move(expression_step));
-    }
-
-    if (has_table_virtual_column && !plan_header->has("_table"))
-    {
-        auto adding_column_dag = ActionsDAG::makeAddingConstantColumnActions("_table", std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>()), table_name);
-        auto expression_step = std::make_unique<ExpressionStep>(child.plan.getCurrentHeader(), std::move(adding_column_dag));
-        expression_step->setStepDescription("Add virtual column _table for Merge");
-        child.plan.addStep(std::move(expression_step));
-    }
 }
 
 QueryPipelineBuilderPtr ReadFromMerge::buildPipeline(
@@ -1377,16 +1267,14 @@ void ReadFromMerge::RowPolicyData::addFilterTransform(QueryPlan & plan) const
 }
 
 StorageMerge::StorageListWithLocks ReadFromMerge::getSelectedTables(
-    ContextPtr query_context,
-    bool filter_by_database_virtual_column,
-    bool filter_by_table_virtual_column) const
+    ContextPtr query_context) const
 {
     const Settings & settings = query_context->getSettingsRef();
     StorageListWithLocks res;
     DatabaseTablesIterators database_table_iterators = assert_cast<StorageMerge &>(*storage_merge).getDatabaseIterators(query_context);
 
     std::function<bool(const String&,const String&)> table_filter;
-    if (filter_actions_dag && (filter_by_database_virtual_column || filter_by_table_virtual_column))
+    if (filter_actions_dag)
     {
         auto lc_string_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>());
         Block sample_block = {
@@ -1431,9 +1319,8 @@ StorageMerge::StorageListWithLocks ReadFromMerge::getSelectedTables(
                 if (!table_filter || table_filter(iterator->databaseName(), iterator->name()))
                     if (granted_show_on_all_tables || access->isGranted(AccessType::SHOW_TABLES, iterator->databaseName(), iterator->name()))
                     {
-
                         if  (!granted_select_on_all_tables)
-                            access->checkAccess(AccessType::SELECT, iterator->databaseName(), iterator->name(), column_names);
+                            access->checkAccess(AccessType::SELECT, iterator->databaseName(), iterator->name(), all_column_names);
 
                         auto table_lock = storage->lockForShare(query_context->getCurrentQueryId(), settings[Setting::lock_acquire_timeout]);
                         res.emplace_back(iterator->databaseName(), storage, std::move(table_lock), iterator->name());

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -1274,7 +1274,7 @@ StorageMerge::StorageListWithLocks ReadFromMerge::getSelectedTables(
     DatabaseTablesIterators database_table_iterators = assert_cast<StorageMerge &>(*storage_merge).getDatabaseIterators(query_context);
 
     std::function<bool(const String&,const String&)> table_filter;
-    if (filter_actions_dag)
+    if (filter_actions_dag && storage_merge->isVirtualColumn("_database", merge_storage_snapshot->metadata) && storage_merge->isVirtualColumn("_table", merge_storage_snapshot->metadata))
     {
         auto lc_string_type = std::make_shared<DataTypeLowCardinality>(std::make_shared<DataTypeString>());
         Block sample_block = {
@@ -1320,7 +1320,10 @@ StorageMerge::StorageListWithLocks ReadFromMerge::getSelectedTables(
                     if (granted_show_on_all_tables || access->isGranted(AccessType::SHOW_TABLES, iterator->databaseName(), iterator->name()))
                     {
                         if  (!granted_select_on_all_tables)
-                            access->checkAccess(AccessType::SELECT, iterator->databaseName(), iterator->name(), all_column_names);
+                        {
+                            const auto columns_to_check = VirtualColumnUtils::filterVirtualColumns(all_column_names, storage_snapshot->metadata, storage_snapshot->virtual_columns, VirtualsKind::All, VirtualsMaterializationPlace::All);
+                            access->checkAccess(AccessType::SELECT, iterator->databaseName(), iterator->name(), columns_to_check);
+                        }
 
                         auto table_lock = storage->lockForShare(query_context->getCurrentQueryId(), settings[Setting::lock_acquire_timeout]);
                         res.emplace_back(iterator->databaseName(), storage, std::move(table_lock), iterator->name());

--- a/src/Storages/StorageMerge.h
+++ b/src/Storages/StorageMerge.h
@@ -196,9 +196,6 @@ private:
 
     StorageListWithLocks selected_tables;
     Names all_column_names;
-    Names column_names;
-    bool has_database_virtual_column;
-    bool has_table_virtual_column;
     StoragePtr storage_merge;
     StorageSnapshotPtr merge_storage_snapshot;
 
@@ -284,12 +281,6 @@ private:
         ContextMutablePtr modified_context,
         size_t streams_num) const;
 
-    void addVirtualColumns(
-        ChildPlan & child,
-        SelectQueryInfo & modified_query_info,
-        QueryProcessingStage::Enum processed_stage,
-        const StorageWithLockAndName & storage_with_lock) const;
-
     QueryPipelineBuilderPtr buildPipeline(
         ChildPlan & child,
         QueryProcessingStage::Enum processed_stage) const;
@@ -305,9 +296,7 @@ private:
         bool is_smallest_column_requested);
 
     StorageMerge::StorageListWithLocks getSelectedTables(
-        ContextPtr query_context,
-        bool filter_by_database_virtual_column,
-        bool filter_by_table_virtual_column) const;
+        ContextPtr query_context) const;
 };
 
 }

--- a/src/Storages/StorageProxy.h
+++ b/src/Storages/StorageProxy.h
@@ -33,6 +33,11 @@ public:
 
     ColumnSizeByName getColumnSizes() const override { return getNested()->getColumnSizes(); }
 
+    StorageSnapshotPtr getStorageSnapshot(const StorageMetadataPtr & metadata_snapshot, ContextPtr /*query_context*/) const override
+    {
+        return std::make_shared<StorageSnapshot>(*this, metadata_snapshot, getNested()->getVirtualsPtr());
+    }
+
     QueryProcessingStage::Enum getQueryProcessingStage(
         ContextPtr context,
         QueryProcessingStage::Enum to_stage,


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

After https://github.com/ClickHouse/ClickHouse/pull/102304 was merged, the storage `merge` can omit handling of virtual columns. 
