### PR TITLE
Fix flaky 03008_uniq_exact_equal_ranges under MSan/WasmEdge

### DIFF
--- a/tests/queries/0_stateless/03008_uniq_exact_equal_ranges.sql
+++ b/tests/queries/0_stateless/03008_uniq_exact_equal_ranges.sql
@@ -5,20 +5,28 @@ CREATE TABLE t_uniq_exact (a UInt64, b String, c UInt64) ENGINE = MergeTree ORDE
 SET group_by_two_level_threshold_bytes = 1;
 SET group_by_two_level_threshold = 1;
 SET max_threads = 4;
+SET max_block_size = 16384;
 SET max_bytes_before_external_group_by = 0;
 SET max_bytes_ratio_before_external_group_by = 0;
 SET optimize_aggregation_in_order = 0;
 
-INSERT INTO t_uniq_exact SELECT 0, randomPrintableASCII(5), rand() FROM numbers(300000);
-INSERT INTO t_uniq_exact SELECT 1, randomPrintableASCII(5), rand() FROM numbers(300000);
-INSERT INTO t_uniq_exact SELECT 2, randomPrintableASCII(5), rand() FROM numbers(300000);
-INSERT INTO t_uniq_exact SELECT 3, randomPrintableASCII(5), rand() FROM numbers(300000);
-INSERT INTO t_uniq_exact SELECT 4, randomPrintableASCII(5), rand() FROM numbers(300000);
-INSERT INTO t_uniq_exact SELECT 5, randomPrintableASCII(5), rand() FROM numbers(300000);
-INSERT INTO t_uniq_exact SELECT 6, randomPrintableASCII(5), rand() FROM numbers(300000);
-INSERT INTO t_uniq_exact SELECT 7, randomPrintableASCII(5), rand() FROM numbers(300000);
-INSERT INTO t_uniq_exact SELECT 8, randomPrintableASCII(5), rand() FROM numbers(300000);
-INSERT INTO t_uniq_exact SELECT 9, randomPrintableASCII(5), rand() FROM numbers(300000);
+-- Data volume is kept small (30k rows per key, 10 parts, 300k total) to let
+-- `OPTIMIZE FINAL` complete quickly under slow CI configurations (MSan +
+-- WasmEdge + aggressive randomized `MergeTree` settings such as tiny
+-- `index_granularity` and forced vertical merge). `max_block_size` is pinned
+-- so that both the threshold=1.0 and threshold=0.5 paths for
+-- `min_hit_rate_to_use_consecutive_keys_optimization` are exercised across
+-- multiple blocks per thread regardless of the randomizer.
+INSERT INTO t_uniq_exact SELECT 0, randomPrintableASCII(5), rand() FROM numbers(30000);
+INSERT INTO t_uniq_exact SELECT 1, randomPrintableASCII(5), rand() FROM numbers(30000);
+INSERT INTO t_uniq_exact SELECT 2, randomPrintableASCII(5), rand() FROM numbers(30000);
+INSERT INTO t_uniq_exact SELECT 3, randomPrintableASCII(5), rand() FROM numbers(30000);
+INSERT INTO t_uniq_exact SELECT 4, randomPrintableASCII(5), rand() FROM numbers(30000);
+INSERT INTO t_uniq_exact SELECT 5, randomPrintableASCII(5), rand() FROM numbers(30000);
+INSERT INTO t_uniq_exact SELECT 6, randomPrintableASCII(5), rand() FROM numbers(30000);
+INSERT INTO t_uniq_exact SELECT 7, randomPrintableASCII(5), rand() FROM numbers(30000);
+INSERT INTO t_uniq_exact SELECT 8, randomPrintableASCII(5), rand() FROM numbers(30000);
+INSERT INTO t_uniq_exact SELECT 9, randomPrintableASCII(5), rand() FROM numbers(30000);
 
 OPTIMIZE TABLE t_uniq_exact FINAL;
 


### PR DESCRIPTION
The test `03008_uniq_exact_equal_ranges` was reported as flaky in #103420 after hitting a 300s query timeout on `OPTIMIZE TABLE t_uniq_exact FINAL;` on `Stateless tests (amd_msan, WasmEdge, parallel, 1/2)`.

## Root cause

Looking at the last 90 days in CIDB, the failure pattern is consistent with slow merges:

- 5 hits of "Timeout exceeded … 300 seconds" on `OPTIMIZE TABLE t_uniq_exact FINAL;` — mostly `amd_msan, WasmEdge` plus `amd_tsan, s3 storage` and `amd_debug, distributed plan, s3 storage`.
- 6 hits of "Test runs too long (> 180s). Make it faster." on the flaky-check variants.

The test writes 3M rows across 10 parts, then `OPTIMIZE FINAL` merges them. Under MSan + WasmEdge runtime overhead plus aggressive randomized `MergeTree` settings (e.g. `index_granularity = 219` — ~37× more granules; `vertical_merge_algorithm_min_rows_to_activate = 1` forcing vertical merge; `min_bytes_for_wide_part = 0` forcing wide parts; small `merge_max_block_size`) the single merge can take well over 5 minutes and crosses the 300s client query timeout.

## Fix

Reduce the data volume 10× (30k rows per key, 10 parts, 300k total) and pin `max_block_size = 16384` so that both the `min_hit_rate_to_use_consecutive_keys_optimization = 1.0` and `= 0.5` paths still fire across multiple blocks per thread regardless of the randomizer.

The reduced test preserves the regression coverage added in ccc6df0e432 / #61257: the `uniqExact` and `sum` results are compared via `EXCEPT` across both hit-rate thresholds, so any divergence between the consecutive-keys-ranges optimization paths still surfaces. Locally verified that `AggregationOptimizedEqualRangesOfKeys` is still incremented (e.g. 8 times at threshold 0.5, 2 at threshold 1.0), so the code paths under test are exercised.

## Test plan

- `clickhouse-test --no-random-settings --no-random-merge-tree-settings 03008_uniq_exact_equal_ranges` — OK in 0.29s.
- `clickhouse-test --test-runs 150 03008_uniq_exact_equal_ranges` — 150/150 passed, max per-run 0.58s.
- Verified via `system.query_log.ProfileEvents` that the consecutive-keys-ranges optimization path still fires for both threshold values.

CI report from the triggering failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=93384&sha=31743b5b76661b9b0d80eaa76718c339f2f0a7e3&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%201%2F2%29

Closes #103420

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required for CI fix.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.37`
<!-- ch-version-info:end -->