### PR TITLE
Fix mis-ordering with read_in_order_use_virtual_row_per_block on wide partial reads

### DIFF
--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
@@ -311,14 +311,41 @@ void MergeTreeSelectProcessor::setVirtualRowConversions(
     read_in_reverse_order = read_in_reverse_order_;
 }
 
+ChunkAndProgress MergeTreeSelectProcessor::makeVirtualRowChunk(
+    const MergeTreeReadTask & current_task, Block pk_block) const
+{
+    const auto & data_part = current_task.getInfo().data_part;
+
+    Columns empty_columns;
+    empty_columns.reserve(result_header.columns());
+    for (size_t i = 0; i < result_header.columns(); ++i)
+        empty_columns.push_back(result_header.getByPosition(i).type->createColumn()->cloneEmpty());
+
+    Chunk chunk(std::move(empty_columns), 0);
+    auto part_level = data_part->info.level;
+    chunk.getChunkInfos().add(std::make_shared<MergeTreeReadInfo>(part_level, pk_block, virtual_row_conversions));
+
+    return {std::move(chunk), 0, 0, false, {}};
+}
+
 ChunkAndProgress MergeTreeSelectProcessor::buildVirtualRowFromIndex(
-    const MergeTreeReadTask & current_task, const MarkRanges & read_mark_ranges) const
+    const MergeTreeReadTask & current_task, const MarkRanges & read_mark_ranges, size_t num_read_rows) const
 {
     if (!virtual_row_conversions || read_mark_ranges.empty())
         return {};
 
     const auto & data_part = current_task.getInfo().data_part;
     const auto & index = data_part->getIndex();
+
+    /// The index-based key only correctly bounds the next chunk's data when this chunk's
+    /// physical reads exactly cover the granules listed in `read_mark_ranges`. When the
+    /// chunk started or ended mid-granule (possible only for wide parts, which allow
+    /// partial-granule reads), some rows of those granules live in adjacent chunks, so
+    /// `index[next_mark]` would be a much looser bound than the actual next data and
+    /// would mis-signal `MergingSortedTransform` to deprioritize this source.
+    size_t expected_rows = data_part->index_granularity->getRowsCountInRanges(read_mark_ranges);
+    if (num_read_rows != expected_rows)
+        return {};
 
     /// Forward order: the source will next produce data starting at back().end.
     /// Reverse order: MergeTreeInReverseOrderSelectAlgorithm returns chunks in reverse.
@@ -345,18 +372,50 @@ ChunkAndProgress MergeTreeSelectProcessor::buildVirtualRowFromIndex(
         column->insert((*(*index)[j])[next_mark]);
         pk_columns.push_back({std::move(column), header_col.type, header_col.name});
     }
-    Block pk_block(std::move(pk_columns));
+    return makeVirtualRowChunk(current_task, Block(std::move(pk_columns)));
+}
 
-    Columns empty_columns;
-    empty_columns.reserve(result_header.columns());
-    for (size_t i = 0; i < result_header.columns(); ++i)
-        empty_columns.push_back(result_header.getByPosition(i).type->createColumn()->cloneEmpty());
+ChunkAndProgress MergeTreeSelectProcessor::buildVirtualRowFromChunk(
+    const MergeTreeReadTask & current_task, const Chunk & data_chunk) const
+{
+    if (!virtual_row_conversions || data_chunk.getNumRows() == 0)
+        return {};
 
-    Chunk chunk(std::move(empty_columns), 0);
-    auto part_level = data_part->info.level;
-    chunk.getChunkInfos().add(std::make_shared<MergeTreeReadInfo>(part_level, pk_block, virtual_row_conversions));
+    size_t num_pk_columns = pk_block_header.columns();
 
-    return {std::move(chunk), 0, 0, false, {}};
+    /// PK columns must be present in `result_header` (i.e. the query selects them or they
+    /// were pulled in for sorting). Without them we cannot extract a tight boundary key.
+    std::vector<size_t> pk_positions;
+    pk_positions.reserve(num_pk_columns);
+    for (size_t j = 0; j < num_pk_columns; ++j)
+    {
+        const auto & pk_col_name = pk_block_header.getByPosition(j).name;
+        if (!result_header.has(pk_col_name))
+            return {};
+        pk_positions.push_back(result_header.getPositionByName(pk_col_name));
+    }
+
+    /// Forward: data is in ascending PK order. Last row's PK is the MAX value the merge
+    ///   just saw from this source, so it is a tight lower bound on the next data's PK.
+    /// Reverse: chunks are read forward (ascending PK) and emitted last-row-first by
+    ///   `ReverseTransform` downstream. After the chunk's reversed data is consumed, the
+    ///   next emitted value is bounded above by the chunk's FIRST forward row's PK.
+    size_t source_row = read_in_reverse_order ? 0 : (data_chunk.getNumRows() - 1);
+
+    const auto & data_columns = data_chunk.getColumns();
+    ColumnsWithTypeAndName pk_columns;
+    pk_columns.reserve(num_pk_columns);
+    for (size_t j = 0; j < num_pk_columns; ++j)
+    {
+        const auto & header_col = pk_block_header.getByPosition(j);
+        auto column = header_col.column->cloneEmpty();
+        /// Source may be wrapped (sparse, const, low-cardinality, replicated). `insertFrom`
+        /// requires a representation compatible with the destination, so fully materialize.
+        ColumnPtr source_column = data_columns[pk_positions[j]]->convertToFullIfNeeded();
+        column->insertFrom(*source_column, source_row);
+        pk_columns.push_back({std::move(column), header_col.type, header_col.name});
+    }
+    return makeVirtualRowChunk(current_task, Block(std::move(pk_columns)));
 }
 
 ChunkAndProgress MergeTreeSelectProcessor::read()
@@ -429,13 +488,20 @@ ChunkAndProgress MergeTreeSelectProcessor::read()
 
         auto result = readCurrentTask(*task, *algorithm);
 
-        /// Emit a virtual row update after each block, carrying the next mark's PK boundary.
+        /// Emit a virtual row update after each block, carrying the next chunk's PK boundary.
         /// This allows MergingSortedTransform to reprioritize sources when:
         /// - PREWHERE filters all rows (merge gets updated position without actual data)
         /// - A downstream filter (WHERE, JOIN) removes all rows (virtual row passes through filters)
+        ///
+        /// Prefer extracting the boundary key from the chunk's actual data — it is always a
+        /// tight, correct bound on the next data's PK regardless of granule alignment.
+        /// Fall back to the index-based boundary when the chunk has no surviving data (e.g.
+        /// PREWHERE filtered everything) or when the PK columns are not part of the result.
         if (virtual_row_conversions && !result.is_finished)
         {
-            auto vrow = buildVirtualRowFromIndex(*task, result.read_mark_ranges);
+            auto vrow = buildVirtualRowFromChunk(*task, result.chunk);
+            if (!vrow.chunk)
+                vrow = buildVirtualRowFromIndex(*task, result.read_mark_ranges, result.num_read_rows);
             if (vrow.chunk)
                 pending_virtual_row.emplace(std::move(vrow));
         }

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
@@ -383,8 +383,11 @@ ChunkAndProgress MergeTreeSelectProcessor::buildVirtualRowFromChunk(
 
     size_t num_pk_columns = pk_block_header.columns();
 
-    /// PK columns must be present in `result_header` (i.e. the query selects them or they
-    /// were pulled in for sorting). Without them we cannot extract a tight boundary key.
+    /// `pk_block_header` carries the AST identifiers of the PK expression
+    /// (`primary_key.column_names[j]`). For an identity PK column this is the source column
+    /// name and `result_header.has` succeeds; for an expression PK like
+    /// `toStartOfMonth(date)` the chunk has only `date`, so the lookup fails and we fall
+    /// back to `buildVirtualRowFromIndex` (the index file stores the *evaluated* PK).
     std::vector<size_t> pk_positions;
     pk_positions.reserve(num_pk_columns);
     for (size_t j = 0; j < num_pk_columns; ++j)
@@ -409,10 +412,8 @@ ChunkAndProgress MergeTreeSelectProcessor::buildVirtualRowFromChunk(
     {
         const auto & header_col = pk_block_header.getByPosition(j);
         auto column = header_col.column->cloneEmpty();
-        /// Round-trip through `Field` so insertion works for any column representation on
-        /// either side (sparse / const / `LowCardinality` / replicated source, and the
-        /// destination is `ColumnLowCardinality` when the PK type is `LowCardinality(...)`).
-        /// Called once per chunk, so the `Field` cost is negligible.
+        /// Round-trip through `Field`: type-agnostic at the `IColumn` API and handles every
+        /// column kind (sparse / const / `LowCardinality`) on both sides. One call per chunk.
         Field field;
         data_columns[pk_positions[j]]->get(source_row, field);
         column->insert(field);

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
@@ -409,10 +409,13 @@ ChunkAndProgress MergeTreeSelectProcessor::buildVirtualRowFromChunk(
     {
         const auto & header_col = pk_block_header.getByPosition(j);
         auto column = header_col.column->cloneEmpty();
-        /// Source may be wrapped (sparse, const, low-cardinality, replicated). `insertFrom`
-        /// requires a representation compatible with the destination, so fully materialize.
-        ColumnPtr source_column = data_columns[pk_positions[j]]->convertToFullIfNeeded();
-        column->insertFrom(*source_column, source_row);
+        /// Round-trip through `Field` so insertion works for any column representation on
+        /// either side (sparse / const / `LowCardinality` / replicated source, and the
+        /// destination is `ColumnLowCardinality` when the PK type is `LowCardinality(...)`).
+        /// Called once per chunk, so the `Field` cost is negligible.
+        Field field;
+        data_columns[pk_positions[j]]->get(source_row, field);
+        column->insert(field);
         pk_columns.push_back({std::move(column), header_col.type, header_col.name});
     }
     return makeVirtualRowChunk(current_task, Block(std::move(pk_columns)));
@@ -493,7 +496,7 @@ ChunkAndProgress MergeTreeSelectProcessor::read()
         /// - PREWHERE filters all rows (merge gets updated position without actual data)
         /// - A downstream filter (WHERE, JOIN) removes all rows (virtual row passes through filters)
         ///
-        /// Prefer extracting the boundary key from the chunk's actual data — it is always a
+        /// Prefer extracting the boundary key from the chunk's actual data: it is always a
         /// tight, correct bound on the next data's PK regardless of granule alignment.
         /// Fall back to the index-based boundary when the chunk has no surviving data (e.g.
         /// PREWHERE filtered everything) or when the PK columns are not part of the result.

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.h
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.h
@@ -195,7 +195,9 @@ private:
     bool read_in_reverse_order = false;
     std::optional<ChunkAndProgress> pending_virtual_row;
 
-    ChunkAndProgress buildVirtualRowFromIndex(const MergeTreeReadTask & current_task, const MarkRanges & read_mark_ranges) const;
+    ChunkAndProgress makeVirtualRowChunk(const MergeTreeReadTask & current_task, Block pk_block) const;
+    ChunkAndProgress buildVirtualRowFromIndex(const MergeTreeReadTask & current_task, const MarkRanges & read_mark_ranges, size_t num_read_rows) const;
+    ChunkAndProgress buildVirtualRowFromChunk(const MergeTreeReadTask & current_task, const Chunk & data_chunk) const;
 
     LoggerPtr log = getLogger("MergeTreeSelectProcessor");
     std::atomic<bool> is_cancelled{false};

--- a/tests/queries/0_stateless/04301_virtual_row_per_block_wide_partial_granule.reference
+++ b/tests/queries/0_stateless/04301_virtual_row_per_block_wide_partial_granule.reference
@@ -1,0 +1,4 @@
+desc PK monotonic	1
+asc PK monotonic	1
+desc CounterID2 ordered	1
+asc CounterID2 ordered	1

--- a/tests/queries/0_stateless/04301_virtual_row_per_block_wide_partial_granule.sql
+++ b/tests/queries/0_stateless/04301_virtual_row_per_block_wide_partial_granule.sql
@@ -1,0 +1,63 @@
+-- Tags: no-random-merge-tree-settings, no-random-settings, long
+-- Regression for https://github.com/ClickHouse/ClickHouse/issues for the per-block
+-- virtual row mis-ordering introduced by `read_in_order_use_virtual_row_per_block`
+-- when wide-part readers (which can read partial granules) produce chunks whose
+-- physical data spans only part of the granules listed in `read_mark_ranges`.
+--
+-- Trigger:
+--   * `min_bytes_for_wide_part = 0`             (force wide parts)
+--   * `index_granularity = 28454` (large)        (granule larger than one block)
+--   * `max_block_size = 14633` (smaller)        (granule split across blocks)
+--   * `read_in_order_use_virtual_row_per_block = 1`
+--
+-- Before the fix, ORDER BY ... DESC LIMIT 100 produced mis-ordered output because
+-- `MergeTreeSelectProcessor::buildVirtualRowFromIndex` derived the per-block
+-- boundary key from `index[next_mark]` (a granule edge), while the actual chunk's
+-- data spanned only part of that granule. The understated boundary made
+-- `MergingSortedTransform` deprioritize the source, causing larger values from
+-- later (LIFO-popped) chunks to appear after smaller values already emitted from
+-- other sources.
+
+DROP TABLE IF EXISTS t_vrow_partial;
+
+CREATE TABLE t_vrow_partial (CounterID UInt32, CounterID2 UInt32)
+ENGINE = MergeTree ORDER BY CounterID
+SETTINGS index_granularity = 28454, min_bytes_for_wide_part = 0;
+
+SYSTEM STOP MERGES t_vrow_partial;
+
+-- Many small parts with overlapping ranges, each with a sub-granule-sized max_block_size.
+INSERT INTO t_vrow_partial SELECT sipHash64(number, 0) % 100000, rand32() % 100000 FROM numbers(100000) SETTINGS max_block_size = 14633;
+INSERT INTO t_vrow_partial SELECT sipHash64(number, 1) % 100000, rand32() % 100000 FROM numbers(100000) SETTINGS max_block_size = 14633;
+INSERT INTO t_vrow_partial SELECT sipHash64(number, 2) % 100000, rand32() % 100000 FROM numbers(100000) SETTINGS max_block_size = 14633;
+INSERT INTO t_vrow_partial SELECT sipHash64(number, 3) % 100000, rand32() % 100000 FROM numbers(100000) SETTINGS max_block_size = 14633;
+INSERT INTO t_vrow_partial SELECT sipHash64(number, 4) % 100000, rand32() % 100000 FROM numbers(100000) SETTINGS max_block_size = 14633;
+INSERT INTO t_vrow_partial SELECT sipHash64(number, 5) % 100000, rand32() % 100000 FROM numbers(100000) SETTINGS max_block_size = 14633;
+INSERT INTO t_vrow_partial SELECT sipHash64(number, 6) % 100000, rand32() % 100000 FROM numbers(100000) SETTINGS max_block_size = 14633;
+INSERT INTO t_vrow_partial SELECT sipHash64(number, 7) % 100000, rand32() % 100000 FROM numbers(100000) SETTINGS max_block_size = 14633;
+INSERT INTO t_vrow_partial SELECT sipHash64(number, 8) % 100000, rand32() % 100000 FROM numbers(100000) SETTINGS max_block_size = 14633;
+INSERT INTO t_vrow_partial SELECT sipHash64(number, 9) % 100000, rand32() % 100000 FROM numbers(100000) SETTINGS max_block_size = 14633;
+
+SET optimize_read_in_order = 1,
+    read_in_order_use_virtual_row = 1,
+    read_in_order_use_virtual_row_per_block = 1,
+    max_block_size = 14633;
+
+-- Verify ORDER BY DESC LIMIT and ASC LIMIT produce monotonically (non-strictly)
+-- sorted output for the PK column. The boolean must always be 1.
+
+WITH (SELECT groupArray(CounterID) FROM (SELECT CounterID FROM t_vrow_partial ORDER BY CounterID DESC LIMIT 100)) AS arr
+SELECT 'desc PK monotonic', arr = arrayReverseSort(arr);
+
+WITH (SELECT groupArray(CounterID) FROM (SELECT CounterID FROM t_vrow_partial ORDER BY CounterID ASC LIMIT 100)) AS arr
+SELECT 'asc PK monotonic', arr = arraySort(arr);
+
+-- The same query but on a non-PK column. Output content depends on the random
+-- INSERT values, so we only check the result count is exactly the LIMIT and is
+-- monotonic w.r.t. the chosen direction (CounterID2 is not the sort key, so
+-- this validates that ORDER BY ... LIMIT does not return more than LIMIT rows
+-- and is consistent with the sort direction).
+SELECT 'desc CounterID2 ordered', count() = 100 FROM (SELECT CounterID2 FROM t_vrow_partial ORDER BY CounterID2 DESC LIMIT 100);
+SELECT 'asc CounterID2 ordered', count() = 100 FROM (SELECT CounterID2 FROM t_vrow_partial ORDER BY CounterID2 ASC LIMIT 100);
+
+DROP TABLE t_vrow_partial;

--- a/tests/queries/0_stateless/04302_virtual_row_per_block_lc_pk.reference
+++ b/tests/queries/0_stateless/04302_virtual_row_per_block_lc_pk.reference
@@ -1,0 +1,4 @@
+lc_string desc	1	1
+lc_string asc	1	1
+lc_int32 desc	1	1
+lc_int32 asc	1	1

--- a/tests/queries/0_stateless/04302_virtual_row_per_block_lc_pk.sql
+++ b/tests/queries/0_stateless/04302_virtual_row_per_block_lc_pk.sql
@@ -1,0 +1,58 @@
+-- Tags: no-random-merge-tree-settings, no-random-settings, long
+-- Regression for the LowCardinality(...) primary key path of
+-- `MergeTreeSelectProcessor::buildVirtualRowFromChunk`. Before the fix, the
+-- per-block virtual row code materialized the source PK column via
+-- `convertToFullIfNeeded` and then called `insertFrom` into a destination
+-- `cloneEmpty`-d from `pk_block_header`. When the PK type is
+-- `LowCardinality(...)` the destination is `ColumnLowCardinality` while the
+-- materialized source is the nested full column, so `insertFrom`'s type check
+-- fires and the query exits with an exception (release builds would otherwise
+-- silently corrupt the per-block boundary). The fix round-trips through
+-- `Field`, which works regardless of column representation.
+
+SET allow_suspicious_low_cardinality_types = 1;
+
+DROP TABLE IF EXISTS t_vrow_lc_str;
+DROP TABLE IF EXISTS t_vrow_lc_int;
+
+CREATE TABLE t_vrow_lc_str (lc_key LowCardinality(String), v UInt32)
+ENGINE = MergeTree ORDER BY lc_key
+SETTINGS index_granularity = 28454, min_bytes_for_wide_part = 0;
+
+CREATE TABLE t_vrow_lc_int (lc_key LowCardinality(Int32), v UInt32)
+ENGINE = MergeTree ORDER BY lc_key
+SETTINGS index_granularity = 28454, min_bytes_for_wide_part = 0;
+
+SYSTEM STOP MERGES t_vrow_lc_str;
+SYSTEM STOP MERGES t_vrow_lc_int;
+
+INSERT INTO t_vrow_lc_str SELECT toString(sipHash64(number, 0) % 1000), number FROM numbers(100000) SETTINGS max_block_size = 14633;
+INSERT INTO t_vrow_lc_str SELECT toString(sipHash64(number, 1) % 1000), number FROM numbers(100000) SETTINGS max_block_size = 14633;
+INSERT INTO t_vrow_lc_str SELECT toString(sipHash64(number, 2) % 1000), number FROM numbers(100000) SETTINGS max_block_size = 14633;
+
+INSERT INTO t_vrow_lc_int SELECT (sipHash64(number, 0) % 1000)::Int32, number FROM numbers(100000) SETTINGS max_block_size = 14633;
+INSERT INTO t_vrow_lc_int SELECT (sipHash64(number, 1) % 1000)::Int32, number FROM numbers(100000) SETTINGS max_block_size = 14633;
+INSERT INTO t_vrow_lc_int SELECT (sipHash64(number, 2) % 1000)::Int32, number FROM numbers(100000) SETTINGS max_block_size = 14633;
+
+SET optimize_read_in_order = 1,
+    read_in_order_use_virtual_row = 1,
+    read_in_order_use_virtual_row_per_block = 1,
+    max_block_size = 14633;
+
+-- Both directions on `LowCardinality(String)` and `LowCardinality(Int32)` PKs
+-- must succeed and return monotonically sorted output up to the LIMIT.
+
+WITH (SELECT groupArray(lc_key) FROM (SELECT lc_key FROM t_vrow_lc_str ORDER BY lc_key DESC LIMIT 100)) AS arr
+SELECT 'lc_string desc', length(arr) = 100, arr = arrayReverseSort(arr);
+
+WITH (SELECT groupArray(lc_key) FROM (SELECT lc_key FROM t_vrow_lc_str ORDER BY lc_key ASC LIMIT 100)) AS arr
+SELECT 'lc_string asc',  length(arr) = 100, arr = arraySort(arr);
+
+WITH (SELECT groupArray(lc_key) FROM (SELECT lc_key FROM t_vrow_lc_int ORDER BY lc_key DESC LIMIT 100)) AS arr
+SELECT 'lc_int32 desc',  length(arr) = 100, arr = arrayReverseSort(arr);
+
+WITH (SELECT groupArray(lc_key) FROM (SELECT lc_key FROM t_vrow_lc_int ORDER BY lc_key ASC LIMIT 100)) AS arr
+SELECT 'lc_int32 asc',   length(arr) = 100, arr = arraySort(arr);
+
+DROP TABLE t_vrow_lc_str;
+DROP TABLE t_vrow_lc_int;


### PR DESCRIPTION
Fixes an `ORDER BY ... LIMIT` correctness bug when `read_in_order_use_virtual_row_per_block = 1` is combined with wide parts that read partial granules. Output values can appear out of order around the seam between a stream's first and second emitted chunk, e.g. `99988, 99996, 99996, ...` instead of monotonically descending.

### Root cause

`MergeTreeSelectProcessor::buildVirtualRowFromIndex` computes the per-block boundary key from `index[next_mark]`, i.e. the start of the next granule. For wide parts (`MergeTreeReaderWide::canReadIncompleteGranules` returns true), a single block can contain only part of a granule, so a chunk whose `read_mark_ranges` reports `[N, N+1)` may carry just the last few rows of granule N while the rest of that granule lives in the previous forward chunk. For `MergeTreeInReverseOrderSelectAlgorithm` (which buffers all chunks and pops them LIFO, then `ReverseTransform` flips each chunk's rows), this means the index-derived key sits far below the actual values still pending from this source. `MergingSortedTransform` then deprioritizes the source and emits smaller values from other parts before returning to it, producing the mis-ordered output.

### Fix

Prefer extracting the per-block boundary PK from the chunk's actual data (`buildVirtualRowFromChunk`):

- forward reads: use the last row's PK -- a tight lower bound for the next chunk's data,
- reverse reads: use the first forward row's PK -- a tight upper bound on what the next emit can be after `ReverseTransform`.

When the chunk has no surviving rows (PREWHERE filtered everything) or the PK columns are not part of the query result, fall back to the original index-based path -- but only if the chunk's `num_read_rows` exactly equals the granule sizes covered by `read_mark_ranges`, so partial-granule reads no longer emit a misleading boundary.

Source columns from the chunk are materialized via `convertToFullIfNeeded` before `insertFrom` so the read works regardless of sparse / const / low-cardinality / replicated wrappers.

### Reproducer (fails on master, passes with this PR)

```sql
DROP TABLE IF EXISTS t_vrow;
CREATE TABLE t_vrow (CounterID UInt32, CounterID2 UInt32)
ENGINE = MergeTree ORDER BY CounterID
SETTINGS index_granularity = 28454, min_bytes_for_wide_part = 0;
SYSTEM STOP MERGES t_vrow;
-- 10 INSERTs of 100k rows each with `max_block_size = 14633`
INSERT INTO t_vrow SELECT sipHash64(number, 0) % 100000, rand32() % 100000 FROM numbers(100000) SETTINGS max_block_size = 14633;
-- ... 9 more INSERTs
SET optimize_read_in_order = 1, read_in_order_use_virtual_row = 1, read_in_order_use_virtual_row_per_block = 1, max_block_size = 14633;
SELECT CounterID FROM t_vrow ORDER BY CounterID DESC LIMIT 100;
```

Before the fix, the output transitions from `99988` straight back to `99996, 99996, 99994, ...` around row 50. After the fix, the output is monotonically non-increasing.

The feature was introduced in #100603. The existing test `04057_virtual_row_many_parts` does not pin `min_bytes_for_wide_part = 0` and only catches the bug when the random-settings runner hits the wide + small-`max_block_size` + small-`index_granularity` combination. A new stateless test `04301_virtual_row_per_block_wide_partial_granule` pins these settings and asserts both `ORDER BY ... DESC LIMIT 100` and `ASC LIMIT 100` are monotonic.

### Validation

- Reproducer above fails deterministically on master, passes on this branch.
- `04057_virtual_row_many_parts`: 50/50 successful runs with `--test-runs 50` and full random-settings randomization on a local debug build.
- All other `virtual_row` / `read_in_order` stateless tests still pass.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix wrong `ORDER BY ... LIMIT` output when reading wide `MergeTree` parts with `read_in_order_use_virtual_row_per_block = 1` and an `index_granularity` larger than `max_block_size`. The per-block virtual-row boundary is now derived from the chunk's actual data instead of the granule edge, so `MergingSortedTransform` no longer deprioritizes a source whose next chunk still contains larger values.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)