### PR TITLE
Fix SYSTEM WAIT VIEW hanging forever when the view is dropped

### DIFF
--- a/src/Storages/MaterializedView/RefreshTask.cpp
+++ b/src/Storages/MaterializedView/RefreshTask.cpp
@@ -229,6 +229,11 @@ void RefreshTask::shutdown()
     set_handle.reset();
 
     view = nullptr;
+
+    /// Wake up any threads blocked in wait(), so they can see !view and throw TABLE_IS_DROPPED.
+    /// Without this, wait() would block forever after deactivate() prevents the background task
+    /// from running (and therefore from ever notifying refresh_cv).
+    refresh_cv.notify_all();
 }
 
 void RefreshTask::drop(ContextPtr context)
@@ -404,8 +409,10 @@ void RefreshTask::wait()
 
     std::unique_lock lock(mutex);
     refresh_cv.wait(lock, [&] {
-        return state != RefreshState::Running && state != RefreshState::Scheduling &&
-            state != RefreshState::RunningOnAnotherReplica && (state == RefreshState::Disabled || !scheduling.out_of_schedule_refresh_requested);
+        return !view
+            || (state != RefreshState::Running && state != RefreshState::Scheduling
+                && state != RefreshState::RunningOnAnotherReplica
+                && (state == RefreshState::Disabled || !scheduling.out_of_schedule_refresh_requested));
     });
     throw_if_error();
 


### PR DESCRIPTION
`RefreshTask::shutdown()` deactivates the background task and sets `view = nullptr`, but never notifies `refresh_cv`. Any SYSTEM WAIT VIEW blocked on that condition variable hangs forever.

Fix: check `!view` in the `wait()` condition and call `refresh_cv.notify_all()` in `shutdown()`.

cc: @al13n321 

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `SYSTEM WAIT VIEW` hanging forever when the refreshable materialized view is dropped while the wait is in progress.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.935`
- Backported to: `26.3.10.4`, `26.2.15.7`, `26.1.10.6`, `25.8.22.26`
<!-- ch-version-info:end -->