### PR TITLE
Text index: allow to filter tokens to be indexed by its length

### DIFF
--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -7,6 +7,7 @@
 #include <Common/ElapsedTimeProfileEventIncrement.h>
 #include <Common/HashTable/HashSet.h>
 #include <Common/Logger.h>
+#include <Common/UTF8Helpers.h>
 #include <Common/formatReadable.h>
 #include <Common/logger_useful.h>
 #include <Common/typeid_cast.h>
@@ -1402,12 +1403,21 @@ void PostingListBuilder::add(UInt32 value, PostingListsHolder & postings_holder)
 
 void MergeTreeIndexTextGranuleBuilder::addDocument(std::string_view document)
 {
+    const bool has_token_char_limits = params.hasTokenCharLimits();
+
     forEachToken(
         *tokenizer,
         document.data(),
         document.size(),
         [&](const char * token_start, size_t token_length)
         {
+            if (has_token_char_limits)
+            {
+                const size_t chars = UTF8::countCodePoints(reinterpret_cast<const UInt8 *>(token_start), token_length);
+                if (chars < params.min_token_chars || chars > params.max_token_chars)
+                    return false;
+            }
+
             bool inserted;
             TokenToPostingsBuilderMap::LookupResult it;
 
@@ -1612,6 +1622,8 @@ static const String ARGUMENT_DICTIONARY_BLOCK_SIZE = "dictionary_block_size";
 static const String ARGUMENT_DICTIONARY_BLOCK_FRONTCODING_COMPRESSION = "dictionary_block_frontcoding_compression";
 static const String ARGUMENT_POSTING_LIST_BLOCK_SIZE = "posting_list_block_size";
 static const String ARGUMENT_POSTING_LIST_CODEC = "posting_list_codec";
+static const String ARGUMENT_MIN_TOKEN_CHARS = "min_token_chars";
+static const String ARGUMENT_MAX_TOKEN_CHARS = "max_token_chars";
 
 namespace
 {
@@ -1707,11 +1719,16 @@ MergeTreeIndexPtr textIndexCreator(const IndexDescription & index)
     UInt64 dictionary_block_size = extractFieldOption<UInt64>(options, ARGUMENT_DICTIONARY_BLOCK_SIZE).value_or(DEFAULT_DICTIONARY_BLOCK_SIZE);
     UInt64 dictionary_block_frontcoding_compression = extractFieldOption<UInt64>(options, ARGUMENT_DICTIONARY_BLOCK_FRONTCODING_COMPRESSION).value_or(DEFAULT_DICTIONARY_BLOCK_USE_FRONTCODING);
     UInt64 posting_list_block_size = extractFieldOption<UInt64>(options, ARGUMENT_POSTING_LIST_BLOCK_SIZE).value_or(DEFAULT_POSTING_LIST_BLOCK_SIZE);
+    UInt64 min_token_chars = extractFieldOption<UInt64>(options, ARGUMENT_MIN_TOKEN_CHARS).value_or(0);
+    UInt64 max_token_chars = extractFieldOption<UInt64>(options, ARGUMENT_MAX_TOKEN_CHARS)
+        .value_or(std::numeric_limits<size_t>::max());
 
     MergeTreeIndexTextParams index_params{
         dictionary_block_size,
         dictionary_block_frontcoding_compression,
         posting_list_block_size,
+        min_token_chars,
+        max_token_chars,
         std::move(preprocessor_ast)};
 
     String posting_list_codec_name = extractFieldOption<String>(options, ARGUMENT_POSTING_LIST_CODEC).value_or(DEFAULT_POSTING_LIST_CODEC);
@@ -1729,7 +1746,7 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
 
     auto tokenizer_ast = extractASTOption(options, ARGUMENT_TOKENIZER, true);
     auto preprocessor_ast = extractASTOption(options, ARGUMENT_PREPROCESSOR, false);
-    TokenizerFactory::instance().get(tokenizer_ast);
+    auto tokenizer = TokenizerFactory::instance().get(tokenizer_ast);
 
     UInt64 dictionary_block_size = extractFieldOption<UInt64>(options, ARGUMENT_DICTIONARY_BLOCK_SIZE).value_or(DEFAULT_DICTIONARY_BLOCK_SIZE);
     if (dictionary_block_size == 0)
@@ -1742,6 +1759,21 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
     UInt64 posting_list_block_size = extractFieldOption<UInt64>(options, ARGUMENT_POSTING_LIST_BLOCK_SIZE).value_or(DEFAULT_POSTING_LIST_BLOCK_SIZE);
     if (posting_list_block_size == 0)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Text index argument '{}' must be greater than 0, but got {}", ARGUMENT_POSTING_LIST_BLOCK_SIZE, posting_list_block_size);
+
+    UInt64 min_token_chars = extractFieldOption<UInt64>(options, ARGUMENT_MIN_TOKEN_CHARS).value_or(0);
+    UInt64 max_token_chars = extractFieldOption<UInt64>(options, ARGUMENT_MAX_TOKEN_CHARS).value_or(0);
+
+    if ((min_token_chars > 0 || max_token_chars > 0)
+        && (tokenizer->getType() == ITokenizer::Type::Ngrams || tokenizer->getType() == ITokenizer::Type::SparseGrams))
+    {
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+            "Text index arguments '{}' and '{}' are not supported with '{}' tokenizer because token length is fixed by the tokenizer",
+            ARGUMENT_MIN_TOKEN_CHARS, ARGUMENT_MAX_TOKEN_CHARS, tokenizer->getTokenizerName());
+    }
+
+    if (max_token_chars != 0 && min_token_chars > max_token_chars)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Text index argument '{}' ({}) must not be greater than '{}' ({})",
+            ARGUMENT_MIN_TOKEN_CHARS, min_token_chars, ARGUMENT_MAX_TOKEN_CHARS, max_token_chars);
 
     String posting_list_codec_name = extractFieldOption<String>(options, ARGUMENT_POSTING_LIST_CODEC).value_or(DEFAULT_POSTING_LIST_CODEC);
     PostingListCodecFactory::createPostingListCodec(posting_list_codec_name, index.name);

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -78,7 +78,11 @@ struct MergeTreeIndexTextParams
     size_t dictionary_block_size = 0;
     size_t dictionary_block_frontcoding_compression = 1;
     size_t posting_list_block_size = 1024 * 1024;
+    size_t min_token_chars = 0;
+    size_t max_token_chars = std::numeric_limits<size_t>::max();
     ASTPtr preprocessor;
+
+    bool hasTokenCharLimits() const { return min_token_chars > 0 || max_token_chars < std::numeric_limits<size_t>::max(); }
 };
 
 using PostingList = roaring::Roaring;

--- a/tests/queries/0_stateless/02346_text_index_min_max_token_chars.reference
+++ b/tests/queries/0_stateless/02346_text_index_min_max_token_chars.reference
@@ -1,0 +1,60 @@
+splitByNonAlpha
+-- no limits
+a
+bb
+ccc
+dddd
+eeeee
+-- min_token_chars = 3
+ccc
+dddd
+eeeee
+-- max_token_chars = 3
+a
+bb
+ccc
+-- min_token_chars = 2, max_token_chars = 4
+bb
+ccc
+dddd
+splitByNonAlpha UTF-8
+-- no limits
+до
+кот
+медведь
+слон
+я
+-- min_token_chars = 3
+кот
+медведь
+слон
+-- max_token_chars = 3
+до
+кот
+я
+asciiCJK
+-- no limits
+hello
+world
+世
+和
+平
+界
+-- min_token_chars = 2 (filters single CJK chars)
+hello
+world
+splitByString
+-- no limits
+a
+bb
+ccc
+dddd
+-- min_token_chars = 3
+ccc
+dddd
+Validation
+-- min > max
+-- ngrams with min_token_chars
+-- ngrams with max_token_chars
+-- sparseGrams with min_token_chars
+-- sparseGrams with max_token_chars

--- a/tests/queries/0_stateless/02346_text_index_min_max_token_chars.sql
+++ b/tests/queries/0_stateless/02346_text_index_min_max_token_chars.sql
@@ -1,0 +1,134 @@
+-- Testing min_token_chars and max_token_chars arguments of text index.
+
+DROP TABLE IF EXISTS tab;
+
+SELECT 'splitByNonAlpha';
+
+SELECT '-- no limits';
+
+CREATE TABLE tab (id UInt64, s String, INDEX idx_s (s) TYPE text(tokenizer = splitByNonAlpha)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (0, 'a bb ccc dddd eeeee');
+
+SELECT token FROM mergeTreeTextIndex(currentDatabase(), tab, idx_s) ORDER BY token;
+
+DROP TABLE tab;
+
+SELECT '-- min_token_chars = 3';
+
+CREATE TABLE tab (id UInt64, s String, INDEX idx_s (s) TYPE text(tokenizer = splitByNonAlpha, min_token_chars = 3)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (0, 'a bb ccc dddd eeeee');
+
+SELECT token FROM mergeTreeTextIndex(currentDatabase(), tab, idx_s) ORDER BY token;
+
+DROP TABLE tab;
+
+SELECT '-- max_token_chars = 3';
+
+CREATE TABLE tab (id UInt64, s String, INDEX idx_s (s) TYPE text(tokenizer = splitByNonAlpha, max_token_chars = 3)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (0, 'a bb ccc dddd eeeee');
+
+SELECT token FROM mergeTreeTextIndex(currentDatabase(), tab, idx_s) ORDER BY token;
+
+DROP TABLE tab;
+
+SELECT '-- min_token_chars = 2, max_token_chars = 4';
+
+CREATE TABLE tab (id UInt64, s String, INDEX idx_s (s) TYPE text(tokenizer = splitByNonAlpha, min_token_chars = 2, max_token_chars = 4)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (0, 'a bb ccc dddd eeeee');
+
+SELECT token FROM mergeTreeTextIndex(currentDatabase(), tab, idx_s) ORDER BY token;
+
+DROP TABLE tab;
+
+SELECT 'splitByNonAlpha UTF-8';
+
+SELECT '-- no limits';
+
+CREATE TABLE tab (id UInt64, s String, INDEX idx_s (s) TYPE text(tokenizer = splitByNonAlpha)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (0, 'я до кот слон медведь');
+
+SELECT token FROM mergeTreeTextIndex(currentDatabase(), tab, idx_s) ORDER BY token;
+
+DROP TABLE tab;
+
+SELECT '-- min_token_chars = 3';
+
+CREATE TABLE tab (id UInt64, s String, INDEX idx_s (s) TYPE text(tokenizer = splitByNonAlpha, min_token_chars = 3)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (0, 'я до кот слон медведь');
+
+SELECT token FROM mergeTreeTextIndex(currentDatabase(), tab, idx_s) ORDER BY token;
+
+DROP TABLE tab;
+
+SELECT '-- max_token_chars = 3';
+
+CREATE TABLE tab (id UInt64, s String, INDEX idx_s (s) TYPE text(tokenizer = splitByNonAlpha, max_token_chars = 3)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (0, 'я до кот слон медведь');
+
+SELECT token FROM mergeTreeTextIndex(currentDatabase(), tab, idx_s) ORDER BY token;
+
+DROP TABLE tab;
+
+SELECT 'asciiCJK';
+
+SELECT '-- no limits';
+
+CREATE TABLE tab (id UInt64, s String, INDEX idx_s (s) TYPE text(tokenizer = asciiCJK)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (0, 'hello world 世界和平');
+
+SELECT token FROM mergeTreeTextIndex(currentDatabase(), tab, idx_s) ORDER BY token;
+
+DROP TABLE tab;
+
+SELECT '-- min_token_chars = 2 (filters single CJK chars)';
+
+CREATE TABLE tab (id UInt64, s String, INDEX idx_s (s) TYPE text(tokenizer = asciiCJK, min_token_chars = 2)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (0, 'hello world 世界和平');
+
+SELECT token FROM mergeTreeTextIndex(currentDatabase(), tab, idx_s) ORDER BY token;
+
+DROP TABLE tab;
+
+SELECT 'splitByString';
+
+SELECT '-- no limits';
+
+CREATE TABLE tab (id UInt64, s String, INDEX idx_s (s) TYPE text(tokenizer = splitByString([',']))) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (0, 'a,bb,ccc,dddd');
+
+SELECT token FROM mergeTreeTextIndex(currentDatabase(), tab, idx_s) ORDER BY token;
+
+DROP TABLE tab;
+
+SELECT '-- min_token_chars = 3';
+
+CREATE TABLE tab (id UInt64, s String, INDEX idx_s (s) TYPE text(tokenizer = splitByString([',']), min_token_chars = 3)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (0, 'a,bb,ccc,dddd');
+
+SELECT token FROM mergeTreeTextIndex(currentDatabase(), tab, idx_s) ORDER BY token;
+
+DROP TABLE tab;
+
+SELECT 'Validation';
+
+SELECT '-- min > max';
+
+CREATE TABLE tab (id UInt64, s String, INDEX idx_s (s) TYPE text(tokenizer = splitByNonAlpha, min_token_chars = 5, max_token_chars = 2)) ENGINE = MergeTree ORDER BY id; -- { serverError BAD_ARGUMENTS }
+
+SELECT '-- ngrams with min_token_chars';
+
+CREATE TABLE tab (id UInt64, s String, INDEX idx_s (s) TYPE text(tokenizer = ngrams(3), min_token_chars = 4)) ENGINE = MergeTree ORDER BY id; -- { serverError BAD_ARGUMENTS }
+
+SELECT '-- ngrams with max_token_chars';
+
+CREATE TABLE tab (id UInt64, s String, INDEX idx_s (s) TYPE text(tokenizer = ngrams(3), max_token_chars = 4)) ENGINE = MergeTree ORDER BY id; -- { serverError BAD_ARGUMENTS }
+
+SELECT '-- sparseGrams with min_token_chars';
+
+CREATE TABLE tab (id UInt64, s String, INDEX idx_s (s) TYPE text(tokenizer = sparseGrams, min_token_chars = 4)) ENGINE = MergeTree ORDER BY id; -- { serverError BAD_ARGUMENTS }
+
+SELECT '-- sparseGrams with max_token_chars';
+
+CREATE TABLE tab (id UInt64, s String, INDEX idx_s (s) TYPE text(tokenizer = sparseGrams, max_token_chars = 4)) ENGINE = MergeTree ORDER BY id; -- { serverError BAD_ARGUMENTS }
+
+DROP TABLE IF EXISTS tab;


### PR DESCRIPTION
This introduced two new arguments to the text index definition named `min_token_chars` and `max_token_chars`, by default they are unlimited.

TODO:
- [ ] Forward params to hasAnyTokens, hasAllTokens and hasPhrase functions [ ] Documentation

### Changelog category (leave one):

- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Allows to filter out tokens not in the provided token length range.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
