### PR TITLE
Replace chassert with diagnostic LOGICAL_ERROR in AggregateFunctionArray

### DIFF
--- a/src/AggregateFunctions/Combinators/AggregateFunctionArray.h
+++ b/src/AggregateFunctions/Combinators/AggregateFunctionArray.h
@@ -41,7 +41,8 @@ public:
             /// parameter set. If this fires, it means some code path in
             /// AggregateFunctionFactory or a combinator wrapper lost/modified parameters.
             /// The diagnostic info below will identify the exact mismatch.
-            String outer_params_str, nested_params_str;
+            String outer_params_str;
+            String nested_params_str;
             for (const auto & p : parameters)
             {
                 if (!outer_params_str.empty()) outer_params_str += ", ";

--- a/src/AggregateFunctions/Combinators/AggregateFunctionArray.h
+++ b/src/AggregateFunctions/Combinators/AggregateFunctionArray.h
@@ -13,6 +13,7 @@ struct Settings;
 
 namespace ErrorCodes
 {
+    extern const int LOGICAL_ERROR;
     extern const int SIZES_OF_ARRAYS_DONT_MATCH;
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
 }
@@ -33,7 +34,32 @@ public:
         : IAggregateFunctionHelper<AggregateFunctionArray>(arguments, params_, createResultType(nested_))
         , nested_func(nested_), num_arguments(arguments.size())
     {
-        chassert(parameters == nested_func->getParameters());
+        if (parameters != nested_func->getParameters())
+        {
+            /// This invariant should always hold: the Array combinator does not transform
+            /// parameters, so the wrapped function must have been created with the same
+            /// parameter set. If this fires, it means some code path in
+            /// AggregateFunctionFactory or a combinator wrapper lost/modified parameters.
+            /// The diagnostic info below will identify the exact mismatch.
+            String outer_params_str, nested_params_str;
+            for (const auto & p : parameters)
+            {
+                if (!outer_params_str.empty()) outer_params_str += ", ";
+                outer_params_str += p.dump();
+            }
+            for (const auto & p : nested_func->getParameters())
+            {
+                if (!nested_params_str.empty()) nested_params_str += ", ";
+                nested_params_str += p.dump();
+            }
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "AggregateFunctionArray: parameters mismatch between Array wrapper '{}' "
+                "and nested function '{}'. Wrapper has {} parameter(s): [{}], "
+                "nested function has {} parameter(s): [{}]",
+                getName(), nested_func->getName(),
+                parameters.size(), outer_params_str,
+                nested_func->getParameters().size(), nested_params_str);
+        }
         for (const auto & type : arguments)
             if (!isArray(type))
                 throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT, "All arguments for aggregate function {} must be arrays", getName());


### PR DESCRIPTION
The assertion `parameters == nested_func->getParameters()` in `AggregateFunctionArray` has been firing sporadically in CI (~4 hits per month) through AST fuzzer and serverfuzz stress tests (STID 4870-4f21, STID 4870-4e45, STID 2508-522c).

The previous `chassert` (converted from C `assert()` in #102856, before that fixed primary root cause in #100679) only provides the expression text — zero information about what the actual parameters are when it fires. This makes investigation of the remaining secondary code path extremely difficult.

**What this PR does:**

Replaces the `chassert` with an explicit `LOGICAL_ERROR` exception that logs:
- The Array wrapper function name (e.g., `quantileIfArrayArray`)
- The nested function name (e.g., `nothingNull`)  
- Both parameter sets with their actual values and sizes

Example error message:
```
AggregateFunctionArray: parameters mismatch between Array wrapper 'quantileIfArrayArray' 
and nested function 'nothingNull'. Wrapper has 1 parameter(s): [0.5], 
nested function has 0 parameter(s): []
```

**Why:**

The invariant that `parameters == nested_func->getParameters()` should always hold because the Array combinator does not transform parameters. When it fails, it indicates a bug in `AggregateFunctionFactory::getImpl()` or a combinator wrapper that loses/modifies parameters during resolution.

The diagnostic info will immediately identify which combinator+function combination triggers the mismatch, enabling targeted root cause analysis on the next CI occurrence.

**Behavior:**
- Debug/sanitizer builds: throws LOGICAL_ERROR (same as chassert, but with useful message)
- Release builds: throws LOGICAL_ERROR (improvement — chassert was a no-op in release)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a]utofill):
- ...no entry required...

- [ ] Documentation is written (if applicable)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1009`
<!-- ch-version-info:end -->