### PR TITLE
CI: make clickhouse-test exit code authoritative

### DIFF
--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -347,15 +347,10 @@ def main():
 
         res = CH.run_test(fast_test_command)
 
-        test_results = FTResultsProcessor(wd=Settings.OUTPUT_DIR).run()
+        test_results = FTResultsProcessor(wd=Settings.OUTPUT_DIR).run(
+            runner_exit_code=0 if res else 1,
+        )
         if not res:
-            test_results.results.append(
-                Result.create_from(
-                    name="clickhouse-test",
-                    status=Result.Status.FAIL,
-                    info="clickhouse-test error",
-                )
-            )
             attach_debug = True
 
         results.append(test_results)

--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -94,14 +94,19 @@ def run_tests(
         extra_args += " --zookeeper"
     # Remove --report-logs-stats, it hides sanitizer errors in def reportLogStats(args): clickhouse_execute(args, "SYSTEM FLUSH LOGS")
     memory_limit = 10 * 2**30 if "asan_ubsan" in Info().job_name else 5 * 2**30
-    command = f"clickhouse-test --testname --check-zookeeper-session --hung-check --memory-limit {memory_limit} --trace \
+    # `set -o pipefail` is required so that the pipeline's exit code reflects
+    # `clickhouse-test`'s exit code rather than `tee`'s. Without it, a non-zero
+    # exit from `clickhouse-test` is silently swallowed by `tee` returning 0.
+    command = f"set -o pipefail; clickhouse-test --testname --check-zookeeper-session --hung-check --memory-limit {memory_limit} --trace \
                 --capture-client-stacktrace --queries ./tests/queries --test-runs {rerun_count} \
                 {extra_args} \
                 --queries ./tests/queries {('--order=random' if random_order else '')} -- {' '.join(tests) if tests else ''} | ts '%Y-%m-%d %H:%M:%S' \
                 | tee -a \"{test_output_file}\""
     if Path(test_output_file).exists():
         Path(test_output_file).unlink()
-    Shell.run(command, verbose=True, timeout=global_time_limit if global_time_limit > 0 else None)
+    return Shell.run(
+        command, verbose=True, timeout=global_time_limit if global_time_limit > 0 else None
+    )
 
 
 OPTIONS_TO_INSTALL_ARGUMENTS = {
@@ -561,7 +566,7 @@ def main():
                 f" remaining: {global_time_limit}s)"
             )
 
-            run_tests(
+            runner_exit_code = run_tests(
                 batch_num=0,
                 batch_total=0,
                 tests=list(tests) if tests else tests,
@@ -582,7 +587,7 @@ def main():
                 f" remaining: {global_time_limit}s)"
             )
 
-            run_tests(
+            runner_exit_code = run_tests(
                 batch_num=0,
                 batch_total=0,
                 tests=list(tests) if tests else tests,
@@ -593,7 +598,7 @@ def main():
             )
 
         else:
-            run_tests(
+            runner_exit_code = run_tests(
                 batch_num=batch_num,
                 batch_total=total_batches,
                 tests=list(tests) if tests else tests,
@@ -603,7 +608,7 @@ def main():
                 global_time_limit=global_time_limit,
             )
 
-        test_result = ft_res_processor.run()
+        test_result = ft_res_processor.run(runner_exit_code=runner_exit_code)
 
         if not info.is_local_run:
             CH.stop_log_exports()

--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -20,12 +20,13 @@ SUCCESS_FINISH_SIGNS = ["All tests have finished", "No tests were run"]
 RETRIES_SIGN = "Some tests were restarted"
 
 # Regex pattern to match test result lines.
-# Accepts both the raw "test_name: [ STATUS ] time sec." form (fast_test.py)
-# and the timestamped "YYYY-MM-DD HH:MM:SS test_name: [ STATUS ] time sec." form
-# (functional_tests.py, which pipes through `ts`).
-# Test names can contain letters, digits, underscores, hyphens, and dots.
+# The shape `name: [ STATUS ] N.NN sec.` is specific enough that we don't pin
+# the leading timestamp - the bounded `^.{0,32}?` lets through any expected
+# framing (raw=0, `ts`=20, `[YYYY-MM-DD HH:MM:SS] `=22) but rules out matches
+# embedded deeper in an error/exception message (see PR #88825). Test names
+# can contain letters, digits, underscores, hyphens, and dots.
 TEST_RESULT_PATTERN = re.compile(
-    r"^(?:\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} )?"
+    r"^.{0,32}?"
     r"([\w\-\.]+):\s+(\[ (?:OK|FAIL|SKIPPED|UNKNOWN|Timeout!) \])\s+([\d.]+) sec\."
 )
 
@@ -212,16 +213,31 @@ class FTResultsProcessor:
 
         # The runner's exit code is the authoritative signal: if `clickhouse-test`
         # exited non-zero, the job must not report OK even when log parsing finds
-        # nothing to blame. This guards against parser regressions and against
-        # failure modes that don't surface as a parseable `[ FAIL ]` line.
+        # nothing to blame. The synthetic leaf is added only when the parser
+        # found nothing - otherwise the real failure already explains the result
+        # and a duplicate entry is just noise.
         if runner_exit_code is not None and runner_exit_code != 0:
             if state == Result.Status.OK:
                 state = Result.Status.FAIL
+                test_results.append(
+                    Result(
+                        name="clickhouse-test",
+                        status=Result.Status.FAIL,
+                        info=f"clickhouse-test exited with code {runner_exit_code}",
+                    )
+                )
+
+        # Defense in depth: a real run must produce at least one parsed test
+        # result. Zero results means the log parser is broken (format drifted)
+        # or the result file is missing rows - never silently report OK in
+        # that case.
+        if state == Result.Status.OK and s.total == 0:
+            state = Result.Status.ERROR
             test_results.append(
                 Result(
-                    name="clickhouse-test",
-                    status=Result.Status.FAIL,
-                    info=f"clickhouse-test exited with code {runner_exit_code}",
+                    name="results parser",
+                    status=Result.Status.ERROR,
+                    info="Parsed zero test results from the log",
                 )
             )
 

--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -7,9 +7,9 @@ from praktika.result import Result
 
 OK_SIGN = "[ OK "
 FAIL_SIGN = "[ FAIL "
-TIMEOUT_SIGN = "[ Timeout! "
 UNKNOWN_SIGN = "[ UNKNOWN "
 SKIPPED_SIGN = "[ SKIPPED "
+NOT_FAILED_SIGN = "[ NOT_FAILED "
 HUNG_SIGN = "Found hung queries in processlist"
 SERVER_DIED_SIGN = "Server died, terminating all processes"
 SERVER_DIED_SIGN2 = "Server does not respond to health check"
@@ -27,7 +27,7 @@ RETRIES_SIGN = "Some tests were restarted"
 # can contain letters, digits, underscores, hyphens, and dots.
 TEST_RESULT_PATTERN = re.compile(
     r"^.{0,32}?"
-    r"([\w\-\.]+):\s+(\[ (?:OK|FAIL|SKIPPED|UNKNOWN|Timeout!) \])\s+([\d.]+) sec\."
+    r"([\w\-\.]+):\s+(\[ (?:OK|FAIL|SKIPPED|UNKNOWN|NOT_FAILED) \])\s+([\d.]+) sec\."
 )
 
 
@@ -97,15 +97,17 @@ class FTResultsProcessor:
                         continue
 
                     total += 1
-                    if TIMEOUT_SIGN in status_marker:
-                        failed += 1
-                        test_results.append((test_name, "Timeout", test_time, []))
-                    elif FAIL_SIGN in status_marker:
+                    if FAIL_SIGN in status_marker:
                         failed += 1
                         test_results.append((test_name, "FAIL", test_time, []))
                     elif UNKNOWN_SIGN in status_marker:
                         unknown += 1
                         test_results.append((test_name, "FAIL", test_time, []))
+                    elif NOT_FAILED_SIGN in status_marker:
+                        # Test was on a blacklist (expected to fail) but passed -
+                        # the blacklist needs updating. Surface as a failure.
+                        failed += 1
+                        test_results.append((test_name, "NOT_FAILED", test_time, []))
                     elif SKIPPED_SIGN in status_marker:
                         skipped += 1
                         test_results.append((test_name, "SKIPPED", test_time, []))
@@ -115,7 +117,7 @@ class FTResultsProcessor:
                     test_end = False
                 elif (
                     len(test_results) > 0
-                    and test_results[-1][1] in ("FAIL", "SKIPPED")
+                    and test_results[-1][1] in ("FAIL", "SKIPPED", "NOT_FAILED")
                     and not test_end
                 ):
                     test_results[-1][3].append(original_line)

--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -227,20 +227,6 @@ class FTResultsProcessor:
                     )
                 )
 
-        # Defense in depth: a real run must produce at least one parsed test
-        # result. Zero results means the log parser is broken (format drifted)
-        # or the result file is missing rows - never silently report OK in
-        # that case.
-        if state == Result.Status.OK and s.total == 0:
-            state = Result.Status.ERROR
-            test_results.append(
-                Result(
-                    name="results parser",
-                    status=Result.Status.ERROR,
-                    info="Parsed zero test results from the log",
-                )
-            )
-
         if not info:
             info = f"Failed: {s.failed}, Passed: {s.success}, Skipped: {s.skipped}"
 

--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -1,7 +1,7 @@
 import dataclasses
 import re
 import traceback
-from typing import List
+from typing import List, Optional
 
 from praktika.result import Result
 
@@ -19,12 +19,14 @@ SUCCESS_FINISH_SIGNS = ["All tests have finished", "No tests were run"]
 
 RETRIES_SIGN = "Some tests were restarted"
 
-# Regex pattern to match test result lines
-# Format: "2025-10-21 04:08:13 test_name: [ STATUS ] time sec."
-# This ensures we only match actual test result lines, not patterns embedded in error messages
-# Note: Test names can contain letters, digits, underscores, hyphens, and dots
+# Regex pattern to match test result lines.
+# Accepts both the raw "test_name: [ STATUS ] time sec." form (fast_test.py)
+# and the timestamped "YYYY-MM-DD HH:MM:SS test_name: [ STATUS ] time sec." form
+# (functional_tests.py, which pipes through `ts`).
+# Test names can contain letters, digits, underscores, hyphens, and dots.
 TEST_RESULT_PATTERN = re.compile(
-    r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} ([\w\-\.]+):\s+(\[ (?:OK|FAIL|SKIPPED|UNKNOWN|Timeout!) \])\s+([\d.]+) sec\."
+    r"^(?:\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} )?"
+    r"([\w\-\.]+):\s+(\[ (?:OK|FAIL|SKIPPED|UNKNOWN|Timeout!) \])\s+([\d.]+) sec\."
 )
 
 
@@ -169,7 +171,7 @@ class FTResultsProcessor:
 
         return s
 
-    def run(self, task_name="Tests"):
+    def run(self, task_name="Tests", runner_exit_code: Optional[int] = None):
         state = Result.Status.OK
         s = self._process_test_output()
         test_results = s.test_results
@@ -207,6 +209,21 @@ class FTResultsProcessor:
             )
         else:
             pass
+
+        # The runner's exit code is the authoritative signal: if `clickhouse-test`
+        # exited non-zero, the job must not report OK even when log parsing finds
+        # nothing to blame. This guards against parser regressions and against
+        # failure modes that don't surface as a parseable `[ FAIL ]` line.
+        if runner_exit_code is not None and runner_exit_code != 0:
+            if state == Result.Status.OK:
+                state = Result.Status.FAIL
+            test_results.append(
+                Result(
+                    name="clickhouse-test",
+                    status=Result.Status.FAIL,
+                    info=f"clickhouse-test exited with code {runner_exit_code}",
+                )
+            )
 
         if not info:
             info = f"Failed: {s.failed}, Passed: {s.success}, Skipped: {s.skipped}"


### PR DESCRIPTION
The merge-queue `Fast test` was passing regardless of the actual outcome — see PR #103604, which had to be filed because `04122_serialization_time64_formats` was failing on master across many builds after #102596 merged. The failure had been visible in the merge-queue `Fast test` log all along (`04122_serialization_time64_formats: [ FAIL ] 0.34 sec.`, with the expected `UNEXPECTED_DATA_AFTER_PARSED_VALUE`), but `result_fast_test.json` reported `Tests: OK 'Failed: 0, Passed: 0, Skipped: 0'` and the merge proceeded. The same `Failed: 0, Passed: 0, Skipped: 0` line shows up in every recent `MergeQueueCI` Fast test that actually ran (PRs 103218, 103376, 103604, 103334, 100478, 102596, …).

Two layered bugs:

1. `TEST_RESULT_PATTERN` in `ci/jobs/scripts/functional_tests_results.py` (introduced in d5d9f96f6aa365cd7994e485cf9815a465e562ae) requires a `YYYY-MM-DD HH:MM:SS ` line prefix. `functional_tests.py` produces that prefix because it pipes through `ts`, but `fast_test.py` does not — so every Fast test parses zero lines, `s.failed == 0`, and `state` stays `OK`. The `[YYYY-MM-DD HH:MM:SS]` (with brackets) seen in CI logs is added by Praktika's `_TimestampedStream` to stdout/RUN_LOG, not to `test_result.txt`.
2. `clickhouse-test`'s exit code was already collected (`res = CH.run_test(...)`), but on failure `fast_test.py` only appended a `clickhouse-test: FAIL` child to a Result whose status was already explicitly set to `OK`. `Result.create_from` only re-derives status from children when no explicit status is passed (`ci/praktika/result.py:163`), so the FAIL child was orphaned and the parent stayed `OK`.

Changes:
- Make the timestamp prefix optional in `TEST_RESULT_PATTERN` so the regex matches both formats (`fast_test.py` raw and `functional_tests.py` `ts`-prefixed).
- Add `runner_exit_code` to `FTResultsProcessor.run`. When non-zero, force `state = FAIL` and append a visible `clickhouse-test exited with code N` leaf. The runner's exit code is now the authoritative signal — log parsing only enriches per-test attribution.
- `fast_test.py` passes `runner_exit_code` and drops the orphaned FAIL append.
- `functional_tests.py` adds `set -o pipefail` so the pipeline's exit code reflects `clickhouse-test`'s rather than `tee`'s, captures `Shell.run`'s return value, and threads it through.

Sanity-checked the regex and the new `runner_exit_code` branch with synthetic fixtures (raw and `ts`-prefixed lines; exit-0 with parsed FAIL → FAIL; exit-1 with no parsed lines → FAIL; exit-None preserves legacy OK; clean run → OK).

Failing CI report context: https://github.com/ClickHouse/ClickHouse/actions/runs/24978667816/job/73135892404 (search for `04122_serialization_time64_formats`)

Related PRs: #102596 (the original fix that broke `04122`), #103604 (the manual reference update).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.147`
<!-- ch-version-info:end -->