### PR TITLE
Fix data race in dictionaries

### DIFF
--- a/src/Dictionaries/ClickHouseDictionarySource.cpp
+++ b/src/Dictionaries/ClickHouseDictionarySource.cpp
@@ -145,10 +145,8 @@ bool ClickHouseDictionarySource::isModified() const
     if (!configuration.invalidate_query.empty())
     {
         auto response = doInvalidateQuery(configuration.invalidate_query);
-        LOG_TRACE(log, "Invalidate query has returned: {}, previous value: {}", response, invalidate_query_response);
-        if (invalidate_query_response == response)
-            return false;
-        invalidate_query_response = response;
+        LOG_TRACE(log, "Invalidate query has returned: {}", response);
+        return invalidate_query_response.updateAndCheckModified(response);
     }
     return true;
 }

--- a/src/Dictionaries/ClickHouseDictionarySource.h
+++ b/src/Dictionaries/ClickHouseDictionarySource.h
@@ -8,6 +8,7 @@
 #include <Dictionaries/DictionaryStructure.h>
 #include <Dictionaries/ExternalQueryBuilder.h>
 #include <Dictionaries/IDictionarySource.h>
+#include <Dictionaries/InvalidateQueryResponse.h>
 
 
 namespace DB
@@ -82,7 +83,7 @@ private:
     std::chrono::time_point<std::chrono::system_clock> update_time;
     const DictionaryStructure dict_struct;
     const Configuration configuration;
-    mutable std::string invalidate_query_response;
+    mutable InvalidateQueryResponse invalidate_query_response;
     ExternalQueryBuilderPtr query_builder;
     Block sample_block;
     ContextMutablePtr context;

--- a/src/Dictionaries/InvalidateQueryResponse.cpp
+++ b/src/Dictionaries/InvalidateQueryResponse.cpp
@@ -18,10 +18,4 @@ bool InvalidateQueryResponse::updateAndCheckModified(const std::string & new_res
     return true;
 }
 
-std::string InvalidateQueryResponse::get() const
-{
-    std::lock_guard lock(mutex);
-    return response;
-}
-
 }

--- a/src/Dictionaries/InvalidateQueryResponse.cpp
+++ b/src/Dictionaries/InvalidateQueryResponse.cpp
@@ -1,0 +1,27 @@
+#include <Dictionaries/InvalidateQueryResponse.h>
+
+namespace DB
+{
+
+InvalidateQueryResponse::InvalidateQueryResponse(const InvalidateQueryResponse & other)
+{
+    std::lock_guard lock(other.mutex);
+    response = other.response;
+}
+
+bool InvalidateQueryResponse::updateAndCheckModified(const std::string & new_response)
+{
+    std::lock_guard lock(mutex);
+    if (response == new_response)
+        return false;
+    response = new_response;
+    return true;
+}
+
+std::string InvalidateQueryResponse::get() const
+{
+    std::lock_guard lock(mutex);
+    return response;
+}
+
+}

--- a/src/Dictionaries/InvalidateQueryResponse.h
+++ b/src/Dictionaries/InvalidateQueryResponse.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <mutex>
+#include <string>
+
+namespace DB
+{
+
+/// Thread-safe holder for the last value returned by a dictionary source's invalidate query.
+class InvalidateQueryResponse
+{
+public:
+    InvalidateQueryResponse() = default;
+    InvalidateQueryResponse(const InvalidateQueryResponse & other);
+    InvalidateQueryResponse & operator=(const InvalidateQueryResponse &) = delete;
+
+    bool updateAndCheckModified(const std::string & new_response);
+    std::string get() const;
+
+private:
+    mutable std::mutex mutex;
+    std::string response;
+};
+
+}

--- a/src/Dictionaries/InvalidateQueryResponse.h
+++ b/src/Dictionaries/InvalidateQueryResponse.h
@@ -15,7 +15,6 @@ public:
     InvalidateQueryResponse & operator=(const InvalidateQueryResponse &) = delete;
 
     bool updateAndCheckModified(const std::string & new_response);
-    std::string get() const;
 
 private:
     mutable std::mutex mutex;

--- a/src/Dictionaries/MySQLDictionarySource.cpp
+++ b/src/Dictionaries/MySQLDictionarySource.cpp
@@ -301,11 +301,7 @@ bool MySQLDictionarySource::isModified() const
     {
         LOG_TRACE(log, "Executing invalidate query: {}", configuration.invalidate_query);
         auto response = doInvalidateQuery(configuration.invalidate_query);
-        if (response == invalidate_query_response)
-            return false;
-
-        invalidate_query_response = response;
-        return true;
+        return invalidate_query_response.updateAndCheckModified(response);
     }
 
     return true;

--- a/src/Dictionaries/MySQLDictionarySource.h
+++ b/src/Dictionaries/MySQLDictionarySource.h
@@ -10,6 +10,7 @@
 #    include <Dictionaries/DictionaryStructure.h>
 #    include <Dictionaries/ExternalQueryBuilder.h>
 #    include <Dictionaries/IDictionarySource.h>
+#    include <Dictionaries/InvalidateQueryResponse.h>
 #    include <Processors/Sources/MySQLSource.h>
 
 namespace Poco
@@ -89,7 +90,7 @@ private:
     Block sample_block;
     ExternalQueryBuilder query_builder;
     const std::string load_all_query;
-    mutable std::string invalidate_query_response;
+    mutable InvalidateQueryResponse invalidate_query_response;
     const StreamSettings settings;
 };
 

--- a/src/Dictionaries/PostgreSQLDictionarySource.cpp
+++ b/src/Dictionaries/PostgreSQLDictionarySource.cpp
@@ -138,9 +138,7 @@ bool PostgreSQLDictionarySource::isModified() const
     if (!configuration.invalidate_query.empty())
     {
         auto response = doInvalidateQuery(configuration.invalidate_query);
-        if (response == invalidate_query_response)
-            return false;
-        invalidate_query_response = response;
+        return invalidate_query_response.updateAndCheckModified(response);
     }
     return true;
 }

--- a/src/Dictionaries/PostgreSQLDictionarySource.h
+++ b/src/Dictionaries/PostgreSQLDictionarySource.h
@@ -3,6 +3,7 @@
 #include "config.h"
 #include <Dictionaries/DictionaryStructure.h>
 #include <Dictionaries/IDictionarySource.h>
+#include <Dictionaries/InvalidateQueryResponse.h>
 
 #if USE_LIBPQXX
 #include <Dictionaries/ExternalQueryBuilder.h>
@@ -65,7 +66,7 @@ private:
     ExternalQueryBuilder query_builder;
     const std::string load_all_query;
     std::chrono::time_point<std::chrono::system_clock> update_time;
-    mutable std::string invalidate_query_response;
+    mutable InvalidateQueryResponse invalidate_query_response;
 
 };
 

--- a/src/Dictionaries/XDBCDictionarySource.cpp
+++ b/src/Dictionaries/XDBCDictionarySource.cpp
@@ -193,9 +193,7 @@ bool XDBCDictionarySource::isModified() const
     if (!configuration.invalidate_query.empty())
     {
         auto response = doInvalidateQuery(configuration.invalidate_query);
-        if (invalidate_query_response == response)
-            return false;
-        invalidate_query_response = response;
+        return invalidate_query_response.updateAndCheckModified(response);
     }
     return true;
 }

--- a/src/Dictionaries/XDBCDictionarySource.h
+++ b/src/Dictionaries/XDBCDictionarySource.h
@@ -7,6 +7,7 @@
 #include <Dictionaries/DictionaryStructure.h>
 #include <Dictionaries/ExternalQueryBuilder.h>
 #include <Dictionaries/IDictionarySource.h>
+#include <Dictionaries/InvalidateQueryResponse.h>
 
 
 namespace Poco
@@ -83,7 +84,7 @@ private:
     Block sample_block;
     ExternalQueryBuilder query_builder;
     const std::string load_all_query;
-    mutable std::string invalidate_query_response;
+    mutable InvalidateQueryResponse invalidate_query_response;
 
     BridgeHelperPtr bridge_helper;
     Poco::URI bridge_url;


### PR DESCRIPTION
### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a data race for ClickHouse, MySQL, PostgreSQL and XDBC dictionary sources where `clone() const` reads from and `isModified() const` writes to the same `invalidate_query_response` string.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.529`
- Backported to: `26.4.3.19`, `26.3.11.19`, `26.2.19.25`, `25.8.24.13`
<!-- ch-version-info:end -->