### PR TITLE
Fix memory leak with materialized CTE

### DIFF
--- a/src/Interpreters/MaterializedCTE.h
+++ b/src/Interpreters/MaterializedCTE.h
@@ -63,5 +63,6 @@ struct MaterializedCTE
 };
 
 using MaterializedCTEPtr = std::shared_ptr<MaterializedCTE>;
+using MaterializedCTEWeakPtr = std::weak_ptr<MaterializedCTE>;
 
 }

--- a/src/Storages/StorageMemory.h
+++ b/src/Storages/StorageMemory.h
@@ -126,8 +126,12 @@ public:
       */
     void delayReadForGlobalSubqueries() { delay_read_for_global_subqueries = true; }
 
-    void setMaterializedCTE(MaterializedCTEPtr materialized_cte_) { materialized_cte = std::move(materialized_cte_); }
-    const MaterializedCTEPtr & getMaterializedCTE() const { return materialized_cte; }
+    /// Stored as a weak_ptr to break the reference cycle: MaterializedCTE owns the StorageMemory
+    /// (via its `storage` and `table_holder` members), and this back-pointer lets us recover the
+    /// CTE descriptor from the storage. If we kept a shared_ptr here, neither object would ever
+    /// be destroyed, and the temporary table would never be removed from `DatabaseMemory`.
+    void setMaterializedCTE(MaterializedCTEPtr materialized_cte_) { materialized_cte = materialized_cte_; }
+    MaterializedCTEPtr getMaterializedCTE() const { return materialized_cte.lock(); }
 
 private:
     static VirtualColumnsDescription createVirtuals();
@@ -142,7 +146,7 @@ private:
     mutable std::mutex mutex;
 
     bool delay_read_for_global_subqueries = false;
-    MaterializedCTEPtr materialized_cte;
+    MaterializedCTEWeakPtr materialized_cte;
 
     std::atomic<size_t> total_size_bytes = 0;
     std::atomic<size_t> total_size_rows = 0;


### PR DESCRIPTION
LeakSanitizer in CI reported leaked `StorageMemory` instances allocated via `TemporaryTableHolder` from `QueryAnalyzer::resolveQueryJoinTreeNode` when resolving `WITH ... AS MATERIALIZED` queries (115704 bytes leaked in 532 allocations on a single shard).

The leak is a `shared_ptr` cycle between `StorageMemory` and `MaterializedCTE`:

```
StorageMemory --shared_ptr--> MaterializedCTE
       ^                              |
       |                              | shared_ptr (storage + table_holder)
       |                              v
       +----------------- StorageMemory
```

`StorageMemory::materialized_cte` was a `MaterializedCTEPtr` (owning), and `MaterializedCTE` kept a `StoragePtr` plus a `TemporaryTableHolder` whose destructor is what removes the temporary table from `DatabaseMemory`. Because of the cycle, neither object was ever destroyed, so the temporary table also stayed alive for the rest of the server's lifetime.

Demote the back-pointer in `StorageMemory` to `weak_ptr<MaterializedCTE>`. The forward owning edge (`MaterializedCTE → StorageMemory`) is preserved; the back-pointer is purely a lookup hook used by `extractCTE`, `RemoteQueryExecutor`, and `ReadFromMemoryStorageStep`, all of which capture the result by value, so adding `.lock()` is a no-op for them.

Failure URL: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=30d0aed4453fd0d3bbfa15f4c3871d9eb205b1a9&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_asan_ubsan%2C%20distributed%20plan%2C%20parallel%2C%201%2F2%29

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a memory leak when running queries with `MATERIALIZED` CTEs.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.334`
- Backported to: `26.4.2.8`, `26.3.10.57`
<!-- ch-version-info:end -->