### PR TITLE
Correct `introduced_in` field for functions `tokenize/highlightQuery`

### DIFF
--- a/src/Functions/highlightQuery.cpp
+++ b/src/Functions/highlightQuery.cpp
@@ -100,7 +100,7 @@ and escape characters are highlighted separately.
         .arguments = {{"query", "A ClickHouse SQL query string. String."}},
         .returned_value = {"An array of named tuples `(begin UInt64, end UInt64, type Enum8(...))` representing highlighted ranges.", {"Array(Tuple(begin UInt64, end UInt64, type Enum8(...)))"}},
         .examples = {{"simple", "SELECT highlightQuery('SELECT 1')", R"([(0,6,'keyword'),(7,8,'number')])"}},
-        .introduced_in = {26, 4},
+        .introduced_in = {26, 5},
         .category = FunctionDocumentation::Category::Other,
     });
 }

--- a/src/Functions/tokenizeQuery.cpp
+++ b/src/Functions/tokenizeQuery.cpp
@@ -58,7 +58,7 @@ Each token is a named tuple with the beginning position (in bytes), the end posi
         .arguments = {{"query", "A ClickHouse SQL query string. String."}},
         .returned_value = {"An array of named tuples `(begin UInt64, end UInt64, type Enum8(...))` representing the tokens of the query.", {"Array(Tuple(begin UInt64, end UInt64, type Enum8(...)))"}},
         .examples = {{"simple", "SELECT tokenizeQuery('SELECT 1')", R"([(0,6,'BareWord'),(6,7,'Whitespace'),(7,8,'Number')])"}},
-        .introduced_in = {26, 4},
+        .introduced_in = {26, 5},
         .category = FunctionDocumentation::Category::Other,
     });
 }


### PR DESCRIPTION
Follow-up to https://github.com/ClickHouse/ClickHouse/pull/101054

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.281`
<!-- ch-version-info:end -->