### PR TITLE
Fix possible crash in MaterializedPostgreSQL replication consumer

### DIFF
--- a/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.cpp
+++ b/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.cpp
@@ -236,14 +236,16 @@ void MaterializedPostgreSQLConsumer::insertDefaultValue(StorageData & storage_da
 
 void MaterializedPostgreSQLConsumer::readString(const char * message, size_t & pos, size_t size, String & result)
 {
-    assert(size > pos + 2);
-    char current = unhex2(message + pos);
-    pos += 2;
-    while (pos < size && current != '\0')
+    while (true)
     {
-        result += current;
-        current = unhex2(message + pos);
+        if (pos + 2 > size)
+            throw Exception(ErrorCodes::POSTGRESQL_REPLICATION_INTERNAL_ERROR,
+                "Cannot read string from replication message: position {} + 2 exceeds message size {}", pos, size);
+        char current = unhex2(message + pos);
         pos += 2;
+        if (current == '\0')
+            return;
+        result += current;
     }
 }
 
@@ -259,33 +261,41 @@ T MaterializedPostgreSQLConsumer::unhexN(const char * message, size_t pos, size_
     return result;
 }
 
-Int64 MaterializedPostgreSQLConsumer::readInt64(const char * message, size_t & pos, [[maybe_unused]] size_t size)
+Int64 MaterializedPostgreSQLConsumer::readInt64(const char * message, size_t & pos, size_t size)
 {
-    assert(size >= pos + 16);
+    if (pos + 16 > size)
+        throw Exception(ErrorCodes::POSTGRESQL_REPLICATION_INTERNAL_ERROR,
+            "Cannot read Int64 from replication message: position {} + 16 exceeds message size {}", pos, size);
     Int64 result = unhexN<Int64>(message, pos, 8);
     pos += 16;
     return result;
 }
 
-Int32 MaterializedPostgreSQLConsumer::readInt32(const char * message, size_t & pos, [[maybe_unused]] size_t size)
+Int32 MaterializedPostgreSQLConsumer::readInt32(const char * message, size_t & pos, size_t size)
 {
-    assert(size >= pos + 8);
+    if (pos + 8 > size)
+        throw Exception(ErrorCodes::POSTGRESQL_REPLICATION_INTERNAL_ERROR,
+            "Cannot read Int32 from replication message: position {} + 8 exceeds message size {}", pos, size);
     Int32 result = unhexN<Int32>(message, pos, 4);
     pos += 8;
     return result;
 }
 
-Int16 MaterializedPostgreSQLConsumer::readInt16(const char * message, size_t & pos, [[maybe_unused]] size_t size)
+Int16 MaterializedPostgreSQLConsumer::readInt16(const char * message, size_t & pos, size_t size)
 {
-    assert(size >= pos + 4);
+    if (pos + 4 > size)
+        throw Exception(ErrorCodes::POSTGRESQL_REPLICATION_INTERNAL_ERROR,
+            "Cannot read Int16 from replication message: position {} + 4 exceeds message size {}", pos, size);
     Int16 result = unhexN<Int16>(message, pos, 2);
     pos += 4;
     return result;
 }
 
-Int8 MaterializedPostgreSQLConsumer::readInt8(const char * message, size_t & pos, [[maybe_unused]] size_t size)
+Int8 MaterializedPostgreSQLConsumer::readInt8(const char * message, size_t & pos, size_t size)
 {
-    assert(size >= pos + 2);
+    if (pos + 2 > size)
+        throw Exception(ErrorCodes::POSTGRESQL_REPLICATION_INTERNAL_ERROR,
+            "Cannot read Int8 from replication message: position {} + 2 exceeds message size {}", pos, size);
     Int8 result = unhex2(message + pos);
     pos += 2;
     return result;

--- a/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.cpp
+++ b/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.cpp
@@ -311,6 +311,12 @@ void MaterializedPostgreSQLConsumer::readTupleData(
 {
     Int16 num_columns = readInt16(message, pos, size);
 
+    const auto & buffer_columns = storage_data.getLastBuffer().columns;
+    if (size_t(num_columns + 2) != buffer_columns.size())
+        throw Exception(ErrorCodes::POSTGRESQL_REPLICATION_INTERNAL_ERROR,
+            "Unexpected num_columns {} in tuple, buffer has {}",
+            num_columns, buffer_columns.size() - 2);
+
     auto process_column_value = [&](Int8 identifier, Int16 column_idx)
     {
         switch (identifier) // NOLINT(bugprone-switch-missing-default-case)

--- a/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.h
+++ b/src/Storages/PostgreSQL/MaterializedPostgreSQLConsumer.h
@@ -9,6 +9,8 @@
 #include <Databases/PostgreSQL/fetchPostgreSQLTableStructure.h>
 
 
+class MaterializedPostgreSQLConsumerReadHelpers_ThrowOnOverrun_Test;
+
 namespace DB
 {
 struct SettingChange;
@@ -125,6 +127,8 @@ private:
     static Int32 readInt32(const char * message, size_t & pos, size_t size);
     static Int16 readInt16(const char * message, size_t & pos, size_t size);
     static Int8 readInt8(const char * message, size_t & pos, size_t size);
+
+    friend class ::MaterializedPostgreSQLConsumerReadHelpers_ThrowOnOverrun_Test;
 
     void markTableAsSkipped(Int32 relation_id, const String & relation_name);
 

--- a/src/Storages/PostgreSQL/tests/gtest_materialized_postgresql_consumer.cpp
+++ b/src/Storages/PostgreSQL/tests/gtest_materialized_postgresql_consumer.cpp
@@ -1,0 +1,33 @@
+#include <gtest/gtest.h>
+
+#include <Common/Exception.h>
+#include <Storages/PostgreSQL/MaterializedPostgreSQLConsumer.h>
+
+namespace DB::ErrorCodes
+{
+    extern const int POSTGRESQL_REPLICATION_INTERNAL_ERROR;
+}
+
+using Consumer = DB::MaterializedPostgreSQLConsumer;
+
+TEST(MaterializedPostgreSQLConsumerReadHelpers, ThrowOnOverrun)
+{
+    const std::string msg = "0123456789abcdef";
+    size_t pos;
+
+    pos = msg.size() - 1;
+    EXPECT_THROW(Consumer::readInt8(msg.data(), pos, msg.size()), DB::Exception);
+    pos = msg.size() - 3;
+    EXPECT_THROW(Consumer::readInt16(msg.data(), pos, msg.size()), DB::Exception);
+    pos = msg.size() - 7;
+    EXPECT_THROW(Consumer::readInt32(msg.data(), pos, msg.size()), DB::Exception);
+    pos = msg.size() - 15;
+    EXPECT_THROW(Consumer::readInt64(msg.data(), pos, msg.size()), DB::Exception);
+
+    const std::string not_nul_terminated = "4869";
+    pos = 0;
+    String result;
+    EXPECT_THROW(
+        Consumer::readString(not_nul_terminated.data(), pos, not_nul_terminated.size(), result),
+        DB::Exception);
+}


### PR DESCRIPTION
`MaterializedPostgreSQLConsumer::readInt8/16/32/64/String` used `assert()` for bounds checking, which is compiled out in release builds. A malformed or truncated WAL replication message could cause the parser to read past the message buffer and crash the server. Each `assert` is replaced with a throw of `POSTGRESQL_REPLICATION_INTERNAL_ERROR`, which the existing `consume()` loop already catches and uses to skip the malformed message. `readString` is also rewritten to bounds-check every byte and throw if a string runs to end-of-buffer without a NUL terminator (previously the loop silently truncated).

Note: when a column read fails mid-row, the pre-existing per-column `try { … } catch (…) { insertDefaultValue }` swallows the throw and inserts a default for the failing column; the row is committed to the per-table buffer with `_sign=1` and a default in place of the unparseable value. This is unchanged behavior — the fix only removes the crash; a cleaner row-drop on structural failure is a possible follow-up.

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a possible crash in `MaterializedPostgreSQL` replication consumer when receiving a malformed or truncated replication message.