### PR TITLE
include projection parts in total pk size asynchronous metrics

### DIFF
--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -377,6 +377,14 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
                         total_primary_key_bytes_memory_allocated += part->getIndexSizeInAllocatedBytes();
                         total_index_granularity_bytes_in_memory += part->getIndexGranularityBytes();
                         total_index_granularity_bytes_in_memory_allocated += part->getIndexGranularityAllocatedBytes();
+
+                        for (const auto & [_, projection_part] : part->getProjectionParts())
+                        {
+                            total_primary_key_bytes_memory += projection_part->getIndexSizeInBytes();
+                            total_primary_key_bytes_memory_allocated += projection_part->getIndexSizeInAllocatedBytes();
+                            total_index_granularity_bytes_in_memory += projection_part->getIndexGranularityBytes();
+                            total_index_granularity_bytes_in_memory_allocated += projection_part->getIndexGranularityAllocatedBytes();
+                        }
                     }
                 }
 
@@ -438,10 +446,10 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
         new_values["TotalRowsOfMergeTreeTablesSystem"] = { total_number_of_rows_system, "Total amount of rows (records) stored in tables of MergeTree family in the system database." };
         new_values["TotalPartsOfMergeTreeTablesSystem"] = { total_number_of_parts_system, "Total amount of data parts in tables of MergeTree family in the system database." };
 
-        new_values["TotalPrimaryKeyBytesInMemory"] = { total_primary_key_bytes_memory, "The total amount of memory (in bytes) used by primary key values (only takes active parts into account)." };
-        new_values["TotalPrimaryKeyBytesInMemoryAllocated"] = { total_primary_key_bytes_memory_allocated, "The total amount of memory (in bytes) reserved for primary key values (only takes active parts into account)." };
-        new_values["TotalIndexGranularityBytesInMemory"] = { total_index_granularity_bytes_in_memory, "The total amount of memory (in bytes) used by index granulas (only takes active parts into account)." };
-        new_values["TotalIndexGranularityBytesInMemoryAllocated"] = { total_index_granularity_bytes_in_memory_allocated, "The total amount of memory (in bytes) reserved for index granulas (only takes active parts into account)." };
+        new_values["TotalPrimaryKeyBytesInMemory"] = { total_primary_key_bytes_memory, "The total amount of memory (in bytes) used by primary key values (only takes active parts and projection parts into account)." };
+        new_values["TotalPrimaryKeyBytesInMemoryAllocated"] = { total_primary_key_bytes_memory_allocated, "The total amount of memory (in bytes) reserved for primary key values (only takes active parts and projection parts into account)." };
+        new_values["TotalIndexGranularityBytesInMemory"] = { total_index_granularity_bytes_in_memory, "The total amount of memory (in bytes) used by index granulas (only takes active parts and projection parts into account)." };
+        new_values["TotalIndexGranularityBytesInMemoryAllocated"] = { total_index_granularity_bytes_in_memory_allocated, "The total amount of memory (in bytes) reserved for index granulas (only takes active parts and projection parts into account)." };
     }
 
     {

--- a/tests/integration/test_asynchronous_metrics_pk_bytes_fields/test.py
+++ b/tests/integration/test_asynchronous_metrics_pk_bytes_fields/test.py
@@ -132,3 +132,72 @@ def test_total_pk_bytes_in_memory_fields(started_cluster):
 
     # finally drop the table
     node.query("DROP table test_pk_bytes;")
+
+
+def test_total_pk_bytes_in_memory_includes_projection_parts(started_cluster):
+    node.query("""
+        CREATE TABLE test_pk_bytes_proj
+        (
+           a UInt64,
+           b UInt64,
+           PROJECTION proj_b (SELECT * ORDER BY b)
+        )
+        Engine=MergeTree()
+        ORDER BY a SETTINGS index_granularity=1
+    """)
+
+    query_pk_bytes = "SELECT value FROM system.asynchronous_metrics WHERE metric = 'TotalPrimaryKeyBytesInMemory';"
+    query_pk_bytes_allocated = "SELECT value FROM system.asynchronous_metrics WHERE metric = 'TotalPrimaryKeyBytesInMemoryAllocated';"
+
+    pk_bytes_before = int(node.query(query_pk_bytes).strip())
+    pk_bytes_allocated_before = int(node.query(query_pk_bytes_allocated).strip())
+
+    node.query("INSERT INTO test_pk_bytes_proj SELECT number, number * 2 FROM numbers(1000000)")
+    node.query("SELECT * FROM test_pk_bytes_proj WHERE a > 1000000")
+
+    def res_pk_bytes():
+        return int(node.query(query_pk_bytes).strip())
+
+    def res_pk_bytes_allocated():
+        return int(node.query(query_pk_bytes_allocated).strip())
+
+    # metrics must increase after insert — projection parts contribute their own index memory
+    pk_bytes_before, pk_bytes_after = query_until_condition(
+        pk_bytes_before, res_pk_bytes, condition=greater
+    )
+    assert pk_bytes_after > pk_bytes_before
+
+    pk_bytes_allocated_before, pk_bytes_allocated_after = query_until_condition(
+        pk_bytes_allocated_before, res_pk_bytes_allocated, condition=greater
+    )
+    assert pk_bytes_allocated_after > pk_bytes_allocated_before
+
+    # create a table with the same schema but no projection, insert same data,
+    # and verify the metric is smaller (projection parts add index memory on top)
+    node.query("""
+        CREATE TABLE test_pk_bytes_no_proj
+        (
+           a UInt64,
+           b UInt64
+        )
+        Engine=MergeTree()
+        ORDER BY a SETTINGS index_granularity=1
+    """)
+    node.query("INSERT INTO test_pk_bytes_no_proj SELECT number, number * 2 FROM numbers(1000000)")
+    node.query("SELECT * FROM test_pk_bytes_no_proj WHERE a > 1000000")
+
+    # capture metric with both tables present; it must be strictly greater than
+    # what the no-projection table alone would contribute
+    pk_bytes_with_proj = int(node.query(query_pk_bytes).strip())
+
+    node.query("DROP TABLE test_pk_bytes_proj")
+
+    def res_pk_bytes_no_proj():
+        return int(node.query(query_pk_bytes).strip())
+
+    _, pk_bytes_no_proj = query_until_condition(
+        pk_bytes_with_proj, res_pk_bytes_no_proj, condition=lesser
+    )
+    assert pk_bytes_with_proj > pk_bytes_no_proj
+
+    node.query("DROP TABLE test_pk_bytes_no_proj")


### PR DESCRIPTION
See: https://github.com/ClickHouse/ClickHouse/pull/57551#issuecomment-4199265039

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Include projection parts in total primary key size allocated asynchronous metrics.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
