### PR TITLE
Fix a few defects in SettingsConstraints

### DIFF
--- a/src/Access/SettingsConstraints.cpp
+++ b/src/Access/SettingsConstraints.cpp
@@ -403,7 +403,12 @@ bool SettingsConstraints::Checker::check(SettingChange & change,
         return false;
     }
 
-    if (!min_value.isNull() && less_or_cannot_compare(new_value, min_value))
+    /// Track the effective value through clamping so that the disallowed-values loop below
+    /// compares against the post-clamp value. Otherwise an overlap between a clamp target and
+    /// a disallowed entry (e.g. min == disallowed) would let the clamped value through.
+    Field effective_value = new_value;
+
+    if (!min_value.isNull() && less_or_cannot_compare(effective_value, min_value))
     {
         if (reaction == THROW_ON_VIOLATION)
         {
@@ -411,9 +416,10 @@ bool SettingsConstraints::Checker::check(SettingChange & change,
                 setting_name, applyVisitor(FieldVisitorToString(), min_value));
         }
         change.value = min_value;
+        effective_value = min_value;
     }
 
-    if (!max_value.isNull() && less_or_cannot_compare(max_value, new_value))
+    if (!max_value.isNull() && less_or_cannot_compare(max_value, effective_value))
     {
         if (reaction == THROW_ON_VIOLATION)
         {
@@ -421,11 +427,12 @@ bool SettingsConstraints::Checker::check(SettingChange & change,
                 setting_name, applyVisitor(FieldVisitorToString(), max_value));
         }
         change.value = max_value;
+        effective_value = max_value;
     }
 
     for (const auto & value : disallowed_values)
     {
-        bool equals = equals_or_cannot_compare(value, new_value);
+        bool equals = equals_or_cannot_compare(value, effective_value);
         if (equals)
         {
             if (reaction == THROW_ON_VIOLATION)

--- a/src/Access/SettingsConstraints.cpp
+++ b/src/Access/SettingsConstraints.cpp
@@ -143,7 +143,7 @@ void SettingsConstraints::merge(const SettingsConstraints & other)
         }
     }
 
-    for (const auto & [other_alias, other_resolved_name] : settings_alias_cache)
+    for (const auto & [other_alias, other_resolved_name] : other.settings_alias_cache)
         settings_alias_cache.try_emplace(other_alias, other_resolved_name);
 }
 

--- a/src/Access/SettingsConstraints.cpp
+++ b/src/Access/SettingsConstraints.cpp
@@ -326,10 +326,15 @@ bool SettingsConstraints::checkImpl(const Settings & current_settings,
 
 bool SettingsConstraints::checkImpl(const MergeTreeSettings & current_settings, SettingChange & change, ReactionOnViolation reaction) const
 {
+    /// Resolve aliases upfront, mirroring the Settings overload above. Otherwise a user can
+    /// bypass a constraint declared on the canonical setting name by writing to an alias,
+    /// because the constraint lookup is a plain hashmap lookup on the (still un-resolved) name.
+    std::string_view setting_name = MergeTreeSettings::resolveName(change.name);
+
     Field new_value = getNewValueToCheck(current_settings, change, /*ignore_unchanged_settings=*/false, reaction == THROW_ON_VIOLATION);
     if (new_value.isNull())
         return false;
-    return getMergeTreeChecker(change.name).check(change, new_value, reaction, SettingSource::QUERY);
+    return getMergeTreeChecker(setting_name).check(change, new_value, reaction, SettingSource::QUERY);
 }
 
 bool SettingsConstraints::Checker::check(SettingChange & change,

--- a/src/Access/SettingsConstraints.cpp
+++ b/src/Access/SettingsConstraints.cpp
@@ -427,8 +427,15 @@ bool SettingsConstraints::Checker::check(SettingChange & change,
     {
         bool equals = equals_or_cannot_compare(value, new_value);
         if (equals)
-            throw Exception(ErrorCodes::SETTING_CONSTRAINT_VIOLATION, "Setting {} shouldn't be {}",
-                setting_name, applyVisitor(FieldVisitorToString(), value));
+        {
+            if (reaction == THROW_ON_VIOLATION)
+                throw Exception(ErrorCodes::SETTING_CONSTRAINT_VIOLATION, "Setting {} shouldn't be {}",
+                    setting_name, applyVisitor(FieldVisitorToString(), value));
+            /// On clamp paths there is no sensible value to clamp to — disallowed entries are a
+            /// deny-list, not a range. Drop the change and let the caller proceed with the
+            /// existing value rather than failing the query.
+            return false;
+        }
     }
 
     if (!getSettingSourceRestrictions(setting_name).isSourceAllowed(source))

--- a/src/Access/SettingsConstraints.h
+++ b/src/Access/SettingsConstraints.h
@@ -71,9 +71,9 @@ public:
     void clear();
     bool empty() const { return constraints.empty(); }
 
-    void set(const String & full_name, const Field & min_value, const Field & max_value, const std::vector<Field> & allowed_values, SettingConstraintWritability writability);
-    void get(const Settings & current_settings, std::string_view short_name, Field & min_value, Field & max_value, std::vector<Field> & allowed_values, SettingConstraintWritability & writability) const;
-    void get(const MergeTreeSettings & current_settings, std::string_view short_name, Field & min_value, Field & max_value, std::vector<Field> & allowed_values, SettingConstraintWritability & writability) const;
+    void set(const String & full_name, const Field & min_value, const Field & max_value, const std::vector<Field> & disallowed_values, SettingConstraintWritability writability);
+    void get(const Settings & current_settings, std::string_view short_name, Field & min_value, Field & max_value, std::vector<Field> & disallowed_values, SettingConstraintWritability & writability) const;
+    void get(const MergeTreeSettings & current_settings, std::string_view short_name, Field & min_value, Field & max_value, std::vector<Field> & disallowed_values, SettingConstraintWritability & writability) const;
 
     void merge(const SettingsConstraints & other);
 

--- a/tests/integration/test_settings_constraints/configs/no_default_constraints.xml
+++ b/tests/integration/test_settings_constraints/configs/no_default_constraints.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <!-- Make the system-wide default profile an empty one, so SQL-created users
+         without an explicit profile do not pick up the constraints declared on
+         the <default> profile in users.xml. The default user is unaffected
+         because it still references <profile>default</profile> directly. -->
+    <default_profile>empty_profile</default_profile>
+</clickhouse>

--- a/tests/integration/test_settings_constraints/configs/users.xml
+++ b/tests/integration/test_settings_constraints/configs/users.xml
@@ -35,6 +35,17 @@
         <no_dll_profile>
             <allow_ddl>0</allow_ddl>
         </no_dll_profile>
+
+        <!-- Same constraint as <merge_tree_enable_block_number_column> above, but declared
+             via the alias name. Used to exercise the reverse direction (constraint on alias,
+             query via canonical) of MergeTreeSettings alias resolution. -->
+        <alias_constraint_profile>
+            <constraints>
+                <merge_tree_allow_experimental_block_number_column>
+                    <const/>
+                </merge_tree_allow_experimental_block_number_column>
+            </constraints>
+        </alias_constraint_profile>
     </profiles>
 
     <users>
@@ -62,6 +73,14 @@
             <profile>no_dll_profile</profile>
             <quota>default</quota>
         </no_dll_user>
+        <alias_constraint_user>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>alias_constraint_profile</profile>
+            <quota>default</quota>
+        </alias_constraint_user>
     </users>
 
     <quotas>

--- a/tests/integration/test_settings_constraints/configs/users.xml
+++ b/tests/integration/test_settings_constraints/configs/users.xml
@@ -16,6 +16,9 @@
                     <max>200000</max>
                     <disallowed>5000</disallowed>
                 </merge_tree_max_parts_in_total>
+                <merge_tree_enable_block_number_column>
+                    <const/>
+                </merge_tree_enable_block_number_column>
                <force_index_by_date>
                    <readonly/>
                </force_index_by_date>

--- a/tests/integration/test_settings_constraints/configs/users.xml
+++ b/tests/integration/test_settings_constraints/configs/users.xml
@@ -53,6 +53,17 @@
              user only via the granted role. -->
         <empty_profile>
         </empty_profile>
+
+        <!-- A clamp target (min) that also appears in disallowed_values. Used to verify that the
+             disallowed check sees the post-clamp value rather than the pre-clamp value. -->
+        <overlap_constraint_profile>
+            <constraints>
+                <max_memory_usage>
+                    <min>5000000000</min>
+                    <disallowed>5000000000</disallowed>
+                </max_memory_usage>
+            </constraints>
+        </overlap_constraint_profile>
     </profiles>
 
     <users>
@@ -88,6 +99,14 @@
             <profile>alias_constraint_profile</profile>
             <quota>default</quota>
         </alias_constraint_user>
+        <overlap_constraint_user>
+            <password></password>
+            <networks incl="networks" replace="replace">
+                <ip>::/0</ip>
+            </networks>
+            <profile>overlap_constraint_profile</profile>
+            <quota>default</quota>
+        </overlap_constraint_user>
     </users>
 
     <quotas>

--- a/tests/integration/test_settings_constraints/configs/users.xml
+++ b/tests/integration/test_settings_constraints/configs/users.xml
@@ -46,6 +46,13 @@
                 </merge_tree_allow_experimental_block_number_column>
             </constraints>
         </alias_constraint_profile>
+
+        <!-- Empty profile used as the system-wide default_profile (see configs/no_default_constraints.xml).
+             SQL-created users without an explicit profile fall back to this one, so the role test below
+             starts from a base profile with no merge_tree constraints and the constraint reaches the
+             user only via the granted role. -->
+        <empty_profile>
+        </empty_profile>
     </profiles>
 
     <users>

--- a/tests/integration/test_settings_constraints/test.py
+++ b/tests/integration/test_settings_constraints/test.py
@@ -227,37 +227,37 @@ def test_disallowed_constraint_merge_tree(started_cluster):
 
 def test_merge_tree_setting_constraint_via_alias(started_cluster):
     """The MergeTreeSettings overload of checkImpl must resolve aliases before
-    looking up the constraint. Otherwise a user can bypass a constraint that was
-    set on the canonical name by writing to the alias instead.
+    looking up the constraint, in both directions: the constraint may be declared
+    on the canonical name or on the alias, and the query may name either side.
+    All four combinations must hit the same constraint.
 
-    `enable_block_number_column` has the alias `allow_experimental_block_number_column`;
-    the constraint in users.xml is declared on the canonical name with <const/>.
-    Both names must be blocked."""
+    enable_block_number_column has the alias allow_experimental_block_number_column.
+    The default profile declares the constraint on the canonical name; the
+    alias_constraint_profile declares it on the alias name.
+    Without the upfront resolveName, querying via an alias against a constraint
+    declared on the canonical name silently bypasses the constraint."""
 
     instance.query("DROP TABLE IF EXISTS test_alias_constraint")
     instance.query(
         "CREATE TABLE test_alias_constraint (x Int) ENGINE=MergeTree ORDER BY x"
     )
 
-    # Canonical name: must be blocked.
-    assert "Setting enable_block_number_column should not be changed" in instance.query_and_get_error(
-        "ALTER TABLE test_alias_constraint MODIFY SETTING enable_block_number_column=1"
-    )
+    # default user: constraint declared on canonical name.
+    for setting in ("enable_block_number_column", "allow_experimental_block_number_column"):
+        assert "should not be changed" in instance.query_and_get_error(
+            f"ALTER TABLE test_alias_constraint MODIFY SETTING {setting}=1"
+        )
+        assert "should not be changed" in instance.query_and_get_error(
+            "CREATE TABLE test_alias_constraint_create (x Int) ENGINE=MergeTree ORDER BY x "
+            f"SETTINGS {setting}=1"
+        )
 
-    # Alias: must also be blocked. Without the fix the alias bypasses the constraint.
-    assert "should not be changed" in instance.query_and_get_error(
-        "ALTER TABLE test_alias_constraint MODIFY SETTING allow_experimental_block_number_column=1"
-    )
-
-    # Also reject at CREATE time via SETTINGS clause.
-    assert "should not be changed" in instance.query_and_get_error(
-        "CREATE TABLE test_alias_constraint_create (x Int) ENGINE=MergeTree ORDER BY x "
-        "SETTINGS enable_block_number_column=1"
-    )
-    assert "should not be changed" in instance.query_and_get_error(
-        "CREATE TABLE test_alias_constraint_create (x Int) ENGINE=MergeTree ORDER BY x "
-        "SETTINGS allow_experimental_block_number_column=1"
-    )
+    # alias_constraint_user: constraint declared on alias name.
+    for setting in ("enable_block_number_column", "allow_experimental_block_number_column"):
+        assert "should not be changed" in instance.query_and_get_error(
+            f"ALTER TABLE test_alias_constraint MODIFY SETTING {setting}=1",
+            user="alias_constraint_user",
+        )
 
     instance.query("DROP TABLE IF EXISTS test_alias_constraint")
 

--- a/tests/integration/test_settings_constraints/test.py
+++ b/tests/integration/test_settings_constraints/test.py
@@ -3,7 +3,11 @@ import pytest
 from helpers.cluster import ClickHouseCluster
 
 cluster = ClickHouseCluster(__file__)
-instance = cluster.add_instance("instance", user_configs=["configs/users.xml"])
+instance = cluster.add_instance(
+    "instance",
+    main_configs=["configs/no_default_constraints.xml"],
+    user_configs=["configs/users.xml"],
+)
 
 
 @pytest.fixture(scope="module")
@@ -260,6 +264,55 @@ def test_merge_tree_setting_constraint_via_alias(started_cluster):
         )
 
     instance.query("DROP TABLE IF EXISTS test_alias_constraint")
+
+
+def test_merge_tree_setting_constraint_via_granted_role(started_cluster):
+    """A constraint declared on a granted role's settings profile (not the
+    user's own base profile) must still be enforced, including through
+    MergeTreeSettings alias resolution. The system-wide default_profile is
+    overridden to an empty profile (see configs/no_default_constraints.xml),
+    so an SQL-created user without an explicit profile inherits no merge_tree
+    constraints; the constraint reaches the user only via the granted role."""
+
+    instance.query("DROP TABLE IF EXISTS test_role_constraint")
+    instance.query("DROP USER IF EXISTS role_constraint_user")
+    instance.query("DROP ROLE IF EXISTS role_with_block_number_constraint")
+    instance.query("DROP SETTINGS PROFILE IF EXISTS role_block_number_profile")
+
+    instance.query("CREATE USER role_constraint_user")
+    instance.query(
+        "CREATE SETTINGS PROFILE role_block_number_profile "
+        "SETTINGS merge_tree_enable_block_number_column CONST"
+    )
+    instance.query(
+        "CREATE ROLE role_with_block_number_constraint "
+        "SETTINGS PROFILE role_block_number_profile"
+    )
+    instance.query(
+        "GRANT role_with_block_number_constraint TO role_constraint_user"
+    )
+
+    instance.query(
+        "CREATE TABLE test_role_constraint (x Int) ENGINE=MergeTree ORDER BY x"
+    )
+    instance.query(
+        "GRANT ALTER ON test_role_constraint TO role_with_block_number_constraint"
+    )
+
+    try:
+        for setting in (
+            "enable_block_number_column",
+            "allow_experimental_block_number_column",
+        ):
+            assert "should not be changed" in instance.query_and_get_error(
+                f"ALTER TABLE test_role_constraint MODIFY SETTING {setting}=1",
+                user="role_constraint_user",
+            )
+    finally:
+        instance.query("DROP TABLE IF EXISTS test_role_constraint")
+        instance.query("DROP USER IF EXISTS role_constraint_user")
+        instance.query("DROP ROLE IF EXISTS role_with_block_number_constraint")
+        instance.query("DROP SETTINGS PROFILE IF EXISTS role_block_number_profile")
 
 
 def test_disallowed_value_is_clamped_not_thrown(started_cluster):

--- a/tests/integration/test_settings_constraints/test.py
+++ b/tests/integration/test_settings_constraints/test.py
@@ -341,6 +341,34 @@ def test_disallowed_value_is_clamped_not_thrown(started_cluster):
     assert result.strip() == "1"
 
 
+def test_disallowed_value_overlapping_clamp_target(started_cluster):
+    """When a clamp target (min/max) coincides with a disallowed entry, the
+    disallowed check must see the post-clamp value rather than the pre-clamp
+    one. Otherwise an out-of-range value gets clamped to a disallowed value
+    and is silently accepted.
+
+    The overlap_constraint_user has min=5000000000 and disallowed=5000000000
+    on max_memory_usage. A secondary query that sends max_memory_usage below
+    the min would clamp up to 5000000000 — which is disallowed — and must
+    therefore be dropped, not applied."""
+
+    result = instance.exec_in_container(
+        [
+            "clickhouse",
+            "client",
+            "--user=overlap_constraint_user",
+            "--query_kind=secondary_query",
+            "--max_memory_usage=4000000000",
+            "--query=SELECT getSetting('max_memory_usage')",
+        ]
+    )
+    # Default max_memory_usage in 0_stateless tests is non-zero; we only need to
+    # verify the clamp-to-disallowed value is NOT what we ended up with.
+    assert result.strip() != "5000000000", (
+        f"Clamped value 5000000000 is on the disallowed list and must not be applied, got: {result!r}"
+    )
+
+
 def test_create_table_query_setting_constraints(started_cluster):
     """Test that query-level settings passed in CREATE TABLE's engine SETTINGS clause
     are validated against setting constraints (not bypassing them)."""

--- a/tests/integration/test_settings_constraints/test.py
+++ b/tests/integration/test_settings_constraints/test.py
@@ -225,6 +225,43 @@ def test_disallowed_constraint_merge_tree(started_cluster):
     instance.query("DROP TABLE IF EXISTS test")
 
 
+def test_merge_tree_setting_constraint_via_alias(started_cluster):
+    """The MergeTreeSettings overload of checkImpl must resolve aliases before
+    looking up the constraint. Otherwise a user can bypass a constraint that was
+    set on the canonical name by writing to the alias instead.
+
+    `enable_block_number_column` has the alias `allow_experimental_block_number_column`;
+    the constraint in users.xml is declared on the canonical name with <const/>.
+    Both names must be blocked."""
+
+    instance.query("DROP TABLE IF EXISTS test_alias_constraint")
+    instance.query(
+        "CREATE TABLE test_alias_constraint (x Int) ENGINE=MergeTree ORDER BY x"
+    )
+
+    # Canonical name: must be blocked.
+    assert "Setting enable_block_number_column should not be changed" in instance.query_and_get_error(
+        "ALTER TABLE test_alias_constraint MODIFY SETTING enable_block_number_column=1"
+    )
+
+    # Alias: must also be blocked. Without the fix the alias bypasses the constraint.
+    assert "should not be changed" in instance.query_and_get_error(
+        "ALTER TABLE test_alias_constraint MODIFY SETTING allow_experimental_block_number_column=1"
+    )
+
+    # Also reject at CREATE time via SETTINGS clause.
+    assert "should not be changed" in instance.query_and_get_error(
+        "CREATE TABLE test_alias_constraint_create (x Int) ENGINE=MergeTree ORDER BY x "
+        "SETTINGS enable_block_number_column=1"
+    )
+    assert "should not be changed" in instance.query_and_get_error(
+        "CREATE TABLE test_alias_constraint_create (x Int) ENGINE=MergeTree ORDER BY x "
+        "SETTINGS allow_experimental_block_number_column=1"
+    )
+
+    instance.query("DROP TABLE IF EXISTS test_alias_constraint")
+
+
 def test_create_table_query_setting_constraints(started_cluster):
     """Test that query-level settings passed in CREATE TABLE's engine SETTINGS clause
     are validated against setting constraints (not bypassing them)."""

--- a/tests/integration/test_settings_constraints/test.py
+++ b/tests/integration/test_settings_constraints/test.py
@@ -262,6 +262,32 @@ def test_merge_tree_setting_constraint_via_alias(started_cluster):
     instance.query("DROP TABLE IF EXISTS test_alias_constraint")
 
 
+def test_disallowed_value_is_clamped_not_thrown(started_cluster):
+    """The disallowed_values check must respect the `reaction` parameter:
+    initial queries throw, but secondary queries (clamp path) must silently
+    drop the change instead of throwing. Otherwise a value that happens to
+    match a disallowed entry can break secondary queries even though the
+    user set a value the initiator already accepted."""
+
+    # Initial query: throws (unchanged behavior).
+    assert " Setting max_memory_usage shouldn't be 6000000000" in instance.query_and_get_error(
+        "SELECT 1", settings={"max_memory_usage": 6000000000}
+    )
+
+    # Secondary query: must not throw. The clamp implementation should leave
+    # the value alone (no clamp target for disallowed entries) and proceed.
+    result = instance.exec_in_container(
+        [
+            "clickhouse",
+            "client",
+            "--query_kind=secondary_query",
+            "--max_memory_usage=6000000000",
+            "--query=SELECT 1",
+        ]
+    )
+    assert result.strip() == "1"
+
+
 def test_create_table_query_setting_constraints(started_cluster):
     """Test that query-level settings passed in CREATE TABLE's engine SETTINGS clause
     are validated against setting constraints (not bypassing them)."""


### PR DESCRIPTION
A few small but related correctness fixes in `src/Access/SettingsConstraints`:

- `checkImpl(MergeTreeSettings, ...)` now resolves the setting name via `MergeTreeSettings::resolveName` before looking up the constraint, mirroring the `Settings` overload. Previously a `MergeTreeSettings` constraint declared on the canonical name could be bypassed by writing to its alias, because the lookup is a plain hashmap lookup on the (un-resolved) name and the alias cache is only populated when the constraint itself is declared via the alias.
- The `disallowed_values` check in `Checker::check` now honors the `reaction` parameter, matching every other branch (`CONST`, min, max). Previously it threw unconditionally, so the clamp path (secondary queries, `ON CLUSTER` DDL workers, SQL SECURITY DEFINER views) would fail with `SETTING_CONSTRAINT_VIOLATION` instead of silently dropping the change.
- `SettingsConstraints::merge` now iterates `other.settings_alias_cache` rather than its own (a no-op self-iteration).
- The `set` / `get` parameter in `SettingsConstraints.h` is renamed from `allowed_values` to `disallowed_values` to match what the implementation populates.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix several defects in setting-constraint handling: `MergeTreeSettings` constraints declared on a setting's canonical name could be bypassed by writing to an alias of that setting; the `disallowed_values` constraint check threw an exception on clamp paths (secondary queries, `ON CLUSTER` workers, `SQL SECURITY DEFINER` views) instead of silently dropping the change.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.686`
<!-- ch-version-info:end -->