### PR TITLE
Fix flaky `02151_http_s_structure_set_eof` on fast builds

### DIFF
--- a/tests/queries/0_stateless/02151_http_s_structure_set_eof.sh
+++ b/tests/queries/0_stateless/02151_http_s_structure_set_eof.sh
@@ -7,23 +7,29 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 tmp_file=$(mktemp "$CURDIR/clickhouse.XXXXXX.csv")
 trap 'rm $tmp_file' EXIT
 
-# NOTE: this file should be huge enough, so that it is impossible to upload it
-# in 0.15s, see _timeout command below, this will ensure, that EOF will be
-# received during creating a set from externally uploaded table.
+# This test verifies that the server handles EOF correctly when an HTTP
+# multipart upload is interrupted mid-stream (the upload is killed by the
+# parent shell after 0.15s).
 #
 # Previously code there wasn't ready for EOF, and you will get one of the
-# following assertions:
+# following exceptions:
 #
 #     - ./src/IO/ReadBuffer.h:58: bool DB::ReadBuffer::next(): Assertion `!hasPendingData()' failed.
 #     - ./src/Server/HTTP/HTMLForm.cpp:245: bool DB::HTMLForm::MultipartReadBuffer::skipToNextBoundary(): Assertion `boundary_hit' failed.
 #     - ./src/IO/LimitReadBuffer.cpp:17: virtual bool DB::LimitReadBuffer::nextImpl(): Assertion `position() >= in->position()' failed.
 #
+# `curl --limit-rate` throttles the upload to a known rate, so the kill at
+# 0.15s reliably arrives mid-upload regardless of CPU speed or network
+# bandwidth. Without it, on a fast (release-style, e.g. `*_binary`) build
+# over loopback the entire 78 MB upload can complete in under 0.15s, and
+# the `Error: completed early` branch fires — leading to a flaky
+# `+Error: completed early` diff against the reference output.
 $CLICKHOUSE_CLIENT -q "SELECT toString(number) FROM numbers(10e6) FORMAT TSV" > "$tmp_file"
 
 _timeout() {
     echo Run
     (
-        ${CLICKHOUSE_CURL} -sS -F "s=@$tmp_file;" "$1" -o /dev/null 2>/dev/null
+        ${CLICKHOUSE_CURL} --limit-rate 100k -sS -F "s=@$tmp_file;" "$1" -o /dev/null 2>/dev/null
         echo Error: completed early
     ) &
     local pid=$!

--- a/tests/queries/0_stateless/02151_http_s_structure_set_eof.sh
+++ b/tests/queries/0_stateless/02151_http_s_structure_set_eof.sh
@@ -11,7 +11,7 @@ trap 'rm $tmp_file' EXIT
 # multipart upload is interrupted mid-stream (the upload is killed by the
 # parent shell after 0.15s).
 #
-# Previously code there wasn't ready for EOF, and you will get one of the
+# Previously the code wasn't ready for EOF, and you will get one of the
 # following exceptions:
 #
 #     - ./src/IO/ReadBuffer.h:58: bool DB::ReadBuffer::next(): Assertion `!hasPendingData()' failed.


### PR DESCRIPTION
The test `02151_http_s_structure_set_eof` is flaky on master and PRs because it depends on a race between a 0.15 s shell `sleep` and a `curl` multipart upload of a 78 MB file. Intended outcome: `kill` wins, the server sees EOF mid-multipart and the EOF-handling code path is exercised. Actual outcome on fast builds: `curl` can complete the whole upload in under 0.15 s, the `Error: completed early` branch fires, and the diff shows `+Error: completed early`.

Add `curl --limit-rate 100k` to throttle the upload to a known rate (~15 KB transferred in 0.15 s). The kill now arrives mid-upload regardless of CPU speed or network bandwidth, so the EOF code path is still exercised — same test intent, but deterministic.

Reproduced locally on a debug build by shrinking the temp file from `numbers(10e6)` to `numbers(1e5)` (equivalent to faster hardware):
- Without the fix: 5/5 runs fail with `+Error: completed early`.
- With the fix: 30/30 runs pass under the same conditions.
- With the fix and the original 10e6 file size: 50/50 runs pass under `clickhouse-test --test-runs 50` with full random-settings randomization.

PR #99266 by @leshikus replaced the GNU `timeout 0.15s` wrapper with a portable `_timeout` helper for macOS, but did not address the underlying CPU-speed-vs-upload-time race. Today's master CI saw a fresh master hit on `Stateless tests (arm_binary, parallel)`:

CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=323e1dac609447557e6f030e365f8a75eaeb2a34&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix flaky `02151_http_s_structure_set_eof`.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.142`
<!-- ch-version-info:end -->