### PR TITLE
Fix NameError in clickhouse-test print_stacktraces under macOS multiprocessing spawn

### DIFF
--- a/ci/tests/test_print_stacktraces.py
+++ b/ci/tests/test_print_stacktraces.py
@@ -1,0 +1,77 @@
+"""
+End-to-end test for ``print_stacktraces`` in tests/clickhouse-test.
+
+Background
+----------
+``clickhouse-test`` assigns ``args = parse_args()`` only inside
+``if __name__ == "__main__":``.  On macOS, Python's default multiprocessing
+start method is ``spawn``, which re-imports the module in each worker
+without executing ``__main__`` — so module-level ``args`` is undefined,
+and any helper that closed over it crashed with ``NameError``.  See the
+fast_test_arm_darwin failure where the hung-check path raised
+``NameError: name 'args' is not defined`` inside ``get_server_pid``.
+
+This test reproduces the same import condition by loading
+``clickhouse-test`` via ``runpy.run_path`` (which, like spawn, does not run
+``__main__``) and then invokes ``print_stacktraces`` against the live
+ClickHouse server provided by the ``ClickHouseService`` fixture in
+``ci/jobs/ci_tests_job.py``.  It exercises the full code path:
+
+  * locate the server PID via the portable ``pgrep`` helper,
+  * query ``system.stack_trace`` through ``args.client``,
+  * format and print the result.
+
+Pre-fix: NameError inside the fresh import.
+Post-fix: prints the stack-trace dump and returns.
+"""
+
+import argparse
+import io
+import runpy
+from contextlib import redirect_stdout
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_CLICKHOUSE_TEST = str(_REPO_ROOT / "tests" / "clickhouse-test")
+
+
+def test_print_stacktraces_against_live_server():
+    # Mimic a spawn worker: load clickhouse-test without running __main__,
+    # so module-level `args` is absent.
+    ct = runpy.run_path(_CLICKHOUSE_TEST)
+    assert "args" not in ct, (
+        "module-level 'args' must not be defined outside __main__; otherwise "
+        "the spawn-worker scenario this test reproduces does not apply"
+    )
+
+    # Sanity-check the precondition: the CI tests job started a server.
+    assert ct["pgrep"](command="clickhouse-server"), (
+        "no clickhouse-server process found — this test expects ClickHouseService "
+        "(see ci/jobs/ci_tests_job.py) to be running on localhost:9000"
+    )
+
+    # Minimal args namespace: only the fields print_stacktraces and its
+    # transitive helpers actually read.  Mirrors what __main__ assigns after
+    # parse_args() for a local-server, plaintext-TCP, default-database run.
+    args = argparse.Namespace(
+        client="clickhouse-client --port=9000",
+        client_option=None,
+        secure=False,
+        tcp_host="localhost",
+        http_port=8123,
+        client_options_query_str="",
+        replicated_database=False,
+        shared_catalog=False,
+        force_color=False,
+    )
+
+    captured = io.StringIO()
+    with redirect_stdout(captured):
+        ct["print_stacktraces"](args)
+    output = captured.getvalue()
+
+    # The function must have queried system.stack_trace and printed traces.
+    # We don't require a specific thread name — any non-trivial output
+    # confirms the round-trip succeeded.
+    assert "Collecting stacktraces" in output, output
+    assert "trace_str" in output or "thread_name" in output, output

--- a/ci/tests/test_print_stacktraces.py
+++ b/ci/tests/test_print_stacktraces.py
@@ -45,9 +45,29 @@ def test_print_stacktraces_against_live_server():
     )
 
     # Sanity-check the precondition: the CI tests job started a server.
-    assert ct["pgrep"](command="clickhouse-server"), (
-        "no clickhouse-server process found — this test expects ClickHouseService "
-        "(see ci/jobs/ci_tests_job.py) to be running on localhost:9000"
+    # If this fails, the assertion message includes a process snapshot to
+    # make debugging easy — ClickHouse's watchdog argv0 rewriting, the
+    # container PID namespace, and the pgrep substring search all interact
+    # in non-obvious ways across platforms.  Diagnostics go into the
+    # assertion message (not print) because pytest captures stdout.
+    matches = ct["pgrep"](command="clickhouse-server")
+    if not matches:
+        import subprocess
+        ps_out = subprocess.run(
+            ["ps", "-eo", "pid,ppid,pgid,command"],
+            capture_output=True, text=True, check=False,
+        ).stdout
+        ch_lines = [ln for ln in ps_out.splitlines() if "clickhouse" in ln.lower()]
+        diagnostics = (
+            "ps lines matching 'clickhouse':\n" + "\n".join(ch_lines)
+            if ch_lines
+            else "no 'clickhouse' substring in ps output; head of ps:\n"
+            + "\n".join(ps_out.splitlines()[:30])
+        )
+    assert matches, (
+        "no clickhouse-server process found — this test expects "
+        "ClickHouseService (see ci/jobs/ci_tests_job.py) to be running.\n"
+        f"{diagnostics}"
     )
 
     # Minimal args namespace: only the fields print_stacktraces and its

--- a/ci/tests/test_print_stacktraces.py
+++ b/ci/tests/test_print_stacktraces.py
@@ -45,29 +45,9 @@ def test_print_stacktraces_against_live_server():
     )
 
     # Sanity-check the precondition: the CI tests job started a server.
-    # If this fails, the assertion message includes a process snapshot to
-    # make debugging easy — ClickHouse's watchdog argv0 rewriting, the
-    # container PID namespace, and the pgrep substring search all interact
-    # in non-obvious ways across platforms.  Diagnostics go into the
-    # assertion message (not print) because pytest captures stdout.
-    matches = ct["pgrep"](command="clickhouse-server")
-    if not matches:
-        import subprocess
-        ps_out = subprocess.run(
-            ["ps", "-eo", "pid,ppid,pgid,command"],
-            capture_output=True, text=True, check=False,
-        ).stdout
-        ch_lines = [ln for ln in ps_out.splitlines() if "clickhouse" in ln.lower()]
-        diagnostics = (
-            "ps lines matching 'clickhouse':\n" + "\n".join(ch_lines)
-            if ch_lines
-            else "no 'clickhouse' substring in ps output; head of ps:\n"
-            + "\n".join(ps_out.splitlines()[:30])
-        )
-    assert matches, (
-        "no clickhouse-server process found — this test expects "
-        "ClickHouseService (see ci/jobs/ci_tests_job.py) to be running.\n"
-        f"{diagnostics}"
+    assert ct["pgrep"](command="clickhouse-server"), (
+        "no clickhouse-server process found — this test expects ClickHouseService "
+        "(see ci/jobs/ci_tests_job.py) to be running on localhost:9000"
     )
 
     # Minimal args namespace: only the fields print_stacktraces and its

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -987,7 +987,11 @@ def get_stacktraces_from_clickhouse(args):
     return shell_get_output(msg)
 
 def pgrep(ppid: int = None, pgid: int = None, command: str = None) -> List[List[str]]:
-    ps = shell_get_output("ps -eo pid,ppid,pgid,command").splitlines()[1:]
+    # -ww disables line-width truncation of the command column.  Without it,
+    # ps cuts the cmdline at 80 chars when stdout is not a TTY, which can hide
+    # the "clickhouse-server" substring when the binary lives deep in the
+    # filesystem (e.g. /home/ubuntu/actions-runner/_work/.../ci/tmp/...).
+    ps = shell_get_output("ps -ww -eo pid,ppid,pgid,command").splitlines()[1:]
     ps = [p.split(None, 3) for p in ps]
     ps = [[int(p[0]), int(p[1]), int(p[2]), p[3]] for p in ps]
 

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1006,7 +1006,7 @@ def get_all_server_pids():
     return [p[0] for p in pgrep(pgid=pgid, command="clickhouse-server")]
 
 
-def is_asan_build():
+def is_asan_build(args):
     """Check if the server is an ASan build — gdb disables LeakSanitizer detections."""
     try:
         result = clickhouse_execute(
@@ -1019,14 +1019,14 @@ def is_asan_build():
         return bool(os.environ.get("ASAN_OPTIONS"))
 
 
-def print_stacktraces() -> None:
+def print_stacktraces(args) -> None:
     server_pid = get_server_pid()
 
     bt = None
 
     # Collect gdb stacktraces from all server processes (main + replicas).
     # Skip gdb under ASan — it disables LeakSanitizer detections.
-    if not is_asan_build():
+    if not is_asan_build(args):
         all_pids = get_all_server_pids()
         if all_pids:
             parts = []
@@ -1052,8 +1052,8 @@ def print_stacktraces() -> None:
 
     print(
         colored(
-            f"\nUnable to locate ClickHouse server process listening at TCP port "
-            f"{args.tcp_port}. It must have crashed or exited prematurely!",
+            f"\nUnable to locate any ClickHouse server process. "
+            f"It must have crashed or exited prematurely!",
             args,
             "red",
             attrs=["bold"],
@@ -1062,22 +1062,15 @@ def print_stacktraces() -> None:
 
 
 def get_server_pid():
-    # lsof does not work in stress tests for some reason
-    cmd_lsof = f"lsof -i tcp:{args.tcp_port} -s tcp:LISTEN -Fp | sed 's/^p//p;d'"
-    cmd_pidof = "pidof -s clickhouse-server"
-
-    commands = [cmd_lsof, cmd_pidof]
-    output = None
-
-    for cmd in commands:
-        try:
-            output = shell_get_output(cmd)
-            if output:
-                return int(output)
-        except Exception as e:
-            print(f"Cannot get server pid with {cmd}, got {output}: {e}")
-
-    return None  # most likely server is dead
+    # Use the portable pgrep helper (built on `ps -eo pid,ppid,pgid,command`)
+    # so this works on both Linux and macOS — `pidof` does not exist on
+    # macOS, and `lsof -i tcp:PORT` would require knowing the port (only
+    # available on `args`, which is undefined in multiprocessing children
+    # spawned with the `spawn` start method).
+    procs = pgrep(command="clickhouse-server")
+    if not procs:
+        return None  # most likely server is dead
+    return procs[0][0]
 
 
 def colored(text, args, color=None, on_color=None, attrs=None):
@@ -4312,7 +4305,7 @@ def run_tests_array(
                 failures_total += 1
                 failures_chain += 1
                 if test_result.reason == FailureReason.SERVER_DIED:
-                    print_stacktraces()
+                    print_stacktraces(args)
                     stop_tests()
                     stop_testing.set()
                     raise ServerDied("Server died")
@@ -4772,7 +4765,7 @@ def do_run_tests(
             if args.hung_check:
                 if not check_server_liveness(args):
                     print("Hung check failed: server is not responding")
-                    print_stacktraces()
+                    print_stacktraces(args)
                     stop_testing.set()
 
             if stop_testing.is_set():
@@ -5077,7 +5070,7 @@ def main(args):
             print(msg)
             pid = get_server_pid()
             print("Got server pid", pid)
-            print_stacktraces()
+            print_stacktraces(args)
         raise TestException(msg)
 
     if args.cloud:
@@ -5480,7 +5473,7 @@ ORDER BY (test_name, callee_offset)
             print(processlist.decode())
             print(get_transactions_list(args))
 
-            print_stacktraces()
+            print_stacktraces(args)
             exit_code.value = 1
         elif not hung_check_failed:
             print(colored("\nNo queries hung.", args, "green", attrs=["bold"]))


### PR DESCRIPTION
On macOS, Python's default `multiprocessing` start method is `spawn`, which re-imports the module in each worker process without executing `__main__`. `tests/clickhouse-test` assigns `args = parse_args()` only inside `if __name__ == "__main__":`, so module-level `args` is undefined in workers. When the hung-check path or a `server_died` handler called `print_stacktraces` from a worker, the helpers raised `NameError: name 'args' is not defined`.

Seen on `fast_test_arm_darwin` in PR #93830:
https://s3.amazonaws.com/clickhouse-test-reports/PRs/93830/bdb44368268a89e2039ccc58c5774e55d7a48228/fast_test_arm_darwin/job.log

The fix:

- `get_server_pid` now uses the existing portable `pgrep` helper (built on `ps -eo pid,ppid,pgid,command`) and no longer references `args.tcp_port`. This works on both Linux and macOS — unlike `pidof`, which is not available on macOS, and `lsof -i tcp:PORT`, which needed `args.tcp_port`.
- `print_stacktraces` and `is_asan_build` now accept `args` as an explicit parameter. All four call sites already had `args` in local scope and were updated to pass it in.
- New `ci/tests/test_print_stacktraces.py` reproduces the spawn import scenario via `runpy.run_path` (which, like `spawn`, does not run `__main__`) and invokes `print_stacktraces` against the live `ClickHouseService` server. Verified end-to-end with `python3 -m ci.praktika run "CI Tests" --test print_stacktraces`.

### Changelog category (leave one):
- CI Fix or Improvement

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.581`
<!-- ch-version-info:end -->