### PR TITLE
Fix NameError masking test_migration diagnostic on count mismatch

### DIFF
--- a/tests/integration/test_storage_s3_queue/test_migration.py
+++ b/tests/integration/test_storage_s3_queue/test_migration.py
@@ -171,32 +171,27 @@ def test_migration(started_cluster, setting_prefix, buckets_num):
             time.sleep(1)
 
         if expected_rows[0] != get_count():
-            files_to_generate = expected_rows[0]  # 1 row per file
-            expected_files = [
-                f"{files_path}/test_{x}.csv" for x in range(files_to_generate)
-            ]
-
             for node in [node1, node2]:
                 node.query("SYSTEM FLUSH LOGS")
 
+            count1 = int(node1.query(f"SELECT count() FROM default.{dst_table_name}"))
+            count2 = int(node2.query(f"SELECT count() FROM default.{dst_table_name}"))
+
             processed_files = (
-                node.query(
+                node1.query(
                     f"SELECT distinct(_path) FROM clusterAllReplicas(cluster, default.{dst_table_name})"
                 )
                 .strip()
                 .split("\n")
             )
-
             processed_files.sort()
             logging.debug(f"Processed files: {processed_files}")
-            missing_files = [
-                file for file in expected_files if file not in processed_files
-            ]
-            missing_files.sort()
 
-            assert (
-                False
-            ), f"Expected {total_rows} in total, got {count1} and {count2} ({count1 + count2}, having {len(missing_files)} missing files: ({missing_files})"
+            assert False, (
+                f"Expected {expected_rows[0]} rows in total, "
+                f"got {count1} on node1 and {count2} on node2 ({count1 + count2}), "
+                f"distinct files processed: {len(processed_files)}"
+            )
 
     add_files_and_check()
 


### PR DESCRIPTION
The diagnostic branch in `test_storage_s3_queue/test_migration.py::test_migration` referenced undefined variables `total_rows`, `count1`, `count2` in its assertion f-string. When the inner wait loop timed out (count didn't converge in 50s), Python raised `NameError` at f-string evaluation, masking what should have been a clear convergence failure.

CIDB confirms **81 failures** of this form over the last 90 days, with a sharp spike to **32 hits on 2026-05-16** across every sanitizer build (`amd_msan`, `amd_asan_ubsan/db disk/old analyzer`, `amd_tsan`, `amd_llvm_coverage`, `arm_binary/distributed plan`). All hits are **PR-only** — `pull_request_number > 0` across 6+ unrelated PRs (none of which touch s3_queue), making this a developer-experience pain point.

The diagnostic also computed `expected_files` using a wrong file naming pattern (`{files_path}/test_{x}.csv`) — the actual files use `{use_prefix}_{i}.csv` where `use_prefix` advances through `["a","b","c","d","e"]` across each `add_files_and_check` call, and `i` starts at the cumulative `start_ind`. The resulting `missing_files` list would always report every expected file as missing, even when convergence was correct.

This change:
- Computes `count1` and `count2` from per-node `SELECT count()` queries (the variables the original author intended).
- Uses `expected_rows[0]` instead of the never-defined `total_rows`.
- Drops the broken `expected_files`/`missing_files` calculation.
- Reports `distinct files processed` from the existing `processed_files` list as a useful proxy without the buggy naming logic.
- Switches the `processed_files` query from `node` (last value from the `for node in [node1, node2]` loop above) to `node1` for clarity.

Demonstration in both directions:
- **Without fix:** `NameError: name 'total_rows' is not defined`
- **With fix:** `AssertionError: Expected 1000 rows in total, got 300 on node1 and 200 on node2 (500), distinct files processed: 5`

CIDB reference: https://play.clickhouse.com/?user=play#U0VMRUNUIHRlc3RfbmFtZSwgY2hlY2tfbmFtZSwgY291bnQoKSBGUk9NIGRlZmF1bHQuY2hlY2tzIFdIRVJFIHRlc3RfbmFtZSBMSUtFICd0ZXN0X3N0b3JhZ2VfczNfcXVldWUvdGVzdF9taWdyYXRpb24ucHklJyBBTkQgdGVzdF9jb250ZXh0X3JhdyBMSUtFICclTmFtZUVycm9yJScgR1JPVVAgQlkgdGVzdF9uYW1lLCBjaGVja19uYW1lIE9SREVSIEJZIGNvdW50KCkgREVTQw==

Past related fix PRs: #97677, #93232.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.719`
<!-- ch-version-info:end -->