### PR TITLE
Disable 04218_limit_by_partitions_independently under MSan (test timeout)

### DIFF
--- a/tests/queries/0_stateless/04218_limit_by_partitions_independently.sql
+++ b/tests/queries/0_stateless/04218_limit_by_partitions_independently.sql
@@ -1,4 +1,5 @@
--- Tags: long, no-random-settings, no-random-merge-tree-settings
+-- Tags: long, no-msan, no-random-settings, no-random-merge-tree-settings
+-- no-msan: ~30 scenarios with INSERT + EXPLAIN; the MSan slowdown blows past the test timeout
 -- no-random-settings, no-random-merge-tree-settings: Explain output may differ
 
 

--- a/tests/queries/0_stateless/04218_limit_by_partitions_independently.sql
+++ b/tests/queries/0_stateless/04218_limit_by_partitions_independently.sql
@@ -1,5 +1,5 @@
--- Tags: long, no-msan, no-random-settings, no-random-merge-tree-settings
--- no-msan: ~30 scenarios with INSERT + EXPLAIN; the MSan slowdown blows past the test timeout
+-- Tags: long, no-tsan, no-asan, no-msan, no-s3-storage, no-random-settings, no-random-merge-tree-settings
+-- nno-tsan, no-asan, no-msan, no-s3-storage: ~30 scenarios with INSERT + EXPLAIN; the slowdown blows past the test timeout
 -- no-random-settings, no-random-merge-tree-settings: Explain output may differ
 
 

--- a/tests/queries/0_stateless/04218_limit_by_partitions_independently.sql
+++ b/tests/queries/0_stateless/04218_limit_by_partitions_independently.sql
@@ -1,5 +1,5 @@
 -- Tags: long, no-tsan, no-asan, no-msan, no-s3-storage, no-random-settings, no-random-merge-tree-settings
--- nno-tsan, no-asan, no-msan, no-s3-storage: ~30 scenarios with INSERT + EXPLAIN; the slowdown blows past the test timeout
+-- no-tsan, no-asan, no-msan, no-s3-storage: ~30 scenarios with INSERT + EXPLAIN; the slowdown blows past the test timeout
 -- no-random-settings, no-random-merge-tree-settings: Explain output may differ
 
 


### PR DESCRIPTION
The test `04218_limit_by_partitions_independently` (added in #105126) has ~30 scenarios that each do `INSERT INTO ... numbers_mt(1e3)` and then `EXPLAIN actions = 1`. Under MSan, the cumulative cost pushes the test past the per-test timeout: in `Stateless tests (amd_msan, meta in keeper, s3 storage)` the test now fails on the majority of runs since #105126 landed, while passing on every other sanitizer/build flavor.

Adding `no-msan` because the test exercises pipeline planning (per-partition `LimitByTransform` fan-out), not memory correctness, so MSan adds little signal here. A follow-up could shrink the per-scenario row counts to restore MSan coverage; this PR is the minimal fix to unblock CI.

Failure mode in CI is a client-side timeout while waiting for results — `__GI___poll` -> `Poco::Net::SocketImpl::pollImpl` -> `DB::ClientBase::receiveResult`.

CI report (first failing master commit, sha `69102a31ed94`, 2026-05-25 06:48 UTC, ~25 min after #105126 was merged):
https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=69102a31ed94&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_msan%2C%20meta%20in%20keeper%2C%20s3%20storage%2C%20parallel%2C%202%2F2%29

No open issue exists for this; searches for `04218`, `04218_limit_by_partitions_independently`, and `allow_limit_by_partitions_independently` against `ClickHouse/ClickHouse` returned nothing.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.175`
<!-- ch-version-info:end -->