### PR TITLE
getClientHTTPHeader: mark as non-deterministic

### DIFF
--- a/src/Functions/getClientHTTPHeader.cpp
+++ b/src/Functions/getClientHTTPHeader.cpp
@@ -36,6 +36,8 @@ public:
 
     String getName() const override { return "getClientHTTPHeader"; }
 
+    bool isDeterministic() const override { return false; }
+
     bool useDefaultImplementationForConstants() const override { return true; }
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo &) const override { return false; }
 


### PR DESCRIPTION
Closes #101120.

`FunctionGetClientHTTPHeader` (`src/Functions/getClientHTTPHeader.cpp`) was missing the `isDeterministic() const override { return false; }` declaration, so the optimizer and the query cache treated it as a pure function. `SELECT getClientHTTPHeader('X-Test') SETTINGS use_query_cache=1` was silently cached, and subsequent requests with different HTTP headers read the stale value instead of the current header.

This is the same correctness hazard #92174 fixed for `connectionId()` (`src/Functions/connectionId.cpp:20`). Mirror that override here.

Verified against current `master`.