### PR TITLE
Fix `04122_serialization_time64_formats` test after `yarik/fix-time64-serialization`

### DIFF
--- a/tests/queries/0_stateless/04122_serialization_time64_formats.reference
+++ b/tests/queries/0_stateless/04122_serialization_time64_formats.reference
@@ -25,9 +25,9 @@
 --- CSV input: deserializeTextCSV with quote char ---
 00:00:00.000
 12:30:45.123
---- CSV input: deserializeTextCSV without quotes (numeric) ---
+--- CSV input: deserializeTextCSV without quotes (unquoted time strings) ---
 00:00:00.000
-00:00:45.000
+12:30:45.123
 --- TSV input: deserializeTextEscaped ---
 00:00:00.000
 12:30:45.123

--- a/tests/queries/0_stateless/04122_serialization_time64_formats.sql
+++ b/tests/queries/0_stateless/04122_serialization_time64_formats.sql
@@ -37,10 +37,10 @@ SELECT t FROM format(CSV, 't Time64(3)',
 '"12:30:45.123"
 ''00:00:00.000''') ORDER BY t;
 
-SELECT '--- CSV input: deserializeTextCSV without quotes (numeric) ---';
+SELECT '--- CSV input: deserializeTextCSV without quotes (unquoted time strings) ---';
 SELECT t FROM format(CSV, 't Time64(3)',
-'45045123
-0') ORDER BY t;
+'12:30:45.123
+00:00:00.000') ORDER BY t;
 
 SELECT '--- TSV input: deserializeTextEscaped ---';
 SELECT t FROM format(TabSeparated, 't Time64(3)',


### PR DESCRIPTION
PR #102596 (`yarik/fix-time64-serialization`) added a trailing-garbage check in `deserializeTextCSV`: after parsing an unquoted field as a time string, it now throws `UNEXPECTED_DATA_AFTER_PARSED_VALUE` if the buffer is not fully consumed.

The test was passing `45045123` as an unquoted CSV value. `readTime64Text` parsed only `45` (SS format) and left `045123` as trailing garbage, causing the test to fail across all stateless-test configurations.

Fix: replace the raw integer with `12:30:45.123`, a proper unquoted time string, and rename the section header accordingly.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)