### PR TITLE
Add test: `updateMutations` early-abort under `SYSTEM STOP PULLING REPLICATION LOG` is untested

### DIFF
--- a/tests/queries/0_stateless/04146_stop_pulling_replication_log_blocks_mutations.reference
+++ b/tests/queries/0_stateless/04146_stop_pulling_replication_log_blocks_mutations.reference
@@ -1,0 +1,6 @@
+r1_mutations	1
+r2_mutations_during_stop	0
+r2_mutations_after_start	1
+r2_data	101
+r2_data	102
+r2_data	103

--- a/tests/queries/0_stateless/04146_stop_pulling_replication_log_blocks_mutations.sql
+++ b/tests/queries/0_stateless/04146_stop_pulling_replication_log_blocks_mutations.sql
@@ -1,0 +1,51 @@
+-- Tags: no-shared-merge-tree
+-- Tag no-shared-merge-tree: relies on per-replica `mutationsUpdatingTask` path
+
+-- Test: exercises `ReplicatedMergeTreeQueue::updateMutations` early-abort branch added at
+--       src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp:1134 — when SYSTEM STOP PULLING
+--       REPLICATION LOG is active, `mutationsUpdatingTask` must NOT load mutation entries
+--       into local state. Without the fix, the background `mutationsUpdatingTask` would still
+--       pull mutations from ZK (the existing `pull_log_blocker.isCancelled()` guard at line 828
+--       only protected `pullLogsToQueue`, not the direct `updateMutations` call from the
+--       background task at `StorageReplicatedMergeTree.cpp:4073`).
+
+DROP TABLE IF EXISTS r1 SYNC;
+DROP TABLE IF EXISTS r2 SYNC;
+
+CREATE TABLE r1 (x UInt32) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/test_pr59895/t', 'r1') ORDER BY tuple();
+CREATE TABLE r2 (x UInt32) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/test_pr59895/t', 'r2') ORDER BY tuple();
+
+INSERT INTO r1 VALUES (1),(2),(3);
+SYSTEM SYNC REPLICA r2;
+
+-- Stop pulling on r2; from now on r2's `mutationsUpdatingTask` must early-abort.
+SYSTEM STOP PULLING REPLICATION LOG r2;
+
+-- Run mutation; mutations_sync=1 waits only for r1.
+ALTER TABLE r1 UPDATE x = x + 100 WHERE 1 SETTINGS mutations_sync=1;
+
+-- Give r2's background `mutationsUpdatingTask` time to fire on the ZK watch.
+-- With the fix, the task throws ABORTED at line 1134 and reschedules; without the fix,
+-- it would pull the mutation into r2's local state.
+SELECT sleep(2) FORMAT Null;
+
+-- r1 must see the mutation in local state.
+SELECT 'r1_mutations', count() FROM system.mutations
+  WHERE database = currentDatabase() AND table = 'r1';
+
+-- r2 must NOT have loaded the mutation while pull is stopped.
+SELECT 'r2_mutations_during_stop', count() FROM system.mutations
+  WHERE database = currentDatabase() AND table = 'r2';
+
+-- Restart pulling — mutation should now propagate.
+SYSTEM START PULLING REPLICATION LOG r2;
+SYSTEM SYNC REPLICA r2;
+
+SELECT 'r2_mutations_after_start', count() FROM system.mutations
+  WHERE database = currentDatabase() AND table = 'r2';
+
+-- Confirm correctness of mutated data on r2 (1+100, 2+100, 3+100).
+SELECT 'r2_data', x FROM r2 ORDER BY x;
+
+DROP TABLE r1 SYNC;
+DROP TABLE r2 SYNC;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #59895](https://github.com/ClickHouse/ClickHouse/pull/59895) (merged 2024-02-16). Confirmed on current codebase — close with a note if already fixed._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #59895](https://github.com/ClickHouse/ClickHouse/pull/59895).
 That PR adds an early-abort check at the top of `ReplicatedMergeTreeQueue::updateMutations` so that when `pull_log_blocker.isCancelled()` is true (set by `SYSTEM STOP PULLING REPLICATION LOG`), the function throws `ABORTED` instead of fetching mutations from ZooKeeper.

**1. `updateMutations` early-abort under `SYSTEM STOP PULLING REPLICATION LOG` is untested**
  `src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp:1134`, `src/Storages/StorageReplicatedMergeTree.cpp:4073`
  **Risk:** Call chain: background `BackgroundSchedulePool` → `StorageReplicatedMergeTree::mutationsUpdatingTask` (`StorageReplicatedMergeTree.cpp:4073`) → `ReplicatedMergeTreeQueue::updateMutations` — without the fix, the background task would pull mutations from ZK even when `STOP PULLING REPLICATION LOG` is active.
  **What's unique vs PR tests:** The PR ships no tests of its own. Existing tests with `STOP PULLING REPLICATION LOG` (02340, 02903, 03002, 03356) exercise OPTIMIZE/DETACH/fetch-error semantics but never query `system.mutations` on the stopped replica.
  **Tags:** `-- Tags: no-shared-merge-tree` — the new branch is in the per-replica ReplicatedMergeTreeQueue path; SharedMergeTree (Cloud) replaces this storage and doesn't exercise `mutationsUpdatingTask` the same way.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.663`
<!-- ch-version-info:end -->