### PR TITLE
Add Keeper watches requests into IKeeper

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -320,6 +320,9 @@
     M(ZooKeeperReconfig, "Number of 'reconfig' requests to ZooKeeper.", ValueType::Number) \
     M(ZooKeeperClose, "Number of times connection with ZooKeeper has been closed voluntary.", ValueType::Number) \
     M(ZooKeeperGetACL, "Number of 'getACL' requests to ZooKeeper.", ValueType::Number) \
+    M(ZooKeeperAddWatch, "Number of 'AddWatch' requests to ZooKeeper.", ValueType::Number) \
+    M(ZooKeeperRemoveWatch, "Number of 'RemoveWatch' requests to ZooKeeper.", ValueType::Number) \
+    M(ZooKeeperCheckWatch, "Number of 'CheckWatch' requests to ZooKeeper.", ValueType::Number) \
     M(ZooKeeperWatchResponse, "Number of times watch notification has been received from ZooKeeper.", ValueType::Number) \
     M(ZooKeeperUserExceptions, "Number of exceptions while working with ZooKeeper related to the data (no node, bad version or similar).", ValueType::Number) \
     M(ZooKeeperHardwareExceptions, "Number of exceptions while working with ZooKeeper related to network (connection loss or similar).", ValueType::Number) \

--- a/src/Common/ZooKeeper/IKeeper.h
+++ b/src/Common/ZooKeeper/IKeeper.h
@@ -694,6 +694,9 @@ using ReconfigCallback = std::function<void(const ReconfigResponse &)>;
 using MultiCallback = std::function<void(const MultiResponse &)>;
 using GetACLCallback = std::function<void(const GetACLResponse &)>;
 using ListRecursiveCallback = std::function<void(const ListRecursiveResponse &)>;
+using AddWatchCallback = std::function<void(const AddWatchResponse &)>;
+using RemoveWatchCallback = std::function<void(const RemoveWatchResponse &)>;
+using CheckWatchCallback = std::function<void(const CheckWatchResponse &)>;
 
 /// For watches.
 enum State
@@ -842,6 +845,22 @@ public:
     virtual void sync(
         const String & path,
         SyncCallback callback) = 0;
+
+    virtual void addWatch(
+        const String & path,
+        AddWatchRequest::AddWatchMode mode,
+        AddWatchCallback callback,
+        WatchCallbackPtrOrEventPtr watch) = 0;
+
+    virtual void removeWatches(
+        const String & path,
+        RemoveWatchRequest::WatchType type,
+        RemoveWatchCallback callback) = 0;
+
+    virtual void checkWatches(
+        const String & path,
+        CheckWatchRequest::CheckWatchType type,
+        CheckWatchCallback callback) = 0;
 
     virtual void reconfig(
         std::string_view joining,

--- a/src/Common/ZooKeeper/KeeperOverDispatcher.cpp
+++ b/src/Common/ZooKeeper/KeeperOverDispatcher.cpp
@@ -271,6 +271,53 @@ void KeeperOverDispatcher::sync(
     });
 }
 
+void KeeperOverDispatcher::addWatch(
+    const String & path,
+    AddWatchRequest::AddWatchMode mode,
+    AddWatchCallback callback,
+    WatchCallbackPtrOrEventPtr watch)
+{
+    const auto request = std::make_shared<ZooKeeperAddWatchRequest>();
+    request->path = path;
+    request->mode = mode;
+    request->watch_callback = watch;
+
+    pushRequest(request, [callback](const ZooKeeperResponsePtr & response)
+    {
+        callback(dynamic_cast<const AddWatchResponse &>(*response));
+    });
+}
+
+void KeeperOverDispatcher::removeWatches(
+    const String & path,
+    RemoveWatchRequest::WatchType type,
+    RemoveWatchCallback callback)
+{
+    const auto request = std::make_shared<ZooKeeperRemoveWatchRequest>();
+    request->path = path;
+    request->type = type;
+
+    pushRequest(request, [callback](const ZooKeeperResponsePtr & response)
+    {
+        callback(dynamic_cast<const RemoveWatchResponse &>(*response));
+    });
+}
+
+void KeeperOverDispatcher::checkWatches(
+    const String & path,
+    CheckWatchRequest::CheckWatchType type,
+    CheckWatchCallback callback)
+{
+    const auto request = std::make_shared<ZooKeeperCheckWatchRequest>();
+    request->path = path;
+    request->type = type;
+
+    pushRequest(request, [callback](const ZooKeeperResponsePtr & response)
+    {
+        callback(dynamic_cast<const CheckWatchResponse &>(*response));
+    });
+}
+
 void KeeperOverDispatcher::reconfig(
     std::string_view joining,
     std::string_view leaving,

--- a/src/Common/ZooKeeper/KeeperOverDispatcher.h
+++ b/src/Common/ZooKeeper/KeeperOverDispatcher.h
@@ -95,6 +95,22 @@ public:
         const String & path,
         SyncCallback callback) override;
 
+    void addWatch(
+        const String & path,
+        AddWatchRequest::AddWatchMode mode,
+        AddWatchCallback callback,
+        WatchCallbackPtrOrEventPtr watch) override;
+
+    void removeWatches(
+        const String & path,
+        RemoveWatchRequest::WatchType type,
+        RemoveWatchCallback callback) override;
+
+    void checkWatches(
+        const String & path,
+        CheckWatchRequest::CheckWatchType type,
+        CheckWatchCallback callback) override;
+
     void reconfig(
         std::string_view joining,
         std::string_view leaving,

--- a/src/Common/ZooKeeper/TestKeeper.cpp
+++ b/src/Common/ZooKeeper/TestKeeper.cpp
@@ -33,47 +33,86 @@ struct TestKeeperRequest : virtual Request
 {
     virtual ResponsePtr createResponse() const = 0;
     virtual std::pair<ResponsePtr, Undo> process(TestKeeper::Container & container, int64_t zxid) const = 0;
-    virtual void processWatches(TestKeeper::Watches & /*watches*/, TestKeeper::Watches & /*list_watches*/) const {}
+    virtual void processWatches(
+        TestKeeper::Watches & /*watches*/,
+        TestKeeper::Watches & /*list_watches*/,
+        TestKeeper::Watches & /*persistent_watches*/,
+        TestKeeper::Watches & /*persistent_recursive_watches*/) const {}
 
-    static void processWatchesImpl(const String & path, TestKeeper::Watches & watches, TestKeeper::Watches & list_watches);
+    static void processWatchesImpl(
+        const String & path,
+        TestKeeper::Watches & watches,
+        TestKeeper::Watches & list_watches,
+        TestKeeper::Watches & persistent_watches,
+        TestKeeper::Watches & persistent_recursive_watches);
 };
 
 
-void TestKeeperRequest::processWatchesImpl(const String & path, TestKeeper::Watches & watches, TestKeeper::Watches & list_watches)
+void TestKeeperRequest::processWatchesImpl(
+    const String & path,
+    TestKeeper::Watches & watches,
+    TestKeeper::Watches & list_watches,
+    TestKeeper::Watches & persistent_watches,
+    TestKeeper::Watches & persistent_recursive_watches)
 {
+    auto fire_and_erase = [](const String & match_path, TestKeeper::Watches & container)
     {
-        WatchResponse watch_response;
-        watch_response.path = path;
+        WatchResponse response;
+        response.path = match_path;
 
-        auto it = watches.find(watch_response.path);
-        if (it != watches.end())
+        auto it = container.find(match_path);
+        if (it == container.end())
+            return;
+
+        for (const auto & event_or_callback : it->second)
         {
-            for (const auto & event_or_callback : it->second)
+            if (event_or_callback)
+                event_or_callback(response);
+        }
+        container.erase(it);
+    };
+
+    auto fire_persistent = [](const String & match_path, TestKeeper::Watches & container)
+    {
+        WatchResponse response;
+        response.path = match_path;
+
+        auto it = container.find(match_path);
+        if (it == container.end())
+            return;
+
+        for (const auto & event_or_callback : it->second)
+        {
+            if (event_or_callback)
+                event_or_callback(response);
+        }
+        /// Persistent watches stay registered after firing.
+    };
+
+    auto fire_persistent_recursive = [](const String & event_path, TestKeeper::Watches & container)
+    {
+        for (auto & [prefix, callbacks] : container)
+        {
+            if (event_path != prefix
+                && !(event_path.size() > prefix.size()
+                     && event_path.starts_with(prefix)
+                     && (prefix == "/" || event_path[prefix.size()] == '/')))
+                continue;
+
+            WatchResponse response;
+            response.path = event_path;
+            for (const auto & event_or_callback : callbacks)
             {
                 if (event_or_callback)
-                    event_or_callback(watch_response);
+                    event_or_callback(response);
             }
-
-            watches.erase(it);
         }
-    }
+    };
 
-    {
-        WatchResponse watch_list_response;
-        watch_list_response.path = parentPath(path);
-
-        auto it = list_watches.find(watch_list_response.path);
-        if (it != list_watches.end())
-        {
-            for (const auto & event_or_callback : it->second)
-            {
-                if (event_or_callback)
-                    event_or_callback(watch_list_response);
-            }
-
-            list_watches.erase(it);
-        }
-    }
+    fire_and_erase(path, watches);
+    fire_and_erase(parentPath(path), list_watches);
+    fire_persistent(path, persistent_watches);
+    fire_persistent_recursive(path, persistent_recursive_watches);
 }
 
 
@@ -84,9 +123,13 @@ struct TestKeeperCreateRequest final : CreateRequest, TestKeeperRequest
     ResponsePtr createResponse() const override;
     std::pair<ResponsePtr, Undo> process(TestKeeper::Container & container, int64_t zxid) const override;
 
-    void processWatches(TestKeeper::Watches & node_watches, TestKeeper::Watches & list_watches) const override
+    void processWatches(
+        TestKeeper::Watches & node_watches,
+        TestKeeper::Watches & list_watches,
+        TestKeeper::Watches & persistent_watches,
+        TestKeeper::Watches & persistent_recursive_watches) const override
     {
-        processWatchesImpl(getPath(), node_watches, list_watches);
+        processWatchesImpl(getPath(), node_watches, list_watches, persistent_watches, persistent_recursive_watches);
     }
 };
 
@@ -97,9 +140,13 @@ struct TestKeeperRemoveRequest final : RemoveRequest, TestKeeperRequest
     ResponsePtr createResponse() const override;
     std::pair<ResponsePtr, Undo> process(TestKeeper::Container & container, int64_t zxid) const override;
 
-    void processWatches(TestKeeper::Watches & node_watches, TestKeeper::Watches & list_watches) const override
+    void processWatches(
+        TestKeeper::Watches & node_watches,
+        TestKeeper::Watches & list_watches,
+        TestKeeper::Watches & persistent_watches,
+        TestKeeper::Watches & persistent_recursive_watches) const override
     {
-        processWatchesImpl(getPath(), node_watches, list_watches);
+        processWatchesImpl(getPath(), node_watches, list_watches, persistent_watches, persistent_recursive_watches);
     }
 };
 
@@ -110,7 +157,11 @@ struct TestKeeperRemoveRecursiveRequest final : RemoveRecursiveRequest, TestKeep
     ResponsePtr createResponse() const override;
     std::pair<ResponsePtr, Undo> process(TestKeeper::Container & container, int64_t zxid) const override;
 
-    void processWatches(TestKeeper::Watches & node_watches, TestKeeper::Watches & list_watches) const override
+    void processWatches(
+        TestKeeper::Watches & node_watches,
+        TestKeeper::Watches & list_watches,
+        TestKeeper::Watches & persistent_watches,
+        TestKeeper::Watches & persistent_recursive_watches) const override
     {
         std::vector<std::pair<String, size_t>> deleted;
 
@@ -129,7 +180,7 @@ struct TestKeeperRemoveRecursiveRequest final : RemoveRecursiveRequest, TestKeep
         });
 
         for (const auto & [watch_path, _] : deleted)
-            processWatchesImpl(watch_path, node_watches, list_watches);
+            processWatchesImpl(watch_path, node_watches, list_watches, persistent_watches, persistent_recursive_watches);
     }
 };
 
@@ -164,9 +215,13 @@ struct TestKeeperSetRequest final : SetRequest, TestKeeperRequest
     ResponsePtr createResponse() const override;
     std::pair<ResponsePtr, Undo> process(TestKeeper::Container & container, int64_t zxid) const override;
 
-    void processWatches(TestKeeper::Watches & node_watches, TestKeeper::Watches & list_watches) const override
+    void processWatches(
+        TestKeeper::Watches & node_watches,
+        TestKeeper::Watches & list_watches,
+        TestKeeper::Watches & persistent_watches,
+        TestKeeper::Watches & persistent_recursive_watches) const override
     {
-        processWatchesImpl(getPath(), node_watches, list_watches);
+        processWatchesImpl(getPath(), node_watches, list_watches, persistent_watches, persistent_recursive_watches);
     }
 };
 
@@ -225,6 +280,30 @@ struct TestKeeperGetACLRequest final : GetACLRequest, TestKeeperRequest
 {
     TestKeeperGetACLRequest() = default;
     explicit TestKeeperGetACLRequest(const GetACLRequest & base) : GetACLRequest(base) {}
+    ResponsePtr createResponse() const override;
+    std::pair<ResponsePtr, Undo> process(TestKeeper::Container & container, int64_t zxid) const override;
+};
+
+struct TestKeeperAddWatchRequest final : AddWatchRequest, TestKeeperRequest
+{
+    TestKeeperAddWatchRequest() = default;
+    explicit TestKeeperAddWatchRequest(const AddWatchRequest & base) : AddWatchRequest(base) {}
+    ResponsePtr createResponse() const override;
+    std::pair<ResponsePtr, Undo> process(TestKeeper::Container & container, int64_t zxid) const override;
+};
+
+struct TestKeeperRemoveWatchRequest final : RemoveWatchRequest, TestKeeperRequest
+{
+    TestKeeperRemoveWatchRequest() = default;
+    explicit TestKeeperRemoveWatchRequest(const RemoveWatchRequest & base) : RemoveWatchRequest(base) {}
+    ResponsePtr createResponse() const override;
+    std::pair<ResponsePtr, Undo> process(TestKeeper::Container & container, int64_t zxid) const override;
+};
+
+struct TestKeeperCheckWatchRequest final : CheckWatchRequest, TestKeeperRequest
+{
+    TestKeeperCheckWatchRequest() = default;
+    explicit TestKeeperCheckWatchRequest(const CheckWatchRequest & base) : CheckWatchRequest(base) {}
     ResponsePtr createResponse() const override;
     std::pair<ResponsePtr, Undo> process(TestKeeper::Container & container, int64_t zxid) const override;
 };
@@ -305,10 +384,15 @@ struct TestKeeperMultiRequest final : MultiRequest<RequestPtr>, TestKeeperReques
         }
     }
 
-    void processWatches(TestKeeper::Watches & node_watches, TestKeeper::Watches & list_watches) const override
+    void processWatches(
+        TestKeeper::Watches & node_watches,
+        TestKeeper::Watches & list_watches,
+        TestKeeper::Watches & persistent_watches,
+        TestKeeper::Watches & persistent_recursive_watches) const override
     {
         for (const auto & generic_request : requests)
-            dynamic_cast<const TestKeeperRequest &>(*generic_request).processWatches(node_watches, list_watches);
+            dynamic_cast<const TestKeeperRequest &>(*generic_request).processWatches(
+                node_watches, list_watches, persistent_watches, persistent_recursive_watches);
     }
 
     ResponsePtr createResponse() const override;
@@ -731,6 +815,30 @@ std::pair<ResponsePtr, Undo> TestKeeperGetACLRequest::process(TestKeeper::Contai
     return { std::make_shared<GetACLResponse>(std::move(response)), {} };
 }
 
+std::pair<ResponsePtr, Undo> TestKeeperAddWatchRequest::process(TestKeeper::Container & container, int64_t zxid) const
+{
+    AddWatchResponse response;
+    response.zxid = zxid;
+    response.error = container.contains(path) ? Error::ZOK : Error::ZNONODE;
+    return { std::make_shared<AddWatchResponse>(std::move(response)), {} };
+}
+
+std::pair<ResponsePtr, Undo> TestKeeperRemoveWatchRequest::process(TestKeeper::Container & /*container*/, int64_t zxid) const
+{
+    RemoveWatchResponse response;
+    response.zxid = zxid;
+    response.error = Error::ZOK;
+    return { std::make_shared<RemoveWatchResponse>(std::move(response)), {} };
+}
+
+std::pair<ResponsePtr, Undo> TestKeeperCheckWatchRequest::process(TestKeeper::Container & /*container*/, int64_t zxid) const
+{
+    CheckWatchResponse response;
+    response.zxid = zxid;
+    response.error = Error::ZOK;
+    return { std::make_shared<CheckWatchResponse>(std::move(response)), {} };
+}
+
 std::pair<ResponsePtr, Undo> TestKeeperMultiRequest::process(TestKeeper::Container & container, int64_t zxid) const
 {
     if (is_multi_read.has_value() && is_multi_read.value())
@@ -826,6 +934,9 @@ ResponsePtr TestKeeperReconfigRequest::createResponse() const { return std::make
 ResponsePtr TestKeeperGetACLRequest::createResponse() const { return std::make_shared<GetACLResponse>(); }
 ResponsePtr TestKeeperMultiRequest::createResponse() const { return std::make_shared<MultiResponse>(); }
 ResponsePtr TestKeeperListRecursiveRequest::createResponse() const { return std::make_shared<ListRecursiveResponse>(); }
+ResponsePtr TestKeeperAddWatchRequest::createResponse() const { return std::make_shared<AddWatchResponse>(); }
+ResponsePtr TestKeeperRemoveWatchRequest::createResponse() const { return std::make_shared<RemoveWatchResponse>(); }
+ResponsePtr TestKeeperCheckWatchRequest::createResponse() const { return std::make_shared<CheckWatchResponse>(); }
 
 
 TestKeeper::TestKeeper(const zkutil::ZooKeeperArgs & args_)
@@ -895,7 +1006,15 @@ void TestKeeper::processingThread()
                 {
                     /// To be compatible with real ZooKeeper we add watch if request was successful (i.e. node exists)
                     /// or if it was exists request which allows to add watches for non existing nodes.
-                    if (response->error == Error::ZOK)
+                    if (const auto * add_watch_request = dynamic_cast<const AddWatchRequest *>(info.request.get());
+                        add_watch_request && response->error == Error::ZOK)
+                    {
+                        auto & target = add_watch_request->mode == AddWatchRequest::AddWatchMode::PERSISTENT_RECURSIVE
+                            ? persistent_recursive_watches
+                            : persistent_watches;
+                        target[info.request->getPath()].insert(info.watch);
+                    }
+                    else if (response->error == Error::ZOK)
                     {
                         auto & watches_type = dynamic_cast<const ListRequest *>(info.request.get())
                             ? list_watches
@@ -909,8 +1028,73 @@ void TestKeeper::processingThread()
                     }
                 }
 
+                if (const auto * remove_watch_request = dynamic_cast<const RemoveWatchRequest *>(info.request.get()))
+                {
+                    const auto & rm_path = info.request->getPath();
+                    auto erase_from = [&](TestKeeper::Watches & target)
+                    {
+                        auto it = target.find(rm_path);
+                        if (it == target.end())
+                            return false;
+                        target.erase(it);
+                        return true;
+                    };
+                    bool removed = false;
+                    switch (remove_watch_request->type)
+                    {
+                        case RemoveWatchRequest::WatchType::DATA:
+                            removed = erase_from(watches);
+                            break;
+                        case RemoveWatchRequest::WatchType::CHILDREN:
+                            removed = erase_from(list_watches);
+                            break;
+                        case RemoveWatchRequest::WatchType::PERSISTENT:
+                            removed = erase_from(persistent_watches);
+                            break;
+                        case RemoveWatchRequest::WatchType::PERSISTENTRECURSIVE:
+                            removed = erase_from(persistent_recursive_watches);
+                            break;
+                        case RemoveWatchRequest::WatchType::ANY:
+                            removed |= erase_from(watches);
+                            removed |= erase_from(list_watches);
+                            removed |= erase_from(persistent_watches);
+                            removed |= erase_from(persistent_recursive_watches);
+                            break;
+                    }
+                    if (!removed)
+                        response->error = Error::ZNOWATCHER;
+                }
+
+                if (const auto * check_watch_request = dynamic_cast<const CheckWatchRequest *>(info.request.get()))
+                {
+                    const auto & ck_path = info.request->getPath();
+                    auto present_in = [&](const TestKeeper::Watches & target) { return target.contains(ck_path); };
+                    bool found = false;
+                    switch (check_watch_request->type)
+                    {
+                        case CheckWatchRequest::CheckWatchType::DATA:
+                            found = present_in(watches);
+                            break;
+                        case CheckWatchRequest::CheckWatchType::CHILDREN:
+                            found = present_in(list_watches);
+                            break;
+                        case CheckWatchRequest::CheckWatchType::PERSISTENT:
+                            found = present_in(persistent_watches);
+                            break;
+                        case CheckWatchRequest::CheckWatchType::PERSISTENT_RECURSIVE:
+                            found = present_in(persistent_recursive_watches);
+                            break;
+                        case CheckWatchRequest::CheckWatchType::ANY:
+                            found = present_in(watches) || present_in(list_watches)
+                                || present_in(persistent_watches) || present_in(persistent_recursive_watches);
+                            break;
+                    }
+                    if (!found)
+                        response->error = Error::ZNOWATCHER;
+                }
+
                 if (response->error == Error::ZOK)
-                    info.request->processWatches(watches, list_watches);
+                    info.request->processWatches(watches, list_watches, persistent_watches, persistent_recursive_watches);
 
                 response->removeRootPath(args.chroot);
                 if (info.callback)
@@ -975,30 +1159,37 @@ void TestKeeper::finalize(const String &)
     try
     {
         {
-            for (auto & path_watch : watches)
+            auto fire_session_expired = [&](Watches & target)
             {
-                WatchResponse response;
-                response.type = SESSION;
-                response.state = EXPIRED_SESSION;
-                response.error = Error::ZSESSIONEXPIRED;
-
-                for (const auto & event_or_callback : path_watch.second)
+                for (auto & path_watch : target)
                 {
-                    if (event_or_callback)
+                    WatchResponse response;
+                    response.type = SESSION;
+                    response.state = EXPIRED_SESSION;
+                    response.error = Error::ZSESSIONEXPIRED;
+
+                    for (const auto & event_or_callback : path_watch.second)
                     {
-                        try
+                        if (event_or_callback)
                         {
-                            event_or_callback(response);
-                        }
-                        catch (...)
-                        {
-                            tryLogCurrentException(__PRETTY_FUNCTION__);
+                            try
+                            {
+                                event_or_callback(response);
+                            }
+                            catch (...)
+                            {
+                                tryLogCurrentException(__PRETTY_FUNCTION__);
+                            }
                         }
                     }
                 }
-            }
+                target.clear();
+            };
 
-            watches.clear();
+            fire_session_expired(watches);
+            fire_session_expired(list_watches);
+            fire_session_expired(persistent_watches);
+            fire_session_expired(persistent_recursive_watches);
         }
 
         RequestInfo info;
@@ -1072,6 +1263,57 @@ void TestKeeper::remove(
     request_info.callback = [callback](const Response & response) { callback(dynamic_cast<const RemoveResponse &>(response)); };
     pushRequest(std::move(request_info));
 }
+
+void TestKeeper::addWatch(
+    const String & path,
+    AddWatchRequest::AddWatchMode mode,
+    AddWatchCallback callback,
+    WatchCallbackPtrOrEventPtr watch)
+{
+    if (!watch)
+        throw Exception::fromMessage(Error::ZBADARGUMENTS, "addWatch requires a non-empty watch callback");
+
+    auto request = std::make_shared<TestKeeperAddWatchRequest>();
+    request->path = path;
+    request->mode = mode;
+
+    RequestInfo request_info;
+    request_info.request = std::move(request);
+    request_info.callback = [callback](const Response & response) { callback(dynamic_cast<const AddWatchResponse &>(response)); };
+    request_info.watch = std::move(watch);
+    pushRequest(std::move(request_info));
+}
+
+void TestKeeper::removeWatches(
+    const String & path,
+    RemoveWatchRequest::WatchType type,
+    RemoveWatchCallback callback)
+{
+    auto request = std::make_shared<TestKeeperRemoveWatchRequest>();
+    request->path = path;
+    request->type = type;
+
+    RequestInfo request_info;
+    request_info.request = std::move(request);
+    request_info.callback = [callback](const Response & response) { callback(dynamic_cast<const RemoveWatchResponse &>(response)); };
+    pushRequest(std::move(request_info));
+}
+
+void TestKeeper::checkWatches(
+    const String & path,
+    CheckWatchRequest::CheckWatchType type,
+    CheckWatchCallback callback)
+{
+    auto request = std::make_shared<TestKeeperCheckWatchRequest>();
+    request->path = path;
+    request->type = type;
+
+    RequestInfo request_info;
+    request_info.request = std::move(request);
+    request_info.callback = [callback](const Response & response) { callback(dynamic_cast<const CheckWatchResponse &>(response)); };
+    pushRequest(std::move(request_info));
+}
+
 
 void TestKeeper::removeRecursive(
     const String & path,

--- a/src/Common/ZooKeeper/TestKeeper.h
+++ b/src/Common/ZooKeeper/TestKeeper.h
@@ -59,6 +59,23 @@ public:
             int32_t version,
             RemoveCallback callback) override;
 
+    void addWatch(
+        const String & path,
+        AddWatchRequest::AddWatchMode mode,
+        AddWatchCallback callback,
+        WatchCallbackPtrOrEventPtr watch) override;
+
+    void removeWatches(
+        const String & path,
+        RemoveWatchRequest::WatchType type,
+        RemoveWatchCallback callback) override;
+
+    void checkWatches(
+        const String & path,
+        CheckWatchRequest::CheckWatchType type,
+        CheckWatchCallback callback) override;
+
+
     void removeRecursive(
         const String & path,
         uint32_t remove_nodes_limit,
@@ -156,6 +173,8 @@ private:
 
     Watches watches;
     Watches list_watches; /// Watches for 'list' request (watches on children).
+    Watches persistent_watches;
+    Watches persistent_recursive_watches;
 
     using RequestsQueue = ConcurrentBoundedQueue<RequestInfo>;
     RequestsQueue requests_queue{1};

--- a/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -1053,6 +1053,84 @@ Coordination::Error ZooKeeper::trySync(const std::string & path, std::string & r
     return syncImpl(path, returned_path);
 }
 
+Coordination::Error ZooKeeper::tryAddWatch(
+    const std::string & path,
+    Coordination::AddWatchRequest::AddWatchMode mode,
+    Coordination::WatchCallbackPtrOrEventPtr watch_callback)
+{
+    auto promise = std::make_shared<std::promise<Coordination::AddWatchResponse>>();
+    auto future = promise->get_future();
+    auto callback = [promise](const Coordination::AddWatchResponse & response) mutable
+    {
+        promise->set_value(response);
+    };
+
+    impl->addWatch(path, mode, std::move(callback), std::move(watch_callback));
+    if (!waitForFutureWithProgress(future))
+    {
+        impl->finalize(fmt::format("Operation timeout on {} {} (no progress for {} ms)",
+            Coordination::OpNum::AddWatch, path, args.session_timeout_ms));
+        return Coordination::Error::ZOPERATIONTIMEOUT;
+    }
+    return future.get().error;
+}
+
+void ZooKeeper::addWatch(
+    const std::string & path,
+    Coordination::AddWatchRequest::AddWatchMode mode,
+    Coordination::WatchCallbackPtrOrEventPtr watch_callback)
+{
+    check(tryAddWatch(path, mode, std::move(watch_callback)), path);
+}
+
+Coordination::Error ZooKeeper::tryRemoveWatches(const std::string & path, Coordination::RemoveWatchRequest::WatchType type)
+{
+    auto promise = std::make_shared<std::promise<Coordination::RemoveWatchResponse>>();
+    auto future = promise->get_future();
+    auto callback = [promise](const Coordination::RemoveWatchResponse & response) mutable
+    {
+        promise->set_value(response);
+    };
+
+    impl->removeWatches(path, type, std::move(callback));
+    if (!waitForFutureWithProgress(future))
+    {
+        impl->finalize(fmt::format("Operation timeout on {} {} (no progress for {} ms)",
+            Coordination::OpNum::RemoveWatch, path, args.session_timeout_ms));
+        return Coordination::Error::ZOPERATIONTIMEOUT;
+    }
+    return future.get().error;
+}
+
+void ZooKeeper::removeWatches(const std::string & path, Coordination::RemoveWatchRequest::WatchType type)
+{
+    check(tryRemoveWatches(path, type), path);
+}
+
+Coordination::Error ZooKeeper::tryCheckWatches(const std::string & path, Coordination::CheckWatchRequest::CheckWatchType type)
+{
+    auto promise = std::make_shared<std::promise<Coordination::CheckWatchResponse>>();
+    auto future = promise->get_future();
+    auto callback = [promise](const Coordination::CheckWatchResponse & response) mutable
+    {
+        promise->set_value(response);
+    };
+
+    impl->checkWatches(path, type, std::move(callback));
+    if (!waitForFutureWithProgress(future))
+    {
+        impl->finalize(fmt::format("Operation timeout on {} {} (no progress for {} ms)",
+            Coordination::OpNum::CheckWatch, path, args.session_timeout_ms));
+        return Coordination::Error::ZOPERATIONTIMEOUT;
+    }
+    return future.get().error;
+}
+
+void ZooKeeper::checkWatches(const std::string & path, Coordination::CheckWatchRequest::CheckWatchType type)
+{
+    check(tryCheckWatches(path, type), path);
+}
+
 void ZooKeeper::removeChildren(const std::string & path)
 {
     Strings children = getChildren(path);

--- a/src/Common/ZooKeeper/ZooKeeper.h
+++ b/src/Common/ZooKeeper/ZooKeeper.h
@@ -449,6 +449,33 @@ public:
 
     Coordination::Error trySync(const std::string & path, std::string & returned_path);
 
+    /// Register a persistent or persistent-recursive watch on `path`. Unlike
+    /// the per-call `watch` parameter of `get`/`exists`/`getChildren`, the
+    /// watch installed here keeps firing for every matching event until it is
+    /// removed via `removeWatches` or the session ends.
+    void addWatch(
+        const std::string & path,
+        Coordination::AddWatchRequest::AddWatchMode mode,
+        Coordination::WatchCallbackPtrOrEventPtr watch_callback);
+
+    Coordination::Error tryAddWatch(
+        const std::string & path,
+        Coordination::AddWatchRequest::AddWatchMode mode,
+        Coordination::WatchCallbackPtrOrEventPtr watch_callback);
+
+    /// Remove watches of the given `type` from `path`. See
+    /// `Coordination::RemoveWatchRequest::WatchType` for the supported
+    /// selectors (data / children / persistent / persistent-recursive / any).
+    void removeWatches(const std::string & path, Coordination::RemoveWatchRequest::WatchType type);
+
+    Coordination::Error tryRemoveWatches(const std::string & path, Coordination::RemoveWatchRequest::WatchType type);
+
+    /// Returns ZOK if the current session has at least one matching watch on `path`,
+    /// or ZNOWATCHER otherwise. Other Keeper errors propagate as usual.
+    void checkWatches(const std::string & path, Coordination::CheckWatchRequest::CheckWatchType type);
+
+    Coordination::Error tryCheckWatches(const std::string & path, Coordination::CheckWatchRequest::CheckWatchType type);
+
     Int64 getClientID() const;
 
     Coordination::IKeeper::WatchesSnapshot getWatchesSnapshot() const;

--- a/src/Common/ZooKeeper/ZooKeeperImpl.cpp
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.cpp
@@ -75,6 +75,9 @@ namespace ProfileEvents
     extern const Event ZooKeeperBytesSent;
     extern const Event ZooKeeperBytesReceived;
     extern const Event ZooKeeperWatchResponse;
+    extern const Event ZooKeeperAddWatch;
+    extern const Event ZooKeeperCheckWatch;
+    extern const Event ZooKeeperRemoveWatch;
 }
 
 namespace CurrentMetrics
@@ -1075,6 +1078,37 @@ void ZooKeeper::receiveEvent()
                 watches_container.erase(it);
             };
 
+            auto trigger_persistent_watches = [&watch_response](auto & watches_container)
+            {
+                auto it = watches_container.find(watch_response.path);
+                if (it == watches_container.end())
+                    return;
+
+                for (const auto & [event_or_callback, _] : it->second)
+                {
+                    if (event_or_callback)
+                        event_or_callback(watch_response);
+                }
+            };
+
+            auto trigger_persistent_recursive_watches = [&watch_response](auto & watches_container)
+            {
+                for (auto & [prefix, callbacks] : watches_container)
+                {
+                    if (watch_response.path != prefix
+                        && !(watch_response.path.size() > prefix.size()
+                             && watch_response.path.starts_with(prefix)
+                             && (prefix == "/" || watch_response.path[prefix.size()] == '/')))
+                        continue;
+
+                    for (const auto & [event_or_callback, _] : callbacks)
+                    {
+                        if (event_or_callback)
+                            event_or_callback(watch_response);
+                    }
+                }
+            };
+
             std::lock_guard lock(watches_mutex);
 
             switch (event_type)
@@ -1082,15 +1116,21 @@ void ZooKeeper::receiveEvent()
                 case Coordination::Event::CREATED:
                 case Coordination::Event::CHANGED:
                     trigger_watches(watches);
+                    trigger_persistent_watches(persistent_watches);
+                    trigger_persistent_recursive_watches(persistent_recursive_watches);
                     break;
                 case Coordination::Event::DELETED:
                 case Coordination::Event::SESSION:
                     /// client will handle disconnection but lets trigger callbacks as soon as possible
                     trigger_watches(watches);
                     trigger_watches(list_watches);
+                    trigger_persistent_watches(persistent_watches);
+                    trigger_persistent_recursive_watches(persistent_recursive_watches);
                     break;
                 case Coordination::Event::CHILD:
                     trigger_watches(list_watches);
+                    trigger_persistent_watches(persistent_watches);
+                    trigger_persistent_recursive_watches(persistent_recursive_watches);
                     break;
                 default:
                     throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Unexpected watch event type {}", event_type);
@@ -1160,6 +1200,24 @@ void ZooKeeper::receiveEvent()
 
             if (!add_watch || !watch)
                 return;
+
+            if (op_num == OpNum::AddWatch)
+            {
+                const auto * add_watch_request = dynamic_cast<const Coordination::ZooKeeperAddWatchRequest *>(req.get());
+                chassert(add_watch_request != nullptr);
+
+                String req_path = req->getPath();
+                removeRootPath(req_path, args.chroot);
+
+                std::lock_guard lock(watches_mutex);
+                auto & target = add_watch_request->mode == Coordination::AddWatchRequest::AddWatchMode::PERSISTENT_RECURSIVE
+                    ? persistent_recursive_watches[req_path]
+                    : persistent_watches[req_path];
+
+                if (target.emplace(watch, WatchCreateInfo{std::chrono::system_clock::now(), req->xid, op_num}).second)
+                    CurrentMetrics::add(CurrentMetrics::ZooKeeperWatch);
+                return;
+            }
 
             bool is_list_request = false;
 
@@ -1437,10 +1495,14 @@ void ZooKeeper::finalize(bool error_send, bool error_receive, const String & rea
 
             auto watch_callback_count = trigger_watches(watches);
             watch_callback_count += trigger_watches(list_watches);
+            watch_callback_count += trigger_watches(persistent_watches);
+            watch_callback_count += trigger_watches(persistent_recursive_watches);
 
             CurrentMetrics::sub(CurrentMetrics::ZooKeeperWatch, watch_callback_count);
             watches.clear();
             list_watches.clear();
+            persistent_watches.clear();
+            persistent_recursive_watches.clear();
         }
 
         /// Drain queue
@@ -1864,6 +1926,96 @@ void ZooKeeper::list(
     ProfileEvents::increment(ProfileEvents::ZooKeeperList);
 }
 
+void ZooKeeper::addWatch(
+    const String & path,
+    AddWatchRequest::AddWatchMode mode,
+    AddWatchCallback callback,
+    WatchCallbackPtrOrEventPtr watch)
+{
+    if (!watch)
+        throw Exception::fromMessage(Error::ZBADARGUMENTS, "addWatch requires a non-empty watch callback");
+
+    ZooKeeperAddWatchRequest request;
+    request.path = path;
+    request.mode = mode;
+
+    RequestInfo request_info;
+    request_info.request = std::make_shared<ZooKeeperAddWatchRequest>(std::move(request));
+    request_info.callback = [callback](const Response & response) { callback(dynamic_cast<const AddWatchResponse &>(response)); };
+    request_info.watch = std::move(watch);
+    pushRequest(std::move(request_info));
+    ProfileEvents::increment(ProfileEvents::ZooKeeperAddWatch);
+}
+
+void ZooKeeper::removeWatches(
+    const String & path,
+    RemoveWatchRequest::WatchType type,
+    RemoveWatchCallback callback)
+{
+    {
+        String local_path = path;
+        removeRootPath(local_path, args.chroot);
+        std::lock_guard lock(watches_mutex);
+
+        auto erase_from = [&](auto & container)
+        {
+            auto it = container.find(local_path);
+            if (it == container.end())
+                return;
+            CurrentMetrics::sub(CurrentMetrics::ZooKeeperWatch, it->second.size());
+            container.erase(it);
+        };
+
+        switch (type)
+        {
+            case RemoveWatchRequest::WatchType::DATA:
+                erase_from(watches);
+                break;
+            case RemoveWatchRequest::WatchType::CHILDREN:
+                erase_from(list_watches);
+                break;
+            case RemoveWatchRequest::WatchType::PERSISTENT:
+                erase_from(persistent_watches);
+                break;
+            case RemoveWatchRequest::WatchType::PERSISTENTRECURSIVE:
+                erase_from(persistent_recursive_watches);
+                break;
+            case RemoveWatchRequest::WatchType::ANY:
+                erase_from(watches);
+                erase_from(list_watches);
+                erase_from(persistent_watches);
+                erase_from(persistent_recursive_watches);
+                break;
+        }
+    }
+
+    ZooKeeperRemoveWatchRequest request;
+    request.path = path;
+    request.type = type;
+
+    RequestInfo request_info;
+    request_info.request = std::make_shared<ZooKeeperRemoveWatchRequest>(std::move(request));
+    request_info.callback = [callback](const Response & response) { callback(dynamic_cast<const RemoveWatchResponse &>(response)); };
+    pushRequest(std::move(request_info));
+    ProfileEvents::increment(ProfileEvents::ZooKeeperRemoveWatch);
+}
+
+void ZooKeeper::checkWatches(
+    const String & path,
+    CheckWatchRequest::CheckWatchType type,
+    CheckWatchCallback callback)
+{
+    ZooKeeperCheckWatchRequest request;
+    request.path = path;
+    request.type = type;
+
+    RequestInfo request_info;
+    request_info.request = std::make_shared<ZooKeeperCheckWatchRequest>(std::move(request));
+    request_info.callback = [callback](const Response & response) { callback(dynamic_cast<const CheckWatchResponse &>(response)); };
+    pushRequest(std::move(request_info));
+    ProfileEvents::increment(ProfileEvents::ZooKeeperCheckWatch);
+}
+
 
 void ZooKeeper::check(
     const String & path,
@@ -2243,6 +2395,14 @@ ZooKeeper::WatchesSnapshot ZooKeeper::getWatchesSnapshot() const
             result[path].push_back(create_info);
 
     for (const auto & [path, callbacks] : list_watches)
+        for (const auto & [_, create_info] : callbacks)
+            result[path].push_back(create_info);
+
+    for (const auto & [path, callbacks] : persistent_watches)
+        for (const auto & [_, create_info] : callbacks)
+            result[path].push_back(create_info);
+
+    for (const auto & [path, callbacks] : persistent_recursive_watches)
         for (const auto & [_, create_info] : callbacks)
             result[path].push_back(create_info);
 

--- a/src/Common/ZooKeeper/ZooKeeperImpl.h
+++ b/src/Common/ZooKeeper/ZooKeeperImpl.h
@@ -193,6 +193,22 @@ public:
         int32_t version,
         CheckCallback callback) override;
 
+    void addWatch(
+        const String & path,
+        AddWatchRequest::AddWatchMode mode,
+        AddWatchCallback callback,
+        WatchCallbackPtrOrEventPtr watch) override;
+
+    void removeWatches(
+        const String & path,
+        RemoveWatchRequest::WatchType type,
+        RemoveWatchCallback callback) override;
+
+    void checkWatches(
+        const String & path,
+        CheckWatchRequest::CheckWatchType type,
+        CheckWatchCallback callback) override;
+
     void sync(
          const String & path,
          SyncCallback callback) override;
@@ -313,6 +329,8 @@ private:
 
     WatchesWithCreateInfo watches TSA_GUARDED_BY(watches_mutex);
     WatchesWithCreateInfo list_watches TSA_GUARDED_BY(watches_mutex);
+    WatchesWithCreateInfo persistent_watches TSA_GUARDED_BY(watches_mutex);
+    WatchesWithCreateInfo persistent_recursive_watches TSA_GUARDED_BY(watches_mutex);
 
     /// A wrapper around ThreadFromGlobalPool that allows to call join() on it from multiple threads.
     class ThreadReference


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add Keeper watches requests into Keeper
