### PR TITLE
Fix flaky test_keeper_snapshot_chunked_transfer[remote_disk]

### DIFF
--- a/tests/integration/test_keeper_snapshot_chunked_transfer/test.py
+++ b/tests/integration/test_keeper_snapshot_chunked_transfer/test.py
@@ -2,6 +2,8 @@
 import concurrent.futures
 import math
 import os
+import time
+
 import pytest
 
 import helpers.keeper_utils as keeper_utils
@@ -210,6 +212,10 @@ def test_recover_after_interrupted_transfer(started_cluster, nodes):
             "root", prefix=s3_prefix + "tmp_snapshot_"
         ))
         assert tmp_objects, "No tmp_snapshot object in S3 after killing mid-transfer"
+        # Record the specific tmp files left by the interrupted transfer so we can
+        # check that *these* are cleaned up, ignoring any transient tmp_ markers
+        # created by background snapshot flushes after the node restarts.
+        interrupted_tmp_names = {o.object_name for o in tmp_objects}
     else:
         snapshot_dir = "/var/lib/clickhouse/coordination/snapshots"
         tmp_snapshot_path = node_lagging.exec_in_container(
@@ -223,10 +229,27 @@ def test_recover_after_interrupted_transfer(started_cluster, nodes):
     lagging_zk.sync(prefix)  # wait until all committed entries (including snapshot) are applied
 
     if is_remote:
-        remaining = list(started_cluster.minio_client.list_objects(
-            "root", prefix=s3_prefix + "tmp_snapshot_"
-        ))
-        assert not remaining, f"tmp_snapshot objects not removed from S3 on startup: {[o.object_name for o in remaining]}"
+        # After restart the node may also create new local snapshots asynchronously
+        # (queued via snapshots_queue), which temporarily produce fresh tmp_ markers
+        # with the same or different log indices.  Poll for the *interrupted* markers
+        # to disappear rather than asserting immediately, so a concurrent background
+        # flush does not cause a false positive.
+        deadline = time.time() + 15
+        remaining = None
+        while True:
+            remaining = [
+                o for o in started_cluster.minio_client.list_objects(
+                    "root", prefix=s3_prefix + "tmp_snapshot_"
+                )
+                if o.object_name in interrupted_tmp_names
+            ]
+            if not remaining or time.time() >= deadline:
+                break
+            time.sleep(1)
+        assert not remaining, (
+            f"tmp_snapshot objects from interrupted transfer not removed within 15 s: "
+            f"{[o.object_name for o in remaining]}"
+        )
     else:
         assert (
             node_lagging.exec_in_container(


### PR DESCRIPTION
The `test_recover_after_interrupted_transfer[remote_disk]` integration test has been chronically flaky (20+ PRs affected, 6 master failures in 30 days — issues #102040, #101969). PR #102643 added a `sync()` call but failures continued (master failure on 2026-04-15 on commit 118bba8d which is ahead of the fix).

### Root cause

After the node restarts, Keeper may create new local snapshots asynchronously — `serializeSnapshotToDisk` is queued via `snapshots_queue` and runs in a background thread. During the write, a `tmp_snapshot_*` marker file is created temporarily (removed once the snapshot is fully written to disk).

The S3 assertion checked for **all** `tmp_snapshot_*` objects immediately after `sync()`. If a background snapshot flush happened to be in progress, its transient marker was caught as a false positive.

The `local_disk` variant was never flaky because it checks the **specific** tmp file path from the interrupted transfer, ignoring any new markers from background operations.

### Fix

1. Record the specific `tmp_snapshot_*` file names left by the interrupted transfer (before restart)
2. After restart + `sync()`, poll for those **specific** files to disappear (15 s timeout) instead of asserting immediately against all `tmp_snapshot_*` objects
3. New transient markers from background snapshot flushes are correctly ignored

The test still verifies the core behavior: interrupted transfer tmp files must be cleaned up on startup. The 15 s timeout ensures genuine cleanup failures are still caught.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.251`
<!-- ch-version-info:end -->