### PR TITLE
Validate hex digits in parseUUID (issue #86714)

### DIFF
--- a/src/IO/ReadHelpers.cpp
+++ b/src/IO/ReadHelpers.cpp
@@ -54,9 +54,20 @@ inline void parseHex(IteratorSrc src, IteratorDst dst)
         dst[dst_pos] = unhex2(reinterpret_cast<const char *>(&src[src_pos]));
 }
 
-UUID parseUUID(std::span<const UInt8> src)
+/// Returns true if all bytes in [begin, end) are valid hexadecimal digits (0-9, a-f, A-F).
+static inline bool areHexChars(const UInt8 * begin, const UInt8 * end)
 {
-    UUID uuid;
+    for (const UInt8 * p = begin; p != end; ++p)
+        if (unhex(static_cast<char>(*p)) == 0xff)
+            return false;
+    return true;
+}
+
+template <typename ReturnType>
+static ReturnType parseUUIDImpl(std::span<const UInt8> src, UUID & uuid)
+{
+    static constexpr bool throw_exception = std::is_same_v<ReturnType, void>;
+
     const auto * src_ptr = src.data();
     const auto size = src.size();
 
@@ -67,6 +78,21 @@ UUID parseUUID(std::span<const UInt8> src)
 #endif
     if (size == 36)
     {
+        /// Validate 8-4-4-4-12 layout: dashes at positions 8, 13, 18, 23 and hex digits in the rest.
+        if (src_ptr[8] != '-' || src_ptr[13] != '-' || src_ptr[18] != '-' || src_ptr[23] != '-'
+            || !areHexChars(src_ptr, src_ptr + 8)
+            || !areHexChars(src_ptr + 9, src_ptr + 13)
+            || !areHexChars(src_ptr + 14, src_ptr + 18)
+            || !areHexChars(src_ptr + 19, src_ptr + 23)
+            || !areHexChars(src_ptr + 24, src_ptr + 36))
+        {
+            if constexpr (throw_exception)
+                throw Exception(
+                    ErrorCodes::CANNOT_PARSE_UUID,
+                    "Cannot parse UUID from String: invalid format, expected 32 or 36 hexadecimal digits with dashes at positions 8, 13, 18, 23");
+            else
+                return ReturnType(false);
+        }
         parseHex<4>(src_ptr, dst + 8);
         parseHex<2>(src_ptr + 9, dst + 12);
         parseHex<2>(src_ptr + 14, dst + 14);
@@ -75,13 +101,39 @@ UUID parseUUID(std::span<const UInt8> src)
     }
     else if (size == 32)
     {
+        if (!areHexChars(src_ptr, src_ptr + 32))
+        {
+            if constexpr (throw_exception)
+                throw Exception(
+                    ErrorCodes::CANNOT_PARSE_UUID,
+                    "Cannot parse UUID from String: invalid format, expected 32 hexadecimal digits");
+            else
+                return ReturnType(false);
+        }
         parseHex<8>(src_ptr, dst + 8);
         parseHex<8>(src_ptr + 16, dst);
     }
     else
-        throw Exception(ErrorCodes::CANNOT_PARSE_UUID, "Unexpected length when trying to parse UUID ({})", size);
+    {
+        if constexpr (throw_exception)
+            throw Exception(ErrorCodes::CANNOT_PARSE_UUID, "Unexpected length when trying to parse UUID ({})", size);
+        else
+            return ReturnType(false);
+    }
 
+    return ReturnType(true);
+}
+
+UUID parseUUID(std::span<const UInt8> src)
+{
+    UUID uuid;
+    parseUUIDImpl<void>(src, uuid);
     return uuid;
+}
+
+bool tryParseUUID(std::span<const UInt8> src, UUID & uuid)
+{
+    return parseUUIDImpl<bool>(src, uuid);
 }
 
 void NO_INLINE throwAtAssertionFailed(const char * s, ReadBuffer & buf)

--- a/src/IO/ReadHelpers.h
+++ b/src/IO/ReadHelpers.h
@@ -707,6 +707,7 @@ inline bool tryReadDateText(ExtendedDayNum & date, ReadBuffer & buf, const DateL
 }
 
 UUID parseUUID(std::span<const UInt8> src);
+bool tryParseUUID(std::span<const UInt8> src, UUID & uuid);
 
 template <typename ReturnType = void>
 inline ReturnType readUUIDTextImpl(UUID & uuid, ReadBuffer & buf)
@@ -737,7 +738,15 @@ inline ReturnType readUUIDTextImpl(UUID & uuid, ReadBuffer & buf)
             }
         }
 
-        uuid = parseUUID({reinterpret_cast<const UInt8 *>(s), size});
+        if constexpr (throw_exception)
+        {
+            uuid = parseUUID({reinterpret_cast<const UInt8 *>(s), size});
+        }
+        else
+        {
+            if (!tryParseUUID({reinterpret_cast<const UInt8 *>(s), size}, uuid))
+                return ReturnType(false);
+        }
         return ReturnType(true);
     }
 

--- a/tests/queries/0_stateless/03773_deterministic_functions_key_condition.reference
+++ b/tests/queries/0_stateless/03773_deterministic_functions_key_condition.reference
@@ -23,7 +23,7 @@ VALUES (
 );
 INSERT INTO events (uuid, person_id, event, timestamp, team_id)
 VALUES (
-    '017adbc0-98b5-0000-3f74-619a368fe65g',
+    '017adbc0-98b5-0000-3f74-619a368fe65b',
     '017adbc0-98b5-0000-3f74-619a368fe65a',
     'page_view',
     toDateTime64('2026-01-01 00:00:01', 6, 'UTC'),
@@ -182,7 +182,7 @@ VALUES (
 );
 INSERT INTO events (uuid, person_id, event, timestamp, team_id)
 VALUES (
-    '017adbc0-98b5-0000-3f74-619a368fe65g',
+    '017adbc0-98b5-0000-3f74-619a368fe65b',
     '017adbc0-98b5-0000-3f74-619a368fe65a',
     'page_view',
     toDateTime64('2026-01-01 00:00:01', 6, 'UTC'),

--- a/tests/queries/0_stateless/03773_deterministic_functions_key_condition.sql.j2
+++ b/tests/queries/0_stateless/03773_deterministic_functions_key_condition.sql.j2
@@ -37,7 +37,7 @@ VALUES (
 
 INSERT INTO events (uuid, person_id, event, timestamp, team_id)
 VALUES (
-    '017adbc0-98b5-0000-3f74-619a368fe65g',
+    '017adbc0-98b5-0000-3f74-619a368fe65b',
     '017adbc0-98b5-0000-3f74-619a368fe65a',
     'page_view',
     toDateTime64('2026-01-01 00:00:01', 6, 'UTC'),

--- a/tests/queries/0_stateless/03773_deterministic_functions_key_condition_explain.reference
+++ b/tests/queries/0_stateless/03773_deterministic_functions_key_condition_explain.reference
@@ -23,7 +23,7 @@ VALUES (
 );
 INSERT INTO events (uuid, person_id, event, timestamp, team_id)
 VALUES (
-    '017adbc0-98b5-0000-3f74-619a368fe65g',
+    '017adbc0-98b5-0000-3f74-619a368fe65b',
     '017adbc0-98b5-0000-3f74-619a368fe65a',
     'page_view',
     toDateTime64('2026-01-01 00:00:01', 6, 'UTC'),
@@ -561,7 +561,7 @@ VALUES (
 );
 INSERT INTO events (uuid, person_id, event, timestamp, team_id)
 VALUES (
-    '017adbc0-98b5-0000-3f74-619a368fe65g',
+    '017adbc0-98b5-0000-3f74-619a368fe65b',
     '017adbc0-98b5-0000-3f74-619a368fe65a',
     'page_view',
     toDateTime64('2026-01-01 00:00:01', 6, 'UTC'),

--- a/tests/queries/0_stateless/03773_deterministic_functions_key_condition_explain.sql.j2
+++ b/tests/queries/0_stateless/03773_deterministic_functions_key_condition_explain.sql.j2
@@ -38,7 +38,7 @@ VALUES (
 
 INSERT INTO events (uuid, person_id, event, timestamp, team_id)
 VALUES (
-    '017adbc0-98b5-0000-3f74-619a368fe65g',
+    '017adbc0-98b5-0000-3f74-619a368fe65b',
     '017adbc0-98b5-0000-3f74-619a368fe65a',
     'page_view',
     toDateTime64('2026-01-01 00:00:01', 6, 'UTC'),

--- a/tests/queries/0_stateless/04211_uuid_parser_strict_validation_86714.reference
+++ b/tests/queries/0_stateless/04211_uuid_parser_strict_validation_86714.reference
@@ -1,0 +1,32 @@
+--- Reproducer from issue #86714: 32-char string with non-hex prefix ---
+\N
+00000000-0000-0000-0000-000000000000
+11111111-1111-1111-1111-111111111111
+--- 36-char string, dashes at the right positions but non-hex elsewhere ---
+\N
+00000000-0000-0000-0000-000000000000
+--- 32-char string of fully non-hex characters ---
+\N
+00000000-0000-0000-0000-000000000000
+--- 36-char string with valid hex but misplaced dashes ---
+\N
+00000000-0000-0000-0000-000000000000
+--- 36-char string with one invalid hex digit at the start ---
+\N
+--- 36-char string with one invalid hex digit at the end ---
+\N
+--- Valid UUIDs must still parse (regression check for the fix itself) ---
+feefefef-6657-8501-4160-310158e823a3
+feefefef-6657-8501-4160-310158e823a3
+00000000-0000-0000-0000-000000000000
+ffffffff-ffff-ffff-ffff-ffffffffffff
+abcdef01-2345-6789-abcd-ef0123456789
+feefefef-6657-8501-4160-310158e823a3
+feefefef-6657-8501-4160-310158e823a3
+feefefef-6657-8501-4160-310158e823a3
+--- Round-trip: parse then format must be identity for valid 36-char input ---
+feefefef-6657-8501-4160-310158e823a3
+feefefef-6657-8501-4160-310158e823a3
+--- CAST(String, UUID) rejects garbage; CAST(String, Nullable(UUID)) returns NULL ---
+\N
+\N

--- a/tests/queries/0_stateless/04211_uuid_parser_strict_validation_86714.sql
+++ b/tests/queries/0_stateless/04211_uuid_parser_strict_validation_86714.sql
@@ -1,0 +1,65 @@
+-- Regression test for issue #86714.
+--
+-- Before the fix, `parseUUID` did not validate that the input characters
+-- were valid hexadecimal digits. The 0..15 lookup table mapped invalid
+-- characters to 0xff, so `unhex2` silently produced garbage bytes
+-- (e.g. `unhex2('s', 't')` overflows back to 0xef in UInt8). This made
+-- the `toUUID*` family accept arbitrary garbage strings of length 32 or
+-- 36 and return a fabricated UUID instead of throwing or returning the
+-- expected default value.
+--
+-- After the fix `parseUUID` and `tryParseUUID` reject any non-hex byte
+-- (and any 36-char input where the dashes are not at positions 8, 13,
+-- 18, 23). The strict `toUUID` throws, the `Or*` variants return their
+-- documented fallback values.
+
+SELECT '--- Reproducer from issue #86714: 32-char string with non-hex prefix ---';
+SELECT toUUID('teststr-665785014160310158e823a3'); -- { serverError CANNOT_PARSE_UUID }
+SELECT toUUIDOrNull('teststr-665785014160310158e823a3');
+SELECT toUUIDOrZero('teststr-665785014160310158e823a3');
+SELECT toUUIDOrDefault('teststr-665785014160310158e823a3', toUUID('11111111-1111-1111-1111-111111111111'));
+
+SELECT '--- 36-char string, dashes at the right positions but non-hex elsewhere ---';
+SELECT toUUID('zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz'); -- { serverError CANNOT_PARSE_UUID }
+SELECT toUUIDOrNull('zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz');
+SELECT toUUIDOrZero('zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz');
+
+SELECT '--- 32-char string of fully non-hex characters ---';
+SELECT toUUID('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'); -- { serverError CANNOT_PARSE_UUID }
+SELECT toUUIDOrNull('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx');
+SELECT toUUIDOrZero('xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx');
+
+SELECT '--- 36-char string with valid hex but misplaced dashes ---';
+-- Layout 12-4-4-4-12 instead of 8-4-4-4-12: every hex digit is valid,
+-- but dashes are shifted, so the dash-position check rejects it.
+SELECT toUUID('feefefef0000-0000-0000-0000-000000000000'); -- { serverError CANNOT_PARSE_UUID }
+SELECT toUUIDOrNull('feefefef0000-0000-0000-0000-000000000000');
+SELECT toUUIDOrZero('feefefef0000-0000-0000-0000-000000000000');
+
+SELECT '--- 36-char string with one invalid hex digit at the start ---';
+SELECT toUUID('Xeefefef-6657-8501-4160-310158e823a3'); -- { serverError CANNOT_PARSE_UUID }
+SELECT toUUIDOrNull('Xeefefef-6657-8501-4160-310158e823a3');
+
+SELECT '--- 36-char string with one invalid hex digit at the end ---';
+SELECT toUUID('feefefef-6657-8501-4160-310158e823aX'); -- { serverError CANNOT_PARSE_UUID }
+SELECT toUUIDOrNull('feefefef-6657-8501-4160-310158e823aX');
+
+SELECT '--- Valid UUIDs must still parse (regression check for the fix itself) ---';
+SELECT toUUID('feefefef-6657-8501-4160-310158e823a3') AS valid_36;
+SELECT toUUID('feefefef665785014160310158e823a3') AS valid_32_no_dashes;
+SELECT toUUID('00000000-0000-0000-0000-000000000000') AS zero_uuid;
+SELECT toUUID('FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF') AS uppercase_hex;
+SELECT toUUID('AbCdEf01-2345-6789-aBcD-eF0123456789') AS mixed_case;
+SELECT toUUIDOrNull('feefefef-6657-8501-4160-310158e823a3') AS or_null_valid;
+SELECT toUUIDOrZero('feefefef-6657-8501-4160-310158e823a3') AS or_zero_valid;
+SELECT toUUIDOrDefault('feefefef-6657-8501-4160-310158e823a3',
+                       toUUID('11111111-1111-1111-1111-111111111111')) AS or_default_valid;
+
+SELECT '--- Round-trip: parse then format must be identity for valid 36-char input ---';
+SELECT toString(toUUID('feefefef-6657-8501-4160-310158e823a3'));
+SELECT toString(toUUID('feefefef665785014160310158e823a3'));
+
+SELECT '--- CAST(String, UUID) rejects garbage; CAST(String, Nullable(UUID)) returns NULL ---';
+SELECT CAST('teststr-665785014160310158e823a3' AS UUID); -- { serverError CANNOT_PARSE_UUID }
+SELECT CAST('teststr-665785014160310158e823a3' AS Nullable(UUID));
+SELECT accurateCastOrNull('teststr-665785014160310158e823a3', 'UUID');


### PR DESCRIPTION
Closes #86714.

## Problem

`parseUUID` did not validate that the input characters were valid hexadecimal digits. The lookup table mapped invalid characters to `0xff`, and `unhex2` then folded that back into `UInt8` arithmetic that wrapped around silently (for example `unhex2('s', 't')` = `0xff*16 + 0xff = 4335`, which truncates to `0xef`). As a result `toUUID*`, `CAST(... AS UUID)`, and any other caller of `parseUUID` happily accepted arbitrary 32- or 36-character garbage strings and fabricated a UUID from them.

```sql
WITH 'teststr-665785014160310158e823a3' AS str
SELECT toUUID(str), toUUIDOrNull(str), toUUIDOrZero(str);

-- Old behaviour: feefefef-6657-8501-4160-310158e823a3 for all three
-- New behaviour: throws CANNOT_PARSE_UUID; OrNull -> NULL; OrZero -> 00000000-0000-0000-0000-000000000000
```

## Fix

`parseUUID` now performs an explicit pre-validation pass:

* For 36-character inputs: dashes must be at positions 8, 13, 18, 23 and every other byte must be a hex digit `0-9 / a-f / A-F`.
* For 32-character inputs: every byte must be a hex digit.
* Other lengths still throw with the same error as before.

A new `tryParseUUID(span, UUID&)` returning `bool` is introduced for the no-throw path. `readUUIDTextImpl<bool>` (used by `tryReadUUIDText`, and therefore by `toUUIDOrNull / OrZero / OrDefault`, `CAST AS Nullable(UUID)`, `accurateCastOrNull`, JSONExtract on UUID, MsgPack input, ...) routes through it so invalid inputs surface as a clean `false` instead of an exception leaking through the try-path.

The fix lives at the parser layer, so all callers benefit at once: `toUUID*`, `CAST`, `SerializationUUID::deserializeTextQuoted` (fast path), `AvroRowInputFormat`, `JSONExtractTree`, `MsgPackRowInputFormat`, `ZooKeeperReplicator`.

## Tests

* All 17 UUID-related stateless tests still pass (`01528_to_uuid_or_null_or_zero`, `04137_conversion_functions_edges`, `00396_uuid`, `00472_compare_uuid_with_constant_string`, `00679_uuid_in_key`, `01032_cityHash64_for_UUID`, `01338_uuid_without_separator`, `01413_if_array_uuid`, `01453_normalize_query_alias_uuid`, `01554_bloom_filter_index_big_integer_uuid`, `02491_part_log_has_table_uuid`, `01746_convert_type_with_default`, `01533_distinct_nullable_uuid`, `03595_funcs_on_zero`, `03593_funcs_on_empty_string`, `03212_variant_dynamic_cast_or_default`, `00396_uuid_v7`).
* New regression test `04211_uuid_parser_strict_validation_86714.sql` covers the exact reproducer from the issue, all four `toUUID*` variants, multiple invalid-input shapes (full-garbage 32-char, 36-char with right dashes but non-hex elsewhere, misplaced dashes, single bad digit at start / end), valid 36-char / 32-char / mixed-case inputs, round-trip identity, `CAST AS UUID`, `CAST AS Nullable(UUID)`, and `accurateCastOrNull`. 30/30 passes with random settings enabled.

### Changelog category (leave one):
- Backward Incompatible Change

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

`toUUID`, `toUUIDOrNull`, `toUUIDOrZero`, `toUUIDOrDefault`, `CAST` to `UUID` and `Nullable(UUID)`, `accurateCastOrNull` to `UUID`, and the input formats that parse a UUID from text (`Avro`, `MsgPack`, `JSONExtract`, ...) now reject strings that have the right length but contain non-hexadecimal characters. Previously such inputs were silently turned into a fabricated UUID by walking off the end of the hex digit lookup table; now `toUUID` throws `CANNOT_PARSE_UUID`, and the `Or*` variants return `NULL` / the zero UUID / the supplied default.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)