### PR TITLE
Fix TPC-H performance test dataset layout

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -493,7 +493,7 @@ def main():
                 "hits100": "https://clickhouse-datasets.s3.amazonaws.com/hits/partitions/hits_100m_single.tar",
                 "hits1": "https://clickhouse-datasets.s3.amazonaws.com/hits/partitions/hits_v1.tar",
                 "values": "https://clickhouse-datasets.s3.amazonaws.com/values_with_expressions/partitions/test_values.tar",
-                "tpch10": "https://clickhouse-datasets.s3.amazonaws.com/h/10/tpch.tar",
+                "tpch10": "https://clickhouse-datasets.s3.amazonaws.com/h/10/tpch_sf10.tar",
                 "tpcds1": "https://clickhouse-datasets.s3.amazonaws.com/ds/scale_1/tpcds.tar",
             }
             cmds = []
@@ -509,15 +509,6 @@ def main():
                 )
             )
             if res:
-                # The tpch.tar has a broken layout: table data is at data/<table>/ instead of data/tpch10/<table>/. Move folders into place.
-                tpch_tables = ["customer","lineitem","nation","orders","part","partsupp","region","supplier"]
-                for t in tpch_tables:
-                    src = Path(f"{db_path}/data/{t}")
-                    dst = Path(f"{db_path}/data/tpch10/{t}")
-                    if src.is_dir() and not dst.exists():
-                        src.rename(dst)
-                        print(f"Moved {src} -> {dst}")
-
                 Shell.check(f"touch {db_path}/.done")
 
     if res and JobStages.CONFIGURE in stages:

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -509,6 +509,15 @@ def main():
                 )
             )
             if res:
+                # The tpch.tar has a broken layout: table data is at data/<table>/ instead of data/tpch10/<table>/. Move folders into place.
+                tpch_tables = ["customer","lineitem","nation","orders","part","partsupp","region","supplier"]
+                for t in tpch_tables:
+                    src = Path(f"{db_path}/data/{t}")
+                    dst = Path(f"{db_path}/data/tpch10/{t}")
+                    if src.is_dir() and not dst.exists():
+                        src.rename(dst)
+                        print(f"Moved {src} -> {dst}")
+
                 Shell.check(f"touch {db_path}/.done")
 
     if res and JobStages.CONFIGURE in stages:

--- a/ci/jobs/scripts/perf/download.sh
+++ b/ci/jobs/scripts/perf/download.sh
@@ -25,7 +25,7 @@ dataset_paths["hits10"]="https://clickhouse-private-datasets.s3.amazonaws.com/hi
 dataset_paths["hits100"]="https://clickhouse-private-datasets.s3.amazonaws.com/hits_100m_single/partitions/hits_100m_single.tar"
 dataset_paths["hits1"]="https://clickhouse-datasets.s3.amazonaws.com/hits/partitions/hits_v1.tar"
 dataset_paths["values"]="https://clickhouse-datasets.s3.amazonaws.com/values_with_expressions/partitions/test_values.tar"
-dataset_paths["tpch10"]="https://clickhouse-datasets.s3.amazonaws.com/h/10/tpch.tar"
+dataset_paths["tpch10"]="https://clickhouse-datasets.s3.amazonaws.com/h/10/tpch_sf10.tar"
 dataset_paths["tpcds1"]="https://clickhouse-datasets.s3.amazonaws.com/ds/scale_1/tpcds.tar"
 
 
@@ -74,15 +74,6 @@ function download
         fi
         echo "Processing dataset '$dataset_name'..."
         if wget -nv -nd -c "$dataset_path" -O- | tar --extract --verbose; then
-            # The tpch.tar has a broken layout: table data is at data/<table>/ instead of data/tpch10/<table>/. Move folders into place.
-            if [ "$dataset_name" = "tpch10" ]; then
-                for t in customer lineitem nation orders part partsupp region supplier; do
-                    if [ -d "data/$t" ] && [ ! -d "data/tpch10/$t" ]; then
-                        mv "data/$t" "data/tpch10/$t"
-                        echo "Moved data/$t -> data/tpch10/$t"
-                    fi
-                done
-            fi
             touch "$done_flag"
             echo "Dataset '$dataset_name' completed."
         else

--- a/ci/jobs/scripts/perf/download.sh
+++ b/ci/jobs/scripts/perf/download.sh
@@ -74,6 +74,15 @@ function download
         fi
         echo "Processing dataset '$dataset_name'..."
         if wget -nv -nd -c "$dataset_path" -O- | tar --extract --verbose; then
+            # The tpch.tar has a broken layout: table data is at data/<table>/ instead of data/tpch10/<table>/. Move folders into place.
+            if [ "$dataset_name" = "tpch10" ]; then
+                for t in customer lineitem nation orders part partsupp region supplier; do
+                    if [ -d "data/$t" ] && [ ! -d "data/tpch10/$t" ]; then
+                        mv "data/$t" "data/tpch10/$t"
+                        echo "Moved data/$t -> data/tpch10/$t"
+                    fi
+                done
+            fi
             touch "$done_flag"
             echo "Dataset '$dataset_name' completed."
         else

--- a/tests/performance/tpch.xml
+++ b/tests/performance/tpch.xml
@@ -1,6 +1,5 @@
 <!-- https://clickhouse.com/docs/getting-started/example-datasets/tpch -->
 <!-- Scale factor: 10 -->
-<!-- cache-bust: force fresh perf run -->
 <test>
 
 <settings file="../benchmarks/tpc-h/settings.json"/>

--- a/tests/performance/tpch.xml
+++ b/tests/performance/tpch.xml
@@ -1,5 +1,6 @@
 <!-- https://clickhouse.com/docs/getting-started/example-datasets/tpch -->
 <!-- Scale factor: 10 -->
+<!-- cache-bust: force fresh perf run -->
 <test>
 
 <settings file="../benchmarks/tpc-h/settings.json"/>

--- a/tests/performance/tpch.xml
+++ b/tests/performance/tpch.xml
@@ -19,7 +19,7 @@
 <!-- Q2 -->  <query file="../benchmarks/tpc-h/queries/query_02.sql"/>
 <!-- Q3 -->  <query file="../benchmarks/tpc-h/queries/query_03.sql"/>
 <!-- Q4 -->  <query file="../benchmarks/tpc-h/queries/query_04.sql"/>
-<!-- Q5 -->  <query file="../benchmarks/tpc-h/queries/query_05.sql"/>
+<!-- Q5 --> <!-- OOM on SF10 --> <!-- query file="../benchmarks/tpc-h/queries/query_05.sql"-->
 <!-- Q6 -->  <query file="../benchmarks/tpc-h/queries/query_06.sql"/>
 <!-- Q7 -->  <query file="../benchmarks/tpc-h/queries/query_07.sql"/>
 <!-- Q8 -->  <query file="../benchmarks/tpc-h/queries/query_08.sql"/>


### PR DESCRIPTION
The `tpch.tar` dataset used by the performance comparison CI had a broken directory layout: table data was placed at `data/<table>/` instead of `data/tpch10/<table>/`. So all 8 TPC-H tables attached as empty and the benchmark was measuring query planning time (parsing, analysis, optimiser passes, etc.). The PR also comments out Q5 because it OOMs on SF10. Once performance is fixed, we will return it

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1032`
<!-- ch-version-info:end -->