### PR TITLE
Speed up test 01655_plan_optimizations_optimize_read_in_window_order

### DIFF
--- a/tests/queries/0_stateless/01655_plan_optimizations_optimize_read_in_window_order.sh
+++ b/tests/queries/0_stateless/01655_plan_optimizations_optimize_read_in_window_order.sh
@@ -6,54 +6,48 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 name=test_01655_plan_optimizations_optimize_read_in_window_order
 
-$CLICKHOUSE_CLIENT -nm -q "
-drop table if exists ${name};
-drop table if exists ${name}_n;
-drop table if exists ${name}_n_x;
-create table ${name} engine=MergeTree order by tuple() as select toInt64((sin(number)+2)*65535)%10 as n, number as x from numbers_mt(1000);
-create table ${name}_n engine=MergeTree order by n as select * from ${name} order by n;
-create table ${name}_n_x engine=MergeTree order by (n, x) as select * from ${name} order by n, x;
-optimize table ${name}_n final;
-optimize table ${name}_n_x final;
-"
+$CLICKHOUSE_CLIENT -q "drop table if exists ${name}"
+$CLICKHOUSE_CLIENT -q "drop table if exists ${name}_n"
+$CLICKHOUSE_CLIENT -q "drop table if exists ${name}_n_x"
+
+$CLICKHOUSE_CLIENT -q "create table ${name} engine=MergeTree order by tuple() settings index_granularity = 10000 as select toInt64((sin(number)+2)*65535)%10 as n, number as x from numbers_mt(100000)"
+$CLICKHOUSE_CLIENT -q "create table ${name}_n engine=MergeTree order by n settings index_granularity = 10000 as select * from ${name} order by n"
+$CLICKHOUSE_CLIENT -q "create table ${name}_n_x engine=MergeTree order by (n, x) settings index_granularity = 10000 as select * from ${name} order by n, x"
+
+$CLICKHOUSE_CLIENT -q "optimize table ${name}_n final"
+$CLICKHOUSE_CLIENT -q "optimize table ${name}_n_x final"
 
 echo 'Partial sorting plan'
-$CLICKHOUSE_CLIENT -nm -q "
-SELECT '  optimize_read_in_window_order=0';
-explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n SETTINGS optimize_read_in_order=0,optimize_read_in_window_order=0,enable_analyzer=0;
-SELECT '  optimize_read_in_window_order=0, enable_analyzer=1';
-explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n SETTINGS optimize_read_in_order=0,optimize_read_in_window_order=0,enable_analyzer=0;
-SELECT '  optimize_read_in_window_order=1';
-explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n SETTINGS optimize_read_in_order=1,enable_analyzer=0;
-SELECT '  optimize_read_in_window_order=1, enable_analyzer=1';
-explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n SETTINGS optimize_read_in_order=1,enable_analyzer=1;
-" | grep -iE "sort description|optimize_read_in_window_order="
+echo '  optimize_read_in_window_order=0'
+$CLICKHOUSE_CLIENT -q "explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n SETTINGS optimize_read_in_order=0,optimize_read_in_window_order=0,enable_analyzer=0" | grep -i "sort description"
+echo '  optimize_read_in_window_order=0, enable_analyzer=1'
+$CLICKHOUSE_CLIENT -q "explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n SETTINGS optimize_read_in_order=0,optimize_read_in_window_order=0,enable_analyzer=0" | grep -i "sort description"
+
+echo '  optimize_read_in_window_order=1'
+$CLICKHOUSE_CLIENT -q "explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n SETTINGS optimize_read_in_order=1,enable_analyzer=0" | grep -i "sort description"
+echo '  optimize_read_in_window_order=1, enable_analyzer=1'
+$CLICKHOUSE_CLIENT -q "explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n SETTINGS optimize_read_in_order=1,enable_analyzer=1" | grep -i "sort description"
 
 echo 'No sorting plan'
-$CLICKHOUSE_CLIENT -nm -q "
-SELECT '  optimize_read_in_window_order=0';
-explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n_x SETTINGS optimize_read_in_order=0,optimize_read_in_window_order=0,enable_analyzer=0;
-SELECT '  optimize_read_in_window_order=0, enable_analyzer=1';
-explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n_x SETTINGS optimize_read_in_order=0,optimize_read_in_window_order=0,enable_analyzer=1;
-SELECT '  optimize_read_in_window_order=1';
-explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n_x SETTINGS optimize_read_in_order=1,enable_analyzer=0;
-SELECT '  optimize_read_in_window_order=1, enable_analyzer=1';
-explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n_x SETTINGS optimize_read_in_order=1,enable_analyzer=1;
-" | grep -iE "sort description|optimize_read_in_window_order="
+echo '  optimize_read_in_window_order=0'
+$CLICKHOUSE_CLIENT -q "explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n_x SETTINGS optimize_read_in_order=0,optimize_read_in_window_order=0,enable_analyzer=0" | grep -i "sort description"
+echo '  optimize_read_in_window_order=0, enable_analyzer=1'
+$CLICKHOUSE_CLIENT -q "explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n_x SETTINGS optimize_read_in_order=0,optimize_read_in_window_order=0,enable_analyzer=1" | grep -i "sort description"
+
+echo '  optimize_read_in_window_order=1'
+$CLICKHOUSE_CLIENT -q "explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n_x SETTINGS optimize_read_in_order=1,enable_analyzer=0" | grep -i "sort description"
+echo '  optimize_read_in_window_order=1, enable_analyzer=1'
+$CLICKHOUSE_CLIENT -q "explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n_x SETTINGS optimize_read_in_order=1,enable_analyzer=1" | grep -i "sort description"
 
 echo 'Complex ORDER BY'
-$CLICKHOUSE_CLIENT -nm -q "
-CREATE TABLE ${name}_complex (unique1 Int32, unique2 Int32, ten Int32) ENGINE=MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192;
-INSERT INTO ${name}_complex VALUES (1, 2, 3), (2, 3, 4), (3, 4, 5);
-SELECT '  optimize_read_in_window_order=0';
-SELECT ten, sum(unique1) + sum(unique2) AS res, rank() OVER (ORDER BY sum(unique1) + sum(unique2) ASC) AS rank FROM ${name}_complex GROUP BY ten ORDER BY ten ASC SETTINGS optimize_read_in_order=0,optimize_read_in_window_order=0;
-SELECT '  optimize_read_in_window_order=1';
-SELECT ten, sum(unique1) + sum(unique2) AS res, rank() OVER (ORDER BY sum(unique1) + sum(unique2) ASC) AS rank FROM ${name}_complex GROUP BY ten ORDER BY ten ASC SETTINGS optimize_read_in_order=1;
-"
+$CLICKHOUSE_CLIENT -q "CREATE TABLE ${name}_complex (unique1 Int32, unique2 Int32, ten Int32) ENGINE=MergeTree ORDER BY tuple()"
+$CLICKHOUSE_CLIENT -q "INSERT INTO ${name}_complex VALUES (1, 2, 3), (2, 3, 4), (3, 4, 5)"
+echo '  optimize_read_in_window_order=0'
+$CLICKHOUSE_CLIENT -q "SELECT ten, sum(unique1) + sum(unique2) AS res, rank() OVER (ORDER BY sum(unique1) + sum(unique2) ASC) AS rank FROM ${name}_complex GROUP BY ten ORDER BY ten ASC SETTINGS optimize_read_in_order=0,optimize_read_in_window_order=0"
+echo '  optimize_read_in_window_order=1'
+$CLICKHOUSE_CLIENT -q "SELECT ten, sum(unique1) + sum(unique2) AS res, rank() OVER (ORDER BY sum(unique1) + sum(unique2) ASC) AS rank FROM ${name}_complex GROUP BY ten ORDER BY ten ASC SETTINGS optimize_read_in_order=1"
 
-$CLICKHOUSE_CLIENT -nm -q "
-drop table ${name};
-drop table ${name}_n;
-drop table ${name}_n_x;
-drop table ${name}_complex;
-"
+$CLICKHOUSE_CLIENT -q "drop table ${name}"
+$CLICKHOUSE_CLIENT -q "drop table ${name}_n"
+$CLICKHOUSE_CLIENT -q "drop table ${name}_n_x"
+$CLICKHOUSE_CLIENT -q "drop table ${name}_complex"

--- a/tests/queries/0_stateless/01655_plan_optimizations_optimize_read_in_window_order.sh
+++ b/tests/queries/0_stateless/01655_plan_optimizations_optimize_read_in_window_order.sh
@@ -6,48 +6,54 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 name=test_01655_plan_optimizations_optimize_read_in_window_order
 
-$CLICKHOUSE_CLIENT -q "drop table if exists ${name}"
-$CLICKHOUSE_CLIENT -q "drop table if exists ${name}_n"
-$CLICKHOUSE_CLIENT -q "drop table if exists ${name}_n_x"
-
-$CLICKHOUSE_CLIENT -q "create table ${name} engine=MergeTree order by tuple() as select toInt64((sin(number)+2)*65535)%10 as n, number as x from numbers_mt(100000)"
-$CLICKHOUSE_CLIENT -q "create table ${name}_n engine=MergeTree order by n as select * from ${name} order by n"
-$CLICKHOUSE_CLIENT -q "create table ${name}_n_x engine=MergeTree order by (n, x) as select * from ${name} order by n, x"
-
-$CLICKHOUSE_CLIENT -q "optimize table ${name}_n final"
-$CLICKHOUSE_CLIENT -q "optimize table ${name}_n_x final"
+$CLICKHOUSE_CLIENT -nm -q "
+drop table if exists ${name};
+drop table if exists ${name}_n;
+drop table if exists ${name}_n_x;
+create table ${name} engine=MergeTree order by tuple() as select toInt64((sin(number)+2)*65535)%10 as n, number as x from numbers_mt(1000);
+create table ${name}_n engine=MergeTree order by n as select * from ${name} order by n;
+create table ${name}_n_x engine=MergeTree order by (n, x) as select * from ${name} order by n, x;
+optimize table ${name}_n final;
+optimize table ${name}_n_x final;
+"
 
 echo 'Partial sorting plan'
-echo '  optimize_read_in_window_order=0'
-$CLICKHOUSE_CLIENT -q "explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n SETTINGS optimize_read_in_order=0,optimize_read_in_window_order=0,enable_analyzer=0" | grep -i "sort description"
-echo '  optimize_read_in_window_order=0, enable_analyzer=1'
-$CLICKHOUSE_CLIENT -q "explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n SETTINGS optimize_read_in_order=0,optimize_read_in_window_order=0,enable_analyzer=0" | grep -i "sort description"
-
-echo '  optimize_read_in_window_order=1'
-$CLICKHOUSE_CLIENT -q "explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n SETTINGS optimize_read_in_order=1,enable_analyzer=0" | grep -i "sort description"
-echo '  optimize_read_in_window_order=1, enable_analyzer=1'
-$CLICKHOUSE_CLIENT -q "explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n SETTINGS optimize_read_in_order=1,enable_analyzer=1" | grep -i "sort description"
+$CLICKHOUSE_CLIENT -nm -q "
+SELECT '  optimize_read_in_window_order=0';
+explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n SETTINGS optimize_read_in_order=0,optimize_read_in_window_order=0,enable_analyzer=0;
+SELECT '  optimize_read_in_window_order=0, enable_analyzer=1';
+explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n SETTINGS optimize_read_in_order=0,optimize_read_in_window_order=0,enable_analyzer=0;
+SELECT '  optimize_read_in_window_order=1';
+explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n SETTINGS optimize_read_in_order=1,enable_analyzer=0;
+SELECT '  optimize_read_in_window_order=1, enable_analyzer=1';
+explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n SETTINGS optimize_read_in_order=1,enable_analyzer=1;
+" | grep -iE "sort description|optimize_read_in_window_order="
 
 echo 'No sorting plan'
-echo '  optimize_read_in_window_order=0'
-$CLICKHOUSE_CLIENT -q "explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n_x SETTINGS optimize_read_in_order=0,optimize_read_in_window_order=0,enable_analyzer=0" | grep -i "sort description"
-echo '  optimize_read_in_window_order=0, enable_analyzer=1'
-$CLICKHOUSE_CLIENT -q "explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n_x SETTINGS optimize_read_in_order=0,optimize_read_in_window_order=0,enable_analyzer=1" | grep -i "sort description"
-
-echo '  optimize_read_in_window_order=1'
-$CLICKHOUSE_CLIENT -q "explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n_x SETTINGS optimize_read_in_order=1,enable_analyzer=0" | grep -i "sort description"
-echo '  optimize_read_in_window_order=1, enable_analyzer=1'
-$CLICKHOUSE_CLIENT -q "explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n_x SETTINGS optimize_read_in_order=1,enable_analyzer=1" | grep -i "sort description"
+$CLICKHOUSE_CLIENT -nm -q "
+SELECT '  optimize_read_in_window_order=0';
+explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n_x SETTINGS optimize_read_in_order=0,optimize_read_in_window_order=0,enable_analyzer=0;
+SELECT '  optimize_read_in_window_order=0, enable_analyzer=1';
+explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n_x SETTINGS optimize_read_in_order=0,optimize_read_in_window_order=0,enable_analyzer=1;
+SELECT '  optimize_read_in_window_order=1';
+explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n_x SETTINGS optimize_read_in_order=1,enable_analyzer=0;
+SELECT '  optimize_read_in_window_order=1, enable_analyzer=1';
+explain plan actions=1, description=1 select n, sum(x) OVER (ORDER BY n, x ROWS BETWEEN 100 PRECEDING AND CURRENT ROW) from ${name}_n_x SETTINGS optimize_read_in_order=1,enable_analyzer=1;
+" | grep -iE "sort description|optimize_read_in_window_order="
 
 echo 'Complex ORDER BY'
-$CLICKHOUSE_CLIENT -q "CREATE TABLE ${name}_complex (unique1 Int32, unique2 Int32, ten Int32) ENGINE=MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192"
-$CLICKHOUSE_CLIENT -q "INSERT INTO ${name}_complex VALUES (1, 2, 3), (2, 3, 4), (3, 4, 5)"
-echo '  optimize_read_in_window_order=0'
-$CLICKHOUSE_CLIENT -q "SELECT ten, sum(unique1) + sum(unique2) AS res, rank() OVER (ORDER BY sum(unique1) + sum(unique2) ASC) AS rank FROM ${name}_complex GROUP BY ten ORDER BY ten ASC SETTINGS optimize_read_in_order=0,optimize_read_in_window_order=0"
-echo '  optimize_read_in_window_order=1'
-$CLICKHOUSE_CLIENT -q "SELECT ten, sum(unique1) + sum(unique2) AS res, rank() OVER (ORDER BY sum(unique1) + sum(unique2) ASC) AS rank FROM ${name}_complex GROUP BY ten ORDER BY ten ASC SETTINGS optimize_read_in_order=1"
+$CLICKHOUSE_CLIENT -nm -q "
+CREATE TABLE ${name}_complex (unique1 Int32, unique2 Int32, ten Int32) ENGINE=MergeTree ORDER BY tuple() SETTINGS index_granularity = 8192;
+INSERT INTO ${name}_complex VALUES (1, 2, 3), (2, 3, 4), (3, 4, 5);
+SELECT '  optimize_read_in_window_order=0';
+SELECT ten, sum(unique1) + sum(unique2) AS res, rank() OVER (ORDER BY sum(unique1) + sum(unique2) ASC) AS rank FROM ${name}_complex GROUP BY ten ORDER BY ten ASC SETTINGS optimize_read_in_order=0,optimize_read_in_window_order=0;
+SELECT '  optimize_read_in_window_order=1';
+SELECT ten, sum(unique1) + sum(unique2) AS res, rank() OVER (ORDER BY sum(unique1) + sum(unique2) ASC) AS rank FROM ${name}_complex GROUP BY ten ORDER BY ten ASC SETTINGS optimize_read_in_order=1;
+"
 
-$CLICKHOUSE_CLIENT -q "drop table ${name}"
-$CLICKHOUSE_CLIENT -q "drop table ${name}_n"
-$CLICKHOUSE_CLIENT -q "drop table ${name}_n_x"
-$CLICKHOUSE_CLIENT -q "drop table ${name}_complex"
+$CLICKHOUSE_CLIENT -nm -q "
+drop table ${name};
+drop table ${name}_n;
+drop table ${name}_n_x;
+drop table ${name}_complex;
+"


### PR DESCRIPTION
The test was spending ~6.5 seconds almost entirely on connection overhead from 24 separate `$CLICKHOUSE_CLIENT` invocations (~270ms each). This caused CI timeouts, e.g. https://github.com/ClickHouse/ClickHouse/pull/97744.

Batch queries into 5 multi-statement client calls instead of 24:
- All DDL (drops, creates, optimizes) into one call
- Each group of `EXPLAIN PLAN` queries into one call, using `SELECT` as inline markers instead of `echo`, then filtering combined output with `grep`
- Complex ORDER BY section (DDL + queries) into one call
- All final drops into one call

Also reduced `numbers_mt(100000)` to `numbers_mt(1000)` since all queries on the large tables are `EXPLAIN PLAN` which only depends on table schema, not data volume.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1045`
<!-- ch-version-info:end -->