### PR TITLE
Tag 01114_database_atomic as long to avoid flaky-check 180s cap

### DIFF
--- a/tests/queries/0_stateless/01114_database_atomic.sh
+++ b/tests/queries/0_stateless/01114_database_atomic.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 # Tags: no-fasttest, no-azure-blob-storage, long
 # Tag no-fasttest: 45 seconds running
-# Tag long: the test has intentional `sleepEachRow` calls; under sanitizer/coverage builds the
-# total duration can exceed 180s (CIDB p95 on `amd_tsan, parallel` is ~356s), which triggers
-# the `clickhouse-test` flaky-check `TEST_MAX_RUN_TIME_IN_SECONDS` cap — the `long` tag
-# exempts the test from that cap.
+# Tag long: the test uses background `sleepEachRow` queries (~66s of parallel sleeps and
+# a ~20s tuple sleep) as a timing floor, but the wall-clock duration is dominated by the
+# concurrent DDL (`CREATE`/`DROP`/`RENAME`/`EXCHANGE`) on `Atomic` databases running on
+# top of those sleeps. The DDL path is instrumented under ASan/TSan/MSan and coverage
+# builds, so the whole test can exceed 180s (CIDB p95 on `amd_tsan, parallel` is ~356s),
+# which trips the `clickhouse-test` flaky-check `TEST_MAX_RUN_TIME_IN_SECONDS = 180s` cap;
+# the `long` tag exempts the test from that cap. The `sleepEachRow` calls themselves are
+# wall-clock sleeps and are not sped up or slowed down by sanitizers.
 
 # Creation of a database with Ordinary engine emits a warning.
 CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=fatal

--- a/tests/queries/0_stateless/01114_database_atomic.sh
+++ b/tests/queries/0_stateless/01114_database_atomic.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-azure-blob-storage
+# Tags: no-fasttest, no-azure-blob-storage, long
 # Tag no-fasttest: 45 seconds running
+# Tag long: the test has intentional `sleepEachRow` calls; under sanitizer/coverage builds the
+# total duration can exceed 180s (CIDB p95 on `amd_tsan, parallel` is ~356s), which triggers
+# the `clickhouse-test` flaky-check `TEST_MAX_RUN_TIME_IN_SECONDS` cap — the `long` tag
+# exempts the test from that cap.
 
 # Creation of a database with Ordinary engine emits a warning.
 CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=fatal


### PR DESCRIPTION
Add the `long` tag to `tests/queries/0_stateless/01114_database_atomic.sh` so the flaky-check variant stops reporting false-positive `TOO_LONG` failures on it.

Motivation: the test uses background `sleepEachRow` queries (~66s of parallel sleeps + a ~20s tuple sleep) as a timing floor, but the wall-clock duration is dominated by concurrent DDL (`CREATE`/`DROP`/`RENAME`/`EXCHANGE`) on `Atomic` databases running on top of those sleeps. The DDL path is instrumented under ASan/TSan/MSan and coverage builds, so the whole test can exceed 180s — CIDB p95 on `amd_tsan, parallel` is ~356s. In flaky-check mode `tests/clickhouse-test` caps per-run duration at `TEST_MAX_RUN_TIME_IN_SECONDS = 180s`, so roughly 5% of flaky-check iterations fall above the cap and fail with `Reason: Test runs too long (> 180s). Make it faster.`. The `sleepEachRow` calls themselves are wall-clock sleeps and are not affected by sanitizers — only the surrounding DDL is.

CIDB shows this signature on `01114_database_atomic` in 150+ failures across 12+ unrelated PRs over the last 30 days, with zero master failures outside the flaky-check code path — it is a CI-classification issue, not a test-logic regression.

CIDB snapshot — typical `OK` run durations for `01114` (14-day window):

| Check | Median (ms) | P95 (ms) |
|---|---|---|
| `Stateless tests (amd_tsan, parallel, 2/2)` | 129421 | **355900** |
| `Stateless tests (amd_llvm_coverage, AsyncInsert, s3 storage, parallel)` | 174232 | **343610** |
| `Stateless tests (amd_debug, distributed plan, s3 storage, parallel)` | 257250 | **339990** |
| `Stateless tests (arm_binary, parallel)` | 141506 | **336270** |
| `Stateless tests (amd_debug, parallel)` | 95932 | **334296** |
| `Stateless tests (amd_tsan, flaky check)` | 83052 | 86660 |
| `Stateless tests (amd_debug, flaky check)` | 73770 | 75453 |

Every observed failure has `test_duration_ms ≈ 345–356s` — the test is killed shortly after hitting the 180s cap.

`tests/clickhouse-test` already honours the `long` tag to skip the flaky-check 180s cap:

```python
if (
    self.testcase_args.test_runs > 1
    and self.testcase_args.flaky_check
    and total_time > TEST_MAX_RUN_TIME_IN_SECONDS
    and "long" not in self.tags
):
    return TestResult(..., FailureReason.TOO_LONG, ...)
```

Effects of adding `long`:
- Flaky-check / targeted check: no longer fires `TOO_LONG`; real flakiness is still detectable because the 50× runs continue normally.
- Regular stateless tests: unchanged — the cap only applies with `--flaky-check`.
- Per-test LLVM coverage: unchanged — that variant does not pass `--no-long`.
- Non-per-test LLVM coverage variants: skip the test, because those variants call `tests/clickhouse-test --no-long`. These variants already see p95 ~340s on OK runs and provide no incremental diagnostic signal for `01114` — the skip is a minor, acceptable loss (coverage for the atomic-database path still runs in all non-coverage variants and in per-test coverage).

Local verification on a debug build (latest master):

- `tests/clickhouse-test 01114_database_atomic` → OK, 68.60s (with randomisation)
- `tests/clickhouse-test --no-random-settings --no-random-merge-tree-settings 01114_database_atomic` → OK, 67.75s
- `tests/clickhouse-test --no-long 01114_database_atomic` → SKIPPED ("not running long tests") — confirms the tag is recognised

Reference output is unchanged; the diff is tags + documentation only.

### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Test-only change — no user-facing effect. Changelog entry is not required for this category.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.54`
<!-- ch-version-info:end -->