### PR TITLE
Fix flaky test 03258_nonexistent_db on LLVM coverage builds

### DIFF
--- a/tests/queries/0_stateless/03258_nonexistent_db.sh
+++ b/tests/queries/0_stateless/03258_nonexistent_db.sh
@@ -4,4 +4,10 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-timeout 5 ${CLICKHOUSE_CLIENT_BINARY} --database "nonexistent" 2>&1 | grep -o "UNKNOWN_DATABASE" && echo "OK" || echo "FAIL"
+# The timeout is only a safety net against a genuinely stuck client.
+# The client reports `UNKNOWN_DATABASE` within milliseconds on a healthy run,
+# but under `amd_llvm_coverage` source-based coverage instrumentation the startup
+# can occasionally exceed 5 s under parallel test load. Raising to 60 s keeps
+# the test fast on happy paths and short enough to catch a real hang, while
+# preserving coverage of this client code path.
+timeout 60 ${CLICKHOUSE_CLIENT_BINARY} --database "nonexistent" 2>&1 | grep -o "UNKNOWN_DATABASE" && echo "OK" || echo "FAIL"


### PR DESCRIPTION
`03258_nonexistent_db.sh` wraps `clickhouse-client --database nonexistent` in `timeout 5` and greps for `UNKNOWN_DATABASE`. On `amd_llvm_coverage` builds under parallel test load the coverage-instrumented client can take longer than 5 s to start and emit the error, the `timeout` kills it first, `grep` finds nothing and the test prints `FAIL`.

```
2026-04-21 13:16:08 @@ -1,2 +1 @@
2026-04-21 13:16:08 -UNKNOWN_DATABASE
2026-04-21 13:16:08 -OK
2026-04-21 13:16:08 +FAIL
2026-04-21 13:16:08 + [13:16:03] timeout 5 clickhouse-client --database nonexistent
2026-04-21 13:16:08 + [13:16:03] grep -o UNKNOWN_DATABASE
2026-04-21 13:16:08 + [13:16:08] echo FAIL
```

The `timeout` is only a safety net against a genuinely stuck client; the happy path completes in milliseconds. Raising it to 60 s accommodates LLVM coverage overhead while still catching a real hang, and preserves coverage of this client code path (no new `no-*` tag).

30-day CIDB: all 19 failures are `amd_llvm_coverage*` variants, including 3 master hits on 2026-04-21. 0 failures on regular builds.

This is the same symptom and fix direction as `04078_native_protocol_input_validation` in #103210, which raised a 5 s socket timeout to 60 s for the same reason.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=1b90aee2d24bd44c14d55c9b27d06012177a1bb6&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%201%2F3%29

### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

N/A — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.36`
<!-- ch-version-info:end -->