### PR TITLE
Filter `Tuple element name 'null' is reserved` in upgrade check

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -344,6 +344,10 @@ cp /var/log/clickhouse-server/clickhouse-server.upgrade.log /test_output/clickho
 #       via regex in the secondary pipe below to require the `rdk:FAIL` tag AND the specific connection-refused
 #       message together, so real Kafka regressions (auth, protocol, config) that also emit `rdk:FAIL` are
 #       not masked.
+# `Tuple element name 'null' is reserved` appears because PR #98377 forbade Tuple element name `null` to avoid
+#       ambiguity with the Nullable null-map subcolumn name. Tables created by older release tests with columns
+#       like `Nullable(Tuple(\`null\` UInt32))` cannot be attached after upgrade. Narrowed to the exact reserved
+#       name so other "Tuple element name" diagnostics are not masked.
 echo "Check for Error messages in server log:"
 rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "Code: 236. DB::Exception: Cancelled mutating parts" \
@@ -412,6 +416,7 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "This engine is deprecated and is not supported in transactions" \
            -e "Prevent converting Nullable type to non-Nullable type inside mutation" \
            -e "e.what() = failed to parse response body" \
+           -e "Tuple element name 'null' is reserved" \
     /test_output/clickhouse-server.upgrade.log \
     | grep -av -e "_repl_01111_.*Mapping for table with UUID" \
     | grep -av -e "Azure::Storage::StorageException.*Not found address of host" \


### PR DESCRIPTION
The upgrade test in CI installs a previous release binary, runs the test suite, then upgrades to the new server build and restarts. Tables created on the old binary with columns like `Nullable(Tuple(`null` UInt32))` fail to attach on the new binary because PR #98377 forbade Tuple element name `null` to avoid ambiguity with the Nullable null-map subcolumn name.

This is a known consequence of the backward-incompatible change, not a regression introduced by any in-flight PR. Add the exact reserved-name phrase to the `upgrade_runner.sh` error filter so unrelated PRs no longer fail the upgrade check on this message.

Observed on PR #100141: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100141&sha=ca91e01ef6f3c799bddb2176485608a8c9eaf151&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29

PR: https://github.com/ClickHouse/ClickHouse/pull/100141

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)