### PR TITLE
Retry wget downloads in Ubuntu and distroless Dockerfiles

### DIFF
--- a/docker/server/Dockerfile.distroless
+++ b/docker/server/Dockerfile.distroless
@@ -46,12 +46,28 @@ ARG DIRECT_DOWNLOAD_URLS=""
 ARG single_binary_location_url=""
 ARG TARGETARCH
 
+# Number of `wget` retries and delay between them, for resilience against
+# transient HTTP errors (e.g. `clickhouse-builds.s3.amazonaws.com` returning
+# `500 Internal Server Error` / `503 Service Unavailable` during builds).
+ARG WGET_RETRIES=5
+ARG WGET_RETRY_DELAY=1
+
 # Install from direct URLs (deb packages provided by CI).
-RUN if [ -n "${DIRECT_DOWNLOAD_URLS}" ]; then \
+RUN wget_with_retry() { \
+        local attempt=1; \
+        while [ "$attempt" -le "${WGET_RETRIES}" ]; do \
+            if wget --progress=bar:force:noscroll "$@"; then return 0; fi; \
+            echo "Attempt $attempt/${WGET_RETRIES} failed, retrying in ${WGET_RETRY_DELAY}s..."; \
+            sleep "${WGET_RETRY_DELAY}"; \
+            attempt=$((attempt + 1)); \
+        done; \
+        echo "ERROR: Failed to download after ${WGET_RETRIES} attempts"; return 1; \
+    } \
+    && if [ -n "${DIRECT_DOWNLOAD_URLS}" ]; then \
         rm -rf /tmp/clickhouse_debs \
         && mkdir -p /tmp/clickhouse_debs \
         && for url in $DIRECT_DOWNLOAD_URLS; do \
-            wget --progress=bar:force:noscroll "$url" -P /tmp/clickhouse_debs || exit 1 \
+            wget_with_retry "$url" -P /tmp/clickhouse_debs || exit 1 \
         ; done \
         && dpkg -i /tmp/clickhouse_debs/*.deb \
         && rm -rf /tmp/* ; \

--- a/docker/server/Dockerfile.ubuntu
+++ b/docker/server/Dockerfile.ubuntu
@@ -48,13 +48,29 @@ ARG single_binary_location_url=""
 
 ARG TARGETARCH
 
+# Number of `wget` retries and delay between them, for resilience against
+# transient HTTP errors (e.g. `clickhouse-builds.s3.amazonaws.com` returning
+# `500 Internal Server Error` / `503 Service Unavailable` during builds).
+ARG WGET_RETRIES=5
+ARG WGET_RETRY_DELAY=1
+
 # install from direct URL
-RUN if [ -n "${DIRECT_DOWNLOAD_URLS}" ]; then \
+RUN wget_with_retry() { \
+        local attempt=1; \
+        while [ "$attempt" -le "${WGET_RETRIES}" ]; do \
+            if wget --progress=bar:force:noscroll "$@"; then return 0; fi; \
+            echo "Attempt $attempt/${WGET_RETRIES} failed, retrying in ${WGET_RETRY_DELAY}s..."; \
+            sleep "${WGET_RETRY_DELAY}"; \
+            attempt=$((attempt + 1)); \
+        done; \
+        echo "ERROR: Failed to download after ${WGET_RETRIES} attempts"; return 1; \
+    } \
+    && if [ -n "${DIRECT_DOWNLOAD_URLS}" ]; then \
         echo "installing from custom predefined urls with deb packages: ${DIRECT_DOWNLOAD_URLS}" \
         && rm -rf /tmp/clickhouse_debs \
         && mkdir -p /tmp/clickhouse_debs \
         && for url in $DIRECT_DOWNLOAD_URLS; do \
-            wget --progress=bar:force:noscroll "$url" -P /tmp/clickhouse_debs || exit 1 \
+            wget_with_retry "$url" -P /tmp/clickhouse_debs || exit 1 \
         ; done \
         && dpkg -i /tmp/clickhouse_debs/*.deb \
         && rm -rf /tmp/* ; \


### PR DESCRIPTION
The `Docker server image` job intermittently fails when fetching the prebuilt `.deb` packages from `clickhouse-builds.s3.amazonaws.com`:

```
ERROR 500: Internal Server Error.
ERROR 503: Service Unavailable.
```

Three unrelated PRs hit this S3 download flake over three days — `#100173` on 2026-05-15 (`500`), `#104694` on 2026-05-14 (`503`), `#104853` on 2026-05-13 (`503`). The 14-day CIDB pattern is below.

```
day         master_hits  pr_hits  distinct_prs
2026-05-15           0        1            1
2026-05-14           0        2            1
2026-05-13           0        1            1
2026-05-08           0        6            1
2026-05-07           0        1            1
2026-05-05           0       12            5   ← apt mirror outage, different shape
2026-05-04           1       20           10   ← apt mirror outage, different shape
```

(Most of `2026-05-04`/`2026-05-05` was a different, apt-`ca-certificates` failure mode; the recent `500`/`503` shape on May 13–15 is the one this PR addresses.)

`docker/server/Dockerfile.alpine` already wraps `wget` with a retry helper (added in #100380 to absorb the same kind of transient errors during Alpine cross-architecture builds via QEMU). The Ubuntu and distroless flavours still call `wget ... || exit 1` on the very first attempt, so a single `500`/`503` from S3 kills the whole build.

This change ports the same `wget_with_retry` wrapper to `docker/server/Dockerfile.ubuntu` and `docker/server/Dockerfile.distroless` for the `DIRECT_DOWNLOAD_URLS` block (the path used by CI). `WGET_RETRIES` (default `5`) and `WGET_RETRY_DELAY` (default `1s`) match the Alpine version and remain overridable via `--build-arg`.

Triggered by @alexey-milovidov's directive on #100173:
> @groeneai, could you investigate the latter two (Docker server image S3 500 / `Stress test (arm_tsan)` global timeout) and provide a fix in a separate PR if a fix is needed?

CI report (#100173, sha `3ceac71`): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100173&sha=3ceac71a43a5fd4fc1a7859937b23e71b8fe42ae&name_0=PR&name_1=Docker%20server%20image

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.797`
<!-- ch-version-info:end -->