### PR TITLE
Add `strict_sql_compatibility` supersetting

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -6586,6 +6586,26 @@ However, the compatibility setting can be overridden at the user, role, profile,
 :::
 )", 0) \
     \
+    DECLARE(Bool, strict_sql_compatibility, false, R"(
+Enables SQL-standard-compatible defaults for several settings at once.
+
+When set to `1`, the following settings are switched to their SQL-standard values, unless they have already been changed manually:
+- `data_type_default_nullable = 1`
+- `group_by_use_nulls = 1`
+- `intersect_default_mode = 'DISTINCT'`
+- `except_default_mode = 'DISTINCT'`
+- `joined_subquery_requires_alias = 1`
+- `join_use_nulls = 1`
+- `union_default_mode = 'DISTINCT'`
+- `aggregate_functions_null_for_empty = 1`
+- `cast_keep_nullable = 1`
+- `prefer_column_name_to_alias = 1`
+
+Switching the setting back to `0` reverts only the settings that this setting changed; settings that the user explicitly overrode are left alone.
+
+Disabled by default.
+)", 0) \
+    \
     DECLARE(Map, additional_table_filters, "", R"(
 An additional filter expression that is applied after reading
 from the specified table.
@@ -8289,8 +8309,10 @@ struct SettingsImpl : public BaseSettings<SettingsTraits>, public IHints<2>
 
 private:
     void applyCompatibilitySetting(const String & compatibility);
+    void applyStrictSqlCompatibility(bool enable);
 
     std::unordered_set<std::string_view> settings_changed_by_compatibility_setting;
+    std::unordered_set<std::string_view> settings_changed_by_strict_sql_compatibility;
 };
 
 /** Set the settings from the profile (in the server configuration, many settings can be listed in one profile).
@@ -8414,13 +8436,20 @@ void SettingsImpl::set(std::string_view name, const Field & value)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unexpected type of value for setting 'compatibility'. Expected String, got {}", value.getTypeName());
         applyCompatibilitySetting(value.safeGet<String>());
     }
-    /// If we change setting that was changed by compatibility setting before
-    /// we should remove it from settings_changed_by_compatibility_setting,
-    /// otherwise the next time we will change compatibility setting
-    /// this setting will be changed too (and we don't want it).
-    /// Resolve aliases so the lookup matches the canonical names stored in the set.
-    else if (auto final_name = SettingsTraits::resolveName(name); settings_changed_by_compatibility_setting.contains(final_name))
+    else if (name == "strict_sql_compatibility")
+    {
+        applyStrictSqlCompatibility(SettingFieldBool{value}.value);
+    }
+    /// If we change a setting that was changed by a compatibility-like setting before,
+    /// we should remove it from the corresponding tracking set; otherwise the next time
+    /// the compatibility-like setting is reapplied it would revert the manual override too.
+    /// Resolve aliases so the lookup matches the canonical names stored in the sets.
+    else
+    {
+        auto final_name = SettingsTraits::resolveName(name);
         settings_changed_by_compatibility_setting.erase(final_name);
+        settings_changed_by_strict_sql_compatibility.erase(final_name);
+    }
 
     BaseSettings::set(name, value);
 }
@@ -8462,6 +8491,53 @@ void SettingsImpl::applyCompatibilitySetting(const String & compatibility_value)
             BaseSettings::set(final_name, change.previous_value);
             settings_changed_by_compatibility_setting.insert(final_name);
         }
+    }
+}
+
+void SettingsImpl::applyStrictSqlCompatibility(bool enable)
+{
+    /// First, revert all changes applied by the previous value of `strict_sql_compatibility`
+    /// (the user can flip the setting on and off, and we only undo what we ourselves changed).
+    for (const auto & setting_name : settings_changed_by_strict_sql_compatibility)
+        resetToDefault(setting_name);
+
+    settings_changed_by_strict_sql_compatibility.clear();
+
+    if (!enable)
+        return;
+
+    /// Curated list of settings whose SQL-standard-aligned values the supersetting flips on.
+    /// Values are encoded as strings because both `Bool` and `SetOperationMode` setting fields
+    /// parse from their string representation, which keeps the table heterogeneous yet uniform.
+    static constexpr std::array<std::pair<std::string_view, std::string_view>, 10> overrides = {{
+        {"data_type_default_nullable",         "1"},
+        {"group_by_use_nulls",                 "1"},
+        {"intersect_default_mode",             "DISTINCT"},
+        {"except_default_mode",                "DISTINCT"},
+        {"joined_subquery_requires_alias",     "1"},
+        {"join_use_nulls",                     "1"},
+        {"union_default_mode",                 "DISTINCT"},
+        {"aggregate_functions_null_for_empty", "1"},
+        {"cast_keep_nullable",                 "1"},
+        {"prefer_column_name_to_alias",        "1"},
+    }};
+
+    for (const auto & [name, value] : overrides)
+    {
+        auto final_name = SettingsTraits::resolveName(name);
+
+        /// If this setting was changed manually, we don't touch it.
+        if (isChanged(final_name) && !settings_changed_by_strict_sql_compatibility.contains(final_name))
+            continue;
+
+        Field new_value{String{value}};
+
+        /// Don't mark as changed if the value isn't really changed.
+        if (get(final_name) == new_value)
+            continue;
+
+        BaseSettings::set(final_name, new_value);
+        settings_changed_by_strict_sql_compatibility.insert(final_name);
     }
 }
 

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -86,6 +86,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"use_top_k_dynamic_filtering_for_variable_length_types", true, false, "Disable `use_top_k_dynamic_filtering` for variable-length sort columns (e.g. `String`) by default; the previous behavior had the optimization apply unconditionally and is preserved under `compatibility`."},
             {"page_cache_max_coalesced_bytes", 16777216, 16777216, "New setting to bound the size of a single coalesced read used to populate the userspace page cache on cache miss."},
             {"input_format_column_name_matching_mode", "match_case", "auto", "Match input column names case-sensitively first and fall back to case-insensitive matching, instead of requiring an exact case match."},
+            {"strict_sql_compatibility", false, false, "New supersetting that, when enabled, flips a curated set of existing settings to their SQL-standard-compliant values."},
         });
         addSettingsChanges(settings_changes_history, "26.4",
         {

--- a/tests/queries/0_stateless/04241_strict_sql_compatibility.reference
+++ b/tests/queries/0_stateless/04241_strict_sql_compatibility.reference
@@ -1,0 +1,46 @@
+-- { echo }
+
+SELECT name, value FROM system.settings WHERE name IN ('data_type_default_nullable', 'group_by_use_nulls', 'intersect_default_mode', 'except_default_mode', 'joined_subquery_requires_alias', 'join_use_nulls', 'union_default_mode', 'aggregate_functions_null_for_empty', 'cast_keep_nullable', 'prefer_column_name_to_alias') ORDER BY name;
+aggregate_functions_null_for_empty	0
+cast_keep_nullable	0
+data_type_default_nullable	0
+except_default_mode	ALL
+group_by_use_nulls	0
+intersect_default_mode	ALL
+join_use_nulls	0
+joined_subquery_requires_alias	1
+prefer_column_name_to_alias	0
+union_default_mode	
+SET strict_sql_compatibility = 1;
+SELECT name, value FROM system.settings WHERE name IN ('data_type_default_nullable', 'group_by_use_nulls', 'intersect_default_mode', 'except_default_mode', 'joined_subquery_requires_alias', 'join_use_nulls', 'union_default_mode', 'aggregate_functions_null_for_empty', 'cast_keep_nullable', 'prefer_column_name_to_alias') ORDER BY name;
+aggregate_functions_null_for_empty	1
+cast_keep_nullable	1
+data_type_default_nullable	1
+except_default_mode	DISTINCT
+group_by_use_nulls	1
+intersect_default_mode	DISTINCT
+join_use_nulls	1
+joined_subquery_requires_alias	1
+prefer_column_name_to_alias	1
+union_default_mode	DISTINCT
+SET join_use_nulls = 0;
+SELECT value FROM system.settings WHERE name = 'join_use_nulls';
+0
+SET strict_sql_compatibility = 0;
+SELECT name, value FROM system.settings WHERE name IN ('data_type_default_nullable', 'group_by_use_nulls', 'intersect_default_mode', 'except_default_mode', 'joined_subquery_requires_alias', 'join_use_nulls', 'union_default_mode', 'aggregate_functions_null_for_empty', 'cast_keep_nullable', 'prefer_column_name_to_alias') ORDER BY name;
+aggregate_functions_null_for_empty	0
+cast_keep_nullable	0
+data_type_default_nullable	0
+except_default_mode	ALL
+group_by_use_nulls	0
+intersect_default_mode	ALL
+join_use_nulls	0
+joined_subquery_requires_alias	1
+prefer_column_name_to_alias	0
+union_default_mode	
+SET cast_keep_nullable = 0;
+SET strict_sql_compatibility = 1;
+SELECT value FROM system.settings WHERE name = 'cast_keep_nullable';
+0
+SELECT value FROM system.settings WHERE name = 'union_default_mode';
+DISTINCT

--- a/tests/queries/0_stateless/04241_strict_sql_compatibility.sql
+++ b/tests/queries/0_stateless/04241_strict_sql_compatibility.sql
@@ -1,0 +1,17 @@
+-- Tests for the `strict_sql_compatibility` supersetting.
+-- When enabled, it flips a curated list of existing settings to their SQL-standard values.
+-- Disabling it reverts only the settings the supersetting itself changed, leaving manual user overrides alone.
+
+-- { echo }
+
+SELECT name, value FROM system.settings WHERE name IN ('data_type_default_nullable', 'group_by_use_nulls', 'intersect_default_mode', 'except_default_mode', 'joined_subquery_requires_alias', 'join_use_nulls', 'union_default_mode', 'aggregate_functions_null_for_empty', 'cast_keep_nullable', 'prefer_column_name_to_alias') ORDER BY name;
+SET strict_sql_compatibility = 1;
+SELECT name, value FROM system.settings WHERE name IN ('data_type_default_nullable', 'group_by_use_nulls', 'intersect_default_mode', 'except_default_mode', 'joined_subquery_requires_alias', 'join_use_nulls', 'union_default_mode', 'aggregate_functions_null_for_empty', 'cast_keep_nullable', 'prefer_column_name_to_alias') ORDER BY name;
+SET join_use_nulls = 0;
+SELECT value FROM system.settings WHERE name = 'join_use_nulls';
+SET strict_sql_compatibility = 0;
+SELECT name, value FROM system.settings WHERE name IN ('data_type_default_nullable', 'group_by_use_nulls', 'intersect_default_mode', 'except_default_mode', 'joined_subquery_requires_alias', 'join_use_nulls', 'union_default_mode', 'aggregate_functions_null_for_empty', 'cast_keep_nullable', 'prefer_column_name_to_alias') ORDER BY name;
+SET cast_keep_nullable = 0;
+SET strict_sql_compatibility = 1;
+SELECT value FROM system.settings WHERE name = 'cast_keep_nullable';
+SELECT value FROM system.settings WHERE name = 'union_default_mode';


### PR DESCRIPTION
Resolves [#98600](https://github.com/ClickHouse/ClickHouse/issues/98600) (and its duplicate [#99796](https://github.com/ClickHouse/ClickHouse/issues/99796)).

ClickHouse deviates from the SQL standard in several places, each controlled by its own setting. Configuring SQL-standard-compatible behavior currently requires discovering and toggling ~10 individual settings. This PR adds a single `Bool` supersetting that does it in one line:

```sql
SET strict_sql_compatibility = 1;
```

The supersetting reuses the proven interceptor pattern of the existing `compatibility` setting (`SettingsImpl::set` -> `applyCompatibilitySetting`). When enabled it flips the listed settings to their SQL-standard values; when disabled it reverts only the settings it itself changed, leaving manual user overrides alone. Settings the user has already modified are not touched.

### Settings affected

| Setting | Current default | SQL-standard value | Source of "standard" claim |
|---|---|---|---|
| `data_type_default_nullable` | `false` | `true` | Issue body; SQL std: columns nullable by default |
| `group_by_use_nulls` | `false` | `true` | Docs: "the same way as the SQL standard says" |
| `intersect_default_mode` | `ALL` | `DISTINCT` | SQL std: `INTERSECT DISTINCT` is the default |
| `except_default_mode` | `ALL` | `DISTINCT` | Symmetric with `INTERSECT`/`UNION` |
| `joined_subquery_requires_alias` | `true` | `true` | Issue body; included for documented intent (no-op against default) |
| `join_use_nulls` | `false` | `true` | Docs: "JOIN behaves the same way as in standard SQL" |
| `union_default_mode` | `Unspecified` | `DISTINCT` | SQL std: `UNION DISTINCT` is the default |
| `aggregate_functions_null_for_empty` | `false` | `true` | Docs literally: "Enable it for SQL standard compatibility" |
| `cast_keep_nullable` | `false` | `true` | @UnamedRus's suggestion on #98600 |
| `prefer_column_name_to_alias` | `false` | `true` | @UnamedRus's suggestion on #98600; docs: "compatible with most other database engines" |

I deliberately limited the scope to settings whose SQL-standard mapping is unambiguous and documented. Borderline candidates (`empty_result_for_aggregation_by_empty_set`, `enable_scopes_for_with_statement`, `decimal_check_overflow`, `insert_null_as_default`) were left out — expanding scope later is cheaper than rolling back behavior.

### Changelog category (leave one):
- New Feature

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Added the `strict_sql_compatibility` setting. When enabled, it flips a curated list of existing settings (`data_type_default_nullable`, `group_by_use_nulls`, `intersect_default_mode`, `except_default_mode`, `joined_subquery_requires_alias`, `join_use_nulls`, `union_default_mode`, `aggregate_functions_null_for_empty`, `cast_keep_nullable`, `prefer_column_name_to_alias`) to their SQL-standard-compliant values, and reverts only those when disabled.

### Documentation entry for user-facing changes

- [x] Documentation included in this PR (the setting docstring in `Settings.cpp` is what feeds the autogenerated `docs/en/operations/settings/settings.md`).

Made with [Cursor](https://cursor.com)