### PR TITLE
Fix azure init params

### DIFF
--- a/src/Storages/ObjectStorage/Azure/Configuration.cpp
+++ b/src/Storages/ObjectStorage/Azure/Configuration.cpp
@@ -356,7 +356,7 @@ void AzureStorageParsedArguments::initializeForOneLake(ASTs & args, ContextPtr c
 
     fillBlobsFromURLCommon(connection_url, ".com", ".dfs.fabric.microsoft.com");
 
-    connection_params.endpoint.additional_params = "resource=REDACTED&directory=REDACTED&recursive=REDACTED";
+    connection_params.endpoint.container_already_exists = true;
 
     auto request_settings = AzureBlobStorage::getRequestSettings(context->getSettingsRef());
     connection_params.client_options = AzureBlobStorage::getClientOptions(context, context->getSettingsRef(), *request_settings, /*for_disk=*/ false);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix azure init params

<!-- ch-version-info:start -->
### Version info
- Backported to: `26.5.2.19`, `26.4.4.22`, `26.3.13.20`
<!-- ch-version-info:end -->