### PR TITLE
Install clickhousectl alongside ClickHouse in the universal installer

### DIFF
--- a/docs/_includes/install/universal.sh
+++ b/docs/_includes/install/universal.sh
@@ -99,3 +99,70 @@ echo "Successfully downloaded the ClickHouse binary, you can run it as:
 echo
 echo "You can also install it:
 sudo ./${clickhouse} install"
+
+# Also install clickhousectl, the CLI for ClickHouse local and Cloud
+chctl_target=
+if [ "${OS}" = "Linux" ]
+then
+    if [ "${ARCH}" = "x86_64" -o "${ARCH}" = "amd64" ]
+    then
+        chctl_target="x86_64-unknown-linux-musl"
+    elif [ "${ARCH}" = "aarch64" -o "${ARCH}" = "arm64" ]
+    then
+        chctl_target="aarch64-unknown-linux-musl"
+    fi
+elif [ "${OS}" = "Darwin" ]
+then
+    if [ "${ARCH}" = "x86_64" -o "${ARCH}" = "amd64" ]
+    then
+        chctl_target="x86_64-apple-darwin"
+    elif [ "${ARCH}" = "aarch64" -o "${ARCH}" = "arm64" ]
+    then
+        chctl_target="aarch64-apple-darwin"
+    fi
+fi
+
+if [ -n "${chctl_target}" ]
+then
+    echo
+    echo "Fetching the latest clickhousectl release..."
+    chctl_tag=$(curl -fsSL "https://api.github.com/repos/ClickHouse/clickhousectl/releases/latest" \
+        | grep '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
+
+    if [ -n "${chctl_tag}" ]
+    then
+        chctl_install_dir="${HOME}/.local/bin"
+        chctl_archive="clickhousectl-${chctl_target}-${chctl_tag}.tar.gz"
+        chctl_url="https://github.com/ClickHouse/clickhousectl/releases/download/${chctl_tag}/${chctl_archive}"
+        echo "Will download ${chctl_url} into ${chctl_install_dir}/clickhousectl"
+        chctl_tmp=$(mktemp -d)
+        if mkdir -p "${chctl_install_dir}" \
+            && curl -fsSL "${chctl_url}" -o "${chctl_tmp}/${chctl_archive}" \
+            && tar -xzf "${chctl_tmp}/${chctl_archive}" -C "${chctl_tmp}" \
+            && mv -f "${chctl_tmp}/clickhousectl-${chctl_target}-${chctl_tag}/clickhousectl" "${chctl_install_dir}/clickhousectl"
+        then
+            chmod a+x "${chctl_install_dir}/clickhousectl"
+            ln -sf "${chctl_install_dir}/clickhousectl" "${chctl_install_dir}/chctl"
+            echo
+            echo "Successfully installed clickhousectl to ${chctl_install_dir}/clickhousectl"
+            echo "Created alias: chctl -> clickhousectl"
+            case ":$PATH:" in
+                *":${chctl_install_dir}:"*) ;;
+                *)
+                    echo
+                    echo "NOTE: ${chctl_install_dir} is not in your PATH."
+                    echo "Add it by running:"
+                    echo
+                    echo "  export PATH=\"${chctl_install_dir}:\$PATH\""
+                    echo
+                    echo "You may want to add that line to your shell profile (~/.bashrc, ~/.zshrc, etc.)"
+                    ;;
+            esac
+        else
+            echo "Warning: failed to download clickhousectl. Continuing."
+        fi
+        rm -rf "${chctl_tmp}"
+    else
+        echo "Warning: could not determine the latest clickhousectl release. Continuing."
+    fi
+fi

--- a/docs/_includes/install/universal.sh
+++ b/docs/_includes/install/universal.sh
@@ -136,7 +136,7 @@ then
         then
             chctl_install_dir="${HOME}/.local/bin"
             chctl_archive="clickhousectl-${chctl_target}-${chctl_tag}.tar.gz"
-            chctl_url="https://github.com/ClickHouse/clickhousectl/releases/download/${chctl_tag}/${chctl_archive}"
+            chctl_url="https://builds.clickhouse.com/clickhousectl/${chctl_archive}"
             echo "Will download ${chctl_url} into ${chctl_install_dir}/clickhousectl"
             chctl_tmp=$(mktemp -d)
             if mkdir -p "${chctl_install_dir}" \

--- a/docs/_includes/install/universal.sh
+++ b/docs/_includes/install/universal.sh
@@ -100,69 +100,73 @@ echo
 echo "You can also install it:
 sudo ./${clickhouse} install"
 
-# Also install clickhousectl, the CLI for ClickHouse local and Cloud
-chctl_target=
-if [ "${OS}" = "Linux" ]
+# Also install clickhousectl, the CLI for ClickHouse local and Cloud.
+# Set CLICKHOUSE_ONLY=1 to skip.
+if [ -z "${CLICKHOUSE_ONLY}" ]
 then
-    if [ "${ARCH}" = "x86_64" -o "${ARCH}" = "amd64" ]
+    chctl_target=
+    if [ "${OS}" = "Linux" ]
     then
-        chctl_target="x86_64-unknown-linux-musl"
-    elif [ "${ARCH}" = "aarch64" -o "${ARCH}" = "arm64" ]
-    then
-        chctl_target="aarch64-unknown-linux-musl"
-    fi
-elif [ "${OS}" = "Darwin" ]
-then
-    if [ "${ARCH}" = "x86_64" -o "${ARCH}" = "amd64" ]
-    then
-        chctl_target="x86_64-apple-darwin"
-    elif [ "${ARCH}" = "aarch64" -o "${ARCH}" = "arm64" ]
-    then
-        chctl_target="aarch64-apple-darwin"
-    fi
-fi
-
-if [ -n "${chctl_target}" ]
-then
-    echo
-    echo "Fetching the latest clickhousectl release..."
-    chctl_tag=$(curl -fsSL "https://api.github.com/repos/ClickHouse/clickhousectl/releases/latest" \
-        | grep '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
-
-    if [ -n "${chctl_tag}" ]
-    then
-        chctl_install_dir="${HOME}/.local/bin"
-        chctl_archive="clickhousectl-${chctl_target}-${chctl_tag}.tar.gz"
-        chctl_url="https://github.com/ClickHouse/clickhousectl/releases/download/${chctl_tag}/${chctl_archive}"
-        echo "Will download ${chctl_url} into ${chctl_install_dir}/clickhousectl"
-        chctl_tmp=$(mktemp -d)
-        if mkdir -p "${chctl_install_dir}" \
-            && curl -fsSL "${chctl_url}" -o "${chctl_tmp}/${chctl_archive}" \
-            && tar -xzf "${chctl_tmp}/${chctl_archive}" -C "${chctl_tmp}" \
-            && mv -f "${chctl_tmp}/clickhousectl-${chctl_target}-${chctl_tag}/clickhousectl" "${chctl_install_dir}/clickhousectl"
+        if [ "${ARCH}" = "x86_64" -o "${ARCH}" = "amd64" ]
         then
-            chmod a+x "${chctl_install_dir}/clickhousectl"
-            ln -sf "${chctl_install_dir}/clickhousectl" "${chctl_install_dir}/chctl"
-            echo
-            echo "Successfully installed clickhousectl to ${chctl_install_dir}/clickhousectl"
-            echo "Created alias: chctl -> clickhousectl"
-            case ":$PATH:" in
-                *":${chctl_install_dir}:"*) ;;
-                *)
-                    echo
-                    echo "NOTE: ${chctl_install_dir} is not in your PATH."
-                    echo "Add it by running:"
-                    echo
-                    echo "  export PATH=\"${chctl_install_dir}:\$PATH\""
-                    echo
-                    echo "You may want to add that line to your shell profile (~/.bashrc, ~/.zshrc, etc.)"
-                    ;;
-            esac
-        else
-            echo "Warning: failed to download clickhousectl. Continuing."
+            chctl_target="x86_64-unknown-linux-musl"
+        elif [ "${ARCH}" = "aarch64" -o "${ARCH}" = "arm64" ]
+        then
+            chctl_target="aarch64-unknown-linux-musl"
         fi
-        rm -rf "${chctl_tmp}"
-    else
-        echo "Warning: could not determine the latest clickhousectl release. Continuing."
+    elif [ "${OS}" = "Darwin" ]
+    then
+        if [ "${ARCH}" = "x86_64" -o "${ARCH}" = "amd64" ]
+        then
+            chctl_target="x86_64-apple-darwin"
+        elif [ "${ARCH}" = "aarch64" -o "${ARCH}" = "arm64" ]
+        then
+            chctl_target="aarch64-apple-darwin"
+        fi
+    fi
+
+    if [ -n "${chctl_target}" ]
+    then
+        echo
+        echo "Fetching the latest clickhousectl release..."
+        chctl_tag=$(curl -fsSL "https://api.github.com/repos/ClickHouse/clickhousectl/releases/latest" \
+            | grep '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
+
+        if [ -n "${chctl_tag}" ]
+        then
+            chctl_install_dir="${HOME}/.local/bin"
+            chctl_archive="clickhousectl-${chctl_target}-${chctl_tag}.tar.gz"
+            chctl_url="https://github.com/ClickHouse/clickhousectl/releases/download/${chctl_tag}/${chctl_archive}"
+            echo "Will download ${chctl_url} into ${chctl_install_dir}/clickhousectl"
+            chctl_tmp=$(mktemp -d)
+            if mkdir -p "${chctl_install_dir}" \
+                && curl -fsSL "${chctl_url}" -o "${chctl_tmp}/${chctl_archive}" \
+                && tar -xzf "${chctl_tmp}/${chctl_archive}" -C "${chctl_tmp}" \
+                && mv -f "${chctl_tmp}/clickhousectl-${chctl_target}-${chctl_tag}/clickhousectl" "${chctl_install_dir}/clickhousectl"
+            then
+                chmod a+x "${chctl_install_dir}/clickhousectl"
+                ln -sf "${chctl_install_dir}/clickhousectl" "${chctl_install_dir}/chctl"
+                echo
+                echo "Successfully installed clickhousectl to ${chctl_install_dir}/clickhousectl"
+                echo "Created alias: chctl -> clickhousectl"
+                case ":$PATH:" in
+                    *":${chctl_install_dir}:"*) ;;
+                    *)
+                        echo
+                        echo "NOTE: ${chctl_install_dir} is not in your PATH."
+                        echo "Add it by running:"
+                        echo
+                        echo "  export PATH=\"${chctl_install_dir}:\$PATH\""
+                        echo
+                        echo "You may want to add that line to your shell profile (~/.bashrc, ~/.zshrc, etc.)"
+                        ;;
+                esac
+            else
+                echo "Warning: failed to download clickhousectl. Continuing."
+            fi
+            rm -rf "${chctl_tmp}"
+        else
+            echo "Warning: could not determine the latest clickhousectl release. Continuing."
+        fi
     fi
 fi


### PR DESCRIPTION
After downloading `clickhouse`, also fetch the latest [`clickhousectl`](https://github.com/ClickHouse/clickhousectl) release into `~/.local/bin` and create a `chctl` symlink, mirroring [upstream `install.sh`](https://github.com/ClickHouse/clickhousectl/blob/main/install.sh). 

Set `CLICKHOUSE_ONLY=1` to skip the `clickhousectl` install and keep the previous behavior.

Skips silently on platforms without prebuilt `clickhousectl` artifacts (FreeBSD, ppc64le, riscv64, s390x). Warns and continues on download/API failure so a `clickhouse` install is never broken.

Downloads come from the `builds.clickhouse.com` mirror. Version discovery still uses the GitHub API (one small JSON call) and can be removed once a `latest` pointer is published on the mirror.

### Changelog category (leave one):
- Improvement

### Changelog entry:
The universal install script now also installs `clickhousectl` into `~/.local/bin` on Linux and macOS, with a `chctl` symlink. Set `CLICKHOUSE_ONLY=1` to skip.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.915`
<!-- ch-version-info:end -->