### PR TITLE
Drop notes for TPC-DS Q51/Q64/Q65

### DIFF
--- a/tests/benchmarks/tpc-ds/README.md
+++ b/tests/benchmarks/tpc-ds/README.md
@@ -128,9 +128,6 @@ ORDER BY v1.sum_sales - v1.avg_monthly_sales, v1.s_store_name
 LIMIT 100;
 ```
 
-## Q51
-The result contains ᴺᵁᴸᴸ. This is correct, but we were using format_tsv_null_representation='' setting to represent nulls as empty strings. This is due to https://github.com/ClickHouse/ClickHouse/issues/95168. Note: running this query for the first time may produce '', but consecutive runs will produce 'ᴺᵁᴸᴸ'.
-
 ## Q57
 The query doesn't work out-of-the-box due to https://github.com/ClickHouse/ClickHouse/issues/94858. The alternative formulation with a minor fix works.
 
@@ -416,10 +413,6 @@ ORDER BY
     ss_item_rev
 LIMIT 100;
 ```
-
-## Q64-65
-The result contains ᴺᵁᴸᴸ. This is correct, but we were using format_tsv_null_representation='' setting to represent nulls as empty strings. This is due to https://github.com/ClickHouse/ClickHouse/issues/95168. Note: running this query for the first time may produce '', but consecutive runs will produce 'ᴺᵁᴸᴸ'.
-
 
 ## Q75
 The query doesn't work out-of-the-box due to https://github.com/ClickHouse/ClickHouse/issues/94671. The alternative formulation with a minor fix works.

--- a/tests/benchmarks/tpc-ds/queries/query_51.sql
+++ b/tests/benchmarks/tpc-ds/queries/query_51.sql
@@ -1,6 +1,3 @@
--- The result contains ᴺᵁᴸᴸ. This is correct, but we were using format_tsv_null_representation='' setting to represent nulls as empty strings
--- https://github.com/ClickHouse/ClickHouse/issues/95168
--- Note: running this query for the first time may produce '', but consecutive runs will produce 'ᴺᵁᴸᴸ'
 WITH
     web_v1 AS
     (

--- a/tests/benchmarks/tpc-ds/queries/query_64.sql
+++ b/tests/benchmarks/tpc-ds/queries/query_64.sql
@@ -1,6 +1,3 @@
--- The result contains ᴺᵁᴸᴸ. This is correct, but we were using format_tsv_null_representation='' setting to represent nulls as empty strings
--- https://github.com/ClickHouse/ClickHouse/issues/95168
--- Note: running this query for the first time may produce '', but consecutive runs will produce 'ᴺᵁᴸᴸ'
 WITH
     cs_ui AS
     (

--- a/tests/benchmarks/tpc-ds/queries/query_65.sql
+++ b/tests/benchmarks/tpc-ds/queries/query_65.sql
@@ -1,6 +1,3 @@
--- The result contains ᴺᵁᴸᴸ. This is correct, but we were using format_tsv_null_representation='' setting to represent nulls as empty strings
--- https://github.com/ClickHouse/ClickHouse/issues/95168
--- Note: running this query for the first time may produce '', but consecutive runs will produce 'ᴺᵁᴸᴸ'
 SELECT
     s_store_name,
     i_item_desc,


### PR DESCRIPTION
Q51/Q64/Q65 referenced a problem that is no longer present, thus the stale notes are dropped from the `README.md` of TPC-DS benchmark and the headers of the query files.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.140`
<!-- ch-version-info:end -->