### PR TITLE
Add test: `fieldToNumber<bool>` out-of-range Float64 branch in `SettingsFields.cpp` untested

### DIFF
--- a/tests/queries/0_stateless/04212_settings_bool_out_of_range_float.reference
+++ b/tests/queries/0_stateless/04212_settings_bool_out_of_range_float.reference
@@ -1,0 +1,4 @@
+true
+false
+true
+true

--- a/tests/queries/0_stateless/04212_settings_bool_out_of_range_float.sql
+++ b/tests/queries/0_stateless/04212_settings_bool_out_of_range_float.sql
@@ -1,0 +1,26 @@
+-- Test: exercises `fieldToNumber<bool>` with out-of-range Float64 values
+-- Covers: src/Core/SettingsFields.cpp:129-130 — bool special case for out-of-range float
+-- The bool special case uses naive comparison (not `accurate::lessOp`) because
+-- `make_unsigned_t<bool>` is ill-formed. This test verifies the check works correctly.
+
+-- Out-of-range positive float should throw
+SET enable_analyzer = 1.5; -- { serverError CANNOT_CONVERT_TYPE }
+SET enable_analyzer = 2.0; -- { serverError CANNOT_CONVERT_TYPE }
+
+-- Out-of-range negative float should throw
+SET enable_analyzer = -0.5; -- { serverError CANNOT_CONVERT_TYPE }
+SET enable_analyzer = -1.0; -- { serverError CANNOT_CONVERT_TYPE }
+
+-- In-range floats should work (truncate to bool: 0->false, non-zero->true)
+SET enable_analyzer = 1.0;
+SELECT getSetting('enable_analyzer') AS v1 FORMAT TabSeparated;
+
+SET enable_analyzer = 0.0;
+SELECT getSetting('enable_analyzer') AS v2 FORMAT TabSeparated;
+
+-- Edge case: values between 0 and 1 should work (truncate to true since non-zero)
+SET enable_analyzer = 0.5;
+SELECT getSetting('enable_analyzer') AS v3 FORMAT TabSeparated;
+
+SET enable_analyzer = 0.999;
+SELECT getSetting('enable_analyzer') AS v4 FORMAT TabSeparated;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #104154](https://github.com/ClickHouse/ClickHouse/pull/104154).
 That PR This PR fixes undefined behavior in `FieldVisitorConvertToNumber<T>::operator()(Float64)` and `fieldToNumber<T>` for wide integer types (UInt64, Int64, Int128, etc.) when the input Float64 is at the 2^64 boundary. The old code used `x > Float64(numeric_limits<T>::max())` which failed for wide intege

**1. `fieldToNumber<bool>` out-of-range Float64 branch in `SettingsFields.cpp` untested**
  `src/Core/SettingsFields.cpp:129`
  **Risk:** `fieldToNumber<bool>` at SettingsFields.cpp:127-130 branches on `std::is_same_v<T, bool>` to use naive comparison instead of `accurate::lessOp` (which won't compile for bool). Call chain: `SettingFiel
  **What's unique vs PR tests:** PR's test 04205_field_visitor_convert_to_number_ubsan_103817.sql tests the UInt64 boundary (1.8446744073709552e19) for aggregate functions and settings. My test covers the BOOL special case branch whi
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/ea1c7d36-9cfe-4a93-9f0c-f9cef083e11e)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)