### PR TITLE
Support `ALIAS` columns in text index direct read optimization

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
@@ -18,6 +18,7 @@
 #include <Processors/QueryPlan/Optimizations/Optimizations.h>
 #include <Processors/QueryPlan/QueryPlan.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
+#include <Storages/MergeTree/KeyCondition.h>
 #include <Storages/MergeTree/MergeTreeIndexConditionText.h>
 #include <Storages/MergeTree/MergeTreeIndexTextPreprocessor.h>
 #include <Storages/MergeTree/RangesInDataPart.h>
@@ -370,8 +371,14 @@ private:
         return function_name == "hasToken" || function_name == "hasAllTokens" || function_name == "hasAnyTokens" || function_name == "hasPhrase";
     }
 
-    std::vector<SelectedCondition> selectConditions(const ActionsDAG::Node & function_node)
+    std::vector<SelectedCondition> selectConditions(const ActionsDAG::Node & function_node, const ContextPtr & context)
     {
+        /// Canonicalize the function-node subtree so that the serialized column names
+        /// fed to MergeTreeIndexConditionText::traverseFunctionNode match the ones
+        /// produced when the condition was originally constructed in ReadFromMergeTree::applyFilters.
+        ActionsDAGWithInversionPushDown canonical_dag(&function_node, context);
+        const auto & canonical_node = canonical_dag.predicate ? *canonical_dag.predicate : function_node;
+
         NameSet used_index_columns;
         std::vector<SelectedCondition> selected_conditions;
 
@@ -386,7 +393,7 @@ private:
             if (index_header.columns() != 1 || used_index_columns.contains(index_header.begin()->name))
                 continue;
 
-            auto search_query = text_index_condition.createTextSearchQuery(function_node);
+            auto search_query = text_index_condition.createTextSearchQuery(canonical_node);
             if (!search_query || search_query->direct_read_mode == TextIndexDirectReadMode::None)
                 continue;
 
@@ -423,7 +430,7 @@ private:
         if (!need_preprocess_function && !direct_read_from_text_index)
             return replacement;
 
-        auto selected_conditions = selectConditions(function_node);
+        auto selected_conditions = selectConditions(function_node, context);
         if (selected_conditions.empty())
             return replacement;
 

--- a/tests/queries/0_stateless/04102_text_index_alias_direct_read.reference
+++ b/tests/queries/0_stateless/04102_text_index_alias_direct_read.reference
@@ -1,0 +1,4 @@
+materialized	1
+alias	1
+materialized EXPLAIN rewritten	1
+alias EXPLAIN rewritten	1

--- a/tests/queries/0_stateless/04102_text_index_alias_direct_read.sql
+++ b/tests/queries/0_stateless/04102_text_index_alias_direct_read.sql
@@ -1,0 +1,49 @@
+-- Regression test: text-index direct-read rewrite should fire for ALIAS
+-- columns, not only for MATERIALIZED ones.
+--
+-- The filter DAG uses analyzer-style constant names (`'='_String`) while the
+-- index `sample_block` is built by the old `ExpressionAnalyzer`
+-- (AST-style `'='`). `MergeTreeIndexConditionText` was originally constructed
+-- from a predicate cloned through `ActionsDAGWithInversionPushDown` (which
+-- canonicalizes constant names), so the header match worked. But the later
+-- optimization pass used the raw filter-DAG node, so `header.has(...)` missed
+-- whenever the indexed expression itself had a constant child — which is
+-- exactly the `ALIAS concat(s, '=', t)` case.
+
+SET query_plan_direct_read_from_text_index = 1;
+
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab
+(
+    s String,
+    t String,
+    stm String MATERIALIZED concat(s, '=', t),
+    sta String ALIAS concat(s, '=', t),
+    INDEX idx_stm stm TYPE text(tokenizer = 'array') GRANULARITY 100000000,
+    INDEX idx_sta sta TYPE text(tokenizer = 'array') GRANULARITY 100000000
+)
+ENGINE = MergeTree
+ORDER BY tuple();
+
+INSERT INTO tab (s, t) VALUES ('a', 'b'), ('a', 'c'), ('c', 'd'), ('e', 'f');
+
+-- Results must be identical for the two equivalent columns.
+SELECT 'materialized', count() FROM tab WHERE hasAllTokens(stm, 'a=c');
+SELECT 'alias',        count() FROM tab WHERE hasAllTokens(sta, 'a=c');
+
+-- Both plans must reference the `__text_index_*` virtual column, proving the
+-- direct-read rewrite fired.
+SELECT 'materialized EXPLAIN rewritten', count() > 0 FROM
+(
+    EXPLAIN actions = 1 SELECT count() FROM tab WHERE hasAllTokens(stm, 'a=c')
+)
+WHERE explain LIKE '%__text_index_idx_stm_hasAllTokens%';
+
+SELECT 'alias EXPLAIN rewritten', count() > 0 FROM
+(
+    EXPLAIN actions = 1 SELECT count() FROM tab WHERE hasAllTokens(sta, 'a=c')
+)
+WHERE explain LIKE '%__text_index_idx_sta_hasAllTokens%';
+
+DROP TABLE tab;

--- a/tests/queries/0_stateless/04103_text_index_alias_direct_read_map.reference
+++ b/tests/queries/0_stateless/04103_text_index_alias_direct_read_map.reference
@@ -1,0 +1,4 @@
+materialized	2
+alias	2
+materialized EXPLAIN rewritten	1
+alias EXPLAIN rewritten	1

--- a/tests/queries/0_stateless/04103_text_index_alias_direct_read_map.sql
+++ b/tests/queries/0_stateless/04103_text_index_alias_direct_read_map.sql
@@ -1,0 +1,51 @@
+-- Regression test: text-index direct-read rewrite should fire for ALIAS
+-- columns that derive from a `Map`, not only for MATERIALIZED ones.
+--
+-- Covers the observable pattern from the bug report — a synthetic
+-- `Array(String)` built from a Map and indexed as text — with a constant
+-- embedded in the indexed expression (here: the `'sentinel'` literal inside
+-- `arrayConcat`). That literal has the analyzer-style `_String` suffix in the
+-- filter DAG and the AST-style bare form in the index `sample_block`;
+-- without the fix the ALIAS case fails to match and the `__text_index_*`
+-- rewrite does not fire.
+
+SET query_plan_direct_read_from_text_index = 1;
+
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab
+(
+    id UInt64,
+    attrs Map(String, String),
+    tokens_m Array(String) MATERIALIZED arrayConcat(mapKeys(attrs), ['sentinel']),
+    tokens_a Array(String) ALIAS        arrayConcat(mapKeys(attrs), ['sentinel']),
+    INDEX idx_tokens_m tokens_m TYPE text(tokenizer = 'array') GRANULARITY 100000000,
+    INDEX idx_tokens_a tokens_a TYPE text(tokenizer = 'array') GRANULARITY 100000000
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+INSERT INTO tab VALUES
+    (1, {'host': '192.168.1.1', 'service': 'web'}),
+    (2, {'host': '5.6.7.8',     'service': 'api'}),
+    (3, {'namespace': 'prod'});
+
+-- Both columns expand to the same expression, so `has` must return the same count.
+SELECT 'materialized', count() FROM tab WHERE has(tokens_m, 'host');
+SELECT 'alias',        count() FROM tab WHERE has(tokens_a, 'host');
+
+-- Both plans must reference the `__text_index_*` virtual column, proving the
+-- direct-read rewrite fired.
+SELECT 'materialized EXPLAIN rewritten', count() > 0 FROM
+(
+    EXPLAIN actions = 1 SELECT count() FROM tab WHERE has(tokens_m, 'host')
+)
+WHERE explain LIKE '%__text_index_idx_tokens_m_has%';
+
+SELECT 'alias EXPLAIN rewritten', count() > 0 FROM
+(
+    EXPLAIN actions = 1 SELECT count() FROM tab WHERE has(tokens_a, 'host')
+)
+WHERE explain LIKE '%__text_index_idx_tokens_a_has%';
+
+DROP TABLE tab;


### PR DESCRIPTION

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added support for `ALIAS` columns in text index direct read optimization.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1041`
<!-- ch-version-info:end -->