### PR TITLE
Fix random crashes in jemalloc due to LTO

### DIFF
--- a/contrib/jemalloc-cmake/CMakeLists.txt
+++ b/contrib/jemalloc-cmake/CMakeLists.txt
@@ -193,6 +193,8 @@ target_compile_definitions(_jemalloc INTERFACE -DJEMALLOC_NO_RENAME)
 
 # Because our coverage callbacks call malloc, and recursive call of malloc could not work.
 target_compile_options(_jemalloc PRIVATE ${WITHOUT_COVERAGE_FLAGS_LIST})
+# Due to LTO there are some UB in tcache
+target_compile_options(_jemalloc PRIVATE -fno-lto -fno-whole-program-vtables)
 
 target_compile_definitions(_jemalloc PRIVATE -DJEMALLOC_PROF=1)
 


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix random crashes in jemalloc due to LTO

It seems that previous integration of jemalloc with --wrap (and actually before --wrap apparently we had the same exact problem) disables complete LTO for jemalloc which hides some bugs in tcache (either due to LTO or UB) when we pushing/poping (and in case of LTO it can inline malloc **and** free) address to stack_head.

For now let's simply disable it (I've been fighting with for a few days, but without any luck to find this exact place, and we need to fix this ASAP) and backport.

As a longterm we need to fix it properly and re-enable LTO.

Fixes: https://github.com/ClickHouse/ClickHouse/issues/102460
Fixes: https://github.com/ClickHouse/ClickHouse/issues/80948 (thanks a lot to @korowa for reliable repro)
Fixes: https://github.com/ClickHouse/ClickHouse/pull/99342
Closes: https://github.com/ClickHouse/ClickHouse/pull/102294

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1012`
- Backported to: `26.3.10.18`
<!-- ch-version-info:end -->