### PR TITLE
Fix typos: 'intialize', 'retreive', 'compatiblity'

### DIFF
--- a/src/Coordination/KeeperDispatcher.h
+++ b/src/Coordination/KeeperDispatcher.h
@@ -141,7 +141,7 @@ public:
     /// (So e.g. we can't remove session ID from this map when the session is closed.)
     std::unordered_map<SessionAndXID, KeeperRequestsForSessions, SessionAndXIDHash> read_request_queue;
 
-    /// Just allocate some objects, real initialization is done by `intialize method`
+    /// Just allocate some objects, real initialization is done by `initialize method`
     KeeperDispatcher();
 
     /// Call shutdown

--- a/tests/ci/clickhouse_helper.py
+++ b/tests/ci/clickhouse_helper.py
@@ -271,7 +271,7 @@ class CiLogsCredentials:
             )  # type: str
         except:
             logging.warning(
-                "Unable to retreive host and/or password from smm, all other "
+                "Unable to retrieve host and/or password from smm, all other "
                 "methods will noop"
             )
             self._host = ""

--- a/tests/ci/git_helper.py
+++ b/tests/ci/git_helper.py
@@ -139,7 +139,7 @@ def checkout_submodule(name: str, retry: int = 3) -> None:
             # progressive sleep before retry
             sleep(start_sleep * (n + 1))
 
-    raise subprocess.SubprocessError(f"Unable to retreive submodule {name}")
+    raise subprocess.SubprocessError(f"Unable to retrieve submodule {name}")
 
 
 def checkout_submodules() -> None:

--- a/tests/queries/0_stateless/01509_dictionary_preallocate.sh
+++ b/tests/queries/0_stateless/01509_dictionary_preallocate.sh
@@ -11,7 +11,7 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 #   [1]: https://github.com/ClickHouse/ClickHouse/pull/23979
 #   [2]: https://github.com/ClickHouse/ClickHouse/pull/45388
 #
-# This is a backward compatiblity test that you can create dictionary with
+# This is a backward compatibility test that you can create dictionary with
 # PREALLOCATE attribute (and also for the history/greppability, that it was
 # such).
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix typos in comments and error messages.

Small typo fixes:
- `src/Coordination/KeeperDispatcher.h`: `intialize` -> `initialize` (comment)
- `tests/ci/git_helper.py`: `Unable to retreive submodule` -> `Unable to retrieve submodule` (error message)
- `tests/ci/clickhouse_helper.py`: `Unable to retreive host` -> `Unable to retrieve host` (error message)
- `tests/queries/0_stateless/01509_dictionary_preallocate.sh`: `backward compatiblity test` -> `backward compatibility test` (comment)