### PR TITLE
Do not run `03809_time64_not_monotonic` under heavy sanitizers

### DIFF
--- a/tests/queries/0_stateless/03809_time64_not_monotonic.sql
+++ b/tests/queries/0_stateless/03809_time64_not_monotonic.sql
@@ -1,4 +1,4 @@
--- Tags: long
+-- Tags: long, no-asan, no-ubsan, no-msan
 -- Regression test for non-monotonic Time64 conversion in MergeTreeSetIndex.
 -- Converting from DateTime to Time64 extracts time-of-day component, which is not monotonic.
 
@@ -9,14 +9,14 @@ CREATE TABLE mt_test (d Date DEFAULT toDate('2015-05-01'), x UInt64) ENGINE = Me
 
 SET min_insert_block_size_rows = 0, min_insert_block_size_bytes = 0;
 SET max_block_size = 1000000;
-INSERT INTO mt_test (x) SELECT number * 10 FROM system.numbers LIMIT 10000;
+INSERT INTO mt_test (x) SELECT number AS x FROM system.numbers LIMIT 100000;
 
 -- Create a Merge table with Time64 column type
 CREATE TABLE merge_test (d Date, x Time64(3)) ENGINE = Merge(currentDatabase(), '^mt_test$');
 
 -- This query previously caused "Invalid binary search result in MergeTreeSetIndex" exception
 -- because the conversion from UInt64 to Time64 was incorrectly marked as monotonic.
-SELECT count() > 0 FROM merge_test WHERE x NOT IN (12340, 67890);
+SELECT count() > 0 FROM merge_test WHERE x NOT IN (12345, 67890);
 
 DROP TABLE merge_test;
 DROP TABLE mt_test;


### PR DESCRIPTION
I still see that there is a chance that the test can time-out under double sanitizers (asan + ubsan), so let's just not run it with them.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.670`
<!-- ch-version-info:end -->