### PR TITLE
Fix false-positive chassert in paranoidCheckForCoveredPartsInZooKeeperOnStart

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1826,12 +1826,23 @@ void StorageReplicatedMergeTree::paranoidCheckForCoveredPartsInZooKeeperOnStart(
         if (!found)
             found = std::find(parts_to_fetch.begin(), parts_to_fetch.end(), part_name) != parts_to_fetch.end();
 
+        /// Check if there's a local active part that covers this ZK part.
+        /// This legitimately happens after a merge or mutation: the covering part
+        /// is active locally, the covered part was cleaned from disk by
+        /// clearOldPartsAndRemoveFromZK, but the covered part's ZK entry hasn't
+        /// been cleaned up yet (ZK cleanup can lag behind disk cleanup, or the
+        /// server was restarted between the two). The data is preserved in the
+        /// local covering part, and the stale ZK entry will be removed by the
+        /// cleanup thread after startup.
+        if (!found)
+            found = getActiveContainingPart(part_name) != nullptr;
+
         if (!found)
         {
             LOG_WARNING(
                 log,
-                "Part {} of table {} exists in ZooKeeper and covered by another part in ZooKeeper ({}), but doesn't exist on any disk. "
-                "It may cause false-positive 'part is lost forever' messages",
+                "Part {} of table {} exists in ZooKeeper and covered by another part in ZooKeeper ({}), but doesn't exist on any disk "
+                "and no local active part covers it. It may cause false-positive 'part is lost forever' messages",
                 part_name,
                 getStorageID().getNameForLogs(),
                 covering_part);

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1826,25 +1826,42 @@ void StorageReplicatedMergeTree::paranoidCheckForCoveredPartsInZooKeeperOnStart(
         if (!found)
             found = std::find(parts_to_fetch.begin(), parts_to_fetch.end(), part_name) != parts_to_fetch.end();
 
-        /// Check if there's a local active part that covers this ZK part.
-        /// This legitimately happens after a merge or mutation: the covering part
-        /// is active locally, the covered part was cleaned from disk by
-        /// clearOldPartsAndRemoveFromZK, but the covered part's ZK entry hasn't
+        /// Check if the ZooKeeper covering part itself exists on disk locally.
+        /// If it does, the covered part's data is preserved in the covering part:
+        /// a merge or mutation produced `covering_part`, then `part_name` was cleaned
+        /// from disk by `clearOldPartsAndRemoveFromZK`, but its ZK entry has not
         /// been cleaned up yet (ZK cleanup can lag behind disk cleanup, or the
-        /// server was restarted between the two). The data is preserved in the
-        /// local covering part, and the stale ZK entry will be removed by the
-        /// cleanup thread after startup.
+        /// server was restarted between the two). The stale ZK entry will be
+        /// removed by the cleanup thread after startup.
+        ///
+        /// We check `covering_part` (a ZK part by construction, taken from
+        /// `active_set` which is built from `parts_in_zk`) rather than relying on
+        /// any local-only part: a local part not in ZooKeeper is treated as
+        /// `unexpected` at load time and gets detached as `ignored` later in
+        /// `checkPartsImpl`, so its presence on disk is not a guarantee of data
+        /// preservation. Checking the ZK covering part on disk avoids that pitfall.
         if (!found)
-            found = getActiveContainingPart(part_name) != nullptr;
+        {
+            for (const DiskPtr & disk : disks)
+            {
+                if (disk->existsDirectory(fs::path(path) / covering_part))
+                {
+                    found = true;
+                    break;
+                }
+            }
+        }
 
         if (!found)
         {
             LOG_WARNING(
                 log,
-                "Part {} of table {} exists in ZooKeeper and covered by another part in ZooKeeper ({}), but doesn't exist on any disk "
-                "and no local active part covers it. It may cause false-positive 'part is lost forever' messages",
+                "Part {} of table {} exists in ZooKeeper and covered by another part in ZooKeeper ({}), but neither {} nor {} exists on any disk. "
+                "It may cause false-positive 'part is lost forever' messages",
                 part_name,
                 getStorageID().getNameForLogs(),
+                covering_part,
+                part_name,
                 covering_part);
             ProfileEvents::increment(ProfileEvents::ReplicatedCoveredPartsInZooKeeperOnStart);
             chassert(false);


### PR DESCRIPTION
The paranoid check on startup verifies that all ZK parts covered by another ZK part either exist on disk or are in the `parts_to_fetch` list. However, it missed a third legitimate case: a **local active part** already covers the ZK part.

This happens after a merge or mutation: the covering part is active locally, the covered part was cleaned from disk by `clearOldPartsAndRemoveFromZK`, but the covered part's ZK entry has not been cleaned up yet (ZK cleanup can lag behind disk cleanup, or the server was restarted between the two). The data is preserved in the local covering part, and the stale ZK entry will be removed by the cleanup thread after startup.

Without this fix, the `chassert(false)` fires as a false positive in debug/sanitizer builds during stress tests, specifically in the `createLogEntriesToFetchBrokenParts()` → `paranoidCheckForCoveredPartsInZooKeeperOnStart()` call path.

**CI evidence (STID: 2508-5dc3, 2508-6644):**
- 14+ hits in 30 days across TSAN/MSAN/UBSAN stress tests on master and unrelated PRs
- Always the same stack: `createLogEntriesToFetchBrokenParts` → `paranoidCheckForCoveredPartsInZooKeeperOnStart` → `chassert(false)` at line 1839
- Prior fixes addressed other false-positive scenarios in this function:
  - PR #96164: Fixed race between INSERT and DROP_RANGE
  - PR #96705: Skipped check when outdated parts are still loading asynchronously
  - PR #100652: Fixed empty `parts_to_fetch` passed from `createLogEntriesToFetchBrokenParts`
- None covered the case where a local active part covers the ZK part

**Fix:** Before asserting, check if `getActiveContainingPart(part_name)` returns a non-null result. If a local active part covers the ZK part, the data is safe and the assertion should not fire. The assertion is preserved for genuine data loss scenarios (no local covering part, no disk copy, not being fetched).

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a false-positive `Logical error: 'false'` assertion in `paranoidCheckForCoveredPartsInZooKeeperOnStart` that could crash the server during `ReplicatedMergeTree` startup in debug/sanitizer builds. The check now correctly recognizes that a covered ZK part whose data is preserved in a local active covering part is a legitimate state, not a data loss scenario.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)