### PR TITLE
claude: use `claude:` prefix for `.claude/` PRs

### DIFF
--- a/.claude/skills/clickhouse-pr-description/SKILL.md
+++ b/.claude/skills/clickhouse-pr-description/SKILL.md
@@ -14,7 +14,7 @@ Generate a good PR description and apply it, with optional confirmation based on
 
 Plain description of what changed. No prefix conventions like `fix():` or `feat():`.
 
-**Exception — `.claude/` changes:** when the PR only touches files under `.claude/` (settings, tools, skills, instructions, etc.), prefix the title with `claude: `. Example: `claude: add fetch_ci_report.js to allowed commands`.
+**Exception — `.claude/` changes:** when the PR only touches files under `.claude/` (settings, tools, skills, instructions, etc.), prefix the title with `claude: ` and use the `Documentation (changelog entry is not required)` changelog category. Example: `claude: add fetch_ci_report.js to allowed commands`.
 
 - Good: `Change default stderr_reaction to log_last for executable UDFs`
 - Good: `Fix exception when inserting NULL into non-nullable column via CAST`

--- a/.claude/skills/clickhouse-pr-description/SKILL.md
+++ b/.claude/skills/clickhouse-pr-description/SKILL.md
@@ -14,7 +14,7 @@ Generate a good PR description and apply it, with optional confirmation based on
 
 Plain description of what changed. No prefix conventions like `fix():` or `feat():`.
 
-**Exception — `.claude/` changes:** when the PR only touches files under `.claude/` (settings, tools, skills, instructions, etc.), prefix the title with `claude: ` and use the `Not for changelog (changelog entry is not required)` changelog category. Example: `claude: add fetch_ci_report.js to allowed commands`.
+**Exception — `.claude/` changes:** when the PR only touches files under `.claude/` (settings, tools, skills, instructions, etc.), prefix the title with `claude: `. Example: `claude: add fetch_ci_report.js to allowed commands`.
 
 - Good: `Change default stderr_reaction to log_last for executable UDFs`
 - Good: `Fix exception when inserting NULL into non-nullable column via CAST`

--- a/.claude/skills/clickhouse-pr-description/SKILL.md
+++ b/.claude/skills/clickhouse-pr-description/SKILL.md
@@ -14,8 +14,11 @@ Generate a good PR description and apply it, with optional confirmation based on
 
 Plain description of what changed. No prefix conventions like `fix():` or `feat():`.
 
+**Exception — `.claude/` changes:** when the PR only touches files under `.claude/` (settings, tools, skills, instructions, etc.), prefix the title with `claude: `. Example: `claude: add fetch_ci_report.js to allowed commands`.
+
 - Good: `Change default stderr_reaction to log_last for executable UDFs`
 - Good: `Fix exception when inserting NULL into non-nullable column via CAST`
+- Good: `claude: allow fetch_ci_report.js and grep in Claude Code settings`
 - Bad: `fix(udf): Change default stderr_reaction` — conventional commits, ClickHouse doesn't use them
 - Bad: `Fuzzer fixes` — too vague, tells the reviewer nothing
 - Bad: `Improve error handling and enrich exit code exceptions with stderr context` — too vague, doesn't say what was actually changed

--- a/.claude/skills/clickhouse-pr-description/SKILL.md
+++ b/.claude/skills/clickhouse-pr-description/SKILL.md
@@ -14,7 +14,7 @@ Generate a good PR description and apply it, with optional confirmation based on
 
 Plain description of what changed. No prefix conventions like `fix():` or `feat():`.
 
-**Exception — `.claude/` changes:** when the PR only touches files under `.claude/` (settings, tools, skills, instructions, etc.), prefix the title with `claude: ` and use the `Documentation (changelog entry is not required)` changelog category. Example: `claude: add fetch_ci_report.js to allowed commands`.
+**Exception — `.claude/` changes:** when the PR only touches files under `.claude/` (settings, tools, skills, instructions, etc.), prefix the title with `claude: ` and use the `Not for changelog (changelog entry is not required)` changelog category. Example: `claude: add fetch_ci_report.js to allowed commands`.
 
 - Good: `Change default stderr_reaction to log_last for executable UDFs`
 - Good: `Fix exception when inserting NULL into non-nullable column via CAST`


### PR DESCRIPTION
Adds a convention to the `clickhouse-pr-description` skill: when a PR only touches files under `.claude/` (settings, tools, skills, instructions, etc.), prefix the title with `claude:`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.550`
<!-- ch-version-info:end -->