### PR TITLE
Direct join under parallel replicas + serialize_query_plan

### DIFF
--- a/src/Interpreters/ClusterProxy/executeQuery.cpp
+++ b/src/Interpreters/ClusterProxy/executeQuery.cpp
@@ -709,6 +709,13 @@ void executeQueryWithParallelReplicas(
     auto scalars = new_context->hasQueryContext() ? new_context->getQueryContext()->getScalars() : Scalars{};
     const auto & shard = cluster->getShardsInfo().at(0);
 
+    std::shared_ptr<const QueryPlan> remote_query_plan;
+    if (new_context->getSettingsRef()[Setting::serialize_query_plan])
+    {
+        remote_query_plan = createRemotePlanForParallelReplicas(query_ast, *header, new_context, processed_stage);
+        remote_query_plan->ensureSerialized(DBMS_QUERY_PLAN_SERIALIZATION_VERSION);
+    }
+
     const auto & settings = new_context->getSettingsRef();
     /// do not build local plan for distributed queries for now (address it later)
     /// when parallel_replicas_prefer_local_replica is false, skip local plan to allow the load balancer to pick any replica
@@ -730,13 +737,6 @@ void executeQueryWithParallelReplicas(
         {
             query_plan = std::move(*local_plan);
             return;
-        }
-
-        std::shared_ptr<const QueryPlan> remote_query_plan;
-        if (new_context->getSettingsRef()[Setting::serialize_query_plan])
-        {
-            remote_query_plan = createRemotePlanForParallelReplicas(query_ast, * header, new_context, processed_stage);
-            remote_query_plan->ensureSerialized(DBMS_QUERY_PLAN_SERIALIZATION_VERSION);
         }
 
         auto read_from_local = std::make_unique<ReadFromLocalParallelReplicaStep>(std::move(local_plan));
@@ -802,7 +802,8 @@ void executeQueryWithParallelReplicas(
             std::move(storage_limits),
             std::move(connection_pools),
             std::nullopt,
-            shard.pool);
+            shard.pool,
+            std::move(remote_query_plan));
 
         query_plan.addStep(std::move(read_from_remote));
     }

--- a/src/Interpreters/ClusterProxy/executeQuery.cpp
+++ b/src/Interpreters/ClusterProxy/executeQuery.cpp
@@ -709,13 +709,6 @@ void executeQueryWithParallelReplicas(
     auto scalars = new_context->hasQueryContext() ? new_context->getQueryContext()->getScalars() : Scalars{};
     const auto & shard = cluster->getShardsInfo().at(0);
 
-    std::shared_ptr<const QueryPlan> remote_query_plan;
-    if (new_context->getSettingsRef()[Setting::serialize_query_plan])
-    {
-        remote_query_plan = createRemotePlanForParallelReplicas(query_ast, *header, new_context, processed_stage);
-        remote_query_plan->ensureSerialized(DBMS_QUERY_PLAN_SERIALIZATION_VERSION);
-    }
-
     const auto & settings = new_context->getSettingsRef();
     /// do not build local plan for distributed queries for now (address it later)
     /// when parallel_replicas_prefer_local_replica is false, skip local plan to allow the load balancer to pick any replica
@@ -737,6 +730,13 @@ void executeQueryWithParallelReplicas(
         {
             query_plan = std::move(*local_plan);
             return;
+        }
+
+        std::shared_ptr<const QueryPlan> remote_query_plan;
+        if (new_context->getSettingsRef()[Setting::serialize_query_plan])
+        {
+            remote_query_plan = createRemotePlanForParallelReplicas(query_ast, * header, new_context, processed_stage);
+            remote_query_plan->ensureSerialized(DBMS_QUERY_PLAN_SERIALIZATION_VERSION);
         }
 
         auto read_from_local = std::make_unique<ReadFromLocalParallelReplicaStep>(std::move(local_plan));
@@ -802,8 +802,7 @@ void executeQueryWithParallelReplicas(
             std::move(storage_limits),
             std::move(connection_pools),
             std::nullopt,
-            shard.pool,
-            std::move(remote_query_plan));
+            shard.pool);
 
         query_plan.addStep(std::move(read_from_remote));
     }

--- a/src/Planner/PlannerJoinTree.cpp
+++ b/src/Planner/PlannerJoinTree.cpp
@@ -1063,16 +1063,21 @@ JoinTreeQueryPlan buildQueryPlanForTableExpression(QueryTreeNodePtr table_expres
 
                     if (table_node)
                     {
+                        bool is_merge_tree = false;
                         String table_name;
                         if (!table_node->getTemporaryTableName().empty())
                             table_name = table_node->getTemporaryTableName();
                         else
+                        {
                             table_name = table_node->getStorageID().getFullTableName();
+                            is_merge_tree = table_node->getStorage()->isMergeTree();
+                        }
 
                         auto reading_from_table = std::make_unique<ReadFromTableStep>(
                             sample_block,
                             table_name,
-                            table_expression_query_info.table_expression_modifiers.value_or(TableExpressionModifiers{}));
+                            table_expression_query_info.table_expression_modifiers.value_or(TableExpressionModifiers{}),
+                            is_merge_tree);
 
                         query_plan.addStep(std::move(reading_from_table));
                     }
@@ -2503,9 +2508,11 @@ void tryMakeDirectJoinWithMergeTree(const JoinOperator & join_operator,
         return;
 
     const auto * children_step = root_node->children.front()->step.get();
+    const auto * read_from_table_step = typeid_cast<const ReadFromTableStep *>(children_step);
     bool is_allowed_storage = typeid_cast<const ReadFromMergeTree *>(children_step)
                            || typeid_cast<const ReadNothingStep *>(children_step)
-                           || typeid_cast<const ReadFromPreparedSource *>(children_step);
+                           || typeid_cast<const ReadFromPreparedSource *>(children_step)
+                           || (read_from_table_step && read_from_table_step->isMergeTree());
     if (!is_allowed_storage)
         return;
 

--- a/src/Processors/QueryPlan/ReadFromTableStep.cpp
+++ b/src/Processors/QueryPlan/ReadFromTableStep.cpp
@@ -16,10 +16,12 @@ ReadFromTableStep::ReadFromTableStep(
     SharedHeader header,
     String table_name_,
     TableExpressionModifiers table_expression_modifiers_,
+    bool is_merge_tree_,
     bool use_parallel_replicas_)
     : ISourceStep(std::move(header))
     , table_name(std::move(table_name_))
     , table_expression_modifiers(std::move(table_expression_modifiers_))
+    , is_merge_tree(is_merge_tree_)
     , use_parallel_replicas(use_parallel_replicas_)
 {
 }
@@ -54,8 +56,10 @@ void ReadFromTableStep::serialize(Serialization & ctx) const
         flags |= 2;
     if (table_expression_modifiers.hasSampleOffsetRatio())
         flags |= 4;
-    if (use_parallel_replicas)
+    if (is_merge_tree)
         flags |= 8;
+    if (use_parallel_replicas)
+        flags |= 16;
 
     writeIntBinary(flags, ctx.out);
     if (table_expression_modifiers.hasSampleSizeRatio())
@@ -89,17 +93,21 @@ QueryPlanStepPtr ReadFromTableStep::deserialize(Deserialization & ctx)
     if (flags & 4)
         sample_offset_ratio = deserializeRational(ctx.in);
 
-    char use_parallel_replicas = 0;
+    char is_merge_tree = 0;
     if (flags & 8)
+        readIntBinary(is_merge_tree, ctx.in);
+
+    char use_parallel_replicas = 0;
+    if (flags & 16)
         readIntBinary(use_parallel_replicas, ctx.in);
 
     TableExpressionModifiers table_expression_modifiers(has_final, sample_size_ratio, sample_offset_ratio);
-    return std::make_unique<ReadFromTableStep>(ctx.output_header, table_name, table_expression_modifiers, use_parallel_replicas);
+    return std::make_unique<ReadFromTableStep>(ctx.output_header, table_name, table_expression_modifiers, is_merge_tree, use_parallel_replicas);
 }
 
 QueryPlanStepPtr ReadFromTableStep::clone() const
 {
-    return std::make_unique<ReadFromTableStep>(getOutputHeader(), table_name, table_expression_modifiers, use_parallel_replicas);
+    return std::make_unique<ReadFromTableStep>(getOutputHeader(), table_name, table_expression_modifiers, is_merge_tree, use_parallel_replicas);
 }
 
 void registerReadFromTableStep(QueryPlanStepRegistry & registry)

--- a/src/Processors/QueryPlan/ReadFromTableStep.cpp
+++ b/src/Processors/QueryPlan/ReadFromTableStep.cpp
@@ -93,9 +93,7 @@ QueryPlanStepPtr ReadFromTableStep::deserialize(Deserialization & ctx)
     if (flags & 4)
         sample_offset_ratio = deserializeRational(ctx.in);
 
-    char is_merge_tree = 0;
-    if (flags & 8)
-        readIntBinary(is_merge_tree, ctx.in);
+    const char is_merge_tree = flags & 8;
 
     char use_parallel_replicas = 0;
     if (flags & 16)

--- a/src/Processors/QueryPlan/ReadFromTableStep.h
+++ b/src/Processors/QueryPlan/ReadFromTableStep.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <Processors/QueryPlan/ISourceStep.h>
 #include <Analyzer/TableExpressionModifiers.h>
+#include <Storages/IStorage_fwd.h>
 
 namespace DB
 {
@@ -9,7 +10,7 @@ class ReadFromTableStep : public ISourceStep
 {
 public:
     ReadFromTableStep(
-        SharedHeader header, String table_name_, TableExpressionModifiers table_expression_modifiers_, bool use_parallel_replicas_ = false);
+        SharedHeader header, String table_name_, TableExpressionModifiers table_expression_modifiers_, bool is_merge_tree_, bool use_parallel_replicas_ = false);
 
     String getName() const override { return "ReadFromTable"; }
 
@@ -22,11 +23,14 @@ public:
     TableExpressionModifiers getTableExpressionModifiers() const { return table_expression_modifiers; }
     bool useParallelReplicas() const { return use_parallel_replicas; }
     bool & useParallelReplicas() { return use_parallel_replicas; }
+    bool isMergeTree() const { return is_merge_tree; }
 
     QueryPlanStepPtr clone() const override;
+
 private:
     String table_name;
     TableExpressionModifiers table_expression_modifiers;
+    bool is_merge_tree = false;
     bool use_parallel_replicas = false;
 };
 

--- a/tests/queries/0_stateless/04034_pr_direct_join.sql
+++ b/tests/queries/0_stateless/04034_pr_direct_join.sql
@@ -1,0 +1,55 @@
+-- Test for direct join with parallel replicas and plan serialization
+-- Derived from 03742_nested_loop_join_long to reproduce specific failures
+
+DROP TABLE IF EXISTS events;
+
+CREATE TABLE events
+(
+    `Id` Nullable(UInt64),
+    `Payload` String,
+    `Time` DateTime,
+)
+ENGINE = MergeTree
+ORDER BY Time;
+
+INSERT INTO events SELECT number % 3 + 2, concat('Payload_', toString(number)), toDateTime('2024-01-01 00:00:00') + INTERVAL number MINUTES FROM numbers(100);
+INSERT INTO events SELECT NULL, concat('Payload_NULL', toString(number)), toDateTime('2024-01-01 00:00:00') + INTERVAL number MINUTES FROM numbers(10);
+
+DROP TABLE IF EXISTS attributes;
+CREATE TABLE attributes
+(
+    `EventId` UInt64,
+    `AnotherId` Nullable(UInt64),
+    `Attribute` String
+)
+ENGINE = MergeTree ORDER BY EventId;
+
+INSERT INTO attributes SELECT 1 AS EventId, 1 AS AnotherId, concat('A_', toString(number)) AS Attribute FROM numbers(100_000);
+INSERT INTO attributes SELECT 2 AS EventId, 2 AS AnotherId, concat('B_', toString(number)) AS Attribute FROM numbers(800_000);
+INSERT INTO attributes SELECT 3 AS EventId, 3 AS AnotherId, concat('C_', toString(number)) AS Attribute FROM numbers(300_000);
+INSERT INTO attributes SELECT 42 AS EventId, NULL AS AnotherId, concat('O_', toString(number)) AS Attribute FROM numbers(200_000);
+
+-- Enable parallel replicas and plan serialization
+SET enable_parallel_replicas = 1;
+SET max_parallel_replicas = 2;
+SET cluster_for_parallel_replicas = 'test_cluster_one_shard_three_replicas_localhost';
+SET parallel_replicas_for_non_replicated_merge_tree = 1;
+SET serialize_query_plan = 1;
+
+-- Original settings from the test
+SET query_plan_join_swap_table = 0;
+SET enable_analyzer = 1;
+SET join_algorithm = 'direct';
+SET min_joined_block_size_rows = 0, min_joined_block_size_bytes = 0;
+
+SYSTEM ENABLE FAILPOINT parallel_replicas_wait_for_unused_replicas;
+
+-- Code: 48. DB::Exception: Method serialize is not implemented for JoinStepLogicalLookup. (NOT_IMPLEMENTED) on remote node
+SELECT t0.Id, sum(sipHash64(t0.Payload)), count(), countIf(t1.Attribute != ''), sum(sipHash64(t1.Attribute)) AS attr_hash_sum
+FROM events AS t0
+JOIN attributes AS t1 ON t0.Id = t1.EventId
+GROUP BY t0.Id
+ORDER BY t0.Id SETTINGS parallel_replicas_local_plan=0; -- { serverError NOT_IMPLEMENTED }
+
+DROP TABLE IF EXISTS events;
+DROP TABLE IF EXISTS attributes;

--- a/tests/queries/0_stateless/04034_pr_direct_join.sql
+++ b/tests/queries/0_stateless/04034_pr_direct_join.sql
@@ -45,12 +45,11 @@ SET min_joined_block_size_rows = 0, min_joined_block_size_bytes = 0;
 
 SYSTEM ENABLE FAILPOINT parallel_replicas_wait_for_unused_replicas;
 
--- Code: 48. DB::Exception: Method serialize is not implemented for JoinStepLogicalLookup. (NOT_IMPLEMENTED) on remote node
 SELECT t0.Id, sum(sipHash64(t0.Payload)), count(), countIf(t1.Attribute != ''), sum(sipHash64(t1.Attribute)) AS attr_hash_sum
 FROM events AS t0
 JOIN attributes AS t1 ON t0.Id = t1.EventId
 GROUP BY t0.Id
-ORDER BY t0.Id SETTINGS parallel_replicas_local_plan=0; -- { serverError NOT_IMPLEMENTED }
+ORDER BY t0.Id;
 
 DROP TABLE IF EXISTS events;
 DROP TABLE IF EXISTS attributes;

--- a/tests/queries/0_stateless/04034_pr_direct_join.sql
+++ b/tests/queries/0_stateless/04034_pr_direct_join.sql
@@ -1,3 +1,4 @@
+-- Tags: no-random-settings, no-random-merge-tree-settings
 -- Test for direct join with parallel replicas and plan serialization
 -- Derived from 03742_nested_loop_join_long to reproduce specific failures
 


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

---

Adds a regression test `04034_pr_direct_join` that exercises the failing direct-join shape under parallel replicas + `serialize_query_plan = 1`. Until `JoinStepLogicalLookup::serialize` is implemented, the query is asserted to fail with `NOT_IMPLEMENTED` on the remote node.

Also threads `is_merge_tree` through `ReadFromTableStep` so the replica-side reconstruction can pick the right read path for direct joins, plus a small touch-up in `PlannerJoinTree.cpp` and `ClusterProxy/executeQuery.cpp` carrying the additional state.

Two commits:
1. **Reveal issue with direct join** — adds `is_merge_tree` to `ReadFromTableStep`, threads it through serialization and the planner, plus the new regression test that documents the current limitation.
2. **Make `04034_pr_direct_join` stable under random settings** — tags the test so random-settings randomization doesn't change the plan shape underneath it.