### PR TITLE
Fix flaky test_s3_cluster: scope generated CSV dir per xdist worker

### DIFF
--- a/tests/integration/test_s3_cluster/test.py
+++ b/tests/integration/test_s3_cluster/test.py
@@ -17,7 +17,9 @@ logging.getLogger().setLevel(logging.INFO)
 logging.getLogger().addHandler(logging.StreamHandler())
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
-S3_DATA = [
+
+# Base CSV files committed to git. Immutable on disk, safe to read concurrently.
+S3_BASE_FILES = [
     "data/clickhouse/part1.csv",
     "data/clickhouse/part123.csv",
     "data/database/part2.csv",
@@ -25,14 +27,48 @@ S3_DATA = [
 ]
 
 
+def _generated_host_dir():
+    """Per-xdist-worker host directory for the dynamically generated CSV files.
+
+    Concurrent xdist workers running this module (especially under
+    `--dist=each`, used by the targeted/flaky integration jobs) all execute
+    this fixture in parallel. Their MinIO containers are isolated by
+    `ClickHouseCluster` (it appends `PYTEST_XDIST_WORKER` to `project_name`),
+    but the host filesystem path is not. With a shared host directory, one
+    worker's teardown (`shutil.rmtree(...)`) deletes files while another
+    worker is still uploading them, producing setup-phase
+    `FileNotFoundError` on `data/generated/file_*.csv` and failing every
+    test in the module via fixture error.
+
+    The MinIO bucket key for tests stays `data/generated/file_N.csv` (each
+    worker uploads to its own MinIO instance); only the host write/read path
+    is scoped per worker.
+    """
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER", "")
+    suffix = f"_{worker_id}" if worker_id else ""
+    return os.path.join(SCRIPT_DIR, f"data/generated{suffix}")
+
+
 def create_buckets_s3(cluster):
     minio = cluster.minio_client
 
+    host_dir = _generated_host_dir()
+    os.makedirs(host_dir, exist_ok=True)
+
+    files_to_upload = []  # list of (bucket_object_key, host_file_path)
+
+    # Base files: committed in git, read from the shared SCRIPT_DIR location.
+    for relative_path in S3_BASE_FILES:
+        files_to_upload.append(
+            (relative_path, os.path.join(SCRIPT_DIR, relative_path))
+        )
+
+    # Generated files: written into a per-worker host directory but uploaded
+    # to MinIO under the canonical `data/generated/` prefix that tests query.
     for file_number in range(100):
-        file_name = f"data/generated/file_{file_number}.csv"
-        os.makedirs(os.path.join(SCRIPT_DIR, "data/generated/"), exist_ok=True)
-        S3_DATA.append(file_name)
-        with open(os.path.join(SCRIPT_DIR, file_name), "w+", encoding="utf-8") as f:
+        bucket_object_key = f"data/generated/file_{file_number}.csv"
+        host_path = os.path.join(host_dir, f"file_{file_number}.csv")
+        with open(host_path, "w+", encoding="utf-8") as f:
             # a String, b UInt64
             data = []
 
@@ -44,12 +80,13 @@ def create_buckets_s3(cluster):
 
             writer = csv.writer(f)
             writer.writerows(data)
+        files_to_upload.append((bucket_object_key, host_path))
 
-    for file in S3_DATA:
+    for bucket_object_key, host_path in files_to_upload:
         minio.fput_object(
             bucket_name=cluster.minio_bucket,
-            object_name=file,
-            file_path=os.path.join(SCRIPT_DIR, file),
+            object_name=bucket_object_key,
+            file_path=host_path,
         )
     for obj in minio.list_objects(cluster.minio_bucket, recursive=True):
         print(obj.object_name)
@@ -68,6 +105,7 @@ def run_s3_mocks(started_cluster):
 
 @pytest.fixture(scope="module")
 def started_cluster():
+    cluster = None
     try:
         cluster = ClickHouseCluster(__file__)
         cluster.add_instance(
@@ -103,8 +141,10 @@ def started_cluster():
 
         yield cluster
     finally:
-        shutil.rmtree(os.path.join(SCRIPT_DIR, "data/generated/"), ignore_errors=True)
-        cluster.shutdown()
+        # Only this worker's directory; never touches other workers' data.
+        shutil.rmtree(_generated_host_dir(), ignore_errors=True)
+        if cluster is not None:
+            cluster.shutdown()
 
 
 def test_select_all(started_cluster):


### PR DESCRIPTION
The `started_cluster` fixture in `tests/integration/test_s3_cluster/test.py`
writes 100 CSV files to `tests/integration/test_s3_cluster/data/generated/`,
uploads them to MinIO, then deletes the directory in teardown.

Under `Integration tests (amd_asan_ubsan, targeted)` the runner uses
pytest-xdist with `--dist=each`, so every test goes to every worker and the
module-scoped fixture runs concurrently in multiple processes. Their MinIO
containers are isolated by `ClickHouseCluster` (it appends
`PYTEST_XDIST_WORKER` to `project_name`), but the host filesystem path was
shared. One worker's teardown could `shutil.rmtree(...)` the directory
while another worker was still iterating over it inside the upload loop in
`create_buckets_s3`, surfacing as `FileNotFoundError` on
`data/generated/file_0.csv` during fixture setup and failing every test in
the module via fixture error.

Pattern matches Issue #102238 (open since 2026-04-09) and CIDB shows ~21–23
unrelated PRs hitting the same setup error in the past 30 days for tests
across the suite (`test_wrong_cluster`, `test_select_all`, `test_count`,
`test_union_all`, `test_hive_partitioning`, etc.) — exactly the symptom
expected when a module-scoped fixture errors and propagates to all 18
tests.

Earlier PR #102144 added `ignore_errors=True` to the teardown `rmtree` to
silence the cleanup-side variant of this race; this change addresses the
upload-side variant by removing the shared resource.

This change scopes the host directory by `PYTEST_XDIST_WORKER` so
concurrent workers no longer share filesystem state. The MinIO bucket key
still uploads under the canonical `data/generated/` prefix, so all test
queries (`SELECT … FROM s3('http://minio1:9001/root/data/generated/*'…)`)
are unchanged. Also decouple the host path from the bucket object key
(previously a single `f"data/generated/file_{n}.csv"` was used as both),
drop the module-level mutable `S3_DATA` list, and guard
`cluster.shutdown()` in the teardown against the pre-existing case where
the `ClickHouseCluster(__file__)` constructor raises before `cluster` gets
bound.

Race deterministically reproduced with a minimal Python harness
(`tmp/race_repro.py`, 2 threads, shared dir): 20/20 trials hit
`FileNotFoundError` without the fix; 0/20 with per-worker dirs.

Closes #102238

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.291`
<!-- ch-version-info:end -->