### PR TITLE
Fix StringZilla build with X86_ARCH_LEVEL=4 by exposing SZ_USE_* defines

### DIFF
--- a/contrib/StringZilla-cmake/CMakeLists.txt
+++ b/contrib/StringZilla-cmake/CMakeLists.txt
@@ -18,9 +18,16 @@ add_library(_stringzilla ${STRINGZILLA_SOURCES} ${STRINGZILLA_HEADERS})
 add_library(ch_contrib::stringzilla ALIAS _stringzilla)
 target_include_directories(_stringzilla SYSTEM PUBLIC "${STRINGZILLA_SOURCE_DIR}/include")
 
+# SZ_USE_* must be PUBLIC: SZ_DYNAMIC_DISPATCH=1 (set below) makes consumer TUs enter the dispatch
+# codepaths in stringzilla/hash.h that reference per-ISA helpers (e.g. sz_hash_*_westmere_*). If
+# these flags were PRIVATE, consumer TUs would fall back to the auto-detection in stringzilla/types.h,
+# which can disagree with the values set here. For example, Westmere auto-detection requires both
+# __SSE4_2__ and __AES__, but -march=x86-64-v4 defines __SSE4_2__ without __AES__, so consumers see
+# SZ_USE_WESTMERE=0 while the library was built with SZ_USE_WESTMERE=1, leaving the referenced
+# helpers undeclared.
 if (ARCH_AMD64)
     target_compile_definitions(
-            _stringzilla PRIVATE
+            _stringzilla PUBLIC
             "SZ_USE_WESTMERE=1"
             "SZ_USE_GOLDMONT=1"
             "SZ_USE_HASWELL=1"
@@ -35,7 +42,7 @@ if (ARCH_AMD64)
     )
 elseif (ARCH_AARCH64)
     target_compile_definitions(
-            _stringzilla PRIVATE
+            _stringzilla PUBLIC
             "SZ_USE_WESTMERE=0"
             "SZ_USE_GOLDMONT=0"
             "SZ_USE_HASWELL=0"


### PR DESCRIPTION
## Problem

Building ClickHouse with `-DX86_ARCH_LEVEL=4 -DENABLE_MULTITARGET_CODE=OFF` fails with undefined references to `sz_hash_*_westmere_*` symbols in consumer translation units (e.g. `src/Common/StringSearcher.cpp`, `src/Common/OptimizedRegularExpression.cpp`):

```
contrib/StringZilla/include/stringzilla/hash.h:2231:9: error: use of undeclared identifier
    'sz_hash_minimal_init_westmere_aligned_'; did you mean 'sz_hash_minimal_init_serial_'?
```

Root cause: a CMake symbol-visibility mismatch.

- `SZ_USE_WESTMERE=1` (and the other `SZ_USE_*` defines) are set as `PRIVATE` on `_stringzilla` — only visible to `stringzilla.c`.
- `SZ_DYNAMIC_DISPATCH=1` is set as `PUBLIC`, so consumer TUs that include the StringZilla headers enter the dispatch codepaths in `hash.h` that reference per-ISA helpers like `sz_hash_minimal_init_westmere_aligned_()`.
- Those helpers are gated on `SZ_USE_WESTMERE=1`. Since consumers don't see the PRIVATE define, they fall back to auto-detection in `stringzilla/types.h`, which requires both `__SSE4_2__` *and* `__AES__`.
- `-march=x86-64-v4` defines `__SSE4_2__` but not `__AES__`, so consumers see `SZ_USE_WESTMERE=0` while the library was built with `SZ_USE_WESTMERE=1` — references to those helpers are then undeclared in the consumer TU.

This only manifests at `X86_ARCH_LEVEL=4`; level 3 builds avoid the issue because the dispatch table structure in `hash.h` happens to compile under v3's broader ISA coverage.

## Fix

Make all `SZ_USE_*` defines `PUBLIC` so consumer TUs see the same ISA settings the library was compiled with, mirroring the existing `PUBLIC` visibility of `SZ_DYNAMIC_DISPATCH=1`.

This is the resolution proposed by the issue reporter in #99172.

## Verification

- [ ] CI build with `-DX86_ARCH_LEVEL=4 -DENABLE_MULTITARGET_CODE=OFF`
- [ ] Standard build matrix (no regression)

Closes #99172