### PR TITLE
Add test: Negative-overflow half of `float64AsSecondsToTimespan` range check at `SettingsFields.cpp`:320 is untested

### DIFF
--- a/tests/queries/0_stateless/04201_too_negative_max_execution_time_setting.sql
+++ b/tests/queries/0_stateless/04201_too_negative_max_execution_time_setting.sql
@@ -1,0 +1,7 @@
+-- Test: exercises `float64AsSecondsToTimespan` with a very negative value triggering the
+--       `d * 1000000 < std::numeric_limits<Poco::Timespan::TimeDiff>::min()` branch.
+-- Covers: src/Core/SettingsFields.cpp:320 — negative-overflow half of the new range check.
+-- The PR-shipped test (03000_too_big_max_execution_time_setting.sql) only covers the
+-- positive-overflow half (`d * 1000000 > max()`); the negative-overflow half is the actual
+-- UBSan trigger from the linked failure report (-9.22337e+24) but has no test exercising it.
+SELECT 1 SETTINGS max_execution_time = -1e18; -- { clientError BAD_ARGUMENTS }


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #60419](https://github.com/ClickHouse/ClickHouse/pull/60419) (merged 2024-02-28). Confirmed on current codebase — close with a note if already fixed._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #60419](https://github.com/ClickHouse/ClickHouse/pull/60419).
 That PR PR adds a range check in `float64AsSecondsToTimespan` (`src/Core/SettingsFields.cpp`:320) that throws `BAD_ARGUMENTS` when `d * 1000000` overflows `Poco::Timespan::TimeDiff` (Int64) in either direction (positive or negative). The check fixes a UBSan-detected runtime error originally triggered by a N

**1. Negative-overflow half of `float64AsSecondsToTimespan` range check at `SettingsFields.cpp`:320 is untested**
  `src/Core/SettingsFields.cpp:320`
  **Risk:** Call chain: `SettingFieldSeconds::SettingFieldTimespan(const Field&)` (`SettingsFields.cpp`:331) → `float64AsSecondsToTimespan(fieldToNumber<Float64>(f))` → range check at line 320 → throws `BAD_ARGUM
  **What's unique vs PR tests:** PR test `03000_too_big_max_execution_time_setting.sql` uses a POSITIVE value (`9223372036854775808`) that triggers only the `d * 1000000 > max()` operand of the `||`. My test uses a NEGATIVE value (`-
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/58d59fd0-a2a2-44c0-9df4-5f03f5d90291)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.429`
<!-- ch-version-info:end -->