### PR TITLE
Unify praktika label/hlabel API with optional links and hover hints

### DIFF
--- a/.claude/tools/fetch_ci_report.js
+++ b/.claude/tools/fetch_ci_report.js
@@ -217,12 +217,21 @@ function parseTestResults(jsonData) {
           test.links = result.links;
         }
 
-        // Extract CIDB links from ext.hlabels
-        if (result.ext && result.ext.hlabels) {
+        // Extract CIDB links from unified ext.labels (or legacy ext.hlabels).
+        if (result.ext) {
           const cidbLinks = [];
-          for (const hlabel of result.ext.hlabels) {
-            if (Array.isArray(hlabel) && hlabel[0] === 'cidb' && hlabel[1]) {
-              cidbLinks.push(hlabel[1]);
+          if (Array.isArray(result.ext.labels)) {
+            for (const label of result.ext.labels) {
+              if (label && typeof label === 'object' && label.name === 'cidb' && label.link) {
+                cidbLinks.push(label.link);
+              }
+            }
+          }
+          if (Array.isArray(result.ext.hlabels)) {
+            for (const hlabel of result.ext.hlabels) {
+              if (Array.isArray(hlabel) && hlabel[0] === 'cidb' && hlabel[1]) {
+                cidbLinks.push(hlabel[1]);
+              }
             }
           }
           if (cidbLinks.length > 0) {

--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,8 @@ tests/casa_del_dolor/_instances*
 
 # Claude preferences
 .claude/*.local.*
+
+# praktika test-mode HTML deploy artifacts (regenerated from json.html by infrastructure --test)
+ci/praktika/json_test.html
+ci/praktika/json_test.html.gz
+ci/praktika/json.html.gz

--- a/ci/jobs/clickhouse_light.py
+++ b/ci/jobs/clickhouse_light.py
@@ -94,7 +94,7 @@ class TestResult:
             info=info,
         )
         if "xfail" in self.tags:
-            r.set_label("xfail")
+            r.set_label(Result.Label.XFAIL)
         return r
 
 

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -719,7 +719,7 @@ def main():
     if is_bugfix_validation and test_result and (Labels.PR_BUGFIX in info.pr_labels or Labels.PR_CRITICAL_BUGFIX in info.pr_labels):
         has_failure = False
         for r in test_result.results:
-            r.set_label("xfail")
+            r.set_label(Result.Label.XFAIL)
             if r.status == Result.Status.FAIL:
                 r.status = Result.Status.OK
                 has_failure = True

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -1048,7 +1048,7 @@ tar -czf ./ci/tmp/logs.tar.gz \
         has_failure = False
         for r in R.results:
             # invert statuses
-            r.set_label("xfail")
+            r.set_label(Result.Label.XFAIL)
             if r.status == Result.Status.FAIL:
                 r.status = Result.Status.OK
                 has_failure = True

--- a/ci/jobs/keeper_stress_job.py
+++ b/ci/jobs/keeper_stress_job.py
@@ -411,9 +411,10 @@ def _add_grafana_links(result, commit_sha, stop_watch, run_faults, run_no_faults
     }
     if scenario_ids:
         p_details["var-scenario"] = scenario_ids
-    result.set_clickable_label(
+    result.set_label(
         "Grafana: Run details (this run)",
-        _url(GRAFANA_DASH_UID["run_details"], p_details),
+        link=_url(GRAFANA_DASH_UID["run_details"], p_details),
+        hint="Open the per-run Grafana dashboard for this Keeper stress run",
     )
 
     p_comp = {
@@ -426,9 +427,10 @@ def _add_grafana_links(result, commit_sha, stop_watch, run_faults, run_no_faults
         "var-baseline_version": compare_short,
         "refresh": "1m",
     }
-    result.set_clickable_label(
+    result.set_label(
         "Grafana: 1vs1 Comparison",
-        _url(GRAFANA_DASH_UID["comparison"], p_comp),
+        link=_url(GRAFANA_DASH_UID["comparison"], p_comp),
+        hint="Compare this run against the baseline branch in Grafana",
     )
 
     p_hist = {
@@ -439,9 +441,10 @@ def _add_grafana_links(result, commit_sha, stop_watch, run_faults, run_no_faults
         "var-scenario": scenario_val,
         "refresh": "1m",
     }
-    result.set_clickable_label(
+    result.set_label(
         "Grafana: Historical progression",
-        _url(GRAFANA_DASH_UID["historical"], p_hist),
+        link=_url(GRAFANA_DASH_UID["historical"], p_hist),
+        hint="View the historical progression of this scenario in Grafana",
     )
 
 

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -203,7 +203,7 @@ Test output:
         title = result.name
         body = f"""\
 Test name: {result.name}
-{ci_report_line}Failing test history: [cidb]({result.get_hlabel_link("cidb")})
+{ci_report_line}Failing test history: [cidb]({result.get_label_link(Result.Label.CIDB)})
 
 Test output:
 ```
@@ -264,7 +264,7 @@ Test output:
             max_line_length=200,
         )
         res += f"\n - flags: {', '.join(result.get_labels()) or 'not flaged'}"
-        res += f"\n - cidb: {result.get_hlabel_link('cidb') or 'not found'}"
+        res += f"\n - cidb: {result.get_label_link(Result.Label.CIDB) or 'not found'}"
         return res
 
     @classmethod
@@ -708,7 +708,7 @@ def process_workflow_failures(workflow_result, repo, pr_num, sha, allow_infra_is
             print(f"{failure_cnt}. [ {failure_result.status} ] {failure_result.name}")
             if job_name != failure_result.name:
                 print(f"  in {job_name}")
-                print(f"cidb: {failure_result.get_hlabel_link('cidb')}")
+                print(f"cidb: {failure_result.get_label_link(Result.Label.CIDB)}")
 
             # Create new issue if user confirms
             if UserPrompt.confirm("Create GitHub issue for this failure?"):
@@ -731,7 +731,7 @@ def process_workflow_failures(workflow_result, repo, pr_num, sha, allow_infra_is
                         issue_catalog.active_test_issues.append(ci_issue)
                         issue_catalog.dump()
                     failure_result.set_comment("ISSUE CREATED")
-                    failure_result.set_clickable_label("issue", ci_issue.url)
+                    failure_result.set_label(Result.Label.ISSUE, link=ci_issue.url)
                     known_failures.append((job_name, failure_result))
                     issues_created_count += 1
                 else:

--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -263,7 +263,7 @@ Test output:
             max_info_lines_cnt=50,
             max_line_length=200,
         )
-        res += f"\n - flags: {', '.join(result.get_labels()) or 'not flaged'}"
+        res += f"\n - flags: {', '.join(result.get_labels()) or 'not flagged'}"
         res += f"\n - cidb: {result.get_label_link(Result.Label.CIDB) or 'not found'}"
         return res
 

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -688,15 +688,19 @@ class GH:
                     else:
                         yield from flatten_results(r.results)
 
-            def extract_hlabels_info(res: Result) -> str:
+            def extract_label_links_md(res: Result) -> str:
+                """Render labels with links as markdown ``[name](link)`` chips.
+                Reads the unified ``ext['labels']`` and falls back to legacy
+                ``ext['hlabels']`` for results stored before the unification.
+                """
                 try:
-                    hlabels = (
-                        res.ext.get("hlabels", [])
-                        if hasattr(res, "ext") and isinstance(res.ext, dict)
-                        else []
-                    )
+                    if not (hasattr(res, "ext") and isinstance(res.ext, dict)):
+                        return ""
                     links = []
-                    for item in hlabels:
+                    for item in res.ext.get("labels", []) or []:
+                        if isinstance(item, dict) and item.get("name") and item.get("link"):
+                            links.append(f"[{item['name']}]({item['link']})")
+                    for item in res.ext.get("hlabels", []) or []:
                         if isinstance(item, (list, tuple)) and len(item) >= 2:
                             text, href = item[0], item[1]
                             if text and href:
@@ -705,6 +709,16 @@ class GH:
                 except Exception:
                     return ""
 
+            def has_label_links(res: Result) -> bool:
+                if not (hasattr(res, "ext") and isinstance(res.ext, dict)):
+                    return False
+                if any(
+                    isinstance(it, dict) and it.get("link")
+                    for it in res.ext.get("labels", []) or []
+                ):
+                    return True
+                return bool(res.ext.get("hlabels"))
+
             summary = cls(
                 name=result.name,
                 status=result.status,
@@ -712,7 +726,7 @@ class GH:
                 start_time=result.start_time,
                 duration=result.duration,
                 failed_results=[],
-                info=extract_hlabels_info(result),
+                info=extract_label_links_md(result),
                 comment=result.ext.get("comment", ""),
             )
 
@@ -735,14 +749,14 @@ class GH:
                 failed_result = cls(
                     name=sub_result.name,
                     status=sub_result.status,
-                    info=extract_hlabels_info(sub_result),
+                    info=extract_label_links_md(sub_result),
                     comment=sub_result.ext.get("comment", ""),
                 )
                 failed_result.failed_results = [
                     cls(
                         name=r.name,
                         status=r.status,
-                        info=extract_hlabels_info(r),
+                        info=extract_label_links_md(r),
                         comment=r.ext.get("comment", ""),
                     )
                     for r in flatten_results(sub_result.results)
@@ -762,11 +776,11 @@ class GH:
                 remaining = len(summary.failed_results) - MAX_JOBS_PER_SUMMARY
                 summary.failed_results = summary.failed_results[:MAX_JOBS_PER_SUMMARY]
                 print(f"NOTE: {remaining} more jobs not shown in PR comment")
-            # Collect links from jobs that have hlabels (e.g. keeper-stress Grafana links).
+            # Collect links from jobs that have labels with links (e.g. keeper-stress Grafana links).
             # Include regardless of success/failure so Grafana links always appear when keeper-stress runs.
             for job_result in getattr(result, "results", []) or []:
-                if job_result.ext.get("hlabels"):
-                    links_md = extract_hlabels_info(job_result)
+                if has_label_links(job_result):
+                    links_md = extract_label_links_md(job_result)
                     if links_md:
                         summary.extra_links.append((job_result.name, links_md))
             return summary

--- a/ci/praktika/issue.py
+++ b/ci/praktika/issue.py
@@ -282,7 +282,7 @@ class Issue:
         print(
             f"Marking '{result.name}' as flaky (matched: {test_name}, issue: #{self.number})"
         )
-        result.set_clickable_label(label=Result.Label.ISSUE, link=self.url)
+        result.set_label(Result.Label.ISSUE, link=self.url)
         return True
 
     def _check_infrastructure_match(
@@ -313,7 +313,7 @@ class Issue:
         print(
             f"  Marking '{result.name}' as infrastructure issue (issue: #{self.number})"
         )
-        result.set_clickable_label(label="issue", link=self.url)
+        result.set_label(Result.Label.ISSUE, link=self.url)
         return True
 
     @classmethod

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -693,6 +693,58 @@
         return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
     }
 
+    // Normalize ext.labels (and legacy ext.hlabels) into a list of
+     // {name, link?, hint?} entries. Accepts the unified dict format as well as
+     // legacy formats: a bare string in ext.labels, or [name, link] in ext.hlabels.
+    function normalizeLabels(labels, hlabels) {
+        const out = [];
+        const indexByName = new Map();
+        const upsert = (entry) => {
+            const existingIdx = indexByName.get(entry.name);
+            if (existingIdx === undefined) {
+                indexByName.set(entry.name, out.length);
+                out.push(entry);
+            } else {
+                out[existingIdx] = {...out[existingIdx], ...entry};
+            }
+        };
+        if (Array.isArray(labels)) {
+            labels.forEach(item => {
+                if (typeof item === 'string') {
+                    upsert({name: item});
+                } else if (item && typeof item === 'object' && item.name) {
+                    upsert({
+                        name: item.name,
+                        ...(item.link ? {link: item.link} : {}),
+                        ...(item.hint ? {hint: item.hint} : {}),
+                    });
+                }
+            });
+        }
+        if (Array.isArray(hlabels)) {
+            hlabels.forEach(item => {
+                if (Array.isArray(item) && item[0]) {
+                    upsert({name: item[0], ...(item[1] ? {link: item[1]} : {})});
+                }
+            });
+        }
+        return out;
+    }
+
+    // Apply common pill styling to a label element.
+    function applyLabelStyles(element, text) {
+        element.textContent = text;
+        element.style.marginLeft = '6px';
+        element.style.padding = '2px 8px';
+        element.style.backgroundColor = stringToColor(text, true);
+        element.style.color = 'white';
+        element.style.fontSize = '12px';
+        element.style.borderRadius = '8px';
+        element.style.fontWeight = 'bold';
+        element.style.display = 'inline-block';
+        element.style.verticalAlign = 'middle';
+    }
+
     function addFileLinksWidget(links) {
         if (!Array.isArray(links) || links.length === 0) return;
 
@@ -1431,8 +1483,9 @@
         displayResults.forEach((result, _index) => {
             const row = document.createElement('tr');
             if (result._downstreamHref) row.classList.add('downstream-row');
-            const labels = result?.ext?.labels;
-            const linklabels = result?.ext?.hlabels;
+            // Unified labels: list of {name, link?, hint?} (or legacy strings).
+            // Legacy ext.hlabels (list of [name, link]) is merged in for backward compat.
+            const labels = normalizeLabels(result?.ext?.labels, result?.ext?.hlabels);
 
             existingColumnsList.forEach(column => {
                 const td = document.createElement('td');
@@ -1486,56 +1539,22 @@
                         td.appendChild(link);
                     }
 
-                    // Helper to apply common label styling
-                    const applyLabelStyles = (element, text) => {
-                        element.textContent = text;
-                        element.style.marginLeft = '6px';
-                        element.style.padding = '2px 8px';
-                        element.style.backgroundColor = stringToColor(text, true);
-                        element.style.color = 'white';
-                        element.style.fontSize = '12px';
-                        element.style.borderRadius = '8px';
-                        element.style.fontWeight = 'bold';
-                        element.style.display = 'inline-block';
-                        element.style.verticalAlign = 'middle';
-                    };
-
-                    // Add whitespace before labels if any exist
-                    if ((labels && labels.length > 0) || (linklabels && linklabels.length > 0)) {
+                    // Render unified labels: plain span, or <a> if link present.
+                    // The hint (when set) becomes the title attribute -> hover tooltip.
+                    if (labels.length > 0) {
                         td.appendChild(document.createTextNode(' '));
-                    }
-
-                    // Render plain labels
-                    if (Array.isArray(labels)) {
-                        labels.forEach(labelStr => {
-                            const label = document.createElement('span');
-                            applyLabelStyles(label, labelStr);
-                            td.appendChild(label);
-                        });
-                    }
-
-                    // Render link labels
-                    if (Array.isArray(linklabels)) {
-                        linklabels.forEach(item => {
-                            let text, href;
-                            if (Array.isArray(item)) {
-                                [text, href] = item;
-                            } else if (item && typeof item === 'object') {
-                                text = item.text || item.label || '';
-                                href = item.href || item.url || '';
-                            } else if (typeof item === 'string') {
-                                text = item;
-                                href = '';
-                            }
-                            if (!text) return;
-
-                            const element = href ? document.createElement('a') : document.createElement('span');
-                            if (href) {
-                                element.href = href;
+                        labels.forEach(({name, link, hint}) => {
+                            const element = link ? document.createElement('a') : document.createElement('span');
+                            if (link) {
+                                element.href = link;
                                 element.target = '_blank';
                                 element.rel = 'noopener noreferrer';
                             }
-                            applyLabelStyles(element, text);
+                            applyLabelStyles(element, name);
+                            if (hint) {
+                                element.title = hint;
+                                element.style.cursor = link ? 'pointer' : 'help';
+                            }
                             td.appendChild(element);
                         });
                     }

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -181,7 +181,7 @@ class Result(MetaClasses.Serializable):
             for result in results:
                 if result.info:
                     infos.append(f"{result.name}: {result.info}")
-        return Result(
+        result = Result(
             name=name,
             status=result_status,
             start_time=start_time,
@@ -191,7 +191,10 @@ class Result(MetaClasses.Serializable):
             assets=assets or [],
             files=files or [],
             links=links or [],
-        ).set_label(labels or [])
+        )
+        for label in labels or []:
+            result.set_label(label)
+        return result
 
     @staticmethod
     def get():
@@ -385,19 +388,10 @@ class Result(MetaClasses.Serializable):
         - hint: optional tooltip text shown on hover. If omitted on a new label,
           falls back to Result.LABEL_HINTS[label] when registered. On an existing
           label, omitting link/hint preserves the current value.
-
-        ``label`` may also be a list whose items are strings, dicts, or
-        (name, link) / (name, link, hint) tuples — each is added in turn.
         """
-        if isinstance(label, list):
-            for item in label:
-                if isinstance(item, dict):
-                    self.set_label(**item)
-                elif isinstance(item, (list, tuple)):
-                    self.set_label(*item)
-                else:
-                    self.set_label(item)
-            return self
+        assert isinstance(label, str), (
+            f"label must be a string, got {type(label).__name__}"
+        )
 
         labels = self.ext.setdefault("labels", [])
         for i, existing in enumerate(labels):

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -192,6 +192,8 @@ class Result(MetaClasses.Serializable):
             files=files or [],
             links=links or [],
         )
+        if isinstance(labels, str):
+            labels = [labels]
         for label in labels or []:
             result.set_label(label)
         return result

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -84,6 +84,20 @@ class Result(MetaClasses.Serializable):
         BLOCKER = "blocker"
         ISSUE = "issue"
         INFRA = "infra"
+        XFAIL = "xfail"
+        CIDB = "cidb"
+
+    # Default hints rendered as a hover tooltip in json.html.
+    # Looked up automatically when set_label is called without an explicit hint.
+    LABEL_HINTS = {
+        Label.OK_ON_RETRY: "Test failed initially but passed on retry",
+        Label.FAILED_ON_RETRY: "Test failed both on the first run and on retry",
+        Label.BLOCKER: "Blocks the merge regardless if a known issue is matched (sanitizer/fatal in server logs, etc.)",
+        Label.ISSUE: "A known open GitHub issue matches this failure",
+        Label.INFRA: "Infrastructure error",
+        Label.XFAIL: "Expected to fail (bugfix validation inverts the status)",
+        Label.CIDB: "Failure history for this test in the CI database",
+    }
 
     name: str
     status: str
@@ -356,52 +370,106 @@ class Result(MetaClasses.Serializable):
         self.duration = stopwatch.duration
         return self
 
-    def set_label(self, label):
-        if not self.ext.get("labels", None):
-            self.ext["labels"] = []
+    @staticmethod
+    def _label_name(entry):
+        """Return the name of a label entry (handles legacy string entries)."""
+        return entry if isinstance(entry, str) else entry.get("name")
+
+    _UNSET = object()
+
+    def set_label(self, label, link=_UNSET, hint=_UNSET):
+        """Add or update a label.
+
+        Each label is stored as a dict {"name": str, "link"?: str, "hint"?: str}.
+        - link: optional URL — clicking the label opens it in a new tab.
+        - hint: optional tooltip text shown on hover. If omitted on a new label,
+          falls back to Result.LABEL_HINTS[label] when registered. On an existing
+          label, omitting link/hint preserves the current value.
+
+        ``label`` may also be a list whose items are strings, dicts, or
+        (name, link) / (name, link, hint) tuples — each is added in turn.
+        """
         if isinstance(label, list):
-            self.ext["labels"].extend(label)
-        else:
-            self.ext["labels"].append(label)
+            for item in label:
+                if isinstance(item, dict):
+                    self.set_label(**item)
+                elif isinstance(item, (list, tuple)):
+                    self.set_label(*item)
+                else:
+                    self.set_label(item)
+            return self
+
+        labels = self.ext.setdefault("labels", [])
+        for i, existing in enumerate(labels):
+            if self._label_name(existing) == label:
+                merged = {"name": label}
+                if isinstance(existing, dict):
+                    for k in ("link", "hint"):
+                        if k in existing:
+                            merged[k] = existing[k]
+                else:
+                    # Legacy string entry — backfill default hint when migrating to dict.
+                    default = self.LABEL_HINTS.get(label)
+                    if default:
+                        merged["hint"] = default
+                if link is not self._UNSET:
+                    if link:
+                        merged["link"] = link
+                    else:
+                        merged.pop("link", None)
+                if hint is not self._UNSET:
+                    if hint:
+                        merged["hint"] = hint
+                    else:
+                        merged.pop("hint", None)
+                labels[i] = merged
+                return self
+
+        entry = {"name": label}
+        if link is not self._UNSET and link:
+            entry["link"] = link
+        resolved_hint = hint if hint is not self._UNSET else self.LABEL_HINTS.get(label)
+        if resolved_hint:
+            entry["hint"] = resolved_hint
+        labels.append(entry)
         return self
 
     def remove_label(self, label):
         if not self.ext.get("labels", None):
-            return
-        self.ext["labels"] = [l for l in self.ext["labels"] if l != label]
+            return self
+        self.ext["labels"] = [
+            l for l in self.ext["labels"] if self._label_name(l) != label
+        ]
         return self
 
     def get_labels(self):
-        return self.ext.get("labels", [])
+        """Return list of label names."""
+        return [self._label_name(l) for l in self.ext.get("labels", [])]
 
     def has_label(self, label):
-        return label in self.ext.get("labels", []) or label in [
-            x[0] for x in self.ext.get("hlabels", [])
-        ]
+        if label in self.get_labels():
+            return True
+        # Legacy fallback for results stored before the label/hlabel unification.
+        return label in [x[0] for x in self.ext.get("hlabels", []) if x]
+
+    def get_label_link(self, label):
+        for l in self.ext.get("labels", []):
+            if isinstance(l, dict) and l.get("name") == label:
+                return l.get("link")
+        # Legacy fallback for results stored before the label/hlabel unification.
+        for h in self.ext.get("hlabels", []):
+            if isinstance(h, (list, tuple)) and len(h) >= 2 and h[0] == label:
+                return h[1]
+        return None
+
+    def get_label_hint(self, label):
+        for l in self.ext.get("labels", []):
+            if isinstance(l, dict) and l.get("name") == label:
+                return l.get("hint")
+        return None
 
     def set_comment(self, comment):
         self.ext["comment"] = comment
-
-    def set_clickable_label(self, label, link):
-        if not self.ext.get("hlabels", None):
-            self.ext["hlabels"] = []
-        for i, (existing_label, existing_link) in enumerate(self.ext["hlabels"]):
-            if existing_label == label:
-                if existing_link != link:
-                    print(
-                        f"WARNING: Updating hlabel '{label}' from '{existing_link}' to '{link}'"
-                    )
-                    self.ext["hlabels"][i] = (label, link)
-                return
-        self.ext["hlabels"].append((label, link))
-
-    def get_hlabel_link(self, label):
-        if not self.ext.get("hlabels", None):
-            return None
-        for hlabel in self.ext["hlabels"]:
-            if hlabel[0] == label:
-                return hlabel[1]
-        return None
 
     @classmethod
     def from_pytest_run(

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -703,9 +703,9 @@ class Runner:
                 if test_cases_result and not test_cases_result.is_ok() and ci_db:
                     for test_case_result in test_cases_result.results:
                         if not test_case_result.is_ok():
-                            test_case_result.set_clickable_label(
-                                "cidb",
-                                ci_db.get_link_to_test_case_statistics(
+                            test_case_result.set_label(
+                                Result.Label.CIDB,
+                                link=ci_db.get_link_to_test_case_statistics(
                                     test_case_result.name,
                                     failure_patterns=Settings.TEST_FAILURE_PATTERNS,
                                     test_output=test_case_result.info,
@@ -722,7 +722,7 @@ class Runner:
             except Exception as ex:
                 if not info_errors:
                     traceback.print_exc()
-                    error = f"ERROR: Failed to set clickable label for test cases, exception [{ex}]"
+                    error = f"ERROR: Failed to set CIDB label for test cases, exception [{ex}]"
                     print(error)
                     info_errors.append(error)
 


### PR DESCRIPTION
Replace the separate `label` (plain) and `hlabel` (clickable) fields on `praktika.Result` with a single unified label that can carry an optional `link` and an optional `hint`. Hints render as a native browser hover tooltip in `json.html`.

- `Result.set_label(name, link=None, hint=None)` is now the single setter. Re-setting an existing label preserves prior `link`/`hint` unless explicitly overridden. Removed `set_clickable_label`/`get_hlabel_link`.
- New `Result.LABEL_HINTS` registry attaches reasonable default hints for `retry_ok`, `retry_failed`, `blocker`, `issue`, `infra`, `xfail`, `cidb`. New `Label.XFAIL` / `Label.CIDB` constants.
- Storage: each entry in `ext["labels"]` is `{name, link?, hint?}`. Reads still tolerate legacy plain-string entries and legacy `ext["hlabels"]`, so old S3 reports keep rendering correctly.
- `json.html`: single `normalizeLabels` helper merges new + legacy formats; the hint becomes the `title` attribute (native hover tooltip).
- Updated all call sites: `runner.py`, `issue.py`, `check_ci.py`, `keeper_stress_job.py`, `integration_test_job.py`, `functional_tests.py`, `clickhouse_light.py`, `gh.py`. Keeper-stress Grafana labels now carry explicit hints.
- `.claude/tools/fetch_ci_report.js` reads cidb links from both the unified format and the legacy fallback.
- `.gitignore`: ignore the transient `json_test.html(.gz)` and `json.html.gz` artifacts produced by `infrastructure --deploy --test`.


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1033`
<!-- ch-version-info:end -->