### PR TITLE
Refresh AWS STS credentials mid-query when Glue catalog reads hit ExpiredToken

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -61,6 +61,7 @@ static struct InitFiu
     ONCE(rmt_lightweight_update_sleep_after_block_allocation) \
     ONCE(rmt_merge_task_sleep_in_prepare) \
     ONCE(s3_read_buffer_throw_expired_token) \
+    ONCE(s3_send_request_throw_expired_token) \
     ONCE(distributed_cache_fail_request_in_the_middle_of_request) \
     ONCE(object_storage_queue_fail_commit_once) \
     ONCE(object_storage_queue_fail_commit_after_success) \
@@ -68,6 +69,8 @@ static struct InitFiu
     ONCE(distributed_cache_fail_choose_server) \
     REGULAR(file_cache_stall_free_space_ratio_keeping_thread) \
     REGULAR(cache_filesystem_failure) \
+    REGULAR(file_segment_range_writer_partial_write_then_network_error) \
+    REGULAR(distributed_cache_simulate_writer_not_keeping_up) \
     REGULAR(distributed_cache_fail_connect_non_retriable) \
     REGULAR(distributed_cache_fail_connect_retriable) \
     ONCE(distributed_cache_simulate_stale_connection) \

--- a/src/Databases/DataLake/GlueCatalog.cpp
+++ b/src/Databases/DataLake/GlueCatalog.cpp
@@ -438,6 +438,27 @@ void GlueCatalog::setCredentials(TableMetadata & metadata) const
     }
 }
 
+ICatalog::CredentialsRefreshCallback GlueCatalog::getCredentialsConfigurationCallback(const DB::StorageID & storage_id)
+{
+    /// The AWS SDK credentials provider chain (instance profile, STS assume-role,
+    /// web-identity, etc.) refreshes its cached credentials internally before
+    /// expiry. The bug we are fixing is that `setCredentials` captures the result
+    /// of `GetAWSCredentials` once at table-load time and embeds the access key,
+    /// secret, and session token as static literals in the storage args, so the
+    /// S3 client is pinned to a snapshot that goes stale on long reads. This
+    /// callback re-asks the same provider for current credentials each time
+    /// `ReadBufferFromS3` reports an `ExpiredToken`, letting the read recover.
+    return [this, storage_id]() -> std::shared_ptr<IStorageCredentials>
+    {
+        LOG_DEBUG(log, "Refreshing AWS credentials for {} after expired token", storage_id.getNameForLogs());
+        auto credentials = credentials_provider->GetAWSCredentials();
+        return std::make_shared<S3Credentials>(
+            credentials.GetAWSAccessKeyId(),
+            credentials.GetAWSSecretKey(),
+            credentials.GetSessionToken());
+    };
+}
+
 bool GlueCatalog::empty() const
 {
     auto all_databases = getDatabases("");

--- a/src/Databases/DataLake/GlueCatalog.h
+++ b/src/Databases/DataLake/GlueCatalog.h
@@ -69,6 +69,12 @@ public:
     bool updateMetadata(const String & namespace_name, const String & table_name, const String & new_metadata_path, Poco::JSON::Object::Ptr new_snapshot) const override;
     void dropTable(const String & namespace_name, const String & table_name) const override;
 
+    /// Returns a callback that re-vends fresh AWS credentials from the configured
+    /// credentials provider chain. Invoked by `ReadBufferFromS3` when an S3 call
+    /// fails with `ExpiredToken`, so that a long-running read can recover without
+    /// the user having to restart the query.
+    ICatalog::CredentialsRefreshCallback getCredentialsConfigurationCallback(const DB::StorageID & storage_id) override;
+
     /// Resolves the precise Iceberg timestamp type for `column_name` by searching the current schema
     /// in the Iceberg `metadata_object`. Falls back to `"timestamp_ns"` when `glue_column_type` is
     /// `"timestamp_nano"`, or `"timestamp"` otherwise, when the column is not found in the metadata.

--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -49,6 +49,7 @@ namespace S3RequestSetting
 namespace FailPoints
 {
     extern const char s3_read_buffer_throw_expired_token[];
+    extern const char s3_send_request_throw_expired_token[];
 }
 
 namespace ErrorCodes
@@ -535,6 +536,19 @@ Aws::S3::Model::GetObjectResult ReadBufferFromS3::sendRequest(size_t attempt, si
     ProfileEvents::increment(ProfileEvents::S3GetObject);
     if (client_ptr->isClientForDisk())
         ProfileEvents::increment(ProfileEvents::DiskS3GetObject);
+
+    /// Simulate a real `ExpiredToken` error returned from S3, used by integration tests for
+    /// the credentials refresh callback path in `processException`. Unlike
+    /// `s3_read_buffer_throw_expired_token` (which is gated by `if (impl)` in `nextImpl` and
+    /// therefore only fires on multi-fill streaming reads), this failpoint fires inside
+    /// `sendRequest` itself, so it covers both `nextImpl`-driven reads and the
+    /// `readBigAt` range-read path used by Parquet column-chunk reads.
+    fiu_do_on(FailPoints::s3_send_request_throw_expired_token,
+    {
+        throw S3Exception(
+            Aws::S3::S3Errors::UNKNOWN,
+            "Unable to parse ExceptionName: ExpiredToken Message: The provided token has expired.");
+    });
 
     ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::ReadBufferFromS3InitMicroseconds);
 

--- a/tests/integration/test_database_glue/test.py
+++ b/tests/integration/test_database_glue/test.py
@@ -264,7 +264,6 @@ def started_cluster():
             main_configs=[
                 "configs/query_log.xml",
                 "configs/text_log.xml",
-                "configs/cluster.xml"
             ],
             user_configs=[],
             stay_alive=True,

--- a/tests/integration/test_database_glue/test.py
+++ b/tests/integration/test_database_glue/test.py
@@ -197,7 +197,7 @@ def generate_arrow_data(num_rows=5):
     return table
 
 def create_clickhouse_glue_database(
-    started_cluster, node, name, additional_settings={}, with_credentials=True
+    started_cluster, node, name, additional_settings={}, query_settings={}, with_credentials=True
 ):
     settings = {
         "catalog_type": "glue",
@@ -264,10 +264,12 @@ def started_cluster():
             main_configs=[
                 "configs/query_log.xml",
                 "configs/text_log.xml",
+                "configs/cluster.xml"
             ],
             user_configs=[],
             stay_alive=True,
             with_glue_catalog=True,
+            with_zookeeper=True
         )
 
         sts = cluster.add_instance(
@@ -601,6 +603,35 @@ def test_empty_table(started_cluster):
     assert len(node.query(f"SELECT * FROM {CATALOG_NAME}.`{root_namespace}.{table_name}`")) == 0
 
 
+def test_cloud_mode(started_cluster):
+    node = started_cluster.instances["node1"]
+
+    test_ref = f"test_cloud_mode_{uuid.uuid4()}"
+    table_name = f"{test_ref}_table"
+    root_namespace = f"{test_ref}_namespace"
+
+    namespace = f"{root_namespace}_A"
+    catalog = load_catalog_impl(started_cluster)
+    catalog.create_namespace(namespace)
+
+    table = create_table(catalog, namespace, table_name)
+
+
+    num_rows = 10
+    df = generate_arrow_data(num_rows)
+    table.append(df)
+
+    create_clickhouse_glue_database(
+        started_cluster,
+        node,
+        CATALOG_NAME, query_settings={"cloud_mode": 1}
+    )
+
+    assert int(
+        node.query(f"SELECT count() FROM {CATALOG_NAME}.`{namespace}.{table_name}`")
+    ) == num_rows
+
+    
 def test_timestamps(started_cluster):
     node = started_cluster.instances["node1"]
 
@@ -975,6 +1006,7 @@ def test_sts_smoke(started_cluster):
             "aws_role_arn": "arn::role",
             "aws_role_session_name": "wrongsession",
         },
+        query_settings={},
         with_credentials=False,
     )
 
@@ -1000,6 +1032,7 @@ def test_sts_smoke(started_cluster):
             "aws_role_arn": "arn::role",
             "aws_role_session_name": "miniorole",
         },
+        query_settings={},
         with_credentials=False,
     )
 
@@ -1010,3 +1043,117 @@ def test_sts_smoke(started_cluster):
     # Cleanup
     node.query(f"DROP DATABASE IF EXISTS {db_name_fail} SYNC")
     node.query(f"DROP DATABASE IF EXISTS {db_name_success} SYNC")
+
+
+def test_sts_credential_refresh_on_expired_token(started_cluster):
+    """When an S3 read fails mid-query with an `ExpiredToken`-style error,
+    `GlueCatalog::getCredentialsConfigurationCallback` should fire and the read
+    should recover with freshly-vended STS credentials.
+
+    Without the override (the previous behavior), the catalog inherits the default
+    `std::nullopt` from `ICatalog::getCredentialsConfigurationCallback`,
+    `ReadBufferFromS3::processException` skips the refresh branch, and the read
+    surfaces the `ExpiredToken` to the user.
+
+    The `s3_send_request_throw_expired_token` failpoint fires inside
+    `ReadBufferFromS3::sendRequest`, so it covers both `nextImpl`-driven
+    streaming reads and the `readBigAt` range-read path that Parquet column-chunk
+    reads go through. It is `ONCE`, so only the first S3 GET fails — the
+    subsequent retry triggered by the credentials refresh callback succeeds.
+    """
+    node = started_cluster.instances["node1"]
+
+    test_ref = f"refresh_token_{uuid.uuid4().hex}"
+    table_name = f"{test_ref}_table"
+    root_namespace = f"{test_ref}_namespace"
+
+    catalog = load_catalog_impl(started_cluster)
+    catalog.create_namespace(root_namespace)
+
+    schema = Schema(
+        NestedField(field_id=1, name="id", field_type=StringType(), required=False),
+        NestedField(field_id=2, name="value", field_type=DoubleType(), required=False),
+    )
+
+    rows = [
+        {"id": "row1", "value": 10.0},
+        {"id": "row2", "value": 20.0},
+        {"id": "row3", "value": 30.0},
+    ]
+    expected_sum = sum(r["value"] for r in rows)
+    create_table(
+        catalog, root_namespace, table_name, schema, PartitionSpec(), DEFAULT_SORT_ORDER, dir=table_name
+    ).append(pa.Table.from_pylist(rows))
+
+    db_name = f"db_{test_ref.replace('-', '_')}"
+    create_clickhouse_glue_database(
+        started_cluster,
+        node,
+        db_name,
+        additional_settings={
+            "aws_role_arn": "arn::role",
+            "aws_role_session_name": "miniorole",
+        },
+        with_credentials=False,
+    )
+
+    # Sanity check: query works without the failpoint.
+    pre_failpoint = node.query(
+        f"SELECT sum(value) FROM {db_name}.`{root_namespace}.{table_name}`"
+    ).strip()
+    assert pre_failpoint == str(int(expected_sum)), (
+        f"Baseline query returned {pre_failpoint}, expected {int(expected_sum)}"
+    )
+
+    qid_select = uuid.uuid4().hex
+    node.query("SYSTEM ENABLE FAILPOINT s3_send_request_throw_expired_token")
+    try:
+        result = node.query(
+            f"SELECT sum(value) FROM {db_name}.`{root_namespace}.{table_name}` "
+            "SETTINGS max_threads = 1",
+            query_id=qid_select,
+        )
+    finally:
+        node.query("SYSTEM DISABLE FAILPOINT s3_send_request_throw_expired_token")
+
+    assert result.strip() == str(int(expected_sum)), (
+        f"Expected sum {int(expected_sum)} after refresh-driven retry, got: {result}"
+    )
+
+    node.query("SYSTEM FLUSH LOGS system.text_log")
+
+    # Diagnostic: confirm the failpoint actually tripped. If this assertion fails,
+    # the test environment did not reach the credential-refresh code path at all
+    # (e.g. column chunks completed in a single `nextImpl` call); the refresh-log
+    # assertion below would be vacuous.
+    failpoint_fired = int(
+        node.query(
+            "SELECT count() FROM system.text_log "
+            "WHERE message LIKE '%Caught exception while reading S3 object%' "
+            "AND message LIKE '%ExpiredToken%' "
+            "AND event_time >= now() - INTERVAL 5 MINUTE"
+        ).strip()
+    )
+    assert failpoint_fired >= 1, (
+        "Failpoint `s3_send_request_throw_expired_token` did not fire — "
+        "`processException` was never invoked, so the credentials-refresh "
+        "code path was not exercised."
+    )
+
+    # The `LOG_DEBUG` in `GlueCatalog::getCredentialsConfigurationCallback` must
+    # have fired — its absence would mean the override is not in place and the
+    # retry was attributable to some other path.
+    refresh_log_count = int(
+        node.query(
+            "SELECT count() FROM system.text_log "
+            "WHERE message LIKE '%Refreshing AWS credentials%after expired token%' "
+            "AND event_time >= now() - INTERVAL 5 MINUTE"
+        ).strip()
+    )
+    assert refresh_log_count >= 1, (
+        "The failpoint fired but `GlueCatalog::getCredentialsConfigurationCallback` "
+        "was not invoked — the override is missing or not wired into "
+        "`StorageS3Configuration::createObjectStorage`"
+    )
+
+    node.query(f"DROP DATABASE IF EXISTS {db_name} SYNC")


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Long-running `INSERT ... SELECT` and other reads from a `DataLakeCatalog` database with `catalog_type = 'glue'` fail with  `Code: 117. DB::Exception: IOError: Code: 499. DB::Exception: Unable to parse ExceptionName: ExpiredToken Message: The provided token has expired. (S3_ERROR) ... While executing ParquetBlockInputFormat: While executing ReadFromObjectStorage. (INCORRECT_DATA)` once the STS session credentials captured at table-metadata load time cross their expiry.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.97`
- Backported to: `26.5.2.7`, `26.4.4.12`, `26.3.13.15`
<!-- ch-version-info:end -->