### PR TITLE
Add test: Post-instruction error paths (`cur < end` malformed input; `buildDateTime` failure) untested for `parseDateTime*Or(Null|Zero)` variants

### DIFF
--- a/tests/queries/0_stateless/04202_parsedatetime_or_null_zero_post_instruction_errors.reference
+++ b/tests/queries/0_stateless/04202_parsedatetime_or_null_zero_post_instruction_errors.reference
@@ -1,0 +1,16 @@
+trailing chars - parseDateTimeOrNull (MySQL)
+1
+trailing chars - parseDateTimeOrZero (MySQL)
+1
+trailing chars - parseDateTimeInJodaSyntaxOrNull
+1
+trailing chars - parseDateTimeInJodaSyntaxOrZero
+1
+negative seconds_since_epoch - parseDateTimeOrNull (MySQL)
+1
+negative seconds_since_epoch - parseDateTimeOrZero (MySQL)
+1
+negative seconds_since_epoch - parseDateTimeInJodaSyntaxOrNull
+1
+negative seconds_since_epoch - parseDateTimeInJodaSyntaxOrZero
+1

--- a/tests/queries/0_stateless/04202_parsedatetime_or_null_zero_post_instruction_errors.sql
+++ b/tests/queries/0_stateless/04202_parsedatetime_or_null_zero_post_instruction_errors.sql
@@ -1,0 +1,33 @@
+-- Test: exercises post-instruction error paths in `parseDateTime[InJodaSyntax]Or(Null|Zero)`.
+-- Covers: src/Functions/parseDateTime.cpp:817-824 ("Invalid format input is malformed at" branch when cur < end)
+--         src/Functions/parseDateTime.cpp:828-834 (buildDateTime error path) via the
+--         "Seconds since epoch is negative" check at line 632-634.
+--
+-- Existing tests for *Or(Null|Zero) only exercise instruction-level errors at line 782-810.
+-- The branches that fire AFTER the instruction loop (trailing characters, buildDateTime
+-- failures) were not covered for the *Or(Null|Zero) variants in any test in 0_stateless or
+-- integration.
+
+SELECT 'trailing chars - parseDateTimeOrNull (MySQL)';
+SELECT parseDateTimeOrNull('2023-01-02 03:04:05extra', '%Y-%m-%d %H:%i:%s', 'UTC') IS NULL;
+
+SELECT 'trailing chars - parseDateTimeOrZero (MySQL)';
+SELECT parseDateTimeOrZero('2023-01-02 03:04:05extra', '%Y-%m-%d %H:%i:%s', 'UTC') = toDateTime('1970-01-01', 'UTC');
+
+SELECT 'trailing chars - parseDateTimeInJodaSyntaxOrNull';
+SELECT parseDateTimeInJodaSyntaxOrNull('2023-01-02extra', 'yyyy-MM-dd', 'UTC') IS NULL;
+
+SELECT 'trailing chars - parseDateTimeInJodaSyntaxOrZero';
+SELECT parseDateTimeInJodaSyntaxOrZero('2023-01-02extra', 'yyyy-MM-dd', 'UTC') = toDateTime('1970-01-01', 'UTC');
+
+SELECT 'negative seconds_since_epoch - parseDateTimeOrNull (MySQL)';
+SELECT parseDateTimeOrNull('1970-01-01 00:00:00', '%Y-%m-%d %H:%i:%s', 'Asia/Shanghai') IS NULL;
+
+SELECT 'negative seconds_since_epoch - parseDateTimeOrZero (MySQL)';
+SELECT parseDateTimeOrZero('1970-01-01 00:00:00', '%Y-%m-%d %H:%i:%s', 'Asia/Shanghai') = toDateTime('1970-01-01', 'UTC');
+
+SELECT 'negative seconds_since_epoch - parseDateTimeInJodaSyntaxOrNull';
+SELECT parseDateTimeInJodaSyntaxOrNull('1970-01-01 00:00:00', 'yyyy-MM-dd HH:mm:ss', 'Asia/Shanghai') IS NULL;
+
+SELECT 'negative seconds_since_epoch - parseDateTimeInJodaSyntaxOrZero';
+SELECT parseDateTimeInJodaSyntaxOrZero('1970-01-01 00:00:00', 'yyyy-MM-dd HH:mm:ss', 'Asia/Shanghai') = toDateTime('1970-01-01', 'UTC');


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #62634](https://github.com/ClickHouse/ClickHouse/pull/62634) (merged 2024-04-16). Confirmed on current codebase — close with a note if already fixed._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #62634](https://github.com/ClickHouse/ClickHouse/pull/62634).
 That PR PR refactors `parseDateTime[InJodaSyntax]Or(Null|Zero)` error handling: replaces internal exception throw/catch with `tl::expected` (now `std::expected`) error returns to avoid the cost of throwing/catching for invalid inputs. The error code/message is propagated as a value through `VoidOrError`, `P

**1. Post-instruction error paths (`cur < end` malformed input; `buildDateTime` failure) untested for `parseDateTime*Or(Null|Zero)` variants**
  `src/Functions/parseDateTime.cpp:817`, `src/Functions/parseDateTime.cpp:828`
  **Risk:** Trace: input '2023-01-02 03:04:05extra' with format '%Y-%m-%d %H:%i:%s' fully consumes the format-driven instructions, leaving `cur` pointing at 'extra' and `cur < end` at line 817. The branch produce
  **What's unique vs PR tests:** PR adds only `tests/performance/parse_illegal_datetime.xml` which measures speed but never asserts the output (FORMAT Null discards rows). Existing correctness tests for the 4 OrNull/OrZero functions 
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/078c3366-f088-4144-830f-56409f9a3a1b)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.352`
<!-- ch-version-info:end -->