### PR TITLE
Restore port argument to enableSecureConnection in ConnectionParameters constructor

### DIFF
--- a/src/Client/ConnectionParameters.cpp
+++ b/src/Client/ConnectionParameters.cpp
@@ -67,7 +67,7 @@ ConnectionParameters::ConnectionParameters(const Poco::Util::AbstractConfigurati
     , port(port_.value_or(getPortFromConfig(config, host_)))
     , default_database(database)
 {
-    security = enableSecureConnection(config, host_) ? Protocol::Secure::Enable : Protocol::Secure::Disable;
+    security = enableSecureConnection(config, host_, port) ? Protocol::Secure::Enable : Protocol::Secure::Disable;
     tls_sni_override = config.getString("tls-sni-override", "");
 
     bind_host = config.getString("bind_host", "");


### PR DESCRIPTION
Closes #101637.

The `ConnectionParameters` constructor refactor in #74212 dropped the port argument from the `enableSecureConnection` call:

```cpp
security = enableSecureConnection(config, host_) ? Protocol::Secure::Enable : Protocol::Secure::Disable;
```

`enableSecureConnection`'s third branch enables TLS automatically when `connection_port == DBMS_DEFAULT_SECURE_PORT` (9440):

```cpp
if (connection_port && connection_port.value() == DBMS_DEFAULT_SECURE_PORT)
    return true;
```

Since the port is no longer passed, `clickhouse-client --port 9440` without `--secure` no longer auto-upgrades to TLS — it sends the plaintext native protocol on a TLS-only port. The other call site (`ConnectionParameters.cpp:191`) still passes `connection_port` correctly.

The `port` member is initialised in the initialiser list (line 67) before the constructor body runs, so passing `port` here is sufficient.

Verified against current `master`.