### PR TITLE
Disable changed/new test detection in targeted check

### DIFF
--- a/ci/jobs/scripts/find_tests.py
+++ b/ci/jobs/scripts/find_tests.py
@@ -1929,12 +1929,12 @@ class Targeting:
                     seen.add(t)
                     ranked.append(t)
 
-        # Integration tests run changed test suboptimally (entire module), it might be too long
-        # limit it to stateless tests only
-        if self.job_type == self.STATELESS_JOB_TYPE:
-            changed_tests, result = self.get_changed_or_new_tests_with_info()
-            add_tests(changed_tests)
-            results.append(result)
+        # Changed/new tests are already covered by the flaky check — skip them
+        # in the targeted check to avoid duplication.
+        # if self.job_type == self.STATELESS_JOB_TYPE:
+        #     changed_tests, result = self.get_changed_or_new_tests_with_info()
+        #     add_tests(changed_tests)
+        #     results.append(result)
 
         previously_failed_tests, result = self.get_previously_failed_tests_with_info()
         add_tests(previously_failed_tests)


### PR DESCRIPTION
Disable `get_changed_or_new_tests_with_info` in the targeted check's `get_all_relevant_tests_with_info` pipeline. Changed/new tests are already covered by the flaky check — running them again in the targeted check is redundant.

The targeted check now only runs previously-failed tests and coverage-ranked tests.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.940`
<!-- ch-version-info:end -->