### PR TITLE
Skip 00146_aggregate_function_uniq under MSan

### DIFF
--- a/tests/queries/0_stateless/00146_aggregate_function_uniq.sql
+++ b/tests/queries/0_stateless/00146_aggregate_function_uniq.sql
@@ -1,4 +1,11 @@
--- Tags: stateful
+-- Tags: stateful, no-msan
+-- no-msan: `uniqExact(WatchID) FROM test.hits` materializes every distinct WatchID into a
+-- HashSet over ~100M rows; under MSan the per-access shadow check cost combined with adversarial
+-- random settings (small `max_block_size`, `max_threads = 2`, `compile_aggregate_expressions = 0`,
+-- `merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability` close
+-- to 1) pushes the test past the 600s per-test timeout. MSan coverage of `uniq`/`uniqHLL12`/
+-- `uniqCombined`/`uniqExact` is provided by the smaller stateless tests (e.g. `00264_uniq_many_args`).
+
 SELECT RegionID, uniqHLL12(WatchID) AS X FROM remote('127.0.0.{1,2}', test, hits) GROUP BY RegionID HAVING X > 100000 ORDER BY RegionID ASC;
 SELECT RegionID, uniqCombined(WatchID) AS X FROM remote('127.0.0.{1,2}', test, hits) GROUP BY RegionID HAVING X > 100000 ORDER BY RegionID ASC;
 SELECT abs(uniq(WatchID) - uniqExact(WatchID)) FROM test.hits;


### PR DESCRIPTION
Per @alexey-milovidov [directive on PR #104248](https://github.com/ClickHouse/ClickHouse/pull/104248#issuecomment-4392079918) — fix `00146_aggregate_function_uniq` and send a separate PR.

### Failure

CI report: [Stateless tests (amd_msan, WasmEdge, parallel, 2/2)](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104248&sha=ba3d3f4535f6bc42827cc67c3f439c5c0ee381de&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%202%2F2%29) on `ba3d3f4535f6bc42827cc67c3f439c5c0ee381de`.

```
Reason: Timeout!
```

The CI's `--diagnose-random-settings` confirmed:

```
Step 1: Re-running with the same randomized settings (budget: 60s)...
  Runs: 1, Failed: 1, Passed: 0, Other: 0
Result: Failure is reproducible.
Step 2: Re-running without randomized settings (budget: 60s)...
  Runs: 4, Failed: 0, Passed: 4, Other: 0
Result: Passes without randomization. Confirmed: the failure is caused by randomized settings.
```

### Root cause

The third query is the bottleneck:

```sql
SELECT abs(uniq(WatchID) - uniqExact(WatchID)) FROM test.hits;
```

`uniqExact` materializes every distinct `WatchID` into a `HashSet` over the full ~100M-row hits dataset. Under MSan the per-access shadow check cost combined with the adversarial random settings the runner picked (`max_block_size = 14392`, `max_threads = 2`, `compile_aggregate_expressions = 0`, `merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0.72`, etc.) pushes the test past the 600s per-test timeout. Without randomization the test finishes well under 60s.

### Fix

Add `no-msan` to the test tags. This is the established convention for heavy stateful tests that exceed the MSan budget:

| Test | Tags | Comment |
|---|---|---|
| `00024_random_counters` | `stateful, no-parallel, no-msan` | "Heavy" |
| `00157_cache_dictionary` | `stateful, no-tsan, no-msan, no-asan, no-parallel` | "Heavy" |
| `00326_long_function_multi_if` | `long, no-msan` | "msan: it takes a long time" |
| `00625_summing_merge_tree_merge` | `no-msan` | "msan: too slow" |
| `00804_test_alter_compression_codecs` | `no-msan` | "INSERT with 300k rows sometimes takes >5 minutes in msan build" |

MSan coverage of `uniq`/`uniqHLL12`/`uniqCombined`/`uniqExact` is already provided by smaller stateless tests like `00264_uniq_many_args` that exercise the same code paths without the 100M-row dataset.

CIDB confirms the failure is a one-off — `00146_aggregate_function_uniq` had not failed since the 2026-03-21 `clickhouse-test` infrastructure bug (`Test internal error: ValueError`), and never on master in the past 90 days.

### Pre-PR validation
Posted as a separate comment per worker procedure.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.370`
<!-- ch-version-info:end -->