### PR TITLE
Fix KQL parser depth and backtracks counter propagation

### DIFF
--- a/src/Parsers/IParser.h
+++ b/src/Parsers/IParser.h
@@ -118,6 +118,18 @@ public:
         {
         }
 
+        /// Construct a new Pos over different Tokens, inheriting depth/backtrack
+        /// counters and limits from an existing Pos. Use this when re-tokenizing
+        /// a sub-expression so that the overall recursion depth is preserved.
+        Pos(Tokens & tokens_, const Pos & inherit_from)
+            : TokenIterator(tokens_)
+            , depth(inherit_from.depth)
+            , max_depth(inherit_from.max_depth)
+            , backtracks(inherit_from.backtracks)
+            , max_backtracks(inherit_from.max_backtracks)
+        {
+        }
+
         ALWAYS_INLINE void increaseDepth()
         {
             ++depth;

--- a/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp
@@ -280,13 +280,13 @@ String IParserKQLFunction::getKQLFunctionName(IParser::Pos & pos)
 }
 
 String IParserKQLFunction::kqlCallToExpression(
-    const std::string_view function_name, const std::initializer_list<const std::string_view> params, uint32_t max_depth, uint32_t max_backtracks)
+    const std::string_view function_name, const std::initializer_list<const std::string_view> params, const IParser::Pos & parent_pos)
 {
-    return kqlCallToExpression(function_name, std::span(params), max_depth, max_backtracks);
+    return kqlCallToExpression(function_name, std::span(params), parent_pos);
 }
 
 String IParserKQLFunction::kqlCallToExpression(
-    const std::string_view function_name, const std::span<const std::string_view> params, uint32_t max_depth, uint32_t max_backtracks)
+    const std::string_view function_name, const std::span<const std::string_view> params, const IParser::Pos & parent_pos)
 {
     const auto params_str = std::accumulate(
         std::cbegin(params),
@@ -303,7 +303,7 @@ String IParserKQLFunction::kqlCallToExpression(
 
     const auto kql_call = fmt::format("{}({})", function_name, params_str);
     Tokens call_tokens(kql_call.data(), kql_call.data() + kql_call.length(), 0, true);
-    IParser::Pos tokens_pos(call_tokens, max_depth, max_backtracks);
+    IParser::Pos tokens_pos(call_tokens, parent_pos);
     return DB::IParserKQLFunction::getExpression(tokens_pos);
 }
 

--- a/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.h
+++ b/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.h
@@ -77,8 +77,8 @@ public:
     static std::optional<String>
     getOptionalArgument(const String & function_name, DB::IParser::Pos & pos, ArgumentState argument_state = ArgumentState::Parsed);
     static String
-    kqlCallToExpression(std::string_view function_name, std::initializer_list<const std::string_view> params, uint32_t max_depth, uint32_t max_backtracks);
-    static String kqlCallToExpression(std::string_view function_name, std::span<const std::string_view> params, uint32_t max_depth, uint32_t max_backtracks);
+    kqlCallToExpression(std::string_view function_name, std::initializer_list<const std::string_view> params, const IParser::Pos & parent_pos);
+    static String kqlCallToExpression(std::string_view function_name, std::span<const std::string_view> params, const IParser::Pos & parent_pos);
     static String escapeSingleQuotes(const String & input);
 
 protected:

--- a/src/Parsers/Kusto/KustoFunctions/KQLCastingFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLCastingFunctions.cpp
@@ -98,7 +98,7 @@ bool ToTimeSpan::convertImpl(String & out, IParser::Pos & pos)
         ++pos;
         try
         {
-            auto result = kqlCallToExpression("time", {arg}, pos.max_depth, pos.max_backtracks);
+            auto result = kqlCallToExpression("time", {arg}, pos);
             out = fmt::format("{}", result);
         }
         catch (const Exception &)

--- a/src/Parsers/Kusto/KustoFunctions/KQLDynamicFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLDynamicFunctions.cpp
@@ -94,7 +94,7 @@ bool ArrayRotateRight::convertImpl(String & out, IParser::Pos & pos)
 
     const auto array = getArgument(function_name, pos, ArgumentState::Raw);
     const auto count = getArgument(function_name, pos, ArgumentState::Raw);
-    out = kqlCallToExpression("array_rotate_left", {array, "-1 * " + count}, pos.max_depth, pos.max_backtracks);
+    out = kqlCallToExpression("array_rotate_left", {array, "-1 * " + count}, pos);
 
     return true;
 }
@@ -135,7 +135,7 @@ bool ArrayShiftRight::convertImpl(String & out, IParser::Pos & pos)
         "array_shift_left",
         fill ? std::initializer_list<std::string_view>{array, negated_count, *fill}
              : std::initializer_list<std::string_view>{array, negated_count},
-        pos.max_depth, pos.max_backtracks);
+        pos);
 
     return true;
 }
@@ -228,8 +228,8 @@ bool JaccardIndex::convertImpl(String & out, IParser::Pos & pos)
     const auto rhs = getArgument(function_name, pos, ArgumentState::Raw);
     out = fmt::format(
         "divide(length({0}), length({1}))",
-        kqlCallToExpression("set_intersect", {lhs, rhs}, pos.max_depth, pos.max_backtracks),
-        kqlCallToExpression("set_union", {lhs, rhs}, pos.max_depth, pos.max_backtracks));
+        kqlCallToExpression("set_intersect", {lhs, rhs}, pos),
+        kqlCallToExpression("set_union", {lhs, rhs}, pos));
 
     return true;
 }
@@ -286,7 +286,7 @@ bool SetDifference::convertImpl(String & out, IParser::Pos & pos)
             while (auto next_array = getOptionalArgument(function_name, pos, ArgumentState::Raw))
                 arrays.push_back(*next_array);
 
-            return kqlCallToExpression("set_union", std::vector<std::string_view>(arrays.cbegin(), arrays.cend()), pos.max_depth, pos.max_backtracks);
+            return kqlCallToExpression("set_union", std::vector<std::string_view>(arrays.cbegin(), arrays.cend()), pos);
         });
 
     out = fmt::format("arrayFilter(x -> not has({1}, x), arrayDistinct({0}))", lhs, rhs);

--- a/src/Parsers/Kusto/KustoFunctions/KQLIPFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLIPFunctions.cpp
@@ -34,10 +34,10 @@ bool Ipv4Compare::convertImpl(String & out, IParser::Pos & pos)
         "sign(IPv4StringToNumOrNull(toString((tupleElement(IPv4CIDRToRange(assumeNotNull(lhs_ip_{5}), "
         "toUInt8(min2({4}, min2(assumeNotNull(lhs_mask_{5}), assumeNotNull(rhs_mask_{5})))) as mask_{5}), 1))))"
         "   - IPv4StringToNumOrNull(toString((tupleElement(IPv4CIDRToRange(assumeNotNull(rhs_ip_{5}), mask_{5}), 1))))))",
-        kqlCallToExpression("parse_ipv4", {lhs}, pos.max_depth, pos.max_backtracks),
-        kqlCallToExpression("ipv4_netmask_suffix", {lhs}, pos.max_depth, pos.max_backtracks),
-        kqlCallToExpression("parse_ipv4", {rhs}, pos.max_depth, pos.max_backtracks),
-        kqlCallToExpression("ipv4_netmask_suffix", {rhs}, pos.max_depth, pos.max_backtracks),
+        kqlCallToExpression("parse_ipv4", {lhs}, pos),
+        kqlCallToExpression("ipv4_netmask_suffix", {lhs}, pos),
+        kqlCallToExpression("parse_ipv4", {rhs}, pos),
+        kqlCallToExpression("ipv4_netmask_suffix", {rhs}, pos),
         mask ? *mask : "32",
         generateUniqueIdentifier());
     return true;
@@ -56,8 +56,8 @@ bool Ipv4IsInRange::convertImpl(String & out, IParser::Pos & pos)
         "or isNull({1} as range_start_ip_{3}) or isNull({2} as range_mask_{3}), null, "
         "bitXor(range_start_ip_{3}, bitAnd(ip_{3}, bitNot(toUInt32(intExp2(toInt32(32 - range_mask_{3})) - 1)))) = 0) ",
         ip_address,
-        kqlCallToExpression("parse_ipv4", {ip_range}, pos.max_depth, pos.max_backtracks),
-        kqlCallToExpression("ipv4_netmask_suffix", {ip_range}, pos.max_depth, pos.max_backtracks),
+        kqlCallToExpression("parse_ipv4", {ip_range}, pos),
+        kqlCallToExpression("ipv4_netmask_suffix", {ip_range}, pos),
         generateUniqueIdentifier());
     return true;
 }
@@ -71,7 +71,7 @@ bool Ipv4IsMatch::convertImpl(String & out, IParser::Pos & pos)
     const auto lhs = getArgument(function_name, pos, ArgumentState::Raw);
     const auto rhs = getArgument(function_name, pos, ArgumentState::Raw);
     const auto mask = getOptionalArgument(function_name, pos, ArgumentState::Raw);
-    out = fmt::format("equals({}, 0)", kqlCallToExpression("ipv4_compare", {lhs, rhs, mask ? *mask : "32"}, pos.max_depth, pos.max_backtracks));
+    out = fmt::format("equals({}, 0)", kqlCallToExpression("ipv4_compare", {lhs, rhs, mask ? *mask : "32"}, pos));
     return true;
 }
 
@@ -196,7 +196,7 @@ bool Ipv6IsMatch::convertImpl(String & out, IParser::Pos & pos)
     const auto lhs = getArgument(function_name, pos, ArgumentState::Raw);
     const auto rhs = getArgument(function_name, pos, ArgumentState::Raw);
     const auto mask = getOptionalArgument(function_name, pos, ArgumentState::Raw);
-    out = fmt::format("equals({}, 0)", kqlCallToExpression("ipv6_compare", {lhs, rhs, mask ? *mask : "128"}, pos.max_depth, pos.max_backtracks));
+    out = fmt::format("equals({}, 0)", kqlCallToExpression("ipv6_compare", {lhs, rhs, mask ? *mask : "128"}, pos));
     return true;
 }
 
@@ -228,9 +228,9 @@ bool ParseIpv6Mask::convertImpl(String & out, IParser::Pos & pos)
     const auto unique_identifier = generateUniqueIdentifier();
     out = fmt::format(
         "if(empty({0} as ipv4_{3}), {1}, {2})",
-        kqlCallToExpression("format_ipv4", {"trim_start('::', " + ip_address + ")", mask + " - 96"}, pos.max_depth, pos.max_backtracks),
-        kqlCallToExpression("parse_ipv6", {"strcat(tostring(parse_ipv6(" + ip_address + ")), '/', tostring(" + mask + "))"}, pos.max_depth, pos.max_backtracks),
-        kqlCallToExpression("parse_ipv6", {"ipv4_" + unique_identifier}, pos.max_depth, pos.max_backtracks),
+        kqlCallToExpression("format_ipv4", {"trim_start('::', " + ip_address + ")", mask + " - 96"}, pos),
+        kqlCallToExpression("parse_ipv6", {"strcat(tostring(parse_ipv6(" + ip_address + ")), '/', tostring(" + mask + "))"}, pos),
+        kqlCallToExpression("parse_ipv6", {"ipv4_" + unique_identifier}, pos),
         unique_identifier);
     return true;
 }
@@ -247,9 +247,9 @@ bool FormatIpv4::convertImpl(String & out, IParser::Pos & pos)
         "ifNull(if(isNotNull(toUInt32OrNull(toString({0})) as param_as_uint32_{3}) and toTypeName({0}) = 'String' or ({1}) < 0 "
         "or isNull(ifNull(param_as_uint32_{3}, {2}) as ip_as_number_{3}), null, "
         "IPv4NumToString(bitAnd(ip_as_number_{3}, bitNot(toUInt32(intExp2(toInt32(32 - ({1}))) - 1))))), '')",
-        ParserKQLBase::getExprFromToken(ip_address, pos.max_depth, pos.max_backtracks),
+        ParserKQLBase::getExprFromToken(ip_address, pos),
         mask ? *mask : "32",
-        kqlCallToExpression("parse_ipv4", {"tostring(" + ip_address + ")"}, pos.max_depth, pos.max_backtracks),
+        kqlCallToExpression("parse_ipv4", {"tostring(" + ip_address + ")"}, pos),
         generateUniqueIdentifier());
     return true;
 }
@@ -266,10 +266,10 @@ bool FormatIpv4Mask::convertImpl(String & out, IParser::Pos & pos)
     out = fmt::format(
         "if(empty({1} as formatted_ip_{2}) or position(toTypeName({0}), 'Int') = 0 or not {0} between 0 and 32, '', "
         "concat(formatted_ip_{2}, '/', toString(toInt64(min2({0}, ifNull({3} as suffix_{2}, 32))))))",
-        ParserKQLBase::getExprFromToken(calculated_mask, pos.max_depth, pos.max_backtracks),
-        kqlCallToExpression("format_ipv4", {ip_address, calculated_mask}, pos.max_depth, pos.max_backtracks),
+        ParserKQLBase::getExprFromToken(calculated_mask, pos),
+        kqlCallToExpression("format_ipv4", {ip_address, calculated_mask}, pos),
         generateUniqueIdentifier(),
-        kqlCallToExpression("ipv4_netmask_suffix", {"tostring(" + ip_address + ")"}, pos.max_depth, pos.max_backtracks));
+        kqlCallToExpression("ipv4_netmask_suffix", {"tostring(" + ip_address + ")"}, pos));
     return true;
 }
 }

--- a/src/Parsers/Kusto/KustoFunctions/KQLStringFunctions.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/KQLStringFunctions.cpp
@@ -454,7 +454,7 @@ bool ParseJSON::convertImpl(String & out, IParser::Pos & pos)
     {
         --pos;
         auto arg = getArgument(fn_name, pos);
-        auto result = kqlCallToExpression("dynamic", {arg}, pos.max_depth, pos.max_backtracks);
+        auto result = kqlCallToExpression("dynamic", {arg}, pos);
         out = fmt::format("{}", result);
     }
     else
@@ -740,7 +740,7 @@ bool Trim::convertImpl(String & out, IParser::Pos & pos)
 
     const auto regex = getArgument(fn_name, pos, ArgumentState::Raw);
     const auto source = getArgument(fn_name, pos, ArgumentState::Raw);
-    out = kqlCallToExpression("trim_start", {regex, fmt::format("trim_end({0}, {1})", regex, source)}, pos.max_depth, pos.max_backtracks);
+    out = kqlCallToExpression("trim_start", {regex, fmt::format("trim_end({0}, {1})", regex, source)}, pos);
 
     return true;
 }

--- a/src/Parsers/Kusto/ParserKQLDistinct.cpp
+++ b/src/Parsers/Kusto/ParserKQLDistinct.cpp
@@ -12,7 +12,7 @@ bool ParserKQLDistinct::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     expr = getExprFromToken(pos);
 
     Tokens tokens(expr.data(), expr.data() + expr.size(), 0, true);
-    IParser::Pos new_pos(tokens, pos.max_depth, pos.max_backtracks);
+    IParser::Pos new_pos(tokens, pos);
 
     if (!ParserNotEmptyExpressionList(false).parse(new_pos, select_expression_list, expected))
         return false;

--- a/src/Parsers/Kusto/ParserKQLExtend.cpp
+++ b/src/Parsers/Kusto/ParserKQLExtend.cpp
@@ -16,7 +16,7 @@ bool ParserKQLExtend ::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     String except_str;
     String new_extend_str;
     Tokens ntokens(extend_expr.data(), extend_expr.data() + extend_expr.size(), 0, true);
-    IParser::Pos npos(ntokens, pos.max_depth, pos.max_backtracks);
+    IParser::Pos npos(ntokens, pos);
 
     String alias;
 
@@ -70,7 +70,7 @@ bool ParserKQLExtend ::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
     String expr = fmt::format("SELECT * {}, {} from prev", except_str, new_extend_str);
     Tokens tokens(expr.data(), expr.data() + expr.size(), 0, true);
-    IParser::Pos new_pos(tokens, pos.max_depth, pos.max_backtracks);
+    IParser::Pos new_pos(tokens, pos);
 
     if (!ParserSelectQuery().parse(new_pos, select_query, expected))
         return false;

--- a/src/Parsers/Kusto/ParserKQLFilter.cpp
+++ b/src/Parsers/Kusto/ParserKQLFilter.cpp
@@ -14,7 +14,7 @@ bool ParserKQLFilter::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     ASTPtr where_expression;
 
     Tokens token_filter(expr.data(), expr.data() + expr.size(), 0, true);
-    IParser::Pos pos_filter(token_filter, pos.max_depth, pos.max_backtracks);
+    IParser::Pos pos_filter(token_filter, pos);
     if (!ParserExpressionWithOptionalAlias(false).parse(pos_filter, where_expression, expected))
         return false;
 

--- a/src/Parsers/Kusto/ParserKQLLimit.cpp
+++ b/src/Parsers/Kusto/ParserKQLLimit.cpp
@@ -14,7 +14,7 @@ bool ParserKQLLimit::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     auto expr = getExprFromToken(pos);
 
     Tokens tokens(expr.data(), expr.data() + expr.size(), 0, true);
-    IParser::Pos new_pos(tokens, pos.max_depth, pos.max_backtracks);
+    IParser::Pos new_pos(tokens, pos);
 
     if (!ParserExpressionWithOptionalAlias(false).parse(new_pos, limit_length, expected))
         return false;

--- a/src/Parsers/Kusto/ParserKQLMVExpand.cpp
+++ b/src/Parsers/Kusto/ParserKQLMVExpand.cpp
@@ -70,7 +70,7 @@ bool ParserKQLMVExpand::parseColumnArrayExprs(ColumnArrayExprs & column_array_ex
 
         auto add_columns = [&]
         {
-            column_array_expr = getExprFromToken(String(expr_begin_pos->begin, expr_end_pos->end), pos.max_depth, pos.max_backtracks);
+            column_array_expr = getExprFromToken(String(expr_begin_pos->begin, expr_end_pos->end), pos);
 
             if (alias.empty())
             {
@@ -190,7 +190,7 @@ bool ParserKQLMVExpand::parserMVExpand(KQLMVExpand & kql_mv_expand, Pos & pos, E
     return true;
 }
 
-bool ParserKQLMVExpand::genQuery(KQLMVExpand & kql_mv_expand, ASTPtr & select_node, uint32_t max_depth, uint32_t max_backtracks)
+bool ParserKQLMVExpand::genQuery(KQLMVExpand & kql_mv_expand, ASTPtr & select_node, const Pos & parent_pos)
 {
     String expand_str;
     String cast_type_column_remove;
@@ -256,7 +256,7 @@ bool ParserKQLMVExpand::genQuery(KQLMVExpand & kql_mv_expand, ASTPtr & select_no
     if (cast_type_column_remove.empty())
     {
         query = fmt::format("Select {} {} From {} {}", columns, extra_columns, input, expand_str);
-        if (!parseSQLQueryByString(std::make_unique<ParserSelectQuery>(), query, sub_query_node, max_depth, max_backtracks))
+        if (!parseSQLQueryByString(std::make_unique<ParserSelectQuery>(), query, sub_query_node, parent_pos))
             return false;
         if (!setSubQuerySource(sub_query_node, select_node, false, false))
             return false;
@@ -265,14 +265,14 @@ bool ParserKQLMVExpand::genQuery(KQLMVExpand & kql_mv_expand, ASTPtr & select_no
     else
     {
         query = fmt::format("(Select {} {} From {} {})", columns, extra_columns, input, expand_str);
-        if (!parseSQLQueryByString(std::make_unique<ParserTablesInSelectQuery>(), query, sub_query_node, max_depth, max_backtracks))
+        if (!parseSQLQueryByString(std::make_unique<ParserTablesInSelectQuery>(), query, sub_query_node, parent_pos))
             return false;
         if (!setSubQuerySource(sub_query_node, select_node, true, false))
             return false;
         select_node = std::move(sub_query_node);
 
         auto rename_query = fmt::format("(Select * {}, {} From {})", cast_type_column_remove, cast_type_column_rename, "query");
-        if (!parseSQLQueryByString(std::make_unique<ParserTablesInSelectQuery>(), rename_query, sub_query_node, max_depth, max_backtracks))
+        if (!parseSQLQueryByString(std::make_unique<ParserTablesInSelectQuery>(), rename_query, sub_query_node, parent_pos))
             return false;
         if (!setSubQuerySource(sub_query_node, select_node, true, true))
             return false;
@@ -280,7 +280,7 @@ bool ParserKQLMVExpand::genQuery(KQLMVExpand & kql_mv_expand, ASTPtr & select_no
         select_node = std::move(sub_query_node);
         query = fmt::format("Select * {}, {} from {}", cast_type_column_restore, cast_type_column_restore_name, "rename_query");
 
-        if (!parseSQLQueryByString(std::make_unique<ParserSelectQuery>(), query, sub_query_node, max_depth, max_backtracks))
+        if (!parseSQLQueryByString(std::make_unique<ParserSelectQuery>(), query, sub_query_node, parent_pos))
             return false;
         sub_query_node->as<ASTSelectQuery>()->setExpression(ASTSelectQuery::Expression::TABLES, std::move(select_node));
         select_node = std::move(sub_query_node);
@@ -297,12 +297,12 @@ bool ParserKQLMVExpand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     KQLMVExpand kql_mv_expand;
     if (!parserMVExpand(kql_mv_expand, pos, expected))
         return false;
-    if (!genQuery(kql_mv_expand, node, pos.max_depth, pos.max_backtracks))
+    if (!genQuery(kql_mv_expand, node, pos))
         return false;
 
     const String setting_str = "enable_unaligned_array_join = 1";
     Tokens token_settings(setting_str.data(), setting_str.data() + setting_str.size(), 0, true);
-    IParser::Pos pos_settings(token_settings, pos.max_depth, pos.max_backtracks);
+    IParser::Pos pos_settings(token_settings, pos);
 
     if (!ParserSetQuery(true).parse(pos_settings, setting, expected))
         return false;

--- a/src/Parsers/Kusto/ParserKQLMVExpand.h
+++ b/src/Parsers/Kusto/ParserKQLMVExpand.h
@@ -33,7 +33,7 @@ protected:
 
     static bool parseColumnArrayExprs(ColumnArrayExprs & column_array_exprs, Pos & pos, Expected & expected);
     static bool parserMVExpand(KQLMVExpand & kql_mv_expand, Pos & pos, Expected & expected);
-    static bool genQuery(KQLMVExpand & kql_mv_expand, ASTPtr & select_node, uint32_t max_depth, uint32_t max_backtracks);
+    static bool genQuery(KQLMVExpand & kql_mv_expand, ASTPtr & select_node, const Pos & parent_pos);
 
     const char * getName() const override { return "KQL mv-expand"; }
     bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override;

--- a/src/Parsers/Kusto/ParserKQLMakeSeries.cpp
+++ b/src/Parsers/Kusto/ParserKQLMakeSeries.cpp
@@ -143,7 +143,7 @@ bool ParserKQLMakeSeries ::parseFromToStepClause(FromToStepClause & from_to_step
         || ParserKQLDateTypeTimespan().parseConstKQLTimespan(from_to_step.step_str))
     {
         from_to_step.is_timespan = true;
-        from_to_step.step = std::stod(getExprFromToken(from_to_step.step_str, pos.max_depth, pos.max_backtracks));
+        from_to_step.step = std::stod(getExprFromToken(from_to_step.step_str, pos));
     }
     else
         from_to_step.step = std::stod(from_to_step.step_str);
@@ -151,7 +151,7 @@ bool ParserKQLMakeSeries ::parseFromToStepClause(FromToStepClause & from_to_step
     return true;
 }
 
-bool ParserKQLMakeSeries ::makeSeries(KQLMakeSeries & kql_make_series, ASTPtr & select_node, uint32_t max_depth, uint32_t max_backtracks)
+bool ParserKQLMakeSeries ::makeSeries(KQLMakeSeries & kql_make_series, ASTPtr & select_node, const Pos & parent_pos)
 {
     const uint64_t era_diff
         = 62135596800; // this magic number is the differicen is second form 0001-01-01 (Azure start time ) and 1970-01-01 (CH start time)
@@ -169,15 +169,15 @@ bool ParserKQLMakeSeries ::makeSeries(KQLMakeSeries & kql_make_series, ASTPtr & 
     auto step = from_to_step.step;
 
     if (!kql_make_series.from_to_step.from_str.empty())
-        start_str = getExprFromToken(kql_make_series.from_to_step.from_str, max_depth, max_backtracks);
+        start_str = getExprFromToken(kql_make_series.from_to_step.from_str, parent_pos);
 
     if (!kql_make_series.from_to_step.to_str.empty())
-        end_str = getExprFromToken(from_to_step.to_str, max_depth, max_backtracks);
+        end_str = getExprFromToken(from_to_step.to_str, parent_pos);
 
     auto date_type_cast = [&](String & src)
     {
         Tokens tokens(src.data(), src.data() + src.size(), 0, true);
-        IParser::Pos pos(tokens, max_depth, max_backtracks);
+        IParser::Pos pos(tokens, parent_pos);
         String res;
         while (isValidKQLPos(pos))
         {
@@ -206,7 +206,7 @@ bool ParserKQLMakeSeries ::makeSeries(KQLMakeSeries & kql_make_series, ASTPtr & 
     {
         std::vector<String> group_expression_tokens;
         Tokens tokens(group_expression.data(), group_expression.data() + group_expression.size(), 0, true);
-        IParser::Pos pos(tokens, max_depth, max_backtracks);
+        IParser::Pos pos(tokens, parent_pos);
         while (isValidKQLPos(pos))
         {
             if (String(pos->begin, pos->end) == "AS")
@@ -302,7 +302,7 @@ bool ParserKQLMakeSeries ::makeSeries(KQLMakeSeries & kql_make_series, ASTPtr & 
 
     ASTPtr sub_query_node;
 
-    if (!ParserSimpleCHSubquery(select_node).parseByString(sub_sub_query, sub_query_node, max_depth, max_backtracks))
+    if (!ParserSimpleCHSubquery(select_node).parseByString(sub_sub_query, sub_query_node, parent_pos))
         return false;
     select_node->as<ASTSelectQuery>()->setExpression(ASTSelectQuery::Expression::TABLES, std::move(sub_query_node));
 
@@ -357,7 +357,7 @@ bool ParserKQLMakeSeries ::makeSeries(KQLMakeSeries & kql_make_series, ASTPtr & 
     else
         main_query = fmt::format("{},{}", group_expression_alias, final_axis_agg_alias_list);
 
-    if (!ParserSimpleCHSubquery(select_node).parseByString(sub_query, sub_query_node, max_depth, max_backtracks))
+    if (!ParserSimpleCHSubquery(select_node).parseByString(sub_query, sub_query_node, parent_pos))
         return false;
     select_node->as<ASTSelectQuery>()->setExpression(ASTSelectQuery::Expression::TABLES, std::move(sub_query_node));
 
@@ -417,10 +417,10 @@ bool ParserKQLMakeSeries ::parseImpl(Pos & pos, ASTPtr & node, Expected & expect
             subquery_columns += ", " + column_str;
     }
 
-    makeSeries(kql_make_series, node, pos.max_depth, pos.max_backtracks);
+    makeSeries(kql_make_series, node, pos);
 
     Tokens token_main_query(kql_make_series.main_query.data(), kql_make_series.main_query.data() + kql_make_series.main_query.size(), 0, true);
-    IParser::Pos pos_main_query(token_main_query, pos.max_depth, pos.max_backtracks);
+    IParser::Pos pos_main_query(token_main_query, pos);
 
     if (!ParserNotEmptyExpressionList(true).parse(pos_main_query, select_expression_list, expected))
         return false;

--- a/src/Parsers/Kusto/ParserKQLMakeSeries.h
+++ b/src/Parsers/Kusto/ParserKQLMakeSeries.h
@@ -42,7 +42,7 @@ protected:
         String main_query;
     };
 
-    static bool makeSeries(KQLMakeSeries & kql_make_series, ASTPtr & select_node, uint32_t max_depth, uint32_t max_backtracks);
+    static bool makeSeries(KQLMakeSeries & kql_make_series, ASTPtr & select_node, const Pos & parent_pos);
     static bool parseAggregationColumns(AggregationColumns & aggregation_columns, Pos & pos);
     static bool parseFromToStepClause(FromToStepClause & from_to_step, Pos & pos);
 

--- a/src/Parsers/Kusto/ParserKQLPrint.cpp
+++ b/src/Parsers/Kusto/ParserKQLPrint.cpp
@@ -10,7 +10,7 @@ bool ParserKQLPrint::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     const String expr = getExprFromToken(pos);
 
     Tokens tokens(expr.data(), expr.data() + expr.size(), 0, true);
-    IParser::Pos new_pos(tokens, pos.max_depth, pos.max_backtracks);
+    IParser::Pos new_pos(tokens, pos);
 
     if (!ParserNotEmptyExpressionList(true).parse(new_pos, select_expression_list, expected))
         return false;

--- a/src/Parsers/Kusto/ParserKQLProject.cpp
+++ b/src/Parsers/Kusto/ParserKQLProject.cpp
@@ -12,7 +12,7 @@ bool ParserKQLProject ::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     expr = getExprFromToken(pos);
 
     Tokens tokens(expr.data(), expr.data() + expr.size(), 0, true);
-    IParser::Pos new_pos(tokens, pos.max_depth, pos.max_backtracks);
+    IParser::Pos new_pos(tokens, pos);
 
     if (!ParserNotEmptyExpressionList(false).parse(new_pos, select_expression_list, expected))
         return false;

--- a/src/Parsers/Kusto/ParserKQLQuery.cpp
+++ b/src/Parsers/Kusto/ParserKQLQuery.cpp
@@ -34,20 +34,20 @@ namespace ErrorCodes
     extern const int SYNTAX_ERROR;
 }
 
-bool ParserKQLBase::parseByString(String expr, ASTPtr & node, uint32_t max_depth, uint32_t max_backtracks)
+bool ParserKQLBase::parseByString(String expr, ASTPtr & node, const Pos & parent_pos)
 {
     Expected expected;
 
     Tokens tokens(expr.data(), expr.data() + expr.size(), 0, true);
-    IParser::Pos pos(tokens, max_depth, max_backtracks);
+    IParser::Pos pos(tokens, parent_pos);
     return parse(pos, node, expected);
 }
 
-bool ParserKQLBase::parseSQLQueryByString(ParserPtr && parser, String & query, ASTPtr & select_node, uint32_t max_depth, uint32_t max_backtracks)
+bool ParserKQLBase::parseSQLQueryByString(ParserPtr && parser, String & query, ASTPtr & select_node, const Pos & parent_pos)
 {
     Expected expected;
     Tokens token_subquery(query.data(), query.data() + query.size(), 0, true);
-    IParser::Pos pos_subquery(token_subquery, max_depth, max_backtracks);
+    IParser::Pos pos_subquery(token_subquery, parent_pos);
     if (!parser->parse(pos_subquery, select_node, expected))
         return false;
     return true;
@@ -122,10 +122,10 @@ bool ParserKQLBase::setSubQuerySource(ASTPtr & select_query, ASTPtr & source, bo
     return true;
 }
 
-String ParserKQLBase::getExprFromToken(const String & text, uint32_t max_depth, uint32_t max_backtracks)
+String ParserKQLBase::getExprFromToken(const String & text, const Pos & parent_pos)
 {
     Tokens tokens(text.data(), text.data() + text.size(), 0, true);
-    IParser::Pos pos(tokens, max_depth, max_backtracks);
+    IParser::Pos pos(tokens, parent_pos);
 
     return getExprFromToken(pos);
 }
@@ -526,7 +526,7 @@ bool ParserKQLQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
 
             String sub_query = fmt::format("({})", String(operation_pos.front().second->begin, last_pos->end));
             Tokens token_subquery(sub_query.data(), sub_query.data() + sub_query.size(), 0, true);
-            IParser::Pos pos_subquery(token_subquery, pos.max_depth, pos.max_backtracks);
+            IParser::Pos pos_subquery(token_subquery, pos);
 
             if (!ParserKQLSubquery().parse(pos_subquery, tables, expected))
                 return false;
@@ -547,7 +547,7 @@ bool ParserKQLQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
             if (oprator)
             {
                 Tokens token_clause(op_calsue.data(), op_calsue.data() + op_calsue.size(), 0, true);
-                IParser::Pos pos_clause(token_clause, pos.max_depth, pos.max_backtracks);
+                IParser::Pos pos_clause(token_clause, pos);
                 if (!oprator->parse(pos_clause, node, expected))
                     return false;
             }
@@ -582,7 +582,7 @@ bool ParserKQLQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     {
         auto expr = String("*");
         Tokens tokens(expr.data(), expr.data() + expr.size(), 0, true);
-        IParser::Pos new_pos(tokens, pos.max_depth, pos.max_backtracks);
+        IParser::Pos new_pos(tokens, pos);
         if (!std::make_unique<ParserKQLProject>()->parse(new_pos, node, expected))
             return false;
     }

--- a/src/Parsers/Kusto/ParserKQLQuery.h
+++ b/src/Parsers/Kusto/ParserKQLQuery.h
@@ -9,11 +9,11 @@ class ParserKQLBase : public IParserBase
 {
 public:
     static String getExprFromToken(Pos & pos);
-    static String getExprFromToken(const String & text, uint32_t max_depth, uint32_t max_backtracks);
+    static String getExprFromToken(const String & text, const Pos & parent_pos);
     static String getExprFromPipe(Pos & pos);
     static bool setSubQuerySource(ASTPtr & select_query, ASTPtr & source, bool dest_is_subquery, bool src_is_subquery);
-    static bool parseSQLQueryByString(ParserPtr && parser, String & query, ASTPtr & select_node, uint32_t max_depth, uint32_t max_backtracks);
-    bool parseByString(String expr, ASTPtr & node, uint32_t max_depth, uint32_t max_backtracks);
+    static bool parseSQLQueryByString(ParserPtr && parser, String & query, ASTPtr & select_node, const Pos & parent_pos);
+    bool parseByString(String expr, ASTPtr & node, const Pos & parent_pos);
 };
 
 class ParserKQLQuery : public IParserBase

--- a/src/Parsers/Kusto/ParserKQLSort.cpp
+++ b/src/Parsers/Kusto/ParserKQLSort.cpp
@@ -19,7 +19,7 @@ bool ParserKQLSort::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     auto expr = getExprFromToken(pos);
 
     Tokens tokens(expr.data(), expr.data() + expr.size(), 0, true);
-    IParser::Pos new_pos(tokens, pos.max_depth, pos.max_backtracks);
+    IParser::Pos new_pos(tokens, pos);
 
     auto pos_backup = new_pos;
     if (!order_list.parse(pos_backup, order_expression_list, expected))

--- a/src/Parsers/Kusto/ParserKQLStatement.cpp
+++ b/src/Parsers/Kusto/ParserKQLStatement.cpp
@@ -105,7 +105,7 @@ bool ParserKQLTableFunction::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
     }
 
     Tokens tokens_kql(kql_statement.data(), kql_statement.data() + kql_statement.size(), 0, true);
-    IParser::Pos pos_kql(tokens_kql, pos.max_depth, pos.max_backtracks);
+    IParser::Pos pos_kql(tokens_kql, pos);
 
     Expected kql_expected;
     kql_expected.enable_highlighting = false;

--- a/src/Parsers/Kusto/ParserKQLSummarize.cpp
+++ b/src/Parsers/Kusto/ParserKQLSummarize.cpp
@@ -176,10 +176,10 @@ bool ParserKQLSummarize::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
             expr_columns = expr_columns + "," + expr_aggregation;
     }
 
-    String converted_columns = getExprFromToken(expr_columns, pos.max_depth, pos.max_backtracks);
+    String converted_columns = getExprFromToken(expr_columns, pos);
 
     Tokens token_converted_columns(converted_columns.data(), converted_columns.data() + converted_columns.size(), 0, true);
-    IParser::Pos pos_converted_columns(token_converted_columns, pos.max_depth, pos.max_backtracks);
+    IParser::Pos pos_converted_columns(token_converted_columns, pos);
 
     if (!ParserNotEmptyExpressionList(true).parse(pos_converted_columns, select_expression_list, expected))
         return false;
@@ -188,10 +188,10 @@ bool ParserKQLSummarize::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
 
     if (groupby)
     {
-        String converted_groupby = getExprFromToken(expr_groupby, pos.max_depth, pos.max_backtracks);
+        String converted_groupby = getExprFromToken(expr_groupby, pos);
 
         Tokens token_converted_groupby(converted_groupby.data(), converted_groupby.data() + converted_groupby.size(), 0, true);
-        IParser::Pos postoken_converted_groupby(token_converted_groupby, pos.max_depth, pos.max_backtracks);
+        IParser::Pos postoken_converted_groupby(token_converted_groupby, pos);
 
         if (!ParserNotEmptyExpressionList(false).parse(postoken_converted_groupby, group_expression_list, expected))
             return false;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This is a dedicated PR with only commit `8f9090355e872a3cea1f1c54df7f030a8b76e9dd`.

It fixes KQL parser logic where depth and parser-backtracks counters could be lost while passing through KQL parser components, which could weaken parser-limit accounting and error behavior for complex KQL queries.

Reference PR with related recent parser/CI context: https://github.com/ClickHouse/ClickHouse/pull/99740

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improved KQL parser robustness by preserving parser depth and backtracks counters across KQL parser stages, so parser limits are tracked consistently for complex KQL queries.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9b84d83-fd58-456b-97e2-c3386af36d84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9b84d83-fd58-456b-97e2-c3386af36d84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

