### PR TITLE
praktika: terminate PR-comment bullet list with a blank line

### DIFF
--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -1107,14 +1107,15 @@ class GH:
             # which job(s) the labels came from without adding extra weight.
             for name, links_md in self.extra_links:
                 body += f"- {name}: {links_md}\n"
-            # Blank line so a following table isn't parsed as list continuation.
-            if self.extra_links:
-                body += "\n"
             if self.failed_results:
+                # Blank line so the failure section isn't parsed as continuation
+                # of the Summary paragraph or the preceding bullet list.
+                body += "\n"
                 if len(self.failed_results) > 15:
-                    body += (
-                        f"    *15 failures out of {len(self.failed_results)} shown*:\n"
-                    )
+                    # Unindented + terminated with a blank line, otherwise the
+                    # 4-space indent turns this into an indented code block that
+                    # swallows the table that follows.
+                    body += f"*15 failures out of {len(self.failed_results)} shown*:\n\n"
                     self.failed_results = self.failed_results[:15]
                 body += "|job_name|test_name|status|info|comment|\n"
                 body += "|:--|:--|:-:|:--|:--|\n"

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -1107,6 +1107,9 @@ class GH:
             # which job(s) the labels came from without adding extra weight.
             for name, links_md in self.extra_links:
                 body += f"- {name}: {links_md}\n"
+            # Blank line so a following table isn't parsed as list continuation.
+            if self.extra_links:
+                body += "\n"
             if self.failed_results:
                 if len(self.failed_results) > 15:
                     body += (

--- a/ci/tests/test_gh.py
+++ b/ci/tests/test_gh.py
@@ -74,6 +74,138 @@ def test_repo_name_from_git_remote_url_rejects_unexpected_format():
     assert GH._repo_name_from_git_remote_url("/home/user/ClickHouse") == ""
 
 
+def _stub_report_url(monkeypatch):
+    """Replace `Info.get_specific_report_url_static` so `to_markdown` can run
+    without the praktika Settings/env being configured for these unit tests."""
+    from ci.praktika.info import Info
+
+    monkeypatch.setattr(
+        Info,
+        "get_specific_report_url_static",
+        staticmethod(
+            lambda pr_number, branch, sha, job_name, workflow_name:
+                f"https://x/json.html?PR={pr_number}&job={job_name}"
+        ),
+    )
+
+
+def _make_summary(extras, n_fails):
+    """Build a `ResultSummaryForGH` with `n_fails` synthetic failed jobs."""
+    S = GH.ResultSummaryForGH
+    fails = [S(name=f"Job {i}", status=Result.Status.FAIL) for i in range(n_fails)]
+    return S(
+        name="PR",
+        status=Result.Status.FAIL if n_fails else Result.Status.OK,
+        extra_links=list(extras),
+        failed_results=fails,
+    )
+
+
+def _assert_table_renders_at_top_level(md):
+    """Verify the failure table is recognisable as a top-level GFM table.
+
+    Markdown renderers require the table header to be immediately preceded
+    by a blank line or the document start — otherwise the header line gets
+    merged into the previous paragraph or list item and the delimiter row
+    is rendered as plain text.
+    """
+    lines = md.split("\n")
+    header_idx = next(
+        (i for i, ln in enumerate(lines) if ln.startswith("|job_name|")),
+        None,
+    )
+    assert header_idx is not None, f"failure-table header missing in:\n{md}"
+    prev = lines[header_idx - 1] if header_idx > 0 else ""
+    assert prev == "", (
+        f"failure-table header must be preceded by a blank line so it is "
+        f"parsed as a top-level table; previous line was: {prev!r}\n\n{md}"
+    )
+    delim = lines[header_idx + 1]
+    assert delim.startswith("|:--"), (
+        f"line after header must be the delimiter row; got: {delim!r}"
+    )
+
+
+def test_to_markdown_extras_plus_truncated_failures_render_correctly(monkeypatch):
+    """Regression: when both `extra_links` bullets and more than 15 failed
+    jobs are present, the truncation note must not be indented (otherwise
+    it becomes an indented code block) and the table must stay outside the
+    bullet (otherwise it renders as plain text inside the last bullet).
+
+    This is the bug from `https://github.com/ClickHouse/ClickHouse/pull/106008`.
+    """
+    _stub_report_url(monkeypatch)
+    extras = [("Performance Comparison", "[Performance dashboard](https://x/runs?q=1)")]
+    md = _make_summary(extras, n_fails=16).to_markdown(
+        pr_number=1, sha="deadbeef", workflow_name="PR", branch="b"
+    )
+
+    lines = md.split("\n")
+
+    bullet_idx = next(i for i, ln in enumerate(lines) if ln.startswith("- "))
+    assert lines[bullet_idx + 1] == "", (
+        f"bullet list must be terminated with a blank line; got: {lines[bullet_idx + 1]!r}"
+    )
+
+    trunc_idx = next(
+        i for i, ln in enumerate(lines) if "failures out of" in ln
+    )
+    assert lines[trunc_idx] == "*15 failures out of 16 shown*:", (
+        f"truncation note must be unindented; got: {lines[trunc_idx]!r}"
+    )
+    assert lines[trunc_idx + 1] == "", (
+        f"truncation note must be followed by a blank line; got: {lines[trunc_idx + 1]!r}"
+    )
+
+    _assert_table_renders_at_top_level(md)
+    assert "|[Job 0](" in md
+    assert "|[Job 14](" in md
+    assert "|[Job 15](" not in md, "rows must be truncated to first 15"
+
+
+def test_to_markdown_extras_plus_small_failure_table(monkeypatch):
+    """With extras and ≤15 failures the table follows the bullet with one
+    blank line separator — no truncation note."""
+    _stub_report_url(monkeypatch)
+    extras = [("Performance Comparison", "[Performance dashboard](https://x/runs?q=1)")]
+    md = _make_summary(extras, n_fails=3).to_markdown(
+        pr_number=1, sha="deadbeef", workflow_name="PR", branch="b"
+    )
+    assert "failures out of" not in md
+    _assert_table_renders_at_top_level(md)
+
+
+def test_to_markdown_no_extras_truncated(monkeypatch):
+    """With no extras but >15 failures the truncation note still stands as
+    its own paragraph, with blank lines around it."""
+    _stub_report_url(monkeypatch)
+    md = _make_summary(extras=[], n_fails=20).to_markdown(
+        pr_number=1, sha="deadbeef", workflow_name="PR", branch="b"
+    )
+    lines = md.split("\n")
+    trunc_idx = next(i for i, ln in enumerate(lines) if "failures out of" in ln)
+    assert lines[trunc_idx] == "*15 failures out of 20 shown*:"
+    assert lines[trunc_idx - 1] == "", (
+        f"truncation paragraph must be preceded by a blank line; "
+        f"got: {lines[trunc_idx - 1]!r}"
+    )
+    assert lines[trunc_idx + 1] == ""
+    _assert_table_renders_at_top_level(md)
+
+
+def test_to_markdown_no_failures(monkeypatch):
+    """With no failures `to_markdown` must not emit a table at all."""
+    _stub_report_url(monkeypatch)
+    extras = [("Performance Comparison", "[Performance dashboard](https://x/runs?q=1)")]
+    md = _make_summary(extras, n_fails=0).to_markdown(
+        pr_number=1, sha="deadbeef", workflow_name="PR", branch="b"
+    )
+    assert "|job_name|" not in md
+    assert "failures out of" not in md
+    # The bullet is still present.
+    assert "- Performance Comparison:" in md
+
+
 def test_post_commit_status_converts_transparently(monkeypatch):
     """post_commit_status must accept Result.Status values and convert them."""
     captured = {}


### PR DESCRIPTION
`Summary.to_markdown` builds the PR comment as

    **Summary:** <symbol>
    - <name>: <links_md>
    ...
    |job_name|test_name|status|info|comment|
    |:--|:--|:-:|:--|:--|
    |[<job>](<url>)|...|

GitHub's markdown parser (and most CommonMark renderers) treats a `|...|` line that comes directly after a `- ` list item as a continuation of the list, so the failure table never builds — it just shows as a long string of pipes inside the last bullet.

Insert an explicit blank line after the `extra_links` bullets so the following section is parsed as its own block. Example PR https://github.com/ClickHouse/ClickHouse/pull/106008 showed the broken rendering — the `Performance Comparison: [Performance dashboard](...)` bullet swallowed the entire `AST fuzzer` failure table.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.220`
<!-- ch-version-info:end -->