### PR TITLE
Fix `FunctionsStress.stress` abort when a worker thread gets stuck

### DIFF
--- a/src/Functions/tests/gtest_functions_stress.cpp
+++ b/src/Functions/tests/gtest_functions_stress.cpp
@@ -2169,8 +2169,11 @@ TEST(FunctionsStress, stress)
 
     auto request_shutdown = [&]
         {
+            /// Stuck workers are converted to nullptr below (see the `t.release()` call). A
+            /// termination signal arriving after that point would otherwise dereference null.
             for (auto & t : threads)
-                t->thread_should_stop.store(true);
+                if (t)
+                    t->thread_should_stop.store(true);
         };
 
     /// Print stack trace and function name on crash.
@@ -2224,7 +2227,7 @@ TEST(FunctionsStress, stress)
             /// then leak the entire `FunctionsStressTestThread` so the worker can keep using
             /// its state safely. See the comment near `threads` declaration above for details.
             t->thread.detach();
-            (void)t.release();
+            [[maybe_unused]] auto * leaked = t.release();
         }
         else
         {

--- a/src/Functions/tests/gtest_functions_stress.cpp
+++ b/src/Functions/tests/gtest_functions_stress.cpp
@@ -2149,13 +2149,28 @@ TEST(FunctionsStress, stress)
     }
     if (num_threads <= 0)
         num_threads = 1;
-    std::vector<FunctionsStressTestThread> threads(static_cast<size_t>(num_threads));
+    /// Use heap-allocated `FunctionsStressTestThread` (via `std::unique_ptr`) so that we can
+    /// intentionally leak the state of stuck workers. If a worker thread gets stuck in some
+    /// runaway operation (e.g. an infinite loop in a tested function), we cannot safely destroy
+    /// its `FunctionsStressTestThread` from the main thread:
+    ///   * The worker is still using `context`, `thread_group`, `function_stats`, `valid_args`,
+    ///     `result`, `mutex`, `operation`, etc. — destroying any of them would race with the
+    ///     worker (use-after-free).
+    ///   * `~ThreadStatus` would run on the main thread, fire `prev.thread_id == curr.thread_id`
+    ///     in `RUsageCounters::incrementProfileEvents`, and abort. See issue #103750.
+    ///   * `~std::thread` on a still-joinable `std::thread` calls `std::terminate`.
+    /// For stuck workers we instead `detach` the `std::thread` and `release` the `unique_ptr`,
+    /// leaving the heap-allocated state alive forever. The test is failing anyway, so this leak
+    /// only persists until the test process exits.
+    std::vector<std::unique_ptr<FunctionsStressTestThread>> threads(static_cast<size_t>(num_threads));
+    for (auto & t : threads)
+        t = std::make_unique<FunctionsStressTestThread>();
     const std::chrono::seconds stop_timeout(30);
 
     auto request_shutdown = [&]
         {
             for (auto & t : threads)
-                t.thread_should_stop.store(true);
+                t->thread_should_stop.store(true);
         };
 
     /// Print stack trace and function name on crash.
@@ -2175,14 +2190,14 @@ TEST(FunctionsStress, stress)
 
     for (size_t i = 0; i < threads.size(); ++i)
     {
-        threads[i].thread_idx = i;
-        threads[i].thread = std::thread([t = &threads[i]] { t->run(); });
+        threads[i]->thread_idx = i;
+        threads[i]->thread = std::thread([t = threads[i].get()] { t->run(); });
     }
 
     signal_listener.waitForTerminationRequest(std::chrono::seconds(options.duration_seconds));
 
     for (auto & t : threads)
-        t.thread_should_stop.store(true);
+        t->thread_should_stop.store(true);
 
     LOG_INFO(logger, "Waiting for threads to stop for up to {} seconds", stop_timeout.count());
 
@@ -2196,21 +2211,26 @@ TEST(FunctionsStress, stress)
     {
         std::optional<Operation> stuck_operation;
         {
-            std::unique_lock lock(t.mutex);
-            t.thread_stop_cv.wait_until(lock, deadline, [&] { return t.thread_stopped; });
-            if (!t.thread_stopped)
-                stuck_operation = t.operation;
+            std::unique_lock lock(t->mutex);
+            t->thread_stop_cv.wait_until(lock, deadline, [&] { return t->thread_stopped; });
+            if (!t->thread_stopped)
+                stuck_operation = t->operation;
         }
         if (stuck_operation.has_value())
         {
             LOG_ERROR(logger, "Thread is stuck while {}", stuck_operation->describe());
             ++stuck_threads;
+            /// Detach the still-joinable `std::thread` so its destructor doesn't `std::terminate`,
+            /// then leak the entire `FunctionsStressTestThread` so the worker can keep using
+            /// its state safely. See the comment near `threads` declaration above for details.
+            t->thread.detach();
+            (void)t.release();
         }
         else
         {
-            t.thread.join();
+            t->thread.join();
             for (size_t i = 0; i < testable_functions.size(); ++i)
-                total_stats[i].merge(t.function_stats[i]);
+                total_stats[i].merge(t->function_stats[i]);
         }
     }
 

--- a/src/Functions/tests/gtest_functions_stress.cpp
+++ b/src/Functions/tests/gtest_functions_stress.cpp
@@ -2162,6 +2162,11 @@ TEST(FunctionsStress, stress)
     /// For stuck workers we instead `detach` the `std::thread` and `release` the `unique_ptr`,
     /// leaving the heap-allocated state alive forever. The test is failing anyway, so this leak
     /// only persists until the test process exits.
+    ///
+    /// The actual `unique_ptr` release for stuck workers is deferred until after the signal
+    /// listener thread has stopped — see the cleanup pass at the bottom of this function.
+    /// `request_shutdown` (the signal listener callback) reads `threads`, so mutating the
+    /// `unique_ptr` slots concurrently would be a data race.
     std::vector<std::unique_ptr<FunctionsStressTestThread>> threads(static_cast<size_t>(num_threads));
     for (auto & t : threads)
         t = std::make_unique<FunctionsStressTestThread>();
@@ -2169,8 +2174,9 @@ TEST(FunctionsStress, stress)
 
     auto request_shutdown = [&]
         {
-            /// Stuck workers are converted to nullptr below (see the `t.release()` call). A
-            /// termination signal arriving after that point would otherwise dereference null.
+            /// `threads` is only mutated after `signal_listener_thread` has been stopped and
+            /// joined, so all entries are non-null while the listener is alive. The `if (t)`
+            /// guard is purely defensive.
             for (auto & t : threads)
                 if (t)
                     t->thread_should_stop.store(true);
@@ -2209,9 +2215,16 @@ TEST(FunctionsStress, stress)
         total_stats[i].function_idx = i;
     size_t stuck_threads = 0;
 
+    /// Indices of workers that turned out to be stuck. We detach their `std::thread` immediately
+    /// (so its destructor doesn't `std::terminate`), but defer the `unique_ptr` release until
+    /// after `signal_listener_thread` has been joined. `request_shutdown` reads `threads`, so
+    /// any concurrent mutation would be a data race.
+    std::vector<size_t> stuck_indices;
+
     auto deadline = std::chrono::steady_clock::now() + stop_timeout;
-    for (auto & t : threads)
+    for (size_t i = 0; i < threads.size(); ++i)
     {
+        auto & t = threads[i];
         std::optional<Operation> stuck_operation;
         {
             std::unique_lock lock(t->mutex);
@@ -2223,25 +2236,36 @@ TEST(FunctionsStress, stress)
         {
             LOG_ERROR(logger, "Thread is stuck while {}", stuck_operation->describe());
             ++stuck_threads;
-            /// Detach the still-joinable `std::thread` so its destructor doesn't `std::terminate`,
-            /// then leak the entire `FunctionsStressTestThread` so the worker can keep using
-            /// its state safely. See the comment near `threads` declaration above for details.
+            /// Detach the still-joinable `std::thread` so its destructor doesn't `std::terminate`.
+            /// Detaching mutates only `t->thread`, which `request_shutdown` does not read, so it
+            /// is safe to do here while the signal listener is still alive.
             t->thread.detach();
-            [[maybe_unused]] auto * leaked = t.release();
+            stuck_indices.push_back(i);
         }
         else
         {
             t->thread.join();
-            for (size_t i = 0; i < testable_functions.size(); ++i)
-                total_stats[i].merge(t->function_stats[i]);
+            for (size_t j = 0; j < testable_functions.size(); ++j)
+                total_stats[j].merge(t->function_stats[j]);
         }
     }
 
     String failure_details = reportResults(total_stats, stuck_threads);
 
+    /// Stop and join the signal listener BEFORE releasing the `unique_ptr` slots for stuck
+    /// workers. While the listener is alive it can fire `request_shutdown`, which iterates
+    /// `threads` and reads each `unique_ptr`. Releasing concurrently would be a data race.
     writeSignalIDtoSignalPipe(SignalListener::StopThread);
     signal_listener_thread.join();
     HandledSignals::instance().reset();
+
+    /// Now that no other thread can read `threads`, release the stuck workers' `unique_ptr`s.
+    /// The heap-allocated state stays alive forever so the still-running stuck workers can keep
+    /// using it safely; the test process is about to exit so the leak is bounded.
+    for (size_t i : stuck_indices)
+    {
+        [[maybe_unused]] auto * leaked = threads[i].release();
+    }
 
     ASSERT_TRUE(failure_details.empty()) << failure_details;
 }


### PR DESCRIPTION
Closes #103750.

When a worker thread in `FunctionsStress.stress` gets stuck (e.g. an infinite loop in some tested function), the test correctly detects it and reports `N threads got stuck`, then fails via gtest. But on return, the implicit destructor of `std::vector<FunctionsStressTestThread>` runs on the main thread, calling `~optional<ThreadStatus>` for each stuck worker. `~ThreadStatus` then runs `detachFromGroup` -> `finalizePerformanceCounters` -> `updatePerformanceCounters` -> `RUsageCounters::updateProfileEvents`, which fires `chassert(prev.thread_id == curr.thread_id)` because `last_rusage->thread_id` was captured on the worker thread while the destructor is now running on the main thread. The same `FunctionsStressTestThread` also still has a joinable `std::thread`, whose destructor would call `std::terminate`.

This PR holds each `FunctionsStressTestThread` behind a `std::unique_ptr`. For stuck workers we `detach` the `std::thread` and `release` the `unique_ptr`, leaving the heap-allocated state alive forever. The worker keeps using its state safely; the main thread does not try to destroy what it cannot safely destroy. Normal (non-stuck) flow is unchanged: threads are joined, stats are merged, and the `unique_ptr` cleanup runs after the worker has fully exited and reset its own `thread_status`.

Reproduces the exact stack trace from #103750 by adding a temporary sleep at the top of `run` for thread 0 (gated on env var `GTEST_FUNCTIONS_STRESS_FORCE_STUCK`):

| state | result |
| --- | --- |
| without fix + injection | SIGABRT, stack matches #103750 byte-for-byte (assert fires inside `~vector<>::__destroy_vector`) |
| with fix + injection | gtest reports `1 threads got stuck` cleanly, `[ FAILED ] FunctionsStress.stress`, no abort |
| with fix + no injection | `[ OK ] FunctionsStress.stress (10506 ms)` (4 threads, 10 s) |

CI report from the issue: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=102356&sha=b9d7659ecdf225030b1fd9300e66e597f3c1706b&name_0=PR&name_1=Unit%20tests%20%28asan_ubsan%2C%20function_prop_fuzzer%29

cc @alexey-milovidov @rschu1ze (per directive on PR #103628 to tag Robert on every PR).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.524`
<!-- ch-version-info:end -->