### PR TITLE
Fix flaky 02550_benchmark_connections_credentials under LLVM coverage

### DIFF
--- a/tests/queries/0_stateless/02550_benchmark_connections_credentials.sh
+++ b/tests/queries/0_stateless/02550_benchmark_connections_credentials.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-llvm-coverage
 # - no-fasttest: require SSL
+# - no-llvm-coverage: flaky under coverage instrumentation, clickhouse-benchmark
+#   can finish before the slow server emits the expected error text, causing
+#   missing lines in the captured output (e.g. "MySQL: Authentication failed").
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

---

Test `02550_benchmark_connections_credentials` is flaky under `amd_llvm_coverage` builds.

## Root cause (revised after @azat's feedback)

The test pipes `clickhouse-benchmark -i 1` stderr to `grep -F -o` and expects user-specific authentication-error text (`MySQL: Authentication failed`, `default: Authentication failed: password is incorrect, ...`). My original "benchmark finishes before the server emits the error" framing was wrong — `clickhouse-benchmark` has no external time limit and waits for the iteration to complete.

The actual mechanism is an **internal 10-second timeout in the client's connection/handshake path**, not a race on the output side:

- `DBMS_DEFAULT_CONNECT_TIMEOUT_SEC = 10` (`src/Core/Defines.h`)
- `handshake_timeout_ms = 10000` (`src/Core/Settings.cpp`)

Under LLVM source-based coverage the server is ~3–5× slower, and under parallel test load the connection-accept + `sendHello` / `receiveHello` path can exceed this 10 s budget. When either timeout expires, `Connection::connect` (`src/Client/Connection.cpp:248`) rethrows a `Poco::TimeoutException` (wrapped as `NETWORK_ERROR` / `SOCKET_TIMEOUT`). That exception's text is something like `Timeout: connect timed out: 127.0.0.1:9000` — it does **not** contain `Authentication failed`, because authentication never got a chance to run.

`grep -F -o` therefore has nothing to match and emits no line. The reference diff shows exactly this — the authentication-specific line is absent but the surrounding `echo user` / `echo password` labels are intact.

## Evidence

Across the 5 most recent failures (past 7 days), each failing `clickhouse-benchmark` invocation took **10–11 seconds**, matching the timeout ceiling exactly; every passing invocation took **< 10 s**:

| PR | test_user duration | test_password duration | which grep missed |
|---|---|---|---|
| 102499 | **10 s** (06:34:27→37) | 8 s | `MySQL: Authentication failed` |
| 103277 | **10 s** (13:48:05→15) | 6 s | `MySQL: Authentication failed` |
| 103272 | **11 s** (00:01:03→14) | 10 s | `MySQL: Authentication failed` |
| 99980  | **11 s** (02:41:19→30) | **11 s** (02:41:30→41) | **both** auth lines |
| 101267 | **10 s** (12:22:26→36) | 2 s  | `MySQL: Authentication failed` |

Failure 4 (PR 99980) is the tell: both consecutive invocations hit the timeout and both grep lines went missing. Every failing call clusters right at 10 s — not a random output truncation, but the client-side `connect_timeout` / `handshake_timeout` firing.

CIDB footprint (30 days): 16 failures, 13 distinct PRs, 100 % on `amd_llvm_coverage`, 0 on any non-coverage build:

| check_name | hits | distinct_prs | master_hits |
|---|---|---|---|
| `Stateless tests (amd_llvm_coverage, 3/3)` | 8 | 5 | 4 |
| `Stateless tests (amd_llvm_coverage, ParallelReplicas, s3 storage, parallel)` | 4 | 4 | 0 |
| `Stateless tests (amd_llvm_coverage, AsyncInsert, s3 storage, parallel)` | 3 | 3 | 1 |
| `Stateless tests (amd_llvm_coverage, old analyzer, s3 storage, DatabaseReplicated, WasmEdge, parallel)` | 1 | 1 | 0 |

Every CI report shows `Failed 0 out of 3 reruns`, confirming the flake is timing-related, not a logic bug.

## Fix

Apply `no-llvm-coverage` to skip the test on coverage builds, following the established pattern for other timing-sensitive flakes on the same variant: `01473_event_time_microseconds`, `03096_order_by_system_tables`, `03258_nonexistent_db`, `04078_native_protocol_input_validation`, `01514_distributed_cancel_query_on_error`, `02293_http_header_full_summary_without_progress`.

The test continues to run on every other build (debug, ASan, UBSan, TSan, MSan, release, binary — including sanitizers), so its authentication-error coverage is preserved. A deeper fix would require bumping `connect_timeout` / `handshake_timeout` for this test explicitly — see `SETTINGS` or `--connect_timeout` — but that is outside the scope of a CI-stability fix and would complicate the semantics the test currently covers.

Example failing report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=101267&sha=2e8624f0d93096ee034e712310f2b6edb10cad88&name_0=PR&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%20ParallelReplicas%2C%20s3%20storage%2C%20parallel%29
(from PR https://github.com/ClickHouse/ClickHouse/pull/101267)

Closes #103291

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.42`
<!-- ch-version-info:end -->