### PR TITLE
Use curl instead of client in `04039_merge_tree_snapshot_teardown_race`

### DIFF
--- a/tests/queries/0_stateless/04039_merge_tree_snapshot_teardown_race.sh
+++ b/tests/queries/0_stateless/04039_merge_tree_snapshot_teardown_race.sh
@@ -12,10 +12,15 @@ TABLE="test_04039_snapshot_teardown_${CLICKHOUSE_TEST_UNIQUE_NAME}"
 TABLE_PROJ="test_04039_proj_teardown_${CLICKHOUSE_TEST_UNIQUE_NAME}"
 ITERATIONS=20
 
+function run_query()
+{
+    ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}" -d "$1" 2>/dev/null
+}
+
 function cleanup()
 {
-    $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS ${TABLE} SYNC" >/dev/null 2>&1 ||:
-    $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS ${TABLE_PROJ} SYNC" >/dev/null 2>&1 ||:
+    run_query "DROP TABLE IF EXISTS ${TABLE} SYNC" >/dev/null 2>&1 ||:
+    run_query "DROP TABLE IF EXISTS ${TABLE_PROJ} SYNC" >/dev/null 2>&1 ||:
 }
 
 function wait_for_reading()
@@ -26,7 +31,7 @@ function wait_for_reading()
 
     while true; do
         local read_rows
-        read_rows=$($CLICKHOUSE_CLIENT --query "SELECT read_rows FROM system.processes WHERE query_id = '${query_id}'" 2>/dev/null || echo "")
+        read_rows=$(run_query "SELECT read_rows FROM system.processes WHERE query_id = '${query_id}'" || echo "")
         if [ -n "$read_rows" ] && [ "$read_rows" -gt 0 ] 2>/dev/null; then
             return 0
         fi
@@ -77,13 +82,13 @@ function run_iteration_proj()
 
     wait_for_query_to_start "$query_id"
     if ! wait_for_reading "$query_id"; then
-        $CLICKHOUSE_CLIENT --query "KILL QUERY WHERE query_id = '${query_id}' SYNC FORMAT Null" >/dev/null 2>&1 ||:
+        run_query "KILL QUERY WHERE query_id = '${query_id}' SYNC FORMAT Null" >/dev/null 2>&1 ||:
         wait "$pid" >/dev/null 2>&1 ||:
         rm -f "$log_file"
         return 1
     fi
 
-    $CLICKHOUSE_CLIENT --query "KILL QUERY WHERE query_id = '${query_id}' SYNC FORMAT Null" >/dev/null 2>&1 ||:
+    run_query "KILL QUERY WHERE query_id = '${query_id}' SYNC FORMAT Null" >/dev/null 2>&1 ||:
     wait "$pid" >/dev/null 2>&1 ||:
 
     if grep -F "Code:" "$log_file" | grep -v -F "QUERY_WAS_CANCELLED" >/dev/null; then
@@ -125,13 +130,13 @@ function run_iteration()
 
     wait_for_query_to_start "$query_id"
     if ! wait_for_reading "$query_id"; then
-        $CLICKHOUSE_CLIENT --query "KILL QUERY WHERE query_id = '${query_id}' SYNC FORMAT Null" >/dev/null 2>&1 ||:
+        run_query "KILL QUERY WHERE query_id = '${query_id}' SYNC FORMAT Null" >/dev/null 2>&1 ||:
         wait "$pid" >/dev/null 2>&1 ||:
         rm -f "$log_file"
         return 1
     fi
 
-    $CLICKHOUSE_CLIENT --query "KILL QUERY WHERE query_id = '${query_id}' SYNC FORMAT Null" >/dev/null 2>&1 ||:
+    run_query "KILL QUERY WHERE query_id = '${query_id}' SYNC FORMAT Null" >/dev/null 2>&1 ||:
     wait "$pid" >/dev/null 2>&1 ||:
 
     if grep -F "Code:" "$log_file" | grep -v -F "QUERY_WAS_CANCELLED" >/dev/null; then


### PR DESCRIPTION
### What this PR does

The test `04039_merge_tree_snapshot_teardown_race` times out at 600s under MSan
(12 failures since Apr 9, 0.88% fail rate on `amd_msan, WasmEdge, parallel`).
The root cause is cumulative overhead from spawning ~120-280 MSan-instrumented
`clickhouse-client` processes per run for polling `system.processes` and issuing
`KILL QUERY`.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=976aa2930e27fa7d3d89b9d2d1c46bcb024dbf1f&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%201%2F2%29

### Changelog category (leave one):
- CI Fix or improvement

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
- Not for changelog.

- [ ] Documentation is written (no doc changes needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.907`
<!-- ch-version-info:end -->