### PR TITLE
Increase select_parser_fuzzer per-input timeout to 60s

### DIFF
--- a/tests/fuzz/select_parser_fuzzer.options
+++ b/tests/fuzz/select_parser_fuzzer.options
@@ -1,5 +1,5 @@
 [libfuzzer]
-timeout = 20
+timeout = 60
 dict = all.dict
 
 [fuzzer_arguments]


### PR DESCRIPTION
The fuzzer `select_parser_fuzzer` keeps timing out on many unrelated PRs in CI on deeply nested SELECT inputs (e.g. PR #96130 [report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96130&sha=8e0106f5809257b068a61a001f58042689b005ab&name_0=PR&name_1=libFuzzer%20tests), artefact `timeout-49fccbae556e7a03ed5e64d5c08cb55653bb10ce`, 524 bytes of malformed SELECT with deeply nested parens).

The `max_parser_backtracks = 10000` cap added in PR #104922 is correctly applied (verified locally: same input bails with `TOO_SLOW_PARSING` in ~0.16s on x86_64 release). But on ASan ARM CI runners the fuzzer runs at ~18-42 exec/s, so reaching 10000 backtracks takes >20 wall seconds and libFuzzer's per-input timeout fires first, producing `timeout-*` artefacts.

Raising the per-input timeout from 20s to 60s gives the backtrack cap room to fire on slow sanitizer/cross-arch runners. The cap, not the timeout, is what bounds real worst-case parse work; the timeout just needs to outlive it.

Refs:
- Open tracker #93438 (`libFuzzer tests are flaky`)
- Closed #92282 (`select_parser_fuzzer` timeout on deeply nested parens) — same class still surfacing on ASan ARM
- PR #104922 (sibling cap fix on `max_parser_backtracks`)
- Example CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=96130&sha=8e0106f5809257b068a61a001f58042689b005ab&name_0=PR&name_1=libFuzzer%20tests

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.741`
<!-- ch-version-info:end -->