### PR TITLE
Tell Dependabot to ignore all Rust dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -99,3 +99,22 @@ updates:
     open-pull-requests-limit: 0
     ignore:
       - dependency-name: "*"
+
+  # Disable Dependabot for all Rust (cargo) dependencies.
+  # Rust crates are pinned via Cargo.lock and built reproducibly; updates must be
+  # done manually together with lockfile and vendored-source refreshes.
+  - package-ecosystem: "cargo"
+    directory: "/rust/chcache"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"
+
+  - package-ecosystem: "cargo"
+    directory: "/rust/workspace"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
Disable Dependabot for all Rust (`cargo`) dependencies in `/rust/chcache` and `/rust/workspace`. Rust crates are pinned via `Cargo.lock` and built reproducibly; updates must be done manually together with lockfile and vendored-source refreshes, so automated bumps are inappropriate.

Context: https://github.com/ClickHouse/ClickHouse/pull/103522#issuecomment-4386976227

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.336`
<!-- ch-version-info:end -->