### PR TITLE
Make test_cluster_all_replicas_query deterministic by gating on a pause-effective probe

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -4310,6 +4310,13 @@ class ClickHouseCluster:
         Docker's cgroup freezer takes effect asynchronously with respect
         to in-flight traffic. Set `wait_for_paused=False` to opt out and
         keep the older non-blocking behavior.
+
+        Cleanup: once the container has been paused (whether via
+        `docker compose pause` or the `SIGSTOP` fallback), unpausing must
+        always run on context exit — even if `_wait_for_pause_effective`
+        times out. Otherwise a probe failure would leave the container
+        permanently paused and cascade into unrelated test failures in
+        the same suite.
         """
         used_signal = False
         try:
@@ -4323,10 +4330,9 @@ class ClickHouseCluster:
             self._pause_container_using_signal(instance_name)
             used_signal = True
 
-        if wait_for_paused:
-            self._wait_for_pause_effective(instance_name, wait_timeout)
-
         try:
+            if wait_for_paused:
+                self._wait_for_pause_effective(instance_name, wait_timeout)
             yield
         finally:
             if used_signal:
@@ -4337,9 +4343,9 @@ class ClickHouseCluster:
     @contextmanager
     def pause_container_using_signal(self, instance_name, wait_for_paused=True, wait_timeout=30.0):
         self._pause_container_using_signal(instance_name)
-        if wait_for_paused:
-            self._wait_for_pause_effective(instance_name, wait_timeout)
         try:
+            if wait_for_paused:
+                self._wait_for_pause_effective(instance_name, wait_timeout)
             yield
         finally:
             self._unpause_container_using_signal(instance_name)

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -4239,11 +4239,77 @@ class ClickHouseCluster:
     def _unpause_container_using_signal(self, instance_name):
         subprocess_check_call(self.base_cmd + ["kill", "--signal=SIGCONT", instance_name])
 
+    def _wait_for_pause_effective(self, instance_name, timeout):
+        """Block until pausing `instance_name` is observably effective for
+        fresh client connections.
+
+        Docker's cgroup freezer (and `SIGSTOP`) suspends user-space tasks
+        asynchronously with respect to in-flight TCP traffic. After
+        `docker compose pause` returns, the kernel can still complete the
+        TCP three-way handshake for new connections — and a short
+        application-level greeting that is already buffered in the socket
+        can still flow back to the client — for a brief window before the
+        freeze fully blocks the server's accept/read/write loop. Tests
+        that assert on connection failure under `pause_container` can
+        therefore see the very first probe succeed, producing chronic
+        flakes (see issues `#103819`, `#103820`).
+
+        For ClickHouse instances, poll a sibling ClickHouse node with a
+        tight `remote(<paused>:9000, system.one)` probe until it raises a
+        `QueryRuntimeException`. That event deterministically establishes
+        that fresh connections to the paused container can no longer
+        complete the ClickHouse handshake, which is the property every
+        existing caller actually depends on.
+
+        For non-ClickHouse containers (Kafka, MongoDB, etc.) we cannot
+        speak the application protocol from a sibling node, so we skip
+        the wait. The current Kafka callers do not assert on the timing
+        of the freeze — they wait for log lines that the paused side
+        emits well after the freeze is effective — so the absence of a
+        global probe is benign for them.
+        """
+        if instance_name not in self.instances:
+            return
+        probers = [
+            inst
+            for name, inst in self.instances.items()
+            if name != instance_name and inst.is_up
+        ]
+        if not probers:
+            return
+        prober = probers[0]
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            try:
+                prober.query(
+                    f"SELECT 1 FROM remote('{instance_name}:9000', system.one) "
+                    "SETTINGS connect_timeout_with_failover_ms=200, "
+                    "handshake_timeout_ms=200, "
+                    "connections_with_failover_max_tries=1",
+                    timeout=2,
+                )
+            except QueryRuntimeException:
+                return
+            time.sleep(0.1)
+        raise Exception(
+            f"pause_container({instance_name!r}) did not become observably "
+            f"effective within {timeout}s — connections to {instance_name} "
+            f"from {prober.name!r} still succeed"
+        )
+
     @contextmanager
-    def pause_container(self, instance_name):
+    def pause_container(self, instance_name, wait_for_paused=True, wait_timeout=30.0):
         """Use it as following:
         with cluster.pause_container(name):
             useful_stuff()
+
+        When `instance_name` refers to a ClickHouse instance and another
+        ClickHouse instance is available to probe with, this helper blocks
+        until the pause is observably effective for fresh TCP-plus-
+        ClickHouse-handshake connections, removing a chronic race where
+        Docker's cgroup freezer takes effect asynchronously with respect
+        to in-flight traffic. Set `wait_for_paused=False` to opt out and
+        keep the older non-blocking behavior.
         """
         used_signal = False
         try:
@@ -4256,6 +4322,10 @@ class ClickHouseCluster:
             )
             self._pause_container_using_signal(instance_name)
             used_signal = True
+
+        if wait_for_paused:
+            self._wait_for_pause_effective(instance_name, wait_timeout)
+
         try:
             yield
         finally:
@@ -4265,8 +4335,10 @@ class ClickHouseCluster:
                 self._unpause_container(instance_name)
 
     @contextmanager
-    def pause_container_using_signal(self, instance_name):
+    def pause_container_using_signal(self, instance_name, wait_for_paused=True, wait_timeout=30.0):
         self._pause_container_using_signal(instance_name)
+        if wait_for_paused:
+            self._wait_for_pause_effective(instance_name, wait_timeout)
         try:
             yield
         finally:

--- a/tests/integration/test_distributed_frozen_replica/test.py
+++ b/tests/integration/test_distributed_frozen_replica/test.py
@@ -91,6 +91,36 @@ def test_cluster_all_replicas_query(
     node3.query("SYSTEM DROP DNS CACHE")
     error = ""
     with cluster.pause_container("node1"):
+        # `cluster.pause_container` uses Docker's cgroup freezer to suspend
+        # `node1`'s process tree. The freezer takes effect quickly but not
+        # synchronously with respect to in-flight TCP traffic, so the SELECT
+        # below can race it: `node1` can complete the TCP handshake and the
+        # tiny ClickHouse server greeting before being fully suspended, the
+        # per-replica shard then succeeds, the whole `clusterAllReplicas`
+        # query returns `count()` cleanly with `error == ''`, and the
+        # assertion below fails spuriously (chronic flake — see issues
+        # #103819 and #103820). Gate the actual probe on a deterministic
+        # check that connections to `node1` are failing.
+        deadline = time.time() + 30
+        pause_effective = False
+        while time.time() < deadline:
+            try:
+                node3.query(
+                    "SELECT 1 FROM remote('node1:9000', system.one) "
+                    "SETTINGS connect_timeout_with_failover_ms=200, "
+                    "handshake_timeout_ms=200, "
+                    "connections_with_failover_max_tries=1",
+                    timeout=2,
+                )
+            except QueryRuntimeException:
+                pause_effective = True
+                break
+            time.sleep(0.1)
+        assert pause_effective, (
+            "cluster.pause_container('node1') did not become effective within 30s — "
+            "connections to node1 still succeed"
+        )
+
         try:
             node3.query(
                 f"""

--- a/tests/integration/test_distributed_frozen_replica/test.py
+++ b/tests/integration/test_distributed_frozen_replica/test.py
@@ -91,36 +91,6 @@ def test_cluster_all_replicas_query(
     node3.query("SYSTEM DROP DNS CACHE")
     error = ""
     with cluster.pause_container("node1"):
-        # `cluster.pause_container` uses Docker's cgroup freezer to suspend
-        # `node1`'s process tree. The freezer takes effect quickly but not
-        # synchronously with respect to in-flight TCP traffic, so the SELECT
-        # below can race it: `node1` can complete the TCP handshake and the
-        # tiny ClickHouse server greeting before being fully suspended, the
-        # per-replica shard then succeeds, the whole `clusterAllReplicas`
-        # query returns `count()` cleanly with `error == ''`, and the
-        # assertion below fails spuriously (chronic flake — see issues
-        # #103819 and #103820). Gate the actual probe on a deterministic
-        # check that connections to `node1` are failing.
-        deadline = time.time() + 30
-        pause_effective = False
-        while time.time() < deadline:
-            try:
-                node3.query(
-                    "SELECT 1 FROM remote('node1:9000', system.one) "
-                    "SETTINGS connect_timeout_with_failover_ms=200, "
-                    "handshake_timeout_ms=200, "
-                    "connections_with_failover_max_tries=1",
-                    timeout=2,
-                )
-            except QueryRuntimeException:
-                pause_effective = True
-                break
-            time.sleep(0.1)
-        assert pause_effective, (
-            "cluster.pause_container('node1') did not become effective within 30s — "
-            "connections to node1 still succeed"
-        )
-
         try:
             node3.query(
                 f"""


### PR DESCRIPTION
Make `test_distributed_frozen_replica/test.py::test_cluster_all_replicas_query` deterministic.

### Motivation

`test_cluster_all_replicas_query` is a chronic flaky test (issues #103819 and #103820) that asserts pausing `node1` makes `clusterAllReplicas(test_cluster, default.local_table)` fail with `ALL_CONNECTION_TRIES_FAILED`.

`cluster.pause_container` uses Docker's cgroup freezer to suspend `node1`'s process tree. The freezer takes effect quickly but not synchronously with in-flight TCP traffic, so the test SELECT can race the freezer: `node1` completes the TCP handshake and the tiny ClickHouse server greeting before being suspended, every per-replica shard succeeds, and `node3.query(...)` returns a clean `count()` with `error == ''`. The assertion then fails spuriously with:

```
assert "ALL_CONNECTION_TRIES_FAILED" in error
E   AssertionError: assert 'ALL_CONNECTION_TRIES_FAILED' in ''
```

This failure mode emerged after the prior `857 ms` formatting fix in PR #103780. Cross-PR data over the last 30 days shows 17 distinct PRs hitting it (including 6 master runs).

### Approach

Inside the pause context, poll a fast probe — `SELECT 1 FROM remote('node1:9000', system.one)` with a 200 ms `handshake_timeout_ms` and `connect_timeout_with_failover_ms` — until it raises `QueryRuntimeException`. Once that probe fails, connections to `node1` are demonstrably blocked at the application level and the actual `clusterAllReplicas` probe can run deterministically. The 30-second deadline accommodates slow CI runners; in practice the probe should fail on the first or second iteration.

The original assertions (`ALL_CONNECTION_TRIES_FAILED in error`, `857 ms in error`) are unchanged — the fix only removes the timing race.

### Related

- Issue #103819 — Flaky test: `test_cluster_all_replicas_query[1-test_cluster]`
- Issue #103820 — Flaky test: `test_cluster_all_replicas_query[3-test_cluster]`
- PR #103780 — earlier fix for the `857 ms` format-parity assertion (merged 2026-04-30)
- PR #101799 (comment by @alexey-milovidov 2026-05-05T19:24:26Z): https://github.com/ClickHouse/ClickHouse/pull/101799#issuecomment-4384287834

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.351` (included in `26.5` and later)
- Backported to: `26.3.33.53`
<!-- ch-version-info:end -->