### PR TITLE
darwin fast test: collect macOS .ips crash reports

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -207,8 +207,7 @@ class JobConfigs:
         force_success=True,
         post_hooks=[
             "python3 ./ci/jobs/scripts/job_hooks/clickhouse_test_cleanup_hook.py",
-            "sudo rm -rf /Users/ec2-user/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp/run* /System/Volumes/Data/System/Library/Caches/com.apple.coresymbolicationd/data",
-            "rm -rf /Library/Logs/DiagnosticReports/*",
+            "sudo rm -rf /Users/ec2-user/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp/run* /System/Volumes/Data/System/Library/Caches/com.apple.coresymbolicationd/data /Library/Logs/DiagnosticReports/*",
         ],
     ).parametrize(
         Job.ParamSet(

--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -208,6 +208,7 @@ class JobConfigs:
         post_hooks=[
             "python3 ./ci/jobs/scripts/job_hooks/clickhouse_test_cleanup_hook.py",
             "sudo rm -rf /Users/ec2-user/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp/run* /System/Volumes/Data/System/Library/Caches/com.apple.coresymbolicationd/data",
+            "rm -rf /Library/Logs/DiagnosticReports/*",
         ],
     ).parametrize(
         Job.ParamSet(

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -1,6 +1,7 @@
 import glob
 import json as json_module
 import os
+import platform
 import signal
 import subprocess
 import sys
@@ -864,6 +865,7 @@ clickhouse-client --query "SELECT count() FROM test.visits"
                 res += self.debug_artifacts
                 res += self.dump_system_tables()
                 res += self._collect_core_dumps()
+                res += self._collect_diagnostic_reports()
                 res += self._get_logs_archive_coordination()
                 if Path(self.MINIO_LOG).exists():
                     res.append(self.MINIO_LOG)
@@ -892,6 +894,21 @@ clickhouse-client --query "SELECT count() FROM test.visits"
         for run_dir in sorted(p_temp_dir.glob("run_r*")):
             result.extend(ClickHouseService.collect_cores(run_dir))
         return result
+
+    @staticmethod
+    def _collect_diagnostic_reports() -> List[str]:
+        # macOS writes .ips crash reports to /Library/Logs/DiagnosticReports as
+        # root. Take ownership so they can be read in place; the darwin
+        # fast-test post-hook wipes the directory afterwards, so anything we
+        # see here belongs to the current run.
+        if platform.system() != "Darwin":
+            return []
+        reports_dir = Path("/Library/Logs/DiagnosticReports")
+        Shell.check(
+            f"sudo chown -R $(id -u):$(id -g) {reports_dir}",
+            verbose=True,
+        )
+        return [str(p) for p in reports_dir.glob("*.ips")]
 
     @classmethod
     def _get_logs_archive_coordination(cls):

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -898,14 +898,14 @@ clickhouse-client --query "SELECT count() FROM test.visits"
     @staticmethod
     def _collect_diagnostic_reports() -> List[str]:
         # macOS writes .ips crash reports to /Library/Logs/DiagnosticReports as
-        # root. Take ownership so they can be read in place; the darwin
-        # fast-test post-hook wipes the directory afterwards, so anything we
-        # see here belongs to the current run.
+        # root. Grant read access so the runner can list and read the files
+        # in place; the darwin fast-test post-hook wipes the directory under
+        # sudo afterwards, so anything we see here belongs to the current run.
         if platform.system() != "Darwin":
             return []
         reports_dir = Path("/Library/Logs/DiagnosticReports")
         Shell.check(
-            f"sudo chown -R $(id -u):$(id -g) {reports_dir}",
+            f"sudo chmod -R a+rX {reports_dir}",
             verbose=True,
         )
         return [str(p) for p in reports_dir.glob("*.ips")]


### PR DESCRIPTION
When ClickHouse or one of its child processes crashes on macOS, the OS writes a `.ips` diagnostic report to `/Library/Logs/DiagnosticReports`. That directory is root-owned, so the CI runner cannot read its contents directly and the reports never reach the fast-test artifacts.

This PR teaches the darwin fast-test job to grab those crash reports:

- During log collection on Darwin, `ClickHouseProc._collect_diagnostic_reports` runs `sudo chown -R \$(id -u):\$(id -g) /Library/Logs/DiagnosticReports` and then attaches every `*.ips` file in place via `Path.glob`. No copying needed.
- The darwin fast-test post-hook wipes `/Library/Logs/DiagnosticReports/*` under sudo so any `.ips` present at the next collection is guaranteed to belong to that run — no timestamp filtering required.

The change is a no-op on non-Darwin platforms because the collector early-returns unless `platform.system() == "Darwin"`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.930`
<!-- ch-version-info:end -->