### PR TITLE
Cap arrayResize size argument in functions stress test

### DIFF
--- a/src/Functions/tests/gtest_functions_stress.cpp
+++ b/src/Functions/tests/gtest_functions_stress.cpp
@@ -488,6 +488,7 @@ const std::unordered_map<std::string_view, std::vector<std::pair</*arg_idx*/ siz
 function_arg_constraints = {
     {"randomStringUTF8", {{0, {.integer_at_most = 50}}}},
     {"arrayWithConstant", {{0, {.integer_at_most = 20}}}},
+    {"arrayResize", {{1, {.integer_at_most = 1000}}}},
 };
 
 constexpr size_t MEMORY_LIMIT_BYTES_PER_THREAD = 256 << 20;


### PR DESCRIPTION
The fuzzer can pick a large random integer as the second argument of `arrayResize` (anything below `MAX_ARRAY_SIZE = 1 << 30`), which makes the function spend many seconds filling the result. If a thread happens to start such a call near the end of the run, the unit test trips its 30s shutdown timeout and reports a stuck thread.

Add `arrayResize` to `function_arg_constraints` so its size argument is capped, mirroring the existing caps on `randomStringUTF8` and `arrayWithConstant`.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104136&sha=latest&name_0=PR&name_1=Unit+tests+%28asan_ubsan%2C+function_prop_fuzzer%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.360`
<!-- ch-version-info:end -->