### PR TITLE
Fix flaky test 04122_serialization_time64_formats

### DIFF
--- a/tests/queries/0_stateless/04122_serialization_time64_formats.reference
+++ b/tests/queries/0_stateless/04122_serialization_time64_formats.reference
@@ -25,9 +25,9 @@
 --- CSV input: deserializeTextCSV with quote char ---
 00:00:00.000
 12:30:45.123
---- CSV input: deserializeTextCSV without quotes (numeric) ---
+--- CSV input: deserializeTextCSV rejects unquoted numeric with trailing data ---
+--- CSV input: deserializeTextCSV accepts valid unquoted numeric ---
 00:00:00.000
-00:00:45.000
 --- TSV input: deserializeTextEscaped ---
 00:00:00.000
 12:30:45.123

--- a/tests/queries/0_stateless/04122_serialization_time64_formats.sql
+++ b/tests/queries/0_stateless/04122_serialization_time64_formats.sql
@@ -37,10 +37,11 @@ SELECT t FROM format(CSV, 't Time64(3)',
 '"12:30:45.123"
 ''00:00:00.000''') ORDER BY t;
 
-SELECT '--- CSV input: deserializeTextCSV without quotes (numeric) ---';
-SELECT t FROM format(CSV, 't Time64(3)',
-'45045123
-0') ORDER BY t;
+SELECT '--- CSV input: deserializeTextCSV rejects unquoted numeric with trailing data ---';
+SELECT t FROM format(CSV, 't Time64(3)', '45045123') ORDER BY t; -- { serverError UNEXPECTED_DATA_AFTER_PARSED_VALUE }
+
+SELECT '--- CSV input: deserializeTextCSV accepts valid unquoted numeric ---';
+SELECT t FROM format(CSV, 't Time64(3)', '0') ORDER BY t;
 
 SELECT '--- TSV input: deserializeTextEscaped ---';
 SELECT t FROM format(TabSeparated, 't Time64(3)',


### PR DESCRIPTION
Test `04122_serialization_time64_formats` was added on master at the same time as the fix in #102596 (\"Do not accept trailing garbage for CSV-deserialized Time64 values\"). The test reference captured the *old* buggy behavior where the unquoted CSV input `45045123` would silently be parsed as just `45` (yielding `00:00:45.000`). After #102596, that input correctly throws `UNEXPECTED_DATA_AFTER_PARSED_VALUE`, so the test now fails on master across many builds (`amd_asan_ubsan`, `amd_debug`, `amd_msan`, `amd_tsan`, `amd_llvm_coverage`, `arm_binary`, ...).

This PR updates the section to assert the new behavior, and adds a separate case for a valid unquoted numeric (`0`) so the original coverage intent is preserved.

Failing CI report (for context):
https://play.clickhouse.com/play?user=play&run=1#U0VMRUNUIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSAxCiAgICBBTkQgY2hlY2tfc3RhcnRfdGltZSA+PSBub3coKSAtIElOVEVSVkFMIDI0IEhPVVIKICAgIEFORCAoaGVhZF9yZWYgPSAnbWFzdGVyJyBBTkQgc3RhcnRzV2l0aChoZWFkX3JlcG8sICdDbGlja0hvdXNlLycpKQogICAgQU5EIHRlc3Rfc3RhdHVzICE9ICdTS0lQUEVEJwogICAgQU5EICh0ZXN0X3N0YXR1cyBMSUtFICdGJScgT1IgdGVzdF9zdGF0dXMgTElLRSAnRSUnKQogICAgQU5EIGNoZWNrX3N0YXR1cyAhPSAnc3VjY2VzcycKICAgIEFORCBjaGVja19uYW1lIE5PVCBMSUtFICdsaWJGdXp6ZXIlJwogICAgQU5EIGNoZWNrX25hbWUgIT0gJ0NsaWNrSG91c2UgS2VlcGVyIEplcHNlbicKICAgIEFORCBjaGVja19uYW1lIE5PVCBJTElLRSAnJWV4cGVyaW1lbnRhbCUnCk9SREVSIEJZIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgY2hlY2tfc3RhcnRfdGltZQ==

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.134`
<!-- ch-version-info:end -->