### PR TITLE
Fix flaky test `03244_skip_index_in_final_query_with_pk_rescan_random`

### DIFF
--- a/tests/queries/0_stateless/03244_skip_index_in_final_query_with_pk_rescan_random.sh
+++ b/tests/queries/0_stateless/03244_skip_index_in_final_query_with_pk_rescan_random.sh
@@ -17,10 +17,10 @@ DROP TABLE IF EXISTS st;
 CREATE TABLE st (id Int32, v Int32, r Int32, INDEX bfv v TYPE bloom_filter) ENGINE=ReplacingMergeTree ORDER BY (id) SETTINGS index_granularity = 64;
 SYSTEM STOP MERGES st;
 
-INSERT INTO st SELECT id % 9999999, if(id % 729 = 0, 4, v), 1  FROM (SELECT * FROM generateRandom('id UInt32, v UInt32', $test_seed) limit 1000000) SETTINGS max_threads = 1;
-INSERT INTO st SELECT id % 9999999, if(id % 243 = 0, 3, v), 2  FROM (SELECT * FROM generateRandom('id UInt32, v UInt32', $test_seed + 1) limit 1000000) SETTINGS max_threads = 1;
-INSERT INTO st SELECT id % 9999999, if(id % 81 = 0, 2, v), 3  FROM (SELECT * FROM generateRandom('id UInt32, v UInt32', $test_seed + 2) limit 1000000) SETTINGS max_threads = 1;
-INSERT into st SELECT id % 9999999, if(id % 27 = 0, 1, v), 4  FROM (SELECT * FROM generateRandom('id UInt32, v UInt32', $test_seed + 3) limit 1000000) SETTINGS max_threads = 1;
+INSERT INTO st SELECT id % 9999999, if(id % 729 = 0, 4, v), 1  FROM (SELECT * FROM generateRandom('id UInt32, v UInt32', $test_seed) limit 200000) SETTINGS max_threads = 1;
+INSERT INTO st SELECT id % 9999999, if(id % 243 = 0, 3, v), 2  FROM (SELECT * FROM generateRandom('id UInt32, v UInt32', $test_seed + 1) limit 200000) SETTINGS max_threads = 1;
+INSERT INTO st SELECT id % 9999999, if(id % 81 = 0, 2, v), 3  FROM (SELECT * FROM generateRandom('id UInt32, v UInt32', $test_seed + 2) limit 200000) SETTINGS max_threads = 1;
+INSERT into st SELECT id % 9999999, if(id % 27 = 0, 1, v), 4  FROM (SELECT * FROM generateRandom('id UInt32, v UInt32', $test_seed + 3) limit 200000) SETTINGS max_threads = 1;
 
 SELECT (id) FROM st FINAL WHERE v = 1 SETTINGS use_skip_indexes_if_final=0,use_skip_indexes_if_final_exact_mode = 0
 EXCEPT

--- a/tests/queries/0_stateless/03244_skip_index_in_final_query_with_pk_rescan_random.sh
+++ b/tests/queries/0_stateless/03244_skip_index_in_final_query_with_pk_rescan_random.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-tsan, no-asan, no-msan, no-s3-storage
+# Tags: long, no-debug, no-tsan, no-asan, no-msan, no-s3-storage
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -17,10 +17,10 @@ DROP TABLE IF EXISTS st;
 CREATE TABLE st (id Int32, v Int32, r Int32, INDEX bfv v TYPE bloom_filter) ENGINE=ReplacingMergeTree ORDER BY (id) SETTINGS index_granularity = 64;
 SYSTEM STOP MERGES st;
 
-INSERT INTO st SELECT id % 9999999, if(id % 729 = 0, 4, v), 1  FROM (SELECT * FROM generateRandom('id UInt32, v UInt32', $test_seed) limit 200000) SETTINGS max_threads = 1;
-INSERT INTO st SELECT id % 9999999, if(id % 243 = 0, 3, v), 2  FROM (SELECT * FROM generateRandom('id UInt32, v UInt32', $test_seed + 1) limit 200000) SETTINGS max_threads = 1;
-INSERT INTO st SELECT id % 9999999, if(id % 81 = 0, 2, v), 3  FROM (SELECT * FROM generateRandom('id UInt32, v UInt32', $test_seed + 2) limit 200000) SETTINGS max_threads = 1;
-INSERT into st SELECT id % 9999999, if(id % 27 = 0, 1, v), 4  FROM (SELECT * FROM generateRandom('id UInt32, v UInt32', $test_seed + 3) limit 200000) SETTINGS max_threads = 1;
+INSERT INTO st SELECT id % 9999999, if(id % 729 = 0, 4, v), 1  FROM (SELECT * FROM generateRandom('id UInt32, v UInt32', $test_seed) limit 1000000) SETTINGS max_threads = 1;
+INSERT INTO st SELECT id % 9999999, if(id % 243 = 0, 3, v), 2  FROM (SELECT * FROM generateRandom('id UInt32, v UInt32', $test_seed + 1) limit 1000000) SETTINGS max_threads = 1;
+INSERT INTO st SELECT id % 9999999, if(id % 81 = 0, 2, v), 3  FROM (SELECT * FROM generateRandom('id UInt32, v UInt32', $test_seed + 2) limit 1000000) SETTINGS max_threads = 1;
+INSERT into st SELECT id % 9999999, if(id % 27 = 0, 1, v), 4  FROM (SELECT * FROM generateRandom('id UInt32, v UInt32', $test_seed + 3) limit 1000000) SETTINGS max_threads = 1;
 
 SELECT (id) FROM st FINAL WHERE v = 1 SETTINGS use_skip_indexes_if_final=0,use_skip_indexes_if_final_exact_mode = 0
 EXCEPT

--- a/tests/queries/0_stateless/03244_skip_index_in_final_query_with_pk_rescan_random.sh
+++ b/tests/queries/0_stateless/03244_skip_index_in_final_query_with_pk_rescan_random.sh
@@ -12,6 +12,7 @@ test_seed=`$CLICKHOUSE_CLIENT -q "SELECT toUnixTimestamp(now())"`
 res=`$CLICKHOUSE_CLIENT -mq "
 set enable_analyzer=1;
 set allow_experimental_analyzer=1;
+set max_threads='auto';
 
 DROP TABLE IF EXISTS st;
 CREATE TABLE st (id Int32, v Int32, r Int32, INDEX bfv v TYPE bloom_filter) ENGINE=ReplacingMergeTree ORDER BY (id) SETTINGS index_granularity = 64;


### PR DESCRIPTION
The test inserts 4 × 1,000,000 rows and runs FINAL queries. With randomized settings (especially `max_threads=1`) in a debug build, this exceeds the 600s timeout. 

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=102338&sha=41026906138c371d1fe6cd79676d664f8abd5a4f&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20flaky%20check%29 https://github.com/ClickHouse/ClickHouse/pull/102338

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.856`
<!-- ch-version-info:end -->