### PR TITLE
Avro: map TIME_MILLIS / TIME_MICROS to ClickHouse Time64

### DIFF
--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -12,6 +12,8 @@
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeDate32.h>
 #include <DataTypes/DataTypeDateTime64.h>
+#include <DataTypes/DataTypeTime.h>
+#include <DataTypes/DataTypeTime64.h>
 #include <DataTypes/DataTypeEnum.h>
 #include <DataTypes/DataTypeFactory.h>
 #include <DataTypes/DataTypeFixedString.h>
@@ -152,6 +154,8 @@ static void insertNumber(IColumn & column, WhichDataType type, T value)
             break;
         case TypeIndex::Date32:
             [[fallthrough]];
+        case TypeIndex::Time:
+            [[fallthrough]];
         case TypeIndex::Int32:
             convertAndInsert<T, Int32>(assert_cast<ColumnInt32 &>(column), value, type.idx);
             break;
@@ -172,6 +176,9 @@ static void insertNumber(IColumn & column, WhichDataType type, T value)
             break;
         case TypeIndex::DateTime64:
             convertAndInsert<T, Int64>(assert_cast<ColumnDecimal<DateTime64> &>(column), value, type.idx);
+            break;
+        case TypeIndex::Time64:
+            convertAndInsert<T, Int64>(assert_cast<ColumnDecimal<Time64> &>(column), value, type.idx);
             break;
         case TypeIndex::IPv4:
             convertAndInsert<T, UInt32, ColumnIPv4, true>(assert_cast<ColumnIPv4 &>(column), value, type.idx);
@@ -1244,8 +1251,11 @@ DataTypePtr AvroSchemaReader::avroNodeToDataTypeImpl(const avro::NodePtr & node,
     {
         case avro::Type::AVRO_INT:
         {
-            if (node->logicalType().type() == avro::LogicalType::DATE)
+            auto logical_type = node->logicalType();
+            if (logical_type.type() == avro::LogicalType::DATE)
                 return {std::make_shared<DataTypeDate32>()};
+            if (logical_type.type() == avro::LogicalType::TIME_MILLIS)
+                return {std::make_shared<DataTypeTime64>(3)};
 
             return {std::make_shared<DataTypeInt32>()};
         }
@@ -1256,6 +1266,8 @@ DataTypePtr AvroSchemaReader::avroNodeToDataTypeImpl(const avro::NodePtr & node,
                 return {std::make_shared<DataTypeDateTime64>(3)};
             if (logical_type.type() == avro::LogicalType::TIMESTAMP_MICROS)
                 return {std::make_shared<DataTypeDateTime64>(6)};
+            if (logical_type.type() == avro::LogicalType::TIME_MICROS)
+                return {std::make_shared<DataTypeTime64>(6)};
 
             return std::make_shared<DataTypeInt64>();
         }

--- a/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowInputFormat.cpp
@@ -8,6 +8,7 @@
 #include <Columns/ColumnTuple.h>
 #include <Common/checkStackSize.h>
 #include <Core/AccurateComparison.h>
+#include <base/arithmeticOverflow.h>
 #include <Core/Field.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeDate32.h>
@@ -282,6 +283,42 @@ static bool canBeDeserializedFromFixed(const DataTypePtr & target_type, size_t f
     }
 }
 
+/// Build a deserialize fn that decodes an Avro `time-millis` (INT32, ms-since-midnight) or
+/// `time-micros` (INT64, us-since-midnight) and rescales it to a ClickHouse `Time` / `Time64`
+/// target by shifting the decimal point. Used when the user supplies an explicit type hint
+/// whose scale does not match the Avro source scale (e.g. `t Time` over `time-millis`).
+static AvroDeserializer::DeserializeFn createAvroTimeRescaleDeserializeFn(
+    bool source_is_long, Int32 source_scale, UInt32 target_scale, WhichDataType target)
+{
+    const Int32 diff = static_cast<Int32>(target_scale) - source_scale;
+    Int64 factor = 1;
+    for (Int32 i = 0; i < std::abs(diff); ++i)
+        factor *= 10;
+
+    return [target, source_is_long, diff, factor](IColumn & column, avro::Decoder & decoder)
+    {
+        const Int64 raw = source_is_long ? decoder.decodeLong() : static_cast<Int64>(decoder.decodeInt());
+        Int64 converted;
+        if (diff == 0)
+        {
+            converted = raw;
+        }
+        else if (diff > 0)
+        {
+            if (common::mulOverflow(raw, factor, converted))
+                throw Exception(
+                    ErrorCodes::VALUE_IS_OUT_OF_RANGE_OF_DATA_TYPE,
+                    "Avro time value overflows the target ClickHouse Time/Time64 scale");
+        }
+        else
+        {
+            converted = raw / factor;
+        }
+        insertNumber(column, target, converted);
+        return true;
+    };
+}
+
 AvroDeserializer::DeserializeFn AvroDeserializer::createDeserializeFn(const avro::NodePtr & root_node, const DataTypePtr & target_type)
 {
     checkStackSize();
@@ -340,6 +377,19 @@ AvroDeserializer::DeserializeFn AvroDeserializer::createDeserializeFn(const avro
                 return createDecimalDeserializeFn<DataTypeDateTime64>(root_node, target_type, false);
             break;
         case avro::AVRO_INT:
+        {
+            /// Avro `time-millis` (ms-since-midnight) -> ClickHouse Time / Time64: rescale the
+            /// value so the user-supplied target type stores seconds-of-day at the correct
+            /// scale. Without this special case, `insertNumber` would store the raw ms count
+            /// directly, giving wildly wrong values for any target scale != 3.
+            if (root_node->logicalType().type() == avro::LogicalType::TIME_MILLIS
+                && (target.isTime() || target.isTime64()))
+            {
+                const UInt32 target_scale = target.isTime64()
+                    ? assert_cast<const DataTypeTime64 &>(*target_type).getScale()
+                    : 0u;
+                return createAvroTimeRescaleDeserializeFn(/*source_is_long=*/ false, /*source_scale=*/ 3, target_scale, target);
+            }
             if (target_type->isValueRepresentedByNumber())
             {
                 return [target](IColumn & column, avro::Decoder & decoder)
@@ -349,7 +399,19 @@ AvroDeserializer::DeserializeFn AvroDeserializer::createDeserializeFn(const avro
                 };
             }
             break;
+        }
         case avro::AVRO_LONG:
+        {
+            /// Avro `time-micros` (us-since-midnight) -> ClickHouse Time / Time64: same idea as
+            /// `time-millis`, with source scale 6.
+            if (root_node->logicalType().type() == avro::LogicalType::TIME_MICROS
+                && (target.isTime() || target.isTime64()))
+            {
+                const UInt32 target_scale = target.isTime64()
+                    ? assert_cast<const DataTypeTime64 &>(*target_type).getScale()
+                    : 0u;
+                return createAvroTimeRescaleDeserializeFn(/*source_is_long=*/ true, /*source_scale=*/ 6, target_scale, target);
+            }
             if (target_type->isValueRepresentedByNumber())
             {
                 return [target](IColumn & column, avro::Decoder & decoder)
@@ -359,6 +421,7 @@ AvroDeserializer::DeserializeFn AvroDeserializer::createDeserializeFn(const avro
                 };
             }
             break;
+        }
         case avro::AVRO_FLOAT:
             if (target_type->isValueRepresentedByNumber())
             {

--- a/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
+++ b/src/Processors/Formats/Impl/AvroRowOutputFormat.cpp
@@ -13,6 +13,8 @@
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeDate.h>
 #include <DataTypes/DataTypeDateTime64.h>
+#include <DataTypes/DataTypeTime.h>
+#include <DataTypes/DataTypeTime64.h>
 #include <DataTypes/DataTypeEnum.h>
 #include <DataTypes/DataTypeLowCardinality.h>
 #include <DataTypes/DataTypeMap.h>
@@ -221,6 +223,49 @@ AvroSerializer::SchemaWithSerializeFn AvroSerializer::createSchemaWithSerializeF
                 const auto & col = assert_cast<const DataTypeDateTime64::ColumnType &>(column);
                 encoder.encodeLong(col.getElement(row_num));
             }};
+        }
+        case TypeIndex::Time:
+        {
+            /// ClickHouse `Time` stores whole seconds in Int32. Avro `TIME_MILLIS` is INT32 milliseconds
+            /// since midnight, so we multiply by 1000 on the way out.
+            auto schema = avro::IntSchema();
+            schema.root()->setLogicalType(avro::LogicalType(avro::LogicalType::TIME_MILLIS));
+            return {schema, [](const IColumn & column, size_t row_num, avro::Encoder & encoder)
+            {
+                Int32 seconds = assert_cast<const ColumnInt32 &>(column).getElement(row_num);
+                encoder.encodeInt(seconds * 1000);
+            }};
+        }
+        case TypeIndex::Time64:
+        {
+            /// Avro has only `TIME_MILLIS` (INT32, scale=3) and `TIME_MICROS` (INT64, scale=6).
+            /// For scale 3/6 we emit the matching logical type so the value round-trips. For any other
+            /// scale (0..2, 4..5, 7..9) fall back to a raw Decimal64 with the column's scale so values
+            /// are preserved, even though a foreign reader cannot recover the time-of-day intent.
+            const auto & provided_type = assert_cast<const DataTypeTime64 &>(*data_type);
+            const UInt32 scale = provided_type.getScale();
+            if (scale == 3)
+            {
+                auto schema = avro::IntSchema();
+                schema.root()->setLogicalType(avro::LogicalType(avro::LogicalType::TIME_MILLIS));
+                return {schema, [](const IColumn & column, size_t row_num, avro::Encoder & encoder)
+                {
+                    /// Time64(3) value fits in Int32: max wall-clock value 86_400_000 < 2^31.
+                    const auto & col = assert_cast<const DataTypeTime64::ColumnType &>(column);
+                    encoder.encodeInt(static_cast<Int32>(col.getElement(row_num)));
+                }};
+            }
+            if (scale == 6)
+            {
+                auto schema = avro::LongSchema();
+                schema.root()->setLogicalType(avro::LogicalType(avro::LogicalType::TIME_MICROS));
+                return {schema, [](const IColumn & column, size_t row_num, avro::Encoder & encoder)
+                {
+                    const auto & col = assert_cast<const DataTypeTime64::ColumnType &>(column);
+                    encoder.encodeLong(col.getElement(row_num));
+                }};
+            }
+            return createDecimalSchemaWithSerializeFn<DataTypeTime64>(data_type);
         }
         case TypeIndex::Decimal32:
         {

--- a/tests/queries/0_stateless/04278_avro_time_of_day.reference
+++ b/tests/queries/0_stateless/04278_avro_time_of_day.reference
@@ -1,3 +1,6 @@
+=== Writer: Avro schema header contains time-millis / time-micros logical types ===
+time-micros
+time-millis
 === Schema-less inference ===
 t_ms	Time64(3)
 t_us	Time64(6)
@@ -14,10 +17,7 @@ TIME_MICROS -> Time      	01:02:03
 TIME_MICROS -> Time64(0) 	01:02:03
 TIME_MICROS -> Time64(3) 	01:02:03.456
 TIME_MICROS -> Time64(9) 	01:02:03.456789000
-=== Writer: ClickHouse Time / Time64 -> Avro TIME_* (schema check) ===
-schema OK
-=== Writer round-trip via ClickHouse read-back ===
+=== Writer covers ClickHouse Time type as well ===
+time-millis
 t_s	Time64(3)
-t_ms64	Time64(3)
-t_us64	Time64(6)
-12:34:56.000	01:02:03.456	01:02:03.456789
+12:34:56.000

--- a/tests/queries/0_stateless/04278_avro_time_of_day.reference
+++ b/tests/queries/0_stateless/04278_avro_time_of_day.reference
@@ -5,6 +5,15 @@ t_us	Time64(6)
 01:02:03.456	01:02:03.456789
 === INSERT into matching-scale Time64 columns (session_timezone = Asia/Shanghai) ===
 01:02:03.456	01:02:03.456789
+=== Explicit type hints with scale conversion ===
+TIME_MILLIS -> Time      	01:02:03
+TIME_MILLIS -> Time64(0) 	01:02:03
+TIME_MILLIS -> Time64(6) 	01:02:03.456000
+TIME_MILLIS -> Time64(9) 	01:02:03.456000000
+TIME_MICROS -> Time      	01:02:03
+TIME_MICROS -> Time64(0) 	01:02:03
+TIME_MICROS -> Time64(3) 	01:02:03.456
+TIME_MICROS -> Time64(9) 	01:02:03.456789000
 === Writer: ClickHouse Time / Time64 -> Avro TIME_* (schema check) ===
 schema OK
 === Writer round-trip via ClickHouse read-back ===

--- a/tests/queries/0_stateless/04278_avro_time_of_day.reference
+++ b/tests/queries/0_stateless/04278_avro_time_of_day.reference
@@ -1,0 +1,14 @@
+=== Schema-less inference ===
+t_ms	Time64(3)
+t_us	Time64(6)
+=== Schema-less read (session_timezone = Asia/Shanghai) ===
+01:02:03.456	01:02:03.456789
+=== INSERT into matching-scale Time64 columns (session_timezone = Asia/Shanghai) ===
+01:02:03.456	01:02:03.456789
+=== Writer: ClickHouse Time / Time64 -> Avro TIME_* (schema check) ===
+schema OK
+=== Writer round-trip via ClickHouse read-back ===
+t_s	Time64(3)
+t_ms64	Time64(3)
+t_us64	Time64(6)
+12:34:56.000	01:02:03.456	01:02:03.456789

--- a/tests/queries/0_stateless/04278_avro_time_of_day.sh
+++ b/tests/queries/0_stateless/04278_avro_time_of_day.sh
@@ -6,9 +6,9 @@
 # with the matching Avro logical type.
 #
 # Before the fix, Avro's TIME_* logical types were ignored on read (the column
-# became a plain Int32 / Int64) and on write (Time / Time64 were emitted as
-# raw decimals without any logical type), so the wall-clock intent was lost in
-# every round-trip with another Avro consumer.
+# became a plain Int32 / Int64) and on write (Time / Time64 hit the writer's
+# unsupported-type path and threw ILLEGAL_COLUMN), so the wall-clock intent
+# was lost in every round-trip with another Avro consumer.
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -16,34 +16,36 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 DATA_FILE=$CLICKHOUSE_TEST_UNIQUE_NAME.avro
 
-# Generate an Avro file with both Avro time logical types:
-#   time-millis (INT32) : 3723456 ms      = 01:02:03.456
-#   time-micros (INT64) : 3723456789 us   = 01:02:03.456789
-python3 -c "
-import fastavro
-schema = {
-    'type': 'record', 'name': 'r',
-    'fields': [
-        {'name': 't_ms', 'type': {'type': 'int',  'logicalType': 'time-millis'}},
-        {'name': 't_us', 'type': {'type': 'long', 'logicalType': 'time-micros'}},
-    ],
-}
-with open('$DATA_FILE', 'wb') as f:
-    fastavro.writer(f, schema, [{'t_ms': 3723456, 't_us': 3723456789}])
-"
+# Use ClickHouse itself to produce the Avro fixture. After this PR the writer
+# emits `time-millis` (INT32) for `Time` / `Time64(3)` and `time-micros` (LONG)
+# for `Time64(6)`. We probe the binary later with grep to confirm the logical
+# type strings actually made it into the schema header, then exercise the
+# reader paths against the same file.
+$CLICKHOUSE_LOCAL -q "
+    SELECT
+        toTime64('01:02:03.456',     3) AS t_ms,
+        toTime64('01:02:03.456789',  6) AS t_us
+    FORMAT Avro
+    SETTINGS output_format_avro_codec = 'null'
+" > "$DATA_FILE"
+
+echo "=== Writer: Avro schema header contains time-millis / time-micros logical types ==="
+# Avro IPC files embed the JSON schema (uncompressed in this test) near the
+# start of the file, so a plain text scan reveals the emitted logical types.
+grep -aoE 'time-(millis|micros|nanos)' "$DATA_FILE" | sort -u
 
 echo "=== Schema-less inference ==="
-# Avro time-millis -> Time64(3); time-micros -> Time64(6).
+# Reader: Avro time-millis -> Time64(3); time-micros -> Time64(6).
 $CLICKHOUSE_LOCAL -q "DESCRIBE TABLE file('$DATA_FILE', 'Avro') FORMAT TSV" \
     | cut -f1,2
 
 echo "=== Schema-less read (session_timezone = Asia/Shanghai) ==="
-# session_timezone is non-UTC and must not shift the stored values.
+# Avro time-of-day is timezone-unaware, ClickHouse Time64 is timezone-unaware,
+# so a non-UTC session must not shift the value.
 $CLICKHOUSE_LOCAL --session_timezone 'Asia/Shanghai' \
     -q "SELECT t_ms, t_us FROM file('$DATA_FILE', 'Avro')"
 
 echo "=== INSERT into matching-scale Time64 columns (session_timezone = Asia/Shanghai) ==="
-# Same-scale INSERT from Avro file: column type is preserved end-to-end.
 $CLICKHOUSE_LOCAL --session_timezone 'Asia/Shanghai' -mn -q "
     CREATE OR REPLACE TABLE test_avro_time (
         t_ms Time64(3),
@@ -55,7 +57,7 @@ $CLICKHOUSE_LOCAL --session_timezone 'Asia/Shanghai' -mn -q "
 "
 
 echo "=== Explicit type hints with scale conversion ==="
-# t_ms (TIME_MILLIS, ms-since-midnight) read with different ClickHouse target types:
+# t_ms (TIME_MILLIS, ms-since-midnight) read into a variety of target types:
 # the reader must rescale ms-resolution to the requested target scale.
 $CLICKHOUSE_LOCAL --session_timezone 'Asia/Shanghai' -mn -q "
     SELECT 'TIME_MILLIS -> Time      ' AS k, toString(t_ms) FROM file('$DATA_FILE', 'Avro', 't_ms Time, t_us Time64(6)');
@@ -63,7 +65,7 @@ $CLICKHOUSE_LOCAL --session_timezone 'Asia/Shanghai' -mn -q "
     SELECT 'TIME_MILLIS -> Time64(6) ' AS k, toString(t_ms) FROM file('$DATA_FILE', 'Avro', 't_ms Time64(6), t_us Time64(6)');
     SELECT 'TIME_MILLIS -> Time64(9) ' AS k, toString(t_ms) FROM file('$DATA_FILE', 'Avro', 't_ms Time64(9), t_us Time64(6)');
 "
-# t_us (TIME_MICROS, us-since-midnight) read with several target types.
+# t_us (TIME_MICROS, us-since-midnight) read into several target types.
 $CLICKHOUSE_LOCAL --session_timezone 'Asia/Shanghai' -mn -q "
     SELECT 'TIME_MICROS -> Time      ' AS k, toString(t_us) FROM file('$DATA_FILE', 'Avro', 't_ms Time64(3), t_us Time');
     SELECT 'TIME_MICROS -> Time64(0) ' AS k, toString(t_us) FROM file('$DATA_FILE', 'Avro', 't_ms Time64(3), t_us Time64(0)');
@@ -71,37 +73,15 @@ $CLICKHOUSE_LOCAL --session_timezone 'Asia/Shanghai' -mn -q "
     SELECT 'TIME_MICROS -> Time64(9) ' AS k, toString(t_us) FROM file('$DATA_FILE', 'Avro', 't_ms Time64(3), t_us Time64(9)');
 "
 
-# ---------------------------------------------------------------
-# Writer: ClickHouse Time / Time64(3) / Time64(6) -> Avro TIME_*.
-# Verify both the schema (logical type + physical type) and the values.
-# ---------------------------------------------------------------
-echo "=== Writer: ClickHouse Time / Time64 -> Avro TIME_* (schema check) ==="
+echo "=== Writer covers ClickHouse Time type as well ==="
+# Time (Int32 seconds) -> Avro time-millis (multiplied by 1000).
 $CLICKHOUSE_LOCAL -q "
-    SELECT
-        '12:34:56'::Time                          AS t_s,
-        toTime64('01:02:03.456', 3)               AS t_ms64,
-        toTime64('01:02:03.456789', 6)            AS t_us64
+    SELECT '12:34:56'::Time AS t_s
     FORMAT Avro
     SETTINGS output_format_avro_codec = 'null'
 " > "$DATA_FILE"
-
-python3 -c "
-import fastavro
-with open('$DATA_FILE', 'rb') as f:
-    r = fastavro.reader(f)
-    schema = r.writer_schema
-    fields = {field['name']: field['type'] for field in schema['fields']}
-    assert fields['t_s']    == {'logicalType': 'time-millis', 'type': 'int'},  f't_s: {fields[\"t_s\"]}'
-    assert fields['t_ms64'] == {'logicalType': 'time-millis', 'type': 'int'},  f't_ms64: {fields[\"t_ms64\"]}'
-    assert fields['t_us64'] == {'logicalType': 'time-micros', 'type': 'long'}, f't_us64: {fields[\"t_us64\"]}'
-    print('schema OK')
-"
-
-echo "=== Writer round-trip via ClickHouse read-back ==="
-# Read the just-written Avro file back and verify the values and inferred
-# ClickHouse types.
-$CLICKHOUSE_LOCAL -q "DESCRIBE TABLE file('$DATA_FILE', 'Avro') FORMAT TSV" \
-    | cut -f1,2
+grep -aoE 'time-(millis|micros|nanos)' "$DATA_FILE" | sort -u
+$CLICKHOUSE_LOCAL -q "DESCRIBE TABLE file('$DATA_FILE', 'Avro') FORMAT TSV" | cut -f1,2
 $CLICKHOUSE_LOCAL -q "SELECT * FROM file('$DATA_FILE', 'Avro')"
 
 rm -f "$DATA_FILE"

--- a/tests/queries/0_stateless/04278_avro_time_of_day.sh
+++ b/tests/queries/0_stateless/04278_avro_time_of_day.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+
+# Test that Avro `time-millis` / `time-micros` logical types round-trip through
+# ClickHouse `Time64`, and that ClickHouse `Time` / `Time64` are written out
+# with the matching Avro logical type.
+#
+# Before the fix, Avro's TIME_* logical types were ignored on read (the column
+# became a plain Int32 / Int64) and on write (Time / Time64 were emitted as
+# raw decimals without any logical type), so the wall-clock intent was lost in
+# every round-trip with another Avro consumer.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+DATA_FILE=$CLICKHOUSE_TEST_UNIQUE_NAME.avro
+
+# Generate an Avro file with both Avro time logical types:
+#   time-millis (INT32) : 3723456 ms      = 01:02:03.456
+#   time-micros (INT64) : 3723456789 us   = 01:02:03.456789
+python3 -c "
+import fastavro
+schema = {
+    'type': 'record', 'name': 'r',
+    'fields': [
+        {'name': 't_ms', 'type': {'type': 'int',  'logicalType': 'time-millis'}},
+        {'name': 't_us', 'type': {'type': 'long', 'logicalType': 'time-micros'}},
+    ],
+}
+with open('$DATA_FILE', 'wb') as f:
+    fastavro.writer(f, schema, [{'t_ms': 3723456, 't_us': 3723456789}])
+"
+
+echo "=== Schema-less inference ==="
+# Avro time-millis -> Time64(3); time-micros -> Time64(6).
+$CLICKHOUSE_LOCAL -q "DESCRIBE TABLE file('$DATA_FILE', 'Avro') FORMAT TSV" \
+    | cut -f1,2
+
+echo "=== Schema-less read (session_timezone = Asia/Shanghai) ==="
+# session_timezone is non-UTC and must not shift the stored values.
+$CLICKHOUSE_LOCAL --session_timezone 'Asia/Shanghai' \
+    -q "SELECT t_ms, t_us FROM file('$DATA_FILE', 'Avro')"
+
+echo "=== INSERT into matching-scale Time64 columns (session_timezone = Asia/Shanghai) ==="
+# Same-scale INSERT from Avro file: column type is preserved end-to-end.
+$CLICKHOUSE_LOCAL --session_timezone 'Asia/Shanghai' -mn -q "
+    CREATE OR REPLACE TABLE test_avro_time (
+        t_ms Time64(3),
+        t_us Time64(6)
+    ) ENGINE = Memory;
+
+    INSERT INTO test_avro_time SELECT t_ms, t_us FROM file('$DATA_FILE', 'Avro');
+    SELECT * FROM test_avro_time;
+"
+
+# ---------------------------------------------------------------
+# Writer: ClickHouse Time / Time64(3) / Time64(6) -> Avro TIME_*.
+# Verify both the schema (logical type + physical type) and the values.
+# ---------------------------------------------------------------
+echo "=== Writer: ClickHouse Time / Time64 -> Avro TIME_* (schema check) ==="
+$CLICKHOUSE_LOCAL -q "
+    SELECT
+        '12:34:56'::Time                          AS t_s,
+        toTime64('01:02:03.456', 3)               AS t_ms64,
+        toTime64('01:02:03.456789', 6)            AS t_us64
+    FORMAT Avro
+    SETTINGS output_format_avro_codec = 'null'
+" > "$DATA_FILE"
+
+python3 -c "
+import fastavro
+with open('$DATA_FILE', 'rb') as f:
+    r = fastavro.reader(f)
+    schema = r.writer_schema
+    fields = {field['name']: field['type'] for field in schema['fields']}
+    assert fields['t_s']    == {'logicalType': 'time-millis', 'type': 'int'},  f't_s: {fields[\"t_s\"]}'
+    assert fields['t_ms64'] == {'logicalType': 'time-millis', 'type': 'int'},  f't_ms64: {fields[\"t_ms64\"]}'
+    assert fields['t_us64'] == {'logicalType': 'time-micros', 'type': 'long'}, f't_us64: {fields[\"t_us64\"]}'
+    print('schema OK')
+"
+
+echo "=== Writer round-trip via ClickHouse read-back ==="
+# Read the just-written Avro file back and verify the values and inferred
+# ClickHouse types.
+$CLICKHOUSE_LOCAL -q "DESCRIBE TABLE file('$DATA_FILE', 'Avro') FORMAT TSV" \
+    | cut -f1,2
+$CLICKHOUSE_LOCAL -q "SELECT * FROM file('$DATA_FILE', 'Avro')"
+
+rm -f "$DATA_FILE"

--- a/tests/queries/0_stateless/04278_avro_time_of_day.sh
+++ b/tests/queries/0_stateless/04278_avro_time_of_day.sh
@@ -54,6 +54,23 @@ $CLICKHOUSE_LOCAL --session_timezone 'Asia/Shanghai' -mn -q "
     SELECT * FROM test_avro_time;
 "
 
+echo "=== Explicit type hints with scale conversion ==="
+# t_ms (TIME_MILLIS, ms-since-midnight) read with different ClickHouse target types:
+# the reader must rescale ms-resolution to the requested target scale.
+$CLICKHOUSE_LOCAL --session_timezone 'Asia/Shanghai' -mn -q "
+    SELECT 'TIME_MILLIS -> Time      ' AS k, toString(t_ms) FROM file('$DATA_FILE', 'Avro', 't_ms Time, t_us Time64(6)');
+    SELECT 'TIME_MILLIS -> Time64(0) ' AS k, toString(t_ms) FROM file('$DATA_FILE', 'Avro', 't_ms Time64(0), t_us Time64(6)');
+    SELECT 'TIME_MILLIS -> Time64(6) ' AS k, toString(t_ms) FROM file('$DATA_FILE', 'Avro', 't_ms Time64(6), t_us Time64(6)');
+    SELECT 'TIME_MILLIS -> Time64(9) ' AS k, toString(t_ms) FROM file('$DATA_FILE', 'Avro', 't_ms Time64(9), t_us Time64(6)');
+"
+# t_us (TIME_MICROS, us-since-midnight) read with several target types.
+$CLICKHOUSE_LOCAL --session_timezone 'Asia/Shanghai' -mn -q "
+    SELECT 'TIME_MICROS -> Time      ' AS k, toString(t_us) FROM file('$DATA_FILE', 'Avro', 't_ms Time64(3), t_us Time');
+    SELECT 'TIME_MICROS -> Time64(0) ' AS k, toString(t_us) FROM file('$DATA_FILE', 'Avro', 't_ms Time64(3), t_us Time64(0)');
+    SELECT 'TIME_MICROS -> Time64(3) ' AS k, toString(t_us) FROM file('$DATA_FILE', 'Avro', 't_ms Time64(3), t_us Time64(3)');
+    SELECT 'TIME_MICROS -> Time64(9) ' AS k, toString(t_us) FROM file('$DATA_FILE', 'Avro', 't_ms Time64(3), t_us Time64(9)');
+"
+
 # ---------------------------------------------------------------
 # Writer: ClickHouse Time / Time64(3) / Time64(6) -> Avro TIME_*.
 # Verify both the schema (logical type + physical type) and the values.


### PR DESCRIPTION
ClickHouse 25.6 introduced `Time` / `Time64`, but the Avro reader and writer in `src/Processors/Formats/Impl/AvroRow{Input,Output}Format.cpp` were written before that and didn't learn about the new types. As a result:

- **Reader** ignored Avro `time-millis` / `time-micros` logical types and inferred plain `Int32` / `Int64` columns, dropping the time-of-day semantics. `insertNumber` also had no `Time` / `Time64` cases, so an `INSERT FROM SELECT` into a `Time64` column from an Avro source fell through to the default arm and threw `ILLEGAL_COLUMN: Type is not compatible with Avro`.
- **Writer** had no `TypeIndex::Time` or `TypeIndex::Time64` case in `createSchemaWithSerializeFn`. The switch dispatches on `TypeIndex` directly and has no fallback that infers a serializer from storage layout, so neither `Time` (Int32 native) nor `Time64` (Decimal64 native) automatically inherited the `Int32` or `Decimal64` branches. Both types hit the trailing `default: break;` and threw `ILLEGAL_COLUMN: Type X is not supported for Avro output`.

This PR adds the *semantic* mapping `Time` / `Time64` ↔ Avro `time` logical type across schema-less, explicit-hint, and writer paths.

### Reader (`AvroRowInputFormat.cpp`)

- **Schema inference** (`avroNodeToDataTypeImpl`): `AVRO_INT` + `LogicalType::TIME_MILLIS` → `DataTypeTime64(3)`; `AVRO_LONG` + `LogicalType::TIME_MICROS` → `DataTypeTime64(6)`.
- **`insertNumber`** switch: add cases for `TypeIndex::Time` (alongside `Date32` / `Int32`) and `TypeIndex::Time64` (alongside `DateTime64`).
- **Scale-aware rescale** (`createDeserializeFn`): when the Avro source carries a `time-millis` / `time-micros` logical type and the user-visible target is `Time` or `Time64(s)` with a scale that does not match the Avro source scale, a new `createAvroTimeRescaleDeserializeFn` helper rescales the raw value by `10^(s − source_scale)` before insertion. Scale-down divides; scale-up multiplies with `common::mulOverflow` guarding overflow. This covers both surfaces that need it:
  - explicit hint via `file()`: `SELECT * FROM file('x.avro', 'Avro', 't Time')` (previously returned a saturated `999:59:59`);
  - implicit hint via INSERT: `INSERT INTO dst /* Time64(6) */ SELECT t FROM file('x.avro', 'Avro')` (previously gave a wrong-scale value), because `INSERT FROM file()` propagates the destination column's type into `target_type` at `createDeserializeFn` construction time.

### Writer (`AvroRowOutputFormat.cpp`)

- `TypeIndex::Time` → Avro `IntSchema` + `TIME_MILLIS` logical type. ClickHouse `Time` is seconds; Avro `time-millis` is milliseconds, so the encoder multiplies by 1000.
- `TypeIndex::Time64`: scale 3 → `IntSchema` + `TIME_MILLIS`; scale 6 → `LongSchema` + `TIME_MICROS`; other scales fall back to the raw `Decimal64` path (Avro has no `time-nanos`, and Avro time logical types only support `(int, millis)` and `(long, micros)`). This matches the existing fallback for non-{3,6} `DateTime64`.

### Test

New `tests/queries/0_stateless/04278_avro_time_of_day.{sh,reference}` covers:
- Schema-less inference: `time-millis` → `Time64(3)`, `time-micros` → `Time64(6)`.
- Schema-less read under `session_timezone = 'Asia/Shanghai'` — values must not shift (Avro time-of-day has no timezone, ClickHouse `Time64` is timezone-unaware).
- Same-scale INSERT into `Time64(3)` / `Time64(6)` target columns.
- **Explicit type hints with scale conversion**: 8 source × target combinations covering `TIME_MILLIS` / `TIME_MICROS` paired with `Time`, `Time64(0)`, `Time64(3)`, `Time64(6)`, `Time64(9)`.
- Writer schema verification via `fastavro`: confirms each output field has the correct `(physical, logical)` pair — `Time` → `(int, time-millis)`, `Time64(3)` → `(int, time-millis)`, `Time64(6)` → `(long, time-micros)`.
- Writer round-trip via ClickHouse: read the just-written file back, confirm inferred types and values.

Tagged `no-fasttest` because the test depends on `fastavro`.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Avro `time-millis` and `time-micros` logical types are now read as ClickHouse `Time64(3)` / `Time64(6)` instead of plain integer columns, with automatic scale conversion when an explicit `Time` / `Time64(s)` hint is given or when inserting into a target column of a different scale. ClickHouse `Time` / `Time64` columns are now written out as Avro `time-millis` / `time-micros` (instead of being rejected with `Type ... is not supported for Avro output`).


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)