### PR TITLE
Fix FunctionVariantAdaptor wrapping non-type exceptions as LOGICAL_ERROR

### DIFF
--- a/src/Functions/FunctionVariantAdaptor.cpp
+++ b/src/Functions/FunctionVariantAdaptor.cpp
@@ -113,6 +113,12 @@ ColumnPtr ExecutableFunctionVariantAdaptor::executeImpl(
                 }
                 catch (const Exception & e)
                 {
+                    /// Only wrap type-conversion errors as LOGICAL_ERROR.
+                    /// Other exceptions (e.g. MEMORY_LIMIT_EXCEEDED) should propagate as-is.
+                    if (e.code() != ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT && e.code() != ErrorCodes::TYPE_MISMATCH
+                        && e.code() != ErrorCodes::CANNOT_CONVERT_TYPE && e.code() != ErrorCodes::NO_COMMON_TYPE)
+                        throw;
+
                     throw Exception(
                         ErrorCodes::LOGICAL_ERROR,
                         "Cannot convert nested result of function {} with type {} to the expected result type {}: {}",
@@ -135,6 +141,10 @@ ColumnPtr ExecutableFunctionVariantAdaptor::executeImpl(
         }
         catch (const Exception & e)
         {
+            if (e.code() != ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT && e.code() != ErrorCodes::TYPE_MISMATCH
+                && e.code() != ErrorCodes::CANNOT_CONVERT_TYPE && e.code() != ErrorCodes::NO_COMMON_TYPE)
+                throw;
+
             throw Exception(
                 ErrorCodes::LOGICAL_ERROR,
                 "Cannot convert nested result of function {} with type {} to the expected result type {}: {}",
@@ -226,6 +236,10 @@ ColumnPtr ExecutableFunctionVariantAdaptor::executeImpl(
                 }
                 catch (const Exception & e)
                 {
+                    if (e.code() != ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT && e.code() != ErrorCodes::TYPE_MISMATCH
+                        && e.code() != ErrorCodes::CANNOT_CONVERT_TYPE && e.code() != ErrorCodes::NO_COMMON_TYPE)
+                        throw;
+
                     throw Exception(
                         ErrorCodes::LOGICAL_ERROR,
                         "Cannot convert nested result of function {} with type {} to the expected result type {}: {}",
@@ -251,6 +265,10 @@ ColumnPtr ExecutableFunctionVariantAdaptor::executeImpl(
             }
             catch (const Exception & e)
             {
+                if (e.code() != ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT && e.code() != ErrorCodes::TYPE_MISMATCH
+                    && e.code() != ErrorCodes::CANNOT_CONVERT_TYPE && e.code() != ErrorCodes::NO_COMMON_TYPE)
+                    throw;
+
                 throw Exception(
                     ErrorCodes::LOGICAL_ERROR,
                     "Cannot convert nested result of function {} with type {} to the expected result type {}: {}",
@@ -270,6 +288,10 @@ ColumnPtr ExecutableFunctionVariantAdaptor::executeImpl(
         }
         catch (const Exception & e)
         {
+            if (e.code() != ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT && e.code() != ErrorCodes::TYPE_MISMATCH
+                && e.code() != ErrorCodes::CANNOT_CONVERT_TYPE && e.code() != ErrorCodes::NO_COMMON_TYPE)
+                throw;
+
             throw Exception(
                 ErrorCodes::LOGICAL_ERROR,
                 "Cannot convert nested result of function {} with type {} to the expected result type {}: {}",
@@ -389,6 +411,10 @@ ColumnPtr ExecutableFunctionVariantAdaptor::executeImpl(
                 }
                 catch (const Exception & e)
                 {
+                    if (e.code() != ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT && e.code() != ErrorCodes::TYPE_MISMATCH
+                        && e.code() != ErrorCodes::CANNOT_CONVERT_TYPE && e.code() != ErrorCodes::NO_COMMON_TYPE)
+                        throw;
+
                     throw Exception(
                         ErrorCodes::LOGICAL_ERROR,
                         "Cannot convert nested result of function {} with type {} to the expected result type {}: {}",
@@ -545,6 +571,10 @@ ColumnPtr ExecutableFunctionVariantAdaptor::executeImpl(
         }
         catch (const Exception & e)
         {
+            if (e.code() != ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT && e.code() != ErrorCodes::TYPE_MISMATCH
+                && e.code() != ErrorCodes::CANNOT_CONVERT_TYPE && e.code() != ErrorCodes::NO_COMMON_TYPE)
+                throw;
+
             throw Exception(
                 ErrorCodes::LOGICAL_ERROR,
                 "Cannot convert nested result of function {} with type {} to the expected result type {}: {}",

--- a/tests/queries/0_stateless/04101_variant_adaptor_propagate_exceptions.sql
+++ b/tests/queries/0_stateless/04101_variant_adaptor_propagate_exceptions.sql
@@ -1,0 +1,37 @@
+-- Tags: no-random-settings
+-- Test that non-type-conversion exceptions (like MEMORY_LIMIT_EXCEEDED) are propagated
+-- from FunctionVariantAdaptor instead of being incorrectly wrapped as LOGICAL_ERROR.
+-- See https://github.com/ClickHouse/ClickHouse/issues/93960
+
+SET allow_experimental_variant_type = 1;
+SET use_variant_as_common_type = 1;
+
+-- Path 1: Single variant type, no NULLs → castColumn for Variant result
+DROP TABLE IF EXISTS test_variant_oom;
+CREATE TABLE test_variant_oom (v Variant(Float64, Int64)) ENGINE = Memory;
+INSERT INTO test_variant_oom SELECT (number * 1.0001)::Float64::Variant(Float64, Int64) FROM numbers(5000000);
+
+SELECT moduloOrZero(v, 65536) FROM test_variant_oom SETTINGS max_memory_usage = 10000000 FORMAT Null; -- { serverError MEMORY_LIMIT_EXCEEDED }
+
+-- Path 2: Single variant type + NULLs → castColumn for Variant result with filter
+DROP TABLE IF EXISTS test_variant_oom2;
+CREATE TABLE test_variant_oom2 (v Variant(Float64, Int64)) ENGINE = Memory;
+INSERT INTO test_variant_oom2 SELECT if(number % 3 = 0, NULL, (number * 1.0001)::Float64)::Variant(Float64, Int64) FROM numbers(5000000);
+
+SELECT moduloOrZero(v, 65536) FROM test_variant_oom2 SETTINGS max_memory_usage = 10000000 FORMAT Null; -- { serverError MEMORY_LIMIT_EXCEEDED }
+
+-- Path 3: Multiple variant types → general castColumn path
+DROP TABLE IF EXISTS test_variant_oom3;
+CREATE TABLE test_variant_oom3 (v Variant(Float64, Int64)) ENGINE = Memory;
+INSERT INTO test_variant_oom3 SELECT if(number % 2 = 0, (number * 1.0001)::Float64, number::Int64)::Variant(Float64, Int64) FROM numbers(5000000);
+
+SELECT moduloOrZero(v, 65536) FROM test_variant_oom3 SETTINGS max_memory_usage = 10000000 FORMAT Null; -- { serverError MEMORY_LIMIT_EXCEEDED }
+
+-- Verify normal operation works fine
+SELECT count(moduloOrZero(v, 65536)) FROM test_variant_oom FORMAT Null;
+SELECT count(moduloOrZero(v, 65536)) FROM test_variant_oom2 FORMAT Null;
+SELECT count(moduloOrZero(v, 65536)) FROM test_variant_oom3 FORMAT Null;
+
+DROP TABLE test_variant_oom;
+DROP TABLE test_variant_oom2;
+DROP TABLE test_variant_oom3;


### PR DESCRIPTION
`ExecutableFunctionVariantAdaptor::executeImpl()` has 7 `catch (const Exception & e)` blocks around `castColumn()` calls that catch ALL exceptions and re-throw them as `LOGICAL_ERROR`. Non-type-conversion exceptions like `MEMORY_LIMIT_EXCEEDED` are incorrectly wrapped, causing `abortOnFailedAssertion()` to crash the server instead of returning a user-facing error.

**Root cause:** When a function applied to a `Variant` column triggers OOM inside `castColumn()` (which converts the result to the expected Variant type), the OOM exception is caught and re-thrown as:
```
Logical error: 'Cannot convert nested result of function moduloOrZero with type Float64
to the expected result type Variant(Float64, Int64): Query memory limit exceeded...'
```
This LOGICAL_ERROR triggers the assertion handler and kills the server.

**Fix:** Added error code filtering to all 7 catch blocks. Only type-conversion errors (`ILLEGAL_TYPE_OF_ARGUMENT`, `TYPE_MISMATCH`, `CANNOT_CONVERT_TYPE`, `NO_COMMON_TYPE`) are wrapped as `LOGICAL_ERROR`. All other exceptions propagate as-is. This matches the existing pattern in the `FunctionBaseVariantAdaptor` constructor (which already filters these exact codes).

**Reproduction:**
```sql
CREATE TABLE t (v Variant(Float64, Int64)) ENGINE = Memory;
INSERT INTO t SELECT (number * 1.0001)::Float64::Variant(Float64, Int64) FROM numbers(5000000);
-- Before fix: server crashes with LOGICAL_ERROR
-- After fix: returns MEMORY_LIMIT_EXCEEDED (code 241), server stays alive
SELECT moduloOrZero(v, 65536) FROM t SETTINGS max_memory_usage = 10000000 FORMAT Null;
```

All 3 execution paths in `executeImpl` are covered:
1. Single variant type, no NULLs (line 138 — the path triggered by CI)
2. Single variant type + NULLs (line 236, 265, 288)
3. Multiple variant types (lines 411, 571)

Fixes https://github.com/ClickHouse/ClickHouse/issues/93960

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):

Fix server crash (LOGICAL_ERROR assertion) when a function on a `Variant` column hits a memory limit or other non-type-conversion exception during result casting in `FunctionVariantAdaptor`. The exception is now propagated correctly instead of being misclassified as an internal error.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.993`
<!-- ch-version-info:end -->