### PR TITLE
Docs: include created test database in system.databases example output

### DIFF
--- a/docs/en/operations/system-tables/databases.md
+++ b/docs/en/operations/system-tables/databases.md
@@ -50,5 +50,6 @@ SELECT * FROM system.databases;
 │ information_schema  │ Memory     │ /data/clickhouse_data/       │                                                                       │ 00000000-0000-0000-0000-000000000000 │ Memory                                                 │         │
 │ replicated_database │ Replicated │ /data/clickhouse_data/store/ │ /data/clickhouse_data/store/da8/da85bb71-102b-4f69-9aad-f8d6c403905e/ │ da85bb71-102b-4f69-9aad-f8d6c403905e │ Replicated('some/path/database', 'shard1', 'replica1') │         │
 │ system              │ Atomic     │ /data/clickhouse_data/store/ │ /data/clickhouse_data/store/b57/b5770419-ac7a-4b67-8229-524122024076/ │ b5770419-ac7a-4b67-8229-524122024076 │ Atomic                                                 │         │
+│ test                │ Atomic     │ /data/clickhouse_data/store/ │ /data/clickhouse_data/store/2a1/2a1b3c4d-5e6f-7890-abcd-ef1234567890/ │ 2a1b3c4d-5e6f-7890-abcd-ef1234567890 │ Atomic                                                 │         │
 └─────────────────────┴────────────┴──────────────────────────────┴───────────────────────────────────────────────────────────────────────┴──────────────────────────────────────┴────────────────────────────────────────────────────────┴─────────┘
 ```


### PR DESCRIPTION
Closes ClickHouse/clickhouse-docs#6090.

## Changelog category

* Documentation (changelog entry is not required)

## Changelog entry

n/a

## Description

The example on the `system.databases` page creates a `test` database and then runs `SELECT * FROM system.databases`, but the rendered response in the docs omits the `test` row. This has confused readers (reported via the docs feedback flow on the Russian translation: ClickHouse/clickhouse-docs#6090). Adding the missing row.

Companion fix for the Russian translation and other reader-reported docs errors: ClickHouse/clickhouse-docs#6168.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.400`
<!-- ch-version-info:end -->