### PR TITLE
Fix flaky 02504_regexp_dictionary_ua_parser on parallel replicas + s3

### DIFF
--- a/tests/queries/0_stateless/02504_regexp_dictionary_ua_parser.sh
+++ b/tests/queries/0_stateless/02504_regexp_dictionary_ua_parser.sh
@@ -69,9 +69,9 @@ select ua, device,
 concat(tupleElement(browser, 1), ' ', tupleElement(browser, 2), '.', tupleElement(browser, 3)) as browser ,
 concat(tupleElement(os, 1), ' ', tupleElement(os, 2), '.', tupleElement(os, 3), '.', tupleElement(os, 4)) as os
 from (
-     select ua, dictGet('regexp_os', ('os_replacement', 'os_v1_replacement', 'os_v2_replacement', 'os_v3_replacement'), ua) os,
-     dictGet('regexp_browser', ('family_replacement', 'v1_replacement', 'v2_replacement'), ua) as browser,
-     dictGet('regexp_device', 'device_replacement', ua) device from user_agents) order by ua;
+     select ua, dictGet('${CLICKHOUSE_DATABASE}.regexp_os', ('os_replacement', 'os_v1_replacement', 'os_v2_replacement', 'os_v3_replacement'), ua) os,
+     dictGet('${CLICKHOUSE_DATABASE}.regexp_browser', ('family_replacement', 'v1_replacement', 'v2_replacement'), ua) as browser,
+     dictGet('${CLICKHOUSE_DATABASE}.regexp_device', 'device_replacement', ua) device from user_agents) order by ua;
 "
 
 $CLICKHOUSE_CLIENT --query="


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry:
Not required (CI fix).

### Documentation entry for user-facing changes
- [x] Documentation is unnecessary (test-only change).

---

Qualifies the three `dictGet` calls in `02504_regexp_dictionary_ua_parser.sh` with `${CLICKHOUSE_DATABASE}.` so the test passes deterministically under parallel replicas.

**Why it flakes:** `dictGet`'s first argument is kept as a string literal end-to-end. On parallel-replica workers the `parallel_replicas` cluster has no `<default_database>` (and `ClientInfo` doesn't carry one), so the worker's `current_database` is empty. When `parallel_replicas_local_plan=0` (e.g. randomized) routes the `getReturnTypeImpl` typing call to a worker, `ExternalDictionariesLoader::resolveDictionaryName` can't find `regexp_os` in the test database and throws `Dictionary (regexp_os) not found`. Qualifying the literal with the database name skips the `current_database` fallback in the resolver.

Smallest-blast-radius fix; the underlying engine issue (workers should inherit `current_database`, or dict literals should be UUID-rewritten before dispatch) is left for a separate PR. Pairs with #104627 which already took this test off the blacklist.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.551`
<!-- ch-version-info:end -->