### PR TITLE
Add test: `StorageFileLog` silent-return branch for path outside `user_files_path` (ATTACH/SECONDARY_CREATE/FORCE_ATTACH/FORCE_RESTORE) untested

### DIFF
--- a/tests/queries/0_stateless/04202_filelog_attach_path_outside_user_files.reference
+++ b/tests/queries/0_stateless/04202_filelog_attach_path_outside_user_files.reference
@@ -1,0 +1,2 @@
+1
+FileLog

--- a/tests/queries/0_stateless/04202_filelog_attach_path_outside_user_files.sh
+++ b/tests/queries/0_stateless/04202_filelog_attach_path_outside_user_files.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# Test: exercises the silent-return branch in StorageFileLog constructor when the
+#   absolute data path is outside `user_files_path` and the loading mode is
+#   >= SECONDARY_CREATE.
+# Covers: src/Storages/FileLog/StorageFileLog.cpp:195-198 — the
+#   `LOG_ERROR(...); return;` path under `if (LoadingStrictnessLevel::SECONDARY_CREATE <= mode)`.
+# The CREATE-mode throw path is already covered by 02125_fix_storage_filelog.sql /
+# 02126_fix_filelog.sh. The silent-return path used by ATTACH/SECONDARY_CREATE/
+# FORCE_ATTACH/FORCE_RESTORE has zero coverage in 0_stateless or integration.
+
+set -eu
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+UUID=$(${CLICKHOUSE_CLIENT} --query "SELECT generateUUIDv4()")
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS filelog_bad_path_attach SYNC;"
+
+# ATTACH TABLE with full table definition triggers LoadingStrictnessLevel::ATTACH (>= SECONDARY_CREATE),
+# so the absolute path /tmp/... (outside `user_files_path`) hits the LOG_ERROR + return
+# branch in the constructor instead of throwing BAD_ARGUMENTS. The table is registered
+# in `system.tables`. Suppress LOG_ERROR / Warning lines on stderr — they are expected.
+${CLICKHOUSE_CLIENT} --query "ATTACH TABLE filelog_bad_path_attach UUID '${UUID}' (k UInt8, v UInt8) ENGINE = FileLog('/tmp/nonexistent_4202_pr62421.csv', 'CSV');" 2>/dev/null
+
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM system.tables WHERE database = currentDatabase() AND name = 'filelog_bad_path_attach';"
+${CLICKHOUSE_CLIENT} --query "SELECT engine FROM system.tables WHERE database = currentDatabase() AND name = 'filelog_bad_path_attach';"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS filelog_bad_path_attach SYNC;"


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #62421](https://github.com/ClickHouse/ClickHouse/pull/62421) (merged 2024-04-09). Confirmed on current codebase — close with a note if already fixed._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #62421](https://github.com/ClickHouse/ClickHouse/pull/62421).
 That PR Single-line change in `StorageFileLog` constructor (`src/Storages/FileLog/StorageFileLog.cpp:195`). The path-outside-`user_files_path` guard now treats `LoadingStrictnessLevel::SECONDARY_CREATE` (used for `RESTORE` from backup and for non-initial-query `DDL` propagation in `DatabaseReplicated`) the 

**1. `StorageFileLog` silent-return branch for path outside `user_files_path` (ATTACH/SECONDARY_CREATE/FORCE_ATTACH/FORCE_RESTORE) untested**
  `src/Storages/FileLog/StorageFileLog.cpp:195`, `src/Storages/FileLog/StorageFileLog.cpp:198`
  **Risk:** Call chain: `InterpreterCreateQuery::createTable` (`src/Interpreters/InterpreterCreateQuery.cpp:1559`) computes `mode = getLoadingStrictnessLevel(create.attach, ..., is_secondary_query || is_restore_f
  **What's unique vs PR tests:** PR ships zero tests. Existing 02125/02126 tests cover only the throw side at line 200 with default CREATE mode. My test is the first to exercise the silent-return side (line 195-198) — the exact branc

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)