### PR TITLE
Fix flaky test 04043_system_asynchronous_inserts_user_filter

### DIFF
--- a/tests/queries/0_stateless/04043_system_asynchronous_inserts_user_filter.sh
+++ b/tests/queries/0_stateless/04043_system_asynchronous_inserts_user_filter.sh
@@ -20,10 +20,15 @@ ${CLICKHOUSE_CLIENT} -q "
     GRANT SELECT ON system.asynchronous_inserts TO restricted_user_${CLICKHOUSE_DATABASE};
 "
 
-# secret_user inserts with async_insert enabled and a very long flush timeout so the entry stays in the queue.
+# `secret_user` inserts with `async_insert` enabled and a very long flush timeout
+# so the entry stays in the queue. `async_insert_use_adaptive_busy_timeout = 0`
+# disables the adaptive shortcut in `AsynchronousInsertQueue::pushImpl`
+# (`max_busy_timeout_exceeded`) that would otherwise flush the entry immediately when
+# the target queue shard happens to have been idle for longer than our 10-minute max.
 ${CLICKHOUSE_CLIENT} \
     --user "secret_user_${CLICKHOUSE_DATABASE}" \
     --async_insert 1 \
+    --async_insert_use_adaptive_busy_timeout 0 \
     --async_insert_busy_timeout_max_ms 600000 \
     --async_insert_busy_timeout_min_ms 600000 \
     --wait_for_async_insert 0 \


### PR DESCRIPTION
The test relies on the queued async insert staying in `system.asynchronous_inserts` long enough for three follow-up `SELECT`s. To keep the entry in the queue, the `INSERT` sets `async_insert_busy_timeout_min_ms = max_ms = 10 minutes`.

With the default `async_insert_use_adaptive_busy_timeout = 1`, the `max_busy_timeout_exceeded` shortcut in `AsynchronousInsertQueue::pushImpl` fires when both `shard.last_insert_time + max_ms < now` and `flush_time_points.first + max_ms < flush_time_points.second`, using the current query's `max_ms`. With our 10-minute `max_ms`, any queue shard that has been idle for longer than 10 minutes - common in a CI run since each test run lands in a different shard via `key.hash` - matches both conditions, so the entry is moved to `data_to_process` and removed from `shard.queue` immediately. The subsequent `SELECT`s then see zero rows.

Smoking gun from master server log on `a0a6cc08b5499fbf8c2ce88e554bdd9f7a929c23` after `36fc6e58b55c` dropped this test's `no-parallel` tag:

```
AsynchronousInsertQueue: Asynchronous timeout increased from 2892 to 600000 for queue shard 13.
AsynchronousInsertQueue: Have 1 pending inserts in shard 13 with total 4 bytes ...
AsynchronousInsertQueue: Scheduling async insert processing job because maximum busy wait timeout exceeded
AsynchronousInsertQueue: Processing batch insert ...
AsynchronousInsertQueue: Flushed 1 rows, 8 bytes
```

Setting `async_insert_use_adaptive_busy_timeout = 0` makes the lambda return on its first check, so the entry uses the fixed 10-minute deadline and survives until the `SELECT`s run. Verified with a deterministic reproducer (warm a shard with two short-timeout flushes, then issue a long-timeout insert: reproduces immediate drain with adaptive on, stays queued with adaptive off) and by running 50 iterations of the test at `-j 16` mixed with the other async-insert stateless tests - no failures.

Failures occurred across 20+ CI runs in the 24h before this fix on `Stateless tests (amd_msan, WasmEdge, parallel)`, `(amd_tsan, parallel)`, `(amd_tsan, s3 storage, parallel)`, `(amd_debug, distributed plan, s3 storage, parallel)`, `(arm_asan_ubsan, targeted)`, plus two `master` hits.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=a0a6cc08b5499fbf8c2ce88e554bdd9f7a929c23&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%202%2F2%29

### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a stateless test to make async insert behavior deterministic; no production code changes.
> 
> **Overview**
> Makes `04043_system_asynchronous_inserts_user_filter.sh` deterministic by disabling adaptive async-insert busy timeout (`--async_insert_use_adaptive_busy_timeout 0`) and documenting why, so the queued insert reliably remains visible in `system.asynchronous_inserts` long enough for the follow-up visibility assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c22e056510546c4c5831f539c1ae4feaa0d558c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->