### PR TITLE
Fix SLRU free-space-keeping crash when probationary queue is empty

### DIFF
--- a/src/Interpreters/FileCache/SLRUFileCachePriority.cpp
+++ b/src/Interpreters/FileCache/SLRUFileCachePriority.cpp
@@ -214,7 +214,12 @@ EvictionInfoPtr SLRUFileCachePriority::collectEvictionInfo(
         size_t evict_size_from_probationary = std::min(size, probationary_queue.getSize(lock));
         size_t evict_elements_from_probationary = std::min(elements, probationary_queue.getElementsCount(lock));
 
-        chassert(evict_size_from_probationary || evict_elements_from_probationary);
+        /// It is valid for the probationary queue to be empty here while the protected queue still
+        /// has entries -- e.g. when `keep_free_space_size(elements)_ratio` is high enough for the
+        /// background thread to want to evict everything, but all entries have already been
+        /// promoted to the protected queue. The downstream code below correctly handles this case
+        /// by passing zeroes to `probationary_queue.collectEvictionInfo` and routing the full
+        /// requested amount to the protected queue.
         size -= evict_size_from_probationary;
         elements -= evict_elements_from_probationary;
 

--- a/src/Interpreters/tests/gtest_filecache.cpp
+++ b/src/Interpreters/tests/gtest_filecache.cpp
@@ -66,6 +66,7 @@ namespace DB::FileCacheSetting
     extern const FileCacheSettingsUInt64 boundary_alignment;
     extern const FileCacheSettingsFileCachePolicy cache_policy;
     extern const FileCacheSettingsDouble slru_size_ratio;
+    extern const FileCacheSettingsDouble keep_free_space_elements_ratio;
     extern const FileCacheSettingsNonZeroUInt64 load_metadata_threads;
     extern const FileCacheSettingsBool load_metadata_asynchronously;
     extern const FileCacheSettingsBool write_cache_per_user_id_directory;
@@ -1539,6 +1540,91 @@ TEST_F(FileCacheTest, SLRUDynamicResizeCorrectEviction)
     /// Verify cache usage is within new limits.
     ASSERT_LE(cache->getUsedCacheSize(), 8);
     ASSERT_LE(cache->getFileSegmentsNum(), 6);
+}
+
+TEST_F(FileCacheTest, SLRUFreeSpaceKeepingProtectedOnly)
+{
+    /// Regression test for https://github.com/ClickHouse/ClickHouse/issues/104307
+    ///
+    /// `freeSpaceRatioKeepingThreadFunc` calls `SLRUFileCachePriority::collectEvictionInfo`
+    /// with `is_total_space_cleanup=true`. With `keep_free_space_elements_ratio = 1.0`
+    /// (or any value high enough that the desired element count is below the current count)
+    /// the function used to chassert that we are evicting at least one element/byte from the
+    /// probationary queue. This is wrong when entries have all been promoted to the protected
+    /// queue and the probationary queue is empty: the function must still be able to evict
+    /// from the protected queue. Without the fix, the chassert aborts the server in
+    /// debug/sanitizer builds.
+    ServerUUID::setRandomForUnitTests();
+    DB::ThreadStatus thread_status;
+
+    ReadSettings read_settings;
+    read_settings.enable_filesystem_cache = true;
+    read_settings.local_fs_method = LocalFSReadMethod::pread;
+
+    auto write_file = [](const std::string & filename, const std::string & s)
+    {
+        std::string file_path = fs::current_path() / filename;
+        auto wb = std::make_unique<WriteBufferFromFile>(file_path, DBMS_DEFAULT_BUFFER_SIZE);
+        wb->write(s.data(), s.size());
+        wb->next();
+        wb->finalize();
+        return file_path;
+    };
+
+    /// Create SLRU cache: max_size=30, max_elements=6, ratio=0.5 -- protected = 15/3, probationary = 15/3.
+    /// Crucially, set `keep_free_space_elements_ratio = 1.0` so the background-keeping thread
+    /// targets `desired_elements_num = 0` and tries to evict every element from total cache.
+    DB::FileCacheSettings settings;
+    settings[FileCacheSetting::path] = cache_base_path2;
+    settings[FileCacheSetting::max_file_segment_size] = 5;
+    settings[FileCacheSetting::max_size] = 30;
+    settings[FileCacheSetting::max_elements] = 6;
+    settings[FileCacheSetting::boundary_alignment] = 1;
+    settings[FileCacheSetting::slru_size_ratio] = 0.5;
+    settings[FileCacheSetting::load_metadata_asynchronously] = false;
+    settings[FileCacheSetting::cache_policy] = FileCachePolicy::SLRU;
+    settings[FileCacheSetting::keep_free_space_elements_ratio] = 1.0;
+
+    auto cache = std::make_shared<DB::FileCache>("slru_free_space_104307", settings);
+    cache->initialize();
+
+    const auto & user = FileCache::getCommonOrigin();
+
+    auto read_and_check = [&](const std::string & file, const FileCacheKey & key, const std::string & expect_result)
+    {
+        auto read_buffer_creator = [&]()
+        {
+            return createReadBufferFromFileBase(file, read_settings, std::nullopt, std::nullopt);
+        };
+        auto cached_buffer = std::make_shared<CachedOnDiskReadBufferFromFile>(
+            file, key, cache, user, read_buffer_creator, read_settings,
+            "test", expect_result.size(), false, false, std::nullopt, nullptr);
+        WriteBufferFromOwnString result;
+        copyData(*cached_buffer, result);
+        ASSERT_EQ(result.str(), expect_result);
+    };
+
+    /// Read file1 twice -> 15 bytes / 3 segments in protected, probationary stays empty.
+    /// This is the exact precondition that used to trigger the chassert.
+    std::string data1(15, '*');
+    auto file1 = write_file("test_free_space_104307", data1);
+    auto key1 = DB::FileCacheKey::fromPath(file1);
+    read_and_check(file1, key1, data1);
+    read_and_check(file1, key1, data1);
+
+    assertProbationary(cache->dumpQueue(), Ranges{});
+    assertProtected(cache->dumpQueue(), { Range(0, 4), Range(5, 9), Range(10, 14) });
+
+    /// Without the fix, this call (or the background scheduling that immediately follows
+    /// `cache->initialize()` with the same precondition) aborts via
+    /// `chassert(evict_size_from_probationary || evict_elements_from_probationary)`.
+    /// With the fix, the function evicts from the protected queue and returns cleanly.
+    ASSERT_NO_THROW(cache->freeSpaceRatioKeepingThreadFunc());
+
+    /// And the eviction thread should make progress -- with `keep_free_space_elements_ratio = 1.0`
+    /// and a `keep_free_space_remove_batch` of 10 by default, all 3 protected entries fit in one batch.
+    ASSERT_EQ(cache->getFileSegmentsNum(), 0);
+    ASSERT_EQ(cache->getUsedCacheSize(), 0);
 }
 
 TEST_F(FileCacheTest, FileCacheGetOrSet)


### PR DESCRIPTION
Fixes #104307.

## Motivation

The background `freeSpaceRatioKeepingThreadFunc` enforces
`keep_free_space_size_ratio` / `keep_free_space_elements_ratio` by
calling `SLRUFileCachePriority::collectEvictionInfo` with
`is_total_space_cleanup=true`. The function had a `chassert` requiring
that we evict at least one byte or element from the probationary queue.

This is wrong: when entries have all been promoted to the protected
queue (probationary empty) and the free-space target asks the cache to
evict everything, the function must still be allowed to evict from the
protected queue. Without the fix the server aborts in debug/sanitizer
builds and throws `LOGICAL_ERROR` in release builds. The bug is
reachable with the user-facing config in #104307:

```xml
<disk1>
  <type>cache</type>
  <disk>disk0</disk>
  <max_size>1Gi</max_size>
  <keep_free_space_elements_ratio>1.0</keep_free_space_elements_ratio>
</disk1>
```

## Approach

Removed the over-zealous assertion in
`SLRUFileCachePriority::collectEvictionInfo`. The downstream code
already handles the empty-probationary case correctly: it passes zeros
to `probationary_queue.collectEvictionInfo` (which returns an empty info
immediately) and routes the full requested amount to
`protected_queue.collectEvictionInfo`.

Added a regression unit test
`FileCacheTest.SLRUFreeSpaceKeepingProtectedOnly` in
`src/Interpreters/tests/gtest_filecache.cpp` that:

1. Creates an SLRU cache with `keep_free_space_elements_ratio = 1.0`.
2. Reads a file twice so all entries get promoted to the protected
   queue (probationary stays empty).
3. Calls `freeSpaceRatioKeepingThreadFunc` directly.
4. Without the fix, this aborts with the exact stack trace from #104307
   (`SLRUFileCachePriority.cpp:217 -> FileCache.cpp:1446`). With the
   fix the call returns cleanly and all 3 protected entries are evicted
   in one batch.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a server abort/`LOGICAL_ERROR` in the filesystem cache background eviction thread (`SLRUFileCachePriority::collectEvictionInfo`) that could fire when `keep_free_space_size_ratio` or `keep_free_space_elements_ratio` was high enough to trigger eviction while all cache entries had already been promoted to the SLRU protected queue (probationary empty).


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

---

Session: cron:clickhouse-ci-task-worker:20260507-164500

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.453`
- Backported to: `26.4.3.4`
<!-- ch-version-info:end -->