### PR TITLE
Fix `CLEAR COLUMN` merges for special engines

### DIFF
--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -372,7 +372,8 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::extractMergingAndGatheringColu
     if (!global_ctx->merging_params.version_column.empty())
         key_columns.emplace(global_ctx->merging_params.version_column);
 
-    /// Force all columns params of Graphite mode
+    /// Force configured `GraphiteMergeTree` rollup columns.
+    /// Generic key/minmax/dedup columns are collected separately.
     if (global_ctx->merging_params.mode == MergeTreeData::MergingParams::Graphite)
     {
         key_columns.emplace(global_ctx->merging_params.graphite_params.path_column_name);
@@ -394,8 +395,34 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::extractMergingAndGatheringColu
 
     key_columns.insert(global_ctx->deduplicate_by_columns.begin(), global_ctx->deduplicate_by_columns.end());
 
-    /// Key columns required for merge, must not be expired early.
-    global_ctx->merge_required_key_columns = key_columns;
+    switch (global_ctx->merging_params.mode)
+    {
+        case MergeTreeData::MergingParams::Summing:
+        case MergeTreeData::MergingParams::Aggregating:
+        case MergeTreeData::MergingParams::Coalescing:
+            for (const auto & column : global_ctx->storage_columns)
+                key_columns.emplace(column.name);
+            break;
+        default:
+            /// Other modes either need only key/sign/version columns already collected above,
+            /// or, for `GraphiteMergeTree`, only configured rollup columns beyond
+            /// the generic columns collected above.
+            break;
+    }
+
+    /// Snapshot columns required by merge semantics before adding columns used only
+    /// to rebuild skip indexes, projections, or TTL filters.
+    ///
+    /// `SummingMergeTree` needs defaults for zero-row deletion.
+    /// `CoalescingMergeTree` needs defaults for last-value/default-value preservation.
+    /// `AggregatingMergeTree` needs defaults for aggregate-state and not-to-aggregate column merging.
+    /// `GraphiteMergeTree` adds only configured `path`, `time`, `value`, and `version` columns
+    /// beyond the generic columns collected above.
+    ///
+    /// Expired required columns may be written with defaults and removed during final
+    /// Wide-part cleanup. Compact parts keep them because per-column file removal
+    /// is not applicable; this keeps merge semantics separate from output cleanup.
+    global_ctx->merge_required_columns = key_columns;
     const auto & skip_indexes = global_ctx->metadata_snapshot->getSecondaryIndices();
 
     for (const auto & index : skip_indexes)
@@ -451,8 +478,6 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::extractMergingAndGatheringColu
         global_ctx->need_block_number_in_merge |= projection->with_block_number;
         global_ctx->need_block_offset_in_merge |= projection->with_block_offset;
     }
-
-    /// TODO: also force "summing" and "aggregating" columns to make Horizontal merge only for such columns
 
     /// For vertical merge with TTL delete optimization, include columns needed by
     /// TTL expressions in the horizontal phase so the TTL filter can be evaluated.
@@ -672,7 +697,7 @@ bool MergeTask::ExecuteAndFinalizeHorizontalPart::prepare() const
             for (const auto & column : input)
             {
                 bool is_expired = expired_columns.contains(column.name);
-                bool is_required_for_merge = global_ctx->merge_required_key_columns.contains(column.name);
+                bool is_required_for_merge = global_ctx->merge_required_columns.contains(column.name);
 
                 if (is_expired)
                     expired_out.push_back(column);

--- a/src/Storages/MergeTree/MergeTask.cpp
+++ b/src/Storages/MergeTree/MergeTask.cpp
@@ -411,17 +411,11 @@ void MergeTask::ExecuteAndFinalizeHorizontalPart::extractMergingAndGatheringColu
     }
 
     /// Snapshot columns required by merge semantics before adding columns used only
-    /// to rebuild skip indexes, projections, or TTL filters.
-    ///
-    /// `SummingMergeTree` needs defaults for zero-row deletion.
-    /// `CoalescingMergeTree` needs defaults for last-value/default-value preservation.
-    /// `AggregatingMergeTree` needs defaults for aggregate-state and not-to-aggregate column merging.
-    /// `GraphiteMergeTree` adds only configured `path`, `time`, `value`, and `version` columns
-    /// beyond the generic columns collected above.
-    ///
-    /// Expired required columns may be written with defaults and removed during final
-    /// Wide-part cleanup. Compact parts keep them because per-column file removal
-    /// is not applicable; this keeps merge semantics separate from output cleanup.
+    /// to rebuild skip indexes, projections, or TTL filters. This covers defaults
+    /// for `SummingMergeTree`, `CoalescingMergeTree`, and `AggregatingMergeTree`,
+    /// and configured rollup columns for `GraphiteMergeTree`.
+    /// Expired required columns may later be removed from Wide parts; Compact
+    /// parts keep them because per-column file removal is not applicable.
     global_ctx->merge_required_columns = key_columns;
     const auto & skip_indexes = global_ctx->metadata_snapshot->getSecondaryIndices();
 

--- a/src/Storages/MergeTree/MergeTask.h
+++ b/src/Storages/MergeTree/MergeTask.h
@@ -231,7 +231,7 @@ private:
         CompressionCodecPtr compression_codec{nullptr};
 
         NamesAndTypesList gathering_columns{};
-        NameSet merge_required_key_columns{};
+        NameSet merge_required_columns{};
         NamesAndTypesList merging_columns{};
         NamesAndTypesList merging_columns_expired_by_ttl{};
         NamesAndTypesList storage_columns{};

--- a/tests/integration/test_graphite_merge_tree/test.py
+++ b/tests/integration/test_graphite_merge_tree/test.py
@@ -527,7 +527,7 @@ CREATE TABLE test.graphite
     ENGINE = GraphiteMergeTree('graphite_rollup')
     PARTITION BY toYYYYMM(date)
     ORDER BY (metric, timestamp)
-    SETTINGS index_granularity=8192;
+    SETTINGS index_granularity=8192, min_rows_for_wide_part=0, min_bytes_for_wide_part=0;
 """
     )
 
@@ -535,3 +535,77 @@ CREATE TABLE test.graphite
     q("INSERT INTO test.graphite FORMAT TSV", to_insert)
     q("OPTIMIZE TABLE test.graphite PARTITION 200109 FINAL")
     q("OPTIMIZE TABLE test.graphite PARTITION 200109 FINAL")
+
+    assert TSV(
+        q(
+            """
+SELECT metric, value, timestamp, date, updated
+FROM test.graphite
+ORDER BY metric, timestamp
+"""
+        )
+    ) == TSV("one_min.x1\t100\t999999600\t2001-09-09\t0\n")
+
+    assert TSV(
+        q(
+            """
+SELECT count()
+FROM system.parts_columns
+WHERE database = 'test'
+  AND table = 'graphite'
+  AND active
+  AND column = 'updated'
+"""
+        )
+    ) == TSV("0\n")
+
+
+def test_ttl_non_rollup_column(graphite_table):
+    q(
+        """
+DROP TABLE IF EXISTS test.graphite;
+CREATE TABLE test.graphite
+    (
+        metric String,
+        value Float64,
+        timestamp UInt32,
+        date Date,
+        updated UInt32,
+        extra UInt32 TTL date + INTERVAL 1 DAY
+    )
+    ENGINE = GraphiteMergeTree('graphite_rollup')
+    PARTITION BY toYYYYMM(date)
+    ORDER BY (metric, timestamp)
+    SETTINGS index_granularity=8192, min_rows_for_wide_part=0, min_bytes_for_wide_part=0;
+"""
+    )
+
+    q(
+        "INSERT INTO test.graphite FORMAT TSV",
+        "one_min.x1\t100\t1000000000\t2001-09-09\t1\t77",
+    )
+    q("OPTIMIZE TABLE test.graphite PARTITION 200109 FINAL")
+    q("OPTIMIZE TABLE test.graphite PARTITION 200109 FINAL")
+
+    assert TSV(
+        q(
+            """
+SELECT metric, value, timestamp, date, updated, extra
+FROM test.graphite
+ORDER BY metric, timestamp
+"""
+        )
+    ) == TSV("one_min.x1\t100\t999999600\t2001-09-09\t1\t0\n")
+
+    assert TSV(
+        q(
+            """
+SELECT count()
+FROM system.parts_columns
+WHERE database = 'test'
+  AND table = 'graphite'
+  AND active
+  AND column = 'extra'
+"""
+        )
+    ) == TSV("0\n")

--- a/tests/queries/0_stateless/04240_clear_column_special_merge_required_columns.reference
+++ b/tests/queries/0_stateless/04240_clear_column_special_merge_required_columns.reference
@@ -1,0 +1,16 @@
+summing_clear_rows	0
+summing_clear_parts_column_v	0
+summing_clear_partition_compact_rows	0
+summing_update_zero_parity_rows	0
+summing_add_column_rows	0
+summing_add_column_parts_column_v	0
+summing_ttl_values	1	0	30
+summing_ttl_parts_column_expired	0
+coalescing_clear_values	1	0
+coalescing_clear_parts_column_v	0
+aggregating_clear_state	1	0	180
+aggregating_clear_parts_column_s	0
+aggregating_ttl_values	1	0	30
+aggregating_ttl_parts_column_expired	0
+replacing_clear_regression	1	2	0
+replacing_clear_parts_column_v	0

--- a/tests/queries/0_stateless/04240_clear_column_special_merge_required_columns.sql
+++ b/tests/queries/0_stateless/04240_clear_column_special_merge_required_columns.sql
@@ -1,0 +1,238 @@
+-- Tags: no-random-merge-tree-settings
+
+SET mutations_sync = 2;
+SET alter_sync = 2;
+SET optimize_on_insert = 0;
+
+DROP TABLE IF EXISTS t_summing_clear_required;
+CREATE TABLE t_summing_clear_required
+(
+    k UInt32,
+    v Int64
+)
+ENGINE = SummingMergeTree()
+ORDER BY k
+SETTINGS min_rows_for_wide_part = 0, min_bytes_for_wide_part = 0;
+
+INSERT INTO t_summing_clear_required VALUES (1, 5), (2, 10);
+INSERT INTO t_summing_clear_required VALUES (2, -10);
+ALTER TABLE t_summing_clear_required CLEAR COLUMN v;
+OPTIMIZE TABLE t_summing_clear_required FINAL;
+
+SELECT 'summing_clear_rows', count() FROM t_summing_clear_required;
+SELECT 'summing_clear_parts_column_v', count()
+FROM system.parts_columns
+WHERE database = currentDatabase()
+  AND table = 't_summing_clear_required'
+  AND active
+  AND column = 'v';
+
+DROP TABLE t_summing_clear_required;
+
+DROP TABLE IF EXISTS t_summing_clear_partition_compact;
+CREATE TABLE t_summing_clear_partition_compact
+(
+    p UInt32,
+    k UInt32,
+    v Int64
+)
+ENGINE = SummingMergeTree()
+PARTITION BY p
+ORDER BY k;
+
+SYSTEM STOP MERGES t_summing_clear_partition_compact;
+INSERT INTO t_summing_clear_partition_compact VALUES (1, 1, 5), (1, 2, 10);
+INSERT INTO t_summing_clear_partition_compact VALUES (1, 2, -10);
+SYSTEM START MERGES t_summing_clear_partition_compact;
+ALTER TABLE t_summing_clear_partition_compact CLEAR COLUMN v IN PARTITION 1;
+OPTIMIZE TABLE t_summing_clear_partition_compact PARTITION 1 FINAL;
+
+SELECT 'summing_clear_partition_compact_rows', count() FROM t_summing_clear_partition_compact;
+
+DROP TABLE t_summing_clear_partition_compact;
+
+DROP TABLE IF EXISTS t_summing_update_zero_parity;
+CREATE TABLE t_summing_update_zero_parity
+(
+    p UInt32,
+    k UInt32,
+    v Int64
+)
+ENGINE = SummingMergeTree()
+PARTITION BY p
+ORDER BY k;
+
+SYSTEM STOP MERGES t_summing_update_zero_parity;
+INSERT INTO t_summing_update_zero_parity VALUES (1, 1, 5), (1, 2, 10);
+INSERT INTO t_summing_update_zero_parity VALUES (1, 2, -10);
+SYSTEM START MERGES t_summing_update_zero_parity;
+ALTER TABLE t_summing_update_zero_parity UPDATE v = 0 IN PARTITION 1 WHERE 1;
+OPTIMIZE TABLE t_summing_update_zero_parity PARTITION 1 FINAL;
+
+SELECT 'summing_update_zero_parity_rows', count() FROM t_summing_update_zero_parity;
+
+DROP TABLE t_summing_update_zero_parity;
+
+DROP TABLE IF EXISTS t_summing_add_required;
+CREATE TABLE t_summing_add_required
+(
+    k UInt32
+)
+ENGINE = SummingMergeTree()
+ORDER BY k
+SETTINGS min_rows_for_wide_part = 0, min_bytes_for_wide_part = 0;
+
+SYSTEM STOP MERGES t_summing_add_required;
+INSERT INTO t_summing_add_required VALUES (1), (2);
+INSERT INTO t_summing_add_required VALUES (1);
+ALTER TABLE t_summing_add_required ADD COLUMN v UInt64;
+SYSTEM START MERGES t_summing_add_required;
+OPTIMIZE TABLE t_summing_add_required FINAL;
+
+SELECT 'summing_add_column_rows', count() FROM t_summing_add_required;
+SELECT 'summing_add_column_parts_column_v', count()
+FROM system.parts_columns
+WHERE database = currentDatabase()
+  AND table = 't_summing_add_required'
+  AND active
+  AND column = 'v';
+
+DROP TABLE t_summing_add_required;
+
+DROP TABLE IF EXISTS t_summing_ttl_required;
+CREATE TABLE t_summing_ttl_required
+(
+    d Date,
+    k UInt32,
+    expired UInt64 TTL d + INTERVAL 1 DAY,
+    keep UInt64
+)
+ENGINE = SummingMergeTree()
+PARTITION BY toYYYYMM(d)
+ORDER BY k
+SETTINGS min_rows_for_wide_part = 0, min_bytes_for_wide_part = 0;
+
+SYSTEM STOP MERGES t_summing_ttl_required;
+INSERT INTO t_summing_ttl_required VALUES ('2001-09-09', 1, 7, 10);
+INSERT INTO t_summing_ttl_required VALUES ('2001-09-09', 1, 11, 20);
+SYSTEM START MERGES t_summing_ttl_required;
+OPTIMIZE TABLE t_summing_ttl_required PARTITION 200109 FINAL;
+OPTIMIZE TABLE t_summing_ttl_required PARTITION 200109 FINAL;
+
+SELECT 'summing_ttl_values', k, expired, keep FROM t_summing_ttl_required ORDER BY k;
+SELECT 'summing_ttl_parts_column_expired', count()
+FROM system.parts_columns
+WHERE database = currentDatabase()
+  AND table = 't_summing_ttl_required'
+  AND active
+  AND column = 'expired';
+
+DROP TABLE t_summing_ttl_required;
+
+DROP TABLE IF EXISTS t_coalescing_clear_required;
+CREATE TABLE t_coalescing_clear_required
+(
+    k UInt32,
+    v UInt64
+)
+ENGINE = CoalescingMergeTree()
+ORDER BY k
+SETTINGS min_rows_for_wide_part = 0, min_bytes_for_wide_part = 0;
+
+INSERT INTO t_coalescing_clear_required VALUES (1, 10);
+INSERT INTO t_coalescing_clear_required VALUES (1, 20);
+ALTER TABLE t_coalescing_clear_required CLEAR COLUMN v;
+OPTIMIZE TABLE t_coalescing_clear_required FINAL;
+
+SELECT 'coalescing_clear_values', k, v FROM t_coalescing_clear_required ORDER BY k;
+SELECT 'coalescing_clear_parts_column_v', count()
+FROM system.parts_columns
+WHERE database = currentDatabase()
+  AND table = 't_coalescing_clear_required'
+  AND active
+  AND column = 'v';
+
+DROP TABLE t_coalescing_clear_required;
+
+DROP TABLE IF EXISTS t_aggregating_clear_required;
+CREATE TABLE t_aggregating_clear_required
+(
+    k UInt32,
+    s AggregateFunction(sum, UInt64),
+    keep AggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree()
+ORDER BY k
+SETTINGS min_rows_for_wide_part = 0, min_bytes_for_wide_part = 0;
+
+INSERT INTO t_aggregating_clear_required SELECT 1, sumState(toUInt64(7)), sumState(toUInt64(70)) FROM numbers(1);
+INSERT INTO t_aggregating_clear_required SELECT 1, sumState(toUInt64(11)), sumState(toUInt64(110)) FROM numbers(1);
+ALTER TABLE t_aggregating_clear_required CLEAR COLUMN s;
+
+OPTIMIZE TABLE t_aggregating_clear_required FINAL;
+
+SELECT 'aggregating_clear_state', k, finalizeAggregation(s), finalizeAggregation(keep) FROM t_aggregating_clear_required ORDER BY k;
+SELECT 'aggregating_clear_parts_column_s', count()
+FROM system.parts_columns
+WHERE database = currentDatabase()
+  AND table = 't_aggregating_clear_required'
+  AND active
+  AND column = 's';
+
+DROP TABLE t_aggregating_clear_required;
+
+DROP TABLE IF EXISTS t_aggregating_ttl_required;
+CREATE TABLE t_aggregating_ttl_required
+(
+    d Date,
+    k UInt32,
+    expired SimpleAggregateFunction(sum, UInt64) TTL d + INTERVAL 1 DAY,
+    keep SimpleAggregateFunction(sum, UInt64)
+)
+ENGINE = AggregatingMergeTree()
+PARTITION BY toYYYYMM(d)
+ORDER BY k
+SETTINGS min_rows_for_wide_part = 0, min_bytes_for_wide_part = 0;
+
+SYSTEM STOP MERGES t_aggregating_ttl_required;
+INSERT INTO t_aggregating_ttl_required VALUES ('2001-09-09', 1, 7, 10);
+INSERT INTO t_aggregating_ttl_required VALUES ('2001-09-09', 1, 11, 20);
+SYSTEM START MERGES t_aggregating_ttl_required;
+OPTIMIZE TABLE t_aggregating_ttl_required PARTITION 200109 FINAL;
+OPTIMIZE TABLE t_aggregating_ttl_required PARTITION 200109 FINAL;
+
+SELECT 'aggregating_ttl_values', k, expired, keep FROM t_aggregating_ttl_required ORDER BY k;
+SELECT 'aggregating_ttl_parts_column_expired', count()
+FROM system.parts_columns
+WHERE database = currentDatabase()
+  AND table = 't_aggregating_ttl_required'
+  AND active
+  AND column = 'expired';
+
+DROP TABLE t_aggregating_ttl_required;
+
+DROP TABLE IF EXISTS t_replacing_clear_regression;
+CREATE TABLE t_replacing_clear_regression
+(
+    k UInt32,
+    version UInt64,
+    v UInt64
+)
+ENGINE = ReplacingMergeTree(version)
+ORDER BY k
+SETTINGS min_rows_for_wide_part = 0, min_bytes_for_wide_part = 0;
+
+INSERT INTO t_replacing_clear_regression VALUES (1, 1, 10);
+INSERT INTO t_replacing_clear_regression VALUES (1, 2, 20);
+ALTER TABLE t_replacing_clear_regression CLEAR COLUMN v;
+OPTIMIZE TABLE t_replacing_clear_regression FINAL;
+
+SELECT 'replacing_clear_regression', k, version, v FROM t_replacing_clear_regression ORDER BY k;
+SELECT 'replacing_clear_parts_column_v', count()
+FROM system.parts_columns
+WHERE database = currentDatabase()
+  AND table = 't_replacing_clear_regression'
+  AND active
+  AND column = 'v';
+
+DROP TABLE t_replacing_clear_regression;


### PR DESCRIPTION
Fixes merge preparation for `CLEAR COLUMN`, added columns, and TTL-expired columns in special `MergeTree` engines. Columns required by `SummingMergeTree`, `AggregatingMergeTree`, and `CoalescingMergeTree` now stay in the merge input so default values are materialized before special merge semantics run, while expired-column cleanup remains separate. `GraphiteMergeTree` remains scoped to configured rollup columns.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `CLEAR COLUMN` and TTL handling during merges for `SummingMergeTree`, `AggregatingMergeTree`, and `CoalescingMergeTree` when merge-required columns are absent or expired. Closes https://github.com/ClickHouse/ClickHouse/issues/101953

### Documentation entry:
- [x] Documentation is not required.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.805`
<!-- ch-version-info:end -->