### PR TITLE
Docs: remove beta badge for `clickhousectl`

### DIFF
--- a/docs/en/interfaces/cli.md
+++ b/docs/en/interfaces/cli.md
@@ -7,10 +7,6 @@ title: 'clickhousectl'
 doc_type: 'reference'
 ---
 
-import BetaBadge from '@theme/badges/BetaBadge';
-
-<BetaBadge/>
-
 `clickhousectl` is the CLI for ClickHouse: local and cloud.
 
 With `clickhousectl` you can:


### PR DESCRIPTION
Remove beta badge for clickhousectl move to GA after Open House
### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.230`
<!-- ch-version-info:end -->