### PR TITLE
Fix stale-read race in test_keeper_snapshot_rotation_race

### DIFF
--- a/tests/integration/test_keeper_snapshot_rotation_race/test.py
+++ b/tests/integration/test_keeper_snapshot_rotation_race/test.py
@@ -135,6 +135,7 @@ def test_deterministic_rotation_race(started_cluster):
 
     # Seed data before stopping the lagger.
     leader_zk.create(prefix, b"basedata")
+    lagger_zk.sync(prefix)
     assert lagger_zk.get(prefix)[0] == b"basedata"
     stop_zk(lagger_zk)
 
@@ -359,6 +360,7 @@ def test_stable_recovery_under_write_load(started_cluster):
     lagger_zk = keeper_utils.get_fake_zk(started_cluster, lagger.name)
 
     leader_zk.create(prefix, b"basedata")
+    lagger_zk.sync(prefix)
     assert lagger_zk.get(prefix)[0] == b"basedata"
     stop_zk(lagger_zk)
 


### PR DESCRIPTION
## Problem

Both tests in `tests/integration/test_keeper_snapshot_rotation_race/test.py` open a fresh `leader_zk` and `lagger_zk` immediately after `_reset_keeper_storage` reboots the cluster, then do:

```python
leader_zk.create(prefix, b"basedata")
assert lagger_zk.get(prefix)[0] == b"basedata"
```

On a freshly-elected leader, the follower can return `NoNodeError` in the 0–1 ms window between leader quorum commit and follower apply. `KazooClientWithImplicitRetries.get` forwards through `KazooRetry`, whose `RETRY_EXCEPTIONS = (ConnectionLoss, OperationTimeoutError, ForceRetryError)` does not include `NoNodeError`, so the exception is raised straight to the test and the assert fails.

This affects both:
- `test_deterministic_rotation_race` at `test.py:138`
- `test_stable_recovery_under_write_load` at `test.py:362`

CIDB + play.clickhouse.com show 13 master/PR failures matching this fingerprint in the last 30 days across `amd_tsan`, `amd_msan`, and `amd_asan_ubsan, db disk, old analyzer`. Sample reports:

- https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?REF=master&sha=aa914354ce429b48674895974ae0e44f8c53ac8a&name_0=MasterCI&name_1=Integration%20tests%20%28amd_asan_ubsan%2C%20db%20disk%2C%20old%20analyzer%2C%205%2F6%29
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=1740310a38459a309261523b48e77f08ef37117b&name_0=MasterCI&name_1=Integration%20tests%20%28amd_tsan%2C%202%2F6%29

## Fix

Insert `lagger_zk.sync(prefix)` between the create and the get on both call sites. `sync` is a session-level barrier that forces the follower to catch up to the leader's commit index before the next read. Every other `lagger_zk` read in this file is already downstream of `verify_test_tree`, which begins with `leader_zk.sync(base)` + `lagging_zk.sync(base)` (`helpers/keeper_snapshot_utils.py:133-134`).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.860`
<!-- ch-version-info:end -->