### PR TITLE
Fix exception in getStructureOfRemoteTable when local shard returns empty columns

### DIFF
--- a/src/Storages/getStructureOfRemoteTable.cpp
+++ b/src/Storages/getStructureOfRemoteTable.cpp
@@ -156,7 +156,12 @@ ColumnsDescription getStructureOfRemoteTable(
         if (shard_info.isLocal())
         {
             const auto & res = getStructureOfRemoteTableInShard(cluster, shard_info, table_id, context, table_func_ptr);
-            chassert(!res.empty());
+
+            /// Columns may be empty due to a race with concurrent DDL (e.g. REPLACE TABLE or lazy storage initialization).
+            /// In that case, fall through to try remote shards.
+            if (res.empty())
+                break;
+
             return res;
         }
     }


### PR DESCRIPTION
The `chassert(!res.empty())` assertion in `getStructureOfRemoteTable` can fire in debug builds when `getStructureOfRemoteTableInShard` returns empty columns for a local shard. This can happen due to a race with concurrent DDL operations (e.g. `REPLACE TABLE` or lazy storage initialization), because the `IStorage` constructor creates metadata with empty columns by default.

Restore the original defensive behavior (from before commit f79f12408d8) that falls through to remote shards when the local shard returns empty columns.

BuzzHouse (amd_debug) failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=102498&sha=0ce3f2c0db68a6f6eae31a5cf54636285b1a640c&name_0=PR&name_1=BuzzHouse%20%28amd_debug%29
PR: https://github.com/ClickHouse/ClickHouse/pull/102498

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix exception in `getStructureOfRemoteTable` when local shard returns empty columns due to concurrent DDL.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.918`
<!-- ch-version-info:end -->