### PR TITLE
Relax per-test flaky-check timeout from 180s to 300s

### DIFF
--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -133,7 +133,10 @@ TEST_FILE_EXTENSIONS = [".sql", ".sql.j2", ".sh", ".py", ".expect"]
 
 VERSION_PATTERN = r"^((\d+\.)?(\d+\.)?(\d+\.)?\d+)$"
 
-TEST_MAX_RUN_TIME_IN_SECONDS = 180
+# Applies only in `--flaky-check` mode. Tests tagged `long` are exempt.
+# 180s was too tight for randomized debug-build runs (e.g. `--max_insert_threads`
+# combined with `enable_parallel_replicas` + `page_cache_inject_eviction`).
+TEST_MAX_RUN_TIME_IN_SECONDS = 300
 
 
 def detect_cgroup_version():

--- a/tests/queries/0_stateless/01114_database_atomic.sh
+++ b/tests/queries/0_stateless/01114_database_atomic.sh
@@ -5,8 +5,8 @@
 # a ~20s tuple sleep) as a timing floor, but the wall-clock duration is dominated by the
 # concurrent DDL (`CREATE`/`DROP`/`RENAME`/`EXCHANGE`) on `Atomic` databases running on
 # top of those sleeps. The DDL path is instrumented under ASan/TSan/MSan and coverage
-# builds, so the whole test can exceed 180s (CIDB p95 on `amd_tsan, parallel` is ~356s),
-# which trips the `clickhouse-test` flaky-check `TEST_MAX_RUN_TIME_IN_SECONDS = 180s` cap;
+# builds, so the whole test can exceed the `clickhouse-test` flaky-check
+# `TEST_MAX_RUN_TIME_IN_SECONDS` cap (CIDB p95 on `amd_tsan, parallel` is ~356s);
 # the `long` tag exempts the test from that cap. The `sleepEachRow` calls themselves are
 # wall-clock sleeps and are not sped up or slowed down by sanitizers.
 

--- a/tests/queries/0_stateless/01903_csvwithnames_subset_of_columns.sh
+++ b/tests/queries/0_stateless/01903_csvwithnames_subset_of_columns.sh
@@ -11,8 +11,9 @@ $CLICKHOUSE_CLIENT -q "CREATE TABLE test_01903 (col0 Date, col1 Nullable(UInt8))
 
 # Use 100k rows: enough to exercise multi-block streaming in the CSVWithNames/TSVWithNames
 # row-format readers (default max_block_size = 65505) while keeping the test well under the
-# 180s flaky-check timeout under sanitizer + WasmEdge runs. The original 1M rows added no
-# extra coverage but was prone to timing out under MSan + WasmEdge (see CIDB).
+# `clickhouse-test` flaky-check `TEST_MAX_RUN_TIME_IN_SECONDS` cap under sanitizer + WasmEdge
+# runs. The original 1M rows added no extra coverage but was prone to timing out under
+# MSan + WasmEdge (see CIDB).
 $CLICKHOUSE_CLIENT -q "INSERT INTO test_01903 FORMAT CSVWithNames" < <(
     echo 'col0,col1'
     yes '2021-05-05,1' | head -n 100000

--- a/tests/queries/0_stateless/02435_rollback_cancelled_queries.sh
+++ b/tests/queries/0_stateless/02435_rollback_cancelled_queries.sh
@@ -2,7 +2,8 @@
 # Tags: long, no-random-settings, no-ordinary-database, no-fasttest, no-azure-blob-storage
 # long: The test inserts 4M+ rows across the initial setup, 20s parallel insert/select/cancel phase,
 #     and final verification. On the encrypted-S3 + ASan+UBSan + meta-in-keeper flaky-check variant
-#     it consistently exceeds the 180s default budget, so we use the 600s budget instead.
+#     it consistently exceeds the `clickhouse-test` flaky-check `TEST_MAX_RUN_TIME_IN_SECONDS` cap,
+#     so we use the 600s `--timeout` budget (the regular per-test cap) instead.
 # no-fasttest: The test is slow (too many small blocks)
 # no-azure-blob-storage: The test uploads many parts to Azure (5k+), and it runs in parallel with other tests.
 #     As a result, they may interfere, and some queries won't be able to finish in 30 seconds timeout leading to a test failure.

--- a/tests/queries/0_stateless/02475_bson_each_row_format.sh
+++ b/tests/queries/0_stateless/02475_bson_each_row_format.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Tags: no-debug, long, no-flaky-check
-# long - under sanitizers this test can run for more than 180 seconds
+# long - under sanitizers this test can run for more than the `clickhouse-test` flaky-check
+# `TEST_MAX_RUN_TIME_IN_SECONDS` cap
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh

--- a/tests/queries/0_stateless/04070_s3_disk_settings_override.sh
+++ b/tests/queries/0_stateless/04070_s3_disk_settings_override.sh
@@ -5,13 +5,15 @@
 # flaky check, the same test runs many times concurrently; the parallel
 # `SYSTEM RELOAD CONFIG` calls serialize inside the server and a single
 # instance has been observed waiting ~3 minutes before its reload starts,
-# blowing the 180s per-test budget even though the actual reload work is
-# fast. Serializing this test removes the queueing.
+# blowing the `clickhouse-test` flaky-check `TEST_MAX_RUN_TIME_IN_SECONDS`
+# per-test budget even though the actual reload work is fast. Serializing
+# this test removes the queueing.
 # Tag no-random-settings: SYSTEM RELOAD CONFIG combined with multipart S3 upload
-# can exceed the flaky-check 180s timeout in debug builds when random settings
-# (e.g. heavy filesystem cache injection, large reduce_blocking_parts_sleep_ms)
-# inflate per-step latency. The bug under test is about config reload settings
-# priority and is independent of these random settings.
+# can exceed the flaky-check `TEST_MAX_RUN_TIME_IN_SECONDS` cap in debug builds
+# when random settings (e.g. heavy filesystem cache injection, large
+# reduce_blocking_parts_sleep_ms) inflate per-step latency. The bug under test
+# is about config reload settings priority and is independent of these random
+# settings.
 
 # Verify that storage_configuration disk settings properly override global <s3>
 # endpoint configuration for the DiskS3 path (S3ObjectStorage::applyNewSettings).


### PR DESCRIPTION
Follow-up to https://github.com/ClickHouse/ClickHouse/pull/76867 per @alexey-milovidov directive.

The `TEST_MAX_RUN_TIME_IN_SECONDS` cap in `tests/clickhouse-test` fires only in
`--flaky-check` mode (with `--test-runs > 1` and tests not tagged `long`). At
180s it was too tight for randomized debug-build runs.

CIDB data (30 days, `check_name LIKE '%flaky check%' AND test_context_raw LIKE '%runs too long%'`):

|Duration bucket|Count|Share|
|-|-|-|
|180-240s|170|64%|
|240-300s|26|10%|
|300-360s|30|11%|
|360-480s|26|10%|
|>480s|14|5%|
|Total|266|100%|

64% of all trips were in the marginal 180-240s range. The 4 historical
`02352_lightweight_delete` trips on PR #76867 are 185s, 199s, 222s, 243s, all
under unlucky randomized combos (`--max_insert_threads {1,2,3}` +
`enable_parallel_replicas 1` + `page_cache_inject_eviction True` on the 1M-row
debug insert). With 300s the cap still catches the 74 historical trips at
300s+ (p95 = 483s) while removing the marginal false positives.

The constant is the only consumer (only used by the failure message and the
single `flaky_check` check at the end of `TestCase.process_result_impl`),
so a single-line bump is sufficient.

Also update the stale `180s` reference in `01114_database_atomic.sh` to
refer to the constant by name so the next bump does not need a paired edit.

CI report referenced in the directive: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=76867&sha=b27932443a4b9a7c5e08fb381274ad9b2b0658e5&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20flaky%20check%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...