### PR TITLE
Fix Logical error when querying dangling Alias table via remote()

### DIFF
--- a/src/Storages/getStructureOfRemoteTable.cpp
+++ b/src/Storages/getStructureOfRemoteTable.cpp
@@ -34,6 +34,7 @@ namespace Setting
 namespace ErrorCodes
 {
     extern const int NO_REMOTE_SHARD_AVAILABLE;
+    extern const int UNKNOWN_TABLE;
 }
 
 
@@ -156,7 +157,14 @@ ColumnsDescription getStructureOfRemoteTable(
         if (shard_info.isLocal())
         {
             const auto & res = getStructureOfRemoteTableInShard(cluster, shard_info, table_id, context, table_func_ptr);
-            chassert(!res.empty());
+            if (res.empty())
+            {
+                throw Exception(
+                    ErrorCodes::UNKNOWN_TABLE,
+                    "Table {}.{} exists but has no columns (possibly an Alias to a non-existent table)",
+                    table_id.database_name,
+                    table_id.table_name);
+            }
             return res;
         }
     }

--- a/tests/queries/0_stateless/04099_alias_to_nonexistent_table.sql
+++ b/tests/queries/0_stateless/04099_alias_to_nonexistent_table.sql
@@ -11,7 +11,7 @@ CREATE TABLE alias_table ENGINE = Alias(currentDatabase(), base_table);
 DROP TABLE base_table;
 
 -- Querying via remote() should throw UNKNOWN_TABLE instead of Logical error
-SELECT * FROM remote('localhost:9900', currentDatabase(), alias_table); -- { serverError UNKNOWN_TABLE }
+SELECT * FROM remote('localhost', currentDatabase(), alias_table); -- { serverError UNKNOWN_TABLE }
 
 -- Cleanup
 DROP TABLE IF EXISTS alias_table;

--- a/tests/queries/0_stateless/04099_alias_to_nonexistent_table.sql
+++ b/tests/queries/0_stateless/04099_alias_to_nonexistent_table.sql
@@ -1,0 +1,17 @@
+-- Test for querying dangling Alias table via remote()
+-- When an Alias table points to a non-existent table, querying via remote() should throw UNKNOWN_TABLE
+
+SET allow_experimental_alias_table_engine = 1;
+
+CREATE TABLE base_table (c1 Int32) ENGINE = TinyLog;
+
+CREATE TABLE alias_table ENGINE = Alias(currentDatabase(), base_table);
+
+-- Drop the base table, leaving the Alias dangling
+DROP TABLE base_table;
+
+-- Querying via remote() should throw UNKNOWN_TABLE instead of Logical error
+SELECT * FROM remote('localhost:9900', currentDatabase(), alias_table); -- { serverError UNKNOWN_TABLE }
+
+-- Cleanup
+DROP TABLE IF EXISTS alias_table;


### PR DESCRIPTION
Fixes a Logical error (`!res.empty()`) that occurs when querying an Alias table that points to a non-existent table via the `remote()` function.

When an Alias table is created pointing to another table, and that target table is dropped, the Alias table still exists but has empty columns. Querying such a dangling Alias table via `remote('localhost', ...)` would trigger `chassert(!res.empty())`, now throws `UNKNOWN_TABLE` exception instead.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a Logical error that occurred when querying an Alias table pointing to a non-existent table via the `remote()` function. Closes #102633.
