### PR TITLE
S3 credentials: use IMDSv2 token for availability-zone detection

### DIFF
--- a/src/IO/S3/Credentials.cpp
+++ b/src/IO/S3/Credentials.cpp
@@ -62,6 +62,7 @@ namespace S3
 #    include <boost/algorithm/string/split.hpp>
 #    include <boost/algorithm/string/classification.hpp>
 #    include <Poco/Exception.h>
+#    include <Poco/String.h>
 #    include <Poco/URI.h>
 #    include <Poco/Net/HTTPClientSession.h>
 #    include <Poco/Net/HTTPRequest.h>
@@ -387,12 +388,49 @@ std::shared_ptr<AWSEC2MetadataClient> createEC2MetadataClient(const Aws::Client:
 
 String AWSEC2MetadataClient::getAvailabilityZoneOrException()
 {
-    Poco::URI uri(getAWSMetadataEndpoint() + EC2_AVAILABILITY_ZONE_RESOURCE);
+    const String endpoint = getAWSMetadataEndpoint();
+
+    /// Try to obtain an IMDSv2 session token. On instances configured for "IMDSv2 only"
+    /// (the AWS-recommended setting), the AZ resource rejects unauthenticated GETs with 401.
+    /// On endpoints that do not support the IMDSv2 token `PUT` the request fails; we then
+    /// fall back to the plain GET. See #81402.
+    String token;
+    try
+    {
+        Poco::URI token_uri(endpoint + EC2_IMDS_TOKEN_RESOURCE);
+        Poco::Net::HTTPClientSession token_session(token_uri.getHost(), token_uri.getPort());
+        token_session.setTimeout(Poco::Timespan(AVAILABILITY_ZONE_REQUEST_TIMEOUT_SECONDS, 0));
+
+        Poco::Net::HTTPRequest token_request(Poco::Net::HTTPRequest::HTTP_PUT, token_uri.getPathAndQuery());
+        token_request.set(EC2_IMDS_TOKEN_TTL_HEADER, EC2_IMDS_TOKEN_TTL_DEFAULT_VALUE);
+        token_request.setContentLength(0);
+        token_session.sendRequest(token_request);
+
+        Poco::Net::HTTPResponse token_response;
+        std::istream & token_stream = token_session.receiveResponse(token_response);
+        if (token_response.getStatus() == Poco::Net::HTTPResponse::HTTP_OK)
+        {
+            String token_payload;
+            Poco::StreamCopier::copyToString(token_stream, token_payload);
+            Poco::trimInPlace(token_payload);
+            token = std::move(token_payload);
+        }
+    }
+    catch (...) // NOLINT(bugprone-empty-catch)
+    {
+        /// Token acquisition is best-effort: any transport-level error here means we
+        /// fall back to the legacy unauthenticated GET below, which preserves
+        /// IMDSv1-only behavior.
+    }
+
+    Poco::URI uri(endpoint + EC2_AVAILABILITY_ZONE_RESOURCE);
     Poco::Net::HTTPClientSession session(uri.getHost(), uri.getPort());
     session.setTimeout(Poco::Timespan(AVAILABILITY_ZONE_REQUEST_TIMEOUT_SECONDS, 0));
 
     Poco::Net::HTTPResponse response;
-    Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, uri.getPath());
+    Poco::Net::HTTPRequest request(Poco::Net::HTTPRequest::HTTP_GET, uri.getPathAndQuery());
+    if (!token.empty())
+        request.set(EC2_IMDS_TOKEN_HEADER, token);
     session.sendRequest(request);
 
     std::istream & rs = session.receiveResponse(response);

--- a/tests/integration/test_placement_info/metadata_servers/imdsv2_server.py
+++ b/tests/integration/test_placement_info/metadata_servers/imdsv2_server.py
@@ -1,0 +1,83 @@
+import http.server
+import sys
+import uuid
+
+
+# Mocks an IMDSv2-only EC2 instance metadata service:
+#   * PUT /latest/api/token returns a fresh token when the
+#     x-aws-ec2-metadata-token-ttl-seconds header is present;
+#   * GET on metadata resources requires a matching x-aws-ec2-metadata-token
+#     header and otherwise returns 401 (matching the AWS contract for
+#     "IMDSv2 only (token required)" instances). Used to verify #81402.
+
+ISSUED_TOKENS = set()
+
+
+class RequestHandler(http.server.BaseHTTPRequestHandler):
+    def do_PUT(self):
+        if self.path != "/latest/api/token":
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        ttl = self.headers.get("x-aws-ec2-metadata-token-ttl-seconds")
+        if ttl is None:
+            self.send_response(400)
+            self.end_headers()
+            return
+
+        # Drain any request body before responding.
+        length = int(self.headers.get("Content-Length") or 0)
+        if length:
+            self.rfile.read(length)
+
+        token = uuid.uuid4().hex
+        ISSUED_TOKENS.add(token)
+        body = token.encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_HEAD(self):
+        return self._serve_get_or_head(write_body=False)
+
+    def do_GET(self):
+        self._serve_get_or_head(write_body=True)
+
+    def _serve_get_or_head(self, write_body):
+        if self.path == "/":
+            body = b"OK"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            if write_body:
+                self.wfile.write(body)
+            return
+
+        token = self.headers.get("x-aws-ec2-metadata-token")
+        if not token or token not in ISSUED_TOKENS:
+            self.send_response(401)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+
+        if self.path == "/latest/meta-data/placement/availability-zone":
+            body = b"ci-test-1a"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            if write_body:
+                self.wfile.write(body)
+            return
+
+        self.send_response(404)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
+httpd = http.server.HTTPServer(("0.0.0.0", int(sys.argv[1])), RequestHandler)
+httpd.serve_forever()

--- a/tests/integration/test_placement_info/test.py
+++ b/tests/integration/test_placement_info/test.py
@@ -7,6 +7,8 @@ from helpers.mock_servers import start_mock_servers
 
 METADATA_SERVER_HOSTNAME = "node_imds"
 METADATA_SERVER_PORT = 8080
+METADATA_SERVER_V2_HOSTNAME = "node_imds_v2"
+METADATA_SERVER_V2_PORT = 8081
 
 cluster = ClickHouseCluster(__file__)
 node_imds = cluster.add_instance(
@@ -14,6 +16,14 @@ node_imds = cluster.add_instance(
     main_configs=["configs/imds_bootstrap.xml"],
     env_variables={
         "AWS_EC2_METADATA_SERVICE_ENDPOINT": f"http://{METADATA_SERVER_HOSTNAME}:{METADATA_SERVER_PORT}",
+    },
+    stay_alive=True,
+)
+node_imds_v2 = cluster.add_instance(
+    "node_imds_v2",
+    main_configs=["configs/imds_bootstrap.xml"],
+    env_variables={
+        "AWS_EC2_METADATA_SERVICE_ENDPOINT": f"http://{METADATA_SERVER_V2_HOSTNAME}:{METADATA_SERVER_V2_PORT}",
     },
     stay_alive=True,
 )
@@ -42,7 +52,12 @@ def start_metadata_server(started_cluster):
                 "simple_server.py",
                 METADATA_SERVER_HOSTNAME,
                 METADATA_SERVER_PORT,
-            )
+            ),
+            (
+                "imdsv2_server.py",
+                METADATA_SERVER_V2_HOSTNAME,
+                METADATA_SERVER_V2_PORT,
+            ),
         ],
     )
 
@@ -67,6 +82,24 @@ def test_placement_info_from_imds():
 
     node_imds.query("SYSTEM FLUSH LOGS")
     assert node_imds.contains_in_log(
+        "CloudPlacementInfo: Loaded info: availability_zone: ci-test-1a"
+    )
+
+
+def test_placement_info_from_imdsv2_only():
+    # Regression test for #81402: an EC2 instance configured with
+    # "IMDSv2 only (token required)" rejects unauthenticated GETs
+    # against the metadata service. The mock server here only honors
+    # GETs that present a freshly-issued IMDSv2 session token.
+    with open(os.path.join(os.path.dirname(__file__), "configs/imds.xml"), "r") as f:
+        node_imds_v2.replace_config(
+            "/etc/clickhouse-server/config.d/imds_bootstrap.xml", f.read()
+        )
+    node_imds_v2.stop_clickhouse(kill=True)
+    node_imds_v2.start_clickhouse()
+
+    node_imds_v2.query("SYSTEM FLUSH LOGS")
+    assert node_imds_v2.contains_in_log(
         "CloudPlacementInfo: Loaded info: availability_zone: ci-test-1a"
     )
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix availability-zone detection on EC2 instances configured for "IMDSv2 only (token required)". `getRunningAvailabilityZone` now obtains an IMDSv2 session token before fetching the AZ resource, falling back to the legacy unauthenticated request when the metadata service does not implement the token endpoint.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!--- Bug fix; behavior now matches what users already expect on AWS-recommended IMDSv2-only instances. -->

---

## Motivation

`AWSEC2MetadataClient::getAvailabilityZoneOrException` performed a plain
unauthenticated `GET` against the EC2 instance metadata service. On
instances configured for "IMDSv2 only" (the AWS-recommended hardening
setting), the metadata endpoint rejects unauthenticated `GET` requests
with `401 Unauthorized`, so `tryGetRunningAvailabilityZone` failed and
ClickHouse / Keeper logged

tryGetRunningAvailabilityZone: ... Failed to get AWS availability zone.
HTTP response code: HTTP_UNAUTHORIZED.
... Failed to find the availability zone, tried AWS and GCP.

even though the metadata service was reachable.

The credentials path in the same client (`getDefaultCredentialsSecurely`)
already does the IMDSv2 dance: PUT `/latest/api/token` to obtain a token,
then GET with `x-aws-ec2-metadata-token` set. The AZ helper still used
the older code path.

## Fix

Acquire an IMDSv2 session token first via `PUT /latest/api/token` with
the `x-aws-ec2-metadata-token-ttl-seconds` header (the constants and
header names already exist in `Credentials.h`), then send the AZ `GET`
with `x-aws-ec2-metadata-token` set. If the token `PUT` fails or returns
a non-200, fall back to the unauthenticated `GET` so endpoints that do
not implement IMDSv2 keep working as before.

## Test

Adds an integration test using a new mock metadata server,
`tests/integration/test_placement_info/metadata_servers/imdsv2_server.py`,
which requires the IMDSv2 token on the AZ `GET` and returns `401` without
it. A new `node_imds_v2` instance and `test_placement_info_from_imdsv2_only`
case in `tests/integration/test_placement_info/test.py` exercise the new
path end-to-end against the mock.

Closes #81402
