### PR TITLE
Add `merge_selector_min_age_to_disable_right_tail_heuristic` to disable right tail heuristic partitions no longer being written to

### DIFF
--- a/src/Client/BuzzHouse/Generator/TableSettings.cpp
+++ b/src/Client/BuzzHouse/Generator/TableSettings.cpp
@@ -309,6 +309,11 @@ static std::unordered_map<String, CHSetting> mergeTreeTableSettings = {
          [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.2, 0.2, 1, 100)); },
          {"0", "1", "2", "8", "10", "100"},
          false)},
+    {"merge_selector_min_age_to_disable_right_tail_heuristic",
+     CHSetting(
+         [](RandomGenerator & rg, FuzzConfig &) { return std::to_string(rg.thresholdGenerator<uint64_t>(0.3, 0.2, 0, 60)); },
+         {"0", "1", "5", "10"},
+         false)},
     {"merge_selector_window_size", rowsRangeSetting},
     {"merge_total_max_bytes_to_prewarm_cache", bytesRangeSetting},
     {"merge_tree_clear_old_parts_interval_seconds", highRangeSetting},

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -1225,6 +1225,7 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
             {"add_minmax_index_for_block_number_column", false, false, "New setting."},
             {"add_minmax_index_for_block_offset_column", false, false, "New setting."},
             {"concurrent_part_removal_threshold_for_remote_disk", 100, 16, "New setting. Lower threshold to enter the concurrent part removal path when any part being removed is on a remote disk, where each removal is typically one network round-trip. The old value (100) matches the legacy `concurrent_part_removal_threshold` default, so older `compatibility` modes preserve the previous behavior."},
+            {"merge_selector_min_age_to_disable_right_tail_heuristic", 0, 0, "New setting"},
         });
         addSettingsChanges(merge_tree_settings_changes_history, "26.4",
         {

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -1219,7 +1219,7 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
     static std::once_flag initialized_flag;
     std::call_once(initialized_flag, [&]
     {
-        addSettingsChanges(merge_tree_settings_changes_history, "26.5",
+        addSettingsChanges(merge_tree_settings_changes_history, "26.6",
         {
             {"part_minmax_index_columns", "partition_key_only", "partition_key_only", "New setting."},
             {"add_minmax_index_for_block_number_column", false, false, "New setting."},

--- a/src/Storages/MergeTree/Compaction/MergeSelectorApplier.cpp
+++ b/src/Storages/MergeTree/Compaction/MergeSelectorApplier.cpp
@@ -26,6 +26,7 @@ namespace MergeTreeSetting
     extern const MergeTreeSettingsUInt64 parts_to_throw_insert;
     extern const MergeTreeSettingsMergeSelectorAlgorithm merge_selector_algorithm;
     extern const MergeTreeSettingsBool merge_selector_enable_heuristic_to_remove_small_parts_at_right;
+    extern const MergeTreeSettingsUInt64 merge_selector_min_age_to_disable_right_tail_heuristic;
     extern const MergeTreeSettingsBool merge_selector_enable_heuristic_to_lower_max_parts_to_merge_at_once;
     extern const MergeTreeSettingsUInt64 merge_selector_heuristic_to_lower_max_parts_to_merge_at_once_exponent;
     extern const MergeTreeSettingsFloat merge_selector_base;
@@ -111,6 +112,8 @@ SimpleMergeSelector::Settings fillSimpleSettings(const ChooseContext & ctx)
     simple_merge_settings.window_size = ctx.merge_tree_settings[MergeTreeSetting::merge_selector_window_size];
     simple_merge_settings.max_parts_to_merge_at_once = ctx.merge_tree_settings[MergeTreeSetting::max_parts_to_merge_at_once];
     simple_merge_settings.enable_heuristic_to_remove_small_parts_at_right = ctx.merge_tree_settings[MergeTreeSetting::merge_selector_enable_heuristic_to_remove_small_parts_at_right];
+    simple_merge_settings.merge_selector_min_age_to_disable_right_tail_heuristic
+        = ctx.merge_tree_settings[MergeTreeSetting::merge_selector_min_age_to_disable_right_tail_heuristic];
     simple_merge_settings.base = ctx.merge_tree_settings[MergeTreeSetting::merge_selector_base];
     simple_merge_settings.min_parts_to_merge_at_once = ctx.merge_tree_settings[MergeTreeSetting::min_parts_to_merge_at_once];
 

--- a/src/Storages/MergeTree/Compaction/MergeSelectors/SimpleMergeSelector.cpp
+++ b/src/Storages/MergeTree/Compaction/MergeSelectors/SimpleMergeSelector.cpp
@@ -27,9 +27,12 @@ public:
     {
     }
 
-    void consider(RangesIterator range_it, PartsIterator begin, PartsIterator end, size_t sum_size, size_t sum_rows, size_t size_prev_at_left, const SimpleMergeSelector::Settings & settings)
+    void consider(RangesIterator range_it, PartsIterator begin, PartsIterator end, size_t sum_size, size_t sum_rows, size_t min_age, size_t size_prev_at_left, const SimpleMergeSelector::Settings & settings)
     {
-        if (settings.enable_heuristic_to_remove_small_parts_at_right)
+        const bool should_remove_small_parts_at_right = settings.enable_heuristic_to_remove_small_parts_at_right
+            && (!settings.merge_selector_min_age_to_disable_right_tail_heuristic
+                || min_age < settings.merge_selector_min_age_to_disable_right_tail_heuristic);
+        if (should_remove_small_parts_at_right)
         {
             size_t size_delta = 0;
             size_t rows_delta = 0;
@@ -320,6 +323,7 @@ void selectWithinPartsRange(
                     range_end,
                     sum_size,
                     sum_rows,
+                    min_age,
                     begin == 0 ? 0 : parts[begin - 1].size,
                     settings);
         }

--- a/src/Storages/MergeTree/Compaction/MergeSelectors/SimpleMergeSelector.h
+++ b/src/Storages/MergeTree/Compaction/MergeSelectors/SimpleMergeSelector.h
@@ -167,6 +167,8 @@ public:
           */
         bool enable_heuristic_to_remove_small_parts_at_right = true;
         double heuristic_to_remove_small_parts_at_right_max_ratio = 0.01;
+        /// Zero means disabled.
+        size_t merge_selector_min_age_to_disable_right_tail_heuristic = 0;
 
         /** Heuristic:
           * Lower max_parts_to_merge_at_once automatically when number of parts in partition approaching parts_to_throw_insert

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -826,6 +826,11 @@ namespace ErrorCodes
     side of range, if their size is less than specified ratio (0.01) of sum_size.
     Works for Simple and StochasticSimple merge selectors
     )", 0) \
+    DECLARE(UInt64, merge_selector_min_age_to_disable_right_tail_heuristic, 0, R"(
+    If greater than zero and `merge_selector_enable_heuristic_to_remove_small_parts_at_right` is enabled,
+    disables that heuristic for ranges where every part is at least this many seconds old. `0` disables this check.
+    Works for Simple and StochasticSimple merge selectors.
+    )", 0) \
     DECLARE(Float, merge_selector_base, 5.0, R"(Affects write amplification of
     assigned merges (expert level setting, don't change if you don't understand
     what it is doing). Works for Simple and StochasticSimple merge selectors

--- a/src/Storages/MergeTree/tests/gtest_simple_merge_selector.cpp
+++ b/src/Storages/MergeTree/tests/gtest_simple_merge_selector.cpp
@@ -1,27 +1,69 @@
 #include <gtest/gtest.h>
 #include <Storages/MergeTree/Compaction/MergeSelectors/SimpleMergeSelector.h>
 
+#include <string>
+#include <vector>
+
 using namespace DB;
+
+namespace
+{
+
+constexpr size_t MiB = 1024 * 1024;
+
+PartsRange makePartsRange(const std::vector<size_t> & sizes, const std::vector<time_t> & ages)
+{
+    EXPECT_EQ(sizes.size(), ages.size());
+    if (sizes.size() != ages.size())
+        return {};
+    PartsRange parts_range;
+    for (size_t i = 0; i < sizes.size(); ++i)
+    {
+        String part_name = "all_" + std::to_string(i) + "_" + std::to_string(i) + "_0";
+        parts_range.push_back(PartProperties
+        {
+            .name = part_name,
+            .info = MergeTreePartInfo::fromPartName(part_name, MERGE_TREE_DATA_MIN_FORMAT_VERSION_WITH_CUSTOM_PARTITIONING),
+            .size = sizes[i],
+            .age = ages[i],
+            .rows = 100,
+        });
+    }
+
+    return parts_range;
+}
+
+std::vector<String> getPartNames(const PartsRange & parts)
+{
+    std::vector<String> names;
+    names.reserve(parts.size());
+
+    for (const auto & part : parts)
+        names.push_back(part.name);
+
+    return names;
+}
+
+PartsRanges selectRightTailRange(SimpleMergeSelector::Settings settings, const std::vector<time_t> & ages)
+{
+    settings.base = 2.0;
+    settings.enable_heuristic_to_align_parts = false;
+
+    SimpleMergeSelector selector(settings);
+    auto parts_range = makePartsRange({10 * MiB, 10 * MiB, 1024}, ages);
+    std::vector<MergeConstraint> constraints{{100 * MiB, 1000}};
+
+    return selector.select({parts_range}, constraints, nullptr);
+}
+
+}
 
 TEST(SimpleMergeSelector, TestRowsConstraint)
 {
     SimpleMergeSelector::Settings settings;
     settings.base = 2.0;
     SimpleMergeSelector selector(settings);
-    std::vector<std::string> part_names = {"all_0_0_0", "all_1_1_0", "all_2_2_0"};
-    PartsRange parts_range;
-
-    for (const auto & part_name : part_names)
-    {
-        parts_range.push_back(PartProperties
-        {
-            .name = part_name,
-            .info = MergeTreePartInfo::fromPartName(part_name, MERGE_TREE_DATA_MIN_FORMAT_VERSION_WITH_CUSTOM_PARTITIONING),
-            .size = 10 * 1024,
-            .age = 0,
-            .rows = 100,
-        });
-    }
+    auto parts_range = makePartsRange({10 * 1024, 10 * 1024, 10 * 1024}, {0, 0, 0});
 
     size_t max_bytes = 100 * 1024 * 1024;
 
@@ -50,4 +92,68 @@ TEST(SimpleMergeSelector, TestRowsConstraint)
 
         ASSERT_EQ(selected.size(), 0);
     }
+}
+
+TEST(SimpleMergeSelector, RemovesSmallPartsAtRightByDefault)
+{
+    auto selected = selectRightTailRange(SimpleMergeSelector::Settings{}, {100, 100, 100});
+
+    ASSERT_EQ(selected.size(), 1);
+    EXPECT_EQ(getPartNames(selected[0]), std::vector<String>({"all_0_0_0", "all_1_1_0"}));
+}
+
+TEST(SimpleMergeSelector, DoesNotRemoveSmallPartsAtRightWhenAllPartsAreOldEnough)
+{
+    SimpleMergeSelector::Settings settings;
+    settings.merge_selector_min_age_to_disable_right_tail_heuristic = 60;
+
+    auto selected = selectRightTailRange(settings, {100, 100, 100});
+
+    ASSERT_EQ(selected.size(), 1);
+    EXPECT_EQ(getPartNames(selected[0]), std::vector<String>({"all_0_0_0", "all_1_1_0", "all_2_2_0"}));
+}
+
+TEST(SimpleMergeSelector, RemovesSmallPartsAtRightWhenAllPartsAreTooYoung)
+{
+    SimpleMergeSelector::Settings settings;
+    settings.merge_selector_min_age_to_disable_right_tail_heuristic = 60;
+
+    auto selected = selectRightTailRange(settings, {10, 10, 10});
+
+    ASSERT_EQ(selected.size(), 1);
+    EXPECT_EQ(getPartNames(selected[0]), std::vector<String>({"all_0_0_0", "all_1_1_0"}));
+}
+
+TEST(SimpleMergeSelector, RemovesSmallPartsAtRightWhenSomePartsAreTooYoung)
+{
+    SimpleMergeSelector::Settings settings;
+    settings.merge_selector_min_age_to_disable_right_tail_heuristic = 60;
+
+    auto selected = selectRightTailRange(settings, {100, 10, 100});
+
+    ASSERT_EQ(selected.size(), 1);
+    EXPECT_EQ(getPartNames(selected[0]), std::vector<String>({"all_0_0_0", "all_1_1_0"}));
+}
+
+TEST(SimpleMergeSelector, DoesNotRemoveSmallPartsAtRightAtAgeThreshold)
+{
+    SimpleMergeSelector::Settings settings;
+    settings.merge_selector_min_age_to_disable_right_tail_heuristic = 60;
+
+    auto selected = selectRightTailRange(settings, {60, 60, 60});
+
+    ASSERT_EQ(selected.size(), 1);
+    EXPECT_EQ(getPartNames(selected[0]), std::vector<String>({"all_0_0_0", "all_1_1_0", "all_2_2_0"}));
+}
+
+TEST(SimpleMergeSelector, DoesNotRemoveSmallPartsAtRightWhenHeuristicDisabled)
+{
+    SimpleMergeSelector::Settings settings;
+    settings.enable_heuristic_to_remove_small_parts_at_right = false;
+    settings.merge_selector_min_age_to_disable_right_tail_heuristic = 60;
+
+    auto selected = selectRightTailRange(settings, {10, 10, 10});
+
+    ASSERT_EQ(selected.size(), 1);
+    EXPECT_EQ(getPartNames(selected[0]), std::vector<String>({"all_0_0_0", "all_1_1_0", "all_2_2_0"}));
 }


### PR DESCRIPTION
Adds an opt-in `MergeTree` setting, `merge_selector_min_age_to_disable_right_tail_heuristic`, for `Simple` and `StochasticSimple` merge selectors.

When set to a non-zero value, the merge selector skips the right-tail small-part removal heuristic for candidate ranges where every part is at least that many seconds old. The default value is `0`, so existing merge behavior is preserved unless the setting is explicitly enabled. This is intended to help compact old immutable partitions where the existing right-tail heuristic can leave small parts stranded near a partition boundary.

### Question for reviewers

This seems like something that should be fixed more broadly than what I've done here

### Changelog category (leave one):
   - Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
   Added the `merge_selector_min_age_to_disable_right_tail_heuristic` `MergeTree` setting to let `Simple` and `StochasticSimple` merge selectors include old right-tail parts in merge
 candidates once all parts in the candidate range are old enough.

### Documentation entry:
   - [x] Documentation is generated from the `MergeTree` setting description in `MergeTreeSettings.cpp`.

Fixes #70912
Should help with #79697