### PR TITLE
Skip 02293_http_header_full_summary_without_progress on LLVM coverage

### DIFF
--- a/tests/queries/0_stateless/02293_http_header_full_summary_without_progress.sh
+++ b/tests/queries/0_stateless/02293_http_header_full_summary_without_progress.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-llvm-coverage
+# no-llvm-coverage: the test relies on HTTP-level timing (max-time 10, max_execution_time 2) to
+# produce a 408 response and an X-ClickHouse-Summary header. LLVM source-based coverage
+# instrumentation slows the server enough that curl sometimes times out before any summary
+# header is emitted, leaving $READ_ROWS empty and failing line 27 with
+# "[: : integer expression expected". See PRs #103287, #103288, #103219, #103226.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
The test hardcodes `curl --max-time 10` together with `max_execution_time=2` and relies on the server producing an `X-ClickHouse-Summary` header (with a non-zero `read_rows` value) and an `HTTP/1.1 408 Request Time-out` response within that 10-second window.

Under `amd_llvm_coverage` builds, source-based coverage instrumentation slows the server enough that `curl` sometimes times out before any summary header is emitted. When that happens `READ_ROWS` becomes an empty string, and line 27's integer comparison `if [ "$READ_ROWS" -ne 0 ]` fails with `[: : integer expression expected`. The runner successfully reruns the test (`Failed 0 out of 3 reruns`), so this is a single-shot timing flake confined to coverage builds.

### CIDB evidence (30 days)

- **Failures:** 10, all on `amd_llvm_coverage` variants (`2/3`, `AsyncInsert s3 storage parallel`, `ParallelReplicas s3 storage parallel`)
- **Master/release-branch hits:** 0
- **Distinct unrelated PRs affected:** 10

```
check_name                                                       count
Stateless tests (amd_llvm_coverage, 2/3)                         6
Stateless tests (amd_llvm_coverage, ParallelReplicas, s3 ...)    2
Stateless tests (amd_llvm_coverage, AsyncInsert, s3 ...)         2
```

Same failure family as 01473, 03096, 03258, 04078, and 01514.

Add `no-llvm-coverage` to skip the test on coverage builds, matching the established pattern used by PRs #103287, #103288, #103219, and #103226.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)