### PR TITLE
Fix file cache dynamic resize race with concurrent incrementSize

### DIFF
--- a/src/Interpreters/FileCache/FileCache.cpp
+++ b/src/Interpreters/FileCache/FileCache.cpp
@@ -2372,15 +2372,32 @@ bool FileCache::doDynamicResizeImpl(
 {
     /// In order to not block cache for the duration of cache resize,
     /// we do:
-    /// a. Take a cache lock.
-    ///     1. Collect eviction candidates,
-    ///     2. If eviction candidates size is non-zero,
+    /// a. Hold the cache state lock continuously, then take the cache priority
+    ///    write lock, while doing the in-memory work:
+    ///     1. Collect eviction info (size to evict),
+    ///     2. Collect eviction candidates,
+    ///     3. If eviction candidates size is non-zero,
     ///        remove their queue entries.
     ///        This will release space we consider to be hold for them,
     ///        so that we can safely modify size limits.
-    ///     3. Modify size limits of cache.
-    /// b. Release a cache lock.
+    ///     4. Modify size limits of cache.
+    /// b. Release both locks.
     ///     1. Do actual eviction from filesystem.
+    ///
+    /// The cache state lock must be held continuously across steps 1-4.
+    /// Otherwise, between sampling `state.size` in step 1 and validating
+    /// `state.size <= max_size_` inside `modifySizeLimits` in step 4,
+    /// concurrent operations could call `incrementSize` (which only requires
+    /// the state lock, not the priority lock) and grow `state.size` above
+    /// the new desired limit. This would trigger a `LOGICAL_ERROR` in
+    /// `LRUFileCachePriority::modifySizeLimits`.
+    ///
+    /// Specifically, `FileCache::doTryReserve` and
+    /// `SLRUFileCachePriority::tryIncreasePriority` both call
+    /// `incrementSize` under the state lock alone, after releasing the
+    /// priority write lock they used for queue mutation. Holding only
+    /// the priority write lock during steps 3-4 is therefore
+    /// insufficient; the state lock is required.
 
     auto eviction_info = main_priority->collectEvictionInfoForResize(
         desired_limits.max_size,
@@ -2410,7 +2427,11 @@ bool FileCache::doDynamicResizeImpl(
         return true;
     }
 
-    state_lock.unlock();
+    /// State lock remains held: this prevents concurrent `incrementSize`
+    /// calls from growing `state.size` while we collect eviction candidates
+    /// and prepare to apply the new limits. `collectCandidatesForEviction`
+    /// uses only the priority read lock internally and does not acquire
+    /// the state lock, so holding the state lock here cannot deadlock.
 
     FileCacheReserveStat stat;
     IFileCachePriority::InvalidatedEntriesInfos invalidated_entries;
@@ -2433,9 +2454,11 @@ bool FileCache::doDynamicResizeImpl(
     }
 
     /// Remove only queue entries of eviction candidates.
-    /// Hold the write lock until after modifying size limits,
-    /// to prevent concurrent `tryIncreasePriority` from promoting entries
-    /// into the protected queue between removal and limit modification.
+    /// We acquire the priority write lock here in addition to the state
+    /// lock that is already held. The priority write lock prevents
+    /// concurrent additions and queue-structural changes; the state lock
+    /// (held since entry to this function) prevents `incrementSize` from
+    /// running between `removeQueueEntries` and `modifySizeLimits`.
     auto write_lock = cache_guard.writeLock();
     eviction_candidates.removeQueueEntries(write_lock);
 
@@ -2444,8 +2467,6 @@ bool FileCache::doDynamicResizeImpl(
     /// only after eviction from filesystem. This is needed to avoid
     /// a race on removal of file from filesystsem and
     /// addition of the same file as part of a newly cached file segment.
-
-    state_lock.lock();
 
     /// Modify cache size limits.
     /// From this point cache eviction will follow them.

--- a/src/Interpreters/FileCache/FileCache.cpp
+++ b/src/Interpreters/FileCache/FileCache.cpp
@@ -2398,6 +2398,18 @@ bool FileCache::doDynamicResizeImpl(
     /// priority write lock they used for queue mutation. Holding only
     /// the priority write lock during steps 3-4 is therefore
     /// insufficient; the state lock is required.
+    ///
+    /// Lock-order note: the order used here is `state -> priority`. The
+    /// only other place in this file that holds both locks simultaneously
+    /// is `loadMetadataForKey`, which uses `priority -> state`. That path
+    /// runs only during `initializeImpl` (gated by `is_initialized`), and
+    /// `applySettingsIfPossible` -> `doDynamicResize` -> `doDynamicResizeImpl`
+    /// is gated by the same `is_initialized` flag (see the early return at
+    /// `applySettingsIfPossible`). The two paths therefore cannot execute
+    /// concurrently, so no ABBA cycle is reachable. Within this function
+    /// the failed-eviction restore path below uses the same `state -> priority`
+    /// order so that all simultaneous acquisitions of both locks inside
+    /// `doDynamicResizeImpl` follow one consistent order.
 
     auto eviction_info = main_priority->collectEvictionInfoForResize(
         desired_limits.max_size,
@@ -2517,8 +2529,12 @@ bool FileCache::doDynamicResizeImpl(
     /// As this case should be very rare (as it can only happen because of a bug)
     /// we allow ourselves to be suboptional here in favour of being robust
     /// and take two locks at the same time to do the restore in the most straightforward way.
-    auto cache_write_lock = cache_guard.writeLock();
+    ///
+    /// Locks are acquired in `state -> priority` order, matching the happy
+    /// path above. This keeps every simultaneous acquisition of both locks
+    /// inside `doDynamicResizeImpl` following a single, consistent order.
     state_lock.lock();
+    auto cache_write_lock = cache_guard.writeLock();
 
     /// Increase the max size and max elements
     /// to the size and number of failed candidates.

--- a/src/Interpreters/tests/gtest_filecache.cpp
+++ b/src/Interpreters/tests/gtest_filecache.cpp
@@ -1663,6 +1663,9 @@ TEST_F(FileCacheTest, SLRUDynamicResizeRaceWithIncreasePriority)
                 }
                 catch (...)
                 {
+                    /// Surface exceptions for diagnosis if this regression test ever fails.
+                    /// ASSERT_EQ(exceptions_in_promoter, 0) below treats any exception as a failure.
+                    std::cerr << getCurrentExceptionMessage(true) << std::endl;
                     exceptions_in_promoter.fetch_add(1);
                 }
             }
@@ -1688,6 +1691,9 @@ TEST_F(FileCacheTest, SLRUDynamicResizeRaceWithIncreasePriority)
             }
             catch (...)
             {
+                /// Surface exceptions for diagnosis if this regression test ever fails.
+                /// ASSERT_EQ(exceptions_in_resizer, 0) below treats any exception as a failure.
+                std::cerr << getCurrentExceptionMessage(true) << std::endl;
                 exceptions_in_resizer.fetch_add(1);
             }
         }

--- a/src/Interpreters/tests/gtest_filecache.cpp
+++ b/src/Interpreters/tests/gtest_filecache.cpp
@@ -1541,6 +1541,178 @@ TEST_F(FileCacheTest, SLRUDynamicResizeCorrectEviction)
     ASSERT_LE(cache->getFileSegmentsNum(), 6);
 }
 
+TEST_F(FileCacheTest, SLRUDynamicResizeRaceWithIncreasePriority)
+{
+    /// Regression test for STID 4012-44fe:
+    ///
+    ///   Logical error: 'Cannot modify size limits to A in size and B in
+    ///   elements: not enough space freed. Current size: C/D, elements:
+    ///   E/F (G) (..., protected)'.
+    ///
+    /// The bug is a race in `FileCache::doDynamicResizeImpl` where the
+    /// cache state lock used to be released between sampling
+    /// `state.size` (in `collectEvictionInfoForResize`) and validating it
+    /// in `modifySizeLimits`. During that gap, concurrent
+    /// `tryIncreasePriority` promotions from the probationary queue to
+    /// the protected queue would call `incrementSize` under the state
+    /// lock alone (no priority write lock needed), growing the protected
+    /// queue's `state.size` above the new desired limit.
+    ///
+    /// This test stresses the race by running concurrent
+    /// `applySettingsIfPossible` calls (resize) and `increasePriority`
+    /// calls (probationary→protected promotions). With the fix in
+    /// place, the state lock is held continuously across the critical
+    /// section and the promotion's `incrementSize` cannot interleave.
+
+    ServerUUID::setRandomForUnitTests();
+    DB::ThreadStatus thread_status;
+
+    /// Use a moderately sized cache and many small file segments
+    /// to give the race a wide window.
+    DB::FileCacheSettings settings;
+    settings[FileCacheSetting::path] = cache_base_path3;
+    settings[FileCacheSetting::max_file_segment_size] = 5;
+    settings[FileCacheSetting::max_size] = 1000;
+    settings[FileCacheSetting::max_elements] = 400;
+    settings[FileCacheSetting::boundary_alignment] = 1;
+    settings[FileCacheSetting::slru_size_ratio] = 0.5;
+    settings[FileCacheSetting::load_metadata_asynchronously] = false;
+    settings[FileCacheSetting::cache_policy] = FileCachePolicy::SLRU;
+    settings[FileCacheSetting::allow_dynamic_cache_resize] = true;
+
+    auto cache = std::make_shared<DB::FileCache>("slru_resize_race", settings);
+    cache->initialize();
+
+    const auto & user = FileCache::getCommonOrigin();
+
+    /// We need entries in both queues:
+    ///   - `protected_keys` are read twice, so they live in protected.
+    ///     Protected starts close to its sub-queue limit (500 bytes /
+    ///     200 elements), so a shrink will need to evict from there.
+    ///   - `probationary_keys` are read once, so they live in
+    ///     probationary. Re-reads of these during the race trigger
+    ///     probationary→protected promotions, which call
+    ///     `incrementSize` on the protected queue.
+    constexpr size_t num_protected = 80;
+    constexpr size_t num_probationary = 80;
+    std::vector<DB::FileCacheKey> protected_keys;
+    std::vector<DB::FileCacheKey> probationary_keys;
+    protected_keys.reserve(num_protected);
+    probationary_keys.reserve(num_probationary);
+
+    auto download_segment = [&](const DB::FileCacheKey & key)
+    {
+        auto holder = cache->getOrSet(key, /* offset */ 0, /* size */ 5, /* file_size */ 5, {}, 0, user);
+        for (auto & segment : *holder)
+        {
+            ASSERT_EQ(segment->getOrSetDownloader(), FileSegment::getCallerId());
+            std::string failure_reason;
+            ASSERT_TRUE(segment->reserve(5, 1000, failure_reason));
+            download(cache_base_path3, *segment);
+            FileSegment::complete(FileSegmentPtr(segment), /*allow_background_download=*/false, /*force_shrink_to_downloaded_size=*/false);
+        }
+    };
+
+    auto bump_priority = [&](const DB::FileCacheKey & key)
+    {
+        auto holder = cache->getOrSet(key, /* offset */ 0, /* size */ 5, /* file_size */ 5, {}, 0, user);
+        for (auto & segment : *holder)
+            segment->increasePriority();
+    };
+
+    for (size_t i = 0; i < num_protected; ++i)
+    {
+        auto key = DB::FileCacheKey::fromPath("race_protected_" + std::to_string(i));
+        protected_keys.push_back(key);
+        download_segment(key);
+        /// Second access promotes to protected.
+        bump_priority(key);
+    }
+    for (size_t i = 0; i < num_probationary; ++i)
+    {
+        auto key = DB::FileCacheKey::fromPath("race_probationary_" + std::to_string(i));
+        probationary_keys.push_back(key);
+        download_segment(key);
+    }
+
+    /// Run resizer and several promoter threads in parallel. The resizer
+    /// alternately shrinks and grows the cache; each shrink forces
+    /// eviction from the protected queue. The promoters re-read
+    /// probationary entries to trigger probationary→protected
+    /// promotions, which without the fix can grow the protected queue's
+    /// `state.size` between resize's eviction-info sampling and
+    /// `modifySizeLimits`.
+
+    std::atomic<bool> stop{false};
+    std::atomic<size_t> exceptions_in_promoter{0};
+    std::atomic<size_t> exceptions_in_resizer{0};
+    std::atomic<size_t> resize_iterations{0};
+
+    auto promoter_fn = [&]()
+    {
+        DB::ThreadStatus inner_thread_status;
+        while (!stop.load(std::memory_order_relaxed))
+        {
+            for (const auto & key : probationary_keys)
+            {
+                if (stop.load(std::memory_order_relaxed))
+                    break;
+                try
+                {
+                    bump_priority(key);
+                }
+                catch (...)
+                {
+                    exceptions_in_promoter.fetch_add(1);
+                }
+            }
+        }
+    };
+
+    auto resizer_fn = [&]()
+    {
+        DB::ThreadStatus inner_thread_status;
+        DB::FileCacheSettings shrunk = settings;
+        shrunk[FileCacheSetting::max_size] = 500;
+        DB::FileCacheSettings grown = settings;
+        grown[FileCacheSetting::max_size] = 1000;
+
+        DB::FileCacheSettings actual = settings;
+        constexpr size_t resize_iters = 600;
+        for (size_t i = 0; i < resize_iters && !stop.load(std::memory_order_relaxed); ++i)
+        {
+            try
+            {
+                cache->applySettingsIfPossible((i & 1) ? grown : shrunk, actual);
+                resize_iterations.fetch_add(1);
+            }
+            catch (...)
+            {
+                exceptions_in_resizer.fetch_add(1);
+            }
+        }
+        stop.store(true, std::memory_order_relaxed);
+    };
+
+    std::thread resizer_thread(resizer_fn);
+    std::vector<std::thread> promoter_threads;
+    promoter_threads.reserve(4);
+    for (size_t i = 0; i < 4; ++i)
+        promoter_threads.emplace_back(promoter_fn);
+
+    resizer_thread.join();
+    for (auto & t : promoter_threads)
+        t.join();
+
+    std::cerr << "Performed " << resize_iterations.load()
+              << " successful resize iterations" << std::endl;
+
+    ASSERT_EQ(exceptions_in_resizer.load(), 0)
+        << "Resize threw an exception (regression of STID 4012-44fe)";
+    ASSERT_EQ(exceptions_in_promoter.load(), 0)
+        << "Priority increase threw an exception during concurrent resize";
+}
+
 TEST_F(FileCacheTest, FileCacheGetOrSet)
 {
     ServerUUID::setRandomForUnitTests();


### PR DESCRIPTION
The stress test (arm_debug / amd_debug) was repeatedly failing with the
following logical error during config reload:

```
Logical error: 'Cannot modify size limits to A in size and B in
elements: not enough space freed. Current size: C/D, elements:
E/F (G) (s3_cache, protected)' (STID 4012-44fe).
```

Despite earlier targeted fixes (#96142, #96980, #102396), the bug
continued to surface on master and unrelated PRs. The remaining race
is at the cache state lock level rather than the priority lock level.

## Root cause

`FileCache::doDynamicResizeImpl` previously released the cache state
lock between sampling `state.size` in `collectEvictionInfoForResize`
and validating `state.size <= max_size_` inside `modifySizeLimits`.
During that gap, concurrent `FileCache::doTryReserve` and SLRU
`SLRUFileCachePriority::tryIncreasePriority` calls could invoke
`incrementSize` on the same protected queue. `incrementSize` only
requires the cache state lock, not the priority write lock, so
holding the priority write lock around `removeQueueEntries` and
`modifySizeLimits` (#96980) was insufficient to keep the protected
queue's `state.size` from growing.

Concretely:

1. Resize thread acquires the state lock, samples
   `protected.state.size = X`, releases state lock.
2. Resize thread collects eviction candidates totalling `X - new_max`
   bytes (via the priority read lock).
3. Resize thread acquires the priority write lock.
4. A concurrent `tryIncreasePriority` for SLRU promotes a
   probationary entry to protected. It performs the queue mutation
   under the priority write lock with size 0, then releases the
   priority write lock and acquires the state lock to call
   `incrementSize(prev_entry->size)` on the protected queue.
5. Resize thread `removeQueueEntries` (atomic `state.sub`); state
   lock is still released.
6. Resize thread re-acquires the state lock and calls
   `modifySizeLimits` — but the concurrent `incrementSize` from step 4
   has now grown `protected.state.size` above the new limit, so the
   guard in `LRUFileCachePriority::modifySizeLimits` throws.

## Fix

Keep the cache state lock held continuously across the entire
in-memory portion of the resize: from sampling eviction info,
through `collectCandidatesForEviction` and `removeQueueEntries`,
all the way through `modifySizeLimits`. The state lock is only
released after limits are applied, before the slow filesystem
eviction (`eviction_candidates.evict`).

`collectCandidatesForEviction` for the resize path uses only the
priority read lock internally and never re-acquires the cache state
lock, so holding the state lock here cannot deadlock.

The contention added to the state lock is bounded: the held section
contains only in-memory work (queue iteration plus atomic state
operations); filesystem eviction continues to run with the locks
released.

## Regression test

Added `FileCacheTest.SLRUDynamicResizeRaceWithIncreasePriority` that
runs concurrent resizes alongside multiple priority-bumping threads.
Without the fix, the test reproduces STID 4012-44fe within a few
hundred resize iterations and aborts the test process; with the fix,
all 600 resize iterations and concurrent priority bumps succeed.

## Verification

* Locally:
  * Without this commit (test only added) — test reproduces the
    exact stress-test failure (`Cannot modify size limits ...
    (slru_resize_race, protected)`) and aborts the binary.
  * With this commit — the new test passes (≈ 740 ms) and the
    full `FileCacheTest` suite (11 tests) continues to pass.

CI report (original failure):
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100700&sha=ea9b612eb138517e83b121f04fee05ac3bc2bc02&name_0=PR&name_1=Stress%20test%20%28arm_debug%29
PR that surfaced the request: https://github.com/ClickHouse/ClickHouse/pull/100700

Closes #95983 (re-occurrence of STID 4012-44fe).

cc @kssenii — assigning to you per @alexey-milovidov's request on
https://github.com/ClickHouse/ClickHouse/pull/100700 ; this preserves
the existing `LOGICAL_ERROR` invariant in `modifySizeLimits` rather
than weakening it (the approach reverted in #100271), and instead
removes the race that allowed the invariant to be violated.
cc @alexey-milovidov

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a `LOGICAL_ERROR` exception (`Cannot modify size limits ... not enough space freed`) that could occur during dynamic filesystem cache resize on config reload when concurrent file segment priority increases or space reservations grew the protected queue size between resize's eviction sample and the limit application.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)