### PR TITLE
feat(promql): Implement Prometheus /api/v1/series, /labels, /label/<name>/values endpoints

### DIFF
--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -36,6 +36,7 @@
 #include <Storages/TimeSeries/PrometheusRemoteWriteProtocol.h>
 #include <Storages/TimeSeries/PrometheusHTTPProtocolAPI.h>
 
+#include <vector>
 
 namespace DB
 {
@@ -437,21 +438,21 @@ public:
             }
             else if (uri.starts_with("/api/v1/series"))
             {
-                String match = params->get("match[]", "");
+                std::vector<String> match_params = params->getAll("match[]");
                 String start = params->get("start", "");
                 String end = params->get("end", "");
 
                 /// TODO: Support limit=<number> optional parameter
 
-                protocol.getSeries(getOutputStream(response), match, start, end);
+                protocol.getSeries(getOutputStream(response), match_params, start, end);
             }
             else if (uri.starts_with("/api/v1/labels"))
             {
-                String match = params->get("match[]", "");
+                std::vector<String> match_params = params->getAll("match[]");
                 String start = params->get("start", "");
                 String end = params->get("end", "");
 
-                protocol.getLabels(getOutputStream(response), match, start, end);
+                protocol.getLabels(getOutputStream(response), match_params, start, end);
             }
             else if (path_without_query.find("/api/v1/label/") != String::npos && path_without_query.ends_with("/values"))
             {
@@ -460,11 +461,11 @@ public:
                 size_t end_pos = path_without_query.find("/values");
                 String label_name = path_without_query.substr(start_pos, end_pos - start_pos);
 
-                String match = params->get("match[]", "");
+                std::vector<String> match_params = params->getAll("match[]");
                 String start = params->get("start", "");
                 String end = params->get("end", "");
 
-                protocol.getLabelValues(getOutputStream(response), label_name, match, start, end);
+                protocol.getLabelValues(getOutputStream(response), label_name, match_params, start, end);
             }
             else
             {

--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -362,7 +362,7 @@ public:
 
         /// Some parameters (database, default_format, everything used in the code above) do not
         /// belong to the Settings class.
-        static const NameSet reserved_param_names{"user", "password", "query", "time", "start", "end", "step"};
+        static const NameSet reserved_param_names{"user", "password", "query", "time", "start", "end", "step", "match[]"};
         return !reserved_param_names.contains(name);
     }
 
@@ -373,6 +373,12 @@ public:
 
 
         const String & uri = request.getURI();
+        /// `uri` includes the query string; path-only checks must ignore it (e.g. `/api/v1/label/x/values?match[]=...`).
+        const String path_without_query = [&]
+        {
+            const auto q = uri.find('?');
+            return q == String::npos ? uri : uri.substr(0, q);
+        }();
         LOG_DEBUG(log(), "Processing Query API request: method={}, uri={}", request.getMethod(), uri);
 
         response.setContentType("application/json");
@@ -447,12 +453,12 @@ public:
 
                 protocol.getLabels(getOutputStream(response), match, start, end);
             }
-            else if (uri.find("/api/v1/label/") != String::npos && uri.ends_with("/values"))
+            else if (path_without_query.find("/api/v1/label/") != String::npos && path_without_query.ends_with("/values"))
             {
                 // Extract label name from URI: /api/v1/label/<name>/values
-                size_t start_pos = uri.find("/api/v1/label/") + 14; // length of "/api/v1/label/"
-                size_t end_pos = uri.find("/values");
-                String label_name = uri.substr(start_pos, end_pos - start_pos);
+                size_t start_pos = path_without_query.find("/api/v1/label/") + 14; // length of "/api/v1/label/"
+                size_t end_pos = path_without_query.find("/values");
+                String label_name = path_without_query.substr(start_pos, end_pos - start_pos);
 
                 String match = params->get("match[]", "");
                 String start = params->get("start", "");

--- a/src/Server/PrometheusRequestHandler.cpp
+++ b/src/Server/PrometheusRequestHandler.cpp
@@ -10,6 +10,7 @@
 #include <base/scope_guard.h>
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/Net/HTTPResponse.h>
+#include <Poco/URI.h>
 #include <Common/logger_useful.h>
 #include <Common/setThreadName.h>
 #include "config.h"
@@ -457,9 +458,17 @@ public:
             else if (path_without_query.find("/api/v1/label/") != String::npos && path_without_query.ends_with("/values"))
             {
                 // Extract label name from URI: /api/v1/label/<name>/values
-                size_t start_pos = path_without_query.find("/api/v1/label/") + 14; // length of "/api/v1/label/"
-                size_t end_pos = path_without_query.find("/values");
-                String label_name = path_without_query.substr(start_pos, end_pos - start_pos);
+                static constexpr std::string_view label_prefix = "/api/v1/label/";
+                static constexpr std::string_view values_suffix = "/values";
+                /// Use the prefix/suffix anchors (not `find("/values")`, which returns the first match) so that
+                /// labels like `foo/values_bar` in `/api/v1/label/foo/values_bar/values` are not truncated.
+                const size_t start_pos = path_without_query.find(label_prefix) + label_prefix.size();
+                const size_t end_pos = path_without_query.size() - values_suffix.size();
+                String encoded_label_name = path_without_query.substr(start_pos, end_pos - start_pos);
+                /// Path segments may be percent-encoded (e.g. `job%2Fname`); decode before matching against
+                /// stored label names. `Poco::URI::decode` handles `%xx` and `+` consistently with Prometheus.
+                String label_name;
+                Poco::URI::decode(encoded_label_name, label_name);
 
                 std::vector<String> match_params = params->getAll("match[]");
                 String start = params->get("start", "");

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -137,9 +137,19 @@ String predicateForMatcher(const Matcher & matcher, const Map & tags_to_columns)
 
     const auto key_lit = quoteString(matcher.label_name);
     const auto map_access = fmt::format("{}[{}]", tags_col_name, key_lit);
+    /// Prometheus treats a missing label as an empty string (same as NE/NRE branches below).
     switch (matcher.matcher_type)
     {
         case MatcherType::EQ:
+            if (matcher.label_value.empty())
+                return fmt::format(
+                    "(NOT mapContains({}, {})) OR (mapContains({}, {}) AND {} = {})",
+                    tags_col_name,
+                    key_lit,
+                    tags_col_name,
+                    key_lit,
+                    map_access,
+                    quoteString(matcher.label_value));
             return fmt::format(
                 "mapContains({}, {}) AND {} = {}", tags_col_name, key_lit, map_access, quoteString(matcher.label_value));
         case MatcherType::NE:
@@ -147,10 +157,26 @@ String predicateForMatcher(const Matcher & matcher, const Map & tags_to_columns)
                 "(NOT mapContains({}, {})) OR ({} != {})", tags_col_name, key_lit, map_access, quoteString(matcher.label_value));
         case MatcherType::RE:
             return fmt::format(
-                "mapContains({}, {}) AND match({}, {})", tags_col_name, key_lit, map_access, quoteString(matcher.label_value));
+                "((NOT mapContains({}, {})) AND match({}, {})) OR (mapContains({}, {}) AND match({}, {}))",
+                tags_col_name,
+                key_lit,
+                quoteString(""),
+                quoteString(matcher.label_value),
+                tags_col_name,
+                key_lit,
+                map_access,
+                quoteString(matcher.label_value));
         case MatcherType::NRE:
             return fmt::format(
-                "(NOT mapContains({}, {})) OR NOT match({}, {})", tags_col_name, key_lit, map_access, quoteString(matcher.label_value));
+                "((NOT mapContains({}, {})) AND NOT match({}, {})) OR (mapContains({}, {}) AND NOT match({}, {}))",
+                tags_col_name,
+                key_lit,
+                quoteString(""),
+                quoteString(matcher.label_value),
+                tags_col_name,
+                key_lit,
+                map_access,
+                quoteString(matcher.label_value));
     }
     UNREACHABLE();
 }

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -709,9 +709,26 @@ void PrometheusHTTPProtocolAPI::getLabels(
     auto tags_table_id = tags_table->getStorageID();
 
     const UInt64 max_series = ts_settings[TimeSeriesSetting::prometheus_max_series];
+
+    /// Derive the label set from matched rows only; do not unconditionally add `__name__` or every promoted label
+    /// from `tags_to_columns`, because `match[]` may exclude all series or matched series may not carry every
+    /// promoted label.
+    String labels_expr = "if(count() > 0, ['__name__'], CAST([], 'Array(String)'))";
+    for (const auto & tag_name_and_column_name : tags_to_columns_map)
+    {
+        const auto & tuple = tag_name_and_column_name.safeGet<Tuple>();
+        const auto & tag_name = tuple.at(0).safeGet<String>();
+        const auto & column_name = tuple.at(1).safeGet<String>();
+        labels_expr += fmt::format(
+            ", if(countIf({} != '') > 0, [{}], CAST([], 'Array(String)'))",
+            backQuoteIfNeed(column_name),
+            quoteString(tag_name));
+    }
+    labels_expr += fmt::format(", groupUniqArrayArray(mapKeys({}))", TimeSeriesColumnNames::Tags);
+
     String query = fmt::format(
-        "SELECT label_key FROM (SELECT arrayJoin(groupUniqArrayArray(mapKeys({}))) AS label_key FROM {}{}) LIMIT {}",
-        TimeSeriesColumnNames::Tags,
+        "SELECT label_key FROM (SELECT arrayJoin(arrayDistinct(arrayConcat({}))) AS label_key FROM {}{}) LIMIT {}",
+        labels_expr,
         tags_table_id.getFullTableName(),
         where_clause,
         max_series);
@@ -724,13 +741,6 @@ void PrometheusHTTPProtocolAPI::getLabels(
     Block result_block;
 
     std::set<String> label_names;
-    label_names.insert("__name__");
-    for (const auto & tag_name_and_column_name : tags_to_columns_map)
-    {
-        const auto & tuple = tag_name_and_column_name.safeGet<Tuple>();
-        label_names.insert(tuple.at(0).safeGet<String>());
-    }
-
     while (executor.pull(result_block))
     {
         if (result_block.empty() || result_block.rows() == 0)

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -802,8 +802,9 @@ void PrometheusHTTPProtocolAPI::getLabelValues(
             map_where = fmt::format(" WHERE mapContains({}, {})", TimeSeriesColumnNames::Tags, key_lit);
         else
             map_where = where_clause + fmt::format(" AND mapContains({}, {})", TimeSeriesColumnNames::Tags, key_lit);
+        /// DISTINCT keeps empty-string label values; `arrayJoin` drops empty strings in ClickHouse.
         query = fmt::format(
-            "SELECT label_value FROM (SELECT arrayJoin(groupUniqArray({})) AS label_value FROM {}{}) ORDER BY label_value LIMIT {}",
+            "SELECT label_value FROM (SELECT DISTINCT {} AS label_value FROM {}{}) ORDER BY label_value LIMIT {}",
             map_access,
             tags_table_id.getFullTableName(),
             map_where,
@@ -830,8 +831,6 @@ void PrometheusHTTPProtocolAPI::getLabelValues(
         for (size_t i = 0; i < result_block.rows(); ++i)
         {
             auto value = value_col->getDataAt(i);
-            if (value.empty())
-                continue;
             if (!first)
                 writeString(",", response);
             first = false;

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -263,7 +263,8 @@ String buildMatchWhere(const std::vector<String> & match_params, const Map & tag
                     or_chain += " OR ";
                 or_chain += selector_predicates[i];
             }
-            top_parts.push_back(or_chain);
+            /// AND binds tighter than OR; wrap the union so we get `(match1 OR match2) AND time`, not `match1 OR (match2 AND time)`.
+            top_parts.push_back("(" + or_chain + ")");
         }
     }
     if (!time_predicate.empty())

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -154,6 +154,10 @@ String predicateForMatcher(const Matcher & matcher, const Map & tags_to_columns)
             return fmt::format(
                 "mapContains({}, {}) AND {} = {}", tags_col_name, key_lit, map_access, quoteString(matcher.label_value));
         case MatcherType::NE:
+            /// `{key!=""}` must exclude series without the label: Prometheus treats an absent label as the
+            /// empty string, so absent should NOT satisfy `!= ""`. Require key presence in that case.
+            if (matcher.label_value.empty())
+                return fmt::format("mapContains({}, {}) AND {} != {}", tags_col_name, key_lit, map_access, quoteString(""));
             return fmt::format(
                 "(NOT mapContains({}, {})) OR ({} != {})", tags_col_name, key_lit, map_access, quoteString(matcher.label_value));
         case MatcherType::RE:

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -44,12 +44,12 @@ namespace TimeSeriesSetting
     extern const TimeSeriesSettingsBool store_min_time_and_max_time;
     extern const TimeSeriesSettingsBool filter_by_min_time_and_max_time;
     extern const TimeSeriesSettingsMap tags_to_columns;
+    extern const TimeSeriesSettingsUInt64 prometheus_max_series;
 }
 
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
-    extern const int NOT_IMPLEMENTED;
 }
 
 namespace
@@ -189,18 +189,16 @@ String buildTimeOverlapWhere(const TimeSeriesSettings & settings, const String &
     return predicates;
 }
 
-String combineWhereClause(const MatcherList & matchers, const Map & tags_to_columns, const String & time_predicate)
+/// Predicate for matchers inside one PromQL instant selector (AND). Empty list matches all (`{}`).
+String predicateForMatcherList(const MatcherList & matchers, const Map & tags_to_columns)
 {
+    if (matchers.empty())
+        return "1";
+
     std::vector<String> parts;
     for (const auto & matcher : matchers)
         parts.push_back(predicateForMatcher(matcher, tags_to_columns));
-    if (!time_predicate.empty())
-        parts.push_back(time_predicate);
-
-    if (parts.empty())
-        return {};
-
-    String out = " WHERE ";
+    String out;
     for (size_t i = 0; i < parts.size(); ++i)
     {
         if (i)
@@ -210,7 +208,54 @@ String combineWhereClause(const MatcherList & matchers, const Map & tags_to_colu
     return out;
 }
 
-void writeJsonPairsFromTagsColumn(
+/// Repeated `match[]` query params are OR across selectors (Prometheus union semantics).
+String buildMatchWhere(const std::vector<String> & match_params, const Map & tags_to_columns, const String & time_predicate)
+{
+    std::vector<String> selector_predicates;
+    for (const auto & mp : match_params)
+    {
+        if (mp.empty())
+            continue;
+        MatcherList ml = parseMatchers(mp);
+        String p = predicateForMatcherList(ml, tags_to_columns);
+        chassert(!p.empty());
+        selector_predicates.push_back("(" + p + ")");
+    }
+
+    std::vector<String> top_parts;
+    if (!selector_predicates.empty())
+    {
+        if (selector_predicates.size() == 1)
+            top_parts.push_back(selector_predicates.front());
+        else
+        {
+            String or_chain;
+            for (size_t i = 0; i < selector_predicates.size(); ++i)
+            {
+                if (i)
+                    or_chain += " OR ";
+                or_chain += selector_predicates[i];
+            }
+            top_parts.push_back(or_chain);
+        }
+    }
+    if (!time_predicate.empty())
+        top_parts.push_back(time_predicate);
+
+    if (top_parts.empty())
+        return {};
+
+    String out = " WHERE ";
+    for (size_t i = 0; i < top_parts.size(); ++i)
+    {
+        if (i)
+            out += " AND ";
+        out += top_parts[i];
+    }
+    return out;
+}
+
+void writeJSONPairsFromTagsColumn(
     const ColumnPtr & tags_column,
     size_t row_index,
     WriteBuffer & response,
@@ -254,8 +299,6 @@ void writeJsonPairsFromTagsColumn(
         }
     }
 }
-
-static constexpr UInt64 DEFAULT_PROMETHEUS_MAX_SERIES = 100000;
 
 }
 
@@ -538,15 +581,15 @@ void PrometheusHTTPProtocolAPI::writeQueryResponseRangeVectorBlock(WriteBuffer &
 
 void PrometheusHTTPProtocolAPI::getSeries(
     WriteBuffer & response,
-    const String & match_param,
+    const std::vector<String> & match_params,
     const String & start_param,
     const String & end_param)
 {
     const auto & ts_settings = time_series_storage->getStorageSettings();
     const Map & tags_to_columns_map = ts_settings[TimeSeriesSetting::tags_to_columns];
-    const MatcherList matchers = parseMatchers(match_param);
     const String time_where = buildTimeOverlapWhere(ts_settings, start_param, end_param);
-    const String where_clause = combineWhereClause(matchers, tags_to_columns_map, time_where);
+    const String where_clause = buildMatchWhere(match_params, tags_to_columns_map, time_where);
+    const UInt64 max_series = ts_settings[TimeSeriesSetting::prometheus_max_series];
 
     auto tags_table = time_series_storage->getTargetTable(ViewTarget::Tags, getContext());
     auto tags_table_id = tags_table->getStorageID();
@@ -577,7 +620,7 @@ void PrometheusHTTPProtocolAPI::getSeries(
         select_expr,
         tags_table_id.getFullTableName(),
         where_clause,
-        DEFAULT_PROMETHEUS_MAX_SERIES);
+        max_series);
 
     LOG_TRACE(log, "Prometheus series query: {}", query);
 
@@ -615,7 +658,7 @@ void PrometheusHTTPProtocolAPI::getSeries(
                 writeJSONString(col->getDataAt(i), response, format_settings);
             }
 
-            writeJsonPairsFromTagsColumn(tags_col, i, response, format_settings);
+            writeJSONPairsFromTagsColumn(tags_col, i, response, format_settings);
             writeString("}", response);
         }
     }
@@ -625,15 +668,14 @@ void PrometheusHTTPProtocolAPI::getSeries(
 
 void PrometheusHTTPProtocolAPI::getLabels(
     WriteBuffer & response,
-    const String & match_param,
+    const std::vector<String> & match_params,
     const String & start_param,
     const String & end_param)
 {
     const auto & ts_settings = time_series_storage->getStorageSettings();
     const Map & tags_to_columns_map = ts_settings[TimeSeriesSetting::tags_to_columns];
-    const MatcherList matchers = parseMatchers(match_param);
     const String time_where = buildTimeOverlapWhere(ts_settings, start_param, end_param);
-    const String where_clause = combineWhereClause(matchers, tags_to_columns_map, time_where);
+    const String where_clause = buildMatchWhere(match_params, tags_to_columns_map, time_where);
 
     auto tags_table = time_series_storage->getTargetTable(ViewTarget::Tags, getContext());
     auto tags_table_id = tags_table->getStorageID();
@@ -689,15 +731,14 @@ void PrometheusHTTPProtocolAPI::getLabels(
 void PrometheusHTTPProtocolAPI::getLabelValues(
     WriteBuffer & response,
     const String & label_name,
-    const String & match_param,
+    const std::vector<String> & match_params,
     const String & start_param,
     const String & end_param)
 {
     const auto & ts_settings = time_series_storage->getStorageSettings();
     const Map & tags_to_columns_map = ts_settings[TimeSeriesSetting::tags_to_columns];
-    const MatcherList matchers = parseMatchers(match_param);
     const String time_where = buildTimeOverlapWhere(ts_settings, start_param, end_param);
-    const String where_clause = combineWhereClause(matchers, tags_to_columns_map, time_where);
+    const String where_clause = buildMatchWhere(match_params, tags_to_columns_map, time_where);
 
     auto tags_table = time_series_storage->getTargetTable(ViewTarget::Tags, getContext());
     auto tags_table_id = tags_table->getStorageID();

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -680,10 +680,16 @@ void PrometheusHTTPProtocolAPI::getSeries(
             for (const auto & [tag_name, column_name] : promoted_tags)
             {
                 const auto & col = result_block.getByName(column_name).column;
+                const auto value = col->getDataAt(i);
+                /// Promoted columns store `''` for series that did not carry the label (column default).
+                /// There is no presence bit to distinguish absent from explicit-empty, and Prometheus
+                /// treats missing == empty, so do not synthesize the label in the response.
+                if (value.empty())
+                    continue;
                 writeString(",", response);
                 writeJSONString(std::string_view{tag_name}, response, format_settings);
                 writeString(":", response);
-                writeJSONString(col->getDataAt(i), response, format_settings);
+                writeJSONString(value, response, format_settings);
             }
 
             writeJSONPairsFromTagsColumn(tags_col, i, response, format_settings);

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -1,6 +1,7 @@
 #include <Storages/TimeSeries/PrometheusHTTPProtocolAPI.h>
 
 #include <Common/logger_useful.h>
+#include <Common/quoteString.h>
 #include <Core/Field.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/WriteHelpers.h>
@@ -10,6 +11,7 @@
 #include <Parsers/Prometheus/parseTimeSeriesTypes.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/Converter.h>
 #include <Storages/TimeSeries/TimeSeriesColumnNames.h>
+#include <Storages/TimeSeries/TimeSeriesSettings.h>
 #include <Interpreters/executeQuery.h>
 #include <Interpreters/Context.h>
 #include <Core/Settings.h>
@@ -22,17 +24,239 @@
 #include <DataTypes/DataTypeDateTime64.h>
 #include <Core/Types.h>
 #include <Columns/ColumnArray.h>
+#include <Columns/ColumnMap.h>
 #include <Columns/ColumnTuple.h>
 #include <Columns/ColumnString.h>
+#include <Common/typeid_cast.h>
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <optional>
+#include <set>
+#include <vector>
 
 
 namespace DB
 {
 
+namespace TimeSeriesSetting
+{
+    extern const TimeSeriesSettingsBool store_min_time_and_max_time;
+    extern const TimeSeriesSettingsBool filter_by_min_time_and_max_time;
+    extern const TimeSeriesSettingsMap tags_to_columns;
+}
+
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
     extern const int NOT_IMPLEMENTED;
+}
+
+namespace
+{
+
+using MatcherList = PrometheusQueryTree::MatcherList;
+using Matcher = PrometheusQueryTree::Matcher;
+using MatcherType = PrometheusQueryTree::MatcherType;
+
+std::optional<String> findColumnForTag(const Map & tags_to_columns, const String & label_name)
+{
+    for (const auto & tag_name_and_column_name : tags_to_columns)
+    {
+        const auto & tuple = tag_name_and_column_name.safeGet<Tuple>();
+        const auto & tag_name = tuple.at(0).safeGet<String>();
+        if (tag_name == label_name)
+            return tuple.at(1).safeGet<String>();
+    }
+    return std::nullopt;
+}
+
+MatcherList parseMatchers(const String & match_param)
+{
+    if (match_param.empty())
+        return {};
+
+    PrometheusQueryTree tree;
+    String err;
+    size_t err_pos = 0;
+    if (tree.tryParse(match_param, 3, &err, &err_pos))
+    {
+        const auto * root = tree.getRoot();
+        if (root && root->node_type == PrometheusQueryTree::NodeType::InstantSelector)
+        {
+            const auto * sel = typeid_cast<const PrometheusQueryTree::InstantSelector *>(root);
+            chassert(sel);
+            return sel->matchers;
+        }
+    }
+
+    MatcherList fallback;
+    Matcher m;
+    m.label_name = "__name__";
+    m.label_value = match_param;
+    m.matcher_type = MatcherType::EQ;
+    fallback.push_back(std::move(m));
+    return fallback;
+}
+
+String predicateForMatcher(const Matcher & matcher, const Map & tags_to_columns)
+{
+    const auto * metric_name_col = TimeSeriesColumnNames::MetricName;
+    const auto * tags_col_name = TimeSeriesColumnNames::Tags;
+
+    if (matcher.label_name == "__name__")
+    {
+        switch (matcher.matcher_type)
+        {
+            case MatcherType::EQ:
+                return fmt::format("{} = {}", metric_name_col, quoteString(matcher.label_value));
+            case MatcherType::NE:
+                return fmt::format("{} != {}", metric_name_col, quoteString(matcher.label_value));
+            case MatcherType::RE:
+                return fmt::format("match({}, {})", metric_name_col, quoteString(matcher.label_value));
+            case MatcherType::NRE:
+                return fmt::format("NOT match({}, {})", metric_name_col, quoteString(matcher.label_value));
+        }
+    }
+
+    if (auto promoted_col = findColumnForTag(tags_to_columns, matcher.label_name))
+    {
+        const auto col = backQuoteIfNeed(*promoted_col);
+        switch (matcher.matcher_type)
+        {
+            case MatcherType::EQ:
+                return fmt::format("{} = {}", col, quoteString(matcher.label_value));
+            case MatcherType::NE:
+                return fmt::format("{} != {}", col, quoteString(matcher.label_value));
+            case MatcherType::RE:
+                return fmt::format("match({}, {})", col, quoteString(matcher.label_value));
+            case MatcherType::NRE:
+                return fmt::format("NOT match({}, {})", col, quoteString(matcher.label_value));
+        }
+    }
+
+    const auto key_lit = quoteString(matcher.label_name);
+    const auto map_access = fmt::format("{}[{}]", tags_col_name, key_lit);
+    switch (matcher.matcher_type)
+    {
+        case MatcherType::EQ:
+            return fmt::format(
+                "mapContains({}, {}) AND {} = {}", tags_col_name, key_lit, map_access, quoteString(matcher.label_value));
+        case MatcherType::NE:
+            return fmt::format(
+                "(NOT mapContains({}, {})) OR ({} != {})", tags_col_name, key_lit, map_access, quoteString(matcher.label_value));
+        case MatcherType::RE:
+            return fmt::format(
+                "mapContains({}, {}) AND match({}, {})", tags_col_name, key_lit, map_access, quoteString(matcher.label_value));
+        case MatcherType::NRE:
+            return fmt::format(
+                "(NOT mapContains({}, {})) OR NOT match({}, {})", tags_col_name, key_lit, map_access, quoteString(matcher.label_value));
+    }
+    UNREACHABLE();
+}
+
+String buildTimeOverlapWhere(const TimeSeriesSettings & settings, const String & start_param, const String & end_param)
+{
+    if (!settings[TimeSeriesSetting::store_min_time_and_max_time] || !settings[TimeSeriesSetting::filter_by_min_time_and_max_time])
+        return {};
+
+    if (start_param.empty() && end_param.empty())
+        return {};
+
+    constexpr UInt32 ts_scale = 3;
+    String predicates;
+    if (!end_param.empty())
+    {
+        const DateTime64 end_ts = parseTimeSeriesTimestamp(end_param, ts_scale);
+        predicates = fmt::format(
+            "{} <= toDateTime64({}, {})",
+            TimeSeriesColumnNames::MinTime,
+            end_ts.value,
+            ts_scale);
+    }
+    if (!start_param.empty())
+    {
+        const DateTime64 start_ts = parseTimeSeriesTimestamp(start_param, ts_scale);
+        String p = fmt::format(
+            "{} >= toDateTime64({}, {})",
+            TimeSeriesColumnNames::MaxTime,
+            start_ts.value,
+            ts_scale);
+        if (!predicates.empty())
+            predicates += " AND ";
+        predicates += p;
+    }
+    return predicates;
+}
+
+String combineWhereClause(const MatcherList & matchers, const Map & tags_to_columns, const String & time_predicate)
+{
+    std::vector<String> parts;
+    for (const auto & matcher : matchers)
+        parts.push_back(predicateForMatcher(matcher, tags_to_columns));
+    if (!time_predicate.empty())
+        parts.push_back(time_predicate);
+
+    if (parts.empty())
+        return {};
+
+    String out = " WHERE ";
+    for (size_t i = 0; i < parts.size(); ++i)
+    {
+        if (i)
+            out += " AND ";
+        out += parts[i];
+    }
+    return out;
+}
+
+void writeJsonPairsFromTagsColumn(
+    const ColumnPtr & tags_column,
+    size_t row_index,
+    WriteBuffer & response,
+    const FormatSettings & format_settings)
+{
+    if (const auto * map_col = typeid_cast<const ColumnMap *>(tags_column.get()))
+    {
+        const auto & array_column = map_col->getNestedColumn();
+        const auto & offsets = array_column.getOffsets();
+        const auto & tuple_column = typeid_cast<const ColumnTuple &>(array_column.getData());
+        const auto & key_column = tuple_column.getColumn(0);
+        const auto & value_column = tuple_column.getColumn(1);
+
+        size_t start = row_index == 0 ? 0 : offsets[row_index - 1];
+        size_t end = offsets[row_index];
+        for (size_t j = start; j < end; ++j)
+        {
+            writeString(",", response);
+            writeJSONString(key_column.getDataAt(j), response, format_settings);
+            writeString(":", response);
+            writeJSONString(value_column.getDataAt(j), response, format_settings);
+        }
+        return;
+    }
+
+    if (const auto * array_column = typeid_cast<const ColumnArray *>(tags_column.get()))
+    {
+        const auto & offsets = array_column->getOffsets();
+        const auto & tuple_column = typeid_cast<const ColumnTuple &>(array_column->getData());
+        const auto & key_column = tuple_column.getColumn(0);
+        const auto & value_column = tuple_column.getColumn(1);
+
+        size_t start = row_index == 0 ? 0 : offsets[row_index - 1];
+        size_t end = offsets[row_index];
+        for (size_t j = start; j < end; ++j)
+        {
+            writeString(",", response);
+            writeJSONString(key_column.getDataAt(j), response, format_settings);
+            writeString(":", response);
+            writeJSONString(value_column.getDataAt(j), response, format_settings);
+        }
+    }
+}
+
+static constexpr UInt64 DEFAULT_PROMETHEUS_MAX_SERIES = 100000;
+
 }
 
 PrometheusHTTPProtocolAPI::PrometheusHTTPProtocolAPI(ConstStoragePtr time_series_storage_, const ContextMutablePtr & context_)
@@ -312,36 +536,236 @@ void PrometheusHTTPProtocolAPI::writeQueryResponseRangeVectorBlock(WriteBuffer &
     }
 }
 
-
 void PrometheusHTTPProtocolAPI::getSeries(
     WriteBuffer & response,
-    const String & /* match_param */,
-    const String & /* start_param */,
-    const String & /* end_param */)
+    const String & match_param,
+    const String & start_param,
+    const String & end_param)
 {
-    UNUSED(response);
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "The series endpoint is not implemented");
+    const auto & ts_settings = time_series_storage->getStorageSettings();
+    const Map & tags_to_columns_map = ts_settings[TimeSeriesSetting::tags_to_columns];
+    const MatcherList matchers = parseMatchers(match_param);
+    const String time_where = buildTimeOverlapWhere(ts_settings, start_param, end_param);
+    const String where_clause = combineWhereClause(matchers, tags_to_columns_map, time_where);
+
+    auto tags_table = time_series_storage->getTargetTable(ViewTarget::Tags, getContext());
+    auto tags_table_id = tags_table->getStorageID();
+
+    std::vector<String> select_list;
+    select_list.push_back(TimeSeriesColumnNames::MetricName);
+    select_list.push_back(TimeSeriesColumnNames::Tags);
+    std::vector<std::pair<String, String>> promoted_tags;
+    for (const auto & tag_name_and_column_name : tags_to_columns_map)
+    {
+        const auto & tuple = tag_name_and_column_name.safeGet<Tuple>();
+        const auto & tag_name = tuple.at(0).safeGet<String>();
+        const auto & column_name = tuple.at(1).safeGet<String>();
+        select_list.push_back(backQuoteIfNeed(column_name));
+        promoted_tags.emplace_back(tag_name, column_name);
+    }
+
+    String select_expr;
+    for (size_t si = 0; si < select_list.size(); ++si)
+    {
+        if (si)
+            select_expr += ", ";
+        select_expr += select_list[si];
+    }
+
+    String query = fmt::format(
+        "SELECT {} FROM {}{} LIMIT {}",
+        select_expr,
+        tags_table_id.getFullTableName(),
+        where_clause,
+        DEFAULT_PROMETHEUS_MAX_SERIES);
+
+    LOG_TRACE(log, "Prometheus series query: {}", query);
+
+    auto [ast, io] = executeQuery(query, getContext(), {}, QueryProcessingStage::Complete);
+
+    PullingPipelineExecutor executor(io.pipeline);
+    Block result_block;
+
+    writeString(R"({"status":"success","data":[)", response);
+
+    bool first_row = true;
+    while (executor.pull(result_block))
+    {
+        if (result_block.empty() || result_block.rows() == 0)
+            continue;
+
+        const auto & metric_name_col = result_block.getByName(TimeSeriesColumnNames::MetricName).column;
+        const auto & tags_col = result_block.getByName(TimeSeriesColumnNames::Tags).column;
+
+        for (size_t i = 0; i < result_block.rows(); ++i)
+        {
+            if (!first_row)
+                writeString(",", response);
+            first_row = false;
+
+            writeString(R"({"__name__":)", response);
+            writeJSONString(metric_name_col->getDataAt(i), response, format_settings);
+
+            for (const auto & [tag_name, column_name] : promoted_tags)
+            {
+                const auto & col = result_block.getByName(column_name).column;
+                writeString(",", response);
+                writeJSONString(std::string_view{tag_name}, response, format_settings);
+                writeString(":", response);
+                writeJSONString(col->getDataAt(i), response, format_settings);
+            }
+
+            writeJsonPairsFromTagsColumn(tags_col, i, response, format_settings);
+            writeString("}", response);
+        }
+    }
+
+    writeString("]}", response);
 }
 
 void PrometheusHTTPProtocolAPI::getLabels(
     WriteBuffer & response,
-    const String & /* match_param */,
-    const String & /* start_param */,
-    const String & /* end_param */)
+    const String & match_param,
+    const String & start_param,
+    const String & end_param)
 {
-    UNUSED(response);
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "The labels endpoint is not implemented");
+    const auto & ts_settings = time_series_storage->getStorageSettings();
+    const Map & tags_to_columns_map = ts_settings[TimeSeriesSetting::tags_to_columns];
+    const MatcherList matchers = parseMatchers(match_param);
+    const String time_where = buildTimeOverlapWhere(ts_settings, start_param, end_param);
+    const String where_clause = combineWhereClause(matchers, tags_to_columns_map, time_where);
+
+    auto tags_table = time_series_storage->getTargetTable(ViewTarget::Tags, getContext());
+    auto tags_table_id = tags_table->getStorageID();
+
+    String query = fmt::format(
+        "SELECT arrayJoin(groupUniqArrayArray(mapKeys({}))) AS label_key FROM {}{}",
+        TimeSeriesColumnNames::Tags,
+        tags_table_id.getFullTableName(),
+        where_clause);
+
+    LOG_TRACE(log, "Prometheus labels query: {}", query);
+
+    auto [ast, io] = executeQuery(query, getContext(), {}, QueryProcessingStage::Complete);
+
+    PullingPipelineExecutor executor(io.pipeline);
+    Block result_block;
+
+    std::set<String> label_names;
+    label_names.insert("__name__");
+    for (const auto & tag_name_and_column_name : tags_to_columns_map)
+    {
+        const auto & tuple = tag_name_and_column_name.safeGet<Tuple>();
+        label_names.insert(tuple.at(0).safeGet<String>());
+    }
+
+    while (executor.pull(result_block))
+    {
+        if (result_block.empty() || result_block.rows() == 0)
+            continue;
+
+        const auto & label_col = result_block.getByName("label_key").column;
+        for (size_t i = 0; i < result_block.rows(); ++i)
+        {
+            auto label = label_col->getDataAt(i);
+            if (label.empty())
+                continue;
+            label_names.insert(String{label});
+        }
+    }
+
+    writeString(R"({"status":"success","data":[)", response);
+    bool first_label = true;
+    for (const auto & name : label_names)
+    {
+        if (!first_label)
+            writeString(",", response);
+        first_label = false;
+        writeJSONString(std::string_view{name}, response, format_settings);
+    }
+    writeString("]}", response);
 }
 
 void PrometheusHTTPProtocolAPI::getLabelValues(
     WriteBuffer & response,
-    const String & /* label_name */,
-    const String & /* match_param */,
-    const String & /* start_param */,
-    const String & /* end_param */)
+    const String & label_name,
+    const String & match_param,
+    const String & start_param,
+    const String & end_param)
 {
-    UNUSED(response);
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "The label values endpoint is not implemented");
+    const auto & ts_settings = time_series_storage->getStorageSettings();
+    const Map & tags_to_columns_map = ts_settings[TimeSeriesSetting::tags_to_columns];
+    const MatcherList matchers = parseMatchers(match_param);
+    const String time_where = buildTimeOverlapWhere(ts_settings, start_param, end_param);
+    const String where_clause = combineWhereClause(matchers, tags_to_columns_map, time_where);
+
+    auto tags_table = time_series_storage->getTargetTable(ViewTarget::Tags, getContext());
+    auto tags_table_id = tags_table->getStorageID();
+
+    String query;
+
+    if (label_name == "__name__")
+    {
+        query = fmt::format(
+            "SELECT DISTINCT {} AS label_value FROM {}{} ORDER BY label_value",
+            TimeSeriesColumnNames::MetricName,
+            tags_table_id.getFullTableName(),
+            where_clause);
+    }
+    else if (auto promoted_col = findColumnForTag(tags_to_columns_map, label_name))
+    {
+        query = fmt::format(
+            "SELECT DISTINCT {} AS label_value FROM {}{} ORDER BY label_value",
+            backQuoteIfNeed(*promoted_col),
+            tags_table_id.getFullTableName(),
+            where_clause);
+    }
+    else
+    {
+        const auto key_lit = quoteString(label_name);
+        const auto map_access = fmt::format("{}[{}]", TimeSeriesColumnNames::Tags, key_lit);
+        String map_where;
+        if (where_clause.empty())
+            map_where = fmt::format(" WHERE mapContains({}, {})", TimeSeriesColumnNames::Tags, key_lit);
+        else
+            map_where = where_clause + fmt::format(" AND mapContains({}, {})", TimeSeriesColumnNames::Tags, key_lit);
+        query = fmt::format(
+            "SELECT label_value FROM (SELECT arrayJoin(groupUniqArray({})) AS label_value FROM {}{}) ORDER BY label_value",
+            map_access,
+            tags_table_id.getFullTableName(),
+            map_where);
+    }
+
+    LOG_TRACE(log, "Prometheus label values query: {}", query);
+
+    auto [ast, io] = executeQuery(query, getContext(), {}, QueryProcessingStage::Complete);
+
+    PullingPipelineExecutor executor(io.pipeline);
+    Block result_block;
+
+    writeString(R"({"status":"success","data":[)", response);
+
+    bool first = true;
+    while (executor.pull(result_block))
+    {
+        if (result_block.empty() || result_block.rows() == 0)
+            continue;
+
+        const auto & value_col = result_block.getByName("label_value").column;
+
+        for (size_t i = 0; i < result_block.rows(); ++i)
+        {
+            auto value = value_col->getDataAt(i);
+            if (value.empty())
+                continue;
+            if (!first)
+                writeString(",", response);
+            first = false;
+            writeJSONString(value, response, format_settings);
+        }
+    }
+
+    writeString("]}", response);
 }
 
 

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -50,6 +50,7 @@ namespace TimeSeriesSetting
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+    extern const int CANNOT_PARSE_PROMQL_QUERY;
 }
 
 namespace
@@ -79,24 +80,24 @@ MatcherList parseMatchers(const String & match_param)
     PrometheusQueryTree tree;
     String err;
     size_t err_pos = 0;
-    if (tree.tryParse(match_param, 3, &err, &err_pos))
-    {
-        const auto * root = tree.getRoot();
-        if (root && root->node_type == PrometheusQueryTree::NodeType::InstantSelector)
-        {
-            const auto * sel = typeid_cast<const PrometheusQueryTree::InstantSelector *>(root);
-            chassert(sel);
-            return sel->matchers;
-        }
-    }
+    if (!tree.tryParse(match_param, 3, &err, &err_pos))
+        throw Exception(
+            ErrorCodes::CANNOT_PARSE_PROMQL_QUERY,
+            "{} at position {} while parsing match[] selector: {}",
+            err,
+            err_pos,
+            match_param);
 
-    MatcherList fallback;
-    Matcher m;
-    m.label_name = "__name__";
-    m.label_value = match_param;
-    m.matcher_type = MatcherType::EQ;
-    fallback.push_back(std::move(m));
-    return fallback;
+    const auto * root = tree.getRoot();
+    if (!root || root->node_type != PrometheusQueryTree::NodeType::InstantSelector)
+        throw Exception(
+            ErrorCodes::CANNOT_PARSE_PROMQL_QUERY,
+            "match[] must be a metric name or label selector {{...}}, got a non-selector expression: {}",
+            match_param);
+
+    const auto * sel = typeid_cast<const PrometheusQueryTree::InstantSelector *>(root);
+    chassert(sel);
+    return sel->matchers;
 }
 
 String predicateForMatcher(const Matcher & matcher, const Map & tags_to_columns)

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -680,11 +680,13 @@ void PrometheusHTTPProtocolAPI::getLabels(
     auto tags_table = time_series_storage->getTargetTable(ViewTarget::Tags, getContext());
     auto tags_table_id = tags_table->getStorageID();
 
+    const UInt64 max_series = ts_settings[TimeSeriesSetting::prometheus_max_series];
     String query = fmt::format(
-        "SELECT arrayJoin(groupUniqArrayArray(mapKeys({}))) AS label_key FROM {}{}",
+        "SELECT label_key FROM (SELECT arrayJoin(groupUniqArrayArray(mapKeys({}))) AS label_key FROM {}{}) LIMIT {}",
         TimeSeriesColumnNames::Tags,
         tags_table_id.getFullTableName(),
-        where_clause);
+        where_clause,
+        max_series);
 
     LOG_TRACE(log, "Prometheus labels query: {}", query);
 
@@ -743,23 +745,26 @@ void PrometheusHTTPProtocolAPI::getLabelValues(
     auto tags_table = time_series_storage->getTargetTable(ViewTarget::Tags, getContext());
     auto tags_table_id = tags_table->getStorageID();
 
+    const UInt64 max_series = ts_settings[TimeSeriesSetting::prometheus_max_series];
     String query;
 
     if (label_name == "__name__")
     {
         query = fmt::format(
-            "SELECT DISTINCT {} AS label_value FROM {}{} ORDER BY label_value",
+            "SELECT label_value FROM (SELECT DISTINCT {} AS label_value FROM {}{}) ORDER BY label_value LIMIT {}",
             TimeSeriesColumnNames::MetricName,
             tags_table_id.getFullTableName(),
-            where_clause);
+            where_clause,
+            max_series);
     }
     else if (auto promoted_col = findColumnForTag(tags_to_columns_map, label_name))
     {
         query = fmt::format(
-            "SELECT DISTINCT {} AS label_value FROM {}{} ORDER BY label_value",
+            "SELECT label_value FROM (SELECT DISTINCT {} AS label_value FROM {}{}) ORDER BY label_value LIMIT {}",
             backQuoteIfNeed(*promoted_col),
             tags_table_id.getFullTableName(),
-            where_clause);
+            where_clause,
+            max_series);
     }
     else
     {
@@ -771,10 +776,11 @@ void PrometheusHTTPProtocolAPI::getLabelValues(
         else
             map_where = where_clause + fmt::format(" AND mapContains({}, {})", TimeSeriesColumnNames::Tags, key_lit);
         query = fmt::format(
-            "SELECT label_value FROM (SELECT arrayJoin(groupUniqArray({})) AS label_value FROM {}{}) ORDER BY label_value",
+            "SELECT label_value FROM (SELECT arrayJoin(groupUniqArray({})) AS label_value FROM {}{}) ORDER BY label_value LIMIT {}",
             map_access,
             tags_table_id.getFullTableName(),
-            map_where);
+            map_where,
+            max_series);
     }
 
     LOG_TRACE(log, "Prometheus label values query: {}", query);

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.cpp
@@ -797,11 +797,19 @@ void PrometheusHTTPProtocolAPI::getLabelValues(
     }
     else if (auto promoted_col = findColumnForTag(tags_to_columns_map, label_name))
     {
+        /// A series without this promoted label is ingested as the column's default value (empty string for
+        /// String/LowCardinality(String)). There is no presence bit to distinguish that from an explicit empty
+        /// value, and Prometheus treats missing == empty, so excluding `''` is consistent with the documented
+        /// label-values contract and with `/labels`, which also gates promoted labels on `countIf(col != '') > 0`.
+        const auto col = backQuoteIfNeed(*promoted_col);
+        const String presence_predicate = fmt::format("{} != ''", col);
+        const String values_where
+            = where_clause.empty() ? " WHERE " + presence_predicate : where_clause + " AND " + presence_predicate;
         query = fmt::format(
             "SELECT label_value FROM (SELECT DISTINCT {} AS label_value FROM {}{}) ORDER BY label_value LIMIT {}",
-            backQuoteIfNeed(*promoted_col),
+            col,
             tags_table_id.getFullTableName(),
-            where_clause,
+            values_where,
             max_series);
     }
     else

--- a/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.h
+++ b/src/Storages/TimeSeries/PrometheusHTTPProtocolAPI.h
@@ -7,6 +7,8 @@
 #include <Parsers/IAST_fwd.h>
 #include <IO/WriteBuffer.h>
 
+#include <vector>
+
 namespace DB
 {
 class StorageTimeSeries;
@@ -48,14 +50,14 @@ public:
     /// Get series metadata (/api/v1/series)
     void getSeries(
         WriteBuffer & response,
-        const String & match_param,
+        const std::vector<String> & match_params,
         const String & start_param,
         const String & end_param);
 
     /// Get all label names (/api/v1/labels)
     void getLabels(
         WriteBuffer & response,
-        const String & match_param,
+        const std::vector<String> & match_params,
         const String & start_param,
         const String & end_param);
 
@@ -63,7 +65,7 @@ public:
     void getLabelValues(
         WriteBuffer & response,
         const String & label_name,
-        const String & match_param,
+        const std::vector<String> & match_params,
         const String & start_param,
         const String & end_param);
 

--- a/src/Storages/TimeSeries/TimeSeriesSettings.cpp
+++ b/src/Storages/TimeSeries/TimeSeriesSettings.cpp
@@ -20,6 +20,7 @@ namespace ErrorCodes
     DECLARE(Bool, store_min_time_and_max_time, true, "If set to true then the table will store 'min_time' and 'max_time' for each time series", 0) \
     DECLARE(Bool, aggregate_min_time_and_max_time, true, "When creating an inner target 'tags' table, this flag enables using 'SimpleAggregateFunction(min, Nullable(DateTime64(3)))' instead of just 'Nullable(DateTime64(3))' as the type of the 'min_time' column, and the same for the 'max_time' column", 0) \
     DECLARE(Bool, filter_by_min_time_and_max_time, true, "If set to true then the table will use the 'min_time' and 'max_time' columns for filtering time series", 0) \
+    DECLARE(UInt64, prometheus_max_series, 100000, "Maximum number of time series rows returned by Prometheus HTTP API /api/v1/series, /api/v1/labels, and /api/v1/label/<name>/values", 0) \
 
 DECLARE_SETTINGS_TRAITS(TimeSeriesSettingsTraits, LIST_OF_TIME_SERIES_SETTINGS)
 IMPLEMENT_SETTINGS_TRAITS(TimeSeriesSettingsTraits, LIST_OF_TIME_SERIES_SETTINGS)

--- a/src/Storages/TimeSeries/TimeSeriesSettings.h
+++ b/src/Storages/TimeSeries/TimeSeriesSettings.h
@@ -12,7 +12,8 @@ struct TimeSeriesSettingsImpl;
 /// List of available types supported in TimeSeriesSettings object
 #define TIMESERIES_SETTINGS_SUPPORTED_TYPES(CLASS_NAME, M) \
     M(CLASS_NAME, Bool) \
-    M(CLASS_NAME, Map)
+    M(CLASS_NAME, Map) \
+    M(CLASS_NAME, UInt64)
 
 TIMESERIES_SETTINGS_SUPPORTED_TYPES(TimeSeriesSettings, DECLARE_SETTING_TRAIT)
 

--- a/tests/integration/test_prometheus_protocols/configs/prometheus.xml
+++ b/tests/integration/test_prometheus_protocols/configs/prometheus.xml
@@ -65,7 +65,7 @@
                 </handler>
             </my_rule_8>
             <my_rule_9>
-                <url>/api/v1/label/*/values</url>
+                <url>regex:^/api/v1/label/[^/]+/values</url>
                 <handler>
                     <type>query_api</type>
                     <table>default.prometheus</table>

--- a/tests/integration/test_prometheus_protocols/test_series_labels_api.py
+++ b/tests/integration/test_prometheus_protocols/test_series_labels_api.py
@@ -131,6 +131,50 @@ def test_label_values_for_nonexistent_label():
     assert len(data) == 0
 
 
+def test_series_multiple_match_union():
+    """Repeated match[] is OR across selectors (Prometheus union semantics)."""
+    data = get_json_from_api(
+        "/api/v1/series",
+        params=[
+            ("match[]", '{__name__="cpu_usage"}'),
+            ("match[]", '{__name__="memory_usage"}'),
+        ],
+    )
+    assert isinstance(data, list)
+    names = {e["__name__"] for e in data if "__name__" in e}
+    assert names == {"cpu_usage", "memory_usage"}
+    assert "http_requests_total" not in names
+
+
+def test_labels_multiple_match_union():
+    """Repeated match[] on /labels unions label names from any matching series."""
+    data = get_json_from_api(
+        "/api/v1/labels",
+        params=[
+            ("match[]", '{__name__="cpu_usage"}'),
+            ("match[]", '{__name__="http_requests_total"}'),
+        ],
+    )
+    assert isinstance(data, list)
+    assert "__name__" in data
+    assert "method" in data
+    assert "datacenter" in data
+
+
+def test_label_values_name_multiple_match_union():
+    """Repeated match[] on /label/__name__/values restricts metric names to the union of selectors."""
+    data = get_json_from_api(
+        "/api/v1/label/__name__/values",
+        params=[
+            ("match[]", '{__name__="cpu_usage"}'),
+            ("match[]", '{__name__="memory_usage"}'),
+        ],
+    )
+    assert isinstance(data, list)
+    assert set(data) == {"cpu_usage", "memory_usage"}
+    assert "http_requests_total" not in data
+
+
 def test_series_with_promql_selector_host():
     """GET /api/v1/series with match[] selector filters by host."""
     data = get_json_from_api(

--- a/tests/integration/test_prometheus_protocols/test_series_labels_api.py
+++ b/tests/integration/test_prometheus_protocols/test_series_labels_api.py
@@ -273,9 +273,11 @@ def test_sql_injection_safe():
     assert isinstance(data, list)
     assert data == []
 
-    data2 = get_json_from_api(
-        "/api/v1/series",
-        params=[("match[]", "foo' OR '1'='1")],
-    )
-    assert isinstance(data2, list)
+    # Invalid PromQL in match[] returns 400 bad_data (no silent fallback to __name__=...).
+    url = f"http://{node.ip_address}:9093/api/v1/series"
+    response = requests.get(url, params=[("match[]", "foo' OR '1'='1")])
+    assert response.status_code == 400, response.text
+    err = response.json()
+    assert err["status"] == "error"
+    assert err["errorType"] == "bad_data"
 

--- a/tests/integration/test_prometheus_protocols/test_series_labels_api.py
+++ b/tests/integration/test_prometheus_protocols/test_series_labels_api.py
@@ -1,0 +1,204 @@
+"""Tests for Prometheus HTTP API endpoints: /api/v1/series, /api/v1/labels, /api/v1/label/<name>/values
+
+Run locally with the in-tree server binary, e.g.:
+  CLICKHOUSE_TESTS_SERVER_BIN_PATH=$PWD/build/programs/clickhouse pytest ...
+"""
+
+import urllib.parse
+
+import pytest
+import requests
+
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
+from .prometheus_test_utils import *
+
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/prometheus.xml"],
+    user_configs=["configs/allow_experimental_time_series_table.xml"],
+    handle_prometheus_remote_write=(9093, "/write"),
+)
+
+
+def send_test_data():
+    """Send test data with known labels for testing series/labels/label-values endpoints."""
+    # Label names must be in strict lexicographic order (TimeSeries / remote write validation).
+    time_series = [
+        (
+            {"__name__": "cpu_usage", "datacenter": "us-east", "host": "server1"},
+            {1000: 0.5, 1015: 0.6, 1030: 0.7},
+        ),
+        (
+            {"__name__": "cpu_usage", "datacenter": "us-west", "host": "server2"},
+            {1000: 0.3, 1015: 0.4, 1030: 0.5},
+        ),
+        (
+            {"__name__": "memory_usage", "datacenter": "us-east", "host": "server1"},
+            {1000: 0.8, 1015: 0.85, 1030: 0.9},
+        ),
+        (
+            {"__name__": "http_requests_total", "host": "server1", "method": "GET", "status": "200"},
+            {1000: 100, 1015: 150, 1030: 200},
+        ),
+    ]
+    protobuf = convert_time_series_to_protobuf(time_series)
+    send_protobuf_to_remote_write(node.ip_address, 9093, "/write", protobuf)
+
+
+def get_json_from_api(path, params=None):
+    """Make a GET request to the ClickHouse Prometheus API and return parsed JSON."""
+    url = f"http://{node.ip_address}:9093{path}"
+    if params:
+        url += "?" + urllib.parse.urlencode(params, doseq=True)
+    print(f"Requesting {url}")
+    response = requests.get(url)
+    print(f"Status code: {response.status_code}, Body: {response.text[:500]}")
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {response.text}"
+    data = response.json()
+    assert data["status"] == "success", f"Expected success, got: {data}"
+    return data["data"]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(request):
+    try:
+        cluster.start()
+        node.query("CREATE TABLE prometheus ENGINE=TimeSeries")
+        send_test_data()
+        # Wait for data to be available
+        assert_eq_with_retry(
+            node, "SELECT count() > 0 FROM timeSeriesData(prometheus)", "1"
+        )
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_labels_returns_all_label_names():
+    """GET /api/v1/labels should return all unique label names including __name__."""
+    data = get_json_from_api("/api/v1/labels")
+    assert isinstance(data, list)
+    assert "__name__" in data
+    assert "host" in data
+    assert "datacenter" in data
+
+
+def test_label_values_for_name():
+    """GET /api/v1/label/__name__/values should return all metric names."""
+    data = get_json_from_api("/api/v1/label/__name__/values")
+    assert isinstance(data, list)
+    assert "cpu_usage" in data
+    assert "memory_usage" in data
+    assert "http_requests_total" in data
+
+
+def test_label_values_for_host():
+    """GET /api/v1/label/host/values should return all host values."""
+    data = get_json_from_api("/api/v1/label/host/values")
+    assert isinstance(data, list)
+    assert "server1" in data
+    assert "server2" in data
+
+
+def test_label_values_for_datacenter():
+    """GET /api/v1/label/datacenter/values should return datacenter values."""
+    data = get_json_from_api("/api/v1/label/datacenter/values")
+    assert isinstance(data, list)
+    assert "us-east" in data
+    assert "us-west" in data
+
+
+def test_series_returns_metric_labels():
+    """GET /api/v1/series should return series with their full label sets."""
+    data = get_json_from_api("/api/v1/series")
+    assert isinstance(data, list)
+    assert len(data) > 0
+
+    # Each entry should be a dict with __name__ and other labels
+    metric_names = {entry["__name__"] for entry in data if "__name__" in entry}
+    assert "cpu_usage" in metric_names
+    assert "memory_usage" in metric_names
+
+
+def test_label_values_for_nonexistent_label():
+    """GET /api/v1/label/nonexistent/values should return empty list."""
+    data = get_json_from_api("/api/v1/label/nonexistent/values")
+    assert isinstance(data, list)
+    assert len(data) == 0
+
+
+def test_series_with_promql_selector_host():
+    """GET /api/v1/series with match[] selector filters by host."""
+    data = get_json_from_api(
+        "/api/v1/series",
+        params=[("match[]", '{host="server1"}')],
+    )
+    assert isinstance(data, list)
+    assert len(data) >= 1
+    for entry in data:
+        assert entry.get("host") == "server1"
+
+
+def test_series_with_promql_selector_regex_and_ne():
+    """GET /api/v1/series with match[] uses method and status matchers."""
+    data = get_json_from_api(
+        "/api/v1/series",
+        params=[("match[]", '{method!="",status=~"2.."}')],
+    )
+    assert isinstance(data, list)
+    assert len(data) >= 1
+    names = {e["__name__"] for e in data if "__name__" in e}
+    assert "http_requests_total" in names
+
+
+def test_labels_with_match_selector():
+    """labels endpoint narrows when match[] matches a subset of metrics."""
+    data = get_json_from_api(
+        "/api/v1/labels",
+        params=[("match[]", "cpu_usage")],
+    )
+    assert isinstance(data, list)
+    assert "__name__" in data
+    assert "host" in data
+    assert "method" not in data
+
+
+def test_label_values_with_regex_match():
+    """label values with match[] regex for host."""
+    data = get_json_from_api(
+        "/api/v1/label/host/values",
+        params=[("match[]", '{host=~"server.*"}')],
+    )
+    assert isinstance(data, list)
+    assert "server1" in data
+    assert "server2" in data
+
+
+def test_time_window_params_smoke():
+    """start/end query params are accepted (time overlap uses min_time/max_time on tags)."""
+    # Sample timestamps are ~1000s epoch; keep window around that range.
+    data = get_json_from_api(
+        "/api/v1/series",
+        params=[("start", "500"), ("end", "2000")],
+    )
+    assert isinstance(data, list)
+
+
+def test_sql_injection_safe():
+    """Malicious-looking label names and match[] must not break the server."""
+    bad_label = "foo'; DROP TABLE x;--"
+    path = f"/api/v1/label/{urllib.parse.quote(bad_label, safe='')}/values"
+    data = get_json_from_api(path)
+    assert isinstance(data, list)
+    assert data == []
+
+    data2 = get_json_from_api(
+        "/api/v1/series",
+        params=[("match[]", "foo' OR '1'='1")],
+    )
+    assert isinstance(data2, list)
+

--- a/tests/integration/test_prometheus_protocols/test_series_labels_api.py
+++ b/tests/integration/test_prometheus_protocols/test_series_labels_api.py
@@ -347,6 +347,53 @@ def test_time_window_params_smoke():
     assert isinstance(data, list)
 
 
+def test_label_values_percent_encoded_label_name():
+    """Label name in the URI may be percent-encoded (Prometheus allows label names that
+    include characters requiring escaping after custom remote-write or instrumentation).
+    The handler must URL-decode the segment before querying storage."""
+    # Ingest a series whose label name is `a/b` (a slash is unusual but allowed for this test).
+    time_series = [
+        (
+            {"__name__": "encoded_label_metric", "a/b": "v1"},
+            {2000: 1.0},
+        ),
+    ]
+    protobuf = convert_time_series_to_protobuf(time_series)
+    send_protobuf_to_remote_write(node.ip_address, 9093, "/write", protobuf)
+    assert_eq_with_retry(
+        node,
+        "SELECT count() > 0 FROM timeSeriesTags(prometheus) WHERE metric_name = 'encoded_label_metric'",
+        "1",
+    )
+
+    # Raw `/api/v1/label/a/b/values` is ambiguous; clients must percent-encode the `/`.
+    data = get_json_from_api("/api/v1/label/a%2Fb/values")
+    assert data == ["v1"], data
+
+
+def test_label_values_trailing_values_segment_not_confused_with_label_name():
+    """`find("/values")` returns the first occurrence; if the label name itself contains
+    `/values` the extraction truncates inside the label. Use the trailing `/values` as the
+    anchor (via `rfind` / size-based suffix strip) so the full label name is preserved."""
+    time_series = [
+        (
+            {"__name__": "tricky_label_metric", "foo/values_bar": "vv"},
+            {2000: 2.0},
+        ),
+    ]
+    protobuf = convert_time_series_to_protobuf(time_series)
+    send_protobuf_to_remote_write(node.ip_address, 9093, "/write", protobuf)
+    assert_eq_with_retry(
+        node,
+        "SELECT count() > 0 FROM timeSeriesTags(prometheus) WHERE metric_name = 'tricky_label_metric'",
+        "1",
+    )
+
+    # Percent-encode the embedded `/` so the server sees one label-name segment.
+    data = get_json_from_api("/api/v1/label/foo%2Fvalues_bar/values")
+    assert data == ["vv"], data
+
+
 def test_sql_injection_safe():
     """Malicious-looking label names and match[] must not break the server."""
     bad_label = "foo'; DROP TABLE x;--"

--- a/tests/integration/test_prometheus_protocols/test_series_labels_api.py
+++ b/tests/integration/test_prometheus_protocols/test_series_labels_api.py
@@ -48,6 +48,11 @@ def send_test_data():
             {"__name__": "with_empty_zone", "datacenter": "us-east", "host": "server1", "zone": ""},
             {1000: 1.0},
         ),
+        # Series with an explicit non-empty `zone` so `{zone!=""}` can be exercised meaningfully.
+        (
+            {"__name__": "rack_metric", "datacenter": "us-east", "zone": "us-east-1a"},
+            {1000: 0.5},
+        ),
     ]
     protobuf = convert_time_series_to_protobuf(time_series)
     send_protobuf_to_remote_write(node.ip_address, 9093, "/write", protobuf)
@@ -265,6 +270,48 @@ def test_series_non_empty_eq_excludes_missing_label():
     assert isinstance(data, list)
     names = {e["__name__"] for e in data if "__name__" in e}
     assert "http_requests_total" not in names
+
+
+def test_series_ne_empty_excludes_missing_and_explicit_empty():
+    """`{zone!=""}` must exclude series where `zone` is absent (Prometheus treats absent == empty)
+    and series where `zone` is explicitly empty. Only series with a non-empty `zone` survive."""
+    data = get_json_from_api(
+        "/api/v1/series",
+        params=[("match[]", '{zone!=""}')],
+    )
+    assert isinstance(data, list)
+    names = {e["__name__"] for e in data if "__name__" in e}
+    # Must include the only series with a non-empty zone.
+    assert names == {"rack_metric"}, names
+    # Sanity: the entry actually carries the non-empty zone value.
+    rack = next(e for e in data if e.get("__name__") == "rack_metric")
+    assert rack.get("zone") == "us-east-1a"
+
+
+def test_labels_ne_empty_includes_zone_only_for_non_empty_rows():
+    """`/api/v1/labels?match[]={zone!=""}` must derive labels from the matched (non-empty zone) rows
+    and not from series where `zone` is absent or explicitly empty."""
+    data = get_json_from_api(
+        "/api/v1/labels",
+        params=[("match[]", '{zone!=""}')],
+    )
+    assert "__name__" in data
+    assert "zone" in data
+    assert "datacenter" in data
+    # Labels not present on `rack_metric` (e.g. `host`, `method`, `status`) must not appear.
+    assert "host" not in data, data
+    assert "method" not in data, data
+
+
+def test_label_values_zone_ne_empty_excludes_empty_string():
+    """`/api/v1/label/zone/values?match[]={zone!=""}` must not surface `""` and must list
+    only the values from rows that actually carry a non-empty `zone`."""
+    data = get_json_from_api(
+        "/api/v1/label/zone/values",
+        params=[("match[]", '{zone!=""}')],
+    )
+    assert "" not in data, data
+    assert data == ["us-east-1a"], data
 
 
 def test_labels_with_match_selector():

--- a/tests/integration/test_prometheus_protocols/test_series_labels_api.py
+++ b/tests/integration/test_prometheus_protocols/test_series_labels_api.py
@@ -157,6 +157,30 @@ def test_series_multiple_match_union():
     assert "http_requests_total" not in names
 
 
+def test_series_multiple_match_with_time_window():
+    """Union of match[] must AND with start/end. Without wrapping the OR chain, `a OR b AND time` wrongly keeps rows matching only `a` when `time` is false for them."""
+    union = get_json_from_api(
+        "/api/v1/series",
+        params=[
+            ("match[]", '{__name__="cpu_usage"}'),
+            ("match[]", '{__name__="memory_usage"}'),
+        ],
+    )
+    assert {e["__name__"] for e in union if "__name__" in e} == {"cpu_usage", "memory_usage"}
+
+    # Far-future window: no series overlaps; result must be empty. Buggy precedence would still return `cpu_usage` (first match[] without time).
+    data_empty = get_json_from_api(
+        "/api/v1/series",
+        params=[
+            ("match[]", '{__name__="cpu_usage"}'),
+            ("match[]", '{__name__="memory_usage"}'),
+            ("start", "1000000000"),
+            ("end", "1000000001"),
+        ],
+    )
+    assert data_empty == []
+
+
 def test_labels_multiple_match_union():
     """Repeated match[] on /labels unions label names from any matching series."""
     data = get_json_from_api(

--- a/tests/integration/test_prometheus_protocols/test_series_labels_api.py
+++ b/tests/integration/test_prometheus_protocols/test_series_labels_api.py
@@ -44,6 +44,10 @@ def send_test_data():
             {"__name__": "http_requests_total", "host": "server1", "method": "GET", "status": "200"},
             {1000: 100, 1015: 150, 1030: 200},
         ),
+        (
+            {"__name__": "with_empty_zone", "datacenter": "us-east", "host": "server1", "zone": ""},
+            {1000: 1.0},
+        ),
     ]
     protobuf = convert_time_series_to_protobuf(time_series)
     send_protobuf_to_remote_write(node.ip_address, 9093, "/write", protobuf)
@@ -110,6 +114,13 @@ def test_label_values_for_datacenter():
     assert isinstance(data, list)
     assert "us-east" in data
     assert "us-west" in data
+
+
+def test_label_values_includes_empty_string():
+    """Prometheus: explicit empty label values must appear in /label/<name>/values."""
+    data = get_json_from_api("/api/v1/label/zone/values")
+    assert isinstance(data, list)
+    assert "" in data
 
 
 def test_series_returns_metric_labels():

--- a/tests/integration/test_prometheus_protocols/test_series_labels_api.py
+++ b/tests/integration/test_prometheus_protocols/test_series_labels_api.py
@@ -199,6 +199,39 @@ def test_series_with_promql_selector_regex_and_ne():
     assert "http_requests_total" in names
 
 
+def test_series_missing_label_matches_empty_eq():
+    """Prometheus: absent label is implicit ''; {zone=\"\"} matches series without zone."""
+    data = get_json_from_api(
+        "/api/v1/series",
+        params=[("match[]", '{zone=""}')],
+    )
+    assert isinstance(data, list)
+    names = {e["__name__"] for e in data if "__name__" in e}
+    assert "http_requests_total" in names
+
+
+def test_series_missing_label_matches_empty_regex():
+    """Absent label is ''; regex matches against empty (e.g. .*)."""
+    data = get_json_from_api(
+        "/api/v1/series",
+        params=[("match[]", '{zone=~".*"}')],
+    )
+    assert isinstance(data, list)
+    names = {e["__name__"] for e in data if "__name__" in e}
+    assert "http_requests_total" in names
+
+
+def test_series_non_empty_eq_excludes_missing_label():
+    """EQ to a non-empty value requires the key in the tag map."""
+    data = get_json_from_api(
+        "/api/v1/series",
+        params=[("match[]", '{zone="us-east"}')],
+    )
+    assert isinstance(data, list)
+    names = {e["__name__"] for e in data if "__name__" in e}
+    assert "http_requests_total" not in names
+
+
 def test_labels_with_match_selector():
     """labels endpoint narrows when match[] matches a subset of metrics."""
     data = get_json_from_api(

--- a/tests/integration/test_prometheus_protocols/test_series_labels_api_promoted.py
+++ b/tests/integration/test_prometheus_protocols/test_series_labels_api_promoted.py
@@ -1,5 +1,7 @@
 """Prometheus series/labels API with tags_to_columns (promoted tag columns)."""
 
+import urllib.parse
+
 import pytest
 import requests
 
@@ -41,6 +43,10 @@ def setup(request):
                 {"__name__": "cpu_usage", "datacenter": "us-east", "host": "server1"},
                 {1000: 0.5, 1015: 0.6, 1030: 0.7},
             ),
+            (
+                {"__name__": "memory_usage", "datacenter": "us-west", "host": "server2"},
+                {1000: 0.1, 1015: 0.2, 1030: 0.3},
+            ),
         ]
         protobuf = convert_time_series_to_protobuf(time_series)
         send_protobuf_to_remote_write(node.ip_address, 9093, "/write", protobuf)
@@ -71,3 +77,18 @@ def test_series_includes_host_from_promoted_column():
     entry = next(e for e in data if e.get("__name__") == "cpu_usage")
     assert entry.get("host") == "server1"
     assert entry.get("datacenter") == "us-east"
+
+
+def test_series_multiple_match_union_with_promoted_host_column():
+    params = [
+        ("match[]", '{__name__="cpu_usage"}'),
+        ("match[]", '{__name__="memory_usage"}'),
+    ]
+    url = f"http://{node.ip_address}:9093/api/v1/series?" + urllib.parse.urlencode(
+        params, doseq=True
+    )
+    response = requests.get(url)
+    assert response.status_code == 200, response.text
+    data = response.json()["data"]
+    names = {e["__name__"] for e in data if "__name__" in e}
+    assert names == {"cpu_usage", "memory_usage"}

--- a/tests/integration/test_prometheus_protocols/test_series_labels_api_promoted.py
+++ b/tests/integration/test_prometheus_protocols/test_series_labels_api_promoted.py
@@ -156,3 +156,19 @@ def test_label_values_promoted_excludes_default_empty_with_match():
         params=[("match[]", '{__name__="disk_usage"}')],
     )
     assert data == [], data
+
+
+def test_series_omits_promoted_label_when_absent_in_original_series():
+    """`/api/v1/series` must not synthesize promoted labels for series that did not carry them.
+
+    `disk_usage` was ingested without `host`; the promoted `host_col` stores `''` by default.
+    Prometheus treats missing == empty, so the series entry must omit the `host` key entirely
+    rather than emit `"host": ""`.
+    """
+    data = get_json_from_api("/api/v1/series")
+    disk_entry = next(e for e in data if e.get("__name__") == "disk_usage")
+    assert "host" not in disk_entry, disk_entry
+    assert disk_entry.get("datacenter") == "us-south"
+
+    cpu_entry = next(e for e in data if e.get("__name__") == "cpu_usage")
+    assert cpu_entry.get("host") == "server1"

--- a/tests/integration/test_prometheus_protocols/test_series_labels_api_promoted.py
+++ b/tests/integration/test_prometheus_protocols/test_series_labels_api_promoted.py
@@ -1,0 +1,73 @@
+"""Prometheus series/labels API with tags_to_columns (promoted tag columns)."""
+
+import pytest
+import requests
+
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import assert_eq_with_retry
+from .prometheus_test_utils import *
+
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/prometheus.xml"],
+    user_configs=["configs/allow_experimental_time_series_table.xml"],
+    handle_prometheus_remote_write=(9093, "/write"),
+)
+
+
+def get_json_from_api(path):
+    url = f"http://{node.ip_address}:9093{path}"
+    response = requests.get(url)
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["status"] == "success"
+    return data["data"]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(request):
+    try:
+        cluster.start()
+        node.query("DROP TABLE IF EXISTS prometheus SYNC")
+        node.query(
+            "CREATE TABLE prometheus (host_col LowCardinality(String)) "
+            "ENGINE=TimeSeries() SETTINGS tags_to_columns = {'host': 'host_col'}"
+        )
+        time_series = [
+            (
+                {"__name__": "cpu_usage", "datacenter": "us-east", "host": "server1"},
+                {1000: 0.5, 1015: 0.6, 1030: 0.7},
+            ),
+        ]
+        protobuf = convert_time_series_to_protobuf(time_series)
+        send_protobuf_to_remote_write(node.ip_address, 9093, "/write", protobuf)
+        assert_eq_with_retry(
+            node, "SELECT count() > 0 FROM timeSeriesData(prometheus)", "1"
+        )
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_labels_includes_promoted_tag_name():
+    data = get_json_from_api("/api/v1/labels")
+    assert isinstance(data, list)
+    assert "__name__" in data
+    assert "host" in data
+    assert "datacenter" in data
+
+
+def test_label_values_host_from_promoted_column():
+    data = get_json_from_api("/api/v1/label/host/values")
+    assert "server1" in data
+
+
+def test_series_includes_host_from_promoted_column():
+    data = get_json_from_api("/api/v1/series")
+    assert len(data) >= 1
+    entry = next(e for e in data if e.get("__name__") == "cpu_usage")
+    assert entry.get("host") == "server1"
+    assert entry.get("datacenter") == "us-east"

--- a/tests/integration/test_prometheus_protocols/test_series_labels_api_promoted.py
+++ b/tests/integration/test_prometheus_protocols/test_series_labels_api_promoted.py
@@ -20,8 +20,10 @@ node = cluster.add_instance(
 )
 
 
-def get_json_from_api(path):
+def get_json_from_api(path, params=None):
     url = f"http://{node.ip_address}:9093{path}"
+    if params:
+        url += "?" + urllib.parse.urlencode(params, doseq=True)
     response = requests.get(url)
     assert response.status_code == 200, response.text
     data = response.json()
@@ -46,6 +48,12 @@ def setup(request):
             (
                 {"__name__": "memory_usage", "datacenter": "us-west", "host": "server2"},
                 {1000: 0.1, 1015: 0.2, 1030: 0.3},
+            ),
+            # Series with no `host` label -- the promoted column should be empty for these rows,
+            # and `/api/v1/labels?match[]={__name__="disk_usage"}` must NOT advertise `host`.
+            (
+                {"__name__": "disk_usage", "datacenter": "us-south"},
+                {1000: 0.9, 1015: 0.91, 1030: 0.92},
             ),
         ]
         protobuf = convert_time_series_to_protobuf(time_series)
@@ -92,3 +100,38 @@ def test_series_multiple_match_union_with_promoted_host_column():
     data = response.json()["data"]
     names = {e["__name__"] for e in data if "__name__" in e}
     assert names == {"cpu_usage", "memory_usage"}
+
+
+def test_labels_match_zero_rows_returns_empty():
+    """`/api/v1/labels?match[]=...` must derive labels from matched rows only:
+    when the selector matches no series, the response must be empty and must not
+    include `__name__` or any promoted label from `tags_to_columns`."""
+    data = get_json_from_api(
+        "/api/v1/labels",
+        params=[("match[]", '{__name__="does_not_exist"}')],
+    )
+    assert data == [], data
+
+
+def test_labels_match_excludes_promoted_label_when_absent_in_matched_rows():
+    """Promoted labels must only appear when at least one matched row carries them.
+    `disk_usage` was inserted without a `host` label, so its promoted `host_col`
+    is empty. Filtering to only `disk_usage` must omit `host` from /labels."""
+    data = get_json_from_api(
+        "/api/v1/labels",
+        params=[("match[]", '{__name__="disk_usage"}')],
+    )
+    assert "__name__" in data
+    assert "datacenter" in data
+    assert "host" not in data, data
+
+
+def test_labels_match_includes_promoted_label_when_present():
+    """Sanity check: when matched rows do carry the promoted label, /labels still includes it."""
+    data = get_json_from_api(
+        "/api/v1/labels",
+        params=[("match[]", '{__name__="cpu_usage"}')],
+    )
+    assert "__name__" in data
+    assert "host" in data
+    assert "datacenter" in data

--- a/tests/integration/test_prometheus_protocols/test_series_labels_api_promoted.py
+++ b/tests/integration/test_prometheus_protocols/test_series_labels_api_promoted.py
@@ -135,3 +135,24 @@ def test_labels_match_includes_promoted_label_when_present():
     assert "__name__" in data
     assert "host" in data
     assert "datacenter" in data
+
+
+def test_label_values_promoted_excludes_default_empty():
+    """`/api/v1/label/<promoted>/values` must NOT surface `""` for series that simply omit the label.
+
+    `disk_usage` was ingested without `host`, so the promoted `host_col` stores `''` (column default).
+    Prometheus treats missing == empty, so the response must include the real `host` values but not `""`.
+    """
+    data = get_json_from_api("/api/v1/label/host/values")
+    assert "" not in data, data
+    assert "server1" in data
+    assert "server2" in data
+
+
+def test_label_values_promoted_excludes_default_empty_with_match():
+    """Same contract under `match[]`: filtering to the no-host series must yield empty values, not [""]."""
+    data = get_json_from_api(
+        "/api/v1/label/host/values",
+        params=[("match[]", '{__name__="disk_usage"}')],
+    )
+    assert data == [], data


### PR DESCRIPTION
Based on https://github.com/ClickHouse/ClickHouse/pull/97032/ with some added performance improvements and test casing.

The Prometheus HTTP API had placeholder implementations for the series, labels, and label-values endpoints that threw NOT_IMPLEMENTED. This makes them functional by querying the TimeSeries tags table:

- /api/v1/series: Returns all series with their full label sets by querying metric_name and tags from the tags table. Supports optional match[] parameter for metric name filtering.

- /api/v1/labels: Returns all unique label names by extracting distinct keys from the tags Map column. Always includes __name__ as a virtual label. Supports optional match[] filtering.

- /api/v1/label/<name>/values: Returns distinct values for a specific label. For __name__, queries the metric_name column directly. For other labels, extracts values from the tags Map column.

These endpoints are required for Grafana's Prometheus data source to function properly (label autocomplete, metric browser, etc.).

### Changelog category (leave one):
- Experimental Feature


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Implement Prometheus /api/v1/series, /labels, /label/<name>/values endpoints

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

This enables users to explore metric/label/value collections through Grafana.