### PR TITLE
Add test: `lowerUTF8` `U_BUFFER_OVERFLOW_ERROR` retry path untested with expanding characters

### DIFF
--- a/tests/queries/0_stateless/04229_lower_utf8_turkish_expansion.reference
+++ b/tests/queries/0_stateless/04229_lower_utf8_turkish_expansion.reference
@@ -1,0 +1,3 @@
+single_row_expansion	2000	3000	1
+multi_row_expansion	3000	4500	1
+mixed_batch	420	620

--- a/tests/queries/0_stateless/04229_lower_utf8_turkish_expansion.sql
+++ b/tests/queries/0_stateless/04229_lower_utf8_turkish_expansion.sql
@@ -1,0 +1,42 @@
+-- Tags: no-fasttest
+-- Test: exercises `lowerUTF8` `U_BUFFER_OVERFLOW_ERROR` retry path at LowerUpperUTF8Impl.h:122-128
+-- Covers: Turkish İ (U+0130) expands 2→3 bytes during lowercase, triggering buffer overflow retry
+
+-- Turkish İ (LATIN CAPITAL LETTER I WITH DOT ABOVE) lowercases to i + combining dot above
+-- This is a 1.5x byte expansion (2 bytes → 3 bytes), which can trigger U_BUFFER_OVERFLOW_ERROR
+-- when the initial buffer (sized to input) is insufficient for the expanded output.
+
+-- Single row with enough İ to trigger overflow: 1000 İ chars = 2000 input bytes → 3000 output bytes
+SELECT 
+    'single_row_expansion' AS test_case,
+    length(input) AS input_bytes,
+    length(output) AS output_bytes,
+    output_bytes > input_bytes AS expanded
+FROM (
+    SELECT repeat('İ', 1000) AS input, lowerUTF8(repeat('İ', 1000)) AS output
+) ORDER BY test_case;
+
+-- Multiple rows to exercise per-row retry path with expansion
+SELECT 
+    'multi_row_expansion' AS test_case,
+    sum(length(s)) AS total_input_bytes,
+    sum(length(lowerUTF8(s))) AS total_output_bytes,
+    sum(length(lowerUTF8(s))) > sum(length(s)) AS expanded
+FROM (
+    SELECT arrayJoin([repeat('İ', 500), repeat('İ', 500), repeat('İ', 500)]) AS s
+) ORDER BY test_case;
+
+-- Mixed batch: some rows expand (İ), some don't (normal Unicode)
+-- This tests the retry path interleaved with non-expanding rows
+SELECT 
+    'mixed_batch' AS test_case,
+    sum(length(s)) AS total_input_bytes,
+    sum(length(lowerUTF8(s))) AS total_output_bytes
+FROM (
+    SELECT arrayJoin([
+        repeat('İ', 100),      -- expands 1.5x
+        'MÜNCHEN',             -- normal (no expansion)
+        repeat('İ', 100),      -- expands 1.5x
+        'ПРИВЕТ'               -- normal (no expansion)
+    ]) AS s
+) ORDER BY test_case;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #104229](https://github.com/ClickHouse/ClickHouse/pull/104229).
 That PR QA brief: (1) PR fixes int32_t overflow in `lowerUTF8`/`upperUTF8` when processing large non-ASCII buffers by capping `destCapacity` at `INT32_MAX` and rejecting single rows that could overflow ICU's int32_t return value. (2) Risk areas: the `U_BUFFER_OVERFLOW_ERROR` retry path (lines 105-129) handl

**1. `lowerUTF8` `U_BUFFER_OVERFLOW_ERROR` retry path untested with expanding characters**
  `src/Functions/LowerUpperUTF8Impl.h:122`
  **Risk:** Call chain: `lowerUTF8(repeat('İ', 1000))` → `LowerUpperUTF8Impl::vector` → initial buffer = 2000 bytes → first `ucasemap_utf8ToLower` call → returns `U_BUFFER_OVERFLOW_ERROR` with dst_size=3000 → buf
  **What's unique vs PR tests:** PR test 04204_lower_upper_utf8_large_buffer.sql tests upperUTF8 with expansion characters (ΐ, ŉ, և, ΰ) but only tests lowerUTF8 with non-expanding strings ('MÜNCHEN', 'ПРИВЕТ МИР'). My test specifical
  **Tags:** `-- Tags: no-fasttest` — `no-fasttest`: lowerUTF8/upperUTF8 require ICU library which is disabled in fast-test build
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/e5bc7f8b-7f09-4025-b518-5315ee9bfa99)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.573`
<!-- ch-version-info:end -->