### PR TITLE
Fix LOGICAL_ERROR in StreamingStorageRegistry::renameTable during batch renames

### DIFF
--- a/src/Storages/StreamingStorageRegistry.cpp
+++ b/src/Storages/StreamingStorageRegistry.cpp
@@ -3,6 +3,7 @@
 #include <Interpreters/Context.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h>
+#include <Common/SipHash.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
 #include <Common/setThreadName.h>
 
@@ -36,6 +37,42 @@ StreamingStorageRegistry & StreamingStorageRegistry::instance()
 {
     static StreamingStorageRegistry ret;
     return ret;
+}
+
+size_t StreamingStorageRegistry::IdentityHash::operator()(const StorageID & storage_id) const
+{
+    SipHash hash;
+    if (storage_id.hasUUID())
+    {
+        const auto & uuid = storage_id.uuid;
+        hash.update(reinterpret_cast<const char *>(&uuid), sizeof(uuid));
+    }
+    else
+    {
+        hash.update(storage_id.database_name.data(), storage_id.database_name.size());
+        hash.update(storage_id.table_name.data(), storage_id.table_name.size());
+    }
+    return hash.get64();
+}
+
+bool StreamingStorageRegistry::IdentityEqual::operator()(const StorageID & lhs, const StorageID & rhs) const
+{
+    const bool lhs_has = lhs.hasUUID();
+    const bool rhs_has = rhs.hasUUID();
+
+    /// Both have UUID — compare by UUID only.
+    if (lhs_has && rhs_has)
+        return lhs.uuid == rhs.uuid;
+
+    /// Mixed: one has UUID, the other does not — treat as non-equal.
+    /// This preserves the hash/equality contract: IdentityHash uses UUID for one
+    /// and name for the other, producing different hashes. Equal elements must
+    /// have identical hashes, so mixed cases must never compare equal.
+    if (lhs_has != rhs_has)
+        return false;
+
+    /// Neither has UUID — fall back to name comparison.
+    return lhs.database_name == rhs.database_name && lhs.table_name == rhs.table_name;
 }
 
 void StreamingStorageRegistry::registerTable(const StorageID & storage)
@@ -85,23 +122,16 @@ void StreamingStorageRegistry::renameTable(const StorageID & from, const Storage
     if (shutdown_called)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Shutdown was called");
 
+    /// With UUID-based identity tracking, `find` locates the entry by UUID (when available),
+    /// so batch renames (e.g., A↔B swap) correctly identify each table regardless of
+    /// intermediate name collisions.
     auto from_it = storages.find(from);
     if (from_it == storages.end())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Table with storage id {} is not registered", from.getNameForLogs());
 
     storages.erase(from_it);
-
-    auto to_it = storages.find(to);
-    if (to_it == storages.end())
-    {
-        storages.emplace(to);
-        LOG_TRACE(log, "Unregistered table: {}, registered table: {}", from.getNameForLogs(), to.getNameForLogs());
-    }
-    else
-    {
-        /// This could happen because of exchange/replace tables.
-        LOG_TRACE(log, "Unregistered table: {}, table {} was already registered", from.getNameForLogs(), to.getNameForLogs());
-    }
+    storages.emplace(to);
+    LOG_TRACE(log, "Renamed table: {} -> {}", from.getNameForLogs(), to.getNameForLogs());
 }
 
 void StreamingStorageRegistry::shutdown()

--- a/src/Storages/StreamingStorageRegistry.h
+++ b/src/Storages/StreamingStorageRegistry.h
@@ -30,10 +30,23 @@ public:
     void shutdown();
 
 private:
+    /// Identity-based hash: uses UUID when available, falls back to database+table name.
+    /// This ensures that during batch renames (e.g., A↔B swap), each table
+    /// is tracked by its stable identity (UUID) rather than its mutable name.
+    struct IdentityHash
+    {
+        size_t operator()(const StorageID & storage_id) const;
+    };
+
+    struct IdentityEqual
+    {
+        bool operator()(const StorageID & lhs, const StorageID & rhs) const;
+    };
+
     const LoggerPtr log = getLogger("StreamingStorageRegistry");
     bool shutdown_called = false;
     std::mutex mutex;
-    std::unordered_set<StorageID, StorageID::DatabaseAndTableNameHash, StorageID::DatabaseAndTableNameEqual> storages;
+    std::unordered_set<StorageID, IdentityHash, IdentityEqual> storages;
 };
 
 /*

--- a/src/Storages/tests/gtest_streaming_storage_registry.cpp
+++ b/src/Storages/tests/gtest_streaming_storage_registry.cpp
@@ -1,0 +1,122 @@
+#include <gtest/gtest.h>
+
+#include <Storages/StreamingStorageRegistry.h>
+#include <Core/UUID.h>
+#include <base/sanitizer_defs.h>
+
+using namespace DB;
+
+/// Each test generates fresh UUIDs, so concurrent or sequential tests
+/// do not collide in the singleton registry.
+class StreamingStorageRegistryTest : public ::testing::Test
+{
+protected:
+    StreamingStorageRegistry & registry = StreamingStorageRegistry::instance();
+
+    UUID uuid1 = UUIDHelpers::generateV4();
+    UUID uuid2 = UUIDHelpers::generateV4();
+};
+
+TEST_F(StreamingStorageRegistryTest, RegisterAndUnregister)
+{
+    StorageID table("test_db", "table_reg", uuid1);
+
+    ASSERT_NO_THROW(registry.registerTable(table));
+    ASSERT_NO_THROW(registry.unregisterTable(table));
+}
+
+TEST_F(StreamingStorageRegistryTest, DuplicateRegisterThrows)
+{
+    StorageID table("test_db", "table_dup", uuid1);
+
+    registry.registerTable(table);
+    EXPECT_THROW(registry.registerTable(table), Exception);
+
+    registry.unregisterTable(table);
+}
+
+/// LOGICAL_ERROR aborts in debug/sanitizer builds, so skip this test there.
+#ifndef DEBUG_OR_SANITIZER_BUILD
+TEST_F(StreamingStorageRegistryTest, UnregisterNonExistentThrows)
+{
+    StorageID table("test_db", "table_missing", uuid1);
+    EXPECT_THROW(registry.unregisterTable(table), Exception);
+}
+#endif
+
+TEST_F(StreamingStorageRegistryTest, SimpleRename)
+{
+    StorageID from("test_db", "old_name", uuid1);
+    StorageID to("test_db", "new_name", uuid1);
+
+    registry.registerTable(from);
+    ASSERT_NO_THROW(registry.renameTable(from, to));
+    ASSERT_NO_THROW(registry.unregisterTable(to));
+}
+
+/// LOGICAL_ERROR aborts in debug/sanitizer builds, so skip this test there.
+#ifndef DEBUG_OR_SANITIZER_BUILD
+TEST_F(StreamingStorageRegistryTest, RenameNonExistentThrows)
+{
+    StorageID from("test_db", "no_such_table", uuid1);
+    StorageID to("test_db", "dest", uuid1);
+
+    EXPECT_THROW(registry.renameTable(from, to), Exception);
+}
+#endif
+
+/// Regression test for the A↔B batch-rename scenario.
+///
+/// SharedDatabaseCatalog::applyState renames streaming tables in sequence.
+/// When two S3Queue tables swap names (e.g., during a dbt RENAME+EXCHANGE
+/// workflow), the rename sequence is:
+///   1. rename A → B   (table uuid1 gets name B)
+///   2. rename B → A   (table uuid2 gets name A)
+///
+/// Before the UUID-based identity fix, the registry matched entries by name
+/// only, so step 1 would silently collide with the existing entry for B.
+/// After step 2 completed, only one of the two tables remained registered,
+/// causing LOGICAL_ERROR on subsequent applyState retries.
+///
+/// With UUID-based tracking, each table is identified by its UUID, so both
+/// survive the swap regardless of intermediate name collisions.
+TEST_F(StreamingStorageRegistryTest, BatchRenameSwapPreservesBothTables)
+{
+    StorageID table_a("test_db", "queue_a", uuid1);
+    StorageID table_b("test_db", "queue_b", uuid2);
+
+    registry.registerTable(table_a);
+    registry.registerTable(table_b);
+
+    /// Step 1: rename A → B (table uuid1 now has name "queue_b")
+    StorageID a_with_new_name("test_db", "queue_b", uuid1);
+    ASSERT_NO_THROW(registry.renameTable(table_a, a_with_new_name));
+
+    /// Step 2: rename B → A (table uuid2 now has name "queue_a")
+    StorageID b_with_new_name("test_db", "queue_a", uuid2);
+    ASSERT_NO_THROW(registry.renameTable(table_b, b_with_new_name));
+
+    /// Both tables must still be registered — unregister must not throw.
+    EXPECT_NO_THROW(registry.unregisterTable(a_with_new_name));
+    EXPECT_NO_THROW(registry.unregisterTable(b_with_new_name));
+}
+
+/// Same swap but across different databases, which is what dbt does when it
+/// renames __new → production and production → __backup in different schemas.
+TEST_F(StreamingStorageRegistryTest, BatchRenameCrossDatabaseSwap)
+{
+    StorageID table_a("db_prod", "queue", uuid1);
+    StorageID table_b("db_staging", "queue", uuid2);
+
+    registry.registerTable(table_a);
+    registry.registerTable(table_b);
+
+    StorageID a_moved("db_staging", "queue", uuid1);
+    ASSERT_NO_THROW(registry.renameTable(table_a, a_moved));
+
+    StorageID b_moved("db_prod", "queue", uuid2);
+    ASSERT_NO_THROW(registry.renameTable(table_b, b_moved));
+
+    EXPECT_NO_THROW(registry.unregisterTable(a_moved));
+    EXPECT_NO_THROW(registry.unregisterTable(b_moved));
+}


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `LOGICAL_ERROR` in `StreamingStorageRegistry::renameTable` when batch-renaming streaming tables (S3Queue, Kafka, RabbitMQ) by using UUID-based identity tracking instead of name-based.

---

Publishing https://github.com/ClickHouse/clickhouse-private/pull/56463

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.332`
- Backported to: `26.4.5.18`, `26.3.14.15`
<!-- ch-version-info:end -->