### PR TITLE
Add support of resolved symbols (Array(String)) for flameGraph()

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionFlameGraph.cpp
+++ b/src/AggregateFunctions/AggregateFunctionFlameGraph.cpp
@@ -13,6 +13,7 @@
 #include <IO/Operators.h>
 #include <Common/UnorderedMapWithMemoryTracking.h>
 #include <Common/VectorWithMemoryTracking.h>
+#include <Common/typeid_cast.h>
 
 namespace DB
 {
@@ -217,6 +218,7 @@ static void fillColumn(PaddedPODArray<UInt8> & chars, PaddedPODArray<UInt64> & o
 
 static void dumpFlameGraphImpl(
     const AggregateFunctionFlameGraphTree::Traces & traces,
+    const VectorWithMemoryTracking<std::string_view> * id_to_string,
     PaddedPODArray<UInt8> & chars,
     PaddedPODArray<UInt64> & offsets)
 {
@@ -237,6 +239,13 @@ static void dumpFlameGraphImpl(
         {
             if (i)
                 out << ";";
+
+            if (id_to_string)
+            {
+                /// trace.frames[i] is a 1-based id into id_to_string (0 is reserved as a stack terminator).
+                writeString((*id_to_string)[trace.frames[i] - 1], out);
+                continue;
+            }
 
             const void * ptr = reinterpret_cast<const void *>(trace.frames[i]);
 
@@ -276,6 +285,31 @@ struct AggregateFunctionFlameGraphData
     Entries entries;
     Entry * free_list = nullptr;
     AggregateFunctionFlameGraphTree tree;
+
+    /// String interning support for Array(String) traces.
+    /// When a trace is provided as Array(String), each unique symbol is interned to a 1-based id and
+    /// the id (rather than a pointer) is stored in TreeNode::ptr. The id 0 stays reserved as a stack
+    /// terminator inside `tree.find`, and `dumpFlameGraphImpl` looks up the original string from
+    /// `id_to_string` instead of running symbol resolution.
+    bool is_string_mode = false;
+    UnorderedMapWithMemoryTracking<std::string_view, UInt64> string_pool;
+    VectorWithMemoryTracking<std::string_view> id_to_string;
+
+    UInt64 internString(std::string_view s, Arena * arena)
+    {
+        if (auto it = string_pool.find(s); it != string_pool.end())
+            return it->second;
+
+        char * dest = arena->alloc(s.size());
+        if (!s.empty())
+            memcpy(dest, s.data(), s.size());
+        std::string_view stable{dest, s.size()};
+
+        UInt64 id = id_to_string.size() + 1;
+        id_to_string.push_back(stable);
+        string_pool.emplace(stable, id);
+        return id;
+    }
 
     Entry * alloc(Arena * arena)
     {
@@ -396,7 +430,8 @@ struct AggregateFunctionFlameGraphData
         }
     }
 
-    void merge(const AggregateFunctionFlameGraphTree & other_tree, Arena * arena)
+    void merge(const AggregateFunctionFlameGraphTree & other_tree,
+               const VectorWithMemoryTracking<std::string_view> * other_id_to_string, Arena * arena)
     {
         AggregateFunctionFlameGraphTree::Trace::Frames frames;
         VectorWithMemoryTracking<AggregateFunctionFlameGraphTree::ListNode *> nodes;
@@ -419,7 +454,10 @@ struct AggregateFunctionFlameGraphData
             AggregateFunctionFlameGraphTree::TreeNode * current = nodes.back()->child;
             nodes.back() = nodes.back()->next;
 
-            frames.push_back(current->ptr);
+            UInt64 ptr_value = current->ptr;
+            if (other_id_to_string)
+                ptr_value = internString((*other_id_to_string)[ptr_value - 1], arena);
+            frames.push_back(ptr_value);
 
             if (current->children)
                 nodes.push_back(current->children);
@@ -435,6 +473,9 @@ struct AggregateFunctionFlameGraphData
 
     void merge(const AggregateFunctionFlameGraphData & other, Arena * arena)
     {
+        is_string_mode = is_string_mode || other.is_string_mode;
+        const auto * other_id_to_string = other.is_string_mode ? &other.id_to_string : nullptr;
+
         AggregateFunctionFlameGraphTree::Trace::Frames frames;
         for (const auto & entry : other.entries)
         {
@@ -444,7 +485,10 @@ struct AggregateFunctionFlameGraphData
                 const auto * node = allocation->trace;
                 while (node->ptr)
                 {
-                    frames.push_back(node->ptr);
+                    UInt64 ptr_value = node->ptr;
+                    if (other_id_to_string)
+                        ptr_value = internString((*other_id_to_string)[ptr_value - 1], arena);
+                    frames.push_back(ptr_value);
                     node = node->parent;
                 }
 
@@ -459,7 +503,7 @@ struct AggregateFunctionFlameGraphData
             }
         }
 
-        merge(other.tree, arena);
+        merge(other.tree, other_id_to_string, arena);
     }
 
     void dumpFlameGraph(
@@ -467,7 +511,7 @@ struct AggregateFunctionFlameGraphData
         PaddedPODArray<UInt64> & offsets,
         size_t max_depth, size_t min_bytes) const
     {
-        dumpFlameGraphImpl(tree.dump(max_depth, min_bytes), chars, offsets);
+        dumpFlameGraphImpl(tree.dump(max_depth, min_bytes), is_string_mode ? &id_to_string : nullptr, chars, offsets);
     }
 };
 
@@ -476,7 +520,9 @@ struct AggregateFunctionFlameGraphData
 /// See https://github.com/brendangregg/FlameGraph
 ///
 /// Syntax: flameGraph(traces, [size = 1], [ptr = 0])
-/// - trace : Array(UInt64), a stacktrace
+/// - trace : Array(UInt64) or Array(String), a stacktrace. For Array(UInt64) the function
+///           resolves symbols itself; for Array(String) the strings are written verbatim
+///           (useful when symbolization is already done, e.g. arrayMap(addressToSymbol, trace)).
 /// - size  : Int64, an allocation size (for memory profiling)
 /// - ptr   : UInt64, an allocation address
 /// In case if ptr != 0, a flameGraph will map allocations (size > 0) and deallocations (size < 0) with the same size and ptr.
@@ -541,7 +587,6 @@ public:
         const auto & trace = assert_cast<const ColumnArray &>(*columns[0]);
 
         const auto & trace_offsets = trace.getOffsets();
-        const auto & trace_values = assert_cast<const ColumnUInt64 &>(trace.getData()).getData();
         UInt64 prev_offset = 0;
         if (row_num)
             prev_offset = trace_offsets[row_num - 1];
@@ -561,6 +606,19 @@ public:
             ptr = ptrs[row_num];
         }
 
+        if (const auto * trace_strings = typeid_cast<const ColumnString *>(&trace.getData()))
+        {
+            auto & d = data(place);
+            d.is_string_mode = true;
+            AggregateFunctionFlameGraphTree::Trace::Frames ids;
+            ids.reserve(trace_size);
+            for (UInt64 i = 0; i < trace_size; ++i)
+                ids.push_back(d.internString(trace_strings->getDataAt(prev_offset + i), arena));
+            d.add(ptr, allocated, ids.data(), ids.size(), arena);
+            return;
+        }
+
+        const auto & trace_values = assert_cast<const ColumnUInt64 &>(trace.getData()).getData();
         data(place).add(ptr, allocated, trace_values.data() + prev_offset, trace_size, arena);
     }
 
@@ -609,12 +667,13 @@ static void check(const std::string & name, const DataTypes & argument_types, co
             name);
 
     auto ptr_type = std::make_shared<DataTypeUInt64>();
-    auto trace_type = std::make_shared<DataTypeArray>(ptr_type);
+    auto trace_uint_type = std::make_shared<DataTypeArray>(ptr_type);
+    auto trace_string_type = std::make_shared<DataTypeArray>(std::make_shared<DataTypeString>());
     auto size_type = std::make_shared<DataTypeInt64>();
 
-    if (!argument_types[0]->equals(*trace_type))
+    if (!argument_types[0]->equals(*trace_uint_type) && !argument_types[0]->equals(*trace_string_type))
         throw Exception(ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
-            "First argument (trace) for function {} must be Array(UInt64), but it has type {}",
+            "First argument (trace) for function {} must be Array(UInt64) or Array(String), but it has type {}",
             name, argument_types[0]->getName());
 
     if (argument_types.size() >= 2 && !argument_types[1]->equals(*size_type))
@@ -652,7 +711,7 @@ Non mapped deallocations are ignored.
     )";
     FunctionDocumentation::Syntax syntax = "flameGraph(traces[, size[, ptr]])";
     FunctionDocumentation::Arguments arguments = {
-        {"traces", "A stacktrace.", {"Array(UInt64)"}},
+        {"traces", "A stacktrace, either as raw addresses or as already-symbolized strings (e.g. `arrayMap(addressToSymbol, trace)`).", {"Array(UInt64)", "Array(String)"}},
         {"size", "Optional. An allocation size for memory profiling (default 1).", {"UInt64"}},
         {"ptr", "Optional. An allocation address (default 0).", {"UInt64"}}
     };

--- a/src/AggregateFunctions/AggregateFunctionFlameGraph.cpp
+++ b/src/AggregateFunctions/AggregateFunctionFlameGraph.cpp
@@ -53,9 +53,11 @@ struct AggregateFunctionFlameGraphTree
 
     static ListNode * createChild(TreeNode * parent, UInt64 ptr, Arena * arena)
     {
-
-        ListNode * list_node = reinterpret_cast<ListNode *>(arena->alloc(sizeof(ListNode)));
-        TreeNode * tree_node = reinterpret_cast<TreeNode *>(arena->alloc(sizeof(TreeNode)));
+        /// Aligned allocation is required: the arena is also used to intern
+        /// arbitrary-sized strings for Array(String) traces, which can leave
+        /// the bump pointer at an offset that is not aligned for these structs.
+        ListNode * list_node = arena->alloc<ListNode>();
+        TreeNode * tree_node = arena->alloc<TreeNode>();
 
         list_node->child = tree_node;
         list_node->next = nullptr;

--- a/src/AggregateFunctions/AggregateFunctionFlameGraph.cpp
+++ b/src/AggregateFunctions/AggregateFunctionFlameGraph.cpp
@@ -322,7 +322,7 @@ struct AggregateFunctionFlameGraphData
             return res;
         }
 
-        return reinterpret_cast<Entry *>(arena->alloc(sizeof(Entry)));
+        return arena->alloc<Entry>();
     }
 
     void release(Entry * entry)

--- a/tests/queries/0_stateless/04113_flame_graph_string_traces.reference
+++ b/tests/queries/0_stateless/04113_flame_graph_string_traces.reference
@@ -1,0 +1,9 @@
+single trace
+main;a;b 1
+aggregated traces
+main;a 2
+main;b 1
+alloc/dealloc by ptr
+main;b 30
+pointer mode
+1

--- a/tests/queries/0_stateless/04113_flame_graph_string_traces.sql
+++ b/tests/queries/0_stateless/04113_flame_graph_string_traces.sql
@@ -1,0 +1,33 @@
+-- Tests that flameGraph can accept Array(String) traces in addition to Array(UInt64).
+-- The Array(String) form is useful for data where addresses have already been symbolized
+-- (e.g. system.trace_log + arrayMap(addressToSymbol, trace), or any external profiler dump).
+
+SET allow_introspection_functions = 1;
+
+-- Single trace with the default size (1).
+SELECT 'single trace';
+SELECT arrayJoin(flameGraph(['main', 'a', 'b'])) AS line ORDER BY line;
+
+-- Multiple aggregated traces. Common prefix `main` collapses; only leaves (self > 0) are emitted.
+SELECT 'aggregated traces';
+SELECT arrayJoin(flameGraph(t)) AS line
+FROM values('t Array(String)', (['main', 'a']), (['main', 'a']), (['main', 'b']))
+ORDER BY line;
+
+-- Memory profiling via (size, ptr): the dealloc cancels the matching alloc by ptr/size.
+SELECT 'alloc/dealloc by ptr';
+SELECT arrayJoin(flameGraph(t, s, p)) AS line
+FROM values('t Array(String), s Int64, p UInt64',
+    (['main', 'a'], 100, 1),
+    (['main', 'b'], 30, 2),
+    (['main', 'a'], -100, 1))
+ORDER BY line;
+
+-- Pointer mode still works after the change. The output uses `0x...` hex for unresolved addresses,
+-- which is platform-dependent only in width — the trace shape is one line for one trace.
+SELECT 'pointer mode';
+SELECT length(flameGraph([42::UInt64, 100::UInt64])) AS num_lines;
+
+-- Reject types that are neither Array(UInt64) nor Array(String).
+SELECT flameGraph([1.5, 2.5]); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT flameGraph([1::UInt32, 2::UInt32]); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add support of resolved symbols (Array(String)) for flameGraph()

Nowadays `trace_log` has `symbols` and `lines` columns

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.760`
<!-- ch-version-info:end -->