### PR TITLE
Fix Slack subscription not cleaning up previous email on re-subscribe

### DIFF
--- a/ci/praktika/infrastructure/native/lambda_slack_worker.py
+++ b/ci/praktika/infrastructure/native/lambda_slack_worker.py
@@ -798,6 +798,21 @@ def lambda_handler(event, context):
 
             # Add user_id to subscription list (supports multiple Slack users per email)
             if subscriptions_s3_path:
+                # Remove user from previous subscription if switching emails
+                prev_email = FeedSubscription.find_user_subscription(
+                    user_id, s3_path=subscriptions_s3_path
+                )
+                if prev_email and prev_email != user_email:
+                    FeedSubscription.remove_user_id(
+                        user_email=prev_email,
+                        user_id=user_id,
+                        s3_path=subscriptions_s3_path,
+                    )
+                    SUBSCRIPTION_CACHE.pop(prev_email, None)
+                    print(
+                        f"Removed user {user_id} from previous subscription: {prev_email}"
+                    )
+
                 subscription = FeedSubscription.add_user_id(
                     user_email=user_email,
                     user_id=user_id,


### PR DESCRIPTION
When a user subscribed to a different email via `/praktika subscribe` (e.g. for testing another user's feed), their Slack user ID was added to the new email's subscription but never removed from the old one. This caused the user to receive home tab updates and DM notifications for both emails.

Now the subscribe action uses `find_user_subscription` to check for an existing subscription under a different email and removes the user from it before adding to the new one.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.961`
<!-- ch-version-info:end -->