### PR TITLE
Add regression test for LEFT ANTI JOIN projection with WHERE (#105738)

### DIFF
--- a/tests/queries/0_stateless/04275_105738_left_anti_join_where_projection.reference
+++ b/tests/queries/0_stateless/04275_105738_left_anti_join_where_projection.reference
@@ -1,0 +1,12 @@
+--- LEFT ANTI JOIN, baseline (no WHERE) ---
+0
+0
+--- LEFT ANTI JOIN, with WHERE on left ---
+0
+0
+--- LEFT ANTI JOIN, parallel_hash ---
+0
+0
+--- LEFT ANTI JOIN, grace_hash ---
+0
+0

--- a/tests/queries/0_stateless/04275_105738_left_anti_join_where_projection.sql
+++ b/tests/queries/0_stateless/04275_105738_left_anti_join_where_projection.sql
@@ -1,0 +1,42 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/105738
+-- Sibling reproducer for https://github.com/ClickHouse/ClickHouse/issues/99959.
+-- In a LEFT ANTI JOIN, the result contains only rows from the left table that have no
+-- matching row in the right table. The right-table columns (including the join key)
+-- must contain default values for those unmatched rows, not the left key value.
+-- The #105738 reproducer self-joins a MergeTree table and varies the presence of a
+-- WHERE predicate, which previously could pick different plans and expose the
+-- right-key projection inconsistency.
+
+DROP TABLE IF EXISTS m_105738;
+
+CREATE TABLE m_105738 (c0 Int32, c1 UInt64, c2 UInt64) ENGINE = MergeTree() ORDER BY (-c0);
+INSERT INTO m_105738 VALUES (1, 100, 999);
+INSERT INTO m_105738 VALUES (2, 200, 888);
+OPTIMIZE TABLE m_105738 FINAL;
+
+SELECT '--- LEFT ANTI JOIN, baseline (no WHERE) ---';
+SELECT right_0.c1
+FROM m_105738 LEFT ANTI JOIN m_105738 AS right_0 ON m_105738.c2 = right_0.c1
+ORDER BY 1;
+
+SELECT '--- LEFT ANTI JOIN, with WHERE on left ---';
+SELECT right_0.c1
+FROM m_105738 LEFT ANTI JOIN m_105738 AS right_0 ON m_105738.c2 = right_0.c1
+WHERE m_105738.c0
+ORDER BY 1;
+
+SELECT '--- LEFT ANTI JOIN, parallel_hash ---';
+SELECT right_0.c1
+FROM m_105738 LEFT ANTI JOIN m_105738 AS right_0 ON m_105738.c2 = right_0.c1
+WHERE m_105738.c0
+ORDER BY 1
+SETTINGS join_algorithm = 'parallel_hash';
+
+SELECT '--- LEFT ANTI JOIN, grace_hash ---';
+SELECT right_0.c1
+FROM m_105738 LEFT ANTI JOIN m_105738 AS right_0 ON m_105738.c2 = right_0.c1
+WHERE m_105738.c0
+ORDER BY 1
+SETTINGS join_algorithm = 'grace_hash';
+
+DROP TABLE m_105738;


### PR DESCRIPTION
Adds a regression test for [issue #105738](https://github.com/ClickHouse/ClickHouse/issues/105738) (sibling reproducer for [#99959](https://github.com/ClickHouse/ClickHouse/issues/99959)).

The actual fix landed in [#105278](https://github.com/ClickHouse/ClickHouse/pull/105278): `HashJoinResult::appendRightColumns` now emits type defaults instead of copying left-key values for `LEFT ANTI JOIN`. This PR is the test-only follow-up requested by @fm4v on the issue.

The reproducer self-joins a `MergeTree` table on `m.c2 = right_0.c1`. Pre-fix, the baseline (no `WHERE`) returned the left-key value, while adding `WHERE m.c0` collapsed to `0`. The test covers `hash`, `parallel_hash` and `grace_hash` algorithms.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.138`
<!-- ch-version-info:end -->