### PR TITLE
Don't block Mergeable Check on Code Review failure

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -184,6 +184,7 @@ class JobConfigs:
         name=JobNames.CODE_REVIEW,
         runs_on=RunnerLabels.STYLE_CHECK_ARM,
         command="python3 ./ci/jobs/copilot_review_job.py --pre",
+        allow_failure=True,
     )
     ci_results_review = Job.Config(
         name=JobNames.CI_RESULTS_REVIEW,


### PR DESCRIPTION
A failed `Code Review` job (automated Copilot review) currently blocks the `Mergeable Check` status, e.g. https://github.com/ClickHouse/ClickHouse/pull/104679.

Marks the `Code Review` job as `allow_failure=True`, mirroring its sibling `CI Results Review`, so a Copilot review failure no longer blocks merge.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.583`
<!-- ch-version-info:end -->