### PR TITLE
Mark `01085_max_distributed_connections` as `no-msan`

### DIFF
--- a/tests/queries/0_stateless/01085_max_distributed_connections.sh
+++ b/tests/queries/0_stateless/01085_max_distributed_connections.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
-# Tags: distributed, no-random-settings
+# Tags: distributed, no-random-settings, no-msan
+# no-msan: under MSan instrumentation the per-shard `only_analyze` Planner pass
+# in `SelectStreamFactory::createForShardWithAnalyzer` costs ~140 ms × 20 shards
+# = ~3 s, which combined with the staggered remote sub-query execution pushes
+# the wall time over the 10 s `timeout` budget below.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
 i=0 retries=300
-# Sometimes five seconds are not enough due to system overload.
-# But if it can run in less than five seconds at least sometimes - it is enough for the test.
+# Sometimes ten seconds are not enough due to system overload.
+# But if it can run in less than ten seconds at least sometimes - it is enough for the test.
 while [[ $i -lt $retries ]]; do
     opts=(
         --max_distributed_connections 20


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---

`01085_max_distributed_connections` runs `SELECT sum(sleepEachRow(1)) FROM remote('127.{2..21}', system.one)` under a `timeout 10s` and asserts that 20 distributed connections fan out in parallel.

Under MSan the test consistently misses the 10 s budget. Tracing one iteration on the `Stateless tests (amd_msan, WasmEdge, parallel, 2/2)` job from PR #90043:

| Phase | Duration |
|---|---|
| First connection probe + `DESC TABLE system.one` on shard 1 | ~0.7 s |
| **22 × `Planner: WithMergeableState only analyze`** on the initiator (one `only_analyze` pass per shard, called from `SelectStreamFactory::createForShardWithAnalyzer` → `InterpreterSelectQueryAnalyzer::getSampleBlockAndPlannerContext`) | **~3.0 s** |
| Open remaining 19 connections | ~0.2 s |
| 20 remote `SELECT sum(sleepEachRow(1)) FROM system.one` (~1.4 s each, staggered) | ~5.5 s |
| **Total** | **~9.5–10.2 s** |

Master shows the same shape on this build (test_duration_ms 5–13 s, mostly 7–10 s) — the per-shard analyze loop is not new, but only MSan's instrumentation overhead inflates each pass enough to push the test past its budget. Real fix would be to cache the shard sample header / planner context across shards in `SelectStreamFactory`, but that's a much larger change; meanwhile the test is the only thing on fire.

Also fixed a stale comment that still claimed the budget was 5 s (it has been 10 s for a while).

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=90043&sha=a61ed3dbbc4da693beb4601322c3f8f6d8b2f8b0&name_0=PR&name_1=Stateless+tests+%28amd_msan%2C+WasmEdge%2C+parallel%2C+2%2F2%29
PR observed in: https://github.com/ClickHouse/ClickHouse/pull/90043

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.455`
<!-- ch-version-info:end -->