### PR TITLE
Add new transaction tests to async insert blacklist

### DIFF
--- a/tests/async_insert_blacklist.txt
+++ b/tests/async_insert_blacklist.txt
@@ -32,6 +32,8 @@
 02421_truncate_isolation_with_mutations
 03167_transactions_are_really_disabled
 01167_isolation_hermitage
+04057_transaction_version_metadata_lifecycle
+04060_transaction_snapshot_visibility
 
     Async inserts with 'implicit_transaction' are not supported. (NOT_IMPLEMENTED)
 01168_mutations_isolation


### PR DESCRIPTION
PR #92141 ("Refactor VersionMetadata") introduced new transaction tests but did not add them to `tests/async_insert_blacklist.txt`. Tests `04057_transaction_version_metadata_lifecycle` and `04060_transaction_snapshot_visibility` use `INSERT` inside `BEGIN TRANSACTION`, which is `NOT_IMPLEMENTED` with async inserts. This causes 100% failure on the `AsyncInsert` CI configuration — 3 master failures and 18 PR failures within 6 hours of the merge.

The existing transaction tests (`01172_transaction_counters`, `01173_transaction_control_queries`, etc.) are already blacklisted. This PR adds the two missing tests.

Closes https://github.com/ClickHouse/ClickHouse/pull/102912

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1014`
<!-- ch-version-info:end -->