### PR TITLE
Fix flaky 00825_protobuf_format_map under map-bucket serialization

### DIFF
--- a/tests/queries/0_stateless/00825_protobuf_format_map.sh
+++ b/tests/queries/0_stateless/00825_protobuf_format_map.sh
@@ -12,10 +12,19 @@ set -eo pipefail
 $CLICKHOUSE_CLIENT <<EOF
 DROP TABLE IF EXISTS map_protobuf_00825;
 
+-- Pin Map serialization to 'basic' so the test output (key order in SELECT *
+-- and the binary representation in the Protobuf hexdump) is deterministic.
+-- CI randomizes map_serialization_version and
+-- map_serialization_version_for_zero_level_parts between 'basic' and
+-- 'with_buckets'; the latter stores Map entries in hash-bucket order on disk,
+-- which both reorders the keys returned by SELECT and changes the bytes in the
+-- Protobuf output. The test verifies the Protobuf round-trip for Map, which
+-- is orthogonal to the storage layout.
 CREATE TABLE map_protobuf_00825
 (
   a Map(String, UInt32)
-) ENGINE = MergeTree ORDER BY tuple();
+) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS map_serialization_version = 'basic', map_serialization_version_for_zero_level_parts = 'basic';
 
 INSERT INTO map_protobuf_00825 VALUES ({'x':5, 'y':7}), ({'z':11}), ({'temp':0}), ({'':0});
 


### PR DESCRIPTION
## Summary

Pin `map_serialization_version` and `map_serialization_version_for_zero_level_parts` to `basic` in the test's `CREATE TABLE SETTINGS` so the `SELECT *` key order and the Protobuf binary hexdump remain deterministic regardless of CI randomization.

## Root cause

CI randomizes both settings between `basic` and `with_buckets` via `tests/clickhouse-test` `MergeTreeSettingsRandomizer` (lines 1574-1575). With `with_buckets`, Map entries are stored in hash-bucket order on disk, so reads return keys in bucket order rather than insertion order, and the Protobuf output bytes change accordingly. The `.reference` file pins both the `SELECT` output and the hexdump, so the test fails whenever the randomizer picks `with_buckets` for either setting.

The test verifies the Protobuf round-trip for the `Map` data type. The Protobuf encoder/decoder logic is orthogonal to the on-disk storage layout, so pinning only the Map serialization format preserves the test's intent.

Deterministic reproducer (current master, no fix):
```
CREATE TABLE t (a Map(String, UInt32)) ENGINE = MergeTree ORDER BY tuple()
  SETTINGS map_serialization_version_for_zero_level_parts = 'with_buckets',
           max_buckets_in_map = 26,
           map_buckets_strategy = 'constant',
           map_buckets_min_avg_size = 1;
INSERT INTO t VALUES ({'x':5, 'y':7});
SELECT * FROM t;
-- returns {'y':7,'x':5} (bucket order) instead of {'x':5,'y':7} (insertion order)
```

Same pattern as the previous fix for `01872_functions_to_subcolumns_analyzer` (PR #103421, merged 2026-04-23) and `02974_analyzer_array_join_subcolumn.sql` (commit `d238b482d5c`).

## Verification

50/50 passes locally with `--test-runs 50` and full randomization enabled.

## CI report

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100146&sha=6ddab321885e13563c3b3881cf4f2fe81a093a23&name_0=PR&name_1=Stateless%20tests%20%28amd_asan_ubsan%2C%20distributed%20plan%2C%20parallel%2C%202%2F2%29

30-day CIDB evidence: 6 distinct PRs hit this failure plus 5 master hits — genuine chronic flaky test, all on configurations where the randomizer picked `with_buckets` for one of the two map serialization settings.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)