### PR TITLE
Preserve hung_check.log on stress-test deadlock failure

### DIFF
--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -641,14 +641,49 @@ def main():
                     tee.stdin.close()
             if res != 0 and have_long_running_queries:
                 logging.info("Hung check failed with exit code %d", res)
+
+                # Embed a tail of the captured hung-check output in
+                # test_results.tsv so the processlist and thread stacktraces
+                # are visible in CIDB. The full log is also kept as a CI
+                # artifact (see process_results in stress_job.py), giving
+                # investigators access to the complete diagnostic output.
+                info_field = ""
+                try:
+                    log_text = hung_check_log.read_text(errors="replace")
+                    # 32 KiB is enough for the processlist and a handful of
+                    # stacktraces. Keep the tail because the diagnostic
+                    # content (Found hung queries, processlist with
+                    # stacktraces, gdb backtraces) appears at the end.
+                    max_chars = 32 * 1024
+                    if len(log_text) > max_chars:
+                        log_text = (
+                            "(truncated; see hung_check.log artifact for the"
+                            " full output; showing last 32 KiB)\n...\n"
+                            + log_text[-max_chars:]
+                        )
+                    # Escape so tab and newline survive the TSV encoding,
+                    # matching the decoder in read_test_results().
+                    info_field = log_text.replace("\t", "\\t").replace(
+                        "\n", "\\n"
+                    )
+                except OSError as ex:
+                    logging.warning(
+                        "Failed to read hung_check.log to embed in"
+                        " test_results.tsv: %s",
+                        ex,
+                    )
+
                 hung_check_status = (
-                    "Hung check failed, possible deadlock found\tFAIL\t\\N\t\n"
+                    "Hung check failed, possible deadlock found\tFAIL\t\\N\t"
+                    f"{info_field}\n"
                 )
                 with open(
                     args.output_folder / "test_results.tsv", "w+", encoding="utf-8"
                 ) as results:
                     results.write(hung_check_status)
-                    hung_check_log.unlink()
+                # Keep hung_check.log on disk so the CI artifact upload picks
+                # it up. Without it, deadlock investigations have no evidence
+                # to work with — see ClickHouse/ClickHouse#100941.
             else:
                 logging.info("No queries hung")
 

--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -647,19 +647,35 @@ def main():
                 # are visible in CIDB. The full log is also kept as a CI
                 # artifact (see process_results in stress_job.py), giving
                 # investigators access to the complete diagnostic output.
+                #
+                # Read only the last 32 KiB rather than the whole file: on
+                # deadlock failures `hung_check.log` can be very large (a
+                # full processlist plus a `gdb` backtrace for every server
+                # process), and the stress-test machine is already under
+                # memory pressure. The diagnostic content we need
+                # (`Found hung queries`, the processlist with stacktraces,
+                # the `gdb` backtraces) is printed at the end of the log,
+                # so the tail is exactly the relevant region.
                 info_field = ""
                 try:
-                    log_text = hung_check_log.read_text(errors="replace")
-                    # 32 KiB is enough for the processlist and a handful of
-                    # stacktraces. Keep the tail because the diagnostic
-                    # content (Found hung queries, processlist with
-                    # stacktraces, gdb backtraces) appears at the end.
-                    max_chars = 32 * 1024
-                    if len(log_text) > max_chars:
+                    tail_bytes_size = 32 * 1024
+                    with open(hung_check_log, "rb") as f:
+                        f.seek(0, os.SEEK_END)
+                        size = f.tell()
+                        offset = max(0, size - tail_bytes_size)
+                        f.seek(offset)
+                        tail_bytes = f.read()
+                    log_text = tail_bytes.decode("utf-8", errors="replace")
+                    if offset > 0:
+                        # Drop the (likely partial) first line so the tail
+                        # always starts on a line boundary.
+                        nl = log_text.find("\n")
+                        if nl >= 0:
+                            log_text = log_text[nl + 1 :]
                         log_text = (
-                            "(truncated; see hung_check.log artifact for the"
-                            " full output; showing last 32 KiB)\n...\n"
-                            + log_text[-max_chars:]
+                            "(truncated; see hung_check.log artifact for"
+                            " the full output; showing last 32 KiB)\n...\n"
+                            + log_text
                         )
                     # Escape so tab and newline survive the TSV encoding,
                     # matching the decoder in read_test_results().


### PR DESCRIPTION
The stress test runs `clickhouse-test --hung-check --capture-client-stacktrace` after every job. When this detects long-running queries the runner collects the processlist and `gdb` backtraces of every server process and writes them all into `hung_check.log`. That log is the primary diagnostic evidence for any deadlock.

`ci/jobs/scripts/stress/stress.py` was deleting the log on exactly the failure path (`hung_check_log.unlink()`), leaving only the bare row `Hung check failed, possible deadlock found\tFAIL\t\N\t` in `test_results.tsv`. The result is that every "Hung check failed" entry in CIDB has an empty `test_context_raw`, the S3 artifact upload picks up nothing useful, and investigators have no way to tell which mutex / condvar / processor was stuck.

This change:
- Keeps `hung_check.log` on disk so the artifact upload (`process_results` in `ci/jobs/stress_job.py`) includes it.
- Embeds the last 32 KiB of the captured output as the 4th column of `test_results.tsv`. The tail is the relevant region (`Found hung queries in processlist:`, the processlist with stacktraces, and the gdb backtraces all print at the end). The encoding mirrors the decoder in `read_test_results` (tab and newline escaped to `\t` / `\n`).
- The success branch (`No queries hung`) is unchanged.

This is the smallest infrastructure fix that unblocks investigation of the chronic "Hung check failed, possible deadlock found" stress-test umbrella (~290 hits / 30 days, multiple independent root causes) — the chronic task explicitly identified the deleted log as the blocker.

Requested by @alexey-milovidov on https://github.com/ClickHouse/ClickHouse/pull/100941

### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Preserve `hung_check.log` and embed its tail in `test_results.tsv` when the stress-test hung check fails, so that the captured processlist and thread stacktraces survive into CI artifacts and CIDB.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.122`
<!-- ch-version-info:end -->