### PR TITLE
Disable lazy materialization for patch parts

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeLazyMaterialization.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeLazyMaterialization.cpp
@@ -34,6 +34,9 @@ static bool canUseLazyMaterializationForReadingStep(ReadFromMergeTree * reading)
     if (reading->isQueryWithSampling())
         return false;
 
+    if (reading->getMutationsSnapshot()->hasPatchParts())
+        return false;
+
     return true;
 }
 

--- a/tests/queries/0_stateless/04102_lazy_materialization_with_patch_parts.reference
+++ b/tests/queries/0_stateless/04102_lazy_materialization_with_patch_parts.reference
@@ -1,0 +1,5 @@
+patched
+patched
+aaa
+aaaa
+aaaaa

--- a/tests/queries/0_stateless/04102_lazy_materialization_with_patch_parts.sql
+++ b/tests/queries/0_stateless/04102_lazy_materialization_with_patch_parts.sql
@@ -1,0 +1,17 @@
+-- Tags: no-shared-merge-tree
+-- Test reproduces regression where for error
+-- Code: 10. DB::Exception: Received from localhost:9000. DB::Exception: Not found column _block_number in block. There are only columns: : While executing MergeTreeSelect(pool: ReadPoolInOrder, algorithm: InOrder). (NOT_FOUND_COLUMN_IN_BLOCK)
+
+SET enable_lightweight_update = 1;
+
+CREATE TABLE t_lazy_patch (id UInt64, filt UInt64, lazy String)
+ENGINE = MergeTree ORDER BY id
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, apply_patches_on_merge = 0;
+
+INSERT INTO t_lazy_patch SELECT number, number % 10, repeat('a', number) FROM numbers(100);
+INSERT INTO t_lazy_patch SELECT number + 100, number % 10, repeat('b', number + 100) FROM numbers(100);
+UPDATE t_lazy_patch SET lazy = 'patched' WHERE filt < 3;
+
+OPTIMIZE TABLE t_lazy_patch FINAL;
+
+SELECT lazy FROM t_lazy_patch WHERE filt > 0 ORDER BY id LIMIT 5;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Lazy materialization is not working with patch parts.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1005`
<!-- ch-version-info:end -->