### PR TITLE
Fix incorrect `VALID UNTIL` timezone example in docs

### DIFF
--- a/docs/en/sql-reference/statements/create/user.md
+++ b/docs/en/sql-reference/statements/create/user.md
@@ -196,7 +196,6 @@ Examples:
 - `CREATE USER name1 VALID UNTIL '2025-01-01'`
 - `CREATE USER name1 VALID UNTIL '2025-01-01 12:00:00 UTC'`
 - `CREATE USER name1 VALID UNTIL 'infinity'`
-- ```CREATE USER name1 VALID UNTIL '2025-01-01 12:00:00 `Asia/Tokyo`'```
 - `CREATE USER name1 IDENTIFIED WITH plaintext_password BY 'no_expiration', bcrypt_password BY 'expiration_set' VALID UNTIL '2025-01-01''`
 
 ## GRANTEES Clause {#grantees-clause}

--- a/docs/en/sql-reference/statements/create/user.md
+++ b/docs/en/sql-reference/statements/create/user.md
@@ -199,6 +199,10 @@ Examples:
 - `CREATE USER name1 VALID UNTIL 'infinity'`
 - `CREATE USER name1 IDENTIFIED WITH plaintext_password BY 'no_expiration', bcrypt_password BY 'expiration_set' VALID UNTIL '2025-01-01'`
 
+:::note
+The datetime string is parsed by `parseDateTimeBestEffort`, which only recognizes the timezone tokens `UTC`, `GMT`, `Z`, `MSK`, `MSD`, and numeric offsets such as `+09:00` or `-05:00`. Named IANA timezones like `Asia/Tokyo` or `Europe/London` are not supported, and a fixed offset is not equivalent to an IANA zone for regions that observe daylight saving time, so you must compute the correct offset for the specific date you are encoding.
+:::
+
 ## GRANTEES Clause {#grantees-clause}
 
 Specifies users or roles which are allowed to receive [privileges](../../../sql-reference/statements/grant.md#privileges) from this user on the condition this user has also all required access granted with [GRANT OPTION](../../../sql-reference/statements/grant.md#granting-privilege-syntax). Options of the `GRANTEES` clause:

--- a/docs/en/sql-reference/statements/create/user.md
+++ b/docs/en/sql-reference/statements/create/user.md
@@ -195,8 +195,9 @@ Examples:
 
 - `CREATE USER name1 VALID UNTIL '2025-01-01'`
 - `CREATE USER name1 VALID UNTIL '2025-01-01 12:00:00 UTC'`
+- `CREATE USER name1 VALID UNTIL '2025-01-01 12:00:00 +09:00'`
 - `CREATE USER name1 VALID UNTIL 'infinity'`
-- `CREATE USER name1 IDENTIFIED WITH plaintext_password BY 'no_expiration', bcrypt_password BY 'expiration_set' VALID UNTIL '2025-01-01''`
+- `CREATE USER name1 IDENTIFIED WITH plaintext_password BY 'no_expiration', bcrypt_password BY 'expiration_set' VALID UNTIL '2025-01-01'`
 
 ## GRANTEES Clause {#grantees-clause}
 

--- a/docs/en/sql-reference/statements/create/user.md
+++ b/docs/en/sql-reference/statements/create/user.md
@@ -188,7 +188,7 @@ ClickHouse treats `user_name@'address'` as a username as a whole. Thus, technica
 
 ## VALID UNTIL Clause {#valid-until-clause}
 
-Allows you to specify the expiration date and, optionally, the time for an authentication method. It accepts a string as a parameter. It is recommended to use the `YYYY-MM-DD [hh:mm:ss] [timezone]` format for datetime. By default, this parameter equals `'infinity'`.
+Allows you to specify the expiration date and, optionally, the time for an authentication method. It accepts a string as a parameter. It is recommended to use the `YYYY-MM-DD [hh:mm:ss] [timezone]` format for datetime, where `[timezone]` must be a numeric offset such as `+09:00` or one of `UTC`, `GMT`, `Z`, `MSK`, `MSD`; named IANA zones like `Asia/Tokyo` are not recognized (see the note below). By default, this parameter equals `'infinity'`.
 The `VALID UNTIL` clause can only be specified along with an authentication method, except for the case where no authentication method has been specified in the query. In this scenario, the `VALID UNTIL` clause will be applied to all existing authentication methods.
 
 Examples:


### PR DESCRIPTION
The example added in #71159 showed:

```sql
CREATE USER name1 VALID UNTIL '2025-01-01 12:00:00 `Asia/Tokyo`'
```

This was my mistake. The intent was to document that timezone names containing `/`
require backtick-quoting inside the datetime string. However, the example doesn't
work as intended:

- A backtick (`` ` ``) is not an alphabetical character, so `parseDateTimeBestEffort`
  — which is used internally by `VALID UNTIL` — hits the `readAlpha` call, gets 0
  characters back, and breaks out of the parsing loop silently.
- The timezone `Asia/Tokyo` is therefore completely discarded.
- The time `12:00:00` is stored as-is in the server timezone rather than being
  converted from UTC+9, producing a result that is 9 hours off.

IANA timezone names embedded in a datetime string are not supported by
`parseDateTimeBestEffort` at all — only `UTC`, `GMT`, `MSK`, `MSD`, `Z`, and
numeric offsets like `+09:00` are handled. So the example documented non-working
behavior as though it works.


This PR removes the wrong example. 

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.399`
<!-- ch-version-info:end -->