### PR TITLE
Don't fail flaky integration check on SKIP_LIST-filtered tests

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -769,12 +769,18 @@ tar -czf ./ci/tmp/logs.tar.gz \
         sequential_test_modules = []
         assert not is_sequential
 
-    if is_targeted_check and not parallel_test_modules and not sequential_test_modules:
-        # All targeted tests were stale (removed or renamed since the CIDB record).
-        # This is expected — skip gracefully instead of producing a "no results" error.
+    if (is_targeted_check or is_flaky_check) and not parallel_test_modules and not sequential_test_modules:
+        # Targeted check: all selected tests were stale (removed or renamed since the CIDB record).
+        # Flaky check: all changed tests were filtered out (e.g. by SKIP_LIST in the private fork).
+        # Either way, skip gracefully instead of producing a "no results" error.
+        skip_info = (
+            "All targeted tests are stale (removed or renamed)"
+            if is_targeted_check
+            else "All changed tests were filtered out (e.g. by SKIP_LIST)"
+        )
         Result.create_from(
             status=Result.Status.SKIPPED,
-            info="All targeted tests are stale (removed or renamed)",
+            info=skip_info,
         ).complete_job()
 
     if is_flaky_check or is_targeted_check:

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -758,7 +758,7 @@ tar -czf ./ci/tmp/logs.tar.gz \
             workers,
             args.options,
             info,
-            no_strict=is_targeted_check,  # targeted check might want to run test that was removed on a merge-commit
+            no_strict=is_targeted_check or is_flaky_check,  # targeted check might want to run test that was removed on a merge-commit; flaky check might pick up a changed test filtered out by SKIP_LIST in the private fork
         )
     )
 


### PR DESCRIPTION
The flaky integration test job collects changed test modules from the PR diff and asks `get_parallel_sequential_tests_to_run` to match each one against the parallel/sequential module lists. Without `no_strict`, a changed test that has been filtered out (e.g. by the private fork's `SKIP_LIST` in `ci/jobs/scripts/integration_tests_configs.py`) trips `assert matched, f"Test [{test_arg}] not found"`, killing the whole job.

This is the same concern that already justifies `no_strict=True` for targeted checks (a CIDB-recorded test may be deleted or renamed before the job runs). Extend the relaxation to flaky checks so a `SKIP_LIST`'d test is silently dropped, then mirror the targeted-check empty-selection short-circuit so a flaky job whose entire test list was filtered out is reported as `SKIPPED` instead of falling through to `Result.create_from(results=[], ...)` and being marked `ERROR`.

Unblocks `CH Inc sync` on PRs that modify any test in `SKIP_LIST` (e.g. `test_kafka_bad_messages`), such as #100276 — its sync PR https://github.com/ClickHouse/clickhouse-private/pull/53191 failed in `Integration tests (amd_asan_ubsan, flaky)` with `AssertionError: Test [test_kafka_bad_messages/test.py] not found`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.563`
<!-- ch-version-info:end -->