### PR TITLE
Fix copy-paste description for IcebergMetadataUpdateMicroseconds

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -104,7 +104,7 @@
     M(ParquetMetadataCacheMisses, "Number of times parquet metadata has not been found in the cache and had to be read from disk.", ValueType::Number) \
     M(ParquetMetadataCacheWeightLost, "Approximate number of bytes evicted from the parquet metadata cache.", ValueType::Number) \
     M(IcebergIteratorInitializationMicroseconds, "Total time spent on synchronous initialization of iceberg data iterators.", ValueType::Microseconds) \
-    M(IcebergMetadataUpdateMicroseconds, "Total time spent on synchronous initialization of iceberg data iterators.", ValueType::Microseconds) \
+    M(IcebergMetadataUpdateMicroseconds, "Total time spent updating iceberg storage metadata from state (buildStorageMetadataFromState).", ValueType::Microseconds) \
     M(IcebergMetadataReturnedObjectInfos, "Total number of returned object infos from iceberg iterator.", ValueType::Number) \
     M(IcebergMinMaxNonPrunedDeleteFiles, "Total number of accepted data files-position delete file pairs by minmax analysis from pairs suitable by partitioning and sequence number.", ValueType::Number) \
     M(IcebergMinMaxPrunedDeleteFiles, "Total number of accepted data files-position delete file pairs by minmax analysis from pairs suitable by partitioning and sequence number.", ValueType::Number) \


### PR DESCRIPTION
Closes #102486.

`src/Common/ProfileEvents.cpp:107` declared `IcebergMetadataUpdateMicroseconds` with the same description as the entry just above it (`IcebergIteratorInitializationMicroseconds`):

```cpp
M(IcebergIteratorInitializationMicroseconds, "Total time spent on synchronous initialization of iceberg data iterators.", ValueType::Microseconds)
M(IcebergMetadataUpdateMicroseconds,         "Total time spent on synchronous initialization of iceberg data iterators.", ValueType::Microseconds)
```

The metric is incremented from `buildStorageMetadataFromState` in `IcebergMetadata.cpp`, not from iterator initialization, so users browsing `system.events` saw two distinct counters with identical descriptions and no way to tell what `IcebergMetadataUpdateMicroseconds` actually measures.

Update the description to reflect the metadata update semantics. Verified against current `master`.