### PR TITLE
CI: bump rss_limit_mb to 4096 for clickhouse_fuzzer to stop chronic OOMs at 2048 Mb default

### DIFF
--- a/tests/fuzz/clickhouse_fuzzer.options
+++ b/tests/fuzz/clickhouse_fuzzer.options
@@ -1,5 +1,6 @@
 [libfuzzer]
 timeout = 20
+rss_limit_mb = 4096
 
 [fuzzer_arguments]
 --max_execution_time=10


### PR DESCRIPTION
`clickhouse_fuzzer` runs the full `clickhouse-local` binary (see `programs/local/fuzzers/clickhouse_fuzzer.cpp`, which constructs a `clickhouseMain` thread on each fuzz iteration). That spins up a complete clickhouse-server-grade runtime: JeMalloc arenas, OpenSSL initialization, static initializers, full query execution machinery. Baseline RSS sits very close to the libFuzzer default `rss_limit_mb=2048`, so any fuzzed input that triggers even moderate query-time allocations pushes the process past the limit.

CIDB shows the failure has been chronic and uniform across many unrelated PRs:

```
libFuzzer  out-of-memory (used: 2049-2056Mb; limit: 2048Mb)  oom-<hash>
```

Last 30 days (all 10 hits — 0 on master because libFuzzer does not run regularly on master):
- PR #99740 — 4 hits (Apr 19-21)
- PRs #104231, #104849, #104956, #96844, #104510, #104492 — 1 hit each (May 13-15, all unrelated authors / code areas)

Every single failure is OOM at the 2048 Mb limit with actual usage just barely over (2049-2056 Mb). Hash-prefix of `oom-*` samples varies (`7a597`, `90c3e`, `32ab8`, `da39a`, `f33b9`), confirming multiple distinct trigger inputs that all sit right at the boundary.

### Fix

Add `rss_limit_mb = 4096` to `tests/fuzz/clickhouse_fuzzer.options`, following the existing precedent for fuzzers with similar workloads:

| Fuzzer | rss_limit_mb |
|---|---|
| `execute_query_fuzzer.options` | 4096 |
| `data_type_deserialization_fuzzer.options` | 4096 |
| `create_parser_fuzzer.options` | 6144 |
| `clickhouse_fuzzer.options` (this PR) | 4096 |

The limit still bounds the target (it does not disable the check via `rss_limit_mb=0`), so genuine memory regressions above 4 GB will still be caught.

Sample CIDB query used to gather the data:

```sql
SELECT pull_request_number, count(), max(check_start_time), any(test_context_raw)
FROM default.checks
WHERE test_name = 'clickhouse_fuzzer'
  AND test_status IN ('FAIL', 'ERROR')
  AND check_start_time > now() - INTERVAL 30 DAY
GROUP BY pull_request_number
ORDER BY count() DESC
```

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Bump libFuzzer `rss_limit_mb` to 4096 for `clickhouse_fuzzer` to fix chronic OOMs at the 2048 Mb default. Matches the existing precedent of `execute_query_fuzzer` and other heavyweight fuzz targets.

### Documentation entry for user-facing changes
- [x] Not required (CI-only configuration change)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.712`
<!-- ch-version-info:end -->