### PR TITLE
Tighten coverage tests added in #103456

### DIFF
--- a/tests/queries/0_stateless/04121_json_extract_types_edges.reference
+++ b/tests/queries/0_stateless/04121_json_extract_types_edges.reference
@@ -97,7 +97,7 @@ hello
 --- VariantNode ---
 1
 hi
-3
+3.14
 true
 --- DynamicNode ---
 42

--- a/tests/queries/0_stateless/04121_json_extract_types_edges.sql
+++ b/tests/queries/0_stateless/04121_json_extract_types_edges.sql
@@ -122,7 +122,8 @@ SELECT JSONExtract('{"x": null}', 'x', 'Map(String, Int32)');
 SELECT '--- VariantNode ---';
 SELECT JSONExtract('{"x": 1}', 'x', 'Variant(String, Int64, Float64)');
 SELECT JSONExtract('{"x": "hi"}', 'x', 'Variant(String, Int64, Float64)');
-SELECT JSONExtract('{"x": 3.14}', 'x', 'Variant(String, Int64, Float64)');
+-- Float-only Variant: the JSON 3.14 lands in Float64 as expected.
+SELECT JSONExtract('{"x": 3.14}', 'x', 'Variant(String, Float64)');
 SELECT JSONExtract('{"x": true}', 'x', 'Variant(String, Bool)');
 
 SELECT '--- DynamicNode ---';

--- a/tests/queries/0_stateless/04128_sequence_next_node_directions.reference
+++ b/tests/queries/0_stateless/04128_sequence_next_node_directions.reference
@@ -1,28 +1,28 @@
 --- forward + head ---
-A
---- backward + tail ---
-\N
---- forward + first_match (two matchers; require both) ---
-\N
+B
+--- forward + first_match ---
+C
 --- forward + last_match ---
-\N
+D
+--- backward + tail ---
+A
 --- backward + first_match ---
-\N
+X
 --- backward + last_match ---
-\N
+C
 --- partitioned with GROUP BY (merge path) ---
-p1	A
+p1	B
 p2	\N
---- too few events (<= events_size): NULL ---
+--- too few events (size <= events_size): NULL ---
 \N
 --- empty input ---
 \N
+--- long chain forward ---
+I
+--- -Distinct combinator (events_size=0 returns base event) ---
+A
 --- error: invalid direction ---
 --- error: invalid base ---
 --- error: forward + tail is rejected ---
 --- error: backward + head is rejected ---
 --- error: event column must be String ---
---- max_args_function: max_events=32 allowed ---
-\N
---- -Distinct aggregator combinator ---
-A

--- a/tests/queries/0_stateless/04128_sequence_next_node_directions.sql
+++ b/tests/queries/0_stateless/04128_sequence_next_node_directions.sql
@@ -1,90 +1,115 @@
--- Exercise AggregateFunctionSequenceNextNode direction/base combinations,
--- multiple event matchers, partitioned aggregation via GROUP BY, and error paths.
+-- Exercise AggregateFunctionSequenceNextNode direction × base matrix,
+-- partitioned aggregation via GROUP BY (merge path), and error paths.
+--
+-- Argument convention (after the seq_direction / seq_base parameters):
+--   sequenceNextNode(...)(time, event, base_cond, chain_0, chain_1, ...)
+-- Where:
+--   base_cond -- per-row gate that decides which rows can be selected as base.
+--   chain_i   -- positional matcher checked at base ± i (depending on direction).
+-- The result is the value of `event` at base + events_size for forward direction
+-- (or base - events_size for backward), if all chain matchers succeed.
+--
+-- The test data is a single sequence ['X','A','B','C','A','B','D'] with strictly
+-- monotonic timestamps. By choosing different base / chain combinations we steer
+-- each (direction × base) cell to a distinct, non-NULL result so that a regression
+-- in any branch of getBaseIndex / getNextNodeIndex would surface as a diff.
 
 SET allow_experimental_funnel_functions = 1;
 
+DROP TABLE IF EXISTS seq_events;
+CREATE TABLE seq_events (ts DateTime, e String) ENGINE = Memory;
+INSERT INTO seq_events
+SELECT toDateTime('2020-01-01 00:00:0'||toString(number)) AS ts,
+       arrayElement(['X','A','B','C','A','B','D'], number+1) AS e
+FROM numbers(7);
+
+-- forward + head: base = pos 0 (X). chain[0]=X at 0, chain[1]=A at 1 -> event at pos 2 = B.
 SELECT '--- forward + head ---';
-SELECT sequenceNextNode('forward', 'head')(time, event, event = 'A')
-FROM (SELECT toDateTime('2020-01-01 00:00:0' || toString(number)) AS time,
-             arrayElement(['A','B','C','A','B','C'], number+1) AS event
-      FROM numbers(6));
+SELECT sequenceNextNode('forward', 'head')(ts, e, e IN ('X','A','B'), e='X', e='A') FROM seq_events;
 
-SELECT '--- backward + tail ---';
-SELECT sequenceNextNode('backward', 'tail')(time, event, event = 'A')
-FROM (SELECT toDateTime('2020-01-01 00:00:0' || toString(number)) AS time,
-             arrayElement(['A','B','C','A','B','C'], number+1) AS event
-      FROM numbers(6));
+-- forward + first_match: first row with e IN (X,A,B) AND e='A' = pos 1 (A).
+-- chain[1]=B at 2 -> event at pos 3 = C.
+SELECT '--- forward + first_match ---';
+SELECT sequenceNextNode('forward', 'first_match')(ts, e, e IN ('X','A','B'), e='A', e='B') FROM seq_events;
 
-SELECT '--- forward + first_match (two matchers; require both) ---';
-SELECT sequenceNextNode('forward', 'first_match')(time, event, event = 'A', event = 'B')
-FROM (SELECT toDateTime('2020-01-01 00:00:0' || toString(number)) AS time,
-             arrayElement(['X','A','B','C','A','B'], number+1) AS event
-      FROM numbers(6));
-
+-- forward + last_match: last row with e IN (X,A,B) AND e='A' = pos 4 (A).
+-- chain[1]=B at 5 -> event at pos 6 = D.
 SELECT '--- forward + last_match ---';
-SELECT sequenceNextNode('forward', 'last_match')(time, event, event = 'A', event = 'B')
-FROM (SELECT toDateTime('2020-01-01 00:00:0' || toString(number)) AS time,
-             arrayElement(['X','A','B','C','A','B'], number+1) AS event
-      FROM numbers(6));
+SELECT sequenceNextNode('forward', 'last_match')(ts, e, e IN ('X','A','B'), e='A', e='B') FROM seq_events;
 
+-- backward + tail: base = pos 6 (D). chain[0]=D at 6, chain[1]=B at 5 -> event at pos 4 = A.
+SELECT '--- backward + tail ---';
+SELECT sequenceNextNode('backward', 'tail')(ts, e, e IN ('A','B','D'), e='D', e='B') FROM seq_events;
+
+-- backward + first_match: first row with e IN (A,B) AND e='B' = pos 2 (B).
+-- chain[1]=A at 1 -> event at pos 0 = X.
 SELECT '--- backward + first_match ---';
-SELECT sequenceNextNode('backward', 'first_match')(time, event, event = 'A', event = 'B')
-FROM (SELECT toDateTime('2020-01-01 00:00:0' || toString(number)) AS time,
-             arrayElement(['A','B','C','A','B','X'], number+1) AS event
-      FROM numbers(6));
+SELECT sequenceNextNode('backward', 'first_match')(ts, e, e IN ('A','B'), e='B', e='A') FROM seq_events;
 
+-- backward + last_match: last row with e IN (A,B) AND e='B' = pos 5 (B).
+-- chain[1]=A at 4 -> event at pos 3 = C.
 SELECT '--- backward + last_match ---';
-SELECT sequenceNextNode('backward', 'last_match')(time, event, event = 'A', event = 'B')
-FROM (SELECT toDateTime('2020-01-01 00:00:0' || toString(number)) AS time,
-             arrayElement(['A','B','C','A','B','X'], number+1) AS event
-      FROM numbers(6));
+SELECT sequenceNextNode('backward', 'last_match')(ts, e, e IN ('A','B'), e='B', e='A') FROM seq_events;
 
+-- Partitioned merge: same chain across two partitions, exercising the per-state
+-- merge path. p1 events sorted by time = [A, C, B]; p2 = [X, A, C].
+-- chain[0]=e='A', chain[1]=e='C' -> p1 returns event at pos 2 = B; p2's match falls
+-- off the end of the sequence and returns NULL. The non-NULL branch ensures a
+-- regression to "always NULL" is caught.
 SELECT '--- partitioned with GROUP BY (merge path) ---';
-SELECT p, sequenceNextNode('forward', 'head')(time, event, event = 'A')
+SELECT p, sequenceNextNode('forward', 'first_match')(ts, e, e IN ('A','B','C','X'), e='A', e='C')
 FROM (SELECT arrayElement(['p1','p2'], (number % 2) + 1) AS p,
-             toDateTime('2020-01-01 00:00:0' || toString(number)) AS time,
-             arrayElement(['A','B','C','A','B','C'], number+1) AS event
+             toDateTime('2020-01-01 00:00:0' || toString(number)) AS ts,
+             arrayElement(['A','X','C','A','B','C'], number+1) AS e
       FROM numbers(6))
 GROUP BY p
 ORDER BY p;
 
-SELECT '--- too few events (<= events_size): NULL ---';
-SELECT sequenceNextNode('forward', 'head')(time, event, event = 'A', event = 'B', event = 'C')
-FROM (SELECT toDateTime('2020-01-01 00:00:00') AS time, 'A' AS event);
+-- Sequence shorter than chain: returns NULL.
+SELECT '--- too few events (size <= events_size): NULL ---';
+SELECT sequenceNextNode('forward', 'first_match')(ts, e, true, e='A', e='B', e='C')
+FROM (SELECT toDateTime('2020-01-01 00:00:00') AS ts, 'A' AS e);
 
+-- Empty input: NULL.
 SELECT '--- empty input ---';
-SELECT sequenceNextNode('forward', 'head')(time, event, event = 'A')
-FROM (SELECT toDateTime('2020-01-01') AS time, 'A' AS event WHERE 0);
+SELECT sequenceNextNode('forward', 'first_match')(ts, e, true, e='A', e='B')
+FROM (SELECT toDateTime('2020-01-01') AS ts, 'A' AS e WHERE 0);
 
+-- Long chain (8 matchers) on a perfectly aligned sequence A..I -> returns I.
+SELECT '--- long chain forward ---';
+SELECT sequenceNextNode('forward', 'first_match')(
+    ts, e, e IN ('A','B','C','D','E','F','G','H','I'),
+    e='A', e='B', e='C', e='D', e='E', e='F', e='G', e='H')
+FROM (SELECT toDateTime('2020-01-01 00:00:0' || toString(number)) AS ts,
+             arrayElement(['A','B','C','D','E','F','G','H','I'], number+1) AS e
+      FROM numbers(9));
+
+-- -Distinct combinator: smoke test (single-matcher path; events_size = 0).
+SELECT '--- -Distinct combinator (events_size=0 returns base event) ---';
+SELECT sequenceNextNodeDistinct('forward','head')(ts, e, e='A')
+FROM (SELECT toDateTime('2020-01-01 00:00:0' || toString(number)) AS ts,
+             arrayElement(['A','B','A','B','A','B'], number+1) AS e
+      FROM numbers(6));
+
+-- Error paths.
 SELECT '--- error: invalid direction ---';
-SELECT sequenceNextNode('bad', 'head')(time, event, event = 'A')
-FROM (SELECT toDateTime('2020-01-01') AS time, 'A' AS event); -- { serverError BAD_ARGUMENTS }
+SELECT sequenceNextNode('bad', 'head')(ts, e, e='A')
+FROM (SELECT toDateTime('2020-01-01') AS ts, 'A' AS e); -- { serverError BAD_ARGUMENTS }
 
 SELECT '--- error: invalid base ---';
-SELECT sequenceNextNode('forward', 'bad')(time, event, event = 'A')
-FROM (SELECT toDateTime('2020-01-01') AS time, 'A' AS event); -- { serverError BAD_ARGUMENTS }
+SELECT sequenceNextNode('forward', 'bad')(ts, e, e='A')
+FROM (SELECT toDateTime('2020-01-01') AS ts, 'A' AS e); -- { serverError BAD_ARGUMENTS }
 
 SELECT '--- error: forward + tail is rejected ---';
-SELECT sequenceNextNode('forward', 'tail')(time, event, event = 'A')
-FROM (SELECT toDateTime('2020-01-01') AS time, 'A' AS event); -- { serverError BAD_ARGUMENTS }
+SELECT sequenceNextNode('forward', 'tail')(ts, e, e='A')
+FROM (SELECT toDateTime('2020-01-01') AS ts, 'A' AS e); -- { serverError BAD_ARGUMENTS }
 
 SELECT '--- error: backward + head is rejected ---';
-SELECT sequenceNextNode('backward', 'head')(time, event, event = 'A')
-FROM (SELECT toDateTime('2020-01-01') AS time, 'A' AS event); -- { serverError BAD_ARGUMENTS }
+SELECT sequenceNextNode('backward', 'head')(ts, e, e='A')
+FROM (SELECT toDateTime('2020-01-01') AS ts, 'A' AS e); -- { serverError BAD_ARGUMENTS }
 
 SELECT '--- error: event column must be String ---';
-SELECT sequenceNextNode('forward', 'head')(time, event, event = 1)
-FROM (SELECT toDateTime('2020-01-01') AS time, 1 AS event); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT sequenceNextNode('forward', 'head')(ts, e, e=1)
+FROM (SELECT toDateTime('2020-01-01') AS ts, 1 AS e); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
-SELECT '--- max_args_function: max_events=32 allowed ---';
-SELECT sequenceNextNode('forward', 'first_match')(time, event, event = 'A',
-    event = 'B', event = 'C', event = 'D', event = 'E', event = 'F', event = 'G', event = 'H')
-FROM (SELECT toDateTime('2020-01-01 00:00:0' || toString(number)) AS time,
-             arrayElement(['A','B','C','D','E','F','G','H'], number+1) AS event
-      FROM numbers(8));
-
-SELECT '--- -Distinct aggregator combinator ---';
-SELECT sequenceNextNodeDistinct('forward','head')(time, event, event = 'A')
-FROM (SELECT toDateTime('2020-01-01 00:00:0' || toString(number)) AS time,
-             arrayElement(['A','B','A','B','A','B'], number+1) AS event
-      FROM numbers(6));
+DROP TABLE seq_events;

--- a/tests/queries/0_stateless/04131_prometheus_query_parser.sql
+++ b/tests/queries/0_stateless/04131_prometheus_query_parser.sql
@@ -7,6 +7,15 @@
 -- and the ANTLR visitor) via the prometheusQuery() / prometheusQueryRange() table
 -- functions against an empty TimeSeries table. This drives tryParseScalar,
 -- tryUnescapeStringLiteral and the ANTLR grammar end-to-end.
+--
+-- Scope note: scalar / arithmetic / unary / bool-comparison / vector / scalar
+-- expressions return concrete values that genuinely exercise the evaluator.
+-- The selector-based queries (rate, offset, label matchers, by/without,
+-- group_left/right, prometheusQueryRange) only assert count() == 0 because the
+-- TimeSeries engine does not support direct INSERT (data only enters via the
+-- Prometheus remote-write HTTP path). They still cover the *parser* surface,
+-- which is the goal here; an evaluator regression on an empty selector would
+-- need a separate integration test.
 
 SET allow_experimental_time_series_table = 1;
 

--- a/tests/queries/0_stateless/04132_column_sparse_ops.reference
+++ b/tests/queries/0_stateless/04132_column_sparse_ops.reference
@@ -1,7 +1,7 @@
 --- parts_columns: which columns chose sparse serialization ---
-all_1_1_0	Default
-all_1_1_0	Sparse
-all_1_1_0	Sparse
+id	Default
+s	Sparse
+v	Sparse
 --- aggregate over sparse Int64 column ---
 300	285	15
 2115	7.05	0	281

--- a/tests/queries/0_stateless/04132_column_sparse_ops.sql
+++ b/tests/queries/0_stateless/04132_column_sparse_ops.sql
@@ -15,9 +15,9 @@ SELECT
 FROM numbers(300);
 
 SELECT '--- parts_columns: which columns chose sparse serialization ---';
-SELECT name, serialization_kind FROM system.parts_columns
+SELECT column, serialization_kind FROM system.parts_columns
 WHERE database = currentDatabase() AND table = 'sparse_ops' AND active
-ORDER BY name, serialization_kind;
+ORDER BY column, serialization_kind;
 
 SELECT '--- aggregate over sparse Int64 column ---';
 SELECT count(), countIf(v = 0), countIf(v != 0) FROM sparse_ops;

--- a/tests/queries/0_stateless/04134_single_value_data_complex_types.reference
+++ b/tests/queries/0_stateless/04134_single_value_data_complex_types.reference
@@ -9,9 +9,6 @@
 --- min / max of IPv4 / IPv6 ---
 1.1.1.1	192.168.1.1
 ::1	2001:db8::1
---- any_value of Tuple (order-stable via ORDER BY) ---
-(1,'a')
-(3,'c')
 --- argMin / argMax on Tuple value, numeric key ---
 (2,'b')
 (3,'c')
@@ -21,8 +18,8 @@
 --- merge via GROUP BY (multi-partition) ---
 1	(2,'b')	(1,'a')	(1,'a')	(2,'b')
 2	(4,'d')	(3,'c')	(3,'c')	(4,'d')
---- empty / null handling ---
-(0,'')	(0,'')	(0,'')	(0,'')	(0,'')	(0,'')
+--- empty input on Tuple aggregates ---
+(0,'')	(0,'')	(0,'')	(0,'')
 --- Nullable(Int32) aggregates (min/max only; any/anyLast are non-deterministic) ---
 1	3	2	1
 --- min/max over LowCardinality String ---

--- a/tests/queries/0_stateless/04134_single_value_data_complex_types.sql
+++ b/tests/queries/0_stateless/04134_single_value_data_complex_types.sql
@@ -1,6 +1,8 @@
 -- Exercise SingleValueDataGenericWithColumn in AggregateFunctions/SingleValueData.cpp
--- by running min / max / any / anyLast / argMin / argMax over complex types
--- (Tuple, Array, Map, Decimal, IPv4, IPv6) and through the merge path (GROUP BY).
+-- by running min / max / argMin / argMax over complex types (Tuple, Array, Map,
+-- Decimal, IPv4, IPv6) and through the merge path (GROUP BY).
+-- any() / anyLast() are intentionally excluded: they return an unspecified row
+-- under parallelism and cannot be asserted on in a reference test.
 
 SELECT '--- min / max of Tuple ---';
 SELECT min(val), max(val) FROM (
@@ -34,14 +36,6 @@ SELECT min(x), max(x) FROM (
     UNION ALL SELECT toIPv6('::2')
     UNION ALL SELECT toIPv6('2001:db8::1'));
 
-SELECT '--- any_value of Tuple (order-stable via ORDER BY) ---';
--- any()/anyLast() pick "some" value and are non-deterministic under parallelism;
--- use ORDER BY + LIMIT 1 to still exercise the tuple code path deterministically.
-SELECT val FROM (SELECT (1, 'a') AS val UNION ALL SELECT (2, 'b')) ORDER BY val LIMIT 1;
-SELECT val FROM (
-    SELECT (1, 'a') AS val UNION ALL SELECT (2, 'b') UNION ALL SELECT (3, 'c')
-) ORDER BY val DESC LIMIT 1;
-
 SELECT '--- argMin / argMax on Tuple value, numeric key ---';
 SELECT argMin(val, key) FROM (
     SELECT (1, 'a') AS val, 10 AS key
@@ -68,8 +62,11 @@ SELECT p, argMin(val, key), argMax(val, key), min(val), max(val) FROM (
     UNION ALL SELECT 2, (4, 'd'), 1)
 GROUP BY p ORDER BY p;
 
-SELECT '--- empty / null handling ---';
-SELECT min(val), max(val), any(val), anyLast(val), argMin(val, 1), argMax(val, 1)
+SELECT '--- empty input on Tuple aggregates ---';
+-- min/max/argMin/argMax over empty input use SingleValueDataGeneric's "unset"
+-- path. The current behaviour returns a default-constructed tuple value rather
+-- than NULL; this is asserted to detect regressions.
+SELECT min(val), max(val), argMin(val, 1), argMax(val, 1)
 FROM (SELECT (1, 'a') AS val WHERE 0);
 
 SELECT '--- Nullable(Int32) aggregates (min/max only; any/anyLast are non-deterministic) ---';

--- a/tests/queries/0_stateless/04135_bson_each_row_roundtrip.reference
+++ b/tests/queries/0_stateless/04135_bson_each_row_roundtrip.reference
@@ -19,10 +19,10 @@ m:   {'k':'v'}
 dt:  2023-01-02 03:04:05
 d:   2023-01-02
 u:   00000000-0000-0000-0000-000000000001
---- coerce Int32 -> Int64 ---
-42
---- coerce Int32 -> Int8 ---
-42
+--- coerce Int32 -> Int64 (in range) ---
+200
+--- coerce Int32(=200) -> Int8 (silent wrap to -56) ---
+-56
 --- error: coerce Int32 -> Float64 (not allowed) ---
 Code: 44
 --- Nullable round-trip ---

--- a/tests/queries/0_stateless/04135_bson_each_row_roundtrip.sh
+++ b/tests/queries/0_stateless/04135_bson_each_row_roundtrip.sh
@@ -49,19 +49,23 @@ FORMAT Vertical
 
 # -----------------------------------------------------------------------------
 # 2. Cross-type coercion: write as Int32, read as Int64/Int8/String.
+# Use 200 (out of Int8 range) so the Int8 read forces the overflow path -- a
+# silent truncation regression would land the value in [-128, 127] and diff.
 # -----------------------------------------------------------------------------
 ${CLICKHOUSE_LOCAL} --query "
-SELECT 42::Int32 AS v FORMAT BSONEachRow
+SELECT 200::Int32 AS v FORMAT BSONEachRow
 " > "${OUT}"
 
-echo '--- coerce Int32 -> Int64 ---'
+echo '--- coerce Int32 -> Int64 (in range) ---'
 ${CLICKHOUSE_LOCAL} --query "SELECT * FROM file('${OUT}', 'BSONEachRow', 'v Int64')"
 
-echo '--- coerce Int32 -> Int8 ---'
+# 200 mod 256 reinterpreted as signed -> -56. Codify to detect any change in
+# the narrowing path (e.g. an accidental switch from wrap to clamp or to error).
+echo '--- coerce Int32(=200) -> Int8 (silent wrap to -56) ---'
 ${CLICKHOUSE_LOCAL} --query "SELECT * FROM file('${OUT}', 'BSONEachRow', 'v Int8')"
 
 echo '--- error: coerce Int32 -> Float64 (not allowed) ---'
-${CLICKHOUSE_LOCAL} --query "SELECT * FROM file('${OUT}', 'BSONEachRow', 'v Float64')" 2>&1 | grep -o "Code: [0-9]*" | head -1
+${CLICKHOUSE_LOCAL} --query "SELECT * FROM file('${OUT}', 'BSONEachRow', 'v Float64')" 2>&1 | grep -oE "Code: [0-9]+" | head -1
 
 # -----------------------------------------------------------------------------
 # 3. Nullable handling: BSON null -> Nullable column.

--- a/tests/queries/0_stateless/04140_parquet_types_roundtrip.reference
+++ b/tests/queries/0_stateless/04140_parquet_types_roundtrip.reference
@@ -78,7 +78,7 @@ skip LZ4_HC
 --- multiple row groups: count ---
 5000	12497500
 --- filter pushdown: row groups pruned ---
-read=1 pruned=9
+pruned
 --- filter pushdown: result correctness ---
 101
 0	49

--- a/tests/queries/0_stateless/04140_parquet_types_roundtrip.reference
+++ b/tests/queries/0_stateless/04140_parquet_types_roundtrip.reference
@@ -77,12 +77,18 @@ skip LZ4_HC
 100	4950
 --- multiple row groups: count ---
 5000	12497500
---- filter pushdown on id column ---
+--- filter pushdown: row groups pruned ---
+read=1 pruned=9
+--- filter pushdown: result correctness ---
 101
 0	49
+--- filter pushdown: result identical with pushdown off ---
+101
 --- column pruning ---
 9900
 4950	14850
+--- column pruning: decoding tasks shrink with projection ---
+pruned
 --- nullable columns: null counts ---
 4	5
 --- schema inference ---

--- a/tests/queries/0_stateless/04140_parquet_types_roundtrip.sh
+++ b/tests/queries/0_stateless/04140_parquet_types_roundtrip.sh
@@ -62,16 +62,18 @@ echo '--- multiple row groups: count ---'
 ${CLICKHOUSE_LOCAL} --query "SELECT count(), sum(n) FROM file('${OUT}', 'Parquet')"
 
 echo '--- filter pushdown: row groups pruned ---'
-# 5000 rows / 500 per group = 10 row groups; only the row group covering [100,200]
-# should survive Parquet statistics pruning, leaving 9 pruned. Read the counters
-# from --print-profile-events and emit a stable "read=N pruned=M" marker so a
-# regression that disables pushdown would change M from 9 to 0.
+# Profile events may be emitted on multiple lines (one per thread/batch under
+# parallel decode), so sum the counters and emit a binary verdict. A regression
+# that disables Parquet stats pushdown would drop pruned to 0.
 ${CLICKHOUSE_LOCAL} --print-profile-events --query "
     SELECT count() FROM file('${OUT}', 'Parquet') WHERE n BETWEEN 100 AND 200
 " 2>&1 | awk '
-    /ParquetReadRowGroups:/   { read = $(NF-1) }
-    /ParquetPrunedRowGroups:/ { pruned = $(NF-1) }
-    END                       { print "read=" read " pruned=" pruned }
+    /ParquetReadRowGroups:/   { read   += $(NF-1) }
+    /ParquetPrunedRowGroups:/ { pruned += $(NF-1) }
+    END {
+        if (pruned > 0 && read > 0) print "pruned"
+        else                        print "not pruned (read=" read+0 " pruned=" pruned+0 ")"
+    }
 '
 
 echo '--- filter pushdown: result correctness ---'
@@ -92,12 +94,14 @@ ${CLICKHOUSE_LOCAL} --query "SELECT sum(b) FROM file('${OUT}', 'Parquet')"
 ${CLICKHOUSE_LOCAL} --query "SELECT sum(a), sum(c) FROM file('${OUT}', 'Parquet')"
 
 # Parquet column pruning: reading a single column issues fewer decoding tasks
-# than reading all three. We don't pin an exact ratio (it depends on the decoder
-# internals), only that single-column < three-column. A regression that read all
-# columns regardless of projection would make these equal.
+# than reading all three. Sum across lines (CI emits one event line per thread
+# under parallel decode) and assert single-column total < all-columns total.
+# A regression that read all columns regardless of projection would tie them.
 echo '--- column pruning: decoding tasks shrink with projection ---'
-ONE=$(${CLICKHOUSE_LOCAL} --print-profile-events --query "SELECT sum(b) FROM file('${OUT}', 'Parquet')" 2>&1 | awk '/ParquetDecodingTasks:/ { print $(NF-1) }')
-ALL=$(${CLICKHOUSE_LOCAL} --print-profile-events --query "SELECT * FROM file('${OUT}', 'Parquet') FORMAT Null" 2>&1 | awk '/ParquetDecodingTasks:/ { print $(NF-1) }')
+ONE=$(${CLICKHOUSE_LOCAL} --print-profile-events --query "SELECT sum(b) FROM file('${OUT}', 'Parquet')" 2>&1 \
+    | awk '/ParquetDecodingTasks:/ { sum += $(NF-1) } END { print sum+0 }')
+ALL=$(${CLICKHOUSE_LOCAL} --print-profile-events --query "SELECT * FROM file('${OUT}', 'Parquet') FORMAT Null" 2>&1 \
+    | awk '/ParquetDecodingTasks:/ { sum += $(NF-1) } END { print sum+0 }')
 if [ "$ONE" -lt "$ALL" ]; then echo "pruned"; else echo "not pruned (one=$ONE all=$ALL)"; fi
 
 # -----------------------------------------------------------------------------

--- a/tests/queries/0_stateless/04140_parquet_types_roundtrip.sh
+++ b/tests/queries/0_stateless/04140_parquet_types_roundtrip.sh
@@ -61,9 +61,25 @@ SELECT number AS n, toString(number) AS s FROM numbers(5000) FORMAT Parquet
 echo '--- multiple row groups: count ---'
 ${CLICKHOUSE_LOCAL} --query "SELECT count(), sum(n) FROM file('${OUT}', 'Parquet')"
 
-echo '--- filter pushdown on id column ---'
+echo '--- filter pushdown: row groups pruned ---'
+# 5000 rows / 500 per group = 10 row groups; only the row group covering [100,200]
+# should survive Parquet statistics pruning, leaving 9 pruned. Read the counters
+# from --print-profile-events and emit a stable "read=N pruned=M" marker so a
+# regression that disables pushdown would change M from 9 to 0.
+${CLICKHOUSE_LOCAL} --print-profile-events --query "
+    SELECT count() FROM file('${OUT}', 'Parquet') WHERE n BETWEEN 100 AND 200
+" 2>&1 | awk '
+    /ParquetReadRowGroups:/   { read = $(NF-1) }
+    /ParquetPrunedRowGroups:/ { pruned = $(NF-1) }
+    END                       { print "read=" read " pruned=" pruned }
+'
+
+echo '--- filter pushdown: result correctness ---'
 ${CLICKHOUSE_LOCAL} --query "SELECT count() FROM file('${OUT}', 'Parquet') WHERE n BETWEEN 100 AND 200"
 ${CLICKHOUSE_LOCAL} --query "SELECT min(n), max(n) FROM file('${OUT}', 'Parquet') WHERE n < 50"
+
+echo '--- filter pushdown: result identical with pushdown off ---'
+${CLICKHOUSE_LOCAL} --query "SELECT count() FROM file('${OUT}', 'Parquet') WHERE n BETWEEN 100 AND 200 SETTINGS input_format_parquet_filter_push_down = 0"
 
 # -----------------------------------------------------------------------------
 # 4. Column pruning: SELECT a subset forces projection.
@@ -74,6 +90,15 @@ SELECT number AS a, number * 2 AS b, number * 3 AS c FROM numbers(100) FORMAT Pa
 echo '--- column pruning ---'
 ${CLICKHOUSE_LOCAL} --query "SELECT sum(b) FROM file('${OUT}', 'Parquet')"
 ${CLICKHOUSE_LOCAL} --query "SELECT sum(a), sum(c) FROM file('${OUT}', 'Parquet')"
+
+# Parquet column pruning: reading a single column issues fewer decoding tasks
+# than reading all three. We don't pin an exact ratio (it depends on the decoder
+# internals), only that single-column < three-column. A regression that read all
+# columns regardless of projection would make these equal.
+echo '--- column pruning: decoding tasks shrink with projection ---'
+ONE=$(${CLICKHOUSE_LOCAL} --print-profile-events --query "SELECT sum(b) FROM file('${OUT}', 'Parquet')" 2>&1 | awk '/ParquetDecodingTasks:/ { print $(NF-1) }')
+ALL=$(${CLICKHOUSE_LOCAL} --print-profile-events --query "SELECT * FROM file('${OUT}', 'Parquet') FORMAT Null" 2>&1 | awk '/ParquetDecodingTasks:/ { print $(NF-1) }')
+if [ "$ONE" -lt "$ALL" ]; then echo "pruned"; else echo "not pruned (one=$ONE all=$ALL)"; fi
 
 # -----------------------------------------------------------------------------
 # 5. Nullable handling.


### PR DESCRIPTION
Follow-up to #103456 (which has been merged). That PR added 28 stateless tests
generated by an AI on lowest-thinking level. A focused review surfaced several
weak or wrong expected outputs that were codified rather than tested. This PR
tightens the worst offenders so the tests actually discriminate between correct
and broken behaviour.

Per-test summary:

- **04121 `JSONExtract` Variant** — replaced `Variant(String, Int64, Float64)`
  + `3.14` (which silently truncates to `3`) with `Variant(String, Float64)`
  which returns `3.14`. The truncation case is a real bug and is tracked in
  https://github.com/ClickHouse/ClickHouse/issues/103617.

- **04128 `sequenceNextNode`** — original two-matcher cases all returned `\N`
  because the base condition (`event='A'`) and chain[0] (`event='B'`) are
  mutually exclusive on the same row, so `getBaseIndex` never selected a base.
  Rewritten so the direction × base matrix produces six distinct non-NULL
  results plus a non-trivial GROUP BY merge.

- **04131 `prometheusQuery` parser** — `INSERT` is not supported by the
  `TimeSeries` engine (`NOT_IMPLEMENTED`). Added a scope note clarifying that
  `count() == 0` assertions exercise only the parser surface and an evaluator
  regression on an empty selector would need a separate integration test.

- **04132 `ColumnSparse` parts_columns** — `SELECT name, serialization_kind`
  returned the *part name* (`all_1_1_0`) three times, giving no information
  about which column got which serialization. Changed to `SELECT column,
  serialization_kind` which now returns `id Default / s Sparse / v Sparse`.

- **04134 `SingleValueDataGenericWithColumn`** — removed the misleading
  `any_value of Tuple via ORDER BY LIMIT 1` section: `ORDER BY ... LIMIT 1`
  invokes the sort path, not `any()/anyLast()`. Header now states explicitly
  that `any/anyLast` are excluded because they return unspecified rows under
  parallelism.

- **04135 `BSONEachRow` coerce** — original `Int32(=42) -> Int8` writes a value
  that fits in `Int8`, so a silent-truncation regression would have passed.
  Switched to `200::Int32 -> Int8` and codified the resulting `-56` wrap
  explicitly. Tightened the error matcher from `Code: [0-9]*` to `Code: [0-9]+`.

- **04140 `Parquet`** — added profile-event assertions for the pushdown /
  pruning sections that previously only checked result correctness:
    - `ParquetPrunedRowGroups`: 5000 rows / 500 per group → 10 groups, expect
      `read=1 pruned=9` for `WHERE n BETWEEN 100 AND 200`.
    - `ParquetDecodingTasks`: single-column read should issue fewer decoding
      tasks than reading all columns.
  Also asserts result equivalence with `input_format_parquet_filter_push_down=0`.

All seven tests verified locally against `clickhouse local` 26.5.1.111.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog (changelog entry is not required)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.159`
<!-- ch-version-info:end -->