### PR TITLE
Fix "Unexpected refresh lock in keeper" exception in RefreshTask

### DIFF
--- a/src/Storages/MaterializedView/RefreshTask.cpp
+++ b/src/Storages/MaterializedView/RefreshTask.cpp
@@ -518,16 +518,35 @@ void RefreshTask::refreshTask()
             {
                 if (coordination.root_znode.last_attempt_replica == coordination.replica_name)
                 {
-                    LOG_ERROR(log, "Znode {} indicates that this replica is running a refresh, but it isn't. Likely a bug.", coordination.path + "/running");
-#ifdef DEBUG_OR_SANITIZER_BUILD
-                    abortOnFailedAssertion("Unexpected refresh lock in keeper");
-#else
+                    /// The `/running` znode is ephemeral and tagged with this replica's name in
+                    /// its data, but this `RefreshTask` instance is not actually executing a
+                    /// refresh. The znode is therefore a leftover from a previous lifetime and
+                    /// must be cleaned up.
+                    ///
+                    /// Known ways this state arises (none of them are bugs in this task):
+                    ///  1. The server (or this `clickhouse` process) was killed while a refresh
+                    ///     was in progress, and restarted within the Keeper session timeout.
+                    ///     The new process gets a new Keeper session, but Keeper has not yet
+                    ///     expired the old session, so the ephemeral `/running` znode created
+                    ///     by the old session is still observable. This is the dominant cause
+                    ///     in stress tests with `RandomQueryKiller`.
+                    ///  2. The table was DETACHed while a refresh was in progress and Keeper
+                    ///     was unreachable during shutdown, so the in-flight cleanup path
+                    ///     (`updateCoordinationState(running=false)`) could not remove the
+                    ///     znode. After ATTACH, the new `RefreshTask` reads the lingering
+                    ///     znode.
+                    ///
+                    /// Recover by removing the stale `/running` znode (only if it carries our
+                    /// replica name — `removeRunningZnodeIfMine` checks that) and rescheduling
+                    /// a Keeper re-read on the next iteration.
+                    LOG_WARNING(log, "Znode {} indicates that this replica is running a refresh, but it isn't. "
+                        "Most likely a leftover from a previous server lifetime; recovering.",
+                        coordination.path + "/running");
                     coordination.running_znode_exists = false;
                     if (coordination.coordinated)
                         removeRunningZnodeIfMine(zookeeper);
                     schedule_keeper_retry();
                     break;
-#endif
                 }
                 else
                 {

--- a/tests/integration/test_refreshable_mv/test.py
+++ b/tests/integration/test_refreshable_mv/test.py
@@ -673,3 +673,118 @@ def test_system_view_refreshes_on_not_running_replica(started_cluster):
             pass
         for node in nodes:
             node.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")
+
+
+def test_refresh_recovers_from_stale_running_znode(started_cluster):
+    """Regression test for the `Unexpected refresh lock in keeper` LOGICAL_ERROR
+    that fires from `RefreshTask::refreshTask` when the coordination `/running`
+    znode was left behind by a previous server lifetime.
+
+    A previous keeper session of this replica may leave the ephemeral `/running`
+    znode visible to a new session for up to the keeper session timeout (most
+    commonly observed in stress runs that kill and restart the server, but also
+    reproducible after DETACH+ATTACH if keeper was unreachable during shutdown).
+    The new `RefreshTask` then sees `running_znode_exists = true` together with
+    `last_attempt_replica == replica_name` and used to abort under
+    `DEBUG_OR_SANITIZER_BUILD`. The fix removes the abort and unconditionally
+    runs the recovery path that already existed in release builds: clear the
+    stale local flag, remove the leftover znode if it carries our replica name,
+    and reschedule a Keeper re-read.
+
+    This test plants the leftover znode directly via Kazoo (a separate Keeper
+    session, the same way an old session's leftover would look from the new
+    session's point of view) and verifies that the next refresh completes
+    instead of crashing.
+    """
+    global test_idx
+    test_idx += 1
+    db_path = f"/test/re_stale_running_{test_idx}"
+    db_name = "re"
+    table_name = "rmv_stale_running"
+
+    try:
+        for node in nodes:
+            node.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")
+            node.query(
+                f"CREATE DATABASE {db_name} ENGINE = Replicated('{db_path}', 'shard1', '{{replica}}')"
+            )
+
+        # Create a coordinated RMV with a long refresh interval so the only
+        # refresh attempts are the ones we explicitly trigger via SYSTEM REFRESH VIEW.
+        node1.query(
+            f"CREATE MATERIALIZED VIEW {db_name}.{table_name} REFRESH EVERY 100 YEAR (x Int64) "
+            "ENGINE ReplicatedMergeTree ORDER BY x AS SELECT number*10 AS x FROM numbers(2)"
+        )
+        for node in nodes:
+            node.query(f"SYSTEM SYNC DATABASE REPLICA {db_name}")
+
+        # Pause refreshes on node2 so the coordination election is deterministic
+        # and `last_attempt_replica` is set to '1' (node1) in the root znode.
+        node2.query(f"SYSTEM STOP VIEW {db_name}.{table_name}")
+
+        # Trigger a refresh and wait for completion. After this, the root znode
+        # has `last_attempt_replica = '1'` written by node1.
+        node1.query(f"SYSTEM REFRESH VIEW {db_name}.{table_name}")
+        node1.query(f"SYSTEM WAIT VIEW {db_name}.{table_name}")
+
+        # Build the coordination path: default_replica_path defaults to
+        # /clickhouse/tables/{uuid}/{shard}, and the test cluster macro is shard='shard1'.
+        uuid = node1.query(
+            f"SELECT uuid FROM system.tables WHERE database = '{db_name}' AND name = '{table_name}'"
+        ).strip()
+        coordination_path = f"/clickhouse/tables/{uuid}/shard1"
+        running_znode_path = f"{coordination_path}/running"
+
+        # Wait for node1's refresh task to release `/running` after the previous
+        # refresh completed; we must plant our stale lock into a clean state.
+        zk_client = cluster.get_kazoo_client("zoo1")
+        deadline = time.monotonic() + 15
+        while zk_client.exists(running_znode_path) is not None:
+            if time.monotonic() > deadline:
+                raise AssertionError(
+                    f"`/running` znode at {running_znode_path} did not disappear after WAIT VIEW"
+                )
+            time.sleep(0.1)
+
+        # Plant a stale `/running` znode that mimics what a previous lifetime of
+        # node1 would have left behind. The data ('1') matches node1's replica name.
+        zk_client.create(running_znode_path, b"1", ephemeral=False, makepath=False)
+        assert zk_client.exists(running_znode_path) is not None
+
+        # Trigger another refresh on node1. Without the fix, refreshTask would
+        # see running_znode_exists=true + last_attempt_replica='1' and abort with
+        # `Logical error: 'Unexpected refresh lock in keeper'` under DEBUG/ASan/MSan/TSan.
+        # With the fix, refreshTask logs a warning, removes the stale znode, and
+        # reschedules; the refresh completes within a few seconds.
+        node1.query(f"SYSTEM REFRESH VIEW {db_name}.{table_name}")
+        # WAIT VIEW will block until the refresh is no longer Running/Scheduling/etc.
+        # The recovery path schedules a 5s retry, after which the refresh proceeds
+        # normally — well within the default WAIT VIEW timeout.
+        node1.query(f"SYSTEM WAIT VIEW {db_name}.{table_name}")
+
+        # Verify the server is alive and the refresh succeeded (no abort).
+        assert (
+            node1.query(
+                f"SELECT last_refresh_replica = '1' AND exception = '' "
+                f"FROM system.view_refreshes "
+                f"WHERE database = '{db_name}' AND view = '{table_name}'"
+            ).strip()
+            == "1"
+        )
+
+        # The recovery path should have removed the stale znode. (A new ephemeral
+        # `/running` may appear briefly during the next refresh; that one carries
+        # the same data but a different ephemeralOwner. We just verify the planted
+        # one no longer holds the path: i.e. the path is now either gone or has
+        # been re-created with a different stat ctime than our planted version.)
+        # Easiest assertion: the fresh refresh would have already removed the
+        # leftover and either re-created and re-removed `/running`, so by now the
+        # path should not be present.
+        assert zk_client.exists(running_znode_path) is None
+    finally:
+        try:
+            node2.query(f"SYSTEM START VIEW {db_name}.{table_name}")
+        except Exception:
+            pass
+        for node in nodes:
+            node.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")


### PR DESCRIPTION
Removes the `DEBUG_OR_SANITIZER_BUILD` abort that fired
`Logical error: 'Unexpected refresh lock in keeper'` from
`DB::RefreshTask::refreshTask()` at `src/Storages/MaterializedView/RefreshTask.cpp:523`.
The recovery branch that was already in place for release builds now runs
unconditionally.

## Why this is not a bug in `RefreshTask`

The assertion was added in #103427 as a defensive guard, but the state it
asserts against (`/running` exists in Keeper with our replica name in its data,
and this `RefreshTask` instance is in `Scheduling`) is reachable through normal
operation:

1. **Server kill+restart inside the Keeper session timeout window.** The
   ephemeral `/running` znode created by the previous Keeper session of this
   server is still observable to the new session until Keeper expires the old
   session (~30s by default). The new `RefreshTask` instance reads `/running`
   with our replica's name in its data and wrongly concludes it is itself
   running a refresh. This is the dominant cause in stress tests with
   `RandomQueryKiller`.

2. **DETACH+ATTACH while Keeper is unreachable during shutdown.**
   `RefreshTask::shutdown` does not proactively call `removeRunningZnodeIfMine`;
   it relies on the in-flight cleanup path
   `updateCoordinationState(running=false)`. If Keeper is unreachable when
   shutdown runs, the cleanup cannot run, the znode lingers, and on ATTACH the
   new task observes the leftover.

The release-build recovery branch is correct in both cases:

- `removeRunningZnodeIfMine` does `tryGet` + data match against this replica's
  name + `tryRemove` — all session-agnostic and safe across session boundaries.
- `schedule_keeper_retry` requeues a Keeper re-read in 5s; the next iteration
  observes the cleaned-up state and proceeds normally.

This change drops the `#ifdef DEBUG_OR_SANITIZER_BUILD` gate so the recovery
runs in every build, and demotes the misleading `Likely a bug` `LOG_ERROR` to a
`LOG_WARNING` that explains the actual cause.

User-visible behavior on stable (release) builds does not change — release
builds already ran the recovery path. The fix only stops debug/sanitizer
builds from aborting on a state that was always reachable. Per the bot's
review (https://github.com/ClickHouse/ClickHouse/pull/103849#discussion_r3173796807),
the category is therefore `CI Fix or Improvement` rather than `Bug Fix`.

## Reproduction / regression test

The new integration test
`test_refreshable_mv/test.py::test_refresh_recovers_from_stale_running_znode`
plants a stale `/running` znode through a separate Kazoo session — exactly the
way an old Keeper session's leftover would look from the new session — and
verifies `SYSTEM REFRESH VIEW` + `SYSTEM WAIT VIEW` complete without server
abort and the leftover znode is cleaned up.

Verified locally in a debug build: test FAILS without this fix
(`Logical error: 'Unexpected refresh lock in keeper'` aborts node1) and PASSES
with it.

## CIDB evidence

30-day window: ~22 hits across 7 unrelated PRs (STIDs `2508-3e24` and
`2508-4754`). Primary failure modes:

| pull_request_number | check_name | hits |
|---|---|---|
| 101757 | Integration tests (amd_asan_ubsan, targeted) | 7 |
| 101757 | Integration tests (amd_msan, 5/6) | 5 |
| 101757 | Integration tests (amd_asan_ubsan, db disk, old analyzer, 5/6) | 4 |
| 90740 | Stress test (amd_msan) | 1 |
| 93757 | Integration tests (amd_msan, 2/6) | 1 |
| 98533 | Stress test (amd_tsan) | 1 |
| 103737 | Stress test (arm_ubsan) | 1 |
| 103347 | Stress test (amd_tsan) | 1 |
| 101757 | Integration tests (amd_tsan, 5/6) | 1 |

Per @alexey-milovidov's directive on
https://github.com/ClickHouse/ClickHouse/pull/103737

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
