### PR TITLE
Use exit code 2 from clickhouse-test to signal stop_testing

### DIFF
--- a/ci/jobs/fast_test.py
+++ b/ci/jobs/fast_test.py
@@ -344,12 +344,12 @@ def main():
             test_pattern = "|".join(args.test)
             fast_test_command += f" -- '{test_pattern}'"
 
-        res = CH.run_test(fast_test_command)
+        test_exit_code = CH.run_test(fast_test_command)
 
         test_results = FTResultsProcessor(wd=Settings.OUTPUT_DIR).run(
-            runner_exit_code=0 if res else 1,
+            runner_exit_code=test_exit_code,
         )
-        if not res:
+        if test_exit_code != 0:
             attach_debug = True
 
         results.append(test_results)

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -748,6 +748,14 @@ clickhouse-client --query "SELECT count() FROM test.visits"
             return False
 
     def run_test(self, cmd, timeout=7200):
+        """Run a `clickhouse-test` command and return its integer exit code.
+
+        Returns 0 on success, non-zero on failure. In particular, exit code
+        `STOP_TESTING_EXIT_CODE` (2) signals that `clickhouse-test` aborted
+        the run via `StopTesting` (server died, hung check failed, etc.) and
+        is forwarded to `FTResultsProcessor.run` as `runner_exit_code` so it
+        can populate the synthetic "Server died" leaf.
+        """
         print(f"Run test: [{cmd}]")
         with open(self.test_output_file, "w") as f:
             process = subprocess.Popen(
@@ -772,7 +780,7 @@ clickhouse-client --query "SELECT count() FROM test.visits"
             try:
                 process.wait(timeout=timeout)
                 reader_thread.join()
-                return process.returncode == 0
+                return process.returncode
             except subprocess.TimeoutExpired:
                 print(
                     f"ERROR: fast test timed out after {timeout}s, killing process group"
@@ -780,7 +788,7 @@ clickhouse-client --query "SELECT count() FROM test.visits"
                 os.killpg(os.getpgid(process.pid), signal.SIGKILL)
                 process.wait()
                 reader_thread.join()
-                return False
+                return process.returncode
             finally:
                 # Kill any test processes that survived clickhouse-test's own cleanup
                 # (e.g. if it was killed with SIGKILL before its signal handlers ran).

--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -1,6 +1,8 @@
 import dataclasses
 import re
+import runpy
 import traceback
+from pathlib import Path
 from typing import List, Optional
 
 from praktika.result import Result
@@ -11,9 +13,12 @@ UNKNOWN_SIGN = "[ UNKNOWN "
 SKIPPED_SIGN = "[ SKIPPED "
 NOT_FAILED_SIGN = "[ NOT_FAILED "
 HUNG_SIGN = "Found hung queries in processlist"
-STOP_TESTING_SIGN = "Stopping tests, terminating all processes"
-STOP_TESTING_SIGN2 = "Server does not respond to health check"
 DATABASE_SIGN = "Database: "
+
+# Pick up `STOP_TESTING_EXIT_CODE` straight from `tests/clickhouse-test` so
+# the contract has a single source of truth.
+_clickhouse_test = Path(__file__).resolve().parents[3] / "tests" / "clickhouse-test"
+STOP_TESTING_EXIT_CODE = runpy.run_path(str(_clickhouse_test))["STOP_TESTING_EXIT_CODE"]
 
 SUCCESS_FINISH_SIGNS = ["All tests have finished", "No tests were run"]
 
@@ -41,7 +46,6 @@ class FTResultsProcessor:
         success: int
         test_results: List[Result]
         hung: bool = False
-        stop_testing: bool = False
         retries: bool = False
         success_finish: bool = False
         test_end: bool = True
@@ -57,7 +61,6 @@ class FTResultsProcessor:
         failed = 0
         success = 0
         hung = False
-        stop_testing = False
         retries = False
         success_finish = False
         test_results = []
@@ -75,8 +78,6 @@ class FTResultsProcessor:
                 if HUNG_SIGN in line:
                     hung = True
                     break
-                if STOP_TESTING_SIGN in line or STOP_TESTING_SIGN2 in line:
-                    stop_testing = True
                 if RETRIES_SIGN in line:
                     retries = True
 
@@ -167,7 +168,6 @@ class FTResultsProcessor:
             success=success,
             test_results=test_results,
             hung=hung,
-            stop_testing=stop_testing,
             success_finish=success_finish,
             retries=retries,
         )
@@ -188,7 +188,7 @@ class FTResultsProcessor:
             test_results.append(
                 Result("Some queries hung", Result.Status.FAIL, info="Some queries hung")
             )
-        elif s.stop_testing:
+        elif runner_exit_code == STOP_TESTING_EXIT_CODE:
             state = Result.Status.FAIL
             failed_results = [r for r in test_results if r.is_failure()]
             if len(failed_results) > 1:

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -76,6 +76,13 @@ def write_text_atomic(path: Path, text: str) -> None:
     except Exception as e:
         print(f"Warning: could not write {path}: {e}", file=sys.stderr)
 
+# Exit code returned by `clickhouse-test` when the run was aborted early via
+# `stop_testing` (typically: server died / health check failed). Distinct from
+# the generic failure code 1 so the job side can populate the synthetic
+# "Server died" leaf without fragile log-line matching. Kept in sync with
+# `STOP_TESTING_EXIT_CODE` in `ci/jobs/scripts/functional_tests_results.py`.
+STOP_TESTING_EXIT_CODE = 2
+
 USE_JINJA = True
 try:
     import jinja2
@@ -4110,13 +4117,16 @@ class TestSuite:
         return TestSuite(args, suite_path, suite_tmp_path, suite)
 
 
-class TestRunAbort(Exception):
-    """Raised to abort the whole test run.
+class StopTesting(Exception):
+    """Raised to abort the whole test run (server crash, hung-check
+    timeout, --max-failures limit, global time limit, etc.). Mirrors
+    `StopIteration` in role: a control-flow exception unwound to a
+    known outer handler.
 
-    The actual reason (server crash, hung-check timeout, --max-failures
-    limit, global time limit, etc.) is in the exception message — the
-    catch handler prefixes it with "Test run aborted:" so it stands out
-    in the log.
+    The reason is in the message — the catch handler prefixes it with
+    "Test run aborted:" so it stands out in the log, and exits with
+    `STOP_TESTING_EXIT_CODE` so the job side treats the run as
+    catastrophically interrupted.
     """
     pass
 
@@ -4348,13 +4358,13 @@ def run_tests_array(
 
         if stop_testing.is_set():
             stop_tests()
-            raise TestRunAbort(
+            raise StopTesting(
                 "another component requested stop (see earlier output for the cause)"
             )
 
         if args.stop_time and time() > args.stop_time:
             stop_tests()
-            raise TestRunAbort("global time limit exceeded (--stop-time)")
+            raise StopTesting("global time limit exceeded (--stop-time)")
 
         test_case = TestCase(test_suite, case, args, is_concurrent)
 
@@ -4445,7 +4455,7 @@ def run_tests_array(
                     print_c_stacktraces(args)
                     stop_tests()
                     stop_testing.set()
-                    raise TestRunAbort(
+                    raise StopTesting(
                         f"ClickHouse server died during test '{test_case.name}'"
                     )
                 if args.max_failures > 0:
@@ -4454,7 +4464,7 @@ def run_tests_array(
                         if total_failures_shared.value >= args.max_failures:
                             stop_tests()
                             stop_testing.set()
-                            raise TestRunAbort(
+                            raise StopTesting(
                                 f"reached --max-failures limit ({args.max_failures})"
                             )
             elif test_result.status == TestStatus.SKIPPED:
@@ -4468,7 +4478,7 @@ def run_tests_array(
         if failures_chain >= args.max_failures_chain:
             stop_tests()
             stop_testing.set()
-            raise TestRunAbort(
+            raise StopTesting(
                 f"reached --max-failures-chain limit ({args.max_failures_chain})"
             )
 
@@ -4926,7 +4936,9 @@ def do_run_tests(
                         p.kill()
                 for p in processes:
                     p.join(timeout=5)
-                break
+                raise StopTesting(
+                    "test run was stopped (see earlier output for the cause)"
+                )
 
             for p in processes[:]:
                 if not p.is_alive():
@@ -5346,7 +5358,7 @@ def main(args):
     except Exception as e:
         print(f"Failed to create databases for tests: {e}")
         stop_testing.set()
-        raise
+        raise StopTesting(f"Failed to create databases for tests: {e}") from e
 
     if (
         args.collect_per_test_coverage
@@ -5544,9 +5556,6 @@ ORDER BY (test_name, callee_offset)
                 stop_testing,
                 runner_process_killed,
             )
-
-    if stop_testing.is_set():
-        exit_code.value = 1
 
     if runner_process_killed.is_set():
         exit_code.value = 1
@@ -6586,10 +6595,10 @@ if __name__ == "__main__":
 
     try:
         main(args)
-    except TestRunAbort as e:
+    except StopTesting as e:
         print(f"Test run aborted: {e}", file=sys.stderr)
         traceback.print_exc()
-        sys.exit(1)
+        sys.exit(STOP_TESTING_EXIT_CODE)
     except Terminated as e:
         print(f"Terminated with {e.signal} signal", file=sys.stderr)
         sys.exit(128 + e.signal)


### PR DESCRIPTION
Follow-up to #105298 ([review thread](https://github.com/ClickHouse/ClickHouse/pull/105298#discussion_r3268844846)) and #104081.

Previously the job-side parser detected the stop_testing condition (server died, hung check failed, `--max-failures` reached, etc.) by matching specific strings in `test_result.txt`. Every wording change in `clickhouse-test` risked silently breaking bugfix validation — exactly what happened when PR #104081 renamed `Server died, terminating all processes...` to `Stopping tests, terminating all processes...`.

Replace that fragile log-line matching with a stable contract: an exit code. `clickhouse-test` now exits with `STOP_TESTING_EXIT_CODE = 2` when the run is aborted via a new `StopTesting` exception (renamed from `TestRunAbort`, mirroring `StopIteration`). All paths that previously set the `stop_testing` event now raise `StopTesting` and unwind to a single outer handler that exits with the new code — including the parent-side hung-check path (which used to `break` after killing workers) and the `create_common_database` failure path (which used to re-raise the original exception, bypassing the handler entirely).

The job-side parser (`functional_tests_results.py`) treats `runner_exit_code == STOP_TESTING_EXIT_CODE` as the authoritative stop_testing signal — no more `STOP_TESTING_SIGN` / `STOP_TESTING_SIGN2` matching. The constant itself is read straight from `tests/clickhouse-test` via `runpy.run_path`, so there is a single source of truth.

`ClickHouseProc.run_test` (used by `fast_test.py`) now returns the integer exit code instead of a bool so this signal reaches the parser for the fast-test invocation too.

Behavioural change worth noting: when `StopTesting` unwinds from `do_run_tests` in the parent-side hung-check path, the end-of-main cleanup steps (final hung check, restarted-tests printing, coverage flush, trace log analysis) are skipped. This is acceptable since the server is unresponsive in that path anyway; the diagnostics would fail.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.892`
<!-- ch-version-info:end -->