### PR TITLE
Document preprocessor inconsistency for text-search functions

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/textindexes.md
+++ b/docs/en/engines/table-engines/mergetree-family/textindexes.md
@@ -212,7 +212,8 @@ Examples:
 
 Using non-deterministic functions is disallowed.
 
-Functions [hasToken](/sql-reference/functions/string-search-functions.md/#hasToken), [hasAllTokens](/sql-reference/functions/string-search-functions.md/#hasAllTokens) and [hasAnyTokens](/sql-reference/functions/string-search-functions.md/#hasAnyTokens) use the preprocessor to first transform the search term before tokenizing it.
+Functions [hasToken](/sql-reference/functions/string-search-functions.md/#hasToken), [hasAllTokens](/sql-reference/functions/string-search-functions.md/#hasAllTokens), [hasAnyTokens](/sql-reference/functions/string-search-functions.md/#hasAnyTokens), and [hasPhrase](/sql-reference/functions/string-search-functions.md/#hasPhrase) use the preprocessor to first transform the search term before tokenizing it.
+Note that because the preprocessor is only applied on the text index path, results from these functions may differ between queries that use the text index and queries that do not (e.g. `SETTINGS use_skip_indexes = 0`).
 
 For example,
 

--- a/src/Functions/hasAnyAllTokens.cpp
+++ b/src/Functions/hasAnyAllTokens.cpp
@@ -449,7 +449,7 @@ Duplicate tokens are ignored.
 For example, ['ClickHouse', 'ClickHouse'] is treated the same as ['ClickHouse'].
 
 :::note
-When a text index defines a [preprocessor](../../engines/table-engines/mergetree-family/textindexes#creating-a-text-index) (for example `lowerUTF8`), `hasAnyTokens` applies it to both `input` and `needles` before tokenization.
+When a text index defines a [preprocessor](../../engines/table-engines/mergetree-family/textindexes#creating-a-text-index) (for example `lowerUTF8`), `hasAnyTokens` applies it to `input` and, when `needles` is a [String](../../sql-reference/data-types/string.md), to `needles` before tokenization. When `needles` is an [Array(String)](../../sql-reference/data-types/array.md), its elements are passed through as-is and the preprocessor is not applied to them.
 The preprocessor is only applied on the text index path, so results may differ between queries that use the text index and queries that do not (e.g. `SETTINGS use_skip_indexes = 0`).
 This inconsistency is tolerated to improve the usability of full-text search.
 :::
@@ -590,7 +590,7 @@ Duplicate tokens are ignored.
 For example, needles = ['ClickHouse', 'ClickHouse'] is treated the same as ['ClickHouse'].
 
 :::note
-When a text index defines a [preprocessor](../../engines/table-engines/mergetree-family/textindexes#creating-a-text-index) (for example `lowerUTF8`), `hasAllTokens` applies it to both `input` and `needles` before tokenization.
+When a text index defines a [preprocessor](../../engines/table-engines/mergetree-family/textindexes#creating-a-text-index) (for example `lowerUTF8`), `hasAllTokens` applies it to `input` and, when `needles` is a [String](../../sql-reference/data-types/string.md), to `needles` before tokenization. When `needles` is an [Array(String)](../../sql-reference/data-types/array.md), its elements are passed through as-is and the preprocessor is not applied to them.
 The preprocessor is only applied on the text index path, so results may differ between queries that use the text index and queries that do not (e.g. `SETTINGS use_skip_indexes = 0`).
 This inconsistency is tolerated to improve the usability of full-text search.
 :::

--- a/src/Functions/hasAnyAllTokens.cpp
+++ b/src/Functions/hasAnyAllTokens.cpp
@@ -447,6 +447,12 @@ If the `needle` argument is of type [Array(String)](../../sql-reference/data-typ
 
 Duplicate tokens are ignored.
 For example, ['ClickHouse', 'ClickHouse'] is treated the same as ['ClickHouse'].
+
+:::note
+When a text index defines a [preprocessor](../../engines/table-engines/mergetree-family/textindexes#creating-a-text-index) (for example `lowerUTF8`), `hasAnyTokens` applies it to both `input` and `needles` before tokenization.
+The preprocessor is only applied on the text index path, so results may differ between queries that use the text index and queries that do not (e.g. `SETTINGS use_skip_indexes = 0`).
+This inconsistency is tolerated to improve the usability of full-text search.
+:::
     )";
     FunctionDocumentation::Syntax syntax_hasAnyTokens = R"(
 hasAnyTokens(input, needles)
@@ -582,6 +588,12 @@ If the `needle` argument is of type [Array(String)](../../sql-reference/data-typ
 
 Duplicate tokens are ignored.
 For example, needles = ['ClickHouse', 'ClickHouse'] is treated the same as ['ClickHouse'].
+
+:::note
+When a text index defines a [preprocessor](../../engines/table-engines/mergetree-family/textindexes#creating-a-text-index) (for example `lowerUTF8`), `hasAllTokens` applies it to both `input` and `needles` before tokenization.
+The preprocessor is only applied on the text index path, so results may differ between queries that use the text index and queries that do not (e.g. `SETTINGS use_skip_indexes = 0`).
+This inconsistency is tolerated to improve the usability of full-text search.
+:::
     )";
     FunctionDocumentation::Syntax syntax_hasAllTokens = R"(
 hasAllTokens(input, needles)

--- a/src/Functions/hasPhrase.cpp
+++ b/src/Functions/hasPhrase.cpp
@@ -228,7 +228,7 @@ ExecutableFunctionHasPhrase::executeImpl(const ColumnsWithTypeAndName & argument
 REGISTER_FUNCTION(HasPhrase)
 {
     FunctionDocumentation::Description description = R"(
-Checks if the `input` contains all tokens from the `phrase` in consecutive order. If `input` is a column, returns all rows that satisfy this condition.
+Checks if the `input` contains all tokens from the `phrase` in consecutive order.
 
 :::note
 Column `input` should have a [text index](../../engines/table-engines/mergetree-family/textindexes) defined for optimal performance.

--- a/src/Functions/hasPhrase.cpp
+++ b/src/Functions/hasPhrase.cpp
@@ -228,11 +228,22 @@ ExecutableFunctionHasPhrase::executeImpl(const ColumnsWithTypeAndName & argument
 REGISTER_FUNCTION(HasPhrase)
 {
     FunctionDocumentation::Description description = R"(
-Checks if the haystack contains all tokens from the phrase in consecutive order.
+Checks if the `input` contains all tokens from the `phrase` in consecutive order. If `input` is a column, returns all rows that satisfy this condition.
 
-Prior to searching, the function tokenizes both the `input` and the `phrase` arguments using the tokenizer specified as the optional third argument.
+:::note
+Column `input` should have a [text index](../../engines/table-engines/mergetree-family/textindexes) defined for optimal performance.
+If no text index is defined, the function performs a brute-force column scan which is orders of magnitude slower than an index lookup.
+:::
+
+Prior to searching, the function tokenizes both the `input` and the `phrase` arguments using the tokenizer specified for the text index.
+If the column has no text index defined, the `splitByNonAlpha` tokenizer is used instead — unless a tokenizer is provided as the optional third argument.
 The tokenizer argument must be one of `splitByNonAlpha`, `splitByString`, `ngrams`, or `asciiCJK`.
-If no tokenizer is specified, by default the `splitByNonAlpha` tokenizer would be used.
+
+:::note
+When a text index defines a [preprocessor](../../engines/table-engines/mergetree-family/textindexes#creating-a-text-index) (for example `lowerUTF8`), `hasPhrase` applies it to both `input` and `phrase` before tokenization.
+The preprocessor is only applied on the text index path, so results may differ between queries that use the text index and queries that do not (e.g. `SETTINGS use_skip_indexes = 0`).
+This inconsistency is tolerated to improve the usability of full-text search.
+:::
 
 Unlike [`hasToken`](#hasToken), [`hasAnyTokens`](#hasAnyTokens) and [`hasAllTokens`](#hasAllTokens), `hasPhrase` requires the tokens to appear in the same order
 and without any intervening tokens. For example, `hasPhrase('the quick brown fox', 'quick fox')` returns 0


### PR DESCRIPTION
The functions `hasPhrase`, `hasAnyTokens`, and `hasAllTokens` apply the text index's preprocessor (e.g. `lowerUTF8`) only on the index path. As a result, the same query can return different rows depending on whether the text index is used (i.e. `SETTINGS use_skip_indexes = 0` vs `1`).

This is expected behavior — the inconsistency is tolerated to improve the usability of full-text search — but it was not documented. Add a note to each function description, mirror the existing `hasAllTokens` performance/text-index note onto `hasPhrase`, and extend the text indexes page to mention `hasPhrase` alongside the other functions that use the preprocessor.

Closes #105231

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Documented that `hasPhrase`, `hasAnyTokens`, and `hasAllTokens` can return different rows when run with vs without the text index, because the text index's preprocessor is only applied on the index path.

### Documentation entry for user-facing changes
- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.831`
<!-- ch-version-info:end -->