### PR TITLE
Fix flaky test_named_collections_encrypted2/test_zk_node_lifecycle

### DIFF
--- a/tests/integration/test_named_collections_encrypted2/test.py
+++ b/tests/integration/test_named_collections_encrypted2/test.py
@@ -61,6 +61,38 @@ def wait_not_exists(node, collection, timeout=10):
     return False
 
 
+def wait_zk_child_exists(zk, path, child, timeout=10):
+    """Poll ZK children of `path` until `child` is present.
+
+    ClickHouse and the test's kazoo client use independent ZK sessions, possibly
+    connected to different nodes of the ZK ensemble. The kazoo session can lag
+    briefly behind a write made via ClickHouse's session — this lag is normally
+    sub-millisecond but is amplified under sanitizer builds (TSan/MSan).
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            if child in zk.get_children(path):
+                return True
+        except Exception:
+            pass
+        time.sleep(0.3)
+    return False
+
+
+def wait_zk_child_absent(zk, path, child, timeout=10):
+    """Poll ZK children of `path` until `child` is gone."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            if child not in zk.get_children(path):
+                return True
+        except Exception:
+            pass
+        time.sleep(0.3)
+    return False
+
+
 def check_encrypted(zk, collection):
     content = zk.get(f"{ZK_PATH}/{collection}.sql")[0]
     assert content[:3] == b"ENC"
@@ -526,11 +558,11 @@ def test_zk_node_lifecycle(cluster):
 
     node1.query("CREATE NAMED COLLECTION zk_test AS key='val'")
 
-    assert "zk_test.sql" in zk.get_children(ZK_PATH)
+    assert wait_zk_child_exists(zk, ZK_PATH, "zk_test.sql")
 
     node1.query("DROP NAMED COLLECTION zk_test")
     assert wait_not_exists(node1, "zk_test")
-    assert "zk_test.sql" not in zk.get_children(ZK_PATH)
+    assert wait_zk_child_absent(zk, ZK_PATH, "zk_test.sql")
 
 
 def test_remote_select_insert(cluster):


### PR DESCRIPTION
The integration test `test_named_collections_encrypted2/test.py::test_zk_node_lifecycle` has been flaking on sanitizer builds with:

```
File: test_named_collections_encrypted2/test.py:529 - in test_zk_node_lifecycle
    assert "zk_test.sql" in zk.get_children(ZK_PATH)
E   AssertionError: assert 'zk_test.sql' in []
```

Observed twice on master CI in the last 60 days (both sanitizer shards):

- PR https://github.com/ClickHouse/ClickHouse/pull/101757 — `Integration tests (amd_tsan, 4/6)` on 2026-05-16
- PR https://github.com/ClickHouse/ClickHouse/pull/102031 — `Integration tests (amd_msan, 6/6)` on 2026-04-10 (this is the failure @alexey-milovidov asked us to investigate; CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=102031&sha=169ea923b985fa66060e440b34cf2a908049afa4&name_0=PR&name_1=Integration%20tests%20%28amd_msan%2C%206%2F6%29)

### Root cause

The test runs:

```python
node1.query("CREATE NAMED COLLECTION zk_test AS key='val'")
assert "zk_test.sql" in zk.get_children(ZK_PATH)
```

`CREATE NAMED COLLECTION` is synchronous on the server side — it calls `ZooKeeper::createOrUpdate` in `NamedCollectionsMetadataStorage::ZooKeeperStorage::write`, which waits for the ZK leader's response. So when the query returns to the test, the znode `/named_collections_path/zk_test.sql` has been committed.

However, the test then reads via a separate kazoo client (`cluster.get_kazoo_client("zoo1")`). That kazoo client is a different ZK session, potentially connected to a different node of the ZK ensemble. ZooKeeper does not guarantee cross-session linearizability between a write on session A and a subsequent read on session B if B is connected to a follower that has not yet applied the write — the follower's view is eventually consistent with the leader on the order of milliseconds. Under TSan/MSan the slowdown is large enough that this normally invisible window becomes wide enough to fail the assertion. The symmetric race exists in the `DROP` branch (the kazoo client may briefly still see the znode after `wait_not_exists` succeeds on `node1`).

### Fix

Add two polling helpers next to the existing `wait_exists` / `wait_not_exists`:

- `wait_zk_child_exists(zk, path, child, timeout=10)`
- `wait_zk_child_absent(zk, path, child, timeout=10)`

Both follow the existing pattern (10 s budget, 0.3 s poll, exception-tolerant). `test_zk_node_lifecycle` is updated to use them in place of the single-shot `get_children` membership checks. The test still asserts the same invariant — the znode appears after `CREATE NAMED COLLECTION` and disappears after `DROP NAMED COLLECTION` — but now tolerates up to 10 s of cross-session replication lag.

The change is strictly additive: when the underlying write IS already visible to the kazoo session (the common case), the first poll iteration returns immediately, so this introduces no measurable runtime overhead. If the server fails to write/remove the znode at all, the 10 s timeout still expires and the assertion fails as before.

cc @alexey-milovidov

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

...


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.683`
<!-- ch-version-info:end -->