### PR TITLE
Fix long queries for unity

### DIFF
--- a/src/Databases/DataLake/UnityCatalog.cpp
+++ b/src/Databases/DataLake/UnityCatalog.cpp
@@ -432,6 +432,12 @@ UnityCatalog::UnityCatalog(
 
 ICatalog::CredentialsRefreshCallback UnityCatalog::getCredentialsConfigurationCallback(const DB::StorageID & table_id)
 {
+    if (!table_id.hasUUID())
+        throw DB::Exception(
+            DB::ErrorCodes::BAD_ARGUMENTS,
+            "Cannot build a Unity credentials refresh callback for `{}`: StorageID has no UUID",
+            table_id.getNameForLogs());
+
     const String unity_table_id = toString(table_id.uuid);
 
     return [this, unity_table_id] () -> std::shared_ptr<IStorageCredentials>

--- a/src/Databases/DataLake/UnityCatalog.cpp
+++ b/src/Databases/DataLake/UnityCatalog.cpp
@@ -138,7 +138,18 @@ void UnityCatalog::getCredentials(const std::string & table_id, TableMetadata & 
     request_body.set("operation", "READ");
     auto response = requestReadCredentials(request_body);
 
-    auto creds = storage_type == StorageType::S3 ? parseS3Credentials(response) : parseAzureCredentials(response);
+    std::shared_ptr<IStorageCredentials> creds;
+    switch (storage_type)
+    {
+    case StorageType::S3:
+        creds = parseS3Credentials(response);
+        break;
+    case StorageType::Azure:
+        creds = parseAzureCredentials(response);
+        break;
+    default:
+        break;
+    }
     if (creds)
         metadata.setStorageCredentials(creds);
 }

--- a/src/Databases/DataLake/UnityCatalog.cpp
+++ b/src/Databases/DataLake/UnityCatalog.cpp
@@ -18,6 +18,7 @@ namespace DB::ErrorCodes
 {
     extern const int DATALAKE_DATABASE_ERROR;
     extern const int LOGICAL_ERROR;
+    extern const int BAD_ARGUMENTS;
 }
 
 namespace
@@ -97,8 +98,12 @@ void UnityCatalog::getTableMetadata(
         throw DB::Exception(DB::ErrorCodes::DATALAKE_DATABASE_ERROR, "No response from unity catalog");
 }
 
-Poco::JSON::Object::Ptr UnityCatalog::requestReadCredentials(const Poco::JSON::Object & request_body) const
+Poco::JSON::Object::Ptr UnityCatalog::requestReadCredentials(const DB::StorageID & table_id) const
 {
+    Poco::JSON::Object request_body;
+    request_body.set("table_id", table_id);
+    request_body.set("operation", "READ");
+
     auto callback = [&request_body] (std::ostream & os) { request_body.stringify(os); };
     auto [json, _] = postJSONRequest(TEMPORARY_CREDENTIALS_ENDPOINT, callback);
     return json.extract<Poco::JSON::Object::Ptr>();
@@ -133,10 +138,7 @@ void UnityCatalog::getCredentials(const std::string & table_id, TableMetadata & 
     if (storage_type != StorageType::S3 && storage_type != StorageType::Azure)
         return;
 
-    Poco::JSON::Object request_body;
-    request_body.set("table_id", table_id);
-    request_body.set("operation", "READ");
-    auto response = requestReadCredentials(request_body);
+    auto response = requestReadCredentials(table_id);
 
     std::shared_ptr<IStorageCredentials> creds;
     switch (storage_type)
@@ -441,6 +443,7 @@ UnityCatalog::UnityCatalog(
 {
 }
 
+/// getCredentialsConfigurationCallback method is supported only for S3 storage
 ICatalog::CredentialsRefreshCallback UnityCatalog::getCredentialsConfigurationCallback(const DB::StorageID & table_id)
 {
     if (!table_id.hasUUID())
@@ -455,10 +458,7 @@ ICatalog::CredentialsRefreshCallback UnityCatalog::getCredentialsConfigurationCa
     {
         LOG_DEBUG(log, "Update credentials in the catalog");
 
-        Poco::JSON::Object request_body;
-        request_body.set("table_id", unity_table_id);
-        request_body.set("operation", "READ");
-        return parseS3Credentials(requestReadCredentials(request_body));
+        return parseS3Credentials(requestReadCredentials(unity_table_id));
     };
 }
 

--- a/src/Databases/DataLake/UnityCatalog.cpp
+++ b/src/Databases/DataLake/UnityCatalog.cpp
@@ -443,13 +443,21 @@ UnityCatalog::UnityCatalog(
 {
 }
 
-ICatalog::CredentialsRefreshCallback UnityCatalog::getCredentialsConfigurationCallback(const DB::StorageID &)
+ICatalog::CredentialsRefreshCallback UnityCatalog::getCredentialsConfigurationCallback(const DB::StorageID & table_id)
 {
-    return [this] () -> std::shared_ptr<IStorageCredentials>
+    return [this, table_id] () -> std::shared_ptr<IStorageCredentials>
     {
         LOG_DEBUG(log, "Update credentials in the catalog");
 
-        auto [json, _] = postJSONRequest(TEMPORARY_CREDENTIALS_ENDPOINT, {});
+        auto callback = [table_id] (std::ostream & os)
+        {
+            Poco::JSON::Object obj;
+            obj.set("table_id", table_id);
+            obj.set("operation", "READ");
+            obj.stringify(os);
+        };
+
+        auto [json, _] = postJSONRequest(TEMPORARY_CREDENTIALS_ENDPOINT, callback);
         const Poco::JSON::Object::Ptr & object = json.extract<Poco::JSON::Object::Ptr>();
 
         if (hasValueAndItsNotNone("aws_temp_credentials", object))

--- a/src/Databases/DataLake/UnityCatalog.cpp
+++ b/src/Databases/DataLake/UnityCatalog.cpp
@@ -446,15 +446,7 @@ UnityCatalog::UnityCatalog(
 /// getCredentialsConfigurationCallback method is supported only for S3 storage
 ICatalog::CredentialsRefreshCallback UnityCatalog::getCredentialsConfigurationCallback(const DB::StorageID & table_id)
 {
-    if (!table_id.hasUUID())
-        throw DB::Exception(
-            DB::ErrorCodes::BAD_ARGUMENTS,
-            "Cannot build a Unity credentials refresh callback for `{}`: StorageID has no UUID",
-            table_id.getNameForLogs());
-
-    const String unity_table_id = toString(table_id.uuid);
-
-    return [this, unity_table_id] () -> std::shared_ptr<IStorageCredentials>
+    return [this, unity_table_id = table_id] () -> std::shared_ptr<IStorageCredentials>
     {
         LOG_DEBUG(log, "Update credentials in the catalog");
 

--- a/src/Databases/DataLake/UnityCatalog.cpp
+++ b/src/Databases/DataLake/UnityCatalog.cpp
@@ -18,7 +18,6 @@ namespace DB::ErrorCodes
 {
     extern const int DATALAKE_DATABASE_ERROR;
     extern const int LOGICAL_ERROR;
-    extern const int BAD_ARGUMENTS;
 }
 
 namespace

--- a/src/Databases/DataLake/UnityCatalog.cpp
+++ b/src/Databases/DataLake/UnityCatalog.cpp
@@ -432,12 +432,14 @@ UnityCatalog::UnityCatalog(
 
 ICatalog::CredentialsRefreshCallback UnityCatalog::getCredentialsConfigurationCallback(const DB::StorageID & table_id)
 {
-    return [this, table_id] () -> std::shared_ptr<IStorageCredentials>
+    const String unity_table_id = toString(table_id.uuid);
+
+    return [this, unity_table_id] () -> std::shared_ptr<IStorageCredentials>
     {
         LOG_DEBUG(log, "Update credentials in the catalog");
 
         Poco::JSON::Object request_body;
-        request_body.set("table_id", table_id);
+        request_body.set("table_id", unity_table_id);
         request_body.set("operation", "READ");
         return parseS3Credentials(requestReadCredentials(request_body));
     };

--- a/src/Databases/DataLake/UnityCatalog.cpp
+++ b/src/Databases/DataLake/UnityCatalog.cpp
@@ -1,4 +1,5 @@
 #include <Databases/DataLake/UnityCatalog.h>
+#include <Interpreters/StorageID.h>
 
 #if USE_PARQUET
 
@@ -18,6 +19,7 @@ namespace DB::ErrorCodes
 {
     extern const int DATALAKE_DATABASE_ERROR;
     extern const int LOGICAL_ERROR;
+    extern const int BAD_ARGUMENTS;
 }
 
 namespace
@@ -97,7 +99,7 @@ void UnityCatalog::getTableMetadata(
         throw DB::Exception(DB::ErrorCodes::DATALAKE_DATABASE_ERROR, "No response from unity catalog");
 }
 
-Poco::JSON::Object::Ptr UnityCatalog::requestReadCredentials(const DB::StorageID & table_id) const
+Poco::JSON::Object::Ptr UnityCatalog::requestReadCredentials(const String & table_id) const
 {
     Poco::JSON::Object request_body;
     request_body.set("table_id", table_id);
@@ -130,7 +132,7 @@ std::shared_ptr<IStorageCredentials> UnityCatalog::parseAzureCredentials(const P
         creds_object->get("sas_token").extract<String>());
 }
 
-void UnityCatalog::getCredentials(const std::string & table_id, TableMetadata & metadata) const
+void UnityCatalog::getCredentials(const String & table_id, TableMetadata & metadata) const
 {
     LOG_DEBUG(log, "Getting credentials for table {}", table_id);
     auto storage_type = parseStorageTypeFromLocation(metadata.getLocation());
@@ -445,8 +447,15 @@ UnityCatalog::UnityCatalog(
 /// getCredentialsConfigurationCallback method is supported only for S3 storage
 ICatalog::CredentialsRefreshCallback UnityCatalog::getCredentialsConfigurationCallback(const DB::StorageID & table_id)
 {
-    return [this, unity_table_id = table_id] () -> std::shared_ptr<IStorageCredentials>
-    {
+    if (!table_id.hasUUID())
+        throw DB::Exception(
+            DB::ErrorCodes::BAD_ARGUMENTS,
+            "Cannot build a Unity credentials refresh callback for `{}`: StorageID has no UUID",
+            table_id.getNameForLogs());
+
+    const String unity_table_id = toString(table_id.uuid);
+
+    return [this, unity_table_id] () -> std::shared_ptr<IStorageCredentials>    {
         LOG_DEBUG(log, "Update credentials in the catalog");
 
         return parseS3Credentials(requestReadCredentials(unity_table_id));

--- a/src/Databases/DataLake/UnityCatalog.cpp
+++ b/src/Databases/DataLake/UnityCatalog.cpp
@@ -97,63 +97,50 @@ void UnityCatalog::getTableMetadata(
         throw DB::Exception(DB::ErrorCodes::DATALAKE_DATABASE_ERROR, "No response from unity catalog");
 }
 
+Poco::JSON::Object::Ptr UnityCatalog::requestReadCredentials(const Poco::JSON::Object & request_body) const
+{
+    auto callback = [&request_body] (std::ostream & os) { request_body.stringify(os); };
+    auto [json, _] = postJSONRequest(TEMPORARY_CREDENTIALS_ENDPOINT, callback);
+    return json.extract<Poco::JSON::Object::Ptr>();
+}
+
+std::shared_ptr<IStorageCredentials> UnityCatalog::parseS3Credentials(const Poco::JSON::Object::Ptr & response) const
+{
+    if (!hasValueAndItsNotNone("aws_temp_credentials", response))
+        return nullptr;
+
+    const Poco::JSON::Object::Ptr & creds_object = response->getObject("aws_temp_credentials");
+    return std::make_shared<S3Credentials>(
+        creds_object->get("access_key_id").extract<String>(),
+        creds_object->get("secret_access_key").extract<String>(),
+        creds_object->get("session_token").extract<String>());
+}
+
+std::shared_ptr<IStorageCredentials> UnityCatalog::parseAzureCredentials(const Poco::JSON::Object::Ptr & response) const
+{
+    if (!hasValueAndItsNotNone("azure_user_delegation_sas", response))
+        return nullptr;
+
+    const Poco::JSON::Object::Ptr & creds_object = response->getObject("azure_user_delegation_sas");
+    return std::make_shared<AzureCredentials>(
+        creds_object->get("sas_token").extract<String>());
+}
+
 void UnityCatalog::getCredentials(const std::string & table_id, TableMetadata & metadata) const
 {
     LOG_DEBUG(log, "Getting credentials for table {}", table_id);
     auto storage_type = parseStorageTypeFromLocation(metadata.getLocation());
-    switch (storage_type)
-    {
-        case StorageType::S3:
-        {
-            auto callback = [table_id] (std::ostream & os)
-            {
-                Poco::JSON::Object obj;
-                obj.set("table_id", table_id);
-                obj.set("operation", "READ");
-                obj.stringify(os);
-            };
+    if (storage_type != StorageType::S3 && storage_type != StorageType::Azure)
+        return;
 
-            auto [json, _] = postJSONRequest(TEMPORARY_CREDENTIALS_ENDPOINT, callback);
-            const Poco::JSON::Object::Ptr & object = json.extract<Poco::JSON::Object::Ptr>();
+    Poco::JSON::Object request_body;
+    request_body.set("table_id", table_id);
+    request_body.set("operation", "READ");
+    auto response = requestReadCredentials(request_body);
 
-            if (hasValueAndItsNotNone("aws_temp_credentials", object))
-            {
-                const Poco::JSON::Object::Ptr & creds_object = object->getObject("aws_temp_credentials");
-                std::string access_key_id = creds_object->get("access_key_id").extract<String>();
-                std::string secret_access_key = creds_object->get("secret_access_key").extract<String>();
-                std::string session_token = creds_object->get("session_token").extract<String>();
-
-                auto creds = std::make_shared<S3Credentials>(access_key_id, secret_access_key, session_token);
-                metadata.setStorageCredentials(creds);
-            }
-            break;
-        }
-        case StorageType::Azure:
-        {
-            auto callback = [table_id] (std::ostream & os)
-            {
-                Poco::JSON::Object obj;
-                obj.set("table_id", table_id);
-                obj.set("operation", "READ");
-                obj.stringify(os);
-            };
-
-            auto [json, _] = postJSONRequest(TEMPORARY_CREDENTIALS_ENDPOINT, callback);
-            const Poco::JSON::Object::Ptr & object = json.extract<Poco::JSON::Object::Ptr>();
-
-            if (hasValueAndItsNotNone("azure_user_delegation_sas", object))
-            {
-                const Poco::JSON::Object::Ptr & creds_object = object->getObject("azure_user_delegation_sas");
-                std::string sas_token = creds_object->get("sas_token").extract<String>();
-
-                auto creds = std::make_shared<AzureCredentials>(sas_token);
-                metadata.setStorageCredentials(creds);
-            }
-            break;
-        }
-        default:
-            break;
-    }
+    auto creds = storage_type == StorageType::S3 ? parseS3Credentials(response) : parseAzureCredentials(response);
+    if (creds)
+        metadata.setStorageCredentials(creds);
 }
 
 bool UnityCatalog::tryGetTableMetadata(
@@ -449,28 +436,10 @@ ICatalog::CredentialsRefreshCallback UnityCatalog::getCredentialsConfigurationCa
     {
         LOG_DEBUG(log, "Update credentials in the catalog");
 
-        auto callback = [table_id] (std::ostream & os)
-        {
-            Poco::JSON::Object obj;
-            obj.set("table_id", table_id);
-            obj.set("operation", "READ");
-            obj.stringify(os);
-        };
-
-        auto [json, _] = postJSONRequest(TEMPORARY_CREDENTIALS_ENDPOINT, callback);
-        const Poco::JSON::Object::Ptr & object = json.extract<Poco::JSON::Object::Ptr>();
-
-        if (hasValueAndItsNotNone("aws_temp_credentials", object))
-        {
-            const Poco::JSON::Object::Ptr & creds_object = object->getObject("aws_temp_credentials");
-            std::string access_key_id = creds_object->get("access_key_id").extract<String>();
-            std::string secret_access_key = creds_object->get("secret_access_key").extract<String>();
-            std::string session_token = creds_object->get("session_token").extract<String>();
-
-            auto creds = std::make_shared<S3Credentials>(access_key_id, secret_access_key, session_token);
-            return creds;
-        }
-        return nullptr;
+        Poco::JSON::Object request_body;
+        request_body.set("table_id", table_id);
+        request_body.set("operation", "READ");
+        return parseS3Credentials(requestReadCredentials(request_body));
     };
 }
 

--- a/src/Databases/DataLake/UnityCatalog.h
+++ b/src/Databases/DataLake/UnityCatalog.h
@@ -64,6 +64,13 @@ private:
     DB::Names getTablesForSchema(const std::string & schema, size_t limit = 0) const;
     void getCredentials(const std::string & table_id, TableMetadata & metadata) const;
 
+    /// POSTs a READ-credentials request to TEMPORARY_CREDENTIALS_ENDPOINT and returns the parsed body.
+    Poco::JSON::Object::Ptr requestReadCredentials(const Poco::JSON::Object & request_body) const;
+
+    /// Extract S3/Azure credentials from a TEMPORARY_CREDENTIALS_ENDPOINT response; nullptr if absent.
+    std::shared_ptr<IStorageCredentials> parseS3Credentials(const Poco::JSON::Object::Ptr & response) const;
+    std::shared_ptr<IStorageCredentials> parseAzureCredentials(const Poco::JSON::Object::Ptr & response) const;
+
     bool getTableMetadataImpl(
         const std::string & namespace_name,
         const std::string & table_name,

--- a/src/Databases/DataLake/UnityCatalog.h
+++ b/src/Databases/DataLake/UnityCatalog.h
@@ -64,10 +64,8 @@ private:
     DB::Names getTablesForSchema(const std::string & schema, size_t limit = 0) const;
     void getCredentials(const std::string & table_id, TableMetadata & metadata) const;
 
-    /// POSTs a READ-credentials request to TEMPORARY_CREDENTIALS_ENDPOINT and returns the parsed body.
     Poco::JSON::Object::Ptr requestReadCredentials(const Poco::JSON::Object & request_body) const;
 
-    /// Extract S3/Azure credentials from a TEMPORARY_CREDENTIALS_ENDPOINT response; nullptr if absent.
     std::shared_ptr<IStorageCredentials> parseS3Credentials(const Poco::JSON::Object::Ptr & response) const;
     std::shared_ptr<IStorageCredentials> parseAzureCredentials(const Poco::JSON::Object::Ptr & response) const;
 

--- a/src/Databases/DataLake/UnityCatalog.h
+++ b/src/Databases/DataLake/UnityCatalog.h
@@ -64,7 +64,7 @@ private:
     DB::Names getTablesForSchema(const std::string & schema, size_t limit = 0) const;
     void getCredentials(const std::string & table_id, TableMetadata & metadata) const;
 
-    Poco::JSON::Object::Ptr requestReadCredentials(const Poco::JSON::Object & request_body) const;
+    Poco::JSON::Object::Ptr requestReadCredentials(const DB::StorageID & table_id) const;
 
     std::shared_ptr<IStorageCredentials> parseS3Credentials(const Poco::JSON::Object::Ptr & response) const;
     std::shared_ptr<IStorageCredentials> parseAzureCredentials(const Poco::JSON::Object::Ptr & response) const;

--- a/src/Databases/DataLake/UnityCatalog.h
+++ b/src/Databases/DataLake/UnityCatalog.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <Interpreters/StorageID.h>
 #include "config.h"
 
 #if USE_PARQUET
@@ -62,9 +63,9 @@ private:
     DataLake::ICatalog::Namespaces getSchemas(const std::string & base_prefix, size_t limit = 0) const;
 
     DB::Names getTablesForSchema(const std::string & schema, size_t limit = 0) const;
-    void getCredentials(const std::string & table_id, TableMetadata & metadata) const;
+    void getCredentials(const String & table_id, TableMetadata & metadata) const;
 
-    Poco::JSON::Object::Ptr requestReadCredentials(const DB::StorageID & table_id) const;
+    Poco::JSON::Object::Ptr requestReadCredentials(const String & table_id) const;
 
     std::shared_ptr<IStorageCredentials> parseS3Credentials(const Poco::JSON::Object::Ptr & response) const;
     std::shared_ptr<IStorageCredentials> parseAzureCredentials(const Poco::JSON::Object::Ptr & response) const;

--- a/src/Databases/DataLake/UnityCatalog.h
+++ b/src/Databases/DataLake/UnityCatalog.h
@@ -69,7 +69,7 @@ private:
         const std::string & table_name,
         TableMetadata & result) const;
 
-    ICatalog::CredentialsRefreshCallback getCredentialsConfigurationCallback(const DB::StorageID & storage_id) override;
+    ICatalog::CredentialsRefreshCallback getCredentialsConfigurationCallback(const DB::StorageID & table_id) override;
 };
 
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix long queries for unity. Add table_id parameter in query request.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.72`
- Backported to: `26.5.3.8`
<!-- ch-version-info:end -->