### PR TITLE
Add test: `Path::hasGlobsIgnorePlaceholders` early-return branch (no placeholder, raw globs) untested

### DIFF
--- a/tests/queries/0_stateless/04202_s3_write_to_globbed_path_non_partitioned.sql
+++ b/tests/queries/0_stateless/04202_s3_write_to_globbed_path_non_partitioned.sql
@@ -1,0 +1,12 @@
+-- Tags: no-fasttest
+
+-- Test: writing to a non-partitioned S3 path with globs throws DATABASE_ACCESS_DENIED.
+-- Covers: src/Storages/ObjectStorage/StorageObjectStorageConfiguration.cpp:230-237
+--   `hasGlobsIgnorePlaceholders` early-return branch when path has neither
+--   `{_partition_id}` nor `{_schema_hash}` placeholder (returns `hasGlobs()` directly).
+--
+-- The PR's own test 03037 only covers the "with placeholder" branch
+-- (`data_*_{_partition_id}.csv` with `partition by`).  This test covers the other
+-- branch: a non-partitioned write to a path containing brace-expansion glob `{a,b}`.
+
+insert into function s3('http://localhost:11111/test/04202_data_glob_brace_{a,b}.csv', 'CSV', 'x UInt32') select 1 as x; -- { serverError DATABASE_ACCESS_DENIED }


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #62423](https://github.com/ClickHouse/ClickHouse/pull/62423) (merged 2024-05-10). Confirmed on current codebase — close with a note if already fixed._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #62423](https://github.com/ClickHouse/ClickHouse/pull/62423).
 That PR PR #62423 fixes the exception message thrown when INSERT-ing into a partitioned `s3`/`hdfs`/`azureBlobStorage` path that ALSO contains globs (e.g. `data_*_{_partition_id}.csv`). Before the fix, such writes hit the partitioned sink and produced a confusing S3-side error; after the fix the storage thr

**1. `Path::hasGlobsIgnorePlaceholders` early-return branch (no placeholder, raw globs) untested**
  `src/Storages/ObjectStorage/StorageObjectStorageConfiguration.cpp:232`, `src/Storages/ObjectStorage/StorageObjectStorage.cpp:572`
  **Risk:** The helper `Path::hasGlobsIgnorePlaceholders` introduced by this PR has two distinct execution paths: (A) the early return `if (!hasPartitionWildcard() && !hasSchemaHashWildcard()) return hasGlobs();`
  **What's unique vs PR tests:** PR test 03037 tests the partitioned + glob case (path has `{_partition_id}` AND globs, with `partition by` clause) — branch B of `hasGlobsIgnorePlaceholders`. This test covers the orthogonal case: non
  **Tags:** `-- Tags: no-fasttest` — `no-fasttest`: Matches the existing PR test 03037 — fast test build does not have the S3 mock at localhost:11111.
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/ae059af6-851d-487d-859e-edc6070363a0)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.415`
<!-- ch-version-info:end -->