### PR TITLE
Add mysql-style runtime pager control for clickhouse-client/local

### DIFF
--- a/src/Client/ClientBase.cpp
+++ b/src/Client/ClientBase.cpp
@@ -944,25 +944,30 @@ void ClientBase::adjustSettings(ContextMutablePtr context)
 {
     /// NOTE: Do not forget to set changed=false to avoid sending it to the server (to avoid breakage read only profiles)
 
-    /// Do not limit pretty format output in case of --pager specified or in case of stdout is not a tty.
-    if (!pager.empty() || !stdout_is_a_tty)
+    /// Do not limit pretty format output when pager is active or stdout is not a tty.
+    /// When the pager is cleared at runtime (e.g. `nopager`) and stdout is a tty,
+    /// restore the defaults so values are truncated again — otherwise the limits
+    /// stay at UInt64::max for the rest of the session.
+    const bool raise = !pager.empty() || !stdout_is_a_tty;
+
+    Settings settings = context->getSettingsCopy();
+    const Settings defaults;
+
+    if (!context->getSettingsRef()[Setting::output_format_pretty_max_rows].changed)
     {
-        Settings settings = context->getSettingsCopy();
-
-        if (!context->getSettingsRef()[Setting::output_format_pretty_max_rows].changed)
-        {
-            settings[Setting::output_format_pretty_max_rows] = std::numeric_limits<UInt64>::max();
-            settings[Setting::output_format_pretty_max_rows].changed = false;
-        }
-
-        if (!context->getSettingsRef()[Setting::output_format_pretty_max_value_width].changed)
-        {
-            settings[Setting::output_format_pretty_max_value_width] = std::numeric_limits<UInt64>::max();
-            settings[Setting::output_format_pretty_max_value_width].changed = false;
-        }
-
-        context->setSettings(settings);
+        const UInt64 default_value = defaults[Setting::output_format_pretty_max_rows];
+        settings[Setting::output_format_pretty_max_rows] = raise ? std::numeric_limits<UInt64>::max() : default_value;
+        settings[Setting::output_format_pretty_max_rows].changed = false;
     }
+
+    if (!context->getSettingsRef()[Setting::output_format_pretty_max_value_width].changed)
+    {
+        const UInt64 default_value = defaults[Setting::output_format_pretty_max_value_width];
+        settings[Setting::output_format_pretty_max_value_width] = raise ? std::numeric_limits<UInt64>::max() : default_value;
+        settings[Setting::output_format_pretty_max_value_width].changed = false;
+    }
+
+    context->setSettings(settings);
 }
 
 void ClientBase::initClientContext(ContextMutablePtr context)
@@ -3203,6 +3208,48 @@ bool ClientBase::processQueryText(const String & text)
             [](char c) { return isWhitespaceASCII(c); });
 
         return processMultiQueryFromFile(file_name);
+    }
+
+    /// mysql-style client-only pager control. Mutates `pager`; the per-query launcher
+    /// in onData() picks up the new value on the next query.
+    if (is_interactive)
+    {
+        auto set_pager_to = [&](const String & cmd)
+        {
+            pager = trim(cmd, [](char c) { return isWhitespaceASCII(c); });
+            /// Re-apply pretty-format width/row limits — they need to be raised when the
+            /// pager is enabled and restored to defaults when it is cleared. Otherwise a
+            /// runtime `pager ...` without `--pager` on the command line would keep the
+            /// truncated defaults, and a `pager ... -> nopager` sequence would leave the
+            /// limits at UInt64::max for the rest of the session.
+            adjustSettings(client_context);
+            if (pager.empty())
+                output_stream << "PAGER set to stdout" << std::endl;
+            else
+                output_stream << "PAGER set to '" << pager << "'" << std::endl;
+        };
+
+        if (trimmed_input == "nopager" || trimmed_input == "\\n")
+        {
+            set_pager_to({});
+            return true;
+        }
+
+        for (const String prefix : {"pager", "\\P"})
+        {
+            if (trimmed_input == prefix)
+            {
+                set_pager_to({});
+                return true;
+            }
+            if (trimmed_input.starts_with(prefix)
+                && trimmed_input.size() > prefix.size()
+                && isWhitespaceASCII(trimmed_input[prefix.size()]))
+            {
+                set_pager_to(trimmed_input.substr(prefix.size()));
+                return true;
+            }
+        }
     }
 
     // Handle `ls` metacommand

--- a/tests/queries/0_stateless/04266_client_pager.expect
+++ b/tests/queries/0_stateless/04266_client_pager.expect
@@ -1,0 +1,202 @@
+#!/usr/bin/expect -f
+
+set basedir [file dirname $argv0]
+set basename [file tail $argv0]
+if {[info exists env(CLICKHOUSE_TMP)]} {
+    set CLICKHOUSE_TMP $env(CLICKHOUSE_TMP)
+} else {
+    set CLICKHOUSE_TMP "."
+}
+exp_internal -f $CLICKHOUSE_TMP/$basename.debuglog 0
+set history_file $CLICKHOUSE_TMP/$basename.history
+set pager_out $CLICKHOUSE_TMP/$basename.pager_out
+
+log_user 0
+set timeout 60
+match_max 100000
+expect_after {
+    -i $any_spawn_id eof { exp_continue }
+    -i $any_spawn_id timeout { exit 1 }
+}
+
+# `tee FILE >/dev/null` is used as the side-channel pager: it captures query
+# bytes in FILE but does NOT echo them to the tty. Echoing through the tty
+# would flood expect's buffer (and the pty's column wrap) on large queries
+# and time out before we ever see the next `:) ` prompt.
+set tee_pager "tee $pager_out >/dev/null"
+
+# Make sure the side-channel file is empty/absent before we begin.
+catch {file delete $pager_out}
+
+spawn bash -c "source $basedir/../shell_config.sh ; \$CLICKHOUSE_CLIENT_BINARY \$CLICKHOUSE_CLIENT_EXPECT_OPT --history_file=$history_file"
+expect ":) "
+
+# ------------------------------------------------------------------
+# 1. Setting the pager at runtime must actually route output through it.
+# ------------------------------------------------------------------
+send -- "pager $tee_pager\r"
+expect "PAGER set to '$tee_pager'"
+expect ":) "
+
+send -- "SELECT 'PAGER_PROOF' FORMAT TSV\r"
+expect ":) "
+
+set fp [open $pager_out r]
+set captured [read $fp]
+close $fp
+if {[string first "PAGER_PROOF" $captured] == -1} {
+    send_user "FAIL: pager did not capture query output. file=<$captured>\n"
+    exit 1
+}
+
+# ------------------------------------------------------------------
+# 2. Disabling the pager at runtime must stop routing through it.
+# ------------------------------------------------------------------
+set fp [open $pager_out w]
+close $fp
+
+send -- "nopager\r"
+expect "PAGER set to stdout"
+expect ":) "
+
+send -- "SELECT 'AFTER_NOPAGER' FORMAT TSV\r"
+expect "AFTER_NOPAGER"
+expect ":) "
+
+set fp [open $pager_out r]
+set captured [read $fp]
+close $fp
+if {[string length $captured] != 0} {
+    send_user "FAIL: pager still capturing after nopager. file=<$captured>\n"
+    exit 1
+}
+
+# ------------------------------------------------------------------
+# 3. Re-enable via the `\P` alias and prove with `md5sum` that the
+#    pager really receives the query bytes. md5sum writes its hash to
+#    its own stdout (the tty), so we can match it directly. The hash
+#    of "PAGER_HASH_PROBE\n" is unique enough to not collide with
+#    query ids, elapsed times, or other client chatter.
+# ------------------------------------------------------------------
+send -- "\\P md5sum\r"
+expect "PAGER set to 'md5sum'"
+expect ":) "
+
+send -- "SELECT 'PAGER_HASH_PROBE' FORMAT TSV\r"
+expect "db1fbed951a80c208d961466aa97e619"
+expect ":) "
+
+# ------------------------------------------------------------------
+# 4. `\n` alias must also disable, and subsequent output goes
+#    directly to the tty (not through md5sum).
+# ------------------------------------------------------------------
+send -- "\\n\r"
+expect "PAGER set to stdout"
+expect ":) "
+
+send -- "SELECT 'DIRECT_OUTPUT' FORMAT TSV\r"
+expect "DIRECT_OUTPUT"
+expect ":) "
+
+# ------------------------------------------------------------------
+# 5a. Trailing `;` on `pager <cmd>` is accepted and the pager is
+#     actually wired up.
+# ------------------------------------------------------------------
+set fp [open $pager_out w]
+close $fp
+
+send -- "pager $tee_pager;\r"
+expect "PAGER set to '$tee_pager'"
+expect ":) "
+
+send -- "SELECT 'SEMI_SET_PROOF' FORMAT TSV\r"
+expect ":) "
+
+set fp [open $pager_out r]
+set captured [read $fp]
+close $fp
+if {[string first "SEMI_SET_PROOF" $captured] == -1} {
+    send_user "FAIL: pager set with trailing ';' did not engage. file=<$captured>\n"
+    exit 1
+}
+
+# 5b. Bare `pager` disables (mysql semantics); subsequent query must
+#     NOT land in the file.
+set fp [open $pager_out w]
+close $fp
+
+send -- "pager\r"
+expect "PAGER set to stdout"
+expect ":) "
+
+send -- "SELECT 'AFTER_BARE_PAGER' FORMAT TSV\r"
+expect "AFTER_BARE_PAGER"
+expect ":) "
+
+set fp [open $pager_out r]
+set captured [read $fp]
+close $fp
+if {[string length $captured] != 0} {
+    send_user "FAIL: bare `pager` did not disable. file=<$captured>\n"
+    exit 1
+}
+
+# ------------------------------------------------------------------
+# 6. SETTINGS must be RAISED on runtime pager change.
+#    Pretty formats default to truncating values wider than 10000
+#    characters with the U+22EF (⋯) ellipsis. With the pager set at
+#    runtime, the limit must be raised so the value survives intact
+#    through the pager pipe. Two columns are used so the single-cell
+#    "don't cut" exception does not apply.
+# ------------------------------------------------------------------
+set fp [open $pager_out w]
+close $fp
+
+send -- "pager $tee_pager\r"
+expect "PAGER set to '$tee_pager'"
+expect ":) "
+
+send -- "SELECT repeat('A', 11000) AS v, 1 AS x FORMAT PrettyCompact\r"
+expect ":) "
+
+set fp [open $pager_out r]
+set captured [read $fp]
+close $fp
+set a_count [regexp -all {A} $captured]
+if {$a_count < 11000} {
+    send_user "FAIL: SETTINGS not raised; only $a_count A's captured (default would truncate at 10000)\n"
+    exit 1
+}
+if {[string first "⋯" $captured] != -1} {
+    send_user "FAIL: ellipsis present, value was truncated despite runtime pager set\n"
+    exit 1
+}
+
+# ------------------------------------------------------------------
+# 7. SETTINGS must be RESTORED on `nopager`.
+#    Counterpart to step 6: after `nopager` the limit must drop back
+#    to its default (10000), so a value wider than the default is
+#    again cut with `⋯` when output goes directly to the tty. If the
+#    limit stays at its raised value, `⋯` never appears and the
+#    `expect "⋯"` below times out (which the global expect_after
+#    handler turns into a test failure).
+# ------------------------------------------------------------------
+send -- "nopager\r"
+expect "PAGER set to stdout"
+expect ":) "
+
+send -- "SELECT repeat('A', 10001) AS v, 1 AS x FORMAT PrettyCompact\r"
+expect "⋯"
+expect ":) "
+
+# ------------------------------------------------------------------
+# 8. Identifier `pager` mid-statement must NOT be intercepted.
+# ------------------------------------------------------------------
+send -- "SELECT 'pager' AS x FORMAT TSV\r"
+expect "pager"
+expect ":) "
+
+send -- "exit\r"
+expect eof
+
+catch {file delete $pager_out}


### PR DESCRIPTION
Add interactive meta-commands to clickhouse-client to set or unset the pager during an interactive session, similar to the mysql CLI:

  pager <cmd...> / \P <cmd...>   set pager command
  pager / nopager / \n           disable pager

This is very handy to avoid quitting client and launching it again.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add mysql-style runtime pager control for clickhouse-client/local

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to interactive `clickhouse-client`/`local` meta-command parsing and output paging behavior, with coverage via a new expect-based regression test.
> 
> **Overview**
> Adds MySQL-style interactive meta-commands to enable/disable the client pager at runtime (`pager <cmd>`/`\\P <cmd>` to set; `pager`/`nopager`/`\\n` to unset), with immediate feedback printed to the console.
> 
> When toggling the pager, the client now re-applies `adjustSettings()` so Pretty-format row/value truncation limits are updated consistently even if `--pager` wasn’t set at startup. A new stateless expect test verifies pager routing, disable/reenable aliases, handling of trailing `;`, settings re-application, and that `pager` used as SQL text is not intercepted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84790f83ec78aee26b08ab6e0bc6712f6e4f1745. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1048`
<!-- ch-version-info:end -->