### PR TITLE
Suppress retryable AWS log noise in tests against the public dataset bucket

### DIFF
--- a/tests/queries/0_stateless/03441_deltalake_clickhouse_public_datasets.sql
+++ b/tests/queries/0_stateless/03441_deltalake_clickhouse_public_datasets.sql
@@ -2,5 +2,8 @@
 -- Tag no-fasttest: Depends on AWS
 -- Tag no-msan: delta-kernel is not built with msan
 
+-- Suppress retryable AWS 5xx noise that would otherwise fail the test via stderr-fatal.
+SET send_logs_level = 'fatal';
+
 SELECT count()
 FROM deltaLake('https://clickhouse-public-datasets.s3.amazonaws.com/delta_lake/hits/', NOSIGN, SETTINGS allow_experimental_delta_kernel_rs = 1);

--- a/tests/queries/0_stateless/03441_deltalake_clickhouse_virtual_columns.sql
+++ b/tests/queries/0_stateless/03441_deltalake_clickhouse_virtual_columns.sql
@@ -3,6 +3,8 @@
 -- Tag no-msan: delta-kernel is not built with msan
 
 SET parallel_replicas_for_cluster_engines = 0;
+-- Suppress retryable AWS 5xx noise that would otherwise fail the test via stderr-fatal.
+SET send_logs_level = 'fatal';
 
 SELECT _data_lake_snapshot_version
 FROM deltaLake('https://clickhouse-public-datasets.s3.amazonaws.com/delta_lake/hits/', NOSIGN)

--- a/tests/queries/0_stateless/03988_cached_read_big_at.sh
+++ b/tests/queries/0_stateless/03988_cached_read_big_at.sh
@@ -8,7 +8,9 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 $CLICKHOUSE_CLIENT -q "SYSTEM CLEAR FILESYSTEM CACHE 'cache_for_readbigat'"
 
 # Reproduces issue from https://github.com/ClickHouse/ClickHouse/issues/97325
-$CLICKHOUSE_CLIENT -q "
+# --send_logs_level=fatal: the long read against the public AWS bucket can hit
+# transient retryable 5xx that the S3 retry strategy recovers from.
+$CLICKHOUSE_CLIENT --send_logs_level=fatal -q "
     SELECT
         (min(Title) <= max(Title)) AND
         (min(URL) <= max(URL)) AND

--- a/tests/queries/0_stateless/04103_deltalake_parquet_metadata_cache.sql
+++ b/tests/queries/0_stateless/04103_deltalake_parquet_metadata_cache.sql
@@ -4,6 +4,8 @@
 -- Tag no-parallel, no-parallel-replicas: the cache is system-wide so concurrent queries can influence the cache
 
 set log_queries = 1;
+-- Suppress retryable AWS 5xx noise that would otherwise fail the test via stderr-fatal.
+set send_logs_level = 'fatal';
 system drop parquet metadata cache;
 
 select count(), ParamCurrency


### PR DESCRIPTION
Tests reading from `https://clickhouse-public-datasets.s3.*.amazonaws.com/` can flake when AWS returns a transient retryable 5xx mid-stream: the request is retried successfully, but the `<Error>` line emitted by `PocoHTTPClient` is captured into `*.stderr-fatal` via `--client_logs_file`, and the runner fails the test with `having stderror`. Worst-affected is `03988_cached_read_big_at`, which streams a 14 GiB parquet with `max_download_threads = 1`.

This raises `send_logs_level` to `fatal` for the four tests that read this bucket and have no other guard. Mirrors the existing precedent in `03271_s3_table_function_asterisk_glob.sql` and ~130 other stateless tests.

Sample failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104253&sha=a4ae04d39170c4d2d821aedb448667867bea5497&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20sequential%29 (PR https://github.com/ClickHouse/ClickHouse/pull/104253). Server log shows `AWSClient: Response status: 500, Internal Server Error` followed by `S3ClientRetryStrategy: Attempt 2/501 succeeded with response code 206` and the query returning the correct result; the test still failed because the `<Error>` line landed in stderr-fatal.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.413`
<!-- ch-version-info:end -->