### PR TITLE
Fix flaky 03237_avro_union_in_complex_types under randomized map_serialization_version

### DIFF
--- a/tests/queries/0_stateless/03237_avro_union_in_complex_types.sh
+++ b/tests/queries/0_stateless/03237_avro_union_in_complex_types.sh
@@ -120,6 +120,12 @@ $CH_CLIENT -q "select * from file('$file_name', 'Avro', '
 echo
 
 echo "== CREATE TABLE avro_union_test_03237 =="
+# Pin `map_serialization_version` to `basic` so the test output is deterministic.
+# With the `with_buckets` format (which the CI runner randomizes) keys inside a
+# Map column can be reordered across the bucketing round-trip — see the comment
+# in `src/DataTypes/Serializations/SerializationMap.cpp::collectMapFromBuckets`.
+# That is valid Map behaviour but makes this reference-based test flaky; the
+# bucketing path has dedicated tests elsewhere.
 $CH_CLIENT -q "CREATE TABLE avro_union_test_03237 (
   string_only String,
   string_or_null Nullable(String),
@@ -133,7 +139,8 @@ $CH_CLIENT -q "CREATE TABLE avro_union_test_03237 (
   double_or_null_or_string_or_long Variant(Float64, String, Int64),
   double_or_long_or_string_in_array Array(Variant(Float64, String, Int64)),
   double_or_string_or_long_or_null_in_map Map(String, Variant(Float64, Int64, String))
-) ENGINE = MergeTree ORDER BY tuple()"
+) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS map_serialization_version = 'basic', map_serialization_version_for_zero_level_parts = 'basic'"
 echo
 
 echo "== SELECT * FORMAT Avro | INSERT INTO avro_union_test_03237 FORMAT Avro =="


### PR DESCRIPTION
## Summary

Chronic flaky test `03237_avro_union_in_complex_types` — 10 unrelated PRs hit it over the last 30 days across `amd_debug`, `amd_asan_ubsan`, `amd_tsan`, `amd_msan`, `arm_binary` and `amd_llvm_coverage` variants. Zero master failures but very visible to developers.

The test stores rows from an Avro file into a `MergeTree` table and compares `SELECT *` output to a reference. When the CI runner randomizes `map_serialization_version_for_zero_level_parts` to `with_buckets` (see `tests/clickhouse-test` line 1574), `SerializationMap` splits map entries by key hash across buckets during `INSERT` and reassembles them bucket-by-bucket during `SELECT` (`collectMapFromBuckets` in `src/DataTypes/Serializations/SerializationMap.cpp`). As a result, keys inside a row's `Map` come out in bucket-hash order rather than insertion order.

That is valid `Map` semantics — entry order is not guaranteed after a bucketed round-trip — but this reference-based test was written assuming insertion order is preserved. Pinning `map_serialization_version = 'basic'` and `map_serialization_version_for_zero_level_parts = 'basic'` at the table level makes the output deterministic regardless of which `MergeTree` randomization the runner selects. The `with_buckets` path has dedicated tests elsewhere.

Typical flaky diff:

```
-zulu ... {'key9':9223372036854775807,'key10':NULL}
+zulu ... {'key10':NULL,'key9':9223372036854775807}
```

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not required — `CI Fix or Improvement`.

### Documentation entry for user-facing changes

- [x] No user-facing change.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1085`
<!-- ch-version-info:end -->