### PR TITLE
Stabilize `Keeper` reconfig test retries

### DIFF
--- a/tests/integration/test_keeper_reconfig_replace_leader_in_one_command/test.py
+++ b/tests/integration/test_keeper_reconfig_replace_leader_in_one_command/test.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 
 import time
-import typing as tp
+from multiprocessing.dummy import Pool
 from os.path import dirname, join, realpath
 
 import pytest
+from kazoo.exceptions import NodeExistsError
 
 import helpers.keeper_utils as ku
 from helpers.cluster import ClickHouseCluster, ClickHouseInstance
@@ -12,9 +13,9 @@ from helpers.cluster import ClickHouseCluster, ClickHouseInstance
 cluster = ClickHouseCluster(__file__)
 CONFIG_DIR = join(dirname(realpath(__file__)), "configs")
 
-node1 = cluster.add_instance("node1", main_configs=["configs/keeper1.xml"])
-node2 = cluster.add_instance("node2", main_configs=["configs/keeper2.xml"])
-node3 = cluster.add_instance("node3", main_configs=["configs/keeper3.xml"])
+node1 = cluster.add_instance("node1", main_configs=["configs/keeper1.xml"], stay_alive=True)
+node2 = cluster.add_instance("node2", main_configs=["configs/keeper2.xml"], stay_alive=True)
+node3 = cluster.add_instance("node3", main_configs=["configs/keeper3.xml"], stay_alive=True)
 node4 = cluster.add_instance("node4", stay_alive=True)
 zk1, zk2, zk3, zk4 = None, None, None, None
 
@@ -33,11 +34,7 @@ def started_cluster():
         yield cluster
 
     finally:
-        conn: tp.Optional[ku.KeeperClient]
-        for conn in [zk1, zk2, zk3, zk4]:
-            if conn:
-                conn.stop()
-                conn.close()
+        close_zk_connections()
 
         cluster.shutdown()
 
@@ -47,12 +44,63 @@ def started_cluster():
 # TODO myrrc this should be removed once keeper-client is updated
 
 
+def close_zk_connections():
+    global zk1, zk2, zk3, zk4
+    for zk in [zk1, zk2, zk3, zk4]:
+        if zk:
+            zk.stop()
+            zk.close()
+    zk1, zk2, zk3, zk4 = None, None, None, None
+
+
 def get_fake_zk(node):
     return ku.get_fake_zk(cluster, node.name)
 
 
 def get_config_str(zk):
     return ku.get_config_str(zk)[0].decode("utf-8")
+
+
+def create_or_confirm(zk, path: str, data: bytes):
+    try:
+        zk.create(path, data)
+    except NodeExistsError:
+        assert zk.get(path)[0] == data
+
+
+def start_clickhouse(node: ClickHouseInstance):
+    node.start_clickhouse()
+
+
+def reset_keepers():
+    close_zk_connections()
+
+    nodes = [node1, node2, node3, node4]
+    for node in nodes:
+        node.stop_clickhouse()
+
+    node4.copy_file_to_container(
+        join(CONFIG_DIR, "keeper4.xml"),
+        "/etc/clickhouse-server/config.d/keeper.xml",
+    )
+
+    pool = Pool(3)
+    waiters = []
+    for node in nodes:
+        node.exec_in_container(["rm", "-rf", "/var/lib/clickhouse/coordination/log"])
+        node.exec_in_container(
+            ["rm", "-rf", "/var/lib/clickhouse/coordination/snapshots"]
+        )
+        node.exec_in_container(["rm", "-rf", "/var/lib/clickhouse/coordination/state"])
+
+        if node != node4:
+            waiters.append(pool.apply_async(start_clickhouse, (node,)))
+
+    for waiter in waiters:
+        waiter.wait()
+
+    for node in [node1, node2, node3]:
+        ku.wait_until_connected(cluster, node)
 
 
 def wait_configs_equal(
@@ -79,7 +127,9 @@ def test_reconfig_replace_leader_in_one_command(started_cluster):
     """
     Remove leader from a cluster of 3 and add a new node to this cluster in a single command
     """
+    reset_keepers()
 
+    global zk1, zk2, zk3, zk4
     zk1 = get_fake_zk(node1)
     config = get_config_str(zk1)
 
@@ -128,7 +178,7 @@ def test_reconfig_replace_leader_in_one_command(started_cluster):
 
     for i in range(100):
         assert zk4.exists(f"test_four_{i}") is not None
-        zk4.create(f"/test_four_{100 + i}", b"somedata")
+        create_or_confirm(zk4, f"/test_four_{100 + i}", b"somedata")
 
     with pytest.raises(Exception):
         zk1.stop()


### PR DESCRIPTION
Syncs the non-private `Keeper` test stabilization from https://github.com/ClickHouse/clickhouse-private/pull/54962 for https://github.com/ClickHouse/ClickHouse/pull/101757.

This makes `test_keeper_reconfig_replace_leader_in_one_command` robust under repeated runs by resetting `Keeper` state, closing stale ZooKeeper connections, and confirming idempotent retried `create` operations after `NodeExistsError`.

No matching open issue was found for `test_keeper_reconfig_replace_leader_in_one_command`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required.

### Documentation entry:
- [x] Documentation is not required because this only changes an integration test.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.162`
<!-- ch-version-info:end -->