### PR TITLE
Fix flaky test 02818_memory_profiler_sample_min_max_allocation_size on amd_llvm_coverage

### DIFF
--- a/tests/queries/0_stateless/02818_memory_profiler_sample_min_max_allocation_size.sh
+++ b/tests/queries/0_stateless/02818_memory_profiler_sample_min_max_allocation_size.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-asan, no-ubsan, no-msan, no-random-settings
+# Tags: no-tsan, no-asan, no-ubsan, no-msan, no-random-settings, no-llvm-coverage
+# no-llvm-coverage: LLVM source-based coverage instrumentation makes the server ~3-5x slower,
+# which causes `SystemLogQueue<TraceLogElement>` flushes to exceed the 180s server-side deadline
+# when the test emits `MemorySample` trace rows with `memory_profiler_sample_probability = 1`.
+# The resulting stderr `Code: 159 TIMEOUT_EXCEEDED` contaminates the reference output.
+# Same pattern as sibling coverage fixes (#103287, #103288, #103293, #103298, #103226, #103219).
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
Add `no-llvm-coverage` tag to `02818_memory_profiler_sample_min_max_allocation_size`. Under LLVM source-based coverage instrumentation the server is ~3-5x slower, and this test runs with `memory_profiler_sample_probability = 1` which emits many `MemorySample` trace rows. The server-side `SystemLogQueue<TraceLogElement>` flush then routinely exceeds its 180s deadline, emitting `Code: 159 TIMEOUT_EXCEEDED` into stderr and causing the `clickhouse-test` stderr-empty check to report the test as `FAIL` even when the assertion output itself is correct.

CIDB evidence (30 days):
- 34 failures, 25+ distinct unrelated PRs, 4 master hits — all on `amd_llvm_coverage` variants only (`1/3`, `ParallelReplicas+s3+parallel`, `AsyncInsert+s3+parallel`).
- Zero failures on debug, asan_ubsan, tsan, msan, release, binary builds in the same window.
- Health check: in the last 7 days the test has 657–706 OK runs on each of the 4 coverage variants — so it passes most of the time; the 180s deadline is a rare stochastic trip.

All 30-day failures show the same stderr signature:
```
Code: 159. DB::Exception: Timeout exceeded (180 s) while flushing system log 'DB::SystemLogQueue<DB::TraceLogElement>'. (TIMEOUT_EXCEEDED)
```

Same pattern and fix as the recent sibling coverage flakes: #103287, #103288, #103293, #103298, #103226, #103219.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.51`
<!-- ch-version-info:end -->