### PR TITLE
FunctionsComparison: treat Variant as nullable in tuple comparison return type

### DIFF
--- a/src/Functions/FunctionsComparison.h
+++ b/src/Functions/FunctionsComparison.h
@@ -1279,7 +1279,7 @@ public:
                                                    {nullptr, right_tuple->getElements()[i], ""}};
                     element_type = func->build(args)->getResultType();
                 }
-                has_nullable = has_nullable || element_type->isNullable() || isDynamic(element_type);
+                has_nullable = has_nullable || element_type->isNullable() || isDynamic(element_type) || isVariant(element_type);
 
                 /// Nullable(Nothing)
                 has_null = has_null || element_type->onlyNull();


### PR DESCRIPTION
Closes #101907.

#80728 added an `isDynamic` check to the `has_nullable` computation for tuple comparisons because Dynamic types report `isNullable() == false` but can carry NULL at runtime. Variant has the exact same property — its `isNullable()` returns false but a Variant column can hold NULL — yet the corresponding `isVariant` check was not added.

As a result, comparing a `Tuple(Variant(...))` against a `String`/another `Tuple(Variant(...))` computes a `Nullable(UInt8)` result internally (the per-element comparison wraps the result in Nullable for variants) while the declared return type stays `UInt8`. The mismatch trips a `LOGICAL_ERROR` in `checkAndGetReturnType`: 'Unexpected return type from equals. Expected UInt8. Got Nullable(UInt8)' — a server-side crash on valid SQL.

Add `isVariant(element_type)` alongside `isDynamic(element_type)` in the `has_nullable` check so the return type matches reality. Both functions are declared in `DataTypes/IDataType.h` (lines 537–538) so no new include is needed.

Verified against current `master`.