### PR TITLE
Require Parquet for ENABLE_HIVE during building process

### DIFF
--- a/contrib/hive-metastore-cmake/CMakeLists.txt
+++ b/contrib/hive-metastore-cmake/CMakeLists.txt
@@ -1,7 +1,7 @@
-if (TARGET ch_contrib::hdfs)
+if (TARGET ch_contrib::hdfs AND TARGET ch_contrib::parquet)
     option(ENABLE_HIVE "Enable Hive" ${ENABLE_LIBRARIES})
 elseif(ENABLE_HIVE)
-    message (${RECONFIGURE_MESSAGE_LEVEL} "Cannot use Hive without HDFS")
+    message (${RECONFIGURE_MESSAGE_LEVEL} "Cannot use Hive without HDFS and Parquet")
 endif()
 
 if (NOT ENABLE_HIVE)


### PR DESCRIPTION
The guard that enables or disables Hive only required HDFS, but Hive also needs Parquet since the Hive storage code includes parquet headers unconditionally, and the Hive branch in TableFunctions links against `ch_contrib::parquet`.

Because of that, configuring with `-DENABLE_HIVE=ON -DENABLE_PARQUET=OFF` fails.

This PR adds Parquet to the guard which will disable Hive when Parquet or HDFS is off.

### Changelog category (leave one):

- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Require Parquet for ENABLE_HIVE during building process to fix build with -DENABLE_HIVE=ON -DENABLE_PARQUET=OFF

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

No documentation changes needed.