### PR TITLE
Bound flaky-check shutdown, timeout doesn't fail a passing run

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -94,12 +94,22 @@ def run_tests(
         extra_args += " --zookeeper"
     # Remove --report-logs-stats, it hides sanitizer errors in def reportLogStats(args): clickhouse_execute(args, "SYSTEM FLUSH LOGS")
     memory_limit = 10 * 2**30 if "asan_ubsan" in Info().job_name else 5 * 2**30
+    # Tell clickhouse-test about the budget so it stops scheduling new tests
+    # gracefully and has time to run the hung-check + post-test diagnostics
+    # before the outer Shell.run wall-clock SIGTERM fires.  Without this the
+    # outer timeout can SIGTERM clickhouse-test in the middle of a query
+    # (e.g. the trace_log post-mortem on debug builds), failing a run where
+    # every test actually passed.
+    SHUTDOWN_HEADROOM = 180  # seconds reserved for hung-check + diagnostics + flush
+    inner_args = extra_args
+    if global_time_limit and global_time_limit > SHUTDOWN_HEADROOM and "--global_time_limit" not in extra_args:
+        inner_args += f" --global_time_limit {global_time_limit - SHUTDOWN_HEADROOM}"
     # `set -o pipefail` is required so that the pipeline's exit code reflects
     # `clickhouse-test`'s exit code rather than `tee`'s. Without it, a non-zero
     # exit from `clickhouse-test` is silently swallowed by `tee` returning 0.
     command = f"set -o pipefail; clickhouse-test --testname --check-zookeeper-session --hung-check --memory-limit {memory_limit} --trace \
                 --capture-client-stacktrace --queries ./tests/queries --test-runs {rerun_count} \
-                {extra_args} \
+                {inner_args} \
                 --queries ./tests/queries {('--order=random' if random_order else '')} -- {' '.join(tests) if tests else ''} | ts '%Y-%m-%d %H:%M:%S' \
                 | tee -a \"{test_output_file}\""
     if Path(test_output_file).exists():

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -5634,19 +5634,25 @@ ORDER BY (test_name, callee_offset)
         print("All tests have finished.")
 
     if args.collect_per_test_coverage and BuildFlags.WITH_COVERAGE_DEPTH in args.build_flags:
+        # Bound post-test bookkeeping so it cannot eat the wall-clock budget.
+        post_settings = {"max_execution_time": 30}
         try:
             # Flush the last test's coverage into system.coverage_log.
-            clickhouse_execute(args, "SYSTEM SET COVERAGE TEST ''")
+            clickhouse_execute(args, "SYSTEM SET COVERAGE TEST ''",
+                               timeout=40, settings=post_settings)
         except Exception as e:
             print("Cannot flush final coverage: ", str(e))
-        cov_rows = int(clickhouse_execute(args, "SELECT count() FROM system.coverage_log FINAL") or 0)
-        cov_tests = int(clickhouse_execute(args, "SELECT uniq(test_name) FROM system.coverage_log FINAL") or 0)
+        cov_rows = int(clickhouse_execute(args, "SELECT count() FROM system.coverage_log FINAL",
+                                          timeout=40, settings=post_settings) or 0)
+        cov_tests = int(clickhouse_execute(args, "SELECT uniq(test_name) FROM system.coverage_log FINAL",
+                                           timeout=40, settings=post_settings) or 0)
         print(f"system.coverage_log: {cov_rows} rows, {cov_tests} distinct tests")
         try:
             ic_rows = int(
                 clickhouse_execute(
                     args,
                     "SELECT count() FROM system.coverage_indirect_calls FINAL",
+                    timeout=40, settings=post_settings,
                 )
                 or 0
             )
@@ -5654,6 +5660,7 @@ ORDER BY (test_name, callee_offset)
                 clickhouse_execute(
                     args,
                     "SELECT uniq(test_name) FROM system.coverage_indirect_calls FINAL",
+                    timeout=40, settings=post_settings,
                 )
                 or 0
             )
@@ -5661,6 +5668,7 @@ ORDER BY (test_name, callee_offset)
                 clickhouse_execute(
                     args,
                     "SELECT uniqExact(callee_offset) FROM system.coverage_indirect_calls FINAL",
+                    timeout=40, settings=post_settings,
                 )
                 or 0
             )
@@ -5680,7 +5688,15 @@ ORDER BY (test_name, callee_offset)
 
     if has_trace_log:
         try:
-            clickhouse_execute(args, "SYSTEM FLUSH LOGS system.trace_log")
+            # Bound these post-test diagnostics: on debug/coverage builds with a
+            # large accumulated trace_log they can otherwise eat tens of seconds
+            # of the wall-clock budget and trip the outer SIGTERM during shutdown.
+            clickhouse_execute(
+                args,
+                "SYSTEM FLUSH LOGS system.trace_log",
+                timeout=30,
+                settings={"max_execution_time": 20},
+            )
 
             unchecked_memory = int(clickhouse_execute(args, f"""
             SELECT sum(size) FROM system.trace_log
@@ -5688,7 +5704,8 @@ ORDER BY (test_name, callee_offset)
                 trace_type = 'MemoryAllocatedWithoutCheck'
                 AND event_date >= toDate(fromUnixTimestamp({int(tests_start_time)}))
                 AND event_time >= fromUnixTimestamp({int(tests_start_time)})
-            """))
+            SETTINGS max_execution_time = 30
+            """, timeout=40))
             if unchecked_memory > 1e9:
                 print(f"""
                 Too much memory has been allocated without checking for memory limits: {unchecked_memory/1024/1024/1024} GiB.


### PR DESCRIPTION
### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)



### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...
