### PR TITLE
Reset supplementary groups in clickhouse su before dropping privileges

### DIFF
--- a/programs/su/su.cpp
+++ b/programs/su/su.cpp
@@ -48,11 +48,14 @@ static void setUserAndGroup(std::string arg_uid, std::string arg_gid)
     static constexpr size_t buf_size = 16384; /// Linux man page says it is enough. Nevertheless, we will check if it's not enough and throw.
     std::unique_ptr<char[]> buf(new char[buf_size]);
 
-    /// Set the group first, because if we set user, the privileges will be already dropped and we will not be able to set the group later.
+    /// Resolve the target group GID first, while we still have privileges.
+    /// The actual setgid() call is deferred until after initgroups() so we
+    /// can reset the supplementary group list before dropping privileges.
 
+    bool has_gid = false;
+    gid_t gid = 0;
     if (!arg_gid.empty())
     {
-        gid_t gid = 0;
         if (!tryParse(gid, arg_gid) || gid == 0)
         {
             group entry{};
@@ -76,19 +79,24 @@ static void setUserAndGroup(std::string arg_uid, std::string arg_gid)
         if (gid == 0 && getgid() != 0)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Group has id 0, but dropping privileges to gid 0 does not make sense");
 
-        if (0 != setgid(gid))
-            throw ErrnoException(ErrorCodes::SYSTEM_ERROR, "Cannot do 'setgid' to user ({})", arg_gid);
+        has_gid = true;
     }
 
+    /// Resolve the target user UID and, where possible, the user name and primary
+    /// GID. We always consult the passwd database (even when arg_uid is numeric) so
+    /// that initgroups() can look up the user's supplementary group memberships.
+
+    bool has_uid = false;
+    uid_t uid = 0;
+    std::string user_name;
+    gid_t user_primary_gid = 0;
     if (!arg_uid.empty())
     {
-        /// Is it numeric id or name?
-        uid_t uid = 0;
+        passwd entry{};
+        passwd * result{};
+
         if (!tryParse(uid, arg_uid) || uid == 0)
         {
-            passwd entry{};
-            passwd * result{};
-
             if (0 != getpwnam_r(arg_uid.data(), &entry, buf.get(), buf_size, &result))
                 throw ErrnoException(ErrorCodes::SYSTEM_ERROR, "Cannot do 'getpwnam_r' to obtain uid from user name ({})", arg_uid);
 
@@ -102,11 +110,57 @@ static void setUserAndGroup(std::string arg_uid, std::string arg_gid)
             }
 
             uid = entry.pw_uid;
+            user_name = entry.pw_name;
+            user_primary_gid = entry.pw_gid;
+        }
+        else
+        {
+            /// Numeric, non-zero UID. Look up the passwd entry to obtain the user
+            /// name needed by initgroups(). If no entry exists we still proceed,
+            /// and the supplementary group list is cleared rather than populated
+            /// from /etc/group.
+            if (0 == getpwuid_r(uid, &entry, buf.get(), buf_size, &result) && result)
+            {
+                user_name = entry.pw_name;
+                user_primary_gid = entry.pw_gid;
+            }
         }
 
         if (uid == 0 && getuid() != 0)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "User has id 0, but dropping privileges to uid 0 does not make sense");
 
+        has_uid = true;
+    }
+
+    /// Reset the supplementary group list before dropping privileges. Otherwise
+    /// the dropped process silently inherits the caller's supplementary groups
+    /// (typically root's), defeating the intent of the privilege drop (CWE-273).
+    if (has_uid)
+    {
+        gid_t group_for_initgroups = has_gid ? gid : user_primary_gid;
+
+        if (!user_name.empty())
+        {
+            if (0 != initgroups(user_name.c_str(), group_for_initgroups))
+                throw ErrnoException(ErrorCodes::SYSTEM_ERROR, "Cannot do 'initgroups' for user ({})", user_name);
+        }
+        else
+        {
+            /// No passwd entry for this UID; clear supplementary groups entirely.
+            if (0 != setgroups(0, nullptr))
+                throw ErrnoException(ErrorCodes::SYSTEM_ERROR, "Cannot do 'setgroups' to clear supplementary groups");
+        }
+    }
+
+    /// Now drop privileges.
+    if (has_gid)
+    {
+        if (0 != setgid(gid))
+            throw ErrnoException(ErrorCodes::SYSTEM_ERROR, "Cannot do 'setgid' to user ({})", arg_gid);
+    }
+
+    if (has_uid)
+    {
         if (0 != setuid(uid))
             throw ErrnoException(ErrorCodes::SYSTEM_ERROR, "Cannot do 'setuid' to user ({})", arg_uid);
     }

--- a/programs/su/su.cpp
+++ b/programs/su/su.cpp
@@ -116,10 +116,15 @@ static void setUserAndGroup(std::string arg_uid, std::string arg_gid)
         else
         {
             /// Numeric, non-zero UID. Look up the passwd entry to obtain the user
-            /// name needed by initgroups(). If no entry exists we still proceed,
-            /// and the supplementary group list is cleared rather than populated
-            /// from /etc/group.
-            if (0 == getpwuid_r(uid, &entry, buf.get(), buf_size, &result) && result)
+            /// name needed by initgroups(). A nonzero return is a real NSS error
+            /// (ERANGE / ENOMEM / backend failure) and must be surfaced. The
+            /// "no entry" case (rc == 0, result == nullptr) is allowed: the
+            /// supplementary list will be cleared rather than populated from
+            /// /etc/group.
+            if (0 != getpwuid_r(uid, &entry, buf.get(), buf_size, &result))
+                throw ErrnoException(ErrorCodes::SYSTEM_ERROR, "Cannot do 'getpwuid_r' to obtain user name from uid ({})", uid);
+
+            if (result)
             {
                 user_name = entry.pw_name;
                 user_primary_gid = entry.pw_gid;
@@ -134,8 +139,12 @@ static void setUserAndGroup(std::string arg_uid, std::string arg_gid)
 
     /// Reset the supplementary group list before dropping privileges. Otherwise
     /// the dropped process silently inherits the caller's supplementary groups
-    /// (typically root's), defeating the intent of the privilege drop (CWE-273).
-    if (has_uid)
+    /// (typically root's), defeating the intent of the privilege drop.
+    /// initgroups()/setgroups() require CAP_SETGID, which a non-root caller does
+    /// not have; skip the reset in that case so same-identity no-op invocations
+    /// (e.g. `clickhouse su user:group` from inside a Docker `--user` container)
+    /// keep working.
+    if (has_uid && geteuid() == 0)
     {
         gid_t group_for_initgroups = has_gid ? gid : user_primary_gid;
 

--- a/programs/su/su.cpp
+++ b/programs/su/su.cpp
@@ -56,7 +56,8 @@ static void setUserAndGroup(std::string arg_uid, std::string arg_gid)
     gid_t gid = 0;
     if (!arg_gid.empty())
     {
-        if (!tryParse(gid, arg_gid) || gid == 0)
+        bool parsed_numeric = tryParse(gid, arg_gid);
+        if (!parsed_numeric || gid == 0)
         {
             group entry{};
             group * result{};
@@ -66,8 +67,12 @@ static void setUserAndGroup(std::string arg_uid, std::string arg_gid)
 
             if (!result)
             {
-                if (0 != getgrgid_r(gid, &entry, buf.get(), buf_size, &result))
-                    throw ErrnoException(ErrorCodes::SYSTEM_ERROR, "Cannot do 'getgrnam_r' to obtain gid from group name ({})", arg_gid);
+                /// Only retry as a numeric gid when the input actually parsed as a
+                /// number. Otherwise `gid` is still 0 and `getgrgid_r(0)` would
+                /// silently resolve to the root group, masking a typo in the
+                /// requested group name.
+                if (parsed_numeric && 0 != getgrgid_r(gid, &entry, buf.get(), buf_size, &result))
+                    throw ErrnoException(ErrorCodes::SYSTEM_ERROR, "Cannot do 'getgrgid_r' to obtain gid ({})", gid);
 
                 if (!result)
                     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Group {} is not found in the system", arg_gid);
@@ -95,15 +100,19 @@ static void setUserAndGroup(std::string arg_uid, std::string arg_gid)
         passwd entry{};
         passwd * result{};
 
-        if (!tryParse(uid, arg_uid) || uid == 0)
+        bool parsed_numeric = tryParse(uid, arg_uid);
+        if (!parsed_numeric || uid == 0)
         {
             if (0 != getpwnam_r(arg_uid.data(), &entry, buf.get(), buf_size, &result))
                 throw ErrnoException(ErrorCodes::SYSTEM_ERROR, "Cannot do 'getpwnam_r' to obtain uid from user name ({})", arg_uid);
 
             if (!result)
             {
-                if (0 != getpwuid_r(uid, &entry, buf.get(), buf_size, &result))
-                    throw ErrnoException(ErrorCodes::SYSTEM_ERROR, "Cannot do 'getpwuid_r' to obtain uid from user name ({})", uid);
+                /// Only retry as a numeric uid when the input actually parsed as a
+                /// number. Otherwise `uid` is still 0 and `getpwuid_r(0)` would
+                /// silently resolve to root, defeating the requested privilege drop.
+                if (parsed_numeric && 0 != getpwuid_r(uid, &entry, buf.get(), buf_size, &result))
+                    throw ErrnoException(ErrorCodes::SYSTEM_ERROR, "Cannot do 'getpwuid_r' to obtain user name from uid ({})", uid);
 
                 if (!result)
                     throw Exception(ErrorCodes::BAD_ARGUMENTS, "User {} is not found in the system", arg_uid);


### PR DESCRIPTION
`programs/su/su.cpp` resolves the target user and group, then calls `setgid` followed by `setuid`. Neither syscall touches the supplementary group list, so the dropped process silently inherits the supplementary groups of the invoker. On a system where root has been granted membership in groups like `disk`, `adm`, `wheel`, `docker`, `sudo`, or where the systemd unit / Docker entrypoint configures supplementary groups, those memberships leak into the unprivileged process and defeat the intent of the privilege drop. For comparison, `/bin/su` and `sudo` both reset the supplementary list via `initgroups` as part of dropping privileges.

`setUserAndGroup` is restructured so the passwd database is consulted even when the UID is supplied numerically (to recover the user name), and `initgroups(user_name, group)` is invoked before `setgid`/`setuid` so the supplementary group list reflects the target user's `/etc/group` memberships. When the target UID has no passwd entry the supplementary list is cleared with `setgroups(0, nullptr)` instead.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Reset the supplementary group list in `clickhouse su` before dropping privileges, matching the behavior of `/bin/su` and `sudo`. Previously the dropped process inherited the invoker's supplementary groups.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.161`
<!-- ch-version-info:end -->