### PR TITLE
Regroup ReadSettings: nest stage-specific fields

### DIFF
--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -155,7 +155,7 @@ namespace
         addThrottler(read_settings.remote_throttler, context->getBackupsThrottler());
         addThrottler(read_settings.local_throttler, context->getBackupsThrottler());
         read_settings.enable_filesystem_cache = backup_settings.read_from_filesystem_cache;
-        read_settings.read_from_filesystem_cache_if_exists_otherwise_bypass_cache = backup_settings.read_from_filesystem_cache;
+        read_settings.filesystem_cache_settings.read_from_filesystem_cache_if_exists_otherwise_bypass_cache = backup_settings.read_from_filesystem_cache;
         return read_settings;
     }
 
@@ -173,7 +173,7 @@ namespace
         addThrottler(read_settings.local_throttler, context->getBackupsThrottler());
         read_settings.enable_filesystem_cache = false;
         read_settings.read_through_distributed_cache = false;
-        read_settings.read_from_filesystem_cache_if_exists_otherwise_bypass_cache = false;
+        read_settings.filesystem_cache_settings.read_from_filesystem_cache_if_exists_otherwise_bypass_cache = false;
         return read_settings;
     }
 

--- a/src/Disks/DiskLocal.cpp
+++ b/src/Disks/DiskLocal.cpp
@@ -417,12 +417,12 @@ void DiskLocal::prepareRead(
         size_t estimated_size = read_hint.value_or(file_size);
         if (use_page_cache && settings.direct_io_threshold
             && estimated_size >= settings.direct_io_threshold
-            && settings.page_cache_block_size % DEFAULT_AIO_FILE_BLOCK_SIZE != 0)
+            && settings.page_cache_settings.page_cache_block_size % DEFAULT_AIO_FILE_BLOCK_SIZE != 0)
             use_page_cache = false;
     }
 
     if (use_page_cache)
-        pipeline.needMemoryCache(settings.page_cache, "local:", settings.getPageCacheSettings());
+        pipeline.needMemoryCache(settings.page_cache, "local:", settings.page_cache_settings);
 }
 
 std::unique_ptr<WriteBufferFromFileBase>

--- a/src/Disks/DiskObjectStorage/DiskObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/DiskObjectStorage.cpp
@@ -782,8 +782,8 @@ void DiskObjectStorage::prepareRead(
 
     /// Avoid cache fragmentation by choosing a bigger buffer size when filesystem cache is active.
     /// Must be done before setSource, which stores read_settings in the pipeline.
-    bool prefer_bigger_buffer_size = read_settings.filesystem_cache_prefer_bigger_buffer_size
-        && !read_settings.read_from_filesystem_cache_if_exists_otherwise_bypass_cache
+    bool prefer_bigger_buffer_size = read_settings.filesystem_cache_settings.filesystem_cache_prefer_bigger_buffer_size
+        && !read_settings.filesystem_cache_settings.read_from_filesystem_cache_if_exists_otherwise_bypass_cache
         && file_cache_enabled;
 #if ENABLE_DISTRIBUTED_CACHE
     if (use_distributed_cache && !read_settings.distributed_cache_settings.prefer_bigger_buffer_size)
@@ -819,7 +819,7 @@ void DiskObjectStorage::prepareRead(
         if (!object_namespace.empty())
             cache_path_prefix += object_namespace + "/";
 
-        pipeline.needMemoryCache(read_settings.page_cache, std::move(cache_path_prefix), read_settings.getPageCacheSettings());
+        pipeline.needMemoryCache(read_settings.page_cache, std::move(cache_path_prefix), read_settings.page_cache_settings);
     }
 
     /// Async prefetch.

--- a/src/Disks/DiskObjectStorage/ObjectStorages/Cached/CachedObjectStorage.cpp
+++ b/src/Disks/DiskObjectStorage/ObjectStorages/Cached/CachedObjectStorage.cpp
@@ -89,7 +89,7 @@ void CachedObjectStorage::prepareRead(
         if (cache->isInitialized())
         {
             auto global_context = Context::getGlobalContextInstance();
-            pipeline.needFilesystemCache(cache, read_settings.getFilesystemCacheSettings(), global_context->getFilesystemCacheLog());
+            pipeline.needFilesystemCache(cache, read_settings.filesystem_cache_settings, global_context->getFilesystemCacheLog());
         }
         else
         {

--- a/src/IO/CachedInMemoryReadBufferFromFile.cpp
+++ b/src/IO/CachedInMemoryReadBufferFromFile.cpp
@@ -20,12 +20,12 @@ namespace ErrorCodes
 }
 
 CachedInMemoryReadBufferFromFile::CachedInMemoryReadBufferFromFile(
-    PageCacheFile cache_file_, PageCachePtr cache_, std::unique_ptr<ReadBufferFromFileBase> in_, const ReadSettings & settings_)
+    PageCacheFile cache_file_, PageCachePtr cache_, std::unique_ptr<ReadBufferFromFileBase> in_, const PageCacheSettings & settings_)
     : ReadBufferFromFileBase(0, nullptr, 0, in_->getFileSize())
     , cache_file(std::move(cache_file_))
     , cache_key_base_hash(cache_file.baseHash())
     , cache(cache_)
-    , settings(settings_.getPageCacheSettings())
+    , settings(settings_)
     , in(std::move(in_)), read_until_position(file_size.value())
     , inner_read_until_position(read_until_position)
 {

--- a/src/IO/CachedInMemoryReadBufferFromFile.h
+++ b/src/IO/CachedInMemoryReadBufferFromFile.h
@@ -17,7 +17,7 @@ public:
     /// `in_` should be seekable and should be able to read the whole file from 0 to in_->getFileSize();
     /// in particular, don't call setReadUntilPosition() on `in_` directly, call
     /// CachedInMemoryReadBufferFromFile::setReadUntilPosition().
-    CachedInMemoryReadBufferFromFile(PageCacheFile cache_file_, PageCachePtr cache_, std::unique_ptr<ReadBufferFromFileBase> in_, const ReadSettings & settings_);
+    CachedInMemoryReadBufferFromFile(PageCacheFile cache_file_, PageCachePtr cache_, std::unique_ptr<ReadBufferFromFileBase> in_, const PageCacheSettings & settings_);
 
     String getFileName() const override;
     String getInfoForLog() override;

--- a/src/IO/ReadPipeline.cpp
+++ b/src/IO/ReadPipeline.cpp
@@ -557,17 +557,8 @@ std::unique_ptr<ReadBufferFromFileBase> ReadPipeline::wrapMemoryCache(std::uniqu
         cache_file.path = memory_cache->cache_path_prefix + first_object.remote_path;
     }
 
-    /// Apply stage-level page cache settings over the source ReadSettings.
-    auto page_cache_read_settings = source->read_settings;
-    const auto & pcs = memory_cache->page_cache_settings;
-    page_cache_read_settings.read_from_page_cache_if_exists_otherwise_bypass_cache = pcs.read_from_page_cache_if_exists_otherwise_bypass_cache;
-    page_cache_read_settings.page_cache_inject_eviction = pcs.page_cache_inject_eviction;
-    page_cache_read_settings.page_cache_block_size = pcs.page_cache_block_size;
-    page_cache_read_settings.page_cache_lookahead_blocks = pcs.page_cache_lookahead_blocks;
-    page_cache_read_settings.page_cache_max_coalesced_bytes = pcs.page_cache_max_coalesced_bytes;
-
     return std::make_unique<CachedInMemoryReadBufferFromFile>(
-        cache_file, memory_cache->cache, std::move(impl), page_cache_read_settings);
+        cache_file, memory_cache->cache, std::move(impl), memory_cache->page_cache_settings);
 }
 
 std::unique_ptr<ReadBufferFromFileBase> ReadPipeline::wrapAsyncPrefetch(std::unique_ptr<ReadBufferFromFileBase> impl) const
@@ -602,7 +593,7 @@ std::unique_ptr<ReadBufferFromFileBase> ReadPipeline::wrapAsyncPrefetch(std::uni
     /// otherwise prefetches don't line up with cache blocks.
     size_t async_page_cache_block_size = memory_cache
         ? memory_cache->page_cache_settings.page_cache_block_size
-        : settings.page_cache_block_size;
+        : settings.page_cache_settings.page_cache_block_size;
 
     return std::make_unique<AsynchronousBoundedReadBuffer>(
         std::move(impl),

--- a/src/IO/ReadSettings.cpp
+++ b/src/IO/ReadSettings.cpp
@@ -47,29 +47,4 @@ ReadSettings ReadSettings::adjustBufferSize(size_t file_size) const
     return res;
 }
 
-FilesystemCacheSettings ReadSettings::getFilesystemCacheSettings() const
-{
-    return FilesystemCacheSettings{
-        .read_from_filesystem_cache_if_exists_otherwise_bypass_cache = read_from_filesystem_cache_if_exists_otherwise_bypass_cache,
-        .filesystem_cache_segments_batch_size = filesystem_cache_segments_batch_size,
-        .filesystem_cache_boundary_alignment = filesystem_cache_boundary_alignment,
-        .filesystem_cache_allow_background_download = filesystem_cache_allow_background_download,
-        .filesystem_cache_reserve_space_wait_lock_timeout_milliseconds = filesystem_cache_reserve_space_wait_lock_timeout_milliseconds,
-        .filesystem_cache_max_download_size = filesystem_cache_max_download_size,
-        .filesystem_cache_skip_download_if_exceeds_per_query_cache_write_limit = filesystem_cache_skip_download_if_exceeds_per_query_cache_write_limit,
-        .enable_filesystem_cache_log = enable_filesystem_cache_log,
-    };
-}
-
-PageCacheSettings ReadSettings::getPageCacheSettings() const
-{
-    return PageCacheSettings{
-        .read_from_page_cache_if_exists_otherwise_bypass_cache = read_from_page_cache_if_exists_otherwise_bypass_cache,
-        .page_cache_inject_eviction = page_cache_inject_eviction,
-        .page_cache_block_size = page_cache_block_size,
-        .page_cache_lookahead_blocks = page_cache_lookahead_blocks,
-        .page_cache_max_coalesced_bytes = page_cache_max_coalesced_bytes,
-    };
-}
-
 }

--- a/src/IO/ReadSettings.h
+++ b/src/IO/ReadSettings.h
@@ -36,10 +36,14 @@ struct FilesystemCacheSettings
     size_t filesystem_cache_segments_batch_size = 20;
     std::optional<size_t> filesystem_cache_boundary_alignment;
     bool filesystem_cache_allow_background_download = true;
+    bool filesystem_cache_allow_background_download_for_metadata_files_in_packed_storage = true;
+    bool filesystem_cache_allow_background_download_during_fetch = true;
+    bool filesystem_cache_prefer_bigger_buffer_size = true;
     size_t filesystem_cache_reserve_space_wait_lock_timeout_milliseconds = 1000;
     size_t filesystem_cache_max_download_size = (128UL * 1024 * 1024 * 1024);
     bool filesystem_cache_skip_download_if_exceeds_per_query_cache_write_limit = true;
     bool enable_filesystem_cache_log = false;
+    std::optional<FileCacheOriginInfo> filecache_origin_info;
 };
 
 struct ReadSettings
@@ -73,30 +77,18 @@ struct ReadSettings
 
     bool enable_filesystem_read_prefetches_log = false;
 
+    /// Toggle for the filesystem cache stage. The stage parameters live in `filesystem_cache_settings`.
     bool enable_filesystem_cache = true;
-    bool read_from_filesystem_cache_if_exists_otherwise_bypass_cache = false;
-    bool enable_filesystem_cache_log = false;
-    size_t filesystem_cache_segments_batch_size = 20;
-    size_t filesystem_cache_reserve_space_wait_lock_timeout_milliseconds = 1000;
-    bool filesystem_cache_allow_background_download = true;
-    bool filesystem_cache_allow_background_download_for_metadata_files_in_packed_storage = true;
-    bool filesystem_cache_allow_background_download_during_fetch = true;
-    bool filesystem_cache_prefer_bigger_buffer_size = true;
-    std::optional<size_t> filesystem_cache_boundary_alignment;
+    FilesystemCacheSettings filesystem_cache_settings;
 
+    /// Toggles for the page cache stage (decided per-disk before composing the pipeline).
+    /// The stage parameters live in `page_cache_settings`.
     bool use_page_cache_for_disks_without_file_cache = false;
     [[maybe_unused]] bool use_page_cache_with_distributed_cache = false;
     bool use_page_cache_for_local_disks = false;
     bool use_page_cache_for_object_storage = false;
-    bool read_from_page_cache_if_exists_otherwise_bypass_cache = false;
-    bool page_cache_inject_eviction = false;
-    size_t page_cache_block_size = 1 << 20;
-    size_t page_cache_lookahead_blocks = 16;
-    size_t page_cache_max_coalesced_bytes = 16 << 20;
     std::shared_ptr<PageCache> page_cache;
-
-    size_t filesystem_cache_max_download_size = (128UL * 1024 * 1024 * 1024);
-    bool filesystem_cache_skip_download_if_exceeds_per_query_cache_write_limit = true;
+    PageCacheSettings page_cache_settings;
 
     size_t remote_read_min_bytes_for_seek = DBMS_DEFAULT_BUFFER_SIZE;
 
@@ -114,17 +106,10 @@ struct ReadSettings
 
     bool read_through_distributed_cache = false;
     DistributedCacheSettings distributed_cache_settings;
-    std::optional<FileCacheOriginInfo> filecache_origin_info;
     bool enable_hdfs_pread = true;
     bool enable_blob_storage_log_for_read_operations = false;
 
     ReadSettings adjustBufferSize(size_t file_size) const;
-
-    /// Extract filesystem cache settings into a dedicated struct.
-    FilesystemCacheSettings getFilesystemCacheSettings() const;
-
-    /// Extract page cache settings into a dedicated struct.
-    PageCacheSettings getPageCacheSettings() const;
 };
 
 ReadSettings getReadSettings();

--- a/src/Interpreters/Context.cpp
+++ b/src/Interpreters/Context.cpp
@@ -7676,31 +7676,34 @@ ReadSettings Context::getReadSettings() const
     res.remote_fs_read_max_backoff_ms = settings_ref[Setting::remote_fs_read_max_backoff_ms];
     res.remote_fs_read_backoff_max_tries = settings_ref[Setting::remote_fs_read_backoff_max_tries];
     res.enable_filesystem_cache = settings_ref[Setting::enable_filesystem_cache];
-    res.read_from_filesystem_cache_if_exists_otherwise_bypass_cache
+    res.filesystem_cache_settings.read_from_filesystem_cache_if_exists_otherwise_bypass_cache
         = settings_ref[Setting::read_from_filesystem_cache_if_exists_otherwise_bypass_cache];
-    res.enable_filesystem_cache_log = settings_ref[Setting::enable_filesystem_cache_log];
-    res.filesystem_cache_segments_batch_size = settings_ref[Setting::filesystem_cache_segments_batch_size];
-    res.filesystem_cache_reserve_space_wait_lock_timeout_milliseconds
+    res.filesystem_cache_settings.enable_filesystem_cache_log = settings_ref[Setting::enable_filesystem_cache_log];
+    res.filesystem_cache_settings.filesystem_cache_segments_batch_size = settings_ref[Setting::filesystem_cache_segments_batch_size];
+    res.filesystem_cache_settings.filesystem_cache_reserve_space_wait_lock_timeout_milliseconds
         = settings_ref[Setting::filesystem_cache_reserve_space_wait_lock_timeout_milliseconds];
-    res.filesystem_cache_allow_background_download = settings_ref[Setting::filesystem_cache_allow_background_download];
-    res.filesystem_cache_allow_background_download_for_metadata_files_in_packed_storage
+    res.filesystem_cache_settings.filesystem_cache_allow_background_download = settings_ref[Setting::filesystem_cache_allow_background_download];
+    res.filesystem_cache_settings.filesystem_cache_allow_background_download_for_metadata_files_in_packed_storage
         = settings_ref[Setting::filesystem_cache_enable_background_download_for_metadata_files_in_packed_storage];
-    res.filesystem_cache_allow_background_download_during_fetch = settings_ref[Setting::filesystem_cache_enable_background_download_during_fetch];
-    res.filesystem_cache_prefer_bigger_buffer_size = settings_ref[Setting::filesystem_cache_prefer_bigger_buffer_size];
+    res.filesystem_cache_settings.filesystem_cache_allow_background_download_during_fetch
+        = settings_ref[Setting::filesystem_cache_enable_background_download_during_fetch];
+    res.filesystem_cache_settings.filesystem_cache_prefer_bigger_buffer_size = settings_ref[Setting::filesystem_cache_prefer_bigger_buffer_size];
 
-    res.filesystem_cache_max_download_size = settings_ref[Setting::filesystem_cache_max_download_size];
-    res.filesystem_cache_skip_download_if_exceeds_per_query_cache_write_limit = settings_ref[Setting::filesystem_cache_skip_download_if_exceeds_per_query_cache_write_limit];
+    res.filesystem_cache_settings.filesystem_cache_max_download_size = settings_ref[Setting::filesystem_cache_max_download_size];
+    res.filesystem_cache_settings.filesystem_cache_skip_download_if_exceeds_per_query_cache_write_limit
+        = settings_ref[Setting::filesystem_cache_skip_download_if_exceeds_per_query_cache_write_limit];
 
     res.page_cache = getPageCache();
     res.use_page_cache_for_disks_without_file_cache = settings_ref[Setting::use_page_cache_for_disks_without_file_cache];
     res.use_page_cache_with_distributed_cache = settings_ref[Setting::use_page_cache_with_distributed_cache];
     res.use_page_cache_for_local_disks = settings_ref[Setting::use_page_cache_for_local_disks];
     res.use_page_cache_for_object_storage = settings_ref[Setting::use_page_cache_for_object_storage];
-    res.read_from_page_cache_if_exists_otherwise_bypass_cache = settings_ref[Setting::read_from_page_cache_if_exists_otherwise_bypass_cache];
-    res.page_cache_inject_eviction = settings_ref[Setting::page_cache_inject_eviction];
-    res.page_cache_block_size = settings_ref[Setting::page_cache_block_size];
-    res.page_cache_lookahead_blocks = settings_ref[Setting::page_cache_lookahead_blocks];
-    res.page_cache_max_coalesced_bytes = settings_ref[Setting::page_cache_max_coalesced_bytes];
+    res.page_cache_settings.read_from_page_cache_if_exists_otherwise_bypass_cache
+        = settings_ref[Setting::read_from_page_cache_if_exists_otherwise_bypass_cache];
+    res.page_cache_settings.page_cache_inject_eviction = settings_ref[Setting::page_cache_inject_eviction];
+    res.page_cache_settings.page_cache_block_size = settings_ref[Setting::page_cache_block_size];
+    res.page_cache_settings.page_cache_lookahead_blocks = settings_ref[Setting::page_cache_lookahead_blocks];
+    res.page_cache_settings.page_cache_max_coalesced_bytes = settings_ref[Setting::page_cache_max_coalesced_bytes];
 
     res.remote_read_min_bytes_for_seek = getSettingsRef()[Setting::remote_read_min_bytes_for_seek];
 

--- a/src/Interpreters/FileCache/Metadata.cpp
+++ b/src/Interpreters/FileCache/Metadata.cpp
@@ -886,7 +886,7 @@ void CacheMetadata::downloadImpl(FileSegment & file_segment, std::optional<Memor
     buf->set(memory->data(), std::min(size_to_download, memory->size()));
 
     const auto reserve_space_lock_wait_timeout_milliseconds =
-        Context::getGlobalContextInstance()->getReadSettings().filesystem_cache_reserve_space_wait_lock_timeout_milliseconds;
+        Context::getGlobalContextInstance()->getReadSettings().filesystem_cache_settings.filesystem_cache_reserve_space_wait_lock_timeout_milliseconds;
 
     size_t offset = file_segment.getCurrentWriteOffset();
     if (offset != static_cast<size_t>(buf->getPosition()))

--- a/src/Interpreters/tests/gtest_filecache.cpp
+++ b/src/Interpreters/tests/gtest_filecache.cpp
@@ -1168,7 +1168,7 @@ TEST_F(FileCacheTest, CachedReadBuffer)
     {
         auto cached_buffer = std::make_shared<CachedOnDiskReadBufferFromFile>(
             file_path, key, cache, user, read_buffer_creator,
-            read_settings.getFilesystemCacheSettings(), read_settings.remote_fs_buffer_size, read_settings.local_fs_buffer_size,
+            read_settings.filesystem_cache_settings, read_settings.remote_fs_buffer_size, read_settings.local_fs_buffer_size,
             "test", s.size(), false, false, std::nullopt, nullptr);
 
         WriteBufferFromOwnString result;
@@ -1181,7 +1181,7 @@ TEST_F(FileCacheTest, CachedReadBuffer)
     {
         auto cached_buffer = std::make_shared<CachedOnDiskReadBufferFromFile>(
             file_path, key, cache, user, read_buffer_creator,
-            read_settings.getFilesystemCacheSettings(), /* remote_fs_buffer_size */ 10, /* local_fs_buffer_size */ 10,
+            read_settings.filesystem_cache_settings, /* remote_fs_buffer_size */ 10, /* local_fs_buffer_size */ 10,
             "test", s.size(), false, false, std::nullopt, nullptr);
 
         cached_buffer->next();
@@ -1396,7 +1396,7 @@ TEST_F(FileCacheTest, SLRUPolicy)
 
             auto cached_buffer = std::make_shared<CachedOnDiskReadBufferFromFile>(
                 file, key, cache, user, read_buffer_creator,
-                read_settings.getFilesystemCacheSettings(), read_settings.remote_fs_buffer_size, read_settings.local_fs_buffer_size,
+                read_settings.filesystem_cache_settings, read_settings.remote_fs_buffer_size, read_settings.local_fs_buffer_size,
                 "test", expect_result.size(), false, false, std::nullopt, nullptr);
 
             WriteBufferFromOwnString result;
@@ -1503,7 +1503,7 @@ TEST_F(FileCacheTest, SLRUDynamicResizeCorrectEviction)
         };
         auto cached_buffer = std::make_shared<CachedOnDiskReadBufferFromFile>(
             file, key, cache, user, read_buffer_creator,
-            read_settings.getFilesystemCacheSettings(), read_settings.remote_fs_buffer_size, read_settings.local_fs_buffer_size,
+            read_settings.filesystem_cache_settings, read_settings.remote_fs_buffer_size, read_settings.local_fs_buffer_size,
             "test", expect_result.size(), false, false, std::nullopt, nullptr);
         WriteBufferFromOwnString result;
         copyData(*cached_buffer, result);

--- a/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
+++ b/src/Storages/MergeTree/MergeTreeSequentialSource.cpp
@@ -148,7 +148,7 @@ MergeTreeSequentialSource::MergeTreeSequentialSource(
 
     const auto & context = storage.getContext();
     ReadSettings read_settings = context->getReadSettings();
-    read_settings.read_from_filesystem_cache_if_exists_otherwise_bypass_cache
+    read_settings.filesystem_cache_settings.read_from_filesystem_cache_if_exists_otherwise_bypass_cache
         = read_settings.distributed_cache_settings.read_if_exists_otherwise_bypass
         = !(*storage.getSettings())[MergeTreeSetting::force_read_through_cache_for_merges];
 

--- a/src/Storages/MergeTree/checkDataPart.cpp
+++ b/src/Storages/MergeTree/checkDataPart.cpp
@@ -482,11 +482,11 @@ IMergeTreeDataPart::Checksums checkDataPart(
         ReadSettings read_settings;
         read_settings.read_through_distributed_cache = false;
         read_settings.enable_filesystem_cache = false;
-        read_settings.enable_filesystem_cache_log = false;
+        read_settings.filesystem_cache_settings.enable_filesystem_cache_log = false;
         read_settings.enable_filesystem_read_prefetches_log = false;
         read_settings.page_cache = nullptr;
         read_settings.remote_fs_prefetch = false;
-        read_settings.page_cache_inject_eviction = false;
+        read_settings.page_cache_settings.page_cache_inject_eviction = false;
         read_settings.use_page_cache_for_disks_without_file_cache = false;
         read_settings.local_fs_method = LocalFSReadMethod::pread;
 

--- a/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSource.cpp
@@ -992,7 +992,7 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBuffer(
     modified_read_settings.remote_read_min_bytes_for_seek = modified_read_settings.remote_fs_buffer_size;
     /// User's object may change, don't cache it.
     modified_read_settings.use_page_cache_for_disks_without_file_cache = false;
-    modified_read_settings.filesystem_cache_boundary_alignment = settings[Setting::filesystem_cache_boundary_alignment];
+    modified_read_settings.filesystem_cache_settings.filesystem_cache_boundary_alignment = settings[Setting::filesystem_cache_boundary_alignment];
 
     // Create a read buffer that will prefetch the first ~1 MB of the file.
     // When reading lots of tiny files, this prefetching almost doubles the throughput.
@@ -1012,7 +1012,7 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBuffer(
     /// so we gate on `use_filesystem_cache` rather than a runtime `isCached()` check.
     /// This means the bigger buffer may be used even when the cache stage is later
     /// skipped (e.g. missing etag) — slightly wasteful but not incorrect.
-    if (modified_read_settings.filesystem_cache_prefer_bigger_buffer_size && use_filesystem_cache)
+    if (modified_read_settings.filesystem_cache_settings.filesystem_cache_prefer_bigger_buffer_size && use_filesystem_cache)
         modified_read_settings.remote_fs_buffer_size = std::max<size_t>(
             modified_read_settings.remote_fs_buffer_size,
             modified_read_settings.prefetch_buffer_size);
@@ -1054,7 +1054,7 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBuffer(
                 cache,
                 cache_key,
                 FileCache::getCommonOrigin(),
-                modified_read_settings.getFilesystemCacheSettings(),
+                modified_read_settings.filesystem_cache_settings,
                 context_->getFilesystemCacheLog());
 
             LOG_TRACE(
@@ -1082,7 +1082,7 @@ std::unique_ptr<ReadBufferFromFileBase> createReadBuffer(
             effective_read_settings.page_cache,
             "s3:" + object_info.getPath(),
             "etag:" + object_info.metadata->etag,
-            modified_read_settings.getPageCacheSettings());
+            modified_read_settings.page_cache_settings);
     }
 
     /// Async prefetch


### PR DESCRIPTION
Follow-up to #103234 (ReadPipeline). Addresses reviewer requests to make `ReadSettings` clearer by grouping stage-specific fields.

`ReadSettings` was a 60-field flat struct mixing source, transport, and cache settings. `PageCacheSettings` and `FilesystemCacheSettings` already existed but only as projection helpers — the same fields were also duplicated at the top level of `ReadSettings`, kept in sync by getter methods. Adding a new stage setting required touching three places; forgetting one would cause silent divergence.

This PR makes the nested structs the single source of truth:

- **`PageCacheSettings`**: 5 fields moved in.
- **`FilesystemCacheSettings`**: 8 fields moved in, plus 4 previously-stray FS-cache fields folded in (`*_for_metadata_files_in_packed_storage`, `*_during_fetch`, `prefer_bigger_buffer_size`, `filecache_origin_info`).
- Stage-enable toggles (`enable_filesystem_cache`, `use_page_cache_for_*`) stay at the top level — they decide *whether* to use the stage, not how it behaves.
- `getFilesystemCacheSettings` / `getPageCacheSettings` projection helpers removed.
- `CachedInMemoryReadBufferFromFile` constructor narrowed to take `PageCacheSettings` directly — it never needed the full `ReadSettings`.

No behavior change. No `Setting::*` renames. All consumers updated; the compiler served as the migration tool — old flat-field names are gone, so every stale reference fails to compile rather than silently reading a default.

Mirrors how `DistributedCacheSettings` was already composed into `ReadSettings`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Internal refactor of `ReadSettings`; no user-visible change.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)