### PR TITLE
Docs: clarify `max_bytes_in_join` and `join_overflow_mode` behavior in docs

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -3327,15 +3327,17 @@ When enabled, ClickHouse will provide exact value for rows_before_limit_at_least
 When enabled, ClickHouse will provide exact value for rows_before_aggregation statistic, represents the number of rows read before aggregation
 )", 0) \
     DECLARE(UInt64, max_rows_in_join, 0, R"(
-Limits the number of rows in the hash table that is used when joining tables.
+Limits the number of rows in the right-side data structure (typically a hash
+table) used when joining tables.
 
-This settings applies to [SELECT ... JOIN](/sql-reference/statements/select/join)
+This setting applies to [SELECT ... JOIN](/sql-reference/statements/select/join)
 operations and the [Join](/engines/table-engines/special/join) table engine.
 
-If a query contains multiple joins, ClickHouse checks this setting for every intermediate result.
-
-ClickHouse can proceed with different actions when the limit is reached. Use the
-[`join_overflow_mode`](/operations/settings/settings#join_overflow_mode) setting to choose the action.
+If a query contains multiple joins, ClickHouse checks this setting for every
+intermediate result. When the limit is reached, the action depends on the
+chosen [`join_algorithm`](/operations/settings/settings#join_algorithm) — see
+that setting for the per-algorithm behavior (spill, re-partition, switch, or
+throw/break per [`join_overflow_mode`](/operations/settings/settings#join_overflow_mode)).
 
 Possible values:
 
@@ -3343,16 +3345,17 @@ Possible values:
 - `0` — Unlimited number of rows.
 )", 0) \
     DECLARE(UInt64, max_bytes_in_join, 0, R"(
-The maximum size in bytes of the hash table used by JOIN execution.
+The maximum size in bytes of the right-side data structure (typically a hash
+table) used when joining tables.
 
 This setting applies to [SELECT ... JOIN](/sql-reference/statements/select/join)
 operations and the [Join table engine](/engines/table-engines/special/join).
 
-For `SELECT ... JOIN`, this limit is used by join algorithms that build a hash
-table in memory (for example, `hash` and `parallel_hash`).
-
-If this limit is reached, ClickHouse follows
-[`join_overflow_mode`](/operations/settings/settings#join_overflow_mode).
+If a query contains multiple joins, ClickHouse checks this setting for every
+intermediate result. When the limit is reached, the action depends on the
+chosen [`join_algorithm`](/operations/settings/settings#join_algorithm) — see
+that setting for the per-algorithm behavior (spill, re-partition, switch, or
+throw/break per [`join_overflow_mode`](/operations/settings/settings#join_overflow_mode)).
 
 Possible values:
 
@@ -3365,18 +3368,18 @@ Defines what action ClickHouse performs when a join reaches any of the following
 - [max_bytes_in_join](/operations/settings/settings#max_bytes_in_join)
 - [max_rows_in_join](/operations/settings/settings#max_rows_in_join)
 
+This setting applies only to
+[`join_algorithm`](/operations/settings/settings#join_algorithm) values that
+build an in-memory hash table (`hash`, `parallel_hash`). Other algorithms
+handle the limits internally - see
+[`join_algorithm`](/operations/settings/settings#join_algorithm).
+
 Possible values:
 
 - `THROW` — ClickHouse throws an exception and stops the query.
 - `BREAK` — ClickHouse stops the query and does not throw an exception.
 
 Default value: `THROW`.
-
-This behavior is used with settings such as
-[`max_bytes_in_join`](/operations/settings/settings#max_bytes_in_join) and
-[`max_rows_in_join`](/operations/settings/settings#max_rows_in_join). The
-limits apply to join algorithms that build an in-memory hash table (for
-example, `hash` and `parallel_hash`).
 
 **See Also**
 

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -3368,10 +3368,11 @@ Defines what action ClickHouse performs when a join reaches any of the following
 - [max_bytes_in_join](/operations/settings/settings#max_bytes_in_join)
 - [max_rows_in_join](/operations/settings/settings#max_rows_in_join)
 
-This setting applies only to
-[`join_algorithm`](/operations/settings/settings#join_algorithm) values that
-build an in-memory hash table (`hash`, `parallel_hash`). Other algorithms
-handle the limits internally - see
+This setting is honored only by the `hash` and `parallel_hash`
+[`join_algorithm`](/operations/settings/settings#join_algorithm) values. Other
+algorithms (for example, `partial_merge`, `grace_hash`, `auto`) handle the
+limits differently — by spilling to disk, re-partitioning, or switching
+strategy — see
 [`join_algorithm`](/operations/settings/settings#join_algorithm).
 
 Possible values:

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -3343,15 +3343,16 @@ Possible values:
 - `0` — Unlimited number of rows.
 )", 0) \
     DECLARE(UInt64, max_bytes_in_join, 0, R"(
-The maximum size in number of bytes of the hash table used when joining tables.
+The maximum size in bytes of the hash table used by JOIN execution.
 
 This setting applies to [SELECT ... JOIN](/sql-reference/statements/select/join)
 operations and the [Join table engine](/engines/table-engines/special/join).
 
-If the query contains joins, ClickHouse checks this setting for every intermediate result.
+For `SELECT ... JOIN`, this limit is used by join algorithms that build a hash
+table in memory (for example, `hash` and `parallel_hash`).
 
-ClickHouse can proceed with different actions when the limit is reached. Use
-the [join_overflow_mode](/operations/settings/settings#join_overflow_mode) settings to choose the action.
+If this limit is reached, ClickHouse follows
+[`join_overflow_mode`](/operations/settings/settings#join_overflow_mode).
 
 Possible values:
 
@@ -3359,17 +3360,23 @@ Possible values:
 - 0 — Memory control is disabled.
 )", 0) \
     DECLARE(OverflowMode, join_overflow_mode, OverflowMode::THROW, R"(
-Defines what action ClickHouse performs when any of the following join limits is reached:
+Defines what action ClickHouse performs when a join reaches any of the following limits:
 
 - [max_bytes_in_join](/operations/settings/settings#max_bytes_in_join)
 - [max_rows_in_join](/operations/settings/settings#max_rows_in_join)
 
 Possible values:
 
-- `THROW` — ClickHouse throws an exception and breaks operation.
-- `BREAK` — ClickHouse breaks operation and does not throw an exception.
+- `THROW` — ClickHouse throws an exception and stops the query.
+- `BREAK` — ClickHouse stops the query and does not throw an exception.
 
 Default value: `THROW`.
+
+This behavior is used with settings such as
+[`max_bytes_in_join`](/operations/settings/settings#max_bytes_in_join) and
+[`max_rows_in_join`](/operations/settings/settings#max_rows_in_join). The
+limits apply to join algorithms that build an in-memory hash table (for
+example, `hash` and `parallel_hash`).
 
 **See Also**
 


### PR DESCRIPTION
- Improve clarity in settings documentation to reduce confusion about how `max_bytes_in_join` interacts with `join_overflow_mode` and which join algorithms the limits apply to. 
- Make explicit that the limits are relevant to join implementations that build an in-memory hash table to avoid support misunderstandings.

### Changelog category (leave one):
- Documentation (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0ec9c10be8832c9d6b4668be6d065f)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.151`
<!-- ch-version-info:end -->