### PR TITLE
Fix use-after-free in `AvroConfluentRowInputFormat`

### DIFF
--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -1327,7 +1327,7 @@ const AvroDeserializer & AvroConfluentRowInputFormat::getOrCreateDeserializer(Sc
         auto schema = schema_registry->getSchema(schema_id);
         AvroDeserializer deserializer(
             output.getHeader(), schema, format_settings.avro.allow_missing_fields, format_settings.null_as_default, format_settings);
-        it = deserializer_cache.emplace(schema_id, deserializer).first;
+        it = deserializer_cache.emplace(schema_id, std::move(deserializer)).first;
     }
     return it->second;
 }

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.h
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.h
@@ -52,6 +52,12 @@ class AvroDeserializer
 public:
     AvroDeserializer(const Block & header, avro::ValidSchema schema, bool allow_missing_fields, bool null_as_default_, const FormatSettings & settings_);
     AvroDeserializer(DataTypePtr data_type, const std::string & column_name, avro::ValidSchema schema, bool allow_missing_fields, bool null_as_default_, const FormatSettings & settings_);
+
+    AvroDeserializer(const AvroDeserializer &) = delete;
+    AvroDeserializer & operator=(const AvroDeserializer &) = delete;
+    AvroDeserializer(AvroDeserializer &&) = default;
+    AvroDeserializer & operator=(AvroDeserializer &&) = delete;
+
     void deserializeRow(MutableColumns & columns, avro::Decoder & decoder, RowReadExtension & ext) const;
 
     using DeserializeFn = std::function<bool(IColumn & column, avro::Decoder & decoder)>;

--- a/tests/integration/test_format_avro_confluent/test.py
+++ b/tests/integration/test_format_avro_confluent/test.py
@@ -90,27 +90,18 @@ def test_select_skip_symbolic(started_cluster):
 
     schema = avro.schema.make_avsc_object(
         {
-            "name": "Outer",
+            "name": "Node",
             "type": "record",
             "fields": [
                 {"name": "value", "type": "long"},
-                {
-                    "name": "a",
-                    "type": {
-                        "type": "record",
-                        "name": "Inner",
-                        "fields": [{"name": "x", "type": "int"}],
-                    },
-                },
-                {"name": "b", "type": "Inner"},
+                {"name": "next", "type": ["null", "Node"]},
             ],
         }
     )
 
+    record = {"value": 0, "next": {"value": 1, "next": {"value": 2, "next": None}}}
     data = serializer.encode_record_with_schema(
-        "test_subject_skip_symbolic",
-        schema,
-        {"value": 0, "a": {"x": 0}, "b": {"x": 0}},
+        "test_subject_skip_symbolic", schema, record
     )
 
     instance = started_cluster.instances["dummy"]  # type: ClickHouseInstance

--- a/tests/integration/test_format_avro_confluent/test.py
+++ b/tests/integration/test_format_avro_confluent/test.py
@@ -81,6 +81,56 @@ def test_select(started_cluster):
     ]
 
 
+def test_select_skip_symbolic(started_cluster):
+    # type: (ClickHouseCluster) -> None
+
+    reg_url = "http://localhost:{}".format(started_cluster.schema_registry_port)
+    schema_registry_client = CachedSchemaRegistryClient({"url": reg_url})
+    serializer = MessageSerializer(schema_registry_client)
+
+    schema = avro.schema.make_avsc_object(
+        {
+            "name": "Outer",
+            "type": "record",
+            "fields": [
+                {"name": "value", "type": "long"},
+                {
+                    "name": "a",
+                    "type": {
+                        "type": "record",
+                        "name": "Inner",
+                        "fields": [{"name": "x", "type": "int"}],
+                    },
+                },
+                {"name": "b", "type": "Inner"},
+            ],
+        }
+    )
+
+    data = serializer.encode_record_with_schema(
+        "test_subject_skip_symbolic",
+        schema,
+        {"value": 0, "a": {"x": 0}, "b": {"x": 0}},
+    )
+
+    instance = started_cluster.instances["dummy"]  # type: ClickHouseInstance
+    schema_registry_url = "http://{}:{}".format(
+        started_cluster.schema_registry_host, started_cluster.schema_registry_port
+    )
+    settings = {"format_avro_schema_registry_url": schema_registry_url}
+    run_query(
+        instance,
+        "create table avro_data_skip_symbolic(value Int64) engine = Memory()",
+    )
+    run_query(
+        instance,
+        "insert into avro_data_skip_symbolic format AvroConfluent",
+        data,
+        settings,
+    )
+    assert run_query(instance, "select value from avro_data_skip_symbolic").strip() == "0"
+
+
 def test_select_auth(started_cluster):
     # type: (ClickHouseCluster) -> None
 


### PR DESCRIPTION
`AvroConfluentRowInputFormat::getOrCreateDeserializer` built an `AvroDeserializer` on the stack and copied it into `deserializer_cache`. The deserializer holds a `symbolic_skip_fn_map`, and a lambda in  `AvroDeserializer::row_action` which captures a reference into that map (`[&skip_fn = it->second]`). Copying deep-copies the map to a new address but leaves the lambda referencing the original. When the stack local is destroyed, those references dangle, and the next row deserialization invokes a `std::function` over freed memory. We should use `std::move` instead of copying.

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix segfault due to a use-after-free bug in `AvroConfluentRowInputFormat`.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.609`
- Backported to: `26.4.3.18`, `26.3.11.18`, `26.2.19.20`, `25.8.24.14`
<!-- ch-version-info:end -->