### PR TITLE
system.completions: stop duplicating MergeTree settings rows

### DIFF
--- a/src/Storages/System/StorageSystemCompletions.cpp
+++ b/src/Storages/System/StorageSystemCompletions.cpp
@@ -241,10 +241,12 @@ void fillDataWithDataTypeFamilies(MutableColumns & res_columns)
 
 void fillDataWithMergeTreeSettings(MutableColumns & res_columns, const ContextPtr & context)
 {
+    /// MergeTreeSettings and ReplicatedMergeTreeSettings expose the same set of setting
+    /// names — the only difference is per-setting default values — so dumping both into
+    /// system.completions used to produce 329 duplicate (word, context, belongs) rows.
+    /// One dump is sufficient for completion purposes.
     const auto & merge_tree_settings = context->getMergeTreeSettings();
-    const auto & replicated_merge_tree_settings = context->getReplicatedMergeTreeSettings();
     merge_tree_settings.dumpToSystemCompletionsColumns(res_columns);
-    replicated_merge_tree_settings.dumpToSystemCompletionsColumns(res_columns);
 }
 
 void fillDataWithSettings(MutableColumns & res_columns, const ContextPtr & context)


### PR DESCRIPTION
Closes #102013.

`fillDataWithMergeTreeSettings` dumped both `context->getMergeTreeSettings()` and `context->getReplicatedMergeTreeSettings()` into `res_columns`. Both registries expose the same set of setting names — the only difference is per-setting default values — so every merge tree setting appeared exactly twice in `system.completions` with identical `(word, context, belongs)` tuples (329 duplicate rows on current master). Third-party tools consuming the table for autocompletion suggestions ended up showing duplicates.

`system.completions` only needs setting names, so one dump is sufficient. Drop the second call. Verified against current `master`.