### PR TITLE
Add regression test for parameterized view crash via remote()/cluster()

### DIFF
--- a/tests/queries/0_stateless/04098_remote_parameterized_view_no_crash.sql
+++ b/tests/queries/0_stateless/04098_remote_parameterized_view_no_crash.sql
@@ -1,0 +1,15 @@
+-- Regression test: INSERT/SELECT via cluster()/remote() into a parameterized view
+-- should return a proper error, not crash with LOGICAL_ERROR '!res.empty()'.
+
+CREATE VIEW pv AS SELECT 1 AS x WHERE x = {p:UInt32};
+
+-- These should produce errors (parameterized view has no columns), not server crashes.
+-- The empty column list from the local shard causes getStructureOfRemoteTable
+-- to fall through to the remote shard path.
+SELECT * FROM cluster('test_shard_localhost', currentDatabase(), 'pv'); -- { serverError NO_REMOTE_SHARD_AVAILABLE }
+SELECT * FROM remote('127.0.0.1:9000', currentDatabase(), 'pv'); -- { serverError NO_REMOTE_SHARD_AVAILABLE }
+
+INSERT INTO FUNCTION cluster('test_shard_localhost', currentDatabase(), 'pv') SELECT 1; -- { serverError NO_REMOTE_SHARD_AVAILABLE }
+INSERT INTO FUNCTION remote('127.0.0.1:9000', currentDatabase(), 'pv') SELECT 1; -- { serverError NO_REMOTE_SHARD_AVAILABLE }
+
+DROP VIEW pv;


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
None.

### What is the problem?

Parameterized views (e.g., `CREATE VIEW v AS SELECT ... WHERE x = {p:UInt32}`) have empty column metadata. Accessing them through `cluster()` or `remote()` table functions used to crash the server with `LOGICAL_ERROR '!res.empty()'` in debug/sanitizer builds.

The source fix was merged in PR #102604 by @alexey-milovidov. This PR adds a regression test to prevent the bug from recurring.

### What is the fix?

This PR adds regression test `04098_remote_parameterized_view_no_crash` covering SELECT and INSERT via both `cluster()` and `remote()` against a parameterized view. The test verifies a proper `NO_REMOTE_SHARD_AVAILABLE` error is returned instead of a server crash.

**Changes from previous version (reviewer feedback):**
- Removed explicit `CREATE DATABASE` — uses the test's own database with `currentDatabase()` (per @azat)
- Removed `no-parallel` tag — test is isolated to its own database
- Dropped source code changes — superseded by PR #102604
- Resolved merge conflicts by rebasing onto current master (per @nikitamikhaylov)

### How was it tested?

- Verified locally that the test passes 50/50 with randomization on a debug build that includes PR #102604's fix
- Test correctly produces `NO_REMOTE_SHARD_AVAILABLE` for all 4 query variants

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1058`
<!-- ch-version-info:end -->