### PR TITLE
Fix `SYSTEM INSTRUMENT REMOVE` without arguments causing `std::bad_optional_access`

### DIFF
--- a/src/Parsers/ParserSystemQuery.cpp
+++ b/src/Parsers/ParserSystemQuery.cpp
@@ -899,6 +899,7 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
                         res->instrumentation_point = field.safeGet<UInt64>();
                         break;
                     default:
+                        expected.add(pos, "String or UInt64 literal for instrumentation point");
                         return false;
                 }
             }
@@ -908,10 +909,14 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
                 if (Poco::toLower(identifier) == "all")
                     res->instrumentation_point = Instrumentation::All{};
                 else
+                {
+                    expected.add(pos, "ALL");
                     return false;
+                }
             }
             else
             {
+                expected.add(pos, "instrumentation point: subquery, literal, or ALL");
                 return false;
             }
 
@@ -923,12 +928,18 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
             if (ParserLiteral{}.parse(pos, temporary_identifier, expected))
                 res->instrumentation_function_name = temporary_identifier->as<ASTLiteral &>().value.safeGet<String>();
             else
+            {
+                expected.add(pos, "function name (string literal)");
                 return false;
+            }
 
             if (ParserIdentifier{}.parse(pos, temporary_identifier, expected))
                 res->instrumentation_handler_name = temporary_identifier->as<ASTIdentifier &>().name();
             else
+            {
+                expected.add(pos, "handler name (LOG or PROFILE)");
                 return false;
+            }
 
             if (Poco::toLower(res->instrumentation_handler_name) == "profile")
             {
@@ -944,10 +955,17 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
                 else if (Poco::toLower(entry_type) == "exit")
                     res->instrumentation_entry_type = Instrumentation::EntryType::EXIT;
                 else
+                {
+                    expected.add(pos, "entry type (ENTRY or EXIT)");
                     return false;
+                }
             }
             else
+            {
+                expected.add(pos, "entry type (ENTRY or EXIT)");
                 return false;
+            }
+
 
             ASTPtr params_ast;
             while (ParserLiteral{}.parse(pos, params_ast, expected))
@@ -964,7 +982,10 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
             }
 
             if (res->instrumentation_parameters.empty())
+            {
+                expected.add(pos, "at least one parameter (string literal)");
                 return false;
+            }
 
             break;
         }

--- a/src/Parsers/ParserSystemQuery.cpp
+++ b/src/Parsers/ParserSystemQuery.cpp
@@ -910,6 +910,10 @@ bool ParserSystemQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, Expected & 
                 else
                     return false;
             }
+            else
+            {
+                return false;
+            }
 
             break;
         }

--- a/tests/queries/0_stateless/04141_system_instrument_remove_no_args.sql
+++ b/tests/queries/0_stateless/04141_system_instrument_remove_no_args.sql
@@ -1,0 +1,8 @@
+-- Tags: use-xray
+
+-- SYSTEM INSTRUMENT REMOVE without arguments should produce SYNTAX_ERROR,
+-- not std::bad_optional_access (STD_EXCEPTION).
+-- https://github.com/ClickHouse/ClickHouse/issues/103244
+
+SYSTEM INSTRUMENT REMOVE; -- { clientError SYNTAX_ERROR }
+SYSTEM INSTRUMENT REMOVE  ; -- { clientError SYNTAX_ERROR }


### PR DESCRIPTION
`SYSTEM INSTRUMENT REMOVE;` (no arguments) was accepted by the parser but caused `std::bad_optional_access` at runtime instead of a clean `SYNTAX_ERROR`. The `INSTRUMENT_REMOVE` case in `ParserSystemQuery` tried three parser alternatives (subquery, literal, identifier) and when all three failed, execution fell through to `break;` without setting `instrumentation_point`. The interpreter then called `.value()` on `std::nullopt`.

Added a missing `else { return false; }` so the parser correctly rejects the query.

Closes #103244

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `SYSTEM INSTRUMENT REMOVE` without arguments producing `std::bad_optional_access` (error code 1001) instead of `SYNTAX_ERROR` (error code 62).

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.218`
<!-- ch-version-info:end -->