### PR TITLE
Reintroduce ArrowMemoryPool to allow throwing MEMORY_LIMIT_EXCEEDED to avoid kernel OOM

### DIFF
--- a/src/Processors/Formats/Impl/ArrowBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ArrowBlockInputFormat.cpp
@@ -166,7 +166,7 @@ static std::shared_ptr<arrow::RecordBatchReader> createStreamReader(ReadBuffer &
     }
 
     auto options = arrow::ipc::IpcReadOptions::Defaults();
-    options.memory_pool = arrow::default_memory_pool();
+    options.memory_pool = ArrowMemoryPool::instance();
     auto stream_reader_status = arrow::ipc::RecordBatchStreamReader::Open(std::make_unique<ArrowInputStreamFromReadBuffer>(in), options);
     if (!stream_reader_status.ok())
         throw Exception(ErrorCodes::UNKNOWN_EXCEPTION,
@@ -181,7 +181,7 @@ static std::shared_ptr<arrow::ipc::RecordBatchFileReader> createFileReader(ReadB
         return nullptr;
 
     auto options = arrow::ipc::IpcReadOptions::Defaults();
-    options.memory_pool = arrow::default_memory_pool();
+    options.memory_pool = ArrowMemoryPool::instance();
     auto file_reader_status = arrow::ipc::RecordBatchFileReader::Open(arrow_file, options);
     if (!file_reader_status.ok())
         throw Exception(ErrorCodes::UNKNOWN_EXCEPTION,

--- a/src/Processors/Formats/Impl/ArrowBufferedStreams.cpp
+++ b/src/Processors/Formats/Impl/ArrowBufferedStreams.cpp
@@ -12,6 +12,7 @@
 #include <arrow/io/memory.h>
 #include <arrow/result.h>
 #include <arrow/memory_pool_internal.h>
+#include <Common/Allocator.h>
 #include <Core/Settings.h>
 
 
@@ -98,7 +99,7 @@ arrow::Result<int64_t> RandomAccessFileFromSeekableReadBuffer::Read(int64_t nbyt
 
 arrow::Result<std::shared_ptr<arrow::Buffer>> RandomAccessFileFromSeekableReadBuffer::Read(int64_t nbytes)
 {
-    ARROW_ASSIGN_OR_RAISE(auto buffer, arrow::AllocateResizableBuffer(nbytes, arrow::default_memory_pool()))
+    ARROW_ASSIGN_OR_RAISE(auto buffer, arrow::AllocateResizableBuffer(nbytes, ArrowMemoryPool::instance()))
     ARROW_ASSIGN_OR_RAISE(int64_t bytes_read, Read(nbytes, buffer->mutable_data()))
 
     if (bytes_read < nbytes)
@@ -155,7 +156,7 @@ arrow::Result<int64_t> ArrowInputStreamFromReadBuffer::Read(int64_t nbytes, void
 
 arrow::Result<std::shared_ptr<arrow::Buffer>> ArrowInputStreamFromReadBuffer::Read(int64_t nbytes)
 {
-    ARROW_ASSIGN_OR_RAISE(auto buffer, arrow::AllocateResizableBuffer(nbytes, arrow::default_memory_pool()))
+    ARROW_ASSIGN_OR_RAISE(auto buffer, arrow::AllocateResizableBuffer(nbytes, ArrowMemoryPool::instance()))
     ARROW_ASSIGN_OR_RAISE(int64_t bytes_read, Read(nbytes, buffer->mutable_data()))
 
     if (bytes_read < nbytes)
@@ -208,7 +209,7 @@ arrow::Result<int64_t> RandomAccessFileFromRandomAccessReadBuffer::ReadAt(int64_
 
 arrow::Result<std::shared_ptr<arrow::Buffer>> RandomAccessFileFromRandomAccessReadBuffer::ReadAt(int64_t position, int64_t nbytes)
 {
-    ARROW_ASSIGN_OR_RAISE(auto buffer, arrow::AllocateResizableBuffer(nbytes, arrow::default_memory_pool()))
+    ARROW_ASSIGN_OR_RAISE(auto buffer, arrow::AllocateResizableBuffer(nbytes, ArrowMemoryPool::instance()))
     ARROW_ASSIGN_OR_RAISE(int64_t bytes_read, ReadAt(position, nbytes, buffer->mutable_data()))
 
     if (bytes_read < nbytes)
@@ -247,6 +248,75 @@ arrow::Status RandomAccessFileFromRandomAccessReadBuffer::Seek(int64_t) { return
 arrow::Result<int64_t> RandomAccessFileFromRandomAccessReadBuffer::Tell() const { return arrow::Status::NotImplemented(""); }
 arrow::Result<int64_t> RandomAccessFileFromRandomAccessReadBuffer::Read(int64_t, void*) { return arrow::Status::NotImplemented(""); }
 arrow::Result<std::shared_ptr<arrow::Buffer>> RandomAccessFileFromRandomAccessReadBuffer::Read(int64_t) { return arrow::Status::NotImplemented(""); }
+
+ArrowMemoryPool * ArrowMemoryPool::instance()
+{
+    static ArrowMemoryPool x;
+    return &x;
+}
+
+arrow::Status ArrowMemoryPool::Allocate(int64_t size, int64_t alignment, uint8_t ** out)
+{
+    if (size == 0)
+    {
+        *out = arrow::memory_pool::internal::kZeroSizeArea;
+        return arrow::Status::OK();
+    }
+
+    try
+    {
+        void * p = Allocator<false>().alloc(size_t(size), size_t(alignment));
+        *out = reinterpret_cast<uint8_t *>(p);
+    }
+    catch (...)
+    {
+        return arrow::Status::OutOfMemory("allocation of size ", size, " failed: ", getCurrentExceptionMessage(false));
+    }
+
+    stats.DidAllocateBytes(size);
+    return arrow::Status::OK();
+}
+
+arrow::Status ArrowMemoryPool::Reallocate(int64_t old_size, int64_t new_size, int64_t alignment, uint8_t ** ptr)
+{
+    if (old_size == 0)
+    {
+        chassert(*ptr == arrow::memory_pool::internal::kZeroSizeArea);
+        return Allocate(new_size, alignment, ptr);
+    }
+    if (new_size == 0)
+    {
+        Free(*ptr, old_size, alignment);
+        *ptr = arrow::memory_pool::internal::kZeroSizeArea;
+        return arrow::Status::OK();
+    }
+
+    try
+    {
+        void * p = Allocator<false>().realloc(*ptr, size_t(old_size), size_t(new_size), size_t(alignment));
+        *ptr = reinterpret_cast<uint8_t *>(p);
+    }
+    catch (...)
+    {
+        return arrow::Status::OutOfMemory("reallocation of size ", new_size, " failed: ", getCurrentExceptionMessage(false));
+    }
+
+    stats.DidReallocateBytes(old_size, new_size);
+    return arrow::Status::OK();
+}
+
+void ArrowMemoryPool::Free(uint8_t * buffer, int64_t size, int64_t alignment)
+{
+    if (size == 0)
+    {
+        chassert(buffer == arrow::memory_pool::internal::kZeroSizeArea);
+        return;
+    }
+
+    Allocator<false>().free(buffer, size_t(size), alignment);
+    stats.DidFreeBytes(size);
+}
+
 
 std::shared_ptr<arrow::io::RandomAccessFile> asArrowFile(
     ReadBuffer & in,

--- a/src/Processors/Formats/Impl/ArrowBufferedStreams.h
+++ b/src/Processors/Formats/Impl/ArrowBufferedStreams.h
@@ -131,6 +131,34 @@ private:
     ARROW_DISALLOW_COPY_AND_ASSIGN(ArrowInputStreamFromReadBuffer);
 };
 
+/// By default, arrow allocates memory using posix_memalign(). Our posix_memalign
+/// interceptor tracks memory, but cannot throw on `MEMORY_LIMIT_EXCEEDED` (throwing
+/// from `malloc`/`posix_memalign` is not allowed because callers, including inside
+/// arrow/parquet, do not expect it). This adapter routes arrow/parquet allocations
+/// through ClickHouse's `Allocator<false>`, which *can* throw
+/// `MEMORY_LIMIT_EXCEEDED`; we catch it and convert to `arrow::Status::OutOfMemory`
+/// so arrow unwinds via its normal error path.
+class ArrowMemoryPool : public arrow::MemoryPool
+{
+public:
+    static ArrowMemoryPool * instance();
+
+    arrow::Status Allocate(int64_t size, int64_t alignment, uint8_t ** out) override;
+    arrow::Status Reallocate(int64_t old_size, int64_t new_size, int64_t alignment, uint8_t ** ptr) override;
+    void Free(uint8_t * buffer, int64_t size, int64_t alignment) override;
+
+    std::string backend_name() const override { return "clickhouse"; }
+
+    int64_t bytes_allocated() const override { return stats.bytes_allocated(); }
+    int64_t total_bytes_allocated() const override { return stats.total_bytes_allocated(); }
+    int64_t num_allocations() const override { return stats.num_allocations(); }
+
+private:
+    ArrowMemoryPool() = default;
+
+    arrow::internal::MemoryPoolStats stats;
+};
+
 std::shared_ptr<arrow::io::RandomAccessFile> asArrowFile(
     ReadBuffer & in,
     const FormatSettings & settings,

--- a/src/Processors/Formats/Impl/ArrowColumnToCHColumn.cpp
+++ b/src/Processors/Formats/Impl/ArrowColumnToCHColumn.cpp
@@ -1804,7 +1804,7 @@ static std::shared_ptr<arrow::ChunkedArray> createArrowColumn(const std::shared_
     std::shared_ptr<arrow::DataType> build_type = unwrapArrowExtensionTypesRecursively(field->type());
 
     std::unique_ptr<arrow::ArrayBuilder> array_builder;
-    arrow::Status status = MakeBuilder(arrow::default_memory_pool(), build_type, &array_builder);
+    arrow::Status status = MakeBuilder(ArrowMemoryPool::instance(), build_type, &array_builder);
     checkStatus(status, field->name(), format_name);
 
     std::shared_ptr<arrow::Array> arrow_array;

--- a/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
+++ b/src/Processors/Formats/Impl/CHColumnToArrowColumn.cpp
@@ -462,7 +462,7 @@ namespace DB
                 &is_column_nullable);
 
             std::unique_ptr<arrow::ArrayBuilder> variant_array_builder;
-            status = MakeBuilder(arrow::default_memory_pool(), arrow_type, &variant_array_builder);
+            status = MakeBuilder(ArrowMemoryPool::instance(), arrow_type, &variant_array_builder);
             checkStatus(status, variant->getName(), format_name);
 
             if (ends[i] == 0)
@@ -747,7 +747,7 @@ namespace DB
         checkStatus(status, column_name, format_name);
 
         auto null_bitmap = nullBytemapToArrowBitmap(null_bytemap, column_name, format_name, start, end);
-        return checkResult(arrow::ListArray::FromArrays(*offsets_array, *data_array, arrow::default_memory_pool(), null_bitmap), column_name, format_name);
+        return checkResult(arrow::ListArray::FromArrays(*offsets_array, *data_array, ArrowMemoryPool::instance(), null_bitmap), column_name, format_name);
     }
 
     static std::shared_ptr<arrow::Array> buildArrowMapArrayWithMapColumnData(
@@ -822,7 +822,7 @@ namespace DB
         /// Convert dictionary values to arrow array.
         auto value_type = assert_cast<arrow::DictionaryType *>(builder->type().get())->value_type();
         std::unique_ptr<arrow::ArrayBuilder> values_builder;
-        arrow::Status status = MakeBuilder(arrow::default_memory_pool(), value_type, &values_builder);
+        arrow::Status status = MakeBuilder(ArrowMemoryPool::instance(), value_type, &values_builder);
         checkStatus(status, column->getName(), format_name);
 
         auto dict_column = dynamic_cast<IColumnUnique &>(*dict_values).getNestedNotNullableColumn();
@@ -1701,7 +1701,7 @@ namespace DB
                     column_type, column, header_column.name, format_name, settings, &is_column_nullable, true /* for_builder */);
 
                 std::unique_ptr<arrow::ArrayBuilder> array_builder;
-                arrow::Status status = MakeBuilder(arrow::default_memory_pool(), builder_type, &array_builder);
+                arrow::Status status = MakeBuilder(ArrowMemoryPool::instance(), builder_type, &array_builder);
                 checkStatus(status, column->getName(), format_name);
 
                 std::shared_ptr<arrow::Array> arrow_array = fillArrowArray(

--- a/src/Processors/Formats/Impl/ORCBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ORCBlockInputFormat.cpp
@@ -114,7 +114,7 @@ static void getFileReaderAndSchema(
     if (is_stopped)
         return;
 
-    auto result = arrow::adapters::orc::ORCFileReader::Open(arrow_file, arrow::default_memory_pool());
+    auto result = arrow::adapters::orc::ORCFileReader::Open(arrow_file, ArrowMemoryPool::instance());
     if (!result.ok())
         throw Exception::createDeprecated(result.status().ToString(), ErrorCodes::BAD_ARGUMENTS);
     file_reader = std::move(result).ValueOrDie();

--- a/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockInputFormat.cpp
@@ -883,7 +883,7 @@ void ParquetBlockInputFormat::initializeRowGroupBatchReader(size_t row_group_bat
     auto & row_group_batch = row_group_batches[row_group_batch_idx];
 
     parquet::ArrowReaderProperties arrow_properties;
-    parquet::ReaderProperties reader_properties(arrow::default_memory_pool());
+    parquet::ReaderProperties reader_properties(ArrowMemoryPool::instance());
     arrow_properties.set_use_threads(false);
     arrow_properties.set_batch_size(row_group_batch.adaptive_chunk_size);
     reader_properties.set_page_checksum_verification(format_settings.parquet.verify_checksums);
@@ -940,7 +940,7 @@ void ParquetBlockInputFormat::initializeRowGroupBatchReader(size_t row_group_bat
     parquet::arrow::FileReaderBuilder builder;
     THROW_ARROW_NOT_OK(builder.Open(arrow_file, reader_properties, metadata));
     builder.properties(arrow_properties);
-    builder.memory_pool(arrow::default_memory_pool());
+    builder.memory_pool(ArrowMemoryPool::instance());
     // should get raw reader before build, raw_reader will set null after build
     auto * parquet_file_reader = builder.raw_reader();
     THROW_ARROW_NOT_OK(builder.Build(&row_group_batch.file_reader));

--- a/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParquetBlockOutputFormat.cpp
@@ -379,7 +379,7 @@ void ParquetBlockOutputFormat::writeUsingArrow(std::vector<Chunk> chunks)
 
         auto result = parquet::arrow::FileWriter::Open(
             *arrow_table->schema(),
-            arrow::default_memory_pool(),
+            ArrowMemoryPool::instance(),
             sink,
             builder.build(),
             writer_props_builder.build());

--- a/src/Storages/Hive/HiveFile.cpp
+++ b/src/Storages/Hive/HiveFile.cpp
@@ -166,7 +166,7 @@ void HiveORCFile::prepareReader()
     in = std::make_unique<ReadBufferFromHDFS>(namenode_url, path, getContext()->getGlobalContext()->getConfigRef(), getContext()->getReadSettings());
     auto format_settings = getFormatSettings(getContext());
     std::atomic<int> is_stopped{0};
-    auto result = arrow::adapters::orc::ORCFileReader::Open(asArrowFile(*in, format_settings, is_stopped, "ORC", ORC_MAGIC_BYTES), arrow::default_memory_pool());
+    auto result = arrow::adapters::orc::ORCFileReader::Open(asArrowFile(*in, format_settings, is_stopped, "ORC", ORC_MAGIC_BYTES), ArrowMemoryPool::instance());
     THROW_ARROW_NOT_OK(result.status());
     reader = std::move(result).ValueOrDie();
 }
@@ -285,7 +285,7 @@ void HiveParquetFile::prepareReader()
     in = std::make_unique<ReadBufferFromHDFS>(namenode_url, path, getContext()->getGlobalContext()->getConfigRef(), getContext()->getReadSettings());
     auto format_settings = getFormatSettings(getContext());
     std::atomic<int> is_stopped{0};
-    auto open_file_res = parquet::arrow::OpenFile(asArrowFile(*in, format_settings, is_stopped, "Parquet", PARQUET_MAGIC_BYTES), arrow::default_memory_pool());
+    auto open_file_res = parquet::arrow::OpenFile(asArrowFile(*in, format_settings, is_stopped, "Parquet", PARQUET_MAGIC_BYTES), ArrowMemoryPool::instance());
     THROW_ARROW_NOT_OK(open_file_res.status());
     reader = *std::move(open_file_res);
 }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadata.cpp
@@ -503,7 +503,7 @@ struct DeltaLakeMetadataImpl
         std::atomic<int> is_stopped{0};
 
         auto open_file_res = parquet::arrow::OpenFile(
-            asArrowFile(*buf, format_settings, is_stopped, "Parquet", PARQUET_MAGIC_BYTES), arrow::default_memory_pool());
+            asArrowFile(*buf, format_settings, is_stopped, "Parquet", PARQUET_MAGIC_BYTES), ArrowMemoryPool::instance());
         THROW_ARROW_NOT_OK(open_file_res.status());
         auto reader = *std::move(open_file_res);
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reintroduce ArrowMemoryPool to allow throwing MEMORY_LIMIT_EXCEEDED to avoid kernel OOM

PR #88035 removed the custom `ArrowMemoryPool` and switched arrow/parquet/ORC allocations to `arrow::default_memory_pool()`, relying on the `posix_memalign` interceptor for memory tracking. However, the interceptor cannot throw `MEMORY_LIMIT_EXCEEDED`, because throwing from `malloc`/`posix_memalign` is not allowed (arrow and its dependencies do not expect exceptions from allocation).

Reintroduce `ArrowMemoryPool` routing allocations through `Allocator<false>`, which *can* throw `MEMORY_LIMIT_EXCEEDED`. The exception is caught and converted into `arrow::Status::OutOfMemory`, so arrow unwinds via its normal error path and the original message is preserved for diagnostics.

All call sites that PR #88035 moved to `arrow::default_memory_pool()` are switched back to `ArrowMemoryPool::instance()`. The `NativeORC` pool is not restored because `orc::MemoryPool::malloc` has no status channel.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1075`
- Backported to: `26.3.10.25`, `26.2.17.17`, `26.1.12.12`
<!-- ch-version-info:end -->