### PR TITLE
Fix `NamedCollection` metric inflation on `IF NOT EXISTS` and missing initialization

### DIFF
--- a/src/Common/NamedCollections/NamedCollectionsFactory.cpp
+++ b/src/Common/NamedCollections/NamedCollectionsFactory.cpp
@@ -127,6 +127,7 @@ void NamedCollectionFactory::add(
             "A named collection `{}` already exists",
             collection_name);
     }
+    CurrentMetrics::set(CurrentMetrics::NamedCollection, loaded_named_collections.size());
 }
 
 void NamedCollectionFactory::add(NamedCollectionsMap collections, std::lock_guard<std::mutex> & lock)
@@ -164,6 +165,7 @@ bool NamedCollectionFactory::removeIfExists(
             collection_name);
     }
     loaded_named_collections.erase(collection_name);
+    CurrentMetrics::set(CurrentMetrics::NamedCollection, loaded_named_collections.size());
     return true;
 }
 
@@ -172,6 +174,7 @@ void NamedCollectionFactory::removeById(NamedCollection::SourceId id, std::lock_
     std::erase_if(
         loaded_named_collections,
         [&](const auto & value) { return value.second->getSourceId() == id; });
+    CurrentMetrics::set(CurrentMetrics::NamedCollection, loaded_named_collections.size());
 }
 
 namespace
@@ -322,7 +325,6 @@ void NamedCollectionFactory::removeFromSQL(const ASTDropNamedCollectionQuery & q
 
     metadata_storage->remove(query.collection_name);
     remove(query.collection_name, lock);
-    CurrentMetrics::sub(CurrentMetrics::NamedCollection);
 }
 
 void NamedCollectionFactory::updateFromSQL(const ASTAlterNamedCollectionQuery & query)

--- a/src/Interpreters/InterpreterCreateNamedCollectionQuery.cpp
+++ b/src/Interpreters/InterpreterCreateNamedCollectionQuery.cpp
@@ -50,7 +50,6 @@ BlockIO InterpreterCreateNamedCollectionQuery::execute()
     }
 
     NamedCollectionFactory::instance().createFromSQL(query);
-    CurrentMetrics::add(CurrentMetrics::NamedCollection);
 
     return {};
 }

--- a/tests/integration/test_table_db_num_limit/config/named_collections.xml
+++ b/tests/integration/test_table_db_num_limit/config/named_collections.xml
@@ -1,0 +1,10 @@
+<clickhouse>
+    <named_collections>
+        <from_config_1>
+            <key1>value1</key1>
+        </from_config_1>
+        <from_config_2>
+            <key2>value2</key2>
+        </from_config_2>
+    </named_collections>
+</clickhouse>

--- a/tests/integration/test_table_db_num_limit/test.py
+++ b/tests/integration/test_table_db_num_limit/test.py
@@ -16,7 +16,7 @@ node2 = cluster.add_instance(
     "node2",
     with_zookeeper=True,
     macros={"replica": "r2"},
-    main_configs=["config/config.xml", "config/config2.xml"],
+    main_configs=["config/config.xml", "config/config2.xml", "config/named_collections.xml"],
 )
 
 
@@ -285,3 +285,87 @@ def test_named_collection_limit(started_cluster):
     finally:
         for i in range(throw_limit + 1):
             node.query(f"DROP NAMED COLLECTION IF EXISTS nc_{i}")
+
+
+def test_named_collection_if_not_exists_metric(started_cluster):
+    """
+    CREATE NAMED COLLECTION IF NOT EXISTS must not inflate the NamedCollection
+    metric when the collection already exists.
+    DROP NAMED COLLECTION IF EXISTS on a nonexistent collection must not
+    deflate the metric either.
+    https://github.com/ClickHouse/ClickHouse/issues/102507
+    """
+
+    def _get_number_of_collections():
+        return int(node.query("SELECT value FROM system.metrics WHERE name = 'NamedCollection'"))
+
+    try:
+        node.query("DROP NAMED COLLECTION IF EXISTS nc_ine_test")
+        before = _get_number_of_collections()
+
+        node.query("CREATE NAMED COLLECTION nc_ine_test AS key = 1")
+        assert _get_number_of_collections() == before + 1
+
+        # IF NOT EXISTS on an already-existing collection must not change the metric
+        node.query("CREATE NAMED COLLECTION IF NOT EXISTS nc_ine_test AS key = 2")
+        assert _get_number_of_collections() == before + 1
+
+        node.query("CREATE NAMED COLLECTION IF NOT EXISTS nc_ine_test AS key = 3")
+        assert _get_number_of_collections() == before + 1
+
+        node.query("DROP NAMED COLLECTION nc_ine_test")
+        assert _get_number_of_collections() == before
+
+        # DROP IF EXISTS on an already-dropped collection must not change the metric
+        node.query("DROP NAMED COLLECTION IF EXISTS nc_ine_test")
+        assert _get_number_of_collections() == before
+
+        node.query("DROP NAMED COLLECTION IF EXISTS nc_ine_test")
+        assert _get_number_of_collections() == before
+
+    finally:
+        node.query("DROP NAMED COLLECTION IF EXISTS nc_ine_test")
+
+
+def test_named_collection_metric_on_startup(started_cluster):
+    """
+    Collections loaded from config on startup must be reflected in the
+    NamedCollection metric. node2 starts with 2 config-defined collections
+    (from_config_1, from_config_2).
+    https://github.com/ClickHouse/ClickHouse/issues/102507
+    """
+
+    def _get_metric(n):
+        return int(n.query("SELECT value FROM system.metrics WHERE name = 'NamedCollection'"))
+
+    metric = _get_metric(node2)
+    assert metric >= 2, (
+        f"Expected NamedCollection metric >= 2 (from_config_1 + from_config_2), got {metric}"
+    )
+
+
+def test_named_collection_metric_after_config_reload(started_cluster):
+    """
+    SYSTEM RELOAD CONFIG must not break the NamedCollection metric for
+    SQL-created collections.
+    https://github.com/ClickHouse/ClickHouse/issues/102507
+    """
+
+    def _get_metric(n):
+        return int(n.query("SELECT value FROM system.metrics WHERE name = 'NamedCollection'"))
+
+    try:
+        node2.query("DROP NAMED COLLECTION IF EXISTS nc_reload_test")
+        before = _get_metric(node2)
+
+        node2.query("CREATE NAMED COLLECTION nc_reload_test AS key = 1")
+        assert _get_metric(node2) == before + 1
+
+        node2.query("SYSTEM RELOAD CONFIG")
+        assert _get_metric(node2) == before + 1
+
+        node2.query("DROP NAMED COLLECTION nc_reload_test")
+        assert _get_metric(node2) == before
+
+    finally:
+        node2.query("DROP NAMED COLLECTION IF EXISTS nc_reload_test")

--- a/tests/queries/0_stateless/02931_max_num_to_warn.reference
+++ b/tests/queries/0_stateless/02931_max_num_to_warn.reference
@@ -3,3 +3,4 @@ The number of attached databases _ exceeds the warning limit of 2.	The number of
 The number of attached dictionaries _ exceeds the warning limit of 5.	The number of attached dictionaries ({}) exceeds the warning limit of {}.
 The number of attached tables _ exceeds the warning limit of 5.	The number of attached tables ({}) exceeds the warning limit of {}.
 The number of attached views _ exceeds the warning limit of 5.	The number of attached views ({}) exceeds the warning limit of {}.
+The number of named collections _ exceeds the warning limit of 5.	The number of named collections ({}) exceeds the warning limit of {}.


### PR DESCRIPTION
Follow-up on https://github.com/ClickHouse/ClickHouse/pull/87343

The `NamedCollection` CurrentMetric was managed incorrectly in several ways:

1. `CREATE NAMED COLLECTION IF NOT EXISTS` on an existing collection unconditionally incremented the metric, inflating it on every no-op call. This caused false `system.warnings` and premature `TOO_MANY_NAMED_COLLECTIONS` exceptions when `max_named_collection_num_to_throw` was configured.

2. Collections loaded from config or SQL storage at startup were never counted — the metric started at 0 regardless of how many collections existed.

3. Config reloads (`SYSTEM RELOAD CONFIG`) and SQL reloads (ZooKeeper watcher) internally removed and re-added collections without updating the metric, which could cause drift.

The fix centralizes all metric updates inside `NamedCollectionFactory`'s `add`, `removeIfExists`, and `removeById` methods using `CurrentMetrics::set` tied to `loaded_named_collections.size()`. This removes the scattered `add`/`sub` calls from interpreters entirely, making it impossible for the metric to drift from the actual collection count.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `NamedCollection` CurrentMetric being inflated by `CREATE NAMED COLLECTION IF NOT EXISTS` on existing collections, and not being initialized for collections loaded from config or SQL storage at startup. Closes #102507.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.938`
- Backported to: `26.3.10.5`, `26.2.15.6`, `26.1.10.7`
<!-- ch-version-info:end -->