### PR TITLE
Add test: `StorageSetOrJoinBase::restore` ascending file-order restore is untested by stateless SQL

### DIFF
--- a/tests/queries/0_stateless/04201_storage_join_restore_order_after_attach.reference
+++ b/tests/queries/0_stateless/04201_storage_join_restore_order_after_attach.reference
@@ -1,0 +1,6 @@
+before-detach	first
+before-detach	a_first
+after-attach	first
+after-attach	a_first
+last-row-before	third
+last-row-after	third

--- a/tests/queries/0_stateless/04201_storage_join_restore_order_after_attach.sql
+++ b/tests/queries/0_stateless/04201_storage_join_restore_order_after_attach.sql
@@ -1,4 +1,3 @@
--- Tags: no-parallel
 -- Test: exercises `StorageSetOrJoinBase::restore` priority_queue file ordering for `StorageJoin`
 -- Covers: src/Storages/StorageSet.cpp:286,308-312 — restore loads .bin files in ascending file_num order
 -- so that ANY-strictness Join keeps the FIRST inserted row per key after table reload (DETACH+ATTACH).

--- a/tests/queries/0_stateless/04201_storage_join_restore_order_after_attach.sql
+++ b/tests/queries/0_stateless/04201_storage_join_restore_order_after_attach.sql
@@ -1,0 +1,49 @@
+-- Tags: no-parallel
+-- Test: exercises `StorageSetOrJoinBase::restore` priority_queue file ordering for `StorageJoin`
+-- Covers: src/Storages/StorageSet.cpp:286,308-312 — restore loads .bin files in ascending file_num order
+-- so that ANY-strictness Join keeps the FIRST inserted row per key after table reload (DETACH+ATTACH).
+
+DROP TABLE IF EXISTS test_join_restore_order;
+
+-- ANY without join_any_take_last_row: first inserted row per key wins.
+-- Each separate INSERT creates a new .bin file (1.bin, 2.bin, 3.bin, ...).
+-- Before the fix, dir_it iteration order was filesystem-dependent so reload
+-- could produce a non-deterministic winner. After the fix the priority_queue
+-- restores ascending by file_num so the in-memory state is identical to the
+-- state right after inserts.
+CREATE TABLE test_join_restore_order (k UInt32, v String) ENGINE = Join(ANY, LEFT, k);
+
+INSERT INTO test_join_restore_order VALUES (1, 'first');
+INSERT INTO test_join_restore_order VALUES (1, 'second');
+INSERT INTO test_join_restore_order VALUES (1, 'third');
+INSERT INTO test_join_restore_order VALUES (2, 'a_first');
+INSERT INTO test_join_restore_order VALUES (2, 'b_second');
+
+SELECT 'before-detach', joinGet('test_join_restore_order', 'v', toUInt32(1));
+SELECT 'before-detach', joinGet('test_join_restore_order', 'v', toUInt32(2));
+
+DETACH TABLE test_join_restore_order;
+ATTACH TABLE test_join_restore_order;
+
+SELECT 'after-attach', joinGet('test_join_restore_order', 'v', toUInt32(1));
+SELECT 'after-attach', joinGet('test_join_restore_order', 'v', toUInt32(2));
+
+DROP TABLE test_join_restore_order;
+
+-- With join_any_take_last_row=1: last inserted row per key wins.
+-- The same restore-ordering fix must keep the in-memory result the same
+-- (last file processed = highest file_num = last INSERT) after reload.
+CREATE TABLE test_join_restore_order (k UInt32, v String) ENGINE = Join(ANY, LEFT, k) SETTINGS join_any_take_last_row = 1;
+
+INSERT INTO test_join_restore_order VALUES (1, 'first');
+INSERT INTO test_join_restore_order VALUES (1, 'second');
+INSERT INTO test_join_restore_order VALUES (1, 'third');
+
+SELECT 'last-row-before', joinGet('test_join_restore_order', 'v', toUInt32(1));
+
+DETACH TABLE test_join_restore_order;
+ATTACH TABLE test_join_restore_order;
+
+SELECT 'last-row-after', joinGet('test_join_restore_order', 'v', toUInt32(1));
+
+DROP TABLE test_join_restore_order;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #61972](https://github.com/ClickHouse/ClickHouse/pull/61972) (merged 2024-04-02). Confirmed on current codebase — close with a note if already fixed._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #61972](https://github.com/ClickHouse/ClickHouse/pull/61972).
 That PR PR #61972 fixes `StorageJoin`/`StorageSet` file-load ordering during `restore` so that the on-disk-and-reload result matches the in-memory result. Before the patch, `StorageSetOrJoinBase::restore` iterated `.bin` files in `disk->iterateDirectory` order, which is filesystem-dependent. With `Join(ANY,

**1. `StorageSetOrJoinBase::restore` ascending file-order restore is untested by stateless SQL**
  `src/Storages/StorageSet.cpp:286`, `src/Storages/StorageSet.cpp:308`
  **Risk:** Call chain: `ATTACH TABLE` → `StorageJoin` constructor (src/Storages/StorageJoin.cpp:89 `restore()`) → `StorageSetOrJoinBase::restore` (src/Storages/StorageSet.cpp:274) → `priority_queue.push({file_nu
  **What's unique vs PR tests:** PR's own tests are integration-only (test_async_load_databases, test_join_set_family_s3) which require docker + server restart. This stateless test exercises the same `StorageSetOrJoinBase::restore` p
  **Tags:** `-- Tags: no-parallel` — `no-parallel`: test uses fixed table name `test_join_restore_order` and DETACH/ATTACH which would conflict if multiple instances ran concurrently
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/eee15ff1-afca-4b6a-8623-ada11ff0131a)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1140` (included in `26.7` and later)
<!-- ch-version-info:end -->