### PR TITLE
Coalesce consecutive page cache misses into single S3 requests

### DIFF
--- a/src/Client/BuzzHouse/Generator/SessionSettings.cpp
+++ b/src/Client/BuzzHouse/Generator/SessionSettings.cpp
@@ -1567,6 +1567,7 @@ void loadFuzzerServerSettings(const FuzzConfig & fc)
            "min_joined_block_size_bytes",
            "output_format_parquet_row_group_size_bytes",
            "page_cache_block_size",
+           "page_cache_max_coalesced_bytes",
            "partial_merge_join_left_table_buffer_bytes",
            "prefer_external_sort_block_bytes",
            "preferred_block_size_bytes",

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6382,6 +6382,11 @@ On userspace page cache miss, read up to this many consecutive blocks at once fr
 
 A higher value is good for high-throughput queries, while low-latency point queries will work better without readahead.
 )", 0) \
+    DECLARE(UInt64, page_cache_max_coalesced_bytes, 16777216, R"(
+When `readBigAt` populates the userspace page cache, consecutive cache misses are coalesced into a single read from the underlying storage. This setting bounds the size of one coalesced read in bytes; longer miss runs are split into multiple reads. It limits transient memory usage of the temporary buffer under parallel cold reads.
+
+A higher value reduces the number of HTTP requests for cold scans on object storage; a lower value reduces peak transient memory.
+)", 0) \
     \
     DECLARE(Bool, load_marks_asynchronously, false, R"(
 Load MergeTree marks asynchronously

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -57,6 +57,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"max_streams_for_union_step", 0, 0, "New setting to limit the number of simultaneously active data streams in a UNION step to reduce peak memory usage."},
             {"max_streams_for_union_step_to_max_threads_ratio", 0, 8, "New setting: the limit on simultaneously active streams in a UNION step is computed as min(max_streams_for_union_step, max_threads * max_streams_for_union_step_to_max_threads_ratio), either being 0 disables that input."},
             {"send_table_structure_on_insert_with_inline_data", true, true, "New setting to control whether server sends table structure for INSERT queries with inline data."},
+            {"page_cache_max_coalesced_bytes", 16777216, 16777216, "New setting to bound the size of a single coalesced read used to populate the userspace page cache on cache miss."},
         });
         addSettingsChanges(settings_changes_history, "26.4",
         {

--- a/src/IO/CachedInMemoryReadBufferFromFile.cpp
+++ b/src/IO/CachedInMemoryReadBufferFromFile.cpp
@@ -1,5 +1,6 @@
 #include <IO/CachedInMemoryReadBufferFromFile.h>
 #include <base/scope_guard.h>
+#include <Common/PODArray.h>
 #include <Common/ProfileEvents.h>
 
 namespace ProfileEvents
@@ -244,17 +245,43 @@ std::vector<PageCache::MappedPtr> CachedInMemoryReadBufferFromFile::populateBloc
         cells[i] = cache->get(block_range.hash(cache_key_base_hash), inject_eviction);
     }
 
-    /// Phase 2: fill each missing block by reading directly into its cache cell,
-    /// avoiding a large temporary buffer and the extra memcpy.
-    for (size_t i = 0; i < num_blocks; ++i)
+    /// Phase 2: fill missing blocks, coalescing consecutive misses into single reads.
+    ///
+    /// On object storage, each `in->readBigAt` is a separate HTTP request, so reading one
+    /// block at a time turns a cold scan into one request per block (~15k for a 14 GB file
+    /// at 1 MiB blocks). Coalescing consecutive misses into a single request amortizes that
+    /// overhead.
+    ///
+    /// The coalesced read uses a temporary buffer, capped at `max_coalesced_bytes` to bound
+    /// transient memory under parallel cold reads. A run longer than the cap is split.
+    /// Single-block misses bypass the buffer and read directly into the cache cell.
+    constexpr size_t max_coalesced_bytes = 16 * 1024 * 1024;
+    const size_t max_blocks_per_fetch = std::max<size_t>(1, max_coalesced_bytes / block_size);
+
+    size_t i = 0;
+    while (i < num_blocks)
     {
-        if (!cells[i])
+        if (cells[i])
         {
-            block_range.offset = first_block_start + i * block_size;
+            if (block_callback && block_callback(cells[i]))
+                return cells;
+            ++i;
+            continue;
+        }
+
+        const size_t miss_begin = i;
+        while (i < num_blocks && !cells[i] && (i - miss_begin) < max_blocks_per_fetch)
+            ++i;
+        const size_t miss_end = i;
+
+        if (miss_end - miss_begin == 1)
+        {
+            /// Single-block miss: read directly into the cache cell (no temp buffer).
+            block_range.offset = first_block_start + miss_begin * block_size;
             block_range.size = std::min(block_size, file_size.value() - block_range.offset);
             UInt128 key_hash = block_range.hash(cache_key_base_hash);
 
-            cells[i] = cache->getOrSet(
+            cells[miss_begin] = cache->getOrSet(
                 cache_file, block_range, detached_if_missing, inject_eviction,
                 [&](const auto & c)
                 {
@@ -265,8 +292,41 @@ std::vector<PageCache::MappedPtr> CachedInMemoryReadBufferFromFile::populateBloc
                 },
                 key_hash);
         }
-        if (block_callback && block_callback(cells[i]))
-            break;
+        else
+        {
+            /// Multi-block miss: fetch the whole run with one `readBigAt`, then distribute into cells.
+            const size_t range_start = first_block_start + miss_begin * block_size;
+            const size_t range_end = std::min(first_block_start + miss_end * block_size, file_size.value());
+            const size_t range_size = range_end - range_start;
+
+            PODArray<char> buf(range_size);
+            size_t bytes_read = in->readBigAt(buf.data(), range_size, range_start, nullptr);
+            if (bytes_read < range_size)
+                throw Exception(ErrorCodes::UNEXPECTED_END_OF_FILE, "File {} ended after {} bytes, but we expected {}",
+                    cache_file.path, range_start + bytes_read, file_size.value());
+
+            for (size_t j = miss_begin; j < miss_end; ++j)
+            {
+                block_range.offset = first_block_start + j * block_size;
+                block_range.size = std::min(block_size, file_size.value() - block_range.offset);
+                const size_t buf_offset = block_range.offset - range_start;
+                UInt128 key_hash = block_range.hash(cache_key_base_hash);
+
+                cells[j] = cache->getOrSet(
+                    cache_file, block_range, detached_if_missing, inject_eviction,
+                    [&](const auto & c)
+                    {
+                        memcpy(c->data(), buf.data() + buf_offset, block_range.size);
+                    },
+                    key_hash);
+            }
+        }
+
+        for (size_t j = miss_begin; j < miss_end; ++j)
+        {
+            if (block_callback && block_callback(cells[j]))
+                return cells;
+        }
     }
 
     return cells;

--- a/src/IO/CachedInMemoryReadBufferFromFile.cpp
+++ b/src/IO/CachedInMemoryReadBufferFromFile.cpp
@@ -252,11 +252,10 @@ std::vector<PageCache::MappedPtr> CachedInMemoryReadBufferFromFile::populateBloc
     /// at 1 MiB blocks). Coalescing consecutive misses into a single request amortizes that
     /// overhead.
     ///
-    /// The coalesced read uses a temporary buffer, capped at `max_coalesced_bytes` to bound
-    /// transient memory under parallel cold reads. A run longer than the cap is split.
+    /// The coalesced read uses a temporary buffer, capped at `page_cache_max_coalesced_bytes` to
+    /// bound transient memory under parallel cold reads. A run longer than the cap is split.
     /// Single-block misses bypass the buffer and read directly into the cache cell.
-    constexpr size_t max_coalesced_bytes = 16 * 1024 * 1024;
-    const size_t max_blocks_per_fetch = std::max<size_t>(1, max_coalesced_bytes / block_size);
+    const size_t max_blocks_per_fetch = std::max<size_t>(1, settings.page_cache_max_coalesced_bytes / block_size);
 
     size_t i = 0;
     while (i < num_blocks)

--- a/src/IO/ReadSettings.h
+++ b/src/IO/ReadSettings.h
@@ -67,6 +67,7 @@ struct ReadSettings
     bool page_cache_inject_eviction = false;
     size_t page_cache_block_size = 1 << 20;
     size_t page_cache_lookahead_blocks = 16;
+    size_t page_cache_max_coalesced_bytes = 16 << 20;
     std::shared_ptr<PageCache> page_cache;
 
     size_t filesystem_cache_max_download_size = (128UL * 1024 * 1024 * 1024);

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -326,6 +326,7 @@ namespace Setting
     extern const SettingsBool read_from_page_cache_if_exists_otherwise_bypass_cache;
     extern const SettingsUInt64 page_cache_block_size;
     extern const SettingsUInt64 page_cache_lookahead_blocks;
+    extern const SettingsUInt64 page_cache_max_coalesced_bytes;
     extern const SettingsInt64 read_priority;
     extern const SettingsString remote_filesystem_read_method;
     extern const SettingsBool remote_filesystem_read_prefetch;
@@ -7639,6 +7640,7 @@ ReadSettings Context::getReadSettings() const
     res.page_cache_inject_eviction = settings_ref[Setting::page_cache_inject_eviction];
     res.page_cache_block_size = settings_ref[Setting::page_cache_block_size];
     res.page_cache_lookahead_blocks = settings_ref[Setting::page_cache_lookahead_blocks];
+    res.page_cache_max_coalesced_bytes = settings_ref[Setting::page_cache_max_coalesced_bytes];
 
     res.remote_read_min_bytes_for_seek = getSettingsRef()[Setting::remote_read_min_bytes_for_seek];
 


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Cold reads of object storage through the userspace page cache (`use_page_cache_for_object_storage = 1`) are now significantly faster, because consecutive cache misses are coalesced into a single HTTP request instead of one request per `page_cache_block_size` block.

### Description

`CachedInMemoryReadBufferFromFile::populateBlockRange` previously issued one `in->readBigAt` per missing 1 MiB block. On object storage, each call is a separate HTTP request, so a cold scan of a 14 GB Parquet file through the userspace page cache made ~15k requests, each paying the TCP/TLS round-trip — measurably slower than the filesystem cache, which fetches in larger segments.

Coalescing was previously implemented in commit 682b070e802 and reverted in c178d2a264f to avoid transient memory spikes from huge temporary buffers under parallel cold reads.

This change re-introduces coalescing with a hard cap on the temporary buffer (``max_coalesced_bytes`` = 16 MiB). Long miss runs are split into multiple fetches, bounding peak transient memory per call. Single-block misses still read directly into the cache cell, avoiding the buffer and the extra ``memcpy``.

### Test results

Measured on c8g.24xlarge against the ClickBench ``clickhouse-datalake`` queries (43 queries, single 14.7 GB Parquet on S3, totals over all queries):

| Config | Cold total | Hot total |
|---|---|---|
| OLD filesystem cache | 62.28s | 18.57s |
| NEW page cache (broken) | 106.14s | 20.14s |
| **NEW page cache + this fix** | **56.58s** | **13.59s** |

Per-query, the worst regressed queries are back to baseline:
- Q24 (heaviest, ``SELECT *``): 15.23s -> 34.61s broken -> **15.27s fixed**
- Q23: 4.89s -> 10.14s broken -> **4.72s fixed**
- Q22: 2.30s -> 5.00s broken -> **2.43s fixed**

Context: https://github.com/ClickHouse/ClickBench/pull/818

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.356`
<!-- ch-version-info:end -->