### PR TITLE
Fix race between DROP and UNDROP in DatabaseCatalog

### DIFF
--- a/src/Interpreters/DatabaseCatalog.cpp
+++ b/src/Interpreters/DatabaseCatalog.cpp
@@ -28,6 +28,7 @@
 #include <Common/checkStackSize.h>
 #include <Common/logger_useful.h>
 #include <Common/noexcept_scope.h>
+#include <base/scope_guard.h>
 #include <Common/quoteString.h>
 #include <Common/threadPoolCallbackRunner.h>
 #include <Common/ZooKeeper/ZooKeeperCommon.h>
@@ -1483,19 +1484,25 @@ time_t DatabaseCatalog::getMinDropTime()
     return min_drop_time;
 }
 
-std::vector<DatabaseCatalog::TablesMarkedAsDropped::iterator> DatabaseCatalog::getTablesToDrop()
+DatabaseCatalog::TablesMarkedAsDropped DatabaseCatalog::getTablesToDrop()
 {
     time_t current_time = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-    decltype(getTablesToDrop()) result;
+    TablesMarkedAsDropped result;
 
     std::lock_guard lock(tables_marked_dropped_mutex);
 
-    for (auto it = tables_marked_dropped.begin(); it != tables_marked_dropped.end(); ++it)
+    for (auto it = tables_marked_dropped.begin(); it != tables_marked_dropped.end();)
     {
         bool in_use = it->table && !isSharedPtrUnique(it->table);
         bool old_enough = it->drop_time <= current_time;
         if (!in_use && old_enough)
-            result.emplace_back(it);
+        {
+            if (first_async_drop_in_queue == it)
+                ++first_async_drop_in_queue;
+            result.splice(result.end(), tables_marked_dropped, it++);
+        }
+        else
+            ++it;
     }
 
     return result;
@@ -1521,16 +1528,27 @@ void DatabaseCatalog::rescheduleDropTableTask()
     (*drop_task)->scheduleAfter(schedule_after_ms);
 }
 
-void DatabaseCatalog::dropTablesParallel(std::vector<DatabaseCatalog::TablesMarkedAsDropped::iterator> tables_to_drop)
+void DatabaseCatalog::dropTablesParallel(TablesMarkedAsDropped tables_to_drop)
 {
     if (tables_to_drop.empty())
         return;
 
     ThreadPoolCallbackRunnerLocal<void> runner(getDatabaseCatalogDropTablesThreadPool().get(), ThreadName::DROP_TABLES);
 
-    for (const auto & item : tables_to_drop)
+    /// Handle cases when enqueueAndKeepTrack() **itself** throws, i.e. CANNOT_SCHEDULE_TASK
+    auto it = tables_to_drop.begin();
+    SCOPE_EXIT({
+        runner.waitForAllToFinish();
+        if (it != tables_to_drop.end())
+        {
+            std::lock_guard lock(tables_marked_dropped_mutex);
+            tables_marked_dropped.splice(tables_marked_dropped.end(), tables_to_drop, it, tables_to_drop.end());
+        }
+    });
+
+    for (; it != tables_to_drop.end(); ++it)
     {
-        auto job = [this, table_iterator = item] ()
+        auto job = [this, table_iterator = it] ()
         {
             try
             {
@@ -1540,14 +1558,10 @@ void DatabaseCatalog::dropTablesParallel(std::vector<DatabaseCatalog::TablesMark
                 {
                     std::lock_guard lock(tables_marked_dropped_mutex);
 
-                    if (first_async_drop_in_queue == table_iterator)
-                        ++first_async_drop_in_queue;
-
                     [[maybe_unused]] auto removed = tables_marked_dropped_ids.erase(table_iterator->table_id.uuid);
                     chassert(removed);
 
                     table_to_delete_without_lock = std::move(*table_iterator);
-                    tables_marked_dropped.erase(table_iterator);
 
                     wait_table_finally_dropped.notify_all();
                 }
@@ -1556,18 +1570,13 @@ void DatabaseCatalog::dropTablesParallel(std::vector<DatabaseCatalog::TablesMark
             {
                 tryLogCurrentException(log, "Cannot drop table " + table_iterator->table_id.getNameForLogs() +
                                             ". Will retry later.");
-                {
-                    std::lock_guard lock(tables_marked_dropped_mutex);
+                std::lock_guard lock(tables_marked_dropped_mutex);
 
-                    if (first_async_drop_in_queue == table_iterator)
-                        ++first_async_drop_in_queue;
+                table_iterator->drop_time = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()) + getContext()->getServerSettings()[ServerSetting::database_catalog_drop_error_cooldown_sec];
+                tables_marked_dropped.emplace_back(std::move(*table_iterator));
 
-                    tables_marked_dropped.splice(tables_marked_dropped.end(), tables_marked_dropped, table_iterator);
-                    table_iterator->drop_time = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()) + getContext()->getServerSettings()[ServerSetting::database_catalog_drop_error_cooldown_sec];
-
-                    if (first_async_drop_in_queue == tables_marked_dropped.end())
-                        --first_async_drop_in_queue;
-                }
+                if (first_async_drop_in_queue == tables_marked_dropped.end())
+                    --first_async_drop_in_queue;
             }
         };
 
@@ -1593,7 +1602,7 @@ void DatabaseCatalog::dropTableDataTask()
 
         try
         {
-            dropTablesParallel(tables_to_drop);
+            dropTablesParallel(std::move(tables_to_drop));
         }
         catch (...)
         {

--- a/src/Interpreters/DatabaseCatalog.h
+++ b/src/Interpreters/DatabaseCatalog.h
@@ -311,8 +311,8 @@ private:
 
     time_t getMinDropTime() TSA_REQUIRES(tables_marked_dropped_mutex);
     std::tuple<size_t, size_t> getDroppedTablesCountAndInuseCount();
-    std::vector<TablesMarkedAsDropped::iterator> getTablesToDrop();
-    void dropTablesParallel(std::vector<TablesMarkedAsDropped::iterator> tables);
+    TablesMarkedAsDropped getTablesToDrop();
+    void dropTablesParallel(TablesMarkedAsDropped tables);
     void rescheduleDropTableTask();
 
     void cleanupStoreDirectoryTask();

--- a/tests/queries/0_stateless/04238_drop_undrop_race.sh
+++ b/tests/queries/0_stateless/04238_drop_undrop_race.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-parallel, no-ordinary-database, no-replicated-database
+
+# Race between DROP vs UNDROP
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+TABLE_PREFIX="test_race_drop_undrop_${CLICKHOUSE_TEST_UNIQUE_NAME}"
+
+function cleanup()
+{
+    for i in {1..4}; do
+        $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS ${TABLE_PREFIX}_$i SYNC" 2>/dev/null ||:
+    done
+}
+
+trap cleanup EXIT
+cleanup
+
+# Run multiple iterations to increase chance of hitting the race
+for iter in {1..3}; do
+    # Create tables using Memory engine - tables without disk storage have
+    # ignore_delay=true, making them immediately eligible for background drop
+    for i in {1..4}; do
+        $CLICKHOUSE_CLIENT --query "CREATE TABLE IF NOT EXISTS ${TABLE_PREFIX}_$i (x Int32) ENGINE = Memory" 2>/dev/null ||:
+        $CLICKHOUSE_CLIENT --query "INSERT INTO ${TABLE_PREFIX}_$i VALUES ($i)" 2>/dev/null ||:
+    done
+
+    # Drop tables asynchronously to populate the drop queue
+    # This queues entries into tables_marked_dropped list and schedules
+    # the background dropTableDataTask immediately (ignore_delay=true)
+    for i in {1..4}; do
+        $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS ${TABLE_PREFIX}_$i" \
+            --database_atomic_wait_for_drop_and_detach_synchronously=0 2>/dev/null &
+    done
+
+    # Concurrently try to undrop tables - this races with dropTableDataTask
+    # undropTable() erases from tables_marked_dropped while dropTablesParallel
+    # is dereferencing iterators without holding the lock
+    for i in {1..4}; do
+        $CLICKHOUSE_CLIENT --query "UNDROP TABLE ${TABLE_PREFIX}_$i" 2>/dev/null &
+    done
+    wait
+
+    # Clean up for next iteration - drop all tables that might exist
+    for i in {1..4}; do
+        $CLICKHOUSE_CLIENT --query "DROP TABLE IF EXISTS ${TABLE_PREFIX}_$i SYNC" 2>/dev/null ||:
+    done
+done


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix race between DROP and UNDROP in DatabaseCatalog

Fixes: https://github.com/ClickHouse/ClickHouse/issues/104914
Fixes: https://github.com/ClickHouse/ClickHouse/pull/66065

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.764`
<!-- ch-version-info:end -->