### PR TITLE
Remove abandoned .net client link

### DIFF
--- a/docs/en/interfaces/third-party/client-libraries.md
+++ b/docs/en/interfaces/third-party/client-libraries.md
@@ -77,7 +77,6 @@ ClickHouse Inc does **not** maintain the libraries listed below and hasn't done 
 ### C# {#c}
 - [Octonica.ClickHouseClient](https://github.com/Octonica/ClickHouseClient)
 - [ClickHouse.Ado](https://github.com/killwort/ClickHouse-Net)
-- [ClickHouse.Client](https://github.com/DarkWanderer/ClickHouse.Client)
 - [ClickHouse.Net](https://github.com/ilyabreev/ClickHouse.Net)
 ### Elixir {#elixir}
 - [clickhousex](https://github.com/appodeal/clickhousex/)


### PR DESCRIPTION
ClickHouse.Client has been archived for a ~year, the codebase was taken over by us in a separate project. No point in linking to it.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.757`
<!-- ch-version-info:end -->