### PR TITLE
WorkloadSettings::getNotNegativeFloat64: actually reject negative Float64 values

### DIFF
--- a/src/Common/Scheduler/WorkloadSettings.cpp
+++ b/src/Common/Scheduler/WorkloadSettings.cpp
@@ -112,7 +112,10 @@ void WorkloadSettings::initFromChanges(CostUnit unit_, const ASTCreateWorkloadQu
                 }
             }
 
-            return field.safeGet<Float64>();
+            Float64 result = field.safeGet<Float64>();
+            if (result < 0)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected negative Float64 value for workload setting '{}'", name);
+            return result;
         }
 
         static Int64 getNotNegativeInt64(const String & name, const Field & field)


### PR DESCRIPTION
Closes #101825.

`getNotNegativeFloat64` validated UInt64/Int64 inputs but fell through to `field.safeGet<Float64>()` without checking the sign:

```cpp
{
    Int64 val;
    if (field.tryGet(val))
    {
        if (val < 0) throw …;
        return static_cast<Float64>(val);
    }
}

return field.safeGet<Float64>();   // <-- no negative check
```

So `CREATE WORKLOAD ... SETTINGS max_bytes_per_second = -100.5` was silently accepted. The negative limit propagated into `ThrottlerConstraint`, where `updateBucket` skips when `max_speed <= 0`, leaving the bucket permanently empty and blocking every request to the workload (same hazard for `max_burst_bytes`, `max_cpus`, `max_cpu_share`, `max_burst_cpu_seconds`, `max_queries_per_second`, `max_burst_queries`).

Mirror the Int64 branch and throw `BAD_ARGUMENTS` when the parsed Float64 is negative. Verified against current `master`.