### PR TITLE
Fix incorrect code around LOG_TEST

### DIFF
--- a/base/poco/Foundation/include/Poco/ConsoleChannel.h
+++ b/base/poco/Foundation/include/Poco/ConsoleChannel.h
@@ -19,9 +19,11 @@
 
 
 #include <ostream>
-#include "Poco/Channel.h"
-#include "Poco/Foundation.h"
-#include "Poco/Mutex.h"
+
+#include <Poco/Channel.h>
+#include <Poco/Foundation.h>
+#include <Poco/Mutex.h>
+#include <Poco/Message.h>
 
 
 namespace Poco
@@ -176,7 +178,7 @@ protected:
 private:
     std::ostream & _str;
     bool _enableColors;
-    Color _colors[9];
+    Color _colors[Poco::Message::PRIO_END];
     static FastMutex _mutex;
     static const std::string CSI;
 };

--- a/base/poco/Foundation/include/Poco/Message.h
+++ b/base/poco/Foundation/include/Poco/Message.h
@@ -54,7 +54,8 @@ public:
         PRIO_INFORMATION, /// An informational message, usually denoting the successful completion of an operation.
         PRIO_DEBUG, /// A debugging message.
         PRIO_TRACE, /// A tracing message. This is the lowest priority useful for production.
-        PRIO_TEST /// A message for test environment.
+        PRIO_TEST, /// A message for test environment.
+        PRIO_END
     };
 
     Message();

--- a/src/Common/ErrorHandlers.h
+++ b/src/Common/ErrorHandlers.h
@@ -47,6 +47,8 @@ public:
                 LOG_TRACE(trace_log, fmt::runtime(msg)); break;
             case Poco::Message::PRIO_TEST:
                 LOG_TEST(trace_log, fmt::runtime(msg)); break;
+            case Poco::Message::PRIO_END:
+                break;
         }
     }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Resubmit #102118.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.590`
<!-- ch-version-info:end -->