### PR TITLE
Fix flaky 03752_attach_as_replicated_transaction_metadata on object storage

### DIFF
--- a/tests/queries/0_stateless/03752_attach_as_replicated_transaction_metadata.sh
+++ b/tests/queries/0_stateless/03752_attach_as_replicated_transaction_metadata.sh
@@ -40,6 +40,22 @@ ${CLICKHOUSE_CLIENT} -n -q "
     INSERT INTO TABLE t0 (c0) SELECT 1 FROM numbers(322);
     INSERT INTO TABLE t0 (c0) SELECT c0 FROM generateRandom('c0 Int', 12294830401837572975, 254, 4) LIMIT 251;
     INSERT INTO TABLE t0 (c0) SELECT c0 FROM generateRandom('c0 Int', 16932182231128798796, 132, 3) LIMIT 98;
+    -- Force the merge to complete deterministically before the \`DELETE\` mutation runs.
+    -- Without this, an in-flight background merge of the source parts can race with the
+    -- mutation cloning the resulting merged part: the merge writes a transient
+    -- \`txn_version.txt.tmp\` on the merged part during \`storeInfoToDataPartStorage\`, and on
+    -- object storage the mutation's queued hardlink for that \`.tmp\` file is committed later,
+    -- after the rename completes, failing with
+    -- \`Can't create hardlink for file ... txn_version.txt.tmp (FILE_DOESNT_EXIST)\`.
+    -- \`OPTIMIZE FINAL\` is synchronous, so when \`COMMIT\` returns the merged part's metadata
+    -- is stable; \`DELETE FROM\` then operates on a single fully-committed part. After that,
+    -- only one active part remains, so no further background merges can be scheduled before
+    -- the mutation. The merge has to run inside a transaction because the table already had
+    -- transactions used on it (\`BEGIN TRANSACTION ... ROLLBACK\` above), and a non-transactional
+    -- merge is rejected with \`Cancelling merge ... transactions were enabled for this table\`.
+    BEGIN TRANSACTION;
+    OPTIMIZE TABLE t0 FINAL;
+    COMMIT;
     DELETE FROM t0 WHERE TRUE;
 
     DETACH TABLE t0 SYNC;


### PR DESCRIPTION
Fix flakiness in `03752_attach_as_replicated_transaction_metadata` (test2) on object-storage CI configurations. Requested by @alexey-milovidov on https://github.com/ClickHouse/ClickHouse/pull/100976#issuecomment.

## Failure mode

CI failure (`Stateless tests (amd_debug, distributed plan, s3 storage, parallel)` on PR #100976, 2026-04-27):

```
Code: 341. DB::Exception: Exception happened during execution of mutation
'mutation_8.txt' with part 'all_1_7_1' reason:
'Code: 107. Can't create hardlink for file
store/52b/52b157be-f5de-4174-aae2-da7e2bd450c0/all_1_7_1/txn_version.txt.tmp:
While committing metadata operation #0. (FILE_DOESNT_EXIST)'
```

The failing query is `DELETE FROM t0 WHERE TRUE;` in test2, which spawns a mutation. On object storage the mutation's part-clone goes through `DataPartStorageOnDiskBase::freeze` → `Backup` → queued `createHardLink` operations on an external metadata transaction (committed later, in `MetadataOperationsHolder::commit`).

Test2 inserts 6 active blocks (plus a rolled-back transactional one). A background merge of those source parts runs concurrently with the subsequent `DELETE` mutation. The merge writes a transient `txn_version.txt.tmp` on the merged part during `VersionMetadataOnDisk::storeInfoToDataPartStorage` (two-phase write: `createFile(*.tmp)` → `writeFile(*.tmp)` → `replaceFile(*.tmp -> txn_version.txt)`).

If the mutation iterates the merged part's directory while `txn_version.txt.tmp` exists, it queues a hardlink operation for that file. By the time the queued op is committed, the rename has completed, the source `.tmp` is gone, and `CreateHardlinkOperation::execute` fails:

```cpp
auto object_metadata = tryReadMetadataFile(compatible_key_prefix, path_from, disk);
if (!object_metadata.has_value())
    throw Exception(ErrorCodes::FILE_DOESNT_EXIST, "Can't create hardlink for file {}", path_from);
```

(`src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDiskTransactionOperations.cpp:368`)

CIDB confirms 4 hits in 30 days across 4 unrelated PRs, three of which are on object-storage configurations (`s3 storage`, `azure`).

## Fix

Force the merge to complete deterministically before the `DELETE` mutation runs:

```sql
BEGIN TRANSACTION;
OPTIMIZE TABLE t0 FINAL;
COMMIT;
DELETE FROM t0 WHERE TRUE;
```

`OPTIMIZE FINAL` is synchronous, so when `COMMIT` returns the merged part's `txn_version.txt` is fully stable (no transient `.tmp`). After it, only one active part remains, so no further background merges can be scheduled before the mutation. The merge has to run inside a transaction because the table already has transactions used on it (`BEGIN TRANSACTION ... ROLLBACK` above) and a non-transactional merge is rejected with `Cancelling merge ... transactions were enabled for this table` (`MergeTreeDataMergerMutator::renameMergedTemporaryPart`).

Only test2 is changed; test1 and test3 only insert two parts each, so they are not exposed to this race in practice.

The output of all three tests is unchanged (`SELECT COUNT(*)` returns `0`, `0`, `418` as before), so `.reference` does not need updating.

## Verification

- `tests/clickhouse-test --test-runs 50 03752_attach_as_replicated_transaction_metadata` → 50/50 passes (61s) on debug local-disk build.
- Reasoning above explains why the queued-hardlink commit failure can no longer occur after the merged part's metadata is fully stable.

## Note on the underlying race

The deeper bug — that `Backup` queues hardlinks for transient `*.tmp` files which can disappear before the queued op is committed on object storage — exists in `src/Storages/MergeTree/Backup.cpp` (no filter for transient version-metadata files) and `src/Storages/MergeTree/DataPartStorageOnDiskBase.cpp` (post-Backup cleanup removes `txn_version.txt` from the destination but not `txn_version.txt.tmp`). Other tests/code paths could theoretically hit the same race. That's worth a separate, source-side fix; this PR only stabilizes the test as requested.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
NO ENTRY

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100976&sha=49f741a8f4d15de6fdbb6d32fc9d996694fa1799&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20distributed%20plan%2C%20s3%20storage%2C%20parallel%29

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.149`
<!-- ch-version-info:end -->