### PR TITLE
CI: switch AI review to `gpt-5.5`

### DIFF
--- a/ci/jobs/copilot_review_job.py
+++ b/ci/jobs/copilot_review_job.py
@@ -259,7 +259,7 @@ def _run_copilot_once(prompt, robot_name):
             # </dev/null: ensure stdin is definitively non-interactive
             command=f"GH_CONFIG_DIR={shlex.quote(gh_config_dir)} "
                     f"copilot -p {shlex.quote(prompt)} --allow-all --no-ask-user "
-                    f"--add-dir . --model gpt-5.3-codex --effort xhigh < /dev/null",
+                    f"--add-dir . --model gpt-5.5 --effort xhigh < /dev/null",
             with_info=True,
         )
 
@@ -291,7 +291,7 @@ def _run_codex_once(prompt, robot_name):
 
         return Result.from_commands_run(
             name="codex review",
-            # -m gpt-5.3-codex: same model the Copilot CLI used, so
+            # -m gpt-5.5: same model the Copilot CLI uses, so
             #   review quality stays comparable across backends.
             # -s workspace-write: writable workspace + /tmp + CODEX_HOME,
             #   read-only elsewhere; sufficient for review output and
@@ -306,7 +306,7 @@ def _run_codex_once(prompt, robot_name):
             command=f"CODEX_HOME={shlex.quote(codex_home)} "
                     f"GH_CONFIG_DIR={shlex.quote(gh_config_dir)} "
                     f"codex exec "
-                    f"-m gpt-5.3-codex -c 'model_reasoning_effort=xhigh' "
+                    f"-m gpt-5.5 -c 'model_reasoning_effort=xhigh' "
                     f"-s workspace-write "
                     f"-c sandbox_workspace_write.network_access=true "
                     f"-c approval_policy=never "


### PR DESCRIPTION
Switch the custom AI review job from `gpt-5.3-codex` to `gpt-5.5` for both `copilot` and `codex exec` backends.

Motivation: in https://github.com/ClickHouse/ClickHouse/pull/105897, `gpt-5.3-codex` did not detect review issues, while `gpt-5.5` does. `Claude 4.7` didn't detect it either.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required.

### Documentation entry:
- [x] Documentation is not required for this CI-only change.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.205`
<!-- ch-version-info:end -->