### PR TITLE
Add test: `validate_experimental_and_suspicious_types_inside_nested_types = 0` bypass branch in `validateDataType` has no behavioural test

### DIFF
--- a/tests/queries/0_stateless/04146_validate_nested_types_setting_bypass.reference
+++ b/tests/queries/0_stateless/04146_validate_nested_types_setting_bypass.reference
@@ -1,0 +1,7 @@
+[42]
+{'a':42}
+('a',42)
+[[[42]]]
+[1,2,3]
+id	UInt64					
+bad	Array(LowCardinality(UInt64))					

--- a/tests/queries/0_stateless/04146_validate_nested_types_setting_bypass.sql
+++ b/tests/queries/0_stateless/04146_validate_nested_types_setting_bypass.sql
@@ -1,0 +1,41 @@
+-- Test: exercises validateDataType bypass when validate_experimental_and_suspicious_types_inside_nested_types=0
+-- Covers: src/Interpreters/parseColumnsListForTableFunction.cpp:159 — `if (settings.validate_nested_types)` branch
+-- The PR adds the bypass setting (default true). When set to false, forEachChild() recursive
+-- validation is skipped, allowing suspicious types nested under Array/Map/Tuple/Variant
+-- (restoring pre-#59385 behaviour). Top-level validation still runs.
+
+SET allow_suspicious_low_cardinality_types = 0;
+SET allow_suspicious_fixed_string_types = 0;
+SET allow_suspicious_variant_types = 0;
+
+-- 1. Default behaviour (validate_nested_types = 1): nested suspicious types are rejected.
+SELECT [42]::Array(LowCardinality(UInt64)) SETTINGS validate_experimental_and_suspicious_types_inside_nested_types = 1; -- { serverError SUSPICIOUS_TYPE_FOR_LOW_CARDINALITY }
+SELECT ['x']::Array(FixedString(1000000)) SETTINGS validate_experimental_and_suspicious_types_inside_nested_types = 1; -- { serverError ILLEGAL_COLUMN }
+
+-- 2. With bypass (validate_nested_types = 0): nested suspicious types are accepted.
+SET validate_experimental_and_suspicious_types_inside_nested_types = 0;
+
+SELECT [42]::Array(LowCardinality(UInt64));
+SELECT map('a', 42)::Map(String, LowCardinality(UInt64));
+SELECT tuple('a', 42)::Tuple(String, LowCardinality(UInt64));
+SELECT [[[42]]]::Array(Array(Array(LowCardinality(UInt64))));
+
+DROP TABLE IF EXISTS test_nested_bypass;
+CREATE TABLE test_nested_bypass (x Array(LowCardinality(UInt64))) ENGINE = Memory;
+INSERT INTO test_nested_bypass VALUES ([1, 2, 3]);
+SELECT * FROM test_nested_bypass ORDER BY x;
+DROP TABLE test_nested_bypass;
+
+CREATE TABLE test_nested_bypass (x Tuple(s String, fs FixedString(1000000))) ENGINE = Memory;
+DROP TABLE test_nested_bypass;
+
+-- 3. Bypass does NOT skip top-level validation: top-level suspicious types still rejected.
+SELECT 1::LowCardinality(UInt64); -- { serverError SUSPICIOUS_TYPE_FOR_LOW_CARDINALITY }
+SELECT ''::FixedString(1000000); -- { serverError ILLEGAL_COLUMN }
+
+-- 4. ALTER path (AlterCommands.cpp also calls validateDataType) honours the bypass.
+DROP TABLE IF EXISTS test_alter_nested_bypass;
+CREATE TABLE test_alter_nested_bypass (id UInt64) ENGINE = MergeTree ORDER BY id;
+ALTER TABLE test_alter_nested_bypass ADD COLUMN bad Array(LowCardinality(UInt64));
+DESCRIBE TABLE test_alter_nested_bypass;
+DROP TABLE test_alter_nested_bypass;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #60353](https://github.com/ClickHouse/ClickHouse/pull/60353) (merged 2024-02-28). Confirmed on current codebase — close with a note if already fixed._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #60353](https://github.com/ClickHouse/ClickHouse/pull/60353).
 That PR PR adds a new boolean setting `validate_experimental_and_suspicious_types_inside_nested_types` (default `true`) to `parseColumnsListForTableFunction.cpp`. When set to `false`, the recursive `forEachChild(validate_callback)` call is skipped, so suspicious/experimental types nested inside `Array`, `Ma

**1. `validate_experimental_and_suspicious_types_inside_nested_types = 0` bypass branch in `validateDataType` has no behavioural test**
  `src/Interpreters/parseColumnsListForTableFunction.cpp:159`, `src/Interpreters/parseColumnsListForTableFunction.h:22`
  **Risk:** Call chain: `CastOverloadResolver`/`InterpreterCreateQuery`/`AlterCommands`/`parseColumnsListFromString` → `validateDataType(type, settings)` → `validate_callback(*type_to_check)` always runs → `if (s
  **What's unique vs PR tests:** The PR ships ZERO tests of its own. The only existing references to the setting are 02995_settings_26_4_1.tsv (lists the default value 1, no behavioural assertion) and 03806_inconsistent_formatting_cr
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/4adcbb85-e0ba-4203-8669-d219d7665f03)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.383`
<!-- ch-version-info:end -->