### PR TITLE
CI: add `force_success` and `allow_failure` fields to `Job.Config`

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -170,7 +170,7 @@ class JobConfigs:
         name=JobNames.PR_BODY,
         runs_on=RunnerLabels.STYLE_CHECK_ARM,
         command="python3 ./ci/jobs/pr_formatter_job.py",
-        allow_merge_on_failure=True,
+        allow_failure=True,
         enable_gh_auth=True,
     )
     code_review = Job.Config(
@@ -182,7 +182,7 @@ class JobConfigs:
         name=JobNames.CI_RESULTS_REVIEW,
         runs_on=RunnerLabels.STYLE_CHECK_ARM,
         command="python3 ./ci/jobs/copilot_review_job.py --post",
-        allow_merge_on_failure=True,
+        allow_failure=True,
         enable_gh_auth=True,
     )
     fast_test = Job.Config(
@@ -198,10 +198,10 @@ class JobConfigs:
     darwin_fast_test_jobs = Job.Config(
         name="Fast test",
         runs_on=None,  # from parametrize()
-        command="python3 ./ci/jobs/fast_test.py --set-status-success",
+        command="python3 ./ci/jobs/fast_test.py",
         digest_config=fast_test_digest_config,
         result_name_for_cidb="Darwin tests",
-        allow_merge_on_failure=True,
+        force_success=True,
         post_hooks=[
             "python3 ./ci/jobs/scripts/job_hooks/clickhouse_test_cleanup_hook.py",
             "sudo rm -rf /Users/ec2-user/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp/run*; sudo find /System/Volumes/Data/System/Library/Caches/com.apple.coresymbolicationd -type f -mtime +2 -delete",
@@ -714,7 +714,7 @@ class JobConfigs:
             for batch in range(1, total_batches + 1)
         ]
     )
-    functional_tests_jobs_azure = common_ft_job_config.set_allow_merge_on_failure(
+    functional_tests_jobs_azure = common_ft_job_config.set_allow_failure(
         True
     ).parametrize(
         Job.ParamSet(

--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -153,7 +153,6 @@ def parse_args():
         nargs="+",
         action="extend")
     parser.add_argument("--param", help="Optional custom job start stage", default=None)
-    parser.add_argument("--set-status-success", help="Forcefully set a green status", action="store_true")
     return parser.parse_args()
 
 def main():
@@ -373,9 +372,8 @@ def main():
 
     CH.terminate(force=True)
 
-    status = Result.Status.OK if args.set_status_success else ""
     Result.create_from(
-        results=results, status=status, stopwatch=stop_watch, files=attach_files, info=job_info
+        results=results, stopwatch=stop_watch, files=attach_files, info=job_info
     ).complete_job()
 
 

--- a/ci/praktika/digest.py
+++ b/ci/praktika/digest.py
@@ -82,7 +82,8 @@ class Digest:
         drop_fields = [
             "requires",
             "enable_commit_status",
-            "allow_merge_on_failure",
+            "allow_failure",
+            "force_success",
             "digest_config",
         ]
         filtered_job_dict = {

--- a/ci/praktika/job.py
+++ b/ci/praktika/job.py
@@ -70,7 +70,14 @@ class Job:
 
         run_unless_cancelled: bool = False
 
-        allow_merge_on_failure: bool = False
+        # If True, the job failure does not block PR merge, but the job
+        # is still shown as failed in the CI report.
+        allow_failure: bool = False
+
+        # If True, the job failure is hidden entirely: the CI report shows
+        # green status and the job does not block PR merge. Use for
+        # experimental jobs that are not yet stable enough to be enforced.
+        force_success: bool = False
 
         enable_commit_status: bool = False
 
@@ -233,9 +240,9 @@ class Job:
             res.provides = provides_res
             return res
 
-        def set_allow_merge_on_failure(self, value=True):
+        def set_allow_failure(self, value=True):
             res = copy.deepcopy(self)
-            res.allow_merge_on_failure = value
+            res.allow_failure = value
             return res
 
         def set_post_hooks(self, post_hooks):

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -902,7 +902,7 @@ def _finish_workflow(workflow, job_name):
                 )
                 update_final_report = True
         job = workflow.get_job(result.name)
-        if not job or not job.allow_merge_on_failure:
+        if not job or not job.allow_failure:
             print(
                 f"NOTE: Result for [{result.name}] has not ok status [{result.status}]"
             )

--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -573,6 +573,9 @@ class Runner:
 
         result.update_duration()
         result.set_files([Settings.RUN_LOG], strict=False)
+        if job.force_success and not result.is_ok():
+            print(f"NOTE: Job has force_success=True - overriding status to OK")
+            result.set_status(Result.Status.OK)
         return result
 
     def _post_run(
@@ -1014,7 +1017,6 @@ class Runner:
             result = self._get_result_object(
                 job, setup_env_code, prerun_code, run_code
             )
-
             if prehook_result:
                 result.results.append(prehook_result)
             if job.post_hooks:
@@ -1042,5 +1044,5 @@ class Runner:
 
             result.dump()
 
-        if not res:
+        if not res and not job.force_success:
             sys.exit(1)

--- a/ci/workflows/pull_request.py
+++ b/ci/workflows/pull_request.py
@@ -66,12 +66,12 @@ workflow = Workflow.Config(
         ],
         *[job.set_run_after(STYLE_AND_FAST_TESTS) for job in JobConfigs.build_llvm_coverage_job],
         JobConfigs.smoke_tests_macos,
-        # TODO: stabilize new jobs and remove set_allow_merge_on_failure
+        # TODO: stabilize new jobs and remove set_allow_failure
         JobConfigs.lightweight_functional_tests_job,
-        *[j.set_allow_merge_on_failure() for j in JobConfigs.stateless_tests_targeted_pr_jobs],
-        JobConfigs.integration_test_targeted_pr_jobs[0].set_allow_merge_on_failure(),
-        JobConfigs.ast_fuzzer_targeted_pr_jobs[0].set_allow_merge_on_failure(),
-        JobConfigs.ast_fuzzer_targeted_pr_jobs[1].set_allow_merge_on_failure(),
+        *[j.set_allow_failure() for j in JobConfigs.stateless_tests_targeted_pr_jobs],
+        JobConfigs.integration_test_targeted_pr_jobs[0].set_allow_failure(),
+        JobConfigs.ast_fuzzer_targeted_pr_jobs[0].set_allow_failure(),
+        JobConfigs.ast_fuzzer_targeted_pr_jobs[1].set_allow_failure(),
         *JobConfigs.stateless_tests_flaky_pr_jobs,
         *JobConfigs.integration_test_asan_flaky_pr_jobs,
         JobConfigs.bugfix_validation_ft_pr_job,


### PR DESCRIPTION
Previously, making a CI job show green in the report despite test failures required two separate, coupled mechanisms:

1. Passing `--set-status-success` in the job command to force `SUCCESS` at the script level.
2. Setting `allow_merge_on_failure=True` on the job config to prevent the \"Ready For Merge\" check from being blocked.

This split the intent across the job script and the job config, and required every job author to know about both.

## Changes

Replace `allow_merge_on_failure` and `report_as_success_on_failure` with two clearer `Job.Config` fields:

- `allow_failure: bool = False` — the job still shows as failed in the report, but does not block PR merge.
- `force_success: bool = False` — the runner overrides the job result status to `OK` after the job script finishes, regardless of the actual outcome. The report shows the job as green, and it naturally does not block merge.

The override happens in `Runner._run()`, after reading the result written by the job script. The runner also exits 0 when `force_success=True`. Both fields are excluded from job cache digests.

`darwin_fast_test_jobs` is updated to use `force_success=True` and the `--set-status-success` flag is removed from `fast_test.py`.

Also fixes a latent bug where the code referenced `Result.Status.SUCCESS` (which does not exist — the correct value is `Result.Status.OK`), which would have raised an exception in `_run` when `force_success=True` on a failing job.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.47`
<!-- ch-version-info:end -->