### PR TITLE
Fix Kafka temporary partition lock loop iterating unshuffled list

### DIFF
--- a/src/Storages/Kafka/KeeperHandlingConsumer.cpp
+++ b/src/Storages/Kafka/KeeperHandlingConsumer.cpp
@@ -361,7 +361,7 @@ void KeeperHandlingConsumer::lockTemporaryLocksLocked(
     pcg64 generator(randomSeed());
     std::shuffle(available_topic_partitions_copy.begin(), available_topic_partitions_copy.end(), generator);
 
-    for (const auto & tp : available_topic_partitions)
+    for (const auto & tp : available_topic_partitions_copy)
     {
         if (tmp_locks.size() >= tmp_locks_quota)
             break;


### PR DESCRIPTION
Closes #102049.

`src/Storages/Kafka/KeeperHandlingConsumer.cpp::lockTemporaryLocksLocked` builds a shuffled copy of `available_topic_partitions` to randomize the order in which replicas race for temporary locks:

```cpp
auto available_topic_partitions_copy = available_topic_partitions;
pcg64 generator(randomSeed());
std::shuffle(available_topic_partitions_copy.begin(), available_topic_partitions_copy.end(), generator);

for (const auto & tp : available_topic_partitions)   // <-- iterates the *original*
{
    ...
}
```

The for-each loop iterates `available_topic_partitions` (the untouched original) instead of `available_topic_partitions_copy`, so the `std::shuffle` is dead code and every replica walks the same deterministic order each round — biasing all replicas toward the same partitions and increasing lock contention.

Iterate `available_topic_partitions_copy` so the shuffle actually has an effect.

Verified against current `master`.