### PR TITLE
fix msan use-of-uninitialized-value in Poco::UTF8Encoding::queryConvert

### DIFF
--- a/src/Common/UTF8Helpers.cpp
+++ b/src/Common/UTF8Helpers.cpp
@@ -250,6 +250,9 @@ size_t convertCodePointToUTF8(int code_point, char * out_bytes, size_t out_lengt
 
 std::optional<uint32_t> convertUTF8ToCodePoint(const char * in_bytes, size_t in_length)
 {
+    if (in_length == 0)
+        return {};
+
     static const Poco::UTF8Encoding utf8;
     int res = utf8.queryConvert(
         reinterpret_cast<const uint8_t *>(in_bytes),


### PR DESCRIPTION
Fixes MSan report found in https://github.com/ClickHouse/ClickHouse/pull/99277
CI https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99277&sha=a30b7172c1e5af85992e77e7f5fbe0bb5e9c5691&name_0=PR

```
[2026-04-17 12:57:28] ==25==WARNING: MemorySanitizer: use-of-uninitialized-value
[2026-04-17 12:57:28] [Detaching after fork from child process 22062]
[2026-04-17 12:57:30]     #0 0x5555c0b7f106 in Poco::UTF8Encoding::queryConvert(unsigned char const*, int) const base/poco/Foundation/src/UTF8Encoding.cpp:156:10
[2026-04-17 12:57:30]     #1 0x5555c01adb1c in DB::UTF8::convertUTF8ToCodePoint(char const*, unsigned long) src/Common/UTF8Helpers.cpp:254:20
[2026-04-17 12:57:30]     #2 0x555570f0bd7b in DB::HasSubsequenceImpl<DB::(anonymous namespace)::NameHasSubsequenceUTF8, DB::(anonymous namespace)::HasSubsequenceCaseSensitiveUTF8>::hasSubsequenceUTF8(char8_t const*, unsigned long, char8_t const*, unsigned long) src/Functions/HasSubsequenceImpl.h:131:36
[2026-04-17 12:57:30]     #3 0x555570f09353 in execute<DB::GatherUtils::StringSource, DB::GatherUtils::StringSource> src/Functions/HasSubsequenceImpl.h:105:37
[2026-04-17 12:57:30]     #4 0x555570f09353 in DB::HasSubsequenceImpl<DB::(anonymous namespace)::NameHasSubsequenceUTF8, DB::(anonymous namespace)::HasSubsequenceCaseSensitiveUTF8>::executeImpl(std::__1::vector<DB::ColumnWithTypeAndName, AllocatorWithMemoryTracking<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long) const src/Functions/HasSubsequenceImpl.h:70:13
[2026-04-17 12:57:30]     #5 0x55558bbf8a9a in DB::FunctionToExecutableFunctionAdaptor::executeImpl(std::__1::vector<DB::ColumnWithTypeAndName, AllocatorWithMemoryTracking<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long) const src/Functions/IFunctionAdaptors.cpp:10:22
[2026-04-17 12:57:30]     #6 0x55558bbdfc86 in DB::IExecutableFunction::executeWithoutLowCardinalityColumns(std::__1::vector<DB::ColumnWithTypeAndName, AllocatorWithMemoryTracking<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const src/Functions/IFunction.cpp:369:15
[2026-04-17 12:57:30]     #7 0x55558bbe56fc in DB::IExecutableFunction::executeWithoutSparseColumns(std::__1::vector<DB::ColumnWithTypeAndName, AllocatorWithMemoryTracking<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const src/Functions/IFunction.cpp:442:22
[2026-04-17 12:57:30]     #8 0x55558bbed17c in DB::IExecutableFunction::executeWithoutReplicatedColumns(std::__1::vector<DB::ColumnWithTypeAndName, AllocatorWithMemoryTracking<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const src/Functions/IFunction.cpp:593:16
[2026-04-17 12:57:30]     #9 0x55558bbeae68 in DB::IExecutableFunction::execute(std::__1::vector<DB::ColumnWithTypeAndName, AllocatorWithMemoryTracking<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const src/Functions/IFunction.cpp:490:20
[2026-04-17 12:57:30]     #10 0x5555626ef13a in FunctionsStressTestThread::executeFunction() src/Functions/tests/gtest_functions_stress.cpp:1598:43
[2026-04-17 12:57:30]     #11 0x5555626e25a1 in FunctionsStressTestThread::run() src/Functions/tests/gtest_functions_stress.cpp:1228:52
[2026-04-17 12:57:30]     #12 0x55556268c337 in FunctionsStress_stress_Test::TestBody()::$_3::operator()() const src/Functions/tests/gtest_functions_stress.cpp:2157:64
[2026-04-17 12:57:30]     #13 0x55556268c337 in std::__1::__invoke_result_impl<void, FunctionsStress_stress_Test::TestBody()::$_3>::type std::__1::__invoke[abi:fqe220101]<FunctionsStress_stress_Test::TestBody()::$_3>(FunctionsStress_stress_Test::TestBody()::$_3&&) contrib/llvm-project/libcxx/include/__type_traits/invoke.h:90:27
[2026-04-17 12:57:30]     #14 0x55556268c337 in void std::__1::__thread_execute[abi:fqe220101]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, FunctionsStress_stress_Test::TestBody()::$_3, 0ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, FunctionsStress_stress_Test::TestBody()::$_3>&, std::__1::__integer_sequence<unsigned long, 0ul>) contrib/llvm-project/libcxx/include/__thread/thread.h:161:3
[2026-04-17 12:57:30]     #15 0x55556268c337 in void* std::__1::__thread_proxy[abi:fqe220101]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, FunctionsStress_stress_Test::TestBody()::$_3>>(void*) contrib/llvm-project/libcxx/include/__thread/thread.h:169:3
[2026-04-17 12:57:30]     #16 0x7ffff7e18ac2 in start_thread nptl/pthread_create.c:442:8
[2026-04-17 12:57:30]     #17 0x7ffff7eaa8cf  misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
[2026-04-17 12:57:30] 
[2026-04-17 12:57:30]   Uninitialized value was created by a heap allocation
[2026-04-17 12:57:31]     #0 0x5555606a1b52 in malloc /ClickHouse/contrib/llvm-project/compiler-rt/lib/msan/msan_interceptors.cpp:1047:3
[2026-04-17 12:57:31]     #1 0x5555bf2e8e3d in void* (anonymous namespace)::allocImpl<false, false>(unsigned long, unsigned long) src/Common/Allocator.cpp:84:19
[2026-04-17 12:57:31]     #2 0x5555bf2e8e3d in Allocator<false, false>::alloc(unsigned long, unsigned long) src/Common/Allocator.cpp:139:12
[2026-04-17 12:57:31]     #3 0x555560b01b27 in void DB::PODArrayBase<1ul, 4096ul, Allocator<false, false>, 63ul, 64ul>::alloc<>(unsigned long) src/Common/PODArray.h:134:65
[2026-04-17 12:57:31]     #4 0x555560b01b27 in void DB::PODArrayBase<1ul, 4096ul, Allocator<false, false>, 63ul, 64ul>::realloc<>(unsigned long) src/Common/PODArray.h:159:13
[2026-04-17 12:57:31]     #5 0x555560b01b27 in void DB::PODArrayBase<1ul, 4096ul, Allocator<false, false>, 63ul, 64ul>::reallocPowerOfTwoElements<>(unsigned long) src/Common/PODArray.h:206:9
[2026-04-17 12:57:31]     #6 0x55557d295cac in reserve<> src/Common/PODArray.h:244:13
[2026-04-17 12:57:31]     #7 0x55557d295cac in resize<> src/Common/PODArray.h:257:9
[2026-04-17 12:57:31]     #8 0x55557d295cac in DB::(anonymous namespace)::FunctionRandomStringUTF8::executeImpl(std::__1::vector<DB::ColumnWithTypeAndName, AllocatorWithMemoryTracking<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long) const src/Functions/randomStringUTF8.cpp:89:17
[2026-04-17 12:57:31]     #9 0x55558bbf8a9a in DB::FunctionToExecutableFunctionAdaptor::executeImpl(std::__1::vector<DB::ColumnWithTypeAndName, AllocatorWithMemoryTracking<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long) const src/Functions/IFunctionAdaptors.cpp:10:22
[2026-04-17 12:57:31]     #10 0x55558bbdfc86 in DB::IExecutableFunction::executeWithoutLowCardinalityColumns(std::__1::vector<DB::ColumnWithTypeAndName, AllocatorWithMemoryTracking<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const src/Functions/IFunction.cpp:369:15
[2026-04-17 12:57:31]     #11 0x55558bbe56fc in DB::IExecutableFunction::executeWithoutSparseColumns(std::__1::vector<DB::ColumnWithTypeAndName, AllocatorWithMemoryTracking<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const src/Functions/IFunction.cpp:442:22
[2026-04-17 12:57:31]     #12 0x55558bbed17c in DB::IExecutableFunction::executeWithoutReplicatedColumns(std::__1::vector<DB::ColumnWithTypeAndName, AllocatorWithMemoryTracking<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const src/Functions/IFunction.cpp:593:16
[2026-04-17 12:57:31]     #13 0x55558bbeae68 in DB::IExecutableFunction::execute(std::__1::vector<DB::ColumnWithTypeAndName, AllocatorWithMemoryTracking<DB::ColumnWithTypeAndName>> const&, std::__1::shared_ptr<DB::IDataType const> const&, unsigned long, bool) const src/Functions/IFunction.cpp:490:20
[2026-04-17 12:57:31]     #14 0x5555626ef13a in FunctionsStressTestThread::executeFunction() src/Functions/tests/gtest_functions_stress.cpp:1598:43
[2026-04-17 12:57:31]     #15 0x5555626e25a1 in FunctionsStressTestThread::run() src/Functions/tests/gtest_functions_stress.cpp:1228:52
[2026-04-17 12:57:31]     #16 0x55556268c337 in FunctionsStress_stress_Test::TestBody()::$_3::operator()() const src/Functions/tests/gtest_functions_stress.cpp:2157:64
[2026-04-17 12:57:31]     #17 0x55556268c337 in std::__1::__invoke_result_impl<void, FunctionsStress_stress_Test::TestBody()::$_3>::type std::__1::__invoke[abi:fqe220101]<FunctionsStress_stress_Test::TestBody()::$_3>(FunctionsStress_stress_Test::TestBody()::$_3&&) contrib/llvm-project/libcxx/include/__type_traits/invoke.h:90:27
[2026-04-17 12:57:31]     #18 0x55556268c337 in void std::__1::__thread_execute[abi:fqe220101]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, FunctionsStress_stress_Test::TestBody()::$_3, 0ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, FunctionsStress_stress_Test::TestBody()::$_3>&, std::__1::__integer_sequence<unsigned long, 0ul>) contrib/llvm-project/libcxx/include/__thread/thread.h:161:3
[2026-04-17 12:57:31]     #19 0x55556268c337 in void* std::__1::__thread_proxy[abi:fqe220101]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, FunctionsStress_stress_Test::TestBody()::$_3>>(void*) contrib/llvm-project/libcxx/include/__thread/thread.h:169:3
[2026-04-17 12:57:31]     #20 0x7ffff7e18ac2 in start_thread nptl/pthread_create.c:442:8
[2026-04-17 12:57:31] 
[2026-04-17 12:57:32] SUMMARY: MemorySanitizer: use-of-uninitialized-value base/poco/Foundation/src/UTF8Encoding.cpp:156:10 in Poco::UTF8Encoding::queryConvert(unsigned char const*, int) const
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
