### PR TITLE
Fix manual setting via alias not overriding compatibility setting

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -8356,8 +8356,9 @@ void SettingsImpl::set(std::string_view name, const Field & value)
     /// we should remove it from settings_changed_by_compatibility_setting,
     /// otherwise the next time we will change compatibility setting
     /// this setting will be changed too (and we don't want it).
-    else if (settings_changed_by_compatibility_setting.contains(name))
-        settings_changed_by_compatibility_setting.erase(name);
+    /// Resolve aliases so the lookup matches the canonical names stored in the set.
+    else if (auto final_name = SettingsTraits::resolveName(name); settings_changed_by_compatibility_setting.contains(final_name))
+        settings_changed_by_compatibility_setting.erase(final_name);
 
     BaseSettings::set(name, value);
 }

--- a/tests/queries/0_stateless/04234_set_alias_compatibility_tracking.reference
+++ b/tests/queries/0_stateless/04234_set_alias_compatibility_tracking.reference
@@ -1,0 +1,3 @@
+after compat 24.1	allow_experimental_analyzer	0
+after alias set	allow_experimental_analyzer	1
+after compat 24.2	allow_experimental_analyzer	1

--- a/tests/queries/0_stateless/04234_set_alias_compatibility_tracking.sql
+++ b/tests/queries/0_stateless/04234_set_alias_compatibility_tracking.sql
@@ -1,0 +1,14 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/104568
+-- Manually changing a setting via its alias name must remove it from the
+-- compatibility-tracking set, so the next `SET compatibility=` doesn't revert it.
+
+SET compatibility = '24.1';
+SELECT 'after compat 24.1', name, value FROM system.settings WHERE name = 'allow_experimental_analyzer';
+
+-- Set the canonical setting through its alias name.
+SET enable_analyzer = 1;
+SELECT 'after alias set', name, value FROM system.settings WHERE name = 'allow_experimental_analyzer';
+
+-- Changing compatibility again must keep the manual value.
+SET compatibility = '24.2';
+SELECT 'after compat 24.2', name, value FROM system.settings WHERE name = 'allow_experimental_analyzer';


### PR DESCRIPTION
When a user sets a setting via its alias (e.g. `SET enable_analyzer = 1`)
after a compatibility setting has been applied, the entry was not being
removed from `settings_changed_by_compatibility_setting`, because that
set stores canonical names while the lookup in `SettingsImpl::set` used
the raw alias. The next `SET compatibility = '...'` then reverted the
user's manual value.

Resolve the name through `SettingsTraits::resolveName` before checking
and erasing, mirroring the fix already in `applyCompatibilitySetting`.

Closes #104568

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a bug where manually overriding a setting via its alias name (e.g. `SET enable_analyzer = 1` instead of `SET allow_experimental_analyzer = 1`) after applying a `compatibility` setting could cause that override to be reverted by a subsequent change of the `compatibility` setting.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.622`
<!-- ch-version-info:end -->