### PR TITLE
Mark `02125_lz4_compression_bug_JSONStringsEachRow` as `no-flaky-check`

### DIFF
--- a/tests/queries/0_stateless/02125_lz4_compression_bug_JSONStringsEachRow.sh
+++ b/tests/queries/0_stateless/02125_lz4_compression_bug_JSONStringsEachRow.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, long
+# Tags: no-fasttest, long, no-flaky-check
 # long - may be too slow under asan
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)


### PR DESCRIPTION
The `02125_lz4_compression_bug_JSONStringsEachRow` test consistently exceeds the flaky check time limit, like its sibling `02125_lz4_compression_bug_*` tests that are already tagged with `no-flaky-check`.

This change brings it in line with the rest of the family.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.72`
<!-- ch-version-info:end -->