### PR TITLE
S3 Poco client: convert iostream errors to retriable network connection exceptions

### DIFF
--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -766,6 +766,11 @@ void PocoHTTPClient::makeRequestInternalImpl(
         account_error();
         throw;
     }
+    catch (const std::ios_base::failure & e) // convert iostream errors to retriable network connection exceptions
+    {
+        LOG_DEBUG(log, "Failed to make request to: {}: will be retried, std::ios_base::failure: {}", uri, getCurrentExceptionMessage(/* with_stacktrace */ true));
+        exception_handler(Aws::Client::CoreErrors::NETWORK_CONNECTION);
+    }
     catch (...) // DB::Exception and all other exceptions
     {
         LOG_DEBUG(log, "Failed to make request to: {}: Unknown exception: {}", uri, getCurrentExceptionMessage(/* with_stacktrace */ true));

--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -766,7 +766,7 @@ void PocoHTTPClient::makeRequestInternalImpl(
         account_error();
         throw;
     }
-    catch (const std::ios_base::failure & e) // convert iostream errors to retriable network connection exceptions
+    catch (const std::ios_base::failure &) // convert iostream errors to retriable network connection exceptions
     {
         LOG_DEBUG(log, "Failed to make request to: {}: will be retried, std::ios_base::failure: {}", uri, getCurrentExceptionMessage(/* with_stacktrace */ true));
         exception_handler(Aws::Client::CoreErrors::NETWORK_CONNECTION);


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Treat iostream exceptions in PocoHTTPClient as retriable network connection exceptions.


context: https://github.com/ClickHouse/support-escalation/issues/7554
