### PR TITLE
Unify Result.Status and Result.StatusExtended into a single enum

### DIFF
--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -97,7 +97,7 @@ def _collect_targeted_queries(info: Info) -> tuple[list[str], Result]:
     except Exception as e:
         logging.warning("[targeted-fuzzer] Step 3 — failed to fetch coverage-relevant tests: %s", e)
         relevant_tests = []
-        relevant_tests_result = Result(name="tests found by coverage", status=Result.StatusExtended.OK, info=f"Skipped: {e}")
+        relevant_tests_result = Result(name="tests found by coverage", status=Result.Status.OK, info=f"Skipped: {e}")
     logging.info("[targeted-fuzzer] Step 3 — coverage-relevant tests (%d)", len(relevant_tests))
 
     # Merge all three sets preserving priority order (changed first)
@@ -252,7 +252,7 @@ def run_fuzz_job(check_name: str):
         Result.create_from(status=Result.Status.ERROR, info=error_info).complete_job()
 
     # parse runner script exit status
-    status = Result.Status.FAILED
+    status = Result.Status.FAIL
     info = []
     is_failed = True
     if server_died:
@@ -261,7 +261,7 @@ def run_fuzz_job(check_name: str):
     elif fuzzer_exit_code in (0, 137, 143):
         # normal exit with timeout or OOM kill
         is_failed = False
-        status = Result.Status.SUCCESS
+        status = Result.Status.OK
         if fuzzer_exit_code == 0:
             info.append("Fuzzer exited with success")
         elif fuzzer_exit_code == 137:
@@ -301,7 +301,7 @@ def run_fuzz_job(check_name: str):
             if sanitizer_oom:
                 print("Sanitizer OOM")
                 info.append("WARNING: Sanitizer OOM - test considered passed")
-                status = Result.Status.SUCCESS
+                status = Result.Status.OK
                 is_failed = False
         else:
             # Check for OOM in dmesg for non-sanitized builds
@@ -332,7 +332,7 @@ def run_fuzz_job(check_name: str):
                 Result(
                     name=parsed_name,
                     info=parsed_info,
-                    status=Result.StatusExtended.FAIL,
+                    status=Result.Status.FAIL,
                     files=files,
                 )
             )

--- a/ci/jobs/build_toolchain.py
+++ b/ci/jobs/build_toolchain.py
@@ -313,7 +313,7 @@ def main():
                     " (link failures with instrumented compiler are expected)."
                     " Profraw files from compilation steps should still be available."
                 )
-                build_result.status = Result.Status.SUCCESS
+                build_result.status = Result.Status.OK
                 build_result.info = "Build failed at link step (expected); profraw files collected"
             results.append(build_result)
 

--- a/ci/jobs/check_style.py
+++ b/ci/jobs/check_style.py
@@ -43,7 +43,7 @@ def run_check_concurrent(check_name, check_function, files, nproc=NPROC):
 
     result = Result(
         name=check_name,
-        status=Result.Status.SUCCESS if not results else Result.Status.FAILED,
+        status=Result.Status.OK if not results else Result.Status.FAIL,
         start_time=stop_watch.start_time,
         duration=stop_watch.duration,
         info="\n".join(results) if results else "",

--- a/ci/jobs/clickbench.py
+++ b/ci/jobs/clickbench.py
@@ -77,7 +77,7 @@ def main():
                     query_results.append(
                         Result(
                             name=f"{QUERY_NUM}_{i}",
-                            status=Result.Status.SUCCESS,
+                            status=Result.Status.OK,
                             duration=float(time_err),
                         )
                     )

--- a/ci/jobs/clickhouse_light.py
+++ b/ci/jobs/clickhouse_light.py
@@ -50,7 +50,7 @@ class TestResult:
     def to_praktika_result(self):
         info = ""
         for idx, query_result in enumerate(self.query_results):
-            if query_result.status != Result.StatusExtended.OK:
+            if query_result.status != Result.Status.OK:
                 info += f"Query ({idx+1}):\n"
                 info += f"{query_result.query}\n\n"
                 if query_result.description.exception:
@@ -218,14 +218,14 @@ class ClickHouseSetup:
                 tag_line = query_stripped[len("-- Tags:") :].strip()
                 tags.update(tag.strip() for tag in tag_line.split(","))
 
-        test_result = TestResult(test_name, status=Result.StatusExtended.OK)
+        test_result = TestResult(test_name, status=Result.Status.OK)
 
         for query in queries:
             query = query.strip()
             if query == "" or query.startswith("--"):
                 continue
 
-            query_result = QueryResult(query, status=Result.StatusExtended.FAIL)
+            query_result = QueryResult(query, status=Result.Status.FAIL)
 
             status_code, stdout, stderr = self.send_query(query)
 
@@ -238,20 +238,20 @@ class ClickHouseSetup:
                     query_result.description.expected_results = expected_lines
                     query_result.description.actual_results = result_lines
                 else:
-                    query_result.status = Result.StatusExtended.OK
+                    query_result.status = Result.Status.OK
 
             test_result.query_results.append(query_result)
-            if query_result.status != Result.StatusExtended.OK:
-                test_result.status = Result.StatusExtended.FAIL
+            if query_result.status != Result.Status.OK:
+                test_result.status = Result.Status.FAIL
 
         # Apply xfail logic: invert status if xfail tag is present
         if "xfail" in tags:
             if "xfail" not in test_result.tags:
                 test_result.tags.append("xfail")
-            if test_result.status == Result.StatusExtended.FAIL:
-                test_result.status = Result.StatusExtended.OK
-            elif test_result.status == Result.StatusExtended.OK:
-                test_result.status = Result.StatusExtended.FAIL
+            if test_result.status == Result.Status.FAIL:
+                test_result.status = Result.Status.OK
+            elif test_result.status == Result.Status.OK:
+                test_result.status = Result.Status.FAIL
 
         return test_result
 

--- a/ci/jobs/collect_statistics.py
+++ b/ci/jobs/collect_statistics.py
@@ -166,7 +166,7 @@ if __name__ == "__main__":
     results.append(
         Result(
             name="Fetch statistics",
-            status=Result.Status.SUCCESS if is_collected else Result.Status.FAILED,
+            status=Result.Status.OK if is_collected else Result.Status.FAIL,
             results=results_stat,
         )
     )

--- a/ci/jobs/copilot_review_job.py
+++ b/ci/jobs/copilot_review_job.py
@@ -126,7 +126,7 @@ def post():
 
 
 if __name__ == "__main__":
-    status = Result.Status.SUCCESS
+    status = Result.Status.OK
     info = ""
     if "--pre" in sys.argv:
         try:
@@ -135,7 +135,7 @@ if __name__ == "__main__":
             info = f"ERROR: {e}"
             print(info)
             traceback.print_exc()
-            status = Result.Status.FAILED
+            status = Result.Status.FAIL
     elif "--post" in sys.argv:
         try:
             post()
@@ -143,7 +143,7 @@ if __name__ == "__main__":
             info = f"ERROR: {e}"
             print(info)
             traceback.print_exc()
-            status = Result.Status.FAILED
+            status = Result.Status.FAIL
     else:
         print("Usage: copilot_review_job.py --pre | --post")
         sys.exit(1)

--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -321,7 +321,7 @@ def test_docker_library(test_results) -> None:
         test_results.append(
             Result(
                 name=test_name,
-                status=Result.Status.FAILED,
+                status=Result.Status.FAIL,
                 info=f"Exception while testing docker library: {traceback.format_exc()}",
             )
         )

--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -879,7 +879,7 @@ def main():
             test_results.results.append(
                 Result.create_from(
                     name="clickhouse-test",
-                    status=Result.StatusExtended.FAIL,
+                    status=Result.Status.FAIL,
                     info="clickhouse-test error",
                 )
             )
@@ -899,7 +899,7 @@ def main():
 
     CH.terminate(force=True)
 
-    status = Result.Status.SUCCESS if args.set_status_success else ""
+    status = Result.Status.OK if args.set_status_success else ""
     Result.create_from(
         results=results, status=status, stopwatch=stop_watch, files=attach_files, info=job_info
     ).complete_job()

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -665,9 +665,9 @@ def main():
                             print(
                                 f"Test {test_case.name} has succeeded after rerun. Mark it as OK"
                             )
-                            test_case.remove_label(Result.Status.FAILED)
-                            test_case.remove_label(Result.StatusExtended.FAIL)
-                            test_case.set_status(Result.StatusExtended.OK)
+                            test_case.remove_label(Result.Status.FAIL)
+                            test_case.remove_label(Result.Status.FAIL)
+                            test_case.set_status(Result.Status.OK)
                         else:
                             test_case.set_label(Result.Label.OK_ON_RETRY)
                     elif test_case.name in failed_after_rerun:
@@ -709,7 +709,7 @@ def main():
             Result.create_from(
                 name="Check errors",
                 results=CH.check_fatal_messages_in_logs(),
-                status=Result.Status.SUCCESS,
+                status=Result.Status.OK,
                 stopwatch=sw_,
             )
         )
@@ -722,11 +722,11 @@ def main():
         has_failure = False
         for r in test_result.results:
             r.set_label("xfail")
-            if r.status == Result.StatusExtended.FAIL:
-                r.status = Result.StatusExtended.OK
+            if r.status == Result.Status.FAIL:
+                r.status = Result.Status.OK
                 has_failure = True
-            elif r.status == Result.StatusExtended.OK:
-                r.status = Result.StatusExtended.FAIL
+            elif r.status == Result.Status.OK:
+                r.status = Result.Status.FAIL
         if not has_failure:
             print("Failed to reproduce the bug")
             test_result.set_failed().set_info("Failed to reproduce the bug")

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -666,7 +666,6 @@ def main():
                                 f"Test {test_case.name} has succeeded after rerun. Mark it as OK"
                             )
                             test_case.remove_label(Result.Status.FAIL)
-                            test_case.remove_label(Result.Status.FAIL)
                             test_case.set_status(Result.Status.OK)
                         else:
                             test_case.set_label(Result.Label.OK_ON_RETRY)

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -51,13 +51,13 @@ def _is_infrastructure_error(result: Result) -> bool:
     """Returns True if the result is a failure caused by infrastructure issues."""
     if not result.info:
         return False
-    if result.status in (Result.Status.ERROR, Result.StatusExtended.ERROR):
+    if result.status == Result.Status.ERROR:
         return any(pattern in result.info for pattern in INFRASTRUCTURE_ERROR_PATTERNS)
     # Docker compose/pull infrastructure failures may appear with FAIL status
     # when pytest reports fixture (setup phase) errors as test failures.
     # Require both docker context and an infrastructure pattern to avoid
     # false positives on genuine test failures.
-    if result.status in (Result.Status.FAILED, Result.StatusExtended.FAIL):
+    if result.status == Result.Status.FAIL:
         has_docker_context = (
             "'docker'" in result.info or "images_pull_cmd" in result.info
         )
@@ -76,7 +76,7 @@ def _mark_infrastructure_errors(results: list) -> int:
     for r in results:
         if _is_infrastructure_error(r):
             r.set_label(Result.Label.INFRA)
-            r.status = Result.StatusExtended.SKIPPED
+            r.status = Result.Status.SKIPPED
             count += 1
     if count:
         print(f"Marked {count} test result(s) as infrastructure errors")
@@ -541,7 +541,7 @@ def run_pytest_and_collect_results(
         test_result.results.append(
             Result(
                 name="Timeout",
-                status=Result.StatusExtended.FAIL,
+                status=Result.Status.FAIL,
                 info=test_result.info,
             )
         )
@@ -996,7 +996,7 @@ tar -czf ./ci/tmp/logs.tar.gz \
             ):
                 test_results.append(
                     Result(
-                        name=OOM_IN_DMESG_TEST_NAME, status=Result.StatusExtended.FAIL
+                        name=OOM_IN_DMESG_TEST_NAME, status=Result.Status.FAIL
                     )
                 )
                 attached_files.append("./ci/tmp/dmesg.log")
@@ -1014,11 +1014,11 @@ tar -czf ./ci/tmp/logs.tar.gz \
         ), "LLVM coverage with bugfix validation is not supported"
         has_failure = False
         for r in R.results:
-            if r.status == Result.StatusExtended.FAIL:
+            if r.status == Result.Status.FAIL:
                 if r.has_label(Result.Label.OK_ON_RETRY):
                     # Remove label and set to OK
                     r.remove_label(Result.Label.OK_ON_RETRY)
-                    r.status = Result.StatusExtended.OK
+                    r.status = Result.Status.OK
                 else:
                     has_failure = True
         if has_failure:
@@ -1049,11 +1049,11 @@ tar -czf ./ci/tmp/logs.tar.gz \
         for r in R.results:
             # invert statuses
             r.set_label("xfail")
-            if r.status == Result.StatusExtended.FAIL:
-                r.status = Result.StatusExtended.OK
+            if r.status == Result.Status.FAIL:
+                r.status = Result.Status.OK
                 has_failure = True
-            elif r.status == Result.StatusExtended.OK:
-                r.status = Result.StatusExtended.FAIL
+            elif r.status == Result.Status.OK:
+                r.status = Result.Status.FAIL
         if not has_failure:
             print("Failed to reproduce the bug")
             R.set_failed()

--- a/ci/jobs/jepsen_check.py
+++ b/ci/jobs/jepsen_check.py
@@ -47,11 +47,11 @@ def _parse_jepsen_output(path: Path):
     with open(path, "r", encoding="utf-8") as f:
         for line in f:
             if SUCCESSFUL_TESTS_ANCHOR in line:
-                current_type = Result.StatusExtended.OK
+                current_type = Result.Status.OK
             elif INTERMINATE_TESTS_ANCHOR in line or CRASHED_TESTS_ANCHOR in line:
-                current_type = Result.StatusExtended.ERROR
+                current_type = Result.Status.ERROR
             elif FAILED_TESTS_ANCHOR in line:
-                current_type = Result.StatusExtended.FAIL
+                current_type = Result.Status.FAIL
 
             if (
                 line.startswith("store/clickhouse") or line.startswith("clickhouse")
@@ -231,25 +231,25 @@ def main():
 
     clear_autoscaling_group()
 
-    status = Result.Status.SUCCESS
+    status = Result.Status.OK
     description = "No invalid analysis found ヽ(‘ー`)ノ"
     jepsen_log_path = result_path / "jepsen_run_all_tests.log"
     additional_data = []
     try:
         test_result = _parse_jepsen_output(jepsen_log_path)
         if len(test_result) == 0:
-            status = Result.Status.FAILED
+            status = Result.Status.FAIL
             description = "No test results found"
         elif any(r.status == "FAIL" for r in test_result):
-            status = Result.Status.FAILED
+            status = Result.Status.FAIL
             description = "Found invalid analysis (ﾉಥ益ಥ）ﾉ ┻━┻"
 
         additional_data.append(Utils.compress_zst(result_path / "store"))
     except Exception as ex:
         print("Exception", ex)
-        status = Result.Status.FAILED
+        status = Result.Status.FAIL
         description = "No Jepsen output log"
-        test_result = [Result("No Jepsen output log", "FAIL")]
+        test_result = [Result("No Jepsen output log", Result.Status.FAIL)]
 
     Result.create_from(
         results=test_result,

--- a/ci/jobs/llvm_coverage_job.py
+++ b/ci/jobs/llvm_coverage_job.py
@@ -292,7 +292,7 @@ if __name__ == "__main__":
             print(msg)
             print_res = Result.create_from(
                 name="Print Uncovered Code",
-                status=Result.Status.SUCCESS,
+                status=Result.Status.OK,
                 info=msg,
             )
             print_res.set_comment(msg)

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -665,7 +665,7 @@ def main():
             results.append(
                 Result(
                     name="Download datasets",
-                    status=Result.Status.SUCCESS if res else Result.Status.ERROR,
+                    status=Result.Status.OK if res else Result.Status.ERROR,
                 )
             )
             if res:
@@ -977,20 +977,20 @@ def main():
             if message_match:
                 message = message_match.group(1).strip()
             # TODO: Remove me, always green mode for the first time, unless errors
-            status = Result.Status.SUCCESS
+            status = Result.Status.OK
             if "errors" in message.lower() or too_many_slow(message.lower()):
-                status = Result.Status.FAILED
+                status = Result.Status.FAIL
             # TODO: Remove until here
         except Exception:
             traceback.print_exc()
-            status = Result.Status.FAILED
+            status = Result.Status.FAIL
             message = "Failed to parse the report."
 
         if not status:
-            status = Result.Status.FAILED
+            status = Result.Status.FAIL
             message = "No status in report."
         elif not message:
-            status = Result.Status.FAILED
+            status = Result.Status.FAIL
             message = "No message in report."
         results.append(
             Result(

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -409,16 +409,16 @@ class CommitStatusCheck:
                 sys.exit(0)
             GH.post_commit_status(
                 CheckStatuses.CH_INC_SYNC,
-                Result.Status.SUCCESS,
+                Result.Status.OK,
                 "Manually overridden",
                 "",
                 sha=sha,
                 repo="ClickHouse/ClickHouse",
             )
             return
-        if commit_status_data.state in (Result.Status.SUCCESS,):
+        if commit_status_data.state in (Result.GHStatus.SUCCESS,):
             pass
-        elif commit_status_data.state in (Result.Status.FAILED,):
+        elif commit_status_data.state in (Result.GHStatus.FAILURE,):
             if commit_status_data.description == "tests failed":
                 print(
                     f"\nCH Sync failed for commit, description: {commit_status_data.description}"
@@ -426,7 +426,7 @@ class CommitStatusCheck:
                 if UserPrompt.confirm("You sure it can be ignored?"):
                     GH.post_commit_status(
                         commit_status_data.context,
-                        Result.Status.SUCCESS,
+                        Result.Status.OK,
                         "Ignored",
                         commit_status_data.url,
                         sha=sha,
@@ -439,7 +439,7 @@ class CommitStatusCheck:
                     f"\nCH Sync commit status state: {commit_status_data.state} and description: {commit_status_data.description} - cannot proceed"
                 )
                 sys.exit(1)
-        elif commit_status_data.state in (Result.Status.PENDING,):
+        elif commit_status_data.state in (Result.GHStatus.PENDING,):
             if commit_status_data.description == "tests started":
                 print(
                     f"\n{commit_status_data.context} is pending with description {commit_status_data.description}"
@@ -447,7 +447,7 @@ class CommitStatusCheck:
                 if UserPrompt.confirm("You sure it can be ignored?"):
                     GH.post_commit_status(
                         commit_status_data.context,
-                        Result.Status.SUCCESS,
+                        Result.Status.OK,
                         "Ignored",
                         commit_status_data.url,
                         sha=sha,
@@ -466,11 +466,11 @@ class CommitStatusCheck:
         commit_status_data: Optional[GH.CommitStatus], sha: str
     ):
         override = False
-        if commit_status_data and commit_status_data.state in (Result.Status.SUCCESS,):
+        if commit_status_data and commit_status_data.state in (Result.GHStatus.SUCCESS,):
             pass
         elif not commit_status_data:
             override = True
-        elif commit_status_data.state in (Result.Status.FAILED,):
+        elif commit_status_data.state in (Result.GHStatus.FAILURE,):
             if UserPrompt.confirm("Do you want to override mergeable check?"):
                 override = True
             else:
@@ -482,7 +482,7 @@ class CommitStatusCheck:
         if override:
             GH.post_commit_status(
                 CheckStatuses.MERGEABLE_CHECK,
-                Result.Status.SUCCESS,
+                Result.Status.OK,
                 "Manually overridden",
                 "",
                 sha=sha,
@@ -872,8 +872,8 @@ def main():
         if (
             status_map[CheckStatuses.PR].state
             not in (
-                Result.Status.SUCCESS,
-                Result.Status.FAILED,
+                Result.GHStatus.SUCCESS,
+                Result.GHStatus.FAILURE,
             )
             and not FORCE_MERGE
         ):
@@ -915,7 +915,7 @@ def main():
     sync_unknown_failures = []
     if (
         sync_status
-        and sync_status.state == Result.Status.FAILED
+        and sync_status.state == Result.GHStatus.FAILURE
         and sync_status.description == "tests failed"
     ):
         print("\n=== Processing Sync PR (CH Inc sync) failures ===")

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -1032,7 +1032,7 @@ clickhouse-client --query "SELECT count() FROM test.visits"
                     Result.create_from(
                         name="Sanitizer assert or Fatal messages in server logs",
                         info="no server logs found",
-                        status=Result.StatusExtended.FAIL,
+                        status=Result.Status.FAIL,
                         labels=[Result.Label.BLOCKER],  # to explicitly block the merge
                     )
                 )
@@ -1048,7 +1048,7 @@ clickhouse-client --query "SELECT count() FROM test.visits"
                         Result.create_from(
                             name=name,
                             info=description,
-                            status=Result.StatusExtended.FAIL,
+                            status=Result.Status.FAIL,
                             files=files,
                             labels=[
                                 Result.Label.BLOCKER
@@ -1060,7 +1060,7 @@ clickhouse-client --query "SELECT count() FROM test.visits"
                         Result.create_from(
                             name="Failed to parse sanitizer/fatal failure from server logs",
                             info=traceback.format_exc(),
-                            status=Result.StatusExtended.FAIL,
+                            status=Result.Status.FAIL,
                             labels=[
                                 Result.Label.BLOCKER
                             ],  # to explicitly block the merge
@@ -1099,9 +1099,9 @@ clickhouse-client --query "SELECT count() FROM test.visits"
         # convert statuses to CH tests notation
         for result in results:
             if result.is_ok():
-                result.set_status(Result.StatusExtended.OK)
+                result.set_status(Result.Status.OK)
             else:
-                result.set_status(Result.StatusExtended.FAIL)
+                result.set_status(Result.Status.FAIL)
         return results
 
     def dump_system_tables(self):
@@ -1168,7 +1168,7 @@ clickhouse-client --query "SELECT count() FROM test.visits"
             for cache_status_path in cache_status_files:
                 Shell.check(f"rm {cache_status_path}", verbose=True)
 
-        scraping_system_table = Result(name=f"Scraping system tables", status="OK")
+        scraping_system_table = Result(name=f"Scraping system tables", status=Result.Status.OK)
         for table in TABLES:
             path_arg = f" --path {self.run_path0}"
             res, stdout, stderr = Shell.get_res_stdout_stderr(
@@ -1248,7 +1248,7 @@ clickhouse-client --query "SELECT count() FROM test.visits"
                         )
 
         if scraping_system_table.info:
-            scraping_system_table.set_status(Result.StatusExtended.FAIL)
+            scraping_system_table.set_status(Result.Status.FAIL)
             self.extra_tests_results.append(scraping_system_table)
         return [f for f in glob.glob(f"{temp_dir}/system_tables/*.tsv")]
 

--- a/ci/jobs/scripts/find_tests.py
+++ b/ci/jobs/scripts/find_tests.py
@@ -1532,7 +1532,7 @@ class Targeting:
             info += f" - {test}\n"
         return tests, Result(
             name="tests that were changed or added",
-            status=Result.StatusExtended.OK,
+            status=Result.Status.OK,
             info=info,
         )
 
@@ -1551,7 +1551,7 @@ class Targeting:
             info += f" - {test}\n"
         return tests, Result(
             name="tests that failed in previous runs",
-            status=Result.StatusExtended.OK,
+            status=Result.Status.OK,
             info=info,
         )
 
@@ -1912,7 +1912,7 @@ class Targeting:
             info += f"Bottom test: {bottom} (score={width_score[bottom]:.6f})\n"
 
         return ranked, Result(
-            name="tests found by coverage", status=Result.StatusExtended.OK, info=info
+            name="tests found by coverage", status=Result.Status.OK, info=info
         )
 
     def get_all_relevant_tests_with_info(self):
@@ -1954,7 +1954,7 @@ class Targeting:
                 results.append(
                     Result(
                         name="tests found by coverage",
-                        status=Result.StatusExtended.OK,
+                        status=Result.Status.OK,
                         info=f"Skipped: {e}",
                     )
                 )
@@ -1962,7 +1962,7 @@ class Targeting:
 
         return ranked, Result(
             name="Fetch relevant tests",
-            status=Result.Status.SUCCESS,
+            status=Result.Status.OK,
             info=f"Found {len(ranked)} relevant tests",
             results=results,
         )

--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -170,21 +170,21 @@ class FTResultsProcessor:
         return s
 
     def run(self, task_name="Tests"):
-        state = Result.Status.SUCCESS
+        state = Result.Status.OK
         s = self._process_test_output()
         test_results = s.test_results
 
         if s.failed != 0 or s.unknown != 0:
-            state = Result.Status.FAILED
+            state = Result.Status.FAIL
 
         info = ""
         if s.hung:
-            state = Result.Status.FAILED
+            state = Result.Status.FAIL
             test_results.append(
-                Result("Some queries hung", "FAIL", info="Some queries hung")
+                Result("Some queries hung", Result.Status.FAIL, info="Some queries hung")
             )
         elif s.server_died:
-            state = Result.Status.FAILED
+            state = Result.Status.FAIL
             failed_results = [r for r in test_results if r.is_failure()]
             if len(failed_results) > 1:
                 # Multiple tests failed when the server died - this is a parallel
@@ -193,17 +193,17 @@ class FTResultsProcessor:
                 # The actual failure is captured by the "Server died" / LOGICAL_ERROR
                 # entry added from the server log.
                 for result in failed_results:
-                    result.status = Result.StatusExtended.UNKNOWN
+                    result.status = Result.Status.UNKNOWN
             elif len(failed_results) == 1:
                 # Single test failed - sequential run, this test is the culprit.
-                failed_results[0].status = Result.StatusExtended.ERROR
-            test_results.append(Result("Server died", "FAIL", info="Server died"))
+                failed_results[0].status = Result.Status.ERROR
+            test_results.append(Result("Server died", Result.Status.FAIL, info="Server died"))
         elif not s.success_finish:
             state = Result.Status.ERROR
             info = "The test runner was terminated unexpectedly"
         elif s.retries:
             test_results.append(
-                Result("Some tests restarted", "SKIPPED", info="Some tests restarted")
+                Result("Some tests restarted", Result.Status.SKIPPED, info="Some tests restarted")
             )
         else:
             pass

--- a/ci/jobs/scripts/print_uncovered_code.py
+++ b/ci/jobs/scripts/print_uncovered_code.py
@@ -236,7 +236,7 @@ if __name__ == "__main__":
         print(msg)
         r = Result.create_from(
             name="Print Uncovered Code",
-            status=Result.Status.SUCCESS,
+            status=Result.Status.OK,
             info=msg,
         )
         r.set_comment(msg)
@@ -459,7 +459,7 @@ if __name__ == "__main__":
 
     r = Result.create_from(
         name="Print Uncovered Code",
-        status=Result.Status.SUCCESS,
+        status=Result.Status.OK,
         info=full_msg,
         with_info_from_results=True,
     )

--- a/ci/jobs/scripts/workflow_hooks/quick_sync.py
+++ b/ci/jobs/scripts/workflow_hooks/quick_sync.py
@@ -5,6 +5,7 @@ import traceback
 from ci.defs.defs import SYNC
 from ci.praktika.gh import GH
 from ci.praktika.info import Info
+from ci.praktika.result import Result
 from ci.praktika.utils import Shell
 
 
@@ -23,11 +24,11 @@ def check():
 
     if not Shell.check(cmd):
         GH.post_commit_status(
-            name=SYNC, status="error", description="failed to start the sync", url=""
+            name=SYNC, status=Result.Status.ERROR, description="failed to start the sync", url=""
         )
     else:
         GH.post_commit_status(
-            name=SYNC, status="pending", description="sync started", url=""
+            name=SYNC, status=Result.Status.PENDING, description="sync started", url=""
         )
 
 

--- a/ci/jobs/scripts/workflow_hooks/set_dummy_sync_commit_status.py
+++ b/ci/jobs/scripts/workflow_hooks/set_dummy_sync_commit_status.py
@@ -1,4 +1,5 @@
 from praktika.gh import GH
+from praktika.result import Result
 
 # Sets dummy commit status for "CH Inc Sync" in the Merge Queue workflow
 
@@ -6,5 +7,5 @@ SYNC = "CH Inc sync"
 
 if __name__ == "__main__":
     GH.post_commit_status(
-        name=SYNC, status="success", description="dummy status to enable merge", url=""
+        name=SYNC, status=Result.Status.OK, description="dummy status to enable merge", url=""
     )

--- a/ci/jobs/smoke_test.py
+++ b/ci/jobs/smoke_test.py
@@ -117,7 +117,7 @@ def main():
             test_results.append(
                 Result.create_from(
                     name="Start server",
-                    status=Result.Status.SUCCESS,
+                    status=Result.Status.OK,
                     info="Server started successfully",
                 )
             )
@@ -131,7 +131,7 @@ def main():
             test_results.append(
                 Result.create_from(
                     name="Start server",
-                    status=Result.Status.FAILED,
+                    status=Result.Status.FAIL,
                     info=f"Server failed to start within timeout\n{err_content}",
                 )
             )
@@ -139,7 +139,7 @@ def main():
         test_results.append(
             Result.create_from(
                 name="Start server",
-                status=Result.Status.FAILED,
+                status=Result.Status.FAIL,
                 info=f"Exception starting server: {e}",
             )
         )

--- a/ci/jobs/stress_job.py
+++ b/ci/jobs/stress_job.py
@@ -263,7 +263,7 @@ def run_stress_test(upgrade_check: bool = False) -> None:
                 Result.create_from(
                     name="Unknown error",
                     info="no server logs found",
-                    status=Result.Status.FAILED,
+                    status=Result.Status.FAIL,
                 )
             )
         else:
@@ -301,7 +301,7 @@ def run_stress_test(upgrade_check: bool = False) -> None:
                     Result.create_from(
                         name=name,
                         info=description,
-                        status=Result.StatusExtended.FAIL,
+                        status=Result.Status.FAIL,
                         files=files,
                     )
                 )
@@ -310,7 +310,7 @@ def run_stress_test(upgrade_check: bool = False) -> None:
                     Result.create_from(
                         name="Parse failure error",
                         info="All log parsing attempts failed",
-                        status=Result.Status.FAILED,
+                        status=Result.Status.FAIL,
                     )
                 )
 
@@ -319,7 +319,7 @@ def run_stress_test(upgrade_check: bool = False) -> None:
             Result.create_from(
                 name="Server died",
                 info="Server died and no specific error was extracted",
-                status=Result.Status.FAILED,
+                status=Result.Status.FAIL,
             )
         )
 
@@ -328,18 +328,18 @@ def run_stress_test(upgrade_check: bool = False) -> None:
             Result.create_from(
                 name="Check failed",
                 info=f"Check failed with exit code {exit_code}",
-                status=Result.Status.FAILED,
+                status=Result.Status.FAIL,
             )
         )
 
     all_results = failed_results + [r for r in test_results if r.is_ok()]
     r = Result.create_from(
         results=all_results,
-        status=Result.Status.SUCCESS if not failed_results else "",
+        status=Result.Status.OK if not failed_results else "",
         stopwatch=stopwatch,
     )
     if not r.is_ok() and is_oom:
-        r.set_status(Result.Status.SUCCESS)
+        r.set_status(Result.Status.OK)
         r.set_info("OOM error (allowed in stress tests)")
 
     if r.is_ok() and exit_code != 0 and not is_oom:

--- a/ci/jobs/vector_search_stress_job.py
+++ b/ci/jobs/vector_search_stress_job.py
@@ -99,7 +99,7 @@ def main():
                 command=f"{temp_dir}/clickhouse-client --query 'select 1'",
             )
         )  # success if exit code is 0
-        test_results.append(Result(name="test 2", status=Result.Status.SUCCESS))
+        test_results.append(Result(name="test 2", status=Result.Status.OK))
 
         results.append(
             Result.create_from(
@@ -110,7 +110,7 @@ def main():
 
     Result.create_from(
         results=results,  # job status success or failure will be generated in accordance with subtask results in this array
-        # status=Result.Status.FAILED, # or set status here
+        # status=Result.Status.FAIL, # or set status here
         stopwatch=stop_watch,
         files=[],  # files you need to store after the job completes
         info="write result info here",  # will be shown in the report

--- a/ci/praktika/cidb.py
+++ b/ci/praktika/cidb.py
@@ -26,6 +26,29 @@ from .utils import Utils
 
 
 class CIDB:
+    _STATUS_TO_CIDB = {
+        Result.Status.OK: "success",
+        Result.Status.FAIL: "failure",
+        Result.Status.ERROR: "error",
+        Result.Status.SKIPPED: "skipped",
+        Result.Status.PENDING: "pending",
+        Result.Status.RUNNING: "running",
+        Result.Status.DROPPED: "dropped",
+        Result.Status.UNKNOWN: "failure",
+        Result.Status.XFAIL: "success",
+        Result.Status.XPASS: "failure",
+    }
+
+    @classmethod
+    def convert_status(cls, status: str) -> str:
+        """Map Result.Status value to legacy CIDB check_status string."""
+        legacy = cls._STATUS_TO_CIDB.get(status)
+        if legacy is not None:
+            return legacy
+        # Already a legacy string — pass through for idempotency
+        assert status in cls._STATUS_TO_CIDB.values(), f"Invalid status [{status}] for CIDB check_status"
+        return status
+
     @dataclasses.dataclass
     class TableRecord:
         pull_request_number: int
@@ -51,7 +74,7 @@ class CIDB:
 
         def __post_init__(self):
             # Transparently convert Result.Status values to legacy CIDB strings
-            self.check_status = Result.convert_to_cidb_status(self.check_status)
+            self.check_status = CIDB.convert_status(self.check_status)
 
     def __init__(self, url, user, passwd):
         self.url = url

--- a/ci/praktika/cidb.py
+++ b/ci/praktika/cidb.py
@@ -49,6 +49,10 @@ class CIDB:
         test_duration_ms: Optional[int]
         test_context_raw: str
 
+        def __post_init__(self):
+            # Transparently convert Result.Status values to legacy CIDB strings
+            self.check_status = Result.convert_to_cidb_status(self.check_status)
+
     def __init__(self, url, user, passwd):
         self.url = url
         self.auth = {
@@ -304,7 +308,7 @@ ORDER BY day DESC
             commit_sha=info.sha,
             commit_url=info.commit_url,
             check_name="Usage Storage",
-            check_status=Result.Status.SUCCESS,
+            check_status=Result.Status.OK,
             check_duration_ms=storage_usage.uploaded,
             check_start_time=Utils.timestamp_to_str(Utils.timestamp()),
             report_url=info.get_report_url(),
@@ -344,7 +348,7 @@ ORDER BY day DESC
                 commit_sha=info.sha,
                 commit_url=info.commit_url,
                 check_name="Usage Compute",
-                check_status=Result.Status.SUCCESS,
+                check_status=Result.Status.OK,
                 check_duration_ms=int(usage * 1000),
                 check_start_time=Utils.timestamp_to_str(Utils.timestamp()),
                 report_url=info.get_report_url(),

--- a/ci/praktika/event.py
+++ b/ci/praktika/event.py
@@ -81,7 +81,7 @@ class EventFeed:
         running_cutoff_timestamp = int(time.time()) - (12 * 60 * 60)
 
         def sanitize_event(e: Event) -> None:
-            if e.timestamp < running_cutoff_timestamp and e.ci_status.upper() in (
+            if e.timestamp < running_cutoff_timestamp and (e.ci_status or "").upper() in (
                 "RUNNING",
                 "PENDING",
             ):

--- a/ci/praktika/event.py
+++ b/ci/praktika/event.py
@@ -36,7 +36,7 @@ class Event:
     timestamp: int  # Unix timestamp when event occurred
     sha: str  # Git commit SHA
     result: dict  # Top-level workflow result
-    ci_status: str  # Overall CI status (success/failure/pending)
+    ci_status: str  # Overall CI status (Result.Status value)
     ext: dict  # Additional extensible metadata (includes: branch, pr_number, pr_status, pr_title)
     linked_events: List["Event"] = dataclasses.field(default_factory=list)
 
@@ -81,11 +81,11 @@ class EventFeed:
         running_cutoff_timestamp = int(time.time()) - (12 * 60 * 60)
 
         def sanitize_event(e: Event) -> None:
-            if e.timestamp < running_cutoff_timestamp and e.ci_status in (
-                "running",
-                "pending",
+            if e.timestamp < running_cutoff_timestamp and e.ci_status.upper() in (
+                "RUNNING",
+                "PENDING",
             ):
-                e.ci_status = "failure"
+                e.ci_status = "FAIL"
                 if not isinstance(e.ext, dict):
                     e.ext = {}
                 e.ext["is_cancelled"] = True

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -621,9 +621,29 @@ class GH:
                 os.unlink(temp_file_path)
         return None
 
+    _STATUS_TO_GH = {
+        Result.Status.OK: Result.GHStatus.SUCCESS,
+        Result.Status.FAIL: Result.GHStatus.FAILURE,
+        Result.Status.ERROR: Result.GHStatus.ERROR,
+        Result.Status.SKIPPED: Result.GHStatus.SUCCESS,
+        Result.Status.PENDING: Result.GHStatus.PENDING,
+        Result.Status.RUNNING: Result.GHStatus.PENDING,
+        Result.Status.DROPPED: Result.GHStatus.ERROR,
+        Result.Status.UNKNOWN: Result.GHStatus.FAILURE,
+        Result.Status.XFAIL: Result.GHStatus.SUCCESS,
+        Result.Status.XPASS: Result.GHStatus.FAILURE,
+    }
+
     @classmethod
     def convert_to_gh_status(cls, status):
-        return Result.convert_to_gh_status(status)
+        """Map Result.Status value to GitHub commit status API string."""
+        gh = cls._STATUS_TO_GH.get(status)
+        if gh is not None:
+            return gh
+        # Already a GH status string — pass through for idempotency
+        _GH_VALUES = set(cls._STATUS_TO_GH.values())
+        assert status in _GH_VALUES, f"Invalid status [{status}] for GH commit status"
+        return status
 
     @classmethod
     def print_log_in_group(cls, group_name: str, lines: Union[str, List[str]]):
@@ -697,7 +717,7 @@ class GH:
             )
 
             # Filter and sort failed/error subresults by priority
-            # Priority: FAILED (0) > ERROR (1) > others (2)
+            # Priority: FAIL (0) > ERROR (1) > others (2)
             def get_status_priority(r):
                 if r.status == Result.Status.FAIL:
                     return 0

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -623,21 +623,7 @@ class GH:
 
     @classmethod
     def convert_to_gh_status(cls, status):
-        if status in (
-            Result.Status.PENDING,
-            Result.Status.SUCCESS,
-            Result.Status.FAILED,
-            Result.Status.ERROR,
-        ):
-            return status
-        if status in Result.Status.RUNNING:
-            return Result.Status.PENDING
-        elif status in Result.Status.DROPPED:
-            return Result.Status.ERROR
-        else:
-            assert (
-                False
-            ), f"Invalid status [{status}] to be set as GH commit status.state"
+        return Result.convert_to_gh_status(status)
 
     @classmethod
     def print_log_in_group(cls, group_name: str, lines: Union[str, List[str]]):
@@ -713,7 +699,7 @@ class GH:
             # Filter and sort failed/error subresults by priority
             # Priority: FAILED (0) > ERROR (1) > others (2)
             def get_status_priority(r):
-                if r.status == Result.Status.FAILED:
+                if r.status == Result.Status.FAIL:
                     return 0
                 elif r.status == Result.Status.ERROR:
                     return 1
@@ -770,9 +756,9 @@ class GH:
                 """Escape pipe characters for markdown tables"""
                 return str(text).replace("|", "\\|")
 
-            if self.status == Result.Status.SUCCESS:
+            if self.status == Result.Status.OK:
                 symbol = "✅"  # Green check mark
-            elif self.status == Result.Status.FAILED:
+            elif self.status == Result.Status.FAIL:
                 symbol = "❌"  # Red cross mark
             else:
                 symbol = "⏳"  # Hourglass (in progress)

--- a/ci/praktika/infrastructure/native/lambda_slack_worker.py
+++ b/ci/praktika/infrastructure/native/lambda_slack_worker.py
@@ -228,7 +228,7 @@ def format_event_text(event, pr_status, indent=""):
     has_failures = False
     if hasattr(event, "result") and event.result and event.result.get("results"):
         has_failures = any(
-            r.get("status") in ["failure", "error"]
+            (r.get("status") or "").lower() in ["failure", "error", "fail"]
             for r in event.result.get("results", [])
         )
 
@@ -293,20 +293,20 @@ def format_event_text(event, pr_status, indent=""):
         total_cnt = 0
 
         for r in event.result.get("results", []):
-            status = r.get("status", "")
+            status = (r.get("status") or "").lower()
             total_cnt += 1
 
-            if status == "failure":
+            if status in ("failure", "fail"):
                 fail_cnt += 1
             elif status == "error":
                 error_cnt += 1
             elif status == "dropped":
                 dropped_cnt += 1
-            elif status == "success":
+            elif status in ("success", "ok"):
                 success_cnt += 1
             elif status == "skipped":
                 skipped_cnt += 1
-            elif status in ["pending", "running"]:
+            elif status in ("pending", "running"):
                 running_cnt += 1
 
         # Build compact one-line summary
@@ -355,7 +355,7 @@ def _format_notification_text(event, notify_type: str) -> str:
         if not isinstance(r, dict):
             continue
         status = (r.get("status") or "").lower()
-        if status not in ("failure", "error"):
+        if status not in ("failure", "error", "fail"):
             continue
         name = r.get("name") or ""
         if name:
@@ -953,7 +953,7 @@ def lambda_handler(event, context):
                 and newest_event.result.get("results")
             ):
                 newest_has_failures = any(
-                    r.get("status") in ["failure", "error"]
+                    (r.get("status") or "").lower() in ["failure", "error", "fail"]
                     for r in newest_event.result.get("results", [])
                 )
 

--- a/ci/praktika/infrastructure/native/lambda_slack_worker.py
+++ b/ci/praktika/infrastructure/native/lambda_slack_worker.py
@@ -233,7 +233,8 @@ def format_event_text(event, pr_status, indent=""):
         )
 
     # CI status emoji based on event.ci_status
-    if event.ci_status in ["pending", "running"]:
+    ci_status_lower = (event.ci_status or "").lower()
+    if ci_status_lower in ("pending", "running"):
         ci_running_status_emoji = ":job_running:"
     else:
         if not is_cancelled:
@@ -241,9 +242,9 @@ def format_event_text(event, pr_status, indent=""):
         else:
             ci_running_status_emoji = ":job_cancelled:"
 
-    if event.ci_status == "success":
+    if ci_status_lower in ("success", "ok"):
         ci_status_emoji = ":success_sign:"
-    elif event.ci_status in ["pending", "running"]:
+    elif ci_status_lower in ("pending", "running"):
         ci_status_emoji = ":failure_sign:" if has_failures else ":job_running:"
     else:
         ci_status_emoji = ":failure_sign:"

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -1438,11 +1438,12 @@
                 if (column === lastColumn) td.classList.add('time-column');
 
                 if (column === 'status') {
+                    const value_ = value ? value.toLowerCase() : "";
                     const span = document.createElement('span');
-                    span.className = getStatusClass(value);
-                    span.textContent = value;
+                    span.className = getStatusClass(value_);
+                    span.textContent = value_;
                     td.classList.add('status-column');
-                    row.dataset.status = value ? value.toLowerCase() : "";
+                    row.dataset.status = value_;
                     if ((result.info && result.info.trim() !== "") || (Array.isArray(result.links) && result.links.length > 0) || (Array.isArray(result.results) && result.results.length > 0)) {
                         span.style.cursor = "pointer";
                         span.addEventListener('click', () => toggleInfoRow(row, result.info, result.results, result.links));

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -602,16 +602,15 @@
     function getStatusPriority(status) {
         const statusLower = (status || '').toLowerCase();
         if (statusLower.includes('error')) return 0;
-        if (statusLower.includes('fail')) return 1;
+        if (statusLower.includes('fail') && statusLower !== 'xfail') return 1;
         if (statusLower === 'xpass') return 2;
         if (statusLower.includes('running')) return 3;
         if (statusLower.includes('dropped')) return 4;
         if (statusLower.includes('pending')) return 5;
-        if (statusLower.includes('success')) return 6;
-        if (statusLower === 'ok') return 7;
-        if (statusLower === 'xfail') return 8;
-        if (statusLower.includes('skipped')) return 9;
-        return 10;
+        if (statusLower === 'ok' || statusLower.includes('success')) return 6;
+        if (statusLower === 'xfail') return 7;
+        if (statusLower.includes('skipped')) return 8;
+        return 9;
     }
 
     function formatTimestamp(timestamp, showDate = true) {
@@ -1202,7 +1201,8 @@
                     x = 0;
                     width = canvas.width;
                     const getCss = (name) => getComputedStyle(document.body).getPropertyValue(name).trim();
-                    color = task.status === "pending" ? getCss('--pending-bar-color') : getCss('--skipped-bar-color');
+                    const sl = (task.status || '').toLowerCase();
+                    color = sl === "pending" ? getCss('--pending-bar-color') : getCss('--skipped-bar-color');
                 } else if (task.duration === null) {
                     x = (task.start_time - minStartTime) * scaleX;
                     width = (maxTime - (task.start_time - minStartTime)) * scaleX;
@@ -1219,7 +1219,8 @@
                 taskRects.push({ x, y, width, height, task });
 
                 // Save failure marker position for second pass
-                if (task.status === "failure" || task.status === "error" || task.status === "dropped") {
+                const tsl = (task.status || '').toLowerCase();
+                if (tsl === "fail" || tsl === "failure" || tsl === "error" || tsl === "dropped") {
                     failedMarkers.push({ x: x + width, y: y + height / 2 });
                 }
             });
@@ -2098,11 +2099,11 @@
 
                 if (nameParams?.length === 1) {
                     // For single-level results, check json0 status
-                    shouldContinue = ["running", "pending"].includes(runtimeCache?.json0?.status);
+                    shouldContinue = ["running", "pending"].includes((runtimeCache?.json0?.status || '').toLowerCase());
                 } else if (nameParams?.length === 2) {
                     // For two-level results, check json1 status (or json0 if json1 is null)
                     if (runtimeCache?.json1) {
-                        shouldContinue = ["running", "pending"].includes(runtimeCache?.json1?.status);
+                        shouldContinue = ["running", "pending"].includes((runtimeCache?.json1?.status || '').toLowerCase());
                     } else {
                         // If json1 is null, we might still be loading, so continue
                         shouldContinue = true;

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -283,12 +283,16 @@
         }
 
         th.name-column, td.name-column,
-        th.status-column, td.status-column,
         td.dur-column, th.dur-column {
             width: 1px;
             max-width: fit-content;
             overflow: hidden;
             text-overflow: ellipsis;
+        }
+        th.status-column, td.status-column {
+            width: 1px;
+            max-width: fit-content;
+            text-align: center;
         }
 
         td.dur-column {

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -113,7 +113,7 @@ def _build_dockers(workflow, job_name):
     dockers = workflow.dockers
     ready = []
     results = []
-    job_status = Result.Status.SUCCESS
+    job_status = Result.Status.OK
     job_info = ""
     dockers = Docker.sort_in_build_order(dockers)
     for d in dockers:
@@ -144,19 +144,19 @@ def _build_dockers(workflow, job_name):
             "docker buildx create --use --name mybuilder --driver docker-container",
             verbose=True,
         ):
-            job_status = Result.Status.FAILED
+            job_status = Result.Status.FAIL
             job_info = "Failed to install docker buildx driver"
 
-    if job_status == Result.Status.SUCCESS:
+    if job_status == Result.Status.OK:
         if not Info().is_local_run and not Docker.login(
             Settings.DOCKERHUB_USERNAME,
             user_password=workflow.get_secret(Settings.DOCKERHUB_SECRET).get_value(),
         ):
-            job_status = Result.Status.FAILED
+            job_status = Result.Status.FAIL
             job_info = "Failed to login to dockerhub"
 
     if (
-        job_status == Result.Status.SUCCESS
+        job_status == Result.Status.OK
         and job_name != Settings.DOCKER_BUILD_MANIFEST_JOB_NAME
     ):
         for docker in dockers:
@@ -189,11 +189,11 @@ def _build_dockers(workflow, job_name):
             if results[-1].is_ok():
                 ready.append(docker.name)
             else:
-                job_status = Result.Status.FAILED
+                job_status = Result.Status.FAIL
                 break
 
     if (
-        job_status == Result.Status.SUCCESS
+        job_status == Result.Status.OK
         and job_name == Settings.DOCKER_BUILD_MANIFEST_JOB_NAME
     ):
         print("Start docker manifest merge")
@@ -234,7 +234,7 @@ def _prepare_submodule_cache(workflow_config: RunConfig) -> Result:
             print("WARNING: No submodules found, skipping submodule cache")
             return Result.create_from(
                 name="Submodule Cache",
-                status=Result.Status.SUCCESS,
+                status=Result.Status.OK,
                 stopwatch=stop_watch,
                 info="No submodules",
             )
@@ -269,12 +269,12 @@ def _prepare_submodule_cache(workflow_config: RunConfig) -> Result:
 
         workflow_config.submodule_cache_hash = cache_hash
         workflow_config.dump()
-        status = Result.Status.SUCCESS
+        status = Result.Status.OK
     except Exception as e:
         print(f"WARNING: Submodule cache failed: {e}")
         traceback.print_exc()
         info = f"{e}\n{traceback.format_exc()}"
-        status = Result.Status.SUCCESS  # non-fatal, jobs fall back to GitHub clone
+        status = Result.Status.OK  # non-fatal, jobs fall back to GitHub clone
 
     return Result.create_from(
         name="Submodule Cache",
@@ -315,7 +315,7 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
         info = "\n".join(infos)
         return Result(
             name="Check Secrets",
-            status=(Result.Status.FAILED if infos else Result.Status.SUCCESS),
+            status=(Result.Status.FAIL if infos else Result.Status.OK),
             start_time=stop_watch.start_time,
             duration=stop_watch.duration,
             info=info,
@@ -330,7 +330,7 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
         ).check()
         return Result(
             name="Check CI DB",
-            status=(Result.Status.FAILED if not res else Result.Status.SUCCESS),
+            status=(Result.Status.FAIL if not res else Result.Status.OK),
             start_time=stop_watch.start_time,
             duration=stop_watch.duration,
             info=info,
@@ -446,7 +446,7 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
     # checks:
     if not results or results[-1].is_ok():
         result_ = _check_yaml_up_to_date()
-        if result_.status != Result.Status.SUCCESS:
+        if result_.status != Result.Status.OK:
             print("ERROR: yaml files are outdated - regenerate, commit and push")
         results.append(result_)
 
@@ -454,7 +454,7 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
     #       An error occurred (ThrottlingException) when calling the GetParameter operation (reached max retries: 2): Rate exceeded
     # if results[-1].is_ok() and workflow.secrets:
     #     result_ = _check_secrets(workflow.secrets)
-    #     if result_.status != Result.Status.SUCCESS:
+    #     if result_.status != Result.Status.OK:
     #         print(f"ERROR: Invalid secrets in workflow [{workflow.name}]")
     #     results.append(result_)
 
@@ -481,7 +481,7 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
         results.append(
             Result.create_from(
                 name="Calculate docker digests",
-                status=Result.Status.SUCCESS,
+                status=Result.Status.OK,
                 stopwatch=sw_,
             )
         )
@@ -500,7 +500,7 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
                         )
                         workflow_config.set_job_as_filtered(job.name, reason)
                         continue
-            status = Result.Status.SUCCESS
+            status = Result.Status.OK
             workflow_config.dump()
             info = ""
         except Exception as e:
@@ -609,7 +609,7 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
         results.append(
             Result(
                 name="Cache Lookup",
-                status=Result.Status.SUCCESS if res else Result.Status.FAILED,
+                status=Result.Status.OK if res else Result.Status.FAIL,
                 start_time=stop_watch.start_time,
                 duration=stop_watch.duration,
                 info=info,
@@ -703,7 +703,7 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
         results.append(
             Result(
                 name="Init Report",
-                status=Result.Status.SUCCESS,
+                status=Result.Status.OK,
                 start_time=stop_watch.start_time,
                 duration=stop_watch.duration,
             )
@@ -796,7 +796,7 @@ def _finish_workflow(workflow, job_name):
             Result.create_from(name="Post Hooks", results=results_, stopwatch=sw_)
         )
 
-    ready_for_merge_status = Result.Status.SUCCESS
+    ready_for_merge_status = Result.Status.OK
     ready_for_merge_description = ""
     failed_results = []
     dropped_results = []
@@ -807,7 +807,7 @@ def _finish_workflow(workflow, job_name):
     for result in workflow_result.results:
         if result.name == job_name:
             continue
-        if result.status == Result.Status.SUCCESS:
+        if result.status == Result.Status.OK:
             continue
         if result.status == Result.Status.SKIPPED:
             continue
@@ -852,7 +852,7 @@ def _finish_workflow(workflow, job_name):
                 print(
                     f"NOTE: not finished job [{result.name}] in the workflow but GitHub status is [{gh_job_result}] - set status to success"
                 )
-                result.status = Result.Status.SUCCESS
+                result.status = Result.Status.OK
                 workflow_result.dump()
                 update_final_report = True
                 continue
@@ -876,7 +876,7 @@ def _finish_workflow(workflow, job_name):
             failed_results.append(result.name)
 
     if failed_results or dropped_results:
-        ready_for_merge_status = Result.Status.FAILED
+        ready_for_merge_status = Result.Status.FAIL
         failed_jobs_csv = ",".join(failed_results)
         if failed_jobs_csv and len(failed_jobs_csv) < 80:
             ready_for_merge_description = f"Failed: {failed_jobs_csv}"
@@ -890,11 +890,11 @@ def _finish_workflow(workflow, job_name):
         fast_test_failed = any(
             "Fast test" in name for name in failed_results
         )
-        if not fast_test_failed and ready_for_merge_status != Result.Status.SUCCESS:
+        if not fast_test_failed and ready_for_merge_status != Result.Status.OK:
             print(
                 f"NOTE: Revert PR detected - setting merge status to success despite failures"
             )
-            ready_for_merge_status = Result.Status.SUCCESS
+            ready_for_merge_status = Result.Status.OK
             ready_for_merge_description = "Revert PR"
 
     if workflow.enable_merge_ready_status:
@@ -917,7 +917,7 @@ def _finish_workflow(workflow, job_name):
         )
     else:
         return Result.create_from(
-            name=job_name, status=Result.Status.SUCCESS, stopwatch=stop_watch
+            name=job_name, status=Result.Status.OK, stopwatch=stop_watch
         )
 
 

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -53,19 +53,11 @@ class Result(MetaClasses.Serializable):
         info (str): Additional information about the result. Free-form text.
 
     Inner Class:
-        Status: Defines possible statuses for the task, such as "success", "failure", etc.
+        Status: Defines possible statuses for the result.
     """
 
     class Status:
-        SKIPPED = "skipped"
-        DROPPED = "dropped"
-        SUCCESS = "success"
-        FAILED = "failure"
-        PENDING = "pending"
-        RUNNING = "running"
-        ERROR = "error"
-
-    class StatusExtended:
+        # Outcome statuses (used for both job-level and sub-result/test-level results)
         OK = "OK"
         FAIL = "FAIL"
         SKIPPED = "SKIPPED"
@@ -73,6 +65,18 @@ class Result(MetaClasses.Serializable):
         UNKNOWN = "UNKNOWN"
         XFAIL = "XFAIL"  # expected failure: test failed as expected, not a problem
         XPASS = "XPASS"  # unexpected pass: test was expected to fail but passed
+        # Lifecycle statuses (used for job-level and workflow-level results)
+        PENDING = "PENDING"
+        RUNNING = "RUNNING"
+        DROPPED = "DROPPED"
+
+    class GHStatus:
+        """GitHub commit status API values — the only four strings GH accepts."""
+
+        PENDING = "pending"
+        SUCCESS = "success"
+        FAILURE = "failure"
+        ERROR = "error"
 
     class Label:
         OK_ON_RETRY = "retry_ok"
@@ -106,7 +110,7 @@ class Result(MetaClasses.Serializable):
         labels=None,
     ) -> "Result":
         if isinstance(status, bool):
-            status = Result.Status.SUCCESS if status else Result.Status.FAILED
+            status = Result.Status.OK if status else Result.Status.FAIL
         if not results and not status:
             print(
                 "WARNING: No results and no status provided - setting status to error"
@@ -129,7 +133,7 @@ class Result(MetaClasses.Serializable):
             start_time = stopwatch.start_time
             duration = stopwatch.duration
 
-        result_status = status or Result.Status.SUCCESS
+        result_status = status or Result.Status.OK
         infos = []
         if info:
             if isinstance(info, str):
@@ -139,26 +143,22 @@ class Result(MetaClasses.Serializable):
         if results and not status:
             for result in results:
                 if result.status in (
-                    Result.Status.SUCCESS,
+                    Result.Status.OK,
                     Result.Status.SKIPPED,
-                    Result.StatusExtended.OK,
-                    Result.StatusExtended.SKIPPED,
-                    Result.StatusExtended.XFAIL,
+                    Result.Status.XFAIL,
                 ):
                     continue
                 elif result.status in (
                     Result.Status.ERROR,
-                    Result.StatusExtended.ERROR,
                 ):
                     result_status = Result.Status.ERROR
                     break
                 elif result.status in (
-                    Result.Status.FAILED,
-                    Result.StatusExtended.FAIL,
-                    Result.StatusExtended.UNKNOWN,
-                    Result.StatusExtended.XPASS,
+                    Result.Status.FAIL,
+                    Result.Status.UNKNOWN,
+                    Result.Status.XPASS,
                 ):
-                    result_status = Result.Status.FAILED
+                    result_status = Result.Status.FAIL
                 else:
                     Utils.raise_with_error(
                         f"Unexpected result status [{result.status}] for [{result.name}]"
@@ -208,24 +208,19 @@ class Result(MetaClasses.Serializable):
 
     def is_ok(self):
         return self.status in (
+            Result.Status.OK,
             Result.Status.SKIPPED,
-            Result.Status.SUCCESS,
-            Result.StatusExtended.OK,
-            Result.StatusExtended.SKIPPED,
-            Result.StatusExtended.XFAIL,
+            Result.Status.XFAIL,
         )
 
     def is_success(self):
-        return self.status in (Result.Status.SUCCESS, Result.StatusExtended.OK, Result.StatusExtended.XFAIL)
+        return self.status in (Result.Status.OK, Result.Status.XFAIL)
 
     def is_failure(self):
-        return self.status in (Result.Status.FAILED, Result.StatusExtended.FAIL, Result.StatusExtended.XPASS)
+        return self.status in (Result.Status.FAIL, Result.Status.XPASS)
 
     def is_error(self):
-        return self.status in (Result.Status.ERROR, Result.StatusExtended.ERROR)
-
-    def is_dropped(self):
-        return self.status in (Result.Status.DROPPED,)
+        return self.status in (Result.Status.ERROR,)
 
     def _dump_if_persisted(self) -> "Result":
         """Dump only if a result file already exists on disk.
@@ -251,13 +246,63 @@ class Result(MetaClasses.Serializable):
         return self
 
     def set_success(self) -> "Result":
-        return self.set_status(Result.Status.SUCCESS)
+        return self.set_status(Result.Status.OK)
 
     def set_failed(self) -> "Result":
-        return self.set_status(Result.Status.FAILED)
+        return self.set_status(Result.Status.FAIL)
 
     def set_error(self) -> "Result":
         return self.set_status(Result.Status.ERROR)
+
+    def to_gh_status(self) -> str:
+        """Map Result status to GitHub commit status API string."""
+        return Result.convert_to_gh_status(self.status)
+
+    @staticmethod
+    def convert_to_gh_status(status: str) -> str:
+        """Map any Result.Status value to a GitHub commit status API string."""
+        _MAP = {
+            Result.Status.OK: Result.GHStatus.SUCCESS,
+            Result.Status.FAIL: Result.GHStatus.FAILURE,
+            Result.Status.ERROR: Result.GHStatus.ERROR,
+            Result.Status.SKIPPED: Result.GHStatus.SUCCESS,
+            Result.Status.PENDING: Result.GHStatus.PENDING,
+            Result.Status.RUNNING: Result.GHStatus.PENDING,
+            Result.Status.DROPPED: Result.GHStatus.ERROR,
+            Result.Status.UNKNOWN: Result.GHStatus.FAILURE,
+            Result.Status.XFAIL: Result.GHStatus.SUCCESS,
+            Result.Status.XPASS: Result.GHStatus.FAILURE,
+        }
+        gh = _MAP.get(status)
+        if gh is not None:
+            return gh
+        # Already a GH status string — pass through for idempotency
+        _GH_VALUES = {Result.GHStatus.PENDING, Result.GHStatus.SUCCESS, Result.GHStatus.FAILURE, Result.GHStatus.ERROR}
+        assert status in _GH_VALUES, f"Invalid status [{status}] for GH commit status"
+        return status
+
+    @staticmethod
+    def convert_to_cidb_status(status: str) -> str:
+        """Map any Result.Status value to the legacy CIDB check_status string."""
+        _MAP = {
+            Result.Status.OK: "success",
+            Result.Status.FAIL: "failure",
+            Result.Status.ERROR: "error",
+            Result.Status.SKIPPED: "skipped",
+            Result.Status.PENDING: "pending",
+            Result.Status.RUNNING: "running",
+            Result.Status.DROPPED: "dropped",
+            Result.Status.UNKNOWN: "failure",
+            Result.Status.XFAIL: "success",
+            Result.Status.XPASS: "failure",
+        }
+        legacy = _MAP.get(status)
+        if legacy is not None:
+            return legacy
+        # Already a legacy string — pass through for idempotency
+        _LEGACY_VALUES = set(_MAP.values())
+        assert status in _LEGACY_VALUES, f"Invalid status [{status}] for CIDB check_status"
+        return status
 
     def set_results(self, results: List["Result"]) -> "Result":
         self.results = results
@@ -584,8 +629,8 @@ class Result(MetaClasses.Serializable):
                 self.Status.ERROR,
                 self.Status.FAILED,
                 self.Status.DROPPED,
-                self.StatusExtended.FAIL,
-                self.StatusExtended.UNKNOWN,
+                self.Status.FAIL,
+                self.Status.UNKNOWN,
             ):
                 has_failed = True
         if has_running:
@@ -1021,7 +1066,7 @@ class Result(MetaClasses.Serializable):
             type=Event.Type.COMPLETED if self.is_completed() else Event.Type.RUNNING,
             timestamp=int(time.time()),
             sha=info.sha,
-            ci_status=self.status,
+            ci_status=Result.convert_to_cidb_status(self.status),
             result=result_dict,
             ext={
                 "pr_number": info.pr_number,
@@ -1391,7 +1436,7 @@ class ResultTranslator:
                 if "failures" in test_case:
                     raw_logs = ""
                     for failure in test_case["failures"]:
-                        raw_logs += failure[Result.Status.FAILED]
+                        raw_logs += failure["failure"]
                     if (
                         "Segmentation fault" in raw_logs  # type: ignore
                         and SEGFAULT not in description
@@ -1403,11 +1448,11 @@ class ResultTranslator:
                     ):
                         description += SIGNAL
                 if test_case["status"] == "NOTRUN":
-                    test_status = "SKIPPED"
+                    test_status = Result.Status.SKIPPED
                 elif raw_logs is None:
-                    test_status = Result.Status.SUCCESS
+                    test_status = Result.Status.OK
                 else:
-                    test_status = Result.Status.FAILED
+                    test_status = Result.Status.FAIL
 
                 test_results.append(
                     Result(
@@ -1418,12 +1463,12 @@ class ResultTranslator:
                     )
                 )
 
-        check_status = Result.Status.SUCCESS
-        test_status = Result.Status.SUCCESS
+        check_status = Result.Status.OK
+        test_status = Result.Status.OK
         tests_time = float(report["time"][:-1])
         if failed_counter:
-            check_status = Result.Status.FAILED
-            test_status = Result.Status.FAILED
+            check_status = Result.Status.FAIL
+            test_status = Result.Status.FAIL
         if error_counter:
             check_status = Result.Status.ERROR
             test_status = Result.Status.ERROR
@@ -1572,7 +1617,7 @@ class ResultTranslator:
                                 # Create a result for the module/node that failed to collect
                                 test_results[node_id or "<collection>"] = Result(
                                     name=node_id or "<collection>",
-                                    status=Result.StatusExtended.ERROR,
+                                    status=Result.Status.ERROR,
                                     duration=None,
                                     info="\n".join([p for p in info_parts if p]),
                                 )
@@ -1738,19 +1783,19 @@ class ResultTranslator:
 
                             # Map pytest outcome to Result status
                             status = {
-                                "passed": Result.StatusExtended.OK,
-                                "failed": Result.StatusExtended.FAIL,
-                                "skipped": Result.StatusExtended.SKIPPED,
-                                "xfailed": Result.StatusExtended.XFAIL,  # expected failure: OK
-                                "xpassed": Result.StatusExtended.XPASS,  # unexpected pass: fails job
-                                "error": Result.StatusExtended.ERROR,
-                            }.get(outcome, Result.StatusExtended.ERROR)
+                                "passed": Result.Status.OK,
+                                "failed": Result.Status.FAIL,
+                                "skipped": Result.Status.SKIPPED,
+                                "xfailed": Result.Status.XFAIL,  # expected failure: OK
+                                "xpassed": Result.Status.XPASS,  # unexpected pass: fails job
+                                "error": Result.Status.ERROR,
+                            }.get(outcome, Result.Status.ERROR)
 
                             # Track failures by phase (XFAIL is not a failure)
                             if status in (
-                                Result.StatusExtended.FAIL,
-                                Result.StatusExtended.ERROR,
-                                Result.StatusExtended.XPASS,
+                                Result.Status.FAIL,
+                                Result.Status.ERROR,
+                                Result.Status.XPASS,
                             ):
                                 if node_id not in test_failures:
                                     test_failures[node_id] = {}
@@ -1795,8 +1840,8 @@ class ResultTranslator:
 
                                 # Always override with a failure, or keep existing failure
                                 _failure_statuses = (
-                                    Result.StatusExtended.FAIL,
-                                    Result.StatusExtended.XPASS,
+                                    Result.Status.FAIL,
+                                    Result.Status.XPASS,
                                 )
                                 if (
                                     status in _failure_statuses
@@ -1815,9 +1860,9 @@ class ResultTranslator:
                                         )
                                 # Only update with non-failure if there's no existing failure
                                 elif test_results[node_id].status not in (
-                                    Result.StatusExtended.FAIL,
-                                    Result.StatusExtended.ERROR,
-                                    Result.StatusExtended.XPASS,
+                                    Result.Status.FAIL,
+                                    Result.Status.ERROR,
+                                    Result.Status.XPASS,
                                 ):
                                     # For non-failures, prefer 'call' phase over others
                                     if when == "call":
@@ -1843,15 +1888,15 @@ class ResultTranslator:
 
             if session_exitstatus == 0:
                 # pytest exit code 0 means all tests passed or xfailed (from pytest's perspective).
-                # We additionally treat XPASS as a failure, so FAILED is also valid here.
+                # We additionally treat XPASS as a failure, so FAIL is also valid here.
                 assert R.status in (
-                    Result.Status.SUCCESS,
-                    Result.Status.FAILED,
+                    Result.Status.OK,
+                    Result.Status.FAIL,
                 ), f"pytest session exit code 0 does not match autogenerated status [{R.status}]"
                 return R
 
             if session_exitstatus == 1:
-                if R.status == Result.Status.SUCCESS:
+                if R.status == Result.Status.OK:
                     print(
                         f"WARNING: Tests are all OK, but exit code is 1; timeout or other runner issue - reset overall status to [{Result.Status.ERROR}]"
                     )

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -254,56 +254,6 @@ class Result(MetaClasses.Serializable):
     def set_error(self) -> "Result":
         return self.set_status(Result.Status.ERROR)
 
-    def to_gh_status(self) -> str:
-        """Map Result status to GitHub commit status API string."""
-        return Result.convert_to_gh_status(self.status)
-
-    @staticmethod
-    def convert_to_gh_status(status: str) -> str:
-        """Map any Result.Status value to a GitHub commit status API string."""
-        _MAP = {
-            Result.Status.OK: Result.GHStatus.SUCCESS,
-            Result.Status.FAIL: Result.GHStatus.FAILURE,
-            Result.Status.ERROR: Result.GHStatus.ERROR,
-            Result.Status.SKIPPED: Result.GHStatus.SUCCESS,
-            Result.Status.PENDING: Result.GHStatus.PENDING,
-            Result.Status.RUNNING: Result.GHStatus.PENDING,
-            Result.Status.DROPPED: Result.GHStatus.ERROR,
-            Result.Status.UNKNOWN: Result.GHStatus.FAILURE,
-            Result.Status.XFAIL: Result.GHStatus.SUCCESS,
-            Result.Status.XPASS: Result.GHStatus.FAILURE,
-        }
-        gh = _MAP.get(status)
-        if gh is not None:
-            return gh
-        # Already a GH status string — pass through for idempotency
-        _GH_VALUES = {Result.GHStatus.PENDING, Result.GHStatus.SUCCESS, Result.GHStatus.FAILURE, Result.GHStatus.ERROR}
-        assert status in _GH_VALUES, f"Invalid status [{status}] for GH commit status"
-        return status
-
-    @staticmethod
-    def convert_to_cidb_status(status: str) -> str:
-        """Map any Result.Status value to the legacy CIDB check_status string."""
-        _MAP = {
-            Result.Status.OK: "success",
-            Result.Status.FAIL: "failure",
-            Result.Status.ERROR: "error",
-            Result.Status.SKIPPED: "skipped",
-            Result.Status.PENDING: "pending",
-            Result.Status.RUNNING: "running",
-            Result.Status.DROPPED: "dropped",
-            Result.Status.UNKNOWN: "failure",
-            Result.Status.XFAIL: "success",
-            Result.Status.XPASS: "failure",
-        }
-        legacy = _MAP.get(status)
-        if legacy is not None:
-            return legacy
-        # Already a legacy string — pass through for idempotency
-        _LEGACY_VALUES = set(_MAP.values())
-        assert status in _LEGACY_VALUES, f"Invalid status [{status}] for CIDB check_status"
-        return status
-
     def set_results(self, results: List["Result"]) -> "Result":
         self.results = results
         self._dump_if_persisted()
@@ -1066,7 +1016,7 @@ class Result(MetaClasses.Serializable):
             type=Event.Type.COMPLETED if self.is_completed() else Event.Type.RUNNING,
             timestamp=int(time.time()),
             sha=info.sha,
-            ci_status=Result.convert_to_cidb_status(self.status),
+            ci_status=self.status,
             result=result_dict,
             ext={
                 "pr_number": info.pr_number,

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -627,10 +627,10 @@ class Result(MetaClasses.Serializable):
                 has_pending = True
             if result_.status in (
                 self.Status.ERROR,
-                self.Status.FAILED,
                 self.Status.DROPPED,
                 self.Status.FAIL,
                 self.Status.UNKNOWN,
+                self.Status.XPASS,
             ):
                 has_failed = True
         if has_running:
@@ -638,9 +638,9 @@ class Result(MetaClasses.Serializable):
         elif has_pending:
             self.status = self.Status.PENDING
         elif has_failed:
-            self.status = self.Status.FAILED
+            self.status = self.Status.FAIL
         else:
-            self.status = self.Status.SUCCESS
+            self.status = self.Status.OK
         if (was_pending or was_running) and self.status not in (
             self.Status.PENDING,
             self.Status.RUNNING,

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -761,7 +761,7 @@ class Runner:
                 if _GH_Auth():
                     GH.post_commit_status(
                         name=workflow.name,
-                        status=GH.convert_to_gh_status(status_updated),
+                        status=status_updated,
                         description="",
                         url=Info().get_report_url(latest=False),
                     )
@@ -843,13 +843,13 @@ class Runner:
                 traceback.print_exc()
 
         # finally, set the status flag for GH Actions
-        pipeline_status = Result.Status.SUCCESS
+        pipeline_status = Result.Status.OK
         if not result.is_ok():
             if result.is_failure() and result.do_not_block_pipeline_on_failure():
                 # job explicitly says to not block ci even though result is failure
                 pass
             else:
-                pipeline_status = Result.Status.FAILED
+                pipeline_status = Result.Status.FAIL
         with open(env.JOB_OUTPUT_STREAM, "a", encoding="utf8") as f:
             print(
                 f"pipeline_status={pipeline_status}",

--- a/ci/tests/test_cidb.py
+++ b/ci/tests/test_cidb.py
@@ -1,0 +1,117 @@
+"""
+Tests for CIDB.convert_status mapping.
+
+Adding a new Result.Status value requires updating CIDB._STATUS_TO_CIDB.
+These tests verify that every status is mapped and TableRecord auto-converts.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.praktika.result import Result
+from ci.praktika.cidb import CIDB
+from ci.tests.test_result import ALL_STATUSES
+
+
+# The set of valid legacy CIDB check_status strings
+VALID_CIDB_STATUSES = {"success", "failure", "error", "skipped", "pending", "running", "dropped"}
+
+
+def test_all_statuses_mapped():
+    """Every Result.Status value must have a CIDB mapping."""
+    for status in ALL_STATUSES:
+        legacy = CIDB.convert_status(status)
+        assert legacy, f"No CIDB mapping for {status}"
+
+
+def test_mapping_values_are_valid():
+    """All mapped values must be known legacy strings."""
+    for status in ALL_STATUSES:
+        legacy = CIDB.convert_status(status)
+        assert legacy in VALID_CIDB_STATUSES, (
+            f"CIDB mapping for {status} is {legacy!r}, not a valid CIDB status"
+        )
+
+
+def test_expected_mappings():
+    assert CIDB.convert_status(Result.Status.OK) == "success"
+    assert CIDB.convert_status(Result.Status.FAIL) == "failure"
+    assert CIDB.convert_status(Result.Status.ERROR) == "error"
+    assert CIDB.convert_status(Result.Status.SKIPPED) == "skipped"
+    assert CIDB.convert_status(Result.Status.PENDING) == "pending"
+    assert CIDB.convert_status(Result.Status.RUNNING) == "running"
+    assert CIDB.convert_status(Result.Status.DROPPED) == "dropped"
+    assert CIDB.convert_status(Result.Status.UNKNOWN) == "failure"
+    assert CIDB.convert_status(Result.Status.XFAIL) == "success"
+    assert CIDB.convert_status(Result.Status.XPASS) == "failure"
+
+
+def test_idempotent():
+    """Passing an already-converted legacy string should return it unchanged."""
+    for legacy in VALID_CIDB_STATUSES:
+        assert CIDB.convert_status(legacy) == legacy
+
+
+def test_invalid_status_asserts():
+    """Unknown strings must raise."""
+    try:
+        CIDB.convert_status("bogus")
+        assert False, "Should have raised"
+    except AssertionError:
+        pass
+
+
+def test_table_record_auto_converts():
+    """TableRecord.__post_init__ must convert Result.Status to legacy string."""
+    record = CIDB.TableRecord(
+        pull_request_number=0,
+        commit_sha="abc",
+        commit_url="",
+        check_name="test",
+        check_status=Result.Status.OK,
+        check_duration_ms=0,
+        check_start_time=0,
+        report_url="",
+        pull_request_url="",
+        base_ref="",
+        base_repo="",
+        head_ref="",
+        head_repo="",
+        task_url="",
+        instance_type="",
+        instance_id="",
+        test_name="",
+        test_status="OK",
+        test_duration_ms=None,
+        test_context_raw="",
+    )
+    assert record.check_status == "success"
+
+
+def test_table_record_preserves_legacy():
+    """TableRecord must not break if check_status is already a legacy string."""
+    record = CIDB.TableRecord(
+        pull_request_number=0,
+        commit_sha="abc",
+        commit_url="",
+        check_name="test",
+        check_status="failure",
+        check_duration_ms=0,
+        check_start_time=0,
+        report_url="",
+        pull_request_url="",
+        base_ref="",
+        base_repo="",
+        head_ref="",
+        head_repo="",
+        task_url="",
+        instance_type="",
+        instance_id="",
+        test_name="",
+        test_status="FAIL",
+        test_duration_ms=None,
+        test_context_raw="",
+    )
+    assert record.check_status == "failure"

--- a/ci/tests/test_event.py
+++ b/ci/tests/test_event.py
@@ -1,0 +1,73 @@
+"""
+Tests for Event ci_status handling.
+
+The Event.ci_status field stores Result.Status values directly.
+The EventFeed sanitizer must handle both old (lowercase) and new (uppercase) formats.
+"""
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.praktika.event import Event, EventFeed
+
+
+def _make_event(ci_status, timestamp=None, pr_number=1, sha="abc123"):
+    return Event(
+        type=Event.Type.RUNNING,
+        timestamp=timestamp or int(time.time()),
+        sha=sha,
+        result={},
+        ci_status=ci_status,
+        ext={"pr_number": pr_number, "repo_name": "test/repo"},
+    )
+
+
+def _sanitize_via_feed(event):
+    """Run the sanitize logic by adding the event to a feed."""
+    feed = EventFeed()
+    feed.add(event)
+    return feed.events[0]
+
+
+def test_event_stores_status_directly():
+    """ci_status should store the value as-is, no conversion."""
+    e = _make_event("OK")
+    assert e.ci_status == "OK"
+
+
+def test_sanitize_stale_running_new_format():
+    """Stale RUNNING events should be marked as FAIL."""
+    old_ts = int(time.time()) - 13 * 3600  # 13 hours ago
+    e = _sanitize_via_feed(_make_event("RUNNING", timestamp=old_ts))
+    assert e.ci_status == "FAIL"
+    assert e.ext.get("is_cancelled") is True
+
+
+def test_sanitize_stale_pending_new_format():
+    """Stale PENDING events should be marked as FAIL."""
+    old_ts = int(time.time()) - 13 * 3600
+    e = _sanitize_via_feed(_make_event("PENDING", timestamp=old_ts))
+    assert e.ci_status == "FAIL"
+
+
+def test_sanitize_stale_running_old_format():
+    """Stale events with old lowercase format should also be handled."""
+    old_ts = int(time.time()) - 13 * 3600
+    e = _sanitize_via_feed(_make_event("running", timestamp=old_ts))
+    assert e.ci_status == "FAIL"
+
+
+def test_sanitize_fresh_running_untouched():
+    """Recent RUNNING events should not be modified."""
+    e = _sanitize_via_feed(_make_event("RUNNING"))
+    assert e.ci_status == "RUNNING"
+
+
+def test_sanitize_completed_untouched():
+    """Completed events should not be modified regardless of age."""
+    old_ts = int(time.time()) - 13 * 3600
+    e = _sanitize_via_feed(_make_event("OK", timestamp=old_ts))
+    assert e.ci_status == "OK"

--- a/ci/tests/test_gh.py
+++ b/ci/tests/test_gh.py
@@ -1,0 +1,77 @@
+"""
+Tests for GH.convert_to_gh_status mapping.
+
+Adding a new Result.Status value requires updating GH._STATUS_TO_GH.
+These tests verify that every status is mapped and the mapping is correct.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.praktika.result import Result
+from ci.praktika.gh import GH
+from ci.tests.test_result import ALL_STATUSES, _get_class_constants
+
+
+def test_all_statuses_mapped():
+    """Every Result.Status value must have a GH mapping."""
+    for status in ALL_STATUSES:
+        gh = GH.convert_to_gh_status(status)
+        assert gh, f"No GH mapping for {status}"
+
+
+def test_mapping_values_are_valid_gh_statuses():
+    """GH API only accepts these four strings."""
+    valid = _get_class_constants(Result.GHStatus)
+    for status in ALL_STATUSES:
+        gh = GH.convert_to_gh_status(status)
+        assert gh in valid, f"GH mapping for {status} is {gh!r}, not a valid GH status"
+
+
+def test_expected_mappings():
+    assert GH.convert_to_gh_status(Result.Status.OK) == "success"
+    assert GH.convert_to_gh_status(Result.Status.FAIL) == "failure"
+    assert GH.convert_to_gh_status(Result.Status.ERROR) == "error"
+    assert GH.convert_to_gh_status(Result.Status.SKIPPED) == "success"
+    assert GH.convert_to_gh_status(Result.Status.PENDING) == "pending"
+    assert GH.convert_to_gh_status(Result.Status.RUNNING) == "pending"
+    assert GH.convert_to_gh_status(Result.Status.DROPPED) == "error"
+    assert GH.convert_to_gh_status(Result.Status.UNKNOWN) == "failure"
+    assert GH.convert_to_gh_status(Result.Status.XFAIL) == "success"
+    assert GH.convert_to_gh_status(Result.Status.XPASS) == "failure"
+
+
+def test_idempotent():
+    """Passing an already-converted GH string should return it unchanged."""
+    for gh_val in _get_class_constants(Result.GHStatus):
+        assert GH.convert_to_gh_status(gh_val) == gh_val
+
+
+def test_invalid_status_asserts():
+    """Unknown strings must raise."""
+    try:
+        GH.convert_to_gh_status("bogus")
+        assert False, "Should have raised"
+    except AssertionError:
+        pass
+
+
+def test_post_commit_status_converts_transparently(monkeypatch):
+    """post_commit_status must accept Result.Status values and convert them."""
+    captured = {}
+
+    def fake_do_command(cmd):
+        captured["cmd"] = cmd
+        return True
+
+    monkeypatch.setattr(GH, "do_command_with_retries", staticmethod(fake_do_command))
+    monkeypatch.setenv("GITHUB_REPOSITORY", "test/repo")
+    monkeypatch.setenv("SHA", "abc123")
+
+    GH.post_commit_status(
+        name="test", status=Result.Status.OK, description="ok", url="http://x",
+        sha="abc123", repo="test/repo",
+    )
+    assert "state=success" in captured["cmd"], f"Expected state=success in command, got: {captured['cmd']}"

--- a/ci/tests/test_pytest_xfail_xpass.py
+++ b/ci/tests/test_pytest_xfail_xpass.py
@@ -67,10 +67,10 @@ def test_xfailed_is_ok():
     path = _write_jsonl(entries)
     try:
         r = ResultTranslator.from_pytest_jsonl(path)
-        assert r.status == Result.Status.SUCCESS, f"job status: {r.status}"
+        assert r.status == Result.Status.OK, f"job status: {r.status}"
         assert len(r.results) == 1
         test = r.results[0]
-        assert test.status == Result.StatusExtended.XFAIL, f"test status: {test.status}"
+        assert test.status == Result.Status.XFAIL, f"test status: {test.status}"
         assert test.is_ok(), "xfailed test should be considered OK"
         assert not test.is_failure(), "xfailed test should not be a failure"
     finally:
@@ -92,10 +92,10 @@ def test_xpassed_fails_job():
     path = _write_jsonl(entries)
     try:
         r = ResultTranslator.from_pytest_jsonl(path)
-        assert r.status == Result.Status.FAILED, f"job status: {r.status}"
+        assert r.status == Result.Status.FAIL, f"job status: {r.status}"
         assert len(r.results) == 1
         test = r.results[0]
-        assert test.status == Result.StatusExtended.XPASS, f"test status: {test.status}"
+        assert test.status == Result.Status.XPASS, f"test status: {test.status}"
         assert not test.is_ok(), "xpassed test should not be considered OK"
         assert test.is_failure(), "xpassed test should be a failure"
     finally:
@@ -118,10 +118,10 @@ def test_xfailed_and_passed_mix():
     path = _write_jsonl(entries)
     try:
         r = ResultTranslator.from_pytest_jsonl(path)
-        assert r.status == Result.Status.SUCCESS, f"job status: {r.status}"
+        assert r.status == Result.Status.OK, f"job status: {r.status}"
         statuses = {t.name: t.status for t in r.results}
-        assert statuses["test_mod.py::test_a"] == Result.StatusExtended.OK
-        assert statuses["test_mod.py::test_b"] == Result.StatusExtended.XFAIL
+        assert statuses["test_mod.py::test_a"] == Result.Status.OK
+        assert statuses["test_mod.py::test_b"] == Result.Status.XFAIL
     finally:
         os.unlink(path)
 
@@ -142,10 +142,10 @@ def test_xpassed_and_passed_mix():
     path = _write_jsonl(entries)
     try:
         r = ResultTranslator.from_pytest_jsonl(path)
-        assert r.status == Result.Status.FAILED, f"job status: {r.status}"
+        assert r.status == Result.Status.FAIL, f"job status: {r.status}"
         statuses = {t.name: t.status for t in r.results}
-        assert statuses["test_mod.py::test_a"] == Result.StatusExtended.OK
-        assert statuses["test_mod.py::test_b"] == Result.StatusExtended.XPASS
+        assert statuses["test_mod.py::test_a"] == Result.Status.OK
+        assert statuses["test_mod.py::test_b"] == Result.Status.XPASS
     finally:
         os.unlink(path)
 

--- a/ci/tests/test_result.py
+++ b/ci/tests/test_result.py
@@ -1,0 +1,200 @@
+"""
+Tests for Result.Status enum and Result helper methods.
+
+Adding a new status to Result.Status is a significant change that affects
+CI reports, CIDB statistics, GitHub commit statuses, Slack notifications,
+and the event feed. Think twice before adding one — and update all mapping
+tables (GH._STATUS_TO_GH, CIDB._STATUS_TO_CIDB) and these tests.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.praktika.result import Result
+
+
+# The canonical set of all statuses.  If you add a new status, you MUST
+# update this set, the GH and CIDB mapping tables, json.html rendering,
+# the Slack lambda, and the event sanitizer.  The test below will remind you.
+ALL_STATUSES = {
+    Result.Status.OK,
+    Result.Status.FAIL,
+    Result.Status.SKIPPED,
+    Result.Status.ERROR,
+    Result.Status.UNKNOWN,
+    Result.Status.XFAIL,
+    Result.Status.XPASS,
+    Result.Status.PENDING,
+    Result.Status.RUNNING,
+    Result.Status.DROPPED,
+}
+
+
+def _get_class_constants(cls):
+    """Return set of all public string constants defined on a class."""
+    return {
+        getattr(cls, k)
+        for k in dir(cls)
+        if not k.startswith("_") and isinstance(getattr(cls, k), str)
+    }
+
+
+def test_all_statuses_accounted_for():
+    """No status was added to Result.Status without updating ALL_STATUSES."""
+    actual = _get_class_constants(Result.Status)
+    assert actual == ALL_STATUSES, (
+        f"Result.Status has changed! New: {actual - ALL_STATUSES}, "
+        f"Removed: {ALL_STATUSES - actual}. "
+        "Update ALL_STATUSES, GH/CIDB mappings, json.html, Slack lambda, and event sanitizer."
+    )
+
+
+def test_status_values_are_uppercase():
+    for status in ALL_STATUSES:
+        assert status == status.upper(), f"Status {status!r} must be uppercase"
+
+
+def test_status_values_are_unique():
+    values = list(ALL_STATUSES)
+    assert len(values) == len(set(values)), "Duplicate status values"
+
+
+# --- is_ok / is_success / is_failure / is_error ---
+
+def test_is_ok():
+    ok_statuses = {Result.Status.OK, Result.Status.SKIPPED, Result.Status.XFAIL}
+    not_ok = ALL_STATUSES - ok_statuses
+    for s in ok_statuses:
+        assert Result("t", s).is_ok(), f"{s} should be ok"
+    for s in not_ok:
+        assert not Result("t", s).is_ok(), f"{s} should not be ok"
+
+
+def test_is_success():
+    success_statuses = {Result.Status.OK, Result.Status.XFAIL}
+    for s in success_statuses:
+        assert Result("t", s).is_success(), f"{s} should be success"
+    for s in ALL_STATUSES - success_statuses:
+        assert not Result("t", s).is_success(), f"{s} should not be success"
+
+
+def test_is_failure():
+    fail_statuses = {Result.Status.FAIL, Result.Status.XPASS}
+    for s in fail_statuses:
+        assert Result("t", s).is_failure(), f"{s} should be failure"
+    for s in ALL_STATUSES - fail_statuses:
+        assert not Result("t", s).is_failure(), f"{s} should not be failure"
+
+
+def test_is_error():
+    assert Result("t", Result.Status.ERROR).is_error()
+    for s in ALL_STATUSES - {Result.Status.ERROR}:
+        assert not Result("t", s).is_error(), f"{s} should not be error"
+
+
+def test_is_pending():
+    assert Result("t", Result.Status.PENDING).is_pending()
+    for s in ALL_STATUSES - {Result.Status.PENDING}:
+        assert not Result("t", s).is_pending(), f"{s} should not be pending"
+
+
+def test_is_running():
+    assert Result("t", Result.Status.RUNNING).is_running()
+    for s in ALL_STATUSES - {Result.Status.RUNNING}:
+        assert not Result("t", s).is_running(), f"{s} should not be running"
+
+
+def test_is_dropped():
+    assert Result("t", Result.Status.DROPPED).is_dropped()
+    for s in ALL_STATUSES - {Result.Status.DROPPED}:
+        assert not Result("t", s).is_dropped(), f"{s} should not be dropped"
+
+
+def test_is_skipped():
+    assert Result("t", Result.Status.SKIPPED).is_skipped()
+    for s in ALL_STATUSES - {Result.Status.SKIPPED}:
+        assert not Result("t", s).is_skipped(), f"{s} should not be skipped"
+
+
+def test_is_completed():
+    not_completed = {Result.Status.PENDING, Result.Status.RUNNING}
+    for s in not_completed:
+        assert not Result("t", s).is_completed(), f"{s} should not be completed"
+    for s in ALL_STATUSES - not_completed:
+        assert Result("t", s).is_completed(), f"{s} should be completed"
+
+
+# --- create_from ---
+
+def test_create_from_bool_true():
+    r = Result.create_from(name="t", status=True)
+    assert r.status == Result.Status.OK
+
+
+def test_create_from_bool_false():
+    r = Result.create_from(name="t", status=False)
+    assert r.status == Result.Status.FAIL
+
+
+def test_create_from_aggregates_ok():
+    subs = [Result("a", Result.Status.OK), Result("b", Result.Status.SKIPPED)]
+    r = Result.create_from(name="t", results=subs)
+    assert r.status == Result.Status.OK
+
+
+def test_create_from_aggregates_fail():
+    subs = [Result("a", Result.Status.OK), Result("b", Result.Status.FAIL)]
+    r = Result.create_from(name="t", results=subs)
+    assert r.status == Result.Status.FAIL
+
+
+def test_create_from_aggregates_error():
+    subs = [Result("a", Result.Status.OK), Result("b", Result.Status.ERROR)]
+    r = Result.create_from(name="t", results=subs)
+    assert r.status == Result.Status.ERROR
+
+
+def test_create_from_aggregates_xfail_is_ok():
+    subs = [Result("a", Result.Status.OK), Result("b", Result.Status.XFAIL)]
+    r = Result.create_from(name="t", results=subs)
+    assert r.status == Result.Status.OK
+
+
+def test_create_from_aggregates_xpass_is_fail():
+    subs = [Result("a", Result.Status.OK), Result("b", Result.Status.XPASS)]
+    r = Result.create_from(name="t", results=subs)
+    assert r.status == Result.Status.FAIL
+
+
+def test_create_from_aggregates_unknown_is_fail():
+    subs = [Result("a", Result.Status.OK), Result("b", Result.Status.UNKNOWN)]
+    r = Result.create_from(name="t", results=subs)
+    assert r.status == Result.Status.FAIL
+
+
+def test_create_from_error_takes_priority():
+    subs = [Result("a", Result.Status.FAIL), Result("b", Result.Status.ERROR)]
+    r = Result.create_from(name="t", results=subs)
+    assert r.status == Result.Status.ERROR
+
+
+# --- set_success / set_failed / set_error ---
+
+def test_set_success():
+    r = Result("t", Result.Status.FAIL)
+    r.set_success()
+    assert r.status == Result.Status.OK
+
+
+def test_set_failed():
+    r = Result("t", Result.Status.OK)
+    r.set_failed()
+    assert r.status == Result.Status.FAIL
+
+
+def test_set_error():
+    r = Result("t", Result.Status.OK)
+    r.set_error()
+    assert r.status == Result.Status.ERROR


### PR DESCRIPTION
Merge the two separate status enums (`Status` for job-level, `StatusExtended` for test-level) into one `Result.Status` class used everywhere. This removes the confusion about which enum to use and fixes several places where the wrong enum was used for sub-results or where bare string literals were used instead of enum constants.

`Result.Status` now has all values in uppercase: `OK`, `FAIL`, `SKIPPED`, `ERROR`, `UNKNOWN`, `XFAIL`, `XPASS`, `PENDING`, `RUNNING`, `DROPPED`.

Boundary conversions are transparent — job code only uses `Result.Status` values and never needs to worry about external formats:
- GH commit status API: `post_commit_status` auto-converts via `Result.GHStatus` mapping
- CIDB `check_status`: `TableRecord.__post_init__` auto-converts via `convert_to_cidb_status`
- Event `ci_status`: `Result.to_event` auto-converts
- `json.html` uses lowercase comparisons for backwards compatibility with old result JSONs

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1029`
<!-- ch-version-info:end -->