### PR TITLE
Escape '#' in CI summary comment table cells

### DIFF
--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -787,8 +787,8 @@ class GH:
 
         def to_markdown(self, pr_number=0, sha="", workflow_name="", branch=""):
             def escape_pipes(text):
-                """Escape pipe characters for markdown tables"""
-                return str(text).replace("|", "\\|")
+                """Escape special markdown characters for table cells"""
+                return str(text).replace("|", "\\|").replace("#", "\\#")
 
             if self.status == Result.Status.OK:
                 symbol = "✅"  # Green check mark
@@ -835,11 +835,10 @@ class GH:
                         for sub_failed_result in failed_result.failed_results:
                             body += "|{}|{}|{}|{}|{}|\n".format(
                                 "",
-                                # Logical erros might have | that break comment formatting
                                 escape_pipes(sub_failed_result.name),
                                 sub_failed_result.status,
-                                sub_failed_result.info or "",
-                                sub_failed_result.comment or "",
+                                escape_pipes(sub_failed_result.info or ""),
+                                escape_pipes(sub_failed_result.comment or ""),
                             )
             return body
 


### PR DESCRIPTION
Test names containing `#` (e.g. parameterized pytest tests like `test_foo[bar#baz]`) were rendered by GitHub as auto-links to issues or PRs, breaking the Markdown table in the CI summary comment.

Fix: extend `escape_pipes` in `GH.Summary.to_markdown` to also escape `#` as `\#`. Also apply escaping consistently to `info` and `comment` fields in sub-result rows.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.23`
<!-- ch-version-info:end -->