### PR TITLE
Fix data corruption in Dynamic Quoted fallback (issue #105441)

### DIFF
--- a/src/DataTypes/Serializations/SerializationDynamic.cpp
+++ b/src/DataTypes/Serializations/SerializationDynamic.cpp
@@ -12,6 +12,7 @@
 
 #include <Columns/ColumnDynamic.h>
 #include <IO/WriteHelpers.h>
+#include <IO/WriteBufferFromString.h>
 #include <IO/ReadHelpers.h>
 #include <IO/ReadBufferFromString.h>
 #include <Formats/EscapingRuleUtils.h>
@@ -848,8 +849,15 @@ static void deserializeTextImpl(
         /// We cannot insert value with incomplete type, insert it as String.
         variant_type = std::make_shared<DataTypeString>();
         /// To be able to deserialize field as String with Quoted escaping rule, it should be quoted.
+        /// Use `writeQuotedString` so inner single quotes and backslashes are escaped properly;
+        /// naive concatenation `"'" + field + "'"` would terminate prematurely at the first inner
+        /// single quote, truncating the stored value (issue #105441).
         if (escaping_rule == FormatSettings::EscapingRule::Quoted && (field.size() < 2 || field.front() != '\'' || field.back() != '\''))
-            field = "'" + field + "'";
+        {
+            WriteBufferFromOwnString quoted;
+            writeQuotedString(field, quoted);
+            field = std::move(quoted.str());
+        }
     }
 
     if (dynamic_column.addNewVariant(variant_type, variant_type->getName()))

--- a/tests/queries/0_stateless/04261_105441_dynamic_quoted_empty_array_map_key.reference
+++ b/tests/queries/0_stateless/04261_105441_dynamic_quoted_empty_array_map_key.reference
@@ -1,0 +1,10 @@
+-- empty array as map key (raw text 11 chars, must round-trip intact)
+{"length(CAST(d, 'String'))":11,"CAST(d, 'String')":"{[]:'came'}","dynamicType(d)":"String"}
+-- empty array key with embedded single quote (would corrupt)
+{"length(CAST(d, 'String'))":21,"CAST(d, 'String')":"{[]:'with\\'embedded'}","dynamicType(d)":"String"}
+-- nested empty array as map key
+{"length(CAST(d, 'String'))":8,"CAST(d, 'String')":"{[[]]:1}","dynamicType(d)":"String"}
+-- empty array key + non-empty key (Array(Int64) is complete, stays as Map)
+{"length(CAST(d, 'String'))":16,"CAST(d, 'String')":"{[]:'a',[1]:'b'}","dynamicType(d)":"Map(Array(Int64), String)"}
+-- already-single-quoted plain string is not double-wrapped
+{"length(CAST(d, 'String'))":12,"CAST(d, 'String')":"plain string","dynamicType(d)":"String"}

--- a/tests/queries/0_stateless/04261_105441_dynamic_quoted_empty_array_map_key.sql
+++ b/tests/queries/0_stateless/04261_105441_dynamic_quoted_empty_array_map_key.sql
@@ -1,0 +1,36 @@
+-- Tags: no-fasttest
+-- Tag no-fasttest: requires Dynamic type, experimental.
+
+-- Regression for issue #105441 ("Empty array as map key, not serialized back").
+-- A `Dynamic` value whose Values/Quoted text infers to `Map(Array(Nothing), ...)` is
+-- considered incomplete, so the deserializer falls back to `String`. The fallback
+-- previously did `"'" + field + "'"`, which terminated prematurely at the first
+-- embedded single quote and silently truncated the stored value. The fix uses
+-- `writeQuotedString` so inner single quotes and backslashes are escaped properly.
+
+SET allow_experimental_dynamic_type = 1;
+
+SELECT '-- empty array as map key (raw text 11 chars, must round-trip intact)';
+SELECT length(d::String), d::String, dynamicType(d)
+FROM format(Values, 'd Dynamic', $$({[]:'came'})$$)
+FORMAT JSONEachRow;
+
+SELECT '-- empty array key with embedded single quote (would corrupt)';
+SELECT length(d::String), d::String, dynamicType(d)
+FROM format(Values, 'd Dynamic', $$({[]:'with\'embedded'})$$)
+FORMAT JSONEachRow;
+
+SELECT '-- nested empty array as map key';
+SELECT length(d::String), d::String, dynamicType(d)
+FROM format(Values, 'd Dynamic', $$({[[]]:1})$$)
+FORMAT JSONEachRow;
+
+SELECT '-- empty array key + non-empty key (Array(Int64) is complete, stays as Map)';
+SELECT length(d::String), d::String, dynamicType(d)
+FROM format(Values, 'd Dynamic', $$({[]:'a', [1]:'b'})$$)
+FORMAT JSONEachRow;
+
+SELECT '-- already-single-quoted plain string is not double-wrapped';
+SELECT length(d::String), d::String, dynamicType(d)
+FROM format(Values, 'd Dynamic', $$('plain string')$$)
+FORMAT JSONEachRow;


### PR DESCRIPTION
`SerializationDynamic::deserializeTextImpl` falls back to `String` when the inferred variant type is incomplete (for example `Map(Array(Nothing), ...)` from `{[]:'came'}`). For the `Quoted` escaping rule the fallback wraps the field in single quotes via naive concatenation `"'" + field + "'"`. If the field already contains a single quote, the resulting quoted string is malformed: `readQuotedStringInto` terminates at the first inner `'` and the stored value is silently truncated.

For the issue reproducer `({[]:'came'})` the round trip produced `{[]:` (4 chars) instead of `{[]:'came'}` (11 chars).

Fix uses `writeQuotedString` so embedded single quotes and backslashes are escaped to match what `readQuotedStringInto<true>` expects.

Closes #105441

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix silent value truncation in `Dynamic` columns when the `Quoted` (Values) text reader falls back to `String` for incomplete inferred types like `Map(Array(Nothing), ...)`. Previously the fallback wrapped the raw field with naive `'...'` concatenation, so an inner single quote (always present for such fallbacks) prematurely terminated the quoted string and the rest of the value was lost.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<details>
<summary>Information about CI checks</summary>

The following docs are available: ...
</details>

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.936`
<!-- ch-version-info:end -->