### PR TITLE
Stabilize apply_patch_parts_join performance test

### DIFF
--- a/tests/performance/apply_patch_parts_join.xml
+++ b/tests/performance/apply_patch_parts_join.xml
@@ -18,6 +18,12 @@
 
     <fill_query>SYSTEM STOP MERGES test_lwu_join</fill_query>
 
+    <!-- Single-threaded INSERT and UPDATE with a block-size that fits each
+         whole patch keep the patch part layout deterministic across runs.
+         Without this, parallel threads race into the patch builder, the
+         split boundary varies, and point-lookup queries below read a
+         varying number of patch granules, producing 18-30% noise on
+         queries #4 to #7. -->
     <fill_query>INSERT INTO test_lwu_join
         SELECT
             number,
@@ -25,14 +31,14 @@
             rand(),
             randomPrintableASCII(8),
             randomPrintableASCII(8),
-        FROM numbers_mt(20000000) SETTINGS max_insert_threads=8
+        FROM numbers_mt(20000000) SETTINGS max_insert_threads=1
     </fill_query>
 
-    <fill_query>UPDATE test_lwu_join SET uint_1p = rand() WHERE id % 100 = 0</fill_query>
-    <fill_query>UPDATE test_lwu_join SET uint_10p = rand() WHERE id % 10 = 0</fill_query>
+    <fill_query>UPDATE test_lwu_join SET uint_1p = rand() WHERE id % 100 = 0 SETTINGS max_threads=1, max_insert_block_size=3000000, min_insert_block_size_rows=3000000</fill_query>
+    <fill_query>UPDATE test_lwu_join SET uint_10p = rand() WHERE id % 10 = 0 SETTINGS max_threads=1, max_insert_block_size=3000000, min_insert_block_size_rows=3000000</fill_query>
 
-    <fill_query>UPDATE test_lwu_join SET str_1p = randomPrintableASCII(8) WHERE id % 100 = 0</fill_query>
-    <fill_query>UPDATE test_lwu_join SET str_10p = randomPrintableASCII(8) WHERE id % 10 = 0</fill_query>
+    <fill_query>UPDATE test_lwu_join SET str_1p = randomPrintableASCII(8) WHERE id % 100 = 0 SETTINGS max_threads=1, max_insert_block_size=3000000, min_insert_block_size_rows=3000000</fill_query>
+    <fill_query>UPDATE test_lwu_join SET str_10p = randomPrintableASCII(8) WHERE id % 10 = 0 SETTINGS max_threads=1, max_insert_block_size=3000000, min_insert_block_size_rows=3000000</fill_query>
 
     <fill_query>SYSTEM START MERGES test_lwu_join</fill_query>
     <fill_query>OPTIMIZE TABLE test_lwu_join PARTITION ID 'all' FINAL</fill_query>


### PR DESCRIPTION
Refs #100759.

The point-lookup queries (#4-#7) in `apply_patch_parts_join` were flagged in #100759 as showing 18-30% noise on master runs. Root cause: the four lightweight UPDATE statements run with default `max_threads`, so parallel threads race into the patch builder and the patch-part split boundary lands at a different row count on every run. The point-lookup queries read a single base granule plus whatever patch granules cover it, so a varying split changes `PatchesReadRows` from 131072 to 327680 across runs of the same fill, and timings vary correspondingly.

Force the INSERT and the four UPDATEs to use a single thread, and set the insert block size large enough that the 10%-update patches stay in one part. Locally verified deterministic `PatchesReadRows` over 20 cycles for all four point-lookup queries. Setup time goes from ~4.2s to ~6.3s. The scan queries (#0-#3) still detect injected regressions in the patch-apply path (verified with a busy-wait at the top of `applyPatchesToBlock`: q0-q3 showed 12-23% slower, p<0.05; q4-q7 remained stable as expected).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.112`
<!-- ch-version-info:end -->