### PR TITLE
Initialize data lake metadata before OPTIMIZE / ALTER on attach

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
+++ b/src/Storages/ObjectStorage/DataLakes/DataLakeConfiguration.h
@@ -153,21 +153,21 @@ public:
         current_metadata->mutate(commands, shared_from_this(), context, storage_id, metadata_snapshot, catalog, format_settings);
     }
 
-    void checkMutationIsPossible(const MutationCommands & commands) override
+    void checkMutationIsPossible(ObjectStoragePtr object_storage, ContextPtr context, const MutationCommands & commands) override
     {
-        assertInitialized();
+        lazyInitializeIfNeeded(object_storage, context);
         current_metadata->checkMutationIsPossible(commands);
     }
 
-    void checkAlterIsPossible(const AlterCommands & commands) override
+    void checkAlterIsPossible(ObjectStoragePtr object_storage, ContextPtr context, const AlterCommands & commands) override
     {
-        assertInitialized();
+        lazyInitializeIfNeeded(object_storage, context);
         current_metadata->checkAlterIsPossible(commands);
     }
 
-    void alter(const AlterCommands & params, ContextPtr context) override
+    void alter(ObjectStoragePtr object_storage, const AlterCommands & params, ContextPtr context) override
     {
-        assertInitialized();
+        lazyInitializeIfNeeded(object_storage, context);
         current_metadata->alter(params, context);
 
     }
@@ -351,9 +351,9 @@ public:
 #endif
     }
 
-    bool optimize(const StorageMetadataPtr & metadata_snapshot, ContextPtr context, const std::optional<FormatSettings> & format_settings) override
+    bool optimize(ObjectStoragePtr object_storage, const StorageMetadataPtr & metadata_snapshot, ContextPtr context, const std::optional<FormatSettings> & format_settings) override
     {
-        assertInitialized();
+        lazyInitializeIfNeeded(object_storage, context);
         return current_metadata->optimize(metadata_snapshot, context, format_settings);
     }
 

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -618,15 +618,7 @@ bool StorageObjectStorage::optimize(
     bool /*cleanup*/,
     [[maybe_unused]] ContextPtr context)
 {
-    /// Initialize the data lake metadata before delegating. Without this, calling `OPTIMIZE`
-    /// on a freshly attached data lake table (e.g. after server restart) raises a
-    /// `LOGICAL_ERROR` exception from `DataLakeConfiguration::optimize` because
-    /// `current_metadata` is only loaded lazily on the read/write paths. By calling
-    /// `update` here we either populate the metadata or surface the underlying load
-    /// failure as a user-facing exception. See https://github.com/ClickHouse/ClickHouse/issues/104711.
-    if (configuration->isDataLakeConfiguration())
-        configuration->update(object_storage, context);
-    return configuration->optimize(metadata_snapshot, context, format_settings);
+    return configuration->optimize(object_storage, metadata_snapshot, context, format_settings);
 }
 
 void StorageObjectStorage::truncate(
@@ -806,17 +798,7 @@ void StorageObjectStorage::mutate([[maybe_unused]] const MutationCommands & comm
 
 void StorageObjectStorage::checkMutationIsPossible(const MutationCommands & commands, const Settings & /* settings */) const
 {
-    /// Initialize the data lake metadata before delegating. The check otherwise raises a
-    /// `LOGICAL_ERROR` exception from `DataLakeConfiguration::checkMutationIsPossible` when
-    /// the table was attached lazily and the metadata has not been loaded yet. We do not
-    /// receive a query `Context` here, so fall back to the thread-local one — same pattern
-    /// as `supportedPrewhereColumns` above. See https://github.com/ClickHouse/ClickHouse/issues/104711.
-    if (configuration->isDataLakeConfiguration())
-    {
-        if (auto context = CurrentThread::tryGetQueryContext())
-            configuration->update(object_storage, context);
-    }
-    configuration->checkMutationIsPossible(commands);
+    configuration->checkMutationIsPossible(object_storage, CurrentThread::tryGetQueryContext(), commands);
 }
 
 Pipe StorageObjectStorage::executeCommand(const String & command_name, const ASTPtr & args, ContextPtr context)
@@ -832,13 +814,7 @@ void StorageObjectStorage::alter(const AlterCommands & params, ContextPtr contex
     StorageInMemoryMetadata new_metadata = *getInMemoryMetadataPtr(context, false);
     params.apply(new_metadata, context);
 
-    /// Initialize the data lake metadata before delegating, to avoid a `LOGICAL_ERROR`
-    /// exception from `DataLakeConfiguration::alter` when the table was attached lazily.
-    /// See https://github.com/ClickHouse/ClickHouse/issues/104711.
-    if (configuration->isDataLakeConfiguration())
-        configuration->update(object_storage, context);
-
-    configuration->alter(params, context);
+    configuration->alter(object_storage, params, context);
 
     DatabaseCatalog::instance()
         .getDatabase(storage_id.database_name)
@@ -848,12 +824,7 @@ void StorageObjectStorage::alter(const AlterCommands & params, ContextPtr contex
 
 void StorageObjectStorage::checkAlterIsPossible(const AlterCommands & commands, ContextPtr context) const
 {
-    /// Initialize the data lake metadata before delegating, to avoid a `LOGICAL_ERROR`
-    /// exception from `DataLakeConfiguration::checkAlterIsPossible` when the table was
-    /// attached lazily. See https://github.com/ClickHouse/ClickHouse/issues/104711.
-    if (configuration->isDataLakeConfiguration())
-        configuration->update(object_storage, context);
-    configuration->checkAlterIsPossible(commands);
+    configuration->checkAlterIsPossible(object_storage, context, commands);
 }
 
 void StorageObjectStorage::startup()

--- a/src/Storages/ObjectStorage/StorageObjectStorage.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorage.cpp
@@ -618,6 +618,14 @@ bool StorageObjectStorage::optimize(
     bool /*cleanup*/,
     [[maybe_unused]] ContextPtr context)
 {
+    /// Initialize the data lake metadata before delegating. Without this, calling `OPTIMIZE`
+    /// on a freshly attached data lake table (e.g. after server restart) raises a
+    /// `LOGICAL_ERROR` exception from `DataLakeConfiguration::optimize` because
+    /// `current_metadata` is only loaded lazily on the read/write paths. By calling
+    /// `update` here we either populate the metadata or surface the underlying load
+    /// failure as a user-facing exception. See https://github.com/ClickHouse/ClickHouse/issues/104711.
+    if (configuration->isDataLakeConfiguration())
+        configuration->update(object_storage, context);
     return configuration->optimize(metadata_snapshot, context, format_settings);
 }
 
@@ -798,6 +806,16 @@ void StorageObjectStorage::mutate([[maybe_unused]] const MutationCommands & comm
 
 void StorageObjectStorage::checkMutationIsPossible(const MutationCommands & commands, const Settings & /* settings */) const
 {
+    /// Initialize the data lake metadata before delegating. The check otherwise raises a
+    /// `LOGICAL_ERROR` exception from `DataLakeConfiguration::checkMutationIsPossible` when
+    /// the table was attached lazily and the metadata has not been loaded yet. We do not
+    /// receive a query `Context` here, so fall back to the thread-local one — same pattern
+    /// as `supportedPrewhereColumns` above. See https://github.com/ClickHouse/ClickHouse/issues/104711.
+    if (configuration->isDataLakeConfiguration())
+    {
+        if (auto context = CurrentThread::tryGetQueryContext())
+            configuration->update(object_storage, context);
+    }
     configuration->checkMutationIsPossible(commands);
 }
 
@@ -814,6 +832,12 @@ void StorageObjectStorage::alter(const AlterCommands & params, ContextPtr contex
     StorageInMemoryMetadata new_metadata = *getInMemoryMetadataPtr(context, false);
     params.apply(new_metadata, context);
 
+    /// Initialize the data lake metadata before delegating, to avoid a `LOGICAL_ERROR`
+    /// exception from `DataLakeConfiguration::alter` when the table was attached lazily.
+    /// See https://github.com/ClickHouse/ClickHouse/issues/104711.
+    if (configuration->isDataLakeConfiguration())
+        configuration->update(object_storage, context);
+
     configuration->alter(params, context);
 
     DatabaseCatalog::instance()
@@ -822,8 +846,13 @@ void StorageObjectStorage::alter(const AlterCommands & params, ContextPtr contex
     setInMemoryMetadata(new_metadata);
 }
 
-void StorageObjectStorage::checkAlterIsPossible(const AlterCommands & commands, ContextPtr /*context*/) const
+void StorageObjectStorage::checkAlterIsPossible(const AlterCommands & commands, ContextPtr context) const
 {
+    /// Initialize the data lake metadata before delegating, to avoid a `LOGICAL_ERROR`
+    /// exception from `DataLakeConfiguration::checkAlterIsPossible` when the table was
+    /// attached lazily. See https://github.com/ClickHouse/ClickHouse/issues/104711.
+    if (configuration->isDataLakeConfiguration())
+        configuration->update(object_storage, context);
     configuration->checkAlterIsPossible(commands);
 }
 

--- a/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
+++ b/src/Storages/ObjectStorage/StorageObjectStorageConfiguration.h
@@ -243,12 +243,12 @@ public:
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Table engine {} doesn't support mutations", getTypeName());
     }
-    virtual void checkMutationIsPossible(const MutationCommands & /*commands*/)
+    virtual void checkMutationIsPossible(ObjectStoragePtr /*object_storage*/, ContextPtr /*context*/, const MutationCommands & /*commands*/)
     {
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Table engine {} doesn't support mutations", getTypeName());
     }
 
-    virtual void checkAlterIsPossible(const AlterCommands & commands)
+    virtual void checkAlterIsPossible(ObjectStoragePtr /*object_storage*/, ContextPtr /*context*/, const AlterCommands & commands)
     {
         for (const auto & command : commands)
         {
@@ -258,7 +258,7 @@ public:
         }
     }
 
-    virtual void alter(const AlterCommands & /*params*/, ContextPtr /*context*/) {}
+    virtual void alter(ObjectStoragePtr /*object_storage*/, const AlterCommands & /*params*/, ContextPtr /*context*/) {}
 
     virtual const DataLakeStorageSettings & getDataLakeSettings() const
     {
@@ -275,7 +275,7 @@ public:
         return nullptr;
     }
 
-    virtual bool optimize(const StorageMetadataPtr & /*metadata_snapshot*/, ContextPtr /*context*/, const std::optional<FormatSettings> & /*format_settings*/)
+    virtual bool optimize(ObjectStoragePtr /*object_storage*/, const StorageMetadataPtr & /*metadata_snapshot*/, ContextPtr /*context*/, const std::optional<FormatSettings> & /*format_settings*/)
     {
         return false;
     }

--- a/tests/queries/0_stateless/04230_iceberg_optimize_metadata_not_initialized_104711.reference
+++ b/tests/queries/0_stateless/04230_iceberg_optimize_metadata_not_initialized_104711.reference
@@ -1,0 +1,5 @@
+INSERT failed as expected
+OPTIMIZE did not crash with Logical error
+ALTER did not crash with Logical error
+ALTER ADD COLUMN did not crash with Logical error
+1

--- a/tests/queries/0_stateless/04230_iceberg_optimize_metadata_not_initialized_104711.sh
+++ b/tests/queries/0_stateless/04230_iceberg_optimize_metadata_not_initialized_104711.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-parallel
+# - no-fasttest: requires `IcebergLocal` (USE_AVRO build option)
+# - no-parallel: uses DETACH/ATTACH which serializes per database
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/104711:
+# `OPTIMIZE TABLE` on a freshly attached `IcebergLocal` table whose metadata
+# could not be loaded used to raise `Logical error: 'Metadata is not initialized'`
+# from `DataLakeConfiguration::optimize`. After the fix, it raises a regular
+# user-facing exception describing the underlying load failure.
+#
+# We reproduce the "could not load metadata" state by:
+#   1. creating an Iceberg table with `iceberg_metadata_compression_method='deflate'`,
+#   2. issuing an `INSERT` with an invalid `output_format_compression_level=11`
+#      so the second metadata file lands on disk corrupted,
+#   3. `DETACH ... SYNC` + `ATTACH` (equivalent to a server restart from the
+#      perspective of `DataLakeConfiguration::current_metadata`),
+#   4. then issuing `OPTIMIZE TABLE` / `ALTER TABLE` / `SELECT` which previously
+#      crashed.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+TABLE="t_${CLICKHOUSE_DATABASE}_${RANDOM}"
+TABLE_PATH="${USER_FILES_PATH}/${TABLE}/"
+
+trap 'rm -rf "${TABLE_PATH}" 2>/dev/null' EXIT
+
+# Step 1: create the table with the deflate metadata format.
+${CLICKHOUSE_CLIENT} --query "
+    CREATE TABLE ${TABLE} (c0 Int32)
+    ENGINE = IcebergLocal('${TABLE_PATH}')
+    SETTINGS iceberg_metadata_compression_method = 'deflate'
+"
+
+# Step 2: provoke the corrupt-metadata-on-disk state via an INSERT with an
+# unsupported compression level. The INSERT itself must fail.
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --output_format_compression_level=11 \
+    --query "INSERT INTO ${TABLE} VALUES (2)" 2>&1 \
+    | grep -F 'INCORRECT_DATA' > /dev/null && echo "INSERT failed as expected"
+
+# Step 3: detach + attach to clear the in-memory `current_metadata` cache,
+# the way a server restart would. The corrupted metadata produces a server-side
+# `<Warning>` log during ATTACH (swallowed by the lazy-init catch in
+# `StorageObjectStorage`'s constructor), so silence the log channel that the
+# client forwards to its stderr — otherwise the test fails on "having stderror".
+${CLICKHOUSE_CLIENT} --query "DETACH TABLE ${TABLE} SYNC"
+${CLICKHOUSE_CLIENT} --send_logs_level=fatal --query "ATTACH TABLE ${TABLE}" 2>/dev/null
+
+# Step 4: the previously-crashing operations must now raise a regular
+# exception instead of `LOGICAL_ERROR`. We do not care which specific
+# error code is reported (it depends on what `update` happens to fail
+# with for the corrupted metadata) — only that it is NOT a logical error
+# and that the server keeps running.
+${CLICKHOUSE_CLIENT} --allow_experimental_iceberg_compaction=1 \
+    --query "OPTIMIZE TABLE ${TABLE}" 2>&1 \
+    | grep -F 'Logical error' > /dev/null && echo "FAIL: OPTIMIZE crashed with Logical error" \
+    || echo "OPTIMIZE did not crash with Logical error"
+
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 \
+    --query "ALTER TABLE ${TABLE} DELETE WHERE c0 = 0" 2>&1 \
+    | grep -F 'Logical error' > /dev/null && echo "FAIL: ALTER crashed with Logical error" \
+    || echo "ALTER did not crash with Logical error"
+
+${CLICKHOUSE_CLIENT} --query "ALTER TABLE ${TABLE} ADD COLUMN c1 Int32" 2>&1 \
+    | grep -F 'Logical error' > /dev/null && echo "FAIL: ALTER ADD COLUMN crashed with Logical error" \
+    || echo "ALTER ADD COLUMN did not crash with Logical error"
+
+# The server is still alive.
+${CLICKHOUSE_CLIENT} --query "SELECT 1"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE} SYNC"


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1691
<!-- End of fixes issue link part, do not remove -->

### Motivation

`OPTIMIZE TABLE` on a freshly attached `IcebergLocal` (or other data lake) table used to raise `Logical error: 'Metadata is not initialized'` and abort the server. Same for `ALTER TABLE ... DELETE`, `ALTER TABLE ... ADD COLUMN`, and the corresponding mutation/alter pre-checks. The user-visible reproducer from #104711:

```sql
SET iceberg_metadata_compression_method = 'deflate';
CREATE TABLE t0 (c0 Int) ENGINE = IcebergLocal(local, path = '...');
SET output_format_compression_level = 11;
INSERT INTO TABLE t0 VALUES (2);  -- fails: INCORRECT_DATA
-- restart server
OPTIMIZE TABLE t0;  -- Fatal: Logical error 'Metadata is not initialized'.
```

A close cousin is the `ALTER TABLE ... DELETE` stack trace in #96806 — same root cause, different entry point.

### Root cause

`DataLakeConfiguration::current_metadata` is loaded lazily. `read`, `write` and `mutate` call `update` / `lazyInitializeIfNeeded` before delegating, but `optimize`, `alter`, `checkMutationIsPossible` and `checkAlterIsPossible` did not.

When the table was attached lazily (typical after a server restart) or the previous `update` failed during ATTACH (in the reproducer above, the failed INSERT leaves a corrupted `vN.deflate.metadata.json` on disk, and the catch in `StorageObjectStorage`'s constructor swallows the load failure), the four methods above hit `DataLakeConfiguration::assertInitialized` and raise `LOGICAL_ERROR` — fatal in debug / sanitizer builds.

### Fix

Call `configuration->update(object_storage, context)` from each of those four methods on `StorageObjectStorage` when the configuration is a data lake. The metadata is either populated successfully and the operation proceeds, or the load error surfaces as a regular user-facing exception (e.g. `INCORRECT_DATA` for the corrupted JSON above) instead of a logical error.

`checkMutationIsPossible` has no `Context` parameter, so it uses `CurrentThread::tryGetQueryContext()` — the same fallback already used by `supportedPrewhereColumns` and `getColumnSizes` in this file.

### Local verification

Built debug, reproduced the LOGICAL_ERROR with the exact issue reproducer, confirmed the fix replaces it with a normal `INCORRECT_DATA` exception, and the server stays alive. A new stateless regression test (`04230_iceberg_optimize_metadata_not_initialized_104711`) reproduces the corrupt-metadata-on-disk state with `DETACH ... SYNC` + `ATTACH` (equivalent to a server restart for `current_metadata`) and asserts that `OPTIMIZE` / `ALTER DELETE` / `ALTER ADD COLUMN` no longer produce a logical error and the server keeps running. The test fails (server crash) on master and passes on this branch.

Related: #104711, #96806.

Closes https://github.com/ClickHouse/ClickHouse/issues/104711

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a `LOGICAL_ERROR` exception (`Metadata is not initialized`) raised by `OPTIMIZE TABLE`, `ALTER TABLE ... DELETE`, `ALTER TABLE ... ADD COLUMN` and other ALTER variants on a lazily-attached `Iceberg` / `IcebergLocal` / `DeltaLake` / `Hudi` table whose metadata had not been loaded yet (typical after a server restart, or after a previous metadata write failed and left a corrupted metadata file on disk). The operation now either proceeds normally if the metadata loads successfully, or surfaces the underlying load failure as a regular user-facing exception instead of aborting the server in debug / sanitizer builds.


### Documentation entry for user-facing changes
- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.626`
- Backported to: `26.4.5.24`, `26.3.14.25`
<!-- ch-version-info:end -->