### PR TITLE
Add docker cleanup post-hook to install_check master jobs

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -489,6 +489,7 @@ class JobConfigs:
             ],
         ),
         timeout=900,
+        post_hooks=["python3 ./ci/jobs/scripts/job_hooks/docker_clean_up_hook.py"],
     ).parametrize(
         Job.ParamSet(
             parameter="amd_release",

--- a/ci/jobs/scripts/job_hooks/docker_clean_up_hook.py
+++ b/ci/jobs/scripts/job_hooks/docker_clean_up_hook.py
@@ -2,27 +2,7 @@ from ci.praktika.utils import Shell
 
 
 def check():
-    print("Remove all images with names starting with clickhouse/clickhouse- (forced)")
-    Shell.check(
-        "docker images --format '{{.Repository}}:{{.Tag}}' | grep '^clickhouse/clickhouse-' | xargs -r docker rmi -f",
-        verbose=True,
-    )
-    print("Clean up non-latest images per each Repository")
-    Shell.check(
-        "docker images --format '{{.Repository}} {{.ID}} {{.CreatedAt}}' "
-        " | sort -k1,1 -k3,3M -k4,4n -k5,5n "
-        " | tac "
-        " | awk '!seen[$1]++ {next} {print $2}' "
-        " | xargs -r docker rmi",
-        verbose=True,
-    )
-    print("Clean up build cache")
-    Shell.check("docker builder prune -a -f", verbose=True)
-    print("Clean up stopped containers")
-    Shell.check("docker container prune -f", verbose=True)
-    Shell.check("docker system prune", verbose=True)
-    print("Clean up all tagged-but-unused images")
-    Shell.check("docker image prune -a -f", verbose=True)
+    Shell.check("docker system prune -a -f", verbose=True)
     return True
 
 

--- a/ci/jobs/scripts/job_hooks/docker_clean_up_hook.py
+++ b/ci/jobs/scripts/job_hooks/docker_clean_up_hook.py
@@ -21,6 +21,8 @@ def check():
     print("Clean up stopped containers")
     Shell.check("docker container prune -f", verbose=True)
     Shell.check("docker system prune", verbose=True)
+    print("Clean up all tagged-but-unused images")
+    Shell.check("docker image prune -a -f", verbose=True)
     return True
 
 

--- a/ci/jobs/scripts/job_hooks/docker_clean_up_hook.py
+++ b/ci/jobs/scripts/job_hooks/docker_clean_up_hook.py
@@ -2,7 +2,27 @@ from ci.praktika.utils import Shell
 
 
 def check():
-    Shell.check("docker system prune -a -f", verbose=True)
+    print(
+        "Remove all images with names starting with clickhouse/clickhouse- or clickhouse/install- (forced)"
+    )
+    Shell.check(
+        "docker images --format '{{.Repository}}:{{.Tag}}' | grep -E '^clickhouse/(clickhouse|install)-' | xargs -r docker rmi -f",
+        verbose=True,
+    )
+    print("Clean up non-latest images per each Repository")
+    Shell.check(
+        "docker images --format '{{.Repository}} {{.ID}} {{.CreatedAt}}' "
+        " | sort -k1,1 -k3,3M -k4,4n -k5,5n "
+        " | tac "
+        " | awk '!seen[$1]++ {next} {print $2}' "
+        " | xargs -r docker rmi",
+        verbose=True,
+    )
+    print("Clean up build cache")
+    Shell.check("docker builder prune -a -f", verbose=True)
+    print("Clean up stopped containers")
+    Shell.check("docker container prune -f", verbose=True)
+    Shell.check("docker system prune", verbose=True)
     return True
 
 


### PR DESCRIPTION
The `install_check_master_jobs` config was missing the `docker_clean_up_hook.py` `post_hooks` entry that is already set on the PR variant `install_check_jobs`. This restores parity so the `STYLE_CHECK_AMD` runner is cleaned up between successive master runs of the `Install packages (amd_release)` job.

The post-hook runs at the end of the job, so it improves the runner state for the *next* job — it does not fix an ongoing `ENOSPC` failure on the last iteration of an in-flight run. If the underlying disk pressure recurs, further mitigations (pre-hook cleanup, larger EBS volume, or per-format shards) will be needed.

Related to #105830

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

...


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)