### PR TITLE
Fix asynchronous_metric_log never populated in keeper-as-server mode

### DIFF
--- a/programs/keeper-bench/Runner.cpp
+++ b/programs/keeper-bench/Runner.cpp
@@ -411,7 +411,7 @@ void Runner::thread(std::vector<std::shared_ptr<Coordination::ZooKeeper>> zookee
             tracing_context.trace_id = DB::UUIDHelpers::generateV4();
             tracing_context.span_id = 0;
             tracing_context.trace_flags = DB::OpenTelemetry::TRACE_FLAG_SAMPLED | DB::OpenTelemetry::TRACE_FLAG_KEEPER_SPANS;
-            request->tracing_context = tracing_context;
+            request->tracing_context = std::make_shared<DB::OpenTelemetry::TracingContext>(tracing_context);
         }
 
         InFlightRequest slot;

--- a/programs/keeper-bench/Runner.cpp
+++ b/programs/keeper-bench/Runner.cpp
@@ -407,11 +407,10 @@ void Runner::thread(std::vector<std::shared_ptr<Coordination::ZooKeeper>> zookee
 
         if (enable_tracing)
         {
-            DB::OpenTelemetry::TracingContext tracing_context;
-            tracing_context.trace_id = DB::UUIDHelpers::generateV4();
-            tracing_context.span_id = 0;
-            tracing_context.trace_flags = DB::OpenTelemetry::TRACE_FLAG_SAMPLED | DB::OpenTelemetry::TRACE_FLAG_KEEPER_SPANS;
-            request->tracing_context = std::make_shared<DB::OpenTelemetry::TracingContext>(tracing_context);
+            request->tracing_context = std::make_shared<DB::OpenTelemetry::TracingContext>();
+            request->tracing_context->trace_id = DB::UUIDHelpers::generateV4();
+            request->tracing_context->span_id = 0;
+            request->tracing_context->trace_flags = DB::OpenTelemetry::TRACE_FLAG_SAMPLED | DB::OpenTelemetry::TRACE_FLAG_KEEPER_SPANS;
         }
 
         InFlightRequest slot;

--- a/src/Common/ZooKeeper/KeeperOverDispatcher.cpp
+++ b/src/Common/ZooKeeper/KeeperOverDispatcher.cpp
@@ -5,6 +5,7 @@
 #include <Common/Exception.h>
 #include <Common/logger_useful.h>
 #include <Common/ZooKeeper/KeeperOverDispatcher.h>
+#include <Common/ZooKeeper/KeeperSpans.h>
 
 namespace DB::ErrorCodes
 {
@@ -69,6 +70,7 @@ void KeeperOverDispatcher::finalize(const String & /* reason */)
 void KeeperOverDispatcher::pushRequest(ZooKeeperRequestPtr request, ResponseCallback callback)
 {
     request->xid = next_xid++;
+    request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
 
     {
         std::lock_guard lock(callback_state->callbacks_mutex);

--- a/src/Common/ZooKeeper/KeeperSpans.cpp
+++ b/src/Common/ZooKeeper/KeeperSpans.cpp
@@ -41,7 +41,7 @@ namespace
 
 void ZooKeeperOpentelemetrySpans::maybeInitialize(
     MaybeSpan & maybe_span,
-    const std::optional<OpenTelemetry::TracingContext> & parent_context,
+    const OpenTelemetry::TracingContext * parent_context,
     UInt64 start_time_us)
 {
     chassert(maybe_span.start_time_us == 0);

--- a/src/Common/ZooKeeper/KeeperSpans.h
+++ b/src/Common/ZooKeeper/KeeperSpans.h
@@ -66,7 +66,7 @@ struct ZooKeeperOpentelemetrySpans
 
     static void maybeInitialize(
         MaybeSpan & maybe_span,
-        const std::optional<OpenTelemetry::TracingContext> & parent_context,
+        const OpenTelemetry::TracingContext * parent_context,
         UInt64 start_time_us = now());
 
     template <typename MakeAttributes>

--- a/src/Common/ZooKeeper/ZooKeeperCommon.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.cpp
@@ -1600,7 +1600,7 @@ ZooKeeperRequestPtr ZooKeeperRequestFactory::get(OpNum op_num) const
         throw Exception(Error::ZBADARGUMENTS, "Unknown operation type {}", op_num);
 
     auto request = it->second();
-    request->spans = std::make_unique<DB::ZooKeeperOpentelemetrySpans>();
+    request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
     return request;
 }
 

--- a/src/Common/ZooKeeper/ZooKeeperCommon.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.cpp
@@ -72,7 +72,7 @@ void ZooKeeperRequest::write(WriteBuffer & out, bool use_xid_64, bool supports_t
 
     if (supports_tracing)
     {
-        const uint8_t has_tracing_context = tracing_context.has_value();
+        const uint8_t has_tracing_context = tracing_context != nullptr;
         Coordination::write(has_tracing_context, out);
         if (has_tracing_context)
         {
@@ -1170,6 +1170,7 @@ void ZooKeeperMultiRequest::readImpl(ReadBuffer & in, RequestValidator request_v
         request->readImpl(in);
         if (request_validator)
             request_validator(*request);
+        request->spans.reset();
         requests.push_back(request);
 
         if (in.eof())
@@ -1598,7 +1599,9 @@ ZooKeeperRequestPtr ZooKeeperRequestFactory::get(OpNum op_num) const
     if (it == op_num_to_request.end())
         throw Exception(Error::ZBADARGUMENTS, "Unknown operation type {}", op_num);
 
-    return it->second();
+    auto request = it->second();
+    request->spans = std::make_unique<DB::ZooKeeperOpentelemetrySpans>();
+    return request;
 }
 
 ZooKeeperRequestFactory & ZooKeeperRequestFactory::instance()

--- a/src/Common/ZooKeeper/ZooKeeperCommon.h
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.h
@@ -63,11 +63,11 @@ struct ZooKeeperRequest : virtual Request
 
     std::chrono::steady_clock::time_point create_ts = {};
 
-    std::optional<OpenTelemetry::TracingContext> tracing_context;
-    DB::ZooKeeperOpentelemetrySpans spans;
+    std::unique_ptr<OpenTelemetry::TracingContext> tracing_context;
+    std::unique_ptr<DB::ZooKeeperOpentelemetrySpans> spans;
 
     ZooKeeperRequest() = default;
-    ZooKeeperRequest(const ZooKeeperRequest &) = default;
+    ZooKeeperRequest(const ZooKeeperRequest &) = delete;
 
     virtual OpNum getOpNum() const = 0;
     virtual int32_t tryGetOpNum() const { return static_cast<int32_t>(getOpNum()); }

--- a/src/Common/ZooKeeper/ZooKeeperCommon.h
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.h
@@ -63,11 +63,11 @@ struct ZooKeeperRequest : virtual Request
 
     std::chrono::steady_clock::time_point create_ts = {};
 
-    std::unique_ptr<OpenTelemetry::TracingContext> tracing_context;
-    std::unique_ptr<DB::ZooKeeperOpentelemetrySpans> spans;
+    std::shared_ptr<OpenTelemetry::TracingContext> tracing_context;
+    std::shared_ptr<DB::ZooKeeperOpentelemetrySpans> spans;
 
     ZooKeeperRequest() = default;
-    ZooKeeperRequest(const ZooKeeperRequest &) = delete;
+    ZooKeeperRequest(const ZooKeeperRequest &) = default;
     ZooKeeperRequest(ZooKeeperRequest &&) = default;
 
     virtual OpNum getOpNum() const = 0;

--- a/src/Common/ZooKeeper/ZooKeeperCommon.h
+++ b/src/Common/ZooKeeper/ZooKeeperCommon.h
@@ -68,6 +68,7 @@ struct ZooKeeperRequest : virtual Request
 
     ZooKeeperRequest() = default;
     ZooKeeperRequest(const ZooKeeperRequest &) = delete;
+    ZooKeeperRequest(ZooKeeperRequest &&) = default;
 
     virtual OpNum getOpNum() const = 0;
     virtual int32_t tryGetOpNum() const { return static_cast<int32_t>(getOpNum()); }

--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -1504,14 +1504,14 @@ void ZooKeeper::pushRequest(RequestInfo && info)
         }
 
         maybeInjectSendFault();
-        info.request->spans = std::make_unique<DB::ZooKeeperOpentelemetrySpans>();
+        info.request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
 
         if (
             const auto & current_trace_context = OpenTelemetry::CurrentContext();
             current_trace_context.isTraceEnabled() && current_trace_context.trace_flags & DB::OpenTelemetry::TRACE_FLAG_KEEPER_SPANS
         )
         {
-            info.request->tracing_context = std::make_unique<OpenTelemetry::TracingContext>(current_trace_context);
+            info.request->tracing_context = std::make_shared<OpenTelemetry::TracingContext>(current_trace_context);
         }
 
         ZooKeeperOpentelemetrySpans::maybeInitialize(info.request->spans->client_requests_queue, info.request->tracing_context.get());
@@ -1951,7 +1951,7 @@ void ZooKeeper::close()
 
     RequestInfo request_info;
     request_info.request = std::make_shared<ZooKeeperCloseRequest>(std::move(request));
-    request_info.request->spans = std::make_unique<DB::ZooKeeperOpentelemetrySpans>();
+    request_info.request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
 
     ZooKeeperOpentelemetrySpans::maybeInitialize(request_info.request->spans->client_requests_queue, request_info.request->tracing_context.get());
 

--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -828,7 +828,7 @@ void ZooKeeper::sendThread()
                     ///  because they must not be lost (callbacks must be called because the user will wait for them).
 
                     ZooKeeperOpentelemetrySpans::maybeFinalize(
-                        info.request->spans.client_requests_queue,
+                        info.request->spans->client_requests_queue,
                         [&]
                         {
                             return std::vector<OpenTelemetry::SpanAttribute>{
@@ -1504,16 +1504,17 @@ void ZooKeeper::pushRequest(RequestInfo && info)
         }
 
         maybeInjectSendFault();
+        info.request->spans = std::make_unique<DB::ZooKeeperOpentelemetrySpans>();
 
         if (
             const auto & current_trace_context = OpenTelemetry::CurrentContext();
             current_trace_context.isTraceEnabled() && current_trace_context.trace_flags & DB::OpenTelemetry::TRACE_FLAG_KEEPER_SPANS
         )
         {
-            info.request->tracing_context = current_trace_context;
+            info.request->tracing_context = std::make_unique<OpenTelemetry::TracingContext>(current_trace_context);
         }
 
-        ZooKeeperOpentelemetrySpans::maybeInitialize(info.request->spans.client_requests_queue, info.request->tracing_context);
+        ZooKeeperOpentelemetrySpans::maybeInitialize(info.request->spans->client_requests_queue, info.request->tracing_context.get());
 
         if (!requests_queue.tryPush(std::move(info), args.operation_timeout_ms))
         {
@@ -1950,8 +1951,9 @@ void ZooKeeper::close()
 
     RequestInfo request_info;
     request_info.request = std::make_shared<ZooKeeperCloseRequest>(std::move(request));
+    request_info.request->spans = std::make_unique<DB::ZooKeeperOpentelemetrySpans>();
 
-    ZooKeeperOpentelemetrySpans::maybeInitialize(request_info.request->spans.client_requests_queue, request_info.request->tracing_context);
+    ZooKeeperOpentelemetrySpans::maybeInitialize(request_info.request->spans->client_requests_queue, request_info.request->tracing_context.get());
 
     if (!requests_queue.tryPush(std::move(request_info), args.operation_timeout_ms))
         throw Exception(Error::ZOPERATIONTIMEOUT, "Cannot push close request to queue within operation timeout of {} ms", args.operation_timeout_ms);

--- a/src/Coordination/KeeperAsynchronousMetrics.cpp
+++ b/src/Coordination/KeeperAsynchronousMetrics.cpp
@@ -6,6 +6,7 @@
 #include <Common/getCurrentProcessFDCount.h>
 #include <Common/getMaxFileDescriptorCount.h>
 #include <Interpreters/Context.h>
+#include <Interpreters/AsynchronousMetricLog.h>
 
 namespace DB
 {
@@ -142,6 +143,13 @@ void KeeperAsynchronousMetrics::updateImpl(TimePoint /*update_time*/, TimePoint 
             updateKeeperInformation(*keeper_dispatcher, new_values);
     }
 #endif
+}
+
+
+void KeeperAsynchronousMetrics::logImpl(AsynchronousMetricValues & new_values)
+{
+    if (auto asynchronous_metric_log = context->getAsynchronousMetricLog())
+        asynchronous_metric_log->addValues(new_values);
 }
 
 }

--- a/src/Coordination/KeeperAsynchronousMetrics.h
+++ b/src/Coordination/KeeperAsynchronousMetrics.h
@@ -24,6 +24,7 @@ private:
     ContextPtr context;
 
     void updateImpl(TimePoint update_time, TimePoint current_time, bool force_update, bool first_run, AsynchronousMetricValues & new_values) override;
+    void logImpl(AsynchronousMetricValues & new_values) override;
 };
 
 

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -674,6 +674,8 @@ bool KeeperDispatcher::putRequest(const Coordination::ZooKeeperRequestPtr & requ
     if (keeper_context->isShutdownCalled())
         return false;
 
+    if (!request->spans)
+        request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
     ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
 
     /// Put close requests without timeouts
@@ -1021,7 +1023,9 @@ void KeeperDispatcher::sessionCleanerTask()
                     auto request = Coordination::ZooKeeperRequestFactory::instance().get(Coordination::OpNum::Close);
                     request->xid = Coordination::CLOSE_XID;
 
-                    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
+                    if (!request->spans)
+        request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
+    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
 
                     using namespace std::chrono;
                     KeeperRequestForSession request_info
@@ -1215,6 +1219,8 @@ int64_t KeeperDispatcher::getSessionID(int64_t session_timeout_ms)
         };
     }
 
+    if (!request->spans)
+        request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
     ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
 
     /// Push new session request to queue

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -1170,7 +1170,7 @@ int64_t KeeperDispatcher::getSessionID(int64_t session_timeout_ms)
     request->internal_id = internal_session_id_counter.fetch_add(1);
     request->session_timeout_ms = session_timeout_ms;
     request->server_id = server->getServerID();
-    request->spans = std::make_unique<DB::ZooKeeperOpentelemetrySpans>();
+    request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
 
     request_info.request = request;
     using namespace std::chrono;

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -674,8 +674,6 @@ bool KeeperDispatcher::putRequest(const Coordination::ZooKeeperRequestPtr & requ
     if (keeper_context->isShutdownCalled())
         return false;
 
-    if (!request->spans)
-        request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
     ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
 
     /// Put close requests without timeouts
@@ -1023,9 +1021,7 @@ void KeeperDispatcher::sessionCleanerTask()
                     auto request = Coordination::ZooKeeperRequestFactory::instance().get(Coordination::OpNum::Close);
                     request->xid = Coordination::CLOSE_XID;
 
-                    if (!request->spans)
-        request->spans = std::make_shared<DB::ZooKeeperOpentelemetrySpans>();
-    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
+                    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
 
                     using namespace std::chrono;
                     KeeperRequestForSession request_info

--- a/src/Coordination/KeeperDispatcher.cpp
+++ b/src/Coordination/KeeperDispatcher.cpp
@@ -180,7 +180,7 @@ void KeeperDispatcher::requestThread()
         const auto handle_opentelemetry_spans = [this](const Coordination::ZooKeeperRequestPtr & request, int64_t session_id)
         {
             ZooKeeperOpentelemetrySpans::maybeFinalize(
-                request->spans.dispatcher_requests_queue,
+                request->spans->dispatcher_requests_queue,
                 [&]
                 {
                     return std::vector<OpenTelemetry::SpanAttribute>{
@@ -254,7 +254,7 @@ void KeeperDispatcher::requestThread()
                         /// when the request was enqueued. Without this the span leaks because
                         /// handle_opentelemetry_spans (which normally finalizes it) is skipped.
                         ZooKeeperOpentelemetrySpans::maybeFinalize(
-                            req.request->spans.dispatcher_requests_queue,
+                            req.request->spans->dispatcher_requests_queue,
                             [&]
                             {
                                 return std::vector<OpenTelemetry::SpanAttribute>{
@@ -328,7 +328,7 @@ void KeeperDispatcher::requestThread()
                         if (!quorum_reads && request.request->isReadRequest())
                         {
                             const auto & last_request = current_batch.back();
-                            ZooKeeperOpentelemetrySpans::maybeInitialize(request.request->spans.read_wait_for_write, request.request->tracing_context);
+                            ZooKeeperOpentelemetrySpans::maybeInitialize(request.request->spans->read_wait_for_write, request.request->tracing_context.get());
                             ProfiledMutexLock lock(read_request_queue_mutex, ProfileEvents::KeeperReadRequestQueueLockWaitMicroseconds);
                             reads_count += 1;
                             reads_bytes_size += request.request->bytesSize();
@@ -554,7 +554,7 @@ void KeeperDispatcher::responseThread()
             if (response_was_sent && response_for_session.request)
             {
                 ZooKeeperOpentelemetrySpans::maybeFinalize(
-                    response_for_session.request->spans.dispatcher_responses_queue,
+                    response_for_session.request->spans->dispatcher_responses_queue,
                     [&]
                     {
                         return std::vector<OpenTelemetry::SpanAttribute>{
@@ -674,7 +674,7 @@ bool KeeperDispatcher::putRequest(const Coordination::ZooKeeperRequestPtr & requ
     if (keeper_context->isShutdownCalled())
         return false;
 
-    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans.dispatcher_requests_queue, request->tracing_context);
+    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
 
     /// Put close requests without timeouts
     if (request->getOpNum() == Coordination::OpNum::Close)
@@ -748,7 +748,7 @@ void KeeperDispatcher::initialize(const Poco::Util::AbstractConfiguration & conf
                     {
                         ProfileEvents::increment(ProfileEvents::KeeperStaleRequestsSkipped);
                         ZooKeeperOpentelemetrySpans::maybeFinalize(
-                            read_request.request->spans.read_wait_for_write,
+                            read_request.request->spans->read_wait_for_write,
                             [&]
                             {
                                 return std::vector<OpenTelemetry::SpanAttribute>{
@@ -772,7 +772,7 @@ void KeeperDispatcher::initialize(const Poco::Util::AbstractConfiguration & conf
                 for (auto & read_request : pending_reads)
                 {
                     ZooKeeperOpentelemetrySpans::maybeFinalize(
-                        read_request.request->spans.read_wait_for_write,
+                        read_request.request->spans->read_wait_for_write,
                         [&]
                         {
                             return std::vector<OpenTelemetry::SpanAttribute>{
@@ -1021,7 +1021,7 @@ void KeeperDispatcher::sessionCleanerTask()
                     auto request = Coordination::ZooKeeperRequestFactory::instance().get(Coordination::OpNum::Close);
                     request->xid = Coordination::CLOSE_XID;
 
-                    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans.dispatcher_requests_queue, request->tracing_context);
+                    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
 
                     using namespace std::chrono;
                     KeeperRequestForSession request_info
@@ -1170,6 +1170,7 @@ int64_t KeeperDispatcher::getSessionID(int64_t session_timeout_ms)
     request->internal_id = internal_session_id_counter.fetch_add(1);
     request->session_timeout_ms = session_timeout_ms;
     request->server_id = server->getServerID();
+    request->spans = std::make_unique<DB::ZooKeeperOpentelemetrySpans>();
 
     request_info.request = request;
     using namespace std::chrono;
@@ -1214,7 +1215,7 @@ int64_t KeeperDispatcher::getSessionID(int64_t session_timeout_ms)
         };
     }
 
-    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans.dispatcher_requests_queue, request->tracing_context);
+    ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->dispatcher_requests_queue, request->tracing_context.get());
 
     /// Push new session request to queue
     if (!requests_queue->tryPush(std::move(request_info), session_timeout_ms))

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -277,12 +277,12 @@ nuraft::ptr<nuraft::buffer> KeeperStateMachine<Storage>::pre_commit(uint64_t log
     const auto maybe_log_opentelemetry_span = [&](OpenTelemetry::SpanStatus status, const std::string & error_message)
     {
         ZooKeeperOpentelemetrySpans::maybeInitialize(
-            request_for_session->request->spans.pre_commit,
-            request_for_session->request->tracing_context,
+            request_for_session->request->spans->pre_commit,
+            request_for_session->request->tracing_context.get(),
             start_time_us);
 
         ZooKeeperOpentelemetrySpans::maybeFinalize(
-            request_for_session->request->spans.pre_commit,
+            request_for_session->request->spans->pre_commit,
             [&]
             {
                 return std::vector<OpenTelemetry::SpanAttribute>{
@@ -413,12 +413,12 @@ std::shared_ptr<KeeperRequestForSession> IKeeperStateMachine::parseRequest(
         xid_helper.xid = static_cast<int32_t>(xid_helper.parts.lower);
     }
 
-    std::optional<OpenTelemetry::TracingContext> tracing_context;
+    std::unique_ptr<OpenTelemetry::TracingContext> tracing_context;
     if (!buffer.eof())
     {
         version = WITH_OPTIONAL_TRACING_CONTEXT;
 
-        tracing_context.emplace();
+        tracing_context = std::make_unique<OpenTelemetry::TracingContext>();
         tracing_context->deserialize(buffer);
     }
 
@@ -628,7 +628,7 @@ nuraft::ptr<nuraft::buffer> KeeperStateMachine<Storage>::commit(const uint64_t l
     {
         response.response->enqueue_ts = std::chrono::steady_clock::now();
         if (response.request)
-            ZooKeeperOpentelemetrySpans::maybeInitialize(response.request->spans.dispatcher_responses_queue, response.request->tracing_context);
+            ZooKeeperOpentelemetrySpans::maybeInitialize(response.request->spans->dispatcher_responses_queue, response.request->tracing_context.get());
         if (!responses_queue.push(response))
         {
             ProfileEvents::increment(ProfileEvents::KeeperCommitsFailed);
@@ -641,12 +641,12 @@ nuraft::ptr<nuraft::buffer> KeeperStateMachine<Storage>::commit(const uint64_t l
     const auto maybe_log_opentelemetry_span = [&](OpenTelemetry::SpanStatus status, const std::string & error_message)
     {
         ZooKeeperOpentelemetrySpans::maybeInitialize(
-            request_for_session->request->spans.commit,
-            request_for_session->request->tracing_context,
+            request_for_session->request->spans->commit,
+            request_for_session->request->tracing_context.get(),
             start_time_us);
 
         ZooKeeperOpentelemetrySpans::maybeFinalize(
-            request_for_session->request->spans.commit,
+            request_for_session->request->spans->commit,
             [&]
             {
                 return std::vector<OpenTelemetry::SpanAttribute>{
@@ -1480,7 +1480,7 @@ void KeeperStateMachine<Storage>::processReadRequests(const KeeperRequestsForSes
         if (response_for_session.response->xid != Coordination::WATCH_XID)
         {
             chassert(response_for_session.request);
-            ZooKeeperOpentelemetrySpans::maybeInitialize(response_for_session.request->spans.dispatcher_responses_queue, response_for_session.request->tracing_context);
+            ZooKeeperOpentelemetrySpans::maybeInitialize(response_for_session.request->spans->dispatcher_responses_queue, response_for_session.request->tracing_context.get());
         }
         if (!responses_queue.push(response_for_session))
             LOG_WARNING(log, "Failed to push response with session id {} to the queue, probably because of shutdown", response_for_session.session_id);

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -418,7 +418,7 @@ std::shared_ptr<KeeperRequestForSession> IKeeperStateMachine::parseRequest(
     {
         version = WITH_OPTIONAL_TRACING_CONTEXT;
 
-        tracing_context = std::make_unique<OpenTelemetry::TracingContext>();
+        tracing_context = std::make_shared<OpenTelemetry::TracingContext>();
         tracing_context->deserialize(buffer);
     }
 

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -413,7 +413,7 @@ std::shared_ptr<KeeperRequestForSession> IKeeperStateMachine::parseRequest(
         xid_helper.xid = static_cast<int32_t>(xid_helper.parts.lower);
     }
 
-    std::unique_ptr<OpenTelemetry::TracingContext> tracing_context;
+    std::shared_ptr<OpenTelemetry::TracingContext> tracing_context;
     if (!buffer.eof())
     {
         version = WITH_OPTIONAL_TRACING_CONTEXT;

--- a/src/Coordination/KeeperStorage.cpp
+++ b/src/Coordination/KeeperStorage.cpp
@@ -4067,12 +4067,12 @@ KeeperResponsesForSessions KeeperStorage<Container>::processLocalRequests(
                 const auto maybe_log_opentelemetry_span = [&](OpenTelemetry::SpanStatus status, const std::string & error_message)
                 {
                     ZooKeeperOpentelemetrySpans::maybeInitialize(
-                        concrete_zk_request.spans.read_process,
-                        concrete_zk_request.tracing_context,
+                        concrete_zk_request.spans->read_process,
+                        concrete_zk_request.tracing_context.get(),
                         start_time_us);
 
                     ZooKeeperOpentelemetrySpans::maybeFinalize(
-                        concrete_zk_request.spans.read_process,
+                        concrete_zk_request.spans->read_process,
                         [&]
                         {
                             return std::vector<OpenTelemetry::SpanAttribute>{

--- a/src/Server/KeeperTCPHandler.cpp
+++ b/src/Server/KeeperTCPHandler.cpp
@@ -781,7 +781,7 @@ std::pair<Coordination::OpNum, Coordination::XID> KeeperTCPHandler::receiveReque
 
         if (has_tracing_context)
         {
-            request->tracing_context = std::make_unique<OpenTelemetry::TracingContext>();
+            request->tracing_context = std::make_shared<OpenTelemetry::TracingContext>();
             request->tracing_context->deserialize(read_buffer);
 
             ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->receive_request, request->tracing_context.get(), receive_start_time);

--- a/src/Server/KeeperTCPHandler.cpp
+++ b/src/Server/KeeperTCPHandler.cpp
@@ -479,7 +479,7 @@ void KeeperTCPHandler::runImpl()
                                  const Coordination::ZooKeeperResponsePtr & response, Coordination::ZooKeeperRequestPtr request)
     {
         if (request)
-            ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans.send_response, request->tracing_context);
+            ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->send_response, request->tracing_context.get());
 
         if (!my_responses->push(RequestWithResponse{response, std::move(request)}))
             throw Exception(ErrorCodes::SYSTEM_ERROR, "Could not push response with xid {} and zxid {}", response->xid, response->zxid);
@@ -581,7 +581,7 @@ void KeeperTCPHandler::runImpl()
                         return;
 
                     ZooKeeperOpentelemetrySpans::maybeFinalize(
-                        request->spans.send_response,
+                        request->spans->send_response,
                         [&]
                         {
                             return std::vector<OpenTelemetry::SpanAttribute>{
@@ -781,12 +781,12 @@ std::pair<Coordination::OpNum, Coordination::XID> KeeperTCPHandler::receiveReque
 
         if (has_tracing_context)
         {
-            request->tracing_context.emplace();
+            request->tracing_context = std::make_unique<OpenTelemetry::TracingContext>();
             request->tracing_context->deserialize(read_buffer);
 
-            ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans.receive_request, request->tracing_context, receive_start_time);
+            ZooKeeperOpentelemetrySpans::maybeInitialize(request->spans->receive_request, request->tracing_context.get(), receive_start_time);
             ZooKeeperOpentelemetrySpans::maybeFinalize(
-                request->spans.receive_request,
+                request->spans->receive_request,
                 [&]
                 {
                     return std::vector<OpenTelemetry::SpanAttribute>{


### PR DESCRIPTION
In keeper-as-server mode (`asynchronous_metrics_keeper_metrics_only: true`), `Server.cpp` creates a `KeeperAsynchronousMetrics` object instead of `ServerAsynchronousMetrics`. However, `KeeperAsynchronousMetrics` does not override `logImpl()`, inheriting the base class no-op. As a result, `system.asynchronous_metric_log` is never populated — metrics are computed and available via `system.asynchronous_metrics`, but never written to the log table.

Override `logImpl()` in `KeeperAsynchronousMetrics` following the same pattern as `ServerAsynchronousMetrics`: get the `AsynchronousMetricLog` from the context and call `addValues()`.

Found while debugging the keeper system logs pipeline — `asynchronous_metric_log` was configured for S3 flushing but the S3 bucket had zero files because the table never received any data.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `system.asynchronous_metric_log` never being populated in keeper-as-server mode because `KeeperAsynchronousMetrics` did not override `logImpl()`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
