### PR TITLE
Fix RESTRICTIVE/PERMISSIVE keywords case in SHOW CREATE ROW POLICY output

### DIFF
--- a/src/Parsers/Access/ASTCreateRowPolicyQuery.cpp
+++ b/src/Parsers/Access/ASTCreateRowPolicyQuery.cpp
@@ -18,7 +18,7 @@ namespace
 
     void formatAsRestrictiveOrPermissive(bool is_restrictive, WriteBuffer & ostr, const IAST::FormatSettings &)
     {
-        ostr << " AS " << (is_restrictive ? "restrictive" : "permissive");
+        ostr << " AS " << (is_restrictive ? "RESTRICTIVE" : "PERMISSIVE");
     }
 
 


### PR DESCRIPTION
## Description

`SHOW CREATE ROW POLICY` returns `restrictive` and `permissive` in lowercase, inconsistent with all other SQL keywords in the output which are uppercase.

Closes #105352

## Example

Before:
```sql
CREATE ROW POLICY users_policy_test ON test.test_table AS restrictive FOR SELECT USING 1 TO my_role
```

After:
```sql
CREATE ROW POLICY users_policy_test ON test.test_table AS RESTRICTIVE FOR SELECT USING 1 TO my_role
```

## Root Cause

In `src/Parsers/Access/ASTCreateRowPolicyQuery.cpp`, the `formatAsRestrictiveOrPermissive` function used lowercase string literals:

```cpp
ostr << " AS " << (is_restrictive ? "restrictive" : "permissive");
```

Fixed to:

```cpp
ostr << " AS " << (is_restrictive ? "RESTRICTIVE" : "PERMISSIVE");
```

### Changelog category:

- Bug Fix (user-visible misbehavior in stable release)

### Changelog entry:

`SHOW CREATE ROW POLICY` now returns `RESTRICTIVE` and `PERMISSIVE` keywords in uppercase, consistent with all other SQL keywords in the output.