### PR TITLE
Add regression test for invalid chunk with lazy materialization on ALIAS column (#97771)

### DIFF
--- a/tests/queries/0_stateless/04248_97771_lazy_materialization_alias_invalid_chunk.reference
+++ b/tests/queries/0_stateless/04248_97771_lazy_materialization_alias_invalid_chunk.reference
@@ -35,8 +35,9 @@ SELECT c2 FROM t_97771_4 ORDER BY c0 LIMIT 1
 SETTINGS query_plan_optimize_lazy_materialization = 1;
 a
 -- 5. ALIAS that wraps the underlying column in an expression - the lazy reader has to
---    materialize both columns through the alias DAG.
-CREATE TABLE t_97771_5 (c0 UInt64, c1 String, c2 String ALIAS upperUTF8(c1)) ENGINE = MergeTree() ORDER BY c0;
+--    materialize both columns through the alias DAG. `upper` is intentionally chosen over
+--    `upperUTF8` because the latter is unavailable in the Fast test build (no ICU).
+CREATE TABLE t_97771_5 (c0 UInt64, c1 String, c2 String ALIAS upper(c1)) ENGINE = MergeTree() ORDER BY c0;
 INSERT INTO t_97771_5 VALUES (1, 'a'), (2, 'b');
 SELECT c1, c2 FROM t_97771_5 ORDER BY c0 LIMIT 2
 SETTINGS query_plan_optimize_lazy_materialization = 1;

--- a/tests/queries/0_stateless/04248_97771_lazy_materialization_alias_invalid_chunk.reference
+++ b/tests/queries/0_stateless/04248_97771_lazy_materialization_alias_invalid_chunk.reference
@@ -1,0 +1,44 @@
+-- { echoOn }
+
+-- 1. Exact reproducer from the issue (https://fiddle.clickhouse.com/ba83d480-7fb5-4b7a-afbf-b1ca1d9f7aa9):
+--    selecting both the underlying column and its ALIAS together with ORDER BY + LIMIT
+--    on a tiny single-row table used to throw `Invalid number of rows in Chunk`.
+CREATE TABLE t_97771_1 (c0 UInt64, c1 String, c2 String ALIAS c1) ENGINE = MergeTree() ORDER BY c0;
+INSERT INTO t_97771_1 VALUES (1, 'a');
+SELECT c1, c2 FROM t_97771_1 ORDER BY c0 LIMIT 1
+SETTINGS query_plan_optimize_lazy_materialization = 1;
+a	a
+-- 2. Multi-row wide-part case with explicit lazy materialization. Wide parts and many rows
+--    exercise the MergeTreeLazilyReader path more aggressively.
+CREATE TABLE t_97771_2 (c0 UInt64, c1 String, c2 String ALIAS c1) ENGINE = MergeTree() ORDER BY c0
+SETTINGS min_bytes_for_wide_part = 1, min_rows_for_wide_part = 1;
+INSERT INTO t_97771_2 SELECT number, 'val_' || toString(number) FROM numbers(100);
+SELECT c1, c2 FROM t_97771_2 ORDER BY c0 LIMIT 3
+SETTINGS query_plan_optimize_lazy_materialization = 1;
+val_0	val_0
+val_1	val_1
+val_2	val_2
+-- 3. With a WHERE predicate that forces the LazyMaterializingTransform pipeline. Pre-fix this
+--    is the path that built the malformed chunk reported in the stack trace.
+CREATE TABLE t_97771_3 (c0 UInt64, c1 String, c2 String ALIAS c1) ENGINE = MergeTree() ORDER BY c0
+SETTINGS min_bytes_for_wide_part = 1, min_rows_for_wide_part = 1;
+INSERT INTO t_97771_3 SELECT number, 'val_' || toString(number) FROM numbers(100);
+SELECT c1, c2 FROM t_97771_3 WHERE c0 > 0 ORDER BY c0 LIMIT 3
+SETTINGS query_plan_optimize_lazy_materialization = 1;
+val_1	val_1
+val_2	val_2
+val_3	val_3
+-- 4. Selecting only the ALIAS column (no direct reference to the underlying column).
+CREATE TABLE t_97771_4 (c0 UInt64, c1 String, c2 String ALIAS c1) ENGINE = MergeTree() ORDER BY c0;
+INSERT INTO t_97771_4 VALUES (1, 'a'), (2, 'b');
+SELECT c2 FROM t_97771_4 ORDER BY c0 LIMIT 1
+SETTINGS query_plan_optimize_lazy_materialization = 1;
+a
+-- 5. ALIAS that wraps the underlying column in an expression - the lazy reader has to
+--    materialize both columns through the alias DAG.
+CREATE TABLE t_97771_5 (c0 UInt64, c1 String, c2 String ALIAS upperUTF8(c1)) ENGINE = MergeTree() ORDER BY c0;
+INSERT INTO t_97771_5 VALUES (1, 'a'), (2, 'b');
+SELECT c1, c2 FROM t_97771_5 ORDER BY c0 LIMIT 2
+SETTINGS query_plan_optimize_lazy_materialization = 1;
+a	A
+b	B

--- a/tests/queries/0_stateless/04248_97771_lazy_materialization_alias_invalid_chunk.sql
+++ b/tests/queries/0_stateless/04248_97771_lazy_materialization_alias_invalid_chunk.sql
@@ -44,8 +44,9 @@ SELECT c2 FROM t_97771_4 ORDER BY c0 LIMIT 1
 SETTINGS query_plan_optimize_lazy_materialization = 1;
 
 -- 5. ALIAS that wraps the underlying column in an expression - the lazy reader has to
---    materialize both columns through the alias DAG.
-CREATE TABLE t_97771_5 (c0 UInt64, c1 String, c2 String ALIAS upperUTF8(c1)) ENGINE = MergeTree() ORDER BY c0;
+--    materialize both columns through the alias DAG. `upper` is intentionally chosen over
+--    `upperUTF8` because the latter is unavailable in the Fast test build (no ICU).
+CREATE TABLE t_97771_5 (c0 UInt64, c1 String, c2 String ALIAS upper(c1)) ENGINE = MergeTree() ORDER BY c0;
 INSERT INTO t_97771_5 VALUES (1, 'a'), (2, 'b');
 SELECT c1, c2 FROM t_97771_5 ORDER BY c0 LIMIT 2
 SETTINGS query_plan_optimize_lazy_materialization = 1;

--- a/tests/queries/0_stateless/04248_97771_lazy_materialization_alias_invalid_chunk.sql
+++ b/tests/queries/0_stateless/04248_97771_lazy_materialization_alias_invalid_chunk.sql
@@ -1,0 +1,59 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/97771
+-- (Invalid number of rows in Chunk with lazy materialization when an ALIAS column
+-- shares its underlying expression with another selected column).
+-- The bug fired for v25.8..v25.11 and surfaced as:
+--   LOGICAL_ERROR: Invalid number of rows in Chunk ... String(size = 0) Lazy(size = 1)
+--   at MergeTreeLazilyReader::transformLazyColumns / ColumnLazyTransform::transform.
+
+DROP TABLE IF EXISTS t_97771_1;
+DROP TABLE IF EXISTS t_97771_2;
+DROP TABLE IF EXISTS t_97771_3;
+DROP TABLE IF EXISTS t_97771_4;
+DROP TABLE IF EXISTS t_97771_5;
+
+-- { echoOn }
+
+-- 1. Exact reproducer from the issue (https://fiddle.clickhouse.com/ba83d480-7fb5-4b7a-afbf-b1ca1d9f7aa9):
+--    selecting both the underlying column and its ALIAS together with ORDER BY + LIMIT
+--    on a tiny single-row table used to throw `Invalid number of rows in Chunk`.
+CREATE TABLE t_97771_1 (c0 UInt64, c1 String, c2 String ALIAS c1) ENGINE = MergeTree() ORDER BY c0;
+INSERT INTO t_97771_1 VALUES (1, 'a');
+SELECT c1, c2 FROM t_97771_1 ORDER BY c0 LIMIT 1
+SETTINGS query_plan_optimize_lazy_materialization = 1;
+
+-- 2. Multi-row wide-part case with explicit lazy materialization. Wide parts and many rows
+--    exercise the MergeTreeLazilyReader path more aggressively.
+CREATE TABLE t_97771_2 (c0 UInt64, c1 String, c2 String ALIAS c1) ENGINE = MergeTree() ORDER BY c0
+SETTINGS min_bytes_for_wide_part = 1, min_rows_for_wide_part = 1;
+INSERT INTO t_97771_2 SELECT number, 'val_' || toString(number) FROM numbers(100);
+SELECT c1, c2 FROM t_97771_2 ORDER BY c0 LIMIT 3
+SETTINGS query_plan_optimize_lazy_materialization = 1;
+
+-- 3. With a WHERE predicate that forces the LazyMaterializingTransform pipeline. Pre-fix this
+--    is the path that built the malformed chunk reported in the stack trace.
+CREATE TABLE t_97771_3 (c0 UInt64, c1 String, c2 String ALIAS c1) ENGINE = MergeTree() ORDER BY c0
+SETTINGS min_bytes_for_wide_part = 1, min_rows_for_wide_part = 1;
+INSERT INTO t_97771_3 SELECT number, 'val_' || toString(number) FROM numbers(100);
+SELECT c1, c2 FROM t_97771_3 WHERE c0 > 0 ORDER BY c0 LIMIT 3
+SETTINGS query_plan_optimize_lazy_materialization = 1;
+
+-- 4. Selecting only the ALIAS column (no direct reference to the underlying column).
+CREATE TABLE t_97771_4 (c0 UInt64, c1 String, c2 String ALIAS c1) ENGINE = MergeTree() ORDER BY c0;
+INSERT INTO t_97771_4 VALUES (1, 'a'), (2, 'b');
+SELECT c2 FROM t_97771_4 ORDER BY c0 LIMIT 1
+SETTINGS query_plan_optimize_lazy_materialization = 1;
+
+-- 5. ALIAS that wraps the underlying column in an expression - the lazy reader has to
+--    materialize both columns through the alias DAG.
+CREATE TABLE t_97771_5 (c0 UInt64, c1 String, c2 String ALIAS upperUTF8(c1)) ENGINE = MergeTree() ORDER BY c0;
+INSERT INTO t_97771_5 VALUES (1, 'a'), (2, 'b');
+SELECT c1, c2 FROM t_97771_5 ORDER BY c0 LIMIT 2
+SETTINGS query_plan_optimize_lazy_materialization = 1;
+
+-- { echoOff }
+
+DROP TABLE t_97771_1;
+DROP TABLE t_97771_2;
+DROP TABLE t_97771_3;
+DROP TABLE t_97771_4;
+DROP TABLE t_97771_5;


### PR DESCRIPTION
Closes #97771.

### Motivation

A query that selected both a regular column and its `ALIAS` in the same projection, combined with `ORDER BY` + `LIMIT` on a `MergeTree` table, used to throw
```
LOGICAL_ERROR: Invalid number of rows in Chunk
  UInt64(size = 1) String(size = 0) Lazy(size = 1)
  column String at position 1: expected 1, got 0.
```
from `MergeTreeLazilyReader::transformLazyColumns` / `ColumnLazyTransform::transform` when `query_plan_optimize_lazy_materialization = 1`. The fault was visible in every release from v25.8 through v25.11 (reproducer fiddle: https://fiddle.clickhouse.com/ba83d480-7fb5-4b7a-afbf-b1ca1d9f7aa9). The bug was fixed on master before this test was added — the issue is labelled `st-fixed` and @PedroTadim asked for a regression test to close it.

### Approach

The new stateless test `04248_97771_lazy_materialization_alias_invalid_chunk` exercises the exact fiddle reproducer plus four variants that protect against subtle regressions in sibling code paths:

1. The exact reproducer from the issue (single-row table, ALIAS shadowing a selected column).
2. Multi-row wide-part table — exercises `MergeTreeLazilyReader` over many granules.
3. A query with `WHERE` that forces the `LazyMaterializingTransform` pipeline (the path that built the malformed chunk in the original stack trace).
4. A query selecting only the `ALIAS` column.
5. An `ALIAS` defined as an expression (`upperUTF8(c1)`) — the lazy reader has to materialize both columns through the alias DAG.

All five variants pin `query_plan_optimize_lazy_materialization = 1` to keep the test useful even if CI randomizes the setting off. The test passes 50/50 with full settings + MergeTree settings randomization on a current master debug build.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add regression test for #97771 (invalid chunk with lazy materialization when an `ALIAS` column shadows a selected column on `MergeTree` with `ORDER BY` + `LIMIT`). The bug was fixed on master before this test was added.

### Documentation entry for user-facing changes
- [x] Documentation is unchanged (test-only PR).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.744`
<!-- ch-version-info:end -->