### PR TITLE
Pin prewhere settings in 04051_pk_analysis_stats

### DIFF
--- a/tests/queries/0_stateless/04051_pk_analysis_stats.sql
+++ b/tests/queries/0_stateless/04051_pk_analysis_stats.sql
@@ -23,6 +23,18 @@ optimize table t final;
 set enable_analyzer=1;
 set use_query_condition_cache=1;
 
+-- Pin the settings that the assertion depends on. The test runner injects
+-- random session settings; without these pins, the runner can flip
+-- `optimize_move_to_prewhere` / `query_plan_optimize_prewhere` to `0` and the
+-- query condition cache then writes its verdict against the WHERE-side hash
+-- instead of the PREWHERE-side hash documented in the comment block at the
+-- top of this file. The assertion still holds for the WHERE-side path, but
+-- pinning both keeps the test exercising the same code path the regression
+-- comment describes and removes a class of CI noise that is unrelated to
+-- the bug under test.
+set optimize_move_to_prewhere=1;
+set query_plan_optimize_prewhere=1;
+
 -- Pre-warm the query condition cache
 select avg(a) from t where s != 'xxx' format Null;
 


### PR DESCRIPTION
The test `04051_pk_analysis_stats` verifies that PK analysis stats correctly account for granules already dropped by the `QueryConditionCache` (QCC). The docstring at the top of the test references a specific log-line example where the QCC drops granules for the `PREWHERE` condition first and PK analysis then runs on the remaining marks.

Without explicit pins, the test runner's `--random-settings` injection can flip `optimize_move_to_prewhere` and/or `query_plan_optimize_prewhere` off. The QCC's verdict then ends up keyed by the `WHERE`-side hash instead of the `PREWHERE`-side hash documented in the comment block, exercising a different code path on every run.

The assertion `ProfileEvents['FilteringMarksWithPrimaryKeyProcessedMarks'] < total_marks` still holds in either path (both sides drop marks before PK analysis runs in `MergeTreeDataSelectExecutor::filterPartsByQueryConditionCache`). But this variability has been a recurring source of confusion: when an unrelated PR's CI surfaces a transient or PR-caused failure for this test, `--diagnose-random-settings` minimizes the culprit set down to a single non-causal session setting (e.g. `--session_timezone`), and the failure then gets misattributed to settings that have no semantic relationship with the test.

Pin both prewhere settings inside the SQL so the test always exercises the documented `PREWHERE` QCC drop path. SETs inside the test SQL override the CLI flags injected by the runner, so this is robust against any future random-settings expansion that touches prewhere.

Verified locally on a debug build:
- 50/50 passes with default `--random-settings` randomisation.
- 100/100 passes with `-j 4 --test-runs 100`.
- 50/50 passes with adversarial overrides (`--use_query_condition_cache 0 --optimize_move_to_prewhere False --query_plan_optimize_prewhere False --session_timezone America/Mazatlan --enable_multiple_prewhere_read_steps 0 --max_threads 1 --max_block_size 17886`).

CI report that motivated the fix: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104225&sha=ef78dcecf6d3c6a1ccad2481e090794460e778cb&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29

Related: https://github.com/ClickHouse/ClickHouse/pull/103857#issuecomment-4391247864 (`@alexey-milovidov` directive to fix this test in a separate PR).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.406`
<!-- ch-version-info:end -->