### PR TITLE
Fix new kafka unexpected messages

### DIFF
--- a/src/Storages/Kafka/KafkaConsumer2.cpp
+++ b/src/Storages/Kafka/KafkaConsumer2.cpp
@@ -149,14 +149,24 @@ void KafkaConsumer2::cleanQueuesAndMessages()
 void KafkaConsumer2::initializeQueues(const cppkafka::TopicPartitionList & topic_partitions)
 {
     cleanQueuesAndMessages();
-    // cppkafka itself calls assign(), but in order to detach the queues here we have to do the assignment manually.
-    // Later on we have to reassign the topic partitions with correct offsets.
-    consumer->assign(topic_partitions);
-    for (const auto & topic_partition : topic_partitions)
-        // This will also detach the partition queues from the consumer, thus the messages won't be forwarded without
-        // attaching them manually
-        queues.emplace(
-            TopicPartition{topic_partition.get_topic(), topic_partition.get_partition()}, consumer->get_partition_queue(topic_partition));
+
+    queues.reserve(topic_partitions.size());
+    // `get_partition_queue` creates the partition queue if needed and disables forwarding to the main consumer queue.
+    // Do this before `assign` starts fetching, otherwise messages may leak into the main queue before we detach it.
+    try
+    {
+        for (const auto & topic_partition : topic_partitions)
+            queues.emplace(
+                TopicPartition{topic_partition.get_topic(), topic_partition.get_partition()},
+                consumer->get_partition_queue(topic_partition));
+
+        consumer->assign(topic_partitions);
+    }
+    catch (...)
+    {
+        cleanQueuesAndMessages();
+        throw;
+    }
 }
 
 // it does the poll when needed


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a rare issue in new Kafka table engine where messages could be incorrectly handled during topic partition reassignment, potentially leading to skipped messages after offset rollback.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.165` (included in `26.6` and later)
- Backported to: `26.3.33.50`
<!-- ch-version-info:end -->