### PR TITLE
Devirtualize emission of non-joined rows in RIGHT and FULL joins

### DIFF
--- a/src/Columns/IColumn.cpp
+++ b/src/Columns/IColumn.cpp
@@ -619,7 +619,7 @@ void IColumnHelper<Derived, Parent>::fillFromRowRefs(const DataTypePtr & type, s
 
 /// Fills column values from list of blocks and row numbers
 /// Implementation with concrete column type allows to de-virtualize col->insertFrom() calls
-template <typename ColumnType>
+template <bool may_have_nulls, typename ColumnType>
 static void fillColumnFromBlocksAndRowNumbers(ColumnType * col, const DataTypePtr & type, size_t source_column_index_in_block, const ColumnsWithRowNumbers & columns_with_row_numbers)
 {
     const auto * columns = columns_with_row_numbers.columns.data();
@@ -630,24 +630,31 @@ static void fillColumnFromBlocksAndRowNumbers(ColumnType * col, const DataTypePt
     col->reserve(col->size() + n);
     for (size_t j = 0; j < n; ++j)
     {
-        if (columns[j])
+        if constexpr (may_have_nulls)
         {
-            if (const auto * source_replicated = columns[j]->replicated_columns[source_column_index_in_block])
-                col->insertFrom(*source_replicated->getNestedColumn(), source_replicated->getIndexes().getIndexAt(row_numbers[j]));
-            else
-                col->insertFrom(*columns[j]->columns[source_column_index_in_block], row_numbers[j]);
+            if (!columns[j])
+            {
+                type->insertDefaultInto(*col);
+                continue;
+            }
         }
+
+        if (const auto * source_replicated = columns[j]->replicated_columns[source_column_index_in_block])
+            col->insertFrom(*source_replicated->getNestedColumn(), source_replicated->getIndexes().getIndexAt(row_numbers[j]));
         else
-        {
-            type->insertDefaultInto(*col);
-        }
+            col->insertFrom(*columns[j]->columns[source_column_index_in_block], row_numbers[j]);
     }
 }
 
 /// Fills column values from list of blocks and row numbers
 void IColumn::fillFromBlocksAndRowNumbers(const DataTypePtr & type, size_t source_column_index_in_block, const ColumnsWithRowNumbers & columns_with_row_numbers)
 {
-    fillColumnFromBlocksAndRowNumbers(this, type, source_column_index_in_block, columns_with_row_numbers);
+    fillColumnFromBlocksAndRowNumbers<true>(this, type, source_column_index_in_block, columns_with_row_numbers);
+}
+
+void IColumn::fillFromBlocksAndRowNumbers(size_t source_column_index_in_block, const ColumnsWithRowNumbers & columns_with_row_numbers)
+{
+    fillColumnFromBlocksAndRowNumbers<false>(this, /*type=*/ nullptr, source_column_index_in_block, columns_with_row_numbers);
 }
 
 /// Fills column values from list of blocks and row numbers
@@ -655,7 +662,14 @@ template <typename Derived, typename Parent>
 void IColumnHelper<Derived, Parent>::fillFromBlocksAndRowNumbers(const DataTypePtr & type, size_t source_column_index_in_block, const ColumnsWithRowNumbers & columns_with_row_numbers)
 {
     auto & self = static_cast<Derived &>(*this);
-    fillColumnFromBlocksAndRowNumbers(&self, type, source_column_index_in_block, columns_with_row_numbers);
+    fillColumnFromBlocksAndRowNumbers<true>(&self, type, source_column_index_in_block, columns_with_row_numbers);
+}
+
+template <typename Derived, typename Parent>
+void IColumnHelper<Derived, Parent>::fillFromBlocksAndRowNumbers(size_t source_column_index_in_block, const ColumnsWithRowNumbers & columns_with_row_numbers)
+{
+    auto & self = static_cast<Derived &>(*this);
+    fillColumnFromBlocksAndRowNumbers<false>(&self, /*type=*/ nullptr, source_column_index_in_block, columns_with_row_numbers);
 }
 
 template <typename Derived, typename Parent>

--- a/src/Columns/IColumn.cpp
+++ b/src/Columns/IColumn.cpp
@@ -638,6 +638,10 @@ static void fillColumnFromBlocksAndRowNumbers(ColumnType * col, const DataTypePt
                 continue;
             }
         }
+        else
+        {
+            chassert(columns[j] != nullptr);
+        }
 
         if (const auto * source_replicated = columns[j]->replicated_columns[source_column_index_in_block])
             col->insertFrom(*source_replicated->getNestedColumn(), source_replicated->getIndexes().getIndexAt(row_numbers[j]));

--- a/src/Columns/IColumn.h
+++ b/src/Columns/IColumn.h
@@ -708,7 +708,11 @@ public:
     virtual void fillFromRowRefs(const DataTypePtr & type, size_t source_column_index_in_block, const UInt64 * row_refs_begin, const UInt64 * row_refs_end, bool row_refs_are_ranges);
 
     /// Fills column values from list of blocks and row numbers
+    /// A nullptr in the list is interpreted as a default value
     virtual void fillFromBlocksAndRowNumbers(const DataTypePtr & type, size_t source_column_index_in_block, const ColumnsWithRowNumbers & columns_with_row_numbers);
+
+    /// Same as above but assumes every entry in the list is non-null
+    virtual void fillFromBlocksAndRowNumbers(size_t source_column_index_in_block, const ColumnsWithRowNumbers & columns_with_row_numbers);
 
     /// Some columns may require finalization before using of other operations.
     virtual void finalize() {}
@@ -981,7 +985,11 @@ private:
     void fillFromRowRefs(const DataTypePtr & type, size_t source_column_index_in_block, const UInt64 * row_refs_begin, const UInt64 * row_refs_end, bool row_refs_are_ranges) override;
 
     /// Fills column values from list of columns and row numbers
+    /// A nullptr in the list is interpreted as a default value
     void fillFromBlocksAndRowNumbers(const DataTypePtr & type, size_t source_column_index_in_block, const ColumnsWithRowNumbers & columns_with_row_numbers) override;
+
+    /// Same as above but assumes every entry in the list is non-null
+    void fillFromBlocksAndRowNumbers(size_t source_column_index_in_block, const ColumnsWithRowNumbers & columns_with_row_numbers) override;
 
     /// Move common implementations into the same translation unit to ensure they are properly inlined.
     char * serializeValueIntoMemoryWithNull(size_t n, char * memory, const UInt8 * is_null, const IColumn::SerializationSettings * settings) const override;

--- a/src/Interpreters/HashJoin/HashJoin.cpp
+++ b/src/Interpreters/HashJoin/HashJoin.cpp
@@ -1410,9 +1410,9 @@ void HashJoin::updateNonJoinedRowsStatus()
 }
 
 template <typename Mapped>
-struct AdderNonJoined
+struct CollectorNonJoined
 {
-    static void add(const Mapped & mapped, size_t & rows_added, MutableColumns & columns_right)
+    static void collect(const Mapped & mapped, VectorWithMemoryTracking<const ColumnsInfo *> & columns_infos, VectorWithMemoryTracking<UInt32> & row_numbers)
     {
         constexpr bool mapped_asof = std::is_same_v<Mapped, AsofRowRefs>;
         [[maybe_unused]] constexpr bool mapped_one = std::is_same_v<Mapped, RowRef>;
@@ -1423,29 +1423,15 @@ struct AdderNonJoined
         }
         else if constexpr (mapped_one)
         {
-            for (size_t j = 0; j < columns_right.size(); ++j)
-            {
-                if (const auto * replicated_column = mapped.columns_info->replicated_columns[j])
-                    columns_right[j]->insertFrom(*replicated_column->getNestedColumn(), replicated_column->getIndexes().getIndexAt(mapped.row_num));
-                else
-                    columns_right[j]->insertFrom(*mapped.columns_info->columns[j], mapped.row_num);
-            }
-
-            ++rows_added;
+            columns_infos.push_back(mapped.columns_info);
+            row_numbers.push_back(mapped.row_num);
         }
         else
         {
             for (auto it = mapped.begin(); it.ok(); ++it)
             {
-                for (size_t j = 0; j < columns_right.size(); ++j)
-                {
-                    if (const auto * replicated_column = it->columns_info->replicated_columns[j])
-                        columns_right[j]->insertFrom(*replicated_column->getNestedColumn(), replicated_column->getIndexes().getIndexAt(it->row_num));
-                    else
-                        columns_right[j]->insertFrom(*it->columns_info->columns[j], it->row_num);
-                }
-
-                ++rows_added;
+                columns_infos.push_back(it->columns_info);
+                row_numbers.push_back(it->row_num);
             }
         }
     }
@@ -1587,7 +1573,11 @@ private:
     template <typename Map>
     size_t fillColumns(const Map & map, MutableColumns & columns_keys_and_right)
     {
-        size_t rows_added = 0;
+        ColumnsWithRowNumbers columns_with_row_numbers;
+        auto & many_columns = columns_with_row_numbers.columns;
+        auto & row_nums = columns_with_row_numbers.row_numbers;
+        many_columns.reserve(max_block_size);
+        row_nums.reserve(max_block_size);
 
         if (flag_per_row)
         {
@@ -1595,14 +1585,14 @@ private:
             /// the data in parent.data->columns is not partitioned by hash buckets, so we can't
             /// distribute it across streams without additional per-row bucket lookups
             if (bucket_idx != 0)
-                return rows_added;
+                return row_nums.size();
 
             if (!used_position.has_value())
                 used_position = parent.data->columns.begin();
 
             auto end = parent.data->columns.end();
 
-            for (auto & it = *used_position; it != end && rows_added < max_block_size; ++it)
+            for (auto & it = *used_position; it != end && row_nums.size() < max_block_size; ++it)
             {
                 const auto & mapped_block = *it;
                 size_t rows = mapped_block.columns_info.columns.at(0)->size();
@@ -1611,14 +1601,8 @@ private:
                 {
                     if (!parent.isUsed(&mapped_block.columns_info.columns, row))
                     {
-                        for (size_t column = 0; column < columns_keys_and_right.size(); ++column)
-                        {
-                            if (const auto * replicated_column = mapped_block.columns_info.replicated_columns[column])
-                                columns_keys_and_right[column]->insertFrom(*replicated_column->getNestedColumn(), replicated_column->getIndexes().getIndexAt(row));
-                            else
-                                columns_keys_and_right[column]->insertFrom(*mapped_block.columns_info.columns[column], row);
-                        }
-                        ++rows_added;
+                        many_columns.push_back(&mapped_block.columns_info);
+                        row_nums.push_back(static_cast<UInt32>(row));
                     }
                 }
             }
@@ -1654,15 +1638,15 @@ private:
 
                 /// position at the first bucket owned by this stream
                 if (!skipToNextOwnedBucket())
-                    return rows_added;
+                    return row_nums.size();
 
-                while (it != end && rows_added < max_block_size)
+                while (it != end && row_nums.size() < max_block_size)
                 {
                     size_t offset = map.offsetInternal(it.getPtr());
                     if (!parent.isUsed(offset))
                     {
                         const Mapped & mapped = it->getMapped();
-                        AdderNonJoined<Mapped>::add(mapped, rows_added, columns_keys_and_right);
+                        CollectorNonJoined<Mapped>::collect(mapped, many_columns, row_nums);
                     }
 
                     ++it;
@@ -1682,9 +1666,9 @@ private:
                         continue;
 
                     const Mapped & mapped = it->getMapped();
-                    AdderNonJoined<Mapped>::add(mapped, rows_added, columns_keys_and_right);
+                    CollectorNonJoined<Mapped>::collect(mapped, many_columns, row_nums);
 
-                    if (rows_added >= max_block_size)
+                    if (row_nums.size() >= max_block_size)
                     {
                         ++it;
                         break;
@@ -1693,7 +1677,10 @@ private:
             }
         }
 
-        return rows_added;
+        for (size_t j = 0; j < columns_keys_and_right.size(); ++j)
+            columns_keys_and_right[j]->fillFromBlocksAndRowNumbers(j, columns_with_row_numbers);
+
+        return row_nums.size();
     }
 
     void fillNullsFromBlocks(MutableColumns & columns_keys_and_right, size_t & rows_added)
@@ -1707,7 +1694,13 @@ private:
 
         auto end = parent.data->nullmaps.end();
 
-        for (auto & it = *nulls_position; it != end && rows_added < max_block_size; ++it)
+        ColumnsWithRowNumbers columns_with_row_numbers;
+        auto & many_columns = columns_with_row_numbers.columns;
+        auto & row_nums = columns_with_row_numbers.row_numbers;
+        many_columns.reserve(max_block_size);
+        row_nums.reserve(max_block_size);
+
+        for (auto & it = *nulls_position; it != end && rows_added + row_nums.size() < max_block_size; ++it)
         {
             const auto * columns = it->columns;
             ConstNullMapPtr nullmap = nullptr;
@@ -1719,17 +1712,15 @@ private:
             {
                 if (nullmap && (*nullmap)[row])
                 {
-                    for (size_t col = 0; col < columns_keys_and_right.size(); ++col)
-                    {
-                        if (const auto * replicated_column = columns->columns_info.replicated_columns[col])
-                            columns_keys_and_right[col]->insertFrom(*replicated_column->getNestedColumn(), replicated_column->getIndexes().getIndexAt(row));
-                        else
-                            columns_keys_and_right[col]->insertFrom(*columns->columns_info.columns[col], row);
-                    }
-                    ++rows_added;
+                    many_columns.push_back(&columns->columns_info);
+                    row_nums.push_back(static_cast<UInt32>(row));
                 }
             }
         }
+
+        for (size_t j = 0; j < columns_keys_and_right.size(); ++j)
+            columns_keys_and_right[j]->fillFromBlocksAndRowNumbers(j, columns_with_row_numbers);
+        rows_added += row_nums.size();
     }
 };
 

--- a/src/Interpreters/HashJoin/HashJoinMethodsImpl.h
+++ b/src/Interpreters/HashJoin/HashJoinMethodsImpl.h
@@ -156,7 +156,7 @@ JoinResultPtr HashJoinMethods<KIND, STRICTNESS, MapsTemplate>::joinBlockImpl(
 
     /** For LEFT/INNER JOIN, the saved blocks do not contain keys.
       * For FULL/RIGHT JOIN, the saved blocks contain keys;
-      *  but they will not be used at this stage of joining (and will be in `AdderNonJoined`), and they need to be skipped.
+      *  but they will not be used at this stage of joining (and will be in `CollectorNonJoined`), and they need to be skipped.
       * For ASOF, the last column is used as the ASOF column
       */
     AddedColumns<!join_features.is_any_join> added_columns(

--- a/tests/performance/right_full_hash_join.xml
+++ b/tests/performance/right_full_hash_join.xml
@@ -1,0 +1,34 @@
+<!-- Performance tests for RIGHT/FULL join non-joined emission. -->
+<test>
+    <substitutions>
+        <substitution>
+            <name>probe_key</name>
+            <values>
+                <value>k1</value>    <!-- 90% unmatched -->
+                <value>k2</value>    <!-- 50% unmatched -->
+                <value>k3</value>    <!-- 10% unmatched -->
+            </values>
+        </substitution>
+    </substitutions>
+
+    <create_query>CREATE TABLE build_wide (k UInt64, a UInt64, b UInt64, c UInt64, d UInt64, e UInt64, f UInt64, g UInt64) ENGINE = MergeTree ORDER BY tuple()</create_query>
+    <create_query>CREATE TABLE build_narrow (k UInt64, a UInt64) ENGINE = MergeTree ORDER BY tuple()</create_query>
+    <create_query>CREATE TABLE build_nullable (k UInt64, a Nullable(UInt64), b Nullable(UInt64), c Nullable(UInt64), d Nullable(UInt64), e Nullable(UInt64), f Nullable(UInt64), g Nullable(UInt64)) ENGINE = MergeTree ORDER BY tuple()</create_query>
+    <create_query> CREATE TABLE probe (k1 UInt64, k2 UInt64, k3 UInt64) ENGINE = MergeTree ORDER BY tuple()</create_query>
+
+    <fill_query>INSERT INTO build_wide SELECT number, number, number, number, number, number, number, number FROM numbers(10000000) ORDER BY rand()</fill_query>
+    <fill_query>INSERT INTO build_narrow SELECT number, number FROM numbers(10000000) ORDER BY rand()</fill_query>
+    <fill_query>INSERT INTO build_nullable WITH if(number % 10 = 0, NULL, number) AS n SELECT number, n, n, n, n, n, n, n FROM numbers(10000000) ORDER BY rand()</fill_query>
+    <fill_query>INSERT INTO probe SELECT number + 9000000, number + 5000000, number + 1000000 FROM numbers(11000000) ORDER BY rand()</fill_query>
+
+    <!-- RIGHT JOIN -->
+    <query>SELECT * FROM probe p RIGHT JOIN build_wide b ON p.{probe_key} = b.k FORMAT Null</query>
+    <query>SELECT * FROM probe p RIGHT JOIN build_narrow b ON p.{probe_key} = b.k FORMAT Null</query>
+    <query>SELECT * FROM probe p RIGHT JOIN build_nullable b ON p.{probe_key} = b.k FORMAT Null</query>
+
+    <!-- FULL JOIN -->
+    <query>SELECT * FROM probe p FULL JOIN build_wide b ON p.{probe_key} = b.k FORMAT Null</query>
+    <query>SELECT * FROM probe p FULL JOIN build_narrow b ON p.{probe_key} = b.k FORMAT Null</query>
+    <query>SELECT * FROM probe p FULL JOIN build_nullable b ON p.{probe_key} = b.k FORMAT Null</query>
+
+</test>


### PR DESCRIPTION
This change de-virtualizes the emission of non-joined rows in RIGHT and FULL join following the same principle used in `AddedColumns.cpp`

Benchmarking results from `right_full_hash_join.xml`:

| nr | query                          | new (ms) | old (ms) | Δ (ms) | Δ%      |
  |---:|--------------------------------|---------:|---------:|-------:|--------:|
  |  0 | RIGHT wide × 90% unmatched     |      584 |      659 |    −75 | **−11.4%** |
  |  1 | RIGHT wide × 50% unmatched     |      597 |      629 |    −32 |   −5.1% |
  |  2 | RIGHT wide × 10% unmatched     |      596 |      592 |     +4 |   +0.7% |
  |  3 | RIGHT narrow × 90% unmatched   |      249 |      269 |    −20 |   −7.4% |
  |  4 | RIGHT narrow × 50% unmatched   |      255 |      271 |    −16 |   −5.9% |
  |  5 | RIGHT narrow × 10% unmatched   |      255 |      253 |     +2 |   +0.8% |
  |  6 | RIGHT nullable × 90% unmatched |      674 |      792 |   −118 | **−14.9%** |
  |  7 | RIGHT nullable × 50% unmatched |      689 |      761 |    −72 |   −9.5% |
  |  8 | RIGHT nullable × 10% unmatched |      695 |      693 |     +2 |   +0.3% |
  |  9 | FULL  wide × 90% unmatched     |      618 |      688 |    −70 | **−10.2%** |
  | 10 | FULL  wide × 50% unmatched     |      641 |      699 |    −58 |   −8.3% |
  | 11 | FULL  wide × 10% unmatched     |      612 |      612 |      0 |    0.0% |
  | 12 | FULL  narrow × 90% unmatched   |      252 |      271 |    −19 |   −7.0% |
  | 13 | FULL  narrow × 50% unmatched   |      252 |      265 |    −13 |   −4.9% |
  | 14 | FULL  narrow × 10% unmatched   |      248 |      250 |     −2 |   −0.8% |
  | 15 | FULL  nullable × 90% unmatched |      738 |      837 |    −99 | **−11.8%** |
  | 16 | FULL  nullable × 50% unmatched |      735 |      819 |    −84 |  −10.3% |
  | 17 | FULL  nullable × 10% unmatched |      701 |      699 |     +2 |   +0.3% |

### Changelog category (leave one):

- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

De-virtualize the emission of non-joined rows in RIGHT and FULL join by batching them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches RIGHT/FULL join non-joined row emission paths and adds a new `IColumn` overload that changes how defaults/null entries are handled; mistakes could lead to incorrect join output rows or crashes in edge cases (replicated columns, nullmaps, parallel buckets).
> 
> **Overview**
> Improves RIGHT/FULL hash join *non-joined row* emission by collecting `(ColumnsInfo*, row_num)` pairs and then batch-filling output columns via `fillFromBlocksAndRowNumbers`, replacing per-row/per-column `insertFrom` loops.
> 
> Extends `IColumn`/`IColumnHelper` with a second `fillFromBlocksAndRowNumbers` overload optimized for the **non-null** case, while keeping the existing API that interprets `nullptr` entries as defaults; adds a performance test (`right_full_hash_join.xml`) covering wide/narrow/nullable build tables and varying unmatched rates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50e13466f7a8f1ce1f5b3ca0801d807b48bc64ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.150`
<!-- ch-version-info:end -->