### PR TITLE
MergeTree: fold JSON dynamic paths into shared data for small Wide parts

### DIFF
--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -1159,7 +1159,7 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
     {
         addSettingsChanges(merge_tree_settings_changes_history, "26.5",
         {
-
+            {"object_shared_data_min_bytes_for_advanced_serialization", 0, 0, "New MergeTree setting that, when set, keeps every dynamic path of a JSON / Object / Dynamic column inside the single shared-data substream while the part's estimated size is below the threshold. Avoids the per-dynamic-path file fan-out (and the corresponding `PUT` amplification on object storage) that an under-filled `Wide` part would otherwise cause. Default 0 disables the gate."},
         });
         addSettingsChanges(merge_tree_settings_changes_history, "26.4",
         {

--- a/src/DataTypes/Serializations/ISerialization.h
+++ b/src/DataTypes/Serializations/ISerialization.h
@@ -350,6 +350,12 @@ public:
         /// Type of MergeTree data part we serialize/deserialize data from if any.
         MergeTreeDataPartType data_part_type = MergeTreeDataPartType::Unknown;
 
+        /// If true, `SerializationObject` should not enumerate any per-dynamic-path
+        /// substreams — every dynamic path stays inside the single `ObjectSharedData`
+        /// substream. Used to prevent `Wide` part file fan-out for small parts when
+        /// `object_shared_data_min_bytes_for_advanced_serialization` is configured.
+        bool force_object_shared_data_only = false;
+
         /// Current level of array. Needed to differentiate stream names of nested array offsets.
         size_t array_level = 0;
     };
@@ -433,6 +439,11 @@ public:
         /// Type of MergeTree data part we serialize data from if any.
         /// Some serializations may differ from type part for more optimal deserialization.
         MergeTreeDataPartType data_part_type = MergeTreeDataPartType::Unknown;
+
+        /// If true, `SerializationObject` folds every dynamic path back into the
+        /// single `ObjectSharedData` substream so the writer does not produce a
+        /// per-path `.bin` file. See `EnumerateStreamsSettings::force_object_shared_data_only`.
+        bool force_object_shared_data_only = false;
     };
 
     struct DeserializeBinaryBulkSettings

--- a/src/DataTypes/Serializations/SerializationObject.cpp
+++ b/src/DataTypes/Serializations/SerializationObject.cpp
@@ -109,6 +109,11 @@ struct SerializeBinaryBulkStateObject: public ISerialization::SerializeBinaryBul
     ColumnObject::Statistics statistics;
     /// If true, statistics will be recalculated during serialization.
     bool recalculate_statistics = false;
+    /// If true, the prefix recorded an empty `sorted_dynamic_paths` and the
+    /// data write must fold every dynamic path of the column into the single
+    /// shared-data substream. Captured at prefix time so the data write does
+    /// not have to re-read the (potentially mutated) settings field.
+    bool fold_dynamic_paths_into_shared_data = false;
 
     /// For flattened serialization only.
     std::vector<std::pair<String, ColumnPtr>> flattened_paths;
@@ -187,6 +192,18 @@ void SerializationObject::enumerateStreams(EnumerateStreamsSettings & settings, 
         {
             sorted_dynamic_paths = structure_state->sorted_dynamic_paths;
         }
+        /// On the write path, when the caller has asked us to keep all paths in the
+        /// shared-data substream (e.g. small Wide part with `object_shared_data_min_bytes_for_advanced_serialization`),
+        /// pretend that the column has no promoted dynamic paths so the writer
+        /// doesn't allocate a substream per path. The same flag is honored in
+        /// `serializeBinaryBulkStatePrefix` (records empty `sorted_dynamic_paths`)
+        /// and in `serializeBinaryBulkWithMultipleStreams` (folds the dynamic
+        /// columns back into shared data before writing). Restricted to Wide because
+        /// the per-column file fan-out problem only exists in Wide.
+        else if (settings.force_object_shared_data_only && settings.data_part_type == MergeTreeDataPartType::Wide)
+        {
+            sorted_dynamic_paths = std::make_shared<VectorWithMemoryTracking<String>>();
+        }
         else
         {
             sorted_dynamic_paths = std::make_shared<VectorWithMemoryTracking<String>>();
@@ -225,8 +242,24 @@ void SerializationObject::enumerateStreams(EnumerateStreamsSettings & settings, 
             if (serialization_version.value == SerializationVersion::V3)
             {
                 shared_data_serialization_version = SerializationObjectSharedData::SerializationVersion(settings.object_shared_data_serialization_version);
+                /// Mirror the prefix-side fallback when the part-bytes threshold has
+                /// disabled the per-path fan-out: keep the substream layout matched
+                /// to what the writer will actually produce on disk. Restricted to
+                /// Wide because the fold itself is restricted to Wide.
+                if (settings.force_object_shared_data_only
+                    && settings.data_part_type == MergeTreeDataPartType::Wide
+                    && shared_data_serialization_version.value == SerializationObjectSharedData::SerializationVersion::ADVANCED)
+                    shared_data_serialization_version.value = SerializationObjectSharedData::SerializationVersion::MAP_WITH_BUCKETS;
                 /// Avoid creating buckets in shared data for Wide part if shared data is empty.
-                if (settings.data_part_type != MergeTreeDataPartType::Wide || !column_object->getOrCalculateStatistics()->shared_data_paths_statistics.empty())
+                /// When folding is active the column's shared data may be empty (paths live in
+                /// `dynamic_paths`) — but the writer will fold them in, so we must enumerate the
+                /// same bucket layout.
+                const bool has_paths_to_fold_into_shared_data = settings.force_object_shared_data_only
+                    && settings.data_part_type == MergeTreeDataPartType::Wide
+                    && column_object && !column_object->getDynamicPaths().empty();
+                if (settings.data_part_type != MergeTreeDataPartType::Wide
+                    || !column_object->getOrCalculateStatistics()->shared_data_paths_statistics.empty()
+                    || has_paths_to_fold_into_shared_data)
                     num_buckets = settings.object_shared_data_buckets;
             }
 
@@ -313,10 +346,30 @@ void SerializationObject::serializeBinaryBulkStatePrefix(
     }
 
     /// Write all dynamic paths in sorted order.
-    object_state->sorted_dynamic_paths.reserve(dynamic_paths.size());
-    for (const auto & [path, _] : dynamic_paths)
-        object_state->sorted_dynamic_paths.push_back(path);
-    std::sort(object_state->sorted_dynamic_paths.begin(), object_state->sorted_dynamic_paths.end());
+    ///
+    /// When `force_object_shared_data_only` is set, we deliberately leave
+    /// `sorted_dynamic_paths` empty so that:
+    ///   - the on-disk prefix records "no dynamic paths" (the reader naturally
+    ///     reconstructs the same layout from disk);
+    ///   - the writer (`MergeTreeDataPartWriterWide::addStreams`) does not
+    ///     allocate one `.bin` per path;
+    ///   - `serializeBinaryBulkWithMultipleStreams` folds the column's dynamic
+    ///     paths back into the single shared-data substream below.
+    ///
+    /// Restricted to Wide parts: the per-column file fan-out problem this fixes
+    /// only exists in Wide. Compact parts pack everything into one .bin and use
+    /// `StatisticsMode::PREFIX`, which would write stale path statistics if the
+    /// fold ran (data is folded after the prefix, but PREFIX commits stats from
+    /// the pre-fold column).
+    object_state->fold_dynamic_paths_into_shared_data
+        = settings.force_object_shared_data_only && settings.data_part_type == MergeTreeDataPartType::Wide;
+    if (!object_state->fold_dynamic_paths_into_shared_data)
+    {
+        object_state->sorted_dynamic_paths.reserve(dynamic_paths.size());
+        for (const auto & [path, _] : dynamic_paths)
+            object_state->sorted_dynamic_paths.push_back(path);
+        std::sort(object_state->sorted_dynamic_paths.begin(), object_state->sorted_dynamic_paths.end());
+    }
 
     /// In V1 version we had max_dynamic_paths parameter written, but now we need only actual number of dynamic paths.
     /// For compatibility we need to write V1 version sometimes, but we should write number of dynamic paths instead of
@@ -337,13 +390,26 @@ void SerializationObject::serializeBinaryBulkStatePrefix(
     if (serialization_version.value == SerializationVersion::V3)
     {
         shared_data_serialization_version = SerializationObjectSharedData::SerializationVersion(settings.object_shared_data_serialization_version);
+        /// `object_shared_data_min_bytes_for_advanced_serialization` requires that the
+        /// "advanced" shared-data serialization is only used once a part is large
+        /// enough to amortize its cost. Below the threshold, fall back to
+        /// `map_with_buckets`, which is what the zero-level-parts default uses.
+        if (object_state->fold_dynamic_paths_into_shared_data
+            && shared_data_serialization_version.value == SerializationObjectSharedData::SerializationVersion::ADVANCED)
+            shared_data_serialization_version.value = SerializationObjectSharedData::SerializationVersion::MAP_WITH_BUCKETS;
         writeVarUInt(static_cast<UInt64>(shared_data_serialization_version.value), *stream);
         /// If serialization supports buckets, write number of buckets that will be used.
         if (shared_data_serialization_version.value == SerializationObjectSharedData::SerializationVersion::MAP_WITH_BUCKETS
             || shared_data_serialization_version.value == SerializationObjectSharedData::SerializationVersion::ADVANCED)
         {
             /// Avoid creating buckets for Wide part if shared data is empty.
-            if (settings.data_part_type != MergeTreeDataPartType::Wide || !statistics->shared_data_paths_statistics.empty())
+            /// When folding is active the input column's shared data may be empty,
+            /// but we are about to fold every dynamic path into it — use the
+            /// configured bucket count so reads of individual paths can still
+            /// parallelize over buckets.
+            if (settings.data_part_type != MergeTreeDataPartType::Wide
+                || !statistics->shared_data_paths_statistics.empty()
+                || (object_state->fold_dynamic_paths_into_shared_data && !dynamic_paths.empty()))
                 shared_data_buckets = settings.object_shared_data_buckets;
 
             writeVarUInt(shared_data_buckets, *stream);
@@ -743,6 +809,77 @@ ISerialization::DeserializeBinaryBulkStatePtr SerializationObject::deserializeOb
     return state;
 }
 
+namespace
+{
+/// Build a `shared_data` column (Array(Tuple(String, String))) covering rows
+/// `[offset, offset + limit)` of `column_object` such that every dynamic path
+/// is folded into shared data alongside the column's existing shared-data
+/// entries. Per-row entries are kept in sorted order by path name, mirroring
+/// the invariant maintained by `ColumnObject::insertFromSharedDataAndFillRemainingDynamicPaths`.
+ColumnPtr foldDynamicPathsIntoSharedData(
+    const ColumnObject & column_object,
+    size_t offset,
+    size_t limit)
+{
+    auto folded_column = DataTypeObject::getTypeOfSharedData()->createColumn();
+    auto [folded_paths, folded_values, folded_offsets] = ColumnObject::getSharedDataPathsValuesAndOffsets(*folded_column);
+
+    const auto [src_shared_paths, src_shared_values, src_shared_offsets_ptr] = ColumnObject::getSharedDataPathsValuesAndOffsets(*column_object.getSharedDataPtr());
+    const auto & src_shared_offsets = *src_shared_offsets_ptr;
+    const auto & dynamic_paths_ptrs = column_object.getDynamicPathsPtrs();
+
+    /// Sort dynamic paths once; per-row insertion preserves the merge order.
+    std::vector<std::string_view> sorted_dynamic_paths;
+    sorted_dynamic_paths.reserve(dynamic_paths_ptrs.size());
+    for (const auto & [path, _] : dynamic_paths_ptrs)
+        sorted_dynamic_paths.emplace_back(path);
+    std::sort(sorted_dynamic_paths.begin(), sorted_dynamic_paths.end());
+
+    const size_t end_row = limit == 0 ? column_object.size() : std::min(offset + limit, column_object.size());
+
+    for (size_t row = offset; row < end_row; ++row)
+    {
+        size_t dynamic_idx = 0;
+        size_t shared_idx = src_shared_offsets[static_cast<ssize_t>(row) - 1];
+        const size_t shared_end = src_shared_offsets[row];
+
+        /// Merge sorted dynamic paths with the row's existing shared-data entries.
+        while (dynamic_idx < sorted_dynamic_paths.size() && shared_idx < shared_end)
+        {
+            const auto dyn_path = sorted_dynamic_paths[dynamic_idx];
+            const auto src_path = src_shared_paths->getDataAt(shared_idx);
+            if (dyn_path < src_path)
+            {
+                const auto & dyn_column = *dynamic_paths_ptrs.find(dyn_path)->second;
+                ColumnObject::serializePathAndValueIntoSharedData(folded_paths, folded_values, dyn_path, dyn_column, row);
+                ++dynamic_idx;
+            }
+            else
+            {
+                folded_paths->insertFrom(*src_shared_paths, shared_idx);
+                folded_values->insertFrom(*src_shared_values, shared_idx);
+                ++shared_idx;
+            }
+        }
+        for (; dynamic_idx < sorted_dynamic_paths.size(); ++dynamic_idx)
+        {
+            const auto dyn_path = sorted_dynamic_paths[dynamic_idx];
+            const auto & dyn_column = *dynamic_paths_ptrs.find(dyn_path)->second;
+            ColumnObject::serializePathAndValueIntoSharedData(folded_paths, folded_values, dyn_path, dyn_column, row);
+        }
+        for (; shared_idx < shared_end; ++shared_idx)
+        {
+            folded_paths->insertFrom(*src_shared_paths, shared_idx);
+            folded_values->insertFrom(*src_shared_values, shared_idx);
+        }
+
+        folded_offsets->push_back(folded_paths->size());
+    }
+
+    return folded_column;
+}
+}
+
 void SerializationObject::serializeBinaryBulkWithMultipleStreams(
     const IColumn & column,
     size_t offset,
@@ -807,7 +944,11 @@ void SerializationObject::serializeBinaryBulkWithMultipleStreams(
     const auto & dynamic_paths = column_object.getDynamicPaths();
     const auto & shared_data = column_object.getSharedDataPtr();
 
-    if (column_object.getDynamicPaths().size() != object_state->sorted_dynamic_paths.size())
+    /// When folding is active, `sorted_dynamic_paths` was forced to empty by the
+    /// prefix; the in-memory column still has its `dynamic_paths` populated. The
+    /// regular mismatch check would fire incorrectly, so it is gated.
+    if (!object_state->fold_dynamic_paths_into_shared_data
+        && column_object.getDynamicPaths().size() != object_state->sorted_dynamic_paths.size())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Mismatch of number of dynamic paths in Object. Expected: {}, Got: {}", object_state->sorted_dynamic_paths.size(), column_object.getDynamicPaths().size());
 
     settings.path.push_back(Substream::ObjectData);
@@ -842,21 +983,50 @@ void SerializationObject::serializeBinaryBulkWithMultipleStreams(
     }
 
     settings.path.push_back(Substream::ObjectSharedData);
-    object_state->shared_data_serialization->serializeBinaryBulkWithMultipleStreams(*shared_data, offset, limit, settings, object_state->shared_data_state);
-    if (object_state->recalculate_statistics)
+    if (object_state->fold_dynamic_paths_into_shared_data && !dynamic_paths.empty())
     {
-        /// Calculate statistics for paths in shared data.
-        const auto [shared_data_paths, _] = column_object.getSharedDataPathsAndValues();
-        const auto & shared_data_offsets = column_object.getSharedDataOffsets();
-        size_t start = shared_data_offsets[offset - 1];
-        size_t end = limit == 0 || offset + limit > shared_data_offsets.size() ? shared_data_paths->size() : shared_data_offsets[offset + limit - 1];
-        for (size_t i = start; i != end; ++i)
+        /// All dynamic paths must be folded into shared data so the writer
+        /// produces a single substream regardless of how many paths the
+        /// in-memory column happens to have promoted.
+        ColumnPtr folded_shared_data = foldDynamicPathsIntoSharedData(column_object, offset, limit);
+        object_state->shared_data_serialization->serializeBinaryBulkWithMultipleStreams(*folded_shared_data, /*offset=*/ 0, /*limit=*/ 0, settings, object_state->shared_data_state);
+
+        if (object_state->recalculate_statistics)
         {
-            auto path = shared_data_paths->getDataAt(i);
-            if (auto it = object_state->statistics.shared_data_paths_statistics.find(path); it != object_state->statistics.shared_data_paths_statistics.end())
-                ++it->second;
-            else if (object_state->statistics.shared_data_paths_statistics.size() < ColumnObject::Statistics::MAX_SHARED_DATA_STATISTICS_SIZE)
-                object_state->statistics.shared_data_paths_statistics.emplace(path, 1);
+            /// Recompute statistics over the folded column. Each dynamic path
+            /// folded in counts towards `shared_data_paths_statistics`; nothing
+            /// is added to `dynamic_paths_statistics` because no dynamic path
+            /// is actually serialized to its own substream.
+            const auto [folded_paths, _, folded_offsets_ptr] = ColumnObject::getSharedDataPathsValuesAndOffsets(*folded_shared_data);
+            const size_t end_idx = folded_paths->size();
+            for (size_t i = 0; i < end_idx; ++i)
+            {
+                auto path = folded_paths->getDataAt(i);
+                if (auto it = object_state->statistics.shared_data_paths_statistics.find(path); it != object_state->statistics.shared_data_paths_statistics.end())
+                    ++it->second;
+                else if (object_state->statistics.shared_data_paths_statistics.size() < ColumnObject::Statistics::MAX_SHARED_DATA_STATISTICS_SIZE)
+                    object_state->statistics.shared_data_paths_statistics.emplace(path, 1);
+            }
+        }
+    }
+    else
+    {
+        object_state->shared_data_serialization->serializeBinaryBulkWithMultipleStreams(*shared_data, offset, limit, settings, object_state->shared_data_state);
+        if (object_state->recalculate_statistics)
+        {
+            /// Calculate statistics for paths in shared data.
+            const auto [shared_data_paths, _] = column_object.getSharedDataPathsAndValues();
+            const auto & shared_data_offsets = column_object.getSharedDataOffsets();
+            size_t start = shared_data_offsets[offset - 1];
+            size_t end = limit == 0 || offset + limit > shared_data_offsets.size() ? shared_data_paths->size() : shared_data_offsets[offset + limit - 1];
+            for (size_t i = start; i != end; ++i)
+            {
+                auto path = shared_data_paths->getDataAt(i);
+                if (auto it = object_state->statistics.shared_data_paths_statistics.find(path); it != object_state->statistics.shared_data_paths_statistics.end())
+                    ++it->second;
+                else if (object_state->statistics.shared_data_paths_statistics.size() < ColumnObject::Statistics::MAX_SHARED_DATA_STATISTICS_SIZE)
+                    object_state->statistics.shared_data_paths_statistics.emplace(path, 1);
+            }
         }
     }
     settings.path.pop_back();

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -921,7 +921,8 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
         /*reset_columns=*/true,
         ctx->blocks_are_granules_size,
         global_ctx->context->getWriteSettings(),
-        &global_ctx->written_offset_substreams);
+        &global_ctx->written_offset_substreams,
+        ctx->sum_uncompressed_bytes_upper_bound);
 
     global_ctx->rows_written = 0;
     ctx->initial_reservation = global_ctx->space_reservation ? global_ctx->space_reservation->getSize() : 0;

--- a/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
+++ b/src/Storages/MergeTree/MergeTreeDataPartWriterWide.cpp
@@ -132,6 +132,7 @@ ISerialization::EnumerateStreamsSettings MergeTreeDataPartWriterWide::getEnumera
     enumerate_settings.map_buckets_coefficient = settings_.map_buckets_coefficient;
     enumerate_settings.map_buckets_min_avg_size = settings_.map_buckets_min_avg_size;
     enumerate_settings.data_part_type = MergeTreeDataPartType::Wide;
+    enumerate_settings.force_object_shared_data_only = settings_.force_object_shared_data_only;
     return enumerate_settings;
 }
 
@@ -521,6 +522,7 @@ ISerialization::SerializeBinaryBulkSettings MergeTreeDataPartWriterWide::getSeri
     serialize_settings.low_cardinality_max_dictionary_size = settings.low_cardinality_max_dictionary_size;
     serialize_settings.low_cardinality_use_single_dictionary_for_part = settings.low_cardinality_use_single_dictionary_for_part;
     serialize_settings.write_statistics = ISerialization::SerializeBinaryBulkSettings::StatisticsMode::SUFFIX;
+    serialize_settings.force_object_shared_data_only = settings.force_object_shared_data_only;
     return serialize_settings;
 }
 

--- a/src/Storages/MergeTree/MergeTreeIOSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.cpp
@@ -53,6 +53,7 @@ namespace MergeTreeSetting
     extern const MergeTreeSettingsMergeTreeObjectSharedDataSerializationVersion object_shared_data_serialization_version_for_zero_level_parts;
     extern const MergeTreeSettingsNonZeroUInt64 object_shared_data_buckets_for_compact_part;
     extern const MergeTreeSettingsNonZeroUInt64 object_shared_data_buckets_for_wide_part;
+    extern const MergeTreeSettingsUInt64 object_shared_data_min_bytes_for_advanced_serialization;
     extern const MergeTreeSettingsMergeTreeDynamicSerializationVersion dynamic_serialization_version;
     extern const MergeTreeSettingsNonZeroUInt64 max_buckets_in_map;
     extern const MergeTreeSettingsMergeTreeMapBucketsStrategy map_buckets_strategy;
@@ -70,7 +71,8 @@ MergeTreeWriterSettings::MergeTreeWriterSettings(
     bool rewrite_primary_key_,
     bool save_marks_in_cache_,
     bool save_primary_index_in_memory_,
-    bool blocks_are_granules_size_)
+    bool blocks_are_granules_size_,
+    size_t part_uncompressed_bytes_estimate_)
     : min_compress_block_size((*storage_settings)[MergeTreeSetting::min_compress_block_size] ? (*storage_settings)[MergeTreeSetting::min_compress_block_size] : global_settings[Setting::min_compress_block_size])
     , max_compress_block_size((*storage_settings)[MergeTreeSetting::max_compress_block_size] ? (*storage_settings)[MergeTreeSetting::max_compress_block_size] : global_settings[Setting::max_compress_block_size])
     , marks_compression_codec((*storage_settings)[MergeTreeSetting::marks_compression_codec])
@@ -99,7 +101,19 @@ MergeTreeWriterSettings::MergeTreeWriterSettings(
     , min_columns_to_activate_adaptive_write_buffer((*storage_settings)[MergeTreeSetting::min_columns_to_activate_adaptive_write_buffer])
     , adaptive_write_buffer_initial_size((*storage_settings)[MergeTreeSetting::adaptive_write_buffer_initial_size])
     , compress_per_column_in_compact_parts((*storage_settings)[MergeTreeSetting::compress_per_column_in_compact_parts])
+    , part_uncompressed_bytes_estimate(part_uncompressed_bytes_estimate_)
 {
+    /// Force JSON / Object / Dynamic columns to keep all dynamic paths inside
+    /// the shared-data substream when the part being written is below the
+    /// configured threshold. Without this gate, a default `JSON` column with
+    /// `max_dynamic_paths = 1024` produces 10000+ substream files per Wide
+    /// part — and on object storage that is one `PUT` per file. We require
+    /// a known size estimate (estimate > 0) so that tests / code paths that
+    /// don't supply one continue to behave as before.
+    const auto threshold = (*storage_settings)[MergeTreeSetting::object_shared_data_min_bytes_for_advanced_serialization];
+    force_object_shared_data_only = threshold > 0
+        && part_uncompressed_bytes_estimate > 0
+        && part_uncompressed_bytes_estimate < threshold;
 }
 
 MergeTreeReaderSettings MergeTreeReaderSettings::createFromContext(const ContextPtr & context)

--- a/src/Storages/MergeTree/MergeTreeIOSettings.h
+++ b/src/Storages/MergeTree/MergeTreeIOSettings.h
@@ -97,7 +97,8 @@ struct MergeTreeWriterSettings
         bool rewrite_primary_key_,
         bool save_marks_in_cache_,
         bool save_primary_index_in_memory_,
-        bool blocks_are_granules_size_);
+        bool blocks_are_granules_size_,
+        size_t part_uncompressed_bytes_estimate_ = 0);
 
     size_t min_compress_block_size;
     size_t max_compress_block_size;
@@ -131,6 +132,17 @@ struct MergeTreeWriterSettings
     size_t min_columns_to_activate_adaptive_write_buffer;
     size_t adaptive_write_buffer_initial_size;
     bool compress_per_column_in_compact_parts;
+
+    /// Estimated uncompressed size of the part being written, used by per-column
+    /// serializations to choose between layouts that scale differently with size
+    /// (e.g. forcing JSON shared-data only for small parts to avoid file fan-out).
+    /// 0 means "unknown" — code that consults this field must treat 0 as "do not
+    /// override the default layout".
+    size_t part_uncompressed_bytes_estimate = 0;
+    /// Derived from the above and from `object_shared_data_min_bytes_for_advanced_serialization`.
+    /// When true, `SerializationObject` keeps every dynamic path inside the single
+    /// `ObjectSharedData` substream instead of materializing one substream per path.
+    bool force_object_shared_data_only = false;
 };
 
 }

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -349,6 +349,24 @@ namespace ErrorCodes
     The number of buckets for JSON shared data serialization in Wide parts. Works with `map_with_buckets` and `advanced` shared data serializations.
     The maximum allowed value is 256.
     )", 0) \
+    DECLARE(UInt64, object_shared_data_min_bytes_for_advanced_serialization, 0, R"(
+    Minimum estimated uncompressed part size (in bytes) at which `JSON` /
+    `Object('json')` / `Dynamic` columns are allowed to materialize each
+    dynamic path as its own `.bin` substream in `Wide` parts. When the part
+    is smaller than this threshold, every dynamic path is folded into the
+    shared-data substream of the column, and the shared-data layout falls
+    back from `advanced` to `map_with_buckets` for that part — collapsing
+    a default 1024-dynamic-path column from 1024+ files down to one bucket
+    set. This avoids the per-file `PUT` amplification on object storage
+    that an under-filled `Wide` part otherwise causes. When set to `0`
+    (the default) the behavior is unchanged: dynamic paths are materialized
+    as individual substreams as soon as the column has them. The threshold
+    only affects `Wide` parts (Compact already packs every column into a
+    single `.bin`) and only the `JSON` / `Object` / `Dynamic` columns of
+    the part — non-dynamic columns keep their `Wide`-style layout.
+    See `https://github.com/ClickHouse/ClickHouse/issues/100960` and
+    `https://github.com/ClickHouse/ClickHouse/issues/102052`.
+    )", 0) \
     DECLARE(MergeTreeDynamicSerializationVersion, dynamic_serialization_version, "v3", R"(
     Serialization version for Dynamic data type. Required for compatibility.
 

--- a/src/Storages/MergeTree/MergedBlockOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.cpp
@@ -36,7 +36,8 @@ MergedBlockOutputStream::MergedBlockOutputStream(
     bool reset_columns_,
     bool blocks_are_granules_size,
     const WriteSettings & write_settings_,
-    WrittenOffsetSubstreams * written_offset_substreams)
+    WrittenOffsetSubstreams * written_offset_substreams,
+    size_t part_uncompressed_bytes_estimate_for_writer)
     : IMergedBlockOutputStream(
           std::move(data_settings), data_part->getDataPartStoragePtr(), metadata_snapshot_, columns_list_, reset_columns_)
     , columns_list(columns_list_)
@@ -48,6 +49,14 @@ MergedBlockOutputStream::MergedBlockOutputStream(
     /// Save primary index in memory if cache is disabled or is enabled with prewarm to avoid re-reading primary index file.
     bool save_primary_index_in_memory = !data_part->storage.getPrimaryIndexCache() || prewarm_caches.primary_index_cache;
 
+    /// Per-column serializations may want to pick a different layout based on
+    /// the estimated part size (e.g. JSON shared-data-only for small parts).
+    /// Fall back to the prewarm hint when the caller did not supply a separate
+    /// estimate — for the insert path the two values are the same.
+    const size_t writer_estimate = part_uncompressed_bytes_estimate_for_writer != 0
+        ? part_uncompressed_bytes_estimate_for_writer
+        : part_uncompressed_bytes;
+
     writer_settings = MergeTreeWriterSettings(
         data_part->storage.getContext()->getSettingsRef(),
         write_settings_,
@@ -57,7 +66,8 @@ MergedBlockOutputStream::MergedBlockOutputStream(
         /* rewrite_primary_key = */ true,
         save_marks_in_cache,
         save_primary_index_in_memory,
-        blocks_are_granules_size);
+        blocks_are_granules_size,
+        writer_estimate);
 
     data_part_storage->createDirectories();
 

--- a/src/Storages/MergeTree/MergedBlockOutputStream.h
+++ b/src/Storages/MergeTree/MergedBlockOutputStream.h
@@ -27,7 +27,8 @@ public:
         bool reset_columns_,
         bool blocks_are_granules_size,
         const WriteSettings & write_settings,
-        WrittenOffsetSubstreams * written_offset_substreams);
+        WrittenOffsetSubstreams * written_offset_substreams,
+        size_t part_uncompressed_bytes_estimate_for_writer = 0);
 
     Block getHeader() const { return metadata_snapshot->getSampleBlock(); }
 

--- a/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
+++ b/src/Storages/MergeTree/MergedColumnOnlyOutputStream.cpp
@@ -41,7 +41,8 @@ MergedColumnOnlyOutputStream::MergedColumnOnlyOutputStream(
         /*rewrite_primary_key=*/ false,
         save_marks_in_cache,
         save_primary_index_in_memory,
-        /*blocks_are_granules_size=*/ false);
+        /*blocks_are_granules_size=*/ false,
+        part_uncompressed_bytes);
 
     writer = createMergeTreeDataPartWriter(
         data_part->getType(),

--- a/tests/queries/0_stateless/04117_json_shared_data_threshold.reference
+++ b/tests/queries/0_stateless/04117_json_shared_data_threshold.reference
@@ -1,0 +1,15 @@
+-- Below threshold: part stays Wide
+Wide
+-- Below threshold: zero per-dynamic-path substreams
+0
+-- Below threshold: data is readable
+200	4
+-- Threshold disabled: per-dynamic-path substreams ARE present
+1
+-- Setting has no effect on tables without dynamic-subcolumn columns
+Wide
+200
+-- Setting does not change Compact part type
+Compact
+-- Compact part data is readable
+200	4

--- a/tests/queries/0_stateless/04117_json_shared_data_threshold.sql
+++ b/tests/queries/0_stateless/04117_json_shared_data_threshold.sql
@@ -1,0 +1,148 @@
+-- Test: `object_shared_data_min_bytes_for_advanced_serialization` keeps every
+-- dynamic path of a JSON column inside the single shared-data substream while
+-- the part stays in `Wide` format. This avoids the per-dynamic-path file
+-- fan-out that otherwise turns into one S3 `PUT` per file on small parts
+-- (https://github.com/ClickHouse/ClickHouse/issues/100960,
+--  https://github.com/ClickHouse/ClickHouse/issues/102052).
+
+SET allow_experimental_json_type = 1;
+
+DROP TABLE IF EXISTS t_json_shared_threshold;
+
+-- Threshold of 1 GiB — far above the test part size, so the gate is active.
+CREATE TABLE t_json_shared_threshold
+(
+    id UInt64,
+    s  String,
+    j  JSON(max_dynamic_paths = 100)
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS
+    min_bytes_for_wide_part = 1,
+    min_rows_for_wide_part = 1,
+    object_serialization_version = 'v3',
+    object_shared_data_serialization_version = 'advanced',
+    object_shared_data_serialization_version_for_zero_level_parts = 'advanced',
+    object_shared_data_buckets_for_wide_part = 4,
+    object_shared_data_min_bytes_for_advanced_serialization = 1073741824;
+
+-- 50 distinct paths — without the gate, each promoted dynamic path would get
+-- its own `.bin` substream, but the threshold is set so high that we expect
+-- all of them to live inside the shared-data substream instead.
+INSERT INTO t_json_shared_threshold
+SELECT
+    number,
+    'row_' || toString(number),
+    '{"path_' || toString(number % 50) || '": ' || toString(number) || '}'
+FROM numbers(200);
+
+SELECT '-- Below threshold: part stays Wide';
+SELECT part_type
+FROM system.parts
+WHERE database = currentDatabase() AND table = 't_json_shared_threshold' AND active = 1
+LIMIT 1;
+
+-- A per-dynamic-path substream is named `j.<path>.dynamic_data` (the leaf of
+-- `SerializationDynamic` under each `Substream::ObjectDynamicPath`). With the
+-- gate active, none of these substreams should exist for the JSON column.
+SELECT '-- Below threshold: zero per-dynamic-path substreams';
+SELECT length(arrayFilter(x -> x LIKE 'j.path\_%' AND position(x, 'object_shared_data') = 0, substreams))
+FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_json_shared_threshold' AND column = 'j' AND active = 1
+LIMIT 1;
+
+SELECT '-- Below threshold: data is readable';
+SELECT count(), countIf(j.path_0 IS NOT NULL) FROM t_json_shared_threshold;
+
+DROP TABLE t_json_shared_threshold;
+
+-- Same data, threshold disabled: the per-dynamic-path substreams DO appear.
+DROP TABLE IF EXISTS t_json_no_threshold;
+
+CREATE TABLE t_json_no_threshold
+(
+    id UInt64,
+    s  String,
+    j  JSON(max_dynamic_paths = 100)
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS
+    min_bytes_for_wide_part = 1,
+    min_rows_for_wide_part = 1,
+    object_serialization_version = 'v3',
+    object_shared_data_serialization_version = 'advanced',
+    object_shared_data_serialization_version_for_zero_level_parts = 'advanced',
+    object_shared_data_buckets_for_wide_part = 4,
+    object_shared_data_min_bytes_for_advanced_serialization = 0;
+
+INSERT INTO t_json_no_threshold
+SELECT
+    number,
+    'row_' || toString(number),
+    '{"path_' || toString(number % 50) || '": ' || toString(number) || '}'
+FROM numbers(200);
+
+SELECT '-- Threshold disabled: per-dynamic-path substreams ARE present';
+SELECT length(arrayFilter(x -> x LIKE 'j.path\_%' AND position(x, 'object_shared_data') = 0, substreams)) > 0
+FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 't_json_no_threshold' AND column = 'j' AND active = 1
+LIMIT 1;
+
+DROP TABLE t_json_no_threshold;
+
+-- A table without any JSON / Object / Dynamic column is unaffected by the
+-- new setting — the part stays Wide and we don't go through the JSON write
+-- path at all.
+DROP TABLE IF EXISTS t_no_json;
+
+CREATE TABLE t_no_json (id UInt64, s String)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS
+    min_bytes_for_wide_part = 1,
+    min_rows_for_wide_part = 1,
+    object_shared_data_min_bytes_for_advanced_serialization = 1073741824;
+
+INSERT INTO t_no_json SELECT number, 'val_' || toString(number) FROM numbers(200);
+
+SELECT '-- Setting has no effect on tables without dynamic-subcolumn columns';
+SELECT part_type FROM system.parts WHERE database = currentDatabase() AND table = 't_no_json' AND active = 1 LIMIT 1;
+SELECT count() FROM t_no_json;
+
+DROP TABLE t_no_json;
+
+-- The gate is intentionally Wide-only: in Compact parts every column is packed
+-- into a single `.bin` file so the per-dynamic-path file fan-out problem does
+-- not exist there, and Compact uses `StatisticsMode::PREFIX` which would
+-- record stale path statistics if folding ran. Verify the data is readable
+-- and unaffected by the setting.
+DROP TABLE IF EXISTS t_json_compact_threshold;
+
+CREATE TABLE t_json_compact_threshold
+(
+    id UInt64,
+    j  JSON(max_dynamic_paths = 100)
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS
+    min_bytes_for_wide_part = '200G',
+    min_rows_for_wide_part = 1000000,
+    object_serialization_version = 'v3',
+    object_shared_data_serialization_version = 'advanced',
+    object_shared_data_serialization_version_for_zero_level_parts = 'advanced',
+    object_shared_data_min_bytes_for_advanced_serialization = 1073741824;
+
+INSERT INTO t_json_compact_threshold
+SELECT number, '{"path_' || toString(number % 50) || '": ' || toString(number) || '}'
+FROM numbers(200);
+
+SELECT '-- Setting does not change Compact part type';
+SELECT part_type FROM system.parts WHERE database = currentDatabase() AND table = 't_json_compact_threshold' AND active = 1 LIMIT 1;
+
+SELECT '-- Compact part data is readable';
+SELECT count(), countIf(j.path_0 IS NOT NULL) FROM t_json_compact_threshold;
+
+DROP TABLE t_json_compact_threshold;


### PR DESCRIPTION
## Linked issues

Fixes #100960

## Motivation

When a `Wide` `MergeTree` part contains a `JSON` (or `Object` / `Dynamic`) column with the default `max_dynamic_paths = 1024`, every dynamic path materializes its own `.bin` / `.cmrk2` substreams, so a single JSON column produces 10 000+ files per part. On S3-backed disks this is one `PUT` per file and dramatic write amplification on small parts — the reporter on #100960 observed ~25 K `PUT` requests for 2 GB of data, with 30 K+ uploads under 1 MiB each.

Existing knobs do not address this cleanly:

- `min_bytes_for_wide_part` flips the *whole* part to `Compact`. For tables that mix a log-style schema (10–20 fixed columns) with one JSON column, that costs every fixed column its per-column read locality just to suppress the JSON column's path fan-out.
- Lowering `max_dynamic_paths` is a schema change with read-path implications and affects every part — past and future — for every workload on that table.

What the file-count problem actually wants is a per-column, write-time decision: keep the part `Wide`, keep the fixed columns per-column, but stop materializing one substream per dynamic JSON path on small parts.

## Approach

Add a new MergeTree setting `object_shared_data_min_bytes_for_advanced_serialization` (default `0` = disabled, recommended `1073741824` = 1 GiB for S3-tiered deployments). When the part's estimated uncompressed size falls below the threshold, `SerializationObject` keeps every dynamic path of `JSON` / `Object` / `Dynamic` columns inside the shared-data substream instead of materializing one substream per path. Only the dynamic-subcolumn column's serialization changes — every non-JSON column of the same part retains its `Wide`-style per-column files.

### Plumbing

`MergedBlockOutputStream` and `MergedColumnOnlyOutputStream` carry an estimated uncompressed-bytes signal into `MergeTreeWriterSettings`. Insert paths reuse `block.bytes()`; the merge path forwards `MergeTask::ctx->sum_uncompressed_bytes_upper_bound`; mutations fall back to the source part's `getBytesUncompressedOnDisk()`. `MergeTreeWriterSettings` derives `force_object_shared_data_only` from the threshold and the estimate. The flag travels through `EnumerateStreamsSettings` and `SerializeBinaryBulkSettings` to `SerializationObject`.

### Wide-only gate

The fold is restricted to `Wide` parts at every decision site (`enumerateStreams`, `serializeBinaryBulkStatePrefix`, `serializeBinaryBulkWithMultipleStreams`). `Compact` parts pack every column into one `.bin`, so the per-column file fan-out problem does not exist there, and `Compact` uses `StatisticsMode::PREFIX` which would commit stale path statistics if folding ran.

### State capture

The fold decision is captured in `SerializeBinaryBulkStateObject::fold_dynamic_paths_into_shared_data` at prefix time, so the data write does not re-read the settings field — defense in depth against settings drift across passes.

### Serialization layout when gated

- `serializeBinaryBulkStatePrefix` records an empty `sorted_dynamic_paths` list and falls back from `advanced` to `map_with_buckets` shared-data serialization (matches the zero-level-parts default).
- `serializeBinaryBulkWithMultipleStreams` folds every dynamic path into a synthesized shared-data column (sorted-merge with the column's existing shared-data entries; NULLs skipped per the existing `serializePathAndValueIntoSharedData` semantics) and writes that.
- The configured `object_shared_data_buckets_for_wide_part` is honored even when the column's shared data is empty, since the writer is about to fold paths into it.
- The reader is unchanged: `deserializeObjectStructureStatePrefix` reads `sorted_dynamic_paths` from disk, so an empty list means "no per-path substreams to enumerate" — the column reconstructs from shared data the same way it does for any path that overflowed `max_dynamic_paths`.

### Side effect

The merge path's `MergedBlockOutputStream` previously passed `total_size_bytes_compressed` into a parameter named `total_size_bytes_uncompressed_`. Routing the new estimate exposed and fixed that mismatch via a separate ctor parameter; existing prewarm-cache call sites are unchanged.

## Test

`04117_json_shared_data_threshold.sql` asserts:

- below the threshold the part stays `Wide` but `system.parts_columns` reports zero per-dynamic-path substreams for the JSON column;
- data is readable both directly after insert and after `OPTIMIZE FINAL`;
- with the threshold disabled (default `0`) the per-dynamic-path substreams reappear;
- tables without dynamic-subcolumn columns are unaffected;
- `Compact` parts are unaffected by the setting.

Verified against the existing `JSON` / `Object` / `Dynamic` test suite — no regressions in 21 related tests (`03553_*`, `03991_*`, `03928_*`, `03917_*`, `03159_*`, `03038_*`, `03762_*`, `04024_*`, etc.).

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added a new MergeTree setting `object_shared_data_min_bytes_for_advanced_serialization` (default `0`, disabled). When set to a positive value, `Wide` parts whose estimated uncompressed size falls below the threshold keep every dynamic path of `JSON` / `Object` / `Dynamic` columns inside the shared-data substream instead of materializing one substream per path. This dramatically reduces file count and S3 `PUT` amplification on small parts that mix log-style schemas with `JSON` columns on S3-backed storage, while preserving per-column read locality for non-JSON columns of the same part. Recommended value for S3-tiered deployments is `1073741824` (1 GiB). Closes #100960.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)