### PR TITLE
Make CHECK TABLE prefer TEMPORARY tables for unqualified names (follow-up #100966)

### DIFF
--- a/src/Interpreters/InterpreterCheckQuery.cpp
+++ b/src/Interpreters/InterpreterCheckQuery.cpp
@@ -418,8 +418,11 @@ BlockIO InterpreterCheckQuery::execute()
     bool is_table_name_in_output = false;
     if (const auto * check_query = query_ptr->as<ASTCheckTableQuery>())
     {
-        /// Check specific table
-        auto table_id = context->resolveStorageID(*check_query, Context::ResolveOrdinary);
+        /// Check specific table. Use `ResolveAll` so that an unqualified name
+        /// prefers a `TEMPORARY` table over a permanent one of the same name,
+        /// matching the scoping precedence of `SHOW CREATE TABLE` and
+        /// `DESCRIBE TABLE` introduced in #100966.
+        auto table_id = context->resolveStorageID(*check_query);
         auto table_check_task = std::make_shared<TableCheckTask>(table_id, check_query->getPartitionOrPartitionID(), context);
         worker_source = std::make_shared<TableCheckSource>(table_check_task, log);
         worker_source->addTotalRowsApprox(table_check_task->size());

--- a/tests/queries/0_stateless/04228_check_optimize_alter_temporary_scoping_100966.reference
+++ b/tests/queries/0_stateless/04228_check_optimize_alter_temporary_scoping_100966.reference
@@ -1,0 +1,11 @@
+CHECK on TEMPORARY-only Log table returns success:
+1
+CHECK on collision targets TEMPORARY Memory (rejects):
+OK
+OPTIMIZE on collision targets TEMPORARY Memory (rejects):
+OK
+ALTER on collision modifies TEMPORARY (z appears in DESCRIBE):
+world	UInt64
+z	UInt8
+ALTER on collision does not modify permanent (no z in system.columns):
+0

--- a/tests/queries/0_stateless/04228_check_optimize_alter_temporary_scoping_100966.sql
+++ b/tests/queries/0_stateless/04228_check_optimize_alter_temporary_scoping_100966.sql
@@ -1,0 +1,66 @@
+-- Test for https://github.com/ClickHouse/ClickHouse/pull/100966 follow-up.
+-- Verify CHECK, OPTIMIZE, and ALTER TABLE use the same scoping precedence
+-- as SHOW CREATE TABLE / DESCRIBE TABLE: an unqualified name resolves to the
+-- TEMPORARY table when one exists, preferring it over a same-named permanent.
+
+SET describe_compact_output = 1;
+
+-- ============================================================================
+-- CHECK TABLE: previously used Context::ResolveOrdinary and ignored TEMPORARY.
+-- ============================================================================
+
+-- (1) CHECK TABLE on a TEMPORARY-only table now succeeds (was UNKNOWN_TABLE).
+DROP TABLE IF EXISTS t SYNC;
+CREATE TEMPORARY TABLE t (x UInt64) ENGINE = Log;
+INSERT INTO t VALUES (1), (2), (3);
+
+SELECT 'CHECK on TEMPORARY-only Log table returns success:';
+CHECK TABLE t SETTINGS check_query_single_value_result = 1;
+
+DROP TABLE t;
+
+-- (2) When a TEMPORARY and a permanent table both exist (Memory + MergeTree),
+--     CHECK TABLE now targets the TEMPORARY one. Memory doesn't support CHECK,
+--     so the query errors out -- previously it would have succeeded against the
+--     permanent MergeTree.
+CREATE TABLE t (hello String) ENGINE = MergeTree ORDER BY hello;
+INSERT INTO t VALUES ('p1'), ('p2'), ('p3');
+CREATE TEMPORARY TABLE t (world UInt64) ENGINE = Memory;
+
+SELECT 'CHECK on collision targets TEMPORARY Memory (rejects):';
+CHECK TABLE t; -- { serverError NOT_IMPLEMENTED }
+SELECT 'OK';
+
+DROP TEMPORARY TABLE t;
+DROP TABLE t;
+
+-- ============================================================================
+-- OPTIMIZE TABLE: already used the default ResolveAll. Lock in.
+-- ============================================================================
+CREATE TABLE t (hello String) ENGINE = MergeTree ORDER BY hello;
+CREATE TEMPORARY TABLE t (world UInt64) ENGINE = Memory;
+
+SELECT 'OPTIMIZE on collision targets TEMPORARY Memory (rejects):';
+OPTIMIZE TABLE t; -- { serverError NOT_IMPLEMENTED }
+SELECT 'OK';
+
+DROP TEMPORARY TABLE t;
+DROP TABLE t;
+
+-- ============================================================================
+-- ALTER TABLE: already used tryResolveStorageID with default ResolveAll. Lock in.
+-- ============================================================================
+CREATE TABLE t (hello String) ENGINE = MergeTree ORDER BY hello;
+CREATE TEMPORARY TABLE t (world UInt64) ENGINE = Memory;
+
+ALTER TABLE t ADD COLUMN z UInt8;
+
+SELECT 'ALTER on collision modifies TEMPORARY (z appears in DESCRIBE):';
+DESCRIBE TEMPORARY TABLE t;
+
+SELECT 'ALTER on collision does not modify permanent (no z in system.columns):';
+SELECT count() FROM system.columns
+WHERE database = currentDatabase() AND table = 't' AND name = 'z';
+
+DROP TEMPORARY TABLE t;
+DROP TABLE t;


### PR DESCRIPTION
Follow-up to #100966 on a request from @PedroTadim ([inline comment](https://github.com/ClickHouse/ClickHouse/pull/100966#discussion_r3217841914)) to keep the scoping precedence consistent across every command.

## Motivation

`InterpreterCheckQuery::execute` explicitly passed `Context::ResolveOrdinary` to `resolveStorageID`, so `CHECK TABLE t` for an unqualified name never consulted the session's `TEMPORARY` tables. Two visible consequences:

1. `CHECK TABLE t` on a `TEMPORARY`-only `Log` / `File` table failed with `UNKNOWN_TABLE`, even though those engines support `CHECK`:
   ```sql
   CREATE TEMPORARY TABLE t (x UInt64) ENGINE = Log;
   INSERT INTO t VALUES (1), (2), (3);
   CHECK TABLE t;                       -- Code: 60. UNKNOWN_TABLE (no permanent `t`)
   ```

2. When both a `TEMPORARY` and a permanent table shared a name, `CHECK TABLE t` silently fell through to the permanent table, even though `SHOW CREATE TABLE`, `DESCRIBE TABLE`, `OPTIMIZE TABLE`, and `ALTER TABLE` already route the same unqualified name to the `TEMPORARY` one (the precedence #100966 made consistent).

Audit of how each "table inspection / mutation" command resolves an unqualified name on master:

| Command | Resolution before this PR |
| --- | --- |
| `SHOW CREATE TABLE` | `ResolveAll` (`TEMPORARY` first) — #100966 |
| `DESCRIBE TABLE` | `ResolveAll` (`TEMPORARY` first) — #100966 |
| `OPTIMIZE TABLE` | `ResolveAll` (default) |
| `ALTER TABLE` | `ResolveAll` (`tryResolveStorageID`, default) |
| `INSERT INTO` / `SELECT FROM` | `ResolveAll` (default) |
| **`CHECK TABLE`** | **`ResolveOrdinary` (permanent only)** ⚠️ |

This PR aligns `CHECK TABLE` with the rest by using the default `ResolveAll` precedence, the same one PR #100966 settled on for the table-inspection family.

## What changes

Only `InterpreterCheckQuery.cpp`:

```diff
-        /// Check specific table
-        auto table_id = context->resolveStorageID(*check_query, Context::ResolveOrdinary);
+        /// Check specific table. Use `ResolveAll` so that an unqualified name
+        /// prefers a `TEMPORARY` table over a permanent one of the same name,
+        /// matching the scoping precedence of `SHOW CREATE TABLE` and
+        /// `DESCRIBE TABLE` introduced in #100966.
+        auto table_id = context->resolveStorageID(*check_query);
```

After:

* `CHECK TABLE t` on a `TEMPORARY`-only `Log` / `File` table succeeds.
* On a `TEMPORARY` + permanent collision, `CHECK TABLE t` targets the temporary one; `CHECK TABLE db.t` still targets the permanent one (qualifying the name disables external lookup).
* `CHECK TABLE t` on a `TEMPORARY` `Memory` table now surfaces `NOT_IMPLEMENTED` from the engine, instead of `UNKNOWN_TABLE` from the catalog — a more accurate error message.

## Verification

* Built locally with `clang-21`, debug.
* Added a new stateless test `04228_check_optimize_alter_temporary_scoping_100966.sql` that exercises `CHECK` / `OPTIMIZE` / `ALTER` scoping with a `TEMPORARY`/permanent collision.
* Without the one-line change: the test fails on the first assertion (`Code: 60. UNKNOWN_TABLE`) — confirmed by reverting, rebuilding, and re-running.
* With the change: 50/50 runs pass under randomized server and `MergeTree` settings.
* Existing `04064_describe_show_create_temporary_table` still passes (5/5).

## Out of scope (not changed)

Other `ResolveOrdinary` call sites I checked:

* `InterpreterDeleteQuery` (lightweight `DELETE`), `InterpreterUpdateQuery` (lightweight `UPDATE`) — `MergeTree`-only operations, temporary engines do not support them.
* `InterpreterWatchQuery` — live views, cannot be temporary.
* `InterpreterSystemQuery` — operates on permanent storage (replication / merges / etc.).
* `InterpreterShowCreateQuery` — already handled by #100966 (`TABLE` uses `ResolveAll`, `VIEW` / `DICTIONARY` keep `ResolveOrdinary`).

So `CHECK TABLE` was the lone outlier among commands that can semantically run against a temporary table.

cc @PedroTadim @alexey-milovidov

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

`CHECK TABLE t` now prefers a `TEMPORARY` table over a permanent one with the same name when no database qualifier is given, matching the precedence already used by `SHOW CREATE TABLE`, `DESCRIBE TABLE`, `OPTIMIZE TABLE`, and `ALTER TABLE`. Previously `CHECK TABLE t` skipped temporary tables entirely, so it failed with `UNKNOWN_TABLE` on a temporary `Log` or `File` table even though those engines support `CHECK`. Follow-up to [#100966](https://github.com/ClickHouse/ClickHouse/pull/100966).


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.552`
<!-- ch-version-info:end -->