### PR TITLE
Do not mark move operations that allocate through memory-tracking containers as noexcept

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -8589,9 +8589,7 @@ Settings::Settings(const Settings & settings)
     : impl(std::make_unique<SettingsImpl>(*settings.impl))
 {}
 
-Settings::Settings(Settings && settings) noexcept
-    : impl(std::make_unique<SettingsImpl>(std::move(*settings.impl)))
-{}
+Settings::Settings(Settings && settings) noexcept = default;
 
 Settings::~Settings() = default;
 

--- a/src/Databases/DataLake/DatabaseDataLakeSettings.cpp
+++ b/src/Databases/DataLake/DatabaseDataLakeSettings.cpp
@@ -63,10 +63,7 @@ DatabaseDataLakeSettings::DatabaseDataLakeSettings(const DatabaseDataLakeSetting
 {
 }
 
-DatabaseDataLakeSettings::DatabaseDataLakeSettings(DatabaseDataLakeSettings && settings) noexcept
-    : impl(std::make_unique<DatabaseDataLakeSettingsImpl>(std::move(*settings.impl)))
-{
-}
+DatabaseDataLakeSettings::DatabaseDataLakeSettings(DatabaseDataLakeSettings && settings) noexcept = default;
 
 DatabaseDataLakeSettings::~DatabaseDataLakeSettings() = default;
 

--- a/src/Databases/DatabaseMetadataDiskSettings.cpp
+++ b/src/Databases/DatabaseMetadataDiskSettings.cpp
@@ -67,10 +67,7 @@ DatabaseMetadataDiskSettings::DatabaseMetadataDiskSettings(const DatabaseMetadat
 {
 }
 
-DatabaseMetadataDiskSettings::DatabaseMetadataDiskSettings(DatabaseMetadataDiskSettings && settings) noexcept
-    : impl(std::make_unique<DatabaseMetadataDiskSettingsImpl>(std::move(*settings.impl)))
-{
-}
+DatabaseMetadataDiskSettings::DatabaseMetadataDiskSettings(DatabaseMetadataDiskSettings && settings) noexcept = default;
 
 DatabaseMetadataDiskSettings::~DatabaseMetadataDiskSettings() = default;
 

--- a/src/Databases/DatabaseReplicatedSettings.cpp
+++ b/src/Databases/DatabaseReplicatedSettings.cpp
@@ -40,10 +40,7 @@ DatabaseReplicatedSettings::DatabaseReplicatedSettings(const DatabaseReplicatedS
 {
 }
 
-DatabaseReplicatedSettings::DatabaseReplicatedSettings(DatabaseReplicatedSettings && settings) noexcept
-    : impl(std::make_unique<DatabaseReplicatedSettingsImpl>(std::move(*settings.impl)))
-{
-}
+DatabaseReplicatedSettings::DatabaseReplicatedSettings(DatabaseReplicatedSettings && settings) noexcept = default;
 
 DatabaseReplicatedSettings::~DatabaseReplicatedSettings() = default;
 

--- a/src/Functions/HMAC.cpp
+++ b/src/Functions/HMAC.cpp
@@ -43,18 +43,40 @@ private:
 
     static void fetchAndGroupSupportedAlgorithms()
     {
-        MapWithMemoryTracking<std::string, SetWithMemoryTracking<std::string>> algorithms_map;
+        /// The callback is invoked from OpenSSL C code (EVP_MD_do_all_sorted), so it must be
+        /// noexcept: a C++ exception (e.g. a memory limit hit while inserting) must not unwind
+        /// through the C frames. Capture it and rethrow once the C call has returned.
+        struct CallbackState
+        {
+            MapWithMemoryTracking<std::string, SetWithMemoryTracking<std::string>> algorithms_map;
+            std::exception_ptr exception;
+        };
+        CallbackState state;
 
         EVP_MD_do_all_sorted(
-            [](const EVP_MD * /* md */, const char * md_name, const char * alias, void * arg)
+            [](const EVP_MD * /* md */, const char * md_name, const char * alias, void * arg) noexcept
             {
-                auto * algos_map = static_cast<MapWithMemoryTracking<std::string, SetWithMemoryTracking<std::string>> *>(arg);
-                std::string primary_name = md_name;
-                (*algos_map)[primary_name].insert(primary_name);
-                if (alias)
-                    (*algos_map)[primary_name].insert(alias);
+                auto & cb_state = *static_cast<CallbackState *>(arg);
+                if (cb_state.exception)
+                    return;
+                try
+                {
+                    std::string primary_name = md_name;
+                    cb_state.algorithms_map[primary_name].insert(primary_name);
+                    if (alias)
+                        cb_state.algorithms_map[primary_name].insert(alias);
+                }
+                catch (...)
+                {
+                    cb_state.exception = std::current_exception();
+                }
             },
-            &algorithms_map);
+            &state);
+
+        if (state.exception)
+            std::rethrow_exception(state.exception);
+
+        auto & algorithms_map = state.algorithms_map;
 
         /// Filter out algorithms that cannot actually be fetched
         /// (e.g., non-approved algorithms when running in FIPS mode)

--- a/src/Functions/registerFunctions.cpp
+++ b/src/Functions/registerFunctions.cpp
@@ -1,6 +1,7 @@
 #include "config.h"
 
 #include <Functions/FunctionFactory.h>
+#include <Common/MemoryTrackerBlockerInThread.h>
 
 
 namespace DB
@@ -8,6 +9,11 @@ namespace DB
 
 void registerFunctions()
 {
+    /// Registration runs once and allocates while building static function metadata (for example
+    /// HMAC enumerates the OpenSSL digests through a C callback). It must not be subject to the
+    /// memory tracker's limit or fault injection, so block tracking for its duration.
+    MemoryTrackerBlockerInThread blocker;
+
     auto & factory = FunctionFactory::instance();
 
     for (const auto & [_, reg] : FunctionRegisterMap::instance())

--- a/src/IO/S3AuthSettings.cpp
+++ b/src/IO/S3AuthSettings.cpp
@@ -101,14 +101,7 @@ S3AuthSettings::S3AuthSettings(const S3AuthSettings & settings)
 {
 }
 
-S3AuthSettings::S3AuthSettings(S3AuthSettings && settings) noexcept
-    : headers(std::move(settings.headers))
-    , access_headers(std::move(settings.access_headers))
-    , users(std::move(settings.users))
-    , server_side_encryption_kms_config(std::move(settings.server_side_encryption_kms_config))
-    , impl(std::make_unique<S3AuthSettingsImpl>(std::move(*settings.impl)))
-{
-}
+S3AuthSettings::S3AuthSettings(S3AuthSettings && settings) noexcept = default;
 
 S3AuthSettings::S3AuthSettings(const DB::Settings & settings) : impl(std::make_unique<S3AuthSettingsImpl>())
 {

--- a/src/IO/S3AuthSettings.cpp
+++ b/src/IO/S3AuthSettings.cpp
@@ -112,16 +112,7 @@ S3AuthSettings::~S3AuthSettings() = default;
 
 S3AUTH_SETTINGS_SUPPORTED_TYPES(S3AuthSettings, IMPLEMENT_SETTING_SUBSCRIPT_OPERATOR)
 
-S3AuthSettings & S3AuthSettings::operator=(S3AuthSettings && settings) noexcept
-{
-    headers = std::move(settings.headers);
-    access_headers = std::move(settings.access_headers);
-    users = std::move(settings.users);
-    server_side_encryption_kms_config = std::move(settings.server_side_encryption_kms_config);
-    *impl = std::move(*settings.impl);
-
-    return *this;
-}
+S3AuthSettings & S3AuthSettings::operator=(S3AuthSettings && settings) noexcept = default;
 
 bool S3AuthSettings::operator==(const S3AuthSettings & right)
 {

--- a/src/IO/S3RequestSettings.cpp
+++ b/src/IO/S3RequestSettings.cpp
@@ -154,14 +154,7 @@ S3RequestSettings::~S3RequestSettings() = default;
 
 S3REQUEST_SETTINGS_SUPPORTED_TYPES(S3RequestSettings, IMPLEMENT_SETTING_SUBSCRIPT_OPERATOR)
 
-S3RequestSettings & S3RequestSettings::operator=(S3RequestSettings && settings) noexcept
-{
-    request_throttler = std::move(settings.request_throttler);
-    proxy_resolver = std::move(settings.proxy_resolver);
-    *impl = std::move(*settings.impl);
-
-    return *this;
-}
+S3RequestSettings & S3RequestSettings::operator=(S3RequestSettings && settings) noexcept = default;
 
 void S3RequestSettings::updateFromSettings(const DB::Settings & settings, bool if_changed, bool validate_settings)
 {

--- a/src/IO/S3RequestSettings.cpp
+++ b/src/IO/S3RequestSettings.cpp
@@ -102,12 +102,7 @@ S3RequestSettings::S3RequestSettings(const S3RequestSettings & settings)
 {
 }
 
-S3RequestSettings::S3RequestSettings(S3RequestSettings && settings) noexcept
-    : request_throttler(std::move(settings.request_throttler))
-    , proxy_resolver(std::move(settings.proxy_resolver))
-    , impl(std::make_unique<S3RequestSettingsImpl>(std::move(*settings.impl)))
-{
-}
+S3RequestSettings::S3RequestSettings(S3RequestSettings && settings) noexcept = default;
 
 S3RequestSettings::S3RequestSettings(
     const Poco::Util::AbstractConfiguration & config,

--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -1705,7 +1705,7 @@ bool ActionsDAG::hasNonDeterministic() const
     return false;
 }
 
-void ActionsDAG::decorrelate() noexcept
+void ActionsDAG::decorrelate()
 {
     for (auto & node : nodes)
     {

--- a/src/Interpreters/ActionsDAG.h
+++ b/src/Interpreters/ActionsDAG.h
@@ -331,7 +331,8 @@ public:
     );
 
     /// Replace all PLACEHOLDER nodes with INPUT nodes
-    void decorrelate() noexcept;
+    /// Not noexcept: appends to the inputs vector, which can throw on allocation.
+    void decorrelate();
 
     /// For apply materialize() function for every output.
     /// Also add aliases so the result names remain unchanged.

--- a/src/Interpreters/FileCache/FileCacheSettings.cpp
+++ b/src/Interpreters/FileCache/FileCacheSettings.cpp
@@ -80,14 +80,11 @@ FileCacheSettings::FileCacheSettings(const FileCacheSettings & settings)
 {
 }
 
-FileCacheSettings::FileCacheSettings(FileCacheSettings && settings) noexcept
-    : impl(std::make_unique<FileCacheSettingsImpl>(std::move(*settings.impl)))
-{
-}
+FileCacheSettings::FileCacheSettings(FileCacheSettings && settings) noexcept = default;
 
 FileCacheSettings & FileCacheSettings::operator=(FileCacheSettings && settings) noexcept
 {
-    impl = std::make_unique<FileCacheSettingsImpl>(std::move(*settings.impl));
+    *impl = std::move(*settings.impl);
     return *this;
 }
 

--- a/src/Interpreters/FileCache/FileCacheSettings.cpp
+++ b/src/Interpreters/FileCache/FileCacheSettings.cpp
@@ -82,11 +82,7 @@ FileCacheSettings::FileCacheSettings(const FileCacheSettings & settings)
 
 FileCacheSettings::FileCacheSettings(FileCacheSettings && settings) noexcept = default;
 
-FileCacheSettings & FileCacheSettings::operator=(FileCacheSettings && settings) noexcept
-{
-    *impl = std::move(*settings.impl);
-    return *this;
-}
+FileCacheSettings & FileCacheSettings::operator=(FileCacheSettings && settings) noexcept = default;
 
 bool FileCacheSettings::operator==(const FileCacheSettings & settings) const noexcept
 {

--- a/src/Processors/QueryPlan/QueryPlan.cpp
+++ b/src/Processors/QueryPlan/QueryPlan.cpp
@@ -55,7 +55,7 @@ SettingsChanges ExplainPlanOptions::toSettingsChanges() const
 QueryPlan::QueryPlan() = default;
 QueryPlan::~QueryPlan() = default;
 QueryPlan::QueryPlan(QueryPlan &&) noexcept = default;
-QueryPlan & QueryPlan::operator=(QueryPlan &&) = default;
+QueryPlan & QueryPlan::operator=(QueryPlan &&) = default; /// NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
 
 void QueryPlan::checkInitialized() const
 {

--- a/src/Processors/QueryPlan/QueryPlan.cpp
+++ b/src/Processors/QueryPlan/QueryPlan.cpp
@@ -55,7 +55,7 @@ SettingsChanges ExplainPlanOptions::toSettingsChanges() const
 QueryPlan::QueryPlan() = default;
 QueryPlan::~QueryPlan() = default;
 QueryPlan::QueryPlan(QueryPlan &&) noexcept = default;
-QueryPlan & QueryPlan::operator=(QueryPlan &&) noexcept = default;
+QueryPlan & QueryPlan::operator=(QueryPlan &&) = default;
 
 void QueryPlan::checkInitialized() const
 {

--- a/src/Processors/QueryPlan/QueryPlan.h
+++ b/src/Processors/QueryPlan/QueryPlan.h
@@ -94,7 +94,7 @@ public:
     QueryPlan(QueryPlan &&) noexcept;
     /// Not noexcept: move-assignment appends the QueryPlanResourceHolder, which allocates and can
     /// throw. The move constructor stays noexcept because it steals the holder instead of appending.
-    QueryPlan & operator=(QueryPlan &&);
+    QueryPlan & operator=(QueryPlan &&); /// NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
 
     void unitePlans(QueryPlanStepPtr step, std::vector<QueryPlanPtr> plans);
     void addStep(QueryPlanStepPtr step);

--- a/src/Processors/QueryPlan/QueryPlan.h
+++ b/src/Processors/QueryPlan/QueryPlan.h
@@ -92,7 +92,9 @@ public:
     QueryPlan();
     ~QueryPlan();
     QueryPlan(QueryPlan &&) noexcept;
-    QueryPlan & operator=(QueryPlan &&) noexcept;
+    /// Not noexcept: move-assignment appends the QueryPlanResourceHolder, which allocates and can
+    /// throw. The move constructor stays noexcept because it steals the holder instead of appending.
+    QueryPlan & operator=(QueryPlan &&);
 
     void unitePlans(QueryPlanStepPtr step, std::vector<QueryPlanPtr> plans);
     void addStep(QueryPlanStepPtr step);

--- a/src/QueryPipeline/BlockIO.cpp
+++ b/src/QueryPipeline/BlockIO.cpp
@@ -32,7 +32,7 @@ void BlockIO::reset()
     /// TODO Do we need also reset callbacks? In which order?
 }
 
-BlockIO & BlockIO::operator= (BlockIO && rhs) noexcept
+BlockIO & BlockIO::operator= (BlockIO && rhs)
 {
     if (this == &rhs)
         return *this;

--- a/src/QueryPipeline/BlockIO.cpp
+++ b/src/QueryPipeline/BlockIO.cpp
@@ -32,7 +32,7 @@ void BlockIO::reset()
     /// TODO Do we need also reset callbacks? In which order?
 }
 
-BlockIO & BlockIO::operator= (BlockIO && rhs)
+BlockIO & BlockIO::operator= (BlockIO && rhs) /// NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
 {
     if (this == &rhs)
         return *this;

--- a/src/QueryPipeline/BlockIO.h
+++ b/src/QueryPipeline/BlockIO.h
@@ -28,7 +28,7 @@ struct BlockIO
 
     /// Not noexcept: moves the QueryPipeline, whose move-assignment appends resources and can
     /// throw MEMORY_LIMIT_EXCEEDED.
-    BlockIO & operator= (BlockIO && rhs);
+    BlockIO & operator= (BlockIO && rhs); /// NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
     ~BlockIO();
 
     BlockIO(const BlockIO &) = delete;

--- a/src/QueryPipeline/BlockIO.h
+++ b/src/QueryPipeline/BlockIO.h
@@ -26,7 +26,9 @@ struct BlockIO
     BlockIO() = default;
     BlockIO(BlockIO &&) = default;
 
-    BlockIO & operator= (BlockIO && rhs) noexcept;
+    /// Not noexcept: moves the QueryPipeline, whose move-assignment appends resources and can
+    /// throw MEMORY_LIMIT_EXCEEDED.
+    BlockIO & operator= (BlockIO && rhs);
     ~BlockIO();
 
     BlockIO(const BlockIO &) = delete;

--- a/src/QueryPipeline/Chain.h
+++ b/src/QueryPipeline/Chain.h
@@ -24,7 +24,8 @@ public:
     Chain(Chain &&) = default;
     Chain(const Chain &) = delete;
 
-    Chain & operator=(Chain &&) = default;
+    /// Not noexcept: the QueryPlanResourceHolder it owns appends on move-assignment, which can throw.
+    Chain & operator=(Chain &&) = default; /// NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
     Chain & operator=(const Chain &) = delete;
 
     explicit Chain(ProcessorPtr processor);

--- a/src/QueryPipeline/QueryPipeline.cpp
+++ b/src/QueryPipeline/QueryPipeline.cpp
@@ -60,7 +60,7 @@ QueryPipeline::QueryPipeline()
 }
 
 QueryPipeline::QueryPipeline(QueryPipeline &&) noexcept = default;
-QueryPipeline & QueryPipeline::operator=(QueryPipeline &&) noexcept = default;
+QueryPipeline & QueryPipeline::operator=(QueryPipeline &&) = default;
 QueryPipeline::~QueryPipeline() = default;
 
 static void checkInput(const InputPort & input, const ProcessorPtr & processor)

--- a/src/QueryPipeline/QueryPipeline.cpp
+++ b/src/QueryPipeline/QueryPipeline.cpp
@@ -60,7 +60,7 @@ QueryPipeline::QueryPipeline()
 }
 
 QueryPipeline::QueryPipeline(QueryPipeline &&) noexcept = default;
-QueryPipeline & QueryPipeline::operator=(QueryPipeline &&) = default;
+QueryPipeline & QueryPipeline::operator=(QueryPipeline &&) = default; /// NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
 QueryPipeline::~QueryPipeline() = default;
 
 static void checkInput(const InputPort & input, const ProcessorPtr & processor)

--- a/src/QueryPipeline/QueryPipeline.h
+++ b/src/QueryPipeline/QueryPipeline.h
@@ -55,7 +55,7 @@ public:
 
     /// Not noexcept: move-assignment appends QueryPlanResourceHolder resources, which allocates
     /// through memory-tracking containers and can throw MEMORY_LIMIT_EXCEEDED.
-    QueryPipeline & operator=(QueryPipeline &&);
+    QueryPipeline & operator=(QueryPipeline &&); /// NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
     QueryPipeline & operator=(const QueryPipeline &) = delete;
 
     ~QueryPipeline();

--- a/src/QueryPipeline/QueryPipeline.h
+++ b/src/QueryPipeline/QueryPipeline.h
@@ -53,7 +53,9 @@ public:
     QueryPipeline(QueryPipeline &&) noexcept;
     QueryPipeline(const QueryPipeline &) = delete;
 
-    QueryPipeline & operator=(QueryPipeline &&) noexcept;
+    /// Not noexcept: move-assignment appends QueryPlanResourceHolder resources, which allocates
+    /// through memory-tracking containers and can throw MEMORY_LIMIT_EXCEEDED.
+    QueryPipeline & operator=(QueryPipeline &&);
     QueryPipeline & operator=(const QueryPipeline &) = delete;
 
     ~QueryPipeline();

--- a/src/QueryPipeline/QueryPipelineBuilder.h
+++ b/src/QueryPipeline/QueryPipelineBuilder.h
@@ -49,7 +49,8 @@ public:
     ~QueryPipelineBuilder() = default;
     QueryPipelineBuilder(QueryPipelineBuilder &&) = default;
     QueryPipelineBuilder(const QueryPipelineBuilder &) = delete;
-    QueryPipelineBuilder & operator= (QueryPipelineBuilder && rhs) = default;
+    /// Not noexcept: the QueryPlanResourceHolder it owns appends on move-assignment, which can throw.
+    QueryPipelineBuilder & operator= (QueryPipelineBuilder && rhs) = default; /// NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
     QueryPipelineBuilder & operator= (const QueryPipelineBuilder & rhs) = delete;
 
     /// All pipes must have same header.

--- a/src/QueryPipeline/QueryPlanResourceHolder.cpp
+++ b/src/QueryPipeline/QueryPlanResourceHolder.cpp
@@ -4,7 +4,7 @@
 namespace DB
 {
 
-QueryPlanResourceHolder & QueryPlanResourceHolder::append(const QueryPlanResourceHolder & rhs) noexcept
+QueryPlanResourceHolder & QueryPlanResourceHolder::append(const QueryPlanResourceHolder & rhs)
 {
     table_locks.insert(table_locks.end(), rhs.table_locks.begin(), rhs.table_locks.end());
     storage_holders.insert(storage_holders.end(), rhs.storage_holders.begin(), rhs.storage_holders.end());
@@ -17,7 +17,7 @@ QueryPlanResourceHolder & QueryPlanResourceHolder::append(const QueryPlanResourc
     return *this;
 }
 
-QueryPlanResourceHolder & QueryPlanResourceHolder::operator=(QueryPlanResourceHolder && rhs) noexcept
+QueryPlanResourceHolder & QueryPlanResourceHolder::operator=(QueryPlanResourceHolder && rhs)
 {
     append(rhs);
     return *this;

--- a/src/QueryPipeline/QueryPlanResourceHolder.cpp
+++ b/src/QueryPipeline/QueryPlanResourceHolder.cpp
@@ -17,7 +17,7 @@ QueryPlanResourceHolder & QueryPlanResourceHolder::append(const QueryPlanResourc
     return *this;
 }
 
-QueryPlanResourceHolder & QueryPlanResourceHolder::operator=(QueryPlanResourceHolder && rhs)
+QueryPlanResourceHolder & QueryPlanResourceHolder::operator=(QueryPlanResourceHolder && rhs) /// NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
 {
     append(rhs);
     return *this;

--- a/src/QueryPipeline/QueryPlanResourceHolder.h
+++ b/src/QueryPipeline/QueryPlanResourceHolder.h
@@ -35,7 +35,7 @@ struct QueryPlanResourceHolder
     /// Custom move assignment does not destroy data from lhs. It appends data from rhs to lhs.
     /// append (and thus this assignment) allocates, so it can throw (`std::bad_alloc`, or
     /// `MEMORY_LIMIT_EXCEEDED` from the memory-tracking containers) and must not be noexcept.
-    QueryPlanResourceHolder & operator=(QueryPlanResourceHolder &&);
+    QueryPlanResourceHolder & operator=(QueryPlanResourceHolder &&); /// NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
     QueryPlanResourceHolder & append(const QueryPlanResourceHolder & rhs);
 
     /// Some processors may implicitly use Context or temporary Storage created by Interpreter.

--- a/src/QueryPipeline/QueryPlanResourceHolder.h
+++ b/src/QueryPipeline/QueryPlanResourceHolder.h
@@ -33,8 +33,8 @@ struct QueryPlanResourceHolder
     QueryPlanResourceHolder & operator=(QueryPlanResourceHolder &) = delete;
 
     /// Custom move assignment does not destroy data from lhs. It appends data from rhs to lhs.
-    /// Note: append (and thus this assignment) allocates through the memory-tracking containers,
-    /// so it can throw MEMORY_LIMIT_EXCEEDED and must not be noexcept.
+    /// append (and thus this assignment) allocates, so it can throw (`std::bad_alloc`, or
+    /// `MEMORY_LIMIT_EXCEEDED` from the memory-tracking containers) and must not be noexcept.
     QueryPlanResourceHolder & operator=(QueryPlanResourceHolder &&);
     QueryPlanResourceHolder & append(const QueryPlanResourceHolder & rhs);
 

--- a/src/QueryPipeline/QueryPlanResourceHolder.h
+++ b/src/QueryPipeline/QueryPlanResourceHolder.h
@@ -33,8 +33,10 @@ struct QueryPlanResourceHolder
     QueryPlanResourceHolder & operator=(QueryPlanResourceHolder &) = delete;
 
     /// Custom move assignment does not destroy data from lhs. It appends data from rhs to lhs.
-    QueryPlanResourceHolder & operator=(QueryPlanResourceHolder &&) noexcept;
-    QueryPlanResourceHolder & append(const QueryPlanResourceHolder & rhs) noexcept;
+    /// Note: append (and thus this assignment) allocates through the memory-tracking containers,
+    /// so it can throw MEMORY_LIMIT_EXCEEDED and must not be noexcept.
+    QueryPlanResourceHolder & operator=(QueryPlanResourceHolder &&);
+    QueryPlanResourceHolder & append(const QueryPlanResourceHolder & rhs);
 
     /// Some processors may implicitly use Context or temporary Storage created by Interpreter.
     /// But lifetime of Streams is not nested in lifetime of Interpreters, so we have to store it here,

--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -107,7 +107,7 @@ ColumnDescription & ColumnDescription::operator=(const ColumnDescription & other
     return *this;
 }
 
-ColumnDescription & ColumnDescription::operator=(ColumnDescription && other)
+ColumnDescription & ColumnDescription::operator=(ColumnDescription && other) /// NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
 {
     if (this == &other)
         return *this;

--- a/src/Storages/ColumnsDescription.cpp
+++ b/src/Storages/ColumnsDescription.cpp
@@ -107,7 +107,7 @@ ColumnDescription & ColumnDescription::operator=(const ColumnDescription & other
     return *this;
 }
 
-ColumnDescription & ColumnDescription::operator=(ColumnDescription && other) noexcept
+ColumnDescription & ColumnDescription::operator=(ColumnDescription && other)
 {
     if (this == &other)
         return *this;

--- a/src/Storages/ColumnsDescription.h
+++ b/src/Storages/ColumnsDescription.h
@@ -106,8 +106,9 @@ struct ColumnDescription
     ColumnDescription() = default;
     ColumnDescription(const ColumnDescription & other) { *this = other; }
     ColumnDescription & operator=(const ColumnDescription & other);
-    ColumnDescription(ColumnDescription && other) noexcept { *this = std::move(other); }
-    ColumnDescription & operator=(ColumnDescription && other) noexcept;
+    /// Not noexcept: the move-assignment clones the codec/TTL ASTs, which allocates and can throw.
+    ColumnDescription(ColumnDescription && other) { *this = std::move(other); }
+    ColumnDescription & operator=(ColumnDescription && other);
 
     ColumnDescription(String name_, DataTypePtr type_);
     ColumnDescription(String name_, DataTypePtr type_, String comment_);

--- a/src/Storages/ColumnsDescription.h
+++ b/src/Storages/ColumnsDescription.h
@@ -107,8 +107,8 @@ struct ColumnDescription
     ColumnDescription(const ColumnDescription & other) { *this = other; }
     ColumnDescription & operator=(const ColumnDescription & other);
     /// Not noexcept: the move-assignment clones the codec/TTL ASTs, which allocates and can throw.
-    ColumnDescription(ColumnDescription && other) { *this = std::move(other); }
-    ColumnDescription & operator=(ColumnDescription && other);
+    ColumnDescription(ColumnDescription && other) { *this = std::move(other); } /// NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
+    ColumnDescription & operator=(ColumnDescription && other); /// NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
 
     ColumnDescription(String name_, DataTypePtr type_);
     ColumnDescription(String name_, DataTypePtr type_, String comment_);

--- a/src/Storages/ConstraintsDescription.cpp
+++ b/src/Storages/ConstraintsDescription.cpp
@@ -310,13 +310,13 @@ ConstraintsDescription & ConstraintsDescription::operator=(const ConstraintsDesc
     return *this;
 }
 
-ConstraintsDescription::ConstraintsDescription(ConstraintsDescription && other)
+ConstraintsDescription::ConstraintsDescription(ConstraintsDescription && other) /// NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
     : constraints(std::move(other.constraints))
 {
     update();
 }
 
-ConstraintsDescription & ConstraintsDescription::operator=(ConstraintsDescription && other)
+ConstraintsDescription & ConstraintsDescription::operator=(ConstraintsDescription && other) /// NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
 {
     constraints = std::move(other.constraints);
     update();

--- a/src/Storages/ConstraintsDescription.cpp
+++ b/src/Storages/ConstraintsDescription.cpp
@@ -310,13 +310,13 @@ ConstraintsDescription & ConstraintsDescription::operator=(const ConstraintsDesc
     return *this;
 }
 
-ConstraintsDescription::ConstraintsDescription(ConstraintsDescription && other) noexcept
+ConstraintsDescription::ConstraintsDescription(ConstraintsDescription && other)
     : constraints(std::move(other.constraints))
 {
     update();
 }
 
-ConstraintsDescription & ConstraintsDescription::operator=(ConstraintsDescription && other) noexcept
+ConstraintsDescription & ConstraintsDescription::operator=(ConstraintsDescription && other)
 {
     constraints = std::move(other.constraints);
     update();

--- a/src/Storages/ConstraintsDescription.h
+++ b/src/Storages/ConstraintsDescription.h
@@ -29,8 +29,10 @@ public:
     ConstraintsDescription(const ConstraintsDescription & other);
     ConstraintsDescription & operator=(const ConstraintsDescription & other);
 
-    ConstraintsDescription(ConstraintsDescription && other) noexcept;
-    ConstraintsDescription & operator=(ConstraintsDescription && other) noexcept;
+    /// Not noexcept: the move operations rebuild the derived data via update(), which allocates
+    /// (make_unique, CNF construction) and can throw, e.g. MEMORY_LIMIT_EXCEEDED.
+    ConstraintsDescription(ConstraintsDescription && other);
+    ConstraintsDescription & operator=(ConstraintsDescription && other);
 
     bool empty() const { return constraints.empty(); }
     String toString() const;

--- a/src/Storages/ConstraintsDescription.h
+++ b/src/Storages/ConstraintsDescription.h
@@ -31,8 +31,8 @@ public:
 
     /// Not noexcept: the move operations rebuild the derived data via update(), which allocates
     /// (make_unique, CNF construction) and can throw, e.g. MEMORY_LIMIT_EXCEEDED.
-    ConstraintsDescription(ConstraintsDescription && other);
-    ConstraintsDescription & operator=(ConstraintsDescription && other);
+    ConstraintsDescription(ConstraintsDescription && other); /// NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
+    ConstraintsDescription & operator=(ConstraintsDescription && other); /// NOLINT(hicpp-noexcept-move,performance-noexcept-move-constructor)
 
     bool empty() const { return constraints.empty(); }
     String toString() const;

--- a/src/Storages/Distributed/DistributedSettings.cpp
+++ b/src/Storages/Distributed/DistributedSettings.cpp
@@ -44,10 +44,7 @@ DistributedSettings::DistributedSettings(const DistributedSettings & settings)
 {
 }
 
-DistributedSettings::DistributedSettings(DistributedSettings && settings) noexcept
-    : impl(std::make_unique<DistributedSettingsImpl>(std::move(*settings.impl)))
-{
-}
+DistributedSettings::DistributedSettings(DistributedSettings && settings) noexcept = default;
 
 DistributedSettings::~DistributedSettings() = default;
 

--- a/src/Storages/ExecutableSettings.cpp
+++ b/src/Storages/ExecutableSettings.cpp
@@ -43,13 +43,7 @@ ExecutableSettings::ExecutableSettings(const ExecutableSettings & settings)
 {
 }
 
-ExecutableSettings::ExecutableSettings(ExecutableSettings && settings) noexcept
-    : script_name(std::move(settings.script_name))
-    , script_arguments(std::move(settings.script_arguments))
-    , is_executable_pool(settings.is_executable_pool)
-    , impl(std::make_unique<ExecutableSettingsImpl>(std::move(*settings.impl)))
-{
-}
+ExecutableSettings::ExecutableSettings(ExecutableSettings && settings) noexcept = default;
 
 ExecutableSettings::~ExecutableSettings() = default;
 

--- a/src/Storages/FileLog/FileLogSettings.cpp
+++ b/src/Storages/FileLog/FileLogSettings.cpp
@@ -42,10 +42,7 @@ FileLogSettings::FileLogSettings(const FileLogSettings & settings) : impl(std::m
 {
 }
 
-FileLogSettings::FileLogSettings(FileLogSettings && settings) noexcept
-    : impl(std::make_unique<FileLogSettingsImpl>(std::move(*settings.impl)))
-{
-}
+FileLogSettings::FileLogSettings(FileLogSettings && settings) noexcept = default;
 
 FileLogSettings::~FileLogSettings() = default;
 

--- a/src/Storages/Hive/HiveSettings.cpp
+++ b/src/Storages/Hive/HiveSettings.cpp
@@ -40,9 +40,7 @@ HiveSettings::HiveSettings(const HiveSettings & settings) : impl(std::make_uniqu
 {
 }
 
-HiveSettings::HiveSettings(HiveSettings && settings) noexcept : impl(std::make_unique<HiveSettingsImpl>(std::move(*settings.impl)))
-{
-}
+HiveSettings::HiveSettings(HiveSettings && settings) noexcept = default;
 
 HiveSettings::~HiveSettings() = default;
 

--- a/src/Storages/Kafka/KafkaSettings.cpp
+++ b/src/Storages/Kafka/KafkaSettings.cpp
@@ -79,9 +79,7 @@ KafkaSettings::KafkaSettings(const KafkaSettings & settings) : impl(std::make_un
 {
 }
 
-KafkaSettings::KafkaSettings(KafkaSettings && settings) noexcept : impl(std::make_unique<KafkaSettingsImpl>(std::move(*settings.impl)))
-{
-}
+KafkaSettings::KafkaSettings(KafkaSettings && settings) noexcept = default;
 
 KafkaSettings::~KafkaSettings() = default;
 

--- a/src/Storages/MaterializedView/RefreshSettings.cpp
+++ b/src/Storages/MaterializedView/RefreshSettings.cpp
@@ -24,10 +24,7 @@ RefreshSettings::RefreshSettings(const RefreshSettings & settings) : impl(std::m
 {
 }
 
-RefreshSettings::RefreshSettings(RefreshSettings && settings) noexcept
-    : impl(std::make_unique<RefreshSettingsImpl>(std::move(*settings.impl)))
-{
-}
+RefreshSettings::RefreshSettings(RefreshSettings && settings) noexcept = default;
 
 RefreshSettings::~RefreshSettings() = default;
 

--- a/src/Storages/MemorySettings.cpp
+++ b/src/Storages/MemorySettings.cpp
@@ -33,9 +33,7 @@ MemorySettings::MemorySettings(const MemorySettings & settings) : impl(std::make
 {
 }
 
-MemorySettings::MemorySettings(MemorySettings && settings) noexcept : impl(std::make_unique<MemorySettingsImpl>(std::move(*settings.impl)))
-{
-}
+MemorySettings::MemorySettings(MemorySettings && settings) noexcept = default;
 
 MemorySettings::~MemorySettings() = default;
 

--- a/src/Storages/MemorySettings.cpp
+++ b/src/Storages/MemorySettings.cpp
@@ -37,11 +37,7 @@ MemorySettings::MemorySettings(MemorySettings && settings) noexcept = default;
 
 MemorySettings::~MemorySettings() = default;
 
-MemorySettings & MemorySettings::operator=(MemorySettings && settings) noexcept
-{
-    *impl = std::move(*settings.impl);
-    return *this;
-}
+MemorySettings & MemorySettings::operator=(MemorySettings && settings) noexcept = default;
 
 MEMORY_SETTINGS_SUPPORTED_TYPES(MemorySettings, IMPLEMENT_SETTING_SUBSCRIPT_OPERATOR)
 

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -2588,10 +2588,7 @@ MergeTreeSettings::MergeTreeSettings(const MergeTreeSettings & settings) : impl(
 {
 }
 
-MergeTreeSettings::MergeTreeSettings(MergeTreeSettings && settings) noexcept
-    : impl(std::make_unique<MergeTreeSettingsImpl>(std::move(*settings.impl)))
-{
-}
+MergeTreeSettings::MergeTreeSettings(MergeTreeSettings && settings) noexcept = default;
 
 MergeTreeSettings::~MergeTreeSettings() = default;
 

--- a/src/Storages/MySQL/MySQLSettings.cpp
+++ b/src/Storages/MySQL/MySQLSettings.cpp
@@ -42,9 +42,7 @@ MySQLSettings::MySQLSettings(const MySQLSettings & settings) : impl(std::make_un
 {
 }
 
-MySQLSettings::MySQLSettings(MySQLSettings && settings) noexcept : impl(std::make_unique<MySQLSettingsImpl>(std::move(*settings.impl)))
-{
-}
+MySQLSettings::MySQLSettings(MySQLSettings && settings) noexcept = default;
 
 MySQLSettings::~MySQLSettings() = default;
 

--- a/src/Storages/NATS/NATSSettings.cpp
+++ b/src/Storages/NATS/NATSSettings.cpp
@@ -61,9 +61,7 @@ NATSSettings::NATSSettings(const NATSSettings & settings) : impl(std::make_uniqu
 {
 }
 
-NATSSettings::NATSSettings(NATSSettings && settings) noexcept : impl(std::make_unique<NATSSettingsImpl>(std::move(*settings.impl)))
-{
-}
+NATSSettings::NATSSettings(NATSSettings && settings) noexcept = default;
 
 NATSSettings::~NATSSettings() = default;
 

--- a/src/Storages/ObjectStorage/DataLakes/DataLakeStorageSettings.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DataLakeStorageSettings.cpp
@@ -22,10 +22,7 @@ DataLakeStorageSettings::DataLakeStorageSettings(const DataLakeStorageSettings &
 {
 }
 
-DataLakeStorageSettings::DataLakeStorageSettings(DataLakeStorageSettings && settings) noexcept
-    : impl(std::make_unique<DataLakeStorageSettingsImpl>(std::move(*settings.impl)))
-{
-}
+DataLakeStorageSettings::DataLakeStorageSettings(DataLakeStorageSettings && settings) noexcept = default;
 
 
 DataLakeStorageSettings::~DataLakeStorageSettings() = default;

--- a/src/Storages/ObjectStorage/StorageObjectStorageSettings.cpp
+++ b/src/Storages/ObjectStorage/StorageObjectStorageSettings.cpp
@@ -23,10 +23,7 @@ StorageObjectStorageSettings::StorageObjectStorageSettings(const StorageObjectSt
 {
 }
 
-StorageObjectStorageSettings::StorageObjectStorageSettings(StorageObjectStorageSettings && settings) noexcept
-    : impl(std::make_unique<StorageObjectStorageSettingsImpl>(std::move(*settings.impl)))
-{
-}
+StorageObjectStorageSettings::StorageObjectStorageSettings(StorageObjectStorageSettings && settings) noexcept = default;
 
 
 StorageObjectStorageSettings::~StorageObjectStorageSettings() = default;

--- a/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
+++ b/src/Storages/ObjectStorageQueue/ObjectStorageQueueSettings.cpp
@@ -85,10 +85,7 @@ ObjectStorageQueueSettings::ObjectStorageQueueSettings(const ObjectStorageQueueS
 {
 }
 
-ObjectStorageQueueSettings::ObjectStorageQueueSettings(ObjectStorageQueueSettings && settings) noexcept
-    : impl(std::make_unique<ObjectStorageQueueSettingsImpl>(std::move(*settings.impl)))
-{
-}
+ObjectStorageQueueSettings::ObjectStorageQueueSettings(ObjectStorageQueueSettings && settings) noexcept = default;
 
 void ObjectStorageQueueSettings::dumpToSystemEngineSettingsColumns(
     MutableColumnsAndConstraints & params,

--- a/src/Storages/PostgreSQL/MaterializedPostgreSQLSettings.cpp
+++ b/src/Storages/PostgreSQL/MaterializedPostgreSQLSettings.cpp
@@ -45,10 +45,7 @@ MaterializedPostgreSQLSettings::MaterializedPostgreSQLSettings(const Materialize
 {
 }
 
-MaterializedPostgreSQLSettings::MaterializedPostgreSQLSettings(MaterializedPostgreSQLSettings && settings) noexcept
-    : impl(std::make_unique<MaterializedPostgreSQLSettingsImpl>(std::move(*settings.impl)))
-{
-}
+MaterializedPostgreSQLSettings::MaterializedPostgreSQLSettings(MaterializedPostgreSQLSettings && settings) noexcept = default;
 
 MaterializedPostgreSQLSettings::~MaterializedPostgreSQLSettings() = default;
 

--- a/src/Storages/RabbitMQ/RabbitMQSettings.cpp
+++ b/src/Storages/RabbitMQ/RabbitMQSettings.cpp
@@ -64,10 +64,7 @@ RabbitMQSettings::RabbitMQSettings(const RabbitMQSettings & settings) : impl(std
 {
 }
 
-RabbitMQSettings::RabbitMQSettings(RabbitMQSettings && settings) noexcept
-    : impl(std::make_unique<RabbitMQSettingsImpl>(std::move(*settings.impl)))
-{
-}
+RabbitMQSettings::RabbitMQSettings(RabbitMQSettings && settings) noexcept = default;
 
 RabbitMQSettings::~RabbitMQSettings() = default;
 

--- a/src/Storages/RocksDB/RocksDBSettings.cpp
+++ b/src/Storages/RocksDB/RocksDBSettings.cpp
@@ -30,10 +30,7 @@ RocksDBSettings::RocksDBSettings(const RocksDBSettings & settings) : impl(std::m
 {
 }
 
-RocksDBSettings::RocksDBSettings(RocksDBSettings && settings) noexcept
-    : impl(std::make_unique<RocksDBSettingsImpl>(std::move(*settings.impl)))
-{
-}
+RocksDBSettings::RocksDBSettings(RocksDBSettings && settings) noexcept = default;
 
 RocksDBSettings::~RocksDBSettings() = default;
 

--- a/src/Storages/SetSettings.cpp
+++ b/src/Storages/SetSettings.cpp
@@ -35,9 +35,7 @@ SetSettings::SetSettings(const SetSettings & settings) : impl(std::make_unique<S
 {
 }
 
-SetSettings::SetSettings(SetSettings && settings) noexcept : impl(std::make_unique<SetSettingsImpl>(std::move(*settings.impl)))
-{
-}
+SetSettings::SetSettings(SetSettings && settings) noexcept = default;
 
 SetSettings::~SetSettings() = default;
 

--- a/src/Storages/TimeSeries/TimeSeriesSettings.cpp
+++ b/src/Storages/TimeSeries/TimeSeriesSettings.cpp
@@ -40,10 +40,7 @@ TimeSeriesSettings::TimeSeriesSettings(const TimeSeriesSettings & settings) : im
 {
 }
 
-TimeSeriesSettings::TimeSeriesSettings(TimeSeriesSettings && settings) noexcept
-    : impl(std::make_unique<TimeSeriesSettingsImpl>(std::move(*settings.impl)))
-{
-}
+TimeSeriesSettings::TimeSeriesSettings(TimeSeriesSettings && settings) noexcept = default;
 
 TimeSeriesSettings & TimeSeriesSettings::operator=(TimeSeriesSettings && settings) noexcept
 {

--- a/src/Storages/TimeSeries/TimeSeriesSettings.cpp
+++ b/src/Storages/TimeSeries/TimeSeriesSettings.cpp
@@ -42,11 +42,7 @@ TimeSeriesSettings::TimeSeriesSettings(const TimeSeriesSettings & settings) : im
 
 TimeSeriesSettings::TimeSeriesSettings(TimeSeriesSettings && settings) noexcept = default;
 
-TimeSeriesSettings & TimeSeriesSettings::operator=(TimeSeriesSettings && settings) noexcept
-{
-    *impl = std::move(*settings.impl);
-    return *this;
-}
+TimeSeriesSettings & TimeSeriesSettings::operator=(TimeSeriesSettings && settings) noexcept = default;
 
 TimeSeriesSettings::~TimeSeriesSettings() = default;
 

--- a/src/Storages/YTsaurus/YTsaurusSettings.cpp
+++ b/src/Storages/YTsaurus/YTsaurusSettings.cpp
@@ -38,9 +38,7 @@ YTsaurusSettings::YTsaurusSettings(const YTsaurusSettings & settings) : impl(std
 {
 }
 
-YTsaurusSettings::YTsaurusSettings(YTsaurusSettings && settings) noexcept : impl(std::make_unique<YTsaurusSettingsImpl>(std::move(*settings.impl)))
-{
-}
+YTsaurusSettings::YTsaurusSettings(YTsaurusSettings && settings) noexcept = default;
 
 YTsaurusSettings::~YTsaurusSettings() = default;
 

--- a/tests/queries/0_stateless/04299_move_assignment_memory_limit.sh
+++ b/tests/queries/0_stateless/04299_move_assignment_memory_limit.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Tags: long, no-random-settings
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# Reproducer from a fuzzer/stress run (https://github.com/ClickHouse/ClickHouse/pull/106096).
+# A UNION query unites query plans via QueryPlan::unitePlans, which calls
+# QueryPlanResourceHolder::append; append inserts into memory-tracking containers and so can throw
+# MEMORY_LIMIT_EXCEEDED. append (and the BlockIO / QueryPipeline / QueryPlanResourceHolder move
+# assignments) must not be noexcept, otherwise that throw crosses a noexcept boundary and terminates
+# the server. Inject a small memory-tracker fault probability with every allocation tracked
+# (max_untracked_memory = 0) and loop, so a fault eventually lands inside append. With the bug the
+# server terminates and clickhouse-test fails the run; without it the queries just fail with
+# MEMORY_LIMIT_EXCEEDED (swallowed below) and the server stays up.
+#
+# The fault probability is deliberately small: a large one makes the query fail early, before it
+# reaches append. Against a buggy build this crashed within a few dozen iterations.
+
+query="SELECT DISTINCT 1025, toFixedString('%', 1048576), 100 UNION ALL SELECT 9223372036854775807, '\0', materialize(toLowCardinality(1025)) SETTINGS extremes = 1 FORMAT Null"
+
+for _ in {1..500}; do
+    $CLICKHOUSE_CLIENT --memory_tracker_fault_probability=0.001 --max_untracked_memory=0 --query="$query" >/dev/null 2>&1 ||:
+done


### PR DESCRIPTION
A recent change (`d45e6cd6d6bc`, "Convert std containers in `src/QueryPipeline` to `*WithMemoryTracking` aliases") made `QueryPlanResourceHolder`'s move-assignment able to throw: it appends into `VectorWithMemoryTracking` members, which allocate through the throwing memory tracker and raise `MEMORY_LIMIT_EXCEEDED`. The function (and the `QueryPipeline` / `BlockIO` move-assignments that call it) are marked `noexcept`, so under a memory limit the throw hits the `noexcept` boundary and calls `std::terminate`. It reproduces with a `SELECT ... SETTINGS extremes = 1, max_memory_usage = '4Mi'`, which terminates the server while the result `BlockIO` is move-assigned in `TCPHandler`.

This removes `noexcept` from that move-assignment chain (`QueryPlanResourceHolder`, `QueryPipeline`, `BlockIO`).

While auditing other `noexcept` specifications it also fixes:
- `ConstraintsDescription` / `ColumnDescription` move operations and `ActionsDAG::decorrelate`, which allocate (rebuild derived data, clone ASTs, append to vectors) and can throw.
- pImpl settings classes: their `noexcept` move constructors and move assignments either allocated a new impl via `make_unique`, or move-assigned the impl in place (`*impl = std::move(*settings.impl)`). The latter is also unsafe: `BaseSettings`/`Data` move walks per-field `SettingField`s, and `SettingFieldString` (and friends) declare a copy assignment but no move, so the rvalue assignment falls back to copying a `String`, which allocates and can throw. Both move ops are now `= default`, so they simply steal the `unique_ptr` (`noexcept` and allocation-free); the impl/`BaseSettings` is never moved.

Closes [ClickHouse/ClickHouse#106079](https://github.com/ClickHouse/ClickHouse/issues/106079)
References [ClickHouse/ClickHouse#105580](https://github.com/ClickHouse/ClickHouse/pull/105580)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.299`
<!-- ch-version-info:end -->