### PR TITLE
[CI Proof] Subquery caching missing overflow mode check allows caching truncated results

### DIFF
--- a/tests/queries/0_stateless/04262_qa_pr99804_proof.sql
+++ b/tests/queries/0_stateless/04262_qa_pr99804_proof.sql
@@ -1,0 +1,30 @@
+-- Tags: no-parallel, no-fasttest
+-- Tag no-parallel: Messes with internal cache
+-- Proof test for subquery caching missing overflow mode check
+-- Bug: checkCanWriteQueryResultCache in Planner.cpp doesn't validate overflow modes,
+-- allowing subqueries with overflow_mode != 'throw' to be cached
+
+DROP TABLE IF EXISTS overflow_cache_test;
+
+CREATE TABLE overflow_cache_test (x UInt64) ENGINE = MergeTree ORDER BY x AS SELECT number FROM numbers(100);
+
+SYSTEM DROP QUERY CACHE;
+
+-- Verify that the top-level query cache correctly rejects overflow modes (this works)
+SELECT sum(x) FROM overflow_cache_test SETTINGS read_overflow_mode = 'break', use_query_cache = 1; -- { serverError QUERY_CACHE_USED_WITH_NON_THROW_OVERFLOW_MODE }
+
+SYSTEM DROP QUERY CACHE;
+
+-- Bug: Subquery caching path should also reject overflow modes but doesn't
+-- Expected: throw QUERY_CACHE_USED_WITH_NON_THROW_OVERFLOW_MODE
+-- Actual (buggy): Query succeeds and caches truncated results
+SELECT * FROM (SELECT sum(x) FROM overflow_cache_test SETTINGS read_overflow_mode = 'break') SETTINGS use_query_cache = true, query_cache_for_subqueries = true; -- { serverError QUERY_CACHE_USED_WITH_NON_THROW_OVERFLOW_MODE }
+
+SYSTEM DROP QUERY CACHE;
+
+-- Test with group_by_overflow_mode (another overflow mode)
+SELECT * FROM (SELECT sum(x) FROM overflow_cache_test SETTINGS group_by_overflow_mode = 'break') SETTINGS use_query_cache = true, query_cache_for_subqueries = true; -- { serverError QUERY_CACHE_USED_WITH_NON_THROW_OVERFLOW_MODE }
+
+SYSTEM DROP QUERY CACHE;
+
+DROP TABLE overflow_cache_test;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

> ⚠️ **This is a CI proof PR — not a fix and not intended for merge.** It submits a test that could not be confirmed locally (code analysis strongly suggests a bug but local test did not trigger it — CI sanitizers and stress runs may catch it). **This PR will be closed automatically** once CI completes. If CI confirms the bug (TSan/ASan/cluster failure), a bug Issue will be filed separately.

**Suspected bug:** Subquery caching missing overflow mode check allows caching truncated results

**Root cause:** Planner.cpp:2613 calls checkCanWriteQueryResultCache which doesn't validate overflow modes. The overflow mode check exists only in executeQuery.cpp, not in the Planner's subquery caching path.

**Affected locations:**
- `src/Planner/Planner.cpp:2613` — checkCanWriteQueryResultCache call without overflow mode validation
- `src/Interpreters/Cache/QueryResultCache.cpp:208` — checkCanWriteQueryResultCache implementation lacks overflow mode check

**Why CI is needed:** Truncated query results can be silently cached and served to future queries when subqueries use non-THROW overflow modes. This defeats the purpose of the safety check in executeQuery.cpp that prevents caching incomplete results.

**Suggested fix:** Add overflow mode validation in checkCanWriteQueryResultCache (QueryResultCache.cpp) or before the cache write in Planner.cpp. Check all overflow_mode settings (read, read_leaf, group_by, sort, result, timeout, set, join, transfer, distinct) against OverflowMode::THROW, matching the check in executeQuery.cpp:1685-1695.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — temporary CI proof PR, will be closed automatically.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
