### PR TITLE
Minimize macOS user_data, delegate provisioning to runner-init

### DIFF
--- a/ci/infra/scripts/user_data_macos.txt
+++ b/ci/infra/scripts/user_data_macos.txt
@@ -1,138 +1,16 @@
 #!/usr/bin/env bash
-# Script to prepare a clean macOS machine as a GitHub Actions runner
-# Based on prepare-ci-ami.sh but adapted for macOS
+# Bootstrap script for macOS GitHub Actions runners.
+# Provisioning (Homebrew, Python venv, CloudWatch agent, actions-runner install, etc.)
+# lives in the runner-init script fetched from S3 — macOS EC2 user_data cannot be
+# updated after launch, so we keep this file minimal.
 
 set -xeuo pipefail
 trap reboot EXIT
 
-echo "Running macOS runner prepare script"
-
-# Set HOME if not already set (EC2 user_data context may not have it)
 export HOME="${HOME:-/Users/ec2-user}"
-cd $HOME
+cd "$HOME"
 
-# If running as root, run brew/pip commands as ec2-user
-export USER="${SUDO_USER:-$(whoami)}"
-if [ "$EUID" -eq 0 ]; then
-  export USER="ec2-user"
-fi
-
-runner_arch() {
-  case $(uname -m) in
-    x86_64 )
-      echo x64;;
-    arm64 )
-      echo arm64;;
-  esac
-}
-
-cloudwatch_arch() {
-  case $(uname -m) in
-    x86_64 )
-      echo amd64;;
-    arm64 )
-      echo arm64;;
-  esac
-}
-
-export RUNNER_HOME="${HOME}/actions-runner"
-
-# Check if already installed - if success marker exists, skip to cloud-init
-if [ -f /tmp/clickhouse-ci-macos-runner.success ]; then
-  echo "Success marker found - skipping installation steps"
-  echo "Jumping directly to cloud-init..."
-else
-  echo "No success marker found - proceeding with installation"
-
-  # Disable greedy system service
-  launchctl disable system/com.apple.bluetoothd
-
-  # Install Homebrew if not already installed
-  if ! sudo -u "$USER" -i command -v brew &> /dev/null; then
-    echo "Installing Homebrew..."
-    sudo -u "$USER" -i bash -c 'NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
-
-    # Add Homebrew to PATH for Apple Silicon Macs
-    if [[ $(uname -m) == "arm64" ]]; then
-      sudo -u "$USER" -i bash -c "echo 'eval \"\$(/opt/homebrew/bin/brew shellenv)\"' >> ~/.zprofile"
-    fi
-  else
-    echo "Homebrew already installed"
-    sudo -u "$USER" -i brew update
-  fi
-
-  # Install essential tools
-  echo "Installing essential tools..."
-  sudo -u "$USER" -i brew install \
-    ca-certificates \
-    curl \
-    gh \
-    jq \
-    pigz \
-    ripgrep \
-    zstd \
-    python@3 \
-    wget \
-    unzip \
-    gnu-sed \
-    grep \
-    bash \
-    coreutils
-
-  # Install Python packages into a virtual environment using Homebrew Python
-  echo "Installing Python packages into venv..."
-  sudo -u "$USER" -i bash -c '$(brew --prefix python@3)/bin/python3 -m venv ~/venv && ~/venv/bin/pip install boto3 pygithub requests urllib3 unidiff dohq-artifactory pyjwt'
-
-  # Add venv/bin and GNU tools to PATH for both bash and zsh login shells
-  GNU_COREUTILS_BIN=$(sudo -u "$USER" -i brew --prefix coreutils)/libexec/gnubin
-  GNU_SED_BIN=$(sudo -u "$USER" -i brew --prefix gnu-sed)/libexec/gnubin
-  GNU_GREP_BIN=$(sudo -u "$USER" -i brew --prefix grep)/libexec/gnubin
-  sudo -u "$USER" -i bash -c "echo 'export PATH=\"\$HOME/venv/bin:${GNU_COREUTILS_BIN}:${GNU_SED_BIN}:${GNU_GREP_BIN}:\$PATH\"' >> ~/.bash_profile"
-  sudo -u "$USER" -i bash -c "echo 'export PATH=\"\$HOME/venv/bin:${GNU_COREUTILS_BIN}:${GNU_SED_BIN}:${GNU_GREP_BIN}:\$PATH\"' >> ~/.zprofile"
-
-  # Download and install CloudWatch agent
-  echo "Installing Amazon CloudWatch agent..."
-  CLOUDWATCH_ARCH=$(cloudwatch_arch)
-  wget --directory-prefix=/tmp "https://s3.amazonaws.com/amazoncloudwatch-agent/darwin/${CLOUDWATCH_ARCH}/latest/amazon-cloudwatch-agent.pkg"
-  sudo installer -pkg /tmp/amazon-cloudwatch-agent.pkg -target /
-
-  # Download and configure CloudWatch agent config, replacing Linux log path with macOS equivalent
-  aws ssm get-parameter --region us-east-1 --name AmazonCloudWatch-github-runners --query 'Parameter.Value' --output text \
-    | jq 'walk(if type == "object" and .file_path == "/var/log/cloud-init-output.log" then .file_path = "/var/log/amazon/ec2/ec2-macos-init.log" else . end)' \
-    | sudo tee /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json > /dev/null
-
-  # Start CloudWatch agent service
-  sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
-    -a fetch-config \
-    -m ec2 \
-    -s \
-    -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
-
-  # Download and install GitHub Actions runner
-  export RUNNER_VERSION=$(curl -fsSL "https://api.github.com/repos/actions/runner/releases/latest" | jq -r '.tag_name | ltrimstr("v")')
-  echo "Installing GitHub Actions runner..."
-  rm -rf "$RUNNER_HOME"  # if it's a reinstall
-  mkdir -p "$RUNNER_HOME" && cd "$RUNNER_HOME"
-
-  RUNNER_ARCHIVE="actions-runner-osx-$(runner_arch)-$RUNNER_VERSION.tar.gz"
-
-  curl -O -L "https://github.com/actions/runner/releases/download/v$RUNNER_VERSION/$RUNNER_ARCHIVE"
-
-  tar xzf "./$RUNNER_ARCHIVE"
-  rm -f "./$RUNNER_ARCHIVE"
-
-  # Note: installdependencies.sh is Linux-only, macOS dependencies are handled via Homebrew above
-
-  echo "GitHub Actions runner installed at: $RUNNER_HOME"
-  echo "See https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/adding-self-hosted-runners for configuration instructions."
-
-  # Create a success marker
-  touch /tmp/clickhouse-ci-macos-runner.success
-  echo "Setup completed successfully!"
-fi
-
-# Download and execute cloud-init script
 INIT_ENVIRONMENT=${INIT_ENVIRONMENT:-macos}
 aws s3 cp "s3://github-runners-data/cloud-init/${INIT_ENVIRONMENT}.py" /tmp/runner-init.py
-rm -rf "$RUNNER_HOME/_work"
+rm -rf "$HOME/actions-runner/_work"
 sudo -u ec2-user -i bash -c "/Users/ec2-user/venv/bin/python /tmp/runner-init.py --environment \"$INIT_ENVIRONMENT\""


### PR DESCRIPTION
## Motivation

macOS EC2 instances do not support updating `user_data` the way Linux instances do — once an instance is launched, its `user_data` is effectively frozen. Anything placed in `ci/infra/scripts/user_data_macos.txt` therefore cannot be iterated on without rebuilding the AMI or relaunching the instance, which makes the macOS runner setup painful to evolve.

## Change

Strip `user_data_macos.txt` down to a minimal bootstrap: set `HOME`, fetch the runner-init script from `s3://github-runners-data/cloud-init/${INIT_ENVIRONMENT}.py`, clean the runner work directory, and exec the script as `ec2-user`.

The following one-time setup is **removed** from `user_data` and will be moved into the S3-hosted runner-init script (which can be updated by simply re-uploading to S3, without touching live AMIs):

- Disabling `com.apple.bluetoothd`
- Homebrew install + update
- `brew install` of `ca-certificates`, `curl`, `gh`, `jq`, `pigz`, `ripgrep`, `zstd`, `python@3`, `wget`, `unzip`, `gnu-sed`, `grep`, `bash`, `coreutils`
- Python venv at `~/venv` with `boto3`, `pygithub`, `requests`, `urllib3`, `unidiff`, `dohq-artifactory`, `pyjwt`
- `PATH` setup in `~/.bash_profile` and `~/.zprofile`
- Amazon CloudWatch agent install + configuration (fetched from SSM, log path patched to `/var/log/amazon/ec2/ec2-macos-init.log`)
- GitHub Actions runner download and unpack
- `/tmp/clickhouse-ci-macos-runner.success` marker gating

After this change, the user_data path is short enough to read at a glance, and iterating on macOS provisioning no longer requires an AMI rebuild.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.711`
<!-- ch-version-info:end -->