### PR TITLE
AI review: don't post CI-redundant findings as inline comments

### DIFF
--- a/ci/jobs/copilot_review_job.py
+++ b/ci/jobs/copilot_review_job.py
@@ -155,6 +155,12 @@ Procedure:
 8. For genuinely new issues that do not already have a thread, post individual inline comments on the
    relevant changed lines. For architectural issues that do not map cleanly to one line, post around
    the most relevant change in the diff.
+9. Do NOT post inline comments for issues that dedicated CI jobs already catch and report: build /
+   compilation failures (missing headers, undeclared symbols, type errors, link errors) and style
+   check failures (formatting, linters, `check_cpp.sh` / `check_style.sh` output). These are not
+   blockers in this review context: the build and Style Check jobs surface them with full toolchain
+   output, so a review comment is pure noise. If you want to mention them, include them only as
+   `💡 Nits` in the summary file, never as inline comments or as `❌ Blockers` / `⚠️ Majors`.
 """
 
 


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

The AI reviewer was posting inline comments for issues that dedicated CI jobs already report (build/compile errors, missing headers, style check failures). That's pure noise — the build and Style Check jobs already surface those with full toolchain context.

Update the CI review prompt to keep these out of inline comments and out of the blocker/major buckets. Mentioning them as nits in the summary message is still allowed. Local `/review` runs are unaffected; only the CI wrapper (`ci/jobs/copilot_review_job.py`) is changed.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.912`
<!-- ch-version-info:end -->