### PR TITLE
Do not fail startup when local active part covers missing part

### DIFF
--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -1827,6 +1827,11 @@ void StorageReplicatedMergeTree::paranoidCheckForCoveredPartsInZooKeeperOnStart(
             if (disk->existsDirectory(fs::path(path) / part_name))
                 found = true;
 
+        /// It is OK if the exact covered part is absent locally when an active
+        /// local part already covers it.
+        if (!found && getActiveContainingPart(part_name))
+            found = true;
+
         if (!found)
             found = std::find(parts_to_fetch.begin(), parts_to_fetch.end(), part_name) != parts_to_fetch.end();
 

--- a/tests/queries/0_stateless/02369_lost_part_intersecting_merges.sh
+++ b/tests/queries/0_stateless/02369_lost_part_intersecting_merges.sh
@@ -44,5 +44,8 @@ $CLICKHOUSE_CLIENT -q "system sync replica rmt2;"
 $CLICKHOUSE_CLIENT -q "select 3, *, _part from rmt1 order by n;"
 $CLICKHOUSE_CLIENT -q "select 4, *, _part from rmt2 order by n;"
 
+$CLICKHOUSE_CLIENT -q "detach table rmt1;"
+$CLICKHOUSE_CLIENT -q "attach table rmt1;"
+
 $CLICKHOUSE_CLIENT -q "drop table rmt1 sync;"
 $CLICKHOUSE_CLIENT -q "drop table rmt2 sync;"


### PR DESCRIPTION
Fixes master CI failures where `Cannot start clickhouse-server` was reported after the stress run left a `ReplicatedMergeTree` replica with an old covered part in `ZooKeeper`, the exact old part missing locally, and a local active covering part already present.

The startup paranoid check now accepts that state instead of raising the debug/sanitizer-only `Logical error: 'false'` exception. The regression test `02369_lost_part_intersecting_merges` now detaches and attaches the replica after creating the same state.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=0f78a222106d4ff05c17068ead6522df52a235ec&name_0=MasterCI&name_1=Stress%20test%20%28experimental%2C%20serverfuzz%2C%20arm_asan_ubsan%29&name_1=Stress%20test%20%28experimental%2C%20serverfuzz%2C%20arm_asan_ubsan%29

Examples: https://play.clickhouse.com/play?user=play&run=1#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIGNoZWNrX25hbWUsIHRlc3RfbmFtZSwgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSAxCiAgICBBTkQgY2hlY2tfc3RhcnRfdGltZSA+PSBub3coKSAtIElOVEVSVkFMIDI0IEhPVVIKICAgIEFORCAoaGVhZF9yZWYgPSAnbWFzdGVyJyBBTkQgc3RhcnRzV2l0aChoZWFkX3JlcG8sICdDbGlja0hvdXNlLycpKQogICAgQU5EIHRlc3Rfc3RhdHVzICE9ICdTS0lQUEVEJwogICAgQU5EICh0ZXN0X3N0YXR1cyBMSUtFICdGJScgT1IgdGVzdF9zdGF0dXMgTElLRSAnRSUnKQogICAgQU5EIGNoZWNrX3N0YXR1cyAhPSAnc3VjY2VzcycKICAgIEFORCBjaGVja19uYW1lIE5PVCBMSUtFICdsaWJGdXp6ZXIlJwogICAgQU5EIGNoZWNrX25hbWUgIT0gJ0NsaWNrSG91c2UgS2VlcGVyIEplcHNlbicKICAgIEFORCBjaGVja19uYW1lIE5PVCBMSUtFICdJbnRlZ3JhdGlvbiB0ZXN0cyAoYW1kX2xsdm1fY292ZXJhZ2UlJwpPUkRFUiBCWSBjaGVja19zdGFydF90aW1lIERFU0M=

Related issue search: no open issue found for `Cannot start clickhouse-server` with `paranoidCheckForCoveredPartsInZooKeeperOnStart`, `ReplicatedCoveredPartsInZooKeeperOnStart`, or `StorageReplicatedMergeTree.cpp:1843`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.567`
<!-- ch-version-info:end -->