### PR TITLE
Fix `INTERPOLATE` + `LIMIT BY` dependency mismatch in planner

### DIFF
--- a/src/Planner/PlannerExpressionAnalysis.cpp
+++ b/src/Planner/PlannerExpressionAnalysis.cpp
@@ -771,6 +771,15 @@ PlannerExpressionsAnalysisResult buildExpressionAnalysisResult(const QueryTreeNo
         current_output_columns = actions_chain.getLastStepAvailableOutputColumns();
     }
 
+    /// `BEFORE_INTERPOLATE` actions are executed later with `WITH FILL`, but aliases produced by this
+    /// step must be visible for projection analysis. Add this step to `ActionsChain` after `LIMIT BY`
+    /// so finalization does not propagate interpolate dependencies into `BEFORE_LIMIT_BY`.
+    if (sort_analysis_result_optional && sort_analysis_result_optional->before_interpolate_actions)
+    {
+        actions_chain.addStep(std::make_unique<ActionsChainStep>(sort_analysis_result_optional->before_interpolate_actions));
+        current_output_columns = actions_chain.getLastStepAvailableOutputColumns();
+    }
+
     const auto * chain_available_output_columns = actions_chain.getLastStepAvailableOutputColumnsOrNull();
     auto project_names_input = chain_available_output_columns ? *chain_available_output_columns : current_output_columns;
 

--- a/src/Planner/PlannerExpressionAnalysis.cpp
+++ b/src/Planner/PlannerExpressionAnalysis.cpp
@@ -546,7 +546,9 @@ SortAnalysisResult analyzeSort(
 
     ActionsAndProjectInputsFlagPtr before_interpolate_actions;
 
-    /// We add only INPUT columns necessary for INTERPOLATE expression in before ORDER BY actions DAG
+    /// We add only INPUT columns necessary for INTERPOLATE expression in before ORDER BY actions DAG.
+    /// This step is executed later together with `WITH FILL`, so it must not participate in `ActionsChain`
+    /// finalization and affect dependencies for earlier steps such as `BEFORE_LIMIT_BY`.
     if (query_node.hasInterpolate())
     {
         auto & interpolate_list_node = query_node.getInterpolate()->as<ListNode &>();
@@ -578,12 +580,6 @@ SortAnalysisResult analyzeSort(
 
         before_interpolate_actions = std::make_shared<ActionsAndProjectInputsFlag>();
         before_interpolate_actions->dag = std::move(before_interpolate_actions_dag);
-    }
-
-    if (before_interpolate_actions)
-    {
-        auto actions_step_before_interpolate = std::make_unique<ActionsChainStep>(before_interpolate_actions);
-        actions_chain.addStep(std::move(actions_step_before_interpolate));
     }
 
     return SortAnalysisResult{std::move(before_sort_actions), has_with_fill, std::move(before_interpolate_actions)};

--- a/tests/queries/0_stateless/04108_with_fill_interpolate_limit_by.reference
+++ b/tests/queries/0_stateless/04108_with_fill_interpolate_limit_by.reference
@@ -1,0 +1,10 @@
+0	hello
+1	hello!
+2	hello
+3	hello!
+4	hello
+0	a
+1	a!
+2	c
+3	c!
+4	e

--- a/tests/queries/0_stateless/04108_with_fill_interpolate_limit_by.sql
+++ b/tests/queries/0_stateless/04108_with_fill_interpolate_limit_by.sql
@@ -1,0 +1,18 @@
+SELECT number AS k, 'hello' AS s
+FROM numbers(5)
+WHERE number % 2 = 0
+ORDER BY k WITH FILL FROM 0 TO 4
+INTERPOLATE (s AS concat(s, '!'))
+LIMIT 1 BY k;
+
+DROP TABLE IF EXISTS test_interp_lb_04108;
+CREATE TABLE test_interp_lb_04108 (k UInt32, v String) ENGINE = MergeTree ORDER BY k;
+INSERT INTO test_interp_lb_04108 VALUES (0, 'a'), (2, 'c'), (4, 'e');
+
+SELECT k, v
+FROM test_interp_lb_04108
+ORDER BY k WITH FILL FROM 0 TO 4
+INTERPOLATE (v AS concat(v, '!'))
+LIMIT 1 BY k;
+
+DROP TABLE test_interp_lb_04108;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #103241.

`BEFORE_INTERPOLATE` actions were participating in `ActionsChain` finalization too early for `LIMIT BY`, which could make `BEFORE_LIMIT_BY` depend on `INTERPOLATE` aliases and fail with `NOT_FOUND_COLUMN_IN_BLOCK`.

The fix keeps `before_interpolate_actions` out of `analyzeSort` chain insertion and adds them to `ActionsChain` only after `LIMIT BY` analysis. This preserves `INTERPOLATE` alias availability for projection while preventing dependency propagation into `BEFORE_LIMIT_BY`.

Added a stateless regression test for `ORDER BY ... WITH FILL INTERPOLATE (...) LIMIT ... BY ...` with both constant and table-column interpolation targets.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `NOT_FOUND_COLUMN_IN_BLOCK` exception for queries that combine `ORDER BY ... WITH FILL INTERPOLATE (...)` with `LIMIT ... BY` by preventing premature `BEFORE_INTERPOLATE` dependency propagation into `BEFORE_LIMIT_BY` while preserving interpolate aliases for projection.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0a4849d-1416-4b61-93e6-2c1b6ecde2c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0a4849d-1416-4b61-93e6-2c1b6ecde2c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

