### PR TITLE
Pin enable_parallel_replicas=0 in 02516_projections_and_context

### DIFF
--- a/tests/queries/0_stateless/02516_projections_and_context.sql
+++ b/tests/queries/0_stateless/02516_projections_and_context.sql
@@ -1,6 +1,10 @@
 DROP TABLE IF EXISTS test1__fuzz_37;
 CREATE TABLE test1__fuzz_37 (`i` Date) ENGINE = MergeTree ORDER BY i;
 insert into test1__fuzz_37 values ('2020-10-10');
+-- Disable parallel replicas: randomized PR rewrite masks the expected
+-- `BAD_ARGUMENTS` from `dictHas` with a `THERE_IS_NO_COLUMN` from pipeline
+-- column matching.
+set enable_parallel_replicas = 0;
 set enable_analyzer = 0;
 set optimize_functions_to_subcolumns = 1;
 set optimize_use_projections = 0;


### PR DESCRIPTION
The test `02516_projections_and_context` fails on master under the CI's parallel replicas randomization (issued via `automatic_parallel_replicas_mode = 2`, which turns on `enable_parallel_replicas` and `parallel_replicas_for_non_replicated_merge_tree` automatically).

When both `enable_parallel_replicas=1` and `parallel_replicas_for_non_replicated_merge_tree=1` are active, the malformed `dictHas(NULL, ...)` queries the test deliberately issues fail with `THERE_IS_NO_COLUMN` (code 8) inside `ActionsDAG::makeConvertingActions` (pipeline column matching), before reaching the `dictHas` argument validation that is supposed to produce the expected `BAD_ARGUMENTS` (code 36).

CI report (master, distributed plan, parallel, 2/2):
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=8d3cf431a93cddf5d608c97169eb421fe3aa33b4&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_asan_ubsan%2C%20distributed%20plan%2C%20parallel%2C%202%2F2%29

`--diagnose-random-settings` confirms the failure is fully deterministic with these two settings: `Runs: 43, Failed: 43`; passes 85/85 without them.

This test exercises projections / old-planner context, not parallel replicas error semantics, so pinning `enable_parallel_replicas = 0` is the targeted fix. The two `enable_analyzer = 0` and `enable_analyzer = 1` paths are preserved as-is. A separate engine-level inconsistency may still be worth investigating: `dictHas` argument validation runs before column resolution on the normal path but after pipeline column matching under parallel replicas, surfacing as a different error code.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix flaky test `02516_projections_and_context`.

### Documentation entry for user-facing changes

- [x] Documentation is unchanged