### PR TITLE
Fix deadlock in ParallelFormattingOutputFormat on schedule failure

### DIFF
--- a/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/ParallelFormattingOutputFormat.cpp
@@ -95,7 +95,18 @@ namespace DB
             unit.rows_num = unit.chunk.getNumRows();
         }
 
-        scheduleFormatterThreadForUnitWithNumber(current_unit_number, first_row_num);
+        try
+        {
+            scheduleFormatterThreadForUnitWithNumber(current_unit_number, first_row_num);
+        }
+        catch (...)
+        {
+            /// Properly terminate in case of exception during scheduling, i.e. CANNOT_SCHEDULE_TASK
+            onBackgroundException();
+            if (can_throw_exception)
+                throw;
+            return;
+        }
         ++writer_unit_number;
     }
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix deadlock in ParallelFormattingOutputFormat on schedule failure

If scheduleFormatterThreadForUnitWithNumber throws (e.g. CANNOT_SCHEDULE_TASK, or an allocation failure when constructing the std::function for the pool job under tight client memory limits), the unit is left in READY_TO_FORMAT with no formatter thread to process it. The collector then waits forever on that unit, and finalizeImpl hangs on collector_finished.wait().

Wrap the schedule call in try/catch and route any failure through onBackgroundException so the collector observes emergency_stop, exits, and sets collector_finished.

Fixes: #87001

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.801`
<!-- ch-version-info:end -->