### PR TITLE
Fix inverted root/dependent job classification in CI cache

### DIFF
--- a/ci/praktika/hook_cache.py
+++ b/ci/praktika/hook_cache.py
@@ -85,16 +85,17 @@ class CacheRunnerHooks:
             dependent_jobs = {}
 
             for job_name, job_digest in eligible_jobs.items():
-                # Check if this digest is a prefix of any other digest
-                has_prefix = False
+                # Check if this job's digest starts with any other job's digest
+                # (meaning it depends on that other job)
+                is_dependent = False
                 for other_digest in eligible_jobs.values():
-                    if other_digest != job_digest and other_digest.startswith(
-                        job_digest + "-"
+                    if other_digest != job_digest and job_digest.startswith(
+                        other_digest + "-"
                     ):
-                        has_prefix = True
+                        is_dependent = True
                         break
 
-                if not has_prefix:
+                if not is_dependent:
                     root_jobs[job_name] = job_digest
                 else:
                     dependent_jobs[job_name] = job_digest


### PR DESCRIPTION
The `startswith` check in the cache fetch optimization was checking the wrong direction: `other_digest.startswith(job_digest)` asks "is my digest a prefix of another job's?" — which identifies parent/dependency jobs, not dependent ones.

This caused parent jobs like `Dockers Build (amd)` to be misclassified as "dependent" and never fetched from cache, because no root job's longer digest could be a prefix of the shorter parent digest. The result: amd docker job was rebuilt on every PR despite a stable digest and a valid cache record in S3.

The fix swaps to `job_digest.startswith(other_digest)` so that jobs whose combined digest incorporates another job's digest are correctly identified as dependents.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.966`
<!-- ch-version-info:end -->