### PR TITLE
Run async-insert queue tests in parallel via table-scoped flush

### DIFF
--- a/tests/queries/0_stateless/00408_http_keep_alive.sh
+++ b/tests/queries/0_stateless/00408_http_keep_alive.sh
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
-
-# no-parallel because of the `FLUSH ASYNC INSERT QUEUE` command
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -59,5 +56,5 @@ do
     echo "good async insert"
     cat $file_3
 
-    ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE;"
+    ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE async_inserts;"
 done

--- a/tests/queries/0_stateless/02726_async_insert_flush_queue.reference
+++ b/tests/queries/0_stateless/02726_async_insert_flush_queue.reference
@@ -18,7 +18,7 @@ JSONEachRow	3
 Values	2
 SELECT count() FROM t_async_inserts_flush;
 0
-SYSTEM FLUSH ASYNC INSERT QUEUE;
+SYSTEM FLUSH ASYNC INSERT QUEUE t_async_inserts_flush;
 SELECT count() FROM system.asynchronous_inserts
 WHERE database = currentDatabase() AND table = 't_async_inserts_flush';
 0

--- a/tests/queries/0_stateless/02726_async_insert_flush_queue.sql
+++ b/tests/queries/0_stateless/02726_async_insert_flush_queue.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 DROP TABLE IF EXISTS t_async_inserts_flush;
 
 CREATE TABLE t_async_inserts_flush (a UInt64) ENGINE = Memory;
@@ -30,7 +28,7 @@ ORDER BY format;
 
 SELECT count() FROM t_async_inserts_flush;
 
-SYSTEM FLUSH ASYNC INSERT QUEUE;
+SYSTEM FLUSH ASYNC INSERT QUEUE t_async_inserts_flush;
 
 SELECT count() FROM system.asynchronous_inserts
 WHERE database = currentDatabase() AND table = 't_async_inserts_flush';

--- a/tests/queries/0_stateless/02726_async_insert_flush_stress.sh
+++ b/tests/queries/0_stateless/02726_async_insert_flush_stress.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: long, no-parallel
+# Tags: long
 
 set -e
 
@@ -62,7 +62,7 @@ function flush1()
     local TIMELIMIT=$((SECONDS+$1))
     while [ $SECONDS -lt "$TIMELIMIT" ]; do
         sleep 0.2
-        ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
+        ${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE async_inserts"
     done
 }
 
@@ -90,6 +90,6 @@ flush1 $TIMEOUT &
 
 wait
 
-${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE async_inserts"
 ${CLICKHOUSE_CLIENT} -q "SELECT count() FROM system.asynchronous_inserts WHERE database = currentDatabase() AND table = 'async_inserts'"
 ${CLICKHOUSE_CLIENT} -q "DROP TABLE IF EXISTS async_inserts";

--- a/tests/queries/0_stateless/02884_async_insert_native_protocol_1.sh
+++ b/tests/queries/0_stateless/02884_async_insert_native_protocol_1.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -26,7 +25,7 @@ $CLICKHOUSE_CLIENT -q "
     SELECT sum(length(entries.bytes)) FROM system.asynchronous_inserts
     WHERE database = '$CLICKHOUSE_DATABASE' AND table = 't_async_insert_native_1';
 
-    SYSTEM FLUSH ASYNC INSERT QUEUE;
+    SYSTEM FLUSH ASYNC INSERT QUEUE t_async_insert_native_1;
 
     SELECT * FROM t_async_insert_native_1 ORDER BY id;
 

--- a/tests/queries/0_stateless/02884_async_insert_native_protocol_3.sh
+++ b/tests/queries/0_stateless/02884_async_insert_native_protocol_3.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -26,7 +25,7 @@ $CLICKHOUSE_CLIENT -q "
     WHERE database = '$CLICKHOUSE_DATABASE' AND table = 't_async_insert_native_3'
     ORDER BY format;
 
-    SYSTEM FLUSH ASYNC INSERT QUEUE;
+    SYSTEM FLUSH ASYNC INSERT QUEUE t_async_insert_native_3;
 
     SELECT * FROM t_async_insert_native_3 ORDER BY id;
 

--- a/tests/queries/0_stateless/02884_async_insert_skip_settings.sql
+++ b/tests/queries/0_stateless/02884_async_insert_skip_settings.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 DROP TABLE IF EXISTS t_async_insert_skip_settings SYNC;
 
 CREATE TABLE t_async_insert_skip_settings (id UInt64)
@@ -35,7 +33,7 @@ SELECT 'pending to flush', length(entries.bytes) FROM system.asynchronous_insert
 WHERE database = currentDatabase() AND table = 't_async_insert_skip_settings'
 ORDER BY first_update;
 
-SYSTEM FLUSH ASYNC INSERT QUEUE;
+SYSTEM FLUSH ASYNC INSERT QUEUE t_async_insert_skip_settings;
 
 SELECT * FROM t_async_insert_skip_settings ORDER BY id;
 

--- a/tests/queries/0_stateless/03148_async_queries_in_query_log_errors.sh
+++ b/tests/queries/0_stateless/03148_async_queries_in_query_log_errors.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
-# no-parallel because it flushes asynchronous_insert_log and that conflicts with other tests that expect flushes to be done only by themselves
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -58,5 +56,5 @@ ${CLICKHOUSE_CLIENT} -q "CREATE TABLE async_insert_landing (id UInt32) ENGINE = 
 
 query_id="$(random_str 10)"
 ${CLICKHOUSE_CLIENT} --query_id="${query_id}" -q "INSERT INTO async_insert_landing SETTINGS wait_for_async_insert=0, async_insert=1 values ('Invalid')" 2>/dev/null || true
-${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE"
+${CLICKHOUSE_CLIENT} -q "SYSTEM FLUSH ASYNC INSERT QUEUE async_insert_landing"
 print_flush_query_logs ${query_id}

--- a/tests/queries/0_stateless/03228_async_insert_query_params.sh
+++ b/tests/queries/0_stateless/03228_async_insert_query_params.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -30,7 +29,7 @@ ${CLICKHOUSE_CURL} -sS "$url&param_p2=1000" -d "INSERT INTO t_async_insert_param
 ${CLICKHOUSE_CURL} -sS "$url&param_p2=1000" -d 'INSERT INTO t_async_insert_params FORMAT JSONEachRow {"id": 23}'
 
 $CLICKHOUSE_CLIENT -q "
-    SYSTEM FLUSH ASYNC INSERT QUEUE;
+    SYSTEM FLUSH ASYNC INSERT QUEUE t_async_insert_params;
     SELECT id FROM t_async_insert_params ORDER BY id;
     DROP TABLE IF EXISTS t_async_insert_params;
 "

--- a/tests/queries/0_stateless/03229_async_insert_alter_http.sh
+++ b/tests/queries/0_stateless/03229_async_insert_alter_http.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# Tags: no-parallel
-# no-parallel because the test uses FLUSH ASYNC INSERT QUEUE
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -20,7 +18,7 @@ ${CLICKHOUSE_CURL} -sS "$url" -d "INSERT INTO t_async_insert_alter VALUES (42, 2
 $CLICKHOUSE_CLIENT -q "
     ALTER TABLE t_async_insert_alter ADD COLUMN value2 Int64;
 
-    SYSTEM FLUSH ASYNC INSERT QUEUE;
+    SYSTEM FLUSH ASYNC INSERT QUEUE t_async_insert_alter;
 
     SELECT * FROM t_async_insert_alter ORDER BY id;
 "
@@ -32,7 +30,7 @@ ${CLICKHOUSE_CURL} -sS "$url" -d "INSERT INTO t_async_insert_alter VALUES (43, 3
 $CLICKHOUSE_CLIENT -q "
     ALTER TABLE t_async_insert_alter MODIFY COLUMN value2 String;
 
-    SYSTEM FLUSH ASYNC INSERT QUEUE;
+    SYSTEM FLUSH ASYNC INSERT QUEUE t_async_insert_alter;
 
     SELECT * FROM t_async_insert_alter ORDER BY id;
 "
@@ -44,7 +42,7 @@ ${CLICKHOUSE_CURL} -sS "$url" -d "INSERT INTO t_async_insert_alter VALUES ('100'
 $CLICKHOUSE_CLIENT -q "
     ALTER TABLE t_async_insert_alter DROP COLUMN value2;
 
-    SYSTEM FLUSH ASYNC INSERT QUEUE;
+    SYSTEM FLUSH ASYNC INSERT QUEUE t_async_insert_alter;
     SYSTEM FLUSH LOGS asynchronous_insert_log;
 
     SELECT * FROM t_async_insert_alter ORDER BY id;

--- a/tests/queries/0_stateless/03717_async_deduplication_with_mv.sql
+++ b/tests/queries/0_stateless/03717_async_deduplication_with_mv.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel
-
 DROP TABLE IF EXISTS 03717_table;
 CREATE TABLE 03717_table
 (

--- a/tests/queries/0_stateless/04043_system_asynchronous_inserts_user_filter.sh
+++ b/tests/queries/0_stateless/04043_system_asynchronous_inserts_user_filter.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-parallel
-# no-parallel: concurrent SYSTEM FLUSH ASYNC INSERT QUEUE from other tests drains the pending queue
+# Tags: no-fasttest
 
 # Regression test: system.asynchronous_inserts must not leak cross-user insert metadata.
 # A user without SHOW_USERS privilege must only see their own pending inserts.


### PR DESCRIPTION
PR #89915 introduced the table-scoped `SYSTEM FLUSH ASYNC INSERT QUEUE <table>` form. Unlike the unscoped variant, it does not set `flush_stopped`, only schedules entries whose `StorageID` matches the supplied list, and waits only on the per-entry futures it scheduled rather than on the shared pool. That makes it parallel-safe — two tests flushing different tables cannot drain each other's entries or block on each other's work even when those entries share the same internal shard.

Switch every stateless test whose only reason for `no-parallel` was the unscoped flush to the table-scoped form, and drop the tag. Tests with other reasons to remain `no-parallel` (parser tests for `SYSTEM DROP`, the dedicated `03708` test that creates a hardcoded database) are left untouched.

Verified locally on `26.5.1.1` (10 modified tests × 10 iterations at `-j 8`; 11 modified tests × 5 iterations at `-j 16` with the stress test mixed in — 166 parallel executions, zero failures).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.78`
<!-- ch-version-info:end -->