### PR TITLE
fixing a possible underflow while parsing postgres array values

### DIFF
--- a/src/Core/PostgreSQL/insertPostgreSQLValue.cpp
+++ b/src/Core/PostgreSQL/insertPostgreSQLValue.cpp
@@ -149,6 +149,9 @@ void insertPostgreSQLValue(
                 {
                     max_dimension = std::max(max_dimension, dimension);
 
+                    if (dimension == 0)
+                        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected array closing bracket");
+
                     --dimension;
                     if (dimension == 0)
                         break;

--- a/src/Core/tests/gtest_insertPostgreSQLValue.cpp
+++ b/src/Core/tests/gtest_insertPostgreSQLValue.cpp
@@ -1,0 +1,96 @@
+#include "config.h"
+
+#if USE_LIBPQXX
+
+#include <gtest/gtest.h>
+
+#include <Core/PostgreSQL/insertPostgreSQLValue.h>
+#include <Core/ExternalResultDescription.h>
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnsNumber.h>
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypesNumber.h>
+
+
+using namespace DB;
+
+namespace DB::ErrorCodes
+{
+    extern const int BAD_ARGUMENTS;
+}
+
+/// Regression test for dimension underflow in PostgreSQL array parser.
+/// When pqxx::array_parser emits row_end before any row_start (e.g. malformed
+/// input starting with '}'), the dimension counter must not underflow from 0.
+/// See https://github.com/ClickHouse/clickhouse-core-incidents/issues/1693
+
+TEST(InsertPostgreSQLValue, MalformedArrayClosingBracketThrows)
+{
+    auto nested_type = std::make_shared<DataTypeInt32>();
+    auto array_type = std::make_shared<DataTypeArray>(nested_type);
+    auto column = ColumnArray::create(ColumnInt32::create());
+
+    std::unordered_map<size_t, PostgreSQLArrayInfo> array_info;
+    preparePostgreSQLArrayInfo(array_info, 0, array_type);
+
+    /// Input "}" causes row_end at dimension 0 — must throw BAD_ARGUMENTS,
+    /// not underflow size_t to SIZE_MAX and crash.
+    try
+    {
+        insertPostgreSQLValue(
+            *column, "}",
+            ExternalResultDescription::ValueType::vtArray,
+            array_type, array_info, 0);
+        FAIL() << "Expected BAD_ARGUMENTS exception for malformed array '}'";
+    }
+    catch (const Exception & e)
+    {
+        EXPECT_EQ(e.code(), ErrorCodes::BAD_ARGUMENTS);
+    }
+}
+
+TEST(InsertPostgreSQLValue, MalformedArrayClosingThenOpeningThrows)
+{
+    auto nested_type = std::make_shared<DataTypeInt32>();
+    auto array_type = std::make_shared<DataTypeArray>(nested_type);
+    auto column = ColumnArray::create(ColumnInt32::create());
+
+    std::unordered_map<size_t, PostgreSQLArrayInfo> array_info;
+    preparePostgreSQLArrayInfo(array_info, 0, array_type);
+
+    /// Input "}{" also starts with row_end at dimension 0.
+    try
+    {
+        insertPostgreSQLValue(
+            *column, "}{",
+            ExternalResultDescription::ValueType::vtArray,
+            array_type, array_info, 0);
+        FAIL() << "Expected BAD_ARGUMENTS exception for malformed array '}{'" ;
+    }
+    catch (const Exception & e)
+    {
+        EXPECT_EQ(e.code(), ErrorCodes::BAD_ARGUMENTS);
+    }
+}
+
+TEST(InsertPostgreSQLValue, WellFormedArraySucceeds)
+{
+    auto nested_type = std::make_shared<DataTypeInt32>();
+    auto array_type = std::make_shared<DataTypeArray>(nested_type);
+    auto column = ColumnArray::create(ColumnInt32::create());
+
+    std::unordered_map<size_t, PostgreSQLArrayInfo> array_info;
+    preparePostgreSQLArrayInfo(array_info, 0, array_type);
+
+    /// Well-formed "{1,2,3}" must succeed without exceptions.
+    EXPECT_NO_THROW(
+        insertPostgreSQLValue(
+            *column, "{1,2,3}",
+            ExternalResultDescription::ValueType::vtArray,
+            array_type, array_info, 0));
+
+    /// Verify the column now has one row with 3 elements.
+    ASSERT_EQ(column->size(), 1u);
+}
+
+#endif

--- a/tests/integration/test_storage_postgresql/test.py
+++ b/tests/integration/test_storage_postgresql/test.py
@@ -1011,46 +1011,47 @@ def test_postgres_date32_array(started_cluster):
     cursor.execute("DROP TABLE test_date32_array")
 
 
-def test_postgres_read_boolean_array(started_cluster):
-    """Test reading PostgreSQL boolean arrays with native 't'/'f' text values.
+def test_postgres_array_parser_dimension_underflow(started_cluster):
+    """Regression test for `size_t` underflow in the PostgreSQL array parser.
 
-    PostgreSQL boolean arrays contain 't'/'f' text values. The array parser
-    must handle these correctly (the scalar boolean path handled 't'/'f' but
-    the array path previously did not, causing a conversion error).
-    Also validates dimension tracking doesn't underflow on well-formed input.
+    When `pqxx::array_parser` emits `row_end` while the parser's `dimension`
+    counter is 0 (for example, an array text starting with `}`), the previous
+    code decremented `dimension` past 0 — a `size_t` underflow to `SIZE_MAX` —
+    and then indexed `dimensions[SIZE_MAX]`, which is out-of-bounds. The fix
+    throws a `BAD_ARGUMENTS` exception in this case instead.
+
+    PostgreSQL itself validates array literals at INSERT time, so the bug is
+    unreachable via a column declared as `boolean[]`/`integer[]` on the
+    PostgreSQL side. The reproducer below stores the malformed payload in a
+    PostgreSQL `text` column and declares the same column as `Array(Int32)` on
+    the ClickHouse side via the `PostgreSQL` table engine. ClickHouse then
+    dispatches the raw `'}'` value through the `vtArray` branch of
+    `insertPostgreSQLValue`, which calls `pqxx::array_parser` on it and
+    reproduces the bug.
     """
     cursor = started_cluster.postgres_conn.cursor()
-    cursor.execute("DROP TABLE IF EXISTS test_read_bool_array")
+    cursor.execute("DROP TABLE IF EXISTS test_array_underflow")
     cursor.execute(
-        """CREATE TABLE test_read_bool_array (
-            id integer,
-            flags boolean[] NOT NULL,
-            nullable_flags boolean[],
-            nested_flags boolean[][] NOT NULL
-        )"""
+        "CREATE TABLE test_array_underflow (id integer, payload text)"
     )
-
-    cursor.execute(
-        "INSERT INTO test_read_bool_array VALUES "
-        "(1, '{t,f,t,f}', '{t,NULL,f}', '{{t,f},{f,t}}'),"
-        "(2, '{t,t,t}', NULL, '{{t,t},{t,t}}'),"
-        "(3, '{f,f}', '{f,f,f,f}', '{{f,f},{f,f}}')"
-    )
+    cursor.execute("INSERT INTO test_array_underflow VALUES (1, '}')")
     started_cluster.postgres_conn.commit()
 
-    table = f"""postgresql('{started_cluster.postgres_ip}:{started_cluster.postgres_port}', 'postgres', 'test_read_bool_array', 'postgres', '{pg_pass}')"""
-
-    result = node1.query(
-        f"SELECT id, flags, nullable_flags, nested_flags FROM {table} ORDER BY id"
+    node1.query("DROP TABLE IF EXISTS pg_array_underflow")
+    node1.query(
+        f"CREATE TABLE pg_array_underflow (id Int32, payload Array(Int32)) "
+        f"ENGINE = PostgreSQL("
+        f"'{started_cluster.postgres_ip}:{started_cluster.postgres_port}', "
+        f"'postgres', 'test_array_underflow', 'postgres', '{pg_pass}')"
     )
-    expected = (
-        "1\t[1,0,1,0]\t[1,NULL,0]\t[[1,0],[0,1]]\n"
-        "2\t[1,1,1]\t[]\t[[1,1],[1,1]]\n"
-        "3\t[0,0]\t[0,0,0,0]\t[[0,0],[0,0]]\n"
-    )
-    assert result == expected
 
-    cursor.execute("DROP TABLE test_read_bool_array")
+    error = node1.query_and_get_error("SELECT id, payload FROM pg_array_underflow")
+    assert "Unexpected array closing bracket" in error, (
+        f"Expected BAD_ARGUMENTS('Unexpected array closing bracket'), got: {error}"
+    )
+
+    node1.query("DROP TABLE pg_array_underflow")
+    cursor.execute("DROP TABLE test_array_underflow")
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_storage_postgresql/test.py
+++ b/tests/integration/test_storage_postgresql/test.py
@@ -1011,6 +1011,48 @@ def test_postgres_date32_array(started_cluster):
     cursor.execute("DROP TABLE test_date32_array")
 
 
+def test_postgres_read_boolean_array(started_cluster):
+    """Test reading PostgreSQL boolean arrays with native 't'/'f' text values.
+
+    PostgreSQL boolean arrays contain 't'/'f' text values. The array parser
+    must handle these correctly (the scalar boolean path handled 't'/'f' but
+    the array path previously did not, causing a conversion error).
+    Also validates dimension tracking doesn't underflow on well-formed input.
+    """
+    cursor = started_cluster.postgres_conn.cursor()
+    cursor.execute("DROP TABLE IF EXISTS test_read_bool_array")
+    cursor.execute(
+        """CREATE TABLE test_read_bool_array (
+            id integer,
+            flags boolean[] NOT NULL,
+            nullable_flags boolean[],
+            nested_flags boolean[][] NOT NULL
+        )"""
+    )
+
+    cursor.execute(
+        "INSERT INTO test_read_bool_array VALUES "
+        "(1, '{t,f,t,f}', '{t,NULL,f}', '{{t,f},{f,t}}'),"
+        "(2, '{t,t,t}', NULL, '{{t,t},{t,t}}'),"
+        "(3, '{f,f}', '{f,f,f,f}', '{{f,f},{f,f}}')"
+    )
+    started_cluster.postgres_conn.commit()
+
+    table = f"""postgresql('{started_cluster.postgres_ip}:{started_cluster.postgres_port}', 'postgres', 'test_read_bool_array', 'postgres', '{pg_pass}')"""
+
+    result = node1.query(
+        f"SELECT id, flags, nullable_flags, nested_flags FROM {table} ORDER BY id"
+    )
+    expected = (
+        "1\t[1,0,1,0]\t[1,NULL,0]\t[[1,0],[0,1]]\n"
+        "2\t[1,1,1]\t[]\t[[1,1],[1,1]]\n"
+        "3\t[0,0]\t[0,0,0,0]\t[[0,0],[0,0]]\n"
+    )
+    assert result == expected
+
+    cursor.execute("DROP TABLE test_read_bool_array")
+
+
 if __name__ == "__main__":
     cluster.start()
     input("Cluster created, press any key to destroy...")


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixes a possible underflow in parsing postgres arrays.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->
When parsing arrays, we decrement a size_t without checking if it is 0 or not.  Now we will throw an exception instead.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.576`
- Backported to: `26.4.3.15`, `26.3.11.15`, `26.2.19.22`, `25.8.24.15`
<!-- ch-version-info:end -->