### PR TITLE
Encode CIDB insert bodies as UTF-8

### DIFF
--- a/ci/jobs/scripts/cidb_cluster.py
+++ b/ci/jobs/scripts/cidb_cluster.py
@@ -48,6 +48,12 @@ class CIDBCluster:
             self._session.close()
             self._session = None
 
+    @staticmethod
+    def _prepare_request_body(data):
+        if isinstance(data, str):
+            return data.encode("utf-8")
+        return data
+
     def is_ready(self):
         if not self.url:
             self.url, self.user, self.pwd = (
@@ -149,7 +155,7 @@ class CIDBCluster:
                 response = self._session.post(
                     url=self.url,
                     params=params,
-                    data=data,
+                    data=self._prepare_request_body(data),
                     headers=self._auth,
                     timeout=timeout,
                 )
@@ -216,7 +222,7 @@ class CIDBCluster:
                 response = requests.post(
                     url=self.url,
                     params=insert_params,
-                    data=body,
+                    data=self._prepare_request_body(body),
                     headers=self._auth,
                     timeout=Settings.CI_DB_INSERT_TIMEOUT_SEC,
                 )

--- a/ci/praktika/cidb.py
+++ b/ci/praktika/cidb.py
@@ -258,6 +258,12 @@ ORDER BY day DESC
                     raise ex
                 time.sleep(2**attempt)
 
+    @staticmethod
+    def _prepare_request_body(data):
+        if isinstance(data, str):
+            return data.encode("utf-8")
+        return data
+
     def insert_rows(self, jsons, retries=3):
         params = {
             "database": Settings.CI_DB_DB_NAME,
@@ -272,7 +278,7 @@ ORDER BY day DESC
                 response = requests.post(
                     url=self.url,
                     params=params,
-                    data="\n".join(jsons),
+                    data=self._prepare_request_body("\n".join(jsons)),
                     headers=self.auth,
                     timeout=Settings.CI_DB_INSERT_TIMEOUT_SEC,
                 )


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Fix `CIDB` HTTP inserts for non-ASCII payloads by encoding text request bodies as UTF-8 bytes before sending them. This updates the shared insert paths in `CIDBCluster` and `CIDB`, so performance comparison jobs can upload rows with Unicode in `query_display_name` and similar fields instead of failing with `'latin-1' codec can't encode characters ... Body ('метрика') is not valid Latin-1`.

[Example error](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=b9d31357ece12e46afbddddc4f6b71418982760e&name_0=MasterCI&name_1=Performance%20Comparison%20%28amd_release%2C%20master_head%2C%202%2F6%29)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1069`
<!-- ch-version-info:end -->