### PR TITLE
Fix wrong date data type inference in case of overflow after timezone adjustment

### DIFF
--- a/src/IO/parseDateTimeBestEffort.cpp
+++ b/src/IO/parseDateTimeBestEffort.cpp
@@ -867,6 +867,15 @@ ReturnType parseDateTimeBestEffortImpl(
             }
             res = *res_maybe;
             adjust_time_zone();
+
+            /// After timezone adjustment, the value may have shifted outside the valid range.
+            /// For example, "2106-02-07 06:28:15-01:00" is within range before adjustment,
+            /// but after converting to UTC it exceeds UINT32_MAX.
+            if constexpr (!is_64)
+            {
+                if (res < 0 || static_cast<uint64_t>(res) > UINT32_MAX)
+                    return false;
+            }
         }
         else
         {

--- a/tests/queries/0_stateless/04093_best_effort_datetime_timezone_boundary_range_check.reference
+++ b/tests/queries/0_stateless/04093_best_effort_datetime_timezone_boundary_range_check.reference
@@ -1,0 +1,4 @@
+2106-02-07 07:28:15.000000000	Nullable(DateTime64(9))
+1969-12-31 23:00:00.000000000	Nullable(DateTime64(9))
+2106-02-07 05:28:15	Nullable(DateTime)
+1970-01-01 00:00:00	Nullable(DateTime)

--- a/tests/queries/0_stateless/04093_best_effort_datetime_timezone_boundary_range_check.sql
+++ b/tests/queries/0_stateless/04093_best_effort_datetime_timezone_boundary_range_check.sql
@@ -1,0 +1,20 @@
+-- Tags: no-fasttest
+-- Test for missing range check after adjust_time_zone in parseDateTimeBestEffortImpl
+-- https://github.com/ClickHouse/ClickHouse/issues/102601
+
+SET session_timezone = 'UTC';
+SET date_time_input_format = 'best_effort';
+
+-- Upper boundary: 2106-02-07 06:28:15 UTC is exactly UINT32_MAX.
+-- With -01:00 offset, UTC time is 2106-02-07 07:28:15, which exceeds UINT32_MAX.
+-- Should be inferred as DateTime64, not DateTime with wrap-around.
+SELECT d, toTypeName(d) FROM format(JSONEachRow, '{"d" : "2106-02-07 06:28:15-01:00"}');
+
+-- Lower boundary: 1970-01-01 00:00:00 UTC is timestamp 0.
+-- With +01:00 offset, UTC time is 1969-12-31 23:00:00, which is negative.
+-- Should be inferred as DateTime64, not DateTime with clamped value.
+SELECT d, toTypeName(d) FROM format(JSONEachRow, '{"d" : "1970-01-01 00:00:00+01:00"}');
+
+-- Control: values that SHOULD remain DateTime (timezone adjustment stays within range)
+SELECT d, toTypeName(d) FROM format(JSONEachRow, '{"d" : "2106-02-07 06:28:15+01:00"}');
+SELECT d, toTypeName(d) FROM format(JSONEachRow, '{"d" : "1970-01-01 01:00:00+01:00"}');


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix wrong date data type inference in case of overflow after timezone adjustment. Closes https://github.com/ClickHouse/ClickHouse/issues/102601

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1003`
- Backported to: `26.3.10.21`, `26.2.17.6`, `26.1.12.3`, `25.8.23.4`
<!-- ch-version-info:end -->