### PR TITLE
Fix flaky test `04043_system_asynchronous_inserts_user_filter`

### DIFF
--- a/tests/queries/0_stateless/04043_system_asynchronous_inserts_user_filter.sh
+++ b/tests/queries/0_stateless/04043_system_asynchronous_inserts_user_filter.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest
+# Tags: no-fasttest, no-parallel
+# no-parallel: the test relies on a pending async insert remaining in the queue;
+# concurrent `SYSTEM FLUSH ASYNC INSERT QUEUE` from other tests can drain it.
 
 # Regression test: system.asynchronous_inserts must not leak cross-user insert metadata.
 # A user without SHOW_USERS privilege must only see their own pending inserts.
@@ -21,13 +23,28 @@ ${CLICKHOUSE_CLIENT} -q "
 "
 
 # secret_user inserts with async_insert enabled and a very long flush timeout so the entry stays in the queue.
+# Disable adaptive busy timeout so the per-query timeout is honored exactly and the entry is not
+# scheduled for early flush by `max_busy_timeout_exceeded` when the shard has been idle for a long time.
 ${CLICKHOUSE_CLIENT} \
     --user "secret_user_${CLICKHOUSE_DATABASE}" \
     --async_insert 1 \
+    --async_insert_use_adaptive_busy_timeout 0 \
     --async_insert_busy_timeout_max_ms 600000 \
     --async_insert_busy_timeout_min_ms 600000 \
     --wait_for_async_insert 0 \
     -q "INSERT INTO ${CLICKHOUSE_DATABASE}.async_insert_test VALUES (42)"
+
+# Wait until the admin can see the pending entry. With `--wait_for_async_insert 0` the client returns
+# as soon as the entry is queued, but in slow CI environments (sanitizers) the visibility through
+# `system.asynchronous_inserts` may lag slightly; poll for up to 30 seconds before giving up.
+for _ in $(seq 1 300); do
+    admin_count=$(${CLICKHOUSE_CLIENT} \
+        -q "SELECT count() FROM system.asynchronous_inserts WHERE table = 'async_insert_test' AND database = '${CLICKHOUSE_DATABASE}'")
+    if [[ "${admin_count}" -ge 1 ]]; then
+        break
+    fi
+    sleep 0.1
+done
 
 # restricted_user must see 0 rows (no cross-user visibility).
 echo "restricted_user sees:"


### PR DESCRIPTION
The test ensures `system.asynchronous_inserts` does not leak insert
metadata across users. To exercise the visibility filter it needs a
pending async insert to actually be in the queue while the user-filtered
`SELECT` queries run, and it has been flaking with both `secret_user
sees:` and `admin sees:` returning 0 - i.e. the entry was no longer in
the queue when the `SELECT` queries ran.

[PR #103032](https://github.com/ClickHouse/ClickHouse/pull/103032)
dropped the `no-parallel` tag added in
[#100233](https://github.com/ClickHouse/ClickHouse/pull/100233) on the
basis that every test that called `SYSTEM FLUSH ASYNC INSERT QUEUE` had
been migrated to the table-scoped variant. That is correct for the
tests that *call* flush, but this test does the opposite - it depends
on a pending entry remaining in the queue between the `INSERT` and the
three subsequent `SELECT` queries. Any concurrent unscoped flush drains
it, and even isolated reruns on sanitizer builds can race the entry's
visibility through `system.asynchronous_inserts`.

The fix:

- Re-add `no-parallel` with a comment that captures the real reason
  (the test consumes pending state, it does not produce it).
- Disable `async_insert_use_adaptive_busy_timeout` so the per-query
  10-minute deadline is honored exactly and `max_busy_timeout_exceeded`
  cannot force an early flush when the shard has been idle for a long
  time.
- Poll `system.asynchronous_inserts` for up to 30 seconds before
  running the user-filter checks so the test fails clean on a real
  visibility regression instead of racing the queue.

CI history of the failure:
https://play.clickhouse.com/play?user=play#V0lUSAogICAgOTAgQVMgaW50ZXJ2YWxfZGF5cwpTRUxFQ1QKICAgIHRvU3RhcnRPZkRheShjaGVja19zdGFydF90aW1lKSBBUyBkYXksCiAgICBjb3VudCgpIEFTIGZhaWx1cmVzLAogICAgZ3JvdXBVbmlxQXJyYXkocHVsbF9yZXF1ZXN0X251bWJlcikgQVMgcHJzLAogICAgYW55KHJlcG9ydF91cmwpIEFTIHJlcG9ydF91cmwKRlJPTSBjaGVja3MKV0hFUkUgKG5vdygpIC0gdG9JbnRlcnZhbERheShpbnRlcnZhbF9kYXlzKSkgPD0gY2hlY2tfc3RhcnRfdGltZQogICAgQU5EIHRlc3RfbmFtZSA9ICcwNDA0M19zeXN0ZW1fYXN5bmNocm9ub3VzX2luc2VydHNfdXNlcl9maWx0ZXInCiAgICBBTkQgdGVzdF9zdGF0dXMgSU4gKCdGQUlMJywgJ0VSUk9SJykKICAgIEFORCAocHVsbF9yZXF1ZXN0X251bWJlciA9IDAgT1IgYmFzZV9yZWYgSU4gKCdtYXN0ZXInKSkKICAgIEFORCB0ZXN0X2NvbnRleHRfcmF3IExJS0UgJyVyZXN1bHQgZGlmZmVycyB3aXRoIHJlZmVyZW5jZSUnCkdST1VQIEJZIGRheQpPUkRFUiBCWSBkYXkgREVTQwo=

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix flaky test `04043_system_asynchronous_inserts_user_filter`.


### Documentation entry for user-facing changes

- [x] Documentation is unchanged.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.124`
<!-- ch-version-info:end -->