### PR TITLE
Do not attribute skip-index-filtered marks to PREWHERE in QueryConditionCache

### DIFF
--- a/src/Storages/MergeTree/IMergeTreeReader.h
+++ b/src/Storages/MergeTree/IMergeTreeReader.h
@@ -86,6 +86,12 @@ public:
 
     virtual bool canSkipMark(size_t, size_t) { return false; }
 
+    /// Returns true if this reader can skip whole marks via `canSkipMark` for at least some inputs.
+    /// Independent of any particular mark index. Used by callers that need to know upfront whether
+    /// the reader chain may filter marks before the PREWHERE step runs — for example, to decide
+    /// whether `read_mark_ranges` with `row_count == 0` can be attributed to the PREWHERE predicate.
+    virtual bool canSkipAnyMark() const { return false; }
+
     virtual void updateAllMarkRanges(const MarkRanges & ranges) { all_mark_ranges = ranges; }
 
     StorageSnapshotPtr getStorageSnapshot() const { return storage_snapshot; }

--- a/src/Storages/MergeTree/MergeTreeReadTask.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadTask.cpp
@@ -451,4 +451,11 @@ void MergeTreeReadTask::addPrewhereUnmatchedMarks(const MarkRanges & mark_ranges
     prewhere_unmatched_marks.insert(prewhere_unmatched_marks.end(), mark_ranges_.begin(), mark_ranges_.end());
 }
 
+bool MergeTreeReadTask::readersChainCanSkipMarksBeforePrewhere() const
+{
+    /// Only `prepared_index` (a `MergeTreeReaderIndex`) sits ahead of the PREWHERE readers in the
+    /// reader chain and is able to skip whole marks via `canSkipMark`.
+    return readers.prepared_index && readers.prepared_index->canSkipAnyMark();
+}
+
 }

--- a/src/Storages/MergeTree/MergeTreeReadTask.h
+++ b/src/Storages/MergeTree/MergeTreeReadTask.h
@@ -202,6 +202,13 @@ public:
     void addPrewhereUnmatchedMarks(const MarkRanges & mark_ranges_);
     const MarkRanges & getPrewhereUnmatchedMarks() { return prewhere_unmatched_marks; }
 
+    /// Returns true if a reader earlier in the chain than PREWHERE can skip whole marks based on
+    /// secondary indexes (skip-index or projection-index). When true, marks that appear in
+    /// `read_mark_ranges` with `row_count == 0` may have been filtered before PREWHERE evaluated
+    /// them, so they must not be attributed to the PREWHERE predicate in the QueryConditionCache.
+    /// See Issue #104781.
+    bool readersChainCanSkipMarksBeforePrewhere() const;
+
     Readers releaseReaders() { return std::move(readers); }
 
     size_t getNumMarksToRead() const { return mark_ranges.getNumberOfMarks(); }

--- a/src/Storages/MergeTree/MergeTreeReaderIndex.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderIndex.cpp
@@ -10,6 +10,16 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
 }
 
+bool MergeTreeReaderIndex::canSkipAnyMark() const
+{
+    /// `canSkipMark` only ever returns true when a skip-index or projection-index read result is present.
+    /// `lazy_materializing_rows` alone affects row-level filtering inside a granule and never returns
+    /// true from `canSkipMark`, so a reader configured only for lazy materialization does not skip
+    /// whole marks.
+    return index_read_result
+        && (index_read_result->skip_index_read_result || index_read_result->projection_index_read_result);
+}
+
 MergeTreeReaderIndex::MergeTreeReaderIndex(const IMergeTreeReader * main_reader_, MergeTreeIndexReadResultPtr index_read_result_, const PaddedPODArray<UInt64> * lazy_materializing_rows_)
     : IMergeTreeReader(
           main_reader_->data_part_info_for_read,

--- a/src/Storages/MergeTree/MergeTreeReaderIndex.h
+++ b/src/Storages/MergeTree/MergeTreeReaderIndex.h
@@ -34,6 +34,8 @@ public:
 
     bool canSkipMark(size_t mark, size_t current_task_last_mark) override;
 
+    bool canSkipAnyMark() const override;
+
     size_t getResultColumnCount() const override { return 1; }
 
     bool producesFilterOnly() const override { return true; }

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
@@ -284,7 +284,13 @@ MergeTreeSelectProcessor::readCurrentTask(MergeTreeReadTask & current_task, IMer
             .is_finished = false, .read_mark_ranges = std::move(res.read_mark_ranges)};
     }
 
-    if (reader_settings.use_query_condition_cache && prewhere_info)
+    /// Suppress PREWHERE attribution when a reader earlier in the chain (skip-index or projection-index)
+    /// can skip whole marks before PREWHERE evaluates them. In that case `res.read_mark_ranges` may
+    /// include marks that were filtered by the index, and recording them under the PREWHERE predicate's
+    /// hash would poison the QueryConditionCache: later queries that share the same PREWHERE predicate
+    /// hash would skip those marks even though the predicate alone matches their rows. See Issue #104781.
+    if (reader_settings.use_query_condition_cache && prewhere_info
+        && !current_task.readersChainCanSkipMarksBeforePrewhere())
         current_task.addPrewhereUnmatchedMarks(res.read_mark_ranges);
 
     return {Chunk(), res.num_read_rows, res.num_read_bytes, false, std::move(res.read_mark_ranges)};
@@ -361,8 +367,12 @@ ChunkAndProgress MergeTreeSelectProcessor::read()
         {
             if (!task || algorithm->needNewTask(*task))
             {
-                /// Update the query condition cache for filters in PREWHERE stage
-                if (reader_settings.use_query_condition_cache && task && prewhere_info)
+                /// Update the query condition cache for filters in PREWHERE stage.
+                /// Skip the write when a reader earlier in the chain (skip-index or projection-index)
+                /// could have filtered marks before PREWHERE saw them, to avoid attributing those
+                /// marks to the PREWHERE predicate hash. See Issue #104781.
+                if (reader_settings.use_query_condition_cache && task && prewhere_info
+                    && !task->readersChainCanSkipMarksBeforePrewhere())
                 {
                     for (const auto * output : prewhere_info->prewhere_actions.getOutputs())
                     {

--- a/tests/queries/0_stateless/04275_104781_qcc_prewhere_skip_index_attribution.reference
+++ b/tests/queries/0_stateless/04275_104781_qcc_prewhere_skip_index_attribution.reference
@@ -1,0 +1,6 @@
+truth	500002
+after_trigger	500002
+after_trigger_no_cache	500002
+after_trigger_workaround	500002
+sanity_prewhere_1	49999
+sanity_prewhere_2	49999

--- a/tests/queries/0_stateless/04275_104781_qcc_prewhere_skip_index_attribution.sql
+++ b/tests/queries/0_stateless/04275_104781_qcc_prewhere_skip_index_attribution.sql
@@ -1,0 +1,81 @@
+-- Tags: no-parallel-replicas
+-- Regression test for #104781: a `SELECT ... PREWHERE pk_prefix = X WHERE non_pk IN [...]` against a
+-- column that has a bloom-filter skip index poisons the query condition cache for the PREWHERE
+-- predicate. A subsequent benign `SELECT count() ... WHERE pk_prefix = X` then under-counts.
+--
+-- The bug requires the read-time skip-index analysis (`use_skip_indexes_on_data_read = 1`, default
+-- since #93407): the bloom-filter reader runs ahead of PREWHERE and the marks it drops were
+-- incorrectly attributed to the PREWHERE predicate, even though the predicate matches all rows.
+
+SET use_query_condition_cache = 1;
+SET use_skip_indexes_on_data_read = 1;
+SET allow_experimental_analyzer = 1;
+
+DROP TABLE IF EXISTS t_104781;
+
+CREATE TABLE t_104781
+(
+    id String,
+    project_id String,
+    created_at DateTime64(3) DEFAULT now64(3),
+    started_at DateTime64(6),
+    INDEX idx_id_bloom id TYPE bloom_filter(0.01) GRANULARITY 1
+)
+ENGINE = ReplacingMergeTree(created_at)
+PARTITION BY toYYYYMM(started_at)
+ORDER BY (project_id, started_at, id)
+SETTINGS min_bytes_for_wide_part = 0, index_granularity = 8192;
+
+-- 500000 rows in partition 202604, all `project_id='P1'`.
+INSERT INTO t_104781 (id, project_id, started_at)
+SELECT concat('id-', toString(number)), 'P1',
+       toDateTime64('2026-04-01 00:00:00', 6) + INTERVAL number SECOND
+FROM numbers(500000);
+
+-- 2 rows in partition 202605, same `project_id`, in a separate part.
+INSERT INTO t_104781 (id, project_id, started_at)
+SELECT concat('id-fresh-', toString(number)), 'P1',
+       toDateTime64('2026-05-15 00:00:00', 6) + INTERVAL number SECOND
+FROM numbers(2);
+
+SYSTEM DROP QUERY CONDITION CACHE;
+
+SELECT 'truth', count() FROM t_104781 WHERE project_id = 'P1';
+
+-- Trigger: PREWHERE on a primary-key-prefix column + WHERE on a non-PK column with `IN`.
+-- The bloom-filter index on `id` drops most marks; before the fix, those marks were recorded as
+-- "PREWHERE-unmatched" under the hash of `project_id = 'P1'`, poisoning the cache.
+SELECT id FROM t_104781
+PREWHERE project_id = 'P1'
+WHERE id IN ['anything-1', 'anything-2']
+FORMAT Null;
+
+-- With the fix, this returns the full 500002. Before the fix, it returns a smaller, wrong count
+-- (typically around 65k on this dataset, but the exact number is bloom-filter-FPR-dependent).
+SELECT 'after_trigger', count() FROM t_104781 WHERE project_id = 'P1';
+
+-- Sanity: the cache off path must agree with `truth`.
+SELECT 'after_trigger_no_cache', count() FROM t_104781 WHERE project_id = 'P1'
+SETTINGS use_query_condition_cache = 0;
+
+-- Sanity: also verify with `use_skip_indexes_on_data_read = 0` (per @nihalzp's workaround).
+SYSTEM DROP QUERY CONDITION CACHE;
+SELECT id FROM t_104781
+PREWHERE project_id = 'P1'
+WHERE id IN ['anything-1', 'anything-2']
+FORMAT Null
+SETTINGS use_skip_indexes_on_data_read = 0;
+SELECT 'after_trigger_workaround', count() FROM t_104781 WHERE project_id = 'P1';
+
+-- Sanity: a normal PREWHERE-only query (without a bloom-filter-backed `WHERE IN`) still benefits
+-- from the PREWHERE-side query condition cache. The fix only suppresses the PREWHERE write when
+-- a skip-index reader is in the chain; ordinary cases are unaffected.
+DROP TABLE IF EXISTS t_104781_sanity;
+CREATE TABLE t_104781_sanity (x UInt32, y UInt32) ENGINE = MergeTree ORDER BY x;
+INSERT INTO t_104781_sanity SELECT number, number FROM numbers(100000);
+SYSTEM DROP QUERY CONDITION CACHE;
+SELECT 'sanity_prewhere_1', count() FROM t_104781_sanity PREWHERE x > 50000;
+SELECT 'sanity_prewhere_2', count() FROM t_104781_sanity PREWHERE x > 50000;
+
+DROP TABLE t_104781;
+DROP TABLE t_104781_sanity;

--- a/tests/queries/0_stateless/04275_104781_qcc_prewhere_skip_index_attribution.sql
+++ b/tests/queries/0_stateless/04275_104781_qcc_prewhere_skip_index_attribution.sql
@@ -1,14 +1,30 @@
--- Tags: no-parallel-replicas
--- Regression test for #104781: a `SELECT ... PREWHERE pk_prefix = X WHERE non_pk IN [...]` against a
--- column that has a bloom-filter skip index poisons the query condition cache for the PREWHERE
--- predicate. A subsequent benign `SELECT count() ... WHERE pk_prefix = X` then under-counts.
---
--- The bug requires the read-time skip-index analysis (`use_skip_indexes_on_data_read = 1`, default
--- since #93407): the bloom-filter reader runs ahead of PREWHERE and the marks it drops were
--- incorrectly attributed to the PREWHERE predicate, even though the predicate matches all rows.
+-- Tags: no-parallel-replicas, no-parallel
+-- Tag no-parallel: messes with the server-level query condition cache
 
-SET use_query_condition_cache = 1;
-SET use_skip_indexes_on_data_read = 1;
+-- Regression test for #104781: a `SELECT ... PREWHERE pk_prefix = X WHERE non_pk IN [...]`
+-- against a column with a `bloom_filter` skip index poisons the query condition cache for
+-- the PREWHERE predicate. A subsequent benign `SELECT count() ... WHERE pk_prefix = X`
+-- then under-counts.
+--
+-- The bug requires `use_skip_indexes_on_data_read = 1` (default since #93407): the
+-- bloom-filter reader runs ahead of PREWHERE and drops marks via `canSkipMark`. Without
+-- the fix, those marks are incorrectly attributed to the PREWHERE predicate, even though
+-- the predicate matches all rows.
+--
+-- Settings pinned per-query so that CI randomization cannot disable the bug ingredients:
+--   * `use_query_condition_cache = 1`         - the cache that can be poisoned.
+--   * `use_skip_indexes_on_data_read = 1`     - puts `MergeTreeReaderIndex` ahead of
+--                                               PREWHERE in the reader chain.
+--   * `optimize_move_to_prewhere = 1` and
+--     `query_plan_optimize_prewhere = 1`      - guarantee `WHERE pk_prefix = X` is hashed
+--                                               under the same PREWHERE-predicate key as
+--                                               the explicit-PREWHERE trigger query.
+--   * `optimize_use_implicit_projections = 0` - disable `_exact_count_projection` so the
+--                                               `count()` queries traverse the data path
+--                                               and can hit the poisoned cache entry. With
+--                                               the implicit projection the count is read
+--                                               from per-part metadata and bypasses QCC.
+
 SET allow_experimental_analyzer = 1;
 
 DROP TABLE IF EXISTS t_104781;
@@ -26,7 +42,7 @@ PARTITION BY toYYYYMM(started_at)
 ORDER BY (project_id, started_at, id)
 SETTINGS min_bytes_for_wide_part = 0, index_granularity = 8192;
 
--- 500000 rows in partition 202604, all `project_id='P1'`.
+-- 500000 rows in partition 202604, all `project_id = 'P1'`.
 INSERT INTO t_104781 (id, project_id, started_at)
 SELECT concat('id-', toString(number)), 'P1',
        toDateTime64('2026-04-01 00:00:00', 6) + INTERVAL number SECOND
@@ -40,42 +56,55 @@ FROM numbers(2);
 
 SYSTEM DROP QUERY CONDITION CACHE;
 
-SELECT 'truth', count() FROM t_104781 WHERE project_id = 'P1';
+SELECT 'truth', count() FROM t_104781 WHERE project_id = 'P1'
+SETTINGS use_query_condition_cache = 1, use_skip_indexes_on_data_read = 1,
+         optimize_move_to_prewhere = 1, query_plan_optimize_prewhere = 1,
+         optimize_use_implicit_projections = 0;
 
 -- Trigger: PREWHERE on a primary-key-prefix column + WHERE on a non-PK column with `IN`.
--- The bloom-filter index on `id` drops most marks; before the fix, those marks were recorded as
--- "PREWHERE-unmatched" under the hash of `project_id = 'P1'`, poisoning the cache.
+-- The bloom-filter index on `id` drops most marks at read time; before the fix, those
+-- marks were attributed to the PREWHERE predicate, poisoning the cache.
 SELECT id FROM t_104781
 PREWHERE project_id = 'P1'
 WHERE id IN ['anything-1', 'anything-2']
-FORMAT Null;
+FORMAT Null
+SETTINGS use_query_condition_cache = 1, use_skip_indexes_on_data_read = 1;
 
--- With the fix, this returns the full 500002. Before the fix, it returns a smaller, wrong count
--- (typically around 65k on this dataset, but the exact number is bloom-filter-FPR-dependent).
-SELECT 'after_trigger', count() FROM t_104781 WHERE project_id = 'P1';
+-- With the fix, this returns the full 500002. Before the fix, it returns a smaller, wrong
+-- count (the exact under-count is bloom-filter-FPR-dependent).
+SELECT 'after_trigger', count() FROM t_104781 WHERE project_id = 'P1'
+SETTINGS use_query_condition_cache = 1, use_skip_indexes_on_data_read = 1,
+         optimize_move_to_prewhere = 1, query_plan_optimize_prewhere = 1,
+         optimize_use_implicit_projections = 0;
 
--- Sanity: the cache off path must agree with `truth`.
+-- Sanity: cache-off path must match `truth`.
 SELECT 'after_trigger_no_cache', count() FROM t_104781 WHERE project_id = 'P1'
-SETTINGS use_query_condition_cache = 0;
+SETTINGS use_query_condition_cache = 0, optimize_use_implicit_projections = 0;
 
--- Sanity: also verify with `use_skip_indexes_on_data_read = 0` (per @nihalzp's workaround).
+-- Sanity: the `use_skip_indexes_on_data_read = 0` workaround (per @nihalzp's bisect)
+-- avoids the bug too.
 SYSTEM DROP QUERY CONDITION CACHE;
 SELECT id FROM t_104781
 PREWHERE project_id = 'P1'
 WHERE id IN ['anything-1', 'anything-2']
 FORMAT Null
-SETTINGS use_skip_indexes_on_data_read = 0;
-SELECT 'after_trigger_workaround', count() FROM t_104781 WHERE project_id = 'P1';
+SETTINGS use_query_condition_cache = 1, use_skip_indexes_on_data_read = 0;
+SELECT 'after_trigger_workaround', count() FROM t_104781 WHERE project_id = 'P1'
+SETTINGS use_query_condition_cache = 1, use_skip_indexes_on_data_read = 1,
+         optimize_move_to_prewhere = 1, query_plan_optimize_prewhere = 1,
+         optimize_use_implicit_projections = 0;
 
--- Sanity: a normal PREWHERE-only query (without a bloom-filter-backed `WHERE IN`) still benefits
--- from the PREWHERE-side query condition cache. The fix only suppresses the PREWHERE write when
--- a skip-index reader is in the chain; ordinary cases are unaffected.
+-- Sanity: a plain PREWHERE-only query (no bloom-filter-backed `WHERE IN`) still benefits
+-- from the PREWHERE-side query condition cache. The fix only suppresses the PREWHERE
+-- write when a skip-index reader is in the chain; ordinary cases are unaffected.
 DROP TABLE IF EXISTS t_104781_sanity;
 CREATE TABLE t_104781_sanity (x UInt32, y UInt32) ENGINE = MergeTree ORDER BY x;
 INSERT INTO t_104781_sanity SELECT number, number FROM numbers(100000);
 SYSTEM DROP QUERY CONDITION CACHE;
-SELECT 'sanity_prewhere_1', count() FROM t_104781_sanity PREWHERE x > 50000;
-SELECT 'sanity_prewhere_2', count() FROM t_104781_sanity PREWHERE x > 50000;
+SELECT 'sanity_prewhere_1', count() FROM t_104781_sanity PREWHERE x > 50000
+SETTINGS use_query_condition_cache = 1, optimize_use_implicit_projections = 0;
+SELECT 'sanity_prewhere_2', count() FROM t_104781_sanity PREWHERE x > 50000
+SETTINGS use_query_condition_cache = 1, optimize_use_implicit_projections = 0;
 
 DROP TABLE t_104781;
 DROP TABLE t_104781_sanity;


### PR DESCRIPTION
Closes #104781.

When `use_skip_indexes_on_data_read = 1` (default since #93407), `MergeTreeReaderIndex` sits ahead of the PREWHERE readers in the reader chain and can drop whole marks via `canSkipMark`. The dropped marks still appear in `read_mark_ranges`, so when a read batch produces zero rows because the skip-index dropped everything, `MergeTreeSelectProcessor::read` attributes the marks to the PREWHERE predicate's action-graph hash and writes a "no marks match" verdict under that key. The next benign query whose `WHERE` hashes to the same PREWHERE-predicate hash hits the poisoned entry and silently under-counts.

The reporter's reduced case on master (26.5.1.587): `SELECT count() ... WHERE project_id = 'P1'` returns `237856` instead of `500002` after running a `PREWHERE project_id = 'P1' WHERE id IN [...]` query against a bloom-filter index on `id`. Locally I reproduced `65536` vs `500002`; the exact under-count depends on the bloom-filter false-positive rate.

`Settings::isQueryConditionCacheWritable` from #104225 does not cover this: the reporter's trigger runs with default settings, no experimental or `allow_suspicious_*` flag.

### Fix

`IMergeTreeReader::canSkipAnyMark` is added (default `false`) and overridden on `MergeTreeReaderIndex` to return `true` only when a skip-index or projection-index read result is present. `MergeTreeReadTask` exposes `readersChainCanSkipMarksBeforePrewhere`, and `MergeTreeSelectProcessor::read` suppresses both `addPrewhereUnmatchedMarks` and the PREWHERE-side `QueryConditionCache::write` when that helper returns `true`. `FilterTransform` writes under the WHERE-side condition hash are unaffected; ordinary PREWHERE-only queries (no skip-index, no projection-index) keep their existing cache pruning.

### Tests

`tests/queries/0_stateless/04275_104781_qcc_prewhere_skip_index_attribution.sql` runs the canonical trigger from #104781 and asserts the cache-on and cache-off counts agree. It also covers the `use_skip_indexes_on_data_read = 0` workaround and a sanity check that a regular PREWHERE-only query (no bloom-filter index) still passes. Without the fix the test reports `after_trigger 65536`; with the fix it reports `after_trigger 500002`.

I also ran the existing QCC test suite locally against the patched server (`02346_*`, `03100_*`, `03229_*`, `03460_*`, `04004_*`): all pass.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a silent under-count in `SELECT` queries when `use_query_condition_cache = 1` (default). A query of the shape `PREWHERE pk_prefix = X WHERE non_pk IN (...)` against a column with a bloom-filter skip index poisoned the `QueryConditionCache` for the `pk_prefix = X` predicate, so a subsequent benign `SELECT count() ... WHERE pk_prefix = X` returned an incorrect, under-counted result. Affected all 26.x releases. [#104781](https://github.com/ClickHouse/ClickHouse/issues/104781).

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MergeTree read path and QueryConditionCache PREWHERE attribution logic; mistakes could reduce caching effectiveness or reintroduce incorrect mark-skipping in edge cases involving skip/projection indexes.
> 
> **Overview**
> Prevents **QueryConditionCache PREWHERE entries** from being poisoned when skip/projection index readers drop whole marks before PREWHERE runs (Issue #104781), which previously could cause later queries to under-count by incorrectly reusing “no marks match” results.
> 
> This adds `IMergeTreeReader::canSkipAnyMark()` (implemented by `MergeTreeReaderIndex`) and a `MergeTreeReadTask::readersChainCanSkipMarksBeforePrewhere()` helper, then uses it in `MergeTreeSelectProcessor` to suppress both collecting PREWHERE-unmatched mark ranges and writing PREWHERE-side cache entries when earlier index readers might have filtered marks. A new stateless regression test reproduces the under-count scenario with a bloom-filter skip index and asserts correct counts with/without the cache and with the workaround setting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd0a30cb8950df6b96a874e8fcb9b6873635d246. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.141`
- Backported to: `26.5.2.12`, `26.4.4.15`, `26.3.13.13`
<!-- ch-version-info:end -->