### PR TITLE
Fix `Keeper` snapshot cleanup after failed writes

### DIFF
--- a/src/Coordination/KeeperSnapshotManager.cpp
+++ b/src/Coordination/KeeperSnapshotManager.cpp
@@ -84,6 +84,52 @@ namespace
         return base;
     }
 
+    void cancelAndResetWriteBuffer(std::unique_ptr<WriteBuffer> & buffer)
+    {
+        if (buffer && !buffer->isFinalized() && !buffer->isCanceled())
+            buffer->cancel();
+
+        buffer.reset();
+    }
+
+    void removeFailedSnapshotArtifacts(
+        const DiskPtr & disk,
+        const std::string & snapshot_file_name,
+        const std::string & tmp_snapshot_file_name,
+        const LoggerPtr & log)
+    {
+        try
+        {
+            disk->removeFileIfExists(snapshot_file_name);
+            LOG_DEBUG(log, "Ensured partial snapshot artifact {} is absent from disk {}", snapshot_file_name, disk->getName());
+        }
+        catch (...)
+        {
+            tryLogCurrentException(
+                log,
+                fmt::format("Failed to remove partial snapshot artifact {} from disk {}", snapshot_file_name, disk->getName()));
+            LOG_WARNING(
+                log,
+                "Keeping partial snapshot marker {} on disk {} because data file {} could not be removed",
+                tmp_snapshot_file_name,
+                disk->getName(),
+                snapshot_file_name);
+            return;
+        }
+
+        try
+        {
+            disk->removeFileIfExists(tmp_snapshot_file_name);
+            LOG_DEBUG(log, "Ensured partial snapshot marker {} is absent from disk {}", tmp_snapshot_file_name, disk->getName());
+        }
+        catch (...)
+        {
+            tryLogCurrentException(
+                log,
+                fmt::format("Failed to remove partial snapshot marker {} from disk {}", tmp_snapshot_file_name, disk->getName()));
+        }
+    }
+
     template<typename Node>
     void writeNode(const Node & node, SnapshotVersion version, WriteBuffer & out)
     {
@@ -807,31 +853,49 @@ SnapshotFileInfoPtr KeeperSnapshotManager<Storage>::serializeSnapshotBufferToDis
     auto disk = getLatestSnapshotDisk();
     LOG_DEBUG(log, "Receiving snapshot {} to {} disk", up_to_log_idx, isLocalDisk(*disk) ? "local" : "remote");
 
-    /// Create empty marker: if both tmp_<name> and <name> exist on restart, the snapshot
-    /// is treated as incomplete and both are removed (see KeeperSnapshotManager constructor).
+    std::unique_ptr<WriteBuffer> plain_buf;
+    try
     {
-        auto buf = disk->writeFile(tmp_snapshot_file_name);
-        buf->finalize();
+        /// Create empty marker: if both tmp_<name> and <name> exist on restart, the snapshot
+        /// is treated as incomplete and both are removed (see KeeperSnapshotManager constructor).
+        {
+            auto buf = disk->writeFile(tmp_snapshot_file_name);
+            buf->finalize();
+        }
+
+        plain_buf = disk->writeFile(snapshot_file_name);
+        copyData(reader, *plain_buf);
+
+        const size_t bytes_written = plain_buf->count();
+        ProfileEvents::increment(ProfileEvents::KeeperSnapshotWrittenBytes, bytes_written);
+
+        plain_buf->finalize();
+
+        Stopwatch watch;
+        plain_buf->sync();
+        ProfileEvents::increment(ProfileEvents::KeeperSnapshotFileSyncMicroseconds, watch.elapsedMicroseconds());
+
+        plain_buf.reset();
+        disk->removeFile(tmp_snapshot_file_name);
     }
-
-    auto plain_buf = disk->writeFile(snapshot_file_name);
-    copyData(reader, *plain_buf);
-
-    const size_t bytes_written = plain_buf->count();
-    ProfileEvents::increment(ProfileEvents::KeeperSnapshotWrittenBytes, bytes_written);
-
-    plain_buf->finalize();
-
-    Stopwatch watch;
-    plain_buf->sync();
-    ProfileEvents::increment(ProfileEvents::KeeperSnapshotFileSyncMicroseconds, watch.elapsedMicroseconds());
-
-    disk->removeFile(tmp_snapshot_file_name);
+    catch (...)
+    {
+        cancelAndResetWriteBuffer(plain_buf);
+        removeFailedSnapshotArtifacts(disk, snapshot_file_name, tmp_snapshot_file_name, log);
+        throw;
+    }
 
     auto snapshot_file_info = makeManagedSnapshotFileInfo(snapshot_file_name, disk, up_to_log_idx);
     existing_snapshots.emplace(up_to_log_idx, snapshot_file_info);
-    removeOutdatedSnapshotsIfNeeded();
-    moveSnapshotsIfNeeded();
+    try
+    {
+        removeOutdatedSnapshotsIfNeeded();
+        moveSnapshotsIfNeeded();
+    }
+    catch (...)
+    {
+        tryLogCurrentException(log, "Failed to cleanup and/or move older snapshots");
+    }
 
     return snapshot_file_info;
 }
@@ -845,30 +909,49 @@ std::unique_ptr<SnapshotReceiveCtx> KeeperSnapshotManager<Storage>::beginSnapsho
 
     const auto tmp_snapshot_file_name = "tmp_" + snapshot_file_name;
 
-    /// Create an empty tmp_ marker file. On restart, if both tmp_<name> and <name> exist,
-    /// the snapshot is treated as incomplete and both are removed (see constructor).
+    try
     {
-        auto buf = disk->writeFile(tmp_snapshot_file_name);
-        buf->finalize();
-    }
+        /// Create an empty tmp_ marker file. On restart, if both tmp_<name> and <name> exist,
+        /// the snapshot is treated as incomplete and both are removed (see constructor).
+        {
+            auto buf = disk->writeFile(tmp_snapshot_file_name);
+            buf->finalize();
+        }
 
-    auto write_buf = disk->writeFile(snapshot_file_name);
-    return std::make_unique<SnapshotReceiveCtx>(std::move(write_buf), disk, std::move(snapshot_file_name), up_to_log_idx);
+        auto write_buf = disk->writeFile(snapshot_file_name);
+        return std::make_unique<SnapshotReceiveCtx>(std::move(write_buf), disk, std::move(snapshot_file_name), up_to_log_idx);
+    }
+    catch (...)
+    {
+        removeFailedSnapshotArtifacts(disk, snapshot_file_name, tmp_snapshot_file_name, log);
+        throw;
+    }
 }
 
 template<typename Storage>
 SnapshotFileInfoPtr KeeperSnapshotManager<Storage>::finalizeSnapshotReceiveToDisk(SnapshotReceiveCtx & ctx)
 {
-    ProfileEvents::increment(ProfileEvents::KeeperSnapshotWrittenBytes, ctx.write_buf->count());
+    const auto tmp_snapshot_file_name = "tmp_" + ctx.snapshot_file_name;
 
-    ctx.write_buf->finalize();
+    try
+    {
+        ProfileEvents::increment(ProfileEvents::KeeperSnapshotWrittenBytes, ctx.write_buf->count());
 
-    Stopwatch watch;
-    ctx.write_buf->sync();
-    ProfileEvents::increment(ProfileEvents::KeeperSnapshotFileSyncMicroseconds, watch.elapsedMicroseconds());
+        ctx.write_buf->finalize();
 
-    ctx.write_buf.reset();
-    ctx.disk->removeFile("tmp_" + ctx.snapshot_file_name);
+        Stopwatch watch;
+        ctx.write_buf->sync();
+        ProfileEvents::increment(ProfileEvents::KeeperSnapshotFileSyncMicroseconds, watch.elapsedMicroseconds());
+
+        ctx.write_buf.reset();
+        ctx.disk->removeFile(tmp_snapshot_file_name);
+    }
+    catch (...)
+    {
+        cancelAndResetWriteBuffer(ctx.write_buf);
+        removeFailedSnapshotArtifacts(ctx.disk, ctx.snapshot_file_name, tmp_snapshot_file_name, log);
+        throw;
+    }
 
     auto snapshot_file_info = makeManagedSnapshotFileInfo(ctx.snapshot_file_name, ctx.disk, ctx.log_idx);
     existing_snapshots.emplace(ctx.log_idx, snapshot_file_info);
@@ -879,8 +962,7 @@ SnapshotFileInfoPtr KeeperSnapshotManager<Storage>::finalizeSnapshotReceiveToDis
     }
     catch (...)
     {
-        tryLogCurrentException(__PRETTY_FUNCTION__);
-        chassert(false);
+        tryLogCurrentException(log, "Failed to cleanup and/or move older snapshots");
     }
 
     return snapshot_file_info;
@@ -1052,32 +1134,45 @@ SnapshotFileInfoPtr KeeperSnapshotManager<Storage>::serializeSnapshotToDisk(cons
     auto tmp_snapshot_file_name = "tmp_" + snapshot_file_name;
 
     auto disk = getLatestSnapshotDisk();
-    /// Create empty marker: if both tmp_<name> and <name> exist on restart, the snapshot
-    /// is treated as incomplete and both are removed (see KeeperSnapshotManager constructor).
-    {
-        auto buf = disk->writeFile(tmp_snapshot_file_name);
-        buf->finalize();
-    }
-
-    auto writer = disk->writeFile(snapshot_file_name);
+    std::unique_ptr<WriteBuffer> writer;
     std::unique_ptr<WriteBuffer> compressed_writer;
-    if (compress_snapshots_zstd)
-        compressed_writer = wrapWriteBufferWithCompressionMethod(std::move(writer), CompressionMethod::Zstd, 3);
-    else
-        compressed_writer = std::make_unique<CompressedWriteBuffer>(*writer);
+    try
+    {
+        /// Create empty marker: if both tmp_<name> and <name> exist on restart, the snapshot
+        /// is treated as incomplete and both are removed (see KeeperSnapshotManager constructor).
+        {
+            auto buf = disk->writeFile(tmp_snapshot_file_name);
+            buf->finalize();
+        }
 
-    const size_t bytes_before = compressed_writer->count();
-    KeeperStorageSnapshot<Storage>::serialize(snapshot, *compressed_writer, keeper_context);
-    const size_t bytes_written = compressed_writer->count() - bytes_before;
-    ProfileEvents::increment(ProfileEvents::KeeperSnapshotWrittenBytes, bytes_written);
+        writer = disk->writeFile(snapshot_file_name);
+        if (compress_snapshots_zstd)
+            compressed_writer = wrapWriteBufferWithCompressionMethod(std::move(writer), CompressionMethod::Zstd, 3);
+        else
+            compressed_writer = std::make_unique<CompressedWriteBuffer>(*writer);
 
-    compressed_writer->finalize();
+        const size_t bytes_before = compressed_writer->count();
+        KeeperStorageSnapshot<Storage>::serialize(snapshot, *compressed_writer, keeper_context);
+        const size_t bytes_written = compressed_writer->count() - bytes_before;
+        ProfileEvents::increment(ProfileEvents::KeeperSnapshotWrittenBytes, bytes_written);
 
-    Stopwatch watch;
-    compressed_writer->sync();
-    ProfileEvents::increment(ProfileEvents::KeeperSnapshotFileSyncMicroseconds, watch.elapsedMicroseconds());
+        compressed_writer->finalize();
 
-    disk->removeFile(tmp_snapshot_file_name);
+        Stopwatch watch;
+        compressed_writer->sync();
+        ProfileEvents::increment(ProfileEvents::KeeperSnapshotFileSyncMicroseconds, watch.elapsedMicroseconds());
+
+        compressed_writer.reset();
+        writer.reset();
+        disk->removeFile(tmp_snapshot_file_name);
+    }
+    catch (...)
+    {
+        cancelAndResetWriteBuffer(compressed_writer);
+        cancelAndResetWriteBuffer(writer);
+        removeFailedSnapshotArtifacts(disk, snapshot_file_name, tmp_snapshot_file_name, log);
+        throw;
+    }
 
     auto snapshot_file_info = makeManagedSnapshotFileInfo(snapshot_file_name, disk, up_to_log_idx);
     existing_snapshots.emplace(up_to_log_idx, snapshot_file_info);

--- a/src/Coordination/KeeperStateMachine.cpp
+++ b/src/Coordination/KeeperStateMachine.cpp
@@ -841,8 +841,6 @@ void KeeperStateMachine<Storage>::create_snapshot(nuraft::snapshot & s, nuraft::
                     }
                     else
                     {
-                        latest_snapshot_meta = snapshot->snapshot_meta;
-
                         /// Drop the cached loader before retiring snapshots; transfer
                         /// contexts keep their own loaders alive.
                         snapshot_loader_info.reset();
@@ -859,6 +857,8 @@ void KeeperStateMachine<Storage>::create_snapshot(nuraft::snapshot & s, nuraft::
                             snapshot_file_info = snapshot_manager.serializeSnapshotBufferToDisk(
                                 *snapshot_buf, snapshot->snapshot_meta->get_last_log_idx());
                         }
+
+                        latest_snapshot_meta = snapshot->snapshot_meta;
                         cancelIfHasUnfinishedSnapshotReceive();
 
                         ProfileEvents::increment(ProfileEvents::KeeperSnapshotCreations);

--- a/src/Coordination/tests/gtest_coordination_snapshot.cpp
+++ b/src/Coordination/tests/gtest_coordination_snapshot.cpp
@@ -16,14 +16,17 @@
 #include <Disks/DiskObjectStorage/ObjectStorages/Local/LocalObjectStorage.h>
 #include <Disks/DiskObjectStorage/Replication/ClusterConfiguration.h>
 #include <Disks/DiskObjectStorage/Replication/ObjectStorageRouter.h>
+#include <Disks/DiskLocal.h>
 
 #include <IO/ReadBufferFromFileBase.h>
+#include <IO/WriteBufferFromFileDecorator.h>
 
 #include <Poco/Util/MapConfiguration.h>
 
 #include <base/scope_guard.h>
 
 #include <limits>
+#include <stdexcept>
 #include <thread>
 
 namespace DB::CoordinationSetting
@@ -53,6 +56,114 @@ public:
         return DB::LocalObjectStorage::readObject(object, read_settings, read_hint, use_external_buffer, restrict_seek);
     }
 };
+
+enum class SnapshotDiskFailureMode
+{
+    OpenFileAfterCreate,
+    SyncFile,
+    SyncFileAndCleanupDataFileRemoveFailure,
+    RemoveFileOnce,
+};
+
+class ThrowingSnapshotWriteBuffer : public DB::WriteBufferFromFileDecorator
+{
+public:
+    explicit ThrowingSnapshotWriteBuffer(std::unique_ptr<DB::WriteBuffer> impl_)
+        : DB::WriteBufferFromFileDecorator(std::move(impl_))
+    {
+    }
+
+    void sync() override
+    {
+        /// Production snapshot paths call `finalize` before `sync`; this injects a failure after pending bytes are flushed.
+        throw std::runtime_error("Injected snapshot sync failure");
+    }
+};
+
+class ThrowingSnapshotDisk : public DB::DiskLocal
+{
+public:
+    ThrowingSnapshotDisk(
+        const std::string & disk_name,
+        const std::string & disk_path,
+        std::string fail_path_,
+        SnapshotDiskFailureMode failure_mode_)
+        : DB::DiskLocal(disk_name, disk_path)
+        , fail_path(std::move(fail_path_))
+        , failure_mode(failure_mode_)
+    {
+    }
+
+    void disarm()
+    {
+        failure_enabled = false;
+    }
+
+    std::unique_ptr<DB::WriteBufferFromFileBase> writeFile(
+        const String & path,
+        size_t buf_size,
+        DB::WriteMode mode,
+        const DB::WriteSettings & settings) override
+    {
+        auto inner = DB::DiskLocal::writeFile(path, buf_size, mode, settings);
+
+        if (failure_enabled && path == fail_path && failure_mode == SnapshotDiskFailureMode::OpenFileAfterCreate)
+            throw std::runtime_error("Injected snapshot open failure");
+
+        if (failure_enabled
+            && path == fail_path
+            && (failure_mode == SnapshotDiskFailureMode::SyncFile
+                || failure_mode == SnapshotDiskFailureMode::SyncFileAndCleanupDataFileRemoveFailure))
+            return std::make_unique<ThrowingSnapshotWriteBuffer>(std::move(inner));
+
+        return inner;
+    }
+
+    void removeFile(const String & path) override
+    {
+        if (failure_enabled && path == fail_path && failure_mode == SnapshotDiskFailureMode::RemoveFileOnce && !remove_failed)
+        {
+            remove_failed = true;
+            throw std::runtime_error("Injected snapshot remove failure");
+        }
+
+        DB::DiskLocal::removeFile(path);
+    }
+
+    void removeFileIfExists(const String & path) override
+    {
+        if (failure_enabled
+            && path == fail_path
+            && failure_mode == SnapshotDiskFailureMode::SyncFileAndCleanupDataFileRemoveFailure
+            && !remove_if_exists_failed)
+        {
+            remove_if_exists_failed = true;
+            throw std::runtime_error("Injected snapshot remove-if-exists failure");
+        }
+
+        DB::DiskLocal::removeFileIfExists(path);
+    }
+
+private:
+    std::string fail_path;
+    SnapshotDiskFailureMode failure_mode;
+    bool failure_enabled = true;
+    bool remove_failed = false;
+    bool remove_if_exists_failed = false;
+};
+
+template <typename Manager>
+void assertNoSnapshotArtifactsAndNoRegistration(
+    Manager & manager,
+    const std::string & snapshot_path,
+    const std::string & tmp_snapshot_path)
+{
+    EXPECT_FALSE(fs::exists(snapshot_path));
+    EXPECT_FALSE(fs::exists(tmp_snapshot_path));
+    EXPECT_EQ(manager.totalSnapshots(), 0);
+    EXPECT_EQ(manager.getLatestSnapshotIndex(), 0);
+    EXPECT_EQ(manager.getLatestSnapshotInfo(), nullptr);
+}
 
 std::pair<std::shared_ptr<DB::DiskObjectStorage>, std::shared_ptr<TestLocalObjectStorage>>
 createLocalObjectStorageDisk(const std::string & meta_path, const std::string & obj_path)
@@ -792,6 +903,253 @@ TYPED_TEST(CoordinationTest, TestReadSnapshotParallelMultiChunk)
     EXPECT_EQ(obj_storage->read_count.load() - reads_after_init, 1);
 
     snap_disk->shutdown();
+}
+
+TYPED_TEST(CoordinationTest, SerializeSnapshotToDiskCleansPartialFilesOnOpenException)
+{
+    ChangelogDirTest snapshots("./snapshots");
+    ChangelogDirTest rocks("./rocksdb");
+    this->setRocksDBDirectory("./rocksdb");
+
+    using Storage = typename TestFixture::Storage;
+
+    const std::string snapshot_file_name = "snapshot_50.bin" + this->extension;
+    this->keeper_context->setSnapshotDisk(std::make_shared<ThrowingSnapshotDisk>(
+        "SnapshotDisk", "./snapshots", snapshot_file_name, SnapshotDiskFailureMode::OpenFileAfterCreate));
+
+    DB::KeeperSnapshotManager<Storage> manager(3, this->keeper_context, this->enable_compression);
+    Storage storage(500, "", this->keeper_context);
+    addNode(storage, "/hello", "world");
+    DB::KeeperStorageSnapshot<Storage> snapshot(&storage, 50, nullptr, this->keeper_context->getWriteSnapshotVersion());
+
+    EXPECT_THROW(manager.serializeSnapshotToDisk(snapshot), std::exception);
+    assertNoSnapshotArtifactsAndNoRegistration(
+        manager, "./snapshots/" + snapshot_file_name, "./snapshots/tmp_" + snapshot_file_name);
+}
+
+TYPED_TEST(CoordinationTest, SerializeSnapshotBufferToDiskCleansPartialFilesOnSyncException)
+{
+    ChangelogDirTest snapshots("./snapshots");
+    ChangelogDirTest rocks("./rocksdb");
+    this->setRocksDBDirectory("./rocksdb");
+
+    using Storage = typename TestFixture::Storage;
+
+    const std::string snapshot_file_name = "snapshot_51.bin" + this->extension;
+    this->keeper_context->setSnapshotDisk(std::make_shared<ThrowingSnapshotDisk>(
+        "SnapshotDisk", "./snapshots", snapshot_file_name, SnapshotDiskFailureMode::SyncFile));
+
+    DB::KeeperSnapshotManager<Storage> manager(3, this->keeper_context, this->enable_compression);
+    Storage storage(500, "", this->keeper_context);
+    addNode(storage, "/hello", "world");
+    DB::KeeperStorageSnapshot<Storage> snapshot(&storage, 51, nullptr, this->keeper_context->getWriteSnapshotVersion());
+    auto buf = manager.serializeSnapshotToBuffer(snapshot);
+
+    EXPECT_THROW(manager.serializeSnapshotBufferToDisk(*buf, 51), std::exception);
+    assertNoSnapshotArtifactsAndNoRegistration(
+        manager, "./snapshots/" + snapshot_file_name, "./snapshots/tmp_" + snapshot_file_name);
+}
+
+TYPED_TEST(CoordinationTest, SerializeSnapshotBufferToDiskKeepsMarkerWhenCleanupCannotRemoveDataFile)
+{
+    ChangelogDirTest snapshots("./snapshots");
+    ChangelogDirTest rocks("./rocksdb");
+    this->setRocksDBDirectory("./rocksdb");
+
+    using Storage = typename TestFixture::Storage;
+
+    const std::string snapshot_file_name = "snapshot_56.bin" + this->extension;
+    const std::string tmp_snapshot_file_name = "tmp_" + snapshot_file_name;
+    this->keeper_context->setSnapshotDisk(std::make_shared<ThrowingSnapshotDisk>(
+        "SnapshotDisk", "./snapshots", snapshot_file_name, SnapshotDiskFailureMode::SyncFileAndCleanupDataFileRemoveFailure));
+
+    DB::KeeperSnapshotManager<Storage> manager(3, this->keeper_context, this->enable_compression);
+    Storage storage(500, "", this->keeper_context);
+    addNode(storage, "/hello", "world");
+    DB::KeeperStorageSnapshot<Storage> snapshot(&storage, 56, nullptr, this->keeper_context->getWriteSnapshotVersion());
+    auto buf = manager.serializeSnapshotToBuffer(snapshot);
+
+    EXPECT_THROW(manager.serializeSnapshotBufferToDisk(*buf, 56), std::exception);
+    EXPECT_TRUE(fs::exists("./snapshots/" + snapshot_file_name));
+    EXPECT_TRUE(fs::exists("./snapshots/" + tmp_snapshot_file_name));
+    EXPECT_EQ(manager.totalSnapshots(), 0);
+    EXPECT_EQ(manager.getLatestSnapshotIndex(), 0);
+    EXPECT_EQ(manager.getLatestSnapshotInfo(), nullptr);
+}
+
+TYPED_TEST(CoordinationTest, SerializeSnapshotBufferToDiskCleansMarkerWhenMarkerCreationFails)
+{
+    ChangelogDirTest snapshots("./snapshots");
+    ChangelogDirTest rocks("./rocksdb");
+    this->setRocksDBDirectory("./rocksdb");
+
+    using Storage = typename TestFixture::Storage;
+
+    const std::string snapshot_file_name = "snapshot_52.bin" + this->extension;
+    const std::string tmp_snapshot_file_name = "tmp_" + snapshot_file_name;
+    this->keeper_context->setSnapshotDisk(std::make_shared<ThrowingSnapshotDisk>(
+        "SnapshotDisk", "./snapshots", tmp_snapshot_file_name, SnapshotDiskFailureMode::OpenFileAfterCreate));
+
+    DB::KeeperSnapshotManager<Storage> manager(3, this->keeper_context, this->enable_compression);
+    Storage storage(500, "", this->keeper_context);
+    addNode(storage, "/hello", "world");
+    DB::KeeperStorageSnapshot<Storage> snapshot(&storage, 52, nullptr, this->keeper_context->getWriteSnapshotVersion());
+    auto buf = manager.serializeSnapshotToBuffer(snapshot);
+
+    EXPECT_THROW(manager.serializeSnapshotBufferToDisk(*buf, 52), std::exception);
+    assertNoSnapshotArtifactsAndNoRegistration(
+        manager, "./snapshots/" + snapshot_file_name, "./snapshots/" + tmp_snapshot_file_name);
+}
+
+TYPED_TEST(CoordinationTest, SerializeSnapshotBufferToDiskRemovesDataFileWhenMarkerRemovalFails)
+{
+    ChangelogDirTest snapshots("./snapshots");
+    ChangelogDirTest rocks("./rocksdb");
+    this->setRocksDBDirectory("./rocksdb");
+
+    using Storage = typename TestFixture::Storage;
+
+    const std::string snapshot_file_name = "snapshot_53.bin" + this->extension;
+    const std::string tmp_snapshot_file_name = "tmp_" + snapshot_file_name;
+    this->keeper_context->setSnapshotDisk(std::make_shared<ThrowingSnapshotDisk>(
+        "SnapshotDisk", "./snapshots", tmp_snapshot_file_name, SnapshotDiskFailureMode::RemoveFileOnce));
+
+    DB::KeeperSnapshotManager<Storage> manager(3, this->keeper_context, this->enable_compression);
+    Storage storage(500, "", this->keeper_context);
+    addNode(storage, "/hello", "world");
+    DB::KeeperStorageSnapshot<Storage> snapshot(&storage, 53, nullptr, this->keeper_context->getWriteSnapshotVersion());
+    auto buf = manager.serializeSnapshotToBuffer(snapshot);
+
+    EXPECT_THROW(manager.serializeSnapshotBufferToDisk(*buf, 53), std::exception);
+    assertNoSnapshotArtifactsAndNoRegistration(
+        manager, "./snapshots/" + snapshot_file_name, "./snapshots/" + tmp_snapshot_file_name);
+}
+
+TYPED_TEST(CoordinationTest, BeginSnapshotReceiveToDiskCleansPartialFilesOnOpenException)
+{
+    ChangelogDirTest snapshots("./snapshots");
+    ChangelogDirTest rocks("./rocksdb");
+    this->setRocksDBDirectory("./rocksdb");
+
+    using Storage = typename TestFixture::Storage;
+
+    const std::string snapshot_file_name = "snapshot_54.bin" + this->extension;
+    this->keeper_context->setSnapshotDisk(std::make_shared<ThrowingSnapshotDisk>(
+        "SnapshotDisk", "./snapshots", snapshot_file_name, SnapshotDiskFailureMode::OpenFileAfterCreate));
+
+    DB::KeeperSnapshotManager<Storage> manager(3, this->keeper_context, this->enable_compression);
+
+    EXPECT_THROW(manager.beginSnapshotReceiveToDisk(54), std::exception);
+    assertNoSnapshotArtifactsAndNoRegistration(
+        manager, "./snapshots/" + snapshot_file_name, "./snapshots/tmp_" + snapshot_file_name);
+}
+
+TYPED_TEST(CoordinationTest, FinalizeSnapshotReceiveToDiskCleansPartialFilesOnSyncException)
+{
+    ChangelogDirTest snapshots("./snapshots");
+    ChangelogDirTest rocks("./rocksdb");
+    this->setRocksDBDirectory("./rocksdb");
+
+    using Storage = typename TestFixture::Storage;
+
+    const std::string snapshot_file_name = "snapshot_55.bin" + this->extension;
+    this->keeper_context->setSnapshotDisk(std::make_shared<ThrowingSnapshotDisk>(
+        "SnapshotDisk", "./snapshots", snapshot_file_name, SnapshotDiskFailureMode::SyncFile));
+
+    DB::KeeperSnapshotManager<Storage> manager(3, this->keeper_context, this->enable_compression);
+    auto receive_ctx = manager.beginSnapshotReceiveToDisk(55);
+    const std::string partial_snapshot_bytes = "partial snapshot bytes";
+    receive_ctx->write_buf->write(partial_snapshot_bytes.data(), partial_snapshot_bytes.size());
+
+    EXPECT_THROW(manager.finalizeSnapshotReceiveToDisk(*receive_ctx), std::exception);
+    EXPECT_FALSE(receive_ctx->write_buf);
+    assertNoSnapshotArtifactsAndNoRegistration(
+        manager, "./snapshots/" + snapshot_file_name, "./snapshots/tmp_" + snapshot_file_name);
+}
+
+TEST(KeeperSnapshotManagerCleanupTest, CreateSnapshotKeepsPreviousMetadataAndAllowsRetryAfterFailedWrite)
+{
+    ChangelogDirTest snapshots("./snapshots");
+    ChangelogDirTest rocks("./rocksdb");
+
+    auto settings = std::make_shared<DB::CoordinationSettings>();
+#if USE_ROCKSDB
+    (*settings)[DB::CoordinationSetting::experimental_use_rocksdb] = false;
+#endif
+    auto ctx = std::make_shared<DB::KeeperContext>(true, settings);
+    ctx->setLocalLogsPreprocessed();
+    auto throwing_disk = std::make_shared<ThrowingSnapshotDisk>(
+        "SnapshotDisk", "./snapshots", "snapshot_2.bin.zstd", SnapshotDiskFailureMode::OpenFileAfterCreate);
+    ctx->setSnapshotDisk(throwing_disk);
+    ctx->setRocksDBDisk(std::make_shared<DB::DiskLocal>("RocksDisk", "./rocksdb"));
+    ctx->setRocksDBOptions();
+
+    DB::SnapshotsQueue snapshots_queue{1};
+    auto state_machine = std::make_shared<DB::KeeperStateMachine<DB::KeeperMemoryStorage>>(nullptr, snapshots_queue, ctx, nullptr);
+    state_machine->init();
+
+    auto execute_snapshot_task = [&](nuraft::snapshot & snapshot, bool & callback_called, bool & callback_result)
+    {
+        nuraft::async_result<bool>::handler_type when_done
+            = [&](bool & ret, nuraft::ptr<std::exception> &)
+        {
+            callback_called = true;
+            callback_result = ret;
+        };
+
+        state_machine->create_snapshot(snapshot, when_done);
+        DB::CreateSnapshotTask snapshot_task;
+        EXPECT_TRUE(snapshots_queue.pop(snapshot_task));
+        return snapshot_task.create_snapshot(std::move(snapshot_task.snapshot), /*execute_only_cleanup=*/false);
+    };
+
+    auto request1 = std::make_shared<Coordination::ZooKeeperCreateRequest>();
+    request1->path = "/node1";
+    auto entry1 = getLogEntryFromZKRequest(0, 1, state_machine->getNextZxid(), request1);
+    state_machine->pre_commit(1, entry1->get_buf());
+    state_machine->commit(1, entry1->get_buf());
+
+    nuraft::snapshot s1(1, 0, std::make_shared<nuraft::cluster_config>());
+    bool callback_called_1 = false;
+    bool callback_result_1 = false;
+    execute_snapshot_task(s1, callback_called_1, callback_result_1);
+    EXPECT_TRUE(callback_called_1);
+    EXPECT_TRUE(callback_result_1);
+    ASSERT_NE(state_machine->last_snapshot(), nullptr);
+    EXPECT_EQ(state_machine->last_snapshot()->get_last_log_idx(), 1);
+    EXPECT_TRUE(fs::exists("./snapshots/snapshot_1.bin.zstd"));
+    EXPECT_FALSE(fs::exists("./snapshots/tmp_snapshot_1.bin.zstd"));
+
+    auto request2 = std::make_shared<Coordination::ZooKeeperCreateRequest>();
+    request2->path = "/node2";
+    auto entry2 = getLogEntryFromZKRequest(0, 1, state_machine->getNextZxid(), request2);
+    state_machine->pre_commit(2, entry2->get_buf());
+    state_machine->commit(2, entry2->get_buf());
+
+    nuraft::snapshot s2(2, 0, std::make_shared<nuraft::cluster_config>());
+    bool callback_called_2 = false;
+    bool callback_result_2 = true;
+    execute_snapshot_task(s2, callback_called_2, callback_result_2);
+    EXPECT_TRUE(callback_called_2);
+    EXPECT_FALSE(callback_result_2);
+    ASSERT_NE(state_machine->last_snapshot(), nullptr);
+    EXPECT_EQ(state_machine->last_snapshot()->get_last_log_idx(), 1);
+    EXPECT_TRUE(fs::exists("./snapshots/snapshot_1.bin.zstd"));
+    EXPECT_FALSE(fs::exists("./snapshots/snapshot_2.bin.zstd"));
+    EXPECT_FALSE(fs::exists("./snapshots/tmp_snapshot_2.bin.zstd"));
+    EXPECT_EQ(state_machine->last_commit_index(), 2);
+
+    throwing_disk->disarm();
+    bool callback_called_3 = false;
+    bool callback_result_3 = false;
+    execute_snapshot_task(s2, callback_called_3, callback_result_3);
+    EXPECT_TRUE(callback_called_3);
+    EXPECT_TRUE(callback_result_3);
+    ASSERT_NE(state_machine->last_snapshot(), nullptr);
+    EXPECT_EQ(state_machine->last_snapshot()->get_last_log_idx(), 2);
+    EXPECT_TRUE(fs::exists("./snapshots/snapshot_1.bin.zstd"));
+    EXPECT_TRUE(fs::exists("./snapshots/snapshot_2.bin.zstd"));
+    EXPECT_FALSE(fs::exists("./snapshots/tmp_snapshot_2.bin.zstd"));
 }
 
 #endif


### PR DESCRIPTION
Fix a `Keeper` snapshot recovery edge case where failed snapshot writes could leave partial artifacts and make retry decisions from metadata for a snapshot that was not persisted.

This change cancels unfinished `WriteBuffer`s, removes only the exact failed `snapshot_*` and `tmp_snapshot_*` artifacts for the current attempt, and keeps the `tmp_snapshot_*` marker if the partial data file cannot be removed so restart recovery still treats the snapshot as incomplete. It also updates `latest_snapshot_meta` only after snapshot persistence succeeds.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `Keeper` snapshot cleanup after failed writes so partial snapshots are cleaned up safely and failed writes can be retried without advancing `latest_snapshot_meta`.

### Documentation entry:
- [x] Documentation is not required because this fixes `Keeper` snapshot failure handling and is covered by unit tests.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.129`
- Backported to: `26.5.2.11`
<!-- ch-version-info:end -->