### PR TITLE
Fix flaky 03636_benchmark_error_messages under LLVM coverage

### DIFF
--- a/tests/queries/0_stateless/03636_benchmark_error_messages.sh
+++ b/tests/queries/0_stateless/03636_benchmark_error_messages.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+# Tags: no-llvm-coverage
+# - no-llvm-coverage: flaky under coverage instrumentation. The internal 10 s
+#   `connect_timeout` / `handshake_timeout` in `clickhouse-benchmark` (see
+#   `DBMS_DEFAULT_CONNECT_TIMEOUT_SEC` and `handshake_timeout_ms`) can fire
+#   under the slowdown of LLVM source-based coverage + parallel test load.
+#   The resulting `Code: 209. DB::NetException: Timeout exceeded ... (SOCKET_TIMEOUT)`
+#   is not in the `grep -v` filter list and bleeds into stdout, tripping the
+#   "exception in stdout" detector. Same pattern fixed for
+#   `02550_benchmark_connections_credentials` (PR #103298).
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
...


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---

Test `03636_benchmark_error_messages` is flaky under `amd_llvm_coverage` builds.

## Root cause

The test pipes `clickhouse-benchmark` stderr through `grep -v` filters that strip the EXPECTED error texts (`Unrecognized option '--bad-option'`, `Bad arguments: the argument ('bad value') for option '--timelimit' is invalid`, `invalid user: Authentication failed`, `Positional option 'pos_arg' is not supported.`). Anything else that lands on stdout fails the test via the "exception in stdout" detector in `clickhouse-test`.

Under `amd_llvm_coverage` builds the server is ~3-5x slower, and under parallel test load the `clickhouse-benchmark` connection / handshake path hits the internal 10 s budget set by `DBMS_DEFAULT_CONNECT_TIMEOUT_SEC` (`src/Core/Defines.h`) and `handshake_timeout_ms = 10000` (`src/Core/Settings.cpp`). When that timeout expires `Connection::connect` (`src/Client/Connection.cpp:248`) rethrows a `Poco::TimeoutException` wrapped as `NETWORK_ERROR` / `SOCKET_TIMEOUT`:

```
Code: 209. DB::NetException: Timeout exceeded while reading from socket
(peer: [::1]:9000, ..., 10000 ms): (localhost:9000, ::1,
local address: [::1]:NNNNN). (SOCKET_TIMEOUT)
```

That text is not in the `grep -v` filter list, so it leaks into stdout and fails the test.

## Evidence

CIDB footprint (last 30 days): **16 failures across 13 distinct PRs, 4 master hits — 100 % on `amd_llvm_coverage`, 0 on any non-coverage build:**

| check_name | hits |
|---|---|
| `Stateless tests (amd_llvm_coverage, 2/3)` | 10 |
| `Stateless tests (amd_llvm_coverage, AsyncInsert, s3 storage, parallel)` | 3 |
| `Stateless tests (amd_llvm_coverage, ParallelReplicas, s3 storage, parallel)` | 2 |
| `Stateless tests (amd_llvm_coverage, old analyzer, s3 storage, DatabaseReplicated, WasmEdge, parallel)` | 1 |

Every CI report shows `Failed 0 out of 3 reruns`, confirming the flake is timing-related, not a logic bug. Every failing log shows the exception with `, 10000 ms)` — the exact `connect_timeout` / `handshake_timeout` ceiling.

## Fix

Apply `no-llvm-coverage` — the established pattern for the same class of flake. The same fix was applied to the closely-related `02550_benchmark_connections_credentials` in PR #103298 with identical root-cause analysis, and to other timing-sensitive flakes on the same variant: `01473_event_time_microseconds`, `03096_order_by_system_tables`, `03258_nonexistent_db`, `04078_native_protocol_input_validation`, `01514_distributed_cancel_query_on_error`, `02293_http_header_full_summary_without_progress`.

The test continues to run on every other build (debug, ASan + UBSan, TSan, MSan, release, binary), so its `clickhouse-benchmark` argument-validation coverage is preserved. A deeper fix would require bumping `connect_timeout` / `handshake_timeout` for this test specifically, but that is outside the scope of a CI-stability fix and would complicate the test's semantics.

Local verification on debug build (`amd_debug`): 50/50 passes with full settings randomization enabled.

Example failing report (master): https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=e964f640e43bd3a1c582d0f610de73085e0ecf40&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%202%2F3%29

CI session: cron:clickhouse-ci-task-worker:20260428-094500

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.162`
<!-- ch-version-info:end -->