### PR TITLE
Fix SYSTEM INSTRUMENT ADD argument formatting and validation

### DIFF
--- a/src/Interpreters/InstrumentationManager.cpp
+++ b/src/Interpreters/InstrumentationManager.cpp
@@ -24,6 +24,7 @@
 #include <llvm/XRay/InstrumentationMap.h>
 
 #include <chrono>
+#include <cmath>
 #include <filesystem>
 #include <thread>
 #include <random>
@@ -59,18 +60,27 @@ static Float64 getSleepArgumentValue(const InstrumentationManager::InstrumentedA
     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected numeric argument (Int64 or Float64) for sleep, but got something else");
 }
 
+static Float64 validateSleepArgumentValue(const InstrumentationManager::InstrumentedArgument & arg)
+{
+    auto value = getSleepArgumentValue(arg);
+    if (!std::isfinite(value))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Sleep duration must be finite");
+
+    return value;
+}
+
 static void validateSleepArguments(const std::vector<InstrumentationManager::InstrumentedArgument> & args)
 {
     if (args.empty() || args.size() > 2)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected one or two arguments for sleep instrumentation, but got {}", args.size());
 
-    auto min = getSleepArgumentValue(args[0]);
+    auto min = validateSleepArgumentValue(args[0]);
     if (min < 0)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Sleep duration must be non-negative");
 
     if (args.size() == 2)
     {
-        auto max = getSleepArgumentValue(args[1]);
+        auto max = validateSleepArgumentValue(args[1]);
         if (max < 0)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Sleep duration must be non-negative");
 

--- a/src/Interpreters/InstrumentationManager.cpp
+++ b/src/Interpreters/InstrumentationManager.cpp
@@ -49,6 +49,33 @@ static constexpr String PROFILE_HANDLER = "profile";
 
 static auto logger = getLogger("InstrumentationManager");
 
+static Float64 getSleepArgumentValue(const InstrumentationManager::InstrumentedArgument & arg)
+{
+    if (std::holds_alternative<Int64>(arg))
+        return static_cast<Float64>(std::get<Int64>(arg));
+    if (std::holds_alternative<Float64>(arg))
+        return std::get<Float64>(arg);
+
+    throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected numeric argument (Int64 or Float64) for sleep, but got something else");
+}
+
+static void validateSleepArguments(const std::vector<InstrumentationManager::InstrumentedArgument> & args)
+{
+    if (args.empty())
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Missing arguments for sleep instrumentation");
+
+    if (args.size() != 1 && args.size() != 2)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected one or two arguments for sleep instrumentation, but got {}", args.size());
+
+    auto min = getSleepArgumentValue(args[0]);
+    if (args.size() == 2)
+    {
+        auto max = getSleepArgumentValue(args[1]);
+        if (min > max)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Sleep minimum duration must be less than or equal to maximum duration");
+    }
+}
+
 namespace Instrumentation
 {
 
@@ -198,6 +225,9 @@ void InstrumentationManager::patchFunction(ContextPtr context, const String & fu
 
     if (std::ranges::none_of(handler_name_to_function, [&](const auto & pair) { return pair.first == handler_name_lower; }))
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Unknown XRay handler: ({})", handler_name);
+
+    if (handler_name_lower == SLEEP_HANDLER)
+        validateSleepArguments(arguments);
 
     /// Lazy load the XRay instrumentation map only once we need to set up a handler
     ensureInitialization();
@@ -441,29 +471,18 @@ void InstrumentationManager::sleep([[maybe_unused]] XRayEntryType entry_type, co
     static thread_local pcg64_fast random_generator{randomSeed()};
 
     const auto & args = instrumented_point.arguments;
-    if (args.empty())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Missing arguments for sleep instrumentation");
-
-    auto get_value = [](auto arg)
-    {
-        if (std::holds_alternative<Int64>(arg))
-            return static_cast<Float64>(std::get<Int64>(arg));
-        else if (std::holds_alternative<Float64>(arg))
-            return std::get<Float64>(arg);
-        else
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected numeric argument (Int64 or Float64) for sleep, but got something else");
-    };
+    validateSleepArguments(args);
 
     Int64 duration_ms = -1;
 
     if (args.size() == 1)
     {
-        duration_ms = static_cast<Int64>(1000 * get_value(args[0]));
+        duration_ms = static_cast<Int64>(1000 * getSleepArgumentValue(args[0]));
     }
     else
     {
-        auto min = get_value(args[0]);
-        auto max = get_value(args[1]);
+        auto min = getSleepArgumentValue(args[0]);
+        auto max = getSleepArgumentValue(args[1]);
 
         std::uniform_real_distribution<> distrib(min, max);
         duration_ms = static_cast<Int64>(1000 * distrib(random_generator));

--- a/src/Interpreters/InstrumentationManager.cpp
+++ b/src/Interpreters/InstrumentationManager.cpp
@@ -48,7 +48,6 @@ extern const int LOGICAL_ERROR;
 static constexpr String SLEEP_HANDLER = "sleep";
 static constexpr String LOG_HANDLER = "log";
 static constexpr String PROFILE_HANDLER = "profile";
-static constexpr Float64 MAX_SLEEP_DURATION_SECONDS = static_cast<Float64>(std::numeric_limits<Int64>::max()) / 1000.0;
 
 static auto logger = getLogger("InstrumentationManager");
 
@@ -62,14 +61,25 @@ static Float64 getSleepArgumentValue(const InstrumentationManager::InstrumentedA
     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected numeric argument (Int64 or Float64) for sleep, but got something else");
 }
 
+static Int64 getSleepDurationMilliseconds(Float64 seconds)
+{
+    if (!std::isfinite(seconds))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Sleep duration must be finite");
+
+    if (seconds < 0)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Sleep duration must be non-negative");
+
+    const auto milliseconds = static_cast<long double>(seconds) * 1000.0L;
+    if (milliseconds > static_cast<long double>(std::numeric_limits<Int64>::max()))
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Sleep duration is too large to represent in milliseconds");
+
+    return static_cast<Int64>(milliseconds);
+}
+
 static Float64 validateSleepArgumentValue(const InstrumentationManager::InstrumentedArgument & arg)
 {
     auto value = getSleepArgumentValue(arg);
-    if (!std::isfinite(value))
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Sleep duration must be finite");
-
-    if (value > MAX_SLEEP_DURATION_SECONDS)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Sleep duration must not exceed {} seconds", MAX_SLEEP_DURATION_SECONDS);
+    getSleepDurationMilliseconds(value);
 
     return value;
 }
@@ -80,14 +90,10 @@ static void validateSleepArguments(const std::vector<InstrumentationManager::Ins
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected one or two arguments for sleep instrumentation, but got {}", args.size());
 
     auto min = validateSleepArgumentValue(args[0]);
-    if (min < 0)
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Sleep duration must be non-negative");
 
     if (args.size() == 2)
     {
         auto max = validateSleepArgumentValue(args[1]);
-        if (max < 0)
-            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Sleep duration must be non-negative");
 
         if (min > max)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Sleep minimum duration must be less than or equal to maximum duration");
@@ -491,11 +497,11 @@ void InstrumentationManager::sleep([[maybe_unused]] XRayEntryType entry_type, co
     const auto & args = instrumented_point.arguments;
     validateSleepArguments(args);
 
-    Int64 duration_ms = -1;
+    Int64 duration_ms;
 
     if (args.size() == 1)
     {
-        duration_ms = static_cast<Int64>(1000 * getSleepArgumentValue(args[0]));
+        duration_ms = getSleepDurationMilliseconds(getSleepArgumentValue(args[0]));
     }
     else
     {
@@ -503,11 +509,8 @@ void InstrumentationManager::sleep([[maybe_unused]] XRayEntryType entry_type, co
         auto max = getSleepArgumentValue(args[1]);
 
         std::uniform_real_distribution<> distrib(min, max);
-        duration_ms = static_cast<Int64>(1000 * distrib(random_generator));
+        duration_ms = getSleepDurationMilliseconds(distrib(random_generator));
     }
-
-    if (duration_ms < 0)
-        throw DB::Exception(ErrorCodes::BAD_ARGUMENTS, "Sleep duration must be non-negative");
 
     LOG_TRACE(logger, "Sleep ({}, function_id {}): sleeping for {} ms", instrumented_point.function_name, instrumented_point.function_id, duration_ms);
     auto now = std::chrono::system_clock::now();

--- a/src/Interpreters/InstrumentationManager.cpp
+++ b/src/Interpreters/InstrumentationManager.cpp
@@ -26,6 +26,7 @@
 #include <chrono>
 #include <cmath>
 #include <filesystem>
+#include <limits>
 #include <thread>
 #include <random>
 #include <ranges>
@@ -47,6 +48,7 @@ extern const int LOGICAL_ERROR;
 static constexpr String SLEEP_HANDLER = "sleep";
 static constexpr String LOG_HANDLER = "log";
 static constexpr String PROFILE_HANDLER = "profile";
+static constexpr Float64 MAX_SLEEP_DURATION_SECONDS = static_cast<Float64>(std::numeric_limits<Int64>::max()) / 1000.0;
 
 static auto logger = getLogger("InstrumentationManager");
 
@@ -65,6 +67,9 @@ static Float64 validateSleepArgumentValue(const InstrumentationManager::Instrume
     auto value = getSleepArgumentValue(arg);
     if (!std::isfinite(value))
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Sleep duration must be finite");
+
+    if (value > MAX_SLEEP_DURATION_SECONDS)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Sleep duration must not exceed {} seconds", MAX_SLEEP_DURATION_SECONDS);
 
     return value;
 }

--- a/src/Interpreters/InstrumentationManager.cpp
+++ b/src/Interpreters/InstrumentationManager.cpp
@@ -61,10 +61,7 @@ static Float64 getSleepArgumentValue(const InstrumentationManager::InstrumentedA
 
 static void validateSleepArguments(const std::vector<InstrumentationManager::InstrumentedArgument> & args)
 {
-    if (args.empty())
-        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Missing arguments for sleep instrumentation");
-
-    if (args.size() != 1 && args.size() != 2)
+    if (args.size() == 0 || args.size() > 2)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected one or two arguments for sleep instrumentation, but got {}", args.size());
 
     auto min = getSleepArgumentValue(args[0]);

--- a/src/Interpreters/InstrumentationManager.cpp
+++ b/src/Interpreters/InstrumentationManager.cpp
@@ -65,9 +65,15 @@ static void validateSleepArguments(const std::vector<InstrumentationManager::Ins
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected one or two arguments for sleep instrumentation, but got {}", args.size());
 
     auto min = getSleepArgumentValue(args[0]);
+    if (min < 0)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Sleep duration must be non-negative");
+
     if (args.size() == 2)
     {
         auto max = getSleepArgumentValue(args[1]);
+        if (max < 0)
+            throw Exception(ErrorCodes::BAD_ARGUMENTS, "Sleep duration must be non-negative");
+
         if (min > max)
             throw Exception(ErrorCodes::BAD_ARGUMENTS, "Sleep minimum duration must be less than or equal to maximum duration");
     }

--- a/src/Interpreters/InstrumentationManager.cpp
+++ b/src/Interpreters/InstrumentationManager.cpp
@@ -61,7 +61,7 @@ static Float64 getSleepArgumentValue(const InstrumentationManager::InstrumentedA
 
 static void validateSleepArguments(const std::vector<InstrumentationManager::InstrumentedArgument> & args)
 {
-    if (args.size() == 0 || args.size() > 2)
+    if (args.empty() || args.size() > 2)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Expected one or two arguments for sleep instrumentation, but got {}", args.size());
 
     auto min = getSleepArgumentValue(args[0]);

--- a/src/Parsers/ASTSystemQuery.cpp
+++ b/src/Parsers/ASTSystemQuery.cpp
@@ -549,13 +549,8 @@ void ASTSystemQuery::formatImpl(WriteBuffer & ostr, const FormatSettings & setti
                     break;
             }
 
-            bool whitespace = false;
             for (const auto & arg : instrumentation_arguments)
             {
-                if (!whitespace)
-                    ostr << ' ';
-                else
-                    whitespace = true;
                 std::visit([&](const auto & value)
                 {
                     using T = std::decay_t<decltype(value)>;

--- a/tests/queries/0_stateless/04295_system_instrument_format_arguments.reference
+++ b/tests/queries/0_stateless/04295_system_instrument_format_arguments.reference
@@ -1,0 +1,3 @@
+SYSTEM INSTRUMENT ADD \'QueryMetricLog::startQuery\' LOG ENTRY \'msg\'
+SYSTEM INSTRUMENT ADD \'QueryMetricLog::startQuery\' SLEEP ENTRY 0.1 0.5
+SYSTEM INSTRUMENT ADD \'QueryMetricLog::startQuery\' SLEEP ENTRY 1 2 3

--- a/tests/queries/0_stateless/04295_system_instrument_format_arguments.sql
+++ b/tests/queries/0_stateless/04295_system_instrument_format_arguments.sql
@@ -1,0 +1,7 @@
+-- Tags: use-xray
+
+-- https://github.com/ClickHouse/ClickHouse/issues/105939
+
+EXPLAIN SYNTAX SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' LOG ENTRY 'msg';
+EXPLAIN SYNTAX SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 0.1 0.5;
+EXPLAIN SYNTAX SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 1 2 3;

--- a/tests/queries/0_stateless/04295_system_instrument_format_arguments.sql
+++ b/tests/queries/0_stateless/04295_system_instrument_format_arguments.sql
@@ -2,6 +2,6 @@
 
 -- https://github.com/ClickHouse/ClickHouse/issues/105939
 
-EXPLAIN SYNTAX SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' LOG ENTRY 'msg';
-EXPLAIN SYNTAX SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 0.1 0.5;
-EXPLAIN SYNTAX SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 1 2 3;
+SELECT formatQuerySingleLine('SYSTEM INSTRUMENT ADD ''QueryMetricLog::startQuery'' LOG ENTRY ''msg''');
+SELECT formatQuerySingleLine('SYSTEM INSTRUMENT ADD ''QueryMetricLog::startQuery'' SLEEP ENTRY 0.1 0.5');
+SELECT formatQuerySingleLine('SYSTEM INSTRUMENT ADD ''QueryMetricLog::startQuery'' SLEEP ENTRY 1 2 3');

--- a/tests/queries/0_stateless/04296_system_instrument_sleep_invalid_arguments.reference
+++ b/tests/queries/0_stateless/04296_system_instrument_sleep_invalid_arguments.reference
@@ -13,9 +13,13 @@ inf_duration
 0
 oversized_duration
 0
+rounded_boundary_duration
+0
 nan_min
 0
 inf_max
 0
 oversized_max
+0
+rounded_boundary_range
 0

--- a/tests/queries/0_stateless/04296_system_instrument_sleep_invalid_arguments.reference
+++ b/tests/queries/0_stateless/04296_system_instrument_sleep_invalid_arguments.reference
@@ -1,3 +1,9 @@
 0
 min_greater_than_max
 0
+negative_duration
+0
+negative_min
+0
+negative_max
+0

--- a/tests/queries/0_stateless/04296_system_instrument_sleep_invalid_arguments.reference
+++ b/tests/queries/0_stateless/04296_system_instrument_sleep_invalid_arguments.reference
@@ -1,0 +1,3 @@
+0
+min_greater_than_max
+0

--- a/tests/queries/0_stateless/04296_system_instrument_sleep_invalid_arguments.reference
+++ b/tests/queries/0_stateless/04296_system_instrument_sleep_invalid_arguments.reference
@@ -7,3 +7,15 @@ negative_min
 0
 negative_max
 0
+nan_duration
+0
+inf_duration
+0
+oversized_duration
+0
+nan_min
+0
+inf_max
+0
+oversized_max
+0

--- a/tests/queries/0_stateless/04296_system_instrument_sleep_invalid_arguments.sql
+++ b/tests/queries/0_stateless/04296_system_instrument_sleep_invalid_arguments.sql
@@ -8,3 +8,15 @@ SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_typ
 SELECT 'min_greater_than_max';
 SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 2 1; -- { serverError BAD_ARGUMENTS }
 SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[2, 1]';
+
+SELECT 'negative_duration';
+SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY -1; -- { serverError BAD_ARGUMENTS }
+SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[-1]';
+
+SELECT 'negative_min';
+SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY -1 1; -- { serverError BAD_ARGUMENTS }
+SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[-1, 1]';
+
+SELECT 'negative_max';
+SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 0 -1; -- { serverError BAD_ARGUMENTS }
+SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[0, -1]';

--- a/tests/queries/0_stateless/04296_system_instrument_sleep_invalid_arguments.sql
+++ b/tests/queries/0_stateless/04296_system_instrument_sleep_invalid_arguments.sql
@@ -20,3 +20,27 @@ SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_typ
 SELECT 'negative_max';
 SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 0 -1; -- { serverError BAD_ARGUMENTS }
 SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[0,-1]';
+
+SELECT 'nan_duration';
+SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY nan; -- { serverError BAD_ARGUMENTS }
+SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[nan]';
+
+SELECT 'inf_duration';
+SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY inf; -- { serverError BAD_ARGUMENTS }
+SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[inf]';
+
+SELECT 'oversized_duration';
+SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 1e20; -- { serverError BAD_ARGUMENTS }
+SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[100000000000000000000]';
+
+SELECT 'nan_min';
+SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY nan 1; -- { serverError BAD_ARGUMENTS }
+SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[nan,1]';
+
+SELECT 'inf_max';
+SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 0 inf; -- { serverError BAD_ARGUMENTS }
+SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[0,inf]';
+
+SELECT 'oversized_max';
+SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 0 1e20; -- { serverError BAD_ARGUMENTS }
+SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[0,100000000000000000000]';

--- a/tests/queries/0_stateless/04296_system_instrument_sleep_invalid_arguments.sql
+++ b/tests/queries/0_stateless/04296_system_instrument_sleep_invalid_arguments.sql
@@ -3,11 +3,11 @@
 -- https://github.com/ClickHouse/ClickHouse/pull/103854#discussion_r3235932168
 
 SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 0 1 2; -- { serverError BAD_ARGUMENTS }
-SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[0, 1, 2]';
+SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[0,1,2]';
 
 SELECT 'min_greater_than_max';
 SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 2 1; -- { serverError BAD_ARGUMENTS }
-SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[2, 1]';
+SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[2,1]';
 
 SELECT 'negative_duration';
 SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY -1; -- { serverError BAD_ARGUMENTS }
@@ -15,8 +15,8 @@ SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_typ
 
 SELECT 'negative_min';
 SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY -1 1; -- { serverError BAD_ARGUMENTS }
-SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[-1, 1]';
+SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[-1,1]';
 
 SELECT 'negative_max';
 SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 0 -1; -- { serverError BAD_ARGUMENTS }
-SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[0, -1]';
+SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[0,-1]';

--- a/tests/queries/0_stateless/04296_system_instrument_sleep_invalid_arguments.sql
+++ b/tests/queries/0_stateless/04296_system_instrument_sleep_invalid_arguments.sql
@@ -1,0 +1,6 @@
+-- Tags: use-xray
+
+-- https://github.com/ClickHouse/ClickHouse/pull/103854#discussion_r3235932168
+
+SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 0 1 2; -- { serverError BAD_ARGUMENTS }
+SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 2 1; -- { serverError BAD_ARGUMENTS }

--- a/tests/queries/0_stateless/04296_system_instrument_sleep_invalid_arguments.sql
+++ b/tests/queries/0_stateless/04296_system_instrument_sleep_invalid_arguments.sql
@@ -3,4 +3,8 @@
 -- https://github.com/ClickHouse/ClickHouse/pull/103854#discussion_r3235932168
 
 SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 0 1 2; -- { serverError BAD_ARGUMENTS }
+SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[0, 1, 2]';
+
+SELECT 'min_greater_than_max';
 SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 2 1; -- { serverError BAD_ARGUMENTS }
+SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[2, 1]';

--- a/tests/queries/0_stateless/04296_system_instrument_sleep_invalid_arguments.sql
+++ b/tests/queries/0_stateless/04296_system_instrument_sleep_invalid_arguments.sql
@@ -33,6 +33,10 @@ SELECT 'oversized_duration';
 SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 1e20; -- { serverError BAD_ARGUMENTS }
 SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[100000000000000000000]';
 
+SELECT 'rounded_boundary_duration';
+SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 9223372036854776; -- { serverError BAD_ARGUMENTS }
+SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[9223372036854776]';
+
 SELECT 'nan_min';
 SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY nan 1; -- { serverError BAD_ARGUMENTS }
 SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[nan,1]';
@@ -44,3 +48,7 @@ SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_typ
 SELECT 'oversized_max';
 SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 0 1e20; -- { serverError BAD_ARGUMENTS }
 SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[0,100000000000000000000]';
+
+SELECT 'rounded_boundary_range';
+SYSTEM INSTRUMENT ADD 'QueryMetricLog::startQuery' SLEEP ENTRY 9223372036854776 9223372036854776; -- { serverError BAD_ARGUMENTS }
+SELECT count() FROM system.instrumentation WHERE handler = 'sleep' AND entry_type = 'Entry' AND toString(arguments) = '[9223372036854776,9223372036854776]';


### PR DESCRIPTION
Fixes two `SYSTEM INSTRUMENT ADD` edge cases found around #103854.

Formatted queries now print handler arguments with a single separator. The `SLEEP`
handler now validates its documented contract at add time: exactly one duration or a
`min max` range. It rejects extra arguments and reversed ranges before constructing
`std::uniform_real_distribution`.

Closes #105939.
Addresses https://github.com/ClickHouse/ClickHouse/pull/103854#discussion_r3235932168.

Local validation included `cmake --build build -- clickhouse`, repeated stateless
tests for the new regressions, repeated `03642_system_instrument_sleep`,
`ci/jobs/scripts/check_style/check_cpp.sh`, and
`ci/jobs/scripts/check_style/various_checks.sh`.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `SYSTEM INSTRUMENT ADD` formatting so handler arguments are separated by a single space, and reject invalid `SLEEP` instrumentation argument lists with more than two values or a range where the minimum is greater than the maximum.

### Documentation entry for user-facing changes
- [x] Documentation is not required.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.231`
<!-- ch-version-info:end -->