### PR TITLE
Fix incorrect introduced_in tags for several functions

### DIFF
--- a/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeSeriesGroupArray.cpp
+++ b/src/AggregateFunctions/TimeSeries/AggregateFunctionTimeSeriesGroupArray.cpp
@@ -144,7 +144,7 @@ SELECT timeSeriesGroupArray(timestamps, values);
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in = {25, 9};
+    FunctionDocumentation::IntroducedIn introduced_in = {25, 8};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::AggregateFunction;
     FunctionDocumentation documentation = {description, syntax, arguments, parameters, returned_value, examples, introduced_in, category};
 

--- a/src/Functions/TimeSeries/timeSeriesGroupToSamplingKey.cpp
+++ b/src/Functions/TimeSeries/timeSeriesGroupToSamplingKey.cpp
@@ -100,7 +100,7 @@ SELECT timeSeriesTagsToGroup([('region', 'eu'), ('env', 'dev')], '__name__', 'ht
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in = {26, 1};
+    FunctionDocumentation::IntroducedIn introduced_in = {26, 4};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::TimeSeries;
     FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 

--- a/src/Functions/area.cpp
+++ b/src/Functions/area.cpp
@@ -68,7 +68,7 @@ REGISTER_FUNCTION(Area)
         };
         FunctionDocumentation::Examples examples;
 
-        FunctionDocumentation::IntroducedIn introduced_in = {25, 10};
+        FunctionDocumentation::IntroducedIn introduced_in = {25, 12};
         FunctionDocumentation::Category category = FunctionDocumentation::Category::Geo;
         FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
@@ -87,7 +87,7 @@ REGISTER_FUNCTION(Area)
             {"Float64"}
         };
         FunctionDocumentation::Examples examples;
-        FunctionDocumentation::IntroducedIn introduced_in = {25, 10};
+        FunctionDocumentation::IntroducedIn introduced_in = {25, 12};
         FunctionDocumentation::Category category = FunctionDocumentation::Category::Geo;
         FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 

--- a/src/Functions/dateTimeToUUIDv7.cpp
+++ b/src/Functions/dateTimeToUUIDv7.cpp
@@ -175,7 +175,7 @@ SELECT dateTimeToUUIDv7(toDateTime('2021-08-15 18:57:56'));
        )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in = {25, 9};
+    FunctionDocumentation::IntroducedIn introduced_in = {25, 8};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::UUID;
     FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 

--- a/src/Functions/endsWith.cpp
+++ b/src/Functions/endsWith.cpp
@@ -60,7 +60,7 @@ Checks whether a string ends with the provided case-insensitive suffix.
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in = {25, 9};
+    FunctionDocumentation::IntroducedIn introduced_in = {25, 10};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
     FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 

--- a/src/Functions/endsWithUTF8.cpp
+++ b/src/Functions/endsWithUTF8.cpp
@@ -63,7 +63,7 @@ If this assumption is violated, no exception is thrown and the result is undefin
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in = {25, 9};
+    FunctionDocumentation::IntroducedIn introduced_in = {25, 10};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
     FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 

--- a/src/Functions/flipCoordinates.cpp
+++ b/src/Functions/flipCoordinates.cpp
@@ -182,7 +182,7 @@ The function supports both individual geometry types (Point, Ring, Polygon, Mult
          "SELECT flipCoordinates(readWkt('POLYGON((0 0, 5 0, 5 5, 0 5, 0 0))'));",
          "[[(0, 0), (0, 5), (5, 5), (5, 0), (0, 0)]]"}
     };
-    FunctionDocumentation::IntroducedIn introduced_in = {25, 10};
+    FunctionDocumentation::IntroducedIn introduced_in = {25, 11};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
 
     FunctionDocumentation function_documentation = {

--- a/src/Functions/isNotDistinctFrom.cpp
+++ b/src/Functions/isNotDistinctFrom.cpp
@@ -43,7 +43,7 @@ SELECT
         )"}
     };
 
-    FunctionDocumentation::IntroducedIn introduced_in = {25, 10};
+    FunctionDocumentation::IntroducedIn introduced_in = {23, 8};
 
     FunctionDocumentation::Category category = FunctionDocumentation::Category::Comparison;
 

--- a/src/Functions/naturalSortKey.cpp
+++ b/src/Functions/naturalSortKey.cpp
@@ -236,7 +236,7 @@ REGISTER_FUNCTION(NaturalSortKey)
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in = {25, 11};
+    FunctionDocumentation::IntroducedIn introduced_in = {26, 3};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
     FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 

--- a/src/Functions/obfuscateQuery.cpp
+++ b/src/Functions/obfuscateQuery.cpp
@@ -354,7 +354,7 @@ REGISTER_FUNCTION(obfuscateQuery)
          "A B"}
     };
 
-    FunctionDocumentation::IntroducedIn introduced_in = {26, 3};
+    FunctionDocumentation::IntroducedIn introduced_in = {26, 4};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::Other;
     FunctionDocumentation::Parameters parameters = {};
 

--- a/src/Functions/perimeter.cpp
+++ b/src/Functions/perimeter.cpp
@@ -67,7 +67,7 @@ REGISTER_FUNCTION(Perimeter)
         };
         FunctionDocumentation::Examples examples;
 
-        FunctionDocumentation::IntroducedIn introduced_in = {25, 10};
+        FunctionDocumentation::IntroducedIn introduced_in = {25, 12};
         FunctionDocumentation::Category category = FunctionDocumentation::Category::Geo;
         FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 
@@ -87,7 +87,7 @@ REGISTER_FUNCTION(Perimeter)
         };
         FunctionDocumentation::Examples examples;
 
-        FunctionDocumentation::IntroducedIn introduced_in = {25, 10};
+        FunctionDocumentation::IntroducedIn introduced_in = {25, 12};
         FunctionDocumentation::Category category = FunctionDocumentation::Category::Geo;
         FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 

--- a/src/Functions/polygonsIntersect.cpp
+++ b/src/Functions/polygonsIntersect.cpp
@@ -132,7 +132,7 @@ REGISTER_FUNCTION(polygonsIntersect)
                 │ 1 │
                 └───────────────────┘
         )"}},
-        .introduced_in = {25, 6},
+        .introduced_in = {25, 7},
         .category = FunctionDocumentation::Category::Geo});
 
     factory.registerFunction<FunctionpolygonsIntersect<SphericalPoint>>(FunctionDocumentation{
@@ -160,7 +160,7 @@ REGISTER_FUNCTION(polygonsIntersect)
                 │ 1 │
                 └───────────────────┘
         )"}},
-        .introduced_in = {25, 6},
+        .introduced_in = {25, 7},
         .category = FunctionDocumentation::Category::Geo});
 }
 

--- a/src/Functions/readWkb.cpp
+++ b/src/Functions/readWkb.cpp
@@ -258,7 +258,7 @@ SELECT toTypeName(readWKBPoint(unhex('0101000000333333333333f33f3333333333330b40
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_point = {25, 11};
+    FunctionDocumentation::IntroducedIn introduced_in_point = {25, 6};
     FunctionDocumentation::Category category_point = FunctionDocumentation::Category::GeoPolygon;
     FunctionDocumentation function_documentation_point = {description_point, syntax_point, arguments_point, {}, returned_value_point, examples_point, introduced_in_point, category_point};
 
@@ -282,7 +282,7 @@ SELECT readWKBLineString(unhex('010200000004000000000000000000f03f000000000000f0
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_linestring = {25, 11};
+    FunctionDocumentation::IntroducedIn introduced_in_linestring = {25, 6};
     FunctionDocumentation::Category category_linestring = FunctionDocumentation::Category::GeoPolygon;
     FunctionDocumentation function_documentation_linestring = {description_linestring, syntax_linestring, arguments_linestring, {}, returned_value_linestring, examples_linestring, introduced_in_linestring, category_linestring};
 
@@ -306,7 +306,7 @@ SELECT readWKBMultiLineString(unhex('0105000000020000000102000000030000000000000
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_multilinestring = {25, 11};
+    FunctionDocumentation::IntroducedIn introduced_in_multilinestring = {25, 6};
     FunctionDocumentation::Category category_multilinestring = FunctionDocumentation::Category::GeoPolygon;
     FunctionDocumentation function_documentation_multilinestring = {description_multilinestring, syntax_multilinestring, arguments_multilinestring, {}, returned_value_multilinestring, examples_multilinestring, introduced_in_multilinestring, category_multilinestring};
 
@@ -332,7 +332,7 @@ Polygon [[(2,0),(10,0),(10,10),(0,10),(2,0)]]
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_polygon = {25, 11};
+    FunctionDocumentation::IntroducedIn introduced_in_polygon = {25, 6};
     FunctionDocumentation::Category category_polygon = FunctionDocumentation::Category::GeoPolygon;
     FunctionDocumentation function_documentation_polygon = {description_polygon, syntax_polygon, arguments_polygon, {}, returned_value_polygon, examples_polygon, introduced_in_polygon, category_polygon};
 
@@ -359,7 +359,7 @@ readWKBMulti~000024c0')): [[[(2,0),(10,0),(10,10),(0,10),(2,0)],[(4,4),(5,4),(5,
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_multipolygon = {25, 11};
+    FunctionDocumentation::IntroducedIn introduced_in_multipolygon = {25, 6};
     FunctionDocumentation::Category category_multipolygon = FunctionDocumentation::Category::GeoPolygon;
     FunctionDocumentation function_documentation_multipolygon = {description_multipolygon, syntax_multipolygon, arguments_multipolygon, {}, returned_value_multipolygon, examples_multipolygon, introduced_in_multipolygon, category_multipolygon};
 

--- a/src/Functions/readWkt.cpp
+++ b/src/Functions/readWkt.cpp
@@ -435,7 +435,7 @@ Parses a Well-Known Text (WKT) representation of Geometry and returns it in the 
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in_common = {25, 7};
+    FunctionDocumentation::IntroducedIn introduced_in_common = {25, 12};
     FunctionDocumentation::Category category_common = FunctionDocumentation::Category::Geo;
     FunctionDocumentation function_documentation_common = {description_common, syntax_common, arguments_common, {}, returned_value_common, examples_common, introduced_in_common, category_common};
 

--- a/src/Functions/startsWith.cpp
+++ b/src/Functions/startsWith.cpp
@@ -60,7 +60,7 @@ Checks whether a string begins with the provided case-insensitive string.
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in = {25, 9};
+    FunctionDocumentation::IntroducedIn introduced_in = {25, 10};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
     FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 

--- a/src/Functions/startsWithUTF8.cpp
+++ b/src/Functions/startsWithUTF8.cpp
@@ -64,7 +64,7 @@ If this assumption is violated, no exception is thrown and the result is undefin
         )"
     }
     };
-    FunctionDocumentation::IntroducedIn introduced_in = {25, 9};
+    FunctionDocumentation::IntroducedIn introduced_in = {25, 10};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::String;
     FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 

--- a/src/TableFunctions/TableFunctionPrimes.cpp
+++ b/src/TableFunctions/TableFunctionPrimes.cpp
@@ -142,7 +142,7 @@ void registerTableFunctionPrimes(TableFunctionFactory & factory)
                 {"The first prime after 1e15", "SELECT prime FROM primes() WHERE prime > toUInt64(1e15) LIMIT 1;", ""},
                 {"The first 7 Mersenne primes", "SELECT prime FROM primes() WHERE bitAnd(prime, prime + 1) = 0 LIMIT 7;", ""},
             },
-            .introduced_in = {26, 1},
+            .introduced_in = {26, 2},
             .category = FunctionDocumentation::Category::TableFunction,
         },
         {.allow_readonly = true}


### PR DESCRIPTION
Follow-up to #103993 which corrected the `introduced_in` field for `tokenizeQuery` and `highlightQuery`. While reviewing that PR I cross-checked every recent `introduced_in` annotation in `src/Functions`, `src/AggregateFunctions` and `src/TableFunctions` against the official release binaries (`system.functions`) and the corresponding release branches, and found a number of additional incorrect tags. They fall into two buckets:

File / function does not exist in the claimed release branch but appears in a later one:
- `obfuscateQuery`: `{26, 3}` → `{26, 4}`
- `areaCartesian`, `areaSpherical` (`area.cpp`): `{25, 10}` → `{25, 12}`
- `perimeterCartesian`, `perimeterSpherical` (`perimeter.cpp`): `{25, 10}` → `{25, 12}`
- `flipCoordinates` (`flipCoordinates.cpp`): `{25, 10}` → `{25, 11}`
- `naturalSortKey` (`naturalSortKey.cpp`): `{25, 11}` → `{26, 3}`
- `polygonsIntersectCartesian`, `polygonsIntersectSpherical` (`polygonsIntersect.cpp`): `{25, 6}` → `{25, 7}`
- `timeSeriesGroupToSamplingKey`: `{26, 1}` → `{26, 4}`
- `primes` table function: `{26, 1}` → `{26, 2}`
- `endsWithCaseInsensitive`, `startsWithCaseInsensitive`, `endsWithCaseInsensitiveUTF8`, `startsWithCaseInsensitiveUTF8`: `{25, 9}` → `{25, 10}`
- `readWKT` (unified, `readWkt.cpp`): `{25, 7}` → `{25, 12}`

Tag is too late — the function exists in earlier binaries than the claimed version:
- `dateTimeToUUIDv7`: `{25, 9}` → `{25, 8}` (was originally `{25, 8}` and incorrectly bumped)
- `timeSeriesGroupArray`: `{25, 9}` → `{25, 8}`
- `isNotDistinctFrom`: `{25, 10}` → `{23, 8}`
- `readWKBPoint`, `readWKBLineString`, `readWKBMultiLineString`, `readWKBPolygon`, `readWKBMultiPolygon` (`readWkb.cpp`): `{25, 11}` → `{25, 6}`

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.272`
<!-- ch-version-info:end -->