### PR TITLE
CI: install GNU coreutils on macOS runners and add them to PATH

### DIFF
--- a/ci/infra/cloud.py
+++ b/ci/infra/cloud.py
@@ -139,7 +139,7 @@ CLOUD = CloudInfrastructure.Config(
             tenancy="host",
             praktika_resource_tag="mac_m2_pro",
             runner_type=RunnerLabels.MACOS_ARM_SMALL[1],
-            quantity=2,
+            quantity=3,
         ),
     ],
     # TODO: add autoscaling and launch templates

--- a/ci/infra/scripts/user_data_macos.txt
+++ b/ci/infra/scripts/user_data_macos.txt
@@ -73,15 +73,19 @@ else
     zstd \
     python@3 \
     wget \
-    unzip
+    unzip \
+    gnu-sed \
+    grep \
+    bash \
+    coreutils
 
   # Install Python packages into a virtual environment using Homebrew Python
   echo "Installing Python packages into venv..."
   sudo -u "$USER" -i bash -c '$(brew --prefix python@3)/bin/python3 -m venv ~/venv && ~/venv/bin/pip install boto3 pygithub requests urllib3 unidiff dohq-artifactory pyjwt'
 
-  # Add venv/bin to PATH for both bash and zsh login shells
-  sudo -u "$USER" -i bash -c "echo 'export PATH=\"\$HOME/venv/bin:\$PATH\"' >> ~/.bash_profile"
-  sudo -u "$USER" -i bash -c "echo 'export PATH=\"\$HOME/venv/bin:\$PATH\"' >> ~/.zprofile"
+  # Add venv/bin and GNU coreutils to PATH for both bash and zsh login shells
+  sudo -u "$USER" -i bash -c "echo 'export PATH=\"\$HOME/venv/bin:/opt/homebrew/opt/coreutils/libexec/gnubin:\$PATH\"' >> ~/.bash_profile"
+  sudo -u "$USER" -i bash -c "echo 'export PATH=\"\$HOME/venv/bin:/opt/homebrew/opt/coreutils/libexec/gnubin:\$PATH\"' >> ~/.zprofile"
 
   # Download and install CloudWatch agent
   echo "Installing Amazon CloudWatch agent..."
@@ -139,6 +143,6 @@ fi
 # Download and execute cloud-init script
 INIT_ENVIRONMENT=${INIT_ENVIRONMENT:-macos}
 aws s3 cp "s3://github-runners-data/cloud-init/${INIT_ENVIRONMENT}.py" /tmp/runner-init.py
-sudo rm -rf /Users/ec2-user/actions-runner/_work
+rm -rf /Users/ec2-user/actions-runner/_work
 sudo -u ec2-user -i bash -c "/Users/ec2-user/venv/bin/python /tmp/runner-init.py --environment \"$INIT_ENVIRONMENT\""
 reboot

--- a/ci/infra/scripts/user_data_macos.txt
+++ b/ci/infra/scripts/user_data_macos.txt
@@ -84,8 +84,9 @@ else
   sudo -u "$USER" -i bash -c '$(brew --prefix python@3)/bin/python3 -m venv ~/venv && ~/venv/bin/pip install boto3 pygithub requests urllib3 unidiff dohq-artifactory pyjwt'
 
   # Add venv/bin and GNU coreutils to PATH for both bash and zsh login shells
-  sudo -u "$USER" -i bash -c "echo 'export PATH=\"\$HOME/venv/bin:/opt/homebrew/opt/coreutils/libexec/gnubin:\$PATH\"' >> ~/.bash_profile"
-  sudo -u "$USER" -i bash -c "echo 'export PATH=\"\$HOME/venv/bin:/opt/homebrew/opt/coreutils/libexec/gnubin:\$PATH\"' >> ~/.zprofile"
+  GNU_COREUTILS_BIN=$(sudo -u "$USER" -i brew --prefix coreutils)/libexec/gnubin
+  sudo -u "$USER" -i bash -c "echo 'export PATH=\"\$HOME/venv/bin:${GNU_COREUTILS_BIN}:\$PATH\"' >> ~/.bash_profile"
+  sudo -u "$USER" -i bash -c "echo 'export PATH=\"\$HOME/venv/bin:${GNU_COREUTILS_BIN}:\$PATH\"' >> ~/.zprofile"
 
   # Download and install CloudWatch agent
   echo "Installing Amazon CloudWatch agent..."

--- a/ci/infra/scripts/user_data_macos.txt
+++ b/ci/infra/scripts/user_data_macos.txt
@@ -83,10 +83,12 @@ else
   echo "Installing Python packages into venv..."
   sudo -u "$USER" -i bash -c '$(brew --prefix python@3)/bin/python3 -m venv ~/venv && ~/venv/bin/pip install boto3 pygithub requests urllib3 unidiff dohq-artifactory pyjwt'
 
-  # Add venv/bin and GNU coreutils to PATH for both bash and zsh login shells
+  # Add venv/bin and GNU tools to PATH for both bash and zsh login shells
   GNU_COREUTILS_BIN=$(sudo -u "$USER" -i brew --prefix coreutils)/libexec/gnubin
-  sudo -u "$USER" -i bash -c "echo 'export PATH=\"\$HOME/venv/bin:${GNU_COREUTILS_BIN}:\$PATH\"' >> ~/.bash_profile"
-  sudo -u "$USER" -i bash -c "echo 'export PATH=\"\$HOME/venv/bin:${GNU_COREUTILS_BIN}:\$PATH\"' >> ~/.zprofile"
+  GNU_SED_BIN=$(sudo -u "$USER" -i brew --prefix gnu-sed)/libexec/gnubin
+  GNU_GREP_BIN=$(sudo -u "$USER" -i brew --prefix grep)/libexec/gnubin
+  sudo -u "$USER" -i bash -c "echo 'export PATH=\"\$HOME/venv/bin:${GNU_COREUTILS_BIN}:${GNU_SED_BIN}:${GNU_GREP_BIN}:\$PATH\"' >> ~/.bash_profile"
+  sudo -u "$USER" -i bash -c "echo 'export PATH=\"\$HOME/venv/bin:${GNU_COREUTILS_BIN}:${GNU_SED_BIN}:${GNU_GREP_BIN}:\$PATH\"' >> ~/.zprofile"
 
   # Download and install CloudWatch agent
   echo "Installing Amazon CloudWatch agent..."


### PR DESCRIPTION
Install `gnu-sed`, `grep`, `bash`, and `coreutils` via Homebrew so that CI scripts running on macOS runners have access to GNU-compatible utilities. Add `/opt/homebrew/opt/coreutils/libexec/gnubin` to `PATH` in both `~/.bash_profile` and `~/.zprofile` so these tools shadow the BSD variants shipped with macOS.

Also remove the unnecessary `sudo` from the workspace cleanup `rm -rf` call (the script already runs as `ec2-user` at that point), and increase the macOS ARM runner pool from 2 to 3 dedicated hosts.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.981`
<!-- ch-version-info:end -->