### PR TITLE
Don't run `00084_external_aggregation` on flaky checks

### DIFF
--- a/tests/queries/0_stateless/00084_external_aggregation.sql
+++ b/tests/queries/0_stateless/00084_external_aggregation.sql
@@ -1,4 +1,6 @@
--- Tags: stateful
+-- Tags: stateful, no-flaky-check
+-- no-flaky-check: times out
+
 SET max_bytes_before_external_group_by = 200000000;
 SET max_bytes_ratio_before_external_group_by = 0;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


---

[cidb](https://play.clickhouse.com/play?user=play&run=1#V0lUSAogICAgOTAgQVMgaW50ZXJ2YWxfZGF5cwpTRUxFQ1QKICAgIHRvU3RhcnRPZkRheShjaGVja19zdGFydF90aW1lKSBBUyBkYXksCiAgICB0ZXN0X3N0YXR1cywKICAgIGNvdW50SWYoY2hlY2tfbmFtZSBMSUtFICclZmxha3kgY2hlY2slJykgQVMgZmxha3ksCiAgICBjb3VudElmKGNoZWNrX25hbWUgTk9UIExJS0UgJyVmbGFreSBjaGVjayUnKSBBUyBvdGhlcl9mYWlsdXJlcywKICAgIGdyb3VwVW5pcUFycmF5KHB1bGxfcmVxdWVzdF9udW1iZXIpIEFTIHBycywKICAgIGFueShyZXBvcnRfdXJsKSBBUyByZXBvcnRfdXJsCkZST00gY2hlY2tzCldIRVJFIChub3coKSAtIHRvSW50ZXJ2YWxEYXkoaW50ZXJ2YWxfZGF5cykpIDw9IGNoZWNrX3N0YXJ0X3RpbWUKICAgIEFORCB0ZXN0X25hbWUgPSAnMDAwODRfZXh0ZXJuYWxfYWdncmVnYXRpb24nCiAgICAtLSBBTkQgY2hlY2tfbmFtZSBMSUtFICclZmxha3kgY2hlY2slJwogICAgQU5EIHRlc3Rfc3RhdHVzIElOICgnRkFJTCcsICdFUlJPUicpCiAgICBBTkQgKHB1bGxfcmVxdWVzdF9udW1iZXIgPSAwIE9SIGJhc2VfcmVmIElOICgnbWFzdGVyJykpCiAgICAtLSBBTkQgdGVzdF9jb250ZXh0X3JhdyBMSUtFICclVGVzdCBydW5zIHRvbyBsb25nJScKR1JPVVAgQlkgZGF5LCB0ZXN0X3N0YXR1cwpPUkRFUiBCWSBkYXkgREVTQywgdGVzdF9zdGF0dXMK)

```
The current flaky check still runs:

  1. Changed/new test files in the PR
  2. Previously failed tests (from prior flaky check runs of this same PR)
  3. Coverage-relevant tests (via the get_most_relevant_tests coverage database)

  The three-step selection code at lines 411–439 is unchanged from the March 24 commit. What the April 9 revert actually did was just bring back is_targeted_check as its own separate code path again.

  So 00084_external_aggregation continues to show up in flaky checks through both of these mechanisms:

  - Coverage-relevant: any PR touching aggregation, filesystem, or memory-management code will have the test flagged as relevant by the coverage database
  - Previously failed: once the test failed in a PR's flaky check (which has been happening to most PRs since April 6), it gets included in all subsequent flaky check runs for that PR via get_previously_failed_tests, which queries the CI database for failures
  within the last 30 days for that pull_request_number

  The second mechanism is self-reinforcing — the test fails because it's selected, which causes it to be selected again, which causes it to fail again.
```

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.916`
<!-- ch-version-info:end -->