### PR TITLE
Add test: `addMilliseconds`/`addMicroseconds`/`addNanoseconds` (and subtract counterparts) untested with `DateTime64` + timezone (3-arg form)

### DIFF
--- a/tests/queries/0_stateless/04201_add_subtract_subsecond_with_timezone.reference
+++ b/tests/queries/0_stateless/04201_add_subtract_subsecond_with_timezone.reference
@@ -1,0 +1,6 @@
+2024-01-01 08:00:00.010	DateTime64(3, \'Asia/Shanghai\')
+2024-01-01 08:00:00.000010	DateTime64(6, \'Asia/Shanghai\')
+2024-01-01 08:00:00.000000010	DateTime64(9, \'Asia/Shanghai\')
+2024-01-01 07:59:59.990	DateTime64(3, \'Asia/Shanghai\')
+2024-01-01 07:59:59.999990	DateTime64(6, \'Asia/Shanghai\')
+2024-01-01 07:59:59.999999990	DateTime64(9, \'Asia/Shanghai\')

--- a/tests/queries/0_stateless/04201_add_subtract_subsecond_with_timezone.sql
+++ b/tests/queries/0_stateless/04201_add_subtract_subsecond_with_timezone.sql
@@ -1,0 +1,14 @@
+-- Test: exercises `addMilliseconds`/`addMicroseconds`/`addNanoseconds` and subtract counterparts
+-- with `DateTime64` + timezone argument (3-arg form).
+-- Covers: src/Functions/FunctionDateOrDateTimeAddInterval.h:814 — `!WhichDataType(arguments[0].type).isDateTimeOrDateTime64()`
+-- The PR widened the check from `isDateTime` to `isDateTimeOrDateTime64`, allowing
+-- `DateTime64` as the 1st argument when a timezone is given. The PR's own tests cover
+-- `addYears`/`Months`/`Weeks`/`Days`/`Hours`/`Minutes`/`Seconds`/`Quarters` and subtract* counterparts.
+-- The subsecond variants below share the same `getReturnTypeImpl` path but are NOT tested
+-- with the 3-arg form anywhere in the test suite.
+SELECT addMilliseconds(toDateTime64('2024-01-01 00:00:00', 3, 'UTC'), 10, 'Asia/Shanghai') AS v, toTypeName(v);
+SELECT addMicroseconds(toDateTime64('2024-01-01 00:00:00', 6, 'UTC'), 10, 'Asia/Shanghai') AS v, toTypeName(v);
+SELECT addNanoseconds(toDateTime64('2024-01-01 00:00:00', 9, 'UTC'), 10, 'Asia/Shanghai') AS v, toTypeName(v);
+SELECT subtractMilliseconds(toDateTime64('2024-01-01 00:00:00', 3, 'UTC'), 10, 'Asia/Shanghai') AS v, toTypeName(v);
+SELECT subtractMicroseconds(toDateTime64('2024-01-01 00:00:00', 6, 'UTC'), 10, 'Asia/Shanghai') AS v, toTypeName(v);
+SELECT subtractNanoseconds(toDateTime64('2024-01-01 00:00:00', 9, 'UTC'), 10, 'Asia/Shanghai') AS v, toTypeName(v);


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #61561](https://github.com/ClickHouse/ClickHouse/pull/61561) (merged 2024-03-21). Confirmed on current codebase — close with a note if already fixed._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #61561](https://github.com/ClickHouse/ClickHouse/pull/61561).
 That PR PR widens type check at `FunctionDateOrDateTimeAddInterval.h`:814 from `WhichDataType(arguments[0].type).isDateTime()` to `isDateTimeOrDateTime64()`, fixing the case where `addDays`/etc. would throw 'Illegal type DateTime64' when called with three arguments (DateTime64, delta, timezone). The fix aff

**1. `addMilliseconds`/`addMicroseconds`/`addNanoseconds` (and subtract counterparts) untested with `DateTime64` + timezone (3-arg form)**
  `src/Functions/FunctionDateOrDateTimeAddInterval.h:814`, `src/Functions/FunctionDateOrDateTimeAddInterval.h:825`
  **Risk:** Call chain: `FunctionDateOrDateTimeAddInterval::getReturnTypeImpl` at `FunctionDateOrDateTimeAddInterval.h`:799 → `arguments.size() == 3` else-branch at line 813 → `WhichDataType(arguments[0].type).is
  **What's unique vs PR tests:** PR's `03013_addDays_with_timezone.sql` covers only `addDays`. PR's update to `00921_datetime64_compatibility_long.reference` covers `add/subtract Years/Months/Weeks/Days/Hours/Minutes/Seconds/Quarters
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/2ca5c01f-ccc4-4e62-bb3f-cd86e1f8a496)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.675`
<!-- ch-version-info:end -->