### PR TITLE
Fix ThreadStatus destructor chassert in functions stress test

### DIFF
--- a/src/Functions/tests/gtest_functions_stress.cpp
+++ b/src/Functions/tests/gtest_functions_stress.cpp
@@ -1452,6 +1452,10 @@ struct FunctionsStressTestThread
             }
         }
 
+        /// We mutate `context->setCurrentQueryId()` per iteration but never refresh
+        /// `ThreadStatus::query_id`, so detach before destroying `thread_status` to
+        /// keep the destructor's id-vs-context invariant happy.
+        CurrentThread::detachFromGroupIfNotDetached();
         thread_status.reset(); // must be done from this thread
 
         {


### PR DESCRIPTION
The `FunctionsStress` unit test trips `~ThreadStatus`'s assertion because each iteration calls `context->setCurrentQueryId("")` without refreshing `ThreadStatus::query_id`. Detaching the thread group before destroying the `ThreadStatus` clears both `query_id` and `query_context`, so the destructor's id-vs-context invariant holds.

Surfaced by #105256 (converting `assert` to `chassert`).

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=105256&sha=a24f314f927ad5c12e928028e20be8d32d10b302&name_0=PR&name_1=Unit%20tests%20%28tsan%2C%20function_prop_fuzzer%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix assertion failure in `FunctionsStress` unit test.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.900`
<!-- ch-version-info:end -->