### PR TITLE
tests: fix 01563_distributed_query_finish flakiness from CI log-sender bursts

### DIFF
--- a/tests/queries/0_stateless/01563_distributed_query_finish.sh
+++ b/tests/queries/0_stateless/01563_distributed_query_finish.sh
@@ -19,7 +19,12 @@ create table dist_01247 as data_01247 engine=Distributed(test_cluster_two_shards
 select * from dist_01247 format Null;
 EOL
 
-# NOTE: it is possible to got NETWORK_ERROR even with no-parallel, at least due to system.*_log_sender to the cloud
+# Silence the CI system.*_log_sender background pool so its NETWORK_ERRORs
+# (when the cloud destination is unreachable) don't contaminate system.errors.
+# This only blocks the async insert sender; SELECT from dist_01247 is unaffected.
+$CLICKHOUSE_CLIENT -q "SYSTEM STOP DISTRIBUTED SENDS"
+trap '$CLICKHOUSE_CLIENT -q "SYSTEM START DISTRIBUTED SENDS"' EXIT
+
 for ((i = 0; i < 100; ++i)); do
     network_errors_before=$($CLICKHOUSE_CLIENT -q "SELECT value FROM system.errors WHERE name = 'NETWORK_ERROR'")
 


### PR DESCRIPTION
The test compares the global `system.errors` `NETWORK_ERROR` counter
before and after each iteration of a `Distributed` `SELECT` loop, and
expects at least one iteration with delta 0. The CI environment installs
`system.*_log_sender` `Distributed` tables (via
`ci/jobs/scripts/functional_tests/setup_log_cluster.sh`) that ship system
logs to a remote ClickHouse endpoint. When that endpoint is unreachable
(today: ~70% connection-reset rate on
`kng4alm55c.us-east-2.aws.clickhouse-staging.com:9440`, peak ~4 errors/s),
every iteration overlaps with at least one new background `NETWORK_ERROR`
and the test fails with `NETWORK_ERROR=N`. All 6 failures today share
this pattern across 5 unrelated PRs and `release/26.2`, clustered in a
single hour — clearly infrastructure, not a code regression.

Wrap the loop in `SYSTEM STOP/START DISTRIBUTED SENDS` so the background
async-insert sender stops shipping queued `.bin` files for the duration
of the test. The `ActionLocks::DistributedSend` lock only gates
`async_insert_blocker` in `StorageDistributed::getActionLock`, which is
consulted exclusively by `DistributedAsyncInsertDirectoryQueue` — so the
test's own `SELECT FROM dist_01247` is unaffected.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=105053&sha=af01ec85282c49af3fed289c244018319a061ba3&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20sequential%2C%202%2F2%29

Closes #105452

### Changelog category (leave one):
- CI Fix or improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):
Fix flakiness of `01563_distributed_query_finish` when the CI log-shipping endpoint is unreachable.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.95`
<!-- ch-version-info:end -->