### PR TITLE
Require can be tested for BackportPR

### DIFF
--- a/ci/workflows/backport_branches.py
+++ b/ci/workflows/backport_branches.py
@@ -3,6 +3,7 @@ from praktika import Workflow
 from ci.defs.defs import DOCKERS, SECRETS, ArtifactConfigs
 from ci.defs.job_configs import JobConfigs
 from ci.jobs.scripts.workflow_hooks.filter_job import should_skip_job
+from ci.jobs.scripts.workflow_hooks.trusted import can_be_tested
 
 workflow = Workflow.Config(
     name="BackportPR",
@@ -54,6 +55,7 @@ workflow = Workflow.Config(
     enable_commit_status_on_failure=True,
     enable_gh_summary_comment=True,
     pre_hooks=[
+        can_be_tested,
         "python3 ./ci/jobs/scripts/workflow_hooks/store_data.py",
         "python3 ./ci/jobs/scripts/workflow_hooks/version_log.py",
         "python3 ./ci/jobs/scripts/workflow_hooks/check_backport_branch.py",


### PR DESCRIPTION
## Summary
- add the existing `can_be_tested` pre-hook to `BackportPR`
- align the release-branch PR workflow with the trusted-contributor gate already used by the main `PR` workflow

## Why
The main `PR` workflow already requires the trusted-contributor / maintainer-approval gate before running jobs. `BackportPR` handles `pull_request` events for release branches but was missing that same pre-hook.

This PR keeps the scope intentionally minimal and only adds the existing gate. It does not change runner labels or any other workflow policy.

## Validation
- `git diff --check`
- regenerated workflows locally with `python3 -m ci.praktika yaml`
- checked that the source diff stays minimal

## Related
- closes #105901
