### PR TITLE
Insert pipeline throtting based on current chunks

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -288,6 +288,7 @@
     \
     M(InsertedRows, "Number of rows INSERTed to all tables.", ValueType::Number) \
     M(InsertedBytes, "Number of bytes (uncompressed; for columns as they stored in memory) INSERTed to all tables.", ValueType::Bytes) \
+    M(InsertPipelineThrottled, "Number of times the INSERT pipeline output ports were throttled due to memory pressure (see setting `enable_insert_memory_throttle`).", ValueType::Number) \
     M(DelayedInserts, "Number of times the INSERT of a block to a MergeTree table was throttled due to high number of active data parts for partition.", ValueType::Number) \
     M(RejectedInserts, "Number of times the INSERT of a block to a MergeTree table was rejected with 'Too many parts' exception due to high number of active data parts for partition.", ValueType::Number) \
     M(DelayedInsertsMilliseconds, "Total number of milliseconds spent while the INSERT of a block to a MergeTree table was throttled due to high number of active data parts for partition.", ValueType::Milliseconds) \

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -7588,6 +7588,9 @@ Normally this setting should be set in user profile (users.xml or queries like `
 
 Note that initially (24.12) there was a server setting (`send_settings_to_client`), but latter it got replaced with this client setting, for better usability.
 )", 0) \
+    DECLARE(Bool, enable_insert_memory_throttle, false, R"(
+When enabled, the INSERT pipeline dynamically disables or re-enables output ports based on the current memory usage. Per-chunk memory cost is estimated from observed chunk sizes; throttling kicks in when the free memory budget can no longer accommodate all sink streams. This is a best-effort mitigation — memory used outside of the chunk flow (aggregations, joins, etc.) may still push the query over the limit, so `MEMORY_LIMIT_EXCEEDED` exceptions are not eliminated.
+)", 0) \
     DECLARE(Bool, allow_archive_path_syntax, true, R"(
 File/S3 engines/table function will parse paths with '::' as `<archive> :: <file>` if the archive has correct extension.
 )", 0) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -78,6 +78,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"enable_blob_storage_log_for_read_operations", false, false, "New setting to log blob storage read operations to system.blob_storage_log"},
             {"max_streams_for_union_step", 0, 0, "New setting to limit the number of simultaneously active data streams in a UNION step to reduce peak memory usage."},
             {"max_streams_for_union_step_to_max_threads_ratio", 0, 8, "New setting: the limit on simultaneously active streams in a UNION step is computed as min(max_streams_for_union_step, max_threads * max_streams_for_union_step_to_max_threads_ratio), either being 0 disables that input."},
+            {"enable_insert_memory_throttle", false, false, "New setting to throttle the INSERT pipeline based on memory usage."},
             {"send_table_structure_on_insert_with_inline_data", true, true, "New setting to control whether server sends table structure for INSERT queries with inline data."},
             {"query_plan_top_k_through_join", false, true, "New setting to enable a query-plan-level optimization that pushes ORDER BY ... LIMIT n through a LEFT/RIGHT join when the sort key only references the preserved side."},
             {"allow_experimental_unique_key", false, false, "New setting to gate the experimental UNIQUE KEY clause on MergeTree-family tables"},

--- a/src/Interpreters/InterpreterInsertQuery.cpp
+++ b/src/Interpreters/InterpreterInsertQuery.cpp
@@ -20,6 +20,7 @@
 #include <Interpreters/TranslateQualifiedNamesVisitor.h>
 #include <Interpreters/processColumnTransformers.h>
 #include <Interpreters/InterpreterSelectQueryAnalyzer.h>
+#include <Interpreters/ProcessList.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Interpreters/ClusterProxy/executeQuery.h>
 #include <Interpreters/Context.h>
@@ -35,6 +36,8 @@
 #include <Processors/Transforms/DeduplicationTokenTransforms.h>
 #include <Processors/Transforms/PlanSquashingTransform.h>
 #include <Processors/Transforms/ApplySquashingTransform.h>
+#include <Processors/Transforms/InsertMemoryThrottle.h>
+#include <Processors/MemoryAwareResizeProcessor.h>
 #include <Processors/Transforms/getSourceFromASTInsertQuery.h>
 #include <QueryPipeline/QueryPipelineBuilder.h>
 #include <Storages/MergeTree/MergeTreeData.h>
@@ -82,6 +85,7 @@ namespace Setting
     extern const SettingsUInt64 min_insert_block_size_bytes;
     extern const SettingsString insert_deduplication_token;
     extern const SettingsBool use_concurrency_control;
+    extern const SettingsBool enable_insert_memory_throttle;
     extern const SettingsSeconds lock_acquire_timeout;
     extern const SettingsUInt64 parallel_distributed_insert_select;
     extern const SettingsBool enable_parsing_to_custom_serialization;
@@ -444,6 +448,18 @@ QueryPipeline InterpreterInsertQuery::addInsertToSelectPipeline(ASTInsertQuery &
     });
 
     auto select_streams = pipeline.getNumStreams();
+
+    InsertMemoryThrottlePtr insert_memory_throttle;
+    if (context->getSettingsRef()[Setting::enable_insert_memory_throttle])
+    {
+        MemoryTracker * query_tracker = nullptr;
+        if (auto process_list_element = context->getProcessListElement())
+            query_tracker = process_list_element->getMemoryTracker();
+
+        auto mem_provider = std::make_shared<QueryMemoryProvider>(query_tracker);
+        insert_memory_throttle = std::make_shared<InsertMemoryThrottle>(mem_provider);
+    }
+
     if (select_streams != 1)
         pipeline.resize(1);
 
@@ -501,7 +517,20 @@ QueryPipeline InterpreterInsertQuery::addInsertToSelectPipeline(ASTInsertQuery &
 
     std::vector<Chain> sink_chains = insert_dependencies->createChainWithDependenciesForAllStreams();
 
-    pipeline.resize(insert_dependencies->getSinkStreamSize());
+    const size_t sink_stream_size = insert_dependencies->getSinkStreamSize();
+    if (insert_memory_throttle && sink_stream_size > 1)
+    {
+        auto memory_aware_resize = std::make_shared<MemoryAwareResizeProcessor>(
+            pipeline.getSharedHeader(),
+            pipeline.getNumStreams(),
+            sink_stream_size,
+            insert_memory_throttle);
+        pipeline.addTransform(std::move(memory_aware_resize));
+    }
+    else
+    {
+        pipeline.resize(sink_stream_size);
+    }
 
     if (should_squash)
     {

--- a/src/Processors/MemoryAwareResizeProcessor.cpp
+++ b/src/Processors/MemoryAwareResizeProcessor.cpp
@@ -48,7 +48,7 @@ void MemoryAwareResizeProcessor::updateAllowedOutputs()
     }
 }
 
-IProcessor::Status MemoryAwareResizeProcessor::prepare(const PortNumbers & updated_inputs, const PortNumbers & updated_outputs)
+IProcessor::Status MemoryAwareResizeProcessor::prepare(const UpdatedInputPorts & updated_inputs, const UpdatedOutputPorts & updated_outputs)
 {
     if (!initialized)
     {
@@ -87,7 +87,7 @@ IProcessor::Status MemoryAwareResizeProcessor::prepare(const PortNumbers & updat
         }
     }
 
-    /// if every active output is finished but inactive ones remain, 
+    /// if every active output is finished but inactive ones remain,
     /// expand `allowed_outputs` so the pipeline can drain
     if (allowed_outputs < output_ports.size())
     {

--- a/src/Processors/MemoryAwareResizeProcessor.cpp
+++ b/src/Processors/MemoryAwareResizeProcessor.cpp
@@ -177,7 +177,11 @@ IProcessor::Status MemoryAwareResizeProcessor::prepare(const UpdatedInputPorts &
 
         if (output_idx >= allowed_outputs)
         {
-            output_ports[output_idx].status = OutputStatus::NotActive;
+            /// port may have finished between being queued, do not set finished
+            /// otherwise the next `updateAllowedOutputs` expansion would re-count this output
+            auto & stale = output_ports[output_idx];
+            if (stale.status != OutputStatus::Finished)
+                stale.status = OutputStatus::NotActive;
             continue;
         }
 

--- a/src/Processors/MemoryAwareResizeProcessor.cpp
+++ b/src/Processors/MemoryAwareResizeProcessor.cpp
@@ -1,0 +1,219 @@
+#include <Processors/MemoryAwareResizeProcessor.h>
+#include <Common/logger_useful.h>
+
+namespace DB
+{
+
+MemoryAwareResizeProcessor::MemoryAwareResizeProcessor(
+    SharedHeader header,
+    size_t num_inputs,
+    size_t num_outputs,
+    InsertMemoryThrottlePtr throttle_)
+    : IProcessor(InputPorts(num_inputs, header), OutputPorts(num_outputs, header))
+    , throttle(std::move(throttle_))
+    , allowed_outputs(num_outputs)
+{
+}
+
+void MemoryAwareResizeProcessor::updateAllowedOutputs()
+{
+    if (!throttle)
+        return;
+
+    const size_t total = output_ports.empty() ? allowed_outputs : output_ports.size();
+    const size_t prev_allowed = allowed_outputs;
+    allowed_outputs = throttle->calculateAllowedOutputs(total, min_outputs);
+
+    /// Outputs we just re-enabled won't be re-notified by the executor, wake them up
+    if (allowed_outputs > prev_allowed && initialized)
+    {
+        for (size_t i = prev_allowed; i < allowed_outputs && i < output_ports.size(); ++i)
+        {
+            auto & output = output_ports[i];
+            if (output.port->isFinished())
+            {
+                if (output.status != OutputStatus::Finished)
+                {
+                    ++num_finished_outputs;
+                    output.status = OutputStatus::Finished;
+                }
+                continue;
+            }
+            if (output.status != OutputStatus::NeedData && output.port->canPush())
+            {
+                output.status = OutputStatus::NeedData;
+                waiting_outputs.push(i);
+            }
+        }
+    }
+}
+
+IProcessor::Status MemoryAwareResizeProcessor::prepare(const PortNumbers & updated_inputs, const PortNumbers & updated_outputs)
+{
+    if (!initialized)
+    {
+        initialized = true;
+
+        for (auto & input : inputs)
+            input_ports.push_back({.port = &input, .status = InputStatus::NotActive});
+
+        for (auto & output : outputs)
+            output_ports.push_back({.port = &output, .status = OutputStatus::NotActive});
+    }
+
+    updateAllowedOutputs();
+
+    for (const auto & output_number : updated_outputs)
+    {
+        auto & output = output_ports[output_number];
+        if (output.port->isFinished())
+        {
+            if (output.status != OutputStatus::Finished)
+            {
+                ++num_finished_outputs;
+                output.status = OutputStatus::Finished;
+            }
+
+            continue;
+        }
+
+        if (output_number < allowed_outputs && output.port->canPush())
+        {
+            if (output.status != OutputStatus::NeedData)
+            {
+                output.status = OutputStatus::NeedData;
+                waiting_outputs.push(output_number);
+            }
+        }
+    }
+
+    /// if every active output is finished but inactive ones remain, 
+    /// expand `allowed_outputs` so the pipeline can drain
+    if (allowed_outputs < output_ports.size())
+    {
+        bool any_active_alive = false;
+        for (size_t i = 0; i < allowed_outputs && i < output_ports.size(); ++i)
+        {
+            if (output_ports[i].status != OutputStatus::Finished)
+            {
+                any_active_alive = true;
+                break;
+            }
+        }
+        if (!any_active_alive)
+        {
+            for (size_t i = allowed_outputs; i < output_ports.size(); ++i)
+            {
+                auto & output = output_ports[i];
+                if (output.port->isFinished())
+                {
+                    if (output.status != OutputStatus::Finished)
+                    {
+                        ++num_finished_outputs;
+                        output.status = OutputStatus::Finished;
+                    }
+                    continue;
+                }
+                if (output.status != OutputStatus::NeedData && output.port->canPush())
+                {
+                    output.status = OutputStatus::NeedData;
+                    waiting_outputs.push(i);
+                }
+            }
+            allowed_outputs = output_ports.size();
+        }
+    }
+
+    if (!is_reading_started && !waiting_outputs.empty())
+    {
+        for (auto & input : inputs)
+            input.setNeeded();
+        is_reading_started = true;
+    }
+
+    if (num_finished_outputs == outputs.size())
+    {
+        for (auto & input : inputs)
+            input.close();
+
+        return Status::Finished;
+    }
+
+    for (const auto & input_number : updated_inputs)
+    {
+        auto & input = input_ports[input_number];
+        if (input.port->isFinished())
+        {
+            if (input.status != InputStatus::Finished)
+            {
+                input.status = InputStatus::Finished;
+                ++num_finished_inputs;
+            }
+            continue;
+        }
+
+        if (input.port->hasData())
+        {
+            if (input.status != InputStatus::HasData)
+            {
+                input.status = InputStatus::HasData;
+                inputs_with_data.push(input_number);
+            }
+        }
+    }
+
+    while (!waiting_outputs.empty() && !inputs_with_data.empty())
+    {
+        auto output_idx = waiting_outputs.front();
+        waiting_outputs.pop();
+
+        if (output_idx >= allowed_outputs)
+        {
+            output_ports[output_idx].status = OutputStatus::NotActive;
+            continue;
+        }
+
+        auto & waiting_output = output_ports[output_idx];
+
+        if (waiting_output.port->isFinished())
+        {
+            if (waiting_output.status != OutputStatus::Finished)
+            {
+                ++num_finished_outputs;
+                waiting_output.status = OutputStatus::Finished;
+            }
+            continue;
+        }
+
+        auto & input_with_data = input_ports[inputs_with_data.front()];
+        inputs_with_data.pop();
+
+        auto data = input_with_data.port->pullData();
+        if (throttle)
+            throttle->observeChunkBytes(data.chunk.bytes());
+        waiting_output.port->pushData(std::move(data));
+        input_with_data.status = InputStatus::NotActive;
+        waiting_output.status = OutputStatus::NotActive;
+
+        if (input_with_data.port->isFinished())
+        {
+            input_with_data.status = InputStatus::Finished;
+            ++num_finished_inputs;
+        }
+    }
+
+    if (num_finished_inputs == inputs.size())
+    {
+        for (auto & output : outputs)
+            output.finish();
+
+        return Status::Finished;
+    }
+
+    if (!waiting_outputs.empty())
+        return Status::NeedData;
+
+    return Status::PortFull;
+}
+
+}

--- a/src/Processors/MemoryAwareResizeProcessor.cpp
+++ b/src/Processors/MemoryAwareResizeProcessor.cpp
@@ -55,16 +55,23 @@ IProcessor::Status MemoryAwareResizeProcessor::prepare(const UpdatedInputPorts &
         initialized = true;
 
         for (auto & input : inputs)
+        {
+            input_port_index[&input] = input_ports.size();
             input_ports.push_back({.port = &input, .status = InputStatus::NotActive});
+        }
 
         for (auto & output : outputs)
+        {
+            output_port_index[&output] = output_ports.size();
             output_ports.push_back({.port = &output, .status = OutputStatus::NotActive});
+        }
     }
 
     updateAllowedOutputs();
 
-    for (const auto & output_number : updated_outputs)
+    for (const auto * output_port : updated_outputs)
     {
+        const auto output_number = output_port_index.at(output_port);
         auto & output = output_ports[output_number];
         if (output.port->isFinished())
         {
@@ -139,8 +146,9 @@ IProcessor::Status MemoryAwareResizeProcessor::prepare(const UpdatedInputPorts &
         return Status::Finished;
     }
 
-    for (const auto & input_number : updated_inputs)
+    for (const auto * input_port : updated_inputs)
     {
+        const auto input_number = input_port_index.at(input_port);
         auto & input = input_ports[input_number];
         if (input.port->isFinished())
         {

--- a/src/Processors/MemoryAwareResizeProcessor.cpp
+++ b/src/Processors/MemoryAwareResizeProcessor.cpp
@@ -1,8 +1,28 @@
 #include <Processors/MemoryAwareResizeProcessor.h>
 #include <Common/logger_useful.h>
+#include <Interpreters/Squashing.h>
 
 namespace DB
 {
+
+namespace
+{
+    size_t estimateChunkBytes(const Chunk & chunk)
+    {
+        size_t bytes = chunk.bytes();
+        if (bytes > 0)
+            return bytes;
+        /// Between PlanSquashingTransform and ApplySquashingTransform the outer Chunk
+        /// carries `ChunksToSquash` as chunk info: the real columns live in `info->data`
+        /// and `Chunk::bytes()` reports 0. Pull the byte size out of the inner chunks.
+        if (auto squashing_info = chunk.getChunkInfos().get<ChunksToSquash>())
+        {
+            for (const auto & entry : squashing_info->data)
+                bytes += entry.chunk.bytes();
+        }
+        return bytes;
+    }
+}
 
 MemoryAwareResizeProcessor::MemoryAwareResizeProcessor(
     SharedHeader header,
@@ -11,7 +31,10 @@ MemoryAwareResizeProcessor::MemoryAwareResizeProcessor(
     InsertMemoryThrottlePtr throttle_)
     : IProcessor(InputPorts(num_inputs, header), OutputPorts(num_outputs, header))
     , throttle(std::move(throttle_))
-    , allowed_outputs(num_outputs)
+    /// Start with just `min_outputs` active — we have no chunk-size estimate yet, so we cannot
+    /// safely fan out. `updateAllowedOutputs` expands the active set on each `prepare` once it
+    /// has observed at least one chunk and confirmed headroom.
+    , allowed_outputs(throttle ? min_outputs : num_outputs)
 {
 }
 
@@ -202,7 +225,7 @@ IProcessor::Status MemoryAwareResizeProcessor::prepare(const UpdatedInputPorts &
 
         auto data = input_with_data.port->pullData();
         if (throttle)
-            throttle->observeChunkBytes(data.chunk.bytes());
+            throttle->observeChunkBytes(estimateChunkBytes(data.chunk));
         waiting_output.port->pushData(std::move(data));
         input_with_data.status = InputStatus::NotActive;
         waiting_output.status = OutputStatus::NotActive;

--- a/src/Processors/MemoryAwareResizeProcessor.h
+++ b/src/Processors/MemoryAwareResizeProcessor.h
@@ -22,7 +22,7 @@ public:
 
     String getName() const override { return "MemoryAwareResize"; }
 
-    Status prepare(const PortNumbers &, const PortNumbers &) override;
+    Status prepare(const UpdatedInputPorts &, const UpdatedOutputPorts &) override;
 
 private:
     InsertMemoryThrottlePtr throttle;

--- a/src/Processors/MemoryAwareResizeProcessor.h
+++ b/src/Processors/MemoryAwareResizeProcessor.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <queue>
+#include <Processors/IProcessor.h>
+#include <Processors/Port.h>
+#include <Processors/Transforms/InsertMemoryThrottle.h>
+
+namespace DB
+{
+
+/// ResizeProcessor variant that activates or deactivates output ports based on
+/// the current memory pressure reported by an InsertMemoryThrottle
+/// Per-chunk memory cost is learned from the chunks passing through this processor
+class MemoryAwareResizeProcessor final : public IProcessor
+{
+public:
+    MemoryAwareResizeProcessor(
+        SharedHeader header,
+        size_t num_inputs,
+        size_t num_outputs,
+        InsertMemoryThrottlePtr throttle_);
+
+    String getName() const override { return "MemoryAwareResize"; }
+
+    Status prepare(const PortNumbers &, const PortNumbers &) override;
+
+private:
+    InsertMemoryThrottlePtr throttle;
+
+    size_t allowed_outputs;
+    static constexpr size_t min_outputs = 1;
+
+    size_t num_finished_inputs = 0;
+    size_t num_finished_outputs = 0;
+    std::queue<UInt64> waiting_outputs;
+    std::queue<UInt64> inputs_with_data;
+    bool initialized = false;
+    bool is_reading_started = false;
+
+    enum class OutputStatus : uint8_t
+    {
+        NotActive,
+        NeedData,
+        Finished,
+    };
+
+    enum class InputStatus : uint8_t
+    {
+        NotActive,
+        HasData,
+        Finished,
+    };
+
+    struct InputPortWithStatus
+    {
+        InputPort * port;
+        InputStatus status;
+    };
+
+    struct OutputPortWithStatus
+    {
+        OutputPort * port;
+        OutputStatus status;
+    };
+
+    std::vector<InputPortWithStatus> input_ports;
+    std::vector<OutputPortWithStatus> output_ports;
+
+    void updateAllowedOutputs();
+};
+
+}

--- a/src/Processors/MemoryAwareResizeProcessor.h
+++ b/src/Processors/MemoryAwareResizeProcessor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <queue>
+#include <unordered_map>
 #include <Processors/IProcessor.h>
 #include <Processors/Port.h>
 #include <Processors/Transforms/InsertMemoryThrottle.h>
@@ -65,6 +66,8 @@ private:
 
     std::vector<InputPortWithStatus> input_ports;
     std::vector<OutputPortWithStatus> output_ports;
+    std::unordered_map<const InputPort *, UInt64> input_port_index;
+    std::unordered_map<const OutputPort *, UInt64> output_port_index;
 
     void updateAllowedOutputs();
 };

--- a/src/Processors/Transforms/InsertMemoryThrottle.cpp
+++ b/src/Processors/Transforms/InsertMemoryThrottle.cpp
@@ -81,9 +81,7 @@ void InsertMemoryThrottle::observeChunkBytes(size_t bytes)
         {
             const double smoothed = EWMA_ALPHA * static_cast<double>(sample)
                                   + (1.0 - EWMA_ALPHA) * static_cast<double>(prev);
-            next = static_cast<Int64>(smoothed);
-            if (next < 1)
-                next = 1;
+            next = std::max<Int64>(1, static_cast<Int64>(smoothed));
         }
     }
     while (!avg_chunk_bytes.compare_exchange_weak(prev, next, std::memory_order_relaxed));

--- a/src/Processors/Transforms/InsertMemoryThrottle.cpp
+++ b/src/Processors/Transforms/InsertMemoryThrottle.cpp
@@ -1,0 +1,132 @@
+#include <Processors/Transforms/InsertMemoryThrottle.h>
+
+#include <Common/CurrentThread.h>
+#include <Common/ProfileEvents.h>
+#include <Common/logger_useful.h>
+
+
+namespace ProfileEvents
+{
+    extern const Event InsertPipelineThrottled;
+}
+
+
+namespace DB
+{
+
+MemorySnapshot QueryMemoryProvider::get() const
+{
+    MemorySnapshot result;
+
+    MemoryTracker * current_tracker = tracker;
+    if (!current_tracker)
+        current_tracker = CurrentThread::getMemoryTracker();
+
+    if (!current_tracker)
+        return result;
+
+    /// walk the tracker hierarchy and pick the tightest (lowest free) hard limit
+    static constexpr int MAX_ITERATIONS = 10;
+    int iterations = 0;
+
+    Int64 min_free_memory = std::numeric_limits<Int64>::max();
+    bool found_any_limit = false;
+
+    while (current_tracker && iterations < MAX_ITERATIONS)
+    {
+        Int64 limit = current_tracker->getHardLimit();
+        if (limit > 0)
+        {
+            Int64 used = current_tracker->get();
+            Int64 free = limit - used;
+
+            if (free < min_free_memory)
+            {
+                min_free_memory = free;
+                result.used_bytes = used;
+                result.hard_limit_bytes = limit;
+                found_any_limit = true;
+            }
+        }
+
+        current_tracker = current_tracker->getParent();
+        ++iterations;
+    }
+
+    if (!found_any_limit)
+    {
+        result.used_bytes = 0;
+        result.hard_limit_bytes = 0;
+    }
+
+    return result;
+}
+
+
+void InsertMemoryThrottle::observeChunkBytes(size_t bytes)
+{
+    if (bytes == 0)
+        return;
+
+    const Int64 sample = static_cast<Int64>(bytes);
+    Int64 prev = avg_chunk_bytes.load(std::memory_order_relaxed);
+    Int64 next;
+    do
+    {
+        if (prev == 0)
+        {
+            next = sample;
+        }
+        else
+        {
+            const double smoothed = EWMA_ALPHA * static_cast<double>(sample)
+                                  + (1.0 - EWMA_ALPHA) * static_cast<double>(prev);
+            next = static_cast<Int64>(smoothed);
+            if (next < 1)
+                next = 1;
+        }
+    }
+    while (!avg_chunk_bytes.compare_exchange_weak(prev, next, std::memory_order_relaxed));
+}
+
+
+size_t InsertMemoryThrottle::calculateAllowedOutputs(size_t max_outputs, size_t min_outputs)
+{
+    MemorySnapshot mem = mem_provider->get();
+
+    if (mem.hard_limit_bytes <= 0)
+        return max_outputs;
+
+    Int64 free_memory = mem.hard_limit_bytes - mem.used_bytes;
+    if (free_memory <= 0)
+    {
+        ProfileEvents::increment(ProfileEvents::InsertPipelineThrottled);
+        LOG_DEBUG(::getLogger("InsertMemoryThrottle"),
+            "Memory limit reached: used {} >= limit {}, throttling to {} outputs",
+            mem.used_bytes, mem.hard_limit_bytes, min_outputs);
+        return min_outputs;
+    }
+
+    Int64 chunk_bytes = avg_chunk_bytes.load(std::memory_order_relaxed);
+    if (chunk_bytes <= 0)
+        return max_outputs;
+
+    Int64 inflated = std::max(
+        static_cast<Int64>(1),
+        static_cast<Int64>(static_cast<double>(chunk_bytes) * safety_factor));
+    size_t calculated_outputs = static_cast<size_t>(free_memory / inflated);
+    size_t allowed = std::clamp(calculated_outputs, min_outputs, max_outputs);
+
+    if (allowed < max_outputs)
+    {
+        ProfileEvents::increment(ProfileEvents::InsertPipelineThrottled);
+        LOG_DEBUG(::getLogger("InsertMemoryThrottle"),
+            "Throttling: free_memory={} bytes, avg_chunk_bytes={} bytes, safety_factor={:.1f}, "
+            "allowed_outputs={}/{}",
+            free_memory, chunk_bytes, safety_factor, allowed, max_outputs);
+    }
+
+    return allowed;
+}
+
+}

--- a/src/Processors/Transforms/InsertMemoryThrottle.h
+++ b/src/Processors/Transforms/InsertMemoryThrottle.h
@@ -35,19 +35,14 @@ private:
 };
 
 
-/// Memory-based throttle for INSERT pipelines
-/// Estimates per-chunk cost from observed `Chunk::bytes()` (EWMA) and throttles
-/// parallelism so that `safety_factor * avg_chunk_bytes * allowed_outputs` stays
-/// below the free memory budget
+/// Estimates per-chunk cost from chunk size and throttles parallelism so that
+/// `safety_factor * avg_chunk_bytes * allowed_outputs` stays below the free memory
 class InsertMemoryThrottle
 {
 public:
-    /// Multiplier applied to the average chunk size to account for downstream
-    /// amplification not seen at the resize point
     static constexpr double DEFAULT_SAFETY_FACTOR = 4.0;
 
-    /// Smoothing factor of the chunk-bytes EWMA: higher = react faster to new chunks,
-    /// lower = smoother estimate
+    /// Smoothing factor of the chunk-bytes EWMA, adapt to change in size
     static constexpr double EWMA_ALPHA = 0.25;
 
     explicit InsertMemoryThrottle(

--- a/src/Processors/Transforms/InsertMemoryThrottle.h
+++ b/src/Processors/Transforms/InsertMemoryThrottle.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <atomic>
+#include <memory>
+
+#include <base/types.h>
+#include <Common/MemoryTracker.h>
+
+
+namespace DB
+{
+
+struct MemorySnapshot
+{
+    Int64 used_bytes = 0;
+    Int64 hard_limit_bytes = 0;  /// 0 = unlimited
+};
+
+class IQueryMemoryProvider
+{
+public:
+    virtual MemorySnapshot get() const = 0;
+    virtual ~IQueryMemoryProvider() = default;
+};
+
+class QueryMemoryProvider : public IQueryMemoryProvider
+{
+public:
+    explicit QueryMemoryProvider(MemoryTracker * tracker_) : tracker(tracker_) {}
+
+    MemorySnapshot get() const override;
+
+private:
+    MemoryTracker * tracker = nullptr;
+};
+
+
+/// Memory-based throttle for INSERT pipelines
+/// Estimates per-chunk cost from observed `Chunk::bytes()` (EWMA) and throttles
+/// parallelism so that `safety_factor * avg_chunk_bytes * allowed_outputs` stays
+/// below the free memory budget
+class InsertMemoryThrottle
+{
+public:
+    /// Multiplier applied to the average chunk size to account for downstream
+    /// amplification not seen at the resize point
+    static constexpr double DEFAULT_SAFETY_FACTOR = 4.0;
+
+    /// Smoothing factor of the chunk-bytes EWMA: higher = react faster to new chunks,
+    /// lower = smoother estimate
+    static constexpr double EWMA_ALPHA = 0.25;
+
+    explicit InsertMemoryThrottle(
+        std::shared_ptr<IQueryMemoryProvider> mem_provider_,
+        double safety_factor_ = DEFAULT_SAFETY_FACTOR)
+        : mem_provider(std::move(mem_provider_))
+        , safety_factor(safety_factor_)
+    {}
+
+    void observeChunkBytes(size_t bytes);
+
+    size_t calculateAllowedOutputs(size_t max_outputs, size_t min_outputs = 1);
+
+    Int64 getAverageChunkBytes() const { return avg_chunk_bytes.load(std::memory_order_relaxed); }
+
+private:
+    std::shared_ptr<IQueryMemoryProvider> mem_provider;
+    double safety_factor;
+
+    std::atomic<Int64> avg_chunk_bytes{0};
+};
+
+using InsertMemoryThrottlePtr = std::shared_ptr<InsertMemoryThrottle>;
+
+}

--- a/tests/integration/test_insert_memory_throttle/configs/memory_limit.xml
+++ b/tests/integration/test_insert_memory_throttle/configs/memory_limit.xml
@@ -1,0 +1,3 @@
+<clickhouse>
+    <max_server_memory_usage>500000000</max_server_memory_usage>
+</clickhouse>

--- a/tests/integration/test_insert_memory_throttle/test.py
+++ b/tests/integration/test_insert_memory_throttle/test.py
@@ -9,6 +9,7 @@ node = cluster.add_instance(
     "node",
     main_configs=["configs/memory_limit.xml"],
     mem_limit="600m",
+    stay_alive=True,
 )
 
 

--- a/tests/integration/test_insert_memory_throttle/test.py
+++ b/tests/integration/test_insert_memory_throttle/test.py
@@ -23,11 +23,10 @@ def started_cluster():
 
 @pytest.fixture(autouse=True)
 def cleanup(started_cluster):
+    node.restart_clickhouse(kill=True)
     node.query("DROP TABLE IF EXISTS src")
     node.query("DROP TABLE IF EXISTS dst")
     yield
-    node.query("DROP TABLE IF EXISTS src")
-    node.query("DROP TABLE IF EXISTS dst")
 
 
 def create_tables():

--- a/tests/integration/test_insert_memory_throttle/test.py
+++ b/tests/integration/test_insert_memory_throttle/test.py
@@ -1,0 +1,130 @@
+import uuid
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/memory_limit.xml"],
+    mem_limit="600m",
+)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def cleanup(started_cluster):
+    node.query("DROP TABLE IF EXISTS src")
+    node.query("DROP TABLE IF EXISTS dst")
+    yield
+    node.query("DROP TABLE IF EXISTS src")
+    node.query("DROP TABLE IF EXISTS dst")
+
+
+def create_tables():
+    node.query(
+        """
+        CREATE TABLE src (x UInt64, s String DEFAULT repeat('x', 1000)) ENGINE = MergeTree ORDER BY x;
+        CREATE TABLE dst (x UInt64, s String) ENGINE = MergeTree ORDER BY x;
+        INSERT INTO src (x) SELECT number FROM numbers(100000);
+        """
+    )
+
+
+def run_insert(query_id, enable_throttle, memory_limit="300M"):
+    node.query(
+        f"""
+        INSERT INTO dst SELECT * FROM src
+        SETTINGS
+            enable_insert_memory_throttle = {int(enable_throttle)},
+            max_insert_threads = 4,
+            max_memory_usage = '{memory_limit}'
+        """,
+        query_id=query_id,
+    )
+
+
+def test_throttle_limits_parallelism(started_cluster):
+    create_tables()
+    qid = f"throttle_parallel_{uuid.uuid4().hex}"
+
+    run_insert(qid, enable_throttle=True)
+
+    node.query("SYSTEM FLUSH LOGS")
+
+    # throttle should have restricted outputs (allowed_outputs < total)
+    throttle_msgs = node.query(
+        f"""
+        SELECT count()
+        FROM system.text_log
+        WHERE query_id = '{qid}'
+            AND logger_name = 'InsertMemoryThrottle'
+            AND message LIKE '%Throttling%allowed_outputs=%'
+        """
+    ).strip()
+
+    assert int(throttle_msgs) > 0, "Expected throttle to restrict parallelism under memory pressure"
+
+    # verify throttle limited to fewer than max outputs
+    allowed = node.query(
+        f"""
+        SELECT extract(message, 'allowed_outputs=(\\d+)')
+        FROM system.text_log
+        WHERE query_id = '{qid}'
+            AND logger_name = 'InsertMemoryThrottle'
+            AND message LIKE '%Throttling%'
+        LIMIT 1
+        """
+    ).strip()
+
+    assert int(allowed) < 4, f"Expected allowed_outputs < 4 (total), got {allowed}"
+
+    assert node.query("SELECT count() FROM dst").strip() == "100000"
+
+
+def test_no_throttle_when_disabled(started_cluster):
+    create_tables()
+    qid = f"no_throttle_{uuid.uuid4().hex}"
+
+    run_insert(qid, enable_throttle=False)
+
+    node.query("SYSTEM FLUSH LOGS")
+
+    throttle_msgs = node.query(
+        f"""
+        SELECT count()
+        FROM system.text_log
+        WHERE query_id = '{qid}'
+            AND logger_name = 'InsertMemoryThrottle'
+        """
+    ).strip()
+
+    assert int(throttle_msgs) == 0, "No throttle messages expected when disabled"
+    assert node.query("SELECT count() FROM dst").strip() == "100000"
+
+
+def test_data_correctness_under_throttle(started_cluster):
+    """All rows and checksums survive the throttled pipeline."""
+    create_tables()
+    qid = f"correctness_{uuid.uuid4().hex}"
+
+    run_insert(qid, enable_throttle=True)
+
+    ok = node.query(
+        "SELECT (SELECT sum(x) FROM dst) = (SELECT sum(x) FROM src)"
+    ).strip()
+    assert ok == "1", "Checksum mismatch between src and dst"
+
+    ok = node.query(
+        "SELECT (SELECT count() FROM dst) = (SELECT count() FROM src)"
+    ).strip()
+    assert ok == "1", "Row count mismatch between src and dst"

--- a/tests/integration/test_insert_memory_throttle/test.py
+++ b/tests/integration/test_insert_memory_throttle/test.py
@@ -53,62 +53,36 @@ def run_insert(query_id, enable_throttle, memory_limit="300M"):
     )
 
 
-def test_throttle_limits_parallelism(started_cluster):
+def get_throttle_event_value():
+    raw = node.query(
+        "SELECT value FROM system.events WHERE event = 'InsertPipelineThrottled'"
+    ).strip()
+    return int(raw) if raw else 0
+
+
+def test_throttle_event_fires_when_enabled(started_cluster):
     create_tables()
     qid = f"throttle_parallel_{uuid.uuid4().hex}"
 
+    before = get_throttle_event_value()
     run_insert(qid, enable_throttle=True)
+    after = get_throttle_event_value()
 
-    node.query("SYSTEM FLUSH LOGS")
-
-    # throttle should have restricted outputs (allowed_outputs < total)
-    throttle_msgs = node.query(
-        f"""
-        SELECT count()
-        FROM system.text_log
-        WHERE query_id = '{qid}'
-            AND logger_name = 'InsertMemoryThrottle'
-            AND message LIKE '%Throttling%allowed_outputs=%'
-        """
-    ).strip()
-
-    assert int(throttle_msgs) > 0, "Expected throttle to restrict parallelism under memory pressure"
-
-    # verify throttle limited to fewer than max outputs
-    allowed = node.query(
-        f"""
-        SELECT extract(message, 'allowed_outputs=(\\d+)')
-        FROM system.text_log
-        WHERE query_id = '{qid}'
-            AND logger_name = 'InsertMemoryThrottle'
-            AND message LIKE '%Throttling%'
-        LIMIT 1
-        """
-    ).strip()
-
-    assert int(allowed) < 4, f"Expected allowed_outputs < 4 (total), got {allowed}"
-
+    assert after != before, \
+        "InsertPipelineThrottled should have changed under memory pressure"
     assert node.query("SELECT count() FROM dst").strip() == "100000"
 
 
-def test_no_throttle_when_disabled(started_cluster):
+def test_throttle_event_unchanged_when_disabled(started_cluster):
     create_tables()
     qid = f"no_throttle_{uuid.uuid4().hex}"
 
+    before = get_throttle_event_value()
     run_insert(qid, enable_throttle=False)
+    after = get_throttle_event_value()
 
-    node.query("SYSTEM FLUSH LOGS")
-
-    throttle_msgs = node.query(
-        f"""
-        SELECT count()
-        FROM system.text_log
-        WHERE query_id = '{qid}'
-            AND logger_name = 'InsertMemoryThrottle'
-        """
-    ).strip()
-
-    assert int(throttle_msgs) == 0, "No throttle messages expected when disabled"
+    assert after == before, \
+        "InsertPipelineThrottled must not change when the throttle is disabled"
     assert node.query("SELECT count() FROM dst").strip() == "100000"
 
 

--- a/tests/queries/0_stateless/04245_insert_memory_throttle.reference
+++ b/tests/queries/0_stateless/04245_insert_memory_throttle.reference
@@ -1,0 +1,7 @@
+--- throttle enabled ---
+1
+--- throttle disabled ---
+0
+--- correctness ---
+10000
+1

--- a/tests/queries/0_stateless/04245_insert_memory_throttle.sh
+++ b/tests/queries/0_stateless/04245_insert_memory_throttle.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04245_insert_memory_throttle.sh
+++ b/tests/queries/0_stateless/04245_insert_memory_throttle.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+
+$CLICKHOUSE_CLIENT --query="CREATE TABLE src (x UInt64, s String) ENGINE = MergeTree ORDER BY x"
+$CLICKHOUSE_CLIENT --query="CREATE TABLE dst (x UInt64, s String) ENGINE = MergeTree ORDER BY x"
+$CLICKHOUSE_CLIENT --query="INSERT INTO src SELECT number, toString(number) FROM numbers(10000)"
+
+# MemoryAwareResize should appear in the pipeline
+echo "--- throttle enabled ---"
+$CLICKHOUSE_CLIENT --query="EXPLAIN PIPELINE INSERT INTO dst SELECT * FROM src SETTINGS enable_insert_memory_throttle = 1, max_insert_threads = 4" | grep -c "MemoryAwareResize"
+
+# here plain Resize is used instead
+echo "--- throttle disabled ---"
+$CLICKHOUSE_CLIENT --query="EXPLAIN PIPELINE INSERT INTO dst SELECT * FROM src SETTINGS enable_insert_memory_throttle = 0, max_insert_threads = 4" | grep -c "MemoryAwareResize"
+
+# all rows survive the throttled pipeline
+echo "--- correctness ---"
+$CLICKHOUSE_CLIENT --query="INSERT INTO dst SELECT * FROM src SETTINGS enable_insert_memory_throttle = 1, max_insert_threads = 4"
+$CLICKHOUSE_CLIENT --query="SELECT count() FROM dst"
+$CLICKHOUSE_CLIENT --query="SELECT sum(x) = (SELECT sum(x) FROM src) AS ok FROM dst"
+
+$CLICKHOUSE_CLIENT --query="DROP TABLE src"
+$CLICKHOUSE_CLIENT --query="DROP TABLE dst"

--- a/tests/queries/0_stateless/04245_insert_memory_throttle.sh
+++ b/tests/queries/0_stateless/04245_insert_memory_throttle.sh
@@ -10,15 +10,15 @@ $CLICKHOUSE_CLIENT --query="INSERT INTO src SELECT number, toString(number) FROM
 
 # MemoryAwareResize should appear in the pipeline
 echo "--- throttle enabled ---"
-$CLICKHOUSE_CLIENT --query="EXPLAIN PIPELINE INSERT INTO dst SELECT * FROM src SETTINGS enable_insert_memory_throttle = 1, max_insert_threads = 4" | grep -c "MemoryAwareResize"
+$CLICKHOUSE_CLIENT --query="EXPLAIN PIPELINE INSERT INTO dst SELECT * FROM src SETTINGS enable_insert_memory_throttle = 1, max_insert_threads = 4, max_threads = 4" | grep -c "MemoryAwareResize"
 
 # here plain Resize is used instead
 echo "--- throttle disabled ---"
-$CLICKHOUSE_CLIENT --query="EXPLAIN PIPELINE INSERT INTO dst SELECT * FROM src SETTINGS enable_insert_memory_throttle = 0, max_insert_threads = 4" | grep -c "MemoryAwareResize"
+$CLICKHOUSE_CLIENT --query="EXPLAIN PIPELINE INSERT INTO dst SELECT * FROM src SETTINGS enable_insert_memory_throttle = 0, max_insert_threads = 4, max_threads = 4" | grep -c "MemoryAwareResize"
 
 # all rows survive the throttled pipeline
 echo "--- correctness ---"
-$CLICKHOUSE_CLIENT --query="INSERT INTO dst SELECT * FROM src SETTINGS enable_insert_memory_throttle = 1, max_insert_threads = 4"
+$CLICKHOUSE_CLIENT --query="INSERT INTO dst SELECT * FROM src SETTINGS enable_insert_memory_throttle = 1, max_insert_threads = 4, max_threads = 4"
 $CLICKHOUSE_CLIENT --query="SELECT count() FROM dst"
 $CLICKHOUSE_CLIENT --query="SELECT sum(x) = (SELECT sum(x) FROM src) AS ok FROM dst"
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Implements insert process throttling based on chunk size to avoid OOMs during inserting
