### PR TITLE
Substitute DDL parameters in parameterized view CREATE statements

### DIFF
--- a/src/Interpreters/ReplaceQueryParameterVisitor.cpp
+++ b/src/Interpreters/ReplaceQueryParameterVisitor.cpp
@@ -11,6 +11,7 @@
 #include <Parsers/ASTIdentifier.h>
 #include <Parsers/ASTLiteral.h>
 #include <Parsers/ASTQueryParameter.h>
+#include <Parsers/ASTSelectWithUnionQuery.h>
 #include <Parsers/ASTViewTargets.h>
 #include <Parsers/Access/ASTCreateUserQuery.h>
 #include <Parsers/Access/ASTUserNameWithHost.h>
@@ -57,17 +58,39 @@ void ReplaceQueryParameterVisitor::visit(ASTPtr & ast)
             }
             visitChildren(ast);
         }
-        else if (auto * create_query = dynamic_cast<ASTCreateQuery *>(ast.get());
-                 create_query && create_query->targets && create_query->targets->hasTableASTWithQueryParams(ViewTarget::To))
+        else if (auto * create_query = dynamic_cast<ASTCreateQuery *>(ast.get()))
         {
-            auto to_table_ast = create_query->targets->getTableASTWithQueryParams(ViewTarget::To);
+            if (create_query->isParameterizedView())
+            {
+                /// For a parameterized view the SELECT body contains query parameters that
+                /// form the view's parameterizable interface; they are substituted at
+                /// view-call time and must be preserved here. Other parts of the query
+                /// (database name, table name, columns list, storage, view targets) are
+                /// still subject to parameter substitution at create time.
+                const IAST * select_node = create_query->select;
+                for (auto & child : create_query->children)
+                {
+                    if (child.get() == select_node)
+                        continue;
+                    IAST * old_ptr = child.get();
+                    visit(child);
+                    if (child.get() != old_ptr)
+                        create_query->updatePointerToChild(old_ptr, child);
+                }
+            }
+            else if (create_query->targets && create_query->targets->hasTableASTWithQueryParams(ViewTarget::To))
+            {
+                auto to_table_ast = create_query->targets->getTableASTWithQueryParams(ViewTarget::To);
 
-            visit(to_table_ast);
+                visit(to_table_ast);
 
-            create_query->targets->setTableID(ViewTarget::To, to_table_ast->as<ASTTableIdentifier>()->getTableId());
-            create_query->targets->resetTableASTWithQueryParams(ViewTarget::To);
+                create_query->targets->setTableID(ViewTarget::To, to_table_ast->as<ASTTableIdentifier>()->getTableId());
+                create_query->targets->resetTableASTWithQueryParams(ViewTarget::To);
 
-            visitChildren(ast);
+                visitChildren(ast);
+            }
+            else
+                visitChildren(ast);
         }
         else
             visitChildren(ast);

--- a/src/Interpreters/executeQuery.cpp
+++ b/src/Interpreters/executeQuery.cpp
@@ -1337,29 +1337,20 @@ static BlockIO executeQueryImpl(
         }
 
         const char * query_end = end;
-        bool is_create_parameterized_view = false;
 
         if (out_ast)
         {
             if (const auto * insert_query = out_ast->as<ASTInsertQuery>(); insert_query && insert_query->data)
                 query_end = insert_query->data;
-
-            if (const auto * create_query = out_ast->as<ASTCreateQuery>())
-            {
-                is_create_parameterized_view = create_query->isParameterizedView();
-            }
-            else if (const auto * explain_query = out_ast->as<ASTExplainQuery>())
-            {
-                if (!explain_query->children.empty())
-                    if (const auto * create_of_explain_query = explain_query->children[0]->as<ASTCreateQuery>())
-                        is_create_parameterized_view = create_of_explain_query->isParameterizedView();
-            }
         }
 
         /// Replace ASTQueryParameter with ASTLiteral for prepared statements.
-        /// Even if we don't have parameters in query_context, check that AST doesn't have unknown parameters
+        /// Even if we don't have parameters in query_context, check that AST doesn't have unknown parameters.
+        /// The visitor handles parameterized views internally: it substitutes parameters in
+        /// DDL parts (database, table, columns, storage, targets) while preserving placeholders
+        /// in the SELECT body, which form the view's parameterizable interface.
         bool probably_has_params = find_first_symbols<'{'>(begin, end) != end;
-        if (out_ast && !is_create_parameterized_view && probably_has_params)
+        if (out_ast && probably_has_params)
         {
             ReplaceQueryParameterVisitor visitor(context->getQueryParameters());
             visitor.visit(out_ast);

--- a/tests/queries/0_stateless/04276_create_view_param_db_with_param_select.reference
+++ b/tests/queries/0_stateless/04276_create_view_param_db_with_param_select.reference
@@ -1,0 +1,1 @@
+create view with param db: ok

--- a/tests/queries/0_stateless/04276_create_view_param_db_with_param_select.sql
+++ b/tests/queries/0_stateless/04276_create_view_param_db_with_param_select.sql
@@ -1,0 +1,34 @@
+-- Regression for STID 3282-3691: CREATE VIEW with a query parameter in the database
+-- identifier and another query parameter in the SELECT body must not trigger the
+-- `!database_name.empty()` assertion in `DatabaseCatalog::tryGetDatabase`.
+--
+-- Before the fix, `ASTCreateQuery::isParameterizedView` returned true whenever the
+-- SELECT body had any query parameter, which made `executeQueryImpl` skip
+-- `ReplaceQueryParameterVisitor` entirely. The `{db:Identifier}` placeholder in the
+-- database name was therefore never substituted, leaving `create.getDatabase()`
+-- empty and aborting the server in debug builds. The fix runs the visitor on the
+-- DDL parts of the parameterized view (database name, table name, columns list,
+-- storage, view targets) while keeping the SELECT body's placeholders intact, so
+-- they can be substituted later at view-call time.
+
+CREATE TABLE {CLICKHOUSE_DATABASE:Identifier}.src_04276 (k UInt64, v String) ENGINE = MergeTree ORDER BY k;
+INSERT INTO {CLICKHOUSE_DATABASE:Identifier}.src_04276 VALUES (10, 'ten');
+
+-- The database identifier is a query parameter and the SELECT contains another query
+-- parameter (the view's parameterizable interface). The exact STID 3282-3691 reproducer
+-- from the AST fuzzer hit this `CREATE VIEW` shape (see issue tracker).
+CREATE VIEW {CLICKHOUSE_DATABASE:Identifier}.pv_04276 AS
+    SELECT k + {n:UInt64} AS x, v
+    FROM src_04276;
+
+-- A second variant exercising the same code path with extra DDL parts and FINAL,
+-- mirroring the original fuzzer query (test_view_01051_d__fuzz_13).
+CREATE VIEW {CLICKHOUSE_DATABASE:Identifier}.pv_04276_fuzz (`key` Nullable(UInt64), `value` LowCardinality(String)) AS
+    SELECT k2 + {fuzz_param_0:UInt64} AS key, concat(v2, '_x') AS value
+    FROM (SELECT k + 2 AS k2, concat('_y', v) AS v2 FROM src_04276) FINAL;
+
+SELECT 'create view with param db: ok';
+
+DROP VIEW {CLICKHOUSE_DATABASE:Identifier}.pv_04276;
+DROP VIEW {CLICKHOUSE_DATABASE:Identifier}.pv_04276_fuzz;
+DROP TABLE {CLICKHOUSE_DATABASE:Identifier}.src_04276;


### PR DESCRIPTION
`ASTCreateQuery::isParameterizedView` returns true whenever the SELECT body has
any query parameter, which made `executeQueryImpl` skip
`ReplaceQueryParameterVisitor` entirely. A `{db:Identifier}` placeholder in the
database name was therefore never substituted, leaving `create.getDatabase()`
empty and aborting the server in debug builds (`assert(!database_name.empty())`
in `DatabaseCatalog::tryGetDatabase`). In release builds the empty database
name silently produced an `UNKNOWN_DATABASE` error late in the CREATE flow.

The visitor now handles parameterized views directly: it substitutes parameters
in the DDL parts of the create query (database name, table name, columns list,
storage, view targets) while keeping the SELECT body's placeholders intact, so
they remain available for substitution at view-call time.

Reproducer (asserts on master, succeeds after the fix):

```sql
SET param_db = 'mydb';
CREATE VIEW {db:Identifier}.pv AS SELECT k + {n:UInt64} AS x FROM src;
```

Discovered by the AST fuzzer (STID 3282-3691). Master CI report:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=ffc21883c7b374f0aed9c9bed5924341b680833e&name_0=MasterCI&name_1=AST%20fuzzer%20%28amd_debug%29

Regression test: `04276_create_view_param_db_with_param_select`.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed an assertion in `DatabaseCatalog::tryGetDatabase` (and resulting `UNKNOWN_DATABASE` error in release builds) when creating a parameterized view whose database name is supplied via a query parameter, for example `CREATE VIEW {db:Identifier}.v AS SELECT {p:UInt64}`. Parameters in the DDL parts of the `CREATE` statement are now substituted at create time, while parameters in the SELECT body remain available for substitution at view-call time.


### Documentation entry for user-facing changes

- [ ] Documentation is unchanged.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.149`
<!-- ch-version-info:end -->