### PR TITLE
Fix missing transitive dependency digests in CI cache keys

### DIFF
--- a/ci/praktika/hook_cache.py
+++ b/ci/praktika/hook_cache.py
@@ -18,7 +18,6 @@ class CacheRunnerHooks:
         assert (
             workflow.enable_cache
         ), f"Outdated yaml pipelines or BUG. Configuration must be run only for workflow with enabled cache, workflow [{workflow.name}]"
-        artifact_digest_map = {}
         job_digest_map = {}
         artifact_name_config_map = {}
         for a in workflow.artifacts:
@@ -31,20 +30,32 @@ class CacheRunnerHooks:
                 artifact_configs=artifact_name_config_map,
             )
             job_digest_map[job.name] = digest
-            if job.provides:
-                # assign the job digest also to the artifacts it provides
-                for artifact in job.provides:
-                    artifact_digest_map[artifact] = digest
+
+        # Build lookup: requires entry (artifact name or job name) -> providing job name
+        dep_job_lookup = {}
+        job_by_name = {}
         for job in workflow.jobs:
+            job_by_name[job.name] = job
+            dep_job_lookup[job.name] = job.name
+            for artifact in job.provides:
+                dep_job_lookup[artifact] = job.name
+
+        # Resolve final digests with transitive dependency digests included.
+        # Uses memoization so result is independent of job ordering.
+        final_digest_cache = {}
+
+        def _resolve_final_digest(job_name):
+            if job_name in final_digest_cache:
+                return final_digest_cache[job_name]
+            job = job_by_name[job_name]
             digests_combined_list = []
             if job.requires and job.digest_config:
-                # include digests of hard dependencies (artifacts and job names)
-                for req_name in job.requires:
-                    if req_name in artifact_digest_map:
-                        digests_combined_list.append(artifact_digest_map[req_name])
-                    elif req_name in job_digest_map:
-                        digests_combined_list.append(job_digest_map[req_name])
-            digests_combined_list.append(job_digest_map[job.name])
+                for req in job.requires:
+                    if req in dep_job_lookup:
+                        digests_combined_list.append(
+                            _resolve_final_digest(dep_job_lookup[req])
+                        )
+            digests_combined_list.append(job_digest_map[job_name])
             # Deduplicate tokens to shrink the key when multiple deps
             # share the same file digest (e.g. amd/arm release builds)
             seen = set()
@@ -53,7 +64,12 @@ class CacheRunnerHooks:
                 if token not in seen:
                     seen.add(token)
                     unique_tokens.append(token)
-            workflow_config.digest_jobs[job.name] = "-".join(unique_tokens)
+            final_digest = "-".join(unique_tokens)
+            final_digest_cache[job_name] = final_digest
+            return final_digest
+
+        for job in workflow.jobs:
+            workflow_config.digest_jobs[job.name] = _resolve_final_digest(job.name)
 
         assert (
             workflow_config.digest_jobs


### PR DESCRIPTION
The digest calculation for jobs with indirect dependencies was missing transitive dependency digests. For example, if Cloud Benchmark depends on Docker server (via `.requires`) and Docker server depends on Build, the cache digest for Cloud Benchmark should include Build + Docker + own digests, but it only included Docker + own. This caused stale cache hits where a Build change did not invalidate downstream jobs.

The root cause was that `artifact_digest_map` was populated with each job's own digest (before dependency resolution). When a downstream job looked up its dependency, it got the dependency's own digest without the transitive deps.

Replace the two-pass linear approach with a recursive memoized resolver (`_resolve_final_digest`) that correctly walks the full dependency chain. This is also order-independent — the result does not depend on job ordering in the workflow definition.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.990`
<!-- ch-version-info:end -->