### PR TITLE
Switch VectorSearch job to runners with a large disk

### DIFF
--- a/.github/workflows/vectorsearchstress.yml
+++ b/.github/workflows/vectorsearchstress.yml
@@ -119,7 +119,7 @@ jobs:
           PYTHONUNBUFFERED=1 python3 -m praktika run 'Dockers Build (arm)' --workflow "VectorSearchStress" --ci --timestamp
 
   vector_search_stress:
-    runs-on: [self-hosted, arm-large]
+    runs-on: [self-hosted, arm-large-storage]
     needs: [config_workflow, dockers_build_amd, dockers_build_arm]
     name: "Vector Search Stress"
     outputs:

--- a/ci/defs/defs.py
+++ b/ci/defs/defs.py
@@ -19,6 +19,7 @@ class RunnerLabels:
     FUNC_TESTER_ARM = ["self-hosted", "arm-medium"]
     AMD_LARGE = ["self-hosted", "amd-large"]
     ARM_LARGE = ["self-hosted", "arm-large"]
+    ARM_LARGE_STORAGE = ["self-hosted", "arm-large-storage"]
     AMD_MEDIUM = ["self-hosted", "amd-medium"]
     ARM_MEDIUM = ["self-hosted", "arm-medium"]
     AMD_MEDIUM_CPU = ["self-hosted", "amd-medium-cpu"]

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -1503,7 +1503,7 @@ class JobConfigs:
     )
     vector_search_stress_job = Job.Config(
         name="Vector Search Stress",
-        runs_on=RunnerLabels.ARM_LARGE,
+        runs_on=RunnerLabels.ARM_LARGE_STORAGE,
         run_in_docker="clickhouse/performance-comparison",
         command="python3 ./ci/jobs/vector_search_stress_tests.py",
     )

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -1506,6 +1506,7 @@ class JobConfigs:
         runs_on=RunnerLabels.ARM_LARGE_STORAGE,
         run_in_docker="clickhouse/performance-comparison",
         command="python3 ./ci/jobs/vector_search_stress_tests.py",
+        timeout=6 * 3600,
     )
     llvm_coverage_job = Job.Config(
         name=JobNames.LLVM_COVERAGE,

--- a/ci/jobs/vector_search_stress_tests.py
+++ b/ci/jobs/vector_search_stress_tests.py
@@ -342,6 +342,10 @@ class RunTest:
             logger("Waiting for optimize table to complete...")
             time.sleep(5)
 
+    # Runs ALTER TABLE ... ADD INDEX and then MATERIALIZE INDEX
+    def build_index(self):
+        logger("Adding vector similarity index")
+
         result = self._chclient.query(
             f"SELECT name, formatReadableSize(bytes) FROM system.parts WHERE table = '{self._table}' AND active=1"
         )
@@ -349,9 +353,6 @@ class RunTest:
         for row in result.result_rows:
             logger(f"{row[0]}\t\t{row[1]} bytes")
 
-    # Runs ALTER TABLE ... ADD INDEX and then MATERIALIZE INDEX
-    def build_index(self):
-        logger("Adding vector similarity index")
         quantization = self._test_params[QUANTIZATION]
         hnsw_M = self._test_params[HNSW_M]
         hnsw_ef_C = self._test_params[HNSW_EF_CONSTRUCTION]
@@ -834,7 +835,7 @@ def install_and_start_clickhouse():
 
 
 # Array of (dataset, test_params)
-"""
+TESTS_TO_RUN = [
     (
         "Test using the laion dataset",
         dataset_laion_5b_mini_for_quick_test,
@@ -845,8 +846,6 @@ def install_and_start_clickhouse():
         dataset_hackernews_openai,
         test_params_hackernews_10m,
     ),
-"""
-TESTS_TO_RUN = [
     (
         "Test using the cohere wiki dataset",
         dataset_cohere_wiki_20m,

--- a/ci/jobs/vector_search_stress_tests.py
+++ b/ci/jobs/vector_search_stress_tests.py
@@ -223,7 +223,8 @@ test_params_cohere_wiki_20m = {
     NEW_TRUTH_SET_FILE: None,
     TRUTH_SET_COUNT: 25000,
     RECALL_K: 10,
-    MERGE_TREE_SETTINGS: None,
+    # Let's have more than 1 part for this dataset (7 - 9 parts)
+    MERGE_TREE_SETTINGS: "max_bytes_to_merge_at_max_space_in_pool=11811160064",
     OTHER_SETTINGS: None,
     CONCURRENCY_TEST: True,
 }
@@ -271,6 +272,8 @@ class RunTest:
         logger(f"Begin loading data into {self._table}")
 
         create_table = f"CREATE TABLE {self._table} ( {self._dataset[SCHEMA]} ) ENGINE = MergeTree ORDER BY {self._id_column}"
+        if self._test_params[MERGE_TREE_SETTINGS] is not None:
+            create_table += f" SETTINGS {self._test_params[MERGE_TREE_SETTINGS]}"
         self._chclient.query(create_table)
 
         for url in self._dataset[S3_URLS]:

--- a/ci/jobs/vector_search_stress_tests.py
+++ b/ci/jobs/vector_search_stress_tests.py
@@ -224,7 +224,7 @@ test_params_cohere_wiki_20m = {
     TRUTH_SET_COUNT: 25000,
     RECALL_K: 10,
     # Let's have more than 1 part for this dataset (7 - 9 parts)
-    MERGE_TREE_SETTINGS: "max_bytes_to_merge_at_max_space_in_pool=11811160064",
+    MERGE_TREE_SETTINGS: "max_bytes_to_merge_at_max_space_in_pool=11811160064, min_insert_block_size_rows = 3000000, min_insert_block_size_bytes=11737418240",
     OTHER_SETTINGS: None,
     CONCURRENCY_TEST: True,
 }
@@ -319,6 +319,11 @@ class RunTest:
                 break
             logger("Waiting for existing merges to complete...")
             time.sleep(5)
+
+        if self._test_params[MERGE_TREE_SETTINGS] is not None:
+            if "max_bytes_to_merge_at_max_space_in_pool" in self._test_params[MERGE_TREE_SETTINGS]:
+                logger("Skipping OPTIMIZE TABLE")
+                return
 
         try:
             self._chclient.query(
@@ -829,7 +834,7 @@ def install_and_start_clickhouse():
 
 
 # Array of (dataset, test_params)
-TESTS_TO_RUN = [
+"""
     (
         "Test using the laion dataset",
         dataset_laion_5b_mini_for_quick_test,
@@ -840,6 +845,8 @@ TESTS_TO_RUN = [
         dataset_hackernews_openai,
         test_params_hackernews_10m,
     ),
+"""
+TESTS_TO_RUN = [
     (
         "Test using the cohere wiki dataset",
         dataset_cohere_wiki_20m,

--- a/ci/jobs/vector_search_stress_tests.py
+++ b/ci/jobs/vector_search_stress_tests.py
@@ -224,8 +224,8 @@ test_params_cohere_wiki_20m = {
     TRUTH_SET_COUNT: 25000,
     RECALL_K: 10,
     # Let's have more than 1 part for this dataset (7 - 9 parts)
-    MERGE_TREE_SETTINGS: "max_bytes_to_merge_at_max_space_in_pool=11811160064, min_insert_block_size_rows = 3000000, min_insert_block_size_bytes=11737418240",
-    OTHER_SETTINGS: None,
+    MERGE_TREE_SETTINGS: "max_bytes_to_merge_at_max_space_in_pool=11811160064",
+    OTHER_SETTINGS: "min_insert_block_size_rows = 3000000, min_insert_block_size_bytes=11737418240",
     CONCURRENCY_TEST: True,
 }
 
@@ -301,6 +301,10 @@ class RunTest:
                     insert
                     + f" ORDER BY {self._id_column} LIMIT {self._test_params[LIMIT_N]}"
                 )
+
+            if self._test_params[OTHER_SETTINGS] is not None:
+                insert += f" SETTINGS {self._test_params[OTHER_SETTINGS]}"
+
             self._chclient.query(insert)
 
             result = self._chclient.query(f"SELECT count() FROM {self._table}")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

VectorSearch job needs larger volume

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.325`
<!-- ch-version-info:end -->