### PR TITLE
Iceberg: do not flag expired originating snapshot_id as spec violation

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFileIterator.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/ManifestFileIterator.cpp
@@ -409,25 +409,13 @@ ProcessedManifestFileEntryPtr ManifestFileIterator::processRow(size_t row_index)
         resolved_snapshot_id = inherited_snapshot_id;
     }
 
+    /// The snapshot that originally added a data file referenced by a manifest entry with
+    /// status=EXISTING may have been expired from the table's snapshot log (e.g. after
+    /// `expire_snapshots`). That is expected and spec-compliant, so we silently fall back
+    /// to the manifest's own schema id, which is the schema under which the manifest's
+    /// statistics (lower/upper bounds, null counts) were written anyway.
     const auto schema_id_opt = schema_processor_ptr->tryGetSchemaIdForSnapshot(resolved_snapshot_id);
-    if (!schema_id_opt.has_value())
-    {
-        /// Error logged but not thrown to avoid breaking whole query because of backward compatibility reasons.
-        /// That's actually an error because it can lead to incorrect query results, so we are creating an exception to put it to system.error_log.
-        try
-        {
-            throw Exception(
-                ErrorCodes::ICEBERG_SPECIFICATION_VIOLATION,
-                "Cannot read Iceberg table: manifest file '{}' has entry with snapshot_id '{}' for which write file schema is unknown",
-                path_to_manifest_file,
-                resolved_snapshot_id);
-        }
-        catch (const Exception &)
-        {
-            tryLogCurrentException("ICEBERG_SPECIFICATION_VIOLATION", "", LogsLevel::error);
-        }
-    }
-    const auto resolved_schema_id = schema_id_opt.has_value() ? *schema_id_opt : manifest_schema_id;
+    const auto resolved_schema_id = schema_id_opt.value_or(manifest_schema_id);
 
     Int64 resolved_sequence_number = 0;
     if (format_version > 1)


### PR DESCRIPTION
The error log:
```
<Error> ICEBERG_SPECIFICATION_VIOLATION: Code: 743. DB::Exception: Cannot read Iceberg table: manifest file
  'lake/obs_tracing/spans/metadata/5ea7d476-64a9-47f3-b9d5-efed8562fea3-m1.avro' has entry with snapshot_id '2500533003030078777' for which write file schema is unknown. (ICEBERG_SPECIFICATION_VIOLATION), Stack trace (when copying this message, always include the lines
  below):

  0. DB::Exception::Exception(DB::Exception::MessageMasked&&, int, bool) @ 0x000000001407a8d0
  1. DB::Exception::Exception(String&&, int, String, bool) @ 0x000000000df6da98
  2. DB::Exception::Exception(PreformattedMessage&&, int) @ 0x000000000df6d38c
  3. DB::Exception::Exception<String const&, long&>(int, FormatStringHelperImpl<std::type_identity<String const&>::type, std::type_identity<long&>::type>, String const&, long&) @ 0x000000001740b25c
  4. DB::Iceberg::ManifestFileIterator::processRow(unsigned long) @ 0x00000000174098b8
  5. DB::Iceberg::SingleThreadIcebergKeysIterator::next() @ 0x00000000173e34cc
  6. void std::__function::__policy_func<void ()>::__call_func[abi:fe210105]<ThreadFromGlobalPoolImpl<true, true>::ThreadFromGlobalPoolImpl<DB::IcebergIterator::IcebergIterator(std::shared_ptr<DB::IObjectStorage>, std::shared_ptr<DB::Context const>, DB::ActionsDAG
  const*, std::function<void (DB::FileProgress)>, std::shared_ptr<DB::Iceberg::TableStateSnapshot>, std::shared_ptr<DB::Iceberg::IcebergDataSnapshot>, DB::Iceberg::PersistentTableComponents)::$_0>(DB::IcebergIterator::IcebergIterator(std::shared_ptr<DB::IObjectStorage>,
  std::shared_ptr<DB::Context const>, DB::ActionsDAG const*, std::function<void (DB::FileProgress)>, std::shared_ptr<DB::Iceberg::TableStateSnapshot>, std::shared_ptr<DB::Iceberg::IcebergDataSnapshot>,
  DB::Iceberg::PersistentTableComponents)::$_0&&)::'lambda'()>(std::__function::__policy_storage const*) @ 0x00000000173eca48
  7. ThreadPoolImpl<std::thread>::ThreadFromThreadPool::worker() @ 0x0000000014205f84
  8. void* std::__thread_proxy[abi:fe210105]<std::tuple<std::unique_ptr<std::__thread_struct, std::default_delete<std::__thread_struct>>, void (ThreadPoolImpl<std::thread>::ThreadFromThreadPool::*)(), ThreadPoolImpl<std::thread>::ThreadFromThreadPool*>>(void*) @
  0x000000001420d1dc
  9. ? @ 0x0000000000080398
  10. ? @ 0x00000000000e9e9c
   (version 26.3.9.8 (official build))
```
However, manifest entries with `status=EXISTING` (produced by `rewrite_manifests`) carry the `snapshot_id` of the snapshot that originally added the data file, which may later be expired from the snapshot log. They are spec compliant.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix Iceberg reader spamming system.error_log with ICEBERG_SPECIFICATION_VIOLATION for manifest entries whose originating snapshot has been expired.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
