### PR TITLE
Add long tag to 00446_clear_column_in_partition_concurrent_zookeeper

### DIFF
--- a/tests/queries/0_stateless/00446_clear_column_in_partition_concurrent_zookeeper.sh
+++ b/tests/queries/0_stateless/00446_clear_column_in_partition_concurrent_zookeeper.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Tags: zookeeper, no-replicated-database, no-shared-merge-tree
+# Tags: long, zookeeper, no-replicated-database, no-shared-merge-tree
+# Tag long: concurrent CLEAR COLUMN + INSERT race test exceeds 180s flaky-check
+# budget under contention; flaky-check enforces TEST_MAX_RUN_TIME_IN_SECONDS
+# only for tests without the `long` tag (see tests/clickhouse-test).
 # Tag no-replicated-database: Old syntax is not allowed
 # no-shared-merge-tree -- old syntax
 


### PR DESCRIPTION
The test exercises concurrent `CLEAR COLUMN IN PARTITION` against a two-replica `ReplicatedMergeTree` with `replication_alter_partitions_sync=2`. Each iteration issues four sync `ALTER`s plus background inserts, and ZooKeeper round-trips serialize behind replica acks. Under flaky-check (which serially re-runs the same test 50x with randomized settings), the cumulative runtime regularly exceeds 180s.

The runner enforces `TEST_MAX_RUN_TIME_IN_SECONDS = 180` in flaky-check mode and fails the test with `TOO_LONG` unless the `long` tag is present (`tests/clickhouse-test`, lines 3067-3083). The runner's own intent at the `no-long` skip site states: "Tests for races and deadlocks usually are run in a loop for a significant amount of time" — which is exactly what this test is.

CIDB shows 218 of 231 failures over the last 30 days are this exact pattern (`Reason: Test runs too long (> 180s). Make it faster.`) in `Stateless tests (*, flaky check)` jobs across 24 distinct PRs. PR #102394 already reduced the loop from 10 to 5 iterations (April 10), which proved insufficient — failures continued April 28-30 including one master hit on `Stateless tests (arm_asan_ubsan, azure, parallel)`.

Adding the `long` tag is the documented fix for this class of test and what PR #96130 author also applied locally on their branch (commit `b413b3be5a36`). The change preserves test intent (same loop count, same concurrent ops, same assertions) and only bypasses the 180s flaky-check budget check.

CIDB: https://play.clickhouse.com/?user=play&query=SELECT+check_start_time%2C+pull_request_number%2C+check_name%2C+substring%28test_context_raw%2C+1%2C+200%29+as+err+FROM+default.checks+WHERE+test_name+LIKE+%2700446_clear_column_in_partition_concurrent_zookeeper%25%27+AND+test_status+IN+%28%27FAIL%27%2C+%27ERROR%27%29+AND+check_start_time+%3E+now%28%29+-+INTERVAL+30+DAY+ORDER+BY+check_start_time+DESC+LIMIT+30+FORMAT+TabSeparatedWithNames

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.253`
<!-- ch-version-info:end -->