### PR TITLE
Add cancellation check for system sync merges

### DIFF
--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -2125,6 +2125,8 @@ void InterpreterSystemQuery::syncMerges()
         std::this_thread::sleep_for(std::chrono::milliseconds(poll_delay.getCurrentDelay()));
         poll_delay.up();
     }
+
+    throw DB::Exception(DB::ErrorCodes::QUERY_WAS_CANCELLED, "Can't wait until all scheduled merges will be completed");
 }
 
 void InterpreterSystemQuery::loadPrimaryKeys()

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <DataTypes/DataTypesNumber.h>
+#include <chrono>
 #include <csignal>
 #include <filesystem>
 #include <utility>
@@ -80,6 +81,7 @@
 #include <Common/ShellCommand.h>
 #include <Common/ThreadFuzzer.h>
 #include <Common/ThreadPool.h>
+#include <Common/CurrentThread.h>
 #include <Common/escapeForFileName.h>
 #include <Common/getNumberOfCPUCoresToUse.h>
 #include <Common/getRandomASCIIString.h>
@@ -170,6 +172,7 @@ namespace ErrorCodes
     extern const int UNSUPPORTED_METHOD;
     extern const int DELTA_KERNEL_ERROR;
     extern const int FAULT_INJECTED;
+    extern const int QUERY_WAS_CANCELLED;
 }
 
 namespace FailPoints
@@ -2104,8 +2107,12 @@ void InterpreterSystemQuery::syncMerges()
     DynamicDelay poll_delay;
     poll_delay.setConfiguration(/*min_delay_=*/50, /*max_delay_=*/500, /*factor_up_=*/2.0, /*factor_lower_=*/1.0);
 
-    while (true)
+    const auto start_ts = std::chrono::steady_clock::now();
+    while (std::chrono::steady_clock::now() - start_ts < std::chrono::seconds(30))
     {
+        if (CurrentThread::isInitialized() && CurrentThread::get().isQueryCanceled())
+            throw DB::Exception(DB::ErrorCodes::QUERY_WAS_CANCELLED, "Query was cancelled");
+
         merge_tree.triggerBackgroundOperations();
 
         ActiveDataPartSet active_set;

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -2109,9 +2109,9 @@ void InterpreterSystemQuery::syncMerges()
     DynamicDelay poll_delay;
     poll_delay.setConfiguration(/*min_delay_=*/50, /*max_delay_=*/500, /*factor_up_=*/2.0, /*factor_lower_=*/1.0);
 
-    const auto max_execution_time_sec = getContext()->getSettingsRef()[Setting::max_execution_time].totalSeconds();
-    const auto timeout = max_execution_time_sec == 0 ? std::numeric_limits<int32_t>::max() : max_execution_time_sec;
-    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(timeout);
+    const auto max_execution_time_ms = getContext()->getSettingsRef()[Setting::max_execution_time].totalMilliseconds();
+    const auto timeout = max_execution_time_ms == 0 ? std::numeric_limits<int32_t>::max() : max_execution_time_ms;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout);
     while (std::chrono::steady_clock::now() < deadline)
     {
         if (CurrentThread::isInitialized() && CurrentThread::get().isQueryCanceled())

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <csignal>
 #include <filesystem>
+#include <limits>
 #include <utility>
 #include <unistd.h>
 #include <Access/AccessControl.h>
@@ -140,6 +141,7 @@ namespace Setting
     extern const SettingsUInt64 keeper_retry_max_backoff_ms;
     extern const SettingsSeconds lock_acquire_timeout;
     extern const SettingsSeconds receive_timeout;
+    extern const SettingsSeconds max_execution_time;
     extern const SettingsMaxThreads max_threads;
     extern const SettingsUInt64 max_parser_backtracks;
     extern const SettingsUInt64 max_parser_depth;
@@ -2107,8 +2109,9 @@ void InterpreterSystemQuery::syncMerges()
     DynamicDelay poll_delay;
     poll_delay.setConfiguration(/*min_delay_=*/50, /*max_delay_=*/500, /*factor_up_=*/2.0, /*factor_lower_=*/1.0);
 
-    const auto timeout = getContext()->getSettingsRef()[Setting::receive_timeout];
-    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout.totalMilliseconds());
+    const auto max_execution_time_sec = getContext()->getSettingsRef()[Setting::max_execution_time].totalSeconds();
+    const auto timeout = max_execution_time_sec == 0 ? std::numeric_limits<int32_t>::max() : max_execution_time_sec;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(timeout);
     while (std::chrono::steady_clock::now() < deadline)
     {
         if (CurrentThread::isInitialized() && CurrentThread::get().isQueryCanceled())
@@ -2127,7 +2130,7 @@ void InterpreterSystemQuery::syncMerges()
         poll_delay.up();
     }
 
-    throw DB::Exception(DB::ErrorCodes::TIMEOUT_EXCEEDED, "SYNC MERGES {}: command timed out. See the 'receive_timeout' setting", table_id.getNameForLogs());
+    throw DB::Exception(DB::ErrorCodes::TIMEOUT_EXCEEDED, "SYNC MERGES {}: command timed out. See the 'max_execution_time' setting", table_id.getNameForLogs());
 }
 
 void InterpreterSystemQuery::loadPrimaryKeys()

--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -2107,8 +2107,9 @@ void InterpreterSystemQuery::syncMerges()
     DynamicDelay poll_delay;
     poll_delay.setConfiguration(/*min_delay_=*/50, /*max_delay_=*/500, /*factor_up_=*/2.0, /*factor_lower_=*/1.0);
 
-    const auto start_ts = std::chrono::steady_clock::now();
-    while (std::chrono::steady_clock::now() - start_ts < std::chrono::seconds(30))
+    const auto timeout = getContext()->getSettingsRef()[Setting::receive_timeout];
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout.totalMilliseconds());
+    while (std::chrono::steady_clock::now() < deadline)
     {
         if (CurrentThread::isInitialized() && CurrentThread::get().isQueryCanceled())
             throw DB::Exception(DB::ErrorCodes::QUERY_WAS_CANCELLED, "Query was cancelled");
@@ -2126,7 +2127,7 @@ void InterpreterSystemQuery::syncMerges()
         poll_delay.up();
     }
 
-    throw DB::Exception(DB::ErrorCodes::QUERY_WAS_CANCELLED, "Can't wait until all scheduled merges will be completed");
+    throw DB::Exception(DB::ErrorCodes::TIMEOUT_EXCEEDED, "SYNC MERGES {}: command timed out. See the 'receive_timeout' setting", table_id.getNameForLogs());
 }
 
 void InterpreterSystemQuery::loadPrimaryKeys()


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

This patch fixes an infinite loop in these queries during stress tests. Now, the system sync merges query will loop up to `receive_timeout` seconds and also respect cancellation.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.680`
<!-- ch-version-info:end -->