### PR TITLE
docs: fix multiSearchFirstPositionUTF8 example output values

### DIFF
--- a/src/Functions/multiSearchFirstPositionCaseInsensitiveUTF8.cpp
+++ b/src/Functions/multiSearchFirstPositionCaseInsensitiveUTF8.cpp
@@ -36,7 +36,7 @@ Like [multiSearchFirstPosition](#multiSearchFirstPosition) but assumes `haystack
         "SELECT multiSearchFirstPositionCaseInsensitiveUTF8('Здравствуй, мир', ['МИР', 'вст', 'Здра'])",
         R"(
 ┌─multiSearchFirstPositionCaseInsensitiveUTF8('Здравствуй, мир', ['мир', 'вст', 'Здра'])─┐
-│                                                                                      3 │
+│                                                                                      1 │
 └────────────────────────────────────────────────────────────────────────────────────────┘
         )"
     }

--- a/src/Functions/multiSearchFirstPositionUTF8.cpp
+++ b/src/Functions/multiSearchFirstPositionUTF8.cpp
@@ -36,7 +36,7 @@ Like [multiSearchFirstPosition](#multiSearchFirstPosition) but assumes `haystack
         "SELECT multiSearchFirstPositionUTF8('Здравствуй, мир',['мир', 'вст', 'авст'])",
         R"(
 ┌─multiSearchFirstPositionUTF8('Здравствуй, мир', ['мир', 'вст', 'авст'])─┐
-│                                                                       3 │
+│                                                                       4 │
 └─────────────────────────────────────────────────────────────────────────┘
         )"
     }


### PR DESCRIPTION
Closes #102662.

Both `multiSearchFirstPositionUTF8` and `multiSearchFirstPositionCaseInsensitiveUTF8` had FunctionDocumentation examples with hard-coded `3` as the expected output. The actual function results are different.

For `multiSearchFirstPositionUTF8('Здравствуй, мир', ['мир','вст','авст'])`, the leftmost match is `'авст'` starting at character 4 — З(1) д(2) р(3) а(4). Result: **4**, not 3.

For `multiSearchFirstPositionCaseInsensitiveUTF8('Здравствуй, мир', ['МИР','вст','Здра'])`, the leftmost case-insensitive match is `'Здра'` starting at character 1. Result: **1**, not 3.

Update both example outputs so `system.functions` and the public docs match the actual behaviour. Verified against current `master`.