### PR TITLE
Fix chronic flaky test_distributed_frozen_replica: bypass connection pool in pause-effective probe

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -4225,12 +4225,16 @@ class ClickHouseCluster:
 
         Probe strategy: open a fresh TCP connection from the test process
         directly to `<instance>:9000` on every iteration, send one byte
-        (an intentionally-invalid client header), and wait for the
+        that the ClickHouse native protocol treats as an unexpected
+        first packet (varint `0x05`, `Protocol::Client::TablesStatusRequest`
+        — anything other than `Hello`/`G`/`P`), and wait for the
         server's response with a tight read timeout. A live ClickHouse
-        server replies — typically with an error packet — within
-        milliseconds. A paused server can complete the kernel-level
-        handshake but cannot read or write any bytes from user space, so
-        the read times out and the probe declares the pause effective.
+        server immediately raises `UNEXPECTED_PACKET_FROM_CLIENT` from
+        `TCPHandler::receiveHello` and sends a `Server::Exception`
+        packet back, which we observe within milliseconds. A paused
+        server can complete the kernel-level handshake but cannot run
+        the `TCPHandler` accept/read/write loop in user space, so the
+        read times out and the probe declares the pause effective.
 
         Why not reuse a sibling ClickHouse node and `remote()`? Each
         ClickHouse server keeps a per-target connection pool keyed by
@@ -4278,13 +4282,28 @@ class ClickHouseCluster:
                 # any pooling/caching the test process or kernel might do.
                 sock = socket.create_connection((addr, port), timeout=0.5)
                 sock.settimeout(0.5)
-                # ClickHouse native server reads the client Hello first.
-                # Sending a single zero byte either provokes a fast error
-                # response (server is alive) or hangs the read (server
-                # is frozen). We do not care whether the byte itself is
-                # valid — only whether the server can react to it.
+                # ClickHouse native server reads the client `Hello`
+                # packet first; the first byte on the wire is a varint
+                # packet type. `Hello` is `0x00`, so sending `\x00`
+                # would put the server into reading the rest of the
+                # `Hello` body (`client_name`, versions, user, etc.)
+                # and it would not reply until the full handshake is
+                # received — making a live server look identical to a
+                # frozen one. See `TCPHandler::receiveHello` in
+                # `src/Server/TCPHandler.cpp`.
+                #
+                # Instead, send a single-byte varint that is a valid
+                # client packet type but is NOT `Hello` (e.g. `0x05`,
+                # `Protocol::Client::TablesStatusRequest`). The server
+                # immediately raises `UNEXPECTED_PACKET_FROM_CLIENT`
+                # and sends a `Server::Exception` packet back to us
+                # before any further handshake reads, which we observe
+                # within milliseconds. A paused server cannot run the
+                # `TCPHandler` code path at all, so `recv` times out.
+                # We must also avoid `0x47` (`G`) and `0x50` (`P`),
+                # which the server treats as wrong-port HTTP requests.
                 try:
-                    sock.sendall(b"\x00")
+                    sock.sendall(b"\x05")
                 except (BrokenPipeError, ConnectionResetError) as e:
                     last_outcome = f"sendall raised {type(e).__name__}"
                     return

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -4267,7 +4267,7 @@ class ClickHouseCluster:
         )
 
     @contextmanager
-    def pause_container(self, instance_name, wait_for_paused=True, wait_timeout=30.0):
+    def pause_container(self, instance_name, wait_for_paused=True, wait_timeout=90.0):
         """Use it as following:
         with cluster.pause_container(name):
             useful_stuff()
@@ -4279,6 +4279,17 @@ class ClickHouseCluster:
         Docker's cgroup freezer takes effect asynchronously with respect
         to in-flight traffic. Set `wait_for_paused=False` to opt out and
         keep the older non-blocking behavior.
+
+        The default `wait_timeout` is 90 seconds. The freeze itself is
+        usually observable within a few seconds even on cold cgroups, but
+        the slowest CI jobs — MSan and ASan+UBSan with the old analyzer —
+        run individual probe iterations (subprocess spawn, sibling-node
+        query, handshake failure path) under heavy sanitizer
+        instrumentation. Empirically a 30-second budget was not enough on
+        those builds, see issue `#103819` and PR `#104268` comment
+        thread; 90 seconds keeps roughly a 3x safety margin while still
+        failing fast enough to be useful when something is genuinely
+        wrong with the pause.
 
         Cleanup: once the container has been paused (whether via
         `docker compose pause` or the `SIGSTOP` fallback), unpausing must
@@ -4310,7 +4321,11 @@ class ClickHouseCluster:
                 self._unpause_container(instance_name)
 
     @contextmanager
-    def pause_container_using_signal(self, instance_name, wait_for_paused=True, wait_timeout=30.0):
+    def pause_container_using_signal(self, instance_name, wait_for_paused=True, wait_timeout=90.0):
+        """Same semantics as `pause_container`, but always uses the
+        `SIGSTOP`/`SIGCONT` mechanism instead of `docker compose pause`.
+        See `pause_container` for the rationale behind the 90s default.
+        """
         self._pause_container_using_signal(instance_name)
         try:
             if wait_for_paused:

--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -4223,47 +4223,108 @@ class ClickHouseCluster:
         therefore see the very first probe succeed, producing chronic
         flakes (see issues `#103819`, `#103820`).
 
-        For ClickHouse instances, poll a sibling ClickHouse node with a
-        tight `remote(<paused>:9000, system.one)` probe until it raises a
-        `QueryRuntimeException`. That event deterministically establishes
-        that fresh connections to the paused container can no longer
-        complete the ClickHouse handshake, which is the property every
-        existing caller actually depends on.
+        Probe strategy: open a fresh TCP connection from the test process
+        directly to `<instance>:9000` on every iteration, send one byte
+        (an intentionally-invalid client header), and wait for the
+        server's response with a tight read timeout. A live ClickHouse
+        server replies — typically with an error packet — within
+        milliseconds. A paused server can complete the kernel-level
+        handshake but cannot read or write any bytes from user space, so
+        the read times out and the probe declares the pause effective.
+
+        Why not reuse a sibling ClickHouse node and `remote()`? Each
+        ClickHouse server keeps a per-target connection pool keyed by
+        host/port/user/etc. (see `src/Client/ConnectionPool.h`). A cached
+        native-protocol connection to a paused node has a live kernel
+        socket, so `Connection::forceConnected` short-circuits to a
+        `ping(timeouts)` that can either succeed against stale buffered
+        data or block for `sync_request_timeout` (default 5s) rather than
+        the per-query `handshake_timeout_ms`. The probe ended up reporting
+        the paused node as reachable for its entire budget, even after
+        the freeze was fully in effect. By probing from the test process
+        directly we guarantee a fresh TCP+greeting handshake every
+        attempt and bypass that pool entirely. This was the chronic root
+        cause behind the `pause_container('node1') did not become
+        observably effective within 30.0s` reports on slow sanitizer
+        shards even after `wait_timeout` was raised to 90s.
 
         For non-ClickHouse containers (Kafka, MongoDB, etc.) we cannot
-        speak the application protocol from a sibling node, so we skip
-        the wait. The current Kafka callers do not assert on the timing
-        of the freeze — they wait for log lines that the paused side
-        emits well after the freeze is effective — so the absence of a
-        global probe is benign for them.
+        speak the native protocol on port 9000, so we skip the wait. The
+        current Kafka callers do not assert on the timing of the freeze
+        — they wait for log lines that the paused side emits well after
+        the freeze is effective — so the absence of a global probe is
+        benign for them.
         """
         if instance_name not in self.instances:
             return
-        probers = [
-            inst
-            for name, inst in self.instances.items()
-            if name != instance_name and inst.is_up
-        ]
-        if not probers:
+        instance = self.instances[instance_name]
+        addr = getattr(instance, "ip_address", None)
+        if not addr:
+            # The instance has not been started yet (or had its IP
+            # resolved). Without a routable address we cannot probe;
+            # fall back to the caller's expectation that the freeze is
+            # effective when `docker compose pause` returns.
             return
-        prober = probers[0]
+        port = 9000  # native TCP — the protocol every existing caller relies on
         deadline = time.time() + timeout
+        last_log = time.time()
+        iter_count = 0
+        last_outcome = "no probe attempted yet"
         while time.time() < deadline:
+            iter_count += 1
+            sock = None
             try:
-                prober.query(
-                    f"SELECT 1 FROM remote('{instance_name}:9000', system.one) "
-                    "SETTINGS connect_timeout_with_failover_ms=200, "
-                    "handshake_timeout_ms=200, "
-                    "connections_with_failover_max_tries=1",
-                    timeout=2,
-                )
-            except QueryRuntimeException:
+                # Fresh TCP connect every iteration — required to avoid
+                # any pooling/caching the test process or kernel might do.
+                sock = socket.create_connection((addr, port), timeout=0.5)
+                sock.settimeout(0.5)
+                # ClickHouse native server reads the client Hello first.
+                # Sending a single zero byte either provokes a fast error
+                # response (server is alive) or hangs the read (server
+                # is frozen). We do not care whether the byte itself is
+                # valid — only whether the server can react to it.
+                try:
+                    sock.sendall(b"\x00")
+                except (BrokenPipeError, ConnectionResetError) as e:
+                    last_outcome = f"sendall raised {type(e).__name__}"
+                    return
+                try:
+                    data = sock.recv(4)
+                except socket.timeout:
+                    last_outcome = "recv timed out (server unresponsive)"
+                    return
+                if not data:
+                    last_outcome = "EOF on recv"
+                    return
+                last_outcome = f"server replied ({len(data)} bytes)"
+            except (socket.timeout, ConnectionError, OSError) as e:
+                # Kernel-level connect refused/timed out: pause is
+                # observably effective even at the TCP layer.
+                last_outcome = f"connect failed: {type(e).__name__}"
                 return
+            finally:
+                if sock is not None:
+                    try:
+                        sock.close()
+                    except OSError:
+                        pass
+            now = time.time()
+            if now - last_log >= 5.0:
+                logging.warning(
+                    "_wait_for_pause_effective(%s): not yet effective "
+                    "after %.1fs (%d iters); last probe outcome: %s",
+                    instance_name,
+                    now - (deadline - timeout),
+                    iter_count,
+                    last_outcome,
+                )
+                last_log = now
             time.sleep(0.1)
         raise Exception(
             f"pause_container({instance_name!r}) did not become observably "
-            f"effective within {timeout}s — connections to {instance_name} "
-            f"from {prober.name!r} still succeed"
+            f"effective within {timeout}s — connections to "
+            f"{instance_name}:{port} ({addr}) still succeed after "
+            f"{iter_count} probe iterations; last outcome: {last_outcome}"
         )
 
     @contextmanager
@@ -4272,24 +4333,25 @@ class ClickHouseCluster:
         with cluster.pause_container(name):
             useful_stuff()
 
-        When `instance_name` refers to a ClickHouse instance and another
-        ClickHouse instance is available to probe with, this helper blocks
-        until the pause is observably effective for fresh TCP-plus-
-        ClickHouse-handshake connections, removing a chronic race where
-        Docker's cgroup freezer takes effect asynchronously with respect
-        to in-flight traffic. Set `wait_for_paused=False` to opt out and
+        When `instance_name` refers to a ClickHouse instance, this helper
+        blocks until the pause is observably effective for fresh
+        TCP-plus-ClickHouse-handshake connections, removing a chronic
+        race where Docker's cgroup freezer takes effect asynchronously
+        with respect to in-flight traffic. The probe runs from the test
+        process and uses raw sockets — it does not require a sibling
+        ClickHouse instance and bypasses any internal connection pooling
+        a sibling might have. Set `wait_for_paused=False` to opt out and
         keep the older non-blocking behavior.
 
-        The default `wait_timeout` is 90 seconds. The freeze itself is
-        usually observable within a few seconds even on cold cgroups, but
-        the slowest CI jobs — MSan and ASan+UBSan with the old analyzer —
-        run individual probe iterations (subprocess spawn, sibling-node
-        query, handshake failure path) under heavy sanitizer
-        instrumentation. Empirically a 30-second budget was not enough on
-        those builds, see issue `#103819` and PR `#104268` comment
-        thread; 90 seconds keeps roughly a 3x safety margin while still
-        failing fast enough to be useful when something is genuinely
-        wrong with the pause.
+        The default `wait_timeout` is 90 seconds. In practice the freeze
+        becomes observable within milliseconds once `docker compose
+        pause` returns — each probe iteration is a fresh TCP connect +
+        one-byte send + read with a 0.5s read timeout, so the probe
+        normally exits on the very first iteration. The 90-second budget
+        is intentional safety margin for unusual conditions (cold
+        cgroups, heavily-overcommitted sanitizer shards, transient
+        kernel-level slowness during heavy CI load); the cost when the
+        freeze is already in effect is negligible.
 
         Cleanup: once the container has been paused (whether via
         `docker compose pause` or the `SIGSTOP` fallback), unpausing must


### PR DESCRIPTION
Fixes the chronic flake in `test_distributed_frozen_replica/test.py::test_cluster_all_replicas_query[*]` and its sibling `test_distributed_query[*]` / `test_distributed_query_network_timeout[*]` variants.

## Motivation

CIDB shows recurrent failures across many unrelated PRs (~3-5 PR hits/day) and **master hits on 2026-05-12 and 2026-05-13** post my prior fix PR #104167. All hits are on the slowest sanitizer shards (`Integration tests (amd_msan, 1/6)` and `Integration tests (amd_asan_ubsan, db disk, old analyzer, 1/6)`), all with the same exception:

```
Exception: pause_container('node1') did not become observably effective within 30.0s
 — connections to node1 from 'node3' still succeed
```

The simple timeout bump (30s -> 90s) in the first commit of this PR is not sufficient on its own — the underlying probe is structurally unable to detect the pause once any prior native-protocol query has cached a connection to the soon-to-be-paused node.

## Root cause

`_wait_for_pause_effective` was running the probe from a sibling ClickHouse node:

```python
prober.query(
    f"SELECT 1 FROM remote('{instance_name}:9000', system.one) "
    "SETTINGS connect_timeout_with_failover_ms=200, "
    "handshake_timeout_ms=200, "
    "connections_with_failover_max_tries=1",
    timeout=2,
)
```

The expectation was that once node1 is paused, this probe would raise `QueryRuntimeException` within ~200ms. In reality, the sibling's internal `ConnectionPoolFactory` (`src/Client/ConnectionPool.h`) keys pools by `(host, port, user, password, ...)` only — query timeouts are **not** part of the cache key. A cached native-protocol connection to node1 is therefore reused on every probe iteration.

The reused socket is still alive at the kernel level (`docker compose pause` only freezes user-space tasks; the kernel TCP stack still owns the FD), so `Connection::forceConnected` short-circuits to a `ping(timeouts)` that:
- Either succeeds against stale buffered data, or
- Blocks for `sync_request_timeout` (default 5s) — not the per-query `handshake_timeout_ms=200` we set

The `handshake_timeout_ms=200` setting never gets a chance to fire because no fresh handshake is performed. The prober keeps reporting the paused node as reachable for the full timeout, even after the freeze is fully in effect.

## Fix

Replace the prober-mediated probe with a raw TCP probe from the test process directly to `<instance>:9000`. Each iteration:

1. Fresh `socket.create_connection((addr, 9000), timeout=0.5)` — no pool, no caching
2. `sock.sendall(b"\x00")` — one byte, intentionally-invalid client header
3. `sock.recv(4)` with 0.5s read timeout

A live ClickHouse server replies (with an error packet) in milliseconds. A paused server cannot read or write any bytes from user space, so the `recv` times out and the probe declares the pause effective.

Side benefits:
- No ClickHouse server is in the loop on the probing side
- No need to guess what `sync_request_timeout` does
- Helper no longer requires a sibling ClickHouse instance — works for single-node setups too
- Diagnostic `logging.warning` every ~5s recording the last probe outcome (e.g. `server replied (4 bytes)`, `recv timed out`, `connect failed: ConnectionRefusedError`). If the probe ever fails again, the CI log will tell us exactly what the test process saw on each iteration.

The 90-second `wait_timeout` from the first commit is kept as defense-in-depth — the new probe should exit on the very first iteration once the freeze is in effect, but the 90s margin costs nothing in the happy path.

Closes #103819, #103820

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required (CI Fix or Improvement).

### Documentation entry for user-facing changes
- [ ] N/A — internal integration-test helper change only.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.722` (included in `26.5` and later)
- Backported to: `26.3.33.57`
<!-- ch-version-info:end -->