### PR TITLE
Fix JSONExtract into Variant silently truncating fractional JSON numbers

### DIFF
--- a/src/Formats/JSONExtractTree.cpp
+++ b/src/Formats/JSONExtractTree.cpp
@@ -134,7 +134,12 @@ void jsonElementToString(const typename JSONParser::Element & element, WriteBuff
 
 template <typename JSONParser, typename NumberType>
 bool tryGetNumericValueFromJSONElement(
-    NumberType & value, const typename JSONParser::Element & element, bool convert_bool_to_number, bool allow_type_conversion, String & error)
+    NumberType & value,
+    const typename JSONParser::Element & element,
+    bool convert_bool_to_number,
+    bool allow_type_conversion,
+    bool no_int_truncation_from_double,
+    String & error)
 {
     switch (element.type())
     {
@@ -149,6 +154,14 @@ bool tryGetNumericValueFromJSONElement(
             else if (!allow_type_conversion || !accurate::convertNumeric<Float64, NumberType, false>(element.getDouble(), value))
             {
                 error = fmt::format("cannot convert double value {} to {}", element.getDouble(), TypeName<NumberType>);
+                return false;
+            }
+            else if (no_int_truncation_from_double && static_cast<Float64>(value) != element.getDouble())
+            {
+                /// The JSON double has a fractional part (or is otherwise not exactly representable as `NumberType`).
+                /// Refuse the conversion so that the caller (e.g. `VariantNode`) can fall through to a
+                /// floating-point or `Decimal` member that represents the value losslessly.
+                error = fmt::format("cannot convert non-integral double value {} to {} without truncation", element.getDouble(), TypeName<NumberType>);
                 return false;
             }
             break;
@@ -207,6 +220,14 @@ bool tryGetNumericValueFromJSONElement(
                     error = fmt::format("cannot parse {} value here: \"{}\"", TypeName<NumberType>, element.getString());
                     return false;
                 }
+
+                if (no_int_truncation_from_double && static_cast<Float64>(value) != tmp_float)
+                {
+                    /// The JSON string parsed as a non-integral float. Refuse the truncating conversion so
+                    /// `VariantNode` can fall through to a floating-point or `Decimal` member.
+                    error = fmt::format("cannot parse {} value here: \"{}\" (non-integral)", TypeName<NumberType>, element.getString());
+                    return false;
+                }
             }
             break;
         }
@@ -262,7 +283,7 @@ public:
         }
 
         NumberType value;
-        if (!tryGetNumericValueFromJSONElement<JSONParser, NumberType>(value, element, /*convert_bool_to_number=*/ true, insert_settings.allow_type_conversion, error))
+        if (!tryGetNumericValueFromJSONElement<JSONParser, NumberType>(value, element, /*convert_bool_to_number=*/ true, insert_settings.allow_type_conversion, insert_settings.no_int_truncation_from_double, error))
         {
             if (error.empty())
                 error = fmt::format("cannot read {} value from JSON element: {}", TypeName<NumberType>, jsonElementToString<JSONParser>(element, format_settings));
@@ -319,7 +340,7 @@ public:
         }
 
         NumberType value;
-        if (!tryGetNumericValueFromJSONElement<JSONParser, NumberType>(value, element, /*convert_bool_to_number=*/ true, insert_settings.allow_type_conversion, error))
+        if (!tryGetNumericValueFromJSONElement<JSONParser, NumberType>(value, element, /*convert_bool_to_number=*/ true, insert_settings.allow_type_conversion, insert_settings.no_int_truncation_from_double, error))
         {
             if (error.empty())
                 error = fmt::format("cannot read {} value from JSON element: {}", TypeName<NumberType>, jsonElementToString<JSONParser>(element, format_settings));
@@ -1527,6 +1548,31 @@ public:
             return true;
         }
 
+        /// First pass: try variants without truncating fractional JSON numbers to integer types.
+        /// This ensures that for `Variant(IntT, FloatT)` the float member claims a fractional
+        /// value like `3.14` instead of an integer member silently truncating it to `3`.
+        ///
+        /// We only do the strict pass when the parent didn't already set the flag — otherwise
+        /// the second pass below would do duplicate work with identical semantics.
+        if (!insert_settings.no_int_truncation_from_double)
+        {
+            auto strict_settings = insert_settings;
+            strict_settings.no_int_truncation_from_double = true;
+            for (size_t i : order)
+            {
+                auto & variant = column_variant.getVariantByGlobalDiscriminator(i);
+                if (variant_nodes[i]->insertResultToColumn(variant, element, strict_settings, format_settings, error))
+                {
+                    column_variant.getLocalDiscriminators().push_back(column_variant.localDiscriminatorByGlobal(static_cast<ColumnVariant::Discriminator>(i)));
+                    column_variant.getOffsets().push_back(variant.size() - 1);
+                    return true;
+                }
+            }
+        }
+
+        /// Fallback: legacy lenient pass. Reached when the strict pass found no match,
+        /// e.g. a `Variant(IntT)` with a fractional JSON number — the integer member
+        /// then accepts the value with truncation, preserving backward compatibility.
         for (size_t i : order)
         {
             auto & variant = column_variant.getVariantByGlobalDiscriminator(i);
@@ -1538,7 +1584,7 @@ public:
             }
         }
 
-        error = fmt::format("cannot read Map value from JSON element: {}", jsonElementToString<JSONParser>(element, format_settings));
+        error = fmt::format("cannot read Variant value from JSON element: {}", jsonElementToString<JSONParser>(element, format_settings));
         return false;
     }
 
@@ -2498,13 +2544,13 @@ template std::unique_ptr<JSONExtractTreeNode<SimdJSONParser>> buildJSONExtractTr
 #if USE_RAPIDJSON
 template void jsonElementToString<RapidJSONParser>(const RapidJSONParser::Element & element, WriteBuffer & buf, const FormatSettings & format_settings);
 template std::unique_ptr<JSONExtractTreeNode<RapidJSONParser>> buildJSONExtractTree<RapidJSONParser>(const DataTypePtr & type, const char * source_for_exception_message);
-template bool tryGetNumericValueFromJSONElement<RapidJSONParser, Float64>(Float64 & value, const RapidJSONParser::Element & element, bool convert_bool_to_number, bool allow_type_conversion, String & error);
+template bool tryGetNumericValueFromJSONElement<RapidJSONParser, Float64>(Float64 & value, const RapidJSONParser::Element & element, bool convert_bool_to_number, bool allow_type_conversion, bool no_int_truncation_from_double, String & error);
 #else
 template void jsonElementToString<DummyJSONParser>(const DummyJSONParser::Element & element, WriteBuffer & buf, const FormatSettings & format_settings);
 template std::unique_ptr<JSONExtractTreeNode<DummyJSONParser>> buildJSONExtractTree<DummyJSONParser>(const DataTypePtr & type, const char * source_for_exception_message);
-template bool tryGetNumericValueFromJSONElement<DummyJSONParser, Float64>(Float64 & value, const DummyJSONParser::Element & element, bool convert_bool_to_number, bool allow_type_conversion, String & error);
-template bool tryGetNumericValueFromJSONElement<DummyJSONParser, Int64>(Int64 & value, const DummyJSONParser::Element & element, bool convert_bool_to_number, bool allow_type_conversion, String & error);
-template bool tryGetNumericValueFromJSONElement<DummyJSONParser, UInt64>(UInt64 & value, const DummyJSONParser::Element & element, bool convert_bool_to_number, bool allow_type_conversion, String & error);
+template bool tryGetNumericValueFromJSONElement<DummyJSONParser, Float64>(Float64 & value, const DummyJSONParser::Element & element, bool convert_bool_to_number, bool allow_type_conversion, bool no_int_truncation_from_double, String & error);
+template bool tryGetNumericValueFromJSONElement<DummyJSONParser, Int64>(Int64 & value, const DummyJSONParser::Element & element, bool convert_bool_to_number, bool allow_type_conversion, bool no_int_truncation_from_double, String & error);
+template bool tryGetNumericValueFromJSONElement<DummyJSONParser, UInt64>(UInt64 & value, const DummyJSONParser::Element & element, bool convert_bool_to_number, bool allow_type_conversion, bool no_int_truncation_from_double, String & error);
 #endif
 
 }

--- a/src/Formats/JSONExtractTree.h
+++ b/src/Formats/JSONExtractTree.h
@@ -29,6 +29,11 @@ struct JSONExtractInsertSettings
     /// Use partial match instead of full to skip paths using regular expressions specified
     /// in JSON data type using SKIP REGEXP.
     bool use_partial_match_to_skip_paths_by_regexp = true;
+    /// If true, fractional JSON DOUBLE values (e.g. `3.14`) and STRING values that parse
+    /// as non-integral floats (e.g. `"3.14"`) are not silently truncated to integer types.
+    /// Used inside `VariantNode` so that `Variant(IntT, FloatT)` picks the float member
+    /// for fractional values instead of silently dropping the fractional part.
+    bool no_int_truncation_from_double = false;
 };
 
 template <typename JSONParser>
@@ -48,6 +53,6 @@ template <typename JSONParser>
 void jsonElementToString(const typename JSONParser::Element & element, WriteBuffer & buf, const FormatSettings & format_settings);
 
 template <typename JSONParser, typename NumberType>
-bool tryGetNumericValueFromJSONElement(NumberType & value, const typename JSONParser::Element & element, bool convert_bool_to_number, bool allow_type_conversion, String & error);
+bool tryGetNumericValueFromJSONElement(NumberType & value, const typename JSONParser::Element & element, bool convert_bool_to_number, bool allow_type_conversion, bool no_int_truncation_from_double, String & error);
 
 }

--- a/src/Functions/FunctionsJSON.cpp
+++ b/src/Functions/FunctionsJSON.cpp
@@ -918,7 +918,7 @@ public:
     {
         NumberType value;
 
-        if (!tryGetNumericValueFromJSONElement<JSONParser, NumberType>(value, element, /*convert_bool_to_number=*/false, /*allow_type_conversion=*/true, error))
+        if (!tryGetNumericValueFromJSONElement<JSONParser, NumberType>(value, element, /*convert_bool_to_number=*/false, /*allow_type_conversion=*/true, /*no_int_truncation_from_double=*/false, error))
             return false;
         auto & col_vec = assert_cast<ColumnVector<NumberType> &>(dest);
         col_vec.insertValue(value);

--- a/tests/queries/0_stateless/04121_json_extract_types_edges.reference
+++ b/tests/queries/0_stateless/04121_json_extract_types_edges.reference
@@ -97,7 +97,7 @@ hello
 --- VariantNode ---
 1
 hi
-3
+3.14
 true
 --- DynamicNode ---
 42

--- a/tests/queries/0_stateless/04141_json_extract_variant_no_int_truncation.reference
+++ b/tests/queries/0_stateless/04141_json_extract_variant_no_int_truncation.reference
@@ -1,0 +1,36 @@
+mixed_variant_fractional_double
+3.14	Float64	3.14	\N
+declaration_order_does_not_matter
+3.14	Float64	3.14	Float64
+negative_fractional
+-2.5	Float64	-2.5
+small_fractional
+0.0001	Float64	0.0001
+integer_literal_picks_int
+3	Int64	3
+overflow_picks_float
+1e100	Float64
+string_with_fractional_no_int_truncation
+3.14	Float64	\N	\N
+string_with_fractional_picks_float
+3.14	Float64	3.14
+decimal_picks_fractional
+1.5	Decimal(10, 4)	1.5
+only_int_variants_fall_back_to_truncation
+3	Int32	\N	3
+direct_int_extract_unchanged
+3
+3
+direct_float_extract_unchanged
+3.14
+big_int_variants_fractional
+7.5	Float64	7.5
+bool_picks_bool
+true	Bool
+closes_103617
+Row 1:
+──────
+v:        3.14
+active:   Float64
+f64_slot: 3.14
+i64_slot: ᴺᵁᴸᴸ

--- a/tests/queries/0_stateless/04141_json_extract_variant_no_int_truncation.reference
+++ b/tests/queries/0_stateless/04141_json_extract_variant_no_int_truncation.reference
@@ -34,3 +34,11 @@ v:        3.14
 active:   Float64
 f64_slot: 3.14
 i64_slot: ᴺᵁᴸᴸ
+string_int_no_float_picks_string
+3.14	String	3.14	\N
+string_smaller_int_no_float_picks_string
+3.14	String	3.14	\N
+string_int_no_float_integer_literal_picks_int
+3	Int64	3
+string_with_multiple_ints_picks_string
+3.14	String

--- a/tests/queries/0_stateless/04141_json_extract_variant_no_int_truncation.sql
+++ b/tests/queries/0_stateless/04141_json_extract_variant_no_int_truncation.sql
@@ -114,3 +114,50 @@ SELECT
     variantElement(v, 'Float64') AS f64_slot,
     variantElement(v, 'Int64') AS i64_slot
 FORMAT Vertical;
+
+-- 16. Intentional broader scope (raised by the automated reviewer on PR #103620):
+--     `Variant(String, IntT)` with a fractional JSON DOUBLE now picks `String` instead
+--     of silently truncating to `IntT`.
+--
+--     Previously the lone lenient pass let `Int64` accept `3.14` and the result was
+--     `Int64 = 3` (silent data loss). With the new strict-first pass, `Int64` rejects
+--     non-integral doubles, the strict pass falls through to `String`, and the JSON
+--     element is serialized losslessly as `"3.14"`.
+--
+--     This is intentional and consistent with the bug being fixed: the original bug is
+--     *silent data loss*, and capturing the value as `String` is strictly better than
+--     dropping the fractional part. Users who want the integer slot to claim fractional
+--     numbers must remove `String` from the variant (test 10 covers `Variant(IntT, IntT)`,
+--     which still falls back to truncation via the legacy lenient pass).
+SELECT 'string_int_no_float_picks_string';
+SELECT
+    JSONExtract('{"x": 3.14}', 'x', 'Variant(String, Int64)') AS v,
+    variantType(v) AS active,
+    variantElement(v, 'String') AS s,
+    variantElement(v, 'Int64') AS i64;
+
+-- 17. Same as 16 with a narrower integer width — verifies the rule applies uniformly
+--     across all integer types in the strict pass.
+SELECT 'string_smaller_int_no_float_picks_string';
+SELECT
+    JSONExtract('{"x": 3.14}', 'x', 'Variant(String, Int32)') AS v,
+    variantType(v) AS active,
+    variantElement(v, 'String') AS s,
+    variantElement(v, 'Int32') AS i32;
+
+-- 18. Backward compat: integer JSON literals still pick the integer member even when a
+--     `String` fallback exists, because the strict pass accepts `Int64` for an exactly
+--     representable value before reaching `String`.
+SELECT 'string_int_no_float_integer_literal_picks_int';
+SELECT
+    JSONExtract('{"x": 3}', 'x', 'Variant(String, Int64)') AS v,
+    variantType(v) AS active,
+    variantElement(v, 'Int64') AS i64;
+
+-- 19. Backward compat: when only String + multiple integer members exist, fractional
+--     doubles still pick `String` (not any integer). Confirms the strict pass uniformly
+--     rejects all integer members for non-integral doubles, regardless of width.
+SELECT 'string_with_multiple_ints_picks_string';
+SELECT
+    JSONExtract('{"x": 3.14}', 'x', 'Variant(String, Int32, Int64, Int128)') AS v,
+    variantType(v);

--- a/tests/queries/0_stateless/04141_json_extract_variant_no_int_truncation.sql
+++ b/tests/queries/0_stateless/04141_json_extract_variant_no_int_truncation.sql
@@ -1,0 +1,116 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/103617
+--
+-- Before the fix, `JSONExtract` into a `Variant` that contained both an integer
+-- and a floating-point member silently truncated fractional JSON numbers: the
+-- integer member won and the fractional part was lost.
+--
+-- After the fix, `VariantNode` first tries every variant with strict semantics
+-- (no truncating doubles to integers) so the float/decimal member claims the
+-- value losslessly. Only when no float/decimal member can hold the value does
+-- the loop fall back to the legacy lenient pass.
+
+-- 1. Mixed-numeric variants must pick the float member for fractional JSON doubles.
+SELECT 'mixed_variant_fractional_double';
+SELECT
+    JSONExtract('{"x": 3.14}', 'x', 'Variant(String, Int64, Float64)') AS v,
+    variantType(v) AS active,
+    variantElement(v, 'Float64') AS f64_slot,
+    variantElement(v, 'Int64') AS i64_slot;
+
+-- 2. Declaration order does not matter: float still wins for fractional values.
+SELECT 'declaration_order_does_not_matter';
+SELECT
+    JSONExtract('{"x": 3.14}', 'x', 'Variant(Int64, Float64)') AS v1,
+    variantType(v1),
+    JSONExtract('{"x": 3.14}', 'x', 'Variant(Float64, Int64)') AS v2,
+    variantType(v2);
+
+-- 3. Negative fractional values pick the float member.
+SELECT 'negative_fractional';
+SELECT
+    JSONExtract('{"x": -2.5}', 'x', 'Variant(String, Int64, Float64)') AS v,
+    variantType(v) AS active,
+    variantElement(v, 'Float64') AS f64;
+
+-- 4. Very small fractional values pick the float member.
+SELECT 'small_fractional';
+SELECT
+    JSONExtract('{"x": 0.0001}', 'x', 'Variant(Int64, Float64)') AS v,
+    variantType(v),
+    variantElement(v, 'Float64');
+
+-- 5. JSON integer literals still pick the integer member.
+SELECT 'integer_literal_picks_int';
+SELECT
+    JSONExtract('{"x": 3}', 'x', 'Variant(String, Int64, Float64)') AS v,
+    variantType(v) AS active,
+    variantElement(v, 'Int64') AS i64;
+
+-- 6. Big fractional numbers that overflow Int64 pick the float member (worked already, kept as smoke).
+SELECT 'overflow_picks_float';
+SELECT
+    JSONExtract('{"x": 1e100}', 'x', 'Variant(String, Int64, Float64)') AS v,
+    variantType(v);
+
+-- 7. STRING containing a fractional number must NOT truncate to Int64. Float64 wins
+--    because variant priority is Int64 > Float64 > String; with the fix Int64 rejects
+--    the non-integral string-as-float and Float64 picks it up.
+SELECT 'string_with_fractional_no_int_truncation';
+SELECT
+    JSONExtract('{"x": "3.14"}', 'x', 'Variant(String, Int64, Float64)') AS v,
+    variantType(v) AS active,
+    variantElement(v, 'String') AS s,
+    variantElement(v, 'Int64') AS i64;
+
+-- 8. STRING containing a fractional number with no String variant: must pick Float64, not Int64.
+SELECT 'string_with_fractional_picks_float';
+SELECT
+    JSONExtract('{"x": "3.14"}', 'x', 'Variant(Int64, Float64)') AS v,
+    variantType(v),
+    variantElement(v, 'Float64');
+
+-- 9. Decimal members claim fractional values too.
+SELECT 'decimal_picks_fractional';
+SELECT
+    JSONExtract('{"x": 1.5}', 'x', 'Variant(Int64, Decimal(10, 4))') AS v,
+    variantType(v),
+    variantElement(v, 'Decimal(10, 4)') AS d;
+
+-- 10. Backward compat: when only integer members exist, fractional doubles still truncate (legacy pass).
+SELECT 'only_int_variants_fall_back_to_truncation';
+SELECT
+    JSONExtract('{"x": 3.14}', 'x', 'Variant(Int64, Int32)') AS v,
+    variantType(v) AS active,
+    variantElement(v, 'Int64') AS i64,
+    variantElement(v, 'Int32') AS i32;
+
+-- 11. Backward compat: direct integer extraction still truncates (this fix is Variant-scoped).
+SELECT 'direct_int_extract_unchanged';
+SELECT JSONExtract('{"x": 3.14}', 'x', 'Int64') AS v;
+SELECT JSONExtractInt('{"x": 3.14}', 'x') AS v;
+
+-- 12. Backward compat: direct float extraction unchanged.
+SELECT 'direct_float_extract_unchanged';
+SELECT JSONExtract('{"x": 3.14}', 'x', 'Float64') AS v;
+
+-- 13. Big integer types that span multiple Variant slots fall through to Float64.
+SELECT 'big_int_variants_fractional';
+SELECT
+    JSONExtract('{"x": 7.5}', 'x', 'Variant(Int64, Int128, Float64)') AS v,
+    variantType(v),
+    variantElement(v, 'Float64') AS f64;
+
+-- 14. Bool JSON values continue to pick Bool variants when present.
+SELECT 'bool_picks_bool';
+SELECT
+    JSONExtract('{"x": true}', 'x', 'Variant(Bool, Int64)') AS v,
+    variantType(v);
+
+-- 15. Closes #103617: original reproducer from the issue.
+SELECT 'closes_103617';
+SELECT
+    JSONExtract('{"x": 3.14}', 'x', 'Variant(String, Int64, Float64)') AS v,
+    variantType(v) AS active,
+    variantElement(v, 'Float64') AS f64_slot,
+    variantElement(v, 'Int64') AS i64_slot
+FORMAT Vertical;


### PR DESCRIPTION
`JSONExtract` into a `Variant` that contained both an integer and a floating-point member silently truncated fractional JSON numbers: the integer member won and the fractional part was lost. Reported and root-caused by @fm4v in #103617.

```sql
SELECT
    JSONExtract('{"x": 3.14}', 'x', 'Variant(String, Int64, Float64)') AS v,
    variantType(v) AS active;
-- Before:  v=3,    active=Int64    (silent data loss)
-- After:   v=3.14, active=Float64
```

The same code path also applies to `STRING` JSON elements that parse as non-integral floats (e.g. `"3.14"`), which previously truncated to `Int64=3` as well.

## Root cause (lines from master `7df6513e4d29`)

1. `SerializationVariant::getVariantsDeserializeTextOrder` orders variants by priority — integers > big integers > decimals > floats > strings (`SerializationVariant.cpp:899-958`).
2. `VariantNode::insertResultToColumn` iterates variants in that order and accepts the first member whose extractor returns true (`JSONExtractTree.cpp:1514`).
3. For an integer target, the JSON DOUBLE branch in `tryGetNumericValueFromJSONElement` calls `accurate::convertNumeric<Float64, NumberType, false>` (`JSONExtractTree.cpp:141`). With `strict=false`, only the overflow check fires — `3.14 -> 3` returns `true` and the `Int64` member wins.
4. The STRING-as-fractional-float fallback inside the same function uses the same lossy `convertNumeric` call.

## Fix

Add `JSONExtractInsertSettings::no_int_truncation_from_double` (default `false`, preserves legacy behavior). When set, `tryGetNumericValueFromJSONElement` rejects DOUBLE -> integer and STRING-as-fractional-float -> integer conversions whose round-trip is lossy.

`VariantNode::insertResultToColumn` now performs a strict first pass with this flag enabled so a `Float`/`Decimal` member can claim the value, and falls back to the legacy lenient pass only when the strict pass found no match (e.g. `Variant(Int64, Int32)` + `3.14` still returns `3` for backward compatibility). Direct integer extraction (`JSONExtract(json, 'Int64')`, `JSONExtractInt`, etc.) is unchanged — the fix is scoped to the `Variant` path.

This mirrors the established pattern used in `DynamicNode::insertResultToColumn` for `try_existing_variants_in_dynamic_first` — try strictly first, fall back to lenient.

Also fixes a pre-existing copy-paste error in the error message: `"cannot read Map value"` -> `"cannot read Variant value"`.

## Intentional broader scope (raised in review)

The strict first pass runs across **all** variant members, not only numeric ones. This means a `Variant` that contains both `String` and an integer member (without a `Float`/`Decimal`) also benefits from the fix: a fractional JSON DOUBLE now lands in `String` instead of being silently truncated into the integer member.

| Query | Before | After |
| --- | --- | --- |
| `JSONExtract('{"x": 3.14}', 'x', 'Variant(String, Int64)')` | `Int64=3` (silent data loss) | `String="3.14"` (lossless) |
| `JSONExtract('{"x": 3.14}', 'x', 'Variant(String, Int32)')` | `Int32=3` | `String="3.14"` |
| `JSONExtract('{"x": 3.14}', 'x', 'Variant(String, Int32, Int64, Int128)')` | `Int128=3` | `String="3.14"` |

This is intentional: the bug being fixed is *silent data loss*, and capturing the value as `String` is strictly better than dropping the fractional part. Users who explicitly want integer truncation must remove `String` from the variant — `Variant(Int64, Int32)` + `3.14` still returns `3` via the legacy lenient pass. Integer JSON literals (`3`) continue to pick the integer member even when `String` is present, because the strict pass accepts an exactly representable value before reaching `String`.

Tests 16-19 in the regression suite codify this behavior.

## Behavior matrix

| Query | Before | After |
| --- | --- | --- |
| `JSONExtract('{"x": 3.14}', 'x', 'Variant(Int64, Float64)')` | `Int64=3`  | `Float64=3.14` |
| `JSONExtract('{"x": 3.14}', 'x', 'Variant(Float64, Int64)')` | `Int64=3`  | `Float64=3.14` |
| `JSONExtract('{"x": "3.14"}', 'x', 'Variant(Int64, Float64)')` | `Int64=3`  | `Float64=3.14` |
| `JSONExtract('{"x": -2.5}', 'x', 'Variant(Int64, Float64)')` | `Int64=-2` | `Float64=-2.5` |
| `JSONExtract('{"x": 1.5}', 'x', 'Variant(Int64, Decimal(10, 4))')` | `Int64=1` | `Decimal=1.5` |
| `JSONExtract('{"x": 3.14}', 'x', 'Variant(String, Int64)')` | `Int64=3` (silent data loss) | `String="3.14"` (lossless) |
| `JSONExtract('{"x": 3}', 'x', 'Variant(String, Int64)')` | `Int64=3` | `Int64=3` (unchanged) |
| `JSONExtract('{"x": 3}', 'x', 'Variant(Int64, Float64)')` | `Int64=3`  | `Int64=3` (unchanged) |
| `JSONExtract('{"x": 3.14}', 'x', 'Variant(Int64, Int32)')` | `Int32=3`  | `Int32=3` (legacy fallback) |
| `JSONExtract('{"x": 3.14}', 'x', 'Int64')` | `3` | `3` (unchanged) |
| `JSONExtractInt('{"x": 3.14}', 'x')` | `3` | `3` (unchanged) |

## Tests

New regression test `tests/queries/0_stateless/04141_json_extract_variant_no_int_truncation.sql` covering 19 cases: declaration order independence, negative fractional, small fractional, integer literals, overflow, string-as-fractional, decimal members, fall-through to truncation when only integer variants exist, direct extraction backward compat, big int variants, bool, the original reproducer, and the four `Variant(String, IntT)` cases that codify the broader-scope behavior described above.

Existing test `04121_json_extract_types_edges` had its `.reference` updated for the `Variant(String, Int64, Float64)` + `3.14` case (`3` -> `3.14`). The issue explicitly called out this test as codifying the bug; @fm4v's PR #103618 also rewrites that case (using `Variant(String, Float64)` to sidestep the bug). Both approaches converge on `3.14` as the correct output, so this update is forward-compatible with #103618.

Closes #103617

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix `JSONExtract` into a `Variant` type silently truncating fractional JSON numbers. Previously, `JSONExtract('{"x": 3.14}', 'x', 'Variant(Int64, Float64)')` returned `Int64=3` and `JSONExtract('{"x": 3.14}', 'x', 'Variant(String, Int64)')` returned `Int64=3`, dropping the fractional part. The fractional value is now preserved losslessly: a `Float64`/`Decimal` member claims it when present, otherwise a `String` member captures the original JSON. `Variant` types containing only integer members (e.g. `Variant(Int64, Int32)`) and direct integer extraction (`JSONExtract(json, 'Int64')`, `JSONExtractInt`, etc.) are unchanged.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.572`
- Backported to: `26.4.3.14`
<!-- ch-version-info:end -->