### PR TITLE
Remove flaky RabbitMQ pause-based integration tests

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3054,17 +3054,43 @@ class ClickHouseCluster:
 
     @contextmanager
     def pause_rabbitmq(self, timeout=120):
-        run_rabbitmqctl(
-            self.rabbitmq_docker_id, self.rabbitmq_cookie, "stop_app", timeout
-        )
+        # `rabbitmqctl stop_app` / `start_app` and the subsequent readiness
+        # check are known to flake, especially on sanitizer builds. If they
+        # do, the container is left in a stopped / half-started state, which
+        # poisons every follow-up test in the module that relies on the
+        # module-scoped RabbitMQ fixture. Recover by restarting the container
+        # from scratch so subsequent tests see a healthy RabbitMQ.
+        try:
+            run_rabbitmqctl(
+                self.rabbitmq_docker_id, self.rabbitmq_cookie, "stop_app", timeout
+            )
+        except RuntimeError as ex:
+            logging.warning(
+                "pause_rabbitmq: `rabbitmqctl stop_app` failed: %s. "
+                "Resetting RabbitMQ container to recover.",
+                ex,
+            )
+            self.reset_rabbitmq(timeout)
+            raise
 
         try:
             yield
         finally:
-            run_rabbitmqctl(
-                self.rabbitmq_docker_id, self.rabbitmq_cookie, "start_app", timeout
-            )
-            self.wait_rabbitmq_to_start(timeout)
+            try:
+                run_rabbitmqctl(
+                    self.rabbitmq_docker_id,
+                    self.rabbitmq_cookie,
+                    "start_app",
+                    timeout,
+                )
+                self.wait_rabbitmq_to_start(timeout)
+            except RuntimeError as ex:
+                logging.warning(
+                    "pause_rabbitmq: failed to bring RabbitMQ back up: %s. "
+                    "Resetting RabbitMQ container to recover.",
+                    ex,
+                )
+                self.reset_rabbitmq(timeout)
 
     def reset_rabbitmq(self, timeout=120):
         try:

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -3052,46 +3052,6 @@ class ClickHouseCluster:
 
         raise RuntimeError("Cannot wait RabbitMQ container")
 
-    @contextmanager
-    def pause_rabbitmq(self, timeout=120):
-        # `rabbitmqctl stop_app` / `start_app` and the subsequent readiness
-        # check are known to flake, especially on sanitizer builds. If they
-        # do, the container is left in a stopped / half-started state, which
-        # poisons every follow-up test in the module that relies on the
-        # module-scoped RabbitMQ fixture. Recover by restarting the container
-        # from scratch so subsequent tests see a healthy RabbitMQ.
-        try:
-            run_rabbitmqctl(
-                self.rabbitmq_docker_id, self.rabbitmq_cookie, "stop_app", timeout
-            )
-        except RuntimeError as ex:
-            logging.warning(
-                "pause_rabbitmq: `rabbitmqctl stop_app` failed: %s. "
-                "Resetting RabbitMQ container to recover.",
-                ex,
-            )
-            self.reset_rabbitmq(timeout)
-            raise
-
-        try:
-            yield
-        finally:
-            try:
-                run_rabbitmqctl(
-                    self.rabbitmq_docker_id,
-                    self.rabbitmq_cookie,
-                    "start_app",
-                    timeout,
-                )
-                self.wait_rabbitmq_to_start(timeout)
-            except RuntimeError as ex:
-                logging.warning(
-                    "pause_rabbitmq: failed to bring RabbitMQ back up: %s. "
-                    "Resetting RabbitMQ container to recover.",
-                    ex,
-                )
-                self.reset_rabbitmq(timeout)
-
     def reset_rabbitmq(self, timeout=120):
         try:
             resp = requests.get(f"http://{self.rabbitmq_ip}:{self.rabbitmq_management_port}/api/overview",

--- a/tests/integration/test_storage_rabbitmq/test.py
+++ b/tests/integration/test_storage_rabbitmq/test.py
@@ -2007,57 +2007,6 @@ def test_rabbitmq_no_connection_at_startup_1(rabbitmq_cluster, db, unique):
     assert "CANNOT_CONNECT_RABBITMQ" in error
 
 
-def test_rabbitmq_no_connection_at_startup_2(rabbitmq_cluster, db, unique):
-    instance.query(
-        f"""
-        CREATE TABLE {db}.cs (key UInt64, value UInt64)
-            ENGINE = RabbitMQ
-            SETTINGS rabbitmq_host_port = 'rabbitmq1:5672',
-                     rabbitmq_exchange_name = '{unique}_cs',
-                     rabbitmq_format = 'JSONEachRow',
-                     rabbitmq_num_consumers = '5',
-                     rabbitmq_flush_interval_ms=1000,
-                     rabbitmq_max_block_size=100,
-                     rabbitmq_row_delimiter = '\\n';
-        CREATE TABLE {db}.view (key UInt64, value UInt64)
-            ENGINE = MergeTree
-            ORDER BY key;
-        CREATE MATERIALIZED VIEW {db}.consumer TO {db}.view AS
-            SELECT * FROM {db}.cs;
-    """
-    )
-    instance.query(f"DETACH TABLE {db}.cs")
-
-    with rabbitmq_cluster.pause_rabbitmq():
-        instance.query(f"ATTACH TABLE {db}.cs")
-
-    messages_num = 1000
-    credentials = pika.PlainCredentials("root", "clickhouse")
-    parameters = pika.ConnectionParameters(
-        rabbitmq_cluster.rabbitmq_ip, rabbitmq_cluster.rabbitmq_port, "/", credentials
-    )
-    connection = pika.BlockingConnection(parameters)
-    channel = connection.channel()
-    for i in range(messages_num):
-        message = json.dumps({"key": i, "value": i})
-        channel.basic_publish(
-            exchange=f"{unique}_cs",
-            routing_key="",
-            body=message,
-            properties=pika.BasicProperties(delivery_mode=2, message_id=str(i)),
-        )
-    connection.close()
-
-    check_expected_result_polling(messages_num, f"SELECT count() FROM {db}.view")
-
-    instance.query(
-        f"""
-        DROP TABLE {db}.consumer;
-        DROP TABLE {db}.cs;
-    """
-    )
-
-
 def test_rabbitmq_format_factory_settings(rabbitmq_cluster, db, unique):
     instance.query(
         f"""
@@ -3740,36 +3689,3 @@ def test_rabbitmq_default_mode_nack_on_parse_error(rabbitmq_cluster, db, unique)
     channel.queue_delete(deadletter_queue)
     channel.exchange_delete(deadletter_exchange)
     connection.close()
-
-
-def test_connection_info_logging_with_rabbitmq_address(rabbitmq_cluster, db, unique):
-    """Verify that reconnection logs show the actual connection address,
-    not ':0', when rabbitmq_address is used instead of rabbitmq_host_port."""
-
-    # Create a table using rabbitmq_address (connection string)
-    instance.query(f"""                                                       
-        CREATE TABLE {db}.rmq_addr_log (key UInt64, value String)
-        ENGINE = RabbitMQ                                                     
-        SETTINGS rabbitmq_address = 'amqp://root:clickhouse@{rabbitmq_cluster.rabbitmq_host}:5672/', rabbitmq_exchange_name = '{unique}_addr_log_exchange', rabbitmq_format = 'JSONEachRow';                              
-        CREATE TABLE {db}.rmq_addr_log_dst (key UInt64, value String)
-        ENGINE = MergeTree ORDER BY key;                                  
-        CREATE MATERIALIZED VIEW {db}.rmq_addr_log_mv TO {db}.rmq_addr_log_dst AS 
-        SELECT * FROM {db}.rmq_addr_log;
-    """)
-    instance.query(f"DETACH TABLE {db}.rmq_addr_log")
-
-    # disconnect/reconnect by briefly pausing RabbitMQ
-    with rabbitmq_cluster.pause_rabbitmq():
-        # forces a reconnection
-        instance.query(f"ATTACH TABLE {db}.rmq_addr_log")
-        instance.wait_for_log_line("Trying to restore connection to")
-
-    # Check server logs for the reconnection message
-    log = instance.grep_in_log("Trying to restore connection to")
-    assert 'Trying to restore connection to :0' not in log, \
-        f"Log contains ':0' instead of actual address: {log}"
-    assert rabbitmq_cluster.rabbitmq_host + ":" + str(rabbitmq_cluster.rabbitmq_port) in log, \
-        f"Log should contain the actual connection address: {log}"
-    assert 'root:clickhouse' not in log
-
-    instance.query(f"DROP TABLE {db}.rmq_addr_log_mv; DROP TABLE {db}.rmq_addr_log; DROP TABLE {db}.rmq_addr_log_dst;")


### PR DESCRIPTION
Remove the only two integration tests that rely on
`ClickHouseCluster.pause_rabbitmq()` and remove the helper itself.

The helper wraps a test body in `rabbitmqctl stop_app` / `start_app` plus
a readiness wait. On RabbitMQ 4.2.1 (shipped in the integration-test
image) the `start_app` RPC silently hangs after a prior `stop_app` — the
broker emits no `Starting RabbitMQ` line for the full 120 s timeout,
then Python's `subprocess.check_output(..., timeout=120)` fires
`TimeoutExpired` and the test fails with
`RuntimeError: rabbitmqctl start_app timed out`. Because the RabbitMQ
fixture is module-scoped, the container is then left in a stopped /
half-started state and every follow-up test in the module fails with
`Cannot wait RabbitMQ container`.

Failure counts from `checks` on `play.clickhouse.com` (last 14 days,
`test_name LIKE 'test_storage_rabbitmq%'`):
- Primary `pause_rabbitmq` timeouts: `test_connection_info_logging_with_rabbitmq_address` 43, `test_rabbitmq_no_connection_at_startup_2` 20.
- Cascade (`Cannot wait RabbitMQ container`): two `Integration tests (arm_binary, distributed plan, 2/4)` runs took down 58 and 57 other tests each.
- Total rabbitmq integration failures attributable to this primitive: ~2/3 of all rabbitmq failures in the window.

Example CI report (ARM distributed plan, 2/4, PR #103252):
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=103252&sha=b0daef3f630d999968660b722401fc27ddd48ecb&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%202%2F4%29

The downloaded docker log shows the smoking gun: broker receives
`stop_app` at 12:21:21, emits `Successfully stopped RabbitMQ and its
dependencies` 87 ms later, then is **silent for 127 s** until the
SIGTERM from pytest teardown at 12:23:28. `start_app` never produces
any log output — the RPC is wedged.

The two removed tests were:
- `test_rabbitmq_no_connection_at_startup_2` — `ATTACH` of a `RabbitMQ`
  engine table while the broker is unreachable. Covers the same async-
  connect path as `test_rabbitmq_no_connection_at_startup_1`, which
  continues to exist and uses a non-resolvable host instead of a paused
  broker.
- `test_connection_info_logging_with_rabbitmq_address` — regression
  guard that the reconnect log line prints a real `host:port` and does
  not leak credentials when the table is configured via
  `rabbitmq_address = 'amqp://...'`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.17`
<!-- ch-version-info:end -->