### PR TITLE
Cap select_parser_fuzzer max_parser_backtracks at 10000

### DIFF
--- a/tests/fuzz/select_parser_fuzzer.options
+++ b/tests/fuzz/select_parser_fuzzer.options
@@ -1,3 +1,6 @@
 [libfuzzer]
 timeout = 20
 dict = all.dict
+
+[fuzzer_arguments]
+max_parser_backtracks = 10000


### PR DESCRIPTION
### Description / motivation

Cap `select_parser_fuzzer`'s per-input `max_parser_backtracks` budget at `10000`
via the `.options` file. This is a CI-only configuration fix; no source code
is changed.

**Regression source.** Commit
[`b5a006c49a7`](https://github.com/ClickHouse/ClickHouse/commit/b5a006c49a7)
(*"add parameters for `select_parser_fuzzer`, set default threshoulds lower"*,
2026-05-11) made the per-input limits configurable via
`-ignore_remaining_args=1 -max_parser_backtracks=N`. As a side effect, the
in-source default for `max_parser_backtracks` went from `5000` to
`DBMS_DEFAULT_MAX_PARSER_BACKTRACKS` (`1000000`) — a 200x increase.

For the sibling `create_parser_fuzzer`, the same author added the matching
`.options` entry in commit
[`e9453b722ae`](https://github.com/ClickHouse/ClickHouse/commit/e9453b722ae)
(*"tune up `create_parser_fuzzer` settings"*) so that `libFuzzer` runs with
a fuzzer-safe 10000-step budget. The matching update to
`tests/fuzz/select_parser_fuzzer.options` was missed, so since 2026-05-11 every
PR running the libFuzzer check has been parsing each `select_parser_fuzzer`
corpus input with a 1,000,000-step budget. On pathological inputs (deeply
nested parentheses with mixed function-call / subquery shapes — exactly the
pattern of closed issue #92282) the parser spends 20-26s before bailing,
which is above the 20s libFuzzer `timeout`.

**CIDB evidence.** `select_parser_fuzzer` FAIL/ERROR rows in the last 30 days:

| day        | fails | distinct PRs                                |
|------------|-------|---------------------------------------------|
| 2026-04-19 | 1     | 1 (PR #99740, author's own branch)          |
| ...        | ...   | ...                                         |
| 2026-05-11 | 1     | 1 (PR #99740)                               |
| **2026-05-13** | **24**    | **24 (all unrelated PRs)**                 |
| **2026-05-14** | **13**    | **13 (all unrelated PRs)**                 |

The 2026-05-13 spike is exactly the first master day after commit
`b5a006c49a7` was merged. Every recent failure is a `timeout-*` artefact of
the form `libFuzzer\ttimeout after 20-26 seconds`, matching the symptom in
issue #92282.

**Local mechanism reproduction** (`clickhouse local`, debug build, same
input):

```
SELECT te(((...((SELECT tuple(... (~470 bytes, deeply nested malformed)
  --max_parser_depth=300 --max_parser_backtracks=10000   -> 0.16s (TOO_SLOW_PARSING)
  --max_parser_depth=300 --max_parser_backtracks=1000000 -> 0.92s (~6x slower)
```

Real `select_parser_fuzzer` corpus inputs are larger and amplify this ratio
to the 20-26s timeouts observed in CI.

**Pre-PR validation gate.**

- **Deterministic repro:** yes — `clickhouse local` shows a 6x parse-time
  ratio on the same input as `max_parser_backtracks` goes from `10000` to
  `1000000`.
- **Root cause explained:** yes — regression date matches commit
  `b5a006c49a7` exactly; the `.options` override that was added for
  `create_parser_fuzzer` was missed for `select_parser_fuzzer`.
- **Fix matches root cause:** yes — the change restores the 10000-step
  budget previously set in PR #92325 to fix the timeout class in #92282.
- **Test intent preserved:** yes — same depth (300/150), same AST
  element / depth limits, same corpus and dictionary. Only the per-input
  backtrack budget changes.
- **Both directions demonstrated:** yes — local repro shows the
  10000-vs-1000000 time difference; CIDB shows the regression spike
  aligned with the commit.

**Refs:**

- Tracker: #93438 (*libFuzzer tests are flaky*)
- Originating closed issue: #92282 (*`select_parser_fuzzer` times out when
  parsing deeply nested parentheses*)
- Sibling `.options` fix already on master: commit
  [`e9453b722ae`](https://github.com/ClickHouse/ClickHouse/commit/e9453b722ae)
- Regressing commit: [`b5a006c49a7`](https://github.com/ClickHouse/ClickHouse/commit/b5a006c49a7)
- Failing CI run referenced in directive: PR #100277 sha=5e956ab02379b6fca74430a22413b07a95340104

### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not required (CI-only fix).

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.645`
<!-- ch-version-info:end -->