### PR TITLE
Fix get_changed_files locally

### DIFF
--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -71,7 +71,7 @@ class GH:
             sha = info.sha
         else:
             repo_name = Shell.get_output(
-                rf"git config --get remote.origin.url | sed -E 's#(git@|https://)[^/:]+[:/](.*)\.git#\\2#'",
+                rf"git config --get remote.origin.url | sed -E 's#(git@|https://)[^/:]+[:/](.*)\.git#\2#'",
                 strict=True,
             )
             sha = Shell.get_output(f"git rev-parse HEAD", strict=True)

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -71,7 +71,7 @@ class GH:
             sha = info.sha
         else:
             repo_name = Shell.get_output(
-                rf"git config --get remote.origin.url | sed -E 's#(git@|https://)[^/:]+[:/](.*)\.git#\2#'",
+                rf"git config --get remote.origin.url | sed -E 's#(git@|https://)[^/:]+[:/](.*?)(\.git)?$#\2#'",
                 strict=True,
             )
             sha = Shell.get_output(f"git rev-parse HEAD", strict=True)

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -70,10 +70,14 @@ class GH:
             repo_name = info.repo_name
             sha = info.sha
         else:
-            repo_name = Shell.get_output(
-                rf"git config --get remote.origin.url | sed -E 's#(git@|https://)[^/:]+[:/](.*?)(\.git)?$#\2#'",
-                strict=True,
+            repo_url = Shell.get_output(
+                "git config --get remote.origin.url", strict=True
             )
+            repo_name = cls._repo_name_from_git_remote_url(repo_url)
+            if not repo_name:
+                raise RuntimeError(
+                    f"Failed to extract repository name from remote URL [{repo_url}]"
+                )
             sha = Shell.get_output(f"git rev-parse HEAD", strict=True)
 
         assert repo_name
@@ -109,6 +113,14 @@ class GH:
             raise RuntimeError("Failed to get changed files")
 
         return res
+
+    @staticmethod
+    def _repo_name_from_git_remote_url(repo_url: str) -> str:
+        match = re.match(
+            r"^(?:https?://[^/]+/|git@[^:]+:|ssh://git@[^/]+/)([^/\s]+/[^/\s]+?)(?:\.git)?/?$",
+            repo_url,
+        )
+        return match.group(1) if match else ""
 
     @classmethod
     def do_command_with_retries(cls, command, verbose=False):

--- a/ci/tests/test_gh.py
+++ b/ci/tests/test_gh.py
@@ -58,6 +58,22 @@ def test_invalid_status_asserts():
         pass
 
 
+def test_repo_name_from_git_remote_url():
+    cases = {
+        "https://github.com/ClickHouse/ClickHouse.git": "ClickHouse/ClickHouse",
+        "https://github.com/ClickHouse/ClickHouse": "ClickHouse/ClickHouse",
+        "git@github.com:ClickHouse/ClickHouse.git": "ClickHouse/ClickHouse",
+        "ssh://git@github.com/ClickHouse/ClickHouse.git": "ClickHouse/ClickHouse",
+        "https://github.com/ClickHouse/ClickHouse.git/": "ClickHouse/ClickHouse",
+    }
+    for repo_url, repo_name in cases.items():
+        assert GH._repo_name_from_git_remote_url(repo_url) == repo_name
+
+
+def test_repo_name_from_git_remote_url_rejects_unexpected_format():
+    assert GH._repo_name_from_git_remote_url("/home/user/ClickHouse") == ""
+
+
 def test_post_commit_status_converts_transparently(monkeypatch):
     """post_commit_status must accept Result.Status values and convert them."""
     captured = {}


### PR DESCRIPTION
The r makes it a raw string, so backslashes aren't Python escapes — \\2 is literally three characters: \, \, 2.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

FYI @maxknv

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.70`
<!-- ch-version-info:end -->