### PR TITLE
CI: store changed_files for local run via praktika with --pr

### DIFF
--- a/ci/praktika/runner.py
+++ b/ci/praktika/runner.py
@@ -114,6 +114,14 @@ class Runner:
             WORKFLOW_CONFIG=workflow_config,
         ).dump()
 
+        if pr and pr > 0:
+            changed_files = GH.get_changed_files()
+            if changed_files is not None:
+                print(f"Storing {len(changed_files)} changed files in JOB_KV_DATA")
+                Info().store_kv_data("changed_files", changed_files)
+            else:
+                print("WARNING: Failed to fetch changed files for PR")
+
         Result.create_from(name=job.name, status=Result.Status.PENDING).dump()
 
     def _setup_env(self, _workflow, job):


### PR DESCRIPTION
When running a job locally via `python -m ci.praktika run ... --pr <N>`,
fetch the list of changed files via `gh pr view --json files` and store
them in `JOB_KV_DATA["changed_files"]`. This mirrors what real CI does,
so `Info().get_changed_files()` and any downstream logic that reads
`changed_files` from KV data behave the same locally as in CI.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.843`
<!-- ch-version-info:end -->