### PR TITLE
Remove redundant includes of config.h

### DIFF
--- a/src/AggregateFunctions/IAggregateFunction.h
+++ b/src/AggregateFunctions/IAggregateFunction.h
@@ -14,7 +14,6 @@
 #include <Common/UnorderedSetWithMemoryTracking.h>
 
 #include <IO/ReadBuffer.h>
-#include "config.h"
 
 #include <cstddef>
 #include <memory>

--- a/src/BridgeHelper/XDBCBridgeHelper.h
+++ b/src/BridgeHelper/XDBCBridgeHelper.h
@@ -16,9 +16,6 @@
 #include <base/range.h>
 #include <BridgeHelper/IBridgeHelper.h>
 
-#include "config.h"
-
-
 namespace DB
 {
 

--- a/src/Common/BufferAllocationPolicy.h
+++ b/src/Common/BufferAllocationPolicy.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "config.h"
 
 #include <memory>
 

--- a/src/Common/JemallocCacheArena.cpp
+++ b/src/Common/JemallocCacheArena.cpp
@@ -1,5 +1,7 @@
 #include <Common/JemallocCacheArena.h>
 
+#include "config.h"
+
 #if USE_JEMALLOC
 
 #include <jemalloc/jemalloc.h>

--- a/src/Common/JemallocCacheArena.h
+++ b/src/Common/JemallocCacheArena.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "config.h"
 
 namespace DB::JemallocCacheArena
 {

--- a/src/Common/JemallocMergeTreeArena.cpp
+++ b/src/Common/JemallocMergeTreeArena.cpp
@@ -1,5 +1,7 @@
 #include <Common/JemallocMergeTreeArena.h>
 
+#include "config.h"
+
 #if USE_JEMALLOC
 
 #include <Common/Jemalloc.h>

--- a/src/Common/JemallocMergeTreeArena.h
+++ b/src/Common/JemallocMergeTreeArena.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "config.h"
 
 namespace DB::JemallocMergeTreeArena
 {

--- a/src/Common/OptimizedRegularExpression.h
+++ b/src/Common/OptimizedRegularExpression.h
@@ -4,7 +4,6 @@
 #include <string>
 #include <vector>
 #include <Common/re2.h>
-#include "config.h"
 
 namespace DB
 {

--- a/src/Common/PODArray.h
+++ b/src/Common/PODArray.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "config.h"
-
 #include <base/getPageSize.h>
 #include <boost/noncopyable.hpp>
 #include <Common/Allocator.h>

--- a/src/Common/QueryProfiler.cpp
+++ b/src/Common/QueryProfiler.cpp
@@ -15,6 +15,8 @@
 #include <Common/thread_local_rng.h>
 #include <csignal>
 
+#include "config.h"
+
 
 namespace CurrentMetrics
 {

--- a/src/Common/QueryProfiler.h
+++ b/src/Common/QueryProfiler.h
@@ -5,8 +5,6 @@
 #include <signal.h>
 #include <time.h>
 
-#include "config.h"
-
 #include <Common/Logger.h>
 
 

--- a/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "config.h"
 
 #include <Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h>
 

--- a/src/Disks/DiskObjectStorage/ObjectStorages/Web/WebObjectStorage.h
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/Web/WebObjectStorage.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "config.h"
 
 #include <Common/SharedMutex.h>
 #include <Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h>

--- a/src/Disks/IO/AsynchronousBoundedReadBuffer.h
+++ b/src/Disks/IO/AsynchronousBoundedReadBuffer.h
@@ -5,7 +5,6 @@
 #include <IO/AsynchronousReader.h>
 #include <IO/ReadBufferFromFile.h>
 #include <Interpreters/FilesystemReadPrefetchesLog.h>
-#include "config.h"
 
 namespace Poco { class Logger; }
 

--- a/src/Disks/IO/ReadBufferFromRemoteFSGather.h
+++ b/src/Disks/IO/ReadBufferFromRemoteFSGather.h
@@ -3,7 +3,6 @@
 #include <Disks/DiskObjectStorage/ObjectStorages/IObjectStorage.h>
 #include <IO/AsynchronousReader.h>
 #include <IO/ReadBufferFromFile.h>
-#include "config.h"
 
 namespace Poco { class Logger; }
 

--- a/src/Disks/IO/WriteBufferWithFinalizeCallback.h
+++ b/src/Disks/IO/WriteBufferWithFinalizeCallback.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "config.h"
 
 #include <IO/WriteBufferFromFile.h>
 #include <IO/WriteBufferFromFileDecorator.h>

--- a/src/Functions/FunctionMathBinaryFloat64.h
+++ b/src/Functions/FunctionMathBinaryFloat64.h
@@ -8,7 +8,6 @@
 #include <Functions/FunctionHelpers.h>
 #include <Interpreters/castColumn.h>
 
-#include "config.h"
 
 namespace DB
 {

--- a/src/Functions/FunctionsEmbeddedDictionaries.h
+++ b/src/Functions/FunctionsEmbeddedDictionaries.h
@@ -17,9 +17,6 @@
 #include <Common/typeid_cast.h>
 #include <Core/Defines.h>
 
-#include "config.h"
-
-
 namespace DB
 {
 

--- a/src/Functions/MatchImpl.h
+++ b/src/Functions/MatchImpl.h
@@ -8,9 +8,6 @@
 #include <Core/ColumnNumbers.h>
 #include <Functions/Regexps.h>
 
-#include "config.h"
-
-
 namespace DB
 {
 

--- a/src/IO/ReadWriteBufferFromHTTP.h
+++ b/src/IO/ReadWriteBufferFromHTTP.h
@@ -22,7 +22,6 @@
 #include <Poco/URI.h>
 #include <Poco/URIStreamFactory.h>
 #include <Common/RemoteHostFilter.h>
-#include "config.h"
 #include <Common/config_version.h>
 
 #include <filesystem>

--- a/src/Server/WebUIRequestHandler.h
+++ b/src/Server/WebUIRequestHandler.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "config.h"
 
 #include <Server/HTTP/HTTPRequestHandler.h>
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/EqualityDeleteObject.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/EqualityDeleteObject.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "config.h"
 
 #include <optional>
 #include <base/types.h>

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergTableStateSnapshot.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/IcebergTableStateSnapshot.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "config.h"
 
 #include <Storages/StorageSnapshot.h>
 

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteObject.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteObject.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "config.h"
 
 #include <optional>
 #include <base/types.h>

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/SchemaProcessor.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "config.h"
 
 
 #include <memory>

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueMetadata.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "config.h"
 
 #include <filesystem>
 #include <optional>

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.h
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSource.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "config.h"
 
 #include <Interpreters/ObjectStorageQueueLog.h>
 #include <Processors/ISource.h>

--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "config.h"
 
 #include <chrono>
 #include <optional>

--- a/src/Storages/StorageLoop.h
+++ b/src/Storages/StorageLoop.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "config.h"
 #include <Storages/IStorage.h>
 #include <Parsers/IAST_fwd.h>
 

--- a/src/Storages/StorageURLCluster.h
+++ b/src/Storages/StorageURLCluster.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "config.h"
 
 #include <memory>
 #include <optional>

--- a/src/TableFunctions/TableFunctionFuzzQuery.h
+++ b/src/TableFunctions/TableFunctionFuzzQuery.h
@@ -6,7 +6,6 @@
 #include <DataTypes/DataTypeString.h>
 #include <Storages/StorageFuzzQuery.h>
 
-#include "config.h"
 
 namespace DB
 {


### PR DESCRIPTION
    $ gg 'include.*"config.h"' src/**.h | cut -d: -f1 | sort -u | xargs -i sh -c 'grep -q -e WITH_COVERAGE -e USE_ -e CLICKHOUSE_CLOUD {} || echo {}' | xargs sed -i '/include "config.h"/d'

Reduces only from 4K to 3K, likely due to inclusion of it in IColumn.h

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.136`
<!-- ch-version-info:end -->