### PR TITLE
Preallocate multipart_tags deque to reduce dynamic memory allocation …

### DIFF
--- a/src/IO/S3/copyS3File.cpp
+++ b/src/IO/S3/copyS3File.cpp
@@ -265,6 +265,8 @@ namespace
             calculatePartSize(size);
             createMultipartUpload();
 
+            multipart_tags.resize(num_parts);
+
             size_t position = start_offset;
             size_t end_position = start_offset + size;
 
@@ -285,9 +287,7 @@ namespace
 
                     assert(part_size);
 
-                    multipart_tags.push_back({});
-                    chassert(part_number == multipart_tags.size());
-                    auto & part_tag = multipart_tags.back();
+                    auto & part_tag = multipart_tags[part_number - 1];
 
                     task_tracker.add([this, part_number, position, part_size, &part_tag]()
                     {


### PR DESCRIPTION
Problem Overview:
Preallocate multipart_tags deque to reduce dynamic memory allocation overhead in S3 upload loop.

Summary:
During S3 multipart file uploads, the previous implementation dynamically allocated storage for part tags element-by-element inside the main scheduling loop using push_back. Since the exact number of file chunks is calculated prior to the loop, this dynamic allocation created completely unnecessary memory overhead and locking contention interleaved with thread queuing. This PR optimizes the flow by pre-allocating the entire container upfront and replacing dynamic sizing with direct index assignment, eliminating repeated heap allocations during chunk queuing.

Changelog category (leave one):
Performance Improvement
Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduce memory allocation overhead during S3 multipart uploads by preallocating internal tracking containers.

Documentation entry for user-facing changes
 Documentation is written (mandatory for new features)