### PR TITLE
Mark flaky 02932_refreshable_materialized_views_2 as `long`

### DIFF
--- a/tests/queries/0_stateless/02932_refreshable_materialized_views_2.sh
+++ b/tests/queries/0_stateless/02932_refreshable_materialized_views_2.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
-# Tags: atomic-database, memory-engine
+# Tags: atomic-database, memory-engine, long
+# ^ `long`: this test exercises many `REFRESH EVERY 1 SECOND` views with
+# `sleepEachRow(1)` source data, multiple `SYSTEM WAIT VIEW` calls and
+# poll loops. Median wall time on the `Fast test` job is ~13s with rare
+# spikes past the 60s per-test timeout under CI load. The `long` tag keeps
+# the test out of `Fast test` (which runs with `--no-long`) while still
+# letting it run on all other stateless test configurations.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
Marks the stateless test `02932_refreshable_materialized_views_2.sh` with the `long` tag so the `Fast test` job (which is invoked with `--no-long` in `ci/jobs/fast_test.py`) stops running it. The test still runs on every other stateless test configuration.

The test exercises ~10 `SYSTEM WAIT VIEW` calls, multiple `REFRESH EVERY 1 SECOND` materialized views with `sleepEachRow(1)` source data, and ~11 polling loops that each spawn a fresh `clickhouse-client`. CIDB shows it passes 99% of `Fast test` runs (median 13s, p99 18s, max-passing 48s) but the remaining ~1% spike past the 60s per-test timeout under CI load and get killed at process-group level — typically on the first `system wait view e;` after creating a `REFRESH EVERY 1 SECOND` view. Over the last 30 days: 30 `Fast test` failures across 27 distinct PRs; 0 failures on `head_ref = 'master'`; the test passes 500+ times on every non-`Fast test` job configuration we ran.

Other stateless test jobs are unaffected — `amd_debug, parallel`, `amd_tsan, parallel`, `amd_msan, WasmEdge`, `amd_asan_ubsan, distributed plan`, `arm_binary`, `arm_asan_ubsan, azure`, `amd_llvm_coverage`, and the various `flaky check` variants all still cover this test.

Issue: closes #97651 (auto-generated flaky test issue for this test name).
Reported on PR https://github.com/ClickHouse/ClickHouse/pull/100539 by @alexey-milovidov.
Representative failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100539&sha=ca588ac6d6dad5bfd61156a014a09e928cea8ed4&name_0=PR&name_1=Fast%20test

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not for changelog.


### Documentation entry for user-facing changes

- [x] Documentation is unchanged (CI-only test classification).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.721`
<!-- ch-version-info:end -->