### PR TITLE
Fix flaky test 04103_user_network_bandwidth_throttler

### DIFF
--- a/tests/queries/0_stateless/04103_user_network_bandwidth_throttler.sh
+++ b/tests/queries/0_stateless/04103_user_network_bandwidth_throttler.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, long
+# Tags: no-fasttest, long, no-random-settings
 # no-fasttest: needs S3, and the test is slow (exercises throttling)
+# no-random-settings: S3 prefetch settings affect read throughput; disabling prefetch can make
+# natural read rate drop below the 1 MB/s throttle limit, causing the throttler to never sleep
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
Add `no-random-settings` tag to fix flaky test `04103_user_network_bandwidth_throttler`.

CI randomized settings can inject `remote_filesystem_read_prefetch=0` and `allow_prefetched_read_pool_for_remote_filesystem=0`, which disable S3 prefetch. On a heavily loaded TSAN machine running parallel tests, this can make the natural S3 read rate drop below the 1 MB/s throttle limit. When natural rate < throttle limit, the token bucket never goes negative and the throttler never sleeps — `UserThrottlerSleepMicroseconds` stays at 0 while `UserThrottlerBytes` is correctly counted, causing the third check to fail transiently.

The write side is unaffected because its data source (`numbers(1e6)`) is memory/CPU-bound and always exceeds 1 MB/s regardless of machine load.

Fixes #103422
Follow-up for: https://github.com/ClickHouse/ClickHouse/pull/103080
CI failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=102547&sha=83f565de244bc2f42b2f51098ea6bbef4bcf2c9d&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%202%2F2%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.401`
<!-- ch-version-info:end -->