### PR TITLE
Check stack size more frequently on Darwin due to smaller default stack

### DIFF
--- a/src/Parsers/IParser.h
+++ b/src/Parsers/IParser.h
@@ -132,7 +132,7 @@ public:
               * The frequency is arbitrary, but not too large, not too small,
               * and a power of two to simplify the division.
               */
-#if defined(USE_MUSL) || defined(SANITIZER) || !defined(NDEBUG)
+#if defined(USE_MUSL) || defined(SANITIZER) || !defined(NDEBUG) || defined(OS_DARWIN)
             static constexpr uint32_t check_frequency = 128;
 #else
             static constexpr uint32_t check_frequency = 8192;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Check stack size more frequently on Darwin due to smaller default stack

Fixes `02985_parser_check_stack_size` triggering SIGILL on Darwin

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1101`
<!-- ch-version-info:end -->