### PR TITLE
Backport #102689 to 25.12: Fix columns_substreams.txt corruption during column rename

### DIFF
--- a/src/DataTypes/Serializations/ISerialization.cpp
+++ b/src/DataTypes/Serializations/ISerialization.cpp
@@ -405,11 +405,11 @@ String ISerialization::getFileNameForRenamedColumnStream(const String & name_fro
 {
     auto name_from_escaped = escapeForFileName(name_from);
     if (file_name.starts_with(name_from_escaped))
-        return escapeForFileName(name_to) + file_name.substr(0, name_from_escaped.size());
+        return escapeForFileName(name_to) + file_name.substr(name_from_escaped.size());
 
     auto nested_storage_name_escaped = escapeForFileName(Nested::extractTableName(name_from));
     if (file_name.starts_with(nested_storage_name_escaped))
-        return escapeForFileName(Nested::extractTableName(name_to)) + file_name.substr(0, nested_storage_name_escaped.size());
+        return escapeForFileName(Nested::extractTableName(name_to)) + file_name.substr(nested_storage_name_escaped.size());
 
     throw Exception(ErrorCodes::LOGICAL_ERROR, "File name {} doesn't correspond to column {}", file_name, name_from);
 }

--- a/tests/queries/0_stateless/04093_rename_column_corrupts_columns_substreams.reference
+++ b/tests/queries/0_stateless/04093_rename_column_corrupts_columns_substreams.reference
@@ -1,0 +1,38 @@
+Before rename:
+columns substreams version: 1
+2 columns:
+1 substreams for column `id`:
+	id
+2 substreams for column `arr`:
+	arr.size0
+	arr
+After rename arr -> brr:
+columns substreams version: 1
+2 columns:
+1 substreams for column `id`:
+	id
+2 substreams for column `brr`:
+	brr.size0
+	brr
+Nested before rename:
+columns substreams version: 1
+3 columns:
+1 substreams for column `id`:
+	id
+2 substreams for column `nested.a`:
+	nested.size0
+	nested%2Ea
+2 substreams for column `nested.b`:
+	nested.size0
+	nested%2Eb
+Nested after rename nested.a -> nested.aa:
+columns substreams version: 1
+3 columns:
+1 substreams for column `id`:
+	id
+2 substreams for column `nested.aa`:
+	nested.size0
+	nested%2Eaa
+2 substreams for column `nested.b`:
+	nested.size0
+	nested%2Eb

--- a/tests/queries/0_stateless/04093_rename_column_corrupts_columns_substreams.sh
+++ b/tests/queries/0_stateless/04093_rename_column_corrupts_columns_substreams.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Tags: no-shared-merge-tree
+# Test for https://github.com/ClickHouse/ClickHouse/issues/102259
+# Verifies that ALTER TABLE RENAME COLUMN on a Wide part produces correct
+# substream names in columns_substreams.txt.
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS test_rename_substreams"
+
+${CLICKHOUSE_CLIENT} --query "
+    CREATE TABLE test_rename_substreams
+    (
+        id UInt32,
+        arr Array(UInt32)
+    )
+    ENGINE = MergeTree
+    ORDER BY id
+    SETTINGS min_rows_for_wide_part = 1, min_bytes_for_wide_part = 1,
+             enable_block_number_column = 0, enable_block_offset_column = 0,
+             replace_long_file_name_to_hash = 0
+"
+
+${CLICKHOUSE_CLIENT} --query "INSERT INTO test_rename_substreams SELECT number, [number, number + 1] FROM numbers(10)"
+
+# Get data path before rename to verify initial state
+DATA_PATH=$(${CLICKHOUSE_CLIENT} --query "SELECT path FROM system.parts WHERE database = currentDatabase() AND table = 'test_rename_substreams' AND active")
+
+echo "Before rename:"
+cat "${DATA_PATH}columns_substreams.txt"
+
+# Rename arr -> brr
+${CLICKHOUSE_CLIENT} --query "ALTER TABLE test_rename_substreams RENAME COLUMN arr TO brr"
+
+# Get the new part path (mutation creates a new part)
+DATA_PATH_NEW=$(${CLICKHOUSE_CLIENT} --query "SELECT path FROM system.parts WHERE database = currentDatabase() AND table = 'test_rename_substreams' AND active")
+
+echo "After rename arr -> brr:"
+cat "${DATA_PATH_NEW}columns_substreams.txt"
+
+# Also rename a Nested column to test the second code path (line 450)
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS test_rename_nested_substreams"
+
+${CLICKHOUSE_CLIENT} --query "
+    CREATE TABLE test_rename_nested_substreams
+    (
+        id UInt32,
+        nested Nested(a UInt32, b UInt32)
+    )
+    ENGINE = MergeTree
+    ORDER BY id
+    SETTINGS min_rows_for_wide_part = 1, min_bytes_for_wide_part = 1,
+             enable_block_number_column = 0, enable_block_offset_column = 0,
+             replace_long_file_name_to_hash = 0
+"
+
+${CLICKHOUSE_CLIENT} --query "INSERT INTO test_rename_nested_substreams SELECT number, [number], [number + 1] FROM numbers(10)"
+
+DATA_PATH_NESTED=$(${CLICKHOUSE_CLIENT} --query "SELECT path FROM system.parts WHERE database = currentDatabase() AND table = 'test_rename_nested_substreams' AND active")
+
+echo "Nested before rename:"
+cat "${DATA_PATH_NESTED}columns_substreams.txt"
+
+# Rename nested.a -> nested.aa
+${CLICKHOUSE_CLIENT} --query "ALTER TABLE test_rename_nested_substreams RENAME COLUMN nested.a TO nested.aa"
+
+DATA_PATH_NESTED_NEW=$(${CLICKHOUSE_CLIENT} --query "SELECT path FROM system.parts WHERE database = currentDatabase() AND table = 'test_rename_nested_substreams' AND active")
+
+echo "Nested after rename nested.a -> nested.aa:"
+cat "${DATA_PATH_NESTED_NEW}columns_substreams.txt"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE test_rename_substreams"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE test_rename_nested_substreams"


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry:
Fix `columns_substreams.txt` corruption during column rename

Backport #102689 to 25.12.

Cherry-pick of d90e5c40e36.
Already backported to 26.2, 26.3, 26.4. This adds the missing 25.12 backport, needed for INC-62804.