### PR TITLE
Install `clickhouse-driver` before running perf tests in PGO collection

### DIFF
--- a/ci/jobs/collect_clickhouse_profiles.py
+++ b/ci/jobs/collect_clickhouse_profiles.py
@@ -245,6 +245,20 @@ def stop_server(proc, log_fd):
         log_fd.close()
 
 
+def install_perf_python_deps():
+    """Install Python packages required by `tests/performance/scripts/perf.py`.
+
+    The `clickhouse/binary-builder` Docker image used by this job inherits
+    `scipy` from `clickhouse/fasttest` but does not bundle `clickhouse-driver`
+    (it is only needed for running perf tests, not for builds). Install it on
+    demand so `perf.py` can `import clickhouse_driver`.
+    """
+    Shell.check(
+        "pip3 install --no-cache-dir 'clickhouse-driver==0.2.7'",
+        verbose=True,
+    )
+
+
 def run_performance_tests(server_dir, port=9000, runs=7, max_queries=10):
     """Run all performance tests against a single server to exercise code paths."""
     test_files = sorted(
@@ -437,6 +451,7 @@ def main():
 
         def collect_pgo():
             install_clickhouse(pgo_binary, pgo_server_dir)
+            install_perf_python_deps()
             if not download_datasets():
                 return False
             if not configure_datasets(pgo_server_dir, port=9000):


### PR DESCRIPTION
The `Collect PGO profiles` stage of the PGO/BOLT profile collection workflow
fails on master because `tests/performance/scripts/perf.py` starts with

    import clickhouse_driver

but the `clickhouse/binary-builder` Docker image used by this job does not
bundle the `clickhouse-driver` Python package. It only inherits `scipy` from
the `clickhouse/fasttest` base image. As soon as the PGO instrumented build
finishes and we try to drive load against the server, `perf.py` raises
`ModuleNotFoundError: No module named 'clickhouse_driver'`.

Failed run:
- https://github.com/ClickHouse/ClickHouse/actions/runs/26210422634/job/77119841725

Install `clickhouse-driver` on demand at the start of `collect_pgo()`, pinned
to `0.2.7` to match `ci/docker/performance-comparison/requirements.txt`. The
BOLT collection step also runs `perf.py` but it runs later in the same process
inside the same container, so the install carries over.

Touching the `binary-builder` Dockerfile would require an image rebuild for
every build job, which is heavier than warranted for a dependency that is
only used by this single job.

Follow-up to #105477 / #105483.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)