### PR TITLE
Fix ReservoirSamplerDeterministic::merge self-merge aliasing

### DIFF
--- a/src/AggregateFunctions/ReservoirSamplerDeterministic.h
+++ b/src/AggregateFunctions/ReservoirSamplerDeterministic.h
@@ -131,6 +131,13 @@ public:
     {
         if (max_sample_size != b.max_sample_size)
             throw Poco::Exception("Cannot merge ReservoirSamplerDeterministic's with different max sample size");
+
+        // There will be an aliasing issue if we merge the same object with itself. I.e. we will insert from `b.samples` into `a.samples`,
+        // but both refer to the same array. It might happen in case of multiplying an aggregate function state by a numeric constant.
+        // ATST, it seems that self-merging cannot improve accuracy, so there is no point to do it anyway.
+        if (this == &b)
+            return;
+
         sorted = false;
 
         if (skip_degree < b.skip_degree)


### PR DESCRIPTION
Closes #101782.

`ReservoirSamplerDeterministic::merge` iterates `b.samples` and calls `insertImpl` which mutates `this->samples`. When `this == &b` — which happens, e.g., when an aggregate-function state is multiplied by a numeric constant — both refer to the same vector and the iteration aliases the mutation, corrupting the reservoir and producing wrong `quantileDeterministic`/`medianDeterministic` results.

`ReservoirSampler::merge` already has this guard (`src/AggregateFunctions/ReservoirSampler.h:166`) with a comment explaining that self-merging cannot improve accuracy anyway. Mirror the guard here.

Verified against current `master`.