### PR TITLE
Skip non-test files in flaky-check test-name derivation

### DIFF
--- a/ci/jobs/scripts/find_tests.py
+++ b/ci/jobs/scripts/find_tests.py
@@ -62,6 +62,39 @@ class Targeting:
         else:
             self.job_type = None
 
+    # Keep in sync with TEST_FILE_EXTENSIONS in tests/clickhouse-test.
+    _TEST_FILE_EXTENSIONS = (".sql.j2", ".sql", ".sh", ".py", ".expect")
+
+    @classmethod
+    def _derive_test_name(cls, fpath: str):
+        """Map a changed file under `tests/queries/0_stateless/` to a test name.
+
+        Returns the test base name (without extension) suitable for `clickhouse-test --test`,
+        or `None` if the file does not correspond to a real test (e.g. a data file like
+        `02995_settings_26_4_1.tsv`, which is consumed by `02995_new_settings_history.sh`
+        but has no test of its own).
+        """
+        fname = os.path.basename(fpath)
+
+        # Direct hit: the changed file is itself a test source file.
+        for ext in cls._TEST_FILE_EXTENSIONS:
+            if fname.endswith(ext):
+                return fname[: -len(ext)]
+
+        # Supporting file (`.reference`, `.reference.j2`, `.tsv`, ...). Walk the
+        # extensions one at a time looking for a sibling test source file with
+        # the same base name. This catches reference updates like
+        # `00172_hits_joins.reference.j2` → `00172_hits_joins.sql.j2` while
+        # rejecting orphan data files like `02995_settings_26_4_1.tsv`.
+        test_dir = Path("tests/queries/0_stateless")
+        candidate = fname
+        while "." in candidate:
+            candidate = candidate.rsplit(".", 1)[0]
+            for ext in cls._TEST_FILE_EXTENSIONS:
+                if (test_dir / f"{candidate}{ext}").is_file():
+                    return candidate
+        return None
+
     def get_changed_tests(self):
         # TODO: add support for integration tests
         result = set()
@@ -87,13 +120,19 @@ class Targeting:
                     print(f"File '{fpath}' was removed — skipping")
                     continue
 
-                print(f"Detected changed test file: '{fpath}'")
+                test_base_name = self._derive_test_name(fpath)
+                if test_base_name is None:
+                    # Avoid emitting a regex like `02995_settings_26_4_1.` that
+                    # matches no test — clickhouse-test exits with code 1 when
+                    # "no tests were run", failing the flaky check.
+                    print(
+                        f"File '{fpath}' is not a test source and has no sibling test — skipping"
+                    )
+                    continue
 
-                fname = os.path.basename(fpath)
-                fname_without_ext = os.path.splitext(fname)[0]
-
+                print(f"Detected changed test: '{test_base_name}' (from '{fpath}')")
                 # Add '.' suffix to precisely match this test only
-                result.add(f"{fname_without_ext}.")
+                result.add(f"{test_base_name}.")
 
             elif fpath.startswith("tests/queries/"):
                 # Log any other changed file under tests/queries for future debugging

--- a/ci/tests/test_find_tests.py
+++ b/ci/tests/test_find_tests.py
@@ -1,0 +1,78 @@
+"""
+Regression tests for `ci/jobs/scripts/find_tests.py` test-name derivation.
+
+PR #104097 changed only `tests/queries/0_stateless/02995_settings_26_4_1.tsv`
+under `tests/queries/0_stateless/`.  The flaky-check driver derived the test
+name `02995_settings_26_4_1` by stripping the extension and asked
+`clickhouse-test` to re-run it 50 times — but no test with that base name
+exists (the `.tsv` is a data file consumed by `02995_new_settings_history.sh`).
+The filter matched zero tests and `clickhouse-test` exited with code 1.
+
+These tests pin the corrected behaviour: orphan supporting files are skipped,
+and supporting files with a real sibling test (e.g. `.reference`) still map
+back to that test.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.jobs.scripts.find_tests import Targeting
+
+
+def test_orphan_data_file_is_skipped():
+    # PR #104097 reproducer: a `.tsv` data file consumed by another test.
+    assert (
+        Targeting._derive_test_name(
+            "tests/queries/0_stateless/02995_settings_26_4_1.tsv"
+        )
+        is None
+    )
+
+
+def test_test_source_files_keep_base_name():
+    assert (
+        Targeting._derive_test_name(
+            "tests/queries/0_stateless/02995_new_settings_history.sh"
+        )
+        == "02995_new_settings_history"
+    )
+    assert (
+        Targeting._derive_test_name(
+            "tests/queries/0_stateless/02995_index_1.sql"
+        )
+        == "02995_index_1"
+    )
+    assert (
+        Targeting._derive_test_name(
+            "tests/queries/0_stateless/00172_hits_joins.sql.j2"
+        )
+        == "00172_hits_joins"
+    )
+
+
+def test_reference_file_maps_to_sibling_test():
+    # `.reference` for a sibling `.sh`.
+    assert (
+        Targeting._derive_test_name(
+            "tests/queries/0_stateless/02995_new_settings_history.reference"
+        )
+        == "02995_new_settings_history"
+    )
+    # `.reference.j2` for a sibling `.sql.j2`.
+    assert (
+        Targeting._derive_test_name(
+            "tests/queries/0_stateless/00172_hits_joins.reference.j2"
+        )
+        == "00172_hits_joins"
+    )
+
+
+def test_unknown_data_file_with_no_sibling_is_skipped():
+    assert (
+        Targeting._derive_test_name(
+            "tests/queries/0_stateless/99999_no_such_test.tsv"
+        )
+        is None
+    )


### PR DESCRIPTION
The flaky-check driver in \`ci/jobs/scripts/find_tests.py\` derives a test name from each changed file under \`tests/queries/0_stateless/\` by stripping the file extension and feeding the result to \`clickhouse-test --test\`. When PR #104097 changed only \`02995_settings_26_4_1.tsv\` (a data file consumed by \`02995_new_settings_history.sh\`), the driver produced the pattern \`02995_settings_26_4_1.\` and asked \`clickhouse-test\` to re-run it 50 times. No test matches that pattern, so \`clickhouse-test\` printed \`Found 0 parallel tests and 0 sequential tests\` and exited with code 1, failing the flaky check.

Now the derivation matches files first against the known test extensions (\`.sql\`, \`.sql.j2\`, \`.sh\`, \`.py\`, \`.expect\`); for supporting files such as \`.reference\` or \`.reference.j2\` it walks back one extension at a time looking for a sibling test source. Orphan data files like \`02995_settings_26_4_1.tsv\` are skipped instead of producing a filter that matches zero tests.

See https://github.com/ClickHouse/ClickHouse/pull/104097#issuecomment-4386868099

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)