### PR TITLE
Text index: allow to filter tokens to be indexed by stop words

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -1408,6 +1408,9 @@ void MergeTreeIndexTextGranuleBuilder::addDocument(std::string_view document)
         document.size(),
         [&](const char * token_start, size_t token_length)
         {
+            if (params.token_filter.count(std::string_view(token_start, token_length)))
+                return false;
+
             bool inserted;
             TokenToPostingsBuilderMap::LookupResult it;
 
@@ -1612,6 +1615,16 @@ static const String ARGUMENT_DICTIONARY_BLOCK_SIZE = "dictionary_block_size";
 static const String ARGUMENT_DICTIONARY_BLOCK_FRONTCODING_COMPRESSION = "dictionary_block_frontcoding_compression";
 static const String ARGUMENT_POSTING_LIST_BLOCK_SIZE = "posting_list_block_size";
 static const String ARGUMENT_POSTING_LIST_CODEC = "posting_list_codec";
+static const String ARGUMENT_TOKEN_FILTER = "token_filter";
+
+/// Same stop words as Lucene EnglishAnalyzer, and CLucene.
+static const std::vector<String> ENGLISH_STOP_WORDS =
+{
+    "a", "an", "and", "are", "as", "at", "be", "but", "by", "for",
+    "if", "in", "into", "is", "it", "no", "not", "of", "on", "or",
+    "such", "that", "the", "their", "then", "there", "these", "they",
+    "this", "to", "was", "will", "with"
+};
 
 namespace
 {
@@ -1661,6 +1674,61 @@ ASTPtr extractASTOption(std::unordered_map<String, ASTPtr> & options, const Stri
     return nullptr;
 }
 
+absl::flat_hash_set<String> extractTokenFilter(std::unordered_map<String, ASTPtr> & options)
+{
+    auto it = options.find(ARGUMENT_TOKEN_FILTER);
+    if (it == options.end())
+        return {};
+
+    ASTPtr ast = it->second;
+    options.erase(it);
+
+    absl::flat_hash_set<String> token_filter;
+
+    if (const auto * literal = ast->as<ASTLiteral>())
+    {
+        if (literal->value.getType() == Field::Types::String)
+        {
+            const String preset = literal->value.safeGet<String>();
+            if (preset == "english")
+                token_filter.insert(ENGLISH_STOP_WORDS.begin(), ENGLISH_STOP_WORDS.end());
+            else
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS,
+                    "Unknown token filter preset '{}'. Supported presets: 'english'",
+                    preset);
+        }
+        else if (literal->value.getType() == Field::Types::Array)
+        {
+            for (const auto & element : literal->value.safeGet<Array>())
+            {
+                if (element.getType() != Field::Types::String)
+                    throw Exception(
+                        ErrorCodes::BAD_ARGUMENTS,
+                        "Text index argument '{}' array elements must be string literals",
+                        ARGUMENT_TOKEN_FILTER);
+                token_filter.insert(element.safeGet<String>());
+            }
+        }
+        else
+        {
+            throw Exception(
+                ErrorCodes::BAD_ARGUMENTS,
+                "Text index argument '{}' must be a string constant ('english') or an array of strings, but got {}",
+                ARGUMENT_TOKEN_FILTER, literal->value.getTypeName());
+        }
+    }
+    else
+    {
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS,
+            "Text index argument '{}' must be a string constant ('english') or an array of strings",
+            ARGUMENT_TOKEN_FILTER);
+    }
+
+    return token_filter;
+}
+
 std::pair<String, ASTPtr> parseNamedArgument(const ASTFunction * ast_equal_function)
 {
     if (!ast_equal_function
@@ -1707,12 +1775,14 @@ MergeTreeIndexPtr textIndexCreator(const IndexDescription & index)
     UInt64 dictionary_block_size = extractFieldOption<UInt64>(options, ARGUMENT_DICTIONARY_BLOCK_SIZE).value_or(DEFAULT_DICTIONARY_BLOCK_SIZE);
     UInt64 dictionary_block_frontcoding_compression = extractFieldOption<UInt64>(options, ARGUMENT_DICTIONARY_BLOCK_FRONTCODING_COMPRESSION).value_or(DEFAULT_DICTIONARY_BLOCK_USE_FRONTCODING);
     UInt64 posting_list_block_size = extractFieldOption<UInt64>(options, ARGUMENT_POSTING_LIST_BLOCK_SIZE).value_or(DEFAULT_POSTING_LIST_BLOCK_SIZE);
+    auto token_filter = extractTokenFilter(options);
 
     MergeTreeIndexTextParams index_params{
         dictionary_block_size,
         dictionary_block_frontcoding_compression,
         posting_list_block_size,
-        std::move(preprocessor_ast)};
+        std::move(preprocessor_ast),
+        std::move(token_filter)};
 
     String posting_list_codec_name = extractFieldOption<String>(options, ARGUMENT_POSTING_LIST_CODEC).value_or(DEFAULT_POSTING_LIST_CODEC);
     auto posting_list_codec = PostingListCodecFactory::createPostingListCodec(posting_list_codec_name, index.name);
@@ -1745,6 +1815,8 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
 
     String posting_list_codec_name = extractFieldOption<String>(options, ARGUMENT_POSTING_LIST_CODEC).value_or(DEFAULT_POSTING_LIST_CODEC);
     PostingListCodecFactory::createPostingListCodec(posting_list_codec_name, index.name);
+
+    std::ignore = extractTokenFilter(options);
 
     if (!options.empty())
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected text index arguments: {}", fmt::join(std::views::keys(options), ", "));

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -79,6 +79,7 @@ struct MergeTreeIndexTextParams
     size_t dictionary_block_frontcoding_compression = 1;
     size_t posting_list_block_size = 1024 * 1024;
     ASTPtr preprocessor;
+    absl::flat_hash_set<String> token_filter;
 };
 
 using PostingList = roaring::Roaring;

--- a/tests/queries/0_stateless/02346_text_index_token_filter.reference
+++ b/tests/queries/0_stateless/02346_text_index_token_filter.reference
@@ -1,0 +1,38 @@
+Negative cases
+-- token_filter must be a string constant (preset name) or an array of strings
+splitByNonAlpha
+-- english filter
+brown
+dog
+fox
+lazy
+quick
+splitByNonAlpha
+-- custom filter
+a
+brown
+lazy
+quick
+the
+splitByString
+-- english filter
+bold
+brave
+ngrams
+-- custom filter
+bcd
+cde
+sparseGrams
+-- custom filter
+array
+-- english filter
+brown
+lazy
+quick
+asciiCJK
+-- english filter
+brown
+dog
+fox
+lazy
+quick

--- a/tests/queries/0_stateless/02346_text_index_token_filter.sql
+++ b/tests/queries/0_stateless/02346_text_index_token_filter.sql
@@ -1,0 +1,141 @@
+-- Tests the token_filter parameter of text index.
+
+DROP TABLE IF EXISTS tab;
+
+SELECT 'Negative cases';
+
+SELECT '-- token_filter must be a string constant (preset name) or an array of strings';
+
+CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = splitByNonAlpha, token_filter = 42))
+ENGINE = MergeTree ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+
+CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = splitByNonAlpha, token_filter = 1.5))
+ENGINE = MergeTree ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+
+CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = splitByNonAlpha, token_filter = 'unknown_preset'))
+ENGINE = MergeTree ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+
+CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = splitByNonAlpha, token_filter = [1, 2]))
+ENGINE = MergeTree ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+
+CREATE TABLE tab (s String, INDEX idx s TYPE text(tokenizer = splitByNonAlpha, token_filter = concat('a', 'b')))
+ENGINE = MergeTree ORDER BY tuple(); -- { serverError BAD_ARGUMENTS }
+
+SELECT 'splitByNonAlpha';
+SELECT '-- english filter';
+
+CREATE TABLE tab
+(
+    id UInt64,
+    s String,
+    INDEX idx s TYPE text(tokenizer = splitByNonAlpha, token_filter = 'english')
+)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (1, 'the quick brown fox'), (2, 'it was a lazy dog');
+
+SELECT token FROM mergeTreeTextIndex(currentDatabase(), tab, idx) ORDER BY token;
+
+DROP TABLE tab;
+
+SELECT 'splitByNonAlpha';
+SELECT '-- custom filter';
+
+CREATE TABLE tab
+(
+    id UInt64,
+    s String,
+    INDEX idx s TYPE text(tokenizer = splitByNonAlpha, token_filter = ['fox', 'dog'])
+)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (1, 'the quick brown fox'), (2, 'a lazy dog');
+
+SELECT token FROM mergeTreeTextIndex(currentDatabase(), tab, idx) ORDER BY token;
+
+DROP TABLE tab;
+
+SELECT 'splitByString';
+SELECT '-- english filter';
+
+CREATE TABLE tab
+(
+    id UInt64,
+    s String,
+    INDEX idx s TYPE text(tokenizer = splitByString([' ']), token_filter = 'english')
+)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (1, 'to be or not to be'), (2, 'brave and bold');
+
+SELECT token FROM mergeTreeTextIndex(currentDatabase(), tab, idx) ORDER BY token;
+
+DROP TABLE tab;
+
+SELECT 'ngrams';
+SELECT '-- custom filter';
+
+CREATE TABLE tab
+(
+    id UInt64,
+    s String,
+    INDEX idx s TYPE text(tokenizer = ngrams(3), token_filter = ['abc', 'def'])
+)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (1, 'abcdef');
+
+SELECT token FROM mergeTreeTextIndex(currentDatabase(), tab, idx) ORDER BY token;
+
+DROP TABLE tab;
+
+SELECT 'sparseGrams';
+SELECT '-- custom filter';
+
+CREATE TABLE tab
+(
+    id UInt64,
+    s String,
+    INDEX idx s TYPE text(tokenizer = sparseGrams(3), token_filter = ['abc'])
+)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (1, 'abc');
+
+SELECT token FROM mergeTreeTextIndex(currentDatabase(), tab, idx) ORDER BY token;
+
+DROP TABLE tab;
+
+SELECT 'array';
+SELECT '-- english filter';
+
+CREATE TABLE tab
+(
+    id UInt64,
+    arr Array(String),
+    INDEX idx arr TYPE text(tokenizer = array, token_filter = 'english')
+)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (1, ['the', 'quick', 'brown']), (2, ['it', 'was', 'lazy']);
+
+SELECT token FROM mergeTreeTextIndex(currentDatabase(), tab, idx) ORDER BY token;
+
+DROP TABLE tab;
+
+SELECT 'asciiCJK';
+SELECT '-- english filter';
+
+CREATE TABLE tab
+(
+    id UInt64,
+    s String,
+    INDEX idx s TYPE text(tokenizer = asciiCJK, token_filter = 'english')
+)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (1, 'the quick brown fox'), (2, 'it was a lazy dog');
+
+SELECT token FROM mergeTreeTextIndex(currentDatabase(), tab, idx) ORDER BY token;
+
+DROP TABLE tab;


### PR DESCRIPTION
This PR introduced a new argument `token_filter` to the text index definition.

TODO:
- [ ] Forward token filter to hasAnyTokens, hasAllTokens and hasPhrase functions [ ] Documentation

### Changelog category (leave one):

- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Allow to filter out tokens (stop words) during build of a text index.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
