### PR TITLE
OvercommitTracker: synchronously purge jemalloc dirty pages on successful kill

### DIFF
--- a/src/Common/OvercommitTracker.cpp
+++ b/src/Common/OvercommitTracker.cpp
@@ -1,5 +1,6 @@
 #include <Common/OvercommitTracker.h>
 
+#include <Common/Jemalloc.h>
 #include <Common/ProfileEvents.h>
 #include <Common/CurrentMetrics.h>
 #include <Interpreters/ProcessList.h>
@@ -102,11 +103,43 @@ OvercommitResult OvercommitTracker::needToStopQuery(MemoryTracker * tracker, Int
     // As we don't need to free memory, we can continue execution of the selected query.
     if (required_memory == 0 && cancellation_state == QueryCancellationState::SELECTED)
         reset();
+    OvercommitResult result;
     if (timeout)
-        return OvercommitResult::TIMEOUTED;
-    if (still_need)
-        return OvercommitResult::NOT_ENOUGH_FREED;
-    return OvercommitResult::MEMORY_FREED;
+        result = OvercommitResult::TIMEOUTED;
+    else if (still_need)
+        result = OvercommitResult::NOT_ENOUGH_FREED;
+    else
+        result = OvercommitResult::MEMORY_FREED;
+
+    /// Release lk before the (potentially multi-second) purge so other
+    /// queries can enter OvercommitTracker while we're draining dirty pages.
+    lk.unlock();
+
+#if USE_JEMALLOC
+    /// The selected query has already freed its memory (logical decrement).
+    /// But the freed extents are still dirty in jemalloc and count toward
+    /// kernel RSS until decay_ms (5s) elapses or MemoryWorker triggers a purge.
+    /// Synchronously purge now so subsequent allocations from other queries
+    /// see actual RSS that matches MemoryTracker.amount.
+    ///
+    /// A single releaseThreads() call wakes up every queued waiter, and all
+    /// of them reach this code path with result==MEMORY_FREED — meaning a
+    /// single kill event triggers as many purges as there were waiters. This
+    /// looks alarming, but in practice deduplicating it (one purge per release
+    /// wave via an atomic flag) was measurably worse in throughput tests:
+    ///   - concurrent per-waiter purges parallelise the drain work, while
+    ///     a single serialised purge per wave is bigger and not pipelined;
+    ///   - more importantly, a waiter that skipped the dedup'd purge would
+    ///     return immediately and attempt its next allocation against a
+    ///     still-stale RSS view, which would then fail.
+    /// Per-waiter purging is wasted-work-bounded by the wave size, runs in
+    /// parallel, and guarantees every waiter sees a fresh RSS before its
+    /// next allocation.
+    if (result == OvercommitResult::MEMORY_FREED)
+        DB::Jemalloc::purgeArenas();
+#endif
+
+    return result;
 }
 
 void OvercommitTracker::tryContinueQueryExecutionAfterFree(Int64 amount)


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Dirty pages are now synchronously freed after the query is killed by the `OvercommitTracker`.

---

When a query is selected for `OvercommitTracker` termination and its memory is released, the freed extents stay dirty in jemalloc until `dirty_decay_ms` (5s default) elapses or `MemoryWorker` triggers a purge on its next iteration. During that window, the kernel-visible RSS stays at the limit even though `MemoryTracker` now believes there is headroom. Other queries trying to allocate hit the RSS check in `MemoryTracker::allocImpl` and OOM cascade.

After `OvercommitTracker` confirms enough memory has been freed, drop the internal lock and synchronously purge dirty pages so the next allocation from a waiting query sees real RSS rather than the lagging-decay value.

The lock is released before the (potentially multi-second) purge so other queries can enter the `OvercommitTracker` path during the drain.

---

Some test results:

```
  ▎ Setup
  ▎
  ▎ - 16 GiB max_server_memory_usage (intentionally tight)
  ▎ - 4 concurrent clients running SELECT URL, COUNT(*) FROM hits GROUP BY URL ORDER BY c DESC LIMIT 10 against ClickBench 100M-row hits dataset
  ▎ - 60-second runs × 5 iterations per binary, repeated twice = 10 iterations / 600 seconds per binary
  ▎ - Server pinned to NUMA-0 + HT (cores 0-31,96-127), spilling disabled
  ▎ - Hardware: Intel Xeon 6975P-C (Granite Rapids), 192 vCPU
  ▎
  ▎ Results across 10 iterations
  ▎
  ▎ |                      | master | master_fix1 | delta |
  ▎ |----------------------|--------|-------------|-------|
  ▎ | Successful queries   | 109    | 122         | +12%  |
  ▎ | Failed queries (OOM) | 650    | 526         | −19%  |
  ▎ | Throughput (qps)     | 0.18   | 0.20        | +11%  |
```