### PR TITLE
Fix format_schema_source='query' silently ignoring multi-row results

### DIFF
--- a/src/Formats/FormatSchemaInfo.cpp
+++ b/src/Formats/FormatSchemaInfo.cpp
@@ -227,6 +227,12 @@ String FormatSchemaInfo::querySchema(const String & query)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected the schema query result to have one column");
 
         auto & column = block.getByPosition(0).column;
+        if (column->size() != 1)
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Expected the schema query result to have one row, got {}",
+                column->size());
+
         if (const auto * col_str = typeid_cast<const ColumnString *>(column.get()))
         {
             result = col_str->getDataAt(0);

--- a/tests/queries/0_stateless/04094_format_schema_source_query_multirow.reference
+++ b/tests/queries/0_stateless/04094_format_schema_source_query_multirow.reference
@@ -1,0 +1,2 @@
+Expected the schema query result to have one row
+1	abc

--- a/tests/queries/0_stateless/04094_format_schema_source_query_multirow.sh
+++ b/tests/queries/0_stateless/04094_format_schema_source_query_multirow.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+# Addresses https://github.com/ClickHouse/ClickHouse/issues/101905
+# format_schema_source='query' should reject multi-row query results
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+PROTO_SCHEMA='syntax = "proto3"; message KVP { uint64 key = 1; string value = 2; }'
+
+# Should fail because the schema query returns multiple rows
+${CLICKHOUSE_LOCAL} --logger.console=0 --query "
+CREATE TABLE test_data (key UInt64, value String) ENGINE = MergeTree() ORDER BY key;
+INSERT INTO test_data VALUES (1, 'abc');
+SELECT * FROM test_data
+SETTINGS
+    format_schema_source = 'query',
+    format_schema = 'SELECT ''${PROTO_SCHEMA}'' FROM numbers(3)',
+    format_schema_message_name = 'KVP'
+FORMAT Protobuf;
+" 2>&1 | grep -o 'Expected the schema query result to have one row'
+
+# Should succeed with a query that returns exactly one row
+${CLICKHOUSE_LOCAL} --logger.console=0 --query "
+CREATE TABLE test_data (key UInt64, value String) ENGINE = MergeTree() ORDER BY key;
+INSERT INTO test_data VALUES (1, 'abc');
+SELECT * FROM test_data
+SETTINGS
+    format_schema_source = 'query',
+    format_schema = 'SELECT ''${PROTO_SCHEMA}''',
+    format_schema_message_name = 'KVP'
+FORMAT Protobuf;
+" | ${CLICKHOUSE_LOCAL} --logger.console=0 --input-format Protobuf --structure 'key UInt64, value String' --query "
+SELECT * FROM table
+SETTINGS
+    format_schema_source = 'query',
+    format_schema = 'SELECT ''${PROTO_SCHEMA}''',
+    format_schema_message_name = 'KVP';
+"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix format_schema_source='query' silently ignoring multi-row results. Closes https://github.com/ClickHouse/ClickHouse/issues/101905

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.957`
<!-- ch-version-info:end -->