### PR TITLE
Make `finished_mutations_to_keep=0` mean "keep no finished mutations"

### DIFF
--- a/docs/en/sql-reference/statements/alter/index.md
+++ b/docs/en/sql-reference/statements/alter/index.md
@@ -61,7 +61,7 @@ Mutations are totally ordered by their creation order and are applied to each pa
 
 A mutation query returns immediately after the mutation entry is added (in case of replicated tables to ZooKeeper, for non-replicated tables - to the filesystem). The mutation itself executes asynchronously using the system profile settings. To track the progress of mutations you can use the [`system.mutations`](/operations/system-tables/mutations) table. A mutation that was successfully submitted will continue to execute even if ClickHouse servers are restarted. There is no way to roll back the mutation once it is submitted, but if the mutation is stuck for some reason it can be cancelled with the [`KILL MUTATION`](/sql-reference/statements/kill.md/#kill-mutation) query.
 
-Entries for finished mutations are not deleted right away (the number of preserved entries is determined by the `finished_mutations_to_keep` storage engine parameter). Older mutation entries are deleted.
+Entries for finished mutations are not deleted right away (the number of preserved entries is determined by the `finished_mutations_to_keep` storage engine parameter; if it is set to zero, no finished mutation entries are kept). Older mutation entries are deleted.
 
 ## Synchronicity of ALTER Queries {#synchronicity-of-alter-queries}
 

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -1636,8 +1636,8 @@ namespace ErrorCodes
     stores less data. For details, see [here](/operations/server-configuration-parameters/settings#use_minimalistic_part_header_in_zookeeper).
     )", 0) \
     DECLARE(UInt64, finished_mutations_to_keep, 100, R"(
-    How many records about mutations that are done to keep. If zero, then keep
-    all of them.
+    How many records about mutations that are done to keep. If zero, then no
+    finished mutation entries are kept.
     )", 0) \
     DECLARE(UInt64, min_merge_bytes_to_use_direct_io, 10ULL * 1024 * 1024 * 1024, R"(
     The minimum data volume for merge operation that is required for using direct

--- a/src/Storages/MergeTree/ReplicatedMergeTreeCleanupThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeCleanupThread.cpp
@@ -505,9 +505,6 @@ void ReplicatedMergeTreeCleanupThread::getBlocksSortedByTime(
 size_t ReplicatedMergeTreeCleanupThread::clearOldMutations()
 {
     auto storage_settings = storage.getSettings();
-    if (!(*storage_settings)[MergeTreeSetting::finished_mutations_to_keep])
-        return 0;
-
     if (storage.queue.countFinishedMutations() <= (*storage_settings)[MergeTreeSetting::finished_mutations_to_keep])
     {
         /// Not strictly necessary, but helps to avoid unnecessary ZooKeeper requests.

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -1837,11 +1837,7 @@ UInt64 StorageMergeTree::getNextMutationVersion(UInt64 data_version, std::unique
 
 size_t StorageMergeTree::clearOldMutations(bool truncate)
 {
-    size_t finished_mutations_to_keep = (*getSettings())[MergeTreeSetting::finished_mutations_to_keep];
-    if (!truncate && !finished_mutations_to_keep)
-        return 0;
-
-    finished_mutations_to_keep = truncate ? 0 : finished_mutations_to_keep;
+    size_t finished_mutations_to_keep = truncate ? 0 : (*getSettings())[MergeTreeSetting::finished_mutations_to_keep];
     std::vector<MergeTreeMutationEntry> mutations_to_delete;
     {
         std::lock_guard lock(currently_processing_in_background_mutex);

--- a/tests/queries/0_stateless/02994_merge_tree_mutations_cleanup.reference
+++ b/tests/queries/0_stateless/02994_merge_tree_mutations_cleanup.reference
@@ -1,4 +1,4 @@
 mutations after ALTER for data_rmt	1
-mutations after cleanup for data_rmt	1
+mutations after cleanup for data_rmt	0
 mutations after ALTER for data_mt	1
-mutations after cleanup for data_mt	1
+mutations after cleanup for data_mt	0

--- a/tests/queries/0_stateless/04146_merge_tree_mutations_cleanup_truncate_drop_partition.sql
+++ b/tests/queries/0_stateless/04146_merge_tree_mutations_cleanup_truncate_drop_partition.sql
@@ -1,13 +1,12 @@
 -- Test: exercises clearOldMutations(truncate=true) and the removal of clearOldMutations from dropPartition.
 -- Covers:
---   src/Storages/StorageMergeTree.cpp:1840 — `if (!truncate && !finished_mutations_to_keep) return 0;` early-return MUST be bypassed when called via TRUNCATE.
---   src/Storages/StorageMergeTree.cpp:2391 — dropPartition no longer calls clearOldMutations, so finished mutations must persist after DROP PARTITION.
+--   TRUNCATE TABLE must clear finished mutations regardless of finished_mutations_to_keep.
+--   dropPartition no longer calls clearOldMutations, so finished mutations must persist after DROP PARTITION.
 
 DROP TABLE IF EXISTS data_truncate_60031;
 DROP TABLE IF EXISTS data_drop_part_60031;
 
--- Part 1: TRUNCATE TABLE must clear finished mutations even when finished_mutations_to_keep=0.
--- (clearOldMutations(truncate=true) bypasses the new early-return at line 1840 and forces finished_mutations_to_keep=0.)
+-- Part 1: TRUNCATE TABLE must clear finished mutations.
 CREATE TABLE data_truncate_60031 (key Int) ENGINE = MergeTree ORDER BY tuple()
     SETTINGS finished_mutations_to_keep = 0;
 INSERT INTO data_truncate_60031 VALUES (1);


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Previously, setting `finished_mutations_to_keep` to 0 was interpreted as "keep all finished mutation entries" (the cleanup code returned early on the zero value). Flip the semantics so that 0 means "do not keep any finished mutation entry" - the natural reading of the setting name.
