### PR TITLE
Add regression test for #65630 — WHERE on UNION ALL without GROUP BY

### DIFF
--- a/tests/queries/0_stateless/04144_filter_union_all_no_group_by.reference
+++ b/tests/queries/0_stateless/04144_filter_union_all_no_group_by.reference
@@ -1,0 +1,6 @@
+number1	5
+--- with LIMIT (pushdown blocker) ---
+number1	5
+--- filter on aggregate value ---
+number3	3
+--- no match returns empty ---

--- a/tests/queries/0_stateless/04144_filter_union_all_no_group_by.sql
+++ b/tests/queries/0_stateless/04144_filter_union_all_no_group_by.sql
@@ -1,0 +1,70 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/65630
+--
+-- A WHERE filter applied on top of a UNION ALL whose branches have a constant
+-- column alias and no explicit GROUP BY used to return one row per non-matching
+-- branch with the aggregate evaluated over an empty set (count = 0). The cause
+-- was the planner pushing the WHERE predicate down into each UNION ALL branch:
+-- inside a branch the predicate evaluates against the branch's constant alias
+-- and becomes false, which filters out the source rows; the implicit (no
+-- GROUP BY) aggregation then still emits a single row with count = 0 per
+-- non-matching branch. The expected behaviour is that WHERE is applied on top
+-- of the UNION, so non-matching branches are dropped entirely.
+
+-- Direct outer WHERE on UNION ALL: should return only the matching branch.
+SELECT * FROM
+(
+    SELECT 'number1' AS id, count(number) AS cnt FROM numbers(5)
+    UNION ALL
+    SELECT 'number2', count(number) FROM numbers(4)
+    UNION ALL
+    SELECT 'number3', count(number) FROM numbers(3)
+)
+WHERE id = 'number1';
+
+SELECT '--- with LIMIT (pushdown blocker) ---';
+
+-- Wrapping in a LIMIT was originally suggested as a workaround because LIMIT
+-- blocks predicate pushdown. It must keep producing the same single row.
+SELECT * FROM
+(
+    SELECT * FROM
+    (
+        SELECT 'number1' AS id, count(number) AS cnt FROM numbers(5)
+        UNION ALL
+        SELECT 'number2', count(number) FROM numbers(4)
+        UNION ALL
+        SELECT 'number3', count(number) FROM numbers(3)
+    )
+    LIMIT 100000000
+)
+WHERE id = 'number1';
+
+SELECT '--- filter on aggregate value ---';
+
+-- Filtering by the aggregate column (post-aggregation) was never affected by
+-- the pushdown bug, but is included so that any future change to predicate
+-- pushdown rules cannot silently regress it.
+SELECT * FROM
+(
+    SELECT 'number1' AS id, count(number) AS cnt FROM numbers(5)
+    UNION ALL
+    SELECT 'number2', count(number) FROM numbers(4)
+    UNION ALL
+    SELECT 'number3', count(number) FROM numbers(3)
+)
+WHERE cnt = 3
+ORDER BY id;
+
+SELECT '--- no match returns empty ---';
+
+-- A predicate that excludes every branch must produce an empty result, not a
+-- row of zeroed aggregates per branch.
+SELECT * FROM
+(
+    SELECT 'number1' AS id, count(number) AS cnt FROM numbers(5)
+    UNION ALL
+    SELECT 'number2', count(number) FROM numbers(4)
+    UNION ALL
+    SELECT 'number3', count(number) FROM numbers(3)
+)
+WHERE id = 'nope';


### PR DESCRIPTION
## Summary

Adds a stateless regression test for [#65630](https://github.com/ClickHouse/ClickHouse/issues/65630) — WHERE filter on a UNION ALL subquery without explicit GROUP BY. The bug was reported on 24.3.4.147 and is already fixed on master (and from 24.8.1 onward per [@den-crane's verification](https://fiddle.clickhouse.com/c2941eb5-a2be-4343-8b8b-20fa28c60a69)). This PR locks the correct behaviour in so any future change to predicate-pushdown rules around UNION ALL cannot silently regress it.

## Background

Originally:

```sql
SELECT *
FROM (
    SELECT 'number1' AS id, count(number) AS cnt FROM numbers(5)
    UNION ALL
    SELECT 'number2', count(number) FROM numbers(4)
    UNION ALL
    SELECT 'number3', count(number) FROM numbers(3)
)
WHERE id = 'number1';
```

returned three rows — `number1, 5`, `number2, 0`, `number3, 0` — instead of the single matching row. The cause: the planner pushed the WHERE predicate down into each UNION ALL branch. Inside a non-matching branch the predicate evaluates against the branch's constant column alias and becomes false, which filters out the source rows; the implicit (no GROUP BY) aggregation then still emits a single row with `count = 0` per non-matching branch.

The fix keeps the WHERE on top of the UNION so non-matching branches are dropped entirely.

## Test cases

`tests/queries/0_stateless/04144_filter_union_all_no_group_by.sql` covers:

1. The original report — outer WHERE on UNION ALL → must return only the matching branch.
2. Wrapping in `LIMIT 100000000` (originally suggested as a workaround because LIMIT blocks predicate pushdown) — must still return the same single row.
3. Filtering on the aggregate column (`WHERE cnt = 3`) — never affected by the pushdown bug, but included so any future change cannot silently regress it.
4. A predicate that excludes every branch — must produce an empty result.

Verified locally on master HEAD (`651bde46a3ab`) — passes 30/30 with default randomized settings.

Closes #65630.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.231`
<!-- ch-version-info:end -->