### PR TITLE
Fix datatype in iceberg history

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -870,11 +870,13 @@ IcebergMetadata::IcebergHistory IcebergMetadata::getHistory(ContextPtr local_con
         history_record.manifest_list_path = IcebergPathFromMetadata::deserialize(snapshot->getValue<String>(f_manifest_list));
         const auto summary = snapshot->getObject(f_summary);
         if (summary->has(f_added_data_files))
-            history_record.added_files = summary->getValue<Int32>(f_added_data_files);
+            history_record.added_files = summary->getValue<Int64>(f_added_data_files);
         if (summary->has(f_added_records))
-            history_record.added_records = summary->getValue<Int32>(f_added_records);
-        history_record.added_files_size = summary->getValue<Int32>(f_added_files_size);
-        history_record.num_partitions = summary->getValue<Int32>(f_changed_partition_count);
+            history_record.added_records = summary->getValue<Int64>(f_added_records);
+        if (summary->has(f_added_files_size))
+            history_record.added_files_size = summary->getValue<Int64>(f_added_files_size);
+        if (summary->has(f_changed_partition_count))
+            history_record.num_partitions = summary->getValue<Int64>(f_changed_partition_count);
 
         if (snapshot->has(f_parent_snapshot_id) && !snapshot->isNull(f_parent_snapshot_id))
             history_record.parent_id = snapshot->getValue<Int64>(f_parent_snapshot_id);

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergMetadata.cpp
@@ -497,13 +497,13 @@ IcebergMetadata::getStateImpl(const ContextPtr & local_context, Poco::JSON::Obje
                 "No snapshot found in snapshot log before requested timestamp for iceberg table {}",
                 persistent_components.table_path);
         auto data_snapshot = getIcebergDataSnapshot(metadata_object, *current_snapshot_id, local_context);
-        return {data_snapshot, data_snapshot->schema_id_on_snapshot_commit};
+        return {data_snapshot, static_cast<Int32>(data_snapshot->schema_id_on_snapshot_commit)};
     }
     else if (snapshot_id_changed)
     {
         Int64 current_snapshot_id = local_context->getSettingsRef()[Setting::iceberg_snapshot_id];
         auto data_snapshot = getIcebergDataSnapshot(metadata_object, current_snapshot_id, local_context);
-        return {data_snapshot, data_snapshot->schema_id_on_snapshot_commit};
+        return {data_snapshot, static_cast<Int32>(data_snapshot->schema_id_on_snapshot_commit)};
     }
     else
     {

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Snapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Snapshot.h
@@ -36,10 +36,10 @@ struct IcebergHistoryRecord
     bool is_current_ancestor;
     Iceberg::IcebergPathFromMetadata manifest_list_path;
 
-    Int32 added_files = 0;
-    Int32 added_records = 0;
-    Int32 added_files_size;
-    Int32 num_partitions;
+    Int64 added_files = 0;
+    Int64 added_records = 0;
+    Int64 added_files_size = 0;
+    Int64 num_partitions = 0;
 };
 
 using IcebergHistory = std::vector<Iceberg::IcebergHistoryRecord>;

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Snapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Snapshot.h
@@ -14,7 +14,7 @@ struct IcebergDataSnapshot
 {
     DB::ManifestFileCacheKeys manifest_list_entries;
     Int64 snapshot_id;
-    Int32 schema_id_on_snapshot_commit;
+    Int64 schema_id_on_snapshot_commit;
     std::optional<size_t> total_rows;
     std::optional<size_t> total_bytes;
     std::optional<size_t> total_position_delete_rows;

--- a/tests/integration/test_storage_iceberg_no_spark/configs/users.d/users.xml
+++ b/tests/integration/test_storage_iceberg_no_spark/configs/users.d/users.xml
@@ -1,4 +1,9 @@
 <clickhouse>
+    <profiles>
+        <default>
+            <allow_insert_into_iceberg>1</allow_insert_into_iceberg>
+        </default>
+    </profiles>
     <users>
         <default>
             <password></password>

--- a/tests/integration/test_storage_iceberg_no_spark/test_iceberg_history_large_summary.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_iceberg_history_large_summary.py
@@ -9,9 +9,6 @@ from helpers.iceberg_utils import (
 )
 
 
-INSERT_SETTINGS = {"allow_insert_into_iceberg": 1}
-
-
 def _metadata_dir(table_name):
     return f"/var/lib/clickhouse/user_files/iceberg_data/default/{table_name}/metadata"
 
@@ -49,13 +46,14 @@ def test_iceberg_history_summary_overflow(started_cluster_iceberg_no_spark, form
         "(x Int)",
         format_version,
     )
-    instance.query(f"INSERT INTO {table_name} VALUES (1);", settings=INSERT_SETTINGS)
+    instance.query(f"INSERT INTO {table_name} VALUES (1);")
 
     meta, prev = _read_latest_metadata(instance, table_name)
     assert meta.get("snapshots"), "snapshot must be present after INSERT"
 
-    # The exact value from the bug report; > INT32_MAX (2147483647).
+    # The exact value from the bug report.
     huge = "6986350573"
+    assert int(huge) > 2147483647
     for snap in meta["snapshots"]:
         summary = snap.setdefault("summary", {})
         summary["added-data-files"] = huge

--- a/tests/integration/test_storage_iceberg_no_spark/test_iceberg_history_large_summary.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_iceberg_history_large_summary.py
@@ -1,4 +1,4 @@
-gimport json
+import json
 import re
 
 import pytest

--- a/tests/integration/test_storage_iceberg_no_spark/test_iceberg_history_large_summary.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_iceberg_history_large_summary.py
@@ -1,14 +1,4 @@
-"""Reproducer for https://github.com/ClickHouse/ClickHouse/issues/94176.
-
-`system.iceberg_history` parses snapshot summary fields (`added-data-files`,
-`added-records`, `added-files-size`, `changed-partition-count`) as `Int32`,
-even though writers such as Spark/Databricks routinely produce values that
-exceed `INT32_MAX` (e.g. a multi-GB `added-files-size`). Reading such a
-table causes a `Not a valid integer` exception, the table is logged as
-broken and skipped, and `system.iceberg_history` returns no rows for it.
-"""
-
-import json
+gimport json
 import re
 
 import pytest

--- a/tests/integration/test_storage_iceberg_no_spark/test_iceberg_history_large_summary.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_iceberg_history_large_summary.py
@@ -1,0 +1,85 @@
+"""Reproducer for https://github.com/ClickHouse/ClickHouse/issues/94176.
+
+`system.iceberg_history` parses snapshot summary fields (`added-data-files`,
+`added-records`, `added-files-size`, `changed-partition-count`) as `Int32`,
+even though writers such as Spark/Databricks routinely produce values that
+exceed `INT32_MAX` (e.g. a multi-GB `added-files-size`). Reading such a
+table causes a `Not a valid integer` exception, the table is logged as
+broken and skipped, and `system.iceberg_history` returns no rows for it.
+"""
+
+import json
+import re
+
+import pytest
+
+from helpers.iceberg_utils import (
+    create_iceberg_table,
+    get_uuid_str,
+)
+
+
+INSERT_SETTINGS = {"allow_insert_into_iceberg": 1}
+
+
+def _metadata_dir(table_name):
+    return f"/var/lib/clickhouse/user_files/iceberg_data/default/{table_name}/metadata"
+
+
+def _read_latest_metadata(instance, table_name):
+    metadata_dir = _metadata_dir(table_name)
+    latest = instance.exec_in_container(
+        ["bash", "-c", f"ls -v {metadata_dir}/v*.metadata.json | tail -1"]
+    ).strip()
+    raw = instance.exec_in_container(["cat", latest])
+    return json.loads(raw), latest
+
+
+def _write_next_metadata(instance, table_name, meta, prev_path):
+    metadata_dir = _metadata_dir(table_name)
+    version_match = re.search(r"/v(\d+)[^/]*\.metadata\.json$", prev_path)
+    new_version = int(version_match.group(1)) + 1
+    new_path = f"{metadata_dir}/v{new_version}.metadata.json"
+    new_content = json.dumps(meta, indent=4)
+    instance.exec_in_container(
+        ["bash", "-c", f"cat > {new_path} << 'JSONEOF'\n{new_content}\nJSONEOF"]
+    )
+
+
+@pytest.mark.parametrize("format_version", [1, 2])
+def test_iceberg_history_summary_overflow(started_cluster_iceberg_no_spark, format_version):
+    instance = started_cluster_iceberg_no_spark.instances["node1"]
+    table_name = "test_iceberg_history_summary_overflow_" + get_uuid_str()
+
+    create_iceberg_table(
+        "local",
+        instance,
+        table_name,
+        started_cluster_iceberg_no_spark,
+        "(x Int)",
+        format_version,
+    )
+    instance.query(f"INSERT INTO {table_name} VALUES (1);", settings=INSERT_SETTINGS)
+
+    meta, prev = _read_latest_metadata(instance, table_name)
+    assert meta.get("snapshots"), "snapshot must be present after INSERT"
+
+    # The exact value from the bug report; > INT32_MAX (2147483647).
+    huge = "6986350573"
+    for snap in meta["snapshots"]:
+        summary = snap.setdefault("summary", {})
+        summary["added-data-files"] = huge
+        summary["added-records"] = huge
+        summary["added-files-size"] = huge
+        summary["changed-partition-count"] = huge
+
+    _write_next_metadata(instance, table_name, meta, prev)
+
+    count = instance.query(
+        f"SELECT count() FROM system.iceberg_history "
+        f"WHERE database = 'default' AND table = '{table_name}'"
+    ).strip()
+    assert count == "1", (
+        f"system.iceberg_history must return the snapshot even when summary "
+        f"values exceed INT32_MAX, got count={count}. See issue #94176."
+    )

--- a/tests/integration/test_storage_iceberg_no_spark/test_time_travel_bug_fix_validation.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_time_travel_bug_fix_validation.py
@@ -16,7 +16,7 @@ def test_time_travel_bug_fix_validation(started_cluster_iceberg_no_spark):
 
     create_iceberg_table("local", instance, TABLE_NAME, started_cluster_iceberg_no_spark, "(x String, y Int64)")
 
-    instance.query(f"INSERT INTO {TABLE_NAME} VALUES ('123', 1);", settings={"allow_insert_into_iceberg": 1, "write_full_path_in_iceberg_metadata": True})
+    instance.query(f"INSERT INTO {TABLE_NAME} VALUES ('123', 1);", settings={"write_full_path_in_iceberg_metadata": True})
 
     default_download_directory(
         started_cluster_iceberg_no_spark,
@@ -27,7 +27,7 @@ def test_time_travel_bug_fix_validation(started_cluster_iceberg_no_spark):
 
     first_snapshot = get_last_snapshot(f"/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/")
 
-    instance.query(f"INSERT INTO {TABLE_NAME} VALUES ('123', 1);", settings={"allow_insert_into_iceberg": 1, "write_full_path_in_iceberg_metadata": True})
+    instance.query(f"INSERT INTO {TABLE_NAME} VALUES ('123', 1);", settings={"write_full_path_in_iceberg_metadata": True})
 
     instance.query(f"SELECT count() FROM {TABLE_NAME}", settings={"iceberg_snapshot_id": first_snapshot})
 

--- a/tests/integration/test_storage_iceberg_no_spark/test_writes_create_table_bugs.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_writes_create_table_bugs.py
@@ -11,13 +11,11 @@ def test_writes_create_table_bugs(started_cluster_iceberg_no_spark):
     TABLE_NAME = "test_writes_create_table_bugs_" + get_uuid_str()
     TABLE_NAME_1 = "test_writes_create_table_bugs_" + get_uuid_str()
     instance.query(
-        f"CREATE TABLE {TABLE_NAME} (c0 Int) ENGINE = IcebergLocal('/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/', 'CSV') AS (SELECT 1 OFFSET 1 ROW);",
-        settings={"allow_insert_into_iceberg": 1}
+        f"CREATE TABLE {TABLE_NAME} (c0 Int) ENGINE = IcebergLocal('/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME}/', 'CSV') AS (SELECT 1 OFFSET 1 ROW);"
     )
 
     error = instance.query_and_get_error(
-        f"CREATE TABLE {TABLE_NAME_1} (c0 Int) ENGINE = IcebergLocal('/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME_1}/', 'CSV') PARTITION BY (icebergTruncate(c0));",
-        settings={"allow_insert_into_iceberg": 1}
+        f"CREATE TABLE {TABLE_NAME_1} (c0 Int) ENGINE = IcebergLocal('/var/lib/clickhouse/user_files/iceberg_data/default/{TABLE_NAME_1}/', 'CSV') PARTITION BY (icebergTruncate(c0));"
     )
 
     assert "BAD_ARGUMENTS" in error

--- a/tests/integration/test_storage_iceberg_no_spark/test_writes_multiple_files.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_writes_multiple_files.py
@@ -23,7 +23,7 @@ def test_writes_multiple_files(started_cluster_iceberg_no_spark, format_version,
         data += f"({i}), "
         expected_result += f"{i}\n"
     data = data[:len(data) - 2]
-    instance.query(f"INSERT INTO {TABLE_NAME} VALUES {data};", settings={"allow_insert_into_iceberg": 1, "iceberg_insert_max_rows_in_data_file" : 1})
+    instance.query(f"INSERT INTO {TABLE_NAME} VALUES {data};", settings={"iceberg_insert_max_rows_in_data_file" : 1})
     assert instance.query(f"SELECT * FROM {TABLE_NAME} ORDER BY ALL") == expected_result
 
     files = default_download_directory(

--- a/tests/integration/test_storage_iceberg_no_spark/test_writes_multiple_threads.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_writes_multiple_threads.py
@@ -22,7 +22,7 @@ def test_writes_multiple_threads(started_cluster_iceberg_no_spark, format_versio
     assert instance.query(f"SELECT * FROM {TABLE_NAME} ORDER BY ALL") == ''
 
     query_id = get_uuid_str()
-    instance.query(f"INSERT INTO {TABLE_NAME} SELECT number from system.numbers_mt LIMIT 4000000", settings={"allow_insert_into_iceberg": 1, "iceberg_insert_max_rows_in_data_file" : 4000000, "query_id": query_id, "max_insert_threads": 32})
+    instance.query(f"INSERT INTO {TABLE_NAME} SELECT number from system.numbers_mt LIMIT 4000000", settings={"iceberg_insert_max_rows_in_data_file" : 4000000, "query_id": query_id, "max_insert_threads": 32})
     instance.query("SYSTEM FLUSH LOGS")
     assert instance.query(f"SELECT count() FROM {TABLE_NAME}") == '4000000\n'
     assert instance.query(f"SELECT sum(x) FROM {TABLE_NAME}") == str(sum(range(4000000))) + '\n'

--- a/tests/integration/test_storage_iceberg_no_spark/test_writes_nullable_bugs2.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_writes_nullable_bugs2.py
@@ -13,6 +13,6 @@ def test_writes_nullable_bugs2(started_cluster_iceberg_no_spark, format_version,
     TABLE_NAME = "test_writes_nullable_bugs2_" + storage_type + "_" + get_uuid_str()
 
     create_iceberg_table(storage_type, instance, TABLE_NAME, started_cluster_iceberg_no_spark, "(c0 Nullable(String))", format_version, "(c0)")
-    instance.query(f"INSERT INTO {TABLE_NAME} VALUES (NULL), ('Monetochka'), ('Maneskin'), ('Noize MC');", settings={"allow_insert_into_iceberg": 1})
+    instance.query(f"INSERT INTO {TABLE_NAME} VALUES (NULL), ('Monetochka'), ('Maneskin'), ('Noize MC');")
 
     assert instance.query(f"SELECT * FROM {TABLE_NAME} ORDER BY ALL") == 'Maneskin\nMonetochka\nNoize MC\n\\N\n'

--- a/tests/integration/test_storage_iceberg_no_spark/test_writes_rename_column.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_writes_rename_column.py
@@ -5,8 +5,6 @@ from helpers.iceberg_utils import (
     get_uuid_str,
 )
 
-INSERT_SETTINGS = {"allow_insert_into_iceberg": 1}
-
 
 @pytest.mark.parametrize("format_version", [1, 2])
 @pytest.mark.parametrize("storage_type", ["local", "s3"])
@@ -24,16 +22,16 @@ def test_rename_column_basic(started_cluster_iceberg_no_spark, format_version, s
         format_version,
     )
 
-    instance.query(f"INSERT INTO {TABLE_NAME} VALUES (1, 'hello'), (2, 'world');", settings=INSERT_SETTINGS)
+    instance.query(f"INSERT INTO {TABLE_NAME} VALUES (1, 'hello'), (2, 'world');")
     assert instance.query(f"SELECT id, value FROM {TABLE_NAME} ORDER BY id") == "1\thello\n2\tworld\n"
 
-    instance.query(f"ALTER TABLE {TABLE_NAME} RENAME COLUMN value TO label;", settings=INSERT_SETTINGS)
+    instance.query(f"ALTER TABLE {TABLE_NAME} RENAME COLUMN value TO label;")
 
     # existing rows readable under the new name
     assert instance.query(f"SELECT id, label FROM {TABLE_NAME} ORDER BY id") == "1\thello\n2\tworld\n"
 
     # new inserts work under the new name
-    instance.query(f"INSERT INTO {TABLE_NAME} VALUES (3, 'foo');", settings=INSERT_SETTINGS)
+    instance.query(f"INSERT INTO {TABLE_NAME} VALUES (3, 'foo');")
     assert instance.query(f"SELECT id, label FROM {TABLE_NAME} ORDER BY id") == "1\thello\n2\tworld\n3\tfoo\n"
 
 
@@ -56,14 +54,12 @@ def test_rename_column_errors(started_cluster_iceberg_no_spark, format_version, 
     # rename a column that does not exist — rejected by AlterCommands::validate (NOT_FOUND_COLUMN_IN_BLOCK)
     error = instance.query_and_get_error(
         f"ALTER TABLE {TABLE_NAME} RENAME COLUMN nonexistent TO other;",
-        settings=INSERT_SETTINGS,
     )
     assert "nonexistent" in error
 
     # rename to a name already used by another column — rejected by AlterCommands::validate (DUPLICATE_COLUMN)
     error = instance.query_and_get_error(
         f"ALTER TABLE {TABLE_NAME} RENAME COLUMN value TO id;",
-        settings=INSERT_SETTINGS,
     )
     assert "DUPLICATE_COLUMN" in error
     assert "id" in error

--- a/tests/integration/test_storage_iceberg_no_spark/test_writes_statistics_by_minmax_pruning.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_writes_statistics_by_minmax_pruning.py
@@ -28,8 +28,7 @@ def test_writes_statistics_by_minmax_pruning(started_cluster_iceberg_no_spark, f
         (1, '2024-01-20',
         '2024-02-20 10:00:00',
         'vasya', 5);
-    """,
-    settings={"allow_insert_into_iceberg": 1}
+    """
     )
 
     instance.query(
@@ -38,8 +37,7 @@ def test_writes_statistics_by_minmax_pruning(started_cluster_iceberg_no_spark, f
         (2, '2024-02-20',
         '2024-03-20 15:00:00',
         'vasilisa', 6);
-    """,
-    settings={"allow_insert_into_iceberg": 1}
+    """
     )
 
     instance.query(
@@ -48,8 +46,7 @@ def test_writes_statistics_by_minmax_pruning(started_cluster_iceberg_no_spark, f
         (3, '2025-03-20',
         '2024-04-30 14:00:00',
         'icebreaker', 7);
-    """,
-    settings={"allow_insert_into_iceberg": 1}
+    """
     )
 
     instance.query(
@@ -58,8 +55,7 @@ def test_writes_statistics_by_minmax_pruning(started_cluster_iceberg_no_spark, f
         (4, '2025-04-20',
         '2024-05-30 14:00:00',
         'iceberg', 8);
-    """,
-    settings={"allow_insert_into_iceberg": 1}
+    """
     )
 
 

--- a/tests/integration/test_storage_iceberg_no_spark/test_writes_with_compression_metadata.py
+++ b/tests/integration/test_storage_iceberg_no_spark/test_writes_with_compression_metadata.py
@@ -15,5 +15,5 @@ def test_writes_with_compression_metadata(started_cluster_iceberg_no_spark, form
     create_iceberg_table(storage_type, instance, TABLE_NAME, started_cluster_iceberg_no_spark, "(x String, y Int64)", format_version, use_version_hint=True, compression_method="gzip")
 
     assert instance.query(f"SELECT * FROM {TABLE_NAME} ORDER BY ALL") == ''
-    instance.query(f"INSERT INTO {TABLE_NAME} VALUES ('123', 1);", settings={"allow_insert_into_iceberg": 1, "iceberg_metadata_compression_method": "gzip"})
+    instance.query(f"INSERT INTO {TABLE_NAME} VALUES ('123', 1);", settings={"iceberg_metadata_compression_method": "gzip"})
     assert instance.query(f"SELECT * FROM {TABLE_NAME} ORDER BY ALL") == '123\t1\n'


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Updated datatype of fields in iceberg history from Int32 - Int64 resolves #https://github.com/ClickHouse/ClickHouse/issues/94176

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes

or

Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.

At a minimum, the following information should be added (but add more as needed).
- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?

- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.

- Example use: A query or command.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.559`
<!-- ch-version-info:end -->