### PR TITLE
Speed up .githooks/pre-push author/committer check

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -22,8 +22,10 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         range=("$remote_sha..$local_sha")
     fi
 
-    # One git-log call per push ref, tab-separated fields per commit.
-    while IFS=$'\t' read -r sha an ae cn ce; do
+    # One git-log call per push ref. Records are NUL-separated (-z) so identities
+    # containing tabs cannot bypass the check; fields within a record are newline-
+    # separated since `\n` cannot appear in `%an` / `%ae` / `%cn` / `%ce`.
+    while IFS=$'\n' read -r -d '' sha an ae cn ce; do
         if [[ $an =~ $blocked_re ]]; then
             echo "ERROR: Commit $sha has a default/generic identity: $an <$ae>" >&2
             failed=1
@@ -32,7 +34,7 @@ while read -r local_ref local_sha remote_ref remote_sha; do
             echo "ERROR: Commit $sha has a default/generic identity: $cn <$ce>" >&2
             failed=1
         fi
-    done < <(git log --format=$'%H\t%an\t%ae\t%cn\t%ce' "${range[@]}")
+    done < <(git log -z --format='%H%n%an%n%ae%n%cn%n%ce' "${range[@]}")
 done
 
 if [ "$failed" -eq 1 ]; then

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -4,6 +4,9 @@
 # Install: git config core.hooksPath .githooks
 
 blocked='ubuntu|root|ec2-user|centos|fedora|debian|admin|bitnami|azureuser|gce-user|runner|jenkins|nobody|user|test|default|guest'
+# Word-boundary match mirroring `grep -w` (word chars = [A-Za-z0-9_]).
+blocked_re="(^|[^A-Za-z0-9_])($blocked)([^A-Za-z0-9_]|\$)"
+shopt -s nocasematch
 
 failed=0
 while read -r local_ref local_sha remote_ref remote_sha; do
@@ -14,25 +17,22 @@ while read -r local_ref local_sha remote_ref remote_sha; do
 
     # For new branches, check commits not reachable from any remote branch
     if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
-        range="$local_sha --not --remotes"
+        range=("$local_sha" --not --remotes)
     else
-        range="$remote_sha..$local_sha"
+        range=("$remote_sha..$local_sha")
     fi
 
-    for sha in $(git log --format='%H' $range); do
-        author_name=$(git log -1 --format='%an' "$sha")
-        author_full=$(git log -1 --format='%an <%ae>' "$sha")
-        committer_name=$(git log -1 --format='%cn' "$sha")
-        committer_full=$(git log -1 --format='%cn <%ce>' "$sha")
-        for name_and_full in "$author_name|$author_full" "$committer_name|$committer_full"; do
-            name="${name_and_full%%|*}"
-            full="${name_and_full#*|}"
-            if echo "$name" | grep -qiw -E "$blocked"; then
-                echo "ERROR: Commit $sha has a default/generic identity: $full" >&2
-                failed=1
-            fi
-        done
-    done
+    # One git-log call per push ref, tab-separated fields per commit.
+    while IFS=$'\t' read -r sha an ae cn ce; do
+        if [[ $an =~ $blocked_re ]]; then
+            echo "ERROR: Commit $sha has a default/generic identity: $an <$ae>" >&2
+            failed=1
+        fi
+        if [[ $cn =~ $blocked_re ]]; then
+            echo "ERROR: Commit $sha has a default/generic identity: $cn <$ce>" >&2
+            failed=1
+        fi
+    done < <(git log --format=$'%H\t%an\t%ae\t%cn\t%ce' "${range[@]}")
 done
 
 if [ "$failed" -eq 1 ]; then


### PR DESCRIPTION
The pre-push hook in `.githooks/pre-push` (added by @alexey-milovidov) spawned ~6 subprocesses per commit: four `git log -1` invocations plus two `echo | grep` invocations. On a long-lived branch where the range is `$local_sha --not --remotes`, that becomes ~10 seconds for ~880 commits, and pushes feel hung.

Use a single `git log` per pushed ref emitting all five fields tab-separated, and match in-shell with bash `[[ =~ ]]` + `shopt -s nocasematch`. The word-boundary regex `(^|[^A-Za-z0-9_])(...)([^A-Za-z0-9_]|$)` reproduces `grep -w`. Also pass the range via an array so `$local_sha --not --remotes` reaches `git log` as three argv tokens rather than via word splitting.

Benchmark on 878 commits: 9.85 s → 0.14 s (~70x faster). Correctness verified: a commit authored as `ubuntu` is still blocked, clean commits still pass.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Speed up the `.githooks/pre-push` author/committer identity check (~70x on long branches).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.145`
<!-- ch-version-info:end -->