### PR TITLE
CI: fix Bugfix validation after stop-testing rename

### DIFF
--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -12,7 +12,7 @@ SKIPPED_SIGN = "[ SKIPPED "
 NOT_FAILED_SIGN = "[ NOT_FAILED "
 HUNG_SIGN = "Found hung queries in processlist"
 STOP_TESTING_SIGN = "Stopping tests, terminating all processes"
-STOP_TESTING_SIGN2 = "Hung check failed: server is not responding"
+STOP_TESTING_SIGN2 = "Server does not respond to health check"
 DATABASE_SIGN = "Database: "
 
 SUCCESS_FINISH_SIGNS = ["All tests have finished", "No tests were run"]

--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -11,8 +11,8 @@ UNKNOWN_SIGN = "[ UNKNOWN "
 SKIPPED_SIGN = "[ SKIPPED "
 NOT_FAILED_SIGN = "[ NOT_FAILED "
 HUNG_SIGN = "Found hung queries in processlist"
-SERVER_DIED_SIGN = "Server died, terminating all processes"
-SERVER_DIED_SIGN2 = "Server does not respond to health check"
+STOP_TESTING_SIGN = "Stopping tests, terminating all processes"
+STOP_TESTING_SIGN2 = "Hung check failed: server is not responding"
 DATABASE_SIGN = "Database: "
 
 SUCCESS_FINISH_SIGNS = ["All tests have finished", "No tests were run"]
@@ -41,7 +41,7 @@ class FTResultsProcessor:
         success: int
         test_results: List[Result]
         hung: bool = False
-        server_died: bool = False
+        stop_testing: bool = False
         retries: bool = False
         success_finish: bool = False
         test_end: bool = True
@@ -57,7 +57,7 @@ class FTResultsProcessor:
         failed = 0
         success = 0
         hung = False
-        server_died = False
+        stop_testing = False
         retries = False
         success_finish = False
         test_results = []
@@ -75,8 +75,8 @@ class FTResultsProcessor:
                 if HUNG_SIGN in line:
                     hung = True
                     break
-                if SERVER_DIED_SIGN in line or SERVER_DIED_SIGN2 in line:
-                    server_died = True
+                if STOP_TESTING_SIGN in line or STOP_TESTING_SIGN2 in line:
+                    stop_testing = True
                 if RETRIES_SIGN in line:
                     retries = True
 
@@ -167,7 +167,7 @@ class FTResultsProcessor:
             success=success,
             test_results=test_results,
             hung=hung,
-            server_died=server_died,
+            stop_testing=stop_testing,
             success_finish=success_finish,
             retries=retries,
         )
@@ -188,7 +188,7 @@ class FTResultsProcessor:
             test_results.append(
                 Result("Some queries hung", Result.Status.FAIL, info="Some queries hung")
             )
-        elif s.server_died:
+        elif s.stop_testing:
             state = Result.Status.FAIL
             failed_results = [r for r in test_results if r.is_failure()]
             if len(failed_results) > 1:


### PR DESCRIPTION
#104081 renamed the `server_died` event to `stop_testing` in `clickhouse-test` and replaced the parent-side print

```
Server died, terminating all processes...
```

with

```
Stopping tests, terminating all processes...
```

The functional-tests results parser in `ci/jobs/scripts/functional_tests_results.py` still searched for the old string, so when a Bugfix validation run actually killed the server it never emitted the synthetic `Server died` leaf that the inversion step in `ci/jobs/functional_tests.py` flips to OK — and the job reported `Failed to reproduce the bug` even though the bug had reproduced.

This PR realigns the two SIGN constants to the wording the runner now emits and renames the carried variable / `Summary` field to `stop_testing` to match.

Observed on the `Bugfix validation (functional tests)` job of #105286 (server crashed under the test; log line `Stopping tests, terminating all processes...`).

Refs #104081.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.856`
<!-- ch-version-info:end -->