### PR TITLE
Fix bugs in parseSize() and parseTime() for combined rotate strategy

### DIFF
--- a/base/poco/Foundation/include/Poco/CombinedRotateStrategy.h
+++ b/base/poco/Foundation/include/Poco/CombinedRotateStrategy.h
@@ -68,6 +68,12 @@ private:
         std::string unit;
         while (it != end && Ascii::isAlpha(*it)) unit += *it++;
 
+        /// Return std::nullopt if n is 0
+        if (n == 0)
+            return std::nullopt;
+
+        while (it != end && Ascii::isSpace(*it)) ++it;
+
         UInt64 size = 0;
         if (unit == "K")
             size = n * 1024;
@@ -75,7 +81,7 @@ private:
             size = n * 1024 * 1024;
         else if (unit == "G")
             size = n * 1024 * 1024 * 1024;
-        else if (unit.empty())
+        else if (unit.empty() && (it == end || *it == ','))
             size = n;
         else
             return std::nullopt; /// Return std::nullopt if fails to parse
@@ -126,7 +132,6 @@ private:
             return std::nullopt; /// Return std::nullopt if fails to parse
 
         /// Try to skip ','
-        while (it != end && Ascii::isSpace(*it)) ++it;
         if (it != end && *it == ',') ++it;
 
         pos = it - str.begin();
@@ -150,7 +155,7 @@ private:
             return res;
         }
 
-        auto res = std::string(str.substr(pos, comma_after_colon));
+        auto res = std::string(str.substr(pos, comma_after_colon - pos));
         pos = comma_after_colon + 1;
         return res;
     }

--- a/base/poco/Foundation/include/Poco/CombinedRotateStrategy.h
+++ b/base/poco/Foundation/include/Poco/CombinedRotateStrategy.h
@@ -132,6 +132,7 @@ private:
             return std::nullopt; /// Return std::nullopt if fails to parse
 
         /// Try to skip ','
+        while (it != end && Ascii::isSpace(*it)) ++it;
         if (it != end && *it == ',') ++it;
 
         pos = it - str.begin();

--- a/src/Common/tests/gtest_log.cpp
+++ b/src/Common/tests/gtest_log.cpp
@@ -7,6 +7,8 @@
 
 #include <Poco/Logger.h>
 #include <Poco/AutoPtr.h>
+#include <Poco/CombinedRotateStrategy.h>
+#include <Poco/Exception.h>
 #include <Poco/FileChannel.h>
 #include <Poco/NullChannel.h>
 #include <Poco/StreamChannel.h>
@@ -256,4 +258,74 @@ TEST(Logger, Rotation)
     EXPECT_EQ(readLogFile(log_dir / "logger.log.1"), "A\nB\n" + std::string(201, 'C') + "\n");
     EXPECT_EQ(readLogFile(log_dir / "logger.log.0"), "D\nE\n");
     EXPECT_EQ(readLogFile(log_dir / "logger.log"), "F\n");
+}
+
+TEST(Logger, RotationParseValid)
+{
+    EXPECT_NO_THROW(Poco::CombinedRotateStrategy("100M", ""));
+    EXPECT_NO_THROW(Poco::CombinedRotateStrategy("100K", ""));
+    EXPECT_NO_THROW(Poco::CombinedRotateStrategy("1G", ""));
+    EXPECT_NO_THROW(Poco::CombinedRotateStrategy("1024", ""));
+    EXPECT_NO_THROW(Poco::CombinedRotateStrategy("daily", ""));
+    EXPECT_NO_THROW(Poco::CombinedRotateStrategy("weekly", ""));
+    EXPECT_NO_THROW(Poco::CombinedRotateStrategy("monthly", ""));
+    EXPECT_NO_THROW(Poco::CombinedRotateStrategy("10 minutes", ""));
+    EXPECT_NO_THROW(Poco::CombinedRotateStrategy("2 hours", ""));
+    EXPECT_NO_THROW(Poco::CombinedRotateStrategy("never", ""));
+    EXPECT_NO_THROW(Poco::CombinedRotateStrategy("12:00", ""));
+    EXPECT_NO_THROW(Poco::CombinedRotateStrategy("02:30", ""));
+    EXPECT_NO_THROW(Poco::CombinedRotateStrategy("Sunday,12:00", ""));
+    EXPECT_NO_THROW(Poco::CombinedRotateStrategy("100M,12:00", ""));
+    EXPECT_NO_THROW(Poco::CombinedRotateStrategy("100M, 12:00", ""));
+    EXPECT_NO_THROW(Poco::CombinedRotateStrategy("100M,daily", ""));
+    EXPECT_NO_THROW(Poco::CombinedRotateStrategy("100M, daily", ""));
+    EXPECT_NO_THROW(Poco::CombinedRotateStrategy("200, 100 milliseconds", ""));
+    EXPECT_NO_THROW(Poco::CombinedRotateStrategy("100M, 10 minutes", ""));
+}
+
+TEST(Logger, RotationParseInvalid)
+{
+    EXPECT_THROW(Poco::CombinedRotateStrategy("", ""), Poco::InvalidArgumentException);
+    EXPECT_THROW(Poco::CombinedRotateStrategy("abc", ""), Poco::InvalidArgumentException);
+    EXPECT_THROW(Poco::CombinedRotateStrategy("100X", ""), Poco::InvalidArgumentException);
+}
+
+TEST(Logger, RotationTimeNotMistakenForSize)
+{
+    Poco::TemporaryFile temp_dir;
+    temp_dir.createDirectories();
+
+    auto my_channel = Poco::AutoPtr<Poco::FileChannel>(new Poco::FileChannel());
+    std::filesystem::path log_dir = std::filesystem::path{temp_dir.path()};
+    my_channel->setProperty(Poco::FileChannel::PROP_PATH, log_dir / "logger.log");
+    my_channel->setProperty(Poco::FileChannel::PROP_ROTATION, "12:00");
+    auto log = createLogger("RotTimeLogger", my_channel.get());
+    log->setLevel("trace");
+
+    LOG_INFO(log, "{}", std::string(100, 'A'));
+
+    /// If "12:00" were mistakenly parsed as size=12, a 100-byte message would trigger rotation.
+    /// With the fix, it's parsed as a time-of-day schedule, so no rotation should happen.
+    std::vector<std::string> expected_log_file_names{"logger.log"};
+    EXPECT_EQ(getLogFileNames(log_dir), expected_log_file_names);
+}
+
+TEST(Logger, RotationSizeWithTime)
+{
+    Poco::TemporaryFile temp_dir;
+    temp_dir.createDirectories();
+
+    auto my_channel = Poco::AutoPtr<Poco::FileChannel>(new Poco::FileChannel());
+    std::filesystem::path log_dir = std::filesystem::path{temp_dir.path()};
+    my_channel->setProperty(Poco::FileChannel::PROP_PATH, log_dir / "logger.log");
+    my_channel->setProperty(Poco::FileChannel::PROP_ROTATION, "200, 12:00");
+    auto log = createLogger("RotSizeTimeLogger", my_channel.get());
+    log->setLevel("trace");
+
+    LOG_INFO(log, "{}", std::string(201, 'B'));
+
+    /// Size-based rotation should still trigger for a message exceeding 200 bytes.
+    LOG_INFO(log, "C");
+    std::vector<std::string> expected_log_file_names{"logger.log", "logger.log.0"};
+    EXPECT_EQ(getLogFileNames(log_dir), expected_log_file_names);
 }

--- a/src/Loggers/Loggers.cpp
+++ b/src/Loggers/Loggers.cpp
@@ -181,7 +181,7 @@ void Loggers::buildLoggers(Poco::Util::AbstractConfiguration & config, Poco::Log
 
         error_log_file = new Poco::FileChannel;
         error_log_file->setProperty(Poco::FileChannel::PROP_PATH, fs::weakly_canonical(errorlog_path));
-        error_log_file->setProperty(Poco::FileChannel::PROP_ROTATION, config.getRawString("logger.size", "100M"));
+        error_log_file->setProperty(Poco::FileChannel::PROP_ROTATION, config.getRawString("logger.rotation", config.getRawString("logger.size", "100M")));
         error_log_file->setProperty(Poco::FileChannel::PROP_ARCHIVE, "number");
         error_log_file->setProperty(Poco::FileChannel::PROP_COMPRESS, config.getRawString("logger.compress", "true"));
         error_log_file->setProperty(Poco::FileChannel::PROP_STREAMCOMPRESS, config.getRawString("logger.stream_compress", "false"));


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed parseSize and parseTime logic to correctly distinguish between size thresholds and time-based rotation schedules (e.g., 12:00). Fixes #103108 and #100910 

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

