### PR TITLE
Add test: `system.parts_columns.estimates.null_count` column values not verified

### DIFF
--- a/tests/queries/0_stateless/04212_statistics_null_count_estimate.reference
+++ b/tests/queries/0_stateless/04212_statistics_null_count_estimate.reference
@@ -1,0 +1,10 @@
+Statistics types:
+col_10pct	['MinMax','NullCount']
+col_50pct	['MinMax','NullCount']
+col_90pct	['MinMax','NullCount']
+col_non_null	['MinMax']
+Null count estimates:
+col_10pct	10
+col_50pct	50
+col_90pct	90
+col_non_null	\N

--- a/tests/queries/0_stateless/04212_statistics_null_count_estimate.sql
+++ b/tests/queries/0_stateless/04212_statistics_null_count_estimate.sql
@@ -1,0 +1,42 @@
+-- Test: Verify system.parts_columns.estimates.null_count shows correct NULL counts
+-- Covers: src/Storages/System/StorageSystemPartsColumns.cpp:327-329
+
+SET allow_statistics = 1;
+SET materialize_statistics_on_insert = 1;
+
+DROP TABLE IF EXISTS test_nullcount_estimate;
+CREATE TABLE test_nullcount_estimate (
+    id UInt64,
+    col_10pct Nullable(Int64),       -- 10% NULL
+    col_50pct Nullable(Int64),       -- 50% NULL
+    col_90pct Nullable(Int64),       -- 90% NULL
+    col_non_null Int64               -- 0% NULL (not Nullable)
+) ENGINE = MergeTree() ORDER BY id
+SETTINGS auto_statistics_types = 'nullcount,minmax';
+
+-- Insert 100 rows with known NULL distribution
+INSERT INTO test_nullcount_estimate SELECT
+    number,
+    if(number % 10 = 0, NULL, number),    -- 10 NULLs
+    if(number % 2 = 0, NULL, number),     -- 50 NULLs
+    if(number % 10 != 0, NULL, number),   -- 90 NULLs
+    number
+FROM numbers(100);
+
+-- Verify statistics types are correct
+SELECT 'Statistics types:';
+SELECT column, statistics
+FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 'test_nullcount_estimate'
+  AND active AND column LIKE 'col_%'
+ORDER BY column;
+
+-- Verify estimates.null_count shows correct values
+SELECT 'Null count estimates:';
+SELECT column, `estimates.null_count`
+FROM system.parts_columns
+WHERE database = currentDatabase() AND table = 'test_nullcount_estimate'
+  AND active AND column LIKE 'col_%'
+ORDER BY column;
+
+DROP TABLE test_nullcount_estimate;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #102356](https://github.com/ClickHouse/ClickHouse/pull/102356).
 That PR This PR adds `NullCount` statistics type for tracking NULL values in Nullable columns. Changes include: (1) New `StatisticsNullCount` class in `StatisticsNullCount.cpp/h` for counting NULLs, (2) Integration with `ConditionSelectivityEstimator` for `IS NULL`/`IS NOT NULL` predicate estimation, (3) Ne

**1. `system.parts_columns.estimates.null_count` column values not verified**
  `src/Storages/System/StorageSystemPartsColumns.cpp:327`
  **Risk:** `StorageSystemPartsColumns.cpp`:327-329 populates `estimates.null_count` from `NullCount` statistics. Risk: if the value extraction is broken (wrong statistics type cast, incorrect field access), user
  **What's unique vs PR tests:** PR test 03625_auto_statistics.sql queries estimates.cardinality/min/max but NOT estimates.null_count. PR test 04063_statistics_null_count_prewhere.sql tests prewhere ordering via EXPLAIN but never que
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/a0c1e7d6-25fa-45fc-b073-893fe653989b)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.491`
<!-- ch-version-info:end -->