### PR TITLE
Add functions arrayTopK and arrayBottomK

### DIFF
--- a/src/Functions/array/arrayTopK.cpp
+++ b/src/Functions/array/arrayTopK.cpp
@@ -8,6 +8,7 @@
 #include <Columns/ColumnsDateTime.h>
 #include <Columns/ColumnsNumber.h>
 #include <Functions/FunctionFactory.h>
+#include <Functions/castTypeToEither.h>
 #include <base/sort.h>
 
 
@@ -16,6 +17,7 @@ namespace DB
 
 namespace ErrorCodes
 {
+    extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
 }
 
@@ -35,10 +37,11 @@ struct Less
 
     bool operator()(size_t lhs, size_t rhs) const
     {
-        if constexpr (IsAscending)
-            return column.compareAt(lhs, rhs, column, 1) < 0;
-        else
-            return column.compareAt(lhs, rhs, column, -1) > 0;
+        int c = column.compareAt(lhs, rhs, column, IsAscending ? 1 : -1);
+        if (c != 0)
+            return IsAscending ? c < 0 : c > 0;
+        /// Make the result deterministic: equal elements keep their original order.
+        return lhs < rhs;
     }
 };
 
@@ -52,21 +55,26 @@ struct GenericLess
 
     bool operator()(size_t lhs, size_t rhs) const
     {
-        if constexpr (IsAscending)
-            return column.compareAt(lhs, rhs, column, 1) < 0;
-        else
-            return column.compareAt(lhs, rhs, column, -1) > 0;
+        int c = column.compareAt(lhs, rhs, column, IsAscending ? 1 : -1);
+        if (c != 0)
+            return IsAscending ? c < 0 : c > 0;
+        /// Make the result deterministic: equal elements keep their original order.
+        return lhs < rhs;
     }
 };
 
-/// Reads K[row] from the K column and clamps negatives (signed columns) to 0.
-size_t readK(const IColumn & k_column, bool k_is_signed, size_t row)
+/// Reads K[row] from the K column and rejects negatives (signed columns).
+size_t readK(const IColumn & k_column, bool k_is_signed, size_t row, const char * function_name)
 {
     const UInt64 k = k_column.getUInt(row);
     /// For a signed K column, a negative value is reinterpreted as a huge UInt64 with the high bit set;
-    /// detect that and clamp to 0.
+    /// detect that and throw.
     if (k_is_signed && k > static_cast<UInt64>(std::numeric_limits<Int64>::max()))
-        return 0;
+        throw Exception(
+            ErrorCodes::BAD_ARGUMENTS,
+            "Argument K of function {} must be non-negative, got {}",
+            function_name,
+            static_cast<Int64>(k));
     return k;
 }
 
@@ -77,7 +85,8 @@ ColumnPtr applyComparator(
     const IColumn & k_column,
     bool k_is_signed,
     const ColumnArray & source,
-    const IColumn & mapped)
+    const IColumn & mapped,
+    const char * function_name)
 {
     const auto & offsets = source.getOffsets();
     const size_t size = offsets.size();
@@ -100,14 +109,14 @@ ColumnPtr applyComparator(
 
     /// Smaller reserve when K is constant.
     if (isColumnConst(k_column))
-        indexes.reserve(std::min(readK(k_column, k_is_signed, 0) * size, nested_size));
+        indexes.reserve(std::min(readK(k_column, k_is_signed, 0, function_name) * size, nested_size));
     else
         indexes.reserve(nested_size);
 
     auto result_offsets_column = ColumnArray::ColumnOffsets::create(size);
     auto & result_offsets = result_offsets_column->getData();
 
-    PaddedPODArray<size_t> row_indices;
+    IColumn::Permutation row_indices;
     ColumnArray::Offset current_offset = 0;
     ColumnArray::Offset result_offset = 0;
 
@@ -116,7 +125,7 @@ ColumnPtr applyComparator(
     {
         const auto next_offset = offsets[i];
 
-        const size_t k = readK(k_column, k_is_signed, i);
+        const size_t k = readK(k_column, k_is_signed, i, function_name);
         if (!k)
         {
             result_offsets[i] = result_offset;
@@ -159,7 +168,8 @@ ColumnPtr dispatchByColumn(
     const IColumn & k_column,
     bool k_is_signed,
     const ColumnArray & source,
-    const IColumn & mapped)
+    const IColumn & mapped,
+    const char * function_name)
 {
     /// A constant lambda (e.g. `(x) -> NULL`) gives `mapped` as `ColumnConst(Nullable(...))`.
     /// Materialize it so the `Nullable` peel below and the null-map access in `applyComparator` work uniformly.
@@ -170,33 +180,39 @@ ColumnPtr dispatchByColumn(
     if (const auto * mapped_nullable = checkAndGetColumn<ColumnNullable>(mapped_full.get()))
         mapped_data = &mapped_nullable->getNestedColumn();
 
-#define DISPATCH(TYPE) \
-    if (checkAndGetColumn<TYPE>(mapped_data)) \
-    { \
-        using LessT = Less<IsAscending, TYPE>; \
-        return applyComparator<LessT>(k_column, k_is_signed, source, *mapped_full); \
-    }
+    /// Try using specialized comparator Less<>.
+    ColumnPtr result;
+    bool dispatched = castTypeToEither<
+        ColumnUInt8,
+        ColumnUInt16,
+        ColumnUInt32,
+        ColumnUInt64,
+        ColumnInt8,
+        ColumnInt16,
+        ColumnInt32,
+        ColumnInt64,
+        ColumnFloat32,
+        ColumnFloat64,
+        ColumnDateTime64,
+        ColumnDecimal<Decimal32>,
+        ColumnDecimal<Decimal64>,
+        ColumnDecimal<Decimal128>,
+        ColumnDecimal<Decimal256>,
+        ColumnString,
+        ColumnFixedString>(
+        mapped_data,
+        [&](const auto & column)
+        {
+            using ColumnT = std::decay_t<decltype(column)>;
+            result = applyComparator<Less<IsAscending, ColumnT>>(k_column, k_is_signed, source, *mapped_full, function_name);
+            return true;
+        });
 
-    DISPATCH(ColumnUInt8)
-    DISPATCH(ColumnUInt16)
-    DISPATCH(ColumnUInt32)
-    DISPATCH(ColumnUInt64)
-    DISPATCH(ColumnInt8)
-    DISPATCH(ColumnInt16)
-    DISPATCH(ColumnInt32)
-    DISPATCH(ColumnInt64)
-    DISPATCH(ColumnFloat32)
-    DISPATCH(ColumnFloat64)
-    DISPATCH(ColumnDateTime64)
-    DISPATCH(ColumnDecimal<Decimal32>)
-    DISPATCH(ColumnDecimal<Decimal64>)
-    DISPATCH(ColumnDecimal<Decimal128>)
-    DISPATCH(ColumnDecimal<Decimal256>)
-    DISPATCH(ColumnString)
-    DISPATCH(ColumnFixedString)
-#undef DISPATCH
+    if (dispatched)
+        return result;
 
-    return applyComparator<GenericLess<IsAscending>>(k_column, k_is_signed, source, *mapped_full);
+    /// Fall back to GenericLess<>.
+    return applyComparator<GenericLess<IsAscending>>(k_column, k_is_signed, source, *mapped_full, function_name);
 }
 
 }
@@ -207,16 +223,18 @@ ColumnPtr ArrayTopKImpl<IsAscending>::execute(
     ColumnPtr mapped,
     const ColumnWithTypeAndName * fixed_arguments)
 {
+    const char * function_name = IsAscending ? "arrayBottomK" : "arrayTopK";
+
     if (!fixed_arguments)
         throw Exception(
             ErrorCodes::LOGICAL_ERROR,
             "Expected fixed arguments to get K for {}",
-            IsAscending ? "arrayBottomK" : "arrayTopK");
+            function_name);
 
     const IColumn & k_column = *fixed_arguments[0].column;
-    const bool k_is_signed = WhichDataType(fixed_arguments[0].type.get()).isNativeInt();
+    const bool k_is_signed = isNativeInt(*fixed_arguments[0].type);
 
-    return dispatchByColumn<IsAscending>(k_column, k_is_signed, array, *mapped);
+    return dispatchByColumn<IsAscending>(k_column, k_is_signed, array, *mapped, function_name);
 }
 
 REGISTER_FUNCTION(ArrayTopK)
@@ -238,7 +256,7 @@ See also `arrayBottomK`, which returns the K smallest elements instead.
     FunctionDocumentation::Syntax syntax = "arrayTopK([f,] K, arr [, arr1, ... ,arrN])";
     FunctionDocumentation::Arguments arguments = {
         {"f(arr[, arr1, ... ,arrN])", "Optional. A lambda function to compute the sort key for each element.", {"Lambda function"}},
-        {"K", "The number of largest elements to return.", {"(U)Int*"}},
+        {"K", "The number of largest elements to return.", {"(U)Int8/16/32/64"}},
         {"arr", "An array.", {"Array(T)"}},
         {"arr1, ... ,arrN", "N additional arrays, in the case when `f` accepts multiple arguments.", {"Array(T)"}}
     };
@@ -283,7 +301,7 @@ also keeps the remaining elements in unspecified order, and does not skip nulls.
     FunctionDocumentation::Syntax syntax = "arrayBottomK([f,] K, arr [, arr1, ... ,arrN])";
     FunctionDocumentation::Arguments arguments = {
         {"f(arr[, arr1, ... ,arrN])", "Optional. A lambda function to compute the sort key for each element.", {"Lambda function"}},
-        {"K", "The number of smallest elements to return.", {"(U)Int*"}},
+        {"K", "The number of smallest elements to return.", {"(U)Int8/16/32/64"}},
         {"arr", "An array.", {"Array(T)"}},
         {"arr1, ... ,arrN", "N additional arrays, in the case when `f` accepts multiple arguments.", {"Array(T)"}}
     };

--- a/src/Functions/array/arrayTopK.cpp
+++ b/src/Functions/array/arrayTopK.cpp
@@ -1,0 +1,308 @@
+#include <Functions/array/arrayTopK.h>
+
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnDecimal.h>
+#include <Columns/ColumnFixedString.h>
+#include <Columns/ColumnNullable.h>
+#include <Columns/ColumnString.h>
+#include <Columns/ColumnsDateTime.h>
+#include <Columns/ColumnsNumber.h>
+#include <Functions/FunctionFactory.h>
+#include <base/sort.h>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+
+namespace
+{
+
+/// Comparator specialized for a concrete column type so `compareAt` is devirtualized and can be inlined.
+template <bool IsAscending, typename ColumnType>
+struct Less
+{
+    const ColumnType & column;
+
+    explicit Less(const IColumn & column_)
+        : column(assert_cast<const ColumnType &>(column_))
+    {
+    }
+
+    bool operator()(size_t lhs, size_t rhs) const
+    {
+        if constexpr (IsAscending)
+            return column.compareAt(lhs, rhs, column, 1) < 0;
+        else
+            return column.compareAt(lhs, rhs, column, -1) > 0;
+    }
+};
+
+/// Comparator fallback for column types not covered by the specialized dispatch — uses virtual `compareAt`.
+template <bool IsAscending>
+struct GenericLess
+{
+    const IColumn & column;
+
+    explicit GenericLess(const IColumn & column_) : column(column_) {}
+
+    bool operator()(size_t lhs, size_t rhs) const
+    {
+        if constexpr (IsAscending)
+            return column.compareAt(lhs, rhs, column, 1) < 0;
+        else
+            return column.compareAt(lhs, rhs, column, -1) > 0;
+    }
+};
+
+/// Reads K[row] from the K column and clamps negatives (signed columns) to 0.
+size_t readK(const IColumn & k_column, bool k_is_signed, size_t row)
+{
+    const UInt64 k = k_column.getUInt(row);
+    /// For a signed K column, a negative value is reinterpreted as a huge UInt64 with the high bit set;
+    /// detect that and clamp to 0.
+    if (k_is_signed && k > static_cast<UInt64>(std::numeric_limits<Int64>::max()))
+        return 0;
+    return k;
+}
+
+/// K-selection pass for a single call, specialized at compile time on the comparator type.
+/// Builds the result `ColumnArray`.
+template <typename Comparator>
+ColumnPtr applyComparator(
+    const IColumn & k_column,
+    bool k_is_signed,
+    const ColumnArray & source,
+    const IColumn & mapped)
+{
+    const auto & offsets = source.getOffsets();
+    const size_t size = offsets.size();
+    const size_t nested_size = source.getData().size();
+
+    /// Peel `Nullable` from `mapped` so the specialized `Less<T>` matches the underlying type,
+    /// and cache the null maps for direct array access in the inner loop.
+    const auto * mapped_nullable = checkAndGetColumn<ColumnNullable>(&mapped);
+    const IColumn & mapped_data = mapped_nullable ? mapped_nullable->getNestedColumn() : mapped;
+    const NullMap * mapped_null_map = mapped_nullable ? &mapped_nullable->getNullMapData() : nullptr;
+
+    /// Same peel for the source data column; the non-null nested column is what we use to build
+    /// the result (matches the declared return type).
+    const auto * source_nullable = checkAndGetColumn<ColumnNullable>(&source.getData());
+    const IColumn & source_data = source_nullable ? source_nullable->getNestedColumn() : source.getData();
+    const NullMap * source_null_map = source_nullable ? &source_nullable->getNullMapData() : nullptr;
+
+    auto indexes_column = ColumnUInt64::create();
+    auto & indexes = indexes_column->getData();
+
+    /// Smaller reserve when K is constant.
+    if (isColumnConst(k_column))
+        indexes.reserve(std::min(readK(k_column, k_is_signed, 0) * size, nested_size));
+    else
+        indexes.reserve(nested_size);
+
+    auto result_offsets_column = ColumnArray::ColumnOffsets::create(size);
+    auto & result_offsets = result_offsets_column->getData();
+
+    PaddedPODArray<size_t> row_indices;
+    ColumnArray::Offset current_offset = 0;
+    ColumnArray::Offset result_offset = 0;
+
+    Comparator cmp(mapped_data);
+    for (size_t i = 0; i < size; ++i)
+    {
+        const auto next_offset = offsets[i];
+
+        const size_t k = readK(k_column, k_is_signed, i);
+        if (!k)
+        {
+            result_offsets[i] = result_offset;
+            current_offset = next_offset;
+            continue;
+        }
+
+        row_indices.clear();
+        row_indices.reserve(next_offset - current_offset);
+        for (size_t j = current_offset; j < next_offset; ++j)
+        {
+            if (mapped_null_map && (*mapped_null_map)[j])
+                continue;
+            if (source_null_map && (*source_null_map)[j])
+                continue;
+            row_indices.push_back(j);
+        }
+
+        const size_t take = std::min(k, row_indices.size());
+
+        if (take == row_indices.size())
+            ::sort(row_indices.begin(), row_indices.end(), cmp);
+        else
+            ::partial_sort(row_indices.begin(), row_indices.begin() + take, row_indices.end(), cmp);
+
+        for (size_t j = 0; j < take; ++j)
+            indexes.push_back(row_indices[j]);
+
+        result_offset += take;
+        result_offsets[i] = result_offset;
+        current_offset = next_offset;
+    }
+
+    return ColumnArray::create(source_data.index(*indexes_column, 0), std::move(result_offsets_column));
+}
+
+/// Iterates the specialized-column type list, falling back to `GenericLess`.
+template <bool IsAscending>
+ColumnPtr dispatchByColumn(
+    const IColumn & k_column,
+    bool k_is_signed,
+    const ColumnArray & source,
+    const IColumn & mapped)
+{
+    /// A constant lambda (e.g. `(x) -> NULL`) gives `mapped` as `ColumnConst(Nullable(...))`.
+    /// Materialize it so the `Nullable` peel below and the null-map access in `applyComparator` work uniformly.
+    auto mapped_full = mapped.convertToFullColumnIfConst();
+
+    /// To match a specialized `Less<T>` we look at the type underneath any `Nullable` wrapper.
+    const IColumn * mapped_data = mapped_full.get();
+    if (const auto * mapped_nullable = checkAndGetColumn<ColumnNullable>(mapped_full.get()))
+        mapped_data = &mapped_nullable->getNestedColumn();
+
+#define DISPATCH(TYPE) \
+    if (checkAndGetColumn<TYPE>(mapped_data)) \
+    { \
+        using LessT = Less<IsAscending, TYPE>; \
+        return applyComparator<LessT>(k_column, k_is_signed, source, *mapped_full); \
+    }
+
+    DISPATCH(ColumnUInt8)
+    DISPATCH(ColumnUInt16)
+    DISPATCH(ColumnUInt32)
+    DISPATCH(ColumnUInt64)
+    DISPATCH(ColumnInt8)
+    DISPATCH(ColumnInt16)
+    DISPATCH(ColumnInt32)
+    DISPATCH(ColumnInt64)
+    DISPATCH(ColumnFloat32)
+    DISPATCH(ColumnFloat64)
+    DISPATCH(ColumnDateTime64)
+    DISPATCH(ColumnDecimal<Decimal32>)
+    DISPATCH(ColumnDecimal<Decimal64>)
+    DISPATCH(ColumnDecimal<Decimal128>)
+    DISPATCH(ColumnDecimal<Decimal256>)
+    DISPATCH(ColumnString)
+    DISPATCH(ColumnFixedString)
+#undef DISPATCH
+
+    return applyComparator<GenericLess<IsAscending>>(k_column, k_is_signed, source, *mapped_full);
+}
+
+}
+
+template <bool IsAscending>
+ColumnPtr ArrayTopKImpl<IsAscending>::execute(
+    const ColumnArray & array,
+    ColumnPtr mapped,
+    const ColumnWithTypeAndName * fixed_arguments)
+{
+    if (!fixed_arguments)
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Expected fixed arguments to get K for {}",
+            IsAscending ? "arrayBottomK" : "arrayTopK");
+
+    const IColumn & k_column = *fixed_arguments[0].column;
+    const bool k_is_signed = WhichDataType(fixed_arguments[0].type.get()).isNativeInt();
+
+    return dispatchByColumn<IsAscending>(k_column, k_is_signed, array, *mapped);
+}
+
+REGISTER_FUNCTION(ArrayTopK)
+{
+    FunctionDocumentation::Description description = R"(
+Returns an array of the K largest elements of the input array, sorted in descending order.
+If a lambda function `f` is specified, elements are compared by the result of `f` applied to each element.
+If `f` accepts multiple arguments, additional arrays are passed to `arrayTopK`, their elements
+correspond to the arguments of `f`.
+
+`NULL` values are skipped and do not appear in the result. The result size is at most `K`
+and may be smaller when the input array contains fewer non-null elements than `K`.
+The element type of the result is the non-nullable counterpart of the input element type.
+
+`arrayTopK` is a [higher-order function](/sql-reference/functions/overview#higher-order-functions).
+
+See also `arrayBottomK`, which returns the K smallest elements instead.
+    )";
+    FunctionDocumentation::Syntax syntax = "arrayTopK([f,] K, arr [, arr1, ... ,arrN])";
+    FunctionDocumentation::Arguments arguments = {
+        {"f(arr[, arr1, ... ,arrN])", "Optional. A lambda function to compute the sort key for each element.", {"Lambda function"}},
+        {"K", "The number of largest elements to return.", {"(U)Int*"}},
+        {"arr", "An array.", {"Array(T)"}},
+        {"arr1, ... ,arrN", "N additional arrays, in the case when `f` accepts multiple arguments.", {"Array(T)"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {R"(
+Returns up to `K` elements of `arr` with the largest values (or largest lambda results), sorted in descending order.
+Nulls are skipped. The returned array has element type `T` even when the input has type `Nullable(T)`.
+    )"};
+    FunctionDocumentation::Examples examples = {
+        {"simple_int", "SELECT arrayTopK(3, [1, 5, 2, 7, 3])", "[7,5,3]"},
+        {"skip_nulls", "SELECT arrayTopK(3, [1, NULL, 5, 2, NULL, 7])", "[7,5,2]"},
+        {"fewer_than_k", "SELECT arrayTopK(5, [1, NULL, 2])", "[2,1]"},
+        {"lambda_simple", "SELECT arrayTopK((x) -> -x, 2, [5, 9, 1, 3])", "[1,3]"},
+        {"lambda_multi", "SELECT arrayTopK((x, y) -> y, 2, ['a', 'b', 'c'], [3, 1, 2])", "['a','c']"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {26, 5};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Array;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionArrayTopK>(documentation);
+}
+
+REGISTER_FUNCTION(ArrayBottomK)
+{
+    FunctionDocumentation::Description description = R"(
+Returns an array of the K smallest elements of the input array, sorted in ascending order.
+If a lambda function `f` is specified, elements are compared by the result of `f` applied to each element.
+If `f` accepts multiple arguments, additional arrays are passed to `arrayBottomK`, their elements
+correspond to the arguments of `f`.
+
+`NULL` values are skipped and do not appear in the result. The result size is at most `K`
+and may be smaller when the input array contains fewer non-null elements than `K`.
+The element type of the result is the non-nullable counterpart of the input element type.
+
+`arrayBottomK` is a [higher-order function](/sql-reference/functions/overview#higher-order-functions).
+
+See also:
+
+- `arrayTopK`, which returns the K largest elements instead.
+- `arrayPartialSort`, which produces the same K elements at positions `[1..K]` but
+also keeps the remaining elements in unspecified order, and does not skip nulls.
+    )";
+    FunctionDocumentation::Syntax syntax = "arrayBottomK([f,] K, arr [, arr1, ... ,arrN])";
+    FunctionDocumentation::Arguments arguments = {
+        {"f(arr[, arr1, ... ,arrN])", "Optional. A lambda function to compute the sort key for each element.", {"Lambda function"}},
+        {"K", "The number of smallest elements to return.", {"(U)Int*"}},
+        {"arr", "An array.", {"Array(T)"}},
+        {"arr1, ... ,arrN", "N additional arrays, in the case when `f` accepts multiple arguments.", {"Array(T)"}}
+    };
+    FunctionDocumentation::ReturnedValue returned_value = {R"(
+Returns up to `K` elements of `arr` with the smallest values (or smallest lambda results), sorted in ascending order.
+Nulls are skipped. The returned array has element type `T` even when the input has type `Nullable(T)`.
+    )"};
+    FunctionDocumentation::Examples examples = {
+        {"simple_int", "SELECT arrayBottomK(3, [1, 5, 2, 7, 3])", "[1,2,3]"},
+        {"skip_nulls", "SELECT arrayBottomK(3, [1, NULL, 5, 2, NULL, 7])", "[1,2,5]"},
+        {"fewer_than_k", "SELECT arrayBottomK(5, [1, NULL, 2])", "[1,2]"},
+        {"lambda_simple", "SELECT arrayBottomK((x) -> -x, 2, [5, 9, 1, 3])", "[9,5]"},
+        {"lambda_multi", "SELECT arrayBottomK((x, y) -> y, 2, ['a', 'b', 'c'], [3, 1, 2])", "['b','c']"}
+    };
+    FunctionDocumentation::IntroducedIn introduced_in = {26, 5};
+    FunctionDocumentation::Category category = FunctionDocumentation::Category::Array;
+    FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
+
+    factory.registerFunction<FunctionArrayBottomK>(documentation);
+}
+
+}

--- a/src/Functions/array/arrayTopK.cpp
+++ b/src/Functions/array/arrayTopK.cpp
@@ -271,7 +271,7 @@ Nulls are skipped. The returned array has element type `T` even when the input h
         {"lambda_simple", "SELECT arrayTopK((x) -> -x, 2, [5, 9, 1, 3])", "[1,3]"},
         {"lambda_multi", "SELECT arrayTopK((x, y) -> y, 2, ['a', 'b', 'c'], [3, 1, 2])", "['a','c']"}
     };
-    FunctionDocumentation::IntroducedIn introduced_in = {26, 5};
+    FunctionDocumentation::IntroducedIn introduced_in = {26, 6};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::Array;
     FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 

--- a/src/Functions/array/arrayTopK.cpp
+++ b/src/Functions/array/arrayTopK.cpp
@@ -316,7 +316,7 @@ Nulls are skipped. The returned array has element type `T` even when the input h
         {"lambda_simple", "SELECT arrayBottomK((x) -> -x, 2, [5, 9, 1, 3])", "[9,5]"},
         {"lambda_multi", "SELECT arrayBottomK((x, y) -> y, 2, ['a', 'b', 'c'], [3, 1, 2])", "['b','c']"}
     };
-    FunctionDocumentation::IntroducedIn introduced_in = {26, 5};
+    FunctionDocumentation::IntroducedIn introduced_in = {26, 6};
     FunctionDocumentation::Category category = FunctionDocumentation::Category::Array;
     FunctionDocumentation documentation = {description, syntax, arguments, {}, returned_value, examples, introduced_in, category};
 

--- a/src/Functions/array/arrayTopK.h
+++ b/src/Functions/array/arrayTopK.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <DataTypes/DataTypeArray.h>
+#include <DataTypes/DataTypeNullable.h>
+#include <Functions/array/FunctionArrayMapped.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int ILLEGAL_TYPE_OF_ARGUMENT;
+    extern const int LOGICAL_ERROR;
+}
+
+
+/** Return the top K (largest) or bottom K (smallest) elements of an array, sorted.
+  * Nulls are skipped and not present in the result, so the result's element type
+  * is the non-nullable counterpart of the input array's element type, and the
+  * result may be shorter than K.
+  */
+template <bool IsAscending>
+struct ArrayTopKImpl
+{
+    /// The K argument is required.
+    static constexpr auto num_fixed_params = 1;
+
+    /// Lambda is optional.
+    static bool needExpression() { return false; }
+
+    /// Lambda can return any type.
+    static bool needBoolean() { return false; }
+
+    /// Additional arrays can be specified with arguments for lambda.
+    static bool needOneArray() { return false; }
+
+    static DataTypePtr getReturnType(const DataTypePtr & /*expression_return*/, const DataTypePtr & array_element)
+    {
+        /// `LowCardinality` is already stripped recursively by IFunctionOverloadResolver::getReturnType()
+        /// (via the default `useDefaultImplementationForLowCardinalityColumns`), so only `Nullable` is left to handle.
+        chassert(!array_element->lowCardinality());
+        return std::make_shared<DataTypeArray>(removeNullable(array_element));
+    }
+
+    static void checkArguments(
+        const String & name,
+        const ColumnWithTypeAndName * fixed_arguments)
+    {
+        if (!fixed_arguments)
+            throw Exception(
+                ErrorCodes::LOGICAL_ERROR,
+                "Expected fixed arguments to get K for {}", name);
+
+        WhichDataType which(fixed_arguments[0].type.get());
+        if (!which.isNativeInteger())
+            throw Exception(
+                ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
+                "Illegal type {} of the K argument of function {} (must be a native integer: UInt8/16/32/64 or Int8/16/32/64)",
+                fixed_arguments[0].type->getName(),
+                name);
+    }
+
+    static ColumnPtr execute(
+        const ColumnArray & array,
+        ColumnPtr mapped,
+        const ColumnWithTypeAndName * fixed_arguments);
+};
+
+struct NameArrayTopK
+{
+    static constexpr auto name = "arrayTopK";
+};
+struct NameArrayBottomK
+{
+    static constexpr auto name = "arrayBottomK";
+};
+
+/// `arrayBottomK` returns the K smallest elements in ascending order.
+/// `arrayTopK` returns the K largest elements in descending order.
+/// Both use `partial_sort` internally; in the presence of ties in the sort key
+/// the choice among equal keys is unspecified.
+using FunctionArrayBottomK = FunctionArrayMapped<ArrayTopKImpl</* IsAscending = */ true>, NameArrayBottomK, /* IsDeterministic = */ false>;
+using FunctionArrayTopK = FunctionArrayMapped<ArrayTopKImpl</* IsAscending = */ false>, NameArrayTopK, /* IsDeterministic = */ false>;
+
+}

--- a/src/Functions/array/arrayTopK.h
+++ b/src/Functions/array/arrayTopK.h
@@ -52,7 +52,7 @@ struct ArrayTopKImpl
                 "Expected fixed arguments to get K for {}", name);
 
         WhichDataType which(fixed_arguments[0].type.get());
-        if (!which.isNativeInteger())
+        if (!isNativeInteger(*fixed_arguments[0].type))
             throw Exception(
                 ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
                 "Illegal type {} of the K argument of function {} (must be a native integer: UInt8/16/32/64 or Int8/16/32/64)",
@@ -77,9 +77,8 @@ struct NameArrayBottomK
 
 /// `arrayBottomK` returns the K smallest elements in ascending order.
 /// `arrayTopK` returns the K largest elements in descending order.
-/// Both use `partial_sort` internally; in the presence of ties in the sort key
-/// the choice among equal keys is unspecified.
-using FunctionArrayBottomK = FunctionArrayMapped<ArrayTopKImpl</* IsAscending = */ true>, NameArrayBottomK, /* IsDeterministic = */ false>;
-using FunctionArrayTopK = FunctionArrayMapped<ArrayTopKImpl</* IsAscending = */ false>, NameArrayTopK, /* IsDeterministic = */ false>;
+/// Equal elements keep their the original order, so the result is deterministic.
+using FunctionArrayBottomK = FunctionArrayMapped<ArrayTopKImpl</* IsAscending = */ true>, NameArrayBottomK, /* IsDeterministic = */ true>;
+using FunctionArrayTopK = FunctionArrayMapped<ArrayTopKImpl</* IsAscending = */ false>, NameArrayTopK, /* IsDeterministic = */ true>;
 
 }

--- a/src/Functions/array/arrayTopK.h
+++ b/src/Functions/array/arrayTopK.h
@@ -51,7 +51,6 @@ struct ArrayTopKImpl
                 ErrorCodes::LOGICAL_ERROR,
                 "Expected fixed arguments to get K for {}", name);
 
-        WhichDataType which(fixed_arguments[0].type.get());
         if (!isNativeInteger(*fixed_arguments[0].type))
             throw Exception(
                 ErrorCodes::ILLEGAL_TYPE_OF_ARGUMENT,
@@ -77,7 +76,7 @@ struct NameArrayBottomK
 
 /// `arrayBottomK` returns the K smallest elements in ascending order.
 /// `arrayTopK` returns the K largest elements in descending order.
-/// Equal elements keep their the original order, so the result is deterministic.
+/// Equal elements keep their original order, so the result is deterministic.
 using FunctionArrayBottomK = FunctionArrayMapped<ArrayTopKImpl</* IsAscending = */ true>, NameArrayBottomK, /* IsDeterministic = */ true>;
 using FunctionArrayTopK = FunctionArrayMapped<ArrayTopKImpl</* IsAscending = */ false>, NameArrayTopK, /* IsDeterministic = */ true>;
 

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyLimitAggregationOperator.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyLimitAggregationOperator.cpp
@@ -15,7 +15,6 @@
 namespace DB::ErrorCodes
 {
     extern const int CANNOT_EXECUTE_PROMQL_QUERY;
-    extern const int NOT_IMPLEMENTED;
 }
 
 
@@ -96,7 +95,7 @@ namespace
     };
 
     /// Converts the k parameter to an AST expression usable in SQL.
-    KArgument getK(SQLQueryPiece && k_arg, std::string_view operator_name, ConverterContext & context)
+    KArgument getK(SQLQueryPiece && k_arg, ConverterContext & context)
     {
         switch (k_arg.store_method)
         {
@@ -115,7 +114,6 @@ namespace
             }
             case StoreMethod::SCALAR_GRID:
             {
-#if 0
                 /// SELECT arrayMap(x -> convertScalarToK(x), values) AS values FROM <scalar_grid>
                 context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(k_arg.select_query), SQLSubqueryType::TABLE});
                 String inner_subquery_name = context.subqueries.back().name;
@@ -129,12 +127,6 @@ namespace
 
                 context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), builder.getSelectQuery(), SQLSubqueryType::SCALAR});
                 return {make_intrusive<ASTIdentifier>(context.subqueries.back().name), /* is_array = */ true};
-#else
-                /// TODO: arrayPartialSort(k, arr) doesn't work when k is different in different rows.
-                throw Exception(ErrorCodes::NOT_IMPLEMENTED,
-                                "Aggregation operator '{}' with a non-constant scalar parameter is not supported",
-                                operator_name);
-#endif
             }
             default:
             {
@@ -143,87 +135,90 @@ namespace
         }
     }
 
-    /// Returns the sort key lambda for `arrayPartialSort` over an index array:
-    /// - ascending  : `i -> assumeNotNull(arr[i])`   (used by `bottomk` with arr=v and by `limitk` with arr=sampling_keys)
-    /// - descending : `i -> -assumeNotNull(arr[i])`  (used by `topk` with arr=v)
-    ASTPtr buildSortKeyLambda(ASTPtr && arr, bool descending)
+    /// Returns all indices: `arrayEnumerate(values)`
+    ASTPtr makeASTForIndices(ASTPtr && values)
     {
-        chassert(arr);
-        auto arr_at_i = makeASTFunction("arrayElement", std::move(arr), make_intrusive<ASTIdentifier>("i"));
-        ASTPtr value_key = makeASTFunction("assumeNotNull", std::move(arr_at_i));
-        if (descending)
-            value_key = makeASTFunction("negate", std::move(value_key));
-        return makeASTLambda({"i"}, std::move(value_key));
+        return makeASTFunction("arrayEnumerate", std::move(values));
     }
 
-    /// Returns a function that builds the sort key lambda for a given operator.
-    /// `values` is an array of values of different time series at a specific time,
-    /// `sampling_keys` is a matching array of sampling keys calculated for each time series.
-    /// `sampling_keys` is used only for `limitk`, it's nullptr for `topk` and `bottomk`.
-    using BuildSortKeyLambdaFunc = ASTPtr (*)(ASTPtr values, ASTPtr sampling_keys);
+    /// Returns non-null indices:
+    /// `arrayFilter((i, x) -> x IS NOT NULL, arrayEnumerate(values), values)`
+    ASTPtr makeASTForNonNullIndices(ASTPtr && values)
+    {
+        return makeASTFunction("arrayFilter",
+            makeASTLambda({"i", "x"}, makeASTFunction("isNotNull", make_intrusive<ASTIdentifier>("x"))),
+            makeASTFunction("arrayEnumerate", values->clone()),
+            std::move(values));
+    }
+
+    /// Returns sort key lambda: `i -> sort_key_arr[i]`
+    ASTPtr makeASTForSortKeyLambda(ASTPtr && sort_key_arr)
+    {
+        return makeASTLambda({"i"},
+            makeASTFunction("arrayElement", std::move(sort_key_arr), make_intrusive<ASTIdentifier>("i")));
+    }
+
+    /// Builds an AST returning the K chosen indices (in unspecified order):
+    ///
+    ///   <arrayTopK|arrayBottomK>(i -> sort_key_arr[i], k, <indices>)
+    ///
+    /// `values` is an array of values of different time series at a specific time.
+    /// `sampling_keys` is a matching array of sampling keys calculated for each time series,
+    /// `sampling_keys` is non-null only for `limitk` (and null for `topk` and `bottomk`).
+    using MakeASTForKIndices = ASTPtr (*)(ASTPtr k, ASTPtr values, ASTPtr sampling_keys);
 
     struct ImplInfo
     {
-        BuildSortKeyLambdaFunc build_sort_key_lambda;
+        /// Builds the AST to choose K indices (see `MakeASTForKIndices`).
+        MakeASTForKIndices make_ast_for_k_indices;
+
         /// Whether `timeSeriesGroupToSamplingKey(group)` should be used as `sampling_keys`
         /// to provide deterministic "pseudo-random" sampling for `limitk`.
-        bool needs_sampling_keys;
+        bool use_sampling_keys = false;
     };
 
     const ImplInfo * getImplInfo(std::string_view operator_name)
     {
         static const std::unordered_map<std::string_view, ImplInfo> impl_map = {
             {"topk",
-             {[](ASTPtr values, ASTPtr /*sampling_keys*/) -> ASTPtr
-              { return buildSortKeyLambda(std::move(values), /*descending=*/ true); },
-              /*needs_sampling_keys=*/ false}},
+             {[](ASTPtr k, ASTPtr values, ASTPtr /* sampling_keys */) -> ASTPtr
+              {
+                  /// `arrayTopK(i -> values[i], k, arrayEnumerate(values))`
+                  return makeASTFunction("arrayTopK",
+                      makeASTForSortKeyLambda(values->clone()),
+                      std::move(k),
+                      makeASTForIndices(values->clone()));
+              },
+              /*use_sampling_keys=*/ false}},
 
             {"bottomk",
-             {[](ASTPtr values, ASTPtr /*sampling_keys*/) -> ASTPtr
-              { return buildSortKeyLambda(std::move(values), /*descending=*/ false); },
-              /*needs_sampling_keys=*/ false}},
+             {[](ASTPtr k, ASTPtr values, ASTPtr /* sampling_keys */) -> ASTPtr
+              {
+                  /// `arrayBottomK(i -> values[i], k, arrayEnumerate(values))`
+                  return makeASTFunction("arrayBottomK",
+                      makeASTForSortKeyLambda(values->clone()),
+                      std::move(k),
+                      makeASTForIndices(values->clone()));
+              },
+              /* use_sampling_keys= */ false}},
 
             {"limitk",
-             {[](ASTPtr /*values*/, ASTPtr sampling_keys) -> ASTPtr
-              { return buildSortKeyLambda(std::move(sampling_keys), /*descending=*/ false); },
-              /*needs_sampling_keys=*/ true}},
+             {[](ASTPtr k, ASTPtr values, ASTPtr sampling_keys) -> ASTPtr
+              {
+                  /// `arrayBottomK(i -> sampling_keys[i], k,
+                  ///     arrayFilter((i, x) -> x IS NOT NULL, arrayEnumerate(values), values))`
+                  return makeASTFunction("arrayBottomK",
+                      makeASTForSortKeyLambda(std::move(sampling_keys)),
+                      std::move(k),
+                      makeASTForNonNullIndices(std::move(values)));
+              },
+              /* use_sampling_keys= */ true}},
         };
 
         auto it = impl_map.find(operator_name);
         if (it == impl_map.end())
             return nullptr;
         return &it->second;
-    }
-
-    /// Builds an expression returning a sorted list of indices:
-    ///
-    ///   arraySort(arraySlice(
-    ///       arrayPartialSort(sort_key_lambda, k,
-    ///           arrayFilter((i, x) -> x IS NOT NULL, arrayEnumerate(values), values)),
-    ///       1, k))
-    ///
-    /// The inner `arrayFilter` drops NULL values; `arrayPartialSort` picks k by `sort_key_lambda`;
-    /// `arraySlice` takes exactly k (the partial sort may return more); the outer `arraySort`
-    /// re-sorts the k indices numerically so Step 3 can use `indexOfAssumeSorted`.
-    ///
-    /// TODO: Consider adding new functions `arrayTopK`/`arrayBottomK` to ClickHouse
-    /// to simplify this expression.
-    ASTPtr buildKIndices(ASTPtr && k, ASTPtr && values, ASTPtr && sort_key_lambda)
-    {
-        /// arrayFilter((i, x) -> x IS NOT NULL, arrayEnumerate(values), values)
-        auto non_null_indices = makeASTFunction("arrayFilter",
-            makeASTLambda({"i", "x"}, makeASTFunction("isNotNull", make_intrusive<ASTIdentifier>("x"))),
-            makeASTFunction("arrayEnumerate", values->clone()),
-            std::move(values));
-
-        return makeASTFunction("arraySort",
-            makeASTFunction("arraySlice",
-                makeASTFunction("arrayPartialSort",
-                    std::move(sort_key_lambda),
-                    k->clone(),
-                    std::move(non_null_indices)),
-                make_intrusive<ASTLiteral>(1u),
-                std::move(k)));
     }
 }
 
@@ -253,7 +248,7 @@ SQLQueryPiece applyLimitAggregationOperator(
 
     vector_arg = toVectorGrid(std::move(vector_arg), context);
 
-    KArgument prepared_k = getK(std::move(k_arg), operator_name, context);
+    KArgument prepared_k = getK(std::move(k_arg), context);
     ASTPtr k = std::move(prepared_k.ast);
     bool k_is_array = prepared_k.is_array;
 
@@ -286,7 +281,7 @@ SQLQueryPiece applyLimitAggregationOperator(
             makeASTFunction("groupArray", make_intrusive<ASTIdentifier>(ColumnNames::Values))));
         builder.select_list.back()->setAlias(ColumnNames::Values);
 
-        if (impl_info->needs_sampling_keys)
+        if (impl_info->use_sampling_keys)
         {
             builder.select_list.push_back(makeASTFunction("groupArray",
                 makeASTFunction("timeSeriesGroupToSamplingKey", make_intrusive<ASTIdentifier>(ColumnNames::Group))));
@@ -325,17 +320,15 @@ SQLQueryPiece applyLimitAggregationOperator(
         builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Values));
 
         ASTPtr sampling_keys;
-        if (impl_info->needs_sampling_keys)
+        if (impl_info->use_sampling_keys)
             sampling_keys = make_intrusive<ASTIdentifier>(ColumnNames::SamplingKeys);
-
-        auto sort_key_lambda = impl_info->build_sort_key_lambda(
-            make_intrusive<ASTIdentifier>("v"),
-            std::move(sampling_keys));
 
         if (k_is_array)
         {
             ASTPtr k_per_step = makeASTFunction("arrayElement", std::move(k), make_intrusive<ASTIdentifier>("j"));
-            ASTPtr indices_expr = buildKIndices(std::move(k_per_step), make_intrusive<ASTIdentifier>("v"), std::move(sort_key_lambda));
+            /// `arraySort` re-sorts the k indices numerically so Step 3 can use `indexOfAssumeSorted`.
+            ASTPtr indices_expr = makeASTFunction("arraySort", impl_info->make_ast_for_k_indices(
+                std::move(k_per_step), make_intrusive<ASTIdentifier>("v"), std::move(sampling_keys)));
             builder.select_list.push_back(makeASTFunction("arrayMap",
                 makeASTLambda({"v", "j"}, std::move(indices_expr)),
                 make_intrusive<ASTIdentifier>(ColumnNames::Values),
@@ -343,7 +336,9 @@ SQLQueryPiece applyLimitAggregationOperator(
         }
         else
         {
-            ASTPtr indices_expr = buildKIndices(std::move(k), make_intrusive<ASTIdentifier>("v"), std::move(sort_key_lambda));
+            /// `arraySort` re-sorts the k indices numerically so Step 3 can use `indexOfAssumeSorted`.
+            ASTPtr indices_expr = makeASTFunction("arraySort", impl_info->make_ast_for_k_indices(
+                std::move(k), make_intrusive<ASTIdentifier>("v"), std::move(sampling_keys)));
             builder.select_list.push_back(makeASTFunction("arrayMap",
                 makeASTLambda({"v"}, std::move(indices_expr)),
                 make_intrusive<ASTIdentifier>(ColumnNames::Values)));

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyLimitAggregationOperator.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyLimitAggregationOperator.cpp
@@ -75,14 +75,16 @@ namespace
     /// This is SQL version of the function convertScalarToK() taking a ScalarType.
     ASTPtr convertScalarToK(ASTPtr scalar)
     {
-        /// toUInt64(if(x < 0, 0, x))
-        /// Pre-clamping negatives is important so that -Inf does not trigger an exception.
-        /// For NaN, `NaN < 0` is false, so the value is passed through to `toUInt64` which throws.
+        /// accurateCast(floor(if(x < 0, 0, x)), 'UInt64')
+        /// Pre-clamping negatives is important so that negative values (including -Inf) do not trigger an exception.
+        /// For NaN and +Inf, `x < 0` is false, so the value is passed through to `accurateCast`
+        /// which throws on values that don't fit into UInt64.
         auto clamped = makeASTFunction("if",
             makeASTFunction("less", scalar, make_intrusive<ASTLiteral>(0.0)),
             make_intrusive<ASTLiteral>(0.0),
             scalar->clone());
-        return makeASTFunction("toUInt64", std::move(clamped));
+        auto floored = makeASTFunction("floor", std::move(clamped));
+        return makeASTFunction("accurateCast", std::move(floored), make_intrusive<ASTLiteral>("UInt64"));
     }
 
     /// Result of `getK`. If `is_array` is false, `ast` is a UInt64 scalar expression that evaluates

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -2904,6 +2904,44 @@ def test_aggregation_operators():
         ],
     )
 
+    # topk(-1): k<0 is clamped to 0, returns no series.
+    do_query_test(
+        "topk(-1, last_over_time(foo[10]))[50:10]",
+        150,
+        '{"resultType": "matrix", "result": []}',
+        [],
+    )
+
+    # topk(+Inf): k=+Inf causes an error because it cannot be converted to an integer.
+    do_query_test_expect_error(
+        "topk(+Inf, last_over_time(foo[10]))[50:10]",
+        150,
+        "Scalar value +Inf overflows int64",
+        "Argument k of aggregation operator is too large",
+    )
+
+    do_query_test(
+        'topk(time() / 10 - 10, last_over_time({__name__=~"foo|bar"}[10]))[50:10]',
+        150,
+        '{"resultType": "matrix", "result": [{"metric": {"__name__": "bar", "shape": "circle", "size": "l"}, "values": [[130, "50"], [150, "1000"]]}, {"metric": {"__name__": "bar", "shape": "rectangle", "size": "l"}, "values": [[130, "90"]]}, {"metric": {"__name__": "bar", "shape": "square", "size": "s"}, "values": [[120, "40"], [140, "700"]]}, {"metric": {"__name__": "bar", "shape": "triangle", "size": "xl"}, "values": [[150, "30"]]}, {"metric": {"__name__": "foo", "shape": "circle", "size": "l"}, "values": [[110, "16"], [150, "16"]]}, {"metric": {"__name__": "foo", "shape": "square", "size": "s"}, "values": [[130, "40"]]}, {"metric": {"__name__": "foo", "shape": "triangle", "size": "m"}, "values": [[120, "80"]]}]}',
+        [
+            ["[('__name__','bar'),('shape','circle'),('size','l')]", "[('1970-01-01 00:02:10.000',50),('1970-01-01 00:02:30.000',1000)]"],
+            ["[('__name__','bar'),('shape','rectangle'),('size','l')]", "[('1970-01-01 00:02:10.000',90)]"],
+            ["[('__name__','bar'),('shape','square'),('size','s')]", "[('1970-01-01 00:02:00.000',40),('1970-01-01 00:02:20.000',700)]"],
+            ["[('__name__','bar'),('shape','triangle'),('size','xl')]", "[('1970-01-01 00:02:30.000',30)]"],
+            ["[('__name__','foo'),('shape','circle'),('size','l')]", "[('1970-01-01 00:01:50.000',16),('1970-01-01 00:02:30.000',16)]"],
+            ["[('__name__','foo'),('shape','square'),('size','s')]", "[('1970-01-01 00:02:10.000',40)]"],
+            ["[('__name__','foo'),('shape','triangle'),('size','m')]", "[('1970-01-01 00:02:00.000',80)]"],
+        ],
+    )
+
+    do_query_test(
+        "topk(2, nonexistent_metric_name)[50:10]",
+        150,
+        '{"resultType": "matrix", "result": []}',
+        [],
+    )
+
     # FIXME: Not deterministic without sort_by_label(), and function sort_by_label() is not implemented yet.
     # do_query_test(
     #     "bottomk(2, bar)",
@@ -3029,14 +3067,7 @@ def test_aggregation_operators():
         ],
     )
 
-    # topk(-1) and limitk(-2): k<0 is clamped to 0, returns no series.
-    do_query_test(
-        "topk(-1, last_over_time(foo[10]))[50:10]",
-        150,
-        '{"resultType": "matrix", "result": []}',
-        [],
-    )
-
+    # limitk(-2): k<0 is clamped to 0, returns no series.
     do_query_test(
         "limitk(-2, last_over_time(foo[10]))[50:10]",
         150,
@@ -3044,30 +3075,18 @@ def test_aggregation_operators():
         [],
     )
 
-    # topk(+Inf): k=+Inf causes an error because it cannot be converted to an integer.
-    do_query_test_expect_error(
-        "topk(+Inf, last_over_time(foo[10]))[50:10]",
+    # limitk with non-constant k=time()/10 - 10 (values 0,1,2,3,4,5 at steps 100..150).
+    # ClickHouse-only because limitk picks series via CityHash64(tags) which differs from Prometheus's xxhash.Sum64.
+    do_clickhouse_only_query_test(
+        "limitk(time() / 10 - 10, last_over_time(foo[10]))[50:10]",
         150,
-        "Scalar value +Inf overflows int64",
-        "Argument k of aggregation operator is too large",
+        '{"resultType": "matrix", "result": [{"metric": {"__name__": "foo", "shape": "circle", "size": "l"}, "values": [[130, "16"], [150, "16"]]}, {"metric": {"__name__": "foo", "shape": "square", "size": "s"}, "values": [[110, "4"], [130, "40"]]}, {"metric": {"__name__": "foo", "shape": "triangle", "size": "m"}, "values": [[120, "80"]]}]}',
+        [
+            ["[('__name__','foo'),('shape','circle'),('size','l')]", "[('1970-01-01 00:02:10.000',16),('1970-01-01 00:02:30.000',16)]"],
+            ["[('__name__','foo'),('shape','square'),('size','s')]", "[('1970-01-01 00:01:50.000',4),('1970-01-01 00:02:10.000',40)]"],
+            ["[('__name__','foo'),('shape','triangle'),('size','m')]", "[('1970-01-01 00:02:00.000',80)]"],
+        ],
     )
-
-    # FIXME: topk/bottomk/limitk with k depending on timestamp are not implemented yet.
-    # topk with k depending on the timestamp: k = time() / 10 - 10 varies per subquery step (1, 2, 3, 4, 5).
-    # do_query_test(
-    #     'topk(time() / 10 - 10, last_over_time({__name__=~"foo|bar"}[10]))[50:10]',
-    #     150,
-    #     '{"resultType": "matrix", "result": [{"metric": {"__name__": "bar", "shape": "circle", "size": "l"}, "values": [[130, "50"], [150, "1000"]]}, {"metric": {"__name__": "bar", "shape": "rectangle", "size": "l"}, "values": [[130, "90"]]}, {"metric": {"__name__": "bar", "shape": "square", "size": "s"}, "values": [[120, "40"], [140, "700"]]}, {"metric": {"__name__": "bar", "shape": "triangle", "size": "xl"}, "values": [[150, "30"]]}, {"metric": {"__name__": "foo", "shape": "circle", "size": "l"}, "values": [[110, "16"], [150, "16"]]}, {"metric": {"__name__": "foo", "shape": "square", "size": "s"}, "values": [[130, "40"]]}, {"metric": {"__name__": "foo", "shape": "triangle", "size": "m"}, "values": [[120, "80"]]}]}',
-    #     [
-    #         ["[('__name__','bar'),('shape','circle'),('size','l')]", "[('1970-01-01 00:02:10.000',50),('1970-01-01 00:02:30.000',1000)]"],
-    #         ["[('__name__','bar'),('shape','rectangle'),('size','l')]", "[('1970-01-01 00:02:10.000',90)]"],
-    #         ["[('__name__','bar'),('shape','square'),('size','s')]", "[('1970-01-01 00:02:00.000',40),('1970-01-01 00:02:20.000',700)]"],
-    #         ["[('__name__','bar'),('shape','triangle'),('size','xl')]", "[('1970-01-01 00:02:30.000',30)]"],
-    #         ["[('__name__','foo'),('shape','circle'),('size','l')]", "[('1970-01-01 00:01:50.000',16),('1970-01-01 00:02:30.000',16)]"],
-    #         ["[('__name__','foo'),('shape','square'),('size','s')]", "[('1970-01-01 00:02:10.000',40)]"],
-    #         ["[('__name__','foo'),('shape','triangle'),('size','m')]", "[('1970-01-01 00:02:00.000',80)]"],
-    #     ],
-    # )
 
 
 def test_label_manipulation_functions():

--- a/tests/queries/0_stateless/04105_array_top_k_bottom_k.reference
+++ b/tests/queries/0_stateless/04105_array_top_k_bottom_k.reference
@@ -1,0 +1,64 @@
+-- Basic numeric arrays:
+[7,5,3]
+[1,2,3]
+[]
+[]
+-- K larger than array size:
+[7,5,3,2,1]
+[1,2,3,5,7]
+-- Empty input:
+[]
+[]
+-- Nulls are skipped, result element type is non-nullable:
+[7,5,2]
+[1,2,5]
+Array(UInt8)
+Array(UInt8)
+-- Result may be shorter than K when non-null count is lower:
+[2,1]
+[1,2]
+-- All-null input returns empty array:
+[]
+[]
+-- Strings:
+['gamma','delta']
+['alpha','beta']
+['gamma','alpha']
+-- Lambda with single argument:
+[1,3]
+[9,5]
+-- Lambda with multiple arguments: result values come from the first array, order from lambda:
+['a','c']
+['b','c']
+-- Lambda that produces NULLs; the corresponding original elements must be skipped:
+[7,5,3]
+[1,3,5]
+-- Constant-NULL lambda: every mapped key is NULL, so every element must be skipped:
+[]
+[]
+-- With materialize to force a non-const column path:
+[7,5,2]
+[1,2,5]
+-- Per-row varying input:
+[]	[]
+[0]	[0]
+[1,0]	[0,1]
+[2,1]	[0,1]
+[3,2]	[0,1]
+[4,3]	[0,1]
+-- K as a materialized column value:
+[7,5]
+-- LowCardinality is removed:
+['gamma','delta']
+['alpha','beta']
+Array(String)
+['gamma','beta','alpha']
+['alpha','beta','gamma']
+Array(String)
+Array(String)
+-- Negative K is clamped to 0 (returns empty array):
+[]
+[]
+[]
+[]
+-- Errors:

--- a/tests/queries/0_stateless/04105_array_top_k_bottom_k.reference
+++ b/tests/queries/0_stateless/04105_array_top_k_bottom_k.reference
@@ -56,9 +56,4 @@ Array(String)
 ['alpha','beta','gamma']
 Array(String)
 Array(String)
--- Negative K is clamped to 0 (returns empty array):
-[]
-[]
-[]
-[]
 -- Errors:

--- a/tests/queries/0_stateless/04105_array_top_k_bottom_k.sql
+++ b/tests/queries/0_stateless/04105_array_top_k_bottom_k.sql
@@ -67,15 +67,12 @@ SELECT arrayBottomK(3, ['alpha', NULL, 'gamma', NULL, 'beta']::Array(LowCardinal
 SELECT toTypeName(arrayTopK(3, ['alpha', NULL, 'beta']::Array(LowCardinality(Nullable(String)))));
 SELECT toTypeName(arrayBottomK(3, ['alpha', NULL, 'beta']::Array(LowCardinality(Nullable(String)))));
 
-SELECT '-- Negative K is clamped to 0 (returns empty array):';
-SELECT arrayTopK(-1, [1, 5, 2, 7, 3]);
-SELECT arrayBottomK(-1, [1, 5, 2, 7, 3]);
-SELECT arrayTopK(-100, [1, NULL, 2]);
-SELECT arrayTopK(materialize(toInt32(-3)), [1, 5, 2]);
-
 SELECT '-- Errors:';
 SELECT arrayTopK([1, 2, 3]);                              -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 SELECT arrayBottomK([1, 2, 3]);                           -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 SELECT arrayTopK('foo', [1, 2, 3]);                       -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 SELECT arrayTopK(2, [1, 2, 3], [1]);                      -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 SELECT arrayTopK(2, [1, 2, 3], 3);                        -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT arrayTopK(-1, [1, 5, 2, 7, 3]);                    -- { serverError BAD_ARGUMENTS }
+SELECT arrayBottomK(-1, [1, 5, 2, 7, 3]);                 -- { serverError BAD_ARGUMENTS }
+SELECT arrayTopK(materialize(toInt32(-3)), [1, 5, 2]);    -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/04105_array_top_k_bottom_k.sql
+++ b/tests/queries/0_stateless/04105_array_top_k_bottom_k.sql
@@ -1,0 +1,81 @@
+SELECT '-- Basic numeric arrays:';
+SELECT arrayTopK(3, [1, 5, 2, 7, 3]);
+SELECT arrayBottomK(3, [1, 5, 2, 7, 3]);
+SELECT arrayTopK(0, [1, 5, 2, 7, 3]);
+SELECT arrayBottomK(0, [1, 5, 2, 7, 3]);
+
+SELECT '-- K larger than array size:';
+SELECT arrayTopK(10, [1, 5, 2, 7, 3]);
+SELECT arrayBottomK(10, [1, 5, 2, 7, 3]);
+
+SELECT '-- Empty input:';
+SELECT arrayTopK(5, emptyArrayUInt32());
+SELECT arrayBottomK(5, emptyArrayUInt32());
+
+SELECT '-- Nulls are skipped, result element type is non-nullable:';
+SELECT arrayTopK(3, [1, NULL, 5, 2, NULL, 7]);
+SELECT arrayBottomK(3, [1, NULL, 5, 2, NULL, 7]);
+SELECT toTypeName(arrayTopK(3, [1, NULL, 5]));
+SELECT toTypeName(arrayBottomK(3, [1, NULL, 5]));
+
+SELECT '-- Result may be shorter than K when non-null count is lower:';
+SELECT arrayTopK(5, [1, NULL, 2]);
+SELECT arrayBottomK(5, [1, NULL, 2]);
+
+SELECT '-- All-null input returns empty array:';
+SELECT arrayTopK(3, [NULL, NULL, NULL]::Array(Nullable(UInt32)));
+SELECT arrayBottomK(3, [NULL, NULL, NULL]::Array(Nullable(UInt32)));
+
+SELECT '-- Strings:';
+SELECT arrayTopK(2, ['alpha', 'beta', 'gamma', 'delta']);
+SELECT arrayBottomK(2, ['alpha', 'beta', 'gamma', 'delta']);
+SELECT arrayTopK(2, ['alpha', NULL, 'gamma', NULL]);
+
+SELECT '-- Lambda with single argument:';
+SELECT arrayTopK((x) -> -x, 2, [5, 9, 1, 3]);
+SELECT arrayBottomK((x) -> -x, 2, [5, 9, 1, 3]);
+
+SELECT '-- Lambda with multiple arguments: result values come from the first array, order from lambda:';
+SELECT arrayTopK((x, y) -> y, 2, ['a', 'b', 'c'], [3, 1, 2]);
+SELECT arrayBottomK((x, y) -> y, 2, ['a', 'b', 'c'], [3, 1, 2]);
+
+SELECT '-- Lambda that produces NULLs; the corresponding original elements must be skipped:';
+SELECT arrayTopK((x) -> if(x % 2 = 0, NULL, x), 3, [1, 2, 3, 4, 5, 6, 7]);
+SELECT arrayBottomK((x) -> if(x % 2 = 0, NULL, x), 3, [1, 2, 3, 4, 5, 6, 7]);
+
+SELECT '-- Constant-NULL lambda: every mapped key is NULL, so every element must be skipped:';
+SELECT arrayTopK((x) -> NULL, 2, [1, 2, 3]);
+SELECT arrayBottomK((x) -> NULL, 2, [1, 2, 3]);
+
+SELECT '-- With materialize to force a non-const column path:';
+SELECT arrayTopK(3, materialize([1, NULL, 5, 2, NULL, 7]));
+SELECT arrayBottomK(3, materialize([1, NULL, 5, 2, NULL, 7]));
+
+SELECT '-- Per-row varying input:';
+SELECT arrayTopK(2, arr), arrayBottomK(2, arr)
+FROM (SELECT arrayMap(x -> x, range(number)) AS arr FROM numbers(6));
+
+SELECT '-- K as a materialized column value:';
+SELECT arrayTopK(materialize(toUInt32(2)), [1, 5, 2, 7, 3]);
+
+SELECT '-- LowCardinality is removed:';
+SELECT arrayTopK(2, ['alpha', 'beta', 'gamma', 'delta']::Array(LowCardinality(String)));
+SELECT arrayBottomK(2, ['alpha', 'beta', 'gamma', 'delta']::Array(LowCardinality(String)));
+SELECT toTypeName(arrayTopK(2, ['alpha', 'beta', 'gamma']::Array(LowCardinality(String))));
+SELECT arrayTopK(3, ['alpha', NULL, 'gamma', NULL, 'beta']::Array(LowCardinality(Nullable(String))));
+SELECT arrayBottomK(3, ['alpha', NULL, 'gamma', NULL, 'beta']::Array(LowCardinality(Nullable(String))));
+SELECT toTypeName(arrayTopK(3, ['alpha', NULL, 'beta']::Array(LowCardinality(Nullable(String)))));
+SELECT toTypeName(arrayBottomK(3, ['alpha', NULL, 'beta']::Array(LowCardinality(Nullable(String)))));
+
+SELECT '-- Negative K is clamped to 0 (returns empty array):';
+SELECT arrayTopK(-1, [1, 5, 2, 7, 3]);
+SELECT arrayBottomK(-1, [1, 5, 2, 7, 3]);
+SELECT arrayTopK(-100, [1, NULL, 2]);
+SELECT arrayTopK(materialize(toInt32(-3)), [1, 5, 2]);
+
+SELECT '-- Errors:';
+SELECT arrayTopK([1, 2, 3]);                              -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT arrayBottomK([1, 2, 3]);                           -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+SELECT arrayTopK('foo', [1, 2, 3]);                       -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT arrayTopK(2, [1, 2, 3], [1]);                      -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT arrayTopK(2, [1, 2, 3], 3);                        -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }


### PR DESCRIPTION
### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add functions arrayTopK and arrayBottomK:
- `arrayTopK(k, array)` returns the K largest elements in descending order
- `arrayBottomK(k, array)` returns the K smallest elements in ascending order

For example `arrayBottomK(3, [1, 5, 2, 7, 3])` returns `[1,2,3]`

Likewise `arraySort()` an optional lambda is supported, so
`arrayBottomK((x, y) -> y, 2, ['a', 'b', 'c'], [3, 1, 2])` returns `['b', 'c']`

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.320`
<!-- ch-version-info:end -->