### PR TITLE
CI: do not swallow ServerDied exception in clickhouse-test

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -6206,6 +6206,10 @@ if __name__ == "__main__":
 
     try:
         main(args)
+    except ServerDied as e:
+        print(f"{e}", file=sys.stderr)
+        traceback.print_exc()
+        sys.exit(1)
     except Terminated as e:
         print(f"Terminated with {e.signal} signal", file=sys.stderr)
         sys.exit(128 + e.signal)

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -6206,9 +6206,6 @@ if __name__ == "__main__":
 
     try:
         main(args)
-    except ServerDied as e:
-        print(f"{e}", file=sys.stderr)
-        sys.exit(1)
     except Terminated as e:
         print(f"Terminated with {e.signal} signal", file=sys.stderr)
         sys.exit(128 + e.signal)


### PR DESCRIPTION
Remove the `except ServerDied` handler at the end of `tests/clickhouse-test` so that an unhandled `ServerDied` exception produces a Python stack trace instead of only printing the exception message. This makes it easier to diagnose where the server death was detected.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.52`
<!-- ch-version-info:end -->