### PR TITLE
Add test: `recursiveRemoveLowCardinality` equivalence stripping in `tryDirectJoin` is untested across the entire suite

### DIFF
--- a/tests/queries/0_stateless/04209_rocksdb_direct_join_lowcardinality_pk_equivalence.reference
+++ b/tests/queries/0_stateless/04209_rocksdb_direct_join_lowcardinality_pk_equivalence.reference
@@ -1,0 +1,13 @@
+inner join legacy planner result
+a	A
+b	B
+c	C
+inner join legacy planner explain
+Algorithm: DirectKeyValueJoin
+left join legacy planner result
+a	A
+b	B
+c	C
+d	
+left join legacy planner explain
+Algorithm: DirectKeyValueJoin

--- a/tests/queries/0_stateless/04209_rocksdb_direct_join_lowcardinality_pk_equivalence.sql
+++ b/tests/queries/0_stateless/04209_rocksdb_direct_join_lowcardinality_pk_equivalence.sql
@@ -1,0 +1,71 @@
+-- Tags: use-rocksdb
+-- Coverage: exercises the `recursiveRemoveLowCardinality` equivalence stripping in
+-- `tryDirectJoin` at src/Planner/PlannerJoins.cpp:1108-1111. The PR
+-- (STID 3436-4175) added a type check between the right join key and the storage
+-- primary key; the check strips `Nullable` AND `LowCardinality` wrappers on both
+-- sides "to match the equivalence semantics used by getByKeys itself."
+--
+-- The PR's own tests (04201_direct_join_type_mismatch_rocksdb.sql) only exercise
+-- the `removeNullable` path — none use `LowCardinality` wrappers, leaving the
+-- `recursiveRemoveLowCardinality` calls completely untested.
+--
+-- Scenario: storage PK is `LowCardinality(String)`, right join key is plain
+-- `String`. The legacy `JOIN ... USING` planner casts both sides to the
+-- common supertype `String`, so at the time `tryDirectJoin` runs:
+--     right_table_expression_header.key.type == String
+--     storage->getSampleBlock().key.type    == LowCardinality(String)
+--
+-- These two types are equivalent for `getByKeys` (which strips `LowCardinality`
+-- via `recursiveRemoveLowCardinality`), so `DirectKeyValueJoin` MUST still be
+-- chosen — fall-back to `HashJoin` here would be a silent performance regression
+-- on every key-value lookup query that uses a `LowCardinality` PK.
+--
+-- Mutation guard: drop `recursiveRemoveLowCardinality` from the storage-side
+-- type computation at PlannerJoins.cpp:1110 and the EXPLAIN assertions below
+-- flip from "Algorithm: DirectKeyValueJoin" to a HashJoin/JOIN line.
+
+DROP TABLE IF EXISTS rdb_lc_pk;
+DROP TABLE IF EXISTS t_str_right;
+
+CREATE TABLE rdb_lc_pk (key LowCardinality(String), value String)
+ENGINE = EmbeddedRocksDB PRIMARY KEY (key);
+INSERT INTO rdb_lc_pk VALUES ('a', 'A'), ('b', 'B'), ('c', 'C');
+
+CREATE TABLE t_str_right (k String) ENGINE = TinyLog;
+INSERT INTO t_str_right VALUES ('a'), ('b'), ('c'), ('d');
+
+-- INNER JOIN: legacy planner must keep DirectKeyValueJoin despite
+-- LowCardinality(String) PK vs plain String right key (post-USING-cast).
+SELECT 'inner join legacy planner result';
+SELECT key, value FROM (SELECT k AS key FROM t_str_right) AS t
+INNER JOIN rdb_lc_pk USING (key)
+ORDER BY key
+SETTINGS query_plan_use_new_logical_join_step = 0;
+
+SELECT 'inner join legacy planner explain';
+SELECT trim(explain) FROM (
+    EXPLAIN actions = 1
+    SELECT key, value FROM (SELECT k AS key FROM t_str_right) AS t
+    INNER JOIN rdb_lc_pk USING (key)
+    SETTINGS query_plan_use_new_logical_join_step = 0
+)
+WHERE explain LIKE '%Algorithm:%';
+
+-- LEFT JOIN: same equivalence path, different `allowed_left` strictness branch.
+SELECT 'left join legacy planner result';
+SELECT key, value FROM (SELECT k AS key FROM t_str_right) AS t
+LEFT JOIN rdb_lc_pk USING (key)
+ORDER BY key
+SETTINGS query_plan_use_new_logical_join_step = 0;
+
+SELECT 'left join legacy planner explain';
+SELECT trim(explain) FROM (
+    EXPLAIN actions = 1
+    SELECT key, value FROM (SELECT k AS key FROM t_str_right) AS t
+    LEFT JOIN rdb_lc_pk USING (key)
+    SETTINGS query_plan_use_new_logical_join_step = 0
+)
+WHERE explain LIKE '%Algorithm:%';
+
+DROP TABLE rdb_lc_pk;
+DROP TABLE t_str_right;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #103928](https://github.com/ClickHouse/ClickHouse/pull/103928).
 That PR PR adds a type check in `tryDirectJoin` (`src/Planner/PlannerJoins.cpp`) so that `DirectKeyValueJoin` is only chosen when the right join key's plan type matches the storage primary key type, modulo `Nullable` and `LowCardinality` wrappers. Previously the legacy `JOIN ... USING` planner inserted a 'C

**1. `recursiveRemoveLowCardinality` equivalence stripping in `tryDirectJoin` is untested across the entire suite**
  `src/Planner/PlannerJoins.cpp:1108`, `src/Planner/PlannerJoins.cpp:1110`
  **Risk:** Call chain: `chooseJoinAlgorithm` -> `tryCreateJoin` -> `tryDirectJoin` (PlannerJoins.cpp:1175-1179). At line 1110 the PR computes `storage_primary_key_type = removeNullable(recursiveRemoveLowCardinal
  **What's unique vs PR tests:** The PR's test (`04201_direct_join_type_mismatch_rocksdb.sql`) covers cases where the right key TYPE differs from the storage PK type after stripping (`Nullable(UInt64)` vs `UInt32`, `Int64` vs `UInt32
  **Tags:** `-- Tags: use-rocksdb` — `use-rocksdb`: Test creates an `EmbeddedRocksDB` storage which is only available when the rocksdb feature is built into ClickHouse; matches the convention used by every other rocksdb stateless test including the PR's own 04201_direct_join_type_mismatch_rocksdb.sql.
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/22d4c172-cb46-44fc-837d-9a2b6cf13dcb)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.485`
<!-- ch-version-info:end -->