### PR TITLE
Add integration tests for AI functions

### DIFF
--- a/tests/integration/test_ai_functions/mock_ai_server.py
+++ b/tests/integration/test_ai_functions/mock_ai_server.py
@@ -26,7 +26,7 @@ import http.server
 import json
 from urllib.parse import urlparse
 
-MOCK_PORT = 9123
+MOCK_PORT = 18123
 DEFAULT_EMBED_DIM = 4
 
 # Single-threaded `HTTPServer` handles one request at a time, so a plain dict is safe.

--- a/tests/integration/test_ai_functions/mock_ai_server.py
+++ b/tests/integration/test_ai_functions/mock_ai_server.py
@@ -1,0 +1,133 @@
+"""
+Mock OpenAI-compatible HTTP server for AI function integration tests.
+
+Endpoints:
+  GET  /health                  — readiness probe, returns "OK"
+  POST /v1/chat/completions     — returns response based on request content:
+      - If response_format with json_schema is present, returns JSON matching the schema
+        with values derived from the user message.
+      - Otherwise echoes the user message as plain text.
+      Fixed tokens: 10 input, 5 output.
+  POST /v1/error                — always returns HTTP 500
+"""
+
+import http.server
+import json
+from urllib.parse import urlparse
+
+MOCK_PORT = 9123
+
+
+def extract_user_message(body):
+    data = json.loads(body)
+    messages = data.get("messages", [])
+    for msg in reversed(messages):
+        if msg.get("role") == "user":
+            return msg.get("content", "")
+    return ""
+
+
+def extract_response_format(body):
+    """Extract the json_schema from response_format if present."""
+    data = json.loads(body)
+    rf = data.get("response_format")
+    if not rf or rf.get("type") != "json_schema":
+        return None
+    return rf.get("json_schema", {})
+
+
+def build_structured_response(json_schema, user_message):
+    """Build a JSON response matching the schema, using the user message as values."""
+    schema = json_schema.get("schema", {})
+    properties = schema.get("properties", {})
+
+    result = {}
+    for key, prop in properties.items():
+        prop_type = prop.get("type", "string")
+        if "enum" in prop:
+            # For classification: return the first enum value
+            result[key] = prop["enum"][0]
+        elif isinstance(prop_type, list):
+            # e.g. ["string", "null"] — return the user message
+            result[key] = user_message
+        else:
+            result[key] = user_message
+
+    return json.dumps(result)
+
+
+def make_success_response(content, prompt_tokens=10, completion_tokens=5):
+    return {
+        "choices": [
+            {
+                "message": {"content": content},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+        },
+    }
+
+
+def make_error_response(message, error_type="server_error"):
+    return {"error": {"message": message, "type": error_type}}
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        parsed = urlparse(self.path)
+
+        if parsed.path == "/health":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"OK")
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+    def do_POST(self):
+        parsed = urlparse(self.path)
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length).decode("utf-8") if content_length else ""
+
+        if parsed.path == "/v1/chat/completions":
+            user_msg = extract_user_message(body)
+            json_schema = extract_response_format(body)
+
+            if json_schema:
+                content = build_structured_response(json_schema, user_msg)
+            else:
+                content = user_msg
+
+            self._send_json(200, make_success_response(content))
+            return
+
+        if parsed.path == "/v1/error":
+            self._send_json(500, make_error_response("permanent failure"))
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+    def _send_json(self, status, obj):
+        body = json.dumps(obj).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        pass  # suppress request logs
+
+
+if __name__ == "__main__":
+    server = http.server.HTTPServer(("0.0.0.0", MOCK_PORT), Handler)
+    try:
+        server.serve_forever()
+    finally:
+        server.server_close()

--- a/tests/integration/test_ai_functions/mock_ai_server.py
+++ b/tests/integration/test_ai_functions/mock_ai_server.py
@@ -27,10 +27,10 @@ import json
 from urllib.parse import urlparse
 
 MOCK_PORT = 9123
+DEFAULT_EMBED_DIM = 4
 
 # Single-threaded `HTTPServer` handles one request at a time, so a plain dict is safe.
 LAST_REQUEST = {"path": None, "body": None}
-DEFAULT_EMBED_DIM = 4
 
 
 def extract_user_message(body):

--- a/tests/integration/test_ai_functions/mock_ai_server.py
+++ b/tests/integration/test_ai_functions/mock_ai_server.py
@@ -2,13 +2,24 @@
 Mock OpenAI-compatible HTTP server for AI function integration tests.
 
 Endpoints:
-  GET  /health                  — readiness probe, returns "OK"
-  POST /v1/chat/completions     — returns response based on request content:
+  GET  /health                       — readiness probe, returns "OK"
+  GET  /last-request                 — returns JSON `{"path": ..., "body": ...}` of the most
+      recent POST received, so tests can assert on request contents (e.g. that
+      `aiTranslate`'s `instructions` argument is forwarded in the prompt).
+  POST /v1/chat/completions          — returns response based on request content:
       - If response_format with json_schema is present, returns JSON matching the schema
         with values derived from the user message.
       - Otherwise echoes the user message as plain text.
       Fixed tokens: 10 input, 5 output.
-  POST /v1/error                — always returns HTTP 500
+  POST /v1/embeddings                — returns one deterministic embedding per input.
+      Honors `dimensions` if provided, otherwise returns DEFAULT_EMBED_DIM floats.
+      `prompt_tokens` = sum of input character lengths.
+  POST /v1/embeddings_dup_index      — like `/v1/embeddings` but reuses `index` 0 for every
+      element, exercising the duplicate-index rejection path.
+  POST /v1/embeddings_wrong_count    — returns one fewer entry than requested, exercising the
+      cardinality mismatch path.
+  POST /v1/error                     — always returns HTTP 500 (used for chat completion errors)
+  POST /v1/embeddings_error          — always returns HTTP 500 (used for embedding errors)
 """
 
 import http.server
@@ -16,6 +27,10 @@ import json
 from urllib.parse import urlparse
 
 MOCK_PORT = 9123
+
+# Single-threaded `HTTPServer` handles one request at a time, so a plain dict is safe.
+LAST_REQUEST = {"path": None, "body": None}
+DEFAULT_EMBED_DIM = 4
 
 
 def extract_user_message(body):
@@ -43,13 +58,9 @@ def build_structured_response(json_schema, user_message):
 
     result = {}
     for key, prop in properties.items():
-        prop_type = prop.get("type", "string")
         if "enum" in prop:
             # For classification: return the first enum value
             result[key] = prop["enum"][0]
-        elif isinstance(prop_type, list):
-            # e.g. ["string", "null"] — return the user message
-            result[key] = user_message
         else:
             result[key] = user_message
 
@@ -75,6 +86,46 @@ def make_error_response(message, error_type="server_error"):
     return {"error": {"message": message, "type": error_type}}
 
 
+def make_embedding_vector(text, dim):
+    """Return a deterministic float vector for `text` of length `dim`.
+
+    Values depend on text content so different inputs produce different vectors.
+    An empty `text` is supported (the function caller filters those out, but the
+    server should not crash if one slips through).
+    """
+    if not text:
+        return [0.0] * dim
+    return [round(((ord(text[i % len(text)]) * (i + 1)) % 1000) / 1000.0, 3) for i in range(dim)]
+
+
+def make_embeddings_response(body, *, duplicate_index=False, drop_last=False):
+    data = json.loads(body)
+    inputs = data.get("input", [])
+    if isinstance(inputs, str):
+        inputs = [inputs]
+    dim = int(data.get("dimensions") or 0) or DEFAULT_EMBED_DIM
+
+    items = []
+    for i, text in enumerate(inputs):
+        items.append({
+            "object": "embedding",
+            "index": 0 if duplicate_index else i,
+            "embedding": make_embedding_vector(text, dim),
+        })
+    if drop_last and items:
+        items.pop()
+
+    return {
+        "object": "list",
+        "data": items,
+        "model": data.get("model", "test-embed-model"),
+        "usage": {
+            "prompt_tokens": sum(len(t) for t in inputs),
+            "total_tokens": sum(len(t) for t in inputs),
+        },
+    }
+
+
 class Handler(http.server.BaseHTTPRequestHandler):
     def do_GET(self):
         parsed = urlparse(self.path)
@@ -86,6 +137,10 @@ class Handler(http.server.BaseHTTPRequestHandler):
             self.wfile.write(b"OK")
             return
 
+        if parsed.path == "/last-request":
+            self._send_json(200, LAST_REQUEST)
+            return
+
         self.send_response(404)
         self.end_headers()
 
@@ -93,6 +148,9 @@ class Handler(http.server.BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         content_length = int(self.headers.get("Content-Length", 0))
         body = self.rfile.read(content_length).decode("utf-8") if content_length else ""
+
+        LAST_REQUEST["path"] = parsed.path
+        LAST_REQUEST["body"] = body
 
         if parsed.path == "/v1/chat/completions":
             user_msg = extract_user_message(body)
@@ -108,6 +166,22 @@ class Handler(http.server.BaseHTTPRequestHandler):
 
         if parsed.path == "/v1/error":
             self._send_json(500, make_error_response("permanent failure"))
+            return
+
+        if parsed.path == "/v1/embeddings":
+            self._send_json(200, make_embeddings_response(body))
+            return
+
+        if parsed.path == "/v1/embeddings_dup_index":
+            self._send_json(200, make_embeddings_response(body, duplicate_index=True))
+            return
+
+        if parsed.path == "/v1/embeddings_wrong_count":
+            self._send_json(200, make_embeddings_response(body, drop_last=True))
+            return
+
+        if parsed.path == "/v1/embeddings_error":
+            self._send_json(500, make_error_response("embedding failure"))
             return
 
         self.send_response(404)

--- a/tests/integration/test_ai_functions/mock_ai_server.py
+++ b/tests/integration/test_ai_functions/mock_ai_server.py
@@ -3,9 +3,11 @@ Mock OpenAI-compatible HTTP server for AI function integration tests.
 
 Endpoints:
   GET  /health                       — readiness probe, returns "OK"
-  GET  /last-request                 — returns JSON `{"path": ..., "body": ...}` of the most
-      recent POST received, so tests can assert on request contents (e.g. that
-      `aiTranslate`'s `instructions` argument is forwarded in the prompt).
+  GET  /last-request                 — returns JSON `{"path": ..., "body": ..., "headers": ...}`
+      of the most recent POST received, so tests can assert on request contents (e.g. that
+      `aiTranslate`'s `instructions` argument is forwarded in the prompt, or that the
+      `Authorization` header is omitted when the named collection has no `api_key`).
+      Header names are lower-cased for case-insensitive lookup.
   POST /v1/chat/completions          — returns response based on request content:
       - If response_format with json_schema is present, returns JSON matching the schema
         with values derived from the user message.
@@ -30,7 +32,7 @@ MOCK_PORT = 18123
 DEFAULT_EMBED_DIM = 4
 
 # Single-threaded `HTTPServer` handles one request at a time, so a plain dict is safe.
-LAST_REQUEST = {"path": None, "body": None}
+LAST_REQUEST = {"path": None, "body": None, "headers": {}}
 
 
 def extract_user_message(body):
@@ -151,6 +153,7 @@ class Handler(http.server.BaseHTTPRequestHandler):
 
         LAST_REQUEST["path"] = parsed.path
         LAST_REQUEST["body"] = body
+        LAST_REQUEST["headers"] = {k.lower(): v for k, v in self.headers.items()}
 
         if parsed.path == "/v1/chat/completions":
             user_msg = extract_user_message(body)

--- a/tests/integration/test_ai_functions/test.py
+++ b/tests/integration/test_ai_functions/test.py
@@ -15,7 +15,7 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import wait_condition
 
-MOCK_PORT = 9123
+MOCK_PORT = 18123
 AI_SETTINGS = {"allow_experimental_ai_functions": 1}
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -359,13 +359,8 @@ def test_translate_multiple_rows(started_cluster):
 def test_translate_with_instructions(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
     instance.query("INSERT INTO test_input VALUES ('Hello')")
-    # Sentinels make this test order-independent against the shared `LAST_REQUEST`
-    # state: even if another request hits the mock between our query and the
-    # /last-request fetch, we can detect it by the missing sentinel.
-    lang_marker = f"LangMarker_{uuid.uuid4().hex[:8]}"
-    instr_marker = f"InstrMarker_{uuid.uuid4().hex[:8]}"
     result = instance.query(
-        f"SELECT aiTranslate('ai_mock', x, '{lang_marker}', '{instr_marker}') FROM test_input",
+        "SELECT aiTranslate('ai_mock', x, 'German', 'Use formal tone') FROM test_input",
         settings=AI_SETTINGS,
     )
     assert result.strip() == "Hello"
@@ -377,8 +372,8 @@ def test_translate_with_instructions(started_cluster):
     )
     assert last["path"] == "/v1/chat/completions"
     sent = last["body"]
-    assert lang_marker in sent, f"target language not in request body: {sent!r}"
-    assert instr_marker in sent, f"instructions not in request body: {sent!r}"
+    assert "German" in sent
+    assert "Use formal tone" in sent
 
 
 def test_translate_profile_events(started_cluster):

--- a/tests/integration/test_ai_functions/test.py
+++ b/tests/integration/test_ai_functions/test.py
@@ -146,8 +146,6 @@ def started_cluster() -> typing.Generator[ClickHouseCluster, None, None]:
 
 
 def test_generate_content_basic(started_cluster):
-    instance.query("TRUNCATE TABLE test_input")
-    instance.query("INSERT INTO test_input VALUES ('hello world')")
     result = instance.query(
         "SELECT aiGenerate('ai_mock', 'hello world')",
         settings=AI_SETTINGS,
@@ -478,10 +476,12 @@ def test_embed_null_and_empty_input(started_cluster):
     assert non_empties == 1
 
     events = get_profile_events(qid)
-    # Only the single non-empty row triggers an API call; NULL/'' are skipped.
+    # Only the single non-empty row triggers an API call; NULL/'' are pre-filtered
+    # and contribute to neither `rows_processed` nor `rows_skipped` (the latter is
+    # reserved for rows that received a default value due to quota or error).
     assert int(events["api_calls"]) == 1
     assert int(events["rows_processed"]) == 1
-    assert int(events["rows_skipped"]) == 2
+    assert int(events["rows_skipped"]) == 0
 
 
 def test_embed_profile_events_token_accounting(started_cluster):
@@ -605,3 +605,7 @@ def test_embed_quota_input_tokens_exceeded(started_cluster):
     assert sum(1 for r in rows if not r) == 3
     events = get_profile_events(qid)
     assert int(events["api_calls"]) == 1
+    # Quota-aborted live rows count as `rows_skipped` — they received a default
+    # value due to a quota cut, matching the documented `AIRowsSkipped` semantics.
+    assert int(events["rows_processed"]) == 1
+    assert int(events["rows_skipped"]) == 3

--- a/tests/integration/test_ai_functions/test.py
+++ b/tests/integration/test_ai_functions/test.py
@@ -2,7 +2,7 @@
 Integration tests for AI function execution paths.
 
 Tests the row-processing loop against a mock OpenAI-compatible HTTP server
-for aiGenerateContent, aiClassify, aiExtract, and aiTranslate.
+for aiGenerate, aiClassify, aiExtract, and aiTranslate.
 """
 
 import json
@@ -32,7 +32,7 @@ def run_mock_server():
         [
             "bash",
             "-c",
-            f"python3 /mock_ai_server.py > /var/log/clickhouse-server/mock_ai_server.log 2>&1",
+            "python3 /mock_ai_server.py > /var/log/clickhouse-server/mock_ai_server.log 2>&1",
         ],
         detach=True,
         user="root",
@@ -64,8 +64,6 @@ def get_profile_events(query_id):
             ProfileEvents['AIRowsSkipped'] AS rows_skipped
         FROM system.query_log
         WHERE query_id = '{query_id}' AND type = 'QueryFinish'
-        ORDER BY event_time_microseconds DESC
-        LIMIT 1
         FORMAT JSONEachRow
         """
     )
@@ -92,6 +90,34 @@ def started_cluster() -> typing.Generator[ClickHouseCluster, None, None]:
             f"model = 'test-model', "
             f"api_key = 'test-key'"
         )
+        instance.query(
+            f"CREATE NAMED COLLECTION ai_embed AS "
+            f"provider = 'openai', "
+            f"endpoint = 'http://localhost:{MOCK_PORT}/v1/embeddings', "
+            f"model = 'test-embed-model', "
+            f"api_key = 'test-key'"
+        )
+        instance.query(
+            f"CREATE NAMED COLLECTION ai_embed_error AS "
+            f"provider = 'openai', "
+            f"endpoint = 'http://localhost:{MOCK_PORT}/v1/embeddings_error', "
+            f"model = 'test-embed-model', "
+            f"api_key = 'test-key'"
+        )
+        instance.query(
+            f"CREATE NAMED COLLECTION ai_embed_dup_index AS "
+            f"provider = 'openai', "
+            f"endpoint = 'http://localhost:{MOCK_PORT}/v1/embeddings_dup_index', "
+            f"model = 'test-embed-model', "
+            f"api_key = 'test-key'"
+        )
+        instance.query(
+            f"CREATE NAMED COLLECTION ai_embed_wrong_count AS "
+            f"provider = 'openai', "
+            f"endpoint = 'http://localhost:{MOCK_PORT}/v1/embeddings_wrong_count', "
+            f"model = 'test-embed-model', "
+            f"api_key = 'test-key'"
+        )
 
         instance.query("CREATE TABLE test_input (x String) ENGINE = Memory")
         instance.query(
@@ -104,7 +130,7 @@ def started_cluster() -> typing.Generator[ClickHouseCluster, None, None]:
 
 
 # ---------------------------------------------------------------------------
-# aiGenerateContent
+# aiGenerate
 # ---------------------------------------------------------------------------
 
 
@@ -112,7 +138,7 @@ def test_generate_content_basic(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
     instance.query("INSERT INTO test_input VALUES ('hello world')")
     result = instance.query(
-        "SELECT aiGenerateContent('ai_mock', 'hello world')",
+        "SELECT aiGenerate('ai_mock', 'hello world')",
         settings=AI_SETTINGS,
     )
     assert result.strip() == "hello world"
@@ -122,7 +148,7 @@ def test_generate_content_multiple_rows(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
     instance.query("INSERT INTO test_input VALUES ('row1'), ('row2'), ('row3')")
     result = instance.query(
-        "SELECT aiGenerateContent('ai_mock', x) FROM test_input ORDER BY x",
+        "SELECT aiGenerate('ai_mock', x) FROM test_input ORDER BY x",
         settings=AI_SETTINGS,
     )
     assert result.strip().split("\n") == ["row1", "row2", "row3"]
@@ -133,7 +159,7 @@ def test_generate_content_profile_events(started_cluster):
     instance.query("INSERT INTO test_input VALUES ('a'), ('b'), ('c')")
     qid = unique_query_id("gen_content_events")
     instance.query(
-        "SELECT aiGenerateContent('ai_mock', x) FROM test_input",
+        "SELECT aiGenerate('ai_mock', x) FROM test_input",
         settings=AI_SETTINGS,
         query_id=qid,
     )
@@ -151,7 +177,7 @@ def test_generate_content_null_input(started_cluster):
         "INSERT INTO test_input_nullable VALUES (NULL), ('hello'), (NULL)"
     )
     result = instance.query(
-        "SELECT aiGenerateContent('ai_mock', x) FROM test_input_nullable",
+        "SELECT aiGenerate('ai_mock', x) FROM test_input_nullable",
         settings=AI_SETTINGS,
     )
     lines = result.strip().split("\n")
@@ -161,7 +187,7 @@ def test_generate_content_null_input(started_cluster):
 
 def test_generate_content_error_throw(started_cluster):
     error = instance.query_and_get_error(
-        "SELECT aiGenerateContent('ai_error', 'hello')",
+        "SELECT aiGenerate('ai_error', 'hello')",
         settings=AI_SETTINGS,
     )
     assert "RECEIVED_ERROR_FROM_REMOTE_IO_SERVER" in error
@@ -169,7 +195,7 @@ def test_generate_content_error_throw(started_cluster):
 
 def test_generate_content_error_graceful(started_cluster):
     result = instance.query(
-        "SELECT aiGenerateContent('ai_error', 'hello')",
+        "SELECT aiGenerate('ai_error', 'hello')",
         settings={**AI_SETTINGS, "ai_function_throw_on_error": 0},
     )
     assert result.strip() == ""
@@ -230,6 +256,7 @@ def test_classify_null_input(started_cluster):
         settings=AI_SETTINGS,
     )
     lines = result.strip().split("\n")
+    assert len(lines) == 2
     assert "\\N" in lines
     assert "a" in lines
 
@@ -329,6 +356,17 @@ def test_translate_with_instructions(started_cluster):
     )
     assert result.strip() == "Hello"
 
+    last = json.loads(
+        instance.exec_in_container(
+            ["curl", "-s", f"http://localhost:{MOCK_PORT}/last-request"]
+        )
+    )
+    assert last["path"] == "/v1/chat/completions"
+    # Both the target language and the extra instructions must reach the prompt.
+    sent = last["body"]
+    assert "German" in sent
+    assert "Use formal tone" in sent
+
 
 def test_translate_profile_events(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
@@ -354,3 +392,201 @@ def test_translate_null_input(started_cluster):
     lines = result.strip().split("\n")
     assert "\\N" in lines
     assert "hello" in lines
+
+
+# ---------------------------------------------------------------------------
+# aiEmbed
+# ---------------------------------------------------------------------------
+
+
+def parse_embedding(s):
+    """Parse a TabSeparated `Array(Float32)` cell like '[0.1,0.2,0.3]' into a list."""
+    s = s.strip()
+    if not s or s == "[]":
+        return []
+    return [float(v) for v in s.strip("[]").split(",")]
+
+
+def test_embed_basic(started_cluster):
+    """Single-row aiEmbed returns an `Array(Float32)` of the model's native size."""
+    result = instance.query(
+        "SELECT aiEmbed('ai_embed', 'hello')",
+        settings=AI_SETTINGS,
+    )
+    vec = parse_embedding(result)
+    assert len(vec) == 4  # DEFAULT_EMBED_DIM in mock server
+    assert any(v != 0.0 for v in vec)
+
+
+def test_embed_multiple_rows(started_cluster):
+    """Multiple rows go through one batched request; each row gets its own vector."""
+    instance.query("TRUNCATE TABLE test_input")
+    instance.query("INSERT INTO test_input VALUES ('alpha'), ('beta'), ('gamma')")
+    result = instance.query(
+        "SELECT aiEmbed('ai_embed', x) FROM test_input ORDER BY x",
+        settings=AI_SETTINGS,
+    )
+    rows = [parse_embedding(line) for line in result.strip().split("\n")]
+    assert len(rows) == 3
+    assert all(len(v) == 4 for v in rows)
+    # Different inputs should yield different vectors (mock uses input bytes).
+    assert len({tuple(v) for v in rows}) == 3
+
+
+def test_embed_with_dimensions(started_cluster):
+    """The `dimensions` argument is forwarded to the provider and honored in the response."""
+    result = instance.query(
+        "SELECT aiEmbed('ai_embed', 'hello world', 16)",
+        settings=AI_SETTINGS,
+    )
+    vec = parse_embedding(result)
+    assert len(vec) == 16
+
+
+def test_embed_null_and_empty_input(started_cluster):
+    """`NULL` and empty-string inputs map to `[]` without making an API call."""
+    instance.query("TRUNCATE TABLE test_input_nullable")
+    instance.query(
+        "INSERT INTO test_input_nullable VALUES (NULL), (''), ('hi')"
+    )
+    qid = unique_query_id("embed_null_empty")
+    result = instance.query(
+        "SELECT aiEmbed('ai_embed', x) FROM test_input_nullable ORDER BY x NULLS FIRST",
+        settings=AI_SETTINGS,
+        query_id=qid,
+    )
+    rows = [parse_embedding(line) for line in result.strip().split("\n")]
+    assert len(rows) == 3
+    empties = sum(1 for v in rows if v == [])
+    non_empties = sum(1 for v in rows if v)
+    assert empties == 2
+    assert non_empties == 1
+
+    events = get_profile_events(qid)
+    # Only the single non-empty row triggers an API call; NULL/'' are skipped.
+    assert int(events["api_calls"]) == 1
+    assert int(events["rows_processed"]) == 1
+    assert int(events["rows_skipped"]) == 2
+
+
+def test_embed_profile_events_token_accounting(started_cluster):
+    """`AIInputTokens` accumulates across rows. Mock reports `prompt_tokens = sum(len(inputs))`."""
+    instance.query("TRUNCATE TABLE test_input")
+    instance.query("INSERT INTO test_input VALUES ('abc'), ('de'), ('fghi')")
+    qid = unique_query_id("embed_tokens")
+    instance.query(
+        "SELECT aiEmbed('ai_embed', x) FROM test_input",
+        settings=AI_SETTINGS,
+        query_id=qid,
+    )
+    events = get_profile_events(qid)
+    # All three rows fit in one batched call (default batch size is 100).
+    assert int(events["api_calls"]) == 1
+    assert int(events["input_tokens"]) == 3 + 2 + 4
+    assert int(events["rows_processed"]) == 3
+    assert int(events["rows_skipped"]) == 0
+
+
+def test_embed_batching(started_cluster):
+    """`ai_function_embedding_max_batch_size` splits inputs across HTTP calls."""
+    instance.query("TRUNCATE TABLE test_input")
+    instance.query(
+        "INSERT INTO test_input SELECT 'row_' || toString(number) FROM numbers(5)"
+    )
+    qid = unique_query_id("embed_batch")
+    instance.query(
+        "SELECT aiEmbed('ai_embed', x) FROM test_input",
+        settings={**AI_SETTINGS, "ai_function_embedding_max_batch_size": 2},
+        query_id=qid,
+    )
+    events = get_profile_events(qid)
+    # 5 rows / batch of 2 -> ceil(5/2) = 3 HTTP calls.
+    assert int(events["api_calls"]) == 3
+    assert int(events["rows_processed"]) == 5
+    assert int(events["rows_skipped"]) == 0
+
+
+def test_embed_error_throw(started_cluster):
+    """By default, provider errors propagate as `RECEIVED_ERROR_FROM_REMOTE_IO_SERVER`."""
+    error = instance.query_and_get_error(
+        "SELECT aiEmbed('ai_embed_error', 'hello')",
+        settings=AI_SETTINGS,
+    )
+    assert "RECEIVED_ERROR_FROM_REMOTE_IO_SERVER" in error
+
+
+def test_embed_error_graceful(started_cluster):
+    """With `ai_function_throw_on_error = 0` the failed batch's rows become `[]`."""
+    instance.query("TRUNCATE TABLE test_input")
+    instance.query("INSERT INTO test_input VALUES ('a'), ('b')")
+    result = instance.query(
+        "SELECT aiEmbed('ai_embed_error', x) FROM test_input",
+        settings={
+            **AI_SETTINGS,
+            "ai_function_throw_on_error": 0,
+            "ai_function_max_retries": 0,
+        },
+    )
+    rows = [parse_embedding(line) for line in result.strip().split("\n")]
+    assert rows == [[], []]
+
+
+def test_embed_duplicate_index_rejected(started_cluster):
+    """`OpenAIProvider::embed` rejects responses with duplicate `index` values."""
+    error = instance.query_and_get_error(
+        "SELECT aiEmbed('ai_embed_dup_index', x) FROM (SELECT arrayJoin(['a', 'b']) AS x)",
+        settings={**AI_SETTINGS, "ai_function_max_retries": 0},
+    )
+    assert "RECEIVED_ERROR_FROM_REMOTE_IO_SERVER" in error
+    assert "duplicates" in error or "duplicate" in error.lower()
+
+
+def test_embed_wrong_count_rejected(started_cluster):
+    """`OpenAIProvider::embed` rejects responses whose `data` size != number of inputs."""
+    error = instance.query_and_get_error(
+        "SELECT aiEmbed('ai_embed_wrong_count', x) FROM (SELECT arrayJoin(['a', 'b']) AS x)",
+        settings={**AI_SETTINGS, "ai_function_max_retries": 0},
+    )
+    assert "RECEIVED_ERROR_FROM_REMOTE_IO_SERVER" in error
+
+
+def test_embed_empty_input_table(started_cluster):
+    """Zero-row input must not make any API calls."""
+    instance.query("TRUNCATE TABLE test_input")
+    qid = unique_query_id("embed_zero_rows")
+    result = instance.query(
+        "SELECT aiEmbed('ai_embed', x) FROM test_input",
+        settings=AI_SETTINGS,
+        query_id=qid,
+    )
+    assert result.strip() == ""
+    events = get_profile_events(qid)
+    assert int(events["api_calls"]) == 0
+    assert int(events["rows_processed"]) == 0
+
+
+def test_embed_quota_input_tokens_exceeded(started_cluster):
+    """When the input-token quota is exceeded, remaining batches are skipped."""
+    instance.query("TRUNCATE TABLE test_input")
+    instance.query(
+        "INSERT INTO test_input SELECT 'row_' || toString(number) FROM numbers(4)"
+    )
+    qid = unique_query_id("embed_quota")
+    # Each batch costs `sum(len(text))` input tokens. With batch_size=1 and rows
+    # of length 5 ("row_0".."row_3"), the second batch pushes us over a 5-token cap.
+    result = instance.query(
+        "SELECT aiEmbed('ai_embed', x) FROM test_input",
+        settings={
+            **AI_SETTINGS,
+            "ai_function_embedding_max_batch_size": 1,
+            "ai_function_max_input_tokens_per_query": 5,
+            "ai_function_throw_on_quota_exceeded": 0,
+        },
+        query_id=qid,
+    )
+    rows = [parse_embedding(line) for line in result.strip().split("\n")]
+    # First batch succeeds, remaining batches are aborted and produce [].
+    assert sum(1 for r in rows if r) == 1
+    assert sum(1 for r in rows if not r) == 3
+    events = get_profile_events(qid)
+    assert int(events["api_calls"]) == 1

--- a/tests/integration/test_ai_functions/test.py
+++ b/tests/integration/test_ai_functions/test.py
@@ -1,0 +1,356 @@
+"""
+Integration tests for AI function execution paths.
+
+Tests the row-processing loop against a mock OpenAI-compatible HTTP server
+for aiGenerateContent, aiClassify, aiExtract, and aiTranslate.
+"""
+
+import json
+import os
+import typing
+import uuid
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import wait_condition
+
+MOCK_PORT = 9123
+AI_SETTINGS = {"allow_experimental_ai_functions": 1}
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+
+cluster = ClickHouseCluster(__file__)
+instance = cluster.add_instance("node")
+
+
+def run_mock_server():
+    instance.copy_file_to_container(
+        os.path.join(SCRIPT_DIR, "mock_ai_server.py"),
+        "/mock_ai_server.py",
+    )
+    instance.exec_in_container(
+        [
+            "bash",
+            "-c",
+            f"python3 /mock_ai_server.py > /var/log/clickhouse-server/mock_ai_server.log 2>&1",
+        ],
+        detach=True,
+        user="root",
+    )
+    wait_condition(
+        lambda: instance.exec_in_container(
+            ["curl", "-s", f"http://localhost:{MOCK_PORT}/health"],
+            nothrow=True,
+        ),
+        lambda r: r == "OK",
+        max_attempts=20,
+        delay=0.5,
+    )
+
+
+def unique_query_id(prefix):
+    return f"{prefix}_{uuid.uuid4().hex[:8]}"
+
+
+def get_profile_events(query_id):
+    instance.query("SYSTEM FLUSH LOGS")
+    result = instance.query(
+        f"""
+        SELECT
+            ProfileEvents['AIAPICalls'] AS api_calls,
+            ProfileEvents['AIInputTokens'] AS input_tokens,
+            ProfileEvents['AIOutputTokens'] AS output_tokens,
+            ProfileEvents['AIRowsProcessed'] AS rows_processed,
+            ProfileEvents['AIRowsSkipped'] AS rows_skipped
+        FROM system.query_log
+        WHERE query_id = '{query_id}' AND type = 'QueryFinish'
+        ORDER BY event_time_microseconds DESC
+        LIMIT 1
+        FORMAT JSONEachRow
+        """
+    )
+    return json.loads(result.strip())
+
+
+@pytest.fixture(scope="module")
+def started_cluster() -> typing.Generator[ClickHouseCluster, None, None]:
+    try:
+        cluster.start()
+        run_mock_server()
+
+        instance.query(
+            f"CREATE NAMED COLLECTION ai_mock AS "
+            f"provider = 'openai', "
+            f"endpoint = 'http://localhost:{MOCK_PORT}/v1/chat/completions', "
+            f"model = 'test-model', "
+            f"api_key = 'test-key'"
+        )
+        instance.query(
+            f"CREATE NAMED COLLECTION ai_error AS "
+            f"provider = 'openai', "
+            f"endpoint = 'http://localhost:{MOCK_PORT}/v1/error', "
+            f"model = 'test-model', "
+            f"api_key = 'test-key'"
+        )
+
+        instance.query("CREATE TABLE test_input (x String) ENGINE = Memory")
+        instance.query(
+            "CREATE TABLE test_input_nullable (x Nullable(String)) ENGINE = Memory"
+        )
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# aiGenerateContent
+# ---------------------------------------------------------------------------
+
+
+def test_generate_content_basic(started_cluster):
+    instance.query("TRUNCATE TABLE test_input")
+    instance.query("INSERT INTO test_input VALUES ('hello world')")
+    result = instance.query(
+        "SELECT aiGenerateContent('ai_mock', 'hello world')",
+        settings=AI_SETTINGS,
+    )
+    assert result.strip() == "hello world"
+
+
+def test_generate_content_multiple_rows(started_cluster):
+    instance.query("TRUNCATE TABLE test_input")
+    instance.query("INSERT INTO test_input VALUES ('row1'), ('row2'), ('row3')")
+    result = instance.query(
+        "SELECT aiGenerateContent('ai_mock', x) FROM test_input ORDER BY x",
+        settings=AI_SETTINGS,
+    )
+    assert result.strip().split("\n") == ["row1", "row2", "row3"]
+
+
+def test_generate_content_profile_events(started_cluster):
+    instance.query("TRUNCATE TABLE test_input")
+    instance.query("INSERT INTO test_input VALUES ('a'), ('b'), ('c')")
+    qid = unique_query_id("gen_content_events")
+    instance.query(
+        "SELECT aiGenerateContent('ai_mock', x) FROM test_input",
+        settings=AI_SETTINGS,
+        query_id=qid,
+    )
+    events = get_profile_events(qid)
+    assert int(events["api_calls"]) == 3
+    assert int(events["input_tokens"]) == 30  # 3 * 10
+    assert int(events["output_tokens"]) == 15  # 3 * 5
+    assert int(events["rows_processed"]) == 3
+    assert int(events["rows_skipped"]) == 0
+
+
+def test_generate_content_null_input(started_cluster):
+    instance.query("TRUNCATE TABLE test_input_nullable")
+    instance.query(
+        "INSERT INTO test_input_nullable VALUES (NULL), ('hello'), (NULL)"
+    )
+    result = instance.query(
+        "SELECT aiGenerateContent('ai_mock', x) FROM test_input_nullable",
+        settings=AI_SETTINGS,
+    )
+    lines = result.strip().split("\n")
+    assert lines.count("\\N") == 2
+    assert lines.count("hello") == 1
+
+
+def test_generate_content_error_throw(started_cluster):
+    error = instance.query_and_get_error(
+        "SELECT aiGenerateContent('ai_error', 'hello')",
+        settings=AI_SETTINGS,
+    )
+    assert "RECEIVED_ERROR_FROM_REMOTE_IO_SERVER" in error
+
+
+def test_generate_content_error_graceful(started_cluster):
+    result = instance.query(
+        "SELECT aiGenerateContent('ai_error', 'hello')",
+        settings={**AI_SETTINGS, "ai_function_throw_on_error": 0},
+    )
+    assert result.strip() == ""
+
+
+# ---------------------------------------------------------------------------
+# aiClassify
+# ---------------------------------------------------------------------------
+
+
+def test_classify_basic(started_cluster):
+    """aiClassify sends a response_format with enum constraint.
+    The mock returns the first enum value."""
+    instance.query("TRUNCATE TABLE test_input")
+    instance.query("INSERT INTO test_input VALUES ('I love this product!')")
+    result = instance.query(
+        "SELECT aiClassify('ai_mock', x, ['positive', 'negative', 'neutral']) FROM test_input",
+        settings=AI_SETTINGS,
+    )
+    # Mock returns first enum value; postProcessResponse extracts "category" from JSON
+    assert result.strip() == "positive"
+
+
+def test_classify_multiple_rows(started_cluster):
+    instance.query("TRUNCATE TABLE test_input")
+    instance.query(
+        "INSERT INTO test_input VALUES ('great'), ('terrible'), ('okay')"
+    )
+    result = instance.query(
+        "SELECT aiClassify('ai_mock', x, ['positive', 'negative', 'neutral']) FROM test_input",
+        settings=AI_SETTINGS,
+    )
+    lines = result.strip().split("\n")
+    # All rows get the first enum value from the mock
+    assert all(l == "positive" for l in lines)
+    assert len(lines) == 3
+
+
+def test_classify_profile_events(started_cluster):
+    instance.query("TRUNCATE TABLE test_input")
+    instance.query("INSERT INTO test_input VALUES ('a'), ('b')")
+    qid = unique_query_id("classify_events")
+    instance.query(
+        "SELECT aiClassify('ai_mock', x, ['cat_a', 'cat_b']) FROM test_input",
+        settings=AI_SETTINGS,
+        query_id=qid,
+    )
+    events = get_profile_events(qid)
+    assert int(events["api_calls"]) == 2
+    assert int(events["rows_processed"]) == 2
+
+
+def test_classify_null_input(started_cluster):
+    instance.query("TRUNCATE TABLE test_input_nullable")
+    instance.query("INSERT INTO test_input_nullable VALUES (NULL), ('text')")
+    result = instance.query(
+        "SELECT aiClassify('ai_mock', x, ['a', 'b']) FROM test_input_nullable",
+        settings=AI_SETTINGS,
+    )
+    lines = result.strip().split("\n")
+    assert "\\N" in lines
+    assert "a" in lines
+
+
+# ---------------------------------------------------------------------------
+# aiExtract — simple instruction mode
+# ---------------------------------------------------------------------------
+
+
+def test_extract_simple_instruction(started_cluster):
+    """With a plain text instruction, aiExtract uses a response_format with a
+    single 'result' field. postProcessResponse extracts the value."""
+    instance.query("TRUNCATE TABLE test_input")
+    instance.query("INSERT INTO test_input VALUES ('The price is $42.99')")
+    result = instance.query(
+        "SELECT aiExtract('ai_mock', x, 'the price') FROM test_input",
+        settings=AI_SETTINGS,
+    )
+    # Mock returns {"result": "<user_message>"}, postProcess extracts the value
+    assert result.strip() == "The price is $42.99"
+
+
+def test_extract_json_schema(started_cluster):
+    """With a JSON schema instruction, aiExtract builds a multi-field response_format.
+    The mock populates each field with the user message."""
+    instance.query("TRUNCATE TABLE test_input")
+    instance.query("INSERT INTO test_input VALUES ('John is 30 years old')")
+    result = instance.query(
+        """SELECT aiExtract('ai_mock', x, '{"name": "person name", "age": "person age"}') FROM test_input""",
+        settings=AI_SETTINGS,
+    )
+    # Mock returns {"name": "<user_msg>", "age": "<user_msg>"}
+    # postProcessResponse returns raw JSON since there's no single "result" field
+    parsed = json.loads(result.strip())
+    assert "name" in parsed
+    assert "age" in parsed
+
+
+def test_extract_multiple_rows(started_cluster):
+    instance.query("TRUNCATE TABLE test_input")
+    instance.query("INSERT INTO test_input VALUES ('text1'), ('text2'), ('text3')")
+    qid = unique_query_id("extract_events")
+    instance.query(
+        "SELECT aiExtract('ai_mock', x, 'main topic') FROM test_input",
+        settings=AI_SETTINGS,
+        query_id=qid,
+    )
+    events = get_profile_events(qid)
+    assert int(events["api_calls"]) == 3
+    assert int(events["rows_processed"]) == 3
+
+
+def test_extract_null_input(started_cluster):
+    instance.query("TRUNCATE TABLE test_input_nullable")
+    instance.query("INSERT INTO test_input_nullable VALUES (NULL), ('some text')")
+    result = instance.query(
+        "SELECT aiExtract('ai_mock', x, 'key info') FROM test_input_nullable",
+        settings=AI_SETTINGS,
+    )
+    lines = result.strip().split("\n")
+    assert "\\N" in lines
+    assert len(lines) == 2
+
+
+# ---------------------------------------------------------------------------
+# aiTranslate
+# ---------------------------------------------------------------------------
+
+
+def test_translate_basic(started_cluster):
+    """aiTranslate has no response_format — plain text echo from mock."""
+    instance.query("TRUNCATE TABLE test_input")
+    instance.query("INSERT INTO test_input VALUES ('Hello world')")
+    result = instance.query(
+        "SELECT aiTranslate('ai_mock', x, 'French') FROM test_input",
+        settings=AI_SETTINGS,
+    )
+    assert result.strip() == "Hello world"
+
+
+def test_translate_multiple_rows(started_cluster):
+    instance.query("TRUNCATE TABLE test_input")
+    instance.query("INSERT INTO test_input VALUES ('one'), ('two'), ('three')")
+    result = instance.query(
+        "SELECT aiTranslate('ai_mock', x, 'Spanish') FROM test_input ORDER BY x",
+        settings=AI_SETTINGS,
+    )
+    assert result.strip().split("\n") == ["one", "three", "two"]
+
+
+def test_translate_with_instructions(started_cluster):
+    instance.query("TRUNCATE TABLE test_input")
+    instance.query("INSERT INTO test_input VALUES ('Hello')")
+    result = instance.query(
+        "SELECT aiTranslate('ai_mock', x, 'German', 'Use formal tone') FROM test_input",
+        settings=AI_SETTINGS,
+    )
+    assert result.strip() == "Hello"
+
+
+def test_translate_profile_events(started_cluster):
+    instance.query("TRUNCATE TABLE test_input")
+    instance.query("INSERT INTO test_input VALUES ('a'), ('b')")
+    qid = unique_query_id("translate_events")
+    instance.query(
+        "SELECT aiTranslate('ai_mock', x, 'Japanese') FROM test_input",
+        settings=AI_SETTINGS,
+        query_id=qid,
+    )
+    events = get_profile_events(qid)
+    assert int(events["api_calls"]) == 2
+    assert int(events["rows_processed"]) == 2
+
+
+def test_translate_null_input(started_cluster):
+    instance.query("TRUNCATE TABLE test_input_nullable")
+    instance.query("INSERT INTO test_input_nullable VALUES (NULL), ('hello')")
+    result = instance.query(
+        "SELECT aiTranslate('ai_mock', x, 'French') FROM test_input_nullable",
+        settings=AI_SETTINGS,
+    )
+    lines = result.strip().split("\n")
+    assert "\\N" in lines
+    assert "hello" in lines

--- a/tests/integration/test_ai_functions/test.py
+++ b/tests/integration/test_ai_functions/test.py
@@ -37,15 +37,24 @@ def run_mock_server():
         detach=True,
         user="root",
     )
-    wait_condition(
-        lambda: instance.exec_in_container(
-            ["curl", "-s", f"http://localhost:{MOCK_PORT}/health"],
+    try:
+        wait_condition(
+            lambda: instance.exec_in_container(
+                ["curl", "-s", f"http://localhost:{MOCK_PORT}/health"],
+                nothrow=True,
+            ),
+            lambda r: r == "OK",
+            max_attempts=40,
+            delay=0.5,
+        )
+    except Exception as e:
+        log = instance.exec_in_container(
+            ["cat", "/var/log/clickhouse-server/mock_ai_server.log"],
             nothrow=True,
-        ),
-        lambda r: r == "OK",
-        max_attempts=20,
-        delay=0.5,
-    )
+        )
+        raise RuntimeError(
+            f"Mock AI server failed to become ready. Server log:\n{log}"
+        ) from e
 
 
 def unique_query_id(prefix):
@@ -64,10 +73,12 @@ def get_profile_events(query_id):
             ProfileEvents['AIRowsSkipped'] AS rows_skipped
         FROM system.query_log
         WHERE query_id = '{query_id}' AND type = 'QueryFinish'
+        LIMIT 1
         FORMAT JSONEachRow
         """
-    )
-    return json.loads(result.strip())
+    ).strip()
+    assert result, f"no system.query_log row found for query_id={query_id}"
+    return json.loads(result)
 
 
 @pytest.fixture(scope="module")
@@ -350,8 +361,13 @@ def test_translate_multiple_rows(started_cluster):
 def test_translate_with_instructions(started_cluster):
     instance.query("TRUNCATE TABLE test_input")
     instance.query("INSERT INTO test_input VALUES ('Hello')")
+    # Sentinels make this test order-independent against the shared `LAST_REQUEST`
+    # state: even if another request hits the mock between our query and the
+    # /last-request fetch, we can detect it by the missing sentinel.
+    lang_marker = f"LangMarker_{uuid.uuid4().hex[:8]}"
+    instr_marker = f"InstrMarker_{uuid.uuid4().hex[:8]}"
     result = instance.query(
-        "SELECT aiTranslate('ai_mock', x, 'German', 'Use formal tone') FROM test_input",
+        f"SELECT aiTranslate('ai_mock', x, '{lang_marker}', '{instr_marker}') FROM test_input",
         settings=AI_SETTINGS,
     )
     assert result.strip() == "Hello"
@@ -362,10 +378,9 @@ def test_translate_with_instructions(started_cluster):
         )
     )
     assert last["path"] == "/v1/chat/completions"
-    # Both the target language and the extra instructions must reach the prompt.
     sent = last["body"]
-    assert "German" in sent
-    assert "Use formal tone" in sent
+    assert lang_marker in sent, f"target language not in request body: {sent!r}"
+    assert instr_marker in sent, f"instructions not in request body: {sent!r}"
 
 
 def test_translate_profile_events(started_cluster):

--- a/tests/integration/test_ai_functions/test.py
+++ b/tests/integration/test_ai_functions/test.py
@@ -101,6 +101,14 @@ def started_cluster() -> typing.Generator[ClickHouseCluster, None, None]:
             f"model = 'test-model', "
             f"api_key = 'test-key'"
         )
+        # `api_key` is optional (some providers, e.g. a local Ollama, need no auth).
+        # This collection omits it so we can assert no `Authorization` header is sent.
+        instance.query(
+            f"CREATE NAMED COLLECTION ai_no_key AS "
+            f"provider = 'openai', "
+            f"endpoint = 'http://localhost:{MOCK_PORT}/v1/chat/completions', "
+            f"model = 'test-model'"
+        )
         instance.query(
             f"CREATE NAMED COLLECTION ai_embed AS "
             f"provider = 'openai', "
@@ -208,6 +216,35 @@ def test_generate_content_error_graceful(started_cluster):
         settings={**AI_SETTINGS, "ai_function_throw_on_error": 0},
     )
     assert result.strip() == ""
+
+
+def last_request():
+    return json.loads(
+        instance.exec_in_container(
+            ["curl", "-s", f"http://localhost:{MOCK_PORT}/last-request"]
+        )
+    )
+
+
+def test_generate_without_api_key(started_cluster):
+    """A named collection that omits `api_key` resolves and runs end-to-end, and the
+    provider sends no `Authorization` header (rather than an empty/dummy token)."""
+    result = instance.query(
+        "SELECT aiGenerate('ai_no_key', 'no key here')",
+        settings=AI_SETTINGS,
+    )
+    assert result.strip() == "no key here"
+    assert "authorization" not in last_request()["headers"]
+
+
+def test_generate_with_api_key_sends_auth_header(started_cluster):
+    """A keyed collection forwards the key as a `Bearer` `Authorization` header."""
+    result = instance.query(
+        "SELECT aiGenerate('ai_mock', 'with key')",
+        settings=AI_SETTINGS,
+    )
+    assert result.strip() == "with key"
+    assert last_request()["headers"].get("authorization") == "Bearer test-key"
 
 
 # ---------------------------------------------------------------------------
@@ -547,7 +584,7 @@ def test_embed_duplicate_index_rejected(started_cluster):
         "SELECT aiEmbed('ai_embed_dup_index', x) FROM (SELECT arrayJoin(['a', 'b']) AS x)",
         settings={**AI_SETTINGS, "ai_function_max_retries": 0},
     )
-    assert "RECEIVED_ERROR_FROM_REMOTE_IO_SERVER" in error
+    assert "MALFORMED_AI_PROVIDER_RESPONSE" in error
     assert "duplicates" in error or "duplicate" in error.lower()
 
 
@@ -557,7 +594,7 @@ def test_embed_wrong_count_rejected(started_cluster):
         "SELECT aiEmbed('ai_embed_wrong_count', x) FROM (SELECT arrayJoin(['a', 'b']) AS x)",
         settings={**AI_SETTINGS, "ai_function_max_retries": 0},
     )
-    assert "RECEIVED_ERROR_FROM_REMOTE_IO_SERVER" in error
+    assert "MALFORMED_AI_PROVIDER_RESPONSE" in error
 
 
 def test_embed_empty_input_table(started_cluster):


### PR DESCRIPTION
Adds integration tests with a mock OpenAI-compatible HTTP server for aiGenerate, aiClassify, aiExtract, aiTranslate, and aiEmbed.

  For chat completions, the mock detects response_format in requests and returns structured JSON matching the schema (for aiClassify and aiExtract), or echoes the user message as plain text (for aiTranslate and aiGenerate). For embeddings, the
  mock returns one deterministic float vector per input, honoring the optional dimensions argument and reporting prompt_tokens so quota and token-accounting paths are exercised.

  Coverage per function:

  - Basic execution, multi-row processing, ProfileEvents, NULL handling
  - aiClassify: JSON schema with enum constraint, postProcessResponse extraction of category field
  - aiExtract: simple instruction mode (single result field) and JSON schema mode (multi-field extraction)
  - aiTranslate: plain text response, optional instructions argument
  - aiGenerate: error throw/graceful paths
  - aiEmbed: native and explicit dimensions, multi-row batching into a single HTTP call, ai_function_embedding_max_batch_size splitting inputs across multiple calls, NULL/empty inputs mapping to [] without a request, error throw/graceful paths,
  rejection of malformed provider responses (duplicate index, wrong cardinality), and ai_function_max_input_tokens_per_query quota truncation

To be merged after https://github.com/ClickHouse/ClickHouse/pull/102922

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds integration-test code and a standalone mock server, with no production logic changes.
> 
> **Overview**
> Adds a new `tests/integration/test_ai_functions` suite that spins up a ClickHouse instance plus a local OpenAI-compatible mock server, then validates `aiGenerate`, `aiClassify`, `aiExtract`, `aiTranslate`, and `aiEmbed` across basic, multi-row, NULL/empty-input, and ProfileEvents/token-accounting scenarios.
> 
> The mock server implements chat-completions and embeddings endpoints (including structured `response_format` JSON-schema replies) plus dedicated failure/malformed-response routes to test error handling, embedding batching (`ai_function_embedding_max_batch_size`), and quota-cut behavior (`ai_function_max_input_tokens_per_query`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e260eec3ceb504a965504a22cba3e73b06e433d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.681`
<!-- ch-version-info:end -->