### PR TITLE
Suppress spurious LOG_ERROR for 4xx during AWS credential-probing (IMDSv2/STS)

### DIFF
--- a/src/IO/ExpectCredentialProbe4xxScope.cpp
+++ b/src/IO/ExpectCredentialProbe4xxScope.cpp
@@ -1,0 +1,29 @@
+#include <IO/ExpectCredentialProbe4xxScope.h>
+
+#include <base/defines.h>
+
+namespace DB
+{
+
+thread_local size_t expected_credential_probe_4xx_scope_count = 0;
+
+ExpectCredentialProbe4xxScope::ExpectCredentialProbe4xxScope()
+    : initial_thread_id(std::this_thread::get_id())
+{
+    ++expected_credential_probe_4xx_scope_count;
+}
+
+ExpectCredentialProbe4xxScope::~ExpectCredentialProbe4xxScope()
+{
+    /// check that instance is destroyed in the same thread
+    chassert(initial_thread_id == std::this_thread::get_id());
+    chassert(expected_credential_probe_4xx_scope_count);
+    --expected_credential_probe_4xx_scope_count;
+}
+
+bool ExpectCredentialProbe4xxScope::isActive()
+{
+    return expected_credential_probe_4xx_scope_count != 0;
+}
+
+}

--- a/src/IO/ExpectCredentialProbe4xxScope.h
+++ b/src/IO/ExpectCredentialProbe4xxScope.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <thread>
+
+namespace DB
+{
+
+/// Inside the inner scope
+/// Remote storage 4xx responses received during AWS credential-provider probing
+/// (e.g., EC2 IMDS metadata negotiation, STS web-identity refresh) are considered
+/// expected. The AWS SDK silently falls through to the next provider in the chain
+/// on these responses; without this scope, `PocoHTTPClient` would log them as
+/// errors and pollute server logs / trigger false alerts.
+///
+/// Suppression is bounded to the 4xx range so that 5xx responses (genuine
+/// regional STS or IMDS infrastructure outages) still surface as errors.
+class ExpectCredentialProbe4xxScope
+{
+public:
+    ExpectCredentialProbe4xxScope();
+    ~ExpectCredentialProbe4xxScope();
+
+    static bool isActive();
+
+private:
+    std::thread::id initial_thread_id;
+};
+
+}

--- a/src/IO/S3/Credentials.cpp
+++ b/src/IO/S3/Credentials.cpp
@@ -1,4 +1,5 @@
 #include <atomic>
+#include <IO/ExpectCredentialProbe4xxScope.h>
 #include <IO/ReadBufferFromFile.h>
 #include <IO/ReadHelpers.h>
 #include <IO/S3/Credentials.h>
@@ -224,6 +225,12 @@ Aws::String AWSEC2MetadataClient::GetResource(const char * resource_path) const
 
 Aws::String AWSEC2MetadataClient::getDefaultCredentials() const
 {
+    /// IMDS HTTP responses with 4xx status are routinely encountered when the
+    /// instance is not running on EC2, when IMDSv2 is enforced, or when the
+    /// metadata hop limit blocks access. The SDK falls through silently in
+    /// these cases; suppress error-level logging so they do not pollute logs.
+    ExpectCredentialProbe4xxScope expect_4xx_scope;
+
     String credentials_string;
     {
         std::lock_guard locker(token_mutex);
@@ -268,6 +275,14 @@ Aws::String AWSEC2MetadataClient::awsComputeUserAgentString()
 
 Aws::String AWSEC2MetadataClient::getDefaultCredentialsSecurely() const
 {
+    /// IMDSv2 token negotiation (the initial PUT) commonly returns 4xx when the
+    /// instance is not on EC2, when IMDSv2 is disabled, or when the metadata
+    /// hop limit blocks access. The SDK handles these responses internally by
+    /// falling through to IMDSv1 or to the next provider in the chain;
+    /// suppress error-level logging so they do not pollute logs / trigger
+    /// false alerts.
+    ExpectCredentialProbe4xxScope expect_4xx_scope;
+
     String user_agent_string = awsComputeUserAgentString();
     auto [new_token, response_code] = getEC2MetadataToken(user_agent_string);
     if (response_code == Aws::Http::HttpResponseCode::BAD_REQUEST
@@ -718,6 +733,13 @@ void AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider::Reload()
         return;
     }
     Aws::Internal::STSCredentialsClient::STSAssumeRoleWithWebIdentityRequest request{session_name, role_arn, token};
+
+    /// STS responses with 4xx status during web-identity refresh are expected
+    /// when the role/token is misconfigured, the session expired, or the regional
+    /// endpoint is unreachable. The SDK retries via a separate retry strategy and
+    /// the chain falls through to subsequent providers; suppress error-level
+    /// logging for the underlying HTTP response so it does not pollute logs.
+    ExpectCredentialProbe4xxScope expect_4xx_scope;
 
     auto result = client->GetAssumeRoleWithWebIdentityCredentials(request);
     AWSCredentialsProvider::Reload();

--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -17,6 +17,7 @@
 #include <Common/Throttler.h>
 #include <Common/re2.h>
 #include <IO/Expect404ResponseScope.h>
+#include <IO/ExpectCredentialProbe4xxScope.h>
 #include <IO/GCPOAuth.h>
 #include <IO/HTTPCommon.h>
 #include <IO/WriteBufferFromString.h>
@@ -651,10 +652,23 @@ void PocoHTTPClient::makeRequestInternalImpl(
                 /// (e.g. If-None-Match: *), not a genuine error.
                 LOG_INFO(log, "Response status: {}, {}", status_code, poco_response.getReason());
             }
-            else if (Poco::Net::HTTPResponse::HTTP_NOT_FOUND != status_code || !Expect404ResponseScope::is404Expected())
+            else
             {
-                /// Error statuses are more important so we show them even if `enable_s3_requests_logging == false`.
-                LOG_ERROR(log, "Response status: {}, {}", status_code, poco_response.getReason());
+                const bool is_expected_404
+                    = (Poco::Net::HTTPResponse::HTTP_NOT_FOUND == status_code && Expect404ResponseScope::is404Expected());
+                const bool is_expected_credential_probe_4xx
+                    = (status_code >= 400 && status_code < 500 && ExpectCredentialProbe4xxScope::isActive());
+
+                if (!is_expected_404 && !is_expected_credential_probe_4xx)
+                {
+                    /// Error statuses are more important so we show them even if `enable_s3_requests_logging == false`.
+                    LOG_ERROR(log, "Response status: {}, {}", status_code, poco_response.getReason());
+                }
+                else if (enable_s3_requests_logging)
+                {
+                    LOG_TEST(log, "Response status: {}, {} (expected during credential probing)",
+                             status_code, poco_response.getReason());
+                }
             }
 
             if (poco_response.getStatus() == Poco::Net::HTTPResponse::HTTP_TEMPORARY_REDIRECT)

--- a/src/IO/S3/tests/gtest_credential_probe_logging.cpp
+++ b/src/IO/S3/tests/gtest_credential_probe_logging.cpp
@@ -1,0 +1,237 @@
+#include <gtest/gtest.h>
+
+#include "config.h"
+
+#if USE_AWS_S3
+
+#include <atomic>
+#include <memory>
+#include <string>
+
+#include <Poco/AutoPtr.h>
+#include <Poco/Channel.h>
+#include <Poco/Logger.h>
+#include <Poco/Message.h>
+#include <Poco/Net/HTTPRequestHandler.h>
+#include <Poco/Net/HTTPRequestHandlerFactory.h>
+#include <Poco/Net/HTTPServer.h>
+#include <Poco/Net/HTTPServerParams.h>
+#include <Poco/Net/HTTPServerRequest.h>
+#include <Poco/Net/HTTPServerResponse.h>
+#include <Poco/Net/HTTPResponse.h>
+#include <Poco/Net/ServerSocket.h>
+#include <Poco/SharedPtr.h>
+#include <Poco/Util/ServerApplication.h>
+
+#include <aws/core/http/HttpRequest.h>
+#include <aws/core/http/HttpResponse.h>
+#include <aws/core/http/standard/StandardHttpRequest.h>
+
+#include <Common/Logger.h>
+#include <Common/RemoteHostFilter.h>
+#include <IO/Expect404ResponseScope.h>
+#include <IO/ExpectCredentialProbe4xxScope.h>
+#include <IO/S3/Client.h>
+#include <IO/S3/PocoHTTPClient.h>
+
+
+/// See gtest_aws_s3_client.cpp for rationale.
+[[maybe_unused]] static Poco::Util::ServerApplication app;
+
+
+namespace
+{
+
+/// Mock handler returning a fixed status code on every request.
+class FixedStatusHandler : public Poco::Net::HTTPRequestHandler
+{
+public:
+    explicit FixedStatusHandler(int status_code_) : status_code(status_code_) {}
+
+    void handleRequest(Poco::Net::HTTPServerRequest &, Poco::Net::HTTPServerResponse & response) override
+    {
+        response.setStatus(static_cast<Poco::Net::HTTPResponse::HTTPStatus>(status_code));
+        response.setReason("Bad Request");
+        response.send();
+    }
+
+private:
+    int status_code;
+};
+
+class FixedStatusHandlerFactory : public Poco::Net::HTTPRequestHandlerFactory
+{
+public:
+    explicit FixedStatusHandlerFactory(int status_code_) : status_code(status_code_) {}
+
+    Poco::Net::HTTPRequestHandler * createRequestHandler(const Poco::Net::HTTPServerRequest &) override
+    {
+        return new FixedStatusHandler(status_code);
+    }
+
+private:
+    int status_code;
+};
+
+class FixedStatusHTTPServer
+{
+public:
+    explicit FixedStatusHTTPServer(int status_code)
+        : server_socket(std::make_unique<Poco::Net::ServerSocket>(0))
+        , handler_factory(new FixedStatusHandlerFactory(status_code))
+        , server_params(new Poco::Net::HTTPServerParams())
+        , server(std::make_unique<Poco::Net::HTTPServer>(handler_factory, *server_socket, server_params))
+    {
+        server->start();
+    }
+
+    std::string getUrl() const
+    {
+        return "http://" + server_socket->address().toString();
+    }
+
+private:
+    std::unique_ptr<Poco::Net::ServerSocket> server_socket;
+    Poco::SharedPtr<FixedStatusHandlerFactory> handler_factory;
+    Poco::AutoPtr<Poco::Net::HTTPServerParams> server_params;
+    std::unique_ptr<Poco::Net::HTTPServer> server;
+};
+
+/// Captures every Poco log message at PRIO_ERROR or above so the test can
+/// assert whether `LOG_ERROR(log, "Response status: ...")` was emitted by
+/// `PocoHTTPClient::makeRequestInternalImpl`.
+class CountingLogChannel : public Poco::Channel
+{
+public:
+    void log(const Poco::Message & msg) override
+    {
+        if (msg.getPriority() <= Poco::Message::PRIO_ERROR
+            && msg.getText().find("Response status: ") != std::string::npos)
+        {
+            error_count.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+
+    size_t getErrorCount() const { return error_count.load(std::memory_order_relaxed); }
+
+private:
+    std::atomic<size_t> error_count{0};
+};
+
+struct LoggerSpy
+{
+    Poco::AutoPtr<CountingLogChannel> channel;
+    Poco::Channel * previous_channel = nullptr;
+    Poco::Logger * logger = nullptr;
+
+    explicit LoggerSpy(const std::string & logger_name)
+        : channel(new CountingLogChannel())
+        , logger(&Poco::Logger::get(logger_name))
+    {
+        /// Hold a reference to the existing channel so that `setChannel` below does
+        /// not free it; restore it in the destructor.
+        previous_channel = logger->getChannel();
+        if (previous_channel)
+            previous_channel->duplicate();
+        logger->setChannel(channel.get());
+    }
+
+    ~LoggerSpy()
+    {
+        logger->setChannel(previous_channel);
+        if (previous_channel)
+            previous_channel->release();
+    }
+};
+
+DB::S3::PocoHTTPClientConfiguration makeClientConfiguration(const std::string & url)
+{
+    DB::RemoteHostFilter remote_host_filter;
+    DB::S3::PocoHTTPClientConfiguration client_configuration = DB::S3::ClientFactory::instance().createClientConfiguration(
+        /* force_region = */ "us-east-1",
+        remote_host_filter,
+        /* s3_max_redirects = */ 0,
+        DB::S3::PocoHTTPClientConfiguration::RetryStrategy{.max_retries = 0},
+        /* s3_slow_all_threads_after_network_error = */ false,
+        /* s3_slow_all_threads_after_retryable_error = */ false,
+        /* enable_s3_requests_logging = */ false,
+        /* for_disk_s3 = */ false,
+        /* opt_disk_name = */ {},
+        /* request_throttler = */ {});
+    client_configuration.endpointOverride = url;
+    return client_configuration;
+}
+
+size_t makeRequestAndCountErrorLogs(const std::string & url, std::function<void()> wrap)
+{
+    LoggerSpy spy("AWSClient");
+
+    DB::S3::PocoHTTPClient client{makeClientConfiguration(url)};
+
+    auto request = std::make_shared<Aws::Http::Standard::StandardHttpRequest>(
+        Aws::String(url), Aws::Http::HttpMethod::HTTP_GET);
+
+    wrap();
+    client.MakeRequest(request, /* readLimiter = */ nullptr, /* writeLimiter = */ nullptr);
+
+    return spy.channel->getErrorCount();
+}
+
+}
+
+
+/// Without any scope active, a 4xx response from the upstream HTTP server
+/// should be logged as `LOG_ERROR("Response status: 4XX, ...")`.
+TEST(CredentialProbeLogging, NoScopeFourHundredLogsError)
+{
+    FixedStatusHTTPServer server{400};
+    size_t count = makeRequestAndCountErrorLogs(server.getUrl(), [] {});
+    EXPECT_GE(count, 1u);
+}
+
+/// When `ExpectCredentialProbe4xxScope` is active, a 4xx response is expected
+/// during AWS credential-provider probing (IMDSv2 token negotiation, STS
+/// web-identity refresh) and should NOT be logged at error level.
+TEST(CredentialProbeLogging, WithCredentialProbeScopeFourHundredDoesNotLogError)
+{
+    FixedStatusHTTPServer server{400};
+    std::optional<DB::ExpectCredentialProbe4xxScope> scope;
+    size_t count = makeRequestAndCountErrorLogs(server.getUrl(), [&] { scope.emplace(); });
+    EXPECT_EQ(count, 0u);
+}
+
+/// `Expect404ResponseScope` only suppresses HTTP 404. A 400 response with
+/// only the 404 scope active must still log at error level (proves the
+/// existing 404-scope is unchanged).
+TEST(CredentialProbeLogging, WithFourOhFourScopeOnlyFourHundredLogsError)
+{
+    FixedStatusHTTPServer server{400};
+    std::optional<DB::Expect404ResponseScope> scope;
+    size_t count = makeRequestAndCountErrorLogs(server.getUrl(), [&] { scope.emplace(); });
+    EXPECT_GE(count, 1u);
+}
+
+/// With both scopes active, the credential-probe scope handles the 4xx
+/// suppression independently of the 404-only scope.
+TEST(CredentialProbeLogging, WithBothScopesFourHundredDoesNotLogError)
+{
+    FixedStatusHTTPServer server{400};
+    std::optional<DB::Expect404ResponseScope> scope_404;
+    std::optional<DB::ExpectCredentialProbe4xxScope> scope_4xx;
+    size_t count = makeRequestAndCountErrorLogs(server.getUrl(), [&] { scope_404.emplace(); scope_4xx.emplace(); });
+    EXPECT_EQ(count, 0u);
+}
+
+/// 5xx responses during credential probing represent genuine infrastructure
+/// outages (e.g., regional STS down). They must still log at error level
+/// even when `ExpectCredentialProbe4xxScope` is active, because the scope is
+/// bounded to the 4xx range.
+TEST(CredentialProbeLogging, WithCredentialProbeScopeFiveOhThreeStillLogsError)
+{
+    FixedStatusHTTPServer server{503};
+    std::optional<DB::ExpectCredentialProbe4xxScope> scope;
+    size_t count = makeRequestAndCountErrorLogs(server.getUrl(), [&] { scope.emplace(); });
+    EXPECT_GE(count, 1u);
+}
+
+#endif


### PR DESCRIPTION
## Linked issues

Fixes #99140

## Summary

When ClickHouse runs on EC2 with no `AWS_*` env vars and no STS web-identity token file, every `s3('s3://bucket/...')` query emits one `Response status: 400, Bad Request` `LOG_ERROR` from `PocoHTTPClient::makeRequestInternalImpl` even when the query succeeds. The 400 originates from the IMDSv2 token negotiation `PUT` to `http://169.254.169.254/latest/api/token`. When IMDSv2 is misconfigured / hop-limit-blocked / disabled, the `PUT` returns `400 BAD_REQUEST`. The SDK at `AWSEC2MetadataClient::getDefaultCredentialsSecurely` already handles this gracefully (returns empty, falls through to IMDSv1 / next provider), but `PocoHTTPClient` has logged the response as a `LOG_ERROR` before the SDK can mask it.

## Approach

Mirroring the existing `Expect404ResponseScope` pattern, this introduces `ExpectCredentialProbe4xxScope` — a thread-local RAII counter that signals to `PocoHTTPClient` that 4xx responses inside the scope are expected and should not be logged at error level. The scope wraps the IMDS HTTP call sites in `AWSEC2MetadataClient::getDefaultCredentials` and `getDefaultCredentialsSecurely`, and the STS web-identity refresh path in `AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider::Reload`. `PocoHTTPClient::makeRequestInternalImpl` honors the scope by suppressing `LOG_ERROR` for HTTP 4xx, downgrading to `LOG_TEST` when `enable_s3_requests_logging` is on. Suppression is bounded to the 4xx range so 5xx responses (e.g. genuine regional STS / IMDS infrastructure outages) still log as `ERROR`.

A C++ unit test (`gtest_credential_probe_logging`) covers four cases: no scope active (logs error), credential-probe scope active (suppresses 4xx), 404 scope only with a 400 response (existing 404 scope is unchanged), both scopes active for a 4xx (still suppressed), and credential-probe scope active for a 503 (5xx still logs).

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Stops logging spurious `Response status: 400` errors from `PocoHTTPClient` when `s3` table function reads or other S3 operations probe the AWS credential chain on EC2. The errors are emitted by `PocoHTTPClient` for IMDSv2 token negotiation and STS web-identity refresh responses that the AWS SDK already handles silently as fall-through. Genuine 5xx infrastructure failures from the same paths continue to log at error level.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)
