### PR TITLE
Add per-object trace logs to object storage cluster sources

### DIFF
--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -506,6 +506,8 @@ Chunk StorageObjectStorageSource::generate()
             && !format_filter_info->filter_actions_dag)
             addNumRowsToCache(*reader.getObjectInfo(), total_rows_in_file);
 
+        LOG_TRACE(log, "Finished reading object: {} ({} rows)", reader.getObjectInfo()->getPath(), total_rows_in_file);
+
         total_rows_in_file = 0;
 
         assert(reader_future.valid());
@@ -1343,6 +1345,8 @@ ObjectInfoPtr StorageObjectStorageSource::ReadTaskIterator::next(size_t)
     {
         object_info =  buffer[current_index];
     }
+
+    LOG_TRACE(log, "Received task: {}", object_info->getPath());
 
     if (!is_archive)
         return object_info;


### PR DESCRIPTION
Adds two `LOG_TRACE` lines to `StorageObjectStorageSource` to give per-replica visibility into work distribution for `s3Cluster` and the other cluster table functions backed by object storage.

`StorageClusterTaskDistributor` already traces the initiator side (request received from a replica, file assigned to a replica). The worker side, however, has had no per-task logs, so it was hard to correlate the dispatch decisions on the initiator with what each replica actually processed.

This change adds:

- `StorageObjectStorageSource::ReadTaskIterator::next` — logs the path of every task the worker receives from the initiator.
- `StorageObjectStorageSource::generate` — logs the path and total row count when a reader exhausts a file.

Together with the existing initiator-side traces, the full per-replica work timeline (dispatch on the initiator, receipt and completion on each worker) is now visible at trace level.

Closes #58603

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Added trace-level logs in object storage cluster sources for per-task receipt and per-file completion, complementing the existing initiator-side dispatch traces from `StorageClusterTaskDistributor`. Makes it easier to correlate work distribution across replicas in `s3Cluster` and related cluster table functions.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CI automatic block start :ci_links: -->

---
Workflow [[PR](https://s3.amazonaws.com/clickhouse-test-reports/praktika.html?PR=103876&sha=latest&name_0=PR)]
Sync PR [[sync-upstream/pr/103876](https://github.com/search?q=head%3Async-upstream%2Fpr%2F103876+org%3AClickHouse+type%3Apr&type=pullrequests)]
<!-- CI automatic block end :ci_links: -->
