### PR TITLE
Define USE_OPENSSL_FIPS in config.h.in to avoid -Wundef

### DIFF
--- a/src/Common/config.h.in
+++ b/src/Common/config.h.in
@@ -86,5 +86,6 @@
 #cmakedefine01 USE_LIBCOTP
 #cmakedefine01 USE_WASMEDGE
 #cmakedefine01 USE_WASMTIME
+#cmakedefine01 USE_OPENSSL_FIPS
 #cmakedefine01 WITH_COVERAGE
 


### PR DESCRIPTION
### Summary

USE_OPENSSL_FIPS is referenced in programs/main.cpp and programs/keeper/keeper_main.cpp under some build configurations, but the macro was not declared in config.h.in. In builds where Common/config.h does not define it, -Werror=undef fires:

```
programs/main.cpp:301:28: error: 'USE_OPENSSL_FIPS' is not defined, evaluates to 0 [-Werror,-Wundef]
```

Declaring it as cmakedefine01 makes the macro always defined (to 0 by default), matching how every other USE_* macro is handled in this codebase and how the corresponding sites already test it (`#if USE_OPENSSL_FIPS`).

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.693`
<!-- ch-version-info:end -->