### PR TITLE
Fix use-after-free in KeeperHandlingConsumer::setKeeper (StorageKafka2)

### DIFF
--- a/src/Storages/Kafka/KeeperHandlingConsumer.cpp
+++ b/src/Storages/Kafka/KeeperHandlingConsumer.cpp
@@ -131,18 +131,8 @@ bool KeeperHandlingConsumer::needsNewKeeper() const
 
 void KeeperHandlingConsumer::setKeeper(const std::shared_ptr<zkutil::ZooKeeper> & keeper_)
 {
-    /// Drop the lock holders BEFORE replacing the `keeper` shared_ptr.
-    ///
-    /// `LockedTopicPartitionInfo::lock` is a `zkutil::EphemeralNodeHolder`, which stores
-    /// a raw `ZooKeeper &` reference captured at construction time (see `EphemeralNodeHolder`
-    /// in `Common/ZooKeeper/ZooKeeper.h`). Its destructor calls `zookeeper.expired()` and
-    /// possibly `zookeeper.tryRemove()`. If we assigned `keeper = keeper_` first and our
-    /// `keeper` was the last shared owner of the previous session, that assignment would
-    /// synchronously destroy the old `ZooKeeper`, and the subsequent `permanent_locks.clear()`
-    /// / `tmp_locks.clear()` would then access a dangling reference -> use-after-free.
-    ///
-    /// `StorageKafka2::partialShutdown()` already documents and applies the same ordering for
-    /// `replica_is_active_node`; this mirrors that fix for the per-consumer lock holders.
+    /// Drop the lock holders before replacing `keeper` -- same use-after-free hazard as
+    /// `replica_is_active_node` in `StorageKafka2::partialShutdown` (see comment there).
     {
         std::lock_guard lock(topic_partition_locks_mutex);
         permanent_locks.clear();

--- a/src/Storages/Kafka/KeeperHandlingConsumer.cpp
+++ b/src/Storages/Kafka/KeeperHandlingConsumer.cpp
@@ -131,12 +131,24 @@ bool KeeperHandlingConsumer::needsNewKeeper() const
 
 void KeeperHandlingConsumer::setKeeper(const std::shared_ptr<zkutil::ZooKeeper> & keeper_)
 {
-    keeper = keeper_;
+    /// Drop the lock holders BEFORE replacing the `keeper` shared_ptr.
+    ///
+    /// `LockedTopicPartitionInfo::lock` is a `zkutil::EphemeralNodeHolder`, which stores
+    /// a raw `ZooKeeper &` reference captured at construction time (see `EphemeralNodeHolder`
+    /// in `Common/ZooKeeper/ZooKeeper.h`). Its destructor calls `zookeeper.expired()` and
+    /// possibly `zookeeper.tryRemove()`. If we assigned `keeper = keeper_` first and our
+    /// `keeper` was the last shared owner of the previous session, that assignment would
+    /// synchronously destroy the old `ZooKeeper`, and the subsequent `permanent_locks.clear()`
+    /// / `tmp_locks.clear()` would then access a dangling reference -> use-after-free.
+    ///
+    /// `StorageKafka2::partialShutdown()` already documents and applies the same ordering for
+    /// `replica_is_active_node`; this mirrors that fix for the per-consumer lock holders.
     {
         std::lock_guard lock(topic_partition_locks_mutex);
         permanent_locks.clear();
         tmp_locks.clear();
     }
+    keeper = keeper_;
     tmp_locks_quota = 0;
     assigned_topic_partitions.clear();
     topic_partition_index_to_consume_from = 0;


### PR DESCRIPTION
## What

Fix a use-after-free in `DB::KeeperHandlingConsumer::setKeeper()` (used by `StorageKafka2`) where, on a Keeper session swap, the lock holders could outlive the `ZooKeeper` instance they reference and crash in `~zkutil::EphemeralNodeHolder()`.

## Why / root cause

`LockedTopicPartitionInfo::lock` (held in `permanent_locks` and `tmp_locks`) is a `zkutil::EphemeralNodeHolder`, which stores a **raw** `ZooKeeper &` reference captured at construction time (see `EphemeralNodeHolder` in `Common/ZooKeeper/ZooKeeper.h`). Its destructor calls `zookeeper.expired()` and possibly `zookeeper.tryRemove()`.

`KeeperHandlingConsumer::setKeeper()` was assigning the new `keeper` shared_ptr **before** clearing the lock maps:

```cpp
void KeeperHandlingConsumer::setKeeper(const std::shared_ptr<zkutil::ZooKeeper> & keeper_)
{
    keeper = keeper_;             // <-- (1) drops shared_ptr to old session
    {
        std::lock_guard lock(topic_partition_locks_mutex);
        permanent_locks.clear();  // <-- (2) destroys EphemeralNodeHolders that hold ZooKeeper&
        tmp_locks.clear();
    }
    ...
}
```

If the consumer was the last shared owner of the previous `ZooKeeper` (which is plausible: by the time `streamToViews()` calls `setKeeper`, `StorageKafka2::keeper` and `Context`'s keeper have typically already moved on to the new session), then step (1) synchronously destroys the old `ZooKeeper`. Step (2) then runs the holders' destructors which call `zookeeper.expired()` on the freed object — SIGSEGV.

This is the **same hazard** already documented and fixed in `StorageKafka2::partialShutdown()` for `replica_is_active_node`. From `src/Storages/Kafka/StorageKafka2.cpp` lines 221-225:

```cpp
/// Reset the active node holder while the old ZooKeeper session is still alive (even if expired).
/// EphemeralNodeHolder stores a raw ZooKeeper reference, so resetting it here prevents a
/// use-after-free: setZooKeeper() called afterwards may free the old session, and the holder's
/// destructor would then access a dangling reference when checking zookeeper.expired().
replica_is_active_node = nullptr;
```

The per-consumer lock holders need the same treatment. This PR clears `permanent_locks` and `tmp_locks` first, then replaces `keeper`.

## Crash report

```
zkutil::EphemeralNodeHolder::~EphemeralNodeHolder() @ 0x15aa9699
DB::KeeperHandlingConsumer::setKeeper(...)            @ 0x15a9985c
DB::StorageKafka2::streamToViews(unsigned long)       @ 0x15b0cf1c
... StorageKafka2 ctor lambda → BackgroundSchedulePool::threadFunction
```

Caught on **Stress test (arm_release)** on PR #101113 (which is unrelated to Kafka/Keeper — the crash surfaced under stress-test ZK fault injection):

- Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=101113&sha=4cf4eb894643c2dac6b52dea6126f1a3f2e75cd2&name_0=PR&name_1=Stress%20test%20%28arm_release%29
- PR that surfaced it (unrelated): https://github.com/ClickHouse/ClickHouse/pull/101113
- STID: `3555-2986`

## Related

- Issue #84616 — *"StorageKafka2 crashed after a connection loss with Keeper"* (open, assignee @antaljanosbenjamin). Different exception type (`cppkafka::HandleException` there, raw SIGSEGV in `~EphemeralNodeHolder` here) but same component and trigger (Keeper session loss). This fix likely addresses one manifestation of that family of bugs; #84616 itself may have additional manifestations.

## Scope review

Audited every `EphemeralNodeHolderPtr` / `EphemeralNodeHolder` usage that could outlive a `keeper` swap:

| Site | Status |
|---|---|
| `StorageKafka2::replica_is_active_node` | already correct (handled in `partialShutdown()`) |
| `StorageReplicatedMergeTree::replica_is_active_node` | already correct (handled in its `partialShutdown()`) |
| `StorageKafka2.cpp:574` `metadata_drop_lock` | safe — local-scope, lives entirely within one function with its own `keeper` shared_ptr alive |
| `StorageKafka2.cpp:766` `drop_lock` | safe — local-scope, same reasoning |
| `KeeperHandlingConsumer::permanent_locks` / `tmp_locks` | **the bug, fixed by this PR** |

## Testing notes

The bug is a race-y use-after-free: it requires the consumer to be the last `shared_ptr` owner of the previous `ZooKeeper`, with at least one acquired ephemeral lock at the moment of `setKeeper`. Reproducing this deterministically requires the stress-test ZK fault-injection harness that originally caught it (the bug is rare in normal operation and the master CIDB shows only one hit so far for STID `3555-2986`).

The fix itself is provably correct from the `shared_ptr` / raw-reference lifetime argument and mirrors the documented and already-merged precedent for `replica_is_active_node`. It is a pure reordering of operations within `setKeeper`; the externally observable post-state of the function is unchanged.

The change compiles cleanly (`ninja -C build src/CMakeFiles/dbms.dir/Storages/Kafka/KeeperHandlingConsumer.cpp.o`).

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a use-after-free in `StorageKafka2` that could crash the server when a Keeper session is replaced while the consumer is holding ephemeral topic-partition locks.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.674`
- Backported to: `26.4.3.23`, `26.3.11.23`, `26.2.19.30`, `25.8.24.17`
<!-- ch-version-info:end -->