### PR TITLE
Bump libarchive form 3.8.6 to 3.8.7

### DIFF
--- a/contrib/libarchive-cmake/config.h
+++ b/contrib/libarchive-cmake/config.h
@@ -1031,6 +1031,9 @@ typedef uint64_t uintmax_t;
 /* Define to 1 if you have the <stdint.h> header file. */
 #define HAVE_STDINT_H 1
 
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
+
 /* Define to 1 if you have the <stdlib.h> header file. */
 #define HAVE_STDLIB_H 1
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.284`
- Backported to: `26.4.1.1135`, `26.3.10.53`, `26.2.18.3`, `25.8.24.2`
<!-- ch-version-info:end -->