### PR TITLE
Fix extract-from-config --try silently dropping from_env values

### DIFF
--- a/src/Common/Config/ConfigProcessor.cpp
+++ b/src/Common/Config/ConfigProcessor.cpp
@@ -804,24 +804,27 @@ XMLDocumentPtr ConfigProcessor::processConfig(
                 include_from_path = default_path;
         }
 
-        if (!throw_on_bad_include_from && !fs::exists(include_from_path))
+        /// When --try is passed and the include_from file is missing, drop the path so that
+        /// processIncludes does not try to parse it. We must still call processIncludes
+        /// because it also performs from_env/from_zk/incl substitutions on the rest of the
+        /// config; skipping it would silently strip those values (issue #101704).
+        if (!throw_on_bad_include_from && !include_from_path.empty() && !fs::exists(include_from_path))
         {
             LOG_WARNING(log, "File {} (from 'include_from') does not exist. Ignoring.", include_from_path);
+            include_from_path.clear();
         }
-        else
-        {
-            processIncludes(
-                config,
-                substitutions,
-                include_from_path,
-                throw_on_bad_incl,
-                dom_parser,
-                log,
-                &contributing_zk_paths,
-                &contributing_files,
-                zk_node_cache,
-                zk_changed_event);
-        }
+
+        processIncludes(
+            config,
+            substitutions,
+            include_from_path,
+            throw_on_bad_incl,
+            dom_parser,
+            log,
+            &contributing_zk_paths,
+            &contributing_files,
+            zk_node_cache,
+            zk_changed_event);
     }
     catch (Exception & e)
     {

--- a/tests/queries/0_stateless/04251_101704_extract_from_config_try_resolves_from_env.reference
+++ b/tests/queries/0_stateless/04251_101704_extract_from_config_try_resolves_from_env.reference
@@ -1,0 +1,14 @@
+--- 1. from_env without include_from, env set, --try ---
+8123
+8443
+9000
+--- 2. from_env without include_from, env set, no --try ---
+8123
+--- 3. from_env with bad include_from, env set, --try ---
+8123
+--- 4. from_env without include_from, env NOT set, --try ---
+
+--- 5. glob *_port with --try ---
+8123
+8443
+9000

--- a/tests/queries/0_stateless/04251_101704_extract_from_config_try_resolves_from_env.sh
+++ b/tests/queries/0_stateless/04251_101704_extract_from_config_try_resolves_from_env.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Regression test for issue #101704
+# `clickhouse extract-from-config --try` must still resolve `from_env` substitutions
+# when the config has no `<include_from>` tag (or when it has one pointing to a
+# non-existent file). Previously, the `--try` codepath skipped all substitutions
+# whenever the include_from file was missing, silently turning `from_env` values
+# into empty strings and breaking the Docker entrypoint port discovery.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+prefix=$CUR_DIR/"04251_101704_extract_from_config_try_resolves_from_env"
+
+# Scenario 1: from_env with no include_from at all. With --try, env vars set.
+# Before the fix: empty output. After the fix: 8123 / 8443 / 9000.
+echo "--- 1. from_env without include_from, env set, --try ---"
+TEST_HTTP_PORT_101704=8123 TEST_HTTPS_PORT_101704=8443 TEST_NATIVE_PORT_101704=9000 \
+    $CLICKHOUSE_BINARY extract-from-config --config-file "$prefix.xml" --key=http_port --try
+TEST_HTTP_PORT_101704=8123 TEST_HTTPS_PORT_101704=8443 TEST_NATIVE_PORT_101704=9000 \
+    $CLICKHOUSE_BINARY extract-from-config --config-file "$prefix.xml" --key=https_port --try
+TEST_HTTP_PORT_101704=8123 TEST_HTTPS_PORT_101704=8443 TEST_NATIVE_PORT_101704=9000 \
+    $CLICKHOUSE_BINARY extract-from-config --config-file "$prefix.xml" --key=tcp_port --try
+
+# Scenario 2: Same config, but without --try (must still work as a sanity check).
+echo "--- 2. from_env without include_from, env set, no --try ---"
+TEST_HTTP_PORT_101704=8123 \
+    $CLICKHOUSE_BINARY extract-from-config --config-file "$prefix.xml" --key=http_port
+
+# Scenario 3: from_env with a *bad* include_from. With --try, the missing file is
+# ignored AND from_env substitutions still run.
+echo "--- 3. from_env with bad include_from, env set, --try ---"
+TEST_HTTP_PORT_101704=8123 \
+    $CLICKHOUSE_BINARY extract-from-config --config-file "${prefix}_bad_include.xml" --key=http_port --try
+
+# Scenario 4: Missing env var with --try - returns empty without erroring.
+echo "--- 4. from_env without include_from, env NOT set, --try ---"
+unset TEST_HTTP_PORT_101704
+$CLICKHOUSE_BINARY extract-from-config --config-file "$prefix.xml" --key=http_port --try
+
+# Scenario 5: Glob key with from_env, --try - prints all three resolved values.
+echo "--- 5. glob *_port with --try ---"
+TEST_HTTP_PORT_101704=8123 TEST_HTTPS_PORT_101704=8443 TEST_NATIVE_PORT_101704=9000 \
+    $CLICKHOUSE_BINARY extract-from-config --config-file "$prefix.xml" --key='*_port' --try | sort

--- a/tests/queries/0_stateless/04251_101704_extract_from_config_try_resolves_from_env.xml
+++ b/tests/queries/0_stateless/04251_101704_extract_from_config_try_resolves_from_env.xml
@@ -1,0 +1,5 @@
+<clickhouse>
+    <http_port from_env="TEST_HTTP_PORT_101704"></http_port>
+    <https_port from_env="TEST_HTTPS_PORT_101704"></https_port>
+    <tcp_port from_env="TEST_NATIVE_PORT_101704"></tcp_port>
+</clickhouse>

--- a/tests/queries/0_stateless/04251_101704_extract_from_config_try_resolves_from_env_bad_include.xml
+++ b/tests/queries/0_stateless/04251_101704_extract_from_config_try_resolves_from_env_bad_include.xml
@@ -1,0 +1,4 @@
+<clickhouse>
+    <include_from>/this/path/should/never/exist/issue-101704.xml</include_from>
+    <http_port from_env="TEST_HTTP_PORT_101704"></http_port>
+</clickhouse>


### PR DESCRIPTION
Fixes https://github.com/ClickHouse/ClickHouse/issues/101704.

### Motivation

After upgrading from 25.1.5.31 to 26.2.5, the Docker entrypoint port discovery silently stopped working. `clickhouse extract-from-config --config-file ... --key=http_port --try` returned an empty string instead of the value of `CLICKHOUSE_HTTP_PORT`, so `entrypoint.sh` failed to wait for the right port and reported `ClickHouse init process timeout`.

@GutOFF traced the regression to 6df7192cdea4 ("Ignore non existing `include_from` files with `--try` for clickhouse-extract-from-config") and @azat asked me to take a look.

### Root cause

`ConfigProcessor::processConfig` used to do:

```cpp
if (!throw_on_bad_include_from && !fs::exists(include_from_path))
{
    LOG_WARNING(log, "File {} (from 'include_from') does not exist. Ignoring.", include_from_path);
}
else
{
    processIncludes(...);
}
```

`processIncludes` is the function that runs `doIncludesRecursive`, which performs the `from_env` / `from_zk` / `incl` substitutions on the whole config — not just the include_from file parsing.

When `--try` is passed, `throw_on_bad_include_from` is `false`. When the config has no `<include_from>` element (and `/etc/metrika.xml` is absent), `include_from_path` is the empty string and `fs::exists("")` returns `false`. Both predicates are true, so the `else` branch is skipped — and with it, all `from_env` substitutions. Every `from_env` element gets serialized as an empty string, which is the bug.

The same silent drop also happens when `<include_from>` is set but the file does not exist; only the `--try` path was affected.

### Fix

Only suppress the include_from *file parsing* when `--try` is on and the path is non-empty and missing. Always call `processIncludes` so `doIncludesRecursive` runs the substitution pass. When the missing-file branch is taken, the path is cleared first so `processIncludes` sees "no include_from", which it already handles correctly.

### Regression test

`tests/queries/0_stateless/04251_101704_extract_from_config_try_resolves_from_env.sh` covers:

1. `from_env` without `include_from`, env set, `--try` — the reported bug
2. Same without `--try` (sanity)
3. `from_env` with a bad `include_from` path, `--try` — related case that this fix also covers
4. Missing env var with `--try` — empty result, no error
5. Glob key with `--try` — all three values resolved

Verified locally with the debug build:

- Test passes 50/50 with the fix.
- Test fails on every scenario without the fix (diff shows the 5 empty-line regressions).
- Existing `03344_clickhouse_extract_from_config_try` still passes.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a regression in `clickhouse extract-from-config --try`: when the config used `from_env` attributes and had no `include_from` element (or had one pointing to a missing file), all `from_env` substitutions were silently dropped and returned empty strings. This broke the Docker entrypoint port discovery in 26.2.5. Closes #101704.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!--
Information about CI checks: https://clickhouse.com/docs/en/development/continuous-integration/
The maintainers will trigger the CI for external contributions automatically once the PR is reviewed.
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.800`
<!-- ch-version-info:end -->