### PR TITLE
Fix numerous semantic inconsistency with `optimize_inverse_dictionary_lookup`

### DIFF
--- a/src/Analyzer/Passes/InverseDictionaryLookupPass.cpp
+++ b/src/Analyzer/Passes/InverseDictionaryLookupPass.cpp
@@ -273,23 +273,16 @@ public:
         NameAndTypePair attr_col{attr_col_name, dict_attr_col_type};
         auto attr_col_node = std::make_shared<ColumnNode>(attr_col, dict_table_function);
 
-        /// Needed for dictGet functions like `dictGetString`, `dictGetInt32`, etc.
-        QueryTreeNodePtr attr_col_node_casted = attr_col_node;
-        if (!attr_col_node->getResultType()->equals(*dictget_function_info.return_type))
-        {
-            attr_col_node_casted = createCastFunction(attr_col_node, dictget_function_info.return_type, getContext());
-        }
-
         auto attr_comparison_function_node = std::static_pointer_cast<FunctionNode>(node_function->clone());
         attr_comparison_function_node->markAsOperator();
 
         if (dict_side == Side::LHS)
         {
-            attr_comparison_function_node->getArguments().getNodes() = { attr_col_node_casted, arguments[1] };
+            attr_comparison_function_node->getArguments().getNodes() = { attr_col_node, arguments[1] };
         }
         else
         {
-            attr_comparison_function_node->getArguments().getNodes() = { arguments[0], attr_col_node_casted };
+            attr_comparison_function_node->getArguments().getNodes() = { arguments[0], attr_col_node };
         }
         resolveOrdinaryFunctionNodeByName(*attr_comparison_function_node, attr_comparison_function_name, getContext());
 

--- a/src/Analyzer/Passes/InverseDictionaryLookupPass.cpp
+++ b/src/Analyzer/Passes/InverseDictionaryLookupPass.cpp
@@ -142,6 +142,14 @@ public:
         if (getSettings()[Setting::rewrite_in_to_join])
             return;
 
+        /// We build an `IN` set from the dictionary subquery, which respects `max_rows_in_set`,
+        /// `max_bytes_in_set` and `set_overflow_mode`. With `set_overflow_mode = 'break'`, the set
+        /// can be truncated and not contain all required elements, so the optimization can produce
+        /// wrong results. Skip optimization for such case.
+        if ((getSettings()[Setting::max_rows_in_set] != 0 || getSettings()[Setting::max_bytes_in_set] != 0)
+            && getSettings()[Setting::set_overflow_mode] == OverflowMode::BREAK)
+            return;
+
         auto * node_function = node->as<FunctionNode>();
 
         if (!node_function)

--- a/src/Analyzer/Passes/InverseDictionaryLookupPass.cpp
+++ b/src/Analyzer/Passes/InverseDictionaryLookupPass.cpp
@@ -13,6 +13,11 @@
 
 #include <Interpreters/Context.h>
 
+#include <DataTypes/DataTypeLowCardinality.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <DataTypes/DataTypeTuple.h>
+
+#include <Functions/FunctionFactory.h>
 #include <Functions/FunctionsExternalDictionaries.h>
 
 #include <Access/ContextAccess.h>
@@ -26,6 +31,9 @@ namespace DB
 
 namespace Setting
 {
+extern const SettingsUInt64 max_bytes_in_set;
+extern const SettingsUInt64 max_rows_in_set;
+extern const SettingsOverflowMode set_overflow_mode;
 extern const SettingsBool optimize_inverse_dictionary_lookup;
 extern const SettingsBool rewrite_in_to_join;
 }
@@ -139,6 +147,83 @@ bool hasNullableComponentInComplexKey(const QueryTreeNodePtr & key_expr_node)
             return true;
     }
     return false;
+}
+
+bool isRewriteSemanticallySafe(
+    const DataTypePtr & dict_attr_type,
+    const DataTypePtr & dictget_result_type,
+    const Field & attr_null_value,
+    const ConstantNode & const_arg_node,
+    bool default_is_lhs,
+    const String & attr_comparison_function_name,
+    const ContextPtr & context)
+{
+    /// Same underlying type after stripping `Nullable` / `LowCardinality` needed. If attribute `n`
+    /// is `UInt32`, `dictGetUInt16(..., 'n', id) = 42` throws because the underlying types differ (`UInt32` vs `UInt16`)
+    const bool stripped_types_match
+        = removeLowCardinalityAndNullable(dict_attr_type)->equals(*removeLowCardinalityAndNullable(dictget_result_type));
+    if (!stripped_types_match)
+        return false;
+
+    /// `dictGet` and `IN` don't have the same stored-NULL attribute semantics.
+    /// Example: if dictionary has `id = 1, name = NULL`, `dictGet(..., 1) = 'x'` gives
+    /// `NULL`. The `IN` rewrite uses `WHERE name = 'x'`, so the row is filtered out and
+    /// `1 IN (...)` gives `0`. This is visible in projection or `isNull(predicate)`.
+    /// Skip optimization when the attribute can contain `NULL`, including
+    /// `LowCardinality(Nullable(...))`.
+    if (isNullableOrLowCardinalityNullable(dict_attr_type))
+        return false;
+
+    const DataTypePtr const_arg_type = const_arg_node.getResultType();
+    const Field & const_arg_value = const_arg_node.getValue();
+
+    auto default_column = ColumnWithTypeAndName(dict_attr_type->createColumnConst(1, attr_null_value), dict_attr_type, "default_value");
+    auto const_arg_column = ColumnWithTypeAndName(const_arg_type->createColumnConst(1, const_arg_value), const_arg_type, "const_value");
+
+    ColumnsWithTypeAndName comparison_arguments;
+    if (default_is_lhs)
+        comparison_arguments = {std::move(default_column), std::move(const_arg_column)};
+    else
+        comparison_arguments = {std::move(const_arg_column), std::move(default_column)};
+
+    /// `dictGet` and `IN` don't have the same missing-key default semantics.
+    /// e.g: `dictGet(..., id) = ''` vs `id IN (SELECT id FROM dictionary(...) WHERE name = '')`
+    /// Example: if dictionary has one row `id = 1, name = 'x'`, data has `id = 2`, and
+    /// attribute `DEFAULT` is `''`, `dictGet(..., 2)` returns `''`, so
+    /// `dictGet(..., id) = ''` is true for `id = 2`. The `IN` rewrite scans only
+    /// dictionary keys, so the subquery has no `id = 2` and `2 IN (...)` is false.
+    ///
+    /// One of the alternatives is to add `OR id NOT IN (SELECT id FROM dictionary(...))` when the
+    /// predicate is true for `DEFAULT`, but it requires another set with all dictionary keys.
+    /// This can be expensive to materialize, so skip optimization for such case.
+    ///
+    /// As a result, given the current rewrite, if `const <op> DEFAULT` is false, only then the
+    /// transformation is semantically correct.
+    Field comparison_result;
+    try
+    {
+        auto function_resolver = FunctionFactory::instance().get(attr_comparison_function_name, context);
+        auto comparison_function_base = function_resolver->build(comparison_arguments);
+        auto comparison_result_column
+            = comparison_function_base->execute(comparison_arguments, comparison_function_base->getResultType(), 1, /* dry_run = */ false);
+        comparison_result = (*comparison_result_column)[0];
+    }
+    catch (const Exception &)
+    {
+        /// The constant fold runs during optimization and can throw for values that runtime
+        /// would not evaluate. Example: `match('', '(')` throws `CANNOT_COMPILE_REGEXP`, but
+        /// `id < 0 AND match(dictGetString(...), '(')` can skip the `match` branch due to
+        /// short-circuit evaluation. If we throw here, the optimization breaks a query that
+        /// works without it. Skip optimization for such case.
+        return false;
+    }
+
+    if (comparison_result.isNull())
+        return false;
+
+    /// Check `const <op> DEFAULT` is false
+    UInt64 comparison_result_uint = 0;
+    return comparison_result.tryGet<UInt64>(comparison_result_uint) && comparison_result_uint == 0;
 }
 
 
@@ -264,7 +349,21 @@ public:
         if (!dict_structure.hasAttribute(attr_col_name))
             return;
 
-        DataTypePtr dict_attr_col_type = dict_structure.getAttribute(attr_col_name).type;
+        const DictionaryAttribute & attr = dict_structure.getAttribute(attr_col_name);
+        DataTypePtr dict_attr_col_type = attr.type;
+
+        const auto * const_arg_node = (dict_side == Side::LHS) ? arguments[1]->as<ConstantNode>() : arguments[0]->as<ConstantNode>();
+
+        /// Skip rewrites that would change query behavior. Details are in the function.
+        if (!isRewriteSemanticallySafe(
+                dict_attr_col_type,
+                dictget_function_info.return_type,
+                attr.null_value,
+                *const_arg_node,
+                dict_side == Side::LHS,
+                attr_comparison_function_name,
+                getContext()))
+            return;
 
         auto dict_table_function = std::make_shared<TableFunctionNode>("dictionary");
         dict_table_function->getArguments().getNodes().push_back(dictget_function_info.dict_name_node);

--- a/src/Analyzer/Passes/InverseDictionaryLookupPass.cpp
+++ b/src/Analyzer/Passes/InverseDictionaryLookupPass.cpp
@@ -68,8 +68,7 @@ bool isSupportedDictGetFunction(const String & name)
            "dictGetDateTime",
            "dictGetUUID",
            "dictGetIPv4",
-           "dictGetIPv6",
-           "dictGetOrNull"};
+           "dictGetIPv6"};
 
     return supported_functions.contains(name);
 }

--- a/src/Analyzer/Passes/InverseDictionaryLookupPass.cpp
+++ b/src/Analyzer/Passes/InverseDictionaryLookupPass.cpp
@@ -127,6 +127,21 @@ void resolveNode(const Node & node, const ContextPtr & context)
     QueryAnalysisPass(/*only_analyze*/ false).run(querytree_node, context);
 }
 
+bool hasNullableComponentInComplexKey(const QueryTreeNodePtr & key_expr_node)
+{
+    auto type = removeNullable(key_expr_node->getResultType());
+    const auto * tuple_type = typeid_cast<const DataTypeTuple *>(type.get());
+    if (!tuple_type)
+        return false;
+
+    for (const auto & element : tuple_type->getElements())
+    {
+        if (isNullableOrLowCardinalityNullable(element))
+            return true;
+    }
+    return false;
+}
+
 
 class InverseDictionaryLookupVisitor : public InDepthQueryTreeVisitorWithContext<InverseDictionaryLookupVisitor>
 {
@@ -233,6 +248,17 @@ public:
         {
             return;
         }
+
+        /// For complex-key dictionaries, `dictGet` and `IN` don't have the same `NULL` key semantics.
+        /// e.g: `dictGet(..., (k1, k2))` vs `(k1, k2) IN (SELECT k1, k2 FROM dictionary(...))`
+        /// Example: if `k1` is `Nullable(UInt64)` and the dictionary has `(NULL, 'a')`,
+        /// `dictGet(..., (k1, k2))` can match it, but `(NULL, 'a') IN (...)` is not a match
+        /// with `transform_null_in = 0`.
+        /// Single-key dictionaries are not affected. Example: if `id` is `Nullable(UInt64)`,
+        /// `dictGet(..., id) = 'x'` gives `NULL` for `id = NULL`, and `id IN (...)` also gives
+        /// `NULL` for `id = NULL`.
+        if (dict_structure.key && hasNullableComponentInComplexKey(dictget_function_info.key_expr_node))
+            return;
 
         const String attr_col_name = dictget_function_info.attr_col_name_node->getValue().safeGet<String>();
 

--- a/tests/queries/0_stateless/03701_optimize_inverse_dictionary_lookup_basic.reference
+++ b/tests/queries/0_stateless/03701_optimize_inverse_dictionary_lookup_basic.reference
@@ -14,6 +14,9 @@ ORDER BY
 Equality, LHS
 1	a
 3	c
+Equality, LHS, opt off
+1	a
+3	c
 Equality, RHS - plan
 SELECT
     __table1.color_id AS color_id,
@@ -28,6 +31,9 @@ ORDER BY
     __table1.color_id ASC,
     __table1.payload ASC
 Equality, RHS
+1	a
+3	c
+Equality, RHS, opt off
 1	a
 3	c
 Inequality <, LHS, no rewrite (default 0 < 10) - plan
@@ -84,6 +90,9 @@ ORDER BY
 LIKE
 1	a
 3	c
+LIKE, opt off
+1	a
+3	c
 ILIKE - plan
 SELECT
     __table1.color_id AS color_id,
@@ -101,6 +110,10 @@ ILIKE
 1	a
 3	c
 5	R
+ILIKE, opt off
+1	a
+3	c
+5	R
 equals() - plan
 SELECT __table1.color_id AS color_id
 FROM default.t AS __table1
@@ -111,6 +124,9 @@ WHERE __table1.color_id IN (
 )
 ORDER BY __table1.color_id ASC
 equals()
+1
+3
+equals(), opt off
 1
 3
 notEquals, no rewrite (default empty string != red) - plan
@@ -167,6 +183,9 @@ ORDER BY
 match ^r
 1	a
 3	c
+match ^r, opt off
+1	a
+3	c
 NOT recursion - plan
 SELECT
     __table1.color_id AS color_id,
@@ -181,6 +200,10 @@ ORDER BY
     __table1.color_id ASC,
     __table1.payload ASC
 NOT recursion
+2	b
+4	d
+5	R
+NOT recursion, opt off
 2	b
 4	d
 5	R
@@ -202,6 +225,9 @@ ORDER BY
     __table1.color_id ASC,
     __table1.payload ASC
 AND/OR recursion
+1	a
+4	d
+AND/OR recursion, opt off
 1	a
 4	d
 NULL constant, no rewrite - plan
@@ -226,6 +252,9 @@ ORDER BY __table1.color_id ASC
 PREWHERE
 1
 3
+PREWHERE, opt off
+1
+3
 QUALIFY - plan
 SELECT
     __table1.color_id AS color_id,
@@ -242,6 +271,9 @@ ORDER BY
 QUALIFY
 1	1
 3	3
+QUALIFY, opt off
+1	1
+3	3
 Empty result set - plan
 SELECT __table1.color_id AS color_id
 FROM default.t AS __table1
@@ -252,6 +284,7 @@ WHERE __table1.color_id IN (
 )
 ORDER BY __table1.color_id ASC
 Empty result set
+Empty result set, opt off
 HAVING - plan
 SELECT
     __table1.color_id AS color_id,
@@ -265,6 +298,9 @@ HAVING __table1.color_id IN (
 )
 ORDER BY __table1.color_id ASC
 HAVING
+1	1
+3	1
+HAVING, opt off
 1	1
 3	1
 JOIN ON (INNER) - plan
@@ -285,6 +321,9 @@ ORDER BY
 JOIN ON (INNER)
 1	a	a
 3	c	c
+JOIN ON (INNER), opt off
+1	a	a
+3	c	c
 JOIN ON (LEFT) - plan
 SELECT
     __table1.color_id AS color_id,
@@ -301,6 +340,12 @@ ORDER BY
     __table1.payload ASC,
     __table2.payload ASC
 JOIN ON (LEFT)
+1	a	a
+2	b	
+3	c	c
+4	d	
+5	R	
+JOIN ON (LEFT), opt off
 1	a	a
 2	b	
 3	c	c
@@ -330,6 +375,12 @@ SELECT multiIf
 3	c	match
 4	d	no_match
 5	R	no_match
+SELECT multiIf, opt off
+1	a	match
+2	b	no_match
+3	c	match
+4	d	no_match
+5	R	no_match
 countIf - plan
 SELECT countIf(__table1.color_id IN (
         SELECT __table1.id AS id
@@ -339,6 +390,8 @@ SELECT countIf(__table1.color_id IN (
 FROM default.t AS __table1
 countIf
 2
+countIf, opt off
+2
 sumIf - plan
 SELECT sumIf(__table1.color_id, (__table1.color_id IN (
         SELECT __table1.id AS id
@@ -347,6 +400,8 @@ SELECT sumIf(__table1.color_id, (__table1.color_id IN (
     ))) AS sum_id_match
 FROM default.t AS __table1
 sumIf
+4
+sumIf, opt off
 4
 ORDER BY - plan
 SELECT
@@ -362,6 +417,12 @@ ORDER BY
     __table1.color_id ASC,
     __table1.payload ASC
 ORDER BY
+1	a
+3	c
+2	b
+4	d
+5	R
+ORDER BY, opt off
 1	a
 3	c
 2	b
@@ -389,6 +450,9 @@ ORDER BY __table1.color_id IN (
 GROUP BY
 0	3
 1	2
+GROUP BY, opt off
+0	3
+1	2
 LIMIT BY - plan
 SELECT
     __table1.color_id AS color_id,
@@ -403,6 +467,9 @@ LIMIT _CAST(1, \'UInt64\') BY __table1.color_id IN (
         WHERE __table1.name = \'red\'
     )
 LIMIT BY
+1	a
+2	b
+LIMIT BY, opt off
 1	a
 2	b
 WINDOW PARTITION BY - plan
@@ -427,9 +494,16 @@ WINDOW PARTITION BY
 3	2
 4	2
 5	3
+WINDOW PARTITION BY, opt off
+1	1
+2	1
+3	2
+4	2
+5	3
 Negative: non-constant RHS - plan
 SELECT __table1.color_id AS color_id
 FROM default.t AS __table1
 WHERE dictGetString(\'colors\', \'name\', __table1.color_id) = __table1.payload
 ORDER BY __table1.color_id ASC
 Negative: non-constant RHS
+Negative: non-constant RHS, opt off

--- a/tests/queries/0_stateless/03701_optimize_inverse_dictionary_lookup_basic.reference
+++ b/tests/queries/0_stateless/03701_optimize_inverse_dictionary_lookup_basic.reference
@@ -30,60 +30,44 @@ ORDER BY
 Equality, RHS
 1	a
 3	c
-Inequality <, LHS - plan
+Inequality <, LHS, no rewrite (default 0 < 10) - plan
 SELECT
     __table1.color_id AS color_id,
     __table1.payload AS payload
 FROM default.t AS __table1
-WHERE __table1.color_id IN (
-    SELECT __table1.id AS id
-    FROM dictionary(\'colors\') AS __table1
-    WHERE __table1.n < 10
-)
+WHERE dictGetUInt64(\'colors\', \'n\', __table1.color_id) < 10
 ORDER BY
     __table1.color_id ASC,
     __table1.payload ASC
-Inequality <, LHS
+Inequality <, LHS, no rewrite (default 0 < 10)
 1	a
 2	b
 4	d
 5	R
-Inequality <, RHS - plan
+Inequality <, RHS, no rewrite (default 0 < 10) - plan
 SELECT
     __table1.color_id AS color_id,
     __table1.payload AS payload
 FROM default.t AS __table1
-WHERE __table1.color_id IN (
-    SELECT __table1.id AS id
-    FROM dictionary(\'colors\') AS __table1
-    WHERE 10 > __table1.n
-)
+WHERE 10 > dictGetUInt64(\'colors\', \'n\', __table1.color_id)
 ORDER BY
     __table1.color_id ASC,
     __table1.payload ASC
-Inequality <, RHS
+Inequality <, RHS, no rewrite (default 0 < 10)
 1	a
 2	b
 4	d
 5	R
-Type variant cast, >= Int32 - plan
+Type mismatch not allowed, >= Int32 - plan
 SELECT
     __table1.color_id AS color_id,
     __table1.payload AS payload
 FROM default.t AS __table1
-WHERE __table1.color_id IN (
-    SELECT __table1.id AS id
-    FROM dictionary(\'colors\') AS __table1
-    WHERE _CAST(__table1.n, \'Int32\') >= 2
-)
+WHERE dictGetInt32(\'colors\', \'n\', __table1.color_id) >= 2
 ORDER BY
     __table1.color_id ASC,
     __table1.payload ASC
-Type variant cast, >= Int32
-1	a
-2	b
-3	c
-5	R
+Type mismatch not allowed, >= Int32
 LIKE - plan
 SELECT
     __table1.color_id AS color_id,
@@ -129,54 +113,42 @@ ORDER BY __table1.color_id ASC
 equals()
 1
 3
-notEquals - plan
+notEquals, no rewrite (default empty string != red) - plan
 SELECT
     __table1.color_id AS color_id,
     __table1.payload AS payload
 FROM default.t AS __table1
-WHERE __table1.color_id IN (
-    SELECT __table1.id AS id
-    FROM dictionary(\'colors\') AS __table1
-    WHERE __table1.name != \'red\'
-)
+WHERE dictGetString(\'colors\', \'name\', __table1.color_id) != \'red\'
 ORDER BY
     __table1.color_id ASC,
     __table1.payload ASC
-notEquals
+notEquals, no rewrite (default empty string != red)
 2	b
 4	d
 5	R
-NOT LIKE r% - plan
+NOT LIKE r%, no rewrite (default empty string NOT LIKE r%) - plan
 SELECT
     __table1.color_id AS color_id,
     __table1.payload AS payload
 FROM default.t AS __table1
-WHERE __table1.color_id IN (
-    SELECT __table1.id AS id
-    FROM dictionary(\'colors\') AS __table1
-    WHERE __table1.name NOT LIKE \'r%\'
-)
+WHERE dictGetString(\'colors\', \'name\', __table1.color_id) NOT LIKE \'r%\'
 ORDER BY
     __table1.color_id ASC,
     __table1.payload ASC
-NOT LIKE r%
+NOT LIKE r%, no rewrite (default empty string NOT LIKE r%)
 2	b
 4	d
 5	R
-NOT ILIKE r% - plan
+NOT ILIKE r%, no rewrite (default empty string NOT ILIKE r%) - plan
 SELECT
     __table1.color_id AS color_id,
     __table1.payload AS payload
 FROM default.t AS __table1
-WHERE __table1.color_id IN (
-    SELECT __table1.id AS id
-    FROM dictionary(\'colors\') AS __table1
-    WHERE __table1.name NOT ILIKE \'r%\'
-)
+WHERE dictGetString(\'colors\', \'name\', __table1.color_id) NOT ILIKE \'r%\'
 ORDER BY
     __table1.color_id ASC,
     __table1.payload ASC
-NOT ILIKE r%
+NOT ILIKE r%, no rewrite (default empty string NOT ILIKE r%)
 2	b
 4	d
 match ^r - plan
@@ -221,11 +193,7 @@ WHERE ((__table1.color_id IN (
     SELECT __table1.id AS id
     FROM dictionary(\'colors\') AS __table1
     WHERE __table1.name = \'red\'
-)) AND (__table1.color_id IN (
-    SELECT __table1.id AS id
-    FROM dictionary(\'colors\') AS __table1
-    WHERE __table1.n < 10
-))) OR (__table1.color_id IN (
+)) AND (dictGetUInt64(\'colors\', \'n\', __table1.color_id) < 10)) OR (__table1.color_id IN (
     SELECT __table1.id AS id
     FROM dictionary(\'colors\') AS __table1
     WHERE __table1.name = \'green\'
@@ -236,7 +204,7 @@ ORDER BY
 AND/OR recursion
 1	a
 4	d
-NULL constant - plan
+NULL constant, no rewrite - plan
 SELECT
     __table1.color_id AS color_id,
     __table1.payload AS payload
@@ -245,7 +213,7 @@ WHERE _CAST(NULL, \'Nullable(Nothing)\')
 ORDER BY
     __table1.color_id ASC,
     __table1.payload ASC
-NULL constant
+NULL constant, no rewrite
 PREWHERE - plan
 SELECT __table1.color_id AS color_id
 FROM default.t AS __table1

--- a/tests/queries/0_stateless/03701_optimize_inverse_dictionary_lookup_basic.sql
+++ b/tests/queries/0_stateless/03701_optimize_inverse_dictionary_lookup_basic.sql
@@ -1,5 +1,6 @@
 -- Tags: no-replicated-database, no-parallel-replicas
--- no-parallel, no-parallel-replicas: Dictionary is not created in parallel replicas.
+-- no-replicated-database: EXPLAIN output differs for replicated database.
+-- no-parallel-replicas: Dictionary is not available on parallel-replica workers.
 
 SET enable_analyzer = 1;
 SET optimize_inverse_dictionary_lookup = 1;

--- a/tests/queries/0_stateless/03701_optimize_inverse_dictionary_lookup_basic.sql
+++ b/tests/queries/0_stateless/03701_optimize_inverse_dictionary_lookup_basic.sql
@@ -79,44 +79,44 @@ FROM t
 WHERE 'red' = dictGetString('colors', 'name', color_id)
 ORDER BY color_id, payload;
 
-SELECT 'Inequality <, LHS - plan';
+SELECT 'Inequality <, LHS, no rewrite (default 0 < 10) - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
 SELECT color_id, payload
 FROM t
 WHERE dictGetUInt64('colors', 'n', color_id) < 10
 ORDER BY color_id, payload;
 
-SELECT 'Inequality <, LHS';
+SELECT 'Inequality <, LHS, no rewrite (default 0 < 10)';
 SELECT color_id, payload
 FROM t
 WHERE dictGetUInt64('colors', 'n', color_id) < 10
 ORDER BY color_id, payload;
 
-SELECT 'Inequality <, RHS - plan';
+SELECT 'Inequality <, RHS, no rewrite (default 0 < 10) - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
 SELECT color_id, payload
 FROM t
 WHERE 10 > dictGetUInt64('colors', 'n', color_id)
 ORDER BY color_id, payload;
 
-SELECT 'Inequality <, RHS';
+SELECT 'Inequality <, RHS, no rewrite (default 0 < 10)';
 SELECT color_id, payload
 FROM t
 WHERE 10 > dictGetUInt64('colors', 'n', color_id)
 ORDER BY color_id, payload;
 
-SELECT 'Type variant cast, >= Int32 - plan';
+SELECT 'Type mismatch not allowed, >= Int32 - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
 SELECT color_id, payload
 FROM t
 WHERE dictGetInt32('colors', 'n', color_id) >= 2
 ORDER BY color_id, payload;
 
-SELECT 'Type variant cast, >= Int32';
+SELECT 'Type mismatch not allowed, >= Int32';
 SELECT color_id, payload
 FROM t
 WHERE dictGetInt32('colors', 'n', color_id) >= 2
-ORDER BY color_id, payload;
+ORDER BY color_id, payload; -- { serverError TYPE_MISMATCH }
 
 SELECT 'LIKE - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -157,40 +157,40 @@ FROM t
 WHERE equals(dictGetString('colors','name', color_id), 'red')
 ORDER BY color_id;
 
-SELECT 'notEquals - plan';
+SELECT 'notEquals, no rewrite (default empty string != red) - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
 SELECT color_id, payload
 FROM t
 WHERE dictGetString('colors','name', color_id) != 'red'
 ORDER BY color_id, payload;
 
-SELECT 'notEquals';
+SELECT 'notEquals, no rewrite (default empty string != red)';
 SELECT color_id, payload
 FROM t
 WHERE dictGetString('colors','name', color_id) != 'red'
 ORDER BY color_id, payload;
 
-SELECT 'NOT LIKE r% - plan';
+SELECT 'NOT LIKE r%, no rewrite (default empty string NOT LIKE r%) - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
 SELECT color_id, payload
 FROM t
 WHERE dictGetString('colors','name', color_id) NOT LIKE 'r%'
 ORDER BY color_id, payload;
 
-SELECT 'NOT LIKE r%';
+SELECT 'NOT LIKE r%, no rewrite (default empty string NOT LIKE r%)';
 SELECT color_id, payload
 FROM t
 WHERE dictGetString('colors','name', color_id) NOT LIKE 'r%'
 ORDER BY color_id, payload;
 
-SELECT 'NOT ILIKE r% - plan';
+SELECT 'NOT ILIKE r%, no rewrite (default empty string NOT ILIKE r%) - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
 SELECT color_id, payload
 FROM t
 WHERE dictGetString('colors','name', color_id) NOT ILIKE 'r%'
 ORDER BY color_id, payload;
 
-SELECT 'NOT ILIKE r%';
+SELECT 'NOT ILIKE r%, no rewrite (default empty string NOT ILIKE r%)';
 SELECT color_id, payload
 FROM t
 WHERE dictGetString('colors','name', color_id) NOT ILIKE 'r%'
@@ -237,14 +237,14 @@ WHERE (dictGetString('colors', 'name', color_id) = 'red' AND dictGetUInt64('colo
    OR dictGetString('colors', 'name', color_id) = 'green'
 ORDER BY color_id, payload;
 
-SELECT 'NULL constant - plan';
+SELECT 'NULL constant, no rewrite - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
 SELECT color_id, payload
 FROM t
 WHERE dictGetString('colors', 'name', color_id) = NULL
 ORDER BY color_id, payload;
 
-SELECT 'NULL constant';
+SELECT 'NULL constant, no rewrite';
 SELECT color_id, payload
 FROM t
 WHERE dictGetString('colors', 'name', color_id) = NULL
@@ -494,4 +494,4 @@ LAYOUT(HASHED());
 SELECT DISTINCT 13, *, or(-32 = dictGetInt32(toFixedString('dictionary_all', toLowCardinality(14)), toFixedString('i32', 3), id), isNotDistinctFrom(1, 9223372036854775806), toLowCardinality(19), not(equals(payload, 9223372036854775806))), isNotNull('dictGetFloat64 - plan'), id, isNotNull(1)
 FROM tab__fuzz_24 PREWHERE equals(9223372036854775806, payload)
 WHERE isNotDistinctFrom(id, isNotDistinctFrom(9223372036854775806, equals(1, isNotNull(9223372036854775806)))) QUALIFY and(NULL, equals(1, isZeroOrNull(1)))
-ORDER BY payload DESC;
+ORDER BY payload DESC; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }

--- a/tests/queries/0_stateless/03701_optimize_inverse_dictionary_lookup_basic.sql
+++ b/tests/queries/0_stateless/03701_optimize_inverse_dictionary_lookup_basic.sql
@@ -66,6 +66,12 @@ SELECT color_id, payload
 FROM t
 WHERE dictGetString('colors', 'name', color_id) = 'red'
 ORDER BY color_id, payload;
+SELECT 'Equality, LHS, opt off';
+SELECT color_id, payload
+FROM t
+WHERE dictGetString('colors', 'name', color_id) = 'red'
+ORDER BY color_id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'Equality, RHS - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -79,6 +85,12 @@ SELECT color_id, payload
 FROM t
 WHERE 'red' = dictGetString('colors', 'name', color_id)
 ORDER BY color_id, payload;
+SELECT 'Equality, RHS, opt off';
+SELECT color_id, payload
+FROM t
+WHERE 'red' = dictGetString('colors', 'name', color_id)
+ORDER BY color_id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'Inequality <, LHS, no rewrite (default 0 < 10) - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -131,6 +143,12 @@ SELECT color_id, payload
 FROM t
 WHERE dictGetString('colors', 'name', color_id) LIKE 'r%'
 ORDER BY color_id, payload;
+SELECT 'LIKE, opt off';
+SELECT color_id, payload
+FROM t
+WHERE dictGetString('colors', 'name', color_id) LIKE 'r%'
+ORDER BY color_id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'ILIKE - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -144,6 +162,12 @@ SELECT color_id, payload
 FROM t
 WHERE dictGetString('colors', 'name', color_id) ILIKE 'r%'
 ORDER BY color_id, payload;
+SELECT 'ILIKE, opt off';
+SELECT color_id, payload
+FROM t
+WHERE dictGetString('colors', 'name', color_id) ILIKE 'r%'
+ORDER BY color_id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'equals() - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -157,6 +181,12 @@ SELECT color_id
 FROM t
 WHERE equals(dictGetString('colors','name', color_id), 'red')
 ORDER BY color_id;
+SELECT 'equals(), opt off';
+SELECT color_id
+FROM t
+WHERE equals(dictGetString('colors','name', color_id), 'red')
+ORDER BY color_id
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'notEquals, no rewrite (default empty string != red) - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -209,6 +239,12 @@ SELECT color_id, payload
 FROM t
 WHERE match(dictGetString('colors','name', color_id), '^r')
 ORDER BY color_id, payload;
+SELECT 'match ^r, opt off';
+SELECT color_id, payload
+FROM t
+WHERE match(dictGetString('colors','name', color_id), '^r')
+ORDER BY color_id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'NOT recursion - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -222,6 +258,12 @@ SELECT color_id, payload
 FROM t
 WHERE NOT (dictGetString('colors', 'name', color_id) = 'red')
 ORDER BY color_id, payload;
+SELECT 'NOT recursion, opt off';
+SELECT color_id, payload
+FROM t
+WHERE NOT (dictGetString('colors', 'name', color_id) = 'red')
+ORDER BY color_id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'AND/OR recursion - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -237,6 +279,13 @@ FROM t
 WHERE (dictGetString('colors', 'name', color_id) = 'red' AND dictGetUInt64('colors', 'n', color_id) < 10)
    OR dictGetString('colors', 'name', color_id) = 'green'
 ORDER BY color_id, payload;
+SELECT 'AND/OR recursion, opt off';
+SELECT color_id, payload
+FROM t
+WHERE (dictGetString('colors', 'name', color_id) = 'red' AND dictGetUInt64('colors', 'n', color_id) < 10)
+   OR dictGetString('colors', 'name', color_id) = 'green'
+ORDER BY color_id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'NULL constant, no rewrite - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -263,6 +312,12 @@ SELECT color_id
 FROM t
 PREWHERE dictGetString('colors', 'name', color_id) = 'red'
 ORDER BY color_id;
+SELECT 'PREWHERE, opt off';
+SELECT color_id
+FROM t
+PREWHERE dictGetString('colors', 'name', color_id) = 'red'
+ORDER BY color_id
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'QUALIFY - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -276,6 +331,12 @@ SELECT color_id, row_number() OVER (PARTITION BY 1 ORDER BY color_id) AS rn
 FROM t
 QUALIFY dictGetString('colors', 'name', color_id) = 'red'
 ORDER BY color_id, rn;
+SELECT 'QUALIFY, opt off';
+SELECT color_id, row_number() OVER (PARTITION BY 1 ORDER BY color_id) AS rn
+FROM t
+QUALIFY dictGetString('colors', 'name', color_id) = 'red'
+ORDER BY color_id, rn
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'Empty result set - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -289,6 +350,12 @@ SELECT color_id
 FROM t
 WHERE dictGetString('colors', 'name', color_id) = 'nonexistent_color'
 ORDER BY color_id;
+SELECT 'Empty result set, opt off';
+SELECT color_id
+FROM t
+WHERE dictGetString('colors', 'name', color_id) = 'nonexistent_color'
+ORDER BY color_id
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'HAVING - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -304,6 +371,13 @@ FROM t
 GROUP BY color_id
 HAVING dictGetString('colors','name', color_id) = 'red'
 ORDER BY color_id, c;
+SELECT 'HAVING, opt off';
+SELECT color_id, count() AS c
+FROM t
+GROUP BY color_id
+HAVING dictGetString('colors','name', color_id) = 'red'
+ORDER BY color_id, c
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'JOIN ON (INNER) - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -321,6 +395,14 @@ INNER JOIN t AS t2
   ON t1.color_id = t2.color_id
  AND dictGetString('colors','name', t1.color_id) = 'red'
 ORDER BY t1.color_id, t1.payload, payload2;
+SELECT 'JOIN ON (INNER), opt off';
+SELECT t1.color_id, t1.payload, t2.payload AS payload2
+FROM t AS t1
+INNER JOIN t AS t2
+  ON t1.color_id = t2.color_id
+ AND dictGetString('colors','name', t1.color_id) = 'red'
+ORDER BY t1.color_id, t1.payload, payload2
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'JOIN ON (LEFT) - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -338,6 +420,14 @@ LEFT JOIN t AS t2
   ON t1.color_id = t2.color_id
  AND dictGetString('colors','name', t1.color_id) = 'red'
 ORDER BY t1.color_id, t1.payload, payload2;
+SELECT 'JOIN ON (LEFT), opt off';
+SELECT t1.color_id, t1.payload, t2.payload AS payload2
+FROM t AS t1
+LEFT JOIN t AS t2
+  ON t1.color_id = t2.color_id
+ AND dictGetString('colors','name', t1.color_id) = 'red'
+ORDER BY t1.color_id, t1.payload, payload2
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'SELECT multiIf - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -351,6 +441,12 @@ SELECT color_id, payload,
        multiIf(dictGetString('colors','name', color_id) = 'red', 'match', 'no_match') AS tag
 FROM t
 ORDER BY color_id, payload, tag;
+SELECT 'SELECT multiIf, opt off';
+SELECT color_id, payload,
+       multiIf(dictGetString('colors','name', color_id) = 'red', 'match', 'no_match') AS tag
+FROM t
+ORDER BY color_id, payload, tag
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'countIf - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -360,6 +456,10 @@ FROM t;
 SELECT 'countIf';
 SELECT countIf(dictGetString('colors','name', color_id) = 'red') AS cnt
 FROM t;
+SELECT 'countIf, opt off';
+SELECT countIf(dictGetString('colors','name', color_id) = 'red') AS cnt
+FROM t
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'sumIf - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -369,6 +469,10 @@ FROM t;
 SELECT 'sumIf';
 SELECT sumIf(color_id, dictGetString('colors','name', color_id) = 'red') AS sum_id_match
 FROM t;
+SELECT 'sumIf, opt off';
+SELECT sumIf(color_id, dictGetString('colors','name', color_id) = 'red') AS sum_id_match
+FROM t
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'ORDER BY - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -380,6 +484,11 @@ SELECT 'ORDER BY';
 SELECT color_id, payload
 FROM t
 ORDER BY (dictGetString('colors','name', color_id) = 'red') DESC, color_id, payload;
+SELECT 'ORDER BY, opt off';
+SELECT color_id, payload
+FROM t
+ORDER BY (dictGetString('colors','name', color_id) = 'red') DESC, color_id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'GROUP BY - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -393,6 +502,12 @@ SELECT (dictGetString('colors','name', color_id) = 'red') AS is_red, count() AS 
 FROM t
 GROUP BY (dictGetString('colors','name', color_id) = 'red')
 ORDER BY is_red, c;
+SELECT 'GROUP BY, opt off';
+SELECT (dictGetString('colors','name', color_id) = 'red') AS is_red, count() AS c
+FROM t
+GROUP BY (dictGetString('colors','name', color_id) = 'red')
+ORDER BY is_red, c
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'LIMIT BY - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -406,6 +521,12 @@ SELECT color_id, payload
 FROM t
 ORDER BY color_id, payload
 LIMIT 1 BY (dictGetString('colors','name', color_id) = 'red');
+SELECT 'LIMIT BY, opt off';
+SELECT color_id, payload
+FROM t
+ORDER BY color_id, payload
+LIMIT 1 BY (dictGetString('colors','name', color_id) = 'red')
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'WINDOW PARTITION BY - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -425,6 +546,15 @@ SELECT color_id,
        ) AS rn
 FROM t
 ORDER BY color_id, rn;
+SELECT 'WINDOW PARTITION BY, opt off';
+SELECT color_id,
+       row_number() OVER (
+           PARTITION BY (dictGetString('colors','name', color_id) = 'red')
+           ORDER BY color_id
+       ) AS rn
+FROM t
+ORDER BY color_id, rn
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 -- Negative: non-constant RHS, expect no rewrite
 SELECT 'Negative: non-constant RHS - plan';
@@ -439,6 +569,12 @@ SELECT color_id
 FROM t
 WHERE dictGetString('colors', 'name', color_id) = payload
 ORDER BY color_id;
+SELECT 'Negative: non-constant RHS, opt off';
+SELECT color_id
+FROM t
+WHERE dictGetString('colors', 'name', color_id) = payload
+ORDER BY color_id
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 
 -- Validation of attribute name

--- a/tests/queries/0_stateless/03702_optimize_inverse_dictionary_lookup_composite_and_layouts.reference
+++ b/tests/queries/0_stateless/03702_optimize_inverse_dictionary_lookup_composite_and_layouts.reference
@@ -17,6 +17,8 @@ ORDER BY
     __table1.payload ASC
 ComplexKeyHashed
 1	a	x
+ComplexKeyHashed, opt off
+1	a	x
 ComplexHashedArray - plan
 SELECT
     __table1.k1 AS k1,
@@ -35,6 +37,8 @@ ORDER BY
     __table1.k2 ASC,
     __table1.payload ASC
 ComplexHashedArray
+1	a	x
+ComplexHashedArray, opt off
 1	a	x
 ComplexKeySparseHashed - plan
 SELECT
@@ -55,6 +59,8 @@ ORDER BY
     __table1.payload ASC
 ComplexKeySparseHashed
 1	a	x
+ComplexKeySparseHashed, opt off
+1	a	x
 Flat - plan
 SELECT
     __table1.id AS id,
@@ -69,6 +75,10 @@ ORDER BY
     __table1.id ASC,
     __table1.payload ASC
 Flat
+1	u
+1	x
+3	z
+Flat, opt off
 1	u
 1	x
 3	z
@@ -89,6 +99,10 @@ Hashed
 1	u
 1	x
 3	z
+Hashed, opt off
+1	u
+1	x
+3	z
 HashedArray - plan
 SELECT
     __table1.id AS id,
@@ -106,6 +120,10 @@ HashedArray
 1	u
 1	x
 3	z
+HashedArray, opt off
+1	u
+1	x
+3	z
 SparseHashed - plan
 SELECT
     __table1.id AS id,
@@ -120,6 +138,10 @@ ORDER BY
     __table1.id ASC,
     __table1.payload ASC
 SparseHashed
+1	u
+1	x
+3	z
+SparseHashed, opt off
 1	u
 1	x
 3	z

--- a/tests/queries/0_stateless/03702_optimize_inverse_dictionary_lookup_composite_and_layouts.sql
+++ b/tests/queries/0_stateless/03702_optimize_inverse_dictionary_lookup_composite_and_layouts.sql
@@ -1,5 +1,6 @@
 -- Tags: no-replicated-database, no-parallel-replicas
--- no-parallel, no-parallel-replicas: Dictionary is not created in parallel replicas.
+-- no-replicated-database: EXPLAIN output differs for replicated database.
+-- no-parallel-replicas: Dictionary is not available on parallel-replica workers.
 
 SET enable_analyzer = 1;
 SET optimize_inverse_dictionary_lookup = 1;

--- a/tests/queries/0_stateless/03702_optimize_inverse_dictionary_lookup_composite_and_layouts.sql
+++ b/tests/queries/0_stateless/03702_optimize_inverse_dictionary_lookup_composite_and_layouts.sql
@@ -157,6 +157,12 @@ SELECT k1, k2, payload
 FROM f
 WHERE dictGet('dict_prices_ckh', 'tag', (k1, k2)) = 'pro'
 ORDER BY k1, k2, payload;
+SELECT 'ComplexKeyHashed, opt off';
+SELECT k1, k2, payload
+FROM f
+WHERE dictGet('dict_prices_ckh', 'tag', (k1, k2)) = 'pro'
+ORDER BY k1, k2, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'ComplexHashedArray - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -170,6 +176,12 @@ SELECT k1, k2, payload
 FROM f
 WHERE dictGet('dict_prices_ch_array', 'tag', (k1, k2)) = 'pro'
 ORDER BY k1, k2, payload;
+SELECT 'ComplexHashedArray, opt off';
+SELECT k1, k2, payload
+FROM f
+WHERE dictGet('dict_prices_ch_array', 'tag', (k1, k2)) = 'pro'
+ORDER BY k1, k2, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'ComplexKeySparseHashed - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -182,6 +194,12 @@ SELECT k1, k2, payload
 FROM f
 WHERE dictGet('dict_prices_ck_sparse_hashed', 'tag', (k1, k2)) = 'pro'
 ORDER BY k1, k2, payload;
+SELECT 'ComplexKeySparseHashed, opt off';
+SELECT k1, k2, payload
+FROM f
+WHERE dictGet('dict_prices_ck_sparse_hashed', 'tag', (k1, k2)) = 'pro'
+ORDER BY k1, k2, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'Flat - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -195,6 +213,12 @@ SELECT id, payload
 FROM f
 WHERE dictGet('dict_items_flat', 'name', id) = 'alpha'
 ORDER BY id, payload;
+SELECT 'Flat, opt off';
+SELECT id, payload
+FROM f
+WHERE dictGet('dict_items_flat', 'name', id) = 'alpha'
+ORDER BY id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'Hashed - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -208,6 +232,12 @@ SELECT id, payload
 FROM f
 WHERE dictGet('dict_items_hashed', 'name', id) = 'alpha'
 ORDER BY id, payload;
+SELECT 'Hashed, opt off';
+SELECT id, payload
+FROM f
+WHERE dictGet('dict_items_hashed', 'name', id) = 'alpha'
+ORDER BY id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'HashedArray - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -221,6 +251,12 @@ SELECT id, payload
 FROM f
 WHERE dictGet('dict_items_hashed_array', 'name', id) = 'alpha'
 ORDER BY id, payload;
+SELECT 'HashedArray, opt off';
+SELECT id, payload
+FROM f
+WHERE dictGet('dict_items_hashed_array', 'name', id) = 'alpha'
+ORDER BY id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'SparseHashed - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -234,3 +270,9 @@ SELECT id, payload
 FROM f
 WHERE dictGet('dict_items_sparse_hashed', 'name', id) = 'alpha'
 ORDER BY id, payload;
+SELECT 'SparseHashed, opt off';
+SELECT id, payload
+FROM f
+WHERE dictGet('dict_items_sparse_hashed', 'name', id) = 'alpha'
+ORDER BY id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;

--- a/tests/queries/0_stateless/03703_optimize_inverse_dictionary_lookup_dictget_family.reference
+++ b/tests/queries/0_stateless/03703_optimize_inverse_dictionary_lookup_dictget_family.reference
@@ -36,7 +36,7 @@ FROM default.tab AS __table1
 WHERE __table1.id IN (
     SELECT __table1.id AS id
     FROM dictionary(\'dictionary_all\') AS __table1
-    WHERE _CAST(__table1.i32, \'Int32\') = -32
+    WHERE __table1.i32 = -32
 )
 ORDER BY
     __table1.id ASC,
@@ -51,7 +51,7 @@ FROM default.tab AS __table1
 WHERE __table1.id IN (
     SELECT __table1.id AS id
     FROM dictionary(\'dictionary_all\') AS __table1
-    WHERE _CAST(__table1.u64, \'UInt64\') = 64
+    WHERE __table1.u64 = 64
 )
 ORDER BY
     __table1.id ASC,
@@ -66,7 +66,7 @@ FROM default.tab AS __table1
 WHERE __table1.id IN (
     SELECT __table1.id AS id
     FROM dictionary(\'dictionary_all\') AS __table1
-    WHERE _CAST(__table1.f64, \'Float64\') = 20.
+    WHERE __table1.f64 = 20.
 )
 ORDER BY
     __table1.id ASC,
@@ -81,7 +81,7 @@ FROM default.tab AS __table1
 WHERE __table1.id IN (
     SELECT __table1.id AS id
     FROM dictionary(\'dictionary_all\') AS __table1
-    WHERE _CAST(__table1.d, \'Date\') = _CAST(\'2025-01-01\', \'Date\')
+    WHERE __table1.d = _CAST(\'2025-01-01\', \'Date\')
 )
 ORDER BY
     __table1.id ASC,
@@ -96,7 +96,7 @@ FROM default.tab AS __table1
 WHERE __table1.id IN (
     SELECT __table1.id AS id
     FROM dictionary(\'dictionary_all\') AS __table1
-    WHERE _CAST(__table1.dt, \'DateTime\') = _CAST(\'2025-01-01 10:00:00\', \'DateTime\')
+    WHERE __table1.dt = _CAST(\'2025-01-01 10:00:00\', \'DateTime\')
 )
 ORDER BY
     __table1.id ASC,
@@ -111,7 +111,7 @@ FROM default.tab AS __table1
 WHERE __table1.id IN (
     SELECT __table1.id AS id
     FROM dictionary(\'dictionary_all\') AS __table1
-    WHERE _CAST(__table1.uid, \'UUID\') = _CAST(\'00000000-0000-0000-0000-000000000001\', \'UUID\')
+    WHERE __table1.uid = _CAST(\'00000000-0000-0000-0000-000000000001\', \'UUID\')
 )
 ORDER BY
     __table1.id ASC,
@@ -126,7 +126,7 @@ FROM default.tab AS __table1
 WHERE __table1.id IN (
     SELECT __table1.id AS id
     FROM dictionary(\'dictionary_all\') AS __table1
-    WHERE _CAST(__table1.ip4, \'IPv4\') = _CAST(\'192.168.0.1\', \'IPv4\')
+    WHERE __table1.ip4 = _CAST(\'192.168.0.1\', \'IPv4\')
 )
 ORDER BY
     __table1.id ASC,
@@ -141,29 +141,25 @@ FROM default.tab AS __table1
 WHERE __table1.id IN (
     SELECT __table1.id AS id
     FROM dictionary(\'dictionary_all\') AS __table1
-    WHERE _CAST(__table1.ip6, \'IPv6\') = _CAST(\'2001:db8::1\', \'IPv6\')
+    WHERE __table1.ip6 = _CAST(\'2001:db8::1\', \'IPv6\')
 )
 ORDER BY
     __table1.id ASC,
     __table1.payload ASC
 dictGetIPv6
 1	x
-dictGetOrNull(String) - plan
+dictGetOrNull(String), no rewrite (dictGetOrNull is not supported by the optimization) - plan
 SELECT
     __table1.id AS id,
     __table1.payload AS payload
 FROM default.tab AS __table1
-WHERE _CAST((__table1.id IN (
-    SELECT __table1.id AS id
-    FROM dictionary(\'dictionary_all\') AS __table1
-    WHERE _CAST(__table1.name, \'Nullable(String)\') = \'alpha\'
-)), \'Nullable(UInt8)\')
+WHERE dictGetOrNull(\'dictionary_all\', \'name\', __table1.id) = \'alpha\'
 ORDER BY
     __table1.id ASC,
     __table1.payload ASC
-dictGetOrNull(String)
+dictGetOrNull(String), no rewrite (dictGetOrNull is not supported by the optimization)
 1	x
-dictGetOrNull(String) IS NULL - plan
+dictGetOrNull(String) IS NULL, no rewrite (dictGetOrNull is not supported by the optimization) - plan
 SELECT
     __table1.id AS id,
     __table1.payload AS payload
@@ -172,5 +168,5 @@ WHERE isNull(dictGetOrNull(\'dictionary_all\', \'name\', __table1.id))
 ORDER BY
     __table1.id ASC,
     __table1.payload ASC
-dictGetOrNull(String) IS NULL
+dictGetOrNull(String) IS NULL, no rewrite (dictGetOrNull is not supported by the optimization)
 99	z

--- a/tests/queries/0_stateless/03703_optimize_inverse_dictionary_lookup_dictget_family.reference
+++ b/tests/queries/0_stateless/03703_optimize_inverse_dictionary_lookup_dictget_family.reference
@@ -13,6 +13,8 @@ ORDER BY
     __table1.payload ASC
 dictGet (generic)
 1	x
+dictGet (generic), opt off
+1	x
 dictGetString - plan
 SELECT
     __table1.id AS id,
@@ -27,6 +29,8 @@ ORDER BY
     __table1.id ASC,
     __table1.payload ASC
 dictGetString
+1	x
+dictGetString, opt off
 1	x
 dictGetInt32 - plan
 SELECT
@@ -43,6 +47,8 @@ ORDER BY
     __table1.payload ASC
 dictGetInt32
 1	x
+dictGetInt32, opt off
+1	x
 dictGetUInt64 - plan
 SELECT
     __table1.id AS id,
@@ -57,6 +63,8 @@ ORDER BY
     __table1.id ASC,
     __table1.payload ASC
 dictGetUInt64
+1	x
+dictGetUInt64, opt off
 1	x
 dictGetFloat64 - plan
 SELECT
@@ -73,6 +81,8 @@ ORDER BY
     __table1.payload ASC
 dictGetFloat64
 1	x
+dictGetFloat64, opt off
+1	x
 dictGetDate - plan
 SELECT
     __table1.id AS id,
@@ -87,6 +97,8 @@ ORDER BY
     __table1.id ASC,
     __table1.payload ASC
 dictGetDate
+1	x
+dictGetDate, opt off
 1	x
 dictGetDateTime - plan
 SELECT
@@ -103,6 +115,8 @@ ORDER BY
     __table1.payload ASC
 dictGetDateTime
 1	x
+dictGetDateTime, opt off
+1	x
 dictGetUUID - plan
 SELECT
     __table1.id AS id,
@@ -117,6 +131,8 @@ ORDER BY
     __table1.id ASC,
     __table1.payload ASC
 dictGetUUID
+1	x
+dictGetUUID, opt off
 1	x
 dictGetIPv4 - plan
 SELECT
@@ -133,6 +149,8 @@ ORDER BY
     __table1.payload ASC
 dictGetIPv4
 1	x
+dictGetIPv4, opt off
+1	x
 dictGetIPv6 - plan
 SELECT
     __table1.id AS id,
@@ -147,6 +165,8 @@ ORDER BY
     __table1.id ASC,
     __table1.payload ASC
 dictGetIPv6
+1	x
+dictGetIPv6, opt off
 1	x
 dictGetOrNull(String), no rewrite (dictGetOrNull is not supported by the optimization) - plan
 SELECT

--- a/tests/queries/0_stateless/03703_optimize_inverse_dictionary_lookup_dictget_family.sql
+++ b/tests/queries/0_stateless/03703_optimize_inverse_dictionary_lookup_dictget_family.sql
@@ -1,5 +1,6 @@
 -- Tags: no-replicated-database, no-parallel-replicas
--- no-parallel, no-parallel-replicas: Dictionary is not created in parallel replicas.
+-- no-replicated-database: EXPLAIN output differs for replicated database.
+-- no-parallel-replicas: Dictionary is not available on parallel-replica workers.
 
 SET enable_analyzer = 1;
 SET optimize_inverse_dictionary_lookup = 1;

--- a/tests/queries/0_stateless/03703_optimize_inverse_dictionary_lookup_dictget_family.sql
+++ b/tests/queries/0_stateless/03703_optimize_inverse_dictionary_lookup_dictget_family.sql
@@ -88,6 +88,11 @@ SELECT 'dictGet (generic)';
 SELECT id, payload FROM tab
 WHERE dictGet('dictionary_all', 'name', id) = 'alpha'
 ORDER BY id, payload;
+SELECT 'dictGet (generic), opt off';
+SELECT id, payload FROM tab
+WHERE dictGet('dictionary_all', 'name', id) = 'alpha'
+ORDER BY id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'dictGetString - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -99,6 +104,11 @@ SELECT 'dictGetString';
 SELECT id, payload FROM tab
 WHERE dictGetString('dictionary_all', 'name', id) = 'alpha'
 ORDER BY id, payload;
+SELECT 'dictGetString, opt off';
+SELECT id, payload FROM tab
+WHERE dictGetString('dictionary_all', 'name', id) = 'alpha'
+ORDER BY id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'dictGetInt32 - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -110,6 +120,11 @@ SELECT 'dictGetInt32';
 SELECT id, payload FROM tab
 WHERE dictGetInt32('dictionary_all', 'i32', id) = -32
 ORDER BY id, payload;
+SELECT 'dictGetInt32, opt off';
+SELECT id, payload FROM tab
+WHERE dictGetInt32('dictionary_all', 'i32', id) = -32
+ORDER BY id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'dictGetUInt64 - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -121,6 +136,11 @@ SELECT 'dictGetUInt64';
 SELECT id, payload FROM tab
 WHERE dictGetUInt64('dictionary_all', 'u64', id) = 64
 ORDER BY id, payload;
+SELECT 'dictGetUInt64, opt off';
+SELECT id, payload FROM tab
+WHERE dictGetUInt64('dictionary_all', 'u64', id) = 64
+ORDER BY id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'dictGetFloat64 - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -132,6 +152,11 @@ SELECT 'dictGetFloat64';
 SELECT id, payload FROM tab
 WHERE dictGetFloat64('dictionary_all', 'f64', id) = 20.0
 ORDER BY id, payload;
+SELECT 'dictGetFloat64, opt off';
+SELECT id, payload FROM tab
+WHERE dictGetFloat64('dictionary_all', 'f64', id) = 20.0
+ORDER BY id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'dictGetDate - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -143,6 +168,11 @@ SELECT 'dictGetDate';
 SELECT id, payload FROM tab
 WHERE dictGetDate('dictionary_all', 'd', id) = toDate('2025-01-01')
 ORDER BY id, payload;
+SELECT 'dictGetDate, opt off';
+SELECT id, payload FROM tab
+WHERE dictGetDate('dictionary_all', 'd', id) = toDate('2025-01-01')
+ORDER BY id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'dictGetDateTime - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -154,6 +184,11 @@ SELECT 'dictGetDateTime';
 SELECT id, payload FROM tab
 WHERE dictGetDateTime('dictionary_all', 'dt', id) = toDateTime('2025-01-01 10:00:00')
 ORDER BY id, payload;
+SELECT 'dictGetDateTime, opt off';
+SELECT id, payload FROM tab
+WHERE dictGetDateTime('dictionary_all', 'dt', id) = toDateTime('2025-01-01 10:00:00')
+ORDER BY id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'dictGetUUID - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -165,6 +200,11 @@ SELECT 'dictGetUUID';
 SELECT id, payload FROM tab
 WHERE dictGetUUID('dictionary_all', 'uid', id) = toUUID('00000000-0000-0000-0000-000000000001')
 ORDER BY id, payload;
+SELECT 'dictGetUUID, opt off';
+SELECT id, payload FROM tab
+WHERE dictGetUUID('dictionary_all', 'uid', id) = toUUID('00000000-0000-0000-0000-000000000001')
+ORDER BY id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'dictGetIPv4 - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -176,6 +216,11 @@ SELECT 'dictGetIPv4';
 SELECT id, payload FROM tab
 WHERE dictGetIPv4('dictionary_all', 'ip4', id) = toIPv4('192.168.0.1')
 ORDER BY id, payload;
+SELECT 'dictGetIPv4, opt off';
+SELECT id, payload FROM tab
+WHERE dictGetIPv4('dictionary_all', 'ip4', id) = toIPv4('192.168.0.1')
+ORDER BY id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'dictGetIPv6 - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
@@ -187,6 +232,11 @@ SELECT 'dictGetIPv6';
 SELECT id, payload FROM tab
 WHERE dictGetIPv6('dictionary_all', 'ip6', id) = toIPv6('2001:db8::1')
 ORDER BY id, payload;
+SELECT 'dictGetIPv6, opt off';
+SELECT id, payload FROM tab
+WHERE dictGetIPv6('dictionary_all', 'ip6', id) = toIPv6('2001:db8::1')
+ORDER BY id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;
 
 SELECT 'dictGetOrNull(String), no rewrite (dictGetOrNull is not supported by the optimization) - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1

--- a/tests/queries/0_stateless/03703_optimize_inverse_dictionary_lookup_dictget_family.sql
+++ b/tests/queries/0_stateless/03703_optimize_inverse_dictionary_lookup_dictget_family.sql
@@ -13,21 +13,21 @@ CREATE TABLE ref_table_all
 (
   id   UInt64,
   name String,
-  i8   String,
-  i16  String,
-  i32  String,
-  i64  String,
-  u8   String,
-  u16  String,
-  u32  String,
-  u64  String,
-  f32  String,
-  f64  String,
-  d    String,
-  dt   String,
-  uid  String,
-  ip4  String,
-  ip6  String
+  i8   Int8,
+  i16  Int16,
+  i32  Int32,
+  i64  Int64,
+  u8   UInt8,
+  u16  UInt16,
+  u32  UInt32,
+  u64  UInt64,
+  f32  Float32,
+  f64  Float64,
+  d    Date,
+  dt   DateTime,
+  uid  UUID,
+  ip4  IPv4,
+  ip6  IPv6
 )
 ENGINE = MergeTree
 ORDER BY id;
@@ -46,21 +46,21 @@ CREATE DICTIONARY dictionary_all
 (
   id   UInt64,
   name String,
-  i8   String,
-  i16  String,
-  i32  String,
-  i64  String,
-  u8   String,
-  u16  String,
-  u32  String,
-  u64  String,
-  f32  String,
-  f64  String,
-  d    String,
-  dt   String,
-  uid  String,
-  ip4  String,
-  ip6  String
+  i8   Int8,
+  i16  Int16,
+  i32  Int32,
+  i64  Int64,
+  u8   UInt8,
+  u16  UInt16,
+  u32  UInt32,
+  u64  UInt64,
+  f32  Float32,
+  f64  Float64,
+  d    Date,
+  dt   DateTime,
+  uid  UUID,
+  ip4  IPv4,
+  ip6  IPv6
 )
 PRIMARY KEY id
 SOURCE(CLICKHOUSE(TABLE 'ref_table_all'))
@@ -187,24 +187,24 @@ SELECT id, payload FROM tab
 WHERE dictGetIPv6('dictionary_all', 'ip6', id) = toIPv6('2001:db8::1')
 ORDER BY id, payload;
 
-SELECT 'dictGetOrNull(String) - plan';
+SELECT 'dictGetOrNull(String), no rewrite (dictGetOrNull is not supported by the optimization) - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
 SELECT id, payload FROM tab
 WHERE dictGetOrNull('dictionary_all', 'name', id) = 'alpha'
 ORDER BY id, payload;
 
-SELECT 'dictGetOrNull(String)';
+SELECT 'dictGetOrNull(String), no rewrite (dictGetOrNull is not supported by the optimization)';
 SELECT id, payload FROM tab
 WHERE dictGetOrNull('dictionary_all', 'name', id) = 'alpha'
 ORDER BY id, payload;
 
-SELECT 'dictGetOrNull(String) IS NULL - plan';
+SELECT 'dictGetOrNull(String) IS NULL, no rewrite (dictGetOrNull is not supported by the optimization) - plan';
 EXPLAIN SYNTAX run_query_tree_passes=1
 SELECT id, payload FROM tab
 WHERE isNull(dictGetOrNull('dictionary_all','name', id))
 ORDER BY id, payload;
 
-SELECT 'dictGetOrNull(String) IS NULL';
+SELECT 'dictGetOrNull(String) IS NULL, no rewrite (dictGetOrNull is not supported by the optimization)';
 SELECT id, payload FROM tab
 WHERE isNull(dictGetOrNull('dictionary_all','name', id))
 ORDER BY id, payload;

--- a/tests/queries/0_stateless/03713_optimize_inverse_dictionary_lookup_setting_rewrite_in_to_join.reference
+++ b/tests/queries/0_stateless/03713_optimize_inverse_dictionary_lookup_setting_rewrite_in_to_join.reference
@@ -10,3 +10,6 @@ ORDER BY
 Equality, LHS
 1	a
 3	c
+Equality, LHS, opt off
+1	a
+3	c

--- a/tests/queries/0_stateless/03713_optimize_inverse_dictionary_lookup_setting_rewrite_in_to_join.sql
+++ b/tests/queries/0_stateless/03713_optimize_inverse_dictionary_lookup_setting_rewrite_in_to_join.sql
@@ -1,5 +1,6 @@
 -- Tags: no-replicated-database, no-parallel-replicas
--- no-parallel, no-parallel-replicas: Dictionary is not created in parallel replicas.
+-- no-replicated-database: EXPLAIN output differs for replicated database.
+-- no-parallel-replicas: Dictionary is not available on parallel-replica workers.
 
 SET enable_analyzer = 1;
 SET optimize_inverse_dictionary_lookup = 1;

--- a/tests/queries/0_stateless/03713_optimize_inverse_dictionary_lookup_setting_rewrite_in_to_join.sql
+++ b/tests/queries/0_stateless/03713_optimize_inverse_dictionary_lookup_setting_rewrite_in_to_join.sql
@@ -67,3 +67,9 @@ SELECT color_id, payload
 FROM t
 WHERE dictGetString('colors', 'name', color_id) = 'red'
 ORDER BY color_id, payload;
+SELECT 'Equality, LHS, opt off';
+SELECT color_id, payload
+FROM t
+WHERE dictGetString('colors', 'name', color_id) = 'red'
+ORDER BY color_id, payload
+SETTINGS optimize_inverse_dictionary_lookup = 0;

--- a/tests/queries/0_stateless/03787_optimize_inverse_dictionary_lookup_remote_shards.sql
+++ b/tests/queries/0_stateless/03787_optimize_inverse_dictionary_lookup_remote_shards.sql
@@ -1,5 +1,6 @@
 -- Tags: no-replicated-database, no-parallel-replicas
--- no-parallel, no-parallel-replicas: Dictionary is not created in parallel replicas.
+-- no-replicated-database: EXPLAIN output differs for replicated database.
+-- no-parallel-replicas: Dictionary is not available on parallel-replica workers.
 
 SET enable_analyzer = 1;
 SET rewrite_in_to_join = 0;

--- a/tests/queries/0_stateless/04201_inverse_dictionary_lookup_edge_cases.reference
+++ b/tests/queries/0_stateless/04201_inverse_dictionary_lookup_edge_cases.reference
@@ -1,0 +1,344 @@
+dictGet = default, missing key, no rewrite (default -1 = -1) - plan
+SELECT
+    __table1.id AS id,
+    dictGet(\'dict_int_default_minus1\', \'from\', toUInt64(__table1.id)) AS a,
+    dictGet(\'dict_int_default_minus1\', \'from\', toUInt64(__table1.id)) = -1 AS pred
+FROM default.data_int AS __table1
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+dictGet = default, missing key, no rewrite (default -1 = -1)
+53	-1	1
+dictGet = default, Nullable source, no rewrite (default -1 = -1) - plan
+SELECT
+    __table1.id AS id,
+    dictGet(\'dict_int_nullable_default_minus1\', \'from\', toUInt64(__table1.id)) AS a,
+    dictGet(\'dict_int_nullable_default_minus1\', \'from\', toUInt64(__table1.id)) = -1 AS pred
+FROM default.data_int AS __table1
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+dictGet = default, Nullable source, no rewrite (default -1 = -1)
+53	-1	1
+dictGetOrNull = const, no rewrite (dictGetOrNull is not supported by the optimization) - plan
+SELECT
+    __table1.id AS id,
+    dictGetOrNull(\'dict_string\', \'name\', __table1.id) = \'abc\' AS pred
+FROM default.data_str AS __table1
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+dictGetOrNull = const, no rewrite (dictGetOrNull is not supported by the optimization)
+1	1
+2	\N
+3	\N
+dictGet != non-default, no rewrite (default empty string != abc) - plan
+SELECT count() AS `count()`
+FROM default.data_str AS __table1
+WHERE dictGet(\'dict_string\', \'name\', __table1.id) != \'abc\'
+SETTINGS optimize_inverse_dictionary_lookup = 1
+dictGet != non-default, no rewrite (default empty string != abc)
+2
+dictGet LIKE %, no rewrite (default empty string LIKE %) - plan
+SELECT count() AS `count()`
+FROM default.data_str AS __table1
+WHERE dictGet(\'dict_string\', \'name\', __table1.id) LIKE \'%\'
+SETTINGS optimize_inverse_dictionary_lookup = 1
+dictGet LIKE %, no rewrite (default empty string LIKE %)
+3
+Nullable key, dictGetString != abc, no rewrite (default empty string != abc) - plan
+SELECT count() AS `count()`
+FROM default.data_str_nullable AS __table1
+WHERE dictGetString(\'dict_string\', \'name\', __table1.id) != \'abc\'
+SETTINGS optimize_inverse_dictionary_lookup = 1
+Nullable key, dictGetString != abc, no rewrite (default empty string != abc)
+1
+LC(Nullable) simple key, dictGetString != abc, no rewrite (default empty string != abc) - plan
+SELECT count() AS `count()`
+FROM default.data_str_lc_nullable AS __table1
+WHERE dictGetString(\'dict_string\', \'name\', __table1.id) != \'abc\'
+SETTINGS optimize_inverse_dictionary_lookup = 1
+LC(Nullable) simple key, dictGetString != abc, no rewrite (default empty string != abc)
+1
+Composite key, Nullable component, no rewrite (skip to preserve dictGet throw on NULL component) - plan
+SELECT
+    __table1.k1 AS k1,
+    dictGetString(\'dict_complex_str\', \'name\', (__table1.k1, __table1.k2)) = \'abc\' AS pred
+FROM default.data_complex AS __table1
+ORDER BY __table1.k1 ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+Composite key, Nullable component, no rewrite (skip to preserve dictGet throw on NULL component)
+1	1
+2	0
+Composite key, LC(Nullable) component, no rewrite (skip to preserve throw) - plan
+SELECT
+    __table1.k1 AS k1,
+    dictGetString(\'dict_complex_str\', \'name\', (__table1.k1, __table1.k2)) = \'abc\' AS pred
+FROM default.data_complex_lc_nullable AS __table1
+ORDER BY __table1.k1 ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+Composite key, LC(Nullable) component, no rewrite (skip to preserve throw)
+1	1
+2	0
+Composite key, dict declares Nullable key, Nullable data, no rewrite - plan
+SELECT count() AS `count()`
+FROM default.data_complex_nullable_dict_key AS __table1
+WHERE dictGetString(\'dict_complex_nullable_dict_key\', \'name\', (__table1.k1, __table1.k2)) = \'nullhit\'
+SETTINGS optimize_inverse_dictionary_lookup = 1
+Composite key, dict declares Nullable key, Nullable data, no rewrite
+1
+Nullable(Tuple(Nullable(K))), no rewrite - plan
+SELECT count() AS `count()`
+FROM default.data_outer_nullable_tuple AS __table1
+WHERE dictGetString(\'dict_complex_nullable_dict_key\', \'name\', __table1.t) = \'nullhit\'
+SETTINGS optimize_inverse_dictionary_lookup = 1
+Nullable(Tuple(Nullable(K))), no rewrite
+1
+Nullable attr with stored NULL, isNull(predicate), no rewrite - plan
+SELECT __table1.id AS id
+FROM default.data_str AS __table1
+WHERE isNull(dictGet(\'dict_nullable_attr_stored\', \'name\', __table1.id) = \'abc\')
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+Nullable attr with stored NULL, isNull(predicate), no rewrite
+2
+op equals, no rewrite
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE dictGetUInt64(\'dict_ops\', \'n\', __table1.id) = 0
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+op notEquals, no rewrite
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE dictGetString(\'dict_ops\', \'name\', __table1.id) != \'zzz\'
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+op less, no rewrite
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE dictGetUInt64(\'dict_ops\', \'n\', __table1.id) < 100
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+op lessOrEquals, no rewrite
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE dictGetUInt64(\'dict_ops\', \'n\', __table1.id) <= 0
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+op greater, no rewrite
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE \'apple\' > dictGetString(\'dict_ops\', \'name\', __table1.id)
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+op greaterOrEquals, no rewrite
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE dictGetUInt64(\'dict_ops\', \'n\', __table1.id) >= 0
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+op like, no rewrite
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE dictGetString(\'dict_ops\', \'name\', __table1.id) LIKE \'%\'
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+op notLike, no rewrite
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE dictGetString(\'dict_ops\', \'name\', __table1.id) NOT LIKE \'a%\'
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+op ilike, no rewrite
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE dictGetString(\'dict_ops\', \'name\', __table1.id) ILIKE \'%\'
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+op notILike, no rewrite
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE dictGetString(\'dict_ops\', \'name\', __table1.id) NOT ILIKE \'A%\'
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+op match, no rewrite
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE match(dictGetString(\'dict_ops\', \'name\', __table1.id), \'.*\')
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+layout Flat, no rewrite
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE dictGetString(\'dict_flat\', \'name\', __table1.id) LIKE \'%\'
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+layout Hashed, no rewrite
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE dictGetString(\'dict_hashed\', \'name\', __table1.id) LIKE \'%\'
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+layout HashedArray, no rewrite
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE dictGetString(\'dict_hashed_array\', \'name\', __table1.id) LIKE \'%\'
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+layout SparseHashed, no rewrite
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE dictGetString(\'dict_sparse_hashed\', \'name\', __table1.id) LIKE \'%\'
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+layout ComplexKeyHashed, no rewrite
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE dictGetString(\'dict_complex\', \'name\', (__table1.id, \'a\')) LIKE \'%\'
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+layout ComplexHashedArray, no rewrite
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE dictGetString(\'dict_complex_array\', \'name\', (__table1.id, \'a\')) LIKE \'%\'
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+layout ComplexKeySparseHashed, no rewrite
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE dictGetString(\'dict_complex_sparse\', \'name\', (__table1.id, \'a\')) LIKE \'%\'
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+rewrite: equals on non-default - plan
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE __table1.id IN (
+    SELECT __table1.id AS id
+    FROM dictionary(\'dict_hashed\') AS __table1
+    WHERE __table1.name = \'red\'
+)
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+rewrite: equals on non-default
+1
+rewrite: equals on non-default, opt off
+1
+rewrite: greater than non-default - plan
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE __table1.id IN (
+    SELECT __table1.id AS id
+    FROM dictionary(\'dict_ops\') AS __table1
+    WHERE __table1.n > 100
+)
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+rewrite: greater than non-default
+rewrite: greater than non-default, opt off
+rewrite: != default (numeric) - plan
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE __table1.id IN (
+    SELECT __table1.id AS id
+    FROM dictionary(\'dict_ops\') AS __table1
+    WHERE __table1.n != 0
+)
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+rewrite: != default (numeric)
+1
+rewrite: != default (numeric), opt off
+1
+rewrite: NOT LIKE default (string) - plan
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE __table1.id IN (
+    SELECT __table1.id AS id
+    FROM dictionary(\'dict_ops\') AS __table1
+    WHERE __table1.name NOT LIKE \'\'
+)
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+rewrite: NOT LIKE default (string)
+1
+rewrite: NOT LIKE default (string), opt off
+1
+rewrite: NOT ILIKE default (string) - plan
+SELECT __table1.id AS id
+FROM default.data_ops AS __table1
+WHERE __table1.id IN (
+    SELECT __table1.id AS id
+    FROM dictionary(\'dict_ops\') AS __table1
+    WHERE __table1.name NOT ILIKE \'\'
+)
+ORDER BY __table1.id ASC
+SETTINGS optimize_inverse_dictionary_lookup = 1
+rewrite: NOT ILIKE default (string)
+1
+rewrite: NOT ILIKE default (string), opt off
+1
+rewrite: plain key - plan
+SELECT count() AS `count()`
+FROM default.data_ops AS __table1
+WHERE __table1.id IN (
+    SELECT __table1.id AS id
+    FROM dictionary(\'dict_ops\') AS __table1
+    WHERE __table1.name = \'apple\'
+)
+SETTINGS optimize_inverse_dictionary_lookup = 1
+rewrite: plain key
+1
+rewrite: plain key, opt off
+1
+rewrite: Nullable(K) key - plan
+SELECT count() AS `count()`
+FROM default.data_str_nullable AS __table1
+WHERE __table1.id IN (
+    SELECT __table1.id AS id
+    FROM dictionary(\'dict_string\') AS __table1
+    WHERE __table1.name = \'abc\'
+)
+SETTINGS optimize_inverse_dictionary_lookup = 1
+rewrite: Nullable(K) key
+1
+rewrite: Nullable(K) key, opt off
+1
+rewrite: LC(Nullable(K)) key - plan
+SELECT count() AS `count()`
+FROM default.data_str_lc_nullable AS __table1
+WHERE _CAST((__table1.id IN (
+    SELECT __table1.id AS id
+    FROM dictionary(\'dict_string\') AS __table1
+    WHERE __table1.name = \'abc\'
+)), \'LowCardinality(Nullable(UInt8))\')
+SETTINGS optimize_inverse_dictionary_lookup = 1
+rewrite: LC(Nullable(K)) key
+1
+rewrite: LC(Nullable(K)) key, opt off
+1
+short-circuited bad-regex match: optimization on, returns 0
+0
+short-circuited bad-regex match: optimization on, returns 0, opt off
+0
+short-circuited bad-regex match, no rewrite - plan
+SELECT count() AS `count()`
+FROM default.data_ops AS __table1
+WHERE (__table1.id < 0) AND match(dictGetString(\'dict_ops\', \'name\', __table1.id), \'[unclosed\')
+SETTINGS optimize_inverse_dictionary_lookup = 1
+max_rows_in_set + break, no rewrite - plan
+SELECT groupArray(__table1.id) AS `groupArray(id)`
+FROM default.data_set_limit AS __table1
+WHERE dictGetString(\'dict_set_limit\', \'name\', __table1.id) = \'hit\'
+SETTINGS optimize_inverse_dictionary_lookup = 1, max_rows_in_set = 1, set_overflow_mode = \'break\'
+max_rows_in_set + break, no rewrite
+[1,2]
+max_rows_in_set + throw, rewrite - plan
+SELECT groupArray(__table1.id) AS `groupArray(id)`
+FROM default.data_set_limit AS __table1
+WHERE __table1.id IN (
+    SELECT __table1.id AS id
+    FROM dictionary(\'dict_set_limit\') AS __table1
+    WHERE __table1.name = \'hit\'
+)
+SETTINGS optimize_inverse_dictionary_lookup = 1, max_rows_in_set = 1, set_overflow_mode = \'throw\'
+max_rows_in_set + throw: execution raises SET_SIZE_LIMIT_EXCEEDED
+max_bytes_in_set + break, no rewrite
+[1,2]

--- a/tests/queries/0_stateless/04201_inverse_dictionary_lookup_edge_cases.sql
+++ b/tests/queries/0_stateless/04201_inverse_dictionary_lookup_edge_cases.sql
@@ -1,5 +1,6 @@
 -- Tags: no-replicated-database, no-parallel-replicas
--- no-replicated-database, no-parallel-replicas: Dictionary is not created in replicated databases, parallel replicas.
+-- no-replicated-database: EXPLAIN output differs for replicated database.
+-- no-parallel-replicas: Dictionary is not available on parallel-replica workers.
 
 SET optimize_or_like_chain = 0;
 SET optimize_rewrite_like_perfect_affix = 0;

--- a/tests/queries/0_stateless/04201_inverse_dictionary_lookup_edge_cases.sql
+++ b/tests/queries/0_stateless/04201_inverse_dictionary_lookup_edge_cases.sql
@@ -1,0 +1,474 @@
+-- Tags: no-replicated-database, no-parallel-replicas
+-- no-replicated-database, no-parallel-replicas: Dictionary is not created in replicated databases, parallel replicas.
+
+SET optimize_or_like_chain = 0;
+SET optimize_rewrite_like_perfect_affix = 0;
+
+DROP DICTIONARY IF EXISTS dict_int_default_minus1;
+DROP DICTIONARY IF EXISTS dict_int_nullable_default_minus1;
+DROP DICTIONARY IF EXISTS dict_string;
+DROP DICTIONARY IF EXISTS dict_complex_str;
+DROP DICTIONARY IF EXISTS dict_nullable_attr_stored;
+DROP DICTIONARY IF EXISTS dict_complex_nullable_dict_key;
+DROP DICTIONARY IF EXISTS dict_set_limit;
+DROP DICTIONARY IF EXISTS dict_ops;
+DROP DICTIONARY IF EXISTS dict_flat;
+DROP DICTIONARY IF EXISTS dict_hashed;
+DROP DICTIONARY IF EXISTS dict_hashed_array;
+DROP DICTIONARY IF EXISTS dict_sparse_hashed;
+DROP DICTIONARY IF EXISTS dict_complex;
+DROP DICTIONARY IF EXISTS dict_complex_array;
+DROP DICTIONARY IF EXISTS dict_complex_sparse;
+DROP TABLE IF EXISTS ref_int;
+DROP TABLE IF EXISTS ref_int_nullable;
+DROP TABLE IF EXISTS ref_str;
+DROP TABLE IF EXISTS ref_complex_str;
+DROP TABLE IF EXISTS ref_nullable_attr_stored;
+DROP TABLE IF EXISTS ref_complex_nullable_dict_key;
+DROP TABLE IF EXISTS ref_set_limit;
+DROP TABLE IF EXISTS ref_ops;
+DROP TABLE IF EXISTS ref_layouts_simple;
+DROP TABLE IF EXISTS ref_layouts_complex;
+DROP TABLE IF EXISTS data_int;
+DROP TABLE IF EXISTS data_str;
+DROP TABLE IF EXISTS data_str_nullable;
+DROP TABLE IF EXISTS data_str_lc_nullable;
+DROP TABLE IF EXISTS data_complex;
+DROP TABLE IF EXISTS data_complex_lc_nullable;
+DROP TABLE IF EXISTS data_complex_single_lc;
+DROP TABLE IF EXISTS data_complex_nullable_dict_key;
+DROP TABLE IF EXISTS data_outer_nullable_tuple;
+DROP TABLE IF EXISTS data_set_limit;
+DROP TABLE IF EXISTS data_ops;
+
+CREATE TABLE ref_int (`to` UInt64, `from` Int32) ENGINE = MergeTree ORDER BY `to`;
+INSERT INTO ref_int VALUES (42, 9289150);
+
+CREATE TABLE ref_int_nullable (`to` UInt64, `from` Nullable(Int32)) ENGINE = MergeTree ORDER BY `to`;
+INSERT INTO ref_int_nullable VALUES (42, 9289150);
+
+CREATE TABLE ref_str (id UInt64, name String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO ref_str VALUES (1, 'abc');
+
+CREATE DICTIONARY dict_int_default_minus1 (`to` UInt64, `from` Int32 DEFAULT -1)
+PRIMARY KEY `to` SOURCE(CLICKHOUSE(TABLE 'ref_int')) LAYOUT(HASHED()) LIFETIME(0);
+
+CREATE DICTIONARY dict_int_nullable_default_minus1 (`to` UInt64, `from` Int32 DEFAULT -1)
+PRIMARY KEY `to` SOURCE(CLICKHOUSE(TABLE 'ref_int_nullable')) LAYOUT(HASHED()) LIFETIME(0);
+
+CREATE DICTIONARY dict_string (id UInt64, name String)
+PRIMARY KEY id SOURCE(CLICKHOUSE(TABLE 'ref_str')) LAYOUT(HASHED()) LIFETIME(0);
+
+CREATE TABLE data_int (id Int32) ENGINE = MergeTree ORDER BY id;
+INSERT INTO data_int VALUES (53);
+
+CREATE TABLE data_str (id UInt64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO data_str VALUES (1), (2), (3);
+
+CREATE TABLE data_str_nullable (id Nullable(UInt64)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO data_str_nullable VALUES (1), (2), (NULL);
+
+CREATE TABLE data_str_lc_nullable (id LowCardinality(Nullable(UInt64))) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS allow_suspicious_low_cardinality_types = 1;
+INSERT INTO data_str_lc_nullable VALUES (1), (2), (NULL);
+
+
+SELECT 'dictGet = default, missing key, no rewrite (default -1 = -1) - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT id, dictGet('dict_int_default_minus1', 'from', toUInt64(id)) AS a, a = -1 AS pred FROM data_int ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'dictGet = default, missing key, no rewrite (default -1 = -1)';
+SELECT id, dictGet('dict_int_default_minus1', 'from', toUInt64(id)) AS a, a = -1 AS pred FROM data_int ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'dictGet = default, Nullable source, no rewrite (default -1 = -1) - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT id, dictGet('dict_int_nullable_default_minus1', 'from', toUInt64(id)) AS a, a = -1 AS pred FROM data_int ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'dictGet = default, Nullable source, no rewrite (default -1 = -1)';
+SELECT id, dictGet('dict_int_nullable_default_minus1', 'from', toUInt64(id)) AS a, a = -1 AS pred FROM data_int ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'dictGetOrNull = const, no rewrite (dictGetOrNull is not supported by the optimization) - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT id, dictGetOrNull('dict_string', 'name', id) = 'abc' AS pred FROM data_str ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'dictGetOrNull = const, no rewrite (dictGetOrNull is not supported by the optimization)';
+SELECT id, dictGetOrNull('dict_string', 'name', id) = 'abc' AS pred FROM data_str ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'dictGet != non-default, no rewrite (default empty string != abc) - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT count() FROM data_str WHERE dictGet('dict_string', 'name', id) != 'abc'
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'dictGet != non-default, no rewrite (default empty string != abc)';
+SELECT count() FROM data_str WHERE dictGet('dict_string', 'name', id) != 'abc'
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'dictGet LIKE %, no rewrite (default empty string LIKE %) - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT count() FROM data_str WHERE dictGet('dict_string', 'name', id) LIKE '%'
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'dictGet LIKE %, no rewrite (default empty string LIKE %)';
+SELECT count() FROM data_str WHERE dictGet('dict_string', 'name', id) LIKE '%'
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'Nullable key, dictGetString != abc, no rewrite (default empty string != abc) - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT count() FROM data_str_nullable WHERE dictGetString('dict_string', 'name', id) != 'abc'
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'Nullable key, dictGetString != abc, no rewrite (default empty string != abc)';
+SELECT count() FROM data_str_nullable WHERE dictGetString('dict_string', 'name', id) != 'abc'
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'LC(Nullable) simple key, dictGetString != abc, no rewrite (default empty string != abc) - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT count() FROM data_str_lc_nullable WHERE dictGetString('dict_string', 'name', id) != 'abc'
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'LC(Nullable) simple key, dictGetString != abc, no rewrite (default empty string != abc)';
+SELECT count() FROM data_str_lc_nullable WHERE dictGetString('dict_string', 'name', id) != 'abc'
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+CREATE TABLE ref_complex_str (k1 UInt64, k2 String, name String) ENGINE = MergeTree ORDER BY (k1, k2);
+INSERT INTO ref_complex_str VALUES (1, 'a', 'abc');
+CREATE DICTIONARY dict_complex_str (k1 UInt64, k2 String, name String)
+PRIMARY KEY k1, k2 SOURCE(CLICKHOUSE(TABLE 'ref_complex_str')) LAYOUT(COMPLEX_KEY_HASHED()) LIFETIME(0);
+CREATE TABLE data_complex (k1 Nullable(UInt64), k2 String) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO data_complex VALUES (1, 'a'), (2, 'a');
+
+SELECT 'Composite key, Nullable component, no rewrite (skip to preserve dictGet throw on NULL component) - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT k1, dictGetString('dict_complex_str', 'name', (k1, k2)) = 'abc' AS pred FROM data_complex ORDER BY k1
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'Composite key, Nullable component, no rewrite (skip to preserve dictGet throw on NULL component)';
+SELECT k1, dictGetString('dict_complex_str', 'name', (k1, k2)) = 'abc' AS pred FROM data_complex ORDER BY k1
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+CREATE TABLE data_complex_lc_nullable (k1 LowCardinality(Nullable(UInt64)), k2 String) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS allow_suspicious_low_cardinality_types = 1;
+INSERT INTO data_complex_lc_nullable VALUES (1, 'a'), (2, 'a');
+
+SELECT 'Composite key, LC(Nullable) component, no rewrite (skip to preserve throw) - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT k1, dictGetString('dict_complex_str', 'name', (k1, k2)) = 'abc' AS pred FROM data_complex_lc_nullable ORDER BY k1
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'Composite key, LC(Nullable) component, no rewrite (skip to preserve throw)';
+SELECT k1, dictGetString('dict_complex_str', 'name', (k1, k2)) = 'abc' AS pred FROM data_complex_lc_nullable ORDER BY k1
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+CREATE TABLE ref_complex_nullable_dict_key (k1 Nullable(UInt64), k2 String, name String) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO ref_complex_nullable_dict_key VALUES (NULL, 'x', 'nullhit'), (1, 'x', 'one');
+CREATE DICTIONARY dict_complex_nullable_dict_key (k1 Nullable(UInt64), k2 String, name String)
+PRIMARY KEY k1, k2 SOURCE(CLICKHOUSE(TABLE 'ref_complex_nullable_dict_key')) LAYOUT(COMPLEX_KEY_HASHED()) LIFETIME(0);
+CREATE TABLE data_complex_nullable_dict_key (k1 Nullable(UInt64), k2 String) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO data_complex_nullable_dict_key VALUES (NULL, 'x'), (1, 'x'), (2, 'x');
+
+SELECT 'Composite key, dict declares Nullable key, Nullable data, no rewrite - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT count() FROM data_complex_nullable_dict_key WHERE dictGetString('dict_complex_nullable_dict_key', 'name', (k1, k2)) = 'nullhit'
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'Composite key, dict declares Nullable key, Nullable data, no rewrite';
+SELECT count() FROM data_complex_nullable_dict_key WHERE dictGetString('dict_complex_nullable_dict_key', 'name', (k1, k2)) = 'nullhit'
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+CREATE TABLE data_outer_nullable_tuple (t Nullable(Tuple(Nullable(UInt64), String))) ENGINE = MergeTree ORDER BY tuple()
+SETTINGS allow_experimental_nullable_tuple_type = 1;
+INSERT INTO data_outer_nullable_tuple VALUES ((NULL, 'x')), ((1, 'x'));
+
+SELECT 'Nullable(Tuple(Nullable(K))), no rewrite - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT count() FROM data_outer_nullable_tuple WHERE dictGetString('dict_complex_nullable_dict_key', 'name', t) = 'nullhit'
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'Nullable(Tuple(Nullable(K))), no rewrite';
+SELECT count() FROM data_outer_nullable_tuple WHERE dictGetString('dict_complex_nullable_dict_key', 'name', t) = 'nullhit'
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+CREATE TABLE ref_nullable_attr_stored (id UInt64, name Nullable(String)) ENGINE = MergeTree ORDER BY id;
+INSERT INTO ref_nullable_attr_stored VALUES (1, 'abc'), (2, NULL);
+CREATE DICTIONARY dict_nullable_attr_stored (id UInt64, name Nullable(String) DEFAULT 'missing')
+PRIMARY KEY id SOURCE(CLICKHOUSE(TABLE 'ref_nullable_attr_stored')) LAYOUT(HASHED()) LIFETIME(0);
+
+SELECT 'Nullable attr with stored NULL, isNull(predicate), no rewrite - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT id FROM data_str WHERE isNull(dictGet('dict_nullable_attr_stored', 'name', id) = 'abc') ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'Nullable attr with stored NULL, isNull(predicate), no rewrite';
+SELECT id FROM data_str WHERE isNull(dictGet('dict_nullable_attr_stored', 'name', id) = 'abc') ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+-- Per-operator no-rewrite examples (default = '' for String, default = 0 for UInt64)
+CREATE TABLE ref_ops (id UInt64, name String, n UInt64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO ref_ops VALUES (1, 'apple', 5);
+CREATE DICTIONARY dict_ops (id UInt64, name String, n UInt64)
+PRIMARY KEY id SOURCE(CLICKHOUSE(TABLE 'ref_ops')) LAYOUT(HASHED()) LIFETIME(0);
+CREATE TABLE data_ops (id UInt64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO data_ops VALUES (1), (2);
+
+SELECT 'op equals, no rewrite';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE dictGetUInt64('dict_ops', 'n', id) = 0 ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'op notEquals, no rewrite';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE dictGetString('dict_ops', 'name', id) != 'zzz' ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'op less, no rewrite';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE dictGetUInt64('dict_ops', 'n', id) < 100 ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'op lessOrEquals, no rewrite';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE dictGetUInt64('dict_ops', 'n', id) <= 0 ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'op greater, no rewrite';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE 'apple' > dictGetString('dict_ops', 'name', id) ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'op greaterOrEquals, no rewrite';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE dictGetUInt64('dict_ops', 'n', id) >= 0 ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'op like, no rewrite';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE dictGetString('dict_ops', 'name', id) LIKE '%' ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'op notLike, no rewrite';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE dictGetString('dict_ops', 'name', id) NOT LIKE 'a%' ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'op ilike, no rewrite';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE dictGetString('dict_ops', 'name', id) ILIKE '%' ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'op notILike, no rewrite';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE dictGetString('dict_ops', 'name', id) NOT ILIKE 'A%' ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'op match, no rewrite';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE match(dictGetString('dict_ops', 'name', id), '.*') ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+
+-- Per-layout no-rewrite examples (predicate `dictGetString... LIKE '%'` always skips)
+CREATE TABLE ref_layouts_simple (id UInt64, name String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO ref_layouts_simple VALUES (1, 'red');
+CREATE TABLE ref_layouts_complex (k1 UInt64, k2 String, name String) ENGINE = MergeTree ORDER BY (k1, k2);
+INSERT INTO ref_layouts_complex VALUES (1, 'a', 'red');
+
+CREATE DICTIONARY dict_flat (id UInt64, name String) PRIMARY KEY id SOURCE(CLICKHOUSE(TABLE 'ref_layouts_simple')) LAYOUT(FLAT()) LIFETIME(0);
+CREATE DICTIONARY dict_hashed (id UInt64, name String) PRIMARY KEY id SOURCE(CLICKHOUSE(TABLE 'ref_layouts_simple')) LAYOUT(HASHED()) LIFETIME(0);
+CREATE DICTIONARY dict_hashed_array (id UInt64, name String) PRIMARY KEY id SOURCE(CLICKHOUSE(TABLE 'ref_layouts_simple')) LAYOUT(HASHED_ARRAY()) LIFETIME(0);
+CREATE DICTIONARY dict_sparse_hashed (id UInt64, name String) PRIMARY KEY id SOURCE(CLICKHOUSE(TABLE 'ref_layouts_simple')) LAYOUT(SPARSE_HASHED()) LIFETIME(0);
+CREATE DICTIONARY dict_complex (k1 UInt64, k2 String, name String) PRIMARY KEY k1, k2 SOURCE(CLICKHOUSE(TABLE 'ref_layouts_complex')) LAYOUT(COMPLEX_KEY_HASHED()) LIFETIME(0);
+CREATE DICTIONARY dict_complex_array (k1 UInt64, k2 String, name String) PRIMARY KEY k1, k2 SOURCE(CLICKHOUSE(TABLE 'ref_layouts_complex')) LAYOUT(COMPLEX_KEY_HASHED_ARRAY()) LIFETIME(0);
+CREATE DICTIONARY dict_complex_sparse (k1 UInt64, k2 String, name String) PRIMARY KEY k1, k2 SOURCE(CLICKHOUSE(TABLE 'ref_layouts_complex')) LAYOUT(COMPLEX_KEY_SPARSE_HASHED()) LIFETIME(0);
+
+SELECT 'layout Flat, no rewrite';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE dictGetString('dict_flat', 'name', id) LIKE '%' ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'layout Hashed, no rewrite';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE dictGetString('dict_hashed', 'name', id) LIKE '%' ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'layout HashedArray, no rewrite';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE dictGetString('dict_hashed_array', 'name', id) LIKE '%' ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'layout SparseHashed, no rewrite';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE dictGetString('dict_sparse_hashed', 'name', id) LIKE '%' ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'layout ComplexKeyHashed, no rewrite';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE dictGetString('dict_complex', 'name', (id, 'a')) LIKE '%' ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'layout ComplexHashedArray, no rewrite';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE dictGetString('dict_complex_array', 'name', (id, 'a')) LIKE '%' ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'layout ComplexKeySparseHashed, no rewrite';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE dictGetString('dict_complex_sparse', 'name', (id, 'a')) LIKE '%' ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+
+SELECT 'rewrite: equals on non-default - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE dictGetString('dict_hashed', 'name', id) = 'red' ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'rewrite: equals on non-default';
+SELECT id FROM data_ops WHERE dictGetString('dict_hashed', 'name', id) = 'red' ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+SELECT 'rewrite: equals on non-default, opt off';
+SELECT id FROM data_ops WHERE dictGetString('dict_hashed', 'name', id) = 'red' ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 0;
+
+SELECT 'rewrite: greater than non-default - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE dictGetUInt64('dict_ops', 'n', id) > 100 ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'rewrite: greater than non-default';
+SELECT id FROM data_ops WHERE dictGetUInt64('dict_ops', 'n', id) > 100 ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+SELECT 'rewrite: greater than non-default, opt off';
+SELECT id FROM data_ops WHERE dictGetUInt64('dict_ops', 'n', id) > 100 ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 0;
+
+SELECT 'rewrite: != default (numeric) - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE dictGetUInt64('dict_ops', 'n', id) != 0 ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'rewrite: != default (numeric)';
+SELECT id FROM data_ops WHERE dictGetUInt64('dict_ops', 'n', id) != 0 ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+SELECT 'rewrite: != default (numeric), opt off';
+SELECT id FROM data_ops WHERE dictGetUInt64('dict_ops', 'n', id) != 0 ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 0;
+
+SELECT 'rewrite: NOT LIKE default (string) - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE dictGetString('dict_ops', 'name', id) NOT LIKE '' ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'rewrite: NOT LIKE default (string)';
+SELECT id FROM data_ops WHERE dictGetString('dict_ops', 'name', id) NOT LIKE '' ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+SELECT 'rewrite: NOT LIKE default (string), opt off';
+SELECT id FROM data_ops WHERE dictGetString('dict_ops', 'name', id) NOT LIKE '' ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 0;
+
+SELECT 'rewrite: NOT ILIKE default (string) - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT id FROM data_ops WHERE dictGetString('dict_ops', 'name', id) NOT ILIKE '' ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'rewrite: NOT ILIKE default (string)';
+SELECT id FROM data_ops WHERE dictGetString('dict_ops', 'name', id) NOT ILIKE '' ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+SELECT 'rewrite: NOT ILIKE default (string), opt off';
+SELECT id FROM data_ops WHERE dictGetString('dict_ops', 'name', id) NOT ILIKE '' ORDER BY id
+SETTINGS optimize_inverse_dictionary_lookup = 0;
+
+
+SELECT 'rewrite: plain key - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT count() FROM data_ops WHERE dictGetString('dict_ops', 'name', id) = 'apple'
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'rewrite: plain key';
+SELECT count() FROM data_ops WHERE dictGetString('dict_ops', 'name', id) = 'apple'
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+SELECT 'rewrite: plain key, opt off';
+SELECT count() FROM data_ops WHERE dictGetString('dict_ops', 'name', id) = 'apple'
+SETTINGS optimize_inverse_dictionary_lookup = 0;
+
+SELECT 'rewrite: Nullable(K) key - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT count() FROM data_str_nullable WHERE dictGetString('dict_string', 'name', id) = 'abc'
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'rewrite: Nullable(K) key';
+SELECT count() FROM data_str_nullable WHERE dictGetString('dict_string', 'name', id) = 'abc'
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+SELECT 'rewrite: Nullable(K) key, opt off';
+SELECT count() FROM data_str_nullable WHERE dictGetString('dict_string', 'name', id) = 'abc'
+SETTINGS optimize_inverse_dictionary_lookup = 0;
+
+SELECT 'rewrite: LC(Nullable(K)) key - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1 SELECT count() FROM data_str_lc_nullable WHERE dictGetString('dict_string', 'name', id) = 'abc'
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+SELECT 'rewrite: LC(Nullable(K)) key';
+SELECT count() FROM data_str_lc_nullable WHERE dictGetString('dict_string', 'name', id) = 'abc'
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+SELECT 'rewrite: LC(Nullable(K)) key, opt off';
+SELECT count() FROM data_str_lc_nullable WHERE dictGetString('dict_string', 'name', id) = 'abc'
+SETTINGS optimize_inverse_dictionary_lookup = 0;
+
+
+SELECT 'short-circuited bad-regex match: optimization on, returns 0';
+SELECT count() FROM data_ops WHERE id < 0 AND match(dictGetString('dict_ops', 'name', id), '[unclosed')
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+SELECT 'short-circuited bad-regex match: optimization on, returns 0, opt off';
+SELECT count() FROM data_ops WHERE id < 0 AND match(dictGetString('dict_ops', 'name', id), '[unclosed')
+SETTINGS optimize_inverse_dictionary_lookup = 0;
+
+SELECT 'short-circuited bad-regex match, no rewrite - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT count() FROM data_ops WHERE id < 0 AND match(dictGetString('dict_ops', 'name', id), '[unclosed')
+SETTINGS optimize_inverse_dictionary_lookup = 1;
+
+
+-- max_rows_in_set / max_bytes_in_set with set_overflow_mode = 'break': skip to avoid silent truncation
+CREATE TABLE ref_set_limit (id UInt64, name String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO ref_set_limit VALUES (1, 'hit'), (2, 'hit'), (3, 'miss');
+CREATE DICTIONARY dict_set_limit (id UInt64, name String)
+PRIMARY KEY id SOURCE(CLICKHOUSE(TABLE 'ref_set_limit')) LAYOUT(HASHED()) LIFETIME(0);
+CREATE TABLE data_set_limit (id UInt64) ENGINE = MergeTree ORDER BY id;
+INSERT INTO data_set_limit VALUES (1), (2), (3);
+
+SELECT 'max_rows_in_set + break, no rewrite - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT groupArray(id) FROM data_set_limit WHERE dictGetString('dict_set_limit', 'name', id) = 'hit'
+SETTINGS optimize_inverse_dictionary_lookup = 1, max_rows_in_set = 1, set_overflow_mode = 'break';
+
+SELECT 'max_rows_in_set + break, no rewrite';
+SELECT groupArray(id) FROM data_set_limit WHERE dictGetString('dict_set_limit', 'name', id) = 'hit'
+SETTINGS optimize_inverse_dictionary_lookup = 1, max_rows_in_set = 1, set_overflow_mode = 'break';
+SELECT 'max_rows_in_set + throw, rewrite - plan';
+EXPLAIN SYNTAX run_query_tree_passes=1
+SELECT groupArray(id) FROM data_set_limit WHERE dictGetString('dict_set_limit', 'name', id) = 'hit'
+SETTINGS optimize_inverse_dictionary_lookup = 1, max_rows_in_set = 1, set_overflow_mode = 'throw';
+
+SELECT 'max_rows_in_set + throw: execution raises SET_SIZE_LIMIT_EXCEEDED';
+SELECT groupArray(id) FROM data_set_limit WHERE dictGetString('dict_set_limit', 'name', id) = 'hit'
+SETTINGS optimize_inverse_dictionary_lookup = 1, max_rows_in_set = 1, set_overflow_mode = 'throw'; -- { serverError SET_SIZE_LIMIT_EXCEEDED }
+
+SELECT 'max_bytes_in_set + break, no rewrite';
+SELECT groupArray(id) FROM data_set_limit WHERE dictGetString('dict_set_limit', 'name', id) = 'hit'
+SETTINGS optimize_inverse_dictionary_lookup = 1, max_bytes_in_set = 1, set_overflow_mode = 'break';
+
+
+DROP DICTIONARY dict_int_default_minus1;
+DROP DICTIONARY dict_int_nullable_default_minus1;
+DROP DICTIONARY dict_string;
+DROP DICTIONARY dict_complex_str;
+DROP DICTIONARY dict_nullable_attr_stored;
+DROP DICTIONARY dict_complex_nullable_dict_key;
+DROP DICTIONARY dict_set_limit;
+DROP DICTIONARY dict_ops;
+DROP DICTIONARY dict_flat;
+DROP DICTIONARY dict_hashed;
+DROP DICTIONARY dict_hashed_array;
+DROP DICTIONARY dict_sparse_hashed;
+DROP DICTIONARY dict_complex;
+DROP DICTIONARY dict_complex_array;
+DROP DICTIONARY dict_complex_sparse;
+DROP TABLE ref_int;
+DROP TABLE ref_int_nullable;
+DROP TABLE ref_str;
+DROP TABLE ref_complex_str;
+DROP TABLE ref_nullable_attr_stored;
+DROP TABLE ref_complex_nullable_dict_key;
+DROP TABLE ref_set_limit;
+DROP TABLE ref_ops;
+DROP TABLE ref_layouts_simple;
+DROP TABLE ref_layouts_complex;
+DROP TABLE data_int;
+DROP TABLE data_str;
+DROP TABLE data_str_nullable;
+DROP TABLE data_str_lc_nullable;
+DROP TABLE data_complex;
+DROP TABLE data_complex_lc_nullable;
+DROP TABLE data_complex_nullable_dict_key;
+DROP TABLE data_outer_nullable_tuple;
+DROP TABLE data_set_limit;
+DROP TABLE data_ops;

--- a/tests/queries/0_stateless/04202_inverse_dictionary_lookup_pruning_key_condition.reference
+++ b/tests/queries/0_stateless/04202_inverse_dictionary_lookup_pruning_key_condition.reference
@@ -1,0 +1,63 @@
+-- { echo }
+
+SET enable_analyzer = 1;
+SET optimize_or_like_chain = 0;
+DROP TABLE IF EXISTS pruning_ref;
+DROP TABLE IF EXISTS pruning_data;
+DROP DICTIONARY IF EXISTS pruning_dict;
+CREATE TABLE pruning_ref (id UInt64, name String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO pruning_ref VALUES (4242, 'match');
+CREATE DICTIONARY pruning_dict (id UInt64, name String)
+PRIMARY KEY id SOURCE(CLICKHOUSE(TABLE 'pruning_ref')) LAYOUT(HASHED()) LIFETIME(0);
+CREATE TABLE pruning_data (id UInt64) ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 100, add_minmax_index_for_numeric_columns = 0;
+SYSTEM STOP MERGES pruning_data;
+INSERT INTO pruning_data SELECT number FROM numbers(10000);
+-- With optimization: predicate becomes `id IN (SELECT id FROM dictionary(...) WHERE name = 'match')`.
+SET optimize_inverse_dictionary_lookup = 1;
+EXPLAIN indexes = 1
+SELECT count() FROM pruning_data
+WHERE dictGetString('pruning_dict', 'name', id) = 'match';
+CreatingSets (Create sets before main query execution)
+  Expression ((Project names + Projection))
+    Aggregating
+      Expression (Before GROUP BY)
+        Filter ((WHERE + Change column names to column identifiers))
+          ReadFromMergeTree (default.pruning_data)
+          Indexes:
+            PrimaryKey
+              Keys:
+                id
+              Condition: (id in 1-element set)
+              Parts: 1/1
+              Granules: 1/100
+              Search Algorithm: binary search
+            Ranges: 1
+-- Without optimization: `dictGet(...)` is stays, so all granules are scanned.
+SET optimize_inverse_dictionary_lookup = 0;
+EXPLAIN indexes = 1
+SELECT count() FROM pruning_data
+WHERE dictGetString('pruning_dict', 'name', id) = 'match';
+Expression ((Project names + Projection))
+  Aggregating
+    Expression (Before GROUP BY)
+      Filter ((WHERE + Change column names to column identifiers))
+        ReadFromMergeTree (default.pruning_data)
+        Indexes:
+          PrimaryKey
+            Condition: true
+            Parts: 1/1
+            Granules: 100/100
+          Ranges: 1
+-- Result are same
+SET optimize_inverse_dictionary_lookup = 1;
+SELECT count() FROM pruning_data
+WHERE dictGetString('pruning_dict', 'name', id) = 'match';
+1
+SET optimize_inverse_dictionary_lookup = 0;
+SELECT count() FROM pruning_data
+WHERE dictGetString('pruning_dict', 'name', id) = 'match';
+1
+DROP DICTIONARY pruning_dict;
+DROP TABLE pruning_data;
+DROP TABLE pruning_ref;

--- a/tests/queries/0_stateless/04202_inverse_dictionary_lookup_pruning_key_condition.sql
+++ b/tests/queries/0_stateless/04202_inverse_dictionary_lookup_pruning_key_condition.sql
@@ -1,5 +1,6 @@
 -- Tags: no-replicated-database, no-parallel-replicas, no-random-merge-tree-settings
--- no-parallel, no-parallel-replicas: Dictionary is not created in parallel replicas.
+-- no-replicated-database: EXPLAIN output differs for replicated database.
+-- no-parallel-replicas: Dictionary is not available on parallel-replica workers.
 
 -- { echo }
 

--- a/tests/queries/0_stateless/04202_inverse_dictionary_lookup_pruning_key_condition.sql
+++ b/tests/queries/0_stateless/04202_inverse_dictionary_lookup_pruning_key_condition.sql
@@ -1,0 +1,48 @@
+-- Tags: no-replicated-database, no-parallel-replicas, no-random-merge-tree-settings
+-- no-parallel, no-parallel-replicas: Dictionary is not created in parallel replicas.
+
+-- { echo }
+
+SET enable_analyzer = 1;
+SET optimize_or_like_chain = 0;
+
+DROP TABLE IF EXISTS pruning_ref;
+DROP TABLE IF EXISTS pruning_data;
+DROP DICTIONARY IF EXISTS pruning_dict;
+
+CREATE TABLE pruning_ref (id UInt64, name String) ENGINE = MergeTree ORDER BY id;
+INSERT INTO pruning_ref VALUES (4242, 'match');
+
+CREATE DICTIONARY pruning_dict (id UInt64, name String)
+PRIMARY KEY id SOURCE(CLICKHOUSE(TABLE 'pruning_ref')) LAYOUT(HASHED()) LIFETIME(0);
+
+CREATE TABLE pruning_data (id UInt64) ENGINE = MergeTree ORDER BY id
+SETTINGS index_granularity = 100, add_minmax_index_for_numeric_columns = 0;
+
+SYSTEM STOP MERGES pruning_data;
+INSERT INTO pruning_data SELECT number FROM numbers(10000);
+
+-- With optimization: predicate becomes `id IN (SELECT id FROM dictionary(...) WHERE name = 'match')`.
+SET optimize_inverse_dictionary_lookup = 1;
+EXPLAIN indexes = 1
+SELECT count() FROM pruning_data
+WHERE dictGetString('pruning_dict', 'name', id) = 'match';
+
+-- Without optimization: `dictGet(...)` is stays, so all granules are scanned.
+SET optimize_inverse_dictionary_lookup = 0;
+EXPLAIN indexes = 1
+SELECT count() FROM pruning_data
+WHERE dictGetString('pruning_dict', 'name', id) = 'match';
+
+-- Result are same
+SET optimize_inverse_dictionary_lookup = 1;
+SELECT count() FROM pruning_data
+WHERE dictGetString('pruning_dict', 'name', id) = 'match';
+
+SET optimize_inverse_dictionary_lookup = 0;
+SELECT count() FROM pruning_data
+WHERE dictGetString('pruning_dict', 'name', id) = 'match';
+
+DROP DICTIONARY pruning_dict;
+DROP TABLE pruning_data;
+DROP TABLE pruning_ref;


### PR DESCRIPTION
#### Rows dropped when `const` was equal to dictionary `default` value
```sql
DROP DICTIONARY IF EXISTS d; DROP TABLE IF EXISTS r; DROP TABLE IF EXISTS t;
CREATE TABLE r (k UInt64, v Int32) ENGINE = MergeTree ORDER BY k; INSERT INTO r VALUES (1, 100);
CREATE DICTIONARY d (k UInt64, v Int32 DEFAULT -1) PRIMARY KEY k SOURCE(CLICKHOUSE(TABLE 'r')) LAYOUT(HASHED()) LIFETIME(0);
CREATE TABLE t (id UInt64) ENGINE = MergeTree ORDER BY id; INSERT INTO t VALUES (999);
SELECT count() FROM t WHERE dictGet('d', 'v', id) = -1; -- returns 0; should be 1
```

#### `dictGetOrNull` rewrite collapses NULL into 0
```sql
DROP DICTIONARY IF EXISTS d; DROP TABLE IF EXISTS r; DROP TABLE IF EXISTS t;
CREATE TABLE r (k UInt64, name String) ENGINE = MergeTree ORDER BY k; INSERT INTO r VALUES (1, 'abc');
CREATE DICTIONARY d (k UInt64, name String) PRIMARY KEY k SOURCE(CLICKHOUSE(TABLE 'r')) LAYOUT(HASHED()) LIFETIME(0);
CREATE TABLE t (id UInt64) ENGINE = MergeTree ORDER BY id; INSERT INTO t VALUES (1), (999);
SELECT id, dictGetOrNull('d', 'name', id) = 'abc' FROM t ORDER BY id;
-- returns (1,1) (999,0); should be (1,1) (999,NULL)
```

#### Rows dropped when attribute column is `Nullable` and contains `NULL`

```sql
DROP DICTIONARY IF EXISTS d; DROP TABLE IF EXISTS r; DROP TABLE IF EXISTS t;
CREATE TABLE r (k UInt64, name Nullable(String)) ENGINE = MergeTree ORDER BY k; INSERT INTO r VALUES (1, 'abc'), (2, NULL);
CREATE DICTIONARY d (k UInt64, name Nullable(String) DEFAULT 'missing') PRIMARY KEY k SOURCE(CLICKHOUSE(TABLE 'r')) LAYOUT(HASHED()) LIFETIME(0);
CREATE TABLE t (id UInt64) ENGINE = MergeTree ORDER BY id; INSERT INTO t VALUES (1), (2), (3);
SELECT count() FROM t WHERE isNull(dictGet('d', 'name', id) = 'abc'); -- returns 0; should be 1
```

#### Complex key with `Nullable` sub-key stops throwing exception
```sql
DROP DICTIONARY IF EXISTS d; DROP TABLE IF EXISTS r; DROP TABLE IF EXISTS t;
CREATE TABLE r (k1 UInt64, k2 String, name String) ENGINE = MergeTree ORDER BY (k1, k2); INSERT INTO r VALUES (1, 'a', 'abc');
CREATE DICTIONARY d (k1 UInt64, k2 String, name String) PRIMARY KEY k1, k2 SOURCE(CLICKHOUSE(TABLE 'r')) LAYOUT(COMPLEX_KEY_HASHED()) LIFETIME(0);
CREATE TABLE t (k1 Nullable(UInt64), k2 String) ENGINE = MergeTree ORDER BY tuple(); INSERT INTO t VALUES (NULL, 'a'), (1, 'a');
SELECT count() FROM t WHERE dictGetString('d', 'name', (k1, k2)) = 'abc'; -- works; but should throw `CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN`
```

#### Different attribute type to `dictGet*` family return type stops throwing exception

```sql
DROP DICTIONARY IF EXISTS d; DROP TABLE IF EXISTS r; DROP TABLE IF EXISTS t;
CREATE TABLE r (k UInt64, n UInt64) ENGINE = MergeTree ORDER BY k; INSERT INTO r VALUES (1, 5);
CREATE DICTIONARY d (k UInt64, n UInt64) PRIMARY KEY k SOURCE(CLICKHOUSE(TABLE 'r')) LAYOUT(HASHED()) LIFETIME(0);
CREATE TABLE t (id UInt64) ENGINE = MergeTree ORDER BY id; INSERT INTO t VALUES (1);
SELECT count() FROM t WHERE dictGetInt32('d', 'n', id) >= 2; -- works; but should throw `TYPE_MISMATCH`
```

#### Wrong answer with `set_overflow_mode='break'`

```sql
DROP DICTIONARY IF EXISTS d; DROP TABLE IF EXISTS r; DROP TABLE IF EXISTS t;
CREATE TABLE r (k UInt64, name String) ENGINE = MergeTree ORDER BY k; INSERT INTO r VALUES (1, 'hit'), (2, 'hit'), (3, 'miss');
CREATE DICTIONARY d (k UInt64, name String) PRIMARY KEY k SOURCE(CLICKHOUSE(TABLE 'r')) LAYOUT(HASHED()) LIFETIME(0);
CREATE TABLE t (id UInt64) ENGINE = MergeTree ORDER BY id; INSERT INTO t VALUES (1), (2), (3);
SELECT groupArray(id) FROM t WHERE dictGetString('d', 'name', id) = 'hit' SETTINGS max_rows_in_set = 1, set_overflow_mode = 'break';  -- returns []; but should be [1,2]
```

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix several edge case correctness issues in setting `optimize_inverse_dictionary_lookup` where the optimization could silently drop rows or suppress exceptions. Closes https://github.com/ClickHouse/ClickHouse/issues/103270. Close https://github.com/ClickHouse/ClickHouse/issues/103085.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.424`
- Backported to: `26.4.3.3`, `26.3.11.5`, `26.2.19.10`
<!-- ch-version-info:end -->