### PR TITLE
claude: Instruct PR description skill to open PRs as draft by default

### DIFF
--- a/.claude/skills/clickhouse-pr-description/SKILL.md
+++ b/.claude/skills/clickhouse-pr-description/SKILL.md
@@ -124,4 +124,6 @@ These patterns make PRs harder to read or signal low effort:
 
 It's fine to mention AI assistance openly. `Co-Authored-By:` in commits or acknowledgements in the PR description are acceptable — ClickHouse is open about AI-assisted development.
 
+When creating a PR, open it as a **Draft** — this prevents accidental merges.
+
 Before creating or updating the PR, check user memory for a confirmation preference. If no preference is stored and the session is interactive, ask once: "Should I always show you the description for approval before applying it, or just go ahead every time?" Save the answer to memory and apply it from then on. If the session is non-interactive, proceed directly without asking.


### PR DESCRIPTION
Add a line to the `clickhouse-pr-description` skill instructing it to open PRs as **Draft** to prevent accidental merges.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1008`
<!-- ch-version-info:end -->