### PR TITLE
Fix pipeline_status GH Actions output broken by status enum rename

### DIFF
--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -843,13 +843,15 @@ class Runner:
                 traceback.print_exc()
 
         # finally, set the status flag for GH Actions
-        pipeline_status = Result.Status.OK
+        # These are GH Actions output values matched by workflow YAML conditions,
+        # not Result.Status values — must stay lowercase "success"/"failure".
+        pipeline_status = "success"
         if not result.is_ok():
             if result.is_failure() and result.do_not_block_pipeline_on_failure():
                 # job explicitly says to not block ci even though result is failure
                 pass
             else:
-                pipeline_status = Result.Status.FAIL
+                pipeline_status = "failure"
         with open(env.JOB_OUTPUT_STREAM, "a", encoding="utf8") as f:
             print(
                 f"pipeline_status={pipeline_status}",


### PR DESCRIPTION
Fix for #102896.

The `pipeline_status` GH Actions output is consumed by workflow YAML via `contains(needs.*.outputs.pipeline_status, 'failure')`. After the `Result.Status` unification, this output changed from `"failure"` to `"FAIL"`, which stopped blocking dependent jobs on failure.

Use literal `"success"`/`"failure"` strings since these are GH Actions output values matched by YAML conditions, not `Result.Status` values.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1051`
<!-- ch-version-info:end -->