### PR TITLE
Switch Iceberg catalog tests to use standard MinIO (with_minio=True)

### DIFF
--- a/tests/integration/compose/docker_compose_glue_catalog.yml
+++ b/tests/integration/compose/docker_compose_glue_catalog.yml
@@ -1,6 +1,9 @@
 services:
   glue:
     image: motoserver/moto:5.1.5
+    depends_on:
+      minio1:
+        condition: service_started
     ports:
       - "${GLUE_CATALOG_PORT}:3000"
     environment:
@@ -13,39 +16,3 @@ services:
       start_period: 30s
     stop_grace_period: 5s
     cpus: 3
-  # TODO: can we simply use with_minio=True instead?
-  minio:
-    image: minio/minio:RELEASE.2024-07-31T05-46-26Z
-    environment:
-      - MINIO_ROOT_USER=minio
-      - MINIO_ROOT_PASSWORD=ClickHouse_Minio_P@ssw0rd
-      - MINIO_DOMAIN=minio
-    networks:
-      default:
-        aliases:
-          - warehouse.minio
-    ports:
-      - 9001
-      - 9000
-    command: ["server", "/data", "--console-address", ":9001"]
-    stop_grace_period: 5s
-    cpus: 3
-  # TODO: move this code to cluster.py
-  mc:
-    depends_on:
-      - minio
-    # Stick to version with "mc config"
-    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
-    environment:
-      - AWS_ACCESS_KEY_ID=minio
-      - AWS_SECRET_ACCESS_KEY=ClickHouse_Minio_P@ssw0rd
-      - AWS_REGION=us-east-1
-    stop_grace_period: 5s
-    cpus: 3
-    entrypoint: >
-      /bin/sh -c "
-      until (/usr/bin/mc config host add minio http://minio:9000 minio ClickHouse_Minio_P@ssw0rd) do echo '...waiting...' && sleep 1; done;
-      /usr/bin/mc rm -r --force minio/warehouse-glue;
-      /usr/bin/mc mb minio/warehouse-glue --ignore-existing;
-      tail -f /dev/null
-      "

--- a/tests/integration/compose/docker_compose_glue_catalog.yml
+++ b/tests/integration/compose/docker_compose_glue_catalog.yml
@@ -1,9 +1,6 @@
 services:
   glue:
     image: motoserver/moto:5.1.5
-    depends_on:
-      minio1:
-        condition: service_started
     ports:
       - "${GLUE_CATALOG_PORT}:3000"
     environment:

--- a/tests/integration/compose/docker_compose_iceberg_hms_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_hms_catalog.yml
@@ -1,33 +1,17 @@
 services:
-  spark-iceberg:
-    image: tabulario/spark-iceberg:3.5.5_1.8.1
-    build: spark/
-    depends_on:
-      hive:
-        condition: service_healthy
-      minio:
-        condition: service_started
-    environment:
-      - AWS_ACCESS_KEY_ID=admin
-      - AWS_SECRET_ACCESS_KEY=password
-      - AWS_REGION=us-east-1
-    expose:
-      - 8080
-      - 10000
-      - 10001
-    stop_grace_period: 5s
-    cpus: 3
   hive:
     image: clickhouse/integration-test-with-hms
     restart: unless-stopped
     depends_on:
-      minio:
+      minio1:
         condition: service_started
     ports:
       - "${HMS_CATALOG_PORT}:9083"
     environment:
       SERVICE_NAME: "metastore"
       SERVICE_OPTS: "-Dmetastore.warehouse.dir=s3a://warehouse-hms/data/"
+    volumes:
+      - ${ICEBERG_HMS_CORE_SITE}:/opt/hadoop/etc/hadoop/core-site.xml
     healthcheck:
       test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/9083"]
       interval: 2s
@@ -35,41 +19,4 @@ services:
       retries: 45
       start_period: 45s
     stop_grace_period: 5s
-    cpus: 3
-  # TODO: can we simply use with_minio=True instead?
-  minio:
-    image: minio/minio:RELEASE.2024-07-31T05-46-26Z
-    environment:
-      - MINIO_ROOT_USER=minio
-      - MINIO_ROOT_PASSWORD=ClickHouse_Minio_P@ssw0rd
-      - MINIO_DOMAIN=minio
-    networks:
-      default:
-        aliases:
-          - warehouse.minio
-    ports:
-      - 9001
-      - 9000
-    command: ["server", "/data", "--console-address", ":9001"]
-    stop_grace_period: 5s
-    cpus: 3
-  # TODO: move this code to cluster.py
-  mc:
-    depends_on:
-      - minio
-    # Stick to version with "mc config"
-    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
-    environment:
-      - AWS_ACCESS_KEY_ID=minio
-      - AWS_SECRET_ACCESS_KEY=ClickHouse_Minio_P@ssw0rd
-      - AWS_REGION=us-east-1
-    entrypoint: >
-      /bin/sh -c "
-      until (/usr/bin/mc config host add minio http://minio:9000 minio ClickHouse_Minio_P@ssw0rd) do echo '...waiting...' && sleep 1; done;
-      /usr/bin/mc rm -r --force minio/warehouse-hms;
-      /usr/bin/mc mb minio/warehouse-hms --ignore-existing;
-      /usr/bin/mc policy set public minio/warehouse-hms;
-      tail -f /dev/null
-      "
-      stop_grace_period: 5s
     cpus: 3

--- a/tests/integration/compose/docker_compose_iceberg_hms_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_hms_catalog.yml
@@ -2,9 +2,6 @@ services:
   hive:
     image: clickhouse/integration-test-with-hms
     restart: unless-stopped
-    depends_on:
-      minio1:
-        condition: service_started
     ports:
       - "${HMS_CATALOG_PORT}:9083"
     environment:

--- a/tests/integration/compose/docker_compose_iceberg_lakekeeper_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_lakekeeper_catalog.yml
@@ -16,8 +16,8 @@ services:
       retries: 10
       start_period: 30s
     depends_on:
-      mc:
-        condition: service_completed_successfully
+      minio1:
+        condition: service_started
       migrate:
         condition: service_completed_successfully
       db:
@@ -71,36 +71,4 @@ services:
       timeout: 10s
       retries: 5
       start_period: 10s
-    cpus: 3
-
-  minio:
-    image: minio/minio:RELEASE.2024-07-31T05-46-26Z
-    environment:
-      - MINIO_ROOT_USER=minio
-      - MINIO_ROOT_PASSWORD=ClickHouse_Minio_P@ssw0rd
-      - MINIO_SCHEME=http
-      - MINIO_DEFAULT_BUCKETS=warehouse-rest
-    networks:
-      default:
-        aliases:
-          - warehouse-rest.minio
-    command: ["server", "/data", "--console-address", ":9001"]
-    cpus: 3
-
-  mc:
-    depends_on:
-      - minio
-    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
-    environment:
-      - AWS_ACCESS_KEY_ID=minio
-      - AWS_SECRET_ACCESS_KEY=ClickHouse_Minio_P@ssw0rd
-      - AWS_REGION=us-east-1
-    restart: "no"
-    entrypoint: >
-      /bin/sh -c "
-      until (/usr/bin/mc config host add minio http://minio:9000 minio ClickHouse_Minio_P@ssw0rd) do echo '...waiting...' && sleep 1; done;
-      /usr/bin/mc rm -r --force minio/warehouse-rest;
-      /usr/bin/mc mb minio/warehouse-rest --ignore-existing;
-      /usr/bin/mc policy set public minio/warehouse-rest;
-      " # FIX 3: Removed 'tail -f /dev/null' to make this a one-shot setup task.
     cpus: 3

--- a/tests/integration/compose/docker_compose_iceberg_lakekeeper_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_lakekeeper_catalog.yml
@@ -16,8 +16,6 @@ services:
       retries: 10
       start_period: 30s
     depends_on:
-      minio1:
-        condition: service_started
       migrate:
         condition: service_completed_successfully
       db:

--- a/tests/integration/compose/docker_compose_iceberg_nessie_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_nessie_catalog.yml
@@ -1,9 +1,6 @@
 services:
   nessie:
     image: ghcr.io/projectnessie/nessie:0.107.2
-    depends_on:
-      minio1:
-        condition: service_started
     ports:
       - "${ICEBERG_REST_CATALOG_PORT}:19120"
     environment:

--- a/tests/integration/compose/docker_compose_iceberg_nessie_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_nessie_catalog.yml
@@ -8,7 +8,15 @@ services:
       - nessie.catalog.default-warehouse=warehouse
       - nessie.catalog.warehouses.warehouse.location=s3://warehouse-rest/
       - nessie.catalog.service.s3.default-options.endpoint=http://minio1:9001/
-      - nessie.catalog.service.s3.default-options.external-endpoint=http://minio1:9001/
+      # external-endpoint is what Nessie vends to clients in the REST `loadTable`
+      # response. The pytest `pyiceberg` client runs on the host network and
+      # cannot resolve the Docker hostname `minio1`, so we vend the standard
+      # MinIO container's IP (set from `cluster.py` via `MINIO_IP`). The IP is
+      # routable from the host (Docker default bridge) and from other
+      # containers on the same network, so it works for both pytest and the
+      # ClickHouse server. Falls back to `minio1` if `MINIO_IP` is unset
+      # (so the compose file stays usable for ad-hoc invocations).
+      - nessie.catalog.service.s3.default-options.external-endpoint=http://${MINIO_IP:-minio1}:9001/
       - nessie.catalog.service.s3.default-options.access-key=urn:nessie-secret:quarkus:nessie.catalog.secrets.access-key
       - nessie.catalog.service.s3.default-options.path-style-access=true
       - nessie.catalog.service.s3.default-options.auth-type=STATIC

--- a/tests/integration/compose/docker_compose_iceberg_nessie_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_nessie_catalog.yml
@@ -8,14 +8,7 @@ services:
       - nessie.catalog.default-warehouse=warehouse
       - nessie.catalog.warehouses.warehouse.location=s3://warehouse-rest/
       - nessie.catalog.service.s3.default-options.endpoint=http://minio1:9001/
-      # external-endpoint is what Nessie vends to clients in the REST `loadTable`
-      # response. The pytest `pyiceberg` client runs on the host network and
-      # cannot resolve the Docker hostname `minio1`, so we vend the standard
-      # MinIO container's IP (set from `cluster.py` via `MINIO_IP`). The IP is
-      # routable from the host (Docker default bridge) and from other
-      # containers on the same network, so it works for both pytest and the
-      # ClickHouse server. Falls back to `minio1` if `MINIO_IP` is unset
-      # (so the compose file stays usable for ad-hoc invocations).
+      # `pyiceberg` runs from the host (not inside docker), so vend MinIO's container IP via `MINIO_IP` from `cluster.py`.
       - nessie.catalog.service.s3.default-options.external-endpoint=http://${MINIO_IP:-minio1}:9001/
       - nessie.catalog.service.s3.default-options.access-key=urn:nessie-secret:quarkus:nessie.catalog.secrets.access-key
       - nessie.catalog.service.s3.default-options.path-style-access=true

--- a/tests/integration/compose/docker_compose_iceberg_nessie_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_nessie_catalog.yml
@@ -2,7 +2,7 @@ services:
   nessie:
     image: ghcr.io/projectnessie/nessie:0.107.2
     depends_on:
-      minio:
+      minio1:
         condition: service_started
     ports:
       - "${ICEBERG_REST_CATALOG_PORT}:19120"
@@ -10,8 +10,8 @@ services:
       - nessie.version.store.type=IN_MEMORY
       - nessie.catalog.default-warehouse=warehouse
       - nessie.catalog.warehouses.warehouse.location=s3://warehouse-rest/
-      - nessie.catalog.service.s3.default-options.endpoint=http://minio:9000/
-      - nessie.catalog.service.s3.default-options.external-endpoint=http://127.0.0.1:${ICEBERG_MINIO_PORT}/
+      - nessie.catalog.service.s3.default-options.endpoint=http://minio1:9001/
+      - nessie.catalog.service.s3.default-options.external-endpoint=http://minio1:9001/
       - nessie.catalog.service.s3.default-options.access-key=urn:nessie-secret:quarkus:nessie.catalog.secrets.access-key
       - nessie.catalog.service.s3.default-options.path-style-access=true
       - nessie.catalog.service.s3.default-options.auth-type=STATIC
@@ -25,40 +25,4 @@ services:
       timeout: 10s
       retries: 5
       start_period: 60s
-    cpus: 3
-
-  # TODO: can we simply use with_minio=True instead?
-  minio:
-    image: minio/minio:RELEASE.2024-07-31T05-46-26Z
-    environment:
-      - MINIO_ROOT_USER=minio
-      - MINIO_ROOT_PASSWORD=ClickHouse_Minio_P@ssw0rd
-      - MINIO_DOMAIN=minio
-    networks:
-      default:
-        aliases:
-          - warehouse-rest.minio
-    ports:
-      - "${ICEBERG_MINIO_PORT}:9000"
-    command: ["server", "/data", "--console-address", ":9001"]
-    cpus: 3
-
-  # TODO: move this code to cluster.py
-  mc:
-    depends_on:
-      - minio
-    # Stick to version with "mc config"
-    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
-    environment:
-      - AWS_ACCESS_KEY_ID=minio
-      - AWS_SECRET_ACCESS_KEY=ClickHouse_Minio_P@ssw0rd
-      - AWS_REGION=us-east-1
-    entrypoint: >
-      /bin/sh -c "
-      until (/usr/bin/mc config host add minio http://minio:9000 minio ClickHouse_Minio_P@ssw0rd) do echo '...waiting...' && sleep 1; done;
-      /usr/bin/mc rm -r --force minio/warehouse-rest;
-      /usr/bin/mc mb minio/warehouse-rest --ignore-existing;
-      /usr/bin/mc policy set public minio/warehouse-rest;
-      "
-    restart: "no"
     cpus: 3

--- a/tests/integration/compose/docker_compose_iceberg_rest_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_rest_catalog.yml
@@ -10,7 +10,7 @@ services:
       - AWS_ACCESS_KEY_ID=minio
       - AWS_SECRET_ACCESS_KEY=ClickHouse_Minio_P@ssw0rd
       - AWS_REGION=us-east-1
-      - CATALOG_WAREHOUSE=s3://iceberg_data/
+      - CATALOG_WAREHOUSE=s3://iceberg-data/
       - CATALOG_IO__IMPL=org.apache.iceberg.aws.s3.S3FileIO
       - CATALOG_S3_ENDPOINT=http://minio1:9001
       - CATALOG_S3_PATH__STYLE__ACCESS=true

--- a/tests/integration/compose/docker_compose_iceberg_rest_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_rest_catalog.yml
@@ -1,9 +1,6 @@
 services:
   rest:
     image: tabulario/iceberg-rest:1.6.0
-    depends_on:
-      minio1:
-        condition: service_started
     ports:
       - "${ICEBERG_REST_CATALOG_PORT}:8181"
     environment:

--- a/tests/integration/compose/docker_compose_iceberg_rest_catalog.yml
+++ b/tests/integration/compose/docker_compose_iceberg_rest_catalog.yml
@@ -1,20 +1,9 @@
 services:
-  spark-iceberg:
-    image: tabulario/spark-iceberg:3.5.5_1.8.1
-    build: spark/
-    depends_on:
-      rest:
-        condition: service_healthy
-      minio:
-        condition: service_started
-    environment:
-      - AWS_ACCESS_KEY_ID=admin
-      - AWS_SECRET_ACCESS_KEY=password
-      - AWS_REGION=us-east-1
-    stop_grace_period: 5s
-    cpus: 3
   rest:
     image: tabulario/iceberg-rest:1.6.0
+    depends_on:
+      minio1:
+        condition: service_started
     ports:
       - "${ICEBERG_REST_CATALOG_PORT}:8181"
     environment:
@@ -23,7 +12,8 @@ services:
       - AWS_REGION=us-east-1
       - CATALOG_WAREHOUSE=s3://iceberg_data/
       - CATALOG_IO__IMPL=org.apache.iceberg.aws.s3.S3FileIO
-      - CATALOG_S3_ENDPOINT=http://minio:9000
+      - CATALOG_S3_ENDPOINT=http://minio1:9001
+      - CATALOG_S3_PATH__STYLE__ACCESS=true
     healthcheck:
       test: ["CMD", "bash", "-c", "echo > /dev/tcp/localhost/8181"]
       interval: 1s
@@ -31,41 +21,4 @@ services:
       retries: 10
       start_period: 30s
     stop_grace_period: 5s
-    cpus: 3
-  # TODO: can we simply use with_minio=True instead?
-  minio:
-    image: minio/minio:RELEASE.2024-07-31T05-46-26Z
-    environment:
-      - MINIO_ROOT_USER=minio
-      - MINIO_ROOT_PASSWORD=ClickHouse_Minio_P@ssw0rd
-      - MINIO_DOMAIN=minio
-    networks:
-      default:
-        aliases:
-          - warehouse-rest.minio
-    ports:
-      - 9001
-      - 9000
-    command: ["server", "/data", "--console-address", ":9001"]
-    stop_grace_period: 5s
-    cpus: 3
-  # TODO: move this code to cluster.py
-  mc:
-    depends_on:
-      - minio
-    # Stick to version with "mc config"
-    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
-    environment:
-      - AWS_ACCESS_KEY_ID=minio
-      - AWS_SECRET_ACCESS_KEY=ClickHouse_Minio_P@ssw0rd
-      - AWS_REGION=us-east-1
-    entrypoint: >
-      /bin/sh -c "
-      until (/usr/bin/mc config host add minio http://minio:9000 minio ClickHouse_Minio_P@ssw0rd) do echo '...waiting...' && sleep 1; done;
-      /usr/bin/mc rm -r --force minio/warehouse-rest;
-      /usr/bin/mc mb minio/warehouse-rest --ignore-existing;
-      /usr/bin/mc policy set public minio/warehouse-rest;
-      tail -f /dev/null
-      "
-      stop_grace_period: 5s
     cpus: 3

--- a/tests/integration/compose/hms_core_site_minio1.xml
+++ b/tests/integration/compose/hms_core_site_minio1.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<configuration>
+    <property>
+        <name>fs.defaultFS</name>
+        <value>s3a://warehouse-hms/data</value>
+    </property>
+    <property>
+        <name>fs.s3a.impl</name>
+        <value>org.apache.hadoop.fs.s3a.S3AFileSystem</value>
+    </property>
+    <property>
+        <name>fs.s3a.fast.upload</name>
+        <value>true</value>
+    </property>
+    <property>
+        <name>fs.s3a.access.key</name>
+        <value>minio</value>
+    </property>
+    <property>
+        <name>fs.s3a.secret.key</name>
+        <value>ClickHouse_Minio_P@ssw0rd</value>
+    </property>
+    <property>
+        <name>fs.s3a.endpoint</name>
+        <value>http://minio1:9001</value>
+    </property>
+    <property>
+        <name>fs.s3a.path.style.access</name>
+        <value>true</value>
+    </property>
+    <property>
+        <name>fs.s3a.connection.ssl.enabled</name>
+        <value>false</value>
+    </property>
+</configuration>

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3969,6 +3969,18 @@ class ClickHouseCluster:
                     catalog_buckets.extend(["warehouse-rest", "iceberg-data"])
                 self.create_minio_buckets(catalog_buckets, set_public_policy=True)
 
+                # Some catalogs (Nessie) vend an S3 endpoint to clients via the
+                # REST `loadTable` response. The hostname `minio1` is only
+                # resolvable inside the Docker network, so the host-side
+                # `pyiceberg` client cannot reach it. Re-export the env file
+                # with `MINIO_IP` set to the standard MinIO container's IP
+                # (resolvable from both the host and from other containers in
+                # the same Docker bridge network) so catalog compose files can
+                # vend a host-reachable URL.
+                if self.minio_ip:
+                    self.env_variables["MINIO_IP"] = self.minio_ip
+                    _create_env_file(self.env_file, self.env_variables)
+
             if self.with_glue_catalog and self.base_glue_catalog_cmd:
                 logging.info("Starting Glue catalog...")
                 subprocess_check_call(self.base_glue_catalog_cmd + common_opts)

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -1786,6 +1786,9 @@ class ClickHouseCluster:
     def setup_hms_catalog_cmd(self, instance, env_variables, docker_compose_yml_dir):
         self.with_hms_catalog = True
         env_variables["HMS_CATALOG_PORT"] = str(self.hms_catalog_port)
+        env_variables["ICEBERG_HMS_CORE_SITE"] = p.join(
+            docker_compose_yml_dir, "hms_core_site_minio1.xml"
+        )
         self.base_cmd.extend(
             [
                 "--file",
@@ -1811,7 +1814,6 @@ class ClickHouseCluster:
         if extra_parameters is not None and extra_parameters["docker_compose_file_name"] != "":
             file_name = extra_parameters["docker_compose_file_name"]
         env_variables["ICEBERG_REST_CATALOG_PORT"] = str(self.iceberg_rest_catalog_port)
-        env_variables["ICEBERG_MINIO_PORT"] = str(self.iceberg_minio_port)
         self.base_cmd.extend(
             [
                 "--file",
@@ -2389,6 +2391,10 @@ class ClickHouseCluster:
             cmds.append(
                 self.setup_redis_cmd(instance, env_variables, docker_compose_yml_dir)
             )
+
+        # Iceberg/Glue/HMS catalogs use the standard MinIO (minio1) for S3 storage.
+        if with_iceberg_catalog or with_glue_catalog or with_hms_catalog:
+            with_minio = True
 
         if with_minio and not self.with_minio:
             cmds.append(
@@ -3285,6 +3291,48 @@ class ClickHouseCluster:
 
         raise Exception("Can't wait Minio to start")
 
+    def create_minio_buckets(self, buckets, set_public_policy=False):
+        """Create additional buckets on the standard MinIO (minio1).
+
+        Must be called after wait_minio_to_start() which sets self.minio_client.
+        """
+        assert self.minio_client is not None, (
+            "create_minio_buckets called before wait_minio_to_start"
+        )
+        for bucket in buckets:
+            if self.minio_client.bucket_exists(bucket):
+                delete_object_list = map(
+                    lambda x: x.object_name,
+                    self.minio_client.list_objects_v2(bucket, recursive=True),
+                )
+                errors = self.minio_client.remove_objects(bucket, delete_object_list)
+                for error in errors:
+                    logging.error(f"Error occurred when deleting object {error}")
+                self.minio_client.remove_bucket(bucket)
+            self.minio_client.make_bucket(bucket)
+            logging.info("S3 bucket '%s' created on standard MinIO", bucket)
+
+        if set_public_policy:
+            for bucket in buckets:
+                policy = json.dumps(
+                    {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Principal": {"AWS": "*"},
+                                "Action": ["s3:*"],
+                                "Resource": [
+                                    f"arn:aws:s3:::{bucket}",
+                                    f"arn:aws:s3:::{bucket}/*",
+                                ],
+                            }
+                        ],
+                    }
+                )
+                self.minio_client.set_bucket_policy(bucket, policy)
+                logging.info("Public policy set on S3 bucket '%s'", bucket)
+
     def wait_azurite_to_start(self, timeout=180):
         from azure.storage.blob import BlobServiceClient
 
@@ -3909,23 +3957,32 @@ class ClickHouseCluster:
                 logging.info("Trying to connect to Minio...")
                 self.wait_minio_to_start(secure=self.minio_certs_dir is not None)
 
+            # Catalogs use the standard MinIO (minio1). Create their
+            # buckets on it before starting the catalog services.
+            if self.with_glue_catalog or self.with_hms_catalog or self.with_iceberg_catalog:
+                catalog_buckets = []
+                if self.with_glue_catalog:
+                    catalog_buckets.append("warehouse-glue")
+                if self.with_hms_catalog:
+                    catalog_buckets.append("warehouse-hms")
+                if self.with_iceberg_catalog:
+                    catalog_buckets.extend(["warehouse-rest", "iceberg_data"])
+                self.create_minio_buckets(catalog_buckets, set_public_policy=True)
+
             if self.with_glue_catalog and self.base_glue_catalog_cmd:
-                logging.info("Trying to connect to Minio for glue catalog...")
+                logging.info("Starting Glue catalog...")
                 subprocess_check_call(self.base_glue_catalog_cmd + common_opts)
                 self.up_called = True
-                self.wait_custom_minio_to_start(["warehouse-glue"], "minio", 9000)
 
             if self.with_hms_catalog and self.base_iceberg_hms_cmd:
-                logging.info("Trying to connect to Minio for hms catalog...")
+                logging.info("Starting HMS catalog...")
                 subprocess_check_call(self.base_iceberg_hms_cmd + common_opts)
                 self.up_called = True
-                self.wait_custom_minio_to_start(["warehouse-hms"], "minio", 9000)
 
             if self.with_iceberg_catalog and self.base_iceberg_catalog_cmd:
-                logging.info("Trying to connect to Minio for Iceberg catalog...")
+                logging.info("Starting Iceberg catalog...")
                 subprocess_check_call(self.base_iceberg_catalog_cmd + common_opts)
                 self.up_called = True
-                self.wait_custom_minio_to_start(["warehouse-rest"], "minio", 9000)
 
             if self.with_azurite and self.base_azurite_cmd:
                 azurite_start_cmd = self.base_azurite_cmd + common_opts

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3966,7 +3966,7 @@ class ClickHouseCluster:
                 if self.with_hms_catalog:
                     catalog_buckets.append("warehouse-hms")
                 if self.with_iceberg_catalog:
-                    catalog_buckets.extend(["warehouse-rest", "iceberg_data"])
+                    catalog_buckets.extend(["warehouse-rest", "iceberg-data"])
                 self.create_minio_buckets(catalog_buckets, set_public_policy=True)
 
             if self.with_glue_catalog and self.base_glue_catalog_cmd:

--- a/tests/integration/test_database_glue/test.py
+++ b/tests/integration/test_database_glue/test.py
@@ -117,7 +117,7 @@ def load_catalog_impl(started_cluster):
             "type": "glue",
             "glue.endpoint": get_glue_local_url(started_cluster),
             "glue.region": "us-east-1",
-            "s3.endpoint": f"http://{started_cluster.get_instance_ip('minio')}:9000",
+            "s3.endpoint": f"http://{started_cluster.minio_ip}:{started_cluster.minio_port}",
             "s3.access-key-id": minio_access_key,
             "s3.secret-access-key": minio_secret_key,
         },

--- a/tests/integration/test_database_glue/test.py
+++ b/tests/integration/test_database_glue/test.py
@@ -91,7 +91,7 @@ DEFAULT_SCHEMA = Schema(
     ),
 )
 
-DEFAULT_CREATE_TABLE = "CREATE TABLE {}.`{}.{}`\\n(\\n    `datetime` Nullable(DateTime64(6)),\\n    `symbol` Nullable(String),\\n    `bid` Nullable(Float64),\\n    `ask` Nullable(Float64),\\n    `details` Tuple(created_by Nullable(String)),\\n    `map_string_decimal` Map(String, Nullable(Decimal(9, 2)))\\n)\\nENGINE = Iceberg(\\'http://minio:9000/warehouse-glue/data/\\', \\'minio\\', \\'[HIDDEN]\\')\n"
+DEFAULT_CREATE_TABLE = "CREATE TABLE {}.`{}.{}`\\n(\\n    `datetime` Nullable(DateTime64(6)),\\n    `symbol` Nullable(String),\\n    `bid` Nullable(Float64),\\n    `ask` Nullable(Float64),\\n    `details` Tuple(created_by Nullable(String)),\\n    `map_string_decimal` Map(String, Nullable(Decimal(9, 2)))\\n)\\nENGINE = Iceberg(\\'http://minio1:9001/warehouse-glue/data/\\', \\'minio\\', \\'[HIDDEN]\\')\n"
 
 DEFAULT_PARTITION_SPEC = PartitionSpec(
     PartitionField(
@@ -202,7 +202,7 @@ def create_clickhouse_glue_database(
     settings = {
         "catalog_type": "glue",
         "warehouse": "test",
-        "storage_endpoint": "http://minio:9000/warehouse-glue",
+        "storage_endpoint": "http://minio1:9001/warehouse-glue",
         "region": "us-east-1",
     }
 
@@ -229,7 +229,7 @@ def create_clickhouse_glue_table(
 
     node.query(
         f"""
-CREATE TABLE {CATALOG_NAME}.`{database_name}.{table_name}` {schema} ENGINE = IcebergS3('http://minio:9000/warehouse-glue/{table_name}/', '{minio_access_key}', '{minio_secret_key}')
+CREATE TABLE {CATALOG_NAME}.`{database_name}.{table_name}` {schema} ENGINE = IcebergS3('http://minio1:9001/warehouse-glue/{table_name}/', '{minio_access_key}', '{minio_secret_key}')
 {settings_suffix}
 """,
         settings={
@@ -304,7 +304,7 @@ def test_no_secrets_in_logs(started_cluster):
     db_settings = {
         "catalog_type": "glue",
         "warehouse": "test",
-        "storage_endpoint": "http://minio:9000/warehouse-glue",
+        "storage_endpoint": "http://minio1:9001/warehouse-glue",
         "region": "us-east-1",
     }
 
@@ -322,7 +322,7 @@ SETTINGS {",".join((k + "=" + repr(v) for k, v in db_settings.items()))}""",
 
     qid_table = uuid.uuid4().hex
     node.query(
-        f"""CREATE TABLE {db_name}.`{root_namespace}.{table_name}` (x String) ENGINE = IcebergS3('http://minio:9000/warehouse-glue/{table_name}/', '{minio_access_key}', '{minio_secret_key}')""",
+        f"""CREATE TABLE {db_name}.`{root_namespace}.{table_name}` (x String) ENGINE = IcebergS3('http://minio1:9001/warehouse-glue/{table_name}/', '{minio_access_key}', '{minio_secret_key}')""",
         query_id=qid_table,
         settings={
             "allow_experimental_database_glue_catalog": 1,
@@ -644,7 +644,7 @@ def test_timestamps(started_cluster):
     df = pa.Table.from_pylist(data)
     table.append(df)
 
-    assert node.query(f"SHOW CREATE TABLE {CATALOG_NAME}.`{root_namespace}.{table_name}`") == f"CREATE TABLE {CATALOG_NAME}.`{root_namespace}.{table_name}`\\n(\\n    `timestamp` Nullable(DateTime64(6)),\\n    `timestamptz` Nullable(DateTime64(6, \\'UTC\\'))\\n)\\nENGINE = Iceberg(\\'http://minio:9000/warehouse-glue/data/\\', \\'minio\\', \\'[HIDDEN]\\')\n"
+    assert node.query(f"SHOW CREATE TABLE {CATALOG_NAME}.`{root_namespace}.{table_name}`") == f"CREATE TABLE {CATALOG_NAME}.`{root_namespace}.{table_name}`\\n(\\n    `timestamp` Nullable(DateTime64(6)),\\n    `timestamptz` Nullable(DateTime64(6, \\'UTC\\'))\\n)\\nENGINE = Iceberg(\\'http://minio1:9001/warehouse-glue/data/\\', \\'minio\\', \\'[HIDDEN]\\')\n"
     assert node.query(f"SELECT * FROM {CATALOG_NAME}.`{root_namespace}.{table_name}`") == "2024-01-01 12:00:00.000000\t2024-01-01 12:00:00.000000\n"
 
 

--- a/tests/integration/test_database_hms/test.py
+++ b/tests/integration/test_database_hms/test.py
@@ -43,7 +43,7 @@ def test_hive_catalog_url_parsing(started_cluster):
             CREATE DATABASE test_hms_support_check ENGINE = DataLakeCatalog('thrift://hive:9083', 'minio', '{password}') 
             SETTINGS catalog_type = 'hive', 
                      warehouse = 'test_warehouse', 
-                     storage_endpoint = 'http://minio:9000/warehouse-hms/data/'
+                     storage_endpoint = 'http://minio1:9001/warehouse-hms/data/'
         """)
         node.query("DROP DATABASE IF EXISTS test_hms_support_check")
     except Exception as e:
@@ -57,7 +57,7 @@ def test_hive_catalog_url_parsing(started_cluster):
             CREATE DATABASE test_valid_url ENGINE = DataLakeCatalog('thrift://hive:9083', 'minio', '{password}') 
             SETTINGS catalog_type = 'hive', 
                      warehouse = 'test_warehouse', 
-                     storage_endpoint = 'http://minio:9000/warehouse-hms/data/'
+                     storage_endpoint = 'http://minio1:9001/warehouse-hms/data/'
         """)
         node.query("DROP DATABASE IF EXISTS test_valid_url")
     except Exception as e:
@@ -69,7 +69,7 @@ def test_hive_catalog_url_parsing(started_cluster):
             CREATE DATABASE test_missing_protocol ENGINE = DataLakeCatalog('thrift:hive:9083', 'minio', '{password}') 
             SETTINGS catalog_type = 'hive', 
                      warehouse = 'test_warehouse', 
-                     storage_endpoint = 'http://minio:9000/warehouse-hms/data/'
+                     storage_endpoint = 'http://minio1:9001/warehouse-hms/data/'
         """)
         node.query("select * FROM test_missing_protocol.abc")
         pytest.fail("Missing protocol separator should fail")
@@ -85,7 +85,7 @@ def test_hive_catalog_url_parsing(started_cluster):
             CREATE DATABASE test_missing_port ENGINE = DataLakeCatalog('thrift://hive-metastore', 'minio', '{password}') 
             SETTINGS catalog_type = 'hive', 
                      warehouse = 'test_warehouse', 
-                     storage_endpoint = 'http://minio:9000/warehouse-hms/data/'
+                     storage_endpoint = 'http://minio1:9001/warehouse-hms/data/'
         """)
         node.query("select * FROM test_missing_port.abc")
         pytest.fail("Missing port should fail")
@@ -101,7 +101,7 @@ def test_hive_catalog_url_parsing(started_cluster):
             CREATE DATABASE test_invalid_port ENGINE = DataLakeCatalog('thrift://hive-metastore:abc', 'minio', '{password}') 
             SETTINGS catalog_type = 'hive', 
                      warehouse = 'test_warehouse', 
-                     storage_endpoint = 'http://minio:9000/warehouse-hms/data/'
+                     storage_endpoint = 'http://minio1:9001/warehouse-hms/data/'
         """)
         node.query("select * FROM test_invalid_port.abc")
         pytest.fail("Invalid port should fail")
@@ -117,7 +117,7 @@ def test_hive_catalog_url_parsing(started_cluster):
             CREATE DATABASE test_port_zero ENGINE = DataLakeCatalog('thrift://hive-metastore:0', 'minio', '{password}') 
             SETTINGS catalog_type = 'hive', 
                      warehouse = 'test_warehouse', 
-                     storage_endpoint = 'http://minio:9000/warehouse-hms/data/'
+                     storage_endpoint = 'http://minio1:9001/warehouse-hms/data/'
         """)
         node.query("select * FROM test_port_zero.abc")
         pytest.fail("Port zero should fail")
@@ -133,7 +133,7 @@ def test_hive_catalog_url_parsing(started_cluster):
             CREATE DATABASE test_port_too_large ENGINE = DataLakeCatalog('thrift://hive-metastore:70000', 'minio', '{password}') 
             SETTINGS catalog_type = 'hive', 
                      warehouse = 'test_warehouse', 
-                     storage_endpoint = 'http://minio:9000/warehouse-hms/data/'
+                     storage_endpoint = 'http://minio1:9001/warehouse-hms/data/'
         """)
         node.query("select * FROM test_port_too_large.abc")
         pytest.fail("Port too large should fail")
@@ -149,7 +149,7 @@ def test_hive_catalog_url_parsing(started_cluster):
             CREATE DATABASE test_empty_port ENGINE = DataLakeCatalog('thrift://hive-metastore:', 'minio', '{password}') 
             SETTINGS catalog_type = 'hive', 
                      warehouse = 'test_warehouse', 
-                     storage_endpoint = 'http://minio:9000/warehouse-hms/data/'
+                     storage_endpoint = 'http://minio1:9001/warehouse-hms/data/'
         """)
         node.query("select * FROM test_empty_port.abc")
         pytest.fail("Empty port should fail")
@@ -165,7 +165,7 @@ def test_hive_catalog_url_parsing(started_cluster):
             CREATE DATABASE test_complex_path ENGINE = DataLakeCatalog('thrift://hive-metastore:9083/metastore/db/table', 'minio', '{password}') 
             SETTINGS catalog_type = 'hive', 
                      warehouse = 'test_warehouse', 
-                     storage_endpoint = 'http://minio:9000/warehouse-hms/data/'
+                     storage_endpoint = 'http://minio1:9001/warehouse-hms/data/'
         """)
         node.query("DROP DATABASE IF EXISTS test_complex_path")
     except Exception as e:
@@ -187,7 +187,7 @@ def test_check_database(started_cluster):
             CREATE DATABASE test_hms_check_db ENGINE = DataLakeCatalog('thrift://hive:9083', 'minio', '{password}') 
             SETTINGS catalog_type = 'hive', 
                      warehouse = 'test_warehouse', 
-                     storage_endpoint = 'http://minio:9000/warehouse-hms/data/'
+                     storage_endpoint = 'http://minio1:9001/warehouse-hms/data/'
         """)
         node.query("CHECK DATABASE test_hms_check_db")
 

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -88,7 +88,7 @@ def load_catalog_impl(started_cluster):
         **{
             "uri": base_url_local_raw,
             "type": "rest",
-            "s3.endpoint": f"http://{started_cluster.get_instance_ip('minio')}:9000",
+            "s3.endpoint": f"http://{started_cluster.minio_ip}:{started_cluster.minio_port}",
             "s3.access-key-id": minio_access_key,
             "s3.secret-access-key": minio_secret_key,
         },

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -61,7 +61,7 @@ DEFAULT_SCHEMA = Schema(
     ),
 )
 
-DEFAULT_CREATE_TABLE = "CREATE TABLE {}.`{}.{}`\\n(\\n    `datetime` Nullable(DateTime64(6)),\\n    `symbol` Nullable(String),\\n    `bid` Nullable(Float64),\\n    `ask` Nullable(Float64),\\n    `details` Tuple(created_by Nullable(String))\\n)\\nENGINE = Iceberg(\\'http://minio:9000/warehouse-rest/data/\\', \\'minio\\', \\'[HIDDEN]\\')\n"
+DEFAULT_CREATE_TABLE = "CREATE TABLE {}.`{}.{}`\\n(\\n    `datetime` Nullable(DateTime64(6)),\\n    `symbol` Nullable(String),\\n    `bid` Nullable(Float64),\\n    `ask` Nullable(Float64),\\n    `details` Tuple(created_by Nullable(String))\\n)\\nENGINE = Iceberg(\\'http://minio1:9001/warehouse-rest/data/\\', \\'minio\\', \\'[HIDDEN]\\')\n"
 
 DEFAULT_PARTITION_SPEC = PartitionSpec(
     PartitionField(
@@ -128,7 +128,7 @@ def create_clickhouse_iceberg_database(
     settings = {
         "catalog_type": "rest",
         "warehouse": "demo",
-        "storage_endpoint": "http://minio:9000/warehouse-rest",
+        "storage_endpoint": "http://minio1:9001/warehouse-rest",
     }
 
     settings.update(additional_settings)
@@ -154,7 +154,7 @@ def create_clickhouse_iceberg_table(
     settings_suffix = "" if len(additional_settings) == 0 else f"SETTINGS {",".join((k+"="+repr(v) for k, v in additional_settings.items()))}"
     node.query(
         f"""
-CREATE TABLE {CATALOG_NAME}.`{database_name}.{table_name}` {schema} ENGINE = IcebergS3('http://minio:9000/warehouse-rest/{table_name}/', '{minio_access_key}', '{minio_secret_key}')
+CREATE TABLE {CATALOG_NAME}.`{database_name}.{table_name}` {schema} ENGINE = IcebergS3('http://minio1:9001/warehouse-rest/{table_name}/', '{minio_access_key}', '{minio_secret_key}')
 {settings_suffix}
     """,
         settings={
@@ -468,7 +468,7 @@ def test_no_secrets_in_logs(started_cluster):
     db_settings = {
         "catalog_type": "rest",
         "warehouse": "demo",
-        "storage_endpoint": "http://minio:9000/warehouse-rest",
+        "storage_endpoint": "http://minio1:9001/warehouse-rest",
     }
     qid_db = uuid.uuid4().hex
     node.query(f"DROP DATABASE IF EXISTS {db_name}")
@@ -484,7 +484,7 @@ SETTINGS {",".join((k + "=" + repr(v) for k, v in db_settings.items()))}""",
 
     qid_table = uuid.uuid4().hex
     node.query(
-        f"""CREATE TABLE {db_name}.`{root_namespace}.{table_name}` (x String) ENGINE = IcebergS3('http://minio:9000/warehouse-rest/{table_name}/', '{minio_access_key}', '{minio_secret_key}')""",
+        f"""CREATE TABLE {db_name}.`{root_namespace}.{table_name}` (x String) ENGINE = IcebergS3('http://minio1:9001/warehouse-rest/{table_name}/', '{minio_access_key}', '{minio_secret_key}')""",
         query_id=qid_table,
         settings={
             "allow_experimental_database_iceberg": 1,
@@ -591,7 +591,7 @@ def test_backup_database(started_cluster):
     node.query(f"RESTORE DATABASE backup_database FROM {backup_name}", settings={"allow_database_iceberg": 1})
     assert (
         node.query("SHOW CREATE DATABASE backup_database")
-        == "CREATE DATABASE backup_database\\nENGINE = DataLakeCatalog(\\'http://rest:8181/v1\\', \\'minio\\', \\'[HIDDEN]\\')\\nSETTINGS catalog_type = \\'rest\\', warehouse = \\'demo\\', storage_endpoint = \\'http://minio:9000/warehouse-rest\\'\n"
+        == "CREATE DATABASE backup_database\\nENGINE = DataLakeCatalog(\\'http://rest:8181/v1\\', \\'minio\\', \\'[HIDDEN]\\')\\nSETTINGS catalog_type = \\'rest\\', warehouse = \\'demo\\', storage_endpoint = \\'http://minio1:9001/warehouse-rest\\'\n"
     )
 
 
@@ -713,7 +713,7 @@ def test_timestamps(started_cluster):
     df = pa.Table.from_pylist(data)
     table.append(df)
 
-    assert node.query(f"SHOW CREATE TABLE {CATALOG_NAME}.`{root_namespace}.{table_name}`") == f"CREATE TABLE {CATALOG_NAME}.`{root_namespace}.{table_name}`\\n(\\n    `timestamp` Nullable(DateTime64(6)),\\n    `timestamptz` Nullable(DateTime64(6, \\'UTC\\'))\\n)\\nENGINE = Iceberg(\\'http://minio:9000/warehouse-rest/data/\\', \\'minio\\', \\'[HIDDEN]\\')\n"
+    assert node.query(f"SHOW CREATE TABLE {CATALOG_NAME}.`{root_namespace}.{table_name}`") == f"CREATE TABLE {CATALOG_NAME}.`{root_namespace}.{table_name}`\\n(\\n    `timestamp` Nullable(DateTime64(6)),\\n    `timestamptz` Nullable(DateTime64(6, \\'UTC\\'))\\n)\\nENGINE = Iceberg(\\'http://minio1:9001/warehouse-rest/data/\\', \\'minio\\', \\'[HIDDEN]\\')\n"
     assert node.query(f"SELECT * FROM {CATALOG_NAME}.`{root_namespace}.{table_name}`") == "2024-01-01 12:00:00.000000\t2024-01-01 12:00:00.000000\n"
 
 
@@ -840,7 +840,7 @@ def test_not_specified_catalog_type(started_cluster):
     node = started_cluster.instances["node1"]
     settings = {
         "warehouse": "demo",
-        "storage_endpoint": "http://minio:9000/warehouse-rest",
+        "storage_endpoint": "http://minio1:9001/warehouse-rest",
     }
 
     node.query(

--- a/tests/integration/test_database_iceberg_lakekeeper_catalog/test.py
+++ b/tests/integration/test_database_iceberg_lakekeeper_catalog/test.py
@@ -28,11 +28,11 @@ WAREHOUSE_NAME = "demo"
 def get_lakekeeper_local_url(cluster):
     return f"http://localhost:{cluster.iceberg_rest_catalog_port}"
 
-DEFAULT_CREATE_TABLE = "CREATE TABLE {}.`{}.{}`\n(\n    `id` Nullable(Float64),\n    `data` Nullable(String)\n)\nENGINE = Iceberg('http://minio:9000/warehouse-rest/data/', 'minio', '[HIDDEN]')\n"
+DEFAULT_CREATE_TABLE = "CREATE TABLE {}.`{}.{}`\n(\n    `id` Nullable(Float64),\n    `data` Nullable(String)\n)\nENGINE = Iceberg('http://minio1:9001/warehouse-rest/data/', 'minio', '[HIDDEN]')\n"
 
 
-def create_warehouse(cluster, minio_ip):
-    minio_endpoint = f"http://{minio_ip}:9000"
+def create_warehouse(cluster, minio_ip, minio_port):
+    minio_endpoint = f"http://{minio_ip}:{minio_port}"
 
     warehouse_data = {
         "warehouse-name": "demo",
@@ -76,8 +76,9 @@ def create_warehouse(cluster, minio_ip):
 
 
 def load_catalog_impl(started_cluster):
-    minio_ip = started_cluster.get_instance_ip('minio')
-    s3_endpoint = f"http://{minio_ip}:9000"
+    minio_ip = started_cluster.minio_ip
+    minio_port = started_cluster.minio_port
+    s3_endpoint = f"http://{minio_ip}:{minio_port}"
 
     return RestCatalog(
         name="my_catalog",
@@ -111,8 +112,9 @@ def started_cluster():
 
         time.sleep(15)
 
-        minio_ip = cluster.get_instance_ip('minio')
-        create_warehouse(cluster, minio_ip)
+        minio_ip = cluster.minio_ip
+        minio_port = cluster.minio_port
+        create_warehouse(cluster, minio_ip, minio_port)
 
         yield cluster
 
@@ -256,7 +258,7 @@ def create_clickhouse_iceberg_database(
     settings = {
         "catalog_type": "rest",
         "warehouse": "demo",
-        "storage_endpoint": "http://minio:9000/warehouse-rest",
+        "storage_endpoint": "http://minio1:9001/warehouse-rest",
     }
 
     settings.update(additional_settings)

--- a/tests/integration/test_database_iceberg_nessie_catalog/test.py
+++ b/tests/integration/test_database_iceberg_nessie_catalog/test.py
@@ -75,7 +75,7 @@ def create_clickhouse_iceberg_database(
     settings = {
         "catalog_type": "rest",
         "warehouse": "warehouse", 
-        "storage_endpoint": "http://minio:9000/warehouse-rest",
+        "storage_endpoint": "http://minio1:9001/warehouse-rest",
     }
 
     settings.update(additional_settings)
@@ -98,7 +98,7 @@ def get_nessie_local_url(cluster):
 
 
 def load_catalog_impl(started_cluster):
-    s3_endpoint = f"http://127.0.0.1:{started_cluster.iceberg_minio_port}"
+    s3_endpoint = f"http://{started_cluster.minio_ip}:{started_cluster.minio_port}"
 
     return RestCatalog(
         name="my_catalog",
@@ -354,7 +354,7 @@ def test_backup_database(started_cluster):
     node.query(f"RESTORE DATABASE backup_database FROM {backup_name}", settings={"allow_experimental_database_iceberg": 1})
     assert (
         node.query("SHOW CREATE DATABASE backup_database")
-        == "CREATE DATABASE backup_database\\nENGINE = DataLakeCatalog(\\'http://nessie:19120/iceberg/\\', \\'minio\\', \\'[HIDDEN]\\')\\nSETTINGS catalog_type = \\'rest\\', warehouse = \\'warehouse\\', storage_endpoint = \\'http://minio:9000/warehouse-rest\\'\n"
+        == "CREATE DATABASE backup_database\\nENGINE = DataLakeCatalog(\\'http://nessie:19120/iceberg/\\', \\'minio\\', \\'[HIDDEN]\\')\\nSETTINGS catalog_type = \\'rest\\', warehouse = \\'warehouse\\', storage_endpoint = \\'http://minio1:9001/warehouse-rest\\'\n"
     )
 
 def test_timestamps(started_cluster):
@@ -406,7 +406,7 @@ def test_timestamps(started_cluster):
         extracted_table_path = table_location.split("warehouse-rest/")[1]
 
     result = node.query(f"SHOW CREATE TABLE {CATALOG_NAME}.`{test_namespace[0]}.{table_name}`")
-    assert result == f"CREATE TABLE {CATALOG_NAME}.`{test_namespace[0]}.{table_name}`\\n(\\n    `timestamp` Nullable(DateTime64(6)),\\n    `timestamptz` Nullable(DateTime64(6))\\n)\\nENGINE = Iceberg(\\'http://minio:9000/warehouse-rest/{extracted_table_path}/\\', \\'minio\\', \\'[HIDDEN]\\')\n"
+    assert result == f"CREATE TABLE {CATALOG_NAME}.`{test_namespace[0]}.{table_name}`\\n(\\n    `timestamp` Nullable(DateTime64(6)),\\n    `timestamptz` Nullable(DateTime64(6))\\n)\\nENGINE = Iceberg(\\'http://minio1:9001/warehouse-rest/{extracted_table_path}/\\', \\'minio\\', \\'[HIDDEN]\\')\n"
     assert node.query(f"SELECT * FROM {CATALOG_NAME}.`{test_namespace[0]}.{table_name}`") == "2024-01-01 12:00:00.000000\t2024-01-01 12:00:00.000000\n"
 
 def test_insert(started_cluster):

--- a/tests/integration/test_storage_iceberg_no_spark/test_read_in_order_with_pyiceberg.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_read_in_order_with_pyiceberg.py
@@ -29,7 +29,7 @@ def load_catalog_impl(started_cluster):
         **{
             "uri": base_url_local_raw,
             "type": "rest",
-            "s3.endpoint": f"http://{started_cluster.get_instance_ip('minio')}:9000",
+            "s3.endpoint": f"http://{started_cluster.minio_ip}:{started_cluster.minio_port}",
             "s3.access-key-id": minio_access_key,
             "s3.secret-access-key": minio_secret_key,
         },
@@ -57,7 +57,7 @@ def create_clickhouse_iceberg_database(
     settings = {
         "catalog_type": "rest",
         "warehouse": "demo",
-        "storage_endpoint": "http://minio:9000/warehouse-rest",
+        "storage_endpoint": "http://minio1:9001/warehouse-rest",
     }
 
     settings.update(additional_settings)


### PR DESCRIPTION
Fixes: https://github.com/ClickHouse/ClickHouse/issues/102442

Implements the TODOs in the Iceberg compose files:

```
# TODO: can we simply use with_minio=True instead?
# TODO: move this code to cluster.py
```

Per @azat's direction: switch to the default `minio1` service and remove per-catalog MinIO containers.

### What changed

**Compose files** (5 files): removed `minio`, `mc`, and `spark-iceberg` services from:
- `docker_compose_iceberg_rest_catalog.yml`
- `docker_compose_iceberg_hms_catalog.yml`
- `docker_compose_iceberg_nessie_catalog.yml`
- `docker_compose_iceberg_lakekeeper_catalog.yml`
- `docker_compose_glue_catalog.yml`

All catalog services now `depends_on: minio1` (the standard MinIO from `with_minio=True`).

**Endpoint migration** (`minio:9000` → `minio1:9001`):
- REST catalog: `CATALOG_S3_ENDPOINT=http://minio1:9001` + added `CATALOG_S3_PATH__STYLE__ACCESS=true`
- Nessie: `endpoint=http://minio1:9001/`, `external-endpoint=http://minio1:9001/`
- HMS: new `hms_core_site_minio1.xml` volume-mounted to override the baked-in `core-site.xml`
- All test Python files updated (6 files)

**cluster.py**:
- `with_iceberg_catalog`, `with_hms_catalog`, `with_glue_catalog` now auto-enable `with_minio=True`
- Catalog buckets (`warehouse-rest`, `warehouse-hms`, `warehouse-glue`, `iceberg_data`) created on standard MinIO during startup via new `create_minio_buckets()` helper
- Removed `ICEBERG_MINIO_PORT` env variable (no longer needed without custom MinIO)
- Removed `wait_custom_minio_to_start()` calls for catalog setup

### Why

Each Iceberg catalog compose file had its own MinIO instance + mc bucket-creation container. This duplicated infrastructure, added 2-3 extra containers per test, and diverged from the standard test MinIO setup. The standard `minio1` service is identical (same credentials, same image family) and already available in tests that use S3.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...

### Documentation check (leave one):
- [ ] No new docs needed

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.731`
<!-- ch-version-info:end -->