### PR TITLE
Add SIGKILL fallback in test_keeper_zookeeper_converter::stop_zookeeper

### DIFF
--- a/tests/integration/test_keeper_zookeeper_converter/test.py
+++ b/tests/integration/test_keeper_zookeeper_converter/test.py
@@ -31,23 +31,48 @@ def start_zookeeper():
             time.sleep(3)
 
 
+# pgrep / pkill -f match against the full command line, which includes the
+# pgrep / pkill process itself. The bracket expression `[o]rg` is a standard
+# trick that keeps `pgrep -f` from matching its own shell process: pgrep's
+# argv contains the literal string `[o]rg.apache.zookeeper.server` (the
+# brackets are passed through verbatim by bash because they are inside single
+# quotes), and the regex `[o]rg\.apache\.zookeeper\.server` does not match
+# that literal string (it needs `o` as the first character, not `[`).
+ZK_JVM_PATTERN = "[o]rg\\.apache\\.zookeeper\\.server"
+
+
+def _zk_jvm_running():
+    return bool(
+        node.exec_in_container(
+            ["bash", "-c", f"pgrep -f '{ZK_JVM_PATTERN}' || true"],
+            nothrow=True,
+        ).strip()
+    )
+
+
 def stop_zookeeper():
+    # `zkServer.sh stop` sends a single SIGTERM to the JVM, removes the PID
+    # file, and returns — it does not wait for the JVM to actually exit and
+    # has no SIGKILL fallback. Under sanitizer-heavy CI builds the JVM can
+    # take a long time to run its shutdown hooks, so we have to do the wait
+    # ourselves and force-kill the JVM if it does not exit in time.
     node.exec_in_container(["bash", "-c", "/opt/zookeeper/bin/zkServer.sh stop"])
-    timeout = time.time() + 60
-    # get_process_pid("zookeeper") uses the regex '^[^ ]*zookeeper' which only
-    # matches the first word of the command line. The ZooKeeper Java process
-    # starts with "java -Dzookeeper..." so it never matches. Use a direct pgrep
-    # for the ZooKeeper main class to properly detect the running JVM.
-    # The bracket expression [o]rg is a standard trick to keep pgrep -f from
-    # matching the shell process that is running pgrep itself (its argv
-    # contains the literal string '[o]rg.apache.zookeeper.server', which the
-    # regex '[o]rg.apache.zookeeper.server' does not match).
-    while node.exec_in_container(
-        ["bash", "-c", "pgrep -f '[o]rg\\.apache\\.zookeeper\\.server' || true"],
-        nothrow=True,
-    ).strip():
-        if time.time() > timeout:
-            raise Exception("Failed to stop ZooKeeper in 60 secs")
+    sigterm_deadline = time.time() + 60
+    while _zk_jvm_running():
+        if time.time() > sigterm_deadline:
+            # SIGTERM did not stop the JVM in time. The JVM is just an
+            # external dependency used to populate test data, so a hard
+            # kill is acceptable — we do not need a clean shutdown.
+            print("ZooKeeper JVM did not exit 60s after SIGTERM; sending SIGKILL")
+            node.exec_in_container(
+                ["bash", "-c", f"pkill -9 -f '{ZK_JVM_PATTERN}' || true"],
+            )
+            sigkill_deadline = time.time() + 10
+            while _zk_jvm_running():
+                if time.time() > sigkill_deadline:
+                    raise Exception("Failed to stop ZooKeeper even after SIGKILL")
+                time.sleep(0.2)
+            return
         time.sleep(0.2)
 
 


### PR DESCRIPTION
Per directive at https://github.com/ClickHouse/ClickHouse/pull/100941#issuecomment-3457500944
(fix `test_keeper_zookeeper_converter/test.py::test_acls[True]` flakiness in a separate PR).

`zkServer.sh stop` in the ZooKeeper 3.6.3 binary used by the test sends a single
SIGTERM to the JVM, removes the PID file, and returns — it does not wait for
the JVM to actually exit and has no SIGKILL fallback (see [`zkServer.sh` upstream](https://github.com/apache/zookeeper/blob/release-3.6.3/bin/zkServer.sh#L191-L201)).
The test's `stop_zookeeper` polls `pgrep` for up to 60 seconds and raises
`Failed to stop ZooKeeper in 60 secs` if the JVM has not finished its shutdown
hooks by then.

Under sanitizer-heavy CI builds (MSan in particular), the ZooKeeper JVM and the
MSan-instrumented ClickHouse server share the same Docker container and the
same CPU. MSan only instruments compiled C/C++ code at the LLVM IR level — the
JVM itself is not sanitizer-instrumented, the OpenJDK `java` binary and the
ZooKeeper bytecode run the same way they do in non-sanitizer builds. But the
~2–10× CPU slowdown MSan adds to ClickHouse leaves the JVM with much less
scheduler share. JVM shutdown hooks (log flushes, snapshot finalization, file
close, ZK-internal teardown) are largely synchronous, and under that scheduler
pressure they can occasionally exceed the 60-second `pgrep` poll. This is the
dominant chronic-flakiness mode this test exhibited before #102492 (the
`pgrep` regex fix and `start_zookeeper` retry loop).

Recent CIDB shows zero `test_acls` failures across ~27,000 runs in the 8 days
since #102492 merged, but the historical pattern is sporadic and sanitizer
load can push JVM shutdown over the 60s line at any time.

The genuine ZooKeeper JVM in this test exists only to populate test data for
the `clickhouse keeper-converter` tool — we do not test the JVM itself and a
clean shutdown is unnecessary. Add a SIGKILL fallback that fires after SIGTERM
does not stop the JVM in 60 seconds, so the test can never fail on a slow or
hung JVM shutdown. The bracket trick `[o]rg.apache.zookeeper.server` in the
`pgrep` / `pkill` pattern is preserved (and now factored into a constant) to
keep the kill from matching its own shell process.

CIDB sample failures showing the addressed pattern:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=00ecef1c87cfebeb52a024307b0a76a68518fb53&name_0=MasterCI&name_1=Integration%20tests%20%28amd_msan%2C%206%2F6%29

### Verification

- `python3 -m ci.praktika run "integration" --test "test_keeper_zookeeper_converter/test.py::test_acls" --count 3` — 6/6 passes locally.
- Direct SIGKILL mechanism check inside `clickhouse/integration-test:latest`:
  - `pgrep -f '[o]rg\.apache\.zookeeper\.server'` matches the running JVM.
  - `pkill -9 -f '[o]rg\.apache\.zookeeper\.server'` kills the JVM and does not match itself.
  - After the kill, `pgrep` returns nothing.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.148`
<!-- ch-version-info:end -->