### PR TITLE
Make `isProbablePrime` cancellable and cap `rounds` to 256

### DIFF
--- a/src/Common/Primality.h
+++ b/src/Common/Primality.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <concepts>
 #include <limits>
 #include <numeric>
 
@@ -11,6 +12,7 @@
 #include <Common/HashTable/Hash.h>
 
 #include <boost/multiprecision/cpp_int.hpp>
+#include <boost/multiprecision/detail/uniform_int_distribution.hpp>
 #include <boost/multiprecision/integer.hpp>
 #include <boost/multiprecision/miller_rabin.hpp>
 
@@ -209,8 +211,66 @@ inline UInt8 isProbablePrime(T num, unsigned /*rounds*/)
     return isPrime(num);
 }
 
-template <is_big_uint T>
-UInt8 isProbablePrime(const T & num, unsigned rounds)
+namespace detail
+{
+
+/// Miller-Rabin primality test for wide integers, adapted from
+/// `boost::multiprecision::miller_rabin_test`, but invokes `check_cancelled` between rounds so
+/// long-running calls can be interrupted by `KILL QUERY` or `max_execution_time`.
+template <typename BoostUInt, typename Engine, std::invocable CheckCancelled>
+bool millerRabinTestBig(const BoostUInt & n, unsigned rounds, Engine & gen, CheckCancelled check_cancelled)
+{
+    using boost::multiprecision::bit_test;
+    using boost::multiprecision::lsb;
+    using boost::multiprecision::powm;
+
+    /// Callers must have rejected even numbers and small composites already.
+    chassert(n > 227);
+    chassert(bit_test(n, 0) != 0);
+
+    const BoostUInt nm1 = n - 1;
+
+    /// Quick Fermat test with a fixed base.
+    BoostUInt q = 228;
+    BoostUInt y = powm(q, nm1, n);
+    if (y != 1u)
+        return false;
+
+    q = nm1;
+    const std::size_t k = lsb(q);
+    q >>= k;
+
+    boost::multiprecision::uniform_int_distribution<BoostUInt> dist(2, n - 2);
+
+    for (unsigned i = 0; i < rounds; ++i)
+    {
+        check_cancelled();
+
+        BoostUInt x = dist(gen);
+        y = powm(x, q, n);
+        std::size_t j = 0;
+        while (true)
+        {
+            if (y == nm1)
+                break;
+            if (y == 1)
+            {
+                if (j == 0)
+                    break;
+                return false;
+            }
+            if (++j == k)
+                return false;
+            y = powm(y, 2, n);
+        }
+    }
+    return true;
+}
+
+}
+
+template <is_big_uint T, std::invocable CheckCancelled>
+UInt8 isProbablePrime(const T & num, unsigned rounds, CheckCancelled check_cancelled)
 {
     /// If the wide value fits in UInt64, use the deterministic UInt64 path.
     if (num <= std::numeric_limits<UInt64>::max())
@@ -229,7 +289,13 @@ UInt8 isProbablePrime(const T & num, unsigned rounds)
     /// Seed deterministically so the same (num, rounds) pair always produces the same result.
     pcg64 rng(DefaultHash<T>{}(num));
 
-    return boost::multiprecision::miller_rabin_test(boost_num, rounds, rng);
+    return detail::millerRabinTestBig(boost_num, rounds, rng, check_cancelled);
+}
+
+template <is_big_uint T>
+UInt8 isProbablePrime(const T & num, unsigned rounds)
+{
+    return isProbablePrime(num, rounds, [] {});
 }
 
 }

--- a/src/Functions/isProbablePrime.cpp
+++ b/src/Functions/isProbablePrime.cpp
@@ -6,6 +6,8 @@
 #include <Functions/FunctionHelpers.h>
 #include <Functions/IFunction.h>
 #include <Functions/castTypeToEither.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/ProcessList.h>
 #include <Common/Primality.h>
 
 
@@ -23,12 +25,22 @@ namespace
 
 constexpr unsigned default_rounds = 25;
 
+/// `4^-max_rounds` is below `10^-150` — well past the point of diminishing returns. The cap also
+/// keeps the worst case bounded under the AST fuzzer (which can rewrite the `rounds` literal to
+/// `std::numeric_limits<unsigned>::max()` and hang the stress test for half an hour, see #101354).
+constexpr unsigned max_rounds = 256;
+
 class FunctionIsProbablePrime : public IFunction
 {
 public:
     static constexpr auto name = "isProbablePrime";
 
-    static FunctionPtr create(ContextPtr) { return std::make_shared<FunctionIsProbablePrime>(); }
+    static FunctionPtr create(ContextPtr context) { return std::make_shared<FunctionIsProbablePrime>(context); }
+
+    explicit FunctionIsProbablePrime(ContextPtr context)
+        : process_list_element(context ? context->getProcessListElement() : nullptr)
+    {
+    }
 
     String getName() const override { return name; }
     size_t getNumberOfArguments() const override { return 0; }
@@ -62,8 +74,23 @@ public:
             const UInt64 r = arguments[1].column->getUInt(0);
             if (r == 0)
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Second argument of function {} must be a positive integer constant", getName());
-            rounds = static_cast<unsigned>(std::min<UInt64>(r, std::numeric_limits<unsigned>::max()));
+            if (r > max_rounds)
+                throw Exception(
+                    ErrorCodes::BAD_ARGUMENTS,
+                    "Second argument of function {} must not exceed {} (got {}); larger values offer no meaningful "
+                    "improvement in confidence and can take too long to compute",
+                    getName(), max_rounds, r);
+            rounds = static_cast<unsigned>(r);
         }
+
+        const QueryStatusPtr query_status = process_list_element;
+        auto check_cancelled = [&query_status]
+        {
+            /// `checkTimeLimit` covers both `KILL QUERY` (via `is_killed`) and `max_execution_time`,
+            /// throwing the appropriate exception when either fires.
+            if (query_status)
+                query_status->checkTimeLimit();
+        };
 
         const IColumn * column = arguments[0].column.get();
         auto result = ColumnUInt8::create(input_rows_count);
@@ -74,8 +101,14 @@ public:
                 [&](const auto & col)
                 {
                     const auto & data = col.getData();
+                    using ValueT = std::decay_t<decltype(data[0])>;
                     for (size_t i = 0; i < input_rows_count; ++i)
-                        result_data[i] = Primality::isProbablePrime(data[i], rounds);
+                    {
+                        if constexpr (Primality::is_big_uint<ValueT>)
+                            result_data[i] = Primality::isProbablePrime(data[i], rounds, check_cancelled);
+                        else
+                            result_data[i] = Primality::isProbablePrime(data[i], rounds);
+                    }
                     return true;
                 }))
             throw Exception(
@@ -86,6 +119,9 @@ public:
 
         return result;
     }
+
+private:
+    QueryStatusPtr process_list_element;
 };
 
 }
@@ -101,7 +137,9 @@ For `UInt8`, `UInt16`, `UInt32`, and `UInt64`, the result is exact and matches
 For `UInt128` and `UInt256`, a return value of `1` is probabilistic. The optional `rounds` argument controls
 how many [Miller-Rabin](https://en.wikipedia.org/wiki/Miller-Rabin_primality_test) rounds are used:
 more rounds reduce the chance of a false positive and increase the running time. For any composite,
-the false-positive rate is bounded by `4^(-rounds)`; the default of `25` keeps it below `10^-15`.
+the false-positive rate is bounded by `4^(-rounds)`; the default of `25` keeps it below `10^-15`. Values above
+`256` are rejected as `BAD_ARGUMENTS`, since the false-positive rate at `256` is already below `10^-150` and
+larger values only waste time.
 
 The function is deterministic: the same input and `rounds` value always produce the same result.
     )";
@@ -109,8 +147,8 @@ The function is deterministic: the same input and `rounds` value always produce 
     FunctionDocumentation::Arguments arguments
         = {{"n", "Unsigned integer to test for primality.", {"UInt8", "UInt16", "UInt32", "UInt64", "UInt128", "UInt256"}},
            {"rounds",
-            "Optional positive integer constant. Number of Miller-Rabin rounds for `UInt128`/`UInt256` (ignored for narrower types). "
-            "Default `25`.",
+            "Optional positive integer constant in `[1, 256]`. Number of Miller-Rabin rounds for `UInt128`/`UInt256` "
+            "(ignored for narrower types). Default `25`.",
             {"UInt8", "UInt16", "UInt32", "UInt64"}}};
     FunctionDocumentation::ReturnedValue returned_value
         = {"Returns `1` if `n` is probably prime, `0` if it is definitely composite.", {"UInt8"}};

--- a/tests/queries/0_stateless/04203_is_prime_wide.reference
+++ b/tests/queries/0_stateless/04203_is_prime_wide.reference
@@ -136,6 +136,13 @@ SELECT isProbablePrime(toUInt64(17), '5');                   -- { serverError IL
 SELECT isProbablePrime(toUInt64(17), CAST(NULL AS Nullable(UInt32)));   -- NULL propagates by default
 \N
 SELECT isProbablePrime(toUInt64(17), 5, 3);                  -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
+-- rounds upper bound: the cap protects against AST-fuzzer-amplified literals that would otherwise
+-- run for hours under sanitizers. 256 is accepted (4^-256 < 10^-150 already), 257 is rejected.
+SELECT isProbablePrime(toUInt128('170141183460469231731687303715884105727'), 256);
+1
+SELECT isProbablePrime(toUInt128('170141183460469231731687303715884105727'), 257);          -- { serverError BAD_ARGUMENTS }
+SELECT isProbablePrime(toUInt256('57896044618658097711785492504343953926634992332820282019728792003956564819949'), 1000);  -- { serverError BAD_ARGUMENTS }
+SELECT isProbablePrime(toUInt64(17), 4294967295);            -- { serverError BAD_ARGUMENTS }
 WITH toUInt256('57896044618658097711785492504343953926634992332820282019728792003956564819949') AS p25519
 SELECT
     p25519 * toUInt256(3) < p25519 AS overflowed,

--- a/tests/queries/0_stateless/04203_is_prime_wide.sql
+++ b/tests/queries/0_stateless/04203_is_prime_wide.sql
@@ -99,6 +99,13 @@ SELECT isProbablePrime(toUInt64(17), '5');                   -- { serverError IL
 SELECT isProbablePrime(toUInt64(17), CAST(NULL AS Nullable(UInt32)));   -- NULL propagates by default
 SELECT isProbablePrime(toUInt64(17), 5, 3);                  -- { serverError NUMBER_OF_ARGUMENTS_DOESNT_MATCH }
 
+-- rounds upper bound: the cap protects against AST-fuzzer-amplified literals that would otherwise
+-- run for hours under sanitizers. 256 is accepted (4^-256 < 10^-150 already), 257 is rejected.
+SELECT isProbablePrime(toUInt128('170141183460469231731687303715884105727'), 256);
+SELECT isProbablePrime(toUInt128('170141183460469231731687303715884105727'), 257);          -- { serverError BAD_ARGUMENTS }
+SELECT isProbablePrime(toUInt256('57896044618658097711785492504343953926634992332820282019728792003956564819949'), 1000);  -- { serverError BAD_ARGUMENTS }
+SELECT isProbablePrime(toUInt64(17), 4294967295);            -- { serverError BAD_ARGUMENTS }
+
 WITH toUInt256('57896044618658097711785492504343953926634992332820282019728792003956564819949') AS p25519
 SELECT
     p25519 * toUInt256(3) < p25519 AS overflowed,


### PR DESCRIPTION
`isProbablePrime` on `UInt128`/`UInt256` delegated to `boost::multiprecision::miller_rabin_test`, which has no cancellation hook. Under heavy sanitizer + ThreadFuzzer instrumentation, a single round can stretch into minutes; combined with the server-side AST fuzzer mutating the `rounds` literal, the function hangs the stress test's `hung_check` for the full 30-minute window.

This PR:

- Adapts Boost's Miller-Rabin loop into `Primality::detail::millerRabinTestBig` and calls `QueryStatus::checkTimeLimit` between rounds, so both `KILL QUERY` and `max_execution_time` interrupt the function.
- Rejects `rounds > 256` with `BAD_ARGUMENTS`. `4^-256 < 10^-150` already, so larger values add no meaningful confidence and only widen the worst-case runtime under the AST fuzzer.

The hang was discovered by the AST-fuzzer-re-enablement PR #101354: every stress test variant hits a `hung_check` on the same root cause — `isProbablePrime` is `is_cancelled=1` but stuck in `boost::multiprecision::miller_rabin_test` → `eval_powm`. Example: https://s3.amazonaws.com/clickhouse-test-reports/PRs/101354/f0038d26f27dc2d179136ae371e632746bab3c30/stress_test_arm_tsan/hung_check.log

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Function `isProbablePrime` now respects `KILL QUERY` and `max_execution_time` mid-computation, and rejects unreasonably large `rounds` arguments (limit: 256) with `BAD_ARGUMENTS`.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)