### PR TITLE
Fix wrong result comparing constant FixedString with materialized String

### DIFF
--- a/src/Functions/FunctionsComparison.h
+++ b/src/Functions/FunctionsComparison.h
@@ -280,6 +280,26 @@ struct StringComparisonImpl
         }
     }
 
+    /// Compare String vector with a constant that is a FixedString.
+    /// FixedString trailing zero bytes are treated as padding (zero-padded comparison).
+    static void NO_INLINE string_vector_fixed_string_constant( /// NOLINT
+        const ColumnString::Chars & a_data, const ColumnString::Offsets & a_offsets,
+        const ColumnString::Chars & b_data, ColumnString::Offset b_size,
+        PaddedPODArray<UInt8> & c)
+    {
+        size_t size = a_offsets.size();
+        ColumnString::Offset prev_a_offset = 0;
+
+        for (size_t i = 0; i < size; ++i)
+        {
+            c[i] = Op::apply(memcmpSmallLikeZeroPaddedAllowOverflow15(
+                a_data.data() + prev_a_offset, a_offsets[i] - prev_a_offset,
+                b_data.data(), b_size), 0);
+
+            prev_a_offset = a_offsets[i];
+        }
+    }
+
     static void fixed_string_vector_string_vector( /// NOLINT
         const ColumnString::Chars & a_data, ColumnString::Offset a_n,
         const ColumnString::Chars & b_data, const ColumnString::Offsets & b_offsets,
@@ -366,6 +386,15 @@ struct StringComparisonImpl
         PaddedPODArray<UInt8> & c)
     {
         StringComparisonImpl<typename Op::SymmetricOp>::string_vector_constant(b_data, b_offsets, a_data, a_size, c);
+    }
+
+    /// Compare a FixedString constant with a String vector (zero-padded comparison).
+    static void fixed_string_constant_string_vector( /// NOLINT
+        const ColumnString::Chars & a_data, ColumnString::Offset a_size,
+        const ColumnString::Chars & b_data, const ColumnString::Offsets & b_offsets,
+        PaddedPODArray<UInt8> & c)
+    {
+        StringComparisonImpl<typename Op::SymmetricOp>::string_vector_fixed_string_constant(b_data, b_offsets, a_data, a_size, c);
     }
 
     static void constant_fixed_string_vector( /// NOLINT
@@ -468,6 +497,28 @@ struct StringEqualsImpl
         }
     }
 
+    /// Compare String vector with a constant that is a FixedString.
+    /// FixedString trailing zero bytes are treated as padding (zero-padded comparison).
+    static void NO_INLINE string_vector_fixed_string_constant( /// NOLINT
+        const ColumnString::Chars & a_data, const ColumnString::Offsets & a_offsets,
+        const ColumnString::Chars & b_data, ColumnString::Offset b_size,
+        PaddedPODArray<UInt8> & c)
+    {
+        size_t size = a_offsets.size();
+        ColumnString::Offset prev_a_offset = 0;
+
+        for (size_t i = 0; i < size; ++i)
+        {
+            auto a_size = a_offsets[i] - prev_a_offset;
+
+            c[i] = positive == memequalSmallLikeZeroPaddedAllowOverflow15(
+                a_data.data() + prev_a_offset, a_size,
+                b_data.data(), b_size);
+
+            prev_a_offset = a_offsets[i];
+        }
+    }
+
     static void NO_INLINE fixed_string_vector_fixed_string_vector_16( /// NOLINT
         const ColumnString::Chars & a_data,
         const ColumnString::Chars & b_data,
@@ -551,6 +602,15 @@ struct StringEqualsImpl
         PaddedPODArray<UInt8> & c)
     {
         string_vector_constant(b_data, b_offsets, a_data, a_size, c);
+    }
+
+    /// Compare a FixedString constant with a String vector (zero-padded comparison).
+    static void fixed_string_constant_string_vector( /// NOLINT
+        const ColumnString::Chars & a_data, ColumnString::Offset a_size,
+        const ColumnString::Chars & b_data, const ColumnString::Offsets & b_offsets,
+        PaddedPODArray<UInt8> & c)
+    {
+        string_vector_fixed_string_constant(b_data, b_offsets, a_data, a_size, c);
     }
 
     static void constant_fixed_string_vector( /// NOLINT
@@ -809,6 +869,8 @@ private:
         const ColumnString::Chars * c1_const_chars = nullptr;
         ColumnString::Offset c0_const_size = 0;
         ColumnString::Offset c1_const_size = 0;
+        bool c0_const_is_fixed = false;
+        bool c1_const_is_fixed = false;
 
         if (c0_const)
         {
@@ -824,6 +886,7 @@ private:
             {
                 c0_const_chars = &c0_const_fixed_string->getChars();
                 c0_const_size = c0_const_fixed_string->getN();
+                c0_const_is_fixed = true;
             }
             else
                 throw Exception(ErrorCodes::ILLEGAL_COLUMN, "ColumnConst contains not String nor FixedString column");
@@ -843,6 +906,7 @@ private:
             {
                 c1_const_chars = &c1_const_fixed_string->getChars();
                 c1_const_size = c1_const_fixed_string->getN();
+                c1_const_is_fixed = true;
             }
             else
                 throw Exception(ErrorCodes::ILLEGAL_COLUMN, "ColumnConst contains not String nor FixedString column");
@@ -870,8 +934,14 @@ private:
             StringImpl::string_vector_fixed_string_vector(
                 c0_string->getChars(), c0_string->getOffsets(), c1_fixed_string->getChars(), c1_fixed_string->getN(), c_res->getData());
         else if (c0_string && c1_const)
-            StringImpl::string_vector_constant(
-                c0_string->getChars(), c0_string->getOffsets(), *c1_const_chars, c1_const_size, c_res->getData());
+        {
+            if (c1_const_is_fixed)
+                StringImpl::string_vector_fixed_string_constant(
+                    c0_string->getChars(), c0_string->getOffsets(), *c1_const_chars, c1_const_size, c_res->getData());
+            else
+                StringImpl::string_vector_constant(
+                    c0_string->getChars(), c0_string->getOffsets(), *c1_const_chars, c1_const_size, c_res->getData());
+        }
         else if (c0_fixed_string && c1_string)
             StringImpl::fixed_string_vector_string_vector(
                 c0_fixed_string->getChars(), c0_fixed_string->getN(), c1_string->getChars(), c1_string->getOffsets(), c_res->getData());
@@ -886,8 +956,14 @@ private:
             StringImpl::fixed_string_vector_constant(
                 c0_fixed_string->getChars(), c0_fixed_string->getN(), *c1_const_chars, c1_const_size, c_res->getData());
         else if (c0_const && c1_string)
-            StringImpl::constant_string_vector(
-                *c0_const_chars, c0_const_size, c1_string->getChars(), c1_string->getOffsets(), c_res->getData());
+        {
+            if (c0_const_is_fixed)
+                StringImpl::fixed_string_constant_string_vector(
+                    *c0_const_chars, c0_const_size, c1_string->getChars(), c1_string->getOffsets(), c_res->getData());
+            else
+                StringImpl::constant_string_vector(
+                    *c0_const_chars, c0_const_size, c1_string->getChars(), c1_string->getOffsets(), c_res->getData());
+        }
         else if (c0_const && c1_fixed_string)
             StringImpl::constant_fixed_string_vector(
                 *c0_const_chars, c0_const_size, c1_fixed_string->getChars(), c1_fixed_string->getN(), c_res->getData());

--- a/tests/queries/0_stateless/04236_fixed_string_const_comparison_with_string.reference
+++ b/tests/queries/0_stateless/04236_fixed_string_const_comparison_with_string.reference
@@ -1,0 +1,37 @@
+-- greater
+0
+0
+0
+0
+-- less
+0
+0
+0
+0
+-- equals
+1
+1
+1
+1
+-- notEquals
+0
+0
+0
+0
+-- greaterOrEquals (padding should be equal)
+1
+1
+1
+1
+-- lessOrEquals (padding should be equal)
+1
+1
+1
+1
+-- Nullable wrapper (original bug report)
+0
+0
+-- Real differences still detected
+1
+1
+1

--- a/tests/queries/0_stateless/04236_fixed_string_const_comparison_with_string.sql
+++ b/tests/queries/0_stateless/04236_fixed_string_const_comparison_with_string.sql
@@ -1,0 +1,51 @@
+-- Regression test: comparison of constant FixedString with materialized String
+-- must use zero-padded semantics (trailing \0 in FixedString is padding, not data).
+-- Previously, the const-FixedString-vs-String-vector code path used plain memcmp
+-- instead of zero-padded memcmp, giving wrong results.
+
+-- All four const/materialized combinations must agree.
+
+SELECT '-- greater';
+SELECT greater(CAST('\0\0\0\0' AS FixedString(4)), CAST('' AS String));
+SELECT greater(CAST('\0\0\0\0' AS FixedString(4)), materialize(CAST('' AS String)));
+SELECT greater(materialize(CAST('\0\0\0\0' AS FixedString(4))), CAST('' AS String));
+SELECT greater(materialize(CAST('\0\0\0\0' AS FixedString(4))), materialize(CAST('' AS String)));
+
+SELECT '-- less';
+SELECT less(CAST('\0\0\0\0' AS FixedString(4)), CAST('' AS String));
+SELECT less(CAST('\0\0\0\0' AS FixedString(4)), materialize(CAST('' AS String)));
+SELECT less(materialize(CAST('\0\0\0\0' AS FixedString(4))), CAST('' AS String));
+SELECT less(materialize(CAST('\0\0\0\0' AS FixedString(4))), materialize(CAST('' AS String)));
+
+SELECT '-- equals';
+SELECT equals(CAST('abc' AS FixedString(6)), CAST('abc' AS String));
+SELECT equals(CAST('abc' AS FixedString(6)), materialize(CAST('abc' AS String)));
+SELECT equals(materialize(CAST('abc' AS FixedString(6))), CAST('abc' AS String));
+SELECT equals(materialize(CAST('abc' AS FixedString(6))), materialize(CAST('abc' AS String)));
+
+SELECT '-- notEquals';
+SELECT notEquals(CAST('abc' AS FixedString(6)), CAST('abc' AS String));
+SELECT notEquals(CAST('abc' AS FixedString(6)), materialize(CAST('abc' AS String)));
+SELECT notEquals(materialize(CAST('abc' AS FixedString(6))), CAST('abc' AS String));
+SELECT notEquals(materialize(CAST('abc' AS FixedString(6))), materialize(CAST('abc' AS String)));
+
+SELECT '-- greaterOrEquals (padding should be equal)';
+SELECT greaterOrEquals(CAST('\0\0\0\0' AS FixedString(4)), CAST('' AS String));
+SELECT greaterOrEquals(CAST('\0\0\0\0' AS FixedString(4)), materialize(CAST('' AS String)));
+SELECT greaterOrEquals(materialize(CAST('\0\0\0\0' AS FixedString(4))), CAST('' AS String));
+SELECT greaterOrEquals(materialize(CAST('\0\0\0\0' AS FixedString(4))), materialize(CAST('' AS String)));
+
+SELECT '-- lessOrEquals (padding should be equal)';
+SELECT lessOrEquals(CAST('\0\0\0\0' AS FixedString(4)), CAST('' AS String));
+SELECT lessOrEquals(CAST('\0\0\0\0' AS FixedString(4)), materialize(CAST('' AS String)));
+SELECT lessOrEquals(materialize(CAST('\0\0\0\0' AS FixedString(4))), CAST('' AS String));
+SELECT lessOrEquals(materialize(CAST('\0\0\0\0' AS FixedString(4))), materialize(CAST('' AS String)));
+
+SELECT '-- Nullable wrapper (original bug report)';
+SELECT greater(CAST('\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0' AS Nullable(FixedString(26))), CAST('' AS String));
+SELECT greater(CAST('\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0' AS Nullable(FixedString(26))), materialize(CAST('' AS String)));
+
+SELECT '-- Real differences still detected';
+SELECT greater(CAST('xyz' AS FixedString(6)), materialize(CAST('abc' AS String)));
+SELECT less(CAST('abc' AS FixedString(6)), materialize(CAST('xyz' AS String)));
+SELECT greater(materialize(CAST('hello' AS String)), CAST('hell' AS FixedString(4)));


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix wrong result comparing constant FixedString with materialized String. Closes https://github.com/ClickHouse/ClickHouse/issues/105040
