### PR TITLE
CI: Strip bloated result data from Slack event feed

### DIFF
--- a/ci/praktika/event.py
+++ b/ci/praktika/event.py
@@ -90,6 +90,33 @@ class EventFeed:
                     e.ext = {}
                 e.ext["is_cancelled"] = True
 
+            # Compact bloated result entries that were stored before the
+            # pruning was added to Result.to_event.  The feed only needs
+            # name+status from each sub-result and report_url from ext.
+            result = getattr(e, "result", None)
+            if isinstance(result, dict):
+                for key in ("start_time", "duration", "files", "assets", "links", "info"):
+                    if key in result:
+                        del result[key]
+                results = result.get("results")
+                if isinstance(results, list) and results:
+                    first = results[0]
+                    if isinstance(first, dict) and len(first) > 2:
+                        result["results"] = [
+                            {
+                                "name": r.get("name", ""),
+                                "status": r.get("status", ""),
+                            }
+                            for r in results
+                            if isinstance(r, dict)
+                        ]
+                ext = result.get("ext")
+                if isinstance(ext, dict) and len(ext) > 1:
+                    report_url = ext.get("report_url", "")
+                    result["ext"] = (
+                        {"report_url": report_url} if report_url else {}
+                    )
+
         # Remove existing events that match the incoming event
         event_pr_number = event.ext.get("pr_number", 0)
         event_repo_name = event.ext.get("repo_name", "")

--- a/ci/praktika/event.py
+++ b/ci/praktika/event.py
@@ -42,7 +42,7 @@ class Event:
 
 
 # Maximum number of days to retain non-open PRs in the timeline
-MAX_TIMELINE_DAYS = 120
+MAX_TIMELINE_DAYS = 30
 
 
 def _sanitize_s3_key_name(name: str) -> str:

--- a/ci/praktika/infrastructure/lambda_function.py
+++ b/ci/praktika/infrastructure/lambda_function.py
@@ -597,7 +597,7 @@ lambda_worker_config = Lambda.Config(
         "praktika_slack_app_token": "SLACK_BOT_TOKEN",
     },
     timeout_ms=30 * 1000,
-    memory_size_mb=128,
+    memory_size_mb=256,
 )
 
 # local tests and development

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -987,18 +987,35 @@ class Result(MetaClasses.Serializable):
     def to_event(self, info: "Info"):
         result_dict = Result.to_dict(self)
 
-        def _prune_result_info(result):
+        def _prune_result_for_feed(result):
+            """Strip result down to fields used by the Slack feed.
+
+            The feed only needs ``name`` and ``status`` from each sub-result,
+            plus ``report_url`` from the top-level ``ext``.  Everything else
+            (links, storage_usage, files, assets, nested results, …) is dead
+            weight that bloats the per-user JSON on S3.
+            """
             if not isinstance(result, dict):
                 return
-            result.pop("info", None)
+
+            for key in ("info", "start_time", "duration", "files", "assets", "links"):
+                result.pop(key, None)
 
             results = result.get("results")
-            if not isinstance(results, list):
-                return
-            for r in results:
-                _prune_result_info(r)
+            if isinstance(results, list):
+                result["results"] = [
+                    {"name": r.get("name", ""), "status": r.get("status", "")}
+                    for r in results
+                    if isinstance(r, dict)
+                ]
 
-        _prune_result_info(result_dict)
+            # Keep only report_url from ext
+            ext = result.get("ext")
+            if isinstance(ext, dict):
+                report_url = ext.get("report_url", "")
+                result["ext"] = {"report_url": report_url} if report_url else {}
+
+        _prune_result_for_feed(result_dict)
 
         return Event(
             type=Event.Type.COMPLETED if self.is_completed() else Event.Type.RUNNING,


### PR DESCRIPTION
The per-user EventFeed JSON on S3 stored full CI job results including
links, `storage_usage`, files, assets, and nested results — none of which
the Slack feed rendering uses. Only `name` and `status` from each
sub-result and `report_url` from `result.ext` are needed.

This caused feeds to balloon (e.g. 2 MiB compressed / 27 MiB
uncompressed for a single user, 52 MiB for `clickhouse-gh[bot]`),
which made the 128 MB worker Lambda time out when loading/parsing
the feed to refresh the home view after a toggle.

- `Result.to_event`: strip result down to only feed-relevant fields
  at creation time
- `EventFeed.add`: retroactively compact old bloated entries on the
  next update so existing feeds shrink without a manual migration
- Bump worker Lambda memory from 128 to 256 MB as a safety net

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.942`
<!-- ch-version-info:end -->