### PR TITLE
chdig: enable TLS (for secure connections)

### DIFF
--- a/contrib/chdig-cmake/CMakeLists.txt
+++ b/contrib/chdig-cmake/CMakeLists.txt
@@ -17,7 +17,7 @@ if (NOT ENABLE_CHDIG OR NOT ENABLE_RUST)
     return()
 endif()
 
-clickhouse_import_crate(MANIFEST_PATH ../chdig/Cargo.toml)
+clickhouse_import_crate(MANIFEST_PATH ../chdig/Cargo.toml FEATURES tls)
 clickhouse_config_crate_flags(chdig)
 add_library(ch_rust::chdig ALIAS chdig)
 


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
chdig: enable TLS for secure connections (previous leads to either "Unknown setting 'skip_verify'" or "Connection reset by peer")

Refs: https://github.com/azat/chdig/issues/249

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.179`
<!-- ch-version-info:end -->