### PR TITLE
Optimize MemoryTracker layout (improves performance of it ~25%)

### DIFF
--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -66,20 +66,22 @@ private:
 #pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
 #pragma clang diagnostic ignored "-Wnested-anon-types"
 
-    /// Hot writes: updated on every alloc/free flush. Isolated on their own cache line
-    /// so that flushes from any core do not invalidate the read-mostly line below.
+    /// Hot: every field touched on the alloc/free path. Packed into a single cache line
+    /// (24B writes + 40B reads = 64B exactly) so each allocation needs at most one line
+    /// in flight. The line bounces among writer cores either way; co-locating the
+    /// read-mostly limits/parent/metric here means writers get them for free with the
+    /// same fetch. The only cost is reader-only cores re-fetching when allocator writes
+    /// invalidate, but allocations dominate over pure reads in practice.
     struct
     {
+        /// Hot writes: updated on every alloc/free flush.
         alignas(DB::CH_CACHE_LINE_SIZE) std::atomic<Int64> amount {0};
         std::atomic<Int64> peak {0};
         std::atomic<Int64> rss {0};
-    };
 
-    /// Read-mostly: read on every alloc to enforce caps and walk the tracker chain,
-    /// but written rarely (set once at construction or via configuration changes).
-    struct
-    {
-        alignas(DB::CH_CACHE_LINE_SIZE) std::atomic<Int64> soft_limit {0};
+        /// Hot reads: checked on every alloc but written only at construction or via
+        /// rare configuration changes.
+        std::atomic<Int64> soft_limit {0};
         std::atomic<Int64> hard_limit {0};
         std::atomic<Int64> profiler_limit {0};
 
@@ -89,14 +91,15 @@ private:
 
         /// You could specify custom metric to track memory usage.
         std::atomic<CurrentMetrics::Metric> metric = CurrentMetrics::end();
-
-        /// This description will be used as prefix into log messages (if isn't nullptr)
-        std::atomic<const char *> description_ptr = nullptr;
     };
 
-    /// Cold: rarely-touched configuration / sampling parameters.
+    /// Cold: rarely-touched configuration, sampling, and log-only fields.
     struct
     {
+        /// This description will be used as prefix into log messages (if isn't nullptr).
+        /// Only read on logging paths, not per allocation.
+        alignas(DB::CH_CACHE_LINE_SIZE) std::atomic<const char *> description_ptr = nullptr;
+
         Int64 profiler_step = 0;
 
         /// To test exception safety of calling code, memory tracker throws an exception on each memory allocation with specified probability.

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -53,6 +53,7 @@ namespace DB
   *
   * @see LockMemoryExceptionInThread
   * @see MemoryTrackerBlockerInThread
+  * @see MemoryTrackerUntrackedAllocationsBlockerInThread
   */
 class MemoryTracker
 {

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -3,10 +3,12 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <type_traits>
 #include <base/types.h>
+#include <Common/AllocationTrace.h>
+#include <Common/CacheLine.h>
 #include <Common/CurrentMetrics.h>
 #include <Common/VariableContext.h>
-#include <Common/AllocationTrace.h>
 
 #if !defined(NDEBUG)
 #define MEMORY_TRACKER_DEBUG_CHECKS
@@ -58,49 +60,70 @@ namespace DB
 class MemoryTracker
 {
 private:
-    std::atomic<Int64> amount {0};
-    std::atomic<Int64> peak {0};
-    std::atomic<Int64> soft_limit {0};
-    std::atomic<Int64> hard_limit {0};
-    std::atomic<Int64> profiler_limit {0};
+    /// Group fields by access pattern onto separate cache lines to avoid false sharing.
+    /// Anonymous nested structs are a GNU/Clang extension; suppress the pedantic warning.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-anonymous-struct"
+#pragma clang diagnostic ignored "-Wnested-anon-types"
 
-    std::atomic<Int64> rss{0};
+    /// Hot writes: updated on every alloc/free flush. Isolated on their own cache line
+    /// so that flushes from any core do not invalidate the read-mostly line below.
+    struct
+    {
+        alignas(DB::CH_CACHE_LINE_SIZE) std::atomic<Int64> amount {0};
+        std::atomic<Int64> peak {0};
+        std::atomic<Int64> rss {0};
+    };
 
-    Int64 profiler_step = 0;
+    /// Read-mostly: read on every alloc to enforce caps and walk the tracker chain,
+    /// but written rarely (set once at construction or via configuration changes).
+    struct
+    {
+        alignas(DB::CH_CACHE_LINE_SIZE) std::atomic<Int64> soft_limit {0};
+        std::atomic<Int64> hard_limit {0};
+        std::atomic<Int64> profiler_limit {0};
 
-    /// To test exception safety of calling code, memory tracker throws an exception on each memory allocation with specified probability.
-    std::atomic<double> fault_probability = 0;
+        /// Singly-linked list. All information will be passed to subsequent memory trackers also (it allows to implement trackers hierarchy).
+        /// In terms of tree nodes it is the list of parents. Lifetime of these trackers should "include" lifetime of current tracker.
+        std::atomic<MemoryTracker *> parent {};
 
-    /// To randomly sample allocations and deallocations in trace_log.
-    double sample_probability = -1;
+        /// You could specify custom metric to track memory usage.
+        std::atomic<CurrentMetrics::Metric> metric = CurrentMetrics::end();
 
-    /// Randomly sample allocations only larger or equal to this size
-    UInt64 min_allocation_size_bytes = 0;
+        /// This description will be used as prefix into log messages (if isn't nullptr)
+        std::atomic<const char *> description_ptr = nullptr;
+    };
 
-    /// Randomly sample allocations only smaller or equal to this size
-    UInt64 max_allocation_size_bytes = 0;
+    /// Cold: rarely-touched configuration / sampling parameters.
+    struct
+    {
+        Int64 profiler_step = 0;
 
-    UInt64 jemalloc_flush_profile_interval_bytes = 0;
-    bool jemalloc_flush_profile_on_memory_exceeded = false;
-    UInt64 jemalloc_flush_profile_on_memory_exceeded_interval_s = 0;
+        /// To test exception safety of calling code, memory tracker throws an exception on each memory allocation with specified probability.
+        std::atomic<double> fault_probability = 0;
 
-    /// Singly-linked list. All information will be passed to subsequent memory trackers also (it allows to implement trackers hierarchy).
-    /// In terms of tree nodes it is the list of parents. Lifetime of these trackers should "include" lifetime of current tracker.
-    std::atomic<MemoryTracker *> parent {};
+        /// To randomly sample allocations and deallocations in trace_log.
+        double sample_probability = -1;
 
-    /// You could specify custom metric to track memory usage.
-    std::atomic<CurrentMetrics::Metric> metric = CurrentMetrics::end();
+        /// Randomly sample allocations only larger or equal to this size
+        UInt64 min_allocation_size_bytes = 0;
 
-    /// This description will be used as prefix into log messages (if isn't nullptr)
-    std::atomic<const char *> description_ptr = nullptr;
+        /// Randomly sample allocations only smaller or equal to this size
+        UInt64 max_allocation_size_bytes = 0;
 
-    std::atomic<std::chrono::microseconds> max_wait_time;
+        UInt64 jemalloc_flush_profile_interval_bytes = 0;
+        bool jemalloc_flush_profile_on_memory_exceeded = false;
+        UInt64 jemalloc_flush_profile_on_memory_exceeded_interval_s = 0;
 
-    std::atomic<OvercommitTracker *> overcommit_tracker = nullptr;
+        std::atomic<std::chrono::microseconds> max_wait_time;
 
-    std::atomic<DB::PageCache *> page_cache = nullptr;
+        std::atomic<OvercommitTracker *> overcommit_tracker = nullptr;
 
-    bool log_peak_memory_usage_in_destructor = true;
+        std::atomic<DB::PageCache *> page_cache = nullptr;
+
+        bool log_peak_memory_usage_in_destructor = true;
+    };
+#pragma clang diagnostic pop
 
     bool updatePeak(Int64 will_be, bool log_memory_usage);
     void logMemoryUsage(Int64 current) const;
@@ -307,6 +330,7 @@ public:
     /// Prints info about peak memory consumption into log.
     void logPeakMemoryUsage();
 };
+static_assert(std::alignment_of_v<MemoryTracker> == DB::CH_CACHE_LINE_SIZE);
 
 extern MemoryTracker total_memory_tracker;
 extern MemoryTracker background_memory_tracker;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Optimize MemoryTracker layout (improves performance of it ~25%)

<details>

<summary>Results</summary>

```sql
# tests/performance/group_by_multiple_strings.xml
$ clickhouse-benchmark -i 100 -q "select key1_8, key2_8, sum(value) from test_group_by_strings group by key1_8, key2_8 format Null settings max_threads = 32, query_profiler_cpu_time_period_ns=0, query_profiler_real_time_period_ns=0, memory_profiler_step=0, memory_profiler_sample_probability=0, max_untracked_memory='0'"

# before
Queries executed: 97 (97%).

localhost:9000, queries: 24, QPS: 23.728, RPS: 71183368.874, MiB/s: 2036.573, result RPS: 0.000, result MiB/s: 0.000.

0%              0.038 sec.
10%             0.039 sec.
20%             0.041 sec.
30%             0.041 sec.
40%             0.041 sec.
50%             0.042 sec.
60%             0.042 sec.
70%             0.042 sec.
80%             0.042 sec.
90%             0.043 sec.
95%             0.043 sec.
99%             0.043 sec.
99.9%           0.043 sec.
99.99%          0.043 sec.

# after
Queries executed: 100 (100%).

localhost:9000, queries: 100, QPS: 27.094, RPS: 81282582.316, MiB/s: 2325.513, result RPS: 0.000, result MiB/s: 0.000.

0%              0.032 sec.
10%             0.033 sec.
20%             0.034 sec.
30%             0.034 sec.
40%             0.034 sec.
50%             0.035 sec.
60%             0.035 sec.
70%             0.036 sec.
80%             0.036 sec.
90%             0.036 sec.
95%             0.037 sec.
99%             0.039 sec.
99.9%           0.041 sec.
99.99%          0.041 sec.
```

</details>