### PR TITLE
Respect input_format_binary_max_type_complexity in decoding aggregate function parameters

### DIFF
--- a/src/DataTypes/DataTypesBinaryEncoding.cpp
+++ b/src/DataTypes/DataTypesBinaryEncoding.cpp
@@ -299,7 +299,7 @@ std::tuple<AggregateFunctionPtr, Array, DataTypes> decodeAggregateFunction(ReadB
     size_t num_arguments;
     readVarUInt(num_arguments, buf);
     if (num_arguments > MAX_ARRAY_SIZE)
-        throw Exception(ErrorCodes::INCORRECT_DATA, "Too many function arguments during AggregateFunction type decoding: {}. Maximum: {}", num_parameters, MAX_ARRAY_SIZE);
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Too many function arguments during AggregateFunction type decoding: {}. Maximum: {}", num_arguments, MAX_ARRAY_SIZE);
 
     DataTypes arguments_types;
     arguments_types.reserve(num_arguments);

--- a/src/DataTypes/DataTypesBinaryEncoding.cpp
+++ b/src/DataTypes/DataTypesBinaryEncoding.cpp
@@ -54,6 +54,8 @@ namespace Setting
 extern const SettingsUInt64 input_format_binary_max_type_complexity;
 }
 
+DataTypePtr decodeDataType(ReadBuffer & buf, size_t & complexity);
+
 namespace
 {
 /// Max array size that is allowed for any nested elements during data type decoding.
@@ -281,7 +283,7 @@ void encodeAggregateFunction(const String & function_name, const Array & paramet
         encodeDataTypeImpl<encode_for_hash_calculation>(argument_type, buf);
 }
 
-std::tuple<AggregateFunctionPtr, Array, DataTypes> decodeAggregateFunction(ReadBuffer & buf)
+std::tuple<AggregateFunctionPtr, Array, DataTypes> decodeAggregateFunction(ReadBuffer & buf, size_t & complexity)
 {
     String function_name;
     readStringBinary(function_name, buf);
@@ -302,7 +304,7 @@ std::tuple<AggregateFunctionPtr, Array, DataTypes> decodeAggregateFunction(ReadB
     DataTypes arguments_types;
     arguments_types.reserve(num_arguments);
     for (size_t i = 0; i != num_arguments; ++i)
-        arguments_types.push_back(decodeDataType(buf));
+        arguments_types.push_back(decodeDataType(buf, complexity));
     AggregateFunctionProperties properties;
     auto action = NullsAction::EMPTY;
     auto function = AggregateFunctionFactory::instance().get(function_name, action, arguments_types, parameters, properties);
@@ -741,12 +743,12 @@ DataTypePtr decodeDataType(ReadBuffer & buf, size_t & complexity)
         {
             size_t version;
             readVarUInt(version, buf);
-            const auto & [function, parameters, arguments_types] = decodeAggregateFunction(buf);
+            const auto & [function, parameters, arguments_types] = decodeAggregateFunction(buf, complexity);
             return std::make_shared<DataTypeAggregateFunction>(function, arguments_types, parameters, version);
         }
         case BinaryTypeIndex::SimpleAggregateFunction:
         {
-            const auto & [function, parameters, arguments_types] = decodeAggregateFunction(buf);
+            const auto & [function, parameters, arguments_types] = decodeAggregateFunction(buf, complexity);
             return createSimpleAggregateFunctionType(function, arguments_types, parameters);
         }
         case BinaryTypeIndex::Nested:

--- a/tests/queries/0_stateless/03288_types_binary_encoding_corrupted_data.reference
+++ b/tests/queries/0_stateless/03288_types_binary_encoding_corrupted_data.reference
@@ -5,7 +5,7 @@ Too many function arguments during Function type decoding: 2000000. Maximum: 100
 Too many variants during Variant type decoding: 2000000. Maximum: 1000000. (INCORRECT_DATA)
 Too many elements during Nested type decoding: 2000000. Maximum: 1000000. (INCORRECT_DATA)
 Too many parameters during AggregateFunction type decoding: 2000000. Maximum: 1000000. (INCORRECT_DATA)
-Too many function arguments during AggregateFunction type decoding: 0. Maximum: 1000000. (INCORRECT_DATA)
+Too many function arguments during AggregateFunction type decoding: 2000000. Maximum: 1000000. (INCORRECT_DATA)
 Too many typed paths during JSON type decoding: 2000000. Maximum: 1000. (INCORRECT_DATA)
 Too many paths to skip during JSON type decoding: 2000000. Maximum: 1000000. (INCORRECT_DATA)
 Too many path regexps to skip during JSON type decoding: 0. Maximum: 1000000. (INCORRECT_DATA)

--- a/tests/queries/0_stateless/04102_decode_aggregate_function_type_complexity.reference
+++ b/tests/queries/0_stateless/04102_decode_aggregate_function_type_complexity.reference
@@ -1,0 +1,2 @@
+Binary type decoding complexity limit exceeded
+Binary type decoding complexity limit exceeded

--- a/tests/queries/0_stateless/04102_decode_aggregate_function_type_complexity.sh
+++ b/tests/queries/0_stateless/04102_decode_aggregate_function_type_complexity.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Control: Nullable(Array(UInt8)) has complexity 3, should be rejected with limit 2.
+$CLICKHOUSE_CLIENT --query "SELECT * FROM format(RowBinaryWithNamesAndTypes, x'010178231e01') SETTINGS input_format_binary_decode_types_in_binary_format=1, input_format_binary_max_type_complexity=2" 2>&1 | grep -o -m1 'Binary type decoding complexity limit exceeded'
+
+# Nested AggregateFunction(sum, ...) also exceeds complexity 2, should be rejected.
+$CLICKHOUSE_CLIENT --query "SELECT * FROM format(RowBinaryWithNamesAndTypes, x'010178' || repeat(x'25000373756d0001', 3) || x'01') SETTINGS input_format_binary_decode_types_in_binary_format=1, input_format_binary_max_type_complexity=2" 2>&1 | grep -o -m1 'Binary type decoding complexity limit exceeded'


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Respect `input_format_binary_max_type_complexity` in decoding aggregate function parameters. Closes https://github.com/ClickHouse/ClickHouse/issues/102903

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.938`
<!-- ch-version-info:end -->