### PR TITLE
Add test: `h3PolygonToCells` `ILLEGAL_COLUMN` argument-type validation paths untested

### DIFF
--- a/tests/queries/0_stateless/04145_h3_polygon_to_cells_invalid_type.sql
+++ b/tests/queries/0_stateless/04145_h3_polygon_to_cells_invalid_type.sql
@@ -1,0 +1,18 @@
+-- Tags: no-fasttest
+-- Test: argument-type validation paths in `h3PolygonToCells`.
+-- Covers: src/Functions/h3PolygonToCells.cpp:93-96 — `ILLEGAL_COLUMN` when arg 1 column is not `ColumnArray`.
+-- Covers: src/Functions/h3PolygonToCells.cpp:100-103 — `ILLEGAL_COLUMN` when arg 2 column is not `ColumnUInt8`.
+-- Both error paths are uncovered per LLVM (lines 94-96 and 101-103) and the PR rewrites them.
+
+-- Argument 1 = Point (Tuple, not Array) -> ILLEGAL_COLUMN.
+SELECT h3PolygonToCells((1.0, 2.0)::Point, 7); -- { serverError ILLEGAL_COLUMN }
+
+-- Same via a stored Point column to exercise the non-const branch.
+DROP TABLE IF EXISTS t_point_04145;
+CREATE TABLE t_point_04145 (p Point) ENGINE = Memory;
+INSERT INTO t_point_04145 VALUES ((1.0, 2.0));
+SELECT h3PolygonToCells(p, 7) FROM t_point_04145; -- { serverError ILLEGAL_COLUMN }
+DROP TABLE t_point_04145;
+
+-- Argument 2 = String (not UInt8) -> ILLEGAL_COLUMN. Reaches the second checkAndGetColumn after `convertToFullColumnIfConst`.
+SELECT h3PolygonToCells([(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)], 'abc'); -- { serverError ILLEGAL_COLUMN }


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #101094](https://github.com/ClickHouse/ClickHouse/pull/101094).
 That PR PR refactors `h3PolygonToCells` argument handling: removes the `getArgumentOrConstArgument` helper and replaces it with explicit `isColumnConst` extraction for arg 1 (geometry) and `convertToFullColumnIfConst` + `checkAndGetColumn<ColumnUInt8>` for arg 2 (resolution). Adds two new `ILLEGAL_COLUMN` t

**1. `h3PolygonToCells` `ILLEGAL_COLUMN` argument-type validation paths untested**
  `src/Functions/h3PolygonToCells.cpp:94`, `src/Functions/h3PolygonToCells.cpp:101`
  **Risk:** Call chain: `executeImpl` -> extract `col_array_holder` -> `checkAndGetColumn<ColumnArray>` returns nullptr for `ColumnTuple` (Point input) -> throws `ILLEGAL_COLUMN` at h3PolygonToCells.cpp:94. Indep
  **What's unique vs PR tests:** PR's `03754_h3_polygon_to_cells_const.sql` covers the success path with all four (const,non-const) x (const,non-const) combinations of valid Ring + UInt8 inputs. It contains zero queries with non-Arra
  **Tags:** `-- Tags: no-fasttest` — `no-fasttest`: h3 functions require USE_H3 build flag; existing 03198/03754 h3PolygonToCells tests already use the same tag for the same reason.
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/ace97f2c-66d4-4bfc-a308-39f68a270813)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.227`
<!-- ch-version-info:end -->