### PR TITLE
Fix crash in cluster discovery static configuration

### DIFF
--- a/src/Interpreters/ClusterDiscovery.cpp
+++ b/src/Interpreters/ClusterDiscovery.cpp
@@ -487,6 +487,9 @@ void ClusterDiscovery::removeCluster(const String & name, bool is_dynamic)
         std::lock_guard lock(mutex);
         cluster_impls.erase(name);
     }
+    /// For static clusters (defined in config), `clusters_to_update` and `get_nodes_callbacks`
+    /// are initialized once at startup and must persist so the cluster can be re-registered after
+    /// a ZooKeeper session loss. Dynamic clusters own their entries and must clean them up.
     if (is_dynamic)
     {
         clusters_to_update->remove(name);

--- a/src/Interpreters/ClusterDiscovery.cpp
+++ b/src/Interpreters/ClusterDiscovery.cpp
@@ -470,20 +470,7 @@ bool ClusterDiscovery::upsertCluster(ClusterInfo & cluster_info)
 
     if (nodes_info.empty())
     {
-        if (cluster_info.zk_root_index != 0)
-        {
-            String name = cluster_info.name;
-            /// cluster_info removed inside removeCluster, can't use reference to name.
-            removeCluster(name);
-        }
-        else
-        {
-            /// Static cluster (defined in config) with no nodes. Don't erase watch callback
-            /// (via removeCluster) - nodes may reappear, and the callback is needed to detect that.
-            /// Just hide the cluster from system.clusters until nodes come back.
-            std::lock_guard lock(mutex);
-            cluster_impls.erase(cluster_info.name);
-        }
+        removeCluster(cluster_info.name, /* is_dynamic_cluster */cluster_info.zk_root_index != 0);
         return true;
     }
 
@@ -494,15 +481,18 @@ bool ClusterDiscovery::upsertCluster(ClusterInfo & cluster_info)
     return true;
 }
 
-void ClusterDiscovery::removeCluster(const String & name)
+void ClusterDiscovery::removeCluster(const String & name, bool is_dynamic)
 {
     {
         std::lock_guard lock(mutex);
         cluster_impls.erase(name);
     }
-    clusters_to_update->remove(name);
-    get_nodes_callbacks.erase(name);
-    LOG_DEBUG(log, "Dynamic cluster '{}' removed successfully", name);
+    if (is_dynamic)
+    {
+        clusters_to_update->remove(name);
+        get_nodes_callbacks.erase(name);
+        LOG_DEBUG(log, "Dynamic cluster '{}' removed successfully", name);
+    }
 }
 
 void ClusterDiscovery::registerInZk(zkutil::ZooKeeperPtr & zk, ClusterInfo & info)
@@ -730,7 +720,7 @@ bool ClusterDiscovery::runMainThread(std::function<void()> up_to_date_callback)
             clusters_to_insert.insert(cluster_name);
 
         for (const auto & cluster_name : clusters_to_remove)
-            removeCluster(cluster_name);
+            removeCluster(cluster_name, /* is_dynamic_cluster */true);
 
         clusters_info.merge(new_dynamic_clusters_info);
 

--- a/src/Interpreters/ClusterDiscovery.cpp
+++ b/src/Interpreters/ClusterDiscovery.cpp
@@ -470,9 +470,20 @@ bool ClusterDiscovery::upsertCluster(ClusterInfo & cluster_info)
 
     if (nodes_info.empty())
     {
-        String name = cluster_info.name;
-        /// cluster_info removed inside removeCluster, can't use reference to name.
-        removeCluster(name);
+        if (cluster_info.zk_root_index != 0)
+        {
+            String name = cluster_info.name;
+            /// cluster_info removed inside removeCluster, can't use reference to name.
+            removeCluster(name);
+        }
+        else
+        {
+            /// Static cluster (defined in config) with no nodes. Don't erase watch callback
+            /// (via removeCluster) - nodes may reappear, and the callback is needed to detect that.
+            /// Just hide the cluster from system.clusters until nodes come back.
+            std::lock_guard lock(mutex);
+            cluster_impls.erase(cluster_info.name);
+        }
         return true;
     }
 

--- a/src/Interpreters/ClusterDiscovery.h
+++ b/src/Interpreters/ClusterDiscovery.h
@@ -126,7 +126,7 @@ private:
 
     bool needUpdate(const Strings & node_uuids, const NodesInfo & nodes);
     bool upsertCluster(ClusterInfo & cluster_info);
-    void removeCluster(const String & name);
+    void removeCluster(const String & name, bool is_dynamic);
 
     bool runMainThread(std::function<void()> up_to_date_callback);
     void shutdown();

--- a/tests/integration/test_cluster_discovery/test.py
+++ b/tests/integration/test_cluster_discovery/test.py
@@ -124,6 +124,59 @@ def test_cluster_discovery_startup_and_stop(start_cluster):
     nodes["node0"].query("DROP TABLE tbl ON CLUSTER 'test_auto_cluster' SYNC")
 
 
+def test_cluster_discovery_no_crash_on_empty_static_cluster(start_cluster):
+    """
+    Regression test: server must not crash when a static cluster temporarily has no nodes.
+
+    Crash path (without fix):
+    1. All member nodes stop → ZK ephemeral nodes deleted → observer detects empty cluster.
+    2. upsertCluster sees nodes_info.empty() → calls removeCluster() → erases watch callback
+       from get_nodes_callbacks.
+    3. A member node restarts → old ZK watch fires → cluster re-queued for update.
+    4. upsertCluster is called again → on_exit calls getNodeNames(set_callback=True).
+    5. Callback not found, zk_root_index==0 → multicluster_discovery_paths[0-1] OOB → crash.
+    """
+    import time
+
+    observer = nodes["node_observer"]
+    member_nodes = [nodes[n] for n in ("node0", "node1", "node2", "node3", "node4")]
+
+    # Wait for cluster to be fully up before the test
+    check_on_cluster(
+        [observer], len(member_nodes), what="count()", msg="Pre-test cluster count wrong"
+    )
+
+    # Stop all member nodes gracefully — closes ZK sessions immediately,
+    # deleting their ephemeral registration nodes in ZK.
+    for node in member_nodes:
+        node.stop_clickhouse()
+
+    # Wait for the observer to detect the now-empty cluster.
+    # This triggers upsertCluster → nodes_info.empty() → removeCluster() erasing the
+    # watch callback (the step that sets up the crash on the subsequent call).
+    check_on_cluster(
+        [observer], 0, what="count()", msg="Cluster should appear empty to observer"
+    )
+
+    assert observer.query("SELECT 1").strip() == "1", "Observer crashed after cluster became empty"
+
+    # Restart one member node. It registers in ZK, which triggers the old watch callback
+    # that was stored in the ZK client (independently of get_nodes_callbacks).
+    # On unfixed code this triggers the second upsertCluster call that crashes.
+    nodes["node0"].start_clickhouse()
+    time.sleep(10)
+
+    assert observer.query("SELECT 1").strip() == "1", "Observer crashed after member node restarted"
+
+    # Restore all nodes for subsequent tests
+    for node in member_nodes[1:]:
+        node.start_clickhouse()
+
+    check_on_cluster(
+        [observer], len(member_nodes), what="count()", msg="Cluster should recover after restart"
+    )
+
+
 def test_cluster_discovery_macros(start_cluster):
     # wait for all nodes to be started
     check_nodes_count = functools.partial(


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1684
<!-- End of fixes issue link part, do not remove -->

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a server exception in ClusterDiscovery when a static cluster (defined in config) temporarily had no live nodes. 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1023`
- Backported to: `26.3.10.34`, `26.2.17.8`, `26.1.12.4`
<!-- ch-version-info:end -->