### PR TITLE
clickhouse-test: split print_stacktraces and dump before timeout

### DIFF
--- a/ci/tests/test_print_stacktraces.py
+++ b/ci/tests/test_print_stacktraces.py
@@ -1,28 +1,25 @@
 """
-End-to-end test for ``print_stacktraces`` in tests/clickhouse-test.
+End-to-end tests for the stacktrace helpers in tests/clickhouse-test.
 
 Background
 ----------
 ``clickhouse-test`` assigns ``args = parse_args()`` only inside
-``if __name__ == "__main__":``.  On macOS, Python's default multiprocessing
-start method is ``spawn``, which re-imports the module in each worker
-without executing ``__main__`` — so module-level ``args`` is undefined,
-and any helper that closed over it crashed with ``NameError``.  See the
-fast_test_arm_darwin failure where the hung-check path raised
-``NameError: name 'args' is not defined`` inside ``get_server_pid``.
+``if __name__ == "__main__":``.  On macOS, Python's default
+multiprocessing start method is ``spawn``, which re-imports the module
+in each worker without executing ``__main__`` — so module-level
+``args`` is undefined, and any helper that closed over it crashed with
+``NameError``.  See the fast_test_arm_darwin failure where the
+hung-check path raised ``NameError: name 'args' is not defined`` inside
+``get_server_pid``.
 
-This test reproduces the same import condition by loading
-``clickhouse-test`` via ``runpy.run_path`` (which, like spawn, does not run
-``__main__``) and then invokes ``print_stacktraces`` against the live
-ClickHouse server provided by the ``ClickHouseService`` fixture in
-``ci/jobs/ci_tests_job.py``.  It exercises the full code path:
-
-  * locate the server PID via the portable ``pgrep`` helper,
-  * query ``system.stack_trace`` through ``args.client``,
-  * format and print the result.
+These tests reproduce the same import condition by loading
+``clickhouse-test`` via ``runpy.run_path`` (which, like spawn, does not
+run ``__main__``) and then invoke each public stacktrace helper against
+the live ClickHouse server provided by the ``ClickHouseService``
+fixture in ``ci/jobs/ci_tests_job.py``.
 
 Pre-fix: NameError inside the fresh import.
-Post-fix: prints the stack-trace dump and returns.
+Post-fix: the helpers run to completion against a live server.
 """
 
 import argparse
@@ -35,7 +32,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 _CLICKHOUSE_TEST = str(_REPO_ROOT / "tests" / "clickhouse-test")
 
 
-def test_print_stacktraces_against_live_server():
+def _load_clickhouse_test():
     # Mimic a spawn worker: load clickhouse-test without running __main__,
     # so module-level `args` is absent.
     ct = runpy.run_path(_CLICKHOUSE_TEST)
@@ -49,11 +46,15 @@ def test_print_stacktraces_against_live_server():
         "no clickhouse-server process found — this test expects ClickHouseService "
         "(see ci/jobs/ci_tests_job.py) to be running on localhost:9000"
     )
+    return ct
 
-    # Minimal args namespace: only the fields print_stacktraces and its
-    # transitive helpers actually read.  Mirrors what __main__ assigns after
-    # parse_args() for a local-server, plaintext-TCP, default-database run.
-    args = argparse.Namespace(
+
+def _make_args():
+    # Minimal args namespace: only the fields the helpers and their
+    # transitive callees actually read.  Mirrors what __main__ assigns
+    # after parse_args() for a local-server, plaintext-TCP,
+    # default-database run.
+    return argparse.Namespace(
         client="clickhouse-client --port=9000",
         client_option=None,
         secure=False,
@@ -65,13 +66,33 @@ def test_print_stacktraces_against_live_server():
         force_color=False,
     )
 
+
+def test_print_c_stacktraces_against_live_server():
+    ct = _load_clickhouse_test()
+    args = _make_args()
+
     captured = io.StringIO()
     with redirect_stdout(captured):
-        ct["print_stacktraces"](args)
+        ct["print_c_stacktraces"](args)
     output = captured.getvalue()
 
-    # The function must have queried system.stack_trace and printed traces.
-    # We don't require a specific thread name — any non-trivial output
-    # confirms the round-trip succeeded.
-    assert "Collecting stacktraces" in output, output
+    # The function must have located the server PID and reached gdb.
+    # Whether the attach itself succeeds depends on the host's
+    # `kernel.yama.ptrace_scope` and is not asserted.
+    assert "Collecting C stacktraces from main server process" in output, output
+
+
+def test_print_sql_stacktraces_against_live_server():
+    ct = _load_clickhouse_test()
+    args = _make_args()
+
+    captured = io.StringIO()
+    with redirect_stdout(captured):
+        ct["print_sql_stacktraces"](args)
+    output = captured.getvalue()
+
+    # The function must have queried system.stack_trace and printed
+    # traces.  We don't require a specific thread name — any non-trivial
+    # output confirms the round-trip succeeded.
+    assert "Collecting stacktraces from system.stack_trace table" in output, output
     assert "trace_str" in output or "thread_name" in output, output

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -3574,12 +3574,17 @@ class TestCase:
         try:
             self._cleanup_database(args, timeout)
         except (ConnectionError, http.client.ImproperConnectionState) as e:
-            # Cleanup is best-effort.  If the server became unreachable
-            # between the test finishing and cleanup running, the test's
-            # database is moot — letting the exception propagate would
-            # downgrade the test's own (already-set) result to FAIL with
-            # SERVER_DIED.  The hung-check or the next test will detect
-            # the dead server and stop the run.
+            # Cleanup is best-effort only when the server is actually dead.
+            # If the server is still alive, this was a real cleanup failure
+            # (leftover state, unfinished DROP) and must propagate so the
+            # outer handler in run() classifies it as CONNECTION_ERROR — a
+            # silent swallow would let a test stay OK while leaving its
+            # database behind, hiding the bug.
+            if check_server_liveness(args):
+                raise
+            # Server died between the test finishing and cleanup running.
+            # The test's database is moot; the hung-check or the next test
+            # will detect the dead server and stop the run.
             print(
                 f"WARNING: cleanup skipped for {self.name}: "
                 f"{type(e).__name__}: {e}",

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1012,10 +1012,15 @@ def pgrep(ppid: int = None, pgid: int = None, command: str = None) -> List[List[
     return ps
 
 def get_all_server_pids():
-    """Get PIDs of clickhouse-server processes belonging to the current process group.
+    """Get PIDs of all clickhouse-server processes visible to the current user.
+
+    No pgid scoping: in every real scenario where this helper is useful the
+    server lives outside `clickhouse-test`'s process group (CI harnesses,
+    Docker, systemd, and the `ClickHouseService` test fixture all spawn the
+    server with `start_new_session=True` or equivalent).  A pgid filter
+    silently filters out everything we are meant to find.
     """
-    pgid = os.getpgrp()
-    return [p[0] for p in pgrep(pgid=pgid, command="clickhouse-server")]
+    return [p[0] for p in pgrep(command="clickhouse-server")]
 
 
 def is_asan_build(args):

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -132,7 +132,7 @@ CGROUP_VERSION = detect_cgroup_version()
 
 BASH = "/bin/bash"
 
-def shell_get_output(cmd: str) -> str:
+def shell_get_output(cmd: str, timeout: Optional[float] = None) -> str:
     try:
         res = subprocess.run(
             cmd,
@@ -144,6 +144,7 @@ def shell_get_output(cmd: str) -> str:
             encoding="utf-8",
             errors="replace",
             check=True,
+            timeout=timeout,
         )
         return res.stdout.strip()
     except Exception as e:
@@ -942,7 +943,14 @@ def get_transactions_list(args):
 
 # collect server stacktraces using gdb
 def get_stacktraces_from_gdb(pid):
-    return shell_get_output(f"gdb -batch -ex 'thread apply all backtrace' -p {pid}")
+    # 30s ceiling: `thread apply all backtrace` should finish in seconds even
+    # on a debug build with many threads; anything beyond that means gdb
+    # itself is wedged (e.g. signal-handler deadlock on the inferior).
+    # Killing gdb leaves the server process untouched.
+    return shell_get_output(
+        f"gdb -batch -ex 'thread apply all backtrace' -p {pid}",
+        timeout=30,
+    )
 
 
 # collect server stacktraces from system.stack_trace table

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -5528,7 +5528,7 @@ ORDER BY (test_name, callee_offset)
             # `processlist` above already shows per-thread stacks for
             # every user query still running (system.processes JOIN
             # system.stack_trace by query_id).  print_sql_stacktraces
-            # here adds the rest of system.stack_trace — BG threads
+            # here dumps the rest of system.stack_trace — BG threads
             # with no query_id (merges, replication, schedule pool),
             # which are the typical lock-holders when a user query is
             # wedged but looks idle.

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -1023,46 +1023,73 @@ def is_asan_build(args):
         return bool(os.environ.get("ASAN_OPTIONS"))
 
 
-def print_stacktraces(args) -> None:
-    server_pid = get_server_pid()
+def print_c_stacktraces(args) -> None:
+    """C++-side backtraces via gdb.  Works whenever the server process
+    exists and is debuggable, independent of whether SQL is reachable.
 
-    bt = None
+    Every call site is one of two situations: we're aborting the whole
+    run (SERVER_DIED, hung-check, check_server_started) or terminating
+    the one wedged test (timeout_handler).  gdb's "thread apply all
+    backtrace" pause is on the order of seconds — acceptable in both
+    cases against the diagnostic value.
 
-    # Collect gdb stacktraces from all server processes (main + replicas).
-    # Skip gdb under ASan — it disables LeakSanitizer detections.
-    if not is_asan_build(args):
-        all_pids = get_all_server_pids()
-        if all_pids:
-            parts = []
-            for pid in all_pids:
-                label = "main server" if pid == server_pid else "replica"
-                print(f"\nCollecting stacktraces from {label} process {pid} with gdb:")
-                one_bt = get_stacktraces_from_gdb(pid)
-                if one_bt and len(one_bt) >= 1000:
-                    parts.append(f"=== PID {pid} ({label}) ===\n{one_bt}")
-                else:
-                    print(f"Got suspiciously small stacktraces from {pid}: {one_bt}")
-            if parts:
-                bt = "\n\n".join(parts)
-
-    if bt is None:
-        print("\nCollecting stacktraces from system.stacktraces table:")
-
-        bt = get_stacktraces_from_clickhouse(args)
-
-    if bt is not None:
-        print(bt)
+    Skipped under ASan, where gdb attach disables LeakSanitizer
+    detections.
+    """
+    if is_asan_build(args):
+        print(
+            colored(
+                "\nCannot collect C stacktraces under ASan: gdb attach is disabled.",
+                args,
+                "red",
+                attrs=["bold"],
+            )
+        )
         return
 
-    print(
-        colored(
-            f"\nUnable to locate any ClickHouse server process. "
-            f"It must have crashed or exited prematurely!",
-            args,
-            "red",
-            attrs=["bold"],
+    server_pid = get_server_pid()
+    all_pids = get_all_server_pids()
+    if not all_pids:
+        print(
+            colored(
+                "\nUnable to locate any ClickHouse server process. "
+                "It must have crashed or exited prematurely!",
+                args,
+                "red",
+                attrs=["bold"],
+            )
         )
-    )
+        return
+
+    for pid in all_pids:
+        label = "main server" if pid == server_pid else "replica"
+        print(f"\nCollecting C stacktraces from {label} process {pid} with gdb:")
+        bt = get_stacktraces_from_gdb(pid)
+        if bt and len(bt) >= 1000:
+            print(f"=== PID {pid} ({label}) ===\n{bt}")
+        else:
+            print(f"Got suspiciously small stacktraces from {pid}: {bt}")
+
+
+def print_sql_stacktraces(args) -> None:
+    """ClickHouse-internal stack view from system.stack_trace.
+
+    Adds thread_name and query_id to the C-side picture, which is the
+    only way to map a stuck thread to the query it was running.
+
+    Self-skips when the server is not answering queries — the SQL dump
+    would hit the same dead socket as the liveness check.  This keeps
+    callers honest: they can invoke this from any context (per-test
+    timeout, end-of-run hung-check) without first checking whether the
+    server still responds.
+    """
+    if not check_server_liveness(args, max_retries=1):
+        print("Skipping system.stack_trace query: server is unreachable.")
+        return
+    print("\nCollecting stacktraces from system.stack_trace table:")
+    bt = get_stacktraces_from_clickhouse(args)
+    if bt:
+        print(bt)
 
 
 def get_server_pid():
@@ -3528,7 +3555,20 @@ class TestCase:
         time_passed = (datetime.now() - args.testcase_start_time).total_seconds()
         timeout = max(args.timeout - time_passed, 20)
 
-        self._cleanup_database(args, timeout)
+        try:
+            self._cleanup_database(args, timeout)
+        except (ConnectionError, http.client.ImproperConnectionState) as e:
+            # Cleanup is best-effort.  If the server became unreachable
+            # between the test finishing and cleanup running, the test's
+            # database is moot — letting the exception propagate would
+            # downgrade the test's own (already-set) result to FAIL with
+            # SERVER_DIED.  The hung-check or the next test will detect
+            # the dead server and stop the run.
+            print(
+                f"WARNING: cleanup skipped for {self.name}: "
+                f"{type(e).__name__}: {e}",
+                file=sys.stderr,
+            )
         shutil.rmtree(args.test_tmp_dir)
 
     def _cleanup_database(self, args, timeout):
@@ -4256,6 +4296,16 @@ def run_tests_array(
                 # It helps with completely frozen processes, like in case of gdb errors
                 def timeout_handler(_signum, _frame):
                     with redirect_stdout(cleanup_output):
+                        # Dump stacktraces *before* stop_tests() kills the
+                        # client connections.  This is the only moment
+                        # the offending user query is still wedged on the
+                        # server with its query_id — once the TCP
+                        # connection drops, the server typically cancels
+                        # the query and its threads go away.  BG threads
+                        # stay around either way and can be captured at
+                        # end-of-run.
+                        print_sql_stacktraces(args)
+                        print_c_stacktraces(args)
                         stop_tests()
                     raise TimeoutError("Test execution timed out")
 
@@ -4309,7 +4359,7 @@ def run_tests_array(
                 failures_total += 1
                 failures_chain += 1
                 if test_result.reason == FailureReason.SERVER_DIED:
-                    print_stacktraces(args)
+                    print_c_stacktraces(args)
                     stop_tests()
                     stop_testing.set()
                     raise ServerDied("Server died")
@@ -4769,7 +4819,7 @@ def do_run_tests(
             if args.hung_check:
                 if not check_server_liveness(args):
                     print("Hung check failed: server is not responding")
-                    print_stacktraces(args)
+                    print_c_stacktraces(args)
                     stop_testing.set()
 
             if stop_testing.is_set():
@@ -5072,9 +5122,7 @@ def main(args):
         msg = "Server is not responding. Cannot execute 'SELECT 1' query."
         if args.hung_check:
             print(msg)
-            pid = get_server_pid()
-            print("Got server pid", pid)
-            print_stacktraces(args)
+            print_c_stacktraces(args)
         raise TestException(msg)
 
     if args.cloud:
@@ -5477,7 +5525,15 @@ ORDER BY (test_name, callee_offset)
             print(processlist.decode())
             print(get_transactions_list(args))
 
-            print_stacktraces(args)
+            # `processlist` above already shows per-thread stacks for
+            # every user query still running (system.processes JOIN
+            # system.stack_trace by query_id).  print_sql_stacktraces
+            # here adds the rest of system.stack_trace — BG threads
+            # with no query_id (merges, replication, schedule pool),
+            # which are the typical lock-holders when a user query is
+            # wedged but looks idle.
+            print_sql_stacktraces(args)
+            print_c_stacktraces(args)
             exit_code.value = 1
         elif not hung_check_failed:
             print(colored("\nNo queries hung.", args, "green", attrs=["bold"]))

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -954,7 +954,7 @@ def get_stacktraces_from_gdb(pid):
 
 
 # collect server stacktraces from system.stack_trace table
-def get_stacktraces_from_clickhouse(args):
+def get_stacktraces_from_clickhouse(args, timeout: float = 30):
     settings_str = " ".join(
         [
             get_additional_client_options(args),
@@ -992,7 +992,10 @@ def get_stacktraces_from_clickhouse(args):
             'FROM system.stack_trace FORMAT Vertical"'
         )
 
-    return shell_get_output(msg)
+    # Bound the dump so timeout_handler / hung-check callers cannot wedge
+    # forever if clickhouse-client itself blocks (e.g. the server accepted
+    # the connection but is not making progress on system.stack_trace).
+    return shell_get_output(msg, timeout=timeout)
 
 def pgrep(ppid: int = None, pgid: int = None, command: str = None) -> List[List[str]]:
     # -ww disables line-width truncation of the command column.  Without it,


### PR DESCRIPTION
Split `print_stacktraces` in `tests/clickhouse-test` into two purpose-built helpers and dump diagnostics at the moment they're still inspectable, instead of long after the wedged query has been killed.

The old `print_stacktraces` combined gdb (C++ backtraces) and a `SELECT FROM system.stack_trace` (per-thread + `query_id`) behind one name, with a gdb-then-SQL fallback. That produced wrong results at every call site:

- The three dead-server call sites (worker `SERVER_DIED`, periodic hung-check, `check_server_started` failing) were reaching the SQL fallback against a socket that had just failed the liveness check — emitting `Code: 210 Connection refused` tracebacks on every failed run, and on Darwin (no gdb) producing nothing else. Seen on `fast_test_arm_darwin`: https://github.com/ClickHouse/ClickHouse/actions/runs/25725869646/job/75622018457?pr=104586
- The per-test SIGALRM `timeout_handler` dumped nothing — by the time the end-of-run hung-check ran, `stop_tests()` had already closed the client connections, the server had cancelled the wedged queries, and the per-`query_id` view that gdb cannot give was already lost.

Split into `print_c_stacktraces` (gdb path, skipped under ASan where attach disables LSan) and `print_sql_stacktraces` (SQL path, self-skips when `check_server_liveness` shows the server is unreachable). Each call site picks the right combination:

- worker `SERVER_DIED` / hung-check / `check_server_started`: C only — the SQL helper would just hit the dead socket.
- `timeout_handler` (per-test SIGALRM): both, before `stop_tests()` — the only moment the user-query threads are still wedged and have a `query_id`.
- end-of-run hung-query block: both — `print_sql_stacktraces` adds the BG-thread stacks that the per-query JOIN above filters out by `query_id`.

Also caps `get_stacktraces_from_gdb` at 30 s (no timeout before), and catches `ConnectionError`/`http.client.ImproperConnectionState` in `TestCase._cleanup` so that a server that dies between a test finishing and its cleanup running no longer downgrades the OK test result to FAIL with a giant `http.client` traceback. The hung-check or the next test will set `stop_testing` and abort the run; the swallow logs a `WARNING:` to stderr.

`ci/tests/test_print_stacktraces.py` now covers both helpers end-to-end against the live `ClickHouseService` fixture.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.616`
<!-- ch-version-info:end -->