### PR TITLE
Fix jemalloc metadata corruption caused by page cache freeing with wrong alignment

### DIFF
--- a/src/Common/Allocator.cpp
+++ b/src/Common/Allocator.cpp
@@ -141,7 +141,7 @@ void * Allocator<clear_memory_, populate>::alloc(size_t size, size_t alignment)
 
 
 template <bool clear_memory_, bool populate>
-void Allocator<clear_memory_, populate>::free(void * buf, size_t size)
+void Allocator<clear_memory_, populate>::free(void * buf, size_t size, size_t /* alignment */)
 {
     try
     {

--- a/src/Common/Allocator.h
+++ b/src/Common/Allocator.h
@@ -46,7 +46,7 @@ public:
     void * alloc(size_t size, size_t alignment = 0);
 
     /// Free memory range.
-    void free(void * buf, size_t size);
+    void free(void * buf, size_t size, size_t alignment = 0);
 
     /** Enlarge memory range.
       * Data from old range is moved to the beginning of new range.
@@ -97,10 +97,10 @@ public:
         return Base::alloc(size, Alignment);
     }
 
-    void free(void * buf, size_t size)
+    void free(void * buf, size_t size, size_t alignment = 0)
     {
         if (size > initial_bytes)
-            Base::free(buf, size);
+            Base::free(buf, size, alignment);
     }
 
     void * realloc(void * buf, size_t old_size, size_t new_size)

--- a/src/Common/JemallocCacheAllocator.cpp
+++ b/src/Common/JemallocCacheAllocator.cpp
@@ -41,9 +41,12 @@ int arenaFlags(size_t alignment)
     return flags;
 }
 
-int freeFlags()
+int freeFlags(size_t alignment)
 {
-    return MALLOCX_TCACHE_NONE;
+    int flags = MALLOCX_TCACHE_NONE;
+    if (alignment > MALLOC_MIN_ALIGNMENT)
+        flags |= MALLOCX_ALIGN(alignment);
+    return flags;
 }
 
 }
@@ -65,12 +68,12 @@ void * JemallocCacheAllocator::alloc(size_t size, size_t alignment)
     return ptr;
 }
 
-void JemallocCacheAllocator::free(void * buf, size_t size)
+void JemallocCacheAllocator::free(void * buf, size_t size, size_t alignment)
 {
     try
     {
         checkSize(size);
-        je_sdallocx(buf, size, freeFlags());
+        je_sdallocx(buf, size, freeFlags(alignment));
         auto trace = CurrentMemoryTracker::free(size);
         trace.onFree(buf, size);
     }

--- a/src/Common/JemallocCacheAllocator.h
+++ b/src/Common/JemallocCacheAllocator.h
@@ -30,7 +30,7 @@ class JemallocCacheAllocator
 {
 public:
     void * alloc(size_t size, size_t alignment = 0);
-    void free(void * buf, size_t size);
+    void free(void * buf, size_t size, size_t alignment = 0);
     void * realloc(void * buf, size_t old_size, size_t new_size, size_t alignment = 0);
 
 protected:

--- a/src/Common/PageCache.cpp
+++ b/src/Common/PageCache.cpp
@@ -269,7 +269,7 @@ PageCacheCell::~PageCacheCell()
     std::optional<MemoryTrackerBlockerInThread> blocker;
     if (!m_temporary)
         blocker.emplace();
-    JemallocCacheAllocator().free(m_data, m_size);
+    JemallocCacheAllocator().free(m_data, m_size, DEFAULT_AIO_FILE_BLOCK_SIZE);
 }
 
 }

--- a/src/IO/BufferWithOwnMemory.h
+++ b/src/IO/BufferWithOwnMemory.h
@@ -142,7 +142,7 @@ private:
         if (!m_data)
             return;
 
-        Allocator::free(m_data, m_capacity);
+        Allocator::free(m_data, m_capacity, alignment);
         m_data = nullptr;    /// To avoid double free if next alloc will throw an exception.
     }
 };

--- a/src/IO/tests/gtest_memory_resize.cpp
+++ b/src/IO/tests/gtest_memory_resize.cpp
@@ -51,7 +51,7 @@ public:
         return dummy_address;
     }
 
-    void free([[maybe_unused]] void * buf, size_t /*size*/)
+    void free([[maybe_unused]] void * buf, size_t /*size*/, size_t /*alignment*/ = 0)
     {
         assert(buf == dummy_address);
     }


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1554
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1555
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1784
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1080
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1811
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1809
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1829
<!-- End of fixes issue link part, do not remove -->

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix jemalloc metadata corruption caused by page cache freeing with wrong alignment that may lead to crashes

`JemallocCacheAllocator::alloc` passes `MALLOCX_ALIGN(alignment)` to `je_mallocx`, which changes the size class of the allocation. But `free` called `je_sdallocx` without the alignment flag, which may cause jemalloc to compute a different size class for the same size — corrupting jemalloc's internal extent/slab metadata.

The only affected caller is `PageCacheCell`, which allocates with `DEFAULT_AIO_FILE_BLOCK_SIZE` alignment but freed without it.

Found with JEMALLOC_OPT_SAFETY_CHECKS/config_opt_safety_checks [1], while working on https://github.com/ClickHouse/ClickHouse/pull/102913 (note, that https://github.com/ClickHouse/ClickHouse/pull/102913 is more important)

  [1]: https://pastila.nl/?0004ee83/c57a3bc6fb7219dc2149b459895c6ac3#nvyVGdUfxMop9XHaDpS36A==GCM

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1062`
- Backported to: `26.3.10.17`
<!-- ch-version-info:end -->