### PR TITLE
docs: Add 1bench to third-party GUI tools

### DIFF
--- a/docs/en/interfaces/third-party/gui.md
+++ b/docs/en/interfaces/third-party/gui.md
@@ -500,3 +500,18 @@ Features:
 - Provides cluster node monitoring and zookeeper monitoring
 - Monitor the status of tables and partitions, and monitor slow SQL statements
 - Provides an easy-to-use SQL execution page
+
+### 1bench {#1bench}
+
+[1bench](https://1bench.dev) is a native desktop GUI for multiple databases with first-class ClickHouse support — spanning server overview, schema management, vector search, and large result-set browsing.
+
+Features:
+
+- Server overview on connect — version, uptime, running queries, active merges, parts and storage sizes, replica status, clusters and nodes at a glance.
+- Visual query builder (column pickers, filters, sort, limit) alongside a Monaco SQL editor with syntax highlighting and query history per connection.
+- Visual `CREATE TABLE` wizard supporting `MergeTree` variants, `ORDER BY`, `PARTITION BY`, `SETTINGS`, and `Nullable()` auto-wrapping.
+- Native ClickHouse type handling — `Nullable`, `Array`, `LowCardinality`, nested objects.
+- Vector search support — `Array(Float32)` embedding columns rendered as compact vector cells, 2D embedding visualization, and Find Similar via `cosineDistance`.
+- Inline data editing in result tables with batched save, plus CSV/JSON/SQL export and import using ClickHouse's native formats.
+- Connection options: HTTP/HTTPS, SSH tunnel for private/firewalled clusters, optional read-only mode for safe production browsing.
+- Works with ClickHouse Cloud and self-hosted.

--- a/docs/en/interfaces/third-party/gui.md
+++ b/docs/en/interfaces/third-party/gui.md
@@ -513,5 +513,5 @@ Features:
 - Native ClickHouse type handling — `Nullable`, `Array`, `LowCardinality`, nested objects.
 - Vector search support — `Array(Float32)` embedding columns rendered as compact vector cells, 2D embedding visualization, and Find Similar via `cosineDistance`.
 - Inline data editing in result tables with batched save, plus CSV/JSON/SQL export and import using ClickHouse's native formats.
-- Connection options: HTTP/HTTPS, SSH tunnel for private/firewalled clusters, optional read-only mode for safe production browsing.
+- Connection options: HTTP/HTTPS, SSH tunnel for private clusters behind a firewall, optional read-only mode for safe production browsing.
 - Works with ClickHouse Cloud and self-hosted.


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Add [1bench](https://1bench.dev) to the list of third-party GUI tools (Commercial section) in `docs/en/interfaces/third-party/gui.md`.

1bench is a native desktop GUI with first-class ClickHouse support, including server overview, visual `CREATE TABLE` wizard for `MergeTree` variants, native handling of ClickHouse types (`Nullable`, `Array`, `LowCardinality`), and vector search via `cosineDistance` on `Array(Float32)` columns. The entry follows the existing format of other Commercial-section tools (DataGrip, Looker, SeekTable, etc.).

Placed at the end of the Commercial section since that section is not alphabetically ordered.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.297`
<!-- ch-version-info:end -->