### PR TITLE
Remove unused is_arm imports from integration tests

### DIFF
--- a/tests/integration/test_allowed_url_from_config/test.py
+++ b/tests/integration/test_allowed_url_from_config/test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from helpers.cluster import ClickHouseCluster, is_arm
+from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 node1 = cluster.add_instance("node1", main_configs=["configs/config_with_hosts.xml"])

--- a/tests/integration/test_database_glue/test.py
+++ b/tests/integration/test_database_glue/test.py
@@ -29,7 +29,7 @@ from pyiceberg.types import (
     DecimalType,
 )
 
-from helpers.cluster import ClickHouseCluster, ClickHouseInstance, is_arm
+from helpers.cluster import ClickHouseCluster, ClickHouseInstance
 from helpers.mock_servers import start_mock_servers
 
 import boto3

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -28,7 +28,7 @@ from pyiceberg.types import (
     TimestamptzType
 )
 
-from helpers.cluster import ClickHouseCluster, ClickHouseInstance, is_arm
+from helpers.cluster import ClickHouseCluster, ClickHouseInstance
 from helpers.config_cluster import minio_secret_key, minio_access_key
 from helpers.s3_tools import get_file_contents, list_s3_objects, prepare_s3_bucket
 from helpers.test_tools import TSV, csv_compare

--- a/tests/integration/test_endpoint_macro_substitution/test.py
+++ b/tests/integration/test_endpoint_macro_substitution/test.py
@@ -1,6 +1,6 @@
 import pytest
 
-from helpers.cluster import ClickHouseCluster, is_arm
+from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import TSV
 
 disk_types = {

--- a/tests/integration/test_non_default_compression/test.py
+++ b/tests/integration/test_non_default_compression/test.py
@@ -3,7 +3,7 @@ import string
 
 import pytest
 
-from helpers.cluster import ClickHouseCluster, is_arm
+from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
 

--- a/tests/integration/test_storage_kafka/test_compression_codec.py
+++ b/tests/integration/test_storage_kafka/test_compression_codec.py
@@ -4,7 +4,7 @@ import logging
 
 import pytest
 
-from helpers.cluster import ClickHouseCluster, is_arm
+from helpers.cluster import ClickHouseCluster
 from helpers.kafka.common_direct import *
 import helpers.kafka.common as k
 from helpers.test_tools import TSV


### PR DESCRIPTION
Six integration-test modules import `is_arm` from `helpers.cluster` but never call it:

- `tests/integration/test_allowed_url_from_config/test.py`
- `tests/integration/test_database_iceberg/test.py`
- `tests/integration/test_database_glue/test.py`
- `tests/integration/test_non_default_compression/test.py`
- `tests/integration/test_endpoint_macro_substitution/test.py`
- `tests/integration/test_storage_kafka/test_compression_codec.py`

Noticed while auditing uses of `is_arm` after #103516.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)