### PR TITLE
Fix flaky test_keeper_snapshot_chunked_transfer

### DIFF
--- a/tests/integration/test_keeper_snapshot_chunked_transfer/test.py
+++ b/tests/integration/test_keeper_snapshot_chunked_transfer/test.py
@@ -210,6 +210,8 @@ def test_recover_after_interrupted_transfer(started_cluster, nodes):
 
     node_lagging.start_clickhouse(20)
     keeper_utils.wait_until_connected(cluster, node_lagging)
+    lagging_zk = keeper_utils.get_fake_zk(cluster, node_lagging.name)
+    lagging_zk.sync(prefix)  # wait until all committed entries (including snapshot) are applied
 
     if is_remote:
         remaining = list(started_cluster.minio_client.list_objects(
@@ -225,7 +227,6 @@ def test_recover_after_interrupted_transfer(started_cluster, nodes):
         ), f"tmp file was not removed on startup: {tmp_snapshot_path}"
 
     leader_zk = keeper_utils.get_fake_zk(cluster, node_leader.name)
-    lagging_zk = keeper_utils.get_fake_zk(cluster, node_lagging.name)
     verify_test_tree(leader_zk, lagging_zk, prefix)
     assert_receiving_snapshot_logged(node_lagging, recovery_time, nodes["disk_type"])
     cleanup_test_tree(cluster, node_leader, prefix)


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.920`
<!-- ch-version-info:end -->