### PR TITLE
Skip LLVM Merge job when llvm jobs are partially launched

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/filter_job.py
+++ b/ci/jobs/scripts/workflow_hooks/filter_job.py
@@ -270,14 +270,20 @@ def should_skip_job(job_name):
     ):
         return True, "Skipped, not labeled with 'pr-performance'"
 
-    # If only the functional tests script changed, run only the first batch of stateless tests
+    # If only CI scripts changed (no product code), run a minimal set of tests
+    # to validate the CI pipeline: stateless batch 1 and amd_asan_ubsan integration batch 1.
+    # Individual coverage test jobs run normally, but the LLVM merge/report job is skipped
+    # so that partial shard data does not corrupt the master coverage number.
     if changed_files and all(
         f.startswith("ci/") and f.endswith(".py") for f in changed_files
     ):
+        if job_name == JobNames.LLVM_COVERAGE:
+            return True, "Skipped: only CI scripts changed; skipping coverage merge to preserve master coverage number"
+
         if JobNames.STATELESS in job_name:
             match = re.search(r"(\d)/\d", job_name)
             if match and match.group(1) != "1" or "sequential" in job_name:
-                return True, "Skipped, only job script changed - run first batch only"
+                return True, "Skipped: only CI scripts changed; running stateless batch 1 only"
 
         if JobNames.INTEGRATION in job_name:
             match = re.search(r"(\d)/\d", job_name)
@@ -287,6 +293,6 @@ def should_skip_job(job_name):
                 or "sequential" in job_name
                 or "_asan" not in job_name
             ):
-                return True, "Skipped, only job script changed - run first batch only"
+                return True, "Skipped: only CI scripts changed; running amd_asan_ubsan integration batch 1 only"
 
     return False, ""


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Prevent launch of `LLVM Merge` job when only `ci/*` files are changed. When only these files are changed, we do not launch all required FT and IT jobs. Therefore the results of code coverage are lower then they are: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=3c3cc3468ba05b92fb3eada94bf200b01d7e5e9a&name_0=MasterCI

Seen in https://github.com/ClickHouse/ClickHouse/pull/101275#issuecomment-4229745194

cc @fm4v @maxknv 

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.157`
<!-- ch-version-info:end -->