### PR TITLE
Fix flaky test_parallel_quorum_actually_parallel

### DIFF
--- a/tests/integration/test_quorum_inserts_parallel/test.py
+++ b/tests/integration/test_quorum_inserts_parallel/test.py
@@ -42,9 +42,15 @@ def test_parallel_quorum_actually_parallel(started_cluster):
 
     p = Pool(10)
 
+    # The total sleep for the long insert (rows * seconds-per-row) must be larger
+    # than the time taken by the parallel inserts and assertions below. Otherwise
+    # the long insert can finish before the COUNT() == 2 assertions run, causing
+    # COUNT() to return 7 instead of 2. Sanitizer builds (`MSan`, `TSan`,
+    # `ASan + UBSan`) can slow client/server interaction by 10-20x, so use a
+    # generous total sleep duration (5 rows * 3s = 15s).
     def long_insert(node):
         node.query(
-            "INSERT INTO r SELECT number, toString(number) FROM numbers(5) where sleepEachRow(1) == 0",
+            "INSERT INTO r SELECT number, toString(number) FROM numbers(5) where sleepEachRow(3) == 0",
             settings=settings,
         )
 


### PR DESCRIPTION
The integration test `test_parallel_quorum_actually_parallel` is chronically flaky on sanitizer builds — 16 hits across 11 PRs in the last 30 days, including 2 master hits.

## Root cause

The test starts a 5-second `INSERT ... numbers(5) WHERE sleepEachRow(1) == 0` in a background pool, then issues 8 client/server operations on three replicas (2 quorum inserts + 6 `SELECT COUNT()` assertions) and expects `COUNT() == 2` while the long insert is still running.

Under `MSan`, `TSan`, and `ASan + UBSan` builds those operations can take 10-20x longer than on a release build. When the cumulative time exceeds the 5-second window, the long insert has already committed by the time the test asserts `COUNT() == 2`, so it returns `7` instead:

```
File: test_quorum_inserts_parallel/test.py:61 - in test_parallel_quorum_actually_parallel
    assert node3.query(\"SELECT COUNT() FROM r\") == \"2\n\"
E   AssertionError: assert '7\n' == '2\n'
```

This pattern accounts for 10 of the 16 chronic failures recorded in CIDB over 30 days — including both master failures (`amd_msan` and `amd_asan_ubsan, db disk, old analyzer`).

## Fix

Triple the per-row sleep (`sleepEachRow(1)` → `sleepEachRow(3)`) so the long insert runs for 15 seconds total. The test's assertions and parallel-quorum semantics are unchanged; the fix just gives a 3x safety margin against sanitizer-induced slowdowns.

## Reproduction & verification

The race only manifests under heavy CI load, so I reproduced it locally by inserting `time.sleep(1.5)` between the operations to simulate sanitizer overhead:

- Original `sleepEachRow(1)` + simulated slowdown → reliably **fails** with `assert '7\n' == '2\n'` (matching the CI failure exactly)
- Fixed `sleepEachRow(3)` + simulated slowdown → **passes**
- Fixed `sleepEachRow(3)` without slowdown → passes in 36s (no measurable runtime regression)

CI failure example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100332&sha=&name_0=PR

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix flaky `test_parallel_quorum_actually_parallel` integration test on sanitizer builds.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

cidb-session: cron:clickhouse-ci-task-worker:20260429-081500

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.180`
<!-- ch-version-info:end -->