### PR TITLE
Treat STATISTICS as read-only in ColumnDependency

### DIFF
--- a/src/Storages/ColumnDependency.h
+++ b/src/Storages/ColumnDependency.h
@@ -37,7 +37,7 @@ struct ColumnDependency
 
     bool isReadOnly() const
     {
-        return kind == SKIP_INDEX || kind == PROJECTION || kind == TTL_EXPRESSION;
+        return kind == SKIP_INDEX || kind == PROJECTION || kind == TTL_EXPRESSION || kind == STATISTICS;
     }
 
     bool operator==(const ColumnDependency & other) const


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Treat STATISTICS as read-only in ColumnDependency to fix LOGICAL_ERROR during MATERIALIZE STATISTICS ALL.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.937`
<!-- ch-version-info:end -->