### PR TITLE
Fix overflow in scalar pointwise ops on `numericIndexedVector`

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionGroupNumericIndexedVectorDataBSI.h
+++ b/src/AggregateFunctions/AggregateFunctionGroupNumericIndexedVectorDataBSI.h
@@ -298,8 +298,6 @@ public:
           * - When value is a Float32/Float64, fraction_bit_num indicates how many bits are used to represent the decimal, Because the
           *   maximum value of total_bit_num(integer_bit_num + fraction_bit_num) is 64, overflow may occur.
           */
-        using ScaledValueType = std::conditional_t<std::is_floating_point_v<ValueType>, ValueType, UInt64>;
-
         Int64 scaled_value;
         if constexpr (std::is_same_v<ValueType, UInt64>)
         {
@@ -325,7 +323,7 @@ public:
         }
         else
         {
-            scaled_value = static_cast<Int64>(value * static_cast<ScaledValueType>(1ULL << fraction_bit_num));
+            scaled_value = static_cast<Int64>(value * static_cast<UInt64>(1ULL << fraction_bit_num));
         }
         for (size_t i = 0; i < total_bit_num; ++i)
         {
@@ -1326,7 +1324,6 @@ public:
 
         /// Convert the scalar to the same fixed-point two's complement representation
         /// used by initializeFromVectorAndValue, then compare bit by bit.
-        using ScaledValueType = std::conditional_t<std::is_floating_point_v<ValueType>, ValueType, UInt64>;
         UInt64 scaling = 1ULL << lhs.fraction_bit_num;
 
         Int64 scaled_value;
@@ -1341,7 +1338,7 @@ public:
         }
         else
         {
-            scaled_value = static_cast<Int64>(rhs * static_cast<ScaledValueType>(scaling));
+            scaled_value = static_cast<Int64>(rhs * scaling);
         }
 
         UInt64 bit_pattern = static_cast<UInt64>(scaled_value);

--- a/src/AggregateFunctions/AggregateFunctionGroupNumericIndexedVectorDataBSI.h
+++ b/src/AggregateFunctions/AggregateFunctionGroupNumericIndexedVectorDataBSI.h
@@ -301,7 +301,14 @@ public:
         using ScaledValueType = std::conditional_t<std::is_floating_point_v<ValueType>, ValueType, UInt64>;
 
         Int64 scaled_value;
-        if constexpr (std::is_floating_point_v<ValueType>)
+        if constexpr (std::is_same_v<ValueType, UInt64>)
+        {
+            if (value > std::numeric_limits<Int64>::max())
+                throw Exception(ErrorCodes::INCORRECT_DATA,
+                    "Value {} does not fit in Int64. It should, even when using UInt64.", value);
+            scaled_value = static_cast<Int64>(value);
+        }
+        else if constexpr (std::is_floating_point_v<ValueType>)
         {
             UInt64 scaling = 1ULL << fraction_bit_num;
             auto scaled = static_cast<Float64>(value * static_cast<ValueType>(scaling));

--- a/tests/queries/0_stateless/03463_numeric_indexed_vector_overflow.sql
+++ b/tests/queries/0_stateless/03463_numeric_indexed_vector_overflow.sql
@@ -66,3 +66,72 @@ INSERT INTO test SELECT groupNumericIndexedVectorState(toUInt32(2), -1.54743e+26
 INSERT INTO test2 SELECT groupNumericIndexedVectorState(toUInt32(1), 18446744073709551615); -- { serverError INCORRECT_DATA }
 DROP TABLE test;
 DROP TABLE test2;
+
+-- Comprehensive coverage of scalar pointwise ops routing through initializeFromVectorAndValue
+-- Float64: overflow on every scalar pointwise op that touches initializeFromVectorAndValue.
+DROP TABLE IF EXISTS uin_value_f64;
+CREATE TABLE uin_value_f64 (uin UInt8, value Float64) ENGINE = MergeTree() ORDER BY uin;
+INSERT INTO uin_value_f64 (uin, value) VALUES (1, 7.3), (2, 8.3);
+
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_f64) AS v
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseAdd(v, 1.54743e+26)); -- { serverError INCORRECT_DATA }
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_f64) AS v
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseAdd(v, -1.54743e+26)); -- { serverError INCORRECT_DATA }
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_f64) AS v
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseSubtract(v, 1.54743e+26)); -- { serverError INCORRECT_DATA }
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_f64) AS v
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseSubtract(v, -1.54743e+26)); -- { serverError INCORRECT_DATA }
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_f64) AS v
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseLess(v, 1.54743e+26)); -- { serverError INCORRECT_DATA }
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_f64) AS v
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseLess(v, -1.54743e+26)); -- { serverError INCORRECT_DATA }
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_f64) AS v
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseLessEqual(v, 1.54743e+26)); -- { serverError INCORRECT_DATA }
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_f64) AS v
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseLessEqual(v, -1.54743e+26)); -- { serverError INCORRECT_DATA }
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_f64) AS v
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseGreater(v, 1.54743e+26)); -- { serverError INCORRECT_DATA }
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_f64) AS v
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseGreater(v, -1.54743e+26)); -- { serverError INCORRECT_DATA }
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_f64) AS v
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseGreaterEqual(v, 1.54743e+26)); -- { serverError INCORRECT_DATA }
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_f64) AS v
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseGreaterEqual(v, -1.54743e+26)); -- { serverError INCORRECT_DATA }
+DROP TABLE uin_value_f64;
+
+-- pointwiseMultiply only reaches initializeFromVectorAndValue when all values of lhs are 1.
+DROP TABLE IF EXISTS uin_ones_f64;
+CREATE TABLE uin_ones_f64 (uin UInt32, value Float64) ENGINE = MergeTree() ORDER BY uin;
+INSERT INTO uin_ones_f64 VALUES (1, 1), (2, 1), (3, 1);
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_ones_f64) AS v
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseMultiply(v, 1.54743e+26)); -- { serverError INCORRECT_DATA }
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_ones_f64) AS v
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseMultiply(v, -1.54743e+26)); -- { serverError INCORRECT_DATA }
+DROP TABLE uin_ones_f64;
+
+-- UInt64: scalar above Int64 max must be rejected through every scalar pointwise op.
+DROP TABLE IF EXISTS uin_value_u64;
+CREATE TABLE uin_value_u64 (uin UInt32, value UInt64) ENGINE = MergeTree() ORDER BY uin;
+INSERT INTO uin_value_u64 VALUES (1, 100), (2, 200);
+
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_u64) AS v
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseAdd(v, 18446744073709551615)); -- { serverError INCORRECT_DATA }
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_u64) AS v
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseSubtract(v, 18446744073709551615)); -- { serverError INCORRECT_DATA }
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_u64) AS v
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseLess(v, 18446744073709551615)); -- { serverError INCORRECT_DATA }
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_u64) AS v
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseLessEqual(v, 18446744073709551615)); -- { serverError INCORRECT_DATA }
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_u64) AS v
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseGreater(v, 18446744073709551615)); -- { serverError INCORRECT_DATA }
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_value_u64) AS v
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseGreaterEqual(v, 18446744073709551615)); -- { serverError INCORRECT_DATA }
+DROP TABLE uin_value_u64;
+
+-- UInt64: pointwiseMultiply path when all values are 1.
+DROP TABLE IF EXISTS uin_ones_u64;
+CREATE TABLE uin_ones_u64 (uin UInt32, value UInt64) ENGINE = MergeTree() ORDER BY uin;
+INSERT INTO uin_ones_u64 VALUES (1, 1), (2, 1), (3, 1);
+WITH (SELECT groupNumericIndexedVectorState(uin, value) FROM uin_ones_u64) AS v
+SELECT numericIndexedVectorToMap(numericIndexedVectorPointwiseMultiply(v, 18446744073709551615)); -- { serverError INCORRECT_DATA }
+DROP TABLE uin_ones_u64;


### PR DESCRIPTION
Closes https://github.com/ClickHouse/ClickHouse/issues/102210

Fix silent Int64 overflow in `initializeFromVectorAndValue` for BSI-based `NumericIndexedVector`. Scalar pointwise operations (`numericIndexedVectorPointwiseAdd/Subtract/Multiply/Less/LessEqual/Greater/GreaterEqual` with a scalar) route through `initializeFromVectorAndValue`, which previously converted `value` to `Int64` without any range check — identical to the overflow that was already fixed in `addValue`. As a result, passing a `UInt64`  above `Int64::max` silently produced corrupted negative values instead of throwing.

This PR applies the same overflow checks used in `addValue`:
- For `UInt64`: reject values above `Int64::max`.

This now throws `INCORRECT_DATA` consistently across all 6 callers of `initializeFromVectorAndValue`.

Found during automated review of #83603.


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed silent overflow in scalar pointwise operations on numericIndexedVector (e.g. `numericIndexedVectorPointwiseAdd`) when the scalar is out of range. Such inputs now raise `INCORRECT_DATA` instead of returning corrupted values.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.517`
<!-- ch-version-info:end -->