### PR TITLE
Widen timing thresholds in 04053_merge_table_large_query_performance

### DIFF
--- a/tests/queries/0_stateless/04053_merge_table_large_query_performance.sh
+++ b/tests/queries/0_stateless/04053_merge_table_large_query_performance.sh
@@ -143,26 +143,29 @@ FORMAT Null"
 
 # Compare planning time on the Merge table against a single underlying table.
 # Pre-fix, planning was O(N * query_tree_size), so merge-table latency scaled with N.
+# With N=200 underlying tables this would be ~100x-200x slower than a single-table query.
 # Post-fix, the Merge planner shares the cloned query tree across tables of identical
 # structure, so merge-table latency stays close to single-table latency.
-# A loose 10x ratio is enough to catch the regression while tolerating CI noise.
+# A loose 20x ratio is enough to catch the regression while tolerating CI noise.
+# The single-table timed run is fast (~250-400ms) and small absolute fluctuations cause
+# large ratio swings under parallel CI load, so the threshold needs comfortable margin.
 QUERY_SINGLE_TIMING="${QUERY/t_merge_perf_all/t_merge_perf_0}"
 
 # Warm up the data-side cache with a small query so the timed runs measure planning.
 $CLICKHOUSE_CLIENT -q "SELECT count() FROM ${CLICKHOUSE_DATABASE}.t_merge_perf_0 FORMAT Null"
 
 T_START=$(date +%s%N)
-$CLICKHOUSE_CLIENT --max_query_size 1048576 --max_execution_time 10 -q "$QUERY" >/dev/null || { echo "FAIL: query on merge table timed out" >&2; exit 1; }
+$CLICKHOUSE_CLIENT --max_query_size 1048576 --max_execution_time 30 -q "$QUERY" >/dev/null || { echo "FAIL: query on merge table timed out" >&2; exit 1; }
 T_END=$(date +%s%N)
 TIME_MERGE_NS=$((T_END - T_START))
 
 T_START=$(date +%s%N)
-$CLICKHOUSE_CLIENT --max_query_size 1048576 --max_execution_time 10 -q "$QUERY_SINGLE_TIMING" >/dev/null || { echo "FAIL: query on single table timed out" >&2; exit 1; }
+$CLICKHOUSE_CLIENT --max_query_size 1048576 --max_execution_time 30 -q "$QUERY_SINGLE_TIMING" >/dev/null || { echo "FAIL: query on single table timed out" >&2; exit 1; }
 T_END=$(date +%s%N)
 TIME_SINGLE_NS=$((T_END - T_START))
 
-if [ "$TIME_MERGE_NS" -gt $((TIME_SINGLE_NS * 10)) ]; then
-    echo "FAIL: merge-table query (${TIME_MERGE_NS}ns) is more than 10x slower than single-table query (${TIME_SINGLE_NS}ns)" >&2
+if [ "$TIME_MERGE_NS" -gt $((TIME_SINGLE_NS * 20)) ]; then
+    echo "FAIL: merge-table query (${TIME_MERGE_NS}ns) is more than 20x slower than single-table query (${TIME_SINGLE_NS}ns)" >&2
     exit 1
 fi
 echo "OK"


### PR DESCRIPTION
The stateless test `04053_merge_table_large_query_performance` is chronically flaky. It asserts that a `Merge`-table query is no more than 10x slower than the equivalent single-table query, with a 10s `max_execution_time` on each timed run. Both bounds are too tight under parallel CI noise: the single-table run is fast (~250-400ms) so small absolute jitter produces large ratio swings, and 10s leaves no margin when the runner is loaded.

Recent CIDB evidence (30-day window, 8 failures across 5 unrelated PRs + 1 master hit on 2026-05-05) shows the test failing in two ways:
- Ratio just over the threshold: 10.3x, 10.3x, 13x, 16x.
- Per-query timeout: 11s, 13s.

This PR widens the ratio threshold from 10x to 20x and the per-query `max_execution_time` from 10s to 30s. The original `O(N * query_complexity)` regression that this test catches (issue [#32465](https://github.com/ClickHouse/ClickHouse/issues/32465)) would scale to ~100x-200x slowdown at `N=200` underlying tables, so 20x still detects it comfortably and 30s easily catches the multi-tens-of-seconds runtime that bug produced.

Sample failing CI report:
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=102351&sha=e940916c39e25638c2ec009450af9199992a9ec9&name_0=PR&name_1=Stateless%20tests%20%28arm_binary%2C%20parallel%29 (PR [#102351](https://github.com/ClickHouse/ClickHouse/pull/102351))

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.412`
<!-- ch-version-info:end -->