### PR TITLE
Fix wrong arguments in error messages of string search functions

### DIFF
--- a/src/Functions/FunctionsStringSearch.h
+++ b/src/Functions/FunctionsStringSearch.h
@@ -144,13 +144,13 @@ public:
             throw Exception(
                 ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
                 "Illegal type {} of argument of function {}",
-                arguments[0]->getName(), getName());
+                haystack_type->getName(), getName());
 
         if (!isString(needle_type))
             throw Exception(
                 ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
                 "Illegal type {} of argument of function {}",
-                arguments[1]->getName(), getName());
+                needle_type->getName(), getName());
 
         if (arguments.size() >= 3)
         {

--- a/tests/queries/0_stateless/04103_haystack_needle_type_error_message.reference
+++ b/tests/queries/0_stateless/04103_haystack_needle_type_error_message.reference
@@ -1,0 +1,5 @@
+Illegal type UInt8
+Illegal type UInt8
+Illegal type UInt8
+Illegal type UInt8
+Illegal type UInt8

--- a/tests/queries/0_stateless/04103_haystack_needle_type_error_message.sh
+++ b/tests/queries/0_stateless/04103_haystack_needle_type_error_message.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Check that `locate` reports the correct type in error messages,
+# under both needle-haystack and haystack-needle argument orders.
+#
+# Previously, `SELECT locate('hi', 42)` reported
+#     Illegal type String of argument of function locate
+# instead of
+#     Illegal type UInt8 of argument of function locate
+
+extract_bad_type() {
+    grep -m1 -o 'Illegal type .* of argument' | sed 's/ of argument$//'
+}
+
+# Default order: locate(needle, haystack[, start_pos])
+$CLICKHOUSE_CLIENT --query "SET function_locate_has_mysql_compatible_argument_order = 1; SELECT locate('hi', 42::UInt8)" 2>&1 | extract_bad_type
+$CLICKHOUSE_CLIENT --query "SET function_locate_has_mysql_compatible_argument_order = 1; SELECT locate(100::UInt8, 'hello')" 2>&1 | extract_bad_type
+$CLICKHOUSE_CLIENT --query "SET function_locate_has_mysql_compatible_argument_order = 1; SELECT locate('hi', 33::UInt8, 1)" 2>&1 | extract_bad_type
+
+# Classic order: locate(haystack, needle[, start_pos])
+$CLICKHOUSE_CLIENT --query "SET function_locate_has_mysql_compatible_argument_order = 0; SELECT locate(42::UInt8, 'hello')" 2>&1 | extract_bad_type
+$CLICKHOUSE_CLIENT --query "SET function_locate_has_mysql_compatible_argument_order = 0; SELECT locate('hi', 42::UInt8)" 2>&1 | extract_bad_type


### PR DESCRIPTION
Functions using `FunctionsStringSearch` can take arguments as `(haystack, needle)` or `(needle, haystack)` forms.

The type check selects the right argument for both orders, but the error message always reports `arguments[0]` or `arguments[1]`, so under the swapped order it names the wrong argument.

Example with `locate`:

    :) SELECT locate('test', 42);
    DB::Exception: Illegal type String of argument of function locate

while the bad argument is `Uint8`.

This commit fixes the error messages and adds a small regression test.

### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed incorrect argument type reported in error messages of string search functions
(e.g. `locate`, `position`) when arguments are passed in swapped order (`locate(needle, haystack)` with `function_locate_has_mysql_compatible_argument_order = 1`).

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

No documentation changes needed.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1097`
<!-- ch-version-info:end -->