### PR TITLE
Make arrayResize honor query cancellation

### DIFF
--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -159,9 +159,10 @@ void LocalConnection::sendQuery(
     {
         /// The interactive cancel callback is now invoked from `CurrentThread::throwIfQueryCancelled`
         /// in addition to the pipeline executor's wait loop, so it can run concurrently from
-        /// multiple worker threads. Serialize the body so writes to `state->is_cancelled` and the
-        /// user-supplied `progress_callback` are race-free; `try_to_lock` skips the call entirely
-        /// when another thread is already inside the callback (it would do the same work).
+        /// multiple worker threads. Serialize the body so the user-supplied `progress_callback` is
+        /// not invoked re-entrantly; `try_to_lock` skips the call entirely when another thread is
+        /// already inside the callback (it would do the same work). `state->is_cancelled` itself
+        /// is `std::atomic<bool>`, so writes and reads from any thread are race-free regardless.
         auto callback_mutex = std::make_shared<std::mutex>();
         query_context->setInteractiveCancelCallback(
             [this, check_cancelled = is_cancelled_callback, progress_callback = process_progress_callback, callback_mutex]() -> bool

--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -1,5 +1,6 @@
 #include <Client/LocalConnection.h>
 #include <memory>
+#include <mutex>
 #include <Client/ClientBase.h>
 #include <Client/ClientApplicationBase.h>
 #include <Core/Protocol.h>
@@ -156,9 +157,19 @@ void LocalConnection::sendQuery(
 
     if (is_cancelled_callback)
     {
+        /// The interactive cancel callback is now invoked from `CurrentThread::throwIfQueryCancelled`
+        /// in addition to the pipeline executor's wait loop, so it can run concurrently from
+        /// multiple worker threads. Serialize the body so writes to `state->is_cancelled` and the
+        /// user-supplied `progress_callback` are race-free; `try_to_lock` skips the call entirely
+        /// when another thread is already inside the callback (it would do the same work).
+        auto callback_mutex = std::make_shared<std::mutex>();
         query_context->setInteractiveCancelCallback(
-            [this, check_cancelled = is_cancelled_callback, progress_callback = process_progress_callback]() -> bool
+            [this, check_cancelled = is_cancelled_callback, progress_callback = process_progress_callback, callback_mutex]() -> bool
         {
+            std::unique_lock lock(*callback_mutex, std::try_to_lock);
+            if (!lock.owns_lock())
+                return false;
+
             /// Send accumulated progress to the client so the progress bar updates during analysis.
             if (progress_callback)
             {

--- a/src/Client/LocalConnection.h
+++ b/src/Client/LocalConnection.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <Client/Connection.h>
 #include <Interpreters/Context_fwd.h>
 #include <QueryPipeline/BlockIO.h>
@@ -46,8 +47,11 @@ struct LocalQueryState
     std::shared_ptr<ColumnsDescription> columns_description;
     std::optional<ProfileInfo> profile_info;
 
-    /// Is request cancelled
-    bool is_cancelled = false;
+    /// Is request cancelled. Atomic because the interactive cancel callback can fire from
+    /// arbitrary pipeline worker threads via `CurrentThread::throwIfQueryCancelled`, while
+    /// `LocalConnection::sendCancel` and the destructor read/write this flag from the main
+    /// thread.
+    std::atomic<bool> is_cancelled{false};
     bool is_finished = false;
 
     bool sent_totals = false;

--- a/src/Common/CurrentThread.cpp
+++ b/src/Common/CurrentThread.cpp
@@ -1,8 +1,10 @@
+#include <chrono>
 #include <memory>
 
 #include <Common/CurrentThread.h>
 #include <Common/logger_useful.h>
 #include <Common/ThreadStatus.h>
+#include <Core/Settings.h>
 #include <Interpreters/ProcessList.h>
 #include <Interpreters/Context.h>
 #include <base/getThreadId.h>
@@ -11,6 +13,11 @@
 
 namespace DB
 {
+
+namespace Setting
+{
+    extern const SettingsUInt64 interactive_delay;
+}
 
 namespace ErrorCodes
 {
@@ -108,8 +115,31 @@ ContextPtr CurrentThread::tryGetQueryContext()
 void CurrentThread::throwIfQueryCancelled()
 {
     if (auto query_context = tryGetQueryContext())
+    {
+        /// Incoming cancel packets on a TCP connection are only processed when we send progress.
+        /// Slow operations (analysis steps, long function calls) don't emit intermediate progress,
+        /// so the interactive cancel callback would never fire from the executor side. Invoke it
+        /// here, throttled to at most once per `interactive_delay` per thread so we don't flood
+        /// the wire or do redundant work in tight polling loops.
+        if (auto cancel_callback = query_context->getInteractiveCancelCallback())
+        {
+            static thread_local std::chrono::steady_clock::time_point last_callback_at{};
+            const auto now = std::chrono::steady_clock::now();
+            const auto period = std::chrono::microseconds(query_context->getSettingsRef()[Setting::interactive_delay]);
+            if (now - last_callback_at >= period)
+            {
+                last_callback_at = now;
+                cancel_callback();
+            }
+        }
+
+        /// `checkTimeLimit` enforces both `is_killed` (set by KILL QUERY or by the
+        /// CancellationChecker reaching the deadline) and the elapsed-time limit directly,
+        /// so the polling site stays responsive even if the CancellationChecker thread is
+        /// slow to fire the deadline.
         if (auto query_status = query_context->getProcessListElementSafe())
-            query_status->throwIfKilled();
+            query_status->checkTimeLimit();
+    }
 }
 
 std::string_view CurrentThread::getQueryId()

--- a/src/Common/CurrentThread.cpp
+++ b/src/Common/CurrentThread.cpp
@@ -105,6 +105,13 @@ ContextPtr CurrentThread::tryGetQueryContext()
     return current_thread->tryGetQueryContext();
 }
 
+void CurrentThread::throwIfQueryCancelled()
+{
+    if (auto query_context = tryGetQueryContext())
+        if (auto query_status = query_context->getProcessListElementSafe())
+            query_status->throwIfKilled();
+}
+
 std::string_view CurrentThread::getQueryId()
 {
     if (unlikely(!current_thread))

--- a/src/Common/CurrentThread.cpp
+++ b/src/Common/CurrentThread.cpp
@@ -123,11 +123,19 @@ void CurrentThread::throwIfQueryCancelled()
         /// the wire or do redundant work in tight polling loops.
         if (auto cancel_callback = query_context->getInteractiveCancelCallback())
         {
+            /// Track context identity so the throttle resets on query boundaries: a worker thread
+            /// can run multiple queries back-to-back, and we don't want query A's recent poll to
+            /// suppress query B's first cancel check. Stored as `const void *` because we never
+            /// dereference it — pointer identity is enough, and a freed-then-reused address only
+            /// risks a single throttled poll (the same outcome as if A and B shared the slot).
+            static thread_local const void * last_query_context = nullptr;
             static thread_local std::chrono::steady_clock::time_point last_callback_at{};
+            const auto * current_query_context = static_cast<const void *>(query_context.get());
             const auto now = std::chrono::steady_clock::now();
             const auto period = std::chrono::microseconds(query_context->getSettingsRef()[Setting::interactive_delay]);
-            if (now - last_callback_at >= period)
+            if (current_query_context != last_query_context || now - last_callback_at >= period)
             {
+                last_query_context = current_query_context;
                 last_callback_at = now;
                 cancel_callback();
             }

--- a/src/Common/CurrentThread.h
+++ b/src/Common/CurrentThread.h
@@ -89,6 +89,11 @@ public:
     /// Returns attached query context or nullptr if there is no query context
     static ContextPtr tryGetQueryContext();
 
+    /// Throws if the running query has been killed (via KILL QUERY or by the
+    /// CancellationChecker reaching max_execution_time). No-op when the thread is not
+    /// attached to a query or no process-list entry has been created yet.
+    static void throwIfQueryCancelled();
+
     static std::string_view getQueryId();
 
     // For IO Scheduling

--- a/src/Functions/GatherUtils/Algorithms.h
+++ b/src/Functions/GatherUtils/Algorithms.h
@@ -2,6 +2,7 @@
 
 #include <base/arithmeticOverflow.h>
 #include <base/types.h>
+#include <Common/CurrentThread.h>
 #include <Common/FieldVisitorConvertToNumber.h>
 #include <Functions/GatherUtils/Sources.h>
 #include <Functions/GatherUtils/Sinks.h>
@@ -22,6 +23,10 @@ namespace DB::GatherUtils
 {
 
 inline constexpr size_t MAX_ARRAY_SIZE = 1 << 30;
+
+/// How often inner fill loops poll for query cancellation. Power of two so the compiler can
+/// turn the modulo into a bitmask test.
+inline constexpr size_t CANCELLATION_CHECK_INTERVAL = 1024;
 
 
 /// Methods to copy Slice to Sink, overloaded for various combinations of types.
@@ -722,7 +727,11 @@ void resizeDynamicSize(ArraySource && array_source, ValueSource && value_source,
                 {
                     writeSlice(array_source.getWhole(), sink);
                     for (size_t i = array_size; i < length; ++i)
+                    {
+                        if (i % CANCELLATION_CHECK_INTERVAL == 0)
+                            CurrentThread::throwIfQueryCancelled();
                         writeSlice(value_source.getWhole(), sink);
+                    }
                 }
                 else
                     writeSlice(array_source.getSliceFromLeft(0, length), sink);
@@ -737,7 +746,11 @@ void resizeDynamicSize(ArraySource && array_source, ValueSource && value_source,
                 if (array_size <= length)
                 {
                     for (size_t i = array_size; i < length; ++i)
+                    {
+                        if (i % CANCELLATION_CHECK_INTERVAL == 0)
+                            CurrentThread::throwIfQueryCancelled();
                         writeSlice(value_source.getWhole(), sink);
+                    }
                     writeSlice(array_source.getWhole(), sink);
                 }
                 else
@@ -771,7 +784,11 @@ void resizeConstantSize(ArraySource && array_source, ValueSource && value_source
             {
                 writeSlice(array_source.getWhole(), sink);
                 for (size_t i = array_size; i < length; ++i)
+                {
+                    if (i % CANCELLATION_CHECK_INTERVAL == 0)
+                        CurrentThread::throwIfQueryCancelled();
                     writeSlice(value_source.getWhole(), sink);
+                }
             }
             else
                 writeSlice(array_source.getSliceFromLeft(0, length), sink);
@@ -786,7 +803,11 @@ void resizeConstantSize(ArraySource && array_source, ValueSource && value_source
             if (array_size <= length)
             {
                 for (size_t i = array_size; i < length; ++i)
+                {
+                    if (i % CANCELLATION_CHECK_INTERVAL == 0)
+                        CurrentThread::throwIfQueryCancelled();
                     writeSlice(value_source.getWhole(), sink);
+                }
                 writeSlice(array_source.getWhole(), sink);
             }
             else

--- a/src/Functions/GatherUtils/Algorithms.h
+++ b/src/Functions/GatherUtils/Algorithms.h
@@ -728,7 +728,7 @@ void resizeDynamicSize(ArraySource && array_source, ValueSource && value_source,
                     writeSlice(array_source.getWhole(), sink);
                     for (size_t i = array_size; i < length; ++i)
                     {
-                        if (i % CANCELLATION_CHECK_INTERVAL == 0)
+                        if ((i - array_size) % CANCELLATION_CHECK_INTERVAL == 0)
                             CurrentThread::throwIfQueryCancelled();
                         writeSlice(value_source.getWhole(), sink);
                     }
@@ -747,7 +747,7 @@ void resizeDynamicSize(ArraySource && array_source, ValueSource && value_source,
                 {
                     for (size_t i = array_size; i < length; ++i)
                     {
-                        if (i % CANCELLATION_CHECK_INTERVAL == 0)
+                        if ((i - array_size) % CANCELLATION_CHECK_INTERVAL == 0)
                             CurrentThread::throwIfQueryCancelled();
                         writeSlice(value_source.getWhole(), sink);
                     }
@@ -785,7 +785,7 @@ void resizeConstantSize(ArraySource && array_source, ValueSource && value_source
                 writeSlice(array_source.getWhole(), sink);
                 for (size_t i = array_size; i < length; ++i)
                 {
-                    if (i % CANCELLATION_CHECK_INTERVAL == 0)
+                    if ((i - array_size) % CANCELLATION_CHECK_INTERVAL == 0)
                         CurrentThread::throwIfQueryCancelled();
                     writeSlice(value_source.getWhole(), sink);
                 }
@@ -804,7 +804,7 @@ void resizeConstantSize(ArraySource && array_source, ValueSource && value_source
             {
                 for (size_t i = array_size; i < length; ++i)
                 {
-                    if (i % CANCELLATION_CHECK_INTERVAL == 0)
+                    if ((i - array_size) % CANCELLATION_CHECK_INTERVAL == 0)
                         CurrentThread::throwIfQueryCancelled();
                     writeSlice(value_source.getWhole(), sink);
                 }

--- a/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.cpp
@@ -21,7 +21,6 @@
 #include <IO/ReadHelpers.h>
 #include <IO/WriteHelpers.h>
 #include <Interpreters/Context.h>
-#include <Interpreters/ProcessList.h>
 #include <Interpreters/castColumn.h>
 
 #include <cmath>
@@ -377,9 +376,7 @@ void updateImpl(const ColumnArray * column_array, const ColumnArray::Offsets & c
         /// Check if the query has been cancelled. USearch internally does not check for cancellation,
         /// and a single `add` call can take a very long time under sanitizers. Without this check, KILL QUERY
         /// cannot stop the index building. The check is cheap (reads an atomic flag).
-        if (auto query_context = CurrentThread::tryGetQueryContext())
-            if (auto query_status = query_context->getProcessListElementSafe())
-                query_status->throwIfKilled();
+        CurrentThread::throwIfQueryCancelled();
 
         const typename Column::ValueType & value = column_array_data_float_data[column_array_offsets[row - 1]];
 

--- a/tests/queries/0_stateless/04237_array_resize_cancellation.reference
+++ b/tests/queries/0_stateless/04237_array_resize_cancellation.reference
@@ -1,0 +1,2 @@
+got expected timeout exception
+elapsed under 5s

--- a/tests/queries/0_stateless/04237_array_resize_cancellation.reference
+++ b/tests/queries/0_stateless/04237_array_resize_cancellation.reference
@@ -1,2 +1,2 @@
 got expected timeout exception
-elapsed under 5s
+elapsed under 20s

--- a/tests/queries/0_stateless/04237_array_resize_cancellation.sh
+++ b/tests/queries/0_stateless/04237_array_resize_cancellation.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 # Tags: no-sanitizers, no-debug
-# Reason: timing assertion (<5s) is flaky on slow builds.
+# Reason: timing assertion is flaky on slow builds.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
 # `arrayResize` must check query cancellation to respect timeouts.
+# Without the fix this query would take ~60s on a release build (longer on slower CI
+# hardware) because the resize loop ignored `max_execution_time`. With the fix it
+# aborts shortly after the deadline. We allow up to 20s to keep ample headroom for
+# the slowest CI machines.
 
 START_NS=$(date +%s%N)
 ${CLICKHOUSE_CLIENT} --max_threads 1 --max_execution_time 1 -q "
@@ -19,9 +23,9 @@ ${CLICKHOUSE_CLIENT} --max_threads 1 --max_execution_time 1 -q "
 " 2>&1 | grep -q -E 'TIMEOUT_EXCEEDED|QUERY_WAS_CANCELLED' && echo "got expected timeout exception"
 ELAPSED_MS=$(( ($(date +%s%N) - START_NS) / 1000000 ))
 
-if (( ELAPSED_MS < 5000 ))
+if (( ELAPSED_MS < 20000 ))
 then
-    echo "elapsed under 5s"
+    echo "elapsed under 20s"
 else
     echo "FAIL: elapsed ${ELAPSED_MS}ms"
 fi

--- a/tests/queries/0_stateless/04237_array_resize_cancellation.sh
+++ b/tests/queries/0_stateless/04237_array_resize_cancellation.sh
@@ -7,10 +7,10 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 . "$CUR_DIR"/../shell_config.sh
 
 # `arrayResize` must check query cancellation to respect timeouts.
-# Without the fix this query would take ~60s on a release build (longer on slower CI
-# hardware) because the resize loop ignored `max_execution_time`. With the fix it
-# aborts shortly after the deadline. We allow up to 20s to keep ample headroom for
-# the slowest CI machines.
+# The ARRAY JOIN list runs the resize once per element. Three copies make the natural
+# completion time on the order of tens of seconds even on the fastest CI machines, so
+# the 20s threshold below clearly distinguishes "fix in effect" from "running to
+# completion." On the unpatched binary the same query takes well over a minute.
 
 START_NS=$(date +%s%N)
 ${CLICKHOUSE_CLIENT} --max_threads 1 --max_execution_time 1 -q "
@@ -18,7 +18,7 @@ ${CLICKHOUSE_CLIENT} --max_threads 1 --max_execution_time 1 -q "
         SELECT a FROM generateRandom(
             'a Array(Nested(e1 Tuple(x Int256, y Float64, z Decimal(38, 10))))',
             1, 4, 4) LIMIT 1)
-    ARRAY JOIN [-1000000000]::Array(Int32) AS b
+    ARRAY JOIN [-1000000000, -1000000000, -1000000000]::Array(Int32) AS b
     FORMAT Null
 " 2>&1 | grep -q -E 'TIMEOUT_EXCEEDED|QUERY_WAS_CANCELLED' && echo "got expected timeout exception"
 ELAPSED_MS=$(( ($(date +%s%N) - START_NS) / 1000000 ))

--- a/tests/queries/0_stateless/04237_array_resize_cancellation.sh
+++ b/tests/queries/0_stateless/04237_array_resize_cancellation.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Tags: no-sanitizers, no-debug
+# Reason: timing assertion (<5s) is flaky on slow builds.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# `arrayResize` must check query cancellation to respect timeouts.
+
+START_NS=$(date +%s%N)
+${CLICKHOUSE_CLIENT} --max_threads 1 --max_execution_time 1 -q "
+    SELECT sum(length(arrayResize(a, b))) FROM (
+        SELECT a FROM generateRandom(
+            'a Array(Nested(e1 Tuple(x Int256, y Float64, z Decimal(38, 10))))',
+            1, 4, 4) LIMIT 1)
+    ARRAY JOIN [-1000000000]::Array(Int32) AS b
+    FORMAT Null
+" 2>&1 | grep -q -E 'TIMEOUT_EXCEEDED|QUERY_WAS_CANCELLED' && echo "got expected timeout exception"
+ELAPSED_MS=$(( ($(date +%s%N) - START_NS) / 1000000 ))
+
+if (( ELAPSED_MS < 5000 ))
+then
+    echo "elapsed under 5s"
+else
+    echo "FAIL: elapsed ${ELAPSED_MS}ms"
+fi

--- a/tests/queries/0_stateless/04237_array_resize_cancellation.sh
+++ b/tests/queries/0_stateless/04237_array_resize_cancellation.sh
@@ -23,9 +23,9 @@ ${CLICKHOUSE_CLIENT} --max_threads 1 --max_execution_time 1 -q "
 " 2>&1 | grep -q -E 'TIMEOUT_EXCEEDED|QUERY_WAS_CANCELLED' && echo "got expected timeout exception"
 ELAPSED_MS=$(( ($(date +%s%N) - START_NS) / 1000000 ))
 
-if (( ELAPSED_MS < 20000 ))
+if (( ELAPSED_MS < 10000 ))
 then
-    echo "elapsed under 20s"
+    echo "elapsed under 10s"
 else
     echo "FAIL: elapsed ${ELAPSED_MS}ms"
 fi

--- a/tests/queries/0_stateless/04238_array_resize_cancellation_kill.reference
+++ b/tests/queries/0_stateless/04238_array_resize_cancellation_kill.reference
@@ -1,2 +1,2 @@
 QUERY_WAS_CANCELLED
-cancelled under 5s
+cancelled under 20s

--- a/tests/queries/0_stateless/04238_array_resize_cancellation_kill.reference
+++ b/tests/queries/0_stateless/04238_array_resize_cancellation_kill.reference
@@ -1,0 +1,2 @@
+QUERY_WAS_CANCELLED
+cancelled under 5s

--- a/tests/queries/0_stateless/04238_array_resize_cancellation_kill.sh
+++ b/tests/queries/0_stateless/04238_array_resize_cancellation_kill.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Tags: no-sanitizers, no-debug
+# Reason: timing assertion is flaky on slow builds.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Ctrl-C in clickhouse-client sends a Cancel packet over TCP. The server has to invoke its
+# interactive cancel callback to read it; while the executor is inside a long-running
+# function call no progress packets flow, so the callback never fires from the executor's
+# wait loop. `throwIfQueryCancelled` invokes the callback itself (throttled to
+# `interactive_delay`), which is what this test verifies.
+
+QUERY_ID="$CLICKHOUSE_TEST_UNIQUE_NAME"
+
+${CLICKHOUSE_CLIENT} --query_id="$QUERY_ID" --max_threads 1 --query "
+    SELECT sum(length(arrayResize(a, b))) FROM (
+        SELECT a FROM generateRandom(
+            'a Array(Nested(e1 Tuple(x Int256, y Float64, z Decimal(38, 10))))',
+            1, 4, 4) LIMIT 1)
+    ARRAY JOIN [-1000000000]::Array(Int32) AS b
+    FORMAT Null
+" >/dev/null 2>&1 &
+CLIENT_PID=$!
+
+for _ in {0..60}
+do
+    ${CLICKHOUSE_CLIENT} --query "SELECT count() > 0 FROM system.processes WHERE query_id = '$QUERY_ID'" | grep -qF '1' && break
+    sleep 0.5
+done
+
+START_NS=$(date +%s%N)
+kill -INT $CLIENT_PID
+wait $CLIENT_PID
+ELAPSED_MS=$(( ($(date +%s%N) - START_NS) / 1000000 ))
+
+${CLICKHOUSE_CLIENT} --query "SYSTEM FLUSH LOGS query_log"
+${CLICKHOUSE_CLIENT} --query "SELECT exception FROM system.query_log
+    WHERE query_id = '$QUERY_ID' AND current_database = '$CLICKHOUSE_DATABASE' AND type != 'QueryStart'" \
+    | grep -oF "QUERY_WAS_CANCELLED" | head -1
+
+if (( ELAPSED_MS < 5000 ))
+then
+    echo "cancelled under 5s"
+else
+    echo "FAIL: cancellation took ${ELAPSED_MS}ms"
+fi

--- a/tests/queries/0_stateless/04238_array_resize_cancellation_kill.sh
+++ b/tests/queries/0_stateless/04238_array_resize_cancellation_kill.sh
@@ -11,6 +11,10 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # function call no progress packets flow, so the callback never fires from the executor's
 # wait loop. `throwIfQueryCancelled` invokes the callback itself (throttled to
 # `interactive_delay`), which is what this test verifies.
+#
+# Without the fix this query would take ~60s on a release build before noticing the
+# cancel. With the fix it aborts shortly after the SIGINT reaches the server. We allow
+# up to 20s to keep ample headroom for the slowest CI machines.
 
 QUERY_ID="$CLICKHOUSE_TEST_UNIQUE_NAME"
 
@@ -40,9 +44,9 @@ ${CLICKHOUSE_CLIENT} --query "SELECT exception FROM system.query_log
     WHERE query_id = '$QUERY_ID' AND current_database = '$CLICKHOUSE_DATABASE' AND type != 'QueryStart'" \
     | grep -oF "QUERY_WAS_CANCELLED" | head -1
 
-if (( ELAPSED_MS < 5000 ))
+if (( ELAPSED_MS < 20000 ))
 then
-    echo "cancelled under 5s"
+    echo "cancelled under 20s"
 else
     echo "FAIL: cancellation took ${ELAPSED_MS}ms"
 fi

--- a/tests/queries/0_stateless/04238_array_resize_cancellation_kill.sh
+++ b/tests/queries/0_stateless/04238_array_resize_cancellation_kill.sh
@@ -12,9 +12,10 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # wait loop. `throwIfQueryCancelled` invokes the callback itself (throttled to
 # `interactive_delay`), which is what this test verifies.
 #
-# Without the fix this query would take ~60s on a release build before noticing the
-# cancel. With the fix it aborts shortly after the SIGINT reaches the server. We allow
-# up to 20s to keep ample headroom for the slowest CI machines.
+# The ARRAY JOIN list runs the resize once per element. Three copies make the natural
+# completion time on the order of tens of seconds even on the fastest CI machines, so
+# the 20s threshold below clearly distinguishes "fix in effect" from "running to
+# completion." On the unpatched binary the same query takes well over a minute.
 
 QUERY_ID="$CLICKHOUSE_TEST_UNIQUE_NAME"
 
@@ -23,7 +24,7 @@ ${CLICKHOUSE_CLIENT} --query_id="$QUERY_ID" --max_threads 1 --query "
         SELECT a FROM generateRandom(
             'a Array(Nested(e1 Tuple(x Int256, y Float64, z Decimal(38, 10))))',
             1, 4, 4) LIMIT 1)
-    ARRAY JOIN [-1000000000]::Array(Int32) AS b
+    ARRAY JOIN [-1000000000, -1000000000, -1000000000]::Array(Int32) AS b
     FORMAT Null
 " >/dev/null 2>&1 &
 CLIENT_PID=$!

--- a/tests/queries/0_stateless/04238_array_resize_cancellation_kill.sh
+++ b/tests/queries/0_stateless/04238_array_resize_cancellation_kill.sh
@@ -45,9 +45,9 @@ ${CLICKHOUSE_CLIENT} --query "SELECT exception FROM system.query_log
     WHERE query_id = '$QUERY_ID' AND current_database = '$CLICKHOUSE_DATABASE' AND type != 'QueryStart'" \
     | grep -oF "QUERY_WAS_CANCELLED" | head -1
 
-if (( ELAPSED_MS < 20000 ))
+if (( ELAPSED_MS < 10000 ))
 then
-    echo "cancelled under 20s"
+    echo "cancelled under 10s"
 else
     echo "FAIL: cancellation took ${ELAPSED_MS}ms"
 fi


### PR DESCRIPTION
arrayResize ignored max_execution_time and KILL QUERY because the inner fill loop of resizeConstantSize / resizeDynamicSize did not check the cancellation flag. A worst-case input could keep one thread busy for tens of seconds (or minutes under sanitizers) past any timeout.

Adds a static `CurrentThread::throwIfQueryCancelled()` helper for general reuse and polls it every 1024 iterations inside both resize variants. The existing inline caller in `MergeTreeIndexVectorSimilarity` migrates to the helper.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Make `arrayResize` honor query cancellation (`max_execution_time`, `KILL QUERY`).