### PR TITLE
Fix StorageArrowFlight named collection: 'dataset' key is optional

### DIFF
--- a/src/Storages/StorageArrowFlight.cpp
+++ b/src/Storages/StorageArrowFlight.cpp
@@ -89,8 +89,6 @@ StorageArrowFlight::Configuration StorageArrowFlight::processNamedCollectionResu
     configuration.port = static_cast<UInt16>(named_collection.get<UInt64>("port"));
     configuration.dataset_name = named_collection.getOrDefault<String>("dataset", "");
 
-    configuration.dataset_name = named_collection.get<String>("dataset");
-
     configuration.use_basic_authentication = named_collection.getOrDefault<bool>("use_basic_authentication", true);
     bool is_username_set = named_collection.has("username") || named_collection.has("user");
     if (configuration.use_basic_authentication && !is_username_set)


### PR DESCRIPTION
Closes #102638.

`processNamedCollectionResult` in `src/Storages/StorageArrowFlight.cpp` set `configuration.dataset_name` twice:

```cpp
configuration.dataset_name = named_collection.getOrDefault<String>("dataset", "");

configuration.dataset_name = named_collection.get<String>("dataset");
```

The second `get<String>` call immediately overwrote the safe `getOrDefault` and throws `BAD_ARGUMENTS: No such key 'dataset'` whenever the key is missing — but `dataset` is in `optional_arguments` (line 82), not `required_arguments` (line 85), so omitting it from the named collection is documented to be valid.

As a result, an ArrowFlight named collection without an explicit `dataset` key cannot be used (engine or table function) even though the schema says it should be optional.

Drop the duplicate `get<String>` call so the optional default actually applies. Verified against current `master`.