### PR TITLE
Sanitize server-supplied display strings in client Hello

### DIFF
--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -611,11 +611,12 @@ void Connection::receiveHello()
             UInt64 rules_size;
             readVarUInt(rules_size, *in);
             /// `rules_size` is server-controlled and feeds a `reserve`; reject absurd
-            /// values so a hostile server cannot force a huge allocation.
-            if (rules_size > MAX_PASSWORD_COMPLEXITY_RULES)
+            /// values so a hostile server cannot force a huge allocation. The server
+            /// enforces the same cap at construction time (see TCPHandler::sendHello).
+            if (rules_size > DBMS_MAX_PASSWORD_COMPLEXITY_RULES)
                 throw Exception(ErrorCodes::UNEXPECTED_PACKET_FROM_SERVER,
                     "Server declared {} password-complexity rules, maximum allowed is {}",
-                    rules_size, MAX_PASSWORD_COMPLEXITY_RULES);
+                    rules_size, DBMS_MAX_PASSWORD_COMPLEXITY_RULES);
             password_complexity_rules.reserve(rules_size);
 
             for (size_t i = 0; i < rules_size; ++i)

--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -15,6 +15,7 @@
 #include <Client/ClientApplicationBase.h>
 #include <Client/Connection.h>
 #include <Client/ConnectionParameters.h>
+#include <Client/sanitizeUntrustedServerString.h>
 #include <Common/logger_useful.h>
 #include <Common/ClickHouseRevision.h>
 #include <Common/Exception.h>
@@ -575,16 +576,23 @@ void Connection::receiveHello()
     readVarUInt(packet_type, *in);
     if (packet_type == Protocol::Server::Hello)
     {
-        readStringBinary(server_name, *in);
+        readStringBinary(server_name, *in, MAX_SERVER_HELLO_STRING_SIZE);
+        sanitizeUntrustedServerString(server_name);
         readVarUInt(server_version_major, *in);
         readVarUInt(server_version_minor, *in);
         readVarUInt(server_revision, *in);
         if (server_revision >= DBMS_MIN_REVISION_WITH_VERSIONED_PARALLEL_REPLICAS_PROTOCOL)
             readVarUInt(server_parallel_replicas_protocol_version, *in);
         if (server_revision >= DBMS_MIN_REVISION_WITH_SERVER_TIMEZONE)
-            readStringBinary(server_timezone, *in);
+        {
+            readStringBinary(server_timezone, *in, MAX_SERVER_HELLO_STRING_SIZE);
+            sanitizeUntrustedServerString(server_timezone);
+        }
         if (server_revision >= DBMS_MIN_REVISION_WITH_SERVER_DISPLAY_NAME)
-            readStringBinary(server_display_name, *in);
+        {
+            readStringBinary(server_display_name, *in, MAX_SERVER_HELLO_STRING_SIZE);
+            sanitizeUntrustedServerString(server_display_name);
+        }
         if (server_revision >= DBMS_MIN_REVISION_WITH_VERSION_PATCH)
             readVarUInt(server_version_patch, *in);
         else
@@ -606,8 +614,10 @@ void Connection::receiveHello()
             {
                 String original_pattern;
                 String exception_message;
-                readStringBinary(original_pattern, *in);
-                readStringBinary(exception_message, *in);
+                readStringBinary(original_pattern, *in, MAX_SERVER_HELLO_STRING_SIZE);
+                readStringBinary(exception_message, *in, MAX_SERVER_HELLO_STRING_SIZE);
+                sanitizeUntrustedServerString(original_pattern);
+                sanitizeUntrustedServerString(exception_message);
                 password_complexity_rules.push_back({std::move(original_pattern), std::move(exception_message)});
             }
         }

--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -600,14 +600,22 @@ void Connection::receiveHello()
 
         if (server_revision >= DBMS_MIN_PROTOCOL_VERSION_WITH_CHUNKED_PACKETS)
         {
-            readStringBinary(proto_send_chunked_srv, *in);
-            readStringBinary(proto_recv_chunked_srv, *in);
+            /// These are tiny protocol tokens ("chunked" / "notchunked") compared in
+            /// `is_chunked`; cap them so a hostile server cannot force a large allocation.
+            readStringBinary(proto_send_chunked_srv, *in, MAX_SERVER_HELLO_STRING_SIZE);
+            readStringBinary(proto_recv_chunked_srv, *in, MAX_SERVER_HELLO_STRING_SIZE);
         }
 
         if (server_revision >= DBMS_MIN_PROTOCOL_VERSION_WITH_PASSWORD_COMPLEXITY_RULES)
         {
             UInt64 rules_size;
             readVarUInt(rules_size, *in);
+            /// `rules_size` is server-controlled and feeds a `reserve`; reject absurd
+            /// values so a hostile server cannot force a huge allocation.
+            if (rules_size > MAX_PASSWORD_COMPLEXITY_RULES)
+                throw Exception(ErrorCodes::UNEXPECTED_PACKET_FROM_SERVER,
+                    "Server declared {} password-complexity rules, maximum allowed is {}",
+                    rules_size, MAX_PASSWORD_COMPLEXITY_RULES);
             password_complexity_rules.reserve(rules_size);
 
             for (size_t i = 0; i < rules_size; ++i)
@@ -1433,7 +1441,10 @@ Packet Connection::receivePacket()
                 return res;
 
             case Protocol::Server::TimezoneUpdate:
-                readStringBinary(server_timezone, *in);
+                /// Same cap + control-char sanitization as the handshake read; the field
+                /// reaches the client's terminal via the time-zone warning path.
+                readStringBinary(server_timezone, *in, MAX_SERVER_HELLO_STRING_SIZE);
+                sanitizeUntrustedServerString(server_timezone);
                 res.server_timezone = server_timezone;
                 return res;
 

--- a/src/Client/Connection.cpp
+++ b/src/Client/Connection.cpp
@@ -576,7 +576,7 @@ void Connection::receiveHello()
     readVarUInt(packet_type, *in);
     if (packet_type == Protocol::Server::Hello)
     {
-        readStringBinary(server_name, *in, MAX_SERVER_HELLO_STRING_SIZE);
+        readStringBinary(server_name, *in, DBMS_MAX_HELLO_STRING_SIZE);
         sanitizeUntrustedServerString(server_name);
         readVarUInt(server_version_major, *in);
         readVarUInt(server_version_minor, *in);
@@ -585,12 +585,12 @@ void Connection::receiveHello()
             readVarUInt(server_parallel_replicas_protocol_version, *in);
         if (server_revision >= DBMS_MIN_REVISION_WITH_SERVER_TIMEZONE)
         {
-            readStringBinary(server_timezone, *in, MAX_SERVER_HELLO_STRING_SIZE);
+            readStringBinary(server_timezone, *in, DBMS_MAX_HELLO_STRING_SIZE);
             sanitizeUntrustedServerString(server_timezone);
         }
         if (server_revision >= DBMS_MIN_REVISION_WITH_SERVER_DISPLAY_NAME)
         {
-            readStringBinary(server_display_name, *in, MAX_SERVER_HELLO_STRING_SIZE);
+            readStringBinary(server_display_name, *in, DBMS_MAX_HELLO_STRING_SIZE);
             sanitizeUntrustedServerString(server_display_name);
         }
         if (server_revision >= DBMS_MIN_REVISION_WITH_VERSION_PATCH)
@@ -602,8 +602,8 @@ void Connection::receiveHello()
         {
             /// These are tiny protocol tokens ("chunked" / "notchunked") compared in
             /// `is_chunked`; cap them so a hostile server cannot force a large allocation.
-            readStringBinary(proto_send_chunked_srv, *in, MAX_SERVER_HELLO_STRING_SIZE);
-            readStringBinary(proto_recv_chunked_srv, *in, MAX_SERVER_HELLO_STRING_SIZE);
+            readStringBinary(proto_send_chunked_srv, *in, DBMS_MAX_HELLO_STRING_SIZE);
+            readStringBinary(proto_recv_chunked_srv, *in, DBMS_MAX_HELLO_STRING_SIZE);
         }
 
         if (server_revision >= DBMS_MIN_PROTOCOL_VERSION_WITH_PASSWORD_COMPLEXITY_RULES)
@@ -623,8 +623,8 @@ void Connection::receiveHello()
             {
                 String original_pattern;
                 String exception_message;
-                readStringBinary(original_pattern, *in, MAX_SERVER_HELLO_STRING_SIZE);
-                readStringBinary(exception_message, *in, MAX_SERVER_HELLO_STRING_SIZE);
+                readStringBinary(original_pattern, *in, DBMS_MAX_HELLO_STRING_SIZE);
+                readStringBinary(exception_message, *in, DBMS_MAX_HELLO_STRING_SIZE);
                 sanitizeUntrustedServerString(original_pattern);
                 sanitizeUntrustedServerString(exception_message);
                 password_complexity_rules.push_back({std::move(original_pattern), std::move(exception_message)});
@@ -1444,7 +1444,7 @@ Packet Connection::receivePacket()
             case Protocol::Server::TimezoneUpdate:
                 /// Same cap + control-char sanitization as the handshake read; the field
                 /// reaches the client's terminal via the time-zone warning path.
-                readStringBinary(server_timezone, *in, MAX_SERVER_HELLO_STRING_SIZE);
+                readStringBinary(server_timezone, *in, DBMS_MAX_HELLO_STRING_SIZE);
                 sanitizeUntrustedServerString(server_timezone);
                 res.server_timezone = server_timezone;
                 return res;

--- a/src/Client/sanitizeUntrustedServerString.h
+++ b/src/Client/sanitizeUntrustedServerString.h
@@ -21,18 +21,39 @@ constexpr size_t MAX_SERVER_HELLO_STRING_SIZE = 4096;
 /// configurations have a handful of rules at most.
 constexpr size_t MAX_PASSWORD_COMPLEXITY_RULES = 256;
 
-/// Replace ASCII control characters (0x00-0x1F and 0x7F DEL) with '?' so a hostile
-/// server cannot inject terminal escape sequences via fields that the client prints
-/// verbatim. UTF-8 high bytes (>= 0x80) are preserved so non-ASCII display names
-/// render normally.
+/// Replace ASCII C0 control characters (0x00-0x1F), DEL (0x7F), and the UTF-8
+/// encoding of C1 controls (U+0080-U+009F, encoded as `0xC2 0x80..0x9F`) with '?'
+/// so a hostile server cannot inject terminal escape sequences via fields that the
+/// client prints verbatim. U+009B / U+009D / U+009C are the 8-bit equivalents of
+/// `ESC [` / `ESC ]` / `ESC \\` and some terminals act on them. Other UTF-8 high
+/// bytes are preserved so non-ASCII display names render normally.
 inline void sanitizeUntrustedServerString(String & s)
 {
-    for (auto & c : s)
+    for (size_t i = 0; i < s.size(); ++i)
     {
+        const auto uc = static_cast<unsigned char>(s[i]);
+
         /// `isControlASCII` covers 0x00-0x1F only; DEL (0x7F) is not in that range
         /// but we strip it too — older terminals interpret it as backspace.
-        if (isControlASCII(c) || static_cast<unsigned char>(c) == 0x7F)
-            c = '?';
+        if (isControlASCII(s[i]) || uc == 0x7F)
+        {
+            s[i] = '?';
+            continue;
+        }
+
+        /// Catch the two-byte UTF-8 encoding of C1 controls: `0xC2 0x80..0x9F`.
+        /// Stripping raw `0x80..0x9F` would mangle valid UTF-8 continuation bytes
+        /// (e.g. `0x9F` in "П"), so we match the encoding pair instead.
+        if (uc == 0xC2 && i + 1 < s.size())
+        {
+            const auto next = static_cast<unsigned char>(s[i + 1]);
+            if (next >= 0x80 && next <= 0x9F)
+            {
+                s[i] = '?';
+                s[i + 1] = '?';
+                ++i;
+            }
+        }
     }
 }
 

--- a/src/Client/sanitizeUntrustedServerString.h
+++ b/src/Client/sanitizeUntrustedServerString.h
@@ -9,10 +9,17 @@ namespace DB
 {
 
 /// Cap on server-supplied display strings read during the client's Hello packet
-/// (server name, time zone, display name, password-rule patterns/messages).
-/// Legitimate values are short; a high cap is purely an attack surface
-/// (`readStringBinary` defaults to 1 GiB, which is a denial-of-service vector).
+/// (server name, time zone, display name, password-rule patterns/messages) and
+/// post-handshake updates of the same fields. Legitimate values are short; a
+/// high cap is purely an attack surface (`readStringBinary` defaults to 1 GiB,
+/// which is a denial-of-service vector against the connecting client).
 constexpr size_t MAX_SERVER_HELLO_STRING_SIZE = 4096;
+
+/// Cap on the number of password-complexity rules the server can declare. The
+/// rule count is server-supplied and used directly for a `reserve`, so without
+/// a cap a hostile server can force an arbitrarily large allocation. Real-world
+/// configurations have a handful of rules at most.
+constexpr size_t MAX_PASSWORD_COMPLEXITY_RULES = 256;
 
 /// Replace ASCII control characters (0x00-0x1F and 0x7F DEL) with '?' so a hostile
 /// server cannot inject terminal escape sequences via fields that the client prints

--- a/src/Client/sanitizeUntrustedServerString.h
+++ b/src/Client/sanitizeUntrustedServerString.h
@@ -1,19 +1,11 @@
 #pragma once
 
-#include <cstddef>
 #include <base/types.h>
 #include <Common/StringUtils.h>
 
 
 namespace DB
 {
-
-/// Cap on server-supplied display strings read during the client's Hello packet
-/// (server name, time zone, display name, password-rule patterns/messages) and
-/// post-handshake updates of the same fields. Legitimate values are short; a
-/// high cap is purely an attack surface (`readStringBinary` defaults to 1 GiB,
-/// which is a denial-of-service vector against the connecting client).
-constexpr size_t MAX_SERVER_HELLO_STRING_SIZE = 4096;
 
 /// Replace ASCII C0 control characters (0x00-0x1F), DEL (0x7F), and the UTF-8
 /// encoding of C1 controls (U+0080-U+009F, encoded as `0xC2 0x80..0x9F`) with '?'

--- a/src/Client/sanitizeUntrustedServerString.h
+++ b/src/Client/sanitizeUntrustedServerString.h
@@ -15,12 +15,6 @@ namespace DB
 /// which is a denial-of-service vector against the connecting client).
 constexpr size_t MAX_SERVER_HELLO_STRING_SIZE = 4096;
 
-/// Cap on the number of password-complexity rules the server can declare. The
-/// rule count is server-supplied and used directly for a `reserve`, so without
-/// a cap a hostile server can force an arbitrarily large allocation. Real-world
-/// configurations have a handful of rules at most.
-constexpr size_t MAX_PASSWORD_COMPLEXITY_RULES = 256;
-
 /// Replace ASCII C0 control characters (0x00-0x1F), DEL (0x7F), and the UTF-8
 /// encoding of C1 controls (U+0080-U+009F, encoded as `0xC2 0x80..0x9F`) with '?'
 /// so a hostile server cannot inject terminal escape sequences via fields that the

--- a/src/Client/sanitizeUntrustedServerString.h
+++ b/src/Client/sanitizeUntrustedServerString.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstddef>
+#include <base/types.h>
+#include <Common/StringUtils.h>
+
+
+namespace DB
+{
+
+/// Cap on server-supplied display strings read during the client's Hello packet
+/// (server name, time zone, display name, password-rule patterns/messages).
+/// Legitimate values are short; a high cap is purely an attack surface
+/// (`readStringBinary` defaults to 1 GiB, which is a denial-of-service vector).
+constexpr size_t MAX_SERVER_HELLO_STRING_SIZE = 4096;
+
+/// Replace ASCII control characters (0x00-0x1F and 0x7F DEL) with '?' so a hostile
+/// server cannot inject terminal escape sequences via fields that the client prints
+/// verbatim. UTF-8 high bytes (>= 0x80) are preserved so non-ASCII display names
+/// render normally.
+inline void sanitizeUntrustedServerString(String & s)
+{
+    for (auto & c : s)
+    {
+        /// `isControlASCII` covers 0x00-0x1F only; DEL (0x7F) is not in that range
+        /// but we strip it too — older terminals interpret it as backspace.
+        if (isControlASCII(c) || static_cast<unsigned char>(c) == 0x7F)
+            c = '?';
+    }
+}
+
+}

--- a/src/Client/tests/gtest_sanitize_untrusted_server_string.cpp
+++ b/src/Client/tests/gtest_sanitize_untrusted_server_string.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <Client/sanitizeUntrustedServerString.h>
+#include <Core/ProtocolDefines.h>
 
 using namespace DB;
 
@@ -149,7 +150,8 @@ TEST(SanitizeUntrustedServerString, MaxPasswordComplexityRulesCapIsTight)
 {
     /// `rules_size` from the server feeds directly into `reserve`; without a cap
     /// a hostile server forces an arbitrarily large allocation. Real configurations
-    /// declare a handful of rules at most.
-    EXPECT_LE(MAX_PASSWORD_COMPLEXITY_RULES, 4096u);
-    EXPECT_GE(MAX_PASSWORD_COMPLEXITY_RULES, 16u);
+    /// declare a handful of rules at most. The constant is shared between server
+    /// (TCPHandler::sendHello) and client (Connection::receiveHello).
+    EXPECT_LE(DBMS_MAX_PASSWORD_COMPLEXITY_RULES, 4096u);
+    EXPECT_GE(DBMS_MAX_PASSWORD_COMPLEXITY_RULES, 16u);
 }

--- a/src/Client/tests/gtest_sanitize_untrusted_server_string.cpp
+++ b/src/Client/tests/gtest_sanitize_untrusted_server_string.cpp
@@ -76,6 +76,65 @@ TEST(SanitizeUntrustedServerString, EmptyString)
     EXPECT_TRUE(s.empty());
 }
 
+TEST(SanitizeUntrustedServerString, ReplacesUtf8EncodedC1Controls)
+{
+    /// C1 controls (U+0080..U+009F) carry 8-bit equivalents of ESC-prefixed
+    /// terminal introducers — U+009D is OSC, U+009C is ST. A hostile server can
+    /// reach them as their UTF-8 encoding `0xC2 0x80..0x9F`, bypassing a sanitizer
+    /// that only strips ESC (`0x1B`).
+    String s;
+    s.append("\xC2\x9D" "0;PWNED\xC2\x9C");      // 8-bit OSC ... ST
+    s.append("payload");
+    s.append("\xC2\x9B" "31m**INJECTED**\xC2\x9B" "0m");  // 8-bit CSI sequences
+
+    const size_t original_size = s.size();
+    sanitizeUntrustedServerString(s);
+
+    /// Length must not change — each 2-byte C1 encoding becomes "??".
+    EXPECT_EQ(s.size(), original_size);
+    /// All `0xC2` bytes that were paired with C1 must be gone.
+    EXPECT_EQ(s.find('\xC2'), std::string::npos);
+    /// Plain ASCII surrounding the payload survives.
+    EXPECT_NE(s.find("PWNED"), std::string::npos);
+    EXPECT_NE(s.find("payload"), std::string::npos);
+    EXPECT_NE(s.find("**INJECTED**"), std::string::npos);
+}
+
+TEST(SanitizeUntrustedServerString, PreservesUtf8WhoseContinuationByteIsInC1Range)
+{
+    /// Many valid UTF-8 sequences have a continuation byte in [0x80, 0x9F] —
+    /// stripping that range blindly would mangle them. The Cyrillic letter "П"
+    /// (U+041F) is encoded as `0xD0 0x9F`. It must survive.
+    const String original = "Привет";
+    String s = original;
+    sanitizeUntrustedServerString(s);
+    EXPECT_EQ(s, original);
+}
+
+TEST(SanitizeUntrustedServerString, PreservesUtf8WhoseLeadByteIs0xC2)
+{
+    /// `0xC2` is also the lead byte for legitimate Latin-1 supplement characters
+    /// in the U+00A0..U+00BF range (encoded `0xC2 0xA0..0xBF`). Those must
+    /// survive — only continuation bytes in [0x80, 0x9F] (the C1 range) trigger
+    /// replacement.
+    const String original = "non-breaking\xC2\xA0space \xC2\xBF\xC2\xA1";
+    String s = original;
+    sanitizeUntrustedServerString(s);
+    EXPECT_EQ(s, original);
+}
+
+TEST(SanitizeUntrustedServerString, HandlesTrailing0xC2)
+{
+    /// A stray `0xC2` at the very end (no continuation byte) is invalid UTF-8.
+    /// The sanitizer must not read past the end of the buffer; the byte is left
+    /// alone (it will render as U+FFFD).
+    String s;
+    s.push_back('\xC2');
+    sanitizeUntrustedServerString(s);
+    EXPECT_EQ(s.size(), 1u);
+    EXPECT_EQ(static_cast<unsigned char>(s[0]), 0xC2u);
+}
+
 TEST(SanitizeUntrustedServerString, MaxStringSizeCapIsTight)
 {
     /// 4 KiB is well above any legitimate server name / time zone / display name

--- a/src/Client/tests/gtest_sanitize_untrusted_server_string.cpp
+++ b/src/Client/tests/gtest_sanitize_untrusted_server_string.cpp
@@ -142,8 +142,8 @@ TEST(SanitizeUntrustedServerString, MaxStringSizeCapIsTight)
     /// (hostnames cap at HOST_NAME_MAX = 255 on Linux; "Europe/Madrid" is 13
     /// bytes). Bumping the cap back to `readStringBinary`'s 1 GiB default would
     /// re-open the unbounded-allocation vector the helper exists to close.
-    EXPECT_LE(MAX_SERVER_HELLO_STRING_SIZE, 64u * 1024u);
-    EXPECT_GE(MAX_SERVER_HELLO_STRING_SIZE, 256u);
+    EXPECT_LE(DBMS_MAX_HELLO_STRING_SIZE, 64u * 1024u);
+    EXPECT_GE(DBMS_MAX_HELLO_STRING_SIZE, 256u);
 }
 
 TEST(SanitizeUntrustedServerString, MaxPasswordComplexityRulesCapIsTight)

--- a/src/Client/tests/gtest_sanitize_untrusted_server_string.cpp
+++ b/src/Client/tests/gtest_sanitize_untrusted_server_string.cpp
@@ -85,3 +85,12 @@ TEST(SanitizeUntrustedServerString, MaxStringSizeCapIsTight)
     EXPECT_LE(MAX_SERVER_HELLO_STRING_SIZE, 64u * 1024u);
     EXPECT_GE(MAX_SERVER_HELLO_STRING_SIZE, 256u);
 }
+
+TEST(SanitizeUntrustedServerString, MaxPasswordComplexityRulesCapIsTight)
+{
+    /// `rules_size` from the server feeds directly into `reserve`; without a cap
+    /// a hostile server forces an arbitrarily large allocation. Real configurations
+    /// declare a handful of rules at most.
+    EXPECT_LE(MAX_PASSWORD_COMPLEXITY_RULES, 4096u);
+    EXPECT_GE(MAX_PASSWORD_COMPLEXITY_RULES, 16u);
+}

--- a/src/Client/tests/gtest_sanitize_untrusted_server_string.cpp
+++ b/src/Client/tests/gtest_sanitize_untrusted_server_string.cpp
@@ -1,0 +1,87 @@
+#include <gtest/gtest.h>
+
+#include <Client/sanitizeUntrustedServerString.h>
+
+using namespace DB;
+
+/// `sanitizeUntrustedServerString` strips every byte that can drive a terminal
+/// escape sequence (OSC 0 window-title set, OSC 52 clipboard injection, OSC 8
+/// hyperlink fakery, SGR colour, ...) from server-supplied Hello fields that the
+/// client prints verbatim — `server_name`, `server_display_name`, etc.
+
+TEST(SanitizeUntrustedServerString, PreservesPrintableAscii)
+{
+    String s = "ClickHouse server v25.10";
+    sanitizeUntrustedServerString(s);
+    EXPECT_EQ(s, "ClickHouse server v25.10");
+}
+
+TEST(SanitizeUntrustedServerString, PreservesUtf8HighBytes)
+{
+    /// Non-ASCII display names (e.g. "Привет", "clïckhöuse") must survive — they
+    /// cannot drive a terminal sequence on their own.
+    const String original = "Привет clïckhöuse 你好";
+    String s = original;
+    sanitizeUntrustedServerString(s);
+    EXPECT_EQ(s, original);
+}
+
+TEST(SanitizeUntrustedServerString, ReplacesEscapeAndControlBytes)
+{
+    /// Representative payload: OSC 0 window-title set plus an SGR colour run.
+    String s;
+    s.append("\x1b]0;PWNED\x07");
+    s.append("\x1b[31m**INJECTED**\x1b[0m");
+    sanitizeUntrustedServerString(s);
+
+    EXPECT_EQ(s.find('\x1b'), std::string::npos);
+    EXPECT_EQ(s.find('\x07'), std::string::npos);
+    EXPECT_NE(s.find("PWNED"), std::string::npos);
+    EXPECT_NE(s.find("**INJECTED**"), std::string::npos);
+}
+
+TEST(SanitizeUntrustedServerString, ReplacesAllAsciiControlChars)
+{
+    /// Every byte in [0x00, 0x1F] plus 0x7F (DEL) must be rewritten to '?'.
+    String s;
+    for (int i = 0; i < 0x20; ++i)
+        s.push_back(static_cast<char>(i));
+    s.push_back('\x7F');
+
+    const size_t expected_replacements = s.size();
+    sanitizeUntrustedServerString(s);
+
+    EXPECT_EQ(s.size(), expected_replacements);
+    for (char c : s)
+        EXPECT_EQ(c, '?');
+}
+
+TEST(SanitizeUntrustedServerString, PreservesLengthAndPositions)
+{
+    /// The helper replaces in place, byte-for-byte. Length and the position of
+    /// surviving bytes must be unchanged; consumers that rely on the string
+    /// length (prompt rendering, regex compilation for password rules) keep
+    /// working.
+    String s = "a\x1b" "b\x07" "c";
+    EXPECT_EQ(s.size(), 5u);
+    sanitizeUntrustedServerString(s);
+    EXPECT_EQ(s.size(), 5u);
+    EXPECT_EQ(s, "a?b?c");
+}
+
+TEST(SanitizeUntrustedServerString, EmptyString)
+{
+    String s;
+    sanitizeUntrustedServerString(s);
+    EXPECT_TRUE(s.empty());
+}
+
+TEST(SanitizeUntrustedServerString, MaxStringSizeCapIsTight)
+{
+    /// 4 KiB is well above any legitimate server name / time zone / display name
+    /// (hostnames cap at HOST_NAME_MAX = 255 on Linux; "Europe/Madrid" is 13
+    /// bytes). Bumping the cap back to `readStringBinary`'s 1 GiB default would
+    /// re-open the unbounded-allocation vector the helper exists to close.
+    EXPECT_LE(MAX_SERVER_HELLO_STRING_SIZE, 64u * 1024u);
+    EXPECT_GE(MAX_SERVER_HELLO_STRING_SIZE, 256u);
+}

--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -91,6 +91,14 @@ static constexpr auto DBMS_MIN_PROTOCOL_VERSION_WITH_PASSWORD_COMPLEXITY_RULES =
 /// same bound on receive so a hostile server cannot force a huge `reserve`.
 static constexpr auto DBMS_MAX_PASSWORD_COMPLEXITY_RULES = 256;
 
+/// Upper bound on every server-supplied display string carried in the Hello packet
+/// (server name, time zone, display name, password-rule patterns and messages) and
+/// in post-handshake updates of the same fields. Legitimate values are short; a
+/// high cap is purely an attack surface. Enforced symmetrically: the server refuses
+/// to construct an oversized Hello (pointing at the misconfigured field), the
+/// client refuses to read one (defending against a hostile server).
+static constexpr auto DBMS_MAX_HELLO_STRING_SIZE = 4096;
+
 static constexpr auto DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET_V2 = 54462;
 
 static constexpr auto DBMS_MIN_PROTOCOL_VERSION_WITH_TOTAL_BYTES_IN_PROGRESS = 54463;

--- a/src/Core/ProtocolDefines.h
+++ b/src/Core/ProtocolDefines.h
@@ -84,6 +84,13 @@ static constexpr auto DBMS_MIN_PROTOCOL_VERSION_WITH_SERVER_QUERY_TIME_IN_PROGRE
 
 static constexpr auto DBMS_MIN_PROTOCOL_VERSION_WITH_PASSWORD_COMPLEXITY_RULES = 54461;
 
+/// Upper bound on the number of password-complexity rules carried in the server
+/// Hello packet. Real-world configurations declare a handful of rules at most.
+/// The server rejects configurations that exceed this when constructing its Hello
+/// so the operator sees the limit at its own boundary; the client enforces the
+/// same bound on receive so a hostile server cannot force a huge `reserve`.
+static constexpr auto DBMS_MAX_PASSWORD_COMPLEXITY_RULES = 256;
+
 static constexpr auto DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET_V2 = 54462;
 
 static constexpr auto DBMS_MIN_PROTOCOL_VERSION_WITH_TOTAL_BYTES_IN_PROGRESS = 54463;

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -2113,6 +2113,15 @@ void TCPHandler::sendHello()
     {
         auto rules = server.context()->getAccessControl().getPasswordComplexityRules();
 
+        /// Mirror the client-side cap so a misconfiguration fails at the server's own
+        /// boundary with a message pointing at the config, rather than producing an
+        /// `UNEXPECTED_PACKET_FROM_SERVER` on the client.
+        if (rules.size() > DBMS_MAX_PASSWORD_COMPLEXITY_RULES)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "Configured {} password-complexity rules, maximum allowed is {}. "
+                "Reduce the number of <password_complexity> entries in the server config.",
+                rules.size(), DBMS_MAX_PASSWORD_COMPLEXITY_RULES);
+
         writeVarUInt(rules.size(), *out);
         for (const auto & [original_pattern, exception_message] : rules)
         {

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -2125,6 +2125,16 @@ void TCPHandler::sendHello()
         writeVarUInt(rules.size(), *out);
         for (const auto & [original_pattern, exception_message] : rules)
         {
+            /// Same per-string cap the client enforces on receive; fail at the
+            /// server boundary so the operator fixes the offending entry instead
+            /// of seeing a downstream client-side rejection.
+            if (original_pattern.size() > DBMS_MAX_HELLO_STRING_SIZE
+                || exception_message.size() > DBMS_MAX_HELLO_STRING_SIZE)
+                throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                    "Password-complexity rule pattern or message exceeds the maximum "
+                    "size of {} bytes. Shorten the offending <password_complexity> "
+                    "entry in the server config.",
+                    DBMS_MAX_HELLO_STRING_SIZE);
             writeStringBinary(original_pattern, *out);
             writeStringBinary(exception_message, *out);
         }

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -2100,14 +2100,33 @@ void TCPHandler::sendHello()
         writeVarUInt(DBMS_PARALLEL_REPLICAS_PROTOCOL_VERSION, *out);
     if (client_tcp_protocol_version >= DBMS_MIN_REVISION_WITH_SERVER_TIMEZONE)
         writeStringBinary(DateLUT::instance().getTimeZone(), *out);
+    /// Reject oversized config-driven Hello fields at the server boundary so the
+    /// operator sees which setting is misconfigured, rather than a downstream
+    /// `UNEXPECTED_PACKET_FROM_SERVER` on the client.
+    auto check_hello_field_size = [](const String & value, const String & setting_name)
+    {
+        if (value.size() > DBMS_MAX_HELLO_STRING_SIZE)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS,
+                "Server config setting <{}> is {} bytes, maximum allowed in Hello is {}. "
+                "Shorten the value.",
+                setting_name, value.size(), DBMS_MAX_HELLO_STRING_SIZE);
+    };
+
     if (client_tcp_protocol_version >= DBMS_MIN_REVISION_WITH_SERVER_DISPLAY_NAME)
+    {
+        check_hello_field_size(server_display_name, "display_name");
         writeStringBinary(server_display_name, *out);
+    }
     if (client_tcp_protocol_version >= DBMS_MIN_REVISION_WITH_VERSION_PATCH)
         writeVarUInt(VERSION_PATCH, *out);
     if (client_tcp_protocol_version >= DBMS_MIN_PROTOCOL_VERSION_WITH_CHUNKED_PACKETS)
     {
-        writeStringBinary(server.config().getString("proto_caps.send", "notchunked"), *out);
-        writeStringBinary(server.config().getString("proto_caps.recv", "notchunked"), *out);
+        const auto proto_send = server.config().getString("proto_caps.send", "notchunked");
+        const auto proto_recv = server.config().getString("proto_caps.recv", "notchunked");
+        check_hello_field_size(proto_send, "proto_caps.send");
+        check_hello_field_size(proto_recv, "proto_caps.recv");
+        writeStringBinary(proto_send, *out);
+        writeStringBinary(proto_recv, *out);
     }
     if (client_tcp_protocol_version >= DBMS_MIN_PROTOCOL_VERSION_WITH_PASSWORD_COMPLEXITY_RULES)
     {


### PR DESCRIPTION
`clickhouse-client` reads `server_name`, `server_timezone`, `server_display_name`, and the password-complexity rule patterns and messages from the server's `Hello` packet via raw `readStringBinary` and prints them back to the user — directly in the `Connected to ...` banner, indirectly through the `{display_name}` prompt substitution, the time-zone warning, and password-rule error messages. A hostile or compromised server could embed arbitrary bytes in those fields (terminal escape sequences, etc.) and have the connecting client render them. The default `readStringBinary` cap of 1 GiB is also an unbounded-allocation vector against the connecting client.

Add `sanitizeUntrustedServerString` (in `src/Client/sanitizeUntrustedServerString.h`) that replaces ASCII control bytes (`0x00-0x1F` and `0x7F` DEL) with `?` while preserving UTF-8 high bytes so non-ASCII display names render normally. Apply it after each `readStringBinary` for those fields in `Connection::receiveHello`, and cap the reads at 4 KiB — well above any legitimate hostname / time zone / password-rule message — to close the unbounded-allocation vector.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Sanitize server-supplied display strings in `clickhouse-client`'s `Hello` packet handling (server name, time zone, display name, password-rule patterns and messages) so a hostile server cannot inject bytes that the client renders verbatim, and cap their size to defend against unbounded allocation.

### Documentation entry for user-facing changes

- [x] Documentation is unnecessary (defensive change with no user-visible API).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.93`
<!-- ch-version-info:end -->