### PR TITLE
CI: add `ci-force-all` label to bypass all job filtering

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -692,6 +692,11 @@ tar -czf ./ci/tmp/logs.tar.gz \
                         changed_test_modules.append(
                             file.removeprefix("tests/integration/")
                         )
+                if not changed_test_modules and Labels.CI_FORCE_ALL in info.pr_labels:
+                    print(
+                        f"NOTE: No changed test modules found, but '{Labels.CI_FORCE_ALL}' label forces run - using sanity test"
+                    )
+                    changed_test_modules = ["test_accept_invalid_certificate/test.py"]
 
     if is_bugfix_validation:
         if Utils.is_arm():

--- a/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
+++ b/ci/jobs/scripts/workflow_hooks/pr_labels_and_category.py
@@ -74,6 +74,7 @@ class Labels:
     SUBMODULE_CHANGED = "submodule changed"
 
     CI_BUILD = "ci-build"
+    CI_FORCE_ALL = "ci-force-all"
 
     CI_PERFORMANCE = "ci-performance"
 

--- a/ci/praktika/hook_cache.py
+++ b/ci/praktika/hook_cache.py
@@ -10,7 +10,7 @@ from .utils import Utils
 
 class CacheRunnerHooks:
     @classmethod
-    def configure(cls, workflow):
+    def configure(cls, workflow, skip_lookup=False):
         workflow_config = RunConfig.from_fs(workflow.name)
         docker_digests = workflow_config.digest_dockers
         cache = Cache()
@@ -74,6 +74,11 @@ class CacheRunnerHooks:
         assert (
             workflow_config.digest_jobs
         ), f"BUG, Workflow with enabled cache must have job digests after configuration, wf [{workflow.name}]"
+
+        if skip_lookup:
+            print("NOTE: Cache lookup skipped, digests computed only")
+            workflow_config.dump()
+            return workflow_config
 
         print("Check remote cache")
 

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -639,33 +639,29 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
         )
 
     if results[-1].is_ok() and workflow.enable_cache:
-        pr_labels = Info().pr_labels
-        if Settings.CI_FORCE_ALL_LABEL in pr_labels:
-            print(
-                f"NOTE: Cache lookup bypassed (label '{Settings.CI_FORCE_ALL_LABEL}')"
-            )
-        else:
-            print("Cache Lookup")
-            stop_watch = Utils.Stopwatch()
-            info = ""
-            try:
-                workflow_config = CacheRunnerHooks.configure(workflow)
-                files.append(RunConfig.file_name_static(workflow.name))
-                res = True
-            except Exception as e:
-                res = False
-                traceback.print_exc()
-                info = traceback.format_exc()
+        print("Cache Lookup")
+        stop_watch = Utils.Stopwatch()
+        info = ""
+        try:
+            pr_labels = Info().pr_labels
+            skip_lookup = Settings.CI_FORCE_ALL_LABEL in pr_labels
+            workflow_config = CacheRunnerHooks.configure(workflow, skip_lookup=skip_lookup)
+            files.append(RunConfig.file_name_static(workflow.name))
+            res = True
+        except Exception as e:
+            res = False
+            traceback.print_exc()
+            info = traceback.format_exc()
 
-            results.append(
-                Result(
-                    name="Cache Lookup",
-                    status=Result.Status.OK if res else Result.Status.FAIL,
-                    start_time=stop_watch.start_time,
-                    duration=stop_watch.duration,
-                    info=info,
-                )
+        results.append(
+            Result(
+                name="Cache Lookup",
+                status=Result.Status.OK if res else Result.Status.FAIL,
+                start_time=stop_watch.start_time,
+                duration=stop_watch.duration,
+                info=info,
             )
+        )
 
     if results[-1].is_ok() and workflow.enable_cache and Settings.ENABLE_SUBMODULE_CACHE:
         result = _prepare_submodule_cache(workflow_config)

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -571,17 +571,23 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
     if results[-1].is_ok() and workflow.workflow_filter_hooks:
         sw_ = Utils.Stopwatch()
         try:
-            for job in workflow.jobs:
-                if _is_praktika_job(job.name):
-                    continue
-                for hook in workflow.workflow_filter_hooks:
-                    should_skip, reason = hook(job.name)
-                    if should_skip:
-                        print(
-                            f"Job [{job.name}] set to skipped by custom hook [{hook.__name__}], reason [{reason}]"
-                        )
-                        workflow_config.set_job_as_filtered(job.name, reason)
+            pr_labels = Info().pr_labels
+            if Settings.CI_FORCE_ALL_LABEL in pr_labels:
+                print(
+                    f"NOTE: Workflow filter hooks bypassed (label '{Settings.CI_FORCE_ALL_LABEL}')"
+                )
+            else:
+                for job in workflow.jobs:
+                    if _is_praktika_job(job.name):
                         continue
+                    for hook in workflow.workflow_filter_hooks:
+                        should_skip, reason = hook(job.name)
+                        if should_skip:
+                            print(
+                                f"Job [{job.name}] set to skipped by custom hook [{hook.__name__}], reason [{reason}]"
+                            )
+                            workflow_config.set_job_as_filtered(job.name, reason)
+                            continue
             status = Result.Status.OK
             workflow_config.dump()
             info = ""
@@ -600,6 +606,13 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
         print("Filter not affected jobs")
 
         def check_affected_jobs():
+            pr_labels = Info().pr_labels
+            if Settings.CI_FORCE_ALL_LABEL in pr_labels:
+                print(
+                    f"NOTE: Job filtering by changed files is bypassed (label '{Settings.CI_FORCE_ALL_LABEL}')"
+                )
+                return
+
             changed_files = Info().get_changed_files()
             if changed_files is None:
                 print(

--- a/ci/praktika/native_jobs.py
+++ b/ci/praktika/native_jobs.py
@@ -639,27 +639,33 @@ def _config_workflow(workflow: Workflow.Config, job_name) -> Result:
         )
 
     if results[-1].is_ok() and workflow.enable_cache:
-        print("Cache Lookup")
-        stop_watch = Utils.Stopwatch()
-        info = ""
-        try:
-            workflow_config = CacheRunnerHooks.configure(workflow)
-            files.append(RunConfig.file_name_static(workflow.name))
-            res = True
-        except Exception as e:
-            res = False
-            traceback.print_exc()
-            info = traceback.format_exc()
-
-        results.append(
-            Result(
-                name="Cache Lookup",
-                status=Result.Status.OK if res else Result.Status.FAIL,
-                start_time=stop_watch.start_time,
-                duration=stop_watch.duration,
-                info=info,
+        pr_labels = Info().pr_labels
+        if Settings.CI_FORCE_ALL_LABEL in pr_labels:
+            print(
+                f"NOTE: Cache lookup bypassed (label '{Settings.CI_FORCE_ALL_LABEL}')"
             )
-        )
+        else:
+            print("Cache Lookup")
+            stop_watch = Utils.Stopwatch()
+            info = ""
+            try:
+                workflow_config = CacheRunnerHooks.configure(workflow)
+                files.append(RunConfig.file_name_static(workflow.name))
+                res = True
+            except Exception as e:
+                res = False
+                traceback.print_exc()
+                info = traceback.format_exc()
+
+            results.append(
+                Result(
+                    name="Cache Lookup",
+                    status=Result.Status.OK if res else Result.Status.FAIL,
+                    start_time=stop_watch.start_time,
+                    duration=stop_watch.duration,
+                    info=info,
+                )
+            )
 
     if results[-1].is_ok() and workflow.enable_cache and Settings.ENABLE_SUBMODULE_CACHE:
         result = _prepare_submodule_cache(workflow_config)

--- a/ci/praktika/settings.py
+++ b/ci/praktika/settings.py
@@ -38,6 +38,8 @@ class _Settings:
     ######################################
     MAX_RETRIES_S3 = 3
     MAX_RETRIES_GH = 3
+    # PR label that bypasses all job filtering (filter hooks and changed-file filtering)
+    CI_FORCE_ALL_LABEL: str = "ci-force-all"
 
     ######################################
     #   S3 (artifact storage) settings   #
@@ -157,6 +159,7 @@ _USER_DEFINED_SETTINGS = [
     "INSTALL_PYTHON_REQS_FOR_NATIVE_JOBS",
     "MAX_RETRIES_S3",
     "MAX_RETRIES_GH",
+    "CI_FORCE_ALL_LABEL",
     "VALIDATE_FILE_PATHS",
     "DOCKERHUB_USERNAME",
     "DOCKERHUB_SECRET",


### PR DESCRIPTION
Add a `CI_FORCE_ALL_LABEL` setting (default: `"ci-force-all"`) to Praktika.
When a PR carries this label, both the workflow filter hooks and the
changed-file-based job filtering are skipped, so every job in the workflow
runs unconditionally.

The label name is a project-level Setting so individual deployments can
override it in their `ci/settings/` directory.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.203`
<!-- ch-version-info:end -->