### PR TITLE
Isolate test_dictionaries_all_layouts_separate_sources dictionary configs per worker

### DIFF
--- a/tests/integration/test_dictionaries_all_layouts_separate_sources/common.py
+++ b/tests/integration/test_dictionaries_all_layouts_separate_sources/common.py
@@ -187,7 +187,12 @@ class BaseLayoutTester:
         self.layouts = []
 
     def get_dict_directory(self):
-        return os.path.join(DICT_CONFIG_PATH, self.test_name)
+        # Append the pytest-xdist worker id so concurrent workers running the same
+        # test module (e.g. with --dist=each in targeted/flaky CI runs) do not race
+        # on the same on-disk config directory.
+        worker = os.environ.get("PYTEST_XDIST_WORKER", "")
+        suffix = f"-{worker}" if worker else ""
+        return os.path.join(DICT_CONFIG_PATH, self.test_name + suffix)
 
     def cleanup(self):
         shutil.rmtree(self.get_dict_directory(), ignore_errors=True)


### PR DESCRIPTION
In `Integration tests (..., targeted)` and flaky-check jobs, every pytest-xdist worker runs the same test module concurrently with its own isolated `ClickHouseCluster`. Cluster project names and instance directories already include the worker id (e.g. `-gw0`), but `BaseLayoutTester.get_dict_directory` returned a single worker-shared path:

    tests/integration/test_dictionaries_all_layouts_separate_sources/
        configs/dictionaries/<test_name>/

Multiple workers therefore raced on `cleanup`, `create_dictionaries`, and `list_dictionaries` for the same on-disk directory. A typical losing interleaving:

1. Worker A writes its dictionary XMLs.
2. Worker B's `simple_tester.cleanup` calls `shutil.rmtree` on the same directory.
3. Worker A's `started_cluster` calls `simple_tester.list_dictionaries`, which now sees only Worker B's partially-written files (or none at all).
4. Worker A's cluster starts without the expected dictionaries, and `dictGet('MongoDB_<layout>_', ...)` later fails server-side with `Code: 36. DB::Exception: Dictionary (MongoDB_direct_) not found`.

CIDB shows this pattern across `test_mongo.py::test_simple_ssl[*-True]` (`direct`/`cache`/`hashed`/`flat`) failing together in `Integration tests (amd_asan_ubsan, targeted)` runs — characteristic of a shared-setup race, not a per-test bug.

Fix: append `PYTEST_XDIST_WORKER` to the dictionary directory name (mirroring how `ClickHouseCluster` already isolates its `project_name` and `instances_dir_name`), so each worker writes to its own directory and the race goes away. When the env var is unset (single-worker local runs), the path is unchanged.

Follow-up to #102734.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.238`
<!-- ch-version-info:end -->