### PR TITLE
Handle old `VersionInfo` metadata format gracefully

### DIFF
--- a/src/Interpreters/MergeTreeTransaction/VersionInfo.cpp
+++ b/src/Interpreters/MergeTreeTransaction/VersionInfo.cpp
@@ -98,8 +98,22 @@ void VersionInfo::readFromMultiLineBuffer(ReadBuffer & buf)
     CSN current_removal_csn = Tx::UnknownCSN;
 
     assertString("version: 1", buf);
+    assertChar('\n', buf);
 
-    assertString(String("\n") + STORING_VERSION_STR, buf);
+    /// Old format (before the `storing_version` field was introduced) starts with `creation_tid:` immediately
+    /// after the version header. Convert such metadata to non-transactional instead of throwing a parse exception.
+    /// `checkString` is safe here because the first character differs ('c' vs 's'), so it never partially consumes.
+    if (checkString(CREATION_TID_STR, buf))
+    {
+        storing_version = current_storing_version;
+        creation_tid = Tx::NonTransactionalTID;
+        creation_csn = Tx::NonTransactionalCSN;
+        removal_tid = Tx::EmptyTID;
+        removal_csn = Tx::UnknownCSN;
+        return;
+    }
+
+    assertString(STORING_VERSION_STR, buf);
     readText(current_storing_version, buf);
 
     assertString(String("\n") + CREATION_TID_STR, buf);


### PR DESCRIPTION
Old format metadata files (before `storing_version` was introduced) have `creation_tid:` immediately after `version: 1`, which caused `assertString` to throw a parse exception when loading parts on upgraded instances.

Detect old format by checking for `creation_tid:` at the position where `storing_version:` is expected. `checkString` is safe here because the first character differs ('c' vs 's'), so it never partially consumes the buffer on a new-format file. Old-format parts are converted to non-transactional to avoid failure.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1099`
<!-- ch-version-info:end -->