### PR TITLE
Add test for #102651

### DIFF
--- a/tests/queries/0_stateless/04228_row_policy_view_join_analyzer_102651.sql
+++ b/tests/queries/0_stateless/04228_row_policy_view_join_analyzer_102651.sql
@@ -1,0 +1,24 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/102651
+-- JOIN of a table with a row policy and a view used to fail under the analyzer with
+-- `NOT_FOUND_COLUMN_IN_BLOCK` for a column referenced by the row policy expression.
+
+DROP ROW POLICY IF EXISTS r_102651 ON t1;
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+DROP VIEW IF EXISTS v;
+
+CREATE TABLE t1 (col Int64, col2 Nullable(Int64), col3 Int64) ENGINE = MergeTree() ORDER BY col;
+CREATE ROW POLICY r_102651 ON t1 USING col2 IS NOT NULL TO ALL;
+INSERT INTO t1 (col, col2, col3) VALUES (0, NULL, 0);
+
+CREATE TABLE t2 (col Int64) ENGINE = MergeTree() ORDER BY col;
+CREATE VIEW v (col Int64) AS SELECT col FROM t2;
+
+SELECT col FROM t1 JOIN t2 ON (t1.col = t2.col) ORDER BY col SETTINGS enable_analyzer = 1;
+SELECT col FROM t1 JOIN v ON (t1.col = v.col) ORDER BY col SETTINGS enable_analyzer = 0;
+SELECT col FROM t1 JOIN v ON (t1.col = v.col) ORDER BY col SETTINGS enable_analyzer = 1;
+
+DROP ROW POLICY r_102651 ON t1;
+DROP VIEW v;
+DROP TABLE t2;
+DROP TABLE t1;


### PR DESCRIPTION
Add a regression test for the `NOT_FOUND_COLUMN_IN_BLOCK` from #102651 (row policy + view JOIN under analyzer). The bug no longer reproduces on master.

Closes #102651.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.536`
<!-- ch-version-info:end -->