### PR TITLE
keeper-bench: fall back to manual recursive remove when server lacks REMOVE_RECURSIVE

### DIFF
--- a/programs/keeper-bench/README.md
+++ b/programs/keeper-bench/README.md
@@ -103,6 +103,7 @@ Config can be YAML or XML.
 | `pipeline_depth` | integer | `1` | In-flight async requests per worker (`>= 1`) |
 | `warmup_seconds` | float | `0` | Measurement warmup window |
 | `enable_tracing` | bool | `false` | Attach OpenTelemetry trace context |
+| `use_remove_recursive` | bool | `true` | Use the native `RemoveRecursive` Keeper request for cleanup; falls back to a manual recursive traversal if the server does not advertise the `REMOVE_RECURSIVE` feature flag or if this is set to `false` (needed for ZooKeeper or older Keeper versions) |
 | `connections` | object | required if `--hosts` absent | Keeper endpoints and connection settings |
 | `setup` | object | optional | Data tree created before run |
 | `generator` | object | optional | Request generator (enables generated mode) |
@@ -200,6 +201,10 @@ warmup_seconds: 5
 
 # attach OpenTelemetry tracing context to requests (default: false)
 enable_tracing: false
+
+# use the native `RemoveRecursive` Keeper request to wipe setup roots; set to
+# false for ZooKeeper or older Keeper servers that do not support it (default: true)
+use_remove_recursive: true
 ```
 
 ---

--- a/programs/keeper-bench/Runner.cpp
+++ b/programs/keeper-bench/Runner.cpp
@@ -1461,20 +1461,54 @@ void addToBatchAndMaybeFlush(Coordination::ZooKeeper & zookeeper, Coordination::
     }
 }
 
-void removeRecursive(Coordination::ZooKeeper & zookeeper, const std::string & path)
+void removeRecursiveManual(Coordination::ZooKeeper & zookeeper, const std::string & path, Coordination::Requests & batch)
 {
+    namespace fs = std::filesystem;
+
     auto promise = std::make_shared<std::promise<Coordination::Error>>();
     auto future = promise->get_future();
-    zookeeper.removeRecursive(path, /*remove_nodes_limit=*/ 100000000,
-        [promise](const Coordination::RemoveRecursiveResponse & response)
-        {
-            promise->set_value(response.error);
-        });
+
+    Strings children;
+    auto list_callback = [promise, &children](const Coordination::ListResponse & response)
+    {
+        children = response.names;
+        promise->set_value(response.error);
+    };
+    zookeeper.list(path, Coordination::ListRequestType::ALL, list_callback, {}, false, false);
     auto error = future.get();
     if (error == Coordination::Error::ZNONODE)
         return;
     if (error != Coordination::Error::ZOK)
-        throw zkutil::KeeperException(error, "Failed to recursively remove {}", path);
+        throw zkutil::KeeperException(error, "Failed to list children of {}", path);
+
+    for (const auto & child : children)
+        removeRecursiveManual(zookeeper, fs::path(path) / child, batch);
+
+    addToBatchAndMaybeFlush(zookeeper, batch, zkutil::makeRemoveRequest(path, -1));
+}
+
+void removeRecursive(Coordination::ZooKeeper & zookeeper, const std::string & path, bool allow_native)
+{
+    if (allow_native && zookeeper.isFeatureEnabled(DB::KeeperFeatureFlag::REMOVE_RECURSIVE))
+    {
+        auto promise = std::make_shared<std::promise<Coordination::Error>>();
+        auto future = promise->get_future();
+        zookeeper.removeRecursive(path, /*remove_nodes_limit=*/ 100000000,
+            [promise](const Coordination::RemoveRecursiveResponse & response)
+            {
+                promise->set_value(response.error);
+            });
+        auto error = future.get();
+        if (error == Coordination::Error::ZNONODE)
+            return;
+        if (error != Coordination::Error::ZOK)
+            throw zkutil::KeeperException(error, "Failed to recursively remove {}", path);
+        return;
+    }
+
+    Coordination::Requests batch;
+    removeRecursiveManual(zookeeper, path, batch);
+    flushMulti(zookeeper, batch);
 }
 
 }
@@ -1482,6 +1516,8 @@ void removeRecursive(Coordination::ZooKeeper & zookeeper, const std::string & pa
 void BenchmarkContext::initializeFromConfig(const Poco::Util::AbstractConfiguration & config)
 {
     default_acls = getDefaultACLs();
+
+    use_remove_recursive = config.getBool("use_remove_recursive", true);
 
     std::cerr << "---- Parsing setup ---- " << std::endl;
     static const std::string setup_key = "setup";
@@ -1621,7 +1657,7 @@ void BenchmarkContext::startup(Coordination::ZooKeeper & zookeeper)
 
         std::string root_path = std::filesystem::path("/") / node_name;
         std::cerr << "Cleaning up " << root_path << std::endl;
-        removeRecursive(zookeeper, root_path);
+        removeRecursive(zookeeper, root_path, use_remove_recursive);
 
         Coordination::Requests batch;
         node->createNodes(zookeeper, batch, "/", default_acls, tagged_paths);
@@ -1649,6 +1685,6 @@ void BenchmarkContext::cleanup(Coordination::ZooKeeper & zookeeper)
         auto node_name = node->name.getString();
         std::string root_path = std::filesystem::path("/") / node_name;
         std::cerr << "Cleaning up " << root_path << std::endl;
-        removeRecursive(zookeeper, root_path);
+        removeRecursive(zookeeper, root_path, use_remove_recursive);
     }
 }

--- a/programs/keeper-bench/Runner.h
+++ b/programs/keeper-bench/Runner.h
@@ -54,6 +54,7 @@ private:
     std::vector<std::shared_ptr<Node>> root_nodes;
     Coordination::ACLs default_acls;
     TaggedPaths tagged_paths;
+    bool use_remove_recursive = true;
 };
 
 class Runner


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

---

#### Description

PR #101801 (`keeper-bench: more features`) switched `keeper-bench` setup/cleanup to the native `RemoveRecursive` Keeper request. That request is only supported by ClickHouse Keeper versions that advertise the `REMOVE_RECURSIVE` feature flag, so running `keeper-bench` against plain ZooKeeper or an older Keeper fails with ``RemoveRecursive request type cannot be used because it's not supported by the server``.

This PR restores the pre-#101801 fallback:

- The cleanup path checks `Coordination::ZooKeeper::isFeatureEnabled(REMOVE_RECURSIVE)`. If the feature flag is enabled, the native `removeRecursive` is used (fast path introduced in #101801). Otherwise, the previous manual implementation — `list` each subtree, then batched `multi(remove)` — is used.
- A new top-level config option `use_remove_recursive` (default `true`) lets users force the manual path even against a Keeper that supports the native request.

The config option and behavior are documented in `programs/keeper-bench/README.md`.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.118`
<!-- ch-version-info:end -->