### PR TITLE
Fix settings-only ALTER on MergeTree with SimpleAggregateFunction in ORDER BY

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -11480,6 +11480,19 @@ void MergeTreeData::verifySortingKey(const KeyDescription & sorting_key)
     }
 }
 
+bool MergeTreeData::sortingKeyChanged(const KeyDescription & old_sorting_key, const KeyDescription & new_sorting_key)
+{
+    /// getName(), not IDataType::equals(): equals() ignores the SimpleAggregateFunction wrapper.
+    if (old_sorting_key.column_names != new_sorting_key.column_names)
+        return true;
+    if (old_sorting_key.data_types.size() != new_sorting_key.data_types.size())
+        return true;
+    for (size_t i = 0; i < old_sorting_key.data_types.size(); ++i)
+        if (old_sorting_key.data_types[i]->getName() != new_sorting_key.data_types[i]->getName())
+            return true;
+    return false;
+}
+
 size_t MergeTreeData::NamesAndTypesListHash::operator()(const NamesAndTypesList & list) const noexcept
 {
     size_t hash = 0;

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1017,6 +1017,9 @@ public:
     std::pair<String, bool> getNewImplicitStatisticsTypes(const StorageInMemoryMetadata & new_metadata, const MergeTreeSettings & old_settings) const;
     static void verifySortingKey(const KeyDescription & sorting_key);
 
+    /// True iff the resolved sorting key (column list or data types) differs between two metadata snapshots.
+    static bool sortingKeyChanged(const KeyDescription & old_sorting_key, const KeyDescription & new_sorting_key);
+
     /// Should be called if part data is suspected to be corrupted.
     /// Has the ability to check all other parts
     /// which reside on the same disk of the suspicious part.

--- a/src/Storages/StorageMergeTree.cpp
+++ b/src/Storages/StorageMergeTree.cpp
@@ -478,9 +478,6 @@ void StorageMergeTree::alter(
     auto [auto_statistics_types, statistics_changed] = getNewImplicitStatisticsTypes(new_metadata, *old_storage_settings);
     addImplicitStatistics(new_metadata.columns, auto_statistics_types);
 
-    if (!query_settings[Setting::allow_suspicious_primary_key])
-        MergeTreeData::verifySortingKey(new_metadata.sorting_key);
-
     /// This alter can be performed at new_metadata level only
     if (commands.isSettingsAlter())
     {
@@ -500,6 +497,11 @@ void StorageMergeTree::alter(
     }
     else
     {
+        /// Re-verify the key only when the ALTER actually changed it (see #104463).
+        if (!query_settings[Setting::allow_suspicious_primary_key]
+            && MergeTreeData::sortingKeyChanged(old_metadata.sorting_key, new_metadata.sorting_key))
+            MergeTreeData::verifySortingKey(new_metadata.sorting_key);
+
         /// Validate the new CREATE query before taking the lock below. Validation
         /// runs through `QueryAnalyzer`, which acquires `storage_snapshot_cache_mutex`.
         /// Query resolution paths acquire `currently_processing_in_background_mutex`

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -6785,6 +6785,8 @@ void StorageReplicatedMergeTree::alter(
 
     auto metadata_snapshot = getInMemoryMetadataPtr(query_context, false);
     StorageInMemoryMetadata future_metadata = *metadata_snapshot;
+    /// Snapshot the sorting key before applying commands, to compare with the resolved future one.
+    KeyDescription old_sorting_key = future_metadata.sorting_key;
 
     removeImplicitStatistics(future_metadata.columns);
     commands.apply(future_metadata, query_context);
@@ -6850,7 +6852,9 @@ void StorageReplicatedMergeTree::alter(
         return;
     }
 
-    if (!query_settings[Setting::allow_suspicious_primary_key])
+    /// Only re-verify the sorting key on ALTERs that can actually change it (see StorageMergeTree::alter).
+    if (!query_settings[Setting::allow_suspicious_primary_key]
+        && MergeTreeData::sortingKeyChanged(old_sorting_key, future_metadata.sorting_key))
     {
         MergeTreeData::verifySortingKey(future_metadata.sorting_key);
     }

--- a/tests/queries/0_stateless/04498_104463_alter_settings_simple_aggregate_func_order_by.sql
+++ b/tests/queries/0_stateless/04498_104463_alter_settings_simple_aggregate_func_order_by.sql
@@ -1,0 +1,25 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/104463
+
+DROP TABLE IF EXISTS t_104463;
+SET allow_suspicious_primary_key = 1;
+CREATE TABLE t_104463 (key Int32, value SimpleAggregateFunction(sum, UInt64))
+ENGINE = AggregatingMergeTree PRIMARY KEY key ORDER BY (key, value) SETTINGS merge_with_ttl_timeout = 30;
+SET allow_suspicious_primary_key = 0;
+
+-- ALTERs that cannot change the sorting key must succeed.
+ALTER TABLE t_104463 MODIFY SETTING merge_with_ttl_timeout = 60;
+ALTER TABLE t_104463 MODIFY COMMENT 'c';
+ALTER TABLE t_104463 MODIFY COLUMN value CODEC(ZSTD);
+
+-- ALTERs that do change the sorting key must still be rejected.
+ALTER TABLE t_104463 MODIFY COLUMN key SimpleAggregateFunction(any, Int32); -- { serverError DATA_TYPE_CANNOT_BE_USED_IN_KEY }
+ALTER TABLE t_104463 ADD COLUMN value2 SimpleAggregateFunction(sum, UInt64), MODIFY ORDER BY (key, value2); -- { serverError DATA_TYPE_CANNOT_BE_USED_IN_KEY }
+DROP TABLE t_104463;
+
+-- StorageReplicatedMergeTree::alter shares the gate (snapshots the key before apply); cover its skip path.
+SET allow_suspicious_primary_key = 1;
+CREATE TABLE t_104463 (key Int32, value SimpleAggregateFunction(sum, UInt64))
+ENGINE = ReplicatedAggregatingMergeTree('/clickhouse/tables/{database}/t_104463', 'r1') ORDER BY (key, value);
+SET allow_suspicious_primary_key = 0;
+ALTER TABLE t_104463 MODIFY SETTING merge_with_ttl_timeout = 60;
+DROP TABLE t_104463;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/104463
-->

Closes: https://github.com/ClickHouse/ClickHouse/issues/104463

`StorageMergeTree::alter` and `StorageReplicatedMergeTree::alter` re-ran `verifySortingKey` on almost every `ALTER` when `allow_suspicious_primary_key` was off, so unrelated ALTERs (settings, comments, codecs, adding a non-key column, ...) failed with `DATA_TYPE_CANNOT_BE_USED_IN_KEY` on tables created with `allow_suspicious_primary_key = 1`. The check now runs only when the resolved sorting key actually changed (`MergeTreeData::sortingKeyChanged`, comparing key column names and data-type names), in the same place in both engines.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix an unexpected `DATA_TYPE_CANNOT_BE_USED_IN_KEY` error on `ALTER` queries that cannot change the sorting key (settings, comments, codecs, adding a non-key column, etc.) for `MergeTree` tables that have a `SimpleAggregateFunction` (or another type allowed only with `allow_suspicious_primary_key = 1`) in the sorting key.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.850` (included in `26.7` and later)
<!-- ch-version-info:end -->