### PR TITLE
Fix UBSan UInt64 overflow when scaling `interactive_delay` by sqrt(fanout)

### DIFF
--- a/src/Client/HedgedConnections.cpp
+++ b/src/Client/HedgedConnections.cpp
@@ -1,10 +1,9 @@
 #include <Core/Protocol.h>
 #if defined(OS_LINUX)
 
-#include <cmath>
 #include <Client/HedgedConnections.h>
+#include <Client/scaleInteractiveDelayByFanout.h>
 #include <Common/ProfileEvents.h>
-#include <Common/thread_local_rng.h>
 #include <Core/Settings.h>
 #include <Core/ProtocolDefines.h>
 #include <Interpreters/ClientInfo.h>
@@ -219,18 +218,9 @@ void HedgedConnections::sendQuery(
         modified_settings[Setting::dialect] = Dialect::clickhouse;
         modified_settings[Setting::dialect].changed = false;
 
-        /// Scale interactive_delay by sqrt(fanout) with jitter, same as in MultiplexedConnections.
-        {
-            size_t total_fanout = distributed_fanout * offset_states.size();
-            if (total_fanout > 1)
-            {
-                UInt64 delay = modified_settings[Setting::interactive_delay];
-                double scale = std::sqrt(static_cast<double>(total_fanout));
-                double jitter = 1.0 + (thread_local_rng() % 1000) / 1000.0;
-                delay = static_cast<UInt64>(std::ceil(static_cast<double>(delay) * scale * jitter));
-                modified_settings[Setting::interactive_delay] = delay;
-            }
-        }
+        modified_settings[Setting::interactive_delay] = scaleInteractiveDelayByFanout(
+            modified_settings[Setting::interactive_delay],
+            distributed_fanout * offset_states.size());
 
         if (disable_two_level_aggregation)
         {

--- a/src/Client/MultiplexedConnections.cpp
+++ b/src/Client/MultiplexedConnections.cpp
@@ -1,7 +1,6 @@
 #include <Client/MultiplexedConnections.h>
 
-#include <cmath>
-#include <Common/thread_local_rng.h>
+#include <Client/scaleInteractiveDelayByFanout.h>
 #include <Core/Protocol.h>
 #include <Core/ProtocolDefines.h>
 #include <Core/Settings.h>
@@ -160,23 +159,9 @@ void MultiplexedConnections::sendQuery(
     modified_settings[Setting::dialect] = Dialect::clickhouse;
     modified_settings[Setting::dialect].changed = false;
 
-    /// Scale interactive_delay by sqrt(fanout) to reduce progress/profile event traffic
-    /// from distributed queries. Each remote server will send updates less frequently,
-    /// proportional to the square root of the total number of remote connections.
-    /// Also add per-connection jitter to avoid TCP incast and make the progress bar smooth.
-    {
-        size_t total_fanout = distributed_fanout * replica_states.size();
-        if (total_fanout > 1)
-        {
-            UInt64 delay = modified_settings[Setting::interactive_delay];
-            double scale = std::sqrt(static_cast<double>(total_fanout));
-            /// Add random jitter in range [1.0, 2.0) to desynchronize progress reports
-            /// across connections, avoiding TCP incast and making the progress bar smooth.
-            double jitter = 1.0 + (thread_local_rng() % 1000) / 1000.0;
-            delay = static_cast<UInt64>(std::ceil(static_cast<double>(delay) * scale * jitter));
-            modified_settings[Setting::interactive_delay] = delay;
-        }
-    }
+    modified_settings[Setting::interactive_delay] = scaleInteractiveDelayByFanout(
+        modified_settings[Setting::interactive_delay],
+        distributed_fanout * replica_states.size());
 
     for (auto & replica : replica_states)
     {

--- a/src/Client/scaleInteractiveDelayByFanout.h
+++ b/src/Client/scaleInteractiveDelayByFanout.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+
+#include <base/types.h>
+#include <Common/thread_local_rng.h>
+
+
+namespace DB
+{
+
+/// Scale `interactive_delay` by `sqrt(total_fanout)` with per-connection jitter in `[1.0, 2.0)`,
+/// to reduce progress/profile event traffic from distributed queries. Each remote server will
+/// send updates less frequently, proportional to the square root of the total number of remote
+/// connections; the jitter desynchronizes progress reports across connections to avoid TCP incast
+/// and make the progress bar smoother.
+///
+/// The scaled value is saturated to `UINT64_MAX` on overflow: user-controlled `interactive_delay`
+/// is an unbounded `UInt64`, so `delay * scale * jitter` as a `double` can exceed the `UInt64`
+/// range. Casting such a `double` back to `UInt64` without saturation is undefined behavior
+/// (UBSan finding in `Stress test (experimental, serverfuzz, arm_asan_ubsan)`).
+inline UInt64 scaleInteractiveDelayByFanout(UInt64 delay, size_t total_fanout)
+{
+    if (total_fanout <= 1)
+        return delay;
+
+    const double scale = std::sqrt(static_cast<double>(total_fanout));
+    /// Random jitter in range [1.0, 2.0).
+    const double jitter = 1.0 + (thread_local_rng() % 1000) / 1000.0;
+    const double scaled = std::ceil(static_cast<double>(delay) * scale * jitter);
+
+    /// `static_cast<UInt64>(x)` is undefined behavior when `x` is outside the `UInt64` range.
+    /// `2^64` is exactly representable as `double`, so comparing against it is reliable.
+    constexpr double two_pow_64 = 18446744073709551616.0;
+    if (scaled >= two_pow_64)
+        return std::numeric_limits<UInt64>::max();
+    return static_cast<UInt64>(scaled);
+}
+
+}

--- a/src/Client/tests/gtest_scale_interactive_delay_by_fanout.cpp
+++ b/src/Client/tests/gtest_scale_interactive_delay_by_fanout.cpp
@@ -1,0 +1,58 @@
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include <Client/scaleInteractiveDelayByFanout.h>
+
+using namespace DB;
+
+TEST(ScaleInteractiveDelayByFanout, NoScalingForSingleConnection)
+{
+    /// total_fanout <= 1 must return the value unchanged (no random jitter applied).
+    EXPECT_EQ(scaleInteractiveDelayByFanout(100'000, 0), 100'000u);
+    EXPECT_EQ(scaleInteractiveDelayByFanout(100'000, 1), 100'000u);
+}
+
+TEST(ScaleInteractiveDelayByFanout, ScalesWithinJitterBounds)
+{
+    /// With fanout = 4 (scale = 2) and jitter in [1.0, 2.0), the result must be in
+    /// [delay * scale * 1.0, delay * scale * 2.0). We allow a +1 slack for the ceil().
+    const UInt64 delay = 10'000'000;
+    const size_t fanout = 4;
+    const double min_expected = static_cast<double>(delay) * 2.0 * 1.0;
+    const double max_expected = static_cast<double>(delay) * 2.0 * 2.0;
+
+    for (int i = 0; i < 1000; ++i)
+    {
+        const UInt64 result = scaleInteractiveDelayByFanout(delay, fanout);
+        EXPECT_GE(result, static_cast<UInt64>(min_expected));
+        EXPECT_LE(result, static_cast<UInt64>(max_expected) + 1);
+    }
+}
+
+TEST(ScaleInteractiveDelayByFanout, SaturatesOnOverflow)
+{
+    /// With `delay` close to `UINT64_MAX` and any fanout > 1, the scaled `double`
+    /// exceeds `UINT64_MAX`. The result must saturate at `UINT64_MAX`, not wrap or
+    /// trigger undefined behavior from `static_cast<UInt64>` on an out-of-range `double`.
+    const UInt64 uint64_max = std::numeric_limits<UInt64>::max();
+    const UInt64 almost_max = uint64_max - 1;
+
+    EXPECT_EQ(scaleInteractiveDelayByFanout(uint64_max, 4), uint64_max);
+    EXPECT_EQ(scaleInteractiveDelayByFanout(almost_max, 2), uint64_max);
+    /// Even a tiny fanout > 1 with a large enough delay overflows the scaled product.
+    EXPECT_EQ(scaleInteractiveDelayByFanout(uint64_max / 2, 16), uint64_max);
+
+    /// Historical UBSan finding reproducer: `delay * scale * jitter` produces a value
+    /// slightly above `UINT64_MAX` (see `Stress test (experimental, serverfuzz, arm_asan_ubsan)`).
+    /// With any `delay >= UINT64_MAX / 2` and fanout >= 4 (scale >= 2), `delay * scale * jitter`
+    /// reliably exceeds `UINT64_MAX` even with minimum jitter 1.0. The saturating cast prevents
+    /// the UBSan trap.
+    EXPECT_EQ(scaleInteractiveDelayByFanout(uint64_max / 2 + 1, 4), uint64_max);
+}
+
+TEST(ScaleInteractiveDelayByFanout, ZeroDelayStaysZero)
+{
+    for (size_t fanout : {size_t{0}, size_t{1}, size_t{2}, size_t{100}, size_t{10'000}})
+        EXPECT_EQ(scaleInteractiveDelayByFanout(0, fanout), 0u);
+}


### PR DESCRIPTION
`MultiplexedConnections::sendQuery` and `HedgedConnections::sendQuery` scale
`interactive_delay` by `sqrt(total_fanout)` with a per-connection jitter in
`[1.0, 2.0)` to reduce progress/profile event traffic from distributed queries
(introduced in f05a4566b0f, "Increase `interactive_delay` by sqrt(fanout) for
distributed queries", #100145).

The scaled value was cast back to `UInt64` without a bounds check. Since
`interactive_delay` is user-controlled and unbounded, the product
`delay * scale * jitter` as a `double` can exceed `UINT64_MAX`, and
`static_cast<UInt64>` on an out-of-range `double` is undefined behavior.
This triggers a UBSan trap in `Stress test (experimental, serverfuzz, arm_asan_ubsan)`:

```
src/Client/MultiplexedConnections.cpp:176:41: runtime error:
1.86135e+19 is outside the range of representable values of type 'unsigned long'

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior
```

(STID `3646-3e82`, seen on master commit `2892de442814d1e629f7ea1e25ed88d7c6441297`
on 2026-04-17 — [CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=2892de442814d1e629f7ea1e25ed88d7c6441297&name_0=MasterCI&name_1=Stress%20test%20%28experimental%2C%20serverfuzz%2C%20arm_asan_ubsan%29).)

### Approach

Factor the scaling logic into `scaleInteractiveDelayByFanout` in a new shared
header used by both `MultiplexedConnections` and `HedgedConnections` (the same
block of code was duplicated in both files, per the pre-existing `"same as in
MultiplexedConnections"` comment).

Saturate to `std::numeric_limits<UInt64>::max()` when the scaled `double` is
`>= 2^64`. `2^64` is exactly representable in `double`, so the comparison is
reliable:

```cpp
const double scaled = std::ceil(static_cast<double>(delay) * scale * jitter);
constexpr double two_pow_64 = 18446744073709551616.0;
if (scaled >= two_pow_64)
    return std::numeric_limits<UInt64>::max();
return static_cast<UInt64>(scaled);
```

### Verification

`gtest_scale_interactive_delay_by_fanout` covers:

- `NoScalingForSingleConnection` — `total_fanout <= 1` returns the value unchanged
- `ScalesWithinJitterBounds` — 1000 iterations validating the scaled result stays
  within `[delay * scale, delay * scale * 2]`
- `SaturatesOnOverflow` — the regression: inputs that previously triggered the
  UBSan cast now return `UINT64_MAX`
- `ZeroDelayStaysZero` — `delay == 0` invariant across any fanout

Without the saturation check, `SaturatesOnOverflow` fails deterministically —
`static_cast<UInt64>` of a too-large `double` returns `0x8000000000000000`
(`INT_INDEFINITE` on x86_64) instead of `UINT64_MAX`. Verified locally:

```
[ RUN      ] ScaleInteractiveDelayByFanout.SaturatesOnOverflow
gtest_scale_interactive_delay_by_fanout.cpp:51: Failure
  scaleInteractiveDelayByFanout(uint64_max / 2 + 1, 4): 9223372036854775808
  uint64_max:                                          18446744073709551615
[  FAILED  ] ScaleInteractiveDelayByFanout.SaturatesOnOverflow
```

With the fix: `4/4` pass.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.20`
<!-- ch-version-info:end -->