### PR TITLE
CI: read prior PR discussion in the Code Review job

### DIFF
--- a/ci/jobs/copilot_review_job.py
+++ b/ci/jobs/copilot_review_job.py
@@ -150,24 +150,65 @@ def pre():
 
     _reauth_gh()
     os.makedirs("./ci/tmp", exist_ok=True)
-    prompt = (
-        f"Follow the Review Instructions in .claude/skills/review/SKILL.md. "
-        f"Review PR {info.pr_url}. Repo is checked out at PR head. "
-        f"Post findings as individual inline review comments on specific lines. "
-        f"Prefix every gh call with `env -u GH_CONFIG_DIR`. "
-        f"IMPORTANT — to post an inline review comment, write the body to a file and call: "
-        f"`env -u GH_CONFIG_DIR python3 ci/praktika/gh.py post-pr-line-comment "
-        f"--file <body.md> --commit <sha> --path <file> --line <N> [--side RIGHT|LEFT]`. "
-        f"This wrapper handles `-F body=@<file>` correctly so the file content is uploaded as the body. "
-        f"Do NOT call `gh api .../pulls/.../comments` directly — past runs have posted the literal "
-        f"`@<file>` string as the body when the wrong gh flag was used. "
-        f"Do NOT use `gh pr review` (that posts a single batched review, not individual line comments). "
-        f"Read inline comments already posted by clickhouse-gh[bot]; do not post a new comment if a similar one already exists. "
-        f"Write a self-contained summary of ALL findings (regardless of previous summaries) "
-        f"as plain Markdown to {REVIEW_FILE} using the REQUESTED OUTPUT FORMAT from .claude/skills/review/SKILL.md — "
-        f"start with `---\n#### AI Review`, then use ##### for section headers. "
-        f"Do NOT post the summary yourself — the job script will post it after you finish."
-    )
+    prompt = f"""\
+Follow the Review Instructions in .claude/skills/review/SKILL.md.
+Review PR {info.pr_url}. Repo is checked out at PR head.
+Post findings as individual inline review comments on specific lines.
+Prefix every gh call with `env -u GH_CONFIG_DIR`.
+
+IMPORTANT: to post an inline review comment, write the body to a file and call:
+`env -u GH_CONFIG_DIR python3 ci/praktika/gh.py post-pr-line-comment --file <body.md> --commit <sha> --path <file> --line <N> [--side RIGHT|LEFT]`.
+This wrapper handles `-F body=@<file>` correctly so the file content is uploaded as the body.
+Do NOT call `gh api .../pulls/.../comments` directly: past runs have posted the literal `@<file>`
+string as the body when the wrong gh flag was used.
+Do NOT use `gh pr review` (that posts a single batched review, not individual line comments).
+
+Before reviewing, fetch all prior discussion on this PR.
+Inline review threads come from
+`env -u GH_CONFIG_DIR python3 ci/praktika/gh.py list-pr-review-threads --pr {info.pr_number}`
+(returns JSON; each thread carries its node `id`, `isResolved`, `path`, `line`, and `comments.nodes`
+with author, body, and `databaseId`).
+Top-level conversation comes from
+`env -u GH_CONFIG_DIR gh api '/repos/{{owner}}/{{repo}}/issues/{info.pr_number}/comments' --paginate`.
+
+Read every reply on every thread before deciding to raise a point.
+A reply from the author is not by itself a resolution.
+Judge it on its merits: an explanation that holds up, a pointer to a commit that actually fixes
+the issue, or a tradeoff you agree with means drop the point.
+A handwave, a misunderstanding of what was originally flagged, a 'will fix later' that never
+landed, or a claim that contradicts the code as it stands now means the issue is still live.
+In that case, push back: reply on the existing thread, restate the concern with the relevant code,
+and explain why the previous answer does not resolve it.
+
+To reply on a thread, use the same wrapper with `--reply-to <parent_databaseId>` (the `databaseId`
+of the first comment on the thread) and omit `--commit`/`--path`/`--line`:
+`env -u GH_CONFIG_DIR python3 ci/praktika/gh.py post-pr-line-comment --file <body.md> --reply-to <parent_databaseId>`.
+Do not open a fresh inline comment for a point that already has a thread; reply on the thread instead.
+Apply the same judgment to your own prior summary: drop findings that have genuinely been addressed,
+keep or sharpen the ones that have not.
+
+After reviewing, mark threads as resolved or unresolved based on the current code.
+Only act on threads you created yourself: that means threads where the first comment in
+`comments.nodes` was authored by `clickhouse-gh[bot]`.
+Never resolve or unresolve threads where the first comment was authored by anyone else
+(other reviewers, the PR author, other bots), even when the code suggests the thread should
+be resolved or re-opened.
+For each bot-authored thread that is not already resolved, if the issue you flagged no longer
+holds in the current code, resolve it via
+`env -u GH_CONFIG_DIR python3 ci/praktika/gh.py resolve-pr-review-thread --thread-id <thread_node_id>`.
+If a bot-authored thread was already resolved (by you or someone else) but the current code still
+has the issue, you can re-open it via
+`env -u GH_CONFIG_DIR python3 ci/praktika/gh.py unresolve-pr-review-thread --thread-id <thread_node_id>`
+and post a follow-up reply explaining what is still wrong.
+Verify the state by reading the current code at the thread's path and line, not by trusting
+the author's reply.
+
+Write a self-contained summary of ALL findings (regardless of previous summaries) as plain Markdown
+to {REVIEW_FILE} using the REQUESTED OUTPUT FORMAT from .claude/skills/review/SKILL.md:
+start with `---
+#### AI Review`, then use ##### for section headers.
+Do NOT post the summary yourself: the job script will post it after you finish.
+"""
     _run(prompt)
 
 
@@ -181,16 +222,17 @@ def post():
     os.makedirs("./ci/tmp", exist_ok=True)
     ci_report_url = info.get_report_url()
 
-    prompt = (
-        f"Fetch CI results: node .claude/tools/fetch_ci_report.js '{ci_report_url}' --failed --links "
-        f"(use --all, --test <name>, or --download-logs for deeper investigation). "
-        f"If all checks passed — stop. "
-        f"Otherwise review the PR {info.pr_url} diff and match each failure to the code changes. "
-        f"Write a self-contained summary as plain Markdown to {REVIEW_FILE} — "
-        f"start with `---\n### AI Review`, then use #### headers for sections only if needed. "
-        f"Do NOT post the summary yourself — the job script will post it after you finish. "
-        f"Do not post inline comments."
-    )
+    prompt = f"""\
+Fetch CI results: node .claude/tools/fetch_ci_report.js '{ci_report_url}' --failed --links
+(use --all, --test <name>, or --download-logs for deeper investigation).
+If all checks passed: stop.
+Otherwise review the PR {info.pr_url} diff and match each failure to the code changes.
+Write a self-contained summary as plain Markdown to {REVIEW_FILE}:
+start with `---
+### AI Review`, then use #### headers for sections only if needed.
+Do NOT post the summary yourself: the job script will post it after you finish.
+Do not post inline comments.
+"""
     _run(prompt)
 
 

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -243,14 +243,22 @@ class GH:
     def post_pr_line_comment(
         cls,
         body_file,
-        commit_id,
-        path,
-        line,
+        commit_id=None,
+        path=None,
+        line=None,
         side="RIGHT",
+        in_reply_to=None,
         pr=None,
         repo=None,
     ):
-        """Post an inline review comment on a specific line of a PR diff.
+        """Post an inline review comment on a specific line of a PR diff,
+        or a reply on an existing inline thread.
+
+        When ``in_reply_to`` is set, the comment is posted as a reply on
+        the thread whose parent comment has that database id, and
+        ``commit_id``/``path``/``line``/``side`` are ignored. Otherwise a
+        new top-level inline comment is created at the given location and
+        all four are required.
 
         The body is read from ``body_file`` and passed via ``-F body=@<file>``,
         which avoids two classes of bugs we have hit before:
@@ -269,17 +277,101 @@ class GH:
         if os.path.getsize(body_file) == 0:
             raise ValueError(f"Body file [{body_file}] is empty")
 
-        cmd = (
-            f"gh api -X POST "
-            f'-H "Accept: application/vnd.github.v3+json" '
-            f'"/repos/{repo}/pulls/{pr}/comments" '
-            f"-F body=@{shlex.quote(body_file)} "
-            f"-f commit_id={shlex.quote(commit_id)} "
-            f"-f path={shlex.quote(path)} "
-            f"-F line={int(line)} "
-            f"-f side={shlex.quote(side)}"
-        )
+        if in_reply_to is not None:
+            cmd = (
+                f"gh api -X POST "
+                f'-H "Accept: application/vnd.github.v3+json" '
+                f'"/repos/{repo}/pulls/{pr}/comments/{int(in_reply_to)}/replies" '
+                f"-F body=@{shlex.quote(body_file)}"
+            )
+        else:
+            if commit_id is None or path is None or line is None:
+                raise ValueError(
+                    "post_pr_line_comment requires commit_id, path, and line "
+                    "when in_reply_to is not set"
+                )
+            cmd = (
+                f"gh api -X POST "
+                f'-H "Accept: application/vnd.github.v3+json" '
+                f'"/repos/{repo}/pulls/{pr}/comments" '
+                f"-F body=@{shlex.quote(body_file)} "
+                f"-f commit_id={shlex.quote(commit_id)} "
+                f"-f path={shlex.quote(path)} "
+                f"-F line={int(line)} "
+                f"-f side={shlex.quote(side)}"
+            )
         return cls.do_command_with_retries(cmd)
+
+    @classmethod
+    def list_pr_review_threads(cls, pr=None, repo=None, verbose=False):
+        """Return all review threads on a PR via GraphQL.
+
+        Each thread carries its node ``id`` (the value to pass to the
+        resolve/unresolve mutations), ``isResolved``, ``isOutdated``,
+        ``path``, ``line``, and the list of comments under it (with
+        ``databaseId`` for use as ``in_reply_to`` when replying).
+        Returns a list of thread dicts; an empty list on failure.
+        """
+        if not repo:
+            repo = _Environment.get().REPOSITORY
+        if not pr:
+            pr = _Environment.get().PR_NUMBER
+        owner, name = repo.split("/", 1)
+        query = (
+            "query($owner:String!,$name:String!,$pr:Int!){"
+            "repository(owner:$owner,name:$name){"
+            "pullRequest(number:$pr){"
+            "reviewThreads(first:100){"
+            "nodes{id isResolved isOutdated path line "
+            "comments(first:50){nodes{databaseId author{login} body path line originalLine}}"
+            "}}}}}"
+        )
+        cmd = (
+            f"gh api graphql "
+            f"-f query={shlex.quote(query)} "
+            f"-F owner={shlex.quote(owner)} "
+            f"-F name={shlex.quote(name)} "
+            f"-F pr={int(pr)}"
+        )
+        out = cls.get_output_with_retries(cmd, verbose=verbose)
+        if not out:
+            return []
+        try:
+            data = json.loads(out)
+            return data["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+        except (json.JSONDecodeError, KeyError, TypeError) as e:
+            print(f"ERROR: Failed to parse review threads JSON: {e}")
+            return []
+
+    @classmethod
+    def _set_review_thread_resolution(cls, thread_id, resolve, verbose=False):
+        mutation_name = "resolveReviewThread" if resolve else "unresolveReviewThread"
+        query = (
+            f"mutation($threadId:ID!){{"
+            f"{mutation_name}(input:{{threadId:$threadId}}){{thread{{isResolved}}}}"
+            f"}}"
+        )
+        cmd = (
+            f"gh api graphql "
+            f"-f query={shlex.quote(query)} "
+            f"-f threadId={shlex.quote(thread_id)}"
+        )
+        return cls.do_command_with_retries(cmd, verbose=verbose)
+
+    @classmethod
+    def resolve_pr_review_thread(cls, thread_id, verbose=False):
+        """Mark a PR review thread as resolved (GraphQL ``resolveReviewThread``).
+
+        ``thread_id`` is the GraphQL node id from
+        :meth:`list_pr_review_threads`, not the REST comment id.
+        """
+        return cls._set_review_thread_resolution(thread_id, resolve=True, verbose=verbose)
+
+    @classmethod
+    def unresolve_pr_review_thread(cls, thread_id, verbose=False):
+        """Re-open a previously resolved PR review thread
+        (GraphQL ``unresolveReviewThread``)."""
+        return cls._set_review_thread_resolution(thread_id, resolve=False, verbose=verbose)
 
     '''
     TODO: @maxknv
@@ -973,20 +1065,67 @@ if __name__ == "__main__":
         help="Path to file containing the comment body (read via -F body=@<file>)",
     )
     line_parser.add_argument(
-        "--commit", required=True, help="Commit SHA the comment refers to"
+        "--commit",
+        default=None,
+        help="Commit SHA the comment refers to (required unless --reply-to is set)",
     )
     line_parser.add_argument(
-        "--path", required=True, help="Path of the file to comment on"
+        "--path",
+        default=None,
+        help="Path of the file to comment on (required unless --reply-to is set)",
     )
     line_parser.add_argument(
-        "--line", required=True, type=int, help="Line number in the PR diff"
+        "--line",
+        type=int,
+        default=None,
+        help="Line number in the PR diff (required unless --reply-to is set)",
     )
     line_parser.add_argument(
         "--side", default="RIGHT", choices=["RIGHT", "LEFT"], help="Diff side"
     )
+    line_parser.add_argument(
+        "--reply-to",
+        type=int,
+        default=None,
+        dest="reply_to",
+        help="databaseId of the parent comment to reply to. "
+        "When set, the comment is posted as a reply on the existing thread "
+        "and --commit/--path/--line are ignored.",
+    )
     line_parser.add_argument("--pr", type=int, default=None, help="PR number")
     line_parser.add_argument(
         "--repo", default=None, help="Repository in owner/repo format"
+    )
+
+    threads_parser = subparsers.add_parser(
+        "list-pr-review-threads",
+        help="List PR review threads via GraphQL (prints JSON to stdout)",
+    )
+    threads_parser.add_argument("--pr", type=int, default=None, help="PR number")
+    threads_parser.add_argument(
+        "--repo", default=None, help="Repository in owner/repo format"
+    )
+
+    resolve_parser = subparsers.add_parser(
+        "resolve-pr-review-thread",
+        help="Resolve a PR review thread via GraphQL",
+    )
+    resolve_parser.add_argument(
+        "--thread-id",
+        required=True,
+        dest="thread_id",
+        help="GraphQL node id of the review thread (from list-pr-review-threads)",
+    )
+
+    unresolve_parser = subparsers.add_parser(
+        "unresolve-pr-review-thread",
+        help="Re-open (unresolve) a PR review thread via GraphQL",
+    )
+    unresolve_parser.add_argument(
+        "--thread-id",
+        required=True,
+        dest="thread_id",
+        help="GraphQL node id of the review thread (from list-pr-review-threads)",
     )
 
     args = parser.parse_args()
@@ -1011,12 +1150,28 @@ if __name__ == "__main__":
             path=args.path,
             line=args.line,
             side=args.side,
+            in_reply_to=args.reply_to,
         )
         if args.pr is not None:
             kwargs["pr"] = args.pr
         if args.repo is not None:
             kwargs["repo"] = args.repo
         ok = GH.post_pr_line_comment(**kwargs)
+        sys.exit(0 if ok else 1)
+    elif args.command == "list-pr-review-threads":
+        kwargs = {}
+        if args.pr is not None:
+            kwargs["pr"] = args.pr
+        if args.repo is not None:
+            kwargs["repo"] = args.repo
+        threads = GH.list_pr_review_threads(**kwargs)
+        print(json.dumps(threads, indent=2))
+        sys.exit(0)
+    elif args.command == "resolve-pr-review-thread":
+        ok = GH.resolve_pr_review_thread(args.thread_id)
+        sys.exit(0 if ok else 1)
+    elif args.command == "unresolve-pr-review-thread":
+        ok = GH.unresolve_pr_review_thread(args.thread_id)
         sys.exit(0 if ok else 1)
     else:
         parser.print_help()

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -303,45 +303,101 @@ class GH:
         return cls.do_command_with_retries(cmd)
 
     @classmethod
+    def _gh_graphql_json(cls, query, variables, verbose=False):
+        """Run a GraphQL query via ``gh api graphql`` and return parsed JSON.
+
+        ``variables`` is a mapping of name to value: ``int`` and ``bool``
+        values use ``-F`` (typed), everything else uses ``-f`` (raw string).
+        Raises ``RuntimeError`` on transport failure (empty output after
+        retries) or if the response cannot be parsed; the caller is
+        responsible for checking GraphQL ``errors`` if any. Failing loud
+        is intentional: a silent empty result is indistinguishable from
+        "no data" and causes the reviewer to lose prior context.
+        """
+        parts = [f"gh api graphql -f query={shlex.quote(query)}"]
+        for k, v in variables.items():
+            if isinstance(v, bool):
+                parts.append(f"-F {k}={'true' if v else 'false'}")
+            elif isinstance(v, int):
+                parts.append(f"-F {k}={int(v)}")
+            else:
+                parts.append(f"-f {k}={shlex.quote(str(v))}")
+        cmd = " ".join(parts)
+        out = cls.get_output_with_retries(cmd, verbose=verbose)
+        if not out:
+            raise RuntimeError(f"gh api graphql failed (no output) for cmd [{cmd}]")
+        try:
+            data = json.loads(out)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"gh api graphql returned non-JSON output [{out[:200]}]: {e}")
+        if "errors" in data and data["errors"]:
+            raise RuntimeError(f"gh api graphql returned errors: {data['errors']}")
+        return data
+
+    @classmethod
     def list_pr_review_threads(cls, pr=None, repo=None, verbose=False):
         """Return all review threads on a PR via GraphQL.
 
         Each thread carries its node ``id`` (the value to pass to the
         resolve/unresolve mutations), ``isResolved``, ``isOutdated``,
-        ``path``, ``line``, and the list of comments under it (with
-        ``databaseId`` for use as ``in_reply_to`` when replying).
-        Returns a list of thread dicts; an empty list on failure.
+        ``path``, ``line``, and the full list of comments under it (with
+        ``databaseId`` for use as ``in_reply_to`` when replying). Both
+        the thread list and each thread's comments are paginated, so
+        long PRs do not silently truncate. Raises ``RuntimeError`` on
+        any transport / parse failure: a failure to read prior
+        discussion must not be confused with "no prior discussion".
         """
         if not repo:
             repo = _Environment.get().REPOSITORY
         if not pr:
             pr = _Environment.get().PR_NUMBER
         owner, name = repo.split("/", 1)
-        query = (
-            "query($owner:String!,$name:String!,$pr:Int!){"
+
+        thread_query = (
+            "query($owner:String!,$name:String!,$pr:Int!,$after:String){"
             "repository(owner:$owner,name:$name){"
             "pullRequest(number:$pr){"
-            "reviewThreads(first:100){"
+            "reviewThreads(first:100,after:$after){"
+            "pageInfo{hasNextPage endCursor}"
             "nodes{id isResolved isOutdated path line "
-            "comments(first:50){nodes{databaseId author{login} body path line originalLine}}"
-            "}}}}}"
+            "comments(first:50){"
+            "pageInfo{hasNextPage endCursor}"
+            "nodes{databaseId author{login} body path line originalLine}"
+            "}}}}}}"
         )
-        cmd = (
-            f"gh api graphql "
-            f"-f query={shlex.quote(query)} "
-            f"-F owner={shlex.quote(owner)} "
-            f"-F name={shlex.quote(name)} "
-            f"-F pr={int(pr)}"
+        comments_query = (
+            "query($id:ID!,$after:String!){"
+            "node(id:$id){... on PullRequestReviewThread{"
+            "comments(first:50,after:$after){"
+            "pageInfo{hasNextPage endCursor}"
+            "nodes{databaseId author{login} body path line originalLine}"
+            "}}}}"
         )
-        out = cls.get_output_with_retries(cmd, verbose=verbose)
-        if not out:
-            return []
-        try:
-            data = json.loads(out)
-            return data["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
-        except (json.JSONDecodeError, KeyError, TypeError) as e:
-            print(f"ERROR: Failed to parse review threads JSON: {e}")
-            return []
+
+        threads = []
+        thread_cursor = None
+        while True:
+            variables = {"owner": owner, "name": name, "pr": int(pr)}
+            if thread_cursor is not None:
+                variables["after"] = thread_cursor
+            data = cls._gh_graphql_json(thread_query, variables, verbose=verbose)
+            page = data["data"]["repository"]["pullRequest"]["reviewThreads"]
+            for thread in page["nodes"]:
+                comments = thread["comments"]
+                while comments["pageInfo"]["hasNextPage"]:
+                    sub = cls._gh_graphql_json(
+                        comments_query,
+                        {"id": thread["id"], "after": comments["pageInfo"]["endCursor"]},
+                        verbose=verbose,
+                    )
+                    next_page = sub["data"]["node"]["comments"]
+                    comments["nodes"].extend(next_page["nodes"])
+                    comments["pageInfo"] = next_page["pageInfo"]
+                threads.append(thread)
+            if not page["pageInfo"]["hasNextPage"]:
+                break
+            thread_cursor = page["pageInfo"]["endCursor"]
+        return threads
 
     @classmethod
     def _set_review_thread_resolution(cls, thread_id, resolve, verbose=False):


### PR DESCRIPTION
The Code Review CI job ignored prior discussion on the PR and could repost findings the author had already responded to. Update the job and its `gh` wrapper so the bot reads earlier inline threads and top-level comments, decides on the merits whether each finding is still live, replies on the existing thread when it pushes back, and resolves or re-opens its own threads based on whether the current code still has the issue.

`ci/praktika/gh.py`:
- `post_pr_line_comment` gains a `--reply-to` flag so a comment can be posted as a reply on an existing inline thread.
- New CLI subcommands `list-pr-review-threads`, `resolve-pr-review-thread`, and `unresolve-pr-review-thread` wrap the GraphQL `reviewThreads` query and the `resolveReviewThread` / `unresolveReviewThread` mutations.

`ci/jobs/copilot_review_job.py`:
- The Code Review prompt now fetches inline threads with replies and the top-level conversation before deciding to raise a point.
- A reply from the author is no longer treated as automatic resolution. The bot judges responses on their merits and pushes back on the existing thread when the response is inadequate.
- After review the bot resolves threads it started itself when the code no longer has the issue, and re-opens its previously-resolved threads when the issue is still live. Threads opened by anyone other than `clickhouse-gh[bot]` are off-limits.
- Both prompts moved to column-0 triple-quoted f-strings.

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.451`
<!-- ch-version-info:end -->