### PR TITLE
Fix test_mysql_dotnet_client by anchoring to /testapp

### DIFF
--- a/tests/integration/test_mysql_protocol/test.py
+++ b/tests/integration/test_mysql_protocol/test.py
@@ -959,7 +959,7 @@ def test_mysql_dotnet_client(started_cluster):
         [
             "bash",
             "-c",
-            f"dotnet run -- --host {node.hostname} --port {server_port} --username default --password 123",
+            f"cd /testapp && dotnet run -- --host {node.hostname} --port {server_port} --username default --password 123",
         ],
     )
     # there is some thrash at the beggining of output, so it's better to use `in` instead of `==``


### PR DESCRIPTION
After PR #80785 (reverted in #105615), the `clickhouse/mysql_dotnet_client:latest` image had `WORKDIR /pg_testapp` as its last directive. The test ran `dotnet run -- ...` without specifying a project, so it executed the PostgreSQL Npgsql client against the MySQL port, failing with `Received unknown response X for SSLRequest (expecting S or N)`.

The revert restored the Dockerfile but did not evict the cached `:latest` image on integration runners (the compose file has no `pull_policy: always`). Anchoring the command to `/testapp` makes the test robust to either image variant, matching the symmetric `cd /pg_testapp && dotnet run` in `tests/integration/test_postgresql_protocol/test.py`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.96`
- Backported to: `26.5.2.3`, `26.4.4.8`, `26.3.13.4`, `25.8.25.7`
<!-- ch-version-info:end -->