### PR TITLE
Fix UBSan shift-exponent UB in HilbertUtils segmentBinaryPartition

### DIFF
--- a/src/Common/HilbertUtils.h
+++ b/src/Common/HilbertUtils.h
@@ -77,7 +77,7 @@ void segmentBinaryPartition(UInt64 start, UInt64 finish, UInt8 current_bits, F &
     {
         /// Use a 64-bit literal: `next_bits` can be up to 62, and shifting
         /// a 32-bit `int` by more than 31 bits is undefined behaviour.
-        if ((finish - start + 1) == (UInt64{1} << next_bits)) // it means that [begin, end] is a range
+        if ((finish - start + 1) == (1UL << next_bits)) // it means that [begin, end] is a range
         {
             callback(HilbertDetails::Segment{.begin = start, .end = finish});
             return;

--- a/src/Common/HilbertUtils.h
+++ b/src/Common/HilbertUtils.h
@@ -75,7 +75,9 @@ void segmentBinaryPartition(UInt64 start, UInt64 finish, UInt8 current_bits, F &
 
     if (start_chunk == finish_chunk)
     {
-        if ((finish - start + 1) == (1 << next_bits)) // it means that [begin, end] is a range
+        /// Use a 64-bit literal: `next_bits` can be up to 62, and shifting
+        /// a 32-bit `int` by more than 31 bits is undefined behaviour.
+        if ((finish - start + 1) == (UInt64{1} << next_bits)) // it means that [begin, end] is a range
         {
             callback(HilbertDetails::Segment{.begin = start, .end = finish});
             return;

--- a/src/Common/HilbertUtils.h
+++ b/src/Common/HilbertUtils.h
@@ -77,7 +77,7 @@ void segmentBinaryPartition(UInt64 start, UInt64 finish, UInt8 current_bits, F &
     {
         /// Use a 64-bit literal: `next_bits` can be up to 62, and shifting
         /// a 32-bit `int` by more than 31 bits is undefined behaviour.
-        if ((finish - start + 1) == (1UL << next_bits)) // it means that [begin, end] is a range
+        if ((finish - start + 1) == (UInt64{1} << next_bits)) // it means that [begin, end] is a range
         {
             callback(HilbertDetails::Segment{.begin = start, .end = finish});
             return;

--- a/src/Common/tests/gtest_hilbert_utils.cpp
+++ b/src/Common/tests/gtest_hilbert_utils.cpp
@@ -1,0 +1,70 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include <base/types.h>
+#include <Common/HilbertUtils.h>
+
+
+/// The bit-shift in `segmentBinaryPartition` at `HilbertUtils.h:78` used the
+/// literal `1` which is a 32-bit `int`. When `next_bits >= 32`, the shift
+/// `1 << next_bits` invoked undefined behaviour (caught by UBSan as
+/// "shift exponent N is too large for 32-bit type 'int'").
+///
+/// The entry below deliberately drives `segmentBinaryPartition` with
+/// `first` and `last` that land in the same top-level quadrant, so the
+/// `start_chunk == finish_chunk` branch is taken and the problematic
+/// comparison `(finish - start + 1) == (1 << next_bits)` is evaluated
+/// with `next_bits = 62`. Before the fix this fires UBSan; after the fix
+/// it completes normally.
+TEST(HilbertUtils, SegmentBinaryPartitionNoShiftOverflow)
+{
+    /// Whole top quadrant: [0xC000_0000_0000_0000, 0xFFFF_FFFF_FFFF_FFFF].
+    /// getLeadingZeroBits(last | first) == 0 → current_bits == 64,
+    /// next_bits == 62, and both ends live in chunk 3.
+    const UInt64 first = 0xC000000000000000ULL;
+    const UInt64 last = 0xFFFFFFFFFFFFFFFFULL;
+
+    std::vector<std::pair<UInt64, UInt64>> x_ranges;
+    std::vector<std::pair<UInt64, UInt64>> y_ranges;
+
+    hilbertIntervalToHyperrectangles2D(first, last, [&](std::array<std::pair<UInt64, UInt64>, 2> range)
+    {
+        x_ranges.push_back(range[0]);
+        y_ranges.push_back(range[1]);
+    });
+
+    /// The full quadrant must produce at least one hyperrectangle.
+    ASSERT_FALSE(x_ranges.empty());
+    ASSERT_EQ(x_ranges.size(), y_ranges.size());
+}
+
+/// A narrower range that still exercises a high `next_bits` during recursion.
+/// `first = 0x4000…0` and `last = 0x7FFF…F` covers quadrant 1, again forcing
+/// `start_chunk == finish_chunk` at `next_bits == 62`.
+TEST(HilbertUtils, SegmentBinaryPartitionSecondQuadrant)
+{
+    const UInt64 first = 0x4000000000000000ULL;
+    const UInt64 last = 0x7FFFFFFFFFFFFFFFULL;
+
+    size_t callback_count = 0;
+    hilbertIntervalToHyperrectangles2D(first, last, [&](std::array<std::pair<UInt64, UInt64>, 2>)
+    {
+        ++callback_count;
+    });
+
+    ASSERT_GT(callback_count, 0u);
+}
+
+/// Small ranges already worked before the fix, but this guards against a
+/// regression that would break short queries.
+TEST(HilbertUtils, SegmentBinaryPartitionSmallRangeStillWorks)
+{
+    size_t callback_count = 0;
+    hilbertIntervalToHyperrectangles2D(0, 15, [&](std::array<std::pair<UInt64, UInt64>, 2>)
+    {
+        ++callback_count;
+    });
+
+    ASSERT_GT(callback_count, 0u);
+}


### PR DESCRIPTION
## Summary

Fix an undefined-behaviour bit shift in `src/Common/HilbertUtils.h` that UBSan has been flagging from stress / serverfuzz runs on master and across several PR branches (tracked as STID 3760-41d4, issue #101332).

In `segmentBinaryPartition`, the branch checking whether `[start, finish]` exactly covers a sub-chunk used a 32-bit literal:

```cpp
if ((finish - start + 1) == (1 << next_bits))  // ← `1` is a 32-bit `int`
```

`next_bits` can reach `62` (when `current_bits == 64` and both endpoints share the top quadrant, so `start_chunk == finish_chunk`). Shifting a 32-bit `int` by 32 or more bits is undefined behaviour per the C++ standard, which UBSan reports as:

```
HilbertUtils.h:78:40: runtime error: shift exponent 62 is too large for 32-bit type 'int'
```

The fuzzer / stress-test stack lands on this expression via `KeyCondition::checkInHyperrectangle` for primary keys using `hilbertEncode(...)` — typical bit pattern reaches it through `arm_ubsan`, `arm_asan_ubsan`, and the `serverfuzz` variants (latest master hits on commit `32e69597b9214cda89982b243e2c471317d89653`, see the [CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=32e69597b9214cda89982b243e2c471317d89653&name_0=MasterCI&name_1=Stress%20test%20%28experimental%2C%20serverfuzz%2C%20arm_ubsan%29)).

### Fix

Shift a 64-bit literal instead. `UInt64{1} << next_bits` is well-defined for `next_bits` ≤ 62 and preserves the comparison's semantics (LHS is already `UInt64`).

### Regression test

New unit test `src/Common/tests/gtest_hilbert_utils.cpp` drives the two top-level quadrants (`[0xC0…, 0xFF…]` and `[0x40…, 0x7F…]`) that trigger `start_chunk == finish_chunk` with `next_bits == 62`, plus a small-range regression guard. Before this change UBSan prints the error above; after the change the tests pass cleanly under `UBSAN_OPTIONS=halt_on_error=1`.

Verified locally against the `asan_ubsan` build:
- `unit_tests_dbms --gtest_filter='HilbertUtils.*'` — 3/3 pass
- `unit_tests_dbms --gtest_filter='HilbertLookupTable.*'` — 6/6 still pass
- `tests/clickhouse-test --test-runs 20 03171_indexing_by_hilbert_curve` — 20/20 pass
- `tests/clickhouse-test 03131_hilbert_coding` — pass

Closes #101332

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.417`
<!-- ch-version-info:end -->