### PR TITLE
 After stringToTokens returns empty, check the original needle value.

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -745,8 +745,17 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
         {
             const String & string_needle = value_field.safeGet<String>();
             if (!string_needle.empty())
-                return false;
-
+            {
+                /// hasToken uses splitByNonAlpha as its tokenizer, so:
+                ///  - A needle without any word character (alphanumeric or non-ASCII) is invalid.
+                ///  - Bypass the index in that case so the row-level evaluation throws BAD_ARGUMENTS (or returns NULL for hasTokenOrNull)
+                ///  -- Consistnt with the no-index behaviour.
+                /// If the needle does contain word characters (e.g. "abc" with ngrams(4)):
+                ///  - It is valid but too short for the index's tokenizer:
+                ///  -- Fall through to push "" so all granules are pruned and the query returns 0 rows.
+                if (std::ranges::none_of(string_needle, [](unsigned char c) { return !isASCII(c) || isAlphaNumericASCII(c); }))
+                    return false;
+            }
             tokens.push_back("");
         }
 

--- a/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexConditionText.cpp
@@ -742,7 +742,13 @@ bool MergeTreeIndexConditionText::traverseFunctionNode(
     {
         auto tokens = stringToTokens(value_field);
         if (tokens.empty())
+        {
+            const String & string_needle = value_field.safeGet<String>();
+            if (!string_needle.empty())
+                return false;
+
             tokens.push_back("");
+        }
 
         out.function = RPNElement::FUNCTION_EQUALS;
         out.text_search_queries.emplace_back(std::make_shared<TextSearchQuery>(function_name, TextSearchMode::All, direct_read_mode, std::move(tokens)));

--- a/tests/queries/0_stateless/02346_text_index_bug102497.reference
+++ b/tests/queries/0_stateless/02346_text_index_bug102497.reference
@@ -1,0 +1,17 @@
+Scalar baseline.
+- hasTokenOrNull with separator-only needle returns NULL
+\N
+Without text index.
+- hasToken with separator-only needle throws BAD_ARGUMENTS
+- hasTokenOrNull with separator-only needle returns NULL per row
+2
+- Empty needle matches nothing, no exception
+0
+2
+With text index.
+- hasToken with separator-only needle throws BAD_ARGUMENTS
+- hasTokenOrNull with separator-only needle returns NULL per row
+2
+- Empty needle matches nothing, no exception
+0
+2

--- a/tests/queries/0_stateless/02346_text_index_bug102497.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug102497.sql
@@ -1,0 +1,58 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/102497
+-- hasToken with separator-only needles should throw BAD_ARGUMENTS consistently,
+-- regardless of whether a text index is present.
+-- hasTokenOrNull with separator-only needles should return NULL per row,
+-- not silently skip all granules.
+
+SELECT 'Scalar baseline.';
+
+SELECT '- hasTokenOrNull with separator-only needle returns NULL';
+SELECT hasTokenOrNull('hello', '()');
+
+SELECT 'Without text index.';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (id Int32, text String) ENGINE = MergeTree() ORDER BY (id);
+INSERT INTO tab VALUES (1, 'hello world'), (2, 'foo bar');
+
+SELECT '- hasToken with separator-only needle throws BAD_ARGUMENTS';
+SELECT count() FROM tab WHERE hasToken(text, '()');     -- { serverError BAD_ARGUMENTS }
+SELECT count() FROM tab WHERE NOT hasToken(text, '()'); -- { serverError BAD_ARGUMENTS }
+SELECT count() FROM tab WHERE hasToken(text, '!!!');    -- { serverError BAD_ARGUMENTS }
+
+SELECT '- hasTokenOrNull with separator-only needle returns NULL per row';
+SELECT count() FROM tab WHERE isNull(hasTokenOrNull(text, '()'));
+
+SELECT '- Empty needle matches nothing, no exception';
+SELECT count() FROM tab WHERE hasToken(text, '');
+SELECT count() FROM tab WHERE NOT hasToken(text, '');
+
+DROP TABLE tab;
+
+SELECT 'With text index.';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab
+(
+    id Int32,
+    text String,
+    INDEX idx_text(text) TYPE text(tokenizer = 'splitByNonAlpha')
+)
+ENGINE = MergeTree()
+ORDER BY (id);
+
+INSERT INTO tab VALUES (1, 'hello world'), (2, 'foo bar');
+
+SELECT '- hasToken with separator-only needle throws BAD_ARGUMENTS';
+SELECT count() FROM tab WHERE hasToken(text, '()');     -- { serverError BAD_ARGUMENTS }
+SELECT count() FROM tab WHERE NOT hasToken(text, '()'); -- { serverError BAD_ARGUMENTS }
+SELECT count() FROM tab WHERE hasToken(text, '!!!');    -- { serverError BAD_ARGUMENTS }
+
+SELECT '- hasTokenOrNull with separator-only needle returns NULL per row';
+SELECT count() FROM tab WHERE isNull(hasTokenOrNull(text, '()'));
+
+SELECT '- Empty needle matches nothing, no exception';
+SELECT count() FROM tab WHERE hasToken(text, '');
+SELECT count() FROM tab WHERE NOT hasToken(text, '');
+
+DROP TABLE tab;


### PR DESCRIPTION
Fixes: #102497

See issue description there.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `hasToken` / `hasTokenOrNull` with separator-only needles (e.g. `'()'`, `'!!!'`) on columns with a text index: previously the index silently skipped all granules instead of throwing `BAD_ARGUMENTS` (for `hasToken`) or returning `NULL` (for `hasTokenOrNull`).

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.905`
<!-- ch-version-info:end -->