### PR TITLE
Restore broken_determinism to ignore_problems in functions stress test

### DIFF
--- a/src/Functions/tests/gtest_functions_stress.cpp
+++ b/src/Functions/tests/gtest_functions_stress.cpp
@@ -208,7 +208,7 @@ struct Options
     /// Use --ignore-problems to override (e.g. pass empty value to enable all checks).
     VectorOfStrings ignore_problems = {{"late_typecheck", "const_dependent_checks", "broken_nullable_input", "data_dependent_const",
         "exception_in_prepare", "bulk_success_but_row_error", "bulk_error_but_row_success",
-        "broken_injectivity", "broken_monotonicity",
+        "broken_determinism", "broken_injectivity", "broken_monotonicity",
         "field_comparison_inconsistency", "validation_infrastructure"}};
     VectorOfStrings functions;
     VectorOfStrings skip_functions;


### PR DESCRIPTION
The check was removed from the default ignore list on 2026-05-12 in `519276200b5` ("Enforce `broken_determinism` in the functions stress test"). Since then the `function_prop_fuzzer` job on `master` surfaces dozens of determinism mismatches per day across many functions (`caseWithExpression`, `if`, `substringUTF8`, `roundDown`, `arrayUnion`, `coalesce`, `ifNull`, `rightUTF8`, `nullIf`, `equals`, ...).

These are pre-existing issues that pre-date the enforcement; they cannot all be fixed at once and the noise drowns out other regressions caught by the same job (stuck workers, `timeout_not_honored`, etc.). Re-add `broken_determinism` to the default ignore list, keeping it controllable via `--ignore-problems` for targeted work as the underlying issues are addressed one at a time.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)