### PR TITLE
PageCache::autoResize: measure now in milliseconds to match history_window

### DIFF
--- a/src/Common/PageCache.cpp
+++ b/src/Common/PageCache.cpp
@@ -190,7 +190,13 @@ bool PageCache::autoResize(Int64 memory_usage_signed, size_t memory_limit)
         }
         else
         {
-            int64_t now = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+            /// `history_window` is std::chrono::milliseconds, so `now` must be measured in
+            /// the same unit. Previously this divided microseconds by milliseconds, making
+            /// each bucket 1000x narrower than intended — with a default 1000 ms window and
+            /// MemoryWorker calling every ~50 ms, every call landed in a brand-new bucket
+            /// and reset peak_memory_buckets to {0, 0}, effectively disabling the smoothing
+            /// window entirely.
+            int64_t now = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
             int64_t bucket = now / history_window.count();
             if (bucket > cur_bucket + 1)
                 peak_memory_buckets = {0, 0};


### PR DESCRIPTION
Closes #101807.

`PageCache::autoResize` (`src/Common/PageCache.cpp:193-194`) computed:

```cpp
int64_t now = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
int64_t bucket = now / history_window.count();
```

`history_window` is `std::chrono::milliseconds`, so dividing microseconds by millisecond counts produced buckets that are 1000x narrower than the configured window. With the default 1000 ms window and `MemoryWorker` calling every ~50 ms, every call landed in a brand-new bucket, the `bucket > cur_bucket + 1` branch reset both `peak_memory_buckets` to `{0, 0}`, and the cache fell back to the per-call instantaneous memory usage instead of the peak over the configured window — leaving `page_cache_history_window_ms` effectively dead.

Cast `now` to milliseconds so each bucket actually spans `history_window.count()` ms. Verified against current `master`.