### PR TITLE
Bypass index uncompressed cache when its size is zero

### DIFF
--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -1778,7 +1778,7 @@ void ServerSettings::dumpToSystemServerSettingsColumns(ServerSettingColumnsParam
             {"mark_cache_size", {std::to_string(context->getMarkCache()->maxSizeInBytes()), ChangeableWithoutRestart::Yes}},
             {"uncompressed_cache_size", {std::to_string(context->getUncompressedCache()->maxSizeInBytes()), ChangeableWithoutRestart::Yes}},
             {"index_mark_cache_size", {std::to_string(context->getIndexMarkCache()->maxSizeInBytes()), ChangeableWithoutRestart::Yes}},
-            {"index_uncompressed_cache_size", {std::to_string(context->getIndexUncompressedCache()->maxSizeInBytes()), ChangeableWithoutRestart::Yes}},
+            {"index_uncompressed_cache_size", {std::to_string(context->getIndexUncompressedCache(/*only_if_enabled=*/ false)->maxSizeInBytes()), ChangeableWithoutRestart::Yes}},
             {"mmap_cache_size", {std::to_string(context->getMMappedFileCache()->maxSizeInBytes()), ChangeableWithoutRestart::Yes}},
             {"query_condition_cache_size", {std::to_string(context->getQueryConditionCache()->maxSizeInBytes()), ChangeableWithoutRestart::Yes}},
             {"primary_index_cache_size", {std::to_string(context->getPrimaryIndexCache()->maxSizeInBytes()), ChangeableWithoutRestart::Yes}},

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -555,7 +555,7 @@ struct ContextSharedPart : boost::noncopyable
     mutable OnceFlag build_vector_similarity_index_threadpool_initialized;
     mutable std::unique_ptr<ThreadPool> build_vector_similarity_index_threadpool; /// Threadpool for vector-similarity index creation.
     mutable UncompressedCachePtr index_uncompressed_cache TSA_GUARDED_BY(mutex);      /// The cache of decompressed blocks for MergeTree indices.
-    mutable bool index_uncompressed_cache_enabled = false TSA_GUARDED_BY(mutex);      /// Whether index_uncompressed_cache should be used.
+    mutable bool index_uncompressed_cache_enabled TSA_GUARDED_BY(mutex) = false;      /// Whether index_uncompressed_cache should be used.
     mutable VectorSimilarityIndexCachePtr vector_similarity_index_cache TSA_GUARDED_BY(mutex);         /// Cache of deserialized secondary index granules.
     mutable TextIndexTokensCachePtr text_index_tokens_cache TSA_GUARDED_BY(mutex);  /// Cache of deserialized text index tokens.
     mutable TextIndexHeaderCachePtr text_index_header_cache TSA_GUARDED_BY(mutex);  /// Cache of deserialized text index headers.

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -4110,10 +4110,12 @@ void Context::updateIndexUncompressedCacheConfiguration(const Poco::Util::Abstra
     shared->index_uncompressed_cache_enabled = shared->index_uncompressed_cache->maxSizeInBytes() != 0;
 }
 
-UncompressedCachePtr Context::getIndexUncompressedCache() const
+UncompressedCachePtr Context::getIndexUncompressedCache(bool only_if_enabled) const
 {
     SharedLockGuard lock(shared->mutex);
-    return shared->index_uncompressed_cache_enabled ? shared->index_uncompressed_cache : nullptr;
+    if (only_if_enabled && !shared->index_uncompressed_cache_enabled)
+        return nullptr;
+    return shared->index_uncompressed_cache;
 }
 
 void Context::clearIndexUncompressedCache() const

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -555,6 +555,7 @@ struct ContextSharedPart : boost::noncopyable
     mutable OnceFlag build_vector_similarity_index_threadpool_initialized;
     mutable std::unique_ptr<ThreadPool> build_vector_similarity_index_threadpool; /// Threadpool for vector-similarity index creation.
     mutable UncompressedCachePtr index_uncompressed_cache TSA_GUARDED_BY(mutex);      /// The cache of decompressed blocks for MergeTree indices.
+    mutable bool index_uncompressed_cache_enabled = false TSA_GUARDED_BY(mutex);      /// Whether index_uncompressed_cache should be used.
     mutable VectorSimilarityIndexCachePtr vector_similarity_index_cache TSA_GUARDED_BY(mutex);         /// Cache of deserialized secondary index granules.
     mutable TextIndexTokensCachePtr text_index_tokens_cache TSA_GUARDED_BY(mutex);  /// Cache of deserialized text index tokens.
     mutable TextIndexHeaderCachePtr text_index_header_cache TSA_GUARDED_BY(mutex);  /// Cache of deserialized text index headers.
@@ -4089,6 +4090,7 @@ void Context::setIndexUncompressedCache(const String & cache_policy, size_t max_
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Index uncompressed cache has been already created.");
 
     shared->index_uncompressed_cache = std::make_shared<UncompressedCache>(cache_policy, CurrentMetrics::IndexUncompressedCacheBytes, CurrentMetrics::IndexUncompressedCacheCells, max_size_in_bytes, size_ratio);
+    shared->index_uncompressed_cache_enabled = shared->index_uncompressed_cache->maxSizeInBytes() != 0;
 }
 
 void Context::updateIndexUncompressedCacheConfiguration(const Poco::Util::AbstractConfiguration & config, size_t max_cache_size)
@@ -4105,12 +4107,13 @@ void Context::updateIndexUncompressedCacheConfiguration(const Poco::Util::Abstra
         LOG_DEBUG(shared->log, "Lowered index uncompressed cache size to {} because the system has limited RAM", formatReadableSizeWithBinarySuffix(size));
     }
     shared->index_uncompressed_cache->setMaxSizeInBytes(size);
+    shared->index_uncompressed_cache_enabled = shared->index_uncompressed_cache->maxSizeInBytes() != 0;
 }
 
 UncompressedCachePtr Context::getIndexUncompressedCache() const
 {
     SharedLockGuard lock(shared->mutex);
-    return shared->index_uncompressed_cache;
+    return shared->index_uncompressed_cache_enabled ? shared->index_uncompressed_cache : nullptr;
 }
 
 void Context::clearIndexUncompressedCache() const

--- a/src/Interpreters/Context.h
+++ b/src/Interpreters/Context.h
@@ -1383,7 +1383,7 @@ public:
 
     void setIndexUncompressedCache(const String & cache_policy, size_t max_size_in_bytes, double size_ratio);
     void updateIndexUncompressedCacheConfiguration(const Poco::Util::AbstractConfiguration & config, size_t max_cache_size);
-    std::shared_ptr<UncompressedCache> getIndexUncompressedCache() const;
+    std::shared_ptr<UncompressedCache> getIndexUncompressedCache(bool only_if_enabled = true) const;
     void clearIndexUncompressedCache() const;
 
     void setIndexMarkCache(const String & cache_policy, size_t max_cache_size_in_bytes, double size_ratio);

--- a/tests/integration/test_index_uncompressed_cache_zero_size/configs/cache_size.xml
+++ b/tests/integration/test_index_uncompressed_cache_zero_size/configs/cache_size.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <index_uncompressed_cache_size>0</index_uncompressed_cache_size>
+</clickhouse>

--- a/tests/integration/test_index_uncompressed_cache_zero_size/test.py
+++ b/tests/integration/test_index_uncompressed_cache_zero_size/test.py
@@ -1,0 +1,113 @@
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+CACHE_CONFIG_PATH = "/etc/clickhouse-server/config.d/cache_size.xml"
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/cache_size.xml"],
+    stay_alive=True,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def start_cluster():
+    try:
+        cluster.start()
+        node.query(
+            """
+            CREATE TABLE t (
+                id UInt64,
+                s String,
+                INDEX bf s TYPE bloom_filter GRANULARITY 1
+            )
+            ENGINE = MergeTree
+            ORDER BY id
+            SETTINGS index_granularity = 1024
+            """
+        )
+        # A single part keeps the bloom-filter file deterministic across phases.
+        node.query(
+            "INSERT INTO t SELECT number, toString(number) FROM numbers(200000)"
+        )
+        yield
+    finally:
+        cluster.shutdown()
+
+
+def run_skip_index_query(query_id):
+    # Filtering on `s` forces the bloom_filter skip index to be loaded for every
+    # mark range, which is the path that exhibited the bug.
+    node.query(
+        "SELECT count() FROM t WHERE s = '12345'",
+        query_id=query_id,
+        settings={"use_skip_indexes": 1},
+    )
+
+
+def get_cache_events(query_id):
+    node.query("SYSTEM FLUSH LOGS")
+    row = node.query(
+        f"""
+        SELECT
+            ProfileEvents['UncompressedCacheHits'],
+            ProfileEvents['UncompressedCacheMisses'],
+            ProfileEvents['UncompressedCacheWeightLost']
+        FROM system.query_log
+        WHERE query_id = '{query_id}' AND type = 'QueryFinish'
+        FORMAT TSV
+        """
+    ).strip()
+    assert row, f"No QueryFinish entry in system.query_log for query_id={query_id}"
+    hits, misses, weight_lost = row.split("\t")
+    return int(hits), int(misses), int(weight_lost)
+
+
+def test_index_uncompressed_cache_runtime_toggle():
+    # Phase 1: cache disabled (size=0 from initial config). The skip-index read
+    # path must bypass the cache entirely - no profile events should fire.
+    run_skip_index_query("phase1_disabled")
+    hits, misses, weight_lost = get_cache_events("phase1_disabled")
+    assert (hits, misses, weight_lost) == (0, 0, 0), (
+        f"Expected zero index-uncompressed-cache events when the cache is "
+        f"disabled, got hits={hits}, misses={misses}, weight_lost={weight_lost}"
+    )
+
+    # Phase 2: enable the cache via runtime SYSTEM RELOAD CONFIG, verify that
+    # the cache is now actually used (misses on first query, hits on second).
+    with node.with_replace_config(
+        CACHE_CONFIG_PATH,
+        "<clickhouse><index_uncompressed_cache_size>10485760</index_uncompressed_cache_size></clickhouse>",
+        reload_before=True,
+        reload_after=True,
+    ):
+        node.query("SYSTEM DROP INDEX UNCOMPRESSED CACHE")
+
+        run_skip_index_query("phase2_first")
+        hits, misses, weight_lost = get_cache_events("phase2_first")
+        assert misses > 0, (
+            f"Expected misses with the cache enabled, "
+            f"got hits={hits}, misses={misses}, weight_lost={weight_lost}"
+        )
+        assert hits == 0, (
+            f"Expected no hits on the first query after dropping the cache, "
+            f"got hits={hits}"
+        )
+
+        run_skip_index_query("phase2_second")
+        hits, misses, weight_lost = get_cache_events("phase2_second")
+        assert hits > 0, (
+            f"Expected hits on the repeated query, "
+            f"got hits={hits}, misses={misses}, weight_lost={weight_lost}"
+        )
+
+    # Phase 3: original config restored and reloaded by `reload_after=True`.
+    # Disabling the cache at runtime must again bypass it for new queries.
+    run_skip_index_query("phase3_redisabled")
+    hits, misses, weight_lost = get_cache_events("phase3_redisabled")
+    assert (hits, misses, weight_lost) == (0, 0, 0), (
+        f"Expected zero index-uncompressed-cache events after re-disabling at "
+        f"runtime, got hits={hits}, misses={misses}, weight_lost={weight_lost}"
+    )


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Avoid index uncompressed cache overhead when the cache is disabled (server setting `index_uncompressed_cache_size = 0`, which is the default).

---

Simple change.

(Artisanally written changelog entry and C++ code. Vibecoded unreviewed test, but I did check that it fails the expected way without this PR. The rest of this PR summary is from claude.)
(See the reverse-linked support escalation for customer report.)

---

With `index_uncompressed_cache_size = 0` (the server default, advertised as "disabled"), `Context::getIndexUncompressedCache` still returned a non-null `UncompressedCache` of capacity zero. `MergeTreeIndexReader` then took the `CachedCompressedReadBuffer` path in `MergeTreeReaderStream::init`, so every skip-index block read acquired the global `CacheBase` mutex twice, evicted itself via `removeOverflow`, and unconditionally incremented `UncompressedCacheMisses` and `UncompressedCacheWeightLost`. With small-`GRANULARITY` skip indexes (`ngrambf_v1`, `bloom_filter`, etc.) this can produce hundreds of thousands of contended mutex acquisitions per query and tens of GB of phantom `UncompressedCacheWeightLost`, with zero `UncompressedCacheHits`.

The original 2021 code only constructed the cache when the configured size was non-zero. The `if (size)` guard at the call site in `Server.cpp` was later removed so the cache could be resized at runtime via `SYSTEM RELOAD CONFIG`; the data uncompressed cache survived this because `MergeTreeReadPoolBase` already gates it on `pool_settings.use_uncompressed_cache`, but the index-read path had no such guard.

This change tracks whether the cache should actually be used in a separate flag, set in `setIndexUncompressedCache` and refreshed in `updateIndexUncompressedCacheConfiguration`. `getIndexUncompressedCache` returns nullptr when the flag is false; `MergeTreeReaderStream::init` already falls through to `CompressedReadBufferFromFile` on a null pointer. Runtime resize from `0 -> N` still works.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.314`
- Backported to: `26.4.2.4`, `26.3.10.62`, `26.2.18.10`, `25.8.24.4`
<!-- ch-version-info:end -->