### PR TITLE
Enforce AI function quotas per query, not per block

### DIFF
--- a/src/Functions/FunctionBaseAI.cpp
+++ b/src/Functions/FunctionBaseAI.cpp
@@ -131,11 +131,15 @@ ColumnPtr FunctionBaseAI::executeImpl(const ColumnsWithTypeAndName & arguments, 
 
     bool throw_on_error = settings[Setting::ai_function_throw_on_error].value;
 
-    AIQuotaTracker quota(
-        settings[Setting::ai_function_max_input_tokens_per_query].value,
-        settings[Setting::ai_function_max_output_tokens_per_query].value,
-        settings[Setting::ai_function_max_api_calls_per_query].value,
-        settings[Setting::ai_function_throw_on_quota_exceeded].value);
+    {
+        std::lock_guard lock(quota_mutex);
+        if (!quota)
+            quota.emplace(
+                settings[Setting::ai_function_max_input_tokens_per_query].value,
+                settings[Setting::ai_function_max_output_tokens_per_query].value,
+                settings[Setting::ai_function_max_api_calls_per_query].value,
+                settings[Setting::ai_function_throw_on_quota_exceeded].value);
+    }
 
     auto timeouts = ConnectionTimeouts::getHTTPTimeouts(settings, getContext()->getServerSettings());
     timeouts.receive_timeout = Poco::Timespan(static_cast<int64_t>(timeout_sec) /*s*/, 0 /*us*/);
@@ -153,7 +157,7 @@ ColumnPtr FunctionBaseAI::executeImpl(const ColumnsWithTypeAndName & arguments, 
 
     for (size_t i = 0; i < input_rows_count; ++i)
     {
-        if (quota.checkQuotas())
+        if (quota->checkQuotas())
         {
             result_col->insertDefault();
             ++rows_skipped;
@@ -179,7 +183,7 @@ ColumnPtr FunctionBaseAI::executeImpl(const ColumnsWithTypeAndName & arguments, 
                 auto ai_response = provider->call(ai_request, timeouts);
                 ++total_api_calls;
 
-                quota.recordResponse(ai_response.input_tokens, ai_response.output_tokens);
+                quota->recordResponse(ai_response.input_tokens, ai_response.output_tokens);
                 total_input_tokens += ai_response.input_tokens;
                 total_output_tokens += ai_response.output_tokens;
 

--- a/src/Functions/FunctionBaseAI.h
+++ b/src/Functions/FunctionBaseAI.h
@@ -6,6 +6,9 @@
 #include <Functions/AI/AIQuotaTracker.h>
 #include <Interpreters/Context.h>
 
+#include <mutex>
+#include <optional>
+
 namespace DB
 {
 
@@ -69,6 +72,13 @@ private:
 
     ResolvedConfig resolveConfig(const ColumnsWithTypeAndName & arguments) const;
     float resolveTemperature(const ColumnsWithTypeAndName & arguments, const ResolvedConfig & config) const;
+
+    /// Quota tracker persists across executeImpl calls (one per block) so that
+    /// per-query limits are enforced for the entire query, not per block.
+    /// Guarded by mutex because the query engine may call executeImpl from
+    /// different threads for different blocks.
+    mutable std::mutex quota_mutex;
+    mutable std::optional<AIQuotaTracker> quota;
 };
 
 }


### PR DESCRIPTION
`AIQuotaTracker` was created as a local variable inside `executeImpl`, which runs once per block. For multi-block queries the quota reset on each block, making `ai_function_max_*_per_query` settings effectively per-block limits.

Move the tracker to a `mutable` member on `FunctionBaseAI`, initialized lazily on the first `executeImpl` call. Since `isStateful` returns true, the same function instance is reused across all blocks in a query, so the quota now accumulates correctly across the entire query.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



