### PR TITLE
Capture jstack/UC liveness diagnostics on Spark hang in test_database_delta

### DIFF
--- a/tests/integration/test_database_delta/test.py
+++ b/tests/integration/test_database_delta/test.py
@@ -108,12 +108,24 @@ def _capture_spark_hang_diagnostics(node):
     """
     # 1. Thread dumps of running Spark JVMs.
     try:
+        # `[o]rg.apache.spark` is a character-class trick: it matches the
+        # literal string `org.apache.spark` (because `[o]` matches `o`) but
+        # the regex itself does NOT contain that string, so `pgrep` will
+        # not match its own command line (`pgrep -f '[o]rg.apache.spark'`).
+        # Without this, on shards where no Spark JVM is left the `bash -c`
+        # wrapper's own cmdline can match and `jstack` then runs against
+        # an unrelated shell PID.
         pids_out = node.exec_in_container(
-            ["bash", "-c", "pgrep -f 'org.apache.spark' || true"],
+            ["bash", "-c", "pgrep -f '[o]rg.apache.spark' || true"],
             nothrow=True,
             timeout=30,
         )
         pids = [p.strip() for p in (pids_out or "").splitlines() if p.strip()]
+        # Cap the number of jstack-ed PIDs at 3 so a hang affecting both
+        # the driver and several executors does not consume 30s per PID
+        # before the test fails. In practice there is one driver JVM per
+        # query; the cap is a belt for the pathological case.
+        pids = pids[:3]
         if not pids:
             print(
                 "Spark hang diag: no running 'org.apache.spark' processes"

--- a/tests/integration/test_database_delta/test.py
+++ b/tests/integration/test_database_delta/test.py
@@ -174,20 +174,29 @@ def _capture_spark_hang_diagnostics(node):
 
     # 3. Socket state snapshot for UC port and Java connections.
     try:
-        # `set -o pipefail` is required so the pipeline's exit code reflects
-        # `ss`'s status, not `head`'s (which is always 0 once any bytes
-        # flow). Without it, the `|| echo ' no_matching_sockets'` sentinel
-        # is unreachable. `grep -E ... || true` swallows the exit-1 that
-        # `grep` produces on no matches, so the sentinel fires only when
-        # `ss` itself fails — which is the intended fallback semantics.
+        # Capture `ss`'s output into a shell variable first, then filter and
+        # truncate from that variable. Checking `ss`'s exit status directly
+        # (via the `if` test on the assignment) avoids the trap of the
+        # earlier `ss | grep | head || sentinel` pipeline: with
+        # `set -o pipefail` enabled, `head -50` closing the pipe early on
+        # outputs longer than 50 lines caused upstream commands to receive
+        # `SIGPIPE`, which made the pipeline status non-zero and falsely
+        # triggered the ` no_matching_sockets` sentinel; without `pipefail`,
+        # the sentinel was unreachable because `head`'s exit code (always
+        # 0 once any bytes flow) masked `ss`'s. Decoupling capture from
+        # truncation breaks both horns of that dilemma. `grep -E ... ||
+        # true` keeps the no-match case from producing an `exit 1` that
+        # would print confusing output, but plays no role in detecting
+        # `ss` failure.
         sockets = node.exec_in_container(
             [
                 "bash",
                 "-c",
-                "set -o pipefail;"
-                " ss -tnp 2>&1 | { grep -E ':8080|java' || true; }"
-                " | head -50"
-                " || echo ' no_matching_sockets'",
+                'if ss_output=$(ss -tnp 2>&1); then '
+                'echo "$ss_output" | { grep -E ":8080|java" || true; } | head -50; '
+                'else '
+                "echo ' no_matching_sockets'; "
+                'fi',
             ],
             nothrow=True,
             timeout=15,

--- a/tests/integration/test_database_delta/test.py
+++ b/tests/integration/test_database_delta/test.py
@@ -121,14 +121,17 @@ def _capture_spark_hang_diagnostics(node):
             )
         for pid in pids:
             try:
-                # Prefer non-force jstack; fall back to ``-F`` if the JVM is
-                # unresponsive to the attach mechanism.
+                # Prefer non-force `jstack`; fall back to `-F` if the JVM is
+                # unresponsive to the attach mechanism. The fallback must
+                # happen BEFORE `head` truncates, otherwise `head`'s exit
+                # code (always 0 once any bytes flow) masks `jstack`'s and
+                # the `||` branch never fires.
                 dump = node.exec_in_container(
                     [
                         "bash",
                         "-c",
-                        f"jstack {pid} 2>&1 | head -500"
-                        f" || jstack -F {pid} 2>&1 | head -500",
+                        f"(jstack {pid} 2>&1 || jstack -F {pid} 2>&1)"
+                        f" | head -500",
                     ],
                     nothrow=True,
                     timeout=30,
@@ -159,11 +162,19 @@ def _capture_spark_hang_diagnostics(node):
 
     # 3. Socket state snapshot for UC port and Java connections.
     try:
+        # `set -o pipefail` is required so the pipeline's exit code reflects
+        # `ss`'s status, not `head`'s (which is always 0 once any bytes
+        # flow). Without it, the `|| echo ' no_matching_sockets'` sentinel
+        # is unreachable. `grep -E ... || true` swallows the exit-1 that
+        # `grep` produces on no matches, so the sentinel fires only when
+        # `ss` itself fails — which is the intended fallback semantics.
         sockets = node.exec_in_container(
             [
                 "bash",
                 "-c",
-                "ss -tnp 2>&1 | grep -E ':8080|java' | head -50"
+                "set -o pipefail;"
+                " ss -tnp 2>&1 | { grep -E ':8080|java' || true; }"
+                " | head -50"
                 " || echo ' no_matching_sockets'",
             ],
             nothrow=True,

--- a/tests/integration/test_database_delta/test.py
+++ b/tests/integration/test_database_delta/test.py
@@ -84,6 +84,96 @@ def started_cluster():
         cluster.shutdown()
 
 
+def _capture_spark_hang_diagnostics(node):
+    """
+    Capture diagnostic data when a Spark query times out or otherwise fails
+    unexpectedly. Each capture is wrapped in its own ``try``/``except`` so a
+    failure in one diagnostic does not prevent collection of the others.
+
+    None of these are intended to recover the test. They only produce data
+    for post-mortem analysis of the chronic Spark hang on
+    ``Integration tests (arm_binary, distributed plan, 4/4)`` and similar
+    shards, where on ``subprocess.TimeoutExpired`` the Spark JVM is killed
+    by SIGKILL and ``stdout``/``stderr`` are typically truncated to whatever
+    Spark logged before the hang point — leaving CIDB without enough
+    information to localize the stuck thread.
+
+    Captured:
+      * ``jstack`` thread dumps of every running ``org.apache.spark`` JVM
+        (shows where the JVM is stuck)
+      * Unity Catalog HTTP liveness probe on ``http://localhost:8080``
+        (shows whether UC is responsive while Spark is hung)
+      * ``ss -tnp`` snapshot of sockets to UC port ``8080`` and ``java``
+        connections (shows whether Spark holds open sockets to UC)
+    """
+    # 1. Thread dumps of running Spark JVMs.
+    try:
+        pids_out = node.exec_in_container(
+            ["bash", "-c", "pgrep -f 'org.apache.spark' || true"],
+            nothrow=True,
+            timeout=30,
+        )
+        pids = [p.strip() for p in (pids_out or "").splitlines() if p.strip()]
+        if not pids:
+            print(
+                "Spark hang diag: no running 'org.apache.spark' processes"
+                " (already exited)"
+            )
+        for pid in pids:
+            try:
+                # Prefer non-force jstack; fall back to ``-F`` if the JVM is
+                # unresponsive to the attach mechanism.
+                dump = node.exec_in_container(
+                    [
+                        "bash",
+                        "-c",
+                        f"jstack {pid} 2>&1 | head -500"
+                        f" || jstack -F {pid} 2>&1 | head -500",
+                    ],
+                    nothrow=True,
+                    timeout=30,
+                )
+                print(f"Spark hang diag: jstack of PID {pid}:\n{dump}")
+            except Exception as je:
+                print(f"Spark hang diag: jstack PID {pid} failed: {str(je)}")
+    except Exception as e:
+        print(f"Spark hang diag: failed to enumerate Spark PIDs: {str(e)}")
+
+    # 2. Unity Catalog HTTP liveness probe.
+    try:
+        uc = node.exec_in_container(
+            [
+                "bash",
+                "-c",
+                "curl --silent --show-error --max-time 5 -o /dev/null"
+                " -w 'http_code=%{http_code} time_total=%{time_total}s'"
+                " http://localhost:8080/api/2.1/unity-catalog/schemas"
+                " || echo ' curl_failed'",
+            ],
+            nothrow=True,
+            timeout=15,
+        )
+        print(f"Spark hang diag: Unity Catalog liveness: {uc}")
+    except Exception as e:
+        print(f"Spark hang diag: UC liveness probe failed: {str(e)}")
+
+    # 3. Socket state snapshot for UC port and Java connections.
+    try:
+        sockets = node.exec_in_container(
+            [
+                "bash",
+                "-c",
+                "ss -tnp 2>&1 | grep -E ':8080|java' | head -50"
+                " || echo ' no_matching_sockets'",
+            ],
+            nothrow=True,
+            timeout=15,
+        )
+        print(f"Spark hang diag: socket state for UC port:\n{sockets}")
+    except Exception as e:
+        print(f"Spark hang diag: ss snapshot failed: {str(e)}")
+
+
 def execute_spark_query(node, query_text):
     # Kill any lingering Spark processes and remove the Derby metastore
     # before starting a new Spark session. The metastore_db is created inside
@@ -148,6 +238,12 @@ def execute_spark_query(node, query_text):
             print("Last 50 lines of UC log:\n", logs)
         except Exception as log_e:
             print(f"Cannot read log file: {str(log_e)}")
+
+        # Capture extra diagnostics that are only useful when the Spark JVM
+        # hangs (timeout case) — thread dumps, UC liveness, socket state.
+        # These run after the existing log capture so the legacy diagnostics
+        # remain at the same position in CI output.
+        _capture_spark_hang_diagnostics(node)
 
         raise
 


### PR DESCRIPTION
The chronic flaky test `test_database_delta::test_check_database_unity` times out on `Integration tests (arm_binary, distributed plan, 4/4)` when the Spark JVM hangs between Hive metastore initialization and actual query execution. PR #102649 (merged 2026-04-14) batched 7 sequential Spark invocations into one, dropping the failure rate to 2 master hits in 30 days, but a residual hang remains and we currently have no data to localize it.

When `subprocess.TimeoutExpired` fires inside `execute_spark_query`, the Spark JVM is killed by SIGKILL so its `stdout`/`stderr` are truncated to whatever it logged before the hang point, and the existing `uc.log` tail is not enough to tell us where the JVM is stuck. CIDB rows for the failing master shards (`2a00d99d`, `2f0c1004` — 2026-05-11) consistently stop at `ObjectStore.setMetaStoreSchemaVersion`, which is the last metastore-init log line. We do not know whether Spark is then blocked on a Unity Catalog HTTP call, on a Derby file lock, or somewhere else entirely.

This PR adds a `_capture_spark_hang_diagnostics` helper that runs after the existing log capture in the exception handler of `execute_spark_query` and collects three pieces of state from inside the test container:

1. `jstack` thread dump of every running `org.apache.spark` JVM — shows exactly where the JVM is stuck during the hang.
2. Unity Catalog HTTP liveness probe on `http://localhost:8080/api/2.1/unity-catalog/schemas` — shows whether UC is responsive while Spark is hung.
3. `ss -tnp` snapshot of sockets matching `:8080` or `java` — shows whether Spark holds open sockets to UC at the moment of the hang.

Each diagnostic is wrapped in its own `try`/`except` so a failure in one does not prevent collection of the others, and all `exec_in_container` calls use short timeouts (15–30 s) so the diagnostics cannot meaningfully extend the test failure time. The helper runs only on the already-failing path so it cannot make a passing test fail. All three tools (`jstack`, `curl`, `ss`) are present in the `clickhouse/integration-test-with-unity-catalog:latest` image used by the test fixture (verified by `docker run --entrypoint /bin/bash ... -c 'which jstack curl ss'`).

This is diagnostic-only — it does not fix the residual hang. The data it captures will let the next master hit be localized to a specific stuck thread or UC RPC instead of "Spark stopped logging".

Sample failure (master): https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=2a00d99de694fda4302148265b75a9d42ae878fa&name_0=MasterCI

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is unchanged (no user-facing behavior change).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.648`
<!-- ch-version-info:end -->