### PR TITLE
Fix SSH exit code

### DIFF
--- a/src/Server/SSH/SSHPtyHandler.cpp
+++ b/src/Server/SSH/SSHPtyHandler.cpp
@@ -101,7 +101,7 @@ public:
     }
 
     bool hasClientFinished() { return client_runner.has_value() && client_runner->hasFinished(); }
-    int getClientExitCode() { return client_runner.has_value() && client_runner->getExitCode(); }
+    int getClientExitCode() { return client_runner.has_value() ? client_runner->getExitCode() : 0; }
 
 
     DescriptorSet client_input_output;

--- a/tests/integration/test_ssh/test.py
+++ b/tests/integration/test_ssh/test.py
@@ -55,10 +55,7 @@ def test_no_queries_from_file(started_cluster):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-    # Not sure which exit code should the ssh command have in this case
-    # Ideally it should be non-zero as be same as `ssh -vvv user@host "false"; echo $?` == 1
-    # But for now it is 0.
-    assert completed_process.returncode == 1
+    assert completed_process.returncode != 0
     assert "SUPPORT_IS_DISABLED" in completed_process.stderr
 
 

--- a/tests/integration/test_ssh/test.py
+++ b/tests/integration/test_ssh/test.py
@@ -55,7 +55,8 @@ def test_no_queries_from_file(started_cluster):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-    assert completed_process.returncode != 0
+    # SUPPORT_IS_DISABLED error code is 344, exit code = 344 % 256 = 88
+    assert completed_process.returncode == 88
     assert "SUPPORT_IS_DISABLED" in completed_process.stderr
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Report actual exit code via SSH client instead of mapping all errors to `1`. Closes https://github.com/ClickHouse/ClickHouse/issues/101741.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.945`
<!-- ch-version-info:end -->