### PR TITLE
Fix flaky 04204_mergetree_arena_routes_writes

### DIFF
--- a/tests/queries/0_stateless/04204_mergetree_arena_routes_writes.sql
+++ b/tests/queries/0_stateless/04204_mergetree_arena_routes_writes.sql
@@ -19,6 +19,11 @@
 -- routing is broken (`getArenaIndex()` returning 0, or scope guards no-op'd), the arena
 -- collapses to ~0 and this assertion catches it.
 
+-- Suppress server-side Error log messages forwarded to the client (e.g. "Cannot get replica
+-- delay for table: ... Table is in readonly mode" from other tests' leftover replicated tables
+-- being scanned by ServerAsynchronousMetrics during SYSTEM RELOAD ASYNCHRONOUS METRICS).
+SET send_logs_level = 'fatal';
+
 DROP TABLE IF EXISTS t_mergetree_arena_smoke SYNC;
 
 CREATE TABLE t_mergetree_arena_smoke (a UInt64, b String, c LowCardinality(String))


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix https://github.com/ClickHouse/ClickHouse/issues/104912

Ignore the error log from `SYSTEM RELOAD ASYNCHRONOUS METRICS;`
