### PR TITLE
Fix 04229_defer_partition_pruning_after_final test on 26.3

### DIFF
--- a/tests/queries/0_stateless/04229_defer_partition_pruning_after_final.sql
+++ b/tests/queries/0_stateless/04229_defer_partition_pruning_after_final.sql
@@ -39,12 +39,14 @@ SELECT 'opt-out count', count() FROM repro_104263 FINAL
 WHERE event_time >= '2026-03-01' AND event_time <= '2026-03-31'
 SETTINGS defer_partition_pruning_after_final = 0;
 
--- The behavioral difference shows up in the `Partition Min-Max` index step of EXPLAIN.
+-- The behavioral difference shows up in the partition-key MinMax index step of EXPLAIN.
 -- Default reads all 5 parts (pruning disabled). Opt-out prunes to 1.
+-- In release/26.3 the step is named `MinMax`; on master / 26.4+ it was renamed to
+-- `Partition Min-Max` by #94140. `%MinMax%` matches both.
 SELECT 'default-defer partition pruning',
-       countIf(explain LIKE '%Partition Min-Max%') AS has_partition_step,
-       countIf(explain LIKE '%Parts: 5/5%')        AS no_pruning,
-       countIf(explain LIKE '%Parts: 1/5%')        AS pruned
+       countIf(explain LIKE '%MinMax%')     AS has_partition_step,
+       countIf(explain LIKE '%Parts: 5/5%') AS no_pruning,
+       countIf(explain LIKE '%Parts: 1/5%') AS pruned
 FROM
 (
     EXPLAIN indexes = 1
@@ -53,9 +55,9 @@ FROM
 );
 
 SELECT 'opt-out partition pruning',
-       countIf(explain LIKE '%Partition Min-Max%') AS has_partition_step,
-       countIf(explain LIKE '%Parts: 5/5%')        AS no_pruning,
-       countIf(explain LIKE '%Parts: 1/5%')        AS pruned
+       countIf(explain LIKE '%MinMax%')     AS has_partition_step,
+       countIf(explain LIKE '%Parts: 5/5%') AS no_pruning,
+       countIf(explain LIKE '%Parts: 1/5%') AS pruned
 FROM
 (
     EXPLAIN indexes = 1


### PR DESCRIPTION
Fix `04229_defer_partition_pruning_after_final` test on the `26.3` release branch. The test was added together with `defer_partition_pruning_after_final` via #104705 (backport landed in `29e7e946bf1`) and asserts that the partition-key min/max index step appears in the EXPLAIN plan via `LIKE '%Partition Min-Max%'`. That step-name string only exists on master / 26.4+, where #94140 renamed `IndexType::MinMax` → `IndexType::PartitionMinMax` and changed `indexTypeToString` to return `"Partition Min-Max"`. On `26.3` the step is still printed as `"MinMax"`, so the test fails the partition-pruning assertion on every CI shard.

Loosen the pattern to `%MinMax%`, which matches both the old `MinMax` (26.3) and the new `Partition Min-Max` (26.4+) names. No behavioral change to the test — the assertion still verifies the partition step is present in EXPLAIN; the `Parts: 5/5` / `Parts: 1/5` columns continue to carry the actual correctness check.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a stateless SQL regression test to tolerate version-dependent EXPLAIN output naming, with no production code changes.
> 
> **Overview**
> Fixes the `04229_defer_partition_pruning_after_final` stateless test to pass on 26.3 by loosening the EXPLAIN index-step assertion from matching `Partition Min-Max` to matching `%MinMax%`, covering both the old `MinMax` label (26.3) and the renamed `Partition Min-Max` label (26.4+).
> 
> Also updates the surrounding comment to document the version-specific EXPLAIN step naming; the partition-pruning correctness checks (`Parts: 5/5` vs `Parts: 1/5`) remain unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4259fc3a045ebe251921c614a5facbd147ebc42d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->