### PR TITLE
Support lazy materialization for LIMIT BY queries

### DIFF
--- a/src/Processors/QueryPlan/LimitByStep.h
+++ b/src/Processors/QueryPlan/LimitByStep.h
@@ -25,6 +25,7 @@ public:
     static QueryPlanStepPtr deserialize(Deserialization & ctx);
 
     void applyOrder(SortDescription sort_desc);
+    const Names & getColumns() const { return columns; }
 private:
     void updateOutputHeader() override
     {

--- a/src/Processors/QueryPlan/Optimizations/optimizeLazyMaterialization.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeLazyMaterialization.cpp
@@ -3,6 +3,7 @@
 #include <Interpreters/ActionsDAG.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/FilterStep.h>
+#include <Processors/QueryPlan/LimitByStep.h>
 #include <Processors/QueryPlan/Optimizations/Optimizations.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
 #include <Processors/QueryPlan/SortingStep.h>
@@ -411,7 +412,34 @@ bool optimizeLazyMaterialization2(QueryPlan::Node & root, QueryPlan & query_plan
     if (limit_step->withTies())
         return false;
 
-    auto * sorting_step = typeid_cast<SortingStep *>(root.children.front()->step.get());
+    auto * limit_by_node = root.children.front();
+    auto * limit_by_step = typeid_cast<LimitByStep *>(root.children.front()->step.get());
+    ExpressionStep * limit_by_expr_step = nullptr;
+    PlanStepWithRequiredDAGPositions limit_by_expr_step_to_split;
+
+    QueryPlan::Node * sorting_node = nullptr;
+    // The query may include a LIMIT BY clause, and in this case lazy
+    // materialization expects the following plan structure:
+    // ORDER BY -> Expression -> LIMIT BY -> LIMIT
+    // where the Expression step computes LIMIT BY columns
+    if (limit_by_step)
+    {
+        if (limit_by_node->children.size() != 1)
+            return false;
+
+        auto * limit_by_expr_node = limit_by_node->children.front();
+        limit_by_expr_step = typeid_cast<ExpressionStep *>(limit_by_expr_node->step.get());
+        if (!limit_by_expr_step || limit_by_expr_node->children.size() != 1)
+            return false;
+
+        limit_by_expr_step_to_split.step = limit_by_expr_step;
+
+        sorting_node = limit_by_expr_node->children.front();
+    }
+    else
+        sorting_node = root.children.front();
+
+    auto * sorting_step = typeid_cast<SortingStep *>(sorting_node->step.get());
     if (!sorting_step)
         return false;
 
@@ -426,7 +454,6 @@ bool optimizeLazyMaterialization2(QueryPlan::Node & root, QueryPlan & query_plan
 
     StepStack steps_to_update;
 
-    auto * sorting_node = root.children.front();
     auto * reading_step = findReadingStep(*sorting_node->children.front(), steps_to_update);
     if (!reading_step)
         return false;
@@ -434,12 +461,38 @@ bool optimizeLazyMaterialization2(QueryPlan::Node & root, QueryPlan & query_plan
     if (!canUseLazyMaterializationForReadingStep(reading_step))
         return false;
 
-    const auto & sorting_header = *sorting_step->getOutputHeader();
     /// At this moment, required_columns are corresponding to output header columns of every step.
-    std::vector<bool> required_columns(sorting_header.columns(), false);
+    std::vector<bool> required_columns;
 
-    for (const auto & descr : sorting_step->getSortDescription())
-        required_columns[sorting_header.getPositionByName(descr.column_name)] = true;
+    if (limit_by_step)
+    {
+        const auto & limit_by_header = *limit_by_step->getOutputHeader();
+        required_columns.assign(limit_by_header.columns(), false);
+
+        for (const auto & column : limit_by_step->getColumns())
+            required_columns[limit_by_header.getPositionByName(column)] = true;
+
+        const auto & limit_by_expr = limit_by_expr_step->getExpression();
+        limit_by_expr_step_to_split.required_positions.insert(
+            limit_by_expr_step_to_split.required_positions.end(),
+            required_columns.begin(),
+            required_columns.begin() + limit_by_expr.getOutputs().size());
+        required_columns = getRequiredHeaderPositions(
+            limit_by_expr,
+            *limit_by_expr_step->getInputHeaders().front(),
+            std::move(required_columns));
+
+        for (const auto & descr : sorting_step->getSortDescription())
+            required_columns[sorting_step->getOutputHeader()->getPositionByName(descr.column_name)] = true;
+    }
+    else
+    {
+        const auto & sorting_header = *sorting_step->getOutputHeader();
+        required_columns.assign(sorting_header.columns(), false);
+
+        for (const auto & descr : sorting_step->getSortDescription())
+            required_columns[sorting_header.getPositionByName(descr.column_name)] = true;
+    }
 
     bool has_filter = false;
 
@@ -577,9 +630,20 @@ bool optimizeLazyMaterialization2(QueryPlan::Node & root, QueryPlan & query_plan
         }
     }
 
-    auto new_sorting_step = std::move(root.children.front()->step); // = std::make_unique<SortingStep>(main_plan.getCurrentHeader(), sorting_step->getSortDescription(), sorting_step->getLimit(), sorting_step->getSettings());
+    auto new_sorting_step = std::move(sorting_node->step);
     new_sorting_step->updateInputHeader(main_plan.getCurrentHeader());
     main_plan.addStep(std::move(new_sorting_step));
+
+    if (limit_by_step)
+    {
+        auto split_result = splitExpressionStep(*limit_by_expr_step, limit_by_expr_step_to_split.required_positions, required_columns);
+        main_plan.addStep(std::make_unique<ExpressionStep>(main_plan.getCurrentHeader(), std::move(split_result.main_expression_step)));
+        lazy_steps.push_back(std::move(split_result.lazy_expression_step));
+
+        auto new_limit_by_step = std::move(limit_by_node->step);
+        new_limit_by_step->updateInputHeader(main_plan.getCurrentHeader());
+        main_plan.addStep(std::move(new_limit_by_step));
+    }
 
     limit_step->updateInputHeader(main_plan.getCurrentHeader());
     main_plan.addStep(std::move(root.step));

--- a/tests/queries/0_stateless/04097_lazy_materialization_limit_by.reference
+++ b/tests/queries/0_stateless/04097_lazy_materialization_limit_by.reference
@@ -1,0 +1,35 @@
+-- Basic:
+Lazily read columns: value
+9	99	val-99
+8	98	val-98
+7	97	val-97
+-- Basic SELECT value:
+Lazily read columns: value
+val-99
+val-98
+val-97
+-- ORDER BY <expr>:
+Lazily read columns: value
+9	99	val-99
+8	98	val-98
+7	97	val-97
+-- LIMIT BY <expr>:
+Lazily read columns: value
+9	99	val-99
+8	98	val-98
+7	97	val-97
+-- ORDER BY <expr> LIMIT BY <expr>:
+Lazily read columns: value
+9	99	val-99
+8	98	val-98
+7	97	val-97
+-- ORDER BY <alias> LIMIT BY <alias>:
+Lazily read columns: value
+9	99	val-99
+8	98	val-98
+7	97	val-97
+-- Basic sorted:
+Lazily read columns: value
+9	99	val-99
+8	98	val-98
+7	97	val-97

--- a/tests/queries/0_stateless/04097_lazy_materialization_limit_by.sql
+++ b/tests/queries/0_stateless/04097_lazy_materialization_limit_by.sql
@@ -1,0 +1,106 @@
+SET query_plan_optimize_lazy_materialization = 1;
+SET query_plan_max_limit_for_lazy_materialization = 10;
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS 04097_data, 04097_data_sorted;
+
+CREATE TABLE 04097_data
+(
+    key UInt64,
+    version UInt64,
+    value String,
+)
+ENGINE = MergeTree()
+ORDER BY tuple();
+
+INSERT INTO 04097_data SELECT number % 10, number, 'val-' || number FROM numbers(100);
+
+SELECT '-- Basic:';
+
+SELECT trimLeft(explain)
+FROM (
+    EXPLAIN PLAN actions=1 SELECT * FROM 04097_data ORDER BY version DESC LIMIT 1 BY key LIMIT 3
+)
+WHERE explain LIKE '%Lazily read columns:%';
+
+SELECT * FROM 04097_data ORDER BY version DESC LIMIT 1 BY key LIMIT 3;
+
+SELECT '-- Basic SELECT value:';
+
+SELECT trimLeft(explain)
+FROM (
+    EXPLAIN PLAN actions=1 SELECT value FROM 04097_data ORDER BY version DESC LIMIT 1 BY key LIMIT 3
+)
+WHERE explain LIKE '%Lazily read columns:%';
+
+SELECT value FROM 04097_data ORDER BY version DESC LIMIT 1 BY key LIMIT 3;
+
+SELECT '-- ORDER BY <expr>:';
+
+SELECT trimLeft(explain)
+FROM (
+    EXPLAIN PLAN actions=1 SELECT * FROM 04097_data ORDER BY version % 100 DESC LIMIT 1 BY key LIMIT 3
+)
+WHERE explain LIKE '%Lazily read columns:%';
+
+SELECT * FROM 04097_data ORDER BY version % 100 DESC LIMIT 1 BY key LIMIT 3;
+
+SELECT '-- LIMIT BY <expr>:';
+
+SELECT trimLeft(explain)
+FROM (
+    EXPLAIN PLAN actions=1 SELECT * FROM 04097_data ORDER BY version DESC LIMIT 1 BY key + 60 LIMIT 3
+)
+WHERE explain LIKE '%Lazily read columns:%';
+
+SELECT * FROM 04097_data ORDER BY version DESC LIMIT 1 BY key + 60 LIMIT 3;
+
+SELECT '-- ORDER BY <expr> LIMIT BY <expr>:';
+
+SELECT trimLeft(explain)
+FROM (
+    EXPLAIN PLAN actions=1 SELECT * FROM 04097_data ORDER BY version - 400 DESC LIMIT 1 BY key + 90 LIMIT 3
+)
+WHERE explain LIKE '%Lazily read columns:%';
+
+SELECT * FROM 04097_data ORDER BY version - 400 DESC LIMIT 1 BY key + 90 LIMIT 3;
+
+SELECT '-- ORDER BY <alias> LIMIT BY <alias>:';
+
+SELECT trimLeft(explain)
+FROM (
+    EXPLAIN PLAN actions=1
+    WITH version - 400 AS sort_key,
+         key + 90 AS limit_by_key
+    SELECT * FROM 04097_data ORDER BY sort_key DESC LIMIT 1 BY limit_by_key LIMIT 3
+)
+WHERE explain LIKE '%Lazily read columns:%';
+
+WITH version - 400 AS sort_key,
+        key + 90 AS limit_by_key
+SELECT * FROM 04097_data ORDER BY sort_key DESC LIMIT 1 BY limit_by_key LIMIT 3;
+
+DROP TABLE 04097_data;
+
+CREATE TABLE 04097_data_sorted
+(
+    key UInt64,
+    version UInt64,
+    value String,
+)
+ENGINE = MergeTree()
+ORDER BY key;
+
+INSERT INTO 04097_data_sorted SELECT number % 10, number, 'val-' || number FROM numbers(100);
+
+SELECT '-- Basic sorted:';
+
+SELECT trimLeft(explain)
+FROM (
+    EXPLAIN PLAN actions=1 SELECT * FROM 04097_data_sorted ORDER BY version DESC LIMIT 1 BY key LIMIT 3
+)
+WHERE explain LIKE '%Lazily read columns:%';
+
+SELECT * FROM 04097_data_sorted ORDER BY version DESC LIMIT 1 BY key LIMIT 3;
+
+DROP TABLE 04097_data_sorted;


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Support lazy materialization for queries with the LIMIT BY clause.

### Details
Current implementation supports only `ORDER BY -> LIMIT` queries, but if there is a `LIMIT BY` between them, the optimization is disabled. This patch makes queries with `LIMIT BY` clause eligible for lazy materialization.