### PR TITLE
Stabilize 04229_trivial_group_by_limit_profile_events under parallel replicas

### DIFF
--- a/tests/queries/0_stateless/04229_trivial_group_by_limit_profile_events.sql
+++ b/tests/queries/0_stateless/04229_trivial_group_by_limit_profile_events.sql
@@ -11,12 +11,21 @@ INSERT INTO t_04229 SELECT number FROM numbers(100000);
 -- the `OverflowAny` count deterministic. The query has 100k distinct keys, so
 -- with the optimization the aggregator hits the 5-key cap and drops all the
 -- subsequent keys, incrementing `OverflowAny`.
+--
+-- `enable_parallel_replicas = 0` is pinned because `OptimizeTrivialGroupByLimitPass`
+-- runs in the analyzer on the initiator and mutates `max_rows_to_group_by` on the
+-- query's local context; this mutation does not propagate to remote replicas, so
+-- under CI's parallel-replicas randomization the aggregator on the remotes never
+-- sees the cap and `OverflowAny` stays at zero. The test verifies the optimization
+-- on the local-coordinator path where it is designed to fire.
 
 SELECT k FROM t_04229 GROUP BY k LIMIT 5 FORMAT Null
-SETTINGS optimize_trivial_group_by_limit_query = 1, max_threads = 1, log_comment = '04229_on';
+SETTINGS optimize_trivial_group_by_limit_query = 1, max_threads = 1,
+    enable_parallel_replicas = 0, log_comment = '04229_on';
 
 SELECT k FROM t_04229 GROUP BY k LIMIT 5 FORMAT Null
-SETTINGS optimize_trivial_group_by_limit_query = 0, max_threads = 1, log_comment = '04229_off';
+SETTINGS optimize_trivial_group_by_limit_query = 0, max_threads = 1,
+    enable_parallel_replicas = 0, log_comment = '04229_off';
 
 SYSTEM FLUSH LOGS query_log;
 


### PR DESCRIPTION
Reported by @alexey-milovidov on https://github.com/ClickHouse/ClickHouse/pull/100146:

> `Stateless tests (amd_llvm_coverage, ParallelReplicas, s3 storage, parallel)` — only failure is `04229_trivial_group_by_limit_profile_events`. This test was added in #104473 and has been failing in this exact profile across many unrelated PRs (e.g. #100146, #101033, #104694, #104966). The optimization apparently doesn't fire under the `ParallelReplicas` profile and the test does not account for that.

### Root cause

`OptimizeTrivialGroupByLimitPass` runs in the analyzer on the initiator and lowers `max_rows_to_group_by` on the query's local context (`mutable_context->setSetting("max_rows_to_group_by", max_rows)`). That mutation is not propagated to remote replicas, so once CI's `automatic_parallel_replicas_mode = 2` randomization is sampled (which sets `enable_parallel_replicas = 1` + `parallel_replicas_for_non_replicated_merge_tree = 1` + `cluster_for_parallel_replicas = 'parallel_replicas'`), the aggregator on the remotes never applies the cap and `OverflowAny` stays at zero. The test then sees `04229_on   0` instead of the expected `04229_on   1` and fails 3/3 reruns.

CIDB cross-PR scope (30 days): the failure has been observed on at least PRs #104473 (the source PR), #100146, #101033, #104694, #104966 — all unrelated to the test or to each other.

### Fix

Pin `enable_parallel_replicas = 0` at the query level in both `SETTINGS` clauses so the optimization is exercised on the local-coordinator path it is designed for. Query-level `SETTINGS` takes priority over the runner's session-level injection, so the pin is robust against any further randomization. No `no-*` tag is added (per `.claude/CLAUDE.md` guidance) and no other randomization is disabled — `max_threads = 1` was already pinned, everything else stays randomized.

The test's intent is preserved: it still checks that `OverflowAny` is incremented when `OptimizeTrivialGroupByLimitPass` fires and stays at zero when it doesn't.

### Reproduction & verification

Locally with a 3-replica `default_parallel_replicas` cluster on loopback (`localhost`, `127.0.0.2`, `127.0.0.3` on port 9700), simulating the runner's parallel-replicas injection:

| Test | Without fix | With fix |
| ---- | ----------- | -------- |
| 5 iterations under parallel-replicas randomization | 0/5 pass — every run shows `04229_on   0` | 20/20 pass |

If you want to test the bug interactively, here is a one-line repro against any server with a multi-replica cluster:

```sql
SELECT k FROM t GROUP BY k LIMIT 5 FORMAT Null
SETTINGS optimize_trivial_group_by_limit_query = 1, max_threads = 1,
    enable_parallel_replicas = 1, parallel_replicas_for_non_replicated_merge_tree = 1,
    cluster_for_parallel_replicas = '<your_cluster>', parallel_replicas_local_plan = 0;
```

Then `SELECT ProfileEvents['OverflowAny'] FROM system.query_log WHERE type = 'QueryFinish'` returns `0` instead of the expected non-zero value.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.734`
<!-- ch-version-info:end -->