### PR TITLE
Fix flaky 04043_system_asynchronous_inserts_user_filter (adaptive busy timeout)

### DIFF
--- a/tests/queries/0_stateless/04043_system_asynchronous_inserts_user_filter.sh
+++ b/tests/queries/0_stateless/04043_system_asynchronous_inserts_user_filter.sh
@@ -21,11 +21,14 @@ ${CLICKHOUSE_CLIENT} -q "
 "
 
 # secret_user inserts with async_insert enabled and a very long flush timeout so the entry stays in the queue.
+# Adaptive busy timeout is disabled: otherwise `max_busy_timeout_exceeded` in
+# `AsynchronousInsertQueue::pushDataChunk` can drain the entry immediately when the shared shard has
+# been idle longer than `async_insert_busy_timeout_max_ms`.
 ${CLICKHOUSE_CLIENT} \
     --user "secret_user_${CLICKHOUSE_DATABASE}" \
     --async_insert 1 \
+    --async_insert_use_adaptive_busy_timeout 0 \
     --async_insert_busy_timeout_max_ms 600000 \
-    --async_insert_busy_timeout_min_ms 600000 \
     --wait_for_async_insert 0 \
     -q "INSERT INTO ${CLICKHOUSE_DATABASE}.async_insert_test VALUES (42)"
 


### PR DESCRIPTION
The test seeds a pending async insert with `async_insert_busy_timeout_max_ms = 600000` so subsequent SELECTs can observe it in `system.asynchronous_inserts`. With adaptive busy timeout on (the default), `AsynchronousInsertQueue::pushDataChunk` evaluates `max_busy_timeout_exceeded` against the *shared* shard's history using the *current* insert's `max_ms`. When the assigned shard has been idle long enough (last insert and previous-flush gap both older than `max_ms`), the conjunction is true and the entry is drained on the spot, before the SELECTs run.

Disable adaptive busy timeout on the inserting client so the queued deadline is honored. With adaptive off both relevant branches short-circuit early, and `_min_ms` is unused.

Failure example: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=105756&sha=9f5558c2288d68e03113b7c230812a2ee5ec422f&name_0=PR&name_1=Stateless%20tests%20%28amd_msan%2C%20WasmEdge%2C%20parallel%2C%202%2F2%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix flaky test `04043_system_asynchronous_inserts_user_filter`.