### PR TITLE
PromQL: Add set binary operators

### DIFF
--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperator.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperator.cpp
@@ -1,6 +1,9 @@
 #include <Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperator.h>
 
 #include <Common/Exception.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorOr.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorUnless.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/applyComparisonOperator.h>
 #include <Storages/TimeSeries/PrometheusQueryToSQL/applyMathBinaryOperator.h>
 
@@ -24,6 +27,15 @@ SQLQueryPiece applyBinaryOperator(
 
     if (isComparisonOperator(operator_name))
         return applyComparisonOperator(operator_node, std::move(left_argument), std::move(right_argument), context);
+
+    if (isBinaryOperatorAnd(operator_name))
+        return applyBinaryOperatorAnd(operator_node, std::move(left_argument), std::move(right_argument), context);
+
+    if (isBinaryOperatorOr(operator_name))
+        return applyBinaryOperatorOr(operator_node, std::move(left_argument), std::move(right_argument), context);
+
+    if (isBinaryOperatorUnless(operator_name))
+        return applyBinaryOperatorUnless(operator_node, std::move(left_argument), std::move(right_argument), context);
 
     throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Binary operator {} is not implemented", operator_name);
 }

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.cpp
@@ -1,0 +1,167 @@
+#include <Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.h>
+
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/ConverterContext.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/SelectQueryBuilder.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/toVectorGrid.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/transformGroupASTForBinaryOperator.h>
+
+
+namespace DB::ErrorCodes
+{
+    extern const int CANNOT_EXECUTE_PROMQL_QUERY;
+}
+
+
+namespace DB::PrometheusQueryToSQL
+{
+
+void checkArgumentTypesForSetBinaryOperator(
+    const PQT::BinaryOperator * operator_node,
+    const SQLQueryPiece & left_argument,
+    const SQLQueryPiece & right_argument,
+    const ConverterContext & context)
+{
+    std::string_view operator_name = operator_node->operator_name;
+
+    if (left_argument.type != ResultType::INSTANT_VECTOR)
+    {
+        throw Exception(ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
+                        "Binary operator '{}' expects two arguments of type {}, but expression {} has type {}",
+                        operator_name, ResultType::INSTANT_VECTOR,
+                        getPromQLText(left_argument, context), left_argument.type);
+    }
+
+    if (right_argument.type != ResultType::INSTANT_VECTOR)
+    {
+        throw Exception(ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
+                        "Binary operator '{}' expects two arguments of type {}, but expression {} has type {}",
+                        operator_name, ResultType::INSTANT_VECTOR,
+                        getPromQLText(right_argument, context), right_argument.type);
+    }
+
+    if (operator_node->group_left)
+    {
+        throw Exception(ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
+                        "Binary operator '{}' doesn't allow group_left",
+                        operator_name);
+    }
+
+    if (operator_node->group_right)
+    {
+        throw Exception(ErrorCodes::CANNOT_EXECUTE_PROMQL_QUERY,
+                        "Binary operator '{}' doesn't allow group_right",
+                        operator_name);
+    }
+}
+
+
+SQLQueryPiece applyBinaryOperatorAnd(
+    const PQT::BinaryOperator * operator_node, SQLQueryPiece && left_argument, SQLQueryPiece && right_argument, ConverterContext & context)
+{
+    checkArgumentTypesForSetBinaryOperator(operator_node, left_argument, right_argument, context);
+
+    /// If one of the arguments is empty then the result is also empty.
+    if ((left_argument.store_method == StoreMethod::EMPTY) || (right_argument.store_method == StoreMethod::EMPTY))
+    {
+        return SQLQueryPiece{operator_node, ResultType::INSTANT_VECTOR, StoreMethod::EMPTY};
+    }
+
+    left_argument = toVectorGrid(std::move(left_argument), context);
+    context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(left_argument.select_query), SQLSubqueryType::TABLE});
+    String left = context.subqueries.back().name;
+
+    right_argument = toVectorGrid(std::move(right_argument), context);
+    context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(right_argument.select_query), SQLSubqueryType::TABLE});
+    String right = context.subqueries.back().name;
+
+    /// Step 1:
+    /// SELECT timeSeriesRemoveAllTagsExcept(group, on_tags) AS join_group,
+    ///        countForEach(values) AS join_count
+    /// GROUP BY join_group
+    /// FROM right
+    ///
+    String step1;
+    {
+        SelectQueryBuilder builder;
+
+        bool right_metric_name_dropped = right_argument.metric_name_dropped;
+        builder.select_list.push_back(transformGroupASTForBinaryOperator(
+            operator_node,
+            make_intrusive<ASTIdentifier>(ColumnNames::Group),
+            /*drop_metric_name=*/ true,
+            right_metric_name_dropped));
+        builder.select_list.back()->setAlias(ColumnNames::JoinGroup);
+
+        builder.select_list.push_back(makeASTFunction("countForEach", make_intrusive<ASTIdentifier>(ColumnNames::Values)));
+        builder.select_list.back()->setAlias(ColumnNames::JoinCount);
+
+        builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::JoinGroup));
+
+        builder.from_table = right;
+
+        ASTPtr step1_ast = builder.getSelectQuery();
+        context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(step1_ast), SQLSubqueryType::TABLE});
+        step1 = context.subqueries.back().name;
+    }
+
+    /// Step 2:
+    /// SELECT group,
+    ///        arrayMap(x, y -> if(y > 0, x, NULL), values, join_count) AS values
+    /// FROM left LEFT SEMI JOIN step1
+    /// ON timeSeriesRemoveAllTagsExcept(group, on_tags) == join_group
+    ///
+    ASTPtr step2;
+    {
+        SelectQueryBuilder builder;
+
+        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Group));
+
+        builder.select_list.push_back(makeASTFunction(
+            "arrayMap",
+            makeASTFunction(
+                "lambda",
+                makeASTFunction("tuple", make_intrusive<ASTIdentifier>("x"), make_intrusive<ASTIdentifier>("y")),
+                makeASTFunction(
+                    "if",
+                    makeASTFunction("greater", make_intrusive<ASTIdentifier>("y"), make_intrusive<ASTLiteral>(0u)),
+                    make_intrusive<ASTIdentifier>("x"),
+                    make_intrusive<ASTLiteral>(Field{} /* NULL */))),
+            make_intrusive<ASTIdentifier>(ColumnNames::Values),
+            make_intrusive<ASTIdentifier>(ColumnNames::JoinCount)));
+
+        builder.select_list.back()->setAlias(ColumnNames::Values);
+
+        builder.from_table = left;
+
+        builder.join_kind = JoinKind::Left;
+        builder.join_strictness = JoinStrictness::Semi;
+        builder.join_table = step1;
+
+        bool left_metric_name_dropped = left_argument.metric_name_dropped;
+        builder.join_on = makeASTFunction(
+            "equals",
+            transformGroupASTForBinaryOperator(
+                operator_node,
+                make_intrusive<ASTIdentifier>(ColumnNames::Group),
+                /*drop_metric_name=*/ true,
+                left_metric_name_dropped),
+            make_intrusive<ASTIdentifier>(ColumnNames::JoinGroup));
+
+        step2 = builder.getSelectQuery();
+    }
+
+    SQLQueryPiece res{operator_node, ResultType::INSTANT_VECTOR, StoreMethod::VECTOR_GRID};
+    res.select_query = std::move(step2);
+    res.metric_name_dropped = left_argument.metric_name_dropped;
+
+    res.start_time = left_argument.start_time;
+    res.end_time = left_argument.end_time;
+    res.step = left_argument.step;
+
+    return res;
+}
+
+}

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.h
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <Storages/TimeSeries/PrometheusQueryToSQL/SQLQueryPiece.h>
+
+
+namespace DB::PrometheusQueryToSQL
+{
+
+inline bool isBinaryOperatorAnd(std::string_view operator_name) { return operator_name == "and"; }
+
+/// Applies a prometheus operator "and".
+SQLQueryPiece applyBinaryOperatorAnd(
+    const PQT::BinaryOperator * operator_node,
+    SQLQueryPiece && left_argument,
+    SQLQueryPiece && right_argument,
+    ConverterContext & context);
+
+/// Check argument types for set binary operator (i.e. one of "and", "or", "unless").
+void checkArgumentTypesForSetBinaryOperator(
+    const PQT::BinaryOperator * operator_node,
+    const SQLQueryPiece & left_argument,
+    const SQLQueryPiece & right_argument,
+    const ConverterContext & context);
+
+}

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorOr.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorOr.cpp
@@ -1,0 +1,201 @@
+#include <Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorOr.h>
+
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/ConverterContext.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/SelectQueryBuilder.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/toVectorGrid.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/transformGroupASTForBinaryOperator.h>
+
+
+namespace DB::PrometheusQueryToSQL
+{
+
+SQLQueryPiece applyBinaryOperatorOr(
+    const PQT::BinaryOperator * operator_node, SQLQueryPiece && left_argument, SQLQueryPiece && right_argument, ConverterContext & context)
+{
+    checkArgumentTypesForSetBinaryOperator(operator_node, left_argument, right_argument, context);
+
+    /// If one of the arguments is empty then we return the other argument.
+    if (left_argument.store_method == StoreMethod::EMPTY)
+    {
+        auto res = std::move(right_argument);
+        res.node = operator_node;
+        return res;
+    }
+
+    if (right_argument.store_method == StoreMethod::EMPTY)
+    {
+        auto res = std::move(left_argument);
+        res.node = operator_node;
+        return res;
+    }
+
+    left_argument = toVectorGrid(std::move(left_argument), context);
+    context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(left_argument.select_query), SQLSubqueryType::TABLE});
+    String left = context.subqueries.back().name;
+
+    right_argument = toVectorGrid(std::move(right_argument), context);
+    context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(right_argument.select_query), SQLSubqueryType::TABLE});
+    String right = context.subqueries.back().name;
+
+    /// Step 1: Count the non-NULL values per `join_group` on the left side, per timestamp.
+    ///
+    /// SELECT timeSeriesRemoveAllTagsExcept(group, on_tags) AS join_group,
+    ///        countForEach(values) AS join_count
+    /// GROUP BY join_group
+    /// FROM left
+    ///
+    String step1;
+    {
+        SelectQueryBuilder builder;
+
+        bool left_metric_name_dropped = left_argument.metric_name_dropped;
+        builder.select_list.push_back(transformGroupASTForBinaryOperator(
+            operator_node,
+            make_intrusive<ASTIdentifier>(ColumnNames::Group),
+            /*drop_metric_name=*/ true,
+            left_metric_name_dropped));
+        builder.select_list.back()->setAlias(ColumnNames::JoinGroup);
+
+        builder.select_list.push_back(makeASTFunction("countForEach", make_intrusive<ASTIdentifier>(ColumnNames::Values)));
+        builder.select_list.back()->setAlias(ColumnNames::JoinCount);
+
+        builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::JoinGroup));
+
+        builder.from_table = left;
+
+        ASTPtr step1_ast = builder.getSelectQuery();
+        context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(step1_ast), SQLSubqueryType::TABLE});
+        step1 = context.subqueries.back().name;
+    }
+
+    /// Step 2: For each row from the right side, replace values with NULLs at timestamps
+    /// where the left side has any value with the matching `join_group`.
+    /// Rows whose `join_group` is absent from the left side pass through unchanged.
+    ///
+    /// SELECT group,
+    ///        if(notEmpty(join_count), arrayMap(x, y -> if(x = 0, y, NULL), join_count, values), values) AS values
+    /// FROM step1 RIGHT ANY JOIN right
+    /// ON join_group == timeSeriesRemoveAllTagsExcept(group, on_tags)
+    ///
+    String step2;
+    {
+        SelectQueryBuilder builder;
+
+        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Group));
+
+        builder.select_list.push_back(makeASTFunction(
+            "if",
+            makeASTFunction("notEmpty", make_intrusive<ASTIdentifier>(ColumnNames::JoinCount)),
+            makeASTFunction(
+                "arrayMap",
+                makeASTFunction(
+                    "lambda",
+                    makeASTFunction("tuple", make_intrusive<ASTIdentifier>("x"), make_intrusive<ASTIdentifier>("y")),
+                    makeASTFunction(
+                        "if",
+                        makeASTFunction("equals", make_intrusive<ASTIdentifier>("x"), make_intrusive<ASTLiteral>(0u)),
+                        make_intrusive<ASTIdentifier>("y"),
+                        make_intrusive<ASTLiteral>(Field{} /* NULL */))),
+                make_intrusive<ASTIdentifier>(ColumnNames::JoinCount),
+                make_intrusive<ASTIdentifier>(ColumnNames::Values)),
+            make_intrusive<ASTIdentifier>(ColumnNames::Values)));
+
+        builder.select_list.back()->setAlias(ColumnNames::Values);
+
+        builder.from_table = step1;
+        builder.join_kind = JoinKind::Right;
+        builder.join_strictness = JoinStrictness::Any;
+        builder.join_table = right;
+
+        bool right_metric_name_dropped = right_argument.metric_name_dropped;
+        builder.join_on = makeASTFunction(
+            "equals",
+            make_intrusive<ASTIdentifier>(ColumnNames::JoinGroup),
+            transformGroupASTForBinaryOperator(
+                operator_node,
+                make_intrusive<ASTIdentifier>(ColumnNames::Group),
+                /*drop_metric_name=*/ true,
+                right_metric_name_dropped));
+
+        ASTPtr step2_ast = builder.getSelectQuery();
+        context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(step2_ast), SQLSubqueryType::TABLE});
+        step2 = context.subqueries.back().name;
+    }
+
+    /// Step 3: Merge the original left rows with the filtered right rows from step 2,
+    /// picking element-wise non-NULL where both sides have a row.
+    ///
+    /// SELECT
+    ///   if(notEmpty(left.values), left.group, step2.group) AS group,
+    ///   multiIf(
+    ///     notEmpty(left.values) AND notEmpty(step2.values),
+    ///        arrayMap((a, b) -> if(isNotNull(a), a, b), left.values, step2.values),
+    ///     notEmpty(left.values),
+    ///        left.values,
+    ///     step2.values) AS values
+    /// FROM left FULL ALL JOIN step2
+    /// ON left.group == step2.group
+    ///
+    ASTPtr step3;
+    {
+        SelectQueryBuilder builder;
+
+        builder.select_list.push_back(makeASTFunction(
+            "if",
+            makeASTFunction("empty", make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Values})),
+            make_intrusive<ASTIdentifier>(Strings{step2, ColumnNames::Group}),
+            make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Group})));
+        builder.select_list.back()->setAlias(ColumnNames::Group);
+
+        builder.select_list.push_back(makeASTFunction(
+            "multiIf",
+            makeASTFunction(
+                "and",
+                makeASTFunction("notEmpty", make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Values})),
+                makeASTFunction("notEmpty", make_intrusive<ASTIdentifier>(Strings{step2, ColumnNames::Values}))),
+            makeASTFunction(
+                "arrayMap",
+                makeASTFunction(
+                    "lambda",
+                    makeASTFunction("tuple", make_intrusive<ASTIdentifier>("a"), make_intrusive<ASTIdentifier>("b")),
+                    makeASTFunction(
+                        "if",
+                        makeASTFunction("isNotNull", make_intrusive<ASTIdentifier>("a")),
+                        make_intrusive<ASTIdentifier>("a"),
+                        make_intrusive<ASTIdentifier>("b"))),
+                make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Values}),
+                make_intrusive<ASTIdentifier>(Strings{step2, ColumnNames::Values})),
+            makeASTFunction("notEmpty", make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Values})),
+            make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Values}),
+            make_intrusive<ASTIdentifier>(Strings{step2, ColumnNames::Values})));
+        builder.select_list.back()->setAlias(ColumnNames::Values);
+
+        builder.from_table = left;
+        builder.join_kind = JoinKind::Full;
+        builder.join_strictness = JoinStrictness::All;
+        builder.join_table = step2;
+
+        builder.join_on = makeASTFunction(
+            "equals",
+            make_intrusive<ASTIdentifier>(Strings{left, ColumnNames::Group}),
+            make_intrusive<ASTIdentifier>(Strings{step2, ColumnNames::Group}));
+
+        step3 = builder.getSelectQuery();
+    }
+
+    SQLQueryPiece res{operator_node, ResultType::INSTANT_VECTOR, StoreMethod::VECTOR_GRID};
+    res.select_query = std::move(step3);
+    res.metric_name_dropped = left_argument.metric_name_dropped && right_argument.metric_name_dropped;
+
+    res.start_time = left_argument.start_time;
+    res.end_time = left_argument.end_time;
+    res.step = left_argument.step;
+
+    return res;
+}
+
+}

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorOr.h
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorOr.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <Storages/TimeSeries/PrometheusQueryToSQL/SQLQueryPiece.h>
+
+
+namespace DB::PrometheusQueryToSQL
+{
+
+inline bool isBinaryOperatorOr(std::string_view operator_name) { return operator_name == "or"; }
+
+/// Applies a prometheus operator "or".
+SQLQueryPiece applyBinaryOperatorOr(
+    const PQT::BinaryOperator * operator_node,
+    SQLQueryPiece && left_argument,
+    SQLQueryPiece && right_argument,
+    ConverterContext & context);
+
+}

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorUnless.cpp
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorUnless.cpp
@@ -1,0 +1,132 @@
+#include <Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorUnless.h>
+
+#include <Parsers/ASTFunction.h>
+#include <Parsers/ASTIdentifier.h>
+#include <Parsers/ASTLiteral.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/ConverterContext.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/SelectQueryBuilder.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorAnd.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/toVectorGrid.h>
+#include <Storages/TimeSeries/PrometheusQueryToSQL/transformGroupASTForBinaryOperator.h>
+
+
+namespace DB::PrometheusQueryToSQL
+{
+
+SQLQueryPiece applyBinaryOperatorUnless(
+    const PQT::BinaryOperator * operator_node, SQLQueryPiece && left_argument, SQLQueryPiece && right_argument, ConverterContext & context)
+{
+    checkArgumentTypesForSetBinaryOperator(operator_node, left_argument, right_argument, context);
+
+    /// If the left argument is empty then the result is also empty.
+    if (left_argument.store_method == StoreMethod::EMPTY)
+        return SQLQueryPiece(operator_node, ResultType::INSTANT_VECTOR, StoreMethod::EMPTY);
+
+    /// If the right argument is empty then we return the left argument.
+    if (right_argument.store_method == StoreMethod::EMPTY)
+    {
+        auto res = std::move(left_argument);
+        res.node = operator_node;
+        return res;
+    }
+
+    left_argument = toVectorGrid(std::move(left_argument), context);
+    context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(left_argument.select_query), SQLSubqueryType::TABLE});
+    String left = context.subqueries.back().name;
+
+    right_argument = toVectorGrid(std::move(right_argument), context);
+    context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(right_argument.select_query), SQLSubqueryType::TABLE});
+    String right = context.subqueries.back().name;
+
+    /// Step 1:
+    /// SELECT timeSeriesRemoveAllTagsExcept(group, on_tags) AS join_group,
+    ///        countForEach(values) AS join_count
+    /// GROUP BY join_group
+    /// FROM right
+    ///
+    String step1;
+    {
+        SelectQueryBuilder builder;
+
+        bool right_metric_name_dropped = right_argument.metric_name_dropped;
+        builder.select_list.push_back(transformGroupASTForBinaryOperator(
+            operator_node,
+            make_intrusive<ASTIdentifier>(ColumnNames::Group),
+            /*drop_metric_name=*/ true,
+            right_metric_name_dropped));
+        builder.select_list.back()->setAlias(ColumnNames::JoinGroup);
+
+        builder.select_list.push_back(makeASTFunction("countForEach", make_intrusive<ASTIdentifier>(ColumnNames::Values)));
+        builder.select_list.back()->setAlias(ColumnNames::JoinCount);
+
+        builder.group_by.push_back(make_intrusive<ASTIdentifier>(ColumnNames::JoinGroup));
+
+        builder.from_table = right;
+
+        ASTPtr step1_ast = builder.getSelectQuery();
+        context.subqueries.emplace_back(SQLSubquery{context.subqueries.size(), std::move(step1_ast), SQLSubqueryType::TABLE});
+        step1 = context.subqueries.back().name;
+    }
+
+    /// Step 2:
+    /// SELECT group,
+    ///        if(notEmpty(join_count), arrayMap(x, y -> if(y = 0, x, NULL), values, join_count), values) AS values
+    /// FROM left LEFT ANY JOIN step1
+    /// ON timeSeriesRemoveAllTagsExcept(group, on_tags) == join_group
+    ///
+    ASTPtr step2;
+    {
+        SelectQueryBuilder builder;
+
+        builder.select_list.push_back(make_intrusive<ASTIdentifier>(ColumnNames::Group));
+
+        builder.select_list.push_back(makeASTFunction(
+            "if",
+            makeASTFunction("notEmpty", make_intrusive<ASTIdentifier>(ColumnNames::JoinCount)),
+            makeASTFunction(
+                "arrayMap",
+                makeASTFunction(
+                    "lambda",
+                    makeASTFunction("tuple", make_intrusive<ASTIdentifier>("x"), make_intrusive<ASTIdentifier>("y")),
+                    makeASTFunction(
+                        "if",
+                        makeASTFunction("equals", make_intrusive<ASTIdentifier>("y"), make_intrusive<ASTLiteral>(0u)),
+                        make_intrusive<ASTIdentifier>("x"),
+                        make_intrusive<ASTLiteral>(Field{} /* NULL */))),
+                make_intrusive<ASTIdentifier>(ColumnNames::Values),
+                make_intrusive<ASTIdentifier>(ColumnNames::JoinCount)),
+            make_intrusive<ASTIdentifier>(ColumnNames::Values)));
+
+        builder.select_list.back()->setAlias(ColumnNames::Values);
+
+        builder.from_table = left;
+
+        builder.join_kind = JoinKind::Left;
+        builder.join_strictness = JoinStrictness::Any;
+        builder.join_table = step1;
+
+        bool left_metric_name_dropped = left_argument.metric_name_dropped;
+        builder.join_on = makeASTFunction(
+            "equals",
+            transformGroupASTForBinaryOperator(
+                operator_node,
+                make_intrusive<ASTIdentifier>(ColumnNames::Group),
+                /*drop_metric_name=*/ true,
+                left_metric_name_dropped),
+            make_intrusive<ASTIdentifier>(ColumnNames::JoinGroup));
+
+        step2 = builder.getSelectQuery();
+    }
+
+    SQLQueryPiece res{operator_node, ResultType::INSTANT_VECTOR, StoreMethod::VECTOR_GRID};
+    res.select_query = std::move(step2);
+    res.metric_name_dropped = left_argument.metric_name_dropped;
+
+    res.start_time = left_argument.start_time;
+    res.end_time = left_argument.end_time;
+    res.step = left_argument.step;
+
+    return res;
+}
+
+}

--- a/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorUnless.h
+++ b/src/Storages/TimeSeries/PrometheusQueryToSQL/applyBinaryOperatorUnless.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <Storages/TimeSeries/PrometheusQueryToSQL/SQLQueryPiece.h>
+
+
+namespace DB::PrometheusQueryToSQL
+{
+
+inline bool isBinaryOperatorUnless(std::string_view operator_name) { return operator_name == "unless"; }
+
+/// Applies a prometheus operator "unless".
+SQLQueryPiece applyBinaryOperatorUnless(
+    const PQT::BinaryOperator * operator_node,
+    SQLQueryPiece && left_argument,
+    SQLQueryPiece && right_argument,
+    ConverterContext & context);
+
+}

--- a/src/Storages/TimeSeries/TimeSeriesColumnNames.h
+++ b/src/Storages/TimeSeries/TimeSeriesColumnNames.h
@@ -47,6 +47,7 @@ struct TimeSeriesColumnNames
     static constexpr const char * MaskedValues = "masked_values";
     static constexpr const char * OriginalGroup = "original_group";
     static constexpr const char * JoinGroup = "join_group";
+    static constexpr const char * JoinCount = "join_count";
     static constexpr const char * Values = "values";
     static constexpr const char * SamplingKeys = "sampling_keys";
 };

--- a/tests/integration/test_prometheus_protocols/test_evaluation.py
+++ b/tests/integration/test_prometheus_protocols/test_evaluation.py
@@ -2381,6 +2381,241 @@ def test_comparison_operators():
     )
 
 
+def test_set_binary_operators():
+    do_query_test(
+        "(last_over_time(foo[10]) and last_over_time(bar[10]))[50:10]",
+        150,
+        '{"resultType": "matrix", "result": [{"metric": {"__name__": "foo", "shape": "circle", "size": "l"}, "values": [[110, "16"], [130, "16"], [150, "16"]]}, {"metric": {"__name__": "foo", "shape": "square", "size": "s"}, "values": [[110, "4"]]}]}',
+        [
+            [
+                "[('__name__','foo'),('shape','circle'),('size','l')]",
+                "[('1970-01-01 00:01:50.000',16),('1970-01-01 00:02:10.000',16),('1970-01-01 00:02:30.000',16)]",
+            ],
+            [
+                "[('__name__','foo'),('shape','square'),('size','s')]",
+                "[('1970-01-01 00:01:50.000',4)]",
+            ],
+        ],
+    )
+
+    do_query_test(
+        "(last_over_time(foo[10]) unless last_over_time(bar[10]))[50:10]",
+        150,
+        '{"resultType": "matrix", "result": [{"metric": {"__name__": "foo", "shape": "square", "size": "s"}, "values": [[130, "40"]]}, {"metric": {"__name__": "foo", "shape": "triangle", "size": "m"}, "values": [[110, "8"], [120, "80"]]}]}',
+        [
+            [
+                "[('__name__','foo'),('shape','square'),('size','s')]",
+                "[('1970-01-01 00:02:10.000',40)]",
+            ],
+            [
+                "[('__name__','foo'),('shape','triangle'),('size','m')]",
+                "[('1970-01-01 00:01:50.000',8),('1970-01-01 00:02:00.000',80)]",
+            ],
+        ],
+    )
+
+    do_query_test(
+        "(last_over_time(foo[10]) or last_over_time(bar[10]))[50:10]",
+        150,
+        '{"resultType": "matrix", "result": [{"metric": {"__name__": "bar", "shape": "circle", "size": "l"}, "values": [[120, "16"]]}, {"metric": {"__name__": "bar", "shape": "rectangle", "size": "l"}, "values": [[110, "9"], [130, "90"]]}, {"metric": {"__name__": "bar", "shape": "square", "size": "s"}, "values": [[120, "40"], [140, "700"]]}, {"metric": {"__name__": "bar", "shape": "triangle", "size": "xl"}, "values": [[110, "8"], [150, "30"]]}, {"metric": {"__name__": "foo", "shape": "circle", "size": "l"}, "values": [[110, "16"], [130, "16"], [150, "16"]]}, {"metric": {"__name__": "foo", "shape": "square", "size": "s"}, "values": [[110, "4"], [130, "40"]]}, {"metric": {"__name__": "foo", "shape": "triangle", "size": "m"}, "values": [[110, "8"], [120, "80"]]}]}',
+        [
+            [
+                "[('__name__','bar'),('shape','circle'),('size','l')]",
+                "[('1970-01-01 00:02:00.000',16)]",
+            ],
+            [
+                "[('__name__','bar'),('shape','rectangle'),('size','l')]",
+                "[('1970-01-01 00:01:50.000',9),('1970-01-01 00:02:10.000',90)]",
+            ],
+            [
+                "[('__name__','bar'),('shape','square'),('size','s')]",
+                "[('1970-01-01 00:02:00.000',40),('1970-01-01 00:02:20.000',700)]",
+            ],
+            [
+                "[('__name__','bar'),('shape','triangle'),('size','xl')]",
+                "[('1970-01-01 00:01:50.000',8),('1970-01-01 00:02:30.000',30)]",
+            ],
+            [
+                "[('__name__','foo'),('shape','circle'),('size','l')]",
+                "[('1970-01-01 00:01:50.000',16),('1970-01-01 00:02:10.000',16),('1970-01-01 00:02:30.000',16)]",
+            ],
+            [
+                "[('__name__','foo'),('shape','square'),('size','s')]",
+                "[('1970-01-01 00:01:50.000',4),('1970-01-01 00:02:10.000',40)]",
+            ],
+            [
+                "[('__name__','foo'),('shape','triangle'),('size','m')]",
+                "[('1970-01-01 00:01:50.000',8),('1970-01-01 00:02:00.000',80)]",
+            ],
+        ],
+    )
+
+    do_query_test(
+        "(last_over_time(foo[10]) and on(shape) last_over_time(bar[10]))[50:10]",
+        150,
+        '{"resultType": "matrix", "result": [{"metric": {"__name__": "foo", "shape": "circle", "size": "l"}, "values": [[110, "16"], [130, "16"], [150, "16"]]}, {"metric": {"__name__": "foo", "shape": "square", "size": "s"}, "values": [[110, "4"]]}, {"metric": {"__name__": "foo", "shape": "triangle", "size": "m"}, "values": [[110, "8"]]}]}',
+        [
+            [
+                "[('__name__','foo'),('shape','circle'),('size','l')]",
+                "[('1970-01-01 00:01:50.000',16),('1970-01-01 00:02:10.000',16),('1970-01-01 00:02:30.000',16)]",
+            ],
+            [
+                "[('__name__','foo'),('shape','square'),('size','s')]",
+                "[('1970-01-01 00:01:50.000',4)]",
+            ],
+            [
+                "[('__name__','foo'),('shape','triangle'),('size','m')]",
+                "[('1970-01-01 00:01:50.000',8)]",
+            ],
+        ],
+    )
+
+    do_query_test(
+        "(last_over_time(foo[10]) unless ignoring(size) last_over_time(bar[10]))[50:10]",
+        150,
+        '{"resultType": "matrix", "result": [{"metric": {"__name__": "foo", "shape": "square", "size": "s"}, "values": [[130, "40"]]}, {"metric": {"__name__": "foo", "shape": "triangle", "size": "m"}, "values": [[120, "80"]]}]}',
+        [
+            [
+                "[('__name__','foo'),('shape','square'),('size','s')]",
+                "[('1970-01-01 00:02:10.000',40)]",
+            ],
+            [
+                "[('__name__','foo'),('shape','triangle'),('size','m')]",
+                "[('1970-01-01 00:02:00.000',80)]",
+            ],
+        ],
+    )
+
+    do_query_test(
+        "(last_over_time(foo[10]) or on(shape) last_over_time(bar[10]))[50:10]",
+        150,
+        '{"resultType": "matrix", "result": [{"metric": {"__name__": "bar", "shape": "circle", "size": "l"}, "values": [[120, "16"]]}, {"metric": {"__name__": "bar", "shape": "rectangle", "size": "l"}, "values": [[110, "9"], [130, "90"]]}, {"metric": {"__name__": "bar", "shape": "square", "size": "s"}, "values": [[120, "40"], [140, "700"]]}, {"metric": {"__name__": "bar", "shape": "triangle", "size": "xl"}, "values": [[150, "30"]]}, {"metric": {"__name__": "foo", "shape": "circle", "size": "l"}, "values": [[110, "16"], [130, "16"], [150, "16"]]}, {"metric": {"__name__": "foo", "shape": "square", "size": "s"}, "values": [[110, "4"], [130, "40"]]}, {"metric": {"__name__": "foo", "shape": "triangle", "size": "m"}, "values": [[110, "8"], [120, "80"]]}]}',
+        [
+            [
+                "[('__name__','bar'),('shape','circle'),('size','l')]",
+                "[('1970-01-01 00:02:00.000',16)]",
+            ],
+            [
+                "[('__name__','bar'),('shape','rectangle'),('size','l')]",
+                "[('1970-01-01 00:01:50.000',9),('1970-01-01 00:02:10.000',90)]",
+            ],
+            [
+                "[('__name__','bar'),('shape','square'),('size','s')]",
+                "[('1970-01-01 00:02:00.000',40),('1970-01-01 00:02:20.000',700)]",
+            ],
+            [
+                "[('__name__','bar'),('shape','triangle'),('size','xl')]",
+                "[('1970-01-01 00:02:30.000',30)]",
+            ],
+            [
+                "[('__name__','foo'),('shape','circle'),('size','l')]",
+                "[('1970-01-01 00:01:50.000',16),('1970-01-01 00:02:10.000',16),('1970-01-01 00:02:30.000',16)]",
+            ],
+            [
+                "[('__name__','foo'),('shape','square'),('size','s')]",
+                "[('1970-01-01 00:01:50.000',4),('1970-01-01 00:02:10.000',40)]",
+            ],
+            [
+                "[('__name__','foo'),('shape','triangle'),('size','m')]",
+                "[('1970-01-01 00:01:50.000',8),('1970-01-01 00:02:00.000',80)]",
+            ],
+        ],
+    )
+
+    # The result of `(foo > 10) or foo` must be exactly `foo`.
+    do_query_test(
+        "((last_over_time(foo[10]) > 10) or last_over_time(foo[10]))[50:10]",
+        150,
+        '{"resultType": "matrix", "result": [{"metric": {"__name__": "foo", "shape": "circle", "size": "l"}, "values": [[110, "16"], [130, "16"], [150, "16"]]}, {"metric": {"__name__": "foo", "shape": "square", "size": "s"}, "values": [[110, "4"], [130, "40"]]}, {"metric": {"__name__": "foo", "shape": "triangle", "size": "m"}, "values": [[110, "8"], [120, "80"]]}]}',
+        [
+            [
+                "[('__name__','foo'),('shape','circle'),('size','l')]",
+                "[('1970-01-01 00:01:50.000',16),('1970-01-01 00:02:10.000',16),('1970-01-01 00:02:30.000',16)]",
+            ],
+            [
+                "[('__name__','foo'),('shape','square'),('size','s')]",
+                "[('1970-01-01 00:01:50.000',4),('1970-01-01 00:02:10.000',40)]",
+            ],
+            [
+                "[('__name__','foo'),('shape','triangle'),('size','m')]",
+                "[('1970-01-01 00:01:50.000',8),('1970-01-01 00:02:00.000',80)]",
+            ],
+        ],
+    )
+
+    # Here bar(rectangle,l) shares {size=l} with the foo(circle,l) / bar(circle,l) pair and
+    # must still appear at the steps where the original foo(circle,l) was filtered to NULL.
+    # And "+ 0" is used here to drop the metric name.
+    do_query_test(
+        "((last_over_time(foo[10]) > 20) + 0 or on(size) (last_over_time(bar[10]) + 0))[50:10]",
+        150,
+        '{"resultType": "matrix", "result": [{"metric": {"shape": "circle", "size": "l"}, "values": [[110, "10"], [120, "16"], [130, "50"], [150, "1000"]]}, {"metric": {"shape": "rectangle", "size": "l"}, "values": [[110, "9"], [130, "90"]]}, {"metric": {"shape": "square", "size": "s"}, "values": [[110, "3"], [120, "40"], [130, "40"], [140, "700"]]}, {"metric": {"shape": "triangle", "size": "m"}, "values": [[120, "80"]]}, {"metric": {"shape": "triangle", "size": "xl"}, "values": [[110, "8"], [150, "30"]]}]}',
+        [
+            [
+                "[('shape','circle'),('size','l')]",
+                "[('1970-01-01 00:01:50.000',10),('1970-01-01 00:02:00.000',16),('1970-01-01 00:02:10.000',50),('1970-01-01 00:02:30.000',1000)]",
+            ],
+            [
+                "[('shape','rectangle'),('size','l')]",
+                "[('1970-01-01 00:01:50.000',9),('1970-01-01 00:02:10.000',90)]",
+            ],
+            [
+                "[('shape','square'),('size','s')]",
+                "[('1970-01-01 00:01:50.000',3),('1970-01-01 00:02:00.000',40),('1970-01-01 00:02:10.000',40),('1970-01-01 00:02:20.000',700)]",
+            ],
+            [
+                "[('shape','triangle'),('size','m')]",
+                "[('1970-01-01 00:02:00.000',80)]",
+            ],
+            [
+                "[('shape','triangle'),('size','xl')]",
+                "[('1970-01-01 00:01:50.000',8),('1970-01-01 00:02:30.000',30)]",
+            ],
+        ],
+    )
+
+    # Here bar(rectangle,l) on the left at t=130 covers {size=l},
+    # so right "(circle,l)=50" at t=130 must be suppressed even though left (circle,l) is NULL there.
+    # And "+ 0" is used here to drop the metric name.
+    do_query_test(
+        "((last_over_time(bar[10]) > 50) + 0 or on(size) (last_over_time(bar[10]) + 0))[50:10]",
+        150,
+        '{"resultType": "matrix", "result": [{"metric": {"shape": "circle", "size": "l"}, "values": [[110, "10"], [120, "16"], [150, "1000"]]}, {"metric": {"shape": "rectangle", "size": "l"}, "values": [[110, "9"], [130, "90"]]}, {"metric": {"shape": "square", "size": "s"}, "values": [[110, "3"], [120, "40"], [140, "700"]]}, {"metric": {"shape": "triangle", "size": "xl"}, "values": [[110, "8"], [150, "30"]]}]}',
+        [
+            [
+                "[('shape','circle'),('size','l')]",
+                "[('1970-01-01 00:01:50.000',10),('1970-01-01 00:02:00.000',16),('1970-01-01 00:02:30.000',1000)]",
+            ],
+            [
+                "[('shape','rectangle'),('size','l')]",
+                "[('1970-01-01 00:01:50.000',9),('1970-01-01 00:02:10.000',90)]",
+            ],
+            [
+                "[('shape','square'),('size','s')]",
+                "[('1970-01-01 00:01:50.000',3),('1970-01-01 00:02:00.000',40),('1970-01-01 00:02:20.000',700)]",
+            ],
+            [
+                "[('shape','triangle'),('size','xl')]",
+                "[('1970-01-01 00:01:50.000',8),('1970-01-01 00:02:30.000',30)]",
+            ],
+        ],
+    )
+
+    do_query_test_expect_error(
+        "last_over_time(foo[10]) and on(shape) group_left last_over_time(bar[10])",
+        150,
+        "no grouping allowed",
+        "Binary operator 'and' doesn't allow group_left",
+    )
+
+    do_query_test_expect_error(
+        "last_over_time(foo[10]) or ignoring(size) group_right last_over_time(bar[10])",
+        150,
+        "no grouping allowed",
+        "Binary operator 'or' doesn't allow group_right",
+    )
+
+
 def test_aggregation_operators():
     do_query_test(
         "sum(bar)",


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
PromQL: Add set binary operators `and`, `or`, `unless`

This was a part of https://github.com/ClickHouse/ClickHouse/pull/98948 ([0c63be2](https://github.com/vitlibar/ClickHouse/commit/0c63be27e8fbcaca2d399a8a25e1c4b14084e31a)) which wasn't merged

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.810`
<!-- ch-version-info:end -->