### PR TITLE
Fix `03772_temporary_files_codec` test

### DIFF
--- a/tests/queries/0_stateless/03772_temporary_files_codec.sql
+++ b/tests/queries/0_stateless/03772_temporary_files_codec.sql
@@ -1,14 +1,12 @@
 -- Tags: long, no-flaky-check
-SET max_bytes_before_external_sort = '256K';
+SET max_bytes_before_external_sort = '100K';
 SET max_bytes_ratio_before_external_sort = 0;
 SET max_block_size = DEFAULT;
-SET max_bytes_before_external_group_by = '1M';
+SET max_bytes_before_external_group_by = '100K';
 SET max_bytes_ratio_before_external_group_by = 0;
 SET group_by_two_level_threshold = '100K';
 SET group_by_two_level_threshold_bytes = '50M';
 SET max_memory_usage = '1G';
-
-CREATE TEMPORARY TABLE start_ts AS ( SELECT now() AS ts );
 
 SELECT * FROM (SELECT number, 'payload' FROM numbers(2_000_000)) ORDER BY number
 SETTINGS log_comment='03772_temporary_files_codec/sort', temporary_files_codec = 'NONE'
@@ -67,8 +65,7 @@ SELECT
     (sumIf(ProfileEvents['ExternalProcessingUncompressedBytesTotal'], Settings['temporary_files_codec'] = 'NONE') AS without_compression) > 0,
     with_compression < without_compression
 FROM system.query_log
-WHERE event_date >= yesterday() AND event_time >= (SELECT ts FROM start_ts)
-    AND current_database = currentDatabase()
+WHERE current_database = currentDatabase()
     AND type != 1
     AND log_comment like '03772_temporary_files_codec/%'
 GROUP BY log_comment

--- a/tests/queries/0_stateless/03772_temporary_files_codec.sql
+++ b/tests/queries/0_stateless/03772_temporary_files_codec.sql
@@ -8,6 +8,8 @@ SET group_by_two_level_threshold = '100K';
 SET group_by_two_level_threshold_bytes = '50M';
 SET max_memory_usage = '1G';
 
+CREATE TEMPORARY TABLE start_ts AS ( SELECT now() AS ts );
+
 SELECT * FROM (SELECT number, 'payload' FROM numbers(2_000_000)) ORDER BY number
 SETTINGS log_comment='03772_temporary_files_codec/sort', temporary_files_codec = 'NONE'
 FORMAT Null;
@@ -65,7 +67,8 @@ SELECT
     (sumIf(ProfileEvents['ExternalProcessingUncompressedBytesTotal'], Settings['temporary_files_codec'] = 'NONE') AS without_compression) > 0,
     with_compression < without_compression
 FROM system.query_log
-WHERE current_database = currentDatabase()
+WHERE event_date >= yesterday() AND event_time >= (SELECT ts FROM start_ts)
+    AND current_database = currentDatabase()
     AND type != 1
     AND log_comment like '03772_temporary_files_codec/%'
 GROUP BY log_comment


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Lower the external sort and grouping threshold to make sure the queries always spill to disk.

Closes https://github.com/ClickHouse/ClickHouse/issues/105911

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.200`
<!-- ch-version-info:end -->