### PR TITLE
Use less severe INCORRECT_DATA over CHECKSUM_DOESNT_MATCH in Parquet reader

### DIFF
--- a/src/Processors/Formats/Impl/Parquet/Reader.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Reader.cpp
@@ -33,7 +33,6 @@ namespace DB::ErrorCodes
     extern const int INCORRECT_DATA;
     extern const int LOGICAL_ERROR;
     extern const int NOT_IMPLEMENTED;
-    extern const int CHECKSUM_DOESNT_MATCH;
 }
 
 namespace ProfileEvents
@@ -1543,7 +1542,7 @@ std::tuple<parq::PageHeader, std::span<const char>> Reader::decodeAndCheckPageHe
     {
         uint32_t crc = arrow::internal::crc32(0, page_data.data(), page_data.size());
         if (crc != uint32_t(header.crc))
-            throw Exception(ErrorCodes::CHECKSUM_DOESNT_MATCH, "Page CRC checksum verification failed");
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Page CRC checksum verification failed");
     }
 
     return {header, page_data};


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use less severe INCORRECT_DATA over CHECKSUM_DOESNT_MATCH in Parquet reader

CHECKSUM_DOESNT_MATCH can be monitored by users to catch severe problems in MergeTree tables

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.350`
<!-- ch-version-info:end -->