### PR TITLE
Relax brittle 'receive timeout' assertion in test_distributed_frozen_replica

### DIFF
--- a/tests/integration/test_distributed_frozen_replica/test.py
+++ b/tests/integration/test_distributed_frozen_replica/test.py
@@ -106,7 +106,15 @@ def test_cluster_all_replicas_query(
         except QueryRuntimeException as e:
             error = str(e)
     assert "ALL_CONNECTION_TRIES_FAILED" in error
-    assert "receive timeout 857 ms" in error
+    # The configured handshake_timeout_ms=857 may surface through the async
+    # `HedgedConnections` / `AsyncTaskExecutor` path (which formats as
+    # "(..., receive timeout {} ms)") OR through the synchronous
+    # `ReadBufferFromPocoSocket` path (which formats as
+    # "(peer: ..., local: ..., {} ms)" without the "receive timeout" prefix).
+    # Both formats include the timeout value in milliseconds, so check for
+    # "857 ms" alone — this verifies the configured timeout was applied
+    # without locking the test to one specific socket-error code path.
+    assert "857 ms" in error
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The integration test `test_distributed_frozen_replica/test.py::test_cluster_all_replicas_query` fails intermittently because it asserts the literal substring `"receive timeout 857 ms"` (the configured `handshake_timeout_ms`) appears in the failure message — but only one of three socket-timeout code paths produces that exact phrasing.

### Root cause

Three places in the codebase format socket-read-timeout errors:

| Path | Format string | Contains "receive timeout"? |
|---|---|---|
| `src/Common/AsyncTaskExecutor.cpp:124` (async I/O fiber) | `({}, receive timeout {} ms)` | Yes |
| `src/Client/HedgedConnections.cpp:449` (hedged-connection failover) | `({}, receive timeout {} ms)` | Yes |
| `src/IO/ReadBufferFromPocoSocket.cpp:88` (synchronous Poco read) | `(peer: {}, local: {}, {} ms)` | No |
| `src/Server/ProxyV1Handler.cpp:124` (Proxy v1 wire handler) | `({}, {} ms)` | No |

All four formats include the timeout value formatted as `{} ms`. When the 857-ms handshake fires through the synchronous `ReadBufferFromPocoSocket` path (more likely on slow sanitizer builds — observed mostly on `Integration tests (amd_msan, 1/6)`, `(amd_tsan, 1/6)`, and `(amd_asan_ubsan, db disk, old analyzer, 1/6)`), the assertion fails because the error contains `857 ms` but not `receive timeout 857 ms`.

Example failing CIDB log (`pull_request_number=100399`, `Integration tests (amd_msan, 1/6)`):

```
DB::Exception: All connection tries failed. Log:

Timeout exceeded while reading from socket (socket ([2001:3984:3989::11]:9000), receive timeout 5000 ms)
Code: 209. DB::NetException: Timeout exceeded while reading from socket
  (peer: [2001:3984:3989::11]:9000, local: [2001:3984:3989::13]:35828, 857 ms): ...
```

The only `receive timeout` phrase here is for the unrelated default-5000ms socket-receive timer. The 857-ms handshake-timeout cancellation surfaces through the sync path and prints `857 ms` without the prefix.

### Fix

Relax the assertion from `"receive timeout 857 ms"` to `"857 ms"`. The test still verifies the configured `handshake_timeout_ms=857` actually took effect (the value appears in the error), but no longer locks the assertion to one specific socket-error code path. The companion assertion `"ALL_CONNECTION_TRIES_FAILED" in error` already verifies the high-level failure mode.

### Failure history

Over the last 30 days, ~10 failures across 9 distinct unrelated PRs in the assertion-mismatch mode (this PR's target). Concentrated on slow sanitizer + old-analyzer integration runners.

CI report data: https://play.clickhouse.com/

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.201` (included in `26.5` and later)
- Backported to: `26.3.33.59`
<!-- ch-version-info:end -->