### PR TITLE
Add test: Slow-path `getGreatestIndexNotNullIf` `>` comparison untested for `argMax`/`argMaxIf` over Nullable wide numerics (Decimal128/256, Int128/256, UInt128/256)

### DIFF
--- a/tests/queries/0_stateless/04201_argMinMax_nullable_wide_numeric.reference
+++ b/tests/queries/0_stateless/04201_argMinMax_nullable_wide_numeric.reference
@@ -1,0 +1,4 @@
+Decimal128	3	1	4	5
+Decimal256	3	1	4	5
+Int128	3	1	4	5
+UInt256	3	1	4	5

--- a/tests/queries/0_stateless/04201_argMinMax_nullable_wide_numeric.sql
+++ b/tests/queries/0_stateless/04201_argMinMax_nullable_wide_numeric.sql
@@ -1,0 +1,58 @@
+-- Test: exercises `getGreatestIndexNotNullIf`/`getSmallestIndexNotNullIf` slow path
+-- with `Nullable(Decimal128)`, `Nullable(Decimal256)`, `Nullable(Int128)`, `Nullable(UInt256)`.
+-- Covers: src/AggregateFunctions/SingleValueData.cpp:776-778 — the `vec_data[i] > vec_data[index]`
+-- branch is reached only for types NOT in `has_find_extreme_implementation` /
+-- `underlying_has_find_extreme_implementation` (i.e., wide ints and Decimal128/256).
+-- The PR's own test uses `Nullable(DateTime64)` which since then was added to the fast path,
+-- so the slow-path comparison branch (the bug-fix line) has zero coverage in the suite.
+
+DROP TABLE IF EXISTS t_argminmax_wide;
+
+CREATE TABLE t_argminmax_wide
+(
+    v Int64,
+    t_dec128 Nullable(Decimal128(0)),
+    t_dec256 Nullable(Decimal256(0)),
+    t_int128 Nullable(Int128),
+    t_uint256 Nullable(UInt256)
+) ENGINE = MergeTree ORDER BY tuple();
+
+-- Greatest key=30 at v=3 (middle row), smallest key=10 at v=1 (first row).
+-- A buggy `<`-instead-of-`>` slow path would never update the index past row 0
+-- and return v=1 for both argMax and argMin.
+INSERT INTO t_argminmax_wide VALUES
+    (1, 10, 10,  10,  10),
+    (2, 20, 20,  20,  20),
+    (3, 30, 30,  30,  30),
+    (4, 25, 25,  25,  25),
+    (5, 15, 15,  15,  15);
+
+SELECT 'Decimal128',
+    argMax(v, t_dec128),
+    argMin(v, t_dec128),
+    argMaxIf(v, t_dec128, v != 3),
+    argMinIf(v, t_dec128, v != 1)
+FROM t_argminmax_wide;
+
+SELECT 'Decimal256',
+    argMax(v, t_dec256),
+    argMin(v, t_dec256),
+    argMaxIf(v, t_dec256, v != 3),
+    argMinIf(v, t_dec256, v != 1)
+FROM t_argminmax_wide;
+
+SELECT 'Int128',
+    argMax(v, t_int128),
+    argMin(v, t_int128),
+    argMaxIf(v, t_int128, v != 3),
+    argMinIf(v, t_int128, v != 1)
+FROM t_argminmax_wide;
+
+SELECT 'UInt256',
+    argMax(v, t_uint256),
+    argMin(v, t_uint256),
+    argMaxIf(v, t_uint256, v != 3),
+    argMinIf(v, t_uint256, v != 1)
+FROM t_argminmax_wide;
+
+DROP TABLE t_argminmax_wide;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #62285](https://github.com/ClickHouse/ClickHouse/pull/62285) (merged 2024-04-05). Confirmed on current codebase — close with a note if already fixed._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #62285](https://github.com/ClickHouse/ClickHouse/pull/62285).
 That PR PR #62285 fixes a one-character typo (`<` → `>`) in the slow non-find-extreme branch of `SingleValueDataFixed<T>::getGreatestIndexNotNullIf` (used by `argMax`/`argMaxIf` for Nullable inputs and `IF`-combinator usage). The PR's own test exercises `Nullable(DateTime64)`, which at the time of the fix w

**1. Slow-path `getGreatestIndexNotNullIf` `>` comparison untested for `argMax`/`argMaxIf` over Nullable wide numerics (Decimal128/256, Int128/256, UInt128/256)**
  `src/AggregateFunctions/SingleValueData.cpp:777`, `src/AggregateFunctions/SingleValueData.cpp:666`
  **Risk:** Call chain: `AggregateFunctionArgMinMax::addBatchSinglePlaceNotNull` (Nullable wraps argument) → `SingleValueDataFixed<Decimal128>::getGreatestIndexNotNullIf` → `else` branch (Decimal128 not in `has_f
  **What's unique vs PR tests:** PR test (03035_argMinMax_numeric_non_extreme_bug.sql) uses `Nullable(DateTime64)`; DateTime64 is in `underlying_has_find_extreme_implementation` so the PR test now routes through the SIMD fast path (l
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/664e69a5-22ae-4bc7-afa9-6daba45bf5f8)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.263`
<!-- ch-version-info:end -->