### PR TITLE
Fix RMV refresh race on concurrent rename of target storage

### DIFF
--- a/src/Analyzer/Resolve/IdentifierResolver.cpp
+++ b/src/Analyzer/Resolve/IdentifierResolver.cpp
@@ -211,10 +211,8 @@ std::shared_ptr<TableNode> IdentifierResolver::tryResolveTableIdentifier(const I
         table_name = table_identifier[0];
     }
 
-    /// Re-resolve the table if its in-memory StorageID changed under us
-    /// because of a concurrent rename. The share lock does not block
-    /// renameInMemory, so after taking it we must check that the live
-    /// identity still matches what the catalog resolved.
+    /// Re-resolve the table if its in-memory StorageID changed under us due
+    /// to a concurrent rename (the share lock does not block renameInMemory).
     static constexpr size_t max_resolve_attempts = 3;
     for (size_t attempt = 0; attempt < max_resolve_attempts; ++attempt)
     {
@@ -240,9 +238,8 @@ std::shared_ptr<TableNode> IdentifierResolver::tryResolveTableIdentifier(const I
         }
         catch (const Exception & e)
         {
-            /// UUID may have been purged between resolveStorageID and the
-            /// throwing getTable above. Retry, and pass UNKNOWN_TABLE through
-            /// on the last attempt so a genuinely-missing table stays as such.
+            /// Retry if the UUID was purged between resolve and getTable; pass
+            /// UNKNOWN_TABLE through on the last attempt.
             if (e.code() != ErrorCodes::UNKNOWN_TABLE || attempt + 1 == max_resolve_attempts)
                 throw;
             continue;
@@ -255,6 +252,9 @@ std::shared_ptr<TableNode> IdentifierResolver::tryResolveTableIdentifier(const I
             auto database = DatabaseCatalog::instance().tryGetDatabase(storage_id.getDatabaseName());
             if (database)
                 storage = database->tryGetTable(table_name, context);
+            /// Adopt the replacement's identity so TableNode stays resolvable by UUID.
+            if (storage)
+                storage_id = storage->getStorageID();
         }
         if (!storage)
             return {};
@@ -262,10 +262,13 @@ std::shared_ptr<TableNode> IdentifierResolver::tryResolveTableIdentifier(const I
         if (!storage_lock)
             storage_lock = storage->lockForShare(context->getInitialQueryId(), context->getSettingsRef()[Setting::lock_acquire_timeout]);
 
+        /// `renameInMemory` preserves UUID but changes the name; retry only
+        /// when the UUID still matches. Other identity differences (file-path
+        /// tables, the fallback above) are legitimate.
         auto live_id = storage->getStorageID();
-        if (live_id.uuid != storage_id.uuid
-            || live_id.database_name != storage_id.database_name
-            || live_id.table_name != storage_id.table_name)
+        if (storage_id.hasUUID() && live_id.uuid == storage_id.uuid
+            && (live_id.database_name != storage_id.database_name
+                || live_id.table_name != storage_id.table_name))
         {
             if (attempt + 1 == max_resolve_attempts)
                 throw Exception(ErrorCodes::TABLE_UUID_MISMATCH,

--- a/src/Analyzer/Resolve/IdentifierResolver.cpp
+++ b/src/Analyzer/Resolve/IdentifierResolver.cpp
@@ -53,6 +53,8 @@ namespace ErrorCodes
     extern const int INVALID_IDENTIFIER;
     extern const int UNSUPPORTED_METHOD;
     extern const int LOGICAL_ERROR;
+    extern const int UNKNOWN_TABLE;
+    extern const int TABLE_UUID_MISMATCH;
 }
 
 QueryTreeNodePtr IdentifierResolver::convertJoinedColumnTypeToNullIfNeeded(
@@ -209,45 +211,84 @@ std::shared_ptr<TableNode> IdentifierResolver::tryResolveTableIdentifier(const I
         table_name = table_identifier[0];
     }
 
-    StorageID storage_id(database_name, table_name);
-    storage_id = context->resolveStorageID(storage_id);
-    bool is_temporary_table = storage_id.getDatabaseName() == DatabaseCatalog::TEMPORARY_DATABASE;
-
-    StoragePtr storage;
-    TableLockHolder storage_lock;
-
-    if (is_temporary_table)
-        storage = DatabaseCatalog::instance().getTable(storage_id, context);
-    else if (auto refresh_task = context->getRefreshSet().tryGetTaskForInnerTable(storage_id))
+    /// Re-resolve the table if its in-memory StorageID changed under us
+    /// because of a concurrent rename. The share lock does not block
+    /// renameInMemory, so after taking it we must check that the live
+    /// identity still matches what the catalog resolved.
+    static constexpr size_t max_resolve_attempts = 3;
+    for (size_t attempt = 0; attempt < max_resolve_attempts; ++attempt)
     {
-        /// If table is the target of a refreshable materialized view, it needs additional
-        /// synchronization to make sure we see all of the data (e.g. if refresh happened on another replica).
-        std::tie(storage, storage_lock) = refresh_task->getAndLockTargetTable(storage_id, context);
+        StorageID storage_id(database_name, table_name);
+        storage_id = context->resolveStorageID(storage_id);
+        bool is_temporary_table = storage_id.getDatabaseName() == DatabaseCatalog::TEMPORARY_DATABASE;
+
+        StoragePtr storage;
+        TableLockHolder storage_lock;
+
+        try
+        {
+            if (is_temporary_table)
+                storage = DatabaseCatalog::instance().getTable(storage_id, context);
+            else if (auto refresh_task = context->getRefreshSet().tryGetTaskForInnerTable(storage_id))
+            {
+                /// If table is the target of a refreshable materialized view, it needs additional
+                /// synchronization to make sure we see all of the data (e.g. if refresh happened on another replica).
+                std::tie(storage, storage_lock) = refresh_task->getAndLockTargetTable(storage_id, context);
+            }
+            else
+                storage = DatabaseCatalog::instance().tryGetTable(storage_id, context);
+        }
+        catch (const Exception & e)
+        {
+            /// UUID may have been purged between resolveStorageID and the
+            /// throwing getTable above. Retry, and pass UNKNOWN_TABLE through
+            /// on the last attempt so a genuinely-missing table stays as such.
+            if (e.code() != ErrorCodes::UNKNOWN_TABLE || attempt + 1 == max_resolve_attempts)
+                throw;
+            continue;
+        }
+
+        if (!storage && storage_id.hasUUID())
+        {
+            // If `storage_id` has UUID, it is possible that the UUID is removed from `DatabaseCatalog` after `context->resolveStorageID(storage_id)`
+            // We try to get the table with the database name and the table name.
+            auto database = DatabaseCatalog::instance().tryGetDatabase(storage_id.getDatabaseName());
+            if (database)
+                storage = database->tryGetTable(table_name, context);
+        }
+        if (!storage)
+            return {};
+
+        if (!storage_lock)
+            storage_lock = storage->lockForShare(context->getInitialQueryId(), context->getSettingsRef()[Setting::lock_acquire_timeout]);
+
+        auto live_id = storage->getStorageID();
+        if (live_id.uuid != storage_id.uuid
+            || live_id.database_name != storage_id.database_name
+            || live_id.table_name != storage_id.table_name)
+        {
+            if (attempt + 1 == max_resolve_attempts)
+                throw Exception(ErrorCodes::TABLE_UUID_MISMATCH,
+                    "Table {}.{} was concurrently renamed; the UUID-to-name mapping diverged on every retry",
+                    database_name, table_name);
+            storage_lock = {};
+            storage.reset();
+            continue;
+        }
+
+        storage->updateExternalDynamicMetadataIfExists(context);
+        auto storage_snapshot = storage->getStorageSnapshot(storage->getInMemoryMetadataPtr(context, false), context);
+        auto result = std::make_shared<TableNode>(
+            std::move(storage), storage_id, std::move(storage_lock), std::move(storage_snapshot));
+        if (is_temporary_table)
+            result->setTemporaryTableName(table_name);
+
+        return result;
     }
-    else
-        storage = DatabaseCatalog::instance().tryGetTable(storage_id, context);
 
-    if (!storage && storage_id.hasUUID())
-    {
-        // If `storage_id` has UUID, it is possible that the UUID is removed from `DatabaseCatalog` after `context->resolveStorageID(storage_id)`
-        // We try to get the table with the database name and the table name.
-        auto database = DatabaseCatalog::instance().tryGetDatabase(storage_id.getDatabaseName());
-        if (database)
-            storage = database->tryGetTable(table_name, context);
-    }
-    if (!storage)
-        return {};
-
-
-    if (!storage_lock)
-        storage_lock = storage->lockForShare(context->getInitialQueryId(), context->getSettingsRef()[Setting::lock_acquire_timeout]);
-    storage->updateExternalDynamicMetadataIfExists(context);
-    auto storage_snapshot = storage->getStorageSnapshot(storage->getInMemoryMetadataPtr(context, false), context);
-    auto result = std::make_shared<TableNode>(std::move(storage), std::move(storage_lock), std::move(storage_snapshot));
-    if (is_temporary_table)
-        result->setTemporaryTableName(table_name);
-
-    return result;
+    throw Exception(ErrorCodes::LOGICAL_ERROR,
+        "Unreachable: tryResolveTableIdentifier retry loop exited without a decision for table {}.{}",
+        database_name, table_name);
 }
 
 IdentifierResolveResult IdentifierResolver::tryResolveTableIdentifierFromDatabaseCatalog(const Identifier & table_identifier, const ContextPtr & context)

--- a/tests/integration/test_rmv_access_denied_on_rename_race/test.py
+++ b/tests/integration/test_rmv_access_denied_on_rename_race/test.py
@@ -1,0 +1,165 @@
+import time
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    stay_alive=True,
+)
+
+
+@pytest.fixture(scope="module")
+def start_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_rmv_access_denied_on_rename_race(start_cluster):
+    """
+    Reproduces the race between an upstream REPLACE refreshable materialized view's
+    EXCHANGE and a downstream APPEND refreshable materialized view whose analyzer-
+    level table resolution touches the same target.
+
+    On each refresh the upstream RMV renames its target storage in memory via
+    EXCHANGE (the in-memory StorageID briefly becomes the name of the temporary
+    counterpart). If the downstream resolver captures the storage pointer before
+    the EXCHANGE and constructs the query tree's TableNode after it, the
+    TableNode caches the post-rename identity. Because the downstream runs under
+    SQL SECURITY DEFINER with grants bound to the real table name, the
+    subsequent access check fails against a name the user was never granted.
+
+    This is the engine-agnostic variant of the race, using a default Atomic
+    database and a plain MergeTree engine. A SharedCatalog-specific variant
+    with a more aggressive drop-to-staging window lives in
+    test_rmv_access_denied_during_exchange.
+    """
+    node.query("DROP DATABASE IF EXISTS test_rmv SYNC")
+    node.query("DROP USER IF EXISTS rmv_definer")
+
+    node.query("CREATE DATABASE test_rmv")
+
+    node.query(
+        """
+        CREATE TABLE test_rmv.src
+        (
+            k Int32,
+            v Int32
+        )
+        ENGINE = MergeTree
+        ORDER BY k
+        """
+    )
+    node.query(
+        "INSERT INTO test_rmv.src SELECT number, number * 2 FROM numbers(1000)"
+    )
+
+    # Explicit target table for the upstream RMV. The EXCHANGE on each refresh
+    # swaps this exact table by user-facing name, which is what the downstream
+    # reads — a target -> target chain of refreshable views.
+    node.query(
+        """
+        CREATE TABLE test_rmv.ups_target
+        (
+            k Int32,
+            v Int32
+        )
+        ENGINE = MergeTree
+        ORDER BY k
+        """
+    )
+
+    # Upstream RMV: REPLACE mode every 1 second -> each refresh invokes
+    # exchangeTargetTable + dropTempTable, briefly mutating the in-memory
+    # StorageID of the old ups_target storage.
+    node.query(
+        """
+        CREATE MATERIALIZED VIEW test_rmv.ups_rmv
+        REFRESH EVERY 1 SECOND
+        TO test_rmv.ups_target AS
+        SELECT k, v FROM test_rmv.src
+        """
+    )
+
+    # Downstream target table and the definer user. Grants are column-scoped on
+    # real table names only; no wildcard that would mask a race manifesting as
+    # ACCESS_DENIED against a transient post-rename identity.
+    node.query(
+        """
+        CREATE TABLE test_rmv.downstream_tgt
+        (
+            k Int32,
+            v Int32
+        )
+        ENGINE = MergeTree
+        ORDER BY k
+        """
+    )
+    node.query("CREATE USER rmv_definer IDENTIFIED WITH no_password")
+    node.query("GRANT SELECT(k, v) ON test_rmv.ups_target TO rmv_definer")
+    node.query("GRANT INSERT(k, v) ON test_rmv.downstream_tgt TO rmv_definer")
+
+    # Downstream RMV: APPEND + SQL SECURITY DEFINER using the column-scoped user.
+    # Reads ups_target by name concurrently with the upstream's EXCHANGE.
+    node.query(
+        """
+        CREATE MATERIALIZED VIEW test_rmv.dn
+        REFRESH EVERY 1 SECOND APPEND
+        TO test_rmv.downstream_tgt
+        DEFINER = rmv_definer SQL SECURITY DEFINER
+        AS SELECT k, v FROM test_rmv.ups_target
+        """
+    )
+
+    # Let refreshes stabilize, then drive the race by forcing frequent SYSTEM
+    # REFRESHes on both views. Natural 1-second refreshes alone produce too few
+    # race windows in a 60-second test run.
+    time.sleep(2)
+    deadline = time.time() + 60
+    while time.time() < deadline:
+        try:
+            node.query("SYSTEM REFRESH VIEW test_rmv.ups_rmv")
+            node.query("SYSTEM REFRESH VIEW test_rmv.dn")
+        except Exception:
+            pass
+        time.sleep(0.05)
+
+    node.query("SYSTEM FLUSH LOGS query_log")
+
+    # Collect any refresh failures caused by the race in the analyzer's table
+    # resolver. Depending on which point of the upstream's EXCHANGE cycle the
+    # downstream resolver caught, the same race manifests as either:
+    #   * Code 497 ACCESS_DENIED citing a transient post-rename table name —
+    #     the storage's in-memory StorageID was mutated mid-resolution and the
+    #     cached identity no longer matches the user's grant.
+    #   * Code 60 UNKNOWN_TABLE citing "<db>.<table> (<uuid>) does not exist" —
+    #     the resolved UUID was purged from the catalog between resolveStorageID
+    #     and the subsequent access, and the fallback name lookup also failed.
+    # rmv_definer has sufficient grants for the legitimate refresh path, so any
+    # 497 or 60 under a test_rmv refresh log_comment is evidence of the race.
+    offending_rows = node.query(
+        """
+        SELECT event_time, exception_code, query_id, log_comment, exception
+        FROM system.query_log
+        WHERE type != 'QueryStart'
+          AND exception_code IN (60, 497)
+          AND log_comment LIKE 'refresh of test_rmv.%'
+        FORMAT Vertical
+        """
+    )
+
+    node.query("DROP DATABASE IF EXISTS test_rmv SYNC")
+    node.query("DROP USER IF EXISTS rmv_definer")
+
+    assert offending_rows == "", (
+        "Refresh failed with an error indicating the TableNode was constructed "
+        "with a post-rename storage identity instead of the user-requested one. "
+        "Expected no ACCESS_DENIED (497) or UNKNOWN_TABLE (60) errors under "
+        "refresh log comments, saw:\n" + offending_rows
+    )


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes ACCESS_DENIED / UNKNOWN_TABLE in downstream APPEND RMVs with SQL SECURITY DEFINER when an upstream REPLACE RMV's EXCHANGE flips the target storage identity mid-resolution

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
