### PR TITLE
Backport distroless Docker image variant to 26.3

### DIFF
--- a/docker/keeper/Dockerfile.distroless
+++ b/docker/keeper/Dockerfile.distroless
@@ -1,0 +1,179 @@
+# Distroless ClickHouse Keeper image.
+# Contains no shell, no package manager, no coreutils.
+# The entrypoint is the compiled `clickhouse docker-init --keeper` subcommand.
+#
+# Build targets:
+#   production  — gcr.io/distroless/cc-debian13:nonroot  (default)
+#   debug       — gcr.io/distroless/cc-debian13:debug-nonroot  (includes busybox shell)
+#
+# Usage:
+#   docker build -f Dockerfile.distroless --target production -t clickhouse/clickhouse-keeper:distroless .
+#   docker build -f Dockerfile.distroless --target debug     -t clickhouse/clickhouse-keeper:distroless-debug .
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Stage 1: Install ClickHouse and assemble the output directory tree.
+# ──────────────────────────────────────────────────────────────────────────────
+FROM ubuntu:22.04 AS ch-builder
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG apt_archive="http://archive.ubuntu.com"
+
+# user/group precreated explicitly with fixed uid/gid on purpose.
+# The same uid/gid (101) is used both for alpine and ubuntu.
+RUN sed -i "s|http://archive.ubuntu.com|${apt_archive}|g" /etc/apt/sources.list \
+    && groupadd -r clickhouse --gid=101 \
+    && useradd -r -g clickhouse --uid=101 --home-dir=/var/lib/clickhouse --shell=/bin/bash clickhouse \
+    && apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        ca-certificates \
+        wget \
+    && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
+
+ARG REPO_CHANNEL="stable"
+ARG REPOSITORY="deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/deb ${REPO_CHANNEL} main"
+ARG VERSION="26.3.4.11"
+ARG PACKAGES="clickhouse-common-static clickhouse-keeper"
+
+ARG deb_location_url=""
+ARG DIRECT_DOWNLOAD_URLS=""
+ARG single_binary_location_url=""
+ARG TARGETARCH
+
+# Install from direct URLs (deb packages provided by CI).
+RUN if [ -n "${DIRECT_DOWNLOAD_URLS}" ]; then \
+        rm -rf /tmp/clickhouse_debs \
+        && mkdir -p /tmp/clickhouse_debs \
+        && for url in $DIRECT_DOWNLOAD_URLS; do \
+            wget --progress=bar:force:noscroll "$url" -P /tmp/clickhouse_debs || exit 1 \
+        ; done \
+        && dpkg -i /tmp/clickhouse_debs/*.deb \
+        && rm -rf /tmp/* ; \
+    fi
+
+# Install from a web location with deb packages.
+RUN arch="${TARGETARCH:-amd64}" \
+    && if [ -n "${deb_location_url}" ]; then \
+        rm -rf /tmp/clickhouse_debs \
+        && mkdir -p /tmp/clickhouse_debs \
+        && for package in ${PACKAGES}; do \
+            { wget --progress=bar:force:noscroll "${deb_location_url}/${package}_${VERSION}_${arch}.deb" -P /tmp/clickhouse_debs || \
+              wget --progress=bar:force:noscroll "${deb_location_url}/${package}_${VERSION}_all.deb" -P /tmp/clickhouse_debs ; } \
+            || exit 1 \
+        ; done \
+        && dpkg -i /tmp/clickhouse_debs/*.deb \
+        && rm -rf /tmp/* ; \
+    fi
+
+# Install from a single binary.
+RUN if [ -n "${single_binary_location_url}" ]; then \
+        rm -rf /tmp/clickhouse_binary \
+        && mkdir -p /tmp/clickhouse_binary \
+        && wget --progress=bar:force:noscroll "${single_binary_location_url}" -O /tmp/clickhouse_binary/clickhouse \
+        && chmod +x /tmp/clickhouse_binary/clickhouse \
+        && /tmp/clickhouse_binary/clickhouse install --user "clickhouse" --group "clickhouse" \
+        && rm -rf /tmp/* ; \
+    fi
+
+# Fall back to installation from the ClickHouse repository.
+RUN clickhouse local -q 'SELECT 1' >/dev/null 2>&1 && exit 0 || : \
+    ; apt-get update \
+    && apt-get install --yes --no-install-recommends dirmngr gnupg2 \
+    && mkdir -p /etc/apt/sources.list.d \
+    && GNUPGHOME=$(mktemp -d) \
+    && GNUPGHOME="$GNUPGHOME" gpg --batch --no-default-keyring \
+        --keyring /usr/share/keyrings/clickhouse-keyring.gpg \
+        --keyserver hkp://keyserver.ubuntu.com:80 \
+        --recv-keys 3a9ea1193a97b548be1457d48919f6bd2b48d754 \
+    && rm -rf "$GNUPGHOME" \
+    && chmod +r /usr/share/keyrings/clickhouse-keyring.gpg \
+    && echo "${REPOSITORY}" > /etc/apt/sources.list.d/clickhouse.list \
+    && echo "installing from repository: ${REPOSITORY}" \
+    && apt-get update \
+    && for package in ${PACKAGES}; do \
+        packages="${packages} ${package}=${VERSION}" \
+    ; done \
+    && apt-get install --yes --no-install-recommends ${packages} \
+    && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/* \
+    && apt-get autoremove --purge -yq dirmngr gnupg2
+
+# Verify the installation.
+# Use "clickhouse local" (not "clickhouse-local") because the clickhouse-local symlink
+# is provided by clickhouse-server which is not installed here.
+RUN clickhouse local -q 'SELECT version()'
+
+ARG DEFAULT_DATA_DIR="/var/lib/clickhouse"
+ARG DEFAULT_LOG_DIR="/var/log/clickhouse-keeper"
+ARG DEFAULT_CONFIG_DIR="/etc/clickhouse-keeper"
+
+# Assemble the output directory tree.
+RUN mkdir -p \
+        /output/usr/bin \
+        /output${DEFAULT_CONFIG_DIR} \
+        /output${DEFAULT_DATA_DIR} \
+        /output${DEFAULT_LOG_DIR} \
+        /output/tmp \
+    && cp /usr/bin/clickhouse /output/usr/bin/clickhouse \
+    && for link in clickhouse-keeper clickhouse-keeper-client clickhouse-docker-init; do \
+        ln -sf /usr/bin/clickhouse "/output/usr/bin/${link}" ; \
+    done \
+    && if [ -d "${DEFAULT_CONFIG_DIR}" ]; then cp -rp "${DEFAULT_CONFIG_DIR}/." "/output${DEFAULT_CONFIG_DIR}/"; fi \
+    && chown -R clickhouse:clickhouse \
+        /output${DEFAULT_CONFIG_DIR} \
+        /output${DEFAULT_DATA_DIR} \
+        /output${DEFAULT_LOG_DIR} \
+    && chmod 1777 /output/tmp \
+    && { \
+        printf 'root:x:0:0:root:/root:/sbin/nologin\n'; \
+        printf 'nobody:x:65534:65534:nobody:/nonexistent:/sbin/nologin\n'; \
+        printf 'nonroot:x:65532:65532:nonroot:/home/nonroot:/sbin/nologin\n'; \
+        printf 'clickhouse:x:101:101:ClickHouse:/var/lib/clickhouse:/sbin/nologin\n'; \
+    } > /output/etc/passwd \
+    && { \
+        printf 'root:x:0:\n'; \
+        printf 'nobody:x:65534:\n'; \
+        printf 'nonroot:x:65532:\n'; \
+        printf 'clickhouse:x:101:\n'; \
+    } > /output/etc/group
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Stage 2: Production distroless image.
+# ──────────────────────────────────────────────────────────────────────────────
+# Pinned 2026-04-02. Refresh: docker pull gcr.io/distroless/cc-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:nonroot
+FROM gcr.io/distroless/cc-debian13:nonroot@sha256:9c4fe2381c2e6d53c4cfdefeff6edbd2a67ec7713e2c3ca6653806cbdbf27a1e AS production
+
+COPY --from=ch-builder /output/ /
+
+ENV TZ=UTC \
+    CLICKHOUSE_WATCHDOG_ENABLE=0
+
+# 9181: ZooKeeper-compatible client port
+# 9234: Raft port (inter-node communication)
+EXPOSE 9181 9234
+
+VOLUME ["/var/lib/clickhouse", "/var/log/clickhouse-keeper"]
+
+USER 101:101
+WORKDIR /var/lib/clickhouse
+
+ENTRYPOINT ["/usr/bin/clickhouse", "docker-init", "--keeper"]
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Stage 3: Debug image — same as production but includes the busybox shell
+#           at /busybox/sh for interactive troubleshooting.
+# ──────────────────────────────────────────────────────────────────────────────
+# Pinned 2026-04-02. Refresh: docker pull gcr.io/distroless/cc-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:debug-nonroot
+FROM gcr.io/distroless/cc-debian13:debug-nonroot@sha256:d47b319b1047dff7cdee335e3e61468f3610fac20060653aabe3786d6ecba621 AS debug
+
+COPY --from=ch-builder /output/ /
+
+ENV TZ=UTC \
+    CLICKHOUSE_WATCHDOG_ENABLE=0
+
+EXPOSE 9181 9234
+
+VOLUME ["/var/lib/clickhouse", "/var/log/clickhouse-keeper"]
+
+USER 101:101
+WORKDIR /var/lib/clickhouse
+
+ENTRYPOINT ["/usr/bin/clickhouse", "docker-init", "--keeper"]

--- a/docker/server/Dockerfile.distroless
+++ b/docker/server/Dockerfile.distroless
@@ -1,0 +1,199 @@
+# Distroless ClickHouse server image.
+# Contains no shell, no package manager, no coreutils.
+# The entrypoint is the compiled `clickhouse docker-init` subcommand.
+#
+# Build targets:
+#   production  — gcr.io/distroless/cc-debian13:nonroot  (default)
+#   debug       — gcr.io/distroless/cc-debian13:debug-nonroot  (includes busybox shell)
+#
+# Usage:
+#   docker build -f Dockerfile.distroless --target production -t clickhouse/clickhouse-server:distroless .
+#   docker build -f Dockerfile.distroless --target debug     -t clickhouse/clickhouse-server:distroless-debug .
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Stage 1: Install ClickHouse and assemble the output directory tree.
+# ──────────────────────────────────────────────────────────────────────────────
+FROM ubuntu:22.04 AS ch-builder
+
+# see https://github.com/moby/moby/issues/4032#issuecomment-192327844
+ARG DEBIAN_FRONTEND=noninteractive
+
+ARG apt_archive="http://archive.ubuntu.com"
+
+# user/group precreated explicitly with fixed uid/gid on purpose.
+# It is especially important for rootless containers: in that case entrypoint
+# can't do chown and owners of mounted volumes should be configured externally.
+# We do that in advance at the beginning of Dockerfile before any packages will be
+# installed to prevent picking those uid/gid by some unrelated software.
+# The same uid/gid (101) is used both for alpine and ubuntu.
+RUN sed -i "s|http://archive.ubuntu.com|${apt_archive}|g" /etc/apt/sources.list \
+    && groupadd -r clickhouse --gid=101 \
+    && useradd -r -g clickhouse --uid=101 --home-dir=/var/lib/clickhouse --shell=/bin/bash clickhouse \
+    && apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        ca-certificates \
+        wget \
+    && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/*
+
+ARG REPO_CHANNEL="stable"
+ARG REPOSITORY="deb [signed-by=/usr/share/keyrings/clickhouse-keyring.gpg] https://packages.clickhouse.com/deb ${REPO_CHANNEL} main"
+ARG VERSION="26.3.4.11"
+ARG PACKAGES="clickhouse-client clickhouse-server clickhouse-common-static"
+
+#docker-official-library:off
+ARG deb_location_url=""
+ARG DIRECT_DOWNLOAD_URLS=""
+ARG single_binary_location_url=""
+ARG TARGETARCH
+
+# Install from direct URLs (deb packages provided by CI).
+RUN if [ -n "${DIRECT_DOWNLOAD_URLS}" ]; then \
+        rm -rf /tmp/clickhouse_debs \
+        && mkdir -p /tmp/clickhouse_debs \
+        && for url in $DIRECT_DOWNLOAD_URLS; do \
+            wget --progress=bar:force:noscroll "$url" -P /tmp/clickhouse_debs || exit 1 \
+        ; done \
+        && dpkg -i /tmp/clickhouse_debs/*.deb \
+        && rm -rf /tmp/* ; \
+    fi
+
+# Install from a web location with deb packages.
+RUN arch="${TARGETARCH:-amd64}" \
+    && if [ -n "${deb_location_url}" ]; then \
+        rm -rf /tmp/clickhouse_debs \
+        && mkdir -p /tmp/clickhouse_debs \
+        && for package in ${PACKAGES}; do \
+            { wget --progress=bar:force:noscroll "${deb_location_url}/${package}_${VERSION}_${arch}.deb" -P /tmp/clickhouse_debs || \
+              wget --progress=bar:force:noscroll "${deb_location_url}/${package}_${VERSION}_all.deb" -P /tmp/clickhouse_debs ; } \
+            || exit 1 \
+        ; done \
+        && dpkg -i /tmp/clickhouse_debs/*.deb \
+        && rm -rf /tmp/* ; \
+    fi
+
+# Install from a single binary.
+RUN if [ -n "${single_binary_location_url}" ]; then \
+        rm -rf /tmp/clickhouse_binary \
+        && mkdir -p /tmp/clickhouse_binary \
+        && wget --progress=bar:force:noscroll "${single_binary_location_url}" -O /tmp/clickhouse_binary/clickhouse \
+        && chmod +x /tmp/clickhouse_binary/clickhouse \
+        && /tmp/clickhouse_binary/clickhouse install --user "clickhouse" --group "clickhouse" \
+        && rm -rf /tmp/* ; \
+    fi
+
+# Fall back to installation from the ClickHouse repository.
+RUN clickhouse local -q 'SELECT 1' >/dev/null 2>&1 && exit 0 || : \
+    ; apt-get update \
+    && apt-get install --yes --no-install-recommends dirmngr gnupg2 \
+    && mkdir -p /etc/apt/sources.list.d \
+    && GNUPGHOME=$(mktemp -d) \
+    && GNUPGHOME="$GNUPGHOME" gpg --batch --no-default-keyring \
+        --keyring /usr/share/keyrings/clickhouse-keyring.gpg \
+        --keyserver hkp://keyserver.ubuntu.com:80 \
+        --recv-keys 3a9ea1193a97b548be1457d48919f6bd2b48d754 \
+    && rm -rf "$GNUPGHOME" \
+    && chmod +r /usr/share/keyrings/clickhouse-keyring.gpg \
+    && echo "${REPOSITORY}" > /etc/apt/sources.list.d/clickhouse.list \
+    && echo "installing from repository: ${REPOSITORY}" \
+    && apt-get update \
+    && for package in ${PACKAGES}; do \
+        packages="${packages} ${package}=${VERSION}" \
+    ; done \
+    && apt-get install --yes --no-install-recommends ${packages} \
+    && rm -rf /var/lib/apt/lists/* /var/cache/debconf /tmp/* \
+    && apt-get autoremove --purge -yq dirmngr gnupg2
+
+#docker-official-library:on
+
+# Verify the installation.
+RUN clickhouse-local -q 'SELECT * FROM system.build_options'
+
+# Assemble the output directory tree that will be COPYed into the distroless image.
+# Symlinks pointing to /usr/bin/clickhouse are preserved by Docker COPY.
+RUN mkdir -p \
+        /output/usr/bin \
+        /output/etc/clickhouse-server/config.d \
+        /output/etc/clickhouse-server/users.d \
+        /output/etc/clickhouse-client \
+        /output/var/lib/clickhouse \
+        /output/var/log/clickhouse-server \
+        /output/docker-entrypoint-initdb.d \
+        /output/tmp \
+    && cp /usr/bin/clickhouse /output/usr/bin/clickhouse \
+    && for link in clickhouse-server clickhouse-client clickhouse-local \
+                   clickhouse-keeper clickhouse-keeper-client \
+                   clickhouse-docker-init; do \
+        ln -sf /usr/bin/clickhouse "/output/usr/bin/${link}" ; \
+    done \
+    && cp -r /etc/clickhouse-server/. /output/etc/clickhouse-server/ \
+    && if [ -d /etc/clickhouse-client ]; then cp -r /etc/clickhouse-client/. /output/etc/clickhouse-client/; fi
+
+COPY docker_related_config.xml /output/etc/clickhouse-server/config.d/
+
+# Set ownership after all config files are in place (including docker_related_config.xml above).
+RUN chown -R clickhouse:clickhouse \
+        /output/etc/clickhouse-server \
+        /output/var/lib/clickhouse \
+        /output/var/log/clickhouse-server \
+        /output/docker-entrypoint-initdb.d \
+    && chmod 1777 /output/tmp
+
+# Create /etc/passwd and /etc/group that include the clickhouse user (uid/gid 101).
+# These entries are merged with the distroless base's existing entries.
+RUN { \
+        printf 'root:x:0:0:root:/root:/sbin/nologin\n'; \
+        printf 'nobody:x:65534:65534:nobody:/nonexistent:/sbin/nologin\n'; \
+        printf 'nonroot:x:65532:65532:nonroot:/home/nonroot:/sbin/nologin\n'; \
+        printf 'clickhouse:x:101:101:ClickHouse:/var/lib/clickhouse:/sbin/nologin\n'; \
+    } > /output/etc/passwd \
+    && { \
+        printf 'root:x:0:\n'; \
+        printf 'nobody:x:65534:\n'; \
+        printf 'nonroot:x:65532:\n'; \
+        printf 'clickhouse:x:101:\n'; \
+    } > /output/etc/group
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Stage 2: Production distroless image.
+# ──────────────────────────────────────────────────────────────────────────────
+# Pinned 2026-04-02. Refresh: docker pull gcr.io/distroless/cc-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:nonroot
+FROM gcr.io/distroless/cc-debian13:nonroot@sha256:9c4fe2381c2e6d53c4cfdefeff6edbd2a67ec7713e2c3ca6653806cbdbf27a1e AS production
+
+COPY --from=ch-builder /output/ /
+
+ENV CLICKHOUSE_CONFIG=/etc/clickhouse-server/config.xml \
+    LC_ALL=C.UTF-8 \
+    TZ=UTC \
+    CLICKHOUSE_WATCHDOG_ENABLE=0
+
+EXPOSE 9000 8123 9009
+
+VOLUME ["/var/lib/clickhouse", "/var/log/clickhouse-server"]
+
+USER 101:101
+WORKDIR /var/lib/clickhouse
+
+ENTRYPOINT ["/usr/bin/clickhouse", "docker-init"]
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Stage 3: Debug image — same as production but includes the busybox shell
+#           at /busybox/sh for interactive troubleshooting.
+# ──────────────────────────────────────────────────────────────────────────────
+# Pinned 2026-04-02. Refresh: docker pull gcr.io/distroless/cc-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:debug-nonroot
+FROM gcr.io/distroless/cc-debian13:debug-nonroot@sha256:d47b319b1047dff7cdee335e3e61468f3610fac20060653aabe3786d6ecba621 AS debug
+
+COPY --from=ch-builder /output/ /
+
+ENV CLICKHOUSE_CONFIG=/etc/clickhouse-server/config.xml \
+    LC_ALL=C.UTF-8 \
+    TZ=UTC \
+    CLICKHOUSE_WATCHDOG_ENABLE=0
+
+EXPOSE 9000 8123 9009
+
+VOLUME ["/var/lib/clickhouse", "/var/log/clickhouse-server"]
+
+USER 101:101
+WORKDIR /var/lib/clickhouse
+
+ENTRYPOINT ["/usr/bin/clickhouse", "docker-init"]


### PR DESCRIPTION
Add distroless Dockerfile for server and keeper images — minimal images with no shell, no package manager, only the ClickHouse binary.

The release workflow on master already includes distroless in its build configs (PR #101941). This backport ensures the Dockerfiles exist at the release tag so the images are actually built. Without this, the workflow skips distroless with "Dockerfile.distroless not found at this tag".

25.8 already has this backport but is blocked from releasing by a flaky test. 26.3 has green CI and is ready for the next auto-release.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Add distroless Docker image variant for server and keeper.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)