### PR TITLE
CI: bump rss_limit_mb to 8192 for create_parser_fuzzer to stop chronic OOMs

### DIFF
--- a/tests/fuzz/create_parser_fuzzer.options
+++ b/tests/fuzz/create_parser_fuzzer.options
@@ -1,7 +1,7 @@
 [libfuzzer]
 timeout = 20
 dict = all.dict
-rss_limit_mb = 6144
+rss_limit_mb = 8192
 
 [fuzzer_arguments]
 max_parser_backtracks = 10000


### PR DESCRIPTION
`create_parser_fuzzer` has been failing chronically with `libFuzzer out-of-memory` for weeks, with the actual usage sitting just above the hardcoded 6144 Mb limit. CIDB shows 55 OOM hits across 49 unrelated PRs in the last 30 days (peaking at 17 hits / 17 PRs on 2026-05-17 alone).

The reported `used:` values cluster around 6221-7329 Mb:

| metric | value |
|---|---|
| min observed used | 6221 Mb |
| avg observed used | 6554 Mb |
| p95 observed used | 7329 Mb |
| max observed used | 8830 Mb |
| current limit | 6144 Mb |

54 of 55 observed OOMs (98%) fall under 8192 Mb. The 6144 limit is essentially at the typical working-set mean for this fuzzer, so any input that triggers even moderate extra allocations during parsing trips the limit.

### Fix

Bump `rss_limit_mb` from 6144 to 8192 in `tests/fuzz/create_parser_fuzzer.options`, following the same precedent as the recently merged PR #105134 which bumped `clickhouse_fuzzer` from 2048 to 4096 for the same class of "just-barely-over-the-limit" chronic OOMs.

The limit is still active (8 GB is not unlimited), so genuine large memory regressions above 8 GB will still be caught. Existing precedent for `rss_limit_mb` values across the fuzz suite:

| fuzzer | rss_limit_mb |
|---|---|
| `clickhouse_fuzzer.options` | 4096 |
| `data_type_deserialization_fuzzer.options` | 4096 |
| `execute_query_fuzzer.options` | 4096 |
| `create_parser_fuzzer.options` (this PR) | 8192 |

### Sibling work

- PR #104922 (merged 2026-05-14) — fixed `select_parser_fuzzer` chronic timeouts via `max_parser_backtracks=10000`. The same setting was already applied to `create_parser_fuzzer`; this PR addresses the parallel OOM symptom.
- PR #105134 (merged 2026-05-16) — same `rss_limit_mb` bump pattern for `clickhouse_fuzzer`.

Filed at the direct request of @alexey-milovidov on PR #100938 (https://github.com/ClickHouse/ClickHouse/pull/100938#issuecomment).

### CIDB query used

```sql
SELECT
    count() AS hits,
    count(DISTINCT pull_request_number) AS distinct_prs,
    countIf(pull_request_number = 0) AS master_hits,
    countIf(pull_request_number > 0) AS pr_hits,
    max(toUInt64(extract(test_context_raw, 'used: ([0-9]+)Mb'))) AS max_used,
    avg(toUInt64(extract(test_context_raw, 'used: ([0-9]+)Mb'))) AS avg_used,
    quantile(0.95)(toUInt64(extract(test_context_raw, 'used: ([0-9]+)Mb'))) AS p95_used
FROM default.checks
WHERE check_name = 'libFuzzer tests'
  AND test_status IN ('FAIL', 'ERROR')
  AND test_name LIKE '%create_parser_fuzzer%'
  AND test_context_raw LIKE '%out-of-memory%'
  AND check_start_time > now() - INTERVAL 30 DAY
```

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Bump libFuzzer `rss_limit_mb` to 8192 for `create_parser_fuzzer` to fix chronic OOMs at the previous 6144 Mb limit.

### Documentation entry for user-facing changes
- [x] Not required (CI-only configuration change)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.861`
<!-- ch-version-info:end -->