### PR TITLE
Fix flaky test_recover_from_snapshot_with_chunked_transfer

### DIFF
--- a/tests/integration/test_keeper_snapshot_chunked_transfer/test.py
+++ b/tests/integration/test_keeper_snapshot_chunked_transfer/test.py
@@ -125,6 +125,15 @@ def test_recover_from_snapshot_with_chunked_transfer(started_cluster, nodes):
     received = get_received_snapshot_info(node_lagging, kill_time)
     assert received is not None
 
+    # The kazoo client created before `stop_clickhouse(kill=True)` may have its
+    # session expire while the server is down (the default session timeout is
+    # shorter than the kill+restart window in CI under load). Once a kazoo
+    # session is expired the client cannot resume it on reconnect — even with
+    # implicit retries — and subsequent requests raise `ConnectionClosedError`.
+    # Re-create the client after the restart, matching the pattern used by the
+    # other test methods in this file.
+    lagging_zk = keeper_utils.get_fake_zk(cluster, node_lagging.name)
+
     assert lagging_zk.get(prefix)[0] == b"somedata"
     verify_test_tree(leader_zk, lagging_zk, prefix)
     verify_test_tree(leader_zk, middle_zk, prefix)


### PR DESCRIPTION
### Description

The integration test `test_recover_from_snapshot_with_chunked_transfer` creates a kazoo client for the lagging node *before* `stop_clickhouse(kill=True)`, then reuses the same client after restart to assert post-recovery state. Under CI load the kill+restart window can exceed the 30 s default kazoo session timeout, after which the session is irrecoverably expired and the client raises `ConnectionClosedError` on the next request — even with the wrapper's implicit retries.

This PR re-creates the kazoo client after the restart, matching the pattern used by every other test method in the same file (`test_recover_after_interrupted_transfer`, `test_recover_with_chunk_size_larger_than_snapshot`, `test_recover_after_s3_read_error_during_transfer`, `test_recover_from_snapshot_sent_by_old_leader`).

### Failure example

CI failure that triggered this fix — PR #103394, `Integration tests (amd_tsan, 6/6)`:

```
File: test_keeper_snapshot_chunked_transfer/test.py:128 - in test_recover_from_snapshot_with_chunked_transfer
    assert lagging_zk.get(prefix)[0] == b"somedata"
...
kazoo.exceptions.ConnectionClosedError: Connection has been closed
```

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=103394&sha=ad4662b27bacbf2146f3ece6456168c7b713946c&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%206%2F6%29

### Chronic flakiness in CIDB

30-day window:
- **11 distinct PRs** hit the failure (PR #100332: 12, PR #101757: 12, plus 9 others with 1 each).
- **1 master hit** on 2026-04-21.
- Open tracking issues: ClickHouse/ClickHouse#102040, ClickHouse/ClickHouse#101969.

The PR-relatedness of failing PRs has been verified — none of them touch Keeper code, and they are spread across unrelated areas (PREWHERE/IN-subquery, throw on unknown config, exact subcolumn match, JSON/text index, skip index aggregation, PK analysis stats, `!subranges.empty()` logical error, MongoDB cleanup, Azure validation). This rules out a real regression and confirms a chronic test-side flake.

### Why kazoo cannot recover

`tests/integration/helpers/kazoo_client.py` wraps every operation in `self.retry(...)`, so transient disconnections are handled. But `stop_clickhouse(kill=True)` followed by a slow restart eventually exceeds the kazoo *session* timeout (30 s by default in `get_fake_zk`). Kazoo distinguishes `LOST` (transient) from `EXPIRED` (terminal); once a session is `EXPIRED` the client moves to a closed state and no retries can resurrect it. The fresh `get_fake_zk` call after restart establishes a new session.

### Local validation

`python3 -m ci.praktika run "integration" --test "test_keeper_snapshot_chunked_transfer/test.py::test_recover_from_snapshot_with_chunked_transfer[local_disk]" --workers 1` — passes cleanly:

```
     setup   passed dur=18.8s
      call   passed dur=5.6s
  teardown   passed dur=6.4s
```

The chronic flake is timing-dependent (kazoo session expiry under CI load), so it cannot be deterministically reproduced on a fast local machine. The structural argument is the strong proof: with this change, the failing test method now follows the same client-recreation pattern as the four sibling test methods in the file that have never exhibited this failure mode.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not for changelog.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.233`
<!-- ch-version-info:end -->