### PR TITLE
Add test: `intDivOrZero` and reverse-order `(Date, Decimal)` paths of the new int_div type-guard untested

### DIFF
--- a/tests/queries/0_stateless/04201_int_div_or_zero_decimal_with_date.sql
+++ b/tests/queries/0_stateless/04201_int_div_or_zero_decimal_with_date.sql
@@ -1,0 +1,21 @@
+-- Test: exercises `intDivOrZero` and reverse-order `intDiv` with Decimal/Date arguments
+-- Covers: src/Functions/FunctionBinaryArithmetic.h:189 — int_div_or_zero branch of the
+--   IsDataTypeDecimalOrNumber<L> && IsDataTypeDecimalOrNumber<R> guard.
+-- The PR's own test (03002_int_div_decimal_with_date_bug.sql) only exercises `intDiv`
+-- with (Decimal, Date) ordering; `intDivOrZero` and reverse-order (Date, Decimal) are
+-- never exercised even though the PR's predicate explicitly covers both functions and
+-- both argument positions.
+
+-- intDivOrZero with Decimal + Date/DateTime variants
+SELECT intDivOrZero(CAST('1.0', 'Decimal256(3)'), today()); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT intDivOrZero(CAST('1.0', 'Decimal256(3)'), toDate('2023-01-02')); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT intDivOrZero(CAST('1.0', 'Decimal256(2)'), toDate32('2023-01-02 12:12:12')); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT intDivOrZero(CAST('1.0', 'Decimal256(2)'), toDateTime('2023-01-02 12:12:12')); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT intDivOrZero(CAST('1.0', 'Decimal256(2)'), toDateTime64('2023-01-02 12:12:12.002', 3)); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
+-- Reverse argument order: Date/DateTime + Decimal
+SELECT intDiv(today(), CAST('1.0', 'Decimal256(3)')); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT intDiv(toDate('2023-01-02'), CAST('1.0', 'Decimal256(3)')); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT intDiv(toDateTime('2023-01-02 12:12:12'), CAST('1.0', 'Decimal256(2)')); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT intDivOrZero(toDate('2023-01-02'), CAST('1.0', 'Decimal256(3)')); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT intDivOrZero(toDateTime64('2023-01-02 12:12:12.002', 3), CAST('1.0', 'Decimal256(2)')); -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #60672](https://github.com/ClickHouse/ClickHouse/pull/60672) (merged 2024-03-05). Confirmed on current codebase — close with a note if already fixed._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #60672](https://github.com/ClickHouse/ClickHouse/pull/60672).
 That PR PR fixes a logical-error crash in `intDiv`/`intDivOrZero` when one operand is a `Decimal` and the other is a Date/DateTime type. The fix is in `BinaryOperationTraits::ResultDataType` (`FunctionBinaryArithmetic.h`:189) — the `int_div || int_div_or_zero` Switch case now resolves to `InvalidType` unles

**1. `intDivOrZero` and reverse-order `(Date, Decimal)` paths of the new int_div type-guard untested**
  `src/Functions/FunctionBinaryArithmetic.h:189`
  **Risk:** The PR's new guard at `FunctionBinaryArithmetic.h`:189 explicitly disjoins `int_div || int_div_or_zero` and uses a SYMMETRIC `IsDataTypeDecimalOrNumber<L> && IsDataTypeDecimalOrNumber<R>` check. The P
  **What's unique vs PR tests:** PR test `03002_int_div_decimal_with_date_bug.sql` covers ONLY `intDiv(Decimal, Date|Date32|DateTime|DateTime64)` — 5 lines, all `intDiv` with LEFT=Decimal. This finding adds (a) the `intDivOrZero` hal
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/7564f475-fcd8-42ad-971c-42d264401c6d)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.100`
<!-- ch-version-info:end -->