### PR TITLE
Fix UBSan null deref in ThreadStatus::flushUntrackedMemory

### DIFF
--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -239,7 +239,7 @@ void ThreadStatus::flushUntrackedMemory()
         return;
 
     MemoryTrackerBlockerInThread blocker(untracked_memory_blocker_level);
-    Int64 current_untracked_memory = current_thread->untracked_memory;
+    Int64 current_untracked_memory = untracked_memory;
     untracked_memory = 0;
     memory_tracker.adjustWithUntrackedMemory(current_untracked_memory);
 }


### PR DESCRIPTION
`flushUntrackedMemory` is a member function of `ThreadStatus` and the surrounding lines access the member `untracked_memory` directly. The new local on line 242 was reading `current_thread->untracked_memory` instead — in the typical case `current_thread == this` so the value is the same, but when `current_thread` is null (e.g. before TLS is set or inside paths where `this != current_thread`) UBSan flags a null pointer dereference. Use the member directly, matching the read/write of `untracked_memory` on the lines around it.

Reported by the `function_prop_fuzzer` unit test:

```
/ClickHouse/src/Common/ThreadStatus.cpp:242:54: runtime error: member access within null pointer of type 'ThreadStatus'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /ClickHouse/src/Common/ThreadStatus.cpp:242:54
```

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104136&sha=latest&name_0=PR&name_1=Unit+tests+%28asan_ubsan%2C+function_prop_fuzzer%29

cc @azat

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)