### PR TITLE
Use oversize arena feature of `jemalloc` to reduce page faults

### DIFF
--- a/contrib/jemalloc-cmake/CMakeLists.txt
+++ b/contrib/jemalloc-cmake/CMakeLists.txt
@@ -44,7 +44,7 @@ if (OS_LINUX)
     # Increasing from default 6(64x) to 8(256x) allows these coalesced blocks to be split and reused.
     # See: https://github.com/ClickHouse/ClickHouse/pull/80245
     # https://github.com/jemalloc/jemalloc/pull/2842
-    set (JEMALLOC_CONFIG_MALLOC_CONF "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:0,dirty_decay_ms:5000,prof:true,prof_active:true,prof_thread_active_init:false,background_thread:true,lg_extent_max_active_fit:8")
+    set (JEMALLOC_CONFIG_MALLOC_CONF "percpu_arena:percpu,oversize_threshold:67108864,muzzy_decay_ms:0,dirty_decay_ms:5000,prof:true,prof_active:true,prof_thread_active_init:false,background_thread:true,lg_extent_max_active_fit:8")
 else()
     # For non-Linux systems, percpu_arena and background_thread are assumed to be not supported by jemalloc.
     # These two settings directly affect arena purging frequency and predictability:


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use oversize arena feature of jemalloc to reduce page faults.

---

More details [below](https://github.com/ClickHouse/ClickHouse/pull/103958#issuecomment-4407915188).

From the [docs](https://man.freebsd.org/cgi/man.cgi?jemalloc(3)):

```
	Note that requests with arena index specified via
	MALLOCX_ARENA, or threads associated
	with explicit arenas will not be considered.
```

so our custom arenas shouldn't be affected.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.758`
<!-- ch-version-info:end -->