### PR TITLE
Make arrayResize honor max_execution_time on heavy element types (#104877)

### DIFF
--- a/src/Functions/GatherUtils/Algorithms.h
+++ b/src/Functions/GatherUtils/Algorithms.h
@@ -694,6 +694,15 @@ void NO_INLINE arrayAllAny(FirstSource && first, SecondSource && second, UInt8 *
     }
 }
 
+/// `writeSlice` of a single element on heavy types (Map, Tuple, String, Array of
+/// big-ints) can cost hundreds of nanoseconds, so a single arrayResize call that
+/// fills hundreds of millions of slots runs for tens of seconds without ever
+/// returning to the pipeline. Poll the per-thread cancellation flag every this
+/// many write iterations so that `max_execution_time` and explicit `KILL QUERY`
+/// take effect promptly. The period is a power of two so the compiler folds the
+/// modulo into a bit-and.
+inline constexpr size_t resize_cancellation_check_period = 16384;
+
 template <typename ArraySource, typename ValueSource, typename Sink>
 void resizeDynamicSize(ArraySource && array_source, ValueSource && value_source, Sink && sink, const IColumn & size_column)
 {
@@ -722,7 +731,11 @@ void resizeDynamicSize(ArraySource && array_source, ValueSource && value_source,
                 {
                     writeSlice(array_source.getWhole(), sink);
                     for (size_t i = array_size; i < length; ++i)
+                    {
+                        if (((i - array_size) % resize_cancellation_check_period) == 0)
+                            checkQueryCancellation();
                         writeSlice(value_source.getWhole(), sink);
+                    }
                 }
                 else
                     writeSlice(array_source.getSliceFromLeft(0, length), sink);
@@ -737,7 +750,11 @@ void resizeDynamicSize(ArraySource && array_source, ValueSource && value_source,
                 if (array_size <= length)
                 {
                     for (size_t i = array_size; i < length; ++i)
+                    {
+                        if (((i - array_size) % resize_cancellation_check_period) == 0)
+                            checkQueryCancellation();
                         writeSlice(value_source.getWhole(), sink);
+                    }
                     writeSlice(array_source.getWhole(), sink);
                 }
                 else
@@ -771,7 +788,11 @@ void resizeConstantSize(ArraySource && array_source, ValueSource && value_source
             {
                 writeSlice(array_source.getWhole(), sink);
                 for (size_t i = array_size; i < length; ++i)
+                {
+                    if (((i - array_size) % resize_cancellation_check_period) == 0)
+                        checkQueryCancellation();
                     writeSlice(value_source.getWhole(), sink);
+                }
             }
             else
                 writeSlice(array_source.getSliceFromLeft(0, length), sink);
@@ -786,7 +807,11 @@ void resizeConstantSize(ArraySource && array_source, ValueSource && value_source
             if (array_size <= length)
             {
                 for (size_t i = array_size; i < length; ++i)
+                {
+                    if (((i - array_size) % resize_cancellation_check_period) == 0)
+                        checkQueryCancellation();
                     writeSlice(value_source.getWhole(), sink);
+                }
                 writeSlice(array_source.getWhole(), sink);
             }
             else

--- a/src/Functions/GatherUtils/GatherUtils.cpp
+++ b/src/Functions/GatherUtils/GatherUtils.cpp
@@ -1,5 +1,19 @@
 #include <Functions/GatherUtils/GatherUtils.h>
 
+#include <Common/CurrentThread.h>
+#include <Common/Exception.h>
+
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int QUERY_WAS_CANCELLED;
+}
+
+}
+
 namespace DB::GatherUtils
 {
 
@@ -23,6 +37,12 @@ void sliceHas(IArraySource & first, IArraySource & second, ArraySearchType searc
             sliceHasEndsWith(first, second, result);
             break;
     }
+}
+
+void checkQueryCancellation()
+{
+    if (CurrentThread::isInitialized() && CurrentThread::get().isQueryCanceled())
+        throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Query was cancelled");
 }
 
 }

--- a/src/Functions/GatherUtils/GatherUtils.cpp
+++ b/src/Functions/GatherUtils/GatherUtils.cpp
@@ -2,6 +2,8 @@
 
 #include <Common/CurrentThread.h>
 #include <Common/Exception.h>
+#include <Interpreters/Context.h>
+#include <Interpreters/ProcessList.h>
 
 
 namespace DB
@@ -41,6 +43,25 @@ void sliceHas(IArraySource & first, IArraySource & second, ArraySearchType searc
 
 void checkQueryCancellation()
 {
+    /// Route through `QueryStatus::throwIfKilled` whenever the thread is attached
+    /// to a query that owns a `ProcessListElement`. This preserves the existing
+    /// error-code semantics from the rest of query execution: a query killed by
+    /// `max_execution_time` surfaces as `TIMEOUT_EXCEEDED`, a user/error cancel
+    /// surfaces as `QUERY_WAS_CANCELLED` (or rethrows a stored cancellation
+    /// exception when one was attached to the `QueryStatus`).
+    if (auto query_context = CurrentThread::tryGetQueryContext())
+    {
+        if (auto query_status = query_context->getProcessListElementSafe())
+        {
+            query_status->throwIfKilled();
+            return;
+        }
+    }
+
+    /// Fallback for code paths that have no query context attached to the process
+    /// list (background tasks that wire a cancellation predicate directly into
+    /// `ThreadStatus`). We cannot tell timeout from user-cancel here, so we keep
+    /// the previous behaviour and report `QUERY_WAS_CANCELLED`.
     if (CurrentThread::isInitialized() && CurrentThread::get().isQueryCanceled())
         throw Exception(ErrorCodes::QUERY_WAS_CANCELLED, "Query was cancelled");
 }

--- a/src/Functions/GatherUtils/GatherUtils.h
+++ b/src/Functions/GatherUtils/GatherUtils.h
@@ -70,10 +70,14 @@ void push(IArraySource & array_source, IValueSource & value_source, IArraySink &
 void resizeDynamicSize(IArraySource & array_source, IValueSource & value_source, IArraySink & sink, const IColumn & size_column);
 void resizeConstantSize(IArraySource & array_source, IValueSource & value_source, IArraySink & sink, ssize_t size);
 
-/// Polls the per-thread query cancellation flag and throws `QUERY_WAS_CANCELLED`
-/// when the query has been killed. Called periodically from hot loops inside
-/// `resizeDynamicSize` and `resizeConstantSize` so that `max_execution_time`
-/// is honored while filling very long arrays with heavy element types.
+/// Polls the per-thread query cancellation state and throws the appropriate
+/// exception when the query has been killed. When a `QueryStatus` is available
+/// the call is routed through `QueryStatus::throwIfKilled`, so a timeout-driven
+/// cancellation surfaces as `TIMEOUT_EXCEEDED` and a user/error cancellation
+/// surfaces as `QUERY_WAS_CANCELLED`, matching the semantics used elsewhere in
+/// query execution. Called periodically from hot loops inside `resizeDynamicSize`
+/// and `resizeConstantSize` so that `max_execution_time` is honored while filling
+/// very long arrays with heavy element types.
 void checkQueryCancellation();
 
 }

--- a/src/Functions/GatherUtils/GatherUtils.h
+++ b/src/Functions/GatherUtils/GatherUtils.h
@@ -70,4 +70,10 @@ void push(IArraySource & array_source, IValueSource & value_source, IArraySink &
 void resizeDynamicSize(IArraySource & array_source, IValueSource & value_source, IArraySink & sink, const IColumn & size_column);
 void resizeConstantSize(IArraySource & array_source, IValueSource & value_source, IArraySink & sink, ssize_t size);
 
+/// Polls the per-thread query cancellation flag and throws `QUERY_WAS_CANCELLED`
+/// when the query has been killed. Called periodically from hot loops inside
+/// `resizeDynamicSize` and `resizeConstantSize` so that `max_execution_time`
+/// is honored while filling very long arrays with heavy element types.
+void checkQueryCancellation();
+
 }

--- a/tests/queries/0_stateless/04252_104877_array_resize_max_execution_time.sql
+++ b/tests/queries/0_stateless/04252_104877_array_resize_max_execution_time.sql
@@ -5,15 +5,19 @@
 -- did not poll the query cancellation flag, so a single call could run for tens of
 -- seconds despite a low `max_execution_time` and was reported as `P_TIMEOUT_NOT_HONORED`
 -- by the function-properties stress test.
+--
+-- The poll routes through `QueryStatus::throwIfKilled`, so a `max_execution_time`
+-- trip surfaces as `TIMEOUT_EXCEEDED` (matching the rest of query execution),
+-- not the generic `QUERY_WAS_CANCELLED`.
 SET max_execution_time = 3;
 
 -- Dynamic (`materialize`d) negative size: triggered the original 79s timeout in
 -- `function_prop_fuzzer`. With the polling guard in place, this is cancelled within
 -- a fraction of the configured budget.
-SELECT length(arrayResize([map(toInt256(1), toFloat64(2))], materialize(toInt256(-550164762)))); -- { serverError TIMEOUT_EXCEEDED, QUERY_WAS_CANCELLED }
+SELECT length(arrayResize([map(toInt256(1), toFloat64(2))], materialize(toInt256(-550164762)))); -- { serverError TIMEOUT_EXCEEDED }
 
 -- Constant negative size: same code path on the `resizeConstantSize` side.
-SELECT length(arrayResize([map(toInt256(1), toFloat64(2))], -550164762)); -- { serverError TIMEOUT_EXCEEDED, QUERY_WAS_CANCELLED }
+SELECT length(arrayResize([map(toInt256(1), toFloat64(2))], -550164762)); -- { serverError TIMEOUT_EXCEEDED }
 
 -- Constant positive size: covers the extend-with-default branch.
-SELECT length(arrayResize([map(toInt256(1), toFloat64(2))], 550164762)); -- { serverError TIMEOUT_EXCEEDED, QUERY_WAS_CANCELLED }
+SELECT length(arrayResize([map(toInt256(1), toFloat64(2))], 550164762)); -- { serverError TIMEOUT_EXCEEDED }

--- a/tests/queries/0_stateless/04252_104877_array_resize_max_execution_time.sql
+++ b/tests/queries/0_stateless/04252_104877_array_resize_max_execution_time.sql
@@ -1,5 +1,5 @@
 -- https://github.com/ClickHouse/ClickHouse/issues/104877
--- Regression test for arrayResize honoring max_execution_time when the requested
+-- Regression test for `arrayResize` honoring `max_execution_time` when the requested
 -- length is very large and the element type is heavy (`Map(Int256, Float64)`).
 -- Previously, the inner write loop inside `resizeDynamicSize`/`resizeConstantSize`
 -- did not poll the query cancellation flag, so a single call could run for tens of
@@ -7,17 +7,21 @@
 -- by the function-properties stress test.
 --
 -- The poll routes through `QueryStatus::throwIfKilled`, so a `max_execution_time`
--- trip surfaces as `TIMEOUT_EXCEEDED` (matching the rest of query execution),
--- not the generic `QUERY_WAS_CANCELLED`.
+-- trip surfaces as `TIMEOUT_EXCEEDED` (matching the rest of query execution).
+-- On tight-memory builds (Fast test, sanitizers, debug parallel) the huge default
+-- allocation for ~550M heavy Map elements can trip the per-query memory limit
+-- before the 3 s deadline, surfacing as `MEMORY_LIMIT_EXCEEDED` — both error codes
+-- prove the inner loop is now bounded and cancellable, which is the regression we
+-- are guarding against.
 SET max_execution_time = 3;
 
--- Dynamic (`materialize`d) negative size: triggered the original 79s timeout in
+-- Dynamic (`materialize`d) negative size: triggered the original 79 s timeout in
 -- `function_prop_fuzzer`. With the polling guard in place, this is cancelled within
 -- a fraction of the configured budget.
-SELECT length(arrayResize([map(toInt256(1), toFloat64(2))], materialize(toInt256(-550164762)))); -- { serverError TIMEOUT_EXCEEDED }
+SELECT length(arrayResize([map(toInt256(1), toFloat64(2))], materialize(toInt256(-550164762)))); -- { serverError TIMEOUT_EXCEEDED, MEMORY_LIMIT_EXCEEDED }
 
 -- Constant negative size: same code path on the `resizeConstantSize` side.
-SELECT length(arrayResize([map(toInt256(1), toFloat64(2))], -550164762)); -- { serverError TIMEOUT_EXCEEDED }
+SELECT length(arrayResize([map(toInt256(1), toFloat64(2))], -550164762)); -- { serverError TIMEOUT_EXCEEDED, MEMORY_LIMIT_EXCEEDED }
 
 -- Constant positive size: covers the extend-with-default branch.
-SELECT length(arrayResize([map(toInt256(1), toFloat64(2))], 550164762)); -- { serverError TIMEOUT_EXCEEDED }
+SELECT length(arrayResize([map(toInt256(1), toFloat64(2))], 550164762)); -- { serverError TIMEOUT_EXCEEDED, MEMORY_LIMIT_EXCEEDED }

--- a/tests/queries/0_stateless/04252_104877_array_resize_max_execution_time.sql
+++ b/tests/queries/0_stateless/04252_104877_array_resize_max_execution_time.sql
@@ -1,27 +1,35 @@
 -- https://github.com/ClickHouse/ClickHouse/issues/104877
--- Regression test for `arrayResize` honoring `max_execution_time` when the requested
--- length is very large and the element type is heavy (`Map(Int256, Float64)`).
--- Previously, the inner write loop inside `resizeDynamicSize`/`resizeConstantSize`
--- did not poll the query cancellation flag, so a single call could run for tens of
--- seconds despite a low `max_execution_time` and was reported as `P_TIMEOUT_NOT_HONORED`
--- by the function-properties stress test.
+-- Regression test for `arrayResize` honoring `max_execution_time` when the
+-- requested length is very large and the element type is heavy
+-- (`Map(Int256, Float64)`). Previously the inner write loop inside
+-- `resizeDynamicSize`/`resizeConstantSize` did not poll the query
+-- cancellation flag, so a single call could run for tens of seconds despite
+-- a low `max_execution_time` and was reported as `P_TIMEOUT_NOT_HONORED`
+-- by `function_prop_fuzzer` (the original reproducer used ~550M elements
+-- and ran for ~79 s under `max_execution_time = 3`).
 --
--- The poll routes through `QueryStatus::throwIfKilled`, so a `max_execution_time`
--- trip surfaces as `TIMEOUT_EXCEEDED` (matching the rest of query execution).
--- On tight-memory builds (Fast test, sanitizers, debug parallel) the huge default
--- allocation for ~550M heavy Map elements can trip the per-query memory limit
--- before the 3 s deadline, surfacing as `MEMORY_LIMIT_EXCEEDED` — both error codes
--- prove the inner loop is now bounded and cancellable, which is the regression we
--- are guarding against.
+-- The poll routes through `QueryStatus::throwIfKilled`, so a
+-- `max_execution_time` trip surfaces as `TIMEOUT_EXCEEDED` (matching the
+-- rest of query execution). To make this regression deterministic for
+-- timeout behaviour we (1) scale the reproducer down to ~200M elements
+-- (~1.6 GB of offsets, well under any per-query / OS memory limit on every
+-- CI builder including sanitizers, while still keeping the unpatched
+-- inner-loop run-time above the 3 s deadline on release builds) and
+-- (2) disable the per-query memory limit via `max_memory_usage = 0` so
+-- that even with allocator overhead the regression cannot terminate via
+-- `MEMORY_LIMIT_EXCEEDED` before the cancellation polling fires. The
+-- only way for the assertion below to be satisfied is via the
+-- cancellation path we are guarding.
 SET max_execution_time = 3;
+SET max_memory_usage = 0;
 
 -- Dynamic (`materialize`d) negative size: triggered the original 79 s timeout in
 -- `function_prop_fuzzer`. With the polling guard in place, this is cancelled within
 -- a fraction of the configured budget.
-SELECT length(arrayResize([map(toInt256(1), toFloat64(2))], materialize(toInt256(-550164762)))); -- { serverError TIMEOUT_EXCEEDED, MEMORY_LIMIT_EXCEEDED }
+SELECT length(arrayResize([map(toInt256(1), toFloat64(2))], materialize(toInt256(-200000000)))); -- { serverError TIMEOUT_EXCEEDED }
 
 -- Constant negative size: same code path on the `resizeConstantSize` side.
-SELECT length(arrayResize([map(toInt256(1), toFloat64(2))], -550164762)); -- { serverError TIMEOUT_EXCEEDED, MEMORY_LIMIT_EXCEEDED }
+SELECT length(arrayResize([map(toInt256(1), toFloat64(2))], -200000000)); -- { serverError TIMEOUT_EXCEEDED }
 
 -- Constant positive size: covers the extend-with-default branch.
-SELECT length(arrayResize([map(toInt256(1), toFloat64(2))], 550164762)); -- { serverError TIMEOUT_EXCEEDED, MEMORY_LIMIT_EXCEEDED }
+SELECT length(arrayResize([map(toInt256(1), toFloat64(2))], 200000000)); -- { serverError TIMEOUT_EXCEEDED }

--- a/tests/queries/0_stateless/04252_104877_array_resize_max_execution_time.sql
+++ b/tests/queries/0_stateless/04252_104877_array_resize_max_execution_time.sql
@@ -1,0 +1,19 @@
+-- https://github.com/ClickHouse/ClickHouse/issues/104877
+-- Regression test for arrayResize honoring max_execution_time when the requested
+-- length is very large and the element type is heavy (`Map(Int256, Float64)`).
+-- Previously, the inner write loop inside `resizeDynamicSize`/`resizeConstantSize`
+-- did not poll the query cancellation flag, so a single call could run for tens of
+-- seconds despite a low `max_execution_time` and was reported as `P_TIMEOUT_NOT_HONORED`
+-- by the function-properties stress test.
+SET max_execution_time = 3;
+
+-- Dynamic (`materialize`d) negative size: triggered the original 79s timeout in
+-- `function_prop_fuzzer`. With the polling guard in place, this is cancelled within
+-- a fraction of the configured budget.
+SELECT length(arrayResize([map(toInt256(1), toFloat64(2))], materialize(toInt256(-550164762)))); -- { serverError TIMEOUT_EXCEEDED, QUERY_WAS_CANCELLED }
+
+-- Constant negative size: same code path on the `resizeConstantSize` side.
+SELECT length(arrayResize([map(toInt256(1), toFloat64(2))], -550164762)); -- { serverError TIMEOUT_EXCEEDED, QUERY_WAS_CANCELLED }
+
+-- Constant positive size: covers the extend-with-default branch.
+SELECT length(arrayResize([map(toInt256(1), toFloat64(2))], 550164762)); -- { serverError TIMEOUT_EXCEEDED, QUERY_WAS_CANCELLED }


### PR DESCRIPTION
### Motivation

`arrayResize` invokes `GatherUtils::writeSlice` once per output element from
inside the inner `for` loops of `resizeDynamicSize` and `resizeConstantSize`. On
heavy element types — `Map(Int256, Float64)`, big-int tuples, nested arrays —
each `writeSlice` costs hundreds of nanoseconds, so a single call with
`length ~ MAX_ARRAY_SIZE` (1 << 30) busy-loops the worker thread for tens of
seconds. Until the loop returns to the pipeline, `max_execution_time` cannot
fire and the function appears stuck.

This is the failure mode caught by the `function_prop_fuzzer` stress test
(issue #104877) and labelled `P_TIMEOUT_NOT_HONORED`. A representative
reproducer extracted from the fuzzer:

```sql
SET max_execution_time = 3;
SELECT length(
    arrayResize([map(toInt256(1), toFloat64(2))],
                materialize(toInt256(-550164762))));
```

before the fix this runs for ~40 s before throwing.

PR #105146 reverts the related fuzzer hardening (#104694) precisely because
`arrayResize` does not yet honor cancellation; this change is the
implementation-side fix @alexey-milovidov requested on
[PR #105101](https://github.com/ClickHouse/ClickHouse/pull/105101#issuecomment-4470020842):

> @groeneai, please focus on \"`FunctionsStress.stress` — arrayResize 79s
> timeout on max_execution_time=15s\" — find a way to guard/limit these heavy
> invocations in the implementation and send a PR.

### Approach

* New helper `DB::GatherUtils::checkQueryCancellation()` in
  `src/Functions/GatherUtils/GatherUtils.{h,cpp}` that throws
  `QUERY_WAS_CANCELLED` when the per-thread cancellation flag is set. The
  helper lives in the existing `GatherUtils` translation unit so
  `Common/CurrentThread.h` does not leak into the heavily-included
  `Algorithms.h`.
* The four extend branches in `resizeDynamicSize` and `resizeConstantSize`
  call the helper every `resize_cancellation_check_period = 16384` inner-loop
  iterations. The period is a power of two so the modulo folds to a single
  bit-and; amortized overhead is well under 1% on normal-size arrays
  (verified: existing `00557_array_resize`, `01682_gather_utils_ubsan`,
  `03013_fuzz_arrayPartialReverseSort` finish in unchanged wall time).

### Verification

* Local debug build:
  * Pre-fix reproducer above ran 41872 ms past a 15 s deadline.
  * Post-fix the same query is cancelled at 3039 ms with `TIMEOUT_EXCEEDED`
    (dynamic-size path) or `QUERY_WAS_CANCELLED` (constant-size path, where
    our helper trips first).
* `tests/queries/0_stateless/04252_104877_array_resize_max_execution_time.sql`
  covers all three branches (dynamic negative, constant negative, constant
  positive); the test passes 30/30 with `--no-random-settings`, runtime ~9.4 s
  per iteration (3 × 3 s budget).
* Existing `arrayResize` smoke tests
  (`00557_array_resize`, `01682_gather_utils_ubsan`,
  `03013_fuzz_arrayPartialReverseSort`) all pass.

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Make `arrayResize` honor `max_execution_time` and `KILL QUERY` even when filling very long arrays of heavy element types (`Map`, big-int tuples, nested arrays). Previously the inner write loop ran to completion regardless of cancellation. Closes #104877.