### PR TITLE
Add skip_alias_columns config for DefaultSystemLogFlushPolicy

### DIFF
--- a/src/Interpreters/SystemLog.cpp
+++ b/src/Interpreters/SystemLog.cpp
@@ -248,6 +248,8 @@ std::shared_ptr<TSystemLog> createSystemLog(
     if constexpr (std::is_same_v<TSystemLog, TraceLog>)
         log_settings.symbolize_traces = config.getBool(config_prefix + ".symbolize", true);
 
+    log_settings.skip_alias_columns = config.getBool("default_system_log_flush_policy.skip_alias_columns", false);
+
     log_settings.queue_settings.turn_off_logger = TSystemLog::shouldTurnOffLogger();
 
     if constexpr (std::is_same_v<TSystemLog, MetricLog>)
@@ -560,7 +562,7 @@ SystemLog<LogElement>::SystemLog(
     , log(getLogger("SystemLog (" + settings_.queue_settings.database + "." + settings_.queue_settings.table + ")"))
     , table_id(settings_.queue_settings.database, settings_.queue_settings.table)
     , storage_def(settings_.engine)
-    , flush_policy(std::make_unique<DefaultSystemLogFlushPolicy>())
+    , flush_policy(std::make_unique<DefaultSystemLogFlushPolicy>(settings_.skip_alias_columns))
 {
     create_query = getCreateTableQuery()->formatWithSecretsOneLine();
     assert(settings_.queue_settings.database == DatabaseCatalog::SYSTEM_DATABASE);

--- a/src/Interpreters/SystemLog.h
+++ b/src/Interpreters/SystemLog.h
@@ -179,6 +179,7 @@ struct SystemLogSettings
 
     String engine;
     bool symbolize_traces = false;
+    bool skip_alias_columns = false;
 };
 
 template <typename LogElement>

--- a/src/Interpreters/SystemLogDefaultFlushPolicy.h
+++ b/src/Interpreters/SystemLogDefaultFlushPolicy.h
@@ -9,11 +9,17 @@ namespace DB
 class DefaultSystemLogFlushPolicy : public ISystemLogFlushPolicy
 {
 public:
+    explicit DefaultSystemLogFlushPolicy(bool skip_alias_columns_ = false)
+        : skip_alias_columns(skip_alias_columns_) {}
+
     bool isManualFlush(uint64_t /*to_flush_end*/) override { return false; }
     void prepareManualFlush(uint64_t /*target_index*/) override {}
     void afterFlush(const BlockIO & /*io*/, bool /*is_manual_flush*/, size_t /*flush_size*/) override {}
     void addInsertSettings(ContextMutablePtr & /*context*/) override {}
-    bool shouldSkipAliasColumns() override { return false; }
+    bool shouldSkipAliasColumns() override { return skip_alias_columns; }
+
+private:
+    bool skip_alias_columns = false;
 };
 
 }


### PR DESCRIPTION
When system log tables use an S3-backed engine (e.g. `ENGINE = S3(...)` in keeper configs), the `build_id` ALIAS column on `trace_log` causes `Code: 36. DB::Exception: Special columns like MATERIALIZED, ALIAS or EPHEMERAL are not supported for s3 storage`. The `DefaultSystemLogFlushPolicy` always returns `false` for `shouldSkipAliasColumns()`, so alias columns are always included in `CREATE TABLE`.

Add a `default_system_log_flush_policy.skip_alias_columns` server-level config option (default `false`) that is passed to `DefaultSystemLogFlushPolicy` and controls whether alias columns are omitted from system log table DDL.

Deployments using raw S3 engines for system logs (e.g. keeper-as-server) can set:
```xml
<default_system_log_flush_policy>
    <skip_alias_columns>true</skip_alias_columns>
</default_system_log_flush_policy>
```

### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add `default_system_log_flush_policy.skip_alias_columns` config option to allow omitting ALIAS columns from system log tables, fixing S3-backed system logs that reject ALIAS columns.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
