### PR TITLE
Preserve ERROR status in bugfix-validation inverter

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -137,6 +137,45 @@ OPTIONS_TO_TEST_RUNNER_ARGUMENTS = {
 }
 
 
+def invert_bugfix_validation_status(test_result: Result) -> None:
+    """Invert FAIL/OK in `test_result.results` for bugfix validation.
+
+    On master HEAD a regression test for the bug is expected to FAIL; the
+    inverter flips that to OK so the job reads as "bug reproduced". A clean
+    OK means the test does not catch the bug and is flipped to FAIL with
+    "Failed to reproduce the bug".
+
+    When the run ended in `Result.Status.ERROR` (runner did not finish,
+    e.g. server crash without proper exit code, Python exception,
+    infrastructure outage) the per-test list is empty or partial and the
+    pre-inversion `ERROR` already tells the truth. Preserve it instead of
+    overwriting with "Failed to reproduce the bug". See #105789.
+    """
+    if test_result.status == Result.Status.ERROR:
+        for r in test_result.results:
+            r.set_label(Result.Label.XFAIL)
+        print(
+            "Bugfix validation inconclusive: the test runner did not "
+            "finish; preserving ERROR rather than reporting "
+            "'Failed to reproduce the bug'."
+        )
+        return
+
+    has_failure = False
+    for r in test_result.results:
+        r.set_label(Result.Label.XFAIL)
+        if r.status == Result.Status.FAIL:
+            r.status = Result.Status.OK
+            has_failure = True
+        elif r.status == Result.Status.OK:
+            r.status = Result.Status.FAIL
+    if not has_failure:
+        print("Failed to reproduce the bug")
+        test_result.set_failed().set_info("Failed to reproduce the bug")
+    else:
+        test_result.set_success()
+
+
 def main():
     args = parse_args()
     test_options = [to.strip() for to in args.options.split(",")]
@@ -749,22 +788,7 @@ def main():
 
     # invert result status for bugfix validation
     if is_bugfix_validation and test_result and (Labels.PR_BUGFIX in info.pr_labels or Labels.PR_CRITICAL_BUGFIX in info.pr_labels):
-        has_failure = False
-        for r in test_result.results:
-            r.set_label(Result.Label.XFAIL)
-            if r.status == Result.Status.FAIL:
-                r.status = Result.Status.OK
-                has_failure = True
-            elif r.status == Result.Status.OK:
-                r.status = Result.Status.FAIL
-        if not has_failure:
-            print("Failed to reproduce the bug")
-            test_result.set_failed().set_info("Failed to reproduce the bug")
-        else:
-            # For bugfix validation, the expected behavior is:
-            # - At least one test must fail (bug reproduced)
-            # - The overall Tests result is treated as success in that case
-            test_result.set_success()
+        invert_bugfix_validation_status(test_result)
 
     if JobStages.COLLECT_LOGS in stages:
         print("Collect logs")

--- a/ci/tests/test_bugfix_validation_inverter.py
+++ b/ci/tests/test_bugfix_validation_inverter.py
@@ -1,0 +1,174 @@
+"""
+Tests for `ci.jobs.functional_tests.invert_bugfix_validation_status`.
+
+The bugfix-validation inverter flips per-test `FAIL`/`OK` so that a regression
+test for a bug, which is expected to `FAIL` on master HEAD, is reported as
+"bug reproduced". When the run itself failed catastrophically (status
+`ERROR`, e.g. runner killed mid-flight or server crashed without a
+synthetic `Server died` leaf reaching `test_result.results`), the inverter
+must preserve `ERROR` rather than overwrite it with the misleading
+"Failed to reproduce the bug" `FAIL`.
+
+See ClickHouse/ClickHouse#105789.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.jobs.functional_tests import invert_bugfix_validation_status
+from ci.praktika.result import Result
+
+
+def _make_leaf(name, status, info=""):
+    return Result(name=name, status=status, info=info)
+
+
+def _make_outer(status, results=None, info=""):
+    return Result(
+        name="Tests",
+        status=status,
+        results=results or [],
+        info=info,
+    )
+
+
+def test_single_fail_is_flipped_to_ok_and_outer_becomes_success():
+    """Regression test FAILed on master -> bug reproduced -> overall OK."""
+    leaf = _make_leaf("01234_regression_test", Result.Status.FAIL,
+                      info="server died with SIGSEGV")
+    outer = _make_outer(Result.Status.FAIL, [leaf])
+
+    invert_bugfix_validation_status(outer)
+
+    assert leaf.status == Result.Status.OK
+    assert outer.status == Result.Status.OK
+
+
+def test_single_ok_is_flipped_to_fail_and_outer_becomes_failed_to_reproduce():
+    """Regression test PASSed on master -> bug not reproduced -> overall FAIL."""
+    leaf = _make_leaf("01234_regression_test", Result.Status.OK)
+    outer = _make_outer(Result.Status.OK, [leaf])
+
+    invert_bugfix_validation_status(outer)
+
+    assert leaf.status == Result.Status.FAIL
+    assert outer.status == Result.Status.FAIL
+    assert "Failed to reproduce the bug" in outer.info
+
+
+def test_mixed_fail_and_ok_treats_any_fail_as_bug_reproduced():
+    """At least one FAIL on master is enough to declare the bug reproduced."""
+    leaf_fail = _make_leaf("01234_regression_test", Result.Status.FAIL)
+    leaf_ok = _make_leaf("99999_unrelated_test", Result.Status.OK)
+    outer = _make_outer(Result.Status.FAIL, [leaf_fail, leaf_ok])
+
+    invert_bugfix_validation_status(outer)
+
+    assert leaf_fail.status == Result.Status.OK
+    assert leaf_ok.status == Result.Status.FAIL
+    assert outer.status == Result.Status.OK
+
+
+def test_server_died_synthetic_fail_leaf_treated_as_bug_reproduced():
+    """Mirrors the leshikus PR #105643 flow: parser synthesises a `Server
+    died` FAIL leaf for `runner_exit_code in {STOP_TESTING_EXIT_CODE, 137,
+    143}`. The inverter must flip it to OK so the bugfix check passes.
+    """
+    leaf = _make_leaf("Server died", Result.Status.FAIL, info="Server died")
+    outer = _make_outer(Result.Status.FAIL, [leaf])
+
+    invert_bugfix_validation_status(outer)
+
+    assert leaf.status == Result.Status.OK
+    assert outer.status == Result.Status.OK
+
+
+def test_error_status_with_empty_results_preserves_error():
+    """The regression in #105789: the runner did not finish, no per-test
+    results were emitted, status is `ERROR`. The inverter must NOT
+    overwrite that with `FAIL` "Failed to reproduce the bug".
+    """
+    outer = _make_outer(
+        Result.Status.ERROR,
+        results=[],
+        info="The test runner was terminated unexpectedly",
+    )
+
+    invert_bugfix_validation_status(outer)
+
+    # The honest ERROR is preserved.
+    assert outer.status == Result.Status.ERROR
+    # The original info is preserved (no "Failed to reproduce" appended).
+    assert outer.info == "The test runner was terminated unexpectedly"
+    assert "Failed to reproduce the bug" not in outer.info
+
+
+def test_error_status_with_partial_results_preserves_error():
+    """Same as the empty case, but with partial per-test data from an
+    interrupted run. We must not flip OK leaves to FAIL on a run that
+    never completed.
+    """
+    leaf = _make_leaf("01234_some_other_test", Result.Status.OK)
+    outer = _make_outer(
+        Result.Status.ERROR,
+        results=[leaf],
+        info="The test runner was terminated unexpectedly",
+    )
+
+    invert_bugfix_validation_status(outer)
+
+    # Outer status preserved.
+    assert outer.status == Result.Status.ERROR
+    # Leaf status not flipped (the run was inconclusive, so flipping
+    # a passing test to FAIL would be incorrect).
+    assert leaf.status == Result.Status.OK
+    # Leaf is still labelled XFAIL so json.html renders it consistently.
+    leaf_labels = [
+        lbl.get("name") if isinstance(lbl, dict) else lbl
+        for lbl in leaf.ext.get("labels", [])
+    ]
+    assert Result.Label.XFAIL in leaf_labels
+
+
+def test_xfail_label_is_applied_to_each_leaf_on_inversion():
+    """Both flipped and non-flipped leaves should get the XFAIL label so
+    json.html renders them consistently in the bugfix-validation report.
+    """
+    leaf_fail = _make_leaf("01234_a", Result.Status.FAIL)
+    leaf_ok = _make_leaf("01234_b", Result.Status.OK)
+    leaf_skipped = _make_leaf("01234_c", Result.Status.SKIPPED)
+    outer = _make_outer(
+        Result.Status.FAIL, [leaf_fail, leaf_ok, leaf_skipped]
+    )
+
+    invert_bugfix_validation_status(outer)
+
+    for leaf in (leaf_fail, leaf_ok, leaf_skipped):
+        labels = [
+            lbl.get("name") if isinstance(lbl, dict) else lbl
+            for lbl in leaf.ext.get("labels", [])
+        ]
+        assert Result.Label.XFAIL in labels, (
+            f"XFAIL label missing on {leaf.name} (status={leaf.status})"
+        )
+
+
+def test_empty_results_with_ok_outer_still_reports_failed_to_reproduce():
+    """If the outer status is OK and there are no per-test results, the
+    existing semantics still apply: no bug was reproduced. (Realistic
+    scenario: the bug-fix PR runs but no test was selected.)
+    """
+    outer = _make_outer(Result.Status.OK, results=[], info="")
+
+    invert_bugfix_validation_status(outer)
+
+    assert outer.status == Result.Status.FAIL
+    assert "Failed to reproduce the bug" in outer.info
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Closes #105789.

Cuts the false-negative `Failed to reproduce the bug` report that the `Bugfix validation (functional tests)` check produced when the test runner did not finish (server crash without proper exit code, runner Python exception, job-level timeout, infrastructure outage). PR #105749 hit this and worked around it by rewriting the regression test as `.sh` so the SEGV stayed in a subprocess.

The inverter at `ci/jobs/functional_tests.py:751-767` walks `test_result.results` to flip `FAIL` to `OK`. When the run ended in `Result.Status.ERROR`, that list was empty or partial, the loop did nothing, `has_failure` stayed `False`, and the `else` branch unconditionally called `set_failed().set_info("Failed to reproduce the bug")` — silently overwriting the honest `ERROR` set by `functional_tests_results.py:run()`.

The fix extracts the inverter to a module-level helper `invert_bugfix_validation_status` and short-circuits when `test_result.status == Result.Status.ERROR`: preserve the original status and `info`, only attach the `XFAIL` label to leaves so the report renders consistently. `FAIL` and `OK` paths continue to invert as before.

The complementary `Server died` synthesis for `runner_exit_code in {STOP_TESTING_EXIT_CODE, 137, 143}` is handled in @leshikus's PR #105643. With that PR, signal-killed runs surface a `FAIL` leaf that this inverter then correctly maps to "bug reproduced". This change covers every other path that leaves `status == ERROR`.

### Tests

`ci/tests/test_bugfix_validation_inverter.py` adds 8 unit tests covering:

- single `FAIL` flipped to `OK` (bug reproduced)
- single `OK` flipped to `FAIL` (bug not reproduced)
- mixed `FAIL` + `OK`
- synthetic `Server died` `FAIL` leaf (#105643 flow)
- `ERROR` + empty results: preserved (the #105789 regression)
- `ERROR` + partial `OK` leaf: preserved, leaf not flipped, `XFAIL` label still applied
- `XFAIL` label applied to every leaf
- `OK` outer + empty results: still reports "Failed to reproduce the bug"

The two `ERROR`-preservation tests were also run against an inlined copy of the pre-fix code path to confirm both directions: the old behaviour overwrites `ERROR` with `FAIL` "Failed to reproduce the bug", the new behaviour preserves `ERROR`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.197`
<!-- ch-version-info:end -->