### PR TITLE
CI Fix or Improvement: declare workflow-level contents: read on 3 hand-written workflows

### DIFF
--- a/.github/workflows/backfill_distroless.yml
+++ b/.github/workflows/backfill_distroless.yml
@@ -19,6 +19,9 @@ concurrency:
 env:
   PYTHONUNBUFFERED: 1
 
+permissions:
+  contents: read
+
 jobs:
   BackfillDistroless:
     runs-on: [self-hosted, release-maker]

--- a/.github/workflows/cherry_pick.yml
+++ b/.github/workflows/cherry_pick.yml
@@ -11,6 +11,9 @@ on: # yamllint disable-line rule:truthy
     - cron: '0 * * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   CherryPick:
     runs-on: [self-hosted, style-checker-aarch64]

--- a/.github/workflows/weekly_official_docker.yml
+++ b/.github/workflows/weekly_official_docker.yml
@@ -22,6 +22,9 @@ env:
 concurrency:
   group: official-docker-library
 
+permissions:
+  contents: read
+
 jobs:
   UpdateOfficialDocker:
     runs-on: [self-hosted, style-checker-aarch64]


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry
(none, CI hygiene)

### Description

Pins the default `GITHUB_TOKEN` to read-only on the three hand-written workflows in `.github/workflows/` that were still implicit. None of them use `GITHUB_TOKEN` for any write operation:

- `backfill_distroless.yml`: `workflow_dispatch` only. Builds distroless Docker images and pushes to Docker Hub via `docker buildx`. No GitHub API call.
- `cherry_pick.yml`: hourly scheduler that cherry-picks PRs across release branches. The actual git push happens via `ROBOT_CLICKHOUSE_COMMIT_TOKEN` (separate PAT) and `ROBOT_CLICKHOUSE_SSH_KEY` (separate SSH key), not `GITHUB_TOKEN`.
- `weekly_official_docker.yml`: weekly cron updating the official Docker Hub repos. Git operations use `ROBOT_CLICKHOUSE_SSH_KEY`, again not `GITHUB_TOKEN`.

So `permissions: contents: read` documents existing behavior and caps runtime authority if a third-party action is ever compromised. No functional change.

The other nine workflows that were flagged as still-implicit (`hourly.yml`, `merge_queue.yml`, the various `nightly_*.yml`, `vectorsearchstress.yml`) are all `# generated by praktika` and should be patched at the praktika generator rather than the emitted YAML, so they are intentionally left out of this PR.

### Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token retained whatever scope was issued at the workflow level. Pinning per workflow bounds runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.