### PR TITLE
Fix granule propagation in text index analysis with reading in order

### DIFF
--- a/src/Processors/QueryPlan/PartsSplitter.cpp
+++ b/src/Processors/QueryPlan/PartsSplitter.cpp
@@ -245,7 +245,8 @@ public:
                 initial_ranges_in_data_parts[part_index].parent_part,
                 initial_ranges_in_data_parts[part_index].part_index_in_query,
                 initial_ranges_in_data_parts[part_index].part_starting_offset_in_query,
-                MarkRanges{mark_range});
+                MarkRanges{mark_range},
+                initial_ranges_in_data_parts[part_index].read_hints);
             part_index_to_initial_ranges_in_data_parts_index[it->second] = part_index;
             return;
         }

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -1388,7 +1388,8 @@ Pipe ReadFromMergeTree::spreadMarkRangesAmongStreamsWithOrder(
                     part.parent_part,
                     part.part_index_in_query,
                     part.part_starting_offset_in_query,
-                    std::move(ranges_to_get_from_part));
+                    std::move(ranges_to_get_from_part),
+                    part.read_hints);
             }
 
             split_parts_and_ranges.emplace_back(std::move(new_parts));
@@ -1731,7 +1732,8 @@ Pipe ReadFromMergeTree::spreadMarkRangesAmongStreamsFinal(
                     part_it->parent_part,
                     part_it->part_index_in_query,
                     part_it->part_starting_offset_in_query,
-                    part_it->ranges);
+                    part_it->ranges,
+                    part_it->read_hints);
                 current_ranges_marks += part_it->getMarksCount();
             }
 
@@ -2714,7 +2716,8 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(
                             it_parts->parent_part,
                             it_parts->part_index_in_query,
                             it_parts->part_starting_offset_in_query,
-                            std::move(diff_ranges));
+                            std::move(diff_ranges),
+                            it_parts->read_hints);
                     }
 
                     ++it_parts;

--- a/src/Processors/Sources/LazyReadFromMergeTreeSource.cpp
+++ b/src/Processors/Sources/LazyReadFromMergeTreeSource.cpp
@@ -79,7 +79,8 @@ RangesInDataParts LazyReadFromMergeTreeSource::splitRanges(RangesInDataParts par
                     part.parent_part,
                     part.part_index_in_query,
                     part.part_starting_offset_in_query,
-                    std::move(part.ranges));
+                    std::move(part.ranges),
+                    part.read_hints);
 
                 break;
             }
@@ -123,7 +124,8 @@ RangesInDataParts LazyReadFromMergeTreeSource::splitRanges(RangesInDataParts par
                 part.parent_part,
                 part.part_index_in_query,
                 part.part_starting_offset_in_query,
-                std::move(ranges));
+                std::move(ranges),
+                part.read_hints);
         }
     }
 

--- a/src/Storages/MergeTree/MergeTreeReaderTextIndex.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderTextIndex.cpp
@@ -183,6 +183,8 @@ void MergeTreeReaderTextIndex::readGranule()
     auto substreams = index.index->getSubstreams();
     auto data_part = getDataPart();
 
+    LOG_TRACE(getLogger("MergeTreeReaderTextIndex"), "Reading text index granule for data part '{}'", data_part->getDataPartStorage().getFullPath());
+
     auto make_stream = [&](const auto & substream)
     {
         return makeTextIndexInputStream(

--- a/src/Storages/MergeTree/RangesInDataPart.cpp
+++ b/src/Storages/MergeTree/RangesInDataPart.cpp
@@ -107,12 +107,14 @@ RangesInDataPart::RangesInDataPart(
     const DataPartPtr & parent_part_,
     size_t part_index_in_query_,
     size_t part_starting_offset_in_query_,
-    const MarkRanges & ranges_)
+    const MarkRanges & ranges_,
+    const RangesInDataPartReadHints & read_hints_)
     : data_part{data_part_}
     , parent_part{parent_part_}
     , part_index_in_query{part_index_in_query_}
     , part_starting_offset_in_query{part_starting_offset_in_query_}
     , ranges{ranges_}
+    , read_hints{read_hints_}
 {
 }
 

--- a/src/Storages/MergeTree/RangesInDataPart.h
+++ b/src/Storages/MergeTree/RangesInDataPart.h
@@ -122,7 +122,8 @@ struct RangesInDataPart
         const DataPartPtr & parent_part_,
         size_t part_index_in_query_,
         size_t part_starting_offset_in_query_,
-        const MarkRanges & ranges_);
+        const MarkRanges & ranges_,
+        const RangesInDataPartReadHints & read_hints_);
 
     explicit RangesInDataPart(
         const DataPartPtr & data_part_,

--- a/tests/queries/0_stateless/04098_text_index_read_once.reference
+++ b/tests/queries/0_stateless/04098_text_index_read_once.reference
@@ -1,4 +1,10 @@
 2
 2
+322
+777
+322
+777
+use_skip_indexes_on_data_read: 0	ReadSparseIndexBlocks: 1	HeaderCacheHits: 0	HeaderCacheMisses: 1
+use_skip_indexes_on_data_read: 1	ReadSparseIndexBlocks: 1	HeaderCacheHits: 0	HeaderCacheMisses: 1
 use_skip_indexes_on_data_read: 0	ReadSparseIndexBlocks: 1	HeaderCacheHits: 0	HeaderCacheMisses: 1
 use_skip_indexes_on_data_read: 1	ReadSparseIndexBlocks: 1	HeaderCacheHits: 0	HeaderCacheMisses: 1

--- a/tests/queries/0_stateless/04098_text_index_read_once.sql
+++ b/tests/queries/0_stateless/04098_text_index_read_once.sql
@@ -5,16 +5,20 @@ DROP TABLE IF EXISTS t_text_index_read_once;
 
 CREATE TABLE t_text_index_read_once
 (
+    id UInt64,
     s String,
     INDEX idx_s(s) TYPE text (tokenizer = splitByNonAlpha)
 )
-ENGINE = MergeTree ORDER BY tuple();
+ENGINE = MergeTree ORDER BY id;
 
-INSERT INTO t_text_index_read_once SELECT 's' || toString(number) FROM numbers(1000);
+INSERT INTO t_text_index_read_once SELECT number, 's' || toString(number) FROM numbers(1000);
 OPTIMIZE TABLE t_text_index_read_once FINAL;
 
 SELECT count() FROM t_text_index_read_once WHERE hasAllTokens(s, 's322') OR hasAllTokens(s, 's777') SETTINGS use_skip_indexes_on_data_read = 0, max_threads = 1, use_text_index_header_cache = 0;
 SELECT count() FROM t_text_index_read_once WHERE hasAllTokens(s, 's322') OR hasAllTokens(s, 's777') SETTINGS use_skip_indexes_on_data_read = 1, max_threads = 1, use_text_index_header_cache = 0;
+
+SELECT id FROM t_text_index_read_once WHERE hasAllTokens(s, 's322') OR hasAllTokens(s, 's777') ORDER BY id SETTINGS use_skip_indexes_on_data_read = 0, max_threads = 1, use_text_index_header_cache = 0;
+SELECT id FROM t_text_index_read_once WHERE hasAllTokens(s, 's322') OR hasAllTokens(s, 's777') ORDER BY id SETTINGS use_skip_indexes_on_data_read = 1, max_threads = 1, use_text_index_header_cache = 0;
 
 SYSTEM FLUSH LOGS query_log;
 
@@ -27,7 +31,7 @@ FROM system.query_log
 WHERE event_date >= yesterday()
     AND current_database = currentDatabase()
     AND type = 'QueryFinish'
-    AND query LIKE 'SELECT count() FROM t_text_index_read_once%'
+    AND query LIKE 'SELECT%FROM t_text_index_read_once%'
 ORDER BY event_time_microseconds;
 
 DROP TABLE t_text_index_read_once;


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1466
<!-- End of fixes issue link part, do not remove -->

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Bugfix for unreleased change. In addition to #102255.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.943`
<!-- ch-version-info:end -->