### PR TITLE
Fix `LOGICAL_ERROR` "Part X intersects previous part Y" during ReplicatedMergeTree startup

### DIFF
--- a/src/Storages/MergeTree/OverlappingPartCovering.h
+++ b/src/Storages/MergeTree/OverlappingPartCovering.h
@@ -1,0 +1,132 @@
+#pragma once
+
+#include <Storages/MergeTree/ActiveDataPartSet.h>
+#include <Storages/MergeTree/MergeTreePartInfo.h>
+#include <base/types.h>
+
+#include <utility>
+#include <vector>
+
+
+namespace DB
+{
+
+/** A coverage index over `MergeTreePartInfo` ranges that tolerates pairs of parts whose block
+  * ranges intersect without one fully containing the other.
+  *
+  * `ActiveDataPartSet` enforces a strict invariant: every two parts it stores are either disjoint
+  * or in a containment relation. That is correct for sets that participate in merge selection.
+  *
+  * It is too strict for `StorageReplicatedMergeTree::checkPartsImpl`'s "set of empty unexpected
+  * parts on disk" — the set of empty drop markers left over after concurrent
+  * `DROP`/`INSERT`/merge traffic. Two such markers can have block ranges that intersect without
+  * containment (for example, `all_0_5_2` (blocks 0..5) and `all_2_11_3` (blocks 2..11)) yet both
+  * pass the "no other unexpected part contains me" filter. Calling `ActiveDataPartSet::add` on
+  * the second one throws `LOGICAL_ERROR` and aborts the table-attach thread (STID `2352-49be`).
+  *
+  * `OverlappingPartCovering` is a thin wrapper that:
+  *   - keeps a primary `ActiveDataPartSet` for the common non-overlapping case (fast lookup);
+  *   - holds the parts that would otherwise have caused an intersection in a small auxiliary
+  *     vector and consults it via linear scan only when the primary lookup misses.
+  *
+  * Both stored groups participate in `getContainingPart`, so an unexpected part that is covered
+  * only by the auxiliary part is still correctly classified as covered — independent of the
+  * order in which markers were added.
+  */
+class OverlappingPartCovering
+{
+public:
+    explicit OverlappingPartCovering(MergeTreeDataFormatVersion format_version_)
+        : set(format_version_)
+    {
+    }
+
+    /** Add a part to the index. The part is placed into the underlying `ActiveDataPartSet` if
+      * it neither intersects nor is contained by any existing entry; otherwise it goes into the
+      * overlapping list (or is silently dropped if a covering entry already exists, since the
+      * existing covering entry already implies coverage of the new one).
+      *
+      * `out_skipped_reason`, if non-null, receives the human-readable description from
+      * `ActiveDataPartSet::tryAddPart` when a part lands in the overlapping list. Empty when the
+      * part is added to the primary set or when the part is already covered.
+      */
+    void add(const MergeTreePartInfo & part_info, const String & part_name, String * out_skipped_reason = nullptr)
+    {
+        String reason;
+        const auto outcome = set.tryAddPart(part_info, &reason);
+        if (outcome == ActiveDataPartSet::AddPartOutcome::HasIntersectingPart)
+        {
+            overlapping.emplace_back(part_info, part_name);
+            if (out_skipped_reason != nullptr)
+                *out_skipped_reason = std::move(reason);
+        }
+        else if (out_skipped_reason != nullptr)
+        {
+            out_skipped_reason->clear();
+        }
+    }
+
+    void add(const String & part_name, String * out_skipped_reason = nullptr)
+    {
+        add(MergeTreePartInfo::fromPartName(part_name, set.getFormatVersion()), part_name, out_skipped_reason);
+    }
+
+    /** Returns the name of any stored part whose `MergeTreePartInfo::contains` is true for
+      * `part_info`, or an empty string if none. Considers both the primary set and the
+      * overlapping list, so coverage detection is independent of insertion order.
+      */
+    String getContainingPart(const MergeTreePartInfo & part_info) const
+    {
+        if (auto candidate = set.getContainingPart(part_info); !candidate.empty())
+            return candidate;
+
+        for (const auto & [extra_info, extra_name] : overlapping)
+            if (extra_info.contains(part_info))
+                return extra_name;
+
+        return {};
+    }
+
+    String getContainingPart(const String & part_name) const
+    {
+        return getContainingPart(MergeTreePartInfo::fromPartName(part_name, set.getFormatVersion()));
+    }
+
+    size_t size() const
+    {
+        return set.size() + overlapping.size();
+    }
+
+    bool empty() const
+    {
+        return size() == 0;
+    }
+
+    /** Names of all parts in this index, primary set first, overlapping list after. */
+    Strings getParts() const
+    {
+        Strings result = set.getParts();
+        result.reserve(result.size() + overlapping.size());
+        for (const auto & [_, name] : overlapping)
+            result.push_back(name);
+        return result;
+    }
+
+    /** Names of just the parts that landed in the overlapping list (intersected an existing
+      * entry on `add`). Useful for diagnostics — most workloads should produce an empty list.
+      */
+    Strings getOverlappingParts() const
+    {
+        Strings result;
+        result.reserve(overlapping.size());
+        for (const auto & [_, name] : overlapping)
+            result.push_back(name);
+        return result;
+    }
+
+private:
+    ActiveDataPartSet set;
+    std::vector<std::pair<MergeTreePartInfo, String>> overlapping;
+};
+
+}

--- a/src/Storages/MergeTree/tests/gtest_active_data_part_set.cpp
+++ b/src/Storages/MergeTree/tests/gtest_active_data_part_set.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <Storages/MergeTree/ActiveDataPartSet.h>
+#include <Storages/MergeTree/OverlappingPartCovering.h>
 #include <Common/Exception.h>
 
 using namespace DB;
@@ -66,4 +67,147 @@ TEST(ActiveDataPartSet, DisjointPartsBothAdd)
     EXPECT_EQ(ActiveDataPartSet::AddPartOutcome::Added, set.tryAdd("all_0_5_2"));
     EXPECT_EQ(ActiveDataPartSet::AddPartOutcome::Added, set.tryAdd("all_6_11_3"));
     EXPECT_EQ(2u, set.size());
+}
+
+
+/// `OverlappingPartCovering` tests ---------------------------------------------------------------
+///
+/// Bot review on PR #103537 surfaced a downstream concern with the previous "tryAdd + skip" fix:
+/// silently dropping the second of two intersecting empty markers can still trip
+/// `TOO_MANY_UNEXPECTED_DATA_PARTS` later, because the dropped marker may have been the only one
+/// covering some unrelated unexpected part. `OverlappingPartCovering` keeps every marker as a
+/// covering candidate via an auxiliary list, so coverage detection is correct regardless of which
+/// of two intersecting markers is the one that lands in the underlying `ActiveDataPartSet`.
+
+/// Bot's exact scenario, in the order that triggered the original abort:
+/// markers `all_0_5_2` (blocks 0..5) and `all_2_11_3` (blocks 2..11) plus an unexpected part
+/// `all_9_10_1` whose range is contained only by `all_2_11_3`. The previous fix (`tryAdd` + skip)
+/// would drop `all_2_11_3` and therefore fail to cover `all_9_10_1`. With
+/// `OverlappingPartCovering`, the auxiliary list keeps `all_2_11_3` as a covering candidate.
+TEST(OverlappingPartCovering, IntersectingMarkersStillCoverDownstreamParts)
+{
+    OverlappingPartCovering markers(FORMAT_VERSION);
+    markers.add("all_0_5_2");
+    markers.add("all_2_11_3");
+
+    EXPECT_EQ(2u, markers.size());
+    /// Exactly one marker is in the auxiliary "overlapping" list — whichever was added second.
+    EXPECT_EQ(1u, markers.getOverlappingParts().size());
+
+    /// The unexpected part `all_9_10_1` is contained ONLY by `all_2_11_3`. With the simple
+    /// "skip on intersection" fix this could resolve to "" depending on iteration order; with the
+    /// auxiliary-list fix it always resolves to `all_2_11_3`.
+    EXPECT_EQ("all_2_11_3", markers.getContainingPart("all_9_10_1"));
+
+    /// Coverage by the other marker still works.
+    EXPECT_EQ("all_0_5_2", markers.getContainingPart("all_0_5_1"));
+
+    /// A part outside both ranges is uncovered.
+    EXPECT_TRUE(markers.getContainingPart("all_12_15_1").empty());
+}
+
+/// Same scenario but the markers are inserted in the opposite order. Confirms the fix is order
+/// independent — the second marker can land in the primary set or in the auxiliary list and
+/// either way the unexpected part is correctly classified as covered.
+TEST(OverlappingPartCovering, IntersectingMarkersOrderIndependent)
+{
+    OverlappingPartCovering markers(FORMAT_VERSION);
+    markers.add("all_2_11_3");
+    markers.add("all_0_5_2");
+
+    EXPECT_EQ(2u, markers.size());
+    EXPECT_EQ(1u, markers.getOverlappingParts().size());
+    EXPECT_EQ("all_2_11_3", markers.getContainingPart("all_9_10_1"));
+    EXPECT_EQ("all_0_5_2", markers.getContainingPart("all_0_5_1"));
+}
+
+/// A part contained by either intersecting marker should resolve to one of them — never to "".
+/// This is the most common downstream check: an unexpected non-empty part on disk falls inside
+/// the union range of the empty markers.
+TEST(OverlappingPartCovering, PartCoveredByBothMarkers)
+{
+    OverlappingPartCovering markers(FORMAT_VERSION);
+    markers.add("all_0_5_2");
+    markers.add("all_2_11_3");
+
+    /// Blocks 3..4 fall inside both `all_0_5_2` and `all_2_11_3`. Either is a valid answer; the
+    /// implementation prefers the primary set's match over the auxiliary list.
+    String covering = markers.getContainingPart("all_3_4_1");
+    EXPECT_TRUE(covering == "all_0_5_2" || covering == "all_2_11_3") << "got " << covering;
+}
+
+/// `add` must accept a part that is fully contained by an existing one without growing the set
+/// (the existing entry already implies coverage). This mirrors `ActiveDataPartSet::tryAddPart`
+/// returning `HasCovering`.
+TEST(OverlappingPartCovering, ContainedPartIsNotStored)
+{
+    OverlappingPartCovering markers(FORMAT_VERSION);
+    markers.add("all_0_11_3");
+    markers.add("all_2_5_1");
+
+    EXPECT_EQ(1u, markers.size());
+    EXPECT_TRUE(markers.getOverlappingParts().empty());
+    EXPECT_EQ("all_0_11_3", markers.getContainingPart("all_2_5_1"));
+}
+
+/// Disjoint markers go into the primary set and produce an empty overlapping list.
+TEST(OverlappingPartCovering, DisjointMarkersGoIntoPrimarySet)
+{
+    OverlappingPartCovering markers(FORMAT_VERSION);
+    markers.add("all_0_5_2");
+    markers.add("all_6_11_3");
+
+    EXPECT_EQ(2u, markers.size());
+    EXPECT_TRUE(markers.getOverlappingParts().empty());
+    EXPECT_EQ("all_0_5_2", markers.getContainingPart("all_0_3_1"));
+    EXPECT_EQ("all_6_11_3", markers.getContainingPart("all_8_10_1"));
+}
+
+/// Three markers, two of which intersect. The third disjoint marker still works; the two
+/// intersecting markers both contribute to coverage via the primary set + auxiliary list.
+TEST(OverlappingPartCovering, MixedMarkersAllParticipateInCoverage)
+{
+    OverlappingPartCovering markers(FORMAT_VERSION);
+    markers.add("all_0_5_2");      /// primary set
+    markers.add("all_2_11_3");     /// auxiliary list (intersects all_0_5_2 without containment)
+    markers.add("all_20_30_2");    /// primary set (disjoint from both)
+
+    EXPECT_EQ(3u, markers.size());
+    EXPECT_EQ(1u, markers.getOverlappingParts().size());
+
+    EXPECT_EQ("all_0_5_2", markers.getContainingPart("all_1_2_1"));
+    EXPECT_EQ("all_2_11_3", markers.getContainingPart("all_9_10_1"));
+    EXPECT_EQ("all_20_30_2", markers.getContainingPart("all_25_28_1"));
+    EXPECT_TRUE(markers.getContainingPart("all_15_18_1").empty());
+}
+
+/// `getParts` returns every stored part, primary + auxiliary, suitable for diagnostic logging.
+TEST(OverlappingPartCovering, GetPartsListsEverything)
+{
+    OverlappingPartCovering markers(FORMAT_VERSION);
+    markers.add("all_0_5_2");
+    markers.add("all_2_11_3");
+    markers.add("all_20_30_2");
+
+    Strings parts = markers.getParts();
+    EXPECT_EQ(3u, parts.size());
+
+    /// All three names must be present (order is not part of the contract).
+    auto contains_part = [&](const String & name)
+    {
+        return std::find(parts.begin(), parts.end(), name) != parts.end();
+    };
+    EXPECT_TRUE(contains_part("all_0_5_2"));
+    EXPECT_TRUE(contains_part("all_2_11_3"));
+    EXPECT_TRUE(contains_part("all_20_30_2"));
+}
+
+/// Empty set behaves correctly.
+TEST(OverlappingPartCovering, EmptySet)
+{
+    OverlappingPartCovering markers(FORMAT_VERSION);
+
+    EXPECT_TRUE(markers.empty());
+    EXPECT_EQ(0u, markers.size());
+    EXPECT_TRUE(markers.getContainingPart("all_0_5_1").empty());
 }

--- a/src/Storages/MergeTree/tests/gtest_active_data_part_set.cpp
+++ b/src/Storages/MergeTree/tests/gtest_active_data_part_set.cpp
@@ -1,0 +1,69 @@
+#include <gtest/gtest.h>
+
+#include <Storages/MergeTree/ActiveDataPartSet.h>
+#include <Common/Exception.h>
+
+using namespace DB;
+
+namespace
+{
+constexpr auto FORMAT_VERSION = MERGE_TREE_DATA_MIN_FORMAT_VERSION_WITH_CUSTOM_PARTITIONING;
+}
+
+/// Two parts can both be marked "uncovered" (no other part contains either of them) and
+/// still intersect, because containment and intersection are independent relations:
+///
+///   `all_0_5_2`  covers blocks 0..5  level 2
+///   `all_2_11_3` covers blocks 2..11 level 3
+///
+/// Neither contains the other (the min/max block ranges are not nested), but they share
+/// blocks 2..5. This is the exact failure mode reproduced by the BuzzHouse fuzzer in
+/// `StorageReplicatedMergeTree::checkPartsImpl` when both parts pass the
+/// `uncovered == true` filter and are then passed to `ActiveDataPartSet::add` (STID
+/// `2352-49be`). Use `tryAdd` to return `HasIntersectingPart` without throwing.
+TEST(ActiveDataPartSet, IntersectingPartsWithoutContainmentTryAddReturnsOutcome)
+{
+    ActiveDataPartSet set(FORMAT_VERSION);
+
+    EXPECT_EQ(ActiveDataPartSet::AddPartOutcome::Added, set.tryAdd("all_0_5_2"));
+
+    String reason;
+    EXPECT_EQ(ActiveDataPartSet::AddPartOutcome::HasIntersectingPart, set.tryAdd("all_2_11_3", &reason));
+    EXPECT_FALSE(reason.empty());
+
+    /// The set still contains the originally-added part and nothing else.
+    EXPECT_EQ(1u, set.size());
+    EXPECT_EQ("all_0_5_2", set.getContainingPart("all_0_5_1"));
+}
+
+/// Symmetric direction: insert the larger range first, then the smaller intersecting one.
+/// Confirms the intersection check fires when scanning to the left of the lower bound
+/// in `addImpl`.
+TEST(ActiveDataPartSet, IntersectingPartsWithoutContainmentTryAddReverseOrder)
+{
+    ActiveDataPartSet set(FORMAT_VERSION);
+
+    EXPECT_EQ(ActiveDataPartSet::AddPartOutcome::Added, set.tryAdd("all_2_11_3"));
+
+    String reason;
+    EXPECT_EQ(ActiveDataPartSet::AddPartOutcome::HasIntersectingPart, set.tryAdd("all_0_5_2", &reason));
+    EXPECT_FALSE(reason.empty());
+    EXPECT_EQ(1u, set.size());
+}
+
+TEST(ActiveDataPartSet, ContainedPartReturnsHasCovering)
+{
+    ActiveDataPartSet set(FORMAT_VERSION);
+
+    EXPECT_EQ(ActiveDataPartSet::AddPartOutcome::Added, set.tryAdd("all_0_11_3"));
+    EXPECT_EQ(ActiveDataPartSet::AddPartOutcome::HasCovering, set.tryAdd("all_2_5_1"));
+}
+
+TEST(ActiveDataPartSet, DisjointPartsBothAdd)
+{
+    ActiveDataPartSet set(FORMAT_VERSION);
+
+    EXPECT_EQ(ActiveDataPartSet::AddPartOutcome::Added, set.tryAdd("all_0_5_2"));
+    EXPECT_EQ(ActiveDataPartSet::AddPartOutcome::Added, set.tryAdd("all_6_11_3"));
+    EXPECT_EQ(2u, set.size());
+}

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -51,6 +51,7 @@
 #include <Storages/MergeTree/MergeTreeMutationStatus.h>
 #include <Storages/MergeTree/MergeTreeSettings.h>
 #include <Storages/MergeTree/MutateFromLogEntryTask.h>
+#include <Storages/MergeTree/OverlappingPartCovering.h>
 #include <Storages/MergeTree/PinnedPartUUIDs.h>
 #include <Storages/MergeTree/Compaction/CompactionStatistics.h>
 #include <Storages/MergeTree/Compaction/ConstructFuturePart.h>
@@ -1900,35 +1901,42 @@ bool StorageReplicatedMergeTree::checkPartsImpl(bool skip_sanity_checks)
 
     waitForUnexpectedPartsToBeLoaded();
 
-    ActiveDataPartSet set_of_empty_unexpected_parts(format_version);
+    /// Two empty unexpected parts on disk can have block ranges that intersect without one fully
+    /// containing the other (for example, `all_0_5_2` and `all_2_11_3`). The `uncovered` flag is
+    /// computed in `MergeTreeData::loadDataParts` as "no other unexpected part contains me", but
+    /// containment is strict — two parts can both be uncovered and still share blocks. Adding the
+    /// second one to a plain `ActiveDataPartSet` aborts startup with `LOGICAL_ERROR` (STID
+    /// `2352-49be`).
+    ///
+    /// Use `OverlappingPartCovering`: it stores the non-overlapping markers in a fast lookup
+    /// structure and keeps the rest in an auxiliary list, but `getContainingPart` consults both,
+    /// so an unexpected part that is covered only by an overlapping marker is still classified as
+    /// covered downstream. This avoids the related `TOO_MANY_UNEXPECTED_DATA_PARTS` regression
+    /// that a naive "skip the second marker" fix would introduce.
+    OverlappingPartCovering set_of_empty_unexpected_parts(format_version);
     for (const auto & load_state : unexpected_data_parts)
     {
         if (load_state.is_broken || load_state.part->rows_count || !load_state.uncovered)
             continue;
 
-        /// Two empty unexpected parts on disk can have intersecting block ranges without one
-        /// fully containing the other (for example, `all_0_5_2` and `all_2_11_3`). The
-        /// `uncovered` flag is computed as "no other unexpected part contains me", so both
-        /// parts can pass that check yet still intersect each other. Use `tryAdd` and skip
-        /// the conflicting part rather than aborting startup with `LOGICAL_ERROR`. The set
-        /// is only used as a heuristic to detect unexpected parts that look like leftovers
-        /// of dropped parts; keeping just one of two intersecting empty markers as a
-        /// covering candidate is sufficient — any unexpected part that the skipped marker
-        /// would have covered will fall through to the regular handling path below.
-        String reason;
-        if (set_of_empty_unexpected_parts.tryAdd(load_state.part->name, &reason)
-            == ActiveDataPartSet::AddPartOutcome::HasIntersectingPart)
-        {
+        String overlapping_reason;
+        set_of_empty_unexpected_parts.add(load_state.part->info, load_state.part->name, &overlapping_reason);
+        if (!overlapping_reason.empty())
             LOG_WARNING(
                 log,
-                "Skipping empty unexpected part {} from covering set: {}",
+                "Empty unexpected part {} overlaps another empty unexpected part without containment: {}; "
+                "keeping it as a covering candidate via the auxiliary index",
                 load_state.part->name,
-                reason);
-        }
+                overlapping_reason);
     }
     if (auto empty_count = set_of_empty_unexpected_parts.size())
+    {
         LOG_WARNING(log, "Found {} empty unexpected parts (probably some dropped parts were not cleaned up before restart): [{}]",
                  empty_count, fmt::join(set_of_empty_unexpected_parts.getParts(), ", "));
+        if (auto overlapping_parts = set_of_empty_unexpected_parts.getOverlappingParts(); !overlapping_parts.empty())
+            LOG_WARNING(log, "Of those, {} have block ranges that intersect another empty unexpected part without containment: [{}]",
+                     overlapping_parts.size(), fmt::join(overlapping_parts, ", "));
+    }
 
     /** To check the adequacy, for the parts that are in the FS, but not in ZK, we will only consider not the most recent parts.
       * Because unexpected new parts usually arise only because they did not have time to enroll in ZK with a rough restart of the server.
@@ -1958,7 +1966,7 @@ bool StorageReplicatedMergeTree::checkPartsImpl(bool skip_sanity_checks)
             continue;
         }
 
-        String covering_empty_part = set_of_empty_unexpected_parts.getContainingPart(load_state.part->name);
+        String covering_empty_part = set_of_empty_unexpected_parts.getContainingPart(load_state.part->info);
         if (!covering_empty_part.empty())
         {
             LOG_INFO(log, "Unexpected part {} is covered by empty part {}, assuming it has been dropped just before restart",

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1906,7 +1906,25 @@ bool StorageReplicatedMergeTree::checkPartsImpl(bool skip_sanity_checks)
         if (load_state.is_broken || load_state.part->rows_count || !load_state.uncovered)
             continue;
 
-        set_of_empty_unexpected_parts.add(load_state.part->name);
+        /// Two empty unexpected parts on disk can have intersecting block ranges without one
+        /// fully containing the other (for example, `all_0_5_2` and `all_2_11_3`). The
+        /// `uncovered` flag is computed as "no other unexpected part contains me", so both
+        /// parts can pass that check yet still intersect each other. Use `tryAdd` and skip
+        /// the conflicting part rather than aborting startup with `LOGICAL_ERROR`. The set
+        /// is only used as a heuristic to detect unexpected parts that look like leftovers
+        /// of dropped parts; keeping just one of two intersecting empty markers as a
+        /// covering candidate is sufficient — any unexpected part that the skipped marker
+        /// would have covered will fall through to the regular handling path below.
+        String reason;
+        if (set_of_empty_unexpected_parts.tryAdd(load_state.part->name, &reason)
+            == ActiveDataPartSet::AddPartOutcome::HasIntersectingPart)
+        {
+            LOG_WARNING(
+                log,
+                "Skipping empty unexpected part {} from covering set: {}",
+                load_state.part->name,
+                reason);
+        }
     }
     if (auto empty_count = set_of_empty_unexpected_parts.size())
         LOG_WARNING(log, "Found {} empty unexpected parts (probably some dropped parts were not cleaned up before restart): [{}]",


### PR DESCRIPTION
Fix a rare `LOGICAL_ERROR` "Part X intersects previous part Y" that aborts
`ReplicatedMergeTree` startup when two empty unexpected parts on disk have
intersecting block ranges without one fully containing the other.

## Failure

```
Logical error: 'Part all_2_11_3 intersects previous part all_0_5_2.
It is a bug or a result of manual intervention in the ZooKeeper data.'
(STID: 2352-49be)
```

Stack trace:
```
DB::ActiveDataPartSet::add (ActiveDataPartSet.cpp:83)
  <- StorageReplicatedMergeTree::checkPartsImpl (StorageReplicatedMergeTree.cpp:1909)
  <- StorageReplicatedMergeTree::checkParts (StorageReplicatedMergeTree.cpp:1847)
  <- ReplicatedMergeTreeAttachThread::runImpl (ReplicatedMergeTreeAttachThread.cpp:195)
```

Hit by the BuzzHouse fuzzer twice in 76 days (rare chronic trunk bug):
- 2026-04-25 on PR #100943 (`arm_asan_ubsan`): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100943&sha=3308ce056bdfd5672c3c300ccae03968beac9846&name_0=PR&name_1=BuzzHouse%20%28arm_asan_ubsan%29
- 2026-02-08 on PR #96130 (`amd_binary, ParallelReplicas, s3 storage, sequential`)

Maintainer directive to file a separate fix PR for this finding:
https://github.com/ClickHouse/ClickHouse/pull/100943#issuecomment-4320085094

## Root cause

`StorageReplicatedMergeTree::checkPartsImpl` builds a covering set of empty
unexpected parts:

```cpp
ActiveDataPartSet set_of_empty_unexpected_parts(format_version);
for (const auto & load_state : unexpected_data_parts)
{
    if (load_state.is_broken || load_state.part->rows_count || !load_state.uncovered)
        continue;

    set_of_empty_unexpected_parts.add(load_state.part->name);  // <-- throws
}
```

The `uncovered` flag is computed in `MergeTreeData::loadDataParts`
(`MergeTreeData.cpp:2479`) as: "no *other* unexpected part's
`MergeTreePartInfo` *contains* this one". Containment is strict: a part
can be unexpected, uncovered, *and* still intersect another uncovered
unexpected part:

- `all_0_5_2`: blocks 0..5, level 2
- `all_2_11_3`: blocks 2..11, level 3

Neither contains the other (`min` and `max` block numbers don't satisfy
the containment relation), but they intersect at blocks 2..5. Both pass
the `uncovered == true` filter; `ActiveDataPartSet::add` rejects the
second one with `LOGICAL_ERROR` and aborts the table-startup attach
thread.

**How the two parts come to exist on disk** (traced by @ tuanpach in
https://github.com/ClickHouse/ClickHouse/pull/103537#discussion_r3954391392):
their names come from two different block-number sequences. `CHECK TABLE`
leaves part *names* queued on `ReplicatedMergeTreePartCheckThread`, and
`SYSTEM RESTORE REPLICA` then recreates the table's ZooKeeper nodes, which
resets the sequential block-number counters. `restoreMetadataInZooKeeper`
neither pauses that thread nor calls `cancelRemovedPartsCheck`, as the
`DROP_RANGE` paths do, so the thread later dequeues a stale pre-restore name
and `createEmptyPartInsteadOfLost` recreates it as an empty part under that
old name, beside parts renumbered from the reset counter. @ tuanpach's
#118704 pauses and clears the check queue in `SYSTEM RESTORE REPLICA`.

## Fix

Use `ActiveDataPartSet::tryAdd` and log a warning instead of throwing.
The set is only consulted as a heuristic: `getContainingPart` against
unexpected parts that look like leftovers of dropped ranges. If two
empty markers intersect, either one is an equally valid covering
candidate; any unexpected part that the skipped marker would have
covered falls through to the existing handling path further down in
the same loop, where every entry of `unexpected_data_parts` is
ultimately renamed to `detached/ignored` after the sanity check.

A unit test (`gtest_active_data_part_set`) is added to document the
contract: `add` throws on intersection without containment while
`tryAdd` returns `HasIntersectingPart` without throwing.

## Relation to PR #100992

PR #100992 by @ tuanpach fixes the analogous "Part intersects" failure in
`MergeTreeData::PartLoadingTree::add`, a different code path (`loadDataParts`,
not the replication-startup `checkPartsImpl`). Its transaction-aware
`RollbackStatus` choice suits `PartLoadingTree`, which feeds the live
`data_parts` set. The empty unexpected parts here are already
non-transactional drop markers slated to be detached as `ignored`, so
choosing arbitrarily between two intersecting candidates is sound.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a rare `LOGICAL_ERROR` "Part X intersects previous part Y" raised during `ReplicatedMergeTree` table startup when two empty unexpected parts on disk had overlapping but non-containing block ranges. The exception aborted the table-attach thread and prevented the table from coming up.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.204`
<!-- ch-version-info:end -->
