### PR TITLE
Remove stale .repodata temp directory before running createrepo_c

### DIFF
--- a/tests/ci/artifactory.py
+++ b/tests/ci/artifactory.py
@@ -230,6 +230,13 @@ class RpmArtifactory:
         for package in paths:
             _copy_if_not_exists(Path(package), dest_dir)
 
+        # Remove stale temp repodata directory left by a previous interrupted run; createrepo_c
+        # refuses to start when it already exists, mistaking it for a concurrent process.
+        stale_repodata = dest_dir / ".repodata"
+        if stale_repodata.exists():
+            print(f"Removing stale temp repodata directory: {stale_repodata}")
+            Shell.check(f"rm -rf {stale_repodata}", strict=True)
+
         # switching between different fuse providers invalidates --update option (apparently some fuse(s) can mess around with mtime)
         #   add --skip-stat to skip mtime check
         commands = (

--- a/tests/ci/artifactory.py
+++ b/tests/ci/artifactory.py
@@ -1,7 +1,7 @@
 import argparse
 import time
 from pathlib import Path
-from shutil import copy2
+from shutil import copy2, rmtree
 from typing import Optional
 
 from ci_utils import Shell, WithIter
@@ -235,7 +235,7 @@ class RpmArtifactory:
         stale_repodata = dest_dir / ".repodata"
         if stale_repodata.exists():
             print(f"Removing stale temp repodata directory: {stale_repodata}")
-            Shell.check(f"rm -rf {stale_repodata}", strict=True)
+            rmtree(stale_repodata)
 
         # switching between different fuse providers invalidates --update option (apparently some fuse(s) can mess around with mtime)
         #   add --skip-stat to skip mtime check


### PR DESCRIPTION
\`createrepo_c\` uses a \`.repodata/\` temp directory during repo generation and refuses to start if it already exists, printing "Another createrepo process is running?". When a previous release run is interrupted, this directory is left behind, causing all subsequent RPM export jobs to fail with exit code 1 — even though no other process is actually running.

Fix: \`RpmArtifactory.export_packages\` now removes \`.repodata/\` from the destination directory before invoking \`createrepo_c\`, if it exists.

CI failure: https://github.com/ClickHouse/ClickHouse/actions/runs/25386526157/job/74449100394

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.333`
<!-- ch-version-info:end -->