### PR TITLE
Fix BSI pointwiseMultiply allValuesEqualOne shortcut using wrong fraction_bit_num

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionGroupNumericIndexedVectorDataBSI.h
+++ b/src/AggregateFunctions/AggregateFunctionGroupNumericIndexedVectorDataBSI.h
@@ -1218,7 +1218,7 @@ public:
         }
         else if (rhs.allValuesEqualOne())
         {
-            lhs.andBitmap(*rhs.getDataArrayAt(lhs.fraction_bit_num), res);
+            lhs.andBitmap(*rhs.getDataArrayAt(rhs.fraction_bit_num), res);
             return;
         }
         UInt32 max_integer_bit_num = std::max(lhs.integer_bit_num, rhs.integer_bit_num);


### PR DESCRIPTION
Closes #101950.

In `BSINumericIndexedVector::pointwiseMultiply` (`src/AggregateFunctions/AggregateFunctionGroupNumericIndexedVectorDataBSI.h:1219-1222`), the shortcut for the case where `rhs` is all-ones uses `lhs.fraction_bit_num` to look up the all-ones bitmap on `rhs`:

```cpp
else if (rhs.allValuesEqualOne())
{
    lhs.andBitmap(*rhs.getDataArrayAt(lhs.fraction_bit_num), res);
    return;
}
```

But the all-ones bitmap on `rhs` lives at `rhs.fraction_bit_num`. When the two operands have different BSI bit configurations, this reads an empty bitmap and the multiply returns an empty result instead of preserving `lhs`. Use `rhs.fraction_bit_num` for the rhs lookup so multiplying by an all-ones vector behaves as the identity. Verified against current `master`.