### PR TITLE
avoid trying cross join first in greedy join reordering

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/joinOrder.cpp
+++ b/src/Processors/QueryPlan/Optimizations/joinOrder.cpp
@@ -582,7 +582,7 @@ std::shared_ptr<DPJoinEntry> JoinOrderOptimizer::solveGreedy()
                 auto edge = getApplicableExpressions(left->relations, right->relations);
                 bool connected = !edge.empty()
                     || query_graph.areTransitivelyConnected(left->relations, right->relations);
-                if (!connected && best_plan)
+                if (!connected)
                     continue;
 
                 auto selectivity = computeSelectivity(edge, left->relations, right->relations);

--- a/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeJoin.cpp
@@ -728,8 +728,6 @@ void buildQueryGraph(QueryGraphBuilder & query_graph, QueryPlan::Node & node, Qu
     size_t rhs_count = addChildQueryGraph(query_graph, rhs_plan, nodes, rhs_label, allow_right_subgraph ? static_cast<int>(join_steps_limit - lhs_count) : 0);
 
     size_t total_inputs = query_graph.inputs.size();
-    if (join_kind == JoinKind::Cross || join_kind == JoinKind::Comma)
-        query_graph.join_kinds[0] = std::make_pair(BitSet{}, JoinKind::Cross);
 
     chassert(lhs_count && rhs_count && lhs_count + rhs_count == total_inputs && query_graph.relation_stats.size() == total_inputs);
 


### PR DESCRIPTION
### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...
