### PR TITLE
Fix NaN handling in minMap/maxMap (array form) and minMappedArrays/maxMappedArrays

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionSumMap.cpp
+++ b/src/AggregateFunctions/AggregateFunctionSumMap.cpp
@@ -13,6 +13,7 @@
 #include <AggregateFunctions/FactoryHelpers.h>
 #include <AggregateFunctions/IAggregateFunction.h>
 #include <Common/FieldVisitorSum.h>
+#include <Common/NaNUtils.h>
 #include <Common/assert_cast.h>
 #include <Common/MapWithMemoryTracking.h>
 #include <Common/SetWithMemoryTracking.h>
@@ -583,6 +584,19 @@ private:
     bool compareImpl(FieldType & x) const
     {
         auto val = rhs.safeGet<FieldType>();
+        if constexpr (is_floating_point<FieldType>)
+        {
+            /// Match `max` semantics: NaN is treated as last (i.e. smaller than
+            /// any non-NaN value), so it is only kept when every observed value
+            /// is NaN. See #100448.
+            if (isNaN(val))
+                return false;
+            if (isNaN(x))
+            {
+                x = val;
+                return true;
+            }
+        }
         if (val > x)
         {
             x = val;
@@ -623,6 +637,19 @@ private:
     bool compareImpl(FieldType & x) const
     {
         auto val = rhs.safeGet<FieldType>();
+        if constexpr (is_floating_point<FieldType>)
+        {
+            /// Match `min` semantics: NaN is treated as last (i.e. larger than
+            /// any non-NaN value), so it is only kept when every observed value
+            /// is NaN. See #100448.
+            if (isNaN(val))
+                return false;
+            if (isNaN(x))
+            {
+                x = val;
+                return true;
+            }
+        }
         if (val < x)
         {
             x = val;

--- a/tests/queries/0_stateless/04256_min_max_mapped_arrays_nan_consistent.reference
+++ b/tests/queries/0_stateless/04256_min_max_mapped_arrays_nan_consistent.reference
@@ -1,0 +1,28 @@
+Queries from issue #105294
+(['y'],[6])
+{'y':6}
+NaN first then a real value
+{'y':6}
+(['y'],[6])
+A real value first then NaN
+{'y':6}
+(['y'],[6])
+{'y':6}
+(['y'],[6])
+All NaN values keep NaN
+{'y':nan}
+(['y'],[nan])
+{'y':nan}
+(['y'],[nan])
+NaN sandwiched between real values
+(['y'],[6])
+(['y'],[3])
+Float32 too
+(['y'],[6])
+(['y'],[6])
+Integer types are unaffected
+(['y'],[6])
+(['y'],[3])
+Merging across groups (forces serialize/deserialize path)
+(['y'],[6])
+(['y'],[6])

--- a/tests/queries/0_stateless/04256_min_max_mapped_arrays_nan_consistent.sql
+++ b/tests/queries/0_stateless/04256_min_max_mapped_arrays_nan_consistent.sql
@@ -1,0 +1,50 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/105294
+-- maxMap / minMap and maxMappedArrays / minMappedArrays must agree on NaN
+-- handling: NaN is treated as last (matches `max`/`min` after PR #100448).
+
+SELECT 'Queries from issue #105294';
+SELECT maxMappedArrays(a, b)
+FROM VALUES('a Array(Char), b Array(Float64)', (['y'], [nan]), (['y'], [6]));
+
+SELECT maxMap(map('y', x))
+FROM VALUES('x Float64', (nan), (6));
+
+SELECT 'NaN first then a real value';
+SELECT minMap(map('y', x)) FROM VALUES('x Float64', (nan), (6));
+SELECT minMappedArrays(a, b) FROM VALUES('a Array(Char), b Array(Float64)', (['y'], [nan]), (['y'], [6]));
+
+SELECT 'A real value first then NaN';
+SELECT maxMap(map('y', x)) FROM VALUES('x Float64', (6), (nan));
+SELECT maxMappedArrays(a, b) FROM VALUES('a Array(Char), b Array(Float64)', (['y'], [6]), (['y'], [nan]));
+SELECT minMap(map('y', x)) FROM VALUES('x Float64', (6), (nan));
+SELECT minMappedArrays(a, b) FROM VALUES('a Array(Char), b Array(Float64)', (['y'], [6]), (['y'], [nan]));
+
+SELECT 'All NaN values keep NaN';
+SELECT maxMap(map('y', x)) FROM VALUES('x Float64', (nan), (nan));
+SELECT maxMappedArrays(a, b) FROM VALUES('a Array(Char), b Array(Float64)', (['y'], [nan]), (['y'], [nan]));
+SELECT minMap(map('y', x)) FROM VALUES('x Float64', (nan), (nan));
+SELECT minMappedArrays(a, b) FROM VALUES('a Array(Char), b Array(Float64)', (['y'], [nan]), (['y'], [nan]));
+
+SELECT 'NaN sandwiched between real values';
+SELECT maxMappedArrays(a, b) FROM VALUES('a Array(Char), b Array(Float64)', (['y'], [3]), (['y'], [nan]), (['y'], [6]));
+SELECT minMappedArrays(a, b) FROM VALUES('a Array(Char), b Array(Float64)', (['y'], [3]), (['y'], [nan]), (['y'], [6]));
+
+SELECT 'Float32 too';
+SELECT maxMappedArrays(a, b) FROM VALUES('a Array(Char), b Array(Float32)', (['y'], [toFloat32(nan)]), (['y'], [toFloat32(6)]));
+SELECT minMappedArrays(a, b) FROM VALUES('a Array(Char), b Array(Float32)', (['y'], [toFloat32(nan)]), (['y'], [toFloat32(6)]));
+
+SELECT 'Integer types are unaffected';
+SELECT maxMappedArrays(a, b) FROM VALUES('a Array(Char), b Array(Int32)', (['y'], [3]), (['y'], [6]));
+SELECT minMappedArrays(a, b) FROM VALUES('a Array(Char), b Array(Int32)', (['y'], [3]), (['y'], [6]));
+
+SELECT 'Merging across groups (forces serialize/deserialize path)';
+SELECT maxMappedArrays(a, b) FROM (
+    SELECT ['y']::Array(Char) AS a, [nan]::Array(Float64) AS b
+    UNION ALL
+    SELECT ['y']::Array(Char) AS a, [6]::Array(Float64) AS b
+) SETTINGS group_by_two_level_threshold = 1, group_by_two_level_threshold_bytes = 1;
+SELECT minMappedArrays(a, b) FROM (
+    SELECT ['y']::Array(Char) AS a, [nan]::Array(Float64) AS b
+    UNION ALL
+    SELECT ['y']::Array(Char) AS a, [6]::Array(Float64) AS b
+) SETTINGS group_by_two_level_threshold = 1, group_by_two_level_threshold_bytes = 1;


### PR DESCRIPTION
`minMap`/`maxMap` (array form, redirected to `minMappedArrays`/`maxMappedArrays` by the `Map` combinator) and `minMappedArrays`/`maxMappedArrays` themselves compared values with raw IEEE 754 `<`/`>`, so a `NaN` seen first as the accumulator was never replaced and stayed in the result regardless of the other inputs.

This disagreed with `minMap`/`maxMap` over a `Map` argument, which goes through `min`/`max` and was fixed in #100448 to treat `NaN` as last. The split was visible to users that migrated between the two argument shapes:

| Version | `maxMappedArrays(a, b)` | `maxMap(map('y', x))` |
|---------|---------------------------|------------------------|
| 26.3    | `(['y'], [nan])`          | `{'y': nan}`           |
| 26.4    | `(['y'], [nan])`          | `{'y': 6}`             |

`FieldVisitorMin`/`FieldVisitorMax` now treat `NaN` as last for floating-point values, so it is only returned when every observed value is `NaN` — matching `ORDER BY ... LIMIT 1` and #100448.

Closes #105294

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`minMap`/`maxMap` (array form) and `minMappedArrays`/`maxMappedArrays` now treat `NaN` consistently with `ORDER BY`: `NaN` is treated as last (returned only when all values are `NaN`). Previously, results depended on the position of `NaN` in the data due to IEEE 754 unordered comparison semantics, and disagreed with the `Map`-argument form of `minMap`/`maxMap` that was fixed in #100448.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.863`
<!-- ch-version-info:end -->