### PR TITLE
Add constinit for various MemoryTracker blockers

### DIFF
--- a/src/Common/LockMemoryExceptionInThread.cpp
+++ b/src/Common/LockMemoryExceptionInThread.cpp
@@ -2,9 +2,9 @@
 #include <base/defines.h>
 
 /// LockMemoryExceptionInThread
-thread_local uint64_t LockMemoryExceptionInThread::counter = 0;
-thread_local VariableContext LockMemoryExceptionInThread::level = VariableContext::Global;
-thread_local bool LockMemoryExceptionInThread::block_fault_injections = false;
+thread_local constinit uint64_t LockMemoryExceptionInThread::counter = 0;
+thread_local constinit VariableContext LockMemoryExceptionInThread::level = VariableContext::Global;
+thread_local constinit bool LockMemoryExceptionInThread::block_fault_injections = false;
 LockMemoryExceptionInThread::LockMemoryExceptionInThread(VariableContext level_, bool block_fault_injections_)
     : previous_level(level)
     , previous_block_fault_injections(block_fault_injections)

--- a/src/Common/LockMemoryExceptionInThread.h
+++ b/src/Common/LockMemoryExceptionInThread.h
@@ -18,9 +18,9 @@
 struct LockMemoryExceptionInThread
 {
 private:
-    static thread_local uint64_t counter;
-    static thread_local VariableContext level;
-    static thread_local bool block_fault_injections;
+    static thread_local constinit uint64_t counter;
+    static thread_local constinit VariableContext level;
+    static thread_local constinit bool block_fault_injections;
 
     VariableContext previous_level;
     bool previous_block_fault_injections;

--- a/src/Common/MemoryTrackerBlockerInThread.cpp
+++ b/src/Common/MemoryTrackerBlockerInThread.cpp
@@ -3,7 +3,7 @@
 #include <utility>
 
 // MemoryTrackerBlockerInThread
-thread_local VariableContext MemoryTrackerBlockerInThread::level = VariableContext::Max;
+thread_local constinit VariableContext MemoryTrackerBlockerInThread::level = VariableContext::Max;
 
 MemoryTrackerBlockerInThread::MemoryTrackerBlockerInThread(VariableContext level_)
     : previous_level(level)

--- a/src/Common/MemoryTrackerBlockerInThread.h
+++ b/src/Common/MemoryTrackerBlockerInThread.h
@@ -20,7 +20,7 @@ class TraceCollector;
 struct MemoryTrackerBlockerInThread
 {
 private:
-    static thread_local VariableContext level;
+    static thread_local constinit VariableContext level;
 
     std::optional<VariableContext> previous_level;
 

--- a/src/Common/MemoryTrackerUntrackedAllocationsBlockerInThread.cpp
+++ b/src/Common/MemoryTrackerUntrackedAllocationsBlockerInThread.cpp
@@ -1,7 +1,7 @@
 #include <Common/MemoryTrackerUntrackedAllocationsBlockerInThread.h>
 #include <cstdint>
 
-static thread_local uint64_t MemoryTrackerUntrackedAllocationsBlockerInThreadCounter;
+static thread_local constinit uint64_t MemoryTrackerUntrackedAllocationsBlockerInThreadCounter = 0;
 
 MemoryTrackerUntrackedAllocationsBlockerInThread::MemoryTrackerUntrackedAllocationsBlockerInThread()
 {


### PR DESCRIPTION
I've noticed the following in asm:

    callq  0x2404e240     ; symbol stub for: thread-local initialization routine for MemoryTrackerBlockerInThread::level

### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add constinit for various MemoryTracker blockers

_Note: marked as `Performance Improvement` mostly for perf tests_

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.106`
<!-- ch-version-info:end -->