### PR TITLE
[CI Proof] `constructLocation` Azure branch uses `find("/" + bucket)` which matches inside the URL host — drops container from URL when bucket name is a prefix of the storage-account hostname

### DIFF
--- a/src/Databases/DataLake/tests/gtest_azure_abfss_parsing.cpp
+++ b/src/Databases/DataLake/tests/gtest_azure_abfss_parsing.cpp
@@ -240,4 +240,55 @@ TEST_F(AzureAbfssParsingTest, TableMetadataGetLocationWithEndpointVirtualHostedD
     EXPECT_EQ(location, "https://my.dotted.bucket.s3.mycompany.com/path/to/table/");
 }
 
+/// Regression coverage for PR #104120: `constructLocation` Azure branch was changed from
+/// `location.ends_with(bucket)` to `location.find("/" + bucket) != npos`. The latter
+/// can match inside the URL host (the second '/' of `//` followed by a host component
+/// that begins with the bucket name), incorrectly concluding that the container is
+/// already present in the URL and dropping it from the constructed path.
+///
+/// The non-Azure branch on line 201 still uses the safer `ends_with`. This test pins
+/// the expected behaviour for the Azure branch: the container must always be included
+/// between host and path when it is not already there.
+TEST_F(AzureAbfssParsingTest, TableMetadataAzureBucketIsHostnamePrefixDoesNotDropContainer)
+{
+    /// Container "data" is a strict prefix of the host "datalake.dfs.core.windows.net".
+    /// `find("/data")` matches inside the host (the second '/' of '//datalake'), so
+    /// the buggy branch returns location without the container segment.
+    TableMetadata metadata;
+    metadata.withLocation();
+    metadata.setLocation("abfss://data@datalake.dfs.core.windows.net/some/path");
+    metadata.setEndpoint("https://datalake.dfs.core.windows.net");
+
+    EXPECT_EQ(
+        metadata.getLocation(),
+        "https://datalake.dfs.core.windows.net/data/some/path/");
+}
+
+TEST_F(AzureAbfssParsingTest, TableMetadataAzureBucketIsHostnamePrefixDoesNotDropContainerVariant)
+{
+    /// Same regression with a different host/container pair where the container name
+    /// ("my") is a strict prefix of the host component ("mycompany").
+    TableMetadata metadata;
+    metadata.withLocation();
+    metadata.setLocation("abfss://my@mycompany.dfs.core.windows.net/tables/t1");
+    metadata.setEndpoint("https://mycompany.dfs.core.windows.net");
+
+    EXPECT_EQ(
+        metadata.getLocation(),
+        "https://mycompany.dfs.core.windows.net/my/tables/t1/");
+}
+
+TEST_F(AzureAbfssParsingTest, TableMetadataAzureBucketIsHostnamePrefixGetLocationWithEndpoint)
+{
+    /// Same scenario routed through `getLocationWithEndpoint` (the explicit-endpoint
+    /// entrypoint used by callers like DatabaseDataLake::tryGetTableImpl when stripping
+    /// to an HTTPS URL). The container must still appear after the host.
+    TableMetadata metadata;
+    metadata.withLocation();
+    metadata.setLocation("abfss://acc@account.dfs.core.windows.net/p/t");
+
+    std::string url = metadata.getLocationWithEndpoint("https://account.dfs.core.windows.net");
+    EXPECT_EQ(url, "https://account.dfs.core.windows.net/acc/p/t/");
+}
+
 }


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

> ⚠️ **This is a CI proof PR — not a fix and not intended for merge.** It submits a test that could not be confirmed locally (code analysis strongly suggests a bug but local test did not trigger it — CI sanitizers and stress runs may catch it). **This PR will be closed automatically** once CI completes. If CI confirms the bug (TSan/ASan/cluster failure), a bug Issue will be filed separately.

**Suspected bug:** `constructLocation` Azure branch uses `find("/" + bucket)` which matches inside the URL host — drops container from URL when bucket name is a prefix of the storage-account hostname

**Root cause:** src/Databases/DataLake/ICatalog.cpp:170 uses `location.find("/" + bucket)` to detect 'bucket already in URL', but `find` matches inside the URL hostname (after `//`), not only in the path. The corresponding non-Azure branch on line 201 uses the safer `location.ends_with(bucket)`. The pre-PR Azure branch also used `location.ends_with(bucket)`, so this is a regression introduced by switching `ends_with` → `find`.

**Affected locations:**
- `src/Databases/DataLake/ICatalog.cpp:170` — `constructLocation` Azure branch — false-positive bucket-already-present check

**Why CI is needed:** Silent wrong-path reads/writes for Azure DataLake catalogs (Iceberg REST, OneLake, Glue, Unity, Paimon REST) whenever the catalog returns a table whose container is a prefix of the storage-account hostname. Affects `getCreateTableQueryImpl` (DatabaseDataLake.cpp:923) and `tryGetTableImpl` (DatabaseDataLake.cpp:540): the storage configuration is initialized with a URL that points to `https://<account>.dfs.core.windows.net/<path>/` instead of `https://<account>.dfs.core.windows.net/<container>/<path>/`. Subsequent `SELECT`/`INSERT`/`SHOW CREATE TABLE` either return wrong data (if a directory with the same prefix exists in another container) or fail with a 404/Not Found. The user has no obvious indication that the bucket was dropped — error messages reference the wrong URL.

**Suggested fix:** Replace `location.find("/" + bucket) != std::string::npos` at line 170 with a check that tests only the URL path component (not the host). Either (a) parse with `Poco::URI` and inspect `getPath()`, or (b) restore `location.ends_with(bucket)` as on line 201, or (c) use `endsWith("/" + bucket) || contains("/" + bucket + "/")`. The previous test `TableMetadataSetLocationAzureAbfssWithEndpoint` happens to pass because `mycontainer`/`mystorageaccount` only share 2 characters before diverging; add a regression test where `bucket` is a strict prefix of the storage account host (e.g. `bucket="data"`, `account="datalake.dfs.core.windows.net"`).

[Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/5dd8bbf3-61a1-492e-8c8a-e11a2b3bbdec)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — temporary CI proof PR, will be closed automatically.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
