### PR TITLE
TableFunctionMongoDB: accept oid_columns as named argument

### DIFF
--- a/src/TableFunctions/TableFunctionMongoDB.cpp
+++ b/src/TableFunctions/TableFunctionMongoDB.cpp
@@ -128,7 +128,7 @@ std::pair<String, ASTPtr> getKeyValueMongoDBArgument(const ASTFunction * ast_fun
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected key-value defined argument, got {}", ast_func->formatForErrorMessage());
 
     const auto & arg_name = function_args[0]->as<ASTIdentifier>()->name();
-    if (arg_name == "structure" || arg_name == "options")
+    if (arg_name == "structure" || arg_name == "options" || arg_name == "oid_columns")
         return std::make_pair(arg_name, function_args[1]);
 
     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected key-value defined argument, got {}", ast_func->formatForErrorMessage());


### PR DESCRIPTION
Closes #101731.

`processArguments` already routes `oid_columns` to `main_arguments` when it appears as a key-value AST node:

```cpp
else if (arg_name == "options" || arg_name == "oid_columns")
    main_arguments.push_back(arg_value);
```

…but `getKeyValueMongoDBArgument` (`src/TableFunctions/TableFunctionMongoDB.cpp:131`) only whitelisted `structure` and `options`:

```cpp
if (arg_name == "structure" || arg_name == "options")
    return std::make_pair(arg_name, function_args[1]);

throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected key-value defined argument, got {}", ast_func->formatForErrorMessage());
```

So any `mongodb(..., oid_columns='_id')` named-argument call was rejected with `BAD_ARGUMENTS` before `processArguments` ever saw it. Users were forced to fall back to positional arguments even though the rest of the table function supports the named form.

Add `oid_columns` to the helper's whitelist. Verified against current `master`.