### PR TITLE
Compare rows instead of marks to select correct projection when using different index_granularity settings

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeUseAggregateProjection.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeUseAggregateProjection.cpp
@@ -730,20 +730,23 @@ std::optional<String> optimizeUseAggregateProjections(
                 stat.filtered_parts = candidate.filtered_parts;
                 candidate.stat = &stat;
 
-                size_t parent_reading_marks = parent_reading_select_result->selected_marks;
-                if (candidate.sum_marks > parent_reading_marks)
+                size_t parent_reading_rows = parent_reading_select_result->selected_rows;
+                if (candidate.sum_rows > parent_reading_rows)
                 {
                     stat.description = fmt::format(
-                        "Projection {} is usable but requires reading {} marks, which is not better than the original table with {} marks",
+                        "Projection {} is usable but requires reading {} marks consisting of {} rows, "
+                        "which is not better than the original table with {} marks consisting of {} rows",
                         candidate.projection->name,
                         candidate.sum_marks,
-                        parent_reading_marks);
+                        candidate.sum_rows,
+                        parent_reading_select_result->selected_marks,
+                        parent_reading_rows);
 
                     LOG_DEBUG(logger, "{}", stat.description);
                     continue;
                 }
 
-                if (best_candidate == nullptr || best_candidate->sum_marks > candidate.sum_marks)
+                if (best_candidate == nullptr || best_candidate->sum_rows > candidate.sum_rows)
                     best_candidate = &candidate;
             }
         }
@@ -769,20 +772,26 @@ std::optional<String> optimizeUseAggregateProjections(
                 chassert(candidate.stat);
                 chassert(candidate.stat->description.empty());
                 candidate.stat->description = fmt::format(
-                    "Projection {} is selected as the best with {} marks to read, while the original table requires scanning {} marks",
+                    "Projection {} is selected as the best with {} marks consisting of {} rows to read, "
+                    "while the original table requires scanning {} marks consisting of {} rows",
                     candidate.projection->name,
                     candidate.sum_marks,
-                    parent_reading_select_result->selected_marks);
+                    candidate.sum_rows,
+                    parent_reading_select_result->selected_marks,
+                    parent_reading_select_result->selected_rows);
                 LOG_DEBUG(logger, "{}", candidate.stat->description);
             }
             else if (candidate.stat && candidate.stat->description.empty())
             {
                 candidate.stat->description = fmt::format(
-                    "Projection {} is usable but requires reading {} marks, which is less efficient than projection {} with {} marks",
+                    "Projection {} is usable but requires reading {} marks consisting of {} rows, "
+                    "which is less efficient than projection {} with {} marks consisting of {} rows",
                     candidate.projection->name,
                     candidate.sum_marks,
+                    candidate.sum_rows,
                     best_candidate->projection->name,
-                    best_candidate->sum_marks);
+                    best_candidate->sum_marks,
+                    best_candidate->sum_rows);
                 LOG_DEBUG(logger, "{}", candidate.stat->description);
             }
         }

--- a/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
@@ -302,29 +302,32 @@ std::optional<String> optimizeUseNormalProjections(
         stat.filtered_parts = candidate.filtered_parts;
         candidate.stat = &stat;
 
-        size_t parent_reading_marks = parent_reading_select_result->selected_marks;
+        size_t parent_reading_rows = parent_reading_select_result->selected_rows;
 
         /// Consider projections with equal read cost only if:
         /// - `force_optimize_projection` is enabled, or
-        /// - the parent reading's `selected_marks` becomes zero
-        if (candidate.sum_marks > parent_reading_marks
-            || (candidate.sum_marks == parent_reading_marks && parent_reading_marks > 0 && !force_optimize_projection))
+        /// - the parent reading's `selected_rows` becomes zero
+        if (candidate.sum_rows > parent_reading_rows
+            || (candidate.sum_rows == parent_reading_rows && parent_reading_rows > 0 && !force_optimize_projection))
         {
             stat.description = fmt::format(
-                "Projection {} is usable but requires reading {} marks, which is not better than the original table with {} marks",
+                "Projection {} is usable but requires reading {} marks consisting of {} rows, "
+                "which is not better than the original table with {} marks consisting of {} rows",
                 candidate.projection->name,
                 candidate.sum_marks,
-                parent_reading_marks);
+                candidate.sum_rows,
+                parent_reading_select_result->selected_marks,
+                parent_reading_rows);
 
             LOG_DEBUG(logger, "{}", stat.description);
             continue;
         }
 
-        if (best_candidate == nullptr || candidate.sum_marks < best_candidate->sum_marks)
+        if (best_candidate == nullptr || candidate.sum_rows < best_candidate->sum_rows)
             best_candidate = &candidate;
 
         /// All parts has been filtered out; no need to analyze further projections.
-        if (parent_reading_marks == 0)
+        if (parent_reading_rows == 0)
             break;
     }
 
@@ -339,20 +342,26 @@ std::optional<String> optimizeUseNormalProjections(
             chassert(candidate.stat);
             chassert(candidate.stat->description.empty());
             candidate.stat->description = fmt::format(
-                "Projection {} is selected as the best with {} marks to read, while the original table requires scanning {} marks",
+                "Projection {} is selected as the best with {} marks consisting of {} rows to read, "
+                "while the original table requires scanning {} marks consisting of {} rows",
                 candidate.projection->name,
                 candidate.sum_marks,
-                parent_reading_select_result->selected_marks);
+                candidate.sum_rows,
+                parent_reading_select_result->selected_marks,
+                parent_reading_select_result->selected_rows);
             LOG_DEBUG(logger, "{}", candidate.stat->description);
         }
         else if (candidate.stat && candidate.stat->description.empty())
         {
             candidate.stat->description = fmt::format(
-                "Projection {} is usable but requires reading {} marks, which is less efficient than projection {} with {} marks",
+                "Projection {} is usable but requires reading {} marks consisting of {} rows, "
+                "which is less efficient than projection {} with {} marks consisting of {} rows",
                 candidate.projection->name,
                 candidate.sum_marks,
+                candidate.sum_rows,
                 best_candidate->projection->name,
-                best_candidate->sum_marks);
+                best_candidate->sum_marks,
+                best_candidate->sum_rows);
             LOG_DEBUG(logger, "{}", candidate.stat->description);
         }
     }

--- a/src/Processors/QueryPlan/Optimizations/projectionsCommon.cpp
+++ b/src/Processors/QueryPlan/Optimizations/projectionsCommon.cpp
@@ -294,6 +294,7 @@ bool analyzeProjectionCandidate(
 {
     RangesInDataParts projection_parts;
     size_t parent_parts_sum_marks = 0;
+    size_t parent_parts_sum_rows = 0;
     for (const auto & part_with_ranges : parent_reading_select_result.parts_with_ranges)
     {
         const auto & created_projections = part_with_ranges.data_part->getProjectionParts();
@@ -310,6 +311,7 @@ bool analyzeProjectionCandidate(
         {
             candidate.parent_parts.emplace(part_with_ranges.data_part.get());
             parent_parts_sum_marks += part_with_ranges.getMarksCount();
+            parent_parts_sum_rows += part_with_ranges.getRowsCount();
         }
     }
 
@@ -344,6 +346,7 @@ bool analyzeProjectionCandidate(
 
     candidate.merge_tree_projection_select_result_ptr = std::move(projection_result_ptr);
     candidate.sum_marks += candidate.merge_tree_projection_select_result_ptr->selected_marks + parent_parts_sum_marks;
+    candidate.sum_rows += candidate.merge_tree_projection_select_result_ptr->selected_rows + parent_parts_sum_rows;
 
     return true;
 }

--- a/src/Processors/QueryPlan/Optimizations/projectionsCommon.h
+++ b/src/Processors/QueryPlan/Optimizations/projectionsCommon.h
@@ -41,6 +41,10 @@ struct ProjectionCandidate
     /// Estimated total marks to read (including parent and projection)
     size_t sum_marks = 0;
 
+    /// Estimated total rows to read (including parent and projection).
+    /// Used for accurate cost comparison when table and projection have different index_granularity.
+    size_t sum_rows = 0;
+
     /// Number of parts, marks, and ranges selected during projection read
     size_t selected_parts = 0;
     size_t selected_marks = 0;

--- a/tests/queries/0_stateless/04104_projection_selection_different_granularity.reference
+++ b/tests/queries/0_stateless/04104_projection_selection_different_granularity.reference
@@ -1,0 +1,1 @@
+ReadFromMergeTree (prj_y)

--- a/tests/queries/0_stateless/04104_projection_selection_different_granularity.sql
+++ b/tests/queries/0_stateless/04104_projection_selection_different_granularity.sql
@@ -1,0 +1,20 @@
+-- Verify that projection selection chooses the right projection when
+-- it has a much smaller index_granularity than the parent table.
+
+CREATE TABLE t
+(
+    x UInt32,
+    y UInt32,
+    PROJECTION prj_y (SELECT x, y ORDER BY y) WITH SETTINGS (index_granularity = 8)
+)
+ENGINE = MergeTree
+ORDER BY x
+SETTINGS index_granularity = 8192;
+
+INSERT INTO t SELECT number, number % 16 FROM numbers(10000);
+
+-- The projection should be chosen: filtering by y on the projection reads far fewer
+-- rows despite having more marks due to the smaller granularity.
+SELECT trimLeft(explain)
+FROM (EXPLAIN projections = 1 SELECT * FROM t WHERE y = 0)
+WHERE explain LIKE '%ReadFromMergeTree%';


### PR DESCRIPTION
The `WITH SETTINGS` functionality allowing us to configure `index_granularity` per projection is great ([#90158](https://github.com/ClickHouse/ClickHouse/pull/90158)). However, it has some edge cases that lead to questionable behaviour when your PK and projections have a big discrepancy in `index_granularity`. This is due to comparing the number of filtered marks instead of the number of filtered rows.

Below is a simple reproduction of the issue.

```
CREATE TABLE default.projection_testing
(
    `x` UInt32,
    `y` UInt32,
    PROJECTION prj_y
    (
        SELECT
            x,
            y
        ORDER BY y
    ) WITH SETTINGS (index_granularity = 8)
)
ENGINE = MergeTree
PRIMARY KEY x
ORDER BY x
SETTINGS index_granularity = 8192

INSERT INTO projection_testing select number % 10000000, number % 16 from system.numbers LIMIT 50000000
```

When filtering by `y` on the table, we see that the projection was not chosen, despite the fact that 390628 marks on the projection is ~3M rows, and 6105 marks on the PK is ~50M rows.

```
EXPLAIN projections = 1
SELECT *
FROM projection_testing
WHERE y = 0
FORMAT raw

Query id: aeb36ab5-3462-4188-86fb-06f9b3f2f1d1

Expression ((Project names + Projection))
  Expression ((WHERE + Change column names to column identifiers))
    ReadFromMergeTree (default.projection_testing)
    Projections:
      Name: prj_y
        Description: Projection prj_y is usable but requires reading 390628 marks, which is not better than the original table with 6105 marks
        Condition: (y in [0, 0])
        Search Algorithm: binary search
        Parts: 5
        Marks: 390628
        Ranges: 5
        Rows: 3125024
        Filtered Parts: 0
```

Changing this to use row count feels more appropriate. With this change, the projection analysis uses the number of rows instead, and will see that ~3M rows < ~50M rows and therefore choose `prj_y`.

```
EXPLAIN projections = 1
SELECT *
FROM projection_testing
WHERE y = 0
FORMAT raw

Query id: 2f9b6628-0ed1-4bcc-bfb8-515c1ded48e2

Expression ((Project names + Projection))
  Expression
    ReadFromMergeTree (prj_y)

```


### Changelog category (leave one):
- Improvement



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Compare rows instead of marks to select correct projection when using different index_granularity settings.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
