### PR TITLE
Don't use failpoint when checking if enabled

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -338,12 +338,12 @@ std::vector<FailPointInjection::FailPointInfo> FailPointInjection::getFailPoints
 {
     std::vector<FailPointInfo> result;
 
-#define SUB_M(NAME, TP)                                 \
-    result.push_back(                                   \
-        FailPointInfo{                                  \
-            .name = FailPoints::NAME,                   \
-            .type = FailPointType::TP,                  \
-            .enabled = fiu_fail(FailPoints::NAME) != 0, \
+#define SUB_M(NAME, TP)                                   \
+    result.push_back(                                     \
+        FailPointInfo{                                    \
+            .name = FailPoints::NAME,                     \
+            .type = FailPointType::TP,                    \
+            .enabled = fiu_status(FailPoints::NAME) != 0, \
         });
 #define ADD_ONCE(NAME) SUB_M(NAME, Once)
 #define ADD_REGULAR(NAME) SUB_M(NAME, Regular)

--- a/tests/queries/0_stateless/03916_system_table.reference
+++ b/tests/queries/0_stateless/03916_system_table.reference
@@ -12,3 +12,10 @@ pauseable	1
 replicated_merge_tree_insert_retry_pause	0
 replicated_merge_tree_insert_retry_pause	1
 replicated_merge_tree_insert_retry_pause	0
+once_first	1
+once_second	1
+once_third	1
+once_disabled	0
+pauseable_once_first	1
+pauseable_once_second	1
+pauseable_once_disabled	0

--- a/tests/queries/0_stateless/03916_system_table.sql
+++ b/tests/queries/0_stateless/03916_system_table.sql
@@ -38,3 +38,22 @@ SELECT name, enabled FROM system.fail_points WHERE name = 'replicated_merge_tree
 SYSTEM DISABLE FAILPOINT replicated_merge_tree_insert_retry_pause;
 SELECT name, enabled FROM system.fail_points WHERE name = 'replicated_merge_tree_insert_retry_pause';
 -- Expected: replicated_merge_tree_insert_retry_pause 0
+
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/103403
+-- Querying system.fail_points must NOT consume ONCE / PAUSEABLE_ONCE failpoints.
+-- Previously fillData called fiu_fail() which triggered and consumed ONETIME points.
+
+-- ONCE failpoint: should still report enabled=1 across repeated SELECTs.
+SYSTEM ENABLE FAILPOINT replicated_queue_fail_next_entry;
+SELECT 'once_first', enabled FROM system.fail_points WHERE name = 'replicated_queue_fail_next_entry';
+SELECT 'once_second', enabled FROM system.fail_points WHERE name = 'replicated_queue_fail_next_entry';
+SELECT 'once_third', enabled FROM system.fail_points WHERE name = 'replicated_queue_fail_next_entry';
+SYSTEM DISABLE FAILPOINT replicated_queue_fail_next_entry;
+SELECT 'once_disabled', enabled FROM system.fail_points WHERE name = 'replicated_queue_fail_next_entry';
+
+-- PAUSEABLE_ONCE failpoint: same regression, must not be consumed by SELECT.
+SYSTEM ENABLE FAILPOINT smt_commit_tweaks_gate_open;
+SELECT 'pauseable_once_first', enabled FROM system.fail_points WHERE name = 'smt_commit_tweaks_gate_open';
+SELECT 'pauseable_once_second', enabled FROM system.fail_points WHERE name = 'smt_commit_tweaks_gate_open';
+SYSTEM DISABLE FAILPOINT smt_commit_tweaks_gate_open;
+SELECT 'pauseable_once_disabled', enabled FROM system.fail_points WHERE name = 'smt_commit_tweaks_gate_open';


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

When calling system.failpoints table, it would use a failpoint, thus possibly disabling it.

Closes https://github.com/ClickHouse/ClickHouse/issues/103403

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.354`
<!-- ch-version-info:end -->