### PR TITLE
Increase value-profiling counter density in PGO toolchain stage1 build

### DIFF
--- a/ci/jobs/build_toolchain.py
+++ b/ci/jobs/build_toolchain.py
@@ -202,6 +202,8 @@ def main():
             f" -DLLVM_ENABLE_TERMINFO=OFF"
             f" -DLLVM_ENABLE_ZLIB=OFF"
             f" -DLLVM_ENABLE_ZSTD=OFF"
+            f' -DCMAKE_C_FLAGS="-mllvm -vp-counters-per-site=8"'
+            f' -DCMAKE_CXX_FLAGS="-mllvm -vp-counters-per-site=8"'
             f" -DCMAKE_INSTALL_PREFIX={STAGE1_INSTALL_DIR}"
             f" -S {LLVM_SOURCE_DIR}/llvm"
             f" -B {STAGE1_BUILD_DIR}"


### PR DESCRIPTION
Pass `-mllvm -vp-counters-per-site=8` via `CMAKE_C_FLAGS`/`CMAKE_CXX_FLAGS` during the instrumented stage1 LLVM build. The default of 1 counter per site often loses indirect-call and `memcpy`-size distribution data; 8 buckets gives LLVM enough resolution to devirtualise and inline hot call targets in the final stage2 toolchain.

### Changelog category (leave one):
- CI Fix or Improvement

Note, this also removes tons of LLVM warnings

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.202`
<!-- ch-version-info:end -->