### PR TITLE
More obvious fix for catalogs with azure

### DIFF
--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -501,7 +501,7 @@ StoragePtr DatabaseDataLake::tryGetTableImpl(const String & name, ContextPtr con
     auto catalog = getCatalog();
     auto table_metadata = DataLake::TableMetadata().withSchema().withLocation().withDataLakeSpecificProperties();
     if (settings[DatabaseDataLakeSetting::polaris_style_paths])
-        table_metadata.withPolarisStyleAbfssPaths();
+        table_metadata.withForceAddBucket();
 
     /// This is added to test that lightweight queries like 'SHOW TABLES' dont end up fetching the table
     fiu_do_on(FailPoints::lightweight_show_tables,
@@ -876,7 +876,7 @@ ASTPtr DatabaseDataLake::getCreateTableQueryImpl(
     auto catalog = getCatalog();
     auto table_metadata = DataLake::TableMetadata().withLocation().withSchema();
     if (settings[DatabaseDataLakeSetting::polaris_style_paths])
-        table_metadata.withPolarisStyleAbfssPaths();
+        table_metadata.withForceAddBucket();
 
     const auto [namespace_name, table_name] = DataLake::parseTableName(name);
 

--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -80,7 +80,7 @@ namespace DatabaseDataLakeSetting
     extern const DatabaseDataLakeSettingsString google_adc_refresh_token;
     extern const DatabaseDataLakeSettingsString google_adc_quota_project_id;
     extern const DatabaseDataLakeSettingsString google_adc_credentials_file;
-    extern const DatabaseDataLakeSettingsBool polaris_style_paths;
+    extern const DatabaseDataLakeSettingsBool force_add_bucket;
 }
 
 namespace Setting
@@ -500,7 +500,7 @@ StoragePtr DatabaseDataLake::tryGetTableImpl(const String & name, ContextPtr con
 {
     auto catalog = getCatalog();
     auto table_metadata = DataLake::TableMetadata().withSchema().withLocation().withDataLakeSpecificProperties();
-    if (settings[DatabaseDataLakeSetting::polaris_style_paths])
+    if (settings[DatabaseDataLakeSetting::force_add_bucket])
         table_metadata.withForceAddBucket();
 
     /// This is added to test that lightweight queries like 'SHOW TABLES' dont end up fetching the table
@@ -875,7 +875,7 @@ ASTPtr DatabaseDataLake::getCreateTableQueryImpl(
 {
     auto catalog = getCatalog();
     auto table_metadata = DataLake::TableMetadata().withLocation().withSchema();
-    if (settings[DatabaseDataLakeSetting::polaris_style_paths])
+    if (settings[DatabaseDataLakeSetting::force_add_bucket])
         table_metadata.withForceAddBucket();
 
     const auto [namespace_name, table_name] = DataLake::parseTableName(name);

--- a/src/Databases/DataLake/DatabaseDataLakeSettings.cpp
+++ b/src/Databases/DataLake/DatabaseDataLakeSettings.cpp
@@ -45,7 +45,7 @@ namespace ErrorCodes
     DECLARE(String, google_adc_credentials_file, "", "Deprecated setting, will throw an exception if used", 0) \
     DECLARE(String, dlf_access_key_id, "", "Access id of DLF token for Paimon REST Catalog", 0) \
     DECLARE(String, dlf_access_key_secret, "", "Access secret of DLF token for Paimon REST Catalog", 0) \
-    DECLARE(Bool, polaris_style_paths, true, "Enable Polaris/ADLS Gen2 path convention: the container name is prepended to the path in ABFSS locations (e.g. abfss://c@account/c/actual/path). When enabled, the redundant container prefix is stripped when building Azure HTTPS URLs. Disable if a real directory inside the container has the same name as the container itself.", 0) \
+    DECLARE(Bool, force_add_bucket, false, "Add bucket name to the metadata path", 0) \
 
 #define LIST_OF_DATABASE_ICEBERG_SETTINGS(M, ALIAS) \
     DATABASE_ICEBERG_RELATED_SETTINGS(M, ALIAS) \

--- a/src/Databases/DataLake/ICatalog.cpp
+++ b/src/Databases/DataLake/ICatalog.cpp
@@ -289,7 +289,7 @@ std::string TableMetadata::getMetadataLocation(const std::string & iceberg_metad
             data_location = data_location.substr(storage_type_str.size());
         else if (!endpoint.empty() && data_location.starts_with(endpoint))
             data_location = data_location.substr(endpoint.size());
-        
+
         if (metadata_location.starts_with(data_location))
         {
             size_t remove_slash = (metadata_location.size() > data_location.size() && metadata_location[data_location.size()] == '/') ? 1 : 0;

--- a/src/Databases/DataLake/ICatalog.cpp
+++ b/src/Databases/DataLake/ICatalog.cpp
@@ -120,9 +120,6 @@ void TableMetadata::setLocation(const std::string & location_)
         bucket = bucket_part.substr(0, at_pos);
         azure_account_with_suffix = bucket_part.substr(at_pos + 1);
 
-        if (force_add_bucket)
-            abfss_has_container_path_prefix = true;
-
         LOG_TEST(getLogger("TableMetadata"),
                  "Parsed Azure location - container: {}, account: {}, path: {}",
                  bucket, azure_account_with_suffix, path);
@@ -170,7 +167,7 @@ std::string TableMetadata::constructLocation(const std::string & endpoint_, DB::
     /// The bucket variable contains the container name for Azure.
     if (!azure_account_with_suffix.empty())
     {
-        if (abfss_has_container_path_prefix && location.find("/" + bucket) != std::string::npos)
+        if (!force_add_bucket && location.find("/" + bucket) != std::string::npos)
             return std::filesystem::path(location) / path / "";
         return std::filesystem::path(location) / bucket / path / "";
     }
@@ -201,7 +198,7 @@ std::string TableMetadata::constructLocation(const std::string & endpoint_, DB::
                 endpoint_uri.getHost(), bucket);
     }
 
-    if (location.ends_with(bucket))
+    if (!force_add_bucket && location.ends_with(bucket))
         return std::filesystem::path(location) / path / "";
     return std::filesystem::path(location) / bucket / path / "";
 }

--- a/src/Databases/DataLake/ICatalog.cpp
+++ b/src/Databases/DataLake/ICatalog.cpp
@@ -120,12 +120,6 @@ void TableMetadata::setLocation(const std::string & location_)
         bucket = bucket_part.substr(0, at_pos);
         azure_account_with_suffix = bucket_part.substr(at_pos + 1);
 
-        /// Some catalogs (e.g. Apache Polaris) follow the ADLS Gen2 filesystem convention
-        /// of including the container name as the first segment of the path in abfss:// locations,
-        /// e.g. abfss://container@account.dfs.core.windows.net/container/actual/path.
-        /// We record this as a flag so that `constructLocation` and `getMetadataLocation` can
-        /// strip the redundant prefix when needed, while `path` itself is left intact so that
-        /// `getLocation` remains a round-trip of `setLocation`.
         if (force_add_bucket)
             abfss_has_container_path_prefix = true;
 

--- a/src/Databases/DataLake/ICatalog.cpp
+++ b/src/Databases/DataLake/ICatalog.cpp
@@ -126,7 +126,7 @@ void TableMetadata::setLocation(const std::string & location_)
         /// We record this as a flag so that `constructLocation` and `getMetadataLocation` can
         /// strip the redundant prefix when needed, while `path` itself is left intact so that
         /// `getLocation` remains a round-trip of `setLocation`.
-        if (polaris_style_abfss_paths && path.starts_with(bucket + "/"))
+        if (force_add_bucket)
             abfss_has_container_path_prefix = true;
 
         LOG_TEST(getLogger("TableMetadata"),
@@ -176,16 +176,9 @@ std::string TableMetadata::constructLocation(const std::string & endpoint_, DB::
     /// The bucket variable contains the container name for Azure.
     if (!azure_account_with_suffix.empty())
     {
-        /// Azure storage - endpoint should be https://<account>.dfs.core.windows.net
-        /// Construct the full URL with container and path.
-        /// When the path carries a Polaris-style redundant container prefix (e.g. "c/actual/path"
-        /// for container "c"), strip it before prepending the container, so we don't double it.
-        std::string_view effective_path = path;
-        if (abfss_has_container_path_prefix && effective_path.starts_with(bucket + "/"))
-            effective_path = effective_path.substr(bucket.size() + 1);
-        if (location.ends_with(bucket))
-            return std::filesystem::path(location) / effective_path / "";
-        return std::filesystem::path(location) / bucket / effective_path / "";
+        if (abfss_has_container_path_prefix && location.find("/" + bucket) != std::string::npos)
+            return std::filesystem::path(location) / path / "";
+        return std::filesystem::path(location) / bucket / path / "";
     }
 
     if (uri_style == DB::S3UriStyle::VIRTUAL_HOSTED)
@@ -300,56 +293,9 @@ std::string TableMetadata::getMetadataLocation(const std::string & iceberg_metad
             metadata_location = metadata_location.substr(storage_type_str.size());
         if (data_location.starts_with(storage_type_str))
             data_location = data_location.substr(storage_type_str.size());
-        else if (!endpoint.empty())
-        {
-            std::string normalized_endpoint = endpoint;
-            if (normalized_endpoint.ends_with('/'))
-                normalized_endpoint.pop_back();
-            if (data_location.starts_with(normalized_endpoint))
-            {
-                data_location = data_location.substr(normalized_endpoint.size());
-                if (azure_account_with_suffix.empty() && !data_location.empty() && data_location.front() == '/')
-                    data_location = data_location.substr(1);
-            }
-        }
-
-        /// For Azure ABFSS locations we need to reconcile two different formats:
-        ///   - metadata_location (from catalog): "container@account.host/path/..."
-        ///   - data_location (with endpoint set): "/container/path/" (HTTPS path after endpoint stripped)
-        /// When no endpoint is set both sides are in ABFSS authority form and compare directly.
-        if (!azure_account_with_suffix.empty() && !bucket.empty())
-        {
-            /// The host part after stripping the ABFSS protocol is: bucket@azure_account_with_suffix/
-            std::string azure_host_prefix = bucket + "@" + azure_account_with_suffix + "/";
-
-            /// For Polaris-style paths: the container name is repeated as the first path segment
-            /// (e.g. abfss://c@account/c/actual/path). Strip that redundant prefix from both sides
-            /// before the comparison below so we identify the correct relative path.
-            /// This runs for both with-endpoint and without-endpoint cases.
-            if (abfss_has_container_path_prefix)
-            {
-                auto strip_container = [&](std::string & location_str)
-                {
-                    if (location_str.starts_with(azure_host_prefix))
-                    {
-                        std::string_view after_host = std::string_view(location_str).substr(azure_host_prefix.size());
-                        if (after_host.starts_with(bucket + "/"))
-                        {
-                            location_str = std::string(azure_host_prefix) + std::string(after_host.substr(bucket.size() + 1));
-                        }
-                    }
-                };
-                strip_container(metadata_location);
-                strip_container(data_location);
-            }
-
-            /// With endpoint: data_location is now in HTTPS path form ("/container/path/").
-            /// Convert metadata_location from ABFSS authority form ("container@account.host/path")
-            /// to the matching HTTPS path form ("/container/path") so the prefix comparison works.
-            if (!endpoint.empty() && metadata_location.starts_with(azure_host_prefix))
-                metadata_location = "/" + bucket + "/" + metadata_location.substr(azure_host_prefix.size());
-        }
-
+        else if (!endpoint.empty() && data_location.starts_with(endpoint))
+            data_location = data_location.substr(endpoint.size());
+        
         if (metadata_location.starts_with(data_location))
         {
             size_t remove_slash = (metadata_location.size() > data_location.size() && metadata_location[data_location.size()] == '/') ? 1 : 0;

--- a/src/Databases/DataLake/ICatalog.h
+++ b/src/Databases/DataLake/ICatalog.h
@@ -95,7 +95,6 @@ private:
     /// This is extracted from URLs like: abfss://container@account.dfs.core.windows.net/path
     std::string azure_account_with_suffix;
     bool force_add_bucket = false;
-    bool abfss_has_container_path_prefix = false;
     /// Endpoint is set and used in case we have non-AWS storage implementation, for example, Minio.
     /// Also not all catalogs support non-AWS storages.
     std::string endpoint;

--- a/src/Databases/DataLake/ICatalog.h
+++ b/src/Databases/DataLake/ICatalog.h
@@ -33,10 +33,7 @@ public:
     TableMetadata & withSchema() { with_schema = true; return *this; }
     TableMetadata & withStorageCredentials() { with_storage_credentials = true; return *this; }
     TableMetadata & withDataLakeSpecificProperties() { with_datalake_specific_metadata = true; return *this; }
-    /// Enable Polaris/ADLS Gen2 convention: when `setLocation` sees an ABFSS URL where the
-    /// first path segment equals the container name, treat it as a redundant prefix and record
-    /// it so that `constructLocation` and `getMetadataLocation` can strip it.
-    TableMetadata & withPolarisStyleAbfssPaths() { polaris_style_abfss_paths = true; return *this; }
+    TableMetadata & withForceAddBucket() { force_add_bucket = true; return *this; }
 
     bool hasLocation() const;
     bool hasSchema() const;
@@ -97,15 +94,7 @@ private:
     /// For Azure ABFSS URLs: stores the account with suffix (e.g., "account.dfs.core.windows.net")
     /// This is extracted from URLs like: abfss://container@account.dfs.core.windows.net/path
     std::string azure_account_with_suffix;
-    /// True when `setLocation` detected that the ABFSS path starts with the container name
-    /// as a redundant first segment — a convention used by some catalogs (e.g. Apache Polaris /
-    /// ADLS Gen2 filesystem paths).
-    /// Example: abfss://c@account.dfs.core.windows.net/c/actual/path — `c` appears in both
-    /// the authority and the first path segment.
-    /// When set, `constructLocation` and `getMetadataLocation` strip that prefix when building
-    /// Azure HTTPS URLs or comparing metadata-file prefixes, but `path` itself is left intact so
-    /// that `getLocation` remains a round-trip of `setLocation`.
-    bool polaris_style_abfss_paths = false;
+    bool force_add_bucket = false;
     bool abfss_has_container_path_prefix = false;
     /// Endpoint is set and used in case we have non-AWS storage implementation, for example, Minio.
     /// Also not all catalogs support non-AWS storages.

--- a/src/Databases/DataLake/tests/gtest_azure_abfss_parsing.cpp
+++ b/src/Databases/DataLake/tests/gtest_azure_abfss_parsing.cpp
@@ -144,20 +144,6 @@ TEST_F(AzureAbfssParsingTest, TableMetadataGetLocationWithEndpointAutoDefaultsTo
     EXPECT_EQ(auto_location, path_location);
 }
 
-TEST_F(AzureAbfssParsingTest, TableMetadataGetMetadataLocationS3WithHttpEndpoint)
-{
-    TableMetadata metadata;
-    metadata.withLocation();
-    metadata.setLocation("s3://warehouse-rest/data/testns/testtable");
-    metadata.setEndpoint("http://minio:9000");
-
-    EXPECT_EQ(metadata.getLocation(), "http://minio:9000/warehouse-rest/data/testns/testtable/");
-
-    const std::string metadata_file =
-        "s3://warehouse-rest/data/testns/testtable/metadata/v1.metadata.json";
-    EXPECT_EQ(metadata.getMetadataLocation(metadata_file), "metadata/v1.metadata.json");
-}
-
 TEST_F(AzureAbfssParsingTest, TableMetadataSetLocationInvalidFormat)
 {
     TableMetadata metadata;
@@ -189,16 +175,6 @@ TEST_F(AzureAbfssParsingTest, TableMetadataSetLocationNonPolarisContainerInPath)
     EXPECT_EQ(metadata.getLocation(), location);
 }
 
-TEST_F(AzureAbfssParsingTest, TableMetadataSetLocationNonPolarisContainerInPathWithEndpoint)
-{
-    TableMetadata metadata;
-    metadata.withLocation().withPolarisStyleAbfssPaths();
-    metadata.setLocation("abfss://c@account.dfs.core.windows.net/c/table");
-    metadata.setEndpoint("https://account.dfs.core.windows.net");
-
-    EXPECT_EQ(metadata.getLocation(), "https://account.dfs.core.windows.net/c/table/");
-}
-
 TEST_F(AzureAbfssParsingTest, TableMetadataGetMetadataLocationNonPolarisContainerInPath)
 {
     TableMetadata metadata;
@@ -213,7 +189,7 @@ TEST_F(AzureAbfssParsingTest, TableMetadataGetMetadataLocationNonPolarisContaine
 TEST_F(AzureAbfssParsingTest, TableMetadataGetMetadataLocationPolarisStyle)
 {
     TableMetadata metadata;
-    metadata.withLocation().withPolarisStyleAbfssPaths();
+    metadata.withLocation().withForceAddBucket();
     metadata.setLocation("abfss://mycontainer@mystorageaccount.dfs.core.windows.net/mycontainer/actual/path");
 
     const std::string metadata_file =
@@ -226,35 +202,11 @@ TEST_F(AzureAbfssParsingTest, TableMetadataSetLocationPolarisStyle)
     const std::string location = "abfss://mycontainer@mystorageaccount.dfs.core.windows.net/mycontainer/actual/path";
 
     TableMetadata metadata;
-    metadata.withLocation().withPolarisStyleAbfssPaths();
+    metadata.withLocation().withForceAddBucket();
     metadata.setLocation(location);
 
     /// `getLocation` without endpoint is always a round-trip regardless of the Polaris flag.
     EXPECT_EQ(metadata.getLocation(), location);
-}
-
-TEST_F(AzureAbfssParsingTest, TableMetadataSetLocationPolarisStyleWithEndpoint)
-{
-    TableMetadata metadata;
-    metadata.withLocation().withPolarisStyleAbfssPaths();
-    metadata.setLocation("abfss://mycontainer@mystorageaccount.dfs.core.windows.net/mycontainer/actual/path");
-    metadata.setEndpoint("https://mystorageaccount.dfs.core.windows.net");
-
-    EXPECT_EQ(
-        metadata.getLocation(),
-        "https://mystorageaccount.dfs.core.windows.net/mycontainer/actual/path/");
-}
-
-TEST_F(AzureAbfssParsingTest, TableMetadataGetMetadataLocationPolarisStyleWithEndpoint)
-{
-    TableMetadata metadata;
-    metadata.withLocation().withPolarisStyleAbfssPaths();
-    metadata.setLocation("abfss://mycontainer@account.dfs.core.windows.net/mycontainer/actual/path");
-    metadata.setEndpoint("https://account.dfs.core.windows.net");
-
-    const std::string metadata_file =
-        "abfss://mycontainer@account.dfs.core.windows.net/mycontainer/actual/path/metadata/v1.metadata.json";
-    EXPECT_EQ(metadata.getMetadataLocation(metadata_file), "metadata/v1.metadata.json");
 }
 
 TEST_F(AzureAbfssParsingTest, TableMetadataGetMetadataLocationEqualStrings)
@@ -265,57 +217,6 @@ TEST_F(AzureAbfssParsingTest, TableMetadataGetMetadataLocationEqualStrings)
 
     const std::string metadata_file = "abfss://c@account.dfs.core.windows.net/c/table";
     EXPECT_EQ(metadata.getMetadataLocation(metadata_file), "");
-}
-
-TEST_F(AzureAbfssParsingTest, TableMetadataGetMetadataLocationPolarisStyleEndpointTrailingSlash)
-{
-    TableMetadata metadata_no_slash;
-    metadata_no_slash.withLocation().withPolarisStyleAbfssPaths();
-    metadata_no_slash.setLocation("abfss://mycontainer@account.dfs.core.windows.net/mycontainer/actual/path");
-    metadata_no_slash.setEndpoint("https://account.dfs.core.windows.net");
-
-    TableMetadata metadata_with_slash;
-    metadata_with_slash.withLocation().withPolarisStyleAbfssPaths();
-    metadata_with_slash.setLocation("abfss://mycontainer@account.dfs.core.windows.net/mycontainer/actual/path");
-    metadata_with_slash.setEndpoint("https://account.dfs.core.windows.net/");
-
-    const std::string metadata_file =
-        "abfss://mycontainer@account.dfs.core.windows.net/mycontainer/actual/path/metadata/v1.metadata.json";
-
-    EXPECT_EQ(metadata_no_slash.getMetadataLocation(metadata_file), "metadata/v1.metadata.json");
-    EXPECT_EQ(metadata_with_slash.getMetadataLocation(metadata_file), "metadata/v1.metadata.json");
-}
-
-TEST_F(AzureAbfssParsingTest, TableMetadataContainerNamedDirNotStrippedWithoutPolarisFlag)
-{
-    TableMetadata metadata;
-    metadata.withLocation();
-    metadata.setLocation("abfss://mycontainer@account.dfs.core.windows.net/mycontainer/data/table");
-    metadata.setEndpoint("https://account.dfs.core.windows.net");
-
-    EXPECT_EQ(
-        metadata.getLocation(),
-        "https://account.dfs.core.windows.net/mycontainer/mycontainer/data/table/");
-
-    const std::string metadata_file =
-        "abfss://mycontainer@account.dfs.core.windows.net/mycontainer/data/table/metadata/v1.metadata.json";
-    EXPECT_EQ(metadata.getMetadataLocation(metadata_file), "metadata/v1.metadata.json");
-}
-
-TEST_F(AzureAbfssParsingTest, TableMetadataContainerNamedDirStrippedWithPolarisFlag)
-{
-    TableMetadata metadata;
-    metadata.withLocation().withPolarisStyleAbfssPaths();
-    metadata.setLocation("abfss://mycontainer@account.dfs.core.windows.net/mycontainer/data/table");
-    metadata.setEndpoint("https://account.dfs.core.windows.net");
-
-    EXPECT_EQ(
-        metadata.getLocation(),
-        "https://account.dfs.core.windows.net/mycontainer/data/table/");
-
-    const std::string metadata_file =
-        "abfss://mycontainer@account.dfs.core.windows.net/mycontainer/data/table/metadata/v1.metadata.json";
-    EXPECT_EQ(metadata.getMetadataLocation(metadata_file), "metadata/v1.metadata.json");
 }
 
 TEST_F(AzureAbfssParsingTest, TableMetadataGetLocationWithEndpointPathStyleRejectedForVirtualHostedEndpoint)


### PR DESCRIPTION
### Changelog category (leave one):
- Backward Incompatible Change


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix rest catalog with azure abfss path

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.316`
<!-- ch-version-info:end -->