### PR TITLE
Fix `addMonotonicChain` crash for `materialize(monotonic_chain(...))`

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/actionsDAGUtils.cpp
+++ b/src/Processors/QueryPlan/Optimizations/actionsDAGUtils.cpp
@@ -111,21 +111,6 @@ MatchedTrees::Matches matchTrees(const ActionsDAG::NodeRawConstPtrs & inner_dag,
             {
                 match = matches[frame.node->children.at(0)];
             }
-            else if (frame.node->type == ActionsDAG::ActionType::FUNCTION
-                && frame.node->children.size() == 1
-                && (frame.node->function_base->getName() == "materialize"
-                    || frame.node->function_base->getName() == "identity"))
-            {
-                /// `materialize`/`identity` are no-op wrappers that do not change values, so
-                /// for matching purposes they behave like `ALIAS` - pass the match of the
-                /// wrapped node through. This lets `optimizeReadInOrder` see through the
-                /// `materialize(...)` wrappers that filter push-down can inject into a
-                /// `MergeTree` prewhere (e.g. for queries through `ReadFromMerge` after
-                /// `convertAndFilterSourceStream`). Without this, `materialize` only
-                /// contributes a non-strict monotonic match and the `ORDER BY` prefix that
-                /// can be served from the sorting key is truncated.
-                match = matches[frame.node->children.at(0)];
-            }
             else if (frame.node->type == ActionsDAG::ActionType::FUNCTION)
             {
                 //std::cerr << "... Processing " << frame.node->function_base->getName() << std::endl;
@@ -236,6 +221,15 @@ MatchedTrees::Matches matchTrees(const ActionsDAG::NodeRawConstPtrs & inner_dag,
                                 monotonicity.strict = info.is_strict;
                                 monotonicity.child_match = &child_match;
                                 monotonicity.child_node = monotonic_child;
+
+                                /// `materialize` does not change values, so it is effectively
+                                /// strictly monotonic. Without this override the `ORDER BY`
+                                /// prefix that can be served from the sorting key gets truncated
+                                /// when filter push-down injects a `materialize(...)` wrapper
+                                /// (e.g. for queries through `ReadFromMerge` after
+                                /// `convertAndFilterSourceStream`).
+                                if (frame.node->function_base->getName() == "materialize")
+                                    monotonicity.strict = true;
 
                                 if (child_match.monotonicity)
                                 {

--- a/tests/queries/0_stateless/04277_merge_read_in_order_with_prewhere.reference
+++ b/tests/queries/0_stateless/04277_merge_read_in_order_with_prewhere.reference
@@ -2,3 +2,4 @@ Ksenia
 Ksenia
 1
 1
+3

--- a/tests/queries/0_stateless/04277_merge_read_in_order_with_prewhere.sql
+++ b/tests/queries/0_stateless/04277_merge_read_in_order_with_prewhere.sql
@@ -32,3 +32,22 @@ SELECT count() FROM
 WHERE explain ILIKE '%ReadType: InOrder%';
 
 DROP TABLE users_86313;
+
+-- Regression for an exception triggered by the AST fuzzer:
+-- `addMonotonicChain` used to crash with "Cannot add column ... because it is nullptr"
+-- when the read-in-order virtual-row code walked an ORDER BY expression wrapped in a
+-- `materialize(...)` (added by the planner for `WITH FILL`) on top of a monotonic chain
+-- (e.g. `toTimezone(toTimezone(x, 'UTC'), 'CET')`).
+
+DROP TABLE IF EXISTS tab_fill_86313;
+
+CREATE TABLE tab_fill_86313 (x DateTime, y UInt32, z UInt32) ENGINE = MergeTree ORDER BY (x, y);
+INSERT INTO tab_fill_86313 SELECT toDateTime('2024-01-01') + number, number, number FROM numbers(3);
+
+SELECT count() FROM
+(
+    SELECT * FROM tab_fill_86313
+    ORDER BY toTimezone(toTimezone(x, 'UTC'), 'CET') ASC NULLS FIRST, intDiv(intDiv(y, -2), -3) ASC WITH FILL
+);
+
+DROP TABLE tab_fill_86313;


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


Fix fuzzers after https://github.com/ClickHouse/ClickHouse/pull/105867

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.225`
<!-- ch-version-info:end -->