### PR TITLE
Add performance tests for H3 functions

### DIFF
--- a/tests/performance/h3_functions.xml
+++ b/tests/performance/h3_functions.xml
@@ -1,0 +1,29 @@
+<test>
+    <!-- Performance tests for the H3 functions whose performance is improved by switching the
+         backend to h3o (Rust) - see https://github.com/ClickHouse/ClickHouse/pull/100272.
+         The existing h3.xml only exercises geoToH3 at resolution 15. -->
+
+    <create_query>CREATE TABLE h3_indexes_perf (h3 UInt64) ENGINE = Memory</create_query>
+    <fill_query>INSERT INTO h3_indexes_perf SELECT geoToH3(55.75 + rand(1) / 0x100000000, 37.62 + rand(2) / 0x100000000, toUInt8(9)) FROM zeros(100000)</fill_query>
+
+    <!-- Forward direction: coordinates -> H3 index -->
+    <query>SELECT count() FROM zeros(100000) WHERE NOT ignore(geoToH3(55.75 + rand(1) / 0x100000000, 37.62 + rand(2) / 0x100000000, toUInt8(9)))</query>
+
+    <!-- Reverse direction: H3 index -> coordinates -->
+    <query>SELECT count() FROM h3_indexes_perf WHERE NOT ignore(h3ToGeo(h3))</query>
+    <query>SELECT count() FROM h3_indexes_perf WHERE NOT ignore(h3ToGeoBoundary(h3))</query>
+
+    <!-- Hierarchy and metrics -->
+    <query>SELECT count() FROM h3_indexes_perf WHERE NOT ignore(h3ToParent(h3, materialize(toUInt8(3))))</query>
+    <query>SELECT count() FROM h3_indexes_perf WHERE NOT ignore(h3CellAreaM2(h3))</query>
+
+    <!-- Validation, neighbours, and grid distance -->
+    <query>SELECT count() FROM h3_indexes_perf WHERE NOT ignore(h3IsValid(h3))</query>
+    <query>SELECT count() FROM h3_indexes_perf WHERE NOT ignore(h3kRing(h3, materialize(toUInt16(1))))</query>
+    <query>SELECT count() FROM h3_indexes_perf WHERE NOT ignore(h3Distance(h3, materialize(geoToH3(55.75, 37.62, toUInt8(9)))))</query>
+
+    <!-- Great-circle distance helper -->
+    <query>SELECT count() FROM zeros(100000) WHERE NOT ignore(h3PointDistM(55.75 + rand(1) / 0x100000000, 37.62 + rand(2) / 0x100000000, 55.76 + rand(3) / 0x100000000, 37.63 + rand(4) / 0x100000000))</query>
+
+    <drop_query>DROP TABLE IF EXISTS h3_indexes_perf</drop_query>
+</test>


### PR DESCRIPTION
The existing `tests/performance/h3.xml` only covers `geoToH3` at resolution 15. PR #100272 reports speed-ups for several other H3 functions when switching the backend to the Rust `h3o` library. To make these speed-ups visible in the CI performance comparison job and to guard against future regressions, add a new perf test that exercises the remaining H3 functions mentioned there:

- `geoToH3` at resolution 9
- `h3ToGeo`
- `h3ToGeoBoundary`
- `h3ToParent`
- `h3CellAreaM2`
- `h3IsValid`
- `h3kRing`
- `h3Distance`
- `h3PointDistM`

H3 indexes for the input column are pre-computed once via a `fill_query` so each query measures the function under test rather than the cost of producing the inputs.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add performance tests for H3 functions.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)