### PR TITLE
Docs: how to alter settings of refreshable materialized views

### DIFF
--- a/docs/en/sql-reference/statements/alter/view.md
+++ b/docs/en/sql-reference/statements/alter/view.md
@@ -195,4 +195,35 @@ SELECT * FROM mv;
 
 ## ALTER TABLE ... MODIFY REFRESH Statement {#alter-table--modify-refresh-statement}
 
-`ALTER TABLE ... MODIFY REFRESH` statement changes refresh parameters of a [Refreshable Materialized View](../create/view.md#refreshable-materialized-view). See [Changing Refresh Parameters](../create/view.md#changing-refresh-parameters).
+`ALTER TABLE ... MODIFY REFRESH` changes refresh parameters of a [Refreshable Materialized View](../create/view.md#refreshable-materialized-view), including the schedule, dependencies, randomization, and [refresh settings](../create/view.md#refresh-settings).
+
+```sql
+ALTER TABLE [db.]name MODIFY REFRESH EVERY|AFTER ... [RANDOMIZE FOR ...] [DEPENDS ON ...] [SETTINGS ...]
+```
+
+The schedule (`EVERY` or `AFTER`) is mandatory: the statement replaces *all* refresh parameters at once. Any clause not specified — `RANDOMIZE FOR`, `DEPENDS ON`, or `SETTINGS` — is removed or reset to defaults. To change only refresh settings, repeat the current schedule.
+
+```sql
+-- Change the schedule.
+ALTER TABLE rmv MODIFY REFRESH EVERY 30 MINUTE;
+
+-- Change retry settings (schedule must be repeated).
+ALTER TABLE rmv MODIFY REFRESH EVERY 1 HOUR
+SETTINGS refresh_retries = 5,
+         refresh_retry_initial_backoff_ms = 500,
+         refresh_retry_max_backoff_ms = 60000;
+
+-- Add or keep a dependency.
+ALTER TABLE rmv MODIFY REFRESH EVERY 6 HOUR DEPENDS ON other_rmv;
+
+-- Drop the dependency by omitting `DEPENDS ON`.
+ALTER TABLE rmv MODIFY REFRESH EVERY 6 HOUR;
+```
+
+Limitations:
+
+- `ALTER TABLE ... MODIFY SETTING` is not supported on materialized views; refresh settings can only be changed via `MODIFY REFRESH`.
+- Adding or removing `APPEND` is not supported.
+- The `all_replicas` refresh setting cannot be changed after the view is created.
+
+The full list of refresh settings is documented in [Refresh Settings](../create/view.md#refresh-settings). Refresh status, including the currently applied settings, is visible in [`system.view_refreshes`](../../../operations/system-tables/view_refreshes.md).

--- a/docs/en/sql-reference/statements/create/view.md
+++ b/docs/en/sql-reference/statements/create/view.md
@@ -271,20 +271,55 @@ A few more examples:
 ### Refresh Settings {#refresh-settings}
 
 Available refresh settings:
-* `refresh_retries` - How many times to retry if refresh query fails with an exception. If all retries fail, skip to the next scheduled refresh time. 0 means no retries, -1 means infinite retries. Default: 0.
+* `refresh_retries` - How many times to retry if refresh query fails with an exception. If all retries fail, skip to the next scheduled refresh time. 0 means no retries, -1 means infinite retries. Default: 2.
 * `refresh_retry_initial_backoff_ms` - Delay before the first retry, if `refresh_retries` is not zero. Each subsequent retry doubles the delay, up to `refresh_retry_max_backoff_ms`. Default: 100 ms.
 * `refresh_retry_max_backoff_ms` - Limit on the exponential growth of delay between refresh attempts. Default: 60000 ms (1 minute).
+* `all_replicas` - In a [Replicated database](../../../engines/database-engines/replicated.md) with `APPEND`, controls whether all replicas refresh independently or only one replica refreshes at each scheduled time. Cannot be changed after the view is created. Default: `false`.
+* `prefer_dependency_replica` - When the view has `DEPENDS ON`, the replica that ran the parent refresh gets priority for running the dependent refresh; other replicas delay their attempt by `prefer_dependency_replica_delay_ms`. Useful with `SharedMergeTree` to avoid replication lag causing missing data in dependent refresh chains. Default: `false`.
+* `prefer_dependency_replica_delay_ms` - How long non-preferred replicas wait before attempting to run a dependent refresh when `prefer_dependency_replica` is enabled. Default: 2000 ms.
 
 ### Changing Refresh Parameters {#changing-refresh-parameters}
 
-To change refresh parameters:
+Refresh parameters of an existing refreshable materialized view are changed with [`ALTER TABLE ... MODIFY REFRESH`](../alter/view.md#alter-table--modify-refresh-statement):
+
 ```sql
 ALTER TABLE [db.]name MODIFY REFRESH EVERY|AFTER ... [RANDOMIZE FOR ...] [DEPENDS ON ...] [SETTINGS ...]
 ```
 
+The schedule (`EVERY` or `AFTER`) is mandatory: the statement always replaces *all* refresh parameters — schedule, `RANDOMIZE FOR`, `DEPENDS ON`, and refresh settings — with what is specified. Anything omitted is reset to its default (settings) or removed (dependencies, randomization).
+
 :::note
-This replaces *all* refresh parameters at once: schedule, dependencies, settings, and APPEND-ness. E.g. if the table had a `DEPENDS ON`, doing a `MODIFY REFRESH` without `DEPENDS ON` will remove the dependencies.
+- To change only refresh settings (e.g. `refresh_retries`), repeat the existing schedule:
+
+  ```sql
+  ALTER TABLE rmv MODIFY REFRESH EVERY 1 HOUR SETTINGS refresh_retries = 5;
+  ```
+
+- `ALTER TABLE ... MODIFY SETTING refresh_retries = ...` is not supported on materialized views; you must go through `MODIFY REFRESH`.
+
+- Adding or removing `APPEND` is not supported.
+
+- The `all_replicas` setting cannot be changed after creation.
 :::
+
+Examples:
+
+```sql
+-- Change the schedule, drop existing settings and dependencies.
+ALTER TABLE rmv MODIFY REFRESH EVERY 30 MINUTE;
+
+-- Change the schedule and tune retry behavior.
+ALTER TABLE rmv MODIFY REFRESH EVERY 30 MINUTE
+SETTINGS refresh_retries = 5,
+         refresh_retry_initial_backoff_ms = 500,
+         refresh_retry_max_backoff_ms = 60000;
+
+-- Keep the dependency while changing the period.
+ALTER TABLE rmv MODIFY REFRESH EVERY 6 HOUR DEPENDS ON other_rmv;
+
+-- Drop the dependency by omitting `DEPENDS ON`.
+ALTER TABLE rmv MODIFY REFRESH EVERY 6 HOUR;
+```
 
 ### Other operations {#other-operations}
 


### PR DESCRIPTION
Documents how to change refresh parameters and refresh settings of a [refreshable materialized view](https://clickhouse.com/docs/materialized-view/refreshable-materialized-view) so that the gotchas of `ALTER TABLE ... MODIFY REFRESH` are explicit:

- `ALTER TABLE ... MODIFY REFRESH` is the only path. `ALTER TABLE ... MODIFY SETTING refresh_retries = ...` is rejected with `NOT_IMPLEMENTED: 'MODIFY_SETTING' is not supported by storage MaterializedView`.
- The schedule clause (`EVERY|AFTER`) is mandatory. To change only refresh settings you must repeat the existing schedule; otherwise the parser fails with `SYNTAX_ERROR`.
- Omitted clauses are dropped or reset: missing `SETTINGS` resets all refresh settings to defaults; missing `DEPENDS ON` removes dependencies; missing `RANDOMIZE FOR` removes randomization.
- Adding or removing `APPEND` is not supported (`NOT_IMPLEMENTED: Adding or removing APPEND is not supported`).
- The `all_replicas` refresh setting cannot be changed after creation.

Also lists the three previously undocumented refresh settings (`all_replicas`, `prefer_dependency_replica`, `prefer_dependency_replica_delay_ms`) and corrects the `refresh_retries` default to `2` (was `0` in the docs).

All examples in the new docs were verified locally against `clickhouse local` 26.5.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.71`
<!-- ch-version-info:end -->