### PR TITLE
Fix max_memory_usage_soft_limit hot reload

### DIFF
--- a/programs/keeper/Keeper.cpp
+++ b/programs/keeper/Keeper.cpp
@@ -363,8 +363,6 @@ try
     if (!config().has("keeper_server"))
         throw Exception(ErrorCodes::NO_ELEMENTS_IN_CONFIG, "Keeper configuration (<keeper_server> section) not found in config");
 
-    KeeperContext::initializeKeeperMemorySoftLimit(config(), log);
-
     std::string path = getKeeperPath(config());
     std::filesystem::create_directories(path);
 
@@ -633,7 +631,6 @@ try
             config().replace("default", loaded_config, PRIO_DEFAULT, true);
 
             updateLevels(config(), logger());
-            KeeperContext::initializeKeeperMemorySoftLimit(config(), log);
 
             if (config().has("keeper_server"))
                 global_context->updateKeeperConfiguration(config());

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -2325,10 +2325,6 @@ try
 
             if (config().has("keeper_server"))
             {
-#if USE_NURAFT
-                if (config().getBool("keeper_server.standalone_keeper", false))
-                    KeeperContext::initializeKeeperMemorySoftLimit(config(), log);
-#endif
                 global_context->updateKeeperConfiguration(config());
             }
 

--- a/src/Coordination/KeeperContext.cpp
+++ b/src/Coordination/KeeperContext.cpp
@@ -593,30 +593,29 @@ void KeeperContext::initializeFeatureFlags(const Poco::Util::AbstractConfigurati
     feature_flags.logFlags(getLogger("KeeperContext"));
 }
 
-void KeeperContext::updateKeeperMemorySoftLimit(const Poco::Util::AbstractConfiguration & config)
+static UInt64 calculateMemorySoftLimit(const Poco::Util::AbstractConfiguration & config)
 {
     if (config.hasProperty("keeper_server.max_memory_usage_soft_limit"))
-        memory_soft_limit = config.getUInt64("keeper_server.max_memory_usage_soft_limit");
-}
-
-void KeeperContext::initializeKeeperMemorySoftLimit(Poco::Util::AbstractConfiguration & config, Poco::Logger * log)
-{
-    UInt64 memory_soft_limit = 0;
-    if (config.has("keeper_server.max_memory_usage_soft_limit"))
-        memory_soft_limit = config.getUInt64("keeper_server.max_memory_usage_soft_limit");
-
-    if (memory_soft_limit == 0)
     {
-        Float64 ratio = config.getDouble("keeper_server.max_memory_usage_soft_limit_ratio", 0.9);
-        size_t physical_server_memory = getMemoryAmount();
-        if (ratio > 0 && physical_server_memory > 0)
-        {
-            memory_soft_limit = static_cast<UInt64>(static_cast<Float64>(physical_server_memory) * ratio);
-            config.setUInt64("keeper_server.max_memory_usage_soft_limit", memory_soft_limit);
-        }
+        UInt64 explicit_value = config.getUInt64("keeper_server.max_memory_usage_soft_limit");
+        // 0 falls through to ratio-based calculation for backward compatibility.
+        if (explicit_value > 0)
+            return explicit_value;
     }
 
-    LOG_INFO(log, "keeper_server.max_memory_usage_soft_limit is set to {}", formatReadableSizeWithBinarySuffix(memory_soft_limit));
+    Float64 ratio = config.getDouble("keeper_server.max_memory_usage_soft_limit_ratio", 0.9);
+    size_t physical_server_memory = getMemoryAmount();
+    if (ratio > 0 && physical_server_memory > 0)
+        return static_cast<UInt64>(static_cast<Float64>(physical_server_memory) * ratio);
+
+    return 0;
+}
+
+void KeeperContext::updateKeeperMemorySoftLimit(const Poco::Util::AbstractConfiguration & config)
+{
+    const auto limit = calculateMemorySoftLimit(config);
+    memory_soft_limit = limit;
+    LOG_INFO(getLogger("KeeperContext"), "keeper_server.max_memory_usage_soft_limit is set to {}", formatReadableSizeWithBinarySuffix(limit));
 }
 
 void KeeperContext::updateSettings(CoordinationSettingsPtr new_settings)

--- a/src/Coordination/KeeperContext.h
+++ b/src/Coordination/KeeperContext.h
@@ -85,8 +85,6 @@ public:
     UInt64 getKeeperMemorySoftLimit() const { return memory_soft_limit; }
     void updateKeeperMemorySoftLimit(const Poco::Util::AbstractConfiguration & config);
 
-    static void initializeKeeperMemorySoftLimit(Poco::Util::AbstractConfiguration & config, Poco::Logger * log);
-
     void updateSettings(CoordinationSettingsPtr new_settings);
 
     bool setShutdownCalled();

--- a/tests/integration/test_keeper_memory_soft_limit/configs/keeper_config1_reload.xml
+++ b/tests/integration/test_keeper_memory_soft_limit/configs/keeper_config1_reload.xml
@@ -1,0 +1,49 @@
+<clickhouse>
+    <listen_try>true</listen_try>
+    <listen_host>::</listen_host>
+    <listen_host>0.0.0.0</listen_host>
+
+    <logger>
+        <level>trace</level>
+        <log>/var/log/clickhouse-keeper/clickhouse-keeper.log</log>
+        <errorlog>/var/log/clickhouse-keeper/clickhouse-keeper.err.log</errorlog>
+    </logger>
+
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <availability_zone>
+            <value>az-zoo1</value>
+        </availability_zone>
+        <server_id>1</server_id>
+        <max_memory_usage_soft_limit_ratio>0.9</max_memory_usage_soft_limit_ratio>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>15000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+            <force_sync>false</force_sync>
+            <election_timeout_lower_bound_ms>2000</election_timeout_lower_bound_ms>
+            <election_timeout_upper_bound_ms>4000</election_timeout_upper_bound_ms>
+
+            <async_replication>1</async_replication>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>zoo1</hostname>
+                <port>9444</port>
+            </server>
+            <server>
+                <id>2</id>
+                <hostname>zoo2</hostname>
+                <port>9444</port>
+            </server>
+            <server>
+                <id>3</id>
+                <hostname>zoo3</hostname>
+                <port>9444</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_memory_soft_limit/test.py
+++ b/tests/integration/test_keeper_memory_soft_limit/test.py
@@ -110,6 +110,8 @@ def test_soft_limit_create(started_cluster):
     raise Exception("all records are inserted but no error occurs")
 
 
+# Verify that `max_memory_usage_soft_limit` is correctly updated
+# on config reload without requiring keeper restart.
 def test_soft_limit_hot_reload(started_cluster):
     started_cluster.wait_zookeeper_to_start()
 

--- a/tests/integration/test_keeper_memory_soft_limit/test.py
+++ b/tests/integration/test_keeper_memory_soft_limit/test.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 import logging
+import os
+import time
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
 
 import pytest
 from kazoo.client import KazooClient
 
 from helpers.cluster import ClickHouseCluster
+
+CURRENT_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 
 cluster = ClickHouseCluster(__file__, keeper_config_dir="configs/")
 
@@ -104,3 +108,61 @@ def test_soft_limit_create(started_cluster):
         return
 
     raise Exception("all records are inserted but no error occurs")
+
+
+def test_soft_limit_hot_reload(started_cluster):
+    started_cluster.wait_zookeeper_to_start()
+
+    zoo1_container = started_cluster.get_container_id("zoo1")
+    keeper_log = "/var/log/clickhouse-keeper/clickhouse-keeper.log"
+
+    # At startup the limit was set to 300 000 000 bytes ≈ 286.10 MiB (explicit value).
+    startup_log = started_cluster.exec_in_container(
+        zoo1_container,
+        ["bash", "-c", f'grep "max_memory_usage_soft_limit is set to" {keeper_log} || true'],
+    )
+    assert "286.10 MiB" in startup_log, (
+        f"Expected startup log to contain '286.10 MiB', got:\n{startup_log}"
+    )
+
+    # Overwrite keeper_config1.xml with the reload variant that uses ratio=0.9 instead of an explicit value.
+    started_cluster.copy_file_to_container(
+        zoo1_container,
+        os.path.join(CURRENT_TEST_DIR, "configs", "keeper_config1_reload.xml"),
+        "/etc/clickhouse-keeper/keeper_config1.xml",
+    )
+
+    # Send SIGHUP to the keeper process to trigger config reload.
+    started_cluster.exec_in_container(
+        zoo1_container,
+        ["bash", "-c", "pkill -HUP clickhouse-keeper 2>/dev/null || pkill -HUP clickhouse 2>/dev/null || true"],
+        user="root",
+    )
+
+    # Poll for up to 30 s until a second log entry appears with a value different from the
+    # startup "286.10 MiB". ratio=0.9 of any realistic machine memory is  differs from 286 MiB.
+    deadline = time.time() + 30
+    reloaded = False
+    while time.time() < deadline:
+        lines = started_cluster.exec_in_container(
+            zoo1_container,
+            ["bash", "-c", f'grep "max_memory_usage_soft_limit is set to" {keeper_log} || true'],
+        ).strip().splitlines()
+        reload_lines = [l for l in lines if "286.10 MiB" not in l]
+        if reload_lines:
+            reloaded = True
+            break
+        time.sleep(1)
+
+    assert reloaded, (
+        "Timeout waiting for a reload log entry with a value different from '286.10 MiB' after SIGHUP. "
+        f"Log lines seen: {lines}"
+    )
+
+    # Verify keeper is still accepting connections after reload.
+    node_zk = get_connection_zk("zoo1")
+    try:
+        assert node_zk.exists("/") is not None, "Keeper root node not accessible after reload"
+    finally:
+        node_zk.stop()
+        node_zk.close()

--- a/tests/integration/test_keeper_memory_soft_limit/test.py
+++ b/tests/integration/test_keeper_memory_soft_limit/test.py
@@ -1,15 +1,11 @@
 #!/usr/bin/env python3
 import logging
-import os
-import time
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
 
 import pytest
 from kazoo.client import KazooClient
 
 from helpers.cluster import ClickHouseCluster
-
-CURRENT_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 
 cluster = ClickHouseCluster(__file__, keeper_config_dir="configs/")
 
@@ -108,63 +104,3 @@ def test_soft_limit_create(started_cluster):
         return
 
     raise Exception("all records are inserted but no error occurs")
-
-
-# Verify that `max_memory_usage_soft_limit` is correctly updated
-# on config reload without requiring keeper restart.
-def test_soft_limit_hot_reload(started_cluster):
-    started_cluster.wait_zookeeper_to_start()
-
-    zoo1_container = started_cluster.get_container_id("zoo1")
-    keeper_log = "/var/log/clickhouse-keeper/clickhouse-keeper.log"
-
-    # At startup the limit was set to 300 000 000 bytes ≈ 286.10 MiB (explicit value).
-    startup_log = started_cluster.exec_in_container(
-        zoo1_container,
-        ["bash", "-c", f'grep "max_memory_usage_soft_limit is set to" {keeper_log} || true'],
-    )
-    assert "286.10 MiB" in startup_log, (
-        f"Expected startup log to contain '286.10 MiB', got:\n{startup_log}"
-    )
-
-    # Overwrite keeper_config1.xml with the reload variant that uses ratio=0.9 instead of an explicit value.
-    started_cluster.copy_file_to_container(
-        zoo1_container,
-        os.path.join(CURRENT_TEST_DIR, "configs", "keeper_config1_reload.xml"),
-        "/etc/clickhouse-keeper/keeper_config1.xml",
-    )
-
-    # Send SIGHUP to the keeper process to trigger config reload.
-    started_cluster.exec_in_container(
-        zoo1_container,
-        ["bash", "-c", "pkill -HUP clickhouse-keeper 2>/dev/null || pkill -HUP clickhouse 2>/dev/null || true"],
-        user="root",
-    )
-
-    # Poll for up to 30 s until a second log entry appears with a value different from the
-    # startup "286.10 MiB". ratio=0.9 of any realistic machine memory is  differs from 286 MiB.
-    deadline = time.time() + 30
-    reloaded = False
-    while time.time() < deadline:
-        lines = started_cluster.exec_in_container(
-            zoo1_container,
-            ["bash", "-c", f'grep "max_memory_usage_soft_limit is set to" {keeper_log} || true'],
-        ).strip().splitlines()
-        reload_lines = [l for l in lines if "286.10 MiB" not in l]
-        if reload_lines:
-            reloaded = True
-            break
-        time.sleep(1)
-
-    assert reloaded, (
-        "Timeout waiting for a reload log entry with a value different from '286.10 MiB' after SIGHUP. "
-        f"Log lines seen: {lines}"
-    )
-
-    # Verify keeper is still accepting connections after reload.
-    node_zk = get_connection_zk("zoo1")
-    try:
-        assert node_zk.exists("/") is not None, "Keeper root node not accessible after reload"
-    finally:
-        node_zk.stop()
-        node_zk.close()

--- a/tests/integration/test_keeper_memory_soft_limit_ratio/configs/keeper_config1.xml
+++ b/tests/integration/test_keeper_memory_soft_limit_ratio/configs/keeper_config1.xml
@@ -1,0 +1,45 @@
+<clickhouse>
+    <listen_try>true</listen_try>
+    <listen_host>::</listen_host>
+    <listen_host>0.0.0.0</listen_host>
+
+    <logger>
+        <level>trace</level>
+        <log>/var/log/clickhouse-keeper/clickhouse-keeper.log</log>
+        <errorlog>/var/log/clickhouse-keeper/clickhouse-keeper.err.log</errorlog>
+    </logger>
+
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>1</server_id>
+        <max_memory_usage_soft_limit_ratio>0.5</max_memory_usage_soft_limit_ratio>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>15000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+            <force_sync>false</force_sync>
+            <election_timeout_lower_bound_ms>2000</election_timeout_lower_bound_ms>
+            <election_timeout_upper_bound_ms>4000</election_timeout_upper_bound_ms>
+            <async_replication>1</async_replication>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>zoo1</hostname>
+                <port>9444</port>
+            </server>
+            <server>
+                <id>2</id>
+                <hostname>zoo2</hostname>
+                <port>9444</port>
+            </server>
+            <server>
+                <id>3</id>
+                <hostname>zoo3</hostname>
+                <port>9444</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_memory_soft_limit_ratio/configs/keeper_config1_reload.xml
+++ b/tests/integration/test_keeper_memory_soft_limit_ratio/configs/keeper_config1_reload.xml
@@ -11,9 +11,6 @@
 
     <keeper_server>
         <tcp_port>2181</tcp_port>
-        <availability_zone>
-            <value>az-zoo1</value>
-        </availability_zone>
         <server_id>1</server_id>
         <max_memory_usage_soft_limit_ratio>0.9</max_memory_usage_soft_limit_ratio>
 
@@ -24,7 +21,6 @@
             <force_sync>false</force_sync>
             <election_timeout_lower_bound_ms>2000</election_timeout_lower_bound_ms>
             <election_timeout_upper_bound_ms>4000</election_timeout_upper_bound_ms>
-
             <async_replication>1</async_replication>
         </coordination_settings>
 

--- a/tests/integration/test_keeper_memory_soft_limit_ratio/configs/keeper_config2.xml
+++ b/tests/integration/test_keeper_memory_soft_limit_ratio/configs/keeper_config2.xml
@@ -1,0 +1,50 @@
+<clickhouse>
+    <listen_try>true</listen_try>
+    <listen_host>::</listen_host>
+    <listen_host>0.0.0.0</listen_host>
+
+    <logger>
+        <level>trace</level>
+        <log>/var/log/clickhouse-keeper/clickhouse-keeper.log</log>
+        <errorlog>/var/log/clickhouse-keeper/clickhouse-keeper.err.log</errorlog>
+    </logger>
+
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>2</server_id>
+        <availability_zone>
+            <value>az-zoo2</value>
+            <enable_auto_detection_on_cloud>1</enable_auto_detection_on_cloud>
+        </availability_zone>
+        <max_memory_usage_soft_limit>300000000</max_memory_usage_soft_limit>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>15000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+            <force_sync>false</force_sync>
+            <election_timeout_lower_bound_ms>2000</election_timeout_lower_bound_ms>
+            <election_timeout_upper_bound_ms>4000</election_timeout_upper_bound_ms>
+
+            <async_replication>1</async_replication>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>zoo1</hostname>
+                <port>9444</port>
+            </server>
+            <server>
+                <id>2</id>
+                <hostname>zoo2</hostname>
+                <port>9444</port>
+            </server>
+            <server>
+                <id>3</id>
+                <hostname>zoo3</hostname>
+                <port>9444</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_memory_soft_limit_ratio/configs/keeper_config3.xml
+++ b/tests/integration/test_keeper_memory_soft_limit_ratio/configs/keeper_config3.xml
@@ -1,0 +1,47 @@
+<clickhouse>
+    <listen_try>true</listen_try>
+    <listen_host>::</listen_host>
+    <listen_host>0.0.0.0</listen_host>
+
+    <logger>
+        <level>trace</level>
+        <log>/var/log/clickhouse-keeper/clickhouse-keeper.log</log>
+        <errorlog>/var/log/clickhouse-keeper/clickhouse-keeper.err.log</errorlog>
+    </logger>
+
+    <keeper_server>
+        <tcp_port>2181</tcp_port>
+        <server_id>3</server_id>
+
+        <max_memory_usage_soft_limit>300000000</max_memory_usage_soft_limit>
+
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>15000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+            <force_sync>false</force_sync>
+            <election_timeout_lower_bound_ms>2000</election_timeout_lower_bound_ms>
+            <election_timeout_upper_bound_ms>4000</election_timeout_upper_bound_ms>
+
+            <async_replication>1</async_replication>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>zoo1</hostname>
+                <port>9444</port>
+            </server>
+            <server>
+                <id>2</id>
+                <hostname>zoo2</hostname>
+                <port>9444</port>
+            </server>
+            <server>
+                <id>3</id>
+                <hostname>zoo3</hostname>
+                <port>9444</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_memory_soft_limit_ratio/test.py
+++ b/tests/integration/test_keeper_memory_soft_limit_ratio/test.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+import os
+import time
+
+import pytest
+from kazoo.client import KazooClient
+
+from helpers.cluster import ClickHouseCluster
+
+CURRENT_TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+
+cluster = ClickHouseCluster(__file__, keeper_config_dir="configs/")
+
+# clickhouse itself will use external zookeeper
+node = cluster.add_instance(
+    "node",
+    stay_alive=True,
+    with_zookeeper=True,
+    with_remote_database_disk=False,
+)
+
+
+def get_connection_zk(nodename, timeout=30.0):
+    _fake_zk_instance = KazooClient(
+        hosts=f"{cluster.get_instance_ip(nodename)}:2181", timeout=timeout
+    )
+    _fake_zk_instance.start()
+    return _fake_zk_instance
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+# Verify that `max_memory_usage_soft_limit` is correctly updated
+# on config reload without requiring keeper restart.
+def test_soft_limit_hot_reload(started_cluster):
+    started_cluster.wait_zookeeper_to_start()
+
+    zoo1_container = started_cluster.get_container_id("zoo1")
+    keeper_log = "/var/log/clickhouse-keeper/clickhouse-keeper.log"
+
+    # zoo1 starts with max_memory_usage_soft_limit_ratio=0.5 only (no explicit value).
+    startup_lines = started_cluster.exec_in_container(
+        zoo1_container,
+        ["bash", "-c", f'grep "max_memory_usage_soft_limit is set to" {keeper_log} || true'],
+    ).strip().splitlines()
+    assert len(startup_lines) >= 1, f"Expected at least 1 startup log line, got: {startup_lines}"
+    startup_value = startup_lines[0].split("is set to ")[-1].strip()
+    startup_count = len(startup_lines)
+
+    # Reload with ratio=0.9 — the new limit must differ from the ratio=0.5 startup value.
+    started_cluster.copy_file_to_container(
+        zoo1_container,
+        os.path.join(CURRENT_TEST_DIR, "configs", "keeper_config1_reload.xml"),
+        "/etc/clickhouse-keeper/keeper_config1.xml",
+    )
+
+    started_cluster.exec_in_container(
+        zoo1_container,
+        ["bash", "-c", "pkill -HUP clickhouse-keeper 2>/dev/null || pkill -HUP clickhouse 2>/dev/null || true"],
+        user="root",
+    )
+
+    # Poll for up to 30 s until a new log entry appears beyond the startup lines with a different value.
+    deadline = time.time() + 30
+    reloaded = False
+    while time.time() < deadline:
+        lines = started_cluster.exec_in_container(
+            zoo1_container,
+            ["bash", "-c", f'grep "max_memory_usage_soft_limit is set to" {keeper_log} || true'],
+        ).strip().splitlines()
+        if len(lines) > startup_count:
+            reload_value = lines[-1].split("is set to ")[-1].strip()
+            if reload_value != startup_value:
+                reloaded = True
+                break
+        time.sleep(1)
+
+    assert reloaded, (
+        f"Timeout: reload value did not change from startup value '{startup_value}'. "
+        f"Log lines seen: {lines}"
+    )
+
+    # Verify keeper is still accepting connections after reload.
+    node_zk = get_connection_zk("zoo1")
+    try:
+        assert node_zk.exists("/") is not None, "Keeper root node not accessible after reload"
+    finally:
+        node_zk.stop()
+        node_zk.close()


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

When `max_memory_usage_soft_limit` is not set explicitly and is auto-calculated from `max_memory_usage_soft_limit_ratio`, `initializeKeeperMemorySoftLimit` called `config.setUInt64()` to cache the result into the writable `MapConfiguration` layer(`PRIO_APPLICATION = -100`). 

On config reload triggered by `CgroupsMemoryUsageObserver`(e.g., when the cgroup memory limit increases), `LayeredConfiguration::replace()`  only swaps the file layer (`PRIO_DEFAULT = 0`) but leaves `MapConfiguration` intact. 

Because `MapConfiguration` has higher priority, the stale startup value shadows the new file config, and `updateKeeperMemorySoftLimit` reads the old value instead of recalculating.

Fix: extract `calculateMemorySoftLimit` and remove the `config.setUInt64()` call, so each reload recalculates from the current config and `getMemoryAmount()`.

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed the `max_memory_usage_soft_limit` was not updated on-the-fly when the configuration changed. The soft memory limit was calculated once at startup and cached, so subsequent config reloads had no effect. After this fix, the limit is recalculated and applied immediately on every config reload, no Keeper restart required.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.893` (included in `26.5` and later)
- Backported to: `26.3.33.43`
<!-- ch-version-info:end -->