### PR TITLE
Fix UBSan pointer-overflow in `LimitSeekableReadBuffer::seek`

### DIFF
--- a/src/IO/LimitSeekableReadBuffer.cpp
+++ b/src/IO/LimitSeekableReadBuffer.cpp
@@ -98,7 +98,8 @@ off_t LimitSeekableReadBuffer::seek(off_t off, int whence)
     /// on pointer differences. Computing `pos + position_change` directly is undefined behavior
     /// when `pos` is null (e.g. when the inner buffer hasn't been materialized yet) or when
     /// `position_change` is large enough that the resulting pointer escapes the allocation.
-    if (working_buffer.begin() - pos <= position_change && position_change <= working_buffer.end() - pos)
+    if (pos && working_buffer.begin() <= pos + position_change
+           && pos + position_change <= working_buffer.end())
     {
         /// Position is still inside the buffer.
         pos += position_change;

--- a/src/IO/LimitSeekableReadBuffer.cpp
+++ b/src/IO/LimitSeekableReadBuffer.cpp
@@ -98,8 +98,7 @@ off_t LimitSeekableReadBuffer::seek(off_t off, int whence)
     /// on pointer differences. Computing `pos + position_change` directly is undefined behavior
     /// when `pos` is null (e.g. when the inner buffer hasn't been materialized yet) or when
     /// `position_change` is large enough that the resulting pointer escapes the allocation.
-    if (pos && working_buffer.begin() <= pos + position_change
-           && pos + position_change <= working_buffer.end())
+    if (working_buffer.begin() - pos <= position_change && position_change <= working_buffer.end() - pos)
     {
         /// Position is still inside the buffer.
         pos += position_change;

--- a/src/IO/LimitSeekableReadBuffer.cpp
+++ b/src/IO/LimitSeekableReadBuffer.cpp
@@ -94,7 +94,11 @@ off_t LimitSeekableReadBuffer::seek(off_t off, int whence)
         throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, "Seek shift out of bounds");
 
     off_t position_change = new_position - current_position;
-    if ((buffer().begin() <= pos + position_change) && (pos + position_change <= buffer().end()))
+    /// Check whether the new position is still inside the working buffer using integer arithmetic
+    /// on pointer differences. Computing `pos + position_change` directly is undefined behavior
+    /// when `pos` is null (e.g. when the inner buffer hasn't been materialized yet) or when
+    /// `position_change` is large enough that the resulting pointer escapes the allocation.
+    if (working_buffer.begin() - pos <= position_change && position_change <= working_buffer.end() - pos)
     {
         /// Position is still inside the buffer.
         pos += position_change;

--- a/src/IO/tests/gtest_limit_seekable_read_buffer.cpp
+++ b/src/IO/tests/gtest_limit_seekable_read_buffer.cpp
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+
+#include <IO/EmptyReadBuffer.h>
+#include <IO/LimitSeekableReadBuffer.h>
+#include <IO/ReadBufferFromMemory.h>
+#include <IO/ReadHelpers.h>
+
+using namespace DB;
+
+/// Regression test for UBSAN finding STID 3079-3df0:
+///   src/IO/LimitSeekableReadBuffer.cpp:97:34:
+///   runtime error: applying non-zero offset 1178 to null pointer
+///
+/// Reproduction scenario: the inner buffer has not materialized its memory yet
+/// (e.g. `ParallelReadBuffer`, `ReadWriteBufferFromHTTP`, `EmptyReadBuffer` —
+/// all start with `pos == nullptr`). When `LimitSeekableReadBuffer` wraps such
+/// a buffer and `seek(non_zero_offset, SEEK_SET)` is called before the first
+/// read, the fast-path check in `LimitSeekableReadBuffer::seek` used to
+/// compute `pos + position_change`. Doing pointer arithmetic with a non-zero
+/// offset on a null pointer is undefined behavior per [expr.add] and UBSAN
+/// catches it under `-fsanitize=pointer-overflow`.
+TEST(LimitSeekableReadBuffer, SeekOnInnerBufferWithNullPos)
+{
+    /// EmptyReadBuffer is constructed via `SeekableReadBuffer(nullptr, 0)`, so
+    /// its `pos` and `working_buffer` are both null pointers. This is the
+    /// cheapest way to reproduce the UB; real-world triggers from the backup
+    /// stack (STID 3079-3df0) involve HTTP or parallel read buffers that also
+    /// start with `pos == nullptr` until the first `next()` call.
+    auto inner = std::make_unique<EmptyReadBuffer>();
+    LimitSeekableReadBuffer limit_buf(std::move(inner), 0, 4096);
+
+    /// Before the fix this line produced:
+    ///   runtime error: applying non-zero offset 1178 to null pointer
+    /// under `-fsanitize=pointer-overflow`. After the fix, the fast-path uses
+    /// integer arithmetic on pointer differences and is well-defined.
+    off_t result = limit_buf.seek(1178, SEEK_SET);
+    ASSERT_EQ(result, 1178);
+}
+
+/// Sanity check that seeks still work correctly after reading when the inner
+/// buffer does have a materialized working buffer. This guards against the
+/// fix accidentally breaking the normal in-buffer seek fast-path.
+TEST(LimitSeekableReadBuffer, SeekInsideMaterializedBuffer)
+{
+    const std::string data = "0123456789abcdef0123456789abcdef";
+    auto inner = std::make_unique<ReadBufferFromMemory>(data.data(), data.size());
+    LimitSeekableReadBuffer limit_buf(std::move(inner), 2, 20);
+
+    /// Force the buffer to materialize.
+    char c = 0;
+    readChar(c, limit_buf);
+    ASSERT_EQ(c, '2'); /// data[2]
+    ASSERT_EQ(limit_buf.getPosition(), 1);
+
+    /// Forward seek inside the working buffer — fast path.
+    off_t result = limit_buf.seek(5, SEEK_SET);
+    ASSERT_EQ(result, 5);
+    readChar(c, limit_buf);
+    ASSERT_EQ(c, '7'); /// data[2 + 5]
+
+    /// Backward seek inside the working buffer — fast path.
+    result = limit_buf.seek(0, SEEK_SET);
+    ASSERT_EQ(result, 0);
+    readChar(c, limit_buf);
+    ASSERT_EQ(c, '2'); /// data[2]
+}
+
+/// Sanity check for the slow-path where the seek target is outside the
+/// currently-buffered range. Ensures we don't accidentally take the fast
+/// path when the target is outside the working buffer.
+TEST(LimitSeekableReadBuffer, SeekOutsideMaterializedBuffer)
+{
+    const std::string data(1024, 'x');
+    auto inner = std::make_unique<ReadBufferFromMemory>(data.data(), data.size());
+    LimitSeekableReadBuffer limit_buf(std::move(inner), 0, data.size());
+
+    char c = 0;
+    readChar(c, limit_buf);
+    ASSERT_EQ(c, 'x');
+
+    /// Seek far forward — outside any reasonable working buffer range.
+    off_t result = limit_buf.seek(512, SEEK_SET);
+    ASSERT_EQ(result, 512);
+    readChar(c, limit_buf);
+    ASSERT_EQ(c, 'x');
+}


### PR DESCRIPTION
`LimitSeekableReadBuffer::seek` used `pos + position_change` inside its
in-buffer fast-path check. When the inner buffer has not materialized
its memory yet — as is the case for `EmptyReadBuffer`,
`ParallelReadBuffer`, and `ReadWriteBufferFromHTTP`, all of which start
with `pos == nullptr` — and a non-zero seek is requested before the
first `next`, this triggers undefined behavior per [expr.add]:
"applying non-zero offset N to null pointer".

On master `BuzzHouse (arm_asan_ubsan)` this surfaced from the BACKUP
write path as **STID 3079-3df0**:

```
src/IO/LimitSeekableReadBuffer.cpp:97:34: runtime error: applying non-zero offset 1178 to null pointer
  #0 DB::LimitSeekableReadBuffer::seek(long, int)
  #1 DB::BackupWriterDefault::copyDataToFile(...)
  #2 DB::BackupImpl::writeFile(...)
  #3 DB::BackupsWorker::writeBackupEntries(...)
```

**Root cause.** `BackupEntryFromAppendOnlyFile::getReadBuffer` wraps the
underlying disk read buffer with `LimitSeekableReadBuffer`. Some inner
buffer types start with `pos == nullptr` until the first read. When
`BackupWriterDefault::copyDataToFile` immediately calls
`read_buffer->seek(base_size, SEEK_SET)` on such a wrapper, the fast-path
check computes `nullptr + position_change`, which is UB.

**Fix.** Replace the pointer-arithmetic comparison with an equivalent
check expressed via pointer *differences* and integer arithmetic, which
is well-defined regardless of whether `pos` is null. The condition is
mathematically identical to the original for all legal inputs (for
non-null `pos` within the working buffer, `begin - pos` and `end - pos`
are valid `ptrdiff_t` values; for an empty buffer with null `pos` the
check only accepts `position_change == 0`, matching the original).

**Test.** Added `gtest_limit_seekable_read_buffer.cpp` with three
scenarios:
1. `SeekOnInnerBufferWithNullPos` — regression test that reproduces the
   exact UBSan error from CI (`runtime error: applying non-zero offset
   1178 to null pointer`) when the fix is reverted.
2. `SeekInsideMaterializedBuffer` — sanity check for the normal
   in-buffer fast-path.
3. `SeekOutsideMaterializedBuffer` — sanity check for the slow-path
   where the seek target is outside the working buffer.

All three pass under `-fsanitize=address,undefined` with
`UBSAN_OPTIONS=halt_on_error=1`. Without the fix the first test
deterministically triggers the CI UBSan error at the exact same
location (line 97, column 34, offset 1178).

CI report:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=4b8132993ce0625e9c0ed0bf15ed16eb6df8262b&name_0=MasterCI&name_1=BuzzHouse+%28arm_asan_ubsan%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix undefined behavior in `LimitSeekableReadBuffer::seek` when the wrapped inner buffer has not been materialized yet. The fast-path in-buffer check performed pointer arithmetic on a possibly-null `pos`, which UBSan reports as "applying non-zero offset to null pointer". Triggered from the BACKUP write path in debug/sanitizer builds.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)