### PR TITLE
FormatSchemaInfo::generateSchemaFileName: hex-encode actual schema content

### DIFF
--- a/src/Formats/FormatSchemaInfo.cpp
+++ b/src/Formats/FormatSchemaInfo.cpp
@@ -348,7 +348,7 @@ String FormatSchemaInfo::generateSchemaFileName(const String & hashing_content, 
 
     String content_sample;
     content_sample.resize(content_sample_len * 2);
-    boost::algorithm::hex(content_sample.begin(), content_sample.begin() + content_sample_len, content_sample.data());
+    boost::algorithm::hex(hashing_content.begin(), hashing_content.begin() + content_sample_len, content_sample.data());
 
     if (file_extention.empty())
         return fmt::format("{}-{}", content_sample, content_hash_hex);


### PR DESCRIPTION
Closes #101904.

The `content_sample` portion of the cached schema filename was hex-encoded from the freshly resized output buffer instead of the input:

```cpp
String content_sample;
content_sample.resize(content_sample_len * 2);
boost::algorithm::hex(content_sample.begin(), content_sample.begin() + content_sample_len, content_sample.data());
```

Since `content_sample` was just `resize`d to zero bytes, the input range was all-zero, and writing back into the same buffer with overlapping ranges produced a constant prefix (`0030333033333330...`) for every cached schema regardless of content.

Pass `hashing_content` as the input range — matching the SHA256 path on the line above — so the prefix actually reflects the first `CONTENT_SAMPLE_MAX_LEN` bytes of the schema. Verified against current `master`.