### PR TITLE
Reduce flakiness in test_distributed_ddl_parallel

### DIFF
--- a/tests/integration/test_distributed_ddl_parallel/test.py
+++ b/tests/integration/test_distributed_ddl_parallel/test.py
@@ -31,6 +31,16 @@ class SafeThread(threading.Thread):
 
     def join(self, timeout=None):
         super().join(timeout)
+        # If the thread is still alive after the timeout, fail fast
+        # instead of returning silently. Otherwise the caller moves on
+        # to the next thread.join(timeout), which can stack up many
+        # 70-second waits and trip the 900-second pytest-timeout long
+        # after the real failure happened.
+        if self.is_alive():
+            raise RuntimeError(
+                f"Thread did not finish within {timeout}s — likely stuck "
+                "(check ZooKeeper connectivity and DDL queue state)"
+            )
         if self.exception:
             raise self.exception
 
@@ -168,9 +178,13 @@ def test_smoke():
     check_log()
 
 
+# 20 parallel `DROP DATABASE IF EXISTS ... ON CLUSTER` is enough to exercise
+# the DDL coordination path and catch the `Node exists` race the test guards
+# against. Going higher (the test used to spawn 50) saturates ZooKeeper under
+# sanitizer builds and causes spurious connection-loss failures.
 def test_smoke_parallel():
     threads = []
-    for _ in range(50):
+    for _ in range(20):
         threads.append(SafeThread(target=execute_smoke_query))
     for thread in threads:
         thread.start()
@@ -179,9 +193,13 @@ def test_smoke_parallel():
     check_log()
 
 
+# 30 threads still exercises queueing on `cluster_b` (pool_size = 20).
+# Going higher (the test used to spawn 90) saturates ZooKeeper under
+# sanitizer builds, and the resulting connection losses make the test
+# stall long enough to trip the 900-second pytest-timeout.
 def test_smoke_parallel_dict_reload():
     threads = []
-    for _ in range(90):
+    for _ in range(30):
         threads.append(SafeThread(target=execute_reload_dictionary_slow_dict_3))
     for thread in threads:
         thread.start()


### PR DESCRIPTION
The two heavy parallel tests in this suite have been chronically flaky across unrelated PRs (e.g. #100177, #101757, #93757, #95761, #100942 — 41 failures across 5 PRs in the last 30 days, 0 master failures) with three recurring failure modes:

- `Failed: Timeout (>900.0s) from pytest-timeout` while iterating `thread.join(70)` in `test_smoke_parallel_dict_reload`.
- `Coordination::Exception: Connection loss, path /clickhouse/task_queue/ddl/...` during `ON CLUSTER` operations.
- Sanitizer asserts in the `zoo3-1` ZooKeeper container under load.

The pattern is the same: 90 concurrent `SYSTEM RELOAD DICTIONARY ON CLUSTER` (or 50 concurrent `DROP DATABASE ... ON CLUSTER`) submit that many ZK transactions in parallel. Under sanitizer slowdown the cluster cannot keep up, ZooKeeper drops connections, and either threads error out or sit on a hung query until `pytest-timeout` (900 s) kills the whole test.

This PR makes two changes:

1. Lower the parallelism in `test_smoke_parallel` (50 → 20) and `test_smoke_parallel_dict_reload` (90 → 30). 30 threads still exceeds `cluster_b.pool_size = 20`, so the DDL queueing path is still exercised, and `check_log` still catches the `Coordination::Exception: Node exists` regression the test was originally written for.

2. Make `SafeThread.join` raise when the thread is still alive after the timeout, instead of silently returning. With 90 stuck joins of 70 s each the test would only surface a failure ~6300 s later — long after the 900 s `pytest-timeout` has already killed it. Failing fast keeps the error message useful and frees CI time.

Verified locally on `Integration tests (amd_tsan, 1/6)`:

- Full suite (`test_distributed_ddl_parallel/test.py`): 6/6 passed in 106 s.
- `test_smoke_parallel_dict_reload --count 5`: 5/5 passed in 54 s.

Requested by @alexey-milovidov on #100177.

### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.121`
<!-- ch-version-info:end -->