### PR TITLE
JIT: register __fixunssfti / __fixunsdfti for toUInt128(Float)

### DIFF
--- a/src/Interpreters/JIT/CHJIT.cpp
+++ b/src/Interpreters/JIT/CHJIT.cpp
@@ -43,6 +43,12 @@ namespace ErrorCodes
 
 /// These functions will be provided to the linker of JIT code,
 /// so it can call them to work with big integers on platforms without native support.
+///
+/// IMPORTANT: every libcall is registered as a signed/unsigned pair. LLVM picks the
+/// signed or unsigned variant based on whether the IR uses `fptosi`/`sitofp`/`sdiv`/`srem`
+/// or `fptoui`/`uitofp`/`udiv`/`urem`. Forgetting the unsigned half compiles fine but
+/// fails the JIT link at run time with `Could not find symbol __fixunsdfti` (or similar).
+/// Keep the lists below symmetric.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wbit-int-extension"
 #pragma clang diagnostic ignored "-Wreserved-identifier"
@@ -53,9 +59,13 @@ using BitUInt128 = unsigned _BitInt(128);
 /// NOLINTBEGIN
 extern "C" BitInt128 __divti3(BitInt128, BitInt128);
 extern "C" BitInt128 __modti3(BitInt128, BitInt128);
+extern "C" BitUInt128 __udivti3(BitUInt128, BitUInt128);
+extern "C" BitUInt128 __umodti3(BitUInt128, BitUInt128);
 
 extern "C" BitInt128 __fixsfti(float);
 extern "C" BitInt128 __fixdfti(double);
+extern "C" BitUInt128 __fixunssfti(float);
+extern "C" BitUInt128 __fixunsdfti(double);
 
 extern "C" float __floattisf(BitInt128);
 extern "C" float __floatuntisf(BitUInt128);
@@ -396,11 +406,16 @@ CHJIT::CHJIT()
     symbol_resolver->registerSymbol("memcmpSmallCharsAllowOverflow15", reinterpret_cast<void *>(&memcmpSmallCharsAllowOverflow15));
 
     symbol_resolver->registerSymbol("fmod", reinterpret_cast<void *>(static_cast<double (*)(double, double)>(&fmod)));
+    /// Signed and unsigned variants must be kept together: see the comment above the extern declarations.
     symbol_resolver->registerSymbol("__divti3", reinterpret_cast<void *>(&__divti3));
     symbol_resolver->registerSymbol("__modti3", reinterpret_cast<void *>(&__modti3));
+    symbol_resolver->registerSymbol("__udivti3", reinterpret_cast<void *>(&__udivti3));
+    symbol_resolver->registerSymbol("__umodti3", reinterpret_cast<void *>(&__umodti3));
 
     symbol_resolver->registerSymbol("__fixsfti", reinterpret_cast<void *>(&__fixsfti));
     symbol_resolver->registerSymbol("__fixdfti", reinterpret_cast<void *>(&__fixdfti));
+    symbol_resolver->registerSymbol("__fixunssfti", reinterpret_cast<void *>(&__fixunssfti));
+    symbol_resolver->registerSymbol("__fixunsdfti", reinterpret_cast<void *>(&__fixunsdfti));
 
     symbol_resolver->registerSymbol("__floattisf", reinterpret_cast<void *>(&__floattisf));
     symbol_resolver->registerSymbol("__floatuntisf", reinterpret_cast<void *>(&__floatuntisf));

--- a/tests/queries/0_stateless/04240_jit_float_to_big_int_libcalls.reference
+++ b/tests/queries/0_stateless/04240_jit_float_to_big_int_libcalls.reference
@@ -1,0 +1,38 @@
+--- JIT ---
+--- Float -> 128-bit / 256-bit integers ---
+2
+2
+2
+2
+2
+2
+2
+2
+--- 128-bit / 256-bit integers -> Float ---
+2
+2
+2
+2
+2
+2
+2
+2
+--- no JIT ---
+--- Float -> 128-bit / 256-bit integers ---
+2
+2
+2
+2
+2
+2
+2
+2
+--- 128-bit / 256-bit integers -> Float ---
+2
+2
+2
+2
+2
+2
+2
+2

--- a/tests/queries/0_stateless/04240_jit_float_to_big_int_libcalls.sql
+++ b/tests/queries/0_stateless/04240_jit_float_to_big_int_libcalls.sql
@@ -1,0 +1,50 @@
+-- Tags: no-fasttest
+-- no-fasttest: JIT compilation is not available in fasttest
+
+-- https://github.com/ClickHouse/ClickHouse/issues/105031
+
+SELECT '--- JIT ---';
+SET compile_expressions = 1, min_count_to_compile_expression = 0;
+
+SELECT '--- Float -> 128-bit / 256-bit integers ---';
+SELECT toInt128 (materialize(1.5) + materialize(0.5));
+SELECT toUInt128(materialize(1.5) + materialize(0.5));
+SELECT toInt256 (materialize(1.5) + materialize(0.5));
+SELECT toUInt256(materialize(1.5) + materialize(0.5));
+SELECT toInt128 (materialize(1.5)::Float32 + materialize(0.5)::Float32);
+SELECT toUInt128(materialize(1.5)::Float32 + materialize(0.5)::Float32);
+SELECT toInt256 (materialize(1.5)::Float32 + materialize(0.5)::Float32);
+SELECT toUInt256(materialize(1.5)::Float32 + materialize(0.5)::Float32);
+
+SELECT '--- 128-bit / 256-bit integers -> Float ---';
+SELECT toFloat32(materialize(2::Int128)  + materialize(0::Int128));
+SELECT toFloat64(materialize(2::Int128)  + materialize(0::Int128));
+SELECT toFloat32(materialize(2::UInt128) + materialize(0::UInt128));
+SELECT toFloat64(materialize(2::UInt128) + materialize(0::UInt128));
+SELECT toFloat32(materialize(2::Int256)  + materialize(0::Int256));
+SELECT toFloat64(materialize(2::Int256)  + materialize(0::Int256));
+SELECT toFloat32(materialize(2::UInt256) + materialize(0::UInt256));
+SELECT toFloat64(materialize(2::UInt256) + materialize(0::UInt256));
+
+SELECT '--- no JIT ---';
+SET compile_expressions = 0;
+
+SELECT '--- Float -> 128-bit / 256-bit integers ---';
+SELECT toInt128 (materialize(1.5) + materialize(0.5));
+SELECT toUInt128(materialize(1.5) + materialize(0.5));
+SELECT toInt256 (materialize(1.5) + materialize(0.5));
+SELECT toUInt256(materialize(1.5) + materialize(0.5));
+SELECT toInt128 (materialize(1.5)::Float32 + materialize(0.5)::Float32);
+SELECT toUInt128(materialize(1.5)::Float32 + materialize(0.5)::Float32);
+SELECT toInt256 (materialize(1.5)::Float32 + materialize(0.5)::Float32);
+SELECT toUInt256(materialize(1.5)::Float32 + materialize(0.5)::Float32);
+
+SELECT '--- 128-bit / 256-bit integers -> Float ---';
+SELECT toFloat32(materialize(2::Int128)  + materialize(0::Int128));
+SELECT toFloat64(materialize(2::Int128)  + materialize(0::Int128));
+SELECT toFloat32(materialize(2::UInt128) + materialize(0::UInt128));
+SELECT toFloat64(materialize(2::UInt128) + materialize(0::UInt128));
+SELECT toFloat32(materialize(2::Int256)  + materialize(0::Int256));
+SELECT toFloat64(materialize(2::Int256)  + materialize(0::Int256));
+SELECT toFloat32(materialize(2::UInt256) + materialize(0::UInt256));
+SELECT toFloat64(materialize(2::UInt256) + materialize(0::UInt256));


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `CANNOT_COMPILE_CODE Could not find symbol __fixunsdfti` when JIT-compiling expressions that convert a `Float` to `UInt128`, such as `toUInt128(<Float64 expression>)`. The unsigned 128-bit float-to-int compiler-rt builtins were missing from the JIT symbol resolver. Closes #105031.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.697`
- Backported to: `26.4.3.24`, `26.3.11.24`, `26.2.19.31`
<!-- ch-version-info:end -->