### PR TITLE
Add clear and /clear terminal meta-command for client and local

### DIFF
--- a/docs/en/operations/utilities/clickhouse-local.md
+++ b/docs/en/operations/utilities/clickhouse-local.md
@@ -279,17 +279,19 @@ file3.xml
 
 ### CLEAR command {#clear-command}
 
-Clears the terminal screen (similar to the `clear` command on Linux or Ctrl+L in many terminals). This is a client-side action: it is not sent to the SQL engine, so you can use it in interactive mode without getting an `UNKNOWN_IDENTIFIER` error.
+Clears the terminal screen (similar to the `clear` command on Linux or Ctrl+L in many terminals). This is a client-side action: it is not sent to the SQL engine.
 
-Supported forms: `clear`, `CLEAR`, `/clear` (optional trailing `;` is ignored). If standard output is not a terminal (for example, when piping output), the command is accepted but does not emit control sequences.
+In `clickhouse-local`, the meta-command is recognized in **interactive** mode and with **`-q`** / query files (same idea as `ls`), so a bare `clear` does not produce an `UNKNOWN_IDENTIFIER` error.
 
-You can also run it with `-q`:
+In `clickhouse-client`, it is recognized only in **interactive** mode. With **`-q`** or query files, `clear` is still parsed as SQL, so automation keeps the previous error behavior instead of turning typos into a silent no-op.
+
+Supported forms: `clear`, `CLEAR`, `/clear` (optional trailing `;` is ignored). If standard output is not a terminal (for example, when piping output), the meta-command is accepted when recognized but does not emit control sequences.
+
+With `clickhouse-local` and `-q`:
 
 ```sh
 ./clickhouse-local -q clear
 ```
-
-The same meta-command is available in `clickhouse-client` interactive mode.
 
 ## Examples {#examples}
 

--- a/docs/en/operations/utilities/clickhouse-local.md
+++ b/docs/en/operations/utilities/clickhouse-local.md
@@ -279,7 +279,7 @@ file3.xml
 
 ### CLEAR command {#clear-command}
 
-Clears the terminal screen (similar to the `clear` command on Linux or Ctrl+L in many terminals). This is a client-side action: it is not sent to the SQL engine, so you can use it during demos in interactive mode without getting an `UNKNOWN_IDENTIFIER` error.
+Clears the terminal screen (similar to the `clear` command on Linux or Ctrl+L in many terminals). This is a client-side action: it is not sent to the SQL engine, so you can use it in interactive mode without getting an `UNKNOWN_IDENTIFIER` error.
 
 Supported forms: `clear`, `CLEAR`, `/clear` (optional trailing `;` is ignored). If standard output is not a terminal (for example, when piping output), the command is accepted but does not emit control sequences.
 

--- a/docs/en/operations/utilities/clickhouse-local.md
+++ b/docs/en/operations/utilities/clickhouse-local.md
@@ -289,7 +289,7 @@ You can also run it with `-q`:
 ./clickhouse-local -q clear
 ```
 
-The same metacommand is available in `clickhouse-client` interactive mode.
+The same meta-command is available in `clickhouse-client` interactive mode.
 
 ## Examples {#examples}
 

--- a/docs/en/operations/utilities/clickhouse-local.md
+++ b/docs/en/operations/utilities/clickhouse-local.md
@@ -277,6 +277,20 @@ file2.json
 file3.xml
 ```
 
+### CLEAR command {#clear-command}
+
+Clears the terminal screen (similar to the `clear` command on Linux or Ctrl+L in many terminals). This is a client-side action: it is not sent to the SQL engine, so you can use it during demos in interactive mode without getting an `UNKNOWN_IDENTIFIER` error.
+
+Supported forms: `clear`, `CLEAR`, `/clear` (optional trailing `;` is ignored). If standard output is not a terminal (for example, when piping output), the command is accepted but does not emit control sequences.
+
+You can also run it with `-q`:
+
+```sh
+./clickhouse-local -q clear
+```
+
+The same metacommand is available in `clickhouse-client` interactive mode.
+
 ## Examples {#examples}
 
 ```bash

--- a/docs/en/operations/utilities/clickhouse-local.md
+++ b/docs/en/operations/utilities/clickhouse-local.md
@@ -281,7 +281,7 @@ file3.xml
 
 Clears the terminal screen (similar to the `clear` command on Linux or Ctrl+L in many terminals). This is a client-side action: it is not sent to the SQL engine.
 
-In `clickhouse-local`, the meta-command is recognized in **interactive** mode and for **`-q`** and **`--queries-file`** input (same client path as `-q`, same idea as `ls`), so a bare `clear` does not produce an `UNKNOWN_IDENTIFIER` error.
+In `clickhouse-local`, the meta-command is recognized in **interactive** mode and for **`-q`** and **`--queries-file`** input (same client path as `-q`, same idea as `ls`), so a bare `clear` does not produce an `UNKNOWN_IDENTIFIER` error. Remote **`clickhouse-client --queries-file`** is unchanged: file contents are executed as SQL only (no text-level meta-commands).
 
 In `clickhouse-client`, it is recognized only in **interactive** mode. With **`-q`** or query files, `clear` is still parsed as SQL, so automation keeps the previous error behavior instead of turning typos into a silent no-op.
 

--- a/docs/en/operations/utilities/clickhouse-local.md
+++ b/docs/en/operations/utilities/clickhouse-local.md
@@ -281,7 +281,7 @@ file3.xml
 
 Clears the terminal screen (similar to the `clear` command on Linux or Ctrl+L in many terminals). This is a client-side action: it is not sent to the SQL engine.
 
-In `clickhouse-local`, the meta-command is recognized in **interactive** mode and with **`-q`** / query files (same idea as `ls`), so a bare `clear` does not produce an `UNKNOWN_IDENTIFIER` error.
+In `clickhouse-local`, the meta-command is recognized in **interactive** mode and for **`-q`** and **`--queries-file`** input (same client path as `-q`, same idea as `ls`), so a bare `clear` does not produce an `UNKNOWN_IDENTIFIER` error.
 
 In `clickhouse-client`, it is recognized only in **interactive** mode. With **`-q`** or query files, `clear` is still parsed as SQL, so automation keeps the previous error behavior instead of turning typos into a silent no-op.
 

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2995,6 +2995,14 @@ bool ClientBase::processQueryText(const String & text)
     if (exit_strings.contains(trimmed_input))
         return false;
 
+    /// Clear the terminal (POSIX `clear`-style), not SQL. Same entry point as `ls` / `\i` metacommands.
+    if (boost::iequals(trimmed_input, "clear") || boost::iequals(trimmed_input, "/clear"))
+    {
+        if (stdout_is_a_tty)
+            output_stream << "\033[2J\033[H" << std::flush;
+        return true;
+    }
+
     if (trimmed_input.starts_with("\\i"))
     {
         size_t skip_prefix_size = std::strlen("\\i");

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2995,7 +2995,7 @@ bool ClientBase::processQueryText(const String & text)
     if (exit_strings.contains(trimmed_input))
         return false;
 
-    /// Clear the terminal (POSIX `clear`-style), not SQL. Same entry point as `ls` / `\i` metacommands.
+    /// Clear the terminal (POSIX `clear`-style), not SQL. Same entry point as `ls` / `\i` meta-commands.
     if (boost::iequals(trimmed_input, "clear") || boost::iequals(trimmed_input, "/clear"))
     {
         if (stdout_is_a_tty)

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -2996,7 +2996,10 @@ bool ClientBase::processQueryText(const String & text)
         return false;
 
     /// Clear the terminal (POSIX `clear`-style), not SQL. Same entry point as `ls` / `\i` meta-commands.
-    if (boost::iequals(trimmed_input, "clear") || boost::iequals(trimmed_input, "/clear"))
+    /// Only in interactive mode, or in clickhouse-local (including `-q`), so `clickhouse-client` batch
+    /// mode still parses `clear` as SQL and errors on mistakes (UNKNOWN_IDENTIFIER).
+    if ((boost::iequals(trimmed_input, "clear") || boost::iequals(trimmed_input, "/clear"))
+        && (is_interactive || supportsLocalMetaCommands()))
     {
         if (stdout_is_a_tty)
             output_stream << "\033[2J\033[H" << std::flush;

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -3843,8 +3843,13 @@ bool ClientBase::processMultiQueryFromFile(const String & file_name)
     ReadBufferFromFile in(file_name);
     readStringUntilEOF(queries_from_file, in);
 
-    /// Same entry point as `-q` / stdin so meta-commands (`clear`, `ls`, `\i`, …) work for whole-file input.
-    return processQueryText(queries_from_file);
+    /// For `clickhouse-local` only: same entry point as `-q` / stdin so meta-commands (`clear`, `ls`,
+    /// `\i`, …) work for whole-file input. Remote `clickhouse-client` keeps `executeMultiQuery` so
+    /// `--queries-file` does not apply `exit_strings` and other text-level metas (avoids silent
+    /// behavior changes for batch automation).
+    if (supportsLocalMetaCommands())
+        return processQueryText(queries_from_file);
+    return executeMultiQuery(queries_from_file);
 }
 
 void ClientBase::runNonInteractive()

--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -3843,7 +3843,8 @@ bool ClientBase::processMultiQueryFromFile(const String & file_name)
     ReadBufferFromFile in(file_name);
     readStringUntilEOF(queries_from_file, in);
 
-    return executeMultiQuery(queries_from_file);
+    /// Same entry point as `-q` / stdin so meta-commands (`clear`, `ls`, `\i`, …) work for whole-file input.
+    return processQueryText(queries_from_file);
 }
 
 void ClientBase::runNonInteractive()

--- a/tests/queries/0_stateless/04037_clickhouse_local_clear_command.reference
+++ b/tests/queries/0_stateless/04037_clickhouse_local_clear_command.reference
@@ -1,0 +1,6 @@
+-- clear variants exit successfully
+OK
+-- clear is not parsed as a bare SQL identifier
+OK
+-- select clear is still SQL
+OK

--- a/tests/queries/0_stateless/04037_clickhouse_local_clear_command.reference
+++ b/tests/queries/0_stateless/04037_clickhouse_local_clear_command.reference
@@ -1,5 +1,7 @@
 -- clear variants exit successfully
 OK
+-- clear via --queries-file (same path as -q)
+OK
 -- clear is not parsed as a bare SQL identifier
 OK
 -- select clear is still SQL

--- a/tests/queries/0_stateless/04037_clickhouse_local_clear_command.reference
+++ b/tests/queries/0_stateless/04037_clickhouse_local_clear_command.reference
@@ -4,3 +4,5 @@ OK
 OK
 -- select clear is still SQL
 OK
+-- clickhouse-client -q clear is still SQL (non-interactive)
+OK

--- a/tests/queries/0_stateless/04037_clickhouse_local_clear_command.sh
+++ b/tests/queries/0_stateless/04037_clickhouse_local_clear_command.sh
@@ -35,13 +35,14 @@ set +o errexit
 out=$($CLICKHOUSE_CLIENT -q "clear" 2>&1)
 rc=$?
 set -o errexit
-# Must not silently succeed (meta-command without gate); UNKNOWN_IDENTIFIER is 47.
+# Must not silently succeed (meta-command without gate). Bare `clear` may fail as
+# UNKNOWN_IDENTIFIER (47) after parse or SYNTAX_ERROR (62) at parse time depending on dialect/path.
 if [[ $rc -eq 0 ]]; then
     echo "FAIL: clickhouse-client -q clear exited 0 (expected SQL error). Output: ${out}" >&2
     exit 1
 fi
-if [[ $rc -ne 47 ]] && ! echo "$out" | grep -qF 'UNKNOWN_IDENTIFIER'; then
-    echo "FAIL: expected exit 47 or UNKNOWN_IDENTIFIER in output, got rc=${rc}: ${out}" >&2
+if [[ $rc -ne 47 && $rc -ne 62 ]] && ! echo "$out" | grep -qE 'UNKNOWN_IDENTIFIER|SYNTAX_ERROR'; then
+    echo "FAIL: expected SQL error (exit 47/62 or UNKNOWN_IDENTIFIER/SYNTAX_ERROR in output), got rc=${rc}: ${out}" >&2
     exit 1
 fi
 echo "OK"

--- a/tests/queries/0_stateless/04037_clickhouse_local_clear_command.sh
+++ b/tests/queries/0_stateless/04037_clickhouse_local_clear_command.sh
@@ -31,5 +31,17 @@ $CLICKHOUSE_LOCAL -q "select clear" 2>&1 | grep -F 'UNKNOWN_IDENTIFIER' > /dev/n
 echo "OK"
 
 echo "-- clickhouse-client -q clear is still SQL (non-interactive)"
-$CLICKHOUSE_CLIENT -q "clear" 2>&1 | grep -F 'UNKNOWN_IDENTIFIER' > /dev/null
+set +o errexit
+out=$($CLICKHOUSE_CLIENT -q "clear" 2>&1)
+rc=$?
+set -o errexit
+# Must not silently succeed (meta-command without gate); UNKNOWN_IDENTIFIER is 47.
+if [[ $rc -eq 0 ]]; then
+    echo "FAIL: clickhouse-client -q clear exited 0 (expected SQL error). Output: ${out}" >&2
+    exit 1
+fi
+if [[ $rc -ne 47 ]] && ! echo "$out" | grep -qF 'UNKNOWN_IDENTIFIER'; then
+    echo "FAIL: expected exit 47 or UNKNOWN_IDENTIFIER in output, got rc=${rc}: ${out}" >&2
+    exit 1
+fi
 echo "OK"

--- a/tests/queries/0_stateless/04037_clickhouse_local_clear_command.sh
+++ b/tests/queries/0_stateless/04037_clickhouse_local_clear_command.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Test the `clear` client metacommand (clickhouse-local / same ClientBase path as clickhouse-client).
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+set -o errexit
+
+echo "-- clear variants exit successfully"
+$CLICKHOUSE_LOCAL -q "clear"
+$CLICKHOUSE_LOCAL -q "CLEAR"
+$CLICKHOUSE_LOCAL -q "/clear"
+$CLICKHOUSE_LOCAL -q "/CLEAR;"
+echo "OK"
+
+echo "-- clear is not parsed as a bare SQL identifier"
+if err="$($CLICKHOUSE_LOCAL -q "clear" 2>&1)"; then
+    if echo "$err" | grep -qF 'UNKNOWN_IDENTIFIER'; then
+        echo "FAIL: clear was interpreted as SQL: $err" >&2
+        exit 1
+    fi
+else
+    echo "FAIL: clear command returned non-zero" >&2
+    exit 1
+fi
+echo "OK"
+
+echo "-- select clear is still SQL"
+$CLICKHOUSE_LOCAL -q "select clear" 2>&1 | grep -F 'UNKNOWN_IDENTIFIER' > /dev/null
+echo "OK"

--- a/tests/queries/0_stateless/04037_clickhouse_local_clear_command.sh
+++ b/tests/queries/0_stateless/04037_clickhouse_local_clear_command.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Test the `clear` client metacommand (clickhouse-local / same ClientBase path as clickhouse-client).
+# Test the `clear` client meta-command (clickhouse-local; gated for clickhouse-client non-interactive).
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -28,4 +28,8 @@ echo "OK"
 
 echo "-- select clear is still SQL"
 $CLICKHOUSE_LOCAL -q "select clear" 2>&1 | grep -F 'UNKNOWN_IDENTIFIER' > /dev/null
+echo "OK"
+
+echo "-- clickhouse-client -q clear is still SQL (non-interactive)"
+$CLICKHOUSE_CLIENT -q "clear" 2>&1 | grep -F 'UNKNOWN_IDENTIFIER' > /dev/null
 echo "OK"

--- a/tests/queries/0_stateless/04037_clickhouse_local_clear_command.sh
+++ b/tests/queries/0_stateless/04037_clickhouse_local_clear_command.sh
@@ -14,6 +14,13 @@ $CLICKHOUSE_LOCAL -q "/clear"
 $CLICKHOUSE_LOCAL -q "/CLEAR;"
 echo "OK"
 
+echo "-- clear via --queries-file (same path as -q)"
+qf="${CLICKHOUSE_TMP}/04037_clear_queries_file_$$.txt"
+printf '%s\n' 'clear' >"$qf"
+$CLICKHOUSE_LOCAL --queries-file "$qf"
+rm -f "$qf"
+echo "OK"
+
 echo "-- clear is not parsed as a bare SQL identifier"
 if err="$($CLICKHOUSE_LOCAL -q "clear" 2>&1)"; then
     if echo "$err" | grep -qF 'UNKNOWN_IDENTIFIER'; then


### PR DESCRIPTION
Interactive clickhouse-client and clickhouse-local accept clear / /clear as a terminal clear (ANSI when stdout is a TTY) instead of SQL. In clickhouse-local, this also applies to -q and to --queries-file contents processed the same way as -q. clickhouse-client -q and clickhouse-client --queries-file still treat clear as SQL, so batch automation is unchanged.

### Changelog category (leave one):
- New Feature


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

clear and /clear now clear the terminal in the ClickHouse command-line tools instead of running as a mistaken query.

### Documentation entry for user-facing changes

- [X] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.519`
<!-- ch-version-info:end -->