### PR TITLE
Fix maxMappedArrays documentation output

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionSumMap.cpp
+++ b/src/AggregateFunctions/AggregateFunctionSumMap.cpp
@@ -924,9 +924,9 @@ SELECT maxMappedArrays(a, b)
 FROM VALUES('a Array(Char), b Array(Int64)', (['x', 'y'], [2, 2]), (['y', 'z'], [3, 1]));
         )",
         R"(
-┌─maxMappedArrays(a, b)────────────────┐
-│ [['x', 'y', 'z'], [2, 3, 1]].        │
-└──────────────────────────────────────┘
+┌─maxMappedArrays(a, b)───┐
+│ (['x','y','z'],[2,3,1]) │
+└─────────────────────────┘
         )"
     }
     };


### PR DESCRIPTION
The `maxMappedArrays` in-source documentation example showed the result as a nested array and included a trailing period. The function returns a tuple of arrays, so the example output is now updated to match the actual result format.

Closes #103061

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Documentation change only.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.549`
<!-- ch-version-info:end -->