### PR TITLE
InterpreterShowAccessEntitiesQuery: throw SUPPORT_IS_DISABLED for SHOW MASKING POLICIES on OSS

### DIFF
--- a/src/Interpreters/Access/InterpreterShowAccessEntitiesQuery.cpp
+++ b/src/Interpreters/Access/InterpreterShowAccessEntitiesQuery.cpp
@@ -12,6 +12,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int NOT_IMPLEMENTED;
+    extern const int SUPPORT_IS_DISABLED;
 }
 
 
@@ -116,24 +117,12 @@ String InterpreterShowAccessEntitiesQuery::getRewrittenQuery() const
 
         case AccessEntityType::MASKING_POLICY:
         {
-            origin = "masking_policies";
-            expr = "name";
-
-            if (!query.short_name.empty())
-                filter = "short_name = " + quoteString(query.short_name);
-
-            if (query.database_and_table_name)
-            {
-                const String & database = query.database_and_table_name->first;
-                const String & table_name = query.database_and_table_name->second;
-                if (!database.empty())
-                    filter += String{filter.empty() ? "" : " AND "} + "database = " + quoteString(database);
-                if (!table_name.empty())
-                    filter += String{filter.empty() ? "" : " AND "} + "table = " + quoteString(table_name);
-                if (!database.empty() && !table_name.empty())
-                    expr = "short_name";
-            }
-            break;
+            /// Match the SHOW CREATE MASKING POLICY path (InterpreterShowCreateAccessEntityQuery.cpp:345)
+            /// and the CREATE path (InterpreterCreateMaskingPolicyQuery.cpp:25): masking policies are
+            /// Cloud-only, so OSS builds must surface a clear SUPPORT_IS_DISABLED error rather than
+            /// rewrite the query against a non-existent system.masking_policies table (which yields a
+            /// confusing UNKNOWN_TABLE).
+            throw Exception(ErrorCodes::SUPPORT_IS_DISABLED, "Masking Policies are available only in ClickHouse Cloud");
         }
 
         case AccessEntityType::MAX:


### PR DESCRIPTION
Closes #101116.

The `MASKING_POLICY` case in `InterpreterShowAccessEntitiesQuery::getRewrittenQuery()` rewrote the query into a `SELECT name FROM system.masking_policies`, but `system.masking_policies` only exists in ClickHouse Cloud builds. On OSS the rewritten query failed with `UNKNOWN_TABLE` (60) — 'Unknown table system.masking_policies' — even though both sibling code paths already throw the clearer `SUPPORT_IS_DISABLED` (344) message:

- `InterpreterShowCreateAccessEntityQuery.cpp:345`: 'Masking Policies are available only in ClickHouse Cloud'
- `InterpreterCreateMaskingPolicyQuery.cpp:25`: 'Masking Policies are available only in ClickHouse Cloud'

Throw the same `SUPPORT_IS_DISABLED` directly from the SHOW path so `SHOW MASKING POLICIES` (and `SHOW MASKING POLICIES ON db.table`) report a consistent, useful error on OSS instead of an internal table-missing leak. Verified against current `master`.