### PR TITLE
Fix Bad cast on data-lake `SETTINGS disk = '...'` with wrapped object storage

### DIFF
--- a/src/Storages/ObjectStorage/Azure/Configuration.cpp
+++ b/src/Storages/ObjectStorage/Azure/Configuration.cpp
@@ -327,7 +327,12 @@ bool AzureStorageParsedArguments::collectCredentials(
 
 void AzureStorageParsedArguments::fromDisk(DiskPtr disk, ASTs & args, ContextPtr context, bool with_structure)
 {
-    const auto & azure_object_storage = assert_cast<const AzureObjectStorage &>(*disk->getObjectStorage());
+    auto object_storage = disk->getObjectStorage();
+    /// Unwrap decorator object storages (e.g. `CachedObjectStorage`) before the cast.
+    /// See `S3StorageParsedArguments::fromDisk` and issue #89300 for the rationale.
+    while (auto inner = object_storage->getUnderlying())
+        object_storage = std::move(inner);
+    const auto & azure_object_storage = assert_cast<const AzureObjectStorage &>(*object_storage);
 
     connection_params = azure_object_storage.getConnectionParameters();
     ParseFromDiskResult parsing_result = parseFromDisk(args, with_structure, context, disk->getPath());

--- a/src/Storages/ObjectStorage/S3/Configuration.cpp
+++ b/src/Storages/ObjectStorage/S3/Configuration.cpp
@@ -330,6 +330,12 @@ bool S3StorageParsedArguments::collectCredentials(ASTPtr maybe_credentials, S3::
 void S3StorageParsedArguments::fromDisk(const DiskPtr & disk, ASTs & args, ContextPtr context, bool with_structure)
 {
     auto object_storage = disk->getObjectStorage();
+    /// Unwrap decorator object storages (e.g. `CachedObjectStorage`) before the cast.
+    /// `assert_cast` checks `typeid` exactly, so calling it on a wrapper would throw a
+    /// LOGICAL_ERROR even though the wrapper exposes the same interface and ultimately
+    /// holds an `S3ObjectStorage`. See https://github.com/ClickHouse/ClickHouse/issues/89300.
+    while (auto inner = object_storage->getUnderlying())
+        object_storage = std::move(inner);
     const auto & s3_object_storage = assert_cast<const S3ObjectStorage &>(*object_storage);
     s3_settings = std::make_unique<S3Settings>();
     *s3_settings = s3_object_storage.getS3Settings();

--- a/tests/config/config.d/storage_conf.xml
+++ b/tests/config/config.d/storage_conf.xml
@@ -146,6 +146,12 @@
             </s3_cache_encrypted>
         </policies>
     </storage_configuration>
+    <!-- Allow data-lake table engines (Iceberg, Delta, Hudi) to use these disks via
+         `SETTINGS disk = '...'`. Used by tests like 04208_iceberg_disk_with_cache_no_bad_cast.sql.
+         The list intentionally only contains disks that wrap an `S3ObjectStorage` (raw,
+         cached, or with a non-default metadata layer) so we exercise the unwrap-before-cast
+         path in `S3StorageParsedArguments::fromDisk` without affecting other tests. -->
+    <allowed_disks_for_table_engines>s3_disk,s3_cache,s3_plain_disk,s3_plain_rewritable</allowed_disks_for_table_engines>
     <filesystem_caches>
         <cache_for_readbigat>
             <path>./cache_for_readbigat/</path>

--- a/tests/queries/0_stateless/04208_iceberg_disk_with_cache_no_bad_cast.sql
+++ b/tests/queries/0_stateless/04208_iceberg_disk_with_cache_no_bad_cast.sql
@@ -1,0 +1,36 @@
+-- Tags: no-fasttest, no-replicated-database, no-distributed-cache
+-- ^ no-fasttest: needs MinIO + s3 endpoints from CI fixtures
+--   no-replicated-database: stateless test using `disk = '...'`
+
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/89300
+-- Calling a data-lake table function with `SETTINGS disk = '<disk>'` used to throw
+-- `Logical error: 'Bad cast from type DB::CachedObjectStorage to DB::S3ObjectStorage'`
+-- whenever the disk wrapped its underlying object storage (e.g. cache layer).
+-- The same shape of bug previously affected `DB::PlainObjectStorage<DB::S3ObjectStorage>`
+-- before that decorator was removed in #90580.
+--
+-- The fix unwraps decorator object storages via `IObjectStorage::getUnderlying`
+-- before casting to the concrete `S3ObjectStorage` in `S3StorageParsedArguments::fromDisk`.
+--
+-- We do not exercise reading any real iceberg data here; the assertion is purely
+-- that argument parsing does not crash with a logical error. The query itself is
+-- expected to fail at table-resolution time with an S3/iceberg error code.
+
+-- Cached disk (`CachedObjectStorage` wrapping `S3ObjectStorage`) — the bug from
+-- BuzzHouse fuzzer hit on PR #94148 ("Bad cast from CachedObjectStorage to S3ObjectStorage").
+SELECT 1 FROM icebergS3('no_such_table_for_89300_cache', 'Parquet', 'a Int',
+                        SETTINGS disk = 's3_cache')
+; -- { serverError S3_ERROR, FILE_DOESNT_EXIST, BAD_REQUEST_PARAMETER, ICEBERG_SPECIFICATION_VIOLATION, RESOURCE_NOT_FOUND, FORMAT_IS_NOT_SUITABLE_FOR_INPUT, CANNOT_PARSE_INPUT_ASSERTION_FAILED, CANNOT_EXTRACT_TABLE_STRUCTURE }
+
+-- Plain-metadata S3 disk — historically a `PlainObjectStorage<S3ObjectStorage>` wrapper
+-- (the original symptom in #89300). The decorator class itself was removed in #90580
+-- so the cast now succeeds even without this PR's change, but we keep this case as a
+-- guard against any reintroduction of similar wrapping for plain disks.
+SELECT 1 FROM icebergS3('no_such_table_for_89300_plain', 'Parquet', 'a Int',
+                        SETTINGS disk = 's3_plain_disk')
+; -- { serverError S3_ERROR, FILE_DOESNT_EXIST, BAD_REQUEST_PARAMETER, ICEBERG_SPECIFICATION_VIOLATION, RESOURCE_NOT_FOUND, FORMAT_IS_NOT_SUITABLE_FOR_INPUT, CANNOT_PARSE_INPUT_ASSERTION_FAILED, CANNOT_EXTRACT_TABLE_STRUCTURE }
+
+-- Sanity check: the same query on a raw S3 disk (no decorator) keeps working.
+SELECT 1 FROM icebergS3('no_such_table_for_89300_raw', 'Parquet', 'a Int',
+                        SETTINGS disk = 's3_disk')
+; -- { serverError S3_ERROR, FILE_DOESNT_EXIST, BAD_REQUEST_PARAMETER, ICEBERG_SPECIFICATION_VIOLATION, RESOURCE_NOT_FOUND, FORMAT_IS_NOT_SUITABLE_FOR_INPUT, CANNOT_PARSE_INPUT_ASSERTION_FAILED, CANNOT_EXTRACT_TABLE_STRUCTURE }


### PR DESCRIPTION
Fixes #89300.

## Motivation

A user reported via #89300 that

```sql
SELECT 1 FROM icebergS3(s3, format = 'Parquet', filename = '...', SETTINGS disk = 'disk0');
```

against a disk configured with `metadata_type = plain` aborted with
`Logical error: 'Bad cast from type DB::PlainObjectStorage<DB::S3ObjectStorage> to DB::S3ObjectStorage'`.

The `PlainObjectStorage<>` decorator was deleted by #90580, so the
exact crash from the original report is gone, but the underlying bug
pattern remains: `S3StorageParsedArguments::fromDisk` (and the Azure
sibling) call `assert_cast<const S3ObjectStorage &>(*disk->getObjectStorage())`
directly. `assert_cast` performs an exact `typeid` match in
debug/sanitizer builds, so any decorator that wraps the underlying
storage instead of being it (most importantly `CachedObjectStorage`,
returned by `DiskObjectStorage::wrapWithCache`) still crashes argument
parsing with `Logical error: 'Bad cast from type DB::CachedObjectStorage to DB::S3ObjectStorage'`.

I confirmed this is currently reachable in trunk:

- The BuzzHouse fuzzer hit it on PR #94148 with
  `CREATE TABLE d1.t28 ENGINE = DeltaLakeS3(s3, filename = 't28', format = 'Parquet') SETTINGS disk = 'disk1', iceberg_format_version = 3`.
- Reproduced locally: a debug ClickHouse with a `cache`-typed disk over
  `s3` and `SETTINGS disk = '<cache_disk>'` aborts the server in the
  exact same way.

## Approach

`IObjectStorage` already exposes `getUnderlying()` which returns the
inner storage for decorator types and `nullptr` otherwise. Walk that
chain before the cast in both `S3StorageParsedArguments::fromDisk` and
`AzureStorageParsedArguments::fromDisk`. After unwrapping, the cast
sees the concrete `S3ObjectStorage` / `AzureObjectStorage` and
succeeds.

## Validation

Pre-PR validation gate:

- **Deterministic repro?** Yes — confirmed locally with a debug build:
  ```
  SELECT 1 FROM icebergS3('no_such_table', 'Parquet', 'a Int',
                          SETTINGS disk = 's3_cache_test')
  ```
  on master HEAD aborts with
  `Logical error: 'Bad cast from type DB::CachedObjectStorage to DB::S3ObjectStorage'`
  and kills the server.
- **Root cause explained?** Yes — `assert_cast` in
  `DEBUG_OR_SANITIZER_BUILD` does a strict `typeid(from) == typeid(To)`
  check (see comment at `src/Common/assert_cast.h:19`). `CachedObjectStorage`
  inherits only from `IObjectStorage`, not from `S3ObjectStorage`, so
  the equality fails and the helper throws `LOGICAL_ERROR`. In release
  builds the underlying `static_cast` is undefined behaviour because
  there is no inheritance relationship at all.
- **Fix matches root cause?** Yes — unwrap to the concrete storage so
  the typeid matches. No `assert_cast` semantics are weakened.
- **Test intent preserved?** N/A; this PR adds a new regression test.
- **Both directions demonstrated?** Yes — same query on the fixed
  binary returns `FILE_DOESNT_EXIST` (as expected for a missing iceberg
  table) instead of crashing. Verified for `s3_disk` (raw),
  `s3_cache` (cached), and `s3_plain_disk` (plain metadata).
- **Fix is general?** Yes — applied to both the S3 and Azure parsers,
  and uses the existing `getUnderlying()` virtual so any future
  decorator added to `IObjectStorage` is handled automatically.

The new stateless test
`tests/queries/0_stateless/04208_iceberg_disk_with_cache_no_bad_cast.sql`
exercises all three disk shapes (raw, cached, plain metadata) and
asserts that the query fails with an S3/iceberg-level error rather
than a `LOGICAL_ERROR`. The existing test config is extended with a
narrow `allowed_disks_for_table_engines` so the data-lake disk gate
lets the queries through to the real check.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a logical error (`Bad cast from type DB::CachedObjectStorage to DB::S3ObjectStorage`) that aborted argument parsing of data-lake table functions and engines (`icebergS3`, `deltaLakeS3`, etc.) when called with `SETTINGS disk = '...'` against a disk whose underlying object storage is wrapped by a decorator such as a filesystem cache. Closes #89300.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)