### PR TITLE
Fix CLEAR COLUMN zero-row deletion regression on SummingMergeTree

### DIFF
--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -612,6 +612,25 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
     ///    making it unclear whether the default should be materialized or recomputed.
     /// 2. Default expressions may introduce semantic changes if re-evaluated during merges, leading to
     ///    non-deterministic results across parts.
+    ///
+    /// Additional constraint: for `Summing`, `Aggregating`, `Coalescing`, and `Graphite` merge modes,
+    /// all non-key columns participate in the merge algorithm and can affect which rows survive the
+    /// merge (e.g. zero-row deletion in `SummingMergeTree`/`CoalescingMergeTree`, aggregate-state
+    /// merging in `AggregatingMergeTree`). If a column is absent from all source parts (for example
+    /// after `ALTER TABLE ... CLEAR COLUMN IN PARTITION`) and we expire it here, the read pipeline
+    /// stops materializing the implicit default-value column for it, and `SummingSortedAlgorithm`
+    /// never sees the column. The zero-row deletion check then sees an empty `columns_to_aggregate`
+    /// and forces `current_row_is_zero = false`, so rows that should have been collapsed survive.
+    /// Skip the optimization for these modes to preserve the pre-#88860 merge semantics.
+    /// See https://github.com/ClickHouse/ClickHouse/issues/101953
+    const auto merge_mode = global_ctx->merging_params.mode;
+    const bool merge_mode_uses_all_non_key_columns =
+        merge_mode == MergeTreeData::MergingParams::Summing
+        || merge_mode == MergeTreeData::MergingParams::Aggregating
+        || merge_mode == MergeTreeData::MergingParams::Coalescing
+        || merge_mode == MergeTreeData::MergingParams::Graphite;
+
+    if (!merge_mode_uses_all_non_key_columns)
     {
         NameSet columns_present_in_parts;
         columns_present_in_parts.reserve(global_ctx->storage_columns.size());

--- a/tests/queries/0_stateless/04243_clear_column_summing_zero_deletion.reference
+++ b/tests/queries/0_stateless/04243_clear_column_summing_zero_deletion.reference
@@ -1,0 +1,14 @@
+before clear
+1	1	100
+2	2	200
+after clear + optimize final
+2	2	200
+cross-check update c=0
+2	2	200
+multi-row partition after clear
+add column with no rewrite
+coalescing keeps rows
+1	1	0
+2	2	200
+ordinary keeps row
+1	1	0

--- a/tests/queries/0_stateless/04243_clear_column_summing_zero_deletion.sql
+++ b/tests/queries/0_stateless/04243_clear_column_summing_zero_deletion.sql
@@ -1,0 +1,175 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/101953
+--
+-- ALTER TABLE ... CLEAR COLUMN IN PARTITION on a SummingMergeTree table must
+-- still trigger zero-row deletion during OPTIMIZE TABLE FINAL, matching the
+-- behaviour of ALTER TABLE ... UPDATE col = 0.
+--
+-- The regression was introduced by https://github.com/ClickHouse/ClickHouse/pull/88860
+-- ("Treat absent columns as expired"), which extended the merge-time
+-- "absent-column-as-expired" optimization from TTL-finished columns to any
+-- column missing from all source parts. CLEAR COLUMN drops the cleared column
+-- from columns.txt entirely, so under the new optimization the column never
+-- reaches SummingSortedAlgorithm and the zero-row deletion is silently bypassed.
+--
+-- The fix narrows the optimization to merge modes where non-key columns do not
+-- affect row inclusion (Ordinary, Collapsing, Replacing, VersionedCollapsing),
+-- and skips it for Summing, Aggregating, Coalescing, and Graphite modes where
+-- every non-key column participates in the merge algorithm.
+
+DROP TABLE IF EXISTS test_clear_summing;
+
+CREATE TABLE test_clear_summing
+(
+    v UInt64,
+    p UInt64,
+    c UInt64
+)
+ENGINE = SummingMergeTree
+PARTITION BY p
+ORDER BY v;
+
+INSERT INTO test_clear_summing VALUES (1, 1, 100);
+INSERT INTO test_clear_summing VALUES (2, 2, 200);
+
+OPTIMIZE TABLE test_clear_summing FINAL;
+
+SELECT 'before clear';
+SELECT * FROM test_clear_summing ORDER BY v;
+
+ALTER TABLE test_clear_summing CLEAR COLUMN c IN PARTITION 1 SETTINGS mutations_sync = 2;
+
+OPTIMIZE TABLE test_clear_summing FINAL;
+
+SELECT 'after clear + optimize final';
+SELECT * FROM test_clear_summing ORDER BY v;
+
+-- Cross-check: ALTER UPDATE c = 0 must produce the same result.
+DROP TABLE test_clear_summing;
+
+CREATE TABLE test_clear_summing
+(
+    v UInt64,
+    p UInt64,
+    c UInt64
+)
+ENGINE = SummingMergeTree
+PARTITION BY p
+ORDER BY v;
+
+INSERT INTO test_clear_summing VALUES (1, 1, 100);
+INSERT INTO test_clear_summing VALUES (2, 2, 200);
+
+OPTIMIZE TABLE test_clear_summing FINAL;
+
+ALTER TABLE test_clear_summing UPDATE c = 0 WHERE v = 1 SETTINGS mutations_sync = 2;
+
+OPTIMIZE TABLE test_clear_summing FINAL;
+
+SELECT 'cross-check update c=0';
+SELECT * FROM test_clear_summing ORDER BY v;
+
+-- Multi-row partition: every row in partition 1 has c = 0 after CLEAR, so the
+-- whole partition must collapse to nothing.
+DROP TABLE test_clear_summing;
+
+CREATE TABLE test_clear_summing
+(
+    v UInt64,
+    p UInt64,
+    c UInt64
+)
+ENGINE = SummingMergeTree
+PARTITION BY p
+ORDER BY v;
+
+INSERT INTO test_clear_summing VALUES (1, 1, 100);
+INSERT INTO test_clear_summing VALUES (2, 1, 50);
+INSERT INTO test_clear_summing VALUES (3, 1, 30);
+
+OPTIMIZE TABLE test_clear_summing FINAL;
+
+ALTER TABLE test_clear_summing CLEAR COLUMN c IN PARTITION 1 SETTINGS mutations_sync = 2;
+
+OPTIMIZE TABLE test_clear_summing FINAL;
+
+SELECT 'multi-row partition after clear';
+SELECT * FROM test_clear_summing ORDER BY v;
+
+DROP TABLE test_clear_summing;
+
+-- ALTER ADD COLUMN that never gets data written to existing parts must also
+-- behave correctly during OPTIMIZE FINAL: the synthesized default-value column
+-- still participates in zero-row deletion.
+CREATE TABLE test_clear_summing
+(
+    v UInt64,
+    p UInt64
+)
+ENGINE = SummingMergeTree
+PARTITION BY p
+ORDER BY v;
+
+INSERT INTO test_clear_summing VALUES (1, 1);
+INSERT INTO test_clear_summing VALUES (2, 2);
+
+OPTIMIZE TABLE test_clear_summing FINAL;
+
+ALTER TABLE test_clear_summing ADD COLUMN c UInt64;
+
+OPTIMIZE TABLE test_clear_summing FINAL;
+
+SELECT 'add column with no rewrite';
+SELECT * FROM test_clear_summing ORDER BY v;
+
+DROP TABLE test_clear_summing;
+
+-- CoalescingMergeTree must NOT drop rows with all-default values (issue #81303
+-- behaviour preserved). The fix to MergeTask.cpp keeps the cleared column in
+-- the merge stream for Coalescing too, but the algorithm's last_value
+-- semantics keep the row.
+CREATE TABLE test_clear_coalescing
+(
+    v UInt64,
+    p UInt64,
+    c UInt64
+)
+ENGINE = CoalescingMergeTree
+PARTITION BY p
+ORDER BY v;
+
+INSERT INTO test_clear_coalescing VALUES (1, 1, 100);
+INSERT INTO test_clear_coalescing VALUES (2, 2, 200);
+
+OPTIMIZE TABLE test_clear_coalescing FINAL;
+
+ALTER TABLE test_clear_coalescing CLEAR COLUMN c IN PARTITION 1 SETTINGS mutations_sync = 2;
+
+OPTIMIZE TABLE test_clear_coalescing FINAL;
+
+SELECT 'coalescing keeps rows';
+SELECT * FROM test_clear_coalescing ORDER BY v;
+
+DROP TABLE test_clear_coalescing;
+
+-- Ordinary MergeTree must keep the absent-column optimization (no change in
+-- behaviour). The cleared column gets default values, and the row stays.
+CREATE TABLE test_clear_ordinary
+(
+    v UInt64,
+    p UInt64,
+    c UInt64
+)
+ENGINE = MergeTree
+PARTITION BY p
+ORDER BY v;
+
+INSERT INTO test_clear_ordinary VALUES (1, 1, 100);
+
+ALTER TABLE test_clear_ordinary CLEAR COLUMN c IN PARTITION 1 SETTINGS mutations_sync = 2;
+
+OPTIMIZE TABLE test_clear_ordinary FINAL;
+
+SELECT 'ordinary keeps row';
+SELECT * FROM test_clear_ordinary ORDER BY v;
+
+DROP TABLE test_clear_ordinary;


### PR DESCRIPTION
`ALTER TABLE ... CLEAR COLUMN IN PARTITION` on a `SummingMergeTree` stopped triggering zero-row deletion during `OPTIMIZE TABLE FINAL` after the merge-time "absent-column-as-expired" optimization (#88860) was backported to 25.8.

### Reproducer

```sql
CREATE TABLE t (v UInt64, p UInt64, c UInt64)
ENGINE = SummingMergeTree PARTITION BY p ORDER BY v;

INSERT INTO t VALUES (1, 1, 100), (2, 2, 200);
OPTIMIZE TABLE t FINAL;
ALTER TABLE t CLEAR COLUMN c IN PARTITION 1 SETTINGS mutations_sync = 2;
OPTIMIZE TABLE t FINAL;

SELECT * FROM t;
-- Expected (≤ 25.7): only (2, 2, 200) — the all-zero row in partition 1 is deleted.
-- Actual   (≥ 25.8): (1, 1, 0) and (2, 2, 200) — zero row survives.
```

`ALTER TABLE t UPDATE c = 0 WHERE v = 1` on the same table still works correctly, because `UPDATE` writes an explicit `0` and keeps `c` in `columns.txt`, while `CLEAR COLUMN` drops the cleared column from `columns.txt` entirely.

### Root cause

`MergeTask::ExecuteAndFinalizeHorizontalPart::prepare` marks any storage column that is missing from every source part and has no default expression as expired:

```cpp
for (const auto & storage_column : global_ctx->storage_columns)
{
    if (!columns_present_in_parts.contains(storage_column.name)
        && !columns_desc.getDefault(storage_column.name))
        global_ctx->new_data_part->expired_columns.emplace(storage_column.name);
}
```

These expired columns are then filtered out of `merging_columns`/`gathering_columns`/`storage_columns`. `SummingSortedAlgorithm::defineColumns` therefore sees only the key columns, builds an empty `columns_to_aggregate`, and in `SummingMergedData::finishGroup`:

```cpp
if (def.columns_to_aggregate.empty())
    current_row_is_zero = false;
```

forces every row to be kept, bypassing zero-row deletion.

### Fix

Skip the absent-column-as-expired optimization for `Summing`, `Aggregating`, `Coalescing`, and `Graphite` merge modes. In these modes every non-key column participates in the merge algorithm — they drive zero-row deletion (Summing/Coalescing), aggregate-state merging (Aggregating), and bucketed value/version aggregation (Graphite). Filtering them out changes merge semantics.

`Ordinary`, `Collapsing`, `Replacing`, and `VersionedCollapsing` are unchanged: they do not depend on non-key columns for row inclusion, and their special columns (`sign_column`/`version_column`/`is_deleted_column`) are already in `merge_required_key_columns`.

### Validation

- New regression test `04243_clear_column_summing_zero_deletion` covers `SummingMergeTree` `CLEAR COLUMN`, `UPDATE c = 0` cross-check, multi-row partition with mixed values, `ALTER ADD COLUMN` with no part rewrite, `CoalescingMergeTree` (rows preserved — issue #81303 behaviour preserved), and `Ordinary` `MergeTree` (rows preserved).
- The new test fails on `master` (returns `1\t1\t0` from the `SummingMergeTree` case) and passes after the fix.
- Existing tests pass: `03566_one_row_summing_merge_tree` (PR #83892's test for issue #81303), `00043_summing_empty_part`, `00084_summing_merge_tree`, `00146_summing_merge_tree_nested_map`, `00148_summing_merge_tree_aggregate_function`, `00148_summing_merge_tree_nested_map_multiple_values`, `00625_summing_merge_tree_merge`, `03409_coalescing_merge_tree`, `03409_coalescing_replicated_merge_tree`, `02346_text_index_coalescingmergetree`.
- 10/10 runs of `04243` pass with random settings + random MergeTree settings.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a regression introduced in 25.8 where `ALTER TABLE ... CLEAR COLUMN IN PARTITION` on a `SummingMergeTree` table no longer triggered zero-row deletion during `OPTIMIZE TABLE FINAL`. The merge-time "absent-column-as-expired" optimization is now skipped for `SummingMergeTree`, `AggregatingMergeTree`, `CoalescingMergeTree`, and `GraphiteMergeTree`, where every non-key column participates in the merge algorithm.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

Closes #101953

Session: cron:clickhouse-ci-task-worker:20260515-054500