### PR TITLE
 Fix stress test log parser losing actual error behind "Parse failure error"

### DIFF
--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -99,7 +99,10 @@ class FuzzerLogParser:
                 )
             else:
                 if flag_name == "is_sanitizer_error":
-                    assert self.stderr_log
+                    if not self.stderr_log:
+                        # stderr.log may be absent when stress_runner.sh exits early (e.g. server failed to restart).
+                        # Skip sanitizer patterns and let the loop check the server log for other error types.
+                        continue
                     file = self.stderr_log
                 else:
                     assert self.server_log

--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -105,7 +105,7 @@ class FuzzerLogParser:
                         continue
                     file = self.stderr_log
                 else:
-                    assert self.server_log
+                    assert self.server_log, "No server log provided"
                     file = self.server_log
                 output = Shell.get_output(
                     f"rg --text -A 10 -o '{pattern}' {file} | head -n10",


### PR DESCRIPTION
When a stress test server crashes and cannot restart, `stress_runner.sh` exits before moving 'stderr.log' to the test output directory. The log parser then receives an empty `stderr_log` path and hits a bare `assert`. The actual error is then never extracted.

Closes https://github.com/ClickHouse/ClickHouse/issues/101321


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
 Fix stress test log parser losing actual error behind "Parse failure error"

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.887`
<!-- ch-version-info:end -->