### PR TITLE
Quote shell arguments in clickhouse install and git-import

### DIFF
--- a/programs/git-import/git-import.cpp
+++ b/programs/git-import/git-import.cpp
@@ -18,6 +18,7 @@
 #include <Common/StringUtils.h>
 #include <Common/ShellCommand.h>
 #include <Common/re2.h>
+#include <Common/shellQuote.h>
 #include <base/find_symbols.h>
 
 #include <IO/ReadHelpers.h>
@@ -1125,9 +1126,12 @@ static void processCommit(
   */
 static auto gitShow(const std::string & hash)
 {
+    /// `hash` is parsed from `git log --pretty=%H` output, which is hex-only today,
+    /// but quote it anyway so a future format change or a hand-crafted hash list
+    /// cannot inject shell syntax through `/bin/sh -c`.
     std::string command = fmt::format(
         "git show --raw --pretty='format:%ct%x00%aN%x00%P%x00%s%x00' --patch --unified=0 {}",
-        hash);
+        shellQuote(hash));
 
     return ShellCommand::execute(command);
 }

--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -19,6 +19,7 @@
 #include <Common/ErrnoException.h>
 #include <Common/ShellCommand.h>
 #include <Common/formatReadable.h>
+#include <Common/shellQuote.h>
 #include <Common/Config/ConfigProcessor.h>
 #include <Common/OpenSSLHelpers.h>
 #include <base/sleep.h>
@@ -102,25 +103,6 @@ static constexpr auto DEFAULT_CLICKHOUSE_BRIDGE_GROUP = "clickhouse-bridge";
 using namespace DB;
 namespace po = boost::program_options;
 namespace fs = std::filesystem;
-
-
-/// POSIX-compliant single-quote escaping: wrap in single quotes and replace any
-/// embedded single quote with '\''. Safe against arbitrary byte content.
-static std::string shellQuote(std::string_view s)
-{
-    std::string out;
-    out.reserve(s.size() + 2);
-    out.push_back('\'');
-    for (char c : s)
-    {
-        if (c == '\'')
-            out.append("'\\''");
-        else
-            out.push_back(c);
-    }
-    out.push_back('\'');
-    return out;
-}
 
 
 static auto executeScript(const std::string & command, bool throw_on_error = false)
@@ -215,7 +197,9 @@ static std::string formatWithSudo(std::string command, bool needed = true)
 
 #if defined(OS_FREEBSD)
     /// FreeBSD does not have 'sudo' installed.
-    return fmt::format("su -m root -c '{}'", command);
+    /// `su -c` takes a single shell command string, so quote the whole command
+    /// to keep embedded shell metacharacters from breaking the wrapper.
+    return fmt::format("su -m root -c {}", shellQuote(command));
 #else
     return fmt::format("sudo {}", command);
 #endif

--- a/programs/install/Install.cpp
+++ b/programs/install/Install.cpp
@@ -158,7 +158,8 @@ static void changeOwnership(const String & file_name, const String & user_name, 
 {
     if (!user_name.empty() || !group_name.empty())
     {
-        std::string command = fmt::format("chown {} {}:{} '{}'", (recursive ? "-R" : ""), user_name, group_name, file_name);
+        std::string command = fmt::format("chown {} {}:{} {}",
+            (recursive ? "-R" : ""), shellQuote(user_name), shellQuote(group_name), shellQuote(file_name));
         fmt::print(" {}\n", command);
         executeScript(command);
     }
@@ -172,11 +173,11 @@ static void createGroup(const String & group_name)
         // TODO: implement.
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Unable to create a group in macOS");
 #elif defined(OS_FREEBSD)
-        std::string command = fmt::format("pw groupadd {}", group_name);
+        std::string command = fmt::format("pw groupadd {}", shellQuote(group_name));
         fmt::print(" {}\n", command);
         executeScript(command);
 #else
-        std::string command = fmt::format("groupadd -r {}", group_name);
+        std::string command = fmt::format("groupadd -r {}", shellQuote(group_name));
         fmt::print(" {}\n", command);
         executeScript(command);
 #endif
@@ -192,14 +193,14 @@ static void createUser(const String & user_name, [[maybe_unused]] const String &
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Unable to create a user in macOS");
 #elif defined(OS_FREEBSD)
         std::string command = group_name.empty()
-            ? fmt::format("pw useradd -s /bin/false -d /nonexistent -n {}", user_name)
-            : fmt::format("pw useradd -s /bin/false -d /nonexistent -g {} -n {}", group_name, user_name);
+            ? fmt::format("pw useradd -s /bin/false -d /nonexistent -n {}", shellQuote(user_name))
+            : fmt::format("pw useradd -s /bin/false -d /nonexistent -g {} -n {}", shellQuote(group_name), shellQuote(user_name));
         fmt::print(" {}\n", command);
         executeScript(command);
 #else
         std::string command = group_name.empty()
-            ? fmt::format("useradd -r --shell /bin/false --home-dir /nonexistent --user-group {}", user_name)
-            : fmt::format("useradd -r --shell /bin/false --home-dir /nonexistent -g {} {}", group_name, user_name);
+            ? fmt::format("useradd -r --shell /bin/false --home-dir /nonexistent --user-group {}", shellQuote(user_name))
+            : fmt::format("useradd -r --shell /bin/false --home-dir /nonexistent -g {} {}", shellQuote(group_name), shellQuote(user_name));
         fmt::print(" {}\n", command);
         executeScript(command);
 #endif
@@ -916,7 +917,7 @@ int mainEntryClickHouseInstall(int argc, char ** argv)
             " || echo \"Cannot set 'net_admin' or 'ipc_lock' or 'sys_nice' or 'net_bind_service' capability for clickhouse binary."
                 " This is optional. Taskstats accounting will be disabled."
                 " To enable taskstats accounting you may add the required capability later manually.\"",
-            fs::canonical(main_bin_path).string());
+            shellQuote(fs::canonical(main_bin_path).string()));
         executeScript(command);
 #endif
 

--- a/src/Common/shellQuote.h
+++ b/src/Common/shellQuote.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+
+namespace DB
+{
+
+/// POSIX-compliant single-quote escaping: wrap in single quotes and replace any
+/// embedded single quote with '\''. Safe against arbitrary byte content.
+inline std::string shellQuote(std::string_view s)
+{
+    std::string out;
+    out.reserve(s.size() + 2);
+    out.push_back('\'');
+    for (char c : s)
+    {
+        if (c == '\'')
+            out.append("'\\''");
+        else
+            out.push_back(c);
+    }
+    out.push_back('\'');
+    return out;
+}
+
+}


### PR DESCRIPTION
A few places under `programs/` build shell command strings via `fmt::format` and run them through `/bin/sh -c`, interpolating CLI arguments or values parsed from external sources without escaping. Going through every command-construction site and wrap interpolated values with the existing `shellQuote` helper so embedded whitespace, single quotes, or other shell metacharacters are handled correctly.

In `clickhouse install`:
- `changeOwnership`, `createGroup`, `createUser` — `chown`, `useradd`/`pw useradd`, `groupadd`/`pw groupadd` now quote the user, group, and path arguments derived from `--user`, `--group`, `--log-path`, `--data-path`, `--pid-path`, `--config-path`.
- The Linux `setcap` invocation now quotes the binary path derived from `--binary-path`/`--prefix`.
- `formatWithSudo`'s FreeBSD branch (`su -m root -c '...'`) now quotes the inner command via `shellQuote` so an embedded `'` cannot break the wrapper. The Linux `sudo {command}` branch is intentionally left as-is.

In `clickhouse git-import`:
- `gitShow` now quotes the commit hash before interpolating it into `git show ... {hash}`. `%H` is hex-only today, but a future format change or a manually-supplied hash list shouldn't be able to influence the shell.

`shellQuote` was a file-local `static` helper in `Install.cpp`. Move it to `src/Common/shellQuote.h` so both programs can use the same implementation.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Quote shell arguments built from CLI options and parsed input in `clickhouse install` and `clickhouse git-import` so paths, user/group names, and commit hashes containing whitespace or shell metacharacters are handled correctly.

### Documentation entry for user-facing changes

- [x] Documentation is unnecessary (general improvement and internal refactor; no user-visible API change).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.779`
<!-- ch-version-info:end -->