### PR TITLE
Report thread-count metrics for <protocols> endpoints

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -1458,10 +1458,10 @@ try
         metrics.reserve(servers_to_start_before_tables.size() + servers.size());
 
         for (const auto & server : servers_to_start_before_tables)
-            metrics.emplace_back(ProtocolServerMetrics{server.getPortName(), server.currentThreads(), server.refusedConnections()});
+            metrics.emplace_back(ProtocolServerMetrics{server.getPortName(), server.currentThreads(), server.refusedConnections(), server.getServerType()});
 
         for (const auto & server : servers)
-            metrics.emplace_back(ProtocolServerMetrics{server.getPortName(), server.currentThreads(), server.refusedConnections()});
+            metrics.emplace_back(ProtocolServerMetrics{server.getPortName(), server.currentThreads(), server.refusedConnections(), server.getServerType()});
         return metrics;
     };
     const unsigned async_metrics_update_period_s = server_settings[ServerSetting::asynchronous_metrics_update_period_s];
@@ -3225,7 +3225,8 @@ std::unique_ptr<TCPProtocolStackFactory> Server::buildProtocolStackFromConfig(
     const std::string & protocol,
     Poco::Net::HTTPServerParams::Ptr http_params,
     AsynchronousMetrics & async_metrics,
-    bool & is_secure)
+    bool & is_secure,
+    ServerType::Type & base_type)
 {
     auto create_factory = [&](const std::string & type, const std::string & conf_name) -> TCPServerConnectionFactory::Ptr
     {
@@ -3293,6 +3294,20 @@ std::unique_ptr<TCPProtocolStackFactory> Server::buildProtocolStackFromConfig(
                     throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER, "Protocol '{}' contains more than one TLS layer", protocol);
                 is_secure = true;
             }
+            else if (type == "tcp")
+                base_type = ServerType::Type::TCP;
+            else if (type == "proxy1")
+                base_type = ServerType::Type::TCP_WITH_PROXY;
+            else if (type == "http")
+                base_type = ServerType::Type::HTTP;
+            else if (type == "mysql")
+                base_type = ServerType::Type::MYSQL;
+            else if (type == "postgres")
+                base_type = ServerType::Type::POSTGRESQL;
+            else if (type == "prometheus")
+                base_type = ServerType::Type::PROMETHEUS;
+            else if (type == "interserver")
+                base_type = ServerType::Type::INTERSERVER_HTTP;
 
             stack->append(create_factory(type, conf_name));
         }
@@ -3305,6 +3320,17 @@ std::unique_ptr<TCPProtocolStackFactory> Server::buildProtocolStackFromConfig(
 
         if (!pset.insert(conf_name).second)
             throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER, "Protocol '{}' configuration contains a loop on '{}'", protocol, conf_name);
+    }
+
+    /// Promote to the secure variant if a TLS layer was seen anywhere in the chain.
+    if (is_secure)
+    {
+        if (base_type == ServerType::Type::TCP || base_type == ServerType::Type::TCP_WITH_PROXY)
+            base_type = ServerType::Type::TCP_SECURE;
+        else if (base_type == ServerType::Type::HTTP)
+            base_type = ServerType::Type::HTTPS;
+        else if (base_type == ServerType::Type::INTERSERVER_HTTP)
+            base_type = ServerType::Type::INTERSERVER_HTTPS;
     }
 
     return stack;
@@ -3368,7 +3394,8 @@ void Server::createServers(
         for (const auto & host : hosts)
         {
             bool is_secure = false;
-            auto stack = buildProtocolStackFromConfig(config, server_settings, protocol, http_params, async_metrics, is_secure);
+            ServerType::Type base_type = ServerType::Type::END;
+            auto stack = buildProtocolStackFromConfig(config, server_settings, protocol, http_params, async_metrics, is_secure, base_type);
 
             if (stack->empty())
                 throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER, "Protocol '{}' stack empty", protocol);
@@ -3380,7 +3407,7 @@ void Server::createServers(
                 socket.setReceiveTimeout(settings[Setting::receive_timeout]);
                 socket.setSendTimeout(settings[Setting::send_timeout]);
 
-                return ProtocolServerAdapter(
+                ProtocolServerAdapter adapter(
                     host,
                     port_name.c_str(),
                     description + ": " + address.toString(),
@@ -3390,6 +3417,8 @@ void Server::createServers(
                         socket,
                         makeServerParams(server_settings),
                         connection_filter));
+                adapter.setServerType(base_type);
+                return adapter;
             });
         }
     }

--- a/programs/server/Server.h
+++ b/programs/server/Server.h
@@ -91,7 +91,8 @@ private:
         const std::string & protocol,
         Poco::Net::HTTPServerParams::Ptr http_params,
         AsynchronousMetrics & async_metrics,
-        bool & is_secure);
+        bool & is_secure,
+        ServerType::Type & base_type);
 
     using CreateServerFunc = std::function<ProtocolServerAdapter(UInt16)>;
     void createServer(

--- a/src/Common/AsynchronousMetrics.cpp
+++ b/src/Common/AsynchronousMetrics.cpp
@@ -2406,14 +2406,83 @@ void AsynchronousMetrics::update(TimePoint update_time, bool force_update)
             return it->second;
         };
 
+        /// Endpoints defined under <protocols> use port names like "protocols.<name>.port" that
+        /// don't match the fixed table above. Route them via the explicit ServerType::Type set on
+        /// the adapter so the same TCPThreads/HTTPThreads/... metrics are still produced.
+        auto threads_get_metric_name_doc_for_type = [](ServerType::Type type) -> std::pair<const char *, const char *>
+        {
+            switch (type)
+            {
+                case ServerType::Type::TCP:
+                case ServerType::Type::TCP_WITH_PROXY:
+                    return {"TCPThreads", "Number of threads in the server of the TCP protocol (without TLS)."};
+                case ServerType::Type::TCP_SECURE:
+                    return {"TCPSecureThreads", "Number of threads in the server of the TCP protocol (with TLS)."};
+                case ServerType::Type::HTTP:
+                    return {"HTTPThreads", "Number of threads in the server of the HTTP interface (without TLS)."};
+                case ServerType::Type::HTTPS:
+                    return {"HTTPSecureThreads", "Number of threads in the server of the HTTPS interface."};
+                case ServerType::Type::MYSQL:
+                    return {"MySQLThreads", "Number of threads in the server of the MySQL compatibility protocol."};
+                case ServerType::Type::POSTGRESQL:
+                    return {"PostgreSQLThreads", "Number of threads in the server of the PostgreSQL compatibility protocol."};
+                case ServerType::Type::GRPC:
+                    return {"GRPCThreads", "Number of threads in the server of the GRPC protocol."};
+                case ServerType::Type::PROMETHEUS:
+                    return {"PrometheusThreads", "Number of threads in the server of the Prometheus endpoint. Note: prometheus endpoints can be also used via the usual HTTP/HTTPs ports."};
+                case ServerType::Type::INTERSERVER_HTTP:
+                    return {"InterserverThreads", "Number of threads in the server of the replicas communication protocol (without TLS)."};
+                case ServerType::Type::INTERSERVER_HTTPS:
+                    return {"InterserverSecureThreads", "Number of threads in the server of the replicas communication protocol (with TLS)."};
+                default:
+                    return {nullptr, nullptr};
+            }
+        };
+
+        auto rejected_get_metric_name_doc_for_type = [](ServerType::Type type) -> std::pair<const char *, const char *>
+        {
+            switch (type)
+            {
+                case ServerType::Type::TCP:
+                case ServerType::Type::TCP_WITH_PROXY:
+                    return {"TCPRejectedConnections", "Number of rejected connections for the TCP protocol (without TLS)."};
+                case ServerType::Type::TCP_SECURE:
+                    return {"TCPSecureRejectedConnections", "Number of rejected connections for the TCP protocol (with TLS)."};
+                case ServerType::Type::HTTP:
+                    return {"HTTPRejectedConnections", "Number of rejected connections for the HTTP interface (without TLS)."};
+                case ServerType::Type::HTTPS:
+                    return {"HTTPSecureRejectedConnections", "Number of rejected connections for the HTTPS interface."};
+                case ServerType::Type::MYSQL:
+                    return {"MySQLRejectedConnections", "Number of rejected connections for the MySQL compatibility protocol."};
+                case ServerType::Type::POSTGRESQL:
+                    return {"PostgreSQLRejectedConnections", "Number of rejected connections for the PostgreSQL compatibility protocol."};
+                case ServerType::Type::GRPC:
+                    return {"GRPCRejectedConnections", "Number of rejected connections for the GRPC protocol."};
+                case ServerType::Type::PROMETHEUS:
+                    return {"PrometheusRejectedConnections", "Number of rejected connections for the Prometheus endpoint. Note: prometheus endpoints can be also used via the usual HTTP/HTTPs ports."};
+                case ServerType::Type::INTERSERVER_HTTP:
+                    return {"InterserverRejectedConnections", "Number of rejected connections for the replicas communication protocol (without TLS)."};
+                case ServerType::Type::INTERSERVER_HTTPS:
+                    return {"InterserverSecureRejectedConnections", "Number of rejected connections for the replicas communication protocol (with TLS)."};
+                default:
+                    return {nullptr, nullptr};
+            }
+        };
+
         const auto server_metrics = protocol_server_metrics_func();
         for (const auto & server_metric : server_metrics)
         {
-            if (auto name_doc = threads_get_metric_name_doc(server_metric.port_name); name_doc.first != nullptr)
-                new_values[name_doc.first] = { server_metric.current_threads, name_doc.second };
+            auto threads_name_doc = threads_get_metric_name_doc(server_metric.port_name);
+            if (threads_name_doc.first == nullptr)
+                threads_name_doc = threads_get_metric_name_doc_for_type(server_metric.server_type);
+            if (threads_name_doc.first != nullptr)
+                new_values[threads_name_doc.first] = { server_metric.current_threads, threads_name_doc.second };
 
-            if (auto name_doc = rejected_connections_get_metric_name_doc(server_metric.port_name); name_doc.first != nullptr)
-                new_values[name_doc.first] = { server_metric.rejected_connections, name_doc.second };
+            auto rejected_name_doc = rejected_connections_get_metric_name_doc(server_metric.port_name);
+            if (rejected_name_doc.first == nullptr)
+                rejected_name_doc = rejected_get_metric_name_doc_for_type(server_metric.server_type);
+            if (rejected_name_doc.first != nullptr)
+                new_values[rejected_name_doc.first] = { server_metric.rejected_connections, rejected_name_doc.second };
         }
     }
 

--- a/src/Common/AsynchronousMetrics.h
+++ b/src/Common/AsynchronousMetrics.h
@@ -7,6 +7,7 @@
 #include <Common/Stopwatch.h>
 #include <Common/SharedMutex.h>
 #include <IO/ReadBufferFromFile.h>
+#include <Server/ServerType.h>
 
 #include <condition_variable>
 #include <string>
@@ -43,6 +44,7 @@ struct ProtocolServerMetrics
     String port_name;
     size_t current_threads;
     size_t rejected_connections;
+    ServerType::Type server_type = ServerType::Type::END;
 };
 
 /** Periodically (by default, each second)

--- a/src/Server/ProtocolServerAdapter.h
+++ b/src/Server/ProtocolServerAdapter.h
@@ -3,6 +3,7 @@
 #include "config.h"
 
 #include <base/types.h>
+#include <Server/ServerType.h>
 #include <memory>
 #include <string>
 
@@ -64,6 +65,11 @@ public:
 
     const std::string & getDescription() const { return description; }
 
+    /// Server type is currently set only for endpoints defined under <protocols>, whose port names
+    /// don't match the fixed tcp_port/http_port/... strings used for thread-count metrics.
+    ServerType::Type getServerType() const { return server_type; }
+    void setServerType(ServerType::Type type) { server_type = type; }
+
 private:
     class Impl
     {
@@ -85,6 +91,7 @@ private:
     std::string description;
     std::unique_ptr<Impl> impl;
     bool supports_runtime_reconfiguration = true;
+    ServerType::Type server_type = ServerType::Type::END;
 };
 
 }

--- a/tests/integration/test_composable_protocols/test.py
+++ b/tests/integration/test_composable_protocols/test.py
@@ -209,3 +209,32 @@ def test_http_proxy_1():
     port = proxy.start((server.ip_address, 8223))
 
     assert execute_query_http("localhost", port, "SELECT 1") == "1\n"
+
+
+# regression for https://github.com/ClickHouse/ClickHouse/issues/80759 --
+# TCPThreads / HTTPThreads / ...Threads metrics must be produced even when the
+# servers are defined under <protocols> (port_name "protocols.<name>.port" does
+# not match the fixed tcp_port/http_port/... strings in AsynchronousMetrics).
+def test_protocols_threads_metrics():
+    import time
+
+    tcp_client = Client(server.ip_address, 9000, command=cluster.client_bin_path)
+    assert tcp_client.query("SELECT 1") == "1\n"
+    assert execute_query_http(server.ip_address, 8123, "SELECT 1") == "1\n"
+
+    expected = {"TCPThreads", "TCPSecureThreads", "HTTPThreads", "HTTPSecureThreads"}
+
+    probe = Client(server.ip_address, 9000, command=cluster.client_bin_path)
+    present = set()
+    for _ in range(15):
+        rows = probe.query(
+            "SELECT metric FROM system.asynchronous_metrics "
+            "WHERE metric IN ('TCPThreads','TCPSecureThreads','HTTPThreads','HTTPSecureThreads') "
+            "FORMAT TSV"
+        ).strip()
+        present = set(rows.split("\n")) if rows else set()
+        if expected.issubset(present):
+            break
+        time.sleep(1)
+
+    assert expected.issubset(present), f"missing async metrics: {expected - present}"


### PR DESCRIPTION
`AsynchronousMetrics` mapped protocol servers to `TCPThreads`/`HTTPThreads`/... by matching `port_name` against a hard-coded set (`"tcp_port"`, `"http_port"`, ...), which never matches endpoints defined under `<protocols>` (their `port_name` is `"protocols.<name>.port"`). Those servers produced no thread-count or rejected-connection metrics at all.

- Track the effective base protocol type while walking the `impl` chain in `buildProtocolStackFromConfig`, and promote it to the secure variant when a `tls` layer is seen.
- Carry the type on `ProtocolServerAdapter` and `ProtocolServerMetrics`.
- In `AsynchronousMetrics`, fall back to a `ServerType::Type`-keyed lookup when the `port_name` doesn't match the existing string table. Default-port servers still use the string path and are unchanged.

Revives the design from the abandoned #87152.

Closes #80759

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`TCPThreads`, `HTTPThreads`, `MySQLThreads` and the related `*RejectedConnections` asynchronous metrics are now reported for protocol servers defined under the `<protocols>` configuration section.

### Documentation entry for user-facing changes

- [x] Documentation is not required (bug fix)