### PR TITLE
Canonicalize NaN bit patterns at hash boundaries (DISTINCT/GROUP BY/uniqExact)

### DIFF
--- a/src/AggregateFunctions/AggregateFunctionUniq.h
+++ b/src/AggregateFunctions/AggregateFunctionUniq.h
@@ -14,6 +14,7 @@
 
 #include <Common/HashTable/Hash.h>
 #include <Common/HashTable/HashSet.h>
+#include <Common/NaNUtils.h>
 #include <Common/HyperLogLogWithSmallSetOptimization.h>
 #include <Common/assert_cast.h>
 #include <Common/typeid_cast.h>
@@ -306,7 +307,10 @@ struct Adder
             else
             {
                 using ValueType = typename decltype(data.set)::value_type;
-                const auto & value = assert_cast<const ColumnVector<T> &>(column).getElement(row_num);
+                /// Canonicalize NaN bit patterns so that approximate uniq estimators
+                /// count every NaN as the same value, matching `uniqExact` semantics
+                /// (see issue #105748).
+                const auto value = canonicalizeNaN(assert_cast<const ColumnVector<T> &>(column).getElement(row_num));
                 data.set.insert(static_cast<ValueType>(AggregateFunctionUniqTraits<T>::hash(value)));
             }
         }
@@ -325,7 +329,12 @@ struct Adder
             }
             else
             {
-                data.set.template insert<const T &, hint>(assert_cast<const ColumnVector<T> &>(column).getData()[row_num]);
+                /// `HashSet` compares keys via `bitEquals`, so two NaNs with different
+                /// bit patterns (e.g. `0./0.` vs the literal `nan`, or scalar `log(-1.)`
+                /// vs the ARM NEON `log` after PR #98230) would otherwise be treated as
+                /// distinct values. Canonicalize NaN before inserting (issue #105748).
+                const T value = canonicalizeNaN(assert_cast<const ColumnVector<T> &>(column).getData()[row_num]);
+                data.set.template insert<const T &, hint>(value);
             }
         }
 #if USE_DATASKETCHES
@@ -371,9 +380,14 @@ private:
         {
             if (!null_map)
             {
+                /// `insertMany` reads raw values from the column without any
+                /// NaN canonicalization; floating-point columns must go through
+                /// the per-row `add` path so that the canonicalization done
+                /// there (see issue #105748) is applied to every value.
                 if constexpr (std::is_same_v<Data, AggregateFunctionUniqUniquesHashSetData> &&
                         !std::is_same_v<T, String> &&
-                        !std::is_same_v<T, IPv6>)
+                        !std::is_same_v<T, IPv6> &&
+                        !is_floating_point<T>)
                 {
                     const auto & column = *columns[0];
                     data.set.template insertMany<T, AggregateFunctionUniqTraits<T>::hash>(

--- a/src/AggregateFunctions/AggregateFunctionUniqCombined.h
+++ b/src/AggregateFunctions/AggregateFunctionUniqCombined.h
@@ -13,6 +13,7 @@
 #include <base/bit_cast.h>
 
 #include <Common/CombinedCardinalityEstimator.h>
+#include <Common/NaNUtils.h>
 #include <Common/SipHash.h>
 #include <Common/typeid_cast.h>
 #include <Common/assert_cast.h>
@@ -113,7 +114,9 @@ public:
             }
             else if constexpr (is_floating_point<T>)
             {
-                hash = static_cast<HashValueType>(intHash64(bit_cast<UInt64>(value)));
+                /// Canonicalize NaN bit patterns so every NaN hashes to the same
+                /// slot, matching `uniqExact` and `DISTINCT` semantics (issue #105748).
+                hash = static_cast<HashValueType>(intHash64(bit_cast<UInt64>(canonicalizeNaN(value))));
             }
             else if constexpr (sizeof(T) > sizeof(UInt64))
             {

--- a/src/Columns/ColumnVector.cpp
+++ b/src/Columns/ColumnVector.cpp
@@ -69,13 +69,30 @@ void ColumnVector<T>::skipSerializedInArena(ReadBuffer & in) const
 template <typename T>
 void ColumnVector<T>::updateHashWithValue(size_t n, SipHash & hash) const
 {
-    hash.update(data[n]);
+    /// For floating-point columns, fold every NaN bit pattern onto the canonical
+    /// NaN before hashing so that `DISTINCT`/`GROUP BY`/`uniqExact` and similar
+    /// hash-based set semantics treat NaNs as a single group regardless of
+    /// where the NaN was produced (see issue #105748).
+    if constexpr (is_floating_point<T>)
+        hash.update(canonicalizeNaN(data[n]));
+    else
+        hash.update(data[n]);
 }
 
 template <typename T>
 void ColumnVector<T>::updateHashWithValueRange(size_t begin, size_t end, SipHash & hash) const
 {
-    hash.update(reinterpret_cast<const char *>(&data[begin]), (end - begin) * sizeof(T));
+    if constexpr (is_floating_point<T>)
+    {
+        /// Per-element path: cannot use the bulk byte update because NaN bit
+        /// patterns must be canonicalized first.
+        for (size_t i = begin; i < end; ++i)
+            hash.update(canonicalizeNaN(data[i]));
+    }
+    else
+    {
+        hash.update(reinterpret_cast<const char *>(&data[begin]), (end - begin) * sizeof(T));
+    }
 }
 
 template <typename T>
@@ -90,7 +107,10 @@ WeakHash32 ColumnVector<T>::getWeakHash32() const
 
     while (begin < end)
     {
-        *hash_data = static_cast<UInt32>(hashCRC32(*begin, *hash_data));
+        if constexpr (is_floating_point<T>)
+            *hash_data = static_cast<UInt32>(hashCRC32(canonicalizeNaN(*begin), *hash_data));
+        else
+            *hash_data = static_cast<UInt32>(hashCRC32(*begin, *hash_data));
         ++begin;
         ++hash_data;
     }
@@ -101,7 +121,16 @@ WeakHash32 ColumnVector<T>::getWeakHash32() const
 template <typename T>
 void ColumnVector<T>::updateHashFast(SipHash & hash) const
 {
-    hash.update(reinterpret_cast<const char *>(data.data()), size() * sizeof(data[0]));
+    if constexpr (is_floating_point<T>)
+    {
+        const size_t s = size();
+        for (size_t i = 0; i < s; ++i)
+            hash.update(canonicalizeNaN(data[i]));
+    }
+    else
+    {
+        hash.update(reinterpret_cast<const char *>(data.data()), size() * sizeof(data[0]));
+    }
 }
 
 template <typename T>

--- a/src/Common/ColumnsHashing/HashMethod.h
+++ b/src/Common/ColumnsHashing/HashMethod.h
@@ -46,11 +46,13 @@ inline bool needsFloatNaNCanonicalization(const IColumn * actual_column)
         return typeid_cast<const ColumnFloat32 *>(actual_column) != nullptr;
     else if constexpr (sizeof(FieldType) == sizeof(Float64))
         return typeid_cast<const ColumnFloat64 *>(actual_column) != nullptr;
+    else if constexpr (sizeof(FieldType) == sizeof(BFloat16))
+        return typeid_cast<const ColumnBFloat16 *>(actual_column) != nullptr;
     else
         return false;
 }
 
-/// Reinterpret the `FieldType` bytes as `Float32`/`Float64`, canonicalize the
+/// Reinterpret the `FieldType` bytes as `Float32`/`Float64`/`BFloat16`, canonicalize the
 /// NaN bit pattern, and return the resulting bytes back as `FieldType`. For
 /// `FieldType` widths that do not correspond to a floating-point type this is
 /// a compile-time no-op.
@@ -69,6 +71,13 @@ inline FieldType canonicalizeFloatBitsAsField(FieldType bits)
         Float64 f = std::bit_cast<Float64>(bits);
         if (isNaN(f))
             return std::bit_cast<FieldType>(canonicalNaN<Float64>());
+        return bits;
+    }
+    else if constexpr (sizeof(FieldType) == sizeof(BFloat16))
+    {
+        BFloat16 f = std::bit_cast<BFloat16>(bits);
+        if (isNaN(f))
+            return std::bit_cast<FieldType>(canonicalNaN<BFloat16>());
         return bits;
     }
     else
@@ -96,14 +105,15 @@ struct HashMethodOneNumber : public columns_hashing_impl::HashMethodBase<
     static constexpr bool has_cheap_key_calculation = true;
     static constexpr bool has_pre_computed_hashes = false;
 
-    /// `FieldType` widths 4 and 8 correspond to `Float32` and `Float64`. For
-    /// smaller widths there is no matching floating-point type so we never
-    /// need a runtime check and the branch is pruned at compile time.
+    /// `FieldType` widths 2, 4 and 8 correspond to `BFloat16`, `Float32` and `Float64`.
+    /// For other widths there is no matching floating-point type so we never need a
+    /// runtime check and the branch is pruned at compile time.
     static constexpr bool may_canonicalize_nan
-        = (sizeof(FieldType) == sizeof(Float32)) || (sizeof(FieldType) == sizeof(Float64));
+        = (sizeof(FieldType) == sizeof(Float32)) || (sizeof(FieldType) == sizeof(Float64))
+          || (sizeof(FieldType) == sizeof(BFloat16));
 
     const char * vec;
-    /// Set in the constructor when the underlying column is `ColumnFloat32`/`ColumnFloat64`.
+    /// Set in the constructor when the underlying column is `ColumnFloat32`/`ColumnFloat64`/`ColumnBFloat16`.
     /// Used by `getKeyHolder` to fold every NaN bit pattern onto the canonical one so that
     /// `DISTINCT`/`GROUP BY`/`uniqExact` hash-based set semantics treat all NaNs as a single
     /// value regardless of where the NaN was produced (see issue #105748).

--- a/src/Common/ColumnsHashing/HashMethod.h
+++ b/src/Common/ColumnsHashing/HashMethod.h
@@ -1,12 +1,16 @@
 #pragma once
 
-#include <Common/ColumnsHashingImpl.h>
-#include <Common/SipHash.h>
 #include <Columns/ColumnFixedString.h>
 #include <Columns/ColumnLowCardinality.h>
 #include <Columns/ColumnString.h>
+#include <Columns/ColumnsNumber.h>
+#include <Common/ColumnsHashingImpl.h>
+#include <Common/NaNUtils.h>
+#include <Common/SipHash.h>
 #include <Interpreters/AggregationCommon.h>
 #include <base/types.h>
+
+#include <bit>
 
 namespace DB
 {
@@ -29,6 +33,52 @@ static inline UInt128 ALWAYS_INLINE hash128( /// NOLINT
     return hash.get128();
 }
 
+namespace columns_hashing_impl
+{
+
+/// Return true when the (already-nullable-unwrapped) column is a `Float` column
+/// whose value width matches `FieldType`. Used by `HashMethodOneNumber` to
+/// decide whether to canonicalize NaN bit patterns when extracting hash keys.
+template <typename FieldType>
+inline bool needsFloatNaNCanonicalization(const IColumn * actual_column)
+{
+    if constexpr (sizeof(FieldType) == sizeof(Float32))
+        return typeid_cast<const ColumnFloat32 *>(actual_column) != nullptr;
+    else if constexpr (sizeof(FieldType) == sizeof(Float64))
+        return typeid_cast<const ColumnFloat64 *>(actual_column) != nullptr;
+    else
+        return false;
+}
+
+/// Reinterpret the `FieldType` bytes as `Float32`/`Float64`, canonicalize the
+/// NaN bit pattern, and return the resulting bytes back as `FieldType`. For
+/// `FieldType` widths that do not correspond to a floating-point type this is
+/// a compile-time no-op.
+template <typename FieldType>
+inline FieldType canonicalizeFloatBitsAsField(FieldType bits)
+{
+    if constexpr (sizeof(FieldType) == sizeof(Float32))
+    {
+        Float32 f = std::bit_cast<Float32>(bits);
+        if (isNaN(f))
+            return std::bit_cast<FieldType>(canonicalNaN<Float32>());
+        return bits;
+    }
+    else if constexpr (sizeof(FieldType) == sizeof(Float64))
+    {
+        Float64 f = std::bit_cast<Float64>(bits);
+        if (isNaN(f))
+            return std::bit_cast<FieldType>(canonicalNaN<Float64>());
+        return bits;
+    }
+    else
+    {
+        return bits;
+    }
+}
+
+}
+
 /// For the case when there is one numeric key.
 /// UInt8/16/32/64 for any type with corresponding bit width.
 template <typename Value, typename Mapped, typename FieldType, bool use_cache = true, bool need_offset = false, bool nullable = false>
@@ -46,7 +96,18 @@ struct HashMethodOneNumber : public columns_hashing_impl::HashMethodBase<
     static constexpr bool has_cheap_key_calculation = true;
     static constexpr bool has_pre_computed_hashes = false;
 
+    /// `FieldType` widths 4 and 8 correspond to `Float32` and `Float64`. For
+    /// smaller widths there is no matching floating-point type so we never
+    /// need a runtime check and the branch is pruned at compile time.
+    static constexpr bool may_canonicalize_nan
+        = (sizeof(FieldType) == sizeof(Float32)) || (sizeof(FieldType) == sizeof(Float64));
+
     const char * vec;
+    /// Set in the constructor when the underlying column is `ColumnFloat32`/`ColumnFloat64`.
+    /// Used by `getKeyHolder` to fold every NaN bit pattern onto the canonical one so that
+    /// `DISTINCT`/`GROUP BY`/`uniqExact` hash-based set semantics treat all NaNs as a single
+    /// value regardless of where the NaN was produced (see issue #105748).
+    bool canonicalize_nan_in_keys = false;
 
     /// If the keys of a fixed length then key_sizes contains their lengths, empty otherwise.
     HashMethodOneNumber(const ColumnRawPtrs & key_columns, const Sizes & /*key_sizes*/, const HashMethodContextPtr &) : Base(key_columns[0])
@@ -54,11 +115,16 @@ struct HashMethodOneNumber : public columns_hashing_impl::HashMethodBase<
         if constexpr (nullable)
         {
             const auto & null_column = checkAndGetColumn<ColumnNullable>(*key_columns[0]);
-            vec = null_column.getNestedColumnPtr()->getRawData().data();
+            const auto * nested = null_column.getNestedColumnPtr().get();
+            vec = nested->getRawData().data();
+            if constexpr (may_canonicalize_nan)
+                canonicalize_nan_in_keys = columns_hashing_impl::needsFloatNaNCanonicalization<FieldType>(nested);
         }
         else
         {
             vec = key_columns[0]->getRawData().data();
+            if constexpr (may_canonicalize_nan)
+                canonicalize_nan_in_keys = columns_hashing_impl::needsFloatNaNCanonicalization<FieldType>(key_columns[0]);
         }
     }
 
@@ -67,11 +133,16 @@ struct HashMethodOneNumber : public columns_hashing_impl::HashMethodBase<
         if constexpr (nullable)
         {
             const auto & null_column = checkAndGetColumn<ColumnNullable>(*column);
-            vec = null_column.getNestedColumnPtr()->getRawData().data();
+            const auto * nested = null_column.getNestedColumnPtr().get();
+            vec = nested->getRawData().data();
+            if constexpr (may_canonicalize_nan)
+                canonicalize_nan_in_keys = columns_hashing_impl::needsFloatNaNCanonicalization<FieldType>(nested);
         }
         else
         {
             vec = column->getRawData().data();
+            if constexpr (may_canonicalize_nan)
+                canonicalize_nan_in_keys = columns_hashing_impl::needsFloatNaNCanonicalization<FieldType>(column);
         }
     }
 
@@ -90,7 +161,16 @@ struct HashMethodOneNumber : public columns_hashing_impl::HashMethodBase<
     using Base::getHash; /// (const Data & data, size_t row, Arena & pool) -> size_t
 
     /// Is used for default implementation in HashMethodBase.
-    FieldType getKeyHolder(size_t row, Arena &) const { return unalignedLoad<FieldType>(vec + row * sizeof(FieldType)); }
+    FieldType getKeyHolder(size_t row, Arena &) const
+    {
+        FieldType bits = unalignedLoad<FieldType>(vec + row * sizeof(FieldType));
+        if constexpr (may_canonicalize_nan)
+        {
+            if (canonicalize_nan_in_keys)
+                return columns_hashing_impl::canonicalizeFloatBitsAsField<FieldType>(bits);
+        }
+        return bits;
+    }
 
     const FieldType * getKeyData() const { return reinterpret_cast<const FieldType *>(vec); }
 };

--- a/src/Common/NaNUtils.h
+++ b/src/Common/NaNUtils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <bit>
 #include <cmath>
 #include <limits>
 #include <type_traits>
@@ -65,17 +66,25 @@ T NaNOrZero()
     return {};
 }
 
-/// Canonical positive quiet NaN for a floating-point type. For BFloat16 we
-/// construct it from the Float32 canonical NaN; for the other floats we use the
-/// implementation-defined `std::numeric_limits<T>::quiet_NaN()`.
+/// Canonical positive quiet NaN for a floating-point type.
+///
+/// Uses explicit IEEE 754 bit patterns rather than `std::numeric_limits<T>::quiet_NaN`,
+/// which is implementation-defined and could pick a different encoding on a different
+/// libc++/libstdc++ build. `uniqExact` and similar set aggregates serialize and
+/// deserialize keys byte-wise without re-canonicalizing on read, so distributed merges
+/// across mixed architectures need a guaranteed-stable canonical form. See issue #105748.
 template <typename T>
 inline T canonicalNaN()
 {
     static_assert(is_floating_point<T>, "canonicalNaN is only defined for floating-point types");
     if constexpr (std::is_same_v<T, BFloat16>)
-        return BFloat16(std::numeric_limits<Float32>::quiet_NaN());
+        return BFloat16::fromBits(0x7FC0);
+    else if constexpr (std::is_same_v<T, Float32>)
+        return std::bit_cast<Float32>(UInt32{0x7FC00000});
+    else if constexpr (std::is_same_v<T, Float64>)
+        return std::bit_cast<Float64>(UInt64{0x7FF8000000000000});
     else
-        return std::numeric_limits<T>::quiet_NaN();
+        static_assert(sizeof(T) == 0, "canonicalNaN: unsupported floating-point type");
 }
 
 /// If `x` is a NaN, return the canonical NaN for type `T`. Otherwise return `x`

--- a/src/Common/NaNUtils.h
+++ b/src/Common/NaNUtils.h
@@ -65,6 +65,41 @@ T NaNOrZero()
     return {};
 }
 
+/// Canonical positive quiet NaN for a floating-point type. For BFloat16 we
+/// construct it from the Float32 canonical NaN; for the other floats we use the
+/// implementation-defined `std::numeric_limits<T>::quiet_NaN()`.
+template <typename T>
+inline T canonicalNaN()
+{
+    static_assert(is_floating_point<T>, "canonicalNaN is only defined for floating-point types");
+    if constexpr (std::is_same_v<T, BFloat16>)
+        return BFloat16(std::numeric_limits<Float32>::quiet_NaN());
+    else
+        return std::numeric_limits<T>::quiet_NaN();
+}
+
+/// If `x` is a NaN, return the canonical NaN for type `T`. Otherwise return `x`
+/// unchanged. For non-floating-point types this is a compile-time no-op.
+///
+/// Different operations and platforms can produce NaN bit patterns that differ
+/// in the sign bit or in the payload (for example glibc's scalar `log(-1.)`
+/// versus the ARM NEON fastops `log` after PR #98230, or division by zero
+/// versus the literal `nan` in SQL). Hash tables in ClickHouse compare keys
+/// byte-wise via `bitEquals`, so two NaNs that differ only in bit pattern are
+/// treated as distinct, which breaks `DISTINCT`, `GROUP BY`, `uniqExact`, and
+/// related set semantics. Call this helper at the hash/equality boundary to
+/// fold every NaN bit pattern onto a single canonical representation.
+template <typename T>
+inline T canonicalizeNaN(T x)
+{
+    if constexpr (is_floating_point<T>)
+    {
+        if (isNaN(x))
+            return canonicalNaN<T>();
+    }
+    return x;
+}
+
 template <typename T>
 bool signBit(T x)
 {

--- a/src/Common/tests/gtest_canonical_nan.cpp
+++ b/src/Common/tests/gtest_canonical_nan.cpp
@@ -1,0 +1,107 @@
+#include <gtest/gtest.h>
+
+#include <bit>
+#include <cmath>
+
+#include <Common/NaNUtils.h>
+#include <base/types.h>
+#include <base/BFloat16.h>
+
+
+/// `canonicalNaN<T>` must return a fixed IEEE 754 positive quiet NaN bit pattern
+/// for each supported floating-point type, regardless of the libc/libstdc++ build.
+/// `uniqExact` and similar set aggregates serialize keys byte-wise without
+/// re-canonicalizing on read, so a stable cross-platform canonical form is
+/// required for correctness of distributed merges. See issue #105748.
+
+TEST(CanonicalNaN, Float32BitPattern)
+{
+    /// IEEE 754 binary32 positive quiet NaN: sign=0, exp=0xFF, mantissa MSB=1.
+    EXPECT_EQ(std::bit_cast<UInt32>(canonicalNaN<Float32>()), UInt32{0x7FC00000});
+}
+
+TEST(CanonicalNaN, Float64BitPattern)
+{
+    /// IEEE 754 binary64 positive quiet NaN: sign=0, exp=0x7FF, mantissa MSB=1.
+    EXPECT_EQ(std::bit_cast<UInt64>(canonicalNaN<Float64>()), UInt64{0x7FF8000000000000});
+}
+
+TEST(CanonicalNaN, BFloat16BitPattern)
+{
+    /// `bf16` positive quiet NaN: sign=0, exp=0xFF, mantissa MSB=1.
+    EXPECT_EQ(std::bit_cast<UInt16>(canonicalNaN<BFloat16>()), UInt16{0x7FC0});
+}
+
+TEST(CanonicalNaN, IsNaN)
+{
+    /// Sanity check: the returned values are NaN according to `isNaN`.
+    EXPECT_TRUE(isNaN(canonicalNaN<Float32>()));
+    EXPECT_TRUE(isNaN(canonicalNaN<Float64>()));
+    EXPECT_TRUE(isNaN(canonicalNaN<BFloat16>()));
+}
+
+TEST(CanonicalizeNaN, FoldsAllNaNBitPatternsFloat32)
+{
+    /// Different NaN producers can yield different bit patterns. After canonicalization
+    /// they must all collapse onto a single representation.
+    const Float32 positive_qnan = std::bit_cast<Float32>(UInt32{0x7FC00000});
+    const Float32 negative_qnan = std::bit_cast<Float32>(UInt32{0xFFC00000});
+    const Float32 positive_qnan_payload = std::bit_cast<Float32>(UInt32{0x7FC12345});
+    const Float32 signaling_nan = std::bit_cast<Float32>(UInt32{0x7F800001});
+
+    const UInt32 expected = 0x7FC00000;
+    EXPECT_EQ(std::bit_cast<UInt32>(canonicalizeNaN(positive_qnan)), expected);
+    EXPECT_EQ(std::bit_cast<UInt32>(canonicalizeNaN(negative_qnan)), expected);
+    EXPECT_EQ(std::bit_cast<UInt32>(canonicalizeNaN(positive_qnan_payload)), expected);
+    EXPECT_EQ(std::bit_cast<UInt32>(canonicalizeNaN(signaling_nan)), expected);
+}
+
+TEST(CanonicalizeNaN, FoldsAllNaNBitPatternsFloat64)
+{
+    const Float64 positive_qnan = std::bit_cast<Float64>(UInt64{0x7FF8000000000000});
+    const Float64 negative_qnan = std::bit_cast<Float64>(UInt64{0xFFF8000000000000});
+    const Float64 positive_qnan_payload = std::bit_cast<Float64>(UInt64{0x7FF8123456789ABC});
+    const Float64 signaling_nan = std::bit_cast<Float64>(UInt64{0x7FF0000000000001});
+
+    const UInt64 expected = 0x7FF8000000000000;
+    EXPECT_EQ(std::bit_cast<UInt64>(canonicalizeNaN(positive_qnan)), expected);
+    EXPECT_EQ(std::bit_cast<UInt64>(canonicalizeNaN(negative_qnan)), expected);
+    EXPECT_EQ(std::bit_cast<UInt64>(canonicalizeNaN(positive_qnan_payload)), expected);
+    EXPECT_EQ(std::bit_cast<UInt64>(canonicalizeNaN(signaling_nan)), expected);
+}
+
+TEST(CanonicalizeNaN, FoldsAllNaNBitPatternsBFloat16)
+{
+    const BFloat16 positive_qnan = BFloat16::fromBits(0x7FC0);
+    const BFloat16 negative_qnan = BFloat16::fromBits(0xFFC0);
+    const BFloat16 positive_qnan_payload = BFloat16::fromBits(0x7FC1);
+    const BFloat16 signaling_nan = BFloat16::fromBits(0x7F81);
+
+    const UInt16 expected = 0x7FC0;
+    EXPECT_EQ(std::bit_cast<UInt16>(canonicalizeNaN(positive_qnan)), expected);
+    EXPECT_EQ(std::bit_cast<UInt16>(canonicalizeNaN(negative_qnan)), expected);
+    EXPECT_EQ(std::bit_cast<UInt16>(canonicalizeNaN(positive_qnan_payload)), expected);
+    EXPECT_EQ(std::bit_cast<UInt16>(canonicalizeNaN(signaling_nan)), expected);
+}
+
+TEST(CanonicalizeNaN, PreservesNonNaNValues)
+{
+    /// Non-NaN floats must be returned unchanged.
+    EXPECT_EQ(canonicalizeNaN(Float32{1.0f}), 1.0f);
+    EXPECT_EQ(canonicalizeNaN(Float32{0.0f}), 0.0f);
+    EXPECT_EQ(canonicalizeNaN(Float32{-1.5f}), -1.5f);
+    EXPECT_EQ(std::bit_cast<UInt32>(canonicalizeNaN(std::bit_cast<Float32>(UInt32{0x7F800000}))), UInt32{0x7F800000}); /// +inf
+    EXPECT_EQ(std::bit_cast<UInt32>(canonicalizeNaN(std::bit_cast<Float32>(UInt32{0xFF800000}))), UInt32{0xFF800000}); /// -inf
+
+    EXPECT_EQ(canonicalizeNaN(Float64{1.0}), 1.0);
+    EXPECT_EQ(canonicalizeNaN(Float64{0.0}), 0.0);
+    EXPECT_EQ(canonicalizeNaN(Float64{-1.5}), -1.5);
+}
+
+TEST(CanonicalizeNaN, IsNoOpForIntegerTypes)
+{
+    /// For non-floating-point types `canonicalizeNaN` is a compile-time no-op.
+    EXPECT_EQ(canonicalizeNaN(UInt32{42}), UInt32{42});
+    EXPECT_EQ(canonicalizeNaN(Int64{-7}), Int64{-7});
+    EXPECT_EQ(canonicalizeNaN(UInt16{0xFFFF}), UInt16{0xFFFF});
+}

--- a/tests/queries/0_stateless/01428_hash_set_nan_key.reference
+++ b/tests/queries/0_stateless/01428_hash_set_nan_key.reference
@@ -4,4 +4,4 @@ nan
 nan
 [nan]
 nan
-10
+1

--- a/tests/queries/0_stateless/01428_hash_set_nan_key.sql
+++ b/tests/queries/0_stateless/01428_hash_set_nan_key.sql
@@ -7,4 +7,7 @@ SELECT topKWeightedMerge(1)(initializeAggregation('topKWeightedState(1)', nan, a
 
 select number + nan k from numbers(256) group by k;
 
+-- Constructs 10 different NaN bit patterns by perturbing the mantissa of `nan`.
+-- Since #105748 (DISTINCT NaN canonicalization), hash-based set semantics fold
+-- every NaN bit pattern onto a single canonical NaN, so all 10 collapse to 1.
 SELECT uniqExact(reinterpretAsFloat64(reinterpretAsFixedString(reinterpretAsUInt64(reinterpretAsFixedString(nan)) + number))) FROM numbers(10);

--- a/tests/queries/0_stateless/04275_105748_distinct_nan_canonicalization.reference
+++ b/tests/queries/0_stateless/04275_105748_distinct_nan_canonicalization.reference
@@ -3,13 +3,18 @@ countDistinct(div0, nan)	1
 countDistinct(div0, nan, log(-1))	1
 uniqExact Float64	1
 uniqExact Float32	1
+uniqExact BFloat16	1
 uniq Float64	1
 SELECT DISTINCT Float64	1
 SELECT DISTINCT Float32	1
+SELECT DISTINCT BFloat16	1
 GROUP BY Float64	1
 GROUP BY Float32	1
+GROUP BY BFloat16	1
 uniqExact Nullable(Float64)	1
 GROUP BY Nullable(Float64)	1
+uniqExact Nullable(BFloat16)	1
+GROUP BY Nullable(BFloat16)	1
 rows in table	4
 distinct NaNs in table	1
 count rows after DISTINCT	1

--- a/tests/queries/0_stateless/04275_105748_distinct_nan_canonicalization.reference
+++ b/tests/queries/0_stateless/04275_105748_distinct_nan_canonicalization.reference
@@ -1,0 +1,16 @@
+countDistinct(div0, log(-1))	1
+countDistinct(div0, nan)	1
+countDistinct(div0, nan, log(-1))	1
+uniqExact Float64	1
+uniqExact Float32	1
+uniq Float64	1
+SELECT DISTINCT Float64	1
+SELECT DISTINCT Float32	1
+GROUP BY Float64	1
+GROUP BY Float32	1
+uniqExact Nullable(Float64)	1
+GROUP BY Nullable(Float64)	1
+rows in table	4
+distinct NaNs in table	1
+count rows after DISTINCT	1
+count groups after GROUP BY	1

--- a/tests/queries/0_stateless/04275_105748_distinct_nan_canonicalization.reference
+++ b/tests/queries/0_stateless/04275_105748_distinct_nan_canonicalization.reference
@@ -5,6 +5,14 @@ uniqExact Float64	1
 uniqExact Float32	1
 uniqExact BFloat16	1
 uniq Float64	1
+uniqCombined Float64	1
+uniqCombined Float32	1
+uniqCombined BFloat16	1
+uniqCombined64 Float64	1
+uniqCombined64 Float32	1
+uniqCombined64 BFloat16	1
+countDistinct uniqCombined	1
+countDistinct uniqCombined64	1
 SELECT DISTINCT Float64	1
 SELECT DISTINCT Float32	1
 SELECT DISTINCT BFloat16	1

--- a/tests/queries/0_stateless/04275_105748_distinct_nan_canonicalization.sql
+++ b/tests/queries/0_stateless/04275_105748_distinct_nan_canonicalization.sql
@@ -17,12 +17,13 @@ SELECT 'countDistinct(div0, nan, log(-1))', countDistinct(arrayJoin([0./0., nan,
 
 SELECT 'uniqExact Float64', uniqExact(arrayJoin([0./0., nan, log(-1.)]));
 SELECT 'uniqExact Float32', uniqExact(arrayJoin([toFloat32(0./0.), toFloat32(nan), toFloat32(log(-1.))]));
+SELECT 'uniqExact BFloat16', uniqExact(arrayJoin([toBFloat16(0./0.), toBFloat16(nan), toBFloat16(log(-1.))]));
 
 -- HLL-based `uniq` should also see one NaN
 
 SELECT 'uniq Float64', uniq(arrayJoin([0./0., nan, log(-1.)]));
 
--- SELECT DISTINCT (DistinctTransform, single Float key, `SetVariants::key64`)
+-- SELECT DISTINCT (DistinctTransform, single Float key, `SetVariants::key64`/`key32`/`key16`)
 
 SELECT 'SELECT DISTINCT Float64', count() FROM (
     SELECT DISTINCT x FROM (SELECT arrayJoin([0./0., nan, log(-1.)]) AS x)
@@ -30,8 +31,11 @@ SELECT 'SELECT DISTINCT Float64', count() FROM (
 SELECT 'SELECT DISTINCT Float32', count() FROM (
     SELECT DISTINCT x FROM (SELECT arrayJoin([toFloat32(0./0.), toFloat32(nan), toFloat32(log(-1.))]) AS x)
 );
+SELECT 'SELECT DISTINCT BFloat16', count() FROM (
+    SELECT DISTINCT x FROM (SELECT arrayJoin([toBFloat16(0./0.), toBFloat16(nan), toBFloat16(log(-1.))]) AS x)
+);
 
--- GROUP BY single Float key (`Aggregator::key64`)
+-- GROUP BY single Float key (`Aggregator::key64`/`key32`/`key16`)
 
 SELECT 'GROUP BY Float64', count() FROM (
     SELECT x FROM (SELECT arrayJoin([0./0., nan, log(-1.)]) AS x) GROUP BY x
@@ -39,9 +43,12 @@ SELECT 'GROUP BY Float64', count() FROM (
 SELECT 'GROUP BY Float32', count() FROM (
     SELECT x FROM (SELECT arrayJoin([toFloat32(0./0.), toFloat32(nan), toFloat32(log(-1.))]) AS x) GROUP BY x
 );
+SELECT 'GROUP BY BFloat16', count() FROM (
+    SELECT x FROM (SELECT arrayJoin([toBFloat16(0./0.), toBFloat16(nan), toBFloat16(log(-1.))]) AS x) GROUP BY x
+);
 
--- Nullable(Float64) for paths that go through `HashMethodOneNumber` (nullable=true):
--- `uniqExact` and `GROUP BY` of a single `Nullable(Float64)` key. `SELECT DISTINCT`
+-- Nullable(Float64)/(BFloat16) for paths that go through `HashMethodOneNumber` (nullable=true):
+-- `uniqExact` and `GROUP BY` of a single `Nullable(Float)` key. `SELECT DISTINCT`
 -- of a single `Nullable` key currently routes through `SetVariants::nullable_keys128`
 -- (HashMethodKeysFixed packing), which is a multi-key path and not covered by this
 -- fix; see follow-up note in the PR description.
@@ -51,6 +58,12 @@ SELECT 'uniqExact Nullable(Float64)', uniqExact(x) FROM (
 );
 SELECT 'GROUP BY Nullable(Float64)', count() FROM (
     SELECT x FROM (SELECT arrayJoin([toNullable(toFloat64(0./0.)), toNullable(toFloat64(nan)), toNullable(toFloat64(log(-1.)))]) AS x) GROUP BY x
+);
+SELECT 'uniqExact Nullable(BFloat16)', uniqExact(x) FROM (
+    SELECT arrayJoin([toNullable(toBFloat16(0./0.)), toNullable(toBFloat16(nan)), toNullable(toBFloat16(log(-1.)))]) AS x
+);
+SELECT 'GROUP BY Nullable(BFloat16)', count() FROM (
+    SELECT x FROM (SELECT arrayJoin([toNullable(toBFloat16(0./0.)), toNullable(toBFloat16(nan)), toNullable(toBFloat16(log(-1.)))]) AS x) GROUP BY x
 );
 
 -- Real table with materialized NaN values of different bit patterns

--- a/tests/queries/0_stateless/04275_105748_distinct_nan_canonicalization.sql
+++ b/tests/queries/0_stateless/04275_105748_distinct_nan_canonicalization.sql
@@ -1,0 +1,67 @@
+-- Regression for https://github.com/ClickHouse/ClickHouse/issues/105748
+-- Different operations and platforms can produce NaN values with different
+-- bit patterns (sign bit, payload). ClickHouse hash tables compare keys
+-- byte-wise, so without canonicalization `DISTINCT`, `GROUP BY`, `uniqExact`
+-- treat such NaNs as separate values. Concretely:
+--   * `0./0.` produces 0xFFF8000000000000 on x86 (constant-folded)
+--   * The literal `nan` is 0x7FF8000000000000
+--   * After PR #98230, ARM NEON `log(-1.)` returns 0xFFF8000000000000
+--     whereas glibc's scalar `log(-1.)` returns 0x7FF8000000000000
+-- All of these must be deduplicated to a single NaN value.
+
+-- countDistinct / uniqExact
+
+SELECT 'countDistinct(div0, log(-1))', countDistinct(arrayJoin([0./0., log(-1.)]));
+SELECT 'countDistinct(div0, nan)', countDistinct(arrayJoin([0./0., nan]));
+SELECT 'countDistinct(div0, nan, log(-1))', countDistinct(arrayJoin([0./0., nan, log(-1.)]));
+
+SELECT 'uniqExact Float64', uniqExact(arrayJoin([0./0., nan, log(-1.)]));
+SELECT 'uniqExact Float32', uniqExact(arrayJoin([toFloat32(0./0.), toFloat32(nan), toFloat32(log(-1.))]));
+
+-- HLL-based `uniq` should also see one NaN
+
+SELECT 'uniq Float64', uniq(arrayJoin([0./0., nan, log(-1.)]));
+
+-- SELECT DISTINCT (DistinctTransform, single Float key, `SetVariants::key64`)
+
+SELECT 'SELECT DISTINCT Float64', count() FROM (
+    SELECT DISTINCT x FROM (SELECT arrayJoin([0./0., nan, log(-1.)]) AS x)
+);
+SELECT 'SELECT DISTINCT Float32', count() FROM (
+    SELECT DISTINCT x FROM (SELECT arrayJoin([toFloat32(0./0.), toFloat32(nan), toFloat32(log(-1.))]) AS x)
+);
+
+-- GROUP BY single Float key (`Aggregator::key64`)
+
+SELECT 'GROUP BY Float64', count() FROM (
+    SELECT x FROM (SELECT arrayJoin([0./0., nan, log(-1.)]) AS x) GROUP BY x
+);
+SELECT 'GROUP BY Float32', count() FROM (
+    SELECT x FROM (SELECT arrayJoin([toFloat32(0./0.), toFloat32(nan), toFloat32(log(-1.))]) AS x) GROUP BY x
+);
+
+-- Nullable(Float64) for paths that go through `HashMethodOneNumber` (nullable=true):
+-- `uniqExact` and `GROUP BY` of a single `Nullable(Float64)` key. `SELECT DISTINCT`
+-- of a single `Nullable` key currently routes through `SetVariants::nullable_keys128`
+-- (HashMethodKeysFixed packing), which is a multi-key path and not covered by this
+-- fix; see follow-up note in the PR description.
+
+SELECT 'uniqExact Nullable(Float64)', uniqExact(x) FROM (
+    SELECT arrayJoin([toNullable(toFloat64(0./0.)), toNullable(toFloat64(nan)), toNullable(toFloat64(log(-1.)))]) AS x
+);
+SELECT 'GROUP BY Nullable(Float64)', count() FROM (
+    SELECT x FROM (SELECT arrayJoin([toNullable(toFloat64(0./0.)), toNullable(toFloat64(nan)), toNullable(toFloat64(log(-1.)))]) AS x) GROUP BY x
+);
+
+-- Real table with materialized NaN values of different bit patterns
+
+DROP TABLE IF EXISTS t_105748_nan;
+CREATE TABLE t_105748_nan (x Float64) ENGINE = Memory;
+INSERT INTO t_105748_nan VALUES (nan), (0./0.), (log(-1.0)), (sqrt(-1.0));
+
+SELECT 'rows in table', count(*) FROM t_105748_nan;
+SELECT 'distinct NaNs in table', uniqExact(x) FROM t_105748_nan;
+SELECT 'count rows after DISTINCT', count() FROM (SELECT DISTINCT x FROM t_105748_nan);
+SELECT 'count groups after GROUP BY', count() FROM (SELECT x, count() AS c FROM t_105748_nan GROUP BY x);
+
+DROP TABLE t_105748_nan;

--- a/tests/queries/0_stateless/04275_105748_distinct_nan_canonicalization.sql
+++ b/tests/queries/0_stateless/04275_105748_distinct_nan_canonicalization.sql
@@ -23,6 +23,25 @@ SELECT 'uniqExact BFloat16', uniqExact(arrayJoin([toBFloat16(0./0.), toBFloat16(
 
 SELECT 'uniq Float64', uniq(arrayJoin([0./0., nan, log(-1.)]));
 
+-- `uniqCombined` / `uniqCombined64` also hash NaN values; both modes are
+-- reachable via `count_distinct_implementation`, so they must canonicalize
+-- NaN too (see issue #105748).
+
+SELECT 'uniqCombined Float64', uniqCombined(arrayJoin([0./0., nan, log(-1.)]));
+SELECT 'uniqCombined Float32', uniqCombined(arrayJoin([toFloat32(0./0.), toFloat32(nan), toFloat32(log(-1.))]));
+SELECT 'uniqCombined BFloat16', uniqCombined(arrayJoin([toBFloat16(0./0.), toBFloat16(nan), toBFloat16(log(-1.))]));
+SELECT 'uniqCombined64 Float64', uniqCombined64(arrayJoin([0./0., nan, log(-1.)]));
+SELECT 'uniqCombined64 Float32', uniqCombined64(arrayJoin([toFloat32(0./0.), toFloat32(nan), toFloat32(log(-1.))]));
+SELECT 'uniqCombined64 BFloat16', uniqCombined64(arrayJoin([toBFloat16(0./0.), toBFloat16(nan), toBFloat16(log(-1.))]));
+
+-- `countDistinct` rewrites to whichever uniq implementation is configured.
+-- Verify the rewrite chain too for `uniqCombined` and `uniqCombined64`.
+
+SELECT 'countDistinct uniqCombined', countDistinct(arrayJoin([0./0., nan, log(-1.)]))
+    SETTINGS count_distinct_implementation = 'uniqCombined';
+SELECT 'countDistinct uniqCombined64', countDistinct(arrayJoin([0./0., nan, log(-1.)]))
+    SETTINGS count_distinct_implementation = 'uniqCombined64';
+
 -- SELECT DISTINCT (DistinctTransform, single Float key, `SetVariants::key64`/`key32`/`key16`)
 
 SELECT 'SELECT DISTINCT Float64', count() FROM (


### PR DESCRIPTION
Closes #105748.

`bitEquals` in `HashTable.h` compares hash keys byte-wise, so two NaN values that differ only in sign bit or mantissa payload are treated as distinct. This breaks `DISTINCT`, `GROUP BY`, `uniqExact`, and `countDistinct`:
- `0./0.` is `0xFFF8000000000000` on x86, the literal `nan` is `0x7FF8000000000000`.
- After #98230, ARM NEON `log(-1.)` returns a NaN whose sign bit differs from glibc's scalar `log(-1.)`.

The fix folds every NaN bit pattern onto the canonical positive quiet NaN at three call sites:
- `ColumnVector<Float>::updateHashWithValue` / `updateHashWithValueRange` / `updateHashFast` / `getWeakHash32` (used by `hashed` / `serialized` set methods and multi-key SipHash paths).
- `ColumnsHashing::HashMethodOneNumber::getKeyHolder` for single-column numeric keys (the `key32` / `key64` and `nullable_key32` / `nullable_key64` variants).
- `AggregateFunctionUniq::Adder` for `uniqExact` / `countDistinct` (which inserts the value directly into `HashSet<Float>` rather than going through `HashMethodOneNumber`), plus the `insertMany` fast path used by the `uniq` HLL family.

For non-floating-point types every change is a compile-time no-op: `canonicalizeNaN<T>` reduces to identity and the `may_canonicalize_nan` flag on `HashMethodOneNumber` is `false` so the branch is pruned. For floating-point columns the cost is one `isNaN` check per key access, on the predicted-not-taken path for non-NaN data.

JOIN with NaN keys: the `HashJoin::KeyGetter` path uses `HashMethodOneNumber`, so after this change two NaN-valued rows compare equal under `ON l.x = r.x` (consistent with `uniqExact`/`DISTINCT`). The scalar `=` operator continues to follow IEEE 754 (`nan = nan` is `0`). This matches the direction PostgreSQL and DuckDB took for cross-platform consistency.

Out of scope (follow-ups, noted in regression-test comments):
- `SELECT DISTINCT Nullable(Float)` of a single nullable key routes through `SetVariants::nullable_keys128` (HashMethodKeysFixed multi-key packing) rather than `HashMethodOneNumber`.
- Multi-key `DISTINCT` / `GROUP BY` of `(Float, ...)`, `Tuple(Float, ...)`, `Array(Float)` likewise use raw bytes when packing the fixed-size hash key.

Regression test: `04275_105748_distinct_nan_canonicalization` covers the reproducer from #105748 plus `Float32` / `Float64` / `Nullable(Float64)` variants and a materialized table with four NaN producers. The pre-existing test `01428_hash_set_nan_key` had a final assertion that constructs ten distinct NaN bit patterns and expected ten distinct values; that expectation is updated to `1` with an inline comment.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed `DISTINCT`, `GROUP BY`, `uniqExact`, and `countDistinct` to treat NaN values consistently regardless of bit pattern. Previously, NaN values produced by different operations (e.g. `0./0.` versus the literal `nan`, or ARM NEON `log(-1.)` versus glibc `log(-1.)` after #98230) were treated as distinct values because hash tables compare keys byte-wise. Now all NaN bit patterns are canonicalized at the hash boundary, so any NaN compares equal to any other NaN inside set semantics. The scalar `=` operator still returns false for `nan = nan` per IEEE 754.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!--
Don't forget to add information about the new features and changes to https://github.com/ClickHouse/clickhouse-docs as well.
-->