### PR TITLE
Fix asynchronous_metric_log never populated in keeper-as-server mode

### DIFF
--- a/src/Coordination/KeeperAsynchronousMetrics.cpp
+++ b/src/Coordination/KeeperAsynchronousMetrics.cpp
@@ -5,6 +5,7 @@
 
 #include <Common/getCurrentProcessFDCount.h>
 #include <Common/getMaxFileDescriptorCount.h>
+#include <Interpreters/AsynchronousMetricLog.h>
 #include <Interpreters/Context.h>
 
 namespace DB
@@ -142,6 +143,12 @@ void KeeperAsynchronousMetrics::updateImpl(TimePoint /*update_time*/, TimePoint 
             updateKeeperInformation(*keeper_dispatcher, new_values);
     }
 #endif
+}
+
+void KeeperAsynchronousMetrics::logImpl(AsynchronousMetricValues & new_values)
+{
+    if (auto asynchronous_metric_log = context->getAsynchronousMetricLog())
+        asynchronous_metric_log->addValues(new_values);
 }
 
 }

--- a/src/Coordination/KeeperAsynchronousMetrics.h
+++ b/src/Coordination/KeeperAsynchronousMetrics.h
@@ -24,6 +24,7 @@ private:
     ContextPtr context;
 
     void updateImpl(TimePoint update_time, TimePoint current_time, bool force_update, bool first_run, AsynchronousMetricValues & new_values) override;
+    void logImpl(AsynchronousMetricValues & new_values) override;
 };
 
 

--- a/tests/integration/test_keeper_metrics_only/configs/config.xml
+++ b/tests/integration/test_keeper_metrics_only/configs/config.xml
@@ -9,6 +9,12 @@
 
     <asynchronous_metrics_keeper_metrics_only>true</asynchronous_metrics_keeper_metrics_only>
 
+    <asynchronous_metric_log>
+        <database>system</database>
+        <table>asynchronous_metric_log</table>
+        <flush_interval_milliseconds>1000</flush_interval_milliseconds>
+    </asynchronous_metric_log>
+
     <keeper_server>
         <tcp_port>9181</tcp_port>
         <server_id>1</server_id>

--- a/tests/integration/test_keeper_metrics_only/test.py
+++ b/tests/integration/test_keeper_metrics_only/test.py
@@ -33,3 +33,12 @@ def test_prometheus_keeper_metrics_only(start_cluster):
     assert prometheus_handler_response.status_code == 200
     assert "ClickHouseAsyncMetrics_KeeperIsStandalone" in prometheus_handler_response.text
     assert "PolygonDictionaryThreads" not in prometheus_handler_response.text
+
+
+
+def test_asynchronous_metric_log(start_cluster):
+    node.query("SYSTEM FLUSH LOGS")
+
+    assert int(node.query(
+        "SELECT count() FROM system.asynchronous_metric_log WHERE metric = 'KeeperIsLeader'"
+    ).strip()) > 0


### PR DESCRIPTION
In keeper-as-server mode (`asynchronous_metrics_keeper_metrics_only: true`), `Server.cpp` creates a `KeeperAsynchronousMetrics` instead of `ServerAsynchronousMetrics`. `KeeperAsynchronousMetrics` does not override `logImpl()`, inheriting the base class no-op, so `system.asynchronous_metric_log` is never populated — metrics are computed and exposed via `system.asynchronous_metrics` but never written to the log table.

Override `logImpl()` in `KeeperAsynchronousMetrics` following the same pattern as `ServerAsynchronousMetrics`.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `system.asynchronous_metric_log` never being populated in keeper-as-server mode because `KeeperAsynchronousMetrics` did not override `logImpl()`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
