### PR TITLE
support three-valued logic in SelectivityEstimator

### DIFF
--- a/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
@@ -107,10 +107,10 @@ RelationProfile ConditionSelectivityEstimator::estimateRelationProfileImpl(std::
                     right_element->finalize(column_estimators, metadata);
                     /// P(c1 and c2) = P(c1) * P(c2)
                     if (element.function == RPNElement::FUNCTION_AND)
-                        element.selectivity = left_element->selectivity * right_element->selectivity;
+                        element.selectivity = left_element->selectivity.applyAnd(right_element->selectivity);
                     /// P(c1 or c2) = 1 - (1 - P(c1)) * (1 - P(c2))
                     else
-                        element.selectivity = 1-(1-left_element->selectivity)*(1-right_element->selectivity);
+                        element.selectivity = left_element->selectivity.applyOr(right_element->selectivity);
                     element.finalized = true;
                     rpn_stack.push(&element);
                 }
@@ -120,7 +120,7 @@ RelationProfile ConditionSelectivityEstimator::estimateRelationProfileImpl(std::
             {
                 auto* last_element = rpn_stack.top();
                 if (last_element->finalized)
-                    last_element->selectivity = 1 - last_element->selectivity;
+                    last_element->selectivity = last_element->selectivity.applyNot();
                 else
                 {
                     std::swap(last_element->column_ranges, last_element->column_not_ranges);
@@ -145,7 +145,7 @@ RelationProfile ConditionSelectivityEstimator::estimateRelationProfileImpl(std::
     auto * final_element = rpn_stack.top();
     final_element->finalize(column_estimators, metadata);
     RelationProfile result;
-    Float64 final_rows = final_element->selectivity * static_cast<Float64>(total_rows);
+    Float64 final_rows = final_element->selectivity.true_sel * static_cast<Float64>(total_rows);
     /// Clamp to [0, total_rows] and handle NaN/Inf to avoid undefined behavior
     /// in the float-to-UInt64 cast below (UBSAN float-cast-overflow).
     if (!std::isfinite(final_rows) || final_rows < 0)
@@ -221,14 +221,14 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
             /// LIKE/ILIKE cannot be represented as a range. Pre-set selectivity
             /// so the estimator uses a tighter default than `default_unknown_cond_factor`.
             if (func_name == "like" || func_name == "ilike")
-                out.selectivity = default_like_factor;
+                out.selectivity.true_sel = default_like_factor;
             else if (func_name == "notLike" || func_name == "notILike")
-                out.selectivity = 1.0 - default_like_factor;
+                out.selectivity.true_sel = 1.0 - default_like_factor;
             else if (func_name == "__applyFilter")
             {
                 /// Runtime join filter. Selectivity 1.0 keeps it last in prewhere ordering
                 /// (after cheaper column predicates) and neutral for join reorder estimates.
-                out.selectivity = 1.0;
+                out.selectivity.true_sel = 1.0;
             }
             else
                 return false;
@@ -323,11 +323,11 @@ bool ConditionSelectivityEstimator::extractAtomFromTree(const StorageMetadataPtr
                     /// Skip range analysis to avoid bad cast when merging ranges of incompatible Field types.
                     /// Pre-set selectivity based on the function type so prewhere ordering is still reasonable.
                     if (func_name == "equals" || func_name == "in")
-                        out.selectivity = default_cond_equal_factor;
+                        out.selectivity.true_sel = default_cond_equal_factor;
                     else if (func_name == "notEquals" || func_name == "notIn")
-                        out.selectivity = 1.0 - default_cond_equal_factor;
+                        out.selectivity.true_sel = 1.0 - default_cond_equal_factor;
                     else /// less, greater, lessOrEquals, greaterOrEquals
-                        out.selectivity = default_cond_range_factor;
+                        out.selectivity.true_sel = default_cond_range_factor;
                     out.finalized = true;
                     return false;
                 }
@@ -459,10 +459,35 @@ ConditionSelectivityEstimatorPtr ConditionSelectivityEstimatorBuilder::getEstima
     return has_data ? estimator : nullptr;
 }
 
-Float64 ConditionSelectivityEstimator::ColumnEstimator::estimateRanges(const PlainRanges & ranges) const
+ConditionSelectivityEstimator::Selectivity ConditionSelectivityEstimator::Selectivity::applyNot() const
+{
+    return {1.0 - true_sel - null_sel, null_sel};
+}
+
+ConditionSelectivityEstimator::Selectivity ConditionSelectivityEstimator::Selectivity::applyOr(const Selectivity & other) const
+{
+    /// case1 : NULL or (false/NULL) = NULL
+    /// case2 : false or NULL = NULL
+    /// case1 : true or (...) = true
+    /// case2 : false/NULL or true = true
+    return {
+        true_sel + (1 - true_sel) * other.true_sel,
+        null_sel * (1 - other.true_sel) + (1 - null_sel - true_sel) * other.null_sel,
+    };
+}
+
+ConditionSelectivityEstimator::Selectivity ConditionSelectivityEstimator::Selectivity::applyAnd(const Selectivity & other) const
+{
+    return {
+        true_sel * other.true_sel,
+        null_sel * (other.true_sel + other.null_sel) + true_sel * other.null_sel,
+    };
+}
+
+ConditionSelectivityEstimator::Selectivity ConditionSelectivityEstimator::ColumnEstimator::estimateRanges(const PlainRanges & ranges) const
 {
     if (stats->getNumRows() == 0)
-        return 0;
+        return {0, 0};
     Float64 result = 0;
     for (const Range & range : ranges.ranges)
     {
@@ -473,19 +498,11 @@ Float64 ConditionSelectivityEstimator::ColumnEstimator::estimateRanges(const Pla
         else
             result += static_cast<Float64>(stats->getNonNullRowCount()) * default_cond_range_factor;
     }
-    Float64 selectivity = result / static_cast<Float64>(stats->getNumRows());
+    Float64 rows = static_cast<Float64>(stats->getNumRows());
+    Float64 selectivity = result / rows;
     /// Clamp to [0, 1]. Selectivity can exceed 1 when summing estimates across
     /// multiple ranges (e.g. IN with many values) that together exceed total rows.
-    return std::max(0.0, std::min(1.0, selectivity));
-}
-
-Float64 ConditionSelectivityEstimator::ColumnEstimator::estimateNotRanges(const PlainRanges & ranges) const
-{
-    if (stats->getNumRows() == 0)
-        return 0;
-    Float64 null_selectivity = 1.0 - static_cast<Float64>(stats->getNonNullRowCount()) / static_cast<Float64>(stats->getNumRows());
-    Float64 ranges_selectivity = estimateRanges(ranges);
-    return std::max(0.0, std::min(1.0, 1.0 - ranges_selectivity - null_selectivity));
+    return {std::max(0.0, std::min(1.0, selectivity)), static_cast<Float64>(stats->getNullCount()) / rows};
 }
 
 UInt64 ConditionSelectivityEstimator::ColumnEstimator::estimateCardinality() const
@@ -646,7 +663,7 @@ void ConditionSelectivityEstimator::RPNElement::finalize(const ColumnEstimators 
 
     if (function == FUNCTION_UNKNOWN)
     {
-        selectivity = default_unknown_cond_factor;
+        selectivity = {default_unknown_cond_factor, 0};
         return;
     }
 
@@ -656,14 +673,14 @@ void ConditionSelectivityEstimator::RPNElement::finalize(const ColumnEstimators 
         for (const Range & range : ranges.ranges)
         {
             if (range.isInfinite())
-                return 1.0;
+                return Selectivity{1.0, 0.0};
 
             if (range.left == range.right)
                 equal_selectivity += default_cond_equal_factor;
             else
-                return default_cond_range_factor;
+                return Selectivity{default_cond_range_factor, 0};
         }
-        return std::min(equal_selectivity, 1.0);
+        return Selectivity{std::min(equal_selectivity, 1.0), 0};
     };
 
     auto get_estimator = [&](const String & column_name) -> const ColumnEstimator *
@@ -674,7 +691,7 @@ void ConditionSelectivityEstimator::RPNElement::finalize(const ColumnEstimators 
         return &it->second;
     };
 
-    std::unordered_map<String, Float64> estimate_results;
+    std::unordered_map<String, Selectivity> estimate_results;
     for (const auto & [column_name, ranges] : column_ranges)
     {
         if (const auto * est = get_estimator(column_name))
@@ -685,11 +702,11 @@ void ConditionSelectivityEstimator::RPNElement::finalize(const ColumnEstimators 
 
     for (const auto & [column_name, ranges] : column_not_ranges)
     {
-        Float64 not_ranges_selectivity;
+        Selectivity not_ranges_selectivity;
         if (const auto * est = get_estimator(column_name))
-            not_ranges_selectivity = est->estimateNotRanges(ranges);
+            not_ranges_selectivity = est->estimateRanges(ranges).applyNot();
         else
-            not_ranges_selectivity = 1.0 - estimate_unknown_ranges(ranges);
+            not_ranges_selectivity = estimate_unknown_ranges(ranges);
 
         auto it = estimate_results.find(column_name);
         if (it == estimate_results.end())
@@ -698,31 +715,22 @@ void ConditionSelectivityEstimator::RPNElement::finalize(const ColumnEstimators 
         }
         else if (function == FUNCTION_AND)
         {
-            it->second *= not_ranges_selectivity;
+            it->second = it->second.applyAnd(not_ranges_selectivity);
         }
         else /// FUNCTION_OR or FUNCTION_IN_RANGE
         {
-            it->second = 1.0 - (1.0 - it->second) * (1.0 - not_ranges_selectivity);
+            it->second = it->second.applyOr(not_ranges_selectivity);
         }
     }
 
     if (function == FUNCTION_AND)
     {
-        for (const auto & col : null_check_columns)
-        {
-            if (column_ranges.contains(col) || column_not_ranges.contains(col))
-            {
-                selectivity = 0;
-                return;
-            }
-        }
-
         /// x IS NULL AND x IS NOT NULL is a contradiction → selectivity = 0
         for (const auto & col : null_check_columns)
         {
             if (not_null_check_columns.contains(col))
             {
-                selectivity = 0;
+                selectivity = Selectivity();
                 return;
             }
         }
@@ -735,7 +743,7 @@ void ConditionSelectivityEstimator::RPNElement::finalize(const ColumnEstimators 
         {
             if (not_null_check_columns.contains(col))
             {
-                selectivity = 1;
+                selectivity = Selectivity(1, 0);
                 return;
             }
         }
@@ -749,39 +757,60 @@ void ConditionSelectivityEstimator::RPNElement::finalize(const ColumnEstimators 
         else
             cur_selectivity = default_cond_equal_factor;
 
-        estimate_results[column_name] += cur_selectivity;
+        if (!estimate_results.contains(column_name))
+        {
+            estimate_results.emplace(column_name, Selectivity{cur_selectivity, 0});
+        }
+        else if (function == FUNCTION_AND)
+        {
+            selectivity = Selectivity();
+            return;
+        }
+        else
+        {
+            Float64 is_true = std::min(1.0, estimate_results[column_name].true_sel + cur_selectivity);
+            estimate_results[column_name] = Selectivity(is_true, 0);
+        }
     }
 
     for (const auto & column_name : not_null_check_columns)
     {
-        if (function == FUNCTION_AND
-            && (estimate_results.contains(column_name)))
-            continue;
-
+        Float64 cur_selectivity;
         if (const auto * est = get_estimator(column_name))
-            estimate_results[column_name] = est->stats->estimateIsNotNull();
+            cur_selectivity = est->stats->estimateIsNotNull();
         else
-            estimate_results[column_name] = 1.0 - default_cond_equal_factor;
+            cur_selectivity = 1.0 - default_cond_equal_factor;
+
+        if (!estimate_results.contains(column_name))
+        {
+            estimate_results.emplace(column_name, Selectivity{cur_selectivity, 0});
+        }
+        else if (function == FUNCTION_OR)
+        {
+            estimate_results[column_name].true_sel = cur_selectivity;
+        }
     }
 
-    selectivity = 1.0;
+    if (function == FUNCTION_OR)
+        selectivity = Selectivity();
+    else
+        selectivity = Selectivity(1, 0);
     for (const auto & estimate_result : estimate_results)
     {
         if (function == FUNCTION_OR)
-            selectivity *= 1 - estimate_result.second;
+            selectivity = selectivity.applyOr(estimate_result.second);
         else
-            selectivity *= estimate_result.second;
+            selectivity = selectivity.applyAnd(estimate_result.second);
     }
-    if (function == FUNCTION_OR)
-        selectivity = 1 - selectivity;
 
     /// Clamp to valid probability range. Selectivity can exceed [0, 1] when
     /// estimateRanges() sums individual range estimates that together exceed the
     /// total row count (e.g. IN with many values and over-counting statistics),
     /// or become NaN from floating-point edge cases.
-    if (!std::isfinite(selectivity))
-        selectivity = default_unknown_cond_factor;
+    if (!std::isfinite(selectivity.true_sel))
+        selectivity.true_sel = default_unknown_cond_factor;
     else
-        selectivity = std::max(0.0, std::min(1.0, selectivity));
+        selectivity.true_sel = std::max(0.0, std::min(1.0, selectivity.true_sel));
 }
+
 }

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
@@ -789,6 +789,10 @@ void ConditionSelectivityEstimator::RPNElement::finalize(const ColumnEstimators 
         {
             estimate_results[column_name].true_sel = cur_selectivity;
         }
+        else
+        {
+            estimate_results[column_name].null_sel = 0;
+        }
     }
 
     if (function == FUNCTION_OR)

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
@@ -468,7 +468,7 @@ ConditionSelectivityEstimator::Selectivity ConditionSelectivityEstimator::Select
 {
     /// case1 : NULL or (false/NULL) = NULL
     /// case2 : false or NULL = NULL
-    /// case1 : true or (...) = true
+    /// case3 : true or (...) = true
     /// case2 : false/NULL or true = true
     return {
         true_sel + (1 - true_sel) * other.true_sel,

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
@@ -706,7 +706,7 @@ void ConditionSelectivityEstimator::RPNElement::finalize(const ColumnEstimators 
         if (const auto * est = get_estimator(column_name))
             not_ranges_selectivity = est->estimateRanges(ranges).applyNot();
         else
-            not_ranges_selectivity = estimate_unknown_ranges(ranges);
+            not_ranges_selectivity = estimate_unknown_ranges(ranges).applyNot();
 
         auto it = estimate_results.find(column_name);
         if (it == estimate_results.end())

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.h
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.h
@@ -34,6 +34,23 @@ class ConditionSelectivityEstimator : public WithContext
 {
     struct ColumnEstimator;
     using ColumnEstimators = std::unordered_map<String, ColumnEstimator>;
+    /// Selectivity of a SQL boolean predicate under three-valued logic (TRUE / NULL / FALSE).
+    /// `true_sel` is the fraction of rows where the predicate is TRUE (the usual "selectivity").
+    /// `null_sel` is the fraction of rows where the predicate is NULL (input column is NULL).
+    /// The FALSE fraction is implicitly `1 - true_sel - null_sel`.
+    struct Selectivity
+    {
+        Float64 true_sel;
+        Float64 null_sel;
+
+        Selectivity() : true_sel(0), null_sel(0) {}
+        explicit Selectivity(Float64 true_sel_) : true_sel(true_sel_), null_sel(0) {}
+        Selectivity(Float64 true_sel_, Float64 null_sel_) : true_sel(true_sel_), null_sel(null_sel_) {}
+        Selectivity applyNot() const;
+        Selectivity applyOr(const Selectivity & other) const;
+        Selectivity applyAnd(const Selectivity & other) const;
+    };
+
 
     friend class ConditionSelectivityEstimatorBuilder;
 public:
@@ -76,7 +93,7 @@ public:
         /// columns checked with IS NOT NULL predicate
         std::unordered_set<String> not_null_check_columns;
         bool finalized = false;
-        Float64 selectivity = 0;
+        Selectivity selectivity;
 
         bool tryToMergeClauses(RPNElement & lhs, RPNElement & rhs);
         void finalize(const ColumnEstimators & column_estimators_, const StorageMetadataPtr & metadata);
@@ -90,8 +107,7 @@ private:
     {
         ColumnStatisticsPtr stats;
 
-        Float64 estimateRanges(const PlainRanges & ranges) const;
-        Float64 estimateNotRanges(const PlainRanges & ranges) const;
+        Selectivity estimateRanges(const PlainRanges & ranges) const;
         UInt64 estimateCardinality() const;
     };
 

--- a/src/Storages/Statistics/Statistics.cpp
+++ b/src/Storages/Statistics/Statistics.cpp
@@ -275,7 +275,7 @@ UInt64 ColumnStatistics::getNullCount() const
 {
     auto it = stats.find(StatisticsType::NullCount);
     if (it == stats.end())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "getNullCount called but NullCount statistics not present");
+        return 0;
     return assert_cast<const StatisticsNullCount &>(*it->second).getNullCount();
 }
 

--- a/src/Storages/Statistics/Statistics.cpp
+++ b/src/Storages/Statistics/Statistics.cpp
@@ -273,10 +273,16 @@ Estimate ColumnStatistics::getEstimate() const
 
 UInt64 ColumnStatistics::getNullCount() const
 {
-    auto it = stats.find(StatisticsType::NullCount);
-    if (it == stats.end())
-        return 0;
-    return assert_cast<const StatisticsNullCount &>(*it->second).getNullCount();
+    if (auto it = stats.find(StatisticsType::NullCount); it != stats.end())
+        return assert_cast<const StatisticsNullCount &>(*it->second).getNullCount();
+    /// MinMax::row_count tracks only non-NULL rows, so the null count can be derived
+    /// as total rows minus MinMax row count when NullCount statistics are absent.
+    if (auto it = stats.find(StatisticsType::MinMax); it != stats.end())
+    {
+        UInt64 non_null = assert_cast<const StatisticsMinMax &>(*it->second).getRowCount();
+        return non_null <= rows ? rows - non_null : 0;
+    }
+    return 0;
 }
 
 UInt64 ColumnStatistics::getNonNullRowCount() const
@@ -299,8 +305,8 @@ Float64 ColumnStatistics::estimateIsNull() const
 {
     if (rows == 0)
         return 0.0;
-    if (stats.contains(StatisticsType::NullCount))
-        return static_cast<Float64>(std::min(getNullCount(), rows)) / static_cast<Float64>(rows);
+    if (stats.contains(StatisticsType::NullCount) || stats.contains(StatisticsType::MinMax))
+        return static_cast<Float64>(getNullCount()) / static_cast<Float64>(rows);
     return ConditionSelectivityEstimator::default_cond_equal_factor;
 }
 
@@ -308,7 +314,7 @@ Float64 ColumnStatistics::estimateIsNotNull() const
 {
     if (rows == 0)
         return 0.0;
-    if (stats.contains(StatisticsType::NullCount))
+    if (stats.contains(StatisticsType::NullCount) || stats.contains(StatisticsType::MinMax))
         return static_cast<Float64>(getNonNullRowCount()) / static_cast<Float64>(rows);
     return 1.0 - ConditionSelectivityEstimator::default_cond_equal_factor;
 }

--- a/src/Storages/Statistics/tests/gtest_stats.cpp
+++ b/src/Storages/Statistics/tests/gtest_stats.cpp
@@ -653,7 +653,7 @@ TEST(Statistics, DeserializeV3ThrowsOnOversizedStat)
     EXPECT_THROW(ColumnStatistics::deserialize(mod_read_buf, data_type), DB::Exception);
 }
 
-TEST(Statistics, NullableEstimator)
+TEST(Statistics, NullableEstimatorWithMinMax)
 {
     /// Two nullable columns with range, IS NULL, and IS NOT NULL predicates.
     ///
@@ -666,8 +666,8 @@ TEST(Statistics, NullableEstimator)
     ///   b: estimateLess/Greater(500) = 450.0 exactly
     tryRegisterFunctions();
 
-    auto stats_a = buildNullableInt32Stats({StatisticsType::NullCount, StatisticsType::MinMax}, 1000, 5);
-    auto stats_b = buildNullableInt32Stats({StatisticsType::NullCount, StatisticsType::MinMax}, 1000, 10);
+    auto stats_a = buildNullableInt32Stats({StatisticsType::MinMax}, 1000, 5);
+    auto stats_b = buildNullableInt32Stats({StatisticsType::MinMax}, 1000, 10);
     ASSERT_EQ(stats_a->getNonNullRowCount(), 800u);
     ASSERT_EQ(stats_b->getNonNullRowCount(), 900u);
 

--- a/src/Storages/Statistics/tests/gtest_stats.cpp
+++ b/src/Storages/Statistics/tests/gtest_stats.cpp
@@ -752,7 +752,7 @@ TEST(Statistics, NullableEstimator)
     check("a IS NOT NULL AND a > 500 AND b IS NULL", 40.0, 2.0);
 
     /// Contradictions spanning two columns
-    check("a > 500 AND b > 500 AND b IS NULL",  0.0, 1e-6);  /// b > 500 contradicts b IS NULL
+    check("a > 500 AND b > 500 AND b IS NULL", 0.0, 1e-6);  /// b > 500 contradicts b IS NULL
     check("a IS NULL AND a > 500 AND b IS NULL", 0.0, 1e-6); /// a IS NULL contradicts a > 500
 }
 

--- a/src/Storages/Statistics/tests/gtest_stats.cpp
+++ b/src/Storages/Statistics/tests/gtest_stats.cpp
@@ -653,6 +653,109 @@ TEST(Statistics, DeserializeV3ThrowsOnOversizedStat)
     EXPECT_THROW(ColumnStatistics::deserialize(mod_read_buf, data_type), DB::Exception);
 }
 
+TEST(Statistics, NullableEstimator)
+{
+    /// Two nullable columns with range, IS NULL, and IS NOT NULL predicates.
+    ///
+    /// column a: Nullable(Int32), 1000 rows, every 5th NULL → 200 NULLs, 800 non-NULLs in [1,999]
+    /// column b: Nullable(Int32), 1000 rows, every 10th NULL → 100 NULLs, 900 non-NULLs in [1,999]
+    ///
+    /// MinMax formulas (min=1, max=999):
+    ///   estimateLess(500) = 499/998 * non_null = non_null/2 exactly (since 499*2==998)
+    ///   a: estimateLess/Greater(500) = 400.0 exactly
+    ///   b: estimateLess/Greater(500) = 450.0 exactly
+    tryRegisterFunctions();
+
+    auto stats_a = buildNullableInt32Stats({StatisticsType::NullCount, StatisticsType::MinMax}, 1000, 5);
+    auto stats_b = buildNullableInt32Stats({StatisticsType::NullCount, StatisticsType::MinMax}, 1000, 10);
+    ASSERT_EQ(stats_a->getNonNullRowCount(), 800u);
+    ASSERT_EQ(stats_b->getNonNullRowCount(), 900u);
+
+    ConditionSelectivityEstimatorBuilder builder(getContext().context);
+    builder.addStatistics("a", stats_a);
+    builder.addStatistics("b", stats_b);
+    builder.incrementRowCount(1000);
+    auto estimator = builder.getEstimator();
+
+    auto check = [&](const String & expression, Float64 expected, Float64 eps)
+    {
+        Float64 actual = estimateRows(estimator, expression);
+        EXPECT_NEAR(actual, expected, eps) << "Expression: " << expression;
+    };
+
+    /// Single column — plain ranges
+    check("a > 500",       400.0, 1.0);
+    check("a < 500",       400.0, 1.0);
+    check("b > 500",       450.0, 1.0);
+    check("b < 500",       450.0, 1.0);
+
+    /// Single column — IS NULL / IS NOT NULL
+    check("a IS NULL",     200.0, 1e-6);
+    check("a IS NOT NULL", 800.0, 1e-6);
+    check("b IS NULL",     100.0, 1e-6);
+    check("b IS NOT NULL", 900.0, 1e-6);
+
+    /// Single column — IS NULL AND range → contradiction
+    check("a IS NULL AND a > 500", 0.0, 1e-6);
+    check("b IS NULL AND b < 500", 0.0, 1e-6);
+
+    /// Single column — IS NULL OR range → null rows ∪ matching range rows
+    check("a IS NULL OR a > 500", 600.0, 1.0);   /// 200 + 400
+    check("b IS NULL OR b < 500", 550.0, 1.0);   /// 100 + 450
+
+    /// Single column — IS NOT NULL AND range → equals the range (implied)
+    check("a IS NOT NULL AND a > 500", 400.0, 1.0);
+    check("b IS NOT NULL AND b < 500", 450.0, 1.0);
+
+    /// Single column — IS NOT NULL OR range → IS NOT NULL dominates
+    check("a IS NOT NULL OR a > 500", 800.0, 1.0);
+    check("b IS NOT NULL OR b < 500", 900.0, 1.0);
+
+    /// Cross-column — range AND range (independent columns)
+    /// P = 0.4 * 0.45 = 0.18
+    check("a > 500 AND b > 500", 180.0, 2.0);
+
+    /// Cross-column — range OR range
+    /// P = 1 - (1-0.4)*(1-0.45) = 1 - 0.33 = 0.67
+    check("a > 500 OR b > 500", 670.0, 2.0);
+
+    /// Cross-column — IS NULL AND range (different columns, independent)
+    /// P = P(a IS NULL) * P(b > 500) = 0.2 * 0.45 = 0.09
+    check("a IS NULL AND b > 500", 90.0, 2.0);
+
+    /// Cross-column — IS NULL OR range
+    /// P = 1 - P(a IS NOT NULL) * P(b <= 500) = 1 - 0.8 * 0.55 = 0.56
+    check("a IS NULL OR b > 500", 560.0, 2.0);
+
+    /// Cross-column — IS NULL AND IS NULL
+    /// P = 0.2 * 0.1 = 0.02
+    check("a IS NULL AND b IS NULL", 20.0, 2.0);
+
+    /// Cross-column — IS NULL OR IS NULL
+    /// P = 1 - 0.8 * 0.9 = 0.28
+    check("a IS NULL OR b IS NULL", 280.0, 2.0);
+
+    /// Cross-column — IS NOT NULL AND IS NOT NULL
+    /// P = 0.8 * 0.9 = 0.72
+    check("a IS NOT NULL AND b IS NOT NULL", 720.0, 2.0);
+
+    /// Cross-column — IS NOT NULL AND IS NULL (different columns)
+    /// P = 0.8 * 0.1 = 0.08
+    check("a IS NOT NULL AND b IS NULL", 80.0, 2.0);
+
+    /// Cross-column — range AND IS NULL (different columns)
+    /// P = P(a > 500) * P(b IS NULL) = 0.4 * 0.1 = 0.04
+    check("a > 500 AND b IS NULL", 40.0, 2.0);
+
+    /// Cross-column — IS NOT NULL AND range on same column, combined with IS NULL on other
+    /// a IS NOT NULL AND a > 500 → same as a > 500 (P=0.4); then AND b IS NULL (P=0.1)
+    check("a IS NOT NULL AND a > 500 AND b IS NULL", 40.0, 2.0);
+
+    /// Contradictions spanning two columns
+    check("a > 500 AND b > 500 AND b IS NULL",  0.0, 1e-6);  /// b > 500 contradicts b IS NULL
+    check("a IS NULL AND a > 500 AND b IS NULL", 0.0, 1e-6); /// a IS NULL contradicts a > 500
+}
+
 TEST(Statistics, LikeSelectivity)
 {
     /// Build a simple estimator to test LIKE / NOT LIKE / ILIKE / NOT ILIKE

--- a/src/Storages/Statistics/tests/gtest_stats.cpp
+++ b/src/Storages/Statistics/tests/gtest_stats.cpp
@@ -413,6 +413,7 @@ TEST(Statistics, NullPredicateEstimates)
 
     auto check = [&](const String & expression, Float64 expected_rows, Float64 eps)
     {
+        std::cout << "check: " << expression << std::endl;
         Float64 actual = estimateRows(estimator, expression);
         EXPECT_NEAR(actual, expected_rows, eps)
             << "Expression: " << expression
@@ -440,6 +441,7 @@ TEST(Statistics, NullPredicateEstimates)
     check("x IS NOT NULL",         50.0, 2.0);
     check("x IS NOT NULL OR x < 50",         50.0, 2.0);
     check("not x < 50",         25.0, 2.0);
+    check("not (x IS NOT NULL AND x < 50)",         75.0, 2.0);
     check("x IS NULL OR not x < 50",         75.0, 2.0);
 
     /// Plain range — must not include NULL rows.


### PR DESCRIPTION
Follow up https://github.com/ClickHouse/ClickHouse/pull/102356

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed selectivity estimation for nullable columns: `x IS NULL OR x > 50 OR y IS NULL `,                                                                                                                     and similar predicates now correctly follow SQL three-valued logic and exclude NULL rows                                                                                                                        from the TRUE selectivity.                                                                                                                            


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.512`
<!-- ch-version-info:end -->