### PR TITLE
CI: expose createdAt for Copilot review thread comments

### DIFF
--- a/ci/jobs/copilot_review_job.py
+++ b/ci/jobs/copilot_review_job.py
@@ -97,7 +97,7 @@ Tools:
 - Fetch inline review threads with:
   `{GH_PREFIX} python3 -m ci.praktika.gh list-pr-review-threads --pr {pr_number} --repo {repo_name}`.
   The command returns JSON; each thread carries its node `id`, `isResolved`, `path`, `line`, and
-  `comments.nodes` with author, body, and `databaseId`.
+  `comments.nodes` with author, body, `databaseId`, and `createdAt`.
 - Fetch top-level conversation with:
   `{GH_PREFIX} gh api '/repos/{repo_name}/issues/{pr_number}/comments' --paginate`.
 - Reply on an existing thread with:
@@ -126,8 +126,8 @@ Procedure:
    and line, not by trusting the author's reply.
 6. For existing live threads, summarize the issue by default instead of replying on the thread. Reply
    only when the thread is marked as resolved, someone replied saying it is not an issue and you
-   believe it still is, or your last comment is older than two days. When replying, restate the concern
-   with the relevant code and explain why the previous answer does not resolve it.
+   believe it still is, or your last comment's `createdAt` is older than two days. When replying,
+   restate the concern with the relevant code and explain why the previous answer does not resolve it.
 7. Resolve or re-open only threads you created yourself: that means threads where the first comment in
    `comments.nodes` was authored by `clickhouse-gh[bot]`. If a bot-authored thread is open and the issue
    no longer holds in the current code, resolve it. If a bot-authored thread was resolved but the

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -341,7 +341,8 @@ class GH:
         Each thread carries its node ``id`` (the value to pass to the
         resolve/unresolve mutations), ``isResolved``, ``isOutdated``,
         ``path``, ``line``, and the full list of comments under it (with
-        ``databaseId`` for use as ``in_reply_to`` when replying). Both
+        ``databaseId`` for use as ``in_reply_to`` when replying, and
+        ``createdAt`` for per-comment timestamps). Both
         the thread list and each thread's comments are paginated, so
         long PRs do not silently truncate. Raises ``RuntimeError`` on
         any transport / parse failure: a failure to read prior
@@ -362,7 +363,7 @@ class GH:
             "nodes{id isResolved isOutdated path line "
             "comments(first:50){"
             "pageInfo{hasNextPage endCursor}"
-            "nodes{databaseId author{login} body path line originalLine}"
+            "nodes{databaseId createdAt author{login} body path line originalLine}"
             "}}}}}}"
         )
         comments_query = (
@@ -370,7 +371,7 @@ class GH:
             "node(id:$id){... on PullRequestReviewThread{"
             "comments(first:50,after:$after){"
             "pageInfo{hasNextPage endCursor}"
-            "nodes{databaseId author{login} body path line originalLine}"
+            "nodes{databaseId createdAt author{login} body path line originalLine}"
             "}}}}"
         )
 


### PR DESCRIPTION
Expose per-comment `createdAt` in `list_pr_review_threads` so `copilot_review_job.py` can tell whether the bot's last comment in a thread is older than two days. The prompt now explicitly references using that field for the existing throttling guidance.

This addresses the repeated bot review pattern seen in https://github.com/ClickHouse/ClickHouse/pull/104718#pullrequestreview-4275220488.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not for changelog.

### Documentation entry:
- [x] Documentation is not required

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.613`
<!-- ch-version-info:end -->