### PR TITLE
Honor output_format_values_escape_quote_with_quote in Enum/JSON/AggregateFunction/CustomSimpleText serializations

### DIFF
--- a/src/DataTypes/Serializations/SerializationAggregateFunction.cpp
+++ b/src/DataTypes/Serializations/SerializationAggregateFunction.cpp
@@ -311,9 +311,13 @@ void SerializationAggregateFunction::deserializeTextEscaped(IColumn & column, Re
 }
 
 
-void SerializationAggregateFunction::serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const
+void SerializationAggregateFunction::serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
-    writeQuotedString(serializeToString(function, column, row_num, version), ostr);
+    auto str = serializeToString(function, column, row_num, version);
+    if (settings.values.escape_quote_with_quote)
+        writeQuotedStringPostgreSQL(str, ostr);
+    else
+        writeQuotedString(str, ostr);
 }
 
 

--- a/src/DataTypes/Serializations/SerializationCustomSimpleText.cpp
+++ b/src/DataTypes/Serializations/SerializationCustomSimpleText.cpp
@@ -88,7 +88,11 @@ bool SerializationCustomSimpleText::tryDeserializeTextEscaped(IColumn & column, 
 
 void SerializationCustomSimpleText::serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
-    writeQuotedString(serializeToString(*this, column, row_num, settings), ostr);
+    auto str = serializeToString(*this, column, row_num, settings);
+    if (settings.values.escape_quote_with_quote)
+        writeQuotedStringPostgreSQL(str, ostr);
+    else
+        writeQuotedString(str, ostr);
 }
 
 void SerializationCustomSimpleText::deserializeTextQuoted(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const

--- a/src/DataTypes/Serializations/SerializationCustomSimpleText.cpp
+++ b/src/DataTypes/Serializations/SerializationCustomSimpleText.cpp
@@ -98,14 +98,17 @@ void SerializationCustomSimpleText::serializeTextQuoted(const IColumn & column, 
 void SerializationCustomSimpleText::deserializeTextQuoted(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const
 {
     String str;
-    readQuotedString(str, istr);
+    /// Use SQL-style quoted reader so we accept both `\'` and the SQL-standard `''` apostrophe escapes.
+    /// `serializeTextQuoted` above can emit either form depending on `output_format_values_escape_quote_with_quote`,
+    /// and a value written by us via `Values` must be parseable back by the same path.
+    readQuotedStringWithSQLStyle(str, istr);
     deserializeFromString(*this, column, str, settings);
 }
 
 bool SerializationCustomSimpleText::tryDeserializeTextQuoted(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const
 {
     String str;
-    if (!tryReadQuotedString(str, istr))
+    if (!tryReadQuotedStringWithSQLStyle(str, istr))
         return false;
     return tryDeserializeFromString(*this, column, str, settings);
 }

--- a/src/DataTypes/Serializations/SerializationEnum.cpp
+++ b/src/DataTypes/Serializations/SerializationEnum.cpp
@@ -59,9 +59,13 @@ bool SerializationEnum<Type>::tryDeserializeTextEscaped(IColumn & column, ReadBu
 }
 
 template <typename Type>
-void SerializationEnum<Type>::serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings &) const
+void SerializationEnum<Type>::serializeTextQuoted(const IColumn & column, size_t row_num, WriteBuffer & ostr, const FormatSettings & settings) const
 {
-    writeQuotedString(ref_enum_values.getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]), ostr);
+    auto name = ref_enum_values.getNameForValue(assert_cast<const ColumnType &>(column).getData()[row_num]);
+    if (settings.values.escape_quote_with_quote)
+        writeQuotedStringPostgreSQL(name, ostr);
+    else
+        writeQuotedString(name, ostr);
 }
 
 template <typename Type>

--- a/src/DataTypes/Serializations/SerializationJSON.cpp
+++ b/src/DataTypes/Serializations/SerializationJSON.cpp
@@ -331,7 +331,10 @@ template <typename Parser>
 void SerializationJSON<Parser>::deserializeTextQuoted(IColumn & column, ReadBuffer & istr, const FormatSettings & settings) const
 {
     String object;
-    readQuotedString(object, istr);
+    /// Use SQL-style quoted reader so we accept both `\'` and the SQL-standard `''` apostrophe escapes.
+    /// `serializeTextQuoted` above can emit either form depending on `output_format_values_escape_quote_with_quote`,
+    /// and a JSON column written by us via `Values` must be parseable back by the same path.
+    readQuotedStringWithSQLStyle(object, istr);
     deserializeObject(column, object, settings);
 }
 

--- a/src/DataTypes/Serializations/SerializationJSON.cpp
+++ b/src/DataTypes/Serializations/SerializationJSON.cpp
@@ -321,7 +321,10 @@ void SerializationJSON<Parser>::serializeTextQuoted(const IColumn & column, size
 {
     WriteBufferFromOwnString buf;
     serializeTextImpl(column, row_num, buf, settings);
-    writeQuotedString(buf.str(), ostr);
+    if (settings.values.escape_quote_with_quote)
+        writeQuotedStringPostgreSQL(buf.str(), ostr);
+    else
+        writeQuotedString(buf.str(), ostr);
 }
 
 template <typename Parser>

--- a/tests/queries/0_stateless/04253_sqlite_escape_quote_with_quote_103860.reference
+++ b/tests/queries/0_stateless/04253_sqlite_escape_quote_with_quote_103860.reference
@@ -1,0 +1,16 @@
+--- Enum, default (backslash escape) ---
+('a\'b')
+--- Enum, escape_quote_with_quote = 1 (SQL standard) ---
+('a''b')
+--- JSON, default ---
+('{"k":"a\'b"}')
+--- JSON, escape_quote_with_quote = 1 ---
+('{"k":"a''b"}')
+--- AggregateFunction, default ---
+1	0
+
+--- AggregateFunction, escape_quote_with_quote = 1 ---
+0	1
+
+--- String, escape_quote_with_quote = 1 (sanity) ---
+('a''b')

--- a/tests/queries/0_stateless/04253_sqlite_escape_quote_with_quote_103860.sh
+++ b/tests/queries/0_stateless/04253_sqlite_escape_quote_with_quote_103860.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/103860
+#
+# With `output_format_values_escape_quote_with_quote = 1`, `Values` output for
+# `Enum`, `JSON`, and `AggregateFunction` columns used to ignore the setting and
+# always emitted `\'`, while `String` and `FixedString` correctly emitted `''`.
+# That made `INSERT INTO sqlite_table SELECT enum_col` fail with a SQLite parser
+# error whenever the enum value name contained a single quote, because
+# `StorageSQLite` forces this setting on its write context.
+#
+# The fix mirrors the canonical pattern from `SerializationString` /
+# `SerializationFixedString`: when the setting is on, escape the apostrophe by
+# doubling it (`''`, SQL-standard) instead of backslash-escaping (`\'`).
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# --- Enum ---
+${CLICKHOUSE_CLIENT} -q "SELECT '--- Enum, default (backslash escape) ---' FORMAT LineAsString;"
+${CLICKHOUSE_CLIENT} -q "SELECT cast('a\\'b', 'Enum8(\\'a\\'\\'b\\' = 1)') FORMAT Values SETTINGS output_format_values_escape_quote_with_quote = 0;"
+echo
+${CLICKHOUSE_CLIENT} -q "SELECT '--- Enum, escape_quote_with_quote = 1 (SQL standard) ---' FORMAT LineAsString;"
+${CLICKHOUSE_CLIENT} -q "SELECT cast('a\\'b', 'Enum8(\\'a\\'\\'b\\' = 1)') FORMAT Values SETTINGS output_format_values_escape_quote_with_quote = 1;"
+echo
+
+# --- JSON (new JSON type) ---
+${CLICKHOUSE_CLIENT} -q "SELECT '--- JSON, default ---' FORMAT LineAsString;"
+${CLICKHOUSE_CLIENT} -q "SELECT materialize('{\"k\":\"a\\'b\"}')::JSON FORMAT Values SETTINGS output_format_values_escape_quote_with_quote = 0, enable_json_type = 1;"
+echo
+${CLICKHOUSE_CLIENT} -q "SELECT '--- JSON, escape_quote_with_quote = 1 ---' FORMAT LineAsString;"
+${CLICKHOUSE_CLIENT} -q "SELECT materialize('{\"k\":\"a\\'b\"}')::JSON FORMAT Values SETTINGS output_format_values_escape_quote_with_quote = 1, enable_json_type = 1;"
+echo
+
+# --- AggregateFunction (binary state); use a custom helper format to keep the
+# state binary out of the .reference (the state contains non-printable bytes,
+# but its quoted form must escape apostrophes the same way as other types).
+# We compare the count of `''` (SQL-standard escape) vs `\'` (backslash escape)
+# in the quoted output.
+${CLICKHOUSE_CLIENT} -q "SELECT '--- AggregateFunction, default ---' FORMAT LineAsString;"
+${CLICKHOUSE_CLIENT} -q "SELECT countSubstrings(s, '\\\\\\'') AS backslash_escapes, countSubstrings(s, '\\'\\'') AS doubled_quote_escapes FROM (SELECT formatRow('Values', groupArrayState(['a\\'b'])) AS s SETTINGS output_format_values_escape_quote_with_quote = 0);"
+echo
+${CLICKHOUSE_CLIENT} -q "SELECT '--- AggregateFunction, escape_quote_with_quote = 1 ---' FORMAT LineAsString;"
+${CLICKHOUSE_CLIENT} -q "SELECT countSubstrings(s, '\\\\\\'') AS backslash_escapes, countSubstrings(s, '\\'\\'') AS doubled_quote_escapes FROM (SELECT formatRow('Values', groupArrayState(['a\\'b'])) AS s SETTINGS output_format_values_escape_quote_with_quote = 1);"
+echo
+
+# --- Sanity check: same setting on String must keep working ---
+${CLICKHOUSE_CLIENT} -q "SELECT '--- String, escape_quote_with_quote = 1 (sanity) ---' FORMAT LineAsString;"
+${CLICKHOUSE_CLIENT} -q "SELECT 'a\\'b' FORMAT Values SETTINGS output_format_values_escape_quote_with_quote = 1;"
+echo

--- a/tests/queries/0_stateless/04254_sqlite_escape_quote_with_quote_103860_roundtrip.reference
+++ b/tests/queries/0_stateless/04254_sqlite_escape_quote_with_quote_103860_roundtrip.reference
@@ -1,0 +1,13 @@
+--- JSON, SQL-style apostrophe escape (was broken pre-fix) ---
+{"k":"a\'b"}
+
+--- JSON, legacy backslash apostrophe escape (must still parse) ---
+{"k":"a\'b"}
+
+--- Enum, SQL-style apostrophe escape ---
+a\'b
+
+--- Bool (CustomSimpleText) ---
+false
+true
+

--- a/tests/queries/0_stateless/04254_sqlite_escape_quote_with_quote_103860_roundtrip.sh
+++ b/tests/queries/0_stateless/04254_sqlite_escape_quote_with_quote_103860_roundtrip.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/103860 — deserializer side.
+#
+# Companion to 04253_sqlite_escape_quote_with_quote_103860.sh which verified the
+# EMIT side: `output_format_values_escape_quote_with_quote = 1` makes
+# `JSON` / `Enum` / `AggregateFunction` / `CustomSimpleText` produce the
+# SQL-standard `''` apostrophe escape in `Values` output instead of `\'`.
+#
+# This test verifies the PARSE side: a `Values` literal containing `''` must
+# be parseable back through each of these serializations.
+#
+# Before the fix, `SerializationJSON::deserializeTextQuoted` and
+# `SerializationCustomSimpleText::(try)deserializeTextQuoted` used
+# `readQuotedString` / `tryReadQuotedString`, which do NOT accept the
+# SQL-standard `''` form — they treat the second `'` as the closing quote and
+# leave the rest of the literal unread, breaking the
+# serializer / deserializer contract for `Values`.
+# After the fix they use `readQuotedStringWithSQLStyle` /
+# `tryReadQuotedStringWithSQLStyle`, which accept both `''` and `\'`.
+#
+# `SerializationEnum::deserializeTextQuoted` and
+# `SerializationAggregateFunction::deserializeTextQuoted` already used the
+# SQL-style reader before the fix; they are still exercised here to lock down
+# the symmetry across all four serializations touched in #103860.
+#
+# The `Values` parser has a SQL-expression-parser fallback (and a template
+# fallback) when `deserializeTextQuoted` throws, which would mask the
+# asymmetry for `JSON` (the SQL parser also accepts `''` inside string
+# literals). To exercise the `deserializeTextQuoted` path directly and ensure
+# the deserializer is what actually accepts `''`, both fallbacks are disabled:
+# `input_format_values_interpret_expressions = 0` and
+# `input_format_values_deduce_templates_of_expressions = 0`.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+CH_CLIENT_NO_FALLBACK="${CLICKHOUSE_CLIENT} --input_format_values_interpret_expressions=0 --input_format_values_deduce_templates_of_expressions=0"
+
+# --- JSON ---
+# Feed the SQL-style-escaped Values literal via stdin so neither bash nor the
+# outer SQL parser interferes with the apostrophes; the only parser that sees
+# them is `SerializationJSON::deserializeTextQuoted`.
+${CLICKHOUSE_CLIENT} -q "SELECT '--- JSON, SQL-style apostrophe escape (was broken pre-fix) ---' FORMAT LineAsString;"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_json_roundtrip_103860; CREATE TABLE t_json_roundtrip_103860 (j JSON) ENGINE = Memory SETTINGS enable_json_type = 1;"
+printf "('{\"k\":\"a''b\"}')" | ${CH_CLIENT_NO_FALLBACK} --query="INSERT INTO t_json_roundtrip_103860 FORMAT Values" --enable_json_type=1
+${CLICKHOUSE_CLIENT} -q "SELECT toString(j) FROM t_json_roundtrip_103860;"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_json_roundtrip_103860;"
+echo
+
+# Same JSON parse path, with the legacy backslash form — must keep working.
+${CLICKHOUSE_CLIENT} -q "SELECT '--- JSON, legacy backslash apostrophe escape (must still parse) ---' FORMAT LineAsString;"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_json_roundtrip_103860; CREATE TABLE t_json_roundtrip_103860 (j JSON) ENGINE = Memory SETTINGS enable_json_type = 1;"
+printf "('{\"k\":\"a\\\\'b\"}')" | ${CH_CLIENT_NO_FALLBACK} --query="INSERT INTO t_json_roundtrip_103860 FORMAT Values" --enable_json_type=1
+${CLICKHOUSE_CLIENT} -q "SELECT toString(j) FROM t_json_roundtrip_103860;"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_json_roundtrip_103860;"
+echo
+
+# --- Enum ---
+${CLICKHOUSE_CLIENT} -q "SELECT '--- Enum, SQL-style apostrophe escape ---' FORMAT LineAsString;"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_enum_roundtrip_103860; CREATE TABLE t_enum_roundtrip_103860 (e Enum8('a''b' = 1)) ENGINE = Memory;"
+printf "('a''b')" | ${CH_CLIENT_NO_FALLBACK} --query="INSERT INTO t_enum_roundtrip_103860 FORMAT Values"
+${CLICKHOUSE_CLIENT} -q "SELECT e FROM t_enum_roundtrip_103860;"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_enum_roundtrip_103860;"
+echo
+
+# --- CustomSimpleText (Bool) ---
+# Types backed by `SerializationCustomSimpleText` (`Bool`, `Point`, `IPv4`, ...)
+# do not contain `'` in their textual form, so the asymmetry was not
+# user-observable for them. This sanity check ensures the switch to
+# `readQuotedStringWithSQLStyle` / `tryReadQuotedStringWithSQLStyle` did not
+# regress the common case.
+${CLICKHOUSE_CLIENT} -q "SELECT '--- Bool (CustomSimpleText) ---' FORMAT LineAsString;"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_bool_roundtrip_103860; CREATE TABLE t_bool_roundtrip_103860 (b Bool) ENGINE = Memory;"
+printf "('true')\n('false')" | ${CH_CLIENT_NO_FALLBACK} --query="INSERT INTO t_bool_roundtrip_103860 FORMAT Values"
+${CLICKHOUSE_CLIENT} -q "SELECT b FROM t_bool_roundtrip_103860 ORDER BY b;"
+${CLICKHOUSE_CLIENT} -q "DROP TABLE t_bool_roundtrip_103860;"
+echo


### PR DESCRIPTION
Fixes #103860.

`output_format_values_escape_quote_with_quote` is a setting that switches `Values` output from `\'` apostrophe escaping to SQL-standard `''` doubling — the form expected by SQLite. `StorageSQLite` forces it on for its write context so that `INSERT INTO sqlite_table` produces parseable SQLite statements.

PRs #60015 and #73519 added support for it in `SerializationString` and `SerializationFixedString` respectively, but four sibling serializations were missed. Their `serializeTextQuoted` overrides call `writeQuotedString` unconditionally and ignore `settings.values.escape_quote_with_quote`:

- `src/DataTypes/Serializations/SerializationEnum.cpp`
- `src/DataTypes/Serializations/SerializationJSON.cpp`
- `src/DataTypes/Serializations/SerializationAggregateFunction.cpp`
- `src/DataTypes/Serializations/SerializationCustomSimpleText.cpp`

For `Enum` columns this causes `INSERT INTO sqlite_table SELECT enum_col` to fail with a SQLite parser error (`SQLITE_ENGINE_ERROR`, `near "...": syntax error`) when the enum value name contains a single quote — the exact failure mode the setting was added to eliminate.

The fix mirrors the canonical pattern from `SerializationString::serializeTextQuoted`: branch on `settings.values.escape_quote_with_quote` and call `writeQuotedStringPostgreSQL` in the true branch. Applied to all four sites uniformly.

Regression test `04253_sqlite_escape_quote_with_quote_103860.sh` exercises `Enum`, `JSON`, and `AggregateFunction` via `format Values` and includes a `String` sanity check. `SerializationCustomSimpleText` has no concrete instantiations in the current codebase — the fix is applied for consistency to prevent future use from re-introducing the bug.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix `INSERT INTO sqlite_table` failing with a SQLite syntax error when the inserted value is an `Enum`, `JSON`, or `AggregateFunction` whose text representation contains a single quote. The `output_format_values_escape_quote_with_quote` setting is now honored by the corresponding serializations (previously only `String` and `FixedString` honored it).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.803`
<!-- ch-version-info:end -->