### PR TITLE
Fix `input_format_json_empty_as_default` not working in JSONStrings* formats

### DIFF
--- a/src/Formats/JSONUtils.cpp
+++ b/src/Formats/JSONUtils.cpp
@@ -281,6 +281,12 @@ namespace JSONUtils
                 String str;
                 readJSONString(str, in, format_settings.json);
 
+                if (format_settings.json.empty_as_default && str.empty())
+                {
+                    column.insertDefault();
+                    return false;
+                }
+
                 ReadBufferFromString buf(str);
 
                 if (as_nullable)

--- a/tests/queries/0_stateless/04260_json_empty_as_default_yield_strings.reference
+++ b/tests/queries/0_stateless/04260_json_empty_as_default_yield_strings.reference
@@ -1,0 +1,31 @@
+-- Simple types with yield_strings formats (JSONStringsEachRow, JSONCompactStringsEachRow)
+-- { echoOn }
+SELECT x FROM format(JSONStringsEachRow, 'x Date', '{"x":""}');
+1970-01-01
+SELECT x FROM format(JSONStringsEachRow, 'x Date32', '{"x":""}');
+1970-01-01
+SELECT toTimeZone(x, 'UTC') FROM format(JSONStringsEachRow, 'x DateTime', '{"x":""}');
+1970-01-01 00:00:00
+SELECT toTimeZone(x, 'UTC') FROM format(JSONStringsEachRow, 'x DateTime64', '{"x":""}');
+1970-01-01 00:00:00.000
+SELECT x FROM format(JSONStringsEachRow, 'x IPv4', '{"x":""}');
+0.0.0.0
+SELECT x FROM format(JSONStringsEachRow, 'x IPv6', '{"x":""}');
+::
+SELECT x FROM format(JSONStringsEachRow, 'x UUID', '{"x":""}');
+00000000-0000-0000-0000-000000000000
+-- JSONCompactStringsEachRow
+SELECT x FROM format(JSONCompactStringsEachRow, 'x Date', '[""]');
+1970-01-01
+SELECT x FROM format(JSONCompactStringsEachRow, 'x IPv6', '[""]');
+::
+SELECT x FROM format(JSONCompactStringsEachRow, 'x UUID', '[""]');
+00000000-0000-0000-0000-000000000000
+-- Nullable
+SELECT x FROM format(JSONStringsEachRow, 'x Nullable(IPv6)', '{"x":""}');
+\N
+-- Multiple columns with some empty
+SELECT x, y FROM format(JSONStringsEachRow, 'x Date, y String', '{"x":"", "y":"hello"}');
+1970-01-01	hello
+SELECT x, y FROM format(JSONStringsEachRow, 'x UUID, y UInt32', '{"x":"", "y":"42"}');
+00000000-0000-0000-0000-000000000000	42

--- a/tests/queries/0_stateless/04260_json_empty_as_default_yield_strings.sql
+++ b/tests/queries/0_stateless/04260_json_empty_as_default_yield_strings.sql
@@ -1,0 +1,23 @@
+SET input_format_json_empty_as_default = 1;
+
+-- Simple types with yield_strings formats (JSONStringsEachRow, JSONCompactStringsEachRow)
+-- { echoOn }
+SELECT x FROM format(JSONStringsEachRow, 'x Date', '{"x":""}');
+SELECT x FROM format(JSONStringsEachRow, 'x Date32', '{"x":""}');
+SELECT toTimeZone(x, 'UTC') FROM format(JSONStringsEachRow, 'x DateTime', '{"x":""}');
+SELECT toTimeZone(x, 'UTC') FROM format(JSONStringsEachRow, 'x DateTime64', '{"x":""}');
+SELECT x FROM format(JSONStringsEachRow, 'x IPv4', '{"x":""}');
+SELECT x FROM format(JSONStringsEachRow, 'x IPv6', '{"x":""}');
+SELECT x FROM format(JSONStringsEachRow, 'x UUID', '{"x":""}');
+
+-- JSONCompactStringsEachRow
+SELECT x FROM format(JSONCompactStringsEachRow, 'x Date', '[""]');
+SELECT x FROM format(JSONCompactStringsEachRow, 'x IPv6', '[""]');
+SELECT x FROM format(JSONCompactStringsEachRow, 'x UUID', '[""]');
+
+-- Nullable
+SELECT x FROM format(JSONStringsEachRow, 'x Nullable(IPv6)', '{"x":""}');
+
+-- Multiple columns with some empty
+SELECT x, y FROM format(JSONStringsEachRow, 'x Date, y String', '{"x":"", "y":"hello"}');
+SELECT x, y FROM format(JSONStringsEachRow, 'x UUID, y UInt32', '{"x":"", "y":"42"}');


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `input_format_json_empty_as_default` not working in JSONStrings* formats. Closes https://github.com/ClickHouse/ClickHouse/issues/104913


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.941`
<!-- ch-version-info:end -->