### PR TITLE
Remove pointless frame options from the web terminal handler

### DIFF
--- a/src/Server/WebTerminalRequestHandler.cpp
+++ b/src/Server/WebTerminalRequestHandler.cpp
@@ -332,15 +332,6 @@ void WebTerminalRequestHandler::serveHTML(HTTPServerRequest & request, HTTPServe
 
     setResponseDefaultHeaders(response);
 
-    /// Refuse framing by any other origin. The web terminal asks the user for
-    /// ClickHouse credentials and forwards keystrokes to a PTY; an embedding
-    /// page (clickjacking) could trick a logged-in user into typing into an
-    /// invisible terminal. `frame-ancestors 'none'` (CSP) is the modern check
-    /// honoured by current browsers, and `X-Frame-Options: DENY` is the legacy
-    /// fallback for older browsers / proxies that ignore CSP.
-    response.set("Content-Security-Policy", "frame-ancestors 'none'");
-    response.set("X-Frame-Options", "DENY");
-
     response.setStatusAndReason(Poco::Net::HTTPResponse::HTTP_OK);
     auto wb = WriteBufferFromHTTPServerResponse(response, request.getMethod() == HTTPRequest::HTTP_HEAD);
     wb.write(reinterpret_cast<const char *>(resource_webterminal_html), std::size(resource_webterminal_html));

--- a/tests/integration/test_webterminal/test.py
+++ b/tests/integration/test_webterminal/test.py
@@ -358,22 +358,6 @@ def test_oversized_preauth_frame_rejected_with_1009():
         sock.close()
 
 
-def test_html_page_sets_clickjacking_headers():
-    """The HTML page must be served with anti-clickjacking response headers.
-
-    The terminal asks the user to type ClickHouse credentials and forwards
-    keystrokes to a PTY, so an embedding page could trick a logged-in
-    user into typing into an invisible terminal. `Content-Security-Policy:
-    frame-ancestors 'none'` (modern browsers) and `X-Frame-Options: DENY`
-    (legacy fallback) together ensure the page cannot be framed.
-    """
-    response = instance.http_request("webterminal", method="GET")
-    assert response.status_code == 200
-    csp = response.headers.get("content-security-policy", "")
-    assert "frame-ancestors 'none'" in csp, f"unexpected CSP: {csp!r}"
-    assert response.headers.get("x-frame-options", "").upper() == "DENY"
-
-
 def test_oversized_frame_rejected_with_1009():
     """A frame whose advertised payload length exceeds the server's per-frame
     cap (`MAX_FRAME_SIZE`, 16 MiB) must trigger an explicit `1009` close.


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Follow-up for #100277.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.694`
<!-- ch-version-info:end -->