### PR TITLE
Fix race in DNSCacheUpdater::run + Context::reloadClusterConfig

### DIFF
--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -5792,7 +5792,12 @@ void Context::setClustersConfig(const ConfigurationPtr & config, bool enable_dis
         }
 
         /// Do not update clusters if this part of config wasn't changed.
-        if (shared->clusters && isSameConfiguration(*config, *shared->clusters_config, config_name))
+        /// Note: clusters_config must be checked for null separately from clusters, because
+        /// reloadClusterConfig() (called e.g. from DNSCacheUpdater on startup) can populate
+        /// shared->clusters using the fallback getConfigRef() without setting shared->clusters_config.
+        /// If setClustersConfig() then runs before the config reloader stores its ConfigurationPtr,
+        /// dereferencing shared->clusters_config would throw Poco::NullPointerException.
+        if (shared->clusters && shared->clusters_config && isSameConfiguration(*config, *shared->clusters_config, config_name))
             return;
 
         auto old_clusters_config = shared->clusters_config;

--- a/src/Interpreters/tests/gtest_context_race.cpp
+++ b/src/Interpreters/tests/gtest_context_race.cpp
@@ -7,6 +7,9 @@
 #include <thread>
 #include <atomic>
 #include <vector>
+#include <sstream>
+#include <Poco/AutoPtr.h>
+#include <Poco/Util/XMLConfiguration.h>
 
 using namespace DB;
 
@@ -163,4 +166,34 @@ TEST(Context, TableFunctionResultsCopyRace)
 
     copier.join();
     writer.join();
+}
+
+/// Regression test for a startup race between DNSCacheUpdater and ConfigReloader.
+///
+/// DNSCacheUpdater::run() can call Context::reloadClusterConfig() before the first
+/// ConfigReloader pass stores a ConfigurationPtr into shared->clusters_config.
+/// reloadClusterConfig() falls back to getConfigRef() and sets shared->clusters (non-null)
+/// but leaves shared->clusters_config null. When setClustersConfig() subsequently runs
+/// it used to dereference shared->clusters_config unconditionally whenever shared->clusters
+/// was non-null, throwing Poco::NullPointerException.
+///
+/// The fix adds a shared->clusters_config null-guard before the isSameConfiguration() call.
+/// This test reproduces the exact call order deterministically (no real threading needed)
+/// and fails without the fix.
+TEST(Context, SetClustersConfigAfterReloadClusterConfig)
+{
+    auto context = Context::createCopy(getContext().context);
+    context->makeGlobalContext();
+
+    /// Simulate DNSCacheUpdater firing before ConfigReloader: this populates
+    /// shared->clusters via the getConfigRef() fallback, leaving clusters_config null.
+    ASSERT_NO_THROW(context->reloadClusterConfig());
+
+    /// Now simulate the first ConfigReloader pass calling setClustersConfig().
+    /// Without the fix this throws Poco::NullPointerException because shared->clusters
+    /// is non-null but shared->clusters_config is still null.
+    std::string xml = "<clickhouse><remote_servers/></clickhouse>";
+    std::istringstream xml_stream(xml); // NOLINT(misc-const-correctness)
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config = new Poco::Util::XMLConfiguration(xml_stream);
+    ASSERT_NO_THROW(context->setClustersConfig(config, /*enable_discovery=*/false));
 }

--- a/src/Interpreters/tests/gtest_context_race.cpp
+++ b/src/Interpreters/tests/gtest_context_race.cpp
@@ -183,7 +183,6 @@ TEST(Context, TableFunctionResultsCopyRace)
 TEST(Context, SetClustersConfigAfterReloadClusterConfig)
 {
     auto context = Context::createCopy(getContext().context);
-    context->makeGlobalContext();
 
     /// Simulate DNSCacheUpdater firing before ConfigReloader: this populates
     /// shared->clusters via the getConfigRef() fallback, leaving clusters_config null.
@@ -192,8 +191,13 @@ TEST(Context, SetClustersConfigAfterReloadClusterConfig)
     /// Now simulate the first ConfigReloader pass calling setClustersConfig().
     /// Without the fix this throws Poco::NullPointerException because shared->clusters
     /// is non-null but shared->clusters_config is still null.
-    std::string xml = "<clickhouse><remote_servers/></clickhouse>";
-    std::istringstream xml_stream(xml); // NOLINT(misc-const-correctness)
-    Poco::AutoPtr<Poco::Util::XMLConfiguration> config = new Poco::Util::XMLConfiguration(xml_stream);
+    std::istringstream config_stream{"<clickhouse><remote_servers/></clickhouse>"};
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> config = new Poco::Util::XMLConfiguration(config_stream);
     ASSERT_NO_THROW(context->setClustersConfig(config, /*enable_discovery=*/false));
+
+    /// Verify the recovered state is sane: getClusters() must not throw and must
+    /// reflect the config we just applied (empty <remote_servers> → empty map).
+    std::map<String, ClusterPtr> clusters;
+    ASSERT_NO_THROW(clusters = context->getClusters());
+    EXPECT_TRUE(clusters.empty());
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add an explicit null-guard for `shared->clusters_config` before dereferencing it to avoid race condition.

### Note
Added `v25.12-must-backport` to address the crash loop caused by this race.

### Root Cause

On server startup, `DNSCacheUpdater` is started **before** `ConfigReloader` completes its
first synchronous config load. This creates a window where the following sequence occurs
across two threads:

```
DNSCacheUpdater thread                  ConfigReloader thread
──────────────────────────────────────────────────────────────
reloadClusterConfig()
  └─ cluster_config = shared->clusters_config  // null
  └─ falls back to getConfigRef()
  └─ shared->clusters = new Clusters(...)      // ← non-null now
  └─ shared->clusters_config unchanged         // ← still null
                                          setClustersConfig(config, ...)
                                            if (shared->clusters           // true ✓
                                             && isSameConfiguration(
                                                  *shared->clusters_config // ← BOOM
```

`reloadClusterConfig()` populates `shared->clusters` using the `getConfigRef()` fallback
but never writes to `shared->clusters_config`. When `setClustersConfig()` subsequently
runs, it sees `shared->clusters` as non-null and enters `isSameConfiguration()`, blindly
dereferencing `shared->clusters_config` - which is still null - causing
`Poco::NullPointerException`.

### Why It Was Rare

All four conditions must coincide within a tiny window:

1. A schedule-pool thread picks up `DNSCacheUpdater::run()` before `ConfigReloader`'s
   first pass finishes (XML parse + ZK include resolution is non-trivial).
2. `updateCache()` / `updateHostNameAndAddresses()` returns `true`, i.e. DNS state looks
   changed - almost guaranteed on a **cold cache** (fresh pod).
3. `reloadClusterConfig()` completes and sets `shared->clusters` before
   `setClustersConfig()` reaches its guard.
4. `setClustersConfig()` enters the guard before `shared->clusters_config` has been stored.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.829`
- Backported to: `26.4.5.30`
<!-- ch-version-info:end -->