### PR TITLE
Fix CI failures in PGO/BOLT profile collection workflow

### DIFF
--- a/ci/jobs/collect_clickhouse_profiles.py
+++ b/ci/jobs/collect_clickhouse_profiles.py
@@ -49,6 +49,13 @@ PERF_SERVER_DIR = f"{PERF_WD}/server"
 BOLT_PROFILE_TIMEOUT = 1800  # 30 minutes
 BOLT_PERF_RUNS = 3  # fewer runs, just need hot paths
 
+# Maximum time to wait for a freshly-spawned `clickhouse-server` to start
+# accepting connections. PGO-instrumented binaries are noticeably slower at
+# startup (every instrumented site updates a counter), so the window has to be
+# generous; for a normal binary readiness is reached within a few seconds.
+SERVER_READINESS_TIMEOUT_S = 600
+SERVER_READINESS_POLL_S = 2
+
 LLVM_VERSION = "21"
 
 
@@ -138,6 +145,58 @@ def download_datasets():
     return res
 
 
+def dump_log_tail(log_path, lines=200):
+    """Print the tail of a server log to stdout for CI diagnostics."""
+    print(f"--- tail of {log_path} (last {lines} lines) ---")
+    if not os.path.exists(log_path):
+        print(f"(log file does not exist: {log_path})")
+        print("--- end ---")
+        return
+    Shell.check(f"tail -n {lines} {log_path}", verbose=True)
+    print("--- end ---")
+
+
+def wait_for_server_ready(proc, server_dir, port, log_file):
+    """Poll `select 1` until the server responds or the timeout elapses.
+
+    Returns True on success. On failure prints the tail of `log_file` so the
+    underlying reason (startup crash, slow init, port conflict, …) is visible
+    in the job log instead of just a wall of failed `select 1` retries.
+    """
+    print(
+        f"Waiting up to {SERVER_READINESS_TIMEOUT_S}s for server on port {port}"
+    )
+    start = time.monotonic()
+    deadline = start + SERVER_READINESS_TIMEOUT_S
+    next_progress = start + 30
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            print(f"Server process exited prematurely with code {proc.returncode}")
+            dump_log_tail(log_file)
+            return False
+        # Polling is intentionally quiet — at one attempt every 2s a 10-minute
+        # window would otherwise produce hundreds of identical `Run command`
+        # lines; emit a progress heartbeat every 30s instead.
+        res, out, _ = Shell.get_res_stdout_stderr(
+            f'{server_dir}/clickhouse-client --port {port} --query "select 1"'
+        )
+        if out.strip() == "1":
+            elapsed = time.monotonic() - start
+            print(f"Server ready after {elapsed:.0f}s")
+            return True
+        now = time.monotonic()
+        if now >= next_progress:
+            print(f"  still waiting, {now - start:.0f}s elapsed")
+            next_progress = now + 30
+        time.sleep(SERVER_READINESS_POLL_S)
+
+    print(
+        f"Server did not become ready within {SERVER_READINESS_TIMEOUT_S}s"
+    )
+    dump_log_tail(log_file)
+    return False
+
+
 def start_server(server_dir, port=9000, keeper_port=9181, raft_port=9234):
     """Start a ClickHouse server and wait for it to be ready."""
     config_file = f"{server_dir}/config/config.xml"
@@ -161,23 +220,10 @@ def start_server(server_dir, port=9000, keeper_port=9181, raft_port=9234):
     proc = subprocess.Popen(
         cmd, stderr=subprocess.STDOUT, stdout=log_fd, shell=True, start_new_session=True
     )
-    time.sleep(2)
-    if proc.poll() is not None:
-        log_fd.close()
-        print(f"Server failed to start, check {log_file}")
-        return None, None
 
-    # Wait for readiness
-    for attempt in range(30):
-        res, out, _ = Shell.get_res_stdout_stderr(
-            f'{server_dir}/clickhouse-client --port {port} --query "select 1"', verbose=True
-        )
-        if out.strip() == "1":
-            print("Server ready")
-            return proc, log_fd
-        time.sleep(2)
+    if wait_for_server_ready(proc, server_dir, port, log_file):
+        return proc, log_fd
 
-    print("Server did not become ready")
     # `shell=True` means `proc` is the wrapper shell, not `clickhouse-server`.
     # Tear down the whole process group via `stop_server` so the server itself
     # doesn't survive and clash with later stages on the same ports.
@@ -237,6 +283,7 @@ def configure_datasets(server_dir, port=9000):
 
     # Start a temporary server to set up the datasets
     config_file = f"{server_dir}/config/config.xml"
+    log_file = f"{server_dir}/preconfig.log"
     cmd = (
         f"{server_dir}/clickhouse-server --config-file={config_file} "
         f"-- --path {PERF_DB_PATH} --user_files_path {PERF_DB_PATH}/user_files "
@@ -244,21 +291,13 @@ def configure_datasets(server_dir, port=9000):
         f"--keeper_server.storage_path {PERF_WD}/coordination0 "
         f"--tcp_port {port}"
     )
-    log_fd = open(f"{server_dir}/preconfig.log", "w")
+    log_fd = open(log_file, "w")
     # See note in `start_server`: dedicated session keeps `terminate_process_group`
     # scoped to the server tree.
     proc = subprocess.Popen(
         cmd, stderr=subprocess.STDOUT, stdout=log_fd, shell=True, start_new_session=True
     )
-    time.sleep(2)
-    for attempt in range(30):
-        res, out, _ = Shell.get_res_stdout_stderr(
-            f'{server_dir}/clickhouse-client --port {port} --query "select 1"', verbose=True
-        )
-        if out.strip() == "1":
-            break
-        time.sleep(2)
-    else:
+    if not wait_for_server_ready(proc, server_dir, port, log_file):
         stop_server(proc, log_fd)
         return False
 


### PR DESCRIPTION
Two CI failures in the new `OptimizeClickHouse` workflow (PR #100938) on master.

## 1. `Collect PGO profiles` times out without diagnostic (amd64)

The freshly-started PGO-instrumented `clickhouse-server` did not respond to
`select 1` within the 30-attempt × 2 s = 60 s readiness window in
`configure_datasets` / `start_server`. PGO instrumentation slows startup
considerably (every instrumented site bumps a counter), so a 60 s window is too
tight for a cold start. The job log carried only a wall of `Run command [...
select 1]` retries — the server's own `preconfig.log` / `server.log` is written
under `perf_wd/pgo_server/` and is not uploaded as an artifact, so the actual
reason was invisible.

Failed run:
- https://github.com/ClickHouse/ClickHouse/actions/runs/26190353268/job/77057127893
- Job report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=31cab7e9b5059f3a9aee1f6a9edf24d322d9cd16&name_0=OptimizeClickHouse&name_1=Collect%20ClickHouse%20Profiles%20%28PGO%2C%20BOLT%29%20%28amd64%29

Fix in `ci/jobs/collect_clickhouse_profiles.py`:
- Extract the readiness loop into `wait_for_server_ready`, switch from a fixed
  retry count to a wall-clock deadline of 600 s, and notice premature process
  exit during the wait (not just in the first 2 s).
- On readiness failure or premature process exit, dump the tail of the server
  log to stdout via a new `dump_log_tail` helper.
- Make polling quiet with a 30 s heartbeat so the longer window does not flood
  the log with `Run command` lines.

## 2. `Build (BOLT)` fails on PGO profile hash mismatches under `-Werror` (aarch64)

After fix 1 landed and PGO collection now succeeds, the next stage `Build (BOLT)`
fails because clang's PGO backend emits `-Wbackend-plugin`:

    function control flow change detected (hash mismatch) <symbol>
        Hash = ... up to N count discarded

for several functions (`ConcurrencyControl.cpp`, `Dwarf.cpp`, `Exception.cpp`),
and the project-wide `-Werror` turns these into hard build failures.

Failed run:
- https://github.com/ClickHouse/ClickHouse/actions/runs/26198563312/job/77083370440
- Job report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=8d1d74ce0bb6e52ff81e58af1b73a86e0b1f32be&name_0=OptimizeClickHouse&name_1=Collect%20ClickHouse%20Profiles%20%28PGO%2C%20BOLT%29%20%28aarch64%29

The instrumented build is required to disable ThinLTO (the cmake check
in `profile_optimization.cmake` enforces this — clang IR instrumentation is
incompatible with ThinLTO), while the BOLT build enables ThinLTO. ThinLTO can
perturb individual function bodies before profile matching, so a non-zero number
of hash mismatches is expected. The compiler simply discards the stale counts
for those functions, which is the correct best-effort behaviour.

Fix in `cmake/profile_optimization.cmake`: add `-Wno-error=backend-plugin`
alongside the `-fprofile-use=...` flags so the mismatches remain visible as
warnings without aborting the build.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.919`
<!-- ch-version-info:end -->