### PR TITLE
Bump libxml2 from 2.15.1 to 2.15.3

### DIFF
--- a/contrib/libxml2-cmake/linux_x86_64/include/config.h
+++ b/contrib/libxml2-cmake/linux_x86_64/include/config.h
@@ -77,7 +77,7 @@
 #define PACKAGE_NAME "libxml2"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libxml2 2.15.1"
+#define PACKAGE_STRING "libxml2 2.15.3"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libxml2"
@@ -86,7 +86,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.15.1"
+#define PACKAGE_VERSION "2.15.3"
 
 /* Define to 1 if all of the C90 standard headers exist (not just the ones
    required in a freestanding environment). This macro is provided for
@@ -94,7 +94,7 @@
 #define STDC_HEADERS 1
 
 /* Version number of package */
-#define VERSION "2.15.1"
+#define VERSION "2.15.3"
 
 /* System configuration directory (/etc) */
 #define XML_SYSCONFDIR "/usr/local/etc"

--- a/contrib/libxml2-cmake/linux_x86_64/include/libxml/xmlversion.h
+++ b/contrib/libxml2-cmake/linux_x86_64/include/libxml/xmlversion.h
@@ -16,17 +16,17 @@
 /**
  * the version string like "1.2.3"
  */
-#define LIBXML_DOTTED_VERSION "2.15.1"
+#define LIBXML_DOTTED_VERSION "2.15.3"
 
 /**
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXML_VERSION 21501
+#define LIBXML_VERSION 21503
 
 /**
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXML_VERSION_STRING "21501"
+#define LIBXML_VERSION_STRING "21503"
 
 /**
  * extra version information, used to show a git commit description
@@ -37,7 +37,7 @@
  * Macro to check that the libxml version in use is compatible with
  * the version the software has been compiled against
  */
-#define LIBXML_TEST_VERSION xmlCheckVersion(21501);
+#define LIBXML_TEST_VERSION xmlCheckVersion(21503);
 
 #if 1
 /**


### PR DESCRIPTION
Routine patch-level bump of the `contrib/libxml2` submodule from `v2.15.1`
to `v2.15.3`. Upstream changes are mostly bug fixes — memory leaks in
schematron and schemas error paths, a stack overflow from self-referencing
SGML catalogs, signed-integer overflow in `xmlBuildRelativeURISafe`, type
confusion in `xmlC14NProcessAttrsAxis`, and several smaller fixes around
`xmlCopyEntity`, `xmlReaderForFd`, `xmlStrncat`, and
`xmlCatalogResolveCache`. Public header changes are additive only
(`xmlCatalogDumpDoc`, `xmlRelaxParserSetIncLImit`), no new source files
joined the build, so on the ClickHouse side only the pre-generated
`config.h` and `xmlversion.h` version strings needed updating. Verified
with a full `clickhouse` build in `build/Debug-public`.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Updated `libxml2` from 2.15.1 to 2.15.3.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.265`
- Backported to: `26.5.2.26`, `26.4.5.16`, `26.3.14.14`, `25.8.25.21`
<!-- ch-version-info:end -->