### PR TITLE
Refreshable MV: relax sanity checks in SECONDARY_CREATE

### DIFF
--- a/src/Storages/StorageMaterializedView.cpp
+++ b/src/Storages/StorageMaterializedView.cpp
@@ -199,7 +199,7 @@ StorageMaterializedView::StorageMaterializedView(
             }
         }
 
-        if (mode < LoadingStrictnessLevel::ATTACH && !fixed_uuid)
+        if (mode < LoadingStrictnessLevel::SECONDARY_CREATE && !fixed_uuid)
         {
             /// Sanity-check the table engine.
             String inner_engine;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

We've seen a RMV in SharedCatalog with non-replicated MergeTree table. This is normally not allowed, and idk how it got created, but it makes sense to allow that for SECONDARY_CREATE anyway.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.353`
- Backported to: `26.4.3.11`, `26.3.11.10`, `26.2.19.14`
<!-- ch-version-info:end -->