### PR TITLE
Document async metrics QueriesMemoryUsage and QueriesPeakMemoryUsage

### DIFF
--- a/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
+++ b/ci/jobs/scripts/check_style/aspell-ignore/en/aspell-dict.txt
@@ -1224,6 +1224,8 @@ QTCreator
 Qaph
 Qoph
 Quantile
+QueriesMemoryUsage
+QueriesPeakMemoryUsage
 QueryCacheBytes
 QueryCacheEntries
 QueryCacheHits

--- a/docs/en/operations/system-tables/asynchronous_metrics.md
+++ b/docs/en/operations/system-tables/asynchronous_metrics.md
@@ -506,7 +506,7 @@ Total memory currently used by all running queries on the server, in bytes. Usef
 
 ### QueriesPeakMemoryUsage {#queriespeakmemoryusage}
 
-Peak memory used by all running queries on the server, in bytes.
+Sum of per-user query memory peaks across all users tracked in `ProcessList`, in bytes. Each user's peak is the high-water mark of that user's memory tracker, which is reset when the user has no running queries. This is therefore an aggregate of currently-tracked per-user peaks, not a single server-wide peak of all queries since startup.
 
 ### ReplicasMaxAbsoluteDelay {#replicasmaxabsolutedelay}
 

--- a/docs/en/operations/system-tables/asynchronous_metrics.md
+++ b/docs/en/operations/system-tables/asynchronous_metrics.md
@@ -500,6 +500,14 @@ The value is similar to `OSUserTime` but divided to the number of CPU cores to b
 
 Number of threads in the server of the PostgreSQL compatibility protocol.
 
+### QueriesMemoryUsage {#queriesmemoryusage}
+
+Total memory currently used by all running queries on the server, in bytes. Useful for attributing memory pressure to the concurrent query load.
+
+### QueriesPeakMemoryUsage {#queriespeakmemoryusage}
+
+Peak memory used by all running queries on the server, in bytes.
+
 ### ReplicasMaxAbsoluteDelay {#replicasmaxabsolutedelay}
 
 Maximum difference in seconds between the most fresh replicated part and the most fresh data part still to be replicated, across Replicated tables. A very high value indicates a replica with no data.


### PR DESCRIPTION
Adds documentation entries for the two asynchronous metrics introduced in #86669 — `QueriesMemoryUsage` and `QueriesPeakMemoryUsage` — to `docs/en/operations/system-tables/asynchronous_metrics.md`. These were merged without docs, and @azat asked for the docs to be synced (https://github.com/ClickHouse/ClickHouse/pull/86669#issuecomment-3231884116).

Both entries follow the existing format of the surrounding memory-related metrics and are inserted in alphabetical order between `PostgreSQLThreads` and `ReplicasMaxAbsoluteDelay`, with explicit `{#kebab-anchor}` IDs as required for new docs headings.

The descriptions mirror the source-side text in `src/Interpreters/ServerAsynchronousMetrics.cpp` (lines 468–469), expanded slightly to explain when the metrics are useful.

cc @azat

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Document new asynchronous metrics `QueriesMemoryUsage` and `QueriesPeakMemoryUsage` in `system.asynchronous_metrics`.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.718`
<!-- ch-version-info:end -->