### PR TITLE
Do not require CREATE TEMPORARY TABLE grant for input table function

### DIFF
--- a/src/TableFunctions/TableFunctionInput.cpp
+++ b/src/TableFunctions/TableFunctionInput.cpp
@@ -97,7 +97,10 @@ StoragePtr TableFunctionInput::executeImpl(const ASTPtr & /*ast_function*/, Cont
 
 void registerTableFunctionInput(TableFunctionFactory & factory)
 {
-    factory.registerFunction<TableFunctionInput>({});
+    /// `input` only reads the data stream that the client is sending alongside the INSERT query;
+    /// it does not access arbitrary hosts or storages, so it does not need the `CREATE TEMPORARY TABLE` grant
+    /// and is allowed in readonly mode.
+    factory.registerFunction<TableFunctionInput>({}, {.allow_readonly = true});
 }
 
 }

--- a/tests/queries/0_stateless/04212_input_no_create_temp_grant.reference
+++ b/tests/queries/0_stateless/04212_input_no_create_temp_grant.reference
@@ -1,0 +1,3 @@
+0	val
+1	val
+2	val

--- a/tests/queries/0_stateless/04212_input_no_create_temp_grant.sh
+++ b/tests/queries/0_stateless/04212_input_no_create_temp_grant.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+set -e
+
+user="user_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+table="t_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+
+${CLICKHOUSE_CLIENT} --query "DROP USER IF EXISTS ${user}"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${table}"
+
+${CLICKHOUSE_CLIENT} --query "CREATE USER ${user} IDENTIFIED WITH PLAINTEXT_PASSWORD BY 'hello'"
+${CLICKHOUSE_CLIENT} --query "CREATE TABLE ${table} (a UInt32, b String) ENGINE = Memory"
+${CLICKHOUSE_CLIENT} --query "GRANT INSERT, SELECT ON ${CLICKHOUSE_DATABASE}.${table} TO ${user}"
+
+# `input` must work without the `CREATE TEMPORARY TABLE` grant: it does not create a temporary table,
+# it only reads the data stream attached to the INSERT query.
+${CLICKHOUSE_CLIENT} --query "SELECT number::UInt32 AS a, 'val' AS b FROM numbers(3) FORMAT Native" | \
+    ${CLICKHOUSE_CURL} -sS \
+        "${CLICKHOUSE_URL}&user=${user}&password=hello&query=INSERT+INTO+${CLICKHOUSE_DATABASE}.${table}+SELECT+*+FROM+input(%27a+UInt32%2C+b+String%27)+FORMAT+Native" \
+        --data-binary @-
+
+${CLICKHOUSE_CLIENT} --user "${user}" --password hello --query "SELECT * FROM ${CLICKHOUSE_DATABASE}.${table} ORDER BY a"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE ${table}"
+${CLICKHOUSE_CLIENT} --query "DROP USER ${user}"


### PR DESCRIPTION
The `input` table function does not actually create a temporary table — it just consumes the data stream attached to an INSERT request. Demanding the `CREATE TEMPORARY TABLE` grant for `INSERT INTO ... SELECT FROM input(...)` made it impractical to grant only the minimal privileges needed to load data into a single table.

`input` is registered with `allow_readonly = true` so the implicit `CREATE TEMPORARY TABLE` access check in `ITableFunction::execute` is skipped. The flag is also semantically correct: `input` does not access arbitrary hosts or storages, so it is safe in readonly mode.

Closes #104468.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

`INSERT INTO ... SELECT FROM input(...)` no longer requires the `CREATE TEMPORARY TABLE` grant.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.480`
<!-- ch-version-info:end -->