### PR TITLE
CI: set --oom-score-adj=1000 on docker containers to protect runner from OOM

### DIFF
--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -443,7 +443,7 @@ class Runner:
                 settings = rewritten_settings
 
             local_env_flag = f"--env-file {self.LOCAL_ENV_FILE}" if Path(self.LOCAL_ENV_FILE).exists() else ""
-            cmd = f"docker run {tty} --rm --name {container_name} {'--user $(id -u):$(id -g)' if not from_root else ''} -e PYTHONUNBUFFERED=1 -e PYTHONPATH='.:./ci' {local_env_flag} --volume {host_dir_q}:{current_dir} {extra_mounts} {gh_mount} {workdir} {' '.join(settings)} {docker} {job.command}"
+            cmd = f"docker run {tty} --rm --oom-score-adj=1000 --name {container_name} {'--user $(id -u):$(id -g)' if not from_root else ''} -e PYTHONUNBUFFERED=1 -e PYTHONPATH='.:./ci' {local_env_flag} --volume {host_dir_q}:{current_dir} {extra_mounts} {gh_mount} {workdir} {' '.join(settings)} {docker} {job.command}"
         else:
             cmd = job.command
             python_path = os.getenv("PYTHONPATH", ":")


### PR DESCRIPTION
Add `--oom-score-adj=1000` to the `docker run` command in the CI runner.

The `docker run` client process is lightweight (~10 MB). The actual memory
consumers are processes inside the container, spawned by `dockerd` and
reaching 10+ GB during builds and tests. When the host runs out of memory,
the OOM killer was targeting `runner.py` (moderate but stable Python RSS)
instead of the container processes that caused the pressure.

`--oom-score-adj=1000` is the maximum allowed value. It tells `dockerd` to
set this adjustment on the container init process and all its descendants,
making every container process the preferred OOM-kill target on the host.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.340`
<!-- ch-version-info:end -->