### PR TITLE
Trim LARGE_FILE_WHITELIST in style check

### DIFF
--- a/ci/jobs/scripts/check_style/various_checks.sh
+++ b/ci/jobs/scripts/check_style/various_checks.sh
@@ -243,12 +243,6 @@ LARGE_FILE_WHITELIST=(
     -e string_int_list_inconsistent_offset_multiple_batches.parquet
     -e known_failures.txt
     -e keeper-java-client-test.jar
-    -e amazon_model.bin
-    -e nbagames_sample.json
-    -e 02731.arrow
-    -e aes-gcm-avx512.s
-    # TODO: these should be removed and the test should build the JAR from source at runtime
-    -e paimon-rest-catalog/chunk_
 )
 # GNU stat (Linux) uses -c, BSD stat (macOS) uses -f — detect once instead of failing per file.
 if stat -c '%s %n' /dev/null >/dev/null 2>&1; then


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.688`
<!-- ch-version-info:end -->