### PR TITLE
Skip local-hostname DNS lookup in client startup

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -2172,6 +2172,11 @@ try
     {
         DNSResolver::instance().setCacheMaxEntries(server_settings[ServerSetting::dns_cache_max_entries]);
 
+        /// Prime the local host name / addresses cache before the updater starts,
+        /// so that the first DNSCacheUpdater tick on a healthy server does not
+        /// see an empty cache and spuriously report "IPs of host name X have been changed".
+        DNSResolver::instance().updateHostNameAndAddresses();
+
         /// Initialize a watcher periodically updating DNS cache
         dns_cache_updater = std::make_unique<DNSCacheUpdater>(
             global_context, server_settings[ServerSetting::dns_cache_update_period], server_settings[ServerSetting::dns_max_consecutive_failures]);

--- a/src/Common/DNSResolver.cpp
+++ b/src/Common/DNSResolver.cpp
@@ -197,20 +197,11 @@ struct DNSResolver::Impl
     /// If disabled, will not make cache lookups, will resolve addresses manually on each call
     std::atomic<bool> disable_cache{false};
 
-    Impl()
-    {
-        try
-        {
-            host_name.emplace(Poco::Net::DNS::hostName());
-            auto addresses = hostByName(*host_name);
-            ::sort(addresses.begin(), addresses.end());
-            host_addresses.emplace(std::move(addresses));
-        }
-        catch (...)
-        {
-            tryLogCurrentException("DNSResolver", __PRETTY_FUNCTION__);
-        }
-    }
+    /// host_name and host_addresses are populated lazily by `getHostName` and
+    /// `updateHostNameAndAddresses`. The latter is called periodically by
+    /// `DNSCacheUpdater` (server-only), and explicitly during server startup,
+    /// so non-server programs (`clickhouse-client`, `-local`, `-keeper`,
+    /// `-disks`) never trigger a DNS lookup of the local hostname here.
 };
 
 struct DNSResolver::AddressFilter

--- a/src/Common/DNSResolver.cpp
+++ b/src/Common/DNSResolver.cpp
@@ -197,9 +197,10 @@ struct DNSResolver::Impl
     /// If disabled, will not make cache lookups, will resolve addresses manually on each call
     std::atomic<bool> disable_cache{false};
 
-    /// host_name and host_addresses are populated lazily by `getHostName` and
-    /// `updateHostNameAndAddresses`. The latter is called periodically by
-    /// `DNSCacheUpdater` (server-only), and explicitly during server startup,
+    /// `host_name` is populated lazily by `getHostName`. `host_addresses`
+    /// (and a re-read of `host_name`) is populated by
+    /// `updateHostNameAndAddresses`, which is called periodically by
+    /// `DNSCacheUpdater` (server-only) and explicitly during server startup,
     /// so non-server programs (`clickhouse-client`, `-local`, `-keeper`,
     /// `-disks`) never trigger a DNS lookup of the local hostname here.
 };


### PR DESCRIPTION
The `DNSResolver` singleton constructor was eagerly calling
`Poco::Net::DNS::hostName` followed by `hostByName` on the local
hostname. The cached result is consumed only by
`updateHostNameAndAddresses` (a server-only periodic task) and by
`getHostName` — both of which have their own lazy fallbacks — yet the
work happened inside a process-wide Meyers singleton, so every program
that calls `DNSResolver::instance` paid the cost: `clickhouse-client`,
`-local`, `-keeper`, `-disks`, etc.

When the local hostname could not be resolved (normal on fresh CI/EC2
runners where the auto-generated `ip-X-X-X-X` name is neither in
`/etc/hosts` nor served by the VPC resolver), the catch block in the
constructor logged a stack trace at error level. The fast-test runner
treats any stderr output as a test failure, so this infrastructure
flake masqueraded as a per-test failure.

The eager priming is moved out of the singleton constructor:

* `DNSResolver::Impl::Impl` is now defaulted; non-server programs no
  longer touch the local hostname during startup.
* `programs/server/Server.cpp` calls `updateHostNameAndAddresses`
  explicitly before starting `DNSCacheUpdater`, so the first cache
  tick on a healthy server still sees a populated value and does not
  spuriously emit `IPs of host name X have been changed`.

Behaviour from #93726 (cluster config reload on host IP change) is
preserved — verified by `test_reload_cluster_config_if_host_address_change`,
which still passes locally.

Affected tests in https://github.com/ClickHouse/ClickHouse/pull/103689
([Fast test report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=103689&sha=3a119a57269adba3557204ce44e58a65054e31df&name_0=PR&name_1=Fast%20test)):
`Tests/02001_hostname_test`, `Tests/03213_deep_json`,
`Tests/03638_merge_max_dynamic_subcolumns_in_compact_part`,
`Tests/02433_default_expression_operator_in` — all hitting the same
`Cannot resolve host (ip-172-31-33-233)` path during
`DNSResolver::Impl::Impl`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.173`
<!-- ch-version-info:end -->