### PR TITLE
Backport distroless CI integration to 26.3

### DIFF
--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -101,7 +101,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--reports", default=True, help=argparse.SUPPRESS)
     parser.add_argument("--push", action="store_true", help=argparse.SUPPRESS)
-    parser.add_argument("--os", default=["ubuntu", "alpine"], help=argparse.SUPPRESS)
+    parser.add_argument("--os", default=["ubuntu", "alpine", "distroless"], help=argparse.SUPPRESS)
     parser.add_argument(
         "--no-ubuntu",
         action=DelOS,
@@ -115,6 +115,13 @@ def parse_args() -> argparse.Namespace:
         nargs=0,
         default=argparse.SUPPRESS,
         help="don't build alpine image",
+    )
+    parser.add_argument(
+        "--no-distroless",
+        action=DelOS,
+        nargs=0,
+        default=argparse.SUPPRESS,
+        help="don't build distroless image",
     )
     parser.add_argument(
         "--allow-build-reuse",
@@ -215,10 +222,25 @@ def build_and_push_image(
         cmd_args = list(init_args)
         urls = []
         if direct_urls:
-            if os == "ubuntu" and "clickhouse-server" in image.name:
-                urls = [url for url in direct_urls[arch] if ".deb" in url]
+            # distroless and ubuntu-server use an Ubuntu builder with dpkg, so they
+            # need .deb packages. alpine and ubuntu-keeper use .tgz packages.
+            uses_deb = os == "distroless" or (
+                os == "ubuntu" and "clickhouse-server" in image.name
+            )
+            if uses_deb:
+                urls = [
+                    url
+                    for url in direct_urls[arch]
+                    if ".deb" in url and "-dbg" not in url
+                ]
             else:
-                urls = [url for url in direct_urls[arch] if ".tgz" in url]
+                # For keeper/alpine tgz builds, only pass the keeper tgz.
+                # Excluding clickhouse-common-static.tgz avoids a large unnecessary download.
+                tgz_urls = [url for url in direct_urls[arch] if ".tgz" in url]
+                if "keeper" in image.name:
+                    urls = [url for url in tgz_urls if "clickhouse-keeper" in url]
+                else:
+                    urls = tgz_urls
         cmd_args.extend(
             buildx_args(
                 repo_urls,
@@ -384,7 +406,16 @@ def main():
                     "clickhouse-common-static",
                 ]
             elif "clickhouse-keeper" in image_repo:
-                PACKAGES = ["clickhouse-keeper"]
+                # Both packages are needed to cover all three keeper image variants:
+                #   distroless: installs from .deb via dpkg; clickhouse-common-static
+                #               provides the clickhouse multi-tool binary (clickhouse-keeper
+                #               is a symlink to it). clickhouse-keeper .deb is not published
+                #               separately, so the common-static .deb is the only source.
+                #   alpine/ubuntu: installs from .tgz; clickhouse-keeper provides the
+                #               standalone keeper binary and its symlinks. The common-static
+                #               .tgz is implicitly excluded because the url filter below
+                #               keeps only urls containing "clickhouse-keeper" in the name.
+                PACKAGES = ["clickhouse-common-static", "clickhouse-keeper"]
             else:
                 assert False, "BUG"
             urls = read_build_urls(build_name)

--- a/ci/jobs/scripts/docker_server/config.sh
+++ b/ci/jobs/scripts/docker_server/config.sh
@@ -3,11 +3,14 @@
 # Get current file directory
 currentDir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
-# interate over all directories in current path
-clickhouseTests=$( find "$currentDir"/tests/ -maxdepth 1 -name 'clickhouse-*' -type d -exec basename {} \; )
+# iterate over all directories in current path
+clickhouseTests=$( find "$currentDir"/tests/ -maxdepth 1 -name 'clickhouse-*' -not -name 'clickhouse-distroless-*' -type d -exec basename {} \; )
+clickhouseDistrolessTests=$( find "$currentDir"/tests/ -maxdepth 1 -name 'clickhouse-distroless-*' -type d -exec basename {} \; )
 keeperTests=$( find "$currentDir"/tests/ -maxdepth 1 -name 'keeper-*' -type d -exec basename {} \; )
 
 imageTests+=(
 	['clickhouse/clickhouse-server']="${clickhouseTests}"
+	['clickhouse/clickhouse-server:distroless']="${clickhouseTests} ${clickhouseDistrolessTests}"
 	['clickhouse/clickhouse-keeper']="${keeperTests}"
+	['clickhouse/clickhouse-keeper:distroless']="${keeperTests}"
 )

--- a/ci/jobs/scripts/docker_server/tests/clickhouse-distroless-initdb/initdb.sql
+++ b/ci/jobs/scripts/docker_server/tests/clickhouse-distroless-initdb/initdb.sql
@@ -1,0 +1,3 @@
+CREATE DATABASE IF NOT EXISTS test_db;
+CREATE TABLE IF NOT EXISTS test_db.test_table (id UInt32, value UInt32) ENGINE = MergeTree ORDER BY id;
+INSERT INTO test_db.test_table VALUES (1, 100), (2, 200);

--- a/ci/jobs/scripts/docker_server/tests/clickhouse-distroless-initdb/run.sh
+++ b/ci/jobs/scripts/docker_server/tests/clickhouse-distroless-initdb/run.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Verify that clickhouse docker-init executes SQL initdb scripts correctly.
+# The distroless image has no shell so initdb scripts must be handled
+# by the compiled docker-init entrypoint, not by entrypoint.sh.
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+source "$dir/../lib.sh"
+
+image="$1"
+
+export CLICKHOUSE_USER='init_test_user'
+export CLICKHOUSE_PASSWORD='init_test_password'
+
+cid="$(
+  docker run -d \
+    -e CLICKHOUSE_USER \
+    -e CLICKHOUSE_PASSWORD \
+    -v "$dir/initdb.sql":/docker-entrypoint-initdb.d/initdb.sql:ro \
+    --name "$(cname)" \
+    "$image"
+)"
+trap 'docker rm -vf $cid > /dev/null' EXIT
+
+chCli() {
+  docker run --rm -i \
+    --link "$cid":clickhouse \
+    -e CLICKHOUSE_USER \
+    -e CLICKHOUSE_PASSWORD \
+    "$image" \
+    clickhouse-client \
+    --host clickhouse \
+    --user "$CLICKHOUSE_USER" \
+    --password "$CLICKHOUSE_PASSWORD" \
+    --query "$*"
+}
+
+# shellcheck source=../../../../../tmp/docker-library/official-images/test/retry.sh
+. "$TESTS_LIB_DIR/retry.sh" \
+  --tries "$CLICKHOUSE_TEST_TRIES" \
+  --sleep "$CLICKHOUSE_TEST_SLEEP" \
+  chCli SELECT 1
+
+# Verify the initdb script ran and created the table with the expected data
+chCli SHOW TABLES IN test_db | grep '^test_table$' >/dev/null
+[ "$(chCli 'SELECT SUM(value) FROM test_db.test_table')" = 300 ]

--- a/ci/jobs/scripts/docker_server/tests/clickhouse-distroless-no-shell/run.sh
+++ b/ci/jobs/scripts/docker_server/tests/clickhouse-distroless-no-shell/run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Verify the distroless production image contains no shell.
+# This is the key property of a distroless image: /bin/sh, /bin/bash,
+# and other shells must be absent to reduce the attack surface.
+set -eo pipefail
+
+image="$1"
+
+if docker run --rm --entrypoint /bin/sh "$image" -c "echo bad" 2>/dev/null; then
+    echo "FAIL: /bin/sh should not exist in the distroless image" >&2
+    exit 1
+fi
+
+if docker run --rm --entrypoint /bin/bash "$image" -c "echo bad" 2>/dev/null; then
+    echo "FAIL: /bin/bash should not exist in the distroless image" >&2
+    exit 1
+fi


### PR DESCRIPTION
Add distroless to the CI Docker build/test pipeline on 26.3:
- Add distroless to default OS list in `docker_server.py`
- Add `--no-distroless` flag
- Add distroless test cases (initdb, no-shell)
- Update test config dispatcher

Depends on #103577 (docker-init binary).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)