### PR TITLE
Fix NULL insert into Variant column via VALUES format during expression parsing

### DIFF
--- a/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
@@ -588,7 +588,7 @@ bool ValuesBlockInputFormat::parseExpression(IColumn & column, size_t column_idx
     Field value = convertFieldToType(expression_value, type, value_raw.second.get(), format_settings);
 
     /// Check that we are indeed allowed to insert a NULL.
-    if (value.isNull() && !type.isNullable() && !type.isLowCardinalityNullable())
+    if (value.isNull() && !canContainNull(type))
     {
         if (format_settings.null_as_default)
         {

--- a/tests/queries/0_stateless/04260_variant_null_insert_values_format.reference
+++ b/tests/queries/0_stateless/04260_variant_null_insert_values_format.reference
@@ -1,0 +1,4 @@
+1	\N	None
+2	\N	None
+3	hello	String
+4	42	Int32

--- a/tests/queries/0_stateless/04260_variant_null_insert_values_format.sql
+++ b/tests/queries/0_stateless/04260_variant_null_insert_values_format.sql
@@ -1,0 +1,14 @@
+SET allow_experimental_variant_type = 1;
+SET input_format_null_as_default = 0;
+
+DROP TABLE IF EXISTS test_variant_null_expr;
+CREATE TABLE test_variant_null_expr (id Int32, v Variant(String, Int32)) ENGINE = Memory;
+
+INSERT INTO test_variant_null_expr VALUES (1, CAST(NULL AS Nullable(UInt8)));
+INSERT INTO test_variant_null_expr VALUES (2, NULL);
+INSERT INTO test_variant_null_expr VALUES (3, 'hello');
+INSERT INTO test_variant_null_expr VALUES (4, 42);
+
+SELECT id, v, variantType(v) FROM test_variant_null_expr ORDER BY id;
+
+DROP TABLE test_variant_null_expr;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix NULL insert into Variant column via VALUES format during expression parsing. Closes https://github.com/ClickHouse/ClickHouse/issues/104909.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.942`
<!-- ch-version-info:end -->