### PR TITLE
Refactor workflow report messages into structured notification panels

### DIFF
--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -208,7 +208,7 @@ def main():
             print(
                 "WARNING: ClickHouse version has not been found in workflow kv storage - read from repo"
             )
-            info.add_warning(
+            info.add_workflow_warning(
                 "ClickHouse version has not been found in workflow kv storage"
             )
     assert version_dict

--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -208,8 +208,8 @@ def main():
             print(
                 "WARNING: ClickHouse version has not been found in workflow kv storage - read from repo"
             )
-            info.add_workflow_report_message(
-                "WARNING: ClickHouse version has not been found in workflow kv storage"
+            info.add_warning(
+                "ClickHouse version has not been found in workflow kv storage"
             )
     assert version_dict
 

--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -360,8 +360,8 @@ def main():
             print(
                 "WARNING: ClickHouse version has not been found in workflow kv storage - read from repo"
             )
-            info.add_workflow_report_message(
-                "WARNING: ClickHouse version has not been found in workflow kv storage"
+            info.add_warning(
+                "ClickHouse version has not been found in workflow kv storage"
             )
     assert version_dict
 

--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -360,7 +360,7 @@ def main():
             print(
                 "WARNING: ClickHouse version has not been found in workflow kv storage - read from repo"
             )
-            info.add_warning(
+            info.add_workflow_warning(
                 "ClickHouse version has not been found in workflow kv storage"
             )
     assert version_dict

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -511,10 +511,10 @@ def main():
 
                 if not Info().is_local_run:
                     if not CH.start_log_exports(stop_watch.start_time):
-                        info.add_warning("Failed to start log export")
+                        info.add_workflow_warning("Failed to start log export")
                         print("Failed to start log export")
                 if not CH.create_minio_log_tables():
-                    info.add_warning("Failed to create minio log tables")
+                    info.add_workflow_warning("Failed to create minio log tables")
                     print("Failed to create minio log tables")
 
                 if has_stateful_tests:

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -511,14 +511,10 @@ def main():
 
                 if not Info().is_local_run:
                     if not CH.start_log_exports(stop_watch.start_time):
-                        info.add_workflow_report_message(
-                            "WARNING: Failed to start log export"
-                        )
+                        info.add_warning("Failed to start log export")
                         print("Failed to start log export")
                 if not CH.create_minio_log_tables():
-                    info.add_workflow_report_message(
-                        "WARNING: Failed to create minio log tables"
-                    )
+                    info.add_warning("Failed to create minio log tables")
                     print("Failed to create minio log tables")
 
                 if has_stateful_tests:

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -899,7 +899,7 @@ clickhouse-client --query "SELECT count() FROM test.visits"
         except Exception as e:
             print(f"WARNING: Failed to collect logs: {e}")
             traceback.print_exc()
-            info.add_warning(
+            info.add_workflow_warning(
                 f"Failed to collect all logs, ex [{e}], see job.log"
             )
         return res

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -899,8 +899,8 @@ clickhouse-client --query "SELECT count() FROM test.visits"
         except Exception as e:
             print(f"WARNING: Failed to collect logs: {e}")
             traceback.print_exc()
-            info.add_workflow_report_message(
-                f"Failed to collect all logs in job [{info.job_name}], ex [{e}], see job.log"
+            info.add_warning(
+                f"Failed to collect all logs, ex [{e}], see job.log"
             )
         return res
 

--- a/ci/jobs/scripts/workflow_hooks/check_report_messages.py
+++ b/ci/jobs/scripts/workflow_hooks/check_report_messages.py
@@ -1,0 +1,30 @@
+import sys
+
+from ci.praktika.info import Info
+from ci.praktika.result import Result
+
+
+def check():
+    info = Info()
+    workflow_result = Result.from_fs(info.workflow_name)
+    ext = workflow_result.ext
+
+    errors = ext.get("errors", [])
+    warnings = ext.get("warnings", [])
+
+    ok = True
+    for item in errors:
+        jobs = ", ".join(item.get("jobs", []))
+        print(f"ERROR: {item['message']} ({jobs})")
+        ok = False
+    for item in warnings:
+        jobs = ", ".join(item.get("jobs", []))
+        print(f"WARNING: {item['message']} ({jobs})")
+        ok = False
+
+    return ok
+
+
+if __name__ == "__main__":
+    if not check():
+        sys.exit(1)

--- a/ci/jobs/scripts/workflow_hooks/check_report_messages.py
+++ b/ci/jobs/scripts/workflow_hooks/check_report_messages.py
@@ -14,12 +14,10 @@ def check():
 
     ok = True
     for item in errors:
-        jobs = ", ".join(item.get("jobs", []))
-        print(f"ERROR: {item['message']} ({jobs})")
+        print(f"ERROR: {item.get('message', '')} (from: {item.get('from', '')})")
         ok = False
     for item in warnings:
-        jobs = ", ".join(item.get("jobs", []))
-        print(f"WARNING: {item['message']} ({jobs})")
+        print(f"WARNING: {item.get('message', '')} (from: {item.get('from', '')})")
         ok = False
 
     return ok

--- a/ci/jobs/scripts/workflow_hooks/check_report_messages.py
+++ b/ci/jobs/scripts/workflow_hooks/check_report_messages.py
@@ -1,3 +1,15 @@
+"""
+Workflow hook that blocks merge whenever any job has posted an error or
+warning to the workflow-level report (``Result.ext["errors"]`` /
+``Result.ext["warnings"]`` on the top-level workflow result).
+
+Warnings are treated as blocking on purpose: if a job decides to surface a
+warning on the workflow page, it is something a human should acknowledge
+before the PR is merged.  After the issue is reviewed (and, if appropriate,
+fixed in a follow-up), the merge can proceed by re-running CI once the
+warning is no longer produced.
+"""
+
 import sys
 
 from ci.praktika.info import Info

--- a/ci/praktika/_environment.py
+++ b/ci/praktika/_environment.py
@@ -39,7 +39,6 @@ class _Environment(MetaClasses.Serializable):
     LINKED_PR_NUMBER: int = 0
     LOCAL_RUN: bool = False
     PR_LABELS: List[str] = dataclasses.field(default_factory=list)
-    REPORT_INFO: List[str] = dataclasses.field(default_factory=list)
     REPORT_MESSAGES: List[Dict[str, str]] = dataclasses.field(default_factory=list)
     JOB_CONFIG: Optional[Job.Config] = None
     TRACEBACKS: List[str] = dataclasses.field(default_factory=list)
@@ -227,7 +226,7 @@ class _Environment(MetaClasses.Serializable):
             COMMIT_MESSAGE=COMMIT_MESSAGE,
             PR_LABELS=PR_LABELS,
             INSTANCE_LIFE_CYCLE=INSTANCE_LIFE_CYCLE,
-            REPORT_INFO=[],
+            REPORT_MESSAGES=[],
             LINKED_PR_NUMBER=LINKED_PR_NUMBER,
             # TODO: Find a better way to store and pass commit authors data through workflow
             JOB_KV_DATA={
@@ -292,10 +291,6 @@ class _Environment(MetaClasses.Serializable):
         env_dict["WORKFLOW_JOB_DATA"] = cls._load_workflow_job_data()
 
         return cls.from_dict(env_dict)
-
-    def add_info(self, info):
-        self.REPORT_INFO.append(info)
-        self.dump()
 
     def add_report_message(self, message, kind, job_name=""):
         self.REPORT_MESSAGES.append(

--- a/ci/praktika/_environment.py
+++ b/ci/praktika/_environment.py
@@ -292,11 +292,29 @@ class _Environment(MetaClasses.Serializable):
 
         return cls.from_dict(env_dict)
 
-    def add_report_message(self, message, kind, job_name=""):
+    def _add_report_message(self, message, kind, source=""):
+        """
+        Accumulate a structured report message in the environment.
+
+        Messages are collected during job execution and later written to both
+        the job and workflow ``Result.ext`` as ``{"message": str, "from": str}``
+        entries.  Grouping of duplicate messages is done at the rendering level
+        in ``json.html``.
+        Prefer the typed wrappers ``add_workflow_warning/error/note``.
+        """
         self.REPORT_MESSAGES.append(
-            {"message": message, "kind": kind, "job": job_name or self.JOB_NAME}
+            {"message": message, "kind": kind, "from": source or self.JOB_NAME}
         )
         self.dump()
+
+    def add_workflow_warning(self, message, source=""):
+        self._add_report_message(message, kind="warning", source=source)
+
+    def add_workflow_error(self, message, source=""):
+        self._add_report_message(message, kind="error", source=source)
+
+    def add_workflow_note(self, message, source=""):
+        self._add_report_message(message, kind="note", source=source)
 
     @classmethod
     def get(cls):

--- a/ci/praktika/_environment.py
+++ b/ci/praktika/_environment.py
@@ -40,6 +40,7 @@ class _Environment(MetaClasses.Serializable):
     LOCAL_RUN: bool = False
     PR_LABELS: List[str] = dataclasses.field(default_factory=list)
     REPORT_INFO: List[str] = dataclasses.field(default_factory=list)
+    REPORT_MESSAGES: List[Dict[str, str]] = dataclasses.field(default_factory=list)
     JOB_CONFIG: Optional[Job.Config] = None
     TRACEBACKS: List[str] = dataclasses.field(default_factory=list)
     WORKFLOW_JOB_DATA: Dict[str, Any] = dataclasses.field(default_factory=dict)
@@ -294,6 +295,12 @@ class _Environment(MetaClasses.Serializable):
 
     def add_info(self, info):
         self.REPORT_INFO.append(info)
+        self.dump()
+
+    def add_report_message(self, message, kind, job_name=""):
+        self.REPORT_MESSAGES.append(
+            {"message": message, "kind": kind, "job": job_name or self.JOB_NAME}
+        )
         self.dump()
 
     @classmethod

--- a/ci/praktika/hook_html.py
+++ b/ci/praktika/hook_html.py
@@ -270,16 +270,16 @@ class HtmlRunnerHooks:
                 print(
                     f"NOTE: Set job [{dependee}] status to [{Result.Status.DROPPED}] due to current failure"
                 )
-                new_sub_results.append(
-                    Result(
-                        name=dependee,
-                        status=Result.Status.DROPPED,
-                        info=ResultInfo.DROPPED_DUE_TO_PREVIOUS_FAILURE
-                        + f" [{_job.name}]",
-                        start_time=Utils.timestamp(),
-                        duration=0,
-                    )
+                dropped_result = Result(
+                    name=dependee,
+                    status=Result.Status.DROPPED,
+                    start_time=Utils.timestamp(),
+                    duration=0,
                 )
+                dropped_result.add_note(
+                    ResultInfo.DROPPED_DUE_TO_PREVIOUS_FAILURE + f" [{_job.name}]"
+                )
+                new_sub_results.append(dropped_result)
 
         updated_status = _ResultS3.update_workflow_results(
             new_sub_results=new_sub_results,

--- a/ci/praktika/hook_html.py
+++ b/ci/praktika/hook_html.py
@@ -237,8 +237,10 @@ class HtmlRunnerHooks:
             storage_usage = StorageUsage.from_fs()
             result.ext["storage_usage"] = storage_usage
         report_messages = env.REPORT_MESSAGES or []
-        if report_messages:
-            _ResultS3._merge_report_messages(result.ext, report_messages)
+        kind_to_key = {"warning": "warnings", "error": "errors", "note": "notes"}
+        for msg in report_messages:
+            key = kind_to_key.get(msg.get("kind"), "notes")
+            result.ext.setdefault(key, []).append(msg["message"])
         _ResultS3.copy_result_to_s3(result)
 
         new_sub_results = [result]

--- a/ci/praktika/hook_html.py
+++ b/ci/praktika/hook_html.py
@@ -219,7 +219,7 @@ class HtmlRunnerHooks:
         pass
 
     @classmethod
-    def post_run(cls, _workflow, _job, info_errors):
+    def post_run(cls, _workflow, _job):
         result = Result.from_fs(_job.name)
         env = _Environment.get()
         if env.WORKFLOW_JOB_DATA:
@@ -242,19 +242,6 @@ class HtmlRunnerHooks:
         _ResultS3.copy_result_to_s3(result)
 
         new_sub_results = [result]
-        new_result_info = ""
-        env_info = env.REPORT_INFO
-        if env_info:
-            print(
-                f"WARNING: some info lines are set in Environment - append to report [{env_info}]"
-            )
-            info_errors += env_info
-        if info_errors:
-            info_errors = [f"    |  {error}" for error in info_errors]
-            info_str = f"{_job.name}:\n"
-            info_str += "\n".join(info_errors)
-            print("Update workflow results with new info")
-            new_result_info = info_str
 
         if not result.is_ok() and not result.do_not_block_pipeline_on_failure():
             print(
@@ -293,7 +280,6 @@ class HtmlRunnerHooks:
                 )
 
         updated_status = _ResultS3.update_workflow_results(
-            new_info=new_result_info,
             new_sub_results=new_sub_results,
             workflow_name=_workflow.name,
             storage_usage=storage_usage,

--- a/ci/praktika/hook_html.py
+++ b/ci/praktika/hook_html.py
@@ -210,8 +210,12 @@ class HtmlRunnerHooks:
     @classmethod
     def pre_run(cls, _workflow, _job):
         result = Result.from_fs(_job.name)
+        # Clear stale workflow-level report messages from this job's previous
+        # run so that resolved warnings/errors don't persist after a rerun.
         _ResultS3.update_workflow_results(
-            workflow_name=_workflow.name, new_sub_results=result
+            workflow_name=_workflow.name,
+            new_sub_results=result,
+            clear_report_sources=[_job.name],
         )
 
     @classmethod

--- a/ci/praktika/hook_html.py
+++ b/ci/praktika/hook_html.py
@@ -240,7 +240,9 @@ class HtmlRunnerHooks:
         kind_to_key = {"warning": "warnings", "error": "errors", "note": "notes"}
         for msg in report_messages:
             key = kind_to_key.get(msg.get("kind"), "notes")
-            result.ext.setdefault(key, []).append(msg["message"])
+            result.ext.setdefault(key, []).append(
+                {"message": msg["message"], "from": msg["from"]}
+            )
         _ResultS3.copy_result_to_s3(result)
 
         new_sub_results = [result]

--- a/ci/praktika/hook_html.py
+++ b/ci/praktika/hook_html.py
@@ -236,6 +236,7 @@ class HtmlRunnerHooks:
             print("Storage usage data found - add to Result")
             storage_usage = StorageUsage.from_fs()
             result.ext["storage_usage"] = storage_usage
+        report_messages = env.REPORT_MESSAGES or []
         _ResultS3.copy_result_to_s3(result)
 
         new_sub_results = [result]
@@ -299,5 +300,6 @@ class HtmlRunnerHooks:
                 duration=result.duration,
                 job_name=_job.name,
             ),
+            report_messages=report_messages,
         )
         return updated_status

--- a/ci/praktika/hook_html.py
+++ b/ci/praktika/hook_html.py
@@ -236,13 +236,8 @@ class HtmlRunnerHooks:
             print("Storage usage data found - add to Result")
             storage_usage = StorageUsage.from_fs()
             result.ext["storage_usage"] = storage_usage
-        report_messages = env.REPORT_MESSAGES or []
-        kind_to_key = {"warning": "warnings", "error": "errors", "note": "notes"}
-        for msg in report_messages:
-            key = kind_to_key.get(msg.get("kind"), "notes")
-            result.ext.setdefault(key, []).append(
-                {"message": msg["message"], "from": msg["from"]}
-            )
+        report_messages = env.REPORT_MESSAGES
+        _ResultS3.append_report_messages(result, report_messages)
         _ResultS3.copy_result_to_s3(result)
 
         new_sub_results = [result]

--- a/ci/praktika/hook_html.py
+++ b/ci/praktika/hook_html.py
@@ -237,6 +237,8 @@ class HtmlRunnerHooks:
             storage_usage = StorageUsage.from_fs()
             result.ext["storage_usage"] = storage_usage
         report_messages = env.REPORT_MESSAGES or []
+        if report_messages:
+            _ResultS3._merge_report_messages(result.ext, report_messages)
         _ResultS3.copy_result_to_s3(result)
 
         new_sub_results = [result]

--- a/ci/praktika/info.py
+++ b/ci/praktika/info.py
@@ -259,10 +259,6 @@ class Info:
         self.env.TRACEBACKS.append(traceback.format_exc())
         self.env.dump()
 
-    def add_workflow_report_message(self, message):
-        self.env.add_info(message)
-        self.env.dump()
-
     def add_warning(self, message):
         self.env.add_report_message(message, kind="warning")
 

--- a/ci/praktika/info.py
+++ b/ci/praktika/info.py
@@ -264,10 +264,10 @@ class Info:
         Add a warning visible on both the job report page and the workflow
         report page.
 
-        The message is written to the current job's ``Result.ext["warnings"]``
-        (as a plain string) and propagated to the workflow ``Result.ext``
-        (grouped with job attribution).  If the same message is posted by
-        multiple jobs, the workflow page groups them into a single entry.
+        The message is stored as ``{"message": str, "from": str}`` in both the
+        current job's ``Result.ext["warnings"]`` and the workflow-level
+        ``Result.ext["warnings"]``.  If the same message is posted by multiple
+        jobs, the report page groups them into a single entry at render time.
 
         Unlike ``Result.add_warning``, which only affects the specific result
         it is called on, this method ensures the message appears at both levels.

--- a/ci/praktika/info.py
+++ b/ci/praktika/info.py
@@ -263,6 +263,15 @@ class Info:
         self.env.add_info(message)
         self.env.dump()
 
+    def add_warning(self, message):
+        self.env.add_report_message(message, kind="warning")
+
+    def add_error(self, message):
+        self.env.add_report_message(message, kind="error")
+
+    def add_note(self, message):
+        self.env.add_report_message(message, kind="note")
+
     def is_workflow_ok(self):
         """
         Experimental function

--- a/ci/praktika/info.py
+++ b/ci/praktika/info.py
@@ -259,14 +259,36 @@ class Info:
         self.env.TRACEBACKS.append(traceback.format_exc())
         self.env.dump()
 
-    def add_warning(self, message):
-        self.env.add_report_message(message, kind="warning")
+    def add_workflow_warning(self, message):
+        """
+        Add a warning visible on both the job report page and the workflow
+        report page.
 
-    def add_error(self, message):
-        self.env.add_report_message(message, kind="error")
+        The message is written to the current job's ``Result.ext["warnings"]``
+        (as a plain string) and propagated to the workflow ``Result.ext``
+        (grouped with job attribution).  If the same message is posted by
+        multiple jobs, the workflow page groups them into a single entry.
 
-    def add_note(self, message):
-        self.env.add_report_message(message, kind="note")
+        Unlike ``Result.add_warning``, which only affects the specific result
+        it is called on, this method ensures the message appears at both levels.
+        """
+        self.env.add_workflow_warning(message)
+
+    def add_workflow_error(self, message):
+        """
+        Add an error visible on both the job and workflow report pages.
+
+        See ``add_workflow_warning`` for propagation semantics.
+        """
+        self.env.add_workflow_error(message)
+
+    def add_workflow_note(self, message):
+        """
+        Add a note visible on both the job and workflow report pages.
+
+        See ``add_workflow_warning`` for propagation semantics.
+        """
+        self.env.add_workflow_note(message)
 
     def is_workflow_ok(self):
         """

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -1909,18 +1909,24 @@
             for (const item of items) {
                 const row = document.createElement('div');
                 row.className = 'notification-item';
-                row.textContent = item.message || '';
 
-                if (Array.isArray(item.jobs) && item.jobs.length > 0) {
-                    const jobsSpan = document.createElement('span');
-                    jobsSpan.className = 'notification-jobs';
-                    if (item.jobs.length === 1) {
-                        jobsSpan.textContent = `(${item.jobs[0]})`;
-                    } else {
-                        jobsSpan.textContent = `(${item.jobs.length} jobs)`;
-                        jobsSpan.title = item.jobs.join('\n');
+                if (typeof item === 'string') {
+                    // Job level: simple string list
+                    row.textContent = item;
+                } else {
+                    // Workflow level: grouped {message, jobs}
+                    row.textContent = item.message || '';
+                    if (Array.isArray(item.jobs) && item.jobs.length > 0) {
+                        const jobsSpan = document.createElement('span');
+                        jobsSpan.className = 'notification-jobs';
+                        if (item.jobs.length === 1) {
+                            jobsSpan.textContent = `(${item.jobs[0]})`;
+                        } else {
+                            jobsSpan.textContent = `(${item.jobs.length} jobs)`;
+                            jobsSpan.title = item.jobs.join('\n');
+                        }
+                        row.appendChild(jobsSpan);
                     }
-                    row.appendChild(jobsSpan);
                 }
 
                 panel.appendChild(row);

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -382,7 +382,7 @@
 
         .notification-panel {
             padding: 10px 14px;
-            margin: 8px 10px;
+            margin: 8px 0;
             border-radius: 6px;
             border-left: 4px solid;
             font-size: 13px;

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -1898,6 +1898,20 @@
             const items = ext?.[key];
             if (!Array.isArray(items) || items.length === 0) continue;
 
+            // Group entries by message text, collecting unique "from" sources
+            const grouped = new Map();
+            for (const item of items) {
+                const text = item.message || '';
+                const source = item.from || '';
+                if (!grouped.has(text)) {
+                    grouped.set(text, []);
+                }
+                const sources = grouped.get(text);
+                if (source && !sources.includes(source)) {
+                    sources.push(source);
+                }
+            }
+
             const panel = document.createElement('div');
             panel.className = `notification-panel ${cssClass}`;
 
@@ -1906,27 +1920,22 @@
             titleEl.textContent = title;
             panel.appendChild(titleEl);
 
-            for (const item of items) {
+            for (const [message, sources] of grouped) {
                 const row = document.createElement('div');
                 row.className = 'notification-item';
+                row.textContent = message;
 
-                if (typeof item === 'string') {
-                    // Job level: simple string list
-                    row.textContent = item;
-                } else {
-                    // Workflow level: grouped {message, jobs}
-                    row.textContent = item.message || '';
-                    if (Array.isArray(item.jobs) && item.jobs.length > 0) {
-                        const jobsSpan = document.createElement('span');
-                        jobsSpan.className = 'notification-jobs';
-                        if (item.jobs.length === 1) {
-                            jobsSpan.textContent = `(${item.jobs[0]})`;
-                        } else {
-                            jobsSpan.textContent = `(${item.jobs.length} jobs)`;
-                            jobsSpan.title = item.jobs.join('\n');
-                        }
-                        row.appendChild(jobsSpan);
-                    }
+                if (sources.length === 1) {
+                    const span = document.createElement('span');
+                    span.className = 'notification-jobs';
+                    span.textContent = `(${sources[0]})`;
+                    row.appendChild(span);
+                } else if (sources.length > 1) {
+                    const span = document.createElement('span');
+                    span.className = 'notification-jobs';
+                    span.textContent = `(${sources.length} jobs)`;
+                    span.title = sources.join('\n');
+                    row.appendChild(span);
                 }
 
                 panel.appendChild(row);

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -1918,6 +1918,7 @@
                         jobsSpan.textContent = `(${item.jobs[0]})`;
                     } else {
                         jobsSpan.textContent = `(${item.jobs.length} jobs)`;
+                        jobsSpan.title = item.jobs.join('\n');
                     }
                     row.appendChild(jobsSpan);
                 }

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -1888,7 +1888,7 @@
         fillInNavigationBar(nameParams.slice(0, i + 1))
     }
 
-    function renderNotificationPanels(container, ext) {
+    function renderNotificationPanels(container, ext, resultName) {
         const kinds = [
             { key: 'errors', cssClass: 'notification-errors', title: 'Errors' },
             { key: 'warnings', cssClass: 'notification-warnings', title: 'Warnings' },
@@ -1925,16 +1925,20 @@
                 row.className = 'notification-item';
                 row.textContent = message;
 
-                if (sources.length === 1) {
+                // Hide source when all sources match the current result name
+                const externalSources = sources.filter(s => s !== resultName);
+                if (externalSources.length === 0) {
+                    // all from this result — no label needed
+                } else if (externalSources.length === 1) {
                     const span = document.createElement('span');
                     span.className = 'notification-jobs';
-                    span.textContent = `(${sources[0]})`;
+                    span.textContent = `(${externalSources[0]})`;
                     row.appendChild(span);
-                } else if (sources.length > 1) {
+                } else {
                     const span = document.createElement('span');
                     span.className = 'notification-jobs';
-                    span.textContent = `(${sources.length} jobs)`;
-                    span.title = sources.join('\n');
+                    span.textContent = `(${externalSources.length} jobs)`;
+                    span.title = externalSources.join('\n');
                     row.appendChild(span);
                 }
 
@@ -1957,7 +1961,7 @@
 
         const resultsDiv = document.getElementById('result-container');
 
-        renderNotificationPanels(resultsDiv, result.ext);
+        renderNotificationPanels(resultsDiv, result.ext, result.name);
 
         if (result.info) {
             const textDiv = document.createElement('div');

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -379,6 +379,57 @@
             color: #808080;
             font-weight: 600;
         }
+
+        .notification-panel {
+            padding: 10px 14px;
+            margin: 8px 10px;
+            border-radius: 6px;
+            border-left: 4px solid;
+            font-size: 13px;
+            line-height: 1.5;
+        }
+        .notification-panel .notification-title {
+            font-weight: 600;
+            margin-bottom: 4px;
+        }
+        .notification-panel .notification-item {
+            margin: 4px 0;
+        }
+        .notification-panel .notification-jobs {
+            font-size: 11px;
+            opacity: 0.75;
+            margin-left: 4px;
+        }
+        .notification-errors {
+            background-color: #fef2f2;
+            border-left-color: #dc2626;
+            color: #991b1b;
+        }
+        .notification-warnings {
+            background-color: #fffbeb;
+            border-left-color: #d97706;
+            color: #92400e;
+        }
+        .notification-notes {
+            background-color: #eff6ff;
+            border-left-color: #2563eb;
+            color: #1e40af;
+        }
+        .night-theme .notification-errors {
+            background-color: #2a1515;
+            border-left-color: #f87171;
+            color: #fca5a5;
+        }
+        .night-theme .notification-warnings {
+            background-color: #2a2515;
+            border-left-color: #fbbf24;
+            color: #fde68a;
+        }
+        .night-theme .notification-notes {
+            background-color: #15202a;
+            border-left-color: #60a5fa;
+            color: #93c5fd;
+        }
     </style>
 </head>
 <body>
@@ -1837,6 +1888,47 @@
         fillInNavigationBar(nameParams.slice(0, i + 1))
     }
 
+    function renderNotificationPanels(container, ext) {
+        const kinds = [
+            { key: 'errors', cssClass: 'notification-errors', title: 'Errors' },
+            { key: 'warnings', cssClass: 'notification-warnings', title: 'Warnings' },
+            { key: 'notes', cssClass: 'notification-notes', title: 'Notes' },
+        ];
+        for (const { key, cssClass, title } of kinds) {
+            const items = ext?.[key];
+            if (!Array.isArray(items) || items.length === 0) continue;
+
+            const panel = document.createElement('div');
+            panel.className = `notification-panel ${cssClass}`;
+
+            const titleEl = document.createElement('div');
+            titleEl.className = 'notification-title';
+            titleEl.textContent = title;
+            panel.appendChild(titleEl);
+
+            for (const item of items) {
+                const row = document.createElement('div');
+                row.className = 'notification-item';
+                row.textContent = item.message || '';
+
+                if (Array.isArray(item.jobs) && item.jobs.length > 0) {
+                    const jobsSpan = document.createElement('span');
+                    jobsSpan.className = 'notification-jobs';
+                    if (item.jobs.length === 1) {
+                        jobsSpan.textContent = `(${item.jobs[0]})`;
+                    } else {
+                        jobsSpan.textContent = `(${item.jobs.length} jobs)`;
+                    }
+                    row.appendChild(jobsSpan);
+                }
+
+                panel.appendChild(row);
+            }
+
+            container.appendChild(panel);
+        }
+    }
+
     async function renderResults(PR, sha, nameParams) {
         const result = getTargetResults(nameParams)
         let i = 1;
@@ -1848,6 +1940,9 @@
         }
 
         const resultsDiv = document.getElementById('result-container');
+
+        renderNotificationPanels(resultsDiv, result.ext);
+
         if (result.info) {
             const textDiv = document.createElement('div');
             textDiv.id = 'info-content';

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -867,8 +867,8 @@ def _finish_workflow(workflow, job_name):
                 env.add_report_message(
                     ResultInfo.NOT_FINALIZED, kind="error", job_name=result.name
                 )
-                # add error info to job info as well
-                result.set_info(ResultInfo.NOT_FINALIZED)
+                # add error to job result as well
+                result.add_error(ResultInfo.NOT_FINALIZED)
                 update_final_report = True
         job = workflow.get_job(result.name)
         if not job or not job.allow_merge_on_failure:

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -864,7 +864,9 @@ def _finish_workflow(workflow, job_name):
                 # dump workflow result after update - to have an updated result in post
                 workflow_result.dump()
                 # add error into env - should appear in the report on the main page
-                env.add_info(f"{result.name}: {ResultInfo.NOT_FINALIZED}")
+                env.add_report_message(
+                    ResultInfo.NOT_FINALIZED, kind="error", job_name=result.name
+                )
                 # add error info to job info as well
                 result.set_info(ResultInfo.NOT_FINALIZED)
                 update_final_report = True
@@ -906,7 +908,7 @@ def _finish_workflow(workflow, job_name):
             url="",
         ):
             print(f"ERROR: failed to set ReadyForMerge status")
-            env.add_info(ResultInfo.GH_STATUS_ERROR)
+            env.add_report_message(ResultInfo.GH_STATUS_ERROR, kind="error")
 
     if update_final_report:
         _ResultS3.copy_result_to_s3_with_version(workflow_result, version + 1)

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -864,8 +864,8 @@ def _finish_workflow(workflow, job_name):
                 # dump workflow result after update - to have an updated result in post
                 workflow_result.dump()
                 # add error into env - should appear in the report on the main page
-                env.add_report_message(
-                    ResultInfo.NOT_FINALIZED, kind="error", job_name=result.name
+                env.add_workflow_error(
+                    ResultInfo.NOT_FINALIZED, source=result.name
                 )
                 # add error to job result as well
                 result.add_error(ResultInfo.NOT_FINALIZED)
@@ -908,7 +908,7 @@ def _finish_workflow(workflow, job_name):
             url="",
         ):
             print(f"ERROR: failed to set ReadyForMerge status")
-            env.add_report_message(ResultInfo.GH_STATUS_ERROR, kind="error")
+            env.add_workflow_error(ResultInfo.GH_STATUS_ERROR)
 
     if update_final_report:
         _ResultS3.copy_result_to_s3_with_version(workflow_result, version + 1)

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -863,12 +863,11 @@ def _finish_workflow(workflow, job_name):
                 result.status = Result.Status.ERROR
                 # dump workflow result after update - to have an updated result in post
                 workflow_result.dump()
-                # add error into env - should appear in the report on the main page
+                # Attribute the error to the failed job (not Finish Workflow)
+                # so it appears under the correct source on the workflow report page.
                 env.add_workflow_error(
                     ResultInfo.NOT_FINALIZED, source=result.name
                 )
-                # add error to job result as well
-                result.add_error(ResultInfo.NOT_FINALIZED)
                 update_final_report = True
         job = workflow.get_job(result.name)
         if not job or not job.allow_merge_on_failure:

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -1354,6 +1354,7 @@ class _ResultS3:
         storage_usage=None,
         compute_usage=None,
         report_messages=None,
+        clear_report_sources=None,
     ):
         assert new_sub_results
 
@@ -1387,6 +1388,14 @@ class _ResultS3:
                     workflow_result.ext.get("compute_usage", {})
                 ).merge_with(compute_usage)
                 workflow_result.ext["compute_usage"] = workflow_compute_usage
+
+            if clear_report_sources:
+                for key in cls._REPORT_MESSAGE_KIND_TO_EXT_KEY.values():
+                    if key in workflow_result.ext:
+                        workflow_result.ext[key] = [
+                            e for e in workflow_result.ext[key]
+                            if e.get("from") not in clear_report_sources
+                        ]
 
             if report_messages:
                 cls.append_report_messages(workflow_result, report_messages)

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -329,6 +329,21 @@ class Result(MetaClasses.Serializable):
         self._dump_if_persisted()
         return self
 
+    def add_warning(self, message: str) -> "Result":
+        self.ext.setdefault("warnings", []).append(message)
+        self._dump_if_persisted()
+        return self
+
+    def add_error(self, message: str) -> "Result":
+        self.ext.setdefault("errors", []).append(message)
+        self._dump_if_persisted()
+        return self
+
+    def add_note(self, message: str) -> "Result":
+        self.ext.setdefault("notes", []).append(message)
+        self._dump_if_persisted()
+        return self
+
     def set_link(self, link) -> "Result":
         self.links.append(link)
         self._dump_if_persisted()

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -330,17 +330,43 @@ class Result(MetaClasses.Serializable):
         return self
 
     def add_warning(self, message: str) -> "Result":
-        self.ext.setdefault("warnings", []).append(message)
+        """
+        Add a warning message to this result only.
+
+        The message is stored in ``self.ext["warnings"]`` as
+        ``{"message": str, "from": str}`` and rendered as a notification panel
+        on the report page for this specific result (workflow, job, sub-task,
+        or test).  It is **not** propagated to parent or child results — use
+        ``Info.add_workflow_warning`` when the message should appear on the job
+        level and be propagated to the top (workflow) level.
+        """
+        self.ext.setdefault("warnings", []).append(
+            {"message": message, "from": self.name}
+        )
         self._dump_if_persisted()
         return self
 
     def add_error(self, message: str) -> "Result":
-        self.ext.setdefault("errors", []).append(message)
+        """
+        Add an error message to this result only.
+
+        See ``add_warning`` for propagation semantics.
+        """
+        self.ext.setdefault("errors", []).append(
+            {"message": message, "from": self.name}
+        )
         self._dump_if_persisted()
         return self
 
     def add_note(self, message: str) -> "Result":
-        self.ext.setdefault("notes", []).append(message)
+        """
+        Add a note message to this result only.
+
+        See ``add_warning`` for propagation semantics.
+        """
+        self.ext.setdefault("notes", []).append(
+            {"message": message, "from": self.name}
+        )
         self._dump_if_persisted()
         return self
 
@@ -1299,34 +1325,6 @@ class _ResultS3:
                 )
         return result
 
-    @staticmethod
-    def _merge_report_messages(ext, new_messages):
-        """
-        Merge structured report messages into Result.ext.
-
-        Each message is ``{"message": str, "kind": str, "job": str}``.
-        Messages are stored in ``ext["warnings"]``, ``ext["errors"]``, and
-        ``ext["notes"]`` as lists of ``{"message": str, "jobs": [str]}``.
-        Duplicate messages (same text) are grouped, accumulating job names.
-        """
-        kind_to_key = {"warning": "warnings", "error": "errors", "note": "notes"}
-        for msg in new_messages:
-            key = kind_to_key.get(msg.get("kind"), "notes")
-            items = ext.setdefault(key, [])
-            text = msg.get("message", "")
-            job = msg.get("job", "")
-            # find existing entry with same message text
-            existing = None
-            for item in items:
-                if item["message"] == text:
-                    existing = item
-                    break
-            if existing:
-                if job and job not in existing["jobs"]:
-                    existing["jobs"].append(job)
-            else:
-                items.append({"message": text, "jobs": [job] if job else []})
-
     @classmethod
     def update_workflow_results(
         cls,
@@ -1370,7 +1368,12 @@ class _ResultS3:
                 workflow_result.ext["compute_usage"] = workflow_compute_usage
 
             if report_messages:
-                cls._merge_report_messages(workflow_result.ext, report_messages)
+                kind_to_key = {"warning": "warnings", "error": "errors", "note": "notes"}
+                for msg in report_messages:
+                    key = kind_to_key.get(msg.get("kind"), "notes")
+                    workflow_result.ext.setdefault(key, []).append(
+                        {"message": msg["message"], "from": msg["from"]}
+                    )
 
             new_status = workflow_result.status
             if cls.copy_result_to_s3_with_version(

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -1316,13 +1316,12 @@ class _ResultS3:
     def update_workflow_results(
         cls,
         workflow_name,
-        new_info="",
         new_sub_results=None,
         storage_usage=None,
         compute_usage=None,
         report_messages=None,
     ):
-        assert new_info or new_sub_results
+        assert new_sub_results
 
         attempt = 1
         prev_status = ""
@@ -1335,8 +1334,6 @@ class _ResultS3:
             )
             workflow_result = Result.from_fs(workflow_name)
             prev_status = workflow_result.status
-            if new_info:
-                workflow_result.set_info(new_info)
             if new_sub_results:
                 if isinstance(new_sub_results, Result):
                     new_sub_results = [new_sub_results]

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -1284,6 +1284,34 @@ class _ResultS3:
                 )
         return result
 
+    @staticmethod
+    def _merge_report_messages(ext, new_messages):
+        """
+        Merge structured report messages into Result.ext.
+
+        Each message is ``{"message": str, "kind": str, "job": str}``.
+        Messages are stored in ``ext["warnings"]``, ``ext["errors"]``, and
+        ``ext["notes"]`` as lists of ``{"message": str, "jobs": [str]}``.
+        Duplicate messages (same text) are grouped, accumulating job names.
+        """
+        kind_to_key = {"warning": "warnings", "error": "errors", "note": "notes"}
+        for msg in new_messages:
+            key = kind_to_key.get(msg.get("kind"), "notes")
+            items = ext.setdefault(key, [])
+            text = msg.get("message", "")
+            job = msg.get("job", "")
+            # find existing entry with same message text
+            existing = None
+            for item in items:
+                if item["message"] == text:
+                    existing = item
+                    break
+            if existing:
+                if job and job not in existing["jobs"]:
+                    existing["jobs"].append(job)
+            else:
+                items.append({"message": text, "jobs": [job] if job else []})
+
     @classmethod
     def update_workflow_results(
         cls,
@@ -1292,6 +1320,7 @@ class _ResultS3:
         new_sub_results=None,
         storage_usage=None,
         compute_usage=None,
+        report_messages=None,
     ):
         assert new_info or new_sub_results
 
@@ -1327,6 +1356,9 @@ class _ResultS3:
                     workflow_result.ext.get("compute_usage", {})
                 ).merge_with(compute_usage)
                 workflow_result.ext["compute_usage"] = workflow_compute_usage
+
+            if report_messages:
+                cls._merge_report_messages(workflow_result.ext, report_messages)
 
             new_status = workflow_result.status
             if cls.copy_result_to_s3_with_version(

--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -1169,6 +1169,27 @@ class ResultInfo:
 
 class _ResultS3:
 
+    # Map the ``kind`` field used in ``_Environment.REPORT_MESSAGES`` to the
+    # ``ext`` bucket rendered by ``json.html``. Unknown kinds fall into notes.
+    _REPORT_MESSAGE_KIND_TO_EXT_KEY = {
+        "warning": "warnings",
+        "error": "errors",
+        "note": "notes",
+    }
+
+    @classmethod
+    def append_report_messages(cls, result, messages):
+        """
+        Append ``{"message", "kind", "from"}`` dicts from
+        ``_Environment.REPORT_MESSAGES`` into ``result.ext`` under the
+        matching ``warnings``/``errors``/``notes`` bucket.
+        """
+        for msg in messages:
+            key = cls._REPORT_MESSAGE_KIND_TO_EXT_KEY.get(msg.get("kind"), "notes")
+            result.ext.setdefault(key, []).append(
+                {"message": msg["message"], "from": msg["from"]}
+            )
+
     @classmethod
     def copy_result_to_s3(cls, result, clean=False):
         result.dump()
@@ -1368,12 +1389,7 @@ class _ResultS3:
                 workflow_result.ext["compute_usage"] = workflow_compute_usage
 
             if report_messages:
-                kind_to_key = {"warning": "warnings", "error": "errors", "note": "notes"}
-                for msg in report_messages:
-                    key = kind_to_key.get(msg.get("kind"), "notes")
-                    workflow_result.ext.setdefault(key, []).append(
-                        {"message": msg["message"], "from": msg["from"]}
-                    )
+                cls.append_report_messages(workflow_result, report_messages)
 
             new_status = workflow_result.status
             if cls.copy_result_to_s3_with_version(

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -590,6 +590,11 @@ class Runner:
         env = _Environment.get()
         is_ok = True
 
+        # TODO: remove after testing notification panels
+        env.add_report_message("Test error message", kind="error")
+        env.add_report_message("Test warning message", kind="warning")
+        env.add_report_message("Test note message", kind="note")
+
 
         is_final_job = job.name == Settings.FINISH_WORKFLOW_JOB_NAME
         is_initial_job = job.name == Settings.CI_CONFIG_JOB_NAME
@@ -750,7 +755,9 @@ class Runner:
                 print(f"ERROR: failed to check open issues: {e}")
                 traceback.print_exc()
                 if is_final_job:
-                    env.add_info(ResultInfo.OPEN_ISSUES_CHECK_ERROR)
+                    env.add_report_message(
+                        ResultInfo.OPEN_ISSUES_CHECK_ERROR, kind="error"
+                    )
 
         # Always run report generation at the end to finalize workflow status with latest job result
         if workflow.enable_report:
@@ -816,7 +823,9 @@ class Runner:
                     description=result.info.splitlines()[0] if result.info else "",
                     url=report_url,
                 ):
-                    env.add_info("Failed to post GH commit status for the job")
+                    env.add_report_message(
+                        "Failed to post GH commit status for the job", kind="error"
+                    )
                     print(f"ERROR: Failed to post commit status for the job")
 
         if workflow.enable_report:

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -489,18 +489,19 @@ class Runner:
                         print(
                             f"WARNING: Job timed out: [{job.name}], timeout [{job.timeout}], exit code [{exit_code}]"
                         )
-                        info = ResultInfo.TIMEOUT
+                        result.add_error(ResultInfo.TIMEOUT)
                     elif result.is_running():
-                        info = f"ERROR: Job killed, exit code [{exit_code}]  - set status to [{Result.Status.ERROR}]."
-                        print(info)
+                        info = f"Job killed, exit code [{exit_code}]"
+                        print(f"ERROR: {info}")
+                        result.add_error(info)
                     else:
-                        info = f"ERROR: Invalid status [{result.status}] for exit code [{exit_code}]  - switch to [{Result.Status.ERROR}]"
-                        print(info)
+                        info = f"Invalid status [{result.status}] for exit code [{exit_code}]"
+                        print(f"ERROR: {info}")
+                        result.add_error(info)
                     result.set_status(Result.Status.ERROR)
-                    result.set_info(info)
-                    result.set_info("---").set_info(
+                    result.set_info(
                         process.get_latest_log(max_lines=20)
-                    ).set_info("---")
+                    )
             result.dump()
 
         print("INFO: disk status after running a job:")
@@ -527,36 +528,31 @@ class Runner:
         result_exist = Result.exist(job.name)
 
         if setup_env_exit_code != 0:
-            info = f"ERROR: {ResultInfo.SETUP_ENV_JOB_FAILED}"
-            print(info)
-            # set Result with error and logs
+            print(f"ERROR: {ResultInfo.SETUP_ENV_JOB_FAILED}")
             Result(
                 name=job.name,
                 status=Result.Status.ERROR,
                 start_time=Utils.timestamp(),
                 duration=0.0,
-                info=info,
+                ext={"errors": [ResultInfo.SETUP_ENV_JOB_FAILED]},
             ).dump()
         elif prerun_exit_code != 0:
-            info = ResultInfo.PRE_JOB_FAILED
-            print(info)
-            # set Result with error and logs
+            print(f"ERROR: {ResultInfo.PRE_JOB_FAILED}")
             Result(
                 name=job.name,
                 status=Result.Status.ERROR,
                 start_time=Utils.timestamp(),
                 duration=0.0,
-                info=info,
+                ext={"errors": [ResultInfo.PRE_JOB_FAILED]},
             ).dump()
         elif not result_exist:
-            info = f"ERROR: {ResultInfo.NOT_FOUND_IMPOSSIBLE}"
-            print(info)
+            print(f"ERROR: {ResultInfo.NOT_FOUND_IMPOSSIBLE}")
             Result(
                 name=job.name,
                 start_time=Utils.timestamp(),
                 duration=None,
                 status=Result.Status.ERROR,
-                info=ResultInfo.NOT_FOUND_IMPOSSIBLE,
+                ext={"errors": [ResultInfo.NOT_FOUND_IMPOSSIBLE]},
             ).dump()
 
         try:

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -741,6 +741,24 @@ class Runner:
                 if is_final_job:
                     env.add_workflow_error(ResultInfo.OPEN_ISSUES_CHECK_ERROR)
 
+        info = Info()
+        report_url = info.get_job_report_url(latest=False)
+
+        if (
+            workflow.enable_commit_status_on_failure and not result.is_ok()
+        ) or job.enable_commit_status:
+            if _GH_Auth():
+                if not GH.post_commit_status(
+                    name=job.name,
+                    status=result.status,
+                    description=result.info.splitlines()[0] if result.info else "",
+                    url=report_url,
+                ):
+                    env.add_workflow_error(
+                        "Failed to post GH commit status for the job"
+                    )
+                    print(f"ERROR: Failed to post commit status for the job")
+
         # Always run report generation at the end to finalize workflow status with latest job result
         if workflow.enable_report:
             print(f"Run html report hook")
@@ -775,9 +793,6 @@ class Runner:
                     )
                     ci_db.insert_compute_usage(workflow_compute_usage)
 
-        info = Info()
-        report_url = info.get_job_report_url(latest=False)
-
         if workflow.enable_gh_summary_comment and (
             job.name == Settings.FINISH_WORKFLOW_JOB_NAME or not result.is_ok()
         ) and _GH_Auth():
@@ -794,21 +809,6 @@ class Runner:
             except Exception as e:
                 print(f"ERROR: failed to post CI summary, ex: {e}")
                 traceback.print_exc()
-
-        if (
-            workflow.enable_commit_status_on_failure and not result.is_ok()
-        ) or job.enable_commit_status:
-            if _GH_Auth():
-                if not GH.post_commit_status(
-                    name=job.name,
-                    status=result.status,
-                    description=result.info.splitlines()[0] if result.info else "",
-                    url=report_url,
-                ):
-                    env.add_workflow_error(
-                        "Failed to post GH commit status for the job"
-                    )
-                    print(f"ERROR: Failed to post commit status for the job")
 
         if workflow.enable_report:
             # to make it visible in GH Actions annotations

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -534,8 +534,7 @@ class Runner:
                 status=Result.Status.ERROR,
                 start_time=Utils.timestamp(),
                 duration=0.0,
-                ext={"errors": [ResultInfo.SETUP_ENV_JOB_FAILED]},
-            ).dump()
+            ).add_error(ResultInfo.SETUP_ENV_JOB_FAILED).dump()
         elif prerun_exit_code != 0:
             print(f"ERROR: {ResultInfo.PRE_JOB_FAILED}")
             Result(
@@ -543,8 +542,7 @@ class Runner:
                 status=Result.Status.ERROR,
                 start_time=Utils.timestamp(),
                 duration=0.0,
-                ext={"errors": [ResultInfo.PRE_JOB_FAILED]},
-            ).dump()
+            ).add_error(ResultInfo.PRE_JOB_FAILED).dump()
         elif not result_exist:
             print(f"ERROR: {ResultInfo.NOT_FOUND_IMPOSSIBLE}")
             Result(
@@ -552,8 +550,7 @@ class Runner:
                 start_time=Utils.timestamp(),
                 duration=None,
                 status=Result.Status.ERROR,
-                ext={"errors": [ResultInfo.NOT_FOUND_IMPOSSIBLE]},
-            ).dump()
+            ).add_error(ResultInfo.NOT_FOUND_IMPOSSIBLE).dump()
 
         try:
             result = Result.from_fs(job.name)
@@ -635,7 +632,7 @@ class Runner:
                         except Exception as e:
                             error = f"Failed to upload artifact [{artifact.name}:{artifact_path}], ex [{e}]"
                             print(f"ERROR: {error}")
-                            env.add_report_message(error, kind="error")
+                            env.add_workflow_error(error)
                             result.set_status(Result.Status.ERROR)
                             is_ok = False
                 if artifact_links:
@@ -688,7 +685,7 @@ class Runner:
                 traceback.print_exc()
                 error = f"Failed to insert data into CI DB, exception [{ex}]"
                 print(f"ERROR: {error}")
-                env.add_report_message(error, kind="error")
+                env.add_workflow_error(error)
 
             try:
                 test_cases_result = result.get_sub_result_by_name(
@@ -717,7 +714,7 @@ class Runner:
                 traceback.print_exc()
                 error = f"Failed to set CIDB label for test cases, exception [{ex}]"
                 print(f"ERROR: {error}")
-                env.add_report_message(error, kind="error")
+                env.add_workflow_error(error)
 
         if env.TRACEBACKS:
             result.set_info("===\n" + "---\n".join(env.TRACEBACKS))
@@ -743,9 +740,7 @@ class Runner:
                 print(f"ERROR: failed to check open issues: {e}")
                 traceback.print_exc()
                 if is_final_job:
-                    env.add_report_message(
-                        ResultInfo.OPEN_ISSUES_CHECK_ERROR, kind="error"
-                    )
+                    env.add_workflow_error(ResultInfo.OPEN_ISSUES_CHECK_ERROR)
 
         # Always run report generation at the end to finalize workflow status with latest job result
         if workflow.enable_report:
@@ -811,8 +806,8 @@ class Runner:
                     description=result.info.splitlines()[0] if result.info else "",
                     url=report_url,
                 ):
-                    env.add_report_message(
-                        "Failed to post GH commit status for the job", kind="error"
+                    env.add_workflow_error(
+                        "Failed to post GH commit status for the job"
                     )
                     print(f"ERROR: Failed to post commit status for the job")
 

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -586,7 +586,6 @@ class Runner:
     def _post_run(
         self, result, workflow, job, run_exit_code,
     ) -> bool:
-        info_errors = []
         env = _Environment.get()
         is_ok = True
 
@@ -644,9 +643,9 @@ class Runner:
                                 result.set_link(link)
                                 artifact_links.append(link)
                         except Exception as e:
-                            error = f"ERROR: Failed to upload artifact [{artifact.name}:{artifact_path}], ex [{e}]"
-                            print(error)
-                            info_errors.append(error)
+                            error = f"Failed to upload artifact [{artifact.name}:{artifact_path}], ex [{e}]"
+                            print(f"ERROR: {error}")
+                            env.add_report_message(error, kind="error")
                             result.set_status(Result.Status.ERROR)
                             is_ok = False
                 if artifact_links:
@@ -697,9 +696,9 @@ class Runner:
                 ).insert(result, result_name_for_cidb=job.result_name_for_cidb)
             except Exception as ex:
                 traceback.print_exc()
-                error = f"ERROR: Failed to insert data into CI DB, exception [{ex}]"
-                print(error)
-                info_errors.append(error)
+                error = f"Failed to insert data into CI DB, exception [{ex}]"
+                print(f"ERROR: {error}")
+                env.add_report_message(error, kind="error")
 
             try:
                 test_cases_result = result.get_sub_result_by_name(
@@ -725,11 +724,10 @@ class Runner:
                             )
                     result.dump()
             except Exception as ex:
-                if not info_errors:
-                    traceback.print_exc()
-                    error = f"ERROR: Failed to set CIDB label for test cases, exception [{ex}]"
-                    print(error)
-                    info_errors.append(error)
+                traceback.print_exc()
+                error = f"Failed to set CIDB label for test cases, exception [{ex}]"
+                print(f"ERROR: {error}")
+                env.add_report_message(error, kind="error")
 
         if env.TRACEBACKS:
             result.set_info("===\n" + "---\n".join(env.TRACEBACKS))
@@ -742,7 +740,7 @@ class Runner:
                 CacheRunnerHooks.post_run(workflow, job)
 
         if workflow.enable_open_issues_check:
-            # should be done before HtmlRunnerHooks.post_run(workflow, job, info_errors)
+            # should be done before HtmlRunnerHooks.post_run(workflow, job)
             #   to upload updated job and workflow results to S3
             try:
                 if is_final_job:
@@ -762,7 +760,7 @@ class Runner:
         # Always run report generation at the end to finalize workflow status with latest job result
         if workflow.enable_report:
             print(f"Run html report hook")
-            status_updated = HtmlRunnerHooks.post_run(workflow, job, info_errors)
+            status_updated = HtmlRunnerHooks.post_run(workflow, job)
             if status_updated:
                 print(f"Update GH commit status [{result.name}]: [{status_updated}]")
                 if _GH_Auth():

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -570,9 +570,8 @@ class Runner:
             ).dump()
 
         if not result.is_completed():
-            info = f"ERROR: {ResultInfo.KILLED}"
-            print(info)
-            result.set_info(info).set_status(Result.Status.ERROR).dump()
+            print(f"ERROR: {ResultInfo.KILLED}")
+            result.add_error(ResultInfo.KILLED).set_status(Result.Status.ERROR).dump()
 
         if result.is_error() and result.get_on_error_hook():
             print(f"--- Run on_error_hook [{result.get_on_error_hook()}]")
@@ -588,11 +587,6 @@ class Runner:
     ) -> bool:
         env = _Environment.get()
         is_ok = True
-
-        # TODO: remove after testing notification panels
-        env.add_report_message("Test error message", kind="error")
-        env.add_report_message("Test warning message", kind="warning")
-        env.add_report_message("Test note message", kind="note")
 
 
         is_final_job = job.name == Settings.FINISH_WORKFLOW_JOB_NAME

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -584,11 +584,6 @@ class Runner:
         is_final_job = job.name == Settings.FINISH_WORKFLOW_JOB_NAME
         is_initial_job = job.name == Settings.CI_CONFIG_JOB_NAME
 
-        # TODO: remove after testing notification panels
-        env.add_workflow_error("Test error message")
-        env.add_workflow_warning("Test warning message")
-        env.add_workflow_note("Test note message")
-
         if run_exit_code == 0 or result.do_not_block_pipeline_on_failure():
             providing_artifacts = []
             if job.provides and workflow.artifacts:

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -581,7 +581,6 @@ class Runner:
         env = _Environment.get()
         is_ok = True
 
-
         is_final_job = job.name == Settings.FINISH_WORKFLOW_JOB_NAME
         is_initial_job = job.name == Settings.CI_CONFIG_JOB_NAME
 

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -585,6 +585,11 @@ class Runner:
         is_final_job = job.name == Settings.FINISH_WORKFLOW_JOB_NAME
         is_initial_job = job.name == Settings.CI_CONFIG_JOB_NAME
 
+        # TODO: remove after testing notification panels
+        env.add_workflow_error("Test error message")
+        env.add_workflow_warning("Test warning message")
+        env.add_workflow_note("Test note message")
+
         if run_exit_code == 0 or result.do_not_block_pipeline_on_failure():
             providing_artifacts = []
             if job.provides and workflow.artifacts:

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -192,6 +192,7 @@ workflow = Workflow.Config(
         "python3 ./ci/jobs/scripts/workflow_hooks/feature_docs.py",
         "python3 ./ci/jobs/scripts/workflow_hooks/new_tests_check.py",
         "python3 ./ci/jobs/scripts/workflow_hooks/can_be_merged.py",
+        "python3 ./ci/jobs/scripts/workflow_hooks/check_report_messages.py",
     ],
     job_aliases={
         "integration": JobConfigs.integration_test_jobs_non_required[


### PR DESCRIPTION
Refactor how CI report messages (warnings, errors, notes) are collected
and displayed.

**Old approach**: plain-text `add_workflow_report_message` / `env.add_info`
appended strings into `Result.info`. No structure, no grouping, no
visual distinction by severity.

**New approach**:
- Typed methods on three levels:
  - `Info.add_workflow_warning/error/note` — adds to both job and
    workflow report pages (propagated via `env.REPORT_MESSAGES`)
  - `Result.add_warning/error/note` — adds to this specific result only
    (no propagation)
  - `_Environment.add_workflow_warning/error/note` — low-level accumulator
    used by runner infrastructure
- Universal message format: `{"message": str, "from": str}` everywhere
- Job `Result.ext` and workflow `Result.ext` store flat lists in the
  same format (`warnings`, `errors`, `notes`)
- `json.html` groups duplicate messages by text at render time, showing
  source count with tooltip listing all sources
- Colored notification panels (red/amber/blue) rendered at the top of
  both workflow and job pages
- `check_report_messages.py` post hook fails the workflow if any errors
  or warnings are present

Removes legacy `REPORT_INFO`, `add_info`, `add_workflow_report_message`,
`info_errors` accumulation path, and server-side `_merge_report_messages`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)
