### PR TITLE
Add htmlParse() function backed by Lexbor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -390,3 +390,6 @@
 [submodule "contrib/zmij"]
 	path = contrib/zmij
 	url = https://github.com/vitaut/zmij.git
+[submodule "contrib/lexbor"]
+	path = contrib/lexbor
+	url = https://github.com/lexbor/lexbor.git

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -187,6 +187,8 @@ if (ENABLE_NLP)
     add_contrib (cld2-cmake cld2)
 endif()
 
+add_contrib (lexbor-cmake lexbor)
+
 add_contrib (sqlite-cmake sqlite-amalgamation)
 add_contrib (s2geometry-cmake s2geometry)
 add_contrib (c-ares-cmake c-ares)

--- a/contrib/lexbor-cmake/CMakeLists.txt
+++ b/contrib/lexbor-cmake/CMakeLists.txt
@@ -1,0 +1,93 @@
+set(LEXBOR_SOURCE_DIR "${ClickHouse_SOURCE_DIR}/contrib/lexbor/source")
+
+# Core module
+set(LEXBOR_CORE_SOURCES
+    ${LEXBOR_SOURCE_DIR}/lexbor/core/array.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/core/array_obj.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/core/avl.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/core/bst.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/core/bst_map.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/core/conv.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/core/diyfp.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/core/dobject.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/core/dtoa.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/core/hash.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/core/in.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/core/mem.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/core/mraw.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/core/plog.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/core/print.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/core/serialize.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/core/shs.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/core/str.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/core/strtod.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/core/utils.c
+)
+
+# POSIX port
+set(LEXBOR_PORT_SOURCES
+    ${LEXBOR_SOURCE_DIR}/lexbor/ports/posix/lexbor/core/fs.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/ports/posix/lexbor/core/memory.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/ports/posix/lexbor/core/perf.c
+)
+
+# DOM module
+set(LEXBOR_DOM_SOURCES
+    ${LEXBOR_SOURCE_DIR}/lexbor/dom/collection.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/dom/exception.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/dom/interface.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/dom/interfaces/attr.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/dom/interfaces/cdata_section.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/dom/interfaces/character_data.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/dom/interfaces/comment.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/dom/interfaces/document.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/dom/interfaces/document_fragment.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/dom/interfaces/document_type.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/dom/interfaces/element.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/dom/interfaces/event_target.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/dom/interfaces/node.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/dom/interfaces/processing_instruction.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/dom/interfaces/shadow_root.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/dom/interfaces/text.c
+)
+
+# Tag + NS modules
+set(LEXBOR_TAG_SOURCES
+    ${LEXBOR_SOURCE_DIR}/lexbor/tag/tag.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/ns/ns.c
+)
+
+# Encoding module
+set(LEXBOR_ENCODING_SOURCES
+    ${LEXBOR_SOURCE_DIR}/lexbor/encoding/decode.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/encoding/encode.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/encoding/encoding.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/encoding/multi_res.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/encoding/range_res.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/encoding/res.c
+    ${LEXBOR_SOURCE_DIR}/lexbor/encoding/single_res.c
+)
+
+# HTML module
+file(GLOB_RECURSE LEXBOR_HTML_SOURCES
+    "${LEXBOR_SOURCE_DIR}/lexbor/html/*.c"
+)
+
+add_library(_lexbor
+    ${LEXBOR_CORE_SOURCES}
+    ${LEXBOR_PORT_SOURCES}
+    ${LEXBOR_DOM_SOURCES}
+    ${LEXBOR_TAG_SOURCES}
+    ${LEXBOR_ENCODING_SOURCES}
+    ${LEXBOR_HTML_SOURCES}
+)
+
+target_include_directories(_lexbor SYSTEM PUBLIC "${LEXBOR_SOURCE_DIR}")
+target_compile_definitions(_lexbor PRIVATE
+    LEXBOR_STATIC
+    LEXBOR_WITHOUT_THREADS
+    _POSIX_C_SOURCE=199309L
+)
+target_compile_options(_lexbor PRIVATE -std=c99 -w)
+
+add_library(ch_contrib::lexbor ALIAS _lexbor)

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7621,6 +7621,9 @@ Enable experimental functions for funnel analysis.
     DECLARE(Bool, allow_experimental_nlp_functions, false, R"(
 Enable experimental functions for natural language processing.
 )", EXPERIMENTAL) \
+    DECLARE(Bool, allow_experimental_html_functions, false, R"(
+Enable experimental HTML processing functions.
+)", EXPERIMENTAL) \
     DECLARE(Bool, allow_experimental_hash_functions, false, R"(
 Enable experimental hash functions
 )", EXPERIMENTAL) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -41,6 +41,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         /// Note: please check if the key already exists to prevent duplicate entries.
         addSettingsChanges(settings_changes_history, "26.4",
         {
+            {"allow_experimental_html_functions", false, false, "New setting to gate experimental HTML processing functions (htmlParse)"},
             {"allow_iceberg_remove_orphan_files", false, false, "New setting to gate Iceberg orphan file removal"},
             {"iceberg_orphan_files_older_than_seconds", 259200, 259200, "New setting for default orphan file age threshold"},
             {"output_format_arrow_unsupported_types_as_binary", false, true, "New setting to convert unsupported CH types to arrow binary instead of UNKNOWN_TYPE exception."},

--- a/src/Databases/enableAllExperimentalSettings.cpp
+++ b/src/Databases/enableAllExperimentalSettings.cpp
@@ -69,6 +69,7 @@ void enableAllExperimentalSettings(ContextMutablePtr context)
     context->setSetting("allow_experimental_full_text_index", 1);
 
     context->setSetting("allow_experimental_ai_functions", 1);
+    context->setSetting("allow_experimental_html_functions", 1);
 
     /// clickhouse-private settings
     context->setSetting("allow_experimental_shared_set_join", 1);

--- a/src/Functions/CMakeLists.txt
+++ b/src/Functions/CMakeLists.txt
@@ -171,6 +171,12 @@ list (APPEND OBJECT_LIBS $<TARGET_OBJECTS:clickhouse_functions_kusto>)
 add_subdirectory(TimeSeries)
 list (APPEND OBJECT_LIBS $<TARGET_OBJECTS:clickhouse_functions_time_series>)
 
+if (TARGET ch_contrib::lexbor)
+    add_subdirectory(HTML)
+    list (APPEND OBJECT_LIBS $<TARGET_OBJECTS:clickhouse_functions_html>)
+    list (APPEND PRIVATE_LIBS ch_contrib::lexbor)
+endif()
+
 if (TARGET ch_contrib::datasketches)
     add_subdirectory(UniqTheta)
     list (APPEND OBJECT_LIBS $<TARGET_OBJECTS:clickhouse_functions_uniqtheta>)

--- a/src/Functions/HTML/CMakeLists.txt
+++ b/src/Functions/HTML/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(clickhouse_functions_html OBJECT FunctionHtml.cpp)
+
+target_link_libraries(clickhouse_functions_html PRIVATE dbms ch_contrib::lexbor)
+
+if (OMIT_HEAVY_DEBUG_SYMBOLS)
+    target_compile_options(clickhouse_functions_html PRIVATE "-g0")
+endif()

--- a/src/Functions/HTML/FunctionHtml.cpp
+++ b/src/Functions/HTML/FunctionHtml.cpp
@@ -1,0 +1,122 @@
+#include <Functions/HTML/LxbDocument.h>
+
+#include <Columns/ColumnString.h>
+#include <Core/Settings.h>
+#include <DataTypes/DataTypeString.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/FunctionHelpers.h>
+#include <Functions/IFunction.h>
+#include <Interpreters/Context.h>
+#include <lexbor/html/serialize.h>
+
+namespace DB
+{
+
+namespace Setting
+{
+    extern const SettingsBool allow_experimental_html_functions;
+}
+
+namespace ErrorCodes
+{
+    extern const int ILLEGAL_COLUMN;
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int SUPPORT_IS_DISABLED;
+}
+
+namespace
+{
+
+lxb_status_t serializeToChars(const lxb_char_t * data, size_t len, void * ctx)
+{
+    auto * chars = static_cast<ColumnString::Chars *>(ctx);
+    chars->insert(chars->end(), data, data + len);
+    return LXB_STATUS_OK;
+}
+
+} // namespace
+
+class FunctionHtmlParse : public IFunction
+{
+public:
+    static constexpr auto name = "htmlParse";
+
+    static FunctionPtr create(ContextPtr context)
+    {
+        if (!context->getSettingsRef()[Setting::allow_experimental_html_functions])
+            throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
+                "HTML function '{}' is experimental. "
+                "Set `allow_experimental_html_functions` setting to enable it", name);
+        return std::make_shared<FunctionHtmlParse>();
+    }
+
+    String getName() const override { return name; }
+    size_t getNumberOfArguments() const override { return 1; }
+    bool useDefaultImplementationForConstants() const override { return true; }
+    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo &) const override { return true; }
+
+    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
+    {
+        if (!isString(arguments[0].type))
+            throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "Illegal type {} of argument of function {}", arguments[0].type->getName(), getName());
+        return std::make_shared<DataTypeString>();
+    }
+
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t) const override
+    {
+        const auto * col = checkAndGetColumn<ColumnString>(arguments[0].column.get());
+        if (!col)
+            throw Exception(ErrorCodes::ILLEGAL_COLUMN,
+                "Illegal column {} of argument of function {}", arguments[0].column->getName(), getName());
+
+        auto result = ColumnString::create();
+        auto & chars = result->getChars();
+        auto & offsets = result->getOffsets();
+
+        const size_t rows = col->size();
+        LxbDocument lxb_doc;
+
+        for (size_t i = 0; i < rows; ++i)
+        {
+            auto html = col->getDataAt(i);
+            chars.reserve(chars.size() + html.size());
+
+            if (html.size() == 0 || !lxb_doc)
+            {
+                chars.insert(chars.end(), html.data(), html.data() + html.size());
+                offsets.push_back(chars.size());
+                continue;
+            }
+
+            lxb_html_document_clean(lxb_doc.doc);
+            lxb_status_t status = lxb_html_document_parse(lxb_doc.doc,
+                reinterpret_cast<const lxb_char_t *>(html.data()), html.size());
+            if (status != LXB_STATUS_OK)
+            {
+                chars.insert(chars.end(), html.data(), html.data() + html.size());
+                offsets.push_back(chars.size());
+                continue;
+            }
+
+            lxb_html_serialize_tree_cb(
+                lxb_dom_interface_node(lxb_doc.doc),
+                serializeToChars, &chars);
+            offsets.push_back(chars.size());
+        }
+        return result;
+    }
+};
+
+REGISTER_FUNCTION(HtmlParse)
+{
+    factory.registerFunction<FunctionHtmlParse>(FunctionDocumentation{
+        .description = R"(Parses HTML and serializes it back. Normalizes malformed HTML into valid HTML5.)",
+        .syntax = "htmlParse(html)",
+        .arguments = {{"html", "HTML string to parse and normalize.", {"String"}}},
+        .returned_value = {"Normalized HTML string.", {"String"}},
+        .introduced_in = {26, 4},
+        .category = FunctionDocumentation::Category::Other});
+}
+
+} // namespace DB

--- a/src/Functions/HTML/FunctionHtml.cpp
+++ b/src/Functions/HTML/FunctionHtml.cpp
@@ -34,9 +34,9 @@ lxb_status_t serializeToChars(const lxb_char_t * data, size_t len, void * ctx)
     return LXB_STATUS_OK;
 }
 
-} // namespace
+}
 
-class FunctionHtmlParse : public IFunction
+class FunctionHTMLParse : public IFunction
 {
 public:
     static constexpr auto name = "htmlParse";
@@ -47,7 +47,7 @@ public:
             throw Exception(ErrorCodes::SUPPORT_IS_DISABLED,
                 "HTML function '{}' is experimental. "
                 "Set `allow_experimental_html_functions` setting to enable it", name);
-        return std::make_shared<FunctionHtmlParse>();
+        return std::make_shared<FunctionHTMLParse>();
     }
 
     String getName() const override { return name; }
@@ -108,9 +108,9 @@ public:
     }
 };
 
-REGISTER_FUNCTION(HtmlParse)
+REGISTER_FUNCTION(HTMLParse)
 {
-    factory.registerFunction<FunctionHtmlParse>(FunctionDocumentation{
+    factory.registerFunction<FunctionHTMLParse>(FunctionDocumentation{
         .description = R"(Parses HTML and serializes it back. Normalizes malformed HTML into valid HTML5.)",
         .syntax = "htmlParse(html)",
         .arguments = {{"html", "HTML string to parse and normalize.", {"String"}}},
@@ -119,4 +119,4 @@ REGISTER_FUNCTION(HtmlParse)
         .category = FunctionDocumentation::Category::Other});
 }
 
-} // namespace DB
+}

--- a/src/Functions/HTML/LxbDocument.h
+++ b/src/Functions/HTML/LxbDocument.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <lexbor/html/parser.h>
+
+namespace DB
+{
+
+/// RAII wrapper for lxb_html_document_t.
+struct LxbDocument
+{
+    lxb_html_document_t * doc;
+
+    LxbDocument() : doc(lxb_html_document_create()) {}
+    ~LxbDocument() { if (doc) lxb_html_document_destroy(doc); }
+
+    explicit operator bool() const { return doc != nullptr; }
+
+    LxbDocument(LxbDocument && other) noexcept : doc(other.doc) { other.doc = nullptr; }
+    LxbDocument & operator=(LxbDocument && other) noexcept
+    {
+        if (this != &other)
+        {
+            if (doc) lxb_html_document_destroy(doc);
+            doc = other.doc;
+            other.doc = nullptr;
+        }
+        return *this;
+    }
+
+    LxbDocument(const LxbDocument &) = delete;
+    LxbDocument & operator=(const LxbDocument &) = delete;
+};
+
+} // namespace DB

--- a/src/Functions/HTML/LxbDocument.h
+++ b/src/Functions/HTML/LxbDocument.h
@@ -31,4 +31,4 @@ struct LxbDocument
     LxbDocument & operator=(const LxbDocument &) = delete;
 };
 
-} // namespace DB
+}

--- a/tests/queries/0_stateless/04105_html_parse.reference
+++ b/tests/queries/0_stateless/04105_html_parse.reference
@@ -1,0 +1,7 @@
+0
+<html><head></head><body></body></html>
+<html><head><title>t</title></head><body><p>hi</p></body></html>
+<html><head></head><body><p>unclosed</p></body></html>
+<html><head></head><body><p>bare</p></body></html>
+1
+100

--- a/tests/queries/0_stateless/04105_html_parse.sql
+++ b/tests/queries/0_stateless/04105_html_parse.sql
@@ -1,0 +1,31 @@
+-- Tags: no-fasttest
+
+-- Experimental gate
+SELECT htmlParse('<html></html>'); -- { serverError SUPPORT_IS_DISABLED }
+
+SET allow_experimental_html_functions = 1;
+
+-- Empty input
+SELECT length(htmlParse(''));
+
+-- Empty document gets <head></head><body></body> filled in
+SELECT htmlParse('<html></html>');
+
+-- Well-formed document round-trips
+SELECT htmlParse('<html><head><title>t</title></head><body><p>hi</p></body></html>');
+
+-- Malformed: missing close tags are added
+SELECT htmlParse('<html><body><p>unclosed');
+
+-- Fragment input: lexbor auto-wraps into a full document
+SELECT htmlParse('<p>bare</p>');
+
+-- Parser is idempotent after first pass
+SELECT htmlParse(htmlParse('<html><head><title>t</title></head><body><p>hi</p></body></html>'))
+     = htmlParse('<html><head><title>t</title></head><body><p>hi</p></body></html>');
+
+-- Illegal type
+SELECT htmlParse(123); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+-- Batch: all 100 rows succeed with the reused parser document
+SELECT count() FROM (SELECT htmlParse('<div>' || toString(number) || '</div>') FROM numbers(100));


### PR DESCRIPTION
### Changelog category (leave one):
- Experimental Feature


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Introduce `htmlParse(html)` — a new SQL function that parses HTML and serializes it back, normalizing malformed HTML into valid HTML5 through Lexbor's WHATWG-compliant parser.

Gated by the new `allow_experimental_html_functions` setting so it can ship alongside other experimental NLP-adjacent functions without being exposed by default.

New submodule: `contrib/lexbor`. Lexbor is MIT-licensed, dependency-free, and implements the HTML/CSS/URL/Encoding specs from scratch in C.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
