### PR TITLE
Add test: `TRUNCATE` clearing mutations and `DROP PARTITION` preserving mutations are untested after the `clearOldMutations` refactor

### DIFF
--- a/tests/queries/0_stateless/04146_merge_tree_mutations_cleanup_truncate_drop_partition.reference
+++ b/tests/queries/0_stateless/04146_merge_tree_mutations_cleanup_truncate_drop_partition.reference
@@ -1,0 +1,4 @@
+mutations before TRUNCATE	1
+mutations after TRUNCATE	0
+mutations before DROP PARTITION	1
+mutations after DROP PARTITION	1

--- a/tests/queries/0_stateless/04146_merge_tree_mutations_cleanup_truncate_drop_partition.sql
+++ b/tests/queries/0_stateless/04146_merge_tree_mutations_cleanup_truncate_drop_partition.sql
@@ -1,0 +1,33 @@
+-- Test: exercises clearOldMutations(truncate=true) and the removal of clearOldMutations from dropPartition.
+-- Covers:
+--   src/Storages/StorageMergeTree.cpp:1840 — `if (!truncate && !finished_mutations_to_keep) return 0;` early-return MUST be bypassed when called via TRUNCATE.
+--   src/Storages/StorageMergeTree.cpp:2391 — dropPartition no longer calls clearOldMutations, so finished mutations must persist after DROP PARTITION.
+
+DROP TABLE IF EXISTS data_truncate_60031;
+DROP TABLE IF EXISTS data_drop_part_60031;
+
+-- Part 1: TRUNCATE TABLE must clear finished mutations even when finished_mutations_to_keep=0.
+-- (clearOldMutations(truncate=true) bypasses the new early-return at line 1840 and forces finished_mutations_to_keep=0.)
+CREATE TABLE data_truncate_60031 (key Int) ENGINE = MergeTree ORDER BY tuple()
+    SETTINGS finished_mutations_to_keep = 0;
+INSERT INTO data_truncate_60031 VALUES (1);
+ALTER TABLE data_truncate_60031 DELETE WHERE 1 SETTINGS mutations_sync = 1;
+SELECT 'mutations before TRUNCATE', count() FROM system.mutations
+    WHERE database = currentDatabase() AND table = 'data_truncate_60031';
+TRUNCATE TABLE data_truncate_60031;
+SELECT 'mutations after TRUNCATE',  count() FROM system.mutations
+    WHERE database = currentDatabase() AND table = 'data_truncate_60031';
+DROP TABLE data_truncate_60031;
+
+-- Part 2: DROP PARTITION must NOT clear finished mutations (the PR removed the clearOldMutations(true) call from dropPartition).
+CREATE TABLE data_drop_part_60031 (key Int) ENGINE = MergeTree PARTITION BY key ORDER BY tuple()
+    SETTINGS finished_mutations_to_keep = 100;
+INSERT INTO data_drop_part_60031 VALUES (1);
+INSERT INTO data_drop_part_60031 VALUES (2);
+ALTER TABLE data_drop_part_60031 DELETE WHERE key = 999 SETTINGS mutations_sync = 1;
+SELECT 'mutations before DROP PARTITION', count() FROM system.mutations
+    WHERE database = currentDatabase() AND table = 'data_drop_part_60031';
+ALTER TABLE data_drop_part_60031 DROP PARTITION 1;
+SELECT 'mutations after DROP PARTITION',  count() FROM system.mutations
+    WHERE database = currentDatabase() AND table = 'data_drop_part_60031';
+DROP TABLE data_drop_part_60031;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #60031](https://github.com/ClickHouse/ClickHouse/pull/60031) (merged 2024-03-19). Confirmed on current codebase — close with a note if already fixed._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #60031](https://github.com/ClickHouse/ClickHouse/pull/60031).
 That PR PR fixes `finished_mutations_to_keep=0` for `MergeTree`. Three behavioral changes: (1) `clearOldMutations(truncate=false)` now early-returns when `finished_mutations_to_keep=0` so background cleanup keeps all finished mutations (per docs); (2) `clearOldMutations(true)` calls were REMOVED from `dropP

**1. `TRUNCATE` clearing mutations and `DROP PARTITION` preserving mutations are untested after the `clearOldMutations` refactor**
  `src/Storages/StorageMergeTree.cpp:1840`, `src/Storages/StorageMergeTree.cpp:2391`
  **Risk:** Call chain (a): `InterpreterAlterQuery`/`InterpreterSystemQuery` → `StorageMergeTree::truncate` (line 2325) → `clearOldMutations(true)` → enters body because `!truncate` is false → sets `finished_muta
  **What's unique vs PR tests:** PR test `02994_merge_tree_mutations_cleanup.sql.j2` exercises only the background-cleanup path with `finished_mutations_to_keep=0` (asserting mutations persist after `merge_tree_clear_old_parts_interv
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/0a22ca98-7d41-438b-a15d-1ba650acb0b3)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.244`
<!-- ch-version-info:end -->