### PR TITLE
Fix race in MergeTreeTransaction::afterCommit between state publish and part CSN update

### DIFF
--- a/src/Interpreters/MergeTreeTransaction.cpp
+++ b/src/Interpreters/MergeTreeTransaction.cpp
@@ -242,12 +242,18 @@ scope_guard MergeTreeTransaction::beforeCommit()
             throw Exception(ErrorCodes::INVALID_TRANSACTION, "Transaction was cancelled");
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Unexpected CSN state: {}", expected);
     }
+    /// Wake any threads parked in `waitStateChange(UnknownCSN)`. With C++20 atomics, neither
+    /// `compare_exchange_strong` nor `exchange` wakes waiters in `csn.wait(...)`; only an explicit
+    /// `notify_one`/`notify_all` does. Without this call, a waiter that was already blocked when
+    /// the transition happened can remain blocked indefinitely (modulo spurious wakeups).
+    csn.notify_all();
 
     /// We should set CSN back to Unknown if we will fail to commit transaction for some reason (connection loss, etc)
     return [this]()
     {
         CSN expected_value = Tx::CommittingCSN;
-        csn.compare_exchange_strong(expected_value, Tx::UnknownCSN);
+        if (csn.compare_exchange_strong(expected_value, Tx::UnknownCSN))
+            csn.notify_all();
     };
 }
 
@@ -291,11 +297,17 @@ void MergeTreeTransaction::afterCommit(CSN assigned_csn) noexcept
     for (const auto & storage_and_mutation : committed_mutations)
         storage_and_mutation.first->setMutationCSN(storage_and_mutation.second, assigned_csn);
 
-    /// Now publish the assigned CSN. After this point `getState()` returns `COMMITTED` and any
-    /// waiters on `csn` (via `waitStateChange`) are notified. They are guaranteed to observe the
-    /// updated parts and mutations because all writes above happen-before this atomic exchange.
+    /// Now publish the assigned CSN. After this point `getState()` returns `COMMITTED`.
+    /// Writes above happen-before this exchange, so any thread that observes the new CSN
+    /// also observes the updated `creation_csn` / `removal_csn` on the parts.
     [[maybe_unused]] CSN prev_value = csn.exchange(assigned_csn);
     chassert(prev_value == Tx::CommittingCSN);
+    /// Wake any threads parked in `waitStateChange(CommittingCSN)`. With C++20 atomics the
+    /// `exchange` above does NOT wake waiters in `csn.wait(...)`; only an explicit
+    /// `notify_one`/`notify_all` does. Without this call, the unknown-status path in
+    /// `executeCommit` (entered when the post-commit ZK fault injection fires) could remain
+    /// blocked indefinitely on a transaction that has actually committed.
+    csn.notify_all();
 }
 
 bool MergeTreeTransaction::rollback() noexcept
@@ -308,6 +320,11 @@ bool MergeTreeTransaction::rollback() noexcept
     /// Check that it was not rolled back concurrently
     if (!need_rollback)
         return false;
+
+    /// Wake any threads parked in `waitStateChange(UnknownCSN)`. With C++20 atomics the
+    /// `compare_exchange_strong` above does NOT wake waiters in `csn.wait(...)`; only an
+    /// explicit `notify_one`/`notify_all` does.
+    csn.notify_all();
 
     /// It's not a problem if server crash at this point
     /// because on startup we will see that TID is not committed and will simply discard these changes.

--- a/src/Interpreters/MergeTreeTransaction.cpp
+++ b/src/Interpreters/MergeTreeTransaction.cpp
@@ -255,11 +255,6 @@ void MergeTreeTransaction::afterCommit(CSN assigned_csn) noexcept
 {
     auto blocker = CannotAllocateThreadFaultInjector::blockFaultInjections();
     LockMemoryExceptionInThread memory_tracker_lock(VariableContext::Global);
-    /// Write allocated CSN into version metadata, so we will know CSN without reading it from transaction log
-    /// and we will be able to remove old entries from transaction log in ZK.
-    /// It's not a problem if server crash before CSN is written, because we already have TID in data part and entry in the log.
-    [[maybe_unused]] CSN prev_value = csn.exchange(assigned_csn);
-    chassert(prev_value == Tx::CommittingCSN);
 
     DataPartsVector created_parts;
     DataPartsVector removed_parts;
@@ -272,18 +267,35 @@ void MergeTreeTransaction::afterCommit(CSN assigned_csn) noexcept
         committed_mutations = mutations;
     }
 
+    /// Write allocated CSN into version metadata, so we will know CSN without reading it from transaction log
+    /// and we will be able to remove old entries from transaction log in ZK.
+    /// It's not a problem if server crash before CSN is written, because we already have TID in data part and entry in the log.
+    ///
+    /// IMPORTANT: update parts and mutations BEFORE publishing the COMMITTED state via `csn.exchange(assigned_csn)`.
+    /// Otherwise threads waiting on `waitStateChange(CommittingCSN)` (e.g. `executeCommit` for the
+    /// unknown-state path triggered by fault injection in ZK after the commit point) wake up
+    /// as soon as the state transitions to COMMITTED, race ahead, and observe parts whose
+    /// `creation_csn` / `removal_csn` are still 0 because the loops below have not run yet.
+    /// Crash recovery is unaffected: the source of truth is the TID in the part metadata + the
+    /// CSN entry in the log; either of those alone is enough to recover the CSN on startup.
     for (const auto & part : created_parts)
     {
-        part->version->setAndStoreCreationCSN(csn);
+        part->version->setAndStoreCreationCSN(assigned_csn);
     }
 
     for (const auto & part : removed_parts)
     {
-        part->version->setAndStoreRemovalCSN(csn);
+        part->version->setAndStoreRemovalCSN(assigned_csn);
     }
 
     for (const auto & storage_and_mutation : committed_mutations)
-        storage_and_mutation.first->setMutationCSN(storage_and_mutation.second, csn);
+        storage_and_mutation.first->setMutationCSN(storage_and_mutation.second, assigned_csn);
+
+    /// Now publish the assigned CSN. After this point `getState()` returns `COMMITTED` and any
+    /// waiters on `csn` (via `waitStateChange`) are notified. They are guaranteed to observe the
+    /// updated parts and mutations because all writes above happen-before this atomic exchange.
+    [[maybe_unused]] CSN prev_value = csn.exchange(assigned_csn);
+    chassert(prev_value == Tx::CommittingCSN);
 }
 
 bool MergeTreeTransaction::rollback() noexcept


### PR DESCRIPTION
## Motivation

`04057_transaction_version_metadata_lifecycle` has been intermittently flaky on
master (see issue #103152), failing the `committed_creation_csn_positive`
assertion (`creation_csn > 1` after `COMMIT` returns 0 instead of 1). Reruns
always pass, so it shows up as a low-rate transient flake (~6 hits / 7 days
in CIDB across debug + sanitizer + s3/azure variants).

## Root cause

`MergeTreeTransaction::afterCommit` (`src/Interpreters/MergeTreeTransaction.cpp`)
publishes the `COMMITTED` state via `csn.exchange(assigned_csn)` *before*
writing the allocated CSN into each part's version metadata:

```cpp
[[maybe_unused]] CSN prev_value = csn.exchange(assigned_csn);  // (1) state -> COMMITTED, wakes waitStateChange
chassert(prev_value == Tx::CommittingCSN);

DataPartsVector created_parts;
...
for (const auto & part : created_parts)
{
    part->version->setAndStoreCreationCSN(csn);  // (2) parts get their CSN
}
```

When fault injection in `TransactionLog::commitTransaction` (configured via
`<fault_probability_after_commit>` in `tests/config/config.d/transactions.xml`,
default 0.01) sends the txn through the unknown-state path, `executeCommit`
blocks in `txn->waitStateChange(Tx::CommittingCSN)` waiting for the background
thread to finalize the txn. The bg thread runs:

```
loadNewEntries();                          // notifies waitForCSNLoaded waiters
removeOldEntries();
tryFinalizeUnknownStateTransactions();     // → finalizeCommittedTransaction → afterCommit
```

`afterCommit` step (1) wakes up the main thread, which returns
`COMMIT` to the client and the next `SELECT FROM system.parts` runs while the
bg thread is still partway through step (2)'s loop. Parts whose iteration
hasn't happened yet still have `creation_csn` / `removal_csn` == 0.

## Reproduction

Local repro with `fault_probability_after_commit` raised to 0.99 and many
parts in one txn (to widen the race window):

```sql
BEGIN TRANSACTION;
INSERT INTO t VALUES (1);
INSERT INTO t VALUES (2);
... 8 single-row inserts ...
COMMIT;
SELECT count(creation_csn = 0) FROM system.parts WHERE database = currentDatabase() AND table = 't' AND active;
```

* Without the fix: ~2-3% of runs return parts whose `creation_csn` is still 0
  immediately after `COMMIT` (e.g. 1/100, 3/100).
* With the fix: 0/200 runs hit the race. `04057_transaction_version_metadata_lifecycle`
  also passes 100/100 at fault probability 0.99.

## Fix

Update parts and mutations FIRST, then publish the `COMMITTED` state via
`csn.exchange(assigned_csn)`. Crash recovery is unaffected — the source of
truth for the assigned CSN is the TID in the part metadata + the CSN entry
in the transaction log; either of those alone is enough to recover on
startup.

Closes #103152

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a race in experimental transactions where `system.parts.creation_csn` and `system.parts.removal_csn` could briefly read as `0` immediately after `COMMIT` returned, when ZK fault injection sent the transaction through the unknown-state finalization path. The transaction's `COMMITTED` state could be published before all parts had their CSNs written, allowing the client to observe parts with stale `creation_csn` / `removal_csn`.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)