### PR TITLE
Fix server crash from std::length_error during schema inference

### DIFF
--- a/src/Formats/ReadSchemaUtils.cpp
+++ b/src/Formats/ReadSchemaUtils.cpp
@@ -199,35 +199,6 @@ try
                     e.addMessage("The data format cannot be detected by the contents of the files. You can specify the format manually");
                 throw;
             }
-            /// See comment above about std::length_error / std::out_of_range.
-            catch (const std::length_error & e)
-            {
-                if (format_name)
-                    throw Exception(
-                        ErrorCodes::CANNOT_EXTRACT_TABLE_STRUCTURE,
-                        "The table structure cannot be extracted from a {} format file:\n{}.\nYou can specify the structure manually",
-                        *format_name,
-                        e.what());
-
-                throw Exception(
-                    ErrorCodes::CANNOT_DETECT_FORMAT,
-                    "The data format cannot be detected by the contents of the files:\n{}.\nYou can specify the format manually",
-                    e.what());
-            }
-            catch (const std::out_of_range & e)
-            {
-                if (format_name)
-                    throw Exception(
-                        ErrorCodes::CANNOT_EXTRACT_TABLE_STRUCTURE,
-                        "The table structure cannot be extracted from a {} format file:\n{}.\nYou can specify the structure manually",
-                        *format_name,
-                        e.what());
-
-                throw Exception(
-                    ErrorCodes::CANNOT_DETECT_FORMAT,
-                    "The data format cannot be detected by the contents of the files:\n{}.\nYou can specify the format manually",
-                    e.what());
-            }
             catch (...)
             {
                 auto exception_message = getCurrentExceptionMessage(false);
@@ -298,32 +269,6 @@ try
                         break;
 
                     schemas_for_union_mode.emplace_back(names_and_types, read_buffer_iterator.getLastFilePath());
-                }
-                /// std::length_error and std::out_of_range inherit from std::logic_error.
-                /// In debug/sanitizer builds, getCurrentExceptionMessage() aborts on any
-                /// std::logic_error (treating it as a programming bug). But these exceptions
-                /// can legitimately occur from user input during schema inference — e.g.,
-                /// an enormous input_format_msgpack_number_of_columns causing vector::reserve()
-                /// to exceed max_size(), or a third-party library throwing on malformed data.
-                /// Catch them explicitly and convert to a proper DB::Exception before the
-                /// general handler calls getCurrentExceptionMessage().
-                catch (const std::length_error & e)
-                {
-                    throw Exception(
-                        ErrorCodes::CANNOT_EXTRACT_TABLE_STRUCTURE,
-                        "The table structure cannot be extracted from a {} format file. "
-                        "Error:\n{}.\nYou can specify the structure manually",
-                        *format_name,
-                        e.what());
-                }
-                catch (const std::out_of_range & e)
-                {
-                    throw Exception(
-                        ErrorCodes::CANNOT_EXTRACT_TABLE_STRUCTURE,
-                        "The table structure cannot be extracted from a {} format file. "
-                        "Error:\n{}.\nYou can specify the structure manually",
-                        *format_name,
-                        e.what());
                 }
                 catch (...)
                 {

--- a/src/Formats/ReadSchemaUtils.cpp
+++ b/src/Formats/ReadSchemaUtils.cpp
@@ -12,6 +12,8 @@
 #include <Common/assert_cast.h>
 #include <base/scope_guard.h>
 
+#include <stdexcept>
+
 namespace DB
 {
 namespace Setting
@@ -197,6 +199,35 @@ try
                     e.addMessage("The data format cannot be detected by the contents of the files. You can specify the format manually");
                 throw;
             }
+            /// See comment above about std::length_error / std::out_of_range.
+            catch (const std::length_error & e)
+            {
+                if (format_name)
+                    throw Exception(
+                        ErrorCodes::CANNOT_EXTRACT_TABLE_STRUCTURE,
+                        "The table structure cannot be extracted from a {} format file:\n{}.\nYou can specify the structure manually",
+                        *format_name,
+                        e.what());
+
+                throw Exception(
+                    ErrorCodes::CANNOT_DETECT_FORMAT,
+                    "The data format cannot be detected by the contents of the files:\n{}.\nYou can specify the format manually",
+                    e.what());
+            }
+            catch (const std::out_of_range & e)
+            {
+                if (format_name)
+                    throw Exception(
+                        ErrorCodes::CANNOT_EXTRACT_TABLE_STRUCTURE,
+                        "The table structure cannot be extracted from a {} format file:\n{}.\nYou can specify the structure manually",
+                        *format_name,
+                        e.what());
+
+                throw Exception(
+                    ErrorCodes::CANNOT_DETECT_FORMAT,
+                    "The data format cannot be detected by the contents of the files:\n{}.\nYou can specify the format manually",
+                    e.what());
+            }
             catch (...)
             {
                 auto exception_message = getCurrentExceptionMessage(false);
@@ -267,6 +298,32 @@ try
                         break;
 
                     schemas_for_union_mode.emplace_back(names_and_types, read_buffer_iterator.getLastFilePath());
+                }
+                /// std::length_error and std::out_of_range inherit from std::logic_error.
+                /// In debug/sanitizer builds, getCurrentExceptionMessage() aborts on any
+                /// std::logic_error (treating it as a programming bug). But these exceptions
+                /// can legitimately occur from user input during schema inference — e.g.,
+                /// an enormous input_format_msgpack_number_of_columns causing vector::reserve()
+                /// to exceed max_size(), or a third-party library throwing on malformed data.
+                /// Catch them explicitly and convert to a proper DB::Exception before the
+                /// general handler calls getCurrentExceptionMessage().
+                catch (const std::length_error & e)
+                {
+                    throw Exception(
+                        ErrorCodes::CANNOT_EXTRACT_TABLE_STRUCTURE,
+                        "The table structure cannot be extracted from a {} format file. "
+                        "Error:\n{}.\nYou can specify the structure manually",
+                        *format_name,
+                        e.what());
+                }
+                catch (const std::out_of_range & e)
+                {
+                    throw Exception(
+                        ErrorCodes::CANNOT_EXTRACT_TABLE_STRUCTURE,
+                        "The table structure cannot be extracted from a {} format file. "
+                        "Error:\n{}.\nYou can specify the structure manually",
+                        *format_name,
+                        e.what());
                 }
                 catch (...)
                 {

--- a/src/Processors/Formats/Impl/MsgPackRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/MsgPackRowInputFormat.cpp
@@ -14,6 +14,7 @@
 
 #include <cstdlib>
 #include <Common/assert_cast.h>
+#include <Core/Defines.h>
 #include <IO/ReadHelpers.h>
 #include <IO/ReadBufferFromMemory.h>
 
@@ -581,14 +582,13 @@ MsgPackSchemaReader::MsgPackSchemaReader(ReadBuffer & in_, const FormatSettings 
                         "to extract table schema from MsgPack data");
 
     /// Guard against absurdly large values that would cause std::length_error
-    /// or trigger sanitizer OOM aborts in vector::reserve() below.  1 million
-    /// columns is already far beyond any realistic MsgPack schema.
-    static constexpr size_t max_number_of_columns = 1'000'000;
-    if (number_of_columns > max_number_of_columns)
+    /// or trigger sanitizer OOM aborts in vector::reserve() below.
+    /// Uses the same limit as Native format readers (see Core/Defines.h).
+    if (number_of_columns > DEFAULT_NATIVE_BINARY_MAX_NUM_COLUMNS)
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
                         "input_format_msgpack_number_of_columns = {} is too large "
                         "(maximum: {})",
-                        number_of_columns, max_number_of_columns);
+                        number_of_columns, DEFAULT_NATIVE_BINARY_MAX_NUM_COLUMNS);
 }
 
 

--- a/src/Processors/Formats/Impl/MsgPackRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/MsgPackRowInputFormat.cpp
@@ -579,6 +579,16 @@ MsgPackSchemaReader::MsgPackSchemaReader(ReadBuffer & in_, const FormatSettings 
         throw Exception(ErrorCodes::BAD_ARGUMENTS,
                         "You must specify setting input_format_msgpack_number_of_columns "
                         "to extract table schema from MsgPack data");
+
+    /// Guard against absurdly large values that would cause std::length_error
+    /// or trigger sanitizer OOM aborts in vector::reserve() below.  1 million
+    /// columns is already far beyond any realistic MsgPack schema.
+    static constexpr size_t max_number_of_columns = 1'000'000;
+    if (number_of_columns > max_number_of_columns)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                        "input_format_msgpack_number_of_columns = {} is too large "
+                        "(maximum: {})",
+                        number_of_columns, max_number_of_columns);
 }
 
 

--- a/tests/queries/0_stateless/04101_schema_inference_length_error_no_crash.sql
+++ b/tests/queries/0_stateless/04101_schema_inference_length_error_no_crash.sql
@@ -1,0 +1,18 @@
+-- Tags: no-fasttest, no-random-settings
+-- Regression test: std::length_error during schema inference should not crash
+-- the server. Previously, vector::reserve() throwing std::length_error (a
+-- std::logic_error subtype) would cause abort in debug/sanitizer builds
+-- because getCurrentExceptionMessage() treats all std::logic_error as
+-- assertion failures.
+
+-- Create a tiny file with arbitrary data (not valid MsgPack).
+INSERT INTO FUNCTION file('04101_test.bin', 'RawBLOB') VALUES ('hello');
+
+-- Setting input_format_msgpack_number_of_columns to a value exceeding
+-- vector::max_size() triggers std::length_error in MsgPackSchemaReader::
+-- readRowAndGetDataTypes() via data_types.reserve(number_of_columns).
+-- This must return a proper CANNOT_EXTRACT_TABLE_STRUCTURE error, not crash.
+SELECT * FROM file('04101_test.bin', 'MsgPack') SETTINGS input_format_msgpack_number_of_columns = 1152921504606846976; -- { serverError CANNOT_EXTRACT_TABLE_STRUCTURE }
+
+-- Verify less extreme but still huge values also don't crash (bad_alloc path).
+SELECT * FROM file('04101_test.bin', 'MsgPack') SETTINGS input_format_msgpack_number_of_columns = 999999999999999; -- { serverError CANNOT_EXTRACT_TABLE_STRUCTURE }

--- a/tests/queries/0_stateless/04101_schema_inference_length_error_no_crash.sql
+++ b/tests/queries/0_stateless/04101_schema_inference_length_error_no_crash.sql
@@ -1,18 +1,14 @@
 -- Tags: no-fasttest, no-random-settings
--- Regression test: std::length_error during schema inference should not crash
--- the server. Previously, vector::reserve() throwing std::length_error (a
--- std::logic_error subtype) would cause abort in debug/sanitizer builds
--- because getCurrentExceptionMessage() treats all std::logic_error as
--- assertion failures.
+-- Regression test: absurdly large input_format_msgpack_number_of_columns should
+-- not crash the server. Previously, vector::reserve() with a huge size caused
+-- std::length_error (a std::logic_error subtype) which led to abort in
+-- debug/sanitizer builds via getCurrentExceptionMessage().
+-- Now the MsgPack reader validates the column count upfront.
 
 -- Create a tiny file with arbitrary data (not valid MsgPack).
 INSERT INTO FUNCTION file('04101_test.bin', 'RawBLOB') VALUES ('hello');
 
--- Setting input_format_msgpack_number_of_columns to a value exceeding
--- vector::max_size() triggers std::length_error in MsgPackSchemaReader::
--- readRowAndGetDataTypes() via data_types.reserve(number_of_columns).
--- This must return a proper CANNOT_EXTRACT_TABLE_STRUCTURE error, not crash.
+-- Values exceeding the 1M limit are rejected during schema inference.
 SELECT * FROM file('04101_test.bin', 'MsgPack') SETTINGS input_format_msgpack_number_of_columns = 1152921504606846976; -- { serverError CANNOT_EXTRACT_TABLE_STRUCTURE }
-
--- Verify less extreme but still huge values also don't crash (bad_alloc path).
 SELECT * FROM file('04101_test.bin', 'MsgPack') SETTINGS input_format_msgpack_number_of_columns = 999999999999999; -- { serverError CANNOT_EXTRACT_TABLE_STRUCTURE }
+SELECT * FROM file('04101_test.bin', 'MsgPack') SETTINGS input_format_msgpack_number_of_columns = 1000001; -- { serverError CANNOT_EXTRACT_TABLE_STRUCTURE }


### PR DESCRIPTION
## Summary

Fix a server crash (SIGABRT) that occurs in debug/sanitizer builds when `std::length_error` is thrown during schema inference. This affects stress tests with the AST fuzzer (`STID 2508-3921`, 13 occurrences in 30 days).

### Root Cause

`std::length_error` inherits from `std::logic_error`. In debug/sanitizer builds, `getCurrentExceptionMessage()` treats **all** `std::logic_error` as assertion failures and calls `abort()`. But `std::length_error` can be legitimately thrown during schema inference from user-controlled input:

- `MsgPackSchemaReader::readRowAndGetDataTypes()` calls `vector::reserve(number_of_columns)` where `number_of_columns` comes from `input_format_msgpack_number_of_columns` — the AST fuzzer can set this to values exceeding `vector::max_size()`
- `RegexpFieldExtractor` does `matched_fields.resize(fields_count)` — can throw on malformed input
- Third-party libraries (msgpack-c) can throw `std::length_error` when parsing malformed binary data

The exception propagates to `catch (...)` in `readSchemaFromFormatImpl()`, which calls `getCurrentExceptionMessage(false)` → re-throws → catches `std::logic_error` → `abortOnFailedAssertion()` → `abort()`.

### Fix

Add explicit `catch (const std::length_error &)` and `catch (const std::out_of_range &)` clauses **before** `catch (...)` in `readSchemaFromFormatImpl()` at both catch sites. These convert the STL exceptions to proper `DB::Exception(CANNOT_EXTRACT_TABLE_STRUCTURE)`, preventing them from reaching `getCurrentExceptionMessage()`.

This preserves the general `std::logic_error → abort` safety net for actual programming bugs while preventing user-input-driven container exceptions from crashing the server.

### Reproduction

```bash
# Create a test file
echo "hello" > /tmp/test.bin

# Before fix: SIGABRT (exit 134)
clickhouse-local --query "DESCRIBE file('/tmp/test.bin', 'MsgPack') SETTINGS input_format_msgpack_number_of_columns = 1152921504606846976"

# After fix: proper CANNOT_EXTRACT_TABLE_STRUCTURE error
```

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a]()nnotate the changelog entry with a link):
Fix server crash in debug/sanitizer builds when `std::length_error` is thrown during schema inference (e.g., from extreme `input_format_msgpack_number_of_columns` values or malformed input data).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1072`
<!-- ch-version-info:end -->