### PR TITLE
Add test: `ASTShowCreateDatabaseQuery::clone` and `ASTExistsDatabaseQuery::clone` overrides not exercised by any stateless fuzzer test

### DIFF
--- a/tests/queries/0_stateless/04201_ast_fuzzer_show_create_database.reference
+++ b/tests/queries/0_stateless/04201_ast_fuzzer_show_create_database.reference
@@ -1,0 +1,3 @@
+CREATE DATABASE default
+ENGINE = Atomic
+1

--- a/tests/queries/0_stateless/04201_ast_fuzzer_show_create_database.sql
+++ b/tests/queries/0_stateless/04201_ast_fuzzer_show_create_database.sql
@@ -1,0 +1,14 @@
+-- Tags: no-fasttest
+
+-- Test: exercises the clone() overrides on `ASTShowCreateDatabaseQuery` and `ASTExistsDatabaseQuery`
+-- by enabling the AST fuzzer, which calls clone() on the AST before mutating and re-formatting.
+-- Without the overrides (added by PR #61269), clone() would slice the AST to the parent template
+-- `ASTQueryWithTableAndOutputImpl<...>` whose formatQueryImpl chassert's on `table != nullptr`
+-- (these queries only set `database`, not `table`) — the original fuzzer crash described in the PR.
+-- Covers: src/Parsers/TablePropertiesQueriesASTs.h — ASTShowCreateDatabaseQuery::clone, ASTExistsDatabaseQuery::clone
+
+SET ast_fuzzer_runs = 5;
+SET send_logs_level = 'fatal';
+
+SHOW CREATE DATABASE default FORMAT TabSeparatedRaw;
+EXISTS DATABASE default;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #61269](https://github.com/ClickHouse/ClickHouse/pull/61269) (merged 2024-03-13). Confirmed on current codebase — close with a note if already fixed._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #61269](https://github.com/ClickHouse/ClickHouse/pull/61269).
 That PR PR #61269 fixes two bugs related to `SHOW CREATE DATABASE`: (1) `DatabaseOverlay::getCreateDatabaseQuery` returned an empty `ASTCreateQuery` causing crashes/garbled output for overlay databases (used in clickhouse-local for the `default` database). PR sets the database name on the ASTCreateQuery so 

**1. `ASTShowCreateDatabaseQuery::clone` and `ASTExistsDatabaseQuery::clone` overrides not exercised by any stateless fuzzer test**
  `src/Parsers/TablePropertiesQueriesASTs.h:87`, `src/Parsers/TablePropertiesQueriesASTs.h:109`
  **Risk:** Call chain: `executeQuery` → `executeASTFuzzerQueries` (when `ast_fuzzer_runs > 0`) → `base_ast->clone()` at `executeQuery.cpp:2107` → derived `clone()` in `TablePropertiesQueriesASTs.h:87` (Exists) a
  **What's unique vs PR tests:** PR test (03009_format_show_database.sh) only covers the `DatabaseOverlay::getCreateDatabaseQuery` fix via `clickhouse-local`. It does NOT enable the AST fuzzer, so the new `ASTShowCreateDatabaseQuery:
  **Tags:** `-- Tags: no-fasttest` — `no-fasttest`: Mirrors existing AST-fuzzer test (03833_server_ast_fuzzer.sql), which is also tagged no-fasttest because the AST fuzzer relies on the full QueryFuzzer machinery.
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/6c789bd2-d8b6-4fd2-ae69-bffd2eb95ef1)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)