### PR TITLE
Reject `ATTACH TABLE` with storage clauses but no `ENGINE`

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1567,6 +1567,21 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
 
     DDLGuardPtr ddl_guard;
 
+    /// `ATTACH TABLE name <storage clauses>;` without `ENGINE` and without a columns list is ambiguous:
+    /// the parser allows `SETTINGS`, `ORDER BY`, `PARTITION BY`, etc. without an `ENGINE` (to support
+    /// `default_table_engine` on CREATE), but the short ATTACH path below reads the full table definition
+    /// from stored metadata and silently overwrites anything the user typed. Surface this as an error so
+    /// users do not assume their settings or storage clauses took effect.
+    if (create.attach && create.storage && !create.storage->engine && !create.columns_list)
+    {
+        throw Exception(ErrorCodes::BAD_ARGUMENTS,
+            "ATTACH TABLE without ENGINE cannot specify storage clauses (SETTINGS, ORDER BY, PARTITION BY, etc.) — "
+            "they would be silently ignored because the table definition is read from stored metadata. "
+            "Use 'ATTACH TABLE {0};' to re-attach with stored metadata, "
+            "or 'ALTER TABLE {0} MODIFY SETTING ...' (or 'MODIFY ORDER BY ...') after ATTACH to change settings.",
+            backQuoteIfNeed(create.getTable()));
+    }
+
     // If this is a stub ATTACH query, read the query definition from the database
     if (create.attach && (!create.storage || !create.storage->engine) && !create.columns_list)
     {

--- a/tests/queries/0_stateless/04237_attach_table_settings_without_engine_error.reference
+++ b/tests/queries/0_stateless/04237_attach_table_settings_without_engine_error.reference
@@ -1,0 +1,1 @@
+MergeTree ORDER BY id SETTINGS index_granularity = 8192

--- a/tests/queries/0_stateless/04237_attach_table_settings_without_engine_error.sql
+++ b/tests/queries/0_stateless/04237_attach_table_settings_without_engine_error.sql
@@ -1,0 +1,30 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/104791
+--
+-- `ATTACH TABLE name <storage clauses>;` without `ENGINE` and without a columns list
+-- used to silently drop the user-provided storage clauses, because the short ATTACH
+-- path reads the table definition from stored metadata and overwrites anything the
+-- user typed. The parser allows `SETTINGS`, `ORDER BY`, `PARTITION BY`, etc. without
+-- an `ENGINE` to support `default_table_engine` on CREATE, but for ATTACH the same
+-- syntax produced no error and no effect — users assumed their settings took effect.
+-- We now reject this with `BAD_ARGUMENTS` so the user notices.
+
+SET default_table_engine = 'MergeTree';
+
+DROP TABLE IF EXISTS t_104791;
+CREATE TABLE t_104791 (id UInt32) ORDER BY id;
+
+-- 1. SETTINGS without ENGINE: should error (the original bug from the issue).
+DETACH TABLE t_104791;
+ATTACH TABLE t_104791 SETTINGS max_part_loading_threads = 16; -- { serverError BAD_ARGUMENTS }
+
+-- 2. ORDER BY without ENGINE: same bug class, same fix.
+ATTACH TABLE t_104791 ORDER BY id; -- { serverError BAD_ARGUMENTS }
+
+-- 3. PARTITION BY without ENGINE: same.
+ATTACH TABLE t_104791 PARTITION BY id; -- { serverError BAD_ARGUMENTS }
+
+-- 4. Short ATTACH (no storage clauses at all): must still work.
+ATTACH TABLE t_104791;
+SELECT engine_full FROM system.tables WHERE database = currentDatabase() AND name = 't_104791';
+
+DROP TABLE t_104791;


### PR DESCRIPTION
Fixes #104791. Reported by @clickgapai during automated review of merged PR #73120; @zlareb1 flagged it for fix.

## Motivation

`ATTACH TABLE name SETTINGS k = v;` (and the same with `ORDER BY`, `PARTITION BY`, etc.) without an explicit `ENGINE` would be parsed and then silently routed through the short-`ATTACH` path that reads the table definition from stored metadata, overwriting the user's input. Users saw no error and assumed their settings took effect.

Reproducer (from the issue):

```sql
SET default_table_engine = 'MergeTree';
CREATE TABLE t (id UInt32) ORDER BY id;
DETACH TABLE t;
ATTACH TABLE t SETTINGS max_part_loading_threads = 16;

SELECT engine_full FROM system.tables WHERE name = 't';
-- Expected: SETTINGS contains max_part_loading_threads = 16
-- Actual:   only the original index_granularity = 8192
```

## Root cause

`ParserCreateQuery.cpp:697` allows `SETTINGS` without `ENGINE` for tables in order to support `default_table_engine` on `CREATE`. For `ATTACH` the same syntax produced an `ASTStorage` with settings but no engine, which made the short-`ATTACH` detection at `InterpreterCreateQuery.cpp:1571` (`!create.storage->engine`) match and discard the user's clauses while reading the full stored definition. The other non-engine storage clauses (`PARTITION BY`, `PRIMARY KEY`, `ORDER BY`, `SAMPLE BY`, `TTL`, `UNIQUE KEY`) have the same shape and the same bug.

## Fix

Reject the ambiguous case before entering the short-`ATTACH` branch. When the user provided storage clauses without an `ENGINE` and no columns list, throw `BAD_ARGUMENTS` and point them at the short form (`ATTACH TABLE t;`) or `ALTER TABLE` for changing settings after attach.

The check fires before `ON CLUSTER` forwarding and before Replicated-database query enqueue, so distributed `ATTACH ... SETTINGS` is rejected at the initiator instead of silently dropping on each replica.

## Tests

Added `tests/queries/0_stateless/04237_attach_table_settings_without_engine_error.sql` covering:
- `ATTACH TABLE t SETTINGS k = v;` — `BAD_ARGUMENTS`
- `ATTACH TABLE t ORDER BY id;` — `BAD_ARGUMENTS`
- `ATTACH TABLE t PARTITION BY id;` — `BAD_ARGUMENTS`
- `ATTACH TABLE t;` — still works (positive control)

Verified locally with the debug build that the bug reproduces without the fix and is rejected with `BAD_ARGUMENTS` with the fix.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`ATTACH TABLE name <storage clauses>;` without an `ENGINE` and without a columns list (e.g. `ATTACH TABLE t SETTINGS max_part_loading_threads = 16;` or `ATTACH TABLE t ORDER BY id;`) used to silently ignore the user-provided storage clauses and re-attach the table with its stored definition. Now this is rejected with `BAD_ARGUMENTS` so users can notice and use the short form `ATTACH TABLE t;` or `ALTER TABLE ... MODIFY SETTING` instead.


### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!---
Session: cron:clickhouse-ci-task-worker:20260513-071500
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.668`
<!-- ch-version-info:end -->