### PR TITLE
Fix `caseWithExpression` returning ELSE on `NULL = NULL`

### DIFF
--- a/src/Functions/caseWithExpression.cpp
+++ b/src/Functions/caseWithExpression.cpp
@@ -205,7 +205,7 @@ public:
             auto dst_supertype = tryGetLeastSupertype(dst_array_types);
             auto expr_type = removeNullable(args.front().type);
             bool can_use_transform = src_supertype && dst_supertype
-                && !src_supertype->isNullable()
+                && !isNullableOrLowCardinalityNullable(src_supertype)
                 && !isDynamic(expr_type)
                 && !isVariant(expr_type);
 

--- a/src/Functions/caseWithExpression.cpp
+++ b/src/Functions/caseWithExpression.cpp
@@ -197,19 +197,15 @@ public:
             /// `Decimal(9, 2)` (`Decimal32`).
             dst_array_types.push_back(args.back().type);
 
-            /// Check whether `transform` can handle these types.
-            /// `transform` casts WHEN values to the expression type; if WHEN values are Nullable
-            /// but the expression is non-Nullable, the cast will fail on NULLs.
+            /// `transform` uses standard equality (`NULL != NULL`), so skip it when WHEN values
+            /// are Nullable; `multiIf` via `caseWhenEquals` handles CASE's `NULL = NULL` semantics.
+            /// See https://github.com/ClickHouse/ClickHouse/issues/101262.
+            /// Also skip Dynamic/Variant: their hash-based lookup keys on type discriminator.
             auto src_supertype = tryGetLeastSupertype(src_array_types);
             auto dst_supertype = tryGetLeastSupertype(dst_array_types);
-
-            /// The `transform` function cannot handle Dynamic/Variant types because its
-            /// hash-based lookup includes the type discriminator, so values with the same
-            /// logical content but different stored subtypes (e.g. Dynamic(UInt8(1)) vs
-            /// Dynamic(Int64(1))) produce different hashes and never match.
             auto expr_type = removeNullable(args.front().type);
             bool can_use_transform = src_supertype && dst_supertype
-                && !(src_supertype->isNullable() && !args.front().type->isNullable())
+                && !src_supertype->isNullable()
                 && !isDynamic(expr_type)
                 && !isVariant(expr_type);
 

--- a/tests/queries/0_stateless/04259_case_with_expression_null_equals_null_101262.reference
+++ b/tests/queries/0_stateless/04259_case_with_expression_null_equals_null_101262.reference
@@ -1,0 +1,9 @@
+YES
+YES
+YES
+matched_null
+one
+else
+YES
+one
+other

--- a/tests/queries/0_stateless/04259_case_with_expression_null_equals_null_101262.sql
+++ b/tests/queries/0_stateless/04259_case_with_expression_null_equals_null_101262.sql
@@ -1,0 +1,16 @@
+-- https://github.com/ClickHouse/ClickHouse/issues/101262
+-- CASE semantics require NULL = NULL to be true. The `transform` optimization path
+-- uses standard equality, so it must be skipped when WHEN values are Nullable.
+
+SELECT caseWithExpression(materialize(NULL), NULL, 'YES', 'NO');
+SELECT caseWithExpression(materialize(NULL), materialize(NULL), 'YES', 'NO');
+SELECT caseWithExpression(materialize(CAST(NULL AS Nullable(Nothing))), CAST(NULL AS Nullable(Nothing)), 'YES', 'NO');
+
+SELECT caseWithExpression(materialize(CAST(NULL AS Nullable(Int32))), CAST(NULL AS Nullable(Int32)), 'matched_null', 1, 'one', 'else');
+SELECT caseWithExpression(materialize(toNullable(1)), CAST(NULL AS Nullable(Int32)), 'matched_null', 1, 'one', 'else');
+SELECT caseWithExpression(materialize(toNullable(5)), CAST(NULL AS Nullable(Int32)), 'matched_null', 1, 'one', 'else');
+
+SELECT CASE materialize(NULL) WHEN NULL THEN 'YES' ELSE 'NO' END;
+
+SELECT caseWithExpression(1, 1, 'one', 2, 'two', 'other');
+SELECT caseWithExpression(3, 1, 'one', 2, 'two', 'other');

--- a/tests/queries/0_stateless/04260_case_with_expression_lowcardinality_nullable_105556.reference
+++ b/tests/queries/0_stateless/04260_case_with_expression_lowcardinality_nullable_105556.reference
@@ -1,0 +1,5 @@
+YES
+YES
+\N	null_match
+1	one
+2	else

--- a/tests/queries/0_stateless/04260_case_with_expression_lowcardinality_nullable_105556.sql
+++ b/tests/queries/0_stateless/04260_case_with_expression_lowcardinality_nullable_105556.sql
@@ -1,0 +1,22 @@
+-- https://github.com/ClickHouse/ClickHouse/pull/105556#discussion_r3282578123
+-- Ensure CASE NULL = NULL semantics also hold when WHEN supertype is LowCardinality(Nullable).
+
+SET allow_suspicious_low_cardinality_types = 1;
+
+SELECT caseWithExpression(materialize(CAST(NULL AS LowCardinality(Nullable(Int32)))), CAST(NULL AS LowCardinality(Nullable(Int32))), 'YES', 'NO');
+SELECT caseWithExpression(materialize(CAST(NULL AS LowCardinality(Nullable(String)))), CAST(NULL AS LowCardinality(Nullable(String))), 'YES', 'NO');
+
+DROP TABLE IF EXISTS t_case_lc_nullable;
+CREATE TABLE t_case_lc_nullable (x LowCardinality(Nullable(Int32))) ENGINE = Memory;
+INSERT INTO t_case_lc_nullable VALUES (NULL), (1), (2);
+
+SELECT
+    x,
+    caseWithExpression(x,
+        CAST(NULL AS LowCardinality(Nullable(Int32))), 'null_match',
+        CAST(1 AS LowCardinality(Nullable(Int32))), 'one',
+        'else')
+FROM t_case_lc_nullable
+ORDER BY x NULLS FIRST;
+
+DROP TABLE t_case_lc_nullable;


### PR DESCRIPTION
Fixes #101262.

When all WHEN/THEN values are constant, `caseWithExpression` takes a `transform`-based fast path. `transform` uses standard equality (`NULL != NULL`), but CASE semantics require `NULL = NULL` to be true. The previous guard only skipped the fast path when the WHEN supertype was `Nullable` and the expression was non-`Nullable` (to avoid a cast exception); when both sides were `Nullable` the fast path was still taken and silently returned the `ELSE` branch instead of the matching `THEN`.

Tighten the guard to skip the fast path for any `Nullable` WHEN supertype, so the `multiIf` fallback (which uses `caseWhenEquals` with `NULL = NULL` semantics) runs in all the affected cases.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix `CASE` expression returning the `ELSE` branch instead of the matching `THEN` when both the expression and a `WHEN` value were `NULL`.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.94`
<!-- ch-version-info:end -->