### PR TITLE
Fix timeout in test_check_database_unity by batching Spark queries

### DIFF
--- a/tests/integration/test_database_delta/test.py
+++ b/tests/integration/test_database_delta/test.py
@@ -223,9 +223,6 @@ def test_check_database_unity(started_cluster):
     db_name = f"check_database_{test_uuid}"
     schema_name = f"test_schema_{test_uuid}"
 
-    # Create a single schema
-    execute_spark_query(node1, f"CREATE SCHEMA {schema_name}")
-
     # Create multiple tables in the same schema
     table_configs = [
         (f"table1_{test_uuid}", "col1 int, col2 double", [(1, 1.0)]),
@@ -233,14 +230,16 @@ def test_check_database_unity(started_cluster):
         (f"table3_{test_uuid}", "col1 int, col2 double", [(3, 3.0)]),
     ]
 
+    # Combine schema creation, table creation and inserts into a single
+    # Spark invocation to avoid multiple slow JVM startups.
+    queries = [f"CREATE SCHEMA {schema_name}"]
     for table_name, table_schema, data_rows in table_configs:
-        # Create table
-        create_query = f"CREATE TABLE {schema_name}.{table_name} ({table_schema}) using Delta location '/var/lib/clickhouse/user_files/tmp/{schema_name}/{table_name}'"
-        execute_spark_query(node1, create_query)
-
-        # Insert data
+        queries.append(
+            f"CREATE TABLE {schema_name}.{table_name} ({table_schema}) using Delta location '/var/lib/clickhouse/user_files/tmp/{schema_name}/{table_name}'"
+        )
         for row in data_rows:
-            execute_spark_query(node1, f"INSERT INTO {schema_name}.{table_name} VALUES {row}")
+            queries.append(f"INSERT INTO {schema_name}.{table_name} VALUES {row}")
+    execute_multiple_spark_queries(node1, queries)
 
     # Create ClickHouse database pointing to Unity Catalog
     node1.query(


### PR DESCRIPTION
Fix timeout in `test_check_database_unity` by combining schema creation, table creation,
and insert queries into a single `execute_multiple_spark_queries` call instead of
multiple `execute_spark_query` calls. Each call starts a new JVM, and the cumulative
startup time was causing the test to exceed the timeout.

Master CI failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=66a2a0e7f28b36ec3f9da7f3b0b67e6926a67b8e&name_0=MasterCI&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%202%2F6%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.927`
<!-- ch-version-info:end -->