### PR TITLE
fix: DateTime64BestEffort milli/nano precision

### DIFF
--- a/src/IO/parseDateTimeBestEffort.cpp
+++ b/src/IO/parseDateTimeBestEffort.cpp
@@ -197,6 +197,12 @@ ReturnType parseDateTimeBestEffortImpl(
         {
             num_digits = readDigits(digits, sizeof(digits), in);
 
+            /// Unix timestamps with subsecond precision are matched on exact digit count, assuming a 10-digit
+            /// seconds part (timestamps on/after 2001-09-09 01:46:40 UTC). This keeps parsing unambiguous.
+            /// Without it, a 9-digit input could be a pre-2001 second timestamp or a microsecond timestamp from
+            /// 1970. The trade-off is that pre-2001 subsecond timestamps (12-digit ms, 15-digit us, 18-digit ns)
+            /// are rejected here; resolving that would require make this function aware of `scale` argument so we could
+            /// split from the right instead.
             if (num_digits == 13 && !year && !has_time)
             {
                 /// This is unix timestamp with millisecond.

--- a/src/IO/parseDateTimeBestEffort.cpp
+++ b/src/IO/parseDateTimeBestEffort.cpp
@@ -213,6 +213,38 @@ ReturnType parseDateTimeBestEffortImpl(
                 }
                 return ReturnType(true);
             }
+            if (num_digits == 16 && !year && !has_time)
+            {
+                /// This is unix timestamp with microsecond.
+                readDecimalNumber<10>(res, digits);
+                if (fractional)
+                {
+                    fractional->digits = 6;
+                    readDecimalNumber<6>(fractional->value, digits + 10);
+                }
+                else if constexpr (strict)
+                {
+                    /// Fractional part is not allowed.
+                    return on_error(ErrorCodes::CANNOT_PARSE_DATETIME, "Cannot read DateTime: unexpected fractional part");
+                }
+                return ReturnType(true);
+            }
+            if (num_digits == 19 && !year && !has_time)
+            {
+                /// This is unix timestamp with nanosecond.
+                readDecimalNumber<10>(res, digits);
+                if (fractional)
+                {
+                    fractional->digits = 9;
+                    readDecimalNumber<9>(fractional->value, digits + 10);
+                }
+                else if constexpr (strict)
+                {
+                    /// Fractional part is not allowed.
+                    return on_error(ErrorCodes::CANNOT_PARSE_DATETIME, "Cannot read DateTime: unexpected fractional part");
+                }
+                return ReturnType(true);
+            }
             if (num_digits == 10 && !year && !has_time)
             {
                 if constexpr (strict)

--- a/tests/queries/0_stateless/04249_parseDateTime64BestEffort_unix_timestamp_subsecond.reference
+++ b/tests/queries/0_stateless/04249_parseDateTime64BestEffort_unix_timestamp_subsecond.reference
@@ -16,3 +16,6 @@ non-const
 parseDateTime64BestEffortUS
 2026-05-18 09:02:48.417585
 2026-05-18 09:02:48.417585845
+pre-2001 subsecond timestamps are not supported (10-digit seconds assumption)
+\N
+1970-01-01 00:00:00.000000000

--- a/tests/queries/0_stateless/04249_parseDateTime64BestEffort_unix_timestamp_subsecond.reference
+++ b/tests/queries/0_stateless/04249_parseDateTime64BestEffort_unix_timestamp_subsecond.reference
@@ -1,0 +1,18 @@
+toDateTime64 cast (cast_string_to_date_time_mode = best_effort)
+2026-05-18 09:02:48.417585
+2026-05-18 09:02:48.417585845
+parseDateTime64BestEffort
+2026-05-18 09:02:48.417585
+2026-05-18 09:02:48.417585845
+scale promotion: microsecond digits, nanosecond scale
+2026-05-18 09:02:48.417585000
+scale truncation: nanosecond digits, microsecond scale
+2026-05-18 09:02:48.417585
+parseDateTime64BestEffortOrNull / OrZero
+2026-05-18 09:02:48.417585845
+2026-05-18 09:02:48.417585845
+non-const
+2026-05-18 09:02:48.417585845
+parseDateTime64BestEffortUS
+2026-05-18 09:02:48.417585
+2026-05-18 09:02:48.417585845

--- a/tests/queries/0_stateless/04249_parseDateTime64BestEffort_unix_timestamp_subsecond.reference
+++ b/tests/queries/0_stateless/04249_parseDateTime64BestEffort_unix_timestamp_subsecond.reference
@@ -1,4 +1,7 @@
-toDateTime64 cast (cast_string_to_date_time_mode = best_effort)
+toDateTime64 cast: explicit cast_string_to_date_time_mode = best_effort
+2026-05-18 09:02:48.417585
+2026-05-18 09:02:48.417585845
+toDateTime64 cast: inherited default (expected to match best_effort)
 2026-05-18 09:02:48.417585
 2026-05-18 09:02:48.417585845
 parseDateTime64BestEffort

--- a/tests/queries/0_stateless/04249_parseDateTime64BestEffort_unix_timestamp_subsecond.sql
+++ b/tests/queries/0_stateless/04249_parseDateTime64BestEffort_unix_timestamp_subsecond.sql
@@ -1,0 +1,29 @@
+-- Unix timestamps with microsecond (16 digits) and nanosecond (19 digits) precision
+-- must be parsed by the best-effort parser. Previously the parser only knew about
+-- 13-digit millisecond timestamps and rejected longer ones with
+-- "unexpected number of decimal digits".
+
+SELECT 'toDateTime64 cast (cast_string_to_date_time_mode = best_effort)';
+SELECT toDateTime64('1779094968417585', 6, 'UTC');
+SELECT toDateTime64('1779094968417585845', 9, 'UTC');
+
+SELECT 'parseDateTime64BestEffort';
+SELECT parseDateTime64BestEffort('1779094968417585', 6, 'UTC');
+SELECT parseDateTime64BestEffort('1779094968417585845', 9, 'UTC');
+
+SELECT 'scale promotion: microsecond digits, nanosecond scale';
+SELECT parseDateTime64BestEffort('1779094968417585', 9, 'UTC');
+
+SELECT 'scale truncation: nanosecond digits, microsecond scale';
+SELECT parseDateTime64BestEffort('1779094968417585845', 6, 'UTC');
+
+SELECT 'parseDateTime64BestEffortOrNull / OrZero';
+SELECT parseDateTime64BestEffortOrNull('1779094968417585845', 9, 'UTC');
+SELECT parseDateTime64BestEffortOrZero('1779094968417585845', 9, 'UTC');
+
+SELECT 'non-const';
+SELECT parseDateTime64BestEffort(materialize('1779094968417585845'), 9, 'UTC');
+
+SELECT 'parseDateTime64BestEffortUS';
+SELECT parseDateTime64BestEffortUS('1779094968417585', 6, 'UTC');
+SELECT parseDateTime64BestEffortUS('1779094968417585845', 9, 'UTC');

--- a/tests/queries/0_stateless/04249_parseDateTime64BestEffort_unix_timestamp_subsecond.sql
+++ b/tests/queries/0_stateless/04249_parseDateTime64BestEffort_unix_timestamp_subsecond.sql
@@ -3,7 +3,17 @@
 -- 13-digit millisecond timestamps and rejected longer ones with
 -- "unexpected number of decimal digits".
 
-SELECT 'toDateTime64 cast (cast_string_to_date_time_mode = best_effort)';
+-- Exercise toDateTime64 cast in two configurations:
+--   1. explicit SETTINGS cast_string_to_date_time_mode = 'best_effort' — pins the parser this PR fixes
+--      so the test keeps exercising the right contract even if the default changes later.
+--   2. inherited default — pins the assumption that `best_effort` IS the default; a silent default
+--      change would flip this section without flipping section 1.
+-- Both must agree.
+SELECT 'toDateTime64 cast: explicit cast_string_to_date_time_mode = best_effort';
+SELECT toDateTime64('1779094968417585', 6, 'UTC') SETTINGS cast_string_to_date_time_mode = 'best_effort';
+SELECT toDateTime64('1779094968417585845', 9, 'UTC') SETTINGS cast_string_to_date_time_mode = 'best_effort';
+
+SELECT 'toDateTime64 cast: inherited default (expected to match best_effort)';
 SELECT toDateTime64('1779094968417585', 6, 'UTC');
 SELECT toDateTime64('1779094968417585845', 9, 'UTC');
 

--- a/tests/queries/0_stateless/04249_parseDateTime64BestEffort_unix_timestamp_subsecond.sql
+++ b/tests/queries/0_stateless/04249_parseDateTime64BestEffort_unix_timestamp_subsecond.sql
@@ -27,3 +27,14 @@ SELECT parseDateTime64BestEffort(materialize('1779094968417585845'), 9, 'UTC');
 SELECT 'parseDateTime64BestEffortUS';
 SELECT parseDateTime64BestEffortUS('1779094968417585', 6, 'UTC');
 SELECT parseDateTime64BestEffortUS('1779094968417585845', 9, 'UTC');
+
+-- Documented limitation: the subsecond branches assume a 10-digit seconds part,
+-- so pre-2001-09-09 subsecond timestamps (12-digit ms, 15-digit us, 18-digit ns)
+-- are not handled here and fail with CANNOT_PARSE_DATETIME. Mirrors the existing
+-- 13-digit-only ms branch. These assertions pin the current behavior.
+SELECT 'pre-2001 subsecond timestamps are not supported (10-digit seconds assumption)';
+SELECT parseDateTime64BestEffort('978307200000', 3, 'UTC'); -- {serverError CANNOT_PARSE_DATETIME}
+SELECT parseDateTime64BestEffort('978307200000000', 6, 'UTC'); -- {serverError CANNOT_PARSE_DATETIME}
+SELECT parseDateTime64BestEffort('978307200000000000', 9, 'UTC'); -- {serverError CANNOT_PARSE_DATETIME}
+SELECT parseDateTime64BestEffortOrNull('978307200000000', 6, 'UTC');
+SELECT parseDateTime64BestEffortOrZero('978307200000000000', 9, 'UTC');


### PR DESCRIPTION


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `best_effort` date time parsing work correctly with `toDateTime64` with `ms` and `ns` precision.

### Explanation.

Looks [like enabling the "best_effort" as default recently caused this?](https://clickhouse.com/docs/operations/settings/settings#cast_string_to_date_time_mode)

This is [exposed by the golang-client tests that runs on head of the master branch.](https://github.com/ClickHouse/clickhouse-go/actions/runs/26023721803/job/76491524925?pr=1861). It used to work in previous versions correctly (because it was using `basic` as default)

Before:
```
$ clickhouse-local
ClickHouse local version 26.3.9.8 (official build).

:) SELECT toDateTime64('1779094968417585845', 9) SETTINGS  cast_string_to_date_time_mode='best_effort'

SELECT toDateTime64('1779094968417585845', 9)
SETTINGS cast_string_to_date_time_mode = 'best_effort'

Query id: b390c272-5a88-4b58-ab93-4b80429e0c1d


Elapsed: 0.014 sec.

Received exception:
Code: 41. DB::Exception: Cannot read DateTime: unexpected number of decimal digits: 19: Cannot parse DateTime64(9) from String: In scope SELECT toDateTime64('1779094968417585845', 9) SETTINGS cast_string_to_date_time_mode = 'best_effort'. (CANNOT_PARSE_DATETIME)

```

After:
```
:) SELECT toDateTime64('1779094968417585845', 9) SETTINGS  cast_string_to_date_time_mode='best_effort'

SELECT toDateTime64('1779094968417585845', 9)
SETTINGS cast_string_to_date_time_mode = 'best_effort'

Query id: d11d292d-6183-4b2d-8bff-1af10e9bee08

   ┌─toDateTime64('⋯417585845', 9)─┐
1. │ 2026-05-18 11:02:48.417585845 │
   └───────────────────────────────┘

1 row in set. Elapsed: 0.004 sec.

```