### PR TITLE
Fix backfill distroless workflow: use release-maker runner

### DIFF
--- a/.github/workflows/backfill_distroless.yml
+++ b/.github/workflows/backfill_distroless.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   BackfillDistroless:
-    runs-on: [self-hosted, style-checker-aarch64]
+    runs-on: [self-hosted, release-maker]
     steps:
       - name: Check out repository code
         uses: ClickHouse/checkout@v1
@@ -31,12 +31,6 @@ jobs:
         uses: ./.github/actions/debug
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to Docker Hub
-        if: ${{ inputs.dry-run != true }}
-        uses: docker/login-action@v3
-        with:
-          username: robotclickhouse
-          password: ${{ secrets.DOCKERHUB_ROBOT_PASSWORD }}
       - name: Build and push distroless images
         shell: bash
         env:


### PR DESCRIPTION
Switch `BackfillDistroless` workflow from `style-checker-aarch64` to `release-maker` runner. The style-checker runner does not have Docker Hub credentials, causing the workflow to fail with `Password required`. The `release-maker` runner has credentials pre-configured, matching how `create_release.yml` pushes Docker images.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.114`
<!-- ch-version-info:end -->