### PR TITLE
Support Processors Removal in Query Runtime

### DIFF
--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -138,7 +138,7 @@ void ExecutingGraph::removeAffectedEdges(Node & node, const std::unordered_set<N
     }
 }
 
-ExecutingGraph::UpdateNodeStatus ExecutingGraph::updatePipeline(boost::container::devector<Node *> & stack, Node & cur_node)
+ExecutingGraph::UpdateNodeStatus ExecutingGraph::updatePipeline(boost::container::devector<Node *> & stack, Node & cur_node, Processors & delayed_destruction)
 {
     IProcessor::PipelineUpdate update;
 
@@ -175,6 +175,10 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updatePipeline(boost::container
         }
     }
 
+    /// Processors that was removed from the pipeline can hold the last strong reference to data.
+    /// It is too expensive to destroy them under the nodes mutex.
+    delayed_destruction.splice(delayed_destruction.end(), update.to_remove);
+
     /// Updated edges for every node.
     std::vector<std::pair<Node *, NewEdges>> added_edges;
     for (auto & node : nodes)
@@ -187,16 +191,16 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updatePipeline(boost::container
     }
 
     /// Record updated ports for each newly added edge for each processor and schedule it for prepare if something changed.
-    for (auto & [updated_node, new_edges] : added_edges)
+    if (!is_cancelled)
     {
-        for (auto * edge : new_edges.back)
-            updated_node->updated_input_ports.emplace_back(edge->input_port);
-
-        for (auto * edge : new_edges.direct)
-            updated_node->updated_output_ports.emplace_back(edge->output_port);
-
-        if (!is_cancelled)
+        for (auto & [updated_node, new_edges] : added_edges)
         {
+            for (auto * edge : new_edges.back)
+                updated_node->updated_input_ports.emplace_back(edge->input_port);
+
+            for (auto * edge : new_edges.direct)
+                updated_node->updated_output_ports.emplace_back(edge->output_port);
+
             if (updated_node->status == ExecutingGraph::ExecStatus::Idle)
             {
                 updated_node->status = ExecutingGraph::ExecStatus::Preparing;
@@ -240,6 +244,10 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Q
     boost::container::devector<Edge *> updated_edges;
     boost::container::devector<Node *> updated_processors;
     updated_processors.push_back(start_node);
+
+    /// Processors removed via updatePipeline accumulate here and die at function exit,
+    /// after all graph mutexes have been released.
+    Processors delayed_destruction;
 
     std::shared_lock read_lock(nodes_mutex);
 
@@ -410,7 +418,7 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Q
                 read_lock.unlock();
                 {
                     std::unique_lock lock(nodes_mutex);
-                    auto status = updatePipeline(updated_processors, node);
+                    auto status = updatePipeline(updated_processors, node, delayed_destruction);
                     if (status != UpdateNodeStatus::Done)
                         return status;
                 }

--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -1,10 +1,12 @@
 #include <Processors/Executors/ExecutingGraph.h>
 #include <Processors/IProcessor.h>
+#include <Processors/Port.h>
 #include <Common/Stopwatch.h>
 #include <Common/CurrentThread.h>
 
 #include <shared_mutex>
 #include <stack>
+#include <unordered_set>
 
 
 namespace DB
@@ -32,12 +34,29 @@ ExecutingGraph::Node & ExecutingGraph::addNode(Processors::iterator processor_it
 {
     IProcessor * processor = processor_iter->get();
     auto & new_node = nodes.emplace_back(processor_iter, next_node_id++);
+    new_node.self_iter = std::prev(nodes.end());
 
     const auto [_, inserted] = processors_map.emplace(processor, &new_node);
     if (!inserted)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Processor {} was already added to pipeline", processor->getName());
 
     return new_node;
+}
+
+ExecutingGraph::Node * ExecutingGraph::removeNode(ProcessorPtr processor)
+{
+    auto node_it = processors_map.find(processor.get());
+    if (node_it == processors_map.end())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Processor {} does not exist in pipeline", processor->getName());
+
+    auto * node = node_it->second;
+    if (node->last_processor_status.value() != IProcessor::Status::Finished)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Trying to remove not finished processor {}", processor->getName());
+
+    processors_map.erase(node_it);
+    processors->erase(node->processor_iter);
+    nodes.erase(node->self_iter);
+    return node;
 }
 
 ExecutingGraph::Node & ExecutingGraph::addNode(ProcessorPtr processor)
@@ -97,13 +116,32 @@ ExecutingGraph::NewEdges ExecutingGraph::addEdges(Node & node)
     return result;
 }
 
-ExecutingGraph::UpdateNodeStatus ExecutingGraph::expandPipeline(boost::container::devector<Node *> & stack, Node & cur_node)
+void ExecutingGraph::removeAffectedEdges(Node & node, const std::unordered_set<Node *> & removed_nodes)
 {
-    Processors new_processors;
+    for (auto it = node.back_edges.begin(); it != node.back_edges.end();)
+    {
+        if (removed_nodes.contains(it->to))
+            it = node.back_edges.erase(it);
+        else
+            it = std::next(it);
+    }
+
+    for (auto it = node.direct_edges.begin(); it != node.direct_edges.end();)
+    {
+        if (removed_nodes.contains(it->to))
+            it = node.direct_edges.erase(it);
+        else
+            it = std::next(it);
+    }
+}
+
+ExecutingGraph::UpdateNodeStatus ExecutingGraph::updatePipeline(boost::container::devector<Node *> & stack, Node & cur_node)
+{
+    IProcessor::PipelineUpdate update;
 
     try
     {
-        new_processors = cur_node.processor()->expandPipeline();
+        update = cur_node.processor()->updatePipeline();
     }
     catch (...)
     {
@@ -111,50 +149,61 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::expandPipeline(boost::container
         return UpdateNodeStatus::Exception;
     }
 
+    bool is_cancelled = false;
+    std::unordered_set<Node *> removed_nodes;
     {
         std::lock_guard guard(processors_mutex);
 
-        /// Even if the query was already cancelled, we must still add the new processors to the list
-        /// to keep them alive, because their ports are already connected to existing processors.
-        /// Destroying them here would leave dangling port references, causing use-after-free
-        /// (e.g. pure virtual call in `dumpPipeline`).
-        for (const auto & new_proc : new_processors)
+        /// Record new processors in pipeline
+        for (const auto & new_proc : update.to_add)
             addNode(new_proc);
 
+        /// Remove deleted processors from pipeline
+        for (const auto & removed_proc : update.to_remove)
+            removed_nodes.insert(removeNode(removed_proc));
+
+        /// Propagate cancellation to newly added processors.
         if (cancel_reason != IProcessor::CancelReason::NotCancelled)
         {
-            /// Propagate the cancellation reason to newly added processors. They decide how to react.
-            for (auto & processor : new_processors)
+            for (auto & processor : update.to_add)
                 processor->cancel(cancel_reason);
 
-            /// For PartialResult the pipeline must still run to drain all left data, so continue normally.
-            if (cancel_reason != IProcessor::CancelReason::PartialResult)
-                return UpdateNodeStatus::Cancelled;
+            is_cancelled = true;
         }
     }
 
-    /// Build new edges for every node.
+    /// Updated edges for every node.
     std::vector<std::pair<Node *, NewEdges>> added_edges;
     for (auto & node : nodes)
+    {
+        if (!removed_nodes.empty())
+            removeAffectedEdges(node, removed_nodes);
+
         if (auto new_edges = addEdges(node); !new_edges.empty())
             added_edges.emplace_back(&node, std::move(new_edges));
+    }
 
     /// Record updated ports for each newly added edge for each processor and schedule it for prepare if something changed.
     for (auto & [updated_node, new_edges] : added_edges)
     {
-        /// Record the updated port pointers so the next prepare() sees them as "updated".
         for (auto * edge : new_edges.back)
             updated_node->updated_input_ports.emplace_back(edge->input_port);
 
         for (auto * edge : new_edges.direct)
             updated_node->updated_output_ports.emplace_back(edge->output_port);
 
-        if (updated_node->status == ExecutingGraph::ExecStatus::Idle)
+        if (!is_cancelled)
         {
-            updated_node->status = ExecutingGraph::ExecStatus::Preparing;
-            stack.push_front(updated_node);
+            if (updated_node->status == ExecutingGraph::ExecStatus::Idle)
+            {
+                updated_node->status = ExecutingGraph::ExecStatus::Preparing;
+                stack.push_front(updated_node);
+            }
         }
     }
+
+    if (is_cancelled)
+        return UpdateNodeStatus::Cancelled;
 
     return UpdateNodeStatus::Done;
 }
@@ -234,7 +283,7 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Q
             /// In this method we have ownership on node.
             auto & node = *current;
 
-            bool need_expand_pipeline = false;
+            bool need_update_pipeline = false;
 
             if (!stack_top_lock)
                 stack_top_lock.emplace(node.status_mutex);
@@ -316,14 +365,14 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Q
                         async_queue.push(&node);
                         break;
                     }
-                    case IProcessor::Status::ExpandPipeline:
+                    case IProcessor::Status::UpdatePipeline:
                     {
-                        need_expand_pipeline = true;
+                        need_update_pipeline = true;
                         break;
                     }
                 }
 
-                if (!need_expand_pipeline)
+                if (!need_update_pipeline)
                 {
                     /// If you wonder why edges are pushed in reverse order,
                     /// it is because updated_edges is a stack, and we prefer to get from stack
@@ -352,13 +401,13 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updateNode(Node * start_node, Q
                 }
             }
 
-            if (need_expand_pipeline)
+            if (need_update_pipeline)
             {
                 // We do not need to upgrade lock atomically, so we can safely release shared_lock and acquire unique_lock
                 read_lock.unlock();
                 {
                     std::unique_lock lock(nodes_mutex);
-                    auto status = expandPipeline(updated_processors, node);
+                    auto status = updatePipeline(updated_processors, node);
                     if (status != UpdateNodeStatus::Done)
                         return status;
                 }

--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -50,6 +50,9 @@ ExecutingGraph::Node * ExecutingGraph::removeNode(ProcessorPtr processor)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Processor {} does not exist in pipeline", processor->getName());
 
     auto * node = node_it->second;
+    if (!node->last_processor_status)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Trying to remove not finished processor {}", processor->getName());
+
     if (node->last_processor_status.value() != IProcessor::Status::Finished)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Trying to remove not finished processor {}", processor->getName());
 

--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -160,7 +160,7 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updatePipeline(boost::container
         return UpdateNodeStatus::Exception;
     }
 
-    bool is_cancelled = false;
+    IProcessor::CancelReason cancel_reason_if_cancelled = IProcessor::CancelReason::NotCancelled;
     std::unordered_set<Node *> removed_nodes;
     {
         std::lock_guard guard(processors_mutex);
@@ -179,7 +179,7 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updatePipeline(boost::container
             for (auto & processor : update.to_add)
                 processor->cancel(cancel_reason);
 
-            is_cancelled = true;
+            cancel_reason_if_cancelled = cancel_reason;
         }
     }
 
@@ -205,7 +205,7 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updatePipeline(boost::container
     }
 
     /// Record updated ports for each newly added edge for each processor and schedule it for prepare if something changed.
-    if (!is_cancelled)
+    if (cancel_reason_if_cancelled == IProcessor::CancelReason::NotCancelled || cancel_reason_if_cancelled == IProcessor::CancelReason::PartialResult)
     {
         for (auto & [updated_node, new_edges] : added_edges)
         {
@@ -223,7 +223,8 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updatePipeline(boost::container
         }
     }
 
-    if (is_cancelled)
+    /// If PartialResult was requested requested - continue normally
+    if (cancel_reason_if_cancelled != IProcessor::CancelReason::NotCancelled && cancel_reason_if_cancelled != IProcessor::CancelReason::PartialResult)
         return UpdateNodeStatus::Cancelled;
 
     return UpdateNodeStatus::Done;

--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -119,8 +119,11 @@ ExecutingGraph::NewEdges ExecutingGraph::addEdges(Node & node)
     return result;
 }
 
-void ExecutingGraph::removeAffectedEdges(Node & node, const std::unordered_set<Node *> & removed_nodes)
+bool ExecutingGraph::removeAffectedEdges(Node & node, const std::unordered_set<Node *> & removed_nodes)
 {
+    const size_t initial_back_edges_count = node.back_edges.size();
+    const size_t initial_direct_edges_count = node.direct_edges.size();
+
     for (auto it = node.back_edges.begin(); it != node.back_edges.end();)
     {
         if (removed_nodes.contains(it->to))
@@ -136,6 +139,11 @@ void ExecutingGraph::removeAffectedEdges(Node & node, const std::unordered_set<N
         else
             it = std::next(it);
     }
+
+    const bool removed_something = initial_back_edges_count != node.back_edges.size()
+                                || initial_direct_edges_count != node.direct_edges.size();
+
+    return removed_something;
 }
 
 ExecutingGraph::UpdateNodeStatus ExecutingGraph::updatePipeline(boost::container::devector<Node *> & stack, Node & cur_node, Processors & delayed_destruction)
@@ -183,11 +191,17 @@ ExecutingGraph::UpdateNodeStatus ExecutingGraph::updatePipeline(boost::container
     std::vector<std::pair<Node *, NewEdges>> added_edges;
     for (auto & node : nodes)
     {
+        std::optional<NewEdges> edges;
+
         if (!removed_nodes.empty())
-            removeAffectedEdges(node, removed_nodes);
+            if (removeAffectedEdges(node, removed_nodes))
+                edges.emplace();
 
         if (auto new_edges = addEdges(node); !new_edges.empty())
-            added_edges.emplace_back(&node, std::move(new_edges));
+            edges = std::move(new_edges);
+
+        if (edges.has_value())
+            added_edges.emplace_back(&node, std::move(edges.value()));
     }
 
     /// Record updated ports for each newly added edge for each processor and schedule it for prepare if something changed.

--- a/src/Processors/Executors/ExecutingGraph.cpp
+++ b/src/Processors/Executors/ExecutingGraph.cpp
@@ -123,11 +123,15 @@ bool ExecutingGraph::removeAffectedEdges(Node & node, const std::unordered_set<N
 {
     const size_t initial_back_edges_count = node.back_edges.size();
     const size_t initial_direct_edges_count = node.direct_edges.size();
+    std::unordered_set<const void *> removed_edge_ids;
 
     for (auto it = node.back_edges.begin(); it != node.back_edges.end();)
     {
         if (removed_nodes.contains(it->to))
+        {
+            removed_edge_ids.insert(it->update_info.id);
             it = node.back_edges.erase(it);
+        }
         else
             it = std::next(it);
     }
@@ -135,9 +139,20 @@ bool ExecutingGraph::removeAffectedEdges(Node & node, const std::unordered_set<N
     for (auto it = node.direct_edges.begin(); it != node.direct_edges.end();)
     {
         if (removed_nodes.contains(it->to))
+        {
+            removed_edge_ids.insert(it->update_info.id);
             it = node.direct_edges.erase(it);
+        }
         else
             it = std::next(it);
+    }
+
+    /// We need to remove cached updates for removed edges. This updates now contain stale pointers.
+    if (!removed_edge_ids.empty())
+    {
+        auto is_stale = [&](void * id) { return removed_edge_ids.contains(id); };
+        std::erase_if(node.post_updated_input_ports, is_stale);
+        std::erase_if(node.post_updated_output_ports, is_stale);
     }
 
     const bool removed_something = initial_back_edges_count != node.back_edges.size()

--- a/src/Processors/Executors/ExecutingGraph.h
+++ b/src/Processors/Executors/ExecutingGraph.h
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <queue>
 #include <unordered_map>
+#include <unordered_set>
 
 #include <boost/container/devector.hpp>
 
@@ -62,11 +63,17 @@ public:
         Async  /// prepare returned Async. Owning.
     };
 
+    /// Forward decl so Node can hold an iterator into the owning Nodes list.
+    using Nodes = std::list<struct Node>;
+
     /// Graph node. Represents single Processor.
     struct Node
     {
         /// Iterator into the graph's processors list.
         Processors::iterator processor_iter{};
+
+        /// Iterator into the graph's nodes list pointing at this node.
+        Nodes::iterator self_iter{};
 
         /// Stable, monotonically-assigned id. Never reused. Used only for diagnostics (logs, system.processors_profile_log).
         uint64_t processors_id = 0;
@@ -116,8 +123,7 @@ public:
     using DequeWithMemoryTracker = boost::container::devector<ExecutingGraph::Node *, AllocatorWithMemoryTracking<ExecutingGraph::Node *>>;
     using Queue = std::queue<ExecutingGraph::Node *, DequeWithMemoryTracker>;
 
-    /// All graph nodes.
-    using Nodes = std::list<Node>;
+    /// All graph nodes. Nodes type is forward-declared above so Node can hold a self-iterator.
     Nodes nodes;
 
     /// Each processor is directly tied to pipeline graph node.
@@ -150,10 +156,8 @@ private:
     /// Append a processor to the graph's processors list, create its Node, assign a stable id,
     /// register it in the processors map. Does not create edges — that is done separately by addEdges.
     Node & addNode(ProcessorPtr processor);
-
-    /// Register a Node for a processor already present in `processors` at `processor_iter`.
-    /// Used during construction (initial processors) and by addNode (just pushed).
     Node & addNode(Processors::iterator processor_iter);
+    Node * removeNode(ProcessorPtr processor);
 
     /// Add single edge to edges list. Check processor is known.
     Edge & addEdge(Edges & edges, Edge edge, const IProcessor * from, const IProcessor * to);
@@ -165,13 +169,12 @@ private:
         std::vector<Edge *> direct;  // direct edges added (outputs side of this node)
         bool empty() const { return back.empty() && direct.empty(); }
     };
-
-    /// Append new edges for node. It is called for new node or when new port were added after ExpandPipeline.
     NewEdges addEdges(Node & node);
+    void removeAffectedEdges(Node & node, const std::unordered_set<Node *> & removed_nodes);
 
-    /// Update graph after processor `node` returned ExpandPipeline status.
+    /// Update graph after processor `node` returned UpdatePipeline status.
     /// All new nodes and nodes with updated ports are pushed into stack.
-    UpdateNodeStatus expandPipeline(boost::container::devector<Node *> & stack, Node & node);
+    UpdateNodeStatus updatePipeline(boost::container::devector<Node *> & stack, Node & node);
 
     /// Shared with QueryPipeline.
     std::shared_ptr<Processors> processors;

--- a/src/Processors/Executors/ExecutingGraph.h
+++ b/src/Processors/Executors/ExecutingGraph.h
@@ -170,7 +170,7 @@ private:
         bool empty() const { return back.empty() && direct.empty(); }
     };
     NewEdges addEdges(Node & node);
-    void removeAffectedEdges(Node & node, const std::unordered_set<Node *> & removed_nodes);
+    bool removeAffectedEdges(Node & node, const std::unordered_set<Node *> & removed_nodes);
 
     /// Update graph after processor `node` returned UpdatePipeline status.
     /// All new nodes and nodes with updated ports are pushed into stack.

--- a/src/Processors/Executors/ExecutingGraph.h
+++ b/src/Processors/Executors/ExecutingGraph.h
@@ -174,7 +174,7 @@ private:
 
     /// Update graph after processor `node` returned UpdatePipeline status.
     /// All new nodes and nodes with updated ports are pushed into stack.
-    UpdateNodeStatus updatePipeline(boost::container::devector<Node *> & stack, Node & node);
+    UpdateNodeStatus updatePipeline(boost::container::devector<Node *> & stack, Node & node, Processors & delayed_destruction);
 
     /// Shared with QueryPipeline.
     std::shared_ptr<Processors> processors;

--- a/src/Processors/Executors/StreamingFormatExecutor.cpp
+++ b/src/Processors/Executors/StreamingFormatExecutor.cpp
@@ -115,7 +115,7 @@ size_t StreamingFormatExecutor::execute(size_t num_bytes)
 
                 case IProcessor::Status::NeedData:
                 case IProcessor::Status::Async:
-                case IProcessor::Status::ExpandPipeline:
+                case IProcessor::Status::UpdatePipeline:
                     throw Exception(ErrorCodes::LOGICAL_ERROR, "Source processor returned status {}", IProcessor::statusToName(status));
             }
         }

--- a/src/Processors/Formats/Impl/ParallelParsingInputFormat.h
+++ b/src/Processors/Formats/Impl/ParallelParsingInputFormat.h
@@ -188,7 +188,7 @@ private:
 
                     case IProcessor::Status::NeedData: break;
                     case IProcessor::Status::Async: break;
-                    case IProcessor::Status::ExpandPipeline:
+                    case IProcessor::Status::UpdatePipeline:
                         throw Exception(ErrorCodes::LOGICAL_ERROR, "One of the parsers returned status {} during parallel parsing",
                                              IProcessor::statusToName(status));
                 }

--- a/src/Processors/IProcessor.cpp
+++ b/src/Processors/IProcessor.cpp
@@ -69,9 +69,9 @@ std::pair<int, uint32_t> IProcessor::scheduleForEvent()
 }
 #endif
 
-Processors IProcessor::expandPipeline()
+IProcessor::PipelineUpdate IProcessor::updatePipeline()
 {
-    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method 'expandPipeline' is not implemented for {} processor", getName());
+    throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Method 'updatePipeline' is not implemented for {} processor", getName());
 }
 
 void IProcessor::cancel(IProcessor::CancelReason reason) noexcept
@@ -226,8 +226,8 @@ std::string IProcessor::statusToName(std::optional<Status> status)
             return "Ready";
         case Status::Async:
             return "Async";
-        case Status::ExpandPipeline:
-            return "ExpandPipeline";
+        case Status::UpdatePipeline:
+            return "UpdatePipeline";
     }
 }
 

--- a/src/Processors/IProcessor.h
+++ b/src/Processors/IProcessor.h
@@ -155,9 +155,9 @@ public:
         /// You need to poll this descriptor and call work() afterwards.
         Async,
 
-        /// Processor wants to add other processors to pipeline.
-        /// New processors must be obtained by expandPipeline() call.
-        ExpandPipeline,
+        /// Processor wants to add new processors and/or remove finished neighbours.
+        /// Update must be obtained by updatePipeline() call.
+        UpdatePipeline,
     };
 
     static std::string statusToName(std::optional<Status> status);
@@ -235,16 +235,21 @@ public:
      */
     virtual void onAsyncJobReady() {}
 
-    /** You must call this method if 'prepare' returned ExpandPipeline.
+    /** You must call this method if 'prepare' returned UpdatePipeline.
       * This method cannot access any port, but it can create new ports for current processor.
       *
-      * Method should return set of new already connected processors.
-      * All added processors must be connected only to each other or current processor.
+      * Method should return set of new already connected processors or disconnected finished processors.
+      * All returned processors must be connected only to each other or current processor.
       *
-      * Method can't remove or reconnect existing ports, move data from/to port or perform calculations.
-      * 'prepare' should be called again after expanding pipeline.
+      * Method can't move data from/to port or perform calculations.
+      * 'prepare' should be called again after this operation.
       */
-    virtual Processors expandPipeline();
+    struct PipelineUpdate
+    {
+        Processors to_add;
+        Processors to_remove;
+    };
+    virtual PipelineUpdate updatePipeline();
 
     /// Why the processor is being cancelled, chosen by the caller of cancel.
     enum class CancelReason : uint8_t

--- a/src/Processors/Port.cpp
+++ b/src/Processors/Port.cpp
@@ -27,4 +27,22 @@ void connect(OutputPort & output, InputPort & input, bool reconnect)
     output.state = input.state;
 }
 
+void disconnect(OutputPort & output, InputPort & input)
+{
+    if (output.input_port != &input || input.output_port != &output)
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Cannot disconnect ports that are not connected to each other");
+
+    /// Disconnect from pipeline edges
+    input.update_info = nullptr;
+    output.update_info = nullptr;
+
+    /// Disconnect from each other
+    input.output_port = nullptr;
+    output.input_port = nullptr;
+
+    /// Reset shared State on both sides
+    input.state.reset();
+    output.state.reset();
+}
+
 }

--- a/src/Processors/Port.h
+++ b/src/Processors/Port.h
@@ -26,6 +26,7 @@ extern const int LOGICAL_ERROR;
 class Port
 {
     friend void connect(OutputPort &, InputPort &, bool);
+    friend void disconnect(OutputPort &, InputPort &);
     friend class IProcessor;
 
 public:
@@ -275,6 +276,7 @@ protected:
 class InputPort : public Port
 {
     friend void connect(OutputPort &, InputPort &, bool);
+    friend void disconnect(OutputPort &, InputPort &);
 
 private:
     OutputPort * output_port = nullptr;
@@ -398,6 +400,7 @@ public:
 class OutputPort : public Port
 {
     friend void connect(OutputPort &, InputPort &, bool);
+    friend void disconnect(OutputPort &, InputPort &);
 
 private:
     InputPort * input_port = nullptr;
@@ -491,5 +494,6 @@ using OutputPorts = std::list<OutputPort>;
 
 
 void connect(OutputPort & output, InputPort & input, bool reconnect = false);
+void disconnect(OutputPort & output, InputPort & input);
 
 }

--- a/src/Processors/Sources/DelayedSource.cpp
+++ b/src/Processors/Sources/DelayedSource.cpp
@@ -52,7 +52,7 @@ IProcessor::Status DelayedSource::prepare()
         if (processors.empty())
             return Status::Ready;
 
-        return Status::ExpandPipeline;
+        return Status::UpdatePipeline;
     }
 
     /// Process ports in order: main, totals, extremes
@@ -149,7 +149,7 @@ void DelayedSource::work()
     synchronizePorts(extremes_output, extremes, header, processors);
 }
 
-Processors DelayedSource::expandPipeline()
+IProcessor::PipelineUpdate DelayedSource::updatePipeline()
 {
     /// Add new inputs. They must have the same header as output.
     for (const auto & output : {main_output, totals_output, extremes_output})
@@ -166,7 +166,7 @@ Processors DelayedSource::expandPipeline()
     }
 
     /// Executor will check that all processors are connected.
-    return std::move(processors);
+    return PipelineUpdate{.to_add = std::move(processors), .to_remove = {}};
 }
 
 Pipe createDelayedPipe(SharedHeader header, DelayedSource::Creator processors_creator, bool add_totals_port, bool add_extremes_port)

--- a/src/Processors/Sources/DelayedSource.h
+++ b/src/Processors/Sources/DelayedSource.h
@@ -25,7 +25,7 @@ public:
 
     Status prepare() override;
     void work() override;
-    Processors expandPipeline() override;
+    PipelineUpdate updatePipeline() override;
 
     OutputPort & getPort() { return *main; }
     OutputPort * getTotalsPort() { return totals; }

--- a/src/Processors/Sources/LazyReadFromMergeTreeSource.cpp
+++ b/src/Processors/Sources/LazyReadFromMergeTreeSource.cpp
@@ -146,7 +146,7 @@ IProcessor::Status LazyReadFromMergeTreeSource::prepare(const UpdatedInputPorts 
         return Status::PortFull;
 
     if (lazy_materializing_rows)
-        return Status::ExpandPipeline;
+        return Status::UpdatePipeline;
 
     /// Here we reading inputs as long as they are ready, to parallelize reading.
     /// But the chunks should be processed in the order of parts and ranges.
@@ -199,7 +199,7 @@ IProcessor::Status LazyReadFromMergeTreeSource::prepare(const UpdatedInputPorts 
     return Status::Finished;
 }
 
-Processors LazyReadFromMergeTreeSource::expandPipeline()
+IProcessor::PipelineUpdate LazyReadFromMergeTreeSource::updatePipeline()
 {
     if (!lazy_materializing_rows)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "LazyReadFromMergeTreeSource: No lazy materializing rows");
@@ -216,7 +216,7 @@ Processors LazyReadFromMergeTreeSource::expandPipeline()
 
     next_input_to_process = inputs.begin();
     chunks.resize(processors.size());
-    return processors;
+    return PipelineUpdate{.to_add = std::move(processors), .to_remove = {}};
 }
 
 Processors LazyReadFromMergeTreeSource::buildReaders()

--- a/src/Processors/Sources/LazyReadFromMergeTreeSource.h
+++ b/src/Processors/Sources/LazyReadFromMergeTreeSource.h
@@ -36,7 +36,7 @@ public:
 
     String getName() const override { return "LazyReadFromMergeTreeSource"; }
     Status prepare(const UpdatedInputPorts & updated_input_ports, const UpdatedOutputPorts & /*updated_output_ports*/) override;
-    Processors expandPipeline() override;
+    PipelineUpdate updatePipeline() override;
 
 private:
     size_t max_block_size;

--- a/src/Processors/Sources/LazyReadReplacingFinalSource.cpp
+++ b/src/Processors/Sources/LazyReadReplacingFinalSource.cpp
@@ -64,7 +64,7 @@ IProcessor::Status LazyReadReplacingFinalSource::prepare()
         if (processors.empty())
             return Status::Ready;
         else
-            return Status::ExpandPipeline;
+            return Status::UpdatePipeline;
     }
 
     /// Forward chunks
@@ -341,12 +341,12 @@ void LazyReadReplacingFinalSource::work()
     processors = Pipe::detachProcessors(std::move(pipe));
 }
 
-Processors LazyReadReplacingFinalSource::expandPipeline()
+IProcessor::PipelineUpdate LazyReadReplacingFinalSource::updatePipeline()
 {
     inputs.emplace_back(pipeline_output->getHeader(), this);
     connect(*pipeline_output, inputs.back());
     inputs.back().setNeeded();
-    return std::move(processors);
+    return PipelineUpdate{.to_add = std::move(processors), .to_remove = {}};
 }
 
 }

--- a/src/Processors/Sources/LazyReadReplacingFinalSource.h
+++ b/src/Processors/Sources/LazyReadReplacingFinalSource.h
@@ -27,7 +27,7 @@ public:
     String getName() const override { return "LazyReadReplacingFinalSource"; }
     Status prepare() override;
     void work() override;
-    Processors expandPipeline() override;
+    PipelineUpdate updatePipeline() override;
 
     /// Build the aggregation plan (sorting key expr + tiebreaker + argMax + rename + is_deleted filter)
     /// on top of a ReadFromMergeTree step. Used both for execution and EXPLAIN.

--- a/src/Processors/Sources/LazyUnorderedReadFromMergeTreeSource.cpp
+++ b/src/Processors/Sources/LazyUnorderedReadFromMergeTreeSource.cpp
@@ -56,7 +56,7 @@ IProcessor::Status LazyUnorderedReadFromMergeTreeSource::prepare()
         return Status::PortFull;
 
     if (lazy_materializing_rows)
-        return Status::ExpandPipeline;
+        return Status::UpdatePipeline;
 
     /// Pass through chunks from any ready input.
     bool all_finished = true;
@@ -83,7 +83,7 @@ IProcessor::Status LazyUnorderedReadFromMergeTreeSource::prepare()
     return Status::NeedData;
 }
 
-Processors LazyUnorderedReadFromMergeTreeSource::expandPipeline()
+IProcessor::PipelineUpdate LazyUnorderedReadFromMergeTreeSource::updatePipeline()
 {
     if (!lazy_materializing_rows)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "LazyUnorderedReadFromMergeTreeSource: No lazy materializing rows");
@@ -99,7 +99,7 @@ Processors LazyUnorderedReadFromMergeTreeSource::expandPipeline()
         inputs.back().setNeeded();
     }
 
-    return readers;
+    return PipelineUpdate{.to_add = std::move(readers), .to_remove = {}};
 }
 
 Processors LazyUnorderedReadFromMergeTreeSource::buildReaders()

--- a/src/Processors/Sources/LazyUnorderedReadFromMergeTreeSource.h
+++ b/src/Processors/Sources/LazyUnorderedReadFromMergeTreeSource.h
@@ -30,7 +30,7 @@ public:
 
     String getName() const override { return "LazyUnorderedReadFromMergeTreeSource"; }
     Status prepare() override;
-    Processors expandPipeline() override;
+    PipelineUpdate updatePipeline() override;
 
 private:
     size_t max_block_size;

--- a/src/Processors/Transforms/AggregatingTransform.cpp
+++ b/src/Processors/Transforms/AggregatingTransform.cpp
@@ -455,7 +455,7 @@ public:
         }
     }
 
-    Processors expandPipeline() override
+    PipelineUpdate updatePipeline() override
     {
         for (auto & source : processors)
         {
@@ -465,7 +465,7 @@ public:
             inputs.back().setNeeded();
         }
 
-        return std::move(processors);
+        return PipelineUpdate{.to_add = std::move(processors), .to_remove = {}};
     }
 
     IProcessor::Status prepare() override
@@ -496,7 +496,7 @@ public:
             return Status::Ready;
 
         if (!processors.empty())
-            return Status::ExpandPipeline;
+            return Status::UpdatePipeline;
 
         if (!single_level_chunks.empty())
             return preparePushToOutput();
@@ -874,7 +874,7 @@ IProcessor::Status AggregatingTransform::prepare()
     }
 
     if (is_generate_initialized.test() && !is_pipeline_created && !processors.empty())
-        return Status::ExpandPipeline;
+        return Status::UpdatePipeline;
 
     /// Only possible while consuming.
     if (read_current_chunk)
@@ -935,15 +935,15 @@ void AggregatingTransform::work()
     }
 }
 
-Processors AggregatingTransform::expandPipeline()
+IProcessor::PipelineUpdate AggregatingTransform::updatePipeline()
 {
     if (processors.empty())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Can not expandPipeline in AggregatingTransform. This is a bug.");
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Can not updatePipeline in AggregatingTransform. This is a bug.");
     auto & out = processors.back()->getOutputs().front();
     inputs.emplace_back(out.getHeader(), this);
     connect(out, inputs.back());
     is_pipeline_created = true;
-    return std::move(processors);
+    return PipelineUpdate{.to_add = std::move(processors), .to_remove = {}};
 }
 
 void AggregatingTransform::consume(Chunk chunk)
@@ -1073,7 +1073,7 @@ void AggregatingTransform::initGenerate()
                                 return std::make_shared<SimpleSquashingChunksTransform>(header, params->params.max_block_size, oneMB);
                             });
                     }
-                    /// AggregatingTransform::expandPipeline expects single output port.
+                    /// AggregatingTransform::updatePipeline expects single output port.
                     /// It's not a big problem because we do resize() to max_threads after AggregatingTransform.
                     pipe.resize(1);
                 }

--- a/src/Processors/Transforms/AggregatingTransform.h
+++ b/src/Processors/Transforms/AggregatingTransform.h
@@ -121,7 +121,7 @@ public:
     String getName() const override { return "AggregatingTransform"; }
     Status prepare() override;
     void work() override;
-    Processors expandPipeline() override;
+    PipelineUpdate updatePipeline() override;
     void setRowsBeforeAggregationCounter(RowsBeforeStepCounterPtr counter) override { rows_before_aggregation.swap(counter); }
 
 protected:

--- a/src/Processors/Transforms/MergeSortingTransform.cpp
+++ b/src/Processors/Transforms/MergeSortingTransform.cpp
@@ -147,7 +147,7 @@ MergeSortingTransform::MergeSortingTransform(
 {
 }
 
-Processors MergeSortingTransform::expandPipeline()
+IProcessor::PipelineUpdate MergeSortingTransform::updatePipeline()
 {
     if (processors.size() > 2)
     {
@@ -173,7 +173,7 @@ Processors MergeSortingTransform::expandPipeline()
         /// Generate
         static_cast<MergingSortedTransform &>(*external_merging_sorted).setHaveAllInputs();
 
-    return std::move(processors);
+    return PipelineUpdate{.to_add = std::move(processors), .to_remove = {}};
 }
 
 void MergeSortingTransform::consume(Chunk chunk)

--- a/src/Processors/Transforms/MergeSortingTransform.h
+++ b/src/Processors/Transforms/MergeSortingTransform.h
@@ -42,7 +42,7 @@ protected:
     void serialize() override;
     void generate() override;
 
-    Processors expandPipeline() override;
+    PipelineUpdate updatePipeline() override;
 
 private:
     size_t max_bytes_before_remerge;

--- a/src/Processors/Transforms/SortingTransform.cpp
+++ b/src/Processors/Transforms/SortingTransform.cpp
@@ -239,7 +239,7 @@ IProcessor::Status SortingTransform::prepare()
     if (stage == Stage::Serialize)
     {
         if (!processors.empty())
-            return Status::ExpandPipeline;
+            return Status::UpdatePipeline;
 
         auto status = prepareSerialize();
         if (status != Status::Finished)
@@ -263,7 +263,7 @@ IProcessor::Status SortingTransform::prepare()
         return Status::Ready;
 
     if (!processors.empty())
-        return Status::ExpandPipeline;
+        return Status::UpdatePipeline;
 
     return prepareGenerate();
 }

--- a/src/Processors/tests/gtest_update_pipeline.cpp
+++ b/src/Processors/tests/gtest_update_pipeline.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <Processors/Executors/PipelineExecutor.h>
+#include <Processors/Executors/PullingAsyncPipelineExecutor.h>
 #include <Processors/Executors/PullingPipelineExecutor.h>
 #include <Processors/IProcessor.h>
 #include <Processors/ISource.h>
@@ -206,4 +207,67 @@ TEST(Processors, UpdatePipeline)
     /// Input slot was reused, not grown.
     EXPECT_EQ(coordinator->getInputs().size(), 1u);
     EXPECT_EQ(coordinator->getOutputs().size(), 1u);
+}
+
+TEST(Processors, UpdatePipelineMultipleCoordinatorsMultithreaded)
+{
+    constexpr size_t num_streams = 16;
+    constexpr size_t total_pulls = 1000;
+    auto header = makeHeader();
+
+    Pipes pipes;
+    std::vector<std::shared_ptr<DynamicSourceCoordinator>> coordinators;
+    coordinators.reserve(num_streams);
+    for (size_t i = 0; i < num_streams; ++i)
+    {
+        auto coordinator = std::make_shared<DynamicSourceCoordinator>(header);
+        coordinators.push_back(coordinator);
+        pipes.emplace_back(std::move(coordinator));
+    }
+
+    auto united = Pipe::unitePipes(std::move(pipes));
+    united.resize(1, /*strict=*/false, /*min_outstreams_per_resize_after_split=*/0);
+
+    QueryPipeline pipeline(std::move(united));
+    pipeline.setNumThreads(num_streams);
+
+    size_t pulled = 0;
+    {
+        PullingAsyncPipelineExecutor executor(pipeline);
+
+        Chunk chunk;
+        while (pulled < total_pulls && executor.pull(chunk))
+        {
+            if (!chunk)
+                continue;
+            ASSERT_EQ(chunk.getNumRows(), 1u);
+            ASSERT_EQ(chunk.getNumColumns(), 1u);
+            ++pulled;
+        }
+
+        executor.cancel();
+    }
+
+    EXPECT_EQ(pulled, total_pulls);
+
+    /// Every pulled chunk came from exactly one cycle of some coordinator.
+    size_t produced = 0;
+    for (const auto & coordinator : coordinators)
+    {
+        produced += coordinator->totalSourcesCreated();
+        EXPECT_EQ(coordinator->getInputs().size(), 1u);
+        EXPECT_EQ(coordinator->getOutputs().size(), 1u);
+
+        /// At most one source (the currently-live one) is still alive per coordinator.
+        size_t alive = 0;
+        for (size_t i = 0; i < coordinator->totalSourcesCreated(); ++i)
+            if (!coordinator->getSourceWeak(i).expired())
+                ++alive;
+        EXPECT_LE(alive, 1u);
+    }
+    EXPECT_GE(produced, total_pulls);
+
+    /// Print statistics
+    for (size_t i = 0; i < coordinators.size(); ++i)
+        std::cout << "Coordinator #" << i << " Created Sources: " << coordinators.at(i)->totalSourcesCreated() << std::endl;
 }

--- a/src/Processors/tests/gtest_update_pipeline.cpp
+++ b/src/Processors/tests/gtest_update_pipeline.cpp
@@ -1,0 +1,209 @@
+#include <gtest/gtest.h>
+
+#include <Processors/Executors/PipelineExecutor.h>
+#include <Processors/Executors/PullingPipelineExecutor.h>
+#include <Processors/IProcessor.h>
+#include <Processors/ISource.h>
+#include <Processors/Port.h>
+#include <QueryPipeline/Pipe.h>
+#include <QueryPipeline/QueryPipeline.h>
+#include <Columns/ColumnsNumber.h>
+#include <Common/assert_cast.h>
+#include <DataTypes/DataTypesNumber.h>
+
+using namespace DB;
+
+namespace
+{
+
+SharedHeader makeHeader()
+{
+    return std::make_shared<Block>(Block{ColumnWithTypeAndName(ColumnUInt8::create(), std::make_shared<DataTypeUInt8>(), "x")});
+}
+
+/// Emits one UInt8 row, then finishes.
+class SingleValueSource final : public ISource
+{
+public:
+    SingleValueSource(SharedHeader header_, UInt8 value)
+        : ISource(std::move(header_), /*enable_auto_progress=*/false)
+    {
+        auto col = ColumnUInt8::create();
+        col->insertValue(value);
+        Columns columns;
+        columns.emplace_back(std::move(col));
+        chunk.emplace(std::move(columns), 1);
+    }
+
+    String getName() const override { return "SingleValueSource"; }
+
+protected:
+    std::optional<Chunk> tryGenerate() override
+    {
+        return std::exchange(chunk, std::nullopt);
+    }
+
+private:
+    std::optional<Chunk> chunk;
+};
+
+/// On each cycle: remove finished upstream, add a fresh one. Never finishes.
+class DynamicSourceCoordinator final : public IProcessor
+{
+public:
+    explicit DynamicSourceCoordinator(SharedHeader header_)
+        : IProcessor({}, {Block(*header_)})
+        , header(std::move(header_))
+    {
+    }
+
+    String getName() const override { return "DynamicSourceCoordinator"; }
+
+    Status prepare() override
+    {
+        auto & output = outputs.front();
+
+        if (!current_source)
+            return Status::UpdatePipeline;
+
+        auto & input = inputs.back();
+        if (input.isFinished())
+            return Status::UpdatePipeline;
+
+        if (!output.canPush())
+            return Status::PortFull;
+
+        if (!input.hasData())
+        {
+            input.setNeeded();
+            return Status::NeedData;
+        }
+
+        output.push(input.pull(/*set_not_needed=*/true));
+        return Status::PortFull;
+    }
+
+    PipelineUpdate updatePipeline() override
+    {
+        PipelineUpdate update;
+
+        if (current_source)
+        {
+            EXPECT_TRUE(inputs.back().isConnected());
+            EXPECT_TRUE(inputs.back().isFinished());
+
+            disconnect(current_source->getOutputs().front(), inputs.back());
+
+            EXPECT_FALSE(inputs.back().isConnected());
+
+            update.to_remove.push_back(current_source);
+            current_source.reset();
+        }
+        else
+        {
+            /// Single input slot, reused across every cycle.
+            inputs.emplace_back(*header, this);
+        }
+
+        auto new_source = std::make_shared<SingleValueSource>(header, static_cast<UInt8>(source_history.size()));
+        source_history.emplace_back(new_source);
+
+        connect(new_source->getOutputs().front(), inputs.back());
+        inputs.back().reopen();
+        inputs.back().setNeeded();
+
+        EXPECT_TRUE(inputs.back().isConnected());
+        EXPECT_FALSE(inputs.back().isFinished());
+
+        current_source = new_source;
+        update.to_add.push_back(std::move(new_source));
+
+        return update;
+    }
+
+    size_t totalSourcesCreated() const { return source_history.size(); }
+    std::weak_ptr<IProcessor> getSourceWeak(size_t idx) const { return source_history.at(idx); }
+
+private:
+    const SharedHeader header;
+    ProcessorPtr current_source;
+    std::vector<std::weak_ptr<IProcessor>> source_history;
+};
+
+}
+
+TEST(Processors, PortDisconnect)
+{
+    auto header = makeHeader();
+
+    OutputPort out(header);
+    InputPort in(header);
+
+    connect(out, in);
+    ASSERT_TRUE(out.isConnected());
+    ASSERT_TRUE(in.isConnected());
+
+    disconnect(out, in);
+    EXPECT_FALSE(out.isConnected());
+    EXPECT_FALSE(in.isConnected());
+    EXPECT_FALSE(out.hasUpdateInfo());
+    EXPECT_FALSE(in.hasUpdateInfo());
+}
+
+TEST(Processors, PortDisconnectThrowsIfMismatch)
+{
+    auto header = makeHeader();
+    OutputPort out_a(header);
+    InputPort  in_a(header);
+    OutputPort out_b(header);
+    InputPort  in_b(header);
+
+    connect(out_a, in_a);
+    connect(out_b, in_b);
+
+#ifndef DEBUG_OR_SANITIZER_BUILD
+    EXPECT_THROW(disconnect(out_a, in_b), Exception);
+    EXPECT_THROW(disconnect(out_b, in_a), Exception);
+#endif
+}
+
+TEST(Processors, UpdatePipeline)
+{
+    auto header = makeHeader();
+    constexpr size_t pulls = 3;
+
+    auto coordinator = std::make_shared<DynamicSourceCoordinator>(header);
+    Pipe pipe(coordinator);
+
+    QueryPipeline pipeline(std::move(pipe));
+    {
+        PullingPipelineExecutor executor(pipeline);
+
+        std::vector<UInt8> values;
+        Chunk chunk;
+        for (size_t i = 0; i < pulls; ++i)
+        {
+            ASSERT_TRUE(executor.pull(chunk)) << "executor yielded no chunk at iteration " << i;
+            ASSERT_EQ(chunk.getNumRows(), 1u);
+            ASSERT_EQ(chunk.getNumColumns(), 1u);
+            const auto & col = assert_cast<const ColumnUInt8 &>(*chunk.getColumns().front());
+            values.push_back(col.getElement(0));
+        }
+
+        EXPECT_EQ(values, (std::vector<UInt8>{0, 1, 2}));
+    }
+
+    /// One upstream per pull, no extras.
+    EXPECT_EQ(coordinator->totalSourcesCreated(), pulls);
+
+    /// All but the last upstream have been removed and destroyed.
+    for (size_t i = 0; i + 1 < pulls; ++i)
+        EXPECT_TRUE(coordinator->getSourceWeak(i).expired()) << "source #" << i;
+
+    /// Last source is still in use.
+    EXPECT_FALSE(coordinator->getSourceWeak(pulls - 1).expired()) << "last source";
+
+    /// Input slot was reused, not grown.
+    EXPECT_EQ(coordinator->getInputs().size(), 1u);
+    EXPECT_EQ(coordinator->getOutputs().size(), 1u);
+}


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

This patch adds the ability for the pipeline to remove processors at runtime. Only Finished processors can be removed from the pipeline, and they must be connected to the initiator graph node directly or indirectly (the same logic that was for expandPipeline).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.12`
<!-- ch-version-info:end -->