### PR TITLE
PromQL: Fix aggregation operator for empty vector

### DIFF
--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorQuantile.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyAggregationOperatorQuantile.cpp
@@ -130,6 +130,12 @@ SQLQueryPiece applyAggregationOperatorQuantile(
         if (operator_node->by || operator_node->without)
             builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
 
+        /// Drop empty-values rows.
+        /// If the input has no rows then quantileExactInclusiveForEach(...)([]) returns [], but the number of values
+        /// in array must always match the number of steps in SQLQueryPiece (see StoreMethod::VECTOR_GRID),
+        /// so we just drop such rows.
+        builder.having = makeASTFunction("notEmpty", make_intrusive<ASTIdentifier>(ColumnNames::Values));
+
         aggregation_query = builder.getSelectQuery();
     }
 

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyOneArgumentAggregationOperator.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyOneArgumentAggregationOperator.cpp
@@ -183,6 +183,12 @@ SQLQueryPiece applyOneArgumentAggregationOperator(
         if (operator_node->by || operator_node->without)
             builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::NewGroup));
 
+        /// Drop empty-values rows.
+        /// If the input has no rows then countForEach([]) returns [], but the number of values
+        /// in array must always match the number of steps in SQLQueryPiece (see StoreMethod::VECTOR_GRID),
+        /// so we just drop such rows.
+        builder.having = makeASTFunction("notEmpty", make_intrusive<ASTIdentifier>(ColumnNames::Values));
+
         aggregation_query = builder.getSelectQuery();
     }
 

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -2396,6 +2396,13 @@ def test_aggregation_operators():
         [["[]", "[('1970-01-01 00:01:50.000',30),('1970-01-01 00:02:00.000',56),('1970-01-01 00:02:10.000',140),('1970-01-01 00:02:20.000',700),('1970-01-01 00:02:30.000',1030)]"]],
     )
 
+    do_query_test(
+        "sum(nonexistent_metric_name)[50:10]",
+        150,
+        '{"resultType": "matrix", "result": []}',
+        [],
+    )
+
     # FIXME: Not deterministic without sort_by_label(), and function sort_by_label() is not implemented yet.
     # do_query_test(
     #     "sum(bar) without (shape)",
@@ -2428,6 +2435,13 @@ def test_aggregation_operators():
             ["[('size','s')]", "[('1970-01-01 00:01:50.000',1),('1970-01-01 00:02:00.000',1),('1970-01-01 00:02:20.000',1)]"],
             ["[('size','xl')]", "[('1970-01-01 00:01:50.000',1),('1970-01-01 00:02:30.000',1)]"],
         ],
+    )
+
+    do_query_test(
+        "count(nonexistent_metric_name)[50:10]",
+        150,
+        '{"resultType": "matrix", "result": []}',
+        [],
     )
 
     do_query_test(
@@ -2501,6 +2515,13 @@ def test_aggregation_operators():
         150,
         '{"resultType": "matrix", "result": [{"metric": {}, "values": [[110, "8.5"], [120, "28"], [130, "70"], [140, "700"], [150, "515"]]}]}',
         [["[]", "[('1970-01-01 00:01:50.000',8.5),('1970-01-01 00:02:00.000',28),('1970-01-01 00:02:10.000',70),('1970-01-01 00:02:20.000',700),('1970-01-01 00:02:30.000',515)]"]],
+    )
+
+    do_query_test(
+        "quantile(0.5, nonexistent_metric_name)[50:10]",
+        150,
+        '{"resultType": "matrix", "result": []}',
+        [],
     )
 
     # FIXME: quantile with phi depending on timestamp is not implemented yet.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
PromQL: Fix aggregation operator for empty vector

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.471`
<!-- ch-version-info:end -->