### PR TITLE
Reproducer for #105021: EXCHANGE TABLES drops MV-source dependencies

### DIFF
--- a/tests/queries/0_stateless/04240_exchange_tables_drops_mv_source_dependencies.reference
+++ b/tests/queries/0_stateless/04240_exchange_tables_drops_mv_source_dependencies.reference
@@ -1,0 +1,7 @@
+count after first insert	1
+before exchange, deps of a	['mv']
+before exchange, deps of b	[]
+after exchange, deps of a	[]
+after exchange, deps of b	['mv']
+after insert into a, count in dst	1
+after insert into b, count in dst	1

--- a/tests/queries/0_stateless/04240_exchange_tables_drops_mv_source_dependencies.sql
+++ b/tests/queries/0_stateless/04240_exchange_tables_drops_mv_source_dependencies.sql
@@ -1,0 +1,46 @@
+-- Reproducer for https://github.com/ClickHouse/ClickHouse/issues/105021
+--
+-- After `EXCHANGE TABLES a, b` where a materialized view `mv` reads from `a`,
+-- inserts into both `a` and `b` silently stop feeding the MV target table.
+-- Regression introduced by https://github.com/ClickHouse/ClickHouse/pull/98779
+-- (correct on v26.4.2.10, broken on master).
+--
+-- This test pins the current buggy behavior so the regression is locked down.
+-- When the bug is fixed, the reference must be updated: at least one of the
+-- post-exchange `count() FROM dst` assertions should change.
+
+DROP TABLE IF EXISTS mv;
+DROP TABLE IF EXISTS dst;
+DROP TABLE IF EXISTS a;
+DROP TABLE IF EXISTS b;
+
+CREATE TABLE a (id Int32, key String) ENGINE = Null;
+CREATE TABLE b (id Int32, key String) ENGINE = Null;
+CREATE TABLE dst (id Int32, key String) ENGINE = MergeTree ORDER BY id;
+CREATE MATERIALIZED VIEW mv TO dst AS SELECT id, key FROM a;
+
+INSERT INTO a VALUES (1, 'a-before');
+SELECT 'count after first insert', count() FROM dst;
+
+SELECT 'before exchange, deps of a', dependencies_table
+FROM system.tables WHERE database = currentDatabase() AND name = 'a';
+SELECT 'before exchange, deps of b', dependencies_table
+FROM system.tables WHERE database = currentDatabase() AND name = 'b';
+
+EXCHANGE TABLES a AND b;
+
+SELECT 'after exchange, deps of a', dependencies_table
+FROM system.tables WHERE database = currentDatabase() AND name = 'a';
+SELECT 'after exchange, deps of b', dependencies_table
+FROM system.tables WHERE database = currentDatabase() AND name = 'b';
+
+INSERT INTO a VALUES (2, 'a-after');
+SELECT 'after insert into a, count in dst', count() FROM dst;
+
+INSERT INTO b VALUES (3, 'b-after');
+SELECT 'after insert into b, count in dst', count() FROM dst;
+
+DROP TABLE mv;
+DROP TABLE dst;
+DROP TABLE a;
+DROP TABLE b;


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Add functional reproducer for #105021. After `EXCHANGE TABLES a, b` where a materialized view reads from `a`, inserts into both `a` and `b` silently stop feeding the `MV` target table. The reference pins the current buggy behavior; once #105021 is fixed, the reference must be updated.

Regression details and proposed fix options in #105021. Confirmed against `v26.4.2.10` (correct) and current master `26.5.1.1` (broken). Bisected to #98779.