### PR TITLE
Make `02493_max_streams_for_merge_tree_reading` deterministic under free-memory limiter

### DIFF
--- a/tests/queries/0_stateless/02493_max_streams_for_merge_tree_reading.sql
+++ b/tests/queries/0_stateless/02493_max_streams_for_merge_tree_reading.sql
@@ -12,6 +12,14 @@ set allow_prefetched_read_pool_for_local_filesystem = 0;
 -- (randomized 0-100, INSERT with max_insert_threads=8 creates ~8 parts)
 set read_in_order_two_level_merge_threshold = 100;
 
+-- The pipeline shape depends on the exact thread count;
+-- disable the free-memory limiter to keep `max_threads` as set in the queries.
+-- Without this, on `per_test_coverage` and other memory-constrained builds
+-- `max_threads=32` is clamped to fewer threads and `Resize 16 → 32` becomes
+-- e.g. `Resize 16 → 24`. See PR #100383.
+set max_threads_min_free_memory_per_thread = 0;
+set max_insert_threads_min_free_memory_per_thread = 0;
+
 -- { echo }
 
 -- The number of output streams is limited by max_streams_for_merge_tree_reading


### PR DESCRIPTION
The test exercises `EXPLAIN PIPELINE` with `max_threads=32` and asserts the resulting pipeline contains exactly `Resize 16 → 32`. Since #100383 (`Limit max_threads and max_insert_threads based on available free memory`), `max_threads` is trimmed when free memory is below `max_threads_min_free_memory_per_thread` (default 1 GiB) per requested thread.

On `Stateless tests (amd_llvm_coverage_per_test, per_test_coverage, 7/8)` the per-test coverage instrumentation reduces available memory, so the limiter clamps the requested 32 threads to ~24 and the test fails:

```
- Resize 16 → 32
- MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
+ Resize 16 → 24
+ MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
```

Disable both `max_threads_min_free_memory_per_thread` and `max_insert_threads_min_free_memory_per_thread` in the test `SET` block so the requested thread count is preserved regardless of concurrent memory pressure. Same fix pattern applied to `02343_aggregation_pipeline.sql` in the original PR (commit `de505d131eb`).

The test had its last master failure wave begin on 2026-05-02 03:55 UTC, ~4 hours after #100383 merged on 2026-05-01 23:22 UTC. CIDB shows 10 master hits in the 14-day window since, all on `per_test_coverage`. The auto-generated `Flaky test` issue #101657 covers an older failure mode that was fixed by #102818 (`read_in_order_two_level_merge_threshold` pin); this PR addresses a separate failure mode introduced by #100383.

**Reproduction (deterministic):**

I injected the limiter manually into `CLICKHOUSE_CLIENT_OPT` to simulate the per-test-coverage memory pressure:

```bash
PATH=build/programs:$PATH \
  CLICKHOUSE_CLIENT_OPT='--max_threads_min_free_memory_per_thread=24000000000 --max_insert_threads_min_free_memory_per_thread=24000000000' \
  tests/clickhouse-test 02493_max_streams_for_merge_tree_reading
```

Before the fix the test fails with `Resize 4 → 4` instead of `Resize 16 → 32` (the same shape as the CI failure):

```
- Resize 16 → 32
- MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 16 0 → 1
+ Resize 4 → 4
+ MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 4 0 → 1
```

After the fix the test passes 10/10 runs with the injected limiter and 50/50 runs with full randomization but without the limiter.

CI failure example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=bbf2861532b8871fbc0e3d7d3362e1f0e3fabf3f&name_0=NightlyCoverage&name_1=Stateless%20tests%20%28amd_llvm_coverage_per_test%2C%20per_test_coverage%2C%207%2F8%29
PR introducing the regression: https://github.com/ClickHouse/ClickHouse/pull/100383
Related issue: https://github.com/ClickHouse/ClickHouse/issues/101657

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

...


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.560`
<!-- ch-version-info:end -->