### PR TITLE
Docs: correct quantileBFloat16 max relative error bound

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionQuantileBFloat16.cpp
+++ b/src/AggregateFunctions/AggregateFunctionQuantileBFloat16.cpp
@@ -56,7 +56,7 @@ Computes an approximate [quantile](https://en.wikipedia.org/wiki/Quantile) of a 
 
 `bfloat16` is a floating-point data type with 1 sign bit, 8 exponent bits and 7 fraction bits.
 The function converts input values to 32-bit floats and takes the most significant 16 bits. Then it calculates `bfloat16` quantile value and converts the result to a 64-bit float by appending zero bits.
-The function is a fast quantile estimator with a relative error no more than 0.390625%.
+The function is a fast quantile estimator with a maximum relative error of `0.78125%` (and an average relative error of approximately `0.27%`), corresponding to the 7-bit mantissa precision of `bfloat16`.
     )";
     FunctionDocumentation::Syntax syntax = R"(
 quantileBFloat16[(level)](expr)

--- a/src/AggregateFunctions/AggregateFunctionQuantileBFloat16Weighted.cpp
+++ b/src/AggregateFunctions/AggregateFunctionQuantileBFloat16Weighted.cpp
@@ -55,7 +55,7 @@ Computes an approximate [quantile](https://en.wikipedia.org/wiki/Quantile) of a 
 `bfloat16` is a floating-point data type with 1 sign bit, 8 exponent bits and 7 fraction bits.
 The function converts input values to 32-bit floats and takes the most significant 16 bits.
 Then it calculates `bfloat16` quantile value and converts the result to a 64-bit float by appending zero bits.
-The function is a fast quantile estimator with a relative error no more than 0.390625%.
+The function is a fast quantile estimator with a maximum relative error of `0.78125%` (and an average relative error of approximately `0.27%`), corresponding to the 7-bit mantissa precision of `bfloat16`.
     )";
     FunctionDocumentation::Syntax syntax = R"(
 quantileBFloat16Weighted(level)(expr, weight)


### PR DESCRIPTION
Internal user flagged that the documented maximum relative error for `quantileBFloat16` / `quantileBFloat16Weighted` was `0.390625%`, but the true maximum relative error matches the 7-bit mantissa precision of `bfloat16`, i.e. `1 / 128 = 0.78125%`. 

Also mention the average relative error (~0.27%) for context.

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.881`
<!-- ch-version-info:end -->