### PR TITLE
Fix test_show_data_lake_catalogs_setting after #103444

### DIFF
--- a/tests/integration/test_e2e_catalogs/test.py
+++ b/tests/integration/test_e2e_catalogs/test.py
@@ -736,16 +736,15 @@ def test_show_data_lake_catalogs_setting(
     db = catalog_manager.make_database_name()
     catalog_manager.create_catalog(node, db)
 
-    assert not node.query(
-        f"SELECT 1 FROM system.databases WHERE name = '{db}' FORMAT TSV",
-        settings={"show_data_lake_catalogs_in_system_tables": 0},
-    ).strip()
-
-    db_row = node.query(
-        f"SELECT engine FROM system.databases WHERE name = '{db}' FORMAT TSV",
-        settings={"show_data_lake_catalogs_in_system_tables": 1},
-    ).strip()
-    assert "DataLakeCatalog" in db_row
+    # system.databases always lists data lake catalog databases regardless of
+    # show_data_lake_catalogs_in_system_tables: the database name is local
+    # metadata and never requires a call to the external catalog service.
+    for setting_value in (0, 1):
+        db_row = node.query(
+            f"SELECT engine FROM system.databases WHERE name = '{db}' FORMAT TSV",
+            settings={"show_data_lake_catalogs_in_system_tables": setting_value},
+        ).strip()
+        assert "DataLakeCatalog" in db_row
 
     catalog_manager.resolve_table_name(node, db, sales_table)
 


### PR DESCRIPTION
PR #103444 ("Fix: `system.databases` always shows data lake catalog databases") changed `system.databases` to always list data lake catalog databases regardless of `show_data_lake_catalogs_in_system_tables`. The setting still gates `system.tables`, `system.columns`, `system.iceberg_history`, etc., where listing requires a remote catalog call.

`tests/integration/test_e2e_catalogs/test.py::test_show_data_lake_catalogs_setting` was still asserting the old contract (DB hidden when the setting is `0`) and started failing in NightlyE2E across all three parametrizations (`biglake`, `glue`, `onelake`). Update the assertion to match the new contract: the catalog DB is visible in `system.databases` for both setting values.

Failing run: https://github.com/ClickHouse/clickhouse-private/actions/runs/24975011007/job/73125306981

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.133`
<!-- ch-version-info:end -->