### PR TITLE
CI: Propagate affected status for all jobs in requires

### DIFF
--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -558,24 +558,15 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
 
                 if is_affected:
                     affected_artifacts.extend(job.provides)
-                    if job.provides:
-                        # Also propagate the job name so that downstream jobs
-                        # requiring this job by name are marked as affected
-                        affected_artifacts.append(job.name)
+                    # Propagate the job name so that downstream jobs
+                    # requiring this job by name are marked as affected
+                    affected_artifacts.append(job.name)
                     # All items in requires are hard dependencies
                     for req in job.requires:
                         all_required_artifacts.add(req)
                 else:
                     print(f"Job [{job.name}] is not affected by the change")
-                    if not job.provides:
-                        workflow_config.set_job_as_filtered(
-                            job.name, "Not affected by the changed files"
-                        )
-                    else:
-                        print(
-                            f"NOTE: Job [{job.name}] is not affected, but may provide required artifacts"
-                        )
-                        unaffected_jobs_with_artifacts[job.name] = job.provides
+                    unaffected_jobs_with_artifacts[job.name] = job.provides
 
             print(f"All required artifacts [{all_required_artifacts}]")
             print(f"Affected artifacts [{affected_artifacts}]")
@@ -585,12 +576,12 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
                     or job_name in all_required_artifacts
                 ):
                     print(
-                        f"NOTE: Job [{job_name}] provides required artifacts - cannot be skipped"
+                        f"NOTE: Job [{job_name}] is required by affected jobs - cannot be skipped"
                     )
                 else:
                     workflow_config.set_job_as_filtered(
                         job_name,
-                        "Not affected by the changed files, and artifacts are not required",
+                        "Not affected by the changed files and not required",
                     )
 
             workflow_config.dump()


### PR DESCRIPTION
Follow up to https://github.com/ClickHouse/ClickHouse/pull/102685

When a job without `provides` (e.g. Docker Server) becomes affected through its hard dependencies in `requires` (e.g. Build changed), its name was not propagated to `affected_artifacts`. As a result, downstream jobs requiring it by name (e.g. Cloud Benchmarks requiring Docker Server) were incorrectly filtered out as unaffected, breaking the chain Build -> Docker Server -> Cloud Benchmarks.

Two fixes:
1. Always add an affected job name to `affected_artifacts`, not just when the job has `provides`. This ensures the affected status propagates through the full dependency chain regardless of whether intermediate jobs provide artifacts.
2. Defer filtering of ALL unaffected jobs to the post-loop check, not just those with `provides`. Previously, unaffected jobs without `provides` were immediately filtered without checking if they are a hard dependency for an affected job.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.960`
<!-- ch-version-info:end -->