### PR TITLE
Fix wrong results in numbers() and generate_series() with relaxed IN/NOT IN

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -4393,6 +4393,14 @@ bool KeyCondition::extractPlainRanges(Ranges & ranges) const
                 if (element.set_index->hasMonotonicFunctionsChain())
                     return false;
 
+                /// A relaxed set is not exact (e.g. `tuple(i, i) IN (tuple(1, 2))` deduplicates to `i IN (1)`,
+                /// which is a superset of the true matches). For ordinary `MergeTree` reads this is harmless
+                /// because the row-level filter rejects false positives, but consumers that treat extracted
+                /// ranges as exact (e.g. `numbers()`/`generate_series()` sources, `LIMIT` pushdown) would
+                /// produce wrong results. Bail out and let the caller fall back to a conservative bound.
+                if (element.relaxed)
+                    return false;
+
                 if (element.set_index->size() == 0)
                 {
                     rpn_stack.push(PlainRanges::makeBlank()); /// skip blank range
@@ -4416,6 +4424,15 @@ bool KeyCondition::extractPlainRanges(Ranges & ranges) const
             else if (element.function == RPNElement::FUNCTION_NOT_IN_SET)
             {
                 if (element.set_index->hasMonotonicFunctionsChain())
+                    return false;
+
+                /// A relaxed set means the deduped/transformed set is a strict subset of the original.
+                /// For `NOT IN`, the complement built below is therefore stricter than the true predicate
+                /// and would incorrectly exclude rows that should match. Example:
+                /// `tuple(i, i) NOT IN (tuple(1, 2))` deduplicates to `i NOT IN (1)`, building ranges
+                /// `(-inf, 1) ∪ (1, +inf)` and skipping `i = 1`, even though `tuple(1, 1) != tuple(1, 2)`.
+                /// Bail out and let the caller fall back to a conservative bound.
+                if (element.relaxed)
                     return false;
 
                 if (element.set_index->size() == 0)

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -4336,6 +4336,24 @@ bool KeyCondition::extractPlainRanges(Ranges & ranges) const
 
     for (const auto & element : rpn)
     {
+        /// `extractPlainRanges` produces a range set that consumers (e.g. `ReadFromSystemNumbersStep`,
+        /// `ReadFromSystemPrimesStep`, `LIMIT` pushdown) treat as the exact set of matching key values.
+        /// A relaxed atom by definition does not yield exact ranges: depending on the source it may be
+        /// a strict superset of true matches (e.g. `LIKE` without a perfect prefix, monotonic-constant
+        /// wrapping) or, after complement, a strict subset that incorrectly skips matching rows
+        /// (e.g. `tuple(i, i) NOT IN (tuple(1, 2))` deduplicates the set to `i NOT IN (1)` and builds
+        /// `(-inf, 1) U (1, +inf)`, skipping `i = 1` even though `tuple(1, 1) != tuple(1, 2)`).
+        ///
+        /// Bail out for any relaxed atom and let the caller fall back to a conservative bound. This
+        /// guard is positioned at the top of the loop intentionally, so it covers all current atom
+        /// kinds (`FUNCTION_IN_SET`, `FUNCTION_NOT_IN_SET`, `FUNCTION_IN_RANGE`, `FUNCTION_NOT_IN_RANGE`,
+        /// `FUNCTION_IS_NULL`, `FUNCTION_IS_NOT_NULL`, ...) and any future atom that introduces
+        /// relaxation handling. Operator elements (`FUNCTION_AND`, `FUNCTION_OR`, `FUNCTION_NOT`,
+        /// `ALWAYS_TRUE`, `ALWAYS_FALSE`) are never set as relaxed; relaxation propagates through them
+        /// via their child atoms (see the comment on `KeyCondition::relaxed` in `KeyCondition.h`).
+        if (element.relaxed)
+            return false;
+
         if (element.function == RPNElement::FUNCTION_AND)
         {
             auto right_ranges = rpn_stack.top();
@@ -4393,14 +4411,6 @@ bool KeyCondition::extractPlainRanges(Ranges & ranges) const
                 if (element.set_index->hasMonotonicFunctionsChain())
                     return false;
 
-                /// A relaxed set is not exact (e.g. `tuple(i, i) IN (tuple(1, 2))` deduplicates to `i IN (1)`,
-                /// which is a superset of the true matches). For ordinary `MergeTree` reads this is harmless
-                /// because the row-level filter rejects false positives, but consumers that treat extracted
-                /// ranges as exact (e.g. `numbers()`/`generate_series()` sources, `LIMIT` pushdown) would
-                /// produce wrong results. Bail out and let the caller fall back to a conservative bound.
-                if (element.relaxed)
-                    return false;
-
                 if (element.set_index->size() == 0)
                 {
                     rpn_stack.push(PlainRanges::makeBlank()); /// skip blank range
@@ -4424,15 +4434,6 @@ bool KeyCondition::extractPlainRanges(Ranges & ranges) const
             else if (element.function == RPNElement::FUNCTION_NOT_IN_SET)
             {
                 if (element.set_index->hasMonotonicFunctionsChain())
-                    return false;
-
-                /// A relaxed set means the deduped/transformed set is a strict subset of the original.
-                /// For `NOT IN`, the complement built below is therefore stricter than the true predicate
-                /// and would incorrectly exclude rows that should match. Example:
-                /// `tuple(i, i) NOT IN (tuple(1, 2))` deduplicates to `i NOT IN (1)`, building ranges
-                /// `(-inf, 1) ∪ (1, +inf)` and skipping `i = 1`, even though `tuple(1, 1) != tuple(1, 2)`.
-                /// Bail out and let the caller fall back to a conservative bound.
-                if (element.relaxed)
                     return false;
 
                 if (element.set_index->size() == 0)

--- a/tests/queries/0_stateless/04145_extract_plain_ranges_relaxed_not_in.reference
+++ b/tests/queries/0_stateless/04145_extract_plain_ranges_relaxed_not_in.reference
@@ -29,3 +29,23 @@ mergetree NOT IN tuple
 2
 3
 4
+primes NOT IN tuple
+2
+3
+5
+7
+11
+13
+17
+19
+primes IN tuple
+numbers NOT IN tuple LIMIT
+0
+1
+2
+primes NOT IN tuple LIMIT
+2
+3
+5
+7
+11

--- a/tests/queries/0_stateless/04145_extract_plain_ranges_relaxed_not_in.reference
+++ b/tests/queries/0_stateless/04145_extract_plain_ranges_relaxed_not_in.reference
@@ -1,0 +1,31 @@
+numbers NOT IN tuple
+0
+1
+2
+3
+4
+numbers NOT has tuple
+0
+1
+2
+3
+4
+per-row eval
+0	1
+1	1
+2	1
+3	1
+4	1
+numbers IN tuple
+generate_series NOT IN tuple
+0
+1
+2
+3
+4
+mergetree NOT IN tuple
+0
+1
+2
+3
+4

--- a/tests/queries/0_stateless/04145_extract_plain_ranges_relaxed_not_in.sql
+++ b/tests/queries/0_stateless/04145_extract_plain_ranges_relaxed_not_in.sql
@@ -35,3 +35,24 @@ SELECT 'mergetree NOT IN tuple';
 SELECT i FROM t_extract_plain_ranges_relaxed WHERE tuple(i, i) NOT IN (tuple(1, 2)) ORDER BY i;
 
 DROP TABLE t_extract_plain_ranges_relaxed;
+
+-- `system.primes` consumes the same extracted ranges via `NumbersLikeUtils::extractRanges`.
+-- Without the fix, the relaxed set `{2}` would build the exact range `(-inf, 2) U (2, +inf)`,
+-- causing the source to skip the prime `2`.
+SELECT 'primes NOT IN tuple';
+SELECT prime FROM system.primes WHERE prime < 20 AND tuple(prime, prime) NOT IN (tuple(2, 3)) ORDER BY prime;
+
+-- The mirror `IN` predicate must remain consistent: no prime has `tuple(p, p) = tuple(2, 3)`.
+SELECT 'primes IN tuple';
+SELECT prime FROM system.primes WHERE prime < 20 AND tuple(prime, prime) IN (tuple(2, 3)) ORDER BY prime;
+
+-- `LIMIT` pushdown over exact ranges is the most user-visible failure mode: the source stops
+-- early, so even a small `LIMIT` reveals the missing row. With the fix, ranges are conservative
+-- and the row-level filter ensures the predicate is evaluated correctly before the `LIMIT` cuts in.
+SELECT 'numbers NOT IN tuple LIMIT';
+SELECT number FROM numbers(100) WHERE tuple(number, number) NOT IN (tuple(1, 2)) ORDER BY number LIMIT 3;
+
+-- Combined `system.primes` + `LIMIT` regression: without the fix the source would skip the prime
+-- `2`, returning `3, 5, 7, 11, 13` instead of `2, 3, 5, 7, 11`.
+SELECT 'primes NOT IN tuple LIMIT';
+SELECT prime FROM system.primes WHERE prime < 100 AND tuple(prime, prime) NOT IN (tuple(2, 3)) ORDER BY prime LIMIT 5;

--- a/tests/queries/0_stateless/04145_extract_plain_ranges_relaxed_not_in.sql
+++ b/tests/queries/0_stateless/04145_extract_plain_ranges_relaxed_not_in.sql
@@ -1,0 +1,37 @@
+-- Regression for https://github.com/ClickHouse/ClickHouse/issues/103660
+-- `KeyCondition::extractPlainRanges` must not treat a relaxed (deduplicated/transformed) set
+-- as exact. For `tuple(i, i) NOT IN (tuple(1, 2))` `MergeTreeSetIndex` deduplicates the tuple
+-- columns to a single key column, producing the relaxed set `{1}`. Building the complement
+-- `(-inf, 1) U (1, +inf)` and treating it as exact ranges incorrectly skips `i = 1`,
+-- even though `tuple(1, 1) != tuple(1, 2)`.
+
+-- `numbers()` consumes the extracted plain ranges directly, so the bug surfaces here.
+SELECT 'numbers NOT IN tuple';
+SELECT number FROM numbers(5) WHERE tuple(number, number) NOT IN (tuple(1, 2)) ORDER BY number;
+
+-- The `NOT has` variant goes through the same code path via `tryPrepareSetIndexForHas`.
+SELECT 'numbers NOT has tuple';
+SELECT number FROM numbers(5) WHERE NOT has([tuple(1, 2)], (number, number)) ORDER BY number;
+
+-- Per-row evaluation sanity check: every `tuple(n, n)` differs from `tuple(1, 2)`,
+-- so `NOT IN` is `1` for every row.
+SELECT 'per-row eval';
+SELECT number, tuple(number, number) NOT IN (tuple(1, 2)) AS val FROM numbers(5) ORDER BY number;
+
+-- The mirror `IN` predicate must remain consistent: no row has `tuple(n, n) = tuple(1, 2)`.
+SELECT 'numbers IN tuple';
+SELECT number FROM numbers(5) WHERE tuple(number, number) IN (tuple(1, 2)) ORDER BY number;
+
+-- `generate_series` shares the same range-honoring source. Its column is named `generate_series`.
+SELECT 'generate_series NOT IN tuple';
+SELECT generate_series FROM generate_series(0, 4) WHERE tuple(generate_series, generate_series) NOT IN (tuple(1, 2)) ORDER BY generate_series;
+
+-- Sanity: a real `MergeTree` table with a relaxed predicate must also return all rows.
+DROP TABLE IF EXISTS t_extract_plain_ranges_relaxed;
+CREATE TABLE t_extract_plain_ranges_relaxed (i UInt64) ENGINE = MergeTree ORDER BY i;
+INSERT INTO t_extract_plain_ranges_relaxed SELECT number FROM numbers(5);
+
+SELECT 'mergetree NOT IN tuple';
+SELECT i FROM t_extract_plain_ranges_relaxed WHERE tuple(i, i) NOT IN (tuple(1, 2)) ORDER BY i;
+
+DROP TABLE t_extract_plain_ranges_relaxed;


### PR DESCRIPTION
Fixes #103660.

`KeyCondition::extractPlainRanges` builds primary-key ranges that are consumed as exact by `numbers`, `generate_series`, and `system.primes` table functions, and by `LIMIT` pushdown. When the underlying set is *relaxed* — deduplicated by `MergeTreeSetIndex` because multiple tuple elements map to the same key column, or transformed via partition functions — the constructed ranges are no longer a faithful representation of the original predicate, and treating them as exact yields wrong results.

Example from the issue:

```sql
SELECT number FROM numbers(5) WHERE tuple(number, number) NOT IN (tuple(1, 2)) ORDER BY number;
-- Returned: {0, 2, 3, 4}
-- Expected: {0, 1, 2, 3, 4} (no row has both `number = 1` AND `number = 2`)
```

`MergeTreeSetIndex` deduplicates the tuple columns to a single key column, so the set `{(1, 2)}` becomes `{1}` and is marked as relaxed. The `FUNCTION_NOT_IN_SET` branch then builds the complement `(-inf, 1) U (1, +inf)`, and `NumbersRangedSource` skips `number = 1` from the output.

The fix bails out of `extractPlainRanges` for both `FUNCTION_IN_SET` and `FUNCTION_NOT_IN_SET` when `element.relaxed` is true; the caller (`extractBounds`) ignores the conjunct and falls back to the universe range, so the row-level filter then determines membership correctly. This mirrors the existing relaxed-aware handling already present in `KeyCondition::checkInHyperrectangle`.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix wrong results from `numbers`, `generate_series`, and similar range-honoring sources when the `WHERE` clause uses `IN` or `NOT IN` over a tuple whose elements deduplicate to a single key column (for example, `WHERE tuple(number, number) NOT IN (tuple(1, 2))`). Closes [#103660](https://github.com/ClickHouse/ClickHouse/issues/103660).

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.275`
<!-- ch-version-info:end -->