### PR TITLE
Add test: `SAMPLE` inside a CTE (analyzer) — `sample_size_ratio` clone path untested

### DIFF
--- a/tests/queries/0_stateless/04202_cte_with_sample.reference
+++ b/tests/queries/0_stateless/04202_cte_with_sample.reference
@@ -1,0 +1,19 @@
+QUERY id: 0
+  PROJECTION COLUMNS
+    count() UInt64
+  PROJECTION
+    LIST id: 1, nodes: 1
+      FUNCTION id: 2, function_name: count, function_type: aggregate, result_type: UInt64
+  JOIN TREE
+    QUERY id: 3, alias: __table1, is_subquery: 1, is_cte: 1, cte_name: cte
+      PROJECTION COLUMNS
+        a UInt64
+        b String
+      PROJECTION
+        LIST id: 4, nodes: 2
+          COLUMN id: 5, column_name: a, result_type: UInt64, source_id: 6
+          COLUMN id: 7, column_name: b, result_type: String, source_id: 6
+      JOIN TREE
+        TABLE id: 6, alias: __table2, table_name: default.t_cte_sample, final: 0, sample_size: 1 / 10
+1
+1

--- a/tests/queries/0_stateless/04202_cte_with_sample.sql
+++ b/tests/queries/0_stateless/04202_cte_with_sample.sql
@@ -1,0 +1,39 @@
+-- Test: exercises `IdentifierNode::cloneImpl` preserving SAMPLE modifier through CTE
+-- Covers: src/Analyzer/IdentifierNode.cpp:60 — clone of `table_expression_modifiers`
+--         specifically the `sample_size_ratio` field, which the PR's own test does not exercise.
+-- Risk: if `sample_size_ratio` is not preserved when an `IdentifierNode` is cloned during
+--       CTE resolution, `SAMPLE 0.1` inside a CTE silently returns the full table → wrong results.
+
+DROP TABLE IF EXISTS t_cte_sample;
+
+CREATE TABLE t_cte_sample (a UInt64, b String)
+ENGINE = MergeTree
+ORDER BY (cityHash64(a), a)
+SAMPLE BY cityHash64(a)
+SETTINGS index_granularity = 1024;
+
+INSERT INTO t_cte_sample SELECT number, toString(number) FROM numbers(100000);
+OPTIMIZE TABLE t_cte_sample FINAL;
+
+SET enable_analyzer = 1;
+
+-- The query tree must show sample_size on the resolved table inside the CTE.
+EXPLAIN QUERY TREE passes=1
+WITH cte AS (
+    SELECT * FROM t_cte_sample SAMPLE 0.1
+)
+SELECT count() FROM cte;
+
+-- Data correctness: count via CTE must equal count via direct SAMPLE.
+WITH cte AS (
+    SELECT * FROM t_cte_sample SAMPLE 0.1
+)
+SELECT (SELECT count() FROM cte) = (SELECT count() FROM t_cte_sample SAMPLE 0.1) AS cte_matches_direct;
+
+-- And the sampled count must be strictly less than the full table.
+WITH cte AS (
+    SELECT * FROM t_cte_sample SAMPLE 0.1
+)
+SELECT count() < 100000 AS sample_actually_applied FROM cte;
+
+DROP TABLE t_cte_sample;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_Retrospective finding from a historical scan of [PR #62811](https://github.com/ClickHouse/ClickHouse/pull/62811) (merged 2024-04-25). Confirmed on current codebase — close with a note if already fixed._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #62811](https://github.com/ClickHouse/ClickHouse/pull/62811).
 That PR PR fixes a single missing line in `IdentifierNode::cloneImpl` (src/Analyzer/IdentifierNode.cpp:60). Previously, when an `IdentifierNode` was cloned (notably during CTE expansion), its `table_expression_modifiers` field was dropped — silently losing FINAL, SAMPLE size, and SAMPLE offset. The PR adds 

**1. `SAMPLE` inside a CTE (analyzer) — `sample_size_ratio` clone path untested**
  `src/Analyzer/IdentifierNode.cpp:60`, `src/Analyzer/TableExpressionModifiers.h:73`
  **Risk:** The PR fix `clone_identifier_node->table_expression_modifiers = table_expression_modifiers;` copies the entire `TableExpressionModifiers` struct, which holds three fields: `has_final`, `sample_size_ra
  **What's unique vs PR tests:** PR's 03129_cte_with_final.sql tests `has_final` clone-through-CTE. This test exercises `sample_size_ratio` clone-through-CTE — a different field of the same `TableExpressionModifiers` struct, a differ
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/33353f39-21d9-4a97-9abe-ae71bbf66c00)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.373`
<!-- ch-version-info:end -->