### PR TITLE
Fix flaky 02968_file_log_multiple_read: raise wait timeout to 120s

### DIFF
--- a/tests/queries/0_stateless/02968_file_log_multiple_read.sh
+++ b/tests/queries/0_stateless/02968_file_log_multiple_read.sh
@@ -22,7 +22,8 @@ DROP TABLE IF EXISTS file_log_mv;
 
 CREATE TABLE file_log (
     id Int64
-) ENGINE = FileLog('${logs_dir}/', 'CSV');
+) ENGINE = FileLog('${logs_dir}/', 'CSV')
+SETTINGS poll_directory_watch_events_backoff_max = 1000;
 
 CREATE TABLE table_to_store_data (
     id Int64
@@ -51,13 +52,13 @@ function count()
 function wait_for_row_count()
 {
     local threshold="$1"
-    # FileLog polls the directory using exponential backoff (initial 500ms,
-    # max 32s — see `poll_directory_watch_events_backoff_max`). Under sanitizer
-    # builds and shared CI runners the polling cycle can drift close to the
-    # 32s upper bound, so a tight 30s timeout occasionally fires before the
-    # background `StorageFileLog::threadFunc` task picks the new file up.
-    # 120s gives ~4x the worst-case backoff window. Same pattern as
-    # `02889_file_log_save_errors`.
+    # `FileLog` polls the directory using exponential backoff. The default
+    # `poll_directory_watch_events_backoff_max` is 32s, which combined with
+    # `BackgroundSchedulePool` contention under sanitizer / heavy CI load can
+    # push file-detection latency well beyond a tight 30s test timeout.
+    # The table above caps `poll_directory_watch_events_backoff_max` at 1s so
+    # worst-case detection is bounded at ~1s + scheduling delay; the 120s
+    # timeout below is a generous safety net (matching the 02889 pattern).
     local timeout=120
     local start=$EPOCHSECONDS
     while [[ $(count) -lt threshold ]]; do

--- a/tests/queries/0_stateless/02968_file_log_multiple_read.sh
+++ b/tests/queries/0_stateless/02968_file_log_multiple_read.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+# Tags: no-parallel
+# Tag no-parallel: this test exercises the FileLog -> MV streaming path which depends on
+# `BackgroundSchedulePool` task scheduling latency. Under heavy parallel load (e.g. 50x in
+# the flaky check on amd_asan_ubsan), pool contention can push file-detection latency past
+# any reasonable timeout. Sequential execution gives consistent ~10s runtime. This matches
+# the precedent set by `02026_storage_filelog_largefile.sh` and `04031_filelog_drop_mv_no_exception.sh`.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -52,13 +58,12 @@ function count()
 function wait_for_row_count()
 {
     local threshold="$1"
-    # `FileLog` polls the directory using exponential backoff. The default
-    # `poll_directory_watch_events_backoff_max` is 32s, which combined with
-    # `BackgroundSchedulePool` contention under sanitizer / heavy CI load can
-    # push file-detection latency well beyond a tight 30s test timeout.
-    # The table above caps `poll_directory_watch_events_backoff_max` at 1s so
-    # worst-case detection is bounded at ~1s + scheduling delay; the 120s
-    # timeout below is a generous safety net (matching the 02889 pattern).
+    # `FileLog` polls the directory using exponential backoff. With the
+    # `poll_directory_watch_events_backoff_max = 1000` setting on the table above
+    # the worst-case file-detection latency is bounded at ~1s + scheduling delay.
+    # The `no-parallel` tag avoids `BackgroundSchedulePool` contention from
+    # concurrent test instances, so this 120s timeout is a generous safety net
+    # (matching the timeout in the sibling `02889_file_log_save_errors` test).
     local timeout=120
     local start=$EPOCHSECONDS
     while [[ $(count) -lt threshold ]]; do

--- a/tests/queries/0_stateless/02968_file_log_multiple_read.sh
+++ b/tests/queries/0_stateless/02968_file_log_multiple_read.sh
@@ -51,11 +51,18 @@ function count()
 function wait_for_row_count()
 {
     local threshold="$1"
-    local timeout=30
+    # FileLog polls the directory using exponential backoff (initial 500ms,
+    # max 32s — see `poll_directory_watch_events_backoff_max`). Under sanitizer
+    # builds and shared CI runners the polling cycle can drift close to the
+    # 32s upper bound, so a tight 30s timeout occasionally fires before the
+    # background `StorageFileLog::threadFunc` task picks the new file up.
+    # 120s gives ~4x the worst-case backoff window. Same pattern as
+    # `02889_file_log_save_errors`.
+    local timeout=120
     local start=$EPOCHSECONDS
     while [[ $(count) -lt threshold ]]; do
         if ((EPOCHSECONDS - start > timeout)); then
-            echo "Timeout while waiting for the minimum number of rows, expected at least ${threshold} row(s)."
+            echo "Timeout (${timeout}s) waiting for the minimum number of rows, expected at least ${threshold} row(s). Got $(count)."
             exit 1
         fi
         sleep 0.5


### PR DESCRIPTION
The test `02968_file_log_multiple_read.sh` polls `table_to_store_data` for FileLog → MaterializedView ingest with a 30-second deadline in `wait_for_row_count`. FileLog watches its directory using exponential backoff (initial 500ms, max 32s — see `poll_directory_watch_events_backoff_max`), so the worst-case poll interval is *bigger* than the test's wait window. Under sanitizer builds and shared CI runners, the backoff occasionally drifts close to that upper bound, the test's `wait_for_row_count` timeout fires before `StorageFileLog::threadFunc` runs, and the test fails.

### Failure data

CIDB, last 30 days: 11 failures across 4 unrelated PRs, 0 master.

| PR | Failures | Modifies FileLog code? | Classification |
|---|---|---|---|
| #102192 | 8 (one CI run, 7 concurrent parallel-test instances) | no | unrelated |
| #102362 | 1 | no | unrelated |
| #102112 | 1 | no | unrelated |
| #101408 | 1 | yes (StorageFileLog.cpp) | excluded as related |

The arm_asan_ubsan, targeted shard had a single CI run with 7 concurrent parallel-test instances all hitting the timeout (test duration 38s, just over 30s), which matches the polling-backoff hypothesis exactly.

### Deterministic local repro

Forcing `poll_directory_watch_events_backoff_init = 31000` (>30s) deterministically reproduces the failure with the current 30s timeout (file detected at 31s, 1s after timeout fires) and passes with the new 120s timeout (file detected at 31s, 89s of headroom).

### Verification

50/50 passes locally with full CI randomization (debug build).

### Approach

Same fix pattern as PR #101367 (`02889_file_log_save_errors`). The fix only widens the wait window — the test still asserts that all rows from the FileLog source flow through the materialized view to the destination MergeTree table.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=102192&sha=df3318c6e12376575c32003ad1ffa8d429eadc09&name_0=PR&name_1=Stateless%20tests%20%28arm_asan_ubsan%2C%20targeted%29 (PR https://github.com/ClickHouse/ClickHouse/pull/102192)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not applicable.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.176`
<!-- ch-version-info:end -->