### PR TITLE
clickhouse-test: make --client-option win over randomized settings

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -2068,10 +2068,13 @@ class TestCase:
         if self.effective_merge_tree_settings:
             new_options += f" --allow_merge_tree_settings {self.cli_format_settings(self.effective_merge_tree_settings)}"
 
+        # Put randomized settings BEFORE base_client_options / client_options so
+        # that user-supplied --client-option values win over them: with
+        # --allow_repeated_settings, the last occurrence is what takes effect.
         if new_options != "":
             new_options += " --allow_repeated_settings"
             os.environ["CLICKHOUSE_CLIENT_OPT"] = (
-                self.base_client_options + new_options + " "
+                new_options + " " + self.base_client_options + " "
             )
         elif client_options:
             client_options += " --allow_repeated_settings"
@@ -2082,7 +2085,7 @@ class TestCase:
         current_value = os.environ.get("CLICKHOUSE_CLIENT_OPT", "")
         os.environ["CLICKHOUSE_CLIENT_OPT"] = f"{current_value} --allow_repeated_settings".strip()
 
-        return client_options + new_options
+        return new_options + " " + client_options
 
     def remove_settings_from_env(self):
         os.environ["CLICKHOUSE_URL_PARAMS"] = self.base_url_params


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.908`
<!-- ch-version-info:end -->