### PR TITLE
Backport #101580 to 26.3: Fix flaky test 03706_statistics_preserve_checksums_on_mutations

### DIFF
--- a/tests/queries/0_stateless/03706_statistics_preserve_checksums_on_mutations.sh
+++ b/tests/queries/0_stateless/03706_statistics_preserve_checksums_on_mutations.sh
@@ -14,6 +14,10 @@ create table mt (key Int, value String) engine=MergeTree() order by key settings
   min_bytes_for_wide_part=0,
   -- otherwise sparse info will be different, since for INSERTs the sparse ratio is calculated for the whole block, while for mutations for each granula (FIXME?)
   ratio_of_defaults_for_sparse_serialization=1,
+  -- Pin `serialization_info_version` to `basic`: with `with_types`, the `INSERT` and mutation
+  -- paths may produce different `serialization.json` content (different type version metadata),
+  -- causing checksum mismatches that are not actual data corruption.
+  serialization_info_version='basic',
   -- This uncovers the bug
   auto_statistics_types='uniq,minmax,countmin,tdigest'
 ;


### PR DESCRIPTION
Backport of PR #101580 to the `26.3` release branch.

### Why
The test `03706_statistics_preserve_checksums_on_mutations` is chronically flaky on the `26.3` release branch:
- 25 direct-push failures on the `26.3` branch over the last 30 days
- 15 backport PRs targeting `26.3` also hit this failure (including #102876, #102835, #102518, #102030, #101962, #102240, #102279 and others)
- The fix has been present on `master` since 2026-04-08 (PR #101580). Zero master failures in 17+ days since — all remaining failures are on `26.3` and its backport PRs.

### Root cause
The test-runner randomizes `serialization_info_version`. When `with_types` is picked, the `INSERT` and `ALTER TABLE REWRITE PARTS` code paths produce different `serialization.json` content (different type version metadata). This causes `hash_of_all_files` and `hash_of_uncompressed_files` mismatches. `uncompressed_hash_of_compressed_files` stays identical — actual data is fine, only the metadata differs between the two paths.

The fix pins `serialization_info_version='basic'` in the `CREATE TABLE` settings so both code paths produce identical metadata.

### Change
Minimal 4-line addition to the `CREATE TABLE` settings. Backport scope is smaller than master's version of the test because `map_serialization_version` pins (from PR #100896) were never applied to `26.3`.

### Evidence on master
Before PR #101580 (April 8): ~1-3 master failures/day, 26 master failures in 14 days.
After PR #101580: 0 master failures in 17+ days. Pattern still active on `26.3`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)