### PR TITLE
ci: restore OK status for flaky tests on LLVM coverage builds

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -688,6 +688,10 @@ def main():
                 if label_key in label_map:
                     test_case.set_label(label_map[label_key])
                 if label_key == "flaky" and is_llvm_coverage:
+                    # Coverage binaries are slow and prone to timing-related flakiness
+                    # (e.g. TIMEOUT_EXCEEDED on SystemLogQueue). Don't penalise them
+                    # for it — mark the test green so it doesn't block coverage jobs.
+                    # See: https://github.com/ClickHouse/ClickHouse/pull/95763
                     test_case.set_status(Result.Status.OK)
             if diag_exit_code != 0:
                 diag_status = Result.Status.FAIL

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -687,6 +687,8 @@ def main():
                 label_key = diag.get("label", "")
                 if label_key in label_map:
                     test_case.set_label(label_map[label_key])
+                if label_key == "flaky" and is_llvm_coverage:
+                    test_case.set_status(Result.Status.OK)
             if diag_exit_code != 0:
                 diag_status = Result.Status.FAIL
                 diag_info = (


### PR DESCRIPTION
PR #102892 replaced the RETRIES stage with a DIAGNOSTICS stage but dropped the
behavior introduced in #95763, where tests that passed on retry were marked as
`OK` on LLVM coverage builds. The new DIAGNOSTICS stage applied the `flaky` label
but left the test status as `FAIL`, causing flaky tests to appear red in CI instead
of green.

Restore: when the DIAGNOSTICS stage classifies a test as `flaky`, set its status
to `OK` for `is_llvm_coverage` builds — matching the original RETRIES stage logic.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.4.1.1113`
<!-- ch-version-info:end -->