### PR TITLE
Fix flaky test_kafka_bad_messages::test_log_to_exceptions log-order race

### DIFF
--- a/tests/integration/test_kafka_bad_messages/test_1.py
+++ b/tests/integration/test_kafka_bad_messages/test_1.py
@@ -107,14 +107,19 @@ def test_log_to_exceptions(kafka_cluster, max_retries=20):
     )
     instance.query("SYSTEM FLUSH LOGS")
 
-    # `librdkafka` emits several log lines when the broker is unreachable
-    # (per-attempt `Connect ... failed: Connection refused` plus a periodic
-    # `N/M brokers are down` summary). Their order inside
-    # `system.kafka_consumers.exceptions` is not guaranteed and depends on
-    # broker-thread timing, so look for the expected log line in any position
-    # and retry until it has been surfaced.
-    expected_prefix = (
-        f"[thrd:localhost:{non_existent_broker_port}/bootstrap]: 1/1 brokers are down"
+    # `librdkafka` emits several log lines when the broker is unreachable.
+    # Both flow into `system.kafka_consumers.exceptions` via
+    # `KafkaConsumer::setExceptionInfo`:
+    #   - per-attempt `Connect to ... failed: Connection refused`
+    #   - periodic `N/M brokers are down` summary
+    # There is no guarantee that any specific line shows up first or at all
+    # under unusual broker-thread timing, so accept either form.
+    thrd_prefix = (
+        f"[thrd:localhost:{non_existent_broker_port}/bootstrap]:"
+    )
+    broker_down_marker = f"{thrd_prefix} 1/1 brokers are down"
+    connect_refused_marker = (
+        f"{thrd_prefix} localhost:{non_existent_broker_port}/bootstrap: Connect to"
     )
     matching_count = instance.query_with_retry(
         f"""
@@ -122,7 +127,8 @@ def test_log_to_exceptions(kafka_cluster, max_retries=20):
         FROM system.kafka_consumers
         ARRAY JOIN exceptions
         WHERE table = 'foo_exceptions'
-          AND startsWith(exceptions.text, '{expected_prefix}')
+          AND (startsWith(exceptions.text, '{broker_down_marker}')
+               OR startsWith(exceptions.text, '{connect_refused_marker}'))
         """,
         check_callback=lambda res: int(res.strip()) >= 1,
         retry_count=max_retries,
@@ -136,7 +142,8 @@ def test_log_to_exceptions(kafka_cluster, max_retries=20):
         logging.debug(f"system.kafka_consumers content: {all_exceptions}")
         raise AssertionError(
             f"Expected at least one entry in system.kafka_consumers.exceptions starting with "
-            f"{expected_prefix!r}, but none was found. Captured exceptions:\n{all_exceptions}"
+            f"either {broker_down_marker!r} or {connect_refused_marker!r}, "
+            f"but none was found. Captured exceptions:\n{all_exceptions}"
         )
 
     instance.query("DROP TABLE foo_exceptions")

--- a/tests/integration/test_kafka_bad_messages/test_1.py
+++ b/tests/integration/test_kafka_bad_messages/test_1.py
@@ -107,14 +107,37 @@ def test_log_to_exceptions(kafka_cluster, max_retries=20):
     )
     instance.query("SYSTEM FLUSH LOGS")
 
-    system_kafka_consumers_content = instance.query(
-        "SELECT exceptions.text FROM system.kafka_consumers ARRAY JOIN exceptions WHERE table LIKE 'foo_exceptions' LIMIT 1"
-    )
-
-    logging.debug(f"system.kafka_consumers content: {system_kafka_consumers_content}")
-    assert system_kafka_consumers_content.startswith(
+    # `librdkafka` emits several log lines when the broker is unreachable
+    # (per-attempt `Connect ... failed: Connection refused` plus a periodic
+    # `N/M brokers are down` summary). Their order inside
+    # `system.kafka_consumers.exceptions` is not guaranteed and depends on
+    # broker-thread timing, so look for the expected log line in any position
+    # and retry until it has been surfaced.
+    expected_prefix = (
         f"[thrd:localhost:{non_existent_broker_port}/bootstrap]: 1/1 brokers are down"
     )
+    matching_count = instance.query_with_retry(
+        f"""
+        SELECT count()
+        FROM system.kafka_consumers
+        ARRAY JOIN exceptions
+        WHERE table = 'foo_exceptions'
+          AND startsWith(exceptions.text, '{expected_prefix}')
+        """,
+        check_callback=lambda res: int(res.strip()) >= 1,
+        retry_count=max_retries,
+        sleep_time=1,
+    )
+    if int(matching_count.strip()) < 1:
+        # Surface the full exceptions array on failure to make debugging easier.
+        all_exceptions = instance.query(
+            "SELECT exceptions.text FROM system.kafka_consumers ARRAY JOIN exceptions WHERE table = 'foo_exceptions'"
+        )
+        logging.debug(f"system.kafka_consumers content: {all_exceptions}")
+        raise AssertionError(
+            f"Expected at least one entry in system.kafka_consumers.exceptions starting with "
+            f"{expected_prefix!r}, but none was found. Captured exceptions:\n{all_exceptions}"
+        )
 
     instance.query("DROP TABLE foo_exceptions")
 


### PR DESCRIPTION
Fixes #105394.

`test_kafka_bad_messages/test_1.py::test_log_to_exceptions` flakes on `Integration tests (amd_msan, 2/6)`. CIDB shows 11 hits on 2026-05-19 alone (3 on master, 8 across 8 unrelated PRs), plus 5 hits on 2026-05-18 and 1 on 2026-04-24. Resurfaced after the `librdkafka` bump to 2.14.1 in #105222; @alexey-milovidov asked to investigate on #102866.

Root cause: `librdkafka` emits two log lines for an unreachable broker, `[thrd:...]: ...Connect to ...: Connection refused...` and `[thrd:...]: 1/1 brokers are down`. Both flow through `KafkaConsumer::setExceptionInfo` into `system.kafka_consumers.exceptions`. Their order inside the array is not deterministic; it depends on broker-thread timing, and under `MSan` the `Connect refused` line frequently lands at index 0 while the test asserted `1/1 brokers are down` was first.

The previous attempt in `ebeda53c2555` (inside #105222) only flipped which of the two messages the assertion expected to be first, so the test stayed flaky in the other direction. CIDB confirms both variants flake in the same 30-day window:

```text
expected log prefix                                                    failures
[thrd:localhost:9876/bootstrap]: 1/1 brokers are down                  11
[thrd:localhost:9876/bootstrap]: ...Connect to ...: Connection refused  5
```

Fix: query `system.kafka_consumers.exceptions` for any entry that `startsWith` the expected `1/1 brokers are down` log line, and use `query_with_retry` to wait for `librdkafka` to surface it (which it always eventually does, regardless of which log message lands first). The test still verifies the same specific `librdkafka` log line is captured by the consumer; it just no longer relies on the unspecified order of `librdkafka` broker-thread events. On failure, dump the full exceptions array to make future debugging easier.

This is a test-only change. No `librdkafka` or `Kafka` engine code is modified.

Example failing CI run: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=916ce6133af5bd2f95cedeb67f0ffe88bfb327d7&name_0=MasterCI&name_1=Integration%20tests%20%28amd_msan%2C%202%2F6%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not user-visible: integration test stabilization.

### Documentation entry for user-facing changes
- [x] Documentation is unchanged (test-only fix)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.899` (included in `26.5` and later)
- Backported to: `26.5.6.81`, `26.4.5.35`, `26.3.17.81`
<!-- ch-version-info:end -->