### PR TITLE
Fix MSan use-of-uninitialized-value in UTF-8 case-insensitive StringSearcher

### DIFF
--- a/src/Common/StringSearcher.h
+++ b/src/Common/StringSearcher.h
@@ -422,6 +422,16 @@ public:
                     return;
                 }
             }
+            else
+            {
+                /// Invalid UTF-8 sequence in the middle of the needle: process bytes verbatim,
+                /// matching the design of the outer if-else above for the first character.
+                /// Without this, the inner loop below would read uninitialized bytes from
+                /// `l_seq` / `u_seq` and insert them into `cachel` / `cacheu`, surfacing later
+                /// as a MemorySanitizer use-of-uninitialized-value in `compare` / `search`.
+                memcpy(l_seq, needle_pos, src_len);
+                memcpy(u_seq, needle_pos, src_len);
+            }
 
             cache_actual_len += src_len;
             if (cache_actual_len < N)

--- a/src/Common/StringSearcher.h
+++ b/src/Common/StringSearcher.h
@@ -359,8 +359,14 @@ public:
             /// Invalid UTF-8
             if (!first_u32)
             {
-                /// Process it verbatim as a sequence of bytes.
-                size_t src_len = UTF8::seqLength(*needle);
+                /// Process it verbatim as a sequence of bytes. The clamp
+                /// against `needle_size` matches the inner-loop clamp at
+                /// `src_len = std::min<size_t>(needle_end - needle_pos, UTF8::seqLength(*needle_pos))`
+                /// below: a truncated first sequence (e.g. a 1-byte needle starting
+                /// with `0xE4`, where `seqLength` is 3) must not read past `needle_end`,
+                /// otherwise the `memcpy` propagates MemorySanitizer noise from
+                /// uninitialized memory past the needle into `l_seq` / `u_seq`.
+                size_t src_len = std::min<size_t>(needle_size, UTF8::seqLength(*needle));
 
                 memcpy(l_seq, needle, src_len);
                 memcpy(u_seq, needle, src_len);

--- a/tests/queries/0_stateless/04255_stringsearcher_utf8_invalid_needle.reference
+++ b/tests/queries/0_stateless/04255_stringsearcher_utf8_invalid_needle.reference
@@ -12,3 +12,15 @@
 1
 -- multi-row ilike
 64
+-- ilike with 1-byte truncated UTF-8 needle
+1
+-- positionCaseInsensitiveUTF8 with 1-byte truncated UTF-8 needle
+0
+-- multiSearchAnyCaseInsensitiveUTF8 with 1-byte truncated UTF-8 needle
+0
+-- startsWithCaseInsensitiveUTF8 with 1-byte truncated UTF-8 needle
+0
+-- endsWithCaseInsensitiveUTF8 with 1-byte truncated UTF-8 needle
+0
+-- multi-row ilike with 1-byte truncated UTF-8 needle
+64

--- a/tests/queries/0_stateless/04255_stringsearcher_utf8_invalid_needle.reference
+++ b/tests/queries/0_stateless/04255_stringsearcher_utf8_invalid_needle.reference
@@ -1,0 +1,14 @@
+-- ilike (Volnitsky -> UTF8CaseInsensitiveStringSearcher)
+1
+-- positionCaseInsensitiveUTF8
+0
+-- multiSearchAnyCaseInsensitiveUTF8
+0
+-- startsWithCaseInsensitiveUTF8
+0
+-- endsWithCaseInsensitiveUTF8
+0
+-- ilike with mixed valid/invalid UTF-8 needle
+1
+-- multi-row ilike
+64

--- a/tests/queries/0_stateless/04255_stringsearcher_utf8_invalid_needle.sql
+++ b/tests/queries/0_stateless/04255_stringsearcher_utf8_invalid_needle.sql
@@ -1,0 +1,53 @@
+-- Regression test for use-of-uninitialized-value in `StringSearcher<false, false>`
+-- (UTF-8 case-insensitive) when the needle contains an invalid UTF-8 sequence
+-- in the middle (i.e. not as the first character).
+--
+-- Reported by MemorySanitizer at `src/Common/StringSearcher.h:563:61` from
+-- `Volnitsky::Volnitsky` -> `MatchImpl::vectorVector` -> `FunctionLike` (`ilike`)
+-- across many unrelated PRs (chronic noise on `Unit tests (msan, function_prop_fuzzer)`).
+--
+-- Root cause:
+--   In the SIMD-cache loop in the `UTF8CaseInsensitiveStringSearcher` constructor,
+--   when `convertUTF8ToCodePoint` returned an empty optional for an invalid byte
+--   sequence in the middle of the needle, the inner loop still inserted
+--   `l_seq[j]` / `u_seq[j]` into `cachel` / `cacheu` even though those buffers
+--   had not been written for this iteration.
+--
+-- The fix mirrors the existing verbatim-bytes handling used for the first
+-- character: when the conversion fails, the bytes of the needle are copied
+-- into `l_seq` / `u_seq` directly.
+
+-- A 3-byte needle: 'a' (valid ASCII), followed by `\xC3\x28` (invalid UTF-8 -
+-- `\xC3` is a 2-byte start byte, but `\x28` is not a continuation byte).
+-- `seqLength(\xC3) = 2` and `needle_end - needle_pos = 2` on the second
+-- iteration, so `src_len = 2`. Without the fix this reads uninitialized
+-- `l_seq[1]` / `u_seq[1]`.
+SELECT '-- ilike (Volnitsky -> UTF8CaseInsensitiveStringSearcher)';
+SELECT count() FROM (SELECT ilike('some long haystack that is much longer than sixteen bytes', concat('%', unhex('61C328'), '%')));
+
+SELECT '-- positionCaseInsensitiveUTF8';
+SELECT positionCaseInsensitiveUTF8('some long haystack that is much longer than sixteen bytes', unhex('61C328'));
+
+SELECT '-- multiSearchAnyCaseInsensitiveUTF8';
+SELECT multiSearchAnyCaseInsensitiveUTF8('some long haystack that is much longer than sixteen bytes', [unhex('61C328')]);
+
+SELECT '-- startsWithCaseInsensitiveUTF8';
+SELECT startsWithCaseInsensitiveUTF8('some long haystack that is much longer than sixteen bytes', unhex('61C328'));
+
+SELECT '-- endsWithCaseInsensitiveUTF8';
+SELECT endsWithCaseInsensitiveUTF8('some long haystack that is much longer than sixteen bytes', unhex('61C328'));
+
+-- A trickier case: valid non-ASCII first character followed by invalid UTF-8 mid-needle.
+-- `\xC3\xA4` is `ä` (valid 2-byte UTF-8). Then `\xE4\x28\x29` is an invalid 3-byte
+-- start (`\xE4` expects two continuation bytes, but `\x28` is ASCII '(').
+SELECT '-- ilike with mixed valid/invalid UTF-8 needle';
+SELECT count() FROM (SELECT ilike('a long enough Bär haystack and some trailing bytes', concat('%', unhex('C3A4E42829'), '%')));
+
+-- Multi-row variant: makes the SIMD path more likely to engage on the cached
+-- needle across many haystacks.
+SELECT '-- multi-row ilike';
+SELECT count() FROM
+(
+    SELECT ilike(materialize('some long haystack that is much longer than sixteen bytes'), concat('%', unhex('61C328'), '%'))
+    FROM numbers(64)
+);

--- a/tests/queries/0_stateless/04255_stringsearcher_utf8_invalid_needle.sql
+++ b/tests/queries/0_stateless/04255_stringsearcher_utf8_invalid_needle.sql
@@ -1,6 +1,5 @@
 -- Regression test for use-of-uninitialized-value in `StringSearcher<false, false>`
--- (UTF-8 case-insensitive) when the needle contains an invalid UTF-8 sequence
--- in the middle (i.e. not as the first character).
+-- (UTF-8 case-insensitive) when the needle contains an invalid UTF-8 sequence.
 --
 -- Reported by MemorySanitizer at `src/Common/StringSearcher.h:563:61` from
 -- `Volnitsky::Volnitsky` -> `MatchImpl::vectorVector` -> `FunctionLike` (`ilike`)
@@ -11,11 +10,17 @@
 --   when `convertUTF8ToCodePoint` returned an empty optional for an invalid byte
 --   sequence in the middle of the needle, the inner loop still inserted
 --   `l_seq[j]` / `u_seq[j]` into `cachel` / `cacheu` even though those buffers
---   had not been written for this iteration.
+--   had not been written for this iteration. Symmetrically, the first-character
+--   invalid-UTF-8 branch above the loop copied `seqLength(*needle)` bytes from
+--   the needle without clamping to `needle_size`, so a truncated first sequence
+--   (e.g. a 1-byte needle starting with `\xE4`, where `seqLength` is 3) would
+--   read past `needle_end` into uninitialized memory and propagate sanitizer
+--   noise from the same family.
 --
 -- The fix mirrors the existing verbatim-bytes handling used for the first
 -- character: when the conversion fails, the bytes of the needle are copied
--- into `l_seq` / `u_seq` directly.
+-- into `l_seq` / `u_seq` directly, with the source length clamped to
+-- `needle_size` (first character) or `needle_end - needle_pos` (inner loop).
 
 -- A 3-byte needle: 'a' (valid ASCII), followed by `\xC3\x28` (invalid UTF-8 -
 -- `\xC3` is a 2-byte start byte, but `\x28` is not a continuation byte).
@@ -49,5 +54,32 @@ SELECT '-- multi-row ilike';
 SELECT count() FROM
 (
     SELECT ilike(materialize('some long haystack that is much longer than sixteen bytes'), concat('%', unhex('61C328'), '%'))
+    FROM numbers(64)
+);
+
+-- Truncated first-character invalid-UTF-8 needle: a 1-byte needle starting with
+-- `\xE4`. `seqLength(\xE4) = 3` but `needle_size = 1`, so without the clamp on
+-- `src_len` in the first-character branch the constructor would memcpy 3 bytes
+-- from a 1-byte needle, reading past `needle_end` into uninitialized memory.
+SELECT '-- ilike with 1-byte truncated UTF-8 needle';
+SELECT count() FROM (SELECT ilike('a long enough haystack that easily exceeds sixteen bytes', concat('%', unhex('E4'), '%')));
+
+SELECT '-- positionCaseInsensitiveUTF8 with 1-byte truncated UTF-8 needle';
+SELECT positionCaseInsensitiveUTF8('a long enough haystack that easily exceeds sixteen bytes', unhex('E4'));
+
+SELECT '-- multiSearchAnyCaseInsensitiveUTF8 with 1-byte truncated UTF-8 needle';
+SELECT multiSearchAnyCaseInsensitiveUTF8('a long enough haystack that easily exceeds sixteen bytes', [unhex('E4')]);
+
+SELECT '-- startsWithCaseInsensitiveUTF8 with 1-byte truncated UTF-8 needle';
+SELECT startsWithCaseInsensitiveUTF8('a long enough haystack that easily exceeds sixteen bytes', unhex('E4'));
+
+SELECT '-- endsWithCaseInsensitiveUTF8 with 1-byte truncated UTF-8 needle';
+SELECT endsWithCaseInsensitiveUTF8('a long enough haystack that easily exceeds sixteen bytes', unhex('E4'));
+
+-- Multi-row variant for the truncated first-character case.
+SELECT '-- multi-row ilike with 1-byte truncated UTF-8 needle';
+SELECT count() FROM
+(
+    SELECT ilike(materialize('a long enough haystack that easily exceeds sixteen bytes'), concat('%', unhex('E4'), '%'))
     FROM numbers(64)
 );


### PR DESCRIPTION
Investigation requested by @alexey-milovidov on https://github.com/ClickHouse/ClickHouse/pull/104966 (the chronic `Unit tests (msan, function_prop_fuzzer)` failure at `src/Common/StringSearcher.h:563:61` via `Volnitsky` -> `MatchImpl::vectorVector` -> `ilike`).

### Cross-PR signature (last 30 days, CIDB)

The same `use-of-uninitialized-value` at `StringSearcher.h:563:61` in `DB::impl::StringSearcher<false, false>::search` hit at least these 7 unrelated PRs on `Unit tests (msan, function_prop_fuzzer)`: #99740, #100277, #100377, #103383, #104545, #104966, #105126. The sibling shape at `StringSearcher.h:496:41` (the same predicate in `compare` instead of `search`) hit other PRs in the same window. Both come from the same chronic family tracked under umbrella issue #104877. PR #105146 ("Stop the bleeding in `function_prop_fuzzer`") did not silence this specific signature; PR #100225 ("Fix use-of-uninitialized-value in `StringSearcher.h`") fixed only the empty-needle path in `compare`, not the path triggered here.

### Root cause

`UTF8CaseInsensitiveStringSearcher` (`StringSearcher<false, false>`) caches the lowercase / uppercase variant of the first 16 needle bytes into the `__m128i` registers `cachel` / `cacheu`. The bytes are first staged through two stack buffers `l_seq` / `u_seq` (6 bytes each, **uninitialized at declaration**), then inserted into the SIMD cache via `_mm_insert_epi8`.

The first character is handled by the outer `if (*needle < 0x80u)` / `else` block, where the `else` branch already takes care of the invalid-UTF-8 case by copying bytes verbatim:

```cpp
if (!first_u32)
{
    /// Process it verbatim as a sequence of bytes.
    size_t src_len = UTF8::seqLength(*needle);
    memcpy(l_seq, needle, src_len);
    memcpy(u_seq, needle, src_len);
}
```

The per-character cache loop just below did **not** have a matching `else`:

```cpp
auto c_u32 = UTF8::convertUTF8ToCodePoint(reinterpret_cast<const char *>(needle_pos), src_len);

if (c_u32)
{
    ...
    size_t dst_l_len = UTF8::convertCodePointToUTF8(c_l_u32, reinterpret_cast<char *>(l_seq), sizeof(l_seq));
    size_t dst_u_len = UTF8::convertCodePointToUTF8(c_u_u32, reinterpret_cast<char *>(u_seq), sizeof(u_seq));
    ...
}
/// <-- no else here; l_seq / u_seq stay whatever they were

for (size_t j = 0; j < src_len && i < N; ++j, ++i)
{
    ...
    cachel = _mm_insert_epi8(cachel, l_seq[j], N - 1);
    cacheu = _mm_insert_epi8(cacheu, u_seq[j], N - 1);
    ...
}
```

When `convertUTF8ToCodePoint` returns an empty optional for an invalid UTF-8 sequence **in the middle of the needle** (e.g. needle bytes `0x61 0xC3 0x28` — `a` followed by an invalid two-byte sequence whose `seqLength(0xC3) = 2`), the `if (c_u32)` body is skipped and `l_seq` / `u_seq` keep whatever the previous iteration left in their first `dst_l_len` bytes — the remaining `src_len - dst_l_len` bytes are uninitialized. Those bytes then flow into `cachel` / `cacheu` and surface as MSan use-of-uninitialized-value the next time `_mm_cmpeq_epi8(v_haystack, cachel)` is evaluated, both in `compare` (line `496:41`) and `search` (line `563:61`).

The fix adds the missing `else` branch — when `c_u32` is empty, the needle bytes are copied verbatim into `l_seq` / `u_seq`, mirroring the existing first-character handling. Semantics are preserved: `compareTrivial` already breaks on invalid UTF-8 sequences in the needle, so the SIMD-prefilter result is irrelevant for those positions; only the MSan poison is removed.

The sibling `StringSearcher<false, true>` (ASCII case-insensitive) is not affected — it uses `std::tolower(*needle_pos)` per byte and never goes through UTF-8 decoding.

### Tests

`tests/queries/0_stateless/04255_stringsearcher_utf8_invalid_needle.sql` exercises the path through `ilike`, `positionCaseInsensitiveUTF8`, `multiSearchAnyCaseInsensitiveUTF8`, `startsWithCaseInsensitiveUTF8`, `endsWithCaseInsensitiveUTF8` with two needle shapes — `unhex('61C328')` (ASCII first byte + invalid 2-byte continuation) and `unhex('C3A4E42829')` (valid two-byte `ä` followed by an invalid three-byte start). Both ask the SIMD path to engage on a 50+ byte haystack so the bug deterministically triggers in the constructor's cache loop without the fix.

Verified locally with the debug build (20/20 passing under `--test-runs 20`). The MSan-only nature of the bug means CI `Unit tests (msan, function_prop_fuzzer)` is the ground-truth check; the test will continue to pass functionally in debug / asan / tsan independent of the fix.

### Coordination note (for #104966)

The other failure on #104966 — `Stress test (arm_msan)` `Cannot start clickhouse-server` `StorageTimeSeries::StorageTimeSeries` null-deref during startup — is the same family as PR #104905, no separate fix needed here.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!---
A technical comment, you are free to remove or leave it as it is when PR is created
The following categories are used in the next scripts, update them accordingly
utils/changelog/changelog.py
tests/ci/cancel_and_rerun_workflow_lambda/app.py
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.807`
<!-- ch-version-info:end -->