### PR TITLE
Evaluate benefits of enabling HP

### DIFF
--- a/contrib/jemalloc-cmake/CMakeLists.txt
+++ b/contrib/jemalloc-cmake/CMakeLists.txt
@@ -44,7 +44,7 @@ if (OS_LINUX)
     # Increasing from default 6(64x) to 8(256x) allows these coalesced blocks to be split and reused.
     # See: https://github.com/ClickHouse/ClickHouse/pull/80245
     # https://github.com/jemalloc/jemalloc/pull/2842
-    set (JEMALLOC_CONFIG_MALLOC_CONF "percpu_arena:percpu,oversize_threshold:67108864,muzzy_decay_ms:0,dirty_decay_ms:5000,prof:true,prof_active:true,prof_thread_active_init:false,background_thread:true,lg_extent_max_active_fit:8,metadata_thp:auto,huge_arena_pac_thp:true")
+    set (JEMALLOC_CONFIG_MALLOC_CONF "percpu_arena:percpu,oversize_threshold:67108864,muzzy_decay_ms:0,dirty_decay_ms:5000,prof:true,prof_active:true,prof_thread_active_init:false,background_thread:true,lg_extent_max_active_fit:8,metadata_thp:always,huge_arena_pac_thp:true")
 else()
     # For non-Linux systems, percpu_arena and background_thread are assumed to be not supported by jemalloc.
     # These two settings directly affect arena purging frequency and predictability:

--- a/contrib/jemalloc-cmake/CMakeLists.txt
+++ b/contrib/jemalloc-cmake/CMakeLists.txt
@@ -44,7 +44,7 @@ if (OS_LINUX)
     # Increasing from default 6(64x) to 8(256x) allows these coalesced blocks to be split and reused.
     # See: https://github.com/ClickHouse/ClickHouse/pull/80245
     # https://github.com/jemalloc/jemalloc/pull/2842
-    set (JEMALLOC_CONFIG_MALLOC_CONF "percpu_arena:percpu,oversize_threshold:67108864,muzzy_decay_ms:0,dirty_decay_ms:5000,prof:true,prof_active:true,prof_thread_active_init:false,background_thread:true,lg_extent_max_active_fit:8")
+    set (JEMALLOC_CONFIG_MALLOC_CONF "percpu_arena:percpu,oversize_threshold:67108864,muzzy_decay_ms:0,dirty_decay_ms:5000,prof:true,prof_active:true,prof_thread_active_init:false,background_thread:true,lg_extent_max_active_fit:8,metadata_thp:auto,huge_arena_pac_thp:true")
 else()
     # For non-Linux systems, percpu_arena and background_thread are assumed to be not supported by jemalloc.
     # These two settings directly affect arena purging frequency and predictability:


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
todo

---

After #103958, we now again (as it was with manual `mmap` allocations) have large allocations being logically separated from the normal ones. It's tempting to implement an option to allocate memory for this oversize arena from the HP pool (if it is configured). I.e., I don't want to use THP to avoid potential fragmentation issues, but since jemalloc natively integrated only with THP it is the easiest way to estimate potential benefits. 