### PR TITLE
Make integration tests idempotent for --count re-runs

### DIFF
--- a/tests/integration/test_cluster_discovery/test_auxiliary_keeper.py
+++ b/tests/integration/test_cluster_discovery/test_auxiliary_keeper.py
@@ -47,6 +47,15 @@ def test_cluster_discovery_with_auxiliary_keeper_startup_and_stop(start_cluster)
     then stop/start some nodes and check that it (dis)appeared in cluster.
     """
 
+    # Ensure all nodes are running (previous run may have left some stopped)
+    for name in ["node1", "node3"]:
+        nodes[name].start_clickhouse(start_wait_sec=60)
+
+    # Clean up table from previous run (drop locally on each node since ON CLUSTER
+    # requires all nodes to be healthy and discoverable)
+    for node in nodes.values():
+        node.query("DROP TABLE IF EXISTS tbl SYNC")
+
     check_nodes_count = functools.partial(
         check_on_cluster, what="count()", msg="Wrong nodes count in cluster"
     )

--- a/tests/integration/test_concurrent_ttl_merges/test.py
+++ b/tests/integration/test_concurrent_ttl_merges/test.py
@@ -12,12 +12,14 @@ node1 = cluster.add_instance(
     main_configs=["configs/fast_background_pool.xml"],
     user_configs=["configs/users.xml"],
     with_zookeeper=True,
+    stay_alive=True,
 )
 node2 = cluster.add_instance(
     "node2",
     main_configs=["configs/fast_background_pool.xml"],
     user_configs=["configs/users.xml"],
     with_zookeeper=True,
+    stay_alive=True,
 )
 
 
@@ -29,6 +31,15 @@ def started_cluster():
 
     finally:
         cluster.shutdown()
+
+
+def ensure_node_alive(node):
+    """Restart ClickHouse if the process died (e.g. OOM-killed in a previous run)."""
+    try:
+        node.query("SELECT 1")
+    except Exception:
+        logging.warning(f"Node {node.name} is not responding, restarting")
+        node.start_clickhouse(start_wait_sec=60)
 
 
 def count_ttl_merges_in_queue(node, table):
@@ -76,6 +87,9 @@ def count_running_mutations(node, table):
 # but it revealed a bug when we assign different merges to the same part
 # on the borders of partitions.
 def test_no_ttl_merges_in_busy_pool(started_cluster):
+    ensure_node_alive(node1)
+    node1.query("DROP TABLE IF EXISTS test_ttl SYNC")
+    node1.query("SYSTEM START TTL MERGES")
     node1.query(
         "CREATE TABLE test_ttl (d DateTime, key UInt64, data UInt64) ENGINE = MergeTree() ORDER BY tuple() PARTITION BY key TTL d + INTERVAL 1 MONTH SETTINGS merge_with_ttl_timeout = 0, number_of_free_entries_in_pool_to_execute_mutation = 0"
     )
@@ -109,6 +123,9 @@ def test_no_ttl_merges_in_busy_pool(started_cluster):
 
 
 def test_limited_ttl_merges_in_empty_pool(started_cluster):
+    ensure_node_alive(node1)
+    node1.query("DROP TABLE IF EXISTS test_ttl_v2 SYNC")
+    node1.query("SYSTEM START TTL MERGES")
     node1.query(
         "CREATE TABLE test_ttl_v2 (d DateTime, key UInt64, data UInt64) ENGINE = MergeTree() ORDER BY tuple() PARTITION BY key TTL d + INTERVAL 1 MONTH SETTINGS merge_with_ttl_timeout = 0"
     )
@@ -138,6 +155,10 @@ def test_limited_ttl_merges_in_empty_pool(started_cluster):
 
 
 def test_limited_ttl_merges_in_empty_pool_replicated(started_cluster):
+    ensure_node_alive(node1)
+    node1.query("DROP TABLE IF EXISTS replicated_ttl SYNC")
+    node1.query("SYSTEM DROP REPLICA '1' FROM ZKPATH '/test/t'", ignore_error=True)
+    node1.query("SYSTEM START TTL MERGES")
     node1.query(
         "CREATE TABLE replicated_ttl (d DateTime, key UInt64, data UInt64) ENGINE = ReplicatedMergeTree('/test/t', '1') ORDER BY tuple() PARTITION BY key TTL d + INTERVAL 1 MONTH SETTINGS merge_with_ttl_timeout = 0"
     )
@@ -172,6 +193,14 @@ def test_limited_ttl_merges_in_empty_pool_replicated(started_cluster):
 
 def test_limited_ttl_merges_two_replicas(started_cluster):
     # Actually this test quite fast and often we cannot catch any merges.
+    ensure_node_alive(node1)
+    ensure_node_alive(node2)
+    node1.query("DROP TABLE IF EXISTS replicated_ttl_2 SYNC")
+    node2.query("DROP TABLE IF EXISTS replicated_ttl_2 SYNC")
+    node1.query("SYSTEM DROP REPLICA '1' FROM ZKPATH '/test/t2'", ignore_error=True)
+    node1.query("SYSTEM DROP REPLICA '2' FROM ZKPATH '/test/t2'", ignore_error=True)
+    node1.query("SYSTEM START TTL MERGES")
+    node2.query("SYSTEM START TTL MERGES")
     node1.query(
         "CREATE TABLE replicated_ttl_2 (d DateTime, key UInt64, data UInt64) ENGINE = ReplicatedMergeTree('/test/t2', '1') ORDER BY tuple() PARTITION BY key TTL d + INTERVAL 1 MONTH SETTINGS merge_with_ttl_timeout = 0"
     )

--- a/tests/integration/test_keeper_remove_rejoin_leader/test.py
+++ b/tests/integration/test_keeper_remove_rejoin_leader/test.py
@@ -393,7 +393,8 @@ def test_leader_election_after_rolling_membership_change(started_cluster):
     # Give the election time to complete before checking for the new leader.
     time.sleep(2)
 
-    keeper_utils.wait_nodes(cluster, [leader, node4, node5, node6])
+    for n in [leader, node4, node5, node6]:
+        keeper_utils.wait_until_connected(cluster, n, timeout=60.0)
 
 
 

--- a/tests/integration/test_storage_s3/test.py
+++ b/tests/integration/test_storage_s3/test.py
@@ -2690,7 +2690,11 @@ def test_archive(started_cluster):
     node = started_cluster.instances["dummy"]
     node2 = started_cluster.instances["dummy2"]
     node_old = started_cluster.instances["dummy_old"]
-    if "25.3" not in node_old.query("SELECT version()"):
+    try:
+        need_restart = "25.3" not in node_old.query("SELECT version()")
+    except Exception:
+        need_restart = True
+    if need_restart:
         node_old.restart_with_original_version(clear_data_dir=True)
 
     assert (
@@ -3000,7 +3004,11 @@ def test_file_pruning_with_hive_style_partitioning(started_cluster):
 
     query_id = f"{table_name}_query_6"
     node_old = started_cluster.instances["dummy_old"]
-    if "25.3" not in node_old.query("SELECT version()"):
+    try:
+        need_restart = "25.3" not in node_old.query("SELECT version()")
+    except Exception:
+        need_restart = True
+    if need_restart:
         node_old.restart_with_original_version(clear_data_dir=True)
 
     node_old.query(
@@ -3174,7 +3182,11 @@ def test_file_pruning_with_hive_style_partitioning_2(started_cluster):
         )
 
     node_old = started_cluster.instances["dummy_old"]
-    if "25.3" not in node_old.query("SELECT version()"):
+    try:
+        need_restart = "25.3" not in node_old.query("SELECT version()")
+    except Exception:
+        need_restart = True
+    if need_restart:
         node_old.restart_with_original_version(clear_data_dir=True)
 
     node_old.query(


### PR DESCRIPTION
Several integration tests previously failed when re-run with `--count > 1`, either because they left behind state (tables, replicas, ZooKeeper paths) or because nodes were killed by OOM during a prior iteration and never restarted. This PR makes them idempotent and OOM-tolerant.

* `test_cluster_discovery/test_auxiliary_keeper.py`: ensure all nodes are running and drop the leftover table locally on each node before the test starts. `ON CLUSTER` cannot be used while some nodes may still be down from a previous run.
* `test_concurrent_ttl_merges/test.py`: enable `stay_alive` on both nodes, restart any node killed by OOM, and reset table/replica state and the `SYSTEM STOP TTL MERGES` flag at the start of each test.
* `test_keeper_remove_rejoin_leader/test.py`: replace `keeper_utils.wait_nodes` with per-node `wait_until_connected` (with a longer timeout), so a slow node does not abort the wait early.
* `test_storage_s3/test.py`: when checking the version of `dummy_old`, treat a query failure as needs-restart instead of propagating the exception, so a node killed by OOM in a previous run is recovered.

These changes were originally part of #100177 and are split out here so the parent PR contains only the `ThreadPool` code changes.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.158`
<!-- ch-version-info:end -->