### PR TITLE
Configure banner for SSH protocol

### DIFF
--- a/src/Server/SSH/SSHBind.cpp
+++ b/src/Server/SSH/SSHBind.cpp
@@ -41,6 +41,12 @@ void SSHBind::setHostKey(const std::string & key_path)
         throw DB::Exception(DB::ErrorCodes::SSH_EXCEPTION, "Failed setting host key in sshbind due to {}", getError());
 }
 
+void SSHBind::setBanner(const std::string & banner)
+{
+    if (ssh_bind_options_set(bind.get(), SSH_BIND_OPTIONS_BANNER, banner.c_str()) != SSH_OK)
+        throw DB::Exception(DB::ErrorCodes::SSH_EXCEPTION, "Failed setting banner in sshbind due to {}", getError());
+}
+
 String SSHBind::getError()
 {
     return String(ssh_get_error(bind.get()));

--- a/src/Server/SSH/SSHBind.h
+++ b/src/Server/SSH/SSHBind.h
@@ -35,6 +35,9 @@ public:
     // Sets host key for a server. It can be set only one time for each key type.
     // If you provide different keys of one type, the first one will be overwritten.
     void setHostKey(const std::string & key_path);
+    // Sets the server banner (the "softwareversion" part of the SSH identification
+    // string sent right after the "SSH-2.0-" prefix, see RFC 4253 section 4.2).
+    void setBanner(const std::string & banner);
     // Passes external socket to ssh_bind
     void setFd(int fd);
     // Listens on a socket. If it was passed via setFd just read hostkeys

--- a/src/Server/SSH/SSHPtyHandlerFactory.h
+++ b/src/Server/SSH/SSHPtyHandlerFactory.h
@@ -18,6 +18,7 @@
 #include <Common/LibSSHLogger.h>
 #include <Server/SSH/SSHBind.h>
 #include <Server/SSH/SSHSession.h>
+#include <Common/config_version.h>
 
 namespace Poco
 {
@@ -56,6 +57,10 @@ public:
     {
         LOG_INFO(log, "Initializing sshbind");
         ssh_bind.disableDefaultConfig();
+        /// Identify ourselves to ssh clients, similar to how OpenSSH prepends its
+        /// own name to the "SSH-2.0-" prefix (e.g. "SSH-2.0-OpenSSH_8.9p1"). Use
+        /// underscore because RFC 4253 forbids spaces and '-' in this field.
+        ssh_bind.setBanner(std::string("ClickHouse_") + VERSION_STRING);
 
         String prefix = "ssh_server.";
         auto rsa_key = config.getString(prefix + "host_rsa_key", "");


### PR DESCRIPTION
Before:

    $ ncat 127.1 9022
    SSH-2.0-libssh_0.9.8

After:

    $ ncat 127.1 9022
    SSH-2.0-ClickHouse_26.5.1.1

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Configure banner for SSH protocol

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.508`
<!-- ch-version-info:end -->