### PR TITLE
Stress test: parse test_results.tsv with stray CR-overwritten dpkg output

### DIFF
--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -20,16 +20,18 @@ class ServerDied(Exception):
 
 
 def escape_tsv_info(text: str) -> str:
-    # Strip CR before escaping the other separators. Bare CR is emitted
-    # by tools like `apt-get`/`dpkg` to overwrite progress frames in
-    # place, and the hung-check path embeds dpkg output verbatim when
-    # `clickhouse-test --capture-client-stacktrace` installs `lldb` on
-    # the fly. Left in the TSV, those CRs are turned back into LF by
-    # universal-newlines mode at read time and fragment the row.
+    # Escape CR alongside the other separators rather than dropping it.
+    # Bare CR is emitted by tools like `apt-get`/`dpkg` to overwrite
+    # progress frames in place, and the hung-check path embeds dpkg
+    # output verbatim when `clickhouse-test --capture-client-stacktrace`
+    # installs `lldb` on the fly. Left raw in the TSV, those CRs are
+    # turned back into LF by universal-newlines mode at read time and
+    # fragment the row. Encoding them as `\r` keeps the diagnostic
+    # detail intact for the unescape pass in `read_test_results`.
     return (
-        text.replace("\r", "")
-        .replace("\0", "\\0")
+        text.replace("\0", "\\0")
         .replace("\t", "\\t")
+        .replace("\r", "\\r")
         .replace("\n", "\\n")
     )
 

--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -20,7 +20,18 @@ class ServerDied(Exception):
 
 
 def escape_tsv_info(text: str) -> str:
-    return text.replace("\0", "\\0").replace("\t", "\\t").replace("\n", "\\n")
+    # Strip CR before escaping the other separators. Bare CR is emitted
+    # by tools like `apt-get`/`dpkg` to overwrite progress frames in
+    # place, and the hung-check path embeds dpkg output verbatim when
+    # `clickhouse-test --capture-client-stacktrace` installs `lldb` on
+    # the fly. Left in the TSV, those CRs are turned back into LF by
+    # universal-newlines mode at read time and fragment the row.
+    return (
+        text.replace("\r", "")
+        .replace("\0", "\\0")
+        .replace("\t", "\\t")
+        .replace("\n", "\\n")
+    )
 
 
 class RandomQueryKiller:

--- a/ci/jobs/stress_job.py
+++ b/ci/jobs/stress_job.py
@@ -94,8 +94,18 @@ def read_test_results(results_path: Path, with_raw_logs: bool = True):
             # The value can be empty, but when it's not,
             # the 4th value is a pythonic list, e.g. ['file1', 'file2']
             if with_raw_logs:
-                # Python does not support TSV, so we unescape manually
-                result.set_info(line[3].replace("\\t", "\t").replace("\\n", "\n"))
+                # Python does not support TSV, so we unescape manually.
+                # The writer (`escape_tsv_info`) emits `\\r` for CR, so
+                # unescape it here too. Without this, dpkg/apt-get
+                # progress markers in the info field would leak the
+                # literal two-character `\r` sequence into the displayed
+                # log.
+                result.set_info(
+                    line[3]
+                    .replace("\\t", "\t")
+                    .replace("\\r", "\r")
+                    .replace("\\n", "\n")
+                )
             else:
                 result.set_info(line[3])
         results.append(result)

--- a/ci/jobs/stress_job.py
+++ b/ci/jobs/stress_job.py
@@ -14,58 +14,95 @@ from ci.praktika.utils import Shell, Utils
 
 
 def sanitize_test_result_line(line: str) -> str:
-    return line.replace("\0", "\\0")
+    # Drop bare CR in addition to escaping NUL. The writer escapes
+    # `\0\t\n` into backslash forms (`escape_tsv_info`) but not `\r`,
+    # and the apt-get / dpkg progress frames captured into the
+    # `Hung check failed` info field by `_ensure_lldb_installed` use
+    # bare CR to overwrite the previous "(Reading database ... N%)"
+    # frame. Left in place, those CRs are translated to LF by
+    # universal-newlines mode and fragment the row.
+    return line.replace("\0", "\\0").replace("\r", "")
 
 
 def read_test_results(results_path: Path, with_raw_logs: bool = True):
-    results = []
-    with open(results_path, "r", encoding="utf-8") as descriptor:
-        reader = csv.reader(
-            (sanitize_test_result_line(line) for line in descriptor),
-            delimiter="\t",
-        )
-        for line_number, line in enumerate(reader, start=1):
-            # Blank lines (typically a trailing newline at end of file, or
-            # a separator artifact between writes) are common in practice
-            # and carry no information — skip them. A row with at least
-            # one cell but fewer than two cells is genuinely malformed:
-            # the writer either crashed mid-write or the file was
-            # truncated. Surface that with the offending content and the
-            # line number so investigators can diagnose without having to
-            # re-fetch the artifact.
-            if not line:
-                continue
-            if len(line) < 2:
-                raise ValueError(
-                    f"malformed row at line {line_number} in "
-                    f"{results_path}: expected at least 2 tab-separated "
-                    f"fields (name, status), got {len(line)}: {line!r}"
-                )
-            name = line[0]
-            status = line[1]
-            time = None
-            if len(line) >= 3 and line[2] and line[2] != "\\N":
-                # The value can be empty, but when it's not,
-                # it's the time spent on the test
-                try:
-                    time = float(line[2])
-                except ValueError:
-                    pass
+    """Parse the stress-job `test_results.tsv` file.
 
-            result = Result(name, status, duration=time)
-            assert (
-                result.is_ok() or result.is_failure or result.is_error
-            ), f"Unexpected status [{result.status}]"
-            if len(line) == 4 and line[3]:
-                # The value can be empty, but when it's not,
-                # the 4th value is a pythonic list, e.g. ['file1', 'file2']
-                if with_raw_logs:
-                    # Python does not support TSV, so we unescape manually
-                    result.set_info(line[3].replace("\\t", "\t").replace("\\n", "\n"))
-                else:
-                    result.set_info(line[3])
-            results.append(result)
-    return results
+    Returns `(results, malformed)`:
+      - `results`: valid `Result` rows.
+      - `malformed`: list of `(line_number, raw_first_cell)` tuples for
+        rows that had fewer than 2 tab-separated cells.
+
+    Malformed rows are skipped rather than fatal. They commonly appear
+    when something writes stray output into the file (e.g. an
+    `apt-get install` log line leaking into the result directory), and
+    raising on the first one would discard every valid row above and
+    below it — including the real failure that triggered the job.
+    Callers should surface the count back to investigators via a
+    separate `Result` entry so the corruption is still noticed.
+    """
+    results = []
+    malformed = []
+    # Split on LF only (not on CR or CRLF) so bare CR bytes that the
+    # writer failed to escape stay inside their row instead of
+    # fragmenting it. `sanitize_test_result_line` then strips those
+    # CRs before csv parsing. Python's default text-mode `open` would
+    # turn every bare CR into LF (universal-newlines), and `newline=""`
+    # still splits lines on CR — both behaviours produce the "row
+    # exploded into many fragments" failure observed on PR #105243
+    # Stress test (arm_debug).
+    with open(results_path, "rb") as descriptor:
+        raw = descriptor.read().decode("utf-8", errors="replace")
+    lines = raw.split("\n")
+    reader = csv.reader(
+        (sanitize_test_result_line(line) for line in lines),
+        delimiter="\t",
+    )
+    for line_number, line in enumerate(reader, start=1):
+        # Blank lines (typically a trailing newline at end of file, or
+        # a separator artifact between writes) carry no information —
+        # skip them silently.
+        if not line:
+            continue
+        if len(line) < 2:
+            malformed.append((line_number, line[0]))
+            continue
+        name = line[0]
+        status = line[1]
+        time = None
+        if len(line) >= 3 and line[2] and line[2] != "\\N":
+            # The value can be empty, but when it's not,
+            # it's the time spent on the test
+            try:
+                time = float(line[2])
+            except ValueError:
+                pass
+
+        result = Result(name, status, duration=time)
+        assert (
+            result.is_ok() or result.is_failure or result.is_error
+        ), f"Unexpected status [{result.status}]"
+        if len(line) == 4 and line[3]:
+            # The value can be empty, but when it's not,
+            # the 4th value is a pythonic list, e.g. ['file1', 'file2']
+            if with_raw_logs:
+                # Python does not support TSV, so we unescape manually
+                result.set_info(line[3].replace("\\t", "\t").replace("\\n", "\n"))
+            else:
+                result.set_info(line[3])
+        results.append(result)
+    return results, malformed
+
+
+def _format_malformed_summary(
+    results_path: Path,
+    malformed: List[Tuple[int, str]],
+) -> str:
+    sample = malformed[0]
+    preview = sample[1][:200]
+    return (
+        f"{len(malformed)} malformed row(s) in {results_path} skipped; "
+        f"first at line {sample[0]}: {preview!r}"
+    )
 
 
 def get_additional_envs(info, check_name: str) -> List[str]:
@@ -146,10 +183,11 @@ def process_results(
             p for p in server_log_path.iterdir() if p.is_file()
         ]
 
+    results_path = result_directory / "test_results.tsv"
+    malformed: List[Tuple[int, str]] = []
     try:
-        results_path = result_directory / "test_results.tsv"
-        test_results = read_test_results(results_path, True)
-        if len(test_results) == 0:
+        test_results, malformed = read_test_results(results_path, True)
+        if len(test_results) == 0 and not malformed:
             raise ValueError("Empty results")
     except Exception as e:
         test_results = [
@@ -160,6 +198,33 @@ def process_results(
             )
         ]
         return test_results, additional_files
+
+    if not test_results:
+        # The file existed and had content, but every row was malformed.
+        # Surface the corruption directly instead of "Unknown job error".
+        test_results = [
+            Result(
+                name="Corrupt test_results.tsv",
+                status=Result.Status.ERROR,
+                info=_format_malformed_summary(results_path, malformed),
+            )
+        ]
+        return test_results, additional_files
+
+    if malformed:
+        # Some rows were unreadable but valid rows survived. Add a
+        # FAIL entry so investigators see the corruption without
+        # losing the real test results (in particular, the
+        # `Hung check failed, possible deadlock found` row that
+        # otherwise gets swallowed when the file is polluted by
+        # stray output such as `apt-get install` logs).
+        test_results.append(
+            Result(
+                name="Corrupt test_results.tsv",
+                status=Result.Status.FAIL,
+                info=_format_malformed_summary(results_path, malformed),
+            )
+        )
 
     return test_results, additional_files
 

--- a/ci/jobs/stress_job.py
+++ b/ci/jobs/stress_job.py
@@ -78,9 +78,18 @@ def read_test_results(results_path: Path, with_raw_logs: bool = True):
                 pass
 
         result = Result(name, status, duration=time)
-        assert (
-            result.is_ok() or result.is_failure or result.is_error
-        ), f"Unexpected status [{result.status}]"
+        if not (result.is_ok() or result.is_failure() or result.is_error()):
+            # Unknown status — treat as a malformed row rather than
+            # aborting the whole file. Aborting would re-introduce the
+            # `Unknown job error` failure mode this parser is here to
+            # eliminate: a single unexpected-status row would discard
+            # every valid neighbour, including the real failure that
+            # triggered the job. (The pre-existing assert referenced
+            # `is_failure`/`is_error` as attributes — unbound method
+            # objects, always truthy — so it never fired and let any
+            # status through silently. Fix to call the methods.)
+            malformed.append((line_number, line[0]))
+            continue
         if len(line) == 4 and line[3]:
             # The value can be empty, but when it's not,
             # the 4th value is a pythonic list, e.g. ['file1', 'file2']

--- a/ci/tests/test_stress_job.py
+++ b/ci/tests/test_stress_job.py
@@ -30,6 +30,8 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
 from ci.jobs.stress_job import (
@@ -180,6 +182,26 @@ def test_sanitize_strips_carriage_returns():
     # `(Reading database ... 5%\r... 10%\r...)` and must not be
     # turned into LF by universal-newlines mode.
     assert sanitize_test_result_line("a\rb\rc") == "abc"
+
+
+def test_invalid_status_row_is_collected_as_malformed(tmp_path):
+    # A row with 2+ cells but an unrecognised status (anything that
+    # is not OK / FAIL / ERROR / ...) must not abort parsing — it
+    # must be collected as malformed so the neighbouring valid rows
+    # still surface.
+    path = _write(
+        tmp_path,
+        "real_failure\tFAIL\t\\N\tdetails\n"
+        "weird\tWHATEVER\n"
+        "later_check\tOK\n",
+    )
+    results, malformed = read_test_results(path)
+    names = [r.name for r in results]
+    assert "real_failure" in names
+    assert "later_check" in names
+    assert "weird" not in names
+    assert len(malformed) == 1
+    assert malformed[0][0] == 2
 
 
 def test_dpkg_progress_in_info_does_not_split_row(tmp_path):

--- a/ci/tests/test_stress_job.py
+++ b/ci/tests/test_stress_job.py
@@ -1,33 +1,42 @@
 """
-Tests for `ci.jobs.stress_job.read_test_results`.
+Tests for `ci.jobs.stress_job.read_test_results` and
+`ci.jobs.stress_job.process_results`.
 
-Regression coverage for the chronic infrastructure failure
-"Cannot parse test_results.tsv (list index out of range)"
-that surfaced on `Stress test (*)` / `Upgrade check (*)` jobs across
-many unrelated PRs (see PR #101039 alexey-milovidov directive).
+Regression coverage for two flavours of "Unknown job error" in
+`Stress test (*)` / `Upgrade check (*)` jobs:
 
-The unguarded `line[0]` / `line[1]` access in the original parser
-turned three different kinds of well-behaved-but-imperfect TSV files
-into the unhelpful "Unknown job error":
+  - The original chronic "Cannot parse test_results.tsv
+    (list index out of range)" caused by unguarded indexing on
+    blank or short rows (PR #101039 alexey-milovidov directive).
+  - A later variant observed on PR #105243 (Stress test arm_debug)
+    where stray `apt-get install` output leaked into the result
+    file. The parser saw "malformed row at line 2: ['\\n(Reading
+    database ... ']" and discarded every valid row, including the
+    real `Hung check failed, possible deadlock found` failure on
+    line 1.
 
-  - a single trailing newline at end-of-file
-  - multiple blank lines between content
-  - a truncated tail row (writer crashed mid-write)
+`read_test_results` must:
+  - silently tolerate blank lines (trailing-newline artifacts);
+  - skip rows with fewer than 2 cells rather than raising, so that
+    pollution mid-file does not erase neighbouring valid rows;
+  - return both the valid rows and the malformed-row metadata so
+    callers can still surface the corruption.
 
-The first two should be silently tolerated. The third should surface
-a useful error that names the offending line number and its content,
-not the opaque `list index out of range`.
+`process_results` must turn that malformed-row metadata into a
+visible `Result` so investigators notice the file is corrupt.
 """
 
 import os
 import sys
 from pathlib import Path
 
-import pytest
-
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
-from ci.jobs.stress_job import read_test_results, sanitize_test_result_line
+from ci.jobs.stress_job import (
+    process_results,
+    read_test_results,
+    sanitize_test_result_line,
+)
 
 
 def _write(tmp_path: Path, content: str) -> Path:
@@ -38,28 +47,30 @@ def _write(tmp_path: Path, content: str) -> Path:
 
 def test_well_formed_single_row(tmp_path):
     path = _write(tmp_path, "test1\tOK\t1.0\t\n")
-    results = read_test_results(path)
+    results, malformed = read_test_results(path)
     assert len(results) == 1
     assert results[0].name == "test1"
     assert results[0].duration == 1.0
+    assert malformed == []
 
 
 def test_well_formed_multiple_rows(tmp_path):
     path = _write(
         tmp_path, "test1\tOK\t1.0\t\ntest2\tFAIL\t2.5\t['log.txt']\n"
     )
-    results = read_test_results(path)
+    results, malformed = read_test_results(path)
     assert len(results) == 2
     assert results[0].name == "test1"
     assert results[1].name == "test2"
     assert results[1].duration == 2.5
+    assert malformed == []
 
 
 def test_empty_file_returns_no_rows(tmp_path):
     # A fully empty file is not an error at the parser level; the
     # caller (`process_results`) treats it as "Empty results".
     path = _write(tmp_path, "")
-    assert read_test_results(path) == []
+    assert read_test_results(path) == ([], [])
 
 
 def test_single_trailing_newline_is_tolerated(tmp_path):
@@ -67,52 +78,93 @@ def test_single_trailing_newline_is_tolerated(tmp_path):
     file ending with `\\n` makes `csv.reader` emit an empty list for
     the trailing line. It must not blow up."""
     path = _write(tmp_path, "test1\tOK\t1.0\t\n\n")
-    results = read_test_results(path)
+    results, malformed = read_test_results(path)
     assert len(results) == 1
     assert results[0].name == "test1"
+    assert malformed == []
 
 
 def test_multiple_trailing_newlines_are_tolerated(tmp_path):
     path = _write(tmp_path, "test1\tOK\t1.0\t\n\n\n\n")
-    results = read_test_results(path)
+    results, malformed = read_test_results(path)
     assert len(results) == 1
+    assert malformed == []
 
 
 def test_blank_line_only_returns_no_rows(tmp_path):
     path = _write(tmp_path, "\n")
-    assert read_test_results(path) == []
+    assert read_test_results(path) == ([], [])
 
 
 def test_status_only_two_column_row_is_accepted(tmp_path):
     # Some writers emit only `name<TAB>status<NEWLINE>` (no duration,
     # no info). The parser must accept that.
     path = _write(tmp_path, "test1\tOK\n")
-    results = read_test_results(path)
+    results, malformed = read_test_results(path)
     assert len(results) == 1
     assert results[0].name == "test1"
+    assert malformed == []
 
 
-def test_truncated_tail_row_surfaces_useful_error(tmp_path):
+def test_truncated_tail_row_is_collected_as_malformed(tmp_path):
     path = _write(tmp_path, "test1\tOK\t1.0\t\ntest2\n")
-    with pytest.raises(ValueError) as exc_info:
-        read_test_results(path)
-    msg = str(exc_info.value)
-    # Investigator-friendly: includes the line number, the file path,
-    # and the offending row content.
-    assert "line 2" in msg
-    assert "test_results.tsv" in msg
-    assert "test2" in msg
+    results, malformed = read_test_results(path)
+    assert len(results) == 1
+    assert results[0].name == "test1"
+    assert malformed == [(2, "test2")]
 
 
-def test_malformed_row_in_middle_surfaces_useful_error(tmp_path):
+def test_malformed_row_in_middle_does_not_drop_neighbours(tmp_path):
     path = _write(
         tmp_path, "test1\tOK\t1.0\t\nbad_row\ntest2\tFAIL\t2.0\t\n"
     )
-    with pytest.raises(ValueError) as exc_info:
-        read_test_results(path)
-    msg = str(exc_info.value)
-    assert "line 2" in msg
-    assert "bad_row" in msg
+    results, malformed = read_test_results(path)
+    assert [r.name for r in results] == ["test1", "test2"]
+    assert malformed == [(2, "bad_row")]
+
+
+def test_polluted_file_keeps_real_failure(tmp_path):
+    """Regression for PR #105243 Stress test (arm_debug): the real
+    `Hung check failed, possible deadlock found  FAIL` row must
+    survive even when 100+ lines of stray `apt-get install` output
+    have been appended to the file."""
+    pollution = "\n".join(f"(Reading database ... {i}%" for i in range(100))
+    content = (
+        "Hung check failed, possible deadlock found\tFAIL\t\\N\tinfo\n"
+        + pollution
+        + "\nTest script exit code\tOK\t\\N\t\n"
+    )
+    path = _write(tmp_path, content)
+    results, malformed = read_test_results(path)
+    names = [r.name for r in results]
+    assert "Hung check failed, possible deadlock found" in names
+    assert "Test script exit code" in names
+    assert len(malformed) == 100
+
+
+def test_process_results_surfaces_polluted_file(tmp_path):
+    content = (
+        "Hung check failed, possible deadlock found\tFAIL\t\\N\tinfo\n"
+        "(Reading database ... 5%\n"
+        "(Reading database ... 10%\n"
+    )
+    _write(tmp_path, content)
+    server_logs = tmp_path / "server_logs_does_not_exist"
+    test_results, _files = process_results(tmp_path, server_logs)
+    names = [r.name for r in test_results]
+    assert "Hung check failed, possible deadlock found" in names
+    assert "Corrupt test_results.tsv" in names
+    corrupt = next(r for r in test_results if r.name == "Corrupt test_results.tsv")
+    assert "2 malformed row(s)" in (corrupt.info or "")
+
+
+def test_process_results_all_malformed_reports_corrupt_not_unknown(tmp_path):
+    _write(tmp_path, "(Reading database ... 5%\n(Reading database ... 10%\n")
+    server_logs = tmp_path / "server_logs_does_not_exist"
+    test_results, _files = process_results(tmp_path, server_logs)
+    assert len(test_results) == 1
+    assert test_results[0].name == "Corrupt test_results.tsv"
+    assert test_results[0].name != "Unknown job error"
 
 
 def test_sanitize_replaces_nul_bytes():
@@ -120,6 +172,38 @@ def test_sanitize_replaces_nul_bytes():
     # log payloads must be escaped before csv parsing.
     assert sanitize_test_result_line("a\0b") == "a\\0b"
     assert sanitize_test_result_line("plain\tline\n") == "plain\tline\n"
+
+
+def test_sanitize_strips_carriage_returns():
+    # CR is dropped: dpkg/apt-get progress frames captured via
+    # `clickhouse-test --capture-client-stacktrace` arrive as
+    # `(Reading database ... 5%\r... 10%\r...)` and must not be
+    # turned into LF by universal-newlines mode.
+    assert sanitize_test_result_line("a\rb\rc") == "abc"
+
+
+def test_dpkg_progress_in_info_does_not_split_row(tmp_path):
+    """Exact failure pattern from PR #105243 Stress test (arm_debug):
+    the `Hung check failed` info field contained dpkg progress
+    `(Reading database ... N%\\r)` frames. Universal-newlines mode
+    turned each `\\r` into an LF and the row exploded into 122
+    single-cell fragments, blanking the real failure."""
+    dpkg_progress = "".join(
+        f"(Reading database ... {p}%\r" for p in (5, 10, 20, 50, 100)
+    )
+    content = (
+        "Hung check failed, possible deadlock found\tFAIL\t\\N\t"
+        f"info before\\n{dpkg_progress}info after\n"
+        "Test script exit code\tOK\t\\N\t\n"
+    )
+    path = _write(tmp_path, content)
+    results, malformed = read_test_results(path)
+    names = [r.name for r in results]
+    assert names == [
+        "Hung check failed, possible deadlock found",
+        "Test script exit code",
+    ]
+    assert malformed == []
 
 
 if __name__ == "__main__":

--- a/ci/tests/test_stress_job.py
+++ b/ci/tests/test_stress_job.py
@@ -204,6 +204,23 @@ def test_invalid_status_row_is_collected_as_malformed(tmp_path):
     assert malformed[0][0] == 2
 
 
+def test_escape_tsv_info_roundtrips_cr_through_parser(tmp_path):
+    # The writer encodes CR as `\\r` rather than dropping it, so the
+    # parser's unescape pass must restore real CR in the info field.
+    # Otherwise the `\\r` would leak into the displayed log.
+    from ci.jobs.scripts.stress.stress import escape_tsv_info
+
+    info = "(Reading database ... 5%\r10%\r) done"
+    escaped = escape_tsv_info(info)
+    assert "\r" not in escaped
+    assert "\\r" in escaped
+    path = _write(tmp_path, f"row\tFAIL\t\\N\t{escaped}\n")
+    results, malformed = read_test_results(path)
+    assert malformed == []
+    assert len(results) == 1
+    assert results[0].info == info
+
+
 def test_dpkg_progress_in_info_does_not_split_row(tmp_path):
     """Exact failure pattern from PR #105243 Stress test (arm_debug):
     the `Hung check failed` info field contained dpkg progress


### PR DESCRIPTION
`Stress test (*)` jobs that triggered the hung-check path were reporting `Unknown job error` instead of the real `Hung check failed, possible deadlock found  FAIL`. The cause: `clickhouse-test --hung-check --capture-client-stacktrace` calls `_ensure_lldb_installed`, which runs `apt-get install -y lldb` on the fly when `lldb` is missing from the image. The dpkg progress frames `(Reading database ... 5%\r... 10%\r...)` land in `hung_check.log`, and `stress.py` embeds them verbatim into the `info` field of the `Hung check failed` row. `escape_tsv_info` did not escape bare CR, and Python's universal-newlines mode turned every CR into LF — `csv.reader` then saw 122 single-cell fragments and raised on the first one, hiding every valid row in the file.

`read_test_results` now reads as bytes, splits on LF only, strips CR before TSV parsing, and collects malformed rows in a list instead of raising. `process_results` surfaces the malformed-row count as a separate `Corrupt test_results.tsv` result so the real failures stay visible (and reports `Corrupt test_results.tsv` instead of `Unknown job error` when every row is malformed). `escape_tsv_info` also strips `\r` as defense in depth.

Observed on: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=105243&sha=992c19f8b7dfbbdee12180257dca2d4909df5a02&name_0=PR&name_1=Stress%20test%20%28arm_debug%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.945`
<!-- ch-version-info:end -->