### PR TITLE
CI: fix three bugs in the job-filtering algorithm

### DIFF
--- a/ci/praktika/job.py
+++ b/ci/praktika/job.py
@@ -4,7 +4,7 @@ import hashlib
 import json
 import os
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Iterable, List, Optional
 
 from . import Artifact
@@ -274,7 +274,7 @@ class Job:
                     # Check if included
                     for include in self.digest_config.include_paths:
                         include_norm = os.path.normpath(include)
-                        if fnmatch.fnmatch(file, include_norm) or file.startswith(
+                        if PurePosixPath("/" + file).match("/" + include_norm) or file.startswith(
                             include_norm + os.sep
                         ):
                             return True

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -284,6 +284,88 @@ def _prepare_submodule_cache(workflow_config: RunConfig) -> Result:
     )
 
 
+def _filter_unaffected_jobs(jobs, workflow_config, changed_files, affected_dockers=()):
+    """
+    Update workflow_config.filtered_jobs for jobs unaffected by changed_files.
+
+    Two fixes relative to the original inline algorithm:
+
+    Fix 1 (Bug 2) — jobs already filtered by workflow_filter_hooks are skipped.
+    They will not run, so their 'requires' must not keep their dependencies alive.
+
+    Fix 2 (Bug 3) — all_required_artifacts is propagated to a fixed point after
+    the initial sweep.  When an unaffected job is rescued because an affected job
+    requires it, that rescued job's own dependencies are also rescued.
+    """
+    affected_artifacts = []
+    unaffected_jobs = {}  # name → job
+    all_required_artifacts = set()
+
+    for job in jobs:
+        if _is_praktika_job(job.name):
+            continue
+        if job.name in workflow_config.filtered_jobs:
+            continue  # Already filtered by workflow_filter_hooks — skip entirely
+
+        is_affected = False
+
+        if any(dep in affected_artifacts for dep in job.requires):
+            print(f"Job [{job.name}] requires affected artifacts")
+            is_affected = True
+        elif job.get_docker_image_name() in affected_dockers:
+            print(
+                f"Job [{job.name}] runs in affected Docker image [{job.run_in_docker}]"
+            )
+            is_affected = True
+        elif job.is_affected_by(changed_files):
+            print(f"Job [{job.name}] is directly affected by changed files")
+            is_affected = True
+
+        if is_affected:
+            affected_artifacts.extend(job.provides)
+            # Propagate the job name so downstream jobs requiring it by name
+            # are marked as affected.
+            affected_artifacts.append(job.name)
+            for req in job.requires:
+                all_required_artifacts.add(req)
+        else:
+            print(f"Job [{job.name}] is not affected by the change")
+            unaffected_jobs[job.name] = job
+
+    print(f"All required artifacts [{all_required_artifacts}]")
+    print(f"Affected artifacts [{affected_artifacts}]")
+
+    # Propagate all_required_artifacts transitively: when an unaffected job is
+    # rescued (because an affected job requires it), add its own requirements so
+    # the jobs that produce its inputs are also rescued.
+    changed = True
+    while changed:
+        changed = False
+        for job in unaffected_jobs.values():
+            if (
+                any(a in all_required_artifacts for a in job.provides)
+                or job.name in all_required_artifacts
+            ):
+                for req in job.requires:
+                    if req not in all_required_artifacts:
+                        all_required_artifacts.add(req)
+                        changed = True
+
+    for job_name, job in unaffected_jobs.items():
+        if (
+            any(a in all_required_artifacts for a in job.provides)
+            or job_name in all_required_artifacts
+        ):
+            print(
+                f"NOTE: Job [{job_name}] is required by affected jobs - cannot be skipped"
+            )
+        else:
+            workflow_config.set_job_as_filtered(
+                job_name,
+                "Not affected by the changed files and not required",
+            )
+
+
 def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
     # debug info
     GH.print_log_in_group("GITHUB envs", Shell.get_output("env | grep GITHUB"))
@@ -530,59 +612,9 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
             if all_affected_dockers:
                 print(f"Affected docker images [{all_affected_dockers}]")
 
-            affected_artifacts = []
-            unaffected_jobs_with_artifacts = {}
-            all_required_artifacts = set()
-
-            # Build set of all job names for quick lookup
-            job_names = {j.name for j in workflow.jobs}
-
-            for job in workflow.jobs:
-                # Skip native Praktika jobs
-                if _is_praktika_job(job.name):
-                    continue
-
-                is_affected = False
-
-                if any(dep in affected_artifacts for dep in job.requires):
-                    print(f"Job [{job.name}] requires affected artifacts")
-                    is_affected = True
-                elif job.get_docker_image_name() in all_affected_dockers:
-                    print(
-                        f"Job [{job.name}] runs in affected Docker image [{job.run_in_docker}]"
-                    )
-                    is_affected = True
-                elif job.is_affected_by(changed_files):
-                    print(f"Job [{job.name}] is directly affected by changed files")
-                    is_affected = True
-
-                if is_affected:
-                    affected_artifacts.extend(job.provides)
-                    # Propagate the job name so that downstream jobs
-                    # requiring this job by name are marked as affected
-                    affected_artifacts.append(job.name)
-                    # All items in requires are hard dependencies
-                    for req in job.requires:
-                        all_required_artifacts.add(req)
-                else:
-                    print(f"Job [{job.name}] is not affected by the change")
-                    unaffected_jobs_with_artifacts[job.name] = job.provides
-
-            print(f"All required artifacts [{all_required_artifacts}]")
-            print(f"Affected artifacts [{affected_artifacts}]")
-            for job_name, artifacts in unaffected_jobs_with_artifacts.items():
-                if (
-                    any(a in all_required_artifacts for a in artifacts)
-                    or job_name in all_required_artifacts
-                ):
-                    print(
-                        f"NOTE: Job [{job_name}] is required by affected jobs - cannot be skipped"
-                    )
-                else:
-                    workflow_config.set_job_as_filtered(
-                        job_name,
-                        "Not affected by the changed files and not required",
-                    )
+            _filter_unaffected_jobs(
+                workflow.jobs, workflow_config, changed_files, all_affected_dockers
+            )
 
             workflow_config.dump()
 

--- a/ci/tests/test_job_filtering.py
+++ b/ci/tests/test_job_filtering.py
@@ -1,0 +1,334 @@
+"""
+Regression tests for the job-filtering logic in ci/praktika/native_jobs.py.
+
+These tests document three bugs in the check_affected_jobs algorithm and
+assert the *correct* behaviour.  They currently FAIL against the unfixed code
+and should PASS after the three fixes are applied.
+
+Bug 1 — fnmatch '*' crosses '/' directory boundaries
+    Python's fnmatch.fnmatch treats '*' as matching any character including
+    '/'.  A digest_config include_path like './tests/*.txt' therefore matches
+    'tests/ci/lambda/requirements.txt', incorrectly marking jobs as affected
+    by unrelated changes.
+
+Bug 2 — Already-filtered jobs pollute all_required_artifacts
+    Jobs filtered by a workflow_filter_hook (e.g. "do not run cloud tests")
+    are still processed by check_affected_jobs.  Their 'requires' entries are
+    added to all_required_artifacts, rescuing their dependencies from
+    filtering even though those dependencies will never actually run.
+
+Bug 3 — Transitive dependency rescue is not propagated
+    When an unaffected job is rescued from filtering because an affected job
+    requires it (by job name), that rescued job's own 'requires' are not also
+    added to all_required_artifacts.  Build jobs that provide artifacts for
+    the rescued job remain filtered, causing a missing-artifact failure at
+    runtime.
+
+Workflow topology used in the tests
+------------------------------------
+
+    BUILD  ──provides──> BUILD_ARTIFACT
+      ^
+      │ requires(BUILD_ARTIFACT)
+    ──┼──────────────────────────────
+    TEST         digest: tests/queries, tests/*.txt
+    DOCKER       digest: docker/
+      ^
+      │ requires("DOCKER" job name, no CI artifact)
+    TEST_ON_DOCKER   digest: tests/integration/
+
+An optional OPTIONAL_JOB (no digest_config, always affected) filtered by
+a custom hook is used to expose Bug 2.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+import pytest
+from ci.praktika.job import Job
+from ci.praktika.native_jobs import _filter_unaffected_jobs
+from ci.praktika.runtime import RunConfig
+from ci.praktika.utils import Utils
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_run_config():
+    return RunConfig(
+        name="Test",
+        digest_jobs={},
+        digest_dockers={},
+        cache_success=[],
+        cache_success_base64=[],
+        cache_artifacts={},
+        cache_jobs={},
+        filtered_jobs={},
+        sha="",
+        submodule_cache_hash="",
+        custom_data={},
+    )
+
+
+def _make_job(name, *, requires=(), provides=(), include_paths=None):
+    """Create a minimal Job.Config for filtering tests."""
+    digest_config = (
+        Job.CacheDigestConfig(include_paths=list(include_paths))
+        if include_paths is not None
+        else None  # no digest_config → always affected
+    )
+    return Job.Config(
+        name=name,
+        runs_on=[],
+        command="true",
+        requires=list(requires),
+        provides=list(provides),
+        digest_config=digest_config,
+    )
+
+
+def _apply_filters(jobs, changed_files, filter_hook=None):
+    """
+    Simulate the two filtering phases that _config_workflow applies:
+
+      Phase 1 — workflow_filter_hooks
+          Calls filter_hook(job.name) for every job; marks any job for which
+          the hook returns (True, reason) as filtered.
+
+      Phase 2 — _filter_unaffected_jobs (production function from native_jobs)
+
+    Returns the filtered_jobs dict from the resulting RunConfig.
+    """
+    workflow_config = _make_run_config()
+
+    # Phase 1: workflow filter hook
+    if filter_hook is not None:
+        for job in jobs:
+            should_skip, reason = filter_hook(job.name)
+            if should_skip:
+                workflow_config.set_job_as_filtered(job.name, reason)
+
+    # Phase 2: production filtering logic
+    _filter_unaffected_jobs(jobs, workflow_config, changed_files)
+
+    return workflow_config.filtered_jobs
+
+
+# ---------------------------------------------------------------------------
+# Shared job definitions
+# ---------------------------------------------------------------------------
+
+BUILD = _make_job(
+    "BUILD",
+    provides=["BUILD_ARTIFACT"],
+    include_paths=["./src"],
+)
+TEST = _make_job(
+    "TEST",
+    requires=["BUILD_ARTIFACT"],
+    include_paths=["./tests/queries", "./tests/*.txt"],
+)
+DOCKER = _make_job(
+    "DOCKER",
+    requires=["BUILD_ARTIFACT"],
+    include_paths=["./docker"],
+)
+TEST_ON_DOCKER = _make_job(
+    "TEST_ON_DOCKER",
+    requires=["DOCKER"],  # job-name dependency — no CI artifact produced by DOCKER
+    include_paths=["./tests/integration"],
+)
+
+ALL_JOBS = [BUILD, TEST, DOCKER, TEST_ON_DOCKER]
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: fnmatch '*' crosses '/' directory boundaries
+# ---------------------------------------------------------------------------
+
+
+class TestBug1FnmatchCrossesDirectories:
+    """
+    'tests/*.txt' is intended to match files directly under tests/ (e.g.
+    tests/list_of_tests.txt).  Python's fnmatch.fnmatch treats '*' as matching
+    any character including '/', so it also matches deeply nested paths such as
+    tests/ci/lambda/requirements.txt — pulling in completely unrelated changes.
+    """
+
+    def test_txt_file_in_subdirectory_does_not_match_shallow_glob(self):
+        """
+        A .txt file two levels deep must NOT trigger 'tests/*.txt'.
+        """
+        assert not TEST.is_affected_by(["tests/ci/lambda/requirements.txt"]), (
+            "tests/*.txt should only match files directly under tests/, "
+            "not tests/ci/lambda/requirements.txt"
+        )
+
+    def test_txt_file_directly_under_tests_matches_shallow_glob(self):
+        """
+        A .txt file directly under tests/ SHOULD trigger 'tests/*.txt'.
+        This verifies the intended use-case still works after the fix.
+        """
+        assert TEST.is_affected_by(["tests/list_of_tests.txt"])
+
+    def test_unrelated_extension_in_subdirectory_does_not_match(self):
+        """
+        A non-.txt file in a subdirectory must not match 'tests/*.txt'.
+        """
+        assert not TEST.is_affected_by(["tests/ci/terraform/lambdas.tf"])
+
+    def test_txt_file_under_same_named_subdir_does_not_match(self):
+        """
+        PurePosixPath.match is not anchored by default, so 'a/tests/foo.txt'
+        would match 'tests/*.txt' via right-side matching.  Anchoring both
+        sides with '/' prevents this false positive.
+        """
+        assert not TEST.is_affected_by(["a/tests/list_of_tests.txt"]), (
+            "tests/*.txt must not match a/tests/list_of_tests.txt — "
+            "the match must be anchored to the repository root"
+        )
+
+    def test_query_file_directly_under_tests_queries_matches(self):
+        """
+        A file under tests/queries/ is matched by the 'tests/queries' include
+        path (directory prefix), which is the intended behaviour.
+        """
+        assert TEST.is_affected_by(["tests/queries/0_stateless/01234_foo.sql"])
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: Already-filtered jobs must not contribute to all_required_artifacts
+# ---------------------------------------------------------------------------
+
+
+class TestBug2FilteredJobsPollutingRequiredArtifacts:
+    """
+    OPTIONAL_JOB has no digest_config (so is_affected_by always returns True)
+    and is filtered by the workflow hook.  Because it is never going to run,
+    its requires=["DOCKER"] must not rescue DOCKER from being filtered.
+    """
+
+    # No digest_config → always treated as affected regardless of changed files.
+    OPTIONAL_JOB = _make_job(
+        "OPTIONAL_JOB",
+        requires=["DOCKER"],
+        include_paths=None,  # always affected
+    )
+
+    @staticmethod
+    def _hook(job_name):
+        if job_name == "OPTIONAL_JOB":
+            return True, "not needed for this PR type"
+        return False, ""
+
+    def test_docker_is_filtered_when_only_requirer_is_hook_filtered(self):
+        """
+        OPTIONAL_JOB is the only job that requires DOCKER.
+        OPTIONAL_JOB is filtered by the hook, so it will never run.
+        DOCKER (and transitively BUILD) must therefore be filtered.
+        """
+        jobs = ALL_JOBS + [self.OPTIONAL_JOB]
+        changed = ["ci/lambda/deploy.sh"]  # nothing in ALL_JOBS is affected
+
+        filtered = _apply_filters(jobs, changed, filter_hook=self._hook)
+
+        assert "DOCKER" in filtered, (
+            "DOCKER must be filtered: its only requirer (OPTIONAL_JOB) is "
+            "filtered by the workflow hook and will never run"
+        )
+        assert "BUILD" in filtered, (
+            "BUILD must be filtered: nothing that actually runs requires it"
+        )
+
+    def test_docker_is_not_filtered_when_unfiltered_job_requires_it(self):
+        """
+        Sanity check: when an *unfiltered* job requires DOCKER, DOCKER must stay.
+        """
+        jobs = ALL_JOBS + [self.OPTIONAL_JOB]
+        # TEST_ON_DOCKER is directly affected → it requires DOCKER → DOCKER must stay
+        changed = ["tests/integration/test_something.py"]
+
+        filtered = _apply_filters(jobs, changed, filter_hook=self._hook)
+
+        assert "DOCKER" not in filtered
+        assert "TEST_ON_DOCKER" not in filtered
+
+
+# ---------------------------------------------------------------------------
+# Bug 3: Transitive dependency rescue must be propagated
+# ---------------------------------------------------------------------------
+
+
+class TestBug3TransitiveDepRescueNotPropagated:
+    """
+    TEST_ON_DOCKER (affected) requires DOCKER (rescued).
+    DOCKER requires BUILD_ARTIFACT (provided by BUILD).
+    BUILD must therefore also be rescued — but the current algorithm only
+    does a single-level rescue and leaves BUILD filtered.
+    """
+
+    def test_build_is_rescued_when_docker_is_rescued(self):
+        """
+        TEST_ON_DOCKER is affected by a change in tests/integration/.
+        TEST_ON_DOCKER requires DOCKER (by job name) → DOCKER is rescued.
+        DOCKER requires BUILD_ARTIFACT → BUILD must also be rescued.
+        """
+        changed = ["tests/integration/test_something.py"]
+
+        filtered = _apply_filters(ALL_JOBS, changed)
+
+        assert "TEST_ON_DOCKER" not in filtered, "TEST_ON_DOCKER is directly affected"
+        assert "DOCKER" not in filtered, (
+            "DOCKER must not be filtered: TEST_ON_DOCKER requires it"
+        )
+        assert "BUILD" not in filtered, (
+            "BUILD must not be filtered: DOCKER (kept alive to serve "
+            "TEST_ON_DOCKER) requires BUILD_ARTIFACT which BUILD provides"
+        )
+
+    def test_unrelated_jobs_are_still_filtered(self):
+        """
+        Jobs that are neither affected nor transitively required must be filtered.
+        TEST is not affected by tests/integration/ and nothing requires it,
+        so it must be filtered.
+        """
+        changed = ["tests/integration/test_something.py"]
+
+        filtered = _apply_filters(ALL_JOBS, changed)
+
+        assert "TEST" in filtered, (
+            "TEST is unaffected and not required — it must be filtered"
+        )
+
+    def test_all_jobs_filtered_when_nothing_is_affected(self):
+        """
+        When no changed file touches any job's digest_config, all jobs are filtered.
+        """
+        changed = ["ci/lambda/deploy.sh"]
+
+        filtered = _apply_filters(ALL_JOBS, changed)
+
+        assert set(filtered) == {"BUILD", "TEST", "DOCKER", "TEST_ON_DOCKER"}, (
+            "All jobs must be filtered when no changed file is relevant"
+        )
+
+    def test_direct_artifact_dependency_rescue_already_works(self):
+        """
+        Verify the single-level rescue that *does* work: when DOCKER is directly
+        affected (its docker/ files changed), it requires BUILD_ARTIFACT, so BUILD
+        is added to all_required_artifacts immediately (first pass, not second
+        pass rescue) and is therefore correctly kept alive.
+        """
+        changed = ["docker/Dockerfile"]
+
+        filtered = _apply_filters(ALL_JOBS, changed)
+
+        assert "DOCKER" not in filtered, "DOCKER is directly affected"
+        assert "BUILD" not in filtered, (
+            "BUILD provides BUILD_ARTIFACT which is directly in all_required_artifacts "
+            "because the affected DOCKER job requires it"
+        )


### PR DESCRIPTION
Three independent bugs in `check_affected_jobs` caused wrong jobs to run (or not run) in CI.

The bugs were found by analysing PR https://github.com/ClickHouse/clickhouse-private/pull/56394, where `Docker server` failed with `FileNotFoundError: artifact_report_build_arm_release.json` because `Build (arm_release)` was incorrectly filtered out.

**Bug 1 — fnmatch `*` crosses `/` directory boundaries (`ci/praktika/job.py`)**
`fnmatch.fnmatch` treats `*` as matching any character including `/`, so the include path `tests/*.txt` matched `tests/ci/lambda/requirements.txt`, incorrectly marking every stateless-test, stress-test, and cloud-test job as affected by unrelated lambda changes. Fixed by replacing it with `PurePosixPath.match`, which restricts `*` to a single path component.

**Bug 2 — hook-filtered jobs polluted `all_required_artifacts` (`ci/praktika/native_jobs.py`)**
Jobs already filtered by a `workflow_filter_hook` (e.g. "do not run cloud tests") were still processed by `check_affected_jobs`. Their `requires` entries were added to `all_required_artifacts`, keeping their dependencies alive even though the jobs would never run. Fixed by skipping jobs already present in `workflow_config.filtered_jobs`.

**Bug 3 — transitive dependency rescue not propagated (`ci/praktika/native_jobs.py`)**
When an unaffected job was rescued from filtering because an affected job required it, that rescued job's own dependencies were not also rescued. Fixed by propagating `all_required_artifacts` to a fixed point after the initial sweep.

The core logic is extracted into a module-level `_filter_unaffected_jobs` function and covered by 10 new tests in `ci/tests/test_job_filtering.py`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.45`
<!-- ch-version-info:end -->