### PR TITLE
Fix ClickBench job: drop test-only `storage_conf_local.xml`

### DIFF
--- a/ci/jobs/clickbench.py
+++ b/ci/jobs/clickbench.py
@@ -25,6 +25,19 @@ def main():
                 f"cp ./ci/jobs/scripts/clickbench/filesystem_caches_path.xml {temp_dir}/config.d/",
                 verbose=True,
             )
+            # `programs/server/config.d/storage_conf_local.xml` is a symlink to
+            # the test-only config that defines pre-configured `local_cache*`
+            # disks with `max_size = 22548578304` (~21 GiB) under relative path
+            # `local_cache/`. With our `filesystem_caches_path` override the
+            # cache base path becomes `/dev/shm/clickhouse/local_cache/`, but
+            # the ClickBench container runs with `--shm-size=16g`, so the
+            # capacity check in `FileCache::initialize` rejects the disk and
+            # the server fails to start. ClickBench doesn't use these test
+            # disks, so drop the config.
+            res = res and Shell.check(
+                f"rm -f {temp_dir}/config.d/storage_conf_local.xml",
+                verbose=True,
+            )
             if info.is_local_run:
                 return res
             return res and ch.create_log_export_config()


### PR DESCRIPTION
The ClickBench Start step has been failing on master for both `amd_release` and `arm_release` since the job started copying the full `programs/server/config.d/` into its temp config directory. The server aborts startup with:

```
Code: 36. DB::Exception: The total capacity of the disk containing cache path
/dev/shm/clickhouse/local_cache/ is less than the specified max_size 22548578304 bytes.
```

`programs/server/config.d/storage_conf_local.xml` is a symlink to the test-only `tests/config/config.d/storage_conf_local.xml`. It declares `local_cache*` cached disks with `max_size = 22548578304` (~21 GiB) and relative path `local_cache/`. With the ClickBench override `<filesystem_caches_path>/dev/shm/clickhouse/</filesystem_caches_path>` the resolved cache base path becomes `/dev/shm/clickhouse/local_cache/`. ClickBench runs in a container with `--shm-size=16g`, so `FileCache::initialize` rejects the disk and the server fails to start.

ClickBench doesn't use these test disks — its own cached disk is declared inline in `create.sql` — so delete the config after install.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=a35593cb7db4bf0604722703bc4b7d57a251bf62&name_0=MasterCI&name_1=ClickBench%20%28arm_release%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.707`
<!-- ch-version-info:end -->