### PR TITLE
Capture fuzzer sanitizer reports via log_path to avoid losing the stack

### DIFF
--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -251,7 +251,14 @@ def run_fuzz_job(check_name: str):
             fuzzer_exit_code = int(fuzzer_exit_code)
     except Exception:
         error_info = f"Unknown error in fuzzer runner script. Traceback:\n{traceback.format_exc()}"
-        Result.create_from(status=Result.Status.ERROR, info=error_info).complete_job()
+        # Runner may have aborted before writing status.tsv (e.g. early server
+        # abort); attach available artifacts (incl. sanitizer.log.*) so the report
+        # is not lost.
+        early_result = Result.create_from(status=Result.Status.ERROR, info=error_info)
+        for file in paths:
+            if file.exists() and file.stat().st_size > 0:
+                early_result.set_files(file)
+        early_result.complete_job()
 
     # parse runner script exit status
     status = Result.Status.FAIL

--- a/ci/jobs/ast_fuzzer_job.py
+++ b/ci/jobs/ast_fuzzer_job.py
@@ -233,6 +233,11 @@ def run_fuzz_job(check_name: str):
     if buzzhouse:
         paths.extend([WORKSPACE_PATH / "fuzzerout.sql", WORKSPACE_PATH / "fuzz.json"])
 
+    # Raw sanitizer reports written via *SAN_OPTIONS=log_path (see run-fuzzer.sh).
+    # Their contents are also merged into stderr.log/server.log, but upload the
+    # originals too for debugging truncated reports.
+    paths.extend(sorted(WORKSPACE_PATH.glob("sanitizer.log.*")))
+
     server_died = False
     server_exit_code = 0
     fuzzer_exit_code = 0

--- a/ci/jobs/scripts/fuzzer/run-fuzzer.sh
+++ b/ci/jobs/scripts/fuzzer/run-fuzzer.sh
@@ -20,22 +20,35 @@ export PYTHONPATH=$repo_dir:$repo_dir/ci
 
 cd /workspace
 
-# Direct sanitizer reports to dedicated files instead of relying on the process
-# stderr. The server's stderr is piped through `tee` (see `fuzz`), and when the
-# server aborts the reader of that pipe can go away, so the sanitizer runtime
-# (and the in-process LLVM symbolizer) fail to write the report with
-# "IO failure on output stream: Broken pipe", truncating it before the stack
-# trace is printed. Writing to a regular file is robust to that, so the full
-# report (including frames needed to compute a stack-trace id) survives. The
-# runtime appends ".<pid>" to `log_path`; the files are merged back into
-# stderr.log and server.log once the server stops (see `fuzz`). Existing options
-# coming from the environment/image are preserved.
+# Direct sanitizer reports to files instead of the server's stderr to avoid 
+# losing the report when the server aborts. The runtime appends ".<pid>"
+# to `log_path`; reports are merged back in by collect_sanitizer_reports.
+# Existing options from the environment/image are preserved.
 SANITIZER_LOG_BASE="/workspace/sanitizer.log"
 for _san in ASAN TSAN MSAN UBSAN LSAN; do
     _var="${_san}_OPTIONS"
     export "$_var"="${!_var:+${!_var} }log_path=${SANITIZER_LOG_BASE}"
 done
 unset _san _var
+
+function collect_sanitizer_reports
+{
+    # Merge sanitizer reports captured via log_path into stderr.log (for the
+    # failure parser) and server.log (for context and the OOM grep). Run from an
+    # EXIT trap so early `set -e` aborts are covered too; `|| true` keeps the
+    # exit code intact.
+    local report
+    for report in "${SANITIZER_LOG_BASE}".*; do
+        [ -e "$report" ] || continue
+        echo "Found sanitizer report: $report"
+        {
+            echo "=== sanitizer report from ${report} ==="
+            cat "$report"
+            echo
+        } | tee -a stderr.log >> server.log || true
+    done
+}
+trap collect_sanitizer_reports EXIT
 
 function configure
 {
@@ -321,21 +334,6 @@ function fuzz
     server_exit_code=0
     wait $server_bg_pid || server_exit_code=$?
     echo "Server exit code is $server_exit_code"
-
-    # Surface sanitizer reports captured via log_path (see the top of the script).
-    # They are appended to stderr.log so the failure parser can extract the stack
-    # trace, and to server.log so the chronological context and the OOM detection
-    # (which greps server.log) keep working.
-    for _san_report in "${SANITIZER_LOG_BASE}".*; do
-        [ -e "$_san_report" ] || continue
-        echo "Found sanitizer report: $_san_report"
-        {
-            echo "=== sanitizer report from ${_san_report} ==="
-            cat "$_san_report"
-            echo
-        } | tee -a stderr.log >> server.log
-    done
-    unset _san_report
 
     echo -e "$server_died\t$server_exit_code\t$fuzzer_exit_code" > status.tsv
 

--- a/ci/jobs/scripts/fuzzer/run-fuzzer.sh
+++ b/ci/jobs/scripts/fuzzer/run-fuzzer.sh
@@ -20,6 +20,23 @@ export PYTHONPATH=$repo_dir:$repo_dir/ci
 
 cd /workspace
 
+# Direct sanitizer reports to dedicated files instead of relying on the process
+# stderr. The server's stderr is piped through `tee` (see `fuzz`), and when the
+# server aborts the reader of that pipe can go away, so the sanitizer runtime
+# (and the in-process LLVM symbolizer) fail to write the report with
+# "IO failure on output stream: Broken pipe", truncating it before the stack
+# trace is printed. Writing to a regular file is robust to that, so the full
+# report (including frames needed to compute a stack-trace id) survives. The
+# runtime appends ".<pid>" to `log_path`; the files are merged back into
+# stderr.log and server.log once the server stops (see `fuzz`). Existing options
+# coming from the environment/image are preserved.
+SANITIZER_LOG_BASE="/workspace/sanitizer.log"
+for _san in ASAN TSAN MSAN UBSAN LSAN; do
+    _var="${_san}_OPTIONS"
+    export "$_var"="${!_var:+${!_var} }log_path=${SANITIZER_LOG_BASE}"
+done
+unset _san _var
+
 function configure
 {
     chmod +x $repo_dir/ci/tmp/clickhouse
@@ -304,6 +321,21 @@ function fuzz
     server_exit_code=0
     wait $server_bg_pid || server_exit_code=$?
     echo "Server exit code is $server_exit_code"
+
+    # Surface sanitizer reports captured via log_path (see the top of the script).
+    # They are appended to stderr.log so the failure parser can extract the stack
+    # trace, and to server.log so the chronological context and the OOM detection
+    # (which greps server.log) keep working.
+    for _san_report in "${SANITIZER_LOG_BASE}".*; do
+        [ -e "$_san_report" ] || continue
+        echo "Found sanitizer report: $_san_report"
+        {
+            echo "=== sanitizer report from ${_san_report} ==="
+            cat "$_san_report"
+            echo
+        } | tee -a stderr.log >> server.log
+    done
+    unset _san_report
 
     echo -e "$server_died\t$server_exit_code\t$fuzzer_exit_code" > status.tsv
 


### PR DESCRIPTION
Fuzzer jobs pipe clickhouse-server stderr through tee into stderr.log/server.log. Sanitizer reports write to that stderr, but when the server aborts the pipe breaks (IO failure on output stream: Broken pipe), truncating the report before any stack frame is printed.

With no frames, log_parser.py can't compute a stack-trace id and names the failure ... (STID: None) — so the CI matcher groups every stack-less sanitizer failure under one auto-generated issue, making unrelated bugs across PRs look like a single recurring failure.

Fix: set *_OPTIONS=log_path=... so the runtime writes reports to a file, robust to the pipe breaking. The files are merged back into stderr.log (for the parser) and server.log (for context and the OOM grep), and uploaded as artifacts. The parser can then compute a real stack-trace id, and distinct failures stop collapsing into one issue.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/PRs/105701/feba3438e46f861025a0cb811816a3138cdb67d9/buzzhouse_amd_msan/
PR: https://github.com/ClickHouse/ClickHouse/pull/105701
Issue: https://github.com/ClickHouse/ClickHouse/issues/106138

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.274`
<!-- ch-version-info:end -->