### PR TITLE
Text index: extract text index analysis into `MergeTreeTextIndexAnalyzer`

### DIFF
--- a/src/Functions/textIndexAnalyzer.cpp
+++ b/src/Functions/textIndexAnalyzer.cpp
@@ -1,0 +1,277 @@
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnFixedString.h>
+#include <Columns/ColumnString.h>
+#include <Common/Exception.h>
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeString.h>
+#include <Functions/FunctionFactory.h>
+#include <Functions/FunctionHelpers.h>
+#include <Functions/IFunction.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/ExpressionActions.h>
+#include <Interpreters/ExpressionAnalyzer.h>
+#include <Interpreters/ITokenizer.h>
+#include <Interpreters/TokenizerFactory.h>
+#include <Interpreters/TreeRewriter.h>
+#include <Storages/MergeTree/MergeTreeTextIndexAnalyzer.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+    extern const int INCORRECT_QUERY;
+}
+
+namespace
+{
+
+/// Internal column name used when building ExpressionActions for the preprocessor.
+constexpr const char * INTERNAL_COLUMN_NAME = "__text_index_analyzer_input";
+
+/// Replaces all occurrences of "{input}" in the definition string with an internal column name
+/// so that the SQL parser sees a valid identifier.
+String substituteInputPlaceholder(const String & definition)
+{
+    static constexpr std::string_view placeholder = "{input}";
+
+    String result;
+    result.reserve(definition.size());
+
+    size_t pos = 0;
+    while (pos < definition.size())
+    {
+        size_t found = definition.find(placeholder, pos);
+        if (found == String::npos)
+        {
+            result.append(definition, pos);
+            break;
+        }
+        result.append(definition, pos, found - pos);
+        result.append(INTERNAL_COLUMN_NAME);
+        pos = found + placeholder.size();
+    }
+
+    return result;
+}
+
+/// Builds ExpressionActions from a preprocessor AST like lower(__text_index_analyzer_input).
+ExpressionActionsPtr buildPreprocessorActions(const ASTPtr & preprocessor_ast)
+{
+    if (!preprocessor_ast)
+        return nullptr;
+
+    ASTPtr expr = preprocessor_ast->clone();
+
+    auto context = Context::getGlobalContextInstance();
+    NamesAndTypesList source_columns = {{INTERNAL_COLUMN_NAME, std::make_shared<DataTypeString>()}};
+
+    auto syntax_result = TreeRewriter(context).analyze(expr, source_columns);
+    auto actions_dag = ExpressionAnalyzer(expr, syntax_result, context).getActionsDAG(false, true);
+
+    auto expression_name = expr->getColumnName();
+    actions_dag.project({{expression_name, expression_name}});
+    actions_dag.removeUnusedActions();
+
+    const auto & outputs = actions_dag.getOutputs();
+    if (outputs.size() != 1)
+        throw Exception(ErrorCodes::INCORRECT_QUERY, "The preprocessor expression must return a single column, but got {} output columns", outputs.size());
+
+    if (outputs.front()->type != ActionsDAG::ActionType::FUNCTION)
+        throw Exception(ErrorCodes::INCORRECT_QUERY, "The preprocessor expression must be a function applied to '{{input}}', but got '{}' action type",
+            outputs.front()->type);
+
+    auto output_type = outputs.front()->result_type;
+    WhichDataType which(output_type);
+    if (!which.isString() && !which.isFixedString())
+        throw Exception(ErrorCodes::INCORRECT_QUERY, "The preprocessor expression must return String or FixedString, but got: {}", output_type->getName());
+
+    return std::make_shared<ExpressionActions>(std::move(actions_dag));
+}
+
+/// Applies preprocessor ExpressionActions to an input column.
+ColumnPtr applyPreprocessor(const ExpressionActions & actions, ColumnPtr col_input, size_t input_rows_count)
+{
+    Block block{{col_input, std::make_shared<DataTypeString>(), INTERNAL_COLUMN_NAME}};
+    actions.execute(block, input_rows_count);
+    return block.safeGetByPosition(0).column;
+}
+
+class ExecutableFunctionTextIndexAnalyzer : public IExecutableFunction
+{
+public:
+    static constexpr auto name = "__textIndexAnalyzer";
+
+    ExecutableFunctionTextIndexAnalyzer(std::shared_ptr<const ITokenizer> tokenizer_, ExpressionActionsPtr preprocessor_)
+        : tokenizer(std::move(tokenizer_))
+        , preprocessor(std::move(preprocessor_))
+    {
+    }
+
+    String getName() const override { return name; }
+    bool useDefaultImplementationForConstants() const override { return true; }
+    ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {0}; }
+
+    ColumnPtr executeImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr &, size_t input_rows_count) const override
+    {
+        auto col_input = arguments[1].column;
+        auto col_result = ColumnString::create();
+        auto col_offsets = ColumnArray::ColumnOffsets::create();
+
+        if (input_rows_count == 0)
+            return ColumnArray::create(std::move(col_result), std::move(col_offsets));
+
+        if (preprocessor)
+            col_input = applyPreprocessor(*preprocessor, std::move(col_input), input_rows_count);
+
+        if (tokenizer->getType() == ITokenizer::Type::SparseGrams)
+        {
+            auto sparse_grams_tokenizer = tokenizer->clone();
+            executeWithTokenizer(*sparse_grams_tokenizer, std::move(col_input), *col_offsets, input_rows_count, *col_result);
+        }
+        else
+        {
+            executeWithTokenizer(*tokenizer, std::move(col_input), *col_offsets, input_rows_count, *col_result);
+        }
+
+        return ColumnArray::create(std::move(col_result), std::move(col_offsets));
+    }
+
+private:
+    void executeWithTokenizer(
+        const ITokenizer & tokenizer_,
+        ColumnPtr col_input,
+        ColumnArray::ColumnOffsets & col_offsets,
+        size_t input_rows_count,
+        ColumnString & col_result) const
+    {
+        if (const auto * column_string = checkAndGetColumn<ColumnString>(col_input.get()))
+            executeImpl(tokenizer_, *column_string, col_offsets, input_rows_count, col_result);
+        else if (const auto * column_fixed_string = checkAndGetColumn<ColumnFixedString>(col_input.get()))
+            executeImpl(tokenizer_, *column_fixed_string, col_offsets, input_rows_count, col_result);
+    }
+
+    template <typename StringColumnType>
+    void executeImpl(
+        const ITokenizer & tokenizer_,
+        const StringColumnType & column_input,
+        ColumnArray::ColumnOffsets & column_offsets_input,
+        size_t input_rows_count,
+        ColumnString & column_result) const
+    {
+        auto & offsets_data = column_offsets_input.getData();
+        offsets_data.resize(input_rows_count);
+        size_t tokens_count = 0;
+
+        for (size_t i = 0; i < input_rows_count; ++i)
+        {
+            std::string_view input = column_input.getDataAt(i);
+
+            forEachToken(
+                tokenizer_,
+                input.data(),
+                input.size(),
+                [&](const char * token_start, size_t token_len)
+                {
+                    column_result.insertData(token_start, token_len);
+                    ++tokens_count;
+                    return false;
+                });
+
+            offsets_data[i] = tokens_count;
+        }
+    }
+
+    std::shared_ptr<const ITokenizer> tokenizer;
+    ExpressionActionsPtr preprocessor;
+};
+
+class FunctionBaseTextIndexAnalyzer : public IFunctionBase
+{
+public:
+    static constexpr auto name = "__textIndexAnalyzer";
+
+    FunctionBaseTextIndexAnalyzer(
+        std::shared_ptr<const ITokenizer> tokenizer_,
+        ExpressionActionsPtr preprocessor_,
+        DataTypes argument_types_,
+        DataTypePtr result_type_)
+        : tokenizer(std::move(tokenizer_))
+        , preprocessor(std::move(preprocessor_))
+        , argument_types(std::move(argument_types_))
+        , result_type(std::move(result_type_))
+    {
+    }
+
+    String getName() const override { return name; }
+    const DataTypes & getArgumentTypes() const override { return argument_types; }
+    const DataTypePtr & getResultType() const override { return result_type; }
+    bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo &) const override { return true; }
+
+    ExecutableFunctionPtr prepare(const ColumnsWithTypeAndName &) const override
+    {
+        return std::make_unique<ExecutableFunctionTextIndexAnalyzer>(tokenizer, preprocessor);
+    }
+
+private:
+    std::shared_ptr<const ITokenizer> tokenizer;
+    ExpressionActionsPtr preprocessor;
+    DataTypes argument_types;
+    DataTypePtr result_type;
+};
+
+class FunctionTextIndexAnalyzerOverloadResolver : public IFunctionOverloadResolver
+{
+public:
+    static constexpr auto name = "__textIndexAnalyzer";
+
+    String getName() const override { return name; }
+    size_t getNumberOfArguments() const override { return 2; }
+    bool isVariadic() const override { return false; }
+    ColumnNumbers getArgumentsThatAreAlwaysConstant() const override { return {0}; }
+
+    static FunctionOverloadResolverPtr create(ContextPtr) { return std::make_unique<FunctionTextIndexAnalyzerOverloadResolver>(); }
+
+    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
+    {
+        FunctionArgumentDescriptors mandatory_args{
+            {"definition", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isString), isColumnConst, "const String"},
+            {"value", static_cast<FunctionArgumentDescriptor::TypeValidator>(&isStringOrFixedString), nullptr, "String or FixedString"},
+        };
+
+        validateFunctionArguments(name, arguments, mandatory_args);
+        return std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>());
+    }
+
+    FunctionBasePtr buildImpl(const ColumnsWithTypeAndName & arguments, const DataTypePtr & return_type) const override
+    {
+        if (!arguments[0].column)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "First argument of function {} must be a constant string", name);
+
+        String definition_str(arguments[0].column->getDataAt(0));
+        definition_str = substituteInputPlaceholder(definition_str);
+
+        auto options = textIndexParseConfigString(definition_str);
+        auto params = textIndexValidateOptions(options);
+
+        auto tokenizer = TokenizerFactory::instance().get(params.tokenizer);
+        auto preprocessor_actions = buildPreprocessorActions(params.preprocessor);
+
+        DataTypes argument_types;
+        argument_types.reserve(arguments.size());
+        for (const auto & arg : arguments)
+            argument_types.push_back(arg.type);
+
+        return std::make_shared<FunctionBaseTextIndexAnalyzer>(
+            std::move(tokenizer), std::move(preprocessor_actions), std::move(argument_types), return_type);
+    }
+};
+
+}
+
+REGISTER_FUNCTION(TextIndexAnalyzer)
+{
+    factory.registerFunction<FunctionTextIndexAnalyzerOverloadResolver>(FunctionDocumentation::INTERNAL_FUNCTION_DOCS);
+}
+}

--- a/src/Storages/MergeTree/MergeTreeIndexText.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexText.cpp
@@ -1,4 +1,5 @@
 #include <Storages/MergeTree/MergeTreeIndexText.h>
+#include <Storages/MergeTree/MergeTreeTextIndexAnalyzer.h>
 
 #include <Core/Settings.h>
 #include <Columns/ColumnString.h>
@@ -20,9 +21,6 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/ITokenizer.h>
 #include <Interpreters/TokenizerFactory.h>
-#include <Parsers/ASTFunction.h>
-#include <Parsers/ASTIdentifier.h>
-#include <Parsers/ASTLiteral.h>
 #include <Storages/MergeTree/IDataPartStorage.h>
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
 #include <Storages/MergeTree/MergeTreeDataPartChecksum.h>
@@ -36,7 +34,6 @@
 
 #include <base/range.h>
 #include <base/types.h>
-#include <fmt/ranges.h>
 
 namespace ProfileEvents
 {
@@ -73,10 +70,6 @@ static constexpr UInt64 MAX_CARDINALITY_FOR_EMBEDDED_POSTINGS = 6;
 static_assert(MAX_CARDINALITY_FOR_EMBEDDED_POSTINGS <= MAX_CARDINALITY_FOR_RAW_POSTINGS, "MAX_CARDINALITY_FOR_EMBEDDED_POSTINGS must be less or equal to MAX_CARDINALITY_FOR_RAW_POSTINGS");
 static_assert(PostingListBuilder::max_small_size <= MAX_CARDINALITY_FOR_RAW_POSTINGS, "max_small_size must be less than or equal to MAX_CARDINALITY_FOR_RAW_POSTINGS");
 
-static constexpr UInt64 DEFAULT_DICTIONARY_BLOCK_SIZE = 512;
-static constexpr bool DEFAULT_DICTIONARY_BLOCK_USE_FRONTCODING = true;
-static constexpr UInt64 DEFAULT_POSTING_LIST_BLOCK_SIZE = 1024 * 1024;
-static constexpr String DEFAULT_POSTING_LIST_CODEC = "none";
 
 bool DictionaryBlockBase::empty() const
 {
@@ -1606,148 +1599,24 @@ DataTypePtr MergeTreeIndexText::getNestedDataType(const DataTypePtr & data_type)
     return nested_type;
 }
 
-static const String ARGUMENT_TOKENIZER = "tokenizer";
-static const String ARGUMENT_PREPROCESSOR = "preprocessor";
-static const String ARGUMENT_DICTIONARY_BLOCK_SIZE = "dictionary_block_size";
-static const String ARGUMENT_DICTIONARY_BLOCK_FRONTCODING_COMPRESSION = "dictionary_block_frontcoding_compression";
-static const String ARGUMENT_POSTING_LIST_BLOCK_SIZE = "posting_list_block_size";
-static const String ARGUMENT_POSTING_LIST_CODEC = "posting_list_codec";
-
-namespace
-{
-
-template <typename Type>
-Type castAs(const Field & field, std::string_view argument_name)
-{
-    auto expected_type = Field::TypeToEnum<Type>::value;
-    if (expected_type != field.getType())
-    {
-        throw Exception(
-            ErrorCodes::BAD_ARGUMENTS,
-            "Text index argument '{}' expected to be {}, but got {}",
-            argument_name, fieldTypeToString(Field::TypeToEnum<Type>::value), field.getTypeName());
-    }
-    return field.safeGet<Type>();
-}
-
-template <typename Type>
-std::optional<Type> extractFieldOption(std::unordered_map<String, ASTPtr> & options, const String & option)
-{
-    auto it = options.find(option);
-    if (it == options.end())
-        return {};
-
-    Field value = getFieldFromIndexArgumentAST(it->second);
-    value = castAs<Type>(value, option);
-
-    options.erase(it);
-    return value.safeGet<Type>();
-}
-
-ASTPtr extractASTOption(std::unordered_map<String, ASTPtr> & options, const String & option, bool is_required)
-{
-    auto it = options.find(option);
-
-    if (it != options.end())
-    {
-        ASTPtr ast = it->second;
-        options.erase(it);
-        return ast;
-    }
-
-    if (is_required)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Text index argument '{}' is required", option);
-
-    return nullptr;
-}
-
-std::pair<String, ASTPtr> parseNamedArgument(const ASTFunction * ast_equal_function)
-{
-    if (!ast_equal_function
-        || ast_equal_function->name != "equals"
-        || ast_equal_function->arguments->children.size() != 2)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot mix key-value pair and single argument as text index arguments");
-
-    const auto & arguments = ast_equal_function->arguments;
-    const auto * key_identifier = arguments->children[0]->as<ASTIdentifier>();
-
-    if (!key_identifier)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Text index argument must be a key-value pair. got {}", ast_equal_function->formatForErrorMessage());
-
-    return {key_identifier->name(), arguments->children[1]};
-}
-
-std::unordered_map<String, ASTPtr> convertArgumentsToOptionsMap(const ASTPtr & arguments)
-{
-    std::unordered_map<String, ASTPtr> options;
-    if (!arguments)
-        return options;
-
-    for (const auto & child : arguments->children)
-    {
-        const auto * ast_equal_function = child->as<ASTFunction>();
-        auto [key, ast] = parseNamedArgument(ast_equal_function);
-
-        if (!options.emplace(key, ast).second)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Text index '{}' argument is specified more than once", key);
-    }
-    return options;
-}
-
-}
-
 MergeTreeIndexPtr textIndexCreator(const IndexDescription & index)
 {
-    auto options = convertArgumentsToOptionsMap(index.arguments);
+    auto options = textIndexConvertArgumentsToOptionsMap(index.arguments);
+    auto params = textIndexValidateOptions(options);
 
-    auto tokenizer_ast = extractASTOption(options, ARGUMENT_TOKENIZER, true);
-    auto preprocessor_ast = extractASTOption(options, ARGUMENT_PREPROCESSOR, false);
-    auto tokenizer = TokenizerFactory::instance().get(tokenizer_ast);
+    auto tokenizer = TokenizerFactory::instance().get(params.tokenizer);
+    auto posting_list_codec = PostingListCodecFactory::createPostingListCodec(params.posting_list_codec, index.name);
 
-    UInt64 dictionary_block_size = extractFieldOption<UInt64>(options, ARGUMENT_DICTIONARY_BLOCK_SIZE).value_or(DEFAULT_DICTIONARY_BLOCK_SIZE);
-    UInt64 dictionary_block_frontcoding_compression = extractFieldOption<UInt64>(options, ARGUMENT_DICTIONARY_BLOCK_FRONTCODING_COMPRESSION).value_or(DEFAULT_DICTIONARY_BLOCK_USE_FRONTCODING);
-    UInt64 posting_list_block_size = extractFieldOption<UInt64>(options, ARGUMENT_POSTING_LIST_BLOCK_SIZE).value_or(DEFAULT_POSTING_LIST_BLOCK_SIZE);
-
-    MergeTreeIndexTextParams index_params{
-        dictionary_block_size,
-        dictionary_block_frontcoding_compression,
-        posting_list_block_size,
-        std::move(preprocessor_ast)};
-
-    String posting_list_codec_name = extractFieldOption<String>(options, ARGUMENT_POSTING_LIST_CODEC).value_or(DEFAULT_POSTING_LIST_CODEC);
-    auto posting_list_codec = PostingListCodecFactory::createPostingListCodec(posting_list_codec_name, index.name);
-
-    if (!options.empty())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected text index arguments: {}", fmt::join(std::views::keys(options), ", "));
-
-    return std::make_shared<MergeTreeIndexText>(index, index_params, std::move(tokenizer), std::move(posting_list_codec));
+    return std::make_shared<MergeTreeIndexText>(index, std::move(params), std::move(tokenizer), std::move(posting_list_codec));
 }
 
 void textIndexValidator(const IndexDescription & index, bool /*attach*/)
 {
-    auto options = convertArgumentsToOptionsMap(index.arguments);
+    auto options = textIndexConvertArgumentsToOptionsMap(index.arguments);
+    auto params = textIndexValidateOptions(options);
 
-    auto tokenizer_ast = extractASTOption(options, ARGUMENT_TOKENIZER, true);
-    auto preprocessor_ast = extractASTOption(options, ARGUMENT_PREPROCESSOR, false);
-    TokenizerFactory::instance().get(tokenizer_ast);
-
-    UInt64 dictionary_block_size = extractFieldOption<UInt64>(options, ARGUMENT_DICTIONARY_BLOCK_SIZE).value_or(DEFAULT_DICTIONARY_BLOCK_SIZE);
-    if (dictionary_block_size == 0)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Text index argument '{}' must be greater than 0, but got {}", ARGUMENT_DICTIONARY_BLOCK_SIZE, dictionary_block_size);
-
-    UInt64 dictionary_block_use_fc_compression = extractFieldOption<UInt64>(options, ARGUMENT_DICTIONARY_BLOCK_FRONTCODING_COMPRESSION).value_or(DEFAULT_DICTIONARY_BLOCK_USE_FRONTCODING);
-    if (dictionary_block_use_fc_compression > 1)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Text index argument '{}' must be 0 or 1, but got {}", ARGUMENT_DICTIONARY_BLOCK_FRONTCODING_COMPRESSION, dictionary_block_use_fc_compression);
-
-    UInt64 posting_list_block_size = extractFieldOption<UInt64>(options, ARGUMENT_POSTING_LIST_BLOCK_SIZE).value_or(DEFAULT_POSTING_LIST_BLOCK_SIZE);
-    if (posting_list_block_size == 0)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Text index argument '{}' must be greater than 0, but got {}", ARGUMENT_POSTING_LIST_BLOCK_SIZE, posting_list_block_size);
-
-    String posting_list_codec_name = extractFieldOption<String>(options, ARGUMENT_POSTING_LIST_CODEC).value_or(DEFAULT_POSTING_LIST_CODEC);
-    PostingListCodecFactory::createPostingListCodec(posting_list_codec_name, index.name);
-
-    if (!options.empty())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected text index arguments: {}", fmt::join(std::views::keys(options), ", "));
+    TokenizerFactory::instance().get(params.tokenizer);
+    PostingListCodecFactory::createPostingListCodec(params.posting_list_codec, index.name);
 
     /// Check that the index is created on a single column
     if (index.column_names.size() != 1 || index.data_types.size() != 1)
@@ -1768,7 +1637,7 @@ void textIndexValidator(const IndexDescription & index, bool /*attach*/)
     /// For very strict validation of the expression we fully parse it here.
     /// However it will be parsed again for index construction, generally immediately after this call.
     /// This is a bit redundant but that doesn't impact performance anyhow because the expression is intended to be simple enough.
-    MergeTreeIndexTextPreprocessor preprocessor(preprocessor_ast, index);
+    MergeTreeIndexTextPreprocessor preprocessor(params.preprocessor, index);
 }
 
 }

--- a/src/Storages/MergeTree/MergeTreeIndexText.h
+++ b/src/Storages/MergeTree/MergeTreeIndexText.h
@@ -2,6 +2,7 @@
 
 #include <Storages/MergeTree/MergeTreeIndices.h>
 #include <Storages/MergeTree/MergeTreeIndexConditionText.h>
+#include <Storages/MergeTree/MergeTreeTextIndexAnalyzer.h>
 #include <Columns/IColumn.h>
 #include <Common/Logger.h>
 #include <Common/HashTable/HashMap.h>
@@ -72,14 +73,6 @@ namespace DB
 
 class IPostingListCodec;
 using PostingListCodecPtr = const IPostingListCodec *;
-
-struct MergeTreeIndexTextParams
-{
-    size_t dictionary_block_size = 0;
-    size_t dictionary_block_frontcoding_compression = 1;
-    size_t posting_list_block_size = 1024 * 1024;
-    ASTPtr preprocessor;
-};
 
 using PostingList = roaring::Roaring;
 using PostingListPtr = std::shared_ptr<PostingList>;

--- a/src/Storages/MergeTree/MergeTreeTextIndexAnalyzer.cpp
+++ b/src/Storages/MergeTree/MergeTreeTextIndexAnalyzer.cpp
@@ -1,0 +1,161 @@
+#include <Storages/MergeTree/MergeTreeTextIndexAnalyzer.h>
+
+#include <Common/Exception.h>
+#include <Core/Field.h>
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ExpressionListParsers.h>
+#include <Parsers/parseQuery.h>
+#include <Storages/IndicesDescription.h>
+
+#include <fmt/ranges.h>
+#include <ranges>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+}
+
+namespace
+{
+
+const String ARGUMENT_TOKENIZER = "tokenizer";
+const String ARGUMENT_PREPROCESSOR = "preprocessor";
+const String ARGUMENT_DICTIONARY_BLOCK_SIZE = "dictionary_block_size";
+const String ARGUMENT_DICTIONARY_BLOCK_FRONTCODING_COMPRESSION = "dictionary_block_frontcoding_compression";
+const String ARGUMENT_POSTING_LIST_BLOCK_SIZE = "posting_list_block_size";
+const String ARGUMENT_POSTING_LIST_CODEC = "posting_list_codec";
+
+constexpr UInt64 DEFAULT_DICTIONARY_BLOCK_SIZE = 512;
+constexpr UInt64 DEFAULT_DICTIONARY_BLOCK_USE_FRONTCODING = 1;
+constexpr UInt64 DEFAULT_POSTING_LIST_BLOCK_SIZE = 1024 * 1024;
+const String DEFAULT_POSTING_LIST_CODEC = "none";
+
+template <typename Type>
+Type castAs(const Field & field, std::string_view argument_name)
+{
+    auto expected_type = Field::TypeToEnum<Type>::value;
+    if (expected_type != field.getType())
+    {
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS,
+            "Text index argument '{}' expected to be {}, but got {}",
+            argument_name, fieldTypeToString(Field::TypeToEnum<Type>::value), field.getTypeName());
+    }
+    return field.safeGet<Type>();
+}
+
+template <typename Type>
+std::optional<Type> extractFieldOption(std::unordered_map<String, ASTPtr> & options, const String & option)
+{
+    auto it = options.find(option);
+    if (it == options.end())
+        return {};
+
+    Field value = getFieldFromIndexArgumentAST(it->second);
+    value = castAs<Type>(value, option);
+
+    options.erase(it);
+    return value.safeGet<Type>();
+}
+
+ASTPtr extractASTOption(std::unordered_map<String, ASTPtr> & options, const String & option, bool is_required)
+{
+    auto it = options.find(option);
+
+    if (it != options.end())
+    {
+        ASTPtr ast = it->second;
+        options.erase(it);
+        return ast;
+    }
+
+    if (is_required)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Text index argument '{}' is required", option);
+
+    return nullptr;
+}
+
+std::pair<String, ASTPtr> parseNamedArgument(const ASTFunction * ast_equal_function)
+{
+    if (!ast_equal_function
+        || ast_equal_function->name != "equals"
+        || ast_equal_function->arguments->children.size() != 2)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot mix key-value pair and single argument as text index arguments");
+
+    const auto & arguments = ast_equal_function->arguments;
+    const auto * key_identifier = arguments->children[0]->as<ASTIdentifier>();
+
+    if (!key_identifier)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Text index argument must be a key-value pair. got {}", ast_equal_function->formatForErrorMessage());
+
+    return {key_identifier->name(), arguments->children[1]};
+}
+
+}
+
+std::unordered_map<String, ASTPtr> textIndexConvertArgumentsToOptionsMap(const ASTPtr & arguments)
+{
+    std::unordered_map<String, ASTPtr> options;
+    if (!arguments)
+        return options;
+
+    for (const auto & child : arguments->children)
+    {
+        const auto * ast_equal_function = child->as<ASTFunction>();
+        auto [key, ast] = parseNamedArgument(ast_equal_function);
+
+        if (!options.emplace(key, ast).second)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Text index '{}' argument is specified more than once", key);
+    }
+    return options;
+}
+
+std::unordered_map<String, ASTPtr> textIndexParseConfigString(const String & config)
+{
+    ParserExpressionList parser(false);
+    ASTPtr ast = parseQuery(
+        parser,
+        config,
+        "text index config",
+        DBMS_DEFAULT_MAX_QUERY_SIZE,
+        DBMS_DEFAULT_MAX_PARSER_DEPTH,
+        DBMS_DEFAULT_MAX_PARSER_BACKTRACKS);
+
+    return textIndexConvertArgumentsToOptionsMap(ast);
+}
+
+MergeTreeIndexTextParams textIndexValidateOptions(std::unordered_map<String, ASTPtr> & options)
+{
+    MergeTreeIndexTextParams params;
+
+    params.tokenizer = extractASTOption(options, ARGUMENT_TOKENIZER, true);
+    params.preprocessor = extractASTOption(options, ARGUMENT_PREPROCESSOR, false);
+
+    params.dictionary_block_size = extractFieldOption<UInt64>(options, ARGUMENT_DICTIONARY_BLOCK_SIZE).value_or(DEFAULT_DICTIONARY_BLOCK_SIZE);
+    if (params.dictionary_block_size == 0)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Text index argument '{}' must be greater than 0, but got {}",
+            ARGUMENT_DICTIONARY_BLOCK_SIZE, params.dictionary_block_size);
+
+    params.dictionary_block_frontcoding_compression = extractFieldOption<UInt64>(options, ARGUMENT_DICTIONARY_BLOCK_FRONTCODING_COMPRESSION).value_or(DEFAULT_DICTIONARY_BLOCK_USE_FRONTCODING);
+    if (params.dictionary_block_frontcoding_compression > 1)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Text index argument '{}' must be 0 or 1, but got {}",
+            ARGUMENT_DICTIONARY_BLOCK_FRONTCODING_COMPRESSION, params.dictionary_block_frontcoding_compression);
+
+    params.posting_list_block_size = extractFieldOption<UInt64>(options, ARGUMENT_POSTING_LIST_BLOCK_SIZE).value_or(DEFAULT_POSTING_LIST_BLOCK_SIZE);
+    if (params.posting_list_block_size == 0)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Text index argument '{}' must be greater than 0, but got {}",
+            ARGUMENT_POSTING_LIST_BLOCK_SIZE, params.posting_list_block_size);
+
+    params.posting_list_codec = extractFieldOption<String>(options, ARGUMENT_POSTING_LIST_CODEC).value_or(DEFAULT_POSTING_LIST_CODEC);
+
+    if (!options.empty())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected text index arguments: {}", fmt::join(std::views::keys(options), ", "));
+
+    return params;
+}
+
+}

--- a/src/Storages/MergeTree/MergeTreeTextIndexAnalyzer.h
+++ b/src/Storages/MergeTree/MergeTreeTextIndexAnalyzer.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <Parsers/IAST_fwd.h>
+#include <base/types.h>
+
+#include <unordered_map>
+
+namespace DB
+{
+
+struct MergeTreeIndexTextParams
+{
+    size_t dictionary_block_size = 0;
+    size_t dictionary_block_frontcoding_compression = 1;
+    size_t posting_list_block_size = 1024 * 1024;
+    ASTPtr tokenizer;
+    ASTPtr preprocessor;
+    String posting_list_codec;
+};
+
+std::unordered_map<String, ASTPtr> textIndexConvertArgumentsToOptionsMap(const ASTPtr & arguments);
+
+/// Parses a text index config string like "tokenizer = splitByNonAlpha, preprocessor = lower(column)"
+/// into the same options map used by the text index.
+std::unordered_map<String, ASTPtr> textIndexParseConfigString(const String & config);
+
+/// Validates and extracts all config-level options from the options map.
+/// Consumes recognized options from the map. Throws on unknown options.
+MergeTreeIndexTextParams textIndexValidateOptions(std::unordered_map<String, ASTPtr> & options);
+
+}

--- a/tests/queries/0_stateless/02346_text_index_analyzer.reference
+++ b/tests/queries/0_stateless/02346_text_index_analyzer.reference
@@ -1,0 +1,38 @@
+Negative tests
+splitByNonAlpha tokenizer
+[]
+['abc','def','foo','bar']
+['xäöüx','code','hello','world']
+ngrams tokenizer
+[]
+['abc','bc ','c d',' de','def']
+['abcde','bcdef']
+splitByString tokenizer
+['a','bb','ccc']
+['a','bb','ccc']
+asciiCJK tokenizer
+['hello','world']
+['你','好','世','界']
+['hello_world']
+array tokenizer
+[]
+['abc def']
+With preprocessor
+['hello','world','abc']
+['HELLO','WORLD']
+Ignores extra text index params
+['hello','world']
+FixedString input
+['abc','def']
+Non-const input
+['abc','def']
+NULL input
+\N
+\N
+Column values
+['abc','DEF']
+['heLlO','World']
+['xäöüx','code']
+['abc','def']
+['hello','world']
+['xäöüx','code']

--- a/tests/queries/0_stateless/02346_text_index_analyzer.sql
+++ b/tests/queries/0_stateless/02346_text_index_analyzer.sql
@@ -1,0 +1,80 @@
+-- Tests the __textIndexAnalyzer function.
+
+SELECT 'Negative tests';
+
+-- Must accept exactly two arguments
+SELECT __textIndexAnalyzer(); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT __textIndexAnalyzer('tokenizer = splitByNonAlpha'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT __textIndexAnalyzer('tokenizer = splitByNonAlpha', 'a', 'b'); -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+-- 1st arg must be const String
+SELECT __textIndexAnalyzer(1, 'a'); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT __textIndexAnalyzer(materialize('tokenizer = splitByNonAlpha'), 'a'); -- { serverError ILLEGAL_COLUMN }
+-- 2nd arg must be String or FixedString
+SELECT __textIndexAnalyzer('tokenizer = splitByNonAlpha', 1); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+-- tokenizer is required
+SELECT __textIndexAnalyzer('dictionary_block_size = 512', 'a'); -- { serverError BAD_ARGUMENTS }
+-- unsupported tokenizer
+SELECT __textIndexAnalyzer('tokenizer = unsupported', 'a'); -- { serverError BAD_ARGUMENTS }
+-- invalid syntax in definition
+SELECT __textIndexAnalyzer('tokenizer = splitByString(,)', 'a'); -- { serverError SYNTAX_ERROR }
+SELECT __textIndexAnalyzer('tokenizer = ngrams(-1)', 'a'); -- { serverError BAD_ARGUMENTS }
+
+SELECT 'splitByNonAlpha tokenizer';
+
+SELECT __textIndexAnalyzer('tokenizer = splitByNonAlpha', '');
+SELECT __textIndexAnalyzer('tokenizer = splitByNonAlpha', 'abc+ def- foo! bar?');
+SELECT __textIndexAnalyzer('tokenizer = splitByNonAlpha', 'xäöüx code; hello: world/');
+
+SELECT 'ngrams tokenizer';
+
+SELECT __textIndexAnalyzer('tokenizer = ngrams(3)', '');
+SELECT __textIndexAnalyzer('tokenizer = ngrams(3)', 'abc def');
+SELECT __textIndexAnalyzer('tokenizer = ngrams(5)', 'abcdef');
+
+SELECT 'splitByString tokenizer';
+
+SELECT __textIndexAnalyzer('tokenizer = splitByString([\',\'])', 'a,bb,ccc');
+SELECT __textIndexAnalyzer('tokenizer = splitByString([\'::\'])', 'a::bb::ccc');
+
+SELECT 'asciiCJK tokenizer';
+
+SELECT __textIndexAnalyzer('tokenizer = asciiCJK', 'hello world');
+SELECT __textIndexAnalyzer('tokenizer = asciiCJK', '你好世界');
+SELECT __textIndexAnalyzer('tokenizer = asciiCJK', 'hello_world');
+
+SELECT 'array tokenizer';
+
+SELECT __textIndexAnalyzer('tokenizer = array', '');
+SELECT __textIndexAnalyzer('tokenizer = array', 'abc def');
+
+SELECT 'With preprocessor';
+
+SELECT __textIndexAnalyzer('tokenizer = splitByNonAlpha, preprocessor = lower({input})', 'Hello World ABC');
+SELECT __textIndexAnalyzer('tokenizer = splitByNonAlpha, preprocessor = upper({input})', 'Hello World');
+
+SELECT 'Ignores extra text index params';
+
+SELECT __textIndexAnalyzer('tokenizer = splitByNonAlpha, dictionary_block_size = 8, posting_list_block_size = 1024', 'hello world');
+
+SELECT 'FixedString input';
+SELECT __textIndexAnalyzer('tokenizer = splitByNonAlpha', toFixedString('abc def', 7));
+
+SELECT 'Non-const input';
+
+SELECT __textIndexAnalyzer('tokenizer = splitByNonAlpha', materialize('abc def'));
+
+SELECT 'NULL input';
+
+SELECT __textIndexAnalyzer('tokenizer = splitByNonAlpha', NULL);
+SELECT __textIndexAnalyzer('tokenizer = splitByNonAlpha', materialize(NULL));
+
+SELECT 'Column values';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab (id UInt64, s String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO tab VALUES (1, 'abc+ DEF-'), (2, 'heLlO: World/'), (3, 'xäöüx code;');
+
+SELECT __textIndexAnalyzer('tokenizer = splitByNonAlpha', s) FROM tab ORDER BY id;
+SELECT __textIndexAnalyzer('tokenizer = splitByNonAlpha, preprocessor = lower({input})', s) FROM tab ORDER BY id;
+
+DROP TABLE tab;


### PR DESCRIPTION
Extract text index analysis (tokenizer, preprocessor, dictionary and posting list parameters) from `MergeTreeIndexText` into a shared `MergeTreeTextIndexAnalyzer` module.

Add a new internal `textIndexAnalyzer` SQL function that accepts the text index definition string and tokenizes input using the same tokenizer and preprocessor. The function reuses the extracted analysis and supports the `{input}` placeholder in preprocessor expressions.

Motivation for this PR:
While working on #103172, I noticed that positional information for the hackernews dataset is huge on disk comparing to other systems. During debugging, I found some tokens occurs a lot in the dataset, even on the same row. Some of those tokens are either very short (1-2 characters) or commonly used prepositions in English. To avoid such tokens I opened these two PRs: #103715 and #103716 to filter out such tokens. These changes looks simple, however functions like `hasAnyTokens`, `hasAllTokens` and `hasPhrase` use the same filtering and tokenization from the text index definition. Forwarding filtering options to those functions is not straightforward, and it might requires some changes. To avoid for today and future, I decided to extract out text index analysis (filtering and tokenization) to a dedicated class and re-use it in those functions. All functions accept a 3rd `tokenizer` argument, instead of forwarding filtering params as 4th, 5th, 6th, ... arguments, we can forward them in a single argument as defined in the text index e.g. `tokenizer = splitByNonAlpha, preprocessor = lower(...)`.

### Changelog category (leave one):

- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Move out text index analysis into a dedicated common place.
