### PR TITLE
Tag `04221_dictgetordefault_arrayjoin_80703` as `no-parallel-replicas`

### DIFF
--- a/tests/queries/0_stateless/04221_dictgetordefault_arrayjoin_80703.sql
+++ b/tests/queries/0_stateless/04221_dictgetordefault_arrayjoin_80703.sql
@@ -1,3 +1,6 @@
+-- Tags: no-parallel-replicas
+-- no-parallel-replicas: Dictionary is not available on parallel-replica workers.
+
 -- Regression test for https://github.com/ClickHouse/ClickHouse/issues/80703
 -- `dictGetOrDefault` + `arrayJoin` in WHERE on a `MergeTree` with a `PROJECTION` used to throw `NOT_FOUND_COLUMN_IN_BLOCK`.
 


### PR DESCRIPTION
The regression test for issue #80703 creates a local `MergeTree`-backed dictionary and uses `dictGetOrDefault` in a `WHERE` clause. Under ParallelReplicas, the query is dispatched to worker replicas that do not have the test database's dictionary registered, and the lookup fails with `Dictionary (tags_80703) not found` (`BAD_ARGUMENTS`):

```
DB::Exception: Dictionary (`tags_80703`) not found
... DB::ExternalDictionariesLoader::resolveDictionaryName(...) ...
: While executing Remote. (BAD_ARGUMENTS)
```

The test has been failing on master since it was added (commit 23d8c1f156c on 2026-05-10), causing red `Stateless tests (amd_llvm_coverage, ParallelReplicas, s3 storage, parallel)` on numerous unrelated PRs.

This matches the existing pattern used in other `dictGet`-based tests (for example `04202_inverse_dictionary_lookup_pruning_key_condition.sql`) that already carry a `no-parallel-replicas` tag with the same rationale.

CI report:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100365&sha=30f0bdefaf1e66139a2972083b1e90047608eb8a&name_0=PR&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%20ParallelReplicas%2C%20s3%20storage%2C%20parallel%29

Related PR: #100365

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Tag `04221_dictgetordefault_arrayjoin_80703` as `no-parallel-replicas` to fix a CI failure on `Stateless tests (..., ParallelReplicas, ...)`.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.607`
<!-- ch-version-info:end -->