### PR TITLE
Bump SystemLogQueue::waitFlush timeout to 600s

### DIFF
--- a/src/Common/SystemLogBase.cpp
+++ b/src/Common/SystemLogBase.cpp
@@ -158,10 +158,12 @@ void SystemLogQueue<LogElement>::waitFlush(SystemLogQueue<LogElement>::Index exp
 {
     LOG_DEBUG(log, "Requested flush up to offset {}", expected_flushed_index);
 
-    // Use an arbitrary timeout to avoid endless waiting. 60s proved to be
-    // too fast for our parallel functional tests, probably because they
-    // heavily load the disk.
-    const int timeout_seconds = 180;
+    // Use an arbitrary timeout to avoid endless waiting. Earlier bumps
+    // (60s -> 180s) still produced TIMEOUT_EXCEEDED in `SYSTEM FLUSH LOGS`
+    // on heavily loaded parallel CI runners. Raised to 600s for the same
+    // reason: heavy parallel tests on slow disks can stall flush longer
+    // than 180s without anything actually going wrong.
+    const int timeout_seconds = 600;
 
     std::unique_lock lock(mutex);
 

--- a/src/Common/SystemLogBase.cpp
+++ b/src/Common/SystemLogBase.cpp
@@ -131,7 +131,11 @@ void SystemLogQueue<LogElement>::handleCrash()
 {
     if (settings.notify_flush_on_crash)
     {
-        waitFlush(getLastLogIndex(),  /* should_prepare_tables_anyway */ true);
+        /// `SignalHandlers.cpp` gives the crash path a hard ~303s wall before the default
+        /// handler kills the process, and `SystemLogs::handleCrash` walks every queue in
+        /// sequence. Keep the per-queue wait short so one stuck queue cannot starve the
+        /// remaining ones (in particular `crash_log`, which is flushed first).
+        waitFlush(getLastLogIndex(), /* should_prepare_tables_anyway */ true, /* timeout_seconds */ 60);
     }
 }
 
@@ -154,16 +158,9 @@ void SystemLogQueue<LogElement>::notifyFlush(SystemLogQueue<LogElement>::Index e
 }
 
 template <typename LogElement>
-void SystemLogQueue<LogElement>::waitFlush(SystemLogQueue<LogElement>::Index expected_flushed_index, bool should_prepare_tables_anyway)
+void SystemLogQueue<LogElement>::waitFlush(SystemLogQueue<LogElement>::Index expected_flushed_index, bool should_prepare_tables_anyway, int timeout_seconds)
 {
     LOG_DEBUG(log, "Requested flush up to offset {}", expected_flushed_index);
-
-    // Use an arbitrary timeout to avoid endless waiting. Earlier bumps
-    // (60s -> 180s) still produced TIMEOUT_EXCEEDED in `SYSTEM FLUSH LOGS`
-    // on heavily loaded parallel CI runners. Raised to 600s for the same
-    // reason: heavy parallel tests on slow disks can stall flush longer
-    // than 180s without anything actually going wrong.
-    const int timeout_seconds = 600;
 
     std::unique_lock lock(mutex);
 

--- a/src/Common/SystemLogBase.h
+++ b/src/Common/SystemLogBase.h
@@ -138,7 +138,9 @@ public:
 
     Index getLastLogIndex();
     void notifyFlush(Index expected_flushed_index, bool should_prepare_tables_anyway);
-    void waitFlush(Index expected_flushed_index, bool should_prepare_tables_anyway);
+    /// `timeout_seconds` bounds how long we block on the flush. The crash path passes a small
+    /// value so a single stuck queue does not starve the signal handler's per-process budget.
+    void waitFlush(Index expected_flushed_index, bool should_prepare_tables_anyway, int timeout_seconds = 600);
 
     /// Handles crash, flushes log without blocking if notify_flush_on_crash is set
     void handleCrash();


### PR DESCRIPTION
Bump the hardcoded `timeout_seconds` in `SystemLogQueue::waitFlush` from 180s to 600s.

The previous bump (60s -> 180s) is no longer sufficient on heavily loaded parallel CI runners. `SYSTEM FLUSH LOGS query_log` periodically throws:

```
Code: 159. DB::Exception: Received from localhost:9000.
DB::Exception: Timeout exceeded (180 s) while flushing system log
'DB::SystemLogQueue<DB::QueryLogElement>'. (TIMEOUT_EXCEEDED)
(query: SYSTEM FLUSH LOGS query_log;)
```

CIDB shows 23 master hits across 4 distinct PRs in the last 30 days for `02345_implicit_transaction` alone, spanning `amd_tsan parallel`, `amd_asan_ubsan distributed plan parallel`, `arm_binary parallel`, `amd_llvm_coverage`, `amd_debug parallel`, `arm_asan_ubsan azure`, and others. The common factor is `parallel` runners with heavy `query_log` backlog, not a specific sanitizer or storage backend.

The throw is server-side from `SystemLogQueue::waitFlush` and is not influenced by client `receive_timeout`. So bumping the server-side constant is the only way to give the flush more headroom under load. Updated the comment to reflect the latest tune-up rationale.

This is the third test in the bundle requested by @rschu1ze in #104648. Companion PRs:

- #105474 — `02435_rollback_cancelled_queries` (LSan leak check skip)
- #105457 — `01563_distributed_query_finish` (CI log-sender bursts)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)
