### PR TITLE
Fix TSan data race in ContextData copy constructor on table_function_results

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -1246,7 +1246,9 @@ ContextData::ContextData(const ContextData &o) :
     query_privileges_info(o.query_privileges_info),
     async_read_counters(o.async_read_counters),
     view_source(o.view_source),
-    table_function_results(o.table_function_results),
+    /// `table_function_results` is copied in the body under `o.table_function_results_mutex`
+    /// to avoid a data race with `Context::executeTableFunction` and other writers
+    /// that mutate the source object's map. See issue #104807.
     query_context(o.query_context),
     session_context(o.session_context),
     global_context(o.global_context),
@@ -1275,6 +1277,8 @@ ContextData::ContextData(const ContextData &o) :
     local_write_query_throttler(o.local_write_query_throttler),
     backups_query_throttler(o.backups_query_throttler)
 {
+    std::lock_guard lock(o.table_function_results_mutex);
+    table_function_results = o.table_function_results;
 }
 
 void ContextData::resetSharedContext()

--- a/src/Interpreters/tests/gtest_context_race.cpp
+++ b/src/Interpreters/tests/gtest_context_race.cpp
@@ -1,5 +1,8 @@
 #include <Interpreters/Context.h>
 #include <Common/tests/gtest_global_context.h>
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTLiteral.h>
+#include <Core/Field.h>
 #include <gtest/gtest.h>
 #include <thread>
 #include <atomic>
@@ -90,4 +93,70 @@ TEST(Context, GetAccessRace)
     writer.join();
     for (auto & t : readers)
         t.join();
+}
+
+/// Test for data race in `ContextData` copy constructor on `table_function_results`.
+///
+/// The writer thread calls `Context::executeTableFunction`, which mutates
+/// `table_function_results` under `table_function_results_mutex`.
+/// The copier thread calls `Context::createCopy`, which invokes the
+/// `ContextData(const ContextData &)` copy constructor.
+///
+/// Without the fix the copy constructor read `o.table_function_results`
+/// in its initializer list without acquiring `o.table_function_results_mutex`,
+/// and TSan reported a data race against the writer's `emplace`. With the fix
+/// the copy of `table_function_results` happens under that mutex.
+///
+/// See issue ClickHouse/ClickHouse#104807 (STID 1003-358c).
+TEST(Context, TableFunctionResultsCopyRace)
+{
+    auto context = Context::createCopy(getContext().context);
+    context->makeQueryContext();
+
+    /// Build a minimal `numbers(1)` AST -- the table function does not need a
+    /// real ClickHouse server backing to exercise the cache path; even if the
+    /// execution itself fails, the code path through `table_function_results`
+    /// is unchanged and is what we need to race against.
+    auto numbers_ast = makeASTFunction("numbers", make_intrusive<ASTLiteral>(Field(UInt64(1))));
+
+    /// Warm up so the table function machinery is initialized -- ignore any
+    /// errors, we only care about reaching the map.
+    try
+    {
+        (void)context->executeTableFunction(numbers_ast);
+    }
+    catch (...) /// NOLINT(bugprone-empty-catch)
+    {
+    }
+
+    constexpr size_t num_iterations = 200;
+    std::atomic<bool> stop{false};
+
+    /// Writer thread: keep calling executeTableFunction so `table_function_results`
+    /// keeps being mutated (insert into the map) under its mutex.
+    std::thread writer([&]
+    {
+        while (!stop.load(std::memory_order_relaxed))
+        {
+            try
+            {
+                (void)context->executeTableFunction(numbers_ast);
+            }
+            catch (...) /// NOLINT(bugprone-empty-catch)
+            {
+            }
+        }
+    });
+
+    /// Copier thread: keep copying the context, which invokes the
+    /// `ContextData` copy constructor that reads `o.table_function_results`.
+    std::thread copier([&]
+    {
+        for (size_t i = 0; i < num_iterations; ++i)
+            (void)Context::createCopy(context);
+        stop.store(true, std::memory_order_relaxed);
+    });
+
+    copier.join();
+    writer.join();
 }

--- a/src/Interpreters/tests/gtest_context_race.cpp
+++ b/src/Interpreters/tests/gtest_context_race.cpp
@@ -113,36 +113,40 @@ TEST(Context, TableFunctionResultsCopyRace)
     auto context = Context::createCopy(getContext().context);
     context->makeQueryContext();
 
-    /// Build a minimal `numbers(1)` AST -- the table function does not need a
-    /// real ClickHouse server backing to exercise the cache path; even if the
-    /// execution itself fails, the code path through `table_function_results`
-    /// is unchanged and is what we need to race against.
-    auto numbers_ast = makeASTFunction("numbers", make_intrusive<ASTLiteral>(Field(UInt64(1))));
-
-    /// Warm up so the table function machinery is initialized -- ignore any
-    /// errors, we only care about reaching the map.
+    /// Warm up the table-function machinery with a literal (`numbers(0)`)
+    /// distinct from the ones the writer loop will use, so the writer still
+    /// hits the cache-miss insertion path on every iteration.
     try
     {
-        (void)context->executeTableFunction(numbers_ast);
+        auto warmup_ast = makeASTFunction("numbers", make_intrusive<ASTLiteral>(Field(UInt64(0))));
+        (void)context->executeTableFunction(warmup_ast);
     }
-    catch (...) /// NOLINT(bugprone-empty-catch)
+    catch (...) // Ok: ignore execution failures, we only care about exercising the cache path  // NOLINT(bugprone-empty-catch)
     {
     }
 
     constexpr size_t num_iterations = 200;
     std::atomic<bool> stop{false};
 
-    /// Writer thread: keep calling executeTableFunction so `table_function_results`
-    /// keeps being mutated (insert into the map) under its mutex.
+    /// Writer thread: vary the integer literal each iteration so the
+    /// `executeTableFunction` call always hashes to a fresh key. This forces
+    /// the cache-miss path that inserts into `table_function_results` (under
+    /// `table_function_results_mutex`) on every iteration, which is the write
+    /// the copier thread must race against. Calling with the same AST would
+    /// hit the cache after the first call and not mutate the map -- making
+    /// the race read-vs-read and invisible to TSan even without the fix.
+    /// See the bot's inline review on PR #104879.
     std::thread writer([&]
     {
+        UInt64 i = 1;
         while (!stop.load(std::memory_order_relaxed))
         {
+            auto ast = makeASTFunction("numbers", make_intrusive<ASTLiteral>(Field(i++)));
             try
             {
-                (void)context->executeTableFunction(numbers_ast);
+                (void)context->executeTableFunction(ast);
             }
-            catch (...) /// NOLINT(bugprone-empty-catch)
+            catch (...) // Ok: ignore execution failures, we only care about exercising the cache path  // NOLINT(bugprone-empty-catch)
             {
             }
         }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

Fix a `ThreadSanitizer` data race in the `ContextData` copy constructor: `table_function_results` was copied from the source object without acquiring `table_function_results_mutex`, so a concurrent `Context::executeTableFunction` writer could race against the unsynchronized read in the copy constructor.

### Documentation entry for user-facing changes
- [x] Documentation is written (mandatory for new features)

---

## Motivation

`table_function_results` is a `Tables` map (`std::map<String, std::shared_ptr<IStorage>>`) protected by `table_function_results_mutex`. PR #94171 added the mutex and locked the production callers (`Context::executeTableFunction` overloads, `Context::clearTableFunctionResults`), but the `ContextData(const ContextData &)` copy constructor at `src/Interpreters/Context.cpp:1249` continued to read `o.table_function_results` in its initializer list without acquiring the source's mutex.

When another thread was mutating the source object's map under the mutex (e.g. inserting a new table-function cache entry from `Context::executeTableFunction`), `ThreadSanitizer` reported a data race against the unsynchronized read inside the copy constructor.

## CI evidence

Reported via STID `1003-358c` (issue #104807). The truncated stack from the AST fuzzer hit on PR #104479 (`amd_tsan`) showed:

- T762 (write, holding `M0`): `Context::executeTableFunction` → `std::map::__insert_node_at`
- T748 (read, no mutex): `ContextData::ContextData(const ContextData &)` → `std::map __copy_construct_tree`

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104479&sha=42334bfbb7d48857ed6741a30fd2a876590b1dff&name_0=PR&name_1=AST%20fuzzer%20%28amd_tsan%29

CIDB confirms 5 occurrences over the last 30 days across 5 unrelated PRs and 4 different check types (AST fuzzer, BuzzHouse, Stress, Stateless) — sporadic but a genuine race.

## Fix

Move the copy of `table_function_results` from the initializer list into the constructor body under `std::lock_guard lock(o.table_function_results_mutex)`. This follows the established pattern used elsewhere in the same file:

- `QueryAccessInfo::QueryAccessInfo(const QueryAccessInfo &)` at line 436
- `QueryFactoriesInfo::QueryFactoriesInfo(const QueryFactoriesInfo &)` at line 492
- `QueryPrivilegesInfo::QueryPrivilegesInfo(const QueryPrivilegesInfo &)` at line 529

All take `std::lock_guard<std::mutex> lock(rhs.mutex)` and copy under it.

## Regression test

Adds `Context.TableFunctionResultsCopyRace` in `src/Interpreters/tests/gtest_context_race.cpp`. The test races a writer thread (calling `Context::executeTableFunction(numbers(1))`, which mutates `table_function_results` under its mutex) against a copier thread (calling `Context::createCopy(context)`, which invokes the `ContextData` copy constructor). Without this fix, the TSan build reports the data race; with the fix it does not.

## Audit

I audited the other mutex-protected fields in `ContextData`:

- `query_access_info`, `query_factories_info`, `query_privileges_info` — already protected via the per-struct copy constructors that lock `rhs.mutex` themselves.
- `sample_block_cache`, `storage_cache` — NOT copied in `ContextData::ContextData(const ContextData &)`, default-initialized in the new object, so no race.

`table_function_results` is the only mutex-protected field that was copied unsynchronized.

## Verification

- Debug build of `Context.cpp.o` and the test object: ✅ compiles.
- TSan build of `Context.cpp.o` and the test object: ✅ compiles (manually re-driven via `compile_commands.json`).
- `unit_tests_dbms` Debug build: ✅ test runs and passes (TSan instrumentation is required to actually flag the race — CI's TSan build will exercise this).

Closes #104807

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.654`
<!-- ch-version-info:end -->