### PR TITLE
Fix out of bounds read in printf with trailing '%'

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -124,7 +124,7 @@
 	url = https://github.com/ClickHouse/libuv
 [submodule "contrib/fmtlib"]
 	path = contrib/fmtlib
-	url = https://github.com/fmtlib/fmt
+	url = https://github.com/ClickHouse/fmt
 [submodule "contrib/krb5"]
 	path = contrib/krb5
 	url = https://github.com/ClickHouse/krb5

--- a/tests/queries/0_stateless/04094_printf_trailing_percent.reference
+++ b/tests/queries/0_stateless/04094_printf_trailing_percent.reference
@@ -1,0 +1,32 @@
+%
+%
+hello %
+hello %
+%val
+%val
+a%b%c
+a%b%c
+% 42
+% 42
+42 %
+42 %
+42 % hi
+42 % hi
+%%
+%%
+42
+42
+hello
+hello
+val=100 end
+val=100 end
+1 x 2
+1 x 2
+42
+   42
+2a
+52
+hello
+%
+abc%def
+%%

--- a/tests/queries/0_stateless/04094_printf_trailing_percent.sql
+++ b/tests/queries/0_stateless/04094_printf_trailing_percent.sql
@@ -1,0 +1,57 @@
+-- Test printf with trailing '%' and various %% escaping edge cases.
+-- Covers both constant and dynamic (materialized) format paths.
+-- Regression test for MSan read-past-end in fmt::sprintf with lone '%'.
+
+-- Constant format: lone '%' with argument (treated as literal)
+SELECT printf('%', 42); -- { serverError BAD_ARGUMENTS }
+SELECT printf('%', 'hello'); -- { serverError BAD_ARGUMENTS }
+
+-- Materialized format: lone '%' with argument
+SELECT printf(materialize('%'), 42); -- { serverError BAD_ARGUMENTS }
+SELECT printf(materialize('%'), 'hello'); -- { serverError BAD_ARGUMENTS }
+
+-- Constant format: lone '%' without argument (error)
+SELECT printf('%'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+
+-- Materialized format: lone '%' without argument (error)
+SELECT printf(materialize('%')); -- { serverError BAD_ARGUMENTS }
+
+-- Trailing '%' after literal text
+SELECT printf('abc%', 42); -- { serverError BAD_ARGUMENTS }
+SELECT printf(materialize('abc%'), 42); -- { serverError BAD_ARGUMENTS }
+
+-- Double percent escaping
+SELECT printf('%%');
+SELECT printf(materialize('%%'));
+SELECT printf('hello %%');
+SELECT printf(materialize('hello %%'));
+SELECT printf('%%val');
+SELECT printf(materialize('%%val'));
+SELECT printf('a%%b%%c');
+SELECT printf(materialize('a%%b%%c'));
+
+-- Double percent with arguments
+SELECT printf('%% %d', 42);
+SELECT printf(materialize('%% %d'), 42);
+SELECT printf('%d %%', 42);
+SELECT printf(materialize('%d %%'), 42);
+SELECT printf('%d %% %s', 42, 'hi');
+SELECT printf(materialize('%d %% %s'), 42, 'hi');
+
+-- Multiple trailing percents
+SELECT printf('%%%%');
+SELECT printf(materialize('%%%%'));
+
+-- Normal format specifiers (sanity check)
+SELECT printf('%d', 42);
+SELECT printf(materialize('%d'), 42);
+SELECT printf('%s', 'hello');
+SELECT printf(materialize('%s'), 'hello');
+SELECT printf('val=%d end', 100);
+SELECT printf(materialize('val=%d end'), 100);
+SELECT printf('%d %s %d', 1, 'x', 2);
+SELECT printf(materialize('%d %s %d'), 1, 'x', 2);
+
+-- Dynamic format from column
+SELECT printf(s, 42) FROM (SELECT arrayJoin(['%d', '%5d', '%x', '%o']) AS s);
+SELECT printf(s) FROM (SELECT arrayJoin(['hello', '%%', 'abc%%def', '%%%%']) AS s);


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix out of bounds read in prinft with trailing '%'

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
