### PR TITLE
Fix flaky test 02493_max_streams_for_merge_tree_reading

### DIFF
--- a/tests/queries/0_stateless/02493_max_streams_for_merge_tree_reading.sql
+++ b/tests/queries/0_stateless/02493_max_streams_for_merge_tree_reading.sql
@@ -8,6 +8,9 @@ insert into t select number from numbers_mt(10000000) settings max_insert_thread
 
 set allow_prefetched_read_pool_for_remote_filesystem = 0;
 set allow_prefetched_read_pool_for_local_filesystem = 0;
+-- Pin to prevent two-level merge from changing pipeline structure when parts > threshold
+-- (randomized 0-100, INSERT with max_insert_threads=8 creates ~8 parts)
+set read_in_order_two_level_merge_threshold = 100;
 
 -- { echo }
 


### PR DESCRIPTION
Pin `read_in_order_two_level_merge_threshold` to prevent the randomized value (0–100) from triggering a two-level merge pipeline when the number of parts exceeds the threshold.

### Root cause

`INSERT` with `max_insert_threads=8` creates ~8 parts. When `read_in_order_two_level_merge_threshold` is randomized below this count (e.g. 6), the read-in-order pipeline switches to a two-level merge structure. Combined with `max_streams_to_max_threads_ratio=8` (used in the last test query), the aggregation collapses to 1 thread, eliminating the expected `Resize 1 → 4` step from the pipeline output.

The previous fix (adding `no-parallel-replicas` tag) addressed a different failure mode but this one persisted — 66+ failures across 30+ unrelated PRs in the last 30 days.

### Reproduction

```sql
-- Create table with 8+ unmerged parts
CREATE TABLE t (x UInt64) ENGINE = MergeTree ORDER BY x
  SETTINGS max_bytes_to_merge_at_max_space_in_pool=1;
INSERT INTO t SELECT number FROM numbers_mt(10000000) SETTINGS max_insert_threads=8;

-- This returns empty (no Resize) — the failure:
SET query_plan_remove_redundant_sorting=0;
SET read_in_order_two_level_merge_threshold=6;  -- randomized, can be < 8
EXPLAIN PIPELINE SELECT sum(x) FROM (SELECT x FROM t ORDER BY x)
  SETTINGS max_threads=4, max_streams_for_merge_tree_reading=16,
    allow_asynchronous_read_from_io_pool_for_merge_tree=1,
    max_streams_to_max_threads_ratio=8,
    optimize_read_in_order=1, query_plan_read_in_order=1;

-- With the fix (threshold=100), Resize 1 → 4 appears correctly
```

### Fix

Pin `read_in_order_two_level_merge_threshold = 100` before the echo block. This is a targeted fix — only the specific setting that causes the issue is pinned, and the test's intent (verifying `max_streams_for_merge_tree_reading` behavior) is fully preserved.

Verified: 100/100 passes with full randomization locally.

Closes #101657

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a]user-readable short description of the changes that goes to CHANGELOG.md):
- ~no changes~

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.983`
<!-- ch-version-info:end -->