### PR TITLE
Fix ReadInOrder for `merge` table with filter push-down to prewhere

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/actionsDAGUtils.cpp
+++ b/src/Processors/QueryPlan/Optimizations/actionsDAGUtils.cpp
@@ -111,6 +111,21 @@ MatchedTrees::Matches matchTrees(const ActionsDAG::NodeRawConstPtrs & inner_dag,
             {
                 match = matches[frame.node->children.at(0)];
             }
+            else if (frame.node->type == ActionsDAG::ActionType::FUNCTION
+                && frame.node->children.size() == 1
+                && (frame.node->function_base->getName() == "materialize"
+                    || frame.node->function_base->getName() == "identity"))
+            {
+                /// `materialize`/`identity` are no-op wrappers that do not change values, so
+                /// for matching purposes they behave like `ALIAS` - pass the match of the
+                /// wrapped node through. This lets `optimizeReadInOrder` see through the
+                /// `materialize(...)` wrappers that filter push-down can inject into a
+                /// `MergeTree` prewhere (e.g. for queries through `ReadFromMerge` after
+                /// `convertAndFilterSourceStream`). Without this, `materialize` only
+                /// contributes a non-strict monotonic match and the `ORDER BY` prefix that
+                /// can be served from the sorting key is truncated.
+                match = matches[frame.node->children.at(0)];
+            }
             else if (frame.node->type == ActionsDAG::ActionType::FUNCTION)
             {
                 //std::cerr << "... Processing " << frame.node->function_base->getName() << std::endl;

--- a/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeReadInOrder.cpp
@@ -954,16 +954,83 @@ SortingInputOrder buildInputOrderFromSortDescription(
 }
 
 
+/// Build a per-child-plan DAG suitable for matching sort columns against a `MergeTree`'s
+/// sorting key. The inner plan (the child plan of `ReadFromMerge`) executes first and feeds
+/// into the outer plan; this function builds them in that order:
+///
+/// 1. Walk the child plan to collect its prewhere/expression/filter chain into `combined_dag`.
+///    After filter push-down moves the WHERE condition into the inner `MergeTree`'s prewhere,
+///    the renaming and `materialize` aliasing performed by `convertAndFilterSourceStream`
+///    lives entirely inside the merge node — this is the chain we recover here.
+/// 2. Clone the outer DAG (which originally lives in the caller and outlives this call) and
+///    merge it on top using `mergeInplace`, recording the input remapping it performs.
+/// 3. Remap the original `outer_fixed_columns` through the clone mapping plus the
+///    `mergeInplace` input remapping, so the resulting `FixedColumns` point at the right
+///    nodes in the combined DAG.
+///
+/// `matchTrees` itself looks through `materialize`/`identity` wrappers, so we do not need
+/// to mutate the DAG to strip them.
+void buildCombinedDAGForMergeChildPlan(
+    QueryPlan * child_plan,
+    const std::optional<ActionsDAG> & outer_dag,
+    const FixedColumns & outer_fixed_columns,
+    std::optional<ActionsDAG> & combined_dag,
+    FixedColumns & combined_fixed_columns,
+    size_t & limit)
+{
+    if (child_plan && child_plan->isInitialized())
+        buildSortingDAG(*child_plan->getRootNode(), combined_dag, combined_fixed_columns, limit);
+
+    if (outer_dag)
+    {
+        ActionsDAG::NodeMapping clone_mapping;
+        ActionsDAG outer_clone = outer_dag->clone(clone_mapping);
+
+        if (!combined_dag)
+        {
+            combined_dag.emplace(std::move(outer_clone));
+
+            for (const auto * outer_node : outer_fixed_columns)
+            {
+                auto it = clone_mapping.find(outer_node);
+                if (it != clone_mapping.end())
+                    combined_fixed_columns.insert(it->second);
+            }
+        }
+        else
+        {
+            ActionsDAG::NodeMapping inputs_map;
+            combined_dag->mergeInplace(std::move(outer_clone), inputs_map, /*remove_dangling_inputs=*/ false);
+
+            for (const auto * outer_node : outer_fixed_columns)
+            {
+                auto it = clone_mapping.find(outer_node);
+                if (it == clone_mapping.end())
+                    continue;
+                const auto * mapped = it->second;
+                if (auto remap_it = inputs_map.find(mapped); remap_it != inputs_map.end())
+                    mapped = remap_it->second;
+                combined_fixed_columns.insert(mapped);
+            }
+        }
+    }
+
+    if (combined_dag && !combined_fixed_columns.empty())
+        enrichFixedColumns(*combined_dag, combined_fixed_columns);
+}
+
 SortingInputOrder buildInputOrderFromSortDescription(
     ReadFromMerge * merge,
-    const FixedColumns & fixed_columns,
-    const std::optional<ActionsDAG> & dag,
+    const FixedColumns & outer_fixed_columns,
+    const std::optional<ActionsDAG> & outer_dag,
     const SortDescription & description,
-    size_t limit)
+    size_t outer_limit)
 {
     const auto & tables = merge->getSelectedTables();
+    auto child_plans = merge->getAllChildPlans();
 
     SortingInputOrder order_info;
+    size_t table_idx = 0;
     for (const auto & table : tables)
     {
         auto storage = std::get<StoragePtr>(table);
@@ -974,12 +1041,19 @@ SortingInputOrder buildInputOrderFromSortDescription(
         if (sorting_key.column_names.empty())
             return {};
 
+        std::optional<ActionsDAG> combined_dag;
+        FixedColumns combined_fixed_columns;
+        size_t combined_limit = outer_limit;
+        QueryPlan * child_plan = (table_idx < child_plans.size()) ? child_plans[table_idx] : nullptr;
+        buildCombinedDAGForMergeChildPlan(
+            child_plan, outer_dag, outer_fixed_columns, combined_dag, combined_fixed_columns, combined_limit);
+
         auto table_order_info = buildInputOrderFromSortDescription(
-            fixed_columns,
-            dag, description,
+            combined_fixed_columns,
+            combined_dag, description,
             sorting_key,
             {},
-            limit);
+            combined_limit);
 
         if (!table_order_info.input_order)
             return {};
@@ -988,6 +1062,8 @@ SortingInputOrder buildInputOrderFromSortDescription(
             order_info = std::move(table_order_info);
         else if (*order_info.input_order != *table_order_info.input_order)
             return {};
+
+        ++table_idx;
     }
 
     return order_info;
@@ -1025,13 +1101,15 @@ InputOrder buildInputOrderFromUnorderedKeys(
 
 InputOrder buildInputOrderFromUnorderedKeys(
     ReadFromMerge * merge,
-    const FixedColumns & fixed_columns,
-    const std::optional<ActionsDAG> & dag,
+    const FixedColumns & outer_fixed_columns,
+    const std::optional<ActionsDAG> & outer_dag,
     const Names & unordered_keys)
 {
     const auto & tables = merge->getSelectedTables();
+    auto child_plans = merge->getAllChildPlans();
 
     InputOrder order_info;
+    size_t table_idx = 0;
     for (const auto & table : tables)
     {
         auto storage = std::get<StoragePtr>(table);
@@ -1042,9 +1120,16 @@ InputOrder buildInputOrderFromUnorderedKeys(
         if (sorting_key_columns.empty())
             return {};
 
+        std::optional<ActionsDAG> combined_dag;
+        FixedColumns combined_fixed_columns;
+        size_t unused_limit = 0;
+        QueryPlan * child_plan = (table_idx < child_plans.size()) ? child_plans[table_idx] : nullptr;
+        buildCombinedDAGForMergeChildPlan(
+            child_plan, outer_dag, outer_fixed_columns, combined_dag, combined_fixed_columns, unused_limit);
+
         auto table_order_info = buildInputOrderFromUnorderedKeys(
-            fixed_columns,
-            dag, unordered_keys,
+            combined_fixed_columns,
+            combined_dag, unordered_keys,
             sorting_key.expression->getActionsDAG(), sorting_key_columns);
 
         if (!table_order_info.input_order)
@@ -1054,6 +1139,8 @@ InputOrder buildInputOrderFromUnorderedKeys(
             order_info = table_order_info;
         else if (*order_info.input_order != *table_order_info.input_order)
             return {};
+
+        ++table_idx;
     }
 
     return order_info;

--- a/src/Storages/StorageMerge.cpp
+++ b/src/Storages/StorageMerge.cpp
@@ -1737,6 +1737,18 @@ QueryPlanRawPtrs ReadFromMerge::getChildPlans()
     return plans;
 }
 
+std::vector<QueryPlan *> ReadFromMerge::getAllChildPlans()
+{
+    filterTablesAndCreateChildrenPlans();
+
+    std::vector<QueryPlan *> plans;
+    plans.reserve(child_plans->size());
+    for (auto & child_plan : *child_plans)
+        plans.push_back(child_plan.plan.isInitialized() ? &child_plan.plan : nullptr);
+
+    return plans;
+}
+
 IStorage::ColumnSizeByName StorageMerge::getColumnSizes() const
 {
     ColumnSizeByName column_sizes;

--- a/src/Storages/StorageMerge.h
+++ b/src/Storages/StorageMerge.h
@@ -187,6 +187,10 @@ public:
 
     QueryPlanRawPtrs getChildPlans() override;
 
+    /// Returns child plans aligned 1:1 with `getSelectedTables()`. Entries for uninitialized
+    /// plans are returned as `nullptr` so that callers can pair tables with their plans.
+    std::vector<QueryPlan *> getAllChildPlans();
+
     void addFilter(FilterDAGInfo filter);
 
 private:

--- a/tests/queries/0_stateless/04277_merge_read_in_order_with_prewhere.reference
+++ b/tests/queries/0_stateless/04277_merge_read_in_order_with_prewhere.reference
@@ -1,0 +1,4 @@
+Ksenia
+Ksenia
+1
+1

--- a/tests/queries/0_stateless/04277_merge_read_in_order_with_prewhere.sql
+++ b/tests/queries/0_stateless/04277_merge_read_in_order_with_prewhere.sql
@@ -1,0 +1,34 @@
+-- Tags: no-random-merge-tree-settings
+
+-- https://github.com/ClickHouse/ClickHouse/issues/86313
+-- When reading from the `merge` table function with a WHERE clause that can be pushed
+-- down to a prewhere on the underlying `MergeTree`, the optimizer used to fail to apply
+-- the read-in-order optimization. After filter push-down, the inner plan injects a
+-- `materialize(...)` wrapper into the prewhere output, which broke the sort-key match.
+
+DROP TABLE IF EXISTS users_86313;
+
+CREATE TABLE users_86313 (uid Int16, name String, age Int16, time Int8, PRIMARY KEY(time, age, name)) ENGINE = MergeTree;
+
+INSERT INTO users_86313 VALUES (1231, 'Ksenia', 33, 2);
+INSERT INTO users_86313 VALUES (6666, 'Ksenia', 48, 2);
+INSERT INTO users_86313 VALUES (8888, 'John', 50, 2);
+
+-- Sanity check that the result is the same for both reads.
+SELECT name FROM users_86313 WHERE time > 1 ORDER BY time, age LIMIT 1;
+SELECT name FROM merge(currentDatabase(), '^users_86313$') WHERE time > 1 ORDER BY time, age LIMIT 1;
+
+-- Both plans must use `ReadType: InOrder` for the underlying `MergeTree`.
+SELECT count() FROM
+(
+    EXPLAIN PLAN actions = 1 SELECT name FROM users_86313 WHERE time > 1 ORDER BY time, age LIMIT 1
+)
+WHERE explain ILIKE '%ReadType: InOrder%';
+
+SELECT count() FROM
+(
+    EXPLAIN PLAN actions = 1 SELECT name FROM merge(currentDatabase(), '^users_86313$') WHERE time > 1 ORDER BY time, age LIMIT 1
+)
+WHERE explain ILIKE '%ReadType: InOrder%';
+
+DROP TABLE users_86313;

--- a/tests/queries/0_stateless/04277_merge_read_in_order_with_prewhere.sql
+++ b/tests/queries/0_stateless/04277_merge_read_in_order_with_prewhere.sql
@@ -14,6 +14,8 @@ INSERT INTO users_86313 VALUES (1231, 'Ksenia', 33, 2);
 INSERT INTO users_86313 VALUES (6666, 'Ksenia', 48, 2);
 INSERT INTO users_86313 VALUES (8888, 'John', 50, 2);
 
+SET optimize_read_in_order=1;
+
 -- Sanity check that the result is the same for both reads.
 SELECT name FROM users_86313 WHERE time > 1 ORDER BY time, age LIMIT 1;
 SELECT name FROM merge(currentDatabase(), '^users_86313$') WHERE time > 1 ORDER BY time, age LIMIT 1;


### PR DESCRIPTION
<details>

<summary>Claude</summary>

When a query through the `merge` table function has a WHERE clause that can be pushed down to the prewhere of the underlying `MergeTree`, the read-in-order optimization was silently disabled. The plan ended up sorting rows even though the underlying parts were already sorted by the requested prefix of the primary key.

Two pieces together broke the sort-key match:

1. `buildSortingDAG` collected expression and prewhere chains only above `ReadFromMerge`. After filter push-down, the column-renaming and `materialize` aliasing performed by `convertAndFilterSourceStream` was hidden inside the merge node, so the outer plan no longer contained the alias chain from `__table1.X` back to the storage's sort-key column.

2. `matchTrees` treated `materialize`/`identity` as monotonic functions with `is_strict = false`. Even when the chain was visible, that non-strict match truncated the matched sort-key prefix to a single column.

Fix:

- Walk into each child plan of `ReadFromMerge` while building the per-table DAG. The outer DAG is cloned and merged on top of the inner DAG; `outer_fixed_columns` pointers are remapped through the clone mapping and the `mergeInplace` input map.
- Teach `matchTrees` to look through single-argument `materialize` / `identity` calls and pass the matched child through, like `ALIAS`.

</details>

Closes: https://github.com/ClickHouse/ClickHouse/issues/86313

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix read-in-order for `Merge` tables (with a new analyzer).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.190`
<!-- ch-version-info:end -->