### PR TITLE
Avoid quoting `Logical error` text verbatim in test 04208 comments

### DIFF
--- a/tests/queries/0_stateless/04208_iceberg_disk_with_cache_no_bad_cast.sql
+++ b/tests/queries/0_stateless/04208_iceberg_disk_with_cache_no_bad_cast.sql
@@ -4,20 +4,25 @@
 
 -- Regression test for https://github.com/ClickHouse/ClickHouse/issues/89300
 -- Calling a data-lake table function with `SETTINGS disk = '<disk>'` used to throw
--- `Logical error: 'Bad cast from type DB::CachedObjectStorage to DB::S3ObjectStorage'`
+-- a bad-cast assertion (from the wrapping decorator down to `S3ObjectStorage`)
 -- whenever the disk wrapped its underlying object storage (e.g. cache layer).
--- The same shape of bug previously affected `DB::PlainObjectStorage<DB::S3ObjectStorage>`
+-- The same shape of bug previously affected `PlainObjectStorage` over `S3ObjectStorage`
 -- before that decorator was removed in #90580.
 --
 -- The fix unwraps decorator object storages via `IObjectStorage::getUnderlying`
 -- before casting to the concrete `S3ObjectStorage` in `S3StorageParsedArguments::fromDisk`.
 --
 -- We do not exercise reading any real iceberg data here; the assertion is purely
--- that argument parsing does not crash with a logical error. The query itself is
--- expected to fail at table-resolution time with an S3/iceberg error code.
+-- that argument parsing does not abort. The query itself is expected to fail at
+-- table-resolution time with an S3/iceberg error code.
+--
+-- NOTE: this comment intentionally avoids quoting the exception text verbatim,
+-- because the stress-test log scanner greps for that pattern in the server log
+-- and a literal copy in the query log produces false-positive failure reports
+-- (the SQL comment is echoed into the `<Error> executeQuery` entry on failure).
 
--- Cached disk (`CachedObjectStorage` wrapping `S3ObjectStorage`) — the bug from
--- BuzzHouse fuzzer hit on PR #94148 ("Bad cast from CachedObjectStorage to S3ObjectStorage").
+-- Cached disk (`CachedObjectStorage` wrapping `S3ObjectStorage`) — the bug
+-- originally reported from a BuzzHouse fuzzer hit on PR #94148.
 SELECT 1 FROM icebergS3('no_such_table_for_89300_cache', 'Parquet', 'a Int',
                         SETTINGS disk = 's3_cache')
 ; -- { serverError S3_ERROR, FILE_DOESNT_EXIST, BAD_REQUEST_PARAMETER, ICEBERG_SPECIFICATION_VIOLATION, RESOURCE_NOT_FOUND, FORMAT_IS_NOT_SUITABLE_FOR_INPUT, CANNOT_PARSE_INPUT_ASSERTION_FAILED, CANNOT_EXTRACT_TABLE_STRUCTURE }


### PR DESCRIPTION
The stress-test log scanner (`ci/jobs/scripts/log_parser.py`) uses
`rg --text -A 10 -o 'Logical error.*'` against the server log. Test
`04208_iceberg_disk_with_cache_no_bad_cast.sql` previously included
the literal exception string in its SQL comments. When such a query
fails (it is expected to fail at table-resolution time), the full
query — including those comments — is echoed into the
`<Error> executeQuery` log entry. If a later, completely unrelated
fatal error occurs in the same stress-test run, the scanner picks up
the SQL-comment occurrence first and uses it as the failure name,
even though the actual stack trace (and `STID`) belong to a different
bug.

Three master/PR runs on 2026-05-07 hit this false positive (all
attributed in CI as `Logical error: 'Bad cast from type DB::CachedObjectStorage to DB::S3ObjectStorage'`):

- `Stress test (experimental, serverfuzz, arm_tsan)` on master
  (commit 69167ef) — actual abort was a `chassert(false)` in
  `paranoidCheckForCoveredPartsInZooKeeperOnStart`,
  reported as `STID 2508-5dc3`.
- `Stress test (arm_asan_ubsan)` on PR #100377 — actual abort was
  `Not-ready Set is passed as the second argument for function 'in'`
  in `FunctionIn::executeImpl`, reported as `STID 0250-4e52`.
- `Stress test (amd_msan)` on PR #93037 — same `Not-ready Set`
  family, reported as `STID 0250-41a5`.

The original `Bad cast` bug that this test guards against is
genuinely fixed by #104258 — the unwrap loop in
`S3StorageParsedArguments::fromDisk` is in place and none of these
three runs actually aborted in that code path.

This PR reworks the comments in 04208 so they describe the bug
without containing the verbatim `Logical error: '...'` pattern that
the scanner greps for, and adds a `NOTE` explaining why the verbatim
text is intentionally avoided. The SQL queries and expected
`serverError` codes are unchanged.

A follow-up to harden `log_parser.py` itself (for example, by
requiring a real log-line prefix before matching `Logical error.*`)
would address the same class of false positive for any future test
that mentions an exception text in a comment, but is intentionally
out of scope here to keep this PR minimal.

CI report (master arm_tsan): https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=69167ef25d21358fd8f171e593849ea73195dd1b&name_0=MasterCI&name_1=Stress%20test%20%28experimental%2C%20serverfuzz%2C%20arm_tsan%29

Related: #89300, #104258 (the original fix this test guards).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.401`
<!-- ch-version-info:end -->