### PR TITLE
Teach review skill that structured docs are auto-generated

### DIFF
--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -100,6 +100,14 @@ WHAT TO REVIEW VS WHAT TO IGNORE
 - Review PR template changelog quality: `Changelog category` must match the change, and `Changelog entry` (when required by the PR template) must be present, specific, and user-readable.
 - Read the changelog-entry standards from `clickhouse-pr-description` and apply them: avoid vague text (e.g. "fix bug"), describe the exact affected feature/behavior, and for backward-incompatible changes explain old behavior, new behavior, and how to preserve old behavior when possible.
 
+**Documentation is auto-generated from source for structured parts of the system — do NOT request separate `docs/` files for these:**
+- ClickHouse auto-generates user-facing documentation for the structured surface of the system directly from the source code. This includes (non-exhaustive): SQL functions and aggregate functions (via `FunctionDocumentation` registered at function factory time), settings (via the doc-string argument of the `DECLARE(...)` macro in `src/Core/Settings.cpp`, `MergeTreeSettings.cpp`, format settings, server settings, etc.), table functions, table engines, formats, system tables, and similar registered components.
+- When a PR adds or changes a function, setting, table function, table engine, format, or system table, the correct place for documentation is **the source code registration** (e.g. `FunctionDocumentation` fields like `description`, `syntax`, `arguments`, `returned_value`, `examples`, `introduced_in`, `category`; or the doc-string in `DECLARE(...)` for settings). A separate hand-written page under `docs/` is **not required** and asking for one is a false positive.
+- Only flag missing documentation when:
+  - The structured doc fields are themselves missing, empty, or clearly inadequate (e.g. no `description`, no `examples`, no `syntax` for a new function; empty doc-string in `DECLARE` for a new setting).
+  - The change is to a **non-structured** area that has no auto-generation (e.g. high-level guides, tutorials, architecture docs, operational/admin docs, integration guides) — those do live under `docs/` and may legitimately need updates.
+- Do **not** ask the contributor to add `docs/` files for new functions, settings, dialects, or other registered components when the source-level documentation is present. If the source-level docs are weak, comment on the source-level fields directly instead.
+
 **Explicitly ignore (do not comment on these unless they indicate a bug):**
 - Commented debugging code (completely ignore for draft PR, no more than one message in total)
 - Pure formatting (whitespace, brace style, minor naming preferences).


### PR DESCRIPTION
The auto-review on https://github.com/ClickHouse/ClickHouse/pull/100412#discussion_r3181243257 asked the contributor to add hand-written docs under `docs/` for new SQL functions and a new setting. This is a false positive: ClickHouse auto-generates user documentation for structured parts of the system (functions, settings, table functions, table engines, formats, system tables, etc.) directly from the source (e.g. `FunctionDocumentation` registered at function factory time, and the doc-string in `DECLARE(...)` in `Settings.cpp` / `MergeTreeSettings.cpp` / etc.).

This PR updates `.claude/skills/review/SKILL.md` so the reviewer:
- recognizes that the source-level registration is the canonical place for docs of structured components,
- flags weak / missing source-level fields (empty `description`, missing `examples`, empty `DECLARE` doc-string) instead of asking for separate `docs/` pages,
- still asks for `docs/` updates for non-structured material (guides, tutorials, architecture, operational/admin docs, integrations).

cc @Algunenano

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.330`
<!-- ch-version-info:end -->