### PR TITLE
Fix flaky 04217_array_concat_json_extract_keys_index under bucketed Map serialization

### DIFF
--- a/tests/queries/0_stateless/04217_array_concat_json_extract_keys_index.reference
+++ b/tests/queries/0_stateless/04217_array_concat_json_extract_keys_index.reference
@@ -1,4 +1,4 @@
 {"cluster":"b","c":1}	{"d":"e","job":"g"}	{}
 {"cluster":"b","c":1}	{"d":"e","job":"g"}	{}
 {"cluster":"b","c":1}	{"d":"e","job":"g"}	{}
-{'cluster':'b','c':'1'}	{'d':'e','job':'g'}	{}
+{'c':'1','cluster':'b'}	{'d':'e','job':'g'}	{}

--- a/tests/queries/0_stateless/04217_array_concat_json_extract_keys_index.sql
+++ b/tests/queries/0_stateless/04217_array_concat_json_extract_keys_index.sql
@@ -41,7 +41,10 @@ ENGINE = MergeTree
 ORDER BY (resource)
 AS SELECT map('cluster', 'b', 'c', '1'), map('d', 'e', 'job', 'g'), map();
 
-SELECT * FROM t_88558_map
+-- Wrap each `Map` column in `mapSort` so the output is deterministic regardless of
+-- the on-disk map serialization version (`map_serialization_version_for_zero_level_parts`),
+-- which CI randomizes (`with_buckets` reorders keys by hash bucket).
+SELECT mapSort(attribute), mapSort(resource), mapSort(scope) FROM t_88558_map
 WHERE has(arrayConcat(mapKeys(attribute), mapKeys(scope), mapKeys(resource)), 'cluster')
   AND has(arrayConcat(mapKeys(attribute), mapKeys(scope), mapKeys(resource)), 'job');
 


### PR DESCRIPTION
The stateless test `04217_array_concat_json_extract_keys_index` fails on CI when the runner randomizes `map_serialization_version_for_zero_level_parts = 'with_buckets'` together with `map_buckets_strategy = 'constant'` and a small `map_buckets_min_avg_size` (observed culprit settings reported by `--diagnose-random-settings` on PR #104473 and PR #103016).

Under `with_buckets` serialization, `Map` entries are written to disk grouped by hash bucket, so iteration order during `SELECT` reflects bucket order rather than insertion order. The test's last query prints three `Map(LowCardinality(String), String)` columns via `SELECT *`, and the `resource` column shows up as `{'job':'g','d':'e'}` instead of `{'d':'e','job':'g'}`.

Fix by wrapping each `Map` column in `mapSort` so the rendered output is deterministic regardless of the underlying on-disk format. This is the idiomatic pattern used in `04060_coalescing_merge_tree_array_tuple_with_column_param.sql`. The test still exercises every randomized serialization configuration — only the `SELECT` output is sorted, the `WHERE` clause and the `arrayConcat(mapKeys(...))` index path that the test was originally added to cover (issue #88558 / PR #94515) are untouched.

Verified locally:
- Original `.sql` + bucketed settings (`with_buckets` + `constant` + `min_avg_size=1`): `resource` column reorders, output differs from reference.
- New `.sql` + same bucketed settings: `mapSort` produces `{'d':'e','job':'g'}` stably.
- New `.sql` under the test runner with full randomization, 50/50 passes.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104473
Related PR comment: https://github.com/ClickHouse/ClickHouse/pull/104473#issuecomment-4422051000

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.610`
<!-- ch-version-info:end -->