### PR TITLE
check_ci.py: surface gh error when auto-merge fails

### DIFF
--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -1040,41 +1040,50 @@ def main():
         mergeable_check_status, sha=head_sha
     )
 
-    if Shell.check(f"gh pr merge {pr_number} --auto --repo ClickHouse/ClickHouse"):
-        # Give GitHub a moment to process auto-merge and update merge state
-        time.sleep(5)
-        merge_status = Shell.get_output(
-            f"gh pr view {pr_number} --json mergeStateStatus --jq '.mergeStateStatus' --repo ClickHouse/ClickHouse"
+    auto_merge_cmd = f"gh pr merge {pr_number} --auto --repo ClickHouse/ClickHouse"
+    if not Shell.check(auto_merge_cmd, verbose=True):
+        print(
+            f"ERROR: Failed to enable auto-merge for PR #{pr_number}. "
+            f"This often happens when mergeStateStatus is UNKNOWN "
+            f"(GitHub is still computing mergeability after a recent push). "
+            f"Retry manually:\n  {auto_merge_cmd}"
         )
-        if merge_status == "CLEAN":
-            # PR checks already passed but GitHub didn't enqueue it — the
-            # state transition was missed. Disable and re-enable auto-merge
-            # to force GitHub to re-evaluate.
-            print(
-                f"WARNING: PR #{pr_number} has mergeStateStatus=CLEAN (checks passed but not queued). "
-                f"Retoggling auto-merge to fix..."
-            )
-            Shell.check(
-                f"gh pr merge {pr_number} --disable-auto --repo ClickHouse/ClickHouse",
-                verbose=True,
-            )
-            time.sleep(2)
-            if Shell.check(
-                f"gh pr merge {pr_number} --auto --repo ClickHouse/ClickHouse",
-                verbose=True,
-            ):
-                print(f"OK: Auto-merge retoggled for PR #{pr_number}")
-            else:
-                print(
-                    f"ERROR: Failed to re-enable auto-merge for PR #{pr_number}. "
-                    f"Please manually click 'Merge when ready' on GitHub."
-                )
-        elif merge_status == "QUEUED":
-            print(f"OK: PR #{pr_number} added to the merge queue")
+        sys.exit(1)
+
+    # Give GitHub a moment to process auto-merge and update merge state
+    time.sleep(5)
+    merge_status = Shell.get_output(
+        f"gh pr view {pr_number} --json mergeStateStatus --jq '.mergeStateStatus' --repo ClickHouse/ClickHouse"
+    )
+    if merge_status == "CLEAN":
+        # PR checks already passed but GitHub didn't enqueue it — the
+        # state transition was missed. Disable and re-enable auto-merge
+        # to force GitHub to re-evaluate.
+        print(
+            f"WARNING: PR #{pr_number} has mergeStateStatus=CLEAN (checks passed but not queued). "
+            f"Retoggling auto-merge to fix..."
+        )
+        Shell.check(
+            f"gh pr merge {pr_number} --disable-auto --repo ClickHouse/ClickHouse",
+            verbose=True,
+        )
+        time.sleep(2)
+        if Shell.check(
+            f"gh pr merge {pr_number} --auto --repo ClickHouse/ClickHouse",
+            verbose=True,
+        ):
+            print(f"OK: Auto-merge retoggled for PR #{pr_number}")
         else:
             print(
-                f"OK: PR #{pr_number} auto-merge enabled (mergeStateStatus={merge_status})"
+                f"ERROR: Failed to re-enable auto-merge for PR #{pr_number}. "
+                f"Please manually click 'Merge when ready' on GitHub."
             )
+    elif merge_status == "QUEUED":
+        print(f"OK: PR #{pr_number} added to the merge queue")
+    else:
+        print(
+            f"OK: PR #{pr_number} auto-merge enabled (mergeStateStatus={merge_status})"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously when `gh pr merge --auto` returned non-zero, `Shell.check` silently returned `False` and the entire merge block was skipped without any output. The user saw only the "Add PR to merge queue (y/n)" prompt and then nothing, with the PR not actually queued.

This change runs the `gh` command with `verbose=True` so its stderr is streamed, and adds an early-exit branch that prints the exact command to retry manually. This typically happens when `mergeStateStatus` is `UNKNOWN` (GitHub is still computing mergeability after a recent push).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.403`
<!-- ch-version-info:end -->