### PR TITLE
Allow NONE authentication for SSH (prevents asking password for no_password users)

### DIFF
--- a/src/Server/SSH/SSHPtyHandler.cpp
+++ b/src/Server/SSH/SSHPtyHandler.cpp
@@ -345,7 +345,8 @@ public:
         server_cb.userdata = this;
         server_cb.auth_pubkey_function = authPublickeyAdapter<ssh_session, const char *, ssh_key, char>;
         server_cb.auth_password_function = authPasswordAdapter<ssh_session, const char *, const char *>;
-        ssh_set_auth_methods(session.getInternalPtr(), SSH_AUTH_METHOD_PASSWORD | SSH_AUTH_METHOD_PUBLICKEY);
+        server_cb.auth_none_function = authNoneAdapter<ssh_session, const char *>;
+        ssh_set_auth_methods(session.getInternalPtr(), SSH_AUTH_METHOD_PASSWORD | SSH_AUTH_METHOD_PUBLICKEY | SSH_AUTH_METHOD_NONE);
         server_cb.channel_open_request_session_function = channelOpenAdapter<ssh_session>;
 
         ssh_callbacks_init(&server_cb)
@@ -451,6 +452,30 @@ public:
     }
 
     GENERATE_ADAPTER_FUNCTION(SessionCallback, authPassword, int)
+
+    int authNone(ssh_session, const char * user) noexcept
+    {
+        try
+        {
+            LOG_TRACE(log, "Authenticating user '{}' with none", user);
+            auto db_session_created = std::make_unique<Session>(server_context, ClientInfo::Interface::LOCAL);
+            /// Accept the "none" method whenever an empty password authenticates the user.
+            /// This covers both `NO_PASSWORD` and any password-type method whose stored
+            /// credential happens to be the empty string (e.g. `IDENTIFIED WITH plaintext_password BY ''`).
+            db_session_created->authenticate(BasicCredentials{String(user), ""}, peer_address);
+            authenticated = true;
+            db_session = std::move(db_session_created);
+            return SSH_AUTH_SUCCESS;
+        }
+        catch (...)
+        {
+            tryLogCurrentException(log);
+            ++auth_attempts;
+            return SSH_AUTH_DENIED;
+        }
+    }
+
+    GENERATE_ADAPTER_FUNCTION(SessionCallback, authNone, int)
 
     ssh_server_callbacks_struct server_cb = {};
 };

--- a/tests/integration/test_ssh/configs/users.xml
+++ b/tests/integration/test_ssh/configs/users.xml
@@ -8,5 +8,8 @@
                  </ssh_key>
             </ssh_keys>
         </lucy>
+        <nobody>
+            <no_password/>
+        </nobody>
     </users>
 </clickhouse>

--- a/tests/integration/test_ssh/test.py
+++ b/tests/integration/test_ssh/test.py
@@ -137,6 +137,85 @@ def test_simple_query_with_paramiko(started_cluster):
 
     client.close()
 
+def test_no_password_user_with_openssh_client(started_cluster):
+    # `no_password` users must be able to log in via SSH "none" authentication
+    # without OpenSSH prompting for an empty password interactively.
+    # `BatchMode=yes` disables any interactive prompt, so if the server does not
+    # accept the "none" method, ssh will fail instead of hanging.
+    ssh_command = (
+        f"ssh -o StrictHostKeyChecking=no -o BatchMode=yes "
+        f"-o PreferredAuthentications=none "
+        f"nobody@{instance.ip_address} -p 9022 \"SELECT 1;\""
+    )
+
+    completed_process = subprocess.run(
+        ssh_command,
+        shell=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+    )
+
+    expected = instance.query("SELECT 1;")
+    assert completed_process.returncode == 0, completed_process.stderr
+    assert completed_process.stdout.replace("\n\x00", "\n") == expected
+
+
+def test_empty_password_user_with_openssh_client(started_cluster):
+    # A user with an explicit empty password (`IDENTIFIED WITH plaintext_password BY ''`)
+    # is functionally equivalent to `no_password` and must also be accepted via the
+    # SSH "none" method without an interactive prompt.
+    instance.query(
+        "CREATE USER OR REPLACE empty_pass IDENTIFIED WITH plaintext_password BY '';"
+    )
+
+    ssh_command = (
+        f"ssh -o StrictHostKeyChecking=no -o BatchMode=yes "
+        f"-o PreferredAuthentications=none "
+        f"empty_pass@{instance.ip_address} -p 9022 \"SELECT 1;\""
+    )
+
+    completed_process = subprocess.run(
+        ssh_command,
+        shell=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+    )
+
+    expected = instance.query("SELECT 1;")
+    assert completed_process.returncode == 0, completed_process.stderr
+    assert completed_process.stdout.replace("\n\x00", "\n") == expected
+
+
+def test_password_user_rejected_with_none_auth(started_cluster):
+    # A user that has a password must NOT be authenticated via the SSH "none"
+    # method. `BatchMode=yes` disables interactive prompts, and
+    # `PreferredAuthentications=none` forces ssh to only try "none" — so the
+    # connection must fail rather than fall through to a password prompt.
+    instance.query("CREATE USER OR REPLACE mister IDENTIFIED BY 'P@$$WORD';")
+
+    ssh_command = (
+        f"ssh -o StrictHostKeyChecking=no -o BatchMode=yes "
+        f"-o PreferredAuthentications=none "
+        f"mister@{instance.ip_address} -p 9022 \"SELECT 1;\""
+    )
+
+    completed_process = subprocess.run(
+        ssh_command,
+        shell=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=30,
+    )
+
+    assert completed_process.returncode != 0
+    assert "Permission denied" in completed_process.stderr
+
+
 def test_paramiko_password(started_cluster):
     instance.query("CREATE USER OR REPLACE mister IDENTIFIED BY 'P@$$WORD';")
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Allow NONE authentication for SSH (prevents asking password for no_password users)

Right now even if user does not have a password it still promps for password, and only after user enters empty password, it authenticate

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.923`
<!-- ch-version-info:end -->