### PR TITLE
Keeper: fix missing last_durable_idx rollback

### DIFF
--- a/src/Coordination/Changelog.cpp
+++ b/src/Coordination/Changelog.cpp
@@ -2379,6 +2379,17 @@ void Changelog::writeAt(uint64_t index, const LogEntryPtr & log_entry)
     flush();
 
     {
+        /// After flush(), last_durable_idx == old max_log_id. But we are about to
+        /// truncate entries from 'index' onward and rewrite them. The new entries
+        /// are not durable until the write thread fsyncs them, so we must decrease
+        /// last_durable_idx to reflect that entries at 'index' and beyond are no
+        /// longer durably persisted. Without this, the NuRaft follower durability
+        /// loop would see the stale high value and skip waiting for the fsync.
+        std::lock_guard lock{durable_idx_mutex};
+        last_durable_idx = std::min(last_durable_idx, index - 1);
+    }
+
+    {
         std::lock_guard lock(writer_mutex);
         /// This write_at require to overwrite everything in this file and also in previous file(s)
         const bool go_to_previous_file = index < current_writer->getStartIndex();


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Trivial bug that could break consistency if nodes crash at just the right moment after leader change.

(Add a test? Idk, that would be a lot of code, doesn't seem worth it and the time. Shouldn't things like jepsen find bugs like this?)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.119`
<!-- ch-version-info:end -->