### PR TITLE
Add a test for #88558

### DIFF
--- a/tests/queries/0_stateless/04217_array_concat_json_extract_keys_index.reference
+++ b/tests/queries/0_stateless/04217_array_concat_json_extract_keys_index.reference
@@ -1,0 +1,4 @@
+{"cluster":"b","c":1}	{"d":"e","job":"g"}	{}
+{"cluster":"b","c":1}	{"d":"e","job":"g"}	{}
+{"cluster":"b","c":1}	{"d":"e","job":"g"}	{}
+{'cluster':'b','c':'1'}	{'d':'e','job':'g'}	{}

--- a/tests/queries/0_stateless/04217_array_concat_json_extract_keys_index.sql
+++ b/tests/queries/0_stateless/04217_array_concat_json_extract_keys_index.sql
@@ -1,0 +1,48 @@
+-- Test for https://github.com/ClickHouse/ClickHouse/issues/88558
+-- Multiple index conditions over the same `arrayConcat` expression used to throw
+-- `NOT_FOUND_COLUMN_IN_BLOCK`. Fixed by https://github.com/ClickHouse/ClickHouse/pull/94515.
+
+DROP TABLE IF EXISTS t_88558_json;
+
+CREATE TABLE t_88558_json
+(
+    `attribute` String,
+    `resource`  LowCardinality(String),
+    `scope`     LowCardinality(String),
+    INDEX attribute_keys arrayConcat(JSONExtractKeys(attribute), JSONExtractKeys(scope), JSONExtractKeys(resource)) TYPE set(100)
+)
+ENGINE = MergeTree
+ORDER BY (resource)
+AS SELECT '{"cluster":"b","c":1}', '{"d":"e","job":"g"}', '{}';
+
+SELECT * FROM t_88558_json
+WHERE has(arrayConcat(JSONExtractKeys(attribute), JSONExtractKeys(scope), JSONExtractKeys(resource)), 'cluster')
+  AND has(arrayConcat(JSONExtractKeys(attribute), JSONExtractKeys(scope), JSONExtractKeys(resource)), 'job');
+
+SELECT * FROM t_88558_json
+WHERE has(arrayConcat(JSONExtractKeys(attribute), JSONExtractKeys(scope), JSONExtractKeys(resource)), 'cluster');
+
+SELECT * FROM t_88558_json
+WHERE has(arrayConcat(JSONExtractKeys(attribute), JSONExtractKeys(scope), JSONExtractKeys(resource)), 'cluster')
+  AND has(arrayConcat(JSONExtractKeys(attribute), JSONExtractKeys(resource), JSONExtractKeys(scope)), 'job');
+
+DROP TABLE t_88558_json;
+
+DROP TABLE IF EXISTS t_88558_map;
+
+CREATE TABLE t_88558_map
+(
+    `attribute` Map(LowCardinality(String), String),
+    `resource`  Map(LowCardinality(String), String),
+    `scope`     Map(LowCardinality(String), String),
+    INDEX attribute_keys arrayConcat(mapKeys(attribute), mapKeys(scope), mapKeys(resource)) TYPE set(100) GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY (resource)
+AS SELECT map('cluster', 'b', 'c', '1'), map('d', 'e', 'job', 'g'), map();
+
+SELECT * FROM t_88558_map
+WHERE has(arrayConcat(mapKeys(attribute), mapKeys(scope), mapKeys(resource)), 'cluster')
+  AND has(arrayConcat(mapKeys(attribute), mapKeys(scope), mapKeys(resource)), 'job');
+
+DROP TABLE t_88558_map;


### PR DESCRIPTION
Adds a regression test for [#88558](https://github.com/ClickHouse/ClickHouse/issues/88558): `NOT_FOUND_COLUMN_IN_BLOCK` when multiple index conditions reference the same `arrayConcat(JSONExtractKeys(...), ...)` / `arrayConcat(mapKeys(...), ...)` expression.

The underlying bug was already fixed in #94515 (which closes #60660); this PR covers the specific reproducers from #88558 so they don't silently regress.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add a test for #88558.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.504`
<!-- ch-version-info:end -->