### PR TITLE
darwin fast test: wipe DiagnosticReports in pre-hook

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -205,9 +205,12 @@ class JobConfigs:
         digest_config=fast_test_digest_config,
         result_name_for_cidb="Tests",
         force_success=True,
+        pre_hooks=[
+            "sudo rm -rf /Library/Logs/DiagnosticReports/*",
+        ],
         post_hooks=[
             "python3 ./ci/jobs/scripts/job_hooks/clickhouse_test_cleanup_hook.py",
-            "sudo rm -rf /Users/ec2-user/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp/run* /System/Volumes/Data/System/Library/Caches/com.apple.coresymbolicationd/data /Library/Logs/DiagnosticReports/*",
+            "sudo rm -rf /Users/ec2-user/actions-runner/_work/ClickHouse/ClickHouse/ci/tmp/run* /System/Volumes/Data/System/Library/Caches/com.apple.coresymbolicationd/data",
         ],
     ).parametrize(
         Job.ParamSet(

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -899,8 +899,9 @@ clickhouse-client --query "SELECT count() FROM test.visits"
     def _collect_diagnostic_reports() -> List[str]:
         # macOS writes .ips crash reports to /Library/Logs/DiagnosticReports as
         # root. Grant read access so the runner can list and read the files
-        # in place; the darwin fast-test post-hook wipes the directory under
-        # sudo afterwards, so anything we see here belongs to the current run.
+        # in place; the darwin fast-test pre-hook wipes the directory under
+        # sudo before the run, so anything we see here belongs to the current
+        # run even if the previous runner was terminated unexpectedly.
         if platform.system() != "Darwin":
             return []
         reports_dir = Path("/Library/Logs/DiagnosticReports")


### PR DESCRIPTION
When a Darwin fast-test runner is terminated unexpectedly, the post-hook never runs and stale `.ips` files survive into the next run. The next collection then attaches them as if they belonged to that run, producing warnings such as:

```
The test runner was terminated unexpectedly
WARNING: File [/Library/Logs/DiagnosticReports/clickhouse-2026-05-21-104448.ips] was not found
```

Move the `/Library/Logs/DiagnosticReports/*` wipe from `post_hooks` to a new `pre_hooks` on the darwin fast-test job. The directory is now empty at the start of every run regardless of how the previous run ended, so the "only this run's `.ips`" invariant holds unconditionally.

Follow-up to #105412.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.87`
<!-- ch-version-info:end -->