### PR TITLE
Add test: `JSONColumnsWithMetadata` input with `input_format_json_validate_types_from_metadata=0` else-branch is untested

### DIFF
--- a/tests/queries/0_stateless/04146_json_columns_with_metadata_no_validate.reference
+++ b/tests/queries/0_stateless/04146_json_columns_with_metadata_no_validate.reference
@@ -1,0 +1,5 @@
+INCORRECT_DATA
+0
+1
+2
+3

--- a/tests/queries/0_stateless/04146_json_columns_with_metadata_no_validate.sh
+++ b/tests/queries/0_stateless/04146_json_columns_with_metadata_no_validate.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Test: exercises `JSONColumnsWithMetadataReader::readChunkStart` with
+# `input_format_json_validate_types_from_metadata=0`, hitting the else-branch
+# that calls `JSONUtils::readMetadata` instead of `readMetadataAndValidateHeader`.
+# Covers: src/Processors/Formats/Impl/JSONColumnsWithMetadataBlockInputFormat.cpp:27-28
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT -q "drop table if exists test_jcm_novalidate"
+$CLICKHOUSE_CLIENT -q "create table test_jcm_novalidate(x UInt32) engine=Memory"
+
+# Default (validate=1): metadata says UInt64 but column is UInt32 → INCORRECT_DATA.
+echo -ne '{"meta":[{"name":"x","type":"UInt64"}],"data":{"x":[1,2,3]}}\n' \
+  | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&query=INSERT%20INTO%20test_jcm_novalidate%20FORMAT%20JSONColumnsWithMetadata" --data-binary @- 2>&1 \
+  | grep -o "INCORRECT_DATA" | head -1
+
+$CLICKHOUSE_CLIENT -q "select count() from test_jcm_novalidate"
+
+# validate=0: same mismatched metadata is ignored; rows parsed using table's UInt32 column type.
+echo -ne '{"meta":[{"name":"x","type":"UInt64"}],"data":{"x":[1,2,3]}}\n' \
+  | ${CLICKHOUSE_CURL} -sS "${CLICKHOUSE_URL}&input_format_json_validate_types_from_metadata=0&query=INSERT%20INTO%20test_jcm_novalidate%20FORMAT%20JSONColumnsWithMetadata" --data-binary @-
+
+$CLICKHOUSE_CLIENT -q "select * from test_jcm_novalidate order by x"
+
+$CLICKHOUSE_CLIENT -q "drop table test_jcm_novalidate"


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #59925](https://github.com/ClickHouse/ClickHouse/pull/59925) (merged 2024-02-14). Confirmed on current codebase — close with a note if already fixed._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #59925](https://github.com/ClickHouse/ClickHouse/pull/59925).
 That PR PR #59925 fixes a crash in the `JSONColumnsWithMetadata` input format over HTTP. Root cause: `JSONColumnsWithMetadataReader` stored `header` as `const Block & header` (reference). In the HTTP path, the source `Block` outlives the reader on the TCP path but does not on the HTTP path, leaving a dangli

**1. `JSONColumnsWithMetadata` input with `input_format_json_validate_types_from_metadata=0` else-branch is untested**
  `src/Processors/Formats/Impl/JSONColumnsWithMetadataBlockInputFormat.cpp:28`
  **Risk:** Call chain: HTTP INSERT → `JSONColumnsBlockInputFormatBase` → `JSONColumnsWithMetadataReader::readChunkStart` → if `format_settings.json.validate_types_from_metadata` is false, calls `JSONUtils::readM
  **What's unique vs PR tests:** PR test `02982_json_columns_with_metadata_http.sh` covers HTTP INSERT happy-path with metadata types matching the header (default validate_types_from_metadata=1, takes the if-branch on line 25-26). My

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)