### PR TITLE
Code review skill: flag `rm -rf` with unescaped substitution as a Blocker

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -205,6 +205,63 @@ Workflow:
 
 5. **Verify test coverage.** The PR's tests must include adversarial edge cases that the original caller would never produce: empty inputs, minimal-length inputs, malformed inputs, NULLs, maximum-length inputs.
 
+**12) Shell-command safety in Python / shell scripts**
+
+Even though Python and shell scripts are secondary to C++ review, **destructive or privileged shell commands with unquoted substitution are a blocker, not a nit**. They are easy to write, easy to miss in review, and have catastrophic blast radius (`rm -rf` on the wrong path, command injection, accidental deletion of unrelated files). Always flag them.
+
+Patterns to flag — any of these is a Blocker (or Major if the substituted value is provably constant in the immediate caller, but the construct is still fragile and should be rewritten):
+
+- **`rm -rf` and other destructive commands with f-string / `%`-format / `+`-concat substitution** passed to `subprocess.run(..., shell=True)`, `subprocess.Popen(..., shell=True)`, `os.system`, `os.popen`, `commands.getoutput`, or any in-tree wrapper that uses `shell=True` under the hood (e.g. ClickHouse's `Shell.check` / `Shell.run` / `Shell.get_output` in `ci/praktika/utils.py` and `tests/ci/ci_utils.py` — all of which call `subprocess.run(..., shell=True, executable="/bin/bash", ...)`). Examples of destructive/privileged commands: `rm`, `rm -rf`, `mv`, `cp -r`, `find ... -delete`, `chmod`, `chown`, `chgrp`, `mkfs`, `mount`, `umount`, `dd`, `kill`, `pkill`, `sudo …`.
+- **Backticks or `$(…)` in shell scripts that interpolate variables into destructive commands** without `"…"` quoting (e.g. `rm -rf $dir/.tmp` without quotes around `"$dir"`).
+- **Path concatenation with `+` or `f"{a}/{b}"` for filesystem operations** when a `pathlib.Path` is already in scope — even when it doesn't go to a shell, mixing string paths and `Path` objects loses the type discipline that prevents these bugs from creeping in.
+
+Bad — every line below is a Blocker:
+
+```python
+Shell.check(f"rm -rf {dest}/.repodata", strict=True)        # ClickHouse Shell wrapper uses shell=True
+subprocess.run(f"rm -rf {tmp}", shell=True, check=True)
+subprocess.run(f"rm -rf {tmp}/*", shell=True)               # globbing AND substitution
+os.system(f"rm -rf {var}")
+os.system("rm -rf " + path)
+Shell.check(f"mv {src} {dst}", strict=True)
+```
+
+```bash
+# In a .sh script
+rm -rf $TMP_DIR/.repodata        # unquoted variable
+rm -rf "$TMP_DIR"/*              # globbing — if $TMP_DIR is empty, becomes `rm -rf /*`
+find $DIR -name '*.tmp' -delete  # unquoted $DIR
+```
+
+Good — preferred replacements:
+
+```python
+# 1. Use Python directly — no shell at all (best for filesystem operations).
+import shutil
+from pathlib import Path
+shutil.rmtree(Path(dest) / ".repodata", ignore_errors=True)
+
+# 2. If a subprocess is genuinely required, pass argv as a list — no shell, no quoting bugs.
+subprocess.run(["rm", "-rf", "--", str(Path(dest) / ".repodata")], check=True)
+
+# 3. If a shell wrapper is the only option (e.g. complex pipelines), use shlex.quote on every
+#    substituted value AND a `--` argument terminator where supported.
+import shlex
+Shell.check(f"rm -rf -- {shlex.quote(str(stale_repodata))}", strict=True)
+```
+
+```bash
+# In .sh: always quote, always use `--` when the command supports it
+rm -rf -- "${TMP_DIR}/.repodata"
+find "${DIR}" -name '*.tmp' -delete
+```
+
+Why this is a Blocker, not a nit:
+- Even if today the substituted value is "obviously safe", paths flow through environment variables, CI parameters, S3 keys, user names, and external configuration — any of which can introduce a space, a `;`, a `&&`, a `*`, a `~`, or an empty string. An empty `$VAR` plus `rm -rf "$VAR"/*` deletes the filesystem root. `rm -rf $VAR` with a space in `$VAR` deletes whatever happens to match the second token.
+- The fix is small and uniformly safer; there is no reason to keep the unquoted form.
+- `subprocess.run(shell=True)` with an f-string is the Python equivalent of `eval` for shell. ClickHouse's `Shell.check` looks like a benign helper but is exactly this construct — wrappers do not make it safe.
+
+When you find one of these, propose the concrete `shutil.rmtree` / argv-list / `shlex.quote` replacement in the suggested fix, do not just say "use quoting".
 
 CLICKHOUSE RULES (MANDATORY)
 - **Deletion logging**
@@ -244,6 +301,7 @@ SEVERITY MODEL – WHAT DESERVES A COMMENT
 - Security or privilege issues, or license incompatibility.
 - Server-side file access with user-controlled paths that bypass `user_files_path` or equivalent restrictions.
 - Large binary files (JARs, archives, datasets, compiled artifacts) committed to git — permanent, irreversible repo bloat.
+- Destructive or privileged shell commands (`rm -rf`, `mv`, `find … -delete`, `chmod`, `chown`, `dd`, `kill`, `sudo …`, etc.) constructed via string interpolation and passed to `shell=True` (`subprocess.run`/`Popen`, `os.system`, `Shell.check`/`Shell.run` and similar wrappers), or unquoted variables in destructive shell-script commands. See checklist item **12) Shell-command safety**.
 
 **Majors** – serious but not catastrophic
 - Under-tested important edge cases or error paths.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -206,62 +206,9 @@ Workflow:
 5. **Verify test coverage.** The PR's tests must include adversarial edge cases that the original caller would never produce: empty inputs, minimal-length inputs, malformed inputs, NULLs, maximum-length inputs.
 
 **12) Shell-command safety in Python / shell scripts**
-
-Even though Python and shell scripts are secondary to C++ review, **destructive or privileged shell commands with unquoted substitution are a blocker, not a nit**. They are easy to write, easy to miss in review, and have catastrophic blast radius (`rm -rf` on the wrong path, command injection, accidental deletion of unrelated files). Always flag them.
-
-Patterns to flag — any of these is a Blocker (or Major if the substituted value is provably constant in the immediate caller, but the construct is still fragile and should be rewritten):
-
-- **`rm -rf` and other destructive commands with f-string / `%`-format / `+`-concat substitution** passed to `subprocess.run(..., shell=True)`, `subprocess.Popen(..., shell=True)`, `os.system`, `os.popen`, `commands.getoutput`, or any in-tree wrapper that uses `shell=True` under the hood (e.g. ClickHouse's `Shell.check` / `Shell.run` / `Shell.get_output` in `ci/praktika/utils.py` and `tests/ci/ci_utils.py` — all of which call `subprocess.run(..., shell=True, executable="/bin/bash", ...)`). Examples of destructive/privileged commands: `rm`, `rm -rf`, `mv`, `cp -r`, `find ... -delete`, `chmod`, `chown`, `chgrp`, `mkfs`, `mount`, `umount`, `dd`, `kill`, `pkill`, `sudo …`.
-- **Backticks or `$(…)` in shell scripts that interpolate variables into destructive commands** without `"…"` quoting (e.g. `rm -rf $dir/.tmp` without quotes around `"$dir"`).
-- **Path concatenation with `+` or `f"{a}/{b}"` for filesystem operations** when a `pathlib.Path` is already in scope — even when it doesn't go to a shell, mixing string paths and `Path` objects loses the type discipline that prevents these bugs from creeping in.
-
-Bad — every line below is a Blocker:
-
-```python
-Shell.check(f"rm -rf {dest}/.repodata", strict=True)        # ClickHouse Shell wrapper uses shell=True
-subprocess.run(f"rm -rf {tmp}", shell=True, check=True)
-subprocess.run(f"rm -rf {tmp}/*", shell=True)               # globbing AND substitution
-os.system(f"rm -rf {var}")
-os.system("rm -rf " + path)
-Shell.check(f"mv {src} {dst}", strict=True)
-```
-
-```bash
-# In a .sh script
-rm -rf $TMP_DIR/.repodata        # unquoted variable
-rm -rf "$TMP_DIR"/*              # globbing — if $TMP_DIR is empty, becomes `rm -rf /*`
-find $DIR -name '*.tmp' -delete  # unquoted $DIR
-```
-
-Good — preferred replacements:
-
-```python
-# 1. Use Python directly — no shell at all (best for filesystem operations).
-import shutil
-from pathlib import Path
-shutil.rmtree(Path(dest) / ".repodata", ignore_errors=True)
-
-# 2. If a subprocess is genuinely required, pass argv as a list — no shell, no quoting bugs.
-subprocess.run(["rm", "-rf", "--", str(Path(dest) / ".repodata")], check=True)
-
-# 3. If a shell wrapper is the only option (e.g. complex pipelines), use shlex.quote on every
-#    substituted value AND a `--` argument terminator where supported.
-import shlex
-Shell.check(f"rm -rf -- {shlex.quote(str(stale_repodata))}", strict=True)
-```
-
-```bash
-# In .sh: always quote, always use `--` when the command supports it
-rm -rf -- "${TMP_DIR}/.repodata"
-find "${DIR}" -name '*.tmp' -delete
-```
-
-Why this is a Blocker, not a nit:
-- Even if today the substituted value is "obviously safe", paths flow through environment variables, CI parameters, S3 keys, user names, and external configuration — any of which can introduce a space, a `;`, a `&&`, a `*`, a `~`, or an empty string. An empty `$VAR` plus `rm -rf "$VAR"/*` deletes the filesystem root. `rm -rf $VAR` with a space in `$VAR` deletes whatever happens to match the second token.
-- The fix is small and uniformly safer; there is no reason to keep the unquoted form.
-- `subprocess.run(shell=True)` with an f-string is the Python equivalent of `eval` for shell. ClickHouse's `Shell.check` looks like a benign helper but is exactly this construct — wrappers do not make it safe.
-
-When you find one of these, propose the concrete `shutil.rmtree` / argv-list / `shlex.quote` replacement in the suggested fix, do not just say "use quoting".
+- Destructive or privileged commands (`rm -rf`, `mv`, `cp -r`, `find … -delete`, `chmod`, `chown`, `dd`, `kill`, `sudo …`) with substituted arguments passed to `shell=True` (`subprocess.run`/`Popen`, `os.system`) or to in-tree wrappers that use `shell=True` under the hood (ClickHouse's `Shell.check` / `Shell.run` / `Shell.get_output`).
+- Unquoted variables in destructive commands inside `.sh` scripts.
+- Prefer `shutil.rmtree` or argv-list `subprocess.run`; if a shell wrapper is unavoidable, use `shlex.quote` and `--`.
 
 CLICKHOUSE RULES (MANDATORY)
 - **Deletion logging**
@@ -301,7 +248,7 @@ SEVERITY MODEL – WHAT DESERVES A COMMENT
 - Security or privilege issues, or license incompatibility.
 - Server-side file access with user-controlled paths that bypass `user_files_path` or equivalent restrictions.
 - Large binary files (JARs, archives, datasets, compiled artifacts) committed to git — permanent, irreversible repo bloat.
-- Destructive or privileged shell commands (`rm -rf`, `mv`, `find … -delete`, `chmod`, `chown`, `dd`, `kill`, `sudo …`, etc.) constructed via string interpolation and passed to `shell=True` (`subprocess.run`/`Popen`, `os.system`, `Shell.check`/`Shell.run` and similar wrappers), or unquoted variables in destructive shell-script commands. See checklist item **12) Shell-command safety**.
+- Destructive shell commands (`rm -rf`, `mv`, `chmod`, `dd`, `sudo`, …) with unquoted substitution under `shell=True` or in shell scripts.
 
 **Majors** – serious but not catastrophic
 - Under-tested important edge cases or error paths.


### PR DESCRIPTION
The bot review of PR #104127 missed an `rm -rf` command constructed with an f-string and passed to `Shell.check`, which under the hood calls `subprocess.run(..., shell=True, executable="/bin/bash", ...)`. Per @alexey-milovidov's directive on that PR:

> `rm -rf` with unescaped substitution is a screaming code defect. Please update our code review Claude skill so that it will be noticed automatically next time; send a PR with this change.

This PR updates `.claude/skills/review/SKILL.md` so the review skill catches the pattern automatically.

## What changed

1. New checklist item **12) Shell-command safety in Python / shell scripts** in the C++ / ClickHouse risk checklist:
   - Lists destructive/privileged commands to flag (`rm`, `rm -rf`, `mv`, `cp -r`, `find … -delete`, `chmod`, `chown`, `chgrp`, `mkfs`, `mount`, `umount`, `dd`, `kill`, `pkill`, `sudo …`).
   - Names the wrappers that route through `shell=True` under the hood, including ClickHouse's own `Shell.check` / `Shell.run` / `Shell.get_output` in `ci/praktika/utils.py` and `tests/ci/ci_utils.py` — so the skill cannot be fooled by helpers that *look* benign.
   - Bad-vs-good examples covering both Python (`subprocess.run` with `shell=True`, `os.system`, `Shell.check`) and shell scripts (unquoted `$VAR`, `$VAR/*` globbing).
   - Concrete replacements: `shutil.rmtree(Path(...) / ...)`, argv list with `--` terminator, or `shlex.quote(str(...))` when a shell wrapper is genuinely required.
   - Argument for why this is a Blocker, not a nit (paths flow through env vars, CI parameters, S3 keys; an empty `$VAR` plus `rm -rf "$VAR"/*` deletes the filesystem root; the safe fix is small).

2. New entry in the **Severity Model → Blockers** list cross-referencing checklist item 12, so the table-style "Blockers" sweep catches this pattern in addition to the long-form checklist walk.

The change is documentation-only — no code paths are touched.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Documentation entry for user-facing changes
- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.331`
<!-- ch-version-info:end -->