### PR TITLE
Use the reinterpret technique to pass query vectors in the vector search stress test

### DIFF
--- a/ci/jobs/vector_search_stress_tests.py
+++ b/ci/jobs/vector_search_stress_tests.py
@@ -45,6 +45,7 @@ TRUTH_SET_COUNT = "truth_set_count"
 RECALL_K = "recall_k"
 NEW_TRUTH_SET_FILE = "new_truth_set_file"
 CONCURRENCY_TEST = "concurrency_test"
+USE_RAW_BYTES_FOR_QUERY_VECTOR = "use_raw_bytes_for_query_vector"
 
 TRUTH_SET_QUERY_SOURCE_ID = "id"
 TRUTH_SET_QUERY_SOURCE_VECTOR = "vector"
@@ -227,6 +228,7 @@ test_params_cohere_wiki_20m = {
     MERGE_TREE_SETTINGS: "max_bytes_to_merge_at_max_space_in_pool=11811160064",
     OTHER_SETTINGS: "min_insert_block_size_rows = 3000000, min_insert_block_size_bytes=11737418240",
     CONCURRENCY_TEST: True,
+    USE_RAW_BYTES_FOR_QUERY_VECTOR: True, # only set if query vector is numpy.Array(Float32)
 }
 
 
@@ -656,10 +658,22 @@ class RunTest:
                 time.sleep(30)
 
         for truth_record in self._truth_set:
-            query_source = self._render_query_source_sql(truth_record)
-            q_start = current_time_ms()
-            ann_search_query = f"SELECT {self._id_column}, distance FROM {self._table} ORDER BY {self._distance_metric}( {self._vector_column}, {query_source} ) AS distance LIMIT {self._k} SETTINGS use_skip_indexes = 1, max_parallel_replicas = 1"
-            result = chclient.query(ann_search_query)
+            if self._test_params.get(USE_RAW_BYTES_FOR_QUERY_VECTOR, False):
+                query_vector = truth_record["query_vector"]
+                if query_vector is None:
+                    raise ValueError(
+                        "USE_RAW_BYTES_FOR_QUERY_VECTOR requires truth records with a materialised query_vector"
+                    )
+                params = {"$search_vector_binary$": query_vector.tobytes()}
+                ann_search_query = f"SELECT {self._id_column}, distance FROM {self._table} ORDER BY {self._distance_metric}( {self._vector_column}, reinterpret($search_vector_binary$, 'Array(Float32)') ) AS distance LIMIT {self._k}"
+                q_start = current_time_ms()
+                result = chclient.query(ann_search_query, parameters=params)
+            else:
+                query_source = self._render_query_source_sql(truth_record)
+                ann_search_query = f"SELECT {self._id_column}, distance FROM {self._table} ORDER BY {self._distance_metric}( {self._vector_column}, {query_source} ) AS distance LIMIT {self._k}"
+                q_start = current_time_ms()
+                result = chclient.query(ann_search_query)
+
             q_end = current_time_ms()
             runtime = runtime + (q_end - q_start)
 
@@ -840,16 +854,6 @@ def install_and_start_clickhouse():
 
 # Array of (dataset, test_params)
 TESTS_TO_RUN = [
-    (
-        "Test using the laion dataset",
-        dataset_laion_5b_mini_for_quick_test,
-        test_params_laion_5b_1m,
-    ),
-    (
-        "Test using the hackernews dataset",
-        dataset_hackernews_openai,
-        test_params_hackernews_10m,
-    ),
     (
         "Test using the cohere wiki dataset",
         dataset_cohere_wiki_20m,

--- a/ci/jobs/vector_search_stress_tests.py
+++ b/ci/jobs/vector_search_stress_tests.py
@@ -855,6 +855,16 @@ def install_and_start_clickhouse():
 # Array of (dataset, test_params)
 TESTS_TO_RUN = [
     (
+        "Test using the laion dataset",
+        dataset_laion_5b_mini_for_quick_test,
+        test_params_laion_5b_1m,
+    ),
+    (
+        "Test using the hackernews dataset",
+        dataset_hackernews_openai,
+        test_params_hackernews_10m,
+    ),
+    (
         "Test using the cohere wiki dataset",
         dataset_cohere_wiki_20m,
         test_params_cohere_wiki_20m,

--- a/ci/jobs/vector_search_stress_tests.py
+++ b/ci/jobs/vector_search_stress_tests.py
@@ -149,6 +149,7 @@ test_params_laion_5b_full_run = {
     MERGE_TREE_SETTINGS: None,
     OTHER_SETTINGS: None,
     CONCURRENCY_TEST: True,
+    USE_RAW_BYTES_FOR_QUERY_VECTOR: False,
 }
 
 test_params_laion_5b_quick_test = {
@@ -169,6 +170,7 @@ test_params_laion_5b_quick_test = {
     MERGE_TREE_SETTINGS: None,
     OTHER_SETTINGS: None,
     CONCURRENCY_TEST: True,
+    USE_RAW_BYTES_FOR_QUERY_VECTOR: False,
 }
 
 test_params_laion_5b_1m = {
@@ -187,6 +189,7 @@ test_params_laion_5b_1m = {
     MERGE_TREE_SETTINGS: None,
     OTHER_SETTINGS: None,
     CONCURRENCY_TEST: True,
+    USE_RAW_BYTES_FOR_QUERY_VECTOR: False,
 }
 
 test_params_hackernews_10m = {
@@ -207,6 +210,7 @@ test_params_hackernews_10m = {
     MERGE_TREE_SETTINGS: None,
     OTHER_SETTINGS: None,
     CONCURRENCY_TEST: True,
+    USE_RAW_BYTES_FOR_QUERY_VECTOR: False,
 }
 
 test_params_cohere_wiki_20m = {
@@ -658,7 +662,8 @@ class RunTest:
                 time.sleep(30)
 
         for truth_record in self._truth_set:
-            if self._test_params.get(USE_RAW_BYTES_FOR_QUERY_VECTOR, False):
+            # Use reinterpret technique to demonstrate CPU savings, ref : https://github.com/ClickHouse/ClickHouse/pull/105504
+            if self._test_params.get(USE_RAW_BYTES_FOR_QUERY_VECTOR):
                 query_vector = truth_record["query_vector"]
                 if query_vector is None:
                     raise ValueError(


### PR DESCRIPTION
We document this technique in the ANN guide -

https://clickhouse.com/docs/engines/table-engines/mergetree-family/annindexes#:~:text=Tuning%20data%20transfer

_Note that most LLM models return an embedding vector as a list or NumPy array of native floats. We therefore recommend Python applications to bind the reference vector parameter in binary form by using the following style.....This saves CPU time on the server side, and avoids bloat in the server logs and system.query_log_

The `Cohere-Wiki-20M` dataset is perfect for this because the truthset already contains vectors in `NumPy` format. This PR just adds code to pass the search vector in `native` format when running the Cohere dataset. 

**Improvement in test run timings -**

Truthset : 25000 vectors

_Before (search vector passed as human readable String)_

```
Sun May 17 21:54:50 2026  :  Runtime for ANN : 292.499 seconds
Sun May 17 21:54:50 2026  :  Calculating recall...
Sun May 17 21:54:50 2026  :  Recall is 0.9891200000000249

Sun May 17 21:54:50 2026  :  Running concurrency test with 25 threads...
Sun May 17 22:25:09 2026  :  Runtime for ANN : 1807.658 seconds
Sun May 17 22:25:09 2026  :  Calculating recall...
Sun May 17 22:25:09 2026  :  Recall is 0.9891240000000251
```

_After (using reinterpret)_

```
Thu May 21 07:59:16 2026  :  Runtime for ANN : 231.007 seconds
Thu May 21 07:59:16 2026  :  Calculating recall...
Thu May 21 07:59:16 2026  :  Recall is 0.9885280000000284

Thu May 21 07:59:16 2026  :  Running concurrency test with 25 threads...
Thu May 21 08:17:41 2026  :  Runtime for ANN : 1103.433 seconds
Thu May 21 08:17:41 2026  :  Calculating recall...
Thu May 21 08:17:41 2026  :  Recall is 0.9885320000000284
```

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.81`
<!-- ch-version-info:end -->