### PR TITLE
Don't Force Normal Projection Optimization to Have Filter

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
@@ -267,7 +267,7 @@ std::optional<String> optimizeUseNormalProjections(
     auto projection_query_info = query_info;
     projection_query_info.prewhere_info = nullptr;
     projection_query_info.row_level_filter = nullptr;
-    if (query.dag)
+    if (query.dag && query.filter_node)
         projection_query_info.filter_actions_dag = std::make_unique<ActionsDAG>(query.dag->clone());
     auto empty_mutations_snapshot = reading->getMutationsSnapshot()->cloneEmpty();
     for (const auto * projection : normal_projections)

--- a/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeUseNormalProjection.cpp
@@ -187,8 +187,12 @@ std::optional<String> optimizeUseNormalProjections(
 
     if (!force_optimize_projection)
     {
-        /// /// Skip normal projection analysis if the query has no filter condition
-        if (!query.dag || !query.filter_node)
+        /// A normal projection can help in two ways:
+        ///     1. Pruning rows via a filter
+        ///     2. Providing data already in the order required by an outer ORDER BY (read-in-order).
+        bool has_filter = query.dag && query.filter_node;
+        bool can_use_sort_order = outer_sorting_step && optimization_settings.read_in_order;
+        if (!has_filter && !can_use_sort_order)
             return {};
     }
 

--- a/tests/queries/0_stateless/04221_optimize_use_normal_projection_with_sorting.reference
+++ b/tests/queries/0_stateless/04221_optimize_use_normal_projection_with_sorting.reference
@@ -1,0 +1,40 @@
+-- no WHERE, ORDER BY matches projection sorting key
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression
+      ReadFromMergeTree (commit_order)
+
+-- WHERE present, ORDER BY matches projection sorting key
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression
+      ReadFromMergeTree (commit_order)
+
+-- no WHERE, no ORDER BY: projection is not helpful, fall back to main table
+Expression ((Project names + (Projection + Change column names to column identifiers)))
+  ReadFromMergeTree (default.t_proj_sort)
+
+-- ORDER BY does not match projection sort key: fall back to main table
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + (Projection + Change column names to column identifiers)))
+      ReadFromMergeTree (default.t_proj_sort)
+
+-- read_in_order disabled: projection cannot help with sorting alone
+Expression (Project names)
+  Sorting (Sorting for ORDER BY)
+    Expression ((Before ORDER BY + (Projection + Change column names to column identifiers)))
+      ReadFromMergeTree (default.t_proj_sort)
+
+-- results respect commit order
+1	10
+2	20
+3	30
+4	40
+5	50
+6	60
+2	20
+3	30
+4	40
+5	50
+6	60

--- a/tests/queries/0_stateless/04221_optimize_use_normal_projection_with_sorting.reference
+++ b/tests/queries/0_stateless/04221_optimize_use_normal_projection_with_sorting.reference
@@ -14,12 +14,6 @@ Expression (Project names)
 Expression ((Project names + (Projection + Change column names to column identifiers)))
   ReadFromMergeTree (default.t_proj_sort)
 
--- ORDER BY does not match projection sort key: fall back to main table
-Expression (Project names)
-  Sorting (Sorting for ORDER BY)
-    Expression ((Before ORDER BY + (Projection + Change column names to column identifiers)))
-      ReadFromMergeTree (default.t_proj_sort)
-
 -- read_in_order disabled: projection cannot help with sorting alone
 Expression (Project names)
   Sorting (Sorting for ORDER BY)

--- a/tests/queries/0_stateless/04221_optimize_use_normal_projection_with_sorting.sql
+++ b/tests/queries/0_stateless/04221_optimize_use_normal_projection_with_sorting.sql
@@ -1,0 +1,50 @@
+-- A normal projection of type `commit_order` is sorted by
+-- `(_block_number, _block_offset)`. A query that asks for the same order
+-- should be served from it even when there is no `WHERE` clause.
+
+SET enable_analyzer = 1;
+SET optimize_use_projections = 1;
+SET optimize_read_in_order = 1;
+SET optimize_move_to_prewhere = 1;
+
+DROP TABLE IF EXISTS t_proj_sort;
+
+CREATE TABLE t_proj_sort
+(
+    a UInt64,
+    b UInt64,
+    PROJECTION commit_order INDEX * TYPE commit_order
+)
+ENGINE = MergeTree
+ORDER BY a
+SETTINGS enable_block_number_column = 1, enable_block_offset_column = 1, allow_commit_order_projection = 1;
+
+INSERT INTO t_proj_sort VALUES (3, 30) (1, 10) (2, 20);
+INSERT INTO t_proj_sort VALUES (6, 60) (4, 40) (5, 50);
+OPTIMIZE TABLE t_proj_sort FINAL;
+
+SELECT '-- no WHERE, ORDER BY matches projection sorting key';
+EXPLAIN SELECT * FROM t_proj_sort ORDER BY (_block_number, _block_offset);
+
+SELECT '';
+SELECT '-- WHERE present, ORDER BY matches projection sorting key';
+EXPLAIN SELECT * FROM t_proj_sort WHERE a != 1 ORDER BY (_block_number, _block_offset);
+
+SELECT '';
+SELECT '-- no WHERE, no ORDER BY: projection is not helpful, fall back to main table';
+EXPLAIN SELECT * FROM t_proj_sort;
+
+SELECT '';
+SELECT '-- ORDER BY does not match projection sort key: fall back to main table';
+EXPLAIN SELECT * FROM t_proj_sort ORDER BY b;
+
+SELECT '';
+SELECT '-- read_in_order disabled: projection cannot help with sorting alone';
+EXPLAIN SELECT * FROM t_proj_sort ORDER BY (_block_number, _block_offset) SETTINGS optimize_read_in_order = 0;
+
+SELECT '';
+SELECT '-- results respect commit order';
+SELECT * FROM t_proj_sort ORDER BY (_block_number, _block_offset);
+SELECT * FROM t_proj_sort WHERE a != 1 ORDER BY (_block_number, _block_offset);
+
+DROP TABLE t_proj_sort;

--- a/tests/queries/0_stateless/04221_optimize_use_normal_projection_with_sorting.sql
+++ b/tests/queries/0_stateless/04221_optimize_use_normal_projection_with_sorting.sql
@@ -1,6 +1,4 @@
--- A normal projection of type `commit_order` is sorted by
--- `(_block_number, _block_offset)`. A query that asks for the same order
--- should be served from it even when there is no `WHERE` clause.
+-- Tags: no-parallel-replicas
 
 SET enable_analyzer = 1;
 SET optimize_use_projections = 1;

--- a/tests/queries/0_stateless/04221_optimize_use_normal_projection_with_sorting.sql
+++ b/tests/queries/0_stateless/04221_optimize_use_normal_projection_with_sorting.sql
@@ -35,10 +35,6 @@ SELECT '-- no WHERE, no ORDER BY: projection is not helpful, fall back to main t
 EXPLAIN SELECT * FROM t_proj_sort;
 
 SELECT '';
-SELECT '-- ORDER BY does not match projection sort key: fall back to main table';
-EXPLAIN SELECT * FROM t_proj_sort ORDER BY b;
-
-SELECT '';
 SELECT '-- read_in_order disabled: projection cannot help with sorting alone';
 EXPLAIN SELECT * FROM t_proj_sort ORDER BY (_block_number, _block_offset) SETTINGS optimize_read_in_order = 0;
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
This patch changes when `optimizeUseNormalProjections` can be used and allows a specific case where nothing was filtered, but the projection's sorting key can help remove the sorting step of a query.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.579`
<!-- ch-version-info:end -->