### PR TITLE
[CI Proof] `getRequiredAccessForDDLOnCluster` checks wrong permission for `PREWARM_PRIMARY_INDEX_CACHE`

### DIFF
--- a/tests/integration/test_prewarm_primary_index_access/configs/config.d/clusters.xml
+++ b/tests/integration/test_prewarm_primary_index_access/configs/config.d/clusters.xml
@@ -1,0 +1,12 @@
+<clickhouse>
+<remote_servers>
+    <test_cluster>
+        <shard>
+            <replica>
+                <host>node1</host>
+                <port>9000</port>
+            </replica>
+        </shard>
+    </test_cluster>
+</remote_servers>
+</clickhouse>

--- a/tests/integration/test_prewarm_primary_index_access/configs/users.d/users.xml
+++ b/tests/integration/test_prewarm_primary_index_access/configs/users.d/users.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <users>
+        <default>
+            <access_management>1</access_management>
+        </default>
+    </users>
+</clickhouse>

--- a/tests/integration/test_prewarm_primary_index_access/test.py
+++ b/tests/integration/test_prewarm_primary_index_access/test.py
@@ -1,0 +1,74 @@
+"""
+Proof test for bug in getRequiredAccessForDDLOnCluster: PREWARM_PRIMARY_INDEX_CACHE case
+checks AccessType::SYSTEM_PREWARM_MARK_CACHE instead of SYSTEM_PREWARM_PRIMARY_INDEX_CACHE.
+
+Bug location: InterpreterSystemQuery.cpp:2539 (copy-paste error from PREWARM_MARK_CACHE case)
+
+Test scenario:
+1. Create a user with ONLY SYSTEM_PREWARM_MARK_CACHE privilege (NOT PRIMARY_INDEX_CACHE)
+2. Try to run SYSTEM PREWARM PRIMARY INDEX CACHE ON CLUSTER as that user
+3. BUG: Access check uses SYSTEM_PREWARM_MARK_CACHE (user has it) -> passes permission check
+       -> continues execution -> BAD_ARGUMENTS (cache not configured)
+   FIXED: Access check uses SYSTEM_PREWARM_PRIMARY_INDEX_CACHE (user lacks it) -> ACCESS_DENIED
+
+Test expects ACCESS_DENIED (correct behavior after fix).
+On buggy master: passes permission check, fails with BAD_ARGUMENTS -> test FAILS
+After fix: ACCESS_DENIED -> test PASSES
+"""
+
+import pytest
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node1 = cluster.add_instance(
+    "node1",
+    main_configs=["configs/config.d/clusters.xml"],
+    user_configs=["configs/users.d/users.xml"],
+    with_zookeeper=True,
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_prewarm_primary_index_cache_permission_on_cluster(started_cluster):
+    """
+    Test that SYSTEM PREWARM PRIMARY INDEX CACHE ON CLUSTER requires
+    SYSTEM_PREWARM_PRIMARY_INDEX_CACHE permission, not SYSTEM_PREWARM_MARK_CACHE.
+    """
+    # Cleanup any existing state
+    node1.query("DROP USER IF EXISTS test_user_prewarm")
+    node1.query("DROP TABLE IF EXISTS test_table_prewarm")
+
+    # Create test table
+    node1.query(
+        "CREATE TABLE test_table_prewarm (a UInt64) ENGINE = MergeTree ORDER BY a"
+    )
+    node1.query("INSERT INTO test_table_prewarm VALUES (1)")
+
+    # Create user with ONLY SYSTEM_PREWARM_MARK_CACHE privilege (NOT PRIMARY_INDEX_CACHE)
+    # This is the WRONG permission for PREWARM PRIMARY INDEX CACHE command
+    node1.query("CREATE USER test_user_prewarm")
+    node1.query("GRANT SYSTEM PREWARM MARK CACHE ON *.* TO test_user_prewarm")
+
+    # Try to run SYSTEM PREWARM PRIMARY INDEX CACHE ON CLUSTER as the test user
+    # Expected: ACCESS_DENIED (user lacks SYSTEM_PREWARM_PRIMARY_INDEX_CACHE)
+    # Bug behavior: Passes permission check (wrong permission checked), then fails with BAD_ARGUMENTS
+    error = node1.query_and_get_error(
+        "SYSTEM PREWARM PRIMARY INDEX CACHE ON CLUSTER test_cluster default.test_table_prewarm",
+        user="test_user_prewarm",
+    )
+
+    # Verify we get ACCESS_DENIED (correct permission check)
+    # The bug would cause BAD_ARGUMENTS instead (permission check passes, but cache not configured)
+    assert "ACCESS_DENIED" in error, f"Expected ACCESS_DENIED error, got: {error}"
+
+    # Cleanup
+    node1.query("DROP USER test_user_prewarm")
+    node1.query("DROP TABLE test_table_prewarm")


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

> ⚠️ **This is a CI proof PR — not a fix and not intended for merge.** It submits a test that could not be confirmed locally (code analysis strongly suggests a bug but local test did not trigger it — CI sanitizers and stress runs may catch it). **This PR will be closed automatically** once CI completes. If CI confirms the bug (TSan/ASan/cluster failure), a bug Issue will be filed separately.

**Suspected bug:** `getRequiredAccessForDDLOnCluster` checks wrong permission for `PREWARM_PRIMARY_INDEX_CACHE`

**Root cause:** InterpreterSystemQuery.cpp:2539: Copy-paste error from PREWARM_MARK_CACHE case directly above. The case statement uses `AccessType::SYSTEM_PREWARM_MARK_CACHE` when it should use `AccessType::SYSTEM_PREWARM_PRIMARY_INDEX_CACHE`.

**Affected locations:**
- `src/Interpreters/InterpreterSystemQuery.cpp:2539` — getRequiredAccessForDDLOnCluster() switch case for PREWARM_PRIMARY_INDEX_CACHE

**Why CI is needed:** Users with only SYSTEM_PREWARM_PRIMARY_INDEX_CACHE grant cannot execute ON CLUSTER prewarm commands (access denied). Users with only SYSTEM_PREWARM_MARK_CACHE can execute ON CLUSTER primary index prewarm commands (unauthorized access).

**Suggested fix:** Change `AccessType::SYSTEM_PREWARM_MARK_CACHE` to `AccessType::SYSTEM_PREWARM_PRIMARY_INDEX_CACHE` at line 2539

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — temporary CI proof PR, will be closed automatically.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
