### PR TITLE
intExp2: disable JIT compilation to avoid unbounded shift wrong results

### DIFF
--- a/src/Functions/intExp2.cpp
+++ b/src/Functions/intExp2.cpp
@@ -43,14 +43,14 @@ struct IntExp2Impl
     }
 
 #if USE_EMBEDDED_COMPILER
-    static constexpr bool compilable = true;
-
-    static llvm::Value * compile(llvm::IRBuilder<> & b, llvm::Value * arg, bool)
-    {
-        if (!arg->getType()->isIntegerTy())
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "IntExp2Impl expected an integral type");
-        return b.CreateShl(llvm::ConstantInt::get(arg->getType(), 1), arg);
-    }
+    /// JIT-compiled path is intentionally disabled: a naive `b.CreateShl(1, arg)`
+    /// has no bounds check for `arg < 0` or `arg >= 64`, while the scalar
+    /// `intExp2(int)` clamps those cases to `0` and `UINT64_MAX` respectively.
+    /// Keeping the JIT path enabled with the unbounded shift produced silently
+    /// wrong results (e.g. `intExp2(64) = 0`) under
+    /// `compile_expressions=1`. Match `intExp10` and fall back to the
+    /// interpreted apply() until a bounds-checked LLVM IR sequence lands.
+    static constexpr bool compilable = false;
 #endif
 };
 


### PR DESCRIPTION
Closes #101540.

The JIT-compiled path emitted a bare `b.CreateShl(1, arg)` with no bounds check, while the scalar `intExp2(int)` helper in `Common/intExp2.h` clamps `arg < 0` to `0` and `arg > 63` to `UINT64_MAX`. With `compile_expressions=1`, `intExp2(64)` returned `0` and `intExp2(67)` returned `8` instead of `UINT64_MAX` — silently wrong results from a previously correct expression.

Sibling `intExp10` already disables JIT (`compilable = false`) and falls back to the interpreted path. Mirror that here until a properly bounds-checked LLVM IR sequence is added. For a function typically called on small constants, the JIT-compiled fast path is not worth the silent-wrong-results hazard.

Verified against current `master`.