### PR TITLE
Reliable key receiving from a chain of keyservers

### DIFF
--- a/docker/keeper/Dockerfile.distroless
+++ b/docker/keeper/Dockerfile.distroless
@@ -80,10 +80,17 @@ RUN clickhouse local -q 'SELECT 1' >/dev/null 2>&1 && exit 0 || : \
     && apt-get install --yes --no-install-recommends dirmngr gnupg2 \
     && mkdir -p /etc/apt/sources.list.d \
     && GNUPGHOME=$(mktemp -d) \
-    && GNUPGHOME="$GNUPGHOME" gpg --batch --no-default-keyring \
-        --keyring /usr/share/keyrings/clickhouse-keyring.gpg \
-        --keyserver hkp://keyserver.ubuntu.com:80 \
-        --recv-keys 3a9ea1193a97b548be1457d48919f6bd2b48d754 \
+    && ( set +e; \
+        for KEYSERVER in \
+            hkp://keys.openpgp.org:80 \
+            hkp://pgp.mit.edu:80 \
+            hkp://keyserver.ubuntu.com:80; do \
+            GNUPGHOME="$GNUPGHOME" gpg --batch --no-default-keyring \
+                --keyring /usr/share/keyrings/clickhouse-keyring.gpg \
+                --keyserver "$KEYSERVER" \
+                --recv-keys 3a9ea1193a97b548be1457d48919f6bd2b48d754 && break; \
+        done || exit 1 \
+    ) \
     && rm -rf "$GNUPGHOME" \
     && chmod +r /usr/share/keyrings/clickhouse-keyring.gpg \
     && echo "${REPOSITORY}" > /etc/apt/sources.list.d/clickhouse.list \

--- a/docker/server/Dockerfile.distroless
+++ b/docker/server/Dockerfile.distroless
@@ -87,10 +87,17 @@ RUN clickhouse local -q 'SELECT 1' >/dev/null 2>&1 && exit 0 || : \
     && apt-get install --yes --no-install-recommends dirmngr gnupg2 \
     && mkdir -p /etc/apt/sources.list.d \
     && GNUPGHOME=$(mktemp -d) \
-    && GNUPGHOME="$GNUPGHOME" gpg --batch --no-default-keyring \
-        --keyring /usr/share/keyrings/clickhouse-keyring.gpg \
-        --keyserver hkp://keyserver.ubuntu.com:80 \
-        --recv-keys 3a9ea1193a97b548be1457d48919f6bd2b48d754 \
+    && ( set +e; \
+        for KEYSERVER in \
+            hkp://keys.openpgp.org:80 \
+            hkp://pgp.mit.edu:80 \
+            hkp://keyserver.ubuntu.com:80; do \
+            GNUPGHOME="$GNUPGHOME" gpg --batch --no-default-keyring \
+                --keyring /usr/share/keyrings/clickhouse-keyring.gpg \
+                --keyserver "$KEYSERVER" \
+                --recv-keys 3a9ea1193a97b548be1457d48919f6bd2b48d754 && break; \
+        done || exit 1 \
+    ) \
     && rm -rf "$GNUPGHOME" \
     && chmod +r /usr/share/keyrings/clickhouse-keyring.gpg \
     && echo "${REPOSITORY}" > /etc/apt/sources.list.d/clickhouse.list \

--- a/docker/server/Dockerfile.ubuntu
+++ b/docker/server/Dockerfile.ubuntu
@@ -98,10 +98,17 @@ RUN clickhouse local -q 'SELECT 1' >/dev/null 2>&1 && exit 0 || : \
         gnupg2 \
     && mkdir -p /etc/apt/sources.list.d \
     && GNUPGHOME=$(mktemp -d) \
-    && GNUPGHOME="$GNUPGHOME" gpg --batch --no-default-keyring \
-        --keyring /usr/share/keyrings/clickhouse-keyring.gpg \
-        --keyserver hkp://keyserver.ubuntu.com:80 \
-        --recv-keys 3a9ea1193a97b548be1457d48919f6bd2b48d754 \
+    && ( set +e; \
+        for KEYSERVER in \
+            hkp://keys.openpgp.org:80 \
+            hkp://pgp.mit.edu:80 \
+            hkp://keyserver.ubuntu.com:80; do \
+            GNUPGHOME="$GNUPGHOME" gpg --batch --no-default-keyring \
+                --keyring /usr/share/keyrings/clickhouse-keyring.gpg \
+                --keyserver "$KEYSERVER" \
+                --recv-keys 3a9ea1193a97b548be1457d48919f6bd2b48d754 && break; \
+        done || exit 1 \
+    ) \
     && rm -rf "$GNUPGHOME" \
     && chmod +r /usr/share/keyrings/clickhouse-keyring.gpg \
     && echo "${REPOSITORY}" > /etc/apt/sources.list.d/clickhouse.list \


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The releases were failing due to a timeout on keyserver.ubuntu.com. This PR fixes it permanently by using a chain of keyservers to reliably receive the GPG key.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

### Note
Here are examples of failing release workflows:
https://github.com/ClickHouse/ClickHouse/actions/runs/25204565798 - 3 attempts
https://github.com/ClickHouse/ClickHouse/actions/runs/25203149998 - 8 attempts

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.237`
- Backported to: `26.4.1.1134`, `26.3.10.52`, `26.2.19.36`, `25.8.23.12`
<!-- ch-version-info:end -->