### PR TITLE
Fix TSan data race in Parquet reader

### DIFF
--- a/src/Processors/Formats/Impl/Parquet/Prefetcher.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Prefetcher.cpp
@@ -5,6 +5,7 @@
 #include <IO/SeekableReadBuffer.h>
 #include <IO/WithFileSize.h>
 #include <IO/WriteBufferFromVector.h>
+#include <Common/Exception.h>
 #include <Common/ProfileEvents.h>
 
 #include <shared_mutex>
@@ -13,7 +14,6 @@ namespace DB::ErrorCodes
 {
     extern const int INCORRECT_DATA;
     extern const int LOGICAL_ERROR;
-    extern const int CANNOT_READ_ALL_DATA;
 }
 
 namespace ProfileEvents
@@ -550,14 +550,8 @@ Prefetcher::Task::State Prefetcher::runTask(Task * task)
 void Prefetcher::rethrowException(Task * task)
 {
     std::lock_guard lock(exception_mutex);
-    if (task->exception)
-        std::rethrow_exception(task->exception);
-    else
-        /// exception_ptr is not copyable, so we rethrow the correct exception only the first time,
-        /// then throw uninformative exceptions if called again (e.g. for multiple requests covered
-        /// by the same task). Hopefully the first thrown exception will usually be propagated to
-        /// the user.
-        throw Exception(ErrorCodes::CANNOT_READ_ALL_DATA, "Read failed");
+    /// Each waiter gets a private copy so callers can safely mutate it (addMessage())
+    std::rethrow_exception(copyMutableException(task->exception));
 }
 
 PrefetchHandle::PrefetchHandle(RequestState * request_) : request(request_) {}


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix TSan data race in Parquet reader

Parquet::ReadManager::runBatchOfTasks() can mutate exception, while Prefetcher::runTask() may rethrow the same exception, and so runBatchOfTasks() may have a data-race

TSan report - https://pastila.nl/?003169db/e279818b622dcecc6ea34bdbbecc2504#9p8Zaqb6CrjGOd9QAF8JjA==GCM

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.261`
<!-- ch-version-info:end -->