### PR TITLE
Add regression test for CREATE TABLE AS ... SETTINGS

### DIFF
--- a/tests/queries/0_stateless/04217_create_table_as_with_settings.reference
+++ b/tests/queries/0_stateless/04217_create_table_as_with_settings.reference
@@ -1,0 +1,10 @@
+CREATE TABLE default.t_21389_dst
+(
+    `rank` UInt32,
+    `domain` String,
+    `log` String CODEC(ZSTD(6)),
+    `content` String CODEC(ZSTD(6))
+)
+ENGINE = MergeTree
+ORDER BY domain
+SETTINGS max_compress_block_size = 65536, index_granularity = 8192

--- a/tests/queries/0_stateless/04217_create_table_as_with_settings.sql
+++ b/tests/queries/0_stateless/04217_create_table_as_with_settings.sql
@@ -1,0 +1,23 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/21389
+-- `CREATE TABLE t2 AS t1 SETTINGS ...` (without explicit ENGINE) used to
+-- silently treat SETTINGS as query-level and discard them from the new table.
+
+DROP TABLE IF EXISTS t_21389_src;
+DROP TABLE IF EXISTS t_21389_dst;
+
+CREATE TABLE t_21389_src
+(
+    rank UInt32,
+    domain String,
+    log String CODEC(ZSTD(6)),
+    content String CODEC(ZSTD(6))
+)
+ENGINE = MergeTree
+ORDER BY domain;
+
+CREATE TABLE t_21389_dst AS t_21389_src SETTINGS max_compress_block_size = 65536;
+
+SHOW CREATE TABLE t_21389_dst FORMAT TSVRaw;
+
+DROP TABLE t_21389_dst;
+DROP TABLE t_21389_src;


### PR DESCRIPTION
Adds a regression test for [#21389](https://github.com/ClickHouse/ClickHouse/issues/21389): `CREATE TABLE t2 AS t1 SETTINGS ...` (without an explicit `ENGINE` clause) used to silently treat `SETTINGS` as query-level and discard them from the new table. The behavior is correct on current `master`; this PR locks it in with a test.

Closes #21389.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.502`
<!-- ch-version-info:end -->