### PR TITLE
Fix flaky test_kafka_engine_put_errors_to_stream and _with_random_malformed_json

### DIFF
--- a/tests/integration/test_storage_kafka/test_batch_fast.py
+++ b/tests/integration/test_storage_kafka/test_batch_fast.py
@@ -2812,8 +2812,19 @@ def test_kafka_engine_put_errors_to_stream(kafka_cluster, create_query_generator
     with k.existing_kafka_topic(k.get_admin_client(kafka_cluster), topic_name):
         instance.wait_for_log_line(f"{kafka_table}.*Committed offset 128")
 
-        assert TSV(instance.query(f"SELECT count() FROM test.{kafka_table}_data")) == TSV("64")
-        assert TSV(instance.query(f"SELECT count() FROM test.{kafka_table}_errors")) == TSV("64")
+        # `Committed offset 128` only tells us the Kafka consumer side committed
+        # the offset; the materialized-view INSERT into the destination
+        # `MergeTree` runs in a separate path and may not have flushed yet.
+        # Poll the destination row counts until they reach the expected values
+        # instead of asserting them once immediately.
+        assert int(instance.query_with_retry(
+            f"SELECT count() FROM test.{kafka_table}_data",
+            check_callback=lambda x: int(x) == 64,
+        )) == 64
+        assert int(instance.query_with_retry(
+            f"SELECT count() FROM test.{kafka_table}_errors",
+            check_callback=lambda x: int(x) == 64,
+        )) == 64
 
         instance.query(f"""
             DROP TABLE test.{kafka_table};
@@ -2879,10 +2890,21 @@ def test_kafka_engine_put_errors_to_stream_with_random_malformed_json(
     k.kafka_produce(kafka_cluster, topic_name, messages)
     with k.existing_kafka_topic(k.get_admin_client(kafka_cluster), topic_name):
         instance.wait_for_log_line(f"{kafka_table}.*Committed offset 128")
+        # `Committed offset 128` only tells us the Kafka consumer side committed
+        # the offset; the materialized-view INSERT into the destination
+        # `MergeTree` runs in a separate path and may not have flushed yet.
+        # Poll the destination row counts until they reach the expected values
+        # instead of asserting them once immediately.
         # 64 good messages, each containing 10 rows
-        assert TSV(instance.query(f"SELECT count() FROM test.{kafka_table}_data")) == TSV("640")
+        assert int(instance.query_with_retry(
+            f"SELECT count() FROM test.{kafka_table}_data",
+            check_callback=lambda x: int(x) == 640,
+        )) == 640
         # 64 bad messages, each containing some broken row
-        assert TSV(instance.query(f"SELECT count() FROM test.{kafka_table}_errors")) == TSV("64")
+        assert int(instance.query_with_retry(
+            f"SELECT count() FROM test.{kafka_table}_errors",
+            check_callback=lambda x: int(x) == 64,
+        )) == 64
 
         instance.query(f"""
             DROP TABLE test.{kafka_table};


### PR DESCRIPTION
`test_kafka_engine_put_errors_to_stream` and `test_kafka_engine_put_errors_to_stream_with_random_malformed_json` in `tests/integration/test_storage_kafka/test_batch_fast.py` are chronically flaky. Across both parametrized variants of each test the family has hit 23+ failures across 5 distinct unrelated PRs in the last 30 days, with the most common symptom being `AssertionError: assert 54 == 64` (i.e. 10 expected error rows missing) on `Integration tests (amd_asan_ubsan, db disk, old analyzer, 2/6)`. The most recent occurrences are on `#96886`, `#104902`, `#104905`.

Surfaced again by @alexey-milovidov on https://github.com/ClickHouse/ClickHouse/pull/104905#issuecomment-4468222777 — no open issue exists for this family.

Root cause: both tests wait for the Kafka `Committed offset 128` log line and then assert the destination row counts immediately:

```python
instance.wait_for_log_line(f"{kafka_table}.*Committed offset 128")

assert TSV(instance.query(f"SELECT count() FROM test.{kafka_table}_data")) == TSV("...")
assert TSV(instance.query(f"SELECT count() FROM test.{kafka_table}_errors")) == TSV("64")
```

`Committed offset 128` only tells us the Kafka consumer side committed the offset; the materialized-view `INSERT` into the destination `MergeTree` runs in a separate path and is not strictly ordered with the offset commit. So the immediate `SELECT count() FROM ..._errors` can fire while the last block(s) are still in flight, undercounting by typically 10 rows (one block at `kafka_max_block_size`-aligned boundaries under `kafka_handle_error_mode = stream`).

The helper file in the same suite already acknowledges this anti-pattern: `tests/integration/helpers/kafka/common.py:463` says *"Since everything is async and shaky when receiving messages from Kafka, we may want to try and check results multiple times in a loop."* Most other tests in `test_batch_fast.py` already use `instance.query_with_retry(..., check_callback=lambda x: int(x) == N)` for exactly this reason (see e.g. line 1053, 1516). These two tests were the outliers.

Fix: replace the bare assertions in both tests with `instance.query_with_retry(..., check_callback=lambda x: int(x) == EXPECTED)`. The polled comparison is the same value the test was always asserting — no test intent is weakened. If the count never reaches the expected value, `query_with_retry` returns the last observed count and the surrounding `assert ... == EXPECTED` fails loudly, so the test still catches real undercounts; it just gives the materialized-view flush a window to complete first.

### Verification

Local smoke run with the fix on `Integration tests (amd_tsan, 1/6)` passes both parametrized variants of `test_kafka_engine_put_errors_to_stream` (and is currently rerunning the `_with_random_malformed_json` variants in another container). Reproducing the original ~10% failure rate locally is impractical (each iteration is a full Docker-orchestrated test), but the diagnosis matches the observed symptom exactly: a constant 10-row undercount in the `_errors` table, never an over-count. The PR's own CI run will exercise the fix at scale.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not for changelog — test-only fix.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

No documentation needed.

---

cc @alexey-milovidov — surfaced this on #104905.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.714`
<!-- ch-version-info:end -->