### PR TITLE
Mark qemu-based tests as no-parallel to avoid 600s timeouts

### DIFF
--- a/tests/queries/0_stateless/01103_check_cpu_instructions_at_startup.sh
+++ b/tests/queries/0_stateless/01103_check_cpu_instructions_at_startup.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-fasttest, no-cpu-aarch64, no-llvm-coverage
+# Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-fasttest, no-cpu-aarch64, no-llvm-coverage, no-parallel
 # Tag no-fasttest: avoid dependency on qemu -- inconvenient when running locally
+# Tag no-parallel: `qemu-x86_64-static` is CPU-bound interpretation; under host load
+#                  the 5 sequential runs can exceed the 600s test timeout.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/03590_simdjson_fallback.sh
+++ b/tests/queries/0_stateless/03590_simdjson_fallback.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-fasttest, no-cpu-aarch64, no-llvm-coverage
+# Tags: no-tsan, no-asan, no-ubsan, no-msan, no-debug, no-fasttest, no-cpu-aarch64, no-llvm-coverage, no-parallel
 # Tag no-fasttest: avoid dependency on qemu -- inconvenient when running locally
+# Tag no-parallel: `qemu-x86_64-static` is CPU-bound interpretation; under host load
+#                  the run can exceed the 600s test timeout.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
The two `qemu-x86_64-static` based tests, `01103_check_cpu_instructions_at_startup` and `03590_simdjson_fallback`, occasionally time out at the 600s default test timeout on `Stateless tests (amd_binary_excluded_from_llvm)`.

qemu user-mode emulation is purely interpreted, so each `clickhouse-local` invocation under qemu is CPU-bound. When other parallel tests on the same CI runner saturate the CPU, the qemu thread gets time-sliced and per-call wall time can grow by 100x or more. `01103` makes 5 sequential qemu calls, so even a moderate slowdown lands the whole test above the timeout.

Over the last 60 days on `Stateless tests (amd_binary_excluded_from_llvm)`:

| Test | OK runs | FAIL runs | avg(OK) | p95(OK) | max(FAIL) |
|---|---|---|---|---|---|
| `01103_check_cpu_instructions_at_startup` | 5567 | 8 (7 timeouts) | 5.0s | 6.2s | 600.1s |
| `03590_simdjson_fallback` | (similar) | 15 (all timeouts) | (similar) | (similar) | 600.1s |

All failures are clean 600s timeouts; reruns pass (e.g. one master hit had 19/19 reruns green). `--diagnose-random-settings` consistently reports "test also fails without randomized settings", confirming this is not a randomization issue.

The fix follows the same convention used by `tests/queries/0_stateless/00097_long_storage_buffer_race_condition.sh`:

```
# Tags: race, no-parallel, no-flaky-check
#  - no-parallel: FIXME start to timeout on bigger machines under high load
```

The `no-parallel` tag only changes scheduling: each test still runs the exact same qemu invocations and validates the same outputs. There is no semantic change.

Report URL (latest hit, PR #103706): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=103706&sha=ebef332dc9d425725e1fe4f906a4e52de719522c&name_0=PR&name_1=Stateless%20tests%20%28amd_binary_excluded_from_llvm%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

CI: stabilize `qemu-x86_64-static`-based stateless tests (`01103_check_cpu_instructions_at_startup`, `03590_simdjson_fallback`) by marking them `no-parallel`, eliminating sporadic 600s timeouts on `amd_binary_excluded_from_llvm` under host CPU load.


### Documentation entry for user-facing changes
- [x] Documentation is unchanged.