### PR TITLE
Fix flaky test_startup_with_small_bg_pool_partitioned timeout

### DIFF
--- a/tests/integration/test_replicated_table_attach/test.py
+++ b/tests/integration/test_replicated_table_attach/test.py
@@ -80,8 +80,17 @@ def test_startup_with_small_bg_pool_partitioned(started_cluster):
         assert_values()
 
     # check that we activate it in the end
+    #
+    # Bound each attempt with `timeout=` so the retry loop can actually fire.
+    # Without it, the first attempt blocks in `subprocess.wait` for
+    # `DEFAULT_QUERY_TIMEOUT` (600s) when the table is still recovering after
+    # fault injection (single background-schedule thread + 0.001 ZK fault
+    # probability + sanitizer overhead), and pytest's 900s test-level timeout
+    # fires before the retry loop can execute even once. With `timeout=15`,
+    # the loop can do up to ~20 attempts within the budget.
     node.query_with_retry(
         "INSERT INTO replicated_table_partitioned VALUES(20, 30)",
         retry_count=20,
         sleep_time=3,
+        timeout=15,
     )


### PR DESCRIPTION
Fixes the chronic flaky `test_startup_with_small_bg_pool_partitioned` failure tracked under issue #101103. CIDB shows 31 failures across 10 distinct PRs over 90 days, all on heavier sanitizer / db-disk / coverage / distributed-plan configurations, 0 master hits.

Most-recent surfacing: https://github.com/ClickHouse/ClickHouse/pull/100976 (per @alexey-milovidov's directive 2026-05-05T15:58Z).

### Root cause

The test does:

```python
with PartitionManager() as pm:
    pm.drop_instance_zk_connections(node)
    node.stop_clickhouse(stop_wait_sec=150)
    # copy fault_injection.xml
    node.start_clickhouse(start_wait_sec=150)
    assert_values()

# check that we activate it in the end
node.query_with_retry(
    "INSERT INTO replicated_table_partitioned VALUES(20, 30)",
    retry_count=20,
    sleep_time=3,
)
```

After the restart with `enable_fault_injections_during_startup=1`, `background_schedule_pool_size=1`, and 0.001 send/recv ZK fault probability, the table is still recovering when the trailing `INSERT` is issued. The `INSERT` blocks server-side waiting for the table to activate.

Because no `timeout=` is passed to `query_with_retry`, the inner `clickhouse-client` subprocess waits up to `DEFAULT_QUERY_TIMEOUT = 600s` (`tests/integration/helpers/client.py:11`) inside `Client.wait_and_read_output -> self.process.wait(timeout=DEFAULT_QUERY_TIMEOUT)`. Combined with the prologue (`stop_wait_sec=150 + start_wait_sec=150 = up to 300s`), the first attempt alone consumes the entire 900s pytest test-level timeout (`tests/integration/pytest.ini`), so `pytest-timeout` kills the test before the retry loop can iterate even once. The `retry_count=20, sleep_time=3` are useless in this code path.

The captured failure stack confirms this — the test was killed inside `subprocess.wait(timeout=DEFAULT_QUERY_TIMEOUT)` on the very first attempt:

```
File: test_replicated_table_attach/test.py:83 - in test_startup_with_small_bg_pool_partitioned
    node.query_with_retry(
File: helpers/cluster.py:4756 - in query_with_retry
    result = self.query(...)
File: helpers/client.py:241 - in wait_and_read_output
    self.process.wait(timeout=DEFAULT_QUERY_TIMEOUT)
```

### Fix

Pass `timeout=15` to `query_with_retry`. This causes `Client.query` to install a 15-second `Timer` that kills the `clickhouse-client` subprocess if it hasn't returned. `Client.get_answer` then raises `QueryTimeoutExceedException` (which extends `Exception` directly, not `QueryRuntimeException`), and is caught by the existing `except Exception` branch in `query_with_retry` (`tests/integration/helpers/cluster.py:4777`). The loop sleeps `sleep_time=3s` and retries.

Worst-case retry budget: 20 × (15 + 3) = 360s. Combined with the up-to-300s prologue, that leaves comfortable margin under the 900s pytest test-level timeout.

`timeout=15` is conservative — a single-row `INSERT VALUES` into a 1-row replicated table on local disk completes in <1s normally, ~1-3s under sanitizers, and ~2-5s under sanitizers + fault injection + table activation. 15s is 3× the worst observed completion time, so it does not introduce false-positive timeouts under healthy conditions while still bounding the pathological hung-on-activation case.

### Why not increase `retry_count` or `pytest-timeout` instead

- **Increasing `retry_count`**: doesn't help — the *first* attempt blocks for 600s with no `timeout=`, so the retry loop never iterates.
- **Increasing `pytest-timeout`**: would just paper over the issue; the test would still exhaust whatever new budget you give it.
- **Removing fault injection / increasing `background_schedule_pool_size`**: would defeat the test's purpose (it specifically validates startup recovery under those constraints).

The retry mechanism was designed to handle exactly this "table not yet activated" pattern. The fix lets it actually work.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.339`
<!-- ch-version-info:end -->