### PR TITLE
Mark *_connections_{rcv,snd}buf server settings as changeable without restart

### DIFF
--- a/src/Common/HTTPConnectionPool.cpp
+++ b/src/Common/HTTPConnectionPool.cpp
@@ -1016,6 +1016,21 @@ public:
         http_group->setSocketBufferSizes(std::move(http));
     }
 
+    HTTPConnectionPools::SocketBufferSizes getSocketBufferSizes(HTTPConnectionGroupType type) const
+    {
+        /// ConnectionGroup has its own mutex, no need for Impl::mutex here.
+        /// The groups are created once in the constructor and never replaced.
+        switch (type)
+        {
+            case HTTPConnectionGroupType::DISK:
+                return disk_group->getSocketBufferSizes();
+            case HTTPConnectionGroupType::STORAGE:
+                return storage_group->getSocketBufferSizes();
+            case HTTPConnectionGroupType::HTTP:
+                return http_group->getSocketBufferSizes();
+        }
+    }
+
     void dropCache()
     {
         std::lock_guard lock(mutex);
@@ -1124,6 +1139,11 @@ void HTTPConnectionPools::setLimits(HTTPConnectionPools::Limits disk, HTTPConnec
 void HTTPConnectionPools::setSocketBufferSizes(HTTPConnectionPools::SocketBufferSizes disk, HTTPConnectionPools::SocketBufferSizes storage, HTTPConnectionPools::SocketBufferSizes http)
 {
     impl->setSocketBufferSizes(std::move(disk), std::move(storage), std::move(http));
+}
+
+HTTPConnectionPools::SocketBufferSizes HTTPConnectionPools::getSocketBufferSizes(HTTPConnectionGroupType type) const
+{
+    return impl->getSocketBufferSizes(type);
 }
 
 void HTTPConnectionPools::dropCache()

--- a/src/Common/HTTPConnectionPool.h
+++ b/src/Common/HTTPConnectionPool.h
@@ -101,6 +101,7 @@ public:
 
     void setLimits(Limits disk, Limits storage, Limits http);
     void setSocketBufferSizes(SocketBufferSizes disk, SocketBufferSizes storage, SocketBufferSizes http);
+    SocketBufferSizes getSocketBufferSizes(HTTPConnectionGroupType type) const;
     void dropCache();
 
     IHTTPConnectionPoolForEndpoint::Ptr getPool(HTTPConnectionGroupType type, const Poco::URI & uri, const ProxyConfiguration & proxy_configuration);

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -26,6 +26,7 @@
 #include <Storages/System/ServerSettingColumnsParams.h>
 #include <base/types.h>
 #include <Common/Config/ConfigReloader.h>
+#include <Common/HTTPConnectionPool.h>
 #include <Common/MemoryTracker.h>
 
 #include <Common/DNSResolver.h>
@@ -1854,6 +1855,19 @@ void ServerSettings::dumpToSystemServerSettingsColumns(ServerSettingColumnsParam
 
             {"dns_allow_resolve_names_to_ipv4", {std::to_string(DNSResolver::instance().getFilterIPv4()), ChangeableWithoutRestart::Yes}},
             {"dns_allow_resolve_names_to_ipv6", {std::to_string(DNSResolver::instance().getFilterIPv6()), ChangeableWithoutRestart::Yes}},
+
+            {"disk_connections_rcvbuf",
+             {std::to_string(HTTPConnectionPools::instance().getSocketBufferSizes(HTTPConnectionGroupType::DISK).rcvbuf), ChangeableWithoutRestart::Yes}},
+            {"disk_connections_sndbuf",
+             {std::to_string(HTTPConnectionPools::instance().getSocketBufferSizes(HTTPConnectionGroupType::DISK).sndbuf), ChangeableWithoutRestart::Yes}},
+            {"storage_connections_rcvbuf",
+             {std::to_string(HTTPConnectionPools::instance().getSocketBufferSizes(HTTPConnectionGroupType::STORAGE).rcvbuf), ChangeableWithoutRestart::Yes}},
+            {"storage_connections_sndbuf",
+             {std::to_string(HTTPConnectionPools::instance().getSocketBufferSizes(HTTPConnectionGroupType::STORAGE).sndbuf), ChangeableWithoutRestart::Yes}},
+            {"http_connections_rcvbuf",
+             {std::to_string(HTTPConnectionPools::instance().getSocketBufferSizes(HTTPConnectionGroupType::HTTP).rcvbuf), ChangeableWithoutRestart::Yes}},
+            {"http_connections_sndbuf",
+             {std::to_string(HTTPConnectionPools::instance().getSocketBufferSizes(HTTPConnectionGroupType::HTTP).sndbuf), ChangeableWithoutRestart::Yes}},
     };
 
     if (context->areBackgroundExecutorsInitialized())

--- a/tests/integration/test_http_connection_socket_buffer_settings/test.py
+++ b/tests/integration/test_http_connection_socket_buffer_settings/test.py
@@ -38,14 +38,16 @@ def remove_config(config_name):
 
 
 def assert_settings(settings_dict):
-    """Check that server_settings match expected values."""
+    """Check that server_settings match expected values and are marked changeable without restart."""
     names = ", ".join(f"'{name}'" for name in settings_dict)
     result = node.query(
-        f"SELECT name, value FROM system.server_settings "
+        f"SELECT name, value, changeable_without_restart FROM system.server_settings "
         f"WHERE name IN ({names}) ORDER BY name"
     )
     for name, value in settings_dict.items():
-        assert f"{name}\t{value}" in result, f"Expected {name}={value}, got: {result}"
+        assert f"{name}\t{value}\tYes" in result, (
+            f"Expected {name}={value} with changeable_without_restart=Yes, got: {result}"
+        )
 
 
 def reload_with_invalid_config_and_check_log(config_name, group_name):


### PR DESCRIPTION
The six socket buffer size settings introduced in #100478 — `{disk,storage,http}_connections_{rcvbuf,sndbuf}` — are already re-applied to `HTTPConnectionPools` from the main config-reload callback in `Server.cpp`, so they functionally take effect on `SYSTEM RELOAD CONFIG`.

This PR surfaces that in `system.server_settings`: the `changeable_without_restart` column now reports `Yes` for these settings and `value` reflects the currently effective per-pool state.

A public `getSocketBufferSizes(type)` accessor is added on `HTTPConnectionPools` so the system table can read the live value, matching the convention already used for limits, throttlers, and thread-pool size settings.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The server settings `{disk,storage,http}_connections_{rcvbuf,sndbuf}` are now reported as changeable without restart in `system.server_settings`. Their values can be updated via `SYSTEM RELOAD CONFIG`; the runtime application path was already in place since #100478.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.390`
<!-- ch-version-info:end -->