### PR TITLE
[DRAFT] Replace per-thread untracked_memory with per-CPU counters

### DIFF
--- a/src/Common/CurrentMemoryTracker.cpp
+++ b/src/Common/CurrentMemoryTracker.cpp
@@ -3,6 +3,11 @@
 #include <Common/Exception.h>
 #include <Common/MemoryTracker.h>
 #include <Common/MemoryTrackerBlockerInThread.h>
+#include <Common/PerCPUUntrackedMemory.h>
+
+#if defined(__linux__)
+#    include <sched.h>
+#endif
 
 
 #ifdef MEMORY_TRACKER_DEBUG_CHECKS
@@ -33,6 +38,24 @@ MemoryTracker * getMemoryTracker()
     return nullptr;
 }
 
+#if defined(__linux__)
+
+/// Resolve the CPU index once per call. The same value is reused for the
+/// paired `drain` on overflow so that overflow-and-flush race against
+/// migration cleanly.
+inline int currentCPU()
+{
+    int cpu = ::sched_getcpu();
+    if (cpu < 0)
+        return 0;
+    int n = DB::PerCPUUntrackedMemory::cpuCount();
+    if (n > 0 && cpu >= n)
+        cpu %= n;
+    return cpu;
+}
+
+#endif
+
 }
 
 using DB::current_thread;
@@ -47,48 +70,90 @@ AllocationTrace CurrentMemoryTracker::allocImpl(Int64 size, bool throw_if_memory
     }
 #endif
 
-    if (auto * memory_tracker = getMemoryTracker())
+    auto * memory_tracker = getMemoryTracker();
+    if (!memory_tracker)
+        return AllocationTrace(0);
+
+    if (!current_thread)
     {
-        if (!current_thread)
-        {
-            /// total_memory_tracker only, ignore untracked_memory
-            return memory_tracker->allocImpl(size, throw_if_memory_exceeded);
-        }
-
-        /// Make sure we do memory tracker calls with the correct level in MemoryTrackerBlockerInThread.
-        /// E.g. suppose allocImpl is called twice: first for 2 MB with blocker set to
-        /// VariableContext::User, then for 3 MB with no blocker. This should increase the
-        /// Global memory tracker by 5 MB and the User memory tracker by 3 MB. So we can't group
-        /// these two calls into one memory_tracker->allocImpl call.
-        VariableContext blocker_level = MemoryTrackerBlockerInThread::getLevel();
-        if (blocker_level != current_thread->untracked_memory_blocker_level)
-        {
-            current_thread->flushUntrackedMemory();
-        }
-        current_thread->untracked_memory_blocker_level = blocker_level;
-
-        Int64 previous_untracked_memory = current_thread->untracked_memory;
-        current_thread->untracked_memory += size;
-        if (current_thread->untracked_memory > current_thread->untracked_memory_limit)
-        {
-            Int64 current_untracked_memory = current_thread->untracked_memory;
-            current_thread->untracked_memory = 0;
-
-            try
-            {
-                return memory_tracker->allocImpl(current_untracked_memory, throw_if_memory_exceeded);
-            }
-            catch (...)
-            {
-                current_thread->untracked_memory += previous_untracked_memory;
-                throw;
-            }
-        }
-
-        return AllocationTrace(current_thread->getEffectiveSampleProbability(size));
+        /// total_memory_tracker only, ignore untracked_memory
+        return memory_tracker->allocImpl(size, throw_if_memory_exceeded);
     }
 
-    return AllocationTrace(0);
+    /// Make sure we do memory tracker calls with the correct level in MemoryTrackerBlockerInThread.
+    /// E.g. suppose allocImpl is called twice: first for 2 MB with blocker set to
+    /// VariableContext::User, then for 3 MB with no blocker. This should increase the
+    /// Global memory tracker by 5 MB and the User memory tracker by 3 MB. So we can't group
+    /// these two calls into one memory_tracker->allocImpl call.
+    VariableContext blocker_level = MemoryTrackerBlockerInThread::getLevel();
+    bool blocker_changed = blocker_level != current_thread->untracked_memory_blocker_level;
+
+#if defined(__linux__)
+    if (likely(DB::PerCPUUntrackedMemory::isEnabled()))
+    {
+        int cpu = currentCPU();
+
+        if (blocker_changed)
+        {
+            Int64 drained = DB::PerCPUUntrackedMemory::drain(cpu);
+            if (drained > 0)
+                std::ignore = memory_tracker->allocImpl(drained, /*throw_if_memory_exceeded=*/false);
+            else if (drained < 0)
+                std::ignore = memory_tracker->free(-drained);
+            current_thread->untracked_memory_blocker_level = blocker_level;
+        }
+
+        Int64 new_local = DB::PerCPUUntrackedMemory::add(cpu, size);
+        if (new_local > current_thread->untracked_memory_limit)
+        {
+            Int64 to_flush = DB::PerCPUUntrackedMemory::drain(cpu);
+            if (to_flush > 0)
+            {
+                try
+                {
+                    return memory_tracker->allocImpl(to_flush, throw_if_memory_exceeded);
+                }
+                catch (...)
+                {
+                    /// Re-stage the drained delta. May land on a different CPU
+                    /// after migration; bounded by `untracked_memory_limit`.
+                    DB::PerCPUUntrackedMemory::add(cpu, to_flush - size);
+                    throw;
+                }
+            }
+            else if (to_flush < 0)
+            {
+                std::ignore = memory_tracker->free(-to_flush);
+            }
+        }
+        return AllocationTrace(current_thread->getEffectiveSampleProbability(size));
+    }
+#endif
+
+    /// Fallback: legacy per-thread path.
+    if (blocker_changed)
+        current_thread->flushUntrackedMemory();
+    current_thread->untracked_memory_blocker_level = blocker_level;
+
+    Int64 previous_untracked_memory = current_thread->untracked_memory;
+    current_thread->untracked_memory += size;
+    if (current_thread->untracked_memory > current_thread->untracked_memory_limit)
+    {
+        Int64 current_untracked_memory = current_thread->untracked_memory;
+        current_thread->untracked_memory = 0;
+
+        try
+        {
+            return memory_tracker->allocImpl(current_untracked_memory, throw_if_memory_exceeded);
+        }
+        catch (...)
+        {
+            current_thread->untracked_memory += previous_untracked_memory;
+            throw;
+        }
+    }
+
+    return AllocationTrace(current_thread->getEffectiveSampleProbability(size));
 }
 
 void CurrentMemoryTracker::check()
@@ -109,32 +174,57 @@ AllocationTrace CurrentMemoryTracker::allocNoThrow(Int64 size)
 
 AllocationTrace CurrentMemoryTracker::free(Int64 size)
 {
-    if (auto * memory_tracker = getMemoryTracker())
+    auto * memory_tracker = getMemoryTracker();
+    if (!memory_tracker)
+        return AllocationTrace(0);
+
+    if (!current_thread)
+        return memory_tracker->free(size);
+
+    VariableContext blocker_level = MemoryTrackerBlockerInThread::getLevel();
+    bool blocker_changed = blocker_level != current_thread->untracked_memory_blocker_level;
+
+#if defined(__linux__)
+    if (likely(DB::PerCPUUntrackedMemory::isEnabled()))
     {
-        if (!current_thread)
+        int cpu = currentCPU();
+
+        if (blocker_changed)
         {
-            return memory_tracker->free(size);
+            Int64 drained = DB::PerCPUUntrackedMemory::drain(cpu);
+            if (drained > 0)
+                std::ignore = memory_tracker->allocImpl(drained, /*throw_if_memory_exceeded=*/false);
+            else if (drained < 0)
+                std::ignore = memory_tracker->free(-drained);
+            current_thread->untracked_memory_blocker_level = blocker_level;
         }
 
-        VariableContext blocker_level = MemoryTrackerBlockerInThread::getLevel();
-        if (blocker_level != current_thread->untracked_memory_blocker_level)
+        Int64 new_local = DB::PerCPUUntrackedMemory::add(cpu, -size);
+        if (new_local < -current_thread->untracked_memory_limit)
         {
-            current_thread->flushUntrackedMemory();
+            Int64 to_flush = DB::PerCPUUntrackedMemory::drain(cpu);
+            if (to_flush < 0)
+                return memory_tracker->free(-to_flush);
+            else if (to_flush > 0)
+                std::ignore = memory_tracker->allocImpl(to_flush, /*throw_if_memory_exceeded=*/false);
         }
-        current_thread->untracked_memory_blocker_level = blocker_level;
-
-        current_thread->untracked_memory -= size;
-        if (current_thread->untracked_memory < -current_thread->untracked_memory_limit)
-        {
-            Int64 untracked_memory = current_thread->untracked_memory;
-            current_thread->untracked_memory = 0;
-            return memory_tracker->free(-untracked_memory);
-        }
-
         return AllocationTrace(current_thread->getEffectiveSampleProbability(size));
     }
+#endif
 
-    return AllocationTrace(0);
+    if (blocker_changed)
+        current_thread->flushUntrackedMemory();
+    current_thread->untracked_memory_blocker_level = blocker_level;
+
+    current_thread->untracked_memory -= size;
+    if (current_thread->untracked_memory < -current_thread->untracked_memory_limit)
+    {
+        Int64 untracked_memory = current_thread->untracked_memory;
+        current_thread->untracked_memory = 0;
+        return memory_tracker->free(-untracked_memory);
+    }
+
+    return AllocationTrace(current_thread->getEffectiveSampleProbability(size));
 }
 
 void CurrentMemoryTracker::injectFault()

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -11,6 +11,7 @@
 #include <Common/MemoryTrackerUntrackedAllocationsBlockerInThread.h>
 #include <Common/OvercommitTracker.h>
 #include <Common/PageCache.h>
+#include <Common/PerCPUUntrackedMemory.h>
 #include <Common/ProfileEvents.h>
 #include <Common/Stopwatch.h>
 #include <Common/ThreadStatus.h>
@@ -361,8 +362,30 @@ AllocationTrace MemoryTracker::allocImpl(Int64 size, bool throw_if_memory_exceed
         incrementAllocationWithoutCheck(size);
     }
 
-    if (unlikely(
-            current_hard_limit && (will_be > current_hard_limit || (level == VariableContext::Global && will_be_rss > current_hard_limit))))
+    bool over = current_hard_limit
+        && (will_be > current_hard_limit
+            || (level == VariableContext::Global && will_be_rss > current_hard_limit));
+
+    /// Per-CPU untracked memory holds allocations that have not yet reached
+    /// `amount`. On the global tracker, when we approach the hard limit, peek
+    /// the per-CPU sum to confirm we are not actually past it. The watermark
+    /// keeps the hot path at a single comparison; the O(ncpu) peek runs only
+    /// in the last `ncpu * default-untracked-bytes` window before OOM.
+    if (!over
+        && current_hard_limit
+        && level == VariableContext::Global
+        && DB::PerCPUUntrackedMemory::isEnabled())
+    {
+        static const Int64 pressure_window
+            = static_cast<Int64>(DB::PerCPUUntrackedMemory::cpuCount()) * (4 * 1024 * 1024);
+        if (will_be > current_hard_limit - pressure_window)
+        {
+            Int64 in_flight = DB::PerCPUUntrackedMemory::peekTotal();
+            over = (will_be + in_flight) > current_hard_limit;
+        }
+    }
+
+    if (unlikely(over))
     {
 #if USE_JEMALLOC
         if (level == VariableContext::Global && (jemalloc_flush_profile_on_memory_exceeded_interval_s || jemalloc_flush_profile_on_memory_exceeded))

--- a/src/Common/PerCPUUntrackedMemory.cpp
+++ b/src/Common/PerCPUUntrackedMemory.cpp
@@ -1,0 +1,85 @@
+#include <Common/PerCPUUntrackedMemory.h>
+
+#include <atomic>
+#include <cstddef>
+
+#if defined(__linux__)
+#    include <sys/mman.h>
+#    include <unistd.h>
+#endif
+
+namespace DB::PerCPUUntrackedMemory
+{
+
+namespace
+{
+
+/// Cache-line padded to keep cross-CPU writes from bouncing the same line.
+struct alignas(64) Slot
+{
+    Int64 value;
+    char pad[64 - sizeof(Int64)];
+};
+
+#if defined(__linux__)
+
+const int n_cpu = []
+{
+    Int64 n = ::sysconf(_SC_NPROCESSORS_CONF);
+    return n > 0 ? static_cast<int>(n) : 0;
+}();
+
+Slot * const slots = []() -> Slot *
+{
+    if (n_cpu <= 0)
+        return nullptr;
+    size_t bytes = sizeof(Slot) * static_cast<size_t>(n_cpu);
+    void * p = ::mmap(nullptr, bytes, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    return p == MAP_FAILED ? nullptr : static_cast<Slot *>(p);
+}();
+
+#else
+
+constexpr int n_cpu = 0;
+Slot * const slots = nullptr;
+
+#endif
+
+}
+
+bool isEnabled()
+{
+    return slots != nullptr;
+}
+
+int cpuCount()
+{
+    return n_cpu;
+}
+
+Int64 add(int cpu, Int64 delta)
+{
+    /// Single-CPU uncontended atomic. Lowers to one instruction on both
+    /// shipped archs — `lock xaddq` (x86_64) and `ldadd` (aarch64 LSE,
+    /// mandatory in our build, see cmake/cpu_features.cmake). The slot is
+    /// L1-resident on the owning CPU, so cost is ~5–10 cycles. Migration
+    /// mid-instruction is harmless: the operation is atomic on whichever
+    /// CPU executes it; only attribution may shift, but the total recovered
+    /// by `peekTotal` and the next `drain` is exact.
+    return __atomic_add_fetch(&slots[cpu].value, delta, __ATOMIC_RELAXED);
+}
+
+Int64 drain(int cpu)
+{
+    return __atomic_exchange_n(&slots[cpu].value, Int64{0}, __ATOMIC_RELAXED);
+}
+
+Int64 peekTotal()
+{
+    Int64 total = 0;
+    for (int i = 0; i < n_cpu; ++i)
+        total += __atomic_load_n(&slots[i].value, __ATOMIC_RELAXED);
+    return total;
+}
+
+}

--- a/src/Common/PerCPUUntrackedMemory.h
+++ b/src/Common/PerCPUUntrackedMemory.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <base/types.h>
+
+/// Per-CPU untracked memory counters.
+///
+/// Replacement for the per-thread `untracked_memory` accumulator used by
+/// `CurrentMemoryTracker`. One Int64 slot per CPU instead of per thread, so
+/// the worst-case unflushed window scales with `ncpu` rather than `nthreads`.
+///
+/// This namespace is intentionally minimal: it owns the slot array and
+/// nothing else. All overflow/limit policy stays in the caller — the per-slot
+/// threshold is the same `untracked_memory_limit` the legacy path uses.
+///
+/// All RMW operations take an explicit CPU index. The caller resolves it
+/// once (typically via `sched_getcpu()`) and reuses the same value for paired
+/// add/drain. There is deliberately no `drainCurrent()` helper, because the
+/// current CPU can change between two calls and silent re-resolution would
+/// race overflow against migration.
+namespace DB::PerCPUUntrackedMemory
+{
+
+/// True iff initialization succeeded (Linux + mmap of slot array OK).
+/// Callers must check this before invoking add/drain/peekTotal.
+bool isEnabled();
+
+/// Number of slots, equal to `sysconf(_SC_NPROCESSORS_CONF)` at startup.
+/// Fixed for the lifetime of the process.
+int cpuCount();
+
+/// slots[cpu] += delta; returns the new value of the slot.
+Int64 add(int cpu, Int64 delta);
+
+/// Atomically exchanges slots[cpu] with 0; returns the prior value.
+Int64 drain(int cpu);
+
+/// Sum of slots[i] across all i, with relaxed loads and no reset. O(ncpu).
+/// Slow path — intended for `MemoryTracker` to consult under memory pressure.
+Int64 peekTotal();
+
+}

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -8,6 +8,7 @@
 #include <Common/setThreadName.h>
 #include <Common/memory.h>
 #include <Common/MemoryTrackerBlockerInThread.h>
+#include <Common/PerCPUUntrackedMemory.h>
 #include <Core/Settings.h>
 #include <base/getPageSize.h>
 #include <Interpreters/Context.h>
@@ -16,6 +17,10 @@
 
 #include <csignal>
 #include <sys/mman.h>
+
+#if defined(__linux__)
+#    include <sched.h>
+#endif
 
 
 namespace DB
@@ -235,12 +240,29 @@ LogsLevel ThreadStatus::getClientLogsLevel() const
 
 void ThreadStatus::flushUntrackedMemory()
 {
-    if (untracked_memory == 0)
+    Int64 current_untracked_memory = untracked_memory;
+    untracked_memory = 0;
+
+#if defined(__linux__)
+    /// Drain the current CPU's slot too. The slot is shared across threads,
+    /// so this picks up other threads' contributions as well — fine for the
+    /// "make all pending memory visible" contract this method provides.
+    /// Attribution drift is bounded by `untracked_memory_limit`.
+    if (PerCPUUntrackedMemory::isEnabled())
+    {
+        int cpu = ::sched_getcpu();
+        if (cpu < 0)
+            cpu = 0;
+        else if (int n = PerCPUUntrackedMemory::cpuCount(); n > 0 && cpu >= n)
+            cpu %= n;
+        current_untracked_memory += PerCPUUntrackedMemory::drain(cpu);
+    }
+#endif
+
+    if (current_untracked_memory == 0)
         return;
 
     MemoryTrackerBlockerInThread blocker(untracked_memory_blocker_level);
-    Int64 current_untracked_memory = current_thread->untracked_memory;
-    untracked_memory = 0;
     memory_tracker.adjustWithUntrackedMemory(current_untracked_memory);
 }
 


### PR DESCRIPTION
**Note: this version will not be merged, the version wth rseq will follow, it is just to measure performance**

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
[DRAFT] Replace per-thread untracked_memory with per-CPU counters

The per-thread untracked_memory bucket lets each thread keep up to max_untracked_memory bytes of unflushed allocations, so the worst-case overcommit window scales as nthreads * max_untracked_memory — gigabytes on busy servers.