### PR TITLE
Skip flaky 00971 max_rows_to_read test on parallel replicas

### DIFF
--- a/tests/queries/0_stateless/00971_merge_tree_uniform_read_distribution_and_max_rows_to_read.sql
+++ b/tests/queries/0_stateless/00971_merge_tree_uniform_read_distribution_and_max_rows_to_read.sql
@@ -1,3 +1,8 @@
+-- Tags: no-parallel-replicas
+-- ^ With parallel replicas, `max_rows_to_read` is enforced per replica, so a
+-- 1M-row scan distributed across replicas can stay under the 900K limit on
+-- each replica and the expected `TOO_MANY_ROWS` error is never raised.
+
 DROP TABLE IF EXISTS merge_tree;
 CREATE TABLE merge_tree (x UInt8) ENGINE = MergeTree ORDER BY x;
 INSERT INTO merge_tree SELECT 0 FROM numbers(1000000);


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
...

### Documentation entry for user-facing changes
- [x] Documentation is written (mandatory for new features)

<!---
A non-trivial change that is hard to write a documentation entry for, requires the author to provide a short documentation entry to be included in the next user-facing release notes.
-->

### Description

`tests/queries/0_stateless/00971_merge_tree_uniform_read_distribution_and_max_rows_to_read.sql` populates a 1M-row `MergeTree` table, sets `max_rows_to_read = 900000`, and expects `SELECT count() FROM merge_tree WHERE not ignore(*)` to throw `TOO_MANY_ROWS`.

With parallel replicas the scan is split across replicas and `max_rows_to_read` is enforced per replica. Each replica then reads fewer than 900K rows, no replica trips the limit, and the expected error is never raised — the test fails with three lines of `1000000` instead of stderr.

`query_log` from the failing CI run on `Stateless tests (amd_llvm_coverage, ParallelReplicas, s3 storage, parallel)` shows the local replica reads only `786432` rows for the offending query, while the result is still `1000000`. CIDB confirms the failure is concentrated on this single configuration: 14 of 19 hits in the last 60 days, including all 3 master hits.

This is a fundamental incompatibility between a per-query row limit and parallel replicas, not a randomization or timing artifact, so the right fix is to mark the test `no-parallel-replicas` rather than rewrite the assertion.

#### Verification

- `clickhouse-test --no-parallel-replicas` (the `ParallelReplicas` runner): test is `SKIPPED` (matches the failing CI configuration).
- Server with parallel replicas enabled by default profile: `count() WHERE not ignore(*)` returns `1000000` instead of throwing — without the fix, the test fails as in CI.
- Server with parallel replicas disabled (regular CI configuration): test passes, 50/50 manual runs throw `TOO_MANY_ROWS` as expected.

CI report (one of 14 failures used for diagnosis): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=102894&sha=e68143336e75b4bb99f42e16ffa4a39d3edb125e&name_0=PR&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%20ParallelReplicas%2C%20s3%20storage%2C%20parallel%29

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.161`
<!-- ch-version-info:end -->