### PR TITLE
Skip 01192 and 01307 on Azure blob storage

### DIFF
--- a/tests/queries/0_stateless/01192_rename_database_zookeeper.sh
+++ b/tests/queries/0_stateless/01192_rename_database_zookeeper.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
-# Tags: zookeeper, no-parallel, no-fasttest, no-shared-merge-tree, no-flaky-check
+# Tags: zookeeper, no-parallel, no-fasttest, no-shared-merge-tree, no-flaky-check, no-azure-blob-storage
 # no-shared-merge-tree: database ordinary not supported
+# no-azure-blob-storage: this test runs concurrent `INSERT` queries with `sleepEachRow` while
+#   issuing `RENAME DATABASE`, and exceeds the test framework timeout reliably on slow Azure
+#   blob storage. CIDB shows 19 failures / 4482 OKs (0.42%) on
+#   `Stateless tests (arm_asan_ubsan, azure, sequential)`, with 0 failures across 50K+ runs
+#   on every other configuration. Coverage is preserved by other sanitizer/storage configs.
 
 # Creation of a database with Ordinary engine emits a warning.
 CLICKHOUSE_CLIENT_SERVER_LOGS_LEVEL=fatal

--- a/tests/queries/0_stateless/01307_multiple_leaders_zookeeper.sh
+++ b/tests/queries/0_stateless/01307_multiple_leaders_zookeeper.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
-# Tags: zookeeper, no-parallel
+# Tags: zookeeper, no-parallel, no-azure-blob-storage
+# no-azure-blob-storage: this test runs parallel `INSERT` threads against
+#   `ReplicatedMergeTree` and exceeds the test framework timeout under slow Azure blob
+#   storage. CIDB shows 14 failures / 4491 OKs (0.31%) on
+#   `Stateless tests (arm_asan_ubsan, azure, sequential)`, with 0 failures across 45K+ runs
+#   on every other non-Fast-test configuration. Coverage is preserved by other
+#   sanitizer/storage configs.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
These two stateless tests reliably exceed the test framework timeout
on the `Stateless tests (arm_asan_ubsan, azure, sequential)`
configuration, while passing on every other configuration without a
single failure.

The failure mode is `Azure::Storage::StorageException: 408 Timeout:
connect timed out: 127.0.0.1:10000` — the Azurite mock storage backend
cannot keep up under the combined load of `arm` + ASan/UBSan
instrumentation slowdown plus the test's concurrent `INSERT` workload.

Both tests target ZooKeeper / `ReplicatedMergeTree` behaviour, not
Azure-specific code paths, so excluding them on the Azure blob storage
config does not reduce coverage of the feature being tested.

CIDB evidence (30-day window):

| Test | Azure config | Other configs |
|---|---|---|
| `01192_rename_database_zookeeper` | 19 FAIL / 4482 OK (0.42%) | 0 FAIL / 50K+ OK |
| `01307_multiple_leaders_zookeeper` | 14 FAIL / 4491 OK (0.31%) | 0 FAIL / 45K+ OK |

This follows the same pattern used by sibling concurrent
replication-chaos tests that already carry the `no-azure-blob-storage`
tag: `01154_move_partition_long.sh` (PR #103857),
`01169_alter_partition_isolation_stress.sh`,
`01171_mv_select_insert_isolation_long.sh`,
`01443_merge_truncate_long.sh`, `01516_drop_table_stress_long.sh`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.357`
<!-- ch-version-info:end -->