### PR TITLE
Fix garbled error message in nested() and 'dimentional' typo

### DIFF
--- a/src/Functions/nested.cpp
+++ b/src/Functions/nested.cpp
@@ -126,10 +126,10 @@ private:
 
             if (!type)
                 throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
-                    "Argument {} for function {} must be {}-dimentional array. Actual {}",
+                    "Argument {} for function {} must be {}-dimensional array. Actual {}",
                     i + 1,
-                    array_depth,
                     getName(),
+                    array_depth,
                     argument.type->getName());
 
             names.push_back(std::string{column.getDataAt(i)});
@@ -156,7 +156,7 @@ private:
 
         if (array_col->size() != 1)
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                "First argument for function {} must be constant column with N-dimentional array of strings, "
+                "First argument for function {} must be constant column with N-dimensional array of strings, "
                 "where the all arrays except the most inner one must have size = 1. "
                 "The size of array at depth {} is {}",
                 getName(), array_depth, array_col->size());


### PR DESCRIPTION
Closes #102441.

### Summary

`src/Functions/nested.cpp:128-133` raises `ILLEGAL_TYPE_OF_ARGUMENT` from `getTupleType` with a format string that has its arguments in the wrong order:

```cpp
throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
    "Argument {} for function {} must be {}-dimentional array. Actual {}",
    i + 1,
    array_depth,   // <-- swapped with getName()
    getName(),     // <-- swapped with array_depth
    argument.type->getName());
```

The format string expects `(arg_num, function_name, dimension, actual_type)` but the call passes `(arg_num, dimension, function_name, actual_type)`. For the reproducer in #102441 (`SELECT nested([['a', 'b']], [1, 2], [3, 4])`) the message becomes `Argument 1 for function 2 must be nested-dimentional array` — with the function name and dimension count interleaved.

### Fix

- Swap `array_depth` and `getName()` in the argument list so the format string renders correctly: `Argument 1 for function nested must be 2-dimensional array`.
- Correct the `dimentional` -> `dimensional` spelling in this message and in the adjacent `BAD_ARGUMENTS` message at line 159 (flagged in the same issue's 'open risks' note).

### Verification

- Source verified against current `master`.
- Placeholder count vs argument count audited for both touched messages (4/4 and 3/3 respectively).