### PR TITLE
Disable 04061_http_pool_tcp_buffer_async_metrics in sanitizer builds

### DIFF
--- a/tests/queries/0_stateless/04061_http_pool_tcp_buffer_async_metrics.sh
+++ b/tests/queries/0_stateless/04061_http_pool_tcp_buffer_async_metrics.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: linux
+# Tags: linux, no-asan, no-tsan, no-msan, no-ubsan
 
 # Verify that asynchronous metrics for HTTP connection pool TCP buffer memory
 # (HTTPConnectionPool*TCP{Rcv,Snd}BufBytes_{p50,p75,p90,p95} and TotalBytes)


### PR DESCRIPTION
Disable `04061_http_pool_tcp_buffer_async_metrics` in sanitizer builds (ASan, TSan, MSan, UBSan).

The test measures async metrics for HTTP connection pool TCP buffer sizes and relies on `sleep`-based timing for coordination. Under sanitizers, the server is significantly slower, making the timing unreliable and the test flaky.

CI report: https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?REF=master&SHA=30287bb9edcf1d2f3b7b0e6fe7e5ce4f42e5e5ed&PR=&REPORT=Stateless+tests+%28asan%2C+keeper%2C+s3+storage%2C+parallel%2C+1%2F3%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1022`
<!-- ch-version-info:end -->