### PR TITLE
Allow `CLEAR COLUMN` for explicit `columns_to_sum`

### DIFF
--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -1414,10 +1414,13 @@ void MergeTreeData::checkTTLExpressions(const StorageInMemoryMetadata & new_meta
 namespace
 {
 
-void checkSpecialColumn(const std::string_view column_meta_name, const AlterCommand & command)
+void checkSpecialColumn(const std::string_view column_meta_name, const AlterCommand & command, bool allow_clear = false)
 {
     if (command.type == AlterCommand::DROP_COLUMN)
     {
+        if (allow_clear && command.clear)
+            return;
+
         throw Exception(
             ErrorCodes::ALTER_OF_COLUMN_IS_FORBIDDEN,
             "Trying to ALTER DROP {} ({}) column",
@@ -4540,9 +4543,9 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
         {
             checkSpecialColumnWithDataType<DataTypeUInt8>("sign", command);
         }
-        else if (merging_params.columns_to_sum.end() != std::find(merging_params.columns_to_sum.begin(), merging_params.columns_to_sum.end(), command.column_name))
+        else if (std::ranges::contains(merging_params.columns_to_sum, command.column_name))
         {
-            checkSpecialColumn("columns to sum", command);
+            checkSpecialColumn("columns to sum", command, /* allow_clear = */ true);
         }
 
         if (command.type == AlterCommand::MODIFY_QUERY)

--- a/tests/queries/0_stateless/04267_clear_column_explicit_summing_columns_to_sum_105782.reference
+++ b/tests/queries/0_stateless/04267_clear_column_explicit_summing_columns_to_sum_105782.reference
@@ -1,0 +1,4 @@
+summing_rows_after_clear	0
+summing_column_meta_after_clear	c	Int64
+coalescing_clear_values	1	0
+coalescing_column_meta_after_clear	c	UInt64

--- a/tests/queries/0_stateless/04267_clear_column_explicit_summing_columns_to_sum_105782.sql
+++ b/tests/queries/0_stateless/04267_clear_column_explicit_summing_columns_to_sum_105782.sql
@@ -1,0 +1,97 @@
+-- Tags: no-random-merge-tree-settings
+
+SET mutations_sync = 2;
+SET alter_sync = 2;
+SET optimize_on_insert = 0;
+
+DROP TABLE IF EXISTS t_clear_column_explicit_sum_105782;
+
+CREATE TABLE t_clear_column_explicit_sum_105782
+(
+    p UInt32,
+    v UInt32,
+    c Int64
+)
+ENGINE = SummingMergeTree(c)
+PARTITION BY p
+ORDER BY v;
+
+SYSTEM STOP MERGES t_clear_column_explicit_sum_105782;
+INSERT INTO t_clear_column_explicit_sum_105782 VALUES (1, 1, 5), (1, 2, 10);
+INSERT INTO t_clear_column_explicit_sum_105782 VALUES (1, 1, 7), (1, 2, 11);
+SYSTEM START MERGES t_clear_column_explicit_sum_105782;
+
+ALTER TABLE t_clear_column_explicit_sum_105782 CLEAR COLUMN c IN PARTITION 1;
+OPTIMIZE TABLE t_clear_column_explicit_sum_105782 PARTITION 1 FINAL;
+
+SELECT 'summing_rows_after_clear', count() FROM t_clear_column_explicit_sum_105782;
+SELECT 'summing_column_meta_after_clear', name, type
+FROM system.columns
+WHERE database = currentDatabase()
+  AND table = 't_clear_column_explicit_sum_105782'
+  AND name = 'c';
+
+ALTER TABLE t_clear_column_explicit_sum_105782 DROP COLUMN c; -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+ALTER TABLE t_clear_column_explicit_sum_105782 RENAME COLUMN c TO c_renamed; -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+
+DROP TABLE t_clear_column_explicit_sum_105782;
+
+DROP TABLE IF EXISTS t_clear_column_explicit_coalescing_105782;
+
+CREATE TABLE t_clear_column_explicit_coalescing_105782
+(
+    k UInt32,
+    c UInt64
+)
+ENGINE = CoalescingMergeTree(c)
+ORDER BY k;
+
+INSERT INTO t_clear_column_explicit_coalescing_105782 VALUES (1, 10);
+INSERT INTO t_clear_column_explicit_coalescing_105782 VALUES (1, 20);
+
+ALTER TABLE t_clear_column_explicit_coalescing_105782 CLEAR COLUMN c;
+OPTIMIZE TABLE t_clear_column_explicit_coalescing_105782 FINAL;
+
+SELECT 'coalescing_clear_values', k, c FROM t_clear_column_explicit_coalescing_105782 ORDER BY k;
+SELECT 'coalescing_column_meta_after_clear', name, type
+FROM system.columns
+WHERE database = currentDatabase()
+  AND table = 't_clear_column_explicit_coalescing_105782'
+  AND name = 'c';
+
+ALTER TABLE t_clear_column_explicit_coalescing_105782 DROP COLUMN c; -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+ALTER TABLE t_clear_column_explicit_coalescing_105782 RENAME COLUMN c TO c_renamed; -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+
+DROP TABLE t_clear_column_explicit_coalescing_105782;
+
+DROP TABLE IF EXISTS t_clear_column_special_replacing_105782;
+
+CREATE TABLE t_clear_column_special_replacing_105782
+(
+    k UInt32,
+    ver UInt64,
+    is_deleted UInt8,
+    v UInt64
+)
+ENGINE = ReplacingMergeTree(ver, is_deleted)
+ORDER BY k;
+
+ALTER TABLE t_clear_column_special_replacing_105782 CLEAR COLUMN ver; -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+ALTER TABLE t_clear_column_special_replacing_105782 CLEAR COLUMN is_deleted; -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+
+DROP TABLE t_clear_column_special_replacing_105782;
+
+DROP TABLE IF EXISTS t_clear_column_special_collapsing_105782;
+
+CREATE TABLE t_clear_column_special_collapsing_105782
+(
+    k UInt32,
+    sign Int8,
+    v UInt64
+)
+ENGINE = CollapsingMergeTree(sign)
+ORDER BY k;
+
+ALTER TABLE t_clear_column_special_collapsing_105782 CLEAR COLUMN sign; -- { serverError ALTER_OF_COLUMN_IS_FORBIDDEN }
+
+DROP TABLE t_clear_column_special_collapsing_105782;


### PR DESCRIPTION
Fix `ALTER TABLE ... CLEAR COLUMN` for explicit `columns_to_sum` columns in engines such as `SummingMergeTree(c)` and `CoalescingMergeTree(c)`.

`CLEAR COLUMN` is represented internally as `DROP_COLUMN` with `clear = true`, so explicit `columns_to_sum` validation rejected it as if it were a real `DROP COLUMN`. This change allows only that clear path while keeping real `DROP COLUMN`, `RENAME COLUMN`, and other special columns forbidden.

Closes https://github.com/ClickHouse/ClickHouse/issues/105782

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `ALTER TABLE ... CLEAR COLUMN` being rejected for explicit `SummingMergeTree` and `CoalescingMergeTree` `columns_to_sum` columns.

### Documentation entry:
- [x] Documentation is not required for this change.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.152`
<!-- ch-version-info:end -->