### PR TITLE
Fix flaky test `02835_nested_array_lowcardinality`

### DIFF
--- a/tests/queries/0_stateless/02835_nested_array_lowcardinality.sql
+++ b/tests/queries/0_stateless/02835_nested_array_lowcardinality.sql
@@ -44,6 +44,6 @@ INSERT INTO cool_table SELECT number, range(number), arrayMap(x -> (arrayMap(y -
 
 ALTER TABLE cool_table ADD COLUMN IF NOT EXISTS `n.lc2` Array(Map(LowCardinality(String), UInt64));
 
-SELECT n.lc1, n.lc2 FROM cool_table ORDER BY id;
+SELECT arrayMap(x -> mapSort(x), n.lc1), arrayMap(x -> mapSort(x), n.lc2) FROM cool_table ORDER BY id;
 
 DROP TABLE IF EXISTS cool_table;


### PR DESCRIPTION
The Map output in the third section of this test has non-deterministic key ordering when bucketed map serialization is enabled via randomized MergeTree settings (`map_serialization_version_for_zero_level_parts = 'with_buckets'`, `map_buckets_strategy = 'constant'`, `map_buckets_min_avg_size = 1`). Keys come out in hash-bucket order instead of insertion order.

Wrap the Map array columns with `mapSort` to make key ordering deterministic.

CI report: [Stateless tests (amd_debug, parallel)](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100230&sha=fd4001476012b7f2827bdaebc87f146ed62f0d4b&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29)

Closes #102473

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.880`
<!-- ch-version-info:end -->