### PR TITLE
Refactor S3 credential chain and AWS logging for region resolution

### DIFF
--- a/src/IO/S3/AWSLogger.cpp
+++ b/src/IO/S3/AWSLogger.cpp
@@ -3,6 +3,8 @@
 #include <IO/Expect404ResponseScope.h>
 #include <Poco/Net/HTTPResponse.h>
 
+#include <string_view>
+
 #if USE_AWS_S3
 
 #include <Core/SettingsEnums.h>
@@ -69,10 +71,32 @@ bool startsWith(const char * str, const char * prefix)
     return *prefix == 0;
 }
 
-bool is404Muted(const char * message)
+/// Case-insensitive substring search; right now only used on the cold 400-error path,
+/// so we don't worry about the implicit strlen here.
+bool containsCaseInsensitive(std::string_view haystack, std::string_view needle)
 {
+    const auto case_eq = [](char a, char b)
+    {
+        return std::tolower(static_cast<unsigned char>(a))
+            == std::tolower(static_cast<unsigned char>(b));
+    };
+    return std::search(haystack.begin(), haystack.end(), needle.begin(), needle.end(), case_eq) != haystack.end();
+}
+
+/// Mute logs from `AWSXMLClient::BuildAWSError` for S3 wrong-signing-region 400
+bool isWrongSigningRegionMuted(const char * message)
+{
+    static const char * prefix = "HTTP response code: 400";
+    if (!startsWith(message, prefix))
+        return false;
+
+    return containsCaseInsensitive(message, "x-amz-bucket-region");
+}
+
     /// This is the way, how to mute scary logs from `AWSXMLClient::BuildAWSError`
     /// about 404 when 404 is the expected response
+bool is404Muted(const char * message)
+{
     if (!Expect404ResponseScope::is404Expected())
         return false;
 
@@ -96,20 +120,26 @@ bool is404Muted(const char * message)
 
     return code == Poco::Net::HTTPResponse::HTTP_NOT_FOUND;
 }
+
+bool isExpectedAwsHttpResponseMuted(const char * message)
+{
+    return isWrongSigningRegionMuted(message) || is404Muted(message);
+}
 }
 
 void AWSLogger::Log(Aws::Utils::Logging::LogLevel log_level, const char * tag, const char * format_str, ...) // NOLINT
 {
-    if (is404Muted(format_str))
+    if (format_str && isExpectedAwsHttpResponseMuted(format_str))
         return;
     callLogImpl(log_level, tag, format_str); /// FIXME. Variadic arguments?
 }
 
 void AWSLogger::LogStream(Aws::Utils::Logging::LogLevel log_level, const char * tag, const Aws::OStringStream & message_stream)
 {
-    if (is404Muted(message_stream.str().c_str()))
+    const auto str = message_stream.str();
+    if (isExpectedAwsHttpResponseMuted(str.c_str()))
         return;
-    callLogImpl(log_level, tag, message_stream.str().c_str());
+    callLogImpl(log_level, tag, str.c_str());
 }
 
 void AWSLogger::callLogImpl(Aws::Utils::Logging::LogLevel log_level, const char * tag, const char * message)
@@ -123,7 +153,7 @@ void AWSLogger::callLogImpl(Aws::Utils::Logging::LogLevel log_level, const char 
 
 void AWSLogger::vaLog(Aws::Utils::Logging::LogLevel log_level, const char * tag, const char * format_str, va_list)
 {
-    if (is404Muted(format_str))
+    if (format_str && isExpectedAwsHttpResponseMuted(format_str))
         return;
     callLogImpl(log_level, tag, format_str); /// FIXME. Variadic arguments?
 }

--- a/src/IO/S3/AWSLogger.cpp
+++ b/src/IO/S3/AWSLogger.cpp
@@ -9,6 +9,7 @@
 
 #include <Core/SettingsEnums.h>
 #include <Common/logger_useful.h>
+#include <boost/algorithm/string/predicate.hpp>
 #include <aws/core/utils/logging/LogLevel.h>
 #include <Poco/Logger.h>
 
@@ -60,68 +61,39 @@ Aws::Utils::Logging::LogLevel AWSLogger::GetLogLevel() const
 
 namespace
 {
-/// This function helps to avoid reading the whole str when strlen is called
-bool startsWith(const char * str, const char * prefix)
-{
-    while (*prefix && *str == *prefix)
-    {
-        ++str;
-        ++prefix;
-    }
-    return *prefix == 0;
-}
-
-/// Case-insensitive substring search; right now only used on the cold 400-error path,
-/// so we don't worry about the implicit strlen here.
-bool containsCaseInsensitive(std::string_view haystack, std::string_view needle)
-{
-    const auto case_eq = [](char a, char b)
-    {
-        return std::tolower(static_cast<unsigned char>(a))
-            == std::tolower(static_cast<unsigned char>(b));
-    };
-    return std::search(haystack.begin(), haystack.end(), needle.begin(), needle.end(), case_eq) != haystack.end();
-}
 
 /// Mute logs from `AWSXMLClient::BuildAWSError` for S3 wrong-signing-region 400
-bool isWrongSigningRegionMuted(const char * message)
+bool isWrongSigningRegionMuted(const std::string_view message)
 {
-    static const char * prefix = "HTTP response code: 400";
-    if (!startsWith(message, prefix))
+    static constexpr std::string_view  prefix = "HTTP response code: 400";
+    if (!boost::starts_with(message, prefix))
         return false;
 
-    return containsCaseInsensitive(message, "x-amz-bucket-region");
+    return boost::icontains(message, "x-amz-bucket-region");
 }
 
     /// This is the way, how to mute scary logs from `AWSXMLClient::BuildAWSError`
     /// about 404 when 404 is the expected response
-bool is404Muted(const char * message)
+bool is404Muted(std::string_view message)
 {
     if (!Expect404ResponseScope::is404Expected())
         return false;
 
-    static const char * prefix_str = "HTTP response code: ";
-    static const size_t prefix_len = strlen(prefix_str);
-
-    if (!startsWith(message, prefix_str))
+    static constexpr std::string_view prefix = "HTTP response code: ";
+    if (!boost::starts_with(message, prefix))
         return false;
 
-    const char * code_str = message + prefix_len;
-    size_t code_len = 3;
-
-    // check that strlen(code_str) >= code_len
-    for (size_t i = 0; i < code_len; ++i)
-        if (!code_str[i])
-            return false;
+    if (message.size() < prefix.size() + 3)
+        return false;
 
     UInt64 code = 0;
-    if (!tryParse<UInt64>(code, code_str, code_len))
+    if (!tryParse<UInt64>(code, message.data() + prefix.size(), 3))
         return false;
 
     return code == Poco::Net::HTTPResponse::HTTP_NOT_FOUND;
 }
 
-bool isExpectedAwsHttpResponseMuted(const char * message)
+bool isExpectedAwsHttpResponseMuted(const std::string_view message)
 {
     return isWrongSigningRegionMuted(message) || is404Muted(message);
 }

--- a/src/IO/S3/AWSLogger.cpp
+++ b/src/IO/S3/AWSLogger.cpp
@@ -66,7 +66,7 @@ namespace
 bool isWrongSigningRegionMuted(const std::string_view message)
 {
     static constexpr std::string_view  prefix = "HTTP response code: 400";
-    if (!boost::starts_with(message, prefix))
+    if (!message.starts_with(prefix))
         return false;
 
     return boost::icontains(message, "x-amz-bucket-region");
@@ -80,7 +80,7 @@ bool is404Muted(std::string_view message)
         return false;
 
     static constexpr std::string_view prefix = "HTTP response code: ";
-    if (!boost::starts_with(message, prefix))
+    if (!message.starts_with(prefix))
         return false;
 
     if (message.size() < prefix.size() + 3)
@@ -109,7 +109,7 @@ void AWSLogger::Log(Aws::Utils::Logging::LogLevel log_level, const char * tag, c
 void AWSLogger::LogStream(Aws::Utils::Logging::LogLevel log_level, const char * tag, const Aws::OStringStream & message_stream)
 {
     const auto str = message_stream.str();
-    if (isExpectedAwsHttpResponseMuted(str.c_str()))
+    if (isExpectedAwsHttpResponseMuted(str))
         return;
     callLogImpl(log_level, tag, str.c_str());
 }

--- a/src/IO/S3/Credentials.cpp
+++ b/src/IO/S3/Credentials.cpp
@@ -702,8 +702,6 @@ void AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider::CacheKey::updateHash(Si
     hash.update(session_name);
 }
 
-
-
 bool AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider::isWebIdentityConfigured(const String & kms_role_arn_override)
 {
     auto resolved = resolveWebIdentitySettingsFromEnvironmentAndProfile(kms_role_arn_override);

--- a/src/IO/S3/Credentials.cpp
+++ b/src/IO/S3/Credentials.cpp
@@ -116,12 +116,12 @@ struct ResolvedWebIdentitySettings
     String tmp_region;
 };
 
-ResolvedWebIdentitySettings resolveWebIdentitySettingsFromEnvironmentAndProfile(const String & role_arn_override)
+ResolvedWebIdentitySettings resolveWebIdentitySettingsFromEnvironmentAndProfile(const String & role_arn_)
 {
     ResolvedWebIdentitySettings resolved;
     // check environment variables
     resolved.tmp_region = Aws::Environment::GetEnv("AWS_DEFAULT_REGION");
-    resolved.role_arn = role_arn_override.empty() ? Aws::Environment::GetEnv("AWS_ROLE_ARN") : role_arn_override;
+    resolved.role_arn = role_arn_.empty() ? Aws::Environment::GetEnv("AWS_ROLE_ARN") : role_arn_;
     resolved.token_file = Aws::Environment::GetEnv("AWS_WEB_IDENTITY_TOKEN_FILE");
     resolved.session_name = Aws::Environment::GetEnv("AWS_ROLE_SESSION_NAME");
 
@@ -702,10 +702,11 @@ void AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider::CacheKey::updateHash(Si
     hash.update(session_name);
 }
 
-bool AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider::isWebIdentityConfigured(const String & kms_role_arn_override)
+bool AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider::isWebIdentityConfigured(const String & role_arn_)
 {
-    auto resolved = resolveWebIdentitySettingsFromEnvironmentAndProfile(kms_role_arn_override);
-    return !resolved.token_file.empty() && !resolved.role_arn.empty();
+    auto resolved = resolveWebIdentitySettingsFromEnvironmentAndProfile(role_arn_);
+    // Either field set means that the operator likely intends web identity, so we still add the provider to warn about misconf. later
+    return !resolved.token_file.empty() || !resolved.role_arn.empty();
 }
 
 std::shared_ptr<Aws::Auth::AWSCredentialsProvider> AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider::create(
@@ -1005,7 +1006,8 @@ S3CredentialsProviderChain::S3CredentialsProviderChain(
         ///
         /// AWS API tries credentials providers one by one. Some of providers (like ProfileConfigFileAWSCredentialsProvider) can be
         /// quite verbose even if nobody configured them. So we use our provider first and only after it use default providers.
-        /// STS web identity is added only when role ARN and token file are configured, so plain EC2/IMDS setups avoid extra warnings.
+        /// STS web identity is added only when role ARN or token file are configured (likely a misconfiguration)
+        //  additionally, plain EC2/IMDS setups avoid extra warning
         if (AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider::isWebIdentityConfigured(credentials_configuration.kms_role_arn))
         {
             DB::S3::PocoHTTPClientConfiguration aws_client_configuration = DB::S3::ClientFactory::instance().createClientConfiguration(

--- a/src/IO/S3/Credentials.cpp
+++ b/src/IO/S3/Credentials.cpp
@@ -108,6 +108,42 @@ bool areCredentialsEmptyOrExpired(const Aws::Auth::AWSCredentials & credentials,
     return now >= credentials.GetExpiration() - std::chrono::seconds(expiration_window_seconds);
 }
 
+struct ResolvedWebIdentitySettings
+{
+    Aws::String role_arn;
+    Aws::String token_file;
+    Aws::String session_name;
+    String tmp_region;
+};
+
+ResolvedWebIdentitySettings resolveWebIdentitySettingsFromEnvironmentAndProfile(const String & role_arn_override)
+{
+    ResolvedWebIdentitySettings resolved;
+    // check environment variables
+    resolved.tmp_region = Aws::Environment::GetEnv("AWS_DEFAULT_REGION");
+    resolved.role_arn = role_arn_override.empty() ? Aws::Environment::GetEnv("AWS_ROLE_ARN") : role_arn_override;
+    resolved.token_file = Aws::Environment::GetEnv("AWS_WEB_IDENTITY_TOKEN_FILE");
+    resolved.session_name = Aws::Environment::GetEnv("AWS_ROLE_SESSION_NAME");
+
+    // check profile_config if either m_roleArn or m_tokenFile is not loaded from environment variable
+    // region source is not enforced, but we need it to construct sts endpoint, if we can't find from environment, we should check if it's set in config file.
+    if (resolved.role_arn.empty() || resolved.token_file.empty() || resolved.tmp_region.empty())
+    {
+        auto profile = Aws::Config::GetCachedConfigProfile(Aws::Auth::GetConfigProfileName());
+        if (resolved.tmp_region.empty())
+            resolved.tmp_region = profile.GetRegion();
+        // If either of these two were not found from environment, use whatever found for all three in config file
+        if (resolved.role_arn.empty() || resolved.token_file.empty())
+        {
+            resolved.role_arn = profile.GetRoleArn();
+            resolved.token_file = profile.GetValue("web_identity_token_file");
+            resolved.session_name = profile.GetValue("role_session_name");
+        }
+    }
+
+    return resolved;
+}
+
 const char SSO_CREDENTIALS_PROVIDER_LOG_TAG[] = "SSOCredentialsProvider";
 constexpr int AVAILABILITY_ZONE_REQUEST_TIMEOUT_SECONDS = 3;
 
@@ -666,34 +702,24 @@ void AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider::CacheKey::updateHash(Si
     hash.update(session_name);
 }
 
+
+
+bool AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider::isWebIdentityConfigured(const String & kms_role_arn_override)
+{
+    auto resolved = resolveWebIdentitySettingsFromEnvironmentAndProfile(kms_role_arn_override);
+    return !resolved.token_file.empty() && !resolved.role_arn.empty();
+}
+
 std::shared_ptr<Aws::Auth::AWSCredentialsProvider> AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider::create(
     DB::S3::PocoHTTPClientConfiguration & aws_client_configuration, uint64_t expiration_window_seconds_, String role_arn_)
 {
     auto logger = getLogger("AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider");
 
-    // check environment variables
-    String tmp_region = Aws::Environment::GetEnv("AWS_DEFAULT_REGION");
-    Aws::String role_arn = role_arn_.empty() ? Aws::Environment::GetEnv("AWS_ROLE_ARN") : role_arn_;
-    Aws::String token_file = Aws::Environment::GetEnv("AWS_WEB_IDENTITY_TOKEN_FILE");
-    Aws::String session_name = Aws::Environment::GetEnv("AWS_ROLE_SESSION_NAME");
-
-    // check profile_config if either m_roleArn or m_tokenFile is not loaded from environment variable
-    // region source is not enforced, but we need it to construct sts endpoint, if we can't find from environment, we should check if it's set in config file.
-    if (role_arn.empty() || token_file.empty() || tmp_region.empty())
-    {
-        auto profile = Aws::Config::GetCachedConfigProfile(Aws::Auth::GetConfigProfileName());
-        if (tmp_region.empty())
-        {
-            tmp_region = profile.GetRegion();
-        }
-        // If either of these two were not found from environment, use whatever found for all three in config file
-        if (role_arn.empty() || token_file.empty())
-        {
-            role_arn = profile.GetRoleArn();
-            token_file = profile.GetValue("web_identity_token_file");
-            session_name = profile.GetValue("role_session_name");
-        }
-    }
+    auto resolved = resolveWebIdentitySettingsFromEnvironmentAndProfile(role_arn_);
+    Aws::String role_arn = std::move(resolved.role_arn);
+    Aws::String token_file = std::move(resolved.token_file);
+    Aws::String session_name = std::move(resolved.session_name);
+    String tmp_region = std::move(resolved.tmp_region);
 
     auto empty_credentials = std::make_shared<Aws::Auth::AnonymousAWSCredentialsProvider>();
     if (token_file.empty())
@@ -981,6 +1007,8 @@ S3CredentialsProviderChain::S3CredentialsProviderChain(
         ///
         /// AWS API tries credentials providers one by one. Some of providers (like ProfileConfigFileAWSCredentialsProvider) can be
         /// quite verbose even if nobody configured them. So we use our provider first and only after it use default providers.
+        /// STS web identity is added only when role ARN and token file are configured, so plain EC2/IMDS setups avoid extra warnings.
+        if (AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider::isWebIdentityConfigured(credentials_configuration.kms_role_arn))
         {
             DB::S3::PocoHTTPClientConfiguration aws_client_configuration = DB::S3::ClientFactory::instance().createClientConfiguration(
                 configuration.region,

--- a/src/IO/S3/Credentials.h
+++ b/src/IO/S3/Credentials.h
@@ -144,8 +144,9 @@ public:
     static std::shared_ptr<Aws::Auth::AWSCredentialsProvider>
     create(DB::S3::PocoHTTPClientConfiguration & aws_client_configuration, uint64_t expiration_window_seconds_, String role_arn_ = "");
 
-    /// True when a role ARN and `web_identity_token_file` are set (environment, profile, or `kms_role_arn_override` for the role).
-    static bool isWebIdentityConfigured(const String & kms_role_arn_override = {});
+    /// True when a role ARN or `web_identity_token_file` is set (environment, profile, or non-empty `role_arn_` override).
+    /// Used to decide whether to add web identity to the credentials chain so partial misconfiguration still surfaces `create` warnings.
+    static bool isWebIdentityConfigured(const String & role_arn_ = {});
 
     explicit AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider(
         DB::S3::PocoHTTPClientConfiguration & aws_client_configuration,

--- a/src/IO/S3/Credentials.h
+++ b/src/IO/S3/Credentials.h
@@ -144,6 +144,9 @@ public:
     static std::shared_ptr<Aws::Auth::AWSCredentialsProvider>
     create(DB::S3::PocoHTTPClientConfiguration & aws_client_configuration, uint64_t expiration_window_seconds_, String role_arn_ = "");
 
+    /// True when a role ARN and `web_identity_token_file` are set (environment, profile, or `kms_role_arn_override` for the role).
+    static bool isWebIdentityConfigured(const String & kms_role_arn_override = {});
+
     explicit AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider(
         DB::S3::PocoHTTPClientConfiguration & aws_client_configuration,
         uint64_t expiration_window_seconds_,

--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -102,6 +102,15 @@ namespace HistogramMetrics
 namespace DB::S3
 {
 
+bool isS3WrongSigningRegionBadRequest(int status_code, const Poco::Net::HTTPMessage & response)
+{
+    if (status_code != Poco::Net::HTTPResponse::HTTP_BAD_REQUEST)
+        return false;
+    if (!response.has("x-amz-bucket-region"))
+        return false;
+    return !response.get("x-amz-bucket-region").empty();
+}
+
 PocoHTTPClientConfiguration::PocoHTTPClientConfiguration(
     std::function<ProxyConfiguration()> per_request_configuration_,
     const String & force_region_,
@@ -653,6 +662,17 @@ void PocoHTTPClient::makeRequestInternalImpl(
                 /// PreconditionFailed (412) is an expected response for conditional writes
                 /// (e.g. If-None-Match: *), not a genuine error.
                 LOG_INFO(log, "Response status: {}, {}", status_code, poco_response.getReason());
+            }
+            else if (isS3WrongSigningRegionBadRequest(status_code, poco_response))
+            {
+                /// Wrong signing region: S3 returns 400 and `x-amz-bucket-region`; `getRegionForBucket` recovers.
+                const auto suggested_region = poco_response.get("x-amz-bucket-region");
+                LOG_INFO(
+                    log,
+                    "Response status: {}, {}. Wrong signing region; server suggests bucket region '{}' in `x-amz-bucket-region`",
+                    status_code,
+                    poco_response.getReason(),
+                    suggested_region);
             }
             else if (Poco::Net::HTTPResponse::HTTP_NOT_FOUND != status_code || !Expect404ResponseScope::is404Expected())
             {

--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -666,13 +666,11 @@ void PocoHTTPClient::makeRequestInternalImpl(
             else if (isS3WrongSigningRegionBadRequest(status_code, poco_response))
             {
                 /// Wrong signing region: S3 returns 400 and `x-amz-bucket-region`; `getRegionForBucket` recovers.
-                const auto suggested_region = poco_response.get("x-amz-bucket-region");
                 LOG_INFO(
                     log,
-                    "Response status: {}, {}. Wrong signing region; server suggests bucket region '{}' in `x-amz-bucket-region`",
+                    "Response status: {}, {}. Wrong signing region.",
                     status_code,
-                    poco_response.getReason(),
-                    suggested_region);
+                    poco_response.getReason());
             }
             else if (Poco::Net::HTTPResponse::HTTP_NOT_FOUND != status_code || !Expect404ResponseScope::is404Expected())
             {

--- a/src/IO/S3/PocoHTTPClient.h
+++ b/src/IO/S3/PocoHTTPClient.h
@@ -35,9 +35,16 @@ namespace DB
 class Context;
 }
 
+namespace Poco::Net
+{
+class HTTPMessage;
+}
 
 namespace DB::S3
 {
+
+/// HTTP 400 from S3 with non-empty `x-amz-bucket-region` (wrong SigV4 signing region for the bucket).
+bool isS3WrongSigningRegionBadRequest(int status_code, const Poco::Net::HTTPMessage & response);
 
 class ClientFactory;
 class PocoHTTPClient;

--- a/src/IO/S3/tests/gtest_aws_logger.cpp
+++ b/src/IO/S3/tests/gtest_aws_logger.cpp
@@ -1,0 +1,123 @@
+#include <gtest/gtest.h>
+
+#include "config.h"
+
+#if USE_AWS_S3
+
+#include <sstream>
+
+#include <aws/core/utils/logging/LogLevel.h>
+#include <aws/core/utils/memory/stl/AWSStringStream.h>
+
+#include <Poco/AutoPtr.h>
+#include <Poco/StreamChannel.h>
+
+#include <Common/logger_useful.h>
+
+#include <IO/Expect404ResponseScope.h>
+#include <IO/S3/AWSLogger.h>
+
+namespace
+{
+
+/// Captures log lines written to the shared `AWSClient` logger used by `DB::S3::AWSLogger`.
+struct ScopedAWSClientLoggerRecording
+{
+    LoggerPtr logger = getLogger("AWSClient");
+    std::ostringstream stream; // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+    Poco::AutoPtr<Poco::StreamChannel> channel = new Poco::StreamChannel(stream);
+    Poco::Channel * old_channel = nullptr;
+    int old_level = 0;
+
+    ScopedAWSClientLoggerRecording()
+    {
+        old_channel = logger->getChannel();
+        old_level = logger->getLevel();
+        logger->setChannel(channel.get());
+        logger->setLevel("trace");
+    }
+
+    ~ScopedAWSClientLoggerRecording()
+    {
+        logger->setChannel(old_channel);
+        logger->setLevel(old_level);
+    }
+
+    std::string captured() const { return stream.str(); }
+};
+
+}
+
+/// Stream starts with HTTP response code: 400 and contains x-amz-bucket-region
+/// Deliberately mixed-case for checking case insensitivity
+TEST(IOTestAwsLogger, LogStreamMutesWrongSigningRegion400)
+{
+    ScopedAWSClientLoggerRecording recording;
+    DB::S3::AWSLogger aws_logger(false);
+
+    Aws::OStringStream oss;
+    oss << "HTTP response code: 400 ... X-Amz-Bucket-Region: us-east-1";
+
+    aws_logger.LogStream(Aws::Utils::Logging::LogLevel::Info, "AWSClient", oss);
+    EXPECT_TRUE(recording.captured().empty());
+}
+
+/// 400 without bucket-region hint, output expected
+TEST(IOTestAwsLogger, LogStreamDoesNotMute400WithoutBucketRegionHeader)
+{
+    ScopedAWSClientLoggerRecording recording;
+    DB::S3::AWSLogger aws_logger(false);
+
+    Aws::OStringStream oss;
+    oss << "HTTP response code: 400 some other error";
+
+    aws_logger.LogStream(Aws::Utils::Logging::LogLevel::Info, "AWSClient", oss);
+    EXPECT_FALSE(recording.captured().empty());
+    EXPECT_NE(recording.captured().find("HTTP response code: 400"), std::string::npos);
+}
+
+/// Scope + 404 -> no output
+TEST(IOTestAwsLogger, LogStreamMutesExpected404InsideScope)
+{
+    ScopedAWSClientLoggerRecording recording;
+    DB::S3::AWSLogger aws_logger(false);
+
+    {
+        DB::Expect404ResponseScope expect_404;
+        Aws::OStringStream oss;
+        oss << "HTTP response code: 404";
+        aws_logger.LogStream(Aws::Utils::Logging::LogLevel::Info, "AWSClient", oss);
+    }
+    EXPECT_TRUE(recording.captured().empty());
+}
+
+/// No scope + 404 -> outputs
+TEST(IOTestAwsLogger, LogStreamDoesNotMute404OutsideScope)
+{
+    ScopedAWSClientLoggerRecording recording;
+    DB::S3::AWSLogger aws_logger(false);
+
+    Aws::OStringStream oss;
+    oss << "HTTP response code: 404";
+    aws_logger.LogStream(Aws::Utils::Logging::LogLevel::Info, "AWSClient", oss);
+    EXPECT_FALSE(recording.captured().empty());
+    EXPECT_NE(recording.captured().find("HTTP response code: 404"), std::string::npos);
+}
+
+/// Scope + 403 -> outputs
+TEST(IOTestAwsLogger, LogStreamDoesNotMuteNon404InsideExpect404Scope)
+{
+    ScopedAWSClientLoggerRecording recording;
+    DB::S3::AWSLogger aws_logger(false);
+
+    {
+        DB::Expect404ResponseScope expect_404;
+        Aws::OStringStream oss;
+        oss << "HTTP response code: 403";
+        aws_logger.LogStream(Aws::Utils::Logging::LogLevel::Info, "AWSClient", oss);
+    }
+    EXPECT_FALSE(recording.captured().empty());
+    EXPECT_NE(recording.captured().find("HTTP response code: 403"), std::string::npos);
+}
+
+#endif

--- a/src/IO/S3/tests/gtest_aws_s3_client.cpp
+++ b/src/IO/S3/tests/gtest_aws_s3_client.cpp
@@ -6,10 +6,15 @@
 
 #if USE_AWS_S3
 
+#include <cstdlib>
 #include <memory>
+#include <string>
+
+#include <base/scope_guard.h>
 
 #include <boost/algorithm/string/split.hpp>
 
+#include <Poco/Net/HTTPResponse.h>
 #include <Poco/URI.h>
 
 #include <aws/core/client/AWSError.h>
@@ -24,6 +29,7 @@
 #include <IO/WriteBufferFromS3.h>
 #include <IO/S3Common.h>
 #include <IO/S3/Client.h>
+#include <IO/S3/PocoHTTPClient.h>
 #include <IO/HTTPHeaderEntries.h>
 #include <IO/S3Settings.h>
 #include <Poco/Util/ServerApplication.h>
@@ -45,6 +51,13 @@ namespace DB::S3RequestSetting
  * */
 [[maybe_unused]] static Poco::Util::ServerApplication app;
 
+static void restoreEnvVarForAwsS3ClientTests(const char * name, bool had_value, const std::string & saved_value)
+{
+    if (had_value)
+        (void)::setenv(name, saved_value.c_str(), 1); // NOLINT(concurrency-mt-unsafe)
+    else
+        (void)::setenv(name, "", 1); // NOLINT(concurrency-mt-unsafe)
+}
 
 String getSSEAndSignedHeaders(const Poco::Net::MessageHeader & message_header)
 {
@@ -583,6 +596,87 @@ TEST(IOTestAwsS3Client, AssumeRole)
         ASSERT_TRUE(sts_http.hasLastRequest());
         validateCredential(get_credential_string(sts_http.getLastRequestHeader()), "sts", access_key_id, region);
         validateAssumeRoleQueryParams(sts_http.getLastQueryParams(), role_arn, "ClickHouseSession");
+    }
+}
+
+TEST(IOTestAwsS3Client, WebIdentityConfiguredFromEnvironment)
+{
+    constexpr const char * k_role = "AWS_ROLE_ARN";
+    constexpr const char * k_token = "AWS_WEB_IDENTITY_TOKEN_FILE";
+
+    const char * prev_role = std::getenv(k_role); // NOLINT(concurrency-mt-unsafe)
+    const char * prev_token = std::getenv(k_token); // NOLINT(concurrency-mt-unsafe)
+    const bool had_role = prev_role && *prev_role;
+    const bool had_token = prev_token && *prev_token;
+    const std::string saved_role = had_role ? std::string(prev_role) : std::string();
+    const std::string saved_token = had_token ? std::string(prev_token) : std::string();
+
+    SCOPE_EXIT({ restoreEnvVarForAwsS3ClientTests(k_role, had_role, saved_role); });
+    SCOPE_EXIT({ restoreEnvVarForAwsS3ClientTests(k_token, had_token, saved_token); });
+
+    ASSERT_EQ(0, ::setenv(k_role, "arn:aws:iam::123456789012:role/clickhouse_unit_test_role", 1)); // NOLINT(concurrency-mt-unsafe)
+    ASSERT_EQ(0, ::setenv(k_token, "/tmp/clickhouse_web_identity_token_path_for_gtest", 1)); // NOLINT(concurrency-mt-unsafe)
+
+    EXPECT_TRUE(DB::S3::AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider::isWebIdentityConfigured({}));
+}
+
+TEST(IOTestAwsS3Client, WebIdentityConfiguredFromKmsRoleOverrideAndTokenFile)
+{
+    constexpr const char * k_role = "AWS_ROLE_ARN";
+    constexpr const char * k_token = "AWS_WEB_IDENTITY_TOKEN_FILE";
+
+    const char * prev_role = std::getenv(k_role); // NOLINT(concurrency-mt-unsafe)
+    const char * prev_token = std::getenv(k_token); // NOLINT(concurrency-mt-unsafe)
+    const bool had_role = prev_role && *prev_role;
+    const bool had_token = prev_token && *prev_token;
+    const std::string saved_role = had_role ? std::string(prev_role) : std::string();
+    const std::string saved_token = had_token ? std::string(prev_token) : std::string();
+
+    SCOPE_EXIT({ restoreEnvVarForAwsS3ClientTests(k_role, had_role, saved_role); });
+    SCOPE_EXIT({ restoreEnvVarForAwsS3ClientTests(k_token, had_token, saved_token); });
+
+    ASSERT_EQ(0, ::setenv(k_role, "", 1)); // NOLINT(concurrency-mt-unsafe)
+    ASSERT_EQ(0, ::setenv(k_token, "/tmp/clickhouse_web_identity_token_path_for_gtest_override", 1)); // NOLINT(concurrency-mt-unsafe)
+
+    EXPECT_TRUE(DB::S3::AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider::isWebIdentityConfigured(
+        "arn:aws:iam::123456789012:role/from_kms_role_arn_override"));
+}
+
+TEST(IOTestAwsS3Client, WrongSigningRegionBadRequest)
+{
+    {
+        SCOPED_TRACE("400 with non-empty x-amz-bucket-region");
+        Poco::Net::HTTPResponse response;
+        response.setStatus(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
+        response.set("x-amz-bucket-region", "us-west-2");
+        EXPECT_TRUE(DB::S3::isS3WrongSigningRegionBadRequest(400, response));
+    }
+    {
+        SCOPED_TRACE("2xx with header");
+        Poco::Net::HTTPResponse response;
+        response.setStatus(Poco::Net::HTTPResponse::HTTP_OK);
+        response.set("x-amz-bucket-region", "eu-central-1");
+        EXPECT_FALSE(DB::S3::isS3WrongSigningRegionBadRequest(200, response));
+    }
+    {
+        SCOPED_TRACE("400 without header");
+        Poco::Net::HTTPResponse response;
+        response.setStatus(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
+        EXPECT_FALSE(DB::S3::isS3WrongSigningRegionBadRequest(400, response));
+    }
+    {
+        SCOPED_TRACE("400 with empty x-amz-bucket-region");
+        Poco::Net::HTTPResponse response;
+        response.setStatus(Poco::Net::HTTPResponse::HTTP_BAD_REQUEST);
+        response.set("x-amz-bucket-region", "");
+        EXPECT_FALSE(DB::S3::isS3WrongSigningRegionBadRequest(400, response));
+    }
+    {
+        SCOPED_TRACE("404 with header");
+        Poco::Net::HTTPResponse response;
+        response.setStatus(Poco::Net::HTTPResponse::HTTP_NOT_FOUND);
+        response.set("x-amz-bucket-region", "ap-south-1");
+        EXPECT_FALSE(DB::S3::isS3WrongSigningRegionBadRequest(404, response));
     }
 }
 

--- a/src/IO/S3/tests/gtest_aws_s3_client.cpp
+++ b/src/IO/S3/tests/gtest_aws_s3_client.cpp
@@ -54,9 +54,13 @@ namespace DB::S3RequestSetting
 static void restoreEnvVarForAwsS3ClientTests(const char * name, bool had_value, const std::string & saved_value)
 {
     if (had_value)
+    {
         (void)::setenv(name, saved_value.c_str(), 1); // NOLINT(concurrency-mt-unsafe)
+    }
     else
-        (void)::setenv(name, "", 1); // NOLINT(concurrency-mt-unsafe)
+    {
+        (void)::unsetenv(name); // NOLINT(concurrency-mt-unsafe)
+    }
 }
 
 String getSSEAndSignedHeaders(const Poco::Net::MessageHeader & message_header)
@@ -606,8 +610,8 @@ TEST(IOTestAwsS3Client, WebIdentityConfiguredFromEnvironment)
 
     const char * prev_role = std::getenv(k_role); // NOLINT(concurrency-mt-unsafe)
     const char * prev_token = std::getenv(k_token); // NOLINT(concurrency-mt-unsafe)
-    const bool had_role = prev_role && *prev_role;
-    const bool had_token = prev_token && *prev_token;
+    const bool had_role = prev_role != nullptr;
+    const bool had_token = prev_token != nullptr;
     const std::string saved_role = had_role ? std::string(prev_role) : std::string();
     const std::string saved_token = had_token ? std::string(prev_token) : std::string();
 
@@ -627,8 +631,8 @@ TEST(IOTestAwsS3Client, WebIdentityConfiguredFromKmsRoleOverrideAndTokenFile)
 
     const char * prev_role = std::getenv(k_role); // NOLINT(concurrency-mt-unsafe)
     const char * prev_token = std::getenv(k_token); // NOLINT(concurrency-mt-unsafe)
-    const bool had_role = prev_role && *prev_role;
-    const bool had_token = prev_token && *prev_token;
+    const bool had_role = prev_role != nullptr;
+    const bool had_token = prev_token != nullptr;
     const std::string saved_role = had_role ? std::string(prev_role) : std::string();
     const std::string saved_token = had_token ? std::string(prev_token) : std::string();
 


### PR DESCRIPTION


S3 sometimes returns HTTP 400 with x-amz-bucket-region when the request was signed for the wrong region; 
 ClickHouse already recovers via getRegionForBucket, but those responses were easy to misread as ordinary failures in logs. They are now classified and logged at INFO with an explicit wrong-signing-region message. 
 Separately, the STS assume-role-with-web-identity provider is only registered when web identity is actually configured (environment, shared config profile, or KMS role ARN override), so typical EC2 or static-key setups no longer see extra warnings from an unused provider. Helper logic for resolving web-identity settings from the environment and profile was consolidated for reuse, and unit tests cover web-identity detection and the wrong-region 400 heuristic.

### Changelog category (leave one):
• Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
S3 client logging now treats HTTP 400 responses that include a non-empty x-amz-bucket-region header (wrong SigV4 signing region) as an informational wrong-region case with a clearer log line instead of the generic error-style path. The STS web identity credentials provider is added to the S3 credentials chain only when web identity is configured, which reduces spurious warnings for deployments that do not use it. Closes #99140.

### Documentation entry for user-facing changes
No documentation change: behavior is logging and internal credential provider selection only; no new settings or SQL surface.


At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?
Sometimes, during a not proper partitioning in s3, wild card usage in s3 function is not the best option (due to listing costs etc)
If we run query per full prefix, there're gonna be tons of queries in the parallel, it means tons of error log messages with 400, which can trigger some alerts (e.g. clickhouse error log rate) and confuse the users.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.644`
<!-- ch-version-info:end -->