### PR TITLE
Fix misleading comment in EscapingRuleUtils.cpp

### DIFF
--- a/src/Formats/EscapingRuleUtils.cpp
+++ b/src/Formats/EscapingRuleUtils.cpp
@@ -303,7 +303,7 @@ DataTypePtr tryInferDataTypeByEscapingRule(const String & field, const FormatSet
                 /// Return String type if one of the following conditions apply
                 ///  - we couldn't infer any type
                 ///  - it's a number and csv.try_infer_numbers_from_strings = 0
-                ///  - it's a tuple and try_infer_strings_from_quoted_tuples = 0
+                ///  - it's a tuple and try_infer_strings_from_quoted_tuples = 1
                 ///  - it's a Bool type (we don't allow reading bool values from strings)
                 if (!type || (format_settings.csv.try_infer_strings_from_quoted_tuples && isTuple(type)) || (!format_settings.csv.try_infer_numbers_from_strings && isNumber(type)) || isBool(type))
                     return std::make_shared<DataTypeString>();


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Closes https://github.com/ClickHouse/ClickHouse/issues/104995

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.159`
<!-- ch-version-info:end -->