### PR TITLE
Fix logical error in tuple-vs-string comparison with nested Nullable elements (STID 3344-4a3c)

### DIFF
--- a/src/Functions/FunctionsComparison.h
+++ b/src/Functions/FunctionsComparison.h
@@ -1279,6 +1279,22 @@ public:
                                                    {nullptr, right_tuple->getElements()[i], ""}};
                     element_type = func->build(args)->getResultType();
                 }
+                else
+                {
+                    /// One side is `String`/`FixedString`. At runtime the string is parsed as a tuple
+                    /// value matching the structure of the tuple side and compared element-wise.
+                    /// Recursively compute the element-vs-string comparison type so that nested
+                    /// `Nullable` (or `Nothing`/`Dynamic`/`Variant`) elements transitively propagate
+                    /// `Nullable` to the outer return type. Without this, e.g.
+                    /// `Tuple(Tuple(Nullable(String))) <= String` would be inferred as `UInt8`
+                    /// while the runtime produces `Nullable(UInt8)`, tripping the type-mismatch
+                    /// assertion in the analyzer's constant-folding path (STID 3344-4a3c).
+                    const DataTypePtr & string_side_type = left_tuple ? arguments[1] : arguments[0];
+                    ColumnsWithTypeAndName args = left_tuple
+                        ? ColumnsWithTypeAndName{{nullptr, element_type, ""}, {nullptr, string_side_type, ""}}
+                        : ColumnsWithTypeAndName{{nullptr, string_side_type, ""}, {nullptr, element_type, ""}};
+                    element_type = func->build(args)->getResultType();
+                }
                 has_nullable = has_nullable || element_type->isNullable() || isDynamic(element_type);
 
                 /// Nullable(Nothing)

--- a/tests/queries/0_stateless/04206_tuple_string_compare_nested_nullable_inference.reference
+++ b/tests/queries/0_stateless/04206_tuple_string_compare_nested_nullable_inference.reference
@@ -1,0 +1,10 @@
+Nullable(UInt8)
+\N
+Nullable(UInt8)
+\N
+UInt8
+Nullable(UInt8)
+Nullable(UInt8)
+\N
+Nullable(UInt8)
+1

--- a/tests/queries/0_stateless/04206_tuple_string_compare_nested_nullable_inference.sql
+++ b/tests/queries/0_stateless/04206_tuple_string_compare_nested_nullable_inference.sql
@@ -1,0 +1,49 @@
+-- Tags: no-fasttest
+
+-- Regression test for STID 3344-4a3c
+-- (Logical error: 'Unexpected return type from lessOrEquals. Expected UInt8. Got Const(Nullable(UInt8))').
+--
+-- When comparing a nested tuple containing `Nullable` elements with a `String` literal
+-- (e.g. `Tuple(Tuple(Nullable(String))) <= '((NULL))'`), the type-inference loop in
+-- `FunctionComparison::getReturnTypeImpl` only recursed for the both-tuples case.
+-- For the tuple-vs-string case it inspected the immediate element type only, so a
+-- `Tuple(Nullable(...))` element was not detected as nullable-producing and the
+-- comparison was inferred as plain `UInt8`. The runtime, which converts the string
+-- to a tuple value and compares element-wise, produced `Nullable(UInt8)`, tripping
+-- the analyzer's constant-folding type-match assertion at
+-- `src/Analyzer/Resolve/resolveFunction.cpp`.
+
+SET enable_analyzer = 1;
+
+-- Minimal reproducers — must NOT crash and must return `Nullable(UInt8)`.
+SELECT toTypeName(tuple(tuple(toNullable('x'))) <= '((NULL))');
+SELECT tuple(tuple(toNullable('x'))) <= '((NULL))';
+
+SELECT toTypeName(tuple(1, tuple(toNullable('x'), 2)) <= '(1, (NULL, 2))');
+SELECT tuple(1, tuple(toNullable('x'), 2)) <= '(1, (NULL, 2))';
+
+-- Use inside a `PREWHERE` filter — this is the shape that surfaced the bug in production
+-- CI on PR #100300 (analyzer constant-folding path).
+DROP TABLE IF EXISTS t64;
+CREATE TABLE t64 (`t_i8` Int8) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t64 VALUES (0), (1), (-1);
+
+SELECT *
+FROM t64
+PREWHERE
+    tuple(2147483648, (SELECT materialize(toNullable('y')), 2)) <= '(1, (NULL, 2))'
+FORMAT Null;
+
+DROP TABLE t64;
+
+-- Sanity: existing well-formed cases keep working.
+SELECT toTypeName(tuple(1) <= '(2)');
+SELECT toTypeName(tuple(toNullable(1)) <= '(NULL)');
+
+-- String on the LEFT, nested-`Nullable` tuple on the RIGHT — symmetric path.
+SELECT toTypeName('((NULL))' <= tuple(tuple(toNullable('x'))));
+SELECT '((NULL))' <= tuple(tuple(toNullable('x')));
+
+-- Both sides are tuples — the previously-existing recursion path. Must keep working.
+SELECT toTypeName(tuple(tuple(toNullable('x'))) <= tuple(tuple(toNullable('y'))));
+SELECT tuple(tuple(toNullable('x'))) <= tuple(tuple(toNullable('y')));


### PR DESCRIPTION
Fixes the AST fuzzer logical error tracked as **STID 3344-4a3c**:

```
Logical error: 'Unexpected return type from lessOrEquals.
Expected UInt8. Got Const(Nullable(UInt8))'
```

First surfaced on https://github.com/ClickHouse/ClickHouse/pull/100300 (`AST fuzzer (amd_debug)`)
and previously hit on https://github.com/ClickHouse/ClickHouse/pull/100035 with the same root cause but
a different operator (`equals` instead of `lessOrEquals`).

### Motivation / approach

When comparing a `Tuple(...)` with a `String` literal (e.g.
`tuple(tuple(toNullable('x'))) <= '((NULL))'`), the type-inference loop in
`FunctionComparison::getReturnTypeImpl` only recurses into per-element
comparisons when **both** sides are tuples. For the `tuple <= string` case
(and the symmetric `string <= tuple`), it inspects the immediate element type
only — so a `Tuple(Nullable(...))` outer element is not detected as
nullable-producing and the comparison gets inferred as plain `UInt8`.

At runtime, however, the string is parsed into a tuple value matching the
structure of the tuple side and compared element-wise, which DOES propagate
`Nullable`. The actual result column is `Nullable(UInt8)`. The mismatch trips
the analyzer's constant-folding type-match assertion at
`src/Analyzer/Resolve/resolveFunction.cpp`.

The fix adds the missing recursion: when one side is `String`/`FixedString`,
we recursively call `func->build({element_type, string_side_type})` to compute
the per-element comparison type. This mirrors the runtime semantics and
correctly propagates `Nullable` (as well as `Dynamic`/`Variant`/`Nothing`)
through arbitrarily-nested tuples. Symmetric for both `tuple <= string` and
`string <= tuple`.

This is the same class of bug fixed in
https://github.com/ClickHouse/ClickHouse/commit/1d24a248c32f (tuple comparison
Nothing-type) and adjacent to the constant-folding fix in
https://github.com/ClickHouse/ClickHouse/commit/c4b3d5221acf (Variant +
`LowCardinality` NULL).

### Reproduction / verification

Minimal repro on master HEAD (crashed the server, `LOGICAL_ERROR` abort):

```sql
SELECT tuple(tuple(toNullable('x'))) <= '((NULL))';
```

After the fix:

```sql
:) SELECT toTypeName(tuple(tuple(toNullable('x'))) <= '((NULL))');
Nullable(UInt8)
:) SELECT tuple(tuple(toNullable('x'))) <= '((NULL))';
\N
```

The original fuzzer query from PR #100300 (the third `INTERSECT DISTINCT`
branch, in particular) no longer crashes — it now returns a clean
`ILLEGAL_TYPE_OF_ARGUMENT` error rejecting the `or(... toInt256 ...)` shape,
which is the expected behaviour. Same for the PR #100035 query.

A regression test was added at
`tests/queries/0_stateless/04206_tuple_string_compare_nested_nullable_inference`
covering:
- `Tuple(Tuple(Nullable(...))) <= String`
- `Tuple(Int, Tuple(Nullable(...), ...)) <= String`
- The shape that surfaced the bug under `PREWHERE`
- `String <= Tuple(Tuple(Nullable(...)))` (the symmetric path)
- `Tuple(Tuple(Nullable(...))) <= Tuple(Tuple(Nullable(...)))` (existing
  both-tuples recursion path — must not regress)

Existing tests `04081_comparison_constant_folding_null_variant_lc`,
`03925_tuple_comparison_nothing_type`, `00250_tuple_comparison`,
`00406_tuples_with_nulls`, and `01329_compare_tuple_string_constant` were
verified to still pass against the patched binary.

CI report where the failure was first caught:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100300&sha=54d442c48654c5f60c620ecee424947caea7f2bf&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%29

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the change):
Fix `LOGICAL_ERROR` exception (`Unexpected return type from <comparison>. Expected `UInt8`. Got `Const(Nullable(UInt8))`) when comparing a nested `Tuple(Tuple(Nullable(...)))` (or deeper nesting) with a `String` literal. The comparison's return type is now correctly inferred as `Nullable(UInt8)`, matching the runtime behaviour.

### Documentation entry for user-facing changes
- [x] Documentation is unchanged (internal type-inference correctness fix; no user-facing API change)