### PR TITLE
Fix possible use of expired process list entry from DatabaseReplicated in getRemoteReadThrottler()

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -4773,7 +4773,7 @@ ThrottlerPtr Context::getRemoteReadThrottler() const
     }
 
     /// User-level throttler (`max_network_bandwidth_for_user` / `max_network_bandwidth_for_all_users`).
-    if (auto process_list_element = getProcessListElement())
+    if (auto process_list_element = getProcessListElementSafe())
         addThrottler(throttler, process_list_element->getUserNetworkThrottler());
 
     if (auto bandwidth = getSettingsRef()[Setting::max_remote_read_network_bandwidth])
@@ -4795,7 +4795,7 @@ ThrottlerPtr Context::getRemoteWriteThrottler() const
     }
 
     /// User-level throttler (`max_network_bandwidth_for_user` / `max_network_bandwidth_for_all_users`).
-    if (auto process_list_element = getProcessListElement())
+    if (auto process_list_element = getProcessListElementSafe())
         addThrottler(throttler, process_list_element->getUserNetworkThrottler());
 
     if (auto bandwidth = getSettingsRef()[Setting::max_remote_write_network_bandwidth])


### PR DESCRIPTION
Trottler can be called from multiple places, including DDLWorker, from ReplicatedDatabase, that calls first executeQuery() (which insert process list entry - QueryStatus, and on exit destroy it), and then calls assertDigestWithProbability(), which needs to get the metadata for the table, and throws LOGICAL_ERROR, because the weak_ptr is expired.

Backtrace: https://pastila.nl/?002a36a2/d8697e4a9a5f66199b03a2bec98c0e59#Ky1XNxVWRfAJiA2szCp9/w==GCM

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.30`
<!-- ch-version-info:end -->