### PR TITLE
Fix test_backup_all[True] for histogram_metric_log

### DIFF
--- a/tests/integration/test_backup_restore_new/test.py
+++ b/tests/integration/test_backup_restore_new/test.py
@@ -1730,6 +1730,7 @@ def test_backup_all(exclude_system_log_tables):
             "crash_log",
             "text_log",
             "metric_log",
+            "histogram_metric_log",
             "filesystem_cache_log",
             "filesystem_read_prefetches_log",
             "asynchronous_metric_log",


### PR DESCRIPTION
### Summary

`test_backup_all[True]` has a hardcoded list of system log tables to exclude from `BACKUP ALL`. PR #103046 ("Histogram metric log") added a new periodic system log `system.histogram_metric_log`, but did not add it to the test's exclusion list.

Because `HistogramMetricLog` is a `PeriodicLog` (same as `MetricLog`), a background thread writes data into `system.histogram_metric_log` continuously from server start. During `test_backup_all[True]`:

1. `BACKUP ALL EXCEPT TABLES <log_tables>` — `histogram_metric_log` is NOT in the exclude list, so it gets backed up with some data.
2. `RESTORE ALL FROM backup` — `allow_non_empty_tables=true` is NOT set, and the live table has accumulated MORE data since the backup.
3. `RESTORE` fails with `Code: 608. Cannot restore the table system.histogram_metric_log because it already contains some data.`

This is the same pattern that existing periodic logs (`metric_log`, `asynchronous_metric_log`, `error_log`, `aggregated_zookeeper_log`, `background_schedule_pool_log`) already follow — they are all in the exclusion list.

### Master regression evidence

Master has been failing on all 4 Integration test variants since PR #103046 merged on 2026-04-21 at 18:28 UTC:
- `Integration tests (amd_asan_ubsan, db disk, old analyzer, 4/6)`
- `Integration tests (amd_msan, 4/6)`
- `Integration tests (amd_tsan, 4/6)`
- `Integration tests (arm_binary, distributed plan, 4/4)`

16+ consecutive failures observed across at least 5 master commits in the first 3 hours post-merge (sha `a7b13e00eb10`, `ec4045214c78`, `fa205863ba68`, `02fe04d51079`).

CI report for latest master (`02fe04d51079`):
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=02fe04d51079&name_0=MasterCI&name_1=Integration%20tests%20%28amd_tsan%2C%204%2F6%29

### Reproduction and validation

- **Without fix:** `test_backup_all[True]` fails deterministically with error `608` (confirmed on 16+ runs across 4 check variants, 4+ master commits).
- **With fix:** `system.histogram_metric_log` is excluded from `BACKUP ALL`, so the non-empty destination never triggers the restore check — matching the pre-existing behaviour for all other periodic system logs.

The fix is a test-only, single-line addition — mirrors the existing handling of `metric_log`, `asynchronous_metric_log`, and other periodic logs that are already excluded.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.6`
- Backported to: `26.4.1.1114`
<!-- ch-version-info:end -->