### PR TITLE
Extend `Run server init.d` retry budget from 5s to 30s

### DIFF
--- a/ci/jobs/install_check.py
+++ b/ci/jobs/install_check.py
@@ -38,9 +38,11 @@ set -e
 trap "bash -ex /packages/preserve_logs.sh" ERR
 test_env='TEST_THE_DEFAULT_PARAMETER=15'
 echo "$test_env" >> /etc/default/clickhouse
-# Do not use systemd, and hence we need to wait until the server will be ready below
+# Do not use systemd, and hence we need to wait until the server will be ready below.
+# The init.d wrapper prints "Server started" once the pid file exists, but the TCP
+# listener can take longer to open on a slow CI host; poll for up to 30s. See #86278.
 SYSTEMCTL_SKIP_REDIRECT=1 /etc/init.d/clickhouse-server start
-for i in {1..5}; do
+for i in {1..30}; do
     clickhouse-client -q 'SELECT version()' && break || sleep 1
 done
 clickhouse-client -q 'SELECT version()'


### PR DESCRIPTION
## Motivation

The `Run server init.d` test in the `Install packages (amd_release)` job has been failing intermittently on master with the same pattern across 3 different ClickHouse versions in the last 30 days:

| Date | Commit | Version |
|---|---|---|
| 2026-05-11 08:30 | `66ce9a35d04f` | 26.5.1.507 |
| 2026-05-22 11:27 | `94976df6f78a` | 26.6.1.88 |
| 2026-05-28 13:34 | `549ac9afd4ee` | 26.6.1.216 |

All three runs end with the same tail:

```
+ SYSTEMCTL_SKIP_REDIRECT=1 /etc/init.d/clickhouse-server start
Waiting for server to start
Waiting for server to start
Server started
+ for i in {1..5}
+ clickhouse-client -q 'SELECT version()'
Code: 210. DB::NetException: Connection refused (localhost:9000). (NETWORK_ERROR)
...
(repeats 5x with sleep 1, then a final unconditional clickhouse-client also fails)
+ exit 1
```

## Root cause

The `initd_test` script in `ci/jobs/install_check.py` polls `clickhouse-client -q 'SELECT version()'` only 5 times with `sleep 1` between attempts after the init.d wrapper returns. The wrapper prints `Server started` once the pid file exists, but the TCP listener on port 9000 can take longer than 5 seconds to bind on a slow CI host.

The preserved `clickhouse-server.log` from the 2026-05-28 hit confirms this: the server process forked at `13:35:50.269225`, and `preserve_logs.sh` (the `trap ... ERR` handler) copied the log at `13:35:50.586761` — only ~317 ms after fork. The server had not yet reached the listener-open stage by the time the test gave up.

The sibling `keeper_test` block in the same file already uses a 20-iteration loop with a `/dev/tcp` probe for the same purpose. This PR aligns `initd_test` with that pattern by bumping the retry budget from 5 to 30 iterations. Passing runs still complete on the first iteration because the loop breaks on the first successful client call.

## Related

- Re-fixes #86278, which was closed under the assumption the failure was no longer occurring.

## CI Reports

- 2026-05-28: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=549ac9afd4ee4fd58d177ad5b7b88b4a517805d6&name_0=MasterCI&name_1=Install%20packages%20%28amd_release%29
- 2026-05-22: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=94976df6f78a&name_0=MasterCI&name_1=Install%20packages%20%28amd_release%29
- 2026-05-11: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=66ce9a35d04f&name_0=MasterCI&name_1=Install%20packages%20%28amd_release%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

...


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.228`
<!-- ch-version-info:end -->