### PR TITLE
Add test for #91849

### DIFF
--- a/tests/queries/0_stateless/04224_special_columns_prewhere_final_91849.reference
+++ b/tests/queries/0_stateless/04224_special_columns_prewhere_final_91849.reference
@@ -1,1 +1,10 @@
-ok
+1	test2
+2	test4
+1
+1
+1	test2
+2	test2
+3	test3
+2	test2_updated
+3
+1

--- a/tests/queries/0_stateless/04224_special_columns_prewhere_final_91849.reference
+++ b/tests/queries/0_stateless/04224_special_columns_prewhere_final_91849.reference
@@ -1,10 +1,1 @@
-1	test2
-2	test4
-1
-1
-1	test2
-2	test2
-3	test3
-2	test2_updated
-3
-1
+ok

--- a/tests/queries/0_stateless/04224_special_columns_prewhere_final_91849.reference
+++ b/tests/queries/0_stateless/04224_special_columns_prewhere_final_91849.reference
@@ -1,0 +1,10 @@
+1	test2
+2	test4
+1
+1
+1	test2
+2	test2
+3	test3
+2	test2_updated
+3
+1

--- a/tests/queries/0_stateless/04224_special_columns_prewhere_final_91849.sql
+++ b/tests/queries/0_stateless/04224_special_columns_prewhere_final_91849.sql
@@ -1,6 +1,9 @@
 -- Regression test for https://github.com/ClickHouse/ClickHouse/issues/91849
 -- Special columns (`ver`, `is_deleted`, `sign`) used in `PREWHERE` on `FINAL`
 -- were dropped from the read plan in `ReadFromMergeTree`, causing `NOT_FOUND_COLUMN_IN_BLOCK`.
+-- The test only checks that the queries no longer throw an exception: the exact
+-- result of `PREWHERE` on `FINAL` is not deterministic across all settings combinations
+-- (it depends on whether `PREWHERE` is applied before or after the `FINAL` merge).
 
 DROP TABLE IF EXISTS test_replacing_mt_91849;
 CREATE TABLE test_replacing_mt_91849
@@ -16,7 +19,7 @@ INSERT INTO test_replacing_mt_91849 VALUES
     (2, 'test3', '2020-06-01'),
     (2, 'test4', '2021-06-01');
 
-SELECT key, someCol FROM test_replacing_mt_91849 FINAL PREWHERE ver > '2020-01-01' ORDER BY key;
+SELECT key, someCol FROM test_replacing_mt_91849 FINAL PREWHERE ver > '2020-01-01' ORDER BY key FORMAT Null;
 
 DROP TABLE test_replacing_mt_91849;
 
@@ -36,9 +39,9 @@ INSERT INTO test_replacing_mt_is_deleted_91849 VALUES
     (2, 'test4', 2, 1),
     (3, 'test5', 1, 1);
 
-SELECT count() FROM test_replacing_mt_is_deleted_91849 FINAL PREWHERE ver > 0 AND is_deleted = 0;
-SELECT count(ver) FROM test_replacing_mt_is_deleted_91849 FINAL PREWHERE is_deleted = 0;
-SELECT key, someCol FROM test_replacing_mt_is_deleted_91849 FINAL PREWHERE ver > 0 AND is_deleted = 0 ORDER BY key;
+SELECT count() FROM test_replacing_mt_is_deleted_91849 FINAL PREWHERE ver > 0 AND is_deleted = 0 FORMAT Null;
+SELECT count(ver) FROM test_replacing_mt_is_deleted_91849 FINAL PREWHERE is_deleted = 0 FORMAT Null;
+SELECT key, someCol FROM test_replacing_mt_is_deleted_91849 FINAL PREWHERE ver > 0 AND is_deleted = 0 ORDER BY key FORMAT Null;
 
 DROP TABLE test_replacing_mt_is_deleted_91849;
 
@@ -56,7 +59,7 @@ INSERT INTO test_collapsing_mt_91849 VALUES
     (2, 'test2',  1),
     (3, 'test3',  1);
 
-SELECT key, someCol FROM test_collapsing_mt_91849 FINAL PREWHERE sign = 1 ORDER BY key;
+SELECT key, someCol FROM test_collapsing_mt_91849 FINAL PREWHERE sign = 1 ORDER BY key FORMAT Null;
 
 DROP TABLE test_collapsing_mt_91849;
 
@@ -77,7 +80,9 @@ INSERT INTO test_versioned_collapsing_mt_91849 VALUES
     (2, 'test2_updated',  1, 3),
     (3, 'test3',          1, 1);
 
-SELECT key, someCol FROM test_versioned_collapsing_mt_91849 FINAL PREWHERE sign = 1 AND ver > 1 ORDER BY key;
-SELECT ver FROM test_versioned_collapsing_mt_91849 FINAL PREWHERE sign = 1 ORDER BY key;
+SELECT key, someCol FROM test_versioned_collapsing_mt_91849 FINAL PREWHERE sign = 1 AND ver > 1 ORDER BY key FORMAT Null;
+SELECT ver FROM test_versioned_collapsing_mt_91849 FINAL PREWHERE sign = 1 ORDER BY key FORMAT Null;
 
 DROP TABLE test_versioned_collapsing_mt_91849;
+
+SELECT 'ok';

--- a/tests/queries/0_stateless/04224_special_columns_prewhere_final_91849.sql
+++ b/tests/queries/0_stateless/04224_special_columns_prewhere_final_91849.sql
@@ -1,0 +1,83 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/91849
+-- Special columns (`ver`, `is_deleted`, `sign`) used in `PREWHERE` on `FINAL`
+-- were dropped from the read plan in `ReadFromMergeTree`, causing `NOT_FOUND_COLUMN_IN_BLOCK`.
+
+DROP TABLE IF EXISTS test_replacing_mt_91849;
+CREATE TABLE test_replacing_mt_91849
+(
+    key Int64,
+    someCol String,
+    ver DateTime
+) ENGINE = ReplacingMergeTree(ver) ORDER BY key;
+
+INSERT INTO test_replacing_mt_91849 VALUES
+    (1, 'test1', '2020-01-01'),
+    (1, 'test2', '2021-01-01'),
+    (2, 'test3', '2020-06-01'),
+    (2, 'test4', '2021-06-01');
+
+SELECT key, someCol FROM test_replacing_mt_91849 FINAL PREWHERE ver > '2020-01-01' ORDER BY key;
+
+DROP TABLE test_replacing_mt_91849;
+
+DROP TABLE IF EXISTS test_replacing_mt_is_deleted_91849;
+CREATE TABLE test_replacing_mt_is_deleted_91849
+(
+    key Int64,
+    someCol String,
+    ver UInt64,
+    is_deleted UInt8
+) ENGINE = ReplacingMergeTree(ver, is_deleted) ORDER BY key;
+
+INSERT INTO test_replacing_mt_is_deleted_91849 VALUES
+    (1, 'test1', 1, 0),
+    (1, 'test2', 2, 0),
+    (2, 'test3', 1, 0),
+    (2, 'test4', 2, 1),
+    (3, 'test5', 1, 1);
+
+SELECT count() FROM test_replacing_mt_is_deleted_91849 FINAL PREWHERE ver > 0 AND is_deleted = 0;
+SELECT count(ver) FROM test_replacing_mt_is_deleted_91849 FINAL PREWHERE is_deleted = 0;
+SELECT key, someCol FROM test_replacing_mt_is_deleted_91849 FINAL PREWHERE ver > 0 AND is_deleted = 0 ORDER BY key;
+
+DROP TABLE test_replacing_mt_is_deleted_91849;
+
+DROP TABLE IF EXISTS test_collapsing_mt_91849;
+CREATE TABLE test_collapsing_mt_91849
+(
+    key Int64,
+    someCol String,
+    sign Int8
+) ENGINE = CollapsingMergeTree(sign) ORDER BY key;
+
+INSERT INTO test_collapsing_mt_91849 VALUES
+    (1, 'test1',  1),
+    (1, 'test1', -1),
+    (2, 'test2',  1),
+    (3, 'test3',  1);
+
+SELECT key, someCol FROM test_collapsing_mt_91849 FINAL PREWHERE sign = 1 ORDER BY key;
+
+DROP TABLE test_collapsing_mt_91849;
+
+DROP TABLE IF EXISTS test_versioned_collapsing_mt_91849;
+CREATE TABLE test_versioned_collapsing_mt_91849
+(
+    key Int64,
+    someCol String,
+    sign Int8,
+    ver UInt64
+) ENGINE = VersionedCollapsingMergeTree(sign, ver) ORDER BY key;
+
+INSERT INTO test_versioned_collapsing_mt_91849 VALUES
+    (1, 'test1',          1, 1),
+    (1, 'test1',         -1, 1),
+    (2, 'test2',          1, 2),
+    (2, 'test2_updated', -1, 2),
+    (2, 'test2_updated',  1, 3),
+    (3, 'test3',          1, 1);
+
+SELECT key, someCol FROM test_versioned_collapsing_mt_91849 FINAL PREWHERE sign = 1 AND ver > 1 ORDER BY key;
+SELECT ver FROM test_versioned_collapsing_mt_91849 FINAL PREWHERE sign = 1 ORDER BY key;
+
+DROP TABLE test_versioned_collapsing_mt_91849;

--- a/tests/queries/0_stateless/04224_special_columns_prewhere_final_91849.sql
+++ b/tests/queries/0_stateless/04224_special_columns_prewhere_final_91849.sql
@@ -1,9 +1,12 @@
 -- Regression test for https://github.com/ClickHouse/ClickHouse/issues/91849
 -- Special columns (`ver`, `is_deleted`, `sign`) used in `PREWHERE` on `FINAL`
 -- were dropped from the read plan in `ReadFromMergeTree`, causing `NOT_FOUND_COLUMN_IN_BLOCK`.
--- The test only checks that the queries no longer throw an exception: the exact
--- result of `PREWHERE` on `FINAL` is not deterministic across all settings combinations
--- (it depends on whether `PREWHERE` is applied before or after the `FINAL` merge).
+--
+-- `OPTIMIZE FINAL` is used to merge all parts into one before the SELECT, so
+-- the result of `PREWHERE` on `FINAL` is deterministic regardless of whether
+-- `PREWHERE` is applied before or after the `FINAL` merge (settings like
+-- `enable_vertical_final`, `query_plan_optimize_prewhere`, etc. would otherwise
+-- affect the output).
 
 DROP TABLE IF EXISTS test_replacing_mt_91849;
 CREATE TABLE test_replacing_mt_91849
@@ -19,7 +22,9 @@ INSERT INTO test_replacing_mt_91849 VALUES
     (2, 'test3', '2020-06-01'),
     (2, 'test4', '2021-06-01');
 
-SELECT key, someCol FROM test_replacing_mt_91849 FINAL PREWHERE ver > '2020-01-01' ORDER BY key FORMAT Null;
+OPTIMIZE TABLE test_replacing_mt_91849 FINAL;
+
+SELECT key, someCol FROM test_replacing_mt_91849 FINAL PREWHERE ver > '2020-01-01' ORDER BY key;
 
 DROP TABLE test_replacing_mt_91849;
 
@@ -39,9 +44,11 @@ INSERT INTO test_replacing_mt_is_deleted_91849 VALUES
     (2, 'test4', 2, 1),
     (3, 'test5', 1, 1);
 
-SELECT count() FROM test_replacing_mt_is_deleted_91849 FINAL PREWHERE ver > 0 AND is_deleted = 0 FORMAT Null;
-SELECT count(ver) FROM test_replacing_mt_is_deleted_91849 FINAL PREWHERE is_deleted = 0 FORMAT Null;
-SELECT key, someCol FROM test_replacing_mt_is_deleted_91849 FINAL PREWHERE ver > 0 AND is_deleted = 0 ORDER BY key FORMAT Null;
+OPTIMIZE TABLE test_replacing_mt_is_deleted_91849 FINAL;
+
+SELECT count() FROM test_replacing_mt_is_deleted_91849 FINAL PREWHERE ver > 0 AND is_deleted = 0;
+SELECT count(ver) FROM test_replacing_mt_is_deleted_91849 FINAL PREWHERE is_deleted = 0;
+SELECT key, someCol FROM test_replacing_mt_is_deleted_91849 FINAL PREWHERE ver > 0 AND is_deleted = 0 ORDER BY key;
 
 DROP TABLE test_replacing_mt_is_deleted_91849;
 
@@ -59,7 +66,9 @@ INSERT INTO test_collapsing_mt_91849 VALUES
     (2, 'test2',  1),
     (3, 'test3',  1);
 
-SELECT key, someCol FROM test_collapsing_mt_91849 FINAL PREWHERE sign = 1 ORDER BY key FORMAT Null;
+OPTIMIZE TABLE test_collapsing_mt_91849 FINAL;
+
+SELECT key, someCol FROM test_collapsing_mt_91849 FINAL PREWHERE sign = 1 ORDER BY key;
 
 DROP TABLE test_collapsing_mt_91849;
 
@@ -80,9 +89,9 @@ INSERT INTO test_versioned_collapsing_mt_91849 VALUES
     (2, 'test2_updated',  1, 3),
     (3, 'test3',          1, 1);
 
-SELECT key, someCol FROM test_versioned_collapsing_mt_91849 FINAL PREWHERE sign = 1 AND ver > 1 ORDER BY key FORMAT Null;
-SELECT ver FROM test_versioned_collapsing_mt_91849 FINAL PREWHERE sign = 1 ORDER BY key FORMAT Null;
+OPTIMIZE TABLE test_versioned_collapsing_mt_91849 FINAL;
+
+SELECT key, someCol FROM test_versioned_collapsing_mt_91849 FINAL PREWHERE sign = 1 AND ver > 1 ORDER BY key;
+SELECT ver FROM test_versioned_collapsing_mt_91849 FINAL PREWHERE sign = 1 ORDER BY key;
 
 DROP TABLE test_versioned_collapsing_mt_91849;
-
-SELECT 'ok';


### PR DESCRIPTION
Add a regression test for the `NOT_FOUND_COLUMN_IN_BLOCK` from #91849 (special columns (`ver`, `is_deleted`, `sign`) with `PREWHERE` on `FINAL`). The bug no longer reproduces on master.

Closes #91849.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.565`
<!-- ch-version-info:end -->