### PR TITLE
Fix CANNOT_CONVERT_TYPE for Merge over Merge over Distributed with distributed_group_by_no_merge=1

### DIFF
--- a/src/Storages/StorageDistributed.cpp
+++ b/src/Storages/StorageDistributed.cpp
@@ -509,16 +509,17 @@ QueryProcessingStage::Enum StorageDistributed::getQueryProcessingStage(
             return QueryProcessingStage::WithMergeableStateAfterAggregation;
         }
 
-        /// NOTE: distributed_group_by_no_merge=1 does not respect distributed_push_down_limit
-        /// (since in this case queries processed separately and the initiator is just a proxy in this case).
+        /// distributed_group_by_no_merge=1 does not respect distributed_push_down_limit:
+        /// shards process the query independently and the initiator just concatenates.
         ///
-        /// We always return Complete here regardless of to_stage, because with
-        /// distributed_group_by_no_merge=1 each shard processes the full query
-        /// independently and the initiator just concatenates results.
-        /// The caller may request a lower stage (e.g. StorageMerge passes
-        /// WithMergeableState when it wraps multiple tables), but that's fine —
-        /// the caller handles storage_stage > processed_stage correctly.
-        return QueryProcessingStage::Complete;
+        /// Each shard processes to Complete, so report at least Complete. Use max with
+        /// to_stage so a caller asking for a higher stage (WithMergeableStateAfterAggregation
+        /// or WithMergeableStateAfterAggregationAndLimit) is not silently downgraded.
+        /// If a caller asks for a lower stage (e.g. StorageMerge passing WithMergeableState
+        /// for a multi-table merge), `read()` still honors `processed_stage` and sends the
+        /// right query to shards; StorageMerge caps its own advertised stage so this
+        /// Complete does not leak into outer headers.
+        return std::max(to_stage, QueryProcessingStage::Complete);
     }
 
     /// Nested distributed query cannot return Complete stage,

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -420,13 +420,19 @@ QueryProcessingStage::Enum StorageMerge::getQueryProcessingStage(
 
     auto stage = selected_table_size == 1 ? stage_in_source_tables : std::min(stage_in_source_tables, QueryProcessingStage::WithMergeableState);
 
-    /// Caller asked for at most WithMergeableState but a child reported a higher stage
+    /// Caller asked for WithMergeableState but a child reported a higher stage
     /// (e.g. Distributed with `distributed_group_by_no_merge=1` reports Complete).
     /// Cap to WithMergeableState so we don't emit finalized values where the caller
     /// expects AggregateFunction states - otherwise `convertAndFilterSourceStream`
     /// throws CANNOT_CONVERT_TYPE. The multi-table branch above already caps at
     /// WithMergeableState for the same reason; this extends it to the single-table branch.
-    if (to_stage <= QueryProcessingStage::WithMergeableState && stage > to_stage)
+    ///
+    /// Only when the caller asked for exactly WithMergeableState: for FetchColumns the
+    /// caller wants raw columns, the child's higher stage (Complete from a single-shard
+    /// Distributed) is fine, and raising it to WithMergeableState routes the child onto a
+    /// path that keeps the analyzer-qualified `__table1.name` header (THERE_IS_NO_COLUMN
+    /// under serialize_query_plan).
+    if (to_stage == QueryProcessingStage::WithMergeableState && stage > to_stage)
         stage = QueryProcessingStage::WithMergeableState;
     return stage;
 }

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -418,7 +418,17 @@ QueryProcessingStage::Enum StorageMerge::getQueryProcessingStage(
         }
     }
 
-    return selected_table_size == 1 ? stage_in_source_tables : std::min(stage_in_source_tables, QueryProcessingStage::WithMergeableState);
+    auto stage = selected_table_size == 1 ? stage_in_source_tables : std::min(stage_in_source_tables, QueryProcessingStage::WithMergeableState);
+
+    /// Caller asked for at most WithMergeableState but a child reported a higher stage
+    /// (e.g. Distributed with `distributed_group_by_no_merge=1` reports Complete).
+    /// Cap to WithMergeableState so we don't emit finalized values where the caller
+    /// expects AggregateFunction states - otherwise `convertAndFilterSourceStream`
+    /// throws CANNOT_CONVERT_TYPE. The multi-table branch above already caps at
+    /// WithMergeableState for the same reason; this extends it to the single-table branch.
+    if (to_stage <= QueryProcessingStage::WithMergeableState && stage > to_stage)
+        stage = QueryProcessingStage::WithMergeableState;
+    return stage;
 }
 
 VirtualColumnsDescription StorageMerge::createVirtuals()

--- a/tests/queries/0_stateless/04256_merge_distributed_group_by_no_merge_nested.reference
+++ b/tests/queries/0_stateless/04256_merge_distributed_group_by_no_merge_nested.reference
@@ -1,0 +1,40 @@
+-- { echoOn }
+-- 1. Same column type at WithMergeableState and Complete (count / sum) - worked even before this fix.
+SELECT count() FROM merge(currentDatabase(), '^(m_inner|t_mem)$')
+    SETTINGS distributed_group_by_no_merge = 1;
+20
+SELECT sum(c0) FROM merge(currentDatabase(), '^(m_inner|t_mem)$')
+    SETTINGS distributed_group_by_no_merge = 1;
+90
+-- 2. Different state vs. final type - this is the case that exposed the
+-- header mismatch via the nested-Merge `must_return_interpreter_select_query_plan` path.
+SELECT uniqExact(c0) FROM merge(currentDatabase(), '^(m_inner|t_mem)$')
+    SETTINGS distributed_group_by_no_merge = 1;
+10
+SELECT round(avg(c0), 4) FROM merge(currentDatabase(), '^(m_inner|t_mem)$')
+    SETTINGS distributed_group_by_no_merge = 1;
+4.5
+SELECT arraySort(groupArray(c0)) FROM merge(currentDatabase(), '^(m_inner|t_mem)$')
+    SETTINGS distributed_group_by_no_merge = 1;
+[0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9]
+-- 3. Same aggregates but without the inner Merge - exercises the
+-- single-table direct path that the previous test already covered for `count` / `sum`.
+SELECT uniqExact(c0) FROM merge(currentDatabase(), '^(t_dist|t_mem)$')
+    SETTINGS distributed_group_by_no_merge = 1;
+10
+SELECT round(avg(c0), 4) FROM merge(currentDatabase(), '^(t_dist|t_mem)$')
+    SETTINGS distributed_group_by_no_merge = 1;
+4.5
+-- 4. GROUP BY with a state-bearing aggregate, with and without the inner Merge.
+SELECT c0 % 3 AS g, uniqExact(c0) AS u FROM merge(currentDatabase(), '^(m_inner|t_mem)$')
+    GROUP BY g ORDER BY g
+    SETTINGS distributed_group_by_no_merge = 1;
+0	4
+1	3
+2	3
+SELECT c0 % 3 AS g, uniqExact(c0) AS u FROM merge(currentDatabase(), '^(t_dist|t_mem)$')
+    GROUP BY g ORDER BY g
+    SETTINGS distributed_group_by_no_merge = 1;
+0	4
+1	3
+2	3

--- a/tests/queries/0_stateless/04256_merge_distributed_group_by_no_merge_nested.sql
+++ b/tests/queries/0_stateless/04256_merge_distributed_group_by_no_merge_nested.sql
@@ -1,0 +1,72 @@
+-- Tags: distributed
+
+-- Follow-up to #100859 / #75604.
+--
+-- The original fix relaxed the `to_stage == Complete` assertion in
+-- `StorageDistributed::getQueryProcessingStage` so that a multi-table
+-- `StorageMerge` wrapping a `Distributed` table no longer crashes with
+-- `LOGICAL_ERROR` under `distributed_group_by_no_merge=1`. It only covered
+-- `count` / `sum`, where the partial state and the final value share the
+-- same column type.
+--
+-- For aggregate functions whose state differs from the final type
+-- (`uniqExact`, `avg`, `groupArray`, ...) the path through
+-- `ReadFromMerge::createPlanForTable`'s `must_return_interpreter_select_query_plan`
+-- branch (triggered when a `Merge` wraps another `Merge`) used to surface as
+-- `CANNOT_CONVERT_TYPE` because the inner `StorageMerge` propagated `Complete`
+-- upward (single-table case, no cap) and the outer `Merge`'s `common_header`
+-- was built at `WithMergeableState` (expecting `AggregateFunction` states).
+
+DROP TABLE IF EXISTS t_mt;
+DROP TABLE IF EXISTS t_dist;
+DROP TABLE IF EXISTS t_mem;
+DROP TABLE IF EXISTS m_inner;
+
+CREATE TABLE t_mt (c0 Int) ENGINE = MergeTree() ORDER BY c0;
+INSERT INTO t_mt SELECT * FROM numbers(10);
+
+CREATE TABLE t_dist (c0 Int) ENGINE = Distributed('test_shard_localhost', currentDatabase(), 't_mt');
+
+CREATE TABLE t_mem (c0 Int) ENGINE = Memory;
+INSERT INTO t_mem SELECT * FROM numbers(10);
+
+-- Inner Merge wraps a single Distributed - forces the single-table branch
+-- of `StorageMerge::getQueryProcessingStage` (no implicit cap to WithMergeableState).
+CREATE TABLE m_inner (c0 Int) ENGINE = Merge(currentDatabase(), '^t_dist$');
+
+-- { echoOn }
+-- 1. Same column type at WithMergeableState and Complete (count / sum) - worked even before this fix.
+SELECT count() FROM merge(currentDatabase(), '^(m_inner|t_mem)$')
+    SETTINGS distributed_group_by_no_merge = 1;
+SELECT sum(c0) FROM merge(currentDatabase(), '^(m_inner|t_mem)$')
+    SETTINGS distributed_group_by_no_merge = 1;
+
+-- 2. Different state vs. final type - this is the case that exposed the
+-- header mismatch via the nested-Merge `must_return_interpreter_select_query_plan` path.
+SELECT uniqExact(c0) FROM merge(currentDatabase(), '^(m_inner|t_mem)$')
+    SETTINGS distributed_group_by_no_merge = 1;
+SELECT round(avg(c0), 4) FROM merge(currentDatabase(), '^(m_inner|t_mem)$')
+    SETTINGS distributed_group_by_no_merge = 1;
+SELECT arraySort(groupArray(c0)) FROM merge(currentDatabase(), '^(m_inner|t_mem)$')
+    SETTINGS distributed_group_by_no_merge = 1;
+
+-- 3. Same aggregates but without the inner Merge - exercises the
+-- single-table direct path that the previous test already covered for `count` / `sum`.
+SELECT uniqExact(c0) FROM merge(currentDatabase(), '^(t_dist|t_mem)$')
+    SETTINGS distributed_group_by_no_merge = 1;
+SELECT round(avg(c0), 4) FROM merge(currentDatabase(), '^(t_dist|t_mem)$')
+    SETTINGS distributed_group_by_no_merge = 1;
+
+-- 4. GROUP BY with a state-bearing aggregate, with and without the inner Merge.
+SELECT c0 % 3 AS g, uniqExact(c0) AS u FROM merge(currentDatabase(), '^(m_inner|t_mem)$')
+    GROUP BY g ORDER BY g
+    SETTINGS distributed_group_by_no_merge = 1;
+SELECT c0 % 3 AS g, uniqExact(c0) AS u FROM merge(currentDatabase(), '^(t_dist|t_mem)$')
+    GROUP BY g ORDER BY g
+    SETTINGS distributed_group_by_no_merge = 1;
+-- { echoOff }
+
+DROP TABLE m_inner;
+DROP TABLE t_mem;
+DROP TABLE t_dist;
+DROP TABLE t_mt;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `CANNOT_CONVERT_TYPE` for `Merge` over `Merge` over `Distributed` with `distributed_group_by_no_merge=1`

#100859 made multi-table `Merge` over `Distributed` with `distributed_group_by_no_merge=1` work for all aggregates: the `processed_stage <= storage_stage` rescue in
`ReadFromMerge::createPlanForTable` takes the if-branch and calls `storage->read` with `processed_stage = WithMergeableState`, so the shards return states and they line up with the Merge's `common_header`.

But that rescue is bypassed when the Merge child is itself a `StorageMerge` (the `must_return_interpreter_select_query_plan` flag forces the else-branch unconditionally). With the shape:

  outer Merge (multi-table - caps its own stage at WithMergeableState)
    -> inner Merge (single Distributed child - no cap on single-table branch)
      -> Distributed with distributed_group_by_no_merge=1
         (now returns Complete instead of throwing)

the inner `Merge` propagated `Complete` upward, the nested interpreter emitted finalized columns, and `convertAndFilterSourceStream` then tried to CAST e.g. `UInt64` to `AggregateFunction(uniqExact, Int)`, which the generic CAST does not support - failing with `CANNOT_CONVERT_TYPE` for state-bearing aggregates (`uniqExact`, `avg`, `groupArray`, `quantile`, ...).

Two fixes:

- `StorageMerge::getQueryProcessingStage`: cap the single-table branch at `WithMergeableState` when the caller asked for `WithMergeableState` or less. Mirrors the multi-table cap already present on the same line.

- `StorageDistributed::getQueryProcessingStage`: return `std::max(to_stage, Complete)` instead of plain `Complete`, so a caller asking for `WithMergeableStateAfterAggregation(/AndLimit)` is not silently downgraded.

Test 04256 covers the nested-Merge case and the state-bearing aggregates that 04064 missed.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.922`
<!-- ch-version-info:end -->