### PR TITLE
Fix flaky 01872_functions_to_subcolumns_analyzer under map-bucket serialization

### DIFF
--- a/tests/queries/0_stateless/01872_functions_to_subcolumns_analyzer.sql
+++ b/tests/queries/0_stateless/01872_functions_to_subcolumns_analyzer.sql
@@ -3,8 +3,15 @@ DROP TABLE IF EXISTS t_func_to_subcolumns;
 SET enable_analyzer = 1;
 SET optimize_functions_to_subcolumns = 1;
 
+-- Pin Map serialization to `basic` so `m.keys`/`m.values` subcolumns return keys in
+-- insertion order. CI randomizes `map_serialization_version_for_zero_level_parts` and
+-- `map_serialization_version` between `basic` and `with_buckets`; the latter stores keys
+-- in hash-bucket order, which reorders `mapKeys(m)`/`mapValues(m)` output. The test
+-- verifies the `optimize_functions_to_subcolumns` rewrite (see EXPLAIN QUERY TREE
+-- assertions below), which is orthogonal to storage format.
 CREATE TABLE t_func_to_subcolumns (id UInt64, arr Array(UInt64), n Nullable(String), m Map(String, UInt64))
-ENGINE = MergeTree ORDER BY tuple();
+ENGINE = MergeTree ORDER BY tuple()
+SETTINGS map_serialization_version = 'basic', map_serialization_version_for_zero_level_parts = 'basic';
 
 INSERT INTO t_func_to_subcolumns VALUES (1, [1, 2, 3], 'abc', map('foo', 1, 'bar', 2)) (2, [], NULL, map());
 


### PR DESCRIPTION
## Summary

Pin `map_serialization_version` and `map_serialization_version_for_zero_level_parts` to `basic` in the test's `CREATE TABLE SETTINGS` so `m.keys`/`m.values` subcolumns return keys in insertion order regardless of CI randomization.

## Root cause

CI randomizes both settings between `basic` and `with_buckets` via `tests/clickhouse-test` `MergeTreeSettingsRandomizer` (lines 1574-1578). With `with_buckets`, Map entries are stored in hash-bucket order on disk, so reads of `m.keys`/`m.values` subcolumns (produced by `optimize_functions_to_subcolumns` rewriting `mapKeys(m)`/`mapValues(m)`) return keys in bucket order rather than insertion order. The reference expects insertion order, so the test fails whenever the randomizer picks `with_buckets`.

The test's purpose is to verify the `optimize_functions_to_subcolumns` rewrite — this is still verified via the `EXPLAIN QUERY TREE` assertions, which are orthogonal to the storage format. Pinning only the serialization format preserves the test's intent.

Deterministic reproducer:
```
CREATE TABLE t (id UInt64, m Map(String, UInt64)) ENGINE = MergeTree ORDER BY tuple()
  SETTINGS map_serialization_version_for_zero_level_parts = 'with_buckets',
           max_buckets_in_map = 39,
           map_buckets_strategy = 'constant',
           map_buckets_min_avg_size = 1;
INSERT INTO t VALUES (1, map('foo', 1, 'bar', 2));
SELECT mapKeys(m), mapValues(m) FROM t
  SETTINGS enable_analyzer = 1, optimize_functions_to_subcolumns = 1;
-- returns ['bar','foo'] [2,1]
```

Same pattern as the earlier fix for `02974_analyzer_array_join_subcolumn.sql` (commit `d238b482d5c`).

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=103290&sha=19fb213a58678837108547442bccac2efe611e9e&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29

30-day CIDB evidence: 5 unrelated PRs hit this failure (after PR-relatedness filter), 0 master failures — genuine chronic flaky test.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.38`
<!-- ch-version-info:end -->