### PR TITLE
Revert PREWHERE in timeSeriesSelector, add optimization barrier step instead

### DIFF
--- a/src/Processors/QueryPlan/OptimizationBarrierStep.cpp
+++ b/src/Processors/QueryPlan/OptimizationBarrierStep.cpp
@@ -1,0 +1,127 @@
+#include <Processors/QueryPlan/OptimizationBarrierStep.h>
+
+#include <Core/Block.h>
+#include <IO/Operators.h>
+#include <IO/ReadHelpers.h>
+#include <IO/WriteHelpers.h>
+#include <Common/JSONBuilder.h>
+#include <Processors/QueryPlan/QueryPlanFormat.h>
+#include <Processors/QueryPlan/QueryPlanStepRegistry.h>
+#include <Processors/QueryPlan/Serialization.h>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int INCORRECT_DATA;
+}
+
+namespace
+{
+    constexpr ITransformingStep::Traits getTraits()
+    {
+        return ITransformingStep::Traits
+        {
+            {
+                .returns_single_stream = false,
+                .preserves_number_of_streams = true,
+                .preserves_sorting = true,
+            },
+            {
+                .preserves_number_of_rows = true,
+            }
+        };
+    }
+
+    String formatAllowedOptimizations(const OptimizationBarrierStep::AllowedOptimizations & a)
+    {
+        WriteBufferFromOwnString out;
+        bool first = true;
+        auto append = [&](const char * name, bool value)
+        {
+            if (!value)
+                return;
+            if (!first)
+                out << ", ";
+            out << name;
+            first = false;
+        };
+        append("push_down_limit", a.push_down_limit);
+        append("remove_unused_columns", a.remove_unused_columns);
+        append("read_in_order", a.read_in_order);
+        if (first)
+            out << "(none)";
+        return out.str();
+    }
+}
+
+OptimizationBarrierStep::OptimizationBarrierStep(
+    const SharedHeader & header,
+    AllowedOptimizations allowed_optimizations_)
+    : ITransformingStep(header, header, getTraits())
+    , allowed_optimizations(allowed_optimizations_)
+{
+}
+
+void OptimizationBarrierStep::describeActions(FormatSettings & settings) const
+{
+    const String & prefix = settings.detail_prefix;
+    settings.out << prefix << "Allowed optimizations: " << formatAllowedOptimizations(allowed_optimizations) << '\n';
+}
+
+void OptimizationBarrierStep::describeActions(JSONBuilder::JSONMap & map) const
+{
+    map.add("AllowedOptimizations", formatAllowedOptimizations(allowed_optimizations));
+}
+
+void OptimizationBarrierStep::serialize(Serialization & ctx) const
+{
+    writeBinary(allowed_optimizations.push_down_limit, ctx.out);
+    writeBinary(allowed_optimizations.remove_unused_columns, ctx.out);
+    writeBinary(allowed_optimizations.read_in_order, ctx.out);
+}
+
+QueryPlanStepPtr OptimizationBarrierStep::deserialize(Deserialization & ctx)
+{
+    if (ctx.input_headers.size() != 1)
+        throw Exception(ErrorCodes::INCORRECT_DATA, "OptimizationBarrierStep must have one input stream");
+
+    AllowedOptimizations a;
+    readBinary(a.push_down_limit, ctx.in);
+    readBinary(a.remove_unused_columns, ctx.in);
+    readBinary(a.read_in_order, ctx.in);
+
+    return std::make_unique<OptimizationBarrierStep>(ctx.input_headers.front(), a);
+}
+
+void registerOptimizationBarrierStep(QueryPlanStepRegistry & registry)
+{
+    registry.registerStep("OptimizationBarrier", OptimizationBarrierStep::deserialize);
+}
+
+IQueryPlanStep::RemovedUnusedColumns OptimizationBarrierStep::removeUnusedColumns(NameMultiSet required_outputs, bool remove_inputs)
+{
+    /// Pass-through step: input and output must stay identical, so shrink only when opted in
+    /// and the optimizer also allows reducing the input side.
+    if (!allow_remove_unused_columns() || !remove_inputs)
+        return RemovedUnusedColumns::None;
+
+    const auto & old_header = *output_header;
+    Block new_header;
+    for (const auto & col : old_header)
+    {
+        if (required_outputs.contains(col.name))
+            new_header.insert(col);
+    }
+
+    if (new_header.columns() == old_header.columns())
+        return RemovedUnusedColumns::None;
+
+    auto new_shared_header = std::make_shared<const Block>(std::move(new_header));
+    updateInputHeader(new_shared_header, 0); /// also refreshes output_header via updateOutputHeader()
+    return RemovedUnusedColumns::OutputAndInput;
+}
+
+}

--- a/src/Processors/QueryPlan/OptimizationBarrierStep.h
+++ b/src/Processors/QueryPlan/OptimizationBarrierStep.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <Processors/QueryPlan/ITransformingStep.h>
+
+
+namespace DB
+{
+
+/// A pass-through step that blocks query-plan optimizations from crossing it.
+///
+/// By default no optimization can cross the barrier.
+/// Specific optimizations (push-downs, column pruning, read-in-order) can be opted in
+/// via `AllowedOptimizations`.
+///
+/// Typical use: a storage's `readImpl` appends the barrier to the top of its
+/// returned plan so outer expressions cannot be reordered relative to
+/// side-effecting or throw-prone steps below.
+///
+class OptimizationBarrierStep : public ITransformingStep
+{
+public:
+    /// Which optimizations are allowed to cross this barrier.
+    /// Anything not set here is blocked.
+    struct AllowedOptimizations
+    {
+        /// Allow an outer `LimitStep` to be pushed below the barrier.
+        /// Handled in tryPushDownLimit().
+        bool push_down_limit = false;
+
+        /// Allow column pruning to remove columns from the barrier's output
+        /// when no downstream consumer reads them.
+        /// Handled in this class via the canRemoveUnusedColumns() /
+        /// canRemoveColumnsFromOutput() / removeUnusedColumns() overrides.
+        bool remove_unused_columns = false;
+
+        /// Allow `optimizeReadInOrder` to treat this step as transparent when
+        /// matching an outer `SortingStep` against storage sort order.
+        /// Handled in findReadingStep() (optimizeReadInOrder.cpp).
+        bool read_in_order = false;
+    };
+
+    OptimizationBarrierStep(
+        const SharedHeader & header,
+        AllowedOptimizations allowed_optimizations_);
+
+    OptimizationBarrierStep(const OptimizationBarrierStep &) = default;
+
+    String getName() const override { return "OptimizationBarrier"; }
+
+    const AllowedOptimizations & getAllowedOptimizations() const { return allowed_optimizations; }
+
+    bool allow_push_down_limit() const { return allowed_optimizations.push_down_limit; }
+    bool allow_remove_unused_columns() const { return allowed_optimizations.remove_unused_columns; }
+    bool allow_read_in_order() const { return allowed_optimizations.read_in_order; }
+
+    void transformPipeline(QueryPipelineBuilder &, const BuildQueryPipelineSettings &) override {}
+
+    QueryPlanStepPtr clone() const override
+    {
+        return std::make_unique<OptimizationBarrierStep>(*this);
+    }
+
+    void describeActions(FormatSettings & settings) const override;
+    void describeActions(JSONBuilder::JSONMap & map) const override;
+
+    bool isSerializable() const override { return true; }
+    void serialize(Serialization & ctx) const override;
+    static QueryPlanStepPtr deserialize(Deserialization & ctx);
+
+    bool canRemoveUnusedColumns() const override { return allow_remove_unused_columns(); }
+    bool canRemoveColumnsFromOutput() const override { return allow_remove_unused_columns(); }
+    RemovedUnusedColumns removeUnusedColumns(NameMultiSet required_outputs, bool remove_inputs) override;
+
+private:
+    void updateOutputHeader() override
+    {
+        output_header = input_headers.front();
+    }
+
+    AllowedOptimizations allowed_optimizations;
+};
+
+}

--- a/src/Processors/QueryPlan/Optimizations/limitPushDown.cpp
+++ b/src/Processors/QueryPlan/Optimizations/limitPushDown.cpp
@@ -1,6 +1,7 @@
 #include <Processors/QueryPlan/Optimizations/Optimizations.h>
 #include <Processors/QueryPlan/ITransformingStep.h>
 #include <Processors/QueryPlan/LimitStep.h>
+#include <Processors/QueryPlan/OptimizationBarrierStep.h>
 #include <Processors/QueryPlan/TotalsHavingStep.h>
 #include <Processors/QueryPlan/SortingStep.h>
 #include <Processors/QueryPlan/UnionStep.h>
@@ -124,6 +125,13 @@ size_t tryPushDownLimit(QueryPlan::Node * parent_node, QueryPlan::Nodes & nodes,
     /// TODO: we can push down limit in some cases if increase the limit value.
     if (typeid_cast<const WindowStep *>(child.get()))
         return 0;
+
+    /// We push down limit through OptimizationBarrierStep if it's allowed.
+    if (auto * barrier = typeid_cast<OptimizationBarrierStep *>(child.get()))
+    {
+        if (!barrier->allow_push_down_limit())
+            return 0;
+    }
 
     /// Now we should decide if pushing down limit possible for this step.
 

--- a/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
@@ -14,6 +14,7 @@
 #include <Processors/QueryPlan/ITransformingStep.h>
 #include <Processors/QueryPlan/JoinStep.h>
 #include <Processors/QueryPlan/JoinStepLogical.h>
+#include <Processors/QueryPlan/OptimizationBarrierStep.h>
 #include <Processors/QueryPlan/Optimizations/Optimizations.h>
 #include <Processors/QueryPlan/Optimizations/actionsDAGUtils.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
@@ -129,6 +130,9 @@ QueryPlan::Node * findReadingStep(QueryPlan::Node & node, FindReadingStepContext
         return findReadingStep(*node.children.front(), data);
 
     if (typeid_cast<CreatingSetsStep *>(step) || typeid_cast<DelayedCreatingSetsStep *>(step))
+        return findReadingStep(*node.children.front(), data);
+
+    if (auto * barrier = typeid_cast<OptimizationBarrierStep *>(step); barrier && barrier->allow_read_in_order())
         return findReadingStep(*node.children.front(), data);
 
     if (data.read_in_order_through_join)

--- a/src/Processors/QueryPlan/QueryPlanStepRegistry.cpp
+++ b/src/Processors/QueryPlan/QueryPlanStepRegistry.cpp
@@ -60,6 +60,7 @@ void registerReadFromTableStep(QueryPlanStepRegistry & registry);
 void registerReadFromTableFunctionStep(QueryPlanStepRegistry & registry);
 void registerBuildRuntimeFilterStep(QueryPlanStepRegistry & registry);
 void registerObjectFilterStep(QueryPlanStepRegistry & registry);
+void registerOptimizationBarrierStep(QueryPlanStepRegistry & registry);
 
 void QueryPlanStepRegistry::registerPlanSteps()
 {
@@ -88,6 +89,7 @@ void QueryPlanStepRegistry::registerPlanSteps()
     registerReadFromTableFunctionStep(registry);
     registerBuildRuntimeFilterStep(registry);
     registerObjectFilterStep(registry);
+    registerOptimizationBarrierStep(registry);
 }
 
 }

--- a/src/Storages/StorageTimeSeriesSelector.cpp
+++ b/src/Storages/StorageTimeSeriesSelector.cpp
@@ -19,6 +19,7 @@
 #include <Parsers/ASTTablesInSelectQuery.h>
 #include <Parsers/Prometheus/parseTimeSeriesTypes.h>
 #include <Parsers/makeASTForLogicalFunction.h>
+#include <Processors/QueryPlan/OptimizationBarrierStep.h>
 #include <Storages/SelectQueryInfo.h>
 #include <Storages/StorageTimeSeries.h>
 #include <Storages/TimeSeries/TimeSeriesColumnNames.h>
@@ -465,6 +466,28 @@ void StorageTimeSeriesSelector::readImpl(
     InterpreterSelectQueryAnalyzer interpreter(select_query_from_data_table, context, options, column_names);
     interpreter.addStorageLimits(*query_info.storage_limits);
     query_plan = std::move(interpreter).extractQueryPlan();
+
+    /// Seal the inner plan behind an optimization barrier.
+    ///
+    /// The inner `WHERE id IN (SELECT timeSeriesStoreTags(...) FROM tags_table ...)` has a side
+    /// effect: `timeSeriesStoreTags` populates `ContextTimeSeriesTagsCollector` for every id it
+    /// returns. Downstream functions such as `timeSeriesIdToGroup(id)` read from that collector.
+    ///
+    /// Without this barrier the outer expression can be fused with the inner filter (via
+    /// `tryMergeExpressions`). Then `timeSeriesIdToGroup(id)` may be evaluated before the
+    /// `id IN (SELECT timeSeriesStoreTags(...) FROM tags_table ...)` filter is applied, so it runs
+    /// on ids for which `timeSeriesStoreTags` has not populated the collector yet, causing
+    /// exception "Unknown identifier".
+    ///
+    /// See also https://github.com/ClickHouse/ClickHouse/issues/83611, https://github.com/ClickHouse/ClickHouse/issues/100827.
+    OptimizationBarrierStep::AllowedOptimizations allowed_optimizations;
+    allowed_optimizations.push_down_limit = true;
+    allowed_optimizations.remove_unused_columns = true;
+    allowed_optimizations.read_in_order = true;
+    auto barrier_step = std::make_unique<OptimizationBarrierStep>(query_plan.getCurrentHeader(), allowed_optimizations);
+    barrier_step->setStepDescription(
+        "timeSeriesStoreTags must populate the per-query tag collector before downstream functions read it");
+    query_plan.addStep(std::move(barrier_step));
 }
 
 }

--- a/src/Storages/StorageTimeSeriesSelector.cpp
+++ b/src/Storages/StorageTimeSeriesSelector.cpp
@@ -383,16 +383,10 @@ namespace
             select_query->setExpression(ASTSelectQuery::Expression::TABLES, tables);
         }
 
-        /// PREWHERE (id IN (SELECT id FROM (select_query_from_tags_table))) AND (timestamp >= min_time) AND (timestamp <= max_time)
-        ///
-        /// NOTE: We have to use PREWHERE and not WHERE here to make sure that tags are stored in ContextTimeSeriesTagsCollector before we use them.
-        /// Otherwise in case the result of timeSeriesSelector() is passed to timeSeriesIdToGroup() as following:
-        /// SELECT timeSeriesIdToGroup(id) AS group, timestamp, value FROM timeSeriesSelector(...)
-        /// ClickHouse may decide to parallelize and execute timeSeriesIdToGroup(id) before executing timeSeriesStoreTags()
-        /// which may cause exception "Unknown identifier".
+        /// WHERE (id IN (SELECT id FROM (select_query_from_tags_table))) AND (timestamp >= min_time) AND (timestamp <= max_time)
         {
-            auto prewhere_filter = makeWhereFilterForDataTable(select_query_from_tags_table, min_time, max_time, timestamp_data_type);
-            select_query->setExpression(ASTSelectQuery::Expression::PREWHERE, std::move(prewhere_filter));
+            auto where_filter = makeWhereFilterForDataTable(select_query_from_tags_table, min_time, max_time, timestamp_data_type);
+            select_query->setExpression(ASTSelectQuery::Expression::WHERE, std::move(where_filter));
         }
 
         /// Wrap the select query into ASTSelectWithUnionQuery.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Revert `PREWHERE` in table function `timeSeriesSelector()`, add optimization barrier step instead