### PR TITLE
Fix replica delay check bypass when Distributed query targets a View

### DIFF
--- a/src/Interpreters/ClusterProxy/SelectStreamFactory.cpp
+++ b/src/Interpreters/ClusterProxy/SelectStreamFactory.cpp
@@ -5,6 +5,7 @@
 #include <Interpreters/ClusterProxy/SelectStreamFactory.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/InterpreterSelectQueryAnalyzer.h>
+#include <Interpreters/ReplicatedTableDelay.h>
 #include <Interpreters/SelectQueryOptions.h>
 #include <Interpreters/TranslateQualifiedNamesVisitor.h>
 #include <Parsers/ASTSelectQuery.h>
@@ -252,15 +253,6 @@ void SelectStreamFactory::createForShardImpl(
             return;
         }
 
-        const auto * replicated_storage = dynamic_cast<const StorageReplicatedMergeTree *>(main_table_storage.get());
-
-        if (!replicated_storage)
-        {
-            /// Table is not replicated, use local server.
-            emplace_local_stream();
-            return;
-        }
-
         const UInt64 max_allowed_delay = settings[Setting::max_replica_delay_for_distributed_queries];
 
         if (!max_allowed_delay)
@@ -269,7 +261,7 @@ void SelectStreamFactory::createForShardImpl(
             return;
         }
 
-        UInt64 local_delay = replicated_storage->getAbsoluteDelay();
+        UInt64 local_delay = getReplicatedDelay(main_table_storage, context).max_absolute_delay;
 
         if (local_delay < max_allowed_delay)
         {

--- a/src/Interpreters/ReplicatedTableDelay.cpp
+++ b/src/Interpreters/ReplicatedTableDelay.cpp
@@ -1,0 +1,59 @@
+#include <algorithm>
+#include <queue>
+
+#include <Common/logger_useful.h>
+#include <Interpreters/DatabaseCatalog.h>
+#include <Interpreters/ReplicatedTableDelay.h>
+#include <Storages/MergeTree/MergeTreeData.h>
+#include <Storages/StorageReplicatedMergeTree.h>
+
+namespace DB
+{
+
+/// Traverse referential dependencies of a storage (e.g. View -> ReplicatedMergeTree)
+/// and aggregate delay/readonly info across all discovered ReplicatedMergeTree tables.
+ReplicatedTableDelay getReplicatedDelay(const StoragePtr & storage, ContextPtr context)
+{
+    if (auto * replicated_storage = dynamic_cast<StorageReplicatedMergeTree *>(storage.get()))
+        return {
+            .max_absolute_delay = replicated_storage->getAbsoluteDelay(),
+            .is_replicated = true,
+            .is_readonly = replicated_storage->isTableReadOnly() };
+
+    if (/* auto * merge_tree_storage = */ dynamic_cast<MergeTreeData *>(storage.get()))
+        return ReplicatedTableDelay{};
+
+    const auto & logger = getLogger("ReplicatedTableDelay");
+    const auto & catalog = DatabaseCatalog::instance();
+    ReplicatedTableDelay info;
+
+    LOG_DEBUG(logger, "Checking replication delay of {} and its dependencies", storage->getStorageID().getNameForLogs());
+
+    /// Do a breadth-first search on all dependencies (direct and transitive) and get the maximum replication delay
+    /// No need for a visited set because ClickHouse does not allow cyclical dependencies and graph should be small
+    std::queue<StoragePtr> queue({ storage });
+    while (!queue.empty())
+    {
+        auto current = queue.front(); queue.pop();
+        if (!current)
+            continue;
+
+        if (auto * replicated = dynamic_cast<StorageReplicatedMergeTree *>(current.get()))
+        {
+            auto delay = replicated->getAbsoluteDelay();
+            info.is_replicated = true;
+            info.max_absolute_delay = std::max(info.max_absolute_delay, delay);
+            info.is_readonly = info.is_readonly || replicated->isTableReadOnly();
+            LOG_TRACE(logger, "Found ReplicatedMergeTree dependency {} with delay of {} seconds",
+                current->getStorageID().getNameForLogs(), delay);
+        }
+
+        for (const auto & dependency : catalog.getReferentialDependencies(current->getStorageID()))
+            queue.push(catalog.tryGetTable(dependency, context));
+    }
+
+    LOG_DEBUG(logger, "Replication delay of {} is {} seconds", storage->getStorageID().getNameForLogs(), info.max_absolute_delay);
+    return info;
+}
+
+}

--- a/src/Interpreters/ReplicatedTableDelay.h
+++ b/src/Interpreters/ReplicatedTableDelay.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <ctime>
+
+#include <Interpreters/Context_fwd.h>
+#include <Storages/IStorage_fwd.h>
+
+namespace DB
+{
+
+struct ReplicatedTableDelay
+{
+    time_t max_absolute_delay = 0;
+    bool is_replicated = false;
+    bool is_readonly = false;
+};
+
+/// Traverse referential dependencies of a storage (e.g. View -> ReplicatedMergeTree)
+/// and aggregate delay/readonly info across all discovered ReplicatedMergeTree tables.
+ReplicatedTableDelay getReplicatedDelay(const StoragePtr & storage, ContextPtr context);
+
+}

--- a/src/Server/TCPHandler.cpp
+++ b/src/Server/TCPHandler.cpp
@@ -25,6 +25,7 @@
 #include <Interpreters/AsynchronousInsertQueue.h>
 #include <Interpreters/DatabaseCatalog.h>
 #include <Interpreters/InternalTextLogsQueue.h>
+#include <Interpreters/ReplicatedTableDelay.h>
 #include <Interpreters/Session.h>
 #include <Interpreters/Squashing.h>
 #include <Interpreters/TablesStatus.h>
@@ -1569,15 +1570,11 @@ void TCPHandler::processTablesStatusRequest()
         if (!table)
             continue;
 
-        TableStatus status;
-        if (auto * replicated_table = dynamic_cast<StorageReplicatedMergeTree *>(table.get()))
-        {
-            status.is_replicated = true;
-            status.absolute_delay = static_cast<UInt32>(replicated_table->getAbsoluteDelay());
-            status.is_readonly = replicated_table->isTableReadOnly();
-        }
-        else
-            status.is_replicated = false;
+        auto delay_info = getReplicatedDelay(table, context_to_resolve_table_names);
+        TableStatus status {
+            .is_replicated = delay_info.is_replicated,
+            .absolute_delay = static_cast<UInt32>(delay_info.max_absolute_delay),
+            .is_readonly = delay_info.is_readonly };
 
         response.table_states_by_id.emplace(table_name, std::move(status));
     }

--- a/tests/queries/0_stateless/04256_stale_replica_view_distributed_delay_check.sh
+++ b/tests/queries/0_stateless/04256_stale_replica_view_distributed_delay_check.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Tags: zookeeper, no-shared-merge-tree
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+set -u
+
+local_settings=(
+    --prefer_localhost_replica=1
+    --fallback_to_stale_replicas_for_distributed_queries=0
+    --max_replica_delay_for_distributed_queries=1)
+
+remote_settings=(
+    --prefer_localhost_replica=0
+    --fallback_to_stale_replicas_for_distributed_queries=0
+    --max_replica_delay_for_distributed_queries=1)
+
+expect_stale_error()
+{
+    local label="$1"
+    shift
+
+    local output
+    if output=$(${CLICKHOUSE_CLIENT} "$@" 2>&1); then
+        echo "FAIL: ${label} should have raised ALL_REPLICAS_ARE_STALE" >&2
+        exit 1
+    fi
+
+    if ! grep -q -E "ALL_REPLICAS_ARE_STALE|Code: 369" <<< "$output"; then
+        echo "FAIL: ${label} raised an unexpected error:" >&2
+        echo "$output" >&2
+        exit 1
+    fi
+}
+
+cleanup()
+{
+    ${CLICKHOUSE_CLIENT} --query="SYSTEM START REPLICATION QUEUES replicated2" >/dev/null 2>&1 || true
+    ${CLICKHOUSE_CLIENT} -n --query="
+        DROP TABLE IF EXISTS distributed_view_replicated2 SYNC;
+        DROP TABLE IF EXISTS distributed_replicated2 SYNC;
+        DROP VIEW IF EXISTS view_replicated2 SYNC;
+        DROP TABLE IF EXISTS replicated2 SYNC;
+        DROP TABLE IF EXISTS replicated1 SYNC;" >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+
+cleanup
+
+${CLICKHOUSE_CLIENT} -n --query="
+    CREATE TABLE replicated1 (n UInt64)
+        ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/03734_stale_delay_test', 'r1')
+        ORDER BY n;
+
+    CREATE TABLE replicated2 (n UInt64)
+        ENGINE = ReplicatedMergeTree('/clickhouse/tables/{database}/03734_stale_delay_test', 'r2')
+        ORDER BY n;
+
+    CREATE VIEW view_replicated2 AS SELECT * FROM replicated2;
+
+    CREATE TABLE distributed_replicated2 AS replicated2
+        ENGINE = Distributed('test_shard_localhost', currentDatabase(), 'replicated2');
+
+    CREATE TABLE distributed_view_replicated2 AS replicated2
+        ENGINE = Distributed('test_shard_localhost', currentDatabase(), 'view_replicated2');
+
+    SYSTEM STOP REPLICATION QUEUES replicated2;
+    INSERT INTO replicated1 VALUES (1), (2), (3);
+    SYSTEM SYNC REPLICA replicated2 PULL;"
+
+delay_ready=0
+for _ in {1..30}; do
+    delay_ready=$(${CLICKHOUSE_CLIENT} --query="SELECT count() FROM system.replicas WHERE database = currentDatabase() AND table = 'replicated2' AND absolute_delay >= 2" 2>/dev/null || true)
+    if [[ "$delay_ready" == "1" ]]; then
+        break
+    fi
+
+    sleep 1
+done
+
+if [[ "$delay_ready" != "1" ]]; then
+    echo "FAIL: replicated2 did not become stale" >&2
+    ${CLICKHOUSE_CLIENT} --query="SELECT database, table, absolute_delay, queue_size FROM system.replicas WHERE database = currentDatabase() AND table = 'replicated2'" >&2 || true
+    exit 1
+fi
+
+# ── Local path (prefer_localhost_replica=1) ──────────────────────────────────
+# The executing node is itself a replica; delay check happens in
+# SelectStreamFactory::createForShardImpl.
+
+expect_stale_error "[local] distributed_replicated2" "${local_settings[@]}" --query="SELECT * FROM distributed_replicated2"
+expect_stale_error "[local] distributed_view_replicated2" "${local_settings[@]}" --query="SELECT count() FROM distributed_view_replicated2"
+
+# ── Remote path (prefer_localhost_replica=0) ─────────────────────────────────
+# The coordinator asks the replica for its table status via TablesStatusRequest;
+# delay check happens in TCPHandler::processTablesStatusRequest.
+
+expect_stale_error "[remote] distributed_replicated2" "${remote_settings[@]}" --query="SELECT * FROM distributed_replicated2"
+expect_stale_error "[remote] distributed_view_replicated2" "${remote_settings[@]}" --query="SELECT count() FROM distributed_view_replicated2"


### PR DESCRIPTION
Fixes #105304.

cc @seandhaynes @c-end

Previously both the local path (`SelectStreamFactory::createForShardImpl`) and the remote path (`TCPHandler::processTablesStatusRequest`) only checked replication delay when the resolved table was directly a StorageReplicatedMergeTree. If the Distributed table targeted a View or MaterializedView wrapping a ReplicatedMergeTree, the dynamic_cast failed and the query would serve stale data without raising `ALL_REPLICAS_ARE_STALE`, even when the user explicitly set `max_replica_delay_for_distributed_queries` and `fallback_to_stale_replicas_for_distributed_queries`.

Extract a shared helper (`getReplicatedDelay`) that traverses the table's referential dependencies via `DatabaseCatalog` to discover underlying ReplicatedMergeTree tables, returning the maximum `absolute_delay` and aggregated readonly status. Wire it into both the local and remote paths so that Distributed over a View behaves identically to Distributed directly over a replicated table with respect to stale-replica checks.

A stateless test (`04256_stale_replica_view_distributed_delay_check.sh`) reproduces the bug across both paths.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix Distributed queries returning stale data when the target table is a View or MaterializedView over a ReplicatedMergeTree. The stale-replica delay check (`max_replica_delay_for_distributed_queries`, `fallback_to_stale_replicas_for_distributed_queries`) is now applied to the underlying replicated tables instead of being silently skipped.