### PR TITLE
Iceberg: Optimize JSON metadata parsing by improving string replacement

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergWrites.cpp
@@ -198,13 +198,24 @@ bool canWriteStatistics(
 
 String removeEscapedSlashes(const String & json_str)
 {
-    auto result = json_str;
-    size_t pos = 0;
-    while ((pos = result.find("\\/", pos)) != std::string::npos)
+    size_t pos = json_str.find("\\/");
+    if (pos == String::npos)
+        return json_str;
+
+    String result;
+    result.reserve(json_str.size());
+
+    size_t start = 0;
+    while (pos != String::npos)
     {
-        result.replace(pos, 2, "/");
-        ++pos;
+        result.append(json_str, start, pos - start);
+        result.push_back('/');
+
+        start = pos + 2;
+        pos = json_str.find("\\/", start);
     }
+    result.append(json_str, start, String::npos);
+
     return result;
 }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Significantly improved query performance when reading Iceberg catalogs with large JSON metadata files by optimizing escaped slash processing.

### Benchmark Results
On a Huge (~13.5 MB) Iceberg metadata file containing numerous escaped slashes, the new implementation provides a ~35x speedup:
```text
File loaded: 13.5313 MB
Stringified (POCO) size: 13.6108 MB

Benchmarking dumpMetadataObjectToString with OLD implementation (3 iterations)...
Average time: 24693.4 ms  (~24.7 seconds)
Throughput: 0.551194 MB/s

Benchmarking dumpMetadataObjectToString with NEW implementation (100 iterations)...
Average time: 702.613 ms  (~0.7 seconds)
Throughput: 19.3717 MB/s
```

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.368` (included in `26.5` and later)
- Backported to: `26.4.6.3`, `26.2.20.5`
<!-- ch-version-info:end -->