### PR TITLE
Add test: GROUPING SETS branch of `analyzeAggregation` const-preservation has no structural assertion

### DIFF
--- a/tests/queries/0_stateless/04146_analyzer_group_by_const_grouping_sets_struct.reference
+++ b/tests/queries/0_stateless/04146_analyzer_group_by_const_grouping_sets_struct.reference
@@ -1,0 +1,5 @@
+String, Const(size = 1, String(size = 1))
+String, Const(size = 1, String(size = 1))
+String, Const(size = 1, String(size = 1))
+String, Const(size = 1, String(size = 1))
+String, Const(size = 1, String(size = 1))

--- a/tests/queries/0_stateless/04146_analyzer_group_by_const_grouping_sets_struct.sql
+++ b/tests/queries/0_stateless/04146_analyzer_group_by_const_grouping_sets_struct.sql
@@ -1,0 +1,19 @@
+-- Test: exercises analyzer's `analyzeAggregation` with GROUP BY GROUPING SETS (const)
+-- Covers: src/Planner/PlannerExpressionAnalysis.cpp:200 — the GROUPING SETS branch
+-- emplace_back of `available_columns_after_aggregation` must preserve the constant
+-- column from `expression_dag_node->column` (was `nullptr` before the fix).
+-- The plain GROUP BY const path is covered by `02992_analyzer_group_by_const.sql`
+-- via `dumpColumnStructure('x') GROUP BY 'x'`. The GROUPING SETS branch (a SEPARATE
+-- code path at line 200) was only covered by a `cityHash64` query that does not
+-- visibly fail in release builds if the column is nullptr — `dumpColumnStructure`
+-- gives a strong mutation guard by directly observing the Const wrapper.
+SET enable_analyzer = 1;
+
+-- GROUPING SETS path (line 200 in PlannerExpressionAnalysis.cpp)
+SELECT dumpColumnStructure('x') GROUP BY GROUPING SETS (('x'));
+
+-- ROLLUP / CUBE / WITH TOTALS share the non-GROUPING SETS branch (line 253),
+-- which is already covered, but verify const-ness end-to-end for these
+-- query shapes too — they did not appear with `dumpColumnStructure` in the suite.
+SELECT dumpColumnStructure('x') GROUP BY ROLLUP ('x');
+SELECT dumpColumnStructure('x') GROUP BY CUBE ('x');


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #59986](https://github.com/ClickHouse/ClickHouse/pull/59986) (merged 2024-03-19). Confirmed on current codebase — close with a note if already fixed._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #59986](https://github.com/ClickHouse/ClickHouse/pull/59986).
 That PR PR #59986 fixes function execution over const and `LowCardinality` with GROUP BY const for the analyzer. Specifically, in `src/Planner/PlannerExpressionAnalysis.cpp::analyzeAggregation`, two `available_columns_after_aggregation.emplace_back(...)` calls changed their first argument from `nullptr` to 

**1. GROUPING SETS branch of `analyzeAggregation` const-preservation has no structural assertion**
  `src/Planner/PlannerExpressionAnalysis.cpp:200`
  **Risk:** `PlannerExpressionAnalysis.cpp` has TWO emplace_back sites the PR fixed (`nullptr` → `expression_dag_node->column`): line 200 (`isGroupByWithGroupingSets`) and line 253 (else, plain GROUP BY / ROLLUP 
  **What's unique vs PR tests:** PR test `02992_analyzer_group_by_const.sql` directly asserts Const-preservation only for plain `GROUP BY 'x'` (line-253 path). The PR's GROUPING SETS test uses `cityHash64` which does NOT observe Cons
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/18f4bf28-c3f7-451e-87ae-770c4c3f9a22)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.245`
<!-- ch-version-info:end -->