### PR TITLE
Skip thread rename on no-op.

### DIFF
--- a/src/Common/setThreadName.cpp
+++ b/src/Common/setThreadName.cpp
@@ -74,7 +74,9 @@ static thread_local ThreadName thread_name = ThreadName::UNKNOWN;
 
 void setThreadName(ThreadName name)
 {
-    thread_name = name;
+    // Skip rename on no-op.
+    if (thread_name == name)
+        return;
 
     auto thread_name_view = toString(name);
     if (thread_name_view.size() > THREAD_NAME_SIZE)
@@ -98,6 +100,8 @@ void setThreadName(ThreadName name)
 #endif
         if (errno != ENOSYS && errno != EPERM)    /// It's ok if the syscall is unsupported or not allowed in some environments.
             throw DB::ErrnoException(DB::ErrorCodes::PTHREAD_ERROR, "Cannot set thread name with prctl(PR_SET_NAME, ...)");
+
+    thread_name = name;
 
 #if USE_JEMALLOC
     DB::Jemalloc::setValue("thread.prof.name", thread_name_str.data());


### PR DESCRIPTION
Analogous to the behavior of getThreadName, update setThreadName to bail out early if the requested thread name matches the cached thread name.

Context: we noticed that setThreadName is expensive on illumos, and ~10% of thread renames are no-ops. Any performance improvement on linux would be minimal, but there's still no reason to rename a thread to its current name, and this parallels the behavior of getThreadName, which already returns early if we have a cached thread name.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.364`
<!-- ch-version-info:end -->