### PR TITLE
AsynchronousMetrics: pass current values to processWarning* after swap

### DIFF
--- a/src/Common/AsynchronousMetrics.cpp
+++ b/src/Common/AsynchronousMetrics.cpp
@@ -2441,11 +2441,16 @@ void AsynchronousMetrics::update(TimePoint update_time, bool force_update)
         values.swap(new_values);
 
         // These methods look at Asynchronous metrics and add,update or remove warnings
-        // which later get inserted into the system.warnings table:
-        processWarningForMutationStats(new_values);
+        // which later get inserted into the system.warnings table.
+        // Note: after the swap above, `values` holds the freshly computed metrics
+        // and `new_values` holds the previous cycle's data, so we must read from
+        // `values` here — passing `new_values` would feed the warning logic the
+        // stale snapshot and lag system.warnings by one async metrics cycle (and
+        // emit no warnings at all on the very first cycle).
+        processWarningForMutationStats(values);
         // server resource overload warnings
-        processWarningForMemoryOverload(new_values);
-        processWarningForCPUOverload(new_values);
+        processWarningForMemoryOverload(values);
+        processWarningForCPUOverload(values);
     }
 }
 


### PR DESCRIPTION
Closes #101759.

`AsynchronousMetrics::update()` swaps the freshly computed values into `values` and then feeds `new_values` into the warning helpers:

```cpp
values.swap(new_values);
processWarningForMutationStats(new_values);
processWarningForMemoryOverload(new_values);
processWarningForCPUOverload(new_values);
```

After the swap, `values` holds the fresh metrics and `new_values` holds the previous cycle's snapshot, so `system.warnings` lags reality by one async metrics cycle for mutation backlog, memory overload, and CPU overload — and on the very first cycle `new_values` is empty/default after the swap, so no warnings are emitted at all even when thresholds are clearly exceeded.

Read from `values` instead so the warning helpers see the same data the rest of the system sees. Verified against current `master`.