### PR TITLE
Reject collection literals as data-type arguments (STID 1941-1bfa)

### DIFF
--- a/src/Parsers/ParserDataType.cpp
+++ b/src/Parsers/ParserDataType.cpp
@@ -508,7 +508,20 @@ bool ParserDataType::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
         else
         {
             ParserDataType data_type_parser;
-            ParserAllCollectionsOfLiterals literal_parser(false);
+            /// Only accept simple literals (numbers, strings, NULL, ...) as
+            /// data-type arguments. We deliberately do NOT accept collection
+            /// literals like `(1)`, `[1, 2]` or `{a: 1}` here: no real data
+            /// type takes a tuple/array/map literal as an argument, and
+            /// accepting them produces an `ASTLiteral` with `Field::Tuple`
+            /// (or `Field::Array`) inside the type's argument list. The
+            /// formatter then prints such a Tuple literal as `tuple(...)`
+            /// (the explicit function form -- see
+            /// `FieldVisitorToString::operator()(const Tuple &)`), and
+            /// re-parsing `tuple(...)` in this context yields an
+            /// `ASTDataType("tuple")` instead of an `ASTLiteral`, breaking
+            /// the AST round-trip check in `executeQuery` (DEBUG/sanitizer
+            /// builds). See STID 1941-1bfa.
+            ParserLiteral literal_parser;
 
             const char * operators[] = {"=", "equals", nullptr};
             ParserLeftAssociativeBinaryOperatorList enum_parser(operators, std::make_unique<ParserLiteral>());

--- a/tests/queries/0_stateless/03210_inconsistent_formatting_of_data_types.reference
+++ b/tests/queries/0_stateless/03210_inconsistent_formatting_of_data_types.reference
@@ -1,7 +1,10 @@
 ALTER TABLE columns_with_multiple_streams (MODIFY COLUMN `field1` Nullable(tupleElement(x, 2), UInt8))
 ALTER TABLE t_update_empty_nested (ADD COLUMN `nested.arr2` Array(tuple('- ON NULL -', toLowCardinality(11), 11, 11, toLowCardinality(11), 11), UInt64))
-ALTER TABLE t (ADD COLUMN `x` Array(tuple(1), UInt8))
 ALTER TABLE enum_alter_issue (MODIFY COLUMN `a` Enum8(equals('one', timeSlots(timeSlots(arrayEnumerateDense(tuple('0.2147483646', toLowCardinality(toUInt128)), NULL), 4, 12.34, materialize(73), 2)), 1)))
 ALTER TABLE t_sparse_mutations_3 (MODIFY COLUMN `s` Tuple(Nullable(tupleElement(s, 1), UInt64), Nullable(UInt64), Nullable(UInt64), Nullable(UInt64), Nullable(String)))
+Syntax error
+Syntax error
+Syntax error
+Syntax error
 Syntax error
 Syntax error

--- a/tests/queries/0_stateless/03210_inconsistent_formatting_of_data_types.sh
+++ b/tests/queries/0_stateless/03210_inconsistent_formatting_of_data_types.sh
@@ -7,10 +7,19 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # Ensure that these (possibly incorrect) queries can at least be parsed back after formatting.
 $CLICKHOUSE_FORMAT --oneline --query "ALTER TABLE columns_with_multiple_streams MODIFY COLUMN field1 Nullable(tupleElement(x, 2), UInt8)" | $CLICKHOUSE_FORMAT --oneline
 $CLICKHOUSE_FORMAT --oneline --query "ALTER TABLE t_update_empty_nested ADD COLUMN \`nested.arr2\` Array(tuple('- ON NULL -', toLowCardinality(11), 11, 11, toLowCardinality(11), 11), UInt64)" | $CLICKHOUSE_FORMAT --oneline
-$CLICKHOUSE_FORMAT --oneline --query "ALTER TABLE t ADD COLUMN x Array((1), UInt8)" | $CLICKHOUSE_FORMAT --oneline
 $CLICKHOUSE_FORMAT --oneline --query "ALTER TABLE enum_alter_issue (MODIFY COLUMN a Enum8(equals('one', timeSlots(timeSlots(arrayEnumerateDense(tuple('0.2147483646', toLowCardinality(toUInt128(12))), NULL), 4, 12.34, materialize(73), 2)), 1)))" | $CLICKHOUSE_FORMAT --oneline
 $CLICKHOUSE_FORMAT --oneline --query "ALTER TABLE t_sparse_mutations_3 MODIFY COLUMN s Tuple(Nullable(tupleElement(s, 1), UInt64), Nullable(UInt64), Nullable(UInt64), Nullable(UInt64), Nullable(String))" | $CLICKHOUSE_FORMAT --oneline
 
 # These invalid queries don't parse and this is normal.
 $CLICKHOUSE_FORMAT --oneline --query "ALTER TABLE alter_compression_codec1 MODIFY COLUMN alter_column CODEC((2 + ignore(1, toUInt128(materialize(2)), 2 + toNullable(toNullable(3))), 3), NONE)" 2>&1 | grep -o -F 'Syntax error'
 $CLICKHOUSE_FORMAT --oneline --query "ALTER TABLE test_table ADD COLUMN \`array\` Array(('110', 3, toLowCardinality(3), 3, toNullable(3), toLowCardinality(toNullable(3)), 3), UInt8) DEFAULT [1, 2, 3]" 2>&1 | grep -o -F 'Syntax error'
+
+# Collection literals like `(1)` or `[1]` are no longer accepted as data type
+# arguments. Real data types do not take tuple/array/map literals as
+# parameters; accepting them previously produced an `ASTLiteral` with
+# `Field::Tuple` inside the type's argument list which broke AST round-trip
+# (see STID 1941-1bfa, fixed by rejecting these at parse time).
+$CLICKHOUSE_FORMAT --oneline --query "ALTER TABLE t ADD COLUMN x Array((1), UInt8)" 2>&1 | grep -o -F 'Syntax error'
+$CLICKHOUSE_FORMAT --oneline --query "CREATE TABLE t1 (a multiply((NULL), Int8)) ENGINE = Memory" 2>&1 | grep -o -F 'Syntax error'
+$CLICKHOUSE_FORMAT --oneline --query "CREATE TABLE t2 (a multiply([NULL], Int8)) ENGINE = Memory" 2>&1 | grep -o -F 'Syntax error'
+$CLICKHOUSE_FORMAT --oneline --query "CREATE TABLE t3 (a Nullable(multiply((NULL), Int8))) ENGINE = Memory" 2>&1 | grep -o -F 'Syntax error'


### PR DESCRIPTION
## Motivation

`AST fuzzer (amd_debug)` and related sanitizer/fuzzer jobs hit a chronic `LOGICAL_ERROR: Inconsistent AST formatting` (STID `1941-1bfa`) in `executeQuery.cpp:1280` whenever a fuzzed query puts a collection literal (`(NULL)`, `[NULL]`, `{a: 1}`) inside a parameterized data type's argument list.

Latest hit: PR [#100177](https://github.com/ClickHouse/ClickHouse/pull/100177) (commit `9322e66`):

```sql
CREATE TABLE t0__fuzz_31 (`a` Nullable(multiply((NULL), Int8)), ...) ENGINE = ReplacingMergeTree ...
```

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100177&sha=9322e66151ea6cc3017cc476e1f8d958bb56421c&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%29

The bug has been hit by 20+ unrelated PRs over the last 30 days. Master is unaffected (the round-trip check fires only in DEBUG/sanitizer builds, and master CI doesn't usually run AST fuzzer mutations against the same seed). PR [#102547](https://github.com/ClickHouse/ClickHouse/pull/102547) by @zoomxi (merged 2026-04-29) fixed one specific variant (`INSERT with SAMPLE and OFFSET`); this PR addresses the broader collection-literal variant.

## Root cause

Inside `ParserDataType::parseImpl` (`src/Parsers/ParserDataType.cpp`), arguments to a parameterized data type were parsed with `ParserAllCollectionsOfLiterals`, which accepts `(...)`, `[...]`, `{...}` (with `false` for the map case). For `multiply((NULL), Int8)` this gives `DataType_multiply -> [Literal_Tuple_(NULL), DataType_Int8]`.

Formatting that AST goes through `FieldVisitorToString::operator()(const Tuple &)`, which prints a single-element Tuple literal as `tuple(NULL)` (the explicit function form, used to avoid `(NULL)` re-parsing as a parenthesized expression in regular SQL contexts).

Re-parsing `multiply(tuple(NULL), Int8)` in data-type-argument context: `tuple(NULL)` starts with an identifier (not `(`/`[`/`{`), so `ParserAllCollectionsOfLiterals` doesn't trigger. Falls through to `ParserDataType`, which parses it as `ASTDataType("tuple")` with a `Literal_NULL` child. Different shape → `getTreeHash` differs → `LOGICAL_ERROR`.

The same goes for `multiply([NULL], Int8)` (`Literal_Array_(NULL)` ↔ `[NULL]` re-parsed as a Literal_Array... but the formatter for empty arrays / various edge cases also drifts). I confirmed the exact same crash for both `(NULL)` and `[NULL]` variants locally.

## Fix

No real data type takes a collection literal as a parameter:
- Simple literals: `FixedString(5)`, `Decimal(10, 2)`, `DateTime64(3, 'UTC')`
- Nested types: `Nullable(Int32)`, `Array(String)`, `LowCardinality(...)`
- Special handling: `Tuple(Int32, String)`, `Enum8('a' = 1, 'b' = 2)` (separate code paths in the same function)

Replace `ParserAllCollectionsOfLiterals literal_parser(false)` with `ParserLiteral literal_parser`. Malformed queries are now rejected at parse time with `SYNTAX_ERROR` (Code 62) instead of crashing later in the round-trip check.

Verified locally:
- `multiply((NULL), Int8)`, `multiply([NULL], Int8)`, `Nullable(multiply((NULL), Int8))` → `SYNTAX_ERROR` (was: `LOGICAL_ERROR` crash)
- Sanity-tested 13 common type families (`UInt32`, `Decimal(10,2)`, `DateTime64(3,'UTC')`, `FixedString(5)`, `Nullable(String)`, `Tuple(...)`, `Array(Tuple(...))`, `Enum8(...)`, `LowCardinality(Nullable(FixedString(10)))`, `Map(String, Array(Int32))`, `SimpleAggregateFunction(sum, UInt64)`, `AggregateFunction(uniq, Int32)`, `Variant(...)`) — all parse correctly.

## Test changes

`tests/queries/0_stateless/03210_inconsistent_formatting_of_data_types.sh` had one case `Array((1), UInt8)` in the "possibly incorrect but should round-trip" section that relied on the old behavior. Move it to the "invalid queries that don't parse" section alongside three new regression cases for STID `1941-1bfa`. The 4 tracked-as-valid cases continue to round-trip unchanged.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Session: cron:clickhouse-ci-task-worker:20260510-124500
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.499`
<!-- ch-version-info:end -->