### PR TITLE
Fix flaky test 03710_parallel_alter_comment_rename_selects timeout

### DIFF
--- a/tests/queries/0_stateless/03710_parallel_alter_comment_rename_selects.sh
+++ b/tests/queries/0_stateless/03710_parallel_alter_comment_rename_selects.sh
@@ -8,7 +8,7 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 set -euo pipefail
 
-RUNS=${RUNS:-25}
+RUNS=${RUNS:-10}
 THREADS_PER_JOB=${THREADS_PER_JOB:-4}
 PRINT_LOGS=${PRINT_LOGS:-0}
 QUERY_TIMEOUT=${QUERY_TIMEOUT:-30}


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a]):
<changelog_will_not_be_checked>

### What is the problem?

The test `03710_parallel_alter_comment_rename_selects` times out on `arm_asan_ubsan, azure, sequential` CI checks. CIDB shows 14 master failures in 30 days (13 on `amd_coverage` daily March 18-31, 1 on `arm_asan_ubsan` April 15) plus 5+ PR failures across unrelated PRs in the last 3 days — all timeouts (exit code 124).

The root cause is that with `RUNS=25` and `THREADS_PER_JOB=4`, the test creates 12 concurrent threads doing RENAME DATABASE / ALTER DATABASE / SELECT operations (1200 total operations across 2 engines). Under ASAN (3x slowdown) + ARM overhead + Azure I/O latency, the heavy lock contention pushes individual queries past the 30s per-query `QUERY_TIMEOUT` set by the test.

### How was it fixed?

Reduce `RUNS` from 25 to 10. This:
- Reduces total operations from 1200 to 480 (10 × 4 threads × 3 job types × 2 ops × 2 engines)
- Reduces test runtime from ~32s to ~14s on debug build (58% reduction)
- Projected ARM ASAN Azure runtime: ~112s (vs ~256s before), well within the 600s test runner timeout
- **Preserves test intent**: 10 iterations × 4 threads = 240 concurrent operations per engine — more than sufficient for deadlock detection (deadlocks are lock-ordering bugs that manifest in 1-3 iterations)

The test already has `no-msan` (added Jan 2026 for the same timeout issue on MSAN builds). The `RUNS` variable remains configurable via environment for anyone who wants to run more iterations locally.

### Local verification

10/10 passes with randomization on debug build, all completing in 13-15 seconds:
```
03710_parallel_alter_comment_rename_selects: [ OK ] 14.21 sec.
03710_parallel_alter_comment_rename_selects: [ OK ] 14.12 sec.
...
03710_parallel_alter_comment_rename_selects: [ OK ] 13.83 sec.
```

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.732`
<!-- ch-version-info:end -->