### PR TITLE
Fix flaky test_parallel_replicas_with_view (ProfileEvent race)

### DIFF
--- a/tests/integration/test_backward_compatibility/test_pr_protocol_with_stream_id.py
+++ b/tests/integration/test_backward_compatibility/test_pr_protocol_with_stream_id.py
@@ -97,15 +97,22 @@ def test_parallel_replicas_with_view(start_cluster):
     result = nodes[1].query("SELECT sum(value) FROM v", settings=settings)
     assert result.strip() == expected
 
-    def run_and_check(extra_settings, expected_unavailable, expected_used):
-        """Run query from new node, verify result and that old replicas are filtered out."""
+    def run_and_check(extra_settings, expected_unavailable, expected_used, *, strict_unavailable=False):
+        """Run query from new node, verify result and that old replicas are filtered out.
+
+        ``strict_unavailable=True`` requires `ParallelReplicasUnavailableCount` to equal
+        `expected_unavailable` exactly. Use it for deterministic configurations
+        (`parallel_replicas_local_plan = 0`). For racy configurations
+        (`parallel_replicas_local_plan = 1`, default), the count is upper-bounded:
+        see comment below.
+        """
         merged = {**settings, **extra_settings}
         qid = f"test_pr_protocol_with_stream_id_{uuid.uuid4()}"
         result = nodes[2].query("SELECT sum(value) FROM v", settings=merged, query_id=qid)
         assert result.strip() == expected, f"Wrong result with settings {extra_settings}"
 
         # node2 is the new node, nodes 0 and 1 are old (no stream_id support).
-        # Old replicas are filtered out at connection time inside RemoteQueryExecutor's
+        # Old replicas are filtered out at connection time inside `RemoteQueryExecutor`'s
         # `create_connections` lambda: the version check disconnects entries whose
         # `parallel_replicas_version` is below `DBMS_PARALLEL_REPLICAS_MIN_VERSION_WITH_STREAM_ID`.
         # The `ParallelReplicasUnavailableCount` ProfileEvent is incremented later in
@@ -116,11 +123,16 @@ def test_parallel_replicas_with_view(start_cluster):
         # BEFORE `tryGenerate` ever calls `sendQuery` (see `RemoteSource::prepare`
         # short-circuit on `isCancelled`). For those replicas the version check never
         # runs and `ParallelReplicasUnavailableCount` is not incremented.
-        # Hence the count is bounded above by `expected_unavailable` but can be smaller
-        # (down to 0) due to this dispatch race. The `ParallelReplicasUsedCount` reflects
-        # how many task assignments the coordinator handed out and remains deterministic
-        # — it must equal `expected_used` (the number of new replicas times the number
-        # of sub-queries). The query result is the primary correctness check; if any old
+        # Hence with `parallel_replicas_local_plan = 1` (default) the count is bounded
+        # above by `expected_unavailable` but can be smaller (down to 0) due to this
+        # dispatch race; we accept any value in that range. With
+        # `parallel_replicas_local_plan = 0` there is no local plan to short-circuit
+        # the pipeline, so `sendQuery` always runs the version check and the count is
+        # deterministic — strict equality is enforced via `strict_unavailable=True`.
+        # `ParallelReplicasUsedCount` reflects how many task assignments the
+        # coordinator handed out and remains deterministic in both cases — it must
+        # equal `expected_used` (the number of new replicas times the number of
+        # sub-queries). The query result is the primary correctness check; if any old
         # replica were ever used, the sum would also be wrong.
         nodes[2].query("SYSTEM FLUSH LOGS")
         profile_events = nodes[2].query(
@@ -141,16 +153,30 @@ def test_parallel_replicas_with_view(start_cluster):
             f"Wrong ParallelReplicasUsedCount with settings {extra_settings}: "
             f"got {used}, expected {expected_used}"
         )
-        assert 0 <= unavail <= expected_unavailable, (
-            f"Wrong ParallelReplicasUnavailableCount with settings {extra_settings}: "
-            f"got {unavail}, expected 0..{expected_unavailable}"
-        )
+        if strict_unavailable:
+            assert unavail == expected_unavailable, (
+                f"Wrong ParallelReplicasUnavailableCount with settings {extra_settings}: "
+                f"got {unavail}, expected {expected_unavailable} (deterministic)"
+            )
+        else:
+            assert 0 <= unavail <= expected_unavailable, (
+                f"Wrong ParallelReplicasUnavailableCount with settings {extra_settings}: "
+                f"got {unavail}, expected 0..{expected_unavailable}"
+            )
 
+    # `parallel_replicas_local_plan` defaults to 1 — racy path, upper-bounded check.
     run_and_check({"parallel_replicas_allow_view_over_mergetree": 1}, 2, 1)
     run_and_check({"parallel_replicas_allow_view_over_mergetree": 1, "parallel_replicas_local_plan": 1}, 2, 1)
-    run_and_check({"parallel_replicas_allow_view_over_mergetree": 1, "parallel_replicas_local_plan": 0}, 2, 1)
+    # `parallel_replicas_local_plan = 0` — no local plan, no early cancel, deterministic count.
+    run_and_check(
+        {"parallel_replicas_allow_view_over_mergetree": 1, "parallel_replicas_local_plan": 0},
+        2,
+        1,
+        strict_unavailable=True,
+    )
     # With view-over-MergeTree disabled, the view is expanded into two separate
     # sub-queries (one per underlying table), each with its own set of replicas.
+    # `parallel_replicas_local_plan` defaults to 1 — racy path, upper-bounded check.
     run_and_check({"parallel_replicas_allow_view_over_mergetree": 0}, 4, 2)
 
     for node in nodes:

--- a/tests/integration/test_backward_compatibility/test_pr_protocol_with_stream_id.py
+++ b/tests/integration/test_backward_compatibility/test_pr_protocol_with_stream_id.py
@@ -98,14 +98,30 @@ def test_parallel_replicas_with_view(start_cluster):
     assert result.strip() == expected
 
     def run_and_check(extra_settings, expected_unavailable, expected_used):
-        """Run query from new node, verify result and that old replicas are unavailable."""
+        """Run query from new node, verify result and that old replicas are filtered out."""
         merged = {**settings, **extra_settings}
         qid = f"test_pr_protocol_with_stream_id_{uuid.uuid4()}"
         result = nodes[2].query("SELECT sum(value) FROM v", settings=merged, query_id=qid)
         assert result.strip() == expected, f"Wrong result with settings {extra_settings}"
 
         # node2 is the new node, nodes 0 and 1 are old (no stream_id support).
-        # Old replicas should be filtered out at connection time and marked unavailable.
+        # Old replicas are filtered out at connection time inside RemoteQueryExecutor's
+        # `create_connections` lambda: the version check disconnects entries whose
+        # `parallel_replicas_version` is below `DBMS_PARALLEL_REPLICAS_MIN_VERSION_WITH_STREAM_ID`.
+        # The `ParallelReplicasUnavailableCount` ProfileEvent is incremented later in
+        # `RemoteQueryExecutor::sendQueryUnlocked` when it observes the empty
+        # `MultiplexedConnections`. However, when `parallel_replicas_local_plan = 1`,
+        # the local plan can serve all required data quickly and cancel the pipeline,
+        # in which case the `RemoteSource` for some old replicas may be cancelled
+        # BEFORE `tryGenerate` ever calls `sendQuery` (see `RemoteSource::prepare`
+        # short-circuit on `isCancelled`). For those replicas the version check never
+        # runs and `ParallelReplicasUnavailableCount` is not incremented.
+        # Hence the count is bounded above by `expected_unavailable` but can be smaller
+        # (down to 0) due to this dispatch race. The `ParallelReplicasUsedCount` reflects
+        # how many task assignments the coordinator handed out and remains deterministic
+        # — it must equal `expected_used` (the number of new replicas times the number
+        # of sub-queries). The query result is the primary correctness check; if any old
+        # replica were ever used, the sum would also be wrong.
         nodes[2].query("SYSTEM FLUSH LOGS")
         profile_events = nodes[2].query(
             f"""
@@ -118,8 +134,17 @@ def test_parallel_replicas_with_view(start_cluster):
             SETTINGS enable_parallel_replicas = 0
             """
         )
-        assert profile_events.strip() == f"{expected_unavailable}\t{expected_used}", \
-            f"Wrong profile events with settings {extra_settings}: {profile_events.strip()}"
+        unavail_str, used_str = profile_events.strip().split("\t")
+        unavail = int(unavail_str)
+        used = int(used_str)
+        assert used == expected_used, (
+            f"Wrong ParallelReplicasUsedCount with settings {extra_settings}: "
+            f"got {used}, expected {expected_used}"
+        )
+        assert 0 <= unavail <= expected_unavailable, (
+            f"Wrong ParallelReplicasUnavailableCount with settings {extra_settings}: "
+            f"got {unavail}, expected 0..{expected_unavailable}"
+        )
 
     run_and_check({"parallel_replicas_allow_view_over_mergetree": 1}, 2, 1)
     run_and_check({"parallel_replicas_allow_view_over_mergetree": 1, "parallel_replicas_local_plan": 1}, 2, 1)


### PR DESCRIPTION
The integration test `test_parallel_replicas_with_view`
(`tests/integration/test_backward_compatibility/test_pr_protocol_with_stream_id.py`,
added in #100958) asserts strict equality on the
`ParallelReplicasUnavailableCount` and `ParallelReplicasUsedCount` ProfileEvents
collected from `system.query_log`. The strict equality on
`ParallelReplicasUnavailableCount` is racy and is the source of recurring CI
failures across unrelated PRs and one master hit on 2026-04-27.

### Why the count is racy

Old replicas (the two 25.12 instances in this test) are filtered at connection
time inside `RemoteQueryExecutor`'s `create_connections` lambda
(`src/QueryPipeline/RemoteQueryExecutor.cpp` ~line 140): the version check
disconnects entries whose `parallel_replicas_version` is below
`DBMS_PARALLEL_REPLICAS_MIN_VERSION_WITH_STREAM_ID`. The
`ParallelReplicasUnavailableCount` ProfileEvent is incremented later, in
`RemoteQueryExecutor::sendQueryUnlocked`, when it observes the resulting empty
`MultiplexedConnections` and calls
`ParallelReplicasReadingCoordinator::markReplicaAsUnavailable`.

With the default `parallel_replicas_local_plan = 1` (and on the call sites that
expand the view into two sub-queries), the local plan can serve all required
data quickly and cancel the pipeline. The `RemoteSource` for some old replicas
may then be cancelled BEFORE `tryGenerate` ever calls `sendQuery` (`prepare`
short-circuits on `isCancelled` in `src/Processors/Sources/RemoteSource.cpp`).
For those replicas the version check never runs, so
`ParallelReplicasUnavailableCount` is not incremented for them.

### CIDB evidence (last 14 days)

| Date (UTC) | PR / branch | Line | Expected | Got |
|---|---|---|---|---|
| 2026-04-29 | PR #100412 | 129 (`parallel_replicas_allow_view_over_mergetree=0`) | `4\t2` | `0\t2` |
| 2026-04-29 | PR #100399 | 129 | `4\t2` | `0\t2` |
| 2026-04-27 | master | 129 | `4\t2` | `1\t2` |
| 2026-04-27 | PR #102197 | 125 (`parallel_replicas_local_plan=1`) | `2\t1` | `0\t1` |

In every case the `SELECT sum(value) FROM v` result was correct and
`ParallelReplicasUsedCount` matched the expected value — only the
`ParallelReplicasUnavailableCount` was below the strict-equality target.

CI report links:
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100412&sha=614dbdeb3cb9742d3f48e0f9bdb3b37a7146890e&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%203%2F4%29
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=529f4ede4&name_0=MasterCI

### Fix

Relax the assertion to:

* `ParallelReplicasUsedCount == expected_used` (kept strict — this is
  deterministic, and a higher-than-expected value would mean an old replica
  was actually used, which is the real bug we want to catch).
* `0 <= ParallelReplicasUnavailableCount <= expected_unavailable` — bounded
  above by the maximum possible (still catches spurious unavailability) but
  tolerant of the cancel-before-`sendQuery` race.

The primary correctness check — `SELECT sum(value) FROM v` matches the
expected sum — is unchanged. If any old replica were ever actually used as
a replica, the sum would be wrong (or `ParallelReplicasUsedCount` would
exceed `expected_used`).

### Verification

Verified locally:

```
sg docker -c 'python3 -m ci.praktika run "integration" --test \
  "test_backward_compatibility/test_pr_protocol_with_stream_id.py::test_parallel_replicas_with_view"'
```

Result: `1 passed in 43.90s` (`Integration tests (amd_tsan, 1/6)`).

Cannot reliably reproduce the race locally (~0.06% failure rate in CI). The
CIDB evidence above is the deterministic signal — fix is conservative and
preserves the strict invariants of the test.

### Pre-PR validation

a) Deterministic repro: NO locally (race ~0.06%) but CIDB evidence is consistent across 4 distinct PRs/master with the same error pattern.
b) Root cause explained: YES (see above).
c) Fix matches root cause: YES (relaxes only the racy assertion, keeps the deterministic ones).
d) Test intent preserved: YES (sum + used count strict; unavailable count bounded above).
e) Both directions: WITH fix passes locally; WITHOUT fix CIDB shows 4 chronic hits over 14d.
f) Fix general not narrow: YES (uniform relaxation across all 4 `run_and_check` calls).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.186`
<!-- ch-version-info:end -->