### PR TITLE
Missing C function checks

### DIFF
--- a/src/Common/Crypto/X509Certificate.cpp
+++ b/src/Common/Crypto/X509Certificate.cpp
@@ -131,10 +131,14 @@ std::string X509Certificate::serialNumber() const
 {
     ASN1_INTEGER * serial = X509_get_serialNumber(certificate);
     BIGNUM * bn = ASN1_INTEGER_to_BN(serial, nullptr);
+    if (!bn)
+        throw Exception(ErrorCodes::OPENSSL_ERROR, "ASN1_INTEGER_to_BN failed: {}", getOpenSSLErrors());
 
     SCOPE_EXIT({ BN_free(bn); });
 
     char * hex = BN_bn2hex(bn);
+    if (!hex)
+        throw Exception(ErrorCodes::OPENSSL_ERROR, "BN_bn2hex failed: {}", getOpenSSLErrors());
     std::string result(hex);
 
     SCOPE_EXIT({ OPENSSL_free(hex); });

--- a/src/Common/OpenSSLHelpers.cpp
+++ b/src/Common/OpenSSLHelpers.cpp
@@ -56,6 +56,8 @@ void encodeSHA256(std::string_view text, unsigned char * out)
 void encodeSHA256(const void * text, size_t size, unsigned char * out)
 {
     auto ctx = std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>(EVP_MD_CTX_new(), EVP_MD_CTX_free);
+    if (!ctx)
+        throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_MD_CTX_new failed: {}", getOpenSSLErrors());
 
     if (!EVP_DigestInit(ctx.get(), EVP_sha256()))
         throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_DigestInit failed: {}", getOpenSSLErrors());
@@ -253,6 +255,8 @@ std::string generateCSR(const std::vector<std::string> domain_names, EVP_PKEY * 
 
     /// And our CSR is ready
     BIO_ptr req_bio(BIO_new(BIO_s_mem()), BIO_free);
+    if (!req_bio)
+        throw Exception(ErrorCodes::OPENSSL_ERROR, "BIO_new failed: {}", getOpenSSLErrors());
     if (i2d_X509_REQ_bio(req_bio.get(), req.get()) < 0)
         throw Exception(ErrorCodes::OPENSSL_ERROR, "Failure in i2d_X509_REQ_bio: {}", getOpenSSLErrors());
 

--- a/src/Compression/CompressionCodecZSTD.cpp
+++ b/src/Compression/CompressionCodecZSTD.cpp
@@ -35,6 +35,8 @@ UInt32 CompressionCodecZSTD::getMaxCompressedDataSize(UInt32 uncompressed_size) 
 UInt32 CompressionCodecZSTD::doCompressData(const char * source, UInt32 source_size, char * dest) const
 {
     ZSTD_CCtx * cctx = ZSTD_createCCtx();
+    if (!cctx)
+        throw Exception(ErrorCodes::CANNOT_COMPRESS, "Cannot compress with ZSTD codec: failed to create compression context");
     ZSTD_CCtx_setParameter(cctx, ZSTD_c_compressionLevel, level);
     if (enable_long_range)
     {

--- a/src/Functions/FunctionsAES.h
+++ b/src/Functions/FunctionsAES.h
@@ -33,6 +33,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
+    extern const int OPENSSL_ERROR;
 }
 
 
@@ -269,6 +270,8 @@ private:
         using namespace OpenSSLDetails;
 
         auto evp_ctx_ptr = std::unique_ptr<EVP_CIPHER_CTX, decltype(&::EVP_CIPHER_CTX_free)>(EVP_CIPHER_CTX_new(), &EVP_CIPHER_CTX_free);
+        if (!evp_ctx_ptr)
+            throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_CIPHER_CTX_new failed");
         auto * evp_ctx = evp_ctx_ptr.get();
 
         const auto block_size = static_cast<size_t>(EVP_CIPHER_block_size(evp_cipher));
@@ -544,6 +547,8 @@ private:
         using namespace OpenSSLDetails;
 
         auto evp_ctx_ptr = std::unique_ptr<EVP_CIPHER_CTX, decltype(&::EVP_CIPHER_CTX_free)>(EVP_CIPHER_CTX_new(), &EVP_CIPHER_CTX_free);
+        if (!evp_ctx_ptr)
+            throw Exception(ErrorCodes::OPENSSL_ERROR, "EVP_CIPHER_CTX_new failed");
         auto * evp_ctx = evp_ctx_ptr.get();
 
         [[maybe_unused]] const auto block_size = static_cast<size_t>(EVP_CIPHER_block_size(evp_cipher));

--- a/src/IO/Archives/LibArchiveReader.cpp
+++ b/src/IO/Archives/LibArchiveReader.cpp
@@ -252,6 +252,8 @@ private:
     Archive openWithReader(StreamInfo * read_stream_)
     {
         auto * archive = archive_read_new();
+        if (!archive)
+            throw Exception(ErrorCodes::CANNOT_UNPACK_ARCHIVE, "Couldn't create archive reader");
         try
         {
             // Support for bzip2, gzip, lzip, xz, zstd and lz4
@@ -289,6 +291,8 @@ private:
     Archive openWithPath(const String & path_to_archive_)
     {
         auto * archive = archive_read_new();
+        if (!archive)
+            throw Exception(ErrorCodes::CANNOT_UNPACK_ARCHIVE, "Couldn't create archive reader");
         try
         {
             // Support for bzip2, gzip, lzip, xz, zstd and lz4

--- a/src/IO/Archives/LibArchiveWriter.cpp
+++ b/src/IO/Archives/LibArchiveWriter.cpp
@@ -245,6 +245,8 @@ void LibArchiveWriter::createArchive()
 {
     std::lock_guard lock{mutex};
     archive = archive_write_new();
+    if (!archive)
+        throw Exception(ErrorCodes::CANNOT_PACK_ARCHIVE, "Couldn't create archive writer");
     setFormatAndSettings();
     if (stream_info)
     {

--- a/src/IO/BrotliReadBuffer.cpp
+++ b/src/IO/BrotliReadBuffer.cpp
@@ -21,6 +21,8 @@ public:
         : state(BrotliDecoderCreateInstance(nullptr, nullptr, nullptr))
         , result(BROTLI_DECODER_RESULT_NEEDS_MORE_INPUT)
     {
+        if (!state)
+            throw Exception(ErrorCodes::BROTLI_READ_FAILED, "brotli decoder instance creation failed");
     }
 
     ~BrotliStateWrapper()

--- a/src/IO/BrotliWriteBuffer.cpp
+++ b/src/IO/BrotliWriteBuffer.cpp
@@ -16,6 +16,8 @@ namespace ErrorCodes
 BrotliWriteBuffer::BrotliStateWrapper::BrotliStateWrapper()
 : state(BrotliEncoderCreateInstance(nullptr, nullptr, nullptr))
 {
+    if (!state)
+        throw Exception(ErrorCodes::BROTLI_WRITE_FAILED, "brotli encoder instance creation failed");
 }
 
 BrotliWriteBuffer::BrotliStateWrapper::~BrotliStateWrapper()

--- a/src/IO/FileEncryptionCommon.cpp
+++ b/src/IO/FileEncryptionCommon.cpp
@@ -299,6 +299,8 @@ void Encryptor::encrypt(const char * data, size_t size, WriteBuffer & out)
     auto current_iv = (init_vector + blocks(offset)).toString();
 
     auto evp_ctx_ptr = std::unique_ptr<EVP_CIPHER_CTX, decltype(&::EVP_CIPHER_CTX_free)>(EVP_CIPHER_CTX_new(), &EVP_CIPHER_CTX_free);
+    if (!evp_ctx_ptr)
+        throw Exception(DB::ErrorCodes::OPENSSL_ERROR, "EVP_CIPHER_CTX_new failed: {}", getOpenSSLErrors());
     auto * evp_ctx = evp_ctx_ptr.get();
 
     if (EVP_EncryptInit_ex(evp_ctx, evp_cipher, nullptr, nullptr, nullptr) != 1)
@@ -347,6 +349,8 @@ void Encryptor::decrypt(const char * data, size_t size, char * out)
     auto current_iv = (init_vector + blocks(offset)).toString();
 
     auto evp_ctx_ptr = std::unique_ptr<EVP_CIPHER_CTX, decltype(&::EVP_CIPHER_CTX_free)>(EVP_CIPHER_CTX_new(), &EVP_CIPHER_CTX_free);
+    if (!evp_ctx_ptr)
+        throw Exception(DB::ErrorCodes::OPENSSL_ERROR, "EVP_CIPHER_CTX_new failed: {}", getOpenSSLErrors());
     auto * evp_ctx = evp_ctx_ptr.get();
 
     if (EVP_DecryptInit_ex(evp_ctx, evp_cipher, nullptr, nullptr, nullptr) != 1)


### PR DESCRIPTION
### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixes https://github.com/ClickHouse/ClickHouse/issues/105221

A few C function calls are not checked to see if they return successfully, so that crashes can happen in OOM situations.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.842`
<!-- ch-version-info:end -->