### PR TITLE
Web Terminal: accept cross-origin postMessage from clickhouse.com/cloud

### DIFF
--- a/programs/server/webterminal.html
+++ b/programs/server/webterminal.html
@@ -345,6 +345,10 @@
     // A 'webterminal-hello' handshake lets the parent register its origin so the iframe
     // can post back even when the parent is cross-origin.
     window.addEventListener('message', function(e) {
+        // Only accept messages from the embedding parent window. Without this, any window
+        // from an allowed origin that obtains a reference to us (e.g. via window.open)
+        // could drive the credentials/refit handlers.
+        if (e.source !== window.parent) return;
         if (!isTrustedParentOrigin(e.origin)) return;
         if (!e.data) return;
 

--- a/programs/server/webterminal.html
+++ b/programs/server/webterminal.html
@@ -83,6 +83,26 @@
     var inIframe = (window.parent !== window);
     var waitingForCredentials = false;
 
+    // Trusted parent origin learned from the first valid postMessage we receive.
+    // We need this because postMessage's targetOrigin must equal the parent's actual origin,
+    // and cross-origin restrictions prevent reading window.parent.location.
+    var trustedParentOrigin = null;
+
+    function isTrustedParentOrigin(origin) {
+        if (origin === window.location.origin) return true;
+        try {
+            var u = new URL(origin);
+            if (u.protocol !== 'https:') return false;
+            var h = u.hostname;
+            return h === 'clickhouse.com'
+                || h === 'clickhouse.cloud'
+                || h.endsWith('.clickhouse.com')
+                || h.endsWith('.clickhouse.cloud');
+        } catch (e) {
+            return false;
+        }
+    }
+
     function getWebSocketURL() {
         var loc = window.location;
         var protocol = loc.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -131,7 +151,9 @@
         if (window.parent !== window) {
             term.attachCustomKeyEventHandler(function(e) {
                 if (e.type === 'keydown' && e.key === 'Escape') {
-                    window.parent.postMessage({type: 'webterminal-escape'}, window.location.origin);
+                    if (trustedParentOrigin) {
+                        window.parent.postMessage({type: 'webterminal-escape'}, trustedParentOrigin);
+                    }
                     return false;
                 }
                 return true;
@@ -304,7 +326,9 @@
                 // Normal disconnect after session was active
                 if (window.parent !== window) {
                     // Inside an iframe - notify parent to deactivate terminal
-                    window.parent.postMessage({type: 'webterminal-closed'}, window.location.origin);
+                    if (trustedParentOrigin) {
+                        window.parent.postMessage({type: 'webterminal-closed'}, trustedParentOrigin);
+                    }
                 } else {
                     window.location.href = 'https://github.com/ClickHouse/ClickHouse';
                 }
@@ -316,12 +340,20 @@
         };
     }
 
-    // Listen for messages from the parent (credentials, refit requests)
+    // Listen for messages from the parent (credentials, refit requests).
+    // Accepted origins: same-origin, *.clickhouse.com, *.clickhouse.cloud (https only).
+    // A 'webterminal-hello' handshake lets the parent register its origin so the iframe
+    // can post back even when the parent is cross-origin.
     window.addEventListener('message', function(e) {
-        if (e.origin !== window.location.origin) return;
+        if (!isTrustedParentOrigin(e.origin)) return;
         if (!e.data) return;
 
-        if (e.data.type === 'webterminal-credentials' && waitingForCredentials) {
+        // Remember the parent origin so outbound posts (escape/closed) can reach it.
+        trustedParentOrigin = e.origin;
+
+        if (e.data.type === 'webterminal-hello') {
+            return;
+        } else if (e.data.type === 'webterminal-credentials' && waitingForCredentials) {
             waitingForCredentials = false;
             currentUser = e.data.user || 'default';
             currentPassword = e.data.password || '';


### PR DESCRIPTION
## Summary

The web terminal (`programs/server/webterminal.html`) uses `postMessage` for three things:

- inbound: receive `webterminal-credentials` and `webterminal-refit` from the parent
- outbound: post `webterminal-escape` (on Escape key) and `webterminal-closed` (on WebSocket close) to the parent

Both directions previously assumed the parent is **same-origin**:

```js
// inbound
if (e.origin !== window.location.origin) return;
// outbound
window.parent.postMessage({...}, window.location.origin);
```

That second arg is the *target* origin — the browser drops the post if the parent's actual origin doesn't equal it. So when the terminal is embedded from a different origin (e.g. `https://clickhouse.com` embedding `https://play.clickhouse.com/webterminal`), inbound is rejected and outbound is silently dropped. The terminal effectively can't be embedded outside `play.clickhouse.com`.

## Changes

- **Inbound allowlist:** accept messages from same-origin and from any **https** origin whose hostname is `clickhouse.com`, `clickhouse.cloud`, or a subdomain of either. Apex domains are matched by equality; subdomains by `endsWith('.clickhouse.com')` / `endsWith('.clickhouse.cloud')`. URL parsing anchors on hostname so suffixes like `evil.clickhouse.com.attacker.tld` are not matched.
- **Outbound parent origin:** remember the parent origin from the first valid inbound message (including an optional `webterminal-hello` handshake), and post back to that exact origin. If we've never heard from a trusted parent, outbound posts are skipped rather than leaked to `'*'`.

## Why an allowlist instead of `'*'`

`'*'` would let any site iframe the terminal and feed it forged `webterminal-credentials`. The user typing their own credentials into an attacker-controlled embed is "their problem," but accepting credentials only from origins ClickHouse controls is a cheap and clear improvement.

## Compatibility

- Same-origin embeds (existing `play.html` flow) keep working — same-origin is the first branch in the trust check, and the outbound target is still the same string.
- Cross-origin embeds from `*.clickhouse.com` / `*.clickhouse.cloud` now work. Other origins are still rejected.

## Test plan

- [ ] Same-origin: load `/play` on a server with `allow_experimental_webterminal=1`, press the terminal toggle, type a query, press Escape — terminal hides as before.
- [ ] Cross-origin: from `https://clickhouse.com` (marketing site PR: https://github.com/ClickHouse/marketing-website/pull/1448), open the dropdown terminal, verify `webterminal-refit` is applied (terminal sizes correctly), and Escape closes the panel.
- [ ] Untrusted origin: embed the terminal from a non-clickhouse origin and verify `postMessage` is ignored both ways (devtools console shows no credential acceptance).

### Changelog category (leave one):
- Experimental Feature

### Changelog entry:
The experimental web terminal (`allow_experimental_webterminal`) can now be embedded cross-origin from `clickhouse.com`, `clickhouse.cloud`, and their subdomains. Previously, `postMessage` from any non-same-origin parent was rejected on inbound and silently dropped on outbound, making the terminal effectively un-embeddable outside `play.clickhouse.com`. The accepted origin list is an explicit allowlist (https only, hostname-anchored), so untrusted origins are still rejected.

### Documentation entry for user-facing changes

- [ ] Documentation is unchanged: the experimental setting and message protocol are not user-facing.
