### PR TITLE
AI func named collection allow missing api key

### DIFF
--- a/docs/en/sql-reference/functions/ai-functions.md
+++ b/docs/en/sql-reference/functions/ai-functions.md
@@ -37,7 +37,7 @@ CREATE NAMED COLLECTION ai_credentials AS
 | `provider` | String | — | Model provider. Supported: `'openai'`, `'anthropic'`. See note below. |
 | `endpoint` | String | — | API endpoint URL. |
 | `model` | String | — | Model name (e.g. `'gpt-4o-mini'`, `'text-embedding-3-small'`). |
-| `api_key` | String | — | Authentication key for the provider. |
+| `api_key` | String | — | Authentication key for the provider. Optional: when omitted, the auth header is not sent, which lets you target OpenAI-compatible servers that do not require authentication (e.g. a local Ollama instance). |
 | `max_tokens` | UInt64 | `1024` | Maximum number of output tokens per API call. |
 | `api_version` | String | — | API version string. Used by Anthropic (`'2023-06-01'`). |
 

--- a/docs/en/sql-reference/functions/ai-functions.md
+++ b/docs/en/sql-reference/functions/ai-functions.md
@@ -37,7 +37,7 @@ CREATE NAMED COLLECTION ai_credentials AS
 | `provider` | String | — | Model provider. Supported: `'openai'`, `'anthropic'`. See note below. |
 | `endpoint` | String | — | API endpoint URL. |
 | `model` | String | — | Model name (e.g. `'gpt-4o-mini'`, `'text-embedding-3-small'`). |
-| `api_key` | String | — | Authentication key for the provider. Optional: when omitted, the auth header is not sent, which lets you target OpenAI-compatible servers that do not require authentication (e.g. a local Ollama instance). |
+| `api_key` | String | — | Authentication key for the provider. Optional: when omitted, the auth header is not sent, which allows targeting OpenAI-compatible servers that do not require authentication. |
 | `max_tokens` | UInt64 | `1024` | Maximum number of output tokens per API call. |
 | `api_version` | String | — | API version string. Used by Anthropic (`'2023-06-01'`). |
 
@@ -51,7 +51,7 @@ All AI-related settings are listed in [Settings](/operations/settings/settings) 
 
 ### Restricting endpoint hosts {#restricting-endpoint-hosts}
 
-The `endpoint` URL in an AI named collection is an outbound destination the server connects to under its own identity, carrying the named collection's `api_key` in the request headers. By default, ClickHouse permits any host. To restrict functions to a specific set of providers, configure [`remote_url_allow_hosts`](/operations/server-configuration-parameters/settings#remote_url_allow_hosts) in the server config, e.g.:
+The `endpoint` URL in an AI named collection is an outbound destination the server connects to under its own identity, potentially carrying (if specified) the named collection's `api_key` in the request headers. By default, ClickHouse permits any host. To restrict functions to a specific set of providers, configure [`remote_url_allow_hosts`](/operations/server-configuration-parameters/settings#remote_url_allow_hosts) in the server config, e.g.:
 
 ```xml
 <remote_url_allow_hosts>

--- a/src/Functions/AI/AnthropicProvider.cpp
+++ b/src/Functions/AI/AnthropicProvider.cpp
@@ -111,7 +111,7 @@ AIResponse AnthropicProvider::call(const AIRequest & ai_request, const Connectio
 
     Poco::Net::HTTPRequest http_request(Poco::Net::HTTPRequest::HTTP_POST, uri.getPathAndQuery(), Poco::Net::HTTPMessage::HTTP_1_1);
     http_request.setContentType("application/json");
-    if (!api_key.empty())
+    if (!api_key.empty()) /// not all providers need API key
         http_request.set("x-api-key", api_key);
     http_request.set("anthropic-version", api_version);
     http_request.setContentLength(body.size());

--- a/src/Functions/AI/AnthropicProvider.cpp
+++ b/src/Functions/AI/AnthropicProvider.cpp
@@ -111,7 +111,8 @@ AIResponse AnthropicProvider::call(const AIRequest & ai_request, const Connectio
 
     Poco::Net::HTTPRequest http_request(Poco::Net::HTTPRequest::HTTP_POST, uri.getPathAndQuery(), Poco::Net::HTTPMessage::HTTP_1_1);
     http_request.setContentType("application/json");
-    http_request.set("x-api-key", api_key);
+    if (!api_key.empty())
+        http_request.set("x-api-key", api_key);
     http_request.set("anthropic-version", api_version);
     http_request.setContentLength(body.size());
 

--- a/src/Functions/AI/OpenAIProvider.cpp
+++ b/src/Functions/AI/OpenAIProvider.cpp
@@ -94,7 +94,8 @@ AIResponse OpenAIProvider::call(const AIRequest & ai_request, const ConnectionTi
 
     Poco::Net::HTTPRequest http_request(Poco::Net::HTTPRequest::HTTP_POST, uri.getPathAndQuery(), Poco::Net::HTTPMessage::HTTP_1_1);
     http_request.setContentType("application/json");
-    http_request.set("Authorization", "Bearer " + api_key);
+    if (!api_key.empty()) /// not all providers need API key
+        http_request.set("Authorization", "Bearer " + api_key);
     http_request.setContentLength(body.size());
 
     auto & out_stream = session->sendRequest(http_request);
@@ -176,7 +177,8 @@ AIEmbeddingResponse OpenAIProvider::embed(const AIEmbeddingRequest & ai_embeddin
 
     Poco::Net::HTTPRequest http_request(Poco::Net::HTTPRequest::HTTP_POST, uri.getPathAndQuery(), Poco::Net::HTTPMessage::HTTP_1_1);
     http_request.setContentType("application/json");
-    http_request.set("Authorization", "Bearer " + api_key);
+    if (!api_key.empty())
+        http_request.set("Authorization", "Bearer " + api_key);
     http_request.setContentLength(body.size());
 
     auto & out_stream = session->sendRequest(http_request);

--- a/src/Functions/AI/OpenAIProvider.cpp
+++ b/src/Functions/AI/OpenAIProvider.cpp
@@ -177,7 +177,7 @@ AIEmbeddingResponse OpenAIProvider::embed(const AIEmbeddingRequest & ai_embeddin
 
     Poco::Net::HTTPRequest http_request(Poco::Net::HTTPRequest::HTTP_POST, uri.getPathAndQuery(), Poco::Net::HTTPMessage::HTTP_1_1);
     http_request.setContentType("application/json");
-    if (!api_key.empty())
+    if (!api_key.empty()) /// not all providers need API key
         http_request.set("Authorization", "Bearer " + api_key);
     http_request.setContentLength(body.size());
 

--- a/src/Functions/FunctionBaseAI.cpp
+++ b/src/Functions/FunctionBaseAI.cpp
@@ -100,8 +100,6 @@ FunctionBaseAI::AINamedCollectionConfig FunctionBaseAI::resolveAINamedCollection
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "AI named collection '{}' must have 'endpoint'", config.collection_name);
     if (config.model.empty())
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "AI named collection '{}' must have 'model'", config.collection_name);
-    if (config.api_key.empty())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "AI named collection '{}' must have 'api_key'", config.collection_name);
 
     context->getRemoteHostFilter().checkURL(Poco::URI(config.endpoint));
 

--- a/src/Functions/FunctionBaseAI.h
+++ b/src/Functions/FunctionBaseAI.h
@@ -61,7 +61,7 @@ public:
 
     /// Resolve the named-collection argument: cast the first argument to a `ColumnConst`, run the
     /// `NAMED_COLLECTION` access check, fetch from `NamedCollectionFactory`, and validate that the
-    /// required fields (`provider`, `endpoint`, `model`, `api_key`) are non-empty.
+    /// required fields (`provider`, `endpoint`, `model`) are non-empty. `api_key` is optional.
     static AINamedCollectionConfig resolveAINamedCollection(const ContextPtr & context, const ColumnPtr & first_arg);
 
     /// Exponential backoff delay capped at one minute, so adversarial values of

--- a/src/Functions/aiClassify.cpp
+++ b/src/Functions/aiClassify.cpp
@@ -192,7 +192,7 @@ The function sends the text together with a fixed classification prompt and a JS
 constraining the model to return exactly one of the supplied labels. When the response is returned as a JSON
 object of the form `{"category": "..."}`, the label is unwrapped and the label string is returned.
 
-The first argument is a named collection that specifies the provider, model, endpoint, and API key.
+The first argument is a named collection that specifies the provider, model, endpoint, and optionally an API key.
 )",
         .syntax = "aiClassify(collection, text, categories[, temperature])",
         .arguments = {

--- a/src/Functions/aiEmbed.cpp
+++ b/src/Functions/aiEmbed.cpp
@@ -307,7 +307,7 @@ Within a single block of rows, inputs are grouped into batches of up to
 [`ai_function_embedding_max_batch_size`](/operations/settings/settings#ai_function_embedding_max_batch_size)
 entries per HTTP request to reduce per-call overhead.
 
-The first argument is a named collection that specifies the provider, model, endpoint, and API key.
+The first argument is a named collection that specifies the provider, model, endpoint, and optionally an API key.
 The optional `dimensions` argument, when supported by the model (e.g. OpenAI's `text-embedding-3-*`),
 requests a vector of the given size; otherwise the model's native size is returned.
 )",

--- a/src/Functions/aiExtract.cpp
+++ b/src/Functions/aiExtract.cpp
@@ -232,7 +232,7 @@ JSON-encoded schema of the form `'{"field_a": "description of field a", "field_b
 In instruction mode, the function returns the extracted value as a plain string, or an empty string if nothing was found.
 In schema mode, the function returns a JSON object string whose keys match the requested schema; missing fields are `null`.
 
-The first argument is a named collection that specifies the provider, model, endpoint, and API key.
+The first argument is a named collection that specifies the provider, model, endpoint, and optionally an API key.
 )",
         .syntax = "aiExtract(collection, text, instruction_or_schema[, temperature])",
         .arguments = {

--- a/src/Functions/aiGenerate.cpp
+++ b/src/Functions/aiGenerate.cpp
@@ -85,7 +85,7 @@ The function sends the prompt to the configured AI provider and returns the gene
 An optional system prompt can be provided to guide the model's behavior (e.g. tone, format, role).
 If no system prompt is given, the default system prompt is: `)" + String(default_system_prompt) + R"(`
 
-The first argument is a named collection that specifies the provider, model, endpoint, and API key.
+The first argument is a named collection that specifies the provider, model, endpoint, and optionally an API key.
 )",
         .syntax = "aiGenerate(collection, prompt[, system_prompt[, temperature]])",
         .arguments

--- a/src/Functions/aiTranslate.cpp
+++ b/src/Functions/aiTranslate.cpp
@@ -89,7 +89,7 @@ Translates the given text into the specified target language using an LLM provid
 
 Additional style or dialect instructions may be passed as a fourth argument (e.g. `'keep technical terms untranslated'`).
 
-The first argument is a named collection that specifies the provider, model, endpoint, and API key.
+The first argument is a named collection that specifies the provider, model, endpoint, and optionally an API key.
 )",
         .syntax = "aiTranslate(collection, text, target_language[, instructions[, temperature]])",
         .arguments = {

--- a/tests/queries/0_stateless/03300_ai_functions.reference
+++ b/tests/queries/0_stateless/03300_ai_functions.reference
@@ -8,6 +8,8 @@ aiGenerate
 -- Named collection missing model
 -- Named collection without api_key resolves
 0
+-- Named collection without api_key reaches HTTP path
+0
 -- Nonexistent named collection
 -- aiGenerate return type
 result	String

--- a/tests/queries/0_stateless/03300_ai_functions.reference
+++ b/tests/queries/0_stateless/03300_ai_functions.reference
@@ -6,7 +6,8 @@ aiGenerate
 -- Named collection missing provider
 -- Named collection missing endpoint
 -- Named collection missing model
--- Named collection missing api_key
+-- Named collection without api_key resolves
+0
 -- Nonexistent named collection
 -- aiGenerate return type
 result	String

--- a/tests/queries/0_stateless/03300_ai_functions.sql
+++ b/tests/queries/0_stateless/03300_ai_functions.sql
@@ -86,6 +86,21 @@ CREATE NAMED COLLECTION ai_no_api_key AS
 SELECT '-- Named collection without api_key resolves';
 SELECT count() FROM (SELECT aiGenerate('ai_no_api_key', x) AS result FROM tab);
 
+-- Force the no-key path through provider construction and an actual HTTP request:
+-- `localhost:1` refuses the connection, `ai_function_throw_on_error = 0` swallows it,
+-- and the row is returned with an empty result. If provider construction had rejected
+-- an empty `api_key`, this would throw before the swallow path is reached.
+SELECT '-- Named collection without api_key reaches HTTP path';
+DROP TABLE IF EXISTS _03300_no_api_key_in;
+CREATE TABLE _03300_no_api_key_in (x String) ENGINE = Memory;
+INSERT INTO _03300_no_api_key_in VALUES ('hello');
+SET ai_function_throw_on_error = 0;
+SET ai_function_request_timeout_sec = 3;
+SELECT length(aiGenerate('ai_no_api_key', x)) FROM _03300_no_api_key_in;
+SET ai_function_throw_on_error = 1;
+SET ai_function_request_timeout_sec = 60;
+DROP TABLE _03300_no_api_key_in;
+
 DROP NAMED COLLECTION ai_no_api_key;
 
 -- =============================================================================

--- a/tests/queries/0_stateless/03300_ai_functions.sql
+++ b/tests/queries/0_stateless/03300_ai_functions.sql
@@ -74,14 +74,17 @@ SELECT aiGenerate('ai_no_model', 'hi'); -- { serverError BAD_ARGUMENTS }
 
 DROP NAMED COLLECTION ai_no_model;
 
+-- `api_key` is optional: it can be omitted for OpenAI-compatible servers that don't
+-- require authentication (e.g. a local Ollama instance). When absent, the provider
+-- omits the auth header rather than sending a dummy token.
 DROP NAMED COLLECTION IF EXISTS ai_no_api_key;
 CREATE NAMED COLLECTION ai_no_api_key AS
     provider = 'openai',
     endpoint = 'http://localhost:1/v1/chat/completions',
     model = 'test-model';
 
-SELECT '-- Named collection missing api_key';
-SELECT aiGenerate('ai_no_api_key', 'hi'); -- { serverError BAD_ARGUMENTS }
+SELECT '-- Named collection without api_key resolves';
+SELECT count() FROM (SELECT aiGenerate('ai_no_api_key', x) AS result FROM tab);
 
 DROP NAMED COLLECTION ai_no_api_key;
 


### PR DESCRIPTION
Will be merged only after https://github.com/ClickHouse/ClickHouse/pull/102922.

### Changelog category (leave one):
- Experimental Feature


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Removing requirement for api key in AI credential named collections.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes validation and request construction so AI providers may be called without an API key, which can alter authentication behavior and lead to unexpected unauthenticated requests if misconfigured.
> 
> **Overview**
> AI named collections no longer require `api_key`; `FunctionBaseAI::resolveAINamedCollection` stops throwing when it’s missing.
> 
> Both `OpenAIProvider` (chat + embeddings) and `AnthropicProvider` now only send auth headers (`Authorization` / `x-api-key`) when `api_key` is non-empty.
> 
> Tests are updated to expect successful resolution/execution with a named collection that omits `api_key`, instead of a `BAD_ARGUMENTS` failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2567711133dd44c3f58c33d9ebb3c9677764700. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.246` (included in `26.6` and later)
- Backported to: `26.5.6.88`
<!-- ch-version-info:end -->