### PR TITLE
CI: use trap reboot EXIT in macOS runner user_data script

### DIFF
--- a/ci/infra/cloud.py
+++ b/ci/infra/cloud.py
@@ -139,7 +139,7 @@ CLOUD = CloudInfrastructure.Config(
             tenancy="host",
             praktika_resource_tag="mac_m2_pro",
             runner_type=RunnerLabels.MACOS_ARM_SMALL[1],
-            quantity=3,
+            quantity=4,
         ),
     ],
     # TODO: add autoscaling and launch templates

--- a/ci/infra/scripts/user_data_macos.txt
+++ b/ci/infra/scripts/user_data_macos.txt
@@ -3,6 +3,7 @@
 # Based on prepare-ci-ami.sh but adapted for macOS
 
 set -xeuo pipefail
+trap reboot EXIT
 
 echo "Running macOS runner prepare script"
 
@@ -148,4 +149,3 @@ INIT_ENVIRONMENT=${INIT_ENVIRONMENT:-macos}
 aws s3 cp "s3://github-runners-data/cloud-init/${INIT_ENVIRONMENT}.py" /tmp/runner-init.py
 rm -rf /Users/ec2-user/actions-runner/_work
 sudo -u ec2-user -i bash -c "/Users/ec2-user/venv/bin/python /tmp/runner-init.py --environment \"$INIT_ENVIRONMENT\""
-reboot


### PR DESCRIPTION
Use `trap reboot EXIT` right after `set -xeuo pipefail` so the machine reboots on
any exit — including early failures caused by `set -e`. The explicit `reboot` at
the end of the script is removed because the trap covers both success and error paths.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.22`
<!-- ch-version-info:end -->