### PR TITLE
Fix flakiness in 03549_system_query_metric_log_with_queries_with_same_query_id on coverage builds

### DIFF
--- a/tests/queries/0_stateless/03549_system_query_metric_log_with_queries_with_same_query_id.sh
+++ b/tests/queries/0_stateless/03549_system_query_metric_log_with_queries_with_same_query_id.sh
@@ -37,7 +37,14 @@ while true; do
     sleep 0.5
 done
 
-$CLICKHOUSE_CLIENT --query-id="$same_query_finish" -q "SELECT sleep(2) SETTINGS query_metric_log_interval=100, replace_running_query=1 FORMAT Null;" &
+# Use a larger `replace_running_query_max_wait_ms` than the 5000ms default because on slow
+# builds (e.g. `amd_llvm_coverage`) the chain
+#     is_killed=true → sleep() notices cancellation → QUERY_WAS_CANCELLED unwinds →
+#     ProcessListEntry destructor removes query from map → notify_all
+# can take longer than 5s, causing a spurious `QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING`
+# "already running and can't be stopped" failure. 30s is well beyond worst-case coverage
+# timing but still bounded.
+$CLICKHOUSE_CLIENT --query-id="$same_query_finish" -q "SELECT sleep(2) SETTINGS query_metric_log_interval=100, replace_running_query=1, replace_running_query_max_wait_ms=30000 FORMAT Null;" &
 $CLICKHOUSE_CLIENT --query-id="$same_query_not_finish" -q "SELECT 'a' SETTINGS query_metric_log_interval=0, replace_running_query=0 FORMAT Null;" 2> /dev/null
 
 # Kill the initial query because the second one didn't replace it


### PR DESCRIPTION
Fix flakiness in `03549_system_query_metric_log_with_queries_with_same_query_id` on the `amd_llvm_coverage` variant.

Under LLVM source-based coverage instrumentation, the chain the test depends on —
`is_killed=true` → `sleep` loop notices cancellation → `QUERY_WAS_CANCELLED` unwinds →
`ProcessListEntry` destructor removes the query from the user map →
`have_space.notify_all` — can take longer than the default 5000ms
`replace_running_query_max_wait_ms`. The replacement query then times out waiting for
the first query to exit `ProcessList` and throws `QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING`
with message "already running and can't be stopped", failing the test.

This failure is strictly a timing artifact of the heavy coverage build — the test's
assertions about `replace_running_query` semantics are unchanged.

### Observed failures (last 30 days, CIDB)

- **master** 2026-04-20 22:55 UTC on `Stateless tests (amd_llvm_coverage, ParallelReplicas, s3 storage, parallel)` — commit `319b7aa2`
- **master** 2026-04-21 08:41 UTC on `Stateless tests (amd_llvm_coverage, 3/3)` — commit `1b90aee2`
- **PR #103189** 2026-04-20 20:48 UTC on `Stateless tests (amd_llvm_coverage, 3/3)` — commit `49c18c55`

All failures have the exact same error:

```
Code: 216. DB::Exception: Query with id = ..._two_finish is already running and can't be stopped. (QUERY_WITH_SAME_ID_IS_ALREADY_RUNNING)
```

Reports:
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=103189&sha=49c18c55bbe03d29ae80bc5a4455d4bb0aca85f2&name_0=PR&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%203%2F3%29
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=1b90aee2d24bd44c14d55c9b27d06012177a1bb6&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%203%2F3%29

### Deterministic local reproduction

Force the failure on any build by shrinking the wait:

```sql
-- session 1: start a sleep with query_id X, replace_running_query=0
SELECT sleep(120) SETTINGS replace_running_query=0

-- session 2 (after 1s): replace with tiny max_wait
SELECT sleep(2) SETTINGS replace_running_query=1, replace_running_query_max_wait_ms=50
-- → Code 216. DB::Exception: Query with id = X is already running and can't be stopped.
```

Bumping `replace_running_query_max_wait_ms=30000` eliminates the race in every repro.

### Fix

Pin `replace_running_query_max_wait_ms=30000` on the replacement query in the test. 30 s
is well beyond the worst-case coverage-build timing while still bounded. No other changes.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Deflake `03549_system_query_metric_log_with_queries_with_same_query_id` on LLVM coverage builds by raising `replace_running_query_max_wait_ms` in the test.

### Documentation entry for user-facing changes

- [ ] Documentation entry not required for this change.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.136`
<!-- ch-version-info:end -->