### PR TITLE
Reorder operations in DiskAccessStorage for consistency: always modify files first

### DIFF
--- a/src/Access/DiskAccessStorage.cpp
+++ b/src/Access/DiskAccessStorage.cpp
@@ -27,6 +27,7 @@ namespace ErrorCodes
 {
     extern const int DIRECTORY_DOESNT_EXIST;
     extern const int FILE_DOESNT_EXIST;
+    extern const int LOGICAL_ERROR;
 }
 
 
@@ -298,8 +299,9 @@ void DiskAccessStorage::writeLists()
         }
     }
 
-    /// The list files was successfully written, we don't need the 'need_rebuild_lists.mark' file any longer.
-    (void)std::filesystem::remove(getNeedRebuildListsMarkFilePath(directory_path));
+    /// The list files were successfully written.
+    if (!has_stale_files_on_disk)
+        (void)std::filesystem::remove(getNeedRebuildListsMarkFilePath(directory_path));
     types_of_lists_to_write.clear();
 }
 
@@ -360,35 +362,120 @@ void DiskAccessStorage::stopListsWritingThread()
 /// and then saves the files "users.list", "roles.list", etc. to the same directory.
 void DiskAccessStorage::reloadAllAndRebuildLists()
 {
-    std::vector<std::pair<UUID, AccessEntityPtr>> all_entities;
+    struct LoadedEntity
+    {
+        UUID id;
+        AccessEntityPtr entity;
+        std::filesystem::path path;
+        std::filesystem::file_time_type mtime;
+    };
+    std::map<std::pair<AccessEntityType, String>, LoadedEntity> loaded_entities;
+    std::vector<std::filesystem::path> files_to_remove;
 
+    /// Iterate through the access directory: load <uuid>.sql files, find stale files for removal.
     for (const auto & directory_entry : std::filesystem::directory_iterator(directory_path))
     {
         if (!directory_entry.is_regular_file())
             continue;
-        const auto & path = directory_entry.path();
-        if (path.extension() != ".sql")
-            continue;
 
+        const auto & path = directory_entry.path();
         UUID id;
         if (!tryParseUUID(path.stem(), id))
+            continue; /// Not an access-entity file (e.g. `users.list`, `need_rebuild_lists.mark`).
+
+        if (path.extension() == ".tmp")
+        {
+            /// writeEntityFile() created a tmp file but failed to rename it, so we try to remove it here.
+            files_to_remove.push_back(path);
+            continue;
+        }
+
+        if (path.extension() != ".sql")
             continue;
 
         const auto access_entity_file_path = getEntityFilePath(directory_path, id);
         auto entity = tryReadEntityFile(access_entity_file_path, getLogger());
         if (!entity)
-            continue;
+            continue; /// Unparsable file; we leave it on disk for inspection.
 
-        all_entities.emplace_back(id, entity);
+        std::error_code mtime_ec;
+        auto mtime = std::filesystem::last_write_time(path, mtime_ec);
+        if (mtime_ec)
+            LOG_WARNING(getLogger(), "Failed to stat {}: {}", path.string(), mtime_ec.message());
+
+        auto key = std::make_pair(entity->getType(), entity->getName());
+        auto it = loaded_entities.find(key);
+
+        if (it == loaded_entities.end())
+        {
+            loaded_entities.emplace(key, LoadedEntity{id, entity, path, mtime});
+        }
+        else
+        {
+            /// Two files <uuid_1>.sql and <uuid_2>.sql claim the same name and type.
+            /// Such duplicates can appear after `insertNoLock` crashes between renaming the new
+            /// `<id>.tmp` and deleting `<old_id>.sql`.
+            /// Here we keep the newer file by mtime and remove the older file.
+            if (mtime > it->second.mtime)
+            {
+                LOG_WARNING(getLogger(), "Duplicate {} {} on disk; keeping newer file {}, removing older {}",
+                    AccessEntityTypeInfo::get(entity->getType()).name, entity->getName(),
+                    path.string(), it->second.path.string());
+                files_to_remove.push_back(it->second.path);
+                it->second = LoadedEntity{id, entity, path, mtime};
+            }
+            else
+            {
+                LOG_WARNING(getLogger(), "Duplicate {} {} on disk; keeping newer file {}, removing older {}",
+                    AccessEntityTypeInfo::get(entity->getType()).name, entity->getName(),
+                    it->second.path.string(), path.string());
+                files_to_remove.push_back(path);
+            }
+        }
     }
+
+    std::vector<std::pair<UUID, AccessEntityPtr>> all_entities;
+    all_entities.reserve(loaded_entities.size());
+    for (auto & [_, loaded] : loaded_entities)
+        all_entities.emplace_back(loaded.id, loaded.entity);
 
     memory_storage.setAll(all_entities);
 
+    /// Mark every entity type as needing its `.list` file rewritten so the next `writeLists`
+    /// regenerates the full index.
     for (auto type : collections::range(AccessEntityType::MAX))
         types_of_lists_to_write.insert(type);
 
-    failed_to_write_lists = false; /// Try again writing lists.
+    /// Write the lists and keep the rebuild marker for now.
+    failed_to_write_lists = false;
+    has_stale_files_on_disk = true;
     writeLists();
+
+    /// Now that the canonical `.list` files are persisted, it's safe to delete the orphan tmp
+    /// files and older duplicate `.sql` files.
+    if (!failed_to_write_lists)
+    {
+        bool stale_files_removed = true;
+        for (const auto & p : files_to_remove)
+        {
+            std::error_code ec;
+            std::filesystem::remove(p, ec);
+            if (ec)
+            {
+                LOG_WARNING(getLogger(), "Failed to remove file {}: {}", p.string(), ec.message());
+                stale_files_removed = false;
+            }
+        }
+
+        if (stale_files_removed)
+        {
+            /// Disk is now consistent: list files are persisted, orphan tmps and older
+            /// duplicates are gone. Clear the flag and drop the marker that writeLists()
+            /// preserved while we did the cleanup.
+            (void)std::filesystem::remove(getNeedRebuildListsMarkFilePath(directory_path));
+            has_stale_files_on_disk = false;
+        }
+    }
 }
 
 
@@ -470,30 +557,82 @@ bool DiskAccessStorage::insertImpl(const UUID & id, const AccessEntityPtr & new_
 
 bool DiskAccessStorage::insertNoLock(const UUID & id, const AccessEntityPtr & new_entity, bool replace_if_exists, bool throw_if_exists, UUID * conflicting_id, bool write_on_disk)
 {
-    /// Check that we can insert.
-    if (readonly)
-        throwReadonlyCannotInsert(new_entity->getType(), new_entity->getName());
+    const AccessEntityType type = new_entity->getType();
+    const String & name = new_entity->getName();
 
-    /// In case of name collision old file should be removed.
-    if (replace_if_exists && write_on_disk)
+    if (readonly)
+        throwReadonlyCannotInsert(type, name);
+
+    /// Step 1: Validate against memory_storage without mutating it.
+    auto id_by_name = memory_storage.find(type, name);
+    bool name_collision = id_by_name.has_value();
+    if (name_collision && !replace_if_exists)
     {
-        std::optional<UUID> collision_id = memory_storage.find(new_entity->getType(), new_entity->getName());
-        if (collision_id.has_value())
+        if (throw_if_exists)
+            throwNameCollisionCannotInsert(type, name, getStorageName());
+        if (conflicting_id)
+            *conflicting_id = *id_by_name;
+        return false;
+    }
+
+    bool id_collision = memory_storage.exists(id);
+    if (id_collision && !replace_if_exists)
+    {
+        if (throw_if_exists)
         {
-            scheduleWriteLists(new_entity->getType());
-            deleteAccessEntityOnDisk(collision_id.value());
+            auto existing = memory_storage.read(id, /* throw_if_not_exists= */ true);
+            throwIDCollisionCannotInsert(id, type, name,
+                existing->getType(), existing->getName(), getStorageName());
+        }
+        if (conflicting_id)
+            *conflicting_id = id;
+        return false;
+    }
+
+    std::optional<UUID> old_id_to_delete;
+    if (name_collision && (id_by_name != id))
+        old_id_to_delete = *id_by_name;
+
+    /// Step 2: Modify files first.
+    if (write_on_disk)
+    {
+        scheduleWriteLists(type);
+
+        /// Write <id>.tmp and atomically rename it to <id>.sql
+        writeAccessEntityToDisk(id, *new_entity);
+
+        if (old_id_to_delete.has_value())
+        {
+            /// Remove conflicting entity <old_id>.sql (same name and type, different id).
+            try
+            {
+                deleteAccessEntityOnDisk(*old_id_to_delete);
+            }
+            catch (...)
+            {
+                /// Failed to remove <old_id>.sql.
+                /// However new entity <id>.sql has been already written on disk,
+                /// so the operation can only be considered successful at this point.
+                /// We can't atomically rename <id>.tmp to <id>.sql and delete <old_id>.sql at the same time,
+                /// so best effort is to keep both <id>.sql and <old_id>.sql for now,
+                /// and let reloadAllAndRebuildLists() resolve the conflict based on mtime on the next start.
+                tryLogCurrentException(getLogger(),
+                    "Failed to remove stale entity file for " + toString(*old_id_to_delete)
+                    + " after replacing with " + toString(id));
+                /// Keep `need_rebuild_lists.mark` so the next startup rebuilds and dedups by mtime.
+                has_stale_files_on_disk = true;
+            }
         }
     }
 
-    /// Do insertion.
-    if (!memory_storage.insert(id, new_entity, replace_if_exists, throw_if_exists, conflicting_id))
-        return false;
-
-    /// Also rewrites existing file in case of id collision.
-    if (write_on_disk)
+    /// Step 3: We modify memory_storage only if disk operation succeeded.
+    if (!memory_storage.insert(id, new_entity, replace_if_exists,
+                               /* throw_if_exists= */ false, conflicting_id))
     {
-        scheduleWriteLists(new_entity->getType());
-        writeAccessEntityToDisk(id, *new_entity);
+        /// We have already validated the operation against memory_storage at step 1,
+        /// so this call of memory_storage.insert() must be successful.
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+            "Failed to insert entity {} into memory_storage after committing disk write", toString(id));
     }
 
     return true;
@@ -509,28 +648,34 @@ bool DiskAccessStorage::removeImpl(const UUID & id, bool throw_if_not_exists)
 
 bool DiskAccessStorage::removeNoLock(const UUID & id, bool throw_if_not_exists, bool write_on_disk)
 {
-    AccessEntityPtr entity = memory_storage.read(id, throw_if_not_exists);
+    /// Step 1: Validate against memory_storage without mutating it.
+    AccessEntityPtr entity = memory_storage.read(id, /* throw_if_not_exists= */ false);
     if (!entity)
     {
         if (throw_if_not_exists)
             throwNotFound(id, getStorageName());
-        else
-            return false;
+        return false;
     }
     AccessEntityType type = entity->getType();
 
     if (readonly)
         throwReadonlyCannotRemove(type, entity->getName());
 
-    /// Do removing.
-    memory_storage.remove(id, /* throw_if_not_exists= */ false);
-
+    /// Step 2: Modify files first.
     if (write_on_disk)
     {
         scheduleWriteLists(type);
         deleteAccessEntityOnDisk(id);
     }
 
+    /// Step 3: We modify memory_storage only if disk operation succeeded.
+    if (!memory_storage.remove(id, /* throw_if_not_exists= */ false))
+    {
+        /// We have already validated the operation against memory_storage at step 1,
+        /// so this call of memory_storage.remove() must be successful.
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+            "Entity {} disappeared from memory_storage during remove", toString(id));
+    }
 
     return true;
 }
@@ -545,33 +690,59 @@ bool DiskAccessStorage::updateImpl(const UUID & id, const UpdateFunc & update_fu
 
 bool DiskAccessStorage::updateNoLock(const UUID & id, const UpdateFunc & update_func, bool throw_if_not_exists, bool write_on_disk)
 {
-    AccessEntityPtr old_entity = memory_storage.read(id, throw_if_not_exists);
+    /// Step 1: Validate against memory_storage without mutating it.
+    AccessEntityPtr old_entity = memory_storage.read(id, /* throw_if_not_exists= */ false);
     if (!old_entity)
     {
         if (throw_if_not_exists)
             throwNotFound(id, getStorageName());
-        else
-            return false;
+        return false;
     }
 
     if (readonly)
         throwReadonlyCannotUpdate(old_entity->getType(), old_entity->getName());
 
+    /// Materialize the placeholder before invoking update_func.
     if (isNotLoadedFromDisk(old_entity))
     {
         old_entity = readAccessEntityFromDisk(id);
         memory_storage.insert(id, old_entity, /* replace_if_exists= */ true, /* throw_if_exists= */ false, /* conflicting_id= */ nullptr);
     }
 
-    if (!memory_storage.update(id, update_func, throw_if_not_exists))
-        return false;
+    AccessEntityPtr new_entity = update_func(old_entity, id);
 
-    AccessEntityPtr new_entity = memory_storage.read(id, throw_if_not_exists);
+    if (!new_entity->isTypeOf(old_entity->getType()))
+        throwBadCast(id, new_entity->getType(), new_entity->getName(), old_entity->getType());
+
+    if (*new_entity == *old_entity)
+        return true;   /// no-op; do not touch disk
+
+    const bool name_changed = (new_entity->getName() != old_entity->getName());
+    if (name_changed)
+    {
+        auto collision = memory_storage.find(new_entity->getType(), new_entity->getName());
+        if (collision.has_value() && *collision != id)
+            throwNameCollisionCannotRename(old_entity->getType(),
+                old_entity->getName(), new_entity->getName(), getStorageName());
+    }
+
+    /// Step 2: Modify files first.
     if (write_on_disk)
     {
-        if (old_entity->getName() != new_entity->getName())
+        if (name_changed)
             scheduleWriteLists(new_entity->getType());
-         writeAccessEntityToDisk(id, *new_entity);
+        writeAccessEntityToDisk(id, *new_entity);   /// tmp + atomic rename overwrites <id>.sql
+    }
+
+    /// Step 3: We modify memory_storage only if disk operation succeeded.
+    if (!memory_storage.update(id,
+            [&](const AccessEntityPtr &, const UUID &) { return new_entity; },
+            /* throw_if_not_exists= */ false))
+    {
+        /// We have already validated the operation against memory_storage at step 1,
+        /// so this call of memory_storage.update() must be successful.
+        throw Exception(ErrorCodes::LOGICAL_ERROR,
+            "Entity {} disappeared from memory_storage during update", toString(id));
     }
 
     return true;

--- a/src/Access/DiskAccessStorage.h
+++ b/src/Access/DiskAccessStorage.h
@@ -86,6 +86,11 @@ private:
     /// Whether writing of the list files has been failed since the recent restart of the server.
     bool failed_to_write_lists TSA_GUARDED_BY(mutex) = false;
 
+    /// Whether there are stale `<old_id>.sql` files on disk which we couldn't remove.
+    /// If this is true, writeLists() keeps the `need_rebuild_lists.mark` file until
+    /// SYSTEM RELOAD USERS or next startup runs reloadAllAndRebuildLists() and resolves the issues.
+    bool has_stale_files_on_disk TSA_GUARDED_BY(mutex) = false;
+
     /// List files are written in a separate thread.
     std::unique_ptr<ThreadFromGlobalPool> lists_writing_thread;
 

--- a/src/Access/tests/gtest_disk_access_storage.cpp
+++ b/src/Access/tests/gtest_disk_access_storage.cpp
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+
+#include <Access/AccessChangesNotifier.h>
+#include <Access/AccessEntityIO.h>
+#include <Access/DiskAccessStorage.h>
+#include <Access/User.h>
+#include <Core/UUID.h>
+#include <IO/WriteHelpers.h>
+
+#include <Poco/TemporaryFile.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+
+
+using namespace DB;
+
+namespace
+{
+
+void writeEntityToFile(const std::filesystem::path & file_path, const IAccessEntity & entity)
+{
+    std::ofstream out(file_path);
+    out << serializeAccessEntity(entity);
+}
+
+void writeNeedRebuildMarker(const String & directory)
+{
+    std::ofstream{directory + "need_rebuild_lists.mark"};
+}
+
+}
+
+TEST(DiskAccessStorageRecovery, RebuildRemovesTempFiles)
+{
+    Poco::TemporaryFile temp_dir;
+    temp_dir.createDirectories();
+    String dir = temp_dir.path() + "/";
+
+    auto stranded_tmp = std::filesystem::path(dir) / (toString(UUIDHelpers::generateV4()) + ".tmp");
+    std::ofstream{stranded_tmp} << "text";
+
+    writeNeedRebuildMarker(dir);
+
+    AccessChangesNotifier notifier;
+    DiskAccessStorage storage("test_disk", dir, notifier, /*readonly_=*/false, /*allow_backup_=*/false);
+
+    EXPECT_FALSE(std::filesystem::exists(stranded_tmp));
+}
+
+TEST(DiskAccessStorageRecovery, RebuildRemovesOlderDuplicates)
+{
+    Poco::TemporaryFile temp_dir;
+    temp_dir.createDirectories();
+    String dir = temp_dir.path() + "/";
+
+    auto user_a = std::make_shared<User>();
+    user_a->setName("alice");
+    UUID id_a = UUIDHelpers::generateV4();
+    auto path_a = std::filesystem::path(dir) / (toString(id_a) + ".sql");
+    writeEntityToFile(path_a, *user_a);
+
+    auto user_b = std::make_shared<User>();
+    user_b->setName("alice");
+    UUID id_b = UUIDHelpers::generateV4();
+    auto path_b = std::filesystem::path(dir) / (toString(id_b) + ".sql");
+    writeEntityToFile(path_b, *user_b);
+
+    /// Make `path_a` older than `path_b` so the deduplication logic keeps `id_b` and remove `id_a`.
+    auto now = std::filesystem::file_time_type::clock::now();
+    std::filesystem::last_write_time(path_a, now - std::chrono::seconds(10));
+    std::filesystem::last_write_time(path_b, now);
+
+    writeNeedRebuildMarker(dir);
+
+    AccessChangesNotifier notifier;
+    DiskAccessStorage storage("test_disk", dir, notifier, /*readonly_=*/false, /*allow_backup_=*/false);
+
+    EXPECT_FALSE(std::filesystem::exists(path_a));
+    EXPECT_TRUE(std::filesystem::exists(path_b));
+
+    auto resolved = storage.find<User>("alice");
+    ASSERT_TRUE(resolved.has_value());
+    EXPECT_EQ(*resolved, id_b);
+}


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Reorder operations in `DiskAccessStorage` for consistency: always modify files first

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.621`
<!-- ch-version-info:end -->