### PR TITLE
Remove targeted tests from the flaky check

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -409,16 +409,10 @@ def main():
                 failed_str = ", ".join(previously_failed) if previously_failed else "(none)"
                 print(f"[flaky-check] Step 2 — previously failed tests ({len(previously_failed)}): {failed_str}")
 
-                # Step 3: coverage-relevant tests (direct lines, indirect callees, siblings)
-                relevant_tests, relevance_result = targeter.get_most_relevant_tests()
-                results.append(relevance_result)
-                relevant_preview = ", ".join(relevant_tests[:20]) + ("..." if len(relevant_tests) > 20 else "")
-                print(f"[flaky-check] Step 3 — coverage-relevant tests ({len(relevant_tests)}): {relevant_preview if relevant_tests else '(none)'}")
-
-                # Merge all three sets preserving priority order (changed first)
+                # Merge both sets preserving priority order (changed first)
                 seen: set = set()
                 tests = []
-                for t in list(changed_tests) + list(previously_failed) + list(relevant_tests):
+                for t in list(changed_tests) + list(previously_failed):
                     if t not in seen:
                         seen.add(t)
                         tests.append(t)

--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -229,12 +229,7 @@ def should_skip_job(job_name):
             except Exception as e:
                 print(f"Warning: failed to fetch previously-failed tests: {e}")
                 previously_failed = []
-            try:
-                relevant_tests, _ = targeter.get_most_relevant_tests()
-            except Exception as e:
-                print(f"Warning: failed to fetch relevant tests: {e}")
-                relevant_tests = []
-            if not changed_tests and not previously_failed and not relevant_tests:
+            if not changed_tests and not previously_failed:
                 return True, "Skipped, no tests to run"
         if "integration" in job_name.lower() and not has_new_integration_tests(
             changed_files


### PR DESCRIPTION
The flaky check used to find "relevant" tests via coverage-based analysis (`get_most_relevant_tests`: direct line coverage, indirect callees, sibling directories, keyword matching) in addition to changed/new tests and previously failed tests. Remove this feature so the flaky check only runs changed and previously failed tests.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.894`
<!-- ch-version-info:end -->