### PR TITLE
CI: address review comments on #101888

### DIFF
--- a/.claude/skills/clickhouse-pr-description/SKILL.md
+++ b/.claude/skills/clickhouse-pr-description/SKILL.md
@@ -41,6 +41,8 @@ Use plain paragraphs. Headers like `## Motivation`, `## Changes`, `## Results` a
 
 Fill in the changelog category (delete the rest of the list), write the changelog entry, and keep the documentation checkbox.
 
+**Exception — CI Fix or Improvement:** omit the Changelog entry and Documentation entry sections entirely (they are not required). Keep the entire PR body under 100 words.
+
 ### Example of a well-written body
 
 From [#96110](https://github.com/ClickHouse/ClickHouse/pull/96110):

--- a/ci/tests/test_cleanup_test_groups.py
+++ b/ci/tests/test_cleanup_test_groups.py
@@ -68,48 +68,50 @@ def test_cleanup_kills_orphaned_test_process():
     )
 
     try:
-        # Wait for clickhouse-test to open the stdout file for the test, which
-        # happens just before the test subprocess is launched.  This gives us
-        # an early confirmation that the harness is actually running the test
-        # rather than, e.g., still parsing options or connecting to the server.
-        deadline_stdout = time.monotonic() + 5
-        while time.monotonic() < deadline_stdout:
-            p = list(_SUITE_TMP.glob(f"{_TEST}*.stdout"))
-            if not p: continue
-            if p[0].stat().st_size:
-                break
-            time.sleep(0.1)
-        else:
-            assert False, f"{_SUITE_TMP}/{_TEST} has no stdout"
-    
-        # The PGID file is written by clickhouse-test synchronously right after
-        # Popen(), before the bash script starts.  By the time SELECT 1 has
-        # completed and the stdout file has content, the file is likely to exist.
-        p = list(_GROUP_PID_PATH.glob(f"{_GROUP_PID_NAME}.*"))[0]
-        pgid = int(p.read_text())
-    
-        def got_procs(procs) -> str:
-            return ", got\n" + '\n'.join(f"{p[0]} {p[3]}" for p in procs)
-    
+        try:
+            # Wait for clickhouse-test to open the stdout file for the test, which
+            # happens just before the test subprocess is launched.  This gives us
+            # an early confirmation that the harness is actually running the test
+            # rather than, e.g., still parsing options or connecting to the server.
+            deadline_stdout = time.monotonic() + 5
+            while time.monotonic() < deadline_stdout:
+                p = list(_SUITE_TMP.glob(f"{_TEST}*.stdout"))
+                if not p: continue
+                if p[0].stat().st_size:
+                    break
+                time.sleep(0.1)
+            else:
+                assert False, f"{_SUITE_TMP}/{_TEST} has no stdout"
+
+            # The PGID file is written by clickhouse-test synchronously right after
+            # Popen(), before the bash script starts.  By the time SELECT 1 has
+            # completed and the stdout file has content, the file is likely to exist.
+            p = list(_GROUP_PID_PATH.glob(f"{_GROUP_PID_NAME}.*"))[0]
+            pgid = int(p.read_text())
+
+            def got_procs(procs) -> str:
+                return ", got\n" + '\n'.join(f"{p[0]} {p[3]}" for p in procs)
+
+            procs = pgrep(pgid=pgid)
+            assert len(procs) == 7, "(Before kill) Expect 7 processes (two bash processes + 5 test processes)" + got_procs(procs)
+
+            # Kill clickhouse-test with SIGKILL — simulates the OOM killer or an
+            # external timeout killing the test runner.
+        finally:
+            os.kill(_ch_proc.pid, signal.SIGKILL)
+
         procs = pgrep(pgid=pgid)
-        assert len(procs) == 7, "(Before kill) Expect 7 processes (two bash processes + 5 test processes)" + got_procs(procs)
-    
-        # Kill clickhouse-test with SIGKILL — simulates the OOM killer or an
-        # external timeout killing the test runner.
+        assert len(procs) == 7, "(After kill) Expect 7 processes" + got_procs(procs)
     finally:
-        os.kill(_ch_proc.pid, signal.SIGKILL)
+        _ch_proc.wait()
+        # Run clickhouse-test --cleanup to kill the orphaned process group.
+        result = subprocess.run(
+            [sys.executable, _CLICKHOUSE_TEST, "--cleanup"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
 
-    procs = pgrep(pgid=pgid)
-    assert len(procs) == 7, "(After kill) Expect 7 processes" + got_procs(procs)
-    _ch_proc.wait()
-
-    # Run clickhouse-test --cleanup to kill the orphaned process group.
-    result = subprocess.run(
-        [sys.executable, _CLICKHOUSE_TEST, "--cleanup"],
-        capture_output=True,
-        text=True,
-        timeout=5,
-    )
     assert result.returncode == 0, (
         f"clickhouse-test --cleanup failed (rc={result.returncode}):\n"
         f"{result.stdout}\n{result.stderr}"

--- a/tests/clickhouse-test-process-management.md
+++ b/tests/clickhouse-test-process-management.md
@@ -94,22 +94,19 @@ if os.getpid() != os.getpgid(0):
 subprocess.run([sys.executable, str(_clickhouse_test), "--cleanup"], check=False)
 ```
 
-### Pre-hook and post-hook guard
+### Post-hook guard
 
-`ci/defs/job_configs.py` registers the hook for both pre- and post-execution:
+`ci/defs/job_configs.py` registers the hook for post-execution:
 
 ```python
 darwin_fast_test_jobs = Job.Config(
     ...
-    pre_hooks=["python3 ./ci/jobs/scripts/job_hooks/clickhouse_test_cleanup_hook.py"],
     post_hooks=["python3 ./ci/jobs/scripts/job_hooks/clickhouse_test_cleanup_hook.py"],
 )
 ```
 
-The **pre-hook** cleans up any orphans left by a previous run (e.g. if the
-runner was rebooted mid-job and the post-hook never fired).  The **post-hook**
-covers the case where `fast_test.py` itself is SIGKILL'd and the `finally`
-block in `run_test` never executes.
+The **post-hook** covers the case where `fast_test.py` itself is SIGKILL'd and
+the `finally` block in `run_test` never executes.
 
 The hook contains no kill logic of its own — it just calls
 `clickhouse-test --cleanup`, the single source of truth for orphan cleanup.
@@ -121,7 +118,6 @@ The hook contains no kill logic of its own — it just calls
 | `cleanup_child_processes` | SIGTERM/SIGINT/SIGHUP to `clickhouse-test` | `killpg` on each direct child's PGID |
 | test `finally` block | Any exit of the per-test code path (incl. SIGKILL to the worker) | `_gpid_file.unlink` — removes the per-worker file |
 | `run_test()` `finally` | Any exit of `clickhouse-test` (incl. SIGKILL) | `clickhouse-test --cleanup` → `kill_process_group` per PGID file |
-| Pre-hook | Job start (cleans up previous run's orphans) | same — `clickhouse-test --cleanup` |
 | Post-hook | Any exit of `fast_test.py` (incl. SIGKILL) | same — `clickhouse-test --cleanup` |
 
 ### Remaining limitation


### PR DESCRIPTION
Follow-up to #101888.

- `tests/clickhouse-test-process-management.md`: remove inaccurate `pre_hooks` entry — `darwin_fast_test_jobs` only has `post_hooks`.
- `ci/tests/test_cleanup_test_groups.py`: restructure nested `try` blocks so `_ch_proc.wait()` and `clickhouse-test --cleanup` always run in the outer `finally`, regardless of whether test setup succeeds.
- `.claude/skills/clickhouse-pr-description/SKILL.md`: document that CI Fix or Improvement PRs omit the changelog and documentation sections.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.952`
<!-- ch-version-info:end -->