### PR TITLE
Stop test 01658 from leaking files into user_files_path, fix 02843 flaky

### DIFF
--- a/tests/queries/0_stateless/01658_read_file_to_stringcolumn.sh
+++ b/tests/queries/0_stateless/01658_read_file_to_stringcolumn.sh
@@ -7,6 +7,17 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+# Clean up on EXIT so a mid-script abort (set -e + a failing query) cannot
+# leave the short filenames `a`, `b`, `c` in `user_files_path` and break
+# other tests that rely on them being absent.
+cleanup() {
+    rm -f "${USER_FILES_PATH}"/{a,b,c}.txt
+    rm -f "${USER_FILES_PATH}"/{a,b,c}
+    rm -f /tmp/c.txt
+    rm -rf "${USER_FILES_PATH}"/dir
+}
+trap cleanup EXIT
+
 echo -n aaaaaaaaa > ${USER_FILES_PATH}/a.txt
 echo -n bbbbbbbbb > ${USER_FILES_PATH}/b.txt
 echo -n ccccccccc > ${USER_FILES_PATH}/c.txt
@@ -81,8 +92,4 @@ echo -n World > ${USER_FILES_PATH}/c
 ${CLICKHOUSE_CLIENT} --query "SELECT file(arrayJoin(['a', 'b', 'c'])) AS s, count() GROUP BY s ORDER BY s"
 ${CLICKHOUSE_CLIENT} --query "SELECT s, count() FROM file('?', TSV, 's String') GROUP BY s ORDER BY s"
 
-# Restore
-rm ${USER_FILES_PATH}/{a,b,c}.txt
-rm ${USER_FILES_PATH}/{a,b,c}
-rm /tmp/c.txt
-rm -rf ${USER_FILES_PATH}/dir
+# Cleanup is handled by the `trap cleanup EXIT` at the top of this script.

--- a/tests/queries/0_stateless/01658_read_file_to_stringcolumn.sh
+++ b/tests/queries/0_stateless/01658_read_file_to_stringcolumn.sh
@@ -7,13 +7,18 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
+# A file outside user_files, used to check that reading such a path is rejected
+# in client mode and allowed in local mode. Keep it in the per-test unique tmp
+# dir instead of a fixed /tmp path so concurrent tests cannot collide on it.
+OUTSIDE_FILE="${CLICKHOUSE_TMP}/01658_outside.txt"
+
 # Clean up on EXIT so a mid-script abort (set -e + a failing query) cannot
 # leave the short filenames `a`, `b`, `c` in `user_files_path` and break
 # other tests that rely on them being absent.
 cleanup() {
     rm -f "${USER_FILES_PATH}"/{a,b,c}.txt
     rm -f "${USER_FILES_PATH}"/{a,b,c}
-    rm -f /tmp/c.txt
+    rm -f "${OUTSIDE_FILE}"
     rm -rf "${USER_FILES_PATH}"/dir
 }
 trap cleanup EXIT
@@ -21,7 +26,7 @@ trap cleanup EXIT
 echo -n aaaaaaaaa > ${USER_FILES_PATH}/a.txt
 echo -n bbbbbbbbb > ${USER_FILES_PATH}/b.txt
 echo -n ccccccccc > ${USER_FILES_PATH}/c.txt
-echo -n ccccccccc > /tmp/c.txt
+echo -n ccccccccc > "${OUTSIDE_FILE}"
 mkdir -p ${USER_FILES_PATH}/dir
 
 
@@ -48,7 +53,7 @@ echo "${CLICKHOUSE_CLIENT} --query "'"select file('"'nonexist.txt'), file('b.txt
 # Test isDir
 echo "${CLICKHOUSE_CLIENT} --query "'"select file('"'dir'), file('b.txt')"'";echo :$?' | bash 2>/dev/null
 # Test path out of the user_files directory. It's not allowed in client mode
-echo "${CLICKHOUSE_CLIENT} --query "'"select file('"'/tmp/c.txt'), file('b.txt')"'";echo :$?' | bash 2>/dev/null
+echo "${CLICKHOUSE_CLIENT} --query "'"select file('"'${OUTSIDE_FILE}'), file('b.txt')"'";echo :$?' | bash 2>/dev/null
 
 # Test relative path consists of ".." whose absolute path is out of the user_files directory.
 echo "${CLICKHOUSE_CLIENT} --query "'"select file('"'../../../../../../../../../../../../../../../../../../../tmp/c.txt'), file('b.txt')"'";echo :$?' | bash 2>/dev/null
@@ -71,7 +76,7 @@ ${CLICKHOUSE_LOCAL} --query "
     insert into data select file('a.txt'), file('b.txt');
     insert into data select file('a.txt'), file('b.txt');
     select file('c.txt'), * from data;
-    select file('/tmp/c.txt'), * from data;
+    select file('${OUTSIDE_FILE}'), * from data;
 "
 echo ":"$?
 

--- a/tests/queries/0_stateless/02843_context_has_expired.sql
+++ b/tests/queries/0_stateless/02843_context_has_expired.sql
@@ -26,7 +26,9 @@ SELECT 1 IN (SELECT joinGetOrNull(02843_join, 'value', materialize(1)));
 
 SELECT 1 IN (SELECT materialize(connectionId()));
 SELECT 1000000 IN (SELECT materialize(getSetting('max_threads')));
-SELECT 1 in (SELECT file(materialize('a'))); -- { serverError FILE_DOESNT_EXIST }
+-- Use a unique path so the FILE_DOESNT_EXIST assertion still fires even if
+-- another test leaks a short filename like `a` into `user_files_path`.
+SELECT 1 in (SELECT file(materialize('02843_nonexistent_'||generateUUIDv4()))); -- { serverError FILE_DOESNT_EXIST }
 
 EXPLAIN ESTIMATE SELECT 1 IN (SELECT dictGet('02843_dict', 'value', materialize('1')));
 EXPLAIN ESTIMATE  SELECT 1 IN (SELECT joinGet(`02843_join`, 'value', materialize(1)));


### PR DESCRIPTION
Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

---

## Why

`02843_context_has_expired.sql` fails sporadically on CI with:

```
The query succeeded but the server error '107' was expected
(query: SELECT 1 in (SELECT file(materialize('a'))); -- { serverError FILE_DOESNT_EXIST })
```

CIDB shows ~4 hits in the past 90 days, all matching the same pattern, on unrelated PRs (e.g. #100651, #101798, #104697). Crucially, the diagnostic always reports "Test also fails without randomized settings (not a randomization issue)" — so this is not a randomized-settings flake, the server is in a stuck state.

## Root cause

`01658_read_file_to_stringcolumn.sh` writes the short filenames `a`, `b`, `c` into `user_files_path` (line 88 in the current script) and removes them only via the manual `rm` at the bottom. The script runs under `set -e`. Any failing query between the write and the cleanup aborts the script and leaves the files behind, where they survive across the rest of that CI session.

Once `${USER_FILES_PATH}/a` exists, `02843`'s assertion `SELECT 1 in (SELECT file(materialize('a')))` returns 0 (the file is read successfully and `1` is not in the resulting Set) instead of throwing `FILE_DOESNT_EXIST`, and the `-- { serverError FILE_DOESNT_EXIST }` check trips the test.

Reproduced locally:
```
$ echo -n Hello > $USER_FILES_PATH/a
$ clickhouse-client -q "SELECT 1 in (SELECT file(materialize('a')))"
0    # ← bug
$ rm $USER_FILES_PATH/a
$ clickhouse-client -q "SELECT 1 in (SELECT file(materialize('a')))"
Code: 107. DB::ErrnoException: Cannot open file ... FILE_DOESNT_EXIST   # ← expected
```

50/50 deterministic.

## Fix

Two changes:

1. **Root cause:** `01658_read_file_to_stringcolumn.sh` now registers `trap cleanup EXIT` immediately after sourcing `shell_config.sh`. The cleanup removes all files the test creates in `user_files_path` and `/tmp`, using `rm -f` so it's idempotent. The redundant manual cleanup at the bottom of the script is removed.

2. **Defense in depth:** `02843_context_has_expired.sql` uses `'02843_nonexistent_'||generateUUIDv4()` as the path passed to `file()`. The test's intent (verifying that `file()` throws `FILE_DOESNT_EXIST` on a missing file) is preserved, and the assertion can no longer be poisoned by another test leaking a short filename like `a`.

## Verification

- Pre-fix, with `${USER_FILES_PATH}/a` pre-seeded: `02843` fails 50/50 (matches CI failure exactly).
- Post-fix, with `${USER_FILES_PATH}/a` pre-seeded: `02843` passes 50/50.
- `01658` trap verified to fire on `set -e` mid-script abort (manual bash test with `false`).
- `bash -n` syntax check on modified `01658` passes.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.635`
<!-- ch-version-info:end -->