### PR TITLE
Fix flaky text_log/query_log scans on busy CI workers (03312, 03335 azure/s3, 03735)

### DIFF
--- a/tests/queries/0_stateless/03312_line_numbers.sql
+++ b/tests/queries/0_stateless/03312_line_numbers.sql
@@ -8,7 +8,7 @@ SELECT 'This is the first query, and it is located on line 4',
 SELECT 'This is the second query, and it is located on line 8';
 
 SYSTEM FLUSH LOGS query_log, text_log;
-SELECT type, script_query_number, script_line_number, query FROM system.query_log WHERE current_database = currentDatabase() AND event_date >= yesterday() AND event_time >= now() - 600 ORDER BY event_time_microseconds, type;
+SELECT type, script_query_number, script_line_number, query FROM system.query_log WHERE current_database = currentDatabase() AND event_date >= yesterday() AND event_time >= now() - 600 ORDER BY event_time_microseconds, type SETTINGS max_rows_to_read = 0; -- system.query_log can be really big
 
-SELECT 'Ok' FROM system.text_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND message LIKE '%(query 1, line 4)%' AND message LIKE '%This is the first query%' LIMIT 1;
-SELECT 'Ok' FROM system.text_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND message LIKE '%(query 2, line 8)%' AND message LIKE '%This is the second query%' LIMIT 1;
+SELECT 'Ok' FROM system.text_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND message LIKE '%(query 1, line 4)%' AND message LIKE '%This is the first query%' LIMIT 1 SETTINGS max_rows_to_read = 0; -- system.text_log can be really big
+SELECT 'Ok' FROM system.text_log WHERE event_date >= yesterday() AND event_time >= now() - 600 AND message LIKE '%(query 2, line 8)%' AND message LIKE '%This is the second query%' LIMIT 1 SETTINGS max_rows_to_read = 0; -- system.text_log can be really big

--- a/tests/queries/0_stateless/03335_empty_blobs_on_azure.sh
+++ b/tests/queries/0_stateless/03335_empty_blobs_on_azure.sh
@@ -50,7 +50,8 @@ $CLICKHOUSE_CLIENT -m -q "
     -- Check logs for skipping empty blob
     SELECT 'Skipped empty blobs after 1 insert:',  count() FROM system.text_log
     WHERE message LIKE 'Skipping writing empty blob for path %$UUID/tmp_insert_all_1_1_0/arr.bin%' AND
-        event_date >= yesterday() AND event_time > now() - interval 10 minute;
+        event_date >= yesterday() AND event_time > now() - interval 10 minute
+    SETTINGS max_rows_to_read = 0; -- system.text_log can be really big
 
     -- Insert another row with empty Arrays to create another part with empty file
     INSERT INTO test_empty_blobs SELECT *, [] from numbers(1, 1);
@@ -85,8 +86,9 @@ $CLICKHOUSE_CLIENT -m -q "
 
     -- Check logs for skipping empty blob
     SYSTEM FLUSH LOGS text_log;
-    SELECT 'Skipped empty blobs after 2 inserts and merge:',  count() FROM system.text_log WHERE 
+    SELECT 'Skipped empty blobs after 2 inserts and merge:',  count() FROM system.text_log WHERE
         message LIKE 'Skipping writing empty blob for path %$UUID/%/arr.bin%' AND
-        event_date >= yesterday() AND event_time > now() - interval 10 minute;
+        event_date >= yesterday() AND event_time > now() - interval 10 minute
+    SETTINGS max_rows_to_read = 0; -- system.text_log can be really big
 ";
 

--- a/tests/queries/0_stateless/03335_empty_blobs_on_s3.sh
+++ b/tests/queries/0_stateless/03335_empty_blobs_on_s3.sh
@@ -40,7 +40,8 @@ $CLICKHOUSE_CLIENT -m -q "
     -- Check logs for skipping empty blob
     SELECT 'Skipped empty blobs after 1 insert:',  count() FROM system.text_log
     WHERE message LIKE 'Skipping writing empty blob for path %$UUID/tmp_insert_all_1_1_0/arr.bin%' AND
-        event_date >= yesterday() AND event_time > now() - interval 10 minute;
+        event_date >= yesterday() AND event_time > now() - interval 10 minute
+    SETTINGS max_rows_to_read = 0; -- system.text_log can be really big
 
     -- Check that there are several non-empty blobs in part dir
     SELECT if (count() > 4, 'Non-empty blobs present', 'Test error: no blobs found') FROM system.blob_storage_log
@@ -80,8 +81,9 @@ $CLICKHOUSE_CLIENT -m -q "
 
     -- Check logs for skipping empty blob
     SYSTEM FLUSH LOGS text_log;
-    SELECT 'Skipped empty blobs after 2 inserts and merge:',  count() FROM system.text_log WHERE 
+    SELECT 'Skipped empty blobs after 2 inserts and merge:',  count() FROM system.text_log WHERE
         message LIKE 'Skipping writing empty blob for path %$UUID/%/arr.bin%' AND
-        event_date >= yesterday() AND event_time > now() - interval 10 minute;
+        event_date >= yesterday() AND event_time > now() - interval 10 minute
+    SETTINGS max_rows_to_read = 0; -- system.text_log can be really big
 ";
 

--- a/tests/queries/0_stateless/03735_excessive_buffer_flush.sql
+++ b/tests/queries/0_stateless/03735_excessive_buffer_flush.sql
@@ -41,4 +41,5 @@ drop table buffer_flush_by_flush_time;
 
 system flush logs text_log;
 -- to avoid flakiness we only check that number of logs < 20, instead of some strict values
-select extractAll(logger_name, 'StorageBuffer \\([^.]+\\.([^)]+)\\)')[1] as table_name, max2(count(), 20) from system.text_log where event_date >= yesterday() AND event_time >= now() - 600 AND logger_name LIKE format('%StorageBuffer ({}.%', currentDatabase()) group by 1 order by 1;
+select extractAll(logger_name, 'StorageBuffer \\([^.]+\\.([^)]+)\\)')[1] as table_name, max2(count(), 20) from system.text_log where event_date >= yesterday() AND event_time >= now() - 600 AND logger_name LIKE format('%StorageBuffer ({}.%', currentDatabase()) group by 1 order by 1
+SETTINGS max_rows_to_read = 0; -- system.text_log can be really big


### PR DESCRIPTION
### Description
Several stateless tests fail on CI workers whose `system.text_log` has accumulated more than 20M rows, with:

```
Code: 158. DB::Exception: Limit for rows (controlled by 'max_rows_to_read' setting)
exceeded, max rows: 20.00 million, current rows: 22.96 million. (TOO_MANY_ROWS)
```

The test queries scan `system.text_log` (or `system.query_log`) with `LIKE` predicates that require a full-table read to find the matching messages, so they hit the randomized `max_rows_to_read` ceiling the test runner injects into `CLICKHOUSE_CLIENT_OPT`. The per-failure CI diagnostic confirms the failures reproduce both with AND without random settings — this is a deterministic environmental flake, not a settings randomization issue.

This PR fixes four tests with the same root cause:

- `03312_line_numbers.sql`
- `03335_empty_blobs_on_azure.sh`
- `03335_empty_blobs_on_s3.sh` (added 2026-05-21)
- `03735_excessive_buffer_flush.sql` (added 2026-05-21)

### Fix
Add `SETTINGS max_rows_to_read = 0` to each `system.text_log` (and the `system.query_log`) query, following the well-established pattern in other tests such as `02935_parallel_replicas_settings.sql`, `02813_starting_in_text_log.sql`, `03096_text_log_format_string_args_not_empty.sh`, and `01165_lost_part_empty_partition.sql`.

For `03312_line_numbers.sql` the fix is applied at the query level rather than as a top-of-file `SET`, because the test asserts on `script_line_number` — adding any line above the tracked queries would shift them and break the reference.

### CIDB evidence (30 days)
- `03312_line_numbers`: 4 genuinely unrelated PRs (+ 0 master) with the same `TOO_MANY_ROWS` signature.
- `03335_empty_blobs_on_azure`: 8 genuinely unrelated PRs (+ 0 master) with the same `TOO_MANY_ROWS` signature.
- `03335_empty_blobs_on_s3`: 1 unrelated PR (#103706) with diagnostic showing 32/32 fail WITH randomization and 68/68 fail WITHOUT randomization.
- `03735_excessive_buffer_flush`: 2 unrelated PRs (#103706, #103182) + 1 master hit (2026-05-04 21:06:28), 3/3 fail WITH and 3/3 fail WITHOUT randomization.

### Verification
- **Without the fix**: running the unmodified `03312_line_numbers.sql` with `CLICKHOUSE_CLIENT_OPT="--max_rows_to_read=1000"` reliably reproduces
  ```
  Code: 158. DB::Exception: ... Limit for rows ...
  (query: SELECT 'Ok' FROM system.text_log ... LIMIT 1;)
  ```
- **With the fix**: 30/30 runs pass at that same restrictive limit with full CI randomization enabled. `03735_excessive_buffer_flush` was additionally verified locally (1 OK / 21s) after the new commit.

### CI report
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=103182&sha=cbef86ec593ee4fe5e82696bbcaaa1a287eebea8&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=103706&sha=cd7c9510df46d19f26bbab6b172239c125ec9c7a&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.113`
<!-- ch-version-info:end -->