### PR TITLE
Reject ATTACH TABLE with non-engine storage clauses (narrower guard, re-land of #104800)

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1567,6 +1567,43 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
 
     DDLGuardPtr ddl_guard;
 
+    /// `ATTACH TABLE name <storage clauses>;` without `ENGINE` and without a columns list is ambiguous:
+    /// the parser allows `SETTINGS`, `ORDER BY`, `PARTITION BY`, etc. without an `ENGINE` (to support
+    /// `default_table_engine` on `CREATE`), but the short `ATTACH` path below reads the full table
+    /// definition from stored metadata and silently overwrites anything the user typed.
+    ///
+    /// However `ATTACH TABLE t SETTINGS log_comment = 'foo';` is a legitimate, supported pattern:
+    /// `InterpreterSetQuery::applySettingsFromQuery` (called from `executeQueryImpl` before this
+    /// interpreter runs) extracts session settings out of `create.storage->settings` and applies
+    /// them to the context, then clears `create.storage->settings` when nothing engine-specific
+    /// is left. So the case we must reject is the *remaining* one: at this point any of the
+    /// non-engine storage fields (`ORDER BY`, `PARTITION BY`, `PRIMARY KEY`, `SAMPLE BY`, `TTL`,
+    /// `UNIQUE KEY`, or `SETTINGS` containing keys that are not known session settings) are still
+    /// populated — those would be silently dropped by the short `ATTACH` path below.
+    if (create.attach && create.storage && !create.storage->engine && !create.columns_list)
+    {
+        const auto & storage = *create.storage;
+        const bool has_non_engine_storage_clauses
+            = storage.partition_by != nullptr
+            || storage.primary_key != nullptr
+            || storage.order_by != nullptr
+            || storage.sample_by != nullptr
+            || storage.ttl_table != nullptr
+            || storage.unique_key != nullptr
+            || storage.settings != nullptr;
+
+        if (has_non_engine_storage_clauses)
+        {
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "ATTACH TABLE without ENGINE cannot specify storage clauses (ORDER BY, PARTITION BY, PRIMARY KEY, "
+                "SAMPLE BY, TTL, UNIQUE KEY, or engine SETTINGS) — they would be silently ignored because the "
+                "table definition is read from stored metadata. Use 'ATTACH TABLE {0};' to re-attach with stored "
+                "metadata, or 'ALTER TABLE {0} MODIFY SETTING ...' (or 'MODIFY ORDER BY ...') after ATTACH to "
+                "change settings. Session settings (e.g. log_comment) are allowed and applied automatically.",
+                backQuoteIfNeed(create.getTable()));
+        }
+    }
+
     // If this is a stub ATTACH query, read the query definition from the database
     if (create.attach && (!create.storage || !create.storage->engine) && !create.columns_list)
     {

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1605,7 +1605,8 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
             || create.is_clone_as
             || !create.as_database.empty()
             || !create.as_table.empty()
-            || create.uuid != UUIDHelpers::Nil;
+            || create.has_attach_from_path
+            || create.has_uuid_clause;
 
         if (has_dropped_clauses)
         {

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1606,7 +1606,8 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
             || !create.as_database.empty()
             || !create.as_table.empty()
             || create.has_attach_from_path
-            || create.has_uuid_clause;
+            || create.has_uuid_clause
+            || create.has_inner_uuid_clause;
 
         if (has_dropped_clauses)
         {

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1567,24 +1567,17 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
 
     DDLGuardPtr ddl_guard;
 
-    /// `ATTACH TABLE name <something>;` without `ENGINE` and without a columns list is ambiguous:
-    /// the parser allows `SETTINGS`, `ORDER BY`, `PARTITION BY`, `COMMENT`, `REFRESH`, `TO`, etc.
-    /// in this position (to support `default_table_engine` on `CREATE` and to share the parser
-    /// between `CREATE` and `ATTACH`), but the short `ATTACH` path below reads the full table
-    /// definition from stored metadata and silently overwrites anything the user typed.
-    ///
-    /// However `ATTACH TABLE t SETTINGS log_comment = 'foo';` is a legitimate, supported pattern:
-    /// `InterpreterSetQuery::applySettingsFromQuery` (called from `executeQueryImpl` before this
-    /// interpreter runs) extracts session settings out of `create.storage->settings` and applies
-    /// them to the context, then clears `create.storage->settings` when nothing engine-specific
-    /// is left. So the case we must reject is the remaining one: at this point any of the
-    /// non-engine storage fields (`ORDER BY`, `PARTITION BY`, `PRIMARY KEY`, `SAMPLE BY`, `TTL`,
-    /// `UNIQUE KEY`, or `SETTINGS` containing keys that are not known session settings) are still
-    /// populated, OR one of the top-level `ASTCreateQuery` fields (`COMMENT`, `REFRESH`,
-    /// `SQL SECURITY`, `TO target`, `EMPTY`, `CLONE`, `AS SELECT`, etc.) is set. Any of those
-    /// would be silently dropped by the short `ATTACH` path below.
-    if (create.attach && !create.columns_list && (!create.storage || !create.storage->engine))
+    // If this is a stub ATTACH query, read the query definition from the database
+    if (create.attach && (!create.storage || !create.storage->engine) && !create.columns_list)
     {
+        /// First, reject any user-supplied storage clauses or top-level fields that the
+        /// short-ATTACH path below would silently drop by overwriting `create` with the
+        /// stored table metadata. `InterpreterSetQuery::applySettingsFromQuery` (called from
+        /// `executeQueryImpl` before this interpreter) has already hoisted session settings
+        /// out of `create.storage->settings`, so anything still here is either engine-specific
+        /// (`ORDER BY`, `PARTITION BY`, `PRIMARY KEY`, `SAMPLE BY`, `TTL`, `UNIQUE KEY`, MergeTree
+        /// `SETTINGS`) or a top-level `ASTCreateQuery` field (`COMMENT`, `REFRESH`, `SQL SECURITY`,
+        /// `TO target`, `EMPTY`, `CLONE`, `AS SELECT`, `UUID`, etc.).
         bool has_dropped_clauses = false;
 
         if (create.storage)
@@ -1600,9 +1593,6 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
                 || storage.settings != nullptr;
         }
 
-        /// Top-level fields on `ASTCreateQuery` that the parser may populate for an `ATTACH`
-        /// query but that the short `ATTACH` path below silently drops by overwriting `create`
-        /// with the stored table metadata.
         has_dropped_clauses = has_dropped_clauses
             || create.comment != nullptr
             || create.refresh_strategy != nullptr
@@ -1614,7 +1604,8 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
             || create.is_create_empty
             || create.is_clone_as
             || !create.as_database.empty()
-            || !create.as_table.empty();
+            || !create.as_table.empty()
+            || create.uuid != UUIDHelpers::Nil;
 
         if (has_dropped_clauses)
         {
@@ -1624,11 +1615,7 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
                 "(or 'MODIFY ORDER BY ...') after ATTACH to change settings.",
                 backQuoteIfNeed(create.getTable()));
         }
-    }
 
-    // If this is a stub ATTACH query, read the query definition from the database
-    if (create.attach && (!create.storage || !create.storage->engine) && !create.columns_list)
-    {
         // In case of an ON CLUSTER query, the database may not be present on the initiator node
         auto database = DatabaseCatalog::instance().tryGetDatabase(database_name);
         if (database && database->shouldReplicateQuery(getContext(), query_ptr))

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1567,9 +1567,10 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
 
     DDLGuardPtr ddl_guard;
 
-    /// `ATTACH TABLE name <storage clauses>;` without `ENGINE` and without a columns list is ambiguous:
-    /// the parser allows `SETTINGS`, `ORDER BY`, `PARTITION BY`, etc. without an `ENGINE` (to support
-    /// `default_table_engine` on `CREATE`), but the short `ATTACH` path below reads the full table
+    /// `ATTACH TABLE name <something>;` without `ENGINE` and without a columns list is ambiguous:
+    /// the parser allows `SETTINGS`, `ORDER BY`, `PARTITION BY`, `COMMENT`, `REFRESH`, `TO`, etc.
+    /// in this position (to support `default_table_engine` on `CREATE` and to share the parser
+    /// between `CREATE` and `ATTACH`), but the short `ATTACH` path below reads the full table
     /// definition from stored metadata and silently overwrites anything the user typed.
     ///
     /// However `ATTACH TABLE t SETTINGS log_comment = 'foo';` is a legitimate, supported pattern:
@@ -1579,20 +1580,43 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
     /// is left. So the case we must reject is the remaining one: at this point any of the
     /// non-engine storage fields (`ORDER BY`, `PARTITION BY`, `PRIMARY KEY`, `SAMPLE BY`, `TTL`,
     /// `UNIQUE KEY`, or `SETTINGS` containing keys that are not known session settings) are still
-    /// populated, and those would be silently dropped by the short `ATTACH` path below.
-    if (create.attach && create.storage && !create.storage->engine && !create.columns_list)
+    /// populated, OR one of the top-level `ASTCreateQuery` fields (`COMMENT`, `REFRESH`,
+    /// `SQL SECURITY`, `TO target`, `EMPTY`, `CLONE`, `AS SELECT`, etc.) is set. Any of those
+    /// would be silently dropped by the short `ATTACH` path below.
+    if (create.attach && !create.columns_list && (!create.storage || !create.storage->engine))
     {
-        const auto & storage = *create.storage;
-        const bool has_non_engine_storage_clauses
-            = storage.partition_by != nullptr
-            || storage.primary_key != nullptr
-            || storage.order_by != nullptr
-            || storage.sample_by != nullptr
-            || storage.ttl_table != nullptr
-            || storage.unique_key != nullptr
-            || storage.settings != nullptr;
+        bool has_dropped_clauses = false;
 
-        if (has_non_engine_storage_clauses)
+        if (create.storage)
+        {
+            const auto & storage = *create.storage;
+            has_dropped_clauses
+                = storage.partition_by != nullptr
+                || storage.primary_key != nullptr
+                || storage.order_by != nullptr
+                || storage.sample_by != nullptr
+                || storage.ttl_table != nullptr
+                || storage.unique_key != nullptr
+                || storage.settings != nullptr;
+        }
+
+        /// Top-level fields on `ASTCreateQuery` that the parser may populate for an `ATTACH`
+        /// query but that the short `ATTACH` path below silently drops by overwriting `create`
+        /// with the stored table metadata.
+        has_dropped_clauses = has_dropped_clauses
+            || create.comment != nullptr
+            || create.refresh_strategy != nullptr
+            || create.sql_security != nullptr
+            || create.select != nullptr
+            || create.targets != nullptr
+            || create.as_table_function != nullptr
+            || create.aliases_list != nullptr
+            || create.is_create_empty
+            || create.is_clone_as
+            || !create.as_database.empty()
+            || !create.as_table.empty();
+
+        if (has_dropped_clauses)
         {
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
                 "ATTACH applies the table definition from stored metadata and can't be changed in the query itself. "

--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1576,10 +1576,10 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
     /// `InterpreterSetQuery::applySettingsFromQuery` (called from `executeQueryImpl` before this
     /// interpreter runs) extracts session settings out of `create.storage->settings` and applies
     /// them to the context, then clears `create.storage->settings` when nothing engine-specific
-    /// is left. So the case we must reject is the *remaining* one: at this point any of the
+    /// is left. So the case we must reject is the remaining one: at this point any of the
     /// non-engine storage fields (`ORDER BY`, `PARTITION BY`, `PRIMARY KEY`, `SAMPLE BY`, `TTL`,
     /// `UNIQUE KEY`, or `SETTINGS` containing keys that are not known session settings) are still
-    /// populated — those would be silently dropped by the short `ATTACH` path below.
+    /// populated, and those would be silently dropped by the short `ATTACH` path below.
     if (create.attach && create.storage && !create.storage->engine && !create.columns_list)
     {
         const auto & storage = *create.storage;
@@ -1595,11 +1595,9 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
         if (has_non_engine_storage_clauses)
         {
             throw Exception(ErrorCodes::BAD_ARGUMENTS,
-                "ATTACH TABLE without ENGINE cannot specify storage clauses (ORDER BY, PARTITION BY, PRIMARY KEY, "
-                "SAMPLE BY, TTL, UNIQUE KEY, or engine SETTINGS) — they would be silently ignored because the "
-                "table definition is read from stored metadata. Use 'ATTACH TABLE {0};' to re-attach with stored "
-                "metadata, or 'ALTER TABLE {0} MODIFY SETTING ...' (or 'MODIFY ORDER BY ...') after ATTACH to "
-                "change settings. Session settings (e.g. log_comment) are allowed and applied automatically.",
+                "ATTACH applies the table definition from stored metadata and can't be changed in the query itself. "
+                "Use 'ATTACH TABLE {0};' to re-attach with stored metadata, or 'ALTER TABLE {0} MODIFY SETTING ...' "
+                "(or 'MODIFY ORDER BY ...') after ATTACH to change settings.",
                 backQuoteIfNeed(create.getTable()));
         }
     }

--- a/src/Parsers/ASTCreateQuery.h
+++ b/src/Parsers/ASTCreateQuery.h
@@ -136,6 +136,7 @@ public:
     bool replace_view : 1 = false;         /// CREATE OR REPLACE VIEW
     bool has_uuid : 1 = false;             /// CREATE TABLE x UUID '...' with a non-`Nil` value (see `has_uuid_clause` for clause-presence tracking)
     bool has_uuid_clause : 1 = false;      /// Parser saw an explicit `UUID '...'` clause, true even when the value is `Nil`
+    bool has_inner_uuid_clause : 1 = false; /// Parser saw an explicit `TO INNER UUID '...'` clause
     bool is_dictionary : 1 = false;        /// CREATE DICTIONARY
     bool is_watermark_strictly_ascending : 1 = false; /// STRICTLY ASCENDING WATERMARK STRATEGY FOR WINDOW VIEW
     bool is_watermark_ascending : 1 = false;          /// ASCENDING WATERMARK STRATEGY FOR WINDOW VIEW

--- a/src/Parsers/ASTCreateQuery.h
+++ b/src/Parsers/ASTCreateQuery.h
@@ -134,7 +134,8 @@ public:
     bool is_create_empty : 1 = false;      /// CREATE TABLE ... EMPTY AS SELECT ...
     bool is_clone_as : 1 = false;          /// CREATE TABLE ... CLONE AS ...
     bool replace_view : 1 = false;         /// CREATE OR REPLACE VIEW
-    bool has_uuid : 1 = false;             /// CREATE TABLE x UUID '...'
+    bool has_uuid : 1 = false;             /// CREATE TABLE x UUID '...' with a non-`Nil` value (see `has_uuid_clause` for clause-presence tracking)
+    bool has_uuid_clause : 1 = false;      /// Parser saw an explicit `UUID '...'` clause, true even when the value is `Nil`
     bool is_dictionary : 1 = false;        /// CREATE DICTIONARY
     bool is_watermark_strictly_ascending : 1 = false; /// STRICTLY ASCENDING WATERMARK STRATEGY FOR WINDOW VIEW
     bool is_watermark_ascending : 1 = false;          /// ASCENDING WATERMARK STRATEGY FOR WINDOW VIEW

--- a/src/Parsers/ASTIdentifier.h
+++ b/src/Parsers/ASTIdentifier.h
@@ -85,6 +85,10 @@ public:
     ASTPtr clone() const override;
 
     UUID uuid = UUIDHelpers::Nil;  // FIXME(ilezhankin): make private
+    /// True iff the parser saw an explicit `UUID '...'` clause, set even when the parsed value is `Nil`.
+    /// Use this (not `uuid != UUIDHelpers::Nil`) when you need to distinguish "user wrote `UUID '...'`"
+    /// from "no UUID clause": explicit `UUID '00000000-0000-0000-0000-000000000000'` parses to `Nil`.
+    bool has_uuid = false;
 
     StorageID getTableId() const;
     String getDatabaseName() const;

--- a/src/Parsers/ExpressionElementParsers.cpp
+++ b/src/Parsers/ExpressionElementParsers.cpp
@@ -457,6 +457,7 @@ bool ParserCompoundIdentifier::parseImpl(Pos & pos, ASTPtr & node, Expected & ex
 
     ParserKeyword s_uuid(Keyword::UUID);
     UUID uuid = UUIDHelpers::Nil;
+    bool has_uuid_clause = false;
 
     if (table_name_with_optional_uuid)
     {
@@ -470,11 +471,13 @@ bool ParserCompoundIdentifier::parseImpl(Pos & pos, ASTPtr & node, Expected & ex
             if (!uuid_p.parse(pos, ast_uuid, expected))
                 return false;
             uuid = parseFromString<UUID>(ast_uuid->as<ASTLiteral>()->value.safeGet<String>());
+            has_uuid_clause = true;
         }
 
         if (parts.size() == 1) node = make_intrusive<ASTTableIdentifier>(parts[0], std::move(params));
         else node = make_intrusive<ASTTableIdentifier>(parts[0], parts[1], std::move(params));
         node->as<ASTTableIdentifier>()->uuid = uuid;
+        node->as<ASTTableIdentifier>()->has_uuid = has_uuid_clause;
     }
     else
         node = make_intrusive<ASTIdentifier>(std::move(parts), false, std::move(params));

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -856,6 +856,7 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
         query->table = table_id->getTable();
         query->uuid = table_id->uuid;
         query->has_uuid = table_id->uuid != UUIDHelpers::Nil;
+        query->has_uuid_clause = table_id->has_uuid;
         query->setIsTemporary(is_temporary);
 
         query->attach_as_replicated = attach_as_replicated;
@@ -1014,6 +1015,7 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
     query->table = table_id->getTable();
     query->uuid = table_id->uuid;
     query->has_uuid = table_id->uuid != UUIDHelpers::Nil;
+    query->has_uuid_clause = table_id->has_uuid;
     query->cluster = cluster_str;
 
     if (query->database)
@@ -1467,6 +1469,7 @@ bool ParserCreateDatabaseQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & e
     if (!name_p.parse(pos, database, expected))
         return false;
 
+    bool has_uuid_clause = false;
     if (s_uuid.ignore(pos, expected))
     {
         ParserStringLiteral uuid_p;
@@ -1474,6 +1477,7 @@ bool ParserCreateDatabaseQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & e
         if (!uuid_p.parse(pos, ast_uuid, expected))
             return false;
         uuid = parseFromString<UUID>(ast_uuid->as<ASTLiteral>()->value.safeGet<String>());
+        has_uuid_clause = true;
     }
 
     if (s_on.ignore(pos, expected))
@@ -1496,6 +1500,7 @@ bool ParserCreateDatabaseQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & e
 
     query->uuid = uuid;
     query->has_uuid = uuid != UUIDHelpers::Nil;
+    query->has_uuid_clause = has_uuid_clause;
     query->cluster = cluster_str;
     query->database = database;
 

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -857,6 +857,7 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
         query->uuid = table_id->uuid;
         query->has_uuid = table_id->uuid != UUIDHelpers::Nil;
         query->has_uuid_clause = table_id->has_uuid;
+        query->has_inner_uuid_clause = to_inner_uuid != nullptr;
         query->setIsTemporary(is_temporary);
 
         query->attach_as_replicated = attach_as_replicated;
@@ -1016,6 +1017,7 @@ bool ParserCreateTableQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expe
     query->uuid = table_id->uuid;
     query->has_uuid = table_id->uuid != UUIDHelpers::Nil;
     query->has_uuid_clause = table_id->has_uuid;
+    query->has_inner_uuid_clause = to_inner_uuid != nullptr;
     query->cluster = cluster_str;
 
     if (query->database)

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -1272,6 +1272,8 @@ bool ParserCreateWindowViewQuery::parseImpl(Pos & pos, ASTPtr & node, Expected &
     query->database = table_id->getDatabase();
     query->table = table_id->getTable();
     query->uuid = table_id->uuid;
+    query->has_uuid = table_id->uuid != UUIDHelpers::Nil;
+    query->has_uuid_clause = table_id->has_uuid;
     query->cluster = cluster_str;
 
     if (query->database)
@@ -1760,6 +1762,8 @@ bool ParserCreateViewQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     query->database = table_id->getDatabase();
     query->table = table_id->getTable();
     query->uuid = table_id->uuid;
+    query->has_uuid = table_id->uuid != UUIDHelpers::Nil;
+    query->has_uuid_clause = table_id->has_uuid;
     query->cluster = cluster_str;
 
     if (query->database)
@@ -1993,6 +1997,8 @@ bool ParserCreateDictionaryQuery::parseImpl(IParser::Pos & pos, ASTPtr & node, E
     query->database = dict_id->getDatabase();
     query->table = dict_id->getTable();
     query->uuid = dict_id->uuid;
+    query->has_uuid = dict_id->uuid != UUIDHelpers::Nil;
+    query->has_uuid_clause = dict_id->has_uuid;
 
     if (query->database)
         query->children.push_back(query->database);

--- a/tests/queries/0_stateless/04247_attach_table_storage_clauses_without_engine_error.reference
+++ b/tests/queries/0_stateless/04247_attach_table_storage_clauses_without_engine_error.reference
@@ -1,0 +1,2 @@
+MergeTree ORDER BY id SETTINGS index_granularity = 8192
+MergeTree ORDER BY id SETTINGS index_granularity = 8192

--- a/tests/queries/0_stateless/04247_attach_table_storage_clauses_without_engine_error.sql
+++ b/tests/queries/0_stateless/04247_attach_table_storage_clauses_without_engine_error.sql
@@ -5,7 +5,7 @@
 -- path reads the table definition from stored metadata and overwrites anything the
 -- user typed. The parser allows `SETTINGS`, `ORDER BY`, `PARTITION BY`, etc. without
 -- an `ENGINE` to support `default_table_engine` on `CREATE`, but for `ATTACH` the
--- same syntax produced no error and no effect — users assumed their settings took
+-- same syntax produced no error and no effect, and users assumed their settings took
 -- effect. We now reject this with `BAD_ARGUMENTS` so the user notices.
 --
 -- However `ATTACH TABLE t SETTINGS log_comment = 'foo';` is a legitimate, supported

--- a/tests/queries/0_stateless/04247_attach_table_storage_clauses_without_engine_error.sql
+++ b/tests/queries/0_stateless/04247_attach_table_storage_clauses_without_engine_error.sql
@@ -110,6 +110,28 @@ ATTACH TABLE t_104791 TO INNER UUID '00000000-0000-0000-0000-000000000000'; -- {
 ATTACH TABLE t_104791;
 DROP TABLE t_104791;
 
+-- Dictionary cases. `ParserCreateDictionaryQuery::parseImpl` previously copied
+-- `dict_id->uuid` to `query->uuid` but did not propagate `dict_id->has_uuid` to
+-- `query->has_uuid_clause`. With the switch from the value-based check to
+-- `has_uuid_clause`, that left the dictionary path bypassing the guard. The
+-- fix propagates both flags in the dictionary parser.
+DROP DICTIONARY IF EXISTS d_104791;
+CREATE DICTIONARY d_104791 (id UInt32, value String) PRIMARY KEY id
+    SOURCE(NULL()) LAYOUT(FLAT()) LIFETIME(0);
+DETACH DICTIONARY d_104791;
+
+-- 16. `ATTACH DICTIONARY d UUID '...'` with a non-`Nil` UUID: silently dropped
+--     before this patch via the parser-propagation gap described above.
+ATTACH DICTIONARY d_104791 UUID '00000000-0000-0000-0000-000000000001'; -- { serverError BAD_ARGUMENTS }
+
+-- 17. `ATTACH DICTIONARY d UUID '...'` with an explicit `Nil` UUID: same gap,
+--     same fix.
+ATTACH DICTIONARY d_104791 UUID '00000000-0000-0000-0000-000000000000'; -- { serverError BAD_ARGUMENTS }
+
+-- Plain short `ATTACH DICTIONARY` still works.
+ATTACH DICTIONARY d_104791;
+DROP DICTIONARY d_104791;
+
 -- Materialized view cases. The parser accepts `ATTACH MATERIALIZED VIEW t ...`
 -- with REFRESH, TO target, and AS SELECT clauses; before this patch all of
 -- them were silently dropped by the short-ATTACH path. The guard now rejects
@@ -124,14 +146,14 @@ CREATE TABLE t_mv_104791_other_target (id UInt32, x UInt32) ENGINE = MergeTree O
 CREATE MATERIALIZED VIEW t_mv_104791 REFRESH EVERY 1 HOUR TO t_mv_104791_target AS SELECT 1 AS id, 2 AS x;
 DETACH TABLE t_mv_104791;
 
--- 16. ATTACH MV with a different REFRESH schedule: silently dropped before this
+-- 18. ATTACH MV with a different REFRESH schedule: silently dropped before this
 --     patch (the stored REFRESH EVERY 1 HOUR replaced the user's EVERY 1 YEAR).
 ATTACH MATERIALIZED VIEW t_mv_104791 REFRESH EVERY 1 YEAR TO t_mv_104791_target AS SELECT 5 AS id, 6 AS x; -- { serverError BAD_ARGUMENTS }
 
--- 17. ATTACH MV with a different TO target: silently dropped before this patch.
+-- 19. ATTACH MV with a different TO target: silently dropped before this patch.
 ATTACH MATERIALIZED VIEW t_mv_104791 TO t_mv_104791_other_target AS SELECT 5 AS id, 6 AS x; -- { serverError BAD_ARGUMENTS }
 
--- 18. ATTACH MV with a different AS SELECT: silently dropped before this patch.
+-- 20. ATTACH MV with a different AS SELECT: silently dropped before this patch.
 ATTACH MATERIALIZED VIEW t_mv_104791 TO t_mv_104791_target AS SELECT 5 AS id, 6 AS x; -- { serverError BAD_ARGUMENTS }
 
 -- Restore the MV so cleanup works.

--- a/tests/queries/0_stateless/04247_attach_table_storage_clauses_without_engine_error.sql
+++ b/tests/queries/0_stateless/04247_attach_table_storage_clauses_without_engine_error.sql
@@ -76,6 +76,22 @@ ATTACH TABLE t_104791 CLONE AS t_104791; -- { serverError BAD_ARGUMENTS }
 --     by stored metadata in the short-ATTACH path below).
 ATTACH TABLE t_104791 UUID '00000000-0000-0000-0000-000000000001'; -- { serverError BAD_ARGUMENTS }
 
+-- 12. Explicit `Nil` UUID on a short ATTACH: also silently dropped before this
+--     patch. `ParserCompoundIdentifier` parses `UUID '...'` into `table_id->uuid`,
+--     and `Nil == Nil` so the value-based check we used previously missed this
+--     case. The fix is the `has_uuid_clause` flag on `ASTTableIdentifier`, which
+--     records that the parser actually saw the `UUID '...'` clause regardless of
+--     value, and which propagates into `ASTCreateQuery::has_uuid_clause`.
+ATTACH TABLE t_104791 UUID '00000000-0000-0000-0000-000000000000'; -- { serverError BAD_ARGUMENTS }
+
+-- 13. `FROM '/path'` on an `ATTACH TABLE`: silently dropped before this patch.
+--     The parser sets `create.has_attach_from_path` and `create.attach_from_path`,
+--     but `create = create_query` in the short-ATTACH path replaces both with the
+--     stored AST. The legitimate use of `FROM` is `ATTACH TABLE t (columns) FROM
+--     '/path' ENGINE = ...` (long ATTACH), which has a columns list and so is
+--     not affected by this guard.
+ATTACH TABLE t_104791 FROM '/var/lib/clickhouse/detached/t_104791'; -- { serverError BAD_ARGUMENTS }
+
 -- Restore the table so cleanup at the end works.
 ATTACH TABLE t_104791;
 DROP TABLE t_104791;
@@ -94,14 +110,14 @@ CREATE TABLE t_mv_104791_other_target (id UInt32, x UInt32) ENGINE = MergeTree O
 CREATE MATERIALIZED VIEW t_mv_104791 REFRESH EVERY 1 HOUR TO t_mv_104791_target AS SELECT 1 AS id, 2 AS x;
 DETACH TABLE t_mv_104791;
 
--- 12. ATTACH MV with a different REFRESH schedule: silently dropped before this
+-- 14. ATTACH MV with a different REFRESH schedule: silently dropped before this
 --     patch (the stored REFRESH EVERY 1 HOUR replaced the user's EVERY 1 YEAR).
 ATTACH MATERIALIZED VIEW t_mv_104791 REFRESH EVERY 1 YEAR TO t_mv_104791_target AS SELECT 5 AS id, 6 AS x; -- { serverError BAD_ARGUMENTS }
 
--- 13. ATTACH MV with a different TO target: silently dropped before this patch.
+-- 15. ATTACH MV with a different TO target: silently dropped before this patch.
 ATTACH MATERIALIZED VIEW t_mv_104791 TO t_mv_104791_other_target AS SELECT 5 AS id, 6 AS x; -- { serverError BAD_ARGUMENTS }
 
--- 14. ATTACH MV with a different AS SELECT: silently dropped before this patch.
+-- 16. ATTACH MV with a different AS SELECT: silently dropped before this patch.
 ATTACH MATERIALIZED VIEW t_mv_104791 TO t_mv_104791_target AS SELECT 5 AS id, 6 AS x; -- { serverError BAD_ARGUMENTS }
 
 -- Restore the MV so cleanup works.

--- a/tests/queries/0_stateless/04247_attach_table_storage_clauses_without_engine_error.sql
+++ b/tests/queries/0_stateless/04247_attach_table_storage_clauses_without_engine_error.sql
@@ -14,6 +14,11 @@
 -- interpreter runs, so by the time the guard sees the storage, those settings have
 -- already been hoisted out and `storage->settings` is reset. The guard must allow
 -- that case.
+--
+-- The guard also covers top-level `ASTCreateQuery` fields (`COMMENT`, `EMPTY`,
+-- `CLONE`, `REFRESH`, `TO target`, `AS SELECT`, etc.) that the parser may attach to
+-- an `ATTACH` query but that the short `ATTACH` path silently drops by overwriting
+-- the user-provided `create` with stored metadata.
 
 SET default_table_engine = 'MergeTree';
 
@@ -54,4 +59,48 @@ DETACH TABLE t_104791;
 ATTACH TABLE t_104791;
 SELECT engine_full FROM system.tables WHERE database = currentDatabase() AND name = 't_104791';
 
+-- 8. Top-level COMMENT on a short ATTACH: silently dropped before this patch,
+--    now rejected. The user-supplied comment would not have replaced the stored
+--    one because the short-ATTACH path overwrites `create.comment` from metadata.
+DETACH TABLE t_104791;
+ATTACH TABLE t_104791 COMMENT 'this comment would be silently dropped'; -- { serverError BAD_ARGUMENTS }
+
+-- 9. EMPTY AS SELECT on a short ATTACH: silently dropped before this patch.
+ATTACH TABLE t_104791 EMPTY AS SELECT 1; -- { serverError BAD_ARGUMENTS }
+
+-- 10. CLONE AS source on a short ATTACH: silently dropped before this patch.
+ATTACH TABLE t_104791 CLONE AS t_104791; -- { serverError BAD_ARGUMENTS }
+
+-- Restore the table so cleanup at the end works.
+ATTACH TABLE t_104791;
 DROP TABLE t_104791;
+
+-- Materialized view cases. The parser accepts `ATTACH MATERIALIZED VIEW t ...`
+-- with REFRESH, TO target, and AS SELECT clauses; before this patch all of
+-- them were silently dropped by the short-ATTACH path. The guard now rejects
+-- them so the user has to use `ATTACH MATERIALIZED VIEW t;` or `ALTER TABLE
+-- t MODIFY REFRESH ...` instead.
+DROP TABLE IF EXISTS t_mv_104791;
+DROP TABLE IF EXISTS t_mv_104791_target;
+DROP TABLE IF EXISTS t_mv_104791_other_target;
+
+CREATE TABLE t_mv_104791_target (id UInt32, x UInt32) ENGINE = MergeTree ORDER BY id;
+CREATE TABLE t_mv_104791_other_target (id UInt32, x UInt32) ENGINE = MergeTree ORDER BY id;
+CREATE MATERIALIZED VIEW t_mv_104791 REFRESH EVERY 1 HOUR TO t_mv_104791_target AS SELECT 1 AS id, 2 AS x;
+DETACH TABLE t_mv_104791;
+
+-- 11. ATTACH MV with a different REFRESH schedule: silently dropped before this
+--     patch (the stored REFRESH EVERY 1 HOUR replaced the user's EVERY 1 YEAR).
+ATTACH MATERIALIZED VIEW t_mv_104791 REFRESH EVERY 1 YEAR TO t_mv_104791_target AS SELECT 5 AS id, 6 AS x; -- { serverError BAD_ARGUMENTS }
+
+-- 12. ATTACH MV with a different TO target: silently dropped before this patch.
+ATTACH MATERIALIZED VIEW t_mv_104791 TO t_mv_104791_other_target AS SELECT 5 AS id, 6 AS x; -- { serverError BAD_ARGUMENTS }
+
+-- 13. ATTACH MV with a different AS SELECT: silently dropped before this patch.
+ATTACH MATERIALIZED VIEW t_mv_104791 TO t_mv_104791_target AS SELECT 5 AS id, 6 AS x; -- { serverError BAD_ARGUMENTS }
+
+-- Restore the MV so cleanup works.
+ATTACH TABLE t_mv_104791;
+DROP TABLE t_mv_104791;
+DROP TABLE t_mv_104791_target;
+DROP TABLE t_mv_104791_other_target;

--- a/tests/queries/0_stateless/04247_attach_table_storage_clauses_without_engine_error.sql
+++ b/tests/queries/0_stateless/04247_attach_table_storage_clauses_without_engine_error.sql
@@ -71,6 +71,11 @@ ATTACH TABLE t_104791 EMPTY AS SELECT 1; -- { serverError BAD_ARGUMENTS }
 -- 10. CLONE AS source on a short ATTACH: silently dropped before this patch.
 ATTACH TABLE t_104791 CLONE AS t_104791; -- { serverError BAD_ARGUMENTS }
 
+-- 11. Top-level UUID on a short ATTACH: silently dropped before this patch
+--     (the stored UUID overwrites the user-supplied one when `create` is replaced
+--     by stored metadata in the short-ATTACH path below).
+ATTACH TABLE t_104791 UUID '00000000-0000-0000-0000-000000000001'; -- { serverError BAD_ARGUMENTS }
+
 -- Restore the table so cleanup at the end works.
 ATTACH TABLE t_104791;
 DROP TABLE t_104791;
@@ -89,14 +94,14 @@ CREATE TABLE t_mv_104791_other_target (id UInt32, x UInt32) ENGINE = MergeTree O
 CREATE MATERIALIZED VIEW t_mv_104791 REFRESH EVERY 1 HOUR TO t_mv_104791_target AS SELECT 1 AS id, 2 AS x;
 DETACH TABLE t_mv_104791;
 
--- 11. ATTACH MV with a different REFRESH schedule: silently dropped before this
+-- 12. ATTACH MV with a different REFRESH schedule: silently dropped before this
 --     patch (the stored REFRESH EVERY 1 HOUR replaced the user's EVERY 1 YEAR).
 ATTACH MATERIALIZED VIEW t_mv_104791 REFRESH EVERY 1 YEAR TO t_mv_104791_target AS SELECT 5 AS id, 6 AS x; -- { serverError BAD_ARGUMENTS }
 
--- 12. ATTACH MV with a different TO target: silently dropped before this patch.
+-- 13. ATTACH MV with a different TO target: silently dropped before this patch.
 ATTACH MATERIALIZED VIEW t_mv_104791 TO t_mv_104791_other_target AS SELECT 5 AS id, 6 AS x; -- { serverError BAD_ARGUMENTS }
 
--- 13. ATTACH MV with a different AS SELECT: silently dropped before this patch.
+-- 14. ATTACH MV with a different AS SELECT: silently dropped before this patch.
 ATTACH MATERIALIZED VIEW t_mv_104791 TO t_mv_104791_target AS SELECT 5 AS id, 6 AS x; -- { serverError BAD_ARGUMENTS }
 
 -- Restore the MV so cleanup works.

--- a/tests/queries/0_stateless/04247_attach_table_storage_clauses_without_engine_error.sql
+++ b/tests/queries/0_stateless/04247_attach_table_storage_clauses_without_engine_error.sql
@@ -92,6 +92,20 @@ ATTACH TABLE t_104791 UUID '00000000-0000-0000-0000-000000000000'; -- { serverEr
 --     not affected by this guard.
 ATTACH TABLE t_104791 FROM '/var/lib/clickhouse/detached/t_104791'; -- { serverError BAD_ARGUMENTS }
 
+-- 14. `TO INNER UUID '...'` on a short `ATTACH TABLE`: silently dropped before
+--     this patch. `ParserCreateTableQuery` parses `TO INNER UUID` into a local
+--     variable BEFORE the short-ATTACH early return, but the short-ATTACH branch
+--     does not persist it into the query AST. The non-short branch persists it
+--     into `create.targets` (already covered by the guard), so we only need the
+--     new `has_inner_uuid_clause` flag to also catch the short-ATTACH shape.
+ATTACH TABLE t_104791 TO INNER UUID '00000000-0000-0000-0000-000000000001'; -- { serverError BAD_ARGUMENTS }
+
+-- 15. Explicit `Nil` `TO INNER UUID` on a short `ATTACH TABLE`: same code path as
+--     case 14, but with the all-zero UUID. The parser sets
+--     `has_inner_uuid_clause = true` based on the presence of the literal, not
+--     its value, so the all-zero case is also rejected.
+ATTACH TABLE t_104791 TO INNER UUID '00000000-0000-0000-0000-000000000000'; -- { serverError BAD_ARGUMENTS }
+
 -- Restore the table so cleanup at the end works.
 ATTACH TABLE t_104791;
 DROP TABLE t_104791;
@@ -110,14 +124,14 @@ CREATE TABLE t_mv_104791_other_target (id UInt32, x UInt32) ENGINE = MergeTree O
 CREATE MATERIALIZED VIEW t_mv_104791 REFRESH EVERY 1 HOUR TO t_mv_104791_target AS SELECT 1 AS id, 2 AS x;
 DETACH TABLE t_mv_104791;
 
--- 14. ATTACH MV with a different REFRESH schedule: silently dropped before this
+-- 16. ATTACH MV with a different REFRESH schedule: silently dropped before this
 --     patch (the stored REFRESH EVERY 1 HOUR replaced the user's EVERY 1 YEAR).
 ATTACH MATERIALIZED VIEW t_mv_104791 REFRESH EVERY 1 YEAR TO t_mv_104791_target AS SELECT 5 AS id, 6 AS x; -- { serverError BAD_ARGUMENTS }
 
--- 15. ATTACH MV with a different TO target: silently dropped before this patch.
+-- 17. ATTACH MV with a different TO target: silently dropped before this patch.
 ATTACH MATERIALIZED VIEW t_mv_104791 TO t_mv_104791_other_target AS SELECT 5 AS id, 6 AS x; -- { serverError BAD_ARGUMENTS }
 
--- 16. ATTACH MV with a different AS SELECT: silently dropped before this patch.
+-- 18. ATTACH MV with a different AS SELECT: silently dropped before this patch.
 ATTACH MATERIALIZED VIEW t_mv_104791 TO t_mv_104791_target AS SELECT 5 AS id, 6 AS x; -- { serverError BAD_ARGUMENTS }
 
 -- Restore the MV so cleanup works.

--- a/tests/queries/0_stateless/04247_attach_table_storage_clauses_without_engine_error.sql
+++ b/tests/queries/0_stateless/04247_attach_table_storage_clauses_without_engine_error.sql
@@ -1,0 +1,57 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/104791
+--
+-- `ATTACH TABLE name <storage clauses>;` without `ENGINE` and without a columns list
+-- used to silently drop the user-provided storage clauses, because the short ATTACH
+-- path reads the table definition from stored metadata and overwrites anything the
+-- user typed. The parser allows `SETTINGS`, `ORDER BY`, `PARTITION BY`, etc. without
+-- an `ENGINE` to support `default_table_engine` on `CREATE`, but for `ATTACH` the
+-- same syntax produced no error and no effect — users assumed their settings took
+-- effect. We now reject this with `BAD_ARGUMENTS` so the user notices.
+--
+-- However `ATTACH TABLE t SETTINGS log_comment = 'foo';` is a legitimate, supported
+-- pattern: `InterpreterSetQuery::applySettingsFromQuery` extracts session settings
+-- out of `create.storage->settings` and applies them to the context BEFORE this
+-- interpreter runs, so by the time the guard sees the storage, those settings have
+-- already been hoisted out and `storage->settings` is reset. The guard must allow
+-- that case.
+
+SET default_table_engine = 'MergeTree';
+
+DROP TABLE IF EXISTS t_104791;
+CREATE TABLE t_104791 (id UInt32) ORDER BY id;
+
+-- 1. SETTINGS with an engine (MergeTree) setting and no ENGINE: should error.
+--    `max_part_loading_threads` is neither a session setting nor a builtin
+--    MergeTree setting, so `applySettingsFromQuery` leaves it inside
+--    `storage->settings`. The guard catches it.
+DETACH TABLE t_104791;
+ATTACH TABLE t_104791 SETTINGS max_part_loading_threads = 16; -- { serverError BAD_ARGUMENTS }
+
+-- 2. SETTINGS with a MergeTree-builtin setting (`index_granularity`): should error.
+--    `applySettingsFromQuery` keeps MergeTree builtin settings inside
+--    `storage->settings`.
+ATTACH TABLE t_104791 SETTINGS index_granularity = 100; -- { serverError BAD_ARGUMENTS }
+
+-- 3. ORDER BY without ENGINE: same bug class, same fix.
+ATTACH TABLE t_104791 ORDER BY id; -- { serverError BAD_ARGUMENTS }
+
+-- 4. PARTITION BY without ENGINE: same.
+ATTACH TABLE t_104791 PARTITION BY id; -- { serverError BAD_ARGUMENTS }
+
+-- 5. Mixed (session + MergeTree builtin) SETTINGS: must still error, because
+--    after `applySettingsFromQuery` extracts `log_comment`, the MergeTree
+--    builtin setting `index_granularity` remains in `storage->settings`.
+ATTACH TABLE t_104791 SETTINGS log_comment = 'attach_test_104791', index_granularity = 100; -- { serverError BAD_ARGUMENTS }
+
+-- 6. Session-only SETTINGS (`log_comment`): must succeed. `applySettingsFromQuery`
+--    hoists `log_comment` to the context and resets `storage->settings`, so the
+--    guard sees an empty storage and falls through to the short-ATTACH path.
+ATTACH TABLE t_104791 SETTINGS log_comment = 'attach_test_104791';
+SELECT engine_full FROM system.tables WHERE database = currentDatabase() AND name = 't_104791';
+
+-- 7. Short ATTACH (no storage clauses at all): must still work.
+DETACH TABLE t_104791;
+ATTACH TABLE t_104791;
+SELECT engine_full FROM system.tables WHERE database = currentDatabase() AND name = 't_104791';
+
+DROP TABLE t_104791;


### PR DESCRIPTION
Re-land of #104800 with a narrower guard that does not break legitimate session-settings `ATTACH`.

PR #104800 was merged then reverted in #105032 because it rejected `ATTACH TABLE t SETTINGS log_comment = 'foo';` — a legitimate pattern internal CI relies on (per @Algunenano in #104791). This re-land fixes the same silent-drop bug from #104791 but only rejects `ATTACH` queries that actually carry non-engine storage clauses that would be silently dropped.

### Background

`ParserCreateQuery.cpp` allows `SETTINGS` (and `ORDER BY`, `PARTITION BY`, etc.) without `ENGINE` for tables (#73120) so that `CREATE TABLE t (...) SETTINGS ...` works under `default_table_engine`. For `ATTACH` the same syntax used to be parsed without error and then silently dropped: the short-`ATTACH` path at `InterpreterCreateQuery.cpp:1571` reads the stored metadata and overwrites `create.storage` / `create.columns_list`, discarding whatever the user typed.

### Why the broad guard from #104800 broke CI

`InterpreterSetQuery::applySettingsFromQuery` runs in `executeQueryImpl` before `InterpreterCreateQuery::createTable`. For `ATTACH TABLE t SETTINGS log_comment = 'foo';` it does what it does for `CREATE`: it walks `create.storage->settings`, splits session settings (anything present in the per-query settings registry but not in the storage's builtin-setting list) from engine settings, applies the session settings to the context, and resets `storage->settings` to `nullptr` if nothing engine-specific is left. The user-visible result is that `log_comment` takes effect and the table is re-attached using stored metadata.

The reverted guard tripped on this case because it only checked that `create.storage` *existed* and had no `engine`. By the time the guard ran, the storage object's only meaningful field had already been hoisted out by `applySettingsFromQuery`, so rejecting was wrong.

### The narrower guard

Check the non-engine storage fields directly instead of just looking at the storage object. The guard now fires only when at least one of `partition_by`, `primary_key`, `order_by`, `sample_by`, `ttl_table`, `unique_key`, or `settings` is still populated at the point `createTable` runs — i.e. the user supplied a storage clause that survived the session-settings hoisting and would otherwise be silently dropped.

| Query                                                                       | Result                          | Reason                                                                                          |
|-----------------------------------------------------------------------------|---------------------------------|-------------------------------------------------------------------------------------------------|
| `ATTACH TABLE t;`                                                           | OK (short ATTACH)               | no storage clauses                                                                              |
| `ATTACH TABLE t SETTINGS log_comment = 'foo';`                              | OK (short ATTACH, session bind) | `applySettingsFromQuery` hoists `log_comment` to context and clears `storage->settings`         |
| `ATTACH TABLE t SETTINGS index_granularity = 100;`                          | `BAD_ARGUMENTS`                 | `index_granularity` is a `MergeTree` builtin → stays in `storage->settings`                     |
| `ATTACH TABLE t SETTINGS max_part_loading_threads = 16;`                    | `BAD_ARGUMENTS`                 | non-session setting → stays in `storage->settings`                                              |
| `ATTACH TABLE t SETTINGS log_comment = 'foo', index_granularity = 100;`     | `BAD_ARGUMENTS`                 | `log_comment` is hoisted, `index_granularity` remains in `storage->settings`                    |
| `ATTACH TABLE t ORDER BY id;` / `... PARTITION BY id;`                      | `BAD_ARGUMENTS`                 | `storage->order_by` / `storage->partition_by` set                                               |

The guard still fires before `database->shouldReplicateQuery(...)` and `executeQueryOnCluster(...)`, so distributed / `Replicated` `ATTACH` is rejected at the initiator instead of silently dropping on each replica.

### Tests

`04247_attach_table_storage_clauses_without_engine_error` covers all six rows of the table above.

### Reverted PR

- #104800 (merged, then reverted via #105032)
- Original issue: #104791

Closes #104791.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

`ATTACH TABLE name <clauses>;` queries that supply storage clauses (`ORDER BY`, `PARTITION BY`, `PRIMARY KEY`, `SAMPLE BY`, `TTL`, `UNIQUE KEY`, or engine `SETTINGS`) without an `ENGINE` now throw `BAD_ARGUMENTS` instead of silently re-attaching the table with its stored definition and discarding the user-supplied clauses. Query-level session `SETTINGS` (such as `log_comment`) are still applied. Use `ATTACH TABLE t;` to re-attach with stored metadata, or `ALTER TABLE t MODIFY SETTING ...` after `ATTACH` to change settings.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.88`
<!-- ch-version-info:end -->