### PR TITLE
Reduce JIT-induced noise in performance tests

### DIFF
--- a/tests/performance/jit_aggregate_functions.xml
+++ b/tests/performance/jit_aggregate_functions.xml
@@ -1,7 +1,6 @@
 <test>
     <settings>
         <compile_aggregate_expressions>1</compile_aggregate_expressions>
-        <min_count_to_compile_aggregate_expression>0</min_count_to_compile_aggregate_expression>
     </settings>
 
     <create_query>

--- a/tests/performance/jit_large_requests.xml
+++ b/tests/performance/jit_large_requests.xml
@@ -49,8 +49,7 @@
         WHERE
             NOT ignore(a / b + c / d + e / f + g / h + i / j)
         SETTINGS
-            compile_expressions = 1,
-            min_count_to_compile_expression = 1
+            compile_expressions = 1
     </query>
     <drop_query>DROP TABLE IF EXISTS jit_test</drop_query>
 </test>

--- a/tests/performance/jit_small_requests.xml
+++ b/tests/performance/jit_small_requests.xml
@@ -22,8 +22,7 @@
             bitXor(x4, bitShiftRight(x4, 33)) AS x5
         SELECT count() FROM numbers(100000000) WHERE NOT ignore(x5)
         SETTINGS
-            compile_expressions = 1,
-            min_count_to_compile_expression = 1
+            compile_expressions = 1
     </query>
 
     <!-- The same expression written as ClickHouse builtin function. -->

--- a/tests/performance/scripts/config/users.d/perf-comparison-tweaks-users.xml
+++ b/tests/performance/scripts/config/users.d/perf-comparison-tweaks-users.xml
@@ -23,6 +23,15 @@
             <compile_aggregate_expressions>0</compile_aggregate_expressions>
             <compile_sort_description>0</compile_sort_description>
 
+            <!--
+                When a test opts back into JIT, force compilation on the first call
+                so the prewarm run populates the JIT cache and the measured runs are
+                not skewed by compilation cost. See https://github.com/ClickHouse/ClickHouse/issues/100759.
+            -->
+            <min_count_to_compile_expression>0</min_count_to_compile_expression>
+            <min_count_to_compile_aggregate_expression>0</min_count_to_compile_aggregate_expression>
+            <min_count_to_compile_sort_description>0</min_count_to_compile_sort_description>
+
             <!-- Don't fail some prewarm queries too early -->
             <timeout_before_checking_execution_speed>60</timeout_before_checking_execution_speed>
 

--- a/tests/performance/string_order_by.xml
+++ b/tests/performance/string_order_by.xml
@@ -2,7 +2,6 @@
     <settings>
         <max_threads>8</max_threads>
         <compile_sort_description>1</compile_sort_description>
-        <min_count_to_compile_sort_description>0</min_count_to_compile_sort_description>
     </settings>
     <create_query>CREATE TABLE str_sort (a String, b UInt64, c FixedString(5), d String, e UInt32, f UInt32) ENGINE = Memory</create_query>
     <fill_query>


### PR DESCRIPTION
The perf-comparison config already turns JIT off globally for the suite (`compile_expressions=0`, `compile_aggregate_expressions=0`, `compile_sort_description=0`). The tests that explicitly opt back into JIT were still bimodal: the JIT cache is global and shared across queries, so whether the first measured runs hit it or not depends on what ran before. With `min_count_to_compile_*` defaulting to 3, JIT compilation could land in the middle of the measured runs.

Set `min_count_to_compile_expression`, `min_count_to_compile_aggregate_expression` and `min_count_to_compile_sort_description` to 0 in the same profile so that when a test does enable JIT, compilation happens on the very first call and the existing prewarm in `perf.py` populates the cache before measurements start. Drop now-redundant per-test overrides of the same settings.

Refs #100759.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.438`
<!-- ch-version-info:end -->