### PR TITLE
Disable 03357_join_pk_sharding on TSan

### DIFF
--- a/tests/queries/0_stateless/03357_join_pk_sharding.sql
+++ b/tests/queries/0_stateless/03357_join_pk_sharding.sql
@@ -1,4 +1,4 @@
--- Tags: long, no-asan, no-msan
+-- Tags: long, no-asan, no-msan, no-tsan
 
 SET max_bytes_before_external_join = 0, max_bytes_ratio_before_external_join = 0; -- Disable automatic spilling for this test
 SET use_statistics = 0;


### PR DESCRIPTION
Disable `03357_join_pk_sharding` on TSan to stop chronic timeout flakes.

The test creates three 1M-row `MergeTree` tables and runs ten multi-table `JOIN` queries with `EXPLAIN ACTIONS`. On TSan it runs ~15-30x slower than on debug or release builds, occasionally exceeding the 600s per-test timeout budget for `long`-tagged tests under unfavorable randomized settings.

CIDB over the last 60 days for `03357_join_pk_sharding`:
- 5 timeout failures, all at exactly `600.06s`.
- All 5 on `Stateless tests (amd_tsan, parallel, ...)` jobs (4 amd_tsan parallel + 1 amd_tsan s3).
- 0 timeouts on any non-TSan build.
- TSan p95 = 120s, p99 = 178s, max = 469s for the passing runs.

5 unrelated PRs were affected: #103112 (vector_spann), #98939 (text index), #102444 (hash join prefetch), #103602, #102001. The test already excludes `ASan` and `MSan` with `no-asan, no-msan` for the same reason. `TSan` is typically the slowest sanitizer and belongs in the same list. Functional coverage of `query_plan_join_shard_by_pk_ranges` is preserved on debug, release, ARM, and `ASan+UBSan` (distributed plan) builds.

Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=103112&sha=3cfc7fde0c115e6368c6f235eddb2cd112767c94&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%202%2F2%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Documentation entry for user-facing changes
- [ ] Documentation is unchanged

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.189`
<!-- ch-version-info:end -->