### PR TITLE
Do not wrap name column in CI report HTML

### DIFF
--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -332,7 +332,7 @@
         }
 
         .disabled {
-            white-space: pre-wrap;
+            white-space: pre;
         }
 
         .status-column span[style*="pointer"] {


### PR DESCRIPTION
Follow-up to #103074. `.disabled` is used for non-clickable name-column text (pending/skipped/running rows), so changing its `white-space` to `pre-wrap` caused test names to wrap unnecessarily. Revert to `pre`; `.info-text pre` still handles wrapping for the info column.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1086`
<!-- ch-version-info:end -->