### PR TITLE
Push outer WHERE through Distributed subqueries containing a JOIN

### DIFF
--- a/src/Processors/QueryPlan/ReadFromRemote.cpp
+++ b/src/Processors/QueryPlan/ReadFromRemote.cpp
@@ -490,9 +490,36 @@ static void addFilters(
         return;
 
     auto table_expressions = extractTableExpressions(query_node->getJoinTree());
-    /// Case with JOIN is not supported so far.
+
+    /// If the inner subquery joins multiple tables, we cannot use the
+    /// single-table column-rewriting path below. Push the predicate as a
+    /// HAVING on the subquery directly — the predicate's identifiers already
+    /// reference the subquery's projection names (see `tryBuildAdditionalFilterAST`
+    /// above), and the downstream analyzer turns HAVING without GROUP BY into
+    /// WHERE and pushes it through the JOIN onto the eligible side. This is
+    /// the JOIN-aware version of the rewrite that `PredicateRewriteVisitor`
+    /// would otherwise perform on a single table. Closes #105855.
     if (table_expressions.size() != 1)
+    {
+        auto & select_query = getSelectQuery(query_ast);
+
+        /// Same set of guardrails as `PredicateRewriteVisitor::rewriteSubquery`
+        /// for the single-table case: bail when pushing the predicate would
+        /// change the semantics of the subquery.
+        bool optimize_final = settings[Setting::enable_optimize_predicate_expression_to_final_subquery];
+        bool optimize_with = settings[Setting::allow_push_predicate_when_subquery_contains_with];
+        if ((!optimize_final && select_query.final())
+            || (select_query.with() && !optimize_with)
+            || select_query.withFill()
+            || select_query.limitBy() || select_query.limitLength() || select_query.limitByLength() || select_query.limitByOffset()
+            || (select_query.orderBy() && select_query.limitOffset()))
+            return;
+
+        ASTPtr existing_having = select_query.having();
+        select_query.setExpression(ASTSelectQuery::Expression::HAVING,
+            existing_having ? makeASTOperator("and", predicate, existing_having) : predicate);
         return;
+    }
 
     const auto * table_node = table_expressions.front()->as<TableNode>();
     if (!table_node)

--- a/tests/queries/0_stateless/04277_105855_distributed_filter_pushdown_through_join.reference
+++ b/tests/queries/0_stateless/04277_105855_distributed_filter_pushdown_through_join.reference
@@ -1,0 +1,2 @@
+remote_subquery_has_predicate
+1

--- a/tests/queries/0_stateless/04277_105855_distributed_filter_pushdown_through_join.sql
+++ b/tests/queries/0_stateless/04277_105855_distributed_filter_pushdown_through_join.sql
@@ -1,0 +1,85 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/105855
+--
+-- Before the fix, the new analyzer did not push an outer `WHERE` through a
+-- subquery containing a `LEFT JOIN` onto a `Distributed` (or `remote(...)`)
+-- table — the predicate stayed on the initiator, so every shard ran the
+-- full join over its entire data before the predicate filtered the result.
+--
+-- The bailout was in `addFilters` in `ReadFromRemote.cpp` ("Case with JOIN
+-- is not supported so far."). The fix lets the predicate ride into the
+-- subquery sent to shards as a `HAVING`, which the downstream analyzer
+-- promotes to `WHERE` and pushes through the JOIN onto the eligible side.
+
+-- Tags: no-random-merge-tree-settings, no-parallel-replicas
+
+SET enable_analyzer = 1;
+SET allow_push_predicate_ast_for_distributed_subqueries = 1;
+SET prefer_localhost_replica = 0;
+SET enable_parallel_replicas = 0;
+SET joined_subquery_requires_alias = 0;
+
+DROP TABLE IF EXISTS t_left_join_pushdown_left;
+DROP TABLE IF EXISTS t_left_join_pushdown_right;
+
+CREATE TABLE t_left_join_pushdown_left
+(
+    col1 UInt64,
+    col2 UInt32,
+    col3 String,
+    timestamp DateTime
+)
+ENGINE = MergeTree
+ORDER BY (timestamp);
+
+CREATE TABLE t_left_join_pushdown_right
+(
+    col2 UInt32,
+    lookup String
+)
+ENGINE = MergeTree
+ORDER BY col2;
+
+INSERT INTO t_left_join_pushdown_left
+SELECT number, number % 100, 'a' || toString(number % 1000), toDateTime('2026-05-20 00:00:00') + INTERVAL number SECOND
+FROM numbers(10000);
+
+INSERT INTO t_left_join_pushdown_right
+SELECT number, 'lk' || toString(number) FROM numbers(500);
+
+-- Run the buggy form (outer WHERE on a subquery containing a JOIN to
+-- a remote table). After the fix, the SQL that ClickHouse serializes
+-- to remote shards must include a HAVING/WHERE that carries the
+-- outer-query predicate. Before the fix, the remote received the
+-- unfiltered `SELECT * FROM left LEFT JOIN right` and ran the full
+-- join over its entire dataset before the initiator filtered.
+SET log_queries = 1;
+SELECT col1
+FROM (
+    SELECT *
+    FROM remote('127.0.0.{1,2}', currentDatabase(), t_left_join_pushdown_left)
+    LEFT JOIN t_left_join_pushdown_right USING (col2)
+)
+WHERE timestamp >= '2026-05-20 00:00:10'
+  AND timestamp < '2026-05-20 00:00:20'
+  AND col3 = 'a50'
+FORMAT Null;
+
+SYSTEM FLUSH LOGS query_log;
+
+-- Inspect the SQL the initiator actually sent to the shards.
+-- After the fix it must contain the outer-query predicate (visible
+-- through any of the column names referenced by the WHERE — we use
+-- `col3` and the `'a50'` literal since either alone is specific enough
+-- to be unambiguous in this test).
+SELECT 'remote_subquery_has_predicate';
+SELECT
+    countIf(query ILIKE '%a50%') > 0 AND countIf(query ILIKE '%LEFT JOIN%') > 0
+        AS remote_query_carries_outer_where
+FROM system.query_log
+WHERE type = 'QueryStart'
+  AND is_initial_query = 0
+  AND query ILIKE concat('%', currentDatabase(), '%t_left_join_pushdown_left%')
+  AND event_time >= now() - INTERVAL 5 MINUTE;
+
+DROP TABLE t_left_join_pushdown_left;
+DROP TABLE t_left_join_pushdown_right;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/105855

With the new analyzer, an outer `WHERE` on a subquery containing a `LEFT JOIN` onto a `Distributed` (or `remote(...)`) table was not pushed into the SQL sent to remote shards. Each shard ran the unfiltered `SELECT * FROM dist LEFT JOIN small` over its entire data, and the initiator-side `Filter` then discarded the rows that did not satisfy the `WHERE`. The reporter (Axis Communications) saw a 2-minute timeout on a 60-billion-row distributed table; moving the `WHERE` inside the subquery returned the same result instantly. The old analyzer handled the same query correctly.

Root cause: `addFilters` in `src/Processors/QueryPlan/ReadFromRemote.cpp` runs after QueryPlan-level pushdown has computed the predicate and attached it to the `ReadFromRemote` step. Its job is to graft that predicate into the SQL string serialized to each shard. For a single-table inner subquery it delegates to `PredicateRewriteVisitor::rewriteSubquery`, which rewrites the predicate identifiers against the inner table and appends them to the subquery's `WHERE`. For a multi-table inner subquery it returned early with the literal comment `Case with JOIN is not supported so far.`, so the SQL sent to each shard was the unfiltered join.

Fix: in the JOIN case, attach the predicate to the inner subquery's `HAVING`. The predicate identifiers already reference the subquery's projection names (built just above by `tryBuildAdditionalFilterAST`), so no column rewriting is required. A pre-existing inner `HAVING` is preserved via `and`. On the shard, `PredicateExpressionsOptimizer::tryMovePredicatesFromHavingToWhere` moves the non-aggregate conjuncts from `HAVING` into `WHERE`, after which the standard JOIN-side pushdown rules apply per join kind (the preserved side for `LEFT` / `RIGHT`, either side for `INNER`). Structural guardrails from the single-table path are applied (`final` / `with` / `withFill` / `LIMIT BY` / `LIMIT OFFSET` / `ORDER BY + LIMIT OFFSET`) so subquery semantics are preserved.

Test `tests/queries/0_stateless/04277_105855_distributed_filter_pushdown_through_join.sql` runs the buggy form (outer `WHERE` over a subquery whose inner `FROM` is `LEFT JOIN` onto `remote('127.0.0.{1,2}', ...)`), flushes `system.query_log`, and asserts that the shard-side query (`is_initial_query = 0`) carries both `LEFT JOIN` and the outer-`WHERE` literal — i.e. the predicate rode into the subquery sent to shards rather than being applied only on the initiator.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed missing predicate pushdown in the new analyzer when an outer `WHERE` references columns from a subquery containing a `JOIN` onto a `Distributed` (or `remote(...)`) table. Previously the predicate was applied on the initiator after the remote shards had run the full join; now it is pushed into the inner subquery sent to shards, so each shard filters at its source.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)