### PR TITLE
ASTDropQuery: add missing space after LIKE in TRUNCATE TABLES formatting

### DIFF
--- a/src/Parsers/ASTDropQuery.cpp
+++ b/src/Parsers/ASTDropQuery.cpp
@@ -110,7 +110,7 @@ void ASTDropQuery::formatQueryImpl(WriteBuffer & ostr, const FormatSettings & se
     {
         ostr
             << (not_like ? " NOT" : "")
-            << (case_insensitive_like ? " ILIKE " : " LIKE")
+            << (case_insensitive_like ? " ILIKE " : " LIKE ")
             << quoteString(like);
     }
 


### PR DESCRIPTION
Closes #101877.

`ASTDropQuery::formatQueryImpl` (`src/Parsers/ASTDropQuery.cpp:113`) emits ` LIKE` (no trailing space) for the case-sensitive branch but ` ILIKE ` (with trailing space) for the case-insensitive one:

```cpp
ostr
    << (not_like ? " NOT" : "")
    << (case_insensitive_like ? " ILIKE " : " LIKE")
    << quoteString(like);
```

So `formatQuery("TRUNCATE TABLES FROM default LIKE '%test%'")` renders as `TRUNCATE TABLES FROM default LIKE'%test%'` (no separator). The output is technically reparseable, but it's inconsistent with the ILIKE branch and shows up in EXPLAIN AST, query logs, DatabaseReplicated DDL serialization, and ON CLUSTER forwarding.

Add the missing trailing space so both branches format consistently. Verified against current `master`.