### PR TITLE
Fix arrayPartialSort and arrayPartialReverseSort documentation

### DIFF
--- a/src/Functions/array/arraySort.cpp
+++ b/src/Functions/array/arraySort.cpp
@@ -232,7 +232,7 @@ If the array to sort contains `-Inf`, `NULL`, `NaN`, or `Inf` they will be sorte
     FunctionDocumentation::Arguments arguments = {
         {"f(y1[, y2 ... yN])", "The lambda function to apply to elements of array `x`."},
         {"arr", "An array to be sorted. [`Array(T)`](/sql-reference/data-types/array)"},
-        {"arr1, ..., yN", "Optional. N additional arrays, in the case when `f` accepts multiple arguments."}
+        {"arr1, ..., arrN", "Optional. N additional arrays, in the case when `f` accepts multiple arguments."}
     };
     FunctionDocumentation::ReturnedValue returned_value = {R"(
 Returns the array `arr` sorted in ascending order if no lambda function is provided, otherwise
@@ -265,7 +265,7 @@ If the array to sort contains `-Inf`, `NULL`, `NaN`, or `Inf` they will be sorte
 
 `arrayReverseSort` is a [higher-order function](/sql-reference/functions/overview#higher-order-functions).
     )";
-    syntax = "arrayReverseSort([f,] arr [, arr1, ... ,arrN)";
+    syntax = "arrayReverseSort([f,] arr [, arr1, ... ,arrN])";
     returned_value = {R"(
 Returns the array `x` sorted in descending order if no lambda function is provided, otherwise
 it returns an array sorted according to the logic of the provided lambda function, and then reversed. [`Array(T)`](/sql-reference/data-types/array).

--- a/src/Functions/array/arraySort.cpp
+++ b/src/Functions/array/arraySort.cpp
@@ -285,12 +285,12 @@ This function is the same as `arraySort` but with an additional `limit` argument
 To retain only the sorted elements use `arrayResize`.
 :::
     )";
-    syntax = "arrayPartialSort([f,] arr [, arr1, ... ,arrN], limit)";
+    syntax = "arrayPartialSort([f,] limit, arr [, arr1, ... ,arrN])";
     arguments = {
         {"f(arr[, arr1, ... ,arrN])", "The lambda function to apply to elements of array `x`.", {"Lambda function"}},
+        {"limit", "Index value up until which sorting will occur.", {"(U)Int*"}},
         {"arr", "Array to be sorted.", {"Array(T)"}},
-        {"arr1, ... ,arrN", "N additional arrays, in the case when `f` accepts multiple arguments.", {"Array(T)"}},
-        {"limit", "Index value up until which sorting will occur.", {"(U)Int*"}}
+        {"arr1, ... ,arrN", "N additional arrays, in the case when `f` accepts multiple arguments.", {"Array(T)"}}
     };
     returned_value = {R"(
 Returns an array of the same size as the original array where elements in the range `[1..limit]` are sorted
@@ -315,7 +315,7 @@ This function is the same as `arrayReverseSort` but with an additional `limit` a
 To retain only the sorted elements use `arrayResize`.
 :::
     )";
-    syntax = "arrayPartialReverseSort([f,] arr [, arr1, ... ,arrN], limit)";
+    syntax = "arrayPartialReverseSort([f,] limit, arr [, arr1, ... ,arrN])";
     returned_value = {R"(
 Returns an array of the same size as the original array where elements in the range `[1..limit]` are sorted
 in descending order. The remaining elements `(limit..N]` are in an unspecified order.


### PR DESCRIPTION
limit is in fact goes before arrays, which is reflected in `Examples`, but not in `Syntax` and `Arguments` section.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.907`
<!-- ch-version-info:end -->