### PR TITLE
tests: restore retry loop in test_trace_log_memory_context

### DIFF
--- a/tests/integration/test_trace_log_memory_context/test.py
+++ b/tests/integration/test_trace_log_memory_context/test.py
@@ -1,4 +1,5 @@
 import uuid
+import time
 import logging
 import pytest
 
@@ -46,13 +47,37 @@ def test_memory_context_in_trace_log(started_cluster):
                      memory_context, memory_blocked_context, trace_type, query_id, res)
         return res
 
-    # Generate some logs to generate entries with memory_blocked_context=Global and trace_type=JemallocSample
-    for i in range(10):
-        node.query("SELECT logTrace('foo')")
-    query_id = uuid.uuid4().hex
-    node.query("SELECT * FROM numbers(100000) ORDER BY number", query_id=query_id)
+    # Each iteration issues allocations and polls `system.trace_log` for the
+    # expected trace-types/contexts. The retries are required because several
+    # of the events we wait for are genuinely probabilistic:
+    #   * `JemallocSample` is emitted by `jemalloc`'s own profile sampler
+    #     (~1 MiB of allocated memory per sample with `lg_prof_sample=20`),
+    #     and a single small query is not guaranteed to allocate enough.
+    #   * `Memory`/`MemoryPeak` with `memory_context = 'Global'` require the
+    #     `total_memory_tracker` to cross its `total_memory_profiler_step`
+    #     watermark (4 MiB by default), which depends on cumulative
+    #     server-wide allocations including background activity, not just
+    #     this query's allocations.
+    # Retrying bounds the test runtime while keeping it reliable.
+    for _ in range(0, 15):
+        # Generate some logs to generate entries with memory_blocked_context=Global and trace_type=JemallocSample
+        for i in range(10):
+            node.query("SELECT logTrace('foo')")
+        query_id = uuid.uuid4().hex
+        node.query("SELECT * FROM numbers(100000) ORDER BY number", query_id=query_id)
 
-    node.query("SYSTEM FLUSH LOGS system.trace_log")
+        node.query("SYSTEM FLUSH LOGS system.trace_log")
+        if (
+            get_trace_events("Unknown", "Max", "MemorySample", query_id) > 0 and
+            get_trace_events("Unknown", "Max", "JemallocSample", query_id) > 0 and
+            get_trace_events("Unknown", "Max", "JemallocSample") > 0 and
+            get_trace_events("Unknown", "Global", "JemallocSample") > 0 and
+            get_trace_events("Global", "Max", "Memory") > 0 and
+            get_trace_events("Global", "Max", "MemoryPeak") > 0 and
+            True
+        ):
+            break
+        time.sleep(1)
 
     # For JemallocSample we have Global (for i.e. logging) and Max (for regular allocations) blocked memory tracker
     for memory_blocked_context in ["Global", "Max"]:


### PR DESCRIPTION
### Motivation

PR #101267 (merged 2026-04-21 20:52 UTC) included a side commit that dropped
the 15-iteration retry loop in `test_trace_log_memory_context`, claiming
that the new cache-based sampling makes a single pass sufficient. Shortly
after the merge the test began failing on master and on unrelated in-flight
PRs at different assertion lines:

- master commit `fa205863` (2026-04-21 21:27 UTC) — fails at
  `get_trace_events('Unknown', 'Global', 'JemallocSample') > 0`
  ([CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=fa205863ba68f05b529e2073defb5cf5df7cc832&name_0=MasterCI&name_1=Integration%20tests%20%28amd_binary_excluded_from_llvm%29))
- PR #103307, #98727, #101434 (2026-04-21 22:06–22:13 UTC) — all fail at
  `get_trace_events('Global', 'Max', 'Memory'/'MemoryPeak') > 0`
- PR #101267 itself before merge (2026-04-19 and 2026-04-20) — fails at
  `get_trace_events('Unknown', 'Max', 'MemorySample', query_id) > 0`

Even with fully-propagated `sample_probability`, two of the trace types
the test waits for are genuinely probabilistic relative to this workload:

- `JemallocSample` is emitted by `jemalloc`'s own profile sampler
  (`lg_prof_sample=20` ≈ one sample per 1 MiB of allocated memory). Ten
  `logTrace('foo')` calls plus a single `SELECT * FROM numbers(100000)
  ORDER BY number` are not guaranteed to allocate enough `jemalloc`-tracked
  memory to trigger a sample inside a `MemoryTrackerBlockerInThread(Global)`
  scope.
- `Memory`/`MemoryPeak` with `memory_context = 'Global'` are only emitted
  when `total_memory_tracker` crosses its `total_memory_profiler_step`
  watermark (4 MiB by default). Whether this happens during a given test
  query depends on cumulative server-wide allocations including background
  activity, not just the query's own allocations.

The retry loop bounds the test runtime at ~15 s while letting these
events accumulate reliably. Restore it, and add a comment explaining why
it is required so it is not dropped again. Only the test is touched;
the `MemoryTracker`/`ThreadStatus` caching changes from #101267 are kept.

### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.32`
- Backported to: `26.4.1.1116`
<!-- ch-version-info:end -->