### PR TITLE
Fix flaky test_mongo.py::test_simple_ssl file errors in dictionary test infrastructure

### DIFF
--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/common.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/common.py
@@ -191,7 +191,7 @@ class BaseLayoutTester:
 
     def cleanup(self):
         shutil.rmtree(self.get_dict_directory(), ignore_errors=True)
-        os.makedirs(self.get_dict_directory())
+        os.makedirs(self.get_dict_directory(), exist_ok=True)
 
     def list_dictionaries(self):
         dictionaries = []
@@ -201,6 +201,7 @@ class BaseLayoutTester:
         return dictionaries
 
     def create_dictionaries(self, source_):
+        os.makedirs(self.get_dict_directory(), exist_ok=True)
         for layout in self.layouts:
             if source_.compatible_with_layout(Layout(layout)):
                 self.layout_to_dictionary[layout] = self.get_dict(


### PR DESCRIPTION
Two filesystem bugs in `BaseLayoutTester` (in `test_dictionaries_all_layouts_separate_sources/common.py`) caused intermittent `FileExistsError` and `FileNotFoundError` crashes in `test_mongo.py::test_simple_ssl` across all 4 layout variants (flat, hashed, cache, direct).

### Root cause

**Bug 1 — `FileExistsError` in `cleanup()` (8 failures in 30 days):**
`cleanup()` calls `shutil.rmtree(path, ignore_errors=True)` then `os.makedirs(path)`. When `rmtree` silently fails to remove the directory (e.g., Docker containers from the previous `secure_connection=False` parametrization still holding file handles), `makedirs()` crashes because the directory already exists.

**Bug 2 — `FileNotFoundError` in `create_dictionaries()` (4 failures in 30 days):**
`complex_tester` and `ranged_tester` fixtures call `create_dictionaries()` which writes config files to a directory that only `simple_tester.cleanup()` creates. Since these three fixtures are independent (no dependency between them), pytest doesn't guarantee resolution order. If `ranged_tester` resolves before `simple_tester`, `generate_config()` → `open(path, "w")` crashes because the directory doesn't exist yet.

### Fix

1. `cleanup()`: Add `exist_ok=True` to `os.makedirs()` — resilient to failed `rmtree`
2. `create_dictionaries()`: Add `os.makedirs(dir, exist_ok=True)` at the start — ensures the directory exists regardless of fixture resolution order

### CIDB evidence (30-day window)

| Date | Failures | Error Type |
|------|----------|------------|
| 2026-04-15 | 4 | FileExistsError |
| 2026-04-11 | 4 | FileNotFoundError |

17 distinct PR/master entries total for `test_simple_ssl`, with 5 master failures. The file errors account for 8 of 22 non-infrastructure failures (the remaining are sanitizer findings and MongoDB connection issues — separate root causes not addressed here).

### Verification

All 4 variants pass locally with the fix:
- ✅ `test_simple_ssl[cache-True]`
- ✅ `test_simple_ssl[direct-True]`
- ✅ `test_simple_ssl[flat-True]`
- ✅ `test_simple_ssl[hashed-True]`

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)