### PR TITLE
Kernel Helper fixes

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -68,7 +68,14 @@ ffi::EngineBuilder * IKernelHelper::createBuilder() const
     catch (...)
     {
         /// The Rust FFI has no free_engine_builder; builder_build consumes it.
-        ffi::builder_build(builder);
+        /// The returned ExternResult owns either an engine handle (Ok) or an
+        /// error allocation (Err) — both must be released to avoid leaks.
+        try
+        {
+            auto engine = KernelUtils::unwrapResult(ffi::builder_build(builder), "createBuilder(cleanup)");
+            ffi::free_engine(engine);
+        }
+        catch (...) {} // NOLINT: preserve the original exception
         throw;
     }
 

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -75,7 +75,7 @@ ffi::EngineBuilder * IKernelHelper::createBuilder() const
             auto engine = KernelUtils::unwrapResult(ffi::builder_build(builder), "createBuilder(cleanup)");
             ffi::free_engine(engine);
         }
-        catch (...) {} // NOLINT: preserve the original exception
+        catch (...) {} // Ok: preserve the original exception
         throw;
     }
 

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -53,6 +53,28 @@ void setBuilderOptionChecked(ffi::EngineBuilder * builder, const std::string & n
 
 }
 
+ffi::EngineBuilder * IKernelHelper::createBuilder() const
+{
+    ffi::EngineBuilder * builder = KernelUtils::unwrapResult(
+        ffi::get_engine_builder(
+            KernelUtils::toDeltaString(getTableLocation()),
+            &KernelUtils::allocateError),
+        "get_engine_builder");
+
+    try
+    {
+        configureBuilder(builder);
+    }
+    catch (...)
+    {
+        /// The Rust FFI has no free_engine_builder; builder_build consumes it.
+        ffi::builder_build(builder);
+        throw;
+    }
+
+    return builder;
+}
+
 /// A helper class to manage S3-compatible storage types.
 class S3KernelHelper final : public IKernelHelper
 {
@@ -81,14 +103,9 @@ public:
 
     const std::string & getDataPath() const override { return url.key; }
 
-    ffi::EngineBuilder * createBuilder() const override
+private:
+    void configureBuilder(ffi::EngineBuilder * builder) const override
     {
-        ffi::EngineBuilder * builder = KernelUtils::unwrapResult(
-            ffi::get_engine_builder(
-                KernelUtils::toDeltaString(table_location),
-                &KernelUtils::allocateError),
-            "get_engine_builder");
-
         auto set_option = [&](const std::string & name, const std::string & value)
         {
             setBuilderOptionChecked(builder, name, value);
@@ -130,11 +147,8 @@ public:
             "has access_key_id: {}, has secret_access_key: {}, has token: {}",
             url.endpoint, url.uri_str, region, url.bucket, no_sign,
             !access_key_id.empty(), !secret_access_key.empty(), !token.empty());
-
-        return builder;
     }
 
-private:
     DB::S3::URI url;
     const std::string table_location;
     const std::shared_ptr<const DB::S3::Client> client;
@@ -166,14 +180,9 @@ public:
 
     const std::string & getDataPath() const override { return data_path; }
 
-    ffi::EngineBuilder * createBuilder() const override
+private:
+    void configureBuilder(ffi::EngineBuilder * builder) const override
     {
-        ffi::EngineBuilder * builder = KernelUtils::unwrapResult(
-            ffi::get_engine_builder(
-                KernelUtils::toDeltaString(table_location),
-                &KernelUtils::allocateError),
-            "get_engine_builder");
-
         auto set_option = [&](const std::string & name, const std::string & value)
         {
             setBuilderOptionChecked(builder, name, value);
@@ -293,11 +302,8 @@ public:
             log,
             "Using azure container: {}, data_path: {}",
             endpoint.container_name, data_path);
-
-        return builder;
     }
 
-private:
     const DB::AzureBlobStorage::ConnectionParams connection_params;
     const std::string table_location;
     const std::string data_path;
@@ -329,24 +335,14 @@ public:
 
     const std::string & getDataPath() const override { return path; }
 
-    ffi::EngineBuilder * createBuilder() const override
-    {
-        ffi::EngineBuilder * builder = KernelUtils::unwrapResult(
-            ffi::get_engine_builder(
-                KernelUtils::toDeltaString(table_location),
-                &KernelUtils::allocateError),
-            "get_engine_builder");
-
-        return builder;
-    }
-
 private:
     const std::string table_location;
     const std::string path;
 
     static std::string getTableLocation(const std::string & path)
     {
-        return "file://" + path + "/";
+        // Don't add double slash at the end of the path
+        return "file://" + path + (path.ends_with('/') ? "" : "/");
     }
 };
 }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -72,10 +72,13 @@ ffi::EngineBuilder * IKernelHelper::createBuilder() const
         /// error allocation (Err) — both must be released to avoid leaks.
         try
         {
-            auto engine = KernelUtils::unwrapResult(ffi::builder_build(builder), "createBuilder(cleanup)");
+            auto * engine = KernelUtils::unwrapResult(ffi::builder_build(builder), "createBuilder(cleanup)");
             ffi::free_engine(engine);
         }
-        catch (...) {} // Ok: preserve the original exception
+        catch (...)
+        {
+            DB::tryLogCurrentException(__PRETTY_FUNCTION__);
+        }
         throw;
     }
 

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -341,7 +341,7 @@ private:
 
     static std::string getTableLocation(const std::string & path)
     {
-        // Don't add double slash at the end of the path
+        /// Don't add double slash at the end of the path
         return "file://" + path + (path.ends_with('/') ? "" : "/");
     }
 };

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.h
@@ -33,7 +33,11 @@ public:
     /// Create "EngineBuilder" which allows to work with
     /// delta-kernel-rs ffi api and performs all interactions
     /// with object storage layer.
-    virtual ffi::EngineBuilder * createBuilder() const = 0;
+    ffi::EngineBuilder * createBuilder() const;
+
+protected:
+    /// Override to set storage-specific options on the builder.
+    virtual void configureBuilder(ffi::EngineBuilder *) const {}
 };
 
 using KernelHelperPtr = std::shared_ptr<IKernelHelper>;


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

1. If the Rust kernel builder configuration fails, consume it, then it won't leak. Fixes the CI leak: https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?PR=59140&sha=latest&name_0=PR&name_1=Stateless+tests+%28amd_asan_ubsan%2C+distributed+cache%2C+meta+in+keeper%2C+s3+storage%2C+parallel%2C+1%2F2%29 

2. For DeltaLake local tables, append a slash only if the path doesn't end with one already.

cc @Algunenano or @kssenii can you review?