### PR TITLE
Compute per-row Tuple range mask in hilbertEncode and mortonEncode

### DIFF
--- a/src/Functions/FunctionSpaceFillingCurve.h
+++ b/src/Functions/FunctionSpaceFillingCurve.h
@@ -35,25 +35,13 @@ public:
 
     bool useDefaultImplementationForConstants() const override { return true; }
 
-    /// Accessor for the optional range-mask `Tuple` argument of `mortonEncode`/`hilbertEncode`.
-    ///
-    /// The range mask may be either:
-    ///   - a `ColumnConst` wrapping a 1-row `ColumnTuple` (the common case: a literal `Tuple` or
-    ///     a constant-folded expression). All rows share the same mask values; we always
-    ///     read row 0 of the underlying tuple. This includes the case where the all-arguments-
-    ///     constant fast path of `useDefaultImplementationForConstants` has already unwrapped
-    ///     the `ColumnConst` into a 1-row `ColumnTuple` (still equivalent to "always row 0").
-    ///   - a non-constant multi-row `ColumnTuple` (e.g. produced by `materialize` or by
-    ///     reading a `Tuple` column from a table). Each row has its own mask values, and the
-    ///     encoder must read row `i` for row `i`. Reading row 0 for every row was a silent
-    ///     wrong-result bug fixed by accepting non-constant masks and computing per-row.
+    /// Range-mask `Tuple` accessor for the expanded mode of `mortonEncode` / `hilbertEncode`.
+    /// `is_const` selects between reading row 0 for every row or reading row `row_idx`.
     struct RangeMask
     {
         const ColumnTuple * tuple = nullptr;
         bool is_const = false;
 
-        /// Read the ratio for tuple element `col_idx` at row `row_idx`. For constant masks
-        /// this always returns row 0 of the underlying tuple (the value shared by all rows).
         UInt64 read(size_t col_idx, size_t row_idx) const
         {
             return tuple->getColumn(col_idx).getUInt(is_const ? 0 : row_idx);
@@ -64,11 +52,6 @@ public:
         explicit operator bool() const { return tuple != nullptr; }
     };
 
-    /// Extracts the optional range-mask `Tuple` from the first argument. Returns an empty
-    /// `RangeMask` (operator bool == false) when the first argument is not a `Tuple` — i.e.
-    /// the simple-mode call, e.g. `hilbertEncode(n1, n2)`. `RangeMask::is_const` tracks
-    /// whether the column is a `ColumnConst`, which determines whether the encoder reads
-    /// the same row 0 for every output row or reads per-row mask values.
     static RangeMask extractRangeMask(const ColumnsWithTypeAndName & arguments)
     {
         if (arguments.empty())

--- a/src/Functions/FunctionSpaceFillingCurve.h
+++ b/src/Functions/FunctionSpaceFillingCurve.h
@@ -35,49 +35,56 @@ public:
 
     bool useDefaultImplementationForConstants() const override { return true; }
 
-    /// Extracts the optional range-mask Tuple from the first argument of `mortonEncode`/`hilbertEncode`.
-    /// Returns nullptr when the first argument is not a Tuple (i.e. the simple-mode call,
-    /// e.g. `hilbertEncode(n1, n2)`).
+    /// Accessor for the optional range-mask `Tuple` argument of `mortonEncode`/`hilbertEncode`.
     ///
-    /// Pre-condition: when `arguments[0]` has Tuple type, `getReturnTypeImpl` has already
-    /// validated that its column is a `ColumnConst`. Therefore at execute time
-    /// `arguments[0].column` is either:
-    ///   - a `ColumnConst` wrapping a `ColumnTuple` (the typical case when other arguments
-    ///     are non-constant), or
-    ///   - a stripped single-row `ColumnTuple` (when ALL arguments are constant and
-    ///     `useDefaultImplementationForConstants` has unwrapped the `ColumnConst`).
-    /// Reading the mask values from row 0 of the tuple is correct in both cases.
-    static const ColumnTuple * extractConstantRangeMask(const ColumnsWithTypeAndName & arguments)
+    /// The range mask may be either:
+    ///   - a `ColumnConst` wrapping a 1-row `ColumnTuple` (the common case: a literal `Tuple` or
+    ///     a constant-folded expression). All rows share the same mask values; we always
+    ///     read row 0 of the underlying tuple. This includes the case where the all-arguments-
+    ///     constant fast path of `useDefaultImplementationForConstants` has already unwrapped
+    ///     the `ColumnConst` into a 1-row `ColumnTuple` (still equivalent to "always row 0").
+    ///   - a non-constant multi-row `ColumnTuple` (e.g. produced by `materialize` or by
+    ///     reading a `Tuple` column from a table). Each row has its own mask values, and the
+    ///     encoder must read row `i` for row `i`. Reading row 0 for every row was a silent
+    ///     wrong-result bug fixed by accepting non-constant masks and computing per-row.
+    struct RangeMask
     {
-        const auto * const_col = typeid_cast<const ColumnConst *>(arguments[0].column.get());
-        if (const_col)
-            return typeid_cast<const ColumnTuple *>(const_col->getDataColumnPtr().get());
-        return typeid_cast<const ColumnTuple *>(arguments[0].column.get());
-    }
+        const ColumnTuple * tuple = nullptr;
+        bool is_const = false;
 
-    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
-    {
-        /// Enforce the constant-only contract on the range-mask Tuple argument BEFORE
-        /// `useDefaultImplementationForConstants` strips any `ColumnConst` wrapper at
-        /// execute time. Without this check, a non-constant Tuple (e.g. produced by
-        /// `materialize` or `ARRAY JOIN`) would have its row-0 mask values used to drive
-        /// the bit-shift for every row, producing silently wrong results. The check is
-        /// performed at type-resolution time, so it is independent of `max_block_size`
-        /// and pipeline chunking. Mirrors the constant-only contract of
-        /// `FunctionSpaceFillingCurveDecode::getReturnTypeImpl`.
-        if (!arguments.empty() && WhichDataType(arguments[0].type).isTuple())
+        /// Read the ratio for tuple element `col_idx` at row `row_idx`. For constant masks
+        /// this always returns row 0 of the underlying tuple (the value shared by all rows).
+        UInt64 read(size_t col_idx, size_t row_idx) const
         {
-            if (!arguments[0].column || !isColumnConst(*arguments[0].column))
-                throw Exception(ErrorCodes::ILLEGAL_COLUMN,
-                                "Illegal column type {} for function {}, the range mask (Tuple) argument must be constant",
-                                arguments[0].type->getName(), getName());
+            return tuple->getColumn(col_idx).getUInt(is_const ? 0 : row_idx);
         }
 
-        DataTypes types;
-        types.reserve(arguments.size());
-        for (const auto & arg : arguments)
-            types.push_back(arg.type);
-        return getReturnTypeImpl(types);
+        size_t tupleSize() const { return tuple->tupleSize(); }
+
+        explicit operator bool() const { return tuple != nullptr; }
+    };
+
+    /// Extracts the optional range-mask `Tuple` from the first argument. Returns an empty
+    /// `RangeMask` (operator bool == false) when the first argument is not a `Tuple` — i.e.
+    /// the simple-mode call, e.g. `hilbertEncode(n1, n2)`. `RangeMask::is_const` tracks
+    /// whether the column is a `ColumnConst`, which determines whether the encoder reads
+    /// the same row 0 for every output row or reads per-row mask values.
+    static RangeMask extractRangeMask(const ColumnsWithTypeAndName & arguments)
+    {
+        if (arguments.empty())
+            return {};
+        const auto * const_col = typeid_cast<const ColumnConst *>(arguments[0].column.get());
+        if (const_col)
+        {
+            const auto * tuple = typeid_cast<const ColumnTuple *>(const_col->getDataColumnPtr().get());
+            if (tuple)
+                return RangeMask{tuple, true};
+            return {};
+        }
+        const auto * tuple = typeid_cast<const ColumnTuple *>(arguments[0].column.get());
+        if (tuple)
+            return RangeMask{tuple, false};
+        return {};
     }
 
     DataTypePtr getReturnTypeImpl(const DB::DataTypes & arguments) const override

--- a/src/Functions/FunctionSpaceFillingCurve.h
+++ b/src/Functions/FunctionSpaceFillingCurve.h
@@ -2,6 +2,7 @@
 #include <Functions/IFunction.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeTuple.h>
+#include <Columns/ColumnConst.h>
 #include <Columns/ColumnTuple.h>
 #include <Functions/FunctionHelpers.h>
 
@@ -33,6 +34,31 @@ public:
     bool isSuitableForShortCircuitArgumentsExecution(const DataTypesWithConstInfo & /*arguments*/) const override { return false; }
 
     bool useDefaultImplementationForConstants() const override { return true; }
+
+    /// Extracts the optional range-mask Tuple from the first argument of `mortonEncode`/`hilbertEncode`.
+    /// Returns nullptr if the first argument is not a Tuple (i.e. the simple-mode call, e.g. `hilbertEncode(n1, n2)`).
+    /// Throws `ILLEGAL_COLUMN` if the first argument is a multi-row non-constant Tuple column:
+    /// the mask is a scaling/range specification, the implementation reads its values once
+    /// to drive bit shifts for every row, and a per-row varying Tuple is not supported.
+    /// (When all arguments are constants, `useDefaultImplementationForConstants` strips the
+    /// `ColumnConst` wrapper and passes a single-row `ColumnTuple` here — that case is safe.)
+    /// Mirrors the constant-only contract of `FunctionSpaceFillingCurveDecode::getReturnTypeImpl`.
+    static const ColumnTuple * extractConstantRangeMask(
+        const ColumnsWithTypeAndName & arguments, const String & function_name, size_t input_rows_count)
+    {
+        const auto * const_col = typeid_cast<const ColumnConst *>(arguments[0].column.get());
+        if (const_col)
+            return typeid_cast<const ColumnTuple *>(const_col->getDataColumnPtr().get());
+        if (const auto * tuple_col = typeid_cast<const ColumnTuple *>(arguments[0].column.get()))
+        {
+            if (input_rows_count > 1)
+                throw Exception(ErrorCodes::ILLEGAL_COLUMN,
+                                "Illegal column type {} for function {}, the range mask (Tuple) argument must be constant",
+                                arguments[0].column->getName(), function_name);
+            return tuple_col;
+        }
+        return nullptr;
+    }
 
     DataTypePtr getReturnTypeImpl(const DB::DataTypes & arguments) const override
     {

--- a/src/Functions/FunctionSpaceFillingCurve.h
+++ b/src/Functions/FunctionSpaceFillingCurve.h
@@ -36,28 +36,48 @@ public:
     bool useDefaultImplementationForConstants() const override { return true; }
 
     /// Extracts the optional range-mask Tuple from the first argument of `mortonEncode`/`hilbertEncode`.
-    /// Returns nullptr if the first argument is not a Tuple (i.e. the simple-mode call, e.g. `hilbertEncode(n1, n2)`).
-    /// Throws `ILLEGAL_COLUMN` if the first argument is a multi-row non-constant Tuple column:
-    /// the mask is a scaling/range specification, the implementation reads its values once
-    /// to drive bit shifts for every row, and a per-row varying Tuple is not supported.
-    /// (When all arguments are constants, `useDefaultImplementationForConstants` strips the
-    /// `ColumnConst` wrapper and passes a single-row `ColumnTuple` here — that case is safe.)
-    /// Mirrors the constant-only contract of `FunctionSpaceFillingCurveDecode::getReturnTypeImpl`.
-    static const ColumnTuple * extractConstantRangeMask(
-        const ColumnsWithTypeAndName & arguments, const String & function_name, size_t input_rows_count)
+    /// Returns nullptr when the first argument is not a Tuple (i.e. the simple-mode call,
+    /// e.g. `hilbertEncode(n1, n2)`).
+    ///
+    /// Pre-condition: when `arguments[0]` has Tuple type, `getReturnTypeImpl` has already
+    /// validated that its column is a `ColumnConst`. Therefore at execute time
+    /// `arguments[0].column` is either:
+    ///   - a `ColumnConst` wrapping a `ColumnTuple` (the typical case when other arguments
+    ///     are non-constant), or
+    ///   - a stripped single-row `ColumnTuple` (when ALL arguments are constant and
+    ///     `useDefaultImplementationForConstants` has unwrapped the `ColumnConst`).
+    /// Reading the mask values from row 0 of the tuple is correct in both cases.
+    static const ColumnTuple * extractConstantRangeMask(const ColumnsWithTypeAndName & arguments)
     {
         const auto * const_col = typeid_cast<const ColumnConst *>(arguments[0].column.get());
         if (const_col)
             return typeid_cast<const ColumnTuple *>(const_col->getDataColumnPtr().get());
-        if (const auto * tuple_col = typeid_cast<const ColumnTuple *>(arguments[0].column.get()))
+        return typeid_cast<const ColumnTuple *>(arguments[0].column.get());
+    }
+
+    DataTypePtr getReturnTypeImpl(const ColumnsWithTypeAndName & arguments) const override
+    {
+        /// Enforce the constant-only contract on the range-mask Tuple argument BEFORE
+        /// `useDefaultImplementationForConstants` strips any `ColumnConst` wrapper at
+        /// execute time. Without this check, a non-constant Tuple (e.g. produced by
+        /// `materialize` or `ARRAY JOIN`) would have its row-0 mask values used to drive
+        /// the bit-shift for every row, producing silently wrong results. The check is
+        /// performed at type-resolution time, so it is independent of `max_block_size`
+        /// and pipeline chunking. Mirrors the constant-only contract of
+        /// `FunctionSpaceFillingCurveDecode::getReturnTypeImpl`.
+        if (!arguments.empty() && WhichDataType(arguments[0].type).isTuple())
         {
-            if (input_rows_count > 1)
+            if (!arguments[0].column || !isColumnConst(*arguments[0].column))
                 throw Exception(ErrorCodes::ILLEGAL_COLUMN,
                                 "Illegal column type {} for function {}, the range mask (Tuple) argument must be constant",
-                                arguments[0].column->getName(), function_name);
-            return tuple_col;
+                                arguments[0].type->getName(), getName());
         }
-        return nullptr;
+
+        DataTypes types;
+        types.reserve(arguments.size());
+        for (const auto & arg : arguments)
+            types.push_back(arg.type);
+        return getReturnTypeImpl(types);
     }
 
     DataTypePtr getReturnTypeImpl(const DB::DataTypes & arguments) const override

--- a/src/Functions/hilbertEncode.cpp
+++ b/src/Functions/hilbertEncode.cpp
@@ -37,9 +37,6 @@ public:
         {
             num_dimensions = mask.tupleSize();
             vector_start_index = 1;
-            /// Validate the ratios. For constant masks only row 0 carries information
-            /// (every output row reads the same values); for non-constant masks every
-            /// row may have its own ratio, so each row must be validated independently.
             const size_t rows_to_check = mask.is_const ? 1 : input_rows_count;
             for (size_t row = 0; row < rows_to_check; ++row)
             {

--- a/src/Functions/hilbertEncode.cpp
+++ b/src/Functions/hilbertEncode.cpp
@@ -32,18 +32,25 @@ public:
 
         size_t num_dimensions = arguments.size();
         size_t vector_start_index = 0;
-        const ColumnTuple * mask = extractConstantRangeMask(arguments);
+        auto mask = extractRangeMask(arguments);
         if (mask)
         {
-            num_dimensions = mask->tupleSize();
+            num_dimensions = mask.tupleSize();
             vector_start_index = 1;
-            for (size_t i = 0; i < num_dimensions; i++)
+            /// Validate the ratios. For constant masks only row 0 carries information
+            /// (every output row reads the same values); for non-constant masks every
+            /// row may have its own ratio, so each row must be validated independently.
+            const size_t rows_to_check = mask.is_const ? 1 : input_rows_count;
+            for (size_t row = 0; row < rows_to_check; ++row)
             {
-                auto ratio = mask->getColumn(i).getUInt(0);
-                if (ratio > 32)
-                    throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND,
-                                    "Illegal argument {} of function {}, should be a number in range 0-32",
-                                    arguments[0].column->getName(), getName());
+                for (size_t i = 0; i < num_dimensions; ++i)
+                {
+                    auto ratio = mask.read(i, row);
+                    if (ratio > 32)
+                        throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND,
+                                        "Illegal argument {} of function {}, should be a number in range 0-32",
+                                        arguments[0].column->getName(), getName());
+                }
             }
         }
 
@@ -51,10 +58,10 @@ public:
         ColumnUInt64::Container & vec_res = col_res->getData();
         vec_res.resize(input_rows_count);
 
-        const auto expand = [mask](const UInt64 value, const UInt8 column_num)
+        const auto expand = [&mask](const size_t row, const UInt64 value, const UInt8 column_num) -> UInt64
         {
             if (mask)
-                return value << mask->getColumn(column_num).getUInt(0);
+                return value << mask.read(column_num, row);
             return value;
         };
 
@@ -63,7 +70,7 @@ public:
         {
             for (size_t i = 0; i < input_rows_count; ++i)
             {
-                vec_res[i] = expand(col0->getUInt(i), 0);
+                vec_res[i] = expand(i, col0->getUInt(i), 0);
             }
             return col_res;
         }
@@ -74,8 +81,8 @@ public:
             for (size_t i = 0; i < input_rows_count; ++i)
             {
                 vec_res[i] = FunctionHilbertEncode2DWIthLookupTableImpl<3>::encode(
-                    expand(col0->getUInt(i), 0),
-                    expand(col1->getUInt(i), 1));
+                    expand(i, col0->getUInt(i), 0),
+                    expand(i, col1->getUInt(i), 1));
             }
             return col_res;
         }

--- a/src/Functions/hilbertEncode.cpp
+++ b/src/Functions/hilbertEncode.cpp
@@ -32,7 +32,7 @@ public:
 
         size_t num_dimensions = arguments.size();
         size_t vector_start_index = 0;
-        const ColumnTuple * mask = extractConstantRangeMask(arguments, getName(), input_rows_count);
+        const ColumnTuple * mask = extractConstantRangeMask(arguments);
         if (mask)
         {
             num_dimensions = mask->tupleSize();

--- a/src/Functions/hilbertEncode.cpp
+++ b/src/Functions/hilbertEncode.cpp
@@ -32,12 +32,7 @@ public:
 
         size_t num_dimensions = arguments.size();
         size_t vector_start_index = 0;
-        const auto * const_col = typeid_cast<const ColumnConst *>(arguments[0].column.get());
-        const ColumnTuple * mask;
-        if (const_col)
-            mask = typeid_cast<const ColumnTuple *>(const_col->getDataColumnPtr().get());
-        else
-            mask = typeid_cast<const ColumnTuple *>(arguments[0].column.get());
+        const ColumnTuple * mask = extractConstantRangeMask(arguments, getName(), input_rows_count);
         if (mask)
         {
             num_dimensions = mask->tupleSize();

--- a/src/Functions/mortonEncode.cpp
+++ b/src/Functions/mortonEncode.cpp
@@ -34,8 +34,6 @@ namespace ErrorCodes
     { \
         nd = mask.tupleSize(); \
         vectorStartIndex = 1; \
-        /* Validate ratios. For constant masks check row 0 only; for non-constant */ \
-        /* masks every row may have its own ratio, so each row is validated. */ \
         const size_t rows_to_check_morton = mask.is_const ? 1 : input_rows_count; \
         for (size_t row = 0; row < rows_to_check_morton; row++) \
         { \

--- a/src/Functions/mortonEncode.cpp
+++ b/src/Functions/mortonEncode.cpp
@@ -29,12 +29,7 @@ namespace ErrorCodes
 #define EXECUTE() \
     size_t nd = arguments.size(); \
     size_t vectorStartIndex = 0; \
-    const auto * const_col = typeid_cast<const ColumnConst *>(arguments[0].column.get()); \
-    const ColumnTuple * mask; \
-    if (const_col) \
-        mask = typeid_cast<const ColumnTuple *>(const_col->getDataColumnPtr().get()); \
-    else \
-        mask = typeid_cast<const ColumnTuple *>(arguments[0].column.get()); \
+    const ColumnTuple * mask = extractConstantRangeMask(arguments, getName(), input_rows_count); \
     if (mask) \
     { \
         nd = mask->tupleSize(); \

--- a/src/Functions/mortonEncode.cpp
+++ b/src/Functions/mortonEncode.cpp
@@ -24,23 +24,29 @@ namespace ErrorCodes
     const ColumnPtr & col##INDEX = non_const_arguments[(INDEX) + vectorStartIndex].column;
 
 #define EXPAND(IDX, ...) \
-    (mask) ? expand(mask->getColumn(IDX).getUInt(0), __VA_ARGS__) : __VA_ARGS__
+    (mask ? expand(mask.read(IDX, i), __VA_ARGS__) : __VA_ARGS__)
 
 #define EXECUTE() \
     size_t nd = arguments.size(); \
     size_t vectorStartIndex = 0; \
-    const ColumnTuple * mask = extractConstantRangeMask(arguments); \
+    auto mask = extractRangeMask(arguments); \
     if (mask) \
     { \
-        nd = mask->tupleSize(); \
+        nd = mask.tupleSize(); \
         vectorStartIndex = 1; \
-        for (size_t i = 0; i < nd; i++) \
+        /* Validate ratios. For constant masks check row 0 only; for non-constant */ \
+        /* masks every row may have its own ratio, so each row is validated. */ \
+        const size_t rows_to_check_morton = mask.is_const ? 1 : input_rows_count; \
+        for (size_t row = 0; row < rows_to_check_morton; row++) \
         { \
-            auto ratio = mask->getColumn(i).getUInt(0); \
-            if (ratio > 8 || ratio < 1) \
-                throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, \
-                                "Illegal argument {} of function {}, should be a number in range 1-8", \
-                                arguments[0].column->getName(), getName()); \
+            for (size_t i = 0; i < nd; i++) \
+            { \
+                auto ratio = mask.read(i, row); \
+                if (ratio > 8 || ratio < 1) \
+                    throw Exception(ErrorCodes::ARGUMENT_OUT_OF_BOUND, \
+                                    "Illegal argument {} of function {}, should be a number in range 1-8", \
+                                    arguments[0].column->getName(), getName()); \
+            } \
         } \
     } \
      \

--- a/src/Functions/mortonEncode.cpp
+++ b/src/Functions/mortonEncode.cpp
@@ -29,7 +29,7 @@ namespace ErrorCodes
 #define EXECUTE() \
     size_t nd = arguments.size(); \
     size_t vectorStartIndex = 0; \
-    const ColumnTuple * mask = extractConstantRangeMask(arguments, getName(), input_rows_count); \
+    const ColumnTuple * mask = extractConstantRangeMask(arguments); \
     if (mask) \
     { \
         nd = mask->tupleSize(); \

--- a/tests/queries/0_stateless/04242_space_filling_curve_encode_non_const_mask.reference
+++ b/tests/queries/0_stateless/04242_space_filling_curve_encode_non_const_mask.reference
@@ -12,3 +12,8 @@
 32768
 ----- hilbertEncode: multi-row non-constant Tuple mask is rejected -----
 ----- mortonEncode: multi-row non-constant Tuple mask is rejected -----
+----- block-size independence: rejection holds with max_block_size = 1 -----
+31
+512
+53
+32768

--- a/tests/queries/0_stateless/04242_space_filling_curve_encode_non_const_mask.reference
+++ b/tests/queries/0_stateless/04242_space_filling_curve_encode_non_const_mask.reference
@@ -1,0 +1,14 @@
+----- hilbertEncode: simple mode (no Tuple) -----
+31
+31
+----- hilbertEncode: constant Tuple mask -----
+4031541586602
+512
+----- mortonEncode: simple mode (no Tuple) -----
+53
+53
+----- mortonEncode: constant Tuple mask -----
+1572864
+32768
+----- hilbertEncode: multi-row non-constant Tuple mask is rejected -----
+----- mortonEncode: multi-row non-constant Tuple mask is rejected -----

--- a/tests/queries/0_stateless/04242_space_filling_curve_encode_non_const_mask.reference
+++ b/tests/queries/0_stateless/04242_space_filling_curve_encode_non_const_mask.reference
@@ -10,10 +10,33 @@
 ----- mortonEncode: constant Tuple mask -----
 1572864
 32768
------ hilbertEncode: multi-row non-constant Tuple mask is rejected -----
------ mortonEncode: multi-row non-constant Tuple mask is rejected -----
------ block-size independence: rejection holds with max_block_size = 1 -----
+----- hilbertEncode: multi-row non-constant Tuple mask is computed per row -----
+3
+6
+12
+3843754
+4209322
+61500074
+67349162
+----- mortonEncode: multi-row non-constant Tuple mask is computed per row -----
+3
+10
+36
+1049088
+4398047035392
+536870912
+549755813888
+----- block-size independence: per-row computation is consistent across chunk sizes -----
 31
 512
 53
 32768
+3
+6
+12
+3
+10
+36
+12
+36
+----- per-row validation: out-of-range mask in any row is rejected -----

--- a/tests/queries/0_stateless/04242_space_filling_curve_encode_non_const_mask.sql
+++ b/tests/queries/0_stateless/04242_space_filling_curve_encode_non_const_mask.sql
@@ -1,12 +1,6 @@
--- Regression for a silent wrong-result bug in `hilbertEncode` and `mortonEncode`:
--- when the first argument was a non-constant `Tuple` column, the implementations
--- read the range mask from row 0 and used it for every row, producing wrong results.
--- Detected by `function_prop_fuzzer` as a determinism violation:
--- single-row vs multi-row execution of the same input row produced different values.
---
--- After the fix, a non-constant `Tuple` first argument is accepted: the encoder reads
--- the mask values of each row independently and produces the same output that a single-
--- row query of the same logical row would produce. Result is block-size independent.
+-- Regression for issue flagged by `function_prop_fuzzer`: a non-constant `Tuple`
+-- range mask in `hilbertEncode` / `mortonEncode` must compute per-row values, not
+-- silently read row 0 for every row.
 
 SELECT '----- hilbertEncode: simple mode (no Tuple) -----';
 SELECT hilbertEncode(3, 4);
@@ -25,22 +19,15 @@ SELECT mortonEncode((1, 2), 1024, 16);
 SELECT mortonEncode(tuple(2), materialize(toUInt32(128)));
 
 SELECT '----- hilbertEncode: multi-row non-constant Tuple mask is computed per row -----';
--- Before the fix the implementation silently used row 0's mask values to drive
--- the bit-shift for every row, producing wrong results (the fuzzer flagged this as
--- single-row vs multi-row determinism violation). After the fix each row uses its
--- own mask: row N has mask `tuple(N)`, value `3`, so the result is `3 << N`.
+-- Row N has mask `tuple(N)`, value `3`, so the result is `3 << N`.
 SELECT hilbertEncode(a, b) FROM (
     SELECT tuple(toUInt64(number)) AS a, toUInt16(3) AS b FROM numbers(3)
 );
--- Two-dimensional mask varying per row: row N has mask `(N, N+1)`, b=1024, c=16.
--- Per-row shifts: b << N and c << (N+1) feed into the 2D Hilbert encoder.
 SELECT hilbertEncode(a, b, c) FROM (
     SELECT (toUInt64(number), toUInt64(number + 1)) AS a, toUInt32(1024) AS b, toUInt32(16) AS c FROM numbers(4)
 );
 
 SELECT '----- mortonEncode: multi-row non-constant Tuple mask is computed per row -----';
--- Row N has mask `tuple(N+1)` (so ratios are 1, 2, 3), value `3`.
--- Per-row results: ratio=1 → 3; ratio=2 → MortonND_2D.Encode(0, 3); ratio=3 → MortonND_3D.Encode(0, 0, 3).
 SELECT mortonEncode(a, b) FROM (
     SELECT tuple(toUInt64(number + 1)) AS a, toUInt16(3) AS b FROM numbers(3)
 );
@@ -49,20 +36,13 @@ SELECT mortonEncode(a, b, c) FROM (
 );
 
 SELECT '----- block-size independence: per-row computation is consistent across chunk sizes -----';
--- Previously, with `SET max_block_size = 1` the same expression silently produced
--- different values because each chunk was 1 row and row 0 of a 1-row chunk is the
--- correct row. With the default block size all rows used row 0 of the multi-row
--- chunk, producing wrong results. After the fix the output is identical regardless
--- of `max_block_size`.
 SET max_block_size = 1;
 
--- Simple-mode and constant-mask paths continue to work with block size 1.
 SELECT hilbertEncode(materialize(toUInt32(3)), materialize(toUInt32(4)));
 SELECT hilbertEncode(tuple(2), materialize(toUInt32(128)));
 SELECT mortonEncode(materialize(toUInt32(1)), materialize(toUInt32(2)), materialize(toUInt32(3)));
 SELECT mortonEncode(tuple(2), materialize(toUInt32(128)));
 
--- Non-constant Tuple masks now produce the same per-row values as with the default block size.
 SELECT hilbertEncode(a, b) FROM (
     SELECT tuple(toUInt64(number)) AS a, toUInt16(3) AS b FROM numbers(3)
 );
@@ -70,7 +50,6 @@ SELECT mortonEncode(a, b) FROM (
     SELECT tuple(toUInt64(number + 1)) AS a, toUInt16(3) AS b FROM numbers(3)
 );
 
--- And the result for a naturally single-row source matches a single row of the multi-row source.
 SELECT hilbertEncode(a, b) FROM (
     SELECT tuple(toUInt64(2)) AS a, toUInt16(3) AS b FROM numbers(1)
 );
@@ -79,12 +58,6 @@ SELECT mortonEncode(a, b) FROM (
 );
 
 SELECT '----- per-row validation: out-of-range mask in any row is rejected -----';
--- For hilbert the ratio must be 0-32 and for morton must be 1-8. Validation now
--- runs per row for non-constant masks, so an out-of-range value in any row throws.
--- The test uses single-row sources so the validation fires before any output is
--- streamed; mid-sequence bad rows would emit the preceding rows in 1-row chunks
--- (with `SET max_block_size = 1` above), which would make the test output depend
--- on chunk size — orthogonal to what we want to assert here.
 SELECT hilbertEncode(a, b) FROM (
     SELECT tuple(toUInt64(33)) AS a, toUInt16(1) AS b FROM numbers(1)
 ); -- { serverError ARGUMENT_OUT_OF_BOUND }

--- a/tests/queries/0_stateless/04242_space_filling_curve_encode_non_const_mask.sql
+++ b/tests/queries/0_stateless/04242_space_filling_curve_encode_non_const_mask.sql
@@ -44,3 +44,36 @@ SELECT mortonEncode(a, b) FROM (
 SELECT mortonEncode(a, b, c) FROM (
     SELECT (toUInt64(number + 1), toUInt64(number + 1)) AS a, toUInt32(1024) AS b, toUInt32(16) AS c FROM numbers(4)
 ); -- { serverError ILLEGAL_COLUMN }
+
+SELECT '----- block-size independence: rejection holds with max_block_size = 1 -----';
+-- The rejection of a non-constant Tuple mask must be independent of pipeline chunk
+-- size. Earlier the check looked at `input_rows_count > 1`, which is the current chunk
+-- size rather than a query-level property: with `SET max_block_size = 1` a non-constant
+-- Tuple was sliced into 1-row chunks and silently produced wrong results instead of
+-- throwing. The check is now done at type-resolution time (in `getReturnTypeImpl`),
+-- so it fires regardless of chunking, and equally for naturally single-row sources
+-- (a `FROM ... LIMIT 1` query produces `input_rows_count = 1` without setting
+-- `max_block_size`).
+SET max_block_size = 1;
+
+-- Simple-mode and constant-mask paths continue to work with block size 1.
+SELECT hilbertEncode(materialize(toUInt32(3)), materialize(toUInt32(4)));
+SELECT hilbertEncode(tuple(2), materialize(toUInt32(128)));
+SELECT mortonEncode(materialize(toUInt32(1)), materialize(toUInt32(2)), materialize(toUInt32(3)));
+SELECT mortonEncode(tuple(2), materialize(toUInt32(128)));
+
+-- Non-constant Tuple masks are still rejected when the pipeline produces 1-row chunks.
+SELECT hilbertEncode(a, b) FROM (
+    SELECT tuple(toUInt64(number)) AS a, toUInt16(3) AS b FROM numbers(3)
+); -- { serverError ILLEGAL_COLUMN }
+SELECT mortonEncode(a, b) FROM (
+    SELECT tuple(toUInt64(number + 1)) AS a, toUInt16(3) AS b FROM numbers(3)
+); -- { serverError ILLEGAL_COLUMN }
+
+-- And also when the source is naturally single-row (independent of `max_block_size`).
+SELECT hilbertEncode(a, b) FROM (
+    SELECT tuple(toUInt64(number)) AS a, toUInt16(3) AS b FROM numbers(1)
+); -- { serverError ILLEGAL_COLUMN }
+SELECT mortonEncode(a, b) FROM (
+    SELECT tuple(toUInt64(number + 1)) AS a, toUInt16(3) AS b FROM numbers(1)
+); -- { serverError ILLEGAL_COLUMN }

--- a/tests/queries/0_stateless/04242_space_filling_curve_encode_non_const_mask.sql
+++ b/tests/queries/0_stateless/04242_space_filling_curve_encode_non_const_mask.sql
@@ -4,9 +4,9 @@
 -- Detected by `function_prop_fuzzer` as a determinism violation:
 -- single-row vs multi-row execution of the same input row produced different values.
 --
--- After the fix, a non-constant `Tuple` first argument is rejected explicitly,
--- mirroring the behaviour of `hilbertDecode` and `mortonDecode`. Simple-mode calls
--- (no `Tuple`) and constant-mask calls continue to work.
+-- After the fix, a non-constant `Tuple` first argument is accepted: the encoder reads
+-- the mask values of each row independently and produces the same output that a single-
+-- row query of the same logical row would produce. Result is block-size independent.
 
 SELECT '----- hilbertEncode: simple mode (no Tuple) -----';
 SELECT hilbertEncode(3, 4);
@@ -24,36 +24,36 @@ SELECT '----- mortonEncode: constant Tuple mask -----';
 SELECT mortonEncode((1, 2), 1024, 16);
 SELECT mortonEncode(tuple(2), materialize(toUInt32(128)));
 
-SELECT '----- hilbertEncode: multi-row non-constant Tuple mask is rejected -----';
+SELECT '----- hilbertEncode: multi-row non-constant Tuple mask is computed per row -----';
 -- Before the fix the implementation silently used row 0's mask values to drive
--- the bit-shift for every row, producing wrong results. The fuzzer flagged this
--- as a determinism violation (single-row vs multi-row gave different results
--- for the same logical input).
+-- the bit-shift for every row, producing wrong results (the fuzzer flagged this as
+-- single-row vs multi-row determinism violation). After the fix each row uses its
+-- own mask: row N has mask `tuple(N)`, value `3`, so the result is `3 << N`.
 SELECT hilbertEncode(a, b) FROM (
     SELECT tuple(toUInt64(number)) AS a, toUInt16(3) AS b FROM numbers(3)
-); -- { serverError ILLEGAL_COLUMN }
--- Two-dimensional mask with varying values per row:
+);
+-- Two-dimensional mask varying per row: row N has mask `(N, N+1)`, b=1024, c=16.
+-- Per-row shifts: b << N and c << (N+1) feed into the 2D Hilbert encoder.
 SELECT hilbertEncode(a, b, c) FROM (
     SELECT (toUInt64(number), toUInt64(number + 1)) AS a, toUInt32(1024) AS b, toUInt32(16) AS c FROM numbers(4)
-); -- { serverError ILLEGAL_COLUMN }
+);
 
-SELECT '----- mortonEncode: multi-row non-constant Tuple mask is rejected -----';
+SELECT '----- mortonEncode: multi-row non-constant Tuple mask is computed per row -----';
+-- Row N has mask `tuple(N+1)` (so ratios are 1, 2, 3), value `3`.
+-- Per-row results: ratio=1 → 3; ratio=2 → MortonND_2D.Encode(0, 3); ratio=3 → MortonND_3D.Encode(0, 0, 3).
 SELECT mortonEncode(a, b) FROM (
     SELECT tuple(toUInt64(number + 1)) AS a, toUInt16(3) AS b FROM numbers(3)
-); -- { serverError ILLEGAL_COLUMN }
+);
 SELECT mortonEncode(a, b, c) FROM (
     SELECT (toUInt64(number + 1), toUInt64(number + 1)) AS a, toUInt32(1024) AS b, toUInt32(16) AS c FROM numbers(4)
-); -- { serverError ILLEGAL_COLUMN }
+);
 
-SELECT '----- block-size independence: rejection holds with max_block_size = 1 -----';
--- The rejection of a non-constant Tuple mask must be independent of pipeline chunk
--- size. Earlier the check looked at `input_rows_count > 1`, which is the current chunk
--- size rather than a query-level property: with `SET max_block_size = 1` a non-constant
--- Tuple was sliced into 1-row chunks and silently produced wrong results instead of
--- throwing. The check is now done at type-resolution time (in `getReturnTypeImpl`),
--- so it fires regardless of chunking, and equally for naturally single-row sources
--- (a `FROM ... LIMIT 1` query produces `input_rows_count = 1` without setting
--- `max_block_size`).
+SELECT '----- block-size independence: per-row computation is consistent across chunk sizes -----';
+-- Previously, with `SET max_block_size = 1` the same expression silently produced
+-- different values because each chunk was 1 row and row 0 of a 1-row chunk is the
+-- correct row. With the default block size all rows used row 0 of the multi-row
+-- chunk, producing wrong results. After the fix the output is identical regardless
+-- of `max_block_size`.
 SET max_block_size = 1;
 
 -- Simple-mode and constant-mask paths continue to work with block size 1.
@@ -62,18 +62,35 @@ SELECT hilbertEncode(tuple(2), materialize(toUInt32(128)));
 SELECT mortonEncode(materialize(toUInt32(1)), materialize(toUInt32(2)), materialize(toUInt32(3)));
 SELECT mortonEncode(tuple(2), materialize(toUInt32(128)));
 
--- Non-constant Tuple masks are still rejected when the pipeline produces 1-row chunks.
+-- Non-constant Tuple masks now produce the same per-row values as with the default block size.
 SELECT hilbertEncode(a, b) FROM (
     SELECT tuple(toUInt64(number)) AS a, toUInt16(3) AS b FROM numbers(3)
-); -- { serverError ILLEGAL_COLUMN }
+);
 SELECT mortonEncode(a, b) FROM (
     SELECT tuple(toUInt64(number + 1)) AS a, toUInt16(3) AS b FROM numbers(3)
-); -- { serverError ILLEGAL_COLUMN }
+);
 
--- And also when the source is naturally single-row (independent of `max_block_size`).
+-- And the result for a naturally single-row source matches a single row of the multi-row source.
 SELECT hilbertEncode(a, b) FROM (
-    SELECT tuple(toUInt64(number)) AS a, toUInt16(3) AS b FROM numbers(1)
-); -- { serverError ILLEGAL_COLUMN }
+    SELECT tuple(toUInt64(2)) AS a, toUInt16(3) AS b FROM numbers(1)
+);
 SELECT mortonEncode(a, b) FROM (
-    SELECT tuple(toUInt64(number + 1)) AS a, toUInt16(3) AS b FROM numbers(1)
-); -- { serverError ILLEGAL_COLUMN }
+    SELECT tuple(toUInt64(3)) AS a, toUInt16(3) AS b FROM numbers(1)
+);
+
+SELECT '----- per-row validation: out-of-range mask in any row is rejected -----';
+-- For hilbert the ratio must be 0-32 and for morton must be 1-8. Validation now
+-- runs per row for non-constant masks, so an out-of-range value in any row throws.
+-- The test uses single-row sources so the validation fires before any output is
+-- streamed; mid-sequence bad rows would emit the preceding rows in 1-row chunks
+-- (with `SET max_block_size = 1` above), which would make the test output depend
+-- on chunk size — orthogonal to what we want to assert here.
+SELECT hilbertEncode(a, b) FROM (
+    SELECT tuple(toUInt64(33)) AS a, toUInt16(1) AS b FROM numbers(1)
+); -- { serverError ARGUMENT_OUT_OF_BOUND }
+SELECT mortonEncode(a, b) FROM (
+    SELECT tuple(toUInt64(9)) AS a, toUInt16(1) AS b FROM numbers(1)
+); -- { serverError ARGUMENT_OUT_OF_BOUND }
+SELECT mortonEncode(a, b) FROM (
+    SELECT tuple(toUInt64(0)) AS a, toUInt16(1) AS b FROM numbers(1)
+); -- { serverError ARGUMENT_OUT_OF_BOUND }

--- a/tests/queries/0_stateless/04242_space_filling_curve_encode_non_const_mask.sql
+++ b/tests/queries/0_stateless/04242_space_filling_curve_encode_non_const_mask.sql
@@ -1,0 +1,46 @@
+-- Regression for a silent wrong-result bug in `hilbertEncode` and `mortonEncode`:
+-- when the first argument was a non-constant `Tuple` column, the implementations
+-- read the range mask from row 0 and used it for every row, producing wrong results.
+-- Detected by `function_prop_fuzzer` as a determinism violation:
+-- single-row vs multi-row execution of the same input row produced different values.
+--
+-- After the fix, a non-constant `Tuple` first argument is rejected explicitly,
+-- mirroring the behaviour of `hilbertDecode` and `mortonDecode`. Simple-mode calls
+-- (no `Tuple`) and constant-mask calls continue to work.
+
+SELECT '----- hilbertEncode: simple mode (no Tuple) -----';
+SELECT hilbertEncode(3, 4);
+SELECT hilbertEncode(materialize(toUInt32(3)), materialize(toUInt32(4)));
+
+SELECT '----- hilbertEncode: constant Tuple mask -----';
+SELECT hilbertEncode((10, 6), 1024, 16);
+SELECT hilbertEncode(tuple(2), materialize(toUInt32(128)));
+
+SELECT '----- mortonEncode: simple mode (no Tuple) -----';
+SELECT mortonEncode(1, 2, 3);
+SELECT mortonEncode(materialize(toUInt32(1)), materialize(toUInt32(2)), materialize(toUInt32(3)));
+
+SELECT '----- mortonEncode: constant Tuple mask -----';
+SELECT mortonEncode((1, 2), 1024, 16);
+SELECT mortonEncode(tuple(2), materialize(toUInt32(128)));
+
+SELECT '----- hilbertEncode: multi-row non-constant Tuple mask is rejected -----';
+-- Before the fix the implementation silently used row 0's mask values to drive
+-- the bit-shift for every row, producing wrong results. The fuzzer flagged this
+-- as a determinism violation (single-row vs multi-row gave different results
+-- for the same logical input).
+SELECT hilbertEncode(a, b) FROM (
+    SELECT tuple(toUInt64(number)) AS a, toUInt16(3) AS b FROM numbers(3)
+); -- { serverError ILLEGAL_COLUMN }
+-- Two-dimensional mask with varying values per row:
+SELECT hilbertEncode(a, b, c) FROM (
+    SELECT (toUInt64(number), toUInt64(number + 1)) AS a, toUInt32(1024) AS b, toUInt32(16) AS c FROM numbers(4)
+); -- { serverError ILLEGAL_COLUMN }
+
+SELECT '----- mortonEncode: multi-row non-constant Tuple mask is rejected -----';
+SELECT mortonEncode(a, b) FROM (
+    SELECT tuple(toUInt64(number + 1)) AS a, toUInt16(3) AS b FROM numbers(3)
+); -- { serverError ILLEGAL_COLUMN }
+SELECT mortonEncode(a, b, c) FROM (
+    SELECT (toUInt64(number + 1), toUInt64(number + 1)) AS a, toUInt32(1024) AS b, toUInt32(16) AS c FROM numbers(4)
+); -- { serverError ILLEGAL_COLUMN }


### PR DESCRIPTION
### Why

When the first argument of `hilbertEncode` or `mortonEncode` was a non-constant `Tuple` column (for example produced by `materialize` or by reading a `Tuple` column from a table), the implementation silently read the range-mask values from row 0 of the tuple and used them to drive the bit-shift for **every** row, producing wrong results.

`function_prop_fuzzer` flagged this as a determinism violation — single-row vs multi-row execution of the same logical input row produced different `hilbertEncode` values. The result also depended on the chunk size: with `SET max_block_size = 1` each row was its own chunk so the bug was hidden, while with the default block size the same query returned wrong values.

Example with the tuple `tuple(N)` and value `3`:

```sql
-- Single-row source: result == 3 << N (correct).
SELECT hilbertEncode(materialize(tuple(toUInt64(7))), materialize(toUInt16(3)));
-- 384

-- Multi-row source with per-row varying masks (0), (1), (2): each row should
-- compute `3 << N` for its own N.
SELECT hilbertEncode(a, b) FROM (
    SELECT tuple(toUInt64(number)) AS a, toUInt16(3) AS b FROM numbers(3)
);
-- before:  3, 3, 3   (row 0's mask = (0) used for all rows)
-- after:   3, 6, 12
```

### What

Introduce `FunctionSpaceFillingCurveEncode::RangeMask` and `extractRangeMask`. The struct carries the underlying `ColumnTuple` plus an `is_const` flag and exposes `read(col_idx, row_idx)` that reads row 0 for constant masks and row `row_idx` for non-constant masks. `FunctionHilbertEncode::executeImpl` and the `EXECUTE` macro in `mortonEncode.cpp` now read each row's ratio inside the encoding loop, and validation runs per row for non-constant masks.

`FunctionSpaceFillingCurveDecode` keeps its existing strict `ColumnConst` requirement — the result tuple size is part of the return type and must be resolvable at analysis time.

Add `04242_space_filling_curve_encode_non_const_mask` regression test covering simple mode, constant masks, per-row non-constant masks, block-size independence (`SET max_block_size = 1`), and per-row out-of-range validation.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a silent wrong-result bug in `hilbertEncode` and `mortonEncode` where a non-constant `Tuple` first argument (range mask) used row 0's values to drive the bit-shift for every row. The functions now compute the per-row mask values, so the result no longer depends on the input being constant or on the block size.

### Documentation entry for user-facing changes

- [x] Documentation is unchanged: the documented examples all pass a constant mask literal such as `(10, 6)`; non-constant `Tuple` masks are now also supported with per-row semantics.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.813`
<!-- ch-version-info:end -->