### PR TITLE
Fix server crash from recursive Avro schema

### DIFF
--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -667,7 +667,15 @@ AvroDeserializer::DeserializeFn AvroDeserializer::createDeserializeFn(const avro
             break;
         }
         case avro::AVRO_SYMBOLIC:
-            return createDeserializeFn(avro::resolveSymbol(root_node), target_type);
+        {
+            const auto & sym_name = root_node->name().fullname();
+            if (!symbolic_deserialize_guard.insert(sym_name).second)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "Recursive Avro schema is not supported: type '{}' references itself", sym_name);
+            auto result = createDeserializeFn(avro::resolveSymbol(root_node), target_type);
+            symbolic_deserialize_guard.erase(sym_name);
+            return result;
+        }
         case avro::AVRO_RECORD:
         {
             if (target.isTuple())
@@ -916,15 +924,22 @@ AvroDeserializer::Action AvroDeserializer::createAction(const Block & header, co
 {
     if (node->type() == avro::AVRO_SYMBOLIC)
     {
+        const auto & sym_name = node->name().fullname();
+        if (!symbolic_deserialize_guard.insert(sym_name).second)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "Recursive Avro schema is not supported: type '{}' references itself", sym_name);
+
         /// continue traversal only if some column name starts with current_path
         auto keep_going = std::any_of(header.begin(), header.end(), [&current_path](const ColumnWithTypeAndName & col)
         {
             return col.name.starts_with(current_path);
         });
         auto resolved_node = avro::resolveSymbol(node);
-        if (keep_going)
-            return createAction(header, resolved_node, current_path);
-        return AvroDeserializer::Action(createSkipFn(resolved_node));
+        Action result = keep_going
+            ? createAction(header, resolved_node, current_path)
+            : AvroDeserializer::Action(createSkipFn(resolved_node));
+        symbolic_deserialize_guard.erase(sym_name);
+        return result;
     }
 
     if (header.has(current_path))
@@ -1338,6 +1353,12 @@ NamesAndTypesList AvroSchemaReader::readSchema()
 
 DataTypePtr AvroSchemaReader::avroNodeToDataType(avro::NodePtr node)
 {
+    std::unordered_set<std::string> seen_names;
+    return avroNodeToDataTypeImpl(node, seen_names);
+}
+
+DataTypePtr AvroSchemaReader::avroNodeToDataTypeImpl(const avro::NodePtr & node, std::unordered_set<std::string> & seen_names)
+{
     switch (node->type())
     {
         case avro::Type::AVRO_INT:
@@ -1406,7 +1427,7 @@ DataTypePtr AvroSchemaReader::avroNodeToDataType(avro::NodePtr node)
             return std::make_shared<DataTypeFixedString>(node->fixedSize());
         }
         case avro::Type::AVRO_ARRAY:
-            return std::make_shared<DataTypeArray>(avroNodeToDataType(node->leafAt(0)));
+            return std::make_shared<DataTypeArray>(avroNodeToDataTypeImpl(node->leafAt(0), seen_names));
         case avro::Type::AVRO_NULL:
             return std::make_shared<DataTypeNothing>();
         case avro::Type::AVRO_UNION:
@@ -1414,7 +1435,7 @@ DataTypePtr AvroSchemaReader::avroNodeToDataType(avro::NodePtr node)
             // Treat union[T] as just T
             if (node->leaves() == 1)
             {
-                return avroNodeToDataType(node->leafAt(0));
+                return avroNodeToDataTypeImpl(node->leafAt(0), seen_names);
             }
 
             // Treat union[T, NULL] and union[NULL, T] as Nullable(T)
@@ -1423,7 +1444,7 @@ DataTypePtr AvroSchemaReader::avroNodeToDataType(avro::NodePtr node)
                 && (node->leafAt(0)->type() == avro::Type::AVRO_NULL || node->leafAt(1)->type() == avro::Type::AVRO_NULL))
             {
                 int nested_leaf_index = node->leafAt(0)->type() == avro::Type::AVRO_NULL ? 1 : 0;
-                auto nested_type = avroNodeToDataType(node->leafAt(nested_leaf_index));
+                auto nested_type = avroNodeToDataTypeImpl(node->leafAt(nested_leaf_index), seen_names);
                 return nested_type->canBeInsideNullable() ? makeNullable(nested_type) : nested_type;
             }
 
@@ -1439,27 +1460,37 @@ DataTypePtr AvroSchemaReader::avroNodeToDataType(avro::NodePtr node)
                 if (node->leafAt(i)->type() == avro::Type::AVRO_NULL) continue;
 
                 const auto & avro_node = node->leafAt(i);
-                nested_types.push_back(avroNodeToDataType(avro_node));
+                nested_types.push_back(avroNodeToDataTypeImpl(avro_node, seen_names));
             }
             return std::make_shared<DataTypeVariant>(nested_types);
         }
         case avro::Type::AVRO_SYMBOLIC:
-            return avroNodeToDataType(avro::resolveSymbol(node));
+        {
+            auto resolved = avro::resolveSymbol(node);
+            return avroNodeToDataTypeImpl(resolved, seen_names);
+        }
         case avro::Type::AVRO_RECORD:
         {
+            const auto & name = node->name().fullname();
+            if (!seen_names.insert(name).second)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "Recursive Avro schema is not supported: type '{}' references itself", name);
+
             DataTypes nested_types;
             nested_types.reserve(node->leaves());
             Names nested_names;
             nested_names.reserve(node->leaves());
             for (int i = 0; i != static_cast<int>(node->leaves()); ++i)
             {
-                nested_types.push_back(avroNodeToDataType(node->leafAt(i)));
+                nested_types.push_back(avroNodeToDataTypeImpl(node->leafAt(i), seen_names));
                 nested_names.push_back(node->nameAt(i));
             }
+
+            seen_names.erase(name);
             return std::make_shared<DataTypeTuple>(nested_types, nested_names);
         }
         case avro::Type::AVRO_MAP:
-            return std::make_shared<DataTypeMap>(avroNodeToDataType(node->leafAt(0)), avroNodeToDataType(node->leafAt(1)));
+            return std::make_shared<DataTypeMap>(avroNodeToDataTypeImpl(node->leafAt(0), seen_names), avroNodeToDataTypeImpl(node->leafAt(1), seen_names));
         default:
             throw Exception(ErrorCodes::ILLEGAL_COLUMN, "Avro column {} is not supported for inserting.", nodeName(node));
     }

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -924,20 +924,30 @@ AvroDeserializer::Action AvroDeserializer::createAction(const Block & header, co
 {
     if (node->type() == avro::AVRO_SYMBOLIC)
     {
-        const auto & sym_name = node->name().fullname();
-        if (!symbolic_deserialize_guard.insert(sym_name).second)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                "Recursive Avro schema is not supported: type '{}' references itself", sym_name);
-
         /// continue traversal only if some column name starts with current_path
         auto keep_going = std::any_of(header.begin(), header.end(), [&current_path](const ColumnWithTypeAndName & col)
         {
             return col.name.starts_with(current_path);
         });
         auto resolved_node = avro::resolveSymbol(node);
-        Action result = keep_going
-            ? createAction(header, resolved_node, current_path)
-            : AvroDeserializer::Action(createSkipFn(resolved_node));
+
+        /// When we do not need to descend into the referenced type, take the safe skip path.
+        /// `createSkipFn` handles cyclic symbolic references via `symbolic_skip_fn_map` (lazy
+        /// placeholder that is filled in on first resolution). So legitimately recursive
+        /// schemas (e.g. a LinkedList with optional self-reference) are still readable when
+        /// the requested columns do not traverse into the cycle.
+        if (!keep_going)
+            return AvroDeserializer::Action(createSkipFn(resolved_node));
+
+        /// If we do need to descend, we cannot build a finite deserializer when the same
+        /// symbolic reference appears on the current path — that would require infinite
+        /// unrolling. Guard with a path-stack (insert on entry, erase on exit) so sibling
+        /// re-uses of the same named type are allowed, and only back-edges are rejected.
+        const auto & sym_name = node->name().fullname();
+        if (!symbolic_deserialize_guard.insert(sym_name).second)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "Recursive Avro schema is not supported: type '{}' references itself", sym_name);
+        Action result = createAction(header, resolved_node, current_path);
         symbolic_deserialize_guard.erase(sym_name);
         return result;
     }

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.h
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.h
@@ -5,6 +5,7 @@
 #if USE_AVRO
 
 #include <unordered_map>
+#include <unordered_set>
 #include <map>
 #include <vector>
 
@@ -149,6 +150,10 @@ private:
     /// This is to avoid infinite recursion when  Avro schema contains self-references. e.g. LinkedList
     std::map<avro::Name, SkipFn> symbolic_skip_fn_map;
 
+    /// Guard against infinite recursion in createDeserializeFn and createAction
+    /// when Avro schema contains cyclic symbolic references (e.g. TypeA -> TypeB -> TypeA).
+    std::unordered_set<std::string> symbolic_deserialize_guard;
+
     bool null_as_default = false;
 
     const FormatSettings & settings;
@@ -213,6 +218,7 @@ public:
 
     static DataTypePtr avroNodeToDataType(avro::NodePtr node);
 private:
+    static DataTypePtr avroNodeToDataTypeImpl(const avro::NodePtr & node, std::unordered_set<std::string> & seen_names);
 
     bool confluent;
     const FormatSettings format_settings;

--- a/tests/queries/0_stateless/04101_avro_recursive_schema_crash.reference
+++ b/tests/queries/0_stateless/04101_avro_recursive_schema_crash.reference
@@ -1,0 +1,2 @@
+Recursive Avro schema is not supported
+Recursive Avro schema is not supported

--- a/tests/queries/0_stateless/04101_avro_recursive_schema_crash.sh
+++ b/tests/queries/0_stateless/04101_avro_recursive_schema_crash.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+# Regression test for Avro infinite recursion crash.
+# A crafted .avro file with a mutually recursive schema (TypeA -> TypeB -> TypeA)
+# would cause avroNodeToDataType() to recurse infinitely, overflowing the stack
+# and crashing the server with SIGSEGV.
+# The fix detects cycles in the Avro schema and throws a user-friendly error.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+# Generate a malicious Avro file with a recursive schema.
+# The schema defines TypeA with field b:TypeB, and TypeB with field a:TypeA (back-reference).
+# The Avro C++ library resolves the symbolic reference into a direct pointer cycle.
+AVRO_FILE="${CLICKHOUSE_TMP}/malicious_recursive.avro"
+
+python3 -c "
+import struct, os, json
+
+def encode_long(n):
+    n = (n << 1) ^ (n >> 63)
+    result = b''
+    while True:
+        b = n & 0x7F
+        n >>= 7
+        if n:
+            result += bytes([b | 0x80])
+        else:
+            result += bytes([b])
+            break
+    return result
+
+def encode_bytes(data):
+    return encode_long(len(data)) + data
+
+def encode_string(s):
+    return encode_bytes(s.encode() if isinstance(s, str) else s)
+
+def encode_map(d):
+    out = encode_long(len(d))
+    for k, v in d.items():
+        out += encode_string(k)
+        out += encode_bytes(v)
+    out += encode_long(0)
+    return out
+
+schema_json = json.dumps({
+    'type': 'record',
+    'name': 'TypeA',
+    'fields': [{
+        'name': 'b',
+        'type': {
+            'type': 'record',
+            'name': 'TypeB',
+            'fields': [{'name': 'a', 'type': 'TypeA'}]
+        }
+    }]
+}).encode()
+
+sync_marker = b'\\x1d\\xe3\\x80\\x44\\xf4\\x96\\xb5\\xd6\\xe6\\xa5\\x7b\\x18\\x63\\xb5\\x10\\x9a'
+
+metadata = {'avro.schema': schema_json, 'avro.codec': b'null'}
+header = b'Obj\\x01' + encode_map(metadata) + sync_marker
+empty_block = encode_long(0) + encode_long(0) + sync_marker
+
+with open('${AVRO_FILE}', 'wb') as f:
+    f.write(header + empty_block)
+"
+
+# This query previously crashed the server. Now it should return an error.
+${CLICKHOUSE_LOCAL} --query "SELECT * FROM file('${AVRO_FILE}', 'Avro')" 2>&1 | grep -o "Recursive Avro schema is not supported"
+
+# Also test via DESCRIBE to exercise avroNodeToDataType schema inference path
+${CLICKHOUSE_LOCAL} --query "DESCRIBE file('${AVRO_FILE}', 'Avro')" 2>&1 | grep -o "Recursive Avro schema is not supported"
+
+rm -f "${AVRO_FILE}"


### PR DESCRIPTION
A crafted `.avro` file with a mutually recursive schema (e.g. `TypeA → TypeB → TypeA`) causes `avroNodeToDataType()`, `createDeserializeFn()`, and `createAction()` to recurse infinitely through `AVRO_SYMBOLIC` nodes, overflowing the stack and crashing the server with SIGSEGV. Any query reading such a file (from S3, HTTP, or local path) triggers the crash — no authentication required.

The fix adds explicit cycle detection to all three vulnerable code paths using name-tracking sets that detect back-references immediately (on the first re-entry, not after thousands of stack frames). Non-recursive re-use of named types is unaffected — verified with existing test `02592_avro_records_with_same_names`.

`createSkipFn()` was already protected via `symbolic_skip_fn_map` — the same defensive pattern.

Complementary to #102417 which adds generic `checkStackSize()` guards (catches all deep nesting including non-recursive). This PR specifically detects logical cycles with an immediate, targeted error message.

**Reproduction:**
```sql
-- With the crafted malicious.avro from #102809:
SELECT * FROM file('malicious.avro', 'Avro');  -- SIGSEGV before fix, clean error after
```

**After fix:**
```
Code: 36. Recursive Avro schema is not supported: type 'TypeB' references itself. (BAD_ARGUMENTS)
```

Closes #102809

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fix server crash (SIGSEGV) when reading Avro files with recursive schemas containing cyclic symbolic type references. Now such schemas are detected and rejected with a clear error message instead of crashing.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1106`
<!-- ch-version-info:end -->