### PR TITLE
Fix logical error in SelectIntersectExceptQueryVisitor on normalized AST

### DIFF
--- a/src/Interpreters/SelectIntersectExceptQueryVisitor.cpp
+++ b/src/Interpreters/SelectIntersectExceptQueryVisitor.cpp
@@ -26,7 +26,15 @@ namespace ErrorCodes
 
 void SelectIntersectExceptQueryMatcher::visit(ASTPtr & ast, Data & data)
 {
-    if (auto * select_union = ast->as<ASTSelectWithUnionQuery>())
+    /// Skip already-normalized union queries: `NormalizeSelectWithUnionQueryMatcher`
+    /// flattens inner `UNION ALL` / `UNION DISTINCT` children into the parent's
+    /// `list_of_selects` without updating `list_of_modes`, so on a normalized AST
+    /// `list_of_modes.size() + 1 == list_of_selects->children.size()` no longer
+    /// holds. A normalized AST also cannot contain `INTERSECT` or `EXCEPT` modes
+    /// (`NormalizeSelectWithUnionQueryMatcher` only sets `union_mode` to
+    /// `UNION_ALL` or `UNION_DISTINCT`), so this matcher has nothing to do.
+    /// Mirrors the early-return check in `NormalizeSelectWithUnionQueryMatcher::visit`.
+    if (auto * select_union = ast->as<ASTSelectWithUnionQuery>(); select_union && !select_union->is_normalized)
         visit(*select_union, data);
 }
 

--- a/tests/queries/0_stateless/04214_create_function_normalized_union_query.reference
+++ b/tests/queries/0_stateless/04214_create_function_normalized_union_query.reference
@@ -1,0 +1,4 @@
+minimal repro OK
+recursive repro OK
+intersect repro OK
+except repro OK

--- a/tests/queries/0_stateless/04214_create_function_normalized_union_query.sql
+++ b/tests/queries/0_stateless/04214_create_function_normalized_union_query.sql
@@ -1,0 +1,57 @@
+-- Regression test for STID 4337-3161:
+-- "Logical error: Incorrect ASTSelectWithUnionQuery (modes: 1, selects: 3)"
+-- raised from `SelectIntersectExceptQueryMatcher::visit` when registering a
+-- SQL UDF whose body contains a parenthesized inner UNION.
+--
+-- Root cause: `executeQueryImpl` runs `SelectIntersectExceptQueryVisitor` and
+-- then `NormalizeSelectWithUnionQueryVisitor` on the parsed AST. The
+-- normalizer flattens inner `UNION ALL` children into the parent's
+-- `list_of_selects` and sets `is_normalized = true` (with `union_mode` =
+-- `UNION_ALL`), but does NOT update `list_of_modes` to match. When the
+-- `Interpreter` then runs `normalizeCreateFunctionQuery`, the
+-- `SelectIntersectExceptQueryVisitor` runs a second time on the now-flattened
+-- AST and triggers the assertion `list_of_modes.size() + 1 ==
+-- list_of_selects->children.size()`.
+--
+-- The fix makes `SelectIntersectExceptQueryMatcher::visit` skip already
+-- normalized union queries (no `INTERSECT` / `EXCEPT` modes can be present
+-- after normalization, so there is nothing for the matcher to do).
+--
+-- See https://github.com/ClickHouse/ClickHouse/issues/103969
+
+DROP FUNCTION IF EXISTS test_04214_repro;
+DROP FUNCTION IF EXISTS test_04214_recursive;
+DROP FUNCTION IF EXISTS test_04214_intersect;
+DROP FUNCTION IF EXISTS test_04214_except;
+
+-- Minimal reproducer: outer UNION ALL with a parenthesized inner UNION ALL.
+CREATE FUNCTION test_04214_repro AS x ->
+    (SELECT 1 UNION ALL (SELECT 1 UNION ALL SELECT 1));
+
+SELECT 'minimal repro OK';
+
+-- Full reproducer from issue #103969 (uses WITH RECURSIVE + parenthesized
+-- UNION ALL inside the recursive CTE body).
+CREATE FUNCTION test_04214_recursive AS x ->
+    (SELECT DISTINCT number FROM numbers(2)
+     UNION ALL
+     WITH RECURSIVE r AS (SELECT 1 UNION ALL (SELECT * FROM numbers(2) UNION ALL SELECT 3))
+     SELECT DISTINCT 1);
+
+SELECT 'recursive repro OK';
+
+-- INTERSECT inside a UDF body must still be normalized correctly (the fix
+-- must not regress this path).
+CREATE FUNCTION test_04214_intersect AS x -> (SELECT 1 INTERSECT SELECT 1);
+
+SELECT 'intersect repro OK';
+
+-- Same for EXCEPT.
+CREATE FUNCTION test_04214_except AS x -> (SELECT 1 EXCEPT SELECT 1);
+
+SELECT 'except repro OK';
+
+DROP FUNCTION test_04214_repro;
+DROP FUNCTION test_04214_recursive;
+DROP FUNCTION test_04214_intersect;
+DROP FUNCTION test_04214_except;

--- a/tests/queries/0_stateless/04214_create_function_normalized_union_query.sql
+++ b/tests/queries/0_stateless/04214_create_function_normalized_union_query.sql
@@ -1,3 +1,10 @@
+-- Tags: no-parallel
+-- ^ User-defined SQL functions are stored at the server level (not per
+-- database), so concurrent runs of this test would collide on the
+-- `CREATE FUNCTION` global namespace and fail with `FUNCTION_ALREADY_EXISTS`.
+-- All other UDF tests under `0_stateless/` use the same tag for this reason
+-- (e.g. `01856_create_function`, `02098`-`02103`, `02125`).
+
 -- Regression test for STID 4337-3161:
 -- "Logical error: Incorrect ASTSelectWithUnionQuery (modes: 1, selects: 3)"
 -- raised from `SelectIntersectExceptQueryMatcher::visit` when registering a


### PR DESCRIPTION
The AST fuzzer found `Logical error: Incorrect ASTSelectWithUnionQuery (modes: 1, selects: 3)` raised from `SelectIntersectExceptQueryMatcher::visit` at `src/Interpreters/SelectIntersectExceptQueryVisitor.cpp:43` when registering a SQL UDF whose body contains a parenthesized inner UNION. The bug appears as STID `4337-3161` across multiple unrelated PRs and on master via `BuzzHouse (experimental, serverfuzz, amd_tsan)`.

Auto-generated issue: https://github.com/ClickHouse/ClickHouse/issues/103969

### Minimal reproducer

```sql
CREATE FUNCTION f AS x ->
    (SELECT 1 UNION ALL (SELECT 1 UNION ALL SELECT 1));
```

### Root cause

For a `CREATE FUNCTION` query, `executeQueryImpl` runs `SelectIntersectExceptQueryVisitor` and then `NormalizeSelectWithUnionQueryVisitor` on the parsed AST. The normalizer flattens inner `UNION ALL` / `UNION DISTINCT` children into the parent's `list_of_selects` and sets `is_normalized = true` (with `union_mode` = `UNION_ALL` / `UNION_DISTINCT`), but does NOT update `list_of_modes` to match the new child count.

The interpreter then calls `InterpreterCreateFunctionQuery::execute` -> `UserDefinedSQLFunctionFactory::registerFunction` -> `normalizeCreateFunctionQuery`, which clones the AST and runs `SelectIntersectExceptQueryVisitor` a second time. On the now-flattened AST, the visitor's invariant `list_of_modes.size() + 1 == list_of_selects->children.size()` no longer holds and the assertion fires.

### Fix

Make `SelectIntersectExceptQueryMatcher::visit(ASTPtr &)` skip already-normalized union queries, mirroring the existing early-return check in `NormalizeSelectWithUnionQueryMatcher::visit(ASTPtr &)`. After normalization, no `INTERSECT` / `EXCEPT` modes can be present (the normalizer only sets `union_mode` to `UNION_ALL` or `UNION_DISTINCT`), so this matcher has nothing to do on such ASTs.

### Test plan

Added `04214_create_function_normalized_union_query` covering:

- the minimal `(... UNION ALL (... UNION ALL ...))` reproducer
- the full reproducer from #103969 (`WITH RECURSIVE` + parenthesized `UNION ALL`)
- `CREATE FUNCTION` with `INTERSECT` and `EXCEPT` bodies (must still normalize correctly)

Verified locally: the test fails (server `SIGABRT` from the assertion) before the fix and passes after; 30/30 runs with full settings randomization. Existing tests `02004_intersect_except_*`, `01856_create_function`, `02099_sql_user_defined_functions_lambda`, `03034_recursive_cte_tree_fuzz_crash_fix`, `03035_recursive_cte_postgres_1` still pass.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `Logical error: Incorrect ASTSelectWithUnionQuery (modes: M, selects: N)` triggered when a SQL user-defined function body contains a parenthesized inner `UNION ALL` (e.g. `CREATE FUNCTION f AS x -> (SELECT 1 UNION ALL (SELECT 1 UNION ALL SELECT 1))`).

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

Closes #103969

Session id: cron:clickhouse-ci-task-worker:20260509-174500

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.488`
<!-- ch-version-info:end -->