### PR TITLE
Fix ClickBench job: allow `/dev/shm/clickhouse/` as filesystem cache path

### DIFF
--- a/ci/jobs/clickbench.py
+++ b/ci/jobs/clickbench.py
@@ -18,6 +18,13 @@ def main():
 
         def install():
             res = ch.install_clickbench_config()
+            # The ClickBench `create.sql` attaches `hits` on a cached disk
+            # rooted at `/dev/shm/clickhouse/`; ship the matching server-side
+            # allowed-directory override alongside it.
+            res = res and Shell.check(
+                f"cp ./ci/jobs/scripts/clickbench/filesystem_caches_path.xml {temp_dir}/config.d/",
+                verbose=True,
+            )
             if info.is_local_run:
                 return res
             return res and ch.create_log_export_config()

--- a/ci/jobs/scripts/clickbench/filesystem_caches_path.xml
+++ b/ci/jobs/scripts/clickbench/filesystem_caches_path.xml
@@ -1,0 +1,10 @@
+<!--
+    The ClickBench `create.sql` attaches the `hits` table on a cached disk
+    rooted at `/dev/shm/clickhouse/`. The server validates that any
+    filesystem cache path lies inside `filesystem_caches_path` /
+    `custom_cached_disks_base_directory`, so point both at the same root.
+-->
+<clickhouse>
+    <filesystem_caches_path replace="replace">/dev/shm/clickhouse/</filesystem_caches_path>
+    <custom_cached_disks_base_directory replace="replace">/dev/shm/clickhouse/</custom_cached_disks_base_directory>
+</clickhouse>

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -322,19 +322,6 @@ profiles:
         file_path = f"{temp_dir}/users.d/allow_introspection_functions.yaml"
         with open(file_path, "w") as file:
             file.write(content)
-
-        # The ClickBench `create.sql` attaches the `hits` table on a cached disk
-        # rooted at `/dev/shm/clickhouse/`. The server validates that any
-        # filesystem cache path lies inside `filesystem_caches_path` /
-        # `custom_cached_disks_base_directory`, so point both at the same root.
-        fs_caches_path_xml = """<clickhouse>
-    <filesystem_caches_path replace="replace">/dev/shm/clickhouse/</filesystem_caches_path>
-    <custom_cached_disks_base_directory replace="replace">/dev/shm/clickhouse/</custom_cached_disks_base_directory>
-</clickhouse>
-"""
-        file_path = f"{temp_dir}/config.d/filesystem_caches_path.xml"
-        with open(file_path, "w") as file:
-            file.write(fs_caches_path_xml)
         return True
 
     def install_fuzzer_config(self):

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -322,6 +322,19 @@ profiles:
         file_path = f"{temp_dir}/users.d/allow_introspection_functions.yaml"
         with open(file_path, "w") as file:
             file.write(content)
+
+        # The ClickBench `create.sql` attaches the `hits` table on a cached disk
+        # rooted at `/dev/shm/clickhouse/`. The server validates that any
+        # filesystem cache path lies inside `filesystem_caches_path` /
+        # `custom_cached_disks_base_directory`, so point both at the same root.
+        fs_caches_path_xml = """<clickhouse>
+    <filesystem_caches_path replace="replace">/dev/shm/clickhouse/</filesystem_caches_path>
+    <custom_cached_disks_base_directory replace="replace">/dev/shm/clickhouse/</custom_cached_disks_base_directory>
+</clickhouse>
+"""
+        file_path = f"{temp_dir}/config.d/filesystem_caches_path.xml"
+        with open(file_path, "w") as file:
+            file.write(fs_caches_path_xml)
         return True
 
     def install_fuzzer_config(self):


### PR DESCRIPTION
The ClickBench job fails on master while attaching the `hits` table:

```
Code: 36. DB::Exception: Filesystem cache absolute path must lie inside `/tmp/filesystem_caches/`,
but have /dev/shm/clickhouse/: While processing disk(type = cache, path = '/dev/shm/clickhouse/', ...).
(BAD_ARGUMENTS)
```

`ci/jobs/scripts/clickbench/create.sql` mounts a cached disk at `/dev/shm/clickhouse/`, but the default
server config (`programs/server/config.d/filesystem_caches_path.xml`) pins both `filesystem_caches_path`
and `custom_cached_disks_base_directory` to `/tmp/filesystem_caches/`, and `RegisterDiskCache.cpp`
rejects any cache disk outside that root.

Override the two settings in `install_clickbench_config` so the allowed directory matches the path the
ClickBench `create.sql` actually uses.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=75fa606f4590bda023a727a000555ca8622b4266&name_0=MasterCI&name_1=ClickBench%20%28arm_release%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.699`
<!-- ch-version-info:end -->