### PR TITLE
Reduce transactions logging

### DIFF
--- a/src/Interpreters/MergeTreeTransaction/VersionMetadata.cpp
+++ b/src/Interpreters/MergeTreeTransaction/VersionMetadata.cpp
@@ -136,7 +136,7 @@ void VersionMetadata::setAndStoreCreationCSN(CSN csn)
 
 void VersionMetadata::setAndStoreRemovalTID(const TransactionID & tid)
 {
-    LOG_DEBUG(log, "Object {}, setAndStoreRemovalTID {}", getObjectName(), tid);
+    LOG_TEST(log, "Object {}, setAndStoreRemovalTID {}", getObjectName(), tid);
 
     auto update_function = [tid](VersionInfo & info)
     {
@@ -154,7 +154,7 @@ void VersionMetadata::setAndStoreRemovalTID(const TransactionID & tid)
 
 void VersionMetadata::lockRemovalTID(const TransactionID & tid, const TransactionInfoContext & context)
 {
-    LOG_DEBUG(
+    LOG_TEST(
         log,
         "Object {}, trying to lock removal_tid by {}, table: {}, part: {}",
         getObjectName(),
@@ -210,7 +210,7 @@ void VersionMetadata::lockRemovalTID(const TransactionID & tid, const Transactio
 
 void VersionMetadata::setAndStoreCreationTID(const TransactionID & tid, TransactionInfoContext * context)
 {
-    LOG_DEBUG(log, "Object {}, setAndStoreCreationTID {}", getObjectName(), tid);
+    LOG_TEST(log, "Object {}, setAndStoreCreationTID {}", getObjectName(), tid);
     auto update_function = [tid](VersionInfo & info)
     {
         /// NOTE ReplicatedMergeTreeSink may add one part multiple times — skip if already set.
@@ -328,7 +328,7 @@ void VersionMetadata::setInfo(const VersionInfo & new_info)
 {
     std::lock_guard lock(version_info_mutex);
 
-    LOG_DEBUG(log, "Object {}, setInfo {}", getObjectName(), new_info.toString(/*one_line=*/true));
+    LOG_TEST(log, "Object {}, setInfo {}", getObjectName(), new_info.toString(/*one_line=*/true));
 
     if (new_info.storing_version < version_info.storing_version)
     {

--- a/src/Interpreters/MergeTreeTransaction/VersionMetadataOnDisk.cpp
+++ b/src/Interpreters/MergeTreeTransaction/VersionMetadataOnDisk.cpp
@@ -41,13 +41,13 @@ VersionMetadataOnDisk::VersionMetadataOnDisk(IMergeTreeDataPart * merge_tree_dat
 {
     log = ::getLogger("VersionMetadataOnDisk");
     is_persist_deferrable = !merge_tree_data_part->getDataPartStorage().existsFile(TXN_VERSION_METADATA_FILE_NAME);
-    LOG_DEBUG(
+    LOG_TEST(
         log, "Object {}, can_write_metadata {}, is_persist_deferrable {}", getObjectName(), can_write_metadata, is_persist_deferrable);
 }
 
 VersionInfo VersionMetadataOnDisk::loadMetadata()
 {
-    LOG_DEBUG(log, "Object {}, loading metadata", getObjectName());
+    LOG_TRACE(log, "Object {}, loading metadata", getObjectName());
     std::optional<VersionInfo> loading_info = std::nullopt;
     bool has_tmp_metadata_file = false;
     auto & data_part_storage = merge_tree_data_part->getDataPartStorage();
@@ -65,7 +65,7 @@ VersionInfo VersionMetadataOnDisk::loadMetadata()
         return *loading_info;
     }
 
-    LOG_DEBUG(log, "Object {}, no metadata", getObjectName());
+    LOG_TEST(log, "Object {}, no metadata", getObjectName());
 
     /// Four (?) cases are possible:
     /// 1. Part was created without transactions.
@@ -106,7 +106,7 @@ void VersionMetadataOnDisk::setAndStoreNonTransactionalRemovalTID(const Transact
 
 bool VersionMetadataOnDisk::tryLockRemovalTID(const TransactionID & tid, const TransactionInfoContext & context, TIDHash * locked_by_id)
 {
-    LOG_DEBUG(
+    LOG_TEST(
         log,
         "Object {}, tryLockRemovalTID by {}, table: {}, part: {}",
         getObjectName(),
@@ -140,7 +140,7 @@ bool VersionMetadataOnDisk::tryLockRemovalTID(const TransactionID & tid, const T
 
 void VersionMetadataOnDisk::unlockRemovalTID(const TransactionID & tid, const TransactionInfoContext & context)
 {
-    LOG_DEBUG(
+    LOG_TEST(
         log,
         "Object {}, unlockRemovalTID by {}, table: {}, part: {}",
         getObjectName(),
@@ -185,7 +185,7 @@ bool VersionMetadataOnDisk::hasPersistedMetadata() const
 
 std::expected<Int32, StaleVersion> VersionMetadataOnDisk::storeInfoUnlocked(VersionInfo new_info)
 {
-    LOG_DEBUG(log, "Object {}, storeInfoUnlocked {}", getObjectName(), new_info.toString(/*one_line=*/true));
+    LOG_TEST(log, "Object {}, storeInfoUnlocked {}", getObjectName(), new_info.toString(/*one_line=*/true));
 
     bool involved_in_transaction = new_info.wasInvolvedInTransaction();
     if (!can_write_metadata)
@@ -204,7 +204,7 @@ std::expected<Int32, StaleVersion> VersionMetadataOnDisk::storeInfoUnlocked(Vers
 
     if (!involved_in_transaction && is_persist_deferrable)
     {
-        LOG_DEBUG(log, "Object {}, pending store metadata", getObjectName());
+        LOG_TEST(log, "Object {}, pending store metadata", getObjectName());
         deferred_persist_info = new_info;
         return ++(*deferred_persist_info).storing_version;
     }


### PR DESCRIPTION
Those are too noisy on an empty server

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.922`
<!-- ch-version-info:end -->