### PR TITLE
Fix OOMs on huge multi requests in keeper

### DIFF
--- a/programs/keeper-bench/Runner.cpp
+++ b/programs/keeper-bench/Runner.cpp
@@ -411,7 +411,7 @@ void Runner::thread(std::vector<std::shared_ptr<Coordination::ZooKeeper>> zookee
             tracing_context.trace_id = DB::UUIDHelpers::generateV4();
             tracing_context.span_id = 0;
             tracing_context.trace_flags = DB::OpenTelemetry::TRACE_FLAG_SAMPLED | DB::OpenTelemetry::TRACE_FLAG_KEEPER_SPANS;
-            request->tracing_context = tracing_context;
+            request->tracing_context = std::make_shared<DB::OpenTelemetry::TracingContext>(tracing_context);
         }
 
         InFlightRequest slot;

--- a/programs/keeper-bench/Runner.cpp
+++ b/programs/keeper-bench/Runner.cpp
@@ -407,11 +407,10 @@ void Runner::thread(std::vector<std::shared_ptr<Coordination::ZooKeeper>> zookee
 
         if (enable_tracing)
         {
-            DB::OpenTelemetry::TracingContext tracing_context;
-            tracing_context.trace_id = DB::UUIDHelpers::generateV4();
-            tracing_context.span_id = 0;
-            tracing_context.trace_flags = DB::OpenTelemetry::TRACE_FLAG_SAMPLED | DB::OpenTelemetry::TRACE_FLAG_KEEPER_SPANS;
-            request->tracing_context = std::make_shared<DB::OpenTelemetry::TracingContext>(tracing_context);
+            request->tracing_context = std::make_shared<DB::OpenTelemetry::TracingContext>();
+            request->tracing_context->trace_id = DB::UUIDHelpers::generateV4();
+            request->tracing_context->span_id = 0;
+            request->tracing_context->trace_flags = DB::OpenTelemetry::TRACE_FLAG_SAMPLED | DB::OpenTelemetry::TRACE_FLAG_KEEPER_SPANS;
         }
 
         InFlightRequest slot;

--- a/src/Common/ZooKeeper/KeeperOverDispatcher.cpp
+++ b/src/Common/ZooKeeper/KeeperOverDispatcher.cpp
@@ -70,7 +70,6 @@ void KeeperOverDispatcher::finalize(const String & /* reason */)
 void KeeperOverDispatcher::pushRequest(ZooKeeperRequestPtr request, ResponseCallback callback)
 {
     request->xid = next_xid++;
-    request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
 
     {
         std::lock_guard lock(callback_state->callbacks_mutex);

--- a/src/Common/ZooKeeper/KeeperOverDispatcher.cpp
+++ b/src/Common/ZooKeeper/KeeperOverDispatcher.cpp
@@ -5,6 +5,7 @@
 #include <Common/Exception.h>
 #include <Common/logger_useful.h>
 #include <Common/ZooKeeper/KeeperOverDispatcher.h>
+#include <Common/ZooKeeper/KeeperSpans.h>
 
 namespace DB::ErrorCodes
 {
@@ -69,6 +70,7 @@ void KeeperOverDispatcher::finalize(const String & /* reason */)
 void KeeperOverDispatcher::pushRequest(ZooKeeperRequestPtr request, ResponseCallback callback)
 {
     request->xid = next_xid++;
+    request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
 
     {
         std::lock_guard lock(callback_state->callbacks_mutex);

--- a/src/Common/ZooKeeper/KeeperSpans.cpp
+++ b/src/Common/ZooKeeper/KeeperSpans.cpp
@@ -41,7 +41,7 @@ namespace
 
 void ZooKeeperOpentelemetrySpans::maybeInitialize(
     MaybeSpan & maybe_span,
-    const std::optional<OpenTelemetry::TracingContext> & parent_context,
+    const OpenTelemetry::TracingContext * parent_context,
     UInt64 start_time_us)
 {
     chassert(maybe_span.start_time_us == 0);

--- a/src/Common/ZooKeeper/KeeperSpans.cpp
+++ b/src/Common/ZooKeeper/KeeperSpans.cpp
@@ -1,7 +1,6 @@
 #include <Common/ZooKeeper/KeeperSpans.h>
 #include <Coordination/KeeperDispatcher.h>
 #include <Interpreters/Context.h>
-#include <optional>
 
 namespace DB
 {
@@ -39,26 +38,40 @@ namespace
 #endif
 }
 
+const SpanDescriptor & ZooKeeperOpentelemetrySpans::getSpanDescriptor(KeeperSpan::Operation operation)
+{
+    static const SpanDescriptor descriptors[] = {
+    #define M(NAME, OP_NAME, KIND, HISTOGRAM) \
+        {OP_NAME, OpenTelemetry::SpanKind::KIND, HistogramMetrics::HISTOGRAM},
+        APPLY_FOR_KEEPER_SPANS(M)
+    #undef M
+    };
+    return descriptors[operation];
+}
+
 void ZooKeeperOpentelemetrySpans::maybeInitialize(
-    MaybeSpan & maybe_span,
+    KeeperSpan::Operation operation,
     const OpenTelemetry::TracingContext * parent_context,
     UInt64 start_time_us)
 {
+    auto & maybe_span = maybe_spans[operation];
+
     chassert(maybe_span.start_time_us == 0);
-    chassert(maybe_span.span == std::nullopt);
+    chassert(maybe_span.span == nullptr);
 
     maybe_span.start_time_us = start_time_us;
 
     if (!parent_context)
         return;
 
-    maybe_span.span.emplace(OpenTelemetry::Span{
+    const auto & span_descriptor = getSpanDescriptor(operation);
+    maybe_span.span = std::make_unique<OpenTelemetry::Span>(OpenTelemetry::Span{
         .trace_id = parent_context->trace_id,
         .span_id = thread_local_rng(),
         .parent_span_id = parent_context->span_id,
-        .operation_name = String(maybe_span.operation_name),
+        .operation_name = String(span_descriptor.operation_name),
         .start_time_us = start_time_us,
-        .kind = maybe_span.kind,
+        .kind = span_descriptor.kind,
     });
 }
 
@@ -69,13 +82,7 @@ void ZooKeeperOpentelemetrySpans::maybeFinalizeImpl(
     const String & error_message,
     UInt64 finish_time_us)
 {
-    chassert(maybe_span.start_time_us != 0);
-
-    maybe_span.histogram.observe((finish_time_us - maybe_span.start_time_us) / 1000);
-
-    if (!maybe_span.span)
-        return;
-
+    chassert(maybe_span.span != nullptr);
     chassert(maybe_span.span->start_time_us != 0);
     chassert(maybe_span.span->span_id != 0);
     chassert(maybe_span.span->trace_id != UUID());

--- a/src/Common/ZooKeeper/KeeperSpans.h
+++ b/src/Common/ZooKeeper/KeeperSpans.h
@@ -65,7 +65,7 @@ class ZooKeeperOpentelemetrySpans
 public:
     ZooKeeperOpentelemetrySpans() = default;
     ZooKeeperOpentelemetrySpans(const ZooKeeperOpentelemetrySpans &) : ZooKeeperOpentelemetrySpans() {}
-    ZooKeeperOpentelemetrySpans & operator=(const ZooKeeperOpentelemetrySpans &) { return *this; }
+    ZooKeeperOpentelemetrySpans & operator=(const ZooKeeperOpentelemetrySpans &) { return *this; } // NOLINT(cert-oop54-cpp)
     ZooKeeperOpentelemetrySpans(ZooKeeperOpentelemetrySpans &&) = default;
     ZooKeeperOpentelemetrySpans & operator=(ZooKeeperOpentelemetrySpans &&) = default;
 

--- a/src/Common/ZooKeeper/KeeperSpans.h
+++ b/src/Common/ZooKeeper/KeeperSpans.h
@@ -5,10 +5,9 @@
 #include <Common/thread_local_rng.h>
 #include <Core/Types.h>
 #include <Interpreters/OpenTelemetrySpanLog.h>
-#include <unordered_map>
-#include <string>
+#include <array>
 #include <chrono>
-#include <optional>
+#include <memory>
 
 namespace HistogramMetrics
 {
@@ -23,40 +22,52 @@ namespace HistogramMetrics
     extern Metric & KeeperReadProcessTime;
 }
 
-namespace Coordination
-{
-    struct ZooKeeperRequest;
-}
-
 namespace DB
 {
 
-struct MaybeSpan
-{
-    const std::string_view operation_name;
-    const OpenTelemetry::SpanKind kind;
-    HistogramMetrics::Metric & histogram;
-    std::optional<OpenTelemetry::Span> span;
-    UInt64 start_time_us = 0;
+#define APPLY_FOR_KEEPER_SPANS(M) \
+    M(ClientRequestsQueue,      "zookeeper.client.requests_queue",    INTERNAL, KeeperClientQueueDuration) \
+    M(ReceiveRequest,           "keeper.receive_request",             SERVER,   KeeperReceiveRequestTime) \
+    M(DispatcherRequestsQueue,  "keeper.dispatcher.requests_queue",   INTERNAL, KeeperDispatcherRequestsQueueTime) \
+    M(DispatcherResponsesQueue, "keeper.dispatcher.responses_queue",  INTERNAL, KeeperDispatcherResponsesQueueTime) \
+    M(SendResponse,             "keeper.send_response",               SERVER,   KeeperSendResponseTime) \
+    M(ReadWaitForWrite,         "keeper.read.wait_for_write",         INTERNAL, KeeperReadWaitForWriteTime) \
+    M(ReadProcess,              "keeper.read.process",                INTERNAL, KeeperReadProcessTime) \
+    M(PreCommit,                "keeper.write.pre_commit",            INTERNAL, KeeperWritePreCommitTime) \
+    M(Commit,                   "keeper.write.commit",                INTERNAL, KeeperWriteCommitTime) \
 
-    MaybeSpan(const std::string_view operation_name_, OpenTelemetry::SpanKind kind_, HistogramMetrics::Metric & histogram_)
-        : operation_name(operation_name_), kind(kind_), histogram(histogram_) {}
+namespace KeeperSpan
+{
+    enum Operation : size_t
+    {
+    #define M(NAME, ...) NAME,
+        APPLY_FOR_KEEPER_SPANS(M)
+    #undef M
+        Count
+    };
+}
+
+struct SpanDescriptor
+{
+    std::string_view operation_name;
+    OpenTelemetry::SpanKind kind;
+    HistogramMetrics::Metric & histogram;
 };
 
-struct ZooKeeperOpentelemetrySpans
+struct MaybeSpan
 {
-    // Keeper client spans
-    MaybeSpan client_requests_queue{"zookeeper.client.requests_queue", OpenTelemetry::SpanKind::INTERNAL, HistogramMetrics::KeeperClientQueueDuration};
+    std::unique_ptr<OpenTelemetry::Span> span;
+    UInt64 start_time_us = 0;
+};
 
-    // Keeper server spans
-    MaybeSpan receive_request{"keeper.receive_request", OpenTelemetry::SpanKind::SERVER, HistogramMetrics::KeeperReceiveRequestTime};
-    MaybeSpan dispatcher_requests_queue{"keeper.dispatcher.requests_queue", OpenTelemetry::SpanKind::INTERNAL, HistogramMetrics::KeeperDispatcherRequestsQueueTime};
-    MaybeSpan dispatcher_responses_queue{"keeper.dispatcher.responses_queue", OpenTelemetry::SpanKind::INTERNAL, HistogramMetrics::KeeperDispatcherResponsesQueueTime};
-    MaybeSpan send_response{"keeper.send_response", OpenTelemetry::SpanKind::SERVER, HistogramMetrics::KeeperSendResponseTime};
-    MaybeSpan read_wait_for_write{"keeper.read.wait_for_write", OpenTelemetry::SpanKind::INTERNAL, HistogramMetrics::KeeperReadWaitForWriteTime};
-    MaybeSpan read_process{"keeper.read.process", OpenTelemetry::SpanKind::INTERNAL, HistogramMetrics::KeeperReadProcessTime};
-    MaybeSpan pre_commit{"keeper.write.pre_commit", OpenTelemetry::SpanKind::INTERNAL, HistogramMetrics::KeeperWritePreCommitTime};
-    MaybeSpan commit{"keeper.write.commit", OpenTelemetry::SpanKind::INTERNAL, HistogramMetrics::KeeperWriteCommitTime};
+class ZooKeeperOpentelemetrySpans
+{
+public:
+    ZooKeeperOpentelemetrySpans() = default;
+    ZooKeeperOpentelemetrySpans(const ZooKeeperOpentelemetrySpans &) : ZooKeeperOpentelemetrySpans() {}
+    ZooKeeperOpentelemetrySpans & operator=(const ZooKeeperOpentelemetrySpans &) { return *this; }
+    ZooKeeperOpentelemetrySpans(ZooKeeperOpentelemetrySpans &&) = default;
+    ZooKeeperOpentelemetrySpans & operator=(ZooKeeperOpentelemetrySpans &&) = default;
 
     static UInt64 now()
     {
@@ -64,28 +75,32 @@ struct ZooKeeperOpentelemetrySpans
             std::chrono::system_clock::now().time_since_epoch()).count();
     }
 
-    static void maybeInitialize(
-        MaybeSpan & maybe_span,
+    void maybeInitialize(
+        KeeperSpan::Operation operation,
         const OpenTelemetry::TracingContext * parent_context,
         UInt64 start_time_us = now());
 
     template <typename MakeAttributes>
-    static void maybeFinalize(
-        MaybeSpan & maybe_span,
+    void maybeFinalize(
+        KeeperSpan::Operation operation,
         MakeAttributes && make_attributes,
         OpenTelemetry::SpanStatus status = OpenTelemetry::SpanStatus::OK,
         const String & error_message = {},
         UInt64 finish_time_us = now())
     {
+        auto & maybe_span = maybe_spans[operation];
+
+        chassert(maybe_span.start_time_us != 0);
+        getSpanDescriptor(operation).histogram.observe((finish_time_us - maybe_span.start_time_us) / 1000);
+
         if (!maybe_span.span)
-        {
-            chassert(maybe_span.start_time_us != 0);
-            maybe_span.histogram.observe((finish_time_us - maybe_span.start_time_us) / 1000);
             return;
-        }
 
         maybeFinalizeImpl(maybe_span, make_attributes(), status, error_message, finish_time_us);
     }
+
+private:
+    static const SpanDescriptor & getSpanDescriptor(KeeperSpan::Operation operation);
 
     static void maybeFinalizeImpl(
         MaybeSpan & maybe_span,
@@ -93,6 +108,8 @@ struct ZooKeeperOpentelemetrySpans
         OpenTelemetry::SpanStatus status = OpenTelemetry::SpanStatus::OK,
         const String & error_message = {},
         UInt64 finish_time_us = now());
+
+    std::array<MaybeSpan, KeeperSpan::Count> maybe_spans = {};
 };
 
 }

--- a/src/Common/ZooKeeper/KeeperSpans.h
+++ b/src/Common/ZooKeeper/KeeperSpans.h
@@ -66,7 +66,7 @@ struct ZooKeeperOpentelemetrySpans
 
     static void maybeInitialize(
         MaybeSpan & maybe_span,
-        const std::optional<OpenTelemetry::TracingContext> & parent_context,
+        const OpenTelemetry::TracingContext * parent_context,
         UInt64 start_time_us = now());
 
     template <typename MakeAttributes>

--- a/src/Common/ZooKeeper/ZooKeeperCommon.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.cpp
@@ -1600,7 +1600,7 @@ ZooKeeperRequestPtr ZooKeeperRequestFactory::get(OpNum op_num) const
         throw Exception(Error::ZBADARGUMENTS, "Unknown operation type {}", op_num);
 
     auto request = it->second();
-    request->spans = std::make_unique<DB::ZooKeeperOpentelemetrySpans>();
+    request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
     return request;
 }
 

--- a/src/Common/ZooKeeper/ZooKeeperCommon.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.cpp
@@ -72,7 +72,7 @@ void ZooKeeperRequest::write(WriteBuffer & out, bool use_xid_64, bool supports_t
 
     if (supports_tracing)
     {
-        const uint8_t has_tracing_context = tracing_context.has_value();
+        const uint8_t has_tracing_context = tracing_context != nullptr;
         Coordination::write(has_tracing_context, out);
         if (has_tracing_context)
         {
@@ -1170,6 +1170,7 @@ void ZooKeeperMultiRequest::readImpl(ReadBuffer & in, RequestValidator request_v
         request->readImpl(in);
         if (request_validator)
             request_validator(*request);
+        request->spans.reset();
         requests.push_back(request);
 
         if (in.eof())
@@ -1598,7 +1599,9 @@ ZooKeeperRequestPtr ZooKeeperRequestFactory::get(OpNum op_num) const
     if (it == op_num_to_request.end())
         throw Exception(Error::ZBADARGUMENTS, "Unknown operation type {}", op_num);
 
-    return it->second();
+    auto request = it->second();
+    request->spans = std::make_unique<DB::ZooKeeperOpentelemetrySpans>();
+    return request;
 }
 
 ZooKeeperRequestFactory & ZooKeeperRequestFactory::instance()

--- a/src/Common/ZooKeeper/ZooKeeperCommon.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.cpp
@@ -1170,7 +1170,6 @@ void ZooKeeperMultiRequest::readImpl(ReadBuffer & in, RequestValidator request_v
         request->readImpl(in);
         if (request_validator)
             request_validator(*request);
-        request->spans.reset();
         requests.push_back(request);
 
         if (in.eof())
@@ -1600,7 +1599,6 @@ ZooKeeperRequestPtr ZooKeeperRequestFactory::get(OpNum op_num) const
         throw Exception(Error::ZBADARGUMENTS, "Unknown operation type {}", op_num);
 
     auto request = it->second();
-    request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
     return request;
 }
 

--- a/src/Common/ZooKeeper/ZooKeeperCommon.h
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.h
@@ -63,11 +63,11 @@ struct ZooKeeperRequest : virtual Request
 
     std::chrono::steady_clock::time_point create_ts = {};
 
-    std::optional<OpenTelemetry::TracingContext> tracing_context;
-    DB::ZooKeeperOpentelemetrySpans spans;
+    std::unique_ptr<OpenTelemetry::TracingContext> tracing_context;
+    std::unique_ptr<DB::ZooKeeperOpentelemetrySpans> spans;
 
     ZooKeeperRequest() = default;
-    ZooKeeperRequest(const ZooKeeperRequest &) = default;
+    ZooKeeperRequest(const ZooKeeperRequest &) = delete;
 
     virtual OpNum getOpNum() const = 0;
     virtual int32_t tryGetOpNum() const { return static_cast<int32_t>(getOpNum()); }

--- a/src/Common/ZooKeeper/ZooKeeperCommon.h
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.h
@@ -63,11 +63,11 @@ struct ZooKeeperRequest : virtual Request
 
     std::chrono::steady_clock::time_point create_ts = {};
 
-    std::unique_ptr<OpenTelemetry::TracingContext> tracing_context;
-    std::unique_ptr<DB::ZooKeeperOpentelemetrySpans> spans;
+    std::shared_ptr<OpenTelemetry::TracingContext> tracing_context;
+    std::shared_ptr<DB::ZooKeeperOpentelemetrySpans> spans;
 
     ZooKeeperRequest() = default;
-    ZooKeeperRequest(const ZooKeeperRequest &) = delete;
+    ZooKeeperRequest(const ZooKeeperRequest &) = default;
     ZooKeeperRequest(ZooKeeperRequest &&) = default;
 
     virtual OpNum getOpNum() const = 0;

--- a/src/Common/ZooKeeper/ZooKeeperCommon.h
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.h
@@ -68,6 +68,7 @@ struct ZooKeeperRequest : virtual Request
 
     ZooKeeperRequest() = default;
     ZooKeeperRequest(const ZooKeeperRequest &) = delete;
+    ZooKeeperRequest(ZooKeeperRequest &&) = default;
 
     virtual OpNum getOpNum() const = 0;
     virtual int32_t tryGetOpNum() const { return static_cast<int32_t>(getOpNum()); }

--- a/src/Common/ZooKeeper/ZooKeeperCommon.h
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.h
@@ -64,7 +64,7 @@ struct ZooKeeperRequest : virtual Request
     std::chrono::steady_clock::time_point create_ts = {};
 
     std::shared_ptr<OpenTelemetry::TracingContext> tracing_context;
-    std::shared_ptr<DB::ZooKeeperOpentelemetrySpans> spans;
+    DB::ZooKeeperOpentelemetrySpans spans;
 
     ZooKeeperRequest() = default;
     ZooKeeperRequest(const ZooKeeperRequest &) = default;

--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -1504,14 +1504,14 @@ void ZooKeeper::pushRequest(RequestInfo && info)
         }
 
         maybeInjectSendFault();
-        info.request->spans = std::make_unique<DB::ZooKeeperOpentelemetrySpans>();
+        info.request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
 
         if (
             const auto & current_trace_context = OpenTelemetry::CurrentContext();
             current_trace_context.isTraceEnabled() && current_trace_context.trace_flags & DB::OpenTelemetry::TRACE_FLAG_KEEPER_SPANS
         )
         {
-            info.request->tracing_context = std::make_unique<OpenTelemetry::TracingContext>(current_trace_context);
+            info.request->tracing_context = std::make_shared<OpenTelemetry::TracingContext>(current_trace_context);
         }
 
         ZooKeeperOpentelemetrySpans::maybeInitialize(info.request->spans->client_requests_queue, info.request->tracing_context.get());
@@ -1951,7 +1951,7 @@ void ZooKeeper::close()
 
     RequestInfo request_info;
     request_info.request = std::make_shared<ZooKeeperCloseRequest>(std::move(request));
-    request_info.request->spans = std::make_unique<DB::ZooKeeperOpentelemetrySpans>();
+    request_info.request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
 
     ZooKeeperOpentelemetrySpans::maybeInitialize(request_info.request->spans->client_requests_queue, request_info.request->tracing_context.get());
 

--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -827,8 +827,8 @@ void ZooKeeper::sendThread()
                     /// After we popped element from the queue, we must register callbacks (even in the case when expired == true right now),
                     ///  because they must not be lost (callbacks must be called because the user will wait for them).
 
-                    ZooKeeperOpentelemetrySpans::maybeFinalize(
-                        info.request->spans->client_requests_queue,
+                    info.request->spans.maybeFinalize(
+                        KeeperSpan::ClientRequestsQueue,
                         [&]
                         {
                             return std::vector<OpenTelemetry::SpanAttribute>{
@@ -1504,7 +1504,6 @@ void ZooKeeper::pushRequest(RequestInfo && info)
         }
 
         maybeInjectSendFault();
-        info.request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
 
         if (
             const auto & current_trace_context = OpenTelemetry::CurrentContext();
@@ -1514,7 +1513,7 @@ void ZooKeeper::pushRequest(RequestInfo && info)
             info.request->tracing_context = std::make_shared<OpenTelemetry::TracingContext>(current_trace_context);
         }
 
-        ZooKeeperOpentelemetrySpans::maybeInitialize(info.request->spans->client_requests_queue, info.request->tracing_context.get());
+        info.request->spans.maybeInitialize(KeeperSpan::ClientRequestsQueue, info.request->tracing_context.get());
 
         if (!requests_queue.tryPush(std::move(info), args.operation_timeout_ms))
         {
@@ -1951,9 +1950,8 @@ void ZooKeeper::close()
 
     RequestInfo request_info;
     request_info.request = std::make_shared<ZooKeeperCloseRequest>(std::move(request));
-    request_info.request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
 
-    ZooKeeperOpentelemetrySpans::maybeInitialize(request_info.request->spans->client_requests_queue, request_info.request->tracing_context.get());
+    request_info.request->spans.maybeInitialize(KeeperSpan::ClientRequestsQueue, request_info.request->tracing_context.get());
 
     if (!requests_queue.tryPush(std::move(request_info), args.operation_timeout_ms))
         throw Exception(Error::ZOPERATIONTIMEOUT, "Cannot push close request to queue within operation timeout of {} ms", args.operation_timeout_ms);

--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -828,7 +828,7 @@ void ZooKeeper::sendThread()
                     ///  because they must not be lost (callbacks must be called because the user will wait for them).
 
                     ZooKeeperOpentelemetrySpans::maybeFinalize(
-                        info.request->spans.client_requests_queue,
+                        info.request->spans->client_requests_queue,
                         [&]
                         {
                             return std::vector<OpenTelemetry::SpanAttribute>{
@@ -1504,16 +1504,17 @@ void ZooKeeper::pushRequest(RequestInfo && info)
         }
 
         maybeInjectSendFault();
+        info.request->spans = std::make_unique<DB::ZooKeeperOpentelemetrySpans>();
 
         if (
             const auto & current_trace_context = OpenTelemetry::CurrentContext();
             current_trace_context.isTraceEnabled() && current_trace_context.trace_flags & DB::OpenTelemetry::TRACE_FLAG_KEEPER_SPANS
         )
         {
-            info.request->tracing_context = current_trace_context;
+            info.request->tracing_context = std::make_unique<OpenTelemetry::TracingContext>(current_trace_context);
         }
 
-        ZooKeeperOpentelemetrySpans::maybeInitialize(info.request->spans.client_requests_queue, info.request->tracing_context);
+        ZooKeeperOpentelemetrySpans::maybeInitialize(info.request->spans->client_requests_queue, info.request->tracing_context.get());
 
         if (!requests_queue.tryPush(std::move(info), args.operation_timeout_ms))
         {
@@ -1950,8 +1951,9 @@ void ZooKeeper::close()
 
     RequestInfo request_info;
     request_info.request = std::make_shared<ZooKeeperCloseRequest>(std::move(request));
+    request_info.request->spans = std::make_unique<DB::ZooKeeperOpentelemetrySpans>();
 
-    ZooKeeperOpentelemetrySpans::maybeInitialize(request_info.request->spans.client_requests_queue, request_info.request->tracing_context);
+    ZooKeeperOpentelemetrySpans::maybeInitialize(request_info.request->spans->client_requests_queue, request_info.request->tracing_context.get());
 
     if (!requests_queue.tryPush(std::move(request_info), args.operation_timeout_ms))
         throw Exception(Error::ZOPERATIONTIMEOUT, "Cannot push close request to queue within operation timeout of {} ms", args.operation_timeout_ms);

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -674,6 +674,8 @@ bool KeeperDispatcher::putRequest(const Coordination::ZooKeeperRequestPtr & requ
     if (keeper_context->isShutdownCalled())
         return false;
 
+    if (!request->spans)
+        request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
     ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
 
     /// Put close requests without timeouts
@@ -1021,7 +1023,9 @@ void KeeperDispatcher::sessionCleanerTask()
                     auto request = Coordination::ZooKeeperRequestFactory::instance().get(Coordination::OpNum::Close);
                     request->xid = Coordination::CLOSE_XID;
 
-                    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
+                    if (!request->spans)
+        request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
+    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
 
                     using namespace std::chrono;
                     KeeperRequestForSession request_info
@@ -1215,6 +1219,8 @@ int64_t KeeperDispatcher::getSessionID(int64_t session_timeout_ms)
         };
     }
 
+    if (!request->spans)
+        request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
     ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
 
     /// Push new session request to queue

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -179,8 +179,8 @@ void KeeperDispatcher::requestThread()
     {
         const auto handle_opentelemetry_spans = [this](const Coordination::ZooKeeperRequestPtr & request, int64_t session_id)
         {
-            ZooKeeperOpentelemetrySpans::maybeFinalize(
-                request->spans->dispatcher_requests_queue,
+            request->spans.maybeFinalize(
+                KeeperSpan::DispatcherRequestsQueue,
                 [&]
                 {
                     return std::vector<OpenTelemetry::SpanAttribute>{
@@ -253,8 +253,8 @@ void KeeperDispatcher::requestThread()
                         /// Finalize the dispatcher_requests_queue span that was initialized
                         /// when the request was enqueued. Without this the span leaks because
                         /// handle_opentelemetry_spans (which normally finalizes it) is skipped.
-                        ZooKeeperOpentelemetrySpans::maybeFinalize(
-                            req.request->spans->dispatcher_requests_queue,
+                        req.request->spans.maybeFinalize(
+                            KeeperSpan::DispatcherRequestsQueue,
                             [&]
                             {
                                 return std::vector<OpenTelemetry::SpanAttribute>{
@@ -328,7 +328,7 @@ void KeeperDispatcher::requestThread()
                         if (!quorum_reads && request.request->isReadRequest())
                         {
                             const auto & last_request = current_batch.back();
-                            ZooKeeperOpentelemetrySpans::maybeInitialize(request.request->spans->read_wait_for_write, request.request->tracing_context.get());
+                            request.request->spans.maybeInitialize(KeeperSpan::ReadWaitForWrite, request.request->tracing_context.get());
                             ProfiledMutexLock lock(read_request_queue_mutex, ProfileEvents::KeeperReadRequestQueueLockWaitMicroseconds);
                             reads_count += 1;
                             reads_bytes_size += request.request->bytesSize();
@@ -553,8 +553,8 @@ void KeeperDispatcher::responseThread()
 
             if (response_was_sent && response_for_session.request)
             {
-                ZooKeeperOpentelemetrySpans::maybeFinalize(
-                    response_for_session.request->spans->dispatcher_responses_queue,
+                response_for_session.request->spans.maybeFinalize(
+                    KeeperSpan::DispatcherResponsesQueue,
                     [&]
                     {
                         return std::vector<OpenTelemetry::SpanAttribute>{
@@ -674,7 +674,7 @@ bool KeeperDispatcher::putRequest(const Coordination::ZooKeeperRequestPtr & requ
     if (keeper_context->isShutdownCalled())
         return false;
 
-    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
+    request->spans.maybeInitialize(KeeperSpan::DispatcherRequestsQueue, request->tracing_context.get());
 
     /// Put close requests without timeouts
     if (request->getOpNum() == Coordination::OpNum::Close)
@@ -747,8 +747,8 @@ void KeeperDispatcher::initialize(const Poco::Util::AbstractConfiguration & conf
                     if (!last_checked_session_live)
                     {
                         ProfileEvents::increment(ProfileEvents::KeeperStaleRequestsSkipped);
-                        ZooKeeperOpentelemetrySpans::maybeFinalize(
-                            read_request.request->spans->read_wait_for_write,
+                        read_request.request->spans.maybeFinalize(
+                            KeeperSpan::ReadWaitForWrite,
                             [&]
                             {
                                 return std::vector<OpenTelemetry::SpanAttribute>{
@@ -771,8 +771,8 @@ void KeeperDispatcher::initialize(const Poco::Util::AbstractConfiguration & conf
             {
                 for (auto & read_request : pending_reads)
                 {
-                    ZooKeeperOpentelemetrySpans::maybeFinalize(
-                        read_request.request->spans->read_wait_for_write,
+                    read_request.request->spans.maybeFinalize(
+                        KeeperSpan::ReadWaitForWrite,
                         [&]
                         {
                             return std::vector<OpenTelemetry::SpanAttribute>{
@@ -1021,7 +1021,7 @@ void KeeperDispatcher::sessionCleanerTask()
                     auto request = Coordination::ZooKeeperRequestFactory::instance().get(Coordination::OpNum::Close);
                     request->xid = Coordination::CLOSE_XID;
 
-                    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
+                    request->spans.maybeInitialize(KeeperSpan::DispatcherRequestsQueue, request->tracing_context.get());
 
                     using namespace std::chrono;
                     KeeperRequestForSession request_info
@@ -1170,7 +1170,6 @@ int64_t KeeperDispatcher::getSessionID(int64_t session_timeout_ms)
     request->internal_id = internal_session_id_counter.fetch_add(1);
     request->session_timeout_ms = session_timeout_ms;
     request->server_id = server->getServerID();
-    request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
 
     request_info.request = request;
     using namespace std::chrono;
@@ -1215,9 +1214,7 @@ int64_t KeeperDispatcher::getSessionID(int64_t session_timeout_ms)
         };
     }
 
-    if (!request->spans)
-        request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
-    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
+    request->spans.maybeInitialize(KeeperSpan::DispatcherRequestsQueue, request->tracing_context.get());
 
     /// Push new session request to queue
     if (!requests_queue->tryPush(std::move(request_info), session_timeout_ms))

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -1170,7 +1170,7 @@ int64_t KeeperDispatcher::getSessionID(int64_t session_timeout_ms)
     request->internal_id = internal_session_id_counter.fetch_add(1);
     request->session_timeout_ms = session_timeout_ms;
     request->server_id = server->getServerID();
-    request->spans = std::make_unique<DB::ZooKeeperOpentelemetrySpans>();
+    request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
 
     request_info.request = request;
     using namespace std::chrono;

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -674,8 +674,6 @@ bool KeeperDispatcher::putRequest(const Coordination::ZooKeeperRequestPtr & requ
     if (keeper_context->isShutdownCalled())
         return false;
 
-    if (!request->spans)
-        request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
     ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
 
     /// Put close requests without timeouts
@@ -1023,9 +1021,7 @@ void KeeperDispatcher::sessionCleanerTask()
                     auto request = Coordination::ZooKeeperRequestFactory::instance().get(Coordination::OpNum::Close);
                     request->xid = Coordination::CLOSE_XID;
 
-                    if (!request->spans)
-        request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
-    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
+                    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
 
                     using namespace std::chrono;
                     KeeperRequestForSession request_info

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -180,7 +180,7 @@ void KeeperDispatcher::requestThread()
         const auto handle_opentelemetry_spans = [this](const Coordination::ZooKeeperRequestPtr & request, int64_t session_id)
         {
             ZooKeeperOpentelemetrySpans::maybeFinalize(
-                request->spans.dispatcher_requests_queue,
+                request->spans->dispatcher_requests_queue,
                 [&]
                 {
                     return std::vector<OpenTelemetry::SpanAttribute>{
@@ -254,7 +254,7 @@ void KeeperDispatcher::requestThread()
                         /// when the request was enqueued. Without this the span leaks because
                         /// handle_opentelemetry_spans (which normally finalizes it) is skipped.
                         ZooKeeperOpentelemetrySpans::maybeFinalize(
-                            req.request->spans.dispatcher_requests_queue,
+                            req.request->spans->dispatcher_requests_queue,
                             [&]
                             {
                                 return std::vector<OpenTelemetry::SpanAttribute>{
@@ -328,7 +328,7 @@ void KeeperDispatcher::requestThread()
                         if (!quorum_reads && request.request->isReadRequest())
                         {
                             const auto & last_request = current_batch.back();
-                            ZooKeeperOpentelemetrySpans::maybeInitialize(request.request->spans.read_wait_for_write, request.request->tracing_context);
+                            ZooKeeperOpentelemetrySpans::maybeInitialize(request.request->spans->read_wait_for_write, request.request->tracing_context.get());
                             ProfiledMutexLock lock(read_request_queue_mutex, ProfileEvents::KeeperReadRequestQueueLockWaitMicroseconds);
                             reads_count += 1;
                             reads_bytes_size += request.request->bytesSize();
@@ -554,7 +554,7 @@ void KeeperDispatcher::responseThread()
             if (response_was_sent && response_for_session.request)
             {
                 ZooKeeperOpentelemetrySpans::maybeFinalize(
-                    response_for_session.request->spans.dispatcher_responses_queue,
+                    response_for_session.request->spans->dispatcher_responses_queue,
                     [&]
                     {
                         return std::vector<OpenTelemetry::SpanAttribute>{
@@ -674,7 +674,7 @@ bool KeeperDispatcher::putRequest(const Coordination::ZooKeeperRequestPtr & requ
     if (keeper_context->isShutdownCalled())
         return false;
 
-    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans.dispatcher_requests_queue, request->tracing_context);
+    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
 
     /// Put close requests without timeouts
     if (request->getOpNum() == Coordination::OpNum::Close)
@@ -748,7 +748,7 @@ void KeeperDispatcher::initialize(const Poco::Util::AbstractConfiguration & conf
                     {
                         ProfileEvents::increment(ProfileEvents::KeeperStaleRequestsSkipped);
                         ZooKeeperOpentelemetrySpans::maybeFinalize(
-                            read_request.request->spans.read_wait_for_write,
+                            read_request.request->spans->read_wait_for_write,
                             [&]
                             {
                                 return std::vector<OpenTelemetry::SpanAttribute>{
@@ -772,7 +772,7 @@ void KeeperDispatcher::initialize(const Poco::Util::AbstractConfiguration & conf
                 for (auto & read_request : pending_reads)
                 {
                     ZooKeeperOpentelemetrySpans::maybeFinalize(
-                        read_request.request->spans.read_wait_for_write,
+                        read_request.request->spans->read_wait_for_write,
                         [&]
                         {
                             return std::vector<OpenTelemetry::SpanAttribute>{
@@ -1021,7 +1021,7 @@ void KeeperDispatcher::sessionCleanerTask()
                     auto request = Coordination::ZooKeeperRequestFactory::instance().get(Coordination::OpNum::Close);
                     request->xid = Coordination::CLOSE_XID;
 
-                    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans.dispatcher_requests_queue, request->tracing_context);
+                    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
 
                     using namespace std::chrono;
                     KeeperRequestForSession request_info
@@ -1170,6 +1170,7 @@ int64_t KeeperDispatcher::getSessionID(int64_t session_timeout_ms)
     request->internal_id = internal_session_id_counter.fetch_add(1);
     request->session_timeout_ms = session_timeout_ms;
     request->server_id = server->getServerID();
+    request->spans = std::make_unique<DB::ZooKeeperOpentelemetrySpans>();
 
     request_info.request = request;
     using namespace std::chrono;
@@ -1214,7 +1215,7 @@ int64_t KeeperDispatcher::getSessionID(int64_t session_timeout_ms)
         };
     }
 
-    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans.dispatcher_requests_queue, request->tracing_context);
+    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
 
     /// Push new session request to queue
     if (!requests_queue->tryPush(std::move(request_info), session_timeout_ms))

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -277,12 +277,12 @@ nuraft::ptr<nuraft::buffer> KeeperStateMachine<Storage>::pre_commit(uint64_t log
     const auto maybe_log_opentelemetry_span = [&](OpenTelemetry::SpanStatus status, const std::string & error_message)
     {
         ZooKeeperOpentelemetrySpans::maybeInitialize(
-            request_for_session->request->spans.pre_commit,
-            request_for_session->request->tracing_context,
+            request_for_session->request->spans->pre_commit,
+            request_for_session->request->tracing_context.get(),
             start_time_us);
 
         ZooKeeperOpentelemetrySpans::maybeFinalize(
-            request_for_session->request->spans.pre_commit,
+            request_for_session->request->spans->pre_commit,
             [&]
             {
                 return std::vector<OpenTelemetry::SpanAttribute>{
@@ -413,12 +413,12 @@ std::shared_ptr<KeeperRequestForSession> IKeeperStateMachine::parseRequest(
         xid_helper.xid = static_cast<int32_t>(xid_helper.parts.lower);
     }
 
-    std::optional<OpenTelemetry::TracingContext> tracing_context;
+    std::unique_ptr<OpenTelemetry::TracingContext> tracing_context;
     if (!buffer.eof())
     {
         version = WITH_OPTIONAL_TRACING_CONTEXT;
 
-        tracing_context.emplace();
+        tracing_context = std::make_unique<OpenTelemetry::TracingContext>();
         tracing_context->deserialize(buffer);
     }
 
@@ -628,7 +628,7 @@ nuraft::ptr<nuraft::buffer> KeeperStateMachine<Storage>::commit(const uint64_t l
     {
         response.response->enqueue_ts = std::chrono::steady_clock::now();
         if (response.request)
-            ZooKeeperOpentelemetrySpans::maybeInitialize(response.request->spans.dispatcher_responses_queue, response.request->tracing_context);
+            ZooKeeperOpentelemetrySpans::maybeInitialize(response.request->spans->dispatcher_responses_queue, response.request->tracing_context.get());
         if (!responses_queue.push(response))
         {
             ProfileEvents::increment(ProfileEvents::KeeperCommitsFailed);
@@ -641,12 +641,12 @@ nuraft::ptr<nuraft::buffer> KeeperStateMachine<Storage>::commit(const uint64_t l
     const auto maybe_log_opentelemetry_span = [&](OpenTelemetry::SpanStatus status, const std::string & error_message)
     {
         ZooKeeperOpentelemetrySpans::maybeInitialize(
-            request_for_session->request->spans.commit,
-            request_for_session->request->tracing_context,
+            request_for_session->request->spans->commit,
+            request_for_session->request->tracing_context.get(),
             start_time_us);
 
         ZooKeeperOpentelemetrySpans::maybeFinalize(
-            request_for_session->request->spans.commit,
+            request_for_session->request->spans->commit,
             [&]
             {
                 return std::vector<OpenTelemetry::SpanAttribute>{
@@ -1480,7 +1480,7 @@ void KeeperStateMachine<Storage>::processReadRequests(const KeeperRequestsForSes
         if (response_for_session.response->xid != Coordination::WATCH_XID)
         {
             chassert(response_for_session.request);
-            ZooKeeperOpentelemetrySpans::maybeInitialize(response_for_session.request->spans.dispatcher_responses_queue, response_for_session.request->tracing_context);
+            ZooKeeperOpentelemetrySpans::maybeInitialize(response_for_session.request->spans->dispatcher_responses_queue, response_for_session.request->tracing_context.get());
         }
         if (!responses_queue.push(response_for_session))
             LOG_WARNING(log, "Failed to push response with session id {} to the queue, probably because of shutdown", response_for_session.session_id);

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -276,13 +276,13 @@ nuraft::ptr<nuraft::buffer> KeeperStateMachine<Storage>::pre_commit(uint64_t log
 
     const auto maybe_log_opentelemetry_span = [&](OpenTelemetry::SpanStatus status, const std::string & error_message)
     {
-        ZooKeeperOpentelemetrySpans::maybeInitialize(
-            request_for_session->request->spans->pre_commit,
+        request_for_session->request->spans.maybeInitialize(
+            KeeperSpan::PreCommit,
             request_for_session->request->tracing_context.get(),
             start_time_us);
 
-        ZooKeeperOpentelemetrySpans::maybeFinalize(
-            request_for_session->request->spans->pre_commit,
+        request_for_session->request->spans.maybeFinalize(
+            KeeperSpan::PreCommit,
             [&]
             {
                 return std::vector<OpenTelemetry::SpanAttribute>{
@@ -628,7 +628,7 @@ nuraft::ptr<nuraft::buffer> KeeperStateMachine<Storage>::commit(const uint64_t l
     {
         response.response->enqueue_ts = std::chrono::steady_clock::now();
         if (response.request)
-            ZooKeeperOpentelemetrySpans::maybeInitialize(response.request->spans->dispatcher_responses_queue, response.request->tracing_context.get());
+            response.request->spans.maybeInitialize(KeeperSpan::DispatcherResponsesQueue, response.request->tracing_context.get());
         if (!responses_queue.push(response))
         {
             ProfileEvents::increment(ProfileEvents::KeeperCommitsFailed);
@@ -640,13 +640,13 @@ nuraft::ptr<nuraft::buffer> KeeperStateMachine<Storage>::commit(const uint64_t l
 
     const auto maybe_log_opentelemetry_span = [&](OpenTelemetry::SpanStatus status, const std::string & error_message)
     {
-        ZooKeeperOpentelemetrySpans::maybeInitialize(
-            request_for_session->request->spans->commit,
+        request_for_session->request->spans.maybeInitialize(
+            KeeperSpan::Commit,
             request_for_session->request->tracing_context.get(),
             start_time_us);
 
-        ZooKeeperOpentelemetrySpans::maybeFinalize(
-            request_for_session->request->spans->commit,
+        request_for_session->request->spans.maybeFinalize(
+            KeeperSpan::Commit,
             [&]
             {
                 return std::vector<OpenTelemetry::SpanAttribute>{
@@ -1480,7 +1480,7 @@ void KeeperStateMachine<Storage>::processReadRequests(const KeeperRequestsForSes
         if (response_for_session.response->xid != Coordination::WATCH_XID)
         {
             chassert(response_for_session.request);
-            ZooKeeperOpentelemetrySpans::maybeInitialize(response_for_session.request->spans->dispatcher_responses_queue, response_for_session.request->tracing_context.get());
+            response_for_session.request->spans.maybeInitialize(KeeperSpan::DispatcherResponsesQueue, response_for_session.request->tracing_context.get());
         }
         if (!responses_queue.push(response_for_session))
             LOG_WARNING(log, "Failed to push response with session id {} to the queue, probably because of shutdown", response_for_session.session_id);

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -418,7 +418,7 @@ std::shared_ptr<KeeperRequestForSession> IKeeperStateMachine::parseRequest(
     {
         version = WITH_OPTIONAL_TRACING_CONTEXT;
 
-        tracing_context = std::make_unique<OpenTelemetry::TracingContext>();
+        tracing_context = std::make_shared<OpenTelemetry::TracingContext>();
         tracing_context->deserialize(buffer);
     }
 

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -413,7 +413,7 @@ std::shared_ptr<KeeperRequestForSession> IKeeperStateMachine::parseRequest(
         xid_helper.xid = static_cast<int32_t>(xid_helper.parts.lower);
     }
 
-    std::unique_ptr<OpenTelemetry::TracingContext> tracing_context;
+    std::shared_ptr<OpenTelemetry::TracingContext> tracing_context;
     if (!buffer.eof())
     {
         version = WITH_OPTIONAL_TRACING_CONTEXT;

--- a/src/Coordination/KeeperStorage.cpp
+++ b/src/Coordination/KeeperStorage.cpp
@@ -4067,12 +4067,12 @@ KeeperResponsesForSessions KeeperStorage<Container>::processLocalRequests(
                 const auto maybe_log_opentelemetry_span = [&](OpenTelemetry::SpanStatus status, const std::string & error_message)
                 {
                     ZooKeeperOpentelemetrySpans::maybeInitialize(
-                        concrete_zk_request.spans.read_process,
-                        concrete_zk_request.tracing_context,
+                        concrete_zk_request.spans->read_process,
+                        concrete_zk_request.tracing_context.get(),
                         start_time_us);
 
                     ZooKeeperOpentelemetrySpans::maybeFinalize(
-                        concrete_zk_request.spans.read_process,
+                        concrete_zk_request.spans->read_process,
                         [&]
                         {
                             return std::vector<OpenTelemetry::SpanAttribute>{

--- a/src/Coordination/KeeperStorage.cpp
+++ b/src/Coordination/KeeperStorage.cpp
@@ -4066,13 +4066,13 @@ KeeperResponsesForSessions KeeperStorage<Container>::processLocalRequests(
             {
                 const auto maybe_log_opentelemetry_span = [&](OpenTelemetry::SpanStatus status, const std::string & error_message)
                 {
-                    ZooKeeperOpentelemetrySpans::maybeInitialize(
-                        concrete_zk_request.spans->read_process,
+                    concrete_zk_request.spans.maybeInitialize(
+                        KeeperSpan::ReadProcess,
                         concrete_zk_request.tracing_context.get(),
                         start_time_us);
 
-                    ZooKeeperOpentelemetrySpans::maybeFinalize(
-                        concrete_zk_request.spans->read_process,
+                    concrete_zk_request.spans.maybeFinalize(
+                        KeeperSpan::ReadProcess,
                         [&]
                         {
                             return std::vector<OpenTelemetry::SpanAttribute>{

--- a/src/Server/KeeperTCPHandler.cpp
+++ b/src/Server/KeeperTCPHandler.cpp
@@ -781,7 +781,7 @@ std::pair<Coordination::OpNum, Coordination::XID> KeeperTCPHandler::receiveReque
 
         if (has_tracing_context)
         {
-            request->tracing_context = std::make_unique<OpenTelemetry::TracingContext>();
+            request->tracing_context = std::make_shared<OpenTelemetry::TracingContext>();
             request->tracing_context->deserialize(read_buffer);
 
             ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->receive_request, request->tracing_context.get(), receive_start_time);

--- a/src/Server/KeeperTCPHandler.cpp
+++ b/src/Server/KeeperTCPHandler.cpp
@@ -479,7 +479,7 @@ void KeeperTCPHandler::runImpl()
                                  const Coordination::ZooKeeperResponsePtr & response, Coordination::ZooKeeperRequestPtr request)
     {
         if (request)
-            ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->send_response, request->tracing_context.get());
+            request->spans.maybeInitialize(KeeperSpan::SendResponse, request->tracing_context.get());
 
         if (!my_responses->push(RequestWithResponse{response, std::move(request)}))
             throw Exception(ErrorCodes::SYSTEM_ERROR, "Could not push response with xid {} and zxid {}", response->xid, response->zxid);
@@ -580,8 +580,8 @@ void KeeperTCPHandler::runImpl()
                     if (!request)
                         return;
 
-                    ZooKeeperOpentelemetrySpans::maybeFinalize(
-                        request->spans->send_response,
+                    request->spans.maybeFinalize(
+                        KeeperSpan::SendResponse,
                         [&]
                         {
                             return std::vector<OpenTelemetry::SpanAttribute>{
@@ -784,9 +784,9 @@ std::pair<Coordination::OpNum, Coordination::XID> KeeperTCPHandler::receiveReque
             request->tracing_context = std::make_shared<OpenTelemetry::TracingContext>();
             request->tracing_context->deserialize(read_buffer);
 
-            ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->receive_request, request->tracing_context.get(), receive_start_time);
-            ZooKeeperOpentelemetrySpans::maybeFinalize(
-                request->spans->receive_request,
+            request->spans.maybeInitialize(KeeperSpan::ReceiveRequest, request->tracing_context.get(), receive_start_time);
+            request->spans.maybeFinalize(
+                KeeperSpan::ReceiveRequest,
                 [&]
                 {
                     return std::vector<OpenTelemetry::SpanAttribute>{

--- a/src/Server/KeeperTCPHandler.cpp
+++ b/src/Server/KeeperTCPHandler.cpp
@@ -479,7 +479,7 @@ void KeeperTCPHandler::runImpl()
                                  const Coordination::ZooKeeperResponsePtr & response, Coordination::ZooKeeperRequestPtr request)
     {
         if (request)
-            ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans.send_response, request->tracing_context);
+            ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->send_response, request->tracing_context.get());
 
         if (!my_responses->push(RequestWithResponse{response, std::move(request)}))
             throw Exception(ErrorCodes::SYSTEM_ERROR, "Could not push response with xid {} and zxid {}", response->xid, response->zxid);
@@ -581,7 +581,7 @@ void KeeperTCPHandler::runImpl()
                         return;
 
                     ZooKeeperOpentelemetrySpans::maybeFinalize(
-                        request->spans.send_response,
+                        request->spans->send_response,
                         [&]
                         {
                             return std::vector<OpenTelemetry::SpanAttribute>{
@@ -781,12 +781,12 @@ std::pair<Coordination::OpNum, Coordination::XID> KeeperTCPHandler::receiveReque
 
         if (has_tracing_context)
         {
-            request->tracing_context.emplace();
+            request->tracing_context = std::make_unique<OpenTelemetry::TracingContext>();
             request->tracing_context->deserialize(read_buffer);
 
-            ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans.receive_request, request->tracing_context, receive_start_time);
+            ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->receive_request, request->tracing_context.get(), receive_start_time);
             ZooKeeperOpentelemetrySpans::maybeFinalize(
-                request->spans.receive_request,
+                request->spans->receive_request,
                 [&]
                 {
                     return std::vector<OpenTelemetry::SpanAttribute>{


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix OOMs on huge multi requests in the keeper. For OpenTelemetry tracing, we unconditionally allocate >1 KiB for OpenTelemetry spans in `ZooKeeperRequest` objects - meaning, for really huge multi requests, we try to allocate >10 GiB extra memory. To fix this, we now keep shared data in static memory and use `std::unique_ptr` over `std::optional` in `ZooKeeperOpentelemetrySpans`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.951`
<!-- ch-version-info:end -->