### PR TITLE
Fix several optimizations after lightweight deletes [2]

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeUseAggregateProjection.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeUseAggregateProjection.cpp
@@ -362,8 +362,9 @@ AggregateProjectionCandidates getAggregateProjectionCandidates(
         if (projection.type == ProjectionDescription::Type::Aggregate)
             agg_projections.push_back(&projection);
 
-    bool can_use_minmax_projection = allow_implicit_projections && metadata->minmax_count_projection
-        && !reading.getMergeTreeData().has_lightweight_delete_parts.load();
+    bool can_use_minmax_projection = allow_implicit_projections
+        && metadata->minmax_count_projection
+        && !reading.getMutationsSnapshot()->hasLightweightDeletedMask();
 
     if (!can_use_minmax_projection && agg_projections.empty())
         return candidates;

--- a/src/Storages/IStorage.h
+++ b/src/Storages/IStorage.h
@@ -272,9 +272,6 @@ public:
     /// is_restore_from_backup = true in StorageFactory::Arguments).
     virtual void finalizeRestoreFromBackup() {}
 
-    /// Return true if there is at least one part containing lightweight deleted mask.
-    virtual bool hasLightweightDeletedMask() const { return false; }
-
     /// Return true if storage can execute lightweight delete mutations.
     virtual bool supportsLightweightDelete() const { return false; }
 

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -707,15 +707,18 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
             addGatheringColumn(global_ctx, BlockOffsetColumn::name, BlockOffsetColumn::type);
     }
 
+    auto parts_info = MergeTreeData::getPartsSnapshotInfo(global_ctx->future_part->parts);
+
     MergeTreeData::IMutationsSnapshot::Params params
     {
         .metadata_version = global_ctx->metadata_snapshot->getMetadataVersion(),
-        .min_part_metadata_version = MergeTreeData::getMinMetadataVersion(global_ctx->future_part->parts),
+        .min_part_metadata_version = parts_info.min_metadata_version,
         .min_part_data_versions = nullptr,
         .max_mutation_versions = nullptr,
         .need_data_mutations = false,
         .need_alter_mutations = !patch_parts.empty(),
         .need_patch_parts = false,
+        .has_lightweight_delete_parts = parts_info.has_lightweight_delete_parts,
     };
 
     auto mutations_snapshot = global_ctx->data->getMutationsSnapshot(params);

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -212,7 +212,6 @@ namespace Setting
     extern const SettingsBool use_statistics;
     extern const SettingsBool use_statistics_cache;
     extern const SettingsBool use_partition_pruning;
-    extern const SettingsBool apply_deleted_mask;
 }
 
 namespace MergeTreeSetting
@@ -2106,6 +2105,9 @@ MergeTreeData::LoadPartResult MergeTreeData::loadDataPart(
         addPartContributionToUncompressedBytesInPatches(res.part);
     }
 
+    if (res.part->hasLightweightDelete())
+        has_lightweight_delete_parts.store(true);
+
     LOG_TRACE(log, "Finished loading {} part {} on disk {}", magic_enum::enum_name(to_state), part_name, part_disk_ptr->getName());
     return res;
 }
@@ -2397,6 +2399,7 @@ void MergeTreeData::loadDataParts(bool skip_sanity_checks, std::optional<std::un
     size_t suspicious_broken_unexpected_parts_bytes = 0;
     bool have_adaptive_parts = false;
     bool have_non_adaptive_parts = false;
+    bool have_lightweight_in_parts = false;
     bool have_parts_with_version_metadata = false;
 
     bool is_static_storage = isStaticStorage();
@@ -2441,6 +2444,7 @@ void MergeTreeData::loadDataParts(bool skip_sanity_checks, std::optional<std::un
                 bool is_adaptive = res.part->index_granularity_info.mark_type.adaptive;
                 have_adaptive_parts |= is_adaptive;
                 have_non_adaptive_parts |= !is_adaptive;
+                have_lightweight_in_parts |= res.part->hasLightweightDelete();
                 have_parts_with_version_metadata |= res.part->wasInvolvedInTransaction();
             }
         }
@@ -2452,6 +2456,7 @@ void MergeTreeData::loadDataParts(bool skip_sanity_checks, std::optional<std::un
                         "but `setting enable_mixed_granularity_parts` is disabled");
 
     has_non_adaptive_index_granularity_parts = have_non_adaptive_parts;
+    has_lightweight_delete_parts = have_lightweight_in_parts;
     transactions_enabled = have_parts_with_version_metadata;
 
     if (!skip_sanity_checks)
@@ -2644,6 +2649,7 @@ try
     }
 
     bool have_non_adaptive_parts = false;
+    bool have_lightweight_in_parts = false;
     bool have_parts_with_version_metadata = false;
 
     for (const auto & my_part : parts_to_add)
@@ -2668,11 +2674,13 @@ try
 
             bool is_adaptive = res.part->index_granularity_info.mark_type.adaptive;
             have_non_adaptive_parts |= !is_adaptive;
+            have_lightweight_in_parts |= res.part->hasLightweightDelete();
             have_parts_with_version_metadata |= res.part->wasInvolvedInTransaction();
         }
     }
 
     has_non_adaptive_index_granularity_parts = have_non_adaptive_parts;
+    has_lightweight_delete_parts = have_lightweight_in_parts;
     transactions_enabled = have_parts_with_version_metadata;
 
     auto old_parts = grabOldParts(true);
@@ -5159,6 +5167,9 @@ bool MergeTreeData::addTempPart(
     if (&out_transaction.data != this)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "MergeTreeData::Transaction for one table cannot be used with another. It is a bug.");
 
+    if (part->hasLightweightDelete())
+        has_lightweight_delete_parts.store(true);
+
     checkPartPartition(part, lock);
     checkPartDuplicate(part, out_transaction, lock);
 
@@ -5223,6 +5234,9 @@ bool MergeTreeData::renameTempPartAndReplaceImpl(
 
     if (hierarchy.duplicate_part)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected duplicate part {}. It is a bug.", hierarchy.duplicate_part->getNameWithState());
+
+    if (part->hasLightweightDelete())
+        has_lightweight_delete_parts.store(true);
 
     /// All checks are passed. Now we can rename the part on disk.
     /// So, we maintain invariant: if a non-temporary part in filesystem then it is in data_parts
@@ -10412,16 +10426,21 @@ SerializationInfoByName MergeTreeData::getSerializationHints() const
 bool MergeTreeData::supportsTrivialCountOptimization(const StorageSnapshotPtr & storage_snapshot, ContextPtr query_context) const
 {
     const auto & settings = query_context->getSettingsRef();
-    bool apply_any_mutations = settings[Setting::apply_mutations_on_fly] || settings[Setting::apply_patch_parts] || settings[Setting::apply_deleted_mask];
+
+    auto supports_trivial_count = [&]()
+    {
+        /// Fallback for callers that don't provide a storage snapshot (e.g. StorageMerge).
+        return !has_lightweight_delete_parts.load(std::memory_order_relaxed) && !settings[Setting::apply_mutations_on_fly] && !settings[Setting::apply_patch_parts];
+    };
 
     if (!storage_snapshot)
-        return !apply_any_mutations;
+        return supports_trivial_count();
 
     const auto & snapshot_data = assert_cast<const MergeTreeData::SnapshotData &>(*storage_snapshot->data);
     const auto & mutations_snapshot = snapshot_data.mutations_snapshot;
 
     if (!mutations_snapshot)
-        return !apply_any_mutations;
+        return supports_trivial_count();
 
     return !mutations_snapshot->hasDataMutations() && !mutations_snapshot->hasPatchParts() && !mutations_snapshot->hasLightweightDeletedMask();
 }

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -211,6 +211,7 @@ namespace Setting
     extern const SettingsBool use_statistics;
     extern const SettingsBool use_statistics_cache;
     extern const SettingsBool use_partition_pruning;
+    extern const SettingsBool apply_deleted_mask;
 }
 
 namespace MergeTreeSetting
@@ -2124,9 +2125,6 @@ MergeTreeData::LoadPartResult MergeTreeData::loadDataPart(
         addPartContributionToUncompressedBytesInPatches(res.part);
     }
 
-    if (res.part->hasLightweightDelete())
-        has_lightweight_delete_parts.store(true);
-
     LOG_TRACE(log, "Finished loading {} part {} on disk {}", magic_enum::enum_name(to_state), part_name, part_disk_ptr->getName());
     return res;
 }
@@ -2418,7 +2416,6 @@ void MergeTreeData::loadDataParts(bool skip_sanity_checks, std::optional<std::un
     size_t suspicious_broken_unexpected_parts_bytes = 0;
     bool have_adaptive_parts = false;
     bool have_non_adaptive_parts = false;
-    bool have_lightweight_in_parts = false;
     bool have_parts_with_version_metadata = false;
 
     bool is_static_storage = isStaticStorage();
@@ -2463,7 +2460,6 @@ void MergeTreeData::loadDataParts(bool skip_sanity_checks, std::optional<std::un
                 bool is_adaptive = res.part->index_granularity_info.mark_type.adaptive;
                 have_adaptive_parts |= is_adaptive;
                 have_non_adaptive_parts |= !is_adaptive;
-                have_lightweight_in_parts |= res.part->hasLightweightDelete();
                 have_parts_with_version_metadata |= res.part->wasInvolvedInTransaction();
             }
         }
@@ -2475,7 +2471,6 @@ void MergeTreeData::loadDataParts(bool skip_sanity_checks, std::optional<std::un
                         "but `setting enable_mixed_granularity_parts` is disabled");
 
     has_non_adaptive_index_granularity_parts = have_non_adaptive_parts;
-    has_lightweight_delete_parts = have_lightweight_in_parts;
     transactions_enabled = have_parts_with_version_metadata;
 
     if (!skip_sanity_checks)
@@ -2668,7 +2663,6 @@ try
     }
 
     bool have_non_adaptive_parts = false;
-    bool have_lightweight_in_parts = false;
     bool have_parts_with_version_metadata = false;
 
     for (const auto & my_part : parts_to_add)
@@ -2693,13 +2687,11 @@ try
 
             bool is_adaptive = res.part->index_granularity_info.mark_type.adaptive;
             have_non_adaptive_parts |= !is_adaptive;
-            have_lightweight_in_parts |= res.part->hasLightweightDelete();
             have_parts_with_version_metadata |= res.part->wasInvolvedInTransaction();
         }
     }
 
     has_non_adaptive_index_granularity_parts = have_non_adaptive_parts;
-    has_lightweight_delete_parts = have_lightweight_in_parts;
     transactions_enabled = have_parts_with_version_metadata;
 
     auto old_parts = grabOldParts(true);
@@ -5186,9 +5178,6 @@ bool MergeTreeData::addTempPart(
     if (&out_transaction.data != this)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "MergeTreeData::Transaction for one table cannot be used with another. It is a bug.");
 
-    if (part->hasLightweightDelete())
-        has_lightweight_delete_parts.store(true);
-
     checkPartPartition(part, lock);
     checkPartDuplicate(part, out_transaction, lock);
 
@@ -5253,10 +5242,6 @@ bool MergeTreeData::renameTempPartAndReplaceImpl(
 
     if (hierarchy.duplicate_part)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected duplicate part {}. It is a bug.", hierarchy.duplicate_part->getNameWithState());
-
-
-    if (part->hasLightweightDelete())
-        has_lightweight_delete_parts.store(true);
 
     /// All checks are passed. Now we can rename the part on disk.
     /// So, we maintain invariant: if a non-temporary part in filesystem then it is in data_parts
@@ -10442,50 +10427,50 @@ SerializationInfoByName MergeTreeData::getSerializationHints() const
 
 bool MergeTreeData::supportsTrivialCountOptimization(const StorageSnapshotPtr & storage_snapshot, ContextPtr query_context) const
 {
-    if (hasLightweightDeletedMask())
-        return false;
-
     const auto & settings = query_context->getSettingsRef();
+    bool apply_any_mutations = settings[Setting::apply_mutations_on_fly] || settings[Setting::apply_patch_parts] || settings[Setting::apply_deleted_mask];
+
     if (!storage_snapshot)
-        return !settings[Setting::apply_mutations_on_fly] && !settings[Setting::apply_patch_parts];
+        return !apply_any_mutations;
 
     const auto & snapshot_data = assert_cast<const MergeTreeData::SnapshotData &>(*storage_snapshot->data);
     const auto & mutations_snapshot = snapshot_data.mutations_snapshot;
 
     if (!mutations_snapshot)
-        return !settings[Setting::apply_mutations_on_fly] && !settings[Setting::apply_patch_parts];
+        return !apply_any_mutations;
 
-    return !mutations_snapshot->hasDataMutations() && !mutations_snapshot->hasPatchParts();
+    return !mutations_snapshot->hasDataMutations() && !mutations_snapshot->hasPatchParts() && !mutations_snapshot->hasLightweightDeletedMask();
 }
 
-Int64 MergeTreeData::getMinMetadataVersion(const DataPartsVector & parts)
+MergeTreeData::PartsSnapshotInfo MergeTreeData::getPartsSnapshotInfo(const DataPartsVector & parts)
 {
-    Int64 version = -1;
-    for (const auto & part : parts)
-    {
-        Int64 part_version = part->getMetadataVersion();
-        if (version == -1 || part_version < version)
-            version = part_version;
-    }
-    return version;
-}
-
-MergeTreeData::PartitionIdToMinBlockPtr MergeTreeData::getMinDataVersionForEachPartition(const DataPartsVector & parts)
-{
-    PartitionIdToMinBlock partition_to_min_data_version;
+    PartsSnapshotInfo info;
+    PartitionIdToMinBlock min_data_versions;
 
     for (const auto & part : parts)
     {
-        const String & partition_id = part->info.getPartitionId();
-        const Int64 data_version = part->info.getDataVersion();
+        {
+            Int64 part_metadata_version = part->getMetadataVersion();
+            if (info.min_metadata_version == -1 || part_metadata_version < info.min_metadata_version)
+                info.min_metadata_version = part_metadata_version;
+        }
 
-        if (auto partition_it = partition_to_min_data_version.find(partition_id); partition_it != partition_to_min_data_version.end())
-            partition_it->second = std::min(partition_it->second, data_version);
-        else
-            partition_to_min_data_version.emplace(partition_id, data_version);
+        {
+            const String & partition_id = part->info.getPartitionId();
+            const Int64 data_version = part->info.getDataVersion();
+
+            if (auto it = min_data_versions.find(partition_id); it != min_data_versions.end())
+                it->second = std::min(it->second, data_version);
+            else
+                min_data_versions.emplace(partition_id, data_version);
+        }
+
+        if (!info.has_lightweight_delete_parts && part->hasLightweightDelete())
+            info.has_lightweight_delete_parts = true;
     }
 
-    return std::make_shared<PartitionIdToMinBlock>(std::move(partition_to_min_data_version));
+    info.min_data_versions = std::make_shared<PartitionIdToMinBlock>(std::move(min_data_versions));
+    return info;
 }
 
 MergeTreeSettingsPtr MergeTreeData::getSettings(ProjectionDescriptionRawPtr projection) const
@@ -10542,18 +10527,21 @@ MergeTreeData::createStorageSnapshot(const StorageMetadataPtr & metadata_snapsho
     auto [query_ranges, query_parts] = getPossiblySharedVisibleDataPartsRanges(query_context);
     snapshot_data->parts = query_ranges;
 
+    auto parts_info = getPartsSnapshotInfo(*query_parts);
+
     bool apply_mutations_on_fly = query_context->getSettingsRef()[Setting::apply_mutations_on_fly];
     bool apply_patch_parts = query_context->getSettingsRef()[Setting::apply_patch_parts];
 
     IMutationsSnapshot::Params params
     {
         .metadata_version = metadata_snapshot->getMetadataVersion(),
-        .min_part_metadata_version = getMinMetadataVersion(*query_parts),
-        .min_part_data_versions = getMinDataVersionForEachPartition(*query_parts),
+        .min_part_metadata_version = parts_info.min_metadata_version,
+        .min_part_data_versions = std::move(parts_info.min_data_versions),
         .max_mutation_versions = query_context->getPartitionIdToMaxBlock(getStorageID().uuid),
         .need_data_mutations = apply_mutations_on_fly,
         .need_alter_mutations = apply_mutations_on_fly || apply_patch_parts,
         .need_patch_parts = apply_patch_parts,
+        .has_lightweight_delete_parts = parts_info.has_lightweight_delete_parts,
     };
 
     snapshot_data->mutations_snapshot = getMutationsSnapshot(params);

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1297,6 +1297,11 @@ public:
 
     bool has_non_adaptive_index_granularity_parts = false;
 
+    /// True if at least one part contains a lightweight delete mask.
+    /// Used as a fallback in `supportsTrivialCountOptimization` when
+    /// no storage snapshot is available (e.g. from `StorageMerge`).
+    mutable std::atomic_bool has_lightweight_delete_parts = false;
+
     /// Parts that currently moving from disk/volume to another.
     /// This set have to be used with `currently_processing_in_background_mutex`.
     /// Moving may conflict with merges and mutations, but this is OK, because

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -562,6 +562,7 @@ public:
             bool need_data_mutations = false;
             bool need_alter_mutations = false;
             bool need_patch_parts = false;
+            bool has_lightweight_delete_parts = false;
         };
 
         static Int64 getMinPartDataVersionForPartition(const Params & params, const String & partition_id);
@@ -583,6 +584,7 @@ public:
         virtual bool hasDataMutations() const = 0;
         virtual bool hasAlterMutations() const = 0;
         virtual bool hasMetadataMutations() const = 0;
+        virtual bool hasLightweightDeletedMask() const = 0;
     };
 
     struct MutationsSnapshotBase : public IMutationsSnapshot
@@ -603,6 +605,7 @@ public:
         bool hasAlterMutations() const final { return counters.num_alter > 0; }
         bool hasMetadataMutations() const final { return counters.num_metadata > 0; }
         bool hasAnyMutations() const { return hasDataMutations() || hasAlterMutations() || hasMetadataMutations(); }
+        bool hasLightweightDeletedMask() const final { return params.has_lightweight_delete_parts; }
 
     protected:
         NameSet getColumnsUpdatedInPatches() const;
@@ -1199,11 +1202,16 @@ public:
     /// Returns a snapshot of mutations that probably will be applied on the fly to parts during reading.
     virtual MutationsSnapshotPtr getMutationsSnapshot(const IMutationsSnapshot::Params & params) const = 0;
 
-    /// Returns the minimum version of metadata among parts.
-    static Int64 getMinMetadataVersion(const DataPartsVector & parts);
+    /// Computes snapshot-related part statistics in a single pass:
+    /// min metadata version, per-partition min data version, and whether any part has a lightweight delete mask.
+    struct PartsSnapshotInfo
+    {
+        Int64 min_metadata_version = -1;
+        PartitionIdToMinBlockPtr min_data_versions;
+        bool has_lightweight_delete_parts = false;
+    };
 
-    /// Returns minimum data version among parts inside each of the partitions.
-    static PartitionIdToMinBlockPtr getMinDataVersionForEachPartition(const DataPartsVector & parts);
+    static PartsSnapshotInfo getPartsSnapshotInfo(const DataPartsVector & parts);
 
     /// Return alter conversions for part which must be applied on fly.
     static AlterConversionsPtr getAlterConversionsForPart(
@@ -1290,9 +1298,6 @@ public:
     SimpleIncrement insert_increment;
 
     bool has_non_adaptive_index_granularity_parts = false;
-
-    /// True if at least one part contains lightweight delete.
-    mutable std::atomic_bool has_lightweight_delete_parts = false;
 
     /// Parts that currently moving from disk/volume to another.
     /// This set have to be used with `currently_processing_in_background_mutex`.

--- a/src/Storages/MergeTree/StorageFromMergeTreeDataPart.h
+++ b/src/Storages/MergeTree/StorageFromMergeTreeDataPart.h
@@ -73,7 +73,7 @@ public:
 
     bool materializeTTLRecalculateOnly() const;
 
-    bool hasLightweightDeletedMask() const override
+    bool hasLightweightDeletedMask() const
     {
         return !parts.empty() && parts.front().data_part->hasLightweightDelete();
     }

--- a/src/Storages/StorageAlias.h
+++ b/src/Storages/StorageAlias.h
@@ -137,7 +137,6 @@ public:
     bool isRemote() const override { return getTargetTable()->isRemote(); }
     bool isSharedStorage() const override { return getTargetTable()->isSharedStorage(); }
     bool supportsReplication() const override { return getTargetTable()->supportsReplication(); }
-    bool hasLightweightDeletedMask() const override { return getTargetTable()->hasLightweightDeletedMask(); }
     bool supportsLightweightDelete() const override { return getTargetTable()->supportsLightweightDelete(); }
     std::expected<void, PreformattedMessage> supportsLightweightUpdate() const override { return getTargetTable()->supportsLightweightUpdate(); }
     bool supportsDelete() const override { return getTargetTable()->supportsDelete(); }

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -896,11 +896,6 @@ QueryPipeline StorageMergeTree::updateLightweight(const MutationCommands & comma
     return pipeline;
 }
 
-bool StorageMergeTree::hasLightweightDeletedMask() const
-{
-    return has_lightweight_delete_parts.load(std::memory_order_relaxed);
-}
-
 namespace
 {
 

--- a/src/Storages/StorageMergeTree.h
+++ b/src/Storages/StorageMergeTree.h
@@ -96,8 +96,6 @@ public:
     void mutate(const MutationCommands & commands, ContextPtr context) override;
     QueryPipeline updateLightweight(const MutationCommands & commands, ContextPtr query_context) override;
 
-    bool hasLightweightDeletedMask() const override;
-
     /// Return introspection information about currently processing or recently processed mutations.
     std::vector<MergeTreeMutationStatus> getMutationsStatus() const override;
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -8443,11 +8443,6 @@ QueryPipeline StorageReplicatedMergeTree::updateLightweight(const MutationComman
     return pipeline;
 }
 
-bool StorageReplicatedMergeTree::hasLightweightDeletedMask() const
-{
-    return has_lightweight_delete_parts.load(std::memory_order_relaxed);
-}
-
 size_t StorageReplicatedMergeTree::clearOldPartsAndRemoveFromZK()
 {
     auto table_lock = lockForShare(RWLockImpl::NO_QUERY, (*getSettings())[MergeTreeSetting::lock_acquire_timeout_for_background_operations]);

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -194,8 +194,6 @@ public:
     bool haveCommittingOps(const CommittingBlocks & committing_blocks, PartitionIdToMaxBlockPtr partitions, std::set<CommittingBlock::Op> ops) const;
     void waitForCommittingOpsToFinish(zkutil::ZooKeeperPtr zookeeper, PartitionIdToMaxBlockPtr partitions, std::set<CommittingBlock::Op> ops, size_t backoff_ms, size_t sync_timeout_ms);
 
-    bool hasLightweightDeletedMask() const override;
-
     /** Removes a replica from ZooKeeper. If there are no other replicas, it deletes the entire table from ZooKeeper.
       */
     void drop() override;

--- a/tests/queries/0_stateless/04068_lwd_minmax_projection_recovery.reference
+++ b/tests/queries/0_stateless/04068_lwd_minmax_projection_recovery.reference
@@ -1,0 +1,7 @@
+before_delete
+1
+after_delete
+0
+lwd_parts_remaining	0
+after_optimize
+1

--- a/tests/queries/0_stateless/04068_lwd_minmax_projection_recovery.sql
+++ b/tests/queries/0_stateless/04068_lwd_minmax_projection_recovery.sql
@@ -1,0 +1,60 @@
+-- Verify that minmax_count_projection is re-enabled after all lightweight-deleted parts are merged away.
+-- Previously, the has_lightweight_delete_parts flag was "sticky" and never reset,
+-- permanently disabling minmax_count_projection even after OPTIMIZE TABLE FINAL.
+
+SET lightweight_deletes_sync = 2, alter_sync = 2;
+
+DROP TABLE IF EXISTS t_lwd_proj;
+
+CREATE TABLE t_lwd_proj
+(
+    dt Date,
+    id UInt64,
+    value String
+)
+ENGINE = ReplacingMergeTree()
+PARTITION BY toYYYYMM(dt)
+ORDER BY (id, dt);
+
+INSERT INTO t_lwd_proj VALUES ('2025-01-15', 1, 'First record');
+INSERT INTO t_lwd_proj VALUES ('2025-02-15', 2, 'Second record');
+INSERT INTO t_lwd_proj VALUES ('2025-03-15', 3, 'Third record');
+INSERT INTO t_lwd_proj VALUES ('2025-04-15', 4, 'Fourth record');
+INSERT INTO t_lwd_proj VALUES ('2025-05-15', 5, 'Fifth record');
+INSERT INTO t_lwd_proj VALUES ('2025-06-15', 6, 'Sixth record');
+INSERT INTO t_lwd_proj VALUES ('2025-07-15', 7, 'Seventh record');
+INSERT INTO t_lwd_proj VALUES ('2025-08-15', 8, 'Eighth record');
+INSERT INTO t_lwd_proj VALUES ('2025-09-15', 9, 'Ninth record');
+INSERT INTO t_lwd_proj VALUES ('2025-10-15', 10, 'Tenth record');
+INSERT INTO t_lwd_proj VALUES ('2025-11-15', 11, 'Eleventh record');
+INSERT INTO t_lwd_proj VALUES ('2025-12-15', 12, 'Twelfth record');
+
+-- Before any delete: minmax_count_projection should be used.
+SELECT 'before_delete';
+SELECT count() FROM (EXPLAIN indexes = 1 SELECT min(dt), max(dt) FROM t_lwd_proj
+    SETTINGS optimize_use_projections = 1, optimize_use_implicit_projections = 1)
+WHERE explain LIKE '%_minmax_count_projection%';
+
+-- Perform lightweight delete.
+DELETE FROM t_lwd_proj WHERE id < 5;
+
+-- After delete: minmax_count_projection should NOT be used (parts have LWD mask).
+SELECT 'after_delete';
+SELECT count() FROM (EXPLAIN indexes = 1 SELECT min(dt), max(dt) FROM t_lwd_proj
+    SETTINGS optimize_use_projections = 1, optimize_use_implicit_projections = 1)
+WHERE explain LIKE '%_minmax_count_projection%';
+
+-- Merge away the LWD parts.
+OPTIMIZE TABLE t_lwd_proj FINAL;
+
+-- Verify no parts have lightweight delete mask.
+SELECT 'lwd_parts_remaining', countIf(has_lightweight_delete) FROM system.parts
+WHERE table = 't_lwd_proj' AND database = currentDatabase() AND active;
+
+-- After merge: minmax_count_projection should be used again.
+SELECT 'after_optimize';
+SELECT count() FROM (EXPLAIN indexes = 1 SELECT min(dt), max(dt) FROM t_lwd_proj
+    SETTINGS optimize_use_projections = 1, optimize_use_implicit_projections = 1)
+WHERE explain LIKE '%_minmax_count_projection%';
+
+DROP TABLE t_lwd_proj;

--- a/tests/queries/0_stateless/04068_lwd_minmax_projection_recovery_rmt.reference
+++ b/tests/queries/0_stateless/04068_lwd_minmax_projection_recovery_rmt.reference
@@ -1,13 +1,7 @@
 before_delete
 1
-1
-12
 after_delete
 0
-0
-8
 lwd_parts_remaining	0
 after_optimize
 1
-1
-8

--- a/tests/queries/0_stateless/04068_lwd_minmax_projection_recovery_rmt.sql
+++ b/tests/queries/0_stateless/04068_lwd_minmax_projection_recovery_rmt.sql
@@ -12,7 +12,7 @@ CREATE TABLE t_lwd_proj
     id UInt64,
     value String
 )
-ENGINE = ReplacingMergeTree()
+ENGINE = ReplicatedReplacingMergeTree('/clickhouse/{database}/tables/test_cleanup/', '1')
 PARTITION BY toYYYYMM(dt)
 ORDER BY (id, dt);
 
@@ -35,12 +35,6 @@ SELECT count() FROM (EXPLAIN indexes = 1 SELECT min(dt), max(dt) FROM t_lwd_proj
     SETTINGS optimize_use_projections = 1, optimize_use_implicit_projections = 1)
 WHERE explain LIKE '%_minmax_count_projection%';
 
--- Before any delete: trivial count optimization should be used.
-SELECT count() FROM (EXPLAIN SELECT count() FROM t_lwd_proj
-    SETTINGS optimize_trivial_count_query = 1)
-WHERE explain LIKE '%Optimized trivial count%';
-SELECT count() FROM t_lwd_proj;
-
 -- Perform lightweight delete.
 DELETE FROM t_lwd_proj WHERE id < 5;
 
@@ -49,12 +43,6 @@ SELECT 'after_delete';
 SELECT count() FROM (EXPLAIN indexes = 1 SELECT min(dt), max(dt) FROM t_lwd_proj
     SETTINGS optimize_use_projections = 1, optimize_use_implicit_projections = 1)
 WHERE explain LIKE '%_minmax_count_projection%';
-
--- After delete: trivial count optimization should NOT be used.
-SELECT count() FROM (EXPLAIN SELECT count() FROM t_lwd_proj
-    SETTINGS optimize_trivial_count_query = 1)
-WHERE explain LIKE '%Optimized trivial count%';
-SELECT count() FROM t_lwd_proj;
 
 -- Merge away the LWD parts.
 OPTIMIZE TABLE t_lwd_proj FINAL;
@@ -68,11 +56,5 @@ SELECT 'after_optimize';
 SELECT count() FROM (EXPLAIN indexes = 1 SELECT min(dt), max(dt) FROM t_lwd_proj
     SETTINGS optimize_use_projections = 1, optimize_use_implicit_projections = 1)
 WHERE explain LIKE '%_minmax_count_projection%';
-
--- After merge: trivial count optimization should be used again.
-SELECT count() FROM (EXPLAIN SELECT count() FROM t_lwd_proj
-    SETTINGS optimize_trivial_count_query = 1)
-WHERE explain LIKE '%Optimized trivial count%';
-SELECT count() FROM t_lwd_proj;
 
 DROP TABLE t_lwd_proj;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `minmax_count_projection` and trivial `COUNT(*)` optimizations being permanently disabled after a lightweight delete, even after all parts with a mask of lightweight delete were merged away.

Replacement for wrong fixes #101212 and #101202.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1091`
- Backported to: `26.3.10.23`, `26.2.17.13`, `26.1.12.9`
<!-- ch-version-info:end -->