### PR TITLE
[CI Proof] `RestorerFromBackup::createTable` uses non-existent setting names causing RESTORE to fail

### DIFF
--- a/tests/integration/test_restore_unknown_setting_bug/configs/backups_disk.xml
+++ b/tests/integration/test_restore_unknown_setting_bug/configs/backups_disk.xml
@@ -1,0 +1,13 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <backups>
+                <type>local</type>
+                <path>/backups/</path>
+            </backups>
+        </disks>
+    </storage_configuration>
+    <backups>
+        <allowed_disk>backups</allowed_disk>
+    </backups>
+</clickhouse>

--- a/tests/integration/test_restore_unknown_setting_bug/configs/zookeeper_retries.xml
+++ b/tests/integration/test_restore_unknown_setting_bug/configs/zookeeper_retries.xml
@@ -1,0 +1,9 @@
+<clickhouse>
+    <profiles>
+        <default>
+            <backup_restore_keeper_max_retries>5</backup_restore_keeper_max_retries>
+            <backup_restore_keeper_retry_initial_backoff_ms>100</backup_restore_keeper_retry_initial_backoff_ms>
+            <backup_restore_keeper_retry_max_backoff_ms>1000</backup_restore_keeper_retry_max_backoff_ms>
+        </default>
+    </profiles>
+</clickhouse>

--- a/tests/integration/test_restore_unknown_setting_bug/test.py
+++ b/tests/integration/test_restore_unknown_setting_bug/test.py
@@ -15,6 +15,7 @@ restores it. On buggy code, the RESTORE fails with UNKNOWN_SETTING error.
 After the fix, RESTORE succeeds.
 """
 
+import uuid
 import pytest
 
 from helpers.cluster import ClickHouseCluster
@@ -67,8 +68,9 @@ def test_restore_replicated_table_uses_correct_keeper_settings(started_cluster):
     )
     node.query("INSERT INTO test_tbl VALUES (1, 'a'), (2, 'b'), (3, 'c')")
 
-    # Backup the table
-    backup_name = "Disk('backups', 'test_restore_setting_bug/')"
+    # Backup the table - use UUID to ensure unique backup name per run
+    backup_id = uuid.uuid4().hex
+    backup_name = f"Disk('backups', 'test_restore_setting_bug_{backup_id}/')"
     node.query(f"BACKUP TABLE test_tbl TO {backup_name}")
 
     # Drop the table

--- a/tests/integration/test_restore_unknown_setting_bug/test.py
+++ b/tests/integration/test_restore_unknown_setting_bug/test.py
@@ -1,0 +1,84 @@
+"""
+Proof test for bug: RestorerFromBackup::createTable uses non-existent setting names
+causing RESTORE to fail with UNKNOWN_SETTING error.
+
+The bug is at src/Backups/RestorerFromBackup.cpp:779-780:
+  create_query_context->setSetting("keeper_initial_backoff_ms", ...);  // WRONG
+  create_query_context->setSetting("keeper_max_backoff_ms", ...);      // WRONG
+
+Correct setting names are:
+  keeper_retry_initial_backoff_ms
+  keeper_retry_max_backoff_ms
+
+This test creates a ReplicatedMergeTree table, backs it up, drops it, and
+restores it. On buggy code, the RESTORE fails with UNKNOWN_SETTING error.
+After the fix, RESTORE succeeds.
+"""
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node1",
+    main_configs=["configs/backups_disk.xml"],
+    user_configs=["configs/zookeeper_retries.xml"],
+    external_dirs=["/backups/"],
+    macros={"replica": "node1", "shard": "shard1"},
+    with_zookeeper=True,
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def cleanup_after_test():
+    """Ensure cleanup happens even if test fails."""
+    try:
+        yield
+    finally:
+        node.query("DROP TABLE IF EXISTS test_tbl SYNC")
+
+
+def test_restore_replicated_table_uses_correct_keeper_settings(started_cluster):
+    """
+    This test exposes PR #72682 bug: wrong setting names in RestorerFromBackup.
+
+    On buggy code: RESTORE fails with "Unknown setting 'keeper_initial_backoff_ms'"
+    After fix: RESTORE succeeds.
+    """
+    # Cleanup from any previous runs
+    node.query("DROP TABLE IF EXISTS test_tbl SYNC")
+
+    # Create ReplicatedMergeTree table with data
+    node.query(
+        "CREATE TABLE test_tbl (x UInt32, y String) "
+        "ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/test_restore_setting_bug_tbl', '{replica}') "
+        "ORDER BY x"
+    )
+    node.query("INSERT INTO test_tbl VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+
+    # Backup the table
+    backup_name = "Disk('backups', 'test_restore_setting_bug/')"
+    node.query(f"BACKUP TABLE test_tbl TO {backup_name}")
+
+    # Drop the table
+    node.query("DROP TABLE test_tbl SYNC")
+
+    # RESTORE the table - this fails on buggy code with:
+    # Code: 115. DB::Exception: Unknown setting 'keeper_initial_backoff_ms'
+    # After fix, this should succeed
+    node.query(f"RESTORE TABLE test_tbl FROM {backup_name}")
+
+    # Verify data is restored correctly
+    result = node.query("SELECT * FROM test_tbl ORDER BY x")
+    assert result.strip() == "1\ta\n2\tb\n3\tc"


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

> ⚠️ **This is a CI proof PR — not a fix and not intended for merge.** It submits a test that could not be confirmed locally (requires CI cluster topology or too many iterations to reproduce locally). **This PR will be closed automatically** once CI completes. If CI confirms the bug (TSan/ASan/cluster failure), a bug Issue will be filed separately.

**Suspected bug:** `RestorerFromBackup::createTable` uses non-existent setting names causing RESTORE to fail

**Root cause:** src/Backups/RestorerFromBackup.cpp:779-780: The code uses `keeper_initial_backoff_ms` instead of `keeper_retry_initial_backoff_ms` and `keeper_max_backoff_ms` instead of `keeper_retry_max_backoff_ms`

**Affected locations:**
- `src/Backups/RestorerFromBackup.cpp:779` — setSetting with wrong setting name
- `src/Backups/RestorerFromBackup.cpp:780` — setSetting with wrong setting name

**Why CI is needed:** All RESTORE TABLE operations fail with Code: 115 UNKNOWN_SETTING exception. Users cannot restore tables from backups.

**Suggested fix:** Change line 779 to use `keeper_retry_initial_backoff_ms` and line 780 to use `keeper_retry_max_backoff_ms`

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — temporary CI proof PR, will be closed automatically.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
