### PR TITLE
Fix CoalescingMergeTree crash on INSERT with nested Map columns

### DIFF
--- a/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
@@ -266,44 +266,47 @@ static SummingSortedAlgorithm::ColumnsDefinition defineColumns(
         bool is_non_empty_tuple = typeid_cast<const DataTypeTuple *>(column.type.get()) && !typeid_cast<const DataTypeTuple *>(column.type.get())->getElements().empty();
         if (aggregate_all_columns && (is_non_empty_tuple || typeid_cast<const DataTypeArray *>(column.type.get())) && !simple)
         {
-            const auto map_name = Nested::extractTableName(column.name);
-            /// if nested table name ends with `Map` it is a possible candidate for special handling
-            if (map_name == column.name || !endsWith(map_name, "Map"))
+            /// `aggregate_all_columns` is only set by `CoalescingMergeTree`, which performs
+            /// `last_value` aggregation per column. Nested `Map` arrays must therefore be
+            /// coalesced element-wise like any other array column. The legacy `nestedName.suffix`
+            /// pattern used by `SummingMergeTree` (where Map-suffixed nested tables route into
+            /// `discovered_maps` for `sumMap`-by-key merging) does not apply here. We must add
+            /// the column to one of the output lists in every case, otherwise the slot in
+            /// `res_columns` inside `postprocessChunk` is left null and `Chunk::checkNumRowsIsConsistent`
+            /// dereferences a null `ColumnPtr` (issue #101937).
+            if (!column_names_to_sum.empty() && !isInNames(column.name, column_names_to_sum))
             {
-                if (!column_names_to_sum.empty() && !isInNames(column.name, column_names_to_sum))
+                def.column_numbers_not_to_aggregate.push_back(i);
+            }
+            else
+            {
+                bool is_agg_func = WhichDataType(column.type).isAggregateFunction();
+
+                SummingSortedAlgorithm::AggregateDescription desc;
+                desc.remove_default_values = remove_default_values;
+                desc.aggregate_all_columns = aggregate_all_columns;
+                desc.sum_function_map_name = sum_function_map_name;
+                desc.is_agg_func_type = is_agg_func;
+                desc.column_numbers = {i};
+
+                desc.real_type = column.type;
+                desc.nested_type = recursiveRemoveLowCardinality(desc.real_type);
+                if (desc.real_type.get() == desc.nested_type.get())
+                    desc.nested_type = nullptr;
+
+                if (simple)
                 {
-                    def.column_numbers_not_to_aggregate.push_back(i);
+                    // simple aggregate function
+                    desc.init(simple->getFunction(), true);
+                    if (desc.function->allocatesMemoryInArena())
+                        def.allocates_memory_in_arena = true;
                 }
-                else
+                else if (!is_agg_func)
                 {
-                    bool is_agg_func = WhichDataType(column.type).isAggregateFunction();
-
-                    SummingSortedAlgorithm::AggregateDescription desc;
-                    desc.remove_default_values = remove_default_values;
-                    desc.aggregate_all_columns = aggregate_all_columns;
-                    desc.sum_function_map_name = sum_function_map_name;
-                    desc.is_agg_func_type = is_agg_func;
-                    desc.column_numbers = {i};
-
-                    desc.real_type = column.type;
-                    desc.nested_type = recursiveRemoveLowCardinality(desc.real_type);
-                    if (desc.real_type.get() == desc.nested_type.get())
-                        desc.nested_type = nullptr;
-
-                    if (simple)
-                    {
-                        // simple aggregate function
-                        desc.init(simple->getFunction(), true);
-                        if (desc.function->allocatesMemoryInArena())
-                            def.allocates_memory_in_arena = true;
-                    }
-                    else if (!is_agg_func)
-                    {
-                        desc.init(sum_function_name.c_str(), {column.type});
-                    }
-
-                    def.columns_to_aggregate.emplace_back(std::move(desc));
+                    desc.init(sum_function_name.c_str(), {column.type});
                 }
+
+                def.columns_to_aggregate.emplace_back(std::move(desc));
             }
 
             continue;

--- a/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp
@@ -274,7 +274,17 @@ static SummingSortedAlgorithm::ColumnsDefinition defineColumns(
             /// the column to one of the output lists in every case, otherwise the slot in
             /// `res_columns` inside `postprocessChunk` is left null and `Chunk::checkNumRowsIsConsistent`
             /// dereferences a null `ColumnPtr` (issue #101937).
-            if (!column_names_to_sum.empty() && !isInNames(column.name, column_names_to_sum))
+            ///
+            /// Match `column_names_to_sum` against both the physical name and the nested
+            /// table name, mirroring `MergeTreeData::MergingParams::check`, which validates
+            /// the engine argument against `Nested::extractTableName(name_and_type.name)`.
+            /// Without this, `CoalescingMergeTree(testMap)` over `testMap.key`/`testMap.value`
+            /// would route both subcolumns into `column_numbers_not_to_aggregate` and silently
+            /// emit the first-row values instead of applying `last_value`.
+            const bool matches_columns_to_sum
+                = isInNames(column.name, column_names_to_sum)
+                || isInNames(Nested::extractTableName(column.name), column_names_to_sum);
+            if (!column_names_to_sum.empty() && !matches_columns_to_sum)
             {
                 def.column_numbers_not_to_aggregate.push_back(i);
             }

--- a/tests/queries/0_stateless/04299_101937_coalescing_merge_tree_nested_map.reference
+++ b/tests/queries/0_stateless/04299_101937_coalescing_merge_tree_nested_map.reference
@@ -1,0 +1,8 @@
+array - before final	1	['a']	[10]
+array - before final	1	['b']	[20]
+array - FINAL	1	['b']	[20]
+array - after optimize	1	['b']	[20]
+mixed - FINAL	1	['::1']	42
+mixed - after optimize	1	['::1']	42
+lc - FINAL	1	['y']	[200]
+lc - after optimize	1	['y']	[200]

--- a/tests/queries/0_stateless/04299_101937_coalescing_merge_tree_nested_map.reference
+++ b/tests/queries/0_stateless/04299_101937_coalescing_merge_tree_nested_map.reference
@@ -6,3 +6,5 @@ mixed - FINAL	1	['::1']	42
 mixed - after optimize	1	['::1']	42
 lc - FINAL	1	['y']	[200]
 lc - after optimize	1	['y']	[200]
+explicit - FINAL	1	[2]	[20]	100
+explicit - after optimize	1	[2]	[20]	100

--- a/tests/queries/0_stateless/04299_101937_coalescing_merge_tree_nested_map.sql
+++ b/tests/queries/0_stateless/04299_101937_coalescing_merge_tree_nested_map.sql
@@ -1,0 +1,78 @@
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/101937
+--
+-- `CoalescingMergeTree` (which delegates to `SummingSortedAlgorithm` with
+-- `aggregate_all_columns = true`) used to silently drop nested `Map` columns
+-- from both the `columns_to_aggregate` and `column_numbers_not_to_aggregate`
+-- lists in `defineColumns`. The unset slot in `res_columns` then surfaced as a
+-- null `ColumnPtr` inside `postprocessChunk`, which `Chunk::checkNumRowsIsConsistent`
+-- dereferenced and crashed the server (SIGSEGV in release builds, `px != 0`
+-- assertion in debug builds, UBSan `member call on null pointer` in arm_asan_ubsan).
+--
+-- A nested table whose name ends with `Map` triggers the bug (`testMap.key`,
+-- `legacy_features_Map.id`, etc.) — the original AST fuzzer reproducer used
+-- `legacy_features_Map.id Array(LowCardinality(IPv6))` together with a non-Array
+-- sibling.
+
+DROP TABLE IF EXISTS test_coal_nested_map_array;
+DROP TABLE IF EXISTS test_coal_nested_map_mixed;
+DROP TABLE IF EXISTS test_coal_nested_map_lc;
+
+-- 1. Classic two-Array nested-Map convention: this is the original reproducer.
+
+CREATE TABLE test_coal_nested_map_array
+(
+    key UInt32,
+    `testMap.key` Array(String),
+    `testMap.value` Array(UInt32)
+)
+ENGINE = CoalescingMergeTree
+ORDER BY key;
+
+INSERT INTO test_coal_nested_map_array VALUES (1, ['a'], [10]);
+INSERT INTO test_coal_nested_map_array VALUES (1, ['b'], [20]);
+
+SELECT 'array - before final', * FROM test_coal_nested_map_array ORDER BY key, `testMap.key`;
+SELECT 'array - FINAL', * FROM test_coal_nested_map_array FINAL ORDER BY key;
+OPTIMIZE TABLE test_coal_nested_map_array FINAL;
+SELECT 'array - after optimize', * FROM test_coal_nested_map_array ORDER BY key;
+
+-- 2. Mixed shape: an Array Map-suffixed column next to a non-Array sibling — this
+--    is the exact shape that fuzzed PR #104563 and PR #104281 onto STID 1003-326e
+--    on `arm_asan_ubsan`.
+
+CREATE TABLE test_coal_nested_map_mixed
+(
+    key UInt128,
+    `legacy_features_Map.id` Array(IPv6),
+    `legacy_features_Map.count` Nullable(Int32)
+)
+ENGINE = CoalescingMergeTree
+ORDER BY key;
+
+INSERT INTO test_coal_nested_map_mixed (key) VALUES (1);
+INSERT INTO test_coal_nested_map_mixed VALUES (1, ['::1'], 42);
+SELECT 'mixed - FINAL', * FROM test_coal_nested_map_mixed FINAL;
+OPTIMIZE TABLE test_coal_nested_map_mixed FINAL;
+SELECT 'mixed - after optimize', * FROM test_coal_nested_map_mixed;
+
+-- 3. Same as (1) but with `LowCardinality` inside the nested Array — the exact
+--    type used by the fuzzer reproducer (`Array(LowCardinality(IPv6))`).
+
+CREATE TABLE test_coal_nested_map_lc
+(
+    key UInt32,
+    `myMap.id` Array(LowCardinality(String)),
+    `myMap.value` Array(UInt64)
+)
+ENGINE = CoalescingMergeTree
+ORDER BY key;
+
+INSERT INTO test_coal_nested_map_lc VALUES (1, ['x'], [100]);
+INSERT INTO test_coal_nested_map_lc VALUES (1, ['y'], [200]);
+SELECT 'lc - FINAL', * FROM test_coal_nested_map_lc FINAL ORDER BY key;
+OPTIMIZE TABLE test_coal_nested_map_lc FINAL;
+SELECT 'lc - after optimize', * FROM test_coal_nested_map_lc;
+
+DROP TABLE test_coal_nested_map_array;
+DROP TABLE test_coal_nested_map_mixed;
+DROP TABLE test_coal_nested_map_lc;

--- a/tests/queries/0_stateless/04299_101937_coalescing_merge_tree_nested_map.sql
+++ b/tests/queries/0_stateless/04299_101937_coalescing_merge_tree_nested_map.sql
@@ -73,6 +73,32 @@ SELECT 'lc - FINAL', * FROM test_coal_nested_map_lc FINAL ORDER BY key;
 OPTIMIZE TABLE test_coal_nested_map_lc FINAL;
 SELECT 'lc - after optimize', * FROM test_coal_nested_map_lc;
 
+-- 4. Explicit nested-table `columns` argument: `CoalescingMergeTree(testMap)`.
+--    `MergeTreeData::MergingParams::check` validates the engine argument against
+--    `Nested::extractTableName(name_and_type.name)`, so the stored
+--    `columns_to_sum` entry is the nested table name (`testMap`), not the
+--    physical subcolumn names (`testMap.key`, `testMap.value`).
+--    `SummingSortedAlgorithm::defineColumns` must match the same way; otherwise
+--    both subcolumns fall through to `column_numbers_not_to_aggregate` and
+--    `finishGroup` emits the first-row values instead of `last_value`.
+
+CREATE TABLE test_coal_nested_map_explicit
+(
+    key UInt32,
+    `testMap.key` Array(UInt32),
+    `testMap.value` Array(UInt32),
+    other_col UInt64
+)
+ENGINE = CoalescingMergeTree(testMap)
+ORDER BY key;
+
+INSERT INTO test_coal_nested_map_explicit VALUES (1, [1], [10], 100);
+INSERT INTO test_coal_nested_map_explicit VALUES (1, [2], [20], 200);
+SELECT 'explicit - FINAL', * FROM test_coal_nested_map_explicit FINAL ORDER BY key;
+OPTIMIZE TABLE test_coal_nested_map_explicit FINAL;
+SELECT 'explicit - after optimize', * FROM test_coal_nested_map_explicit ORDER BY key;
+
 DROP TABLE test_coal_nested_map_array;
 DROP TABLE test_coal_nested_map_mixed;
 DROP TABLE test_coal_nested_map_lc;
+DROP TABLE test_coal_nested_map_explicit;


### PR DESCRIPTION
`CoalescingMergeTree` SIGSEGVed on INSERT into a table with a nested column whose parent table name ends with `Map` (e.g. `testMap.key`, `legacy_features_Map.id`). In debug builds this surfaced as an `intrusive_ptr` `px != 0` assertion; in `arm_asan_ubsan` it surfaced as STID 1003-326e (`UndefinedBehaviorSanitizer: member call on null pointer of type 'DB::IColumn'`) inside `Chunk::checkNumRowsIsConsistent`.

`CoalescingMergeTree` runs `SummingSortedAlgorithm` with `aggregate_all_columns = true`. The dedicated branch for that case in `defineColumns` (`src/Processors/Merges/Algorithms/SummingSortedAlgorithm.cpp`) wrapped its bookkeeping in `if (map_name == column.name || !endsWith(map_name, \"Map\"))` and then fell through to an unconditional `continue`. For any column whose nested table name ends with `Map`, the inner branch was skipped while the `continue` still fired, so the column was added to neither `columns_to_aggregate` nor `column_numbers_not_to_aggregate`. `postprocessChunk` then constructed `res_columns` of size `num_result_columns` and left those slots null, and `Chunk::setColumns` -> `Chunk::checkNumRowsIsConsistent` dereferenced the null `ColumnPtr`.

`CoalescingMergeTree` performs per-column `last_value` coalescing, so nested `Map` arrays must be coalesced element-wise like any other array column. The legacy `nestedName.suffix` routing into `discovered_maps` for `sumMap`-by-key merging is a `SummingMergeTree` concept that does not apply here, so the Map-suffix exclusion is dropped from the `aggregate_all_columns = true` branch. `SummingMergeTree` code paths are untouched.

Closes #101937.

CI report (STID 1003-326e on `AST fuzzer (arm_asan_ubsan)` for PR #104563): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104563&sha=c2e0f0fe3b92d48b5a47fa90555f7d4aca54c553&name_0=PR&name_1=AST%20fuzzer%20%28arm_asan_ubsan%29

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix server crash on `INSERT` / `OPTIMIZE` into a `CoalescingMergeTree` table that has a nested column whose parent table name ends with `Map` (e.g. `testMap.key Array(...)`). The column was silently dropped from the merging metadata in `defineColumns`, producing a null `ColumnPtr` inside `Chunk::checkNumRowsIsConsistent`.


### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)