### PR TITLE
Fix uniqThetaIntersect with empty state on the right-hand side

### DIFF
--- a/src/AggregateFunctions/ThetaSketchData.h
+++ b/src/AggregateFunctions/ThetaSketchData.h
@@ -98,6 +98,21 @@ public:
 
     void intersect(const ThetaSketchData & rhs)
     {
+        /// If `rhs` has no recorded values it represents an empty set, and the
+        /// intersection with an empty set is always empty. Without this guard
+        /// `theta_intersection` would only receive `this` as a single input and
+        /// `get_result` would return that input unchanged — yielding a wrong,
+        /// non-empty result. This matters for example after
+        /// `uniqThetaMergeStateIf(state, predicate)` when the predicate excludes
+        /// every row: the resulting state is freshly created and has neither
+        /// `sk_update` nor `sk_union` allocated.
+        if (!rhs.sk_update && !rhs.sk_union)
+        {
+            sk_update.reset(nullptr);
+            sk_union.reset(nullptr);
+            return;
+        }
+
         datasketches::theta_union * u = getSkUnion();
 
         if (sk_update)

--- a/tests/queries/0_stateless/04215_91595_uniq_theta_intersect_empty_state.reference
+++ b/tests/queries/0_stateless/04215_91595_uniq_theta_intersect_empty_state.reference
@@ -1,0 +1,12 @@
+reproducer from den-crane
+0
+intersect non_empty with filter-excluded empty state
+0
+intersect filter-excluded empty state with non_empty (commuted)
+0
+intersect two filter-excluded empty states
+0
+sanity check - non-empty intersection still works
+5
+AggregatingMergeTree variant from the issue
+0

--- a/tests/queries/0_stateless/04215_91595_uniq_theta_intersect_empty_state.sql
+++ b/tests/queries/0_stateless/04215_91595_uniq_theta_intersect_empty_state.sql
@@ -1,0 +1,75 @@
+-- Tags: no-fasttest
+-- ^ no-fasttest because uniqTheta requires the DataSketches library
+
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/91595
+-- `uniqThetaIntersect` previously returned the cardinality of the first
+-- argument when the second argument was a freshly-created (never-updated)
+-- state. Such states arise naturally from
+-- `uniqThetaMergeStateIf(s, predicate)` when the predicate excludes every
+-- row, and the intersection with an empty set must always be empty.
+
+SELECT 'reproducer from den-crane';
+SELECT finalizeAggregation(
+    uniqThetaIntersect(
+        uniqThetaMergeStateIf(arrayReduce('uniqThetaState', [1, 2]::Array(UInt32)), 1),
+        uniqThetaMergeStateIf(arrayReduce('uniqThetaState', []::Array(UInt32)), 0)
+    )
+);
+
+SELECT 'intersect non_empty with filter-excluded empty state';
+SELECT finalizeAggregation(
+    uniqThetaIntersect(
+        uniqThetaStateIf(number, 1),
+        uniqThetaStateIf(number, 0)
+    )
+)
+FROM numbers(10);
+
+SELECT 'intersect filter-excluded empty state with non_empty (commuted)';
+SELECT finalizeAggregation(
+    uniqThetaIntersect(
+        uniqThetaStateIf(number, 0),
+        uniqThetaStateIf(number, 1)
+    )
+)
+FROM numbers(10);
+
+SELECT 'intersect two filter-excluded empty states';
+SELECT finalizeAggregation(
+    uniqThetaIntersect(
+        uniqThetaStateIf(number, 0),
+        uniqThetaStateIf(number, 0)
+    )
+)
+FROM numbers(10);
+
+SELECT 'sanity check - non-empty intersection still works';
+SELECT finalizeAggregation(
+    uniqThetaIntersect(
+        uniqThetaState(number),
+        uniqThetaStateIf(number, number < 5)
+    )
+)
+FROM numbers(10);
+
+SELECT 'AggregatingMergeTree variant from the issue';
+DROP TABLE IF EXISTS test_uniq_theta_intersect_91595;
+
+CREATE TABLE test_uniq_theta_intersect_91595
+(
+    cid UInt32,
+    users AggregateFunction(uniqTheta, UInt32)
+)
+ENGINE = AggregatingMergeTree() ORDER BY cid;
+
+INSERT INTO test_uniq_theta_intersect_91595 VALUES (1, arrayReduce('uniqThetaState', [1, 2]::Array(UInt32))), (2, arrayReduce('uniqThetaState', [2, 3]::Array(UInt32)));
+
+SELECT finalizeAggregation(
+    uniqThetaIntersect(
+        uniqThetaMergeStateIf(users, cid = 1),
+        uniqThetaMergeStateIf(users, cid = 3) -- cid = 3 never matches -> empty state
+    )
+)
+FROM test_uniq_theta_intersect_91595;
+
+DROP TABLE test_uniq_theta_intersect_91595;


### PR DESCRIPTION
`uniqThetaIntersect(a, b)` returned the cardinality of `a` whenever `b` was a freshly-created `uniqTheta` state that had never been updated -- e.g. the result of `uniqThetaMergeStateIf(s, predicate)` when the predicate excluded every row.

Closes #91595.

### Root cause

In `ThetaSketchData::intersect` we feed the local data into a `datasketches::theta_intersection`, then update it with whatever sketch `rhs` carries (`rhs.sk_update` or `rhs.sk_union`). When `rhs` had neither pointer allocated, we never called `update` for `rhs` and the intersection ended up with a single input -- `theta_intersection::get_result` returns that single input unchanged, so the wrong, non-empty result was used.

Reproducer (from #91595, simplified by @den-crane):

```sql
SELECT finalizeAggregation(
    uniqThetaIntersect(
        uniqThetaMergeStateIf(arrayReduce('uniqThetaState', [1, 2]::Array(UInt32)), 1),
        uniqThetaMergeStateIf(arrayReduce('uniqThetaState', []::Array(UInt32)), 0)
    )
);
-- Before: 2
-- After:  0
```

### Fix

Intersection with an empty set is always empty, so short-circuit in `ThetaSketchData::intersect` before calling into DataSketches: when `rhs` has neither `sk_update` nor `sk_union` allocated, drop our own state and return. `merge` (union with empty = self) and `aNotB` (`A \ empty = A`) already behave correctly for an empty rhs and need no change.

### Tests

Added `04215_91595_uniq_theta_intersect_empty_state.sql` covering:
- the den-crane reproducer
- `intersect(non_empty, filter-excluded empty)`
- `intersect(filter-excluded empty, non_empty)` -- commuted
- `intersect(filter-excluded empty, filter-excluded empty)`
- a sanity check that non-empty intersections still work
- the `AggregatingMergeTree` variant from the original issue

The pre-existing `01798_uniq_theta_union_intersect_not.sql` still passes locally with the fix applied.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix `uniqThetaIntersect` returning the cardinality of the first argument instead of `0` when the second argument is an empty `uniqTheta` state -- for example the result of `uniqThetaMergeStateIf(s, predicate)` when the predicate excludes every row.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.505`
<!-- ch-version-info:end -->