### PR TITLE
Stabilize flaky test_system_view_refreshes_on_not_running_replica

### DIFF
--- a/tests/integration/test_refreshable_mv/test.py
+++ b/tests/integration/test_refreshable_mv/test.py
@@ -605,21 +605,53 @@ def test_replicated_db_startup_race(started_cluster, cleanup):
 
 
 def test_system_view_refreshes_on_not_running_replica(started_cluster):
+    # Use a unique znode path / database name per invocation so that residual state
+    # from previous test runs (orphaned RefreshTasks, stale Keeper znodes — see
+    # https://github.com/ClickHouse/ClickHouse/issues/76418 ) cannot leak in.
+    global test_idx
+    test_idx += 1
+    db_name = f"test_nrr_{test_idx}"
+    db_path = f"/db/test_nrr_{test_idx}"
+
     try:
         for node in nodes:
-            node.query("DROP DATABASE IF EXISTS test SYNC")
+            node.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")
             node.query(
-                r"CREATE DATABASE test ENGINE = Replicated('/db/test', '{shard}', '{replica}')"
+                f"CREATE DATABASE {db_name} ENGINE = Replicated('{db_path}', '{{shard}}', '{{replica}}')"
             )
 
         node1.query(
-            "CREATE MATERIALIZED VIEW test.rmv REFRESH EVERY 1 HOUR (x Int64) ENGINE ReplicatedMergeTree ORDER BY x AS SELECT number*10 AS x FROM numbers(2)"
+            f"CREATE MATERIALIZED VIEW {db_name}.rmv REFRESH EVERY 1 HOUR (x Int64) "
+            "ENGINE ReplicatedMergeTree ORDER BY x AS SELECT number*10 AS x FROM numbers(2)"
         )
-        node1.query("SYSTEM REFRESH VIEW test.rmv")
+        # Make sure node2 is aware of the MV (so SYSTEM STOP VIEW below has a target).
+        for node in nodes:
+            node.query(f"SYSTEM SYNC DATABASE REPLICA {db_name}")
+
+        # The refresh-runner replica is chosen via Keeper coordination, so calling
+        # SYSTEM REFRESH VIEW on node1 is not enough to guarantee node1 actually
+        # runs the refresh. Pause refreshes on node2 so node1 wins the election.
+        node2.query(f"SYSTEM STOP VIEW {db_name}.rmv")
+        # Trigger an immediate refresh on node1 and wait for it to complete.
+        node1.query(f"SYSTEM REFRESH VIEW {db_name}.rmv")
+        node1.query(f"SYSTEM WAIT VIEW {db_name}.rmv")
+        # Wait for node2 to observe (via its znode cache) that node1 was the
+        # last-attempt replica. Otherwise StorageSystemViewRefreshes::fillData
+        # falls into the `last_attempt_replica.empty()` branch on node2 and
+        # returns local progress (often 0) instead of NULL.
+        assert_eq_with_retry(
+            node2,
+            f"SELECT last_refresh_replica FROM system.view_refreshes WHERE database='{db_name}' AND view='rmv'",
+            "1\n",
+            sleep_time=0.5,
+            retry_count=60,
+        )
 
         def get_view_refresh_value(node, column_name: str):
             return node.query(
-                f"SELECT {column_name} FROM system.view_refreshes WHERE view='rmv' SETTINGS format_tsv_null_representation='NULL'"
+                f"SELECT {column_name} FROM system.view_refreshes "
+                f"WHERE database='{db_name}' AND view='rmv' "
+                "SETTINGS format_tsv_null_representation='NULL'"
             ).strip()
 
         assert get_view_refresh_value(node1, "read_rows") != "NULL"
@@ -634,5 +666,10 @@ def test_system_view_refreshes_on_not_running_replica(started_cluster):
         assert get_view_refresh_value(node2, "written_rows") == "NULL"
         assert get_view_refresh_value(node2, "written_bytes") == "NULL"
     finally:
+        # Re-enable refreshes on node2 in case other tests reuse the cluster.
+        try:
+            node2.query(f"SYSTEM START VIEW {db_name}.rmv")
+        except Exception:
+            pass
         for node in nodes:
-            node.query("DROP DATABASE IF EXISTS test SYNC")
+            node.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")


### PR DESCRIPTION
The integration test
`test_refreshable_mv/test.py::test_system_view_refreshes_on_not_running_replica`
has been chronically flaky — 37 hits across 9 unrelated PRs in the last
30 days, also tracked in [#100840](https://github.com/ClickHouse/ClickHouse/issues/100840).

The test races on three things:

1. `SYSTEM REFRESH VIEW` is asynchronous — it requests a refresh but
   does not wait for completion. The test reads `system.view_refreshes`
   immediately after, so on the running replica the stats may still be
   their pre-refresh values (`NULL`/`0`). Failure mode:
   `assert get_view_refresh_value(node1, "written_rows") != "NULL"`
   failing with `'NULL' != 'NULL'`.

2. In a replicated database the refresh-runner replica is chosen via
   Keeper coordination, so calling `SYSTEM REFRESH VIEW` on `node1`
   does not guarantee `node1` actually wins the election. When `node2`
   wins, `last_attempt_replica` becomes `2` and the test's expectations
   on `node1` and `node2` are inverted. Failure mode:
   `assert get_view_refresh_value(node2, "total_rows") == "NULL"`
   failing with `'2' == 'NULL'`.

3. Even when `node1` runs the refresh, `node2`'s cached view of the
   coordination znode is updated lazily. Until that update lands
   `last_attempt_replica` is still empty on `node2`, and
   `StorageSystemViewRefreshes::fillData` falls into the
   `last_attempt_replica.empty()` branch and returns local progress
   (often `0`) instead of `NULL`. Failure mode:
   `'0' == 'NULL'`.

The fix is to make the test deterministic on all three axes:

- Pause refreshes on `node2` (`SYSTEM STOP VIEW`) before triggering the
  refresh, so `node1` always wins the Keeper election.
- Wait for the refresh to finish on `node1` (`SYSTEM WAIT VIEW`).
- Poll `node2` (`assert_eq_with_retry`) until it observes
  `last_refresh_replica = 1`, which guarantees its znode cache is fresh
  before the assertions run.

Also use a unique znode path / database name per test invocation
(matching the pattern already used in `test_refreshable_mv_in_replicated_db`)
so that residual `RefreshTask` state from previous runs cannot leak in
and produce extra rows in `system.view_refreshes` (the rare
`'NULL\n0' == 'NULL'` failure mode).

### Local verification

20 consecutive passes on the `Integration tests (amd_tsan, 1/6)`
configuration via:

```
python3 -m ci.praktika run "integration" \
    --test "test_refreshable_mv/test.py::test_system_view_refreshes_on_not_running_replica" \
    --count 20
```

(the unfixed test fails on ~0.7% of CI runs across many sanitizer
build flavors).

### Pre-PR validation gate

- a) Deterministic repro: yes — the three race conditions above are
  explainable from the source (`StorageSystemViewRefreshes.cpp:104`,
  `RefreshTask.cpp:400`, `InterpreterSystemQuery.cpp:841`); no hidden
  state.
- b) Root cause explained: yes (see body above).
- c) Fix matches root cause: each step targets one of the three axes.
- d) Test intent preserved: yes — same assertions, same expected
  behaviour. The fix only adds explicit synchronisation; it does not
  weaken any assertion.
- e) Both directions: 20/20 passing locally with the fix; CIDB has 30
  days of failure history with the unfixed code (~0.7% rate, too rare
  to repro in a small local loop).
- f) Fix is general: this is a test-only change so f) is N/A.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Closes #100840

Session: cron:clickhouse-ci-task-worker:20260429-071500

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.189`
<!-- ch-version-info:end -->