### PR TITLE
Cascade access entity removal to dependents on disk

### DIFF
--- a/src/Access/IAccessStorage.cpp
+++ b/src/Access/IAccessStorage.cpp
@@ -11,6 +11,7 @@
 #include <Common/Exception.h>
 #include <Common/quoteString.h>
 #include <Common/callOnce.h>
+#include <base/scope_guard.h>
 #include <IO/WriteHelpers.h>
 #include <Interpreters/Context.h>
 #include <Parsers/parseIdentifierOrStringLiteral.h>
@@ -47,6 +48,14 @@ namespace
     {
         return "ID(" + toString(id) + ")";
     }
+
+    /// Tracks how deep we are inside `IAccessStorage::remove`. Concrete storages (e.g.
+    /// `DiskAccessStorage`) call `remove` on their internal in-memory cache, and
+    /// `MultipleAccessStorage::removeImpl` delegates to a sub-storage's `remove`. We
+    /// only want to cascade dependency cleanup once — at the outermost user-facing call —
+    /// otherwise an inner cascade can update the in-memory state without writing it to
+    /// disk, and the outer cascade then sees no work to do.
+    thread_local size_t remove_depth = 0;
 }
 
 
@@ -315,7 +324,12 @@ bool IAccessStorage::insertImpl(const UUID &, const AccessEntityPtr & entity, bo
 
 bool IAccessStorage::remove(const UUID & id, bool throw_if_not_exists)
 {
-    return removeImpl(id, throw_if_not_exists);
+    ++remove_depth;
+    SCOPE_EXIT(--remove_depth);
+    bool removed = removeImpl(id, throw_if_not_exists);
+    if (removed && remove_depth == 1)
+        removeReferencesToRemovedIDs({id});
+    return removed;
 }
 
 
@@ -326,13 +340,18 @@ std::vector<UUID> IAccessStorage::remove(const std::vector<UUID> & ids, bool thr
     if (ids.size() == 1)
         return remove(ids[0], throw_if_not_exists) ? ids : std::vector<UUID>{};
 
+    ++remove_depth;
+    SCOPE_EXIT(--remove_depth);
+
     Strings removed_names;
+    std::vector<UUID> removed_ids;
     try
     {
-        std::vector<UUID> removed_ids;
         std::vector<UUID> readonly_ids;
 
-        /// First we call remove() for non-readonly entities.
+        /// First we call removeImpl() for non-readonly entities. We bypass remove() here
+        /// to defer the dependency cleanup until after every entity has been removed —
+        /// otherwise we'd run the cascade once per id and waste work.
         for (const auto & id : ids)
         {
             if (isReadOnly(id))
@@ -340,7 +359,7 @@ std::vector<UUID> IAccessStorage::remove(const std::vector<UUID> & ids, bool thr
             else
             {
                 auto name = tryReadName(id);
-                if (remove(id, throw_if_not_exists))
+                if (removeImpl(id, throw_if_not_exists))
                 {
                     removed_ids.push_back(id);
                     if (name)
@@ -349,24 +368,30 @@ std::vector<UUID> IAccessStorage::remove(const std::vector<UUID> & ids, bool thr
             }
         }
 
-        /// For readonly entities we're still going to call remove() because
+        /// For readonly entities we're still going to call removeImpl() because
         /// isReadOnly(id) could change and even if it's not then a storage-specific
         /// implementation of removeImpl() will probably generate a better error message.
         for (const auto & id : readonly_ids)
         {
             auto name = tryReadName(id);
-            if (remove(id, throw_if_not_exists))
+            if (removeImpl(id, throw_if_not_exists))
             {
                 removed_ids.push_back(id);
                 if (name)
                     removed_names.push_back(std::move(name).value());
             }
         }
-
-        return removed_ids;
     }
     catch (Exception & e)
     {
+        /// Even on failure, clean up references for the entities we did remove so the
+        /// access state on disk does not retain dangling UUIDs.
+        if (!removed_ids.empty() && remove_depth == 1)
+        {
+            std::unordered_set<UUID> removed_set(removed_ids.begin(), removed_ids.end());
+            removeReferencesToRemovedIDs(removed_set);
+        }
+
         /// Try to add more information to the error message.
         if (!removed_names.empty())
         {
@@ -380,6 +405,82 @@ std::vector<UUID> IAccessStorage::remove(const std::vector<UUID> & ids, bool thr
             e.addMessage("After successfully removing {}/{}: {}", removed_names.size(), ids.size(), removed_names_str);
         }
         throw;
+    }
+
+    if (!removed_ids.empty() && remove_depth == 1)
+    {
+        std::unordered_set<UUID> removed_set(removed_ids.begin(), removed_ids.end());
+        removeReferencesToRemovedIDs(removed_set);
+    }
+    return removed_ids;
+}
+
+
+void IAccessStorage::removeReferencesToRemovedIDs(const std::unordered_set<UUID> & removed_ids)
+{
+    if (removed_ids.empty())
+        return;
+
+    auto update_func = [&removed_ids](const AccessEntityPtr & old, const UUID &) -> AccessEntityPtr
+    {
+        auto new_entity = old->clone();
+        new_entity->removeDependencies(removed_ids);
+        return new_entity;
+    };
+
+    /// Any access entity type can reference any other (e.g. a user references roles, a
+    /// settings profile references roles/users, a row policy references roles/users, etc.),
+    /// so we walk every type. Iteration is O(N) where N is the total number of access
+    /// entities — typically small.
+    for (auto type : collections::range(AccessEntityType::MAX))
+    {
+        std::vector<UUID> dependent_ids;
+        try
+        {
+            dependent_ids = findAllImpl(type);
+        }
+        catch (...)
+        {
+            tryLogCurrentException(getLogger(), "while listing access entities for dependency cleanup");
+            continue;
+        }
+
+        for (const auto & dependent_id : dependent_ids)
+        {
+            /// An entity can never depend on itself in the relevant sense, and we just
+            /// removed entities in `removed_ids` — there is nothing to update for them.
+            if (removed_ids.contains(dependent_id))
+                continue;
+
+            try
+            {
+                auto entity = readImpl(dependent_id, /* throw_if_not_exists= */ false);
+                if (!entity)
+                    continue;
+                if (!entity->hasDependencies(removed_ids))
+                    continue;
+
+                /// `update()` will dispatch to the same storage that owns the entity,
+                /// so for `MultipleAccessStorage` this naturally crosses sub-storages.
+                /// `throw_if_not_exists=false` covers concurrent removals.
+                update(dependent_id, update_func, /* throw_if_not_exists= */ false);
+            }
+            catch (Exception & e)
+            {
+                /// A read-only sub-storage (e.g. `users.xml`) cannot be updated. That is
+                /// expected — its content is reloaded from the config so any references
+                /// will be reconciled on the next reload. Don't fail the whole cascade.
+                if (e.code() == ErrorCodes::ACCESS_STORAGE_READONLY)
+                    continue;
+                tryLogCurrentException(getLogger(),
+                    "while removing references to dropped access entities from " + outputID(dependent_id));
+            }
+            catch (...)
+            {
+                tryLogCurrentException(getLogger(),
+                    "while removing references to dropped access entities from " + outputID(dependent_id));
+            }
+        }
     }
 }
 

--- a/src/Access/IAccessStorage.h
+++ b/src/Access/IAccessStorage.h
@@ -9,6 +9,7 @@
 
 #include <functional>
 #include <optional>
+#include <unordered_set>
 #include <vector>
 
 #include <boost/noncopyable.hpp>
@@ -179,6 +180,10 @@ public:
     std::vector<UUID> insertOrReplace(const std::vector<AccessEntityPtr> & multiple_entities);
 
     /// Removes an entity from the storage. Throws an exception if couldn't remove.
+    /// After a successful removal, references to the removed entity are stripped from
+    /// any other access entities that referenced it (e.g. a user's `DEFAULT ROLE` list,
+    /// a settings profile's `TO` list, a row policy's grantees, etc.). Affected entities
+    /// are re-serialized so the cleanup is persisted on disk.
     bool remove(const UUID & id, bool throw_if_not_exists = true);
     std::vector<UUID> remove(const std::vector<UUID> & ids, bool throw_if_not_exists = true);
 
@@ -255,6 +260,11 @@ protected:
     virtual bool isAddressAllowed(const User & user, const Poco::Net::IPAddress & address) const;
     static UUID generateRandomID();
     LoggerPtr getLogger() const;
+    /// Iterates over all access entities in this storage and strips any reference to
+    /// the given (already removed) IDs. Failures for individual entities are logged
+    /// and swallowed so a single broken or read-only entity cannot block the cascade.
+    /// Called automatically after a successful `remove`.
+    void removeReferencesToRemovedIDs(const std::unordered_set<UUID> & removed_ids);
     static String formatEntityTypeWithName(AccessEntityType type, const String & name) { return AccessEntityTypeInfo::get(type).formatEntityNameWithType(name); }
     static void clearConflictsInEntitiesList(std::vector<std::pair<UUID, AccessEntityPtr>> & entities, LoggerPtr log_);
     virtual bool acquireReplicatedRestore(RestorerFromBackup &) const { return false; }

--- a/tests/integration/test_disk_access_storage/test.py
+++ b/tests/integration/test_disk_access_storage/test.py
@@ -170,3 +170,108 @@ def test_drop():
     check()
     instance.restart_clickhouse()  # Check persistency
     check()
+
+
+def test_drop_role_cascades_to_disk():
+    """
+    Regression test for https://github.com/ClickHouse/ClickHouse/issues/104298.
+
+    Before the fix, DROP ROLE only removed the role from the in-memory entity map. Other
+    entities that referenced the dropped role (e.g. a user's DEFAULT ROLE list, a settings
+    profile's TO list) still kept the dropped UUID in their on-disk *.sql files. The
+    SHOW CREATE output looked clean only because the rendering layer filters unknown UUIDs,
+    but on the next server restart those references were loaded back into memory and
+    surfaced as `ACCESS_ENTITY_NOT_FOUND` errors during distributed/Remote query execution.
+
+    This test creates a role, references it from several other entities, drops the role,
+    and asserts that the dropped UUID is no longer present in any *.sql file under the
+    access directory — and that after a restart no entity refers back to it.
+    """
+    instance.query(
+        """
+        DROP USER     IF EXISTS u_104298;
+        DROP ROLE     IF EXISTS r_keep_104298, r_drop_104298, r_parent_104298;
+        DROP SETTINGS PROFILE IF EXISTS sp_104298;
+        DROP ROW POLICY IF EXISTS rp_104298 ON mydb.mytable;
+        DROP QUOTA    IF EXISTS q_104298;
+        """
+    )
+
+    instance.query("CREATE ROLE r_keep_104298")
+    instance.query("CREATE ROLE r_drop_104298")
+    instance.query("CREATE ROLE r_parent_104298")
+    instance.query(
+        "CREATE USER u_104298 DEFAULT ROLE r_keep_104298, r_drop_104298"
+    )
+    instance.query("GRANT r_keep_104298, r_drop_104298 TO u_104298")
+    instance.query("GRANT r_drop_104298 TO r_parent_104298")
+    instance.query(
+        "CREATE SETTINGS PROFILE sp_104298 SETTINGS max_memory_usage = 1000000 TO r_drop_104298"
+    )
+    instance.query(
+        "CREATE ROW POLICY rp_104298 ON mydb.mytable FOR SELECT USING 1 TO r_drop_104298"
+    )
+    instance.query(
+        "CREATE QUOTA q_104298 FOR INTERVAL 1 HOUR MAX QUERIES 100 TO r_drop_104298"
+    )
+
+    drop_uuid = instance.query(
+        "SELECT id FROM system.roles WHERE name = 'r_drop_104298'"
+    ).strip()
+    assert drop_uuid
+
+    instance.query("DROP ROLE r_drop_104298")
+
+    def grep_dropped_uuid():
+        # Returns the names of any *.sql file under the access dir that still
+        # references the dropped role's UUID.
+        return instance.exec_in_container(
+            [
+                "bash",
+                "-c",
+                f"grep -l '{drop_uuid}' /var/lib/clickhouse/access/*.sql || true",
+            ]
+        ).strip()
+
+    # The fix must propagate the cleanup to disk synchronously.
+    assert grep_dropped_uuid() == "", (
+        f"Dropped role UUID {drop_uuid} still found in access dir on disk"
+    )
+
+    # And after a restart the in-memory state must still be clean: nobody references
+    # the dropped role any more.
+    instance.restart_clickhouse()
+
+    assert grep_dropped_uuid() == ""
+
+    assert (
+        instance.query("SHOW CREATE USER u_104298")
+        == "CREATE USER u_104298 IDENTIFIED WITH no_password DEFAULT ROLE r_keep_104298\n"
+    )
+    assert (
+        instance.query("SHOW GRANTS FOR u_104298") == "GRANT r_keep_104298 TO u_104298\n"
+    )
+    assert instance.query("SHOW GRANTS FOR r_parent_104298") == ""
+    assert (
+        instance.query("SHOW CREATE SETTINGS PROFILE sp_104298")
+        == "CREATE SETTINGS PROFILE `sp_104298` SETTINGS max_memory_usage = 1000000\n"
+    )
+    assert (
+        instance.query("SHOW CREATE ROW POLICY rp_104298 ON mydb.mytable")
+        == "CREATE ROW POLICY rp_104298 ON mydb.mytable FOR SELECT USING 1\n"
+    )
+    assert (
+        instance.query("SHOW CREATE QUOTA q_104298")
+        == "CREATE QUOTA q_104298 FOR INTERVAL 1 hour MAX queries = 100\n"
+    )
+
+    # Cleanup so we don't leak state into other tests.
+    instance.query(
+        """
+        DROP USER     IF EXISTS u_104298;
+        DROP ROLE     IF EXISTS r_keep_104298, r_parent_104298;
+        DROP SETTINGS PROFILE IF EXISTS sp_104298;
+        DROP ROW POLICY IF EXISTS rp_104298 ON mydb.mytable;
+        DROP QUOTA    IF EXISTS q_104298;
+        """
+    )


### PR DESCRIPTION
Fixes #104298.

`DROP ROLE` (and similarly `DROP USER`, `DROP SETTINGS PROFILE`, `DROP ROW POLICY`, `DROP QUOTA`, `DROP MASKING POLICY`) deleted the entity's own `.sql` file but did not strip the dropped UUID from any other entity that referenced it. A user's `DEFAULT ROLE` and `GRANT` lists, a settings profile's `TO` list, a row policy's grantees, a quota's grantees and a parent role's grants all kept dangling `ID('<dropped-uuid>')` entries on disk. `SHOW CREATE` and the `system.*` tables masked the bug — they all call `tryReadName` and silently drop unknown UUIDs at render time — but on the next server restart those references were loaded back into memory and surfaced as `ACCESS_ENTITY_NOT_FOUND` errors during distributed query execution and other operations.

The `removeDependencies` infrastructure already exists on every access entity type but was only invoked from `RestorerFromBackup`. This PR hooks it into the public `IAccessStorage::remove(...)`: after a successful remove the storage walks every entity type and strips references to the just-removed IDs. Updates go through the polymorphic public `update(...)`, which for `MultipleAccessStorage` naturally crosses sub-storages and for `DiskAccessStorage` re-serializes the affected entity to disk.

A thread-local depth guard ensures the cascade fires only at the outermost user-facing call. Concrete storages call `remove` on an internal in-memory cache (`DiskAccessStorage::removeNoLock` -> `memory_storage.remove`) and `MultipleAccessStorage::removeImpl` delegates to a sub-storage's `remove`. Without the guard the inner cache cascade would update state in memory before the outer disk-writing cascade could see it, leaving the disk file stale.

Read-only sub-storages (e.g. `users.xml`) are skipped gracefully — their content is reloaded from the config so references are reconciled on the next reload.

A new integration test in `tests/integration/test_disk_access_storage` verifies the cascade end-to-end: it creates a role, references it from a user (`DEFAULT ROLE` and `GRANT`), a parent role, a settings profile, a row policy and a quota; drops the role; asserts the dropped UUID disappears from every `*.sql` file under the access dir; then restarts the server and confirms the in-memory state is still clean.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix `DROP ROLE`, `DROP USER`, `DROP SETTINGS PROFILE`, `DROP ROW POLICY`, `DROP QUOTA` and `DROP MASKING POLICY` to remove references to the dropped entity from any other access entity that referenced it (e.g. a user's `DEFAULT ROLE` list, a settings profile's `TO` list, a row policy's grantees) and persist the cleanup to disk. Previously the in-memory state appeared correct because `SHOW CREATE` filters unknown UUIDs, but the on-disk `.sql` files retained dangling `ID('<dropped-uuid>')` entries and the references were resurrected on the next server restart, surfacing as `ACCESS_ENTITY_NOT_FOUND` errors during distributed query execution.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)