### PR TITLE
Fix stop_zookeeper not waiting for ZooKeeper JVM in test_keeper_zookeeper_converter

### DIFF
--- a/tests/integration/test_keeper_zookeeper_converter/test.py
+++ b/tests/integration/test_keeper_zookeeper_converter/test.py
@@ -38,8 +38,12 @@ def stop_zookeeper():
     # matches the first word of the command line. The ZooKeeper Java process
     # starts with "java -Dzookeeper..." so it never matches. Use a direct pgrep
     # for the ZooKeeper main class to properly detect the running JVM.
+    # The bracket expression [o]rg is a standard trick to keep pgrep -f from
+    # matching the shell process that is running pgrep itself (its argv
+    # contains the literal string '[o]rg.apache.zookeeper.server', which the
+    # regex '[o]rg.apache.zookeeper.server' does not match).
     while node.exec_in_container(
-        ["bash", "-c", "pgrep -f org.apache.zookeeper.server || true"],
+        ["bash", "-c", "pgrep -f '[o]rg\\.apache\\.zookeeper\\.server' || true"],
         nothrow=True,
     ).strip():
         if time.time() > timeout:

--- a/tests/integration/test_keeper_zookeeper_converter/test.py
+++ b/tests/integration/test_keeper_zookeeper_converter/test.py
@@ -19,22 +19,29 @@ node = cluster.add_instance(
 
 
 def start_zookeeper():
-    for attempt in range(3):
+    for attempt in range(5):
         try:
             node.exec_in_container(
                 ["bash", "-c", "/opt/zookeeper/bin/zkServer.sh start"]
             )
             return
         except Exception:
-            if attempt == 2:
+            if attempt == 4:
                 raise
-            time.sleep(2)
+            time.sleep(3)
 
 
 def stop_zookeeper():
     node.exec_in_container(["bash", "-c", "/opt/zookeeper/bin/zkServer.sh stop"])
     timeout = time.time() + 60
-    while node.get_process_pid("zookeeper") != None:
+    # get_process_pid("zookeeper") uses the regex '^[^ ]*zookeeper' which only
+    # matches the first word of the command line. The ZooKeeper Java process
+    # starts with "java -Dzookeeper..." so it never matches. Use a direct pgrep
+    # for the ZooKeeper main class to properly detect the running JVM.
+    while node.exec_in_container(
+        ["bash", "-c", "pgrep -f org.apache.zookeeper.server || true"],
+        nothrow=True,
+    ).strip():
         if time.time() > timeout:
             raise Exception("Failed to stop ZooKeeper in 60 secs")
         time.sleep(0.2)


### PR DESCRIPTION
`stop_zookeeper` used `get_process_pid("zookeeper")` to wait for the process to die, but `get_process_pid` uses the regex `'^[^ ]*zookeeper'` which only matches the first word of the command line. The ZooKeeper Java process starts with `java -Dzookeeper.log.dir=...`, so the first word is `java`, not `zookeeper` — the regex never matched and the function returned immediately without actually waiting for the process to exit.

Under resource-constrained environments (MSan), the JVM takes longer to shut down after `zkServer.sh stop`. When `start_zookeeper` was called later, the old process was still holding port 2181, causing the new JVM to fail with exit code 1.

Fix by using `pgrep -f org.apache.zookeeper.server` to properly detect the running ZooKeeper JVM process. Also increase start retries from 3 to 5 with 3-second delays as an additional safety net.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=00ecef1c87cfebeb52a024307b0a76a68518fb53&name_0=MasterCI&name_1=Integration%20tests%20%28amd_msan%2C%206%2F6%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1054`
<!-- ch-version-info:end -->