### PR TITLE
Allow DP join reordering with parallel replicas

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
@@ -158,8 +158,7 @@ QueryPlanOptimizationSettings::QueryPlanOptimizationSettings(
     try_use_top_k_optimization = from[Setting::use_skip_indexes_for_top_k] || from[Setting::use_top_k_dynamic_filtering];
     top_k_through_join = from[Setting::query_plan_enable_optimizations] && from[Setting::query_plan_top_k_through_join];
 
-    bool use_parallel_replicas = from[Setting::allow_experimental_parallel_reading_from_replicas] && from[Setting::max_parallel_replicas] > 1;
-    query_plan_optimize_join_order_limit = use_parallel_replicas ? 0 : from[Setting::query_plan_optimize_join_order_limit];
+    query_plan_optimize_join_order_limit = from[Setting::query_plan_optimize_join_order_limit];
     if (query_plan_optimize_join_order_limit > 64)
         throw Exception(ErrorCodes::INVALID_SETTING_VALUE,
             "The value of the setting `query_plan_optimize_join_order_limit` is too large: {}, "

--- a/tests/queries/0_stateless/04277_parallel_replicas_join_dp_reorder.reference
+++ b/tests/queries/0_stateless/04277_parallel_replicas_join_dp_reorder.reference
@@ -1,0 +1,2 @@
+pr_dp_large
+pr_dp_small

--- a/tests/queries/0_stateless/04277_parallel_replicas_join_dp_reorder.reference
+++ b/tests/queries/0_stateless/04277_parallel_replicas_join_dp_reorder.reference
@@ -1,1 +1,3 @@
-1
+pr_dp_c
+pr_dp_b
+pr_dp_a

--- a/tests/queries/0_stateless/04277_parallel_replicas_join_dp_reorder.reference
+++ b/tests/queries/0_stateless/04277_parallel_replicas_join_dp_reorder.reference
@@ -1,2 +1,1 @@
-pr_dp_large
-pr_dp_small
+1

--- a/tests/queries/0_stateless/04277_parallel_replicas_join_dp_reorder.reference
+++ b/tests/queries/0_stateless/04277_parallel_replicas_join_dp_reorder.reference
@@ -1,3 +1,4 @@
 pr_dp_c
 pr_dp_b
 pr_dp_a
+100000

--- a/tests/queries/0_stateless/04277_parallel_replicas_join_dp_reorder.sql
+++ b/tests/queries/0_stateless/04277_parallel_replicas_join_dp_reorder.sql
@@ -1,0 +1,31 @@
+-- Regression test: the DP join-order optimizer must keep running when parallel replicas is enabled.
+-- Previously `QueryPlanOptimizationSettings` forced `query_plan_optimize_join_order_limit=0`
+-- whenever `allow_experimental_parallel_reading_from_replicas && max_parallel_replicas > 1`, which
+-- silently skipped join reordering for any PR query.
+
+DROP TABLE IF EXISTS pr_dp_small;
+DROP TABLE IF EXISTS pr_dp_large;
+
+CREATE TABLE pr_dp_small (x UInt32) ENGINE = MergeTree ORDER BY x AS SELECT number FROM numbers(100);
+CREATE TABLE pr_dp_large (x UInt32) ENGINE = MergeTree ORDER BY x AS SELECT number FROM numbers(100000);
+
+-- `small JOIN large` is the shape DP swaps so the larger table ends up on the left (probe) side.
+-- Extract the table names of `ReadFromMergeTree` steps from the plan in tree-walk order — left
+-- child first. With DP active, the larger table should appear before the smaller one; with DP
+-- disabled (the previous forced behaviour), the user-written order would be preserved.
+SELECT extract(explain, '(pr_dp_small|pr_dp_large)')
+FROM ( EXPLAIN PLAN
+    SELECT count() FROM pr_dp_small INNER JOIN pr_dp_large USING (x)
+    SETTINGS
+        enable_parallel_replicas = 1,
+        cluster_for_parallel_replicas = 'parallel_replicas',
+        max_parallel_replicas = 3,
+        parallel_replicas_for_non_replicated_merge_tree = 1,
+        parallel_replicas_local_plan = 1,
+        query_plan_join_swap_table = 'auto',
+        query_plan_optimize_join_order_limit = 10
+)
+WHERE explain LIKE '%ReadFromMergeTree%';
+
+DROP TABLE pr_dp_small;
+DROP TABLE pr_dp_large;

--- a/tests/queries/0_stateless/04277_parallel_replicas_join_dp_reorder.sql
+++ b/tests/queries/0_stateless/04277_parallel_replicas_join_dp_reorder.sql
@@ -3,19 +3,28 @@
 -- whenever `allow_experimental_parallel_reading_from_replicas && max_parallel_replicas > 1`, which
 -- silently skipped join reordering for any PR query.
 
-DROP TABLE IF EXISTS pr_dp_small;
-DROP TABLE IF EXISTS pr_dp_large;
+DROP TABLE IF EXISTS pr_dp_a;
+DROP TABLE IF EXISTS pr_dp_b;
+DROP TABLE IF EXISTS pr_dp_c;
 
-CREATE TABLE pr_dp_small (x UInt32) ENGINE = MergeTree ORDER BY x AS SELECT number FROM numbers(100);
-CREATE TABLE pr_dp_large (x UInt32) ENGINE = MergeTree ORDER BY x AS SELECT number FROM numbers(100000);
+CREATE TABLE pr_dp_a (x UInt32) ENGINE = MergeTree ORDER BY x AS SELECT number % 100   FROM numbers(100);
+CREATE TABLE pr_dp_b (x UInt32) ENGINE = MergeTree ORDER BY x AS SELECT number % 1000  FROM numbers(1000);
+CREATE TABLE pr_dp_c (x UInt32) ENGINE = MergeTree ORDER BY x AS SELECT number % 100   FROM numbers(100000);
 
--- `small JOIN large` is the shape DP swaps so the larger table ends up on the left (probe) side.
--- Extract the table names of `ReadFromMergeTree` steps from the plan in tree-walk order — left
--- child first. With DP active, the larger table should appear before the smaller one; with DP
--- disabled (the previous forced behaviour), the user-written order would be preserved.
-SELECT extract(explain, '(pr_dp_small|pr_dp_large)')
+-- Three-way join written as `(a JOIN b) JOIN c` with `a` (100 rows) < `b` (1000) < `c` (100000).
+-- The 2-table swap can also go through the legacy `optimizeJoinLegacy` path, so this test forces
+-- `query_plan_optimize_join_order_algorithm='dpsize'` and uses a 3-way join to exercise the actual
+-- DP optimizer (`query_graph_size_limit > 2` in `optimizeJoinLogicalImpl`).
+--
+-- With DP disabled (`query_plan_optimize_join_order_limit=0`) `optimizeJoinLogicalImpl` exits
+-- early without converting the `JoinStepLogical`s, and `optimizeJoinLegacy` is a no-op on them, so
+-- the user-written order `(a JOIN b) JOIN c` reaches `ReadFromMergeTree` unchanged — EXPLAIN
+-- traversal yields `[a, b, c]`. With DP active the order is whatever DP's cost model picks (the
+-- exact shape varies under the stateless randomizer); whatever it is, it will not be the original
+-- `[a, b, c]`. So the test asserts the EXPLAIN read-step order is non-identity.
+SELECT groupArray(extract(explain, '(pr_dp_a|pr_dp_b|pr_dp_c)')) != ['pr_dp_a', 'pr_dp_b', 'pr_dp_c']
 FROM ( EXPLAIN PLAN
-    SELECT count() FROM pr_dp_small INNER JOIN pr_dp_large USING (x)
+    SELECT count() FROM pr_dp_a AS a JOIN pr_dp_b AS b ON a.x = b.x JOIN pr_dp_c AS c ON b.x = c.x
     SETTINGS
         enable_parallel_replicas = 1,
         cluster_for_parallel_replicas = 'parallel_replicas',
@@ -23,9 +32,12 @@ FROM ( EXPLAIN PLAN
         parallel_replicas_for_non_replicated_merge_tree = 1,
         parallel_replicas_local_plan = 1,
         query_plan_join_swap_table = 'auto',
-        query_plan_optimize_join_order_limit = 10
+        query_plan_optimize_join_order_algorithm = 'dpsize',
+        query_plan_optimize_join_order_limit = 10,
+        query_plan_optimize_join_order_randomize = 0
 )
 WHERE explain LIKE '%ReadFromMergeTree%';
 
-DROP TABLE pr_dp_small;
-DROP TABLE pr_dp_large;
+DROP TABLE pr_dp_a;
+DROP TABLE pr_dp_b;
+DROP TABLE pr_dp_c;

--- a/tests/queries/0_stateless/04277_parallel_replicas_join_dp_reorder.sql
+++ b/tests/queries/0_stateless/04277_parallel_replicas_join_dp_reorder.sql
@@ -3,6 +3,12 @@
 -- whenever `allow_experimental_parallel_reading_from_replicas && max_parallel_replicas > 1`, which
 -- silently skipped join reordering for any PR query.
 
+-- `query_plan_optimize_join_order_randomize` injects random cardinalities/NDVs into the DP cost
+-- model when non-zero, so the chosen tree shape becomes non-deterministic. Pin it off at the
+-- session level so the EXPLAIN output is stable under any randomizer config (this knob is only
+-- randomized in stress tests today, but pinning is cheap insurance).
+SET query_plan_optimize_join_order_randomize = 0;
+
 DROP TABLE IF EXISTS pr_dp_a;
 DROP TABLE IF EXISTS pr_dp_b;
 DROP TABLE IF EXISTS pr_dp_c;
@@ -16,13 +22,13 @@ CREATE TABLE pr_dp_c (x UInt32) ENGINE = MergeTree ORDER BY x AS SELECT number %
 -- `query_plan_optimize_join_order_algorithm='dpsize'` and uses a 3-way join to exercise the actual
 -- DP optimizer (`query_graph_size_limit > 2` in `optimizeJoinLogicalImpl`).
 --
--- With DP disabled (`query_plan_optimize_join_order_limit=0`) `optimizeJoinLogicalImpl` exits
--- early without converting the `JoinStepLogical`s, and `optimizeJoinLegacy` is a no-op on them, so
--- the user-written order `(a JOIN b) JOIN c` reaches `ReadFromMergeTree` unchanged — EXPLAIN
--- traversal yields `[a, b, c]`. With DP active the order is whatever DP's cost model picks (the
--- exact shape varies under the stateless randomizer); whatever it is, it will not be the original
--- `[a, b, c]`. So the test asserts the EXPLAIN read-step order is non-identity.
-SELECT groupArray(extract(explain, '(pr_dp_a|pr_dp_b|pr_dp_c)')) != ['pr_dp_a', 'pr_dp_b', 'pr_dp_c']
+-- With DP active DP's cost model picks a left-deep tree that surfaces the largest table on the
+-- parallelized (outer probe) side, giving the EXPLAIN read-step traversal `c, b, a`. With DP
+-- disabled (`query_plan_optimize_join_order_limit=0` — the previously forced behaviour)
+-- `optimizeJoinLogicalImpl` exits early without converting the `JoinStepLogical`s, and
+-- `optimizeJoinLegacy` is a no-op on them, so the user-written order `(a JOIN b) JOIN c` reaches
+-- `ReadFromMergeTree` unchanged and the traversal is `a, b, c`.
+SELECT extract(explain, '(pr_dp_a|pr_dp_b|pr_dp_c)')
 FROM ( EXPLAIN PLAN
     SELECT count() FROM pr_dp_a AS a JOIN pr_dp_b AS b ON a.x = b.x JOIN pr_dp_c AS c ON b.x = c.x
     SETTINGS
@@ -34,7 +40,10 @@ FROM ( EXPLAIN PLAN
         query_plan_join_swap_table = 'auto',
         query_plan_optimize_join_order_algorithm = 'dpsize',
         query_plan_optimize_join_order_limit = 10,
-        query_plan_optimize_join_order_randomize = 0
+        -- Transitive predicate derivation adds the implicit `a.x = c.x` edge to the join graph,
+        -- which gives DP a different cost surface and a different left-deep choice. Pin it off so
+        -- the EXPLAIN order is stable regardless of the randomizer (which flips this 30% of runs).
+        enable_join_transitive_predicates = 0
 )
 WHERE explain LIKE '%ReadFromMergeTree%';
 

--- a/tests/queries/0_stateless/04277_parallel_replicas_join_dp_reorder.sql
+++ b/tests/queries/0_stateless/04277_parallel_replicas_join_dp_reorder.sql
@@ -5,9 +5,11 @@
 
 -- `query_plan_optimize_join_order_randomize` injects random cardinalities/NDVs into the DP cost
 -- model when non-zero, so the chosen tree shape becomes non-deterministic. Pin it off at the
--- session level so the EXPLAIN output is stable under any randomizer config (this knob is only
--- randomized in stress tests today, but pinning is cheap insurance).
+-- session level so the EXPLAIN output is stable under any randomizer config.
 SET query_plan_optimize_join_order_randomize = 0;
+
+-- For runs with old analyzer
+SET enable_analyzer=1;
 
 DROP TABLE IF EXISTS pr_dp_a;
 DROP TABLE IF EXISTS pr_dp_b;
@@ -16,6 +18,20 @@ DROP TABLE IF EXISTS pr_dp_c;
 CREATE TABLE pr_dp_a (x UInt32) ENGINE = MergeTree ORDER BY x AS SELECT number % 100   FROM numbers(100);
 CREATE TABLE pr_dp_b (x UInt32) ENGINE = MergeTree ORDER BY x AS SELECT number % 1000  FROM numbers(1000);
 CREATE TABLE pr_dp_c (x UInt32) ENGINE = MergeTree ORDER BY x AS SELECT number % 100   FROM numbers(100000);
+
+SET
+  enable_parallel_replicas = 1,
+  cluster_for_parallel_replicas = 'parallel_replicas',
+  max_parallel_replicas = 3,
+  parallel_replicas_for_non_replicated_merge_tree = 1,
+  parallel_replicas_local_plan = 1,
+  query_plan_join_swap_table = 'auto',
+  query_plan_optimize_join_order_algorithm = 'dpsize',
+  query_plan_optimize_join_order_limit = 10,
+  -- Transitive predicate derivation adds the implicit `a.x = c.x` edge to the join graph,
+  -- which gives DP a different cost surface and a different left-deep choice. Pin it off so
+  -- the EXPLAIN order is stable regardless of the randomizer.
+  enable_join_transitive_predicates = 0;
 
 -- Three-way join written as `(a JOIN b) JOIN c` with `a` (100 rows) < `b` (1000) < `c` (100000).
 -- The 2-table swap can also go through the legacy `optimizeJoinLegacy` path, so this test forces
@@ -29,23 +45,14 @@ CREATE TABLE pr_dp_c (x UInt32) ENGINE = MergeTree ORDER BY x AS SELECT number %
 -- `optimizeJoinLegacy` is a no-op on them, so the user-written order `(a JOIN b) JOIN c` reaches
 -- `ReadFromMergeTree` unchanged and the traversal is `a, b, c`.
 SELECT extract(explain, '(pr_dp_a|pr_dp_b|pr_dp_c)')
-FROM ( EXPLAIN PLAN
-    SELECT count() FROM pr_dp_a AS a JOIN pr_dp_b AS b ON a.x = b.x JOIN pr_dp_c AS c ON b.x = c.x
-    SETTINGS
-        enable_parallel_replicas = 1,
-        cluster_for_parallel_replicas = 'parallel_replicas',
-        max_parallel_replicas = 3,
-        parallel_replicas_for_non_replicated_merge_tree = 1,
-        parallel_replicas_local_plan = 1,
-        query_plan_join_swap_table = 'auto',
-        query_plan_optimize_join_order_algorithm = 'dpsize',
-        query_plan_optimize_join_order_limit = 10,
-        -- Transitive predicate derivation adds the implicit `a.x = c.x` edge to the join graph,
-        -- which gives DP a different cost surface and a different left-deep choice. Pin it off so
-        -- the EXPLAIN order is stable regardless of the randomizer (which flips this 30% of runs).
-        enable_join_transitive_predicates = 0
+FROM (
+  EXPLAIN PLAN
+  SELECT count() FROM pr_dp_a AS a JOIN pr_dp_b AS b ON a.x = b.x JOIN pr_dp_c AS c ON b.x = c.x
 )
 WHERE explain LIKE '%ReadFromMergeTree%';
+
+-- Check the query result itself
+SELECT count() FROM pr_dp_a AS a JOIN pr_dp_b AS b ON a.x = b.x JOIN pr_dp_c AS c ON b.x = c.x;
 
 DROP TABLE pr_dp_a;
 DROP TABLE pr_dp_b;

--- a/tests/queries/0_stateless/04277_parallel_replicas_join_dp_reorder.sql
+++ b/tests/queries/0_stateless/04277_parallel_replicas_join_dp_reorder.sql
@@ -31,7 +31,8 @@ SET
   -- Transitive predicate derivation adds the implicit `a.x = c.x` edge to the join graph,
   -- which gives DP a different cost surface and a different left-deep choice. Pin it off so
   -- the EXPLAIN order is stable regardless of the randomizer.
-  enable_join_transitive_predicates = 0;
+  enable_join_transitive_predicates = 0,
+  automatic_parallel_replicas_mode = 0;
 
 -- Three-way join written as `(a JOIN b) JOIN c` with `a` (100 rows) < `b` (1000) < `c` (100000).
 -- The 2-table swap can also go through the legacy `optimizeJoinLegacy` path, so this test forces


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
DP JOIN reordering is now allowed with parallel replicas.

---

It looks like I really need it to implement support for JOINs with AutoPR. Otherwise, the local and distributed plans won't match in too many cases.