### PR TITLE
Fix DROP MASKING POLICY grammar comment

### DIFF
--- a/src/Parsers/Access/ASTDropAccessEntityQuery.h
+++ b/src/Parsers/Access/ASTDropAccessEntityQuery.h
@@ -14,7 +14,7 @@ struct MaskingPolicyName;
   * DROP ROLE [IF EXISTS] name [,...]
   * DROP QUOTA [IF EXISTS] name [,...]
   * DROP [ROW] POLICY [IF EXISTS] name [,...] ON [database.]table [,...]
-  * DROP MASKING POLICY [IF EXISTS] name [,...] ON [database.]table [,...]
+  * DROP MASKING POLICY [IF EXISTS] name ON [database.]table
   * DROP [SETTINGS] PROFILE [IF EXISTS] name [,...]
   */
 class ASTDropAccessEntityQuery final : public IAST, public ASTQueryWithOnCluster

--- a/src/Parsers/Access/ParserDropAccessEntityQuery.h
+++ b/src/Parsers/Access/ParserDropAccessEntityQuery.h
@@ -11,7 +11,7 @@ namespace DB
   * DROP QUOTA [IF EXISTS] name [,...]
   * DROP [SETTINGS] PROFILE [IF EXISTS] name [,...]
   * DROP [ROW] POLICY [IF EXISTS] name [,...] ON [database.]table [,...]
-  * DROP MASKING POLICY [IF EXISTS] name [,...] ON [database.]table [,...]
+  * DROP MASKING POLICY [IF EXISTS] name ON [database.]table
   */
 class ParserDropAccessEntityQuery final : public IParserBase
 {


### PR DESCRIPTION
The header comments in `src/Parsers/Access/ParserDropAccessEntityQuery.h` and `src/Parsers/Access/ASTDropAccessEntityQuery.h` advertised:

```
DROP MASKING POLICY [IF EXISTS] name [,...] ON [database.]table [,...]
```

but the implementation only accepts a single name and a single table:

- `parseMaskingPolicyName` (`ParserDropAccessEntityQuery.cpp:42`) reads exactly one identifier plus one `database.table`, with no comma loop.
- `ASTDropAccessEntityQuery::masking_policy_name` (`ASTDropAccessEntityQuery.h:28`) is a singular `std::shared_ptr<MaskingPolicyName>`, not a vector — contrast with the plural `boost::intrusive_ptr<ASTRowPolicyNames>` used for row policies.
- `ASTDropAccessEntityQuery::formatImpl` (`ASTDropAccessEntityQuery.cpp:57-60`) emits exactly one entity.
- `InterpreterDropAccessEntityQuery` (`InterpreterDropAccessEntityQuery.cpp:71-72`) wraps it in a 1-element `Strings` for the shared drop helper.

This change updates both header comments to match the actual grammar, which also lines up with the sibling `CREATE` / `ALTER` / `SHOW CREATE MASKING POLICY` parsers (`name ON [database.]table`, singular).

Doc-only change; no behavior change.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes
- [x] Documentation is unchanged

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.547`
<!-- ch-version-info:end -->