### PR TITLE
Stress test: install thread-pool fault injection after the smoke check passes

### DIFF
--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -236,6 +236,34 @@ def get_options(i: int, upgrade_check: bool, encrypted_storage: bool) -> str:
     return " ".join(options)
 
 
+def install_thread_pool_fault_injection() -> None:
+    """Install `cannot_allocate_thread_injection.xml` and reload config so
+    `cannot_allocate_thread_fault_injection_probability` becomes active.
+    Fail-close on persistent reload failure or inactive setting after reload."""
+    src = "/repo/tests/config/config.d/cannot_allocate_thread_injection.xml"
+    dst = "/etc/clickhouse-server/config.d/cannot_allocate_thread_injection.xml"
+
+    if not os.path.exists(src):
+        raise RuntimeError(f"Thread-pool fault-injection source config not found at {src}")
+
+    logging.info("Installing thread-pool fault-injection config: %s -> %s", src, dst)
+    subprocess.run(["ln", "-sf", src, dst], check=True)
+    call_with_retry(make_query_command("SYSTEM RELOAD CONFIG"), timeout=30, retry_count=5)
+
+    # Fail-close: `call_with_retry` is silent on persistent failure, so verify
+    # the injector probability is actually non-zero after reload.
+    verify_query = make_query_command(
+        "SELECT value FROM system.server_settings "
+        "WHERE name = 'cannot_allocate_thread_fault_injection_probability'"
+    )
+    value = check_output(verify_query, shell=True, timeout=30, text=True).strip()
+    if not value or float(value) <= 0:
+        raise RuntimeError(
+            f"cannot_allocate_thread_fault_injection_probability is {value!r} after reload"
+        )
+    logging.info("Thread-pool fault injection active: probability=%s", value)
+
+
 def run_func_test(
     cmd: str,
     output_prefix: Path,
@@ -282,10 +310,10 @@ def run_func_test(
             logging.info("Smoke check stdout:\n%s", e.stdout)
             logging.info("Smoke check stderr:\n%s", e.stderr)
 
-            # Ignore fault injects and transient errors, but most of the time tests should complete successfully
+            # Thread-pool fault injection is off during smoke check, so the
+            # tolerated transients are ZK fault injection + per-worker
+            # `memory_tracker_fault_probability` only.
             ignored_errors = [
-                "CANNOT_SCHEDULE_TASK",
-                "Fault injection",
                 "Query memory tracker: fault injected",
                 "KEEPER_EXCEPTION",
                 "DATABASE_REPLICATION_FAILED",
@@ -303,6 +331,12 @@ def run_func_test(
                 f"stdout:\n{e.stdout}\n"
                 f"stderr:\n{e.stderr}"
             ) from e
+
+    # Smoke check passed: activate thread-pool fault injection for the real
+    # stress test. Upgrade-check never had it (old binary may not support
+    # the setting), so keep that behavior.
+    if not upgrade_check:
+        install_thread_pool_fault_injection()
 
     # Start the query killer after smoke check completes, before actual stress test
     if query_killer is not None:

--- a/tests/docker_scripts/stress_runner.sh
+++ b/tests/docker_scripts/stress_runner.sh
@@ -229,7 +229,10 @@ stop_server
 # Let's enable S3 storage by default
 export RANDOMIZE_OBJECT_KEY_TYPE=1
 export ZOOKEEPER_FAULT_INJECTION=1
-export THREAD_POOL_FAULT_INJECTION=1
+# THREAD_POOL_FAULT_INJECTION is not exported here: if `cannot_allocate_thread_injection.xml`
+# is installed before the server starts, the smoke-check `CREATE DATABASE ... ON CLUSTER`
+# can hit `CANNOT_SCHEDULE_TASK` and break the HTTP response. `stress.py` installs the
+# config and `SYSTEM RELOAD CONFIG`s the server after the smoke check passes.
 export CLICKHOUSE_FAILPOINTS_INJECTION=1
 configure
 configure_limits
@@ -296,10 +299,10 @@ mv /var/log/clickhouse-server/clickhouse-server.log /var/log/clickhouse-server/c
 # NOTE Disable thread fuzzer before server start with data after stress test.
 # In debug build it can take a lot of time.
 unset "${!THREAD_@}"
-# Also disable cannot_allocate_thread_fault_injection_probability, since this
-# will not allow to load tables asynchronously. Anyway the stress tests was
-# running with fault injection.
-rm /etc/clickhouse-server/config.d/cannot_allocate_thread_injection.xml
+# Disable cannot_allocate_thread_fault_injection_probability so the post-stress
+# restart can load tables asynchronously. `-f` covers the case where the smoke
+# check aborted before stress.py installed the symlink.
+rm -f /etc/clickhouse-server/config.d/cannot_allocate_thread_injection.xml
 rm -f /etc/clickhouse-server/config.d/fail_points_active.xml
 
 # Use a larger timeout for the post-stress restart: under sanitizers with


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/96844
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not required, CI infrastructure fix.


### Description

The stress smoke check runs `CREATE DATABASE ... ON CLUSTER`. With thread-pool fault injection enabled before the server starts, it could hit `CANNOT_SCHEDULE_TASK` while the Replicated database loaded; the server then broke the chunked HTTP response and the whole stress job aborted (a chronic ~weekly flake across unrelated PRs).

`stress_runner.sh` no longer exports `THREAD_POOL_FAULT_INJECTION` before the server starts. `stress.py` installs the config and reloads it only after the smoke check passes, then verifies `cannot_allocate_thread_fault_injection_probability` is non-zero (fail-close). The upgrade check keeps running without it.

Related: #96844

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.674`
<!-- ch-version-info:end -->