### PR TITLE
Fix Iceberg position deletes returning wrong result with multi-file deletes

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.cpp
@@ -7,6 +7,7 @@
 
 #include <Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.h>
 
+#include <Columns/IColumn.h>
 #include <Core/Settings.h>
 #include <Formats/FormatFactory.h>
 #include <Formats/ReadSchemaUtils.h>
@@ -140,6 +141,45 @@ size_t IcebergPositionDeleteTransform::getColumnIndex(const std::shared_ptr<IInp
     throw Exception(ErrorCodes::LOGICAL_ERROR, "Could not find column {} in chunk", column_name);
 }
 
+size_t IcebergPositionDeleteTransform::filterChunkToCurrentDataFile(Chunk & chunk, size_t filename_column_index) const
+{
+    const size_t num_rows = chunk.getNumRows();
+    if (num_rows == 0)
+        return 0;
+
+    const auto & filename_column = *chunk.getColumns()[filename_column_index];
+    const auto iceberg_uri = iceberg_object_info->info.data_object_file_path_key.serialize();
+    const auto storage_path = iceberg_object_info->getPath();
+
+    IColumn::Filter filter(num_rows, 0);
+    size_t num_matched = 0;
+    for (size_t i = 0; i < num_rows; ++i)
+    {
+        const auto file_to_delete = filename_column.getDataAt(i);
+        if (file_to_delete == iceberg_uri || file_to_delete == "/" + iceberg_uri
+            || file_to_delete == storage_path || file_to_delete == "/" + storage_path)
+        {
+            filter[i] = 1;
+            ++num_matched;
+        }
+    }
+
+    if (num_matched == num_rows)
+        return num_rows;
+
+    if (num_matched == 0)
+    {
+        chunk.clear();
+        return 0;
+    }
+
+    auto columns = chunk.detachColumns();
+    for (auto & column : columns)
+        column = column->filter(filter, static_cast<ssize_t>(num_matched));
+    chunk.setColumns(std::move(columns), num_matched);
+    return num_matched;
+}
+
 void IcebergBitmapPositionDeleteTransform::transform(Chunk & chunk)
 {
     DeletionVectorTransform::transform(chunk, bitmap);
@@ -149,24 +189,17 @@ void IcebergBitmapPositionDeleteTransform::initialize()
 {
     for (auto & delete_source : delete_sources)
     {
+        const auto position_index = getColumnIndex(delete_source, IcebergPositionDeleteTransform::positions_column_name);
+        const auto filename_index = getColumnIndex(delete_source, IcebergPositionDeleteTransform::data_file_path_column_name);
+
         while (auto delete_chunk = delete_source->read())
         {
-            auto position_index = getColumnIndex(delete_source, IcebergPositionDeleteTransform::positions_column_name);
-            auto filename_index = getColumnIndex(delete_source, IcebergPositionDeleteTransform::data_file_path_column_name);
+            if (filterChunkToCurrentDataFile(delete_chunk, filename_index) == 0)
+                continue;
 
-            auto position_column = delete_chunk.getColumns()[position_index];
-            auto filename_column = delete_chunk.getColumns()[filename_index];
-
-            auto iceberg_uri = iceberg_object_info->info.data_object_file_path_key.serialize();
-            auto storage_path = iceberg_object_info->getPath();
+            const auto & position_column = *delete_chunk.getColumns()[position_index];
             for (size_t i = 0; i < delete_chunk.getNumRows(); ++i)
-            {
-                auto position_to_delete = position_column->get64(i);
-                auto file_to_delete = filename_column->getDataAt(i);
-                if (file_to_delete == iceberg_uri || file_to_delete == "/" + iceberg_uri
-                    || file_to_delete == storage_path || file_to_delete == "/" + storage_path)
-                    bitmap.add(position_to_delete);
-            }
+                bitmap.add(position_column.get64(i));
         }
     }
 }
@@ -184,28 +217,41 @@ void IcebergStreamingPositionDeleteTransform::initialize()
             .filename_index = filename_index,
             .position_index = position_index
         });
-        auto latest_chunk = delete_source->read();
         iterator_at_latest_chunks.push_back(0);
-        if (latest_chunk.hasRows())
-        {
-            size_t first_position_value_in_delete_file = latest_chunk.getColumns()[delete_source_column_indices.back().position_index]->get64(0);
-            latest_positions.insert(std::pair<size_t, size_t>{first_position_value_in_delete_file, i});
-        }
-        latest_chunks.push_back(std::move(latest_chunk));
+        latest_chunks.emplace_back();
+        fetchNewChunkFromSource(i);
     }
 }
 
 void IcebergStreamingPositionDeleteTransform::fetchNewChunkFromSource(size_t delete_source_index)
 {
-    auto latest_chunk = delete_sources[delete_source_index]->read();
-    if (latest_chunk.hasRows())
-    {
-        size_t first_position_value_in_delete_file = latest_chunk.getColumns()[delete_source_column_indices[delete_source_index].position_index]->get64(0);
-        latest_positions.insert(std::pair<size_t, size_t>{first_position_value_in_delete_file, delete_source_index});
-    }
-
     iterator_at_latest_chunks[delete_source_index] = 0;
-    latest_chunks[delete_source_index] = std::move(latest_chunk);
+
+    /// The delete file is sorted by (file_path, pos), so positions for one data file
+    /// arrive in ascending order. But a chunk read from the Parquet reader may still
+    /// contain rows for other data files because filter_actions_dag is only used for
+    /// row-group/page pruning, not row-level filtering. Drop those rows here so the
+    /// streaming merge invariant (positions ascending per source) is preserved.
+    /// Keep reading until we find a chunk with at least one matching row, or end of source.
+    while (true)
+    {
+        auto chunk = delete_sources[delete_source_index]->read();
+        if (!chunk.hasRows())
+        {
+            latest_chunks[delete_source_index] = std::move(chunk);
+            return;
+        }
+
+        const auto filename_index = delete_source_column_indices[delete_source_index].filename_index;
+        if (filterChunkToCurrentDataFile(chunk, filename_index) == 0)
+            continue;
+
+        const auto position_index = delete_source_column_indices[delete_source_index].position_index;
+        size_t first_position_value_in_delete_file = chunk.getColumns()[position_index]->get64(0);
+        latest_positions.insert(std::pair<size_t, size_t>{first_position_value_in_delete_file, delete_source_index});
+        latest_chunks[delete_source_index] = std::move(chunk);
+        return;
+    }
 }
 
 void IcebergStreamingPositionDeleteTransform::transform(Chunk & chunk)

--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.h
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/PositionDeleteTransform.h
@@ -49,6 +49,12 @@ protected:
     LoggerPtr log = getLogger("IcebergPositionDeleteTransform");
     static size_t getColumnIndex(const std::shared_ptr<IInputFormat> & delete_source, const String & column_name);
 
+    /// Drops rows whose `file_path` column does not match the current data file path.
+    /// The WHERE filter on `delete_sources` only drives row-group/page pruning at the
+    /// Parquet reader; rows inside surviving row groups still need to be filtered explicitly.
+    /// Returns the number of rows kept (0 if the chunk has no matching rows).
+    size_t filterChunkToCurrentDataFile(Chunk & chunk, size_t filename_column_index) const;
+
     SharedHeader header;
     IcebergDataObjectInfoPtr iceberg_object_info;
     const ObjectStoragePtr object_storage;

--- a/tests/queries/0_stateless/04291_91525_iceberg_position_deletes_multi_file.reference
+++ b/tests/queries/0_stateless/04291_91525_iceberg_position_deletes_multi_file.reference
@@ -1,0 +1,8 @@
+roaring=0 parquet_v3=0:
+7	73	[1,5,7,11,13,17,19]
+roaring=0 parquet_v3=1:
+7	73	[1,5,7,11,13,17,19]
+roaring=1 parquet_v3=0:
+7	73	[1,5,7,11,13,17,19]
+roaring=1 parquet_v3=1:
+7	73	[1,5,7,11,13,17,19]

--- a/tests/queries/0_stateless/04291_91525_iceberg_position_deletes_multi_file.sh
+++ b/tests/queries/0_stateless/04291_91525_iceberg_position_deletes_multi_file.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/91525
+# Position deletes returned wrong results when:
+#   * one delete file referenced multiple data files (typical of v2 merge-on-read),
+#   * AND multiple delete files applied to the same data file.
+# The streaming transform passed the WHERE filter to the Parquet reader, but that
+# filter only drives row-group/page pruning, not row-level filtering. Rows for
+# other data files survived inside surviving row groups and broke the streaming
+# merge invariant that positions arrive in ascending order per delete source.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+TABLE="t_${CLICKHOUSE_DATABASE}_${RANDOM}"
+TABLE_PATH="${USER_FILES_PATH}/${TABLE}/"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE}"
+${CLICKHOUSE_CLIENT} --query "
+    CREATE TABLE ${TABLE} (a Int64, b String)
+    ENGINE = IcebergLocal('${TABLE_PATH}', 'Parquet')
+"
+
+# Two inserts create two data files (rows 0..9 and 10..19).
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query \
+    "INSERT INTO ${TABLE} SELECT number, char(number + ascii('a')) FROM numbers(0, 10)"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query \
+    "INSERT INTO ${TABLE} SELECT number, char(number + ascii('a')) FROM numbers(10, 10)"
+
+# Two deletes; each delete touches both data files, producing one delete file
+# per ALTER with rows that reference both data files.
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query \
+    "ALTER TABLE ${TABLE} DELETE WHERE a % 2 = 0"
+${CLICKHOUSE_CLIENT} --allow_insert_into_iceberg=1 --query \
+    "ALTER TABLE ${TABLE} DELETE WHERE a % 3 = 0"
+
+# Expected survivors: 1, 5, 7, 11, 13, 17, 19 (7 rows). Verify in both
+# streaming and roaring-bitmap modes, with and without the native Parquet v3 reader.
+for roaring in 0 1; do
+    for v3 in 0 1; do
+        echo "roaring=${roaring} parquet_v3=${v3}:"
+        ${CLICKHOUSE_CLIENT} \
+            --use_roaring_bitmap_iceberg_positional_deletes=${roaring} \
+            --input_format_parquet_use_native_reader_v3=${v3} \
+            --query "SELECT count(), sum(a), groupArray(a) FROM (SELECT a FROM ${TABLE} ORDER BY a)"
+    done
+done
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS ${TABLE}"
+rm -rf "${TABLE_PATH}"


### PR DESCRIPTION
## Linked issues
- Closes #91525

For a v2 merge-on-read Iceberg table where a single position-delete file references rows in multiple data files, applying two or more such delete files to the same data file produced the wrong result. The streaming reader returned a different set of rows than the roaring-bitmap reader, and neither matched what Spark sees.

### Reproducer (full SQL in the regression test)

```sql
SET allow_experimental_insert_into_iceberg = 1;
SET allow_insert_into_iceberg = 1;
CREATE TABLE t (a Int64, b String) ENGINE = IcebergLocal('/path/', 'Parquet');
INSERT INTO t SELECT number, char(number + ascii('a')) FROM numbers(0, 10);
INSERT INTO t SELECT number, char(number + ascii('a')) FROM numbers(10, 10);
ALTER TABLE t DELETE WHERE a % 2 = 0;
ALTER TABLE t DELETE WHERE a % 3 = 0;
SELECT groupArray(a) FROM (SELECT a FROM t ORDER BY a);
-- Expected: [1,5,7,11,13,17,19]
-- Before fix (use_roaring_bitmap_iceberg_positional_deletes = 0): [1,3,7,11,13,17]
```

### Root cause

`IcebergStreamingPositionDeleteTransform` requires positions to arrive in ascending order per delete source. It relies on the `equals(file_path, current_data_file)` WHERE clause that `initializeDeleteSources` builds to filter the delete file down to rows for the current data file. That WHERE clause is wired into the Parquet reader as `FormatFilterInfo::filter_actions_dag`, which only drives `KeyCondition`-based row-group / page pruning. It does not filter individual rows. With one row group covering positions for several data files, rows for the wrong data files survive pruning and appear inside the chunk in `(file_path, pos)` order. From the perspective of one data file, positions then come out out of order (e.g. `5, 3, 9`), and the streaming merge silently produces the wrong deletion set.

`IcebergBitmapPositionDeleteTransform` already worked around this by re-checking the path in C++ before adding positions to the roaring bitmap, which is why the bug only surfaced with `use_roaring_bitmap_iceberg_positional_deletes = 0` (the default).

### Fix

Pulled the path matching into a shared helper `IcebergPositionDeleteTransform::filterChunkToCurrentDataFile`. Both readers now call the helper to drop rows that do not match the current data file before consuming the chunk:

- The streaming reader filters each chunk in place and keeps reading until it finds one with at least one matching row, restoring the ascending-positions invariant.
- The bitmap reader uses the same helper instead of inlining the four path variants; behaviour is unchanged.

### Tests

Added stateless test `04291_91525_iceberg_position_deletes_multi_file.sh` that creates an `IcebergLocal` table with two data files, runs two `ALTER ... DELETE` statements that each touch both data files, and verifies the result under all four combinations of `use_roaring_bitmap_iceberg_positional_deletes` and `input_format_parquet_use_native_reader_v3`. Without this fix the streaming variants return `[1,3,7,11,13,17]`; with it they return `[1,5,7,11,13,17,19]`. The Spark-based reproducer from the issue exercises the same code path.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed Iceberg v2 merge-on-read position deletes returning wrong rows when a single delete file references multiple data files and several such delete files apply to the same data file. The streaming reader (`use_roaring_bitmap_iceberg_positional_deletes = 0`) now filters delete-file rows by `file_path` in C++ instead of relying on Parquet row-group pruning, restoring the ascending-positions invariant.

### Documentation entry for user-facing changes
- [x] Documentation is unchanged (bug fix only).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.248`
<!-- ch-version-info:end -->