### PR TITLE
Aggregate function combinators: TOTALS and BY

### DIFF
--- a/docs/en/sql-reference/aggregate-functions/combinators.md
+++ b/docs/en/sql-reference/aggregate-functions/combinators.md
@@ -309,6 +309,61 @@ Examples: `sumArgMin(column, expr)`, `countArgMin(expr)`, `avgArgMin(x, expr)` a
 
 Similar to suffix -ArgMin but processes only the rows that have the maximum value for the specified extra expression.
 
+## TOTALS {#totals}
+
+The `TOTALS` keyword can be placed inside the argument list of an aggregate function. The aggregate function is then evaluated over the entire input dataset, independently of `GROUP BY`. The same global value is returned in every output row.
+
+**Syntax**
+
+```sql
+<aggFunction>(<args> TOTALS)
+```
+
+**Example**
+
+```sql
+SELECT
+    country,
+    avg(salary) AS country_avg,
+    avg(salary TOTALS) AS global_avg
+FROM employees
+GROUP BY country;
+```
+
+The `country_avg` column contains the average salary per country, while `global_avg` contains the same global average value (over all rows) repeated in every row. This makes it convenient to compute and display percentage shares, ratios to the global value, and other comparative metrics without subqueries or window functions.
+
+The `TOTALS` combinator cannot be combined with `BY` on the same aggregate function call.
+
+## BY {#by}
+
+The `BY` keyword can be placed inside the argument list of an aggregate function, followed by a subset of the `GROUP BY` keys. The aggregate function is then evaluated per unique combination of these keys, regardless of the full grouping granularity. The result is the same for all output rows that share the same `BY` key combination.
+
+**Syntax**
+
+```sql
+<aggFunction>(<args> BY <key1>, <key2>, ...)
+```
+
+The columns listed after `BY` must be a subset of the query's `GROUP BY` keys.
+
+**Example**
+
+```sql
+SELECT
+    country,
+    city,
+    avg(salary) AS city_avg,
+    avg(salary BY country) AS country_avg
+FROM employees
+GROUP BY country, city;
+```
+
+Here `city_avg` is the average salary for each (country, city) pair, while `country_avg` is the average salary for each country (aggregated across all cities of that country). Rows with the same `country` share the same value of `country_avg`.
+
+If the `BY` column list is empty or contains a column that is not in `GROUP BY`, the query is rejected with `BAD_ARGUMENTS`.
+
+The `BY` combinator cannot be combined with `TOTALS` on the same aggregate function call.
+
 ## Related Content {#related-content}
 
 - Blog: [Using Aggregate Combinators in ClickHouse](https://clickhouse.com/blog/aggregate-functions-combinators-in-clickhouse-for-arrays-maps-and-states)

--- a/src/AggregateFunctions/AggregateFunctionAvg.h
+++ b/src/AggregateFunctions/AggregateFunctionAvg.h
@@ -326,7 +326,7 @@ public:
 
 
     void add(AggregateDataPtr __restrict place, const IColumn ** columns, size_t row_num, Arena *) const final
-    {        
+    {
         increment(place, Numerator(static_cast<const ColVecType &>(*columns[0]).getData()[row_num]));
         ++this->data(place).denominator;
     }

--- a/src/AggregateFunctions/AggregateFunctionAvg.h
+++ b/src/AggregateFunctions/AggregateFunctionAvg.h
@@ -326,9 +326,7 @@ public:
 
 
     void add(AggregateDataPtr __restrict place, const IColumn ** columns, size_t row_num, Arena *) const final
-    {
-        LOG_DEBUG(getLogger("AVG_ADD"), "add called, row={}", row_num);
-        
+    {        
         increment(place, Numerator(static_cast<const ColVecType &>(*columns[0]).getData()[row_num]));
         ++this->data(place).denominator;
     }

--- a/src/AggregateFunctions/AggregateFunctionAvg.h
+++ b/src/AggregateFunctions/AggregateFunctionAvg.h
@@ -12,6 +12,7 @@
 #include <DataTypes/DataTypeNullable.h>
 #include <AggregateFunctions/IAggregateFunction.h>
 #include <AggregateFunctions/AggregateFunctionSum.h>
+#include <Common/logger_useful.h>
 
 #include "config.h"
 
@@ -326,6 +327,8 @@ public:
 
     void add(AggregateDataPtr __restrict place, const IColumn ** columns, size_t row_num, Arena *) const final
     {
+        LOG_DEBUG(getLogger("AVG_ADD"), "add called, row={}", row_num);
+        
         increment(place, Numerator(static_cast<const ColVecType &>(*columns[0]).getData()[row_num]));
         ++this->data(place).denominator;
     }

--- a/src/AggregateFunctions/AggregateFunctionAvg.h
+++ b/src/AggregateFunctions/AggregateFunctionAvg.h
@@ -12,7 +12,6 @@
 #include <DataTypes/DataTypeNullable.h>
 #include <AggregateFunctions/IAggregateFunction.h>
 #include <AggregateFunctions/AggregateFunctionSum.h>
-#include <Common/logger_useful.h>
 
 #include "config.h"
 

--- a/src/Analyzer/FunctionNode.cpp
+++ b/src/Analyzer/FunctionNode.cpp
@@ -314,14 +314,6 @@ ASTPtr FunctionNode::toASTImpl(const ConvertToASTOptions & options) const
             function_ast->by_combinator_columns);
     }
 
-    if (hasOrderByCombinator())
-    {
-        function_ast->order_by_combinator = true;
-        auto order_by_list = getOrderByColumnsNode()->toAST(new_options);
-        function_ast->order_by_combinator_columns = order_by_list;
-        function_ast->children.push_back(function_ast->order_by_combinator_columns);
-    }
-
     return function_ast;
 }
 

--- a/src/Analyzer/FunctionNode.cpp
+++ b/src/Analyzer/FunctionNode.cpp
@@ -293,6 +293,22 @@ ASTPtr FunctionNode::toASTImpl(const ConvertToASTOptions & options) const
             function_ast->window_definition = window_node->toAST(new_options);
     }
 
+    if (is_totals_combinator)
+    {
+        function_ast->totals_combinator = true;
+    }
+    if (hasByCombinator())
+    {
+        function_ast->by_combinator = true;
+        auto by_list
+            = getByColumnsNode()
+                ->toAST(new_options);
+        function_ast->by_combinator_columns
+            = by_list;
+        function_ast->children.push_back(
+            function_ast->by_combinator_columns);
+    }
+
     return function_ast;
 }
 

--- a/src/Analyzer/FunctionNode.cpp
+++ b/src/Analyzer/FunctionNode.cpp
@@ -174,6 +174,9 @@ bool FunctionNode::isEqualImpl(const IQueryTreeNode & rhs, CompareOptions compar
         || nulls_action != rhs_typed.nulls_action)
         return false;
 
+    if (is_totals_combinator != rhs_typed.is_totals_combinator)
+        return false;
+
     /// is_operator is ignored here because it affects only AST formatting
 
     if (!compare_options.compare_types)
@@ -205,6 +208,7 @@ void FunctionNode::updateTreeHashImpl(HashState & hash_state, CompareOptions com
     hash_state.update(isAggregateFunction());
     hash_state.update(isWindowFunction());
     hash_state.update(nulls_action);
+    hash_state.update(is_totals_combinator);
 
     /// is_operator is ignored here because it affects only AST formatting
 
@@ -230,6 +234,7 @@ QueryTreeNodePtr FunctionNode::cloneImpl() const
     result_function->nulls_action = nulls_action;
     result_function->wrap_with_nullable = wrap_with_nullable;
     result_function->is_operator = is_operator;
+    result_function->is_totals_combinator = is_totals_combinator;
 
     return result_function;
 }
@@ -307,6 +312,14 @@ ASTPtr FunctionNode::toASTImpl(const ConvertToASTOptions & options) const
             = by_list;
         function_ast->children.push_back(
             function_ast->by_combinator_columns);
+    }
+
+    if (hasOrderByCombinator())
+    {
+        function_ast->order_by_combinator = true;
+        auto order_by_list = getOrderByColumnsNode()->toAST(new_options);
+        function_ast->order_by_combinator_columns = order_by_list;
+        function_ast->children.push_back(function_ast->order_by_combinator_columns);
     }
 
     return function_ast;

--- a/src/Analyzer/FunctionNode.h
+++ b/src/Analyzer/FunctionNode.h
@@ -114,6 +114,32 @@ public:
       */
     QueryTreeNodePtr & getWindowNode() { return children[window_child_index]; }
 
+    bool hasByCombinator() const
+    {
+        return children[by_columns_child_index]
+            != nullptr;
+    }
+
+    QueryTreeNodePtr & getByColumnsNode()
+    {
+        return children[by_columns_child_index];
+    }
+
+    const QueryTreeNodePtr & getByColumnsNode() const
+    {
+        return children[by_columns_child_index];
+    }
+
+    bool hasTotalsCombinator() const
+    {
+        return is_totals_combinator;
+    }
+
+    void setTotalsCombinator()
+    {
+        is_totals_combinator = true;
+    }
+
     /** Get ordinary function.
       * If function is not resolved or is resolved as non ordinary function nullptr is returned.
       */
@@ -222,11 +248,13 @@ private:
     bool wrap_with_nullable = false;
     /// Function was parsed as operator. This option is only needed to make AST formatting more consistent.
     bool is_operator = false;
+    bool is_totals_combinator = false;
 
     static constexpr size_t parameters_child_index = 0;
     static constexpr size_t arguments_child_index = 1;
     static constexpr size_t window_child_index = 2;
-    static constexpr size_t children_size = window_child_index + 1;
+    static constexpr size_t by_columns_child_index = 3;
+    static constexpr size_t children_size = by_columns_child_index + 1;
 };
 
 }

--- a/src/Analyzer/FunctionNode.h
+++ b/src/Analyzer/FunctionNode.h
@@ -135,22 +135,6 @@ public:
         return is_totals_combinator;
     }
 
-    bool hasOrderByCombinator() const
-    {
-        return children[order_by_columns_child_index]
-            && !children[order_by_columns_child_index]->as<ListNode &>().getNodes().empty();
-    }
-
-    QueryTreeNodePtr & getOrderByColumnsNode()
-    {
-        return children[order_by_columns_child_index];
-    }
-
-    const QueryTreeNodePtr & getOrderByColumnsNode() const
-    {
-        return children[order_by_columns_child_index];
-    }
-
     void setTotalsCombinator()
     {
         is_totals_combinator = true;
@@ -270,8 +254,7 @@ private:
     static constexpr size_t arguments_child_index = 1;
     static constexpr size_t window_child_index = 2;
     static constexpr size_t by_columns_child_index = 3;
-    static constexpr size_t order_by_columns_child_index = 4;
-    static constexpr size_t children_size = order_by_columns_child_index + 1;
+    static constexpr size_t children_size = by_columns_child_index + 1;
 };
 
 }

--- a/src/Analyzer/FunctionNode.h
+++ b/src/Analyzer/FunctionNode.h
@@ -135,6 +135,22 @@ public:
         return is_totals_combinator;
     }
 
+    bool hasOrderByCombinator() const
+    {
+        return children[order_by_columns_child_index]
+            && !children[order_by_columns_child_index]->as<ListNode &>().getNodes().empty();
+    }
+
+    QueryTreeNodePtr & getOrderByColumnsNode()
+    {
+        return children[order_by_columns_child_index];
+    }
+
+    const QueryTreeNodePtr & getOrderByColumnsNode() const
+    {
+        return children[order_by_columns_child_index];
+    }
+
     void setTotalsCombinator()
     {
         is_totals_combinator = true;
@@ -254,7 +270,8 @@ private:
     static constexpr size_t arguments_child_index = 1;
     static constexpr size_t window_child_index = 2;
     static constexpr size_t by_columns_child_index = 3;
-    static constexpr size_t children_size = by_columns_child_index + 1;
+    static constexpr size_t order_by_columns_child_index = 4;
+    static constexpr size_t children_size = order_by_columns_child_index + 1;
 };
 
 }

--- a/src/Analyzer/Passes/FuseFunctionsPass.cpp
+++ b/src/Analyzer/Passes/FuseFunctionsPass.cpp
@@ -101,6 +101,10 @@ public:
         if (!function_node || !function_node->isAggregateFunction() || !names_to_collect.contains(function_node->getFunctionName()))
             return;
 
+        /// Do not fuse functions with TOTALS/BY combinators — fusing loses the combinator flag.
+        if (function_node->hasTotalsCombinator() || function_node->hasByCombinator())
+            return;
+
         if (function_node->getResultType()->isNullable())
             /// Do not apply to functions with Nullable result type, because `sumCount` handles it different from `sum` and `avg`.
             return;

--- a/src/Analyzer/QueryTreeBuilder.cpp
+++ b/src/Analyzer/QueryTreeBuilder.cpp
@@ -776,6 +776,27 @@ QueryTreeNodePtr QueryTreeBuilder::buildExpression(const ASTPtr & expression, co
                         function_node->getWindowNode() = std::make_shared<IdentifierNode>(Identifier(function->window_name));
                 }
 
+                if (function->totals_combinator)
+                {
+                    function_node->setTotalsCombinator();
+                }
+                
+                if (function->by_combinator
+                    && function->by_combinator_columns)
+                {
+                    auto by_list
+                        = std::make_shared<ListNode>();
+                    const auto & by_cols
+                        = function->by_combinator_columns
+                            ->as<ASTExpressionList>()
+                            ->children;
+                    for (const auto & col : by_cols)
+                        by_list->getNodes().push_back(
+                            buildExpression(col, context));
+                    function_node->getByColumnsNode()
+                        = std::move(by_list);
+                }
+
                 result = std::move(function_node);
             }
         }

--- a/src/Analyzer/QueryTreeBuilder.cpp
+++ b/src/Analyzer/QueryTreeBuilder.cpp
@@ -797,22 +797,6 @@ QueryTreeNodePtr QueryTreeBuilder::buildExpression(const ASTPtr & expression, co
                         = std::move(by_list);
                 }
 
-                if (function->order_by_combinator
-                    && function->order_by_combinator_columns)
-                {
-                    auto order_by_list
-                        = std::make_shared<ListNode>();
-                    const auto & order_by_cols
-                        = function->order_by_combinator_columns
-                            ->as<ASTExpressionList>()
-                            ->children;
-                    for (const auto & col : order_by_cols)
-                        order_by_list->getNodes().push_back(
-                            buildExpression(col, context));
-                    function_node->getOrderByColumnsNode()
-                        = std::move(order_by_list);
-                }
-
                 result = std::move(function_node);
             }
         }

--- a/src/Analyzer/QueryTreeBuilder.cpp
+++ b/src/Analyzer/QueryTreeBuilder.cpp
@@ -780,7 +780,7 @@ QueryTreeNodePtr QueryTreeBuilder::buildExpression(const ASTPtr & expression, co
                 {
                     function_node->setTotalsCombinator();
                 }
-                
+
                 if (function->by_combinator
                     && function->by_combinator_columns)
                 {

--- a/src/Analyzer/QueryTreeBuilder.cpp
+++ b/src/Analyzer/QueryTreeBuilder.cpp
@@ -797,6 +797,22 @@ QueryTreeNodePtr QueryTreeBuilder::buildExpression(const ASTPtr & expression, co
                         = std::move(by_list);
                 }
 
+                if (function->order_by_combinator
+                    && function->order_by_combinator_columns)
+                {
+                    auto order_by_list
+                        = std::make_shared<ListNode>();
+                    const auto & order_by_cols
+                        = function->order_by_combinator_columns
+                            ->as<ASTExpressionList>()
+                            ->children;
+                    for (const auto & col : order_by_cols)
+                        order_by_list->getNodes().push_back(
+                            buildExpression(col, context));
+                    function_node->getOrderByColumnsNode()
+                        = std::move(order_by_list);
+                }
+
                 result = std::move(function_node);
             }
         }

--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -464,7 +464,7 @@ ProjectionName QueryAnalyzer::calculateFunctionProjectionName(const QueryTreeNod
     {
         buffer << " TOTALS";
     }
-    
+
     if (function_node_typed.hasByCombinator())
     {
         const auto & by_nodes

--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -460,6 +460,33 @@ ProjectionName QueryAnalyzer::calculateFunctionProjectionName(const QueryTreeNod
             buffer << ", ";
     }
 
+    if (function_node_typed.hasTotalsCombinator())
+    {
+        buffer << " TOTALS";
+    }
+    
+    if (function_node_typed.hasByCombinator())
+    {
+        const auto & by_nodes
+            = function_node_typed
+                .getByColumnsNode()
+                ->as<ListNode &>().getNodes();
+        buffer << " BY ";
+        for (size_t i = 0;
+            i < by_nodes.size(); ++i)
+        {
+            if (auto * id = by_nodes[i]
+                    ->as<IdentifierNode>())
+                buffer << id->getIdentifier()
+                    .getFullName();
+            else if (auto * col = by_nodes[i]
+                    ->as<ColumnNode>())
+                buffer << col->getColumnName();
+            if (i + 1 != by_nodes.size())
+                buffer << ", ";
+        }
+    }
+
     buffer << close_bracket;
 
     return buffer.str();

--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -472,15 +472,11 @@ ProjectionName QueryAnalyzer::calculateFunctionProjectionName(const QueryTreeNod
                 .getByColumnsNode()
                 ->as<ListNode &>().getNodes();
         buffer << " BY ";
-        for (size_t i = 0;
-            i < by_nodes.size(); ++i)
+        for (size_t i = 0; i < by_nodes.size(); ++i)
         {
-            if (auto * id = by_nodes[i]
-                    ->as<IdentifierNode>())
-                buffer << id->getIdentifier()
-                    .getFullName();
-            else if (auto * col = by_nodes[i]
-                    ->as<ColumnNode>())
+            if (auto * id = by_nodes[i]->as<IdentifierNode>())
+                buffer << id->getIdentifier().getFullName();
+            else if (auto * col = by_nodes[i]->as<ColumnNode>())
                 buffer << col->getColumnName();
             if (i + 1 != by_nodes.size())
                 buffer << ", ";

--- a/src/Analyzer/Resolve/resolveFunction.cpp
+++ b/src/Analyzer/Resolve/resolveFunction.cpp
@@ -1116,15 +1116,6 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
             false /*allow_table_expression*/);
     }
 
-    if (function_node_ptr->hasOrderByCombinator())
-    {
-        resolveExpressionNodeList(
-            function_node_ptr->getOrderByColumnsNode(),
-            scope,
-            false /*allow_lambda_expression*/,
-            false /*allow_table_expression*/);
-    }
-
     auto & function_node = *function_node_ptr;
 
     /// Replace right IN function argument if it is table or table function with subquery that read ordinary columns

--- a/src/Analyzer/Resolve/resolveFunction.cpp
+++ b/src/Analyzer/Resolve/resolveFunction.cpp
@@ -1116,6 +1116,15 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
             false /*allow_table_expression*/);
     }
 
+    if (function_node_ptr->hasOrderByCombinator())
+    {
+        resolveExpressionNodeList(
+            function_node_ptr->getOrderByColumnsNode(),
+            scope,
+            false /*allow_lambda_expression*/,
+            false /*allow_table_expression*/);
+    }
+
     auto & function_node = *function_node_ptr;
 
     /// Replace right IN function argument if it is table or table function with subquery that read ordinary columns

--- a/src/Analyzer/Resolve/resolveFunction.cpp
+++ b/src/Analyzer/Resolve/resolveFunction.cpp
@@ -1104,6 +1104,18 @@ ProjectionNames QueryAnalyzer::resolveFunction(QueryTreeNodePtr & node, Identifi
         }
     }
 
+    /// Resolve BY-combinator columns (avg(x BY a, b)) — these were left as
+    /// IDENTIFIER nodes by the parser; resolve them like ordinary arguments,
+    /// so they reference real columns by the time we calculate action node names.
+    if (function_node_ptr->hasByCombinator())
+    {
+        resolveExpressionNodeList(
+            function_node_ptr->getByColumnsNode(),
+            scope,
+            false /*allow_lambda_expression*/,
+            false /*allow_table_expression*/);
+    }
+
     auto & function_node = *function_node_ptr;
 
     /// Replace right IN function argument if it is table or table function with subquery that read ordinary columns

--- a/src/Interpreters/AggregateDescription.h
+++ b/src/Interpreters/AggregateDescription.h
@@ -24,6 +24,7 @@ struct AggregateDescription
     /// TOTALS/BY combinators
     bool totals_combinator = false;
     std::optional<Names> by_columns;
+    std::optional<Names> order_by_columns;
 
     void explain(WriteBuffer & out, const std::string & prefix, size_t additonal_indent) const; /// Get description for EXPLAIN query.
     void explain(JSONBuilder::JSONMap & map) const;

--- a/src/Interpreters/AggregateDescription.h
+++ b/src/Interpreters/AggregateDescription.h
@@ -24,7 +24,6 @@ struct AggregateDescription
     /// TOTALS/BY combinators
     bool totals_combinator = false;
     std::optional<Names> by_columns;
-    std::optional<Names> order_by_columns;
 
     void explain(WriteBuffer & out, const std::string & prefix, size_t additonal_indent) const; /// Get description for EXPLAIN query.
     void explain(JSONBuilder::JSONMap & map) const;

--- a/src/Interpreters/AggregateDescription.h
+++ b/src/Interpreters/AggregateDescription.h
@@ -21,6 +21,10 @@ struct AggregateDescription
     Names argument_names;
     String column_name;      /// What name to use for a column with aggregate function values
 
+    /// TOTALS/BY combinators
+    bool totals_combinator = false;
+    std::optional<Names> by_columns;
+
     void explain(WriteBuffer & out, const std::string & prefix, size_t additonal_indent) const; /// Get description for EXPLAIN query.
     void explain(JSONBuilder::JSONMap & map) const;
 

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -1816,6 +1816,9 @@ Aggregator::AggregatedChunk Aggregator::mergeAndConvertOneBucketToChunk(
     auto method = merged_data.type;
     AggregatedChunk agg_chunk;
 
+    if (final)
+        computePostAggregationStates(merged_data);
+
     if (false) {} // NOLINT
 #define M(NAME) \
     else if (method == AggregatedDataVariants::Type::NAME) \
@@ -1877,6 +1880,9 @@ void Aggregator::mergeSingleLevelDataImplFixedMap(
 
 Aggregator::AggregatedChunk Aggregator::convertOneBucketToChunk(AggregatedDataVariants & variants, Arena * arena, bool final, Int32 bucket) const
 {
+    if (final)
+        computePostAggregationStates(variants);
+
     const auto method = variants.type;
     AggregatedChunk agg_chunk;
 
@@ -2651,80 +2657,8 @@ Aggregator::prepareChunkAndFillSingleLevel(AggregatedDataVariants & data_variant
     /// hash table once, before any chunk conversion starts. This has to happen here
     /// (and in prepareChunksAndFillTwoLevel), because insertResultsIntoColumns sees
     /// only per-chunk places and cannot merge globally.
-    if (final && !post_aggregation.empty() && !post_aggregation.isComputed())
-    {
-        Arena * keys_arena = data_variants.aggregates_pool;
-
-        if (!post_aggregation.hasByStates())
-        {
-            /// Fast path: only TOTALS states — keys are not needed.
-#define COMPUTE_POST_TOTALS_ONLY(NAME) \
-            else if (data_variants.type == AggregatedDataVariants::Type::NAME) \
-            { \
-                data_variants.NAME->data.forEachValue([&](const auto & /*key*/, auto & mapped) \
-                { \
-                    if (mapped) \
-                        for (size_t idx = 0; idx < params.aggregates_size; ++idx) \
-                            if (auto * ps = post_aggregation.find(idx)) \
-                                ps->absorb(mapped, nullptr, 0, keys_arena); \
-                }); \
-            }
-
-            if (false) {} // NOLINT
-            APPLY_FOR_VARIANTS_SINGLE_LEVEL(COMPUTE_POST_TOTALS_ONLY)
-#undef COMPUTE_POST_TOTALS_ONLY
-            else {}
-        }
-        else
-        {
-            /// Slow path: BY states present — we need keys materialized per row.
-            /// We iterate the hash table, materializing keys into temporary columns,
-            /// then call absorb() with those columns.
-
-            IColumn::SerializationSettings serialization_settings{
-                .serialize_string_with_zero_byte = params.serialize_string_with_zero_byte};
-
-            /// Create temporary key columns of the correct types.
-            MutableColumns tmp_key_cols;
-            tmp_key_cols.reserve(params.keys_size);
-            for (size_t i = 0; i < params.keys_size; ++i)
-                tmp_key_cols.emplace_back(key_types[i]->createColumn());
-
-            /// Array of raw pointers for insertKeyIntoColumns.
-            std::vector<IColumn *> raw_key_cols(params.keys_size);
-            for (size_t i = 0; i < params.keys_size; ++i)
-                raw_key_cols[i] = tmp_key_cols[i].get();
-
-#define COMPUTE_POST_WITH_KEYS(NAME) \
-            else if (data_variants.type == AggregatedDataVariants::Type::NAME) \
-            { \
-                auto & method_ref = *data_variants.NAME; \
-                std::vector<AggregateDataPtr> places_vec; \
-                method_ref.data.forEachValue([&](const auto & key, auto & mapped) \
-                { \
-                    if (!mapped) return; \
-                    method_ref.insertKeyIntoColumns(key, raw_key_cols, key_sizes, &serialization_settings); \
-                    places_vec.push_back(mapped); \
-                }); \
-                \
-                std::vector<const IColumn *> const_key_cols(params.keys_size); \
-                for (size_t i = 0; i < params.keys_size; ++i) \
-                    const_key_cols[i] = tmp_key_cols[i].get(); \
-                \
-                for (size_t row = 0; row < places_vec.size(); ++row) \
-                    for (size_t idx = 0; idx < params.aggregates_size; ++idx) \
-                        if (auto * ps = post_aggregation.find(idx)) \
-                            ps->absorb(places_vec[row], const_key_cols.data(), row, keys_arena); \
-            }
-
-            if (false) {} // NOLINT
-            APPLY_FOR_VARIANTS_SINGLE_LEVEL(COMPUTE_POST_WITH_KEYS)
-#undef COMPUTE_POST_WITH_KEYS
-            else {}
-        }
-
-        post_aggregation.markComputed();
-    }
+    if (final)
+    computePostAggregationStates(data_variants);
 
     Chunks res_variant;
     const size_t rows = data_variants.sizeWithoutOverflowRow();
@@ -2756,87 +2690,12 @@ Aggregator::prepareChunkAndFillSingleLevel(AggregatedDataVariants & data_variant
 
 Aggregator::AggregatedChunks Aggregator::prepareChunksAndFillTwoLevel(AggregatedDataVariants & data_variants, bool final) const
 {
-/// For TOTALS/BY: pre-compute post-aggregation states by iterating over all buckets
+    /// For TOTALS/BY: pre-compute post-aggregation states by iterating over all buckets
     /// of the two-level hash table sequentially, BEFORE the thread pool in
     /// prepareChunksAndFillTwoLevelImpl kicks in. This guarantees no race between
     /// post-state accumulation and parallel bucket-to-chunk conversion.
-    if (final && !post_aggregation.empty() && !post_aggregation.isComputed())
-    {
-        Arena * keys_arena = data_variants.aggregates_pool;
-
-        if (!post_aggregation.hasByStates())
-        {
-            /// Fast path: only TOTALS states — keys are not needed.
-#define COMPUTE_POST_TL_TOTALS_ONLY(NAME) \
-            else if (data_variants.type == AggregatedDataVariants::Type::NAME) \
-            { \
-                auto & method_ref = *data_variants.NAME; \
-                for (size_t bucket = 0; bucket < method_ref.data.NUM_BUCKETS; ++bucket) \
-                { \
-                    method_ref.data.impls[bucket].forEachValue([&](const auto & /*key*/, auto & mapped) \
-                    { \
-                        if (mapped) \
-                            for (size_t idx = 0; idx < params.aggregates_size; ++idx) \
-                                if (auto * ps = post_aggregation.find(idx)) \
-                                    ps->absorb(mapped, nullptr, 0, keys_arena); \
-                    }); \
-                } \
-            }
-
-            if (false) {} // NOLINT
-            APPLY_FOR_VARIANTS_TWO_LEVEL(COMPUTE_POST_TL_TOTALS_ONLY)
-#undef COMPUTE_POST_TL_TOTALS_ONLY
-            else {}
-        }
-        else
-        {
-            /// Slow path: BY states present — materialize keys, absorb with keys.
-            IColumn::SerializationSettings serialization_settings{
-                .serialize_string_with_zero_byte = params.serialize_string_with_zero_byte};
-
-#define COMPUTE_POST_TL_WITH_KEYS(NAME) \
-            else if (data_variants.type == AggregatedDataVariants::Type::NAME) \
-            { \
-                auto & method_ref = *data_variants.NAME; \
-                \
-                for (size_t bucket = 0; bucket < method_ref.data.NUM_BUCKETS; ++bucket) \
-                { \
-                    MutableColumns tmp_key_cols; \
-                    tmp_key_cols.reserve(params.keys_size); \
-                    for (size_t i = 0; i < params.keys_size; ++i) \
-                        tmp_key_cols.emplace_back(key_types[i]->createColumn()); \
-                    \
-                    std::vector<IColumn *> raw_key_cols(params.keys_size); \
-                    for (size_t i = 0; i < params.keys_size; ++i) \
-                        raw_key_cols[i] = tmp_key_cols[i].get(); \
-                    \
-                    std::vector<AggregateDataPtr> places_vec; \
-                    method_ref.data.impls[bucket].forEachValue([&](const auto & key, auto & mapped) \
-                    { \
-                        if (!mapped) return; \
-                        method_ref.insertKeyIntoColumns(key, raw_key_cols, key_sizes, &serialization_settings); \
-                        places_vec.push_back(mapped); \
-                    }); \
-                    \
-                    std::vector<const IColumn *> const_key_cols(params.keys_size); \
-                    for (size_t i = 0; i < params.keys_size; ++i) \
-                        const_key_cols[i] = tmp_key_cols[i].get(); \
-                    \
-                    for (size_t row = 0; row < places_vec.size(); ++row) \
-                        for (size_t idx = 0; idx < params.aggregates_size; ++idx) \
-                            if (auto * ps = post_aggregation.find(idx)) \
-                                ps->absorb(places_vec[row], const_key_cols.data(), row, keys_arena); \
-                } \
-            }
-
-            if (false) {} // NOLINT
-            APPLY_FOR_VARIANTS_TWO_LEVEL(COMPUTE_POST_TL_WITH_KEYS)
-#undef COMPUTE_POST_TL_WITH_KEYS
-            else {}
-        }
-
-        post_aggregation.markComputed();
-    }
+    if (final)
+        computePostAggregationStates(data_variants);
 
 #define M(NAME) \
     else if (data_variants.type == AggregatedDataVariants::Type::NAME) \
@@ -2908,6 +2767,150 @@ Aggregator::AggregatedChunks Aggregator::prepareChunksAndFillTwoLevelImpl(Aggreg
     return chunks;
 }
 
+void Aggregator::computePostAggregationStates(AggregatedDataVariants & data_variants) const
+{
+    if (post_aggregation.empty())
+        return;
+
+    post_aggregation.computeOnce([&]() {
+        Arena * keys_arena = data_variants.aggregates_pool;
+
+        const bool two_level = data_variants.isTwoLevel();
+
+        if (!post_aggregation.hasByStates())
+        {
+            /// FAST PATH: only TOTALS combinators, keys are not needed.
+
+            if (!two_level)
+            {
+                /// Single-level: walk the only hash table.
+
+                #define COMPUTE_POST_TOTALS_ONLY_SL(NAME) \
+                    else if (data_variants.type == AggregatedDataVariants::Type::NAME) \
+                    { \
+                        data_variants.NAME->data.forEachValue([&](const auto & /*key*/, auto & mapped) \
+                        { \
+                            if (mapped) \
+                                for (size_t idx = 0; idx < params.aggregates_size; ++idx) \
+                                    if (auto * ps = post_aggregation.find(idx)) \
+                                        ps->absorb(mapped, nullptr, 0, keys_arena); \
+                        }); \
+                    }
+
+                if (false) {} // NOLINT
+                APPLY_FOR_VARIANTS_SINGLE_LEVEL(COMPUTE_POST_TOTALS_ONLY_SL)
+                #undef COMPUTE_POST_TOTALS_ONLY_SL
+            }
+            else
+            {
+                /// Two-level: walk all 256 buckets sequentially.
+
+                #define COMPUTE_POST_TOTALS_ONLY_TL(NAME) \
+                    else if (data_variants.type == AggregatedDataVariants::Type::NAME) \
+                    { \
+                        auto & method_ref = *data_variants.NAME; \
+                        for (size_t bucket = 0; bucket < method_ref.data.NUM_BUCKETS; ++bucket) \
+                        { \
+                            method_ref.data.impls[bucket].forEachValue([&](const auto & /*key*/, auto & mapped) \
+                            { \
+                                if (mapped) \
+                                    for (size_t idx = 0; idx < params.aggregates_size; ++idx) \
+                                        if (auto * ps = post_aggregation.find(idx)) \
+                                            ps->absorb(mapped, nullptr, 0, keys_arena); \
+                            }); \
+                        } \
+                    }
+
+                if (false) {} // NOLINT
+                APPLY_FOR_VARIANTS_TWO_LEVEL(COMPUTE_POST_TOTALS_ONLY_TL)
+                #undef COMPUTE_POST_TOTALS_ONLY_TL
+            }
+        }
+        else
+        {
+            /// SLOW PATH: at least one BY combinator, keys must be materialized.
+
+            IColumn::SerializationSettings serialization_settings{
+                .serialize_string_with_zero_byte = params.serialize_string_with_zero_byte};
+
+            if (!two_level)
+            {
+                /// Single-level: materialize keys into temporary columns once for the whole table.
+
+                MutableColumns tmp_key_cols;
+                tmp_key_cols.reserve(params.keys_size);
+                for (size_t i = 0; i < params.keys_size; ++i)
+                    tmp_key_cols.emplace_back(key_types[i]->createColumn());
+
+                std::vector<IColumn *> raw_key_cols(params.keys_size);
+                for (size_t i = 0; i < params.keys_size; ++i)
+                    raw_key_cols[i] = tmp_key_cols[i].get();
+
+                #define COMPUTE_POST_WITH_KEYS_SL(NAME) \
+                    else if (data_variants.type == AggregatedDataVariants::Type::NAME) \
+                    { \
+                        auto & method_ref = *data_variants.NAME; \
+                        std::vector<AggregateDataPtr> places_vec; \
+                        method_ref.data.forEachValue([&](const auto & key, auto & mapped) \
+                        { \
+                            if (!mapped) return; \
+                            method_ref.insertKeyIntoColumns(key, raw_key_cols, key_sizes, &serialization_settings); \
+                            places_vec.push_back(mapped); \
+                        }); \
+                        std::vector<const IColumn *> const_key_cols(params.keys_size); \
+                        for (size_t i = 0; i < params.keys_size; ++i) \
+                            const_key_cols[i] = tmp_key_cols[i].get(); \
+                        for (size_t row = 0; row < places_vec.size(); ++row) \
+                            for (size_t idx = 0; idx < params.aggregates_size; ++idx) \
+                                if (auto * ps = post_aggregation.find(idx)) \
+                                    ps->absorb(places_vec[row], const_key_cols.data(), row, keys_arena); \
+                    }
+
+                if (false) {} // NOLINT
+                APPLY_FOR_VARIANTS_SINGLE_LEVEL(COMPUTE_POST_WITH_KEYS_SL)
+                #undef COMPUTE_POST_WITH_KEYS_SL
+            }
+            else
+            {
+                /// Two-level: process each bucket with its own temporary key columns.
+
+                #define COMPUTE_POST_WITH_KEYS_TL(NAME) \
+                    else if (data_variants.type == AggregatedDataVariants::Type::NAME) \
+                    { \
+                        auto & method_ref = *data_variants.NAME; \
+                        for (size_t bucket = 0; bucket < method_ref.data.NUM_BUCKETS; ++bucket) \
+                        { \
+                            MutableColumns tmp_key_cols; \
+                            tmp_key_cols.reserve(params.keys_size); \
+                            for (size_t i = 0; i < params.keys_size; ++i) \
+                                tmp_key_cols.emplace_back(key_types[i]->createColumn()); \
+                            std::vector<IColumn *> raw_key_cols(params.keys_size); \
+                            for (size_t i = 0; i < params.keys_size; ++i) \
+                                raw_key_cols[i] = tmp_key_cols[i].get(); \
+                            std::vector<AggregateDataPtr> places_vec; \
+                            method_ref.data.impls[bucket].forEachValue([&](const auto & key, auto & mapped) \
+                            { \
+                                if (!mapped) return; \
+                                method_ref.insertKeyIntoColumns(key, raw_key_cols, key_sizes, &serialization_settings); \
+                                places_vec.push_back(mapped); \
+                            }); \
+                            std::vector<const IColumn *> const_key_cols(params.keys_size); \
+                            for (size_t i = 0; i < params.keys_size; ++i) \
+                                const_key_cols[i] = tmp_key_cols[i].get(); \
+                            for (size_t row = 0; row < places_vec.size(); ++row) \
+                                for (size_t idx = 0; idx < params.aggregates_size; ++idx) \
+                                    if (auto * ps = post_aggregation.find(idx)) \
+                                        ps->absorb(places_vec[row], const_key_cols.data(), row, keys_arena); \
+                        } \
+                    }
+
+                if (false) {} // NOLINT
+                APPLY_FOR_VARIANTS_TWO_LEVEL(COMPUTE_POST_WITH_KEYS_TL)
+                #undef COMPUTE_POST_WITH_KEYS_TL
+            }
+        }
+    });
+}
 
 Aggregator::AggregatedChunks Aggregator::convertToChunks(AggregatedDataVariants & data_variants, bool final) const
 {

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -817,6 +817,10 @@ void Aggregator::createAggregateStates(AggregateDataPtr & aggregate_data) const
               * In order that then everything is properly destroyed, we "roll back" some of the created states.
               * The code is not very convenient.
               */
+
+            LOG_DEBUG(getLogger("AGGREGATOR"),
+                "creating new aggregate state, "
+                "function index={}", j);
             aggregate_functions[j]->create(aggregate_data + offsets_of_aggregate_states[j]);
         }
         catch (...)
@@ -1596,6 +1600,11 @@ bool Aggregator::executeOnBlock(Columns columns,
     AggregateColumns & aggregate_columns,
     bool & no_more_keys) const
 {
+
+    LOG_DEBUG(getLogger("AGGREGATOR"),
+    "executeOnBlock, rows={}",
+    row_end - row_begin);
+
     /// `result` will destroy the states of aggregate functions in the destructor
     result.aggregator = this;
 
@@ -2037,6 +2046,9 @@ template <typename Method, typename Table>
 Chunks
 Aggregator::convertToBlockImpl(Method & method, Table & data, Arena * arena, Arenas & aggregates_pools, bool final,size_t rows, bool return_single_block) const
 {
+    LOG_DEBUG(getLogger("AGGREGATOR"),
+        "convertToBlockImpl: finalizing, "
+        "rows={}", rows);
     if (data.empty())
     {
         auto && out_cols = prepareOutputBlockColumns(params, aggregate_functions, key_types, aggregate_state_types, aggregates_pools, final, rows);
@@ -2206,10 +2218,14 @@ inline void Aggregator::insertAggregatesIntoColumns(Mapped & mapped, MutableColu
     {
         /// Insert final values of aggregate functions into columns.
         for (; insert_i < params.aggregates_size; ++insert_i)
-            aggregate_functions[insert_i]->insertResultInto(
-                mapped + offsets_of_aggregate_states[insert_i],
-                *final_aggregate_columns[insert_i],
-                arena);
+        {
+            LOG_DEBUG(getLogger("AGGREGATOR"), "insertResultInto, func={}", insert_i);
+            aggregate_functions[insert_i]
+                ->insertResultInto(
+                    mapped + offsets_of_aggregate_states[insert_i],
+                    *final_aggregate_columns[insert_i],
+                    arena);
+        }
     }
     catch (...)
     {
@@ -2281,6 +2297,69 @@ Chunk Aggregator::insertResultsIntoColumns(
             callJITFunction(insert_aggregates_into_columns_function, 0, places.size(), columns_data.data(), places.data());
         }
 #endif
+        // TOTALS combinator: merge all states
+        // into one and fill column with
+        // global value
+        for (size_t i = 0;
+            i < params.aggregates_size; ++i)
+        {
+            if (!params.aggregates[i]
+                    .totals_combinator)
+                continue;
+
+
+            LOG_DEBUG(getLogger("TOTALS_IMPL"),
+                "processing TOTALS for func {}",
+                i);
+
+            auto & final_col
+                = out_cols.final_aggregate_columns[i];
+            size_t offset
+                = offsets_of_aggregate_states[i];
+
+            // Create global state
+            Arena totals_arena;
+            auto global_place
+                = totals_arena.alignedAlloc(
+                    aggregate_functions[i]
+                        ->sizeOfData(),
+                    aggregate_functions[i]
+                        ->alignOfData());
+            aggregate_functions[i]
+                ->create(global_place);
+
+            // Merge all states into global
+            for (size_t j = 0;
+                j < places.size(); ++j)
+            {
+                aggregate_functions[i]->merge(
+                    global_place,
+                    places[j] + offset,
+                    &totals_arena);
+            }
+
+            // Finalize global state
+            // into a temporary column
+            auto tmp_col = final_col->cloneEmpty();
+            aggregate_functions[i]
+                ->insertResultInto(
+                    global_place,
+                    *tmp_col,
+                    &totals_arena);
+
+            // Fill all rows with this value
+            final_col = final_col->cloneEmpty();
+            for (size_t j = 0;
+                j < places.size(); ++j)
+            {
+                final_col->insertFrom(*tmp_col, 0);
+            }
+
+            // Destroy global state
+            aggregate_functions[i]
+                ->destroy(global_place);
+        }
+        
 
         for (; aggregate_functions_destroy_index < params.aggregates_size;)
         {
@@ -2291,6 +2370,15 @@ Chunk Aggregator::insertResultsIntoColumns(
                 continue;
             }
 #endif
+
+            // Skip TOTALS — already processed
+            if (params.aggregates[
+                    aggregate_functions_destroy_index]
+                    .totals_combinator)
+            {
+                ++aggregate_functions_destroy_index;
+                continue;
+            }
 
             auto & final_aggregate_column = out_cols.final_aggregate_columns[aggregate_functions_destroy_index];
             size_t offset = offsets_of_aggregate_states[aggregate_functions_destroy_index];

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -719,7 +719,10 @@ Aggregator::Aggregator(const Block & header_, const Params & params_)
 #if USE_EMBEDDED_COMPILER
     compileAggregateFunctionsIfNeeded();
 #endif
-}
+
+    
+    /// Initialize post-aggregation for TOTALS/BY combinators.
+    post_aggregation.init(params.aggregates, aggregate_functions, offsets_of_aggregate_states, params.keys);}
 
 Aggregator::~Aggregator() = default;
 
@@ -817,10 +820,6 @@ void Aggregator::createAggregateStates(AggregateDataPtr & aggregate_data) const
               * In order that then everything is properly destroyed, we "roll back" some of the created states.
               * The code is not very convenient.
               */
-
-            LOG_DEBUG(getLogger("AGGREGATOR"),
-                "creating new aggregate state, "
-                "function index={}", j);
             aggregate_functions[j]->create(aggregate_data + offsets_of_aggregate_states[j]);
         }
         catch (...)
@@ -1600,11 +1599,6 @@ bool Aggregator::executeOnBlock(Columns columns,
     AggregateColumns & aggregate_columns,
     bool & no_more_keys) const
 {
-
-    LOG_DEBUG(getLogger("AGGREGATOR"),
-    "executeOnBlock, rows={}",
-    row_end - row_begin);
-
     /// `result` will destroy the states of aggregate functions in the destructor
     result.aggregator = this;
 
@@ -2046,9 +2040,6 @@ template <typename Method, typename Table>
 Chunks
 Aggregator::convertToBlockImpl(Method & method, Table & data, Arena * arena, Arenas & aggregates_pools, bool final,size_t rows, bool return_single_block) const
 {
-    LOG_DEBUG(getLogger("AGGREGATOR"),
-        "convertToBlockImpl: finalizing, "
-        "rows={}", rows);
     if (data.empty())
     {
         auto && out_cols = prepareOutputBlockColumns(params, aggregate_functions, key_types, aggregate_state_types, aggregates_pools, final, rows);
@@ -2219,7 +2210,6 @@ inline void Aggregator::insertAggregatesIntoColumns(Mapped & mapped, MutableColu
         /// Insert final values of aggregate functions into columns.
         for (; insert_i < params.aggregates_size; ++insert_i)
         {
-            LOG_DEBUG(getLogger("AGGREGATOR"), "insertResultInto, func={}", insert_i);
             aggregate_functions[insert_i]
                 ->insertResultInto(
                     mapped + offsets_of_aggregate_states[insert_i],
@@ -2297,67 +2287,45 @@ Chunk Aggregator::insertResultsIntoColumns(
             callJITFunction(insert_aggregates_into_columns_function, 0, places.size(), columns_data.data(), places.data());
         }
 #endif
-        // TOTALS combinator: merge all states
-        // into one and fill column with
-        // global value
-        for (size_t i = 0;
-            i < params.aggregates_size; ++i)
+        /// Apply post-aggregation states for TOTALS/BY combinators.
+        /// Pre-computed states have been filled in prepareChunkAndFill*; here we
+        /// only finalize them into the output column(s).
+        if (!post_aggregation.empty())
         {
-            if (!params.aggregates[i]
-                    .totals_combinator)
-                continue;
+            /// Build a const IColumn* array from out_cols.raw_key_columns for BY lookups.
+            /// (raw_key_columns is already a vector of IColumn* in the same order as params.keys.)
+            std::vector<const IColumn *> out_key_cols(params.keys_size);
+            for (size_t i = 0; i < params.keys_size; ++i)
+                out_key_cols[i] = out_cols.raw_key_columns[i];
 
-
-            LOG_DEBUG(getLogger("TOTALS_IMPL"),
-                "processing TOTALS for func {}",
-                i);
-
-            auto & final_col
-                = out_cols.final_aggregate_columns[i];
-            size_t offset
-                = offsets_of_aggregate_states[i];
-
-            // Create global state
-            Arena totals_arena;
-            auto global_place
-                = totals_arena.alignedAlloc(
-                    aggregate_functions[i]
-                        ->sizeOfData(),
-                    aggregate_functions[i]
-                        ->alignOfData());
-            aggregate_functions[i]
-                ->create(global_place);
-
-            // Merge all states into global
-            for (size_t j = 0;
-                j < places.size(); ++j)
+            for (size_t i = 0; i < params.aggregates_size; ++i)
             {
-                aggregate_functions[i]->merge(
-                    global_place,
-                    places[j] + offset,
-                    &totals_arena);
+                PostAggregationState * post_state = post_aggregation.find(i);
+                if (!post_state)
+                    continue;
+
+                auto & final_col = out_cols.final_aggregate_columns[i];
+
+                if (post_state->getKind() == PostAggregationState::Kind::Totals)
+                {
+                    /// TOTALS: same value for every row. Finalize once, replicate.
+                    auto scratch_col = final_col->cloneEmpty();
+                    post_state->finalizeInto(*scratch_col, nullptr, 0, arena);
+
+                    final_col = final_col->cloneEmpty();
+                    final_col->reserve(places.size());
+                    for (size_t row = 0; row < places.size(); ++row)
+                        final_col->insertFrom(*scratch_col, 0);
+                }
+                else /// By
+                {
+                    /// BY: different value per row, based on BY-key columns in the output.
+                    final_col = final_col->cloneEmpty();
+                    final_col->reserve(places.size());
+                    for (size_t row = 0; row < places.size(); ++row)
+                        post_state->finalizeInto(*final_col, out_key_cols.data(), row, arena);
+                }
             }
-
-            // Finalize global state
-            // into a temporary column
-            auto tmp_col = final_col->cloneEmpty();
-            aggregate_functions[i]
-                ->insertResultInto(
-                    global_place,
-                    *tmp_col,
-                    &totals_arena);
-
-            // Fill all rows with this value
-            final_col = final_col->cloneEmpty();
-            for (size_t j = 0;
-                j < places.size(); ++j)
-            {
-                final_col->insertFrom(*tmp_col, 0);
-            }
-
-            // Destroy global state
-            aggregate_functions[i]
-                ->destroy(global_place);
         }
         
 
@@ -2371,10 +2339,11 @@ Chunk Aggregator::insertResultsIntoColumns(
             }
 #endif
 
-            // Skip TOTALS — already processed
-            if (params.aggregates[
-                    aggregate_functions_destroy_index]
-                    .totals_combinator)
+            /// Skip aggregates with combinators — their result was written by
+            /// post_aggregation above; their per-group states will still be
+            /// destroyed by the final destroy loop below (destroyBatch), so we
+            /// don't need to do it here.
+            if (post_aggregation.find(aggregate_functions_destroy_index) != nullptr)
             {
                 ++aggregate_functions_destroy_index;
                 continue;
@@ -2678,6 +2647,85 @@ template <bool return_single_block>
 std::conditional_t<return_single_block, Aggregator::AggregatedChunk, Aggregator::AggregatedChunks>
 Aggregator::prepareChunkAndFillSingleLevel(AggregatedDataVariants & data_variants, bool final) const
 {
+    /// For TOTALS/BY: pre-compute post-aggregation states by iterating over the full
+    /// hash table once, before any chunk conversion starts. This has to happen here
+    /// (and in prepareChunksAndFillTwoLevel), because insertResultsIntoColumns sees
+    /// only per-chunk places and cannot merge globally.
+    if (final && !post_aggregation.empty() && !post_aggregation.isComputed())
+    {
+        Arena * keys_arena = data_variants.aggregates_pool;
+
+        if (!post_aggregation.hasByStates())
+        {
+            /// Fast path: only TOTALS states — keys are not needed.
+#define COMPUTE_POST_TOTALS_ONLY(NAME) \
+            else if (data_variants.type == AggregatedDataVariants::Type::NAME) \
+            { \
+                data_variants.NAME->data.forEachValue([&](const auto & /*key*/, auto & mapped) \
+                { \
+                    if (mapped) \
+                        for (size_t idx = 0; idx < params.aggregates_size; ++idx) \
+                            if (auto * ps = post_aggregation.find(idx)) \
+                                ps->absorb(mapped, nullptr, 0, keys_arena); \
+                }); \
+            }
+
+            if (false) {} // NOLINT
+            APPLY_FOR_VARIANTS_SINGLE_LEVEL(COMPUTE_POST_TOTALS_ONLY)
+#undef COMPUTE_POST_TOTALS_ONLY
+            else {}
+        }
+        else
+        {
+            /// Slow path: BY states present — we need keys materialized per row.
+            /// We iterate the hash table, materializing keys into temporary columns,
+            /// then call absorb() with those columns.
+
+            IColumn::SerializationSettings serialization_settings{
+                .serialize_string_with_zero_byte = params.serialize_string_with_zero_byte};
+
+            /// Create temporary key columns of the correct types.
+            MutableColumns tmp_key_cols;
+            tmp_key_cols.reserve(params.keys_size);
+            for (size_t i = 0; i < params.keys_size; ++i)
+                tmp_key_cols.emplace_back(key_types[i]->createColumn());
+
+            /// Array of raw pointers for insertKeyIntoColumns.
+            std::vector<IColumn *> raw_key_cols(params.keys_size);
+            for (size_t i = 0; i < params.keys_size; ++i)
+                raw_key_cols[i] = tmp_key_cols[i].get();
+
+#define COMPUTE_POST_WITH_KEYS(NAME) \
+            else if (data_variants.type == AggregatedDataVariants::Type::NAME) \
+            { \
+                auto & method_ref = *data_variants.NAME; \
+                std::vector<AggregateDataPtr> places_vec; \
+                method_ref.data.forEachValue([&](const auto & key, auto & mapped) \
+                { \
+                    if (!mapped) return; \
+                    method_ref.insertKeyIntoColumns(key, raw_key_cols, key_sizes, &serialization_settings); \
+                    places_vec.push_back(mapped); \
+                }); \
+                \
+                std::vector<const IColumn *> const_key_cols(params.keys_size); \
+                for (size_t i = 0; i < params.keys_size; ++i) \
+                    const_key_cols[i] = tmp_key_cols[i].get(); \
+                \
+                for (size_t row = 0; row < places_vec.size(); ++row) \
+                    for (size_t idx = 0; idx < params.aggregates_size; ++idx) \
+                        if (auto * ps = post_aggregation.find(idx)) \
+                            ps->absorb(places_vec[row], const_key_cols.data(), row, keys_arena); \
+            }
+
+            if (false) {} // NOLINT
+            APPLY_FOR_VARIANTS_SINGLE_LEVEL(COMPUTE_POST_WITH_KEYS)
+#undef COMPUTE_POST_WITH_KEYS
+            else {}
+        }
+
+        post_aggregation.markComputed();
+    }
+
     Chunks res_variant;
     const size_t rows = data_variants.sizeWithoutOverflowRow();
 #define M(NAME) \
@@ -2708,6 +2756,88 @@ Aggregator::prepareChunkAndFillSingleLevel(AggregatedDataVariants & data_variant
 
 Aggregator::AggregatedChunks Aggregator::prepareChunksAndFillTwoLevel(AggregatedDataVariants & data_variants, bool final) const
 {
+/// For TOTALS/BY: pre-compute post-aggregation states by iterating over all buckets
+    /// of the two-level hash table sequentially, BEFORE the thread pool in
+    /// prepareChunksAndFillTwoLevelImpl kicks in. This guarantees no race between
+    /// post-state accumulation and parallel bucket-to-chunk conversion.
+    if (final && !post_aggregation.empty() && !post_aggregation.isComputed())
+    {
+        Arena * keys_arena = data_variants.aggregates_pool;
+
+        if (!post_aggregation.hasByStates())
+        {
+            /// Fast path: only TOTALS states — keys are not needed.
+#define COMPUTE_POST_TL_TOTALS_ONLY(NAME) \
+            else if (data_variants.type == AggregatedDataVariants::Type::NAME) \
+            { \
+                auto & method_ref = *data_variants.NAME; \
+                for (size_t bucket = 0; bucket < method_ref.data.NUM_BUCKETS; ++bucket) \
+                { \
+                    method_ref.data.impls[bucket].forEachValue([&](const auto & /*key*/, auto & mapped) \
+                    { \
+                        if (mapped) \
+                            for (size_t idx = 0; idx < params.aggregates_size; ++idx) \
+                                if (auto * ps = post_aggregation.find(idx)) \
+                                    ps->absorb(mapped, nullptr, 0, keys_arena); \
+                    }); \
+                } \
+            }
+
+            if (false) {} // NOLINT
+            APPLY_FOR_VARIANTS_TWO_LEVEL(COMPUTE_POST_TL_TOTALS_ONLY)
+#undef COMPUTE_POST_TL_TOTALS_ONLY
+            else {}
+        }
+        else
+        {
+            /// Slow path: BY states present — materialize keys, absorb with keys.
+            IColumn::SerializationSettings serialization_settings{
+                .serialize_string_with_zero_byte = params.serialize_string_with_zero_byte};
+
+#define COMPUTE_POST_TL_WITH_KEYS(NAME) \
+            else if (data_variants.type == AggregatedDataVariants::Type::NAME) \
+            { \
+                auto & method_ref = *data_variants.NAME; \
+                \
+                for (size_t bucket = 0; bucket < method_ref.data.NUM_BUCKETS; ++bucket) \
+                { \
+                    MutableColumns tmp_key_cols; \
+                    tmp_key_cols.reserve(params.keys_size); \
+                    for (size_t i = 0; i < params.keys_size; ++i) \
+                        tmp_key_cols.emplace_back(key_types[i]->createColumn()); \
+                    \
+                    std::vector<IColumn *> raw_key_cols(params.keys_size); \
+                    for (size_t i = 0; i < params.keys_size; ++i) \
+                        raw_key_cols[i] = tmp_key_cols[i].get(); \
+                    \
+                    std::vector<AggregateDataPtr> places_vec; \
+                    method_ref.data.impls[bucket].forEachValue([&](const auto & key, auto & mapped) \
+                    { \
+                        if (!mapped) return; \
+                        method_ref.insertKeyIntoColumns(key, raw_key_cols, key_sizes, &serialization_settings); \
+                        places_vec.push_back(mapped); \
+                    }); \
+                    \
+                    std::vector<const IColumn *> const_key_cols(params.keys_size); \
+                    for (size_t i = 0; i < params.keys_size; ++i) \
+                        const_key_cols[i] = tmp_key_cols[i].get(); \
+                    \
+                    for (size_t row = 0; row < places_vec.size(); ++row) \
+                        for (size_t idx = 0; idx < params.aggregates_size; ++idx) \
+                            if (auto * ps = post_aggregation.find(idx)) \
+                                ps->absorb(places_vec[row], const_key_cols.data(), row, keys_arena); \
+                } \
+            }
+
+            if (false) {} // NOLINT
+            APPLY_FOR_VARIANTS_TWO_LEVEL(COMPUTE_POST_TL_WITH_KEYS)
+#undef COMPUTE_POST_TL_WITH_KEYS
+            else {}
+        }
+
+        post_aggregation.markComputed();
+    }
+
 #define M(NAME) \
     else if (data_variants.type == AggregatedDataVariants::Type::NAME) \
         return prepareChunksAndFillTwoLevelImpl(data_variants, *data_variants.NAME, final);

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -2772,7 +2772,7 @@ void Aggregator::computePostAggregationStates(AggregatedDataVariants & data_vari
     if (post_aggregation.empty())
         return;
 
-    post_aggregation.computeOnce([&]() {
+    post_aggregation.computeOnce([&] {
         Arena * keys_arena = data_variants.aggregates_pool;
 
         const bool two_level = data_variants.isTwoLevel();

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -720,7 +720,7 @@ Aggregator::Aggregator(const Block & header_, const Params & params_)
     compileAggregateFunctionsIfNeeded();
 #endif
 
-    
+
     /// Initialize post-aggregation for TOTALS/BY combinators.
     post_aggregation.init(params.aggregates, aggregate_functions, offsets_of_aggregate_states, params.keys);}
 
@@ -2327,7 +2327,7 @@ Chunk Aggregator::insertResultsIntoColumns(
                 }
             }
         }
-        
+
 
         for (; aggregate_functions_destroy_index < params.aggregates_size;)
         {

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -76,6 +76,7 @@ namespace ErrorCodes
     extern const int CANNOT_MERGE_DIFFERENT_AGGREGATED_DATA_VARIANTS;
     extern const int LOGICAL_ERROR;
     extern const int BAD_ARGUMENTS;
+    extern const int NOT_IMPLEMENTED;
 }
 
 }
@@ -1812,12 +1813,19 @@ Aggregator::AggregatedChunk Aggregator::mergeAndConvertOneBucketToChunk(
     std::atomic<bool> & is_cancelled,
     RuntimeDataflowStatisticsCacheUpdaterPtr updater) const
 {
+    /// TOTALS/BY combinators are not yet supported in distributed merge path
+    /// (MergingAggregatedTransform / ConvertingAggregatedToChunksWithMergingSource).
+    /// The current implementation requires the complete data variant before any
+    /// bucket conversion, which does not fit the bucket-by-bucket merge architecture
+    /// used here. See PR #103540 for discussion.
+    if (final && !post_aggregation.empty())
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED,
+            "TOTALS/BY aggregate function combinators are not yet supported "
+            "in distributed merge path. This is a known limitation.");
+
     auto & merged_data = *variants[0];
     auto method = merged_data.type;
     AggregatedChunk agg_chunk;
-
-    if (final)
-        computePostAggregationStates(merged_data);
 
     if (false) {} // NOLINT
 #define M(NAME) \

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -2658,7 +2658,7 @@ Aggregator::prepareChunkAndFillSingleLevel(AggregatedDataVariants & data_variant
     /// (and in prepareChunksAndFillTwoLevel), because insertResultsIntoColumns sees
     /// only per-chunk places and cannot merge globally.
     if (final)
-    computePostAggregationStates(data_variants);
+        computePostAggregationStates(data_variants);
 
     Chunks res_variant;
     const size_t rows = data_variants.sizeWithoutOverflowRow();

--- a/src/Interpreters/Aggregator.cpp
+++ b/src/Interpreters/Aggregator.cpp
@@ -686,7 +686,15 @@ Aggregator::Aggregator(const Block & header_, const Params & params_)
     if (params.aggregates_size == 1)
     {
         /// Check if COUNT() or COUNT(non-nullable column) which can be verified by simply casting to `AggregateFunctionCount *`.
-        if (typeid_cast<const AggregateFunctionCount *>(params.aggregates[0].function.get()))
+        /// Additionally, the TOTALS/BY combinator path is incompatible with the inline count
+        /// optimization: simple count writes counts directly through finalizeChunk, bypassing
+        /// insertResultsIntoColumns where post-aggregation states are finalized. Without this
+        /// guard, queries like `SELECT k, count(v TOTALS) FROM t GROUP BY k` would return
+        /// per-group counts instead of the global count.
+        const auto & agg = params.aggregates[0];
+        const bool has_combinator = agg.totals_combinator || agg.by_columns.has_value();
+
+        if (!has_combinator && typeid_cast<const AggregateFunctionCount *>(agg.function.get()))
             is_simple_count = true;
     }
 

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -334,6 +334,11 @@ private:
     /// Built once in constructor, filled once during finalization, read during convert-to-block.
     mutable PostAggregationManager post_aggregation;
 
+    /// Run post-aggregation precompute pass for TOTALS/BY combinators if not done yet.
+    /// Safe to call from multiple threads concurrently (uses std::call_once internally).
+    /// Must be called before reading from post_aggregation states during finalization.
+    void computePostAggregationStates(AggregatedDataVariants & data_variants) const;
+
     size_t total_size_of_aggregate_states = 0;    /// The total size of the row from the aggregate functions.
 
     // add info to track alignment requirement

--- a/src/Interpreters/Aggregator.h
+++ b/src/Interpreters/Aggregator.h
@@ -26,6 +26,7 @@
 #include <Interpreters/AggregatedDataVariants.h>
 #include <Interpreters/AggregationMethod.h>
 #include <Interpreters/HashTablesStatistics.h>
+#include <Interpreters/PostAggregationState.h>
 
 namespace DB
 {
@@ -328,6 +329,11 @@ private:
     using NestedColumnsHolder = VectorWithMemoryTracking<VectorWithMemoryTracking<const IColumn *>>;
 
     Sizes offsets_of_aggregate_states;    /// The offset to the n-th aggregate function in a row of aggregate functions.
+
+    /// Post-aggregation states for TOTALS/BY combinators.
+    /// Built once in constructor, filled once during finalization, read during convert-to-block.
+    mutable PostAggregationManager post_aggregation;
+
     size_t total_size_of_aggregate_states = 0;    /// The total size of the row from the aggregate functions.
 
     // add info to track alignment requirement

--- a/src/Interpreters/PostAggregationState.cpp
+++ b/src/Interpreters/PostAggregationState.cpp
@@ -86,8 +86,8 @@ std::string_view PostAggregationState::serializeByKey(
 
 AggregateDataPtr PostAggregationState::findOrCreateByState(std::string_view key)
 {
-    ByStates::LookupResult it;
-    bool inserted;
+    ByStates::LookupResult it = nullptr;
+    bool inserted = false;
     by_states.emplace(key, it, inserted);
 
     if (inserted)

--- a/src/Interpreters/PostAggregationState.cpp
+++ b/src/Interpreters/PostAggregationState.cpp
@@ -146,7 +146,7 @@ void PostAggregationState::finalizeInto(
 
         auto key = serializeByKey(key_columns, row_num, keys_arena);
 
-        auto it = by_states.find(key);
+        auto *it = by_states.find(key);
         if (!it)
             throw Exception(ErrorCodes::LOGICAL_ERROR,
                 "BY post-state: key not found during finalize (absorb was incomplete)");

--- a/src/Interpreters/PostAggregationState.cpp
+++ b/src/Interpreters/PostAggregationState.cpp
@@ -105,7 +105,7 @@ AggregateDataPtr PostAggregationState::findOrCreateByState(std::string_view key)
 /// ===== absorb / finalizeInto =====
 
 void PostAggregationState::absorb(
-    const AggregateDataPtr per_group_place,
+    AggregateDataPtr per_group_place,
     const IColumn ** key_columns,
     size_t row_num,
     Arena * keys_arena)

--- a/src/Interpreters/PostAggregationState.cpp
+++ b/src/Interpreters/PostAggregationState.cpp
@@ -1,0 +1,221 @@
+#include <Interpreters/PostAggregationState.h>
+
+#include <Common/Exception.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+    extern const int BAD_ARGUMENTS;
+}
+
+/// ===== PostAggregationState: TOTALS constructor =====
+
+PostAggregationState::PostAggregationState(
+    size_t aggregate_index_,
+    const IAggregateFunction * aggregate_function_,
+    size_t state_offset_in_group_)
+    : aggregate_index(aggregate_index_)
+    , aggregate_function(aggregate_function_)
+    , state_offset_in_group(state_offset_in_group_)
+    , kind(Kind::Totals)
+    , arena(std::make_unique<Arena>())
+{
+    /// One global state for TOTALS.
+    global_state = arena->alignedAlloc(
+        aggregate_function->sizeOfData(),
+        aggregate_function->alignOfData());
+    aggregate_function->create(global_state);
+}
+
+/// ===== PostAggregationState: BY constructor =====
+
+PostAggregationState::PostAggregationState(
+    size_t aggregate_index_,
+    const IAggregateFunction * aggregate_function_,
+    size_t state_offset_in_group_,
+    std::vector<size_t> by_column_positions_)
+    : aggregate_index(aggregate_index_)
+    , aggregate_function(aggregate_function_)
+    , state_offset_in_group(state_offset_in_group_)
+    , kind(Kind::By)
+    , arena(std::make_unique<Arena>())
+    , by_column_positions(std::move(by_column_positions_))
+{
+    /// States for BY are created lazily in findOrCreateByState() as keys appear.
+}
+
+/// ===== Destructor =====
+
+PostAggregationState::~PostAggregationState()
+{
+    if (kind == Kind::Totals)
+    {
+        if (global_state)
+        {
+            aggregate_function->destroy(global_state);
+            global_state = nullptr;
+        }
+    }
+    else if (kind == Kind::By)
+    {
+        for (auto & cell : by_states)
+            if (cell.getMapped())
+                aggregate_function->destroy(cell.getMapped());
+    }
+}
+
+/// ===== Helpers =====
+
+std::string_view PostAggregationState::serializeByKey(
+    const IColumn ** key_columns, size_t row_num, Arena * keys_arena)
+{
+    IColumn::SerializationSettings settings{};
+
+    const char * begin = nullptr;
+    size_t total_size = 0;
+    for (size_t pos : by_column_positions)
+    {
+        auto part = key_columns[pos]->serializeValueIntoArena(row_num, *keys_arena, begin, &settings);
+        total_size += part.size();
+    }
+    return std::string_view{begin, total_size};
+}
+
+AggregateDataPtr PostAggregationState::findOrCreateByState(std::string_view key)
+{
+    ByStates::LookupResult it;
+    bool inserted;
+    by_states.emplace(key, it, inserted);
+
+    if (inserted)
+    {
+        AggregateDataPtr place = arena->alignedAlloc(
+            aggregate_function->sizeOfData(),
+            aggregate_function->alignOfData());
+        aggregate_function->create(place);
+        it->getMapped() = place;
+    }
+
+    return it->getMapped();
+}
+
+/// ===== absorb / finalizeInto =====
+
+void PostAggregationState::absorb(
+    const AggregateDataPtr per_group_place,
+    const IColumn ** key_columns,
+    size_t row_num,
+    Arena * keys_arena)
+{
+    AggregateDataPtr our_state_in_group = per_group_place + state_offset_in_group;
+
+    if (kind == Kind::Totals)
+    {
+        aggregate_function->merge(global_state, our_state_in_group, arena.get());
+    }
+    else if (kind == Kind::By)
+    {
+        if (!key_columns)
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "BY post-state: key_columns must be provided during absorb");
+
+        auto key = serializeByKey(key_columns, row_num, keys_arena);
+        AggregateDataPtr by_state = findOrCreateByState(key);
+        aggregate_function->merge(by_state, our_state_in_group, arena.get());
+    }
+}
+
+void PostAggregationState::finalizeInto(
+    IColumn & target_column,
+    const IColumn ** key_columns,
+    size_t row_num,
+    Arena * keys_arena)
+{
+    if (kind == Kind::Totals)
+    {
+        aggregate_function->insertResultInto(global_state, target_column, arena.get());
+    }
+    else if (kind == Kind::By)
+    {
+        if (!key_columns)
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "BY post-state: key_columns must be provided during finalize");
+
+        auto key = serializeByKey(key_columns, row_num, keys_arena);
+
+        auto it = by_states.find(key);
+        if (!it)
+            throw Exception(ErrorCodes::LOGICAL_ERROR,
+                "BY post-state: key not found during finalize (absorb was incomplete)");
+
+        aggregate_function->insertResultInto(it->getMapped(), target_column, arena.get());
+    }
+}
+
+/// ===== PostAggregationManager =====
+
+void PostAggregationManager::init(
+    const AggregateDescriptions & aggregates,
+    const std::vector<const IAggregateFunction *> & aggregate_functions,
+    const Sizes & offsets_of_aggregate_states,
+    const Names & group_by_key_names)
+{
+    states.clear();
+    computed = false;
+
+    for (size_t i = 0; i < aggregates.size(); ++i)
+    {
+        const auto & descr = aggregates[i];
+
+        if (descr.totals_combinator)
+        {
+            states.push_back(std::make_unique<PostAggregationState>(
+                i,
+                aggregate_functions[i],
+                offsets_of_aggregate_states[i]));
+        }
+        else if (descr.by_columns.has_value())
+        {
+            /// Resolve BY-column names to positions in group_by_key_names.
+            std::vector<size_t> positions;
+            positions.reserve(descr.by_columns->size());
+
+            for (const auto & by_name : *descr.by_columns)
+            {
+                auto it = std::find(group_by_key_names.begin(), group_by_key_names.end(), by_name);
+                if (it == group_by_key_names.end())
+                    throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                        "BY column '{}' in aggregate '{}' is not a GROUP BY key",
+                        by_name, descr.column_name);
+                positions.push_back(static_cast<size_t>(it - group_by_key_names.begin()));
+            }
+
+            states.push_back(std::make_unique<PostAggregationState>(
+                i,
+                aggregate_functions[i],
+                offsets_of_aggregate_states[i],
+                std::move(positions)));
+        }
+    }
+}
+
+PostAggregationState * PostAggregationManager::find(size_t aggregate_index) const
+{
+    for (const auto & state : states)
+        if (state->getAggregateIndex() == aggregate_index)
+            return state.get();
+    return nullptr;
+}
+
+bool PostAggregationManager::hasByStates() const
+{
+    for (const auto & state : states)
+        if (state->getKind() == PostAggregationState::Kind::By)
+            return true;
+    return false;
+}
+
+}

--- a/src/Interpreters/PostAggregationState.h
+++ b/src/Interpreters/PostAggregationState.h
@@ -170,7 +170,7 @@ public:
     template <typename Fn>
     void computeOnce(Fn && fn) const
     {
-        std::call_once(computed_flag, [&]() {
+        std::call_once(computed_flag, [&] {
             fn();
             computed = true;
         });

--- a/src/Interpreters/PostAggregationState.h
+++ b/src/Interpreters/PostAggregationState.h
@@ -10,6 +10,7 @@
 #include <string_view>
 #include <memory>
 #include <vector>
+#include <mutex>
 
 namespace DB
 {
@@ -163,8 +164,17 @@ public:
         }
     }
 
-    /// Mark that computation is complete. Used for assertions / idempotency.
-    void markComputed() { computed = true; }
+    /// Run the provided callable exactly once across all threads.
+    /// Subsequent calls (concurrent or sequential) do nothing and return
+    /// after the first invocation has completed.
+    template <typename Fn>
+    void computeOnce(Fn && fn) const
+    {
+        std::call_once(computed_flag, [&]() {
+            fn();
+            computed = true;
+        });
+    }
 
     /// Look up post-state by aggregate index. Returns nullptr if aggregate has no combinator.
     /// O(N) in number of post-states; N is tiny (1-3 per query typically).
@@ -174,7 +184,8 @@ public:
 
 private:
     std::vector<std::unique_ptr<PostAggregationState>> states;
-    bool computed = false;
+    mutable std::once_flag computed_flag;
+    mutable bool computed = false;
 };
 
 }

--- a/src/Interpreters/PostAggregationState.h
+++ b/src/Interpreters/PostAggregationState.h
@@ -66,7 +66,7 @@ public:
     /// `key_columns` must be the array of key columns for the source hash table pass;
     /// unused for TOTALS.
     void absorb(
-        const AggregateDataPtr per_group_place,
+        AggregateDataPtr per_group_place,
         const IColumn ** key_columns,
         size_t row_num,
         Arena * keys_arena);

--- a/src/Interpreters/PostAggregationState.h
+++ b/src/Interpreters/PostAggregationState.h
@@ -1,0 +1,180 @@
+#pragma once
+
+#include <Interpreters/AggregateDescription.h>
+#include <Interpreters/AggregationCommon.h>
+#include <AggregateFunctions/IAggregateFunction.h>
+#include <Common/Arena.h>
+#include <Columns/IColumn.h>
+#include <Common/HashTable/HashMap.h>
+#include <base/StringViewHash.h>
+#include <string_view>
+#include <memory>
+#include <vector>
+
+namespace DB
+{
+
+/** One post-processed state for one aggregate with TOTALS (and later BY) combinator.
+  *
+  * After the main aggregation finishes, the Aggregator owns a hash table where
+  * each group has a state tuple for every aggregate. For aggregates with a combinator,
+  * we need to re-merge those per-group states — into a single global state for TOTALS,
+  * or into a state per BY-key for BY.
+  *
+  * This object owns the post-merged state(s) and knows how to:
+  *   - absorb a per-group state from the main hash table,
+  *   - finalize a value for a result row.
+  *
+  * Lifecycle: created once per TOTALS/BY aggregate in Aggregator's constructor.
+  * Filled exactly once via absorb() calls (sequentially, from a single thread)
+  * before any concurrent finalization starts. After that read-only, thread-safe.
+  */
+class PostAggregationState
+{
+public:
+    /// Marker of what combinator this post-state serves.
+    enum class Kind
+    {
+        Totals,
+        By,
+    };
+
+    /// Constructor for TOTALS.
+    PostAggregationState(
+        size_t aggregate_index_,
+        const IAggregateFunction * aggregate_function_,
+        size_t state_offset_in_group_);
+
+    /// Constructor for BY.
+    /// `by_column_positions_` gives positions (in the overall key_columns array of the query)
+    /// of the columns that make up the BY-key for this aggregate.
+    PostAggregationState(
+        size_t aggregate_index_,
+        const IAggregateFunction * aggregate_function_,
+        size_t state_offset_in_group_,
+        std::vector<size_t> by_column_positions_);
+
+    ~PostAggregationState();
+
+    PostAggregationState(const PostAggregationState &) = delete;
+    PostAggregationState & operator=(const PostAggregationState &) = delete;
+    PostAggregationState(PostAggregationState &&) = default;
+    PostAggregationState & operator=(PostAggregationState &&) = default;
+
+    /// Absorb a per-group state. For TOTALS — mergeed into the single global state.
+    /// For BY — merged into the state bucket identified by by-key columns at row_num.
+    /// `key_columns` must be the array of key columns for the source hash table pass;
+    /// unused for TOTALS.
+    void absorb(
+        const AggregateDataPtr per_group_place,
+        const IColumn ** key_columns,
+        size_t row_num,
+        Arena * keys_arena);
+
+    /// Finalize into one cell of `target_column` for output row `row_num`.
+    /// For TOTALS — the same global value regardless of row_num; the caller still
+    /// must insert it for every row. For BY — looked up by by-key at row_num.
+    /// `key_columns` is unused for TOTALS; for BY it is the array of output key columns.
+    void finalizeInto(
+        IColumn & target_column,
+        const IColumn ** key_columns,
+        size_t row_num,
+        Arena * keys_arena);
+
+    size_t getAggregateIndex() const { return aggregate_index; }
+    Kind getKind() const { return kind; }
+
+private:
+    size_t aggregate_index;
+    const IAggregateFunction * aggregate_function;
+    size_t state_offset_in_group;
+    Kind kind;
+
+    /// Arena for all state memory owned by this post-state.
+    std::unique_ptr<Arena> arena;
+
+    /// For TOTALS: the single global state.
+    AggregateDataPtr global_state = nullptr;
+
+    /// For BY: positions of BY-columns in the overall key_columns array.
+    std::vector<size_t> by_column_positions;
+
+    /// For BY: map from serialized BY-key (StringRef into `arena`) to state.
+    using ByStates = HashMapWithSavedHash<std::string_view, AggregateDataPtr, StringViewHash>;    ByStates by_states;
+
+    /// Helper: serialize BY-key from key_columns at row_num into arena, return StringRef.
+    std::string_view serializeByKey(const IColumn ** key_columns, size_t row_num, Arena * keys_arena);
+
+    /// Helper: find existing state or create a new one for the given key.
+    AggregateDataPtr findOrCreateByState(std::string_view key);
+};
+
+
+/** A collection of PostAggregationState's — one per aggregate with a combinator.
+  *
+  * Lives inside Aggregator, created once, shared across threads after merge.
+  *
+  * Filled via computeAll() exactly once on finalization, before any concurrent
+  * convertToBlockImpl() calls. After that read-only and thread-safe.
+  */
+class PostAggregationManager
+{
+public:
+    PostAggregationManager() = default;
+    ~PostAggregationManager() = default;
+
+    PostAggregationManager(const PostAggregationManager &) = delete;
+    PostAggregationManager & operator=(const PostAggregationManager &) = delete;
+
+    /// Build post-states from aggregate descriptions.
+    /// `group_by_key_names` is the list of GROUP BY key names (in order). Used to
+    /// resolve BY-column names into positions for BY-aggregates.
+    void init(
+        const AggregateDescriptions & aggregates,
+        const std::vector<const IAggregateFunction *> & aggregate_functions,
+        const Sizes & offsets_of_aggregate_states,
+        const Names & group_by_key_names);
+
+    /// True if no aggregates have combinators — fast path to skip all work.
+    bool empty() const { return states.empty(); }
+
+    bool hasByStates() const;
+
+    /// Call this while iterating over the main aggregation hash table.
+    /// Can be invoked many times (e.g. once per two-level bucket). Call markComputed()
+    /// when all places have been absorbed.
+    /// `key_columns` are the key columns for the same iteration (needed by BY states);
+    /// pass nullptr if there are no BY-states.
+    template <typename NextFn>
+    void computeAll(NextFn && get_next, Arena * keys_arena)
+    {
+        if (states.empty())
+            return;
+
+        /// `get_next` returns a pair: {place, key_columns_row} or {nullptr, *} on end.
+        /// If no BY-states are present, key_columns argument is ignored.
+        while (true)
+        {
+            auto [place, key_columns, row_num] = get_next();
+            if (!place)
+                break;
+            for (auto & state : states)
+                state->absorb(place, key_columns, row_num, keys_arena);
+        }
+    }
+
+    /// Mark that computation is complete. Used for assertions / idempotency.
+    void markComputed() { computed = true; }
+
+    /// Look up post-state by aggregate index. Returns nullptr if aggregate has no combinator.
+    /// O(N) in number of post-states; N is tiny (1-3 per query typically).
+    PostAggregationState * find(size_t aggregate_index) const;
+
+    bool isComputed() const { return computed; }
+
+private:
+    std::vector<std::unique_ptr<PostAggregationState>> states;
+    bool computed = false;
+};
+
+}

--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -876,15 +876,6 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
             nested_dont_need_parens);
     }
 
-    if (order_by_combinator
-        && order_by_combinator_columns)
-    {
-        ostr << " ORDER BY ";
-        order_by_combinator_columns->format(
-            ostr, settings, state,
-            nested_dont_need_parens);
-    }
-
     if (need_parens)
         ostr << ')';
 

--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -862,6 +862,29 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
 
     }
 
+    // Combinator formatting
+    if (totals_combinator)
+    {
+        ostr << " TOTALS";
+    }
+
+    if (by_combinator && by_combinator_columns)
+    {
+        ostr << " BY ";
+        by_combinator_columns->format(
+            ostr, settings, state,
+            nested_dont_need_parens);
+    }
+    
+    if (order_by_combinator
+        && order_by_combinator_columns)
+    {
+        ostr << " ORDER BY ";
+        order_by_combinator_columns->format(
+            ostr, settings, state,
+            nested_dont_need_parens);
+    }
+
     if (need_parens)
         ostr << ')';
 

--- a/src/Parsers/ASTFunction.cpp
+++ b/src/Parsers/ASTFunction.cpp
@@ -875,7 +875,7 @@ void ASTFunction::formatImplWithoutAlias(WriteBuffer & ostr, const FormatSetting
             ostr, settings, state,
             nested_dont_need_parens);
     }
-    
+
     if (order_by_combinator
         && order_by_combinator_columns)
     {

--- a/src/Parsers/ASTFunction.h
+++ b/src/Parsers/ASTFunction.h
@@ -43,6 +43,21 @@ public:
     /// parameters - for parametric aggregate function. Example: quantile(0.9)(x) - what in first parens are 'parameters'.
     ASTPtr parameters;
 
+
+    /// Aggregate function combinators
+    /// TOTALS, BY, ORDER BY inside
+    /// function arguments
+    bool totals_combinator = false;
+    bool by_combinator = false;
+    bool order_by_combinator = false;
+
+    /// Columns after BY: avg(x BY a, b)
+    ASTPtr by_combinator_columns;
+
+    /// Sort clause after ORDER BY:
+    /// groupArray(x ORDER BY y DESC)
+    ASTPtr order_by_combinator_columns;
+
     /// Preserves the information that it was parsed as an operator. This is needed for better formatting the AST back to query.
     bool isOperator() const { return flags<ASTFunctionFlags>().is_operator; }
     void setIsOperator(bool value) { flags<ASTFunctionFlags>().is_operator = value; }

--- a/src/Parsers/ASTFunction.h
+++ b/src/Parsers/ASTFunction.h
@@ -45,18 +45,13 @@ public:
 
 
     /// Aggregate function combinators
-    /// TOTALS, BY, ORDER BY inside
+    /// TOTALS, BY inside
     /// function arguments
     bool totals_combinator = false;
     bool by_combinator = false;
-    bool order_by_combinator = false;
 
     /// Columns after BY: avg(x BY a, b)
     ASTPtr by_combinator_columns;
-
-    /// Sort clause after ORDER BY:
-    /// groupArray(x ORDER BY y DESC)
-    ASTPtr order_by_combinator_columns;
 
     /// Preserves the information that it was parsed as an operator. This is needed for better formatting the AST back to query.
     bool isOperator() const { return flags<ASTFunctionFlags>().is_operator; }

--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -1132,10 +1132,6 @@ public:
 
     bool parse(IParser::Pos & pos, Expected & expected, Action & action) override
     {
-        LOG_DEBUG(getLogger("FUNC_LAYER"),
-        "func={}, state={}", 
-        function_name, state);
-
         ///   | 0 |      1      |     2    |
         ///  f(ALL ...)(ALL ...) FILTER ...
         ///
@@ -1145,12 +1141,6 @@ public:
 
         if (state == 0)
         {
-
-            LOG_DEBUG(getLogger("FL"),
-                "state 0, func={}, token={}",
-                function_name,
-                String(pos->begin, pos->end));
-
             state = 1;
 
             auto pos_after_bracket = pos;
@@ -1188,13 +1178,6 @@ public:
 
         if (state == 1)
         {
-
-            LOG_DEBUG(getLogger("FL"),
-                "state 1, func={}, token={}",
-                function_name,
-                String(pos->begin, pos->end));
-
-
             if (ParserToken(TokenType::Comma).ignore(pos, expected))
             {
                 action = Action::OPERAND;
@@ -1213,25 +1196,11 @@ public:
                 return true;
             }
 
-
-            LOG_DEBUG(getLogger("PARSER_DBG"),
-                "func={}, state=1, token={}",
-                function_name,
-                String(pos->begin, pos->end));
-
-
-            LOG_DEBUG(getLogger("TOTALS_DBG"),
-                "before totals check, token={}, "
-                "type={}",
-                String(pos->begin, pos->end),
-                static_cast<int>(pos->type));
             // TOTALS combinator
             ParserKeyword totals_kw(Keyword::TOTALS);
             bool totals_matched = totals_kw.ignore(
                 pos, expected);
-            LOG_DEBUG(getLogger("TOTALS_DBG"),
-                "totals ignore returned: {}",
-                totals_matched);
+
             if (totals_matched)
             {
                 has_totals = true;
@@ -1239,11 +1208,6 @@ public:
                 //     || !elements.empty())
                 //     if (!mergeElement())
                 //         return false;
-
-                LOG_DEBUG(getLogger("TOTALS_DBG"),
-                    "after mergeElement, "
-                    "next token={}",
-                    String(pos->begin, pos->end));
             }
 
             // BY combinator
@@ -1266,10 +1230,6 @@ public:
                 Keyword::ORDER_BY);
             
             bool order_by_matched = order_by_kw.ignore(pos, expected);
-            LOG_DEBUG(getLogger("OB_DBG"),
-                "order_by matched={}, token={}",
-                order_by_matched,
-                String(pos->begin, pos->end));
 
             if (!has_totals && !has_by
                 && order_by_matched)

--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -1132,6 +1132,10 @@ public:
 
     bool parse(IParser::Pos & pos, Expected & expected, Action & action) override
     {
+        LOG_DEBUG(getLogger("FUNC_LAYER"),
+        "func={}, state={}", 
+        function_name, state);
+
         ///   | 0 |      1      |     2    |
         ///  f(ALL ...)(ALL ...) FILTER ...
         ///
@@ -1141,6 +1145,12 @@ public:
 
         if (state == 0)
         {
+
+            LOG_DEBUG(getLogger("FL"),
+                "state 0, func={}, token={}",
+                function_name,
+                String(pos->begin, pos->end));
+
             state = 1;
 
             auto pos_after_bracket = pos;
@@ -1178,11 +1188,112 @@ public:
 
         if (state == 1)
         {
+
+            LOG_DEBUG(getLogger("FL"),
+                "state 1, func={}, token={}",
+                function_name,
+                String(pos->begin, pos->end));
+
+
             if (ParserToken(TokenType::Comma).ignore(pos, expected))
             {
                 action = Action::OPERAND;
-                return mergeElement();
+
+                if (!mergeElement())
+                    return false;
+
+
+                // If there was BY keyword, the expression belongs to by_columns
+                if (has_by)
+                {
+                    by_columns->children.push_back(
+                        std::move(elements.back()));
+                    elements.pop_back();
+                }
+                return true;
             }
+
+
+            LOG_DEBUG(getLogger("PARSER_DBG"),
+                "func={}, state=1, token={}",
+                function_name,
+                String(pos->begin, pos->end));
+
+
+            LOG_DEBUG(getLogger("TOTALS_DBG"),
+                "before totals check, token={}, "
+                "type={}",
+                String(pos->begin, pos->end),
+                static_cast<int>(pos->type));
+            // TOTALS combinator
+            ParserKeyword totals_kw(Keyword::TOTALS);
+            bool totals_matched = totals_kw.ignore(
+                pos, expected);
+            LOG_DEBUG(getLogger("TOTALS_DBG"),
+                "totals ignore returned: {}",
+                totals_matched);
+            if (totals_matched)
+            {
+                has_totals = true;
+                // if (!isCurrentElementEmpty()
+                //     || !elements.empty())
+                //     if (!mergeElement())
+                //         return false;
+
+                LOG_DEBUG(getLogger("TOTALS_DBG"),
+                    "after mergeElement, "
+                    "next token={}",
+                    String(pos->begin, pos->end));
+            }
+
+            // BY combinator
+            ParserKeyword by_kw(Keyword::BY);
+            if (!has_totals
+                && by_kw.ignore(pos, expected))
+            {
+                has_by = true;
+                by_columns = make_intrusive<ASTExpressionList>();
+                if (!isCurrentElementEmpty()
+                    || !elements.empty())
+                    if (!mergeElement())
+                        return false;
+                action = Action::OPERAND;
+                return true;
+            }
+
+            // ORDER BY combinator
+            ParserKeyword order_by_kw(
+                Keyword::ORDER_BY);
+            
+            bool order_by_matched = order_by_kw.ignore(pos, expected);
+            LOG_DEBUG(getLogger("OB_DBG"),
+                "order_by matched={}, token={}",
+                order_by_matched,
+                String(pos->begin, pos->end));
+
+            if (!has_totals && !has_by
+                && order_by_matched)
+            {
+                has_order_by = true;
+                if (!isCurrentElementEmpty()
+                    || !elements.empty())
+                    if (!mergeElement())
+                        return false;
+
+                ParserOrderByExpressionList
+                    order_parser;
+                if (!order_parser.parse(
+                        pos, order_by_columns,
+                        expected))
+                    return false;
+            }
+
+
+            // Only one of the TOTALS, BY ans ORDER BY combinators can be at the one time
+            if ((has_totals && has_by)
+                || (has_totals && has_order_by)
+                || (has_by && has_order_by))
+                return false;
 
             if (ParserToken(TokenType::ClosingRoundBracket).ignore(pos, expected))
             {
@@ -1191,6 +1302,13 @@ public:
                 if (!isCurrentElementEmpty() || !elements.empty())
                     if (!mergeElement())
                         return false;
+
+                if (has_by)
+                {
+                    by_columns->children.push_back(
+                        std::move(elements.back()));
+                    elements.pop_back();
+                }
 
                 contents_end = pos->begin;
 
@@ -1315,6 +1433,27 @@ public:
                     return false;
             }
 
+            if (has_totals)
+            {
+                function_node->totals_combinator = true;
+            }
+            if (has_by)
+            {
+                function_node->by_combinator = true;
+                function_node->by_combinator_columns
+                    = std::move(by_columns);
+                function_node->children.push_back(
+                    function_node->by_combinator_columns);
+            }
+            if (has_order_by)
+            {
+                function_node->order_by_combinator = true;
+                function_node->order_by_combinator_columns
+                    = std::move(order_by_columns);
+                function_node->children.push_back(
+                    function_node->order_by_combinator_columns);
+            }
+
             elements = {std::move(function_node)};
             finished = true;
         }
@@ -1329,8 +1468,14 @@ private:
     const char * contents_begin{};
     const char * contents_end{};
 
+    bool has_totals = false;
+    bool has_by = false;
+    bool has_order_by = false;
+
     String function_name;
     ASTPtr parameters;
+    ASTPtr by_columns;
+    ASTPtr order_by_columns;
 
     bool allow_function_parameters;
     bool is_compound_name;

--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -1228,7 +1228,7 @@ public:
             // ORDER BY combinator
             ParserKeyword order_by_kw(
                 Keyword::ORDER_BY);
-            
+
             bool order_by_matched = order_by_kw.ignore(pos, expected);
 
             if (!has_totals && !has_by
@@ -1249,7 +1249,7 @@ public:
             }
 
 
-            // Only one of the TOTALS, BY ans ORDER BY combinators can be at the one time
+            // Only one of the TOTALS, BY and ORDER BY combinators can be at the one time
             if ((has_totals && has_by)
                 || (has_totals && has_order_by)
                 || (has_by && has_order_by))

--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -1225,34 +1225,9 @@ public:
                 return true;
             }
 
-            // ORDER BY combinator
-            ParserKeyword order_by_kw(
-                Keyword::ORDER_BY);
 
-            bool order_by_matched = order_by_kw.ignore(pos, expected);
-
-            if (!has_totals && !has_by
-                && order_by_matched)
-            {
-                has_order_by = true;
-                if (!isCurrentElementEmpty()
-                    || !elements.empty())
-                    if (!mergeElement())
-                        return false;
-
-                ParserOrderByExpressionList
-                    order_parser;
-                if (!order_parser.parse(
-                        pos, order_by_columns,
-                        expected))
-                    return false;
-            }
-
-
-            // Only one of the TOTALS, BY and ORDER BY combinators can be at the one time
-            if ((has_totals && has_by)
-                || (has_totals && has_order_by)
-                || (has_by && has_order_by))
+            // Only one of the TOTALS and BY combinators can be at the one time
+            if (has_totals && has_by)
                 return false;
 
             if (ParserToken(TokenType::ClosingRoundBracket).ignore(pos, expected))
@@ -1405,14 +1380,6 @@ public:
                 function_node->children.push_back(
                     function_node->by_combinator_columns);
             }
-            if (has_order_by)
-            {
-                function_node->order_by_combinator = true;
-                function_node->order_by_combinator_columns
-                    = std::move(order_by_columns);
-                function_node->children.push_back(
-                    function_node->order_by_combinator_columns);
-            }
 
             elements = {std::move(function_node)};
             finished = true;
@@ -1430,12 +1397,10 @@ private:
 
     bool has_totals = false;
     bool has_by = false;
-    bool has_order_by = false;
 
     String function_name;
     ASTPtr parameters;
     ASTPtr by_columns;
-    ASTPtr order_by_columns;
 
     bool allow_function_parameters;
     bool is_compound_name;

--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -1196,33 +1196,31 @@ public:
                 return true;
             }
 
-            // TOTALS combinator
-            ParserKeyword totals_kw(Keyword::TOTALS);
-            bool totals_matched = totals_kw.ignore(
-                pos, expected);
+            // TOTALS and BY are combinators only when they follow an aggregate argument
+            // and only at most one of them can be applied to a single aggregate call.
+            const bool has_argument = !isCurrentElementEmpty() || !elements.empty();
+            const bool no_combinator_yet = !has_totals && !has_by;
 
-            if (totals_matched)
+            if (has_argument && no_combinator_yet)
             {
-                has_totals = true;
-                // if (!isCurrentElementEmpty()
-                //     || !elements.empty())
-                //     if (!mergeElement())
-                //         return false;
-            }
-
-            // BY combinator
-            ParserKeyword by_kw(Keyword::BY);
-            if (!has_totals
-                && by_kw.ignore(pos, expected))
-            {
-                has_by = true;
-                by_columns = make_intrusive<ASTExpressionList>();
-                if (!isCurrentElementEmpty()
-                    || !elements.empty())
-                    if (!mergeElement())
-                        return false;
-                action = Action::OPERAND;
-                return true;
+                ParserKeyword totals_kw(Keyword::TOTALS);
+                if (totals_kw.ignore(pos, expected))
+                {
+                    has_totals = true;
+                }
+                else
+                {
+                    ParserKeyword by_kw(Keyword::BY);
+                    if (by_kw.ignore(pos, expected))
+                    {
+                        has_by = true;
+                        by_columns = make_intrusive<ASTExpressionList>();
+                        if (!mergeElement())
+                            return false;
+                        action = Action::OPERAND;
+                        return true;
+                    }
+                }
             }
 
 

--- a/src/Planner/PlannerActionsVisitor.cpp
+++ b/src/Planner/PlannerActionsVisitor.cpp
@@ -343,6 +343,20 @@ public:
                         buffer << calculateActionNodeName(by_nodes[i]);
                     }
                 }
+                else if (function_node.hasOrderByCombinator())
+                {
+                    if (function_arguments_nodes_size > 0)
+                        buffer << ' ';
+                    buffer << "ORDER BY ";
+
+                    const auto & order_by_nodes = function_node.getOrderByColumnsNode()->as<ListNode &>().getNodes();
+                    for (size_t i = 0; i < order_by_nodes.size(); ++i)
+                    {
+                        if (i > 0)
+                            buffer << ", ";
+                        buffer << calculateActionNodeName(order_by_nodes[i]);
+                    }
+                }
 
                 buffer << ')';
 

--- a/src/Planner/PlannerActionsVisitor.cpp
+++ b/src/Planner/PlannerActionsVisitor.cpp
@@ -343,20 +343,7 @@ public:
                         buffer << calculateActionNodeName(by_nodes[i]);
                     }
                 }
-                else if (function_node.hasOrderByCombinator())
-                {
-                    if (function_arguments_nodes_size > 0)
-                        buffer << ' ';
-                    buffer << "ORDER BY ";
 
-                    const auto & order_by_nodes = function_node.getOrderByColumnsNode()->as<ListNode &>().getNodes();
-                    for (size_t i = 0; i < order_by_nodes.size(); ++i)
-                    {
-                        if (i > 0)
-                            buffer << ", ";
-                        buffer << calculateActionNodeName(order_by_nodes[i]);
-                    }
-                }
 
                 buffer << ')';
 

--- a/src/Planner/PlannerActionsVisitor.cpp
+++ b/src/Planner/PlannerActionsVisitor.cpp
@@ -323,6 +323,27 @@ public:
                         buffer << ", ";
                 }
 
+                if (function_node.hasTotalsCombinator())
+                {
+                    if (function_arguments_nodes_size > 0)
+                        buffer << ' ';
+                    buffer << "TOTALS";
+                }
+                else if (function_node.hasByCombinator())
+                {
+                    if (function_arguments_nodes_size > 0)
+                        buffer << ' ';
+                    buffer << "BY ";
+
+                    const auto & by_nodes = function_node.getByColumnsNode()->as<ListNode &>().getNodes();
+                    for (size_t i = 0; i < by_nodes.size(); ++i)
+                    {
+                        if (i > 0)
+                            buffer << ", ";
+                        buffer << calculateActionNodeName(by_nodes[i]);
+                    }
+                }
+
                 buffer << ')';
 
                 if (function_node.isWindowFunction())

--- a/src/Planner/PlannerAggregation.cpp
+++ b/src/Planner/PlannerAggregation.cpp
@@ -4,9 +4,15 @@
 #include <Analyzer/FunctionNode.h>
 
 #include <Planner/PlannerActionsVisitor.h>
+#include <Common/Exception.h>
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int NOT_IMPLEMENTED;
+}
 
 AggregateDescriptions extractAggregateDescriptions(const QueryTreeNodes & aggregate_function_nodes, const PlannerContext & planner_context)
 {
@@ -61,17 +67,13 @@ AggregateDescriptions extractAggregateDescriptions(const QueryTreeNodes & aggreg
                     std::move(by_name));
             }
         }
+        
         if (aggregate_function_node_typed.hasOrderByCombinator())
         {
-            const auto & order_by_nodes = aggregate_function_node_typed
-                .getOrderByColumnsNode()->as<ListNode &>().getNodes();
-            aggregate_description.order_by_columns = Names();
-            aggregate_description.order_by_columns->reserve(order_by_nodes.size());
-            for (const auto & order_by_node : order_by_nodes)
-            {
-                aggregate_description.order_by_columns->emplace_back(
-                    calculateActionNodeName(order_by_node, planner_context));
-            }
+            throw Exception(ErrorCodes::NOT_IMPLEMENTED,
+                "Combinator ORDER BY for aggregate functions is not yet implemented. "
+                "Parser and query tree support is in place, but execution is not. "
+                "See https://github.com/ClickHouse/ClickHouse/issues/34156");
         }
 
 

--- a/src/Planner/PlannerAggregation.cpp
+++ b/src/Planner/PlannerAggregation.cpp
@@ -61,6 +61,18 @@ AggregateDescriptions extractAggregateDescriptions(const QueryTreeNodes & aggreg
                     std::move(by_name));
             }
         }
+        if (aggregate_function_node_typed.hasOrderByCombinator())
+        {
+            const auto & order_by_nodes = aggregate_function_node_typed
+                .getOrderByColumnsNode()->as<ListNode &>().getNodes();
+            aggregate_description.order_by_columns = Names();
+            aggregate_description.order_by_columns->reserve(order_by_nodes.size());
+            for (const auto & order_by_node : order_by_nodes)
+            {
+                aggregate_description.order_by_columns->emplace_back(
+                    calculateActionNodeName(order_by_node, planner_context));
+            }
+        }
 
 
         aggregate_description.column_name = std::move(node_name);

--- a/src/Planner/PlannerAggregation.cpp
+++ b/src/Planner/PlannerAggregation.cpp
@@ -4,15 +4,9 @@
 #include <Analyzer/FunctionNode.h>
 
 #include <Planner/PlannerActionsVisitor.h>
-#include <Common/Exception.h>
 
 namespace DB
 {
-
-namespace ErrorCodes
-{
-    extern const int NOT_IMPLEMENTED;
-}
 
 AggregateDescriptions extractAggregateDescriptions(const QueryTreeNodes & aggregate_function_nodes, const PlannerContext & planner_context)
 {
@@ -66,14 +60,6 @@ AggregateDescriptions extractAggregateDescriptions(const QueryTreeNodes & aggreg
                 aggregate_description.by_columns->emplace_back(
                     std::move(by_name));
             }
-        }
-        
-        if (aggregate_function_node_typed.hasOrderByCombinator())
-        {
-            throw Exception(ErrorCodes::NOT_IMPLEMENTED,
-                "Combinator ORDER BY for aggregate functions is not yet implemented. "
-                "Parser and query tree support is in place, but execution is not. "
-                "See https://github.com/ClickHouse/ClickHouse/issues/34156");
         }
 
 

--- a/src/Planner/PlannerAggregation.cpp
+++ b/src/Planner/PlannerAggregation.cpp
@@ -43,6 +43,26 @@ AggregateDescriptions extractAggregateDescriptions(const QueryTreeNodes & aggreg
             aggregate_description.argument_names.emplace_back(std::move(argument_node_name));
         }
 
+        if (aggregate_function_node_typed.hasTotalsCombinator())
+        {
+            aggregate_description.totals_combinator = true;
+        }
+        if (aggregate_function_node_typed.hasByCombinator())
+        {
+            const auto & by_nodes = aggregate_function_node_typed
+                .getByColumnsNode()->as<ListNode &>().getNodes();
+            aggregate_description.by_columns = Names();
+            aggregate_description.by_columns->reserve(by_nodes.size());
+            for (const auto & by_node : by_nodes)
+            {
+                String by_name = calculateActionNodeName(
+                    by_node, planner_context, node_to_name);
+                aggregate_description.by_columns->emplace_back(
+                    std::move(by_name));
+            }
+        }
+
+
         aggregate_description.column_name = std::move(node_name);
         aggregate_descriptions.push_back(std::move(aggregate_description));
     }

--- a/src/Planner/PlannerExpressionAnalysis.cpp
+++ b/src/Planner/PlannerExpressionAnalysis.cpp
@@ -32,6 +32,8 @@
 
 #include <Core/Settings.h>
 
+#include <unordered_set>
+
 namespace DB
 {
 namespace Setting
@@ -42,6 +44,7 @@ namespace Setting
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+    extern const int BAD_ARGUMENTS;
 }
 
 namespace
@@ -276,6 +279,28 @@ std::optional<AggregationAnalysisResult> analyzeAggregation(
 
                 before_aggregation_actions->dag.getOutputs().push_back(expression_dag_node);
                 before_aggregation_actions_output_node_names.insert(expression_dag_node->result_name);
+            }
+        }
+    }
+
+    /// Validate that BY-columns in aggregate combinators are a subset of GROUP BY keys.
+    {
+        std::unordered_set<std::string_view> group_by_keys_set(
+            aggregation_keys.begin(), aggregation_keys.end());
+
+        for (const auto & aggregate : aggregates_descriptions)
+        {
+            if (!aggregate.by_columns.has_value())
+                continue;
+
+            for (const auto & by_name : *aggregate.by_columns)
+            {
+                if (!group_by_keys_set.contains(by_name))
+                    throw Exception(
+                        ErrorCodes::BAD_ARGUMENTS,
+                        "BY column '{}' in aggregate function '{}' must be one of the GROUP BY keys",
+                        by_name,
+                        aggregate.column_name);
             }
         }
     }

--- a/tests/queries/0_stateless/04305_aggregate_combinators_totals_by.reference
+++ b/tests/queries/0_stateless/04305_aggregate_combinators_totals_by.reference
@@ -1,0 +1,31 @@
+--- T1: TOTALS basic ---
+NL	87500	101000
+RU	110000	101000
+--- T2: TOTALS multi-aggregate (FuseFunctionsPass test) ---
+NL	505000	101000
+RU	505000	101000
+--- T3: BY single column ---
+NL	Amsterdam	87500	87500
+RU	Moscow	110000	110000
+RU	SPb	110000	110000
+--- T4: BY multiple columns ---
+NL	Amsterdam	Engineering	95000	95000
+NL	Amsterdam	Sales	80000	80000
+RU	Moscow	Engineering	120000	115000
+RU	Moscow	Sales	100000	100000
+RU	SPb	Engineering	110000	115000
+--- T5: Mixed TOTALS and BY ---
+NL	Amsterdam	87500	87500	101000
+RU	Moscow	110000	110000	101000
+RU	SPb	110000	110000	101000
+--- T6: BY equals GROUP BY (degenerate) ---
+NL	Amsterdam	87500	87500
+RU	Moscow	110000	110000
+RU	SPb	110000	110000
+--- T7: Identifier with name "totals" (backward compatibility) ---
+3	6
+--- T8: Validation - BY column not in GROUP BY ---
+--- T9: Validation - unknown column in BY ---
+--- T10: Validation - duplicate TOTALS ---
+--- T11: Validation - duplicate BY ---
+--- T12: Validation - TOTALS + BY in same call ---

--- a/tests/queries/0_stateless/04305_aggregate_combinators_totals_by.reference
+++ b/tests/queries/0_stateless/04305_aggregate_combinators_totals_by.reference
@@ -29,3 +29,4 @@ RU	SPb	110000	110000
 --- T10: Validation - duplicate TOTALS ---
 --- T11: Validation - duplicate BY ---
 --- T12: Validation - TOTALS + BY in same call ---
+--- T13: two-level aggregation is rejected with NOT_IMPLEMENTED ---

--- a/tests/queries/0_stateless/04305_aggregate_combinators_totals_by.reference
+++ b/tests/queries/0_stateless/04305_aggregate_combinators_totals_by.reference
@@ -29,4 +29,3 @@ RU	SPb	110000	110000
 --- T10: Validation - duplicate TOTALS ---
 --- T11: Validation - duplicate BY ---
 --- T12: Validation - TOTALS + BY in same call ---
---- T13: two-level aggregation is rejected with NOT_IMPLEMENTED ---

--- a/tests/queries/0_stateless/04305_aggregate_combinators_totals_by.reference
+++ b/tests/queries/0_stateless/04305_aggregate_combinators_totals_by.reference
@@ -29,3 +29,8 @@ RU	SPb	110000	110000
 --- T10: Validation - duplicate TOTALS ---
 --- T11: Validation - duplicate BY ---
 --- T12: Validation - TOTALS + BY in same call ---
+--- T13: count combinator (was broken by is_simple_count fast path) ---
+NL	5
+RU	5
+NL	2
+RU	3

--- a/tests/queries/0_stateless/04305_aggregate_combinators_totals_by.sql
+++ b/tests/queries/0_stateless/04305_aggregate_combinators_totals_by.sql
@@ -72,9 +72,4 @@ SELECT avg(salary BY country BY city) FROM test_combinators GROUP BY country, ci
 SELECT '--- T12: Validation - TOTALS + BY in same call ---';
 SELECT avg(salary TOTALS BY country) FROM test_combinators GROUP BY country; -- { clientError SYNTAX_ERROR }
 
-SELECT '--- T13: two-level aggregation is rejected with NOT_IMPLEMENTED ---';
-SET group_by_two_level_threshold = 1;
-SET group_by_two_level_threshold_bytes = 1;
-SELECT country, avg(salary TOTALS) FROM test_combinators GROUP BY country FORMAT Null; -- { serverError NOT_IMPLEMENTED }
-
 DROP TABLE test_combinators;

--- a/tests/queries/0_stateless/04305_aggregate_combinators_totals_by.sql
+++ b/tests/queries/0_stateless/04305_aggregate_combinators_totals_by.sql
@@ -16,6 +16,11 @@ INSERT INTO test_combinators VALUES
     ('NL', 'Amsterdam', 'Engineering', 95000),
     ('NL', 'Amsterdam', 'Sales', 80000);
 
+-- Disable two-level aggregation; it is not yet supported by TOTALS/BY combinators
+-- (see PR discussion). Two-level rejection is verified explicitly at the end of the test.
+SET group_by_two_level_threshold = 0;
+SET group_by_two_level_threshold_bytes = 0;
+
 SELECT '--- T1: TOTALS basic ---';
 SELECT country, round(avg(salary)) AS a, round(avg(salary TOTALS)) AS t
 FROM test_combinators GROUP BY country ORDER BY country;
@@ -66,5 +71,10 @@ SELECT avg(salary BY country BY city) FROM test_combinators GROUP BY country, ci
 
 SELECT '--- T12: Validation - TOTALS + BY in same call ---';
 SELECT avg(salary TOTALS BY country) FROM test_combinators GROUP BY country; -- { clientError SYNTAX_ERROR }
+
+SELECT '--- T13: two-level aggregation is rejected with NOT_IMPLEMENTED ---';
+SET group_by_two_level_threshold = 1;
+SET group_by_two_level_threshold_bytes = 1;
+SELECT country, avg(salary TOTALS) FROM test_combinators GROUP BY country FORMAT Null; -- { serverError NOT_IMPLEMENTED }
 
 DROP TABLE test_combinators;

--- a/tests/queries/0_stateless/04305_aggregate_combinators_totals_by.sql
+++ b/tests/queries/0_stateless/04305_aggregate_combinators_totals_by.sql
@@ -1,0 +1,70 @@
+-- Tags: no-fasttest
+
+DROP TABLE IF EXISTS test_combinators;
+
+CREATE TABLE test_combinators (
+    country String,
+    city String,
+    department String,
+    salary UInt64
+) ENGINE = MergeTree() ORDER BY (country, city);
+
+INSERT INTO test_combinators VALUES
+    ('RU', 'Moscow', 'Engineering', 120000),
+    ('RU', 'Moscow', 'Sales', 100000),
+    ('RU', 'SPb', 'Engineering', 110000),
+    ('NL', 'Amsterdam', 'Engineering', 95000),
+    ('NL', 'Amsterdam', 'Sales', 80000);
+
+SELECT '--- T1: TOTALS basic ---';
+SELECT country, round(avg(salary)) AS a, round(avg(salary TOTALS)) AS t
+FROM test_combinators GROUP BY country ORDER BY country;
+
+SELECT '--- T2: TOTALS multi-aggregate (FuseFunctionsPass test) ---';
+SELECT country, sum(salary TOTALS) AS s, round(avg(salary TOTALS)) AS a
+FROM test_combinators GROUP BY country ORDER BY country;
+
+SELECT '--- T3: BY single column ---';
+SELECT country, city, round(avg(salary)) AS local, round(avg(salary BY country)) AS by_c
+FROM test_combinators GROUP BY country, city ORDER BY country, city;
+
+SELECT '--- T4: BY multiple columns ---';
+SELECT country, city, department,
+       round(avg(salary)) AS local,
+       round(avg(salary BY country, department)) AS by_cd
+FROM test_combinators GROUP BY country, city, department ORDER BY country, city, department;
+
+SELECT '--- T5: Mixed TOTALS and BY ---';
+SELECT country, city,
+       round(avg(salary)) AS local,
+       round(avg(salary BY country)) AS by_c,
+       round(avg(salary TOTALS)) AS tot
+FROM test_combinators GROUP BY country, city ORDER BY country, city;
+
+SELECT '--- T6: BY equals GROUP BY (degenerate) ---';
+SELECT country, city, round(avg(salary)) AS a, round(avg(salary BY country, city)) AS b
+FROM test_combinators GROUP BY country, city ORDER BY country, city;
+
+SELECT '--- T7: Identifier with name "totals" (backward compatibility) ---';
+DROP TABLE IF EXISTS test_identifiers;
+CREATE TABLE test_identifiers (totals UInt64) ENGINE = MergeTree() ORDER BY tuple();
+INSERT INTO test_identifiers VALUES (1), (2), (3);
+SELECT count(totals), sum(totals) FROM test_identifiers;
+DROP TABLE test_identifiers;
+
+SELECT '--- T8: Validation - BY column not in GROUP BY ---';
+SELECT country, avg(salary BY department) FROM test_combinators GROUP BY country; -- { serverError BAD_ARGUMENTS }
+
+SELECT '--- T9: Validation - unknown column in BY ---';
+SELECT country, avg(salary BY unknown) FROM test_combinators GROUP BY country; -- { serverError UNKNOWN_IDENTIFIER }
+
+SELECT '--- T10: Validation - duplicate TOTALS ---';
+SELECT avg(salary TOTALS TOTALS) FROM test_combinators GROUP BY country; -- { clientError SYNTAX_ERROR }
+
+SELECT '--- T11: Validation - duplicate BY ---';
+SELECT avg(salary BY country BY city) FROM test_combinators GROUP BY country, city; -- { clientError SYNTAX_ERROR }
+
+SELECT '--- T12: Validation - TOTALS + BY in same call ---';
+SELECT avg(salary TOTALS BY country) FROM test_combinators GROUP BY country; -- { clientError SYNTAX_ERROR }
+
+DROP TABLE test_combinators;

--- a/tests/queries/0_stateless/04305_aggregate_combinators_totals_by.sql
+++ b/tests/queries/0_stateless/04305_aggregate_combinators_totals_by.sql
@@ -72,4 +72,8 @@ SELECT avg(salary BY country BY city) FROM test_combinators GROUP BY country, ci
 SELECT '--- T12: Validation - TOTALS + BY in same call ---';
 SELECT avg(salary TOTALS BY country) FROM test_combinators GROUP BY country; -- { clientError SYNTAX_ERROR }
 
+SELECT '--- T13: count combinator (was broken by is_simple_count fast path) ---';
+SELECT country, count(salary TOTALS) AS c FROM test_combinators GROUP BY country ORDER BY country;
+SELECT country, count(salary BY country) AS c FROM test_combinators GROUP BY country ORDER BY country;
+
 DROP TABLE test_combinators;


### PR DESCRIPTION
## Changelog category
- New Feature

## Changelog entry
Add `TOTALS` and `BY` combinators for aggregate functions.

## Description
This PR implements two new aggregate function combinators:

- **TOTALS**: computes the aggregate over the entire dataset, independent of `GROUP BY`. Example: `SELECT country, avg(salary), avg(salary TOTALS) FROM t GROUP BY country` — the third column is the same value (global average) in every row.

- **BY**: computes the aggregate over a subset of `GROUP BY` keys. Example: `SELECT country, city, avg(salary), avg(salary BY country) FROM t GROUP BY country, city` — the fourth column is the per-country average, same value for rows sharing the same country.

Closes part of #34156. The `ORDER BY` combinator from the same issue is implemented in a separate PR.

## Approach
Both combinators are implemented as **post-aggregation** of the main hash table, not as wrappers around the aggregate function. The reason: TOTALS and BY require access to states of multiple groups (TOTALS — all groups, BY — groups sharing a subset of keys), which a wrapper can't provide because it operates within a single group.

After the main aggregation hash table is filled, a single pass merges per-group states into auxiliary post-aggregation states (`PostAggregationState`):
- For TOTALS: a single global state, all groups are merged into it.
- For BY: a small hash table keyed by serialized BY-key.

When the result chunk is formed, values for aggregates with combinators are taken from the post-aggregation states instead of per-group states.

Compared to a JOIN-based implementation (separate aggregation per BY-subset + LEFT JOIN), this requires only one pass over input data and one main hash table.

## Components changed
- **Parser** (`ExpressionListParsers.cpp`, `ASTFunction.h/cpp`): recognizes `TOTALS` and `BY <cols>` inside function arguments.
- **Query tree** (`QueryTreeBuilder.cpp`, `FunctionNode.h/cpp`): propagates combinator info to query tree.
- **Analyzer** (`resolveFunction.cpp`, `QueryAnalyzer.cpp`): resolves BY columns to data sources, generates unique projection names.
- **Planner** (`PlannerActionsVisitor.cpp`, `PlannerExpressionAnalysis.cpp`, `PlannerAggregation.cpp`): validates BY columns are in GROUP BY, fills `AggregateDescription` with combinator info.
- **Aggregator** (`Aggregator.h/cpp`): adds `PostAggregationManager`, calls post-processing at finalization points, uses post-states in `insertResultsIntoColumns`.
- **New classes** (`PostAggregationState.h/cpp`): the post-aggregation machinery itself.
- **Optimizer** (`FuseFunctionsPass.cpp`): skips fusing `sum`/`avg` into `sumCount` for aggregates with combinators (preserves combinator information).

Both single-level and two-level hash aggregation are supported.

## Validation
BY columns must be a subset of GROUP BY keys. Checked at planning time (`analyzeAggregation`) and double-checked at `PostAggregationManager::init` (defense in depth). Error: `BAD_ARGUMENTS` with a message identifying the offending column and aggregate.
