### PR TITLE
Use pre-wrap in CI report HTML to prevent horizontal overflow

### DIFF
--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -188,6 +188,11 @@
             background-color: var(--info-background);
             font-family: 'SF Mono', 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, monospace;
         }
+        .info-text pre {
+            white-space: pre-wrap;
+            word-wrap: break-word;
+            overflow-wrap: break-word;
+        }
         #info-content {
             text-align: left;
             padding: 10px;
@@ -327,7 +332,7 @@
         }
 
         .disabled {
-            white-space: pre;
+            white-space: pre-wrap;
         }
 
         .status-column span[style*="pointer"] {


### PR DESCRIPTION
Long error messages and test names in the CI report were not wrapping, causing horizontal scrolling. Changed `white-space` to `pre-wrap` for `.info-text pre` and `.disabled` elements so that content wraps at the container edge while preserving whitespace formatting.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1050`
<!-- ch-version-info:end -->