### PR TITLE
FileCache won't throw on create directories failures

### DIFF
--- a/src/Interpreters/FileCache/FileCache.cpp
+++ b/src/Interpreters/FileCache/FileCache.cpp
@@ -1278,7 +1278,7 @@ bool FileCache::doTryReserve(
 
     if (auto ec = file_segment.getKeyMetadata()->createBaseDirectory(); ec)
     {
-        failure_reason = ec.message();
+        failure_reason = "Failed to create base directory for key, error: " + ec.message();
         return false;
     }
 

--- a/src/Interpreters/FileCache/FileCache.cpp
+++ b/src/Interpreters/FileCache/FileCache.cpp
@@ -1278,14 +1278,8 @@ bool FileCache::doTryReserve(
 
     if (auto ec = file_segment.getKeyMetadata()->createBaseDirectory(); ec)
     {
-        if (skip_cache_on_disk_failure)
-        {
-            failure_reason = ec.message();
-            return false;
-        }
-
-        throw std::filesystem::filesystem_error(
-            fmt::format("failed to create base directory for a key {}", file_segment.getKeyMetadata()->getPath()), ec);
+        failure_reason = ec.message();
+        return false;
     }
 
     return true;

--- a/src/Interpreters/FileCache/FileCache.cpp
+++ b/src/Interpreters/FileCache/FileCache.cpp
@@ -1276,10 +1276,16 @@ bool FileCache::doTryReserve(
     file_segment.reserved_size += size;
     chassert(file_segment.reserved_size == main_priority_iterator->getEntry()->size);
 
-    if (!file_segment.getKeyMetadata()->createBaseDirectory())
+    if (auto ec = file_segment.getKeyMetadata()->createBaseDirectory(); ec)
     {
-        failure_reason = "not enough space on device";
-        return false;
+        if (skip_cache_on_disk_failure)
+        {
+            failure_reason = ec.message();
+            return false;
+        }
+
+        throw std::filesystem::filesystem_error(
+            fmt::format("failed to create base directory for a key {}", file_segment.getKeyMetadata()->getPath()), ec);
     }
 
     return true;

--- a/src/Interpreters/FileCache/Metadata.cpp
+++ b/src/Interpreters/FileCache/Metadata.cpp
@@ -148,10 +148,9 @@ std::error_code KeyMetadata::createBaseDirectory()
         created_base_directory.store(true);
         ProfileEvents::increment(ProfileEvents::FilesystemCacheCreatedKeyDirectories);
     }
-    else
-    {
+    else if (ec != std::errc::no_space_on_device && ec != std::errc::too_many_files_open)
         LOG_TRACE(cache_metadata->log, "Failed to create base directory for key {}, {}", key, ec.message());
-    }
+
 
     return ec;
 }

--- a/src/Interpreters/FileCache/Metadata.cpp
+++ b/src/Interpreters/FileCache/Metadata.cpp
@@ -130,42 +130,30 @@ KeyMetadata::KeyState KeyMetadata::getState()
     return key_state;
 }
 
-bool KeyMetadata::createBaseDirectory(bool throw_if_failed)
+std::error_code KeyMetadata::createBaseDirectory()
 {
     if (created_base_directory.load())
-        return true;
+        return {};
 
     std::shared_lock lock(cache_metadata->key_prefix_directory_mutex);
 
     if (created_base_directory.load(std::memory_order_relaxed))
-        return true;
+        return {};
 
-    try
+    std::error_code ec;
+    fs::create_directories(getPath(), ec);
+
+    if (!ec)
     {
-        fs::create_directories(getPath());
         created_base_directory.store(true);
         ProfileEvents::increment(ProfileEvents::FilesystemCacheCreatedKeyDirectories);
     }
-    catch (const fs::filesystem_error & e)
+    else
     {
-        created_base_directory = false;
-
-        if (!throw_if_failed &&
-            (e.code() == std::errc::no_space_on_device
-                || e.code() == std::errc::read_only_file_system
-                || e.code() == std::errc::permission_denied
-                || e.code() == std::errc::too_many_files_open
-                || e.code() == std::errc::operation_not_permitted))
-        {
-            LOG_TRACE(cache_metadata->log, "Failed to create base directory for key {}, "
-                        "because no space left on device", key);
-
-            return false;
-        }
-        throw;
+        LOG_TRACE(cache_metadata->log, "Failed to create base directory for key {}, {}", key, ec.message());
     }
 
-    return true;
+    return ec;
 }
 
 std::string KeyMetadata::getPath() const

--- a/src/Interpreters/FileCache/Metadata.h
+++ b/src/Interpreters/FileCache/Metadata.h
@@ -124,7 +124,7 @@ struct KeyMetadata : private std::map<size_t, FileSegmentMetadataPtr>,
     /// Will only fail if key is not in ACTIVE state, e.g. REMOVING or REMOVED.
     LockedKeyPtr tryLock();
 
-    bool createBaseDirectory(bool throw_if_failed = false);
+    std::error_code createBaseDirectory();
 
     std::string getPath() const;
 

--- a/src/Interpreters/FileCache/Metadata.h
+++ b/src/Interpreters/FileCache/Metadata.h
@@ -124,7 +124,7 @@ struct KeyMetadata : private std::map<size_t, FileSegmentMetadataPtr>,
     /// Will only fail if key is not in ACTIVE state, e.g. REMOVING or REMOVED.
     LockedKeyPtr tryLock();
 
-    std::error_code createBaseDirectory();
+    [[nodiscard]] std::error_code createBaseDirectory();
 
     std::string getPath() const;
 

--- a/src/Interpreters/TemporaryDataOnDisk.cpp
+++ b/src/Interpreters/TemporaryDataOnDisk.cpp
@@ -1,3 +1,4 @@
+#include <filesystem>
 #include <memory>
 #include <DataTypes/DataTypeArray.h>
 #include <mutex>
@@ -103,7 +104,8 @@ public:
             CreateFileSegmentSettings(FileSegmentKind::Ephemeral), FileCache::getCommonOrigin());
 
         chassert(segment_holder->size() == 1);
-        segment_holder->front().getKeyMetadata()->createBaseDirectory(/* throw_if_failed */true);
+        if (auto ec = segment_holder->front().getKeyMetadata()->createBaseDirectory(); ec)
+            throw std::filesystem::filesystem_error(fmt::format("createBaseDirectory failed for {}", key), ec);
     }
 
     std::unique_ptr<WriteBuffer> write() override


### PR DESCRIPTION
`DB::KeyMetadata::createBaseDirectory(bool)` fails on some filesystem errors and on some errors the exception is propogated to the caller, so it can fail executeQuery and etc, even if `skip_cache_on_disk_failure=1`.

This PR removes this errors nitpicking and won't throw this errors from FileCache, it just writes logs for such errors.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Query can be executed successfully even If FileCache fails to create some directory on disk for caching.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.395`
<!-- ch-version-info:end -->