### PR TITLE
Optimize per-event trace flags: move into separate array and lazy allocation

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -1472,6 +1472,8 @@ Counters::Counters(Counters && src) noexcept
     : counters(std::exchange(src.counters, nullptr))
     , counters_holder(std::move(src.counters_holder))
     , parent(src.parent.exchange(nullptr))
+    , should_trace_array(src.should_trace_array.exchange(nullptr, std::memory_order_relaxed))
+    , should_trace_holder(std::move(src.should_trace_holder))
     , trace_all_profile_events(src.trace_all_profile_events.load(std::memory_order_relaxed))
     , level(src.level)
 {
@@ -1539,6 +1541,26 @@ Event getByName(std::string_view name)
     };
 
     return map.at(name);
+}
+
+void Counters::setTraceProfileEvent(Event event)
+{
+    auto * trace_array = should_trace_array.load(std::memory_order_relaxed);
+    if (!trace_array)
+    {
+        /// It is very unlikely that it will be allocated twice, since we set it at the beginning of the query
+        auto fresh = std::make_unique<std::atomic_bool[]>(num_counters);
+        auto * fresh_raw = fresh.get();
+        std::atomic_bool * expected = nullptr;
+        if (should_trace_array.compare_exchange_strong(expected, fresh_raw, std::memory_order_release, std::memory_order_relaxed))
+        {
+            should_trace_holder = std::move(fresh);
+            trace_array = fresh_raw;
+        }
+        else
+            trace_array = expected;
+    }
+    trace_array[event].store(true, std::memory_order_relaxed);
 }
 
 void Counters::setTraceProfileEvents(const String & events_list)
@@ -1646,7 +1668,8 @@ void Counters::increment(Event event, Count amount)
     do
     {
         current->counters[event].fetch_add(amount, std::memory_order_relaxed);
-        send_to_trace_log |= current->counters[event].should_trace;
+        if (auto * trace_arr = current->should_trace_array.load(std::memory_order_relaxed))
+            send_to_trace_log |= trace_arr[event].load(std::memory_order_relaxed);
         send_to_trace_log |= current->trace_all_profile_events.load(std::memory_order_relaxed);
 
         current = current->parent;

--- a/src/Common/ProfileEvents.h
+++ b/src/Common/ProfileEvents.h
@@ -26,8 +26,6 @@ namespace ProfileEvents
     struct Counter : public std::atomic<Count>
     {
         using std::atomic<Count>::atomic;
-        /// When we should send it to system.trace_log
-        bool should_trace = false;
     };
     class Counters;
 
@@ -68,9 +66,13 @@ namespace ProfileEvents
         std::unique_ptr<Counter[]> counters_holder;
         /// Used to propagate increments
         std::atomic<Counters *> parent = {};
-        std::atomic_bool trace_all_profile_events = false;
         Counter prev_cpu_wait_microseconds = 0;
         Counter prev_cpu_virtual_time_microseconds = 0;
+
+        /// Lazily allocated on first setTraceProfileEvent()
+        std::atomic<std::atomic_bool *> should_trace_array = nullptr;
+        std::unique_ptr<std::atomic_bool[]> should_trace_holder;
+        std::atomic_bool trace_all_profile_events = false;
 
     public:
 
@@ -157,11 +159,7 @@ namespace ProfileEvents
             trace_all_profile_events.store(true, std::memory_order_relaxed);
         }
 
-        void setTraceProfileEvent(ProfileEvents::Event event)
-        {
-            counters[event].should_trace = true;
-        }
-
+        void setTraceProfileEvent(ProfileEvents::Event event);
         void setTraceProfileEvents(const String & events_list);
 
         /// Set all counters to zero


### PR DESCRIPTION
Those flags are rarely used, since it is only for debugging under `trace_profile_events`, but it increase the size of the structure 2x (Counter increased from 8 bytes to 16 due to alignment)

So move it into separate array, and allocate it lazily.

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Optimize per-event trace flags: move into separate array and lazy allocation

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.820`
<!-- ch-version-info:end -->