### PR TITLE
Fix std::bad_alloc on first-use JIT init in non-jemalloc macOS builds

### DIFF
--- a/src/Common/memory.h
+++ b/src/Common/memory.h
@@ -45,7 +45,14 @@ inline ALWAYS_INLINE void * newNoExcept(std::size_t size) noexcept
 
 inline ALWAYS_INLINE void * newNoExcept(std::size_t size, std::align_val_t align) noexcept
 {
-    return __real_aligned_alloc(static_cast<size_t>(align), alignUp(size, static_cast<size_t>(align)));
+    size_t alignment = static_cast<size_t>(align);
+#if !USE_JEMALLOC
+    /// POSIX `aligned_alloc` requires alignment >= `sizeof(void *)` (strictly enforced on macOS).
+    /// Mirror libc++'s `operator_new_aligned_impl` in `contrib/llvm-project/libcxx/src/new.cpp`.
+    if (alignment < sizeof(void *))
+        alignment = sizeof(void *);
+#endif
+    return __real_aligned_alloc(alignment, alignUp(size, alignment));
 }
 
 inline ALWAYS_INLINE void deleteImpl(void * ptr) noexcept


### PR DESCRIPTION
On macOS non-jemalloc builds, the first JIT compilation in `clickhouse local` fails with `std::bad_alloc: std::bad_alloc. (STD_EXCEPTION)`. LLVM's `DenseMap<MCRegister, int>::grow` requests `::operator new(512, std::align_val_t(4), std::nothrow)`, and ClickHouse's aligned `newNoExcept` forwarded that straight to system `aligned_alloc(4, 512)`, which returns `nullptr` (`EINVAL`) because POSIX requires alignment >= `sizeof(void *)`. macOS enforces this strictly; glibc happens to be lenient, which is why Linux non-jemalloc builds don't trip on it.

This patch mirrors what libc++ already does in `operator_new_aligned_impl` (`contrib/llvm-project/libcxx/src/new.cpp`): if the requested alignment is below `sizeof(void *)`, bump it up before calling `aligned_alloc`. The jemalloc path is unaffected — jemalloc's `je_aligned_alloc` sets `sopts.min_alignment = 1` and accepts any power-of-two alignment by design, which is why the official macOS binary (built `RelWithDebInfo` with jemalloc) does not hit this.

Closes #105868.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.202`
<!-- ch-version-info:end -->