### PR TITLE
ci(promql): Add compliance report comment from integration tests

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -148,13 +148,18 @@ common_integration_test_job_config = Job.Config(
         include_paths=[
             "./ci/jobs/integration_test_job.py",
             "./ci/jobs/scripts/integration_tests_configs.py",
+            "./ci/jobs/scripts/job_hooks/promql_compliance_hook.py",
+            "./ci/jobs/scripts/job_hooks/promql_compliance_s3.py",
             "./tests/integration/",
             "./ci/docker/integration",
             "./ci/jobs/scripts/docker_in_docker.sh",
         ],
     ),
     run_in_docker=f"clickhouse/integration-tests-runner+root+--memory={LIMITED_MEM}+--privileged+--dns-search='.'+--security-opt seccomp=unconfined+--cap-add=SYS_PTRACE+{docker_sock_mount}+--volume=clickhouse_integration_tests_volume:/var/lib/docker+--cgroupns=host",
-    post_hooks=["python3 ci/jobs/scripts/job_hooks/docker_volume_clean_up_hook.py"],
+    post_hooks=[
+        "python3 ci/jobs/scripts/job_hooks/docker_volume_clean_up_hook.py",
+        "python3 ci/jobs/scripts/job_hooks/promql_compliance_hook.py",
+    ],
 )
 
 

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -818,6 +818,10 @@ tar -czf ./ci/tmp/logs.tar.gz \
         "CLICKHOUSE_USE_DATABASE_DISK": "1" if use_database_disk else "0",
         "PYTEST_CLEANUP_CONTAINERS": "1",
         "JAVA_PATH": java_path,
+        # PromQL compliance: deterministic JSON for post-hook (see promql_compliance_hook.py).
+        "COMPLIANCE_RESULT_FILE": os.environ.get(
+            "COMPLIANCE_RESULT_FILE", os.path.join(temp_path, "promql_compliance_result.json")
+        ),
     }
     if is_llvm_coverage:
         test_env["LLVM_PROFILE_FILE"] = f"it-%4m.profraw"

--- a/ci/jobs/scripts/job_hooks/promql_compliance_hook.py
+++ b/ci/jobs/scripts/job_hooks/promql_compliance_hook.py
@@ -117,6 +117,11 @@ def _check_impl() -> None:
         traceback.print_exc()
         return
 
+    for _k in ("pct", "passed", "failed", "unsupported"):
+        if _k not in new:
+            print(f"PromQL compliance hook: result JSON missing key {_k!r}")
+            return
+
     commits = master_track_commits(info)
     base, s3_sha = fetch_baseline_from_s3(commits)
     if base is not None and s3_sha:

--- a/ci/jobs/scripts/job_hooks/promql_compliance_hook.py
+++ b/ci/jobs/scripts/job_hooks/promql_compliance_hook.py
@@ -1,0 +1,215 @@
+"""Post LLVM-style PromQL compliance Baseline/Current/Δ comment on PRs (label-gated).
+
+Runs as a post-hook after each Integration tests batch. Only the batch that
+executed ``test_compliance.py`` leaves the JSON path given by
+``COMPLIANCE_RESULT_FILE`` (default ``./ci/tmp/promql_compliance_result.json``,
+same default as ``integration_test_job.py``).
+
+Baseline (PRs): first available ``promql_compliance_result.json`` on S3 under
+``REFs/master/<sha>/promql_compliance/`` for SHAs in ``master_track_commits_sha``
+(same walk idea as LLVM coverage). If none exists, the baseline in the table is
+zero (0% score, 0 / 0 / 0 counts) and the comment states that explicitly.
+
+Upstream ``master`` pushes: uploads the result JSON to that S3 path so the next
+PRs can use it as baseline.
+
+Posts when the PR is labeled ``comp-promql`` and the score delta vs the chosen
+baseline is non-zero. Never fails the job on GH errors.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import traceback
+from pathlib import Path
+
+from ci.jobs.scripts.job_hooks.promql_compliance_s3 import (
+    fetch_baseline_from_s3,
+    master_track_commits,
+    should_publish_master_baseline,
+    upload_master_result,
+    result_url_for_master_commit,
+)
+from ci.jobs.scripts.workflow_hooks.pr_labels_and_category import Labels
+from ci.praktika.gh import GH
+from ci.praktika.info import Info
+
+RESULT_FILE = Path(
+    os.environ.get(
+        "COMPLIANCE_RESULT_FILE",
+        os.path.join(".", "ci", "tmp", "promql_compliance_result.json"),
+    )
+)
+EPS = 1e-4
+COMMENT_TAG = "promql-compliance"
+
+_ZERO_BASELINE = {
+    "pct": 0.0,
+    "passed": 0,
+    "failed": 0,
+    "unsupported": 0,
+}
+
+
+def _bump_baseline_block_s3(new_pct: float, base_pct: float, base_sha: str) -> str:
+    return (
+        "\n### Baseline update\n\n"
+        f"This run reports {new_pct:.2f}% vs master baseline {base_pct:.2f}% "
+        f"([`{base_sha[:9]}`]({result_url_for_master_commit(base_sha)})). "
+        "Merging to `master` will publish a new S3 object from the integration job that runs "
+        "`test_promql_compliance`, which becomes the baseline for later PRs.\n"
+    )
+
+
+def _no_s3_baseline_block() -> str:
+    return (
+        "\n### No master baseline on S3 yet\n\n"
+        "None of the checked `master` commits had "
+        "`REFs/master/<sha>/promql_compliance/promql_compliance_result.json`. "
+        "The table above uses zero as the baseline so you still see current "
+        "scores and deltas. After a green `master` integration run uploads that "
+        "object, PRs will compare against the published master snapshot instead.\n"
+    )
+
+
+def check() -> None:
+    try:
+        _check_impl()
+    except Exception:
+        print("WARNING: PromQL compliance hook failed with unexpected error")
+        traceback.print_exc()
+
+
+def _check_impl() -> None:
+    if not RESULT_FILE.is_file():
+        print(
+            f"PromQL compliance hook: no result at {RESULT_FILE} (batch did not run test_compliance), skip"
+        )
+        return
+
+    info = Info()
+
+    if should_publish_master_baseline(info):
+        sha = (info.sha or "").strip()
+        if len(sha) == 40:
+            upload_master_result(RESULT_FILE, sha)
+        else:
+            print(f"PromQL compliance hook: skip S3 upload, unexpected SHA [{sha!r}]")
+        print("PromQL compliance hook: master / non-PR run, skip PR comment")
+        return
+
+    if info.pr_number <= 0:
+        print("PromQL compliance hook: not a PR run, skip comment")
+        return
+
+    if not _pr_has_comp_promql(info):
+        print(
+            f"PromQL compliance hook: PR not labeled '{Labels.COMP_PROMQL}', skip comment"
+        )
+        return
+
+    try:
+        new = json.loads(RESULT_FILE.read_text())
+    except Exception as e:
+        print(f"PromQL compliance hook: failed to read result JSON: {e}")
+        traceback.print_exc()
+        return
+
+    commits = master_track_commits(info)
+    base, s3_sha = fetch_baseline_from_s3(commits)
+    if base is not None and s3_sha:
+        baseline_source = f"S3 master `{s3_sha[:9]}`"
+        from_zero = False
+    else:
+        base = dict(_ZERO_BASELINE)
+        baseline_source = "none on S3 (baseline 0 — see note below)"
+        from_zero = True
+        s3_sha = None
+
+    try:
+        new_pct = float(new["pct"])
+        base_pct = float(base["pct"])
+        cur_passed = int(new["passed"])
+        cur_failed = int(new["failed"])
+        cur_unsup = int(new["unsupported"])
+        base_passed = int(base["passed"])
+        base_failed = int(base["failed"])
+        base_unsup = int(base["unsupported"])
+    except (KeyError, TypeError, ValueError) as e:
+        print(
+            "PromQL compliance hook: invalid result or baseline "
+            f"(missing keys or non-numeric pct/counts): {e}"
+        )
+        return
+
+    if not math.isfinite(new_pct) or not math.isfinite(base_pct):
+        print(
+            "PromQL compliance hook: result or baseline has non-finite 'pct'; skip comment"
+        )
+        return
+
+    delta = new_pct - base_pct
+    if abs(delta) < EPS:
+        print("PromQL compliance hook: delta vs baseline is ~0, skip comment")
+        return
+
+    dp = new_pct - base_pct
+    d_passed = cur_passed - base_passed
+    d_failed = cur_failed - base_failed
+    d_unsup = cur_unsup - base_unsup
+
+    body = (
+        "### PromQL Compliance Report\n\n"
+        f"Baseline: {baseline_source}\n\n"
+        "| Metric | Baseline | Current | Δ |\n"
+        "|--------|----------|---------|---|\n"
+        f"| Score | {base_pct:.2f}% | {new_pct:.2f}% | {dp:+.2f}% |\n"
+        f"| Passed | {base_passed} | {cur_passed} | {d_passed:+d} |\n"
+        f"| Failed | {base_failed} | {cur_failed} | {d_failed:+d} |\n"
+        f"| Unsupported | {base_unsup} | {cur_unsup} | {d_unsup:+d} |\n"
+    )
+
+    report_url = ""
+    try:
+        report_url = info.get_job_report_url(latest=False)
+    except Exception:
+        pass
+    if report_url:
+        body += f"\n[CI report for this job]({report_url})\n"
+
+    if from_zero:
+        body += _no_s3_baseline_block()
+    elif delta > EPS and s3_sha:
+        body += _bump_baseline_block_s3(new_pct, base_pct, s3_sha)
+    elif not from_zero and delta < -EPS:
+        body += (
+            "\nNote: score is below the chosen baseline (informational only; "
+            "this job does not enforce a hard floor).\n"
+        )
+
+    try:
+        GH.post_fresh_comment(tag=COMMENT_TAG, body=body)
+    except Exception:
+        print("WARNING: PromQL compliance hook failed to post GitHub comment")
+        traceback.print_exc()
+
+
+def _pr_has_comp_promql(info: Info) -> bool:
+    labels = list(info.pr_labels or [])
+    if Labels.COMP_PROMQL in labels:
+        return True
+    if info.is_local_run or not info.pr_number:
+        return False
+    try:
+        remote_labels = GH.get_pr_labels(pr=info.pr_number)
+        if Labels.COMP_PROMQL in remote_labels:
+            return True
+    except Exception:
+        pass
+    return False
+
+
+if __name__ == "__main__":
+    check()

--- a/ci/jobs/scripts/job_hooks/promql_compliance_s3.py
+++ b/ci/jobs/scripts/job_hooks/promql_compliance_s3.py
@@ -1,0 +1,111 @@
+"""S3 baseline for PromQL compliance (same layout idea as LLVM coverage .info).
+
+Master publishes to (HTTPS, public read):
+  https://clickhouse-builds.s3.amazonaws.com/REFs/master/<sha>/promql_compliance/promql_compliance_result.json
+
+PR jobs walk ``master_track_commits_sha`` (Config Workflow / store_data) and use the first
+object that exists, mirroring ``generate_diff_coverage_report.sh`` for LLVM.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any, Optional, Tuple
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from ci.defs.defs import S3_BUCKET_HTTP_ENDPOINT
+from ci.praktika.info import Info
+from ci.praktika.settings import Settings
+from ci.praktika.s3 import S3
+
+S3_KEY_DIR = "promql_compliance"
+RESULT_NAME = "promql_compliance_result.json"
+UPSTREAM_REPO = "ClickHouse/ClickHouse"
+MASTER_BRANCH = "master"
+URL_TIMEOUT_SEC = 30
+
+
+def _baseline_payload_ok(data: dict[str, Any]) -> bool:
+    """Reject malformed or non-finite S3 JSON (same spirit as strict baseline checks)."""
+    for k in ("pct", "passed", "failed", "unsupported"):
+        if k not in data:
+            return False
+    try:
+        pct = float(data["pct"])
+        if not math.isfinite(pct):
+            return False
+        for k in ("passed", "failed", "unsupported"):
+            int(data[k])
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def result_url_for_master_commit(sha: str) -> str:
+    return (
+        f"https://{S3_BUCKET_HTTP_ENDPOINT}/REFs/{MASTER_BRANCH}/{sha}/"
+        f"{S3_KEY_DIR}/{RESULT_NAME}"
+    )
+
+
+def fetch_baseline_from_s3(commits: list[str]) -> Tuple[Optional[dict[str, Any]], Optional[str]]:
+    """Return (parsed_json, commit_sha_used) or (None, None) if no hit."""
+    for c in commits:
+        c = (c or "").strip()
+        if len(c) != 40:
+            continue
+        url = result_url_for_master_commit(c)
+        try:
+            req = Request(
+                url,
+                headers={"User-Agent": "ClickHouse-CI-promql-compliance"},
+            )
+            with urlopen(req, timeout=URL_TIMEOUT_SEC) as resp:
+                if resp.status != 200:
+                    continue
+                raw = resp.read()
+            data = json.loads(raw.decode("utf-8"))
+            if isinstance(data, dict) and _baseline_payload_ok(data):
+                return data, c
+        except HTTPError as e:
+            if e.code == 404:
+                continue
+        except (URLError, json.JSONDecodeError, OSError, ValueError):
+            continue
+    return None, None
+
+
+def master_track_commits(info: Info) -> list[str]:
+    out = list(info.get_kv_data("master_track_commits_sha") or [])
+    if out:
+        return out
+    return []
+
+
+def upload_master_result(local_path: Path, commit_sha: str) -> Optional[str]:
+    """Upload JSON to canonical S3 path; return public URL or None on failure."""
+    if not local_path.is_file():
+        return None
+    prefix = Settings.S3_ARTIFACT_PATH or ""
+    if not prefix:
+        print("PromQL compliance S3: S3_ARTIFACT_PATH empty, skip upload")
+        return None
+    s3_dir = f"{prefix}/REFs/{MASTER_BRANCH}/{commit_sha}/{S3_KEY_DIR}"
+    try:
+        link = S3.copy_file_to_s3(s3_path=s3_dir, local_path=str(local_path))
+        print(f"PromQL compliance S3: uploaded baseline to {link}")
+        return link
+    except Exception as e:
+        print(f"PromQL compliance S3: upload failed: {e}")
+        return None
+
+
+def should_publish_master_baseline(info: Info) -> bool:
+    return (
+        info.pr_number <= 0
+        and (info.git_branch or "").strip() == MASTER_BRANCH
+        and (info.repo_name or "").strip() == UPSTREAM_REPO
+    )

--- a/ci/jobs/scripts/job_hooks/promql_compliance_s3.py
+++ b/ci/jobs/scripts/job_hooks/promql_compliance_s3.py
@@ -20,6 +20,7 @@ from ci.defs.defs import S3_BUCKET_HTTP_ENDPOINT
 from ci.praktika.info import Info
 from ci.praktika.settings import Settings
 from ci.praktika.s3 import S3
+from ci.praktika.utils import Shell
 
 S3_KEY_DIR = "promql_compliance"
 RESULT_NAME = "promql_compliance_result.json"
@@ -79,10 +80,31 @@ def fetch_baseline_from_s3(commits: list[str]) -> Tuple[Optional[dict[str, Any]]
 
 
 def master_track_commits(info: Info) -> list[str]:
+    """SHAs on master from store_data, or GH merge-base walk (same fallback as llvm_coverage_job)."""
     out = list(info.get_kv_data("master_track_commits_sha") or [])
     if out:
         return out
-    return []
+    if info.is_local_run or info.pr_number <= 0:
+        return []
+    sha = (info.sha or "").strip()
+    if len(sha) != 40:
+        return []
+    try:
+        merge_base = Shell.get_output(
+            f"gh api repos/ClickHouse/ClickHouse/compare/master...{sha} -q .merge_base_commit.sha",
+            strict=False,
+            verbose=False,
+        ).strip()
+        if not merge_base:
+            return []
+        raw = Shell.get_output(
+            f"gh api 'repos/ClickHouse/ClickHouse/commits?sha={merge_base}&per_page=30' -q '.[].sha'",
+            strict=False,
+            verbose=False,
+        )
+        return [ln.strip() for ln in raw.splitlines() if ln.strip()]
+    except Exception:
+        return []
 
 
 def upload_master_result(local_path: Path, commit_sha: str) -> Optional[str]:

--- a/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
@@ -84,6 +84,9 @@ class Labels:
     CI_FUNCTIONAL = "ci-functional-test"
     CI_TOOLCHAIN = "ci-toolchain"
 
+    # Gates the PromQL compliance PR comment from integration-test post-hooks (see promql_compliance_hook.py).
+    COMP_PROMQL = "comp-promql"
+
     # automatic backport for critical bug fixes
     AUTO_BACKPORT = {"pr-critical-bugfix"}
 

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -191,7 +191,7 @@ class GH:
                 temp_file.write(comment_body)
                 temp_file_path = temp_file.name
 
-            cmd = f"gh pr comment {pr} --body-file {temp_file_path}"
+            cmd = f"gh pr comment {pr} --repo {repo} --body-file {temp_file_path}"
             return cls.do_command_with_retries(cmd)
         finally:
             if temp_file_path and os.path.exists(temp_file_path):
@@ -259,7 +259,9 @@ class GH:
             ) as temp_file:
                 temp_file.write(full_body)
                 temp_file_path = temp_file.name
-            cmd = f"gh pr comment {pr} --body-file {temp_file_path}"
+            # Pass --repo so gh does not probe git remotes (Docker mounts can hit
+            # "detected dubious ownership" and fail comment creation).
+            cmd = f"gh pr comment {pr} --repo {repo} --body-file {temp_file_path}"
             return cls.do_command_with_retries(cmd)
         finally:
             if temp_file_path and os.path.exists(temp_file_path):
@@ -356,7 +358,9 @@ class GH:
             res = cls.do_command_with_retries(cmd)
         else:
             if not only_update:
-                cmd = f"gh pr comment {pr} --body-file {temp_file_path}"
+                # Pass --repo so gh does not probe git remotes (Docker mounts can hit
+                # "detected dubious ownership" and fail comment creation).
+                cmd = f"gh pr comment {pr} --repo {repo} --body-file {temp_file_path}"
                 print(f"Create new comment")
                 res = cls.do_command_with_retries(cmd)
             else:

--- a/tests/integration/test_prometheus_protocols/test_compliance.py
+++ b/tests/integration/test_prometheus_protocols/test_compliance.py
@@ -577,9 +577,9 @@ def test_promql_compliance():
     print(f"             {result.passed} / {result.total} passed")
     print("=" * 80)
 
+    categories = {}  # key -> [(query, reason)]
     if result.failures:
         import re as _re
-        categories = {}  # key -> [(query, reason)]
         for query, reason in result.failures:
             if "UNSUPPORTED:" in reason:
                 m = _re.search(r"(Function \S+ is not implemented|"
@@ -620,5 +620,20 @@ def test_promql_compliance():
                     r_short = r if len(r) <= 100 else r[:97] + "..."
                     print(f"             {q_short}")
                     print(f"               → {r_short}")
+
+    breakdown = {cat: len(entries) for cat, entries in categories.items()}
+    out_path = os.environ.get("COMPLIANCE_RESULT_FILE")
+    if out_path:
+        record = {
+            "passed": result.passed,
+            "failed": result.failed,
+            "unsupported": result.unsupported,
+            "total": result.total,
+            "pct": round(result.score, 4),
+            "breakdown": breakdown,
+        }
+        with open(out_path, "w") as out_f:
+            json.dump(record, out_f, indent=2)
+            out_f.write("\n")
 
     print()

--- a/tests/integration/test_prometheus_protocols/update_compliance_baseline.py
+++ b/tests/integration/test_prometheus_protocols/update_compliance_baseline.py
@@ -39,8 +39,8 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-_THIS_DIR = Path(__file__).resolve().parent
-_REPO_ROOT = _THIS_DIR.parent.parent.parent
+# Repo root: file is under tests/integration/test_prometheus_protocols/; parents[3] is repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
 _TESTS_INTEGRATION = _REPO_ROOT / "tests" / "integration"
 _CI_TMP = _REPO_ROOT / "ci" / "tmp"
 _DEFAULT_OUT = _CI_TMP / "promql_compliance_baseline_export.json"

--- a/tests/integration/test_prometheus_protocols/update_compliance_baseline.py
+++ b/tests/integration/test_prometheus_protocols/update_compliance_baseline.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+Run :func:`test_promql_compliance` locally and write a JSON snapshot of scores.
+
+CI compares PRs to the latest matching object on S3 under
+``REFs/master/<sha>/promql_compliance/promql_compliance_result.json``; this script
+is for local inspection or attaching a file to a discussion — not for a committed
+baseline file.
+
+Requirements
+
+- Docker (the integration test starts containers).
+- A fresh ``clickhouse`` binary, e.g. ``ninja -C build clickhouse`` on an up-to-date tree.
+
+Example
+
+.. code-block:: bash
+
+   export CLICKHOUSE_TESTS_SERVER_BIN_PATH="$PWD/build/programs/clickhouse"
+   ./tests/integration/test_prometheus_protocols/update_compliance_baseline.py \\
+       --capture-log /tmp/promql_compliance_refresh.log
+
+Or pass the binary explicitly::
+
+   ./tests/integration/test_prometheus_protocols/update_compliance_baseline.py \\
+       --binary "$PWD/build/programs/clickhouse" --dry-run
+
+By default writes JSON to ``ci/tmp/promql_compliance_baseline_export.json`` (override
+with ``--output``). ``--dry-run`` prints JSON to stdout only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_THIS_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _THIS_DIR.parent.parent.parent
+_TESTS_INTEGRATION = _REPO_ROOT / "tests" / "integration"
+_CI_TMP = _REPO_ROOT / "ci" / "tmp"
+_DEFAULT_OUT = _CI_TMP / "promql_compliance_baseline_export.json"
+_DEFAULT_NOTE = (
+    "Exported by tests/integration/test_prometheus_protocols/update_compliance_baseline.py "
+    "from a local test_promql_compliance run."
+)
+
+
+def _git_short_sha() -> str:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=str(_REPO_ROOT),
+            text=True,
+        ).strip()
+        return out[:12]
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "local"
+
+
+def _resolve_binary(path: str | None) -> Path:
+    if path:
+        p = Path(path).resolve()
+        if not p.is_file():
+            sys.exit(f"ERROR: binary not found: {p}")
+        return p
+    env = os.environ.get("CLICKHOUSE_TESTS_SERVER_BIN_PATH", "").strip()
+    if env:
+        p = Path(env).resolve()
+        if p.is_file():
+            return p
+    cand = _REPO_ROOT / "build" / "programs" / "clickhouse"
+    if cand.is_file():
+        return cand.resolve()
+    sys.exit(
+        "ERROR: set --binary or CLICKHOUSE_TESTS_SERVER_BIN_PATH to a clickhouse executable, "
+        f"or build {cand}"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--binary",
+        help="Path to clickhouse server binary (default: env or build/programs/clickhouse)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=_DEFAULT_OUT,
+        metavar="PATH",
+        help=f"Write JSON here (default: {_DEFAULT_OUT})",
+    )
+    parser.add_argument(
+        "--capture-log",
+        type=Path,
+        metavar="PATH",
+        help="Append pytest stdout/stderr to this file (tee)",
+    )
+    parser.add_argument(
+        "--note",
+        default=_DEFAULT_NOTE,
+        help="Value for the note field in the JSON",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print JSON to stdout only; do not write --output",
+    )
+    args = parser.parse_args()
+
+    binary = _resolve_binary(args.binary)
+    _CI_TMP.mkdir(parents=True, exist_ok=True)
+    result_path = _CI_TMP / "compliance_baseline_refresh_result.json"
+    if result_path.exists():
+        result_path.unlink()
+
+    env = os.environ.copy()
+    env["COMPLIANCE_RESULT_FILE"] = str(result_path)
+    env["CLICKHOUSE_TESTS_SERVER_BIN_PATH"] = str(binary)
+    env["CLICKHOUSE_TESTS_BASE_CONFIG_DIR"] = str(_REPO_ROOT / "programs" / "server")
+    env.setdefault("PYTEST_TIMEOUT", os.environ.get("PYTEST_TIMEOUT", "3600"))
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "test_prometheus_protocols/test_compliance.py::test_promql_compliance",
+        "-vv",
+        "--tb=short",
+    ]
+    print(f"Running (cwd={_TESTS_INTEGRATION}): {' '.join(cmd)}", flush=True)
+    print(f"COMPLIANCE_RESULT_FILE={result_path}", flush=True)
+    print(f"CLICKHOUSE_TESTS_SERVER_BIN_PATH={binary}", flush=True)
+
+    log_fp = None
+    try:
+        if args.capture_log:
+            args.capture_log.parent.mkdir(parents=True, exist_ok=True)
+            append = (
+                args.capture_log.exists() and args.capture_log.stat().st_size > 0
+            )
+            log_fp = open(args.capture_log, "a", encoding="utf-8")
+            if append:
+                log_fp.write("\n" + "=" * 72 + "\n")
+
+        proc = subprocess.run(
+            cmd,
+            cwd=str(_TESTS_INTEGRATION),
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        combined = proc.stdout + ("\n" + proc.stderr if proc.stderr else "")
+        print(combined, end="" if combined.endswith("\n") else "\n", flush=True)
+        if log_fp:
+            log_fp.write(combined)
+            log_fp.flush()
+    finally:
+        if log_fp:
+            log_fp.close()
+
+    if proc.returncode != 0:
+        sys.exit(f"ERROR: pytest exited with code {proc.returncode}")
+
+    if not result_path.is_file():
+        sys.exit(f"ERROR: expected result file at {result_path}")
+
+    record = json.loads(result_path.read_text())
+    for key in ("passed", "failed", "unsupported", "total", "pct"):
+        if key not in record:
+            sys.exit(f"ERROR: result JSON missing key {key!r}")
+
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    baseline = {
+        "passed": record["passed"],
+        "failed": record["failed"],
+        "unsupported": record["unsupported"],
+        "total": record["total"],
+        "pct": record["pct"],
+        "commit": _git_short_sha(),
+        "updated_utc": now,
+        "note": args.note,
+    }
+    if "breakdown" in record:
+        baseline["breakdown"] = record["breakdown"]
+
+    text = json.dumps(baseline, indent=2) + "\n"
+    if args.dry_run:
+        print(text, end="")
+        print("\n(dry-run: no file written)", flush=True)
+        return
+
+    out = args.output.resolve()
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(text)
+    print(f"Wrote {out}", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR introduces a sticky GitHub comment on pull requests, modeled on the LLVM coverage PR comment: one tagged comment that is refreshed in place, a Baseline / Current / Δ markdown table, and an optional link to the integration job report. Here the metrics are PromQL compliance (score %, passed / failed / unsupported counts).

### When the comment is posted

Only if all of the following hold:

- The run is a pull request (the hook does not post this comment on `master`; it only uploads there—see below).
- The PR has the `comp-promql` label (`GH.get_pr_labels` is used if labels are not in the job environment; `gh pr comment` paths use explicit `--repo`).
- This integration batch produced `ci/tmp/promql_compliance_result.json` via `COMPLIANCE_RESULT_FILE` (the batch that runs `test_promql_compliance`).
- The measured `pct` differs from the chosen baseline by more than a small epsilon, and `pct` is finite (otherwise the hook skips posting).

On `master` (upstream repo), the hook uploads that JSON to `clickhouse-builds` at `REFs/master/<sha>/promql_compliance/promql_compliance_result.json`. On PRs, the baseline is the first such object found when walking `master_track_commits_sha` (same merge-line walk idea as LLVM coverage’s S3 baseline). If none exists yet, the table uses zero as baseline and the comment includes a short note that no master snapshot is on S3 yet.

### Example (illustrative)

````markdown
### PromQL Compliance Report

Baseline: S3 master `a1b2c3d4e`

| Metric | Baseline | Current | Δ |
|--------|----------|---------|---|
| Score | 72.50% | 74.00% | +1.50% |
| Passed | 290 | 296 | +6 |
| Failed | 85 | 79 | -6 |
| Unsupported | 25 | 25 | +0 |

[CI report for this job](https://example.invalid/job)

### Baseline update

This run reports 74.00% vs master baseline 72.50% ([`a1b2c3d4`](https://clickhouse-builds.s3.amazonaws.com/REFs/master/a1b2c3d4e5f6789012345678901234567890abcdef/promql_compliance/promql_compliance_result.json)). Merging to `master` will publish a new S3 object from the integration run so later PRs compare against it.
````

Also introduced: the `promql_compliance_s3` helper for those URLs and uploads, integration post-hooks that run the hook after each batch, and `update_compliance_baseline.py` as a local helper that runs the compliance pytest and writes `ci/tmp/promql_compliance_baseline_export.json` (overridable with `--output`).

### Changelog category

- Not for changelog (changelog entry is not required)

### Changelog entry

- N/A



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.452`
<!-- ch-version-info:end -->