### PR TITLE
Fix DISTINCT silently dropped through UNION ALL CTE in RemoveUnusedProjectionColumnsPass

### DIFF
--- a/src/Analyzer/Passes/RemoveUnusedProjectionColumnsPass.cpp
+++ b/src/Analyzer/Passes/RemoveUnusedProjectionColumnsPass.cpp
@@ -68,6 +68,20 @@ void updateUsedProjectionIndexes(const QueryTreeNodePtr & query_or_union_node, s
     const auto & projection_nodes = query_node.getProjection().getNodes();
     size_t projection_nodes_size = projection_nodes.size();
 
+    /// If the query uses DISTINCT, all of its projection columns are
+    /// significant — `DISTINCT` deduplicates over the full row of selected
+    /// columns, so removing any of them changes the result.
+    /// The pass-level guard in `run` skips DISTINCT queries that are direct
+    /// FROM-children, but a DISTINCT query reached through a `UNION ALL`
+    /// is processed here (via the recursion above) and would otherwise
+    /// have its columns silently pruned.
+    if (query_node.isDistinct())
+    {
+        for (size_t i = 0; i < projection_nodes_size; ++i)
+            used_projection_columns_indexes.insert(i);
+        return;
+    }
+
     for (size_t i = 0; i < projection_nodes_size; ++i)
     {
         const auto & projection_node = projection_nodes[i];

--- a/tests/queries/0_stateless/04204_distinct_outside_cte_103785.reference
+++ b/tests/queries/0_stateless/04204_distinct_outside_cte_103785.reference
@@ -38,3 +38,5 @@ product_1
 product_1
 -- Query H: den-crane VALUES-based count(c2) repro from PR #104114
 3
+-- Query I: den-crane VALUES-based count() repro from PR #104114
+3

--- a/tests/queries/0_stateless/04204_distinct_outside_cte_103785.reference
+++ b/tests/queries/0_stateless/04204_distinct_outside_cte_103785.reference
@@ -36,3 +36,5 @@ product_0
 product_1
 product_1
 product_1
+-- Query H: den-crane VALUES-based count(c2) repro from PR #104114
+3

--- a/tests/queries/0_stateless/04204_distinct_outside_cte_103785.reference
+++ b/tests/queries/0_stateless/04204_distinct_outside_cte_103785.reference
@@ -1,0 +1,38 @@
+-- Query A: full projection (ID, Qty) - was already correct
+115	100000
+116	130000
+117	150000
+118	150000
+-- Query B: subset projection (Qty only) - used to drop a row
+100000
+130000
+150000
+150000
+-- Query C: subset projection through nested SELECT - used to drop a row
+100000
+130000
+150000
+150000
+-- Query D: DISTINCT in second branch of UNION ALL
+100000
+130000
+150000
+150000
+-- Query E: DISTINCT inside a nested UNION ALL
+100000
+130000
+150000
+150000
+150000
+-- Query F: workaround setting still works as before
+100000
+130000
+150000
+150000
+-- Query G: existing 03023 case - DISTINCT as direct FROM-child (already worked)
+product_0
+product_0
+product_0
+product_1
+product_1
+product_1

--- a/tests/queries/0_stateless/04204_distinct_outside_cte_103785.sql
+++ b/tests/queries/0_stateless/04204_distinct_outside_cte_103785.sql
@@ -90,4 +90,18 @@ SELECT count(c2) FROM
     SELECT c1, c2 FROM VALUES ((118, 150000))
 );
 
+SELECT '-- Query I: den-crane VALUES-based count() repro from PR #104114';
+-- Same shape as Query H but with `count()` (no argument) instead of
+-- `count(c2)`. Pre-fix: returned 2 because `RemoveUnusedProjectionColumnsPass`
+-- pruned both `c1` and `c2` from the inner `SELECT DISTINCT c1, c2` (the outer
+-- `count()` references no column at all), collapsing the entire DISTINCT side
+-- into a single empty-projection row.
+-- Post-fix: returns 3 (2 distinct rows from the LHS DISTINCT side + 1 from the RHS).
+SELECT count() FROM
+(
+    SELECT DISTINCT c1, c2 FROM VALUES ((1, 1), (1, 2))
+    UNION ALL
+    SELECT c1, c2 FROM VALUES ((1, 1))
+);
+
 DROP TABLE t_qty_103785;

--- a/tests/queries/0_stateless/04204_distinct_outside_cte_103785.sql
+++ b/tests/queries/0_stateless/04204_distinct_outside_cte_103785.sql
@@ -1,0 +1,80 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/103785
+-- DISTINCT inside a CTE branch was being silently weakened when an outer
+-- query projected only a subset of the CTE's columns. The new analyzer's
+-- `RemoveUnusedProjectionColumnsPass` correctly skipped DISTINCT
+-- query-as-FROM-children, but did not skip DISTINCT query-as-children
+-- of a `UNION ALL`, so the unused column was pruned out of the inner
+-- DISTINCT projection — turning `SELECT DISTINCT ID, Qty` into
+-- effectively `SELECT DISTINCT Qty` and dropping rows that share the
+-- same `Qty` value but have different `ID`.
+
+DROP TABLE IF EXISTS t_qty_103785;
+CREATE TABLE t_qty_103785 (ID UInt32, Qty UInt64) ENGINE = Memory;
+INSERT INTO t_qty_103785 VALUES (115, 100000), (116, 130000), (117, 150000), (118, 150000);
+
+SELECT '-- Query A: full projection (ID, Qty) - was already correct';
+WITH a AS (
+    SELECT DISTINCT ID, Qty FROM t_qty_103785 WHERE ID IN (116, 117, 118)
+    UNION ALL
+    SELECT ID, Qty FROM t_qty_103785 WHERE ID = 115
+)
+SELECT ID, Qty FROM a ORDER BY ID;
+
+SELECT '-- Query B: subset projection (Qty only) - used to drop a row';
+WITH a AS (
+    SELECT DISTINCT ID, Qty FROM t_qty_103785 WHERE ID IN (116, 117, 118)
+    UNION ALL
+    SELECT ID, Qty FROM t_qty_103785 WHERE ID = 115
+)
+SELECT Qty FROM a ORDER BY Qty;
+
+SELECT '-- Query C: subset projection through nested SELECT - used to drop a row';
+WITH a AS (
+    SELECT DISTINCT ID, Qty FROM t_qty_103785 WHERE ID IN (116, 117, 118)
+    UNION ALL
+    SELECT ID, Qty FROM t_qty_103785 WHERE ID = 115
+)
+SELECT Qty FROM (SELECT ID, Qty FROM a) ORDER BY Qty;
+
+SELECT '-- Query D: DISTINCT in second branch of UNION ALL';
+WITH a AS (
+    SELECT ID, Qty FROM t_qty_103785 WHERE ID = 115
+    UNION ALL
+    SELECT DISTINCT ID, Qty FROM t_qty_103785 WHERE ID IN (116, 117, 118)
+)
+SELECT Qty FROM a ORDER BY Qty;
+
+SELECT '-- Query E: DISTINCT inside a nested UNION ALL';
+WITH a AS (
+    SELECT ID, Qty FROM t_qty_103785 WHERE ID = 115
+    UNION ALL
+    (
+        SELECT DISTINCT ID, Qty FROM t_qty_103785 WHERE ID IN (116, 117, 118)
+        UNION ALL
+        SELECT ID, Qty FROM t_qty_103785 WHERE ID = 117
+    )
+)
+SELECT Qty FROM a ORDER BY Qty;
+
+SELECT '-- Query F: workaround setting still works as before';
+WITH a AS (
+    SELECT DISTINCT ID, Qty FROM t_qty_103785 WHERE ID IN (116, 117, 118)
+    UNION ALL
+    SELECT ID, Qty FROM t_qty_103785 WHERE ID = 115
+)
+SELECT Qty FROM a ORDER BY Qty SETTINGS enable_analyzer = 0, optimize_duplicate_order_by_and_distinct = 0;
+
+SELECT '-- Query G: existing 03023 case - DISTINCT as direct FROM-child (already worked)';
+SELECT product_id
+FROM (
+    SELECT DISTINCT product_id, section_id
+    FROM (
+        SELECT
+            concat('product_', number % 2) AS product_id,
+            concat('section_', number % 3) AS section_id
+        FROM numbers(10)
+    )
+)
+ORDER BY product_id;
+
+DROP TABLE t_qty_103785;

--- a/tests/queries/0_stateless/04204_distinct_outside_cte_103785.sql
+++ b/tests/queries/0_stateless/04204_distinct_outside_cte_103785.sql
@@ -77,4 +77,17 @@ FROM (
 )
 ORDER BY product_id;
 
+SELECT '-- Query H: den-crane VALUES-based count(c2) repro from PR #104114';
+-- Pre-fix: count(c2) returned 2 because the inner SELECT DISTINCT c1, c2 had
+-- its `c1` column pruned by `RemoveUnusedProjectionColumnsPass` (the outer
+-- query only references `c2`), turning the DISTINCT into `DISTINCT c2` and
+-- collapsing (117, 150000) and (118, 150000) into a single row.
+-- Post-fix: returns 3 (2 distinct rows from the LHS + 1 row from the RHS).
+SELECT count(c2) FROM
+(
+    SELECT DISTINCT c1, c2 FROM VALUES ((117, 150000), (118, 150000))
+    UNION ALL
+    SELECT c1, c2 FROM VALUES ((118, 150000))
+);
+
 DROP TABLE t_qty_103785;


### PR DESCRIPTION
When a `WITH` CTE built by `UNION ALL` had `SELECT DISTINCT` in one of
its branches and the outer query projected only a subset of the CTE's
columns, the analyzer pass `RemoveUnusedProjectionColumnsPass` silently
pruned the un-referenced column from the inner DISTINCT projection. The
DISTINCT was then evaluated over a narrower row, collapsing rows that
should have been distinct (different `ID`, same `Qty`) into one.

The pass-level guard at the top of `RemoveUnusedProjectionColumnsPass::run` already
protects DISTINCT queries that are direct FROM-children of the outer query
(the case originally tested by `03023_remove_unused_column_distinct.sql`).
But when the FROM-child is a `UnionNode`, the code falls through and
`UnionNode::removeUnusedProjectionColumns` propagates the pruning down to
every child query — including any child that uses `SELECT DISTINCT`. The
"must keep" set computed by `updateUsedProjectionIndexes` already protects
aggregate-without-`GROUP BY` and `arrayJoin`, but did not consider DISTINCT.

Fix: in `updateUsedProjectionIndexes`, mark **all** projection columns of a
DISTINCT `QueryNode` as used. This mirrors the existing precedent for
`UNION DISTINCT` / `INTERSECT DISTINCT` / `EXCEPT DISTINCT`, which already
mark every union projection index as used. Since the recursion in that
function descends into `UNION ALL` children, this naturally handles
arbitrarily nested unions.

Verified locally: without the fix four queries in the new regression test
drop a row; with the fix the new test passes 30/30 with full
`clickhouse-test` randomization, and existing tests
`03023_remove_unused_column_distinct`, `02387_analyzer_cte`,
`01711_cte_subquery_fix`, and `02341_global_join_cte` continue to pass.

Closes #103785

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed wrong results when a CTE constructed with `UNION ALL` contained a `SELECT DISTINCT` branch and the outer query projected only a subset of the CTE's columns. The new analyzer's `RemoveUnusedProjectionColumnsPass` was incorrectly removing the un-referenced column from the inner `DISTINCT` projection, causing rows that should have remained distinct (same value in the projected column but different value in the dropped column) to collapse into one.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.408`
<!-- ch-version-info:end -->