### PR TITLE
Add test: Positive overflow branch of `max_streams_to_max_threads_ratio` check untested (existing test only covers negative)

### DIFF
--- a/tests/queries/0_stateless/04201_max_streams_to_max_threads_ratio_positive_overflow.sql
+++ b/tests/queries/0_stateless/04201_max_streams_to_max_threads_ratio_positive_overflow.sql
@@ -1,0 +1,21 @@
+-- Test: exercises `max_streams * max_streams_to_max_threads_ratio` POSITIVE overflow path.
+-- Covers: src/Interpreters/InterpreterSelectQuery.cpp:2798-2806 (legacy planner) and
+--         src/Planner/PlannerJoinTree.cpp:848-856 (new analyzer).
+-- The existing test 03148 only covers the NEGATIVE overflow path
+-- (max_streams_to_max_threads_ratio = -9223372036854775808 -> x < lowest()).
+-- This test covers the POSITIVE overflow path (x > size_t::max()) which was the
+-- ORIGINAL AST fuzzer crash: "inf is outside the range of representable values of type 'unsigned long'".
+DROP TABLE IF EXISTS test_pos_overflow;
+CREATE TABLE test_pos_overflow
+(
+    id UInt64,
+    value String
+) ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO test_pos_overflow VALUES (0, 'Value_0');
+
+SELECT * FROM test_pos_overflow SETTINGS max_threads = 1025, max_streams_to_max_threads_ratio = 1e30, enable_analyzer = 1; -- { serverError PARAMETER_OUT_OF_BOUND }
+
+SELECT * FROM test_pos_overflow SETTINGS max_threads = 1025, max_streams_to_max_threads_ratio = 1e30, enable_analyzer = 0; -- { serverError PARAMETER_OUT_OF_BOUND }
+
+DROP TABLE test_pos_overflow;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #61248](https://github.com/ClickHouse/ClickHouse/pull/61248) (merged 2024-03-13). Confirmed on current codebase — close with a note if already fixed._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #61248](https://github.com/ClickHouse/ClickHouse/pull/61248).
 That PR PR 61248 fixes a UBSan runtime error in `InterpreterSelectQuery::executeFetchColumns` where `max_streams * settings.max_streams_to_max_threads_ratio` could produce `inf` (when computed in float) which then UB-faulted on `static_cast<size_t>`. The fix wraps the multiplication in a bounds check that t

**1. Positive overflow branch of `max_streams_to_max_threads_ratio` check untested (existing test only covers negative)**
  `src/Interpreters/InterpreterSelectQuery.cpp:2798`, `src/Planner/PlannerJoinTree.cpp:849`
  **Risk:** Call chain: `InterpreterSelectQuery::executeFetchColumns` (or `PlannerJoinTree::buildQueryPlanForTableExpression`) computes `streams_with_ratio = static_cast<double>(max_streams) * settings[Setting::m
  **What's unique vs PR tests:** The PR (and the trunk follow-up that introduced `canConvertTo<size_t>`) shipped only the existing test `03148_setting_max_streams_to_max_threads_ratio_overflow.sql`, which covers ONLY negative-overflo
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/56ea6520-97e7-4841-afb5-f8920a6ebe72)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.428`
<!-- ch-version-info:end -->