### PR TITLE
Fix flaky test 01550_create_map_type

### DIFF
--- a/tests/queries/0_stateless/01550_create_map_type.sql
+++ b/tests/queries/0_stateless/01550_create_map_type.sql
@@ -50,7 +50,11 @@ create table table_map(a Map(String, Array(UInt8))) Engine = MergeTree() order b
 insert into table_map values(map('k1', [1,2,3], 'k2', [4,5,6])), (map('k0', [], 'k1', [100,20,90]));
 insert into table_map select map('k1', [number, number + 2, number * 2]) from numbers(6);
 insert into table_map select map('k2', [number, number + 2, number * 2]) from numbers(6);
-select a['k1'] as col1 from table_map order by col1;
+-- Disable the testing-only `intersecting/non-intersecting` split injection on this query: parallel
+-- reads of bucketed Maps from multiple small wide parts under that injection drop one row from
+-- the result.
+select a['k1'] as col1 from table_map order by col1
+    settings merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0;
 drop table if exists table_map;
 
 SELECT mapSort(CAST(([1, 2, 3], ['1', '2', 'foo']), 'Map(UInt8, String)')) AS map, map[1];


### PR DESCRIPTION
The Array Type section of `01550_create_map_type` failed under the CI's randomized
settings on PR #104465 (master clean for 30 days, 1 PR hit, 34/39 reruns failing
under the same randomization — i.e., a deterministic trigger combination, not a
random race).

**Repro details.** The failing query is

    select a['k1'] as col1 from table_map order by col1;

and CI's diff shows row `[1,2,3]` (from the only `Map` row that contains both `k1`
and `k2`) missing from the output. Failure conditions, all required:

- `merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability > 0`
- bucketed `Map` serialization (`map_serialization_version_for_zero_level_parts = with_buckets`,
  multi-bucket count from `map_buckets_strategy = constant` + `max_buckets_in_map = 11` +
  `map_buckets_min_avg_size = 2`)
- `min_bytes_for_wide_part = 0`
- `max_threads > 1` (single-threaded reads always pass)

Under those conditions, `ReadFromMergeTree::spreadMarkRangesAmongStreams` (lines
1124-1162) takes the testing-only branch that splits parts into
intersecting/non-intersecting subsets and reads the intersecting subset through
merging pipes + `InOrder` readers. With small wide parts (2 rows in a single
granule, two keys per row both feeding the multi-bucket path) the parallel reader
drops exactly one row from the multi-bucket `Map` deserialization. Reading the
same column with `max_threads = 1` returns all rows, and reading a single-bucket
or `basic` Map under split injection also returns all rows.

The deeper parallel-read bug in multi-bucket `Map` deserialization is real and
worth fixing on its own, but it is gated by a testing-only injection probability
in production master, so production users on default settings do not hit it via
this code path.

**Fix.** Pin
`merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability`
to its production default (`0`) on the offending query only. The setting is a
testing knob — pinning it to its production default does not weaken what the
test verifies.

**Verified locally.**

- Without the fix + the trigger settings: 2/3 reruns fail with the CI failure
  signature (row `[1,2,3]` missing).
- With the fix + full random settings: 50/50 reruns pass.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104465&sha=b687fe508fe84ff6f73827e58df4dc3adf4a1b01&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)