### PR TITLE
check_ci.py: enqueue PR via GraphQL instead of broken auto-merge

### DIFF
--- a/ci/jobs/scripts/check_ci.py
+++ b/ci/jobs/scripts/check_ci.py
@@ -1040,49 +1040,47 @@ def main():
         mergeable_check_status, sha=head_sha
     )
 
-    auto_merge_cmd = f"gh pr merge {pr_number} --auto --repo ClickHouse/ClickHouse"
-    if not Shell.check(auto_merge_cmd, verbose=True):
+    # `gh pr merge --auto` calls the `enablePullRequestAutoMerge` mutation,
+    # which the repo disables in favor of a merge queue on `master`. Call
+    # `enqueuePullRequest` directly: it is the mutation the "Merge when ready"
+    # button on github.com uses.
+    pr_node_id = Shell.get_output(
+        f"gh pr view {pr_number} --json id --jq '.id' --repo ClickHouse/ClickHouse"
+    ).strip()
+    if not pr_node_id:
+        print(f"ERROR: Failed to fetch node ID for PR #{pr_number}")
+        sys.exit(1)
+
+    enqueue_cmd = (
+        "gh api graphql "
+        "-f 'query=mutation($id:ID!){enqueuePullRequest(input:{pullRequestId:$id})"
+        "{mergeQueueEntry{position state}}}' "
+        f"-f id={pr_node_id}"
+    )
+    if not Shell.check(enqueue_cmd, verbose=True):
         print(
-            f"ERROR: Failed to enable auto-merge for PR #{pr_number}. "
+            f"ERROR: Failed to add PR #{pr_number} to the merge queue. "
             f"This often happens when mergeStateStatus is UNKNOWN "
-            f"(GitHub is still computing mergeability after a recent push). "
-            f"Retry manually:\n  {auto_merge_cmd}"
+            f"(GitHub is still computing mergeability after a recent push) "
+            f"or the PR is not yet eligible (failing required checks, "
+            f"missing approvals, out of date with base). "
+            f"Retry manually:\n  {enqueue_cmd}"
         )
         sys.exit(1)
 
-    # Give GitHub a moment to process auto-merge and update merge state
+    # Give GitHub a moment to update the PR's merge state, then verify it
+    # actually landed in the queue.
     time.sleep(5)
     merge_status = Shell.get_output(
         f"gh pr view {pr_number} --json mergeStateStatus --jq '.mergeStateStatus' --repo ClickHouse/ClickHouse"
     )
-    if merge_status == "CLEAN":
-        # PR checks already passed but GitHub didn't enqueue it — the
-        # state transition was missed. Disable and re-enable auto-merge
-        # to force GitHub to re-evaluate.
-        print(
-            f"WARNING: PR #{pr_number} has mergeStateStatus=CLEAN (checks passed but not queued). "
-            f"Retoggling auto-merge to fix..."
-        )
-        Shell.check(
-            f"gh pr merge {pr_number} --disable-auto --repo ClickHouse/ClickHouse",
-            verbose=True,
-        )
-        time.sleep(2)
-        if Shell.check(
-            f"gh pr merge {pr_number} --auto --repo ClickHouse/ClickHouse",
-            verbose=True,
-        ):
-            print(f"OK: Auto-merge retoggled for PR #{pr_number}")
-        else:
-            print(
-                f"ERROR: Failed to re-enable auto-merge for PR #{pr_number}. "
-                f"Please manually click 'Merge when ready' on GitHub."
-            )
-    elif merge_status == "QUEUED":
+    if merge_status == "QUEUED":
         print(f"OK: PR #{pr_number} added to the merge queue")
     else:
         print(
-            f"OK: PR #{pr_number} auto-merge enabled (mergeStateStatus={merge_status})"
+            f"WARNING: PR #{pr_number} enqueue mutation succeeded but "
+            f"mergeStateStatus is {merge_status} (expected QUEUED). "
+            f"Check the PR on github.com."
         )
 
 


### PR DESCRIPTION
`gh pr merge --auto` (called by `check_ci.py` to add a PR to the merge queue) hits the `enablePullRequestAutoMerge` GraphQL mutation. That mutation is disabled on this repo because `master` uses a merge queue, so the call fails with `Auto merge is not allowed for this repository (enablePullRequestAutoMerge)`. `gh` v2.92 detects the queue and warns about it, but still issues the auto-merge mutation rather than `enqueuePullRequest`, so the workflow has been broken in practice.

This PR calls `enqueuePullRequest` directly via `gh api graphql` — the same mutation github.com's "Merge when ready" button uses. It also drops the `CLEAN`-state retoggle workaround, which existed to nudge the auto-merge feature when checks had already passed and does not apply to the merge queue.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.89`
<!-- ch-version-info:end -->