### PR TITLE
Fix SELECT error with unmerged patch parts when lazy materialization …

### DIFF
--- a/src/Storages/MergeTree/MergeTreeReadersChain.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadersChain.cpp
@@ -301,6 +301,9 @@ void MergeTreeReadersChain::addPatchVirtuals(Block & to, const Block & from) con
 
 void MergeTreeReadersChain::readPatches(const Block & result_header, std::vector<MarkRanges> & patch_ranges, ReadResult & read_result)
 {
+    /// If result_header is empty (e.g., due to lazy materialization), use the patch reader's header instead
+    const Block & header_to_use = result_header.empty() && !patch_readers.empty() ? patch_readers[0]->getHeader() : result_header;
+
     for (size_t i = 0; i < patches_results.size(); ++i)
     {
         auto & patch_results = patches_results[i];
@@ -312,7 +315,7 @@ void MergeTreeReadersChain::readPatches(const Block & result_header, std::vector
         }
 
         const auto * last_read_patch = patch_results.empty() ? nullptr : patch_results.back().get();
-        auto new_patches = patch_readers[i]->readPatches(patch_ranges[i], read_result, result_header, last_read_patch);
+        auto new_patches = patch_readers[i]->readPatches(patch_ranges[i], read_result, header_to_use, last_read_patch);
         patch_results.insert(patch_results.end(), new_patches.begin(), new_patches.end());
     }
 }

--- a/tests/queries/0_stateless/04031_patch_parts_without_part_offset.sql
+++ b/tests/queries/0_stateless/04031_patch_parts_without_part_offset.sql
@@ -3,12 +3,8 @@
 -- We use apply_patches_on_merge = 0 so OPTIMIZE merges data parts but keeps patches intact.
 -- Pre-merge patches become PatchMode::Join, post-merge patches are PatchMode::Merge.
 --
--- Note: query_plan_optimize_lazy_materialization is disabled because lazy materializing
--- has a separate bug with patch parts (empty read_sample_block passed to readPatches).
-
 SET enable_lightweight_update = 1;
 SET mutations_sync = 2;
-SET query_plan_optimize_lazy_materialization = 0;
 
 DROP TABLE IF EXISTS t_lwu_merge_join_patch;
 
@@ -33,6 +29,10 @@ UPDATE t_lwu_merge_join_patch SET b = 2, c = ['a', 'b', 'c'] WHERE a % 3 = 0;
 
 -- Step 5: This SELECT triggers the bug when both Merge and Join patches exist.
 -- Without the fix, fails with "Min/max part offset must be set in RangeReader"
+SELECT * FROM t_lwu_merge_join_patch ORDER BY a LIMIT 10;
+
+-- Step 6: Test with lazy materialization enabled (previously caused empty read_sample_block issue)
+SET query_plan_optimize_lazy_materialization = 1;
 SELECT * FROM t_lwu_merge_join_patch ORDER BY a LIMIT 10;
 
 DROP TABLE IF EXISTS t_lwu_merge_join_patch;

--- a/tests/queries/0_stateless/04097_04035_patch_parts_select_before_merge.sql
+++ b/tests/queries/0_stateless/04097_04035_patch_parts_select_before_merge.sql
@@ -1,0 +1,32 @@
+-- Test for issue where SELECT fails when patch parts are not yet merged
+-- This test verifies that SELECT should work correctly even when
+-- there are unmerged patch parts, including with lazy materialization enabled
+
+SET enable_lightweight_update = 1;
+SET mutations_sync = 2;
+
+DROP TABLE IF EXISTS t_patch_select;
+
+CREATE TABLE t_patch_select(a UInt64, b UInt64 DEFAULT 0, c String DEFAULT '')
+ENGINE = MergeTree ORDER BY a
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1;
+
+-- Insert initial data
+INSERT INTO t_patch_select (a) SELECT number FROM numbers(100);
+
+-- Create patch parts via UPDATE (without merging)
+UPDATE t_patch_select SET b = 1 WHERE a % 2 = 0;
+
+-- This SELECT should work even though patches are not merged
+SELECT count() FROM t_patch_select;
+SELECT * FROM t_patch_select WHERE a < 10 ORDER BY a;
+
+-- Verify the data is correct
+SELECT count() FROM t_patch_select WHERE b = 1;
+
+-- Test with lazy materialization enabled (this was causing issues before the fix)
+SET query_plan_optimize_lazy_materialization = 1;
+SELECT count() FROM t_patch_select;
+SELECT * FROM t_patch_select WHERE a < 10 ORDER BY a;
+
+DROP TABLE t_patch_select;


### PR DESCRIPTION
…is enabled

When lazy materialization is enabled, the result_header passed to readPatches could be empty, causing errors when trying to read and apply patch parts. This fix ensures that if the result_header is empty, we use the patch reader's header instead, allowing SELECT queries to work correctly even when there are unmerged patch parts.

The issue manifested as SELECT commands failing with errors instead of returning records when patch parts were yet to be merged, particularly when query_plan_optimize_lazy_materialization was enabled.

Fixes the known issue mentioned in test 04031 where lazy materialization had a separate bug with patch parts (empty read_sample_block passed to readPatches).

Generated with Devin (https://cli.devin.ai/docs)

### Changelog category (leave one):
- New Feature
- Experimental Feature
- Improvement
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Critical Bug Fix (crash, data loss, RBAC)
- Bug Fix (user-visible misbehavior in an official stable release)
- CI Fix or Improvement (changelog entry is not required)
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
