### PR TITLE
Fix reference for 03707_set_index_bad_get_null_bug on 25.8

### DIFF
--- a/tests/queries/0_stateless/03707_set_index_bad_get_null_bug.reference
+++ b/tests/queries/0_stateless/03707_set_index_bad_get_null_bug.reference
@@ -11,4 +11,4 @@ Expression
         Description: set GRANULARITY 1
         Parts: 0/1
         Granules: 0/1
-      Ranges: 0
+        Ranges: 0


### PR DESCRIPTION
The backport of PR #89429 to 25.8 (PR #92409, merged 2026-03-31) cherry-picked
the test reference file from master. But master's reference uses the post-fix
indentation for `Ranges:` (6 spaces) produced by
`ReadFromMergeTree::describeIndexes`, whereas 25.8 was branched **before**
commit ed65cfdd3fc ("Fix indent for Ranges output in EXPLAIN indexes=1",
2025-09-23). So 25.8's C++ still emits `Ranges:` at the double indent
(8 spaces), consistent with every other 25.8 reference file that prints
`Ranges:` (e.g. `01786_explain_merge_tree.reference`).

### Impact

Every `Stateless tests (amd_asan, distributed plan, parallel, 1/2)` run on
25.8 has failed 100% (23/23 on 25.8 tip, 27/27 on 25.8 backport PRs) since
PR #92409 merged on 2026-03-31 — 50 total CI failures across 19+ backport
PRs to 25.8 in the last ~17 days. CIDB:

```
SELECT pull_request_number, head_ref, count() as cnt FROM default.checks
WHERE test_name = '03707_set_index_bad_get_null_bug' AND test_status='FAIL'
  AND check_start_time > now() - INTERVAL 30 DAY GROUP BY pull_request_number, head_ref;
```

### Fix

Change the one `Ranges:` line in `03707_set_index_bad_get_null_bug.reference`
from 6 to 8 leading spaces so it matches what 25.8's `describeIndexes` actually
emits. Minimal, consistent with 25.8's other references. Not backporting
`ed65cfdd3fc` itself because that would require regenerating many reference
files on a release branch.

### Verified

- On 25.8 `describeIndexes` prints `prefix << indent << indent << "Ranges: "`
  = 4 + 2 + 2 = 8 leading spaces.
- On master (fixed) it prints `prefix << indent << "Ranges: "` = 4 + 2 = 6.
- 25.8 sibling reference `01786_explain_merge_tree.reference` already uses
  8 leading spaces for `Ranges:` — this PR brings `03707` in line.

Cron session: cron:clickhouse-ci-task-worker:20260417-091500

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix reference for `03707_set_index_bad_get_null_bug` on 25.8 (not required for changelog).


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)