### PR TITLE
docs: add new `laravel-clickhouse` library to PHP client list

### DIFF
--- a/docs/en/interfaces/third-party/client-libraries.md
+++ b/docs/en/interfaces/third-party/client-libraries.md
@@ -34,6 +34,7 @@ ClickHouse Inc does **not** maintain the libraries listed below and hasn't done 
 - [kolya7k ClickHouse PHP extension](https://github.com//kolya7k/clickhouse-php)
 - [hyvor/clickhouse-php](https://github.com/hyvor/clickhouse-php)
 - [beeterty/clickhouse-php-client](https://github.com/beeterty-technologies/clickhouse-php-client) 
+- [laravel-clickhouse/laravel-clickhouse](https://github.com/laravel-clickhouse/laravel-clickhouse)
 ### Go {#go}
 - [clickhouse](https://github.com/kshvakov/clickhouse/)
 - [go-clickhouse](https://github.com/roistat/go-clickhouse)


### PR DESCRIPTION
### Changelog category (leave one):
- Documentation

### Description

Adds the new PHP Laravel package [`laravel-clickhouse/laravel-clickhouse`](https://github.com/laravel-clickhouse/laravel-clickhouse) to the list of third-party clients.

The package was recently featured in an article on the official Laravel News blog, which was also included in today’s Laravel News newsletter:
- https://laravel-news.com/laravel-clickhouse-a-full-featured-clickhouse-driver-for-laravel


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.541`
<!-- ch-version-info:end -->