### PR TITLE
CI: collect server stacktraces on server death, simplify stop logic

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -3994,10 +3994,6 @@ class TestSuite:
         return TestSuite(args, suite_path, suite_tmp_path, suite)
 
 
-class ServerDied(Exception):
-    pass
-
-
 class GlobalTimeout(Exception):
     pass
 
@@ -4229,7 +4225,7 @@ def run_tests_array(
 
         if server_died.is_set():
             stop_tests()
-            raise ServerDied("Server died")
+            break
 
         if args.stop_time and time() > args.stop_time:
             print("\nStop tests run because global time limit is exceeded.\n")
@@ -4312,15 +4308,17 @@ def run_tests_array(
                 failures_total += 1
                 failures_chain += 1
                 if test_result.reason == FailureReason.SERVER_DIED:
+                    print_stacktraces()
                     stop_tests()
                     server_died.set()
-                    raise ServerDied("Server died")
+                    break
                 if args.max_failures > 0:
                     with total_failures_shared.get_lock():
                         total_failures_shared.value += 1
                         if total_failures_shared.value >= args.max_failures:
+                            print(f"\nReached --max-failures limit ({args.max_failures}), stopping.")
                             stop_tests()
-                            raise ServerDied(f"Reached --max-failures limit ({args.max_failures})")
+                            break
             elif test_result.status == TestStatus.SKIPPED:
                 skipped_total += 1
 
@@ -4330,8 +4328,9 @@ def run_tests_array(
             raise e
 
         if failures_chain >= args.max_failures_chain:
+            print(f"\nMax failures chain ({args.max_failures_chain}) reached, stopping.")
             stop_tests()
-            raise ServerDied("Max failures chain")
+            break
 
     if failures_total > 0:
         print(
@@ -4769,6 +4768,7 @@ def do_run_tests(
             if args.hung_check:
                 if not check_server_liveness(args):
                     print("Hung check failed: server is not responding")
+                    print_stacktraces()
                     server_died.set()
 
             if server_died.is_set():
@@ -6440,10 +6440,6 @@ if __name__ == "__main__":
 
     try:
         main(args)
-    except ServerDied as e:
-        print(f"{e}", file=sys.stderr)
-        traceback.print_exc()
-        sys.exit(1)
     except Terminated as e:
         print(f"Terminated with {e.signal} signal", file=sys.stderr)
         sys.exit(128 + e.signal)

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -4318,6 +4318,7 @@ def run_tests_array(
                         if total_failures_shared.value >= args.max_failures:
                             print(f"\nReached --max-failures limit ({args.max_failures}), stopping.")
                             stop_tests()
+                            server_died.set()
                             break
             elif test_result.status == TestStatus.SKIPPED:
                 skipped_total += 1
@@ -4330,6 +4331,7 @@ def run_tests_array(
         if failures_chain >= args.max_failures_chain:
             print(f"\nMax failures chain ({args.max_failures_chain}) reached, stopping.")
             stop_tests()
+            server_died.set()
             break
 
     if failures_total > 0:

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -3994,6 +3994,10 @@ class TestSuite:
         return TestSuite(args, suite_path, suite_tmp_path, suite)
 
 
+class ServerDied(Exception):
+    pass
+
+
 class GlobalTimeout(Exception):
     pass
 
@@ -4225,7 +4229,7 @@ def run_tests_array(
 
         if stop_testing.is_set():
             stop_tests()
-            break
+            raise ServerDied("Server died")
 
         if args.stop_time and time() > args.stop_time:
             print("\nStop tests run because global time limit is exceeded.\n")
@@ -4311,15 +4315,14 @@ def run_tests_array(
                     print_stacktraces()
                     stop_tests()
                     stop_testing.set()
-                    break
+                    raise ServerDied("Server died")
                 if args.max_failures > 0:
                     with total_failures_shared.get_lock():
                         total_failures_shared.value += 1
                         if total_failures_shared.value >= args.max_failures:
-                            print(f"\nReached --max-failures limit ({args.max_failures}), stopping.")
                             stop_tests()
                             stop_testing.set()
-                            break
+                            raise ServerDied(f"Reached --max-failures limit ({args.max_failures})")
             elif test_result.status == TestStatus.SKIPPED:
                 skipped_total += 1
 
@@ -4329,10 +4332,9 @@ def run_tests_array(
             raise e
 
         if failures_chain >= args.max_failures_chain:
-            print(f"\nMax failures chain ({args.max_failures_chain}) reached, stopping.")
             stop_tests()
             stop_testing.set()
-            break
+            raise ServerDied("Max failures chain")
 
     if failures_total > 0:
         print(
@@ -6442,6 +6444,10 @@ if __name__ == "__main__":
 
     try:
         main(args)
+    except ServerDied as e:
+        print(f"{e}", file=sys.stderr)
+        traceback.print_exc()
+        sys.exit(1)
     except Terminated as e:
         print(f"Terminated with {e.signal} signal", file=sys.stderr)
         sys.exit(128 + e.signal)

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -3998,7 +3998,7 @@ class GlobalTimeout(Exception):
     pass
 
 
-def run_diagnose_from_artifacts(args, server_died):
+def run_diagnose_from_artifacts(args, stop_testing):
     """Read saved randomized settings artifacts and run diagnosis for each entry."""
     entries = load_random_settings_artifacts(args)
     if not entries:
@@ -4025,7 +4025,7 @@ def run_diagnose_from_artifacts(args, server_died):
     results_path = get_random_settings_diagnostics_results_path(args)
     # Non-zero exit code is reserved for unexpected script termination
     # (e.g. uncaught exception in the diagnosis machinery). Environmental
-    # conditions like server_died are not script failures — they are
+    # conditions like stop_testing are not script failures — they are
     # already surfaced by the main test stage, so the diagnostics stage
     # should exit cleanly when interrupted by them.
     exit_code = 0
@@ -4036,9 +4036,9 @@ def run_diagnose_from_artifacts(args, server_died):
             settings = entry.get("settings", {})
             mt_settings = entry.get("merge_tree_settings", {})
 
-            # Server died — stop diagnosing further tests but exit cleanly:
-            # the main test stage has already reported the server failure.
-            if server_died.is_set():
+            # Testing stopped — stop diagnosing further tests but exit cleanly:
+            # the main test stage has already reported the failure.
+            if stop_testing.is_set():
                 break
 
             # Find the test case file across suites
@@ -4147,7 +4147,7 @@ def run_tests_array(
         is_concurrent,
         args,
         exit_code,
-        server_died,
+        stop_testing,
         workers_to_shed,
         restarted_tests,
         process_index,
@@ -4223,7 +4223,7 @@ def run_tests_array(
         else:
             break
 
-        if server_died.is_set():
+        if stop_testing.is_set():
             stop_tests()
             break
 
@@ -4310,7 +4310,7 @@ def run_tests_array(
                 if test_result.reason == FailureReason.SERVER_DIED:
                     print_stacktraces()
                     stop_tests()
-                    server_died.set()
+                    stop_testing.set()
                     break
                 if args.max_failures > 0:
                     with total_failures_shared.get_lock():
@@ -4318,7 +4318,7 @@ def run_tests_array(
                         if total_failures_shared.value >= args.max_failures:
                             print(f"\nReached --max-failures limit ({args.max_failures}), stopping.")
                             stop_tests()
-                            server_died.set()
+                            stop_testing.set()
                             break
             elif test_result.status == TestStatus.SKIPPED:
                 skipped_total += 1
@@ -4331,7 +4331,7 @@ def run_tests_array(
         if failures_chain >= args.max_failures_chain:
             print(f"\nMax failures chain ({args.max_failures_chain}) reached, stopping.")
             stop_tests()
-            server_died.set()
+            stop_testing.set()
             break
 
     if failures_total > 0:
@@ -4651,7 +4651,7 @@ def do_run_tests(
     args,
     exit_code,
     restarted_tests,
-    server_died,
+    stop_testing,
     runner_process_killed,
 ):
     print(
@@ -4716,7 +4716,7 @@ def do_run_tests(
                         True,
                         args,
                         exit_code,
-                        server_died,
+                        stop_testing,
                         workers_to_shed,
                         restarted_tests,
                         i,  # process index
@@ -4771,10 +4771,10 @@ def do_run_tests(
                 if not check_server_liveness(args):
                     print("Hung check failed: server is not responding")
                     print_stacktraces()
-                    server_died.set()
+                    stop_testing.set()
 
-            if server_died.is_set():
-                print("Server died, terminating all processes...")
+            if stop_testing.is_set():
+                print("Stopping tests, terminating all processes...")
                 # Wait briefly for test results to be written
                 sleep(5)
                 for p in processes:
@@ -4812,7 +4812,7 @@ def do_run_tests(
                 False,
                 args,
                 exit_code,
-                server_died,
+                stop_testing,
                 multiprocessing.Value('i', 0),  # sequential runner is never shed
                 restarted_tests,
                 jobs + 1,
@@ -5063,7 +5063,7 @@ def try_get_skip_list(base_dir, name, remove_comment=True):
 
 def main(args):
     exit_code = multiprocessing.Value("i", 0)
-    server_died = multiprocessing.Event()
+    stop_testing = multiprocessing.Event()
     runner_process_killed = multiprocessing.Event()
     multiprocessing_manager = multiprocessing.Manager()
     restarted_tests = multiprocessing_manager.list()
@@ -5209,7 +5209,7 @@ def main(args):
             create_common_database(args, "test")
     except Exception as e:
         print(f"Failed to create databases for tests: {e}")
-        server_died.set()
+        stop_testing.set()
         raise
 
     if (
@@ -5373,7 +5373,7 @@ ORDER BY (test_name, callee_offset)
         cloud_skip_errors_list += ["Cannot attach table with UUID"]
 
     if args.diagnose_random_settings:
-        diag_exit_code = run_diagnose_from_artifacts(args, server_died)
+        diag_exit_code = run_diagnose_from_artifacts(args, stop_testing)
         # Exit immediately: post-run checks below (hung check, coverage export,
         # log stats, etc.) assume a completed test run and would surface spurious
         # failures in diagnose mode. Any real diagnostics error is already in
@@ -5387,7 +5387,7 @@ ORDER BY (test_name, callee_offset)
             pass
 
         for suite in sorted(os.listdir(base_dir), key=suite_key_func):
-            if server_died.is_set():
+            if stop_testing.is_set():
                 break
 
             test_suite = TestSuite.read_test_suite(args, suite)
@@ -5405,11 +5405,11 @@ ORDER BY (test_name, callee_offset)
                 args,
                 exit_code,
                 restarted_tests,
-                server_died,
+                stop_testing,
                 runner_process_killed,
             )
 
-    if server_died.is_set():
+    if stop_testing.is_set():
         exit_code.value = 1
 
     if runner_process_killed.is_set():


### PR DESCRIPTION
`clickhouse-test` has a `print_stacktraces` function that collects gdb/`system.stack_trace` backtraces, but it was only called at startup and during the hung-query check — never when the server was detected dead mid-run. This left the most important failure mode without any trace output.

## Changes

**Stacktrace collection on server death** — `print_stacktraces` is now called at the two earliest detection points:
- When a test result comes back with `FailureReason.SERVER_DIED` (in `run_tests_array`)
- When the liveness hung-check finds the server unresponsive (in `do_run_tests`)

**Removed `ServerDied` exception** — the exception was raised immediately after setting the `server_died` event, so it was redundant: the event already signals all workers to stop, and `main` already sets exit code 1 when the event is set. Replaced all raises with `break`. The two non-server-death stops (`--max-failures` limit and max failures chain) now print an explicit message before breaking. A bug was also fixed where these two cases did not set the stop flag, so `main`'s suite loop would continue into subsequent suites.

**Renamed `server_died` → `stop_testing`** — the flag is now set for `--max-failures` and failures-chain limits too, not only for actual server death, so the old name was misleading.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.456`
<!-- ch-version-info:end -->