### PR TITLE
Surface real callback exceptions in ZipArchiveReader instead of "Code = -100"

### DIFF
--- a/src/IO/Archives/ZipArchiveReader.cpp
+++ b/src/IO/Archives/ZipArchiveReader.cpp
@@ -41,18 +41,37 @@ namespace
     ///
     /// C++ exceptions must not propagate through the minizip C library (undefined behavior).
     /// All callbacks catch exceptions and store them for later re-throwing in C++ code.
+    ///
+    /// Exception capture happens at two levels:
+    ///  - in `StreamFromReadBuffer::stored_exception` — used during normal operation,
+    ///    rethrown by `rethrowIfNeeded()`.
+    ///  - in the shared `Opaque::stored_exception` accessible via every callback — used when
+    ///    `unzOpen2_64()` fails: minizip's internal cleanup then invokes `closeFileFunc()`
+    ///    which deletes the stream, leaving the in-stream exception unreachable. Storing a
+    ///    copy in `Opaque` (which lives on the caller's stack across `unzOpen2_64()`) keeps
+    ///    the original error available so we can surface it instead of the generic
+    ///    "Couldn't open zip archive" or "Code = -100" messages.
     class StreamFromReadBuffer
     {
     public:
+        struct Opaque
+        {
+            std::unique_ptr<SeekableReadBuffer> read_buffer;
+            UInt64 total_size = 0;
+            StreamFromReadBuffer * created_stream = nullptr;
+            std::exception_ptr stored_exception;
+        };
+
         struct OpenResult
         {
             RawHandle handle = nullptr;
             StreamFromReadBuffer * stream = nullptr;
+            std::exception_ptr stored_exception;
         };
 
         static OpenResult open(std::unique_ptr<SeekableReadBuffer> archive_read_buffer, UInt64 archive_size)
         {
-            StreamFromReadBuffer::Opaque opaque{std::move(archive_read_buffer), archive_size, nullptr};
+            Opaque opaque{std::move(archive_read_buffer), archive_size, nullptr, nullptr};
 
             zlib_filefunc64_def func_def;
             func_def.zopen64_file = &StreamFromReadBuffer::openFileFunc;
@@ -65,11 +84,17 @@ namespace
             func_def.opaque = &opaque;
 
             RawHandle handle = unzOpen2_64(/* path= */ nullptr, &func_def);
-            return {handle, opaque.created_stream};
+
+            /// If `unzOpen2_64` failed, minizip already called `closeFileFunc()`, so
+            /// `opaque.created_stream` now points to freed memory. Do NOT propagate it.
+            if (!handle)
+                return {nullptr, nullptr, std::move(opaque.stored_exception)};
+
+            return {handle, opaque.created_stream, nullptr};
         }
 
         /// Re-throws a stored exception from a callback, if any.
-        void rethrowIfNeeded()
+        void rethrowIfNeeded() const
         {
             if (stored_exception)
             {
@@ -80,24 +105,26 @@ namespace
         }
 
     private:
-        void storeException()
+        static void storeException(StreamFromReadBuffer & strm, void * opaque)
         {
-            if (!stored_exception)
-                stored_exception = std::current_exception();
+            auto ex = std::current_exception();
+            if (!strm.stored_exception)
+                strm.stored_exception = ex;
+            /// Also save it in the shared `Opaque` so we can recover the original
+            /// exception even when minizip destroys the stream during a failed open.
+            if (opaque)
+            {
+                auto & opq = *reinterpret_cast<Opaque *>(opaque);
+                if (!opq.stored_exception)
+                    opq.stored_exception = ex;
+            }
         }
 
         std::unique_ptr<SeekableReadBuffer> read_buffer;
         UInt64 start_offset = 0;
         UInt64 total_size = 0;
         bool at_end = false;
-        std::exception_ptr stored_exception;
-
-        struct Opaque
-        {
-            std::unique_ptr<SeekableReadBuffer> read_buffer;
-            UInt64 total_size = 0;
-            StreamFromReadBuffer * created_stream = nullptr;
-        };
+        mutable std::exception_ptr stored_exception;
 
         static void * openFileFunc(void * opaque, const void *, int)
         {
@@ -127,7 +154,7 @@ namespace
             return strm.stored_exception ? ZIP_ERRNO : ZIP_OK;
         }
 
-        static unsigned long readFileFunc(void *, void * stream, void * buf, unsigned long size) // NOLINT(google-runtime-int)
+        static unsigned long readFileFunc(void * opaque, void * stream, void * buf, unsigned long size) // NOLINT(google-runtime-int)
         {
             auto & strm = get(stream);
             if (strm.stored_exception)
@@ -140,12 +167,12 @@ namespace
             }
             catch (...)
             {
-                strm.storeException();
+                storeException(strm, opaque);
                 return 0;
             }
         }
 
-        static ZPOS64_T tellFunc(void *, void * stream)
+        static ZPOS64_T tellFunc(void * opaque, void * stream)
         {
             auto & strm = get(stream);
             if (strm.stored_exception)
@@ -158,12 +185,12 @@ namespace
             }
             catch (...)
             {
-                strm.storeException();
+                storeException(strm, opaque);
                 return static_cast<ZPOS64_T>(-1);
             }
         }
 
-        static long seekFunc(void *, void * stream, ZPOS64_T offset, int origin) // NOLINT(google-runtime-int)
+        static long seekFunc(void * opaque, void * stream, ZPOS64_T offset, int origin) // NOLINT(google-runtime-int)
         {
             auto & strm = get(stream);
             if (strm.stored_exception)
@@ -185,7 +212,7 @@ namespace
             }
             catch (...)
             {
-                strm.storeException();
+                storeException(strm, opaque);
                 return -1;
             }
         }
@@ -364,11 +391,23 @@ public:
             checkResult(err);
     }
 
-    void checkResult(int code) const { reader->checkResult(code); }
-    [[noreturn]] void showError(const String & message) const { reader->showError(message); }
+    /// Re-throw a stored callback exception first so the user sees the real cause
+    /// of the failure (e.g. a network error or `CANNOT_SEEK_THROUGH_FILE`) instead
+    /// of the cryptic minizip error code formatted by `ZipArchiveReader::checkResult`.
+    void checkResult(int code) const
+    {
+        rethrowStreamException();
+        reader->checkResult(code);
+    }
+
+    [[noreturn]] void showError(const String & message) const
+    {
+        rethrowStreamException();
+        reader->showError(message);
+    }
 
     /// Re-throws a stored exception from the stream's C callback, if any.
-    void rethrowStreamException()
+    void rethrowStreamException() const
     {
         if (stream)
             stream->rethrowIfNeeded();
@@ -715,11 +754,13 @@ ZipArchiveReader::RawHandleWithStream ZipArchiveReader::acquireRawHandle()
     }
 
     RawHandleWithStream result;
+    std::exception_ptr stored_exception;
     if (archive_read_function)
     {
         auto open_result = StreamFromReadBuffer::open(archive_read_function(), archive_size);
         result.handle = open_result.handle;
         result.stream = open_result.stream;
+        stored_exception = std::move(open_result.stored_exception);
     }
     else
     {
@@ -727,7 +768,26 @@ ZipArchiveReader::RawHandleWithStream ZipArchiveReader::acquireRawHandle()
     }
 
     if (!result.handle)
+    {
+        /// If a callback threw while reading the underlying buffer (e.g. an S3 seek
+        /// error during EOCD lookup), surface that original exception instead of the
+        /// generic `Couldn't open zip archive` message. Otherwise minizip's internal
+        /// error code (frequently `MZ_END_OF_LIST`) bubbles up as the unhelpful
+        /// `Code = -100` reported in issue #104681.
+        if (stored_exception)
+        {
+            try
+            {
+                std::rethrow_exception(stored_exception);
+            }
+            catch (Exception & e)
+            {
+                e.addMessage("while opening zip archive {}", quoteString(path_to_archive));
+                throw;
+            }
+        }
         throw Exception(ErrorCodes::CANNOT_UNPACK_ARCHIVE, "Couldn't open zip archive {}", quoteString(path_to_archive));
+    }
 
     return result;
 }

--- a/src/IO/Archives/ZipArchiveReader.cpp
+++ b/src/IO/Archives/ZipArchiveReader.cpp
@@ -48,9 +48,15 @@ namespace
     ///  - in the shared `Opaque::stored_exception` accessible via every callback — used when
     ///    `unzOpen2_64()` fails: minizip's internal cleanup then invokes `closeFileFunc()`
     ///    which deletes the stream, leaving the in-stream exception unreachable. Storing a
-    ///    copy in `Opaque` (which lives on the caller's stack across `unzOpen2_64()`) keeps
-    ///    the original error available so we can surface it instead of the generic
-    ///    "Couldn't open zip archive" or "Code = -100" messages.
+    ///    copy in `Opaque` keeps the original error available so we can surface it instead
+    ///    of the generic "Couldn't open zip archive" or "Code = -100" messages.
+    ///
+    /// `Opaque` is heap-allocated (via `std::shared_ptr`) and pinned for the entire lifetime
+    /// of the `unzFile` handle. Minizip stores the `opaque` pointer internally during
+    /// `unzOpen2_64` and dereferences it from every later callback (`readFileFunc`,
+    /// `seekFunc`, `tellFunc`); a stack-local `Opaque` would dangle after `open()` returns
+    /// successfully, so the owning shared pointer is propagated through `OpenResult` and
+    /// stored in `RawHandleWithStream::opaque`.
     class StreamFromReadBuffer
     {
     public:
@@ -67,11 +73,14 @@ namespace
             RawHandle handle = nullptr;
             StreamFromReadBuffer * stream = nullptr;
             std::exception_ptr stored_exception;
+            std::shared_ptr<Opaque> opaque;
         };
 
         static OpenResult open(std::unique_ptr<SeekableReadBuffer> archive_read_buffer, UInt64 archive_size)
         {
-            Opaque opaque{std::move(archive_read_buffer), archive_size, nullptr, nullptr};
+            auto opaque = std::make_shared<Opaque>();
+            opaque->read_buffer = std::move(archive_read_buffer);
+            opaque->total_size = archive_size;
 
             zlib_filefunc64_def func_def;
             func_def.zopen64_file = &StreamFromReadBuffer::openFileFunc;
@@ -81,16 +90,16 @@ namespace
             func_def.zseek64_file = &StreamFromReadBuffer::seekFunc;
             func_def.ztell64_file = &StreamFromReadBuffer::tellFunc;
             func_def.zerror_file = &StreamFromReadBuffer::testErrorFunc;
-            func_def.opaque = &opaque;
+            func_def.opaque = opaque.get();
 
             RawHandle handle = unzOpen2_64(/* path= */ nullptr, &func_def);
 
             /// If `unzOpen2_64` failed, minizip already called `closeFileFunc()`, so
-            /// `opaque.created_stream` now points to freed memory. Do NOT propagate it.
+            /// `opaque->created_stream` now points to freed memory. Do NOT propagate it.
             if (!handle)
-                return {nullptr, nullptr, std::move(opaque.stored_exception)};
+                return {nullptr, nullptr, std::move(opaque->stored_exception), nullptr};
 
-            return {handle, opaque.created_stream, nullptr};
+            return {handle, opaque->created_stream, nullptr, opaque};
         }
 
         /// Re-throws a stored exception from a callback, if any.
@@ -240,6 +249,9 @@ public:
         auto handle_info = reader->acquireRawHandle();
         raw_handle = handle_info.handle;
         stream = reinterpret_cast<StreamFromReadBuffer *>(handle_info.stream);
+        /// Pin the heap-allocated `StreamFromReadBuffer::Opaque` while the handle is checked
+        /// out — minizip dereferences the stored opaque pointer from every later callback.
+        opaque = std::move(handle_info.opaque);
     }
 
     ~HandleHolder()
@@ -254,7 +266,7 @@ public:
             {
                 tryLogCurrentException("ZipArchiveReader");
             }
-            reader->releaseRawHandle({raw_handle, stream});
+            reader->releaseRawHandle({raw_handle, stream, std::move(opaque)});
         }
     }
 
@@ -268,6 +280,7 @@ public:
         reader = std::exchange(src.reader, nullptr);
         raw_handle = std::exchange(src.raw_handle, nullptr);
         stream = std::exchange(src.stream, nullptr);
+        opaque = std::exchange(src.opaque, nullptr);
         file_name = std::exchange(src.file_name, {});
         file_info = std::exchange(src.file_info, {});
         return *this;
@@ -448,6 +461,10 @@ private:
     std::shared_ptr<ZipArchiveReader> reader;
     RawHandle raw_handle = nullptr;
     StreamFromReadBuffer * stream = nullptr;
+    /// Pins the heap-allocated `StreamFromReadBuffer::Opaque` for the whole time this handle
+    /// is checked out. Moved back into the free-handle slot in `~HandleHolder` so the cache
+    /// retains ownership across acquire/release cycles.
+    std::shared_ptr<void> opaque;
     mutable std::optional<String> file_name;
     mutable std::optional<FileInfoImpl> file_info;
 };
@@ -760,6 +777,12 @@ ZipArchiveReader::RawHandleWithStream ZipArchiveReader::acquireRawHandle()
         auto open_result = StreamFromReadBuffer::open(archive_read_function(), archive_size);
         result.handle = open_result.handle;
         result.stream = open_result.stream;
+        /// The heap-allocated `Opaque` must outlive the `unzFile` handle: minizip stores
+        /// `&opaque` internally during `unzOpen2_64` and dereferences it from every later
+        /// stream callback. Pinning it via the shared pointer keeps the post-open callbacks
+        /// from touching freed memory; the storage is released only when `unzClose()` runs
+        /// in the destructor of `ZipArchiveReader`.
+        result.opaque = std::move(open_result.opaque);
         stored_exception = std::move(open_result.stored_exception);
     }
     else

--- a/src/IO/Archives/ZipArchiveReader.h
+++ b/src/IO/Archives/ZipArchiveReader.h
@@ -5,6 +5,7 @@
 #if USE_MINIZIP
 #include <IO/Archives/IArchiveReader.h>
 #include <Common/VectorWithMemoryTracking.h>
+#include <memory>
 #include <mutex>
 
 
@@ -73,10 +74,18 @@ private:
     /// The stream pointer is opaque here (StreamFromReadBuffer* in the .cpp file).
     /// It's non-null when reading from a buffer via archive_read_function,
     /// null when reading from a file path.
+    ///
+    /// `opaque` keeps the heap-allocated `StreamFromReadBuffer::Opaque` struct alive
+    /// for the entire lifetime of the underlying `unzFile` handle. The minizip library
+    /// stores the `opaque` pointer internally during `unzOpen2_64` and dereferences it
+    /// from every subsequent stream callback (`readFileFunc`, `seekFunc`, `tellFunc`).
+    /// Allocating `Opaque` on the heap and pinning it via this shared pointer prevents
+    /// use-after-scope when post-open callbacks need to record exception state.
     struct RawHandleWithStream
     {
         RawHandle handle = nullptr;
         void * stream = nullptr;
+        std::shared_ptr<void> opaque;
     };
 
     RawHandleWithStream acquireRawHandle();

--- a/src/IO/tests/gtest_archive_reader_and_writer.cpp
+++ b/src/IO/tests/gtest_archive_reader_and_writer.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include "config.h"
 
+#include <atomic>
 #include <filesystem>
 
 #include <IO/Archives/ArchiveUtils.h>
@@ -1017,6 +1018,117 @@ TEST(ZipArchiveReaderTest, RethrowsCallbackExceptionOnOpen)
         /// If creation succeeded we must still trigger a failing seek; the EOCD lookup
         /// is performed lazily on the first `fileExists` / `getFileInfo` call.
         (void)reader->getAllFiles();
+        FAIL() << "Expected exception was not thrown";
+    }
+    catch (const Exception & e)
+    {
+        EXPECT_EQ(e.code(), ErrorCodes::CANNOT_SEEK_THROUGH_FILE)
+            << "Underlying CANNOT_SEEK_THROUGH_FILE must surface unchanged, got: " << e.displayText();
+        EXPECT_EQ(e.message().find("Code = -100"), String::npos)
+            << "Cryptic minizip code must not appear in user-visible message: " << e.message();
+    }
+}
+
+
+/// A `SeekableReadBuffer` whose callbacks can be switched into a failing mode AFTER the
+/// archive has been opened. The flag is held by an externally-owned `shared_ptr` so the
+/// test can flip it between the successful open and the first post-open callback.
+class SwitchableFailingReadBuffer : public SeekableReadBuffer
+{
+public:
+    SwitchableFailingReadBuffer(const String & data_, std::shared_ptr<std::atomic<bool>> fail_flag_)
+        : SeekableReadBuffer(nullptr, 0)
+        , data(data_)
+        , fail_flag(std::move(fail_flag_))
+    {
+    }
+
+    off_t seek(off_t off, int whence) override
+    {
+        if (fail_flag->load())
+            throw Exception(ErrorCodes::CANNOT_SEEK_THROUGH_FILE, "Forced post-open seek failure");
+        if (whence != SEEK_SET)
+            throw Exception(ErrorCodes::CANNOT_SEEK_THROUGH_FILE, "Only SEEK_SET allowed");
+        if (off < 0 || static_cast<size_t>(off) > data.size())
+            throw Exception(ErrorCodes::CANNOT_SEEK_THROUGH_FILE, "Seek out of bounds");
+
+        pos = nullptr;
+        working_buffer = Buffer(nullptr, nullptr);
+        position_in_file = off;
+        return off;
+    }
+
+    off_t getPosition() override
+    {
+        return static_cast<off_t>(position_in_file) - available();
+    }
+
+    bool nextImpl() override
+    {
+        if (fail_flag->load())
+            throw Exception(ErrorCodes::CANNOT_SEEK_THROUGH_FILE, "Forced post-open read failure");
+        if (position_in_file >= data.size())
+            return false;
+        size_t avail = data.size() - position_in_file;
+        size_t to_read = std::min<size_t>(avail, 1024);
+        buf.resize(to_read);
+        std::copy(data.begin() + position_in_file, data.begin() + position_in_file + to_read, buf.begin());
+        BufferBase::set(buf.data(), to_read, 0);
+        position_in_file += to_read;
+        return true;
+    }
+
+private:
+    const String & data;
+    std::shared_ptr<std::atomic<bool>> fail_flag;
+    std::vector<char> buf;
+    size_t position_in_file = 0;
+};
+
+
+/// Targets the dangling-`Opaque` use-after-scope pointed out by `clickhouse-gh[bot]` on
+/// PR #105103: minizip stores the `opaque` pointer internally during `unzOpen2_64` and
+/// dereferences it from every later callback (`readFileFunc`, `seekFunc`, `tellFunc`).
+/// Before the fix, `Opaque` was a stack-local in `StreamFromReadBuffer::open`, so any
+/// post-open callback that took the exception-capture path wrote to freed stack memory.
+/// This test triggers that exact path: open succeeds, then the underlying buffer is
+/// flipped into failure mode, causing the next stream callback to throw. With the fix,
+/// `Opaque` is heap-allocated and pinned for the handle's lifetime, so the post-open
+/// failure surfaces the underlying exception cleanly. Under ASan, this test would
+/// detect the dangling write without the fix.
+TEST(ZipArchiveReaderTest, RethrowsCallbackExceptionAfterOpenSucceeded)
+{
+    String archive_in_memory;
+    {
+        auto writer = createArchiveWriter("archive.zip", std::make_unique<WriteBufferFromString>(archive_in_memory));
+        auto out = writer->writeFile("file.txt");
+        /// Make the content large enough that reading it back requires several callback
+        /// invocations after open has completed.
+        writeString(getRandomASCIIString(16 * 1024), *out);
+        out->finalize();
+        writer->finalize();
+    }
+
+    auto fail_flag = std::make_shared<std::atomic<bool>>(false);
+    auto read_archive_func = [&]() -> std::unique_ptr<SeekableReadBuffer>
+    { return std::make_unique<SwitchableFailingReadBuffer>(archive_in_memory, fail_flag); };
+
+    /// Step 1: open the archive normally. `Opaque` is stored inside the handle; minizip
+    /// has captured a pointer to it.
+    auto reader = createArchiveReader("archive.zip", read_archive_func, archive_in_memory.size());
+    EXPECT_TRUE(reader->fileExists("file.txt"));
+
+    /// Step 2: flip the buffer into failure mode and trigger a post-open callback. With
+    /// the stack-local `Opaque` (pre-fix), the callback's `storeException` write would
+    /// dereference a dangling pointer; with the heap-allocated `Opaque` (post-fix), the
+    /// exception is surfaced cleanly.
+    fail_flag->store(true);
+
+    try
+    {
+        auto in = reader->readFile("file.txt", /*throw_on_not_found=*/true);
+        String content;
+        readStringUntilEOF(content, *in);
         FAIL() << "Expected exception was not thrown";
     }
     catch (const Exception & e)

--- a/src/IO/tests/gtest_archive_reader_and_writer.cpp
+++ b/src/IO/tests/gtest_archive_reader_and_writer.cpp
@@ -11,6 +11,7 @@
 #include <IO/ReadBufferFromFile.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/ReadHelpers.h>
+#include <IO/SeekableReadBuffer.h>
 #include <IO/WriteBufferFromFileBase.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/WriteHelpers.h>
@@ -24,6 +25,7 @@ namespace DB::ErrorCodes
 {
     extern const int CANNOT_PACK_ARCHIVE;
     extern const int CANNOT_UNPACK_ARCHIVE;
+    extern const int CANNOT_SEEK_THROUGH_FILE;
     extern const int LOGICAL_ERROR;
     extern const int NOT_IMPLEMENTED;
 }
@@ -916,6 +918,117 @@ TEST_P(ArchiveReaderAndWriterTest, WriteErrorProducesException)
     out.reset();
     writer->cancel();
 }
+
+
+#if USE_MINIZIP
+
+/// A `SeekableReadBuffer` that wraps another buffer but raises `CANNOT_SEEK_THROUGH_FILE`
+/// on the second seek. This mimics `ReadBufferFromS3` with `restricted_seek = true`,
+/// which throws once a GET stream has been started and a subsequent backward seek is needed.
+class SeekFailingReadBuffer : public SeekableReadBuffer
+{
+public:
+    explicit SeekFailingReadBuffer(const String & data_)
+        : SeekableReadBuffer(nullptr, 0)
+        , data(data_)
+    {
+    }
+
+    off_t seek(off_t off, int whence) override
+    {
+        if (whence != SEEK_SET)
+            throw Exception(ErrorCodes::CANNOT_SEEK_THROUGH_FILE, "Only SEEK_SET allowed");
+
+        ++seek_count;
+        /// Allow the first seek (which precedes any read), then refuse the EOCD-search
+        /// backward seek that follows the first nextImpl().
+        if (seek_count > 1 && read_count > 0)
+            throw Exception(
+                ErrorCodes::CANNOT_SEEK_THROUGH_FILE,
+                "Seek is allowed only before first read attempt from the buffer");
+
+        if (off < 0 || static_cast<size_t>(off) > data.size())
+            throw Exception(ErrorCodes::CANNOT_SEEK_THROUGH_FILE, "Seek out of bounds");
+
+        pos = nullptr;
+        working_buffer = Buffer(nullptr, nullptr);
+        position_in_file = off;
+        return off;
+    }
+
+    off_t getPosition() override
+    {
+        return static_cast<off_t>(position_in_file) - available();
+    }
+
+    bool nextImpl() override
+    {
+        if (position_in_file >= data.size())
+            return false;
+        ++read_count;
+        size_t avail = data.size() - position_in_file;
+        size_t to_read = std::min<size_t>(avail, 1024);
+        buf.resize(to_read);
+        std::copy(data.begin() + position_in_file, data.begin() + position_in_file + to_read, buf.begin());
+        BufferBase::set(buf.data(), to_read, 0);
+        position_in_file += to_read;
+        return true;
+    }
+
+private:
+    const String & data;
+    std::vector<char> buf;
+    size_t position_in_file = 0;
+    size_t seek_count = 0;
+    size_t read_count = 0;
+};
+
+
+/// Reproducer for https://github.com/ClickHouse/ClickHouse/issues/104681.
+///
+/// Before the fix, when a callback throws (here: a backward seek into S3 with
+/// `restricted_seek = true`), `ZipArchiveReader` swallowed the C++ exception inside
+/// the C stream callback, let minizip report `MZ_END_OF_LIST` (-100), and surfaced
+/// the unhelpful `Couldn't unpack zip archive ...: Code = -100` error. After the
+/// fix the original exception (`CANNOT_SEEK_THROUGH_FILE`) is rethrown unchanged.
+TEST(ZipArchiveReaderTest, RethrowsCallbackExceptionOnOpen)
+{
+    /// Build a valid zip in memory. `ManyFilesInMemory` shows this works; we use a
+    /// small number of files here so the EOCD search has to look back further than
+    /// a single read's worth of data.
+    String archive_in_memory;
+    {
+        auto writer = createArchiveWriter("archive.zip", std::make_unique<WriteBufferFromString>(archive_in_memory));
+        for (int i = 0; i < 4; ++i)
+        {
+            auto out = writer->writeFile(fmt::format("file{}.txt", i));
+            writeString(getRandomASCIIString(64), *out);
+            out->finalize();
+        }
+        writer->finalize();
+    }
+
+    auto read_archive_func
+        = [&]() -> std::unique_ptr<SeekableReadBuffer> { return std::make_unique<SeekFailingReadBuffer>(archive_in_memory); };
+
+    try
+    {
+        auto reader = createArchiveReader("archive.zip", read_archive_func, archive_in_memory.size());
+        /// If creation succeeded we must still trigger a failing seek; the EOCD lookup
+        /// is performed lazily on the first `fileExists` / `getFileInfo` call.
+        (void)reader->getAllFiles();
+        FAIL() << "Expected exception was not thrown";
+    }
+    catch (const Exception & e)
+    {
+        EXPECT_EQ(e.code(), ErrorCodes::CANNOT_SEEK_THROUGH_FILE)
+            << "Underlying CANNOT_SEEK_THROUGH_FILE must surface unchanged, got: " << e.displayText();
+        EXPECT_EQ(e.message().find("Code = -100"), String::npos)
+            << "Cryptic minizip code must not appear in user-visible message: " << e.message();
+    }
+}
+
+#endif
 
 
 namespace


### PR DESCRIPTION
When reading a zip archive whose underlying `SeekableReadBuffer` throws (for example `ReadBufferFromS3` with `restricted_seek = true` rejecting a backward seek during minizip's EOCD search), the exception was caught inside the `StreamFromReadBuffer` C callbacks, the callback returned an error code, and minizip's state machine then surfaced a generic `MZ_END_OF_LIST` (-100). The result was the unhelpful

```
Couldn't unpack zip archive 'X': Code = -100
```

reported in #104681, with the actual cause (e.g. `CANNOT_SEEK_THROUGH_FILE`) silently dropped.

### What changed

* `HandleHolder::checkResult` and `showError` now rethrow any stored stream exception before falling through to the cryptic minizip error formatter, so every post-open failure surfaces the underlying error instead of `Code = -100`.
* `StreamFromReadBuffer::open` returns the captured exception when `unzOpen2_64` fails. Minizip cleans up the stream during its own failure path, so the in-stream `stored_exception` is unreachable afterwards. The read/seek/tell callbacks therefore also write a copy of the exception into the shared `Opaque` struct (lives on the caller's stack), which `acquireRawHandle` rethrows instead of the generic `Couldn't open zip archive` message.

### Testing

A new gtest `ZipArchiveReaderTest.RethrowsCallbackExceptionOnOpen` reproduces the issue with a `SeekFailingReadBuffer` that fails on the second seek after a read. With the fix the underlying `CANNOT_SEEK_THROUGH_FILE` is surfaced unchanged; without the fix the test fails (gets code 643 / "Couldn't open zip archive" instead of expected 87 / `CANNOT_SEEK_THROUGH_FILE`).

All 79 existing archive gtests continue to pass.

Closes #104681

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Surface the real underlying exception when a zip archive cannot be unpacked because the input buffer (e.g. an S3 read buffer with `restricted_seek = true`) refuses a seek or read requested by minizip. Previously the actual error was hidden behind the generic `Couldn't unpack zip archive: Code = -100` / `Couldn't open zip archive` message.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.126`
<!-- ch-version-info:end -->