### PR TITLE
Fix empty Unicode-quoted identifier raising CANNOT_PARSE_QUOTED_STRING instead of SYNTAX_ERROR

### DIFF
--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -244,8 +244,10 @@ bool ParserIdentifier::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     if (pos->type == TokenType::QuotedIdentifier)
     {
         /// The case of Unicode quotes. No escaping is supported. Assuming UTF-8.
-        if (*pos->begin == '\xE2' && pos->size() > 6) /// Empty identifiers are not allowed.
+        if (*pos->begin == '\xE2' && pos->size() >= 6)
         {
+            if (pos->size() == 6) /// Empty Unicode-quoted identifiers are not allowed.
+                return false;
             node = make_intrusive<ASTIdentifier>(String(pos->begin + 3, pos->end - 3));
             ++pos;
             return true;

--- a/tests/queries/0_stateless/04204_empty_unicode_quoted_identifier_syntax_error.sql
+++ b/tests/queries/0_stateless/04204_empty_unicode_quoted_identifier_syntax_error.sql
@@ -1,0 +1,7 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/104170
+-- Empty Unicode-quoted identifier “” should raise SYNTAX_ERROR,
+-- not CANNOT_PARSE_QUOTED_STRING.
+
+SET enable_analyzer=1;
+
+SELECT 1 AS “”; -- { clientError SYNTAX_ERROR }


### PR DESCRIPTION
### Issue
Closes #104170

### Problem
When a user writes `SELECT 1 AS ""` (empty Unicode-quoted identifier, exactly 6 bytes), ClickHouse raises `CANNOT_PARSE_QUOTED_STRING (26)` instead of returning `SYNTAX_ERROR (62)` or `false`.

### Root cause
In `ExpressionElementParsers.cpp:244`, the condition uses strict greater-than:
```cpp
if (*pos->begin == ''''''' && pos->size() > 6)
```
The empty Unicode quote pair (`\xE2\x80\x9C\xE2\x80\x9D`) has size exactly 6, so this condition misses it, falling through to `readDoubleQuotedStringWithSQLStyle` which throws `CANNOT_PARSE_QUOTED_STRING`.

### Fix
Changed `> 6` to `>= 6` so that empty Unicode-quoted identifiers reach the `s.empty()` check and correctly return `false`, consistent with empty backtick-quoted identifier behavior.

### Testing
- [x] Logic verified: size==6 now enters the Unicode identifier branch
- [x] Empty "" identifier returns `false` instead of throwing exception

### Changelog category (leave one):
Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.300`
<!-- ch-version-info:end -->