### PR TITLE
Add test: `ReplicatedMergeTree` w/o columns + non-trivial `PARTITION BY`/`ORDER BY` (`minmax_count_projection` with column refs) is untested

### DIFF
--- a/tests/queries/0_stateless/04201_rmt_create_columns_from_replica_partitioned.reference
+++ b/tests/queries/0_stateless/04201_rmt_create_columns_from_replica_partitioned.reference
@@ -1,0 +1,13 @@
+CREATE TABLE default.rmt_part_r2
+(
+    `key` Int32,
+    `val` String,
+    `dt` Date
+)
+ENGINE = ReplicatedMergeTree('/clickhouse/test/04201_rmt_part/default', 'r2')
+PARTITION BY toYYYYMM(dt)
+ORDER BY key
+SETTINGS index_granularity = 8192
+2
+1	a	2024-01-01
+2	b	2024-02-01

--- a/tests/queries/0_stateless/04201_rmt_create_columns_from_replica_partitioned.sql
+++ b/tests/queries/0_stateless/04201_rmt_create_columns_from_replica_partitioned.sql
@@ -1,0 +1,38 @@
+-- Tags: zookeeper, no-shared-merge-tree
+-- Test: exercises CREATE TABLE w/o columns for ReplicatedMergeTree with PARTITION BY clause —
+-- this triggers the `getMinMaxCountProjection` call with non-empty partition columns and
+-- non-empty primary key, validating the fix that passes `columns` (fetched from ZooKeeper)
+-- instead of `args.columns` (empty) at registerStorageMergeTree.cpp:706.
+-- Covers: src/Storages/MergeTree/registerStorageMergeTree.cpp:706 (extended syntax) where
+-- columns from replica must be passed to projection construction.
+
+drop table if exists rmt_part_r1 sync;
+drop table if exists rmt_part_r2 sync;
+
+-- Replica 1 with explicit columns + non-trivial PARTITION BY + ORDER BY
+create table rmt_part_r1 (key Int32, val String, dt Date)
+    engine=ReplicatedMergeTree('/clickhouse/test/04201_rmt_part/{database}', 'r1')
+    partition by toYYYYMM(dt)
+    order by key;
+
+-- Replica 2 without explicit columns — columns are fetched from ZooKeeper.
+-- This exercises the fix: minmax_count_projection must use the fetched columns,
+-- not the empty `args.columns`. Without the fix, projection construction would
+-- fail because partition column `dt` and order-by column `key` are referenced
+-- in the projection AST but missing from the underlying storage columns.
+create table rmt_part_r2
+    engine=ReplicatedMergeTree('/clickhouse/test/04201_rmt_part/{database}', 'r2')
+    partition by toYYYYMM(dt)
+    order by key;
+
+-- Verify schema fetched correctly
+show create rmt_part_r2 format LineAsString;
+
+-- Verify replication actually works after the fix
+insert into rmt_part_r1 values (1, 'a', '2024-01-01'), (2, 'b', '2024-02-01');
+system sync replica rmt_part_r2;
+select count() from rmt_part_r2;
+select * from rmt_part_r2 order by key;
+
+drop table rmt_part_r1 sync;
+drop table rmt_part_r2 sync;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #62040](https://github.com/ClickHouse/ClickHouse/pull/62040) (merged 2024-03-30). Confirmed on current codebase — close with a note if already fixed._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #62040](https://github.com/ClickHouse/ClickHouse/pull/62040).
 That PR PR #62040 fixes `CREATE TABLE w/o columns` for `ReplicatedMergeTree`: when columns are omitted, they are fetched from ZooKeeper at `registerStorageMergeTree.cpp`:633-634. The fix changes two `getMinMaxCountProjection` call sites (lines 706 and 858 in current file) to pass the locally-resolved `colum

**1. `ReplicatedMergeTree` w/o columns + non-trivial `PARTITION BY`/`ORDER BY` (`minmax_count_projection` with column refs) is untested**
  `src/Storages/MergeTree/registerStorageMergeTree.cpp:706`, `src/Storages/MergeTree/registerStorageMergeTree.cpp:633`
  **Risk:** Call chain: `StorageFactory::create` → `registerStorageMergeTree.cpp:706 getMinMaxCountProjection(columns, partition_key, minmax_columns, metadata.primary_key, &metadata.partition_key, context)` → `Pr
  **What's unique vs PR tests:** PR test 03032 uses `ORDER BY tuple()` and no `PARTITION BY`. In `getMinMaxCountProjection` this means `minmax_columns=[]`, `partition_columns->children.empty()=true`, and `primary_key.expression_list_
  **Tags:** `-- Tags: zookeeper, no-shared-merge-tree` — `zookeeper`: Test creates `ReplicatedMergeTree` tables which require ZooKeeper/Keeper. Test framework filters this tag in environments without ZK.; `no-shared-merge-tree`: Test asserts behavior of `ReplicatedMergeTree` specifically — `SharedMergeTree` (Cloud variant) replaces this engine and uses a different `registerStorageMergeTree` code path, so the fix's specific path (line 706 with ZK-fetched `columns`) is not relevant there.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)