### PR TITLE
Treat SIGTERM/SIGKILL kill codes as aborted run in functional-test parser

### DIFF
--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -1,6 +1,7 @@
 import dataclasses
 import re
 import runpy
+import signal
 import traceback
 from pathlib import Path
 from typing import List, Optional
@@ -19,6 +20,28 @@ DATABASE_SIGN = "Database: "
 # the contract has a single source of truth.
 _clickhouse_test = Path(__file__).resolve().parents[3] / "tests" / "clickhouse-test"
 STOP_TESTING_EXIT_CODE = runpy.run_path(str(_clickhouse_test))["STOP_TESTING_EXIT_CODE"]
+
+# Exit codes that mean the run was aborted mid-flight, so per-test results
+# (if any) are incomplete and we cannot trust which test "caused" the
+# failure. `STOP_TESTING_EXIT_CODE` is the in-band signal — the parent
+# raised `StopTesting` and reached the outer handler. `128 + SIGTERM/SIGKILL`
+# cover the out-of-band variants where the parent was killed before it
+# could exit through that handler (currently reachable via the
+# worker -> parent SIGTERM feedback loop in `stop_tests`: each worker the
+# parent terminates re-broadcasts SIGTERM to the whole process group via
+# `killpg`, hitting the parent before it can `sys.exit(STOP_TESTING_EXIT_CODE)`).
+#
+# Exit code 1 is deliberately NOT in this set: it is set by end-of-run
+# checks (final hung-check, `runner_process_killed`, `total_tests_run == 0`)
+# that run AFTER all tests have finished. Per-test results in that case are
+# complete and authoritative and must not be demoted.
+ABORTED_RUN_EXIT_CODES = frozenset(
+    {
+        STOP_TESTING_EXIT_CODE,
+        128 + signal.SIGTERM,  # 143
+        128 + signal.SIGKILL,  # 137
+    }
+)
 
 SUCCESS_FINISH_SIGNS = ["All tests have finished", "No tests were run"]
 
@@ -188,7 +211,7 @@ class FTResultsProcessor:
             test_results.append(
                 Result("Some queries hung", Result.Status.FAIL, info="Some queries hung")
             )
-        elif runner_exit_code == STOP_TESTING_EXIT_CODE:
+        elif runner_exit_code in ABORTED_RUN_EXIT_CODES:
             state = Result.Status.FAIL
             failed_results = [r for r in test_results if r.is_failure()]
             if len(failed_results) > 1:

--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -24,12 +24,20 @@ STOP_TESTING_EXIT_CODE = runpy.run_path(str(_clickhouse_test))["STOP_TESTING_EXI
 # Exit codes that mean the run was aborted mid-flight, so per-test results
 # (if any) are incomplete and we cannot trust which test "caused" the
 # failure. `STOP_TESTING_EXIT_CODE` is the in-band signal — the parent
-# raised `StopTesting` and reached the outer handler. `128 + SIGTERM/SIGKILL`
-# cover the out-of-band variants where the parent was killed before it
-# could exit through that handler (currently reachable via the
+# raised `StopTesting` and reached the outer handler. The kill-by-signal
+# variants cover the out-of-band cases where the parent was killed before
+# it could exit through that handler (currently reachable via the
 # worker -> parent SIGTERM feedback loop in `stop_tests`: each worker the
 # parent terminates re-broadcasts SIGTERM to the whole process group via
-# `killpg`, hitting the parent before it can `sys.exit(STOP_TESTING_EXIT_CODE)`).
+# `killpg`, hitting the parent before it can `sys.exit(STOP_TESTING_EXIT_CODE)`;
+# also covers external kills like job-level timeouts and runner shutdown).
+#
+# Both `128 + N` (bash's convention when its child died from signal N) and
+# the negative form `-N` are included: `Shell.run` wraps the command in
+# `bash -c`, so most kills surface as `128 + N` via bash's exit status, but
+# `Shell._check_timeout` calls `os.killpg` on the whole group, so the
+# wrapper bash can itself die from the signal — and Python's
+# `subprocess.Popen.returncode` reports that as `-N`, not `128 + N`.
 #
 # Exit code 1 is deliberately NOT in this set: it is set by end-of-run
 # checks (final hung-check, `runner_process_killed`, `total_tests_run == 0`)
@@ -40,6 +48,8 @@ ABORTED_RUN_EXIT_CODES = frozenset(
         STOP_TESTING_EXIT_CODE,
         128 + signal.SIGTERM,  # 143
         128 + signal.SIGKILL,  # 137
+        -signal.SIGTERM,  # -15
+        -signal.SIGKILL,  # -9
     }
 )
 


### PR DESCRIPTION
## Motivation

Follow-up to PR #105298 (commit fc45ec909cd) which introduced
`STOP_TESTING_EXIT_CODE = 2` as the stable signal from `clickhouse-test`
to the job-side parser for "the run was aborted mid-flight (server died,
hung-check tripped, etc.)". The parser uses that signal to attach a
synthetic `Server died` leaf and demote ambiguous per-test failures to
`UNKNOWN`.

The contract holds when `clickhouse-test` reaches `sys.exit(STOP_TESTING_EXIT_CODE)`
through the `except StopTesting` handler. It does *not* hold in the
parent-side hung-check path, which is the most common abort scenario:
when the parent terminates a worker via `p.terminate()`, the worker's
`signal_handler` raises `Terminated` (subclass of `KeyboardInterrupt`),
`run_tests_array`'s `except KeyboardInterrupt` calls `stop_tests`,
which `killpg`s the entire process group - hitting the parent before it
can exit through `StopTesting`. The parent's own `signal_handler` then
raises `Terminated` and `__main__` exits `128 + SIGTERM = 143`.

## Concrete failure mode

On PR #105041, [bugfix validation report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=105041&sha=68cd608314c8187b7813ab0317a528ec6aff3409&name_0=PR&name_1=Bugfix%20validation%20%28functional%20tests%29):
master hung running the PR's new tests, `clickhouse-test` was killed
with exit code 143, no per-test result lines reached `test_result.txt`,
the parser fell through to `not s.success_finish` (state = `ERROR`,
`results = []`), and the bugfix-validation inverter then overwrote that
honest ERROR with `set_failed().set_info("Failed to reproduce the bug")` -
exactly the opposite of what actually happened (the server died on
master, so the bug *was* reproduced, just more catastrophically than
the test expected).

## Change

Replace the singleton `runner_exit_code == STOP_TESTING_EXIT_CODE` check
with a `frozenset` that also matches `128 + SIGTERM` (143) and
`128 + SIGKILL` (137). All three carry the same semantics: the run was
aborted mid-flight, partial per-test results are incomplete, the
`Server died` leaf is appropriate.

Exit code 1 is deliberately *not* in the set. It is set by end-of-run
post-checks (final hung-check, `runner_process_killed`,
`total_tests_run == 0`) that run after every test has finished -
per-test results are authoritative in that case and must not be demoted.
The existing tail handler at the bottom of `FTResultsProcessor.run`
already handles exit 1 by appending a generic `clickhouse-test exited
with code N` leaf without touching per-test results.

## What this does not fix

This commit does not fix the underlying `worker -> parent` SIGTERM
feedback loop in `tests/clickhouse-test`. That root-cause fix (mask
SIGTERM on the parent during the worker-cleanup block, or stop
`Terminated` from triggering `stop_tests` in workers) is left for a
separate change. Adding the kill codes here is defence-in-depth that
makes the parser robust to the loop without depending on whether it
ever gets fixed - and also covers external kills (job-level timeout,
runner shutdown) which would otherwise fall through to the same
incorrect ERROR path.

A second bug surfaced by the same CI report - the bugfix-validation
inverter overwriting `status=ERROR` with `set_failed("Failed to
reproduce the bug")` when `test_result.results` is empty - is also a
separate change.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.242`
<!-- ch-version-info:end -->