### PR TITLE
Fix wrong results for tables sorted by a monotonically decreasing function

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -1642,6 +1642,8 @@ bool KeyCondition::canConstantBeWrappedByMonotonicFunctions(
     if (out_value.isNull())
         return false;
 
+    /// Track whether the function chain preserves or reverses comparison order.
+    bool chain_is_positive = true;
     MonotonicFunctionsChain transform_functions;
     auto can_transform_constant = extractMonotonicFunctionsChainFromKey(
         node.getTreeContext().getQueryContext(),
@@ -1650,6 +1652,7 @@ bool KeyCondition::canConstantBeWrappedByMonotonicFunctions(
         out_key_column_num,
         out_key_column_type,
         transform_functions,
+        chain_is_positive,
         [this](const IFunctionBase & func, const IDataType & type)
         {
             if (!func.hasInformationAboutMonotonicity())
@@ -1682,23 +1685,6 @@ bool KeyCondition::canConstantBeWrappedByMonotonicFunctions(
 
     if (!constant_transformed)
         return false;
-
-    /// Track whether the function chain preserves or reverses comparison order.
-    ///
-    /// If its cumulative monotonicity direction is negative, applying it to the constant
-    /// reverses range comparisons. For example, with `ORDER BY (intDiv(c0, 5) / -7)`,
-    /// `c0 < 0` becomes `divide(intDiv(c0, 5), -7) > divide(intDiv(0, 5), -7)`.
-    ///
-    /// Directions compose by parity: each non-increasing function reverses the current
-    /// direction, so two non-increasing functions preserve the original comparison.
-    bool chain_is_positive = true;
-    for (const auto & func : transform_functions)
-    {
-        auto arg_type = getArgumentTypeOfMonotonicFunction(*func);
-        auto monotonicity = func->getMonotonicityForRange(*arg_type, Field(), Field());
-        if (!monotonicity.is_positive)
-            chain_is_positive = !chain_is_positive;
-    }
 
     out_value = (*transformed_const_column)[0];
     out_type = transformed_const_type;
@@ -2868,8 +2854,11 @@ bool KeyCondition::extractMonotonicFunctionsChainFromKey(
     size_t & out_key_column_num,
     DataTypePtr & out_key_column_type,
     MonotonicFunctionsChain & out_functions_chain,
+    bool & out_chain_is_positive,
     std::function<bool(const IFunctionBase &, const IDataType &)> always_monotonic) const
 {
+    out_chain_is_positive = true;
+
     const auto & sample_block = info.key_expr->getSampleBlock();
 
     for (const auto & node : info.key_expr->getNodes())
@@ -2918,6 +2907,7 @@ bool KeyCondition::extractMonotonicFunctionsChainFromKey(
 
             if (is_valid_chain)
             {
+                bool chain_is_positive = true;
                 while (!chain.empty())
                 {
                     const auto * func = chain.top();
@@ -2928,6 +2918,16 @@ bool KeyCondition::extractMonotonicFunctionsChainFromKey(
 
                     auto func_name = func->function_base->getName();
                     auto func_base = func->function_base;
+
+                    /// If its cumulative monotonicity direction is negative, applying it to the constant
+                    /// reverses range comparisons. For example, with `ORDER BY (intDiv(c0, 5) / -7)`,
+                    /// `c0 < 0` becomes `divide(intDiv(c0, 5), -7) > divide(intDiv(0, 5), -7)`.
+                    ///
+                    /// Directions compose by parity: each non-increasing function reverses the current
+                    /// direction, so two non-increasing functions preserve the original comparison.
+                    auto monotonicity = func_base->getMonotonicityForRange(*func->result_type, Field(), Field());
+                    if (!monotonicity.is_positive)
+                        chain_is_positive = !chain_is_positive;
 
                     ColumnWithTypeAndName const_arg;
                     FunctionWithOptionalConstArg::Kind kind = FunctionWithOptionalConstArg::Kind::NO_CONST;
@@ -2984,6 +2984,7 @@ bool KeyCondition::extractMonotonicFunctionsChainFromKey(
 
                 out_key_column_num = it->second;
                 out_key_column_type = sample_block.getByName(it->first).type;
+                out_chain_is_positive = chain_is_positive;
                 return true;
             }
         }

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -708,6 +708,27 @@ static const std::map<std::string, std::string> inverse_relations =
     {"notEmpty", "empty"},
 };
 
+/// Returns the comparison operator after reversing comparison direction.
+///
+/// This is needed when normalizing `const op key` into `key op const`, and when
+/// pushing a comparison through a monotonic function chain with negative direction.
+/// For example, `a < b` becomes `b > a`, and for decreasing `f`,
+/// `f(a) < f(b)` is checked as `a > b`.
+///
+/// Symmetric operators, such as `equals` and `notEquals`, are returned unchanged.
+/// Returns an empty view for operators that are not order comparisons, such as
+/// `like` and `startsWith`.
+static std::string_view reverseComparisonOperator(std::string_view op)
+{
+    if (op == "equals") return "equals";
+    if (op == "notEquals") return "notEquals";
+    if (op == "less") return "greater";
+    if (op == "greater") return "less";
+    if (op == "lessOrEquals") return "greaterOrEquals";
+    if (op == "greaterOrEquals") return "lessOrEquals";
+    return {};
+}
+
 
 static bool isLogicalOperator(const String & func_name)
 {
@@ -816,17 +837,13 @@ static const ActionsDAG::Node * tryRewriteCoalesceComparison(
     if (node.children.size() != 2)
         return nullptr;
 
-    /// `less(const, x)` ≡ `greater(x, const)`; also the allowlist of ops we rewrite at all.
-    auto mirrored_op = [](std::string_view op) -> std::string_view
-    {
-        if (op == "equals") return "equals";
-        if (op == "less") return "greater";
-        if (op == "greater") return "less";
-        if (op == "lessOrEquals") return "greaterOrEquals";
-        if (op == "greaterOrEquals") return "lessOrEquals";
-        return {};
-    };
-    const std::string_view mirrored = mirrored_op(op_name);
+    /// `notEquals` is excluded because the OR-of-branches rewrite below does not preserve
+    /// SQL three-valued logic for `!=` when intermediate `coalesce` args are NULL.
+    if (op_name == "notEquals")
+        return nullptr;
+
+    /// `less(const, x)` becomes `greater(x, const)`; also the allowlist of ops we rewrite at all.
+    const std::string_view mirrored = reverseComparisonOperator(op_name);
     if (mirrored.empty())
         return nullptr;
 
@@ -1611,8 +1628,11 @@ bool KeyCondition::canConstantBeWrappedByMonotonicFunctions(
     size_t & out_key_column_num,
     DataTypePtr & out_key_column_type,
     Field & out_value,
-    DataTypePtr & out_type)
+    DataTypePtr & out_type,
+    bool & out_chain_is_positive)
 {
+    out_chain_is_positive = true;
+
     String expr_name = node.getColumnName();
 
     if (!info.key_subexpr_names.contains(expr_name))
@@ -1662,8 +1682,26 @@ bool KeyCondition::canConstantBeWrappedByMonotonicFunctions(
     if (!constant_transformed)
         return false;
 
+    /// Track whether the function chain preserves or reverses comparison order.
+    ///
+    /// If its cumulative monotonicity direction is negative, applying it to the constant
+    /// reverses range comparisons. For example, with `ORDER BY (intDiv(c0, 5) / -7)`,
+    /// `c0 < 0` becomes `divide(intDiv(c0, 5), -7) > divide(intDiv(0, 5), -7)`.
+    ///
+    /// Directions compose by parity: each non-increasing function reverses the current
+    /// direction, so two non-increasing functions preserve the original comparison.
+    bool chain_is_positive = true;
+    for (const auto & func : transform_functions)
+    {
+        auto arg_type = getArgumentTypeOfMonotonicFunction(*func);
+        auto monotonicity = func->getMonotonicityForRange(*arg_type, Field(), Field());
+        if (!monotonicity.is_positive)
+            chain_is_positive = !chain_is_positive;
+    }
+
     out_value = (*transformed_const_column)[0];
     out_type = transformed_const_type;
+    out_chain_is_positive = chain_is_positive;
     return true;
 }
 
@@ -3434,6 +3472,7 @@ bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, const Bu
             }
 
             bool condition_is_relaxed = false;
+            bool constant_chain_is_positive = true;
 
             /// If the table sorting key is `x` and the query predicate is `f(x) <op> const`, we try to analyze `f`.
             /// If `f` is a monotonic function chain, we store the chain and later, in `checkInRange`, apply it to
@@ -3463,7 +3502,7 @@ bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, const Bu
             else if (
                 !no_relaxed_atom_functions.contains(func_name)
                 && canConstantBeWrappedByMonotonicFunctions(
-                    key_arg, info, key_column_num, key_expr_type, const_value, const_type))
+                    key_arg, info, key_column_num, key_expr_type, const_value, const_type, constant_chain_is_positive))
             {
                 condition_is_relaxed = true;
             }
@@ -3482,21 +3521,15 @@ bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, const Bu
             if (key_column_num == static_cast<size_t>(-1))
                 throw Exception(ErrorCodes::LOGICAL_ERROR, "`key_column_num` wasn't initialized. It is a bug.");
 
-            /// Replace <const> <sign> <data> on to <data> <-sign> <const>
+            /// Replace <const> <sign> <data> on to <data> <-sign> <const>.
+            /// Ops without a meaningful operand reorder (`like`, `startsWith`, `match`, ...)
+            /// return empty from the helper and are rejected.
             if (key_arg_pos == 1)
             {
-                if (func_name == "less")
-                    func_name = "greater";
-                else if (func_name == "greater")
-                    func_name = "less";
-                else if (func_name == "greaterOrEquals")
-                    func_name = "lessOrEquals";
-                else if (func_name == "lessOrEquals")
-                    func_name = "greaterOrEquals";
-                else if (func_name == "like" || func_name == "notLike" ||
-                         func_name == "ilike" || func_name == "notILike" ||
-                         func_name == "startsWith" || func_name == "startsWithUTF8" || func_name == "match")
+                auto reversed = reverseComparisonOperator(func_name);
+                if (reversed.empty())
                     return false;
+                func_name = String(reversed);
             }
 
             key_expr_type = recursiveRemoveLowCardinality(key_expr_type);
@@ -3606,6 +3639,15 @@ bool KeyCondition::extractAtomFromTree(const RPNBuilderTreeNode & node, const Bu
                     func_name = "greaterOrEquals";
 
                 out.relaxed = true;
+            }
+
+            /// `const_value` has already been transformed into the key-expression domain.
+            /// If that transformation reverses order, reverse the comparison operator too.
+            /// Symmetric operators such as `equals` and `notEquals` are unchanged.
+            if (!constant_chain_is_positive)
+            {
+                if (auto reversed = reverseComparisonOperator(func_name); !reversed.empty())
+                    func_name = String(reversed);
             }
         }
         else

--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -837,8 +837,9 @@ static const ActionsDAG::Node * tryRewriteCoalesceComparison(
     if (node.children.size() != 2)
         return nullptr;
 
-    /// `notEquals` is excluded because the OR-of-branches rewrite below does not preserve
-    /// SQL three-valued logic for `!=` when intermediate `coalesce` args are NULL.
+    /// Do not rewrite `notEquals`: if an earlier `coalesce` argument is `NULL`, the branch-wise `OR`
+    /// can produce `NULL` where the original predicate is `false`. For example, `coalesce(NULL, 5) != 5`
+    /// is `false`, but the rewritten form `(NULL != 5) OR (isNull(NULL) AND 5 != 5)` is `NULL`.
     if (op_name == "notEquals")
         return nullptr;
 

--- a/src/Storages/MergeTree/KeyCondition.h
+++ b/src/Storages/MergeTree/KeyCondition.h
@@ -436,7 +436,8 @@ private:
         size_t & out_key_column_num,
         DataTypePtr & out_key_column_type,
         Field & out_value,
-        DataTypePtr & out_type);
+        DataTypePtr & out_type,
+        bool & out_chain_is_positive);
 
     bool canConstantBeWrappedByDeterministicFunctions(
         const RPNBuilderTreeNode & node,

--- a/src/Storages/MergeTree/KeyCondition.h
+++ b/src/Storages/MergeTree/KeyCondition.h
@@ -420,6 +420,7 @@ private:
         size_t & out_key_column_num,
         DataTypePtr & out_key_column_type,
         MonotonicFunctionsChain & out_functions_chain,
+        bool & out_chain_is_positive,
         std::function<bool(const IFunctionBase &, const IDataType &)> always_monotonic) const;
 
 

--- a/tests/queries/0_stateless/04299_key_condition_not_positive_monotonicity.reference
+++ b/tests/queries/0_stateless/04299_key_condition_not_positive_monotonicity.reference
@@ -1,0 +1,198 @@
+-- { echo }
+
+SET use_query_condition_cache = 0;
+-- divide(var, neg_const): is_always_monotonic=true, is_positive=false.
+-- When the constant in the predicate is pushed through the chain, the comparison
+-- operator must be flipped because the function is monotonically decreasing.
+-- index_granularity = 1 makes each row its own granule, so `max_rows_to_read`
+-- equals the number of granules the optimizer should select.
+
+DROP TABLE IF EXISTS test_divide_neg;
+CREATE TABLE test_divide_neg (c0 Int32) ENGINE = MergeTree() ORDER BY (c0 / -42) SETTINGS index_granularity = 1;
+INSERT INTO test_divide_neg VALUES (-100), (-1), (0), (1), (100);
+SELECT c0 FROM test_divide_neg WHERE c0 < 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 4;
+-100
+-1
+SELECT c0 FROM test_divide_neg WHERE c0 <= 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 4;
+-100
+-1
+0
+SELECT c0 FROM test_divide_neg WHERE c0 > 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+1
+100
+SELECT c0 FROM test_divide_neg WHERE c0 >= 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+0
+1
+100
+SELECT c0 FROM test_divide_neg WHERE c0 = -1 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 2;
+-1
+SELECT c0 FROM test_divide_neg WHERE c0 != 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+-100
+-1
+1
+100
+-- Reversed-argument form (constant on the left).
+SELECT c0 FROM test_divide_neg WHERE 0 > c0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 4;
+-100
+-1
+SELECT c0 FROM test_divide_neg WHERE 0 < c0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+1
+100
+EXPLAIN indexes = 1
+SELECT c0 FROM test_divide_neg WHERE c0 < 0;
+Expression ((Project names + Projection))
+  Filter ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_divide_neg)
+    Indexes:
+      PrimaryKey
+        Keys:
+          divide(c0, -42)
+        Condition: (divide(c0, -42) in [-0., +Inf))
+        Parts: 1/1
+        Granules: 4/5
+        Search Algorithm: binary search
+      Ranges: 1
+-- intDiv(var, neg_const): integer result variant of the same case. The integer divisor
+-- collapses multiple `c0` values to the same key (e.g. intDiv(-1,-42) = intDiv(0,-42) =
+-- intDiv(1,-42) = 0), which makes the boundary granule wider and prunes fewer granules.
+
+DROP TABLE IF EXISTS test_intdiv_neg;
+CREATE TABLE test_intdiv_neg (c0 Int32) ENGINE = MergeTree() ORDER BY intDiv(c0, -42) SETTINGS index_granularity = 1;
+INSERT INTO test_intdiv_neg VALUES (-100), (-1), (0), (1), (100);
+SELECT c0 FROM test_intdiv_neg WHERE c0 < 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+-100
+-1
+SELECT c0 FROM test_intdiv_neg WHERE c0 <= 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+-100
+-1
+0
+SELECT c0 FROM test_intdiv_neg WHERE c0 > 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 4;
+1
+100
+SELECT c0 FROM test_intdiv_neg WHERE c0 >= 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 4;
+0
+1
+100
+SELECT c0 FROM test_intdiv_neg WHERE c0 = -1 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 4;
+-1
+SELECT c0 FROM test_intdiv_neg WHERE c0 != 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+-100
+-1
+1
+100
+EXPLAIN indexes = 1
+SELECT c0 FROM test_intdiv_neg WHERE c0 < 0;
+Expression ((Project names + Projection))
+  Filter ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_intdiv_neg)
+    Indexes:
+      PrimaryKey
+        Keys:
+          intDiv(c0, -42)
+        Condition: (intDiv(c0, -42) in [0, +Inf))
+        Parts: 1/1
+        Granules: 5/5
+        Search Algorithm: binary search
+      Ranges: 1
+-- Compound chain: two non-positive functions compose to a positive direction (no flip).
+
+DROP TABLE IF EXISTS test_double_neg;
+CREATE TABLE test_double_neg (c0 Int32) ENGINE = MergeTree() ORDER BY (intDiv(c0, -5) / -7) SETTINGS index_granularity = 1;
+INSERT INTO test_double_neg VALUES (-100), (-1), (0), (1), (100);
+SELECT c0 FROM test_double_neg WHERE c0 < 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 4;
+-100
+-1
+SELECT c0 FROM test_double_neg WHERE c0 > 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+1
+100
+EXPLAIN indexes = 1
+SELECT c0 FROM test_double_neg WHERE c0 < 0;
+Expression ((Project names + Projection))
+  Filter ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_double_neg)
+    Indexes:
+      PrimaryKey
+        Keys:
+          divide(intDiv(c0, -5), -7)
+        Condition: (divide(intDiv(c0, -5), -7) in (-Inf, -0.])
+        Parts: 1/1
+        Granules: 4/5
+        Search Algorithm: binary search
+      Ranges: 1
+-- Compound chain: one non-positive function, one positive (overall non-increasing).
+
+DROP TABLE IF EXISTS test_mixed_neg;
+CREATE TABLE test_mixed_neg (c0 Int32) ENGINE = MergeTree() ORDER BY (intDiv(c0, 5) / -7) SETTINGS index_granularity = 1;
+INSERT INTO test_mixed_neg VALUES (-100), (-1), (0), (1), (100);
+SELECT c0 FROM test_mixed_neg WHERE c0 < 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+-100
+-1
+SELECT c0 FROM test_mixed_neg WHERE c0 > 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 4;
+1
+100
+EXPLAIN indexes = 1
+SELECT c0 FROM test_mixed_neg WHERE c0 < 0;
+Expression ((Project names + Projection))
+  Filter ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_mixed_neg)
+    Indexes:
+      PrimaryKey
+        Keys:
+          divide(intDiv(c0, 5), -7)
+        Condition: (divide(intDiv(c0, 5), -7) in [-0., +Inf))
+        Parts: 1/1
+        Granules: 5/5
+        Search Algorithm: binary search
+      Ranges: 1
+-- `negate` returns is_positive=false but is_always_monotonic=false, so the
+-- constant-pushed-through-chain path is rejected and no pruning is attempted.
+
+DROP TABLE IF EXISTS test_negate;
+CREATE TABLE test_negate (c0 Int32) ENGINE = MergeTree() ORDER BY negate(c0) SETTINGS index_granularity = 1;
+INSERT INTO test_negate VALUES (-100), (-1), (0), (1), (100);
+SELECT c0 FROM test_negate WHERE c0 < 0 ORDER BY c0;
+-100
+-1
+SELECT c0 FROM test_negate WHERE c0 > 0 ORDER BY c0;
+1
+100
+EXPLAIN indexes = 1
+SELECT c0 FROM test_negate WHERE c0 < 0;
+Expression ((Project names + Projection))
+  Filter ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_negate)
+    Indexes:
+      PrimaryKey
+        Condition: true
+        Parts: 1/1
+        Granules: 5/5
+      Ranges: 1
+-- `multiply(var, neg_const)` is is_always_monotonic=false (overflow risk), so it also
+-- does not trigger the path.
+
+DROP TABLE IF EXISTS test_multiply_neg;
+CREATE TABLE test_multiply_neg (c0 Int32) ENGINE = MergeTree() ORDER BY (c0 * -2) SETTINGS index_granularity = 1;
+INSERT INTO test_multiply_neg VALUES (-100), (-1), (0), (1), (100);
+SELECT c0 FROM test_multiply_neg WHERE c0 < 0 ORDER BY c0;
+-100
+-1
+SELECT c0 FROM test_multiply_neg WHERE c0 > 0 ORDER BY c0;
+1
+100
+EXPLAIN indexes = 1
+SELECT c0 FROM test_multiply_neg WHERE c0 < 0;
+Expression ((Project names + Projection))
+  Filter ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.test_multiply_neg)
+    Indexes:
+      PrimaryKey
+        Condition: true
+        Parts: 1/1
+        Granules: 5/5
+      Ranges: 1
+DROP TABLE test_divide_neg;
+DROP TABLE test_intdiv_neg;
+DROP TABLE test_double_neg;
+DROP TABLE test_mixed_neg;
+DROP TABLE test_negate;
+DROP TABLE test_multiply_neg;

--- a/tests/queries/0_stateless/04299_key_condition_not_positive_monotonicity.sql
+++ b/tests/queries/0_stateless/04299_key_condition_not_positive_monotonicity.sql
@@ -1,0 +1,105 @@
+-- Tags: no-replicated-database, no-parallel-replicas, no-random-merge-tree-settings
+-- EXPLAIN output may differ
+
+-- { echo }
+
+SET use_query_condition_cache = 0;
+
+-- divide(var, neg_const): is_always_monotonic=true, is_positive=false.
+-- When the constant in the predicate is pushed through the chain, the comparison
+-- operator must be flipped because the function is monotonically decreasing.
+-- index_granularity = 1 makes each row its own granule, so `max_rows_to_read`
+-- equals the number of granules the optimizer should select.
+
+DROP TABLE IF EXISTS test_divide_neg;
+CREATE TABLE test_divide_neg (c0 Int32) ENGINE = MergeTree() ORDER BY (c0 / -42) SETTINGS index_granularity = 1;
+INSERT INTO test_divide_neg VALUES (-100), (-1), (0), (1), (100);
+
+SELECT c0 FROM test_divide_neg WHERE c0 < 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 4;
+SELECT c0 FROM test_divide_neg WHERE c0 <= 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 4;
+SELECT c0 FROM test_divide_neg WHERE c0 > 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+SELECT c0 FROM test_divide_neg WHERE c0 >= 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+SELECT c0 FROM test_divide_neg WHERE c0 = -1 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 2;
+SELECT c0 FROM test_divide_neg WHERE c0 != 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+
+-- Reversed-argument form (constant on the left).
+SELECT c0 FROM test_divide_neg WHERE 0 > c0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 4;
+SELECT c0 FROM test_divide_neg WHERE 0 < c0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 3;
+
+EXPLAIN indexes = 1
+SELECT c0 FROM test_divide_neg WHERE c0 < 0;
+
+-- intDiv(var, neg_const): integer result variant of the same case. The integer divisor
+-- collapses multiple `c0` values to the same key (e.g. intDiv(-1,-42) = intDiv(0,-42) =
+-- intDiv(1,-42) = 0), which makes the boundary granule wider and prunes fewer granules.
+
+DROP TABLE IF EXISTS test_intdiv_neg;
+CREATE TABLE test_intdiv_neg (c0 Int32) ENGINE = MergeTree() ORDER BY intDiv(c0, -42) SETTINGS index_granularity = 1;
+INSERT INTO test_intdiv_neg VALUES (-100), (-1), (0), (1), (100);
+
+SELECT c0 FROM test_intdiv_neg WHERE c0 < 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+SELECT c0 FROM test_intdiv_neg WHERE c0 <= 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+SELECT c0 FROM test_intdiv_neg WHERE c0 > 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 4;
+SELECT c0 FROM test_intdiv_neg WHERE c0 >= 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 4;
+SELECT c0 FROM test_intdiv_neg WHERE c0 = -1 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 4;
+SELECT c0 FROM test_intdiv_neg WHERE c0 != 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+
+EXPLAIN indexes = 1
+SELECT c0 FROM test_intdiv_neg WHERE c0 < 0;
+
+-- Compound chain: two non-positive functions compose to a positive direction (no flip).
+
+DROP TABLE IF EXISTS test_double_neg;
+CREATE TABLE test_double_neg (c0 Int32) ENGINE = MergeTree() ORDER BY (intDiv(c0, -5) / -7) SETTINGS index_granularity = 1;
+INSERT INTO test_double_neg VALUES (-100), (-1), (0), (1), (100);
+
+SELECT c0 FROM test_double_neg WHERE c0 < 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 4;
+SELECT c0 FROM test_double_neg WHERE c0 > 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+
+EXPLAIN indexes = 1
+SELECT c0 FROM test_double_neg WHERE c0 < 0;
+
+-- Compound chain: one non-positive function, one positive (overall non-increasing).
+
+DROP TABLE IF EXISTS test_mixed_neg;
+CREATE TABLE test_mixed_neg (c0 Int32) ENGINE = MergeTree() ORDER BY (intDiv(c0, 5) / -7) SETTINGS index_granularity = 1;
+INSERT INTO test_mixed_neg VALUES (-100), (-1), (0), (1), (100);
+
+SELECT c0 FROM test_mixed_neg WHERE c0 < 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 5;
+SELECT c0 FROM test_mixed_neg WHERE c0 > 0 ORDER BY c0 SETTINGS force_primary_key = 1, max_rows_to_read = 4;
+
+EXPLAIN indexes = 1
+SELECT c0 FROM test_mixed_neg WHERE c0 < 0;
+
+-- `negate` returns is_positive=false but is_always_monotonic=false, so the
+-- constant-pushed-through-chain path is rejected and no pruning is attempted.
+
+DROP TABLE IF EXISTS test_negate;
+CREATE TABLE test_negate (c0 Int32) ENGINE = MergeTree() ORDER BY negate(c0) SETTINGS index_granularity = 1;
+INSERT INTO test_negate VALUES (-100), (-1), (0), (1), (100);
+
+SELECT c0 FROM test_negate WHERE c0 < 0 ORDER BY c0;
+SELECT c0 FROM test_negate WHERE c0 > 0 ORDER BY c0;
+
+EXPLAIN indexes = 1
+SELECT c0 FROM test_negate WHERE c0 < 0;
+
+-- `multiply(var, neg_const)` is is_always_monotonic=false (overflow risk), so it also
+-- does not trigger the path.
+
+DROP TABLE IF EXISTS test_multiply_neg;
+CREATE TABLE test_multiply_neg (c0 Int32) ENGINE = MergeTree() ORDER BY (c0 * -2) SETTINGS index_granularity = 1;
+INSERT INTO test_multiply_neg VALUES (-100), (-1), (0), (1), (100);
+
+SELECT c0 FROM test_multiply_neg WHERE c0 < 0 ORDER BY c0;
+SELECT c0 FROM test_multiply_neg WHERE c0 > 0 ORDER BY c0;
+
+EXPLAIN indexes = 1
+SELECT c0 FROM test_multiply_neg WHERE c0 < 0;
+
+DROP TABLE test_divide_neg;
+DROP TABLE test_intdiv_neg;
+DROP TABLE test_double_neg;
+DROP TABLE test_mixed_neg;
+DROP TABLE test_negate;
+DROP TABLE test_multiply_neg;


### PR DESCRIPTION
```sql
CREATE TABLE t0 (c0 Int32) ENGINE = MergeTree() ORDER BY (c0  / -42) SETTINGS index_granularity = 1;
INSERT INTO t0 VALUES (-1);

SELECT t0.c0
FROM t0
WHERE t0.c0 < 0
SETTINGS use_primary_key = 0; -- Correct; returns 1 row


SELECT t0.c0
FROM t0
WHERE t0.c0 < 0
SETTINGS use_primary_key = 1; -- Incorrectly prunes; returns 0 row
```

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix incorrect results for queries against tables whose `ORDER BY` contains a monotonically decreasing function such as `(c0 / -42)` or `intDiv(c0, -42)`. Predicates on the underlying column (for example, `c0 < 0`) could wrongly prune granules that contained matching rows, producing missing results. Closes https://github.com/ClickHouse/ClickHouse/issues/106084. Closes https://github.com/ClickHouse/ClickHouse/issues/106124. Closes https://github.com/ClickHouse/ClickHouse/issues/106080.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.853`
<!-- ch-version-info:end -->