### PR TITLE
Fix backward compatibility break in sendProgress for INSERT queries

### DIFF
--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -128,6 +128,8 @@ static constexpr auto DBMS_MIN_REVISION_WITH_REPLICATED_SERIALIZATION = 54482;
 
 static constexpr auto DBMS_MIN_REVISION_WITH_NULLABLE_SPARSE_SERIALIZATION = 54483;
 
+static constexpr auto DBMS_MIN_PROTOCOL_VERSION_WITH_PROGRESS_IN_ASYNC_INSERT = 54484;
+
 
 /// Version of ClickHouse TCP protocol.
 ///
@@ -136,5 +138,5 @@ static constexpr auto DBMS_MIN_REVISION_WITH_NULLABLE_SPARSE_SERIALIZATION = 544
 /// NOTE: DBMS_TCP_PROTOCOL_VERSION has nothing common with VERSION_REVISION,
 /// later is just a number for server version (one number instead of commit SHA)
 /// for simplicity (sometimes it may be more convenient in some use cases).
-static constexpr auto DBMS_TCP_PROTOCOL_VERSION = 54483;
+static constexpr auto DBMS_TCP_PROTOCOL_VERSION = 54484;
 }

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -1409,7 +1409,8 @@ void TCPHandler::processInsertQuery(QueryState & state)
 
             {
                 std::lock_guard lock(*callback_mutex);
-                sendProgress(state);
+                if (client_tcp_protocol_version >= DBMS_MIN_PROTOCOL_VERSION_WITH_PROGRESS_IN_ASYNC_INSERT)
+                    sendProgress(state);
                 sendInsertProfileEvents(state);
             }
             return;
@@ -1433,7 +1434,6 @@ void TCPHandler::processInsertQuery(QueryState & state)
     }
 
     std::lock_guard lock(*callback_mutex);
-    sendProgress(state);
     sendInsertProfileEvents(state);
 }
 

--- a/tests/integration/test_old_versions/test.py
+++ b/tests/integration/test_old_versions/test.py
@@ -7,7 +7,7 @@ cluster = ClickHouseCluster(__file__)
 node_oldest = cluster.add_instance(
     "node_oldest",
     image="clickhouse/clickhouse-server",
-    tag="25.12",
+    tag=CLICKHOUSE_CI_MIN_TESTED_VERSION,
     with_installed_binary=True,
     main_configs=["configs/config.d/test_cluster.xml"],
 )

--- a/tests/queries/0_stateless/02010_lc_native.python
+++ b/tests/queries/0_stateless/02010_lc_native.python
@@ -254,9 +254,6 @@ def insertValidLowCardinalityRow():
         # Fin block
         sendEmptyBlock(s)
 
-        assertPacket(readVarUInt(s), 3)  # Progress
-        readProgress(s)
-
         assertPacket(readVarUInt(s), 5)  # End of stream
         s.close()
 


### PR DESCRIPTION
PR #99879 added `sendProgress` at the end of `processInsertQuery` for both sync and async insert paths. This broke backward compatibility — old clients whose `RemoteInserter::onFinish` does not handle `Progress` packets fail with `UNEXPECTED_PACKET_FROM_SERVER` when inserting into a newer server (e.g. 25.8 → 26.4 via `INSERT INTO remote()`).

**Changes:**
- Remove `sendProgress` from the sync insert path (it was unintentional — PR #99879 aimed to fix async insert progress only, sync inserts never sent `Progress` at the end of `processInsertQuery` before)
- Gate the async insert path's `sendProgress` behind a new protocol revision `DBMS_MIN_PROTOCOL_VERSION_WITH_PROGRESS_IN_ASYNC_INSERT` (54484)
- Restore `test_old_versions` to use `CLICKHOUSE_CI_MIN_TESTED_VERSION` instead of the hardcoded `"25.12"` pin that was introduced as a workaround

Fixes https://github.com/ClickHouse/clickhouse-private/issues/54601
Related PR: https://github.com/ClickHouse/ClickHouse/pull/99879

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix backward compatibility break where old clients fail with `UNEXPECTED_PACKET_FROM_SERVER` when inserting into a newer server via `remote()` or distributed tables, caused by unconditional `sendProgress` at the end of `processInsertQuery`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.720`
- Backported to: `26.4.3.28`, `26.3.11.36`
<!-- ch-version-info:end -->