### PR TITLE
Fix Parquet ColumnIndex stats min_value > max_value for String columns

### DIFF
--- a/src/Processors/Formats/Impl/Parquet/Write.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Write.cpp
@@ -223,14 +223,12 @@ struct StatisticsStringRef
         parq::Statistics s;
         if (min.ptr == nullptr)
             return s;
-        if (static_cast<size_t>(min.len) <= options.max_statistics_size)
+        if (static_cast<size_t>(min.len) <= options.max_statistics_size
+            && static_cast<size_t>(max.len) <= options.max_statistics_size)
         {
             s.__set_min_value(std::string(reinterpret_cast<const char *>(min.ptr), static_cast<size_t>(min.len)));
-            s.__set_is_min_value_exact(true);
-        }
-        if (static_cast<size_t>(max.len) <= options.max_statistics_size)
-        {
             s.__set_max_value(std::string(reinterpret_cast<const char *>(max.ptr), static_cast<size_t>(max.len)));
+            s.__set_is_min_value_exact(true);
             s.__set_is_max_value_exact(true);
         }
         return s;
@@ -286,14 +284,12 @@ struct StatisticsStringCopy
         parq::Statistics s;
         if (empty)
             return s;
-        if (min.size() <= options.max_statistics_size)
+        if (min.size() <= options.max_statistics_size
+            && max.size() <= options.max_statistics_size)
         {
             s.__set_min_value(std::string(min.data(), min.size()));
-            s.__set_is_min_value_exact(true);
-        }
-        if (max.size() <= options.max_statistics_size)
-        {
             s.__set_max_value(std::string(max.data(), max.size()));
+            s.__set_is_min_value_exact(true);
             s.__set_is_max_value_exact(true);
         }
         return s;
@@ -949,6 +945,10 @@ void writeColumnImpl(
         if (options.write_page_index)
         {
             bool all_null_page = data_count == 0;
+            bool has_stats = page_stats.__isset.min_value && page_stats.__isset.max_value;
+            if (!all_null_page && !has_stats)
+                s.indexes.column_index_valid = false;
+
             s.indexes.column_index.min_values.push_back(page_stats.min_value);
             s.indexes.column_index.max_values.push_back(page_stats.max_value);
             if (has_null_count)
@@ -1404,6 +1404,9 @@ static void writePageIndex(FileWriteState & file, WriteBuffer & out)
         chassert(rg.column_indexes.size() == rg.row_group.columns.size());
         for (size_t j = 0; j < rg.column_indexes.size(); ++j)
         {
+            if (!rg.column_indexes.at(j).column_index_valid)
+                continue;
+
             auto & column = rg.row_group.columns.at(j);
             column.__set_column_index_offset(file.offset);
             size_t length = serializeThriftStruct(rg.column_indexes.at(j).column_index, out);

--- a/src/Processors/Formats/Impl/Parquet/Write.h
+++ b/src/Processors/Formats/Impl/Parquet/Write.h
@@ -76,6 +76,9 @@ struct ColumnChunkIndexes
 {
     parq::ColumnIndex column_index; // if write_page_index
     parq::OffsetIndex offset_index; // if write_page_index
+    /// Set to false when a non-null page has stats dropped (e.g. value exceeded max_statistics_size).
+    /// When false, the column index must not be written because it would contain invalid bounds.
+    bool column_index_valid = true;
     parq::BloomFilterHeader bloom_filter_header;
     PODArray<UInt32> bloom_filter_data; // if write_bloom_filter, and not flushed yet
 };

--- a/src/Processors/tests/gtest_write_parquet_page_index.cpp
+++ b/src/Processors/tests/gtest_write_parquet_page_index.cpp
@@ -367,5 +367,47 @@ TEST(Parquet, WriteParquetPageIndexArrowEncoder)
         /// arrow doesn't write statistics to data page headers
         /*expect_statistics_in_page_headers*/ false);
 }
+
+/// Regression test for https://github.com/ClickHouse/ClickHouse/issues/103039
+/// When a page has a short min and a long max (exceeding max_statistics_size=4096),
+/// the column index must not be written because it would contain invalid bounds
+/// (e.g. min_value="a", max_value="" which violates min <= max).
+TEST(Parquet, WriteParquetPageIndexOversizedStringStats)
+{
+    FormatSettings format_settings;
+    format_settings.parquet.row_group_rows = 10000;
+    format_settings.parquet.use_custom_encoder = true;
+    format_settings.parquet.parallel_encoding = false;
+    format_settings.parquet.write_page_index = true;
+    format_settings.parquet.data_page_size = 32;
+
+    std::vector<std::vector<String>> values;
+    std::vector<String> col;
+    col.push_back("a");
+    col.push_back(String(5000, 'z'));
+    values.push_back(col);
+
+    auto source = multiColumnsSource<String>(
+        {std::make_shared<DataTypeString>()}, values, 1);
+    String path = "/tmp/test_oversized_stats.parquet";
+    writeParquet(source, format_settings, path);
+
+    auto reader = parquet::ParquetFileReader::OpenFile(path);
+    auto metadata = reader->metadata();
+
+    ASSERT_EQ(metadata->num_row_groups(), 1);
+    auto row_group = metadata->RowGroup(0);
+    ASSERT_EQ(row_group->num_columns(), 1);
+
+    auto column_chunk = row_group->ColumnChunk(0);
+    auto column_index_location = column_chunk->GetColumnIndexLocation();
+    auto offset_index_location = column_chunk->GetOffsetIndexLocation();
+
+    ASSERT_FALSE(column_index_location.has_value());
+
+    ASSERT_TRUE(offset_index_location.has_value());
+    ASSERT_GT(offset_index_location.value().offset, 0);
+    ASSERT_GT(offset_index_location.value().length, 0);
+}
 }
 #endif


### PR DESCRIPTION
### Problem
Closes https://github.com/ClickHouse/ClickHouse/issues/103039

When writing Parquet files with the custom encoder, the per-page ColumnIndex for variable-length BYTE_ARRAY (String) columns can have min_value > max_value. This happens when only one side of the min/max pair exceeds max_statistics_size (4096 bytes) -- the oversized side is dropped to an empty string while the other is kept, violating the min <= max invariant.

On read, this causes the query to fail:
`DB::Exception: Statistics have min_value > max_value: {…} > {…}: in column index`

### Root Cause
StatisticsStringRef::get() and StatisticsStringCopy::get() check min and max against max_statistics_size independently. When a page has a short min (e.g. "a") and a long max (e.g. 5000 bytes), the max is dropped while the min is kept. The ColumnIndex then contains min_values[i] = "a", max_values[i] = "".

### Fix
Symmetric drop in statistics: Modified StatisticsStringRef::get() and StatisticsStringCopy::get() to only emit min/max when both fit within the size limit. If either exceeds it, neither is written.

Skip invalid ColumnIndex: Added a column_index_valid flag to ColumnChunkIndexes. When a non-null page has its stats dropped (both min and max empty), the flag is set to false. writePageIndex then skips writing the ColumnIndex for that column entirely, since empty bounds on a non-null page would mislead readers into incorrectly skipping the page during predicate pushdown. 




### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix Parquet ColumnIndex stats min_value > max_value for String columns

### Documentation entry for user-facing changes

- [ ] Documentation is not required (bug fix)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.131`
- Backported to: `26.4.1.1123`, `26.3.10.46`, `26.2.17.27`, `26.1.12.22`, `25.8.23.11`
<!-- ch-version-info:end -->