### PR TITLE
Initialize ASTIndexDeclaration::granularity in header

### DIFF
--- a/src/Parsers/ASTIndexDeclaration.h
+++ b/src/Parsers/ASTIndexDeclaration.h
@@ -19,7 +19,7 @@ public:
     ASTIndexDeclaration(ASTPtr expression, ASTPtr type, const String & name_);
 
     String name;
-    UInt64 granularity;
+    UInt64 granularity = DEFAULT_INDEX_GRANULARITY;
     bool part_of_create_index_query = false;
 
     /** Get the text that identifies this element. */


### PR DESCRIPTION
SVACE static analysis (UNINIT.CTOR) flagged that `ASTIndexDeclaration`'s 3-argument constructor only initializes `name`, leaving `granularity` (a plain `UInt64`) with no in-class default. `formatImpl` reads the field via `if (granularity)` and `clone` copies it, so a caller that forgets to assign `granularity` would read indeterminate memory.

All four current construction sites (`ParserCreateQuery`, `ParserCreateIndexQuery`, `IndicesDescription`, and `clone` itself) already assign `granularity` immediately after construction, so the finding is theoretical for current code. The change is defense in depth: future call sites get a sensible default and the SAST warning goes away.

Closes #105517.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

N/A (SVACE hygiene fix; no user-visible behavior change).


### Documentation entry for user-facing changes

- [x] Documentation is unaffected.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.99`
<!-- ch-version-info:end -->