### PR TITLE
Add test: Short-circuit `filter`/`execute`/`expand` branch in `IExecutableFunction::defaultImplementationForNulls` has zero deterministic stateless coverage

### DIFF
--- a/tests/queries/0_stateless/04146_short_circuit_evaluation_for_nulls.reference
+++ b/tests/queries/0_stateless/04146_short_circuit_evaluation_for_nulls.reference
@@ -1,0 +1,63 @@
+concat short-circuit
+abc
+\N
+\N
+\N
+abc
+\N
+\N
+\N
+concat baseline
+abc
+\N
+\N
+\N
+abc
+\N
+\N
+\N
+concat no short-circuit due to high threshold
+abc
+\N
+\N
+\N
+abc
+\N
+\N
+\N
+concat mostly non-null, threshold=0
+x-y
+x-y
+x-y
+\N
+x-y
+x-y
+x-y
+x-y
+concat mostly non-null baseline
+x-y
+x-y
+x-y
+\N
+x-y
+x-y
+x-y
+x-y
+lower short-circuit
+hello
+\N
+\N
+\N
+hello
+\N
+\N
+\N
+substring short-circuit
+hello
+\N
+\N
+\N
+hello
+\N
+\N
+\N

--- a/tests/queries/0_stateless/04146_short_circuit_evaluation_for_nulls.sql
+++ b/tests/queries/0_stateless/04146_short_circuit_evaluation_for_nulls.sql
@@ -1,0 +1,50 @@
+-- Test: exercises short-circuit branch in `IExecutableFunction::defaultImplementationForNulls`
+-- Covers: src/Functions/IFunction.cpp:301-321 — filter / execute on filtered subset / expand path
+-- This branch is only reached when `null_ratio >= short_circuit_function_evaluation_for_nulls_threshold`
+-- AND `rows_without_nulls > 0` (i.e. mixed null and non-null rows with threshold < 1.0).
+-- With the default threshold of 1.0 this branch is unreachable (the all-null early-return
+-- at line 281 takes over), so no deterministic stateless test exercised lines 301-321 prior
+-- to this test. Risk: a regression in `filter`/`expand`/`wrapInNullable(src, null_map)` could
+-- silently produce wrong values for users who set `short_circuit_function_evaluation_for_nulls_threshold` < 1.0.
+
+-- 1. concat over Nullable(String): mostly-null block, short-circuit triggered (ratio=0.75 >= 0.5)
+SELECT 'concat short-circuit';
+SELECT concat(materialize(if(number % 4 = 0, 'a', NULL)::Nullable(String)), materialize('b'), materialize('c'))
+FROM numbers(8) ORDER BY number
+SETTINGS short_circuit_function_evaluation_for_nulls = 1, short_circuit_function_evaluation_for_nulls_threshold = 0.5;
+
+-- 2. Same query with short-circuit disabled — output MUST be identical.
+SELECT 'concat baseline';
+SELECT concat(materialize(if(number % 4 = 0, 'a', NULL)::Nullable(String)), materialize('b'), materialize('c'))
+FROM numbers(8) ORDER BY number
+SETTINGS short_circuit_function_evaluation_for_nulls = 0;
+
+-- 3. Same query with threshold=1.0 (default): null_ratio (0.75) < threshold → no short-circuit
+SELECT 'concat no short-circuit due to high threshold';
+SELECT concat(materialize(if(number % 4 = 0, 'a', NULL)::Nullable(String)), materialize('b'), materialize('c'))
+FROM numbers(8) ORDER BY number
+SETTINGS short_circuit_function_evaluation_for_nulls = 1, short_circuit_function_evaluation_for_nulls_threshold = 1.0;
+
+-- 4. Mostly non-null, threshold=0.0 → short-circuit forced, exercises path with few null rows
+SELECT 'concat mostly non-null, threshold=0';
+SELECT concat(materialize(if(number = 3, NULL, 'x')::Nullable(String)), materialize('-'), materialize('y'))
+FROM numbers(8) ORDER BY number
+SETTINGS short_circuit_function_evaluation_for_nulls = 1, short_circuit_function_evaluation_for_nulls_threshold = 0.0;
+
+-- 5. Same scenario, short-circuit OFF — outputs must match line-for-line with #4.
+SELECT 'concat mostly non-null baseline';
+SELECT concat(materialize(if(number = 3, NULL, 'x')::Nullable(String)), materialize('-'), materialize('y'))
+FROM numbers(8) ORDER BY number
+SETTINGS short_circuit_function_evaluation_for_nulls = 0;
+
+-- 6. lower over Nullable(String): unary string function — also reaches the non-numeric path
+SELECT 'lower short-circuit';
+SELECT lower(materialize(if(number % 4 = 0, 'HELLO', NULL)::Nullable(String)))
+FROM numbers(8) ORDER BY number
+SETTINGS short_circuit_function_evaluation_for_nulls = 1, short_circuit_function_evaluation_for_nulls_threshold = 0.5;
+
+-- 7. substring with mixed-arg types and Nullable(String) — multi-arg path
+SELECT 'substring short-circuit';
+SELECT substring(materialize(if(number % 4 = 0, 'hello world', NULL)::Nullable(String)), materialize(1), materialize(5))
+FROM numbers(8) ORDER BY number
+SETTINGS short_circuit_function_evaluation_for_nulls = 1, short_circuit_function_evaluation_for_nulls_threshold = 0.5;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #60129](https://github.com/ClickHouse/ClickHouse/pull/60129) (merged 2024-11-19). Confirmed on current codebase — close with a note if already fixed._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #60129](https://github.com/ClickHouse/ClickHouse/pull/60129).
 That PR PR adds short-circuit optimization for functions executed over `Nullable` arguments via two new settings: `short_circuit_function_evaluation_for_nulls` (default true) and `short_circuit_function_evaluation_for_nulls_threshold` (default 1.0). Modifies `IExecutableFunction::defaultImplementationForNul

**1. Short-circuit `filter`/`execute`/`expand` branch in `IExecutableFunction::defaultImplementationForNulls` has zero deterministic stateless coverage**
  `src/Functions/IFunction.cpp:301`, `src/Functions/IFunction.cpp:313`
  **Risk:** Call chain: `IExecutableFunction::execute` → `executeWithoutSparseColumns` → `executeWithoutLowCardinalityColumns` → `defaultImplementationForNulls` → short-circuit branch at lines 301-321. RISK: a re
  **What's unique vs PR tests:** PR ships only `tests/performance/short_circuit_nulls.xml` (a benchmark using FORMAT Null — no correctness assertions) and a one-line WHERE clause edit to `02809_storage_set_analysis_bug.sql` (unrelate
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/9c1d9f0a-6c26-4c7b-8056-5726969012f3)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.411`
<!-- ch-version-info:end -->