### PR TITLE
Update NuRaft Keeper settings

### DIFF
--- a/src/Coordination/CoordinationSettings.cpp
+++ b/src/Coordination/CoordinationSettings.cpp
@@ -93,6 +93,8 @@ namespace ErrorCodes
     DECLARE(UInt64, nuraft_max_log_gap_in_stream, 0, "Maximum number of in-flight log entries per follower when streaming mode is enabled. Acts as a throttling cap. Only effective when nuraft_streaming_mode is true.", 0) \
     DECLARE(UInt64, commit_profiler_real_time_period_ns, 0, "Period for real clock timer of the query profiler on the Keeper commit thread (in nanoseconds). The profiling results appear in system.trace_log with query_id = 'KeeperCommit'. 0 means disabled.", 0) \
     DECLARE(UInt64, nuraft_max_bytes_in_flight_in_stream, 32 * 1024 * 1024, "Maximum bytes of in-flight data per follower when streaming mode is enabled. Acts as a data volume throttle. Only effective when nuraft_streaming_mode is true.", 0) \
+    DECLARE(UInt64, nuraft_max_uncommitted_log_entries, 100000, "Maximum number of uncommitted NuRaft log entries on the leader before rejecting new client requests. 0 disables the limit.", 0) \
+    DECLARE(UInt64, nuraft_append_entries_backward_probe_throttle_threshold, 5, "Number of consecutive backward log-match probes after which NuRaft limits append entries payloads to one log entry. 0 disables the throttle.", 0) \
 
 DECLARE_SETTINGS_TRAITS(CoordinationSettingsTraits, LIST_OF_COORDINATION_SETTINGS, COORDINATION_SETTINGS_SUPPORTED_TYPES)
 

--- a/src/Coordination/KeeperServer.cpp
+++ b/src/Coordination/KeeperServer.cpp
@@ -90,6 +90,8 @@ namespace CoordinationSetting
     extern const CoordinationSettingsBool nuraft_streaming_mode;
     extern const CoordinationSettingsUInt64 nuraft_max_log_gap_in_stream;
     extern const CoordinationSettingsUInt64 nuraft_max_bytes_in_flight_in_stream;
+    extern const CoordinationSettingsUInt64 nuraft_max_uncommitted_log_entries;
+    extern const CoordinationSettingsUInt64 nuraft_append_entries_backward_probe_throttle_threshold;
     extern const CoordinationSettingsBool use_new_dispatcher;
 }
 
@@ -581,6 +583,11 @@ void KeeperServer::launchRaftServer(const Poco::Util::AbstractConfiguration & co
         = getValueOrMaxInt32AndLogWarning(coordination_settings[CoordinationSetting::nuraft_max_log_gap_in_stream], "nuraft_max_log_gap_in_stream", log);
     params.max_bytes_in_flight_in_stream_
         = static_cast<int64_t>(coordination_settings[CoordinationSetting::nuraft_max_bytes_in_flight_in_stream]);
+    params.max_uncommitted_log_entries_ = coordination_settings[CoordinationSetting::nuraft_max_uncommitted_log_entries];
+    params.append_entries_backward_probe_throttle_threshold_ = getValueOrMaxInt32AndLogWarning(
+        coordination_settings[CoordinationSetting::nuraft_append_entries_backward_probe_throttle_threshold],
+        "nuraft_append_entries_backward_probe_throttle_threshold",
+        log);
 
     params.return_method_ = nuraft::raft_params::async_handler;
 

--- a/tests/casa_del_dolor/properties.py
+++ b/tests/casa_del_dolor/properties.py
@@ -1666,7 +1666,13 @@ keeper_settings = {
         "nuraft_max_bytes_in_flight_in_stream": threshold_generator(
             0.2, 0.2, 0, 256 * 1024 * 1024
         ),
+        "nuraft_append_entries_backward_probe_throttle_threshold": threshold_generator(
+            0.2, 0.2, 0, 128
+        ),
         "nuraft_max_log_gap_in_stream": threshold_generator(0.2, 0.2, 0, 1024),
+        "nuraft_max_uncommitted_log_entries": threshold_generator(
+            0.2, 0.2, 0, 1000000
+        ),
         "nuraft_streaming_mode": true_false_lambda,
         "parallel_read_chunk_size": threshold_generator(0.2, 0.2, 1, 1024),
         "parallel_read_min_batch": threshold_generator(0.2, 0.2, 0, 4096),

--- a/tests/integration/test_keeper_nuraft_streaming/configs/enable_keeper1.xml
+++ b/tests/integration/test_keeper_nuraft_streaming/configs/enable_keeper1.xml
@@ -11,6 +11,8 @@
             <nuraft_streaming_mode>true</nuraft_streaming_mode>
             <nuraft_max_log_gap_in_stream>16</nuraft_max_log_gap_in_stream>
             <nuraft_max_bytes_in_flight_in_stream>4194304</nuraft_max_bytes_in_flight_in_stream>
+            <nuraft_max_uncommitted_log_entries>12345</nuraft_max_uncommitted_log_entries>
+            <nuraft_append_entries_backward_probe_throttle_threshold>7</nuraft_append_entries_backward_probe_throttle_threshold>
         </coordination_settings>
         <raft_configuration>
             <server>

--- a/tests/integration/test_keeper_nuraft_streaming/configs/enable_keeper2.xml
+++ b/tests/integration/test_keeper_nuraft_streaming/configs/enable_keeper2.xml
@@ -11,6 +11,8 @@
             <nuraft_streaming_mode>true</nuraft_streaming_mode>
             <nuraft_max_log_gap_in_stream>16</nuraft_max_log_gap_in_stream>
             <nuraft_max_bytes_in_flight_in_stream>4194304</nuraft_max_bytes_in_flight_in_stream>
+            <nuraft_max_uncommitted_log_entries>12345</nuraft_max_uncommitted_log_entries>
+            <nuraft_append_entries_backward_probe_throttle_threshold>7</nuraft_append_entries_backward_probe_throttle_threshold>
         </coordination_settings>
         <raft_configuration>
             <server>

--- a/tests/integration/test_keeper_nuraft_streaming/configs/enable_keeper3.xml
+++ b/tests/integration/test_keeper_nuraft_streaming/configs/enable_keeper3.xml
@@ -11,6 +11,8 @@
             <nuraft_streaming_mode>true</nuraft_streaming_mode>
             <nuraft_max_log_gap_in_stream>16</nuraft_max_log_gap_in_stream>
             <nuraft_max_bytes_in_flight_in_stream>4194304</nuraft_max_bytes_in_flight_in_stream>
+            <nuraft_max_uncommitted_log_entries>12345</nuraft_max_uncommitted_log_entries>
+            <nuraft_append_entries_backward_probe_throttle_threshold>7</nuraft_append_entries_backward_probe_throttle_threshold>
         </coordination_settings>
         <raft_configuration>
             <server>

--- a/tests/integration/test_keeper_nuraft_streaming/test.py
+++ b/tests/integration/test_keeper_nuraft_streaming/test.py
@@ -35,7 +35,10 @@ def test_streaming_mode(started_cluster):
     assert "nuraft_streaming_mode=true" in conf, f"Streaming mode not found in conf output:\n{conf}"
     assert "nuraft_max_log_gap_in_stream=16" in conf
     assert "nuraft_max_bytes_in_flight_in_stream=4194304" in conf
+    assert "nuraft_max_uncommitted_log_entries=12345" in conf
+    assert "nuraft_append_entries_backward_probe_throttle_threshold=7" in conf
 
     log = node1.grep_in_log("streaming mode max log gap")
     assert log, "NuRaft startup message with streaming mode parameters not found in log"
     assert "16" in log, f"Expected max_log_gap=16 in log message: {log}"
+    assert "max uncommitted log entries 12345" in log


### PR DESCRIPTION
Update `NuRaft` to commit `62ab4edc621a65432badf60d7f85fa8695debeff`.

This brings the upstream leader-side admission limit for uncommitted log entries and the append-entries backward-probe throttle, then exposes both through Keeper `coordination_settings` so they can be configured in ClickHouse.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added Keeper `coordination_settings` for `NuRaft` uncommitted log entry admission limiting and append-entries backward-probe throttling.

### Documentation entry for user-facing changes
- [x] Documentation is not required because this change exposes internal Keeper tuning settings.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.241`
- Backported to: `26.5.2.23`
<!-- ch-version-info:end -->