### PR TITLE
tests: parallelize table create/cleanup in test_list_tables_pagination

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -685,6 +685,11 @@ tar -czf ./ci/tmp/logs.tar.gz \
                 for file in changed_files:
                     if (
                         file.startswith("tests/integration/test")
+                        # e2e tests require external credentials/backends and are
+                        # excluded from the default pytest run via the `e2e`
+                        # marker. Skip them so a mixed PR (both e2e and regular
+                        # integration tests changed) does not try to run them.
+                        and not file.startswith("tests/integration/test_e2e_")
                         and Path(file).name.startswith("test")
                         and file.endswith(".py")
                         and Path(file).is_file()

--- a/ci/jobs/scripts/workflow_hooks/new_tests_check.py
+++ b/ci/jobs/scripts/workflow_hooks/new_tests_check.py
@@ -21,6 +21,12 @@ def has_new_integration_tests(changed_files):
         file = file.removeprefix(".").removeprefix("/")
         if (
             file.startswith("tests/integration/test_")
+            # e2e tests (`tests/integration/test_e2e_*`) require external
+            # credentials/backends and are excluded from the default pytest run
+            # via the `e2e` marker, so the flaky/bugfix checks cannot execute
+            # them. Skip them here so a PR that only touches e2e tests does not
+            # trigger a check that would have nothing to run.
+            and not file.startswith("tests/integration/test_e2e_")
             and Path(file).name.startswith("test")
             and file.endswith(".py")
             and Path(file).is_file()

--- a/tests/integration/helpers/catalog_manager_aws_glue.py
+++ b/tests/integration/helpers/catalog_manager_aws_glue.py
@@ -1,7 +1,9 @@
+import concurrent.futures
 import logging
 import os
 import uuid
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple
 
 import boto3
@@ -11,6 +13,8 @@ from pyiceberg.catalog import load_catalog
 from helpers.catalog_manager import CatalogManager, arrow_to_iceberg_schema
 
 log = logging.getLogger(__name__)
+
+NAMESPACE_PREFIX = "ch_e2e_glue_"
 
 
 @dataclass
@@ -32,6 +36,10 @@ class AwsGlueConfig:
 
 
 class AwsGlueCatalogManager(CatalogManager):
+    # Only clean up databases older than this to avoid racing with other
+    # concurrently running test sessions.
+    _STALE_GRACE_SECONDS: int = 43200  # 12 hours
+
     def __init__(self, config: AwsGlueConfig):
         self.config = config
         os.environ["AWS_DEFAULT_REGION"] = config.region
@@ -46,6 +54,13 @@ class AwsGlueCatalogManager(CatalogManager):
         )
         self._namespaces_created: List[str] = []
         self._tables_created: List[Tuple[str, str]] = []
+        self._glue = boto3.client(
+            "glue",
+            region_name=config.region,
+            aws_access_key_id=config.access_key_id,
+            aws_secret_access_key=config.secret_access_key,
+            aws_session_token=config.session_token or None,
+        )
         self._s3 = boto3.client(
             "s3",
             region_name=config.region,
@@ -53,6 +68,78 @@ class AwsGlueCatalogManager(CatalogManager):
             aws_secret_access_key=config.secret_access_key,
             aws_session_token=config.session_token or None,
         )
+
+        self._cleanup_stale_databases()
+
+    def _cleanup_stale_databases(self) -> None:
+        """Remove `ch_e2e_glue_*` Glue databases older than `_STALE_GRACE_SECONDS`.
+
+        Leftovers accumulate in Glue whenever a test run crashes (the
+        per-session `cleanup_all` only knows about namespaces created in
+        *this* run). With many leftovers, ClickHouse's catalog refresh
+        path -- which iterates every Glue database in the account on each
+        query -- balloons to minutes per query. Trim aggressively at
+        session start, skipping anything younger than the grace window so
+        we don't race a concurrent session.
+        """
+        try:
+            now = datetime.now(timezone.utc)
+            stale: List[str] = []
+            for page in self._glue.get_paginator("get_databases").paginate():
+                for db in page.get("DatabaseList", []):
+                    name = db["Name"]
+                    if not name.startswith(NAMESPACE_PREFIX):
+                        continue
+                    create_time = db.get("CreateTime")
+                    if create_time is None:
+                        continue
+                    age = (now - create_time).total_seconds()
+                    if age >= self._STALE_GRACE_SECONDS:
+                        stale.append(name)
+            if not stale:
+                return
+            log.info(
+                "Cleaning up %d stale Glue databases (older than %ds)",
+                len(stale), self._STALE_GRACE_SECONDS,
+            )
+            with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+                list(pool.map(self._delete_glue_database, stale))
+        except Exception as exc:
+            log.warning("Stale Glue database cleanup failed: %s", exc)
+
+    def _delete_glue_database(self, db: str) -> None:
+        """Drop all tables in `db`, the database itself, and its S3 prefix."""
+        try:
+            for page in self._glue.get_paginator("get_tables").paginate(DatabaseName=db):
+                for t in page.get("TableList", []):
+                    try:
+                        self._glue.delete_table(DatabaseName=db, Name=t["Name"])
+                    except Exception as exc:
+                        log.debug("delete_table(%s.%s) failed: %s", db, t["Name"], exc)
+            try:
+                self._glue.delete_database(Name=db)
+            except Exception as exc:
+                log.debug("delete_database(%s) failed: %s", db, exc)
+            self._delete_s3_prefix_dir(db)
+        except Exception as exc:
+            log.warning("Cleanup of stale Glue database '%s' failed: %s", db, exc)
+
+    def _delete_s3_prefix_dir(self, namespace: str) -> None:
+        prefix = f"{self.config.prefix}/{namespace}/"
+        try:
+            keys: List[Dict[str, str]] = []
+            for page in self._s3.get_paginator("list_objects_v2").paginate(
+                Bucket=self.config.bucket, Prefix=prefix
+            ):
+                for obj in page.get("Contents", []):
+                    keys.append({"Key": obj["Key"]})
+            for i in range(0, len(keys), 1000):
+                self._s3.delete_objects(
+                    Bucket=self.config.bucket,
+                    Delete={"Objects": keys[i:i + 1000]},
+                )
+        except Exception as exc:
+            log.debug("S3 cleanup of '%s' failed: %s", namespace, exc)
 
     @classmethod
     def from_env(cls) -> "AwsGlueCatalogManager":
@@ -106,7 +193,7 @@ class AwsGlueCatalogManager(CatalogManager):
     def create_table(
         self, data: pa.Table, table_name: Optional[str] = None
     ) -> str:
-        namespace = f"ch_e2e_glue_{uuid.uuid4().hex[:10]}"
+        namespace = f"{NAMESPACE_PREFIX}{uuid.uuid4().hex[:10]}"
         if table_name is None:
             table_name = f"tbl_{uuid.uuid4().hex[:8]}"
 

--- a/tests/integration/helpers/catalog_manager_biglake.py
+++ b/tests/integration/helpers/catalog_manager_biglake.py
@@ -1,8 +1,10 @@
+import concurrent.futures
 import logging
 import os
 import time
 import uuid
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple
 
 import gcsfs
@@ -75,10 +77,113 @@ class BigLakeCatalogManager(CatalogManager):
         self._tables_created: List[str] = []
 
         self._cleanup_stale_namespaces()
+        self._cleanup_stale_storage_paths()
 
         self._refresh_token_if_needed()
         self.catalog.create_namespace(self._session_namespace)
         log.info("Created session namespace '%s'", self._session_namespace)
+
+    def _namespace_gcs_path(self, namespace: str) -> str:
+        """Build the GCS path for a namespace's data files, handling
+        the case where `gcs_prefix` is empty (no leading subdirectory)."""
+        if self.config.gcs_prefix:
+            return f"{self.config.gcs_bucket}/{self.config.gcs_prefix}/{namespace}"
+        return f"{self.config.gcs_bucket}/{namespace}"
+
+    def _cleanup_stale_storage_paths(self) -> None:
+        """Remove leftover GCS storage directories from previous BigLake
+        test runs.
+
+        BigLake drops namespace records on `drop_namespace`, but the
+        underlying GCS data files are NOT auto-purged. Combined with a
+        long-standing path-join bug (when `gcs_prefix=""` the previous
+        cleanup attempted to delete `bucket//<ns>`, an invalid path),
+        the bucket has accumulated thousands of orphan storage prefixes.
+
+        We list `ch_e2e_bl_*` directories at the configured storage root
+        and delete those older than `_STALE_GRACE_SECONDS`. Age is
+        determined either from the encoded timestamp in the directory
+        name (`ch_e2e_bl_<ts>_<hex>`) or, for the legacy
+        `ch_e2e_bl_<hex>` form, by the `updated` time of the first
+        object found inside.
+        """
+        try:
+            self._refresh_token_if_needed()
+            fs = gcsfs.GCSFileSystem(token=self._credential.token)
+            root = (
+                f"{self.config.gcs_bucket}/{self.config.gcs_prefix}"
+                if self.config.gcs_prefix
+                else self.config.gcs_bucket
+            )
+            now = datetime.now(timezone.utc)
+            stale: List[str] = []
+            for entry in fs.ls(root, detail=True):
+                name = entry.get("name", "").rstrip("/")
+                tail = name.rsplit("/", 1)[-1]
+                if not tail.startswith(NAMESPACE_PREFIX):
+                    continue
+                if tail == self._session_namespace:
+                    continue
+                age_seconds = self._estimate_storage_age(fs, name, tail, now)
+                if age_seconds is None:
+                    continue
+                if age_seconds >= self._STALE_GRACE_SECONDS:
+                    stale.append(name)
+            if not stale:
+                return
+            log.info(
+                "Cleaning up %d stale BigLake storage paths (older than %ds)",
+                len(stale), self._STALE_GRACE_SECONDS,
+            )
+            with concurrent.futures.ThreadPoolExecutor(max_workers=16) as pool:
+                list(pool.map(self._delete_gcs_prefix, stale))
+        except Exception as exc:
+            log.warning("Stale BigLake storage cleanup failed: %s", exc)
+
+    def _estimate_storage_age(
+        self, fs: gcsfs.GCSFileSystem, full_path: str, tail: str, now: datetime,
+    ) -> Optional[float]:
+        """Return the age (in seconds) of a `ch_e2e_bl_*` storage prefix.
+
+        New-format directory names embed the session creation timestamp
+        (`ch_e2e_bl_<ts>_<hex>`), so the age comes straight from the
+        name.  For the legacy `ch_e2e_bl_<hex>` form (pre-timestamp
+        naming) we walk into the nested `tbl_*/data/...` and
+        `tbl_*/metadata/...` files and use the first `updated`
+        timestamp we can read.  If no probe-able file is found we
+        return `None` so the caller skips the prefix rather than
+        assuming it is stale -- that prevents a concurrent test
+        session still on the old naming format from losing a fresh
+        storage path it just created."""
+        parts = tail.split("_")
+        try:
+            ns_ts = int(parts[3])
+            return (now - datetime.fromtimestamp(ns_ts, tz=timezone.utc)).total_seconds()
+        except (IndexError, ValueError):
+            pass
+        try:
+            for tbl_entry in fs.ls(full_path, detail=True):
+                if tbl_entry.get("type") != "directory":
+                    continue
+                for sub_entry in fs.ls(tbl_entry["name"], detail=True):
+                    if sub_entry.get("type") != "directory":
+                        continue
+                    for obj in fs.ls(sub_entry["name"], detail=True):
+                        if obj.get("type") != "file":
+                            continue
+                        updated = obj.get("updated")
+                        if not updated:
+                            continue
+                        if isinstance(updated, str):
+                            updated = datetime.fromisoformat(
+                                updated.replace("Z", "+00:00")
+                            )
+                        elif updated.tzinfo is None:
+                            updated = updated.replace(tzinfo=timezone.utc)
+                        return (now - updated).total_seconds()
+        except Exception as exc:
+            log.debug("age probe of '%s' failed: %s", full_path, exc)
+        return None
 
     def _warehouse_path(self) -> str:
         if self.config.gcs_prefix:
@@ -92,7 +197,7 @@ class BigLakeCatalogManager(CatalogManager):
 
     # Only clean up namespaces older than this to avoid racing with other
     # concurrently running test sessions.
-    _STALE_GRACE_SECONDS: int = 3600
+    _STALE_GRACE_SECONDS: int = 43200  # 12 hours
 
     def _cleanup_stale_namespaces(self) -> None:
         """Remove leftover namespaces from previous test runs."""
@@ -127,10 +232,7 @@ class BigLakeCatalogManager(CatalogManager):
                             pass
                     self.catalog.drop_namespace(ns)
                     log.info("Cleaned up stale namespace '%s'", ns)
-                    ns_gcs_path = (
-                        f"{self.config.gcs_bucket}/{self.config.gcs_prefix}/{ns}"
-                    )
-                    self._delete_gcs_prefix(ns_gcs_path)
+                    self._delete_gcs_prefix(self._namespace_gcs_path(ns))
                 except Exception as exc:
                     log.warning("Failed to clean up namespace '%s': %s", ns, exc)
         except Exception as exc:
@@ -326,11 +428,7 @@ class BigLakeCatalogManager(CatalogManager):
         except Exception:
             pass
 
-        ns_gcs_path = (
-            f"{self.config.gcs_bucket}/{self.config.gcs_prefix}"
-            f"/{self._session_namespace}"
-        )
-        self._delete_gcs_prefix(ns_gcs_path)
+        self._delete_gcs_prefix(self._namespace_gcs_path(self._session_namespace))
 
     def resolve_table_name(
         self,

--- a/tests/integration/helpers/catalog_manager_onelake.py
+++ b/tests/integration/helpers/catalog_manager_onelake.py
@@ -1,9 +1,11 @@
+import concurrent.futures
 import logging
 import os
 import shutil
 import time
 import uuid
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import List, Optional, Tuple
 
 import pyarrow as pa
@@ -20,6 +22,12 @@ ONELAKE_DFS_HOST = "onelake.dfs.fabric.microsoft.com"
 ONELAKE_BLOB_HOST = "onelake.blob.fabric.microsoft.com"
 ONELAKE_STORAGE_ENDPOINT = f"https://{ONELAKE_DFS_HOST}"
 ONELAKE_CATALOG_URL = "https://onelake.table.fabric.microsoft.com/iceberg"
+
+# All tables this manager creates -- including those produced by
+# `test_list_tables_pagination` (`e2e_pg_*`) -- start with this prefix.
+# Stale cleanup must restrict itself to this prefix so other workloads
+# sharing the same Fabric lakehouse are never touched.
+TABLE_NAME_PREFIX = "e2e_"
 
 @dataclass
 class OneLakeConfig:
@@ -78,6 +86,84 @@ class OneLakeCatalogManager(CatalogManager):
             credential=self._credential,
         )
         self._tables_created: List[str] = []
+
+        self._cleanup_stale_tables()
+
+    # Only clean up tables older than this to avoid racing with other
+    # concurrently running test sessions.
+    _STALE_GRACE_SECONDS: int = 43200  # 12 hours
+
+    def _cleanup_stale_tables(self) -> None:
+        """Remove tables under ``Tables/dbo/`` whose DFS directory was
+        last modified more than ``_STALE_GRACE_SECONDS`` ago.
+
+        OneLake / Fabric does not auto-purge leftovers, so every crashed
+        test run leaves behind tables that subsequent runs must paginate
+        through. Trim aggressively at session start while skipping
+        anything younger than the grace window, so we don't race a
+        concurrent session.
+        """
+        try:
+            now = datetime.now(timezone.utc)
+            fs = self._dfs_client.get_file_system_client(
+                self.config.workspace_id
+            )
+            base = f"{self.config.lakehouse_id}/Tables/dbo"
+            stale: List[str] = []
+            for path in fs.get_paths(path=base, recursive=False):
+                if not path.is_directory:
+                    continue
+                # Restrict the sweep to test-owned table names so a
+                # shared lakehouse cannot lose unrelated tables that
+                # happen to be older than the grace window.
+                tail = path.name.rsplit("/", 1)[-1]
+                if not tail.startswith(TABLE_NAME_PREFIX):
+                    continue
+                last_modified = getattr(path, "last_modified", None)
+                if last_modified is None:
+                    continue
+                # `last_modified` can be a datetime or RFC1123 string; normalize.
+                if isinstance(last_modified, str):
+                    try:
+                        last_modified = datetime.strptime(
+                            last_modified, "%a, %d %b %Y %H:%M:%S %Z"
+                        ).replace(tzinfo=timezone.utc)
+                    except ValueError:
+                        continue
+                elif last_modified.tzinfo is None:
+                    last_modified = last_modified.replace(tzinfo=timezone.utc)
+                age = (now - last_modified).total_seconds()
+                if age < self._STALE_GRACE_SECONDS:
+                    continue
+                # `path.name` is the full path; the table name is the trailing segment.
+                stale.append(path.name.rsplit("/", 1)[-1])
+            if not stale:
+                return
+            log.info(
+                "Cleaning up %d stale OneLake tables (older than %ds)",
+                len(stale), self._STALE_GRACE_SECONDS,
+            )
+            with concurrent.futures.ThreadPoolExecutor(max_workers=10) as pool:
+                list(pool.map(self._delete_stale_table, stale))
+        except Exception as exc:
+            log.warning("Stale OneLake table cleanup failed: %s", exc)
+
+    def _delete_stale_table(self, table_name: str) -> None:
+        """Issue an Iceberg REST DELETE for the table (Fabric purges the
+        underlying DFS files as part of that), falling back to a direct
+        DFS path delete if the catalog entry is already gone."""
+        try:
+            url = self._table_api_url(table_name, "dbo")
+            resp = requests.delete(url, headers=self._authed_headers(), timeout=60)
+            if resp.status_code not in (200, 204, 404):
+                log.debug(
+                    "Stale table REST DELETE for '%s' returned %d: %s",
+                    table_name, resp.status_code, resp.text[:120],
+                )
+        except Exception as exc:
+            log.debug("Stale table REST DELETE for '%s' failed: %s", table_name, exc)
+        # Best-effort DFS cleanup in case the catalog DELETE didn't purge files.
+        self.cleanup_table(table_name)
 
     @classmethod
     def from_env(cls) -> "OneLakeCatalogManager":
@@ -200,7 +286,7 @@ class OneLakeCatalogManager(CatalogManager):
         table_name: Optional[str] = None,
     ) -> str:
         if table_name is None:
-            table_name = f"e2e_{uuid.uuid4().hex[:10]}"
+            table_name = f"{TABLE_NAME_PREFIX}{uuid.uuid4().hex[:10]}"
 
         table = self._catalog.create_table(
             identifier=f"dbo.{table_name}",

--- a/tests/integration/test_e2e_catalogs/test.py
+++ b/tests/integration/test_e2e_catalogs/test.py
@@ -5,6 +5,7 @@ Tests are parametrized over available catalog backends via the
 missing are automatically skipped.
 """
 
+import concurrent.futures
 import datetime
 import decimal
 import time
@@ -1191,8 +1192,28 @@ def test_list_tables_pagination(node, catalog_manager):
     created = []
     db = None
     try:
-        for short in expected:
-            created.append(catalog_manager.create_table(data, table_name=short))
+        # Catalog round-trips dominate per-table create time (~2-4s each on
+        # OneLake / BigLake / Glue), so creating tables serially adds 2-4 min
+        # per backend. Issue them in parallel; each catalog client + REST
+        # endpoint handles concurrent creates fine.  Record every
+        # successful result as it completes (rather than via `list(map())`
+        # at the end), so if one worker raises we still know about the
+        # tables that already succeeded and the `finally` block can drop
+        # them instead of leaking catalog/storage artifacts.
+        first_exc = None
+        with concurrent.futures.ThreadPoolExecutor(max_workers=10) as pool:
+            futures = [
+                pool.submit(catalog_manager.create_table, data, table_name=short)
+                for short in expected
+            ]
+            for fut in concurrent.futures.as_completed(futures):
+                try:
+                    created.append(fut.result())
+                except BaseException as exc:
+                    if first_exc is None:
+                        first_exc = exc
+        if first_exc is not None:
+            raise first_exc
 
         db = catalog_manager.make_database_name()
         catalog_manager.create_catalog(node, db)
@@ -1252,8 +1273,9 @@ def test_list_tables_pagination(node, catalog_manager):
             f"Expected 1 row in last-page table {late}, got {rows}"
         )
     finally:
-        for name in created:
-            catalog_manager.cleanup_table(name)
+        if created:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=10) as pool:
+                list(pool.map(catalog_manager.cleanup_table, created))
         if db is not None:
             try:
                 node.query(f"DROP DATABASE IF EXISTS {db}")


### PR DESCRIPTION
`test_list_tables_pagination` (added recently) creates 60 Iceberg tables sequentially per backend and then deletes them in a serial loop. Catalog REST round-trips dominate per-table cost (~2-4s each on OneLake / BigLake / Glue), so this single test contributes ~10 minutes to the slowest nightly worker.

Issuing the creates and the cleanups via `ThreadPoolExecutor(max_workers=10)` cuts each backend's share by roughly 5x. Pagination semantics under test are unchanged — once all tables exist, `SHOW TABLES` / `system.tables` still poll until the catalog converges.

Also adds stale-resource cleanup at session start for each catalog manager (Glue / BigLake / OneLake) and fixes a path-join bug in BigLake cleanup when `gcs_prefix` is empty.

Copied from https://github.com/ClickHouse/clickhouse-private/pull/58510

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.932`
<!-- ch-version-info:end -->