### PR TITLE
Refresh distroless base image digests (libssl3t64 CVE fix)

### DIFF
--- a/docker/keeper/Dockerfile.distroless
+++ b/docker/keeper/Dockerfile.distroless
@@ -139,7 +139,7 @@ RUN mkdir -p \
 # Stage 2: Production distroless image.
 # ──────────────────────────────────────────────────────────────────────────────
 # Pinned 2026-04-02. Refresh: docker pull gcr.io/distroless/cc-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:nonroot
-FROM gcr.io/distroless/cc-debian13:nonroot@sha256:9c4fe2381c2e6d53c4cfdefeff6edbd2a67ec7713e2c3ca6653806cbdbf27a1e AS production
+FROM gcr.io/distroless/cc-debian13:nonroot@sha256:8f960b7fc6a5d6e28bb07f982655925d6206678bd9a6cde2ad00ddb5e2077d78 AS production
 
 COPY --from=ch-builder /output/ /
 
@@ -162,7 +162,7 @@ ENTRYPOINT ["/usr/bin/clickhouse", "docker-init", "--keeper"]
 #           at /busybox/sh for interactive troubleshooting.
 # ──────────────────────────────────────────────────────────────────────────────
 # Pinned 2026-04-02. Refresh: docker pull gcr.io/distroless/cc-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:debug-nonroot
-FROM gcr.io/distroless/cc-debian13:debug-nonroot@sha256:d47b319b1047dff7cdee335e3e61468f3610fac20060653aabe3786d6ecba621 AS debug
+FROM gcr.io/distroless/cc-debian13:debug-nonroot@sha256:55dd32378f7562c890342098a04726f4ef386bb86c87bec3db6ed4eef27d99fb AS debug
 
 COPY --from=ch-builder /output/ /
 

--- a/docker/server/Dockerfile.distroless
+++ b/docker/server/Dockerfile.distroless
@@ -157,7 +157,7 @@ RUN { \
 # Stage 2: Production distroless image.
 # ──────────────────────────────────────────────────────────────────────────────
 # Pinned 2026-04-02. Refresh: docker pull gcr.io/distroless/cc-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:nonroot
-FROM gcr.io/distroless/cc-debian13:nonroot@sha256:9c4fe2381c2e6d53c4cfdefeff6edbd2a67ec7713e2c3ca6653806cbdbf27a1e AS production
+FROM gcr.io/distroless/cc-debian13:nonroot@sha256:8f960b7fc6a5d6e28bb07f982655925d6206678bd9a6cde2ad00ddb5e2077d78 AS production
 
 COPY --from=ch-builder /output/ /
 
@@ -180,7 +180,7 @@ ENTRYPOINT ["/usr/bin/clickhouse", "docker-init"]
 #           at /busybox/sh for interactive troubleshooting.
 # ──────────────────────────────────────────────────────────────────────────────
 # Pinned 2026-04-02. Refresh: docker pull gcr.io/distroless/cc-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/cc-debian13:debug-nonroot
-FROM gcr.io/distroless/cc-debian13:debug-nonroot@sha256:d47b319b1047dff7cdee335e3e61468f3610fac20060653aabe3786d6ecba621 AS debug
+FROM gcr.io/distroless/cc-debian13:debug-nonroot@sha256:55dd32378f7562c890342098a04726f4ef386bb86c87bec3db6ed4eef27d99fb AS debug
 
 COPY --from=ch-builder /output/ /
 


### PR DESCRIPTION
Refresh pinned `cc-debian13` digests from 2026-04-26. Picks up `libssl3t64` `3.5.5-1~deb13u2` which fixes:

- CVE-2026-31789 (CRITICAL)
- CVE-2026-28387, CVE-2026-28388, CVE-2026-28389, CVE-2026-28390 (HIGH)
- CVE-2026-31790 (MEDIUM)
- CVE-2026-2673 (LOW)

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Refresh distroless Docker base image to fix OpenSSL CVEs in `libssl3t64`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)