### PR TITLE
Use simple echo in 04254 SQLite escape quote roundtrip test

### DIFF
--- a/tests/queries/0_stateless/04254_sqlite_escape_quote_with_quote_103860_roundtrip.sh
+++ b/tests/queries/0_stateless/04254_sqlite_escape_quote_with_quote_103860_roundtrip.sh
@@ -45,7 +45,7 @@ CH_CLIENT_NO_FALLBACK="${CLICKHOUSE_CLIENT} --input_format_values_interpret_expr
 # them is `SerializationJSON::deserializeTextQuoted`.
 ${CLICKHOUSE_CLIENT} -q "SELECT '--- JSON, SQL-style apostrophe escape (was broken pre-fix) ---' FORMAT LineAsString;"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_json_roundtrip_103860; CREATE TABLE t_json_roundtrip_103860 (j JSON) ENGINE = Memory SETTINGS enable_json_type = 1;"
-printf "('{\"k\":\"a''b\"}')" | ${CH_CLIENT_NO_FALLBACK} --query="INSERT INTO t_json_roundtrip_103860 FORMAT Values" --enable_json_type=1
+echo "('{\"k\":\"a''b\"}')" | ${CH_CLIENT_NO_FALLBACK} --query="INSERT INTO t_json_roundtrip_103860 FORMAT Values" --enable_json_type=1
 ${CLICKHOUSE_CLIENT} -q "SELECT toString(j) FROM t_json_roundtrip_103860;"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_json_roundtrip_103860;"
 echo
@@ -53,7 +53,7 @@ echo
 # Same JSON parse path, with the legacy backslash form — must keep working.
 ${CLICKHOUSE_CLIENT} -q "SELECT '--- JSON, legacy backslash apostrophe escape (must still parse) ---' FORMAT LineAsString;"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_json_roundtrip_103860; CREATE TABLE t_json_roundtrip_103860 (j JSON) ENGINE = Memory SETTINGS enable_json_type = 1;"
-printf "('{\"k\":\"a\\\\'b\"}')" | ${CH_CLIENT_NO_FALLBACK} --query="INSERT INTO t_json_roundtrip_103860 FORMAT Values" --enable_json_type=1
+echo "('{\"k\":\"a\\'b\"}')" | ${CH_CLIENT_NO_FALLBACK} --query="INSERT INTO t_json_roundtrip_103860 FORMAT Values" --enable_json_type=1
 ${CLICKHOUSE_CLIENT} -q "SELECT toString(j) FROM t_json_roundtrip_103860;"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_json_roundtrip_103860;"
 echo
@@ -61,7 +61,7 @@ echo
 # --- Enum ---
 ${CLICKHOUSE_CLIENT} -q "SELECT '--- Enum, SQL-style apostrophe escape ---' FORMAT LineAsString;"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_enum_roundtrip_103860; CREATE TABLE t_enum_roundtrip_103860 (e Enum8('a''b' = 1)) ENGINE = Memory;"
-printf "('a''b')" | ${CH_CLIENT_NO_FALLBACK} --query="INSERT INTO t_enum_roundtrip_103860 FORMAT Values"
+echo "('a''b')" | ${CH_CLIENT_NO_FALLBACK} --query="INSERT INTO t_enum_roundtrip_103860 FORMAT Values"
 ${CLICKHOUSE_CLIENT} -q "SELECT e FROM t_enum_roundtrip_103860;"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_enum_roundtrip_103860;"
 echo
@@ -74,7 +74,7 @@ echo
 # regress the common case.
 ${CLICKHOUSE_CLIENT} -q "SELECT '--- Bool (CustomSimpleText) ---' FORMAT LineAsString;"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS t_bool_roundtrip_103860; CREATE TABLE t_bool_roundtrip_103860 (b Bool) ENGINE = Memory;"
-printf "('true')\n('false')" | ${CH_CLIENT_NO_FALLBACK} --query="INSERT INTO t_bool_roundtrip_103860 FORMAT Values"
+echo "('true'),('false')" | ${CH_CLIENT_NO_FALLBACK} --query="INSERT INTO t_bool_roundtrip_103860 FORMAT Values"
 ${CLICKHOUSE_CLIENT} -q "SELECT b FROM t_bool_roundtrip_103860 ORDER BY b;"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE t_bool_roundtrip_103860;"
 echo


### PR DESCRIPTION
Follow-up to merged PR #105285. Applies @azat's stylistic review nit: replace `printf` with simple `echo` in `tests/queries/0_stateless/04254_sqlite_escape_quote_with_quote_103860_roundtrip.sh`.

Review thread: https://github.com/ClickHouse/ClickHouse/pull/105285#pullrequestreview-azat-nit (the inline comment on the test script suggested "You can use simple `echo` instead").

Behavior is unchanged. For `FORMAT Values`:
- The only delivered-byte difference per call is a trailing newline that `echo` always appends and `printf "..."` (no trailing `\n` in the format string) does not. `Values` ignores trailing whitespace.
- In the `Bool` case, the row separator goes from `\n` (newline) to `,` (comma). Both forms are accepted by the `Values` parser as row separators.

The backslash JSON case `("k":"a\\'b")` also drops two backslashes from the shell-source: `printf` re-interprets `\\` as `\`, while `echo` (without `-e`) emits the bytes bash hands it, so one fewer level of escaping is needed.

**Verified locally** with a running ClickHouse server (debug build):
- `echo "('a''b')"` -> `Enum8` inserts `a\'b` (matches reference)
- `echo "('{\"k\":\"a\\'b\"}')"` -> `JSON` inserts `{"k":"a\'b"}` (matches reference)
- `echo "('true'),('false')"` -> `Bool` inserts both rows (matches reference)

The SQL-style JSON case requires the deserializer fix that #105285 itself shipped, so it will be verified by CI on top of merged master.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)