### PR TITLE
Fix flaky test_grpc_protocol::test_cancel_while_generating_output

### DIFF
--- a/tests/integration/test_grpc_protocol/test.py
+++ b/tests/integration/test_grpc_protocol/test.py
@@ -604,7 +604,13 @@ def test_cancel_while_generating_output():
     output = b""
     for result in results:
         output += result.output
-    assert output == b"0\t0\n1\t0\n2\t0\n3\t0\n"
+    # The exact number of rows emitted before the cancel takes effect depends on
+    # how the server-side block production races against the cancel signal,
+    # which is timing-sensitive under load. Verify cancellation interrupted the
+    # query mid-stream by checking the output is a strict prefix of the full result.
+    full_output = b"".join(b"%d\t0\n" % i for i in range(10))
+    assert full_output.startswith(output), f"output not a prefix of full result: {output!r}"
+    assert len(output) < len(full_output), "cancel did not interrupt: got the full result"
 
 
 def test_compressed_output():


### PR DESCRIPTION
The strict equality `output == b"0\t0\n1\t0\n2\t0\n3\t0\n"` assumed that
exactly two blocks (4 rows) would reach the client before the `cancel`
signal interrupted execution. The exact number depends on how the
server-side block production races against cancel propagation, which is
timing-sensitive under load. Locally with a TSan build, reducing the
client-side wait to ~0.3s reliably produces a 2-row outcome, matching
the observed CI failure.

The flakiness became visible in `Integration tests (amd_tsan, 6/6)` after
PR #105281 (`test_distributed_async_insert_batch_recovery`) shifted
`test_grpc_protocol` from the lighter `5/6` shard into `6/6` via the
deterministic round-robin assignment in `get_optimal_test_batch`. The
test itself was fragile regardless; any future shard reshuffle could
re-trigger it.

Relax the assertion to verify the real invariants: cancel was delivered,
output is a strict prefix of the full 10-row result, and execution was
actually interrupted (fewer than 10 rows received).

Closes #105411

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=105334&sha=8006f97a75b8020900c12641809d69eaa153c14c&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%206%2F6%29

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix flakiness in `test_grpc_protocol::test_cancel_while_generating_output`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.917`
<!-- ch-version-info:end -->