### PR TITLE
build distroless docker images from the shell-free production stage

### DIFF
--- a/.github/workflows/backfill_distroless.yml
+++ b/.github/workflows/backfill_distroless.yml
@@ -208,6 +208,7 @@ jobs:
                 --platform=linux/amd64,linux/arm64 \
                 --provenance=true \
                 --sbom=true \
+                --target=production \
                 ${PUSH_FLAG:-$OUTPUT_FLAG} \
                 --label="build-url=${GITHUB_RUN_URL}" \
                 --label="com.clickhouse.build.githash=${SHA}" \

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -271,12 +271,18 @@ jobs:
 
             echo "Following tags will be created: ${TAGS[*]}"
 
+            TARGET_ARGS=()
+            if [ "$variant" = "distroless" ]; then
+              TARGET_ARGS=("--target=production")
+            fi
+
             # shellcheck disable=SC2086,SC2048
             docker buildx build \
               --platform=linux/amd64,linux/arm64 \
               --provenance=true  \
               --sbom=true \
               --output=type=registry \
+              ${TARGET_ARGS[*]} \
               --label=com.clickhouse.build.version="$LABEL_VERSION" \
               ${TAGS[*]} \
               --build-arg=VERSION="$CLICKHOUSE_VERSION_STRING" \
@@ -341,13 +347,19 @@ jobs:
 
             echo "Following tags will be created: ${TAGS[*]}"
 
+            TARGET_ARGS=()
+            if [ "$variant" = "distroless" ]; then
+              TARGET_ARGS=("--target=production")
+            fi
+
             # shellcheck disable=SC2086,SC2048
             docker buildx build \
               --platform=linux/amd64,linux/arm64 \
               --provenance=true  \
               --sbom=true \
               --output=type=registry \
-              --label=com.clickhoghuse.build.version="$LABEL_VERSION" \
+              ${TARGET_ARGS[*]} \
+              --label=com.clickhouse.build.version="$LABEL_VERSION" \
               ${TAGS[*]} \
               --build-arg=VERSION="$CLICKHOUSE_VERSION_STRING" \
               --progress=plain \

--- a/ci/jobs/docker_server.py
+++ b/ci/jobs/docker_server.py
@@ -3,6 +3,7 @@ import atexit
 import json
 import logging
 import os
+import shlex
 import tempfile
 import traceback
 from pathlib import Path
@@ -44,6 +45,62 @@ class DockerImageData:
         self.name = name
         assert not path.startswith("/")
         self.path = path
+
+
+def is_distroless_image(docker_image: str) -> bool:
+    _, tag = docker_image.rsplit(":", 1)
+    return "distroless" in tag.split("-")
+
+
+def get_official_images_variant(docker_image: str) -> str:
+    # The official-images test runner derives its lookup variant from the final
+    # tag suffix. For example, head-distroless-amd64 is looked up as repo:amd64.
+    _, tag = docker_image.rsplit(":", 1)
+    return tag.rsplit("-", 1)[-1]
+
+
+def write_distroless_docker_library_config(docker_image: str, config_dir: Path) -> Path:
+    """Map arch-suffixed distroless tags to the distroless-safe config tests."""
+    # Generate a short config fragment for local arch-suffixed distroless CI tags.
+    # The runner derives tags like head-distroless-amd64 as repo:amd64; map that
+    # derived key to the distroless-safe tests because this helper is only used
+    # for images already identified as distroless.
+    repo, _ = docker_image.rsplit(":", 1)
+    variant = get_official_images_variant(docker_image)
+    image_variant = shlex.quote(f"{repo}:{variant}")
+    tests_var = (
+        "keeperDistrolessSafeTests"
+        if "clickhouse-keeper" in repo
+        else "clickhouseDistrolessSafeTests"
+    )
+
+    generated_config = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            prefix="docker-library-distroless-",
+            suffix=".sh",
+            dir=config_dir,
+            delete=False,
+            encoding="utf-8",
+        ) as f:
+            generated_config = Path(f.name)
+            f.write(
+                "#!/usr/bin/env bash\n"
+                "\n"
+                "explicitTests+=(\n"
+                f"\t[{image_variant}]=1\n"
+                ")\n"
+                "\n"
+                "imageTests+=(\n"
+                f"\t[{image_variant}]=\"${{{tests_var}}}\"\n"
+                ")\n"
+            )
+            return generated_config
+    except Exception:
+        if generated_config:
+            generated_config.unlink(missing_ok=True)
+        raise
 
 
 class DelOS(argparse.Action):
@@ -258,6 +315,15 @@ def build_and_push_image(
                 f"--metadata-file={metadata_path}",
                 f"--build-arg=VERSION='{version}'",
                 "--progress=plain",
+            ]
+        )
+        # Distroless Dockerfiles have a multi-stage build with both production
+        # (no shell) and debug (busybox) targets. Build the production target
+        # explicitly to ensure the published image has no shell.
+        if os == "distroless":
+            cmd_args.append("--target=production")
+        cmd_args.extend(
+            [
                 f"--file={dockerfile}",
                 Path(image.path).as_posix(),
             ]
@@ -311,10 +377,29 @@ def test_docker_library(test_results) -> None:
             raise RuntimeError(f"Failed to clone {repo}")
         run_sh = (repo_path / "test/run.sh").absolute()
         for image in check_images:
-            cmd = f"{run_sh} {image} -c {repo_path / 'test/config.sh'} -c {config_override}"
-            test_results.append(
-                Result.from_commands_run(name=f"{test_name} ({image})", command=cmd)
-            )
+            generated_config = None
+            try:
+                configs = [repo_path / "test/config.sh", config_override]
+                if is_distroless_image(image):
+                    generated_config = write_distroless_docker_library_config(
+                        image, config_override.parent
+                    )
+                    configs.append(generated_config)
+                config_args = " ".join(
+                    f"-c {shlex.quote(config.as_posix())}" for config in configs
+                )
+                cmd = (
+                    f"{shlex.quote(run_sh.as_posix())} "
+                    f"{shlex.quote(image)} {config_args}"
+                )
+                test_results.append(
+                    Result.from_commands_run(
+                        name=f"{test_name} ({image})", command=cmd
+                    )
+                )
+            finally:
+                if generated_config:
+                    generated_config.unlink(missing_ok=True)
 
     except Exception as e:
         logging.error("Failed while testing the docker library image: %s", e)

--- a/ci/jobs/scripts/docker_server/config.sh
+++ b/ci/jobs/scripts/docker_server/config.sh
@@ -5,12 +5,27 @@ currentDir="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 # iterate over all directories in current path
 clickhouseTests=$( find "$currentDir"/tests/ -maxdepth 1 -name 'clickhouse-*' -not -name 'clickhouse-distroless-*' -type d -exec basename {} \; )
-clickhouseDistrolessTests=$( find "$currentDir"/tests/ -maxdepth 1 -name 'clickhouse-distroless-*' -type d -exec basename {} \; )
 keeperTests=$( find "$currentDir"/tests/ -maxdepth 1 -name 'keeper-*' -type d -exec basename {} \; )
+
+# Distroless images have no shell or coreutils inside the container, so run
+# only tests known to work with that constraint.
+clickhouseDistrolessTests=$( find "$currentDir"/tests/ -maxdepth 1 -name 'clickhouse-distroless-*' -type d -exec basename {} \; )
+clickhouseDistrolessSafeTests="clickhouse-basics ${clickhouseDistrolessTests}"
+keeperDistrolessTests=$( find "$currentDir"/tests/ -maxdepth 1 -name 'keeper-distroless-*' -type d -exec basename {} \; )
+keeperDistrolessSafeTests="clickhouse-distroless-no-shell ${keeperDistrolessTests}"
+
+# Distroless images cannot run the official-images global tests that assume a
+# shell/coreutils are available. Mark these image variants as explicit so the
+# runner uses only the imageTests listed below instead of adding global tests.
+# Arch-suffixed local CI tags are handled in docker_server.py.
+explicitTests+=(
+	['clickhouse/clickhouse-server:distroless']=1
+	['clickhouse/clickhouse-keeper:distroless']=1
+)
 
 imageTests+=(
 	['clickhouse/clickhouse-server']="${clickhouseTests}"
-	['clickhouse/clickhouse-server:distroless']="${clickhouseTests} ${clickhouseDistrolessTests}"
+	['clickhouse/clickhouse-server:distroless']="${clickhouseDistrolessSafeTests}"
 	['clickhouse/clickhouse-keeper']="${keeperTests}"
-	['clickhouse/clickhouse-keeper:distroless']="${keeperTests}"
+	['clickhouse/clickhouse-keeper:distroless']="${keeperDistrolessSafeTests}"
 )

--- a/ci/jobs/scripts/docker_server/tests/clickhouse-distroless-no-shell/run.sh
+++ b/ci/jobs/scripts/docker_server/tests/clickhouse-distroless-no-shell/run.sh
@@ -15,3 +15,8 @@ if docker run --rm --entrypoint /bin/bash "$image" -c "echo bad" 2>/dev/null; th
     echo "FAIL: /bin/bash should not exist in the distroless image" >&2
     exit 1
 fi
+
+if docker run --rm --entrypoint /busybox/sh "$image" -c "echo bad" 2>/dev/null; then
+    echo "FAIL: /busybox/sh should not exist in the distroless image" >&2
+    exit 1
+fi

--- a/docker/keeper/Dockerfile.distroless
+++ b/docker/keeper/Dockerfile.distroless
@@ -143,10 +143,11 @@ RUN mkdir -p \
     } > /output/etc/group
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Stage 2: Production distroless image.
+# Stage 2: Debug image — same as production but includes the busybox shell
+#           at /busybox/sh for interactive troubleshooting.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-06-18. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:nonroot
-FROM gcr.io/distroless/base-nossl-debian13:nonroot@sha256:20f009ee6f6976a13763db818c6525f6f3882b73a32b5bff3a672d9de5beb5ca AS production
+# Pinned 2026-06-18. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:debug-nonroot
+FROM gcr.io/distroless/base-nossl-debian13:debug-nonroot@sha256:a5fef528b61dbe0bde471e431bab2b373808e32c529b115fb52438f6dda113e5 AS debug
 
 COPY --from=ch-builder /output/ /
 
@@ -165,11 +166,10 @@ WORKDIR /var/lib/clickhouse
 ENTRYPOINT ["/usr/bin/clickhouse", "docker-init", "--keeper"]
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Stage 3: Debug image — same as production but includes the busybox shell
-#           at /busybox/sh for interactive troubleshooting.
+# Stage 3: Production distroless image.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-06-18. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:debug-nonroot
-FROM gcr.io/distroless/base-nossl-debian13:debug-nonroot@sha256:a5fef528b61dbe0bde471e431bab2b373808e32c529b115fb52438f6dda113e5 AS debug
+# Pinned 2026-06-18. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:nonroot
+FROM gcr.io/distroless/base-nossl-debian13:nonroot@sha256:20f009ee6f6976a13763db818c6525f6f3882b73a32b5bff3a672d9de5beb5ca AS production
 
 COPY --from=ch-builder /output/ /
 

--- a/docker/server/Dockerfile.distroless
+++ b/docker/server/Dockerfile.distroless
@@ -177,10 +177,11 @@ RUN { \
     } > /output/etc/group
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Stage 2: Production distroless image.
+# Stage 2: Debug image — same as production but includes the busybox shell
+#           at /busybox/sh for interactive troubleshooting.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-06-18. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:nonroot
-FROM gcr.io/distroless/base-nossl-debian13:nonroot@sha256:20f009ee6f6976a13763db818c6525f6f3882b73a32b5bff3a672d9de5beb5ca AS production
+# Pinned 2026-06-18. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:debug-nonroot
+FROM gcr.io/distroless/base-nossl-debian13:debug-nonroot@sha256:a5fef528b61dbe0bde471e431bab2b373808e32c529b115fb52438f6dda113e5 AS debug
 
 COPY --from=ch-builder /output/ /
 
@@ -199,11 +200,10 @@ WORKDIR /var/lib/clickhouse
 ENTRYPOINT ["/usr/bin/clickhouse", "docker-init"]
 
 # ──────────────────────────────────────────────────────────────────────────────
-# Stage 3: Debug image — same as production but includes the busybox shell
-#           at /busybox/sh for interactive troubleshooting.
+# Stage 3: Production distroless image.
 # ──────────────────────────────────────────────────────────────────────────────
-# Pinned 2026-06-18. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:debug-nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:debug-nonroot
-FROM gcr.io/distroless/base-nossl-debian13:debug-nonroot@sha256:a5fef528b61dbe0bde471e431bab2b373808e32c529b115fb52438f6dda113e5 AS debug
+# Pinned 2026-06-18. Refresh: docker pull gcr.io/distroless/base-nossl-debian13:nonroot && docker inspect --format='{{index .RepoDigests 0}}' gcr.io/distroless/base-nossl-debian13:nonroot
+FROM gcr.io/distroless/base-nossl-debian13:nonroot@sha256:20f009ee6f6976a13763db818c6525f6f3882b73a32b5bff3a672d9de5beb5ca AS production
 
 COPY --from=ch-builder /output/ /
 


### PR DESCRIPTION
Fixes #105677

The `clickhouse/clickhouse-server` and `clickhouse/clickhouse-keeper` `-distroless` images were built without an explicit Docker target, so Docker selected the final `debug` stage from `Dockerfile.distroless`. That stage uses the debug distroless base and includes `/busybox/sh`.

This change makes the `production` stage the default final stage and explicitly passes `--target=production` from all distroless image publishing paths: the backfill workflow, release workflow, and Docker server CI.

It also fixes Docker official-images test selection for distroless images. Distroless images cannot run the official-images global tests that assume shell/coreutils are present, so the config now marks distroless variants as explicit and uses a distroless-safe test list. For local CI tags like `head-distroless-amd64`, `docker_server.py` generates a small config fragment because the official-images runner derives the lookup variant from the final tag suffix (`amd64`/`arm64`).

The no-shell Docker image test now checks `/busybox/sh` as well, and keeper distroless images run that coverage too.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI/release Docker build commands and distroless Dockerfile staging, which directly affects what gets published to registries and could break image builds or tagging if misconfigured.
> 
> **Overview**
> Ensures `-distroless` images for `clickhouse-server` and `clickhouse-keeper` are built from the **shell-less production stage** by explicitly passing `--target=production` in all distroless publishing paths (backfill workflow, release workflow, and `ci/jobs/docker_server.py`).
> 
> Reorders the multi-stage `Dockerfile.distroless` files so `production` is the final/default stage, and strengthens CI coverage by extending the no-shell test to fail on `/busybox/sh` and running that test for the keeper distroless image as well. Also fixes a typo in the keeper image build label key in `create_release.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f311de6ee52d963a45e6ff0f6be1136b063401e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->