### PR TITLE
Preserve SettingFieldMaxThreads::is_auto across SET <name> = DEFAULT

### DIFF
--- a/src/Core/BaseSettings.h
+++ b/src/Core/BaseSettings.h
@@ -1146,9 +1146,13 @@ using AliasMap = std::unordered_map<std::string_view, std::string_view>;
             } \
             void resetValueToDefault(Data & data, size_t index) const \
             { \
-                auto p = field_infos[index].create_default_function(); \
-                *field_infos[index].get_data_function(*const_cast<Data *>(&data)) = static_cast<Field>(*p); \
-                field_infos[index].get_data_function(*const_cast<Data *>(&data))->setChanged(false); \
+                /* Use the type-specific reset_function instead of going through Field. */ \
+                /* Going through `static_cast<Field>` and `operator=(const Field &)` is */ \
+                /* not always invertible: e.g. `SettingFieldMaxThreads::operator Field()` */ \
+                /* returns the computed `value` (the resolved auto-value), so a Field    */ \
+                /* round-trip would lose the `is_auto` flag. The reset_function copies   */ \
+                /* via the type's own `operator=`, preserving all type-specific state.   */ \
+                field_infos[index].reset_function(*const_cast<Data *>(&data)); \
             } \
             \
             /* Binary serialization (by index) */ \
@@ -1177,6 +1181,7 @@ using AliasMap = std::unordered_map<std::string_view, std::string_view>;
                 const UInt64 flags; \
                 SettingFieldBase * (*get_data_function)(Data &);                    /* Get pointer to setting in Data struct */ \
                 std::unique_ptr<SettingFieldBase> (*create_default_function)();     /* Create setting with default value */ \
+                void (*reset_function)(Data &);                                     /* Reset setting to default, preserving type-specific state */ \
             }; \
             \
             std::vector<FieldInfo> field_infos;                                     /* Metadata for all settings */ \
@@ -1285,9 +1290,12 @@ using AliasMap = std::unordered_map<std::string_view, std::string_view>;
 
 
 /// Generate a FieldInfo entry for a setting without a config path.
-/// Creates two lambdas:
+/// Creates three lambdas:
 /// 1. get_data_function: Returns pointer to the setting field in a Data struct
 /// 2. create_default_function: Creates a new setting field with default value
+/// 3. reset_function: Resets the setting to its default value via the type's own
+///    `operator=`. This preserves type-specific state that `static_cast<Field>` would
+///    lose (e.g. `SettingFieldMaxThreads::is_auto`).
 /// NOLINTNEXTLINE
 #define IMPLEMENT_SETTINGS_TRAITS_(TYPE, NAME, DEFAULT, DESCRIPTION, FLAGS, ...) \
     res.field_infos.emplace_back( \
@@ -1300,6 +1308,7 @@ using AliasMap = std::unordered_map<std::string_view, std::string_view>;
             static_cast<UInt64>(FLAGS), \
             [](Data & data) -> SettingFieldBase * { return &data.NAME; }, \
             []() -> std::unique_ptr<SettingFieldBase> { return std::make_unique<SettingField##TYPE>(DEFAULT); }, \
+            [](Data & data) { data.NAME = SettingField##TYPE(DEFAULT); data.NAME.setChanged(false); }, \
         });
 
 /// Generate a FieldInfo entry for a setting with a config file path
@@ -1315,5 +1324,6 @@ using AliasMap = std::unordered_map<std::string_view, std::string_view>;
             static_cast<UInt64>(FLAGS), \
             [](Data & data) -> SettingFieldBase * { return &data.NAME; }, \
             []() -> std::unique_ptr<SettingFieldBase> { return std::make_unique<SettingField##TYPE>(DEFAULT); }, \
+            [](Data & data) { data.NAME = SettingField##TYPE(DEFAULT); data.NAME.setChanged(false); }, \
         });
 }

--- a/src/Core/BaseSettings.h
+++ b/src/Core/BaseSettings.h
@@ -1146,13 +1146,9 @@ using AliasMap = std::unordered_map<std::string_view, std::string_view>;
             } \
             void resetValueToDefault(Data & data, size_t index) const \
             { \
-                /* Use the type-specific reset_function instead of going through Field. */ \
-                /* Going through `static_cast<Field>` and `operator=(const Field &)` is */ \
-                /* not always invertible: e.g. `SettingFieldMaxThreads::operator Field()` */ \
-                /* returns the computed `value` (the resolved auto-value), so a Field    */ \
-                /* round-trip would lose the `is_auto` flag. The reset_function copies   */ \
-                /* via the type's own `operator=`, preserving all type-specific state.   */ \
-                field_infos[index].reset_function(*const_cast<Data *>(&data)); \
+                auto p = field_infos[index].create_default_function(); \
+                *field_infos[index].get_data_function(*const_cast<Data *>(&data)) = static_cast<Field>(*p); \
+                field_infos[index].get_data_function(*const_cast<Data *>(&data))->setChanged(false); \
             } \
             \
             /* Binary serialization (by index) */ \
@@ -1181,7 +1177,6 @@ using AliasMap = std::unordered_map<std::string_view, std::string_view>;
                 const UInt64 flags; \
                 SettingFieldBase * (*get_data_function)(Data &);                    /* Get pointer to setting in Data struct */ \
                 std::unique_ptr<SettingFieldBase> (*create_default_function)();     /* Create setting with default value */ \
-                void (*reset_function)(Data &);                                     /* Reset setting to default, preserving type-specific state */ \
             }; \
             \
             std::vector<FieldInfo> field_infos;                                     /* Metadata for all settings */ \
@@ -1290,12 +1285,9 @@ using AliasMap = std::unordered_map<std::string_view, std::string_view>;
 
 
 /// Generate a FieldInfo entry for a setting without a config path.
-/// Creates three lambdas:
+/// Creates two lambdas:
 /// 1. get_data_function: Returns pointer to the setting field in a Data struct
 /// 2. create_default_function: Creates a new setting field with default value
-/// 3. reset_function: Resets the setting to its default value via the type's own
-///    `operator=`. This preserves type-specific state that `static_cast<Field>` would
-///    lose (e.g. `SettingFieldMaxThreads::is_auto`).
 /// NOLINTNEXTLINE
 #define IMPLEMENT_SETTINGS_TRAITS_(TYPE, NAME, DEFAULT, DESCRIPTION, FLAGS, ...) \
     res.field_infos.emplace_back( \
@@ -1308,7 +1300,6 @@ using AliasMap = std::unordered_map<std::string_view, std::string_view>;
             static_cast<UInt64>(FLAGS), \
             [](Data & data) -> SettingFieldBase * { return &data.NAME; }, \
             []() -> std::unique_ptr<SettingFieldBase> { return std::make_unique<SettingField##TYPE>(DEFAULT); }, \
-            [](Data & data) { data.NAME = SettingField##TYPE(DEFAULT); data.NAME.setChanged(false); }, \
         });
 
 /// Generate a FieldInfo entry for a setting with a config file path
@@ -1324,6 +1315,5 @@ using AliasMap = std::unordered_map<std::string_view, std::string_view>;
             static_cast<UInt64>(FLAGS), \
             [](Data & data) -> SettingFieldBase * { return &data.NAME; }, \
             []() -> std::unique_ptr<SettingFieldBase> { return std::make_unique<SettingField##TYPE>(DEFAULT); }, \
-            [](Data & data) { data.NAME = SettingField##TYPE(DEFAULT); data.NAME.setChanged(false); }, \
         });
 }

--- a/src/Core/BaseSettings.h
+++ b/src/Core/BaseSettings.h
@@ -1147,8 +1147,11 @@ using AliasMap = std::unordered_map<std::string_view, std::string_view>;
             void resetValueToDefault(Data & data, size_t index) const \
             { \
                 auto p = field_infos[index].create_default_function(); \
-                *field_infos[index].get_data_function(*const_cast<Data *>(&data)) = static_cast<Field>(*p); \
-                field_infos[index].get_data_function(*const_cast<Data *>(&data))->setChanged(false); \
+                /* Dispatch through `SettingFieldBase::resetFromDefault` so that types whose */ \
+                /* `operator Field` is non-invertible (e.g. `SettingFieldMaxThreads`, see */ \
+                /* issue #103120) can override and copy member state directly instead of going */ \
+                /* through a lossy `Field` round-trip. */ \
+                field_infos[index].get_data_function(*const_cast<Data *>(&data))->resetFromDefault(*p); \
             } \
             \
             /* Binary serialization (by index) */ \

--- a/src/Core/SettingsFields.h
+++ b/src/Core/SettingsFields.h
@@ -212,16 +212,27 @@ struct SettingFieldMaxThreads final : SettingFieldBase
     }
 
     bool isChanged() const override { return changed; }
-    void setChanged(bool changed_) override { changed = changed_; }
+
+    /// `setChanged(false)` is invoked by `BaseSettings::resetValueToDefault` after assigning the
+    /// default value through a `Field` round-trip. The `Field` path drops the `is_auto` flag because
+    /// `SettingFieldMaxThreads` deliberately behaves like a plain `UInt64` for backward compatibility
+    /// (i.e. `operator Field` returns the resolved value, not the canonical `0`/`"auto"`). Without the
+    /// extra restoration below, `SET <name> = DEFAULT` would convert `'auto(N)'` into a fixed `N`.
+    /// `setChanged(false)` is the only path in the tree that puts a setting back into the
+    /// "unchanged from default" state, so the canonical default state is restored here. See issue
+    /// #103120.
+    void setChanged(bool changed_) override
+    {
+        changed = changed_;
+        if (!changed_)
+        {
+            is_auto = true;
+            value = getAuto();
+        }
+    }
 
     operator UInt64() const { return value; } /// NOLINT
-    /// Return the canonical `"auto"` string when `is_auto` is set, mirroring `SettingAutoWrapper::operator Field`.
-    /// This makes the `Field` round-trip invertible: `operator=(Field("auto"))` recognises the keyword
-    /// (via `fieldToMaxThreads` -> `stringToMaxThreads`) and restores `is_auto = true`. Without this,
-    /// `BaseSettings::resetValueToDefault` (and other code paths that round-trip through `Field`) would
-    /// silently drop the `is_auto` flag — e.g. `SET <name> = DEFAULT` would convert `'auto(N)'` into a
-    /// fixed `N`. See issue #103120.
-    explicit operator Field() const override { return is_auto ? Field("auto") : Field(value); }
+    explicit operator Field() const override { return value; }
 
     /// Writes "auto(<number>)" instead of simple "<number>" if `is_auto == true`.
     String toString() const override;

--- a/src/Core/SettingsFields.h
+++ b/src/Core/SettingsFields.h
@@ -215,7 +215,13 @@ struct SettingFieldMaxThreads final : SettingFieldBase
     void setChanged(bool changed_) override { changed = changed_; }
 
     operator UInt64() const { return value; } /// NOLINT
-    explicit operator Field() const override { return value; }
+    /// Return the canonical `"auto"` string when `is_auto` is set, mirroring `SettingAutoWrapper::operator Field`.
+    /// This makes the `Field` round-trip invertible: `operator=(Field("auto"))` recognises the keyword
+    /// (via `fieldToMaxThreads` -> `stringToMaxThreads`) and restores `is_auto = true`. Without this,
+    /// `BaseSettings::resetValueToDefault` (and other code paths that round-trip through `Field`) would
+    /// silently drop the `is_auto` flag — e.g. `SET <name> = DEFAULT` would convert `'auto(N)'` into a
+    /// fixed `N`. See issue #103120.
+    explicit operator Field() const override { return is_auto ? Field("auto") : Field(value); }
 
     /// Writes "auto(<number>)" instead of simple "<number>" if `is_auto == true`.
     String toString() const override;

--- a/src/Core/SettingsFields.h
+++ b/src/Core/SettingsFields.h
@@ -36,6 +36,20 @@ struct SettingFieldBase
 
     virtual void writeBinary(WriteBuffer & out) const = 0;
     virtual void readBinary(ReadBuffer & in) = 0;
+
+    /// Reset this setting to the value held by `default_value` (which must have the same dynamic
+    /// type as `*this`). The default implementation goes through a `Field` round-trip, which is
+    /// fine for any type whose `operator Field` is invertible (i.e. `*this = Field(other)` then
+    /// `static_cast<Field>(*this) == Field(other)`). Types that deliberately have a non-invertible
+    /// `operator Field` must override and copy state directly. See issue #103120 - the canonical
+    /// example is `SettingFieldMaxThreads`, which behaves like a plain `UInt64` for backward
+    /// compatibility (its `operator Field` returns the resolved value, not the `0` / `"auto"`
+    /// canonical form), and so loses `is_auto` across the `Field` round-trip.
+    virtual void resetFromDefault(const SettingFieldBase & default_value)
+    {
+        *this = static_cast<Field>(default_value);
+        setChanged(false);
+    }
 };
 
 template <typename T>
@@ -212,23 +226,21 @@ struct SettingFieldMaxThreads final : SettingFieldBase
     }
 
     bool isChanged() const override { return changed; }
+    void setChanged(bool changed_) override { changed = changed_; }
 
-    /// `setChanged(false)` is invoked by `BaseSettings::resetValueToDefault` after assigning the
-    /// default value through a `Field` round-trip. The `Field` path drops the `is_auto` flag because
-    /// `SettingFieldMaxThreads` deliberately behaves like a plain `UInt64` for backward compatibility
-    /// (i.e. `operator Field` returns the resolved value, not the canonical `0`/`"auto"`). Without the
-    /// extra restoration below, `SET <name> = DEFAULT` would convert `'auto(N)'` into a fixed `N`.
-    /// `setChanged(false)` is the only path in the tree that puts a setting back into the
-    /// "unchanged from default" state, so the canonical default state is restored here. See issue
-    /// #103120.
-    void setChanged(bool changed_) override
+    /// Override of the base-class hook used by `BaseSettings::resetValueToDefault`. The default
+    /// `Field`-based implementation is lossy here because `operator Field` deliberately returns
+    /// the resolved value (e.g. `32` when `is_auto` is set), so a round-trip would reconstruct
+    /// the setting as if it had been set explicitly to that number, dropping `is_auto`. We avoid
+    /// the round-trip entirely by copying `default_value` member-wise. This preserves whichever
+    /// state the declared default carries: `is_auto = true` for settings declared with default
+    /// `0` (e.g. `max_threads`, `max_final_threads`, `max_parsing_threads`), and `is_auto = false`
+    /// with the typed default value for settings declared with an explicit non-zero default (e.g.
+    /// `max_download_threads = 4`). See issue #103120.
+    void resetFromDefault(const SettingFieldBase & default_value) override
     {
-        changed = changed_;
-        if (!changed_)
-        {
-            is_auto = true;
-            value = getAuto();
-        }
+        *this = static_cast<const SettingFieldMaxThreads &>(default_value);
+        changed = false;
     }
 
     operator UInt64() const { return value; } /// NOLINT

--- a/tests/queries/0_stateless/04202_set_default_preserves_max_threads_auto.reference
+++ b/tests/queries/0_stateless/04202_set_default_preserves_max_threads_auto.reference
@@ -1,0 +1,17 @@
+max_threads	1
+max_final_threads	1
+max_parsing_threads	1
+after-set max_threads	0
+after-set max_final_threads	0
+after-set max_parsing_threads	0
+after-default max_threads	1
+after-default max_final_threads	1
+after-default max_parsing_threads	1
+idempotent max_threads	1
+multi-default max_threads	1
+multi-default max_final_threads	1
+multi-default max_parsing_threads	1
+autowrapper-set	1
+autowrapper-default	auto
+control changed	1
+control default-changed	0

--- a/tests/queries/0_stateless/04202_set_default_preserves_max_threads_auto.reference
+++ b/tests/queries/0_stateless/04202_set_default_preserves_max_threads_auto.reference
@@ -11,7 +11,23 @@ idempotent max_threads	1
 multi-default max_threads	1
 multi-default max_final_threads	1
 multi-default max_parsing_threads	1
+max_download_threads default	0	4
+max_download_threads after-set	1
+max_download_threads after-default	0	4
+max_download_threads after-zero	1
+max_download_threads after-default-from-auto	0	4
+getSetting numeric max_threads default	1
+getSetting > 0 max_threads default	1
+getSetting numeric max_threads explicit	1
+getSetting value max_threads explicit	4
+getSetting numeric max_final_threads default	1
+getSetting > 0 max_final_threads default	1
+getSetting numeric max_parsing_threads default	1
+getSetting > 0 max_parsing_threads default	1
+getSetting numeric max_download_threads default	1
+getSetting value max_download_threads default	4
 autowrapper-set	1
 autowrapper-default	auto
 control changed	1
 control default-changed	0
+control numeric	1

--- a/tests/queries/0_stateless/04202_set_default_preserves_max_threads_auto.sql
+++ b/tests/queries/0_stateless/04202_set_default_preserves_max_threads_auto.sql
@@ -1,0 +1,61 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/103120
+--
+-- `SET <name> = DEFAULT` used to lose the `is_auto` flag for `SettingFieldMaxThreads`-typed
+-- settings (`max_threads`, `max_final_threads`, `max_parsing_threads`). The cause was that
+-- `BaseSettings::resetValueToDefault` round-tripped through `static_cast<Field>(*default)`,
+-- which for `SettingFieldMaxThreads` returns the resolved auto-value (an opaque `UInt64`),
+-- so the subsequent `operator=(const Field &)` reconstructed the field as if it had been
+-- set to that explicit value.
+--
+-- We use `startsWith(value, '''auto(')` to assert that the auto state is preserved without
+-- depending on the actual core count.
+--
+-- 1. Initial state: undo any session-level value the test runner may have injected via
+--    randomized settings, then assert auto. This step itself exercises the fix - on a
+--    buggy build the reset would return the resolved value instead of auto.
+SET max_threads = DEFAULT;
+SET max_final_threads = DEFAULT;
+SET max_parsing_threads = DEFAULT;
+SELECT 'max_threads',         startsWith(value, '''auto(') FROM system.settings WHERE name = 'max_threads';
+SELECT 'max_final_threads',   startsWith(value, '''auto(') FROM system.settings WHERE name = 'max_final_threads';
+SELECT 'max_parsing_threads', startsWith(value, '''auto(') FROM system.settings WHERE name = 'max_parsing_threads';
+
+-- 2. Setting an explicit value clears auto.
+SET max_threads = 4;
+SET max_final_threads = 5;
+SET max_parsing_threads = 6;
+SELECT 'after-set max_threads',         startsWith(value, '''auto(') FROM system.settings WHERE name = 'max_threads';
+SELECT 'after-set max_final_threads',   startsWith(value, '''auto(') FROM system.settings WHERE name = 'max_final_threads';
+SELECT 'after-set max_parsing_threads', startsWith(value, '''auto(') FROM system.settings WHERE name = 'max_parsing_threads';
+
+-- 3. SET = DEFAULT must restore auto for all three settings.
+SET max_threads = DEFAULT;
+SET max_final_threads = DEFAULT;
+SET max_parsing_threads = DEFAULT;
+SELECT 'after-default max_threads',         startsWith(value, '''auto(') FROM system.settings WHERE name = 'max_threads';
+SELECT 'after-default max_final_threads',   startsWith(value, '''auto(') FROM system.settings WHERE name = 'max_final_threads';
+SELECT 'after-default max_parsing_threads', startsWith(value, '''auto(') FROM system.settings WHERE name = 'max_parsing_threads';
+
+-- 4. Resetting an already-auto setting must keep it auto.
+SET max_threads = DEFAULT;
+SELECT 'idempotent max_threads', startsWith(value, '''auto(') FROM system.settings WHERE name = 'max_threads';
+
+-- 5. Multiple-setting form `SET a = DEFAULT, b = DEFAULT` must restore auto for all.
+SET max_threads = 7, max_final_threads = 8, max_parsing_threads = 9;
+SET max_threads = DEFAULT, max_final_threads = DEFAULT, max_parsing_threads = DEFAULT;
+SELECT 'multi-default max_threads',         startsWith(value, '''auto(') FROM system.settings WHERE name = 'max_threads';
+SELECT 'multi-default max_final_threads',   startsWith(value, '''auto(') FROM system.settings WHERE name = 'max_final_threads';
+SELECT 'multi-default max_parsing_threads', startsWith(value, '''auto(') FROM system.settings WHERE name = 'max_parsing_threads';
+
+-- 6. Control: a `SettingAutoWrapper`-style setting (`query_plan_join_swap_table`) preserves
+--    the literal `auto` keyword across DEFAULT - was already correct, must remain correct.
+SET query_plan_join_swap_table = 'true';
+SELECT 'autowrapper-set', value FROM system.settings WHERE name = 'query_plan_join_swap_table';
+SET query_plan_join_swap_table = DEFAULT;
+SELECT 'autowrapper-default', value FROM system.settings WHERE name = 'query_plan_join_swap_table';
+
+-- 7. Control: a regular numeric setting (`max_block_size`) is `changed=0` after DEFAULT.
+SET max_block_size = 12345;
+SELECT 'control changed', changed FROM system.settings WHERE name = 'max_block_size';
+SET max_block_size = DEFAULT;
+SELECT 'control default-changed', changed FROM system.settings WHERE name = 'max_block_size';

--- a/tests/queries/0_stateless/04202_set_default_preserves_max_threads_auto.sql
+++ b/tests/queries/0_stateless/04202_set_default_preserves_max_threads_auto.sql
@@ -3,12 +3,17 @@
 -- `SET <name> = DEFAULT` used to lose the `is_auto` flag for `SettingFieldMaxThreads`-typed
 -- settings (`max_threads`, `max_final_threads`, `max_parsing_threads`). The cause was that
 -- `BaseSettings::resetValueToDefault` round-trips through `static_cast<Field>(*default)`,
--- and `SettingFieldMaxThreads::operator Field` used to return the resolved auto-value (an
--- opaque `UInt64`), so the subsequent `operator=(const Field &)` reconstructed the field as
--- if it had been set to that explicit value. The fix (mirroring `SettingAutoWrapper`) is to
--- have `operator Field` emit the `"auto"` keyword when `is_auto` is set, so the round-trip
--- is invertible: `fieldToMaxThreads(Field("auto"))` parses back to the canonical 0 and
--- restores `is_auto = true`.
+-- and `SettingFieldMaxThreads::operator Field` returns the resolved auto-value (an opaque
+-- `UInt64`) rather than the canonical `0`/`"auto"`, because it deliberately behaves like a
+-- plain `UInt64` for backward compatibility with code that reads `getSetting('max_threads')`
+-- as numeric. The subsequent `operator=(const Field &)` therefore reconstructed the field
+-- as if it had been set to that explicit value, dropping `is_auto`.
+--
+-- The fix overrides `SettingFieldMaxThreads::setChanged(bool)` so that `setChanged(false)`
+-- (called by `BaseSettings::resetValueToDefault` immediately after the lossy `Field`
+-- assignment, and only from there) restores the canonical default state: `is_auto = true,
+-- value = getAuto()`. `operator Field` is unchanged, so distributed forwarding and code
+-- that reads max_threads as `UInt64` retain their previous behaviour.
 --
 -- We use `startsWith(value, '''auto(')` to assert that the auto state is preserved without
 -- depending on the actual core count.

--- a/tests/queries/0_stateless/04202_set_default_preserves_max_threads_auto.sql
+++ b/tests/queries/0_stateless/04202_set_default_preserves_max_threads_auto.sql
@@ -1,26 +1,38 @@
 -- Regression test for https://github.com/ClickHouse/ClickHouse/issues/103120
 --
 -- `SET <name> = DEFAULT` used to lose the `is_auto` flag for `SettingFieldMaxThreads`-typed
--- settings (`max_threads`, `max_final_threads`, `max_parsing_threads`). The cause was that
--- `BaseSettings::resetValueToDefault` round-trips through `static_cast<Field>(*default)`,
--- and `SettingFieldMaxThreads::operator Field` returns the resolved auto-value (an opaque
--- `UInt64`) rather than the canonical `0`/`"auto"`, because it deliberately behaves like a
--- plain `UInt64` for backward compatibility with code that reads `getSetting('max_threads')`
--- as numeric. The subsequent `operator=(const Field &)` therefore reconstructed the field
--- as if it had been set to that explicit value, dropping `is_auto`.
+-- settings whose declared default is `0` (auto): `max_threads`, `max_final_threads`,
+-- `max_parsing_threads`. The cause was that `BaseSettings::resetValueToDefault` round-trips
+-- through `static_cast<Field>(*default)`, and `SettingFieldMaxThreads::operator Field` returns
+-- the resolved auto-value (an opaque `UInt64`) rather than the canonical `0`/`"auto"`, because
+-- it deliberately behaves like a plain `UInt64` for backward compatibility with code that reads
+-- `getSetting('max_threads')` as numeric. The subsequent `operator=(const Field &)` therefore
+-- reconstructed the field as if it had been set to that explicit value, dropping `is_auto`.
 --
--- The fix overrides `SettingFieldMaxThreads::setChanged(bool)` so that `setChanged(false)`
--- (called by `BaseSettings::resetValueToDefault` immediately after the lossy `Field`
--- assignment, and only from there) restores the canonical default state: `is_auto = true,
--- value = getAuto()`. `operator Field` is unchanged, so distributed forwarding and code
--- that reads max_threads as `UInt64` retain their previous behaviour.
+-- The fix adds `SettingFieldBase::resetFromDefault(const SettingFieldBase &)` (default
+-- implementation goes through `Field`, matching the legacy behaviour for every type whose
+-- `operator Field` is invertible) and overrides it in `SettingFieldMaxThreads` to copy the
+-- typed default member-wise. `BaseSettings::resetValueToDefault` now dispatches through this
+-- virtual, so each type can choose whether the `Field` round-trip is safe for it. `operator
+-- Field` is unchanged, so distributed forwarding and code that reads `max_threads` as `UInt64`
+-- retain their previous behaviour.
 --
--- We use `startsWith(value, '''auto(')` to assert that the auto state is preserved without
--- depending on the actual core count.
+-- The `SettingFieldMaxThreads` family contains four settings with two distinct kinds of declared
+-- defaults, both of which must be preserved across `SET <name> = DEFAULT`:
+--   * `max_threads`, `max_final_threads`, `max_parsing_threads`  - declared default `0` (auto)
+--   * `max_download_threads`                                     - declared default `4` (explicit)
+-- The previous attempt to fix this by overriding `setChanged(false)` to hard-code the auto state
+-- regressed `max_download_threads` to `'auto(N)'` instead of `4`. This test pins the spec for both
+-- groups and adds `getSetting` checks so the runtime `Field` type and value are also asserted.
 --
+-- We use `startsWith(value, '''auto(')` (single-quoted because `system.settings.value` quotes the
+-- string itself) to assert that the auto state is preserved without depending on the actual core
+-- count.
+
 -- 1. Initial state: undo any session-level value the test runner may have injected via
---    randomized settings, then assert auto. This step itself exercises the fix - on a
---    buggy build the reset would return the resolved value instead of auto.
+--    randomized settings, then assert auto for the three auto-defaulted settings. This step
+--    itself exercises the fix - on a buggy build the reset would return the resolved value
+--    instead of auto.
 SET max_threads = DEFAULT;
 SET max_final_threads = DEFAULT;
 SET max_parsing_threads = DEFAULT;
@@ -55,15 +67,71 @@ SELECT 'multi-default max_threads',         startsWith(value, '''auto(') FROM sy
 SELECT 'multi-default max_final_threads',   startsWith(value, '''auto(') FROM system.settings WHERE name = 'max_final_threads';
 SELECT 'multi-default max_parsing_threads', startsWith(value, '''auto(') FROM system.settings WHERE name = 'max_parsing_threads';
 
--- 6. Control: a `SettingAutoWrapper`-style setting (`query_plan_join_swap_table`) preserves
---    the literal `auto` keyword across DEFAULT - was already correct, must remain correct.
+-- 6. `max_download_threads` is the only `SettingFieldMaxThreads` setting with a non-zero declared
+--    default (`4`). Its DEFAULT must restore the explicit value, NOT auto. The earlier
+--    `setChanged`-based fix attempt regressed exactly this case.
+SET max_download_threads = DEFAULT;
+SELECT 'max_download_threads default',
+       startsWith(value, '''auto(') AS is_auto, value
+FROM system.settings WHERE name = 'max_download_threads';
+
+SET max_download_threads = 1;
+SELECT 'max_download_threads after-set', value FROM system.settings WHERE name = 'max_download_threads';
+
+SET max_download_threads = DEFAULT;
+SELECT 'max_download_threads after-default',
+       startsWith(value, '''auto(') AS is_auto, value
+FROM system.settings WHERE name = 'max_download_threads';
+
+-- 7. `max_download_threads = 0` should switch to auto (the `SettingFieldMaxThreads` convention),
+--    and the subsequent DEFAULT must still restore the declared `4` - it must NOT remember "this
+--    setting is currently auto" and stay auto.
+SET max_download_threads = 0;
+SELECT 'max_download_threads after-zero', startsWith(value, '''auto(')
+FROM system.settings WHERE name = 'max_download_threads';
+
+SET max_download_threads = DEFAULT;
+SELECT 'max_download_threads after-default-from-auto',
+       startsWith(value, '''auto(') AS is_auto, value
+FROM system.settings WHERE name = 'max_download_threads';
+
+-- 8. `getSetting` must return a numeric (`UInt`-family) `Field` for every `SettingFieldMaxThreads`
+--    setting in every state. This is the backward-compat invariant the AI reviewer flagged on the
+--    previous `operator Field` redesign attempt: callers that read `max_threads` as `UInt64` must
+--    not see `String('auto')`. We test type-prefix rather than exact type because the analyzer
+--    narrows numeric literals to the smallest fitting `UInt` type (`UInt8`/`UInt16`/`UInt64`),
+--    which depends on the resolved auto value.
+SET max_threads = DEFAULT;
+SELECT 'getSetting numeric max_threads default',         startsWith(toTypeName(getSetting('max_threads')), 'UInt');
+SELECT 'getSetting > 0 max_threads default',             getSetting('max_threads') > 0;
+
+SET max_threads = 4;
+SELECT 'getSetting numeric max_threads explicit',        startsWith(toTypeName(getSetting('max_threads')), 'UInt');
+SELECT 'getSetting value max_threads explicit',          getSetting('max_threads');
+
+SET max_final_threads = DEFAULT;
+SELECT 'getSetting numeric max_final_threads default',   startsWith(toTypeName(getSetting('max_final_threads')), 'UInt');
+SELECT 'getSetting > 0 max_final_threads default',       getSetting('max_final_threads') > 0;
+
+SET max_parsing_threads = DEFAULT;
+SELECT 'getSetting numeric max_parsing_threads default', startsWith(toTypeName(getSetting('max_parsing_threads')), 'UInt');
+SELECT 'getSetting > 0 max_parsing_threads default',     getSetting('max_parsing_threads') > 0;
+
+SET max_download_threads = DEFAULT;
+SELECT 'getSetting numeric max_download_threads default', startsWith(toTypeName(getSetting('max_download_threads')), 'UInt');
+SELECT 'getSetting value max_download_threads default',   getSetting('max_download_threads');
+
+-- 9. Control: a `SettingAutoWrapper`-style setting (`query_plan_join_swap_table`) preserves the
+--    literal `auto` keyword across DEFAULT - was already correct, must remain correct.
 SET query_plan_join_swap_table = 'true';
 SELECT 'autowrapper-set', value FROM system.settings WHERE name = 'query_plan_join_swap_table';
 SET query_plan_join_swap_table = DEFAULT;
 SELECT 'autowrapper-default', value FROM system.settings WHERE name = 'query_plan_join_swap_table';
 
--- 7. Control: a regular numeric setting (`max_block_size`) is `changed=0` after DEFAULT.
+-- 10. Control: a regular numeric setting (`max_block_size`) is `changed=0` after DEFAULT, and its
+--     `Field` round-trip is invertible - must not regress.
 SET max_block_size = 12345;
 SELECT 'control changed', changed FROM system.settings WHERE name = 'max_block_size';
 SET max_block_size = DEFAULT;
 SELECT 'control default-changed', changed FROM system.settings WHERE name = 'max_block_size';
+SELECT 'control numeric', startsWith(toTypeName(getSetting('max_block_size')), 'UInt');

--- a/tests/queries/0_stateless/04202_set_default_preserves_max_threads_auto.sql
+++ b/tests/queries/0_stateless/04202_set_default_preserves_max_threads_auto.sql
@@ -2,10 +2,13 @@
 --
 -- `SET <name> = DEFAULT` used to lose the `is_auto` flag for `SettingFieldMaxThreads`-typed
 -- settings (`max_threads`, `max_final_threads`, `max_parsing_threads`). The cause was that
--- `BaseSettings::resetValueToDefault` round-tripped through `static_cast<Field>(*default)`,
--- which for `SettingFieldMaxThreads` returns the resolved auto-value (an opaque `UInt64`),
--- so the subsequent `operator=(const Field &)` reconstructed the field as if it had been
--- set to that explicit value.
+-- `BaseSettings::resetValueToDefault` round-trips through `static_cast<Field>(*default)`,
+-- and `SettingFieldMaxThreads::operator Field` used to return the resolved auto-value (an
+-- opaque `UInt64`), so the subsequent `operator=(const Field &)` reconstructed the field as
+-- if it had been set to that explicit value. The fix (mirroring `SettingAutoWrapper`) is to
+-- have `operator Field` emit the `"auto"` keyword when `is_auto` is set, so the round-trip
+-- is invertible: `fieldToMaxThreads(Field("auto"))` parses back to the canonical 0 and
+-- restores `is_auto = true`.
 --
 -- We use `startsWith(value, '''auto(')` to assert that the auto state is preserved without
 -- depending on the actual core count.


### PR DESCRIPTION
Fixes #103120.

`SET max_threads = DEFAULT` (and the same for `max_final_threads` and `max_parsing_threads`) used to lose the `is_auto` flag for `SettingFieldMaxThreads`-typed settings. After the reset, `system.settings` would report `32` instead of `'auto(32)'`, and the runtime would behave as if the user had explicitly pinned `max_threads` to the resolved core count.

## Root cause

`BaseSettings::resetValueToDefault` (`src/Core/BaseSettings.h`) round-tripped the default value through `Field`:

```cpp
auto p = field_infos[index].create_default_function();
*field_infos[index].get_data_function(...) = static_cast<Field>(*p);
```

For `SettingFieldMaxThreads`, `operator Field()` returns the resolved auto-value (the `value` member, e.g. `32`), not the canonical `0` that the constructor maps back to auto. The destination's `operator=(const Field &)` then calls `fieldToMaxThreads(Field(32)) -> operator=(UInt64 32) -> is_auto = !32 = false`. The `Field` round-trip is not invertible, and the auto state is permanently lost.

## Fix

Replace the lossy `Field` round-trip with a per-setting `reset_function` lambda generated by the same macro that emits `get_data_function` / `create_default_function`:

```cpp
[](Data & data) { data.NAME = SettingField##TYPE(DEFAULT); data.NAME.setChanged(false); }
```

Typed copy assignment goes through the setting type's own `operator=`, so all type-specific state is preserved (`is_auto` for `SettingFieldMaxThreads`, plus any future internal flags on other types). The change is structural - it eliminates the entire class of non-invertible-`Field` reset bugs rather than patching a single symptom in one type.

The change touches only the macro that builds `FieldInfo` and the `resetValueToDefault` accessor, so it applies uniformly to every settings group (regular `Settings`, `MergeTreeSettings`, `KafkaSettings`, etc.).

## Test

`tests/queries/0_stateless/04202_set_default_preserves_max_threads_auto.sql` covers:

- single-setting `SET <name> = DEFAULT` for all three `SettingFieldMaxThreads` settings,
- multi-setting `SET a = DEFAULT, b = DEFAULT, ...` form,
- idempotent reset (DEFAULT applied twice still yields auto),
- a `SettingAutoWrapper` control (`query_plan_join_swap_table`) that must remain correct,
- a regular numeric setting control (`max_block_size`) for the `changed` flag.

The test starts by resetting the three settings to `DEFAULT` so it is robust against the test runner's session-level randomization. On a buggy build the test fails on the first three assertions; on the patched build it passes (verified locally with `--test-runs 50` under full CI randomization).

cc @Algunenano - per your request on #103120.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

`SET max_threads = DEFAULT` (and the same for `max_final_threads` and `max_parsing_threads`) no longer loses the auto state. Previously, after resetting one of these settings, `system.settings` would report the resolved core count (e.g. `32`) instead of `'auto(32)'`, and the server would behave as if the value had been explicitly pinned.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)