### PR TITLE
Enable `apply_row_policy_after_final` by default on 26.1

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -1469,7 +1469,7 @@ Split parts ranges into intersecting and non intersecting during FINAL optimizat
     DECLARE(Bool, split_intersecting_parts_ranges_into_layers_final, true, R"(
 Split intersecting parts ranges into layers during FINAL optimization
 )", 0) \
-    DECLARE(Bool, apply_row_policy_after_final, false, R"(
+    DECLARE(Bool, apply_row_policy_after_final, true, R"(
 When enabled, row policies and PREWHERE are applied after FINAL processing for *MergeTree tables. (Especially for ReplacingMergeTree)
 When disabled, row policies are applied before FINAL, which can cause different results when the policy
 filters out rows that should be used for deduplication in ReplacingMergeTree or similar engines.

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -41,6 +41,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         /// Note: please check if the key already exists to prevent duplicate entries.
         addSettingsChanges(settings_changes_history, "26.1",
         {
+            {"apply_row_policy_after_final", false, true, "Re-enable apply_row_policy_after_final by default on 26.1. #97279 restored this default on master / 25.12 / 26.2+; the 26.1 backport (#97403) was previously closed without merging, leaving 26.1 with the buggy `false` default from #87303."},
             {"http_max_fields", 1000000, 1000, "Reduce default to limit pre-authentication memory usage by HTTP connections."},
             {"http_max_field_name_size", 131072, 4096, "Reduce default to limit pre-authentication memory usage by HTTP connections."},
             {"http_max_request_header_size", 0, 10485760, "New setting to limit total HTTP request header size before authentication."},

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -109,7 +109,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"aggregate_function_input_format", "state", "state", "New setting to control AggregateFunction input format during INSERT operations. Setting Value set to state by default"},
             {"delta_lake_snapshot_start_version", -1, -1, "New setting."},
             {"delta_lake_snapshot_end_version", -1, -1, "New setting."},
-            {"apply_row_policy_after_final", false, false, "New setting to control if row policies and PREWHERE are applied after FINAL processing for *MergeTree tables"},
+            {"apply_row_policy_after_final", true, true, "New setting to control if row policies and PREWHERE are applied after FINAL processing for *MergeTree tables"},
             {"apply_prewhere_after_final", false, false, "New setting. When enabled, PREWHERE conditions are applied after FINAL processing."},
             {"compatibility_s3_presigned_url_query_in_path", false, false, "New setting."},
             {"serialize_string_in_memory_with_zero_byte", true, true, "New setting"},

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -41,7 +41,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
         /// Note: please check if the key already exists to prevent duplicate entries.
         addSettingsChanges(settings_changes_history, "26.1",
         {
-            {"apply_row_policy_after_final", false, true, "Re-enable apply_row_policy_after_final by default on 26.1. #97279 restored this default on master / 25.12 / 26.2+; the 26.1 backport (#97403) was previously closed without merging, leaving 26.1 with the buggy `false` default from #87303."},
+            {"apply_row_policy_after_final", true, true, "Re-enable apply_row_policy_after_final by default on 26.1. #97279 restored this default on master / 25.12 / 26.2+; the 26.1 backport (#97403) was previously closed without merging, leaving 26.1 with the buggy `false` default from #87303."},
             {"http_max_fields", 1000000, 1000, "Reduce default to limit pre-authentication memory usage by HTTP connections."},
             {"http_max_field_name_size", 131072, 4096, "Reduce default to limit pre-authentication memory usage by HTTP connections."},
             {"http_max_request_header_size", 0, 10485760, "New setting to limit total HTTP request header size before authentication."},

--- a/tests/queries/0_stateless/03742_apply_row_policy_after_final.sql
+++ b/tests/queries/0_stateless/03742_apply_row_policy_after_final.sql
@@ -19,6 +19,10 @@ SELECT * FROM tab FINAL ORDER BY x;
 CREATE ROW POLICY pol1 ON tab USING y != 'ccc' TO ALL;
 
 SELECT '= with row policy (default behavior - filter before FINAL) =';
+-- The default of apply_row_policy_after_final is `true` on 26.1 after #97279 was
+-- finally backported. Pin to `0` here so this section continues to exercise the
+-- pre-#97279 filter-before-FINAL behavior it was designed to test.
+SET apply_row_policy_after_final = 0;
 SELECT '--- raw';
 SELECT * FROM tab ORDER BY x, version;
 SELECT '--- final';


### PR DESCRIPTION
The 26.1 branch still ships with `apply_row_policy_after_final = false` — the unintended side effect of #87303 (the fix-move-to-PREWHERE-in-the-presence-of-a-row-policy patch). #97279 restored the correct default of `true` on master and was backported to 25.12 and 26.2+ via #97402, but the 26.1 backport (#97403) was closed without merging at the time. Result: 26.1 is the only maintained branch on which row policies and PREWHERE are applied before FINAL by default — a correctness regression for ReplacingMergeTree users (rows that should win deduplication can be dropped by the row policy before FINAL ever sees them).

This PR applies the same fix that landed on every other maintained branch:

- Flip `DECLARE(Bool, apply_row_policy_after_final, …)` from `false` to `true` in `src/Core/Settings.cpp`.
- Update the existing `25.12`-block history entry from `{false, false, "…"}` to `{true, true, "…"}` (in-place, original comment preserved) so the `compatibility` walker resolves to `true` for every level on this branch, matching the DECLARE default and every other maintained branch.

Equivalent in effect to #97279 + #105637 collapsed into a single in-place edit.

> ⚠️ This is a backward-incompatible change to the 26.1 default. Queries that depended on the buggy `false` default will start applying row policies after FINAL.

### Changelog category (leave one):
- Backward Incompatible Change


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Enable `apply_row_policy_after_final` by default on `26.1`, matching every other maintained release. This restores the correctness-safe row-policy-after-FINAL semantics that were unintentionally disabled in `26.1` by #87303.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)