### PR TITLE
Fix linux tag not being respected in clickhouse-test on Darwin

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1143,6 +1143,7 @@ class FailureReason(enum.Enum):
     NO_OPENSSL_FIPS = "no-openssl-fips"
     ENCRYPTED_STORAGE = "encrypted-storage"
     NOT_SUPPORTED_ON_DARWIN = "not supported on Darwin"
+    LINUX_ONLY = "supported only on Linux"
 
     # UNKNOWN reasons
     NO_REFERENCE = "no reference file"
@@ -2403,10 +2404,11 @@ class TestCase:
         if "no-async-insert" in tags and args.no_async_insert:
             return FailureReason.NO_ASYNC_INSERT
 
-        if (
-            "no-darwin" in tags or "linux" in tags
-        ) and platform.system() == "Darwin":
+        if "no-darwin" in tags and platform.system() == "Darwin":
             return FailureReason.NOT_SUPPORTED_ON_DARWIN
+
+        if "linux" in tags and platform.system() != "Linux":
+            return FailureReason.LINUX_ONLY
 
         # Do not run *Log and Memory engine-specific tests
         if (

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2403,7 +2403,9 @@ class TestCase:
         if "no-async-insert" in tags and args.no_async_insert:
             return FailureReason.NO_ASYNC_INSERT
 
-        if "no-darwin" in tags and platform.system() == "Darwin":
+        if (
+            "no-darwin" in tags or "linux" in tags
+        ) and platform.system() == "Darwin":
             return FailureReason.NOT_SUPPORTED_ON_DARWIN
 
         # Do not run *Log and Memory engine-specific tests


### PR DESCRIPTION
The `linux` tag on a test is supposed to restrict it to Linux-only runs, but `clickhouse-test` did not check for it. Only the `no-darwin` tag triggered a skip on macOS. As a result, tests like `04061_http_pool_tcp_buffer_async_metrics` (which uses Linux-specific netlink socket diagnostics to collect TCP buffer async metrics) were being executed on macOS in the Fast Test (arm_darwin) job and failing.

The fix extends the existing `no-darwin` guard to also trigger when the `linux` tag is present, making both tags equivalent for Darwin.

Closes #103206

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.21`
<!-- ch-version-info:end -->