### PR TITLE
darwin fast test: spawn watchdog child via posix_spawn to avoid SIGILL on macOS 26

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -495,7 +495,10 @@ int mainEntryClickHouseServer(int argc, char ** argv)
     /// Do not fork separate process from watchdog if we attached to terminal.
     /// Otherwise it breaks gdb usage.
     /// Can be overridden by environment variable (cannot use server config at this moment).
-    if (argc > 0)
+    /// CLICKHOUSE_WATCHDOG_CHILD=1 marks the re-exec'd child on platforms where the
+    /// watchdog uses posix_spawn (Darwin) — the child must not enable its own watchdog.
+    const bool is_watchdog_child = nullptr != getenv("CLICKHOUSE_WATCHDOG_CHILD"); // NOLINT(concurrency-mt-unsafe)
+    if (argc > 0 && !is_watchdog_child)
     {
         const char * env_watchdog = getenv("CLICKHOUSE_WATCHDOG_ENABLE"); // NOLINT(concurrency-mt-unsafe)
         if (env_watchdog)

--- a/src/Daemon/BaseDaemon.cpp
+++ b/src/Daemon/BaseDaemon.cpp
@@ -19,7 +19,13 @@
 #include <iostream>
 #include <memory>
 #include <sstream>
+#include <spawn.h>
 #include <unistd.h>
+
+#if defined(OS_DARWIN)
+#include <crt_externs.h>
+extern char ** environ;
+#endif
 
 #include <Poco/Message.h>
 #include <Poco/Util/Application.h>
@@ -570,6 +576,45 @@ void BaseDaemon::setupWatchdog()
         auto * async_channel = dynamic_cast<OwnAsyncSplitChannel *>(logger().getChannel());
         if (async_channel)
             async_channel->close();
+
+#if defined(OS_DARWIN)
+        /// macOS libsystem_c kills any forked child that performs non-async-signal-safe
+        /// work (logger, malloc, mutex) before exec*(). Spawn a fresh server instance
+        /// via posix_spawn and use CLICKHOUSE_WATCHDOG_CHILD as a sentinel so the
+        /// re-exec'd process does not enable its own watchdog.
+        {
+            setenv("CLICKHOUSE_WATCHDOG_CHILD", "1", 1); // NOLINT(concurrency-mt-unsafe)
+
+            char ** orig_argv = *_NSGetArgv();
+
+            posix_spawn_file_actions_t file_actions;
+            posix_spawn_file_actions_init(&file_actions);
+            /// The synchronization pipe is only used by the fork-based watchdog path;
+            /// close both ends in the spawned child to avoid leaking fds for its lifetime.
+            posix_spawn_file_actions_addclose(&file_actions, notify_sync.readHandle());
+            posix_spawn_file_actions_addclose(&file_actions, notify_sync.writeHandle());
+
+            posix_spawnattr_t attr;
+            posix_spawnattr_init(&attr);
+            sigset_t empty_mask;
+            sigemptyset(&empty_mask);
+            posix_spawnattr_setsigmask(&attr, &empty_mask);
+            posix_spawnattr_setflags(&attr, POSIX_SPAWN_SETSIGMASK);
+
+            int rc = posix_spawn(&pid, orig_argv[0], &file_actions, &attr, orig_argv, environ);
+
+            posix_spawn_file_actions_destroy(&file_actions);
+            posix_spawnattr_destroy(&attr);
+
+            unsetenv("CLICKHOUSE_WATCHDOG_CHILD"); // NOLINT(concurrency-mt-unsafe)
+
+            if (async_channel)
+                async_channel->open();
+
+            if (rc != 0)
+                throw ErrnoException(ErrorCodes::SYSTEM_ERROR, rc, "Cannot posix_spawn watchdog child");
+        }
+#else
         pid = fork();
 
 #if USE_JEMALLOC
@@ -612,6 +657,7 @@ void BaseDaemon::setupWatchdog()
 
             return;
         }
+#endif
 
 #if defined(OS_LINUX)
         /// Tell the service manager the actual main process is not this one but the forked process


### PR DESCRIPTION
Every `Fast test (arm_darwin)` run on `macOS 26.3.1` emits an `.ips` crash report with an identical signature, regardless of whether the test job itself succeeds. The root cause is the new `libsystem_c` hardening on `macOS 26` (Tahoe), which `SIGILL`s any forked child that performs non-async-signal-safe work between `fork()` and `exec*()`.

## Diagnosis

98 of 99 sampled `.ips` files from the 100 most recent runs share the exact same signature (`bug_type 309`, the missing 1 was a download error):

- Exception: `EXC_CRASH` / `SIGILL` ("Illegal instruction: 4")
- ASI message: `libsystem_c.dylib: crashed on child side of fork pre-exec`
- Crashing process: `clickhouse` (forked child of `clickhouse-server`)
- OS: `macOS 26.3.1 (25D2128)`
- The "triggered" thread shown in the IPS is the *parent's* main thread sitting in `SignalListener::waitForTerminationRequest` — misleading. The actual `SIGILL` is delivered to the child while it is still in the post-`fork` pre-`exec` window.

The offending fork is `BaseDaemon::setupWatchdog` (`src/Daemon/BaseDaemon.cpp:573`). The watchdog auto-enables in CI mode (no TTY on stdin/stdout/stderr, see `programs/server/Server.cpp:508`), `fork()`s, and the child path immediately calls non-async-signal-safe code: `Jemalloc::setup`, `OwnAsyncSplitChannel::open`, `updateCurrentThreadIdAfterFork`, `logger().information(...)`, then `Poco::Pipe::readBytes`. Because the child never calls `exec*()` (it instead `return`s from `setupWatchdog` and continues running the parent's already-initialized code), the entire child lifetime is "pre-exec" from `libsystem_c`'s point of view, and the first non-AS-safe call trips the hardening check.

Other forks in the server are not affected:
- `ShellCommand::executeImpl` uses `vfork()` and a strictly AS-safe child block (`dup2`, `sigprocmask`, `execv`, `_exit`).
- `Poco::Process::launch` is not used by `clickhouse-server` (no references in `src/`).
- `mainEntryClickHouseChdig`, `programs/docker-init`, and friends are unrelated to the server runtime.

## Change

On Darwin only, replace the `fork()`-and-continue pattern in `BaseDaemon::setupWatchdog` with `posix_spawn`. The spawned child is a fresh `clickhouse-server` process that re-runs `main` and re-initializes everything cleanly — `libsystem_c` has no exposed post-fork pre-exec window from userland's view, so the hardening cannot fire. A sentinel env var `CLICKHOUSE_WATCHDOG_CHILD=1` is set before the spawn so the re-exec'd child knows not to enable its own watchdog (otherwise watchdogs would nest infinitely).

Linux is unchanged — the existing `fork`-based watchdog path is kept verbatim, gated behind `#if !defined(OS_DARWIN)`. The parent-side `waitpid` loop, signal forwarding, and `systemd` notification are untouched.

Why `posix_spawn` rather than explicit `fork()` + `execv()`:
- AS-safety by construction. There is no child block to maintain; future contributors cannot accidentally reintroduce the `SIGILL` by adding a non-AS-safe call.
- Failures return an `errno`-style code from `posix_spawn` synchronously, observable in the parent. With explicit `fork`+`exec`, AS-safety mistakes manifest as silent `SIGILL` only visible in the resulting `.ips`.
- Apple-recommended pattern for `macOS` spawns.

The trade-off versus the existing in-memory continuation is that respawning the child requires re-parsing argv and re-reading the config file (~1-2s extra per respawn). The watchdog respawns very rarely in steady state, so this cost is acceptable. The behavioral cost is scoped to Darwin.

Reference query used to surface the universal `.ips`:
```sql
SELECT check_name, check_status, task_url, report_url, check_start_time
FROM default.checks
WHERE check_name = 'Fast test (arm_darwin)' AND test_name = ''
ORDER BY check_start_time DESC
LIMIT 100
```
on `play.clickhouse.com`.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes
- [x] Documentation is written (mandatory for new features)