### PR TITLE
Skip test_numbers_check on release branches

### DIFF
--- a/ci/jobs/check_style.py
+++ b/ci/jobs/check_style.py
@@ -6,6 +6,7 @@ import re
 from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 
+from praktika.info import Info
 from praktika.result import Result
 from praktika.utils import Shell, Utils
 
@@ -546,7 +547,13 @@ if __name__ == "__main__":
             )
         )
     testname = "test_numbers_check"
-    if testpattern.lower() in testname.lower():
+    # Skip on release branches and backport PRs: backports cherry-pick a small
+    # subset of test files, which legitimately leaves large gaps in the numbering.
+    info = Info()
+    release_branch_re = re.compile(r"^\d{2}\.\d+$")
+    branch_to_check = (info.base_branch or info.git_branch or "").removeprefix("release/")
+    is_release_branch = bool(release_branch_re.match(branch_to_check))
+    if testpattern.lower() in testname.lower() and not is_release_branch:
         results.append(
             Result.from_commands_run(
                 name=testname,


### PR DESCRIPTION
Backport PRs cherry-pick a small subset of test files, which legitimately leaves large gaps in the test numbering. The `test_numbers_check` style check fails on these gaps and forces backports to manipulate file numbering for no benefit.

Skip the check when the target branch (for PRs) or current branch (for pushes) matches the release version pattern, e.g. `25.3`, `25.10`, `release/24.12`.

Style check failure that motivated this:
- CI log: https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/PRs/58624/c1764fc841816af643f0b0f0d96e093bc6932f52//style_check/job.log
- PR (private): https://github.com/ClickHouse/clickhouse-private/pull/58624

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.76`
- Backported to: `26.5.2.2`, `26.4.4.6`, `26.3.11.35`, `25.8.25.5`
<!-- ch-version-info:end -->