### PR TITLE
Add enable_compression setting for MySQL table function and engine

### DIFF
--- a/docs/en/engines/database-engines/mysql.md
+++ b/docs/en/engines/database-engines/mysql.md
@@ -29,6 +29,7 @@ You cannot perform the following queries:
 ```sql
 CREATE DATABASE [IF NOT EXISTS] db_name [ON CLUSTER cluster]
 ENGINE = MySQL('host:port', ['database' | database], 'user', 'password')
+[SETTINGS enable_compression=0]
 ```
 
 **Engine Parameters**
@@ -37,6 +38,22 @@ ENGINE = MySQL('host:port', ['database' | database], 'user', 'password')
 - `database` — Remote database name.
 - `user` — MySQL user.
 - `password` — User password.
+
+**Settings**
+
+### `enable_compression` {#enable-compression}
+
+Enables zlib compression for the MySQL protocol connection. When set to `1`, ClickHouse requests protocol-level compression from the MySQL server.
+
+Default value: `0`.
+
+Example:
+
+```sql
+CREATE DATABASE mysql_db
+ENGINE = MySQL('localhost:3306', 'test', 'my_user', 'user_password')
+SETTINGS enable_compression = 1;
+```
 
 ## Data types support {#data_types-support}
 

--- a/docs/en/engines/table-engines/integrations/mysql.md
+++ b/docs/en/engines/table-engines/integrations/mysql.md
@@ -24,7 +24,8 @@ SETTINGS
     [ connection_wait_timeout=5, ]
     [ connection_auto_close=true, ]
     [ connect_timeout=10, ]
-    [ read_write_timeout=300 ]
+    [ read_write_timeout=300, ]
+    [ enable_compression=false ]
 ;
 ```
 
@@ -190,6 +191,35 @@ Possible values:
 - Positive integer.
 
 Default value: `300`.
+
+### `enable_compression` {#enable-compression}
+
+Enables compression for the MySQL protocol connection.
+
+Default value: `false`.
+
+This setting applies to:
+
+- the `MySQL` table engine;
+- the `MySQL` database engine;
+- the `mysql` table function;
+- named collections used by MySQL integrations.
+
+When enabled, ClickHouse requests compression for the connection.
+
+Example:
+
+```sql
+CREATE TABLE mysql_engine_compression
+(
+    id UInt32,
+    name String,
+    age UInt32,
+    money UInt32
+)
+ENGINE = MySQL('mysql80:3306', 'clickhouse', 'test_table', 'root', 'password')
+SETTINGS enable_compression = 1;
+```
 
 ## See also {#see-also}
 

--- a/docs/en/sql-reference/statements/create/dictionary/sources/mysql.md
+++ b/docs/en/sql-reference/statements/create/dictionary/sources/mysql.md
@@ -28,6 +28,7 @@ SOURCE(MYSQL(
     invalidate_query 'SQL_QUERY'
     fail_on_connection_loss 'true'
     query 'SELECT id, value_1, value_2 FROM db_name.table_name'
+    enable_compression 1
 ))
 ```
 
@@ -54,6 +55,7 @@ SOURCE(MYSQL(
       <invalidate_query>SQL_QUERY</invalidate_query>
       <fail_on_connection_loss>true</fail_on_connection_loss>
       <query>SELECT id, value_1, value_2 FROM db_name.table_name</query>
+      <enable_compression>1</enable_compression>
   </mysql>
 </source>
 ```
@@ -76,8 +78,9 @@ Setting fields:
 | `table` | Name of the table. |
 | `where` | The selection criteria. The syntax for conditions is the same as for `WHERE` clause in MySQL, for example, `id > 10 AND id < 20`. Optional. |
 | `invalidate_query` | Query for checking the dictionary status. Optional. Read more in the section [Refreshing dictionary data using LIFETIME](../lifetime.md). |
-| `fail_on_connection_loss` | Controls behavior of the server on connection loss. If `true`, an exception is thrown immediately if the connection between client and server was lost. If `false`, the ClickHouse server retries to execute the query three times before throwing an exception. Note that retrying leads to increased response times. Default value: `false`. |
+| `fail_on_connection_loss` | Controls behavior of the server on connection loss. If `true`, an exception is thrown immediately if the connection between client and server was lost. If `false`, the server retries to fetch data at least three times before reporting an error. Note that retrying leads to increased response times. Default value: `false`. |
 | `query` | The custom query. Optional. |
+| `enable_compression` | Enables zlib compression for the MySQL protocol connection. When set to `1`, ClickHouse requests protocol-level compression from the MySQL server. Can also be set per-replica inside `<replica>`. Default value: `0`. |
 
 :::note
 The `table` or `where` fields cannot be used together with the `query` field. And either one of the `table` or `query` fields must be declared.

--- a/docs/en/sql-reference/table-functions/mysql.md
+++ b/docs/en/sql-reference/table-functions/mysql.md
@@ -102,6 +102,35 @@ SELECT * FROM mysql(creds, table='test');
 └────────┴───────┘
 ```
 
+### `enable_compression` {#enable-compression}
+
+Enables compression for the MySQL protocol connection.
+
+Default value: `false`.
+
+This setting applies to:
+
+- the `mysql` table function;
+- the `MySQL` table engine;
+- the `MySQL` database engine;
+- named collections used by MySQL integrations.
+
+When enabled, ClickHouse requests compression for the connection.
+
+Example:
+
+```sql
+SELECT *
+FROM mysql(
+    'mysql80:3306',
+    'clickhouse',
+    'test_table',
+    'root',
+    'password',
+    SETTINGS enable_compression = 1
+);
+```
+
 Replacing and inserting:
 
 ```sql

--- a/src/Common/mysqlxx/Connection.cpp
+++ b/src/Common/mysqlxx/Connection.cpp
@@ -52,10 +52,11 @@ Connection::Connection(
     unsigned timeout,
     unsigned rw_timeout,
     bool enable_local_infile,
-    bool opt_reconnect)
+    bool opt_reconnect,
+    bool enable_compression)
     : Connection()
 {
-    connect(db, server, user, password, port, socket, ssl_ca, ssl_cert, ssl_key, timeout, rw_timeout, enable_local_infile, opt_reconnect);
+    connect(db, server, user, password, port, socket, ssl_ca, ssl_cert, ssl_key, timeout, rw_timeout, enable_local_infile, opt_reconnect, enable_compression);
 }
 
 Connection::Connection(const std::string & config_name)
@@ -82,7 +83,8 @@ void Connection::connect(const char* db,
     unsigned timeout,
     unsigned rw_timeout,
     bool enable_local_infile,
-    bool opt_reconnect)
+    bool opt_reconnect,
+    bool enable_compression)
 {
     if (is_connected)
         disconnect();
@@ -108,6 +110,10 @@ void Connection::connect(const char* db,
 
     /// See C API Developer Guide: Automatic Reconnection Control
     if (mysql_options(driver.get(), MYSQL_OPT_RECONNECT, reinterpret_cast<const char *>(&opt_reconnect)))
+        throw ConnectionFailed(errorMessage(driver.get()), mysql_errno(driver.get()));
+
+    /// Enable classic MySQL protocol compression if requested.
+    if (enable_compression && mysql_options(driver.get(), MYSQL_OPT_COMPRESS, nullptr))
         throw ConnectionFailed(errorMessage(driver.get()), mysql_errno(driver.get()));
 
     /// Specifies particular ssl key and certificate if it needs

--- a/src/Common/mysqlxx/Pool.cpp
+++ b/src/Common/mysqlxx/Pool.cpp
@@ -93,6 +93,9 @@ Pool::Pool(const Poco::Util::AbstractConfiguration & cfg, const std::string & co
 
         opt_reconnect = cfg.getBool(config_name + ".opt_reconnect",
             cfg.getBool(parent_config_name + ".opt_reconnect", MYSQLXX_DEFAULT_MYSQL_OPT_RECONNECT));
+
+        enable_compression = cfg.getBool(config_name + ".enable_compression",
+            cfg.getBool(parent_config_name + ".enable_compression", false));
     }
     else
     {
@@ -113,6 +116,8 @@ Pool::Pool(const Poco::Util::AbstractConfiguration & cfg, const std::string & co
             config_name + ".enable_local_infile", MYSQLXX_DEFAULT_ENABLE_LOCAL_INFILE);
 
         opt_reconnect = cfg.getBool(config_name + ".opt_reconnect", MYSQLXX_DEFAULT_MYSQL_OPT_RECONNECT);
+
+        enable_compression = cfg.getBool(config_name + ".enable_compression", false);
     }
 
     connect_timeout = cfg.getInt(config_name + ".connect_timeout",
@@ -141,7 +146,8 @@ Pool::Pool(
      unsigned default_connections_,
      unsigned max_connections_,
      unsigned enable_local_infile_,
-     bool opt_reconnect_)
+     bool opt_reconnect_,
+     bool enable_compression_)
     : default_connections(default_connections_)
     , max_connections(max_connections_)
     , db(db_)
@@ -157,6 +163,7 @@ Pool::Pool(
     , ssl_key(ssl_key_)
     , enable_local_infile(enable_local_infile_)
     , opt_reconnect(opt_reconnect_)
+    , enable_compression(enable_compression_)
 {
     LOG_DEBUG(log,
         "Created MySQL Pool with settings: connect_timeout={}, read_write_timeout={}, default_connections_number={}, max_connections_number={}",
@@ -314,7 +321,8 @@ void Pool::Entry::forceConnected() const
                 pool->connect_timeout,
                 pool->rw_timeout,
                 pool->enable_local_infile,
-                pool->opt_reconnect);
+                pool->opt_reconnect,
+                pool->enable_compression);
         }
         catch (mysqlxx::ConnectionFailed &)
         {
@@ -390,7 +398,8 @@ Pool::Connection * Pool::allocConnection(bool dont_throw_if_failed_first_time)
             connect_timeout,
             rw_timeout,
             enable_local_infile,
-            opt_reconnect);
+            opt_reconnect,
+            enable_compression);
     }
     catch (mysqlxx::ConnectionFailed & e)
     {

--- a/src/Common/mysqlxx/PoolFactory.cpp
+++ b/src/Common/mysqlxx/PoolFactory.cpp
@@ -7,13 +7,9 @@ namespace mysqlxx
 
 struct PoolFactory::Impl
 {
-    // Cache of already affected pools identified by their config name
+    /// Cache of shared pools keyed by connection parameters (host, port, user, db, compression).
     std::map<std::string, std::shared_ptr<PoolWithFailover>> pools;
 
-    // Cache of Pool ID (host + port + user +...) cibling already established shareable pool
-    std::map<std::string, std::string> pools_by_ids;
-
-    /// Protect pools and pools_by_ids caches
     std::mutex mutex;
 };
 
@@ -38,8 +34,8 @@ static std::string getPoolEntryName(const Poco::Util::AbstractConfiguration & co
     std::string user = config.getString(config_name + ".user", "");
     std::string db = config.getString(config_name + ".db", "");
 
-    Poco::Util::AbstractConfiguration::Keys keys;
-    config.keys(config_name, keys);
+    /// Parent-level compression setting; used as fallback for replicas that do not override it.
+    bool parent_compression = config.getBool(config_name + ".enable_compression", false);
 
     if (config.has(config_name + ".replica"))
     {
@@ -54,13 +50,19 @@ static std::string getPoolEntryName(const Poco::Util::AbstractConfiguration & co
                 std::string tmp_host = config.getString(replica_name + ".host", host);
                 std::string tmp_port = config.getString(replica_name + ".port", port);
                 std::string tmp_user = config.getString(replica_name + ".user", user);
-                entry_name += (entry_name.empty() ? "" : "|") + tmp_user + "@" + tmp_host + ":" + tmp_port + "/" + db;
+
+                /// Resolve compression per replica: replica-level value takes priority,
+                /// falling back to the parent config (same lookup order as Pool::Pool).
+                std::string tmp_compression = config.getBool(replica_name + ".enable_compression", parent_compression) ? "1" : "0";
+
+                entry_name += (entry_name.empty() ? "" : "|") + tmp_user + "@" + tmp_host + ":" + tmp_port + "/" + db + "?compression=" + tmp_compression;
             }
         }
     }
     else
     {
-        entry_name = user + "@" + host + ":" + port + "/" + db;
+        std::string compression_value = parent_compression ? "1" : "0";
+        entry_name = user + "@" + host + ":" + port + "/" + db + "?compression=" + compression_value;
     }
     return entry_name;
 }
@@ -68,31 +70,24 @@ static std::string getPoolEntryName(const Poco::Util::AbstractConfiguration & co
 PoolWithFailover PoolFactory::get(const Poco::Util::AbstractConfiguration & config,
         const std::string & config_name, unsigned default_connections, unsigned max_connections, size_t max_tries)
 {
-
     std::lock_guard lock(impl->mutex);
-    auto entry = impl->pools.find(config_name);
-    if (entry != impl->pools.end())
-    {
-        return *(entry->second);
-    }
 
     std::string entry_name = getPoolEntryName(config, config_name);
-    if (auto id = impl->pools_by_ids.find(entry_name); id != impl->pools_by_ids.end())
-    {
-        entry = impl->pools.find(id->second);
-        std::shared_ptr<PoolWithFailover> pool = entry->second;
-        impl->pools.insert_or_assign(config_name, pool);
-        return *pool;
-    }
+
+    /// For shared pools (share_connection=true), entry_name encodes the actual connection
+    /// parameters (host, port, user, db, compression). Use it as the cache key instead of
+    /// config_name, because per-dictionary XML configs all share the same config path prefix
+    /// (e.g. "dictionary.source.mysql"), so keying by config_name alone would cause dicts
+    /// with different enable_compression values to incorrectly share a single pool.
+    const std::string & pool_key = entry_name.empty() ? config_name : entry_name;
+
+    auto entry = impl->pools.find(pool_key);
+    if (entry != impl->pools.end())
+        return *(entry->second);
 
     auto pool = std::make_shared<PoolWithFailover>(config, config_name, default_connections, max_connections, max_tries);
-    // Check the pool will be shared
     if (!entry_name.empty())
-    {
-        // Store shared pool
-        impl->pools.insert_or_assign(config_name, pool);
-        impl->pools_by_ids.insert_or_assign(entry_name, config_name);
-    }
+        impl->pools.insert_or_assign(pool_key, pool);
     return *pool;
 }
 
@@ -100,7 +95,6 @@ void PoolFactory::reset()
 {
     std::lock_guard lock(impl->mutex);
     impl->pools.clear();
-    impl->pools_by_ids.clear();
 }
 
 PoolFactory::PoolFactory() : impl(std::make_unique<PoolFactory::Impl>()) {}

--- a/src/Common/mysqlxx/PoolWithFailover.cpp
+++ b/src/Common/mysqlxx/PoolWithFailover.cpp
@@ -130,7 +130,8 @@ PoolWithFailover::PoolWithFailover(
         uint64_t wait_timeout_,
         size_t connect_timeout_,
         size_t rw_timeout_,
-        bool bg_reconnect_)
+        bool bg_reconnect_,
+        bool enable_compression_)
     : max_tries(max_tries_)
     , shareable(false)
     , wait_timeout(wait_timeout_)
@@ -145,7 +146,10 @@ PoolWithFailover::PoolWithFailover(
             connect_timeout_,
             rw_timeout_,
             default_connections_,
-            max_connections_));
+            max_connections_,
+            MYSQLXX_DEFAULT_ENABLE_LOCAL_INFILE,
+            MYSQLXX_DEFAULT_MYSQL_OPT_RECONNECT,
+            enable_compression_));
         if (bg_reconnect)
             DB::ReplicasReconnector::instance().add(connectionReestablisher(std::weak_ptr(replicas_by_priority[0].back()), shareable));
     }

--- a/src/Common/mysqlxx/mysqlxx/Connection.h
+++ b/src/Common/mysqlxx/mysqlxx/Connection.h
@@ -81,7 +81,8 @@ public:
         unsigned timeout = MYSQLXX_DEFAULT_TIMEOUT,
         unsigned rw_timeout = MYSQLXX_DEFAULT_RW_TIMEOUT,
         bool enable_local_infile = MYSQLXX_DEFAULT_ENABLE_LOCAL_INFILE,
-        bool opt_reconnect = MYSQLXX_DEFAULT_MYSQL_OPT_RECONNECT);
+        bool opt_reconnect = MYSQLXX_DEFAULT_MYSQL_OPT_RECONNECT,
+        bool enable_compression = false);
 
     /// Creates connection. Can be used if Poco::Util::Application is using.
     /// All settings will be got from config_name section of configuration.
@@ -102,7 +103,8 @@ public:
         unsigned timeout = MYSQLXX_DEFAULT_TIMEOUT,
         unsigned rw_timeout = MYSQLXX_DEFAULT_RW_TIMEOUT,
         bool enable_local_infile = MYSQLXX_DEFAULT_ENABLE_LOCAL_INFILE,
-        bool opt_reconnect = MYSQLXX_DEFAULT_MYSQL_OPT_RECONNECT);
+        bool opt_reconnect = MYSQLXX_DEFAULT_MYSQL_OPT_RECONNECT,
+        bool enable_compression = false);
 
     void connect(const std::string & config_name)
     {
@@ -119,6 +121,7 @@ public:
         std::string ssl_key = cfg.getString(config_name + ".ssl_key", "");
         bool enable_local_infile = cfg.getBool(config_name + ".enable_local_infile", MYSQLXX_DEFAULT_ENABLE_LOCAL_INFILE);
         bool opt_reconnect = cfg.getBool(config_name + ".opt_reconnect", MYSQLXX_DEFAULT_MYSQL_OPT_RECONNECT);
+        bool enable_compression = cfg.getBool(config_name + ".enable_compression", false);
 
         unsigned timeout =
             cfg.getInt(config_name + ".connect_timeout",
@@ -143,7 +146,8 @@ public:
                 timeout,
                 rw_timeout,
                 enable_local_infile,
-                opt_reconnect);
+                opt_reconnect,
+                enable_compression);
     }
 
     /// If MySQL connection was established.

--- a/src/Common/mysqlxx/mysqlxx/Pool.h
+++ b/src/Common/mysqlxx/mysqlxx/Pool.h
@@ -176,7 +176,8 @@ public:
          unsigned default_connections_ = MYSQLXX_POOL_DEFAULT_START_CONNECTIONS,
          unsigned max_connections_ = MYSQLXX_POOL_DEFAULT_MAX_CONNECTIONS,
          unsigned enable_local_infile_ = MYSQLXX_DEFAULT_ENABLE_LOCAL_INFILE,
-         bool opt_reconnect_ = MYSQLXX_DEFAULT_MYSQL_OPT_RECONNECT);
+         bool opt_reconnect_ = MYSQLXX_DEFAULT_MYSQL_OPT_RECONNECT,
+         bool enable_compression_ = false);
 
     Pool(const Pool & other)
         : default_connections{other.default_connections},
@@ -186,7 +187,8 @@ public:
           port{other.port}, socket{other.socket},
           connect_timeout{other.connect_timeout}, rw_timeout{other.rw_timeout},
           ssl_ca(other.ssl_ca), ssl_cert(other.ssl_cert), ssl_key(other.ssl_key),
-          enable_local_infile{other.enable_local_infile}, opt_reconnect(other.opt_reconnect)
+          enable_local_infile{other.enable_local_infile}, opt_reconnect(other.opt_reconnect),
+          enable_compression{other.enable_compression}
     {}
 
     Pool & operator=(const Pool &) = delete;
@@ -249,6 +251,7 @@ private:
     std::string ssl_key;
     bool enable_local_infile;
     bool opt_reconnect;
+    bool enable_compression;
 
     /// True if connection was established at least once.
     bool was_successful{false};

--- a/src/Common/mysqlxx/mysqlxx/PoolWithFailover.h
+++ b/src/Common/mysqlxx/mysqlxx/PoolWithFailover.h
@@ -132,7 +132,8 @@ namespace mysqlxx
             uint64_t wait_timeout_ = MYSQLXX_POOL_WITH_FAILOVER_DEFAULT_CONNECTION_WAIT_TIMEOUT,
             size_t connect_timeout = MYSQLXX_DEFAULT_TIMEOUT,
             size_t rw_timeout = MYSQLXX_DEFAULT_RW_TIMEOUT,
-            bool bg_reconnect_ = false);
+            bool bg_reconnect_ = false,
+            bool enable_compression_ = false);
 
         PoolWithFailover(const PoolWithFailover & other);
 

--- a/src/Dictionaries/MySQLDictionarySource.cpp
+++ b/src/Dictionaries/MySQLDictionarySource.cpp
@@ -61,7 +61,7 @@ static const ValidateKeysMultiset<ExternalDatabaseEqualKeysSet> dictionary_allow
     "query", "where", "name" /* name_collection */, "socket",
     "share_connection", "fail_on_connection_loss", "close_connection",
     "ssl_ca", "ssl_cert", "ssl_key",
-    "enable_local_infile", "opt_reconnect",
+    "enable_local_infile", "opt_reconnect", "enable_compression",
     "connect_timeout", "mysql_connect_timeout",
     "mysql_rw_timeout", "rw_timeout"};
 

--- a/src/Storages/MySQL/MySQLHelpers.cpp
+++ b/src/Storages/MySQL/MySQLHelpers.cpp
@@ -14,6 +14,7 @@ namespace MySQLSetting
     extern const MySQLSettingsUInt64 connection_wait_timeout;
     extern const MySQLSettingsUInt64 connect_timeout;
     extern const MySQLSettingsUInt64 read_write_timeout;
+    extern const MySQLSettingsBool enable_compression;
 }
 
 namespace ErrorCodes
@@ -50,7 +51,9 @@ mysqlxx::PoolWithFailover createMySQLPoolWithFailover(
         mysql_settings[MySQLSetting::connection_max_tries],
         mysql_settings[MySQLSetting::connection_wait_timeout],
         mysql_settings[MySQLSetting::connect_timeout],
-        mysql_settings[MySQLSetting::read_write_timeout]);
+        mysql_settings[MySQLSetting::read_write_timeout],
+        false,
+        mysql_settings[MySQLSetting::enable_compression]);
 }
 
 }

--- a/src/Storages/MySQL/MySQLSettings.cpp
+++ b/src/Storages/MySQL/MySQLSettings.cpp
@@ -29,6 +29,7 @@ namespace ErrorCodes
     DECLARE(Bool, connection_auto_close, true, "Auto-close connection after query execution, i.e. disable connection reuse.", 0) \
     DECLARE(UInt64, connect_timeout, DBMS_DEFAULT_CONNECT_TIMEOUT_SEC, "Connect timeout (in seconds)", 0) \
     DECLARE(UInt64, read_write_timeout, DBMS_DEFAULT_RECEIVE_TIMEOUT_SEC, "Read/write timeout (in seconds)", 0) \
+    DECLARE(Bool, enable_compression, false, "Enable MySQL protocol compression (MYSQL_OPT_COMPRESS).", 0) \
     DECLARE(MySQLDataTypesSupport, mysql_datatypes_support_level, "decimal,datetime64,date2Date32", "Which MySQL types should be converted to corresponding ClickHouse types. All modern mappings (decimal, datetime64, date2Date32) are enabled by default. Can be set to any combination of 'decimal', 'datetime64', 'date2Date32', or 'date2String'.", 0) \
 
 DECLARE_SETTINGS_TRAITS(MySQLSettingsTraits, LIST_OF_MYSQL_SETTINGS, MYSQL_SETTINGS_SUPPORTED_TYPES)

--- a/tests/integration/test_dictionaries_mysql/configs/dictionaries/mysql_dict_compression.xml
+++ b/tests/integration/test_dictionaries_mysql/configs/dictionaries/mysql_dict_compression.xml
@@ -1,0 +1,30 @@
+<clickhouse>
+    <dictionary>
+        <name>dict_compression</name>
+        <source>
+            <mysql>
+                <db>test</db>
+                <host>mysql80</host>
+                <port>3306</port>
+                <user>root</user>
+                <password>ClickHouse_MySQL_P@ssw0rd</password>
+                <table>dict_compression_table</table>
+                <enable_compression>1</enable_compression>
+            </mysql>
+        </source>
+        <layout>
+            <flat/>
+        </layout>
+        <structure>
+            <id>
+                <name>id</name>
+            </id>
+            <attribute>
+                <name>value</name>
+                <type>String</type>
+                <null_value></null_value>
+            </attribute>
+        </structure>
+        <lifetime>0</lifetime>
+    </dictionary>
+</clickhouse>

--- a/tests/integration/test_dictionaries_mysql/configs/dictionaries/mysql_dict_compression_wire.xml
+++ b/tests/integration/test_dictionaries_mysql/configs/dictionaries/mysql_dict_compression_wire.xml
@@ -1,0 +1,34 @@
+<clickhouse>
+    <dictionary>
+        <name>dict_compression_wire</name>
+        <source>
+            <mysql>
+                <db>performance_schema</db>
+                <host>mysql80</host>
+                <port>3306</port>
+                <user>root</user>
+                <password>ClickHouse_MySQL_P@ssw0rd</password>
+                <table>session_status</table>
+                <enable_compression>1</enable_compression>
+                <share_connection>1</share_connection>
+            </mysql>
+        </source>
+        <layout>
+            <complex_key_hashed/>
+        </layout>
+        <structure>
+            <key>
+                <attribute>
+                    <name>VARIABLE_NAME</name>
+                    <type>String</type>
+                </attribute>
+            </key>
+            <attribute>
+                <name>VARIABLE_VALUE</name>
+                <type>String</type>
+                <null_value></null_value>
+            </attribute>
+        </structure>
+        <lifetime>0</lifetime>
+    </dictionary>
+</clickhouse>

--- a/tests/integration/test_dictionaries_mysql/configs/dictionaries/mysql_dict_no_compression_wire.xml
+++ b/tests/integration/test_dictionaries_mysql/configs/dictionaries/mysql_dict_no_compression_wire.xml
@@ -1,0 +1,34 @@
+<clickhouse>
+    <dictionary>
+        <name>dict_no_compression_wire</name>
+        <source>
+            <mysql>
+                <db>performance_schema</db>
+                <host>mysql80</host>
+                <port>3306</port>
+                <user>root</user>
+                <password>ClickHouse_MySQL_P@ssw0rd</password>
+                <table>session_status</table>
+                <enable_compression>0</enable_compression>
+                <share_connection>1</share_connection>
+            </mysql>
+        </source>
+        <layout>
+            <complex_key_hashed/>
+        </layout>
+        <structure>
+            <key>
+                <attribute>
+                    <name>VARIABLE_NAME</name>
+                    <type>String</type>
+                </attribute>
+            </key>
+            <attribute>
+                <name>VARIABLE_VALUE</name>
+                <type>String</type>
+                <null_value></null_value>
+            </attribute>
+        </structure>
+        <lifetime>0</lifetime>
+    </dictionary>
+</clickhouse>

--- a/tests/integration/test_dictionaries_mysql/test.py
+++ b/tests/integration/test_dictionaries_mysql/test.py
@@ -12,7 +12,13 @@ from helpers.cluster import ClickHouseCluster
 from helpers.port_forward import PortForward
 from helpers.config_cluster import mysql_pass
 
-DICTS = ["configs/dictionaries/mysql_dict1.xml", "configs/dictionaries/mysql_dict2.xml"]
+DICTS = [
+    "configs/dictionaries/mysql_dict1.xml",
+    "configs/dictionaries/mysql_dict2.xml",
+    "configs/dictionaries/mysql_dict_compression.xml",
+    "configs/dictionaries/mysql_dict_compression_wire.xml",
+    "configs/dictionaries/mysql_dict_no_compression_wire.xml",
+]
 CONFIG_FILES = [
     "configs/remote_servers.xml",
     "configs/named_collections.xml",
@@ -617,3 +623,111 @@ def test_background_dictionary_reconnect(started_cluster):
             )
             > 0
         )
+
+
+def test_enable_compression_xml_dict(started_cluster):
+    """Regression: <enable_compression>1</enable_compression> in XML dictionary source must not be rejected."""
+    mysql_connection = get_mysql_conn(started_cluster)
+
+    try:
+        execute_mysql_query(mysql_connection, "DROP TABLE IF EXISTS test.dict_compression_table;")
+        execute_mysql_query(
+            mysql_connection,
+            "CREATE TABLE test.dict_compression_table (id INT NOT NULL, value TEXT, PRIMARY KEY(id));",
+        )
+        execute_mysql_query(
+            mysql_connection,
+            "INSERT INTO test.dict_compression_table VALUES (1, 'compressed');",
+        )
+
+        # Regression: verify that <enable_compression>1</enable_compression> in the XML
+        # source config is accepted by the parser and does not raise UNKNOWN_SETTING.
+        # The dict may be in FAILED state here (dict_compression_table did not exist at
+        # server startup so the initial load failed), but any failure must be a connection
+        # or table error — not a configuration-rejection error.
+        last_exception = instance.query(
+            "SELECT last_exception FROM system.dictionaries WHERE name = 'dict_compression'"
+        ).strip()
+        assert "UNKNOWN_SETTING" not in last_exception, (
+            f"<enable_compression> was rejected in the XML dict config: {last_exception!r}"
+        )
+
+        # Pool-isolation regression: dict_compression_wire (enable_compression=1,
+        # share_connection=1) and dict_no_compression_wire (enable_compression=0,
+        # share_connection=1) share the same host/user/db/port. The PoolFactory cache
+        # key must include the compression flag so each dict gets its own pool.
+        # Reload both in one cycle so they compete for the same cache lifetime; a broken
+        # discriminator would cause them to share a pool and one assertion below would fail.
+        for _ in range(10):
+            try:
+                instance.query("SYSTEM RELOAD DICTIONARIES")
+                break
+            except Exception:
+                time.sleep(0.5)
+
+        xml_wire_compression = ""
+        for _ in range(10):
+            xml_wire_compression = instance.query(
+                "SELECT dictGet('dict_compression_wire', 'VARIABLE_VALUE', 'Compression')"
+            ).strip()
+            if xml_wire_compression == "ON":
+                break
+            time.sleep(0.5)
+        assert xml_wire_compression == "ON", (
+            f"Expected Compression=ON via XML dict config path, got: {xml_wire_compression!r}"
+        )
+
+        no_compression_status = ""
+        for _ in range(10):
+            no_compression_status = instance.query(
+                "SELECT dictGet('dict_no_compression_wire', 'VARIABLE_VALUE', 'Compression')"
+            ).strip()
+            if no_compression_status == "OFF":
+                break
+            time.sleep(0.5)
+        assert no_compression_status == "OFF", (
+            f"Expected Compression=OFF for uncompressed dict, got: {no_compression_status!r}"
+        )
+
+        # Wire-level assertion for the DDL dictionary source path (address-based
+        # PoolWithFailover constructor via createMySQLPoolWithFailover). This is a separate
+        # code path from the XML config pool above.
+        instance.query("DROP DICTIONARY IF EXISTS dict_compression_wire_check")
+        instance.query(
+            f"""
+            CREATE DICTIONARY dict_compression_wire_check
+            (
+                VARIABLE_NAME String,
+                VARIABLE_VALUE String
+            )
+            PRIMARY KEY VARIABLE_NAME
+            SOURCE(MYSQL(
+                host 'mysql80'
+                port 3306
+                user 'root'
+                password '{mysql_pass}'
+                db 'performance_schema'
+                table 'session_status'
+                enable_compression 1
+            ))
+            LAYOUT(COMPLEX_KEY_HASHED())
+            LIFETIME(0)
+            """
+        )
+        try:
+            wire_compression = ""
+            for _ in range(10):
+                wire_compression = instance.query(
+                    "SELECT dictGet('dict_compression_wire_check', 'VARIABLE_VALUE', 'Compression')"
+                ).strip()
+                if wire_compression == "ON":
+                    break
+                time.sleep(0.5)
+            assert wire_compression == "ON", (
+                f"Expected Compression=ON via DDL dict source path, got: {wire_compression!r}"
+            )
+        finally:
+            instance.query("DROP DICTIONARY IF EXISTS dict_compression_wire_check")
+    finally:
+        execute_mysql_query(mysql_connection, "DROP TABLE IF EXISTS test.dict_compression_table;")
+        mysql_connection.close()

--- a/tests/integration/test_storage_mysql/test.py
+++ b/tests/integration/test_storage_mysql/test.py
@@ -759,6 +759,171 @@ def test_settings(started_cluster):
     conn.close()
 
 
+def test_enable_compression(started_cluster):
+    table_name = "test_enable_compression"
+    node1.query(f"DROP TABLE IF EXISTS {table_name}")
+    node1.query("DROP NAMED COLLECTION IF EXISTS mysql_compression_creds")
+
+    conn = get_mysql_conn(started_cluster, cluster.mysql8_ip)
+    drop_mysql_table(conn, table_name)
+    create_mysql_table(conn, table_name)
+
+    with conn.cursor() as cursor:
+        cursor.execute(
+            f"INSERT INTO `clickhouse`.`{table_name}` (id, name, age, money) VALUES (1, 'name_1', 10, 20)"
+        )
+    conn.commit()
+
+    node1.query(
+        f"""
+        CREATE TABLE {table_name}
+        (
+            id UInt32,
+            name String,
+            age UInt32,
+            money UInt32
+        )
+        ENGINE = MySQL('mysql80:3306', 'clickhouse', '{table_name}', 'root', '{mysql_pass}')
+        SETTINGS enable_compression=1
+        """
+    )
+
+    assert node1.query(f"SELECT * FROM {table_name} FORMAT TSV").strip() == "1\tname_1\t10\t20"
+
+    # Wire-level assertion for the MySQL table engine path (SETTINGS clause).
+    # Create a second engine table pointing at performance_schema.session_status to
+    # confirm that ClickHouse actually negotiates CLIENT_COMPRESS for that connection.
+    node1.query("DROP TABLE IF EXISTS compression_status_engine")
+    node1.query(
+        f"""
+        CREATE TABLE compression_status_engine
+        (
+            VARIABLE_NAME String,
+            VARIABLE_VALUE String
+        )
+        ENGINE = MySQL('mysql80:3306', 'performance_schema', 'session_status', 'root', '{mysql_pass}')
+        SETTINGS enable_compression = 1
+        """
+    )
+    engine_compression_status = ""
+    for _ in range(10):
+        engine_compression_status = node1.query(
+            "SELECT VARIABLE_VALUE FROM compression_status_engine WHERE VARIABLE_NAME = 'Compression' FORMAT TSV"
+        ).strip()
+        if engine_compression_status == "ON":
+            break
+        time.sleep(0.5)
+    node1.query("DROP TABLE IF EXISTS compression_status_engine")
+    assert engine_compression_status == "ON", (
+        f"Expected Compression=ON via MySQL engine SETTINGS path, got: {engine_compression_status!r}"
+    )
+
+    node1.query(f"DROP TABLE IF EXISTS {table_name}")
+
+    assert (
+        node1.query(
+            f"""
+            SELECT id, name, age, money
+            FROM mysql('mysql80:3306', 'clickhouse', '{table_name}', 'root', '{mysql_pass}',
+                SETTINGS enable_compression = 1)
+            FORMAT TSV
+            """
+        ).strip()
+        == "1\tname_1\t10\t20"
+    )
+
+    node1.query(
+        f"""
+        CREATE NAMED COLLECTION mysql_compression_creds AS
+            host = 'mysql80',
+            port = 3306,
+            database = 'clickhouse',
+            user = 'root',
+            password = '{mysql_pass}',
+            enable_compression = 1
+        """
+    )
+    try:
+        assert (
+            node1.query(
+                f"SELECT id, name, age, money FROM mysql(mysql_compression_creds, table='{table_name}') FORMAT TSV"
+            ).strip()
+            == "1\tname_1\t10\t20"
+        )
+
+        # Verify wire-level compression is actually negotiated via the named-collection path.
+        # Named collections use a different settings carrier than the literal SETTINGS clause,
+        # so this is a distinct code path. Override database+table to query performance_schema
+        # so MySQL reports the compression state of the ClickHouse-opened connection.
+        nc_compression_status = ""
+        for _ in range(10):
+            nc_compression_status = node1.query(
+                """
+                SELECT VARIABLE_VALUE
+                FROM mysql(mysql_compression_creds, database='performance_schema', table='session_status')
+                WHERE VARIABLE_NAME = 'Compression'
+                FORMAT TSV
+                """
+            ).strip()
+            if nc_compression_status == "ON":
+                break
+            time.sleep(0.5)
+
+        assert nc_compression_status == "ON", (
+            f"Expected Compression=ON via named collection, got: {nc_compression_status!r}"
+        )
+    finally:
+        node1.query("DROP NAMED COLLECTION IF EXISTS mysql_compression_creds")
+
+    # Separately verify wire-level compression via the literal table-function path (SETTINGS clause).
+    # This is a distinct code path from the named-collection path above.
+    compression_status = ""
+    for _ in range(10):
+        compression_status = node1.query(
+            f"""
+            SELECT VARIABLE_VALUE
+            FROM mysql('mysql80:3306', 'performance_schema', 'session_status', 'root', '{mysql_pass}',
+                SETTINGS enable_compression = 1)
+            WHERE VARIABLE_NAME = 'Compression'
+            FORMAT TSV
+            """
+        ).strip()
+        if compression_status == "ON":
+            break
+        time.sleep(0.5)
+
+    assert compression_status == "ON", (
+        f"Expected MySQL compression to be ON, got: {compression_status!r}"
+    )
+
+    # Wire-level assertion for the MySQL database engine path.
+    # Create a DATABASE pointing at performance_schema, then read session_status through
+    # it to confirm CLIENT_COMPRESS is negotiated on the database-engine connection.
+    node1.query("DROP DATABASE IF EXISTS compression_test_db")
+    node1.query(
+        f"""
+        CREATE DATABASE compression_test_db
+        ENGINE = MySQL('mysql80:3306', 'performance_schema', 'root', '{mysql_pass}')
+        SETTINGS enable_compression = 1
+        """
+    )
+    db_compression_status = ""
+    for _ in range(10):
+        db_compression_status = node1.query(
+            "SELECT VARIABLE_VALUE FROM compression_test_db.session_status WHERE VARIABLE_NAME = 'Compression' FORMAT TSV"
+        ).strip()
+        if db_compression_status == "ON":
+            break
+        time.sleep(0.5)
+    node1.query("DROP DATABASE IF EXISTS compression_test_db")
+    assert db_compression_status == "ON", (
+        f"Expected Compression=ON via MySQL database engine path, got: {db_compression_status!r}"
+    )
+
+    drop_mysql_table(conn, table_name)
+    conn.close()
+
+
 def test_mysql_point(started_cluster):
     table_name = "test_mysql_point"
     node1.query(f"DROP TABLE IF EXISTS {table_name}")


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Add `enable_compression` setting for the `mysql` table function, the `MySQL` table engine, the `MySQL` database engine, dictionary `SOURCE(MYSQL)`, and named collections. When enabled, ClickHouse negotiates MySQL protocol-level compression for all data transferred over the connection.

### Documentation entry for user-facing changes
- [x] Documentation is written (mandatory for new features)

Motivation: MySQL connections will benefit from protocol compression, **bandwidth is expensive** especially large transfers over public or bandwidth-constrained networks. `enable_compression` enables MySQL protocol compression for connections created through the `mysql` table function, `MySQL` table engine, `MySQL` database engine, dictionary `SOURCE(MYSQL)`, and named collections.

Parameters:
- `enable_compression` enables MySQL protocol compression for connections created through the `mysql` table function, `MySQL` table engine, `MySQL` database engine, dictionary `SOURCE(MYSQL)`, and named collections.

Example use:
```sql
SELECT *
FROM mysql(
    'host:3306',
    'database',
    'table',
    'user',
    'password',
    SETTINGS enable_compression = 1
);
```

Example with named collection:
```sql
SELECT *
FROM mysql(my_mysql_conn, table = 'remote_table', enable_compression = 1);
```

Example with MySQL table engine:

```sql
CREATE TABLE mysql_table
ENGINE = MySQL('host:3306', 'database', 'table', 'user', 'password')
SETTINGS enable_compression = 1;
```

Example with MySQL dictionary source:

```sql
CREATE DICTIONARY my_dict (id UInt64, value String)
PRIMARY KEY id
SOURCE(MYSQL(
    host 'host' port 3306
    user 'user' password 'password'
    db 'database' table 'table'
    enable_compression 1
))
LAYOUT(FLAT()) LIFETIME(0);
```

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.418`
<!-- ch-version-info:end -->