### PR TITLE
CI fix: improve fast test report when server dies

### DIFF
--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -876,13 +876,24 @@ def main():
 
         test_results = FTResultsProcessor(wd=Settings.OUTPUT_DIR).run()
         if not res:
-            test_results.results.append(
-                Result.create_from(
-                    name="clickhouse-test",
-                    status=Result.Status.FAIL,
-                    info="clickhouse-test error",
-                )
+            server_died = any(
+                r.name == "Server died" for r in test_results.results
             )
+            if server_died:
+                # The non-zero exit code is caused by the server dying.
+                # Parse the server log with FuzzerLogParser to find crash info
+                # (signal, sanitizer error, logical error, etc.) and add any failures to the report.
+                for crash_result in CH.check_fatal_messages_in_logs():
+                    if crash_result.is_failure():
+                        test_results.results.append(crash_result)
+            else:
+                test_results.results.append(
+                    Result.create_from(
+                        name="clickhouse-test",
+                        status=Result.Status.FAIL,
+                        info="clickhouse-test error",
+                    )
+                )
             attach_debug = True
 
         results.append(test_results)


### PR DESCRIPTION

 **Suppress redundant `clickhouse-test error` when server died** (`ci/jobs/fast_test.py`): previously, when the server died (hung check or crash), the report showed both `Server died` and a redundant `clickhouse-test error` entry — the latter being a meaningless consequence of the former. Now, when `Server died` is already in the results, that entry is skipped. Instead, `check_fatal_messages_in_logs` is called to scan the server log with `FuzzerLogParser` for a concrete crash cause (signal, sanitizer error, fatal message), and any failures found are added as dedicated entries.

Example failure that triggered this: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=103226&sha=816fe2dd57bc64e3bc66048a0956155d3d42f51c&name_0=PR&name_1=Fast%20test%20%28arm_darwin%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)
