### PR TITLE
Fix columns descriptions cache eviction for Nested columns

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeDataPart.cpp
+++ b/src/Storages/MergeTree/IMergeTreeDataPart.cpp
@@ -727,7 +727,9 @@ void IMergeTreeDataPart::setColumns(const NamesAndTypesList & new_columns, const
 
     auto columns_descriptions = storage.getColumnsDescriptionForColumns(columns);
     columns_description = columns_descriptions.original;
-    columns_description_with_collected_nested = columns_descriptions.with_collected_nested;
+    columns_description_with_collected_nested = columns_descriptions.with_collected_nested
+        ? columns_descriptions.with_collected_nested
+        : columns_descriptions.original;
 }
 
 String IMergeTreeDataPart::getProjectionName() const

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -11076,8 +11076,11 @@ MergeTreeData::ColumnsDescriptionCache MergeTreeData::getColumnsDescriptionForCo
             ? std::make_shared<ColumnsDescription>(Nested::collect(columns))
             : nullptr,
     };
-    if (!cache.with_collected_nested || *cache.with_collected_nested == *cache.original)
-        cache.with_collected_nested = cache.original;
+    /// Keep `with_collected_nested` only when `Nested::collect` produced a distinct list.
+    /// The caller falls back to `original` when this is null, so the cache always holds
+    /// exactly one ref to `original` regardless of the schema shape.
+    if (cache.with_collected_nested && *cache.with_collected_nested == *cache.original)
+        cache.with_collected_nested.reset();
     auto [_, inserted] = columns_descriptions_cache.emplace(columns, cache);
     columns_descriptions_metric_handle.add(inserted);
     return cache;
@@ -11090,12 +11093,10 @@ void MergeTreeData::decrefColumnsDescriptionForColumns(const NamesAndTypesList &
     if (it == columns_descriptions_cache.end())
         return;
 
-    /// `original` always contributes one ref from the cache entry. `with_collected_nested`
-    /// is either aliased to `original` (no `Nested` columns or `share_nested_offsets=0`)
-    /// or a distinct object. In the aliased case the cache contributes 2 refs to the
-    /// `original` shared_ptr; otherwise 1. Evict only when no part still holds a ref.
-    const bool aliased = it->second.original == it->second.with_collected_nested;
-    if (it->second.original.use_count() == (aliased ? 2 : 1))
+    /// The cache entry holds exactly one ref to `original` (via `cache.original`).
+    /// `with_collected_nested` is either null or a distinct shared_ptr, so it does
+    /// not contribute additional refs to `original`. Evict once no part holds a ref.
+    if (it->second.original.use_count() == 1)
     {
         columns_descriptions_cache.erase(it);
         columns_descriptions_metric_handle.sub(1);

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -11086,21 +11086,19 @@ MergeTreeData::ColumnsDescriptionCache MergeTreeData::getColumnsDescriptionForCo
 void MergeTreeData::decrefColumnsDescriptionForColumns(const NamesAndTypesList & columns) const
 {
     std::lock_guard lock(columns_descriptions_cache_mutex);
-    if (auto it = columns_descriptions_cache.find(columns); it != columns_descriptions_cache.end())
+    auto it = columns_descriptions_cache.find(columns);
+    if (it == columns_descriptions_cache.end())
+        return;
+
+    /// `original` always contributes one ref from the cache entry. `with_collected_nested`
+    /// is either aliased to `original` (no `Nested` columns or `share_nested_offsets=0`)
+    /// or a distinct object. In the aliased case the cache contributes 2 refs to the
+    /// `original` shared_ptr; otherwise 1. Evict only when no part still holds a ref.
+    const bool aliased = it->second.original == it->second.with_collected_nested;
+    if (it->second.original.use_count() == (aliased ? 2 : 1))
     {
-        /// 1 in the container + 1 in the iterator
-        ///
-        /// Note, we cannot check original.use_count() == with_collected_nested.use_count(),
-        /// since in IMergeTreeDataPart::setColumns() there is a tiny window when it is not correct.
-        ///
-        /// But, if original.use_count() == 2 then it is **always** safe to delete,
-        /// since this means that there are no other references to the shared_ptr
-        /// except in the columns_descriptions_cache and local copy here in iterator.
-        if (it->second.original.use_count() == 2)
-        {
-            columns_descriptions_cache.erase(it);
-            columns_descriptions_metric_handle.sub(1);
-        }
+        columns_descriptions_cache.erase(it);
+        columns_descriptions_metric_handle.sub(1);
     }
 }
 

--- a/tests/queries/0_stateless/04257_102926_columns_descriptions_cache_nested_eviction.reference
+++ b/tests/queries/0_stateless/04257_102926_columns_descriptions_cache_nested_eviction.reference
@@ -1,0 +1,14 @@
+-- { echoOn }
+create table t_nested_leak (key Int, `n.a` Array(Int32), `n.b` Array(String)) engine=MergeTree() order by key;
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_nested_leak';
+0
+insert into t_nested_leak values (1, [10], ['hello']);
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_nested_leak';
+1
+alter table t_nested_leak add column value String settings mutations_sync=2;
+insert into t_nested_leak values (10, [30], ['!'], '10');
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_nested_leak';
+2
+alter table t_nested_leak detach part 'all_1_1_0';
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_nested_leak';
+1

--- a/tests/queries/0_stateless/04257_102926_columns_descriptions_cache_nested_eviction.sql
+++ b/tests/queries/0_stateless/04257_102926_columns_descriptions_cache_nested_eviction.sql
@@ -1,0 +1,19 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/102926
+-- `decrefColumnsDescriptionForColumns` must evict cache entries for schemas with
+-- `Nested` columns where `Nested::collect` produces a distinct `with_collected_nested`.
+
+drop table if exists t_nested_leak;
+
+-- { echoOn }
+create table t_nested_leak (key Int, `n.a` Array(Int32), `n.b` Array(String)) engine=MergeTree() order by key;
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_nested_leak';
+insert into t_nested_leak values (1, [10], ['hello']);
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_nested_leak';
+alter table t_nested_leak add column value String settings mutations_sync=2;
+insert into t_nested_leak values (10, [30], ['!'], '10');
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_nested_leak';
+alter table t_nested_leak detach part 'all_1_1_0';
+select columns_descriptions_cache_size from system.tables where database = currentDatabase() and table = 't_nested_leak';
+-- { echoOff }
+
+drop table t_nested_leak;


### PR DESCRIPTION
Closes #102926.

`MergeTreeData::decrefColumnsDescriptionForColumns` used `use_count() == 2` as the eviction threshold. That holds only when `with_collected_nested` aliases `original` (no `Nested` columns or `share_nested_offsets=0`); when `Nested::collect` returns a distinct list, the cache stores two separate `shared_ptr` objects and `original.use_count()` is 1 after the last part is destroyed, so the entry leaks across `ALTER ADD/DROP COLUMN` cycles.

Pick the expected refcount based on whether the pair aliases.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a memory leak in the per-table `ColumnsDescription` cache for `MergeTree`-family tables with `Nested` columns. Entries were never evicted across `ALTER ADD COLUMN`/`DROP COLUMN` cycles when `share_nested_offsets=1` (the default).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.872`
<!-- ch-version-info:end -->