### PR TITLE
Fix flaky test 02974_analyzer_array_join_subcolumn

### DIFF
--- a/tests/queries/0_stateless/02974_analyzer_array_join_subcolumn.sql
+++ b/tests/queries/0_stateless/02974_analyzer_array_join_subcolumn.sql
@@ -7,17 +7,17 @@ INSERT INTO t2 VALUES (1, {'a': (1, 2), 'b': (2, 3)}),;
 CREATE TABLE t3 (id Int32, c Tuple(v String, pe Map(String, Tuple(a UInt64, b UInt64)))) ENGINE = MergeTree ORDER BY id;
 INSERT INTO t3 VALUES (1, ('A', {'a':(1, 2),'b':(2, 3)}));
 
-SELECT pe, pe.values.a FROM (SELECT * FROM t2) ARRAY JOIN pe SETTINGS enable_analyzer = 1;
-SELECT p, p.values.a FROM (SELECT * FROM t2) ARRAY JOIN pe AS p SETTINGS enable_analyzer = 1;
+SELECT pe, pe.values.a FROM (SELECT * FROM t2) ARRAY JOIN pe ORDER BY 1 SETTINGS enable_analyzer = 1;
+SELECT p, p.values.a FROM (SELECT * FROM t2) ARRAY JOIN pe AS p ORDER BY 1 SETTINGS enable_analyzer = 1;
 
-SELECT pe, pe.values.a FROM t2 ARRAY JOIN pe;
-SELECT p, p.values.a FROM t2 ARRAY JOIN pe AS p;
+SELECT pe, pe.values.a FROM t2 ARRAY JOIN pe ORDER BY 1;
+SELECT p, p.values.a FROM t2 ARRAY JOIN pe AS p ORDER BY 1;
 
-SELECT c.pe, c.pe.values.a FROM (SELECT * FROM t3) ARRAY JOIN c.pe SETTINGS enable_analyzer = 1;
-SELECT p, p.values.a FROM (SELECT * FROM t3) ARRAY JOIN c.pe as p SETTINGS enable_analyzer = 1;
+SELECT c.pe, c.pe.values.a FROM (SELECT * FROM t3) ARRAY JOIN c.pe ORDER BY 1 SETTINGS enable_analyzer = 1;
+SELECT p, p.values.a FROM (SELECT * FROM t3) ARRAY JOIN c.pe as p ORDER BY 1 SETTINGS enable_analyzer = 1;
 
-SELECT c.pe, c.pe.values.a FROM t3 ARRAY JOIN c.pe SETTINGS enable_analyzer = 1;
-SELECT p, p.values.a FROM t3 ARRAY JOIN c.pe as p;
+SELECT c.pe, c.pe.values.a FROM t3 ARRAY JOIN c.pe ORDER BY 1 SETTINGS enable_analyzer = 1;
+SELECT p, p.values.a FROM t3 ARRAY JOIN c.pe as p ORDER BY 1;
 
 
 DROP TABLE IF EXISTS t2;


### PR DESCRIPTION
Add `ORDER BY 1` to all `ARRAY JOIN` queries on Map columns to ensure deterministic row ordering regardless of randomized Map serialization settings.

### Root Cause

When `map_serialization_version_for_zero_level_parts = 'with_buckets'` is combined with `max_buckets_in_map = 98`, `map_buckets_strategy = 'constant'`, and `map_buckets_min_avg_size = 1` (all randomized by the CI test runner), Map entries are serialized into hash-bucket order during zero-level part creation. On read-back, `ARRAY JOIN` iterates entries in bucket order rather than insertion order, reversing the output for keys `'a'` and `'b'`.

The test verifies that `ARRAY JOIN` on Map columns correctly accesses subcolumns (`.values.a`) through subqueries, aliases, and nested Tuples. It does not test Map iteration order. Adding `ORDER BY 1` makes the output deterministic while fully preserving the test's original intent.

### Reproduction

```sql
CREATE TABLE t2 (id Int32, pe Map(String, Tuple(a UInt64, b UInt64)))
ENGINE = MergeTree ORDER BY id
SETTINGS map_serialization_version_for_zero_level_parts = 'with_buckets',
         max_buckets_in_map = 98, map_buckets_strategy = 'constant',
         map_buckets_min_avg_size = 1;
INSERT INTO t2 VALUES (1, {'a': (1, 2), 'b': (2, 3)});
-- Without ORDER BY: ('b',...) before ('a',...) — reversed
SELECT pe, pe.values.a FROM (SELECT * FROM t2) ARRAY JOIN pe SETTINGS enable_analyzer = 1;
-- With ORDER BY 1: ('a',...) before ('b',...) — correct
SELECT pe, pe.values.a FROM (SELECT * FROM t2) ARRAY JOIN pe ORDER BY 1 SETTINGS enable_analyzer = 1;
```

### Validation

- 100/100 passes with full randomization (`--test-runs 100`)
- Deterministic failure without fix confirmed with the 4-setting combination above
- Reference file unchanged — output is identical with ORDER BY

<!-- Changelog category (leave one): -->
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- Changelog entry: -->
### Changelog entry (a]one-liner human-readable description of the changes):
- (not required)

<!-- Are there docs changes needed? -->
### Documentation check
- [ ] Documentation is not needed.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.984`
<!-- ch-version-info:end -->