### PR TITLE
Docs: fix link in extractGroups documentation

### DIFF
--- a/src/Functions/extractGroups.cpp
+++ b/src/Functions/extractGroups.cpp
@@ -112,7 +112,7 @@ public:
 REGISTER_FUNCTION(ExtractGroups)
 {
     FunctionDocumentation::Description description = R"(
-Extracts the capturing groups from the first substring matched by a regular expression. To extract groups from all matches, use [`extractAllGroupsHorizontal`](#extractAllGroupsHorizontal) or [`extractAllGroupsVertical`](#extractAllGroupsVertical).
+Extracts the capturing groups from the first substring matched by a regular expression. To extract groups from all matches, use [`extractAllGroupsHorizontal`](#extractAllGroupsHorizontal) or [`extractAllGroupsVertical`](/sql-reference/functions/splitting-merging-functions#extractAllGroupsVertical).
     )";
     FunctionDocumentation::Syntax syntax = "extractGroups(s, regexp)";
     FunctionDocumentation::Arguments arguments = {


### PR DESCRIPTION
## Summary

- Correct the embedded `FunctionDocumentation` for `extractGroups`: the prior text described the return type as `Array(Array(String))` with an example showing groups from every match, but the function only returns the capturing groups of the first match (`re2->Match` is called once per row). Update the description, return type, and example to match the actual behavior.
- Fix a broken cross-reference: `[extractAllGroupsVertical](#extractAllGroupsVertical)` resolved against the rendered `string-search-functions` page, where that anchor does not exist. Point it to `/sql-reference/functions/splitting-merging-functions#extractAllGroupsVertical` where the function actually lives.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

## Test plan

- [ ] Confirm rendered docs on the docs site show the corrected description, return type, and example for `extractGroups`.
- [ ] Confirm the `extractAllGroupsVertical` link resolves to the splitting-merging-functions page anchor.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.473`
<!-- ch-version-info:end -->