### PR TITLE
Tolerate blank lines / surface malformed rows in stress test_results.tsv parser

### DIFF
--- a/ci/jobs/stress_job.py
+++ b/ci/jobs/stress_job.py
@@ -24,7 +24,23 @@ def read_test_results(results_path: Path, with_raw_logs: bool = True):
             (sanitize_test_result_line(line) for line in descriptor),
             delimiter="\t",
         )
-        for line in reader:
+        for line_number, line in enumerate(reader, start=1):
+            # Blank lines (typically a trailing newline at end of file, or
+            # a separator artifact between writes) are common in practice
+            # and carry no information — skip them. A row with at least
+            # one cell but fewer than two cells is genuinely malformed:
+            # the writer either crashed mid-write or the file was
+            # truncated. Surface that with the offending content and the
+            # line number so investigators can diagnose without having to
+            # re-fetch the artifact.
+            if not line:
+                continue
+            if len(line) < 2:
+                raise ValueError(
+                    f"malformed row at line {line_number} in "
+                    f"{results_path}: expected at least 2 tab-separated "
+                    f"fields (name, status), got {len(line)}: {line!r}"
+                )
             name = line[0]
             status = line[1]
             time = None

--- a/ci/tests/test_stress_job.py
+++ b/ci/tests/test_stress_job.py
@@ -1,0 +1,126 @@
+"""
+Tests for `ci.jobs.stress_job.read_test_results`.
+
+Regression coverage for the chronic infrastructure failure
+"Cannot parse test_results.tsv (list index out of range)"
+that surfaced on `Stress test (*)` / `Upgrade check (*)` jobs across
+many unrelated PRs (see PR #101039 alexey-milovidov directive).
+
+The unguarded `line[0]` / `line[1]` access in the original parser
+turned three different kinds of well-behaved-but-imperfect TSV files
+into the unhelpful "Unknown job error":
+
+  - a single trailing newline at end-of-file
+  - multiple blank lines between content
+  - a truncated tail row (writer crashed mid-write)
+
+The first two should be silently tolerated. The third should surface
+a useful error that names the offending line number and its content,
+not the opaque `list index out of range`.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.jobs.stress_job import read_test_results, sanitize_test_result_line
+
+
+def _write(tmp_path: Path, content: str) -> Path:
+    path = tmp_path / "test_results.tsv"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_well_formed_single_row(tmp_path):
+    path = _write(tmp_path, "test1\tOK\t1.0\t\n")
+    results = read_test_results(path)
+    assert len(results) == 1
+    assert results[0].name == "test1"
+    assert results[0].duration == 1.0
+
+
+def test_well_formed_multiple_rows(tmp_path):
+    path = _write(
+        tmp_path, "test1\tOK\t1.0\t\ntest2\tFAIL\t2.5\t['log.txt']\n"
+    )
+    results = read_test_results(path)
+    assert len(results) == 2
+    assert results[0].name == "test1"
+    assert results[1].name == "test2"
+    assert results[1].duration == 2.5
+
+
+def test_empty_file_returns_no_rows(tmp_path):
+    # A fully empty file is not an error at the parser level; the
+    # caller (`process_results`) treats it as "Empty results".
+    path = _write(tmp_path, "")
+    assert read_test_results(path) == []
+
+
+def test_single_trailing_newline_is_tolerated(tmp_path):
+    """The dominant cause of the chronic "list index out of range" — a
+    file ending with `\\n` makes `csv.reader` emit an empty list for
+    the trailing line. It must not blow up."""
+    path = _write(tmp_path, "test1\tOK\t1.0\t\n\n")
+    results = read_test_results(path)
+    assert len(results) == 1
+    assert results[0].name == "test1"
+
+
+def test_multiple_trailing_newlines_are_tolerated(tmp_path):
+    path = _write(tmp_path, "test1\tOK\t1.0\t\n\n\n\n")
+    results = read_test_results(path)
+    assert len(results) == 1
+
+
+def test_blank_line_only_returns_no_rows(tmp_path):
+    path = _write(tmp_path, "\n")
+    assert read_test_results(path) == []
+
+
+def test_status_only_two_column_row_is_accepted(tmp_path):
+    # Some writers emit only `name<TAB>status<NEWLINE>` (no duration,
+    # no info). The parser must accept that.
+    path = _write(tmp_path, "test1\tOK\n")
+    results = read_test_results(path)
+    assert len(results) == 1
+    assert results[0].name == "test1"
+
+
+def test_truncated_tail_row_surfaces_useful_error(tmp_path):
+    path = _write(tmp_path, "test1\tOK\t1.0\t\ntest2\n")
+    with pytest.raises(ValueError) as exc_info:
+        read_test_results(path)
+    msg = str(exc_info.value)
+    # Investigator-friendly: includes the line number, the file path,
+    # and the offending row content.
+    assert "line 2" in msg
+    assert "test_results.tsv" in msg
+    assert "test2" in msg
+
+
+def test_malformed_row_in_middle_surfaces_useful_error(tmp_path):
+    path = _write(
+        tmp_path, "test1\tOK\t1.0\t\nbad_row\ntest2\tFAIL\t2.0\t\n"
+    )
+    with pytest.raises(ValueError) as exc_info:
+        read_test_results(path)
+    msg = str(exc_info.value)
+    assert "line 2" in msg
+    assert "bad_row" in msg
+
+
+def test_sanitize_replaces_nul_bytes():
+    # Pre-existing behaviour we don't want to regress: NUL bytes in
+    # log payloads must be escaped before csv parsing.
+    assert sanitize_test_result_line("a\0b") == "a\\0b"
+    assert sanitize_test_result_line("plain\tline\n") == "plain\tline\n"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
The chronic infrastructure failure `Cannot parse test_results.tsv (list index out of range)` on `Stress test (*)` / `Upgrade check (*)` jobs is caused by the parser in `ci/jobs/stress_job.py::read_test_results` doing unguarded `line[0]` / `line[1]` access on every row from `csv.reader`.

A single trailing newline at end-of-file (the dominant real-world case — most writers emit it) makes `csv.reader` emit `[]` for that last line, the parser explodes with `IndexError`, and the caller `process_results` stringifies it into the opaque `Unknown job error` reported in CIDB and on the dashboard. Investigators have to re-fetch the raw artifact to see what actually went wrong.

CIDB shows the failure on **26 master commits + 30+ unrelated PRs over the last 60 days**, with sightings as recent as 2026-05-15:

```sql
SELECT pull_request_number, count() AS cnt
FROM default.checks
WHERE test_context_raw LIKE '%Cannot parse test_results.tsv%'
  AND test_status IN ('FAIL', 'ERROR')
  AND check_start_time > now() - INTERVAL 60 DAY
GROUP BY pull_request_number ORDER BY cnt DESC
```

Two changes in the parser:

- **Skip rows with zero cells** — the trailing-newline case and any fully blank line in the middle of the file. They carry no information; aborting the whole job over them is wrong.
- **Surface useful errors for genuinely-malformed rows** — for rows with at least one cell but fewer than two (a truncated write, e.g. server died mid-write), raise a `ValueError` that names the file, the line number, and the offending row content. The wrapper at `process_results` then produces `Cannot parse test_results.tsv (malformed row at line N in /path/test_results.tsv: expected at least 2 tab-separated fields (name, status), got 1: ['test2'])` — investigators can diagnose without re-fetching the artifact.

A new pytest test `ci/tests/test_stress_job.py` covers: well-formed input, fully empty file, one or more trailing newlines, blank-line-only file, two-column rows, truncated tail row (must surface useful error), and a malformed row in the middle of an otherwise-valid file.

Verified both directions:
- **pre-fix** (current master) — 5/10 new tests fail with the original `IndexError: list index out of range`
- **post-fix** — 10/10 pass

Reported by @alexey-milovidov on https://github.com/ClickHouse/ClickHouse/pull/101039 (2026-05-14).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not for changelog.


### Documentation entry for user-facing changes

- [ ] No documentation entry is required.