### PR TITLE
Fix residual flakiness in test_overcommit_tracker

### DIFF
--- a/tests/integration/test_overcommit_tracker/test.py
+++ b/tests/integration/test_overcommit_tracker/test.py
@@ -21,14 +21,23 @@ def start_cluster():
         cluster.shutdown()
 
 
-# Use larger queries (128 MB each) and a lower user memory limit (300 MB) so that
-# memory pressure is reached even when only a handful of queries overlap in time.
-# This prevents flakiness on slow builds (coverage, ARM) where fewer queries run
-# concurrently and the old 2 GB limit was rarely hit.
+# Query A allocates ~40 MB (5M × 8 bytes) with denominator=1 → highest overcommit
+# ratio → killed first under memory pressure.
+# Query B allocates ~8 MB (1M × 8 bytes) with denominator=80000000 → lowest ratio
+# → survives.
+#
+# User memory limit is 300 MB.  With 10 × A + 10 × B running concurrently the total
+# demand (~480 MB) comfortably exceeds the limit, triggering the overcommit tracker.
+# After all A queries are killed, B's total (~80 MB) fits well within the 300 MB
+# limit, so at least one B query can finish — which is exactly what the test asserts.
+#
+# Previous parameters used numbers(5000000) for both A and B, making B's total
+# (20 × 40 MB = 800 MB) exceed the 300 MB limit even after A was killed.  This
+# caused ~1 % residual flakiness where ALL B queries were also killed.
 USER_TEST_QUERY_A = "SELECT groupArray(number) FROM numbers(5000000) SETTINGS max_threads=1, max_memory_usage_for_user=300000000, memory_overcommit_ratio_denominator=1"
-USER_TEST_QUERY_B = "SELECT groupArray(number) FROM numbers(5000000) SETTINGS max_threads=1, max_memory_usage_for_user=300000000, memory_overcommit_ratio_denominator=80000000"
+USER_TEST_QUERY_B = "SELECT groupArray(number) FROM numbers(1000000) SETTINGS max_threads=1, max_memory_usage_for_user=300000000, memory_overcommit_ratio_denominator=80000000"
 
-QUERY_COUNT = 40  # 20 × A + 20 × B
+QUERY_COUNT = 20  # 10 × A + 10 × B
 
 
 def test_user_overcommit():


### PR DESCRIPTION
Follow-up to #101574 which reduced `test_overcommit_tracker/test_user_overcommit`
failures by ~93%. A ~1% residual failure remained: 2 master failures and ~6 PR
failures per week since the fix was merged on Apr 2.

**Root cause:** both query A (denominator=1, should be killed) and query B
(denominator=80000000, should survive) used `numbers(5000000)` (~40 MB each).
With 20 B queries, their collective memory (800 MB) far exceeded the 300 MB
`max_memory_usage_for_user` limit.  After `UserOvercommitTracker` killed all A
queries (highest `committed/soft_limit` ratio), B's total still exceeded the
limit — so B queries were also killed, failing the `finished` assertion.

**Fix:** reduce B query data from `numbers(5000000)` to `numbers(1000000)` (~8 MB
each) and `QUERY_COUNT` from 40 to 20.  After A is killed, B's collective memory
(10 × 8 MB = 80 MB) fits within the 300 MB limit.  Total demand (480 MB) still
exceeds the limit to trigger the overcommit tracker.

The test still verifies the core invariant: queries with low
`memory_overcommit_ratio_denominator` are killed first while queries with high
denominator survive.

Validated with 50 consecutive local passes.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a]user-readable short description of the changes that goes to CHANGELOG):

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.977`
<!-- ch-version-info:end -->