### PR TITLE
Remove redundant per-query SETTINGS in 03772_temporary_files_codec

### DIFF
--- a/tests/queries/0_stateless/03772_temporary_files_codec.sql
+++ b/tests/queries/0_stateless/03772_temporary_files_codec.sql
@@ -11,28 +11,23 @@ SET max_memory_usage = '1G';
 CREATE TEMPORARY TABLE start_ts AS ( SELECT now() AS ts );
 
 SELECT * FROM (SELECT number, 'payload' FROM numbers(2_000_000)) ORDER BY number
-SETTINGS log_comment='03772_temporary_files_codec/sort', temporary_files_codec = 'NONE',
-    max_bytes_before_external_sort = '256K', max_bytes_ratio_before_external_sort = 0 -- CI may inject 0 for bytes and ratio, or a constant-string column whose ColumnConst::byteSize() is tiny (~7 bytes not N*7); use 256K to ensure spill triggers on the first block of UInt64 data (~512KB)
+SETTINGS log_comment='03772_temporary_files_codec/sort', temporary_files_codec = 'NONE'
 FORMAT Null;
 
 SELECT * FROM (SELECT number, 'payload' FROM numbers(2_000_000)) ORDER BY number
-SETTINGS log_comment='03772_temporary_files_codec/sort', temporary_files_codec = 'LZ4',
-    max_bytes_before_external_sort = '256K', max_bytes_ratio_before_external_sort = 0
+SETTINGS log_comment='03772_temporary_files_codec/sort', temporary_files_codec = 'LZ4'
 FORMAT Null;
 
 SELECT key, sum(val) FROM (SELECT number AS key, number as val FROM numbers(2_000_000)) GROUP BY key
-SETTINGS log_comment='03772_temporary_files_codec/agg', temporary_files_codec = 'NONE',
-    max_bytes_before_external_group_by = '1M', max_bytes_ratio_before_external_group_by = 0 -- CI may inject 0 for bytes and ratio; pin bytes threshold to ensure spill occurs
+SETTINGS log_comment='03772_temporary_files_codec/agg', temporary_files_codec = 'NONE'
 FORMAT Null;
 
 SELECT key, sum(val) FROM (SELECT number AS key, number as val FROM numbers(2_000_000)) GROUP BY key
-SETTINGS log_comment='03772_temporary_files_codec/agg', temporary_files_codec = 'LZ4',
-    max_bytes_before_external_group_by = '1M', max_bytes_ratio_before_external_group_by = 0
+SETTINGS log_comment='03772_temporary_files_codec/agg', temporary_files_codec = 'LZ4'
 FORMAT Null;
 
 SELECT key, sum(val) FROM (SELECT number AS key, number as val FROM numbers(2_000_000)) GROUP BY key
-SETTINGS log_comment='03772_temporary_files_codec/agg', temporary_files_codec = 'NONE',
-    max_bytes_before_external_group_by = '1M', max_bytes_ratio_before_external_group_by = 0
+SETTINGS log_comment='03772_temporary_files_codec/agg', temporary_files_codec = 'NONE'
 FORMAT Null;
 
 SET max_bytes_in_join = '1M';


### PR DESCRIPTION
The five `SELECT`/`GROUP BY` queries in `tests/queries/0_stateless/03772_temporary_files_codec.sql` (sort × 2, agg × 3) each carried per-query `SETTINGS` clauses re-pinning `max_bytes_before_external_sort`, `max_bytes_ratio_before_external_sort`, `max_bytes_before_external_group_by`, and `max_bytes_ratio_before_external_group_by` to the exact same values that are already pinned at session level by the `SET` statements at the top of the file.

Session `SET` already overrides the test runner's randomization, so the per-query `SETTINGS` were redundant. Removing them keeps the session-level pins (the authoritative ones) and leaves only query-specific settings (`log_comment`, `temporary_files_codec`) on each query.

Verified by running the test 30 times with randomization on a local debug build (`-- Tags: long` temporarily removed to allow more iterations): 30/30 passed. `long` tag restored before commit.

Follow-up to #101995 and #102195, addressing @azat's request:

> Though maybe reducing block size helps — https://github.com/ClickHouse/ClickHouse/pull/102195/files. But anyway, we do not need to add SETTINGS for each query, @groeneai can you please cleanup the test.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Cleanup test `03772_temporary_files_codec`: remove redundant per-query `SETTINGS` clauses that duplicate the session-level `SET` values.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.715`
<!-- ch-version-info:end -->