### PR TITLE
Use `postgres` REL_18_4

### DIFF
--- a/contrib/postgres-cmake/CMakeLists.txt
+++ b/contrib/postgres-cmake/CMakeLists.txt
@@ -56,6 +56,7 @@ set(SRCS
     "${POSTGRES_SOURCE_DIR}/src/port/pgstrcasecmp.c"
     "${POSTGRES_SOURCE_DIR}/src/port/pg_bitutils.c"
     "${POSTGRES_SOURCE_DIR}/src/port/path.c"
+    "${POSTGRES_SOURCE_DIR}/src/port/timingsafe_bcmp.c"
 )
 
 if(NOT OS_DARWIN)

--- a/contrib/postgres-cmake/pg_config.h
+++ b/contrib/postgres-cmake/pg_config.h
@@ -618,19 +618,24 @@
 #define PG_MAJORVERSION_NUM 18
 
 /* PostgreSQL minor version number */
-#define PG_MINORVERSION_NUM 3
+#define PG_MINORVERSION_NUM 4
 
-/* Define to best printf format archetype, usually gnu_printf if available. */
-#define PG_PRINTF_ATTRIBUTE gnu_printf
+/* Define to best C++ printf format archetype, usually gnu_printf if
+   available. */
+#define PG_CXX_PRINTF_ATTRIBUTE gnu_printf
+
+/* Define to best C printf format archetype, usually gnu_printf if available.
+   */
+#define PG_C_PRINTF_ATTRIBUTE gnu_printf
 
 /* PostgreSQL version as a string */
-#define PG_VERSION "18.3"
+#define PG_VERSION "18.4"
 
 /* PostgreSQL version as a number */
-#define PG_VERSION_NUM 180003
+#define PG_VERSION_NUM 180004
 
 /* A string containing the version number, platform, and C compiler */
-#define PG_VERSION_STR "PostgreSQL 18.3 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 15.2.1 20250813, 64-bit"
+#define PG_VERSION_STR "PostgreSQL 18.4 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 15.2.1 20250813, 64-bit"
 
 /* Define to 1 to allow profiling output to be saved separately for each
    process. */


### PR DESCRIPTION
Bumps the vendored PostgreSQL sources used to build libpq from REL_18_3 to REL_18_4.

Build adjustments:
- Added `src/port/timingsafe_bcmp.c` to the libpq source list; upstream switched SCRAM authentication paths to use constant-time `timingsafe_bcmp` instead of `memcmp`.
- Split `PG_PRINTF_ATTRIBUTE` into `PG_C_PRINTF_ATTRIBUTE` and `PG_CXX_PRINTF_ATTRIBUTE` in `pg_config.h` to match the upstream rework in `src/include/c.h`.
- Bumped `PG_VERSION`, `PG_VERSION_NUM` and `PG_MINORVERSION_NUM` to `18.4`.

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Use `postgres` REL_18_4.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.262`
- Backported to: `26.5.2.28`, `26.4.5.22`, `26.3.14.8`, `25.8.25.10`
<!-- ch-version-info:end -->