### PR TITLE
Fix `out_of_range` exception in `CollectSetsVisitor`

### DIFF
--- a/src/Planner/CollectSets.cpp
+++ b/src/Planner/CollectSets.cpp
@@ -31,6 +31,7 @@ namespace ErrorCodes
 {
     extern const int UNSUPPORTED_METHOD;
     extern const int LOGICAL_ERROR;
+    extern const int NUMBER_OF_ARGUMENTS_DOESNT_MATCH;
 }
 
 namespace
@@ -77,6 +78,13 @@ public:
         auto * function_node = node->as<FunctionNode>();
         if (!function_node || !isNameOfInFunction(function_node->getFunctionName()))
             return;
+
+        if (function_node->getArguments().getNodes().size() < 2)
+            throw Exception(
+                ErrorCodes::NUMBER_OF_ARGUMENTS_DOESNT_MATCH,
+                "Function '{}' is expected to have at least 2 arguments, got {}",
+                function_node->getFunctionName(),
+                function_node->getArguments().getNodes().size());
 
         auto in_first_argument = function_node->getArguments().getNodes().at(0);
         auto in_second_argument = function_node->getArguments().getNodes().at(1);

--- a/tests/queries/0_stateless/04100_collect_sets_crash_with_unresolved_in_function.sql
+++ b/tests/queries/0_stateless/04100_collect_sets_crash_with_unresolved_in_function.sql
@@ -1,0 +1,8 @@
+-- Reproducer for CollectSetsVisitor crash when an unresolved IN-family function
+-- with wrong number of arguments ends up in a table function's non-skipped argument.
+DROP TABLE IF EXISTS data;
+CREATE TABLE data (date Date, c0 UInt64) ENGINE = MergeTree ORDER BY date;
+
+SELECT * FROM mergeTreeAnalyzeIndexes(currentDatabase(), data, 1 = 1, [], '', globalNotIn(unknown_col)); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+
+DROP TABLE data;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.980`
<!-- ch-version-info:end -->