### PR TITLE
Set CTCACHE_S3_READ_ONLY for PR builds to fix AccessDenied errors

### DIFF
--- a/ci/jobs/build_clickhouse.py
+++ b/ci/jobs/build_clickhouse.py
@@ -143,6 +143,10 @@ def main():
         os.environ["CTCACHE_DIR"] = f"{temp_dir}/ccache/clang-tidy-cache"
         os.environ["CTCACHE_S3_BUCKET"] = Settings.S3_ARTIFACT_PATH
         os.environ["CTCACHE_S3_FOLDER"] = "ccache/clang-tidy-cache"
+        # PR builds run on untrusted runners without S3 write access; only
+        # master/release builds (pr_number == 0) are allowed to write entries.
+        if info.pr_number > 0:
+            os.environ["CTCACHE_S3_READ_ONLY"] = "true"
 
         os.environ["CH_HOSTNAME"] = (
             "https://build-cache.eu-west-1.aws.clickhouse-staging.com"


### PR DESCRIPTION
PR builds run on untrusted runners that lack `s3:PutObject` permission on the shared cache bucket. `clang-tidy-cache.py` was trying to upload entries on every cache miss and logging errors like:

```
ERROR:clang-tidy-cache.py:Error calling S3:put_object An error occurred (AccessDenied) when calling the PutObject operation: User: arn:aws:sts::542516086801:assumed-role/untrusted_runner/... is not authorized to perform: s3:PutObject
```

The fix mirrors the existing `SCCACHE_S3_READ_ONLY` pattern already in place for sccache: set `CTCACHE_S3_READ_ONLY=true` for PR builds (`pr_number > 0`) so untrusted runners can still read from the shared S3 cache but never attempt writes.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.240`
<!-- ch-version-info:end -->