### PR TITLE
Demote PGO profile-mismatch warnings from -Werror in the BOLT build

### DIFF
--- a/cmake/profile_optimization.cmake
+++ b/cmake/profile_optimization.cmake
@@ -52,6 +52,18 @@ if (CLICKHOUSE_PGO_PROFILE_PATH)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-use=${CLICKHOUSE_PGO_PROFILE_PATH}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-use=${CLICKHOUSE_PGO_PROFILE_PATH}")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-use=${CLICKHOUSE_PGO_PROFILE_PATH}")
+    # When a function's CFG hash at use time does not match what was recorded
+    # in the profile, clang's PGO backend emits `-Wbackend-plugin` with text
+    # like "function control flow change detected (hash mismatch)" and
+    # discards the stale counts for that function. This is expected to
+    # happen for some functions because the instrumented build runs without
+    # ThinLTO (required by IR instrumentation) while the use build enables
+    # ThinLTO, which can perturb individual function bodies before profile
+    # matching. Under the project-wide `-Werror` policy these informational
+    # warnings would otherwise abort the whole build, so demote them to
+    # plain warnings here.
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error=backend-plugin")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=backend-plugin")
 endif()
 
 # Apply BOLT linker flags


### PR DESCRIPTION
The `Build (BOLT)` stage of `Collect ClickHouse Profiles (PGO, BOLT)` fails on
master because clang's PGO backend emits `-Wbackend-plugin` of the form

    function control flow change detected (hash mismatch) <symbol>
        Hash = ... up to N count discarded

for several functions (`ConcurrencyControl.cpp`, `Dwarf.cpp`,
`Exception.cpp`), and the project-wide `-Werror` turns these informational
warnings into hard build failures. The same kind of warning also appears for
`base/glibc-compatibility/musl/exp.c`, `log.c`, `pow.c`, etc., but those are
not under `-Werror` and so did not break the build.

Failed run:
- https://github.com/ClickHouse/ClickHouse/actions/runs/26198563312/job/77083370440
- Job report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=8d1d74ce0bb6e52ff81e58af1b73a86e0b1f32be&name_0=OptimizeClickHouse&name_1=Collect%20ClickHouse%20Profiles%20%28PGO%2C%20BOLT%29%20%28aarch64%29

The mismatch is *not* a BOLT vs. ThinLTO issue (LLVM's own `BOLT-PGO.cmake`
combines PGO + ThinLTO + BOLT successfully). It is a PGO-instrument vs.
PGO-use mismatch: clang's IR instrumentation requires ThinLTO=OFF (the cmake
check in `cmake/profile_optimization.cmake` enforces this), while our use
build enables ThinLTO. ThinLTO perturbs individual function bodies before
profile matching, so a non-zero number of CFG-hash mismatches between
instrumented and used builds is expected. The compiler simply discards the
stale counts for those functions and the rest of the profile is still
applied, which is the right best-effort behaviour.

Fix: add `-Wno-error=backend-plugin` alongside the `-fprofile-use=...` flags
in `cmake/profile_optimization.cmake` so the mismatches remain visible as
warnings without aborting the build. The flag is scoped to the PGO-use branch,
so non-PGO builds are unaffected.

Follow-up to #105477.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.925`
<!-- ch-version-info:end -->