### PR TITLE
Skip 03096_order_by_system_tables under LLVM coverage builds

### DIFF
--- a/tests/queries/0_stateless/03096_order_by_system_tables.sql
+++ b/tests/queries/0_stateless/03096_order_by_system_tables.sql
@@ -1,3 +1,14 @@
+-- Tags: no-llvm-coverage
+-- Tag no-llvm-coverage: `SYSTEM FLUSH LOGS` flushes every system log table (including
+-- `trace_log`) and must wait for the shared backlog accumulated by other parallel tests.
+-- Under LLVM source-based coverage instrumentation the accumulated `trace_log` queue can
+-- exceed the 180s server-side `waitFlush` timeout (`SystemLogBase.cpp`), producing:
+--   Code: 159. DB::Exception: Timeout exceeded (180 s) while flushing system log
+--   'DB::SystemLogQueue<DB::TraceLogElement>'. (TIMEOUT_EXCEEDED)
+-- Same pattern as `01473_event_time_microseconds` / `00974_query_profiler` /
+-- `01569_query_profiler_big_query_id` and the precedent of commit cec04c17241
+-- (Kafka tests under coverage).
+
 SYSTEM FLUSH LOGS /* all tables */;
 
 -- Check for system tables which have non-default sorting key


### PR DESCRIPTION
The stateless test `03096_order_by_system_tables` intermittently fails on `Stateless tests (amd_llvm_coverage, */3)` with:

```
Code: 159. DB::Exception: Timeout exceeded (180 s) while flushing system log
'DB::SystemLogQueue<DB::TraceLogElement>'. (TIMEOUT_EXCEEDED) (version 26.4.1.1093)
```

The test only does `SYSTEM FLUSH LOGS /* all tables */` followed by a `system.tables` scan. Under LLVM source-based coverage the per-branch profiling overhead compounds across the `trace_log` backlog that parallel tests accumulate on the shared server, pushing `SystemLogBase::waitFlush` past its 180s default. The test itself has no timing assertions — the only path that fails here is the CI-shared `trace_log` flush.

This is the same failure mode as `01473_event_time_microseconds` on the same build variant (see PR #103219). 30-day CIDB across all branches:

- 7 failures across 6 unrelated PRs
- All on `amd_llvm_coverage*` variants
- 0 failures on `amd_llvm_coverage` master

Adding `no-llvm-coverage` follows the established precedent of `01473_event_time_microseconds`, `00974_query_profiler`, `01569_query_profiler_big_query_id`, and commit cec04c17241 (Kafka tests under coverage). The test still runs on every other build configuration so it continues to catch system-table sorting-key regressions.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100777&sha=4892bb02456a3a49a0a21553f684b664020674c9&name_0=PR&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%203%2F3%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Skip timing-sensitive system log test under LLVM coverage builds.

### Documentation entry for user-facing changes
- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1104`
<!-- ch-version-info:end -->