### PR TITLE
Fix is_arm() to actually detect ARM hosts

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -6218,4 +6218,4 @@ class ClickHouseKiller(object):
 
 @cache
 def is_arm():
-    return any(arch in platform.processor().lower() for arch in ("arm, aarch"))
+    return platform.machine().lower() in ("arm64", "aarch64")


### PR DESCRIPTION
The `is_arm` helper in `tests/integration/helpers/cluster.py` was:

```python
return any(arch in platform.processor().lower() for arch in ("arm, aarch"))
```

`("arm, aarch")` is a single string, not a tuple, so the generator iterates character-by-character (`'a'`, `'r'`, `'m'`, `','`, ` '`, ...) and checks each single character against `platform.processor().lower()`. It never matches real arch names like `aarch64`, and on many Linux hosts `platform.processor()` is empty anyway, so `is_arm` effectively always returned a meaningless value.

Replace with `platform.machine().lower() in ("arm64", "aarch64")`, which reliably returns `aarch64` on Linux arm64 and `arm64` on macOS Apple Silicon.

Spotted by `clickhouse-gh[bot]` while reviewing #103248:
https://github.com/ClickHouse/ClickHouse/pull/103248#discussion_r3137306555

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)