### PR TITLE
Add test: `splitByRegexp` trivial-char fallback with `max_substrings` argument and `splitby_max_substrings_includes_remaining_string` setting is untested

### DIFF
--- a/tests/queries/0_stateless/04202_split_by_regexp_trivial_char_with_max_substrings.reference
+++ b/tests/queries/0_stateless/04202_split_by_regexp_trivial_char_with_max_substrings.reference
@@ -1,0 +1,22 @@
+-- 3-arg trivial-char fallback (max_substrings, default setting)
+['a','b','c','d']
+['a','b','c','d']
+['a']
+['a','b']
+['a','b','c']
+['a','b','c','d']
+['a','b','c','d']
+-- 3-arg trivial-char fallback (max_substrings, include_remaining_string=1)
+['a b c d']
+['a','b c d']
+['a','b','c d']
+['a','b','c','d']
+-- non-const 2nd argument flowing through trivial-char fallback
+['a','b']
+['1','2']
+['x','y']
+-- equivalence with splitByChar across all branches
+1
+1
+1
+1

--- a/tests/queries/0_stateless/04202_split_by_regexp_trivial_char_with_max_substrings.sql
+++ b/tests/queries/0_stateless/04202_split_by_regexp_trivial_char_with_max_substrings.sql
@@ -1,0 +1,34 @@
+-- Test: exercises the new `splitByRegexp` trivial-char fallback path with the 3-arg
+-- (max_substrings) form and the `splitby_max_substrings_includes_remaining_string` setting.
+-- Covers: src/Functions/splitByRegexp.cpp:170-171 — buildImpl trivial-char branch
+--   `if (patternIsTrivialChar(arguments)) return FunctionFactory::instance().getImpl("splitByChar", context)->build(arguments);`
+-- The PR's own tests only cover the 2-argument form for trivial chars; the 3-argument
+-- form (with max_substrings) and the splitby_max_substrings_includes_remaining_string
+-- setting were not exercised through the new fallback. If the resolver ever drops the
+-- 3rd argument or fails to propagate the setting context, results would silently differ
+-- from the regex-based behavior.
+
+SELECT '-- 3-arg trivial-char fallback (max_substrings, default setting)';
+SELECT splitByRegexp(' ', 'a b c d', -1);
+SELECT splitByRegexp(' ', 'a b c d', 0);
+SELECT splitByRegexp(' ', 'a b c d', 1);
+SELECT splitByRegexp(' ', 'a b c d', 2);
+SELECT splitByRegexp(' ', 'a b c d', 3);
+SELECT splitByRegexp(' ', 'a b c d', 4);
+SELECT splitByRegexp(' ', 'a b c d', 5);
+
+SELECT '-- 3-arg trivial-char fallback (max_substrings, include_remaining_string=1)';
+SELECT splitByRegexp(' ', 'a b c d', 1) SETTINGS splitby_max_substrings_includes_remaining_string = 1;
+SELECT splitByRegexp(' ', 'a b c d', 2) SETTINGS splitby_max_substrings_includes_remaining_string = 1;
+SELECT splitByRegexp(' ', 'a b c d', 3) SETTINGS splitby_max_substrings_includes_remaining_string = 1;
+SELECT splitByRegexp(' ', 'a b c d', 4) SETTINGS splitby_max_substrings_includes_remaining_string = 1;
+
+SELECT '-- non-const 2nd argument flowing through trivial-char fallback';
+SELECT splitByRegexp(' ', materialize('a b c'), 2);
+SELECT splitByRegexp('-', s, 2) FROM (SELECT arrayJoin(['1-2-3', 'x-y-z']) AS s) ORDER BY 1;
+
+SELECT '-- equivalence with splitByChar across all branches';
+SELECT splitByRegexp('-', 'a-b-c-d', 2) = splitByChar('-', 'a-b-c-d', 2);
+SELECT splitByRegexp(' ', '', 5) = splitByChar(' ', '', 5);
+SELECT splitByRegexp(' ', 'no separators', 3) = splitByChar(' ', 'no separators', 3);
+SELECT splitByRegexp(' ', 'a  b', 5) = splitByChar(' ', 'a  b', 5);


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #62392](https://github.com/ClickHouse/ClickHouse/pull/62392) (merged 2024-04-16). Confirmed on current codebase — close with a note if already fixed._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #62392](https://github.com/ClickHouse/ClickHouse/pull/62392).
 That PR PR adds a `SplitByRegexpOverloadResolver` that intercepts `splitByRegexp` calls and, when the regex pattern is a single literal byte that the regex analyzer reports as `is_trivial`, delegates the call to `splitByChar` for ~1.3-1.8x performance. (1) Changes: new resolver replaces direct registration 

**1. `splitByRegexp` trivial-char fallback with `max_substrings` argument and `splitby_max_substrings_includes_remaining_string` setting is untested**
  `src/Functions/splitByRegexp.cpp:170`, `src/Functions/splitByRegexp.cpp:171`
  **Risk:** Call chain: SQL `splitByRegexp(' ', 'a b c d', 2)` → `SplitByRegexpOverloadResolver::buildImpl` (line 168) → `patternIsTrivialChar` returns true for ' ' → `FunctionFactory::instance().getImpl("splitBy
  **What's unique vs PR tests:** PR's own 01866_split_by_regexp.sql tests the trivial-char fallback only with the 2-argument form and only with literal const strings. Existing 02475_split_with_max_substrings.sql tests the 3-argument 
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/8af17b5d-173a-40e6-bcda-7c364d3c4fc3)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)