### PR TITLE
Fix race condition and error masking in `test_accept_invalid_certificate`

### DIFF
--- a/tests/integration/test_accept_invalid_certificate/test.py
+++ b/tests/integration/test_accept_invalid_certificate/test.py
@@ -1,5 +1,6 @@
+import os
 import os.path
-from os import remove
+import tempfile
 
 import pytest
 
@@ -62,27 +63,27 @@ config_connection_accept = """<clickhouse>
 
 
 def execute_query_native(node, query, config):
-    config_path = f"{SCRIPT_DIR}/configs/client.xml"
-
-    file = open(config_path, "w")
-    file.write(config)
-    file.close()
-
-    client = Client(
-        node.ip_address,
-        9440,
-        command=cluster.client_bin_path,
-        secure=True,
-        config=config_path,
+    fd, config_path = tempfile.mkstemp(
+        prefix="client_", suffix=".xml", dir=f"{SCRIPT_DIR}/configs"
     )
-
     try:
-        result = client.query(query)
-        remove(config_path)
-        return result
-    except:
-        remove(config_path)
-        raise
+        with os.fdopen(fd, "w") as f:
+            f.write(config)
+
+        client = Client(
+            node.ip_address,
+            9440,
+            command=cluster.client_bin_path,
+            secure=True,
+            config=config_path,
+        )
+
+        return client.query(query)
+    finally:
+        try:
+            os.remove(config_path)
+        except FileNotFoundError:
+            pass
 
 
 def test_default():


### PR DESCRIPTION
`execute_query_native` wrote all test configurations to the same `configs/client.xml` path, causing parallel test invocations to clobber each other's config and produce inconsistent TLS behaviour. Additionally, calling `remove()` inside the `except` block could raise `FileNotFoundError`, which replaced the real SSL exception and broke the `assert "certificate verify failed"` checks.

Fix: write each config to a unique temp file via `tempfile.mkstemp` and clean it up in a `finally` block that swallows `FileNotFoundError`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.132`
<!-- ch-version-info:end -->