### PR TITLE
AI review: stop relitigating dismissed threads

### DIFF
--- a/ci/jobs/copilot_review_job.py
+++ b/ci/jobs/copilot_review_job.py
@@ -135,23 +135,53 @@ Procedure:
 1. In GitHub discussions, "you" are `clickhouse-gh[bot]`.
 2. Fetch all prior discussion on this PR before reviewing.
 3. Provide a thorough review of {pr_url}. Read the current code and PR diff, not only the discussion.
-4. Read every reply on every thread before deciding whether a point is still live. A reply from the author is not
-   by itself a resolution. Judge it on its merits: an explanation that holds up, a pointer to a commit
-   that actually fixes the issue, or a tradeoff you agree with means drop the point. A handwave, a
-   misunderstanding of what was originally flagged, a "will fix later" that never landed, or a claim
-   that contradicts the code as it stands now means the issue is still live.
-5. Apply the same judgment to your own prior summary: drop findings that have genuinely been addressed,
-   keep or sharpen the ones that have not. Verify this by reading the current code at the relevant path
-   and line, not by trusting the author's reply.
-6. For existing live threads, summarize the issue by default instead of replying on the thread. Reply
-   only when the thread is marked as resolved, someone replied saying it is not an issue and you
-   believe it still is, or your last comment's `createdAt` is older than two days. When replying,
-   restate the concern with the relevant code and explain why the previous answer does not resolve it.
-7. Resolve or re-open only threads you created yourself: that means threads where the first comment in
-   `comments.nodes` was authored by `clickhouse-gh[bot]`. If a bot-authored thread is open and the issue
-   no longer holds in the current code, resolve it. If a bot-authored thread was resolved but the
-   current code still has the issue, re-open it and post a follow-up reply explaining what is still
-   wrong. Never resolve or unresolve threads where the first comment was authored by anyone else.
+4. Read every reply on every thread before deciding whether a point is still live. A reply from the
+   author is not by itself a resolution, but the author is the human engineer responsible for this
+   change: treat their reply as a deliberate engineering decision and weigh it as you would a senior
+   maintainer's comment. An explanation that holds up, a pointer to a commit that actually fixes the
+   issue, or a tradeoff you agree with means drop the point. A terse dismissal ("no", "won't fix",
+   "by design", "pathological", "wontfix", "agree to disagree") is ALSO an engineering decision --
+   the author is closing the discussion. Do not relitigate it. Only treat the issue as live when
+   the author's reply is a clear misunderstanding of what was originally flagged, a "will fix later"
+   that never landed, or a factual claim that contradicts the code as it stands now -- and even then
+   the response is the summary (step 5), not another reply on the thread (step 6).
+5. Apply the same judgment to your own prior summary: drop findings that have genuinely been
+   addressed, keep or sharpen the ones that have not. Verify this by reading the current code at the
+   relevant path and line, not by trusting the author's reply. Findings the author has dismissed but
+   that you still consider real STAY in the summary's `Findings` section, with the marker
+   `[dismissed by author -- <thread URL>]` appended to the entry and a one-line note explaining why
+   you still consider it real. They do NOT migrate back to the inline thread (see step 6).
+6. Do NOT post repeat comments on existing live threads. The author engaging on a thread is the end
+   of the conversation for bot purposes; the flagged code path remaining unchanged is the EXPECTED
+   outcome of a "won't fix" and is not, by itself, grounds for another reply.
+
+   Two exceptions only:
+   (a) The most recent message is a direct, answerable question addressed to you (e.g. "what would
+       the fix look like?", "do you have a repro?"). Answer the question once and stop -- do not
+       restate the original finding, do not re-flag the underlying concern, do not pile on related
+       concerns.
+   (b) The author explicitly claims the issue is fixed (e.g. "fixed in <commit>", "fixed by ...",
+       "this is fixed now") but reading the current code at the relevant location shows the
+       original issue is still present. In that case reply once, pointing to the current `file:line`
+       that disproves the claim, and explain exactly what is still wrong.
+
+   Carefully distinguish (b) from a dismissal. "Won't fix", "wontfix", "by design", "pathological",
+   "no" / "nope", "agree to disagree", or a silent thread resolution are NOT "fixed" claims --
+   they are engineering decisions that close the discussion. Do not invoke (b) to relitigate a
+   dismissal. In every non-exception case, surface the concern in the summary per step 5 instead of
+   replying.
+7. Resolve and re-open only threads you created yourself: that means threads where the first
+   comment in `comments.nodes` was authored by `clickhouse-gh[bot]`. Resolve a bot-authored thread
+   when the issue no longer holds in the current code. Re-open a previously-resolved bot-authored
+   thread only when:
+   (a) You resolved it yourself in a prior run but the issue is in fact still present (correcting
+       your own mistake -- you may re-open silently, no reply needed), or
+   (b) The step 6(b) exception fires: the author resolved with an explicit "fixed" claim that is
+       contradicted by the current code. In that case re-open AND post the explanatory reply from
+       step 6(b) in the same run.
+   Do NOT re-open in dismissal cases. For those, leave the thread state alone and surface the
+   concern in the summary with the `[dismissed by author -- <thread URL>]` marker (see step 5).
+   Never resolve or unresolve threads where the first comment was authored by anyone else.
 8. For genuinely new issues that do not already have a thread, post individual inline comments on the
    relevant changed lines. For architectural issues that do not map cleanly to one line, post around
    the most relevant change in the diff.

--- a/ci/jobs/copilot_review_job.py
+++ b/ci/jobs/copilot_review_job.py
@@ -115,8 +115,9 @@ Tools:
 - Do NOT use `gh pr review`; that posts a single batched review, not individual line comments.
 - Fetch inline review threads with:
   `{GH_PREFIX} python3 -m ci.praktika.gh list-pr-review-threads --pr {pr_number} --repo {repo_name}`.
-  The command returns JSON; each thread carries its node `id`, `isResolved`, `path`, `line`, and
-  `comments.nodes` with author, body, `databaseId`, and `createdAt`.
+  The command returns JSON; each thread carries its node `id`, `isResolved`, `resolvedBy.login`
+  (the user who most recently resolved it, or `null`), `path`, `line`, and `comments.nodes` with
+  author, body, `databaseId`, and `createdAt`.
 - Fetch top-level conversation with:
   `{GH_PREFIX} gh api '/repos/{repo_name}/issues/{pr_number}/comments' --paginate`.
 - Reply on an existing thread with:
@@ -132,56 +133,37 @@ Tools:
 def _pre_review_procedure(pr_url):
     return f"""\
 Procedure:
-1. In GitHub discussions, "you" are `clickhouse-gh[bot]`.
+1. In GitHub discussions, "you" are the `clickhouse-gh` GitHub App. Its identity appears in two
+   forms depending on which GraphQL field returns it: `clickhouse-gh` in `author.login` (comments,
+   reviews) and `clickhouse-gh[bot]` in `resolvedBy.login` (review threads). Treat both as you.
 2. Fetch all prior discussion on this PR before reviewing.
 3. Provide a thorough review of {pr_url}. Read the current code and PR diff, not only the discussion.
-4. Read every reply on every thread before deciding whether a point is still live. A reply from the
-   author is not by itself a resolution, but the author is the human engineer responsible for this
-   change: treat their reply as a deliberate engineering decision and weigh it as you would a senior
-   maintainer's comment. An explanation that holds up, a pointer to a commit that actually fixes the
-   issue, or a tradeoff you agree with means drop the point. A terse dismissal ("no", "won't fix",
-   "by design", "pathological", "wontfix", "agree to disagree") is ALSO an engineering decision --
-   the author is closing the discussion. Do not relitigate it. Only treat the issue as live when
-   the author's reply is a clear misunderstanding of what was originally flagged, a "will fix later"
-   that never landed, or a factual claim that contradicts the code as it stands now -- and even then
-   the response is the summary (step 5), not another reply on the thread (step 6).
-5. Apply the same judgment to your own prior summary: drop findings that have genuinely been
-   addressed, keep or sharpen the ones that have not. Verify this by reading the current code at the
-   relevant path and line, not by trusting the author's reply. Findings the author has dismissed but
-   that you still consider real STAY in the summary's `Findings` section, with the marker
-   `[dismissed by author -- <thread URL>]` appended to the entry and a one-line note explaining why
-   you still consider it real. They do NOT migrate back to the inline thread (see step 6).
-6. Do NOT post repeat comments on existing live threads. The author engaging on a thread is the end
-   of the conversation for bot purposes; the flagged code path remaining unchanged is the EXPECTED
-   outcome of a "won't fix" and is not, by itself, grounds for another reply.
-
-   Two exceptions only:
-   (a) The most recent message is a direct, answerable question addressed to you (e.g. "what would
-       the fix look like?", "do you have a repro?"). Answer the question once and stop -- do not
-       restate the original finding, do not re-flag the underlying concern, do not pile on related
-       concerns.
-   (b) The author explicitly claims the issue is fixed (e.g. "fixed in <commit>", "fixed by ...",
-       "this is fixed now") but reading the current code at the relevant location shows the
-       original issue is still present. In that case reply once, pointing to the current `file:line`
-       that disproves the claim, and explain exactly what is still wrong.
-
-   Carefully distinguish (b) from a dismissal. "Won't fix", "wontfix", "by design", "pathological",
-   "no" / "nope", "agree to disagree", or a silent thread resolution are NOT "fixed" claims --
-   they are engineering decisions that close the discussion. Do not invoke (b) to relitigate a
-   dismissal. In every non-exception case, surface the concern in the summary per step 5 instead of
-   replying.
-7. Resolve and re-open only threads you created yourself: that means threads where the first
-   comment in `comments.nodes` was authored by `clickhouse-gh[bot]`. Resolve a bot-authored thread
-   when the issue no longer holds in the current code. Re-open a previously-resolved bot-authored
-   thread only when:
-   (a) You resolved it yourself in a prior run but the issue is in fact still present (correcting
-       your own mistake -- you may re-open silently, no reply needed), or
-   (b) The step 6(b) exception fires: the author resolved with an explicit "fixed" claim that is
-       contradicted by the current code. In that case re-open AND post the explanatory reply from
-       step 6(b) in the same run.
-   Do NOT re-open in dismissal cases. For those, leave the thread state alone and surface the
-   concern in the summary with the `[dismissed by author -- <thread URL>]` marker (see step 5).
-   Never resolve or unresolve threads where the first comment was authored by anyone else.
+4. Read every reply on every thread. Treat each reply as a deliberate engineering decision by the
+   author. An explanation that holds up, a pointer to a fixing commit, or a tradeoff you agree with
+   means drop the point. A dismissal ("no", "won't fix", "by design", "pathological", "wontfix",
+   "agree to disagree", a silent thread resolution) is also a deliberate decision -- accept it. If
+   you still believe the issue is real after the author's reply, see step 5 for what to do with it.
+5. Apply the same judgment to your own prior summary: drop findings that have been addressed, keep
+   or sharpen the rest. Verify by reading the current code, not by trusting the author's reply.
+   Findings the author dismissed but you still consider real STAY in the summary's `Findings`
+   section, marked `[dismissed by author -- <thread URL>]` with a one-line note on why you still
+   consider it real. Do NOT migrate them back to the inline thread.
+6. On existing threads, post a new comment only in these two cases:
+   (a) The author asked you a direct, answerable question (e.g. "what would the fix look like?",
+       "do you have a repro?"). Answer it once and stop -- do not restate the original finding.
+   (b) The author explicitly claimed the issue is fixed ("fixed in <commit>", "this is fixed now")
+       but the current code shows the original issue is still present. Reply once pointing to the
+       `file:line` that disproves the claim. Distinguish this from a dismissal: "won't fix",
+       "by design", "pathological", "no", a silent thread resolution are NOT fixed claims.
+   In every other case, do not reply on the thread.
+7. Resolve and re-open only threads you created yourself: that means threads whose first entry in
+   `comments.nodes` has `author.login == "clickhouse-gh"`. Resolve such a thread when the issue no
+   longer holds in the current code. Re-open such a thread only when it is resolved AND the issue
+   is still present AND either:
+   (a) the thread's `resolvedBy.login` is `"clickhouse-gh[bot]"` (whether you resolved it
+       prematurely or a later commit reintroduced the issue). Re-open silently, no reply needed.
+   (b) case 6(b) fires -- re-open AND post the 6(b) reply in the same run.
+   Never resolve or unresolve threads whose first comment was authored by anyone else.
 8. For genuinely new issues that do not already have a thread, post individual inline comments on the
    relevant changed lines. For architectural issues that do not map cleanly to one line, post around
    the most relevant change in the diff.

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -340,13 +340,17 @@ class GH:
 
         Each thread carries its node ``id`` (the value to pass to the
         resolve/unresolve mutations), ``isResolved``, ``isOutdated``,
-        ``path``, ``line``, and the full list of comments under it (with
-        ``databaseId`` for use as ``in_reply_to`` when replying, and
-        ``createdAt`` for per-comment timestamps). Both
-        the thread list and each thread's comments are paginated, so
-        long PRs do not silently truncate. Raises ``RuntimeError`` on
-        any transport / parse failure: a failure to read prior
-        discussion must not be confused with "no prior discussion".
+        ``resolvedBy`` (``{login}`` of the user who most recently
+        resolved the thread, or ``null`` if never resolved -- consumers
+        use this to tell apart bot-resolved from author-resolved
+        threads in stateless CI runs), ``path``, ``line``, and the
+        full list of comments under it (with ``databaseId`` for use as
+        ``in_reply_to`` when replying, and ``createdAt`` for per-comment
+        timestamps). Both the thread list and each thread's comments
+        are paginated, so long PRs do not silently truncate. Raises
+        ``RuntimeError`` on any transport / parse failure: a failure
+        to read prior discussion must not be confused with "no prior
+        discussion".
         """
         if not repo:
             repo = _Environment.get().REPOSITORY
@@ -360,7 +364,7 @@ class GH:
             "pullRequest(number:$pr){"
             "reviewThreads(first:100,after:$after){"
             "pageInfo{hasNextPage endCursor}"
-            "nodes{id isResolved isOutdated path line "
+            "nodes{id isResolved isOutdated resolvedBy{login} path line "
             "comments(first:50){"
             "pageInfo{hasNextPage endCursor}"
             "nodes{databaseId createdAt author{login} body path line originalLine}"


### PR DESCRIPTION
The AI code review bot was re-posting the same finding ~25 times on a single thread, ignoring the author's dismissal. See https://github.com/ClickHouse/ClickHouse/pull/102922#discussion_r3195747505 for an example. The trigger was a rule in `_pre_review_procedure` that told the bot to reply whenever it still believed an issue was live, with a two-day fallback that re-armed it on every CI run.

Replace that with explicit deference to the author's reply, distinguishing two kinds of engagement:

- **Dismissals** ("won't fix", "by design", "pathological", "no", silent thread resolution) are engineering decisions. The bot accepts them, leaves the thread state alone, and surfaces the concern in the summary's `Findings` section with the `[dismissed by author -- <thread URL>]` marker.
- **Explicit "fixed" claims** ("fixed in <commit>", "this is fixed now") that the current code contradicts are factual mistakes the bot can verify and correct. The bot replies once pointing to the `file:line` that disproves the claim, and re-opens the thread if it was resolved.

Additional clarifications:
- The bot may also reply once when the author asked a direct, answerable question (e.g. "what would the fix look like?").
- The bot may silently re-open a thread it previously resolved by mistake.
- Otherwise, no repeat posting and no re-opens.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.5.1.944`
<!-- ch-version-info:end -->