### PR TITLE
Flush buffered logs before delivering exception in clickhouse-local

### DIFF
--- a/src/Client/LocalConnection.cpp
+++ b/src/Client/LocalConnection.cpp
@@ -457,6 +457,11 @@ bool LocalConnection::poll(size_t)
 
     if (state->exception)
     {
+        /// Flush any buffered logs before delivering the exception, otherwise
+        /// the user would not see log messages produced before the failure.
+        if (needSendLogs())
+            return true;
+
         next_packet_type = Protocol::Server::Exception;
         return true;
     }

--- a/tests/queries/0_stateless/04240_80087_clickhouse_local_logs_on_exception.reference
+++ b/tests/queries/0_stateless/04240_80087_clickhouse_local_logs_on_exception.reference
@@ -1,0 +1,2 @@
+logs printed: ok
+exception printed: ok

--- a/tests/queries/0_stateless/04240_80087_clickhouse_local_logs_on_exception.sh
+++ b/tests/queries/0_stateless/04240_80087_clickhouse_local_logs_on_exception.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/80087
+# With send_logs_level set in clickhouse-local, logs accumulated before a query
+# failure must still be printed; previously the exception was sent without
+# flushing the buffered log queue.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# A query that fails fast during analysis. With send_logs_level=trace, a few
+# log lines are produced before the failure (executeQuery, ContextAccess, ...).
+output=$($CLICKHOUSE_LOCAL --send_logs_level=trace -q "SELECT * FROM nonexistent_table_xyz_04240" 2>&1)
+
+echo "$output" | grep -qE '<(Debug|Trace)>' && echo "logs printed: ok"
+echo "$output" | grep -q "UNKNOWN_TABLE" && echo "exception printed: ok"


### PR DESCRIPTION
With `send_logs_level` set in `clickhouse-local`, log messages accumulated before a query failure were not printed. The exception itself was delivered, but earlier log entries were lost.

`LocalConnection::poll` had an early return that emitted the `Protocol::Server::Exception` packet without first draining the `InternalTextLogsQueue`. The second exception path inside the same function already calls `needSendLogs`; this PR adds the same flush on the early-return path so the queue is always drained before the exception is sent.

Fixes #80087.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix `clickhouse-local` not printing log messages from a failed query when `send_logs_level` is set.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.695`
<!-- ch-version-info:end -->