### PR TITLE
CI: skip integration flaky check when only test deletions are present

### DIFF
--- a/ci/jobs/scripts/workflow_hooks/new_tests_check.py
+++ b/ci/jobs/scripts/workflow_hooks/new_tests_check.py
@@ -8,7 +8,10 @@ from ci.praktika.info import Info
 def has_new_functional_tests(changed_files):
     for file in changed_files:
         file = file.removeprefix(".").removeprefix("/")
-        if file.startswith("tests/queries/0_stateless"):
+        # Deleted files are still listed in changed_files; skip them so a PR that
+        # only removes tests does not trigger flaky/bugfix checks that would then
+        # find nothing to run.
+        if file.startswith("tests/queries/0_stateless") and Path(file).is_file():
             return True
     return False
 
@@ -20,6 +23,7 @@ def has_new_integration_tests(changed_files):
             file.startswith("tests/integration/test_")
             and Path(file).name.startswith("test")
             and file.endswith(".py")
+            and Path(file).is_file()
         ):
             return True
     return False
@@ -28,7 +32,7 @@ def has_new_integration_tests(changed_files):
 def has_new_unit_tests(changed_files):
     for file in changed_files:
         file = file.removeprefix(".").removeprefix("/")
-        if file.startswith("src") and "/tests/" in file:
+        if file.startswith("src") and "/tests/" in file and Path(file).is_file():
             return True
     return False
 


### PR DESCRIPTION
The `Integration tests (..., flaky)` job re-runs changed integration test modules many times to flush out flakiness. Its upstream filter in `ci/jobs/scripts/workflow_hooks/filter_job.py` calls `has_new_integration_tests` to decide whether to schedule the job, but that helper only inspected the path of each entry in the diff — it did not check whether the file still exists. Files removed by the PR are still listed in `changed_files`, so a PR whose only `tests/integration/` change is a deletion still scheduled the job.

Inside the runner, `integration_test_job.py` does filter changed test modules by `Path(file).is_file()`, so the resulting list ends up empty and the job trips its own assertion:

```
AssertionError: No changed test modules found, either job must be skipped or bug in changed test search logic
```

This change makes `has_new_functional_tests`, `has_new_integration_tests`, and `has_new_unit_tests` consistent with the downstream filter by also requiring `Path(file).is_file()`. PRs whose only test changes are deletions no longer trigger the flaky / bugfix-validation checks.

Reproduced on #104262 — the revert deletes `tests/integration/test_backward_compatibility/test_aggregate_function_state_contingency_functions.py`. CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104262&sha=805164d84959823927a55a66aea96a4c3b48ea55&name_0=PR&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20flaky%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.355`
<!-- ch-version-info:end -->