### PR TITLE
clickhouse-benchmark: restore bare --reconnect by adding implicit_value(1)

### DIFF
--- a/programs/benchmark/Benchmark.cpp
+++ b/programs/benchmark/Benchmark.cpp
@@ -877,7 +877,7 @@ int mainEntryClickHouseBenchmark(int argc, char ** argv)
             ("query_id_prefix", value<std::string>()->default_value(""), "")
             ("max-consecutive-errors", value<size_t>()->default_value(0), "set number of allowed consecutive errors")
             ("ignore-error,continue_on_errors", "continue testing even if a query fails")
-            ("reconnect", value<size_t>()->default_value(0), "control reconnection behaviour: 0 (never reconnect), 1 (reconnect for every query), or N (reconnect after every N queries)")
+            ("reconnect", value<size_t>()->default_value(0)->implicit_value(1), "control reconnection behaviour: 0 (never reconnect), 1 (reconnect for every query), or N (reconnect after every N queries). Bare --reconnect is equivalent to --reconnect=1.")
             ("client-side-time", "display the time including network communication instead of server-side time; note that for server versions before 22.8 we always display client-side time")
             ("proto_caps", value<std::string>(), "Enable/disable chunked protocol (comma-separated): chunked_optional, notchunked, notchunked_optional, send_chunked, send_chunked_optional, send_notchunked, send_notchunked_optional, recv_chunked, recv_chunked_optional, recv_notchunked, recv_notchunked_optional")
         ;


### PR DESCRIPTION
Closes #101748.

#79465 turned `--reconnect` into a value-bearing option (`size_t` with default 0) but did not add `->implicit_value(1)`, so:

```
$ clickhouse-benchmark --reconnect ...
Bad arguments: the required argument for option --reconnect is missing
```

Existing scripts and docs that used the old boolean-flag form silently break.

Add `->implicit_value(1)` so a bare `--reconnect` is equivalent to `--reconnect=1` (reconnect for every query), preserving backward compatibility while keeping the new `--reconnect=N` functionality. Verified against current `master`.