### PR TITLE
Add test: `throwIfWindowViewIsDisabled` paths and `disabled_due_to_analyzer` ATTACH state are entirely untested

### DIFF
--- a/tests/queries/0_stateless/04202_window_view_disabled_with_analyzer.sql
+++ b/tests/queries/0_stateless/04202_window_view_disabled_with_analyzer.sql
@@ -1,0 +1,57 @@
+-- Tags: no-fasttest, no-parallel, no-replicated-database
+-- Test: exercises `throwIfWindowViewIsDisabled` paths in `StorageWindowView`
+-- Covers: src/Storages/WindowView/StorageWindowView.cpp
+--   line 1797 — throwIfWindowViewIsDisabled definition (member-flag and per-query setting branch)
+--   line 1265 — constructor CREATE-mode check
+--   line 467  — optimize()
+--   line 478  — alter()
+--   line 538  — checkAlterIsPossible()
+--   line 1178 — read()
+-- These error paths block window view operations when the analyzer setting is on, so the
+-- server does not crash on startup and operations on a window view loaded in disabled state fail clearly.
+
+DROP TABLE IF EXISTS wv_src_4202;
+DROP TABLE IF EXISTS wv_4202;
+
+SET allow_experimental_window_view = 1;
+SET allow_experimental_analyzer = 0;
+CREATE TABLE wv_src_4202 (a Int32, ts DateTime) ENGINE = MergeTree ORDER BY tuple();
+
+-- 1) CREATE WINDOW VIEW with analyzer enabled must fail (constructor check at line 1265).
+SET allow_experimental_analyzer = 1;
+CREATE WINDOW VIEW wv_4202 ENGINE Memory AS
+    SELECT count(a) AS cnt, tumbleStart(wid) AS w_start
+    FROM wv_src_4202
+    GROUP BY tumble(ts, INTERVAL '5' SECOND) AS wid; -- { serverError UNSUPPORTED_METHOD }
+
+-- 2) Create the window view with analyzer disabled, then exercise per-query analyzer setting.
+SET allow_experimental_analyzer = 0;
+CREATE WINDOW VIEW wv_4202 ENGINE Memory AS
+    SELECT count(a) AS cnt, tumbleStart(wid) AS w_start
+    FROM wv_src_4202
+    GROUP BY tumble(ts, INTERVAL '5' SECOND) AS wid;
+
+-- read() throw path (line 1178) — query context has analyzer=1.
+SELECT * FROM wv_4202 SETTINGS allow_experimental_analyzer = 1; -- { serverError UNSUPPORTED_METHOD }
+
+-- optimize() throw path (line 467).
+OPTIMIZE TABLE wv_4202 SETTINGS allow_experimental_analyzer = 1; -- { serverError UNSUPPORTED_METHOD }
+
+-- alter() throw path (lines 478, 538) — set analyzer flag at session level.
+SET allow_experimental_analyzer = 1;
+ALTER TABLE wv_4202 MODIFY QUERY
+    SELECT count(a) AS cnt, tumbleStart(wid) AS w_start
+    FROM wv_src_4202
+    GROUP BY tumble(ts, INTERVAL '10' SECOND) AS wid; -- { serverError UNSUPPORTED_METHOD }
+SET allow_experimental_analyzer = 0;
+
+-- 3) Re-attach with analyzer enabled puts the table in disabled_due_to_analyzer state
+--    (line 1262); SELECT then fails even with analyzer=0 in the query context (member-flag branch at line 1799).
+DETACH TABLE wv_4202;
+SET allow_experimental_analyzer = 1;
+ATTACH TABLE wv_4202;
+SET allow_experimental_analyzer = 0;
+SELECT * FROM wv_4202; -- { serverError UNSUPPORTED_METHOD }
+
+DROP TABLE wv_4202;
+DROP TABLE wv_src_4202;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #62367](https://github.com/ClickHouse/ClickHouse/pull/62367) (merged 2024-04-08). Confirmed on current codebase — close with a note if already fixed._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #62367](https://github.com/ClickHouse/ClickHouse/pull/62367).
 That PR PR62367 fixes a server-startup crash that happened when a `WindowView` table was loaded from disk with the analyzer enabled (the original code threw UNSUPPORTED_METHOD inside the constructor, aborting metadata load). The fix replaces the constructor-time throw with a `disabled_due_to_analyzer` flag 

**1. `throwIfWindowViewIsDisabled` paths and `disabled_due_to_analyzer` ATTACH state are entirely untested**
  `src/Storages/WindowView/StorageWindowView.cpp:1797`, `src/Storages/WindowView/StorageWindowView.cpp:1265`
  **Risk:** Call chain: client query → `StorageWindowView::read`/`optimize`/`alter`/`checkAlterIsPossible` → `throwIfWindowViewIsDisabled(local_context)` → `if (disabled_due_to_analyzer || (local_context && local
  **What's unique vs PR tests:** The PR's own test changes are limited to adding `SET allow_experimental_analyzer = 0` lines in the watch-tests `.py` files (those tests have since been removed from upstream). None of the PR's tests a
  **Tags:** `-- Tags: no-fasttest, no-parallel, no-replicated-database` — `no-fasttest`: WINDOW VIEW feature is excluded from the fast build (allow_experimental_window_view setting + supporting code).; `no-parallel`: Window view creates fixed-name inner tables (.inner.<name>, .inner.target.<name>) that would collide if the test ran concurrently with another window view test.; `no-replicated-database`: WINDOW VIEW is not supported by Replicated database engine; the wrapper would route DDL through ZK and fail unrelated assertions.
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/c9d5f4ed-efa9-412b-94f3-745fd434b683)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.388`
<!-- ch-version-info:end -->