### PR TITLE
CI: add disk usage snapshot before BOLT cmake configuration (testing)

### DIFF
--- a/ci/jobs/build_toolchain.py
+++ b/ci/jobs/build_toolchain.py
@@ -518,6 +518,17 @@ def main():
                 print(f"Failed to create clang++ symlink: {e}")
                 bolt_ok = False
 
+        # Disk usage snapshot before BOLT cmake configuration.
+        # This helps diagnose disk exhaustion failures: clang-21.inst writes a
+        # BOLT profile file for every cmake compiler-feature test, which can
+        # consume several GB before the real build starts.
+        if bolt_ok:
+            print("=== Disk usage before BOLT cmake configuration ===")
+            Shell.check("du / 2>/dev/null | sort -rn | head -100 || true")
+            print("=== df -h ===")
+            Shell.check("df -h || true")
+            print("=== End disk usage snapshot ===")
+
         # Step 3: Configure ClickHouse build with BOLT-instrumented clang
         if bolt_ok:
             cmake_cmd = (


### PR DESCRIPTION
Testing PR to diagnose the BOLT toolchain build failure from #103307.

Every cmake compiler-feature test invokes `clang-21.inst` (BOLT-instrumented
clang), which writes a profile file per invocation. With hundreds of tests this
may fill several GB of disk before the real build starts, killing the runner
silently. This PR adds `du / | sort -rn | head -100` and `df -h` right before
the BOLT cmake step to confirm whether disk exhaustion is the root cause.

The `build_toolchain.py` change also busts the toolchain cache so the
`Build Toolchain (PGO, BOLT) (amd64)` job actually runs in the PR workflow.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)