### PR TITLE
Fix dictGetOrDefault with Nullable default expressions under short-circuit evaluation

### DIFF
--- a/src/Functions/FunctionsExternalDictionaries.h
+++ b/src/Functions/FunctionsExternalDictionaries.h
@@ -617,6 +617,46 @@ public:
 
 private:
 
+    /// When maskedExecute evaluates a short-circuit argument only on the rows where the
+    /// dictionary key was not found (mask == 1), it expands the result back to full size by
+    /// filling mask == 0 rows with NULLs via ColumnNullable::expand. Those rows are about to
+    /// be overwritten by the dictionary result, but castColumnAccurate rejects the column if
+    /// it contains any NULLs while casting to a non-Nullable type.
+    /// This helper clears the spurious null-map bits at mask == 0 positions so the cast only
+    /// fails when the user-provided default genuinely evaluates to NULL on a row that needs it.
+    static void clearMaskedNullsBeforeCast(
+        IColumn & column,
+        const IColumn::Filter & mask,
+        const DataTypePtr & result_type)
+    {
+        if (result_type->isNullable())
+            return;
+
+        if (auto * nullable = typeid_cast<ColumnNullable *>(&column))
+        {
+            auto & null_map = nullable->getNullMapData();
+            chassert(null_map.size() == mask.size());
+            for (size_t i = 0; i < null_map.size(); ++i)
+            {
+                if (!mask[i])
+                    null_map[i] = 0;
+            }
+            /// Recurse in case nested is e.g. Tuple(Nullable(...)).
+            clearMaskedNullsBeforeCast(nullable->getNestedColumn(), mask, result_type);
+        }
+        else if (auto * tuple_col = typeid_cast<ColumnTuple *>(&column))
+        {
+            if (const auto * tuple_type = typeid_cast<const DataTypeTuple *>(result_type.get()))
+            {
+                for (size_t col_idx = 0; col_idx < tuple_col->tupleSize(); ++col_idx)
+                {
+                    clearMaskedNullsBeforeCast(
+                        tuple_col->getColumn(col_idx), mask, tuple_type->getElements()[col_idx]);
+                }
+            }
+        }
+    }
+
     std::pair<ColumnPtr, ColumnPtr> getDefaultsShortCircuit(
         IColumn::Filter && default_mask,
         const DataTypePtr & result_type,
@@ -625,8 +665,11 @@ private:
         ColumnWithTypeAndName column_before_cast = last_argument;
         maskedExecute(column_before_cast, default_mask);
 
+        auto mutable_col = IColumn::mutate(column_before_cast.column->convertToFullColumnIfConst());
+        clearMaskedNullsBeforeCast(*mutable_col, default_mask, result_type);
+
         ColumnWithTypeAndName column_to_cast = {
-            column_before_cast.column->convertToFullColumnIfConst(),
+            std::move(mutable_col),
             column_before_cast.type,
             column_before_cast.name};
 

--- a/src/Functions/FunctionsExternalDictionaries.h
+++ b/src/Functions/FunctionsExternalDictionaries.h
@@ -648,7 +648,8 @@ private:
         {
             if (const auto * tuple_type = typeid_cast<const DataTypeTuple *>(result_type.get()))
             {
-                for (size_t col_idx = 0; col_idx < tuple_col->tupleSize(); ++col_idx)
+                const size_t n = std::min(tuple_col->tupleSize(), tuple_type->getElements().size());
+                for (size_t col_idx = 0; col_idx < n; ++col_idx)
                 {
                     clearMaskedNullsBeforeCast(
                         tuple_col->getColumn(col_idx), mask, tuple_type->getElements()[col_idx]);

--- a/tests/queries/0_stateless/04259_dictgetordefault_nullable_default_short_circuit.reference
+++ b/tests/queries/0_stateless/04259_dictgetordefault_nullable_default_short_circuit.reference
@@ -1,0 +1,20 @@
+a0
+a1
+fb_99
+fb_100
+String
+('a0',10)
+('a1',11)
+('fb_99',1099)
+('fb_100',1100)
+Tuple(\n    a String,\n    b UInt32)
+('a0',10)
+('a1',11)
+('fb_99',1099)
+('fb_100',1100)
+Tuple(\n    a String,\n    b UInt32)
+('a0',10)
+('a1',11)
+('fb_99',1099)
+('fb_100',1100)
+Tuple(\n    a String,\n    b UInt32)

--- a/tests/queries/0_stateless/04259_dictgetordefault_nullable_default_short_circuit.sql
+++ b/tests/queries/0_stateless/04259_dictgetordefault_nullable_default_short_circuit.sql
@@ -65,6 +65,11 @@ FROM test_dict_nullable_default_keys;
 SELECT toTypeName(dictGetOrDefault('test_dict_nullable_default_tuple', ('a', 'b'), toUInt64(0),
     toNullable((toNullable(toString(x)), toNullable(toUInt32(x)))))) FROM test_dict_nullable_default_keys LIMIT 1;
 
+-- Negative: a default that genuinely evaluates to NULL on a not-found row must still fail.
+SELECT dictGetOrDefault('test_dict_nullable_default_single', 'a', x,
+    materialize(NULL::Nullable(String)))
+FROM test_dict_nullable_default_keys; -- { serverError CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN }
+
 DROP DICTIONARY IF EXISTS test_dict_nullable_default_single;
 DROP DICTIONARY IF EXISTS test_dict_nullable_default_tuple;
 DROP TABLE IF EXISTS test_dict_nullable_default_keys;

--- a/tests/queries/0_stateless/04259_dictgetordefault_nullable_default_short_circuit.sql
+++ b/tests/queries/0_stateless/04259_dictgetordefault_nullable_default_short_circuit.sql
@@ -1,3 +1,6 @@
+-- Tags: no-parallel-replicas
+-- no-parallel-replicas: Dictionary source tables are not available on parallel-replica workers.
+
 -- https://github.com/ClickHouse/ClickHouse/issues/104511
 -- dictGetOrDefault should not throw CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN when
 -- the default argument is a Nullable expression and short-circuit evaluation is enabled.

--- a/tests/queries/0_stateless/04259_dictgetordefault_nullable_default_short_circuit.sql
+++ b/tests/queries/0_stateless/04259_dictgetordefault_nullable_default_short_circuit.sql
@@ -1,0 +1,71 @@
+-- https://github.com/ClickHouse/ClickHouse/issues/104511
+-- dictGetOrDefault should not throw CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN when
+-- the default argument is a Nullable expression and short-circuit evaluation is enabled.
+-- clearMaskedNullsBeforeCast handles: Nullable(T), Tuple(Nullable(T)),
+-- Nullable(Tuple(T)), Nullable(Tuple(Nullable(T))).
+
+SET short_circuit_function_evaluation = 'enable';
+
+DROP TABLE IF EXISTS test_dict_nullable_default_src;
+DROP TABLE IF EXISTS test_dict_nullable_default_keys;
+DROP DICTIONARY IF EXISTS test_dict_nullable_default_single;
+DROP DICTIONARY IF EXISTS test_dict_nullable_default_tuple;
+
+CREATE TABLE test_dict_nullable_default_src (id UInt64, a String, b UInt32) ENGINE = MergeTree ORDER BY id;
+INSERT INTO test_dict_nullable_default_src VALUES (0, 'a0', 10), (1, 'a1', 11);
+
+CREATE TABLE test_dict_nullable_default_keys (x UInt64) ENGINE = MergeTree ORDER BY x;
+INSERT INTO test_dict_nullable_default_keys VALUES (0), (1), (99), (100);
+
+CREATE DICTIONARY test_dict_nullable_default_single
+(
+    `id` UInt64,
+    `a`  String DEFAULT ''
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 'test_dict_nullable_default_src'))
+LAYOUT(DIRECT());
+
+CREATE DICTIONARY test_dict_nullable_default_tuple
+(
+    `id` UInt64,
+    `a`  String DEFAULT '',
+    `b`  UInt32 DEFAULT 0
+)
+PRIMARY KEY id
+SOURCE(CLICKHOUSE(TABLE 'test_dict_nullable_default_src'))
+LAYOUT(HASHED())
+LIFETIME(0);
+
+-- Nullable(String) -> String, single attribute with mixed found/not-found keys.
+SELECT dictGetOrDefault('test_dict_nullable_default_single', 'a', x,
+    toNullable(concat('fb_', toString(x)))) AS v
+FROM test_dict_nullable_default_keys;
+SELECT toTypeName(dictGetOrDefault('test_dict_nullable_default_single', 'a', toUInt64(0),
+    toNullable(toString(x)))) FROM test_dict_nullable_default_keys LIMIT 1;
+
+-- Tuple(Nullable(String), Nullable(UInt32)) -> Tuple(String, UInt32).
+SELECT dictGetOrDefault('test_dict_nullable_default_tuple', ('a', 'b'), x,
+    (toNullable(concat('fb_', toString(x))), toNullable(toUInt32(x + 1000)))) AS v
+FROM test_dict_nullable_default_keys;
+SELECT toTypeName(dictGetOrDefault('test_dict_nullable_default_tuple', ('a', 'b'), toUInt64(0),
+    (toNullable(toString(x)), toNullable(toUInt32(x))))) FROM test_dict_nullable_default_keys LIMIT 1;
+
+-- Nullable(Tuple(String, UInt32)) -> Tuple(String, UInt32).
+SELECT dictGetOrDefault('test_dict_nullable_default_tuple', ('a', 'b'), x,
+    toNullable((concat('fb_', toString(x)), toUInt32(x + 1000)))) AS v
+FROM test_dict_nullable_default_keys;
+SELECT toTypeName(dictGetOrDefault('test_dict_nullable_default_tuple', ('a', 'b'), toUInt64(0),
+    toNullable((toString(x), toUInt32(x))))) FROM test_dict_nullable_default_keys LIMIT 1;
+
+-- Nullable(Tuple(Nullable(String), Nullable(UInt32))) -> Tuple(String, UInt32).
+SELECT dictGetOrDefault('test_dict_nullable_default_tuple', ('a', 'b'), x,
+    toNullable((toNullable(concat('fb_', toString(x))), toNullable(toUInt32(x + 1000))))) AS v
+FROM test_dict_nullable_default_keys;
+SELECT toTypeName(dictGetOrDefault('test_dict_nullable_default_tuple', ('a', 'b'), toUInt64(0),
+    toNullable((toNullable(toString(x)), toNullable(toUInt32(x)))))) FROM test_dict_nullable_default_keys LIMIT 1;
+
+DROP DICTIONARY IF EXISTS test_dict_nullable_default_single;
+DROP DICTIONARY IF EXISTS test_dict_nullable_default_tuple;
+DROP TABLE IF EXISTS test_dict_nullable_default_keys;
+DROP TABLE IF EXISTS test_dict_nullable_default_src;


### PR DESCRIPTION
`dictGetOrDefault` threw `CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN` when the default argument had a `Nullable` type (e.g. `toString(materialize(toNullable('fallback')))`) and short-circuit evaluation was enabled, with a mix of found and not-found dictionary keys.

**Root cause:** `getDefaultsShortCircuit` calls `maskedExecute` to evaluate the default expression only on rows where the dictionary key was not found (mask == 1). Internally, `maskedExecute` uses `ColumnNullable::expand` to restore the column to full size, filling mask == 0 rows (found keys, where the default is irrelevant) with NULLs. The subsequent `castColumnAccurate` call then rejected the column because it detected NULLs while casting to a non-`Nullable` result type.

**Fix:** introduced `clearMaskedNullsBeforeCast`, a recursive helper that clears the spurious null-map bits at mask == 0 positions before the cast. It handles all combinations that arise in practice:

- `Nullable(T)` → `T` (single attribute, original issue)
- `Tuple(Nullable(T), ...)` → `Tuple(T, ...)` (tuple attributes with nullable elements)
- `Nullable(Tuple(T, ...))` → `Tuple(T, ...)` (nullable wrapper around a tuple)
- `Nullable(Tuple(Nullable(T), ...))` → `Tuple(T, ...)` (fully nested case)

Genuine NULLs at mask == 1 positions (rows where the default is actually used) are left untouched, so `castColumnAccurate` still correctly rejects a default expression that evaluates to `NULL` on a row that needs it.

Closes #104511

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `dictGetOrDefault` throwing `CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN` when the default argument is a `Nullable` expression and `short_circuit_function_evaluation` is enabled with a mix of found and not-found dictionary keys.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.156`
- Backported to: `26.5.2.14`, `26.4.4.18`, `26.3.13.17`
<!-- ch-version-info:end -->