### PR TITLE
Fix Keeper termination on get `/keeper/availability_zone` with `quorum_reads=true`

### DIFF
--- a/src/Coordination/KeeperStorage.cpp
+++ b/src/Coordination/KeeperStorage.cpp
@@ -1887,8 +1887,7 @@ std::list<KeeperStorageBase::Delta> preprocess(
     ProfileEvents::increment(ProfileEvents::KeeperGetRequest);
 
     if (zk_request.path == Coordination::keeper_api_feature_flags_path
-        || zk_request.path == Coordination::keeper_config_path
-        || zk_request.path == Coordination::keeper_availability_zone_path)
+        || zk_request.path == Coordination::keeper_config_path)
         return {};
 
     if (!storage.uncommitted_state.getNode(zk_request.path))
@@ -2453,8 +2452,7 @@ std::list<KeeperStorageBase::Delta> preprocess(
     ProfileEvents::increment(ProfileEvents::KeeperListRecursiveRequest);
 
     if (zk_request.path == Coordination::keeper_api_feature_flags_path
-        || zk_request.path == Coordination::keeper_config_path
-        || zk_request.path == Coordination::keeper_availability_zone_path)
+        || zk_request.path == Coordination::keeper_config_path)
         return {};
 
     if (!storage.uncommitted_state.getNode(zk_request.path))

--- a/tests/integration/test_keeper_availability_zone_quorum_reads/configs/keeper_config.xml
+++ b/tests/integration/test_keeper_availability_zone_quorum_reads/configs/keeper_config.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<clickhouse>
+    <!--
+        Keeper without <placement> configured, so /keeper/availability_zone is
+        not registered in the storage container. Combined with quorum_reads=true,
+        a Get request for that path used to take the raft commit path and
+        terminate the server (onStorageInconsistency). This test ensures the
+        request now returns ZNONODE gracefully.
+    -->
+    <keeper_server>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+        <coordination_settings>
+            <operation_timeout_ms>5000</operation_timeout_ms>
+            <session_timeout_ms>10000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+            <quorum_reads>true</quorum_reads>
+        </coordination_settings>
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>node</hostname>
+                <port>2888</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+
+    <zookeeper>
+        <node index="1">
+            <host>node</host>
+            <port>9181</port>
+        </node>
+    </zookeeper>
+</clickhouse>

--- a/tests/integration/test_keeper_availability_zone_quorum_reads/configs/keeper_config_configured.xml
+++ b/tests/integration/test_keeper_availability_zone_quorum_reads/configs/keeper_config_configured.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<clickhouse>
+    <!--
+        Keeper with <placement> configured and quorum_reads=true. A Get request
+        for /keeper/availability_zone takes the raft commit path and should
+        return the configured AZ value with stat. This pins the configured
+        branch of the fix: when AZ is registered in system_nodes_with_data the
+        container lookup must still succeed under the quorum-read path.
+    -->
+    <placement>
+        <use_imds>0</use_imds>
+        <availability_zone>az-configured</availability_zone>
+    </placement>
+
+    <keeper_server>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+        <coordination_settings>
+            <operation_timeout_ms>5000</operation_timeout_ms>
+            <session_timeout_ms>10000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+            <quorum_reads>true</quorum_reads>
+        </coordination_settings>
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>node_configured</hostname>
+                <port>2888</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+
+    <zookeeper>
+        <node index="1">
+            <host>node_configured</host>
+            <port>9181</port>
+        </node>
+    </zookeeper>
+</clickhouse>

--- a/tests/integration/test_keeper_availability_zone_quorum_reads/configs/keeper_config_local_reads.xml
+++ b/tests/integration/test_keeper_availability_zone_quorum_reads/configs/keeper_config_local_reads.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<clickhouse>
+    <!--
+        Keeper without <placement> configured and with quorum_reads=false
+        (the default). A Get request for /keeper/availability_zone takes the
+        local read path via processLocalRequests and returns ZNONODE
+        gracefully. The companion config keeper_config.xml exercises the
+        raft commit path (quorum_reads=true) where the bug used to live;
+        this config pins the equivalence between the two read modes after
+        the fix.
+    -->
+    <keeper_server>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+        <coordination_settings>
+            <operation_timeout_ms>5000</operation_timeout_ms>
+            <session_timeout_ms>10000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+            <quorum_reads>false</quorum_reads>
+        </coordination_settings>
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>node_local</hostname>
+                <port>2888</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+
+    <zookeeper>
+        <node index="1">
+            <host>node_local</host>
+            <port>9181</port>
+        </node>
+    </zookeeper>
+</clickhouse>

--- a/tests/integration/test_keeper_availability_zone_quorum_reads/test.py
+++ b/tests/integration/test_keeper_availability_zone_quorum_reads/test.py
@@ -10,7 +10,9 @@ re-triggered the termination on every restart.
 The companion test under `quorum_reads=false` exercises the local read path
 (`processLocalRequests` -> `processImpl<true>`), which already returned
 `ZNONODE` gracefully before the fix. Running both ensures the two read modes
-return the same response for an unconfigured AZ.
+return the same response for an unconfigured AZ. A third case pins the
+configured branch: with `<placement>` set, a `quorum_reads=true` `Get` should
+return the AZ value normally.
 """
 
 import pytest
@@ -30,6 +32,12 @@ node = cluster.add_instance(
 node_local = cluster.add_instance(
     "node_local",
     main_configs=["configs/keeper_config_local_reads.xml"],
+    stay_alive=True,
+)
+
+node_configured = cluster.add_instance(
+    "node_configured",
+    main_configs=["configs/keeper_config_configured.xml"],
     stay_alive=True,
 )
 
@@ -75,3 +83,16 @@ def test_get_availability_zone_returns_znonode_under_local_reads():
     `processLocalRequests` and `processImpl<true>` and should also return
     `ZNONODE`, matching the response of the quorum-read path after the fix."""
     _assert_znonode(node_local, "node_local")
+
+
+def test_get_availability_zone_returns_value_when_configured():
+    """When `<placement>` is configured, a `quorum_reads=true` `Get` must
+    return the configured AZ value. This pins the configured branch of the
+    fix: the container lookup still succeeds under the raft commit path."""
+    keeper_utils.wait_until_connected(cluster, node_configured)
+    assert _keeper_alive(node_configured)
+
+    with KeeperClient.from_cluster(cluster, "node_configured", port=9181) as client:
+        assert client.get("/keeper/availability_zone") == "az-configured"
+
+    assert _keeper_alive(node_configured)

--- a/tests/integration/test_keeper_availability_zone_quorum_reads/test.py
+++ b/tests/integration/test_keeper_availability_zone_quorum_reads/test.py
@@ -6,6 +6,11 @@ is sent to a keeper that was started without `<placement>` and runs with
 Before the fix the keeper called `onStorageInconsistency` (=> `std::terminate`)
 on commit, and the request entry persisted in the raft log, so log replay
 re-triggered the termination on every restart.
+
+The companion test under `quorum_reads=false` exercises the local read path
+(`processLocalRequests` -> `processImpl<true>`), which already returned
+`ZNONODE` gracefully before the fix. Running both ensures the two read modes
+return the same response for an unconfigured AZ.
 """
 
 import pytest
@@ -22,6 +27,12 @@ node = cluster.add_instance(
     stay_alive=True,
 )
 
+node_local = cluster.add_instance(
+    "node_local",
+    main_configs=["configs/keeper_config_local_reads.xml"],
+    stay_alive=True,
+)
+
 
 @pytest.fixture(scope="module", autouse=True)
 def started_cluster():
@@ -32,19 +43,15 @@ def started_cluster():
         cluster.shutdown()
 
 
-def _keeper_alive() -> bool:
-    return keeper_utils.send_4lw_cmd(cluster, node, "ruok") == "imok"
+def _keeper_alive(target) -> bool:
+    return keeper_utils.send_4lw_cmd(cluster, target, "ruok") == "imok"
 
 
-def test_get_availability_zone_returns_znonode_under_quorum_reads():
-    """Keeper without `<placement>` should reply with `ZNONODE` for the AZ
-    path even when `quorum_reads=true` routes the read through the raft
-    commit path. The keeper must remain alive afterwards."""
+def _assert_znonode(target, instance_name):
+    keeper_utils.wait_until_connected(cluster, target)
+    assert _keeper_alive(target)
 
-    keeper_utils.wait_until_connected(cluster, node)
-    assert _keeper_alive()
-
-    with KeeperClient.from_cluster(cluster, "node", port=9181) as client:
+    with KeeperClient.from_cluster(cluster, instance_name, port=9181) as client:
         with pytest.raises(KeeperException) as ex:
             client.get("/keeper/availability_zone")
 
@@ -53,4 +60,18 @@ def test_get_availability_zone_returns_znonode_under_quorum_reads():
     assert "/keeper/availability_zone" in error
 
     # The keeper should still be alive — no SIGABRT, no raft-log poisoning.
-    assert _keeper_alive()
+    assert _keeper_alive(target)
+
+
+def test_get_availability_zone_returns_znonode_under_quorum_reads():
+    """Keeper without `<placement>` should reply with `ZNONODE` for the AZ
+    path even when `quorum_reads=true` routes the read through the raft
+    commit path. The keeper must remain alive afterwards."""
+    _assert_znonode(node, "node")
+
+
+def test_get_availability_zone_returns_znonode_under_local_reads():
+    """Same path, `quorum_reads=false` (the default). The read goes through
+    `processLocalRequests` and `processImpl<true>` and should also return
+    `ZNONODE`, matching the response of the quorum-read path after the fix."""
+    _assert_znonode(node_local, "node_local")

--- a/tests/integration/test_keeper_availability_zone_quorum_reads/test.py
+++ b/tests/integration/test_keeper_availability_zone_quorum_reads/test.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Regression test for keeper termination when `Get /keeper/availability_zone`
+is sent to a keeper that was started without `<placement>` and runs with
+`quorum_reads=true`.
+
+Before the fix the keeper called `onStorageInconsistency` (=> `std::terminate`)
+on commit, and the request entry persisted in the raft log, so log replay
+re-triggered the termination on every restart.
+"""
+
+import pytest
+
+import helpers.keeper_utils as keeper_utils
+from helpers.cluster import ClickHouseCluster
+from helpers.keeper_utils import KeeperClient, KeeperException
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/keeper_config.xml"],
+    stay_alive=True,
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def _keeper_alive() -> bool:
+    return keeper_utils.send_4lw_cmd(cluster, node, "ruok") == "imok"
+
+
+def test_get_availability_zone_returns_znonode_under_quorum_reads():
+    """Keeper without `<placement>` should reply with `ZNONODE` for the AZ
+    path even when `quorum_reads=true` routes the read through the raft
+    commit path. The keeper must remain alive afterwards."""
+
+    keeper_utils.wait_until_connected(cluster, node)
+    assert _keeper_alive()
+
+    with KeeperClient.from_cluster(cluster, "node", port=9181) as client:
+        with pytest.raises(KeeperException) as ex:
+            client.get("/keeper/availability_zone")
+
+    error = str(ex.value)
+    assert "node doesn't exist" in error
+    assert "/keeper/availability_zone" in error
+
+    # The keeper should still be alive — no SIGABRT, no raft-log poisoning.
+    assert _keeper_alive()


### PR DESCRIPTION
**Problem.** When ClickHouse Keeper runs with `<quorum_reads>true</quorum_reads>` and `<placement>` absent, `get /keeper/availability_zone` reaches `processImpl<false>` via the raft commit path, fails the `container.find` lookup, and triggers `onStorageInconsistency` → `std::terminate`. The request is already in the raft log, so every restart replays it and the Keeper terminates again — raft-log poisoning that leaves the Keeper cluster stuck in a restart crash loop.

**Fix.** Drop `keeper_availability_zone_path` from the `preprocess` early-return list in both `Get` and `ListRecursive`. The regular `uncommitted_state.getNode` check now runs and emits a `ZNONODE` `ErrorDelta` when the AZ node is not in the container.

**Why.** The early-return skip was correct only while AZ was served by a dedicated `processImpl` branch and never lived in `storage.container`. Commit 06ff714e2e3 moved AZ into `system_nodes_with_data` behind `if (!keeper_az.empty())` and removed that branch, but the `preprocess` skip was left behind. With `<placement>` absent the node is never registered. The skip prevents `preprocess` from producing the `ZNONODE` `ErrorDelta` that would have short-circuited `commit`, so the request flows on to `container.find` and trips the fail-fast branch. `ListRecursive` was introduced with the same skip line in PR #100998. Removing the skip makes the `quorum_reads=true` response match the `quorum_reads=false` response (`processLocalRequests` → `processImpl<true>`'s graceful `ZNONODE`).

`tests/integration/test_keeper_availability_zone_quorum_reads/` covers unconfigured + configured AZ under `quorum_reads=true`, plus the local-read path.

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix Keeper termination and restart loop when `get /keeper/availability_zone` is sent with `quorum_reads=true` to a Keeper without `<placement>` configured.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.561`
- Backported to: `26.4.3.29`, `26.3.11.27`, `26.2.19.37`, `25.8.24.20`
<!-- ch-version-info:end -->