### PR TITLE
Match interrupted tmp_snapshot markers by (name, last_modified) in test_recover_after_interrupted_transfer

### DIFF
--- a/tests/integration/test_keeper_snapshot_chunked_transfer/test.py
+++ b/tests/integration/test_keeper_snapshot_chunked_transfer/test.py
@@ -212,10 +212,16 @@ def test_recover_after_interrupted_transfer(started_cluster, nodes):
             "root", prefix=s3_prefix + "tmp_snapshot_"
         ))
         assert tmp_objects, "No tmp_snapshot object in S3 after killing mid-transfer"
-        # Record the specific tmp files left by the interrupted transfer so we can
-        # check that *these* are cleaned up, ignoring any transient tmp_ markers
-        # created by background snapshot flushes after the node restarts.
-        interrupted_tmp_names = {o.object_name for o in tmp_objects}
+        # Record (name, last_modified) tuples to uniquely identify these specific
+        # files.  A new snapshot transfer after restart may create a tmp_ marker
+        # with the *same* object_name (the leader can resend the same log_idx if
+        # nothing committed in the meantime), so matching by name alone causes
+        # false positives where the new in-flight marker is mistaken for the
+        # interrupted-transfer marker that startup cleanup already removed.
+        # last_modified has microsecond precision in MinIO and is monotonically
+        # increasing across writes, so the (name, last_modified) tuple is a
+        # reliable identity for the original interrupted-transfer file.
+        interrupted_tmp_ids = {(o.object_name, o.last_modified) for o in tmp_objects}
     else:
         snapshot_dir = "/var/lib/clickhouse/coordination/snapshots"
         tmp_snapshot_path = node_lagging.exec_in_container(
@@ -230,10 +236,12 @@ def test_recover_after_interrupted_transfer(started_cluster, nodes):
 
     if is_remote:
         # After restart the node may also create new local snapshots asynchronously
-        # (queued via snapshots_queue), which temporarily produce fresh tmp_ markers
-        # with the same or different log indices.  Poll for the *interrupted* markers
-        # to disappear rather than asserting immediately, so a concurrent background
-        # flush does not cause a false positive.
+        # (queued via snapshots_queue) or receive a fresh snapshot from the leader
+        # that re-uses the same log_idx, both of which temporarily produce a tmp_
+        # marker with the same object_name as the interrupted-transfer marker.
+        # Match on (name, last_modified) so we only count the *original* file —
+        # the one whose cleanup we are verifying — and ignore unrelated in-flight
+        # markers created after the restart.
         deadline = time.time() + 15
         remaining = None
         while True:
@@ -241,7 +249,7 @@ def test_recover_after_interrupted_transfer(started_cluster, nodes):
                 o for o in started_cluster.minio_client.list_objects(
                     "root", prefix=s3_prefix + "tmp_snapshot_"
                 )
-                if o.object_name in interrupted_tmp_names
+                if (o.object_name, o.last_modified) in interrupted_tmp_ids
             ]
             if not remaining or time.time() >= deadline:
                 break


### PR DESCRIPTION
Fix the polling assertion in `test_recover_after_interrupted_transfer[remote_disk]`
so it identifies the original interrupted-transfer `tmp_snapshot_*.bin.zstd`
markers by `(object_name, last_modified)` instead of `object_name` alone.

## Motivation

The test has shown up across 15+ unrelated PRs in the last 14 days
(`Integration tests (arm_binary, distributed plan, 4/4)`, also
`amd_msan`, `amd_asan_ubsan`, `amd_llvm_coverage` variants). All failures
look the same:

```
File: test_keeper_snapshot_chunked_transfer/test.py:229 - in test_recover_after_interrupted_transfer
    assert not remaining, ...
E   AssertionError: tmp_snapshot objects from interrupted transfer not removed within 15 s:
    ['keeper-snapshots/node9/tmp_snapshot_1050.bin.zstd']
```

The reported file is always 0 bytes with `etag='d41d8cd98f00b204e9800998ecf8427e'`
(empty-string MD5) — the same shape as the marker file written by both
`beginSnapshotReceiveToDisk` and `serializeSnapshotToDisk` in
`KeeperSnapshotManager`.

Three fix PRs already landed (#102643, #102899, #103767) but
`test_recover_after_interrupted_transfer[remote_disk]` keeps failing.

## Root cause

Sequence:

1. The test pauses a chunked transfer at `keeper_save_snapshot_pause_mid_transfer`
   and records `interrupted_tmp_names = {o.object_name for o in tmp_objects}`.
2. The node is killed and restarted.
3. `KeeperSnapshotManager` constructor cleanup (lines 700–748 of
   `src/Coordination/KeeperSnapshotManager.cpp`) iterates the snapshot disk,
   collects `tmp_*` files into `incomplete_files`, and removes them. The
   *original* `tmp_snapshot_1050.bin.zstd` is correctly deleted at this point.
4. NuRaft re-attempts the snapshot transfer. If no new entries were committed
   on the leader between pause and restart (typical when the kill window is
   short), it resends the snapshot for the **same** `log_idx`.
5. `beginSnapshotReceiveToDisk(1050)` runs again, creating a fresh
   `tmp_snapshot_1050.bin.zstd` marker — same `object_name`, but a newer
   `last_modified`.
6. The polling loop matches by `object_name` only, so the new in-flight marker
   is mistaken for the original. The 15 s deadline expires while the new
   transfer is still copying chunks and the assertion fails.

The C++ cleanup is doing the right thing; the test's identity check is too loose.

## Fix

Record `(object_name, last_modified)` tuples for the interrupted markers
before the kill, and filter the post-restart listing on the same tuple.
MinIO returns `last_modified` with microsecond precision, so the original
file (created before the kill) and any new in-flight marker (created after
the restart) always have different timestamps. Synthesised "directory"
entries (`is_dir=True`, `last_modified=None`) are also naturally excluded.

A genuine cleanup regression still fails the assertion: if the original
`tmp_snapshot_1050.bin.zstd` is left on the disk after restart, its
`(name, T1)` tuple is unchanged and matches the recorded set.

## CI report

`Integration tests (arm_binary, distributed plan, 4/4)` on PR #100146 — one
of 15+ unrelated PRs hit by this test in the last 14 days:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100146&sha=60fad4c4a87adad7da97b1b7249acf9d6370d4ff&name_0=PR&name_1=Integration%20tests%20%28arm_binary%2C%20distributed%20plan%2C%204%2F4%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.434`
<!-- ch-version-info:end -->