### PR TITLE
Default `input_format_column_name_matching_mode` to `auto`

### DIFF
--- a/src/Core/FormatFactorySettings.h
+++ b/src/Core/FormatFactorySettings.h
@@ -1557,7 +1557,7 @@ Allow to write information about geo columns in parquet metadata and encode colu
     DECLARE(Bool, into_outfile_create_parent_directories, false, R"(
 Automatically create parent directories when using INTO OUTFILE if they do not already exists.
 )", 0) \
-    DECLARE(InputFormatColumnMatchingCaseSensitivity, input_format_column_name_matching_mode, FormatSettings::InputFormatColumnMatchingCaseSensitivity::MATCH_CASE, R"(
+    DECLARE(InputFormatColumnMatchingCaseSensitivity, input_format_column_name_matching_mode, FormatSettings::InputFormatColumnMatchingCaseSensitivity::AUTO, R"(
 Defines the column name matching mode when ingesting data through various formats (including but not limited to JSONEachRow, CSVWithNames, JSONColumns, BSONEachRow, RowBinaryWithNames).
 Supported modes:
     - match_case: match case-sensitively

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -61,6 +61,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"send_table_structure_on_insert_with_inline_data", true, true, "New setting to control whether server sends table structure for INSERT queries with inline data."},
             {"use_top_k_dynamic_filtering_for_variable_length_types", true, false, "Disable `use_top_k_dynamic_filtering` for variable-length sort columns (e.g. `String`) by default; the previous behavior had the optimization apply unconditionally and is preserved under `compatibility`."},
             {"page_cache_max_coalesced_bytes", 16777216, 16777216, "New setting to bound the size of a single coalesced read used to populate the userspace page cache on cache miss."},
+            {"input_format_column_name_matching_mode", "match_case", "auto", "Match input column names case-sensitively first and fall back to case-insensitive matching, instead of requiring an exact case match."},
         });
         addSettingsChanges(settings_changes_history, "26.4",
         {

--- a/src/Formats/FormatSettings.h
+++ b/src/Formats/FormatSettings.h
@@ -132,7 +132,7 @@ struct FormatSettings
         AUTO, /// First tries to match case-sensitively, if fails, tries to match case-insensitively
     };
 
-    InputFormatColumnMatchingCaseSensitivity input_format_column_matching_case_sensitivity = InputFormatColumnMatchingCaseSensitivity::MATCH_CASE;
+    InputFormatColumnMatchingCaseSensitivity input_format_column_matching_case_sensitivity = InputFormatColumnMatchingCaseSensitivity::AUTO;
 
     UInt64 client_protocol_version = 0;
 

--- a/tests/queries/0_stateless/04209_column_name_matching_mode_default.reference
+++ b/tests/queries/0_stateless/04209_column_name_matching_mode_default.reference
@@ -1,0 +1,4 @@
+auto
+1	a
+match_case
+0	a

--- a/tests/queries/0_stateless/04209_column_name_matching_mode_default.sql
+++ b/tests/queries/0_stateless/04209_column_name_matching_mode_default.sql
@@ -1,0 +1,36 @@
+-- Tags: no-async-insert
+-- Verify the default of `input_format_column_name_matching_mode` and its
+-- compatibility rollback. See PR #104320.
+
+-- 1. Default behavior (no SET).
+--    1a. Value-level: system.settings reports the new default `auto`.
+--    1b. Behavior-level: under `auto`, the input field "ID" falls back to the
+--        table column `id` via case-insensitive match.
+SELECT value FROM system.settings WHERE name = 'input_format_column_name_matching_mode';
+
+DROP TABLE IF EXISTS test_default;
+CREATE TABLE test_default (id Int, name String) ENGINE = Memory;
+
+INSERT INTO test_default FORMAT JSONEachRow {"ID": 1, "name": "a"};
+
+SELECT id, name FROM test_default;
+
+DROP TABLE test_default;
+
+-- 2. Compatibility rollback to a pre-26.5 version must restore `match_case`.
+--    2a. Value-level: system.settings reports the restored old default.
+--    2b. Behavior-level: "ID" no longer matches `id` and is treated as an
+--        unknown field (skipped under the default
+--        `input_format_skip_unknown_fields = true`); `id` defaults to 0.
+SET compatibility = '26.4';
+
+SELECT value FROM system.settings WHERE name = 'input_format_column_name_matching_mode';
+
+DROP TABLE IF EXISTS test_compat;
+CREATE TABLE test_compat (id Int, name String) ENGINE = Memory;
+
+INSERT INTO test_compat FORMAT JSONEachRow {"ID": 1, "name": "a"};
+
+SELECT id, name FROM test_compat;
+
+DROP TABLE test_compat;


### PR DESCRIPTION
Make the column-name matching for input formats (e.g. `JSONEachRow`, `CSVWithNames`, `JSONColumns`, `BSONEachRow`, `RowBinaryWithNames`) match case-sensitively first and fall back to case-insensitive matching on miss.

The previous default of `match_case` required an exact case match, which is unnecessarily strict for the common case where input column names happen to differ in capitalization from the table's columns. The `auto` mode is unambiguous when the table has no two columns that differ only in case, and reports `INCORRECT_DATA` on ambiguity, so this is a safe relaxation. The previous behavior is preserved under `compatibility`.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

The default of `input_format_column_name_matching_mode` is changed from `match_case` to `auto`. Input formats that match input column names against the table schema (`JSONEachRow`, `CSVWithNames`, `JSONColumns`, `BSONEachRow`, `RowBinaryWithNames`, etc.) now first try a case-sensitive match and fall back to case-insensitive matching when the case-sensitive match misses. The previous strict behavior is preserved under `compatibility`.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)