### PR TITLE
Add link to combined Performance dashboard from CI report

### DIFF
--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -1525,12 +1525,26 @@ def main():
     if Path(f"{perf_wd}/logs.tar.zst").is_file():
         files_to_attach.append(f"{perf_wd}/logs.tar.zst")
 
-    Result.create_from(
+    result = Result.create_from(
         results=results,
         stopwatch=stop_watch,
         files=files_to_attach + [f"{perf_wd}/report/all-query-metrics.tsv"],
         info=message,
-    ).complete_job()
+    )
+    if info.pr_number:
+        dashboard_link = (
+            f"https://performance.ci.clickhouse.com/runs?q={info.pr_number}"
+        )
+    else:
+        dashboard_link = (
+            f"https://performance.ci.clickhouse.com/runs?scope=master&q={(info.sha or '')[:12]}"
+        )
+    result.set_label(
+        "Performance dashboard",
+        link=dashboard_link,
+        hint="Combined performance dashboard for this run (all shards, amd + arm)",
+    )
+    result.complete_job()
 
 
 if __name__ == "__main__":

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -1032,13 +1032,61 @@ class GH:
                 remaining = len(summary.failed_results) - MAX_JOBS_PER_SUMMARY
                 summary.failed_results = summary.failed_results[:MAX_JOBS_PER_SUMMARY]
                 print(f"NOTE: {remaining} more jobs not shown in PR comment")
-            # Collect links from jobs that have labels with links (e.g. keeper-stress Grafana links).
-            # Include regardless of success/failure so Grafana links always appear when keeper-stress runs.
+            # Collect links from jobs that have labels with links (e.g. keeper-stress Grafana
+            # links, perf-comparison combined dashboard). Include regardless of success/failure
+            # so links always appear when the job runs.
+            #
+            # Dedup key = the URL set (sorted tuple of label links), not the rendered markdown.
+            # We group by *destination*: jobs that point at the same set of URLs are collapsed
+            # into one PR-comment row regardless of label text or ordering. This is what makes
+            # the 6 (or 12) `Performance Comparison` shards collapse to a single row, while
+            # `keeper-stress` jobs — whose `Grafana: Run details` URL embeds a per-run time
+            # window — stay distinct because their URL sets differ.
+            #
+            # The collapsed row's label is the longest common prefix of the job names trimmed
+            # at a natural break (`(` or `,`), so `Performance Comparison (arm_release,
+            # master_head, 1/6)` ... `6/6` becomes `Performance Comparison`.
+            def _shared_job_label(names):
+                if len(names) == 1:
+                    return names[0]
+                common = os.path.commonprefix(names)
+                for sep in (" (", ", ", "("):
+                    idx = common.rfind(sep)
+                    if idx > 0:
+                        common = common[:idx]
+                        break
+                common = common.rstrip(" ,(-")
+                return common or f"{names[0]} (+{len(names) - 1} more)"
+
+            def _url_key(res):
+                """Sorted tuple of label link URLs (the dedup key)."""
+                urls = []
+                for item in (getattr(res, "ext", {}) or {}).get("labels", []) or []:
+                    if isinstance(item, dict) and item.get("link"):
+                        urls.append(item["link"])
+                for item in (getattr(res, "ext", {}) or {}).get("hlabels", []) or []:
+                    if isinstance(item, (list, tuple)) and len(item) >= 2 and item[1]:
+                        urls.append(item[1])
+                return tuple(sorted(urls))
+
+            groups = {}
+            group_order = []
             for job_result in getattr(result, "results", []) or []:
-                if has_label_links(job_result):
-                    links_md = extract_label_links_md(job_result)
-                    if links_md:
-                        summary.extra_links.append((job_result.name, links_md))
+                if not has_label_links(job_result):
+                    continue
+                links_md = extract_label_links_md(job_result)
+                if not links_md:
+                    continue
+                key = _url_key(job_result)
+                if key not in groups:
+                    groups[key] = {"names": [], "links_md": links_md}
+                    group_order.append(key)
+                groups[key]["names"].append(job_result.name)
+            for key in group_order:
+                group = groups[key]
+                summary.extra_links.append(
+                    (_shared_job_label(group["names"]), group["links_md"])
+                )
             return summary
 
         def to_markdown(self, pr_number=0, sha="", workflow_name="", branch=""):
@@ -1054,9 +1102,11 @@ class GH:
                 symbol = "⏳"  # Hourglass (in progress)
 
             body = f"**Summary:** {symbol}\n"
-            if self.extra_links:
-                for job_name, links_md in self.extra_links:
-                    body += f"**{job_name}:** {links_md}\n"
+            # Render each extra_links group as a plain bullet under the Summary
+            # line. Keeping the (un-bolded) job-name prefix tells the reader
+            # which job(s) the labels came from without adding extra weight.
+            for name, links_md in self.extra_links:
+                body += f"- {name}: {links_md}\n"
             if self.failed_results:
                 if len(self.failed_results) > 15:
                     body += (

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -805,6 +805,40 @@
         element.style.verticalAlign = 'middle';
     }
 
+    // Render the current Result's own labels in the sidebar. Without this the
+    // labels of a drilled-into job would only be visible in the parent
+    // overview row, never on the job's own page.
+    function addLabelsWidget(ext) {
+        const labels = normalizeLabels(ext?.labels, ext?.hlabels);
+        if (labels.length === 0) return;
+
+        const statusContainer = document.getElementById('status-container');
+        const widget = document.createElement('div');
+        widget.className = 'status-widget';
+        widget.style.textAlign = 'left';
+
+        labels.forEach(({name, link, hint}) => {
+            const element = link ? document.createElement('a') : document.createElement('span');
+            if (link) {
+                element.href = link;
+                element.target = '_blank';
+                element.rel = 'noopener noreferrer';
+            }
+            applyLabelStyles(element, name);
+            element.style.marginLeft = '0';
+            if (hint) {
+                element.title = hint;
+                element.style.cursor = link ? 'pointer' : 'help';
+            }
+            const line = document.createElement('div');
+            line.style.margin = '4px 0';
+            line.appendChild(element);
+            widget.appendChild(line);
+        });
+
+        statusContainer.appendChild(widget);
+    }
+
     function addFileLinksWidget(links) {
         if (!Array.isArray(links) || links.length === 0) return;
 
@@ -2004,6 +2038,7 @@
             duration: result.duration
         };
         let statusWidget = addStatusWidget(result.name, result.status, result.start_time, result.duration);
+        addLabelsWidget(result.ext);
         if (nameParams.length > 1) {
             addFileLinksWidget(result.links);
             if (nameParams.length === 2) {


### PR DESCRIPTION
Attach a `Performance dashboard` label with link to the top-level `Result` of every performance comparison job in performance_tests, so in the CI report has a one-click jump to the unified dashboard at `performance.ci.clickhouse.com/runs` in addition to per-shard static HTML reports.

- PR runs link to `?q={pr_number}`.
- Master/push runs link to `?scope=master&q={short_sha}` (first 12 hex chars of `info.sha`).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.192`
<!-- ch-version-info:end -->