### PR TITLE
Fix flaky 04060_coalescing_merge_tree_array_tuple_with_column_param

### DIFF
--- a/tests/queries/0_stateless/04060_coalescing_merge_tree_array_tuple_with_column_param.sql
+++ b/tests/queries/0_stateless/04060_coalescing_merge_tree_array_tuple_with_column_param.sql
@@ -18,12 +18,15 @@ VALUES ('k', 'first', ['a', 'b'], ('hello', 42), {'x': 1, 'y': 2});
 INSERT INTO 04060_test (key, update_column)
 VALUES ('k', 'v2');
 
-SELECT str_col, arr_col, tuple_col, map_col, update_column
+-- Wrap `map_col` in `mapSort` so the output is deterministic regardless of
+-- the on-disk map serialization version (`map_serialization_version_for_zero_level_parts`),
+-- which CI randomizes (`with_buckets` reorders keys by hash bucket).
+SELECT str_col, arr_col, tuple_col, mapSort(map_col), update_column
 FROM 04060_test FINAL;
 
 OPTIMIZE TABLE 04060_test FINAL;
 
-SELECT str_col, arr_col, tuple_col, map_col, update_column
+SELECT str_col, arr_col, tuple_col, mapSort(map_col), update_column
 FROM 04060_test;
 
 DROP TABLE 04060_test;


### PR DESCRIPTION
### Description

Wrap `map_col` in `mapSort` in the two SELECTs of `04060_coalescing_merge_tree_array_tuple_with_column_param.sql` so its output is stable regardless of the randomized `map_serialization_version_for_zero_level_parts` MergeTree setting. CI's `--diagnose-random-settings` flagged the test 229/229 failing under the culprit set:

```
--map_serialization_version_for_zero_level_parts with_buckets
--max_buckets_in_map 37
--map_buckets_strategy constant
--map_buckets_min_avg_size 1
```

…with 0/346 failures when randomization is disabled. With `with_buckets`, `Map` keys are persisted in hash-bucket order, so the test's literal reference (`{'x':1,'y':2}`, insertion order) no longer matches what storage returns (`{'y':2,'x':1}`).

This is the same root cause and same fix pattern already merged in PR #103421 (`01872_functions_to_subcolumns_analyzer`) and PR #102874 (`02169_map_functions`), and proposed in PR #103532 (`00825_protobuf_format_map`). `mapSort` only reorders the SELECT projection — the underlying CoalescingMergeTree column behavior the test verifies (array, tuple, map, and `update_column` interaction with `FINAL` and `OPTIMIZE … FINAL`) is preserved.

Local verification with the fix applied: 200/200 passes under full CI randomization on this build (Debug, master HEAD `5a5c4d66086`). Without the fix, the manual reproduction with the four culprit settings deterministically returns the wrong key order; with the fix it returns `{'x':1,'y':2}`.

CI report that surfaced the failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100752&sha=d42192932164a7878cc41513a8deca263e3e73f1&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29
Originating PR (unrelated, "Snappy HTTP/file compression"): https://github.com/ClickHouse/ClickHouse/pull/100752

### Documentation entry for user-facing changes

- [x] Documentation entry is not required.

### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

(none — CI fix)