### PR TITLE
Fix OOM in create_parser fuzzer from nested KQL array indexing

### DIFF
--- a/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp
+++ b/src/Parsers/Kusto/KustoFunctions/IParserKQLFunction.cpp
@@ -215,7 +215,11 @@ String IParserKQLFunction::getConvertedArgument(const String & fn_name, IParser:
                                 array_index.size(), DBMS_DEFAULT_MAX_QUERY_SIZE);
                         ++pos;
                     }
-                    token = fmt::format("[ {0} >=0 ? {0} + 1 : {0}]", array_index);
+                    /// Bind `array_index` to a SQL alias once and reuse it. Otherwise the
+                    /// expression is duplicated three times in the generated SQL — which causes
+                    /// exponential memory growth when array indexing is nested.
+                    const auto alias = "_kql_array_index_" + generateUniqueIdentifier();
+                    token = fmt::format("[((({0}) AS {1}) >= 0 ? {1} + 1 : {1})]", array_index, alias);
                 }
                 else
                     token = String(pos->begin, pos->end);
@@ -433,7 +437,13 @@ String IParserKQLFunction::getExpression(IParser::Pos & pos)
             array_index += getExpression(pos);
             ++pos;
         }
-        arg = fmt::format("[ {0} >=0 ? {0} + 1 : {0}]", array_index);
+        /// Bind `array_index` to a SQL alias once and reuse it. Otherwise the
+        /// expression is duplicated three times in the generated SQL — which
+        /// causes exponential memory growth when array indexing is nested
+        /// (e.g. `a[a[a[...]]]`) and is also incorrect for non-deterministic
+        /// expressions because each fragment could observe a different value.
+        const auto alias = "_kql_array_index_" + generateUniqueIdentifier();
+        arg = fmt::format("[((({0}) AS {1}) >= 0 ? {1} + 1 : {1})]", array_index, alias);
     }
 
     /// If this was a timespan literal and it's NOT in an arithmetic context,

--- a/tests/queries/0_stateless/04241_kql_array_index_no_oom.sql
+++ b/tests/queries/0_stateless/04241_kql_array_index_no_oom.sql
@@ -1,0 +1,11 @@
+-- Tags: no-fasttest
+-- Regression test: parsing KQL array indexing with deeply nested square brackets used to allocate
+-- exponentially with depth (3^N) because the converted SQL duplicated the inner expression three
+-- times. With N ~ 20 the create_parser fuzzer OOMed at 6+ GB of RSS.
+SET allow_experimental_kusto_dialect = 1;
+SET max_memory_usage = '256Mi';
+
+-- Parsing must complete with bounded memory. The input is intentionally unbalanced so the
+-- inner expression is empty — we only care that the parse attempt does not balloon memory
+-- while building the intermediate string for `getExpression`.
+SELECT ignore(formatQuerySingleLine('SELECT * FROM kql($$Customers | where x' || repeat('[', 30) || '$$);')) FORMAT Null;

--- a/tests/queries/0_stateless/04241_kql_array_index_no_oom.sql
+++ b/tests/queries/0_stateless/04241_kql_array_index_no_oom.sql
@@ -1,4 +1,3 @@
--- Tags: no-fasttest
 -- Regression test: parsing KQL array indexing with deeply nested square brackets used to allocate
 -- exponentially with depth (3^N) because the converted SQL duplicated the inner expression three
 -- times. With N ~ 20 the create_parser fuzzer OOMed at 6+ GB of RSS.


### PR DESCRIPTION
The KQL parser's `IParserKQLFunction::getExpression` converts KQL `arr[X]` into SQL `arr[ X >=0 ? X + 1 : X]`, duplicating the inner expression three times. With N levels of nested array indexing (e.g. `arr[arr[arr[...]]]`) the generated SQL grows as `3^N` because each level's inner expression is the output of the previous level. The `create_parser_fuzzer` hit this with ~30 unbalanced `[` characters and OOMed at 6+ GB of RSS.

Local reproduction confirms the exponential growth (resident memory after parsing `SELECT * FROM kql($$Customers | where x[…[$$);`):

| Number of `[` | RSS before fix | RSS after fix |
| ---: | ---: | ---: |
| 5  | 328 MB |   159 MB |
| 10 | 330 MB |   159 MB |
| 15 | 906 MB |   159 MB |
| 20 | 16.7 GB |  159 MB |
| 30 | (OOM) |    160 MB |

The fix binds the inner expression to a SQL alias once and reuses it, so the output grows linearly in the input depth instead of exponentially. This mirrors how `formatTimespanSQL` avoids the same problem in the same file.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=105121&sha=e751e896f794f50455eabbaf3359e72aeb681da3&name_0=PR
Source PR: https://github.com/ClickHouse/ClickHouse/pull/105121

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix exponential memory growth in the KQL parser when converting nested array indexing (`arr[arr[arr[...]]]`).


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.723`
<!-- ch-version-info:end -->