### PR TITLE
ci: retry Copilot Code Review on transient gh API failures

### DIFF
--- a/ci/jobs/copilot_review_job.py
+++ b/ci/jobs/copilot_review_job.py
@@ -10,6 +10,11 @@ done by the job script itself (not copilot) and fails the job if it does not wor
 Copilot writes the review to REVIEW_FILE; the job script then posts it via
 `ci/praktika/gh.py post-or-update --tag review` so the comment is always posted
 as the pre-authenticated app, not the Copilot robot.
+
+The Copilot CLI occasionally hits transient GitHub authorization errors mid-run
+("Authorization error, you may need to run /login"). The whole `gh auth` +
+`copilot` sequence is wrapped in a retry loop with exponential backoff so a
+single transient API failure does not fail the Code Review job.
 """
 
 import os
@@ -17,6 +22,7 @@ import shlex
 import subprocess
 import sys
 import tempfile
+import time
 import traceback
 
 from ci.praktika import Secret
@@ -24,6 +30,13 @@ from ci.praktika.info import Info
 from ci.praktika.result import Result
 
 REVIEW_FILE = "./ci/tmp/copilot_review.md"
+
+# Number of attempts at the full gh-auth + copilot run. The Copilot CLI
+# fetches auth state and makes GitHub API calls during execution; either
+# layer can hit a transient 5xx / authorization error that no single inner
+# subprocess controls. Re-authing and retrying the whole sequence is the
+# only reliable way to recover.
+COPILOT_MAX_ATTEMPTS = 3
 
 
 def _reauth_gh():
@@ -48,7 +61,19 @@ def _post_review():
     )
 
 
-def _run(prompt):
+def _run_copilot_once(prompt):
+    """Run a single attempt of `gh auth login` + `copilot`.
+
+    Removes any stale REVIEW_FILE first so a successful prior attempt's
+    artifact cannot be mistaken for the result of a later failed attempt.
+    Returns the praktika ``Result`` of the copilot subprocess.
+    """
+    if os.path.exists(REVIEW_FILE):
+        try:
+            os.unlink(REVIEW_FILE)
+        except OSError as e:
+            print(f"WARNING: Failed to remove stale {REVIEW_FILE}: {e}")
+
     with tempfile.TemporaryDirectory() as gh_config_dir:
         token = Secret.Config(
             name="/ci/robot-ch-test-poll-copilot", type=Secret.Type.AWS_SSM_PARAMETER
@@ -59,7 +84,7 @@ def _run(prompt):
             env={**os.environ, "GH_CONFIG_DIR": gh_config_dir},
         )
         token = None
-        Result.from_commands_run(
+        return Result.from_commands_run(
             name="copilot review",
             # --allow-all-tools: run non-interactively
             # --add-dir .: restrict file access to repo root (default,
@@ -69,11 +94,51 @@ def _run(prompt):
             with_info=True,
         )
 
+
+def _run(prompt):
+    """Run Copilot with retries, then post the review comment.
+
+    Each attempt re-fetches the secret, re-auths the temporary
+    ``GH_CONFIG_DIR``, and re-runs Copilot. The attempt counts as success
+    only if the copilot subprocess exits 0 AND ``REVIEW_FILE`` was written
+    with non-empty content. Authorization-style failures inside Copilot do
+    not surface as a Python exception — they show up as a non-zero exit
+    code and a missing review file — so both have to be checked here.
+    """
+    last_error = None
+    for attempt in range(1, COPILOT_MAX_ATTEMPTS + 1):
+        try:
+            result = _run_copilot_once(prompt)
+            if not result.is_ok():
+                last_error = (
+                    f"copilot subprocess exited with non-OK status [{result.status}]"
+                )
+                print(f"WARNING: Copilot attempt {attempt}/{COPILOT_MAX_ATTEMPTS} failed: {last_error}")
+            elif not os.path.exists(REVIEW_FILE):
+                last_error = f"Copilot did not write {REVIEW_FILE}"
+                print(f"WARNING: Copilot attempt {attempt}/{COPILOT_MAX_ATTEMPTS} failed: {last_error}")
+            elif os.path.getsize(REVIEW_FILE) == 0:
+                last_error = f"{REVIEW_FILE} is empty"
+                print(f"WARNING: Copilot attempt {attempt}/{COPILOT_MAX_ATTEMPTS} failed: {last_error}")
+            else:
+                last_error = None
+                break
+        except Exception as e:  # noqa: BLE001 — broad catch: any exception is retryable here
+            last_error = f"{type(e).__name__}: {e}"
+            print(f"WARNING: Copilot attempt {attempt}/{COPILOT_MAX_ATTEMPTS} raised: {last_error}")
+            traceback.print_exc()
+
+        if attempt < COPILOT_MAX_ATTEMPTS:
+            delay = min(2 ** attempt, 60)
+            print(f"Retrying Copilot in {delay}s ...")
+            time.sleep(delay)
+
+    if last_error is not None:
+        raise RuntimeError(
+            f"Copilot review failed after {COPILOT_MAX_ATTEMPTS} attempts: {last_error}"
+        )
+
     # Post the summary from the job script so the job fails loudly if anything is broken.
-    if not os.path.exists(REVIEW_FILE):
-        raise RuntimeError(f"Copilot did not write {REVIEW_FILE}")
-    if os.path.getsize(REVIEW_FILE) == 0:
-        raise RuntimeError(f"{REVIEW_FILE} is empty")
     _post_review()
 
 

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -140,6 +140,45 @@ class GH:
         return res
 
     @classmethod
+    def get_output_with_retries(cls, command, verbose=False):
+        """Run a read-style ``gh`` command and return its stdout.
+
+        Mirrors :meth:`do_command_with_retries` but returns the captured
+        stdout instead of a boolean. Use this for any GitHub API read
+        (``gh api ...``, ``gh pr view ...``, ``gh pr diff ...``) that
+        previously used :meth:`Shell.get_output` without retries — those
+        calls would silently return an empty string on a transient 5xx
+        and propagate as ``json.loads('')`` errors or empty-result bugs.
+
+        Returns the trimmed stdout on success; an empty string if the
+        command keeps failing after ``MAX_RETRIES_GH`` attempts.
+        """
+        retry_count = 0
+        out, err, ret_code = "", "", -1
+        while retry_count < Settings.MAX_RETRIES_GH:
+            ret_code, out, err = Shell.get_res_stdout_stderr(command, verbose=verbose)
+            if ret_code == 0:
+                return out
+            # Same non-retryable error classes as do_command_with_retries.
+            if "Validation Failed" in err:
+                print(f"ERROR: GH command validation error {[err]}")
+                break
+            if "Bad credentials" in err:
+                print("ERROR: GH credentials/auth failure")
+                break
+            if "Resource not accessible" in err:
+                print("ERROR: GH permissions failure")
+                break
+            retry_count += 1
+            delay = min(2 ** (retry_count + 1), 60)
+            time.sleep(delay)
+
+        print(
+            f"ERROR: Failed to execute gh command [{command}] out:[{out}] err:[{err}] after [{retry_count}] attempts"
+        )
+        return ""
+
+    @classmethod
     def post_pr_comment(
         cls, comment_body, or_update_comment_with_substring="", pr=None, repo=None
     ):
@@ -158,7 +197,7 @@ class GH:
                     f'"/repos/{repo}/issues/{pr}/comments" '
                     f"--jq '.[] | {{id: .id, body: .body}}' | grep -F {safe_substr}"
                 )
-                output = Shell.get_output(cmd_check_created)
+                output = cls.get_output_with_retries(cmd_check_created)
                 if output:
                     comment_ids = []
                     try:
@@ -233,7 +272,7 @@ class GH:
             f'"/repos/{repo}/issues/{pr}/comments" '
             f"--jq '[.[] | {{id: .id, body: .body}}]' --paginate"
         )
-        output = Shell.get_output(cmd_list, verbose=verbose)
+        output = cls.get_output_with_retries(cmd_list, verbose=verbose)
         if output:
             try:
                 for comment in json.loads(output):
@@ -287,9 +326,15 @@ class GH:
         cmd_check_created = f'gh api -H "Accept: application/vnd.github.v3+json" \
             "/repos/{repo}/issues/{pr}/comments" \
             --jq \'[.[] | {{id: .id, body: .body}}]\' --paginate'
-        output = Shell.get_output(cmd_check_created, verbose=verbose)
+        output = cls.get_output_with_retries(cmd_check_created, verbose=verbose)
 
-        comments = json.loads(output)
+        try:
+            comments = json.loads(output) if output else []
+        except json.JSONDecodeError as e:
+            print(
+                f"ERROR: Failed to parse gh comments JSON: {e}. Treating as no existing comments."
+            )
+            comments = []
 
         comment_to_update = None
         id_to_update = None
@@ -377,7 +422,7 @@ class GH:
             pr = _Environment.get().PR_NUMBER
 
         cmd = f"gh pr view {pr} --repo {repo} --json commits --jq '[.commits[].authors[].login]'"
-        contributors_str = Shell.get_output(cmd, verbose=True)
+        contributors_str = cls.get_output_with_retries(cmd, verbose=True)
         res = []
         if contributors_str:
             try:
@@ -397,7 +442,7 @@ class GH:
             pr = _Environment.get().PR_NUMBER
 
         cmd = f"gh pr view {pr} --repo {repo} --json labels --jq '.labels[].name'"
-        output = Shell.get_output(cmd, verbose=True)
+        output = cls.get_output_with_retries(cmd, verbose=True)
         res = []
         if output:
             res = output.splitlines()
@@ -411,7 +456,7 @@ class GH:
             pr = _Environment.get().PR_NUMBER
 
         cmd = f"gh pr view {pr} --json title,body,labels --repo {repo}"
-        output = Shell.get_output(cmd, verbose=True)
+        output = cls.get_output_with_retries(cmd, verbose=True)
         try:
             pr_data = json.loads(output)
             title = pr_data["title"]
@@ -432,7 +477,7 @@ class GH:
             pr = _Environment.get().PR_NUMBER
 
         cmd = f'gh api repos/{repo}/issues/{pr}/events --jq \'.[] | select(.event=="labeled" and .label.name=="{label}") | .actor.login\''
-        return Shell.get_output(cmd, verbose=True)
+        return cls.get_output_with_retries(cmd, verbose=True)
 
     @classmethod
     def get_pr_diff(cls, pr=None, repo=None):
@@ -442,7 +487,7 @@ class GH:
             pr = _Environment.get().PR_NUMBER
 
         cmd = f"gh pr diff {pr} --repo {repo}"
-        return Shell.get_output(cmd, verbose=True)
+        return cls.get_output_with_retries(cmd, verbose=True)
 
     @classmethod
     def update_pr_body(cls, new_body=None, body_file=None, pr=None, repo=None):
@@ -552,15 +597,15 @@ class GH:
         cmd = f"gh pr merge {pr} --repo {repo} {extra_args}"
         return cls.do_command_with_retries(cmd)
 
-    @staticmethod
-    def pr_has_conflicts(pr=None, repo=None, verbose=False):
+    @classmethod
+    def pr_has_conflicts(cls, pr=None, repo=None, verbose=False):
         if not repo:
             repo = _Environment.get().REPOSITORY
         if not pr:
             pr = _Environment.get().PR_NUMBER
 
         cmd = f"gh pr view {pr} --repo {repo} --json mergeable --jq .mergeable"
-        output = Shell.get_output(cmd, verbose=verbose)
+        output = cls.get_output_with_retries(cmd, verbose=verbose)
         return output == "CONFLICTING"
 
     @classmethod


### PR DESCRIPTION
On PR [#104204](https://github.com/ClickHouse/ClickHouse/pull/104204), the
"Code Review" check failed because the Copilot CLI hit a transient
GitHub authorization error mid-run, after ~1m 9s of work:

```
[10:08:14] Authorization error, you may need to run /login (Request ID: F924:13DD23:2A50C17:2E8FB85:69FB130D)
[10:08:14] ERROR: command failed after 1/1 attempt(s), exit code: 1
[10:08:14] ERROR: Copilot did not write ./ci/tmp/copilot_review.md
RuntimeError: Copilot did not write ./ci/tmp/copilot_review.md
```

Failed job: <https://github.com/ClickHouse/ClickHouse/actions/runs/25428876194/job/74589889048>
(workflow attempt 2 / Code Review attempt 1 of run `25428876194`).
A 3rd workflow attempt re-ran Code Review at 11:03:54Z and finished cleanly,
which confirmed the failure was a transient blip — but by that point the
`Mergeable Check` status had already been set to `failure` ("Failed: Code
Review, Dropped: 71") at 10:22:35Z when Finish Workflow saw the failed run.

Per @alexey-milovidov's directive ([comment](https://github.com/ClickHouse/ClickHouse/pull/104204#issuecomment-4387120942)):
> @groeneai, check why "Code review" has failed. Likely, we need to add
> retries in some of the GitHub-related commands inside it. Send a PR.

This PR adds two layers of retry:

1. **`ci/jobs/copilot_review_job.py`** — wrap the gh-auth + copilot
   subprocess sequence in a 3-attempt retry loop with exponential
   backoff. Each attempt re-fetches the secret, re-runs `gh auth login`
   against a fresh `GH_CONFIG_DIR`, and re-invokes Copilot. An attempt
   counts as success only if the subprocess exits 0 AND `REVIEW_FILE` is
   written non-empty — auth failures inside Copilot don't surface as
   exceptions, only as exit code ≠ 0 and a missing review file.

2. **`ci/praktika/gh.py`** — add `GH.get_output_with_retries(cmd)`, the
   read-style counterpart of `do_command_with_retries`. Replace bare
   `Shell.get_output(cmd)` with the new helper for every
   GitHub-API read in `gh.py`:

   - `post_pr_comment`
   - `post_fresh_comment`
   - `post_updateable_comment`
   - `get_pr_contributors`
   - `get_pr_labels`
   - `get_pr_title_body_labels`
   - `get_pr_label_assigner`
   - `get_pr_diff`
   - `pr_has_conflicts`

   These would previously return `""` on a transient `gh` failure and
   either propagate as `json.loads('')` crashes or silently misclassify
   the PR (e.g. miss an existing comment and post a duplicate). Same
   non-retryable error classes as `do_command_with_retries`
   (`Validation Failed`, `Bad credentials`, `Resource not accessible`).

   Also harden `post_updateable_comment` against malformed JSON: catch
   `json.JSONDecodeError` and treat it as "no existing comments" rather
   than crashing the caller.

Local sanity check:
```
$ PYTHONPATH=./ci python3 -c "from praktika.gh import GH; print(GH.get_output_with_retries('echo hello'))"
hello
$ PYTHONPATH=./ci python3 -c "from praktika.gh import GH; print(repr(GH.get_output_with_retries('false')))"
... 3 attempts, exponential backoff, then ...
''
```

CI Report (failed run that motivated this fix):
<https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104204&sha=4e0497e7d58595bbab725d3f27d16c9303577b0f&name_0=PR&name_1=Code%20Review>

### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not applicable — CI fix.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.349`
<!-- ch-version-info:end -->