### PR TITLE
Fix macOS fast test post-hook to actually clean coresymbolicationd cache

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -213,7 +213,7 @@ class JobConfigs:
         force_success=True,
         post_hooks=[
             "python3 ./ci/jobs/scripts/job_hooks/clickhouse_test_cleanup_hook.py",
-            "sudo rm -rf /Users/ec2-user/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp/run*; sudo find /System/Volumes/Data/System/Library/Caches/com.apple.coresymbolicationd -type f -mtime +2 -delete",
+            "sudo rm -rf /Users/ec2-user/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp/run* /System/Volumes/Data/System/Library/Caches/com.apple.coresymbolicationd/data",
         ],
     ).parametrize(
         Job.ParamSet(


### PR DESCRIPTION
The `Fast test (arm_darwin)` post-hook used `find -type f -mtime +2 -delete`
to reclaim the ~60 GB `com.apple.coresymbolicationd` cache, but `coresymbolicationd`
keeps its `data` file constantly up-to-date, so `-mtime +2` never matches.
The disk fills to 99%, causing the next run to fail with `Permission denied`
when executing the downloaded binary. Replace with a direct `rm -rf` of `data`;
macOS rebuilds it automatically.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.184`
<!-- ch-version-info:end -->