### PR TITLE
Cap pre-auth Hello packet strings to 64 KB and limit handshake time

### DIFF
--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -1273,6 +1273,7 @@ The policy on how to perform a scheduling of CPU slots specified by `concurrent_
     DECLARE(Float, distributed_cache_keep_up_free_connections_ratio, 0.1f, "Soft limit for number of active connection distributed cache will try to keep free. After the number of free connections goes below distributed_cache_keep_up_free_connections_ratio * max_connections, connections with oldest activity will be closed until the number goes above the limit.", 0) \
     DECLARE(UInt64, tcp_close_connection_after_queries_num, 0, R"(Maximum number of queries allowed per TCP connection before the connection is closed. Set to 0 for unlimited queries.)", 0) \
     DECLARE(UInt64, tcp_close_connection_after_queries_seconds, 0, R"(Maximum lifetime of a TCP connection in seconds before it is closed. Set to 0 for unlimited connection lifetime.)", 0) \
+    DECLARE(UInt64, handshake_timeout_milliseconds, 30000, R"(Wall-clock timeout in milliseconds for the entire TCP handshake phase (Hello + Addendum). Limits how long an unauthenticated connection can hold a thread. Set to 0 to disable.)", 0) \
     DECLARE(Bool, skip_binary_checksum_checks, false, R"(Skips ClickHouse binary checksum integrity checks)", 0) \
     DECLARE(Bool, abort_on_logical_error, false, R"(Crash the server on LOGICAL_ERROR exceptions. Only for experts.)", 0) \
     DECLARE(UInt64, jemalloc_flush_profile_interval_bytes, 0, R"(Flushing jemalloc profile will be done after global peak memory usage increased by jemalloc_flush_profile_interval_bytes)", 0) \

--- a/src/IO/ReadBufferFromPocoSocket.cpp
+++ b/src/IO/ReadBufferFromPocoSocket.cpp
@@ -102,6 +102,13 @@ ssize_t ReadBufferFromPocoSocketBase::socketReceiveBytesImpl(char * ptr, size_t 
 
 bool ReadBufferFromPocoSocketBase::nextImpl()
 {
+    if (handshake_timeout_milliseconds > 0 && handshake_stopwatch.elapsedMilliseconds() > handshake_timeout_milliseconds)
+        throw NetException(
+            ErrorCodes::SOCKET_TIMEOUT,
+            "Handshake timeout exceeded ({} milliseconds, peer: {})",
+            handshake_timeout_milliseconds,
+            peer_address.toString());
+
     if (internal_buffer.size() > INT_MAX)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Buffer overflow");
 
@@ -150,6 +157,19 @@ bool ReadBufferFromPocoSocketBase::poll(size_t timeout_microseconds) const
 void ReadBufferFromPocoSocketBase::setReceiveTimeout(size_t receive_timeout_microseconds)
 {
     socket.setReceiveTimeout(Poco::Timespan(receive_timeout_microseconds, 0));
+}
+
+void ReadBufferFromPocoSocketBase::setHandshakeTimeout(size_t timeout_milliseconds)
+{
+    handshake_timeout_milliseconds = timeout_milliseconds;
+    if (handshake_timeout_milliseconds > 0)
+        handshake_stopwatch.restart();
+}
+
+void ReadBufferFromPocoSocketBase::clearHandshakeTimeout()
+{
+    handshake_timeout_milliseconds = 0;
+    handshake_stopwatch.stop();
 }
 
 }

--- a/src/IO/ReadBufferFromPocoSocket.h
+++ b/src/IO/ReadBufferFromPocoSocket.h
@@ -3,6 +3,7 @@
 #include <IO/BufferWithOwnMemory.h>
 #include <IO/ReadBuffer.h>
 #include <Common/AsyncTaskExecutor.h>
+#include <Common/Stopwatch.h>
 #include <Poco/Net/Socket.h>
 
 namespace DB
@@ -36,9 +37,19 @@ public:
 
     void setReceiveTimeout(size_t receive_timeout_microseconds);
 
+    /// Set a wall-clock deadline for the entire handshake phase.
+    /// Every nextImpl() call will check elapsed time and throw SOCKET_TIMEOUT if exceeded.
+    /// Call clearHandshakeTimeout() after the handshake completes.
+    void setHandshakeTimeout(size_t timeout_milliseconds);
+    void clearHandshakeTimeout();
+
 private:
     AsyncCallback async_callback;
     std::string socket_description;
+
+    /// Wall-clock deadline for the handshake phase (optional).
+    size_t handshake_timeout_milliseconds = 0;
+    Stopwatch handshake_stopwatch = Stopwatch(STOPWATCH_DEFAULT_CLOCK, 0, /* is running */ false);
 };
 
 class ReadBufferFromPocoSocket : public ReadBufferFromPocoSocketBase

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -126,6 +126,7 @@ namespace ServerSetting
     extern const ServerSettingsBool process_query_plan_packet;
     extern const ServerSettingsUInt64 tcp_close_connection_after_queries_num;
     extern const ServerSettingsUInt64 tcp_close_connection_after_queries_seconds;
+    extern const ServerSettingsUInt64 handshake_timeout_milliseconds;
 }
 
 namespace FailPoints
@@ -354,6 +355,11 @@ void TCPHandler::runImpl()
 
     in = std::make_shared<ReadBufferFromPocoSocketChunked>(socket(), read_event);
 
+    /// Limit the total wall-clock time for the handshake phase to prevent
+    /// slowloris-style attacks from holding a thread indefinitely.
+    UInt64 handshake_timeout_ms = server.context()->getServerSettings()[ServerSetting::handshake_timeout_milliseconds];
+    in->setHandshakeTimeout(handshake_timeout_ms);
+
     /// Support for PROXY protocol
     if (parse_proxy_protocol && !receiveProxyHeader())
         return;
@@ -382,6 +388,8 @@ void TCPHandler::runImpl()
 
         if (client_tcp_protocol_version >= DBMS_MIN_PROTOCOL_VERSION_WITH_ADDENDUM)
             receiveAddendum();
+
+        in->clearHandshakeTimeout();
 
         {
             /// Server side of chunked protocol negotiation.
@@ -1883,6 +1891,11 @@ std::unique_ptr<Session> TCPHandler::makeSession()
 }
 
 
+/// Maximum size of a string field during the Hello handshake.
+/// Applied before authentication to prevent unauthenticated clients
+/// from consuming excessive memory. See #52501.
+static constexpr size_t MAX_HELLO_STRING_SIZE = 64 * 1024;
+
 void TCPHandler::receiveHello()
 {
     /// Receive `hello` packet.
@@ -1909,16 +1922,16 @@ void TCPHandler::receiveHello()
                                "Unexpected packet from client (expected Hello, got {})", packet_type);
     }
 
-    readStringBinary(client_name, *in);
+    readStringBinary(client_name, *in, MAX_HELLO_STRING_SIZE);
     readVarUInt(client_version_major, *in);
     readVarUInt(client_version_minor, *in);
     // NOTE For backward compatibility of the protocol, client cannot send its version_patch.
     readVarUInt(client_tcp_protocol_version, *in);
-    readStringBinary(default_db, *in);
+    readStringBinary(default_db, *in, MAX_HELLO_STRING_SIZE);
     if (!default_db.empty())
         default_database = default_db;
-    readStringBinary(user, *in);
-    readStringBinary(password, *in);
+    readStringBinary(user, *in, MAX_HELLO_STRING_SIZE);
+    readStringBinary(password, *in, MAX_HELLO_STRING_SIZE);
 
     if (user.empty())
         throw Exception(ErrorCodes::UNEXPECTED_PACKET_FROM_CLIENT, "Unexpected packet from client (no user in Hello package)");
@@ -2018,7 +2031,7 @@ void TCPHandler::receiveHello()
         readVarUInt(packet_type, *in);
         if (packet_type != Protocol::Client::SSHChallengeResponse)
             throw Exception(ErrorCodes::UNEXPECTED_PACKET_FROM_CLIENT, "Server expected to receive a packet with a response for a challenge");
-        readStringBinary(signature, *in);
+        readStringBinary(signature, *in, MAX_HELLO_STRING_SIZE);
 
         auto prepare_string_for_ssh_validation = [&](const String & username, const String & challenge_)
         {
@@ -2043,15 +2056,15 @@ void TCPHandler::receiveHello()
 void TCPHandler::receiveAddendum()
 {
     if (client_tcp_protocol_version >= DBMS_MIN_PROTOCOL_VERSION_WITH_QUOTA_KEY)
-        readStringBinary(quota_key, *in);
+        readStringBinary(quota_key, *in, MAX_HELLO_STRING_SIZE);
 
     if (!is_interserver_mode)
         session->setQuotaClientKey(quota_key);
 
     if (client_tcp_protocol_version >= DBMS_MIN_PROTOCOL_VERSION_WITH_CHUNKED_PACKETS)
     {
-        readStringBinary(proto_send_chunked_cl, *in);
-        readStringBinary(proto_recv_chunked_cl, *in);
+        readStringBinary(proto_send_chunked_cl, *in, MAX_HELLO_STRING_SIZE);
+        readStringBinary(proto_recv_chunked_cl, *in, MAX_HELLO_STRING_SIZE);
     }
 
     if (client_tcp_protocol_version >= DBMS_MIN_REVISION_WITH_VERSIONED_PARALLEL_REPLICAS_PROTOCOL)
@@ -2064,13 +2077,13 @@ void TCPHandler::processUnexpectedHello()
     UInt64 skip_uint_64;
     String skip_string;
 
-    readStringBinary(skip_string, *in);
+    readStringBinary(skip_string, *in, MAX_HELLO_STRING_SIZE);
     readVarUInt(skip_uint_64, *in);
     readVarUInt(skip_uint_64, *in);
     readVarUInt(skip_uint_64, *in);
-    readStringBinary(skip_string, *in);
-    readStringBinary(skip_string, *in);
-    readStringBinary(skip_string, *in);
+    readStringBinary(skip_string, *in, MAX_HELLO_STRING_SIZE);
+    readStringBinary(skip_string, *in, MAX_HELLO_STRING_SIZE);
+    readStringBinary(skip_string, *in, MAX_HELLO_STRING_SIZE);
 
     throw Exception(ErrorCodes::UNEXPECTED_PACKET_FROM_CLIENT, "Unexpected packet Hello received from client");
 }
@@ -2205,7 +2218,7 @@ std::optional<ParallelReadResponse> TCPHandler::receivePartitionMergeTreeReadTas
 
 void TCPHandler::processClusterNameAndSalt()
 {
-    readStringBinary(cluster, *in);
+    readStringBinary(cluster, *in, MAX_HELLO_STRING_SIZE);
     readStringBinary(salt, *in, 32);
 }
 

--- a/tests/integration/test_tcp_hello_string_limits/configs/config.d/handshake_timeout.xml
+++ b/tests/integration/test_tcp_hello_string_limits/configs/config.d/handshake_timeout.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <handshake_timeout_milliseconds>3000</handshake_timeout_milliseconds>
+</clickhouse>

--- a/tests/integration/test_tcp_hello_string_limits/test.py
+++ b/tests/integration/test_tcp_hello_string_limits/test.py
@@ -1,0 +1,454 @@
+import socket
+import struct
+import time
+
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/config.d/handshake_timeout.xml"],
+)
+
+MAX_HELLO_STRING_SIZE = 64 * 1024
+OVERSIZED = 1 * 1024 * 1024  # 1 MB — exceeds the 64 KB limit
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def encode_varuint(n):
+    """Encode an integer as a VarUInt (7 bits per byte, MSB continuation)."""
+    buf = bytearray()
+    while n >= 0x80:
+        buf.append((n & 0x7F) | 0x80)
+        n >>= 7
+    buf.append(n & 0x7F)
+    return bytes(buf)
+
+
+def encode_string(s):
+    """Encode a string as VarUInt length prefix + UTF-8 bytes."""
+    if isinstance(s, str):
+        s = s.encode("utf-8")
+    return encode_varuint(len(s)) + s
+
+
+def encode_oversized_string(size):
+    """Encode a string header claiming `size` bytes, followed by actual data.
+
+    We only send a small amount of actual data — the server should reject
+    the connection after reading the size prefix (before the full payload).
+    """
+    return encode_varuint(size) + b"A" * min(size, 4096)
+
+
+def build_hello_packet(
+    client_name=b"test",
+    version_major=24,
+    version_minor=1,
+    tcp_protocol_version=54471,
+    default_db=b"",
+    user=b"default",
+    password=b"",
+    oversized_field=None,
+    oversized_size=OVERSIZED,
+):
+    """Build a native protocol Hello packet.
+
+    If `oversized_field` is set to one of "client_name", "default_db",
+    "user", "password", the corresponding field will be replaced with
+    an oversized string header.
+    """
+    parts = []
+
+    # Packet type: Client::Hello = 0
+    parts.append(encode_varuint(0))
+
+    # client_name
+    if oversized_field == "client_name":
+        parts.append(encode_oversized_string(oversized_size))
+    else:
+        parts.append(encode_string(client_name))
+
+    # version_major, version_minor, tcp_protocol_version
+    parts.append(encode_varuint(version_major))
+    parts.append(encode_varuint(version_minor))
+    parts.append(encode_varuint(tcp_protocol_version))
+
+    # default_db
+    if oversized_field == "default_db":
+        parts.append(encode_oversized_string(oversized_size))
+    else:
+        parts.append(encode_string(default_db))
+
+    # user
+    if oversized_field == "user":
+        parts.append(encode_oversized_string(oversized_size))
+    else:
+        parts.append(encode_string(user))
+
+    # password
+    if oversized_field == "password":
+        parts.append(encode_oversized_string(oversized_size))
+    else:
+        parts.append(encode_string(password))
+
+    return b"".join(parts)
+
+
+USER_INTERSERVER_MARKER = " INTERSERVER SECRET "
+
+
+def build_interserver_hello_with_oversized_cluster(oversized_size=OVERSIZED):
+    """Build a Hello packet that triggers the interserver path,
+    then sends an oversized cluster name."""
+    parts = []
+
+    # Hello packet with interserver marker as user and empty password
+    parts.append(encode_varuint(0))  # Client::Hello = 0
+    parts.append(encode_string(b"test"))  # client_name
+    parts.append(encode_varuint(24))  # version_major
+    parts.append(encode_varuint(1))  # version_minor
+    parts.append(encode_varuint(54471))  # tcp_protocol_version
+    parts.append(encode_string(b""))  # default_db
+    parts.append(encode_string(USER_INTERSERVER_MARKER.encode()))  # user
+    parts.append(encode_string(b""))  # password (empty for interserver)
+
+    # After the hello fields, the server calls processClusterNameAndSalt
+    # which reads cluster (string) and salt (string, max 32 bytes)
+    parts.append(encode_oversized_string(oversized_size))  # cluster — oversized
+
+    return b"".join(parts)
+
+
+def decode_varuint(sock):
+    """Read a VarUInt from a socket."""
+    result = 0
+    shift = 0
+    while True:
+        byte = sock.recv(1)
+        if not byte:
+            raise ConnectionError("Connection closed while reading VarUInt")
+        b = byte[0]
+        result |= (b & 0x7F) << shift
+        if (b & 0x80) == 0:
+            break
+        shift += 7
+    return result
+
+
+def skip_string(sock):
+    """Read and discard a length-prefixed string from a socket."""
+    length = decode_varuint(sock)
+    remaining = length
+    while remaining > 0:
+        chunk = sock.recv(min(remaining, 65536))
+        if not chunk:
+            raise ConnectionError("Connection closed while reading string")
+        remaining -= len(chunk)
+
+
+def read_exact(sock, n):
+    """Read exactly n bytes from a socket."""
+    buf = b""
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise ConnectionError("Connection closed while reading bytes")
+        buf += chunk
+    return buf
+
+
+def skip_settings(sock):
+    """Read and discard a serialized Settings block from a socket.
+
+    Format: sequence of (String name, VarUInt flags, String value),
+    terminated by an empty name (single 0x00 byte).
+    """
+    while True:
+        name_len = decode_varuint(sock)
+        if name_len == 0:
+            break
+        remaining = name_len
+        while remaining > 0:
+            chunk = sock.recv(min(remaining, 65536))
+            if not chunk:
+                raise ConnectionError("Connection closed while reading settings name")
+            remaining -= len(chunk)
+        decode_varuint(sock)  # flags
+        skip_string(sock)  # value
+
+
+def complete_hello_handshake(sock, tcp_protocol_version=54471):
+    """Send a valid Hello packet and read the server's Hello response.
+
+    Returns the socket ready for sending addendum or query packets.
+    The Hello uses user=default with empty password (no auth needed
+    for default user in test config).
+    """
+    # Send Hello
+    hello = build_hello_packet(tcp_protocol_version=tcp_protocol_version)
+    sock.sendall(hello)
+
+    # Read server Hello response:
+    # VarUInt packet_type (0 = Hello), String server_name,
+    # VarUInt major, VarUInt minor, VarUInt revision
+    packet_type = decode_varuint(sock)
+    if packet_type == 2:
+        # Exception packet — auth failure or other error
+        raise Exception("Server returned exception during Hello")
+    assert packet_type == 0, f"Expected Hello response (0), got {packet_type}"
+
+    skip_string(sock)  # server_name
+    decode_varuint(sock)  # version_major
+    decode_varuint(sock)  # version_minor
+    decode_varuint(sock)  # revision
+
+    # Conditional fields based on protocol version
+    if tcp_protocol_version >= 54471:  # DBMS_MIN_REVISION_WITH_VERSIONED_PARALLEL_REPLICAS_PROTOCOL
+        decode_varuint(sock)  # parallel_replicas_protocol_version
+    if tcp_protocol_version >= 54058:  # DBMS_MIN_REVISION_WITH_SERVER_TIMEZONE
+        skip_string(sock)  # server_timezone
+    if tcp_protocol_version >= 54372:  # DBMS_MIN_REVISION_WITH_SERVER_DISPLAY_NAME
+        skip_string(sock)  # server_display_name
+    if tcp_protocol_version >= 54401:  # DBMS_MIN_REVISION_WITH_VERSION_PATCH
+        decode_varuint(sock)  # version_patch
+    if tcp_protocol_version >= 54470:  # DBMS_MIN_PROTOCOL_VERSION_WITH_CHUNKED_PACKETS
+        skip_string(sock)  # proto_send_chunked
+        skip_string(sock)  # proto_recv_chunked
+    if tcp_protocol_version >= 54461:  # DBMS_MIN_PROTOCOL_VERSION_WITH_PASSWORD_COMPLEXITY_RULES
+        num_rules = decode_varuint(sock)
+        for _ in range(num_rules):
+            skip_string(sock)  # original_pattern
+            skip_string(sock)  # exception_message
+    if tcp_protocol_version >= 54462:  # DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET_V2
+        read_exact(sock, 8)  # nonce (Int64)
+    if tcp_protocol_version >= 54474:  # DBMS_MIN_REVISION_WITH_SERVER_SETTINGS
+        skip_settings(sock)
+    if tcp_protocol_version >= 54477:  # DBMS_MIN_REVISION_WITH_QUERY_PLAN_SERIALIZATION
+        decode_varuint(sock)  # query_plan_serialization_version
+    if tcp_protocol_version >= 54479:  # DBMS_MIN_REVISION_WITH_VERSIONED_CLUSTER_FUNCTION_PROTOCOL
+        decode_varuint(sock)  # cluster_processing_protocol_version
+
+    return sock
+
+
+def send_packet_expect_rejection(node, packet):
+    """Send a raw packet to the ClickHouse native port and expect rejection.
+
+    The server should close the connection or send an error response.
+    Returns True if the connection was rejected (as expected).
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(10)
+    try:
+        sock.connect((node.ip_address, 9000))
+        sock.sendall(packet)
+        # Try to receive — we expect the server to close the connection
+        # or send an exception packet
+        try:
+            response = sock.recv(4096)
+            # If we get a response, check it is an exception (packet type 2)
+            if response and response[0] == 2:
+                return True  # Exception packet — rejected as expected
+            # Empty response means connection closed
+            assert len(response) == 0
+        except (ConnectionResetError, BrokenPipeError):
+            return True  # Connection reset — rejected as expected
+        except socket.timeout:
+            return False  # Server did not reject in time
+    finally:
+        sock.close()
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    ["client_name", "default_db", "user", "password"],
+)
+def test_oversized_hello_field_rejected(started_cluster, field_name):
+    """Each Hello string field exceeding 64 KB must be rejected."""
+    packet = build_hello_packet(oversized_field=field_name)
+    assert send_packet_expect_rejection(
+        node, packet
+    ), f"Server did not reject oversized {field_name}"
+
+
+def test_oversized_cluster_name_rejected(started_cluster):
+    """The cluster field in processClusterNameAndSalt must be rejected
+    when exceeding 64 KB (reachable via interserver marker user)."""
+    packet = build_interserver_hello_with_oversized_cluster()
+    assert send_packet_expect_rejection(
+        node, packet
+    ), "Server did not reject oversized cluster name"
+
+
+def test_boundary_just_over_limit_rejected(started_cluster):
+    """A string of exactly 64 KB + 1 byte must be rejected."""
+    packet = build_hello_packet(
+        oversized_field="client_name",
+        oversized_size=MAX_HELLO_STRING_SIZE + 1,
+    )
+    assert send_packet_expect_rejection(
+        node, packet
+    ), "Server did not reject string of 64 KB + 1"
+
+
+def test_boundary_at_limit_accepted(started_cluster):
+    """A string of exactly 64 KB must be accepted (not rejected)."""
+    # Build a Hello packet where client_name is exactly 64 KB
+    large_name = b"A" * MAX_HELLO_STRING_SIZE
+    packet = build_hello_packet(client_name=large_name)
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(10)
+    try:
+        sock.connect((node.ip_address, 9000))
+        sock.sendall(packet)
+        # The server should NOT reject this — it should proceed to auth
+        # (which will fail because user is "default" with no password,
+        # but that is after reading all fields successfully).
+        response = sock.recv(4096)
+        # We expect either a Hello response (packet type 0) or an
+        # Exception (packet type 2) from auth failure — NOT a connection
+        # reset from TOO_LARGE_STRING_SIZE.
+        assert len(response) > 0, "Server closed connection for a 64 KB string"
+    finally:
+        sock.close()
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    ["quota_key", "proto_send_chunked", "proto_recv_chunked"],
+)
+def test_oversized_addendum_field_rejected(started_cluster, field_name):
+    """Addendum string fields exceeding 64 KB must be rejected.
+
+    The addendum is sent after the Hello handshake completes.
+    quota_key is sent when protocol >= 54458,
+    proto_send_chunked/proto_recv_chunked when protocol >= 54470.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(10)
+    try:
+        sock.connect((node.ip_address, 9000))
+        complete_hello_handshake(sock, tcp_protocol_version=54471)
+
+        # Build addendum with one oversized field
+        parts = []
+
+        # quota_key (protocol >= 54458)
+        if field_name == "quota_key":
+            parts.append(encode_oversized_string(OVERSIZED))
+        else:
+            parts.append(encode_string(b""))
+
+        # proto_send_chunked_cl, proto_recv_chunked_cl (protocol >= 54470)
+        if field_name == "proto_send_chunked":
+            parts.append(encode_oversized_string(OVERSIZED))
+        else:
+            parts.append(encode_string(b"notchunked"))
+
+        if field_name == "proto_recv_chunked":
+            parts.append(encode_oversized_string(OVERSIZED))
+        else:
+            parts.append(encode_string(b"notchunked"))
+
+        sock.sendall(b"".join(parts))
+        response = b""
+
+        # Expect rejection
+        try:
+            response = sock.recv(4096)
+            if response and response[0] == 2:
+                return  # Exception packet — rejected as expected
+            assert len(response) == 0, f"Server did not reject oversized {field_name}, got response: {response}"
+        except (ConnectionResetError, BrokenPipeError):
+            pass  # Connection reset — rejected as expected
+    finally:
+        sock.close()
+
+
+def test_oversized_unexpected_hello_rejected(started_cluster):
+    """processUnexpectedHello string fields exceeding 64 KB must be rejected.
+
+    After completing the handshake + addendum, sending a Hello packet (type 0)
+    instead of a Query triggers processUnexpectedHello which reads 4 strings.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(10)
+    try:
+        sock.connect((node.ip_address, 9000))
+        complete_hello_handshake(sock, tcp_protocol_version=54471)
+
+        # Send valid addendum to complete the handshake
+        parts = []
+        parts.append(encode_string(b""))  # quota_key
+        parts.append(encode_string(b"notchunked"))  # proto_send_chunked
+        parts.append(encode_string(b"notchunked"))  # proto_recv_chunked
+        # parallel_replicas_protocol_version (protocol >= 54471)
+        parts.append(encode_varuint(0))
+        sock.sendall(b"".join(parts))
+
+        # Now send a Hello packet (type 0) with an oversized string —
+        # this triggers processUnexpectedHello
+        unexpected = []
+        unexpected.append(encode_varuint(0))  # Client::Hello = 0
+        unexpected.append(encode_oversized_string(OVERSIZED))  # oversized client_name
+        sock.sendall(b"".join(unexpected))
+
+        # Expect rejection
+        try:
+            response = sock.recv(4096)
+            if response and response[0] == 2:
+                return  # Exception packet — rejected as expected
+            assert len(response) == 0, "Server did not reject oversized unexpected Hello"
+        except (ConnectionResetError, BrokenPipeError):
+            pass  # Connection reset — rejected as expected
+    finally:
+        sock.close()
+
+
+def test_slowloris_handshake_timeout(started_cluster):
+    """A client that trickles data too slowly must be disconnected
+    by the handshake wall-clock timeout (set to 3 seconds in test config)."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(10)
+    try:
+        sock.connect((node.ip_address, 9000))
+        # Send just the Hello packet type byte, then trickle slowly
+        sock.sendall(encode_varuint(0))  # Client::Hello = 0
+        # Send client_name length prefix claiming a small string (10 bytes)
+        sock.sendall(encode_varuint(10))
+        # Trickle 1 byte per second — the handshake timeout (3s) should fire
+        # before we finish sending the 10-byte string
+        for i in range(10):
+            time.sleep(1)
+            try:
+                sock.sendall(b"A")
+            except (BrokenPipeError, ConnectionResetError, OSError):
+                return  # Server closed the connection — expected
+        # If we sent all 10 bytes, try to send more / receive response
+        # The server should have closed the connection by now
+        try:
+            response = sock.recv(4096)
+            # Exception packet (type 2) with timeout error is acceptable
+            if response and response[0] == 2:
+                return
+            assert len(response) == 0, "Server did not enforce handshake timeout"
+        except (ConnectionResetError, BrokenPipeError, OSError):
+            pass  # Server closed the connection — expected
+    finally:
+        sock.close()
+
+
+def test_server_healthy_after_rejections(started_cluster):
+    """After rejecting oversized packets, the server must still be healthy."""
+    result = node.query("SELECT 1")
+    assert result.strip() == "1"


### PR DESCRIPTION
An unauthenticated TCP client can allocate excessive server memory per connection by sending a crafted Hello packet with oversized string fields. Each `readStringBinary` call in `receiveHello` uses a default max size of 1 GiB (`DEFAULT_MAX_STRING_SIZE`), and all string fields are read before any authentication check.

This caps all pre-auth `readStringBinary` calls to 64 KB and adds a wall-clock handshake timeout (`handshake_timeout_milliseconds`, default 10 000 ms) to prevent slowloris-style attacks.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Cap pre-auth TCP Hello packet strings to 64 KB and add `handshake_timeout_milliseconds` server setting to limit total handshake time, preventing unauthenticated clients from consuming excessive memory or holding threads indefinitely.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

New server setting `handshake_timeout_milliseconds` (default: 10000). When set, limits the total wall-clock time for the TCP handshake phase (Hello + Addendum). Connections exceeding this timeout are closed.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.10`
- Backported to: `26.4.1.1119`, `26.3.10.39`, `26.2.17.24`, `26.1.12.20`
<!-- ch-version-info:end -->