### PR TITLE
ci/find_tests: skip shared registry files from targeted check

### DIFF
--- a/ci/jobs/scripts/find_tests.py
+++ b/ci/jobs/scripts/find_tests.py
@@ -187,6 +187,25 @@ class Targeting:
     PASS_WEIGHT_SIBLING       = 0.25  # Pass 2: test covers a sibling file in the same source directory
     PASS_WEIGHT_KEYWORD       = 0.20  # Fallback: test filename contains domain keywords from changed files
 
+    # Shared-registry files: purely declarative files whose changes are virtually always
+    # additive (`extern const Event …`, new setting entries, new error codes).  Every
+    # test emits profile events / reads settings, so coverage for any changed line in
+    # these files returns thousands of tests and floods the candidate pool with noise
+    # (the real signal lives in the other files touched by the same PR).  Skip them
+    # entirely from coverage, sibling, indirect, and keyword-fallback passes.
+    SHARED_REGISTRY_FILES = frozenset({
+        "src/Common/ProfileEvents.cpp",
+        "src/Common/ProfileEvents.h",
+        "src/Common/CurrentMetrics.cpp",
+        "src/Common/CurrentMetrics.h",
+        "src/Common/ErrorCodes.cpp",
+        "src/Common/ErrorCodes.h",
+        "src/Common/SettingsChanges.cpp",
+        "src/Core/Settings.cpp",
+        "src/Core/SettingsChangesHistory.cpp",
+        "src/Core/SettingsChangesHistory.h",
+    })
+
     def get_tests_by_changed_lines(self, changed_lines: list,
                                    hunk_ranges: dict | None = None) -> dict:
         """
@@ -222,12 +241,21 @@ class Targeting:
             (f, ln)
             for f, ln in changed_lines
             if any(f.startswith(p) for p in COVERAGE_TRACKED_PREFIXES)
+            and f not in self.SHARED_REGISTRY_FILES
         ]
         skipped = len(changed_lines) - len(coverage_lines)
         if skipped:
             print(
-                f"[find_tests] skipping {skipped} lines in non-tracked files "
-                f"(test scripts, docs, CI, contrib)"
+                f"[find_tests] skipping {skipped} lines in non-tracked or shared-registry "
+                f"files (test scripts, docs, CI, contrib, ProfileEvents/Settings registries)"
+            )
+        skipped_registry = sorted(
+            {f for f, _ in changed_lines if f in self.SHARED_REGISTRY_FILES}
+        )
+        if skipped_registry:
+            print(
+                f"[find_tests] skipping {len(skipped_registry)} shared-registry file(s): "
+                f"{skipped_registry}"
             )
 
         # Return the original (full) key-set in the result dict so that
@@ -1692,6 +1720,7 @@ class Targeting:
             f for f, ln in changed_lines
             if any(f.startswith(p) for p in COVERAGE_TRACKED_PREFIXES)
             and (f.endswith(".cpp") or f.endswith(".h"))
+            and f not in self.SHARED_REGISTRY_FILES
             and not any(pairs for (ff, _), pairs in line_to_tests.items() if ff == f)
         ]
         # Deduplicate file list.
@@ -1728,6 +1757,7 @@ class Targeting:
             if any(f.startswith(p) for p in COVERAGE_TRACKED_PREFIXES)
             and (f.endswith(".cpp") or f.endswith(".h"))
             and f not in cpp_with_zero_coverage
+            and f not in self.SHARED_REGISTRY_FILES
             and any(pairs for (ff, _), pairs in line_to_tests.items() if ff == f)
         ))
         # Always run the supplementary keyword pass: keyword tests get PASS_WEIGHT_KEYWORD


### PR DESCRIPTION
Files like `ProfileEvents.cpp`, `Settings.cpp`, `SettingsChangesHistory.cpp`, `ErrorCodes.cpp`, and `CurrentMetrics.cpp` are pure declaration registries — every query emits profile events and reads settings, so CIDB coverage for any changed line in these files matches thousands of tests. A typical PR only adds a new `extern const Event ...` line, yet the targeted check currently picks up every `profile_events` / `system_processes` / `system_events` test via the broad-tier2 path.

Example: https://github.com/ClickHouse/ClickHouse/pull/103080 added 4 lines to `src/Common/ProfileEvents.cpp` and the targeted check pulled in dozens of unrelated profile-events tests.

This PR adds a `SHARED_REGISTRY_FILES` skip-list in `find_tests.py` and filters those files out of the coverage, sibling, indirect, and keyword-fallback passes. The real signal for such PRs lives in the other files they touch (e.g. `Context.cpp`, `ProcessList.cpp`), which remain fully analyzed.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1059`
<!-- ch-version-info:end -->