### PR TITLE
Fix losing HTTP headers for dynamic/predefined query handlers

### DIFF
--- a/src/Server/HTTPHandler.cpp
+++ b/src/Server/HTTPHandler.cpp
@@ -965,8 +965,12 @@ HTTPRequestHandlerFactoryPtr createDynamicHandlerFactory(IServer & server,
 
     HTTPHandlerConnectionConfig connection_config(config, config_prefix);
     HTTPResponseHeaderSetup http_response_headers_override = parseHTTPResponseHeaders(config, config_prefix);
-    if (http_response_headers_override.has_value())
+    if (!common_headers.empty())
+    {
+        if (!http_response_headers_override.has_value())
+            http_response_headers_override.emplace();
         http_response_headers_override.value().insert(common_headers.begin(), common_headers.end());
+    }
 
     auto creator = [&server, query_param_name, http_response_headers_override, connection_config]() -> std::unique_ptr<DynamicQueryHandler>
     { return std::make_unique<DynamicQueryHandler>(server, connection_config, query_param_name, http_response_headers_override); };
@@ -1031,8 +1035,12 @@ HTTPRequestHandlerFactoryPtr createPredefinedHandlerFactory(IServer & server,
     }
 
     HTTPResponseHeaderSetup http_response_headers_override = parseHTTPResponseHeaders(config, config_prefix);
-    if (http_response_headers_override.has_value())
+    if (!common_headers.empty())
+    {
+        if (!http_response_headers_override.has_value())
+            http_response_headers_override.emplace();
         http_response_headers_override.value().insert(common_headers.begin(), common_headers.end());
+    }
 
     std::shared_ptr<HandlingRuleHTTPHandlerFactory<PredefinedQueryHandler>> factory;
 

--- a/tests/integration/test_http_handlers_config/test.py
+++ b/tests/integration/test_http_handlers_config/test.py
@@ -678,6 +678,32 @@ def test_headers_in_response():
         assert response_predefined.headers["X-My-Common-Header"] == "Common header present"
 
 
+def test_common_headers_without_per_handler():
+    """Test that common_http_response_headers are present in responses from
+    dynamic_query_handler and predefined_query_handler even when those handlers
+    have no per-handler http_response_headers configured."""
+    with contextlib.closing(
+            SimpleCluster(
+                ClickHouseCluster(__file__), "common_headers_no_per_handler",
+                "test_common_headers_without_per_handler"
+            )
+    ) as cluster:
+        # dynamic_query_handler without per-handler headers
+        response = cluster.instance.http_request("?query=SELECT%201", method="GET")
+        assert response.status_code == 200
+        assert "X-My-Common-Header" in response.headers, \
+            "common_http_response_headers missing from dynamic_query_handler without per-handler headers"
+        assert response.headers["X-My-Common-Header"] == "Common header present"
+
+        # predefined_query_handler without per-handler headers
+        response_predefined = cluster.instance.http_request(
+            "query_param_with_url", method="GET", headers={"PARAMS_XXX": "test_param"})
+        assert response_predefined.status_code == 200
+        assert "X-My-Common-Header" in response_predefined.headers, \
+            "common_http_response_headers missing from predefined_query_handler without per-handler headers"
+        assert response_predefined.headers["X-My-Common-Header"] == "Common header present"
+
+
 def test_redirect_handler():
     with contextlib.closing(
         SimpleCluster(

--- a/tests/integration/test_http_handlers_config/test_common_headers_without_per_handler/config.xml
+++ b/tests/integration/test_http_handlers_config/test_common_headers_without_per_handler/config.xml
@@ -1,0 +1,29 @@
+<clickhouse>
+    <http_handlers>
+        <common_http_response_headers>
+            <X-My-Common-Header>Common header present</X-My-Common-Header>
+        </common_http_response_headers>
+
+        <rule>
+            <url>/query_param_with_url</url>
+            <methods>GET,HEAD</methods>
+            <headers>
+                <PARAMS_XXX><![CDATA[regex:(?P<name_1>[^/]+)]]></PARAMS_XXX>
+            </headers>
+            <handler>
+                <type>predefined_query_handler</type>
+                <query>
+                    SELECT {name_1:String}
+                </query>
+            </handler>
+        </rule>
+
+        <rule>
+            <methods>GET,POST,HEAD,OPTIONS</methods>
+            <handler>
+                <type>dynamic_query_handler</type>
+                <query_param_name>query</query_param_name>
+            </handler>
+        </rule>
+    </http_handlers>
+</clickhouse>


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix losing HTTP headers for dynamic/predefined query handlers. Closes https://github.com/ClickHouse/ClickHouse/issues/101846.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.955`
<!-- ch-version-info:end -->