### PR TITLE
Set charset=utf-8 on text uploads to S3 for CI logs

### DIFF
--- a/ci/praktika/s3.py
+++ b/ci/praktika/s3.py
@@ -125,7 +125,7 @@ class S3:
                     inferred_content_type, _ = mimetypes.guess_type(key)
 
                 if text and not content_type:
-                    extra_args["ContentType"] = "text/plain"
+                    extra_args["ContentType"] = "text/plain; charset=utf-8"
                 elif content_type:
                     extra_args["ContentType"] = content_type
                 elif inferred_content_type:
@@ -169,7 +169,7 @@ class S3:
             # boto3 not available, use AWS CLI
             cmd = f"aws s3 cp {local_path} s3://{s3_full_path}"
             if text and not content_type:
-                cmd += " --content-type text/plain"
+                cmd += ' --content-type "text/plain; charset=utf-8"'
             elif content_type:
                 cmd += f" --content-type {content_type}"
             if content_encoding:
@@ -243,7 +243,7 @@ class S3:
                 command += f" --metadata {k}={v}"
 
         if text:
-            command += " --content-type text/plain"
+            command += ' --content-type "text/plain; charset=utf-8"'
         res = cls.run_command_with_retries(command, no_strict=no_strict)
         if res:
             StorageUsage.add_uploaded(local_path)
@@ -585,7 +585,9 @@ class S3:
                     client = cls._get_boto3_client()
                     extra_args = {
                         "ContentType": (
-                            "text/plain" if text else "application/octet-stream"
+                            "text/plain; charset=utf-8"
+                            if text
+                            else "application/octet-stream"
                         ),
                         "Metadata": {"version": str(version)},
                     }
@@ -621,7 +623,7 @@ class S3:
                                 Key=key,
                                 Body=f,
                                 ContentType=(
-                                    "text/plain"
+                                    "text/plain; charset=utf-8"
                                     if text
                                     else "application/octet-stream"
                                 ),
@@ -694,8 +696,12 @@ class S3:
                     return False
 
                 # Upload with If-Match condition
-                content_type = "text/plain" if text else "application/octet-stream"
-                command = f'aws s3api put-object --bucket {bucket} --key {key} --body {local_path} --content-type {content_type} --metadata version={version} --if-match "{current_etag}"'
+                content_type = (
+                    "text/plain; charset=utf-8"
+                    if text
+                    else "application/octet-stream"
+                )
+                command = f'aws s3api put-object --bucket {bucket} --key {key} --body {local_path} --content-type "{content_type}" --metadata version={version} --if-match "{current_etag}"'
                 res = cls.run_command_with_retries(command, no_strict=no_strict)
                 if not res:
                     print("Failed to put file (precondition failed or other error)")


### PR DESCRIPTION
CI logs (and other text artifacts) are valid UTF-8, but `ci/praktika/s3.py` uploaded them with `Content-Type: text/plain` (no charset). Browsers fall back to Latin-1 in that case, so an em-dash `—` from system-table `COMMENT` text rendered as `â€—`.

Example log with the broken rendering: https://s3.amazonaws.com/clickhouse-test-reports/PRs/104097/a1f746ae407f13695591735e3a509b1136c036a2/stateless_tests_amd_tsan_flaky_check/job.log

The bytes themselves are valid UTF-8 (`e2 80 94` = U+2014 em-dash), so this is a server-header issue, not a content issue. The em-dashes originate from human-readable `COMMENT` text in source files like `src/Interpreters/AsynchronousInsertLog.cpp`, `OpenTelemetrySpanLog.cpp`, `PartLog.cpp`.

Set the charset explicitly on every text upload path in `ci/praktika/s3.py` (boto3 and AWS CLI, plain and versioned).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.312`
<!-- ch-version-info:end -->