### PR TITLE
Allowlist `02555_davengers_rename_chain` upgrade-check errors

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -349,10 +349,15 @@ cp /var/log/clickhouse-server/clickhouse-server.upgrade.log /test_output/clickho
 #       `<renamed><original>.bin` instead of `<renamed>.bin`). The fix is in PR #102689; until it lands, the
 #       upgraded server detaches the renamed-column parts of `02538_alter_rename_sequence`'s `wrong_metadata_wide`
 #       table. Matched via the exact corrupted filename + column name, which is unique to that test and that bug.
-# `wrong_metadata_wide` + `Detaching broken part` + `backward incompatibility` is the follow-up cleanup line for
-#       the same issue: a "Detaching broken part" notice that does not contain the corrupted filename. Filtered
-#       via regex in the secondary pipe below to require all three substrings together, so unrelated broken-part
-#       detach messages are not masked.
+# `No stream (ba1.bin) file checksum for column b` is the same bug observed on
+#       `02555_davengers_rename_chain`'s `wrong_metadata` table. The test chains `a -> a1` and then
+#       `a1 -> b`, so the corrupted file name is `<new=b><old=a1>.bin = ba1.bin` for column `b`. The
+#       `<column><stream>` combination is unique to this chained-rename test.
+# `wrong_metadata` + `Detaching broken part` + `backward incompatibility` is the follow-up cleanup line for
+#       the same issue: a "Detaching broken part" notice that does not contain the corrupted filename.
+#       Filtered via regex in the secondary pipe below to require all three substrings together, so unrelated
+#       broken-part detach messages are not masked. The regex matches both `wrong_metadata` (from
+#       `02555_davengers_rename_chain`) and `wrong_metadata_wide` (from `02538_alter_rename_sequence`).
 echo "Check for Error messages in server log:"
 rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "Code: 236. DB::Exception: Cancelled mutating parts" \
@@ -423,6 +428,7 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "e.what() = failed to parse response body" \
            -e "Tuple element name 'null' is reserved" \
            -e "No stream (column1_renamedcolumn1.bin) file checksum for column column1_renamed" \
+           -e "No stream (ba1.bin) file checksum for column b" \
     /test_output/clickhouse-server.upgrade.log \
     | grep -av -e "_repl_01111_.*Mapping for table with UUID" \
     | grep -av -e "Azure::Storage::StorageException.*Not found address of host" \
@@ -430,7 +436,7 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
     | grep -av -e "TraceCollector.*CANNOT_READ_FROM_FILE_DESCRIPTOR" \
     | grep -av -e "while loading statistics.*ILLEGAL_STATISTICS" \
     | grep -av -e "rdk:FAIL.*Connect to.*failed: Connection refused" \
-    | grep -av -e "wrong_metadata_wide.*Detaching broken part.*backward incompatibility" \
+    | grep -av -e "wrong_metadata.*Detaching broken part.*backward incompatibility" \
     | grep -Fa "<Error>" > /test_output/upgrade_error_messages.txt || true
 
 if [ -s /test_output/upgrade_error_messages.txt ]; then


### PR DESCRIPTION
### Description

PR #103917 narrowed the `wrong_metadata_wide` allowlist in `tests/docker_scripts/upgrade_runner.sh` to the specific corrupted-filename signature emitted by `02538_alter_rename_sequence` after the `getFileNameForRenamedColumnStream` `substr(0, N)` bug (issue #102259, fix in PR #102689). The same bug also surfaces on `02555_davengers_rename_chain`'s `wrong_metadata` table, but with a different column/stream pair (`b`/`ba1.bin` instead of `column1_renamed`/`column1_renamedcolumn1.bin`), so the narrow regex did not catch it and the upgrade check began failing on unrelated PRs.

This PR adds a matching narrow signature for the chained-rename variant and loosens the secondary `Detaching broken part` regex so it covers both the narrow and wide table variants. The other two substrings of the secondary regex (`Detaching broken part` + `backward incompatibility`) keep the allowlist scoped to the same symptom.

Verified against the failing log from PR #103874:
https://s3.amazonaws.com/clickhouse-test-reports/PRs/103874/49885046aba0893d06655439d554aeac6998469e/upgrade_check_amd_release/upgrade_error_messages.txt

All six lines from that log are filtered, while synthetic unrelated errors (other tables, generic detach notices, log lines that mention the table name in passing) pass through.

Source PR with the failing run: https://github.com/ClickHouse/ClickHouse/pull/103874

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.319`
<!-- ch-version-info:end -->