### PR TITLE
MergeTreeData::refreshDataParts: reschedule background task on exception

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2697,6 +2697,10 @@ try
 catch (...)
 {
     tryLogCurrentException(log, "Failed to refresh parts");
+    /// A transient error (e.g. temporary disk unavailability or network hiccup) must not
+    /// permanently disable the background refresh task; otherwise the readonly table is
+    /// stale until the server restarts. Mirror refreshStatistics's catch-block reschedule.
+    refresh_parts_task->scheduleAfter(interval_milliseconds);
 }
 
 void MergeTreeData::refreshStatistics(UInt64 interval_seconds)


### PR DESCRIPTION
Closes #102045.

The catch-all in `MergeTreeData::refreshDataParts` (`src/Storages/MergeTree/MergeTreeData.cpp:2697`) only logged the exception without rescheduling the `BackgroundSchedulePool` task:

```cpp
catch (...)
{
    tryLogCurrentException(log, "Failed to refresh parts");
}
```

Any transient failure (temporary disk unavailability, brief network hiccup, …) therefore permanently stopped the background refresh, leaving readonly MergeTree tables stale until server restart.

The sibling `refreshStatistics` catch handler at line 2739 already reschedules the task. Mirror that pattern and reschedule `refresh_parts_task->scheduleAfter(interval_milliseconds)` so the next attempt happens at the regular cadence.

Verified against current `master`.