### PR TITLE
Pass virtual columns through prewhere filter

### DIFF
--- a/src/Storages/MergeTree/Streaming/MergeTreeCommitOrderSequentialSource.cpp
+++ b/src/Storages/MergeTree/Streaming/MergeTreeCommitOrderSequentialSource.cpp
@@ -263,6 +263,21 @@ SelectQueryInfo makeStreamingSelectQueryInfo(SelectQueryInfo info)
     return info;
 }
 
+PrewhereInfoPtr makeStreamingPrewhereInfo(PrewhereInfoPtr info)
+{
+    if (!info)
+        return nullptr;
+
+    auto patched_info = std::make_shared<PrewhereInfo>(info->clone());
+
+    /// This columns are needed for cursor calculation. Do not loose them during prewhere.
+    patched_info->prewhere_actions.tryRestoreColumn(PartitionIdColumn::name);
+    patched_info->prewhere_actions.tryRestoreColumn(BlockNumberColumn::name);
+    patched_info->prewhere_actions.tryRestoreColumn(BlockOffsetColumn::name);
+
+    return patched_info;
+}
+
 }
 
 MergeTreeCommitOrderSequentialSource::MergeTreeCommitOrderSequentialSource(
@@ -279,7 +294,7 @@ MergeTreeCommitOrderSequentialSource::MergeTreeCommitOrderSequentialSource(
     , header(std::move(header_))
     , storage(storage_)
     , query_info(makeStreamingSelectQueryInfo(query_info_))
-    , initial_prewhere_info(query_info_.prewhere_info)
+    , initial_prewhere_info(makeStreamingPrewhereInfo(query_info_.prewhere_info))
     , context(makeStreamingContext(std::move(context_)))
     , user_requested_columns(std::move(user_requested_columns_))
     , requested_num_streams(requested_num_streams_)

--- a/tests/queries/0_stateless/04297_streaming_virtual_columns_prewhere.reference
+++ b/tests/queries/0_stateless/04297_streaming_virtual_columns_prewhere.reference
@@ -1,0 +1,7 @@
+42
+
+****************
+Killing process
+Removing FIFO
+****************
+

--- a/tests/queries/0_stateless/04297_streaming_virtual_columns_prewhere.sh
+++ b/tests/queries/0_stateless/04297_streaming_virtual_columns_prewhere.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Tags: long
+
+CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CURDIR"/../shell_config.sh
+# shellcheck source=./streaming.lib
+. "$CURDIR"/streaming.lib
+
+$STREAMING_CLIENT -q "DROP TABLE IF EXISTS t_streaming_virtuals_prewhere"
+$STREAMING_CLIENT -q "CREATE TABLE t_streaming_virtuals_prewhere (a UInt64) ENGINE = MergeTree ORDER BY a SETTINGS $STREAMING_TABLE_SETTINGS"
+$STREAMING_CLIENT -q "INSERT INTO t_streaming_virtuals_prewhere VALUES (42)"
+
+# Filter by _partition_id, _block_number and _block_offset must not break internal cursor calculation.
+read -r fifo_1 pid_1 < <(spawn $STREAMING_CLIENT -q "SELECT a FROM t_streaming_virtuals_prewhere STREAM WHERE _partition_id = 'all' AND _block_number = 1 AND _block_offset = 0")
+read_until "$fifo_1" "42"
+
+cleanup "$fifo_1" "$pid_1"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

This patch fixes a problem where prewhere in the inner query removed via the filter DAG columns needed for the cursor calculation.

```
Not found column _block_number in block. There are only columns: a: While executing MergeTreeCommitOrderSequentialSource. (NOT_FOUND_COLUMN_IN_BLOCK) (version 26.6.1.1) (from 127.0.0.1:44470) (comment: 04297_streaming_virtual_columns_prewhere.sh-default) (query 1, line 1) (in query: SELECT a FROM t_streaming_virtuals_prewhere STREAM WHERE _partition_id = 'all' AND _block_number = 1 AND _block_offset = 0), Stack trace (when copying this message, always include the lines below):
```

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.232`
<!-- ch-version-info:end -->