### PR TITLE
Apply soft-timeout to integration tests flaky check

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -872,6 +872,24 @@ tar -czf ./ci/tmp/logs.tar.gz \
         session_timeout_parallel = args.session_timeout * 2
         session_timeout_sequential = args.session_timeout
 
+    # Flaky-check soft timeout. Mirrors the pattern in `ci/jobs/functional_tests.py`:
+    # bound the total time spent inside pytest so the job has headroom for cleanup,
+    # log collection and reporting before the workflow global timeout fires. Without
+    # this, a flaky-check run over many modified test modules can be hard-killed by
+    # the global timeout, producing `Unknown error (exit status: None)` instead of
+    # a proper report.
+    FLAKY_CHECK_TIME_LIMIT = 90 * 60  # 90 min, integration tests are slower than functional
+    if is_flaky_check:
+        elapsed_for_flaky = int(sw.duration)
+        flaky_check_remaining_s = max(FLAKY_CHECK_TIME_LIMIT - elapsed_for_flaky, 60)
+        print(
+            f"Flaky-check time limit: {FLAKY_CHECK_TIME_LIMIT}s "
+            f"(elapsed so far: {elapsed_for_flaky}s, remaining: {flaky_check_remaining_s}s)"
+        )
+        # Cap per-phase session timeouts so a single phase cannot consume the entire budget.
+        session_timeout_parallel = min(session_timeout_parallel, flaky_check_remaining_s)
+        session_timeout_sequential = min(session_timeout_sequential, flaky_check_remaining_s)
+
     error_info = []
 
     failed_test_cases = []
@@ -914,21 +932,38 @@ tar -czf ./ci/tmp/logs.tar.gz \
         if test_result_parallel.files:
             failed_tests_files.extend(test_result_parallel.files)
         if test_result_parallel.is_error():
-            if not is_targeted_check:
+            if not is_targeted_check and not is_flaky_check:
                 # In targeted checks we may overload the run with many heavy tests running
-                # in parallel. A session-timeout is an expected risk rather than an
-                # infrastructure problem, so we do not treat such errors as job-level failures.
+                # in parallel; in flaky checks the soft FLAKY_CHECK_TIME_LIMIT may cap the
+                # pytest session-timeout. In both cases a session-timeout is an expected
+                # risk rather than an infrastructure problem, so we do not treat such
+                # errors as job-level failures.
                 has_error = True
                 error_info.append(test_result_parallel.info)
 
     fail_num = len([r for r in test_results if not r.is_ok()])
     if sequential_test_modules and fail_num < MAX_FAILS_BEFORE_DROP and not has_error:
         for attempt in range(sequential_repeat_cnt):
+            # Recompute remaining budget for flaky-check at every iteration and stop
+            # scheduling new runs once it is exhausted (soft timeout).
+            iter_session_timeout_sequential = session_timeout_sequential
+            if is_flaky_check:
+                elapsed_for_flaky = int(sw.duration)
+                flaky_check_remaining_s = max(FLAKY_CHECK_TIME_LIMIT - elapsed_for_flaky, 0)
+                if flaky_check_remaining_s < 60:
+                    print(
+                        f"Flaky-check time limit reached after [{attempt}/{sequential_repeat_cnt}] sequential attempts "
+                        f"(elapsed: {elapsed_for_flaky}s, limit: {FLAKY_CHECK_TIME_LIMIT}s); stopping"
+                    )
+                    break
+                iter_session_timeout_sequential = min(
+                    session_timeout_sequential, flaky_check_remaining_s
+                )
             test_result_sequential = run_pytest_and_collect_results(
-                command=f"{' '.join(sequential_test_modules)} --report-log-exclude-logs-on-passed-tests --tb=short {repeat_option} -n 1 --dist=loadfile --session-timeout={session_timeout_sequential}",
+                command=f"{' '.join(sequential_test_modules)} --report-log-exclude-logs-on-passed-tests --tb=short {repeat_option} -n 1 --dist=loadfile --session-timeout={iter_session_timeout_sequential}",
                 env=test_env,
                 report_name="sequential",
-                timeout=session_timeout_sequential + 600,
+                timeout=iter_session_timeout_sequential + 600,
             )
             test_results.extend(test_result_sequential.results)
             _mark_infrastructure_errors(test_result_sequential.results)
@@ -938,10 +973,12 @@ tar -czf ./ci/tmp/logs.tar.gz \
             if test_result_sequential.files:
                 failed_tests_files.extend(test_result_sequential.files)
             if test_result_sequential.is_error():
-                if not is_targeted_check:
+                if not is_targeted_check and not is_flaky_check:
                     # In targeted checks we may overload the run with many heavy tests running
-                    # sequentially. A session-timeout is an expected risk rather than an
-                    # infrastructure problem, so we do not treat such errors as job-level failures.
+                    # sequentially; in flaky checks the per-iteration `iter_session_timeout_sequential`
+                    # may be capped by FLAKY_CHECK_TIME_LIMIT. In both cases a session-timeout is
+                    # an expected risk rather than an infrastructure problem, so we do not treat
+                    # such errors as job-level failures.
                     has_error = True
                     error_info.append(test_result_sequential.info)
                 break
@@ -1022,9 +1059,10 @@ tar -czf ./ci/tmp/logs.tar.gz \
                 )
                 attached_files.append("./ci/tmp/dmesg.log")
 
-    # For targeted checks, session-timeout is an expected risk (because of --count N
-    # overloading), so do not propagate the synthetic "Timeout" result as a failure.
-    if is_targeted_check:
+    # For targeted and flaky checks, session-timeout is an expected risk (because of
+    # `--count N` overloading on targeted, and the soft FLAKY_CHECK_TIME_LIMIT on flaky),
+    # so do not propagate the synthetic `Timeout` result as a failure.
+    if is_targeted_check or is_flaky_check:
         test_results = [r for r in test_results if r.name != "Timeout"]
 
     R = Result.create_from(results=test_results, stopwatch=sw, files=attached_files)


### PR DESCRIPTION
The integration tests flaky check runs each modified test ~50 times across every changed test module. With existing per-phase pytest session timeouts (`session_timeout_parallel` = 2h, `session_timeout_sequential` = 1h × N attempts), total wall-clock time can far exceed the workflow's global job timeout. When the global timeout fires, the pytest subprocess is hard-killed by `Shell.run`'s subprocess timeout, leaving no session-finish record in the pytest jsonl and producing `Unknown error (exit status: None)` instead of a proper FAIL/OK summary.

Observed on `Integration tests (amd_asan_ubsan, flaky)` for PR #105171: ran 2h18m54s, errored with `Unknown error (exit status: None)`, no test results in the report.
Job log: https://github.com/ClickHouse/ClickHouse/actions/runs/26416267614/job/77763513026

The functional tests flaky check already handles this via a soft `FLAKY_CHECK_TIME_LIMIT` in `ci/jobs/functional_tests.py:544-554`. This PR ports the same logic to `ci/jobs/integration_test_job.py`:

1. `FLAKY_CHECK_TIME_LIMIT = 90 * 60` (90 min; longer than functional's 45 min because integration tests are slower).
2. Cap both `session_timeout_parallel` and `session_timeout_sequential` to the remaining budget at the start so a single phase cannot consume the entire budget.
3. In the sequential-attempts loop, recompute remaining budget each iteration; break early when < 60s left; cap each iteration's `--session-timeout` to remaining.
4. Treat session-timeout in flaky check as expected (do not propagate as a job-level error, filter out the synthetic `Timeout` result), matching how targeted checks already handle session-timeout.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

cc @alexey-milovidov (per directive on #105171), @maxknv, @leshikus (comp-ci-infrastructure)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.275`
<!-- ch-version-info:end -->