### PR TITLE
Fix stale materialized view dependency collection

### DIFF
--- a/src/Interpreters/InsertDependenciesBuilder.cpp
+++ b/src/Interpreters/InsertDependenciesBuilder.cpp
@@ -1108,6 +1108,22 @@ bool InsertDependenciesBuilder::observePath(const DependencyPath & path)
 
     chassert(storage);
     auto metadata = storage->getInMemoryMetadataPtr(init_context, false);
+    auto * materialized_view = dynamic_cast<StorageMaterializedView *>(storage.get());
+
+    if (materialized_view && current != init_table_id)
+    {
+        StorageIDMaybeEmpty select_table_id = metadata->getSelectQuery().select_table_id;
+        if (select_table_id != parent)
+        {
+            /// It may happen if materialized view query was changed and it doesn't depend on this source table anymore.
+            /// See setting `allow_experimental_alter_materialized_view_structure`.
+            /// A stale dependency can also point through a table name that now belongs to another valid dependency.
+            /// Validate the relation before updating the shared maps, so rejecting this path cannot remove the valid one.
+            LOG_INFO(logger, "Table '{}' is not a source for view '{}' anymore, current source is '{}'",
+                parent, current, select_table_id);
+            return false;
+        }
+    }
 
     storages[current] = storage;
     metadata_snapshots[current] = metadata;
@@ -1133,31 +1149,13 @@ bool InsertDependenciesBuilder::observePath(const DependencyPath & path)
         dependent_views[root_view] = {};
     };
 
-    if (auto * materialized_view = dynamic_cast<StorageMaterializedView *>(storage.get()))
+    if (materialized_view)
     {
         if (current == init_table_id)
         {
             set_defaults_for_root_view(init_table_id, materialized_view->getTargetTableId());
             view_types[init_table_id] = QueryViewsLogElement::ViewType::MATERIALIZED;
             return true;
-        }
-
-        StorageIDMaybeEmpty select_table_id = metadata->getSelectQuery().select_table_id;
-        if (select_table_id != parent)
-        {
-            /// It may happen if materialize view query was changed and it doesn't depend on this source table anymore.
-            /// See setting `allow_experimental_alter_materialized_view_structure`
-            LOG_INFO(logger, "Table '{}' is not a source for view '{}' anymore, current source is '{}'",
-                parent, current, select_table_id);
-            /// The storage was tentatively recorded above before this check; back it out so that
-            /// downstream passes (e.g. the `supportsParallelInsert` scan in the constructor) do
-            /// not invoke methods on a materialized view that has been rejected as unrelated to
-            /// the current insert path. Such methods may dereference stale `target_table_id`
-            /// values and throw.
-            storages.erase(current);
-            metadata_snapshots.erase(current);
-            storage_locks.erase(current);
-            return false;
         }
 
         inner_tables[current] = materialized_view->getTargetTableId();

--- a/tests/queries/0_stateless/04216_materialized_view_reused_target_name_dependency.reference
+++ b/tests/queries/0_stateless/04216_materialized_view_reused_target_name_dependency.reference
@@ -1,0 +1,2 @@
+dst	1	A
+mv_dst	1	A

--- a/tests/queries/0_stateless/04216_materialized_view_reused_target_name_dependency.sql
+++ b/tests/queries/0_stateless/04216_materialized_view_reused_target_name_dependency.sql
@@ -1,0 +1,51 @@
+DROP TABLE IF EXISTS mv_second;
+DROP TABLE IF EXISTS mv_dst;
+DROP TABLE IF EXISTS dst;
+
+CREATE TABLE dst
+(
+    `key` Int64,
+    `value` String
+)
+ENGINE = MergeTree
+ORDER BY tuple();
+
+CREATE TABLE mv_dst
+(
+    `key` Int64,
+    `value` String
+)
+ENGINE = MergeTree
+ORDER BY tuple();
+
+CREATE MATERIALIZED VIEW mv_second
+TO mv_dst
+AS SELECT
+    0 AS key,
+    value
+FROM dst;
+
+DROP TABLE mv_dst;
+
+CREATE MATERIALIZED VIEW mv_dst
+(
+    `key` Int64,
+    `value` String
+)
+ENGINE = MergeTree
+ORDER BY tuple()
+AS SELECT
+    1 AS key,
+    value
+FROM dst;
+
+SET use_async_executor_for_materialized_views = 1;
+
+INSERT INTO dst VALUES (1, 'A');
+
+SELECT 'dst', key, value FROM dst ORDER BY ALL;
+SELECT 'mv_dst', key, value FROM mv_dst ORDER BY ALL;
+
+DROP TABLE mv_second;
+DROP TABLE mv_dst;
+DROP TABLE dst;


### PR DESCRIPTION
Fix dependency collection for `INSERT` into a table with materialized views when a stale materialized view dependency points through a table name that has since been reused. This avoids the `std::out_of_range` exception with `unordered_map::at: key not found` seen in CI.

Examples:
https://play.clickhouse.com/play?user=play&run=1#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSAxCiAgICBBTkQgY2hlY2tfc3RhcnRfdGltZSA+PSBub3coKSAtIElOVEVSVkFMIDI0IEhPVVIKICAgIEFORCAoaGVhZF9yZWYgPSAnbWFzdGVyJyBBTkQgc3RhcnRzV2l0aChoZWFkX3JlcG8sICdDbGlja0hvdXNlLycpKQogICAgQU5EIHRlc3Rfc3RhdHVzICE9ICdTS0lQUEVEJwogICAgQU5EICh0ZXN0X3N0YXR1cyBMSUtFICdGJScgT1IgdGVzdF9zdGF0dXMgTElLRSAnRSUnKQogICAgQU5EIGNoZWNrX3N0YXR1cyAhPSAnc3VjY2VzcycKICAgIEFORCBjaGVja19uYW1lIE5PVCBMSUtFICdsaWJGdXp6ZXIlJwogICAgQU5EIGNoZWNrX25hbWUgIT0gJ0NsaWNrSG91c2UgS2VlcGVyIEplcHNlbicKICAgIEFORCBjaGVja19uYW1lIE5PVCBMSUtFICdJbnRlZ3JhdGlvbiB0ZXN0cyAoYW1kX2xsdm1fY292ZXJhZ2UlJwpPUkRFUiBCWSBjaGVja19zdGFydF90aW1lIERFU0M=

CI report:
https://s3.amazonaws.com/clickhouse-test-reports/9250c759214b3d8f726ee4e38cc3148d783f8766/stress_test__arm_asan_ubsan__s3_.html

Related issue:
https://github.com/ClickHouse/ClickHouse/issues/104444

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not needed.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

No user-facing documentation is needed for this CI fix.

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.497`
<!-- ch-version-info:end -->