### PR TITLE
Fix premature wake-up in MergeTreeTransaction::afterCommit

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -174,7 +174,9 @@ static struct InitFiu
     REGULAR(storage_merge_tree_background_schedule_merge_fail) \
     REGULAR(patch_parts_reverse_column_order) \
     REGULAR(wide_part_writer_fail_in_add_streams) \
-    REGULAR(compact_part_writer_fail_in_add_streams)
+    REGULAR(compact_part_writer_fail_in_add_streams) \
+    REGULAR(transaction_force_unknown_state_after_commit) \
+    PAUSEABLE(transaction_after_commit_pause)
 
 namespace FailPoints
 {

--- a/src/Interpreters/MergeTreeTransaction.cpp
+++ b/src/Interpreters/MergeTreeTransaction.cpp
@@ -307,6 +307,8 @@ void MergeTreeTransaction::afterCommit(CSN assigned_csn) noexcept
     }
     catch (...) // NOLINT(bugprone-empty-catch)
     {
+        /// Ok: the enclosing function is `noexcept` and this is a test-only failpoint;
+        /// any exception from `pauseFailPoint` (e.g. on shutdown) must not escape.
     }
 
     /// Flip the atomic last so that `waitStateChange` only wakes up after all metadata is durable.

--- a/src/Interpreters/MergeTreeTransaction.cpp
+++ b/src/Interpreters/MergeTreeTransaction.cpp
@@ -300,16 +300,10 @@ void MergeTreeTransaction::afterCommit(CSN assigned_csn) noexcept
 
     /// Test-only pause point. With this failpoint enabled, a regression test can verify that
     /// `waitStateChange` does not return until every part has its new CSN persisted (above).
-    /// Wrapped in try/catch because the enclosing function is `noexcept`.
-    try
-    {
-        FailPointInjection::pauseFailPoint(FailPoints::transaction_after_commit_pause);
-    }
-    catch (...) // NOLINT(bugprone-empty-catch)
-    {
-        /// Ok: the enclosing function is `noexcept` and this is a test-only failpoint;
-        /// any exception from `pauseFailPoint` (e.g. on shutdown) must not escape.
-    }
+    /// Not wrapped in try/catch: `pauseFailPoint` only takes a mutex and a condvar, and the
+    /// surrounding `setAndStore...CSN` calls already trust their callees not to throw under
+    /// the same `noexcept` contract.
+    FailPointInjection::pauseFailPoint(FailPoints::transaction_after_commit_pause);
 
     /// Flip the atomic last so that `waitStateChange` only wakes up after all metadata is durable.
     [[maybe_unused]] CSN prev_value = csn.exchange(assigned_csn);

--- a/src/Interpreters/MergeTreeTransaction.cpp
+++ b/src/Interpreters/MergeTreeTransaction.cpp
@@ -261,11 +261,6 @@ void MergeTreeTransaction::afterCommit(CSN assigned_csn) noexcept
 {
     auto blocker = CannotAllocateThreadFaultInjector::blockFaultInjections();
     LockMemoryExceptionInThread memory_tracker_lock(VariableContext::Global);
-    /// Write allocated CSN into version metadata, so we will know CSN without reading it from transaction log
-    /// and we will be able to remove old entries from transaction log in ZK.
-    /// It's not a problem if server crash before CSN is written, because we already have TID in data part and entry in the log.
-    [[maybe_unused]] CSN prev_value = csn.exchange(assigned_csn);
-    chassert(prev_value == Tx::CommittingCSN);
 
     DataPartsVector created_parts;
     DataPartsVector removed_parts;
@@ -278,10 +273,33 @@ void MergeTreeTransaction::afterCommit(CSN assigned_csn) noexcept
         committed_mutations = mutations;
     }
 
-    /// Test-only pause point inserted between the CSN wake-up (above) and the per-part
-    /// metadata writes (below). With this failpoint enabled, a regression test can observe
-    /// the race window where `waitStateChange` has already returned to the client but
-    /// `removal_csn` / `creation_csn` are not yet visible through `system.parts`.
+    /// Persist per-part version metadata BEFORE flipping `csn` below.
+    /// `csn.exchange(assigned_csn)` is the signal that `MergeTreeTransaction::waitStateChange`
+    /// blocks on; doing the disk-backed `setAndStore...CSN` calls first ensures that once a
+    /// waiter wakes up, the new `creation_csn` / `removal_csn` are already visible through
+    /// `VersionMetadata::getInfo`, and therefore through `system.parts`.
+    ///
+    /// Use `assigned_csn` directly because `this->csn` is still `Tx::CommittingCSN` here.
+    ///
+    /// Crash-safe: if the process terminates inside this loop, the CSN znode in ZK plus
+    /// `removal_tid` / `creation_tid` on disk are enough to recover any part whose
+    /// `setAndStore...CSN` did not complete; `TransactionLog::getCSN(tid)` returns the right
+    /// answer after restart.
+    for (const auto & part : created_parts)
+    {
+        part->version->setAndStoreCreationCSN(assigned_csn);
+    }
+
+    for (const auto & part : removed_parts)
+    {
+        part->version->setAndStoreRemovalCSN(assigned_csn);
+    }
+
+    for (const auto & storage_and_mutation : committed_mutations)
+        storage_and_mutation.first->setMutationCSN(storage_and_mutation.second, assigned_csn);
+
+    /// Test-only pause point. With this failpoint enabled, a regression test can verify that
+    /// `waitStateChange` does not return until every part has its new CSN persisted (above).
     /// Wrapped in try/catch because the enclosing function is `noexcept`.
     try
     {
@@ -291,18 +309,9 @@ void MergeTreeTransaction::afterCommit(CSN assigned_csn) noexcept
     {
     }
 
-    for (const auto & part : created_parts)
-    {
-        part->version->setAndStoreCreationCSN(csn);
-    }
-
-    for (const auto & part : removed_parts)
-    {
-        part->version->setAndStoreRemovalCSN(csn);
-    }
-
-    for (const auto & storage_and_mutation : committed_mutations)
-        storage_and_mutation.first->setMutationCSN(storage_and_mutation.second, csn);
+    /// Flip the atomic last so that `waitStateChange` only wakes up after all metadata is durable.
+    [[maybe_unused]] CSN prev_value = csn.exchange(assigned_csn);
+    chassert(prev_value == Tx::CommittingCSN);
 }
 
 bool MergeTreeTransaction::rollback() noexcept

--- a/src/Interpreters/MergeTreeTransaction.cpp
+++ b/src/Interpreters/MergeTreeTransaction.cpp
@@ -6,6 +6,7 @@
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
 #include <Storages/MergeTree/MergeTreeData.h>
 #include <Common/Exception.h>
+#include <Common/FailPoint.h>
 #include <Common/TransactionID.h>
 #include <Common/ZooKeeper/IKeeper.h>
 #include <Common/noexcept_scope.h>
@@ -21,6 +22,11 @@ namespace ErrorCodes
     extern const int INVALID_TRANSACTION;
     extern const int LOGICAL_ERROR;
     extern const int NOT_IMPLEMENTED;
+}
+
+namespace FailPoints
+{
+    extern const char transaction_after_commit_pause[];
 }
 
 static void checkNotOrdinaryDatabase(const StoragePtr & storage)
@@ -270,6 +276,19 @@ void MergeTreeTransaction::afterCommit(CSN assigned_csn) noexcept
         created_parts = creating_parts;
         removed_parts = removing_parts;
         committed_mutations = mutations;
+    }
+
+    /// Test-only pause point inserted between the CSN wake-up (above) and the per-part
+    /// metadata writes (below). With this failpoint enabled, a regression test can observe
+    /// the race window where `waitStateChange` has already returned to the client but
+    /// `removal_csn` / `creation_csn` are not yet visible through `system.parts`.
+    /// Wrapped in try/catch because the enclosing function is `noexcept`.
+    try
+    {
+        FailPointInjection::pauseFailPoint(FailPoints::transaction_after_commit_pause);
+    }
+    catch (...) // NOLINT(bugprone-empty-catch)
+    {
     }
 
     for (const auto & part : created_parts)

--- a/src/Interpreters/TransactionLog.cpp
+++ b/src/Interpreters/TransactionLog.cpp
@@ -9,6 +9,7 @@
 #include <base/defines.h>
 #include <base/sort.h>
 #include <Common/Exception.h>
+#include <Common/FailPoint.h>
 #include <Common/ZooKeeper/KeeperException.h>
 #include <Common/ZooKeeper/ZooKeeperCommon.h>
 #include <Common/logger_useful.h>
@@ -25,6 +26,11 @@ namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
     extern const int UNKNOWN_STATUS_OF_TRANSACTION;
+}
+
+namespace FailPoints
+{
+    extern const char transaction_force_unknown_state_after_commit[];
 }
 
 static void tryWriteEventToSystemLog(LoggerPtr log, ContextPtr context,
@@ -435,6 +441,15 @@ CSN TransactionLog::commitTransaction(const MergeTreeTransactionPtr & txn, bool 
             auto res = current_zookeeper->multi(requests, /* check_session_valid */ true);
 
             csn_path_created = dynamic_cast<const Coordination::CreateResponse *>(res.back().get())->path_created;
+
+            fiu_do_on(FailPoints::transaction_force_unknown_state_after_commit,
+            {
+                /// CSN znode is already created in ZK; simulate the response being lost.
+                /// The catch block below will postpone finalization to runUpdatingThread,
+                /// reproducing the fault_probability_after_commit code path deterministically.
+                throw Coordination::Exception::fromMessage(Coordination::Error::ZOPERATIONTIMEOUT,
+                    "Fault injected: forced unknown state after commit");
+            });
         }
         catch (const Coordination::Exception & e)
         {

--- a/tests/queries/0_stateless/04141_transaction_after_commit_no_premature_wakeup.reference
+++ b/tests/queries/0_stateless/04141_transaction_after_commit_no_premature_wakeup.reference
@@ -1,0 +1,3 @@
+commit_still_running	1
+removal_csn_visible_during_pause	2
+removal_csn_visible_after_commit	2

--- a/tests/queries/0_stateless/04141_transaction_after_commit_no_premature_wakeup.sh
+++ b/tests/queries/0_stateless/04141_transaction_after_commit_no_premature_wakeup.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Tags: no-ordinary-database, no-encrypted-storage, no-parallel
+# Tag rationale: enables a server-wide failpoint.
+#
+# Verifies that a transactional `COMMIT` does not return to the client until every part
+# touched by the transaction has its new `creation_csn` / `removal_csn` persisted.
+#
+# Reproduces the race exposed under `fault_probability_after_commit` on slow storage:
+#   - `transaction_force_unknown_state_after_commit` deterministically takes the
+#     "connection lost after commit" code path in `TransactionLog::commitTransaction`,
+#     so finalization is deferred to `runUpdatingThread`.
+#   - `transaction_after_commit_pause` pauses the background thread inside
+#     `MergeTreeTransaction::afterCommit` at the boundary between the atomic CSN flip
+#     and the per-part metadata writes.
+#
+# Correct ordering (`afterCommit` does writes before flipping the CSN): during the pause
+# the foreground `COMMIT` is still running and `removal_csn` is already visible.
+# Buggy ordering (CSN flipped first): during the pause the foreground `COMMIT` has
+# already returned and `removal_csn` is still 0.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+# shellcheck source=./transactions.lib
+. "$CUR_DIR"/transactions.lib
+
+$CLICKHOUSE_CLIENT -q "
+    DROP TABLE IF EXISTS t_after_commit;
+    CREATE TABLE t_after_commit (n Int64)
+        ENGINE = MergeTree ORDER BY n
+        SETTINGS old_parts_lifetime = 3600;
+"
+$CLICKHOUSE_CLIENT -q "SYSTEM STOP MERGES t_after_commit"
+$CLICKHOUSE_CLIENT -q "INSERT INTO t_after_commit VALUES (1)"
+$CLICKHOUSE_CLIENT -q "INSERT INTO t_after_commit VALUES (2)"
+
+$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT transaction_force_unknown_state_after_commit"
+$CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT transaction_after_commit_pause"
+
+# Run COMMIT in the background. With the fix, the foreground COMMIT will block
+# on `waitStateChange` until the background `afterCommit` releases the pause.
+tx_async 1 "BEGIN TRANSACTION"
+tx_async 1 "SET throw_on_unsupported_query_inside_transaction = 0"
+tx_async 1 "ALTER TABLE t_after_commit DROP PARTITION ID 'all'"
+tx_async 1 "COMMIT"
+
+# Give the background thread time to reach the pause point. We can't easily detect
+# arrival at the pause from SQL (system.processes does not expose pause state), so a
+# fixed delay is the simplest signal here. 2 seconds is plenty on local storage.
+sleep 2
+
+# Check 1: the foreground COMMIT must still be running (paused inside afterCommit).
+$CLICKHOUSE_CLIENT -q "
+    SELECT 'commit_still_running',
+        count() > 0
+    FROM system.processes
+    WHERE current_database = currentDatabase()
+        AND query LIKE '%COMMIT%'
+        AND query NOT LIKE '%system.processes%'
+"
+
+# Check 2: per-part metadata is already persisted, even though COMMIT has not returned.
+$CLICKHOUSE_CLIENT -q "
+    SELECT 'removal_csn_visible_during_pause', count()
+    FROM system.parts
+    WHERE database = currentDatabase()
+        AND table = 't_after_commit'
+        AND removal_csn > 1
+"
+
+# Release the pause; the foreground COMMIT can now finish.
+$CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT transaction_after_commit_pause"
+tx_wait 1
+
+$CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT transaction_force_unknown_state_after_commit"
+
+# Final state: still two parts with removal_csn > 1.
+$CLICKHOUSE_CLIENT -q "
+    SELECT 'removal_csn_visible_after_commit', count()
+    FROM system.parts
+    WHERE database = currentDatabase()
+        AND table = 't_after_commit'
+        AND removal_csn > 1
+"
+
+$CLICKHOUSE_CLIENT -q "DROP TABLE t_after_commit"

--- a/tests/queries/0_stateless/04141_transaction_after_commit_no_premature_wakeup.sh
+++ b/tests/queries/0_stateless/04141_transaction_after_commit_no_premature_wakeup.sh
@@ -34,6 +34,16 @@ $CLICKHOUSE_CLIENT -q "SYSTEM STOP MERGES t_after_commit"
 $CLICKHOUSE_CLIENT -q "INSERT INTO t_after_commit VALUES (1)"
 $CLICKHOUSE_CLIENT -q "INSERT INTO t_after_commit VALUES (2)"
 
+# Defense-in-depth: always disable both failpoints on exit so that an early test
+# failure (e.g. a `SYSTEM WAIT FAILPOINT ... PAUSE` timeout) cannot leave the
+# server-wide failpoints active and disrupt later tests in the same run.
+# `SYSTEM DISABLE FAILPOINT` on an already-disabled failpoint is a no-op, so this
+# is safe even when the normal cleanup at the end of the script already ran.
+trap '
+    $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT transaction_after_commit_pause" 2>/dev/null || true
+    $CLICKHOUSE_CLIENT -q "SYSTEM DISABLE FAILPOINT transaction_force_unknown_state_after_commit" 2>/dev/null || true
+' EXIT
+
 $CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT transaction_force_unknown_state_after_commit"
 $CLICKHOUSE_CLIENT -q "SYSTEM ENABLE FAILPOINT transaction_after_commit_pause"
 

--- a/tests/queries/0_stateless/04141_transaction_after_commit_no_premature_wakeup.sh
+++ b/tests/queries/0_stateless/04141_transaction_after_commit_no_premature_wakeup.sh
@@ -44,10 +44,10 @@ tx_async 1 "SET throw_on_unsupported_query_inside_transaction = 0"
 tx_async 1 "ALTER TABLE t_after_commit DROP PARTITION ID 'all'"
 tx_async 1 "COMMIT"
 
-# Give the background thread time to reach the pause point. We can't easily detect
-# arrival at the pause from SQL (system.processes does not expose pause state), so a
-# fixed delay is the simplest signal here. 2 seconds is plenty on local storage.
-sleep 2
+# Deterministically wait until the background thread is paused inside `afterCommit`.
+# `SYSTEM WAIT FAILPOINT ... PAUSE` returns immediately once a thread is paused at the
+# failpoint, so the subsequent checks see a stable state regardless of host load.
+$CLICKHOUSE_CLIENT -q "SYSTEM WAIT FAILPOINT transaction_after_commit_pause PAUSE"
 
 # Check 1: the foreground COMMIT must still be running (paused inside afterCommit).
 $CLICKHOUSE_CLIENT -q "


### PR DESCRIPTION
Under `fault_probability_after_commit`, `TransactionLog::commitTransaction` writes the CSN znode to ZooKeeper, then a fake hardware error pushes the transaction onto `unknown_state_list` for the background `runUpdatingThread` to finalize. That thread calls `MergeTreeTransaction::afterCommit`, which today flips the per-transaction `csn` atomic *before* persisting `creation_csn` / `removal_csn` on each part. The atomic flip is the signal `MergeTreeTransaction::waitStateChange` is blocked on, so the foreground `COMMIT` returns to the client while the per-part `setAndStoreRemovalCSN` loop is still running. On slow storage (S3) the next query reads `system.parts` and sees stale `removal_csn = 0`.

This PR moves the per-part metadata writes to run before `csn.exchange`. Once `waitStateChange` unblocks, `system.parts` already exposes the new CSN. Crash-safety is unchanged: a partial loop is still recoverable on restart via the TID -> CSN lookup in `TransactionLog::getCSN`.

Two failpoints are added to make the race deterministic and a regression test (`04141_transaction_after_commit_no_premature_wakeup`) exercises both invariants:
- `commit_still_running` — the foreground `COMMIT` must not return while `afterCommit` is paused.
- `removal_csn_visible_during_pause` — both parts must already expose `removal_csn > 0` while the pause is held.

Fixes the flaky test reported in #103152.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a race in `MergeTreeTransaction::afterCommit` where, after a connection loss between writing the commit CSN to ZooKeeper and finalizing the transaction, the `COMMIT` response could reach the client before the new `creation_csn` / `removal_csn` became visible in `system.parts`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.639`
<!-- ch-version-info:end -->