### PR TITLE
Do not defer row policy after FINAL on blending MergeTree engines

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -2189,7 +2189,25 @@ void ReadFromMergeTree::deferFiltersAfterFinalIfNeeded()
         return;
 
     const auto & settings = context->getSettingsRef();
-    bool defer_row_policy = settings[Setting::apply_row_policy_after_final] && query_info.row_level_filter;
+
+    /// `apply_row_policy_after_final` was introduced for the soft-delete pattern in
+    /// `ReplacingMergeTree`, where the row policy must not filter out delete-marker
+    /// rows before they win deduplication. For engines whose `FINAL` blends column
+    /// values across multiple source rows (`Summing`, `Aggregating`, `Coalescing`,
+    /// `Graphite`), deferring the row policy is unsafe: the merged row can carry
+    /// data from rows the policy was meant to hide, leaking sensitive values.
+    /// Only the engines that pick a single source row per dedup group can safely
+    /// defer the row-level filter.
+    const auto merging_mode = data.merging_params.mode;
+    const bool engine_safe_to_defer_row_policy =
+           merging_mode == MergeTreeData::MergingParams::Replacing
+        || merging_mode == MergeTreeData::MergingParams::Collapsing
+        || merging_mode == MergeTreeData::MergingParams::VersionedCollapsing
+        || merging_mode == MergeTreeData::MergingParams::Ordinary;
+
+    bool defer_row_policy = settings[Setting::apply_row_policy_after_final]
+        && query_info.row_level_filter
+        && engine_safe_to_defer_row_policy;
     bool defer_prewhere = settings[Setting::apply_prewhere_after_final] && query_info.prewhere_info;
 
     /// If row policy touches non-sorting-key columns, prewhere must be deferred too

--- a/tests/queries/0_stateless/04142_row_policy_after_final_blending_engines.reference
+++ b/tests/queries/0_stateless/04142_row_policy_after_final_blending_engines.reference
@@ -1,0 +1,21 @@
+== CoalescingMergeTree ==
+-- apply_row_policy_after_final = 1 --
+key	not sensitive data	\N
+-- apply_row_policy_after_final = 0 --
+key	not sensitive data	\N
+== AggregatingMergeTree (anyLast) ==
+-- apply_row_policy_after_final = 1 --
+key	not sensitive data	\N
+-- apply_row_policy_after_final = 0 --
+key	not sensitive data	\N
+== SummingMergeTree ==
+-- apply_row_policy_after_final = 1 --
+k	public	5
+-- apply_row_policy_after_final = 0 --
+k	public	5
+== ReplacingMergeTree (deferral still works) ==
+-- apply_row_policy_after_final = 1 --
+2	2
+-- apply_row_policy_after_final = 0 --
+1	1
+2	2

--- a/tests/queries/0_stateless/04142_row_policy_after_final_blending_engines.reference
+++ b/tests/queries/0_stateless/04142_row_policy_after_final_blending_engines.reference
@@ -13,6 +13,11 @@ key	not sensitive data	\N
 k	public	5
 -- apply_row_policy_after_final = 0 --
 k	public	5
+== GraphiteMergeTree ==
+-- apply_row_policy_after_final = 1 --
+public	sum_test	5	2
+-- apply_row_policy_after_final = 0 --
+public	sum_test	5	2
 == ReplacingMergeTree (deferral still works) ==
 -- apply_row_policy_after_final = 1 --
 2	2

--- a/tests/queries/0_stateless/04142_row_policy_after_final_blending_engines.sql
+++ b/tests/queries/0_stateless/04142_row_policy_after_final_blending_engines.sql
@@ -89,6 +89,38 @@ DROP ROW POLICY p_sum ON t_sum;
 DROP TABLE t_sum;
 
 
+SELECT '== GraphiteMergeTree ==';
+DROP TABLE IF EXISTS t_graphite;
+DROP ROW POLICY IF EXISTS p_graphite ON t_graphite;
+
+-- Both rows share the same `(Path, Time)` rollup bucket; the `sum` pattern in
+-- the test config rolls `Value` up across all rows in the bucket. A policy on
+-- the non-aggregated `visibility` column would be evaluated against the merged
+-- row, whose `Value` would carry the contribution of the private row.
+CREATE TABLE t_graphite
+(
+    visibility String,
+    Path       String,
+    Time       DateTime('UTC'),
+    Value      Float64,
+    Version    UInt32
+) ENGINE = GraphiteMergeTree('graphite_rollup') ORDER BY (Path, Time);
+
+INSERT INTO t_graphite VALUES ('private', 'sum_test', toDateTime('2026-04-28 00:00:00', 'UTC'), 100.0, 1);
+INSERT INTO t_graphite VALUES ('public',  'sum_test', toDateTime('2026-04-28 00:00:00', 'UTC'),   5.0, 2);
+
+CREATE ROW POLICY p_graphite ON t_graphite USING visibility = 'public' TO ALL;
+
+-- The private row must not contribute to the visible `Value`.
+SELECT '-- apply_row_policy_after_final = 1 --';
+SELECT visibility, Path, Value, Version FROM t_graphite FINAL ORDER BY visibility SETTINGS apply_row_policy_after_final = 1;
+SELECT '-- apply_row_policy_after_final = 0 --';
+SELECT visibility, Path, Value, Version FROM t_graphite FINAL ORDER BY visibility SETTINGS apply_row_policy_after_final = 0;
+
+DROP ROW POLICY p_graphite ON t_graphite;
+DROP TABLE t_graphite;
+
+
 SELECT '== ReplacingMergeTree (deferral still works) ==';
 -- Sanity check: for engines where deferral is safe, the original
 -- soft-delete semantics introduced by `apply_row_policy_after_final` are kept.

--- a/tests/queries/0_stateless/04142_row_policy_after_final_blending_engines.sql
+++ b/tests/queries/0_stateless/04142_row_policy_after_final_blending_engines.sql
@@ -1,0 +1,120 @@
+-- Tags: no-parallel
+-- Verify that `apply_row_policy_after_final` is not applied for *MergeTree engines
+-- whose FINAL blends column values across multiple source rows. Deferring the row
+-- policy on such engines used to leak sensitive column values from rows the policy
+-- was supposed to hide (see "[Security] apply_row_policy_after_final=true leaks
+-- sensitive column values"). The expected behaviour is identical regardless of the
+-- `apply_row_policy_after_final` setting on these engines.
+
+SET apply_row_policy_after_final = 1;
+
+SELECT '== CoalescingMergeTree ==';
+DROP TABLE IF EXISTS t_coalescing;
+DROP ROW POLICY IF EXISTS p_coalescing ON t_coalescing;
+
+CREATE TABLE t_coalescing
+(
+    key   String,
+    data1 Nullable(String),
+    data2 Nullable(String)
+) ENGINE = CoalescingMergeTree ORDER BY key;
+
+INSERT INTO t_coalescing VALUES ('key', 'sensitive_data', 'top_secret');
+INSERT INTO t_coalescing VALUES ('key', 'not sensitive data', NULL);
+
+CREATE ROW POLICY p_coalescing ON t_coalescing USING NOT (data1 = 'sensitive_data') TO ALL;
+
+-- Must never expose 'top_secret' regardless of the setting.
+SELECT '-- apply_row_policy_after_final = 1 --';
+SELECT * FROM t_coalescing FINAL SETTINGS apply_row_policy_after_final = 1;
+SELECT '-- apply_row_policy_after_final = 0 --';
+SELECT * FROM t_coalescing FINAL SETTINGS apply_row_policy_after_final = 0;
+
+DROP ROW POLICY p_coalescing ON t_coalescing;
+DROP TABLE t_coalescing;
+
+
+SELECT '== AggregatingMergeTree (anyLast) ==';
+DROP TABLE IF EXISTS t_agg;
+DROP ROW POLICY IF EXISTS p_agg ON t_agg;
+
+CREATE TABLE t_agg
+(
+    key   String,
+    data1 SimpleAggregateFunction(anyLast, String),
+    data2 SimpleAggregateFunction(anyLast, Nullable(String))
+) ENGINE = AggregatingMergeTree ORDER BY key;
+
+INSERT INTO t_agg VALUES ('key', 'sensitive_data',     'top_secret');
+INSERT INTO t_agg VALUES ('key', 'not sensitive data', NULL);
+
+CREATE ROW POLICY p_agg ON t_agg USING NOT (data1 = 'sensitive_data') TO ALL;
+
+SELECT '-- apply_row_policy_after_final = 1 --';
+SELECT * FROM t_agg FINAL SETTINGS apply_row_policy_after_final = 1;
+SELECT '-- apply_row_policy_after_final = 0 --';
+SELECT * FROM t_agg FINAL SETTINGS apply_row_policy_after_final = 0;
+
+DROP ROW POLICY p_agg ON t_agg;
+DROP TABLE t_agg;
+
+
+SELECT '== SummingMergeTree ==';
+DROP TABLE IF EXISTS t_sum;
+DROP ROW POLICY IF EXISTS p_sum ON t_sum;
+
+-- Both rows fall into the same dedup group (`key`); the non-summed `visibility`
+-- column takes its value from the first row, so a policy filtering on
+-- `visibility = 'public'` would pass on the merged row when the first row is
+-- public — while `cnt` would still include the contribution of the hidden row.
+CREATE TABLE t_sum
+(
+    key        String,
+    visibility String,
+    cnt        UInt64
+) ENGINE = SummingMergeTree(cnt) ORDER BY key;
+
+INSERT INTO t_sum VALUES ('k', 'public',  5);
+INSERT INTO t_sum VALUES ('k', 'private', 100);
+
+CREATE ROW POLICY p_sum ON t_sum USING visibility = 'public' TO ALL;
+
+-- The visible `cnt` must not include the contribution of the private row.
+SELECT '-- apply_row_policy_after_final = 1 --';
+SELECT * FROM t_sum FINAL SETTINGS apply_row_policy_after_final = 1;
+SELECT '-- apply_row_policy_after_final = 0 --';
+SELECT * FROM t_sum FINAL SETTINGS apply_row_policy_after_final = 0;
+
+DROP ROW POLICY p_sum ON t_sum;
+DROP TABLE t_sum;
+
+
+SELECT '== ReplacingMergeTree (deferral still works) ==';
+-- Sanity check: for engines where deferral is safe, the original
+-- soft-delete semantics introduced by `apply_row_policy_after_final` are kept.
+DROP TABLE IF EXISTS t_repl;
+DROP ROW POLICY IF EXISTS p_repl ON t_repl;
+
+CREATE TABLE t_repl
+(
+    a UInt64,
+    b UInt64,
+    is_deleted UInt8,
+    version UInt64
+) ENGINE = ReplacingMergeTree(version, is_deleted) ORDER BY a;
+
+INSERT INTO t_repl VALUES (1, 1, 0, 1);
+INSERT INTO t_repl VALUES (1, 1, 1, 2);
+INSERT INTO t_repl VALUES (2, 2, 0, 1);
+
+CREATE ROW POLICY p_repl ON t_repl AS RESTRICTIVE FOR SELECT USING (is_deleted = 0) TO ALL;
+
+-- With deferral the soft-deleted row (a = 1) is correctly hidden, only (2, 2) survives.
+SELECT '-- apply_row_policy_after_final = 1 --';
+SELECT a, b FROM t_repl FINAL ORDER BY a SETTINGS apply_row_policy_after_final = 1;
+-- Without deferral, the delete-marker is filtered out before FINAL and (1, 1) reappears.
+SELECT '-- apply_row_policy_after_final = 0 --';
+SELECT a, b FROM t_repl FINAL ORDER BY a SETTINGS apply_row_policy_after_final = 0;
+
+DROP ROW POLICY p_repl ON t_repl;
+DROP TABLE t_repl;


### PR DESCRIPTION
Fixes a security issue tracked in [`clickhouse-private` #54794](https://github.com/ClickHouse/clickhouse-private/issues/54794) / [`COR-1664`](https://linear.app/clickhouse/issue/COR-1664/security-apply-row-policy-after-finaltrue-leaks-sensitive-column).

`apply_row_policy_after_final` was introduced in #91065 for the soft-delete pattern in `ReplacingMergeTree`, where the row policy must not filter out delete-marker rows before they win deduplication. #97279 enabled it by default to restore legacy behaviour broken by an earlier `PREWHERE` optimization.

The deferral, however, is applied uniformly to all `*MergeTree` engines. For engines whose `FINAL` blends column values across multiple source rows (`Coalescing`, `Summing`, `Aggregating`, `Graphite`), the merged row carries data from rows the policy was meant to hide, so applying the policy after `FINAL` leaks sensitive values.

PoC reproduced on master with `clickhouse local`:

```sql
CREATE TABLE test (key String, data1 Nullable(String), data2 Nullable(String))
ENGINE = CoalescingMergeTree ORDER BY key;

INSERT INTO test VALUES ('key', 'sensitive_data',     'top_secret');
INSERT INTO test VALUES ('key', 'not sensitive data', NULL);

CREATE ROW POLICY p ON test USING NOT (data1 = 'sensitive_data') TO ALL;

SELECT * FROM test FINAL SETTINGS apply_row_policy_after_final = 1;
-- key | not sensitive data | top_secret   <-- 'top_secret' leaks
SELECT * FROM test FINAL SETTINGS apply_row_policy_after_final = 0;
-- key | not sensitive data | \N
```

The fix restricts the deferral in `ReadFromMergeTree::deferFiltersAfterFinalIfNeeded` to engines that pick a single source row per dedup group (`Replacing`, `Collapsing`, `VersionedCollapsing`, `Ordinary`). Existing tests for the `ReplacingMergeTree` soft-delete use case (`03742_apply_row_policy_after_final`, `03915_row_policy_should_respect_final_by_default`, `03928_deferred_filters_after_final_in_explain`) keep their semantics. A new `04142_row_policy_after_final_blending_engines` covers the affected engines and confirms the leaks are gone.

`apply_prewhere_after_final` is left unchanged — `PREWHERE` is the user's own predicate, defaults to off, and is not a security boundary.

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a leak of sensitive column values when querying with \`FINAL\` on \`CoalescingMergeTree\`, \`SummingMergeTree\`, \`AggregatingMergeTree\` or \`GraphiteMergeTree\` under a row policy. The setting \`apply_row_policy_after_final\` (enabled by default since 26.2) was deferring the row-level filter even on engines that blend column values across rows during \`FINAL\`, which could expose data from rows the policy was meant to hide. The deferral is now restricted to engines that pick a single source row per dedup group.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

> *Generated by [Nerve](https://github.com/ClickHouse/nerve)*