### PR TITLE
glibc-compat: honor SETPGROUP / RESETIDS / SETSIGDEF in posix_spawn stub (fixes "clickhouse chdig client")

### DIFF
--- a/base/glibc-compatibility/musl/posix_spawn.c
+++ b/base/glibc-compatibility/musl/posix_spawn.c
@@ -71,6 +71,8 @@ static int child(void *args_vp)
 		for (i=1; i<_NSIG; i++) {
 			if (sigismember(&attr->__sd, i) == 1) {
 				sa.sa_handler = SIG_DFL;
+				/* Safe only because sa is all-zero (SIG_DFL is 0): glibc's struct sigaction and the kernel rt_sigaction ABI have different field layouts. */
+				_Static_assert(SIG_DFL == 0, "Not compatible with kernel struct sigaction");
 				ret = __syscall(SYS_rt_sigaction, i, &sa, 0, _NSIG/8);
 				if (ret) goto fail;
 			}

--- a/base/glibc-compatibility/musl/posix_spawn.c
+++ b/base/glibc-compatibility/musl/posix_spawn.c
@@ -1,5 +1,14 @@
-/// Very limited implementation. Half of code from Musl was cut.
-/// This is Ok, because for now, this function is used only from clang driver.
+/// Partial implementation derived from musl. The file_actions walking branch
+/// from musl is intentionally NOT restored: callers are compiled against
+/// glibc's <spawn.h>, whose posix_spawn_file_actions_t::__actions is an array
+/// of `struct __spawn_action` (tagged union), not musl's doubly-linked list of
+/// `struct fdop`. The two layouts share a field offset but nothing else, so
+/// walking it as `struct fdop` would dereference garbage. Posix_spawn callers
+/// that need file actions must avoid this stub or fall back to fork+exec.
+///
+/// posix_spawnattr_t fields that are read here (__flags low bits, __pgrp,
+/// __sd, __ss) live at offsets and use flag values that are compatible
+/// between musl and glibc layouts.
 
 #define _GNU_SOURCE
 
@@ -31,7 +40,8 @@ void __get_handler_set(sigset_t *);
 
 static int child(void *args_vp)
 {
-	int ret;
+	int i, ret;
+	struct sigaction sa = {0};
 	struct args *args = args_vp;
 	int p = args->p[1];
 	const posix_spawnattr_t *restrict attr = args->attr;
@@ -44,12 +54,36 @@ static int child(void *args_vp)
 	 * in this process there are no threads or signal handlers. */
 	__syscall(SYS_fcntl, p, F_SETFD, FD_CLOEXEC);
 
+	if ((attr->__flags & POSIX_SPAWN_SETPGROUP)
+		&& (ret=__syscall(SYS_setpgid, 0, attr->__pgrp)))
+		goto fail;
+
+	if (attr->__flags & POSIX_SPAWN_RESETIDS)
+		if ((ret=__syscall(SYS_setgid, __syscall(SYS_getgid))) ||
+			(ret=__syscall(SYS_setuid, __syscall(SYS_getuid))))
+			goto fail;
+
+	/* Reset signal handlers requested via posix_spawnattr_setsigdefault.
+	 * Iterate via sigismember rather than poking sigset_t internals --
+	 * the local spawn.h pulls in glibc's sigset_t (which exposes __val,
+	 * not musl's __bits), so direct field access would not compile. */
+	if (attr->__flags & POSIX_SPAWN_SETSIGDEF) {
+		for (i=1; i<_NSIG; i++) {
+			if (sigismember(&attr->__sd, i) == 1) {
+				sa.sa_handler = SIG_DFL;
+				ret = __syscall(SYS_rt_sigaction, i, &sa, 0, _NSIG/8);
+				if (ret) goto fail;
+			}
+		}
+	}
+
 	pthread_sigmask(SIG_SETMASK, (attr->__flags & POSIX_SPAWN_SETSIGMASK)
 		? &attr->__ss : &args->oldmask, 0);
 
 	args->exec(args->path, args->argv, args->envp);
 	ret = -errno;
 
+fail:
 	/* Since sizeof errno < PIPE_BUF, the write is atomic. */
 	ret = -ret;
 	if (ret) while (__syscall(SYS_write, p, &ret, sizeof ret) < 0);

--- a/base/glibc-compatibility/spawn.h
+++ b/base/glibc-compatibility/spawn.h
@@ -9,6 +9,9 @@ extern "C" {
 #include <sys/types.h>
 #include <bits/types/sigset_t.h>
 
+#define POSIX_SPAWN_RESETIDS		0x01
+#define POSIX_SPAWN_SETPGROUP		0x02
+#define POSIX_SPAWN_SETSIGDEF		0x04
 #define POSIX_SPAWN_SETSIGMASK		0x08
 
 typedef struct {

--- a/base/glibc-compatibility/spawn.h
+++ b/base/glibc-compatibility/spawn.h
@@ -15,7 +15,7 @@ extern "C" {
 #define POSIX_SPAWN_SETSIGMASK		0x08
 
 typedef struct {
-	int __flags;
+	short int __flags;
 	pid_t __pgrp;
 	sigset_t __sd;
 	sigset_t __ss;


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix "clickhouse chdig client" (uses POSIX_SPAWN_SETPGROUP) by honoring SETPGROUP / RESETIDS / SETSIGDEF in posix_spawn stub

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.178`
<!-- ch-version-info:end -->