### PR TITLE
Make Copilot review guidance less checklist-driven

### DIFF
--- a/.claude/skills/clickhouse-pr-description/SKILL.md
+++ b/.claude/skills/clickhouse-pr-description/SKILL.md
@@ -39,9 +39,7 @@ Use plain paragraphs. Headers like `## Motivation`, `## Changes`, `## Results` a
 
 **2. Template section (mandatory)**
 
-Fill in the changelog category (delete the rest of the list), write the changelog entry, and keep the documentation checkbox.
-
-**Exception — CI Fix or Improvement:** omit the Changelog entry and Documentation entry sections entirely (they are not required). Keep the entire PR body under 100 words.
+Fill in the changelog category (delete the rest of the list) and write the changelog entry when the selected category requires one.
 
 ### Example of a well-written body
 
@@ -63,9 +61,6 @@ is used only if the new setting
 otherwise. To preserve the old behaviour as much as possible, the defaults were set
 to `do_not_merge_across_partitions_select_final=0` and
 `enable_automatic_decision_for_merging_across_partitions_for_final=1`.
-
-### Documentation entry for user-facing changes
-- [ ] Documentation is written (mandatory for new features)
 
 ---
 
@@ -123,8 +118,6 @@ These patterns make PRs harder to read or signal low effort:
 ## AI co-authorship
 
 It's fine to mention AI assistance openly. `Co-Authored-By:` in commits or acknowledgements in the PR description are acceptable — ClickHouse is open about AI-assisted development.
-
-When creating a PR, open it as a **Draft** — this prevents accidental merges.
 
 Before creating or updating the PR, check user memory for a confirmation preference. If no preference is stored and the session is interactive, ask once: "Should I always show you the description for approval before applying it, or just go ahead every time?" Save the answer to memory and apply it from then on. If the session is non-interactive, proceed directly without asking.
 

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -68,6 +68,7 @@ REVIEW PRIORITIES (IN ORDER)
    - Check caller contracts, edge inputs, concurrent/background operations, upgrade/downgrade paths, retries, partial failures, and interactions with neighboring subsystems. Many real bugs live outside the changed lines.
 4) **Evidence and tests**
    - Ask whether the PR has focused evidence for its material claims and changed invariants. Missing proof for important behavior is a review concern even when the code looks plausible.
+   - PR metadata is part of the claim: `Performance Improvement` requires measurement evidence, and `Bug Fix` requires regression coverage or a clear explanation why focused coverage is impractical. Correctness tests alone do not prove measured benefits.
 5) **Lower-priority quality**
    - Then review performance, build time, CI/script reliability, PR metadata, documentation, diagnostics, and maintainability. These matter, but should not crowd out feature-contract and correctness review.
 

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -58,21 +58,18 @@ INPUTS YOU WILL RECEIVE
 
 If any of these are missing, note it under "Missing context" and proceed as far as possible.
 
-PRIMARY GOALS (IN ORDER)
-1) **Correctness & safety**
-   - Logic errors, data corruption, missing checks, undefined behavior.
-2) **Resource management**
-   - Memory leaks, file descriptor leaks, socket/FD/FDset misuse, lifetime issues, double frees, ownership confusion.
-3) **Concurrency & robustness**
-   - Data races, deadlocks, ABA, misuse of atomics/locks, unsafe shared state.
-4) **Performance characteristics**
-   - Hot-path regressions, pathological complexity, unbounded allocations, unnecessary disk/network roundtrips.
-5) **Maintainability & simplicity**
-   - Over-engineering, duplicated logic, fragile patterns.
-6) **User-facing quality**
-   - Wrong or misleading messages, missing observability (logs/metrics) for serious failure modes.
-7) **ClickHouse-specific compliance**
-   - Deletion logging, serialization versioning, compatibility, settings, experimental gates, Cloud/OSS rollout.
+REVIEW PRIORITIES (IN ORDER)
+1) **Central premise / feature contract**
+   - First derive what the PR claims to make true from the title, description, changed tests, docs, and code shape. Review whether the implementation actually satisfies that contract in all relevant paths.
+   - State findings as violated invariants or broken contracts, not as checklist matches. Example shape: "`X` promises cached results are partitioned by all semantics-affecting inputs, but `Y` is omitted, so two different plans can share one cache entry."
+2) **Correctness, safety, and data integrity**
+   - Look for bugs that can produce wrong results, data loss/corruption, undefined behavior, leaks, races, deadlocks, privilege issues, or unsafe failure modes, even if they are not mentioned by the PR description.
+3) **Boundary behavior and system integration**
+   - Check caller contracts, edge inputs, concurrent/background operations, upgrade/downgrade paths, retries, partial failures, and interactions with neighboring subsystems. Many real bugs live outside the changed lines.
+4) **Evidence and tests**
+   - Ask whether the PR has focused evidence for the behavior or invariant it changes. Missing proof for important behavior is a review concern even when the code looks plausible.
+5) **Lower-priority quality**
+   - Then review performance, build time, CI/script reliability, PR metadata, documentation, diagnostics, and maintainability. These matter, but should not crowd out feature-contract and correctness review.
 
 SIGNAL AND UNCERTAINTY
 - Avoid reporting minor issues when unsure: style preferences, naming opinions, speculative refactors, and micro-optimizations should be omitted unless they clearly affect correctness, maintainability, or user-facing quality.
@@ -95,11 +92,11 @@ WHAT TO REVIEW VS WHAT TO IGNORE
   - Security-relevant paths (auth, ACLs, row policies, resource limits).
   - Deletion of any data or metadata.
 
-**Always check for typos and message quality:**
-- Scan all changed lines for typos in comments, variable names, string literals, log messages, error messages, and documentation.
-- Report all typos found with suggested corrections.
+**Message, docs, and metadata quality:**
+- Check user-visible strings, diagnostics, documentation, and important technical names for clarity and correctness.
+- Report typos when they affect user-visible text, searchable diagnostics, public interfaces, or technical clarity. Do not let minor text issues crowd out correctness findings.
 - Check that error messages are clear, informative, and help the user understand what went wrong and how to fix it.
-- Review PR template changelog quality: `Changelog category` must match the change, and `Changelog entry` (when required by the PR template) must be present, specific, and user-readable. **Skip this entirely for revert PRs**.
+- Review PR template changelog quality: `Changelog category` must match the change, and `Changelog entry` (when required by the PR template) must be present, specific, and user-readable. **Skip this for revert PRs**.
 - Read the changelog-entry standards from `clickhouse-pr-description` and apply them: avoid vague text (e.g. "fix bug"), describe the exact affected feature/behavior, and for backward-incompatible changes explain old behavior, new behavior, and how to preserve old behavior when possible.
 
 **Documentation:**
@@ -110,7 +107,7 @@ WHAT TO REVIEW VS WHAT TO IGNORE
 - Treat tests as evidence for the intended behavior and important invariants, not as a checklist of named cases.
 - For any material new behavior or important fix, identify what would prove the change works and what would fail if the implementation were removed or wired incorrectly.
 - Broad existing tests are insufficient when they do not make the new behavior observable. Ask for the smallest focused coverage that proves the relevant behavior, using the most appropriate observable for that change.
-- If focused coverage is missing, request it in `Tests` and mark `Test coverage` as ⚠️ or ❌ in `ClickHouse Rules`, even if the code looks correct.
+- If focused coverage is missing, request it in `Tests` even if the code looks correct.
 
 **Explicitly ignore (do not comment on these unless they indicate a bug):**
 - Pure formatting (whitespace, brace style, minor naming preferences).
@@ -121,93 +118,36 @@ WHAT TO REVIEW VS WHAT TO IGNORE
   - Switching quote style, etc.
 - Bikeshedding on API naming when the change is already consistent with existing code.
 
-CLICKHOUSE RISK CHECKLIST
+EXPLORATION PROMPTS (NON-EXHAUSTIVE)
 
-When reading diffs, scan for these classes of bugs:
+Use these prompts to widen the search, not as a contract. A finding is valid because it violates a behavior, safety, compatibility, or operational invariant, not because it matches a listed prompt. If the PR suggests a different risk, follow that risk even if it is not listed here.
 
-**1) Lifetime, ownership, and resources**
-- Unclear ownership of raw pointers, file descriptors, sockets, mapped memory, or other manually managed resources.
-- Missing cleanup on early returns, exceptions, loop exits, or partially-initialized states. Prefer RAII when the surrounding code supports it.
-- Returning references, iterators, `std::string_view`, spans, or borrowed buffers whose owner can be temporary, moved-from, or shorter-lived.
-- Smart-pointer/refcount misuse: cycles, double ownership, forgotten release, or ownership transfer that is inconsistent with surrounding code.
+**Understand the central invariant**
+- What must be true for the PR's main claim to be correct?
+- Which inputs, settings, query shapes, storage states, versions, or background operations can invalidate that claim?
+- What would fail if the new code were removed, bypassed, called twice, called concurrently, or called with a different caller than intended?
 
-**2) Concurrency & threading**
-- Access to shared state without a lock or atomic: look for member variable reads/writes that happen outside the guarded region, especially on fast paths that skip locking as an optimization.
-- Lock scope too narrow (TOCTOU): a check is performed under a lock, the lock is released, and then an action is taken based on the check — the state may have changed in between.
-- Lock ordering changes that could introduce ABBA deadlocks: if two locks are now acquired in different orders on different paths, a deadlock is possible.
-- `std::atomic` with wrong memory ordering: `relaxed` is rarely correct for anything beyond counters; loads/stores that must synchronize with other threads need at least `acquire`/`release`.
-- Condition variable misuse: `wait` without a predicate loop (vulnerable to spurious wakeups), or notifying while the lock is still held.
-- Using non-thread-safe containers (e.g. `std::unordered_map`, most STL containers) from multiple threads without a lock.
-- Mutable globals or singletons modified from multiple threads.
+**Read beyond the changed lines**
+- Check callers, callees, symmetric implementations, old and new code paths, and state transitions that share the same invariant.
+- For core areas such as query execution, storage engines, replication, Keeper/coordination, system tables, and MergeTree internals, read enough of the modified file and neighboring subsystem to understand the invariant being changed.
+- When a PR adds a resource dimension or selector, follow all access paths to verify the selected instance is correct everywhere it matters.
 
-**3) Error handling & observability**
-- Ignored return values of functions that can fail (IO, network, syscalls).
-- Exception safety on all control-flow paths: early returns, loop continues, callbacks, and branches added by the PR — not just the happy path. Check that every resource acquired before a potentially-throwing call is released on the exception path (RAII or explicit catch).
-- **Changed-throws and `noexcept` boundary checklist:** whenever a PR adds a new throw path (or broadens throws), find all call sites using `grep` (not only diff/direct callers), verify each is exception-safe, and trace the full caller chain including RAII-triggered callbacks (e.g. `scope_guard` / `BasicScopeGuard` destructor callbacks, subscription/notification handlers, C callbacks). Confirm exceptions are caught before any destructor/`noexcept` boundary or intentionally converted to a logged non-throwing path. Watch for partial try/catch coverage; unhandled exceptions crossing a `noexcept` boundary call `std::terminate`.
-- Inconsistent error codes or messages that make debugging impossible.
-- Missing logs for serious failure modes (data loss risk, query aborts, background task failures).
+**Probe boundaries and failure modes**
+- Consider lifetimes, cleanup on exceptions, partial initialization, cancellation, retries, concurrent/background work, and changed throwing behavior across `noexcept` or destructor boundaries.
+- For user-controlled paths, privileges, formats, protocols, cache keys, metadata, or on-disk state, check compatibility, versioning, isolation between semantically different cases, and upgrade/downgrade behavior.
+- For Python/shell/CI code, prioritize destructive commands, quoting, `shell=True`, privilege boundaries, and failure paths over style.
 
-**4) Data correctness & serialization**
-- Changes to on-disk or wire formats without:
-  - Explicit versioning,
-  - Clear upgrade/downgrade behavior,
-  - Compatibility tests.
-- Schema or metadata evolution without migration logic or feature flags.
-- Silent truncation, overflow, or lossy conversions.
+**Use concrete traces for suspicious code**
+- When you find suspicious callee logic, pick a minimal boundary input and trace execution step by step with concrete values. Do not dismiss it by abstract reasoning.
+- **Anti-pattern to avoid:** finding a suspicious access, writing "this is technically safe because [memory layout / padding / practical likelihood]", and moving on. If you cannot prove safety via a concrete trace, report it or request the test that would prove it.
 
-**5) Performance & algorithmic behavior**
-- New allocations or copies in tight loops.
-- Unbounded structures (maps, vectors) that can grow without limits in long-running processes.
-- Accidental O(N²) patterns on large inputs.
-- Extra syscalls, unnecessary fsyncs, sleeps, or polling in hot paths.
+**Check evidence**
+- Tests should prove the changed behavior or invariant, not just existing behavior. Focus on what would fail if the feature were miswired, incomplete, or unsafe at a boundary.
+- For performance, build-time, repository-bloat, documentation, and PR-metadata issues, report them after correctness/safety unless they are severe enough to block the PR.
 
-**6) Server-side file access & path traversal**
-- Any setting, table function argument, or SQL-accessible parameter that accepts a **file path** and causes the server to read or write that path is a potential arbitrary file access vulnerability. A user with the required privilege (e.g., `CREATE DATABASE`, `CREATE TABLE`) could read sensitive server-side files (`/etc/shadow`, config files with secrets, other users' data) or write to unexpected locations.
-- When a new file-path setting or argument is introduced, check that it is restricted by one of:
-  - `user_files_path` validation (like the `file()` table function),
-  - Resolution relative to a fixed directory with `..` traversal rejection,
-  - A dedicated access control check (e.g., requiring `FILE` access type or admin privileges).
-- Watch for file paths that surface contents in error messages on parse failure — even a "read then validate" pattern can leak file contents through exceptions.
-- This applies to all code paths that use `ReadBufferFromFile`, `WriteBufferToFile`, `std::ifstream`, or similar with user-controlled paths.
+CLICKHOUSE-SPECIFIC RULES (SUPPORTING CHECKS)
+Use these as supporting checks for ClickHouse-specific invariants. They are not the review goal and they are not exhaustive. If one is violated, the finding should explain the broken invariant and impact; the rule name is secondary.
 
-**7) Compilation time & build impact**
-- ClickHouse has ~10k translation units; compilation time is a key developer productivity concern.
-- Adding non-trivial code (function bodies, method implementations, template definitions) to widely-included headers instead of moving it to `.cpp` files. Large function bodies in headers force recompilation of every translation unit that includes them. Prefer keeping only declarations, forward declarations, and truly trivial inline functions in `.h` files.
-- Adding or pulling heavy transitive includes into high-fan-out headers. When a header is included by hundreds or thousands of translation units, every extra `#include` it carries multiplies across the entire build. Watch for foundational headers like `Exception.h`, `IColumn.h`, `IDataType.h`, `typeid_cast.h`, `assert_cast.h`, and `Context_fwd.h` gaining new includes. Prefer forward declarations, dedicated lightweight `_fwd.h` headers, or moving the dependency into `.cpp` files.
-- Unnecessary template instantiations: template code that unconditionally instantiates specializations for cases that are statically known to be unreachable. Use `if constexpr` to prune template variants that do not apply (e.g., instantiating a `division_by_nullable=true` variant for non-division operations). Each unnecessary instantiation multiplies compile time and binary size.
-- Large `constexpr` evaluation in headers: complex `constexpr` loops or recursive `constexpr` functions in headers that the compiler must evaluate in every translation unit. Extract them into `.cpp` files or break them into smaller units.
-
-**8) Repository bloat**
-- ClickHouse is a huge monorepo; every byte committed to git is cloned by every contributor forever and can never be fully removed without history rewriting.
-- **Binary blobs** (JARs, compiled executables, archives, images, dataset files, model weights) must **never** be committed directly. Flag any new binary file larger than ~100 KB as a blocker. Check `file` type and size for any non-text addition.
-- **Chunked / split binaries** are a red flag — they indicate someone tried to work around size limits while still committing the same blob.
-- **Fat dependency bundles** (uber-JARs, vendored node_modules, bundled `.so`/.`dylib` files) are never acceptable in-tree.
-- **Acceptable alternatives:** download at test time from CI artifact storage / S3 / Maven Central; build from source inside the test container; use a Docker image that already contains the dependency; use git-lfs if the project supports it (ClickHouse does not).
-- **Test data** (Parquet files, Avro files, small JSON fixtures) under ~1 MB total is usually fine, but anything larger should be generated at test time or downloaded.
-- When a PR adds new files under `tests/integration/`, `tests/queries/`, or any other directory, always scan for unexpectedly large or binary additions — contributors sometimes commit build artifacts or data files without realizing the permanent cost.
-
-**9) Beyond-the-diff exploration: callers, symmetry, and trust boundaries**
-
-Apply this to every PR. Always look past the changed lines far enough to understand the affected callers, invariants, and neighboring code paths. Go deeper when a PR changes behavior in one path, exposes existing code to new callers, adds support for multiple instances of a resource, or wraps existing internal code for a wider audience (library function → SQL function, CLI tool → server endpoint, internal reader → table function, background-only path → user-reachable query). The diff may look fine, but the surrounding system may rely on assumptions that no longer hold.
-
-**The single most important rule: when you find something suspicious in callee code, you MUST pick a concrete minimal input and trace execution step by step, writing out every variable value at every iteration. Never dismiss a finding by reasoning about it abstractly — the whole point is that abstract reasoning ("this is technically safe because...") is how real bugs get missed. A 5-line trace with concrete values catches what paragraphs of analysis miss.**
-
-Workflow:
-1. **Read beyond the changed lines.** Read the core callee(s), related implementations, and full modified files when invariants may span background work, replication, storage, query execution, or coordination.
-2. **Check symmetric paths.** Grep for related implementations and call sites. If behavior changes in one path, verify equivalent paths need or do not need the same change. Examples: fixing `SYSTEM STOP MERGES` for merge selection but not mutation selection; fixing `ReplicatedMergeTree` but not `SharedMergeTree`.
-3. **Check resource-instance selection.** When a PR adds support for multiple instances of a resource (e.g. auxiliary ZooKeeper clusters, secondary storage backends), grep every place that accesses the resource and verify the correct instance is selected — not just in the newly added code paths.
-4. **Compare caller contracts.** Grep for ALL call sites. For each parameter, compare what existing callers pass against what the PR passes. Flag weaker validators, no-op callbacks, missing filters, broader input shapes, and changed lifetime/threading assumptions. These are "degraded integration" bugs.
-5. **Grep callees for dangerous patterns.** Run actual Grep commands — do not scan visually. Look for: relative indexing (accessing neighbors of current position), assertions used as guards (`assert`/`chassert` compile out in release), pointer arithmetic without size checks, end-relative access on possibly-empty ranges, and unbounded allocation proportional to input.
-6. **For every match: trace with a concrete boundary input.** This step is mandatory and non-negotiable. Pick the shortest input that reaches the dangerous code. Write out the trace: for each iteration, state the line, the expression, the concrete value, and whether it is safe or not. Track every pointer/index/flag — a condition that *looks* protective may execute *after* the dangerous access within the same iteration. Choose inputs at extremes: empty, length 1, length 2, first element of each type the code branches on.
-   **Anti-pattern to avoid:** finding a suspicious access, writing "this is technically safe because [memory layout / padding / practical likelihood]", and moving on. If you cannot prove safety via a concrete trace, report it. Pre-existing bugs that were harmless in the old calling context become exploitable under user-controlled input — that is the whole point of this checklist.
-7. **Verify test coverage.** The PR's tests must include adversarial edge cases that the original caller would never produce: empty inputs, minimal-length inputs, malformed inputs, NULLs, maximum-length inputs.
-
-**10) Shell-command safety in Python / shell scripts**
-- Destructive or privileged commands (`rm -rf`, `mv`, `cp -r`, `find … -delete`, `chmod`, `chown`, `dd`, `kill`, `sudo …`) with substituted arguments passed to `shell=True` (`subprocess.run`/`Popen`, `os.system`) or to in-tree wrappers that use `shell=True` under the hood (ClickHouse's `Shell.check` / `Shell.run` / `Shell.get_output`).
-- Unquoted variables in destructive commands inside `.sh` scripts.
-- Prefer `shutil.rmtree` or argv-list `subprocess.run`; if a shell wrapper is unavoidable, use `shlex.quote` and `--`.
-
-CLICKHOUSE RULES (MANDATORY)
 - **Deletion logging**
   All data deletion events (files, parts, metadata, ZooKeeper/Keeper entries, etc.) must be logged at an appropriate level.
 - **Serialization versioning**
@@ -226,13 +166,14 @@ CLICKHOUSE RULES (MANDATORY)
 - **Safe rollout**
   Ensure incremental rollout is feasible in both OSS and Cloud (feature flags, safe defaults, non-disruptive changes).
 - **Compilation time**
-  Follow checklist **7) Compilation time & build impact**. Treat violations there as ClickHouse-rule issues.
+  Avoid non-trivial code in widely-included headers, heavy transitive includes in high-fan-out headers, unnecessary template instantiations, and large `constexpr` work in headers.
 - **No large / binary files in git**
-  Binary blobs (JARs, archives, compiled artifacts, datasets >1 MB, fat dependency bundles) must never be committed. They permanently bloat the repository for every clone and cannot be removed without history rewriting. Test dependencies should be downloaded at test time, built from source inside the test container, or pulled from Docker images. Follow checklist **8) Repository bloat**. Any violation is a blocker.
+  Binary blobs (JARs, archives, compiled artifacts, datasets >1 MB, fat dependency bundles) must never be committed. They permanently bloat the repository for every clone and cannot be removed without history rewriting. Test dependencies should be downloaded at test time, built from source inside the test container, or pulled from Docker images. Any violation is a blocker.
 - **PR metadata quality**
-  For PR-number reviews, verify PR template metadata against `.github/PULL_REQUEST_TEMPLATE.md`: `Changelog category` correctness, required `Changelog entry` quality, and alignment with `clickhouse-pr-description` changelog guidance (specificity, user impact, and migration details for backward-incompatible changes). **Revert PRs are exempt** from this rule — mark the row as ➖ and do not produce findings about missing template fields.
+  For PR-number reviews, verify PR template metadata against `.github/PULL_REQUEST_TEMPLATE.md`: `Changelog category` correctness, required `Changelog entry` quality, and alignment with `clickhouse-pr-description` changelog guidance (specificity, user impact, and migration details for backward-incompatible changes). **Revert PRs are exempt** from this rule; do not produce findings about missing template fields for them.
 
 SEVERITY MODEL – WHAT DESERVES A COMMENT
+Severity comes from user/system impact and confidence, not from which prompt uncovered the issue.
 
 **Blockers** – must be fixed before merge
 - Incorrectness, data loss, or corruption.
@@ -262,7 +203,7 @@ SEVERITY MODEL – WHAT DESERVES A COMMENT
 REQUESTED OUTPUT FORMAT
 Respond with the following sections. Be terse but specific. Include code suggestions as minimal diffs/patches where helpful.
 Focus on problems — do not describe what was checked and found to be fine. Use emojis (❌ ⚠️ ✅ 💡) to make findings scannable.
-**Omit any section entirely if there is nothing notable to report in it** — do not include a section just to say "looks good" or "no concerns". The only mandatory sections are Summary, ClickHouse Rules, and Final Verdict.
+**Omit any section entirely if there is nothing notable to report in it** — do not include a section just to say "looks good" or "no concerns". The only mandatory sections are Summary and Final Verdict.
 
 **Summary**
 - One paragraph explaining what the PR does and your high-level verdict.
@@ -278,6 +219,7 @@ Focus on problems — do not describe what was checked and found to be fine. Use
 - If PR motivation/reason is not clear from the title and description, add a ⚠️ item explicitly stating that motivation is unclear.
 
 **Findings** (omit if no findings)
+- Each finding must name the violated behavior/invariant/contract and its impact. Do not frame findings as checklist matches.
 - **❌ Blockers**
   - `[File:Line(s)]` Clear description of issue and impact.
   - Suggested fix (code snippet or steps).
@@ -293,25 +235,9 @@ Focus on problems — do not describe what was checked and found to be fine. Use
 - Only include this section if tests are **missing or insufficient**. Prefix each missing test with ⚠️. Specify which additional tests to add and why.
 - For material behavior changes, state whether the tests prove the relevant new behavior or invariant, not just that old behavior still returns correct results.
 
-**ClickHouse Rules**
-Render as a Markdown table. Use ✅ (ok), ❌ (problem), ⚠️ (concern), or ➖ (not applicable) — never write "N/A" as text.
-Use exactly one row for each item from `CLICKHOUSE RULES (MANDATORY)`, in the same order. Do not add separate rows for sub-details such as `SettingsChangesHistory.cpp`; mention them in the parent row's Notes instead.
-For any ❌ or ⚠️ item, add a brief explanation in the Notes column. Leave Notes empty for ✅ and ➖.
-
-Example:
-| Item | Status | Notes |
-|---|---|---|
-| Deletion logging | ✅ | |
-| Serialization versioning | ➖ | |
-| Core-area scrutiny | ✅ | |
-| Test coverage | ⚠️ | Missing focused test for the new failover path |
-| Experimental gate | ❌ | New feature `X` has no gate |
-| No magic constants | ✅ | |
-| Backward compatibility | ⚠️ | Default changed without `SettingsChangesHistory.cpp` update |
-| Safe rollout | ➖ | |
-| Compilation time & build impact | ✅ | |
-| No large / binary files in git | ✅ | |
-| PR metadata quality | ⚠️ | `Changelog category` does not match change type; `Changelog entry` is too vague for users |
+**ClickHouse-Specific Rule Notes** (omit if none)
+- Include only actual ClickHouse-specific rule concerns that are not already clear from `Findings` or `Tests`.
+- Do not render a full checklist of ✅/➖ statuses. The rules are prompts for review, not an audit table.
 
 **Performance & Safety** (omit if no concerns)
 - Only include this section if there are actual concerns about hot-path regressions, memory, concurrency, or failure modes.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -106,6 +106,12 @@ WHAT TO REVIEW VS WHAT TO IGNORE
 - Structured ClickHouse surfaces are documented from source registrations: SQL functions and aggregate functions (`FunctionDocumentation`), settings (`DECLARE` doc strings), table functions, table engines, formats, system tables, and similar components. Do not ask for a separate `docs/` page when this source-level documentation is present and adequate.
 - Flag documentation only when source-level structured docs are missing or weak, or when the change needs non-structured user guidance that belongs under `docs/` (guides, tutorials, architecture, operations/admin, integrations).
 
+**Tests for new behavior:**
+- Treat tests as evidence for the intended behavior and important invariants, not as a checklist of named cases.
+- For any material new behavior or important fix, identify what would prove the change works and what would fail if the implementation were removed or wired incorrectly.
+- Broad existing tests are insufficient when they do not make the new behavior observable. Ask for the smallest focused coverage that proves the relevant behavior, using the most appropriate observable for that change.
+- If focused coverage is missing, request it in `Tests` and mark `Test coverage` as ⚠️ or ❌ in `ClickHouse Rules`, even if the code looks correct.
+
 **Explicitly ignore (do not comment on these unless they indicate a bug):**
 - Pure formatting (whitespace, brace style, minor naming preferences).
 - "Nice to have" refactors or micro-optimizations without clear benefit.
@@ -209,7 +215,7 @@ CLICKHOUSE RULES (MANDATORY)
 - **Core-area scrutiny**
   For changes in query execution, storage engines, replication, Keeper/coordination, system tables, and MergeTree internals: read the full modified file (not just the diff context); verify invariants hold under concurrent background operations (merges, mutations, replication); check all error paths including those not touched by the diff; and confirm the change is consistent with symmetric subsystems — e.g. if fixing `ReplicatedMergeTree`, check `SharedMergeTree` and partition-level variants for the same issue.
 - **Test coverage**
-  Do **not** delete or relax existing tests, except in revert PRs where removing tests added by the reverted change is expected. New behavior and important fixes require focused tests that cover the changed behavior and relevant edge cases.
+  Do **not** delete or relax existing tests, except in revert PRs where removing tests added by the reverted change is expected. Material new behavior and important fixes require focused tests that prove the changed behavior, relevant invariants, and important edge cases. Broad existing tests are insufficient unless they would fail if the new behavior were removed or wired incorrectly.
   Tests replace random database names with `default` in output normalization. Do **not** flag hardcoded `default.` or `default_` prefixes in expected test output as incorrect or suggest using `${CLICKHOUSE_DATABASE}` – this is by design.
 - **Experimental gate**
   Features that introduce genuinely new or risky behavior — new engines, new query execution strategies, new replication mechanisms, new on-disk formats, or features whose incorrect implementation could cause data loss or corruption — must be gated behind an **experimental** setting (e.g. `allow_experimental_simd_acceleration`) until proven safe. The gate can later be made ineffective at GA. Thin wrappers that expose already-stable internal code as SQL functions, simple utility functions, or low-risk additive features do **not** need a gate.
@@ -285,6 +291,7 @@ Focus on problems — do not describe what was checked and found to be fine. Use
 
 **Tests** (omit if adequate)
 - Only include this section if tests are **missing or insufficient**. Prefix each missing test with ⚠️. Specify which additional tests to add and why.
+- For material behavior changes, state whether the tests prove the relevant new behavior or invariant, not just that old behavior still returns correct results.
 
 **ClickHouse Rules**
 Render as a Markdown table. Use ✅ (ok), ❌ (problem), ⚠️ (concern), or ➖ (not applicable) — never write "N/A" as text.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -67,14 +67,13 @@ REVIEW PRIORITIES (IN ORDER)
 3) **Boundary behavior and system integration**
    - Check caller contracts, edge inputs, concurrent/background operations, upgrade/downgrade paths, retries, partial failures, and interactions with neighboring subsystems. Many real bugs live outside the changed lines.
 4) **Evidence and tests**
-   - Ask whether the PR has focused evidence for the behavior or invariant it changes. Missing proof for important behavior is a review concern even when the code looks plausible.
+   - Ask whether the PR has focused evidence for its material claims and changed invariants. Missing proof for important behavior is a review concern even when the code looks plausible.
 5) **Lower-priority quality**
    - Then review performance, build time, CI/script reliability, PR metadata, documentation, diagnostics, and maintainability. These matter, but should not crowd out feature-contract and correctness review.
 
 SIGNAL AND UNCERTAINTY
 - Avoid reporting minor issues when unsure: style preferences, naming opinions, speculative refactors, and micro-optimizations should be omitted unless they clearly affect correctness, maintainability, or user-facing quality.
 - Do not suppress potentially serious findings only because the proof is incomplete. If the evidence points to a plausible correctness, safety, data-loss, security, compatibility, or operational risk, report it as a concern and state exactly what would prove the code correct.
-- Prefer requesting focused tests when runtime behavior is the missing proof. Name the concrete scenario, edge case, concurrency interleaving, upgrade path, or failure mode the test must cover.
 - Use confidence-aware wording: definite bugs belong in `Findings`; plausible serious risks can be framed as "needs verification" or "missing/insufficient tests". Do not present speculation as fact.
 
 WHAT TO REVIEW VS WHAT TO IGNORE
@@ -102,12 +101,6 @@ WHAT TO REVIEW VS WHAT TO IGNORE
 **Documentation:**
 - Structured ClickHouse surfaces are documented from source registrations: SQL functions and aggregate functions (`FunctionDocumentation`), settings (`DECLARE` doc strings), table functions, table engines, formats, system tables, and similar components. Do not ask for a separate `docs/` page when this source-level documentation is present and adequate.
 - Flag documentation only when source-level structured docs are missing or weak, or when the change needs non-structured user guidance that belongs under `docs/` (guides, tutorials, architecture, operations/admin, integrations).
-
-**Tests for new behavior:**
-- Treat tests as evidence for the intended behavior and important invariants, not as a checklist of named cases.
-- For any material new behavior or important fix, identify what would prove the change works and what would fail if the implementation were removed or wired incorrectly.
-- Broad existing tests are insufficient when they do not make the new behavior observable. Ask for the smallest focused coverage that proves the relevant behavior, using the most appropriate observable for that change.
-- If focused coverage is missing, request it in `Tests` even if the code looks correct.
 
 **Explicitly ignore (do not comment on these unless they indicate a bug):**
 - Pure formatting (whitespace, brace style, minor naming preferences).
@@ -140,10 +133,6 @@ Use these prompts to widen the search, not as a contract. A finding is valid bec
 **Use concrete traces for suspicious code**
 - When you find suspicious callee logic, pick a minimal boundary input and trace execution step by step with concrete values. Do not dismiss it by abstract reasoning.
 - **Anti-pattern to avoid:** finding a suspicious access, writing "this is technically safe because [memory layout / padding / practical likelihood]", and moving on. If you cannot prove safety via a concrete trace, report it or request the test that would prove it.
-
-**Check evidence**
-- Tests should prove the changed behavior or invariant, not just existing behavior. Focus on what would fail if the feature were miswired, incomplete, or unsafe at a boundary.
-- For performance, build-time, repository-bloat, documentation, and PR-metadata issues, report them after correctness/safety unless they are severe enough to block the PR.
 
 CLICKHOUSE-SPECIFIC RULES (SUPPORTING CHECKS)
 Use these as supporting checks for ClickHouse-specific invariants. They are not the review goal and they are not exhaustive. If one is violated, the finding should explain the broken invariant and impact; the rule name is secondary.
@@ -232,8 +221,7 @@ Focus on problems — do not describe what was checked and found to be fine. Use
 
 
 **Tests** (omit if adequate)
-- Only include this section if tests are **missing or insufficient**. Prefix each missing test with ⚠️. Specify which additional tests to add and why.
-- For material behavior changes, state whether the tests prove the relevant new behavior or invariant, not just that old behavior still returns correct results.
+- Only include this section if evidence is **missing or insufficient**. Prefix each missing test/evidence item with ⚠️. Ask for the smallest focused test, benchmark, or measurement that would prove the relevant behavior, invariant, or claimed benefit.
 
 **ClickHouse-Specific Rule Notes** (omit if none)
 - Include only actual ClickHouse-specific rule concerns that are not already clear from `Findings` or `Tests`.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -15,8 +15,8 @@ allowed-tools: Task, Bash, Read, Glob, Grep, WebFetch, AskUserQuestion
 ## Obtaining the Diff
 
 **If a PR number is given:**
-- Fetch PR metadata (title, description, base/head refs, changed files).
 - Fetch the full PR diff.
+- Fetch PR metadata (title, description, base/head refs, comments, changed files).
 - Note the PR title, description, and linked issues
 - **Detect revert PRs** before validating template metadata. A PR is a revert when the title starts with `Revert "..."` (the GitHub default), or the body matches `Reverts ClickHouse/ClickHouse#<N>` / `This reverts commit <sha>`. Revert PRs are **exempt** from PR template validation: skip `Changelog category` and `Changelog entry` checks for them, and do not flag missing template fields. Only verify that the body identifies the reverted PR or commit.
 - For non-revert PRs, validate PR template metadata against `.github/PULL_REQUEST_TEMPLATE.md`:
@@ -74,9 +74,11 @@ PRIMARY GOALS (IN ORDER)
 7) **ClickHouse-specific compliance**
    - Deletion logging, serialization versioning, compatibility, settings, experimental gates, Cloud/OSS rollout.
 
-FALSE POSITIVES ARE WORSE THAN MISSED NITS
-- Prefer **high precision**: if you are not reasonably confident that something is a real problem or a serious risk, do **not** flag it.
-- When in doubt between "possible minor style issue" and "no issue" – choose **no issue**.
+SIGNAL AND UNCERTAINTY
+- Avoid reporting minor issues when unsure: style preferences, naming opinions, speculative refactors, and micro-optimizations should be omitted unless they clearly affect correctness, maintainability, or user-facing quality.
+- Do not suppress potentially serious findings only because the proof is incomplete. If the evidence points to a plausible correctness, safety, data-loss, security, compatibility, or operational risk, report it as a concern and state exactly what would prove the code correct.
+- Prefer requesting focused tests when runtime behavior is the missing proof. Name the concrete scenario, edge case, concurrency interleaving, upgrade path, or failure mode the test must cover.
+- Use confidence-aware wording: definite bugs belong in `Findings`; plausible serious risks can be framed as "needs verification" or "missing/insufficient tests". Do not present speculation as fact.
 
 WHAT TO REVIEW VS WHAT TO IGNORE
 
@@ -113,7 +115,7 @@ WHAT TO REVIEW VS WHAT TO IGNORE
   - Switching quote style, etc.
 - Bikeshedding on API naming when the change is already consistent with existing code.
 
-C++ / CLICKHOUSE RISK CHECKLIST
+CLICKHOUSE RISK CHECKLIST
 
 When reading diffs, scan for these classes of bugs:
 
@@ -159,14 +161,7 @@ When reading diffs, scan for these classes of bugs:
 - Accidental O(N²) patterns on large inputs.
 - Extra syscalls, unnecessary fsyncs, sleeps, or polling in hot paths.
 
-**7) Compilation time & build impact**
-- ClickHouse has ~10k translation units; compilation time is a key developer productivity concern.
-- Adding non-trivial code (function bodies, method implementations, template definitions) to widely-included headers instead of moving it to `.cpp` files. Large function bodies in headers force recompilation of every translation unit that includes them. Prefer keeping only declarations, forward declarations, and truly trivial inline functions in `.h` files.
-- Adding or pulling heavy transitive includes into high-fan-out headers. When a header is included by hundreds or thousands of translation units, every extra `#include` it carries multiplies across the entire build. Watch for foundational headers like `Exception.h`, `IColumn.h`, `IDataType.h`, `typeid_cast.h`, `assert_cast.h`, and `Context_fwd.h` gaining new includes. Prefer forward declarations, dedicated lightweight `_fwd.h` headers, or moving the dependency into `.cpp` files.
-- Unnecessary template instantiations: template code that unconditionally instantiates specializations for cases that are statically known to be unreachable. Use `if constexpr` to prune template variants that do not apply (e.g., instantiating a `division_by_nullable=true` variant for non-division operations). Each unnecessary instantiation multiplies compile time and binary size.
-- Large `constexpr` evaluation in headers: complex `constexpr` loops or recursive `constexpr` functions in headers that the compiler must evaluate in every translation unit. Extract them into `.cpp` files or break them into smaller units.
-
-**8) Server-side file access & path traversal**
+**7) Server-side file access & path traversal**
 - Any setting, table function argument, or SQL-accessible parameter that accepts a **file path** and causes the server to read or write that path is a potential arbitrary file access vulnerability. A user with the required privilege (e.g., `CREATE DATABASE`, `CREATE TABLE`) could read sensitive server-side files (`/etc/shadow`, config files with secrets, other users' data) or write to unexpected locations.
 - When a new file-path setting or argument is introduced, check that it is restricted by one of:
   - `user_files_path` validation (like the `file()` table function),
@@ -175,7 +170,14 @@ When reading diffs, scan for these classes of bugs:
 - Watch for file paths that surface contents in error messages on parse failure — even a "read then validate" pattern can leak file contents through exceptions.
 - This applies to all code paths that use `ReadBufferFromFile`, `WriteBufferToFile`, `std::ifstream`, or similar with user-controlled paths.
 
-**9) Repository bloat — large & binary files**
+**8) Compilation time & build impact**
+- ClickHouse has ~10k translation units; compilation time is a key developer productivity concern.
+- Adding non-trivial code (function bodies, method implementations, template definitions) to widely-included headers instead of moving it to `.cpp` files. Large function bodies in headers force recompilation of every translation unit that includes them. Prefer keeping only declarations, forward declarations, and truly trivial inline functions in `.h` files.
+- Adding or pulling heavy transitive includes into high-fan-out headers. When a header is included by hundreds or thousands of translation units, every extra `#include` it carries multiplies across the entire build. Watch for foundational headers like `Exception.h`, `IColumn.h`, `IDataType.h`, `typeid_cast.h`, `assert_cast.h`, and `Context_fwd.h` gaining new includes. Prefer forward declarations, dedicated lightweight `_fwd.h` headers, or moving the dependency into `.cpp` files.
+- Unnecessary template instantiations: template code that unconditionally instantiates specializations for cases that are statically known to be unreachable. Use `if constexpr` to prune template variants that do not apply (e.g., instantiating a `division_by_nullable=true` variant for non-division operations). Each unnecessary instantiation multiplies compile time and binary size.
+- Large `constexpr` evaluation in headers: complex `constexpr` loops or recursive `constexpr` functions in headers that the compiler must evaluate in every translation unit. Extract them into `.cpp` files or break them into smaller units.
+
+**9) Repository bloat**
 - ClickHouse is a huge monorepo; every byte committed to git is cloned by every contributor forever and can never be fully removed without history rewriting.
 - **Binary blobs** (JARs, compiled executables, archives, images, dataset files, model weights) must **never** be committed directly. Flag any new binary file larger than ~100 KB as a blocker. Check `file` type and size for any non-text addition.
 - **Chunked / split binaries** are a red flag — they indicate someone tried to work around size limits while still committing the same blob.
@@ -184,31 +186,23 @@ When reading diffs, scan for these classes of bugs:
 - **Test data** (Parquet files, Avro files, small JSON fixtures) under ~1 MB total is usually fine, but anything larger should be generated at test time or downloaded.
 - When a PR adds new files under `tests/integration/`, `tests/queries/`, or any other directory, always scan for unexpectedly large or binary additions — contributors sometimes commit build artifacts or data files without realizing the permanent cost.
 
-**10) Semantic correctness & fix completeness**
-- **Partial / asymmetric fixes:** when a behavior is changed in one code path, check whether symmetric paths need the same change. Examples: fixing `SYSTEM STOP MERGES` for merge selection but not mutation selection; fixing `ReplicatedMergeTree` but not `SharedMergeTree`. Use `grep` to find all related call sites.
-- **Multi-instance resource selection:** when a PR adds support for multiple instances of a resource (e.g. auxiliary ZooKeeper clusters, secondary storage backends), grep for every place that accesses the resource and verify the correct instance is selected — not just in the newly added code paths.
+**10) Beyond-the-diff exploration: callers, symmetry, and trust boundaries**
 
-**11) Trust boundary expansion — looking beyond the diff**
-
-Trigger: a PR wraps existing internal code for a wider audience (library function → SQL function, CLI tool → server endpoint, internal reader → table function, background-only path → user-reachable query). The wrapper diff may look fine, but the callee was written with assumptions about its original callers that no longer hold.
+Apply this to every PR. Always look past the changed lines far enough to understand the affected callers, invariants, and neighboring code paths. Go deeper when a PR changes behavior in one path, exposes existing code to new callers, adds support for multiple instances of a resource, or wraps existing internal code for a wider audience (library function → SQL function, CLI tool → server endpoint, internal reader → table function, background-only path → user-reachable query). The diff may look fine, but the surrounding system may rely on assumptions that no longer hold.
 
 **The single most important rule: when you find something suspicious in callee code, you MUST pick a concrete minimal input and trace execution step by step, writing out every variable value at every iteration. Never dismiss a finding by reasoning about it abstractly — the whole point is that abstract reasoning ("this is technically safe because...") is how real bugs get missed. A 5-line trace with concrete values catches what paragraphs of analysis miss.**
 
 Workflow:
-
-1. **Read the core callee(s)** — full implementation, not just signatures.
-
-2. **Compare existing callers vs. the PR.** Grep for ALL call sites. For each parameter, compare what existing callers pass against what the PR passes. Flag any parameter where the PR passes a weaker, degenerate, or no-op value (callback, validator, filter, flag). These are "degraded integration" bugs.
-
-3. **Grep the callee for dangerous patterns.** Run actual Grep commands — do not scan visually. Look for: relative indexing (accessing neighbors of current position), assertions used as guards (`assert`/`chassert` compile out in release), pointer arithmetic without size checks, end-relative access on possibly-empty ranges, and unbounded allocation proportional to input.
-
-4. **For every match: trace with a concrete boundary input.** This step is mandatory and non-negotiable. Pick the shortest input that reaches the dangerous code. Write out the trace: for each iteration, state the line, the expression, the concrete value, and whether it is safe or not. Track every pointer/index/flag — a condition that *looks* protective may execute *after* the dangerous access within the same iteration. Choose inputs at extremes: empty, length 1, length 2, first element of each type the code branches on.
-
+1. **Read beyond the changed lines.** Read the core callee(s), related implementations, and full modified files when invariants may span background work, replication, storage, query execution, or coordination.
+2. **Check symmetric paths.** Grep for related implementations and call sites. If behavior changes in one path, verify equivalent paths need or do not need the same change. Examples: fixing `SYSTEM STOP MERGES` for merge selection but not mutation selection; fixing `ReplicatedMergeTree` but not `SharedMergeTree`.
+3. **Check resource-instance selection.** When a PR adds support for multiple instances of a resource (e.g. auxiliary ZooKeeper clusters, secondary storage backends), grep every place that accesses the resource and verify the correct instance is selected — not just in the newly added code paths.
+4. **Compare caller contracts.** Grep for ALL call sites. For each parameter, compare what existing callers pass against what the PR passes. Flag weaker validators, no-op callbacks, missing filters, broader input shapes, and changed lifetime/threading assumptions. These are "degraded integration" bugs.
+5. **Grep callees for dangerous patterns.** Run actual Grep commands — do not scan visually. Look for: relative indexing (accessing neighbors of current position), assertions used as guards (`assert`/`chassert` compile out in release), pointer arithmetic without size checks, end-relative access on possibly-empty ranges, and unbounded allocation proportional to input.
+6. **For every match: trace with a concrete boundary input.** This step is mandatory and non-negotiable. Pick the shortest input that reaches the dangerous code. Write out the trace: for each iteration, state the line, the expression, the concrete value, and whether it is safe or not. Track every pointer/index/flag — a condition that *looks* protective may execute *after* the dangerous access within the same iteration. Choose inputs at extremes: empty, length 1, length 2, first element of each type the code branches on.
    **Anti-pattern to avoid:** finding a suspicious access, writing "this is technically safe because [memory layout / padding / practical likelihood]", and moving on. If you cannot prove safety via a concrete trace, report it. Pre-existing bugs that were harmless in the old calling context become exploitable under user-controlled input — that is the whole point of this checklist.
+7. **Verify test coverage.** The PR's tests must include adversarial edge cases that the original caller would never produce: empty inputs, minimal-length inputs, malformed inputs, NULLs, maximum-length inputs.
 
-5. **Verify test coverage.** The PR's tests must include adversarial edge cases that the original caller would never produce: empty inputs, minimal-length inputs, malformed inputs, NULLs, maximum-length inputs.
-
-**12) Shell-command safety in Python / shell scripts**
+**11) Shell-command safety in Python / shell scripts**
 - Destructive or privileged commands (`rm -rf`, `mv`, `cp -r`, `find … -delete`, `chmod`, `chown`, `dd`, `kill`, `sudo …`) with substituted arguments passed to `shell=True` (`subprocess.run`/`Popen`, `os.system`) or to in-tree wrappers that use `shell=True` under the hood (ClickHouse's `Shell.check` / `Shell.run` / `Shell.get_output`).
 - Unquoted variables in destructive commands inside `.sh` scripts.
 - Prefer `shutil.rmtree` or argv-list `subprocess.run`; if a shell wrapper is unavoidable, use `shlex.quote` and `--`.
@@ -232,7 +226,7 @@ CLICKHOUSE RULES (MANDATORY)
 - **Safe rollout**
   Ensure incremental rollout is feasible in both OSS and Cloud (feature flags, safe defaults, non-disruptive changes).
 - **Compilation time**
-  Follow checklist **7) Compilation time & build impact**. Treat violations there as ClickHouse-rule issues.
+  Follow checklist **8) Compilation time & build impact**. Treat violations there as ClickHouse-rule issues.
 - **No large / binary files in git**
   Binary blobs (JARs, archives, compiled artifacts, datasets >1 MB, fat dependency bundles) must never be committed. They permanently bloat the repository for every clone and cannot be removed without history rewriting. Test dependencies should be downloaded at test time, built from source inside the test container, or pulled from Docker images. Follow checklist **9) Repository bloat**. Any violation is a blocker.
 - **PR metadata quality**
@@ -300,6 +294,7 @@ Focus on problems — do not describe what was checked and found to be fine. Use
 
 **ClickHouse Rules**
 Render as a Markdown table. Use ✅ (ok), ❌ (problem), ⚠️ (concern), or ➖ (not applicable) — never write "N/A" as text.
+Use exactly one row for each item from `CLICKHOUSE RULES (MANDATORY)`, in the same order. Do not add separate rows for sub-details such as `SettingsChangesHistory.cpp`; mention them in the parent row's Notes instead.
 For any ❌ or ⚠️ item, add a brief explanation in the Notes column. Leave Notes empty for ✅ and ➖.
 
 Example:
@@ -308,15 +303,14 @@ Example:
 | Deletion logging | ✅ | |
 | Serialization versioning | ➖ | |
 | Core-area scrutiny | ✅ | |
-| Test coverage | ✅ | |
+| Test coverage | ⚠️ | Missing focused test for the new failover path |
 | Experimental gate | ❌ | New feature `X` has no gate |
 | No magic constants | ✅ | |
 | Backward compatibility | ⚠️ | Default changed without `SettingsChangesHistory.cpp` update |
-| `SettingsChangesHistory.cpp` | ❌ | Not updated |
-| PR metadata quality | ⚠️ | `Changelog category` does not match change type; `Changelog entry` is too vague for users |
 | Safe rollout | ➖ | |
-| Compilation time | ✅ | |
-| No large/binary files | ✅ | |
+| Compilation time & build impact | ✅ | |
+| No large / binary files in git | ✅ | |
+| PR metadata quality | ⚠️ | `Changelog category` does not match change type; `Changelog entry` is too vague for users |
 
 **Performance & Safety** (omit if no concerns)
 - Only include this section if there are actual concerns about hot-path regressions, memory, concurrency, or failure modes.
@@ -333,5 +327,5 @@ STYLE & CONDUCT
 - Prefer small, surgical suggestions over broad rewrites.
 - Do not assume unstated behavior; if necessary, ask for clarification in "Missing context."
 - Avoid changing scope: review what's in the PR; suggest follow-ups separately.
-- If you are not reasonably confident a finding is a real issue or meaningful risk, **do not mention it**.
+- Avoid uncertain minor comments. For serious plausible risks, state the uncertainty and request the needed verification or tests.
 - When performing a code review, **ignore `/.github/workflows/*` files**.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -56,21 +56,22 @@ INPUTS YOU WILL RECEIVE
 - CI status and logs (if available)
 - Tests added/modified and their results
 
-If any of these are missing, note it under "Missing context" and proceed as far as possible.
+If any of these are missing, note it under "Missing context / blind spots" and proceed as far as possible.
 
-REVIEW PRIORITIES (IN ORDER)
-1) **Central premise / feature contract**
-   - First derive what the PR claims to make true from the title, description, changed tests, docs, and code shape. Review whether the implementation actually satisfies that contract in all relevant paths.
+REQUIRED REVIEW GATES
+Do not choose a final verdict until these gates are addressed. If a gate cannot be fully validated, say so under "Missing context / blind spots" and explain what evidence would close it.
+
+1) **Contract**
+   - Derive the behavior the PR promises from title, description, metadata, tests, docs, and code shape. Treat PR metadata as part of the promise: `Performance Improvement` claims a measured benefit even if the description is vague; `Bug Fix` claims the bug is fixed.
    - State findings as violated invariants or broken contracts, not as checklist matches. Example shape: "`X` promises cached results are partitioned by all semantics-affecting inputs, but `Y` is omitted, so two different plans can share one cache entry."
-2) **Correctness, safety, and data integrity**
-   - Look for bugs that can produce wrong results, data loss/corruption, undefined behavior, leaks, races, deadlocks, privilege issues, or unsafe failure modes, even if they are not mentioned by the PR description.
-3) **Boundary behavior and system integration**
-   - Check caller contracts, edge inputs, concurrent/background operations, upgrade/downgrade paths, retries, partial failures, and interactions with neighboring subsystems. Many real bugs live outside the changed lines.
-4) **Evidence and tests**
-   - Ask whether the PR has focused evidence for its material claims and changed invariants. Missing proof for important behavior is a review concern even when the code looks plausible.
-   - PR metadata is part of the claim: `Performance Improvement` requires measurement evidence, and `Bug Fix` requires regression coverage or a clear explanation why focused coverage is impractical. Correctness tests alone do not prove measured benefits.
+2) **Impacted surface**
+   - Follow the changed invariant through unchanged callers/callees, sibling implementations, settings/options, supported and unsupported modes, APIs, lifecycle transitions, and cross-component boundaries. New settings/flags/options must be implemented consistently where supported and rejected where unsupported.
+3) **Failure and divergence**
+   - Check state transitions and failure paths: startup, steady state, shutdown, retries, cancellation, exceptions, partial progress, async work already in flight, and anything that can still mutate after a guard or role check fires. For stateful/distributed changes, also check what can diverge over time across metadata, paths, identities, leases, caches, and ownership.
+4) **Evidence**
+   - Map each material claim to proof before approving. Performance claims need before/after measurements, a benchmark, or a focused performance test; correctness claims need regression coverage or a clear reason coverage is impractical. Missing proof for important behavior is a review concern even when the code looks plausible.
 5) **Lower-priority quality**
-   - Then review performance, build time, CI/script reliability, PR metadata, documentation, diagnostics, and maintainability. These matter, but should not crowd out feature-contract and correctness review.
+   - After the contract and high-impact risks are covered, review performance regressions, build time, CI/script reliability, PR metadata, documentation, diagnostics, and maintainability.
 
 SIGNAL AND UNCERTAINTY
 - Avoid reporting minor issues when unsure: style preferences, naming opinions, speculative refactors, and micro-optimizations should be omitted unless they clearly affect correctness, maintainability, or user-facing quality.
@@ -112,28 +113,17 @@ WHAT TO REVIEW VS WHAT TO IGNORE
   - Switching quote style, etc.
 - Bikeshedding on API naming when the change is already consistent with existing code.
 
-EXPLORATION PROMPTS (NON-EXHAUSTIVE)
+TRIGGERED EXPANSIONS
 
-Use these prompts to widen the search, not as a contract. A finding is valid because it violates a behavior, safety, compatibility, or operational invariant, not because it matches a listed prompt. If the PR suggests a different risk, follow that risk even if it is not listed here.
+Run these only when the trigger appears. They are small expansion passes, not a universal matrix. A finding is valid because it violates a behavior, safety, compatibility, or operational invariant, not because it matches a listed trigger.
 
-**Understand the central invariant**
-- What must be true for the PR's main claim to be correct?
-- Which inputs, settings, query shapes, storage states, versions, or background operations can invalidate that claim?
-- What would fail if the new code were removed, bypassed, called twice, called concurrently, or called with a different caller than intended?
-
-**Read beyond the changed lines**
-- Check callers, callees, symmetric implementations, old and new code paths, and state transitions that share the same invariant.
-- For core areas such as query execution, storage engines, replication, Keeper/coordination, system tables, and MergeTree internals, read enough of the modified file and neighboring subsystem to understand the invariant being changed.
-- When a PR adds a resource dimension or selector, follow all access paths to verify the selected instance is correct everywhere it matters.
-
-**After finding a serious issue**
-- Do not stop at the first blocker. Treat it as evidence that an invariant is fragile, then continue following that invariant through related entry points, lifecycle transitions, and mostly unchanged code.
-- Check whether the same broken assumption affects reads, writes, metadata, cleanup, recovery, retries, or ownership changes as applicable to the PR. Group related issues when they share a cause, but do not omit distinct user-impacting paths.
-
-**Probe boundaries and failure modes**
-- Consider lifetimes, cleanup on exceptions, partial initialization, cancellation, retries, concurrent/background work, and changed throwing behavior across `noexcept` or destructor boundaries.
-- For user-controlled paths, privileges, formats, protocols, cache keys, metadata, or on-disk state, check compatibility, versioning, isolation between semantically different cases, and upgrade/downgrade behavior.
-- For Python/shell/CI code, prioritize destructive commands, quoting, `shell=True`, privilege boundaries, and failure paths over style.
+- **After first serious invariant failure:** fan out once through the same invariant in foreground paths, background paths, DDL/mutating entrypoints, lifecycle transitions, and sibling engines/settings. Group related issues when they share a cause, but do not omit distinct user-impacting paths.
+- **New setting/flag/option:** grep consumers that share the settings class or configuration surface. Each relevant engine/mode/API must implement it, reject it, or make an explicit harmless no-op contract.
+- **Ownership, leadership, leases, locks, or failover:** inspect ownership gain, ownership loss, active in-flight work, delayed commits after waits, and anything that can still mutate after the guard changes state.
+- **Subclass adds guards:** inspect inherited mutating operations it does not override, especially `rename`, `drop`, `truncate`, `alter`, partition commands, and background callbacks.
+- **Shared storage or distributed state:** identify which state is shared and which remains local. If local state affects correctness after failover/restart, it must be synchronized, rejected, or explicitly unsupported.
+- **Tests weaker than contract:** if a test asserts weaker behavior than the PR promises, treat it as suspicious evidence rather than validation.
+- **Delegated review:** subagent or helper output can provide leads, but it does not close required gates for the highest-risk touched subsystem; keep enough local tracing to verify the invariant.
 
 **Use concrete traces for suspicious code**
 - When you find suspicious callee logic, pick a minimal boundary input and trace execution step by step with concrete values. Do not dismiss it by abstract reasoning.
@@ -208,8 +198,8 @@ Focus on problems — do not describe what was checked and found to be fine. Use
 - Evaluate `Changelog entry` quality using `clickhouse-pr-description` criteria (specific change, user impact, and migration guidance for backward-incompatible changes).
 - If any item is incorrect, provide the exact replacement text.
 
-**Missing context** (omit if none)
-- Bullet list of critical info you lacked. Prefix each item with ⚠️ (e.g., ⚠️ No CI logs available, ⚠️ No benchmarks provided).
+**Missing context / blind spots** (omit if none)
+- Bullet list of critical info or impacted surfaces you could not fully validate. Prefix each item with ⚠️ and say what would close the gap.
 - If PR motivation/reason is not clear from the title and description, add a ⚠️ item explicitly stating that motivation is unclear.
 
 **Findings** (omit if no findings)
@@ -226,7 +216,7 @@ Focus on problems — do not describe what was checked and found to be fine. Use
 
 
 **Tests** (omit if adequate)
-- Only include this section if evidence is **missing or insufficient**. Prefix each missing test/evidence item with ⚠️. Ask for the smallest focused test, benchmark, or measurement that would prove the relevant behavior, invariant, or claimed benefit.
+- Only include this section if evidence is **missing or insufficient**. Prefix each missing test/evidence item with ⚠️. Ask for the smallest focused test, benchmark, or measurement that would prove the relevant behavior, invariant, or claimed benefit. For `Performance Improvement`, missing before/after evidence belongs here even if the implementation looks reasonable.
 
 **ClickHouse-Specific Rule Notes** (omit if none)
 - Include only actual ClickHouse-specific rule concerns that are not already clear from `Findings` or `Tests`.
@@ -240,12 +230,12 @@ Focus on problems — do not describe what was checked and found to be fine. Use
 
 **Final Verdict**
 - Status: **✅ Approve** / **⚠️ Request changes** / **❌ Block**
-- If not approving, list the **minimum** required actions.
+- Approve only if there are no unresolved contract violations, no unresolved high-impact plausible risks, and no missing evidence for material claims. A `Performance Improvement` without performance evidence, or a `Bug Fix` without regression evidence or a clear exception, should be **⚠️ Request changes**. If not approving, list the **minimum** required actions.
 
 STYLE & CONDUCT
 - Be precise, evidence-based, and neutral.
 - Prefer small, surgical suggestions over broad rewrites.
-- Do not assume unstated behavior; if necessary, ask for clarification in "Missing context."
+- Do not assume unstated behavior; if necessary, ask for clarification in "Missing context / blind spots."
 - Avoid changing scope: review what's in the PR; suggest follow-ups separately.
 - Avoid uncertain minor comments. For serious plausible risks, state the uncertainty and request the needed verification or tests.
 - When performing a code review, **ignore `/.github/workflows/*` files**.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -125,6 +125,10 @@ Use these prompts to widen the search, not as a contract. A finding is valid bec
 - For core areas such as query execution, storage engines, replication, Keeper/coordination, system tables, and MergeTree internals, read enough of the modified file and neighboring subsystem to understand the invariant being changed.
 - When a PR adds a resource dimension or selector, follow all access paths to verify the selected instance is correct everywhere it matters.
 
+**After finding a serious issue**
+- Do not stop at the first blocker. Treat it as evidence that an invariant is fragile, then continue following that invariant through related entry points, lifecycle transitions, and mostly unchanged code.
+- Check whether the same broken assumption affects reads, writes, metadata, cleanup, recovery, retries, or ownership changes as applicable to the PR. Group related issues when they share a cause, but do not omit distinct user-impacting paths.
+
 **Probe boundaries and failure modes**
 - Consider lifetimes, cleanup on exceptions, partial initialization, cancellation, retries, concurrent/background work, and changed throwing behavior across `noexcept` or destructor boundaries.
 - For user-controlled paths, privileges, formats, protocols, cache keys, metadata, or on-disk state, check compatibility, versioning, isolation between semantically different cases, and upgrade/downgrade behavior.

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -119,19 +119,13 @@ CLICKHOUSE RISK CHECKLIST
 
 When reading diffs, scan for these classes of bugs:
 
-**1) Memory & lifetime**
-- Raw pointers where ownership is unclear or inconsistent with surrounding code.
-- Missing `delete` / `free` / `unmap` / `close` on early returns or exceptions.
-- Containers or views returning references/iterators to temporary or moved-from objects.
-- Use of `std::string_view`, spans, or references to buffers whose lifetime is not guaranteed.
-- Manual `new`/`delete` instead of RAII where the surrounding code uses RAII types.
+**1) Lifetime, ownership, and resources**
+- Unclear ownership of raw pointers, file descriptors, sockets, mapped memory, or other manually managed resources.
+- Missing cleanup on early returns, exceptions, loop exits, or partially-initialized states. Prefer RAII when the surrounding code supports it.
+- Returning references, iterators, `std::string_view`, spans, or borrowed buffers whose owner can be temporary, moved-from, or shorter-lived.
+- Smart-pointer/refcount misuse: cycles, double ownership, forgotten release, or ownership transfer that is inconsistent with surrounding code.
 
-**2) Resource management**
-- Opened file descriptors or sockets not closed on all paths (including error paths).
-- Leaks in loops where allocation happens inside the loop but deallocation depends on conditions.
-- Misuse of `std::unique_ptr` / `std::shared_ptr` / intrusive refcounts: cycles, double ownership, or forgotten release.
-
-**3) Concurrency & threading**
+**2) Concurrency & threading**
 - Access to shared state without a lock or atomic: look for member variable reads/writes that happen outside the guarded region, especially on fast paths that skip locking as an optimization.
 - Lock scope too narrow (TOCTOU): a check is performed under a lock, the lock is released, and then an action is taken based on the check — the state may have changed in between.
 - Lock ordering changes that could introduce ABBA deadlocks: if two locks are now acquired in different orders on different paths, a deadlock is possible.
@@ -140,14 +134,14 @@ When reading diffs, scan for these classes of bugs:
 - Using non-thread-safe containers (e.g. `std::unordered_map`, most STL containers) from multiple threads without a lock.
 - Mutable globals or singletons modified from multiple threads.
 
-**4) Error handling & observability**
+**3) Error handling & observability**
 - Ignored return values of functions that can fail (IO, network, syscalls).
 - Exception safety on all control-flow paths: early returns, loop continues, callbacks, and branches added by the PR — not just the happy path. Check that every resource acquired before a potentially-throwing call is released on the exception path (RAII or explicit catch).
 - **Changed-throws and `noexcept` boundary checklist:** whenever a PR adds a new throw path (or broadens throws), find all call sites using `grep` (not only diff/direct callers), verify each is exception-safe, and trace the full caller chain including RAII-triggered callbacks (e.g. `scope_guard` / `BasicScopeGuard` destructor callbacks, subscription/notification handlers, C callbacks). Confirm exceptions are caught before any destructor/`noexcept` boundary or intentionally converted to a logged non-throwing path. Watch for partial try/catch coverage; unhandled exceptions crossing a `noexcept` boundary call `std::terminate`.
 - Inconsistent error codes or messages that make debugging impossible.
 - Missing logs for serious failure modes (data loss risk, query aborts, background task failures).
 
-**5) Data correctness & serialization**
+**4) Data correctness & serialization**
 - Changes to on-disk or wire formats without:
   - Explicit versioning,
   - Clear upgrade/downgrade behavior,
@@ -155,13 +149,13 @@ When reading diffs, scan for these classes of bugs:
 - Schema or metadata evolution without migration logic or feature flags.
 - Silent truncation, overflow, or lossy conversions.
 
-**6) Performance & algorithmic behavior**
+**5) Performance & algorithmic behavior**
 - New allocations or copies in tight loops.
 - Unbounded structures (maps, vectors) that can grow without limits in long-running processes.
 - Accidental O(N²) patterns on large inputs.
 - Extra syscalls, unnecessary fsyncs, sleeps, or polling in hot paths.
 
-**7) Server-side file access & path traversal**
+**6) Server-side file access & path traversal**
 - Any setting, table function argument, or SQL-accessible parameter that accepts a **file path** and causes the server to read or write that path is a potential arbitrary file access vulnerability. A user with the required privilege (e.g., `CREATE DATABASE`, `CREATE TABLE`) could read sensitive server-side files (`/etc/shadow`, config files with secrets, other users' data) or write to unexpected locations.
 - When a new file-path setting or argument is introduced, check that it is restricted by one of:
   - `user_files_path` validation (like the `file()` table function),
@@ -170,14 +164,14 @@ When reading diffs, scan for these classes of bugs:
 - Watch for file paths that surface contents in error messages on parse failure — even a "read then validate" pattern can leak file contents through exceptions.
 - This applies to all code paths that use `ReadBufferFromFile`, `WriteBufferToFile`, `std::ifstream`, or similar with user-controlled paths.
 
-**8) Compilation time & build impact**
+**7) Compilation time & build impact**
 - ClickHouse has ~10k translation units; compilation time is a key developer productivity concern.
 - Adding non-trivial code (function bodies, method implementations, template definitions) to widely-included headers instead of moving it to `.cpp` files. Large function bodies in headers force recompilation of every translation unit that includes them. Prefer keeping only declarations, forward declarations, and truly trivial inline functions in `.h` files.
 - Adding or pulling heavy transitive includes into high-fan-out headers. When a header is included by hundreds or thousands of translation units, every extra `#include` it carries multiplies across the entire build. Watch for foundational headers like `Exception.h`, `IColumn.h`, `IDataType.h`, `typeid_cast.h`, `assert_cast.h`, and `Context_fwd.h` gaining new includes. Prefer forward declarations, dedicated lightweight `_fwd.h` headers, or moving the dependency into `.cpp` files.
 - Unnecessary template instantiations: template code that unconditionally instantiates specializations for cases that are statically known to be unreachable. Use `if constexpr` to prune template variants that do not apply (e.g., instantiating a `division_by_nullable=true` variant for non-division operations). Each unnecessary instantiation multiplies compile time and binary size.
 - Large `constexpr` evaluation in headers: complex `constexpr` loops or recursive `constexpr` functions in headers that the compiler must evaluate in every translation unit. Extract them into `.cpp` files or break them into smaller units.
 
-**9) Repository bloat**
+**8) Repository bloat**
 - ClickHouse is a huge monorepo; every byte committed to git is cloned by every contributor forever and can never be fully removed without history rewriting.
 - **Binary blobs** (JARs, compiled executables, archives, images, dataset files, model weights) must **never** be committed directly. Flag any new binary file larger than ~100 KB as a blocker. Check `file` type and size for any non-text addition.
 - **Chunked / split binaries** are a red flag — they indicate someone tried to work around size limits while still committing the same blob.
@@ -186,7 +180,7 @@ When reading diffs, scan for these classes of bugs:
 - **Test data** (Parquet files, Avro files, small JSON fixtures) under ~1 MB total is usually fine, but anything larger should be generated at test time or downloaded.
 - When a PR adds new files under `tests/integration/`, `tests/queries/`, or any other directory, always scan for unexpectedly large or binary additions — contributors sometimes commit build artifacts or data files without realizing the permanent cost.
 
-**10) Beyond-the-diff exploration: callers, symmetry, and trust boundaries**
+**9) Beyond-the-diff exploration: callers, symmetry, and trust boundaries**
 
 Apply this to every PR. Always look past the changed lines far enough to understand the affected callers, invariants, and neighboring code paths. Go deeper when a PR changes behavior in one path, exposes existing code to new callers, adds support for multiple instances of a resource, or wraps existing internal code for a wider audience (library function → SQL function, CLI tool → server endpoint, internal reader → table function, background-only path → user-reachable query). The diff may look fine, but the surrounding system may rely on assumptions that no longer hold.
 
@@ -202,7 +196,7 @@ Workflow:
    **Anti-pattern to avoid:** finding a suspicious access, writing "this is technically safe because [memory layout / padding / practical likelihood]", and moving on. If you cannot prove safety via a concrete trace, report it. Pre-existing bugs that were harmless in the old calling context become exploitable under user-controlled input — that is the whole point of this checklist.
 7. **Verify test coverage.** The PR's tests must include adversarial edge cases that the original caller would never produce: empty inputs, minimal-length inputs, malformed inputs, NULLs, maximum-length inputs.
 
-**11) Shell-command safety in Python / shell scripts**
+**10) Shell-command safety in Python / shell scripts**
 - Destructive or privileged commands (`rm -rf`, `mv`, `cp -r`, `find … -delete`, `chmod`, `chown`, `dd`, `kill`, `sudo …`) with substituted arguments passed to `shell=True` (`subprocess.run`/`Popen`, `os.system`) or to in-tree wrappers that use `shell=True` under the hood (ClickHouse's `Shell.check` / `Shell.run` / `Shell.get_output`).
 - Unquoted variables in destructive commands inside `.sh` scripts.
 - Prefer `shutil.rmtree` or argv-list `subprocess.run`; if a shell wrapper is unavoidable, use `shlex.quote` and `--`.
@@ -226,9 +220,9 @@ CLICKHOUSE RULES (MANDATORY)
 - **Safe rollout**
   Ensure incremental rollout is feasible in both OSS and Cloud (feature flags, safe defaults, non-disruptive changes).
 - **Compilation time**
-  Follow checklist **8) Compilation time & build impact**. Treat violations there as ClickHouse-rule issues.
+  Follow checklist **7) Compilation time & build impact**. Treat violations there as ClickHouse-rule issues.
 - **No large / binary files in git**
-  Binary blobs (JARs, archives, compiled artifacts, datasets >1 MB, fat dependency bundles) must never be committed. They permanently bloat the repository for every clone and cannot be removed without history rewriting. Test dependencies should be downloaded at test time, built from source inside the test container, or pulled from Docker images. Follow checklist **9) Repository bloat**. Any violation is a blocker.
+  Binary blobs (JARs, archives, compiled artifacts, datasets >1 MB, fat dependency bundles) must never be committed. They permanently bloat the repository for every clone and cannot be removed without history rewriting. Test dependencies should be downloaded at test time, built from source inside the test container, or pulled from Docker images. Follow checklist **8) Repository bloat**. Any violation is a blocker.
 - **PR metadata quality**
   For PR-number reviews, verify PR template metadata against `.github/PULL_REQUEST_TEMPLATE.md`: `Changelog category` correctness, required `Changelog entry` quality, and alignment with `clickhouse-pr-description` changelog guidance (specificity, user impact, and migration details for backward-incompatible changes). **Revert PRs are exempt** from this rule — mark the row as ➖ and do not produce findings about missing template fields.
 

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -18,7 +18,7 @@ allowed-tools: Task, Bash, Read, Glob, Grep, WebFetch, AskUserQuestion
 - Fetch PR metadata (title, description, base/head refs, changed files).
 - Fetch the full PR diff.
 - Note the PR title, description, and linked issues
-- **Detect revert PRs** before validating template metadata. A PR is a revert when the title starts with `Revert "..."` (the GitHub default), or the body matches `Reverts ClickHouse/ClickHouse#<N>` / `This reverts commit <sha>`. Revert PRs are **exempt** from PR template validation: skip all `Changelog category`, `Changelog entry`, and documentation checkbox checks for them, and do not flag missing template fields. Only verify that the body identifies the reverted PR or commit.
+- **Detect revert PRs** before validating template metadata. A PR is a revert when the title starts with `Revert "..."` (the GitHub default), or the body matches `Reverts ClickHouse/ClickHouse#<N>` / `This reverts commit <sha>`. Revert PRs are **exempt** from PR template validation: skip `Changelog category` and `Changelog entry` checks for them, and do not flag missing template fields. Only verify that the body identifies the reverted PR or commit.
 - For non-revert PRs, validate PR template metadata against `.github/PULL_REQUEST_TEMPLATE.md`:
   - `Changelog category` is present, valid, and semantically correct for the actual code change.
   - `Changelog entry` is present and user-readable when required by the selected category.
@@ -55,7 +55,6 @@ INPUTS YOU WILL RECEIVE
 - Linked issues / discussions
 - CI status and logs (if available)
 - Tests added/modified and their results
-- Docs changes (user docs, release notes)
 
 If any of these are missing, note it under "Missing context" and proceed as far as possible.
 
@@ -98,19 +97,14 @@ WHAT TO REVIEW VS WHAT TO IGNORE
 - Scan all changed lines for typos in comments, variable names, string literals, log messages, error messages, and documentation.
 - Report all typos found with suggested corrections.
 - Check that error messages are clear, informative, and help the user understand what went wrong and how to fix it.
-- Review PR template changelog quality: `Changelog category` must match the change, and `Changelog entry` (when required by the PR template) must be present, specific, and user-readable. **Skip this entirely for revert PRs** (see "Obtaining the Diff" for detection).
+- Review PR template changelog quality: `Changelog category` must match the change, and `Changelog entry` (when required by the PR template) must be present, specific, and user-readable. **Skip this entirely for revert PRs**.
 - Read the changelog-entry standards from `clickhouse-pr-description` and apply them: avoid vague text (e.g. "fix bug"), describe the exact affected feature/behavior, and for backward-incompatible changes explain old behavior, new behavior, and how to preserve old behavior when possible.
 
-**Documentation is auto-generated from source for structured parts of the system — do NOT request separate `docs/` files for these:**
-- ClickHouse auto-generates user-facing documentation for the structured surface of the system directly from the source code. This includes (non-exhaustive): SQL functions and aggregate functions (via `FunctionDocumentation` registered at function factory time), settings (via the doc-string argument of the `DECLARE(...)` macro in `src/Core/Settings.cpp`, `MergeTreeSettings.cpp`, format settings, server settings, etc.), table functions, table engines, formats, system tables, and similar registered components.
-- When a PR adds or changes a function, setting, table function, table engine, format, or system table, the correct place for documentation is **the source code registration** (e.g. `FunctionDocumentation` fields like `description`, `syntax`, `arguments`, `returned_value`, `examples`, `introduced_in`, `category`; or the doc-string in `DECLARE(...)` for settings). A separate hand-written page under `docs/` is **not required** and asking for one is a false positive.
-- Only flag missing documentation when:
-  - The structured doc fields are themselves missing, empty, or clearly inadequate (e.g. no `description`, no `examples`, no `syntax` for a new function; empty doc-string in `DECLARE` for a new setting).
-  - The change is to a **non-structured** area that has no auto-generation (e.g. high-level guides, tutorials, architecture docs, operational/admin docs, integration guides) — those do live under `docs/` and may legitimately need updates.
-- Do **not** ask the contributor to add `docs/` files for new functions, settings, dialects, or other registered components when the source-level documentation is present. If the source-level docs are weak, comment on the source-level fields directly instead.
+**Documentation:**
+- Structured ClickHouse surfaces are documented from source registrations: SQL functions and aggregate functions (`FunctionDocumentation`), settings (`DECLARE` doc strings), table functions, table engines, formats, system tables, and similar components. Do not ask for a separate `docs/` page when this source-level documentation is present and adequate.
+- Flag documentation only when source-level structured docs are missing or weak, or when the change needs non-structured user guidance that belongs under `docs/` (guides, tutorials, architecture, operations/admin, integrations).
 
 **Explicitly ignore (do not comment on these unless they indicate a bug):**
-- Commented debugging code (completely ignore for draft PR, no more than one message in total)
 - Pure formatting (whitespace, brace style, minor naming preferences).
 - "Nice to have" refactors or micro-optimizations without clear benefit.
 - Python/Ruby/CI config nitpicks such as:
@@ -226,8 +220,8 @@ CLICKHOUSE RULES (MANDATORY)
   Any format (columns, aggregates, protocol, settings serialization, replication metadata) must be versioned. Check upgrade/downgrade resilience and the impact on existing clusters.
 - **Core-area scrutiny**
   For changes in query execution, storage engines, replication, Keeper/coordination, system tables, and MergeTree internals: read the full modified file (not just the diff context); verify invariants hold under concurrent background operations (merges, mutations, replication); check all error paths including those not touched by the diff; and confirm the change is consistent with symmetric subsystems — e.g. if fixing `ReplicatedMergeTree`, check `SharedMergeTree` and partition-level variants for the same issue.
-- **No test removal**
-  Do **not** delete or relax existing tests. New behavior requires **new tests**.
+- **Test coverage**
+  Do **not** delete or relax existing tests, except in revert PRs where removing tests added by the reverted change is expected. New behavior and important fixes require focused tests that cover the changed behavior and relevant edge cases.
   Tests replace random database names with `default` in output normalization. Do **not** flag hardcoded `default.` or `default_` prefixes in expected test output as incorrect or suggest using `${CLICKHOUSE_DATABASE}` – this is by design.
 - **Experimental gate**
   Features that introduce genuinely new or risky behavior — new engines, new query execution strategies, new replication mechanisms, new on-disk formats, or features whose incorrect implementation could cause data loss or corruption — must be gated behind an **experimental** setting (e.g. `allow_experimental_simd_acceleration`) until proven safe. The gate can later be made ineffective at GA. Thin wrappers that expose already-stable internal code as SQL functions, simple utility functions, or low-risk additive features do **not** need a gate.
@@ -314,7 +308,7 @@ Example:
 | Deletion logging | ✅ | |
 | Serialization versioning | ➖ | |
 | Core-area scrutiny | ✅ | |
-| No test removal | ✅ | |
+| Test coverage | ✅ | |
 | Experimental gate | ❌ | New feature `X` has no gate |
 | No magic constants | ✅ | |
 | Backward compatibility | ⚠️ | Default changed without `SettingsChangesHistory.cpp` update |

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,22 +14,3 @@
 
 ### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
 ...
-
-### Documentation entry for user-facing changes
-
-- [ ] Documentation is written (mandatory for new features)
-
-<!---
-Directly edit documentation source files in the "docs" folder with the same pull-request as code changes
-
-or
-
-Add a user-readable short description of the changes that should be added to docs.clickhouse.com below.
-
-At a minimum, the following information should be added (but add more as needed).
-- Motivation: Why is this function, table engine, etc. useful to ClickHouse users?
-
-- Parameters: If the feature being added takes arguments, options or is influenced by settings, please list them below with a brief explanation.
-
-- Example use: A query or command.
--->

--- a/ci/jobs/copilot_review_job.py
+++ b/ci/jobs/copilot_review_job.py
@@ -30,6 +30,7 @@ from ci.praktika.info import Info
 from ci.praktika.result import Result
 
 REVIEW_FILE = "./ci/tmp/copilot_review.md"
+GH_PREFIX = "env -u GH_CONFIG_DIR"
 
 # Number of attempts at the full gh-auth + copilot run. The Copilot CLI
 # fetches auth state and makes GitHub API calls during execution; either
@@ -37,6 +38,130 @@ REVIEW_FILE = "./ci/tmp/copilot_review.md"
 # subprocess controls. Re-authing and retrying the whole sequence is the
 # only reliable way to recover.
 COPILOT_MAX_ATTEMPTS = 3
+
+
+def _join_prompt(*sections):
+    return "\n\n".join(section.rstrip() for section in sections if section).rstrip() + "\n"
+
+
+def _pre_review_instructions():
+    return """\
+Review instructions:
+- Follow the Review Instructions in .claude/skills/review/SKILL.md.
+- Repo is checked out at PR head.
+- Post findings as individual inline review comments on specific lines.
+"""
+
+
+def _pre_review_tools(pr_number):
+    return f"""\
+Tools:
+- Prefix every `gh` call with `{GH_PREFIX}`.
+- Post a new inline review comment by writing the body to a file and running:
+  `{GH_PREFIX} python3 ci/praktika/gh.py post-pr-line-comment --file <body.md> --commit <sha> --path <file> --line <N> [--side RIGHT|LEFT]`.
+  This wrapper handles `-F body=@<file>` correctly so the file content is uploaded as the body.
+- Do NOT call `gh api .../pulls/.../comments` directly: past runs have posted the literal `@<file>`
+  string as the body when the wrong `gh` flag was used.
+- Do NOT use `gh pr review`; that posts a single batched review, not individual line comments.
+- Fetch inline review threads with:
+  `{GH_PREFIX} python3 ci/praktika/gh.py list-pr-review-threads --pr {pr_number}`.
+  The command returns JSON; each thread carries its node `id`, `isResolved`, `path`, `line`, and
+  `comments.nodes` with author, body, and `databaseId`.
+- Fetch top-level conversation with:
+  `{GH_PREFIX} gh api '/repos/{{owner}}/{{repo}}/issues/{pr_number}/comments' --paginate`.
+- Reply on an existing thread with:
+  `{GH_PREFIX} python3 ci/praktika/gh.py post-pr-line-comment --file <body.md> --reply-to <parent_databaseId>`.
+  Use the `databaseId` of the first comment on the thread as `<parent_databaseId>`, and omit
+  `--commit`, `--path`, and `--line`.
+- Resolve or unresolve bot-authored review threads with:
+  `{GH_PREFIX} python3 ci/praktika/gh.py resolve-pr-review-thread --thread-id <thread_node_id>`
+  `{GH_PREFIX} python3 ci/praktika/gh.py unresolve-pr-review-thread --thread-id <thread_node_id>`.
+"""
+
+
+def _pre_review_procedure(pr_url):
+    return f"""\
+Procedure:
+1. In GitHub discussions, "you" are `clickhouse-gh[bot]`.
+2. Fetch all prior discussion on this PR before reviewing.
+3. Provide a thorough review of {pr_url}. Read the current code and PR diff, not only the discussion.
+4. Read every reply on every thread before deciding whether a point is still live. A reply from the author is not
+   by itself a resolution. Judge it on its merits: an explanation that holds up, a pointer to a commit
+   that actually fixes the issue, or a tradeoff you agree with means drop the point. A handwave, a
+   misunderstanding of what was originally flagged, a "will fix later" that never landed, or a claim
+   that contradicts the code as it stands now means the issue is still live.
+5. Apply the same judgment to your own prior summary: drop findings that have genuinely been addressed,
+   keep or sharpen the ones that have not. Verify this by reading the current code at the relevant path
+   and line, not by trusting the author's reply.
+6. For existing live threads, summarize the issue by default instead of replying on the thread. Reply
+   only when the thread is marked as resolved, someone replied saying it is not an issue and you
+   believe it still is, or your last comment is older than two days. When replying, restate the concern
+   with the relevant code and explain why the previous answer does not resolve it.
+7. Resolve or re-open only threads you created yourself: that means threads where the first comment in
+   `comments.nodes` was authored by `clickhouse-gh[bot]`. If a bot-authored thread is open and the issue
+   no longer holds in the current code, resolve it. If a bot-authored thread was resolved but the
+   current code still has the issue, re-open it and post a follow-up reply explaining what is still
+   wrong. Never resolve or unresolve threads where the first comment was authored by anyone else.
+8. For genuinely new issues that do not already have a thread, post individual inline comments on the
+   relevant changed lines. For architectural issues that do not map cleanly to one line, post around
+   the most relevant change in the diff.
+"""
+
+
+def _pre_review_output():
+    return f"""\
+Output:
+Write a self-contained summary of ALL findings, regardless of previous summaries, as plain Markdown
+to {REVIEW_FILE} using the REQUESTED OUTPUT FORMAT from .claude/skills/review/SKILL.md:
+start with `---
+#### AI Review`, then use ##### for section headers.
+Do NOT post the summary yourself: the job script will post it after you finish.
+"""
+
+
+def _pre_review_prompt(info):
+    return _join_prompt(
+        _pre_review_instructions(),
+        _pre_review_tools(info.pr_number),
+        _pre_review_procedure(info.pr_url),
+        _pre_review_output(),
+    )
+
+
+def _post_review_tools(ci_report_url):
+    return f"""\
+Tools:
+- Fetch CI results with:
+  `node .claude/tools/fetch_ci_report.js '{ci_report_url}' --failed --links`.
+- Use `--all`, `--test <name>`, or `--download-logs` for deeper investigation.
+"""
+
+
+def _post_review_procedure(pr_url):
+    return f"""\
+Procedure:
+1. If all checks passed, stop.
+2. Otherwise review the PR {pr_url} diff and match each failure to the code changes.
+3. Do not post inline comments.
+"""
+
+
+def _post_review_output():
+    return f"""\
+Output:
+Write a self-contained summary as plain Markdown to {REVIEW_FILE}:
+start with `---
+### AI Review`, then use #### headers for sections only if needed.
+Do NOT post the summary yourself: the job script will post it after you finish.
+"""
+
+
+def _post_review_prompt(info, ci_report_url):
+    return _join_prompt(
+        _post_review_tools(ci_report_url),
+        _post_review_procedure(info.pr_url),
+        _post_review_output(),
+    )
 
 
 def _reauth_gh():
@@ -90,7 +215,7 @@ def _run_copilot_once(prompt):
             # --add-dir .: restrict file access to repo root (default,
             #   but explicit; do NOT add --allow-all-paths)
             command=f"GH_CONFIG_DIR={shlex.quote(gh_config_dir)} "
-                    f"copilot -p {shlex.quote(prompt)} --allow-all-tools --add-dir . --model gpt-5.3-codex",
+                    f"copilot -p {shlex.quote(prompt)} --allow-all-tools --add-dir . --model gpt-5.3-codex --effort xhigh",
             with_info=True,
         )
 
@@ -150,65 +275,7 @@ def pre():
 
     _reauth_gh()
     os.makedirs("./ci/tmp", exist_ok=True)
-    prompt = f"""\
-Follow the Review Instructions in .claude/skills/review/SKILL.md.
-Review PR {info.pr_url}. Repo is checked out at PR head.
-Post findings as individual inline review comments on specific lines.
-Prefix every gh call with `env -u GH_CONFIG_DIR`.
-
-IMPORTANT: to post an inline review comment, write the body to a file and call:
-`env -u GH_CONFIG_DIR python3 ci/praktika/gh.py post-pr-line-comment --file <body.md> --commit <sha> --path <file> --line <N> [--side RIGHT|LEFT]`.
-This wrapper handles `-F body=@<file>` correctly so the file content is uploaded as the body.
-Do NOT call `gh api .../pulls/.../comments` directly: past runs have posted the literal `@<file>`
-string as the body when the wrong gh flag was used.
-Do NOT use `gh pr review` (that posts a single batched review, not individual line comments).
-
-Before reviewing, fetch all prior discussion on this PR.
-Inline review threads come from
-`env -u GH_CONFIG_DIR python3 ci/praktika/gh.py list-pr-review-threads --pr {info.pr_number}`
-(returns JSON; each thread carries its node `id`, `isResolved`, `path`, `line`, and `comments.nodes`
-with author, body, and `databaseId`).
-Top-level conversation comes from
-`env -u GH_CONFIG_DIR gh api '/repos/{{owner}}/{{repo}}/issues/{info.pr_number}/comments' --paginate`.
-
-Read every reply on every thread before deciding to raise a point.
-A reply from the author is not by itself a resolution.
-Judge it on its merits: an explanation that holds up, a pointer to a commit that actually fixes
-the issue, or a tradeoff you agree with means drop the point.
-A handwave, a misunderstanding of what was originally flagged, a 'will fix later' that never
-landed, or a claim that contradicts the code as it stands now means the issue is still live.
-In that case, push back: reply on the existing thread, restate the concern with the relevant code,
-and explain why the previous answer does not resolve it.
-
-To reply on a thread, use the same wrapper with `--reply-to <parent_databaseId>` (the `databaseId`
-of the first comment on the thread) and omit `--commit`/`--path`/`--line`:
-`env -u GH_CONFIG_DIR python3 ci/praktika/gh.py post-pr-line-comment --file <body.md> --reply-to <parent_databaseId>`.
-Do not open a fresh inline comment for a point that already has a thread; reply on the thread instead.
-Apply the same judgment to your own prior summary: drop findings that have genuinely been addressed,
-keep or sharpen the ones that have not.
-
-After reviewing, mark threads as resolved or unresolved based on the current code.
-Only act on threads you created yourself: that means threads where the first comment in
-`comments.nodes` was authored by `clickhouse-gh[bot]`.
-Never resolve or unresolve threads where the first comment was authored by anyone else
-(other reviewers, the PR author, other bots), even when the code suggests the thread should
-be resolved or re-opened.
-For each bot-authored thread that is not already resolved, if the issue you flagged no longer
-holds in the current code, resolve it via
-`env -u GH_CONFIG_DIR python3 ci/praktika/gh.py resolve-pr-review-thread --thread-id <thread_node_id>`.
-If a bot-authored thread was already resolved (by you or someone else) but the current code still
-has the issue, you can re-open it via
-`env -u GH_CONFIG_DIR python3 ci/praktika/gh.py unresolve-pr-review-thread --thread-id <thread_node_id>`
-and post a follow-up reply explaining what is still wrong.
-Verify the state by reading the current code at the thread's path and line, not by trusting
-the author's reply.
-
-Write a self-contained summary of ALL findings (regardless of previous summaries) as plain Markdown
-to {REVIEW_FILE} using the REQUESTED OUTPUT FORMAT from .claude/skills/review/SKILL.md:
-start with `---
-#### AI Review`, then use ##### for section headers.
-Do NOT post the summary yourself: the job script will post it after you finish.
-"""
+    prompt = _pre_review_prompt(info)
     _run(prompt)
 
 
@@ -222,17 +289,7 @@ def post():
     os.makedirs("./ci/tmp", exist_ok=True)
     ci_report_url = info.get_report_url()
 
-    prompt = f"""\
-Fetch CI results: node .claude/tools/fetch_ci_report.js '{ci_report_url}' --failed --links
-(use --all, --test <name>, or --download-logs for deeper investigation).
-If all checks passed: stop.
-Otherwise review the PR {info.pr_url} diff and match each failure to the code changes.
-Write a self-contained summary as plain Markdown to {REVIEW_FILE}:
-start with `---
-### AI Review`, then use #### headers for sections only if needed.
-Do NOT post the summary yourself: the job script will post it after you finish.
-Do not post inline comments.
-"""
+    prompt = _post_review_prompt(info, ci_report_url)
     _run(prompt)
 
 

--- a/ci/jobs/copilot_review_job.py
+++ b/ci/jobs/copilot_review_job.py
@@ -24,6 +24,7 @@ import sys
 import tempfile
 import time
 import traceback
+import urllib.parse
 
 from ci.praktika import Secret
 from ci.praktika.info import Info
@@ -44,6 +45,17 @@ def _join_prompt(*sections):
     return "\n\n".join(section.rstrip() for section in sections if section).rstrip() + "\n"
 
 
+def _repo_from_pr_url(pr_url):
+    path_parts = urllib.parse.urlparse(pr_url).path.strip("/").split("/")
+    if len(path_parts) >= 4 and path_parts[2] == "pull":
+        return f"{path_parts[0]}/{path_parts[1]}"
+    return ""
+
+
+def _pr_repository(info):
+    return _repo_from_pr_url(info.pr_url) or info.repo_name
+
+
 def _pre_review_instructions():
     return """\
 Review instructions:
@@ -53,24 +65,37 @@ Review instructions:
 """
 
 
-def _pre_review_tools(pr_number):
+def _review_target(info):
+    repo_name = _pr_repository(info)
+    return f"""\
+Review target:
+- PR URL: {info.pr_url}
+- PR repository: `{repo_name}`
+- Always derive the PR repository from the PR URL or the CI event. For ClickHouse reviews this will be either
+  `ClickHouse/ClickHouse` or `ClickHouse/ClickHouse-private`. Do not infer the review repository from
+  the local checkout remote, because local checkouts may point to a fork.
+"""
+
+
+def _pre_review_tools(pr_number, repo_name):
     return f"""\
 Tools:
 - Prefix every `gh` call with `{GH_PREFIX}`.
+- Pass the explicit PR repository to every helper or `gh` command that accepts it: `--repo {repo_name}`.
 - Post a new inline review comment by writing the body to a file and running:
-  `{GH_PREFIX} python3 ci/praktika/gh.py post-pr-line-comment --file <body.md> --commit <sha> --path <file> --line <N> [--side RIGHT|LEFT]`.
+  `{GH_PREFIX} python3 ci/praktika/gh.py post-pr-line-comment --file <body.md> --commit <sha> --path <file> --line <N> --repo {repo_name} [--side RIGHT|LEFT]`.
   This wrapper handles `-F body=@<file>` correctly so the file content is uploaded as the body.
 - Do NOT call `gh api .../pulls/.../comments` directly: past runs have posted the literal `@<file>`
   string as the body when the wrong `gh` flag was used.
 - Do NOT use `gh pr review`; that posts a single batched review, not individual line comments.
 - Fetch inline review threads with:
-  `{GH_PREFIX} python3 ci/praktika/gh.py list-pr-review-threads --pr {pr_number}`.
+  `{GH_PREFIX} python3 ci/praktika/gh.py list-pr-review-threads --pr {pr_number} --repo {repo_name}`.
   The command returns JSON; each thread carries its node `id`, `isResolved`, `path`, `line`, and
   `comments.nodes` with author, body, and `databaseId`.
 - Fetch top-level conversation with:
-  `{GH_PREFIX} gh api '/repos/{{owner}}/{{repo}}/issues/{pr_number}/comments' --paginate`.
+  `{GH_PREFIX} gh api '/repos/{repo_name}/issues/{pr_number}/comments' --paginate`.
 - Reply on an existing thread with:
-  `{GH_PREFIX} python3 ci/praktika/gh.py post-pr-line-comment --file <body.md> --reply-to <parent_databaseId>`.
+  `{GH_PREFIX} python3 ci/praktika/gh.py post-pr-line-comment --file <body.md> --reply-to <parent_databaseId> --repo {repo_name}`.
   Use the `databaseId` of the first comment on the thread as `<parent_databaseId>`, and omit
   `--commit`, `--path`, and `--line`.
 - Resolve or unresolve bot-authored review threads with:
@@ -120,9 +145,11 @@ Do NOT post the summary yourself: the job script will post it after you finish.
 
 
 def _pre_review_prompt(info):
+    repo_name = _pr_repository(info)
     return _join_prompt(
         _pre_review_instructions(),
-        _pre_review_tools(info.pr_number),
+        _review_target(info),
+        _pre_review_tools(info.pr_number, repo_name),
         _pre_review_procedure(info.pr_url),
         _pre_review_output(),
     )
@@ -158,6 +185,7 @@ Do NOT post the summary yourself: the job script will post it after you finish.
 
 def _post_review_prompt(info, ci_report_url):
     return _join_prompt(
+        _review_target(info),
         _post_review_tools(ci_report_url),
         _post_review_procedure(info.pr_url),
         _post_review_output(),

--- a/ci/jobs/copilot_review_job.py
+++ b/ci/jobs/copilot_review_job.py
@@ -8,8 +8,8 @@ Copilot errors are logged as warnings only. Posting the review comment is
 done by the job script itself (not copilot) and fails the job if it does not work.
 
 Copilot writes the review to REVIEW_FILE; the job script then posts it via
-`ci/praktika/gh.py post-or-update --tag review` so the comment is always posted
-as the pre-authenticated app, not the Copilot robot.
+`python3 -m ci.praktika.gh post-or-update --tag review` so the comment is
+always posted as the pre-authenticated app, not the Copilot robot.
 
 The Copilot CLI occasionally hits transient GitHub authorization errors mid-run
 ("Authorization error, you may need to run /login"). The whole `gh auth` +
@@ -83,24 +83,24 @@ Tools:
 - Prefix every `gh` call with `{GH_PREFIX}`.
 - Pass the explicit PR repository to every helper or `gh` command that accepts it: `--repo {repo_name}`.
 - Post a new inline review comment by writing the body to a file and running:
-  `{GH_PREFIX} python3 ci/praktika/gh.py post-pr-line-comment --file <body.md> --commit <sha> --path <file> --line <N> --repo {repo_name} [--side RIGHT|LEFT]`.
+  `{GH_PREFIX} python3 -m ci.praktika.gh post-pr-line-comment --file <body.md> --commit <sha> --path <file> --line <N> --repo {repo_name} [--side RIGHT|LEFT]`.
   This wrapper handles `-F body=@<file>` correctly so the file content is uploaded as the body.
 - Do NOT call `gh api .../pulls/.../comments` directly: past runs have posted the literal `@<file>`
   string as the body when the wrong `gh` flag was used.
 - Do NOT use `gh pr review`; that posts a single batched review, not individual line comments.
 - Fetch inline review threads with:
-  `{GH_PREFIX} python3 ci/praktika/gh.py list-pr-review-threads --pr {pr_number} --repo {repo_name}`.
+  `{GH_PREFIX} python3 -m ci.praktika.gh list-pr-review-threads --pr {pr_number} --repo {repo_name}`.
   The command returns JSON; each thread carries its node `id`, `isResolved`, `path`, `line`, and
   `comments.nodes` with author, body, and `databaseId`.
 - Fetch top-level conversation with:
   `{GH_PREFIX} gh api '/repos/{repo_name}/issues/{pr_number}/comments' --paginate`.
 - Reply on an existing thread with:
-  `{GH_PREFIX} python3 ci/praktika/gh.py post-pr-line-comment --file <body.md> --reply-to <parent_databaseId> --repo {repo_name}`.
+  `{GH_PREFIX} python3 -m ci.praktika.gh post-pr-line-comment --file <body.md> --reply-to <parent_databaseId> --repo {repo_name}`.
   Use the `databaseId` of the first comment on the thread as `<parent_databaseId>`, and omit
   `--commit`, `--path`, and `--line`.
 - Resolve or unresolve bot-authored review threads with:
-  `{GH_PREFIX} python3 ci/praktika/gh.py resolve-pr-review-thread --thread-id <thread_node_id>`
-  `{GH_PREFIX} python3 ci/praktika/gh.py unresolve-pr-review-thread --thread-id <thread_node_id>`.
+  `{GH_PREFIX} python3 -m ci.praktika.gh resolve-pr-review-thread --thread-id <thread_node_id>`
+  `{GH_PREFIX} python3 -m ci.praktika.gh unresolve-pr-review-thread --thread-id <thread_node_id>`.
 """
 
 
@@ -207,7 +207,7 @@ def _post_review():
     """Post REVIEW_FILE as a PR comment. Raises on failure, failing the job."""
     subprocess.run(
         [
-            sys.executable, "ci/praktika/gh.py",
+            sys.executable, "-m", "ci.praktika.gh",
             "post-or-update", "--tag", "review", "--file", REVIEW_FILE,
         ],
         check=True,


### PR DESCRIPTION
Reworks the Copilot review guidance so the agent has more freedom to reason from the PR's central promise instead of matching a long checklist. The review skill now asks the agent to derive the contract first, follow violated invariants across impacted surfaces, and use small triggered expansions only when the PR contains relevant signals such as new settings, ownership, failover, shared state, or subclass guards.

The skill also tightens evidence handling: `Performance Improvement` is treated as a measured-benefit claim, `Bug Fix` is treated as a fixed-behavior claim, and missing tests, benchmarks, metrics, or clear exceptions should block approval when they are material. This should make reviews more likely to ask for focused proof without turning every review into a universal matrix.

The supporting `ci/jobs/copilot_review_job.py` changes keep prompt construction clearer by separating tool/instruction text from the review procedure and passing explicit repository context for public/private ClickHouse targets.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.538`
<!-- ch-version-info:end -->