### PR TITLE
Infer schema for input() table function from fixed-schema formats

### DIFF
--- a/src/TableFunctions/TableFunctionInput.cpp
+++ b/src/TableFunctions/TableFunctionInput.cpp
@@ -84,7 +84,7 @@ ColumnsDescription TableFunctionInput::getActualTableStructure(ContextPtr contex
         /// `QueryAnalyzer::resolveTableFunction`). Honour that hint first — the
         /// user's destination column names take precedence over a format's
         /// fixed schema, so queries like
-        ///     INSERT INTO t (data String) SELECT data FROM input() FORMAT LineAsString
+        ///     INSERT INTO t (data) SELECT data FROM input() FORMAT LineAsString
         /// keep working even though `LineAsString` declares its column as `line`.
         if (!structure_hint.empty())
             return structure_hint;

--- a/src/TableFunctions/TableFunctionInput.cpp
+++ b/src/TableFunctions/TableFunctionInput.cpp
@@ -1,7 +1,10 @@
 #include <TableFunctions/TableFunctionFactory.h>
+#include <Formats/FormatFactory.h>
+#include <Interpreters/Context.h>
 #include <Interpreters/parseColumnsListForTableFunction.h>
 #include <Parsers/ASTFunction.h>
 #include <Parsers/ASTLiteral.h>
+#include <Processors/Formats/ISchemaReader.h>
 #include <Common/Exception.h>
 #include <Storages/StorageInput.h>
 #include <Storages/checkAndGetLiteralArgument.h>
@@ -75,6 +78,21 @@ ColumnsDescription TableFunctionInput::getActualTableStructure(ContextPtr contex
 {
     if (structure == "auto")
     {
+        /// Some formats have a fixed schema that can be derived without reading any data
+        /// (e.g. `LineAsString`, `RawBLOB`, `JSONAsString`). When the surrounding `INSERT`
+        /// query specifies such a format, use it as the source of truth so the user does
+        /// not have to repeat the structure on the table function.
+        const auto & insert_format = context->getInsertFormat();
+        if (!insert_format.empty())
+        {
+            const auto & factory = FormatFactory::instance();
+            if (factory.checkIfFormatHasExternalSchemaReader(insert_format))
+            {
+                auto external_schema_reader = factory.getExternalSchemaReader(insert_format, context);
+                return ColumnsDescription(external_schema_reader->readSchema());
+            }
+        }
+
         if (structure_hint.empty())
             throw Exception(
                 ErrorCodes::CANNOT_EXTRACT_TABLE_STRUCTURE,

--- a/src/TableFunctions/TableFunctionInput.cpp
+++ b/src/TableFunctions/TableFunctionInput.cpp
@@ -78,10 +78,23 @@ ColumnsDescription TableFunctionInput::getActualTableStructure(ContextPtr contex
 {
     if (structure == "auto")
     {
-        /// Some formats have a fixed schema that can be derived without reading any data
-        /// (e.g. `LineAsString`, `RawBLOB`, `JSONAsString`). When the surrounding `INSERT`
-        /// query specifies such a format, use it as the source of truth so the user does
-        /// not have to repeat the structure on the table function.
+        /// The analyzer may have already set a structure hint by mapping
+        /// destination-table columns to identifier expressions in the surrounding
+        /// `INSERT ... SELECT` (see `Context::executeTableFunction` and
+        /// `QueryAnalyzer::resolveTableFunction`). Honour that hint first — the
+        /// user's destination column names take precedence over a format's
+        /// fixed schema, so queries like
+        ///     INSERT INTO t (data String) SELECT data FROM input() FORMAT LineAsString
+        /// keep working even though `LineAsString` declares its column as `line`.
+        if (!structure_hint.empty())
+            return structure_hint;
+
+        /// No analyzer hint. If the surrounding `INSERT` specifies a fixed-schema
+        /// format (`LineAsString`, `RawBLOB`, `JSONAsString`, ...), derive the
+        /// structure from the format. This handles the case from #104532 where
+        /// the SELECT list cannot be matched to the destination columns by name
+        /// (e.g. literals projected before the input column), so `structure_hint`
+        /// is left empty.
         const auto & insert_format = context->getInsertFormat();
         if (!insert_format.empty())
         {
@@ -93,13 +106,11 @@ ColumnsDescription TableFunctionInput::getActualTableStructure(ContextPtr contex
             }
         }
 
-        if (structure_hint.empty())
-            throw Exception(
-                ErrorCodes::CANNOT_EXTRACT_TABLE_STRUCTURE,
-                "Table function '{}' was used without structure argument but structure could not be determined automatically. Please, "
-                "provide structure manually",
-                getName());
-        return structure_hint;
+        throw Exception(
+            ErrorCodes::CANNOT_EXTRACT_TABLE_STRUCTURE,
+            "Table function '{}' was used without structure argument but structure could not be determined automatically. Please, "
+            "provide structure manually",
+            getName());
     }
     return parseColumnsListFromString(structure, context);
 }

--- a/tests/queries/0_stateless/04215_input_fixed_schema_format.reference
+++ b/tests/queries/0_stateless/04215_input_fixed_schema_format.reference
@@ -1,0 +1,6 @@
+3	['one','two','three']
+2	[('@system@','@repo@','log-a'),('@system@','@repo@','log-b')]
+binary content here
+2	['{"a": 1}','{"b": 2}']
+CANNOT_EXTRACT_TABLE_STRUCTURE
+2	['still','works']

--- a/tests/queries/0_stateless/04215_input_fixed_schema_format.sh
+++ b/tests/queries/0_stateless/04215_input_fixed_schema_format.sh
@@ -48,10 +48,19 @@ ${CLICKHOUSE_CLIENT} --query="SELECT count(), arraySort(groupArray(json)) FROM t
 
 # 5. Negative case: a format with no fixed schema (`CSV`). The user must still provide
 #    a structure manually; we should preserve the old, actionable error message.
+#    Capture the client's exit status explicitly so the test fails loudly if the
+#    `INSERT` unexpectedly succeeds instead of silently producing an empty line that
+#    would only be caught by the reference diff.
 ${CLICKHOUSE_CLIENT} --query="CREATE TABLE t_input_csv (a Int32, b Int32) ENGINE = Memory"
-printf '1,2\n' | \
-    ${CLICKHOUSE_CLIENT} --query="INSERT INTO t_input_csv SELECT a, b FROM input() FORMAT CSV" 2>&1 \
-    | grep -oF 'CANNOT_EXTRACT_TABLE_STRUCTURE' | head -n 1
+set +e
+csv_output=$(printf '1,2\n' | ${CLICKHOUSE_CLIENT} --query="INSERT INTO t_input_csv SELECT a, b FROM input() FORMAT CSV" 2>&1)
+csv_status=$?
+set -e
+if [ "$csv_status" -eq 0 ]; then
+    echo "ERROR: INSERT FROM input() FORMAT CSV was expected to fail but succeeded; output: $csv_output"
+    exit 1
+fi
+echo "$csv_output" | grep -oF 'CANNOT_EXTRACT_TABLE_STRUCTURE' | head -n 1
 
 # 6. Existing behaviour: explicit structure on `input(...)` still works, including when
 #    its column name does not match the format's fixed schema.

--- a/tests/queries/0_stateless/04215_input_fixed_schema_format.sh
+++ b/tests/queries/0_stateless/04215_input_fixed_schema_format.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Tests that the `input` table function infers its structure from the surrounding
+# `INSERT` query's `FORMAT` when that format has a fixed schema (e.g. `LineAsString`,
+# `RawBLOB`, `JSONAsString`). For these formats the user no longer has to repeat the
+# structure as `input('line String')` etc.
+#
+# See https://github.com/ClickHouse/ClickHouse/issues/104532
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+set -e
+
+${CLICKHOUSE_CLIENT} --query="DROP TABLE IF EXISTS t_input_line_as_string"
+${CLICKHOUSE_CLIENT} --query="DROP TABLE IF EXISTS t_input_line_as_string_wide"
+${CLICKHOUSE_CLIENT} --query="DROP TABLE IF EXISTS t_input_raw_blob"
+${CLICKHOUSE_CLIENT} --query="DROP TABLE IF EXISTS t_input_json_as_string"
+${CLICKHOUSE_CLIENT} --query="DROP TABLE IF EXISTS t_input_csv"
+
+# 1. LineAsString — the original issue from #104532. The `input()` call has no structure,
+#    but the format is fixed-schema and provides `line String`.
+${CLICKHOUSE_CLIENT} --query="CREATE TABLE t_input_line_as_string (line String) ENGINE = Memory"
+printf 'one\ntwo\nthree\n' | \
+    ${CLICKHOUSE_CLIENT} --query="INSERT INTO t_input_line_as_string SELECT line FROM input() FORMAT LineAsString"
+${CLICKHOUSE_CLIENT} --query="SELECT count(), groupArray(line) FROM t_input_line_as_string"
+
+# 2. LineAsString with extra constant columns derived in the SELECT list. This is the
+#    exact shape from the issue: the destination has columns the input format does not
+#    provide, so they are filled in by literals around the inferred `line` reference.
+${CLICKHOUSE_CLIENT} --query="CREATE TABLE t_input_line_as_string_wide (system String, repo String, line String) ENGINE = Memory"
+printf 'log-a\nlog-b\n' | \
+    ${CLICKHOUSE_CLIENT} --query="INSERT INTO t_input_line_as_string_wide SELECT '@system@' AS system, '@repo@' AS repo, line FROM input() FORMAT LineAsString"
+${CLICKHOUSE_CLIENT} --query="SELECT count(), groupArray((system, repo, line)) FROM t_input_line_as_string_wide"
+
+# 3. RawBLOB — fixed-schema format with column name `raw_blob`. Single value per request.
+${CLICKHOUSE_CLIENT} --query="CREATE TABLE t_input_raw_blob (data String) ENGINE = Memory"
+printf 'binary content here' | \
+    ${CLICKHOUSE_CLIENT} --query="INSERT INTO t_input_raw_blob SELECT raw_blob FROM input() FORMAT RawBLOB"
+${CLICKHOUSE_CLIENT} --query="SELECT * FROM t_input_raw_blob"
+
+# 4. JSONAsString — fixed-schema format with column name `json`.
+${CLICKHOUSE_CLIENT} --query="CREATE TABLE t_input_json_as_string (json String) ENGINE = Memory"
+printf '{"a": 1}\n{"b": 2}\n' | \
+    ${CLICKHOUSE_CLIENT} --query="INSERT INTO t_input_json_as_string SELECT json FROM input() FORMAT JSONAsString"
+${CLICKHOUSE_CLIENT} --query="SELECT count(), arraySort(groupArray(json)) FROM t_input_json_as_string"
+
+# 5. Negative case: a format with no fixed schema (`CSV`). The user must still provide
+#    a structure manually; we should preserve the old, actionable error message.
+${CLICKHOUSE_CLIENT} --query="CREATE TABLE t_input_csv (a Int32, b Int32) ENGINE = Memory"
+printf '1,2\n' | \
+    ${CLICKHOUSE_CLIENT} --query="INSERT INTO t_input_csv SELECT a, b FROM input() FORMAT CSV" 2>&1 \
+    | grep -oF 'CANNOT_EXTRACT_TABLE_STRUCTURE' | head -n 1
+
+# 6. Existing behaviour: explicit structure on `input(...)` still works, including when
+#    its column name does not match the format's fixed schema.
+${CLICKHOUSE_CLIENT} --query="TRUNCATE TABLE t_input_line_as_string"
+printf 'still\nworks\n' | \
+    ${CLICKHOUSE_CLIENT} --query="INSERT INTO t_input_line_as_string SELECT my_col FROM input('my_col String') FORMAT LineAsString"
+${CLICKHOUSE_CLIENT} --query="SELECT count(), groupArray(line) FROM t_input_line_as_string"
+
+${CLICKHOUSE_CLIENT} --query="DROP TABLE t_input_line_as_string"
+${CLICKHOUSE_CLIENT} --query="DROP TABLE t_input_line_as_string_wide"
+${CLICKHOUSE_CLIENT} --query="DROP TABLE t_input_raw_blob"
+${CLICKHOUSE_CLIENT} --query="DROP TABLE t_input_json_as_string"
+${CLICKHOUSE_CLIENT} --query="DROP TABLE t_input_csv"


### PR DESCRIPTION
## Description

When the surrounding `INSERT` query specifies a format that has a fixed schema (`LineAsString`, `RawBLOB`, `JSONAsString`, `JSONAsObject`, ...), the `input` table function now derives its structure from that format. Previously the user had to repeat the structure on the table function itself, e.g. `input('line String')`.

The reported regression:

```sql
INSERT INTO logs SELECT '@system@' AS system, '$machine' AS machine,
                       '@repo@' AS repo, '@branch@' AS branch, line
FROM input()
FORMAT LineAsString
```

failed with `CANNOT_EXTRACT_TABLE_STRUCTURE` even though `LineAsString` unambiguously declares a single `String` column named `line`. The existing `structure_hint` mechanism is set by the analyzer from the destination table's columns, but it doesn't fire when the `SELECT` has constant projections in front of the `input` reference, when destination column names don't line up with the format's column name, or when there is no insertion table at all.

The fix consults `FormatFactory::getExternalSchemaReader` from inside `TableFunctionInput::getActualTableStructure`. Formats that register an external schema reader (`LineAsString`, `RawBLOB`, `JSONAsString`, `JSONAsObject`, `Protobuf`, `CapnProto`, etc.) declare a schema that is independent of the data, so it is the authoritative source for `input` when no explicit structure was given. Formats without an external schema reader (`CSV`, `JSONEachRow`, ...) fall through to the existing `structure_hint` / "please provide structure manually" path and behave as before.

For `Protobuf`/`CapnProto` (which need `format_schema`) the format's own readSchema error now surfaces directly to the user, e.g. `The format Protobuf requires a schema. The corresponding setting should be set.`, which is more actionable than the previous `provide structure manually` message.

Reproducible locally with the new stateless test `04215_input_fixed_schema_format.sh`, which covers `LineAsString`, `RawBLOB`, `JSONAsString`, the original issue's exact shape, the negative case for `CSV`, and that the existing `input('my_col String')` path still works unchanged.

Closes #104532

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The `input` table function now infers its structure from the surrounding `INSERT` query's `FORMAT` clause when that format has a fixed schema (`LineAsString`, `RawBLOB`, `JSONAsString`, etc.), so users no longer have to repeat the structure as `input('line String')` for these formats. [#104532](https://github.com/ClickHouse/ClickHouse/issues/104532).

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!--
Session: cron:clickhouse-ci-task-worker:20260510-151500
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.781`
<!-- ch-version-info:end -->