### PR TITLE
Make Profile Events ±30x faster by using Per CPU atomics for server-wide and users

### DIFF
--- a/ci/jobs/scripts/check_style/check_cpp.sh
+++ b/ci/jobs/scripts/check_style/check_cpp.sh
@@ -100,6 +100,7 @@ EXTERN_TYPES_EXCLUDES=(
     ProfileEvents::checkCPUOverload
     ProfileEvents::getDocumentation
     ProfileEvents::NAME
+    ProfileEvents::setUserPerCPUEnabled
 
     CurrentMetrics::add
     CurrentMetrics::max

--- a/ci/jobs/scripts/check_style/check_cpp.sh
+++ b/ci/jobs/scripts/check_style/check_cpp.sh
@@ -83,6 +83,7 @@ EXTERN_TYPES_EXCLUDES=(
     ProfileEvents::end
     ProfileEvents::increment
     ProfileEvents::incrementNoTrace
+    ProfileEvents::incrementSignalSafe
     ProfileEvents::incrementForLogMessage
     ProfileEvents::incrementLoggerElapsedNanoseconds
     ProfileEvents::getName

--- a/programs/server/MetricsTransmitter.cpp
+++ b/programs/server/MetricsTransmitter.cpp
@@ -88,7 +88,7 @@ void MetricsTransmitter::transmit(std::vector<ProfileEvents::Count> & prev_count
     {
         for (ProfileEvents::Event i = ProfileEvents::Event(0), end = ProfileEvents::end(); i < end; ++i)
         {
-            const auto counter = ProfileEvents::global_counters[i].load(std::memory_order_relaxed);
+            const auto counter = ProfileEvents::global_counters[i];
             const auto counter_increment = counter - prev_counters[i];
             prev_counters[i] = counter;
 
@@ -101,7 +101,7 @@ void MetricsTransmitter::transmit(std::vector<ProfileEvents::Count> & prev_count
     {
         for (ProfileEvents::Event i = ProfileEvents::Event(0), end = ProfileEvents::end(); i < end; ++i)
         {
-            const auto counter = ProfileEvents::global_counters[i].load(std::memory_order_relaxed);
+            const auto counter = ProfileEvents::global_counters[i];
             std::string key{ProfileEvents::getName(static_cast<ProfileEvents::Event>(i))};
             key_vals.emplace_back(profile_events_cumulative_path_prefix + key, counter);
         }

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -361,6 +361,7 @@ namespace ServerSetting
     extern const ServerSettingsUInt64 query_condition_cache_size;
     extern const ServerSettingsDouble query_condition_cache_size_ratio;
     extern const ServerSettingsBool prepare_system_log_tables_on_startup;
+    extern const ServerSettingsBool user_profile_events_per_cpu;
     extern const ServerSettingsBool show_addresses_in_stack_traces;
     extern const ServerSettingsBool shutdown_wait_backups_and_restores;
     extern const ServerSettingsUInt64 shutdown_wait_unfinished;
@@ -1331,6 +1332,8 @@ try
 #endif
 
     StackTrace::setShowAddresses(server_settings[ServerSetting::show_addresses_in_stack_traces]);
+
+    ProfileEvents::setUserPerCPUEnabled(server_settings[ServerSetting::user_profile_events_per_cpu]);
 
 #if USE_HDFS
     /// This will point libhdfs3 to the right location for its config.

--- a/src/Common/PerCPU.cpp
+++ b/src/Common/PerCPU.cpp
@@ -1,0 +1,28 @@
+#include <Common/PerCPU.h>
+
+#if defined(OS_LINUX)
+#include <sys/sysinfo.h>
+#endif
+
+#include <algorithm>
+
+namespace PerCPU
+{
+
+uint32_t getNumCPUs() noexcept
+{
+#if defined(OS_LINUX)
+    static const uint32_t cached = []
+    {
+        const int n = get_nprocs_conf();
+        if (n <= 0)
+            return uint32_t{1};
+        return std::min(static_cast<uint32_t>(n), MAX_CPUS);
+    }();
+    return cached;
+#else
+    return 1;
+#endif
+}
+
+}

--- a/src/Common/PerCPU.h
+++ b/src/Common/PerCPU.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+#include <base/defines.h>
+
+#if defined(OS_LINUX)
+#include <sched.h>
+#endif
+
+namespace PerCPU
+{
+
+/// Hard upper bound on the kernel cpu_id we'll route to. The BSS-backed per-CPU storage in
+/// callers is sized with this constant, so it must be a compile-time value — but only the
+/// first `getNumCPUs()` shards are used at runtime (and only those get faulted in).
+constexpr uint32_t MAX_CPUS = 1024;
+
+/// Runtime CPU count, capped at `MAX_CPUS`. Cached on first call.
+/// Returns `min(get_nprocs_conf(), MAX_CPUS)`, or 1 on non-Linux.
+uint32_t getNumCPUs() noexcept;
+
+/// Current CPU id via `sched_getcpu` (read from TLS).
+/// Returns -1 on error or non-Linux.
+ALWAYS_INLINE inline int32_t getCurrentCPU()
+{
+#if defined(OS_LINUX)
+    return sched_getcpu();
+#else
+    return -1;
+#endif
+}
+
+}

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -1854,6 +1854,11 @@ void incrementNoTrace(Event event, Count amount)
     DB::CurrentThread::getProfileEvents().incrementNoTrace(event, amount);
 }
 
+void incrementSignalSafe(Event event, Count amount)
+{
+    DB::CurrentThread::getProfileEvents().incrementSignalSafe(event, amount);
+}
+
 double Counters::getCPUOverload(Int64 os_cpu_busy_time_threshold, bool reset)
 {
     /// It's possible that we'll have slightly inconsistent values between wait time and busy time. But since we take the value of CPU wait time first,
@@ -1905,6 +1910,18 @@ void Counters::incrementNoTrace(Event event, Count amount)
     do
     {
         current->fetchAdd(event, amount, cpu);
+        current = current->parent;
+    } while (current != nullptr);
+}
+
+void Counters::incrementSignalSafe(Event event, Count amount)
+{
+    Counters * current = this;
+    /// Must stay async-signal-safe (called from signal/crash handlers), so unlike `incrementNoTrace`
+    /// it does not call `sched_getcpu`; `cpu = -1` routes every level to its row 0.
+    do
+    {
+        current->fetchAdd(event, amount, -1);
         current = current->parent;
     } while (current != nullptr);
 }

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -2,6 +2,7 @@
 #include <Common/StackTrace.h>
 #include <Common/thread_local_rng.h>
 #include <Common/ProfileEvents.h>
+#include <Common/PerCPU.h>
 #include <Common/CurrentThread.h>
 #include <Common/TraceSender.h>
 #include <Interpreters/Context.h>
@@ -1530,10 +1531,74 @@ namespace ProfileEvents
 #undef M
 constexpr Event END = Event(__COUNTER__);
 
-/// Global variable, initialized by zeros.
-static constinit Counter global_counters_array[END] {};
-/// Constant-initialized so it is ready before any dynamic initializer can allocate memory.
-constinit Counters global_counters(global_counters_array);
+/// Row stride padded so each per-CPU row ends on a cache-line boundary. Without this the last
+/// few events of one row share a cache line with the first events of the next row, causing
+/// false sharing across CPUs at row boundaries.
+constexpr size_t counts_per_cache_line = DB::CH_CACHE_LINE_SIZE / sizeof(Count);
+static_assert((counts_per_cache_line & (counts_per_cache_line - 1)) == 0);
+constexpr size_t per_cpu_stride = (static_cast<size_t>(END) + counts_per_cache_line - 1) & ~(counts_per_cache_line - 1);
+
+/// Cell count for a layout: `cpus` padded rows, or a compact single row of raw events.
+ALWAYS_INLINE inline size_t cellCount(uint32_t cpus)
+{
+    return cpus ? static_cast<size_t>(cpus) * per_cpu_stride : static_cast<size_t>(END);
+}
+
+/// Cells are plain `Count` accessed via `std::atomic_ref`; over a suitably aligned object it is
+/// lock-free and generates the same code as a `std::atomic` member (required_alignment == 8).
+ALWAYS_INLINE inline std::atomic_ref<Count> cell(Count * counters, size_t cpu, Event event)
+{
+    return std::atomic_ref<Count>(counters[cpu * per_cpu_stride + event]);
+}
+
+ALWAYS_INLINE inline AlignedCounters allocateCounters(size_t n)
+{
+    return AlignedCounters(new (std::align_val_t{DB::CH_CACHE_LINE_SIZE}) Count[n] {});
+}
+
+/// Per-CPU storage for `global_counters`, cache-line aligned. `Count` is trivially default-
+/// constructible, so this static array is a guaranteed zero-init BSS with no dynamic initializer:
+/// valid before any dynamic initializer can touch `global_counters` (which points here), and only
+/// touched rows fault in. An `atomic` element is not trivially constructible and would reintroduce
+/// dynamic initialization for an array this large — hence plain `Count` cells + `atomic_ref`.
+static_assert(std::is_trivially_default_constructible_v<Count>);
+alignas(DB::CH_CACHE_LINE_SIZE) static Count global_counters_storage[PerCPU::MAX_CPUS * per_cpu_stride];
+
+/// `cpus` starts at 0 (single-row layout); `ProfileEventsPerCPUInitializer` flips it to
+/// `PerCPU::getNumCPUs()` before any worker thread exists.
+constexpr Counters::Counters(Count * allocated_counters) noexcept
+    : counters(allocated_counters)
+    , parent(nullptr)
+    , level(VariableContext::Global)
+{}
+
+constinit Counters global_counters(global_counters_storage);
+
+/// Per-CPU width applied to newly-created `User`-level `Counters`. Set to `getNumCPUs()` during
+/// dynamic static init; `setUserPerCPUEnabled(false)` resets it to 0 to force the compact single-row
+/// layout. Read once per `User` ctor; the server sets it at startup before any user exists.
+constinit std::atomic<uint32_t> user_counters_cpus = 0;
+
+/// Switches `global_counters` to per-CPU layout during dynamic static init. Only `cpus` is
+/// mutated — storage stays put, so both pre- and post-flip readers see a valid view of the same
+/// BSS array (pre-flip increments land in row 0, which post-flip sums include). The store is
+/// relaxed-atomic because a thread spawned by an earlier TU's dynamic initializer may already be
+/// incrementing counters while this runs.
+struct ProfileEventsPerCPUInitializer
+{
+    ProfileEventsPerCPUInitializer()
+    {
+        const uint32_t cpus = PerCPU::getNumCPUs();
+        global_counters.cpus.store(cpus, std::memory_order_relaxed);
+        user_counters_cpus.store(cpus, std::memory_order_relaxed);
+    }
+};
+static const ProfileEventsPerCPUInitializer profile_events_per_cpu_initializer;
+
+void setUserPerCPUEnabled(bool enabled)
+{
+    user_counters_cpus.store(enabled ? PerCPU::getNumCPUs() : 0, std::memory_order_relaxed);
+}
 
 const Event Counters::num_counters = END;
 
@@ -1561,15 +1626,20 @@ void Timer::end()
 }
 
 Counters::Counters(VariableContext level_, Counters * parent_)
-    : counters_holder(new Counter[num_counters] {}),
-      parent(parent_),
-      level(level_)
+    /// `User`-level instances snapshot `user_counters_cpus` (stable post-init, server-tunable);
+    /// other levels stay single-row (`cpus == 0`). `cpus` is read once and the allocation is
+    /// sized from it, so the layout and the row count cannot disagree.
+    : cpus(level_ == VariableContext::User ? user_counters_cpus.load(std::memory_order_relaxed) : 0)
+    , counters_holder(allocateCounters(cellCount(cpus.load(std::memory_order_relaxed))))
+    , parent(parent_)
+    , level(level_)
 {
     counters = counters_holder.get();
 }
 
 Counters::Counters(Counters && src) noexcept
     : counters(std::exchange(src.counters, nullptr))
+    , cpus(src.cpus.exchange(0, std::memory_order_relaxed))
     , counters_holder(std::move(src.counters_holder))
     , parent(src.parent.exchange(nullptr))
     , should_trace_array(src.should_trace_array.exchange(nullptr, std::memory_order_relaxed))
@@ -1581,11 +1651,60 @@ Counters::Counters(Counters && src) noexcept
 
 void Counters::resetCounters()
 {
-    if (counters)
+    if (!counters)
+        return;
+    const size_t total = cellCount(cpus.load(std::memory_order_relaxed));
+    for (size_t i = 0; i < total; ++i)
+        std::atomic_ref<Count>(counters[i]).store(0, std::memory_order_relaxed);
+}
+
+Count Counters::load(Event event) const
+{
+    const uint32_t rows = cpus.load(std::memory_order_relaxed);
+    if (!rows)
+        return cell(counters, 0, event).load(std::memory_order_relaxed);
+    Count sum = 0;
+    for (uint32_t s = 0; s < rows; ++s)
+        sum += cell(counters, s, event).load(std::memory_order_relaxed);
+    return sum;
+}
+
+void Counters::setParent(Counters * parent_)
+{
+    parent.store(parent_, std::memory_order_relaxed);
+}
+
+void Counters::setUserCounters(Counters * user)
+{
+    auto * current_val = this;
+    auto * parent_val = this->parent.load(std::memory_order_relaxed);
+
+    while (parent_val != nullptr && parent_val->level != VariableContext::Global && parent_val->level != VariableContext::User)
     {
-        for (Event i = Event(0); i < num_counters; ++i)
-            counters[i].store(0, std::memory_order_relaxed);
+        current_val = parent_val;
+        parent_val = current_val->parent.load(std::memory_order_relaxed);
     }
+
+    current_val->parent.store(user, std::memory_order_relaxed);
+}
+
+void Counters::setTraceAllProfileEvents()
+{
+    trace_all_profile_events.store(true, std::memory_order_relaxed);
+}
+
+void Counters::fetchAdd(Event event, Count amount, int32_t cpu)
+{
+    const uint32_t rows = cpus.load(std::memory_order_relaxed);
+    if (rows)
+    {
+        /// `cpu` may be >= rows if a CPU above `MAX_CPUS` is online, and -1 on error. In both
+        /// cases, fall back to row 0 — still atomic, still correct, just with less cache locality.
+        const size_t row = (cpu >= 0 && static_cast<uint32_t>(cpu) < rows) ? static_cast<size_t>(cpu) : 0;
+        cell(counters, row, event).fetch_add(amount, std::memory_order_relaxed);
+    }
+    else
+        cell(counters, 0, event).fetch_add(amount, std::memory_order_relaxed);
 }
 
 void Counters::reset()
@@ -1602,7 +1721,7 @@ Counters::Snapshot Counters::getPartiallyAtomicSnapshot() const
 {
     Snapshot res;
     for (Event i = Event(0); i < num_counters; ++i)
-        res.counters_holder[i] = counters[i].load(std::memory_order_relaxed);
+        res.counters_holder[i] = load(i);
     return res;
 }
 
@@ -1739,8 +1858,8 @@ double Counters::getCPUOverload(Int64 os_cpu_busy_time_threshold, bool reset)
 {
     /// It's possible that we'll have slightly inconsistent values between wait time and busy time. But since we take the value of CPU wait time first,
     /// it should not affect the situation a lot. In the worst case scenario we will have a slightly lower CPU overload value than it should be, but it's fine.
-    Int64 curr_cpu_wait_microseconds = counters[OSCPUWaitMicroseconds];
-    Int64 curr_cpu_virtual_time_microseconds = counters[OSCPUVirtualTimeMicroseconds];
+    Int64 curr_cpu_wait_microseconds = static_cast<Int64>(load(OSCPUWaitMicroseconds));
+    Int64 curr_cpu_virtual_time_microseconds = static_cast<Int64>(load(OSCPUVirtualTimeMicroseconds));
 
     Int64 os_cpu_wait_microseconds = curr_cpu_wait_microseconds - prev_cpu_wait_microseconds.load(std::memory_order_acquire);
     Int64 os_cpu_virtual_time_microseconds = curr_cpu_virtual_time_microseconds - prev_cpu_virtual_time_microseconds.load(std::memory_order_acquire);
@@ -1763,10 +1882,11 @@ void Counters::increment(Event event, Count amount)
 {
     Counters * current = this;
     bool send_to_trace_log = false;
+    const int32_t cpu = PerCPU::getCurrentCPU();
 
     do
     {
-        current->counters[event].fetch_add(amount, std::memory_order_relaxed);
+        current->fetchAdd(event, amount, cpu);
         if (auto * trace_arr = current->should_trace_array.load(std::memory_order_relaxed))
             send_to_trace_log |= trace_arr[event].load(std::memory_order_relaxed);
         send_to_trace_log |= current->trace_all_profile_events.load(std::memory_order_relaxed);
@@ -1781,9 +1901,10 @@ void Counters::increment(Event event, Count amount)
 void Counters::incrementNoTrace(Event event, Count amount)
 {
     Counters * current = this;
+    const int32_t cpu = PerCPU::getCurrentCPU();
     do
     {
-        current->counters[event].fetch_add(amount, std::memory_order_relaxed);
+        current->fetchAdd(event, amount, cpu);
         current = current->parent;
     } while (current != nullptr);
 }

--- a/src/Common/ProfileEvents.h
+++ b/src/Common/ProfileEvents.h
@@ -112,6 +112,7 @@ namespace ProfileEvents
 
         void increment(Event event, Count amount = 1);
         void incrementNoTrace(Event event, Count amount = 1);
+        void incrementSignalSafe(Event event, Count amount = 1);
 
         struct Snapshot
         {
@@ -190,6 +191,10 @@ namespace ProfileEvents
     /// The same as above but ignores value of setting 'trace_profile_events'
     /// and never sends profile event to trace log.
     void incrementNoTrace(Event event, Count amount = 1);
+
+    /// Async-signal-safe variant of `incrementNoTrace` (no `sched_getcpu`). Use ONLY from
+    /// signal/crash handlers.
+    void incrementSignalSafe(Event event, Count amount = 1);
 
     /// Get name of event by identifier. Returns statically allocated string.
     const std::string_view & getName(Event event);

--- a/src/Common/ProfileEvents.h
+++ b/src/Common/ProfileEvents.h
@@ -2,11 +2,13 @@
 
 #include <Common/VariableContext.h>
 #include <Common/Stopwatch.h>
+#include <Common/CacheLine.h>
 #include <Interpreters/Context_fwd.h>
 #include <base/types.h>
 #include <base/strong_typedef.h>
 #include <atomic>
 #include <memory>
+#include <new>
 #include <cstddef>
 
 
@@ -22,10 +24,16 @@ namespace ProfileEvents
     using Count = size_t;
     using Increment = Int64;
 
-    struct Counter : public std::atomic<Count>
+    /// Counter cells are plain `Count`, accessed atomically via `std::atomic_ref`. Keeping the
+    /// storage trivially default-constructible is what lets the static `global_counters` backing
+    /// array be a guaranteed zero-init BSS with no dynamic initializer (an `atomic` element is not
+    /// trivially constructible, which reintroduces dynamic init for a large enough array).
+    struct AlignedCountersDeleter
     {
-        using std::atomic<Count>::atomic;
+        void operator()(Count * p) const noexcept { ::operator delete[](p, std::align_val_t{DB::CH_CACHE_LINE_SIZE}); }
     };
+    using AlignedCounters = std::unique_ptr<Count[], AlignedCountersDeleter>;
+
     class Counters;
 
     /// Counters - how many times each event happened
@@ -61,17 +69,28 @@ namespace ProfileEvents
     class Counters
     {
     private:
-        Counter * counters = nullptr;
-        std::unique_ptr<Counter[]> counters_holder;
+        /// Per-CPU: `cpus * per_cpu_stride` cells, cell for CPU `c`/event `e` at `c * per_cpu_stride + e`
+        /// (stride rounds `num_counters` up to keep rows on separate cache lines). An out-of-range CPU
+        /// falls back to row 0. Otherwise just `num_counters` cells indexed by event.
+        Count * counters = nullptr;
+        /// 0 → no per-CPU. Set once (static init flips it for `global_counters`, ctor for `User`)
+        /// and only grows the view over the same zeroed storage, so relaxed loads suffice; atomic
+        /// because a thread spawned during another TU's dynamic init may increment concurrently
+        /// with the flip.
+        std::atomic<uint32_t> cpus = 0;
+        AlignedCounters counters_holder;
         /// Used to propagate increments
         std::atomic<Counters *> parent = {};
-        Counter prev_cpu_wait_microseconds = 0;
-        Counter prev_cpu_virtual_time_microseconds = 0;
+        std::atomic<Count> prev_cpu_wait_microseconds = 0;
+        std::atomic<Count> prev_cpu_virtual_time_microseconds = 0;
 
         /// Lazily allocated on first setTraceProfileEvent()
         std::atomic<std::atomic_bool *> should_trace_array = nullptr;
         std::unique_ptr<std::atomic_bool[]> should_trace_holder;
         std::atomic_bool trace_all_profile_events = false;
+
+        Count load(Event event) const;
+        void fetchAdd(Event event, Count amount, int32_t cpu);
 
     public:
 
@@ -80,24 +99,16 @@ namespace ProfileEvents
         /// By default, any instance have to increment global counters
         explicit Counters(VariableContext level_ = VariableContext::Thread, Counters * parent_ = &global_counters);
 
-        /// Global level static initializer (constexpr to enable constant initialization
-        /// before any dynamic initializer can allocate memory and call ProfileEvents::increment)
-        constexpr explicit Counters(Counter * allocated_counters) noexcept
-            : counters(allocated_counters), parent(nullptr), level(VariableContext::Global) {}
+        /// constexpr so `global_counters` can be `constinit` — usable before any dynamic init.
+        constexpr explicit Counters(Count * allocated_counters) noexcept;
+
+        friend struct ProfileEventsPerCPUInitializer;
 
         Counters(Counters && src) noexcept;
 
-        Counter & operator[] (Event event)
-        {
-            return counters[event];
-        }
-
-        const Counter & operator[] (Event event) const
-        {
-            return counters[event];
-        }
-
         double getCPUOverload(Int64 os_cpu_busy_time_threshold, bool reset = false);
+
+        Count operator[] (Event event) const { return load(event); }
 
         void increment(Event event, Count amount = 1);
         void incrementNoTrace(Event event, Count amount = 1);
@@ -126,37 +137,13 @@ namespace ProfileEvents
         /// Reset all counters to zero and reset parent.
         void reset();
 
-        /// Get parent (thread unsafe)
-        Counters * getParent()
-        {
-            return parent.load(std::memory_order_relaxed);
-        }
+        /// Set parent (thread unsafe)
+        void setUserCounters(Counters * user);
 
         /// Set parent (thread unsafe)
-        void setUserCounters(Counters * user)
-        {
-            auto * current_val = this;
-            auto * parent_val = this->parent.load(std::memory_order_relaxed);
+        void setParent(Counters * parent_);
 
-            while (parent_val != nullptr && parent_val->level != VariableContext::Global && parent_val->level != VariableContext::User)
-            {
-                current_val = parent_val;
-                parent_val = current_val->parent.load(std::memory_order_relaxed);
-            }
-
-            current_val->parent.store(user, std::memory_order_relaxed);
-        }
-
-        /// Set parent (thread unsafe)
-        void setParent(Counters * parent_)
-        {
-            parent.store(parent_, std::memory_order_relaxed);
-        }
-
-        void setTraceAllProfileEvents()
-        {
-            trace_all_profile_events.store(true, std::memory_order_relaxed);
-        }
+        void setTraceAllProfileEvents();
 
         void setTraceProfileEvent(ProfileEvents::Event event);
         void setTraceProfileEvents(const String & events_list);
@@ -193,6 +180,9 @@ namespace ProfileEvents
         Microseconds,
         Nanoseconds,
     };
+
+    /// Enable/disable per-CPU sharding for newly-created `User`-level `Counters` (server-wide).
+    void setUserPerCPUEnabled(bool enabled);
 
     /// Increment a counter for event. Thread-safe.
     void increment(Event event, Count amount = 1);

--- a/src/Common/QueryProfiler.cpp
+++ b/src/Common/QueryProfiler.cpp
@@ -56,7 +56,7 @@ namespace
         SCOPE_EXIT({ concurrent_invocations.fetch_sub(1, std::memory_order_relaxed); });
         if (concurrent_invocations.fetch_add(1, std::memory_order_relaxed) > 100)
         {
-            ProfileEvents::incrementNoTrace(ProfileEvents::QueryProfilerConcurrencyOverruns);
+            ProfileEvents::incrementSignalSafe(ProfileEvents::QueryProfilerConcurrencyOverruns);
             return;
         }
 
@@ -78,11 +78,11 @@ namespace
                 /// But pass with some frequency to avoid drop of all traces.
                 if (overrun_count > 0 && write_trace_iteration % (overrun_count + 1) == 0)
                 {
-                    ProfileEvents::incrementNoTrace(ProfileEvents::QueryProfilerSignalOverruns, overrun_count);
+                    ProfileEvents::incrementSignalSafe(ProfileEvents::QueryProfilerSignalOverruns, overrun_count);
                 }
                 else
                 {
-                    ProfileEvents::incrementNoTrace(ProfileEvents::QueryProfilerSignalOverruns, std::max(0, overrun_count) + 1);
+                    ProfileEvents::incrementSignalSafe(ProfileEvents::QueryProfilerSignalOverruns, std::max(0, overrun_count) + 1);
                     return;
                 }
             }
@@ -107,7 +107,7 @@ namespace
         }
         else
         {
-            ProfileEvents::incrementNoTrace(ProfileEvents::QueryProfilerErrors);
+            ProfileEvents::incrementSignalSafe(ProfileEvents::QueryProfilerErrors);
         }
         asynchronous_stack_unwinding = false;
 #endif
@@ -115,7 +115,7 @@ namespace
         if (stack_trace)
             TraceSender::send(trace_type, *stack_trace, {});
 
-        ProfileEvents::incrementNoTrace(ProfileEvents::QueryProfilerRuns);
+        ProfileEvents::incrementSignalSafe(ProfileEvents::QueryProfilerRuns);
         errno = saved_errno;
     }
 

--- a/src/Common/Scheduler/Nodes/tests/gtest_workload_resource_manager.cpp
+++ b/src/Common/Scheduler/Nodes/tests/gtest_workload_resource_manager.cpp
@@ -1544,7 +1544,7 @@ struct EventCounter
 private:
     size_t getValue() const
     {
-        return ProfileEvents::global_counters[event].load(std::memory_order_relaxed);
+        return ProfileEvents::global_counters[event];
     }
 };
 

--- a/src/Common/benchmarks/CMakeLists.txt
+++ b/src/Common/benchmarks/CMakeLists.txt
@@ -22,3 +22,8 @@ clickhouse_add_executable(wrap_in_nullable wrap_in_nullable.cpp)
 target_link_libraries (wrap_in_nullable PRIVATE
     ch_contrib::gbenchmark_all
     dbms)
+
+clickhouse_add_executable(profile_events profile_events.cpp)
+target_link_libraries (profile_events PRIVATE
+    ch_contrib::gbenchmark_all
+    dbms)

--- a/src/Common/benchmarks/profile_events.cpp
+++ b/src/Common/benchmarks/profile_events.cpp
@@ -1,0 +1,438 @@
+/// Benchmark for `ProfileEvents::Counters::increment` on the realistic
+/// thread → thread-group → user → global propagation chain
+/// (matches `ThreadStatusExt.cpp:353` and `ProcessList.cpp:278`).
+///
+/// Setup:
+///   - 500 worker threads
+///   - 50 thread-group `Counters` (`VariableContext::Process`)
+///   - 1 user `Counters` (`VariableContext::User`, parent = `global_counters`)
+///   - groups round-robin onto users → ~10 groups per user
+///   - threads round-robin onto groups → ~10 threads per group
+///
+/// What this stresses:
+///   - Thread shard: uncontended (single writer).
+///   - Group shard: ~10 threads → cache-line ping-pong.
+///   - User shard: ~100 threads × 10 groups → heavy ping-pong.
+///   - Global shard: all 500 threads, but sharded by CPU (atomic per-CPU row).
+///
+/// The reader variants add one thread taking the full `global_counters`
+/// snapshot (`END` events × per-CPU rows), as `metric_log` does, to measure the
+/// read-side interference on the writer hot path:
+///   - `ConcurrentRead`: snapshots back-to-back (worst case).
+///   - `PeriodicRead`: snapshots, then waits `read_us` between scans (state.range(1)),
+///     i.e. the realistic "once in a while" exporter cadence.
+///   - `ReadLatency`: throughput hides per-scrape stalls. Here one pinned victim times
+///     each increment individually while background writers and a pinned reader run,
+///     reporting the latency tail (p50/p99/p999/p9999, with OS-descheduling outliers
+///     counted separately). The victim has a private chain, so the only cross-core traffic on its
+///     path is the reader pulling its global per-CPU row — that coherence miss is the tail.
+
+#include <Common/PerCPU.h>
+#include <Common/ProfileEvents.h>
+#include <Common/Stopwatch.h>
+#include <benchmark/benchmark.h>
+
+#include <algorithm>
+#include <cmath>
+#include <array>
+#include <atomic>
+#include <barrier>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+#if defined(OS_LINUX)
+#include <pthread.h>
+#include <sched.h>
+#endif
+
+namespace
+{
+
+constexpr size_t NUM_THREADS = 500;
+constexpr size_t NUM_GROUPS = 50;
+constexpr size_t NUM_USERS = 1;
+
+/// Pick a stable event id near the start of the table; any event would do,
+/// the sharded write doesn't depend on which one.
+const ProfileEvents::Event TEST_EVENT{0};
+
+/// Shared control state polled by worker threads every iteration through reference captures.
+/// Must occupy its own cache line: as a plain stack local it can land on the same line as
+/// locals the measuring thread writes each iteration (the stack's 64-byte phase depends on
+/// argv/env size), and the resulting false sharing adds ~500 ns to every measured op.
+struct alignas(DB::CH_CACHE_LINE_SIZE) PaddedAtomicBool
+{
+    std::atomic<bool> value{false};
+};
+
+struct alignas(DB::CH_CACHE_LINE_SIZE) PaddedAtomicUInt64
+{
+    std::atomic<uint64_t> value{0};
+};
+
+/// The realistic propagation chain: `num_threads` thread shards round-robin onto
+/// `NUM_GROUPS` process shards, themselves round-robin onto `NUM_USERS` user shards,
+/// all rooted at `global_counters`.
+struct Chain
+{
+    std::vector<std::unique_ptr<ProfileEvents::Counters>> users;
+    std::vector<std::unique_ptr<ProfileEvents::Counters>> groups;
+    std::vector<std::unique_ptr<ProfileEvents::Counters>> threads;
+};
+
+Chain buildChain(size_t num_threads)
+{
+    Chain c;
+    c.users.reserve(NUM_USERS);
+    for (size_t u = 0; u < NUM_USERS; ++u)
+        c.users.push_back(std::make_unique<ProfileEvents::Counters>(VariableContext::User, &ProfileEvents::global_counters));
+
+    c.groups.reserve(NUM_GROUPS);
+    for (size_t g = 0; g < NUM_GROUPS; ++g)
+        c.groups.push_back(std::make_unique<ProfileEvents::Counters>(VariableContext::Process, c.users[g % NUM_USERS].get()));
+
+    c.threads.reserve(num_threads);
+    for (size_t t = 0; t < num_threads; ++t)
+        c.threads.push_back(std::make_unique<ProfileEvents::Counters>(VariableContext::Thread, c.groups[t % NUM_GROUPS].get()));
+
+    return c;
+}
+
+#if defined(OS_LINUX)
+bool pinToCPU(unsigned cpu)
+{
+    cpu_set_t set;
+    CPU_ZERO(&set);
+    CPU_SET(cpu, &set);
+    return pthread_setaffinity_np(pthread_self(), sizeof(set), &set) == 0;
+}
+
+/// Restores the calling thread's affinity on scope exit. The benchmark driver thread runs every
+/// benchmark in the binary, so a leaked pin would confine all subsequent ones to a single core.
+struct AffinityRestorer
+{
+    cpu_set_t saved;
+    bool valid = false;
+    AffinityRestorer() { valid = pthread_getaffinity_np(pthread_self(), sizeof(saved), &saved) == 0; }
+    ~AffinityRestorer()
+    {
+        if (valid)
+            pthread_setaffinity_np(pthread_self(), sizeof(saved), &saved);
+    }
+};
+#else
+bool pinToCPU(unsigned) { return false; }
+struct AffinityRestorer {};
+#endif
+
+/// `reader_period_us` < 0 disables the reader; 0 snapshots back-to-back;
+/// > 0 waits that many microseconds between snapshots.
+void run(benchmark::State & state, int64_t reader_period_us)
+{
+    const bool with_reader = reader_period_us >= 0;
+    /// Iterations performed by each thread per outer step.
+    const size_t inner_iters = static_cast<size_t>(state.range(0));
+
+    Chain chain = buildChain(NUM_THREADS);
+    auto & thread_counters = chain.threads;
+
+    PaddedAtomicBool stop;
+    std::atomic<uint64_t> total_ops{0};
+
+    /// `metric_log`-style reader: sums every per-CPU row of every event.
+    PaddedAtomicBool stop_reader;
+    PaddedAtomicUInt64 global_scans;
+    std::thread reader;
+    if (with_reader)
+    {
+        reader = std::thread([&]()
+        {
+            const size_t end = ProfileEvents::end();
+            while (!stop_reader.value.load(std::memory_order_relaxed))
+            {
+                ProfileEvents::Count acc = 0;
+                for (size_t i = 0; i < end; ++i)
+                    acc += ProfileEvents::global_counters[ProfileEvents::Event(i)];
+                benchmark::DoNotOptimize(acc);
+                global_scans.value.fetch_add(1, std::memory_order_relaxed);
+                if (reader_period_us > 0)
+                    std::this_thread::sleep_for(std::chrono::microseconds(reader_period_us));
+            }
+        });
+    }
+
+    /// +1 for the benchmark driver thread, which arrives at the barrier
+    /// both after starting the workers and before joining them — that gives
+    /// us a well-defined window where all workers are simultaneously active.
+    std::barrier<> sync_start(NUM_THREADS + 1);
+    std::barrier<> sync_end(NUM_THREADS + 1);
+
+    std::vector<std::thread> workers;
+    workers.reserve(NUM_THREADS);
+    for (size_t t = 0; t < NUM_THREADS; ++t)
+    {
+        workers.emplace_back([&, t]()
+        {
+            auto & cnt = *thread_counters[t];
+            while (true)
+            {
+                sync_start.arrive_and_wait();
+                if (stop.value.load(std::memory_order_relaxed))
+                    return;
+                for (size_t i = 0; i < inner_iters; ++i)
+                    cnt.increment(TEST_EVENT, 1);
+                sync_end.arrive_and_wait();
+            }
+        });
+    }
+
+    for (auto _ : state)
+    {
+        sync_start.arrive_and_wait();
+        sync_end.arrive_and_wait();
+        total_ops.fetch_add(static_cast<uint64_t>(NUM_THREADS) * inner_iters,
+                            std::memory_order_relaxed);
+    }
+
+    stop.value.store(true, std::memory_order_relaxed);
+    sync_start.arrive_and_wait();
+    for (auto & w : workers)
+        w.join();
+
+    if (with_reader)
+    {
+        stop_reader.value.store(true, std::memory_order_relaxed);
+        reader.join();
+        state.counters["global_scans"] = static_cast<double>(global_scans.value.load());
+        state.counters["read_us"] = static_cast<double>(reader_period_us);
+    }
+
+    state.SetItemsProcessed(static_cast<int64_t>(total_ops.load()));
+    /// Inverse rate: wall-time ns per increment, summed across threads.
+    state.counters["ns/inc"] = benchmark::Counter(
+        static_cast<double>(total_ops.load()),
+        benchmark::Counter::kIsRate | benchmark::Counter::kInvert);
+    state.counters["threads"] = NUM_THREADS;
+    state.counters["groups"] = NUM_GROUPS;
+    state.counters["users"] = NUM_USERS;
+}
+
+void BM_ProfileEvents(benchmark::State & state) { run(state, /*reader_period_us=*/ -1); }
+void BM_ProfileEventsConcurrentRead(benchmark::State & state) { run(state, /*reader_period_us=*/ 0); }
+void BM_ProfileEventsPeriodicRead(benchmark::State & state) { run(state, /*reader_period_us=*/ state.range(1)); }
+
+/// Fixed-resolution (1ns) latency histogram over the recorded per-increment samples.
+struct LatencyHist
+{
+    static constexpr size_t N = 4096;
+    std::array<uint64_t, N> buckets{};
+    uint64_t overflow = 0;
+    uint64_t max_ns = 0;
+    uint64_t count = 0;
+
+    void add(uint64_t ns)
+    {
+        if (ns < N)
+            ++buckets[ns];
+        else
+            ++overflow;
+        max_ns = std::max(ns, max_ns);
+        ++count;
+    }
+
+    /// Percentile over the in-histogram samples only (nearest-rank): overflow samples are OS
+    /// descheduling (reported separately as `descheduled`), not coherence, and must not be able
+    /// to turn a tail percentile into a preemption outlier.
+    double percentile(double p) const
+    {
+        const uint64_t in_range = count - overflow;
+        if (!in_range)
+            return 0;
+        const uint64_t target = std::max<uint64_t>(static_cast<uint64_t>(std::ceil(p * static_cast<double>(in_range))), 1);
+        uint64_t cum = 0;
+        for (size_t i = 0; i < N; ++i)
+        {
+            cum += buckets[i];
+            if (cum >= target)
+                return static_cast<double>(i);
+        }
+        return static_cast<double>(N - 1);
+    }
+};
+
+void BM_ProfileEventsReadLatency(benchmark::State & state)
+{
+    const int64_t reader_period_us = state.range(0);
+    const size_t batch = static_cast<size_t>(state.range(1));
+    const bool with_reader = reader_period_us >= 0;
+
+    const uint32_t num_cpus = PerCPU::getNumCPUs();
+    /// Cores 0 and 1 are the victim and the reader. Background writers use only the lower
+    /// half of the logical CPUs (assuming 2-way SMT with siblings in the upper half; on
+    /// core-paired sibling enumerations the victim and reader may share a core and the tail
+    /// then includes SMT sharing), leaving every used core's sibling idle so the victim is
+    /// rarely descheduled - otherwise OS preemption (ms-scale) swamps the ~100ns coherence
+    /// signal. Still leaves enough hot per-CPU rows for the scrape to sum.
+    if (num_cpus < 6)
+    {
+        state.SkipWithError("requires at least 6 CPUs (distinct cores for victim, reader and background writers)");
+        return;
+    }
+    const size_t usable = num_cpus / 2;
+    const size_t num_bg = usable - 2;
+    Chain bg = buildChain(num_bg);
+
+    /// Pin the driver (victim) thread before spawning workers; restore on exit so the pin does
+    /// not leak into subsequently run benchmarks.
+    [[maybe_unused]] AffinityRestorer affinity_restorer;
+    if (!pinToCPU(0))
+    {
+        state.SkipWithError("cannot pin the victim thread");
+        return;
+    }
+
+    /// Private victim chain: thread/group/user shards are single-writer, so the only
+    /// cross-core traffic on the victim's path is the reader pulling its global row.
+    auto victim_user = std::make_unique<ProfileEvents::Counters>(VariableContext::User, &ProfileEvents::global_counters);
+    auto victim_group = std::make_unique<ProfileEvents::Counters>(VariableContext::Process, victim_user.get());
+    auto victim_thread = std::make_unique<ProfileEvents::Counters>(VariableContext::Thread, victim_group.get());
+
+    PaddedAtomicBool stop;
+    PaddedAtomicBool stop_reader;
+    PaddedAtomicUInt64 global_scans;
+
+    std::vector<std::thread> bg_workers;
+    bg_workers.reserve(num_bg);
+    for (size_t t = 0; t < num_bg; ++t)
+    {
+        bg_workers.emplace_back([&, t]()
+        {
+            pinToCPU(static_cast<unsigned>(2 + t));
+            auto & cnt = *bg.threads[t];
+            while (!stop.value.load(std::memory_order_relaxed))
+                cnt.increment(TEST_EVENT, 1);
+        });
+    }
+
+    std::thread reader;
+    if (with_reader)
+    {
+        reader = std::thread([&]()
+        {
+            pinToCPU(1);
+            const size_t end = ProfileEvents::end();
+            while (!stop_reader.value.load(std::memory_order_relaxed))
+            {
+                ProfileEvents::Count acc = 0;
+                for (size_t i = 0; i < end; ++i)
+                    acc += ProfileEvents::global_counters[ProfileEvents::Event(i)];
+                benchmark::DoNotOptimize(acc);
+                global_scans.value.fetch_add(1, std::memory_order_relaxed);
+                if (reader_period_us > 0)
+                    std::this_thread::sleep_for(std::chrono::microseconds(reader_period_us));
+            }
+        });
+    }
+
+    LatencyHist hist;
+    Stopwatch sw(CLOCK_MONOTONIC);
+    for (auto _ : state)
+    {
+        sw.restart();
+        for (size_t i = 0; i < batch; ++i)
+            victim_thread->increment(TEST_EVENT, 1);
+        const uint64_t ns = sw.elapsedNanoseconds() / batch;
+        benchmark::DoNotOptimize(ns);
+        hist.add(ns);
+    }
+
+    stop.value.store(true, std::memory_order_relaxed);
+    stop_reader.value.store(true, std::memory_order_relaxed);
+    for (auto & w : bg_workers)
+        w.join();
+    if (with_reader)
+        reader.join();
+
+    state.counters["p50_ns"] = hist.percentile(0.50);
+    state.counters["p99_ns"] = hist.percentile(0.99);
+    state.counters["p999_ns"] = hist.percentile(0.999);
+    state.counters["p9999_ns"] = hist.percentile(0.9999);
+    /// Samples above the histogram (> N ns) - OS descheduling, not coherence; kept visible
+    /// so a noisy run (large `descheduled`) is not mistaken for read interference.
+    state.counters["descheduled"] = static_cast<double>(hist.overflow);
+    state.counters["global_scans"] = static_cast<double>(global_scans.value.load());
+    state.counters["read_us"] = static_cast<double>(reader_period_us);
+    state.counters["bg_threads"] = static_cast<double>(num_bg);
+}
+
+/// Cost of one full `metric_log`-style read of every event, with per-CPU sharding off
+/// (`Thread` level, single row) vs on (`User` level, sums `cpus` rows). No writers, so this
+/// isolates the collector-side scan cost that per-CPU multiplies by the row count.
+void BM_ProfileEventsReadAll(benchmark::State & state)
+{
+    const bool per_cpu = state.range(0) != 0;
+    ProfileEvents::Counters counters(per_cpu ? VariableContext::User : VariableContext::Thread, nullptr);
+
+    const size_t end = ProfileEvents::end();
+    for (auto _ : state)
+    {
+        ProfileEvents::Count acc = 0;
+        for (size_t e = 0; e < end; ++e)
+            acc += counters[ProfileEvents::Event(e)];
+        benchmark::DoNotOptimize(acc);
+    }
+
+    state.counters["events"] = static_cast<double>(end);
+    state.counters["ncpus"] = static_cast<double>(PerCPU::getNumCPUs());
+}
+
+}
+
+BENCHMARK(BM_ProfileEvents)
+    ->Arg(1000)
+    ->Arg(10000)
+    ->Arg(100000)
+    ->Unit(benchmark::kMillisecond)
+    ->MeasureProcessCPUTime()
+    ->UseRealTime();
+
+BENCHMARK(BM_ProfileEventsConcurrentRead)
+    ->Arg(1000)
+    ->Arg(10000)
+    ->Arg(100000)
+    ->Unit(benchmark::kMillisecond)
+    ->MeasureProcessCPUTime()
+    ->UseRealTime();
+
+/// Fixed write load, varying scrape cadence: {inner_iters, read_us}.
+BENCHMARK(BM_ProfileEventsPeriodicRead)
+    ->Args({100000, 100})
+    ->Args({100000, 1000})
+    ->Args({100000, 10000})
+    ->ArgNames({"iters", "read_us"})
+    ->Unit(benchmark::kMillisecond)
+    ->MeasureProcessCPUTime()
+    ->UseRealTime();
+
+/// Per-increment latency tail vs scrape cadence: {read_us, batch}. read_us=-1 is the
+/// reader-off baseline; compare its tail/stalls against the reader-on rows.
+BENCHMARK(BM_ProfileEventsReadLatency)
+    ->Args({-1, 1})
+    ->Args({0, 1})
+    ->Args({1000, 1})
+    ->Args({1000000, 1})
+    ->ArgNames({"read_us", "batch"})
+    ->Unit(benchmark::kNanosecond)
+    ->UseRealTime()
+    ->MinTime(2.0);
+
+/// Full-scan read cost, sharding off vs on: per_cpu = 0 (single row) / 1 (cpus + 1 rows).
+BENCHMARK(BM_ProfileEventsReadAll)
+    ->Arg(0)
+    ->Arg(1)
+    ->ArgNames({"per_cpu"})
+    ->Unit(benchmark::kMicrosecond)
+    ->UseRealTime();
+
+BENCHMARK_MAIN();

--- a/src/Common/tests/gtest_concurrency_control.cpp
+++ b/src/Common/tests/gtest_concurrency_control.cpp
@@ -28,14 +28,14 @@ namespace
 
     struct DelayedMetricsScope
     {
-        ProfileEvents::Count slots_before = ProfileEvents::global_counters[ProfileEvents::ConcurrencyControlSlotsDelayed].load();
-        ProfileEvents::Count queries_before = ProfileEvents::global_counters[ProfileEvents::ConcurrencyControlQueriesDelayed].load();
+        ProfileEvents::Count slots_before = ProfileEvents::global_counters[ProfileEvents::ConcurrencyControlSlotsDelayed];
+        ProfileEvents::Count queries_before = ProfileEvents::global_counters[ProfileEvents::ConcurrencyControlQueriesDelayed];
 
         DelayedMetrics diff() const
         {
             return {
-                ProfileEvents::global_counters[ProfileEvents::ConcurrencyControlSlotsDelayed].load() - slots_before,
-                ProfileEvents::global_counters[ProfileEvents::ConcurrencyControlQueriesDelayed].load() - queries_before,
+                ProfileEvents::global_counters[ProfileEvents::ConcurrencyControlSlotsDelayed] - slots_before,
+                ProfileEvents::global_counters[ProfileEvents::ConcurrencyControlQueriesDelayed] - queries_before,
             };
         }
     };

--- a/src/Common/tests/gtest_connection_pool.cpp
+++ b/src/Common/tests/gtest_connection_pool.cpp
@@ -691,7 +691,7 @@ TEST_F(ConnectionPoolTest, ProxyConnectFailureDoesNotPessimizeTarget)
     auto metrics = pool->getMetrics();
     auto resolver_metrics = DB::HostResolver::getMetrics();
 
-    UInt64 failed_before = DB::CurrentThread::getProfileEvents()[resolver_metrics.failed].load();
+    UInt64 failed_before = DB::CurrentThread::getProfileEvents()[resolver_metrics.failed];
 
     ASSERT_ANY_THROW({
         auto connection = pool->getConnection(timeouts, nullptr);
@@ -702,7 +702,7 @@ TEST_F(ConnectionPoolTest, ProxyConnectFailureDoesNotPessimizeTarget)
     /// `setFail` was not called on any target address: the failure is on the proxy path,
     /// and pessimizing the target resolver would mis-attribute the failure (and trigger
     /// extra DNS refreshes for a host that was never actually contacted).
-    ASSERT_EQ(failed_before, DB::CurrentThread::getProfileEvents()[resolver_metrics.failed].load());
+    ASSERT_EQ(failed_before, DB::CurrentThread::getProfileEvents()[resolver_metrics.failed]);
 }
 
 TEST_F(ConnectionPoolTest, ProxyConnectSkipsTargetResolution)
@@ -817,9 +817,9 @@ TEST_F(ConnectionPoolTest, RetriesNextAddressOnConnectFailure)
     auto metrics = pool->getMetrics();
     auto resolver_metrics = DB::HostResolver::getMetrics();
 
-    UInt64 created_before = DB::CurrentThread::getProfileEvents()[metrics.created].load();
-    UInt64 errors_before = DB::CurrentThread::getProfileEvents()[metrics.errors].load();
-    UInt64 failed_before = DB::CurrentThread::getProfileEvents()[resolver_metrics.failed].load();
+    UInt64 created_before = DB::CurrentThread::getProfileEvents()[metrics.created];
+    UInt64 errors_before = DB::CurrentThread::getProfileEvents()[metrics.errors];
+    UInt64 failed_before = DB::CurrentThread::getProfileEvents()[resolver_metrics.failed];
 
     UInt64 connect_time = 0;
     auto connection = pool->getConnection(timeouts, &connect_time);
@@ -827,9 +827,9 @@ TEST_F(ConnectionPoolTest, RetriesNextAddressOnConnectFailure)
 
     /// First attempt: connect to `bad_ip` → fails (counted in `errors` and resolver `failed`).
     /// Retry: connect to `good_ip` → succeeds (counted in `created`).
-    ASSERT_EQ(1, DB::CurrentThread::getProfileEvents()[metrics.created].load() - created_before);
-    ASSERT_EQ(1, DB::CurrentThread::getProfileEvents()[metrics.errors].load() - errors_before);
-    ASSERT_EQ(1, DB::CurrentThread::getProfileEvents()[resolver_metrics.failed].load() - failed_before);
+    ASSERT_EQ(1, DB::CurrentThread::getProfileEvents()[metrics.created] - created_before);
+    ASSERT_EQ(1, DB::CurrentThread::getProfileEvents()[metrics.errors] - errors_before);
+    ASSERT_EQ(1, DB::CurrentThread::getProfileEvents()[resolver_metrics.failed] - failed_before);
 
     /// The retry path must still report the connection-establishment time to the caller: the
     /// connect duration is accumulated across the failed and the successful attempt and written

--- a/src/Common/tests/gtest_profile_events.cpp
+++ b/src/Common/tests/gtest_profile_events.cpp
@@ -1,0 +1,88 @@
+#include <gtest/gtest.h>
+
+#include <Common/ProfileEvents.h>
+#include <Common/VariableContext.h>
+
+#include <memory>
+#include <thread>
+#include <vector>
+
+namespace ProfileEvents
+{
+    extern const Event Query;
+}
+
+/// Drive the real `Thread` -> `User` -> `global_counters` chain: every thread increments its own
+/// `Thread`-level counter, propagating up to a shared `User`-level counter (per-CPU layout,
+/// so increments scatter across CPU rows and `load` sums them) and the process-wide sharded
+/// `global_counters`. Verify each level is accounted exactly; asserting on the `global_counters`
+/// delta is what covers the static per-CPU storage (tests run sequentially, and only this test's
+/// threads increment during it).
+TEST(ProfileEvents, ChainAccountsPerThreadUserAndGlobal)
+{
+    const ProfileEvents::Count global_before = ProfileEvents::global_counters[ProfileEvents::Query];
+
+    ProfileEvents::Counters user(VariableContext::User, &ProfileEvents::global_counters);
+
+    constexpr size_t num_threads = 16;
+    constexpr size_t increments_per_thread = 100'000;
+
+    std::vector<std::unique_ptr<ProfileEvents::Counters>> per_thread;
+    for (size_t t = 0; t < num_threads; ++t)
+        per_thread.push_back(std::make_unique<ProfileEvents::Counters>(VariableContext::Thread, &user));
+
+    std::vector<std::thread> threads;
+    for (size_t t = 0; t < num_threads; ++t)
+        threads.emplace_back([&, t]
+        {
+            for (size_t i = 0; i < increments_per_thread; ++i)
+                per_thread[t]->increment(ProfileEvents::Query);
+        });
+
+    for (auto & thread : threads)
+        thread.join();
+
+    for (size_t t = 0; t < num_threads; ++t)
+        EXPECT_EQ((*per_thread[t])[ProfileEvents::Query], increments_per_thread);
+
+    EXPECT_EQ(user[ProfileEvents::Query], num_threads * increments_per_thread);
+    EXPECT_EQ(ProfileEvents::global_counters[ProfileEvents::Query] - global_before, num_threads * increments_per_thread);
+}
+
+/// With per-CPU sharding disabled the `User` level falls back to a single shared atomic per event.
+/// Accounting must stay exact; only the layout (and memory) differs from the sharded path above.
+TEST(ProfileEvents, ChainAccountsWithPerCPUDisabled)
+{
+    struct PerCPUGuard
+    {
+        explicit PerCPUGuard(bool enabled) { ProfileEvents::setUserPerCPUEnabled(enabled); }
+        ~PerCPUGuard() { ProfileEvents::setUserPerCPUEnabled(true); }
+    } guard(false);
+
+    ProfileEvents::Counters global(VariableContext::Global, nullptr);
+    ProfileEvents::Counters user(VariableContext::User, &global);
+
+    constexpr size_t num_threads = 16;
+    constexpr size_t increments_per_thread = 100'000;
+
+    std::vector<std::unique_ptr<ProfileEvents::Counters>> per_thread;
+    for (size_t t = 0; t < num_threads; ++t)
+        per_thread.push_back(std::make_unique<ProfileEvents::Counters>(VariableContext::Thread, &user));
+
+    std::vector<std::thread> threads;
+    for (size_t t = 0; t < num_threads; ++t)
+        threads.emplace_back([&, t]
+        {
+            for (size_t i = 0; i < increments_per_thread; ++i)
+                per_thread[t]->increment(ProfileEvents::Query);
+        });
+
+    for (auto & thread : threads)
+        thread.join();
+
+    for (size_t t = 0; t < num_threads; ++t)
+        EXPECT_EQ((*per_thread[t])[ProfileEvents::Query], increments_per_thread);
+
+    EXPECT_EQ(user[ProfileEvents::Query], num_threads * increments_per_thread);
+    EXPECT_EQ(global[ProfileEvents::Query], num_threads * increments_per_thread);
+}

--- a/src/Coordination/FourLetterCommand.cpp
+++ b/src/Coordination/FourLetterCommand.cpp
@@ -702,7 +702,7 @@ String ProfileEventsCommand::run()
 
     for (auto i : ProfileEvents::keeper_profile_events)
     {
-        const auto counter = ProfileEvents::global_counters[i].load(std::memory_order_relaxed);
+        const auto counter = ProfileEvents::global_counters[i];
         std::string metric_name{ProfileEvents::getName(static_cast<ProfileEvents::Event>(i))};
         std::string metric_doc{ProfileEvents::getDocumentation(static_cast<ProfileEvents::Event>(i))};
         append(metric_name, counter, metric_doc);

--- a/src/Core/ServerSettings.cpp
+++ b/src/Core/ServerSettings.cpp
@@ -1071,6 +1071,7 @@ The policy on how to perform a scheduling of CPU slots specified by `concurrent_
     )", 0) \
     DECLARE(UInt64, total_memory_profiler_sample_min_allocation_size, 0, R"(Collect random allocations of size greater or equal than specified value with probability equal to `total_memory_profiler_sample_probability`. 0 means disabled. You may want to set 'max_untracked_memory' to 0 to make this threshold to work as expected.)", 0) \
     DECLARE(UInt64, total_memory_profiler_sample_max_allocation_size, 0, R"(Collect random allocations of size less or equal than specified value with probability equal to `total_memory_profiler_sample_probability`. 0 means disabled. You may want to set 'max_untracked_memory' to 0 to make this threshold to work as expected.)", 0) \
+    DECLARE(Bool, user_profile_events_per_cpu, true, R"(Shard per-user `ProfileEvents` counters per CPU to avoid cross-CPU cache-line contention under high thread counts. Each user pays `getNumCPUs() * num_events * sizeof(atomic)` of memory (hundreds of KiB on machines with many cores). Disable to fall back to a single shared atomic per event per user, trading throughput for memory.)", 0) \
     DECLARE(Bool, validate_tcp_client_information, false, R"(Determines whether validation of client information is enabled when a query packet is received.
 
     By default, it is `false`:

--- a/src/IO/WriteBufferFromFileDescriptorDiscardOnFailure.cpp
+++ b/src/IO/WriteBufferFromFileDescriptorDiscardOnFailure.cpp
@@ -21,7 +21,7 @@ void WriteBufferFromFileDescriptorDiscardOnFailure::nextImpl()
             /// Never send this profile event to trace log because it may cause another
             /// write into the same fd and likely will trigger the same error
             /// and will lead to infinite recursion.
-            ProfileEvents::incrementNoTrace(ProfileEvents::CannotWriteToWriteBufferDiscard);
+            ProfileEvents::incrementSignalSafe(ProfileEvents::CannotWriteToWriteBufferDiscard);
             break;  /// Discard
         }
 

--- a/src/IO/tests/gtest_reader_executor.cpp
+++ b/src/IO/tests/gtest_reader_executor.cpp
@@ -47,7 +47,7 @@ struct TestThreadGroup
 
     ProfileEvents::Count get(ProfileEvents::Event event) const
     {
-        return thread_group->performance_counters[event].load(std::memory_order_relaxed);
+        return thread_group->performance_counters[event];
     }
 };
 

--- a/src/Interpreters/MetricLog.cpp
+++ b/src/Interpreters/MetricLog.cpp
@@ -94,7 +94,7 @@ void MetricLog::stepFunction(const std::chrono::system_clock::time_point current
     elem.profile_events.resize(ProfileEvents::end());
     for (ProfileEvents::Event i = ProfileEvents::Event(0), end = ProfileEvents::end(); i < end; ++i)
     {
-        const ProfileEvents::Count new_value = ProfileEvents::global_counters[i].load(std::memory_order_relaxed);
+        const ProfileEvents::Count new_value = ProfileEvents::global_counters[i];
         auto & old_value = previous_profile_events[i];
 
         /// Profile event counters are supposed to be monotonic. However, at least the `NetworkReceiveBytes` can be inaccurate.

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -489,6 +489,8 @@ ProcessListEntry::~ProcessListEntry()
     parent.have_space.notify_all();
 
     /// If there are no more queries for the user, then we will reset memory tracker.
+    /// The `user_to_queries` entry is intentionally kept (do not erase it here): `getUserInfo`
+    /// reads entries lock-free via raw pointers and relies on them never being erased.
     if (user_process_list.queries.empty())
         user_process_list.resetTrackers();
 }
@@ -986,14 +988,22 @@ ProcessListForUserInfo ProcessListForUser::getInfo(bool get_profile_events) cons
 
 ProcessList::UserInfo ProcessList::getUserInfo(bool get_profile_events) const
 {
+    /// Snapshot each user outside the lock (with sharded `User` counters `getInfo(true)` is
+    /// O(num_events * cpus)). Safe: `user_to_queries` entries are never erased (see the comment in
+    /// `ProcessListEntry`'s destructor) and `unordered_map` keeps element pointers valid across
+    /// inserts, so they outlive the lock; `getInfo` reads only atomics.
+    std::vector<std::pair<String, const ProcessListForUser *>> users;
+    {
+        LockAndBlocker lock(mutex);
+        users.reserve(user_to_queries.size());
+        for (const auto & [user, user_queries] : user_to_queries)
+            users.emplace_back(user, &user_queries);
+    }
+
     UserInfo per_user_infos;
-
-    LockAndBlocker lock(mutex);
-
-    per_user_infos.reserve(user_to_queries.size());
-
-    for (const auto & [user, user_queries] : user_to_queries)
-        per_user_infos.emplace(user, user_queries.getInfo(get_profile_events));
+    per_user_infos.reserve(users.size());
+    for (const auto & [user, user_queries] : users)
+        per_user_infos.emplace(user, user_queries->getInfo(get_profile_events));
 
     return per_user_infos;
 }

--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -219,10 +219,8 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
     /// Experimental ReaderExecutor read-path efficiency KPI: modeled cost (ms) per MiB of
     /// requested bytes, as a ratio of two ProfileEvents' deltas over the interval (idle -> 0).
     {
-        const UInt64 cost_us = static_cast<UInt64>(
-            ProfileEvents::global_counters[ProfileEvents::ReaderExecutorModeledCostMicroseconds].load(std::memory_order_relaxed));
-        const UInt64 req_bytes = static_cast<UInt64>(
-            ProfileEvents::global_counters[ProfileEvents::ReaderExecutorRequestedBytes].load(std::memory_order_relaxed));
+        const UInt64 cost_us = static_cast<UInt64>(ProfileEvents::global_counters[ProfileEvents::ReaderExecutorModeledCostMicroseconds]);
+        const UInt64 req_bytes = static_cast<UInt64>(ProfileEvents::global_counters[ProfileEvents::ReaderExecutorRequestedBytes]);
         if (!first_run)
         {
             const UInt64 d_cost = cost_us - prev_reader_executor_cost_us;

--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -556,7 +556,7 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
     }
 
     {
-        const auto user_info = getContext()->getProcessList().getUserInfo(true);
+        const auto user_info = getContext()->getProcessList().getUserInfo(false);
         size_t queries_memory_usage = 0;
         size_t queries_peak_memory_usage = 0;
         for (const auto & [user, info] : user_info)

--- a/src/Interpreters/TransposedMetricLog.cpp
+++ b/src/Interpreters/TransposedMetricLog.cpp
@@ -86,7 +86,7 @@ void TransposedMetricLog::stepFunction(TimePoint current_time)
 
     for (ProfileEvents::Event i = ProfileEvents::Event(0), end = ProfileEvents::end(); i < end; ++i)
     {
-        const ProfileEvents::Count new_value = ProfileEvents::global_counters[i].load(std::memory_order_relaxed);
+        const ProfileEvents::Count new_value = ProfileEvents::global_counters[i];
         auto & old_value = previous_profile_events[i];
 
         /// Profile event counters are supposed to be monotonic. However, at least the `NetworkReceiveBytes` can be inaccurate.

--- a/src/Interpreters/tests/gtest_filecache.cpp
+++ b/src/Interpreters/tests/gtest_filecache.cpp
@@ -3058,12 +3058,12 @@ TEST_F(FileCacheTest, SLRUDowngradeMetric)
     auto prob_it = add_segment(10, 10, IFileCachePriority::QueueEntryType::SLRU_Probationary);
 
     auto & events = CurrentThread::getProfileEvents();
-    const auto downgraded_before = events[ProfileEvents::FilesystemCacheDowngradedFileSegments].load();
-    const auto evicted_before = events[ProfileEvents::FilesystemCacheEvictedFileSegments].load();
+    const auto downgraded_before = events[ProfileEvents::FilesystemCacheDowngradedFileSegments];
+    const auto evicted_before = events[ProfileEvents::FilesystemCacheEvictedFileSegments];
 
     /// Protected is full, so promoting the probationary entry downgrades (moves) the protected one, not evicts it.
     ASSERT_TRUE(priority.tryIncreasePriority(*prob_it, /* is_space_reservation_complete */true, cache_guard, state_guard));
 
-    ASSERT_EQ(events[ProfileEvents::FilesystemCacheDowngradedFileSegments].load(), downgraded_before + 1);
-    ASSERT_EQ(events[ProfileEvents::FilesystemCacheEvictedFileSegments].load(), evicted_before);
+    ASSERT_EQ(events[ProfileEvents::FilesystemCacheDowngradedFileSegments], downgraded_before + 1);
+    ASSERT_EQ(events[ProfileEvents::FilesystemCacheEvictedFileSegments], evicted_before);
 }

--- a/src/Server/PrometheusMetricsWriter.cpp
+++ b/src/Server/PrometheusMetricsWriter.cpp
@@ -79,7 +79,7 @@ constexpr auto dimensional_metrics_prefix = "ClickHouseDimensionalMetrics_";
 
 void writeEvent(DB::WriteBuffer & wb, ProfileEvents::Event event)
 {
-    const auto counter = ProfileEvents::global_counters[event].load(std::memory_order_relaxed);
+    const auto counter = ProfileEvents::global_counters[event];
 
     std::string metric_name{ProfileEvents::getName(static_cast<ProfileEvents::Event>(event))};
     std::string metric_doc{ProfileEvents::getDocumentation(static_cast<ProfileEvents::Event>(event))};

--- a/src/Storages/MergeTree/tests/gtest_unique_key_index_cache.cpp
+++ b/src/Storages/MergeTree/tests/gtest_unique_key_index_cache.cpp
@@ -56,8 +56,8 @@ TEST(UniqueKeyIndexCache, InsertLookupAndHitMissCounters)
     UniqueKeyIndexCache cache = makeCache(1 << 20);
 
     auto & counters = CurrentThread::getProfileEvents();
-    const auto hits_before = counters[ProfileEvents::UniqueKeyIndexCacheHits].load();
-    const auto misses_before = counters[ProfileEvents::UniqueKeyIndexCacheMisses].load();
+    const auto hits_before = counters[ProfileEvents::UniqueKeyIndexCacheHits];
+    const auto misses_before = counters[ProfileEvents::UniqueKeyIndexCacheMisses];
 
     auto * obj = new FakeObject{nullptr, 42};
     rocksdb::Slice key("key-1");
@@ -76,8 +76,8 @@ TEST(UniqueKeyIndexCache, InsertLookupAndHitMissCounters)
                                rocksdb::Cache::Priority::LOW, nullptr);
     EXPECT_EQ(miss, nullptr);
 
-    EXPECT_EQ(counters[ProfileEvents::UniqueKeyIndexCacheHits].load() - hits_before, 1u);
-    EXPECT_EQ(counters[ProfileEvents::UniqueKeyIndexCacheMisses].load() - misses_before, 1u);
+    EXPECT_EQ(counters[ProfileEvents::UniqueKeyIndexCacheHits] - hits_before, 1u);
+    EXPECT_EQ(counters[ProfileEvents::UniqueKeyIndexCacheMisses] - misses_before, 1u);
 
     cache.Release(lh, /*erase_if_last_ref=*/false);
     cache.Release(ih, /*erase_if_last_ref=*/false);


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Make Profile Events ±30x faster by using Per CPU atomics for server-wide and users. Guarded with "user_profile_events_per_cpu" server setting (uses ±640KiB per user on 64 cores, so in case of lots of users it may make sense to keep it disabled)

<details>

<summary>Benchmark</summary>

- fb57ea09e112e93354e24580a1117e6013e3da0d

```
azat:.../clickhouse/build (shard-profile-events-per-cpu) {elapsed: 242s}$ src/Common/benchmarks/profile_events
2026-07-02T09:40:02+02:00
Running src/Common/benchmarks/profile_events
Run on (64 X 4561.83 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x32)
  L1 Instruction 32 KiB (x32)
  L2 Unified 512 KiB (x32)
  L3 Unified 32768 KiB (x4)
Load Average: 2.74, 17.29, 17.43
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
-----------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                               Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------------------------------------------------------
BM_ProfileEvents/1000/process_time/real_time                                        0.954 ms         25.9 ms          658 groups=50 items_per_second=523.846M/s ns/inc=1.90896ns threads=500 users=1
BM_ProfileEvents/10000/process_time/real_time                                        5.35 ms          201 ms           97 groups=50 items_per_second=934.66M/s ns/inc=1069.91ps threads=500 users=1
BM_ProfileEvents/100000/process_time/real_time                                       36.8 ms         1778 ms           17 groups=50 items_per_second=1.35935G/s ns/inc=735.645ps threads=500 users=1
BM_ProfileEventsConcurrentRead/1000/process_time/real_time                           1.01 ms         28.5 ms          651 global_scans=13.857k groups=50 items_per_second=494.135M/s ns/inc=2.02374ns read_us=0 threads=500 users=1
BM_ProfileEventsConcurrentRead/10000/process_time/real_time                          5.82 ms          227 ms           99 global_scans=10.744k groups=50 items_per_second=859.358M/s ns/inc=1.16366ns read_us=0 threads=500 users=1
BM_ProfileEventsConcurrentRead/100000/process_time/real_time                         43.5 ms         1868 ms           13 global_scans=9.062k groups=50 items_per_second=1.14917G/s ns/inc=870.192ps read_us=0 threads=500 users=1
BM_ProfileEventsPeriodicRead/iters:100000/read_us:100/process_time/real_time         37.1 ms         1817 ms           18 global_scans=1.288k groups=50 items_per_second=1.34718G/s ns/inc=742.29ps read_us=100 threads=500 users=1
BM_ProfileEventsPeriodicRead/iters:100000/read_us:1000/process_time/real_time        36.8 ms         1805 ms           18 global_scans=296 groups=50 items_per_second=1.35873G/s ns/inc=735.983ps read_us=1000 threads=500 users=1
BM_ProfileEventsPeriodicRead/iters:100000/read_us:10000/process_time/real_time       36.3 ms         1785 ms           19 global_scans=57 groups=50 items_per_second=1.3757G/s ns/inc=726.902ps read_us=10k threads=500 users=1
BM_ProfileEventsReadLatency/read_us:-1/batch:1/min_time:2.000/real_time              67.2 ns         66.6 ns     41701286 bg_threads=30 descheduled=884 global_scans=0 p50_ns=30 p9999_ns=150 p999_ns=60 p99_ns=41 read_us=-1
BM_ProfileEventsReadLatency/read_us:0/batch:1/min_time:2.000/real_time               69.8 ns         69.2 ns     39971938 bg_threads=30 descheduled=1.196k global_scans=64.365k p50_ns=40 p9999_ns=160 p999_ns=90 p99_ns=70 read_us=0
BM_ProfileEventsReadLatency/read_us:1000/batch:1/min_time:2.000/real_time            69.4 ns         68.2 ns     41663250 bg_threads=30 descheduled=1.289k global_scans=2.534k p50_ns=31 p9999_ns=721 p999_ns=150 p99_ns=50 read_us=1000
BM_ProfileEventsReadLatency/read_us:1000000/batch:1/min_time:2.000/real_time         67.5 ns         66.9 ns     41649125 bg_threads=30 descheduled=1021 global_scans=3 p50_ns=31 p9999_ns=140 p999_ns=61 p99_ns=50 read_us=1000k
BM_ProfileEventsReadAll/per_cpu:0/real_time                                          2.89 us         2.88 us       239444 events=1.339k ncpus=64
BM_ProfileEventsReadAll/per_cpu:1/real_time                                          27.7 us         27.6 us        26853 events=1.339k ncpus=64

```

</details>


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.470` (included in `26.7` and later)
<!-- ch-version-info:end -->