### PR TITLE
Fix ignore_drop_queries_probability breaking dependencies during DROP DATABASE

### DIFF
--- a/src/Interpreters/InterpreterDropQuery.cpp
+++ b/src/Interpreters/InterpreterDropQuery.cpp
@@ -206,7 +206,14 @@ BlockIO InterpreterDropQuery::executeToTableImpl(const ContextPtr & context_, AS
         auto * materialized_view = dynamic_cast<StorageMaterializedView *>(table.get());
         bool is_refreshable_view = materialized_view && materialized_view->isRefreshable();
 
-        if (!secondary_query && !is_refreshable_view
+        /// Prevents recursive drop from drop database query. The original query must specify a table.
+        bool is_drop_or_detach_database = !current_query_ptr->as<ASTDropQuery>()->table;
+
+        /// Don't ignore DROP when it's part of DROP DATABASE: selectively ignoring individual
+        /// table drops can break dependency invariants (e.g., a dependent table's drop is ignored
+        /// while the table it depends on is dropped, since DROP DATABASE skips same-database
+        /// dependency checks), leaving orphaned tables that prevent server restart.
+        if (!secondary_query && !is_refreshable_view && !is_drop_or_detach_database
             && settings[Setting::ignore_drop_queries_probability] != 0 && ast_drop_query.kind == ASTDropQuery::Kind::Drop
             && std::uniform_real_distribution<>(0.0, 1.0)(thread_local_rng) <= settings[Setting::ignore_drop_queries_probability])
         {
@@ -223,9 +230,6 @@ BlockIO InterpreterDropQuery::executeToTableImpl(const ContextPtr & context_, AS
 
         /// Now get UUID, so we can wait for table data to be finally dropped
         table_id.uuid = database->tryGetTableUUID(table_id.table_name);
-
-        /// Prevents recursive drop from drop database query. The original query must specify a table.
-        bool is_drop_or_detach_database = !current_query_ptr->as<ASTDropQuery>()->table;
 
         AccessFlags drop_storage;
 


### PR DESCRIPTION
The stress test setting `ignore_drop_queries_probability` could selectively ignore individual table drops within a `DROP DATABASE` operation. Since `DROP DATABASE` skips same-database dependency checks (by design), this could leave a dependent table alive while dropping the table it depends on.

For example, table A with a TTL `WHERE a IN (SELECT a FROM B)` referencing table B: if A's drop is ignored but B's drop proceeds, the server cannot restart because A's TTL expression references a nonexistent table B.

The fix disables `ignore_drop_queries_probability` for table drops that are part of a `DROP DATABASE` operation, similar to how it's already disabled for secondary queries and refreshable materialized views.

Root cause analysis of the Stress test (arm_debug) failure in https://github.com/ClickHouse/ClickHouse/pull/100300:
1. Test `02908_table_ttl_dependency` creates `02908_main` and `02908_dependent` (TTL WHERE references `02908_main`) in `test_3`
2. Cleanup DROPs are ignored by `ignore_drop_queries_probability=0.2` — both tables survive
3. A different test (`03655_keeper_map_alter_comment`) runs `DROP DATABASE IF EXISTS test_3`
4. Tables are sorted by dependency order for dropping: `02908_dependent` first
5. `DROP TABLE 02908_dependent` is randomly ignored (20% probability)
6. `DROP TABLE 02908_main` passes the dependency check (same-database dependents are skipped for `DROP DATABASE`) and succeeds
7. `02908_dependent` is orphaned with a TTL referencing nonexistent `02908_main`
8. Server restart fails: `Unknown table expression identifier 'test_3.02908_main'`

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100300&sha=4bcde9f5e2ff130c9fdb0192330170491c0b9015&name_0=PR&name_1=Stress%20test%20%28arm_debug%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.865`
<!-- ch-version-info:end -->