### PR TITLE
Avoid conflicts on renamed files when creating cherry-picks

### DIFF
--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -252,13 +252,21 @@ close it.
         # other actions are required. It's possible when changes are backported
         # manually to the release branch already
         try:
-            output = git_runner(
+            git_runner(
                 f"{GIT_PREFIX} -c merge.renameLimit=999999 "
                 f"merge --no-ff --no-edit {self.pr.merge_commit_sha}"
             )
-            # 'up-to-date', 'up to date', who knows what else (╯°v°)╯ ^┻━┻
-            if output.startswith("Already up") and output.endswith("date."):
-                # The changes are already in the release branch, we are done here
+            # The merge succeeded. If it produced no tree change vs
+            # backport_branch, the PR is effectively already backported to
+            # the release branch - either "Already up to date" (no merge
+            # commit at all) or an empty merge commit whose resolution
+            # collapsed onto backport_branch's tree (e.g. the PR was
+            # manually applied with equivalent content). In either case,
+            # skip creating an empty cherry-pick PR.
+            if not git_runner(
+                f"{GIT_PREFIX} diff --name-only "
+                f"{self.backport_branch} {self.cherrypick_branch}"
+            ):
                 logging.info(
                     "Release branch %s already contain changes from %s",
                     self.name,

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -238,23 +238,29 @@ close it.
         first_parent = git_runner(f"git rev-parse {self.pr.merge_commit_sha}^1")
         git_runner(f"{GIT_PREFIX} merge -s ours --no-edit {first_parent}")
 
-        # Second step, create cherrypick branch on top of backport_branch and
-        # perform the merge locally. When it succeeds, cherrypick_branch points
-        # at a merge commit with the resolution baked in, so GitHub's merge of
-        # the cherry-pick PR becomes trivial. This avoids a failure mode where
-        # files renamed between the release branch and master produce conflicts
-        # in GitHub's merge even though local `git merge` resolves them via
-        # rename detection. The rename limit is raised to prevent git from
-        # silently disabling rename detection on large diffs.
-        git_runner(f"{GIT_PREFIX} checkout -B {self.cherrypick_branch}")
+        # Second step, create cherrypick branch
+        git_runner(
+            f"{GIT_PREFIX} checkout --no-track -B "
+            f"{self.cherrypick_branch} {self.pr.merge_commit_sha}"
+        )
 
-        # Check if there are actually any changes between branches. If no, then no
-        # other actions are required. It's possible when changes are backported
-        # manually to the release branch already
+        # Try to merge backport_branch into cherrypick_branch locally. When it
+        # succeeds, the merge commit (with rename detection etc. resolved) is
+        # baked into cherrypick_branch, so GitHub's merge of the cherry-pick PR
+        # becomes trivial - backport_branch is an ancestor of cherrypick_branch
+        # via the merge commit. This avoids a failure mode where files renamed
+        # between the release branch and master produce conflicts in GitHub's
+        # merge even though local `git merge` resolves them via rename
+        # detection. The rename limit is raised to prevent git from silently
+        # disabling rename detection on large diffs.
+        #
+        # On conflict, cherrypick_branch stays at pr.merge_commit_sha (the
+        # merge --abort restores HEAD), and conflicts are surfaced on the
+        # GitHub PR for manual resolution by the assigned engineer.
         try:
             git_runner(
                 f"{GIT_PREFIX} -c merge.renameLimit=999999 "
-                f"merge --no-ff --no-edit {self.pr.merge_commit_sha}"
+                f"merge --no-ff --no-edit {self.backport_branch}"
             )
             # The merge succeeded. If it produced no tree change vs
             # backport_branch, the PR is effectively already backported to
@@ -275,15 +281,7 @@ close it.
                 self._backported = True
                 return
         except CalledProcessError:
-            # Local merge has conflicts. Abort and fall back to the old
-            # behavior: cherrypick_branch points at the raw master commit,
-            # and conflicts are surfaced on the GitHub PR for manual
-            # resolution by the assigned engineer.
             git_runner(f"{GIT_PREFIX} merge --abort")
-            git_runner(
-                f"{GIT_PREFIX} checkout -B "
-                f"{self.cherrypick_branch} {self.pr.merge_commit_sha}"
-            )
 
         # Push, create the cherry-pick PR and label it
         for branch in [self.cherrypick_branch, self.backport_branch]:

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -238,18 +238,23 @@ close it.
         first_parent = git_runner(f"git rev-parse {self.pr.merge_commit_sha}^1")
         git_runner(f"{GIT_PREFIX} merge -s ours --no-edit {first_parent}")
 
-        # Second step, create cherrypick branch
-        git_runner(
-            f"{GIT_PREFIX} branch -f "
-            f"{self.cherrypick_branch} {self.pr.merge_commit_sha}"
-        )
+        # Second step, create cherrypick branch on top of backport_branch and
+        # perform the merge locally. When it succeeds, cherrypick_branch points
+        # at a merge commit with the resolution baked in, so GitHub's merge of
+        # the cherry-pick PR becomes trivial. This avoids a failure mode where
+        # files renamed between the release branch and master produce conflicts
+        # in GitHub's merge even though local `git merge` resolves them via
+        # rename detection. The rename limit is raised to prevent git from
+        # silently disabling rename detection on large diffs.
+        git_runner(f"{GIT_PREFIX} checkout -B {self.cherrypick_branch}")
 
         # Check if there are actually any changes between branches. If no, then no
         # other actions are required. It's possible when changes are backported
         # manually to the release branch already
         try:
             output = git_runner(
-                f"{GIT_PREFIX} merge --no-commit --no-ff {self.cherrypick_branch}"
+                f"{GIT_PREFIX} -c merge.renameLimit=999999 "
+                f"merge --no-ff --no-edit {self.pr.merge_commit_sha}"
             )
             # 'up-to-date', 'up to date', who knows what else (╯°v°)╯ ^┻━┻
             if output.startswith("Already up") and output.endswith("date."):
@@ -262,11 +267,15 @@ close it.
                 self._backported = True
                 return
         except CalledProcessError:
-            # There are most probably conflicts, they'll be resolved in PR
-            git_runner(f"{GIT_PREFIX} reset --merge")
-        else:
-            # There are changes to apply, so continue
-            git_runner(f"{GIT_PREFIX} reset --merge")
+            # Local merge has conflicts. Abort and fall back to the old
+            # behavior: cherrypick_branch points at the raw master commit,
+            # and conflicts are surfaced on the GitHub PR for manual
+            # resolution by the assigned engineer.
+            git_runner(f"{GIT_PREFIX} merge --abort")
+            git_runner(
+                f"{GIT_PREFIX} checkout -B "
+                f"{self.cherrypick_branch} {self.pr.merge_commit_sha}"
+            )
 
         # Push, create the cherry-pick PR and label it
         for branch in [self.cherrypick_branch, self.backport_branch]:


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


---

When the patched file was renamed between the `cherrypick_branch` and `master`, our automatic cherry-pick PR will have a conflict. Moreover, this conflict will be "too complex to resolve in the UI", i.e., it will require manual intervention. The required manipulation cannot be more stupid - you just need to run `git merge` locally, and `git` will resolve everything automatically.
I'm not sure if there was any strong reason to use `--no-commit` and always outsource the merge to GH, so I need some feedback from the CI team. 

Was tested on https://github.com/ClickHouse/ClickHouse/pull/102849. 

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.449`
<!-- ch-version-info:end -->