### PR TITLE
Add more keeper profile events for watches

### DIFF
--- a/src/Access/ZooKeeperReplicator.cpp
+++ b/src/Access/ZooKeeperReplicator.cpp
@@ -25,6 +25,11 @@ String makeWatchIdFromId(const DB::UUID & id)
 
 }
 
+namespace ProfileEvents
+{
+    extern const Event ZooKeeperWatchTriggeredReplicatedAccessControl;
+}
+
 namespace DB
 {
 namespace ErrorCodes
@@ -574,7 +579,7 @@ void ZooKeeperReplicator::refreshEntities(const zkutil::ZooKeeperPtr & zookeeper
     const auto entity_uuid_strs = zookeeper->getChildrenWatch(
         zookeeper_uuids_path,
         &stat,
-        Coordination::WatchCallbackPtrOrEventPtr{watch_entities_list, Coordination::WatchCallbackKind::ReplicatedAccessControl});
+        Coordination::WatchCallbackPtrOrEventPtr{watch_entities_list, ProfileEvents::ZooKeeperWatchTriggeredReplicatedAccessControl});
 
     std::vector<UUID> entity_uuids;
     entity_uuids.reserve(entity_uuid_strs.size());
@@ -643,7 +648,7 @@ AccessEntityPtr ZooKeeperReplicator::tryReadEntityFromZooKeeper(const zkutil::Zo
                 [[maybe_unused]] bool push_result = my_watched_queue->push(id);
         };
     });
-    watch.setKind(Coordination::WatchCallbackKind::ReplicatedAccessControl);
+    watch.setTriggeredEvent(ProfileEvents::ZooKeeperWatchTriggeredReplicatedAccessControl);
 
     Coordination::Stat entity_stat;
     const String entity_path = zookeeper_path + "/uuid/" + toString(id);

--- a/src/Access/ZooKeeperReplicator.cpp
+++ b/src/Access/ZooKeeperReplicator.cpp
@@ -571,7 +571,10 @@ void ZooKeeperReplicator::refreshEntities(const zkutil::ZooKeeperPtr & zookeeper
 
     const String zookeeper_uuids_path = zookeeper_path + "/uuid";
     Coordination::Stat stat;
-    const auto entity_uuid_strs = zookeeper->getChildrenWatch(zookeeper_uuids_path, &stat, watch_entities_list);
+    const auto entity_uuid_strs = zookeeper->getChildrenWatch(
+        zookeeper_uuids_path,
+        &stat,
+        Coordination::WatchCallbackPtrOrEventPtr{watch_entities_list, Coordination::WatchCallbackKind::ReplicatedAccessControl});
 
     std::vector<UUID> entity_uuids;
     entity_uuids.reserve(entity_uuid_strs.size());
@@ -640,6 +643,7 @@ AccessEntityPtr ZooKeeperReplicator::tryReadEntityFromZooKeeper(const zkutil::Zo
                 [[maybe_unused]] bool push_result = my_watched_queue->push(id);
         };
     });
+    watch.setKind(Coordination::WatchCallbackKind::ReplicatedAccessControl);
 
     Coordination::Stat entity_stat;
     const String entity_path = zookeeper_path + "/uuid/" + toString(id);

--- a/src/Backups/BackupCoordinationStageSync.cpp
+++ b/src/Backups/BackupCoordinationStageSync.cpp
@@ -8,11 +8,17 @@
 #include <IO/ReadHelpers.h>
 #include <IO/WriteBufferFromString.h>
 #include <IO/WriteHelpers.h>
+#include <Common/ProfileEvents.h>
 #include <Backups/BackupCoordinationStage.h>
 #include <Backups/BackupConcurrencyCheck.h>
 #include <Poco/URI.h>
 #include <boost/algorithm/string/join.hpp>
 
+
+namespace ProfileEvents
+{
+    extern const Event ZooKeeperWatchTriggeredBackupCoordination;
+}
 
 namespace DB
 {
@@ -583,7 +589,10 @@ void BackupCoordinationStageSync::readCurrentState(Coordination::ZooKeeperWithFa
     (*zk_nodes_changed).reset();
 
     /// Get zk nodes and subscribe on their changes.
-    Strings new_zk_nodes = zookeeper->getChildren(zookeeper_path, nullptr, zk_nodes_changed);
+    Strings new_zk_nodes = zookeeper->getChildrenWatch(
+        zookeeper_path,
+        nullptr,
+        Coordination::WatchCallbackPtrOrEventPtr{zk_nodes_changed, ProfileEvents::ZooKeeperWatchTriggeredBackupCoordination});
     std::sort(new_zk_nodes.begin(), new_zk_nodes.end()); /// Sorting is necessary because we compare the list of zk nodes with its previous versions.
 
     State new_state;

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -324,19 +324,16 @@
     M(ZooKeeperWatchCallbackDurationMicroseconds, "Total time spent inside ZooKeeper watch callbacks (network thread).", ValueType::Microseconds) \
     M(ZooKeeperWatchCallbackErrors, "Number of exceptions thrown from ZooKeeper watch callbacks.", ValueType::Number) \
     M(ZooKeeperWatchTriggeredOther, "Number of watch notifications dispatched to uncategorized callbacks.", ValueType::Number) \
-    M(ZooKeeperWatchTriggeredReplicatedMergeTreeQueue, "Number of watch notifications dispatched to ReplicatedMergeTree per-replica queue.", ValueType::Number) \
     M(ZooKeeperWatchTriggeredReplicatedMergeTreeLog, "Number of watch notifications dispatched to ReplicatedMergeTree log entries.", ValueType::Number) \
     M(ZooKeeperWatchTriggeredReplicatedMergeTreeMutations, "Number of watch notifications dispatched to ReplicatedMergeTree mutations.", ValueType::Number) \
     M(ZooKeeperWatchTriggeredReplicatedMergeTreeLeaderElection, "Number of watch notifications dispatched to ReplicatedMergeTree leader election / replica locks.", ValueType::Number) \
     M(ZooKeeperWatchTriggeredDistributedDDL, "Number of watch notifications dispatched to DDLWorker queue.", ValueType::Number) \
-    M(ZooKeeperWatchTriggeredKeeperMap, "Number of watch notifications dispatched to StorageKeeperMap.", ValueType::Number) \
     M(ZooKeeperWatchTriggeredReplicatedAccessControl, "Number of watch notifications dispatched to ReplicatedAccessStorage.", ValueType::Number) \
     M(ZooKeeperWatchTriggeredUserDefinedSQLObjects, "Number of watch notifications dispatched to UserDefinedSQLObjectsZooKeeperStorage.", ValueType::Number) \
     M(ZooKeeperWatchTriggeredBackupCoordination, "Number of watch notifications dispatched to backup / restore coordination.", ValueType::Number) \
     M(ZooKeeperWatchTriggeredObjectStorageQueue, "Number of watch notifications dispatched to ObjectStorageQueue / S3Queue.", ValueType::Number) \
     M(ZooKeeperWatchTriggeredClusterDiscovery, "Number of watch notifications dispatched to ClusterDiscovery.", ValueType::Number) \
     M(ZooKeeperWatchTriggeredMaterializedViewRefresh, "Number of watch notifications dispatched to MaterializedView refresh coordination.", ValueType::Number) \
-    M(ZooKeeperWatchTriggeredPartMovesBetweenShards, "Number of watch notifications dispatched to PartMovesBetweenShardsOrchestrator.", ValueType::Number) \
     M(ZooKeeperUserExceptions, "Number of exceptions while working with ZooKeeper related to the data (no node, bad version or similar).", ValueType::Number) \
     M(ZooKeeperHardwareExceptions, "Number of exceptions while working with ZooKeeper related to network (connection loss or similar).", ValueType::Number) \
     M(ZooKeeperOtherExceptions, "Number of exceptions while working with ZooKeeper other than ZooKeeperUserExceptions and ZooKeeperHardwareExceptions.", ValueType::Number) \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -321,6 +321,22 @@
     M(ZooKeeperClose, "Number of times connection with ZooKeeper has been closed voluntary.", ValueType::Number) \
     M(ZooKeeperGetACL, "Number of 'getACL' requests to ZooKeeper.", ValueType::Number) \
     M(ZooKeeperWatchResponse, "Number of times watch notification has been received from ZooKeeper.", ValueType::Number) \
+    M(ZooKeeperWatchCallbackDurationMicroseconds, "Total time spent inside ZooKeeper watch callbacks (network thread).", ValueType::Microseconds) \
+    M(ZooKeeperWatchCallbackErrors, "Number of exceptions thrown from ZooKeeper watch callbacks.", ValueType::Number) \
+    M(ZooKeeperWatchTriggeredOther, "Number of watch notifications dispatched to uncategorized callbacks.", ValueType::Number) \
+    M(ZooKeeperWatchTriggeredReplicatedMergeTreeQueue, "Number of watch notifications dispatched to ReplicatedMergeTree per-replica queue.", ValueType::Number) \
+    M(ZooKeeperWatchTriggeredReplicatedMergeTreeLog, "Number of watch notifications dispatched to ReplicatedMergeTree log entries.", ValueType::Number) \
+    M(ZooKeeperWatchTriggeredReplicatedMergeTreeMutations, "Number of watch notifications dispatched to ReplicatedMergeTree mutations.", ValueType::Number) \
+    M(ZooKeeperWatchTriggeredReplicatedMergeTreeLeaderElection, "Number of watch notifications dispatched to ReplicatedMergeTree leader election / replica locks.", ValueType::Number) \
+    M(ZooKeeperWatchTriggeredDistributedDDL, "Number of watch notifications dispatched to DDLWorker queue.", ValueType::Number) \
+    M(ZooKeeperWatchTriggeredKeeperMap, "Number of watch notifications dispatched to StorageKeeperMap.", ValueType::Number) \
+    M(ZooKeeperWatchTriggeredReplicatedAccessControl, "Number of watch notifications dispatched to ReplicatedAccessStorage.", ValueType::Number) \
+    M(ZooKeeperWatchTriggeredUserDefinedSQLObjects, "Number of watch notifications dispatched to UserDefinedSQLObjectsZooKeeperStorage.", ValueType::Number) \
+    M(ZooKeeperWatchTriggeredBackupCoordination, "Number of watch notifications dispatched to backup / restore coordination.", ValueType::Number) \
+    M(ZooKeeperWatchTriggeredObjectStorageQueue, "Number of watch notifications dispatched to ObjectStorageQueue / S3Queue.", ValueType::Number) \
+    M(ZooKeeperWatchTriggeredClusterDiscovery, "Number of watch notifications dispatched to ClusterDiscovery.", ValueType::Number) \
+    M(ZooKeeperWatchTriggeredMaterializedViewRefresh, "Number of watch notifications dispatched to MaterializedView refresh coordination.", ValueType::Number) \
+    M(ZooKeeperWatchTriggeredPartMovesBetweenShards, "Number of watch notifications dispatched to PartMovesBetweenShardsOrchestrator.", ValueType::Number) \
     M(ZooKeeperUserExceptions, "Number of exceptions while working with ZooKeeper related to the data (no node, bad version or similar).", ValueType::Number) \
     M(ZooKeeperHardwareExceptions, "Number of exceptions while working with ZooKeeper related to network (connection loss or similar).", ValueType::Number) \
     M(ZooKeeperOtherExceptions, "Number of exceptions while working with ZooKeeper other than ZooKeeperUserExceptions and ZooKeeperHardwareExceptions.", ValueType::Number) \
@@ -1006,6 +1022,11 @@ The server successfully detected this situation and will download merged part fr
     M(KeeperRequestRejectedDueToSoftMemoryLimitCount, "Number requests that have been rejected due to soft memory limit exceeded", ValueType::Number) \
     M(KeeperStaleRequestsSkipped, "Number of Keeper requests skipped because the session is no longer live", ValueType::Number) \
     M(KeeperLiveSessionsLockWaitMicroseconds, "Time spent waiting to acquire Keeper live sessions lock", ValueType::Microseconds) \
+    M(KeeperWatchesTriggered, "Number of watch triggers", ValueType::Number) \
+    M(KeeperWatchTriggeredNodeCreated, "Number of watch triggers by `CREATE` operation", ValueType::Number) \
+    M(KeeperWatchTriggeredNodeDeleted, "Number of watch triggers by `DELETE` operation", ValueType::Number) \
+    M(KeeperWatchTriggeredNodeDataChanged, "Number of watch triggers by change operations", ValueType::Number) \
+    M(KeeperWatchTriggeredNodeChildrenChanged, "Number of watch triggers by children change operations", ValueType::Number) \
     \
     M(OverflowBreak, "Number of times, data processing was cancelled by query complexity limitation with setting '*_overflow_mode' = 'break' and the result is incomplete.", ValueType::Number) \
     M(OverflowThrow, "Number of times, data processing was cancelled by query complexity limitation with setting '*_overflow_mode' = 'throw' and exception was thrown.", ValueType::Number) \

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -327,9 +327,11 @@
     M(ZooKeeperWatchTriggeredReplicatedMergeTreeLog, "Number of watch notifications dispatched to ReplicatedMergeTree log entries.", ValueType::Number) \
     M(ZooKeeperWatchTriggeredReplicatedMergeTreeMutations, "Number of watch notifications dispatched to ReplicatedMergeTree mutations.", ValueType::Number) \
     M(ZooKeeperWatchTriggeredReplicatedMergeTreeLeaderElection, "Number of watch notifications dispatched to ReplicatedMergeTree leader election / replica locks.", ValueType::Number) \
+    M(ZooKeeperWatchTriggeredReplicatedMergeTreeReplicaSync, "Number of watch notifications dispatched while waiting for replicas to process log entries (SYNC REPLICA, ALTER, mutations).", ValueType::Number) \
     M(ZooKeeperWatchTriggeredDistributedDDL, "Number of watch notifications dispatched to DDLWorker queue.", ValueType::Number) \
     M(ZooKeeperWatchTriggeredReplicatedAccessControl, "Number of watch notifications dispatched to ReplicatedAccessStorage.", ValueType::Number) \
     M(ZooKeeperWatchTriggeredUserDefinedSQLObjects, "Number of watch notifications dispatched to UserDefinedSQLObjectsZooKeeperStorage.", ValueType::Number) \
+    M(ZooKeeperWatchTriggeredWorkloadEntity, "Number of watch notifications dispatched to WorkloadEntityKeeperStorage.", ValueType::Number) \
     M(ZooKeeperWatchTriggeredBackupCoordination, "Number of watch notifications dispatched to backup / restore coordination.", ValueType::Number) \
     M(ZooKeeperWatchTriggeredObjectStorageQueue, "Number of watch notifications dispatched to ObjectStorageQueue / S3Queue.", ValueType::Number) \
     M(ZooKeeperWatchTriggeredClusterDiscovery, "Number of watch notifications dispatched to ClusterDiscovery.", ValueType::Number) \

--- a/src/Common/Scheduler/Workload/WorkloadEntityKeeperStorage.cpp
+++ b/src/Common/Scheduler/Workload/WorkloadEntityKeeperStorage.cpp
@@ -14,7 +14,13 @@
 #include <Common/quoteString.h>
 #include <Common/scope_guard_safe.h>
 #include <Common/setThreadName.h>
+#include <Common/ProfileEvents.h>
 #include <Core/Settings.h>
+
+namespace ProfileEvents
+{
+    extern const Event ZooKeeperWatchTriggeredWorkloadEntity;
+}
 
 namespace DB
 {
@@ -228,11 +234,12 @@ std::pair<String, Int32> WorkloadEntityKeeperStorage::getDataAndSetWatch(const z
 {
     Coordination::Stat stat;
     String data;
-    bool exists = zookeeper->tryGetWatch(zookeeper_path, data, &stat, zookeeper_watch);
+    Coordination::WatchCallbackPtrOrEventPtr labelled_watch{zookeeper_watch, ProfileEvents::ZooKeeperWatchTriggeredWorkloadEntity};
+    bool exists = zookeeper->tryGetWatch(zookeeper_path, data, &stat, labelled_watch);
     if (!exists)
     {
         createRootNodes(zookeeper);
-        data = zookeeper->getWatch(zookeeper_path, &stat, zookeeper_watch);
+        data = zookeeper->getWatch(zookeeper_path, &stat, labelled_watch);
     }
     return {data, stat.version};
 }

--- a/src/Common/ZooKeeper/IKeeper.h
+++ b/src/Common/ZooKeeper/IKeeper.h
@@ -2,6 +2,7 @@
 
 #include <base/defines.h>
 #include <base/types.h>
+#include <Common/ProfileEvents.h>
 #include <Common/ZooKeeper/KeeperFeatureFlags.h>
 #include <Common/ZooKeeper/ZooKeeperConstants.h>
 
@@ -26,6 +27,11 @@
   * - fake ZooKeeper client for testing;
   * - ZooKeeper emulation layer on top of Etcd, FoundationDB, whatever.
   */
+
+namespace ProfileEvents
+{
+    extern const Event ZooKeeperWatchTriggeredOther;
+}
 
 namespace Coordination
 {
@@ -180,24 +186,6 @@ using WatchCallbackPtr = std::shared_ptr<WatchCallback>;
 using EventPtr = std::shared_ptr<Poco::Event>;
 struct TestKeeperRequest;
 
-enum class WatchCallbackKind : uint8_t
-{
-    Other,
-    ReplicatedMergeTreeQueue,
-    ReplicatedMergeTreeLog,
-    ReplicatedMergeTreeMutations,
-    ReplicatedMergeTreeLeaderElection,
-    DistributedDDL,
-    KeeperMap,
-    ReplicatedAccessControl,
-    UserDefinedSQLObjects,
-    BackupCoordination,
-    ObjectStorageQueue,
-    ClusterDiscovery,
-    MaterializedViewRefresh,
-    PartMovesBetweenShards,
-};
-
 struct WatchCallbackPtrOrEventPtr
 {
 private:
@@ -208,7 +196,8 @@ private:
 
     WatchCallbackPtr callback;
     EventPtr event;
-    WatchCallbackKind kind = WatchCallbackKind::Other;
+    /// The ProfileEvent incremented when this watch is triggered, identifying the subsystem that owns the callback.
+    ProfileEvents::Event triggered_event = ProfileEvents::ZooKeeperWatchTriggeredOther;
 
     void operator()(WatchResponse response) const
     {
@@ -223,13 +212,13 @@ public:
 
     WatchCallbackPtrOrEventPtr(WatchCallbackPtr callback_) : callback(std::move(callback_)) {} // NOLINT(google-explicit-constructor)
     WatchCallbackPtrOrEventPtr(EventPtr event_) : event(std::move(event_)) {} // NOLINT(google-explicit-constructor)
-    WatchCallbackPtrOrEventPtr(WatchCallbackPtr callback_, WatchCallbackKind kind_)
-        : callback(std::move(callback_)), kind(kind_) {} // NOLINT(google-explicit-constructor)
-    WatchCallbackPtrOrEventPtr(EventPtr event_, WatchCallbackKind kind_)
-        : event(std::move(event_)), kind(kind_) {} // NOLINT(google-explicit-constructor)
+    WatchCallbackPtrOrEventPtr(WatchCallbackPtr callback_, ProfileEvents::Event triggered_event_)
+        : callback(std::move(callback_)), triggered_event(triggered_event_) {} // NOLINT(google-explicit-constructor)
+    WatchCallbackPtrOrEventPtr(EventPtr event_, ProfileEvents::Event triggered_event_)
+        : event(std::move(event_)), triggered_event(triggered_event_) {} // NOLINT(google-explicit-constructor)
 
-    WatchCallbackKind getKind() const { return kind; }
-    void setKind(WatchCallbackKind kind_) { kind = kind_; }
+    ProfileEvents::Event getTriggeredEvent() const { return triggered_event; }
+    void setTriggeredEvent(ProfileEvents::Event triggered_event_) { triggered_event = triggered_event_; }
 
     void invoke(WatchResponse response) const { (*this)(std::move(response)); }
 

--- a/src/Common/ZooKeeper/IKeeper.h
+++ b/src/Common/ZooKeeper/IKeeper.h
@@ -179,6 +179,25 @@ using WatchCallback = std::function<void(const WatchResponse &)>;
 using WatchCallbackPtr = std::shared_ptr<WatchCallback>;
 using EventPtr = std::shared_ptr<Poco::Event>;
 struct TestKeeperRequest;
+
+enum class WatchCallbackKind : uint8_t
+{
+    Other,
+    ReplicatedMergeTreeQueue,
+    ReplicatedMergeTreeLog,
+    ReplicatedMergeTreeMutations,
+    ReplicatedMergeTreeLeaderElection,
+    DistributedDDL,
+    KeeperMap,
+    ReplicatedAccessControl,
+    UserDefinedSQLObjects,
+    BackupCoordination,
+    ObjectStorageQueue,
+    ClusterDiscovery,
+    MaterializedViewRefresh,
+    PartMovesBetweenShards,
+};
+
 struct WatchCallbackPtrOrEventPtr
 {
 private:
@@ -189,6 +208,7 @@ private:
 
     WatchCallbackPtr callback;
     EventPtr event;
+    WatchCallbackKind kind = WatchCallbackKind::Other;
 
     void operator()(WatchResponse response) const
     {
@@ -203,6 +223,15 @@ public:
 
     WatchCallbackPtrOrEventPtr(WatchCallbackPtr callback_) : callback(std::move(callback_)) {} // NOLINT(google-explicit-constructor)
     WatchCallbackPtrOrEventPtr(EventPtr event_) : event(std::move(event_)) {} // NOLINT(google-explicit-constructor)
+    WatchCallbackPtrOrEventPtr(WatchCallbackPtr callback_, WatchCallbackKind kind_)
+        : callback(std::move(callback_)), kind(kind_) {} // NOLINT(google-explicit-constructor)
+    WatchCallbackPtrOrEventPtr(EventPtr event_, WatchCallbackKind kind_)
+        : event(std::move(event_)), kind(kind_) {} // NOLINT(google-explicit-constructor)
+
+    WatchCallbackKind getKind() const { return kind; }
+    void setKind(WatchCallbackKind kind_) { kind = kind_; }
+
+    void invoke(WatchResponse response) const { (*this)(std::move(response)); }
 
     WatchCallbackPtrOrEventPtr(WatchCallbackPtrOrEventPtr &&) = default;
     WatchCallbackPtrOrEventPtr(const WatchCallbackPtrOrEventPtr &) = default;

--- a/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -1308,7 +1308,7 @@ namespace
     using WaitForDisappearStatePtr = std::shared_ptr<WaitForDisappearState>;
 }
 
-bool ZooKeeper::waitForDisappear(const std::string & path, const WaitCondition & condition)
+bool ZooKeeper::waitForDisappear(const std::string & path, const WaitCondition & condition, ProfileEvents::Event triggered_event)
 {
     WaitForDisappearStatePtr state = std::make_shared<WaitForDisappearState>();
 
@@ -1332,6 +1332,7 @@ bool ZooKeeper::waitForDisappear(const std::string & path, const WaitCondition &
             }
         };
     });
+    watch.setTriggeredEvent(triggered_event);
 
     /// do-while control structure to allow using this function in non-blocking
     /// fashion with a wait condition which returns false by the time this

--- a/src/Common/ZooKeeper/ZooKeeper.h
+++ b/src/Common/ZooKeeper/ZooKeeper.h
@@ -27,6 +27,7 @@ namespace Poco::Net
 namespace ProfileEvents
 {
     extern const Event CannotRemoveEphemeralNode;
+    extern const Event ZooKeeperWatchTriggeredOther;
 }
 
 namespace CurrentMetrics

--- a/src/Common/ZooKeeper/ZooKeeper.h
+++ b/src/Common/ZooKeeper/ZooKeeper.h
@@ -486,7 +486,11 @@ public:
     /// Wait for the node to disappear or return immediately if it doesn't exist.
     /// If condition is specified, it is used to return early (when condition returns false)
     /// The function returns true if waited and false if waiting was interrupted by condition.
-    bool waitForDisappear(const std::string & path, const WaitCondition & condition = {});
+    /// triggered_event identifies the subsystem owning the watch for profile-event accounting.
+    bool waitForDisappear(
+        const std::string & path,
+        const WaitCondition & condition = {},
+        ProfileEvents::Event triggered_event = ProfileEvents::ZooKeeperWatchTriggeredOther);
 
     /// Checks if a the ephemeral node exists. These nodes are removed automatically by ZK when the session ends
     /// If the node exists and its value is equal to fast_delete_if_equal_value it will remove it

--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -75,6 +75,22 @@ namespace ProfileEvents
     extern const Event ZooKeeperBytesSent;
     extern const Event ZooKeeperBytesReceived;
     extern const Event ZooKeeperWatchResponse;
+    extern const Event ZooKeeperWatchCallbackDurationMicroseconds;
+    extern const Event ZooKeeperWatchCallbackErrors;
+    extern const Event ZooKeeperWatchTriggeredOther;
+    extern const Event ZooKeeperWatchTriggeredReplicatedMergeTreeQueue;
+    extern const Event ZooKeeperWatchTriggeredReplicatedMergeTreeLog;
+    extern const Event ZooKeeperWatchTriggeredReplicatedMergeTreeMutations;
+    extern const Event ZooKeeperWatchTriggeredReplicatedMergeTreeLeaderElection;
+    extern const Event ZooKeeperWatchTriggeredDistributedDDL;
+    extern const Event ZooKeeperWatchTriggeredKeeperMap;
+    extern const Event ZooKeeperWatchTriggeredReplicatedAccessControl;
+    extern const Event ZooKeeperWatchTriggeredUserDefinedSQLObjects;
+    extern const Event ZooKeeperWatchTriggeredBackupCoordination;
+    extern const Event ZooKeeperWatchTriggeredObjectStorageQueue;
+    extern const Event ZooKeeperWatchTriggeredClusterDiscovery;
+    extern const Event ZooKeeperWatchTriggeredMaterializedViewRefresh;
+    extern const Event ZooKeeperWatchTriggeredPartMovesBetweenShards;
 }
 
 namespace CurrentMetrics
@@ -335,6 +351,57 @@ namespace Coordination
 {
 
 using namespace DB;
+
+namespace
+{
+
+ProfileEvents::Event watchTriggeredProfileEvent(WatchCallbackKind kind)
+{
+    switch (kind)
+    {
+        case WatchCallbackKind::Other: return ProfileEvents::ZooKeeperWatchTriggeredOther;
+        case WatchCallbackKind::ReplicatedMergeTreeQueue: return ProfileEvents::ZooKeeperWatchTriggeredReplicatedMergeTreeQueue;
+        case WatchCallbackKind::ReplicatedMergeTreeLog: return ProfileEvents::ZooKeeperWatchTriggeredReplicatedMergeTreeLog;
+        case WatchCallbackKind::ReplicatedMergeTreeMutations: return ProfileEvents::ZooKeeperWatchTriggeredReplicatedMergeTreeMutations;
+        case WatchCallbackKind::ReplicatedMergeTreeLeaderElection: return ProfileEvents::ZooKeeperWatchTriggeredReplicatedMergeTreeLeaderElection;
+        case WatchCallbackKind::DistributedDDL: return ProfileEvents::ZooKeeperWatchTriggeredDistributedDDL;
+        case WatchCallbackKind::KeeperMap: return ProfileEvents::ZooKeeperWatchTriggeredKeeperMap;
+        case WatchCallbackKind::ReplicatedAccessControl: return ProfileEvents::ZooKeeperWatchTriggeredReplicatedAccessControl;
+        case WatchCallbackKind::UserDefinedSQLObjects: return ProfileEvents::ZooKeeperWatchTriggeredUserDefinedSQLObjects;
+        case WatchCallbackKind::BackupCoordination: return ProfileEvents::ZooKeeperWatchTriggeredBackupCoordination;
+        case WatchCallbackKind::ObjectStorageQueue: return ProfileEvents::ZooKeeperWatchTriggeredObjectStorageQueue;
+        case WatchCallbackKind::ClusterDiscovery: return ProfileEvents::ZooKeeperWatchTriggeredClusterDiscovery;
+        case WatchCallbackKind::MaterializedViewRefresh: return ProfileEvents::ZooKeeperWatchTriggeredMaterializedViewRefresh;
+        case WatchCallbackKind::PartMovesBetweenShards: return ProfileEvents::ZooKeeperWatchTriggeredPartMovesBetweenShards;
+    }
+    return ProfileEvents::ZooKeeperWatchTriggeredOther;
+}
+
+void triggerWatchCallback(
+    const WatchCallbackPtrOrEventPtr & event_or_callback,
+    const WatchResponse & response,
+    const LoggerPtr & log)
+{
+    ProfileEvents::increment(watchTriggeredProfileEvent(event_or_callback.getKind()));
+
+    const auto start_time = std::chrono::steady_clock::now();
+    try
+    {
+        event_or_callback.invoke(response);
+    }
+    catch (...)
+    {
+        ProfileEvents::increment(ProfileEvents::ZooKeeperWatchCallbackErrors);
+        if (log)
+            tryLogCurrentException(log);
+    }
+
+    const auto elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now() - start_time).count();
+    ProfileEvents::increment(ProfileEvents::ZooKeeperWatchCallbackDurationMicroseconds, elapsed_us);
+}
+
+}
 
 template <typename T>
 void ZooKeeper::write(const T & x)
@@ -1013,7 +1080,7 @@ void ZooKeeper::receiveEvent()
             const WatchResponse & watch_response = dynamic_cast<const WatchResponse &>(response_);
 
             auto event_type = watch_response.type;
-            auto trigger_watches = [&watch_response](auto & watches_container)
+            auto trigger_watches = [&watch_response, this](auto & watches_container)
             {
                 auto it = watches_container.find(watch_response.path);
                 if (it == watches_container.end())
@@ -1033,7 +1100,7 @@ void ZooKeeper::receiveEvent()
                 for (const auto & [event_or_callback, _] : it->second)
                 {
                     if (event_or_callback)
-                        event_or_callback(watch_response);
+                        triggerWatchCallback(event_or_callback, watch_response, log);
                 }
 
                 CurrentMetrics::sub(CurrentMetrics::ZooKeeperWatch, it->second.size());
@@ -1384,16 +1451,7 @@ void ZooKeeper::finalize(bool error_send, bool error_receive, const String & rea
                         watch_callback_count += 1;
                         // TODO: there is impossible to have watch which will be "nullptr"
                         if (event_or_callback)
-                        {
-                            try
-                            {
-                                event_or_callback(response);
-                            }
-                            catch (...)
-                            {
-                                tryLogCurrentException(log);
-                            }
-                        }
+                            triggerWatchCallback(event_or_callback, response, log);
                     }
                 }
 
@@ -1439,15 +1497,7 @@ void ZooKeeper::finalize(bool error_send, bool error_receive, const String & rea
                 response.type = SESSION;
                 response.state = EXPIRED_SESSION;
                 response.error = Error::ZSESSIONEXPIRED;
-                try
-                {
-                    const WatchCallbackPtrOrEventPtr & event_or_callback = info.watch;
-                    event_or_callback(response);
-                }
-                catch (...)
-                {
-                    tryLogCurrentException(log);
-                }
+                triggerWatchCallback(info.watch, response, log);
             }
         }
     }

--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -78,20 +78,6 @@ namespace ProfileEvents
     extern const Event ZooKeeperWatchResponse;
     extern const Event ZooKeeperWatchCallbackDurationMicroseconds;
     extern const Event ZooKeeperWatchCallbackErrors;
-    extern const Event ZooKeeperWatchTriggeredOther;
-    extern const Event ZooKeeperWatchTriggeredReplicatedMergeTreeQueue;
-    extern const Event ZooKeeperWatchTriggeredReplicatedMergeTreeLog;
-    extern const Event ZooKeeperWatchTriggeredReplicatedMergeTreeMutations;
-    extern const Event ZooKeeperWatchTriggeredReplicatedMergeTreeLeaderElection;
-    extern const Event ZooKeeperWatchTriggeredDistributedDDL;
-    extern const Event ZooKeeperWatchTriggeredKeeperMap;
-    extern const Event ZooKeeperWatchTriggeredReplicatedAccessControl;
-    extern const Event ZooKeeperWatchTriggeredUserDefinedSQLObjects;
-    extern const Event ZooKeeperWatchTriggeredBackupCoordination;
-    extern const Event ZooKeeperWatchTriggeredObjectStorageQueue;
-    extern const Event ZooKeeperWatchTriggeredClusterDiscovery;
-    extern const Event ZooKeeperWatchTriggeredMaterializedViewRefresh;
-    extern const Event ZooKeeperWatchTriggeredPartMovesBetweenShards;
 }
 
 namespace CurrentMetrics
@@ -1053,7 +1039,7 @@ void ZooKeeper::receiveEvent()
             const WatchResponse & watch_response = dynamic_cast<const WatchResponse &>(response_);
 
             auto event_type = watch_response.type;
-            auto trigger_watches = [&watch_response, this](auto & watches_container)
+            auto trigger_watches = [&watch_response](auto & watches_container)
             {
                 auto it = watches_container.find(watch_response.path);
                 if (it == watches_container.end())

--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -356,34 +356,11 @@ using namespace DB;
 namespace
 {
 
-ProfileEvents::Event watchTriggeredProfileEvent(WatchCallbackKind kind)
-{
-    switch (kind)
-    {
-        case WatchCallbackKind::Other: return ProfileEvents::ZooKeeperWatchTriggeredOther;
-        case WatchCallbackKind::ReplicatedMergeTreeQueue: return ProfileEvents::ZooKeeperWatchTriggeredReplicatedMergeTreeQueue;
-        case WatchCallbackKind::ReplicatedMergeTreeLog: return ProfileEvents::ZooKeeperWatchTriggeredReplicatedMergeTreeLog;
-        case WatchCallbackKind::ReplicatedMergeTreeMutations: return ProfileEvents::ZooKeeperWatchTriggeredReplicatedMergeTreeMutations;
-        case WatchCallbackKind::ReplicatedMergeTreeLeaderElection: return ProfileEvents::ZooKeeperWatchTriggeredReplicatedMergeTreeLeaderElection;
-        case WatchCallbackKind::DistributedDDL: return ProfileEvents::ZooKeeperWatchTriggeredDistributedDDL;
-        case WatchCallbackKind::KeeperMap: return ProfileEvents::ZooKeeperWatchTriggeredKeeperMap;
-        case WatchCallbackKind::ReplicatedAccessControl: return ProfileEvents::ZooKeeperWatchTriggeredReplicatedAccessControl;
-        case WatchCallbackKind::UserDefinedSQLObjects: return ProfileEvents::ZooKeeperWatchTriggeredUserDefinedSQLObjects;
-        case WatchCallbackKind::BackupCoordination: return ProfileEvents::ZooKeeperWatchTriggeredBackupCoordination;
-        case WatchCallbackKind::ObjectStorageQueue: return ProfileEvents::ZooKeeperWatchTriggeredObjectStorageQueue;
-        case WatchCallbackKind::ClusterDiscovery: return ProfileEvents::ZooKeeperWatchTriggeredClusterDiscovery;
-        case WatchCallbackKind::MaterializedViewRefresh: return ProfileEvents::ZooKeeperWatchTriggeredMaterializedViewRefresh;
-        case WatchCallbackKind::PartMovesBetweenShards: return ProfileEvents::ZooKeeperWatchTriggeredPartMovesBetweenShards;
-    }
-    return ProfileEvents::ZooKeeperWatchTriggeredOther;
-}
-
 void triggerWatchCallback(
     const WatchCallbackPtrOrEventPtr & event_or_callback,
-    const WatchResponse & response,
-    const LoggerPtr & log)
+    const WatchResponse & response)
 {
-    ProfileEvents::increment(watchTriggeredProfileEvent(event_or_callback.getKind()));
+    ProfileEvents::increment(event_or_callback.getTriggeredEvent());
 
     DB::ProfileEventTimeIncrement<DB::Microseconds> watch_callback_duration(ProfileEvents::ZooKeeperWatchCallbackDurationMicroseconds);
     try
@@ -393,10 +370,7 @@ void triggerWatchCallback(
     catch (...)
     {
         ProfileEvents::increment(ProfileEvents::ZooKeeperWatchCallbackErrors);
-        if (log)
-            tryLogCurrentException(log);
-        else
-            tryLogCurrentException(__PRETTY_FUNCTION__);
+        throw;
     }
 }
 
@@ -1099,7 +1073,7 @@ void ZooKeeper::receiveEvent()
                 for (const auto & [event_or_callback, _] : it->second)
                 {
                     if (event_or_callback)
-                        triggerWatchCallback(event_or_callback, watch_response, log);
+                        triggerWatchCallback(event_or_callback, watch_response);
                 }
 
                 CurrentMetrics::sub(CurrentMetrics::ZooKeeperWatch, it->second.size());
@@ -1450,7 +1424,17 @@ void ZooKeeper::finalize(bool error_send, bool error_receive, const String & rea
                         watch_callback_count += 1;
                         // TODO: there is impossible to have watch which will be "nullptr"
                         if (event_or_callback)
-                            triggerWatchCallback(event_or_callback, response, log);
+                        {
+                            try
+                            {
+                                triggerWatchCallback(event_or_callback, response);
+                            }
+                            catch (...)
+                            {
+                                /// We must continue to all other callbacks, because the user is waiting for them.
+                                tryLogCurrentException(log);
+                            }
+                        }
                     }
                 }
 
@@ -1496,7 +1480,14 @@ void ZooKeeper::finalize(bool error_send, bool error_receive, const String & rea
                 response.type = SESSION;
                 response.state = EXPIRED_SESSION;
                 response.error = Error::ZSESSIONEXPIRED;
-                triggerWatchCallback(info.watch, response, log);
+                try
+                {
+                    triggerWatchCallback(info.watch, response);
+                }
+                catch (...)
+                {
+                    tryLogCurrentException(log);
+                }
             }
         }
     }

--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -33,6 +33,7 @@
 #include <Common/setThreadName.h>
 #include <Common/thread_local_rng.h>
 #include <Common/MemoryTrackerUntrackedAllocationsBlockerInThread.h>
+#include <Common/ElapsedTimeProfileEventIncrement.h>
 #include <Core/Settings.h>
 #include <Core/ServerSettings.h>
 
@@ -384,7 +385,7 @@ void triggerWatchCallback(
 {
     ProfileEvents::increment(watchTriggeredProfileEvent(event_or_callback.getKind()));
 
-    const auto start_time = std::chrono::steady_clock::now();
+    DB::ProfileEventTimeIncrement<DB::Microseconds> watch_callback_duration(ProfileEvents::ZooKeeperWatchCallbackDurationMicroseconds);
     try
     {
         event_or_callback.invoke(response);
@@ -394,11 +395,9 @@ void triggerWatchCallback(
         ProfileEvents::increment(ProfileEvents::ZooKeeperWatchCallbackErrors);
         if (log)
             tryLogCurrentException(log);
+        else
+            tryLogCurrentException(__PRETTY_FUNCTION__);
     }
-
-    const auto elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(
-        std::chrono::steady_clock::now() - start_time).count();
-    ProfileEvents::increment(ProfileEvents::ZooKeeperWatchCallbackDurationMicroseconds, elapsed_us);
 }
 
 }

--- a/src/Coordination/KeeperConstants.cpp
+++ b/src/Coordination/KeeperConstants.cpp
@@ -280,6 +280,11 @@
     M(KeeperCheckWatchRequest) \
     M(KeeperAddWatchRequest) \
     M(KeeperRemoveWatchRequest) \
+    M(KeeperWatchesTriggered) \
+    M(KeeperWatchTriggeredNodeCreated) \
+    M(KeeperWatchTriggeredNodeDeleted) \
+    M(KeeperWatchTriggeredNodeDataChanged) \
+    M(KeeperWatchTriggeredNodeChildrenChanged) \
     M(KeeperChangelogWrittenBytes) \
     M(KeeperChangelogFileSyncMicroseconds) \
     M(KeeperSnapshotWrittenBytes) \

--- a/src/Coordination/KeeperStorage.cpp
+++ b/src/Coordination/KeeperStorage.cpp
@@ -52,6 +52,11 @@ namespace ProfileEvents
     extern const Event KeeperCheckWatchRequest;
     extern const Event KeeperRemoveWatchRequest;
     extern const Event KeeperAddWatchRequest;
+    extern const Event KeeperWatchesTriggered;
+    extern const Event KeeperWatchTriggeredNodeCreated;
+    extern const Event KeeperWatchTriggeredNodeDeleted;
+    extern const Event KeeperWatchTriggeredNodeDataChanged;
+    extern const Event KeeperWatchTriggeredNodeChildrenChanged;
 }
 
 
@@ -153,6 +158,30 @@ void unregisterEphemeralPath(KeeperStorageBase::Ephemerals & ephemerals, int64_t
         ephemerals.erase(ephemerals_it);
 }
 
+void incrementTriggeredWatchProfileEvent(Coordination::Event event_type, size_t count)
+{
+    if (count == 0)
+        return;
+    ProfileEvents::increment(ProfileEvents::KeeperWatchesTriggered, count);
+    switch (event_type)
+    {
+        case Coordination::Event::CREATED:
+            ProfileEvents::increment(ProfileEvents::KeeperWatchTriggeredNodeCreated, count);
+            break;
+        case Coordination::Event::DELETED:
+            ProfileEvents::increment(ProfileEvents::KeeperWatchTriggeredNodeDeleted, count);
+            break;
+        case Coordination::Event::CHANGED:
+            ProfileEvents::increment(ProfileEvents::KeeperWatchTriggeredNodeDataChanged, count);
+            break;
+        case Coordination::Event::CHILD:
+            ProfileEvents::increment(ProfileEvents::KeeperWatchTriggeredNodeChildrenChanged, count);
+            break;
+        default:
+            break;
+    }
+}
+
 KeeperResponsesForSessions processWatchesImplBase(
     const String & path,
     KeeperStorageBase::Watches & watches,
@@ -182,6 +211,7 @@ KeeperResponsesForSessions processWatchesImplBase(
             }
             result.push_back(KeeperResponseForSession{watcher_session, watch_response});
         }
+        incrementTriggeredWatchProfileEvent(event_type, watch_it->second.size());
 
         if (should_delete)
             watches.erase(watch_it);
@@ -227,6 +257,9 @@ KeeperResponsesForSessions processWatchesImplBase(
                 }
                 result.push_back(KeeperResponseForSession{watcher_session, watch_list_response});
             }
+            incrementTriggeredWatchProfileEvent(
+                static_cast<Coordination::Event>(watch_list_response->type),
+                watch_it->second.size());
 
             if (should_delete)
                 list_watches.erase(watch_it);
@@ -263,6 +296,7 @@ std::pair<KeeperResponsesForSessions, Int64> processWatchesImpl(
                 watch_list_response->state = Coordination::State::CONNECTED;
                 for (auto watcher_session : watch_it->second)
                     result.push_back(KeeperResponseForSession{watcher_session, watch_list_response});
+                incrementTriggeredWatchProfileEvent(event_type, watch_it->second.size());
             }
 
             if (current_path == "/")

--- a/src/Functions/UserDefined/UserDefinedSQLObjectsZooKeeperStorage.cpp
+++ b/src/Functions/UserDefined/UserDefinedSQLObjectsZooKeeperStorage.cpp
@@ -19,6 +19,11 @@
 #include <Core/Settings.h>
 #include <IO/WriteHelpers.h>
 
+namespace ProfileEvents
+{
+    extern const Event ZooKeeperWatchTriggeredUserDefinedSQLObjects;
+}
+
 namespace DB
 {
 namespace Setting
@@ -321,7 +326,7 @@ bool UserDefinedSQLObjectsZooKeeperStorage::getObjectDataAndSetWatch(
             /// Event::DELETED is processed as child event by getChildren watch
         };
     });
-    object_watcher.setKind(Coordination::WatchCallbackKind::UserDefinedSQLObjects);
+    object_watcher.setTriggeredEvent(ProfileEvents::ZooKeeperWatchTriggeredUserDefinedSQLObjects);
 
     Coordination::Stat entity_stat;
     return zookeeper->tryGetWatch(path, data, &entity_stat, object_watcher);
@@ -396,7 +401,7 @@ Strings UserDefinedSQLObjectsZooKeeperStorage::getObjectNamesAndSetWatch(
             /// `inserted` can be false if `watch_queue` was already finalized (which happens when stopWatching() is called).
         };
     });
-    object_list_watcher.setKind(Coordination::WatchCallbackKind::UserDefinedSQLObjects);
+    object_list_watcher.setTriggeredEvent(ProfileEvents::ZooKeeperWatchTriggeredUserDefinedSQLObjects);
 
     Coordination::Stat stat;
     const auto node_names = zookeeper->getChildrenWatch(zookeeper_path, &stat, object_list_watcher);

--- a/src/Functions/UserDefined/UserDefinedSQLObjectsZooKeeperStorage.cpp
+++ b/src/Functions/UserDefined/UserDefinedSQLObjectsZooKeeperStorage.cpp
@@ -321,6 +321,7 @@ bool UserDefinedSQLObjectsZooKeeperStorage::getObjectDataAndSetWatch(
             /// Event::DELETED is processed as child event by getChildren watch
         };
     });
+    object_watcher.setKind(Coordination::WatchCallbackKind::UserDefinedSQLObjects);
 
     Coordination::Stat entity_stat;
     return zookeeper->tryGetWatch(path, data, &entity_stat, object_watcher);
@@ -395,6 +396,7 @@ Strings UserDefinedSQLObjectsZooKeeperStorage::getObjectNamesAndSetWatch(
             /// `inserted` can be false if `watch_queue` was already finalized (which happens when stopWatching() is called).
         };
     });
+    object_list_watcher.setKind(Coordination::WatchCallbackKind::UserDefinedSQLObjects);
 
     Coordination::Stat stat;
     const auto node_names = zookeeper->getChildrenWatch(zookeeper_path, &stat, object_list_watcher);

--- a/src/Interpreters/ClusterDiscovery.cpp
+++ b/src/Interpreters/ClusterDiscovery.cpp
@@ -36,6 +36,11 @@
 #include <fmt/ranges.h>
 
 
+namespace ProfileEvents
+{
+    extern const Event ZooKeeperWatchTriggeredClusterDiscovery;
+}
+
 namespace DB
 {
 
@@ -305,7 +310,7 @@ Strings ClusterDiscovery::getNodeNames(zkutil::ZooKeeperPtr & zk,
         nodes = zk->getChildrenWatch(
             getShardsListPath(zk_root),
             &stat,
-            Coordination::WatchCallbackPtrOrEventPtr{callback->second, Coordination::WatchCallbackKind::ClusterDiscovery});
+            Coordination::WatchCallbackPtrOrEventPtr{callback->second, ProfileEvents::ZooKeeperWatchTriggeredClusterDiscovery});
     }
     else
         nodes = zk->getChildren(getShardsListPath(zk_root), &stat);
@@ -594,7 +599,7 @@ void ClusterDiscovery::findDynamicClusters(
         auto clusters = zk->getChildrenWatch(
             path.zk_path,
             nullptr,
-            Coordination::WatchCallbackPtrOrEventPtr{path.watch_callback, Coordination::WatchCallbackKind::ClusterDiscovery});
+            Coordination::WatchCallbackPtrOrEventPtr{path.watch_callback, ProfileEvents::ZooKeeperWatchTriggeredClusterDiscovery});
 
         for (const auto & cluster : clusters)
         {

--- a/src/Interpreters/ClusterDiscovery.cpp
+++ b/src/Interpreters/ClusterDiscovery.cpp
@@ -302,7 +302,10 @@ Strings ClusterDiscovery::getNodeNames(zkutil::ZooKeeperPtr & zk,
             auto res = get_nodes_callbacks.insert(std::make_pair(cluster_name, watch_dynamic_callback));
             callback = res.first;
         }
-        nodes = zk->getChildrenWatch(getShardsListPath(zk_root), &stat, callback->second);
+        nodes = zk->getChildrenWatch(
+            getShardsListPath(zk_root),
+            &stat,
+            Coordination::WatchCallbackPtrOrEventPtr{callback->second, Coordination::WatchCallbackKind::ClusterDiscovery});
     }
     else
         nodes = zk->getChildren(getShardsListPath(zk_root), &stat);
@@ -588,7 +591,10 @@ void ClusterDiscovery::findDynamicClusters(
 
         auto zk = context->getDefaultOrAuxiliaryZooKeeper(path.zk_name);
 
-        auto clusters = zk->getChildrenWatch(path.zk_path, nullptr, path.watch_callback);
+        auto clusters = zk->getChildrenWatch(
+            path.zk_path,
+            nullptr,
+            Coordination::WatchCallbackPtrOrEventPtr{path.watch_callback, Coordination::WatchCallbackKind::ClusterDiscovery});
 
         for (const auto & cluster : clusters)
         {

--- a/src/Interpreters/DDLWorker.cpp
+++ b/src/Interpreters/DDLWorker.cpp
@@ -27,6 +27,7 @@
 
 #include <Poco/Timestamp.h>
 #include <Common/OpenTelemetryTraceContext.h>
+#include <Common/ProfileEvents.h>
 #include <Common/ThreadPool.h>
 #include <Common/ZooKeeper/KeeperException.h>
 #include <Common/ZooKeeper/ZooKeeper.h>
@@ -54,6 +55,11 @@ namespace CurrentMetrics
     extern const Metric DDLWorkerThreads;
     extern const Metric DDLWorkerThreadsActive;
     extern const Metric DDLWorkerThreadsScheduled;
+}
+
+namespace ProfileEvents
+{
+    extern const Event ZooKeeperWatchTriggeredDistributedDDL;
 }
 
 namespace DB
@@ -399,7 +405,10 @@ void DDLWorker::scheduleTasks(bool reinitialized)
         first_failed_task_name.reset();
     }
 
-    Strings queue_nodes = zookeeper->getChildren(queue_dir, &queue_node_stat, queue_updated_event);
+    Strings queue_nodes = zookeeper->getChildrenWatch(
+        queue_dir,
+        &queue_node_stat,
+        Coordination::WatchCallbackPtrOrEventPtr{queue_updated_event, ProfileEvents::ZooKeeperWatchTriggeredDistributedDDL});
     size_t size_before_filtering = queue_nodes.size();
     filterAndSortQueueNodes(queue_nodes);
     /// The following message is too verbose, but it can be useful to debug mysterious test failures in CI
@@ -859,7 +868,7 @@ bool DDLWorker::tryExecuteQueryOnSingleReplica(
     Coordination::EventPtr event = std::make_shared<Poco::Event>();
     /// We must use exists request instead of get, because zookeeper will not setup event
     /// for non existing node after get request
-    if (zookeeper->exists(is_executed_path, nullptr, event))
+    if (zookeeper->existsWatch(is_executed_path, nullptr, Coordination::WatchCallbackPtrOrEventPtr{event, ProfileEvents::ZooKeeperWatchTriggeredDistributedDDL}))
     {
         LOG_DEBUG(log, "Task {} has already been executed by replica ({}) of the same shard.", task.entry_name, zookeeper->get(is_executed_path));
         if (auto op = task.getOpToUpdateLogPointer())

--- a/src/Storages/MaterializedView/RefreshTask.cpp
+++ b/src/Storages/MaterializedView/RefreshTask.cpp
@@ -1182,15 +1182,17 @@ void RefreshTask::readZnodesIfNeeded(std::shared_ptr<zkutil::ZooKeeper> zookeepe
         throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Keeper server doesn't support multi-reads. Refreshable materialized views won't work.");
 
     /// Set watches. (This is a lot of code, is there a better way?)
+    Coordination::WatchCallbackPtrOrEventPtr labelled_watch{
+        watch_callback, Coordination::WatchCallbackKind::MaterializedViewRefresh};
     if (!coordination.watches->root_watch_active.load())
     {
         coordination.watches->root_watch_active.store(true);
-        zookeeper->existsWatch(coordination.path, nullptr, watch_callback);
+        zookeeper->existsWatch(coordination.path, nullptr, labelled_watch);
     }
     if (!coordination.watches->children_watch_active.load())
     {
         coordination.watches->children_watch_active.store(true);
-        zookeeper->getChildrenWatch(coordination.path, nullptr, watch_callback);
+        zookeeper->getChildrenWatch(coordination.path, nullptr, labelled_watch);
     }
 
     Strings paths {coordination.path, coordination.path + "/running", coordination.path + "/paused"};

--- a/src/Storages/MaterializedView/RefreshTask.cpp
+++ b/src/Storages/MaterializedView/RefreshTask.cpp
@@ -41,6 +41,7 @@ namespace ProfileEvents
     extern const Event RefreshableViewSyncReplicaSuccess;
     extern const Event RefreshableViewSyncReplicaRetry;
     extern const Event RefreshableViewLockTableRetry;
+    extern const Event ZooKeeperWatchTriggeredMaterializedViewRefresh;
 }
 
 namespace DB
@@ -1183,7 +1184,7 @@ void RefreshTask::readZnodesIfNeeded(std::shared_ptr<zkutil::ZooKeeper> zookeepe
 
     /// Set watches. (This is a lot of code, is there a better way?)
     Coordination::WatchCallbackPtrOrEventPtr labelled_watch{
-        watch_callback, Coordination::WatchCallbackKind::MaterializedViewRefresh};
+        watch_callback, ProfileEvents::ZooKeeperWatchTriggeredMaterializedViewRefresh};
     if (!coordination.watches->root_watch_active.load())
     {
         coordination.watches->root_watch_active.store(true);

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -23,6 +23,12 @@
 #include <shared_mutex>
 #include <Poco/Timestamp.h>
 
+namespace ProfileEvents
+{
+    extern const Event ZooKeeperWatchTriggeredReplicatedMergeTreeLog;
+    extern const Event ZooKeeperWatchTriggeredReplicatedMergeTreeMutations;
+}
+
 namespace DB
 {
 
@@ -838,7 +844,7 @@ std::pair<int32_t, int32_t> ReplicatedMergeTreeQueue::pullLogsToQueue(zkutil::Zo
     Strings log_entries = zookeeper->getChildrenWatch(
         fs::path(zookeeper_path) / "log",
         nullptr,
-        Coordination::WatchCallbackPtrOrEventPtr{watch_callback, Coordination::WatchCallbackKind::ReplicatedMergeTreeLog});
+        Coordination::WatchCallbackPtrOrEventPtr{watch_callback, ProfileEvents::ZooKeeperWatchTriggeredReplicatedMergeTreeLog});
 
     /// We update mutations after we have loaded the list of log entries, but before we insert them
     /// in the queue.
@@ -1143,7 +1149,7 @@ int32_t ReplicatedMergeTreeQueue::updateMutations(zkutil::ZooKeeperPtr zookeeper
     Strings entries_in_zk = zookeeper->getChildrenWatch(
         fs::path(zookeeper_path) / "mutations",
         &mutations_stat,
-        Coordination::WatchCallbackPtrOrEventPtr{watch_callback, Coordination::WatchCallbackKind::ReplicatedMergeTreeMutations});
+        Coordination::WatchCallbackPtrOrEventPtr{watch_callback, ProfileEvents::ZooKeeperWatchTriggeredReplicatedMergeTreeMutations});
     StringSet entries_in_zk_set(entries_in_zk.begin(), entries_in_zk.end());
 
     /// Compare with the local state, delete obsolete entries and determine which new entries to load.

--- a/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeQueue.cpp
@@ -835,7 +835,10 @@ std::pair<int32_t, int32_t> ReplicatedMergeTreeQueue::pullLogsToQueue(zkutil::Zo
     Coordination::Stat stat;
     zookeeper->get(fs::path(zookeeper_path) / "log", &stat);
 
-    Strings log_entries = zookeeper->getChildrenWatch(fs::path(zookeeper_path) / "log", nullptr, watch_callback);
+    Strings log_entries = zookeeper->getChildrenWatch(
+        fs::path(zookeeper_path) / "log",
+        nullptr,
+        Coordination::WatchCallbackPtrOrEventPtr{watch_callback, Coordination::WatchCallbackKind::ReplicatedMergeTreeLog});
 
     /// We update mutations after we have loaded the list of log entries, but before we insert them
     /// in the queue.
@@ -1137,7 +1140,10 @@ int32_t ReplicatedMergeTreeQueue::updateMutations(zkutil::ZooKeeperPtr zookeeper
     std::lock_guard lock(update_mutations_mutex);
 
     Coordination::Stat mutations_stat;
-    Strings entries_in_zk = zookeeper->getChildrenWatch(fs::path(zookeeper_path) / "mutations", &mutations_stat, watch_callback);
+    Strings entries_in_zk = zookeeper->getChildrenWatch(
+        fs::path(zookeeper_path) / "mutations",
+        &mutations_stat,
+        Coordination::WatchCallbackPtrOrEventPtr{watch_callback, Coordination::WatchCallbackKind::ReplicatedMergeTreeMutations});
     StringSet entries_in_zk_set(entries_in_zk.begin(), entries_in_zk.end());
 
     /// Compare with the local state, delete obsolete entries and determine which new entries to load.

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -58,6 +58,7 @@ namespace ProfileEvents
     extern const Event ObjectStorageQueueUnsuccessfulCommits;
     extern const Event ObjectStorageQueueInsertIterations;
     extern const Event ObjectStorageQueueProcessedRows;
+    extern const Event ZooKeeperWatchTriggeredObjectStorageQueue;
 }
 
 
@@ -1814,7 +1815,7 @@ void StorageObjectStorageQueue::waitForPathToBeProcessed(
                 ///              when the node is first created.
                 std::string dummy_data;
                 Coordination::Stat dummy_stat{};
-                Coordination::WatchCallbackPtrOrEventPtr labelled_event{event, Coordination::WatchCallbackKind::ObjectStorageQueue};
+                Coordination::WatchCallbackPtrOrEventPtr labelled_event{event, ProfileEvents::ZooKeeperWatchTriggeredObjectStorageQueue};
                 const bool node_exists = zk->tryGetWatch(processed_node_path, dummy_data, &dummy_stat, labelled_event);
                 if (!node_exists)
                     zk->existsWatch(processed_node_path, nullptr, labelled_event);
@@ -1824,13 +1825,13 @@ void StorageObjectStorageQueue::waitForPathToBeProcessed(
                 /// Unordered: each file gets its own processed node; watch for its creation.
                 zk->existsWatch(
                     processed_node_path, nullptr,
-                    Coordination::WatchCallbackPtrOrEventPtr{event, Coordination::WatchCallbackKind::ObjectStorageQueue});
+                    Coordination::WatchCallbackPtrOrEventPtr{event, ProfileEvents::ZooKeeperWatchTriggeredObjectStorageQueue});
             }
 
             /// Per-file failed node: watch for creation regardless of mode.
             zk->existsWatch(
                 failed_node_path, nullptr,
-                Coordination::WatchCallbackPtrOrEventPtr{event, Coordination::WatchCallbackKind::ObjectStorageQueue});
+                Coordination::WatchCallbackPtrOrEventPtr{event, ProfileEvents::ZooKeeperWatchTriggeredObjectStorageQueue});
         });
 
         std::string failure_message;

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -1814,18 +1814,23 @@ void StorageObjectStorageQueue::waitForPathToBeProcessed(
                 ///              when the node is first created.
                 std::string dummy_data;
                 Coordination::Stat dummy_stat{};
-                const bool node_exists = zk->tryGetWatch(processed_node_path, dummy_data, &dummy_stat, event);
+                Coordination::WatchCallbackPtrOrEventPtr labelled_event{event, Coordination::WatchCallbackKind::ObjectStorageQueue};
+                const bool node_exists = zk->tryGetWatch(processed_node_path, dummy_data, &dummy_stat, labelled_event);
                 if (!node_exists)
-                    zk->existsWatch(processed_node_path, nullptr, event);
+                    zk->existsWatch(processed_node_path, nullptr, labelled_event);
             }
             else
             {
                 /// Unordered: each file gets its own processed node; watch for its creation.
-                zk->existsWatch(processed_node_path, nullptr, event);
+                zk->existsWatch(
+                    processed_node_path, nullptr,
+                    Coordination::WatchCallbackPtrOrEventPtr{event, Coordination::WatchCallbackKind::ObjectStorageQueue});
             }
 
             /// Per-file failed node: watch for creation regardless of mode.
-            zk->existsWatch(failed_node_path, nullptr, event);
+            zk->existsWatch(
+                failed_node_path, nullptr,
+                Coordination::WatchCallbackPtrOrEventPtr{event, Coordination::WatchCallbackKind::ObjectStorageQueue});
         });
 
         std::string failure_message;

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -154,6 +154,7 @@ namespace ProfileEvents
     extern const Event ReplicaPartialShutdown;
     extern const Event ReplicatedCoveredPartsInZooKeeperOnStart;
     extern const Event MergesRejectedByMemoryLimit;
+    extern const Event ZooKeeperWatchTriggeredReplicatedMergeTreeLeaderElection;
 }
 
 namespace CurrentMetrics
@@ -10928,7 +10929,7 @@ void StorageReplicatedMergeTree::watchZeroCopyLock(const String & part_name, con
                 *flag = false;
             };
         });
-        watch.setKind(Coordination::WatchCallbackKind::ReplicatedMergeTreeLeaderElection);
+        watch.setTriggeredEvent(ProfileEvents::ZooKeeperWatchTriggeredReplicatedMergeTreeLeaderElection);
         bool exists = zookeeper->tryGetWatch(lock_path, replica, nullptr, watch);
 
         if (exists)

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -10928,6 +10928,7 @@ void StorageReplicatedMergeTree::watchZeroCopyLock(const String & part_name, con
                 *flag = false;
             };
         });
+        watch.setKind(Coordination::WatchCallbackKind::ReplicatedMergeTreeLeaderElection);
         bool exists = zookeeper->tryGetWatch(lock_path, replica, nullptr, watch);
 
         if (exists)

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -155,6 +155,8 @@ namespace ProfileEvents
     extern const Event ReplicatedCoveredPartsInZooKeeperOnStart;
     extern const Event MergesRejectedByMemoryLimit;
     extern const Event ZooKeeperWatchTriggeredReplicatedMergeTreeLeaderElection;
+    extern const Event ZooKeeperWatchTriggeredReplicatedMergeTreeReplicaSync;
+    extern const Event ZooKeeperWatchTriggeredReplicatedMergeTreeMutations;
 }
 
 namespace CurrentMetrics
@@ -740,7 +742,10 @@ void StorageReplicatedMergeTree::waitMutationToFinishOnReplicas(
             /// Mutation maybe killed or whole replica was deleted.
             /// Wait event will unblock at this moment.
             Coordination::Stat exists_stat;
-            if (!getZooKeeper()->exists(fs::path(zookeeper_path) / "mutations" / mutation_id, &exists_stat, wait_event))
+            if (!getZooKeeper()->existsWatch(
+                    fs::path(zookeeper_path) / "mutations" / mutation_id,
+                    &exists_stat,
+                    Coordination::WatchCallbackPtrOrEventPtr{wait_event, ProfileEvents::ZooKeeperWatchTriggeredReplicatedMergeTreeMutations}))
             {
                 throw Exception(ErrorCodes::UNFINISHED, "Mutation {} was killed, manually removed or table was dropped", mutation_id);
             }
@@ -763,7 +768,11 @@ void StorageReplicatedMergeTree::waitMutationToFinishOnReplicas(
 
             std::string mutation_pointer_value;
             /// Replica could be removed
-            if (!zookeeper->tryGet(mutation_pointer, mutation_pointer_value, nullptr, wait_event))
+            if (!zookeeper->tryGetWatch(
+                    mutation_pointer,
+                    mutation_pointer_value,
+                    nullptr,
+                    Coordination::WatchCallbackPtrOrEventPtr{wait_event, ProfileEvents::ZooKeeperWatchTriggeredReplicatedMergeTreeMutations}))
             {
                 LOG_WARNING(log, "Replica {} was removed during mutation. "
                     "Mutation will be done asynchronously when replica is restored.", replica);
@@ -7567,7 +7576,10 @@ bool StorageReplicatedMergeTree::tryWaitForReplicaToProcessLogEntry(
         bool pulled_to_queue = false;
         do
         {
-            String log_pointer = getZooKeeper()->get(fs::path(table_zookeeper_path) / "replicas" / replica / "log_pointer", nullptr, watch_event);
+            String log_pointer = getZooKeeper()->getWatch(
+                fs::path(table_zookeeper_path) / "replicas" / replica / "log_pointer",
+                nullptr,
+                Coordination::WatchCallbackPtrOrEventPtr{watch_event, ProfileEvents::ZooKeeperWatchTriggeredReplicatedMergeTreeReplicaSync});
             if (!log_pointer.empty() && parse<UInt64>(log_pointer) > log_index)
             {
                 pulled_to_queue = true;
@@ -7635,7 +7647,10 @@ bool StorageReplicatedMergeTree::tryWaitForReplicaToProcessLogEntry(
             {
                 Coordination::EventPtr event = std::make_shared<Poco::Event>();
 
-                log_pointer = getZooKeeper()->get(fs::path(table_zookeeper_path) / "replicas" / replica / "log_pointer", nullptr, event);
+                log_pointer = getZooKeeper()->getWatch(
+                    fs::path(table_zookeeper_path) / "replicas" / replica / "log_pointer",
+                    nullptr,
+                    Coordination::WatchCallbackPtrOrEventPtr{event, ProfileEvents::ZooKeeperWatchTriggeredReplicatedMergeTreeReplicaSync});
                 if (!log_pointer.empty() && parse<UInt64>(log_pointer) > log_index)
                 {
                     pulled_to_queue = true;
@@ -7703,7 +7718,8 @@ bool StorageReplicatedMergeTree::tryWaitForReplicaToProcessLogEntry(
     /// Third - wait until the entry disappears from the replica queue or replica become inactive.
     String path_to_wait_on = fs::path(table_zookeeper_path) / "replicas" / replica / "queue" / queue_entry_to_wait_for;
 
-    return getZooKeeper()->waitForDisappear(path_to_wait_on, stop_waiting);
+    return getZooKeeper()->waitForDisappear(
+        path_to_wait_on, stop_waiting, ProfileEvents::ZooKeeperWatchTriggeredReplicatedMergeTreeReplicaSync);
 }
 
 

--- a/tests/integration/test_keeper_watch_profile_events/configs/enable_keeper.xml
+++ b/tests/integration/test_keeper_watch_profile_events/configs/enable_keeper.xml
@@ -1,0 +1,27 @@
+<clickhouse>
+    <keeper_server>
+        <use_cluster>false</use_cluster>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+
+        <coordination_settings>
+            <operation_timeout_ms>5000</operation_timeout_ms>
+            <session_timeout_ms>10000</session_timeout_ms>
+            <raft_logs_level>trace</raft_logs_level>
+            <force_sync>false</force_sync>
+            <heart_beat_interval_ms>0</heart_beat_interval_ms>
+            <election_timeout_lower_bound_ms>0</election_timeout_lower_bound_ms>
+            <election_timeout_upper_bound_ms>0</election_timeout_upper_bound_ms>
+        </coordination_settings>
+
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>localhost</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+</clickhouse>

--- a/tests/integration/test_keeper_watch_profile_events/test.py
+++ b/tests/integration/test_keeper_watch_profile_events/test.py
@@ -1,0 +1,111 @@
+import threading
+import uuid
+
+import pytest
+
+import helpers.keeper_utils as keeper_utils
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["configs/enable_keeper.xml"],
+    stay_alive=True,
+    with_remote_database_disk=False,
+)
+
+
+def get_fake_zk():
+    return keeper_utils.get_fake_zk(cluster, "node")
+
+
+def stop_zk(zk):
+    try:
+        if zk:
+            zk.stop()
+            zk.close()
+    except:
+        pass
+
+
+def get_event_value(event_name):
+    result = node.query(
+        f"SELECT value FROM system.events WHERE event = '{event_name}'"
+    ).strip()
+    return int(result) if result else 0
+
+
+def make_watch():
+    """Return (event, callback). The callback is fired by kazoo once the watch is triggered."""
+    fired = threading.Event()
+
+    def callback(_watched_event):
+        fired.set()
+
+    return fired, callback
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_keeper_watch_triggered_profile_events(started_cluster):
+    zk = None
+    try:
+        zk = get_fake_zk()
+
+        root = f"/test_watch_events_{uuid.uuid4().hex[:8]}"
+        zk.create(root)
+
+        total_before = get_event_value("KeeperWatchesTriggered")
+        created_before = get_event_value("KeeperWatchTriggeredNodeCreated")
+        deleted_before = get_event_value("KeeperWatchTriggeredNodeDeleted")
+        changed_before = get_event_value("KeeperWatchTriggeredNodeDataChanged")
+        children_before = get_event_value("KeeperWatchTriggeredNodeChildrenChanged")
+
+        created_path = f"{root}/created"
+        fired, callback = make_watch()
+        assert zk.exists(created_path, watch=callback) is None
+        zk.create(created_path)
+        assert fired.wait(timeout=30), "CREATED watch was not triggered"
+
+        fired, callback = make_watch()
+        zk.get(created_path, watch=callback)
+        zk.set(created_path, b"new-data")
+        assert fired.wait(timeout=30), "CHANGED watch was not triggered"
+
+        fired, callback = make_watch()
+        zk.get_children(root, watch=callback)
+        child_path = f"{root}/child"
+        zk.create(child_path)
+        assert fired.wait(timeout=30), "CHILD watch was not triggered"
+
+        fired, callback = make_watch()
+        zk.get(child_path, watch=callback)
+        zk.delete(child_path)
+        assert fired.wait(timeout=30), "DELETED watch was not triggered"
+
+        created_diff = get_event_value("KeeperWatchTriggeredNodeCreated") - created_before
+        changed_diff = get_event_value("KeeperWatchTriggeredNodeDataChanged") - changed_before
+        children_diff = (
+            get_event_value("KeeperWatchTriggeredNodeChildrenChanged") - children_before
+        )
+        deleted_diff = get_event_value("KeeperWatchTriggeredNodeDeleted") - deleted_before
+        total_diff = get_event_value("KeeperWatchesTriggered") - total_before
+
+        assert created_diff >= 1, f"KeeperWatchTriggeredNodeCreated diff {created_diff} < 1"
+        assert changed_diff >= 1, f"KeeperWatchTriggeredNodeDataChanged diff {changed_diff} < 1"
+        assert (
+            children_diff >= 1
+        ), f"KeeperWatchTriggeredNodeChildrenChanged diff {children_diff} < 1"
+        assert deleted_diff >= 1, f"KeeperWatchTriggeredNodeDeleted diff {deleted_diff} < 1"
+
+        assert total_diff >= 4, f"KeeperWatchesTriggered diff {total_diff} < 4"
+    finally:
+        stop_zk(zk)


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add more keeper profile (server-side + client-side) events for watches. Closes https://github.com/ClickHouse/ClickHouse/issues/97703

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.398`
<!-- ch-version-info:end -->