### PR TITLE
Make AsyncReadCounters lockless

### DIFF
--- a/src/Disks/IO/ThreadPoolRemoteFSReader.cpp
+++ b/src/Disks/IO/ThreadPoolRemoteFSReader.cpp
@@ -55,15 +55,13 @@ namespace
         explicit AsyncReadIncrement(std::shared_ptr<AsyncReadCounters> counters_)
             : counters(counters_)
         {
-            std::lock_guard lock(counters->mutex);
-            if (++counters->current_parallel_read_tasks > counters->max_parallel_read_tasks)
-                counters->max_parallel_read_tasks = counters->current_parallel_read_tasks;
+            AsyncReadCounters::incrementAndUpdateMax(
+                counters->current_parallel_read_tasks, counters->max_parallel_read_tasks);
         }
 
         ~AsyncReadIncrement()
         {
-            std::lock_guard lock(counters->mutex);
-            --counters->current_parallel_read_tasks;
+            counters->current_parallel_read_tasks.fetch_sub(1, std::memory_order_relaxed);
         }
 
         std::shared_ptr<AsyncReadCounters> counters;

--- a/src/IO/AsyncReadCounters.cpp
+++ b/src/IO/AsyncReadCounters.cpp
@@ -30,11 +30,9 @@ void AsyncReadCounters::dumpToMapColumn(IColumn * column) const
         }
     };
 
-    std::lock_guard lock(mutex);
-
-    load_if_not_empty("max_parallel_read_tasks", max_parallel_read_tasks);
-    load_if_not_empty("max_parallel_prefetch_tasks", max_parallel_prefetch_tasks);
-    load_if_not_empty("total_prefetch_tasks", total_prefetch_tasks);
+    load_if_not_empty("max_parallel_read_tasks", max_parallel_read_tasks.load(std::memory_order_relaxed));
+    load_if_not_empty("max_parallel_prefetch_tasks", max_parallel_prefetch_tasks.load(std::memory_order_relaxed));
+    load_if_not_empty("total_prefetch_tasks", total_prefetch_tasks.load(std::memory_order_relaxed));
 
     offsets.push_back(offsets.back() + size);
 }

--- a/src/IO/AsyncReadCounters.h
+++ b/src/IO/AsyncReadCounters.h
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <mutex>
+#include <atomic>
+#include <cstddef>
+#include <memory>
 
 namespace DB
 {
@@ -8,26 +10,42 @@ namespace DB
 class IColumn;
 
 /// Metrics for asynchronous reading feature.
+///
+/// All fields are atomic and updated with relaxed memory ordering: the values
+/// are only used for monitoring (dumped into `system.query_log` via
+/// `dumpToMapColumn`), so we don't need any synchronization between updaters
+/// or between updaters and readers, only per-counter atomicity. This avoids a
+/// mutex which used to show up in profiles of read-heavy workloads.
 struct AsyncReadCounters
 {
     /// Count current and max number of tasks in a asynchronous read pool.
     /// The tasks are requests to read the data.
-    size_t max_parallel_read_tasks = 0;
-    size_t current_parallel_read_tasks = 0;
+    std::atomic<size_t> max_parallel_read_tasks = 0;
+    std::atomic<size_t> current_parallel_read_tasks = 0;
 
     /// Count current and max number of tasks in a reader prefetch read pool.
     /// The tasks are calls to IMergeTreeReader::prefetch(), which does not do
     /// any reading but creates a request for read. But as we need to wait for
     /// marks to be loaded during this prefetch, we do it in a threadpool too.
-    size_t max_parallel_prefetch_tasks = 0;
-    size_t current_parallel_prefetch_tasks = 0;
-    size_t total_prefetch_tasks = 0;
-
-    mutable std::mutex mutex;
+    std::atomic<size_t> max_parallel_prefetch_tasks = 0;
+    std::atomic<size_t> current_parallel_prefetch_tasks = 0;
+    std::atomic<size_t> total_prefetch_tasks = 0;
 
     AsyncReadCounters() = default;
 
     void dumpToMapColumn(IColumn * column) const;
+
+    /// Atomically increments `current` and updates `max` to be at least the new
+    /// value of `current`, both with relaxed memory ordering.
+    static void incrementAndUpdateMax(std::atomic<size_t> & current, std::atomic<size_t> & max)
+    {
+        size_t new_value = current.fetch_add(1, std::memory_order_relaxed) + 1;
+        size_t prev_max = max.load(std::memory_order_relaxed);
+        while (prev_max < new_value
+               && !max.compare_exchange_weak(prev_max, new_value, std::memory_order_relaxed))
+        {
+        }
+    }
 };
 using AsyncReadCountersPtr = std::shared_ptr<AsyncReadCounters>;
 

--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.h
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.h
@@ -141,17 +141,14 @@ private:
         explicit PrefetchIncrement(std::shared_ptr<AsyncReadCounters> counters_)
             : counters(counters_)
         {
-            std::lock_guard lock(counters->mutex);
-            ++counters->total_prefetch_tasks;
-            if (++counters->current_parallel_prefetch_tasks > counters->max_parallel_prefetch_tasks)
-                counters->max_parallel_prefetch_tasks = counters->current_parallel_prefetch_tasks;
-
+            counters->total_prefetch_tasks.fetch_add(1, std::memory_order_relaxed);
+            AsyncReadCounters::incrementAndUpdateMax(
+                counters->current_parallel_prefetch_tasks, counters->max_parallel_prefetch_tasks);
         }
 
         ~PrefetchIncrement()
         {
-            std::lock_guard lock(counters->mutex);
-            --counters->current_parallel_prefetch_tasks;
+            counters->current_parallel_prefetch_tasks.fetch_sub(1, std::memory_order_relaxed);
         }
 
         std::shared_ptr<AsyncReadCounters> counters;


### PR DESCRIPTION
The `std::mutex` in `AsyncReadCounters` is taken on every remote-FS read task and every prefetch submission, and shows up in production profiles of read-heavy workloads under `pthread_mutex_lock` in `DB::ThreadPoolRemoteFSReader::execute` and `DB::ThreadPoolRemoteFSReader::submit`.

The counters are only read by `dumpToMapColumn` for the `AsyncReadCounters` map in `system.query_log`, so per-field atomicity is enough. Replace the fields and the mutex with `std::atomic<size_t>` and a relaxed CAS loop for the "bump max" pattern.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reduced lock contention on the asynchronous remote-FS read path by making the per-query `AsyncReadCounters` lockless.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

Made with [Cursor](https://cursor.com)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.459`
- Backported to: `26.4.3.10`, `26.2.19.12`
<!-- ch-version-info:end -->