### PR TITLE
Fix right_full_hash_join performance stability

### DIFF
--- a/tests/performance/right_full_hash_join.xml
+++ b/tests/performance/right_full_hash_join.xml
@@ -5,30 +5,33 @@
             <name>probe_key</name>
             <values>
                 <value>k1</value>    <!-- 90% unmatched -->
-                <value>k2</value>    <!-- 50% unmatched -->
-                <value>k3</value>    <!-- 10% unmatched -->
+                <value>k2</value>    <!-- 10% unmatched -->
             </values>
         </substitution>
     </substitutions>
 
-    <create_query>CREATE TABLE build_wide (k UInt64, a UInt64, b UInt64, c UInt64, d UInt64, e UInt64, f UInt64, g UInt64) ENGINE = MergeTree ORDER BY tuple()</create_query>
-    <create_query>CREATE TABLE build_narrow (k UInt64, a UInt64) ENGINE = MergeTree ORDER BY tuple()</create_query>
-    <create_query>CREATE TABLE build_nullable (k UInt64, a Nullable(UInt64), b Nullable(UInt64), c Nullable(UInt64), d Nullable(UInt64), e Nullable(UInt64), f Nullable(UInt64), g Nullable(UInt64)) ENGINE = MergeTree ORDER BY tuple()</create_query>
-    <create_query> CREATE TABLE probe (k1 UInt64, k2 UInt64, k3 UInt64) ENGINE = MergeTree ORDER BY tuple()</create_query>
+    <settings>
+        <join_algorithm>hash</join_algorithm>
+        <query_plan_join_swap_table>0</query_plan_join_swap_table>
+    </settings>
 
-    <fill_query>INSERT INTO build_wide SELECT number, number, number, number, number, number, number, number FROM numbers(10000000) ORDER BY rand()</fill_query>
-    <fill_query>INSERT INTO build_narrow SELECT number, number FROM numbers(10000000) ORDER BY rand()</fill_query>
-    <fill_query>INSERT INTO build_nullable WITH if(number % 10 = 0, NULL, number) AS n SELECT number, n, n, n, n, n, n, n FROM numbers(10000000) ORDER BY rand()</fill_query>
-    <fill_query>INSERT INTO probe SELECT number + 9000000, number + 5000000, number + 1000000 FROM numbers(11000000) ORDER BY rand()</fill_query>
+    <create_query>CREATE TABLE build_wide (k UInt64, a UInt64, b UInt64, c UInt64, d UInt64, e UInt64, f UInt64, g UInt64) ENGINE = MergeTree ORDER BY tuple()</create_query>
+    <create_query>CREATE TABLE build_nullable (k UInt64, a Nullable(UInt64), b Nullable(UInt64), c Nullable(UInt64), d Nullable(UInt64), e Nullable(UInt64), f Nullable(UInt64), g Nullable(UInt64)) ENGINE = MergeTree ORDER BY tuple()</create_query>
+    <create_query> CREATE TABLE probe (k1 UInt64, k2 UInt64) ENGINE = MergeTree ORDER BY tuple()</create_query>
+
+    <fill_query>INSERT INTO build_wide SELECT number, number, number, number, number, number, number, number FROM numbers(2000000)</fill_query>
+    <fill_query>INSERT INTO build_nullable WITH if(number % 10 = 0, NULL, number) AS n SELECT number, n, n, n, n, n, n, n FROM numbers(2000000)</fill_query>
+    <fill_query>INSERT INTO probe SELECT number + 1800000, number + 200000 FROM numbers(2000000) ORDER BY rand()</fill_query>
 
     <!-- RIGHT JOIN -->
     <query>SELECT * FROM probe p RIGHT JOIN build_wide b ON p.{probe_key} = b.k FORMAT Null</query>
-    <query>SELECT * FROM probe p RIGHT JOIN build_narrow b ON p.{probe_key} = b.k FORMAT Null</query>
     <query>SELECT * FROM probe p RIGHT JOIN build_nullable b ON p.{probe_key} = b.k FORMAT Null</query>
 
     <!-- FULL JOIN -->
     <query>SELECT * FROM probe p FULL JOIN build_wide b ON p.{probe_key} = b.k FORMAT Null</query>
-    <query>SELECT * FROM probe p FULL JOIN build_narrow b ON p.{probe_key} = b.k FORMAT Null</query>
     <query>SELECT * FROM probe p FULL JOIN build_nullable b ON p.{probe_key} = b.k FORMAT Null</query>
 
+    <drop_query>DROP TABLE IF EXISTS build_wide</drop_query>
+    <drop_query>DROP TABLE IF EXISTS build_nullable</drop_query>
+    <drop_query>DROP TABLE IF EXISTS probe</drop_query>
 </test>


### PR DESCRIPTION
Using `concurrent hash join` in `right_full_hash_join.xml` (added in https://github.com/ClickHouse/ClickHouse/pull/105679) made the runtime unstable because of contention in `FillingRightJoinSideTansform`. 

<img width="2386" height="994" alt="image" src="https://github.com/user-attachments/assets/b4672ec3-c7cf-496a-8bd9-f3c355322cee" />


Forcing `hash join` instead made the numbers more consistent. Can be verified by running this on [play.clickhouse.com](https://play.clickhouse.com/play?user=play) (results for arm only, amd run skipped in the ci):
```
 SELECT
    query_index,
    side,
    count() AS n_runs,
    groupArray(round(metric_value, 4)) AS iterations,
    round(min(metric_value), 4) AS min_s,
    round(max(metric_value), 4) AS max_s
FROM query_metric_runs_v1
WHERE pr_number = 106097
  AND test = 'right_full_hash_join'
  AND metric_name = 'client_time'
  AND arch LIKE '%arm%'
GROUP BY query_index, side
ORDER BY query_index, side
FORMAT PrettyCompact
```

### Changelog category (leave one):

- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...
