### PR TITLE
Fix skip-index matching for ALIAS columns with lambda + constants

### DIFF
--- a/src/Storages/MergeTree/RPNBuilder.cpp
+++ b/src/Storages/MergeTree/RPNBuilder.cpp
@@ -47,7 +47,89 @@ namespace ErrorCodes
 namespace
 {
 
-void appendColumnNameWithoutAlias(const ActionsDAG::Node & node, WriteBuffer & out, const ContextPtr & context, bool use_analyzer, bool legacy = false)
+void appendColumnNameWithoutAlias(const ActionsDAG::Node & node, WriteBuffer & out, const ContextPtr & context, bool use_analyzer, bool legacy = false);
+
+/// Produces the lambda's column name in the AST format `lambda(tuple(args), body)`.
+/// Used both for live FUNCTION nodes wrapping `ExecutableFunctionCapture`/`FunctionCapture` and for
+/// constant-folded COLUMN nodes that hold a `ColumnConst<ColumnFunction>` (e.g. when all captured
+/// arguments are constants and `removeUnusedActions` collapsed the FUNCTION into a COLUMN).
+void appendLambdaColumnName(
+    const LambdaCapture & capture,
+    ActionsDAG capture_dag,
+    WriteBuffer & out,
+    const ContextPtr & context,
+    bool use_analyzer,
+    bool legacy)
+{
+    writeString("lambda(tuple(", out);
+    bool first = true;
+    for (const auto & arg : capture.lambda_arguments)
+    {
+        if (!first)
+            writeCString(", ", out);
+        first = false;
+
+        writeString(arg.name, out);
+    }
+    writeString("), ", out);
+
+    ActionsDAGWithInversionPushDown inverted_capture_dag(capture_dag.getOutputs().at(0), context);
+    appendColumnNameWithoutAlias(*inverted_capture_dag.predicate, out, context, use_analyzer, legacy);
+    writeChar(')', out);
+}
+
+/// For a constant-folded lambda (`ColumnConst` wrapping `ColumnFunction`), reconstruct the lambda
+/// AST-format name. Returns true on success and writes the name to `out`.
+bool tryAppendConstantFunctionColumnName(
+    const ActionsDAG::Node & node,
+    WriteBuffer & out,
+    const ContextPtr & context,
+    bool use_analyzer,
+    bool legacy)
+{
+    const auto * column_const = typeid_cast<const ColumnConst *>(node.column.get());
+    if (!column_const)
+        return false;
+
+    const auto * column_function = typeid_cast<const ColumnFunction *>(&column_const->getDataColumn());
+    if (!column_function)
+        return false;
+
+    const auto * function_expression = typeid_cast<const FunctionExpression *>(column_function->getFunction().get());
+    if (!function_expression)
+        return false;
+
+    const auto & capture = function_expression->getCapture();
+    auto capture_dag = function_expression->getAcionsDAG().clone();
+
+    /// Stitch the captured constant columns into the body DAG so the body's input nodes
+    /// are resolved to actual constants. After `ActionsDAGWithInversionPushDown` rewrites
+    /// the constant column names to their AST form, the resulting name will match the one
+    /// produced for the index sample block (which was built via the old analyzer).
+    const auto & captured_columns = column_function->getCapturedColumns();
+    if (!captured_columns.empty())
+    {
+        if (captured_columns.size() != capture.captured_names.size())
+            return false;
+
+        ActionsDAG captured_columns_dag;
+        auto & outputs = captured_columns_dag.getOutputs();
+        outputs.reserve(captured_columns.size());
+        for (size_t i = 0; i < captured_columns.size(); ++i)
+        {
+            const auto & captured_node = captured_columns_dag.addColumn(captured_columns[i]);
+            const auto & alias_node = captured_columns_dag.addAlias(captured_node, capture.captured_names[i]);
+            outputs.push_back(&alias_node);
+        }
+
+        capture_dag = ActionsDAG::merge(std::move(captured_columns_dag), std::move(capture_dag));
+    }
+
+    appendLambdaColumnName(capture, std::move(capture_dag), out, context, use_analyzer, legacy);
+    return true;
+}
+
+void appendColumnNameWithoutAlias(const ActionsDAG::Node & node, WriteBuffer & out, const ContextPtr & context, bool use_analyzer, bool legacy)
 {
     switch (node.type)
     {
@@ -56,6 +138,12 @@ void appendColumnNameWithoutAlias(const ActionsDAG::Node & node, WriteBuffer & o
             break;
         case ActionsDAG::ActionType::COLUMN:
         {
+            /// A constant-folded lambda is a `ColumnConst` of a `ColumnFunction`. Recover the
+            /// `lambda(tuple(args), body)` AST form so the name aligns with what the index sample
+            /// block produced for the same expression (the index goes through the old analyzer).
+            if (tryAppendConstantFunctionColumnName(node, out, context, use_analyzer, legacy))
+                break;
+
             /// If it was created from ASTLiteral, then result_name can be an alias.
             /// We need to convert value back to string here.
             const auto * column_const = typeid_cast<const ColumnConst *>(node.column.get());
@@ -89,21 +177,7 @@ void appendColumnNameWithoutAlias(const ActionsDAG::Node & node, WriteBuffer & o
                     capture_dag = ActionsDAG::merge(std::move(captured_columns_dag), std::move(capture_dag));
                 }
 
-                writeString("lambda(tuple(", out);
-                bool first = true;
-                for (const auto & arg : capture->lambda_arguments)
-                {
-                    if (!first)
-                        writeCString(", ", out);
-                    first = false;
-
-                    writeString(arg.name, out);
-                }
-                writeString("), ", out);
-
-                ActionsDAGWithInversionPushDown inverted_capture_dag(capture_dag.getOutputs().at(0), context);
-                appendColumnNameWithoutAlias(*inverted_capture_dag.predicate, out, context, use_analyzer, legacy);
-                writeChar(')', out);
+                appendLambdaColumnName(*capture, std::move(capture_dag), out, context, use_analyzer, legacy);
                 break;
             }
             else

--- a/tests/queries/0_stateless/04141_text_index_alias_lambda_with_constants.reference
+++ b/tests/queries/0_stateless/04141_text_index_alias_lambda_with_constants.reference
@@ -1,0 +1,3 @@
+splitByChar	1
+arrayMap	1
+concat-prefix	1

--- a/tests/queries/0_stateless/04141_text_index_alias_lambda_with_constants.reference
+++ b/tests/queries/0_stateless/04141_text_index_alias_lambda_with_constants.reference
@@ -6,3 +6,5 @@ bloom_filter concat-prefix	1
 quoted lambda args	1
 keyword lambda arg text	1
 keyword lambda arg bloom_filter	1
+concatWithSeparator text	1
+concatWithSeparator bloom_filter	1

--- a/tests/queries/0_stateless/04141_text_index_alias_lambda_with_constants.reference
+++ b/tests/queries/0_stateless/04141_text_index_alias_lambda_with_constants.reference
@@ -3,3 +3,6 @@ arrayMap	1
 concat-prefix	1
 bloom_filter arrayMap	1
 bloom_filter concat-prefix	1
+quoted lambda args	1
+keyword lambda arg text	1
+keyword lambda arg bloom_filter	1

--- a/tests/queries/0_stateless/04141_text_index_alias_lambda_with_constants.reference
+++ b/tests/queries/0_stateless/04141_text_index_alias_lambda_with_constants.reference
@@ -1,3 +1,5 @@
 splitByChar	1
 arrayMap	1
 concat-prefix	1
+bloom_filter arrayMap	1
+bloom_filter concat-prefix	1

--- a/tests/queries/0_stateless/04141_text_index_alias_lambda_with_constants.sql
+++ b/tests/queries/0_stateless/04141_text_index_alias_lambda_with_constants.sql
@@ -98,3 +98,35 @@ SELECT 'bloom_filter concat-prefix', id FROM t_bf_arr WHERE has(arr_prefixed, '-
 SETTINGS force_data_skipping_indices = 'idx_prefixed_bf';
 
 DROP TABLE t_bf_arr;
+
+-- Lambda argument names that require backquoting (contain whitespace, or clash
+-- with SQL keywords) must produce identical column names on the AST and DAG
+-- sides, so index matching keeps working.
+DROP TABLE IF EXISTS t_quoted_lambda;
+
+CREATE TABLE t_quoted_lambda
+(
+    user_id UInt64,
+    color_map Map(String, String),
+    colors_kv Array(String) ALIAS arrayMap((`my key`, `my value`) -> concat(`my key`, '=', `my value`), mapKeys(color_map), mapValues(color_map)),
+    arr Array(String),
+    arr_keyword Array(String) ALIAS arrayMap(`select` -> concat('-', `select`), arr),
+    INDEX idx_kv_quoted colors_kv TYPE text(tokenizer = 'array') GRANULARITY 100000000,
+    INDEX idx_kw_text arr_keyword TYPE text(tokenizer = 'array') GRANULARITY 100000000,
+    INDEX idx_kw_bf arr_keyword TYPE bloom_filter GRANULARITY 100000000
+)
+ENGINE = MergeTree
+ORDER BY user_id;
+
+INSERT INTO t_quoted_lambda VALUES (1, {'favorite': 'red', 'second': 'blue'}, ['hello', 'world']);
+
+SELECT 'quoted lambda args', user_id FROM t_quoted_lambda WHERE has(colors_kv, 'favorite=red')
+SETTINGS force_data_skipping_indices = 'idx_kv_quoted';
+
+SELECT 'keyword lambda arg text', user_id FROM t_quoted_lambda WHERE has(arr_keyword, '-hello')
+SETTINGS force_data_skipping_indices = 'idx_kw_text';
+
+SELECT 'keyword lambda arg bloom_filter', user_id FROM t_quoted_lambda WHERE has(arr_keyword, '-hello')
+SETTINGS force_data_skipping_indices = 'idx_kw_bf';
+
+DROP TABLE t_quoted_lambda;

--- a/tests/queries/0_stateless/04141_text_index_alias_lambda_with_constants.sql
+++ b/tests/queries/0_stateless/04141_text_index_alias_lambda_with_constants.sql
@@ -57,3 +57,44 @@ SELECT 'concat-prefix', id FROM t_arr WHERE has(arr_prefixed, '-hello')
 SETTINGS force_data_skipping_indices = 'idx_prefixed';
 
 DROP TABLE t_arr;
+
+-- Same column-name-matching path is taken by `bloom_filter`-family indices, so
+-- guard them too: with the same captured-constant lambda an `ALIAS` column
+-- bound to a `bloom_filter` index must still be selectable.
+DROP TABLE IF EXISTS t_bf;
+
+CREATE TABLE t_bf
+(
+    user_id UInt64,
+    color_map Map(String, String),
+    colors_kv Array(String) ALIAS arrayMap((k, v) -> concat(k, '=', v), mapKeys(color_map), mapValues(color_map)),
+    INDEX idx_kv_bf colors_kv TYPE bloom_filter GRANULARITY 100000000
+)
+ENGINE = MergeTree
+ORDER BY user_id;
+
+INSERT INTO t_bf VALUES (1, {'favorite': 'red', 'second': 'blue'});
+
+SELECT 'bloom_filter arrayMap', user_id FROM t_bf WHERE has(colors_kv, 'favorite=red')
+SETTINGS force_data_skipping_indices = 'idx_kv_bf';
+
+DROP TABLE t_bf;
+
+DROP TABLE IF EXISTS t_bf_arr;
+
+CREATE TABLE t_bf_arr
+(
+    id UInt64,
+    arr Array(String),
+    arr_prefixed Array(String) ALIAS arrayMap(s -> concat('-', s), arr),
+    INDEX idx_prefixed_bf arr_prefixed TYPE bloom_filter GRANULARITY 100000000
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+INSERT INTO t_bf_arr VALUES (1, ['hello', 'world']);
+
+SELECT 'bloom_filter concat-prefix', id FROM t_bf_arr WHERE has(arr_prefixed, '-hello')
+SETTINGS force_data_skipping_indices = 'idx_prefixed_bf';
+
+DROP TABLE t_bf_arr;

--- a/tests/queries/0_stateless/04141_text_index_alias_lambda_with_constants.sql
+++ b/tests/queries/0_stateless/04141_text_index_alias_lambda_with_constants.sql
@@ -130,3 +130,32 @@ SELECT 'keyword lambda arg bloom_filter', user_id FROM t_quoted_lambda WHERE has
 SETTINGS force_data_skipping_indices = 'idx_kw_bf';
 
 DROP TABLE t_quoted_lambda;
+
+-- A lambda with more than three captured arguments and a captured-constant
+-- separator (`concatWithSeparator('-', x1, x2, x3, x4)`) exercises the same
+-- folding path with a wider capture list and a different higher-order function.
+DROP TABLE IF EXISTS t_cws;
+
+CREATE TABLE t_cws
+(
+    id UInt64,
+    a Array(String),
+    b Array(String),
+    c Array(String),
+    d Array(String),
+    joined Array(String) ALIAS arrayMap((x1, x2, x3, x4) -> concatWithSeparator('-', x1, x2, x3, x4), a, b, c, d),
+    INDEX idx_joined_text joined TYPE text(tokenizer = 'array') GRANULARITY 100000000,
+    INDEX idx_joined_bf joined TYPE bloom_filter GRANULARITY 100000000
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+INSERT INTO t_cws VALUES (1, ['hello', 'foo'], ['world', 'bar'], ['a', 'baz'], ['b', 'qux']);
+
+SELECT 'concatWithSeparator text', id FROM t_cws WHERE has(joined, 'hello-world-a-b')
+SETTINGS force_data_skipping_indices = 'idx_joined_text';
+
+SELECT 'concatWithSeparator bloom_filter', id FROM t_cws WHERE has(joined, 'hello-world-a-b')
+SETTINGS force_data_skipping_indices = 'idx_joined_bf';
+
+DROP TABLE t_cws;

--- a/tests/queries/0_stateless/04141_text_index_alias_lambda_with_constants.sql
+++ b/tests/queries/0_stateless/04141_text_index_alias_lambda_with_constants.sql
@@ -1,0 +1,59 @@
+-- Regression test: text index on an ALIAS column whose expression contains a
+-- lambda with captured constants must be usable in queries.
+--
+-- The lambda body materializes captured constants as a constant `ColumnFunction`
+-- (e.g. `arrayMap((k, v) -> concat(k, '=', v), ...)` captures `'='`). The new
+-- analyzer's column name for that constant carries an `_String` suffix and the
+-- whole lambda is rendered as `k String, v String -> ...`, while the index
+-- `sample_block` (built via the old analyzer) uses the AST form
+-- `lambda(tuple(k, v), ...)` with bare literals. Without the fix
+-- `header.has(...)` failed and the index was not used.
+
+DROP TABLE IF EXISTS user_favorites;
+
+CREATE TABLE user_favorites
+(
+    user_id UInt64,
+    colors String,
+    color_map Map(String, String),
+    colors_text Array(String) ALIAS splitByChar(',', colors),
+    colors_kv Array(String) ALIAS arrayMap((k, v) -> concat(k, '=', v), mapKeys(color_map), mapValues(color_map)),
+    INDEX idx_colors_text colors_text TYPE text(tokenizer = 'array') GRANULARITY 100000000,
+    INDEX idx_colors_kv_text colors_kv TYPE text(tokenizer = 'array') GRANULARITY 100000000
+)
+ENGINE = MergeTree
+ORDER BY user_id;
+
+INSERT INTO user_favorites VALUES (1, 'favorite=red,second=blue', {'favorite': 'red', 'second': 'blue'});
+INSERT INTO user_favorites VALUES (2, 'favorite=green,favorite=blue', {'favorite': 'green', 'second': 'blue'});
+
+-- The simple alias works (no lambda, no constants captured).
+SELECT 'splitByChar', user_id FROM user_favorites WHERE has(colors_text, 'favorite=red')
+SETTINGS force_data_skipping_indices = 'idx_colors_text';
+
+-- The arrayMap alias used to be broken because of the captured `'='` constant.
+SELECT 'arrayMap', user_id FROM user_favorites WHERE has(colors_kv, 'favorite=red')
+SETTINGS force_data_skipping_indices = 'idx_colors_kv_text';
+
+DROP TABLE user_favorites;
+
+-- Minimal reproducer: a lambda body that captures a constant breaks index matching
+-- whenever the lambda is folded into a constant `ColumnFunction`.
+DROP TABLE IF EXISTS t_arr;
+
+CREATE TABLE t_arr
+(
+    id UInt64,
+    arr Array(String),
+    arr_prefixed Array(String) ALIAS arrayMap(s -> concat('-', s), arr),
+    INDEX idx_prefixed arr_prefixed TYPE text(tokenizer = 'array') GRANULARITY 100000000
+)
+ENGINE = MergeTree
+ORDER BY id;
+
+INSERT INTO t_arr VALUES (1, ['hello', 'world']);
+
+SELECT 'concat-prefix', id FROM t_arr WHERE has(arr_prefixed, '-hello')
+SETTINGS force_data_skipping_indices = 'idx_prefixed';
+
+DROP TABLE t_arr;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed an issue where text and bloom filter skip indices on `ALIAS` columns whose expression contained a lambda with captured constants (e.g. `arrayMap((k, v) -> concat(k, '=', v), mapKeys(m), mapValues(m)))` were silently ignored

<!-- ch-version-info:start -->
### Version info
- Backported to: `26.4.3.9`, `26.3.11.9`, `26.2.19.11`
<!-- ch-version-info:end -->