### PR TITLE
Stop flaky and targeted checks after 10 failures, limit targeted to 50 min

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -584,15 +584,18 @@ def main():
                 f" remaining: {global_time_limit}s)"
             )
 
-            run_tests(
-                batch_num=0,
-                batch_total=0,
-                tests=list(tests) if tests else tests,
-                extra_args=f"{runner_options} --max-failures {max_failures}",
-                random_order=True,
-                rerun_count=rerun_count,
-                global_time_limit=global_time_limit,
-            )
+            if global_time_limit <= 0:
+                print("Targeted-check time budget exhausted during setup, skipping tests")
+            else:
+                run_tests(
+                    batch_num=0,
+                    batch_total=0,
+                    tests=list(tests) if tests else tests,
+                    extra_args=f"{runner_options} --max-failures {max_failures}",
+                    random_order=True,
+                    rerun_count=rerun_count,
+                    global_time_limit=global_time_limit,
+                )
 
         else:
             run_tests(

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -238,7 +238,7 @@ def main():
 
     if is_flaky_check or is_targeted_check:
         # Stop after 10 total failures across all parallel workers (fast feedback on broken PRs).
-        runner_options += " --max-failures 10"
+        runner_options += " --max-failures 5"
 
     if is_excluded_from_llvm:
         # Run only tests that are normally disabled under LLVM coverage
@@ -269,7 +269,7 @@ def main():
     elif is_flaky_check:
         # Large repeat count so the 45-min global_time_limit is the effective stopping
         # condition, not the repeat count.  Tests run in parallel (--jobs N) with fresh
-        # random settings per TestCase; --max-failures 10 stops early on broken PRs.
+        # random settings per TestCase; --max-failures 5 stops early on broken PRs.
         rerun_count = 50
     elif is_targeted_check:
         rerun_count = 50

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -237,7 +237,7 @@ def main():
     runner_options += f" --jobs {workers}"
 
     if is_flaky_check or is_targeted_check:
-        # Stop after 10 total failures across all parallel workers (fast feedback on broken PRs).
+        # Stop after 5 total failures across all parallel workers (fast feedback on broken PRs).
         runner_options += " --max-failures 5"
 
     if is_excluded_from_llvm:

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -236,10 +236,9 @@ def main():
 
     runner_options += f" --jobs {workers}"
 
-    if is_flaky_check:
-        # Stop after 5 total failures across all parallel workers (fast feedback on broken PRs).
-        # The 45-min global_time_limit is the primary stopping condition for healthy PRs.
-        runner_options += " --max-failures 5"
+    if is_flaky_check or is_targeted_check:
+        # Stop after 10 total failures across all parallel workers (fast feedback on broken PRs).
+        runner_options += " --max-failures 10"
 
     if is_excluded_from_llvm:
         # Run only tests that are normally disabled under LLVM coverage
@@ -270,7 +269,7 @@ def main():
     elif is_flaky_check:
         # Large repeat count so the 45-min global_time_limit is the effective stopping
         # condition, not the repeat count.  Tests run in parallel (--jobs N) with fresh
-        # random settings per TestCase; --max-failures 5 stops early on broken PRs.
+        # random settings per TestCase; --max-failures 10 stops early on broken PRs.
         rerun_count = 50
     elif is_targeted_check:
         rerun_count = 50
@@ -551,7 +550,6 @@ def main():
         ft_res_processor = FTResultsProcessor(wd=temp_dir)
 
         global_time_limit = 0
-        max_failures = 10
         if is_flaky_check:
             FLAKY_CHECK_TIME_LIMIT = 45 * 60  # 45 min
             global_time_limit = max(
@@ -567,7 +565,7 @@ def main():
                 batch_num=0,
                 batch_total=0,
                 tests=list(tests) if tests else tests,
-                extra_args=f"{runner_options} --max-failures {max_failures}",
+                extra_args=runner_options,
                 random_order=True,
                 rerun_count=rerun_count,
                 global_time_limit=global_time_limit,
@@ -588,7 +586,7 @@ def main():
                 batch_num=0,
                 batch_total=0,
                 tests=list(tests) if tests else tests,
-                extra_args=f"{runner_options} --max-failures {max_failures}",
+                extra_args=runner_options,
                 random_order=True,
                 rerun_count=rerun_count,
                 global_time_limit=global_time_limit,

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -584,18 +584,15 @@ def main():
                 f" remaining: {global_time_limit}s)"
             )
 
-            if global_time_limit <= 0:
-                print("Targeted-check time budget exhausted during setup, skipping tests")
-            else:
-                run_tests(
-                    batch_num=0,
-                    batch_total=0,
-                    tests=list(tests) if tests else tests,
-                    extra_args=f"{runner_options} --max-failures {max_failures}",
-                    random_order=True,
-                    rerun_count=rerun_count,
-                    global_time_limit=global_time_limit,
-                )
+            run_tests(
+                batch_num=0,
+                batch_total=0,
+                tests=list(tests) if tests else tests,
+                extra_args=f"{runner_options} --max-failures {max_failures}",
+                random_order=True,
+                rerun_count=rerun_count,
+                global_time_limit=global_time_limit,
+            )
 
         else:
             run_tests(

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -576,7 +576,7 @@ def main():
         elif is_targeted_check:
             TARGETED_CHECK_TIME_LIMIT = 50 * 60  # 50 min
             global_time_limit = max(
-                TARGETED_CHECK_TIME_LIMIT - int(stop_watch.duration), 0
+                TARGETED_CHECK_TIME_LIMIT - int(stop_watch.duration), 60
             )
             print(
                 f"Targeted-check time limit: {TARGETED_CHECK_TIME_LIMIT}s"

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -551,6 +551,7 @@ def main():
         ft_res_processor = FTResultsProcessor(wd=temp_dir)
 
         global_time_limit = 0
+        max_failures = 10
         if is_flaky_check:
             FLAKY_CHECK_TIME_LIMIT = 45 * 60  # 45 min
             global_time_limit = max(
@@ -566,28 +567,28 @@ def main():
                 batch_num=0,
                 batch_total=0,
                 tests=list(tests) if tests else tests,
-                extra_args=runner_options,
+                extra_args=f"{runner_options} --max-failures {max_failures}",
                 random_order=True,
                 rerun_count=rerun_count,
                 global_time_limit=global_time_limit,
             )
 
         elif is_targeted_check:
-            job_timeout = int(3600 * 2.5)
-            soft_limit_margin = 3600
+            TARGETED_CHECK_TIME_LIMIT = 50 * 60  # 50 min
             global_time_limit = max(
-                job_timeout - soft_limit_margin - int(stop_watch.duration), 0
+                TARGETED_CHECK_TIME_LIMIT - int(stop_watch.duration), 0
             )
             print(
-                f"Soft time limit for test runner: {global_time_limit}s"
-                f" (elapsed so far: {int(stop_watch.duration)}s)"
+                f"Targeted-check time limit: {TARGETED_CHECK_TIME_LIMIT}s"
+                f" (elapsed so far: {int(stop_watch.duration)}s,"
+                f" remaining: {global_time_limit}s)"
             )
 
             run_tests(
                 batch_num=0,
                 batch_total=0,
                 tests=list(tests) if tests else tests,
-                extra_args=runner_options,
+                extra_args=f"{runner_options} --max-failures {max_failures}",
                 random_order=True,
                 rerun_count=rerun_count,
                 global_time_limit=global_time_limit,

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2540,10 +2540,7 @@ class TestCase:
             return FailureReason.SKIP
 
         if "no-flaky-check" in tags and args.flaky_check:
-            # In flaky check mode, no-flaky-check tests run sequentially (like no-parallel)
-            # with --sequential-test-runs runs instead of being skipped entirely.
-            # They are still excluded from parallel execution — see is_sequential_test().
-            pass
+            return FailureReason.SKIP
         if "stateful" in tags and args.no_stateful:
             return FailureReason.NO_STATEFUL
         if "stateful" not in tags and args.no_stateless:
@@ -3836,8 +3833,6 @@ class TestSuite:
 
         tags = self.all_tags[test_name]
         if "no-parallel" in tags or "sequential" in tags:
-            return True
-        if "no-flaky-check" in tags and args.flaky_check:
             return True
         return False
 


### PR DESCRIPTION
Add `--max-failures 10` to both flaky check and targeted check so they stop early instead of burning time after hitting 10 failures.

Reduce the targeted check time limit from ~1.5h to 50 minutes. Tests that haven't started when the timeout is reached are simply not run — they are not marked as failed.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.992`
<!-- ch-version-info:end -->