### PR TITLE
claude: Add `clickhouse-pr-description` skill instruction to project CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,3 +1,5 @@
+When creating or updating a PR description, use the `clickhouse-pr-description` skill.
+
 When working with a branch, do not use rebase or amend - add new commits instead.
 
 Do not commit to the master branch. Create a new branch for every task.


### PR DESCRIPTION
Add an instruction to `.claude/CLAUDE.md` to use the `clickhouse-pr-description` skill whenever creating or updating a PR description in this repository.

### Changelog category (leave one):
- Documentation (changelog entry is not required)