### PR TITLE
Cap FileLog polling-cycle backoff in 04031_filelog_drop_mv_no_exception

### DIFF
--- a/tests/queries/0_stateless/04031_filelog_drop_mv_no_exception.sh
+++ b/tests/queries/0_stateless/04031_filelog_drop_mv_no_exception.sh
@@ -36,9 +36,18 @@ for iteration in {1..5}; do
     ${CLICKHOUSE_CLIENT} --query "
         CREATE TABLE ${CLICKHOUSE_DATABASE}.filelog_dst (k UInt64, v UInt64) ENGINE = MergeTree ORDER BY k
     "
+    # `FileLog` polls the directory using exponential backoff. The default
+    # `poll_directory_watch_events_backoff_max` is 32s, and under sanitizer
+    # builds (especially `MSan` and `ASan`+azure) with `BackgroundSchedulePool`
+    # contention the polling cycle can drift to that upper bound, so the
+    # 150s warm-up loop below occasionally times out before the file is
+    # picked up. Cap the backoff at 1s to bound the worst-case polling
+    # cycle to ~1s plus scheduling jitter — same pattern as in
+    # `02968_file_log_multiple_read`.
     ${CLICKHOUSE_CLIENT} --query "
         CREATE TABLE ${CLICKHOUSE_DATABASE}.filelog_src (k UInt64, v UInt64)
         ENGINE = FileLog('${DATA_DIR}/', 'CSV')
+        SETTINGS poll_directory_watch_events_backoff_max = 1000
     "
     ${CLICKHOUSE_CLIENT} --query "
         CREATE MATERIALIZED VIEW ${CLICKHOUSE_DATABASE}.filelog_mv TO ${CLICKHOUSE_DATABASE}.filelog_dst


### PR DESCRIPTION
The 150s warm-up loop in `04031_filelog_drop_mv_no_exception` polls the
destination MergeTree table waiting for the `FileLog` background thread
to ingest the prepared CSV file. The default
`poll_directory_watch_events_backoff_max` is 32s, and under sanitizer
builds with `BackgroundSchedulePool` contention the polling cycle can
drift to that upper bound. On slow runners (`ASan`+azure, `MSan`+WasmEdge)
the file is occasionally not picked up within 150s and the test reports
`Warm-up failed: only 0 rows consumed after 300 attempts`.

CIDB for the 30-day window after #102386 merged the timeout bump
(2026-04-17) shows 12 failures still remaining — 10/12 with the warm-up
timeout signature, dominated by
`Stateless tests (arm_asan_ubsan, azure, sequential)` (10 hits) and
`amd_msan` variants (2 hits).

Cap `poll_directory_watch_events_backoff_max` at 1s on the test's
`FileLog` table so the worst-case polling cycle is bounded by 1s plus
scheduling jitter, well below the 150s warm-up loop. Same pattern as
#103602 for sister test `02968_file_log_multiple_read`.

The fix preserves the test's original purpose (regression test for
`DEPENDENCIES_NOT_FOUND` race when the materialized view is dropped
during streaming) — only the file-detection latency is bounded, the
DROP-during-streaming race window is unchanged.

Verified locally:
- 50/50 passes with `--no-random-settings --no-random-merge-tree-settings`.
- Deterministic repro without the fix: with
  `poll_directory_watch_events_backoff_init=200000`,
  `poll_directory_watch_events_backoff_max=200000` (simulating a 200s
  polling cycle), the warm-up fails: `REPRODUCED: only 0 rows after 150s warm-up`.

CI report (sample failure on `amd_msan` WasmEdge):
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=102302&sha=a4cc3a4d5acd3ee9dae8860b032a8fe7b91b2dce&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20sequential%2C%202%2F2%29

Closes https://github.com/ClickHouse/ClickHouse/issues/102388

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Cap `poll_directory_watch_events_backoff_max` at 1s in flaky test `04031_filelog_drop_mv_no_exception` to prevent warm-up timeouts on slow sanitizer/azure runners.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.160`
<!-- ch-version-info:end -->