### PR TITLE
Support NULL / NOT NULL modifier in ALTER ADD/MODIFY COLUMN

### DIFF
--- a/src/Parsers/ParserAlterQuery.cpp
+++ b/src/Parsers/ParserAlterQuery.cpp
@@ -774,6 +774,17 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
                 if (!parser_modify_col_decl.parse(pos, command_col_decl, expected))
                     return false;
 
+                /// A trailing NULL / NOT NULL modifier needs an explicit column type to apply it
+                /// to, the same way ADD COLUMN / CREATE TABLE do. A type-less MODIFY / ALTER COLUMN
+                /// has no type, so reject it here instead of silently ignoring the modifier.
+                if (const auto & col_decl = command_col_decl->as<const ASTColumnDeclaration &>();
+                    col_decl.null_modifier.has_value() && !col_decl.getType())
+                {
+                    throw Exception(
+                        ErrorCodes::SYNTAX_ERROR,
+                        "NULL / NOT NULL modifier requires an explicit column type");
+                }
+
                 auto check_no_type = [&](const std::string_view keyword)
                 {
                     const auto & column_decl = command_col_decl->as<const ASTColumnDeclaration &>();

--- a/src/Parsers/ParserAlterQuery.cpp
+++ b/src/Parsers/ParserAlterQuery.cpp
@@ -135,13 +135,13 @@ bool ParserAlterCommand::parseImpl(Pos & pos, ASTPtr & node, Expected & expected
     ParserCompoundIdentifier parser_name;
     ParserStringLiteral parser_string_literal;
     ParserStringAndSubstitution parser_string_and_substituion;
-    ParserCompoundColumnDeclaration parser_col_decl;
+    ParserCompoundColumnDeclaration parser_col_decl(/* require_type = */ true, /* allow_null_modifiers = */ true);
     ParserIndexDeclaration parser_idx_decl;
     ParserStatisticsDeclaration parser_stat_decl;
     ParserStatisticsDeclarationWithoutTypes parser_stat_decl_without_types;
     ParserConstraintDeclaration parser_constraint_decl;
     ParserProjectionDeclaration parser_projection_decl;
-    ParserCompoundColumnDeclaration parser_modify_col_decl(false, false, true);
+    ParserCompoundColumnDeclaration parser_modify_col_decl(/* require_type = */ false, /* allow_null_modifiers = */ true, /* check_keywords_after_name = */ true);
     ParserPartition parser_partition;
     ParserExpressionWithOptionalAlias parser_exp_elem(false);
     ParserList parser_assignment_list(

--- a/src/Storages/AlterCommands.cpp
+++ b/src/Storages/AlterCommands.cpp
@@ -80,6 +80,7 @@ namespace ErrorCodes
     extern const int DUPLICATE_COLUMN;
     extern const int NOT_IMPLEMENTED;
     extern const int ALTER_OF_COLUMN_IS_FORBIDDEN;
+    extern const int ILLEGAL_SYNTAX_FOR_DATA_TYPE;
 }
 
 namespace MergeTreeSetting
@@ -119,6 +120,18 @@ AlterCommand::RemoveProperty removePropertyFromString(const String & property)
     throw Exception(ErrorCodes::BAD_ARGUMENTS, "Cannot remove unknown property '{}'", property);
 }
 
+/// Apply the trailing `NULL` / `NOT NULL` column modifier, mirroring the logic in
+/// InterpreterCreateQuery so that ALTER ADD/MODIFY COLUMN behaves like CREATE TABLE.
+void applyNullModifier(DataTypePtr & data_type, const std::optional<bool> & null_modifier)
+{
+    if (!null_modifier)
+        return;
+    if (data_type->isNullable())
+        throw Exception(ErrorCodes::ILLEGAL_SYNTAX_FOR_DATA_TYPE, "Can't use [NOT] NULL modifier with Nullable type");
+    if (*null_modifier)
+        data_type = makeNullable(data_type);
+}
+
 }
 
 std::optional<AlterCommand> AlterCommand::parse(const ASTAlterCommand * command_ast)
@@ -137,6 +150,7 @@ std::optional<AlterCommand> AlterCommand::parse(const ASTAlterCommand * command_
         if (ast_col_decl.getType())
         {
             command.data_type = data_type_factory.get(ast_col_decl.getType());
+            applyNullModifier(command.data_type, ast_col_decl.null_modifier);
         }
         if (ast_col_decl.getDefaultExpression())
         {
@@ -194,6 +208,7 @@ std::optional<AlterCommand> AlterCommand::parse(const ASTAlterCommand * command_
         if (ast_col_decl.getType())
         {
             command.data_type = data_type_factory.get(ast_col_decl.getType());
+            applyNullModifier(command.data_type, ast_col_decl.null_modifier);
         }
 
         if (ast_col_decl.getDefaultExpression())

--- a/tests/queries/0_stateless/02302_column_decl_null_before_defaul_value.reference
+++ b/tests/queries/0_stateless/02302_column_decl_null_before_defaul_value.reference
@@ -18,5 +18,6 @@ create table, column -type +DEFAULT +NULL
 id	Nullable(UInt8)	DEFAULT	1			
 create table, column -type +DEFAULT +NOT NULL
 id	UInt8	DEFAULT	1			
-alter column, NULL modifier is not allowed
-modify column, NULL modifier is not allowed
+alter column, type + NULL modifier
+id	Nullable(Int32)					
+modify column, type-less NULL modifier is not allowed

--- a/tests/queries/0_stateless/02302_column_decl_null_before_defaul_value.sql
+++ b/tests/queries/0_stateless/02302_column_decl_null_before_defaul_value.sql
@@ -48,12 +48,13 @@ DROP TABLE IF EXISTS null_before SYNC;
 CREATE TABLE null_before (id DEFAULT 1 NOT NULL) ENGINE=MergeTree() ORDER BY tuple();
 DESCRIBE TABLE null_before;
 
-select 'alter column, NULL modifier is not allowed';
+select 'alter column, type + NULL modifier';
 DROP TABLE IF EXISTS null_before SYNC;
 CREATE TABLE null_before (id INT NOT NULL) ENGINE=MergeTree() ORDER BY tuple();
-ALTER TABLE null_before ALTER COLUMN id TYPE INT NULL; -- { clientError SYNTAX_ERROR }
+ALTER TABLE null_before ALTER COLUMN id TYPE INT NULL;
+DESCRIBE TABLE null_before;
 
-select 'modify column, NULL modifier is not allowed';
+select 'modify column, type-less NULL modifier is not allowed';
 DROP TABLE IF EXISTS null_before SYNC;
 CREATE TABLE null_before (id INT NOT NULL) ENGINE=MergeTree() ORDER BY tuple();
 ALTER TABLE null_before MODIFY COLUMN id NULL DEFAULT 1; -- { clientError SYNTAX_ERROR }

--- a/tests/queries/0_stateless/04299_alter_column_null_modifier.reference
+++ b/tests/queries/0_stateless/04299_alter_column_null_modifier.reference
@@ -1,6 +1,14 @@
+add
 a	Int32
 b	Nullable(Int32)
 c	Int32
 d	Nullable(UInt8)
 e	Float64
+modify
+a	Int32
+b	Int32
+c	Nullable(Int32)
+d	Nullable(UInt8)
+e	Nullable(Float64)
+alter_column
 Nullable(Int32)

--- a/tests/queries/0_stateless/04299_alter_column_null_modifier.reference
+++ b/tests/queries/0_stateless/04299_alter_column_null_modifier.reference
@@ -1,0 +1,6 @@
+a	Int32
+b	Nullable(Int32)
+c	Int32
+d	Nullable(UInt8)
+e	Float64
+Nullable(Int32)

--- a/tests/queries/0_stateless/04299_alter_column_null_modifier.sql
+++ b/tests/queries/0_stateless/04299_alter_column_null_modifier.sql
@@ -41,4 +41,8 @@ WHERE database = currentDatabase() AND table = 't_alter_null' AND name = 'a';
 ALTER TABLE t_alter_null ADD COLUMN f Nullable(Int32) NULL; -- { serverError ILLEGAL_SYNTAX_FOR_DATA_TYPE }
 ALTER TABLE t_alter_null MODIFY COLUMN c Nullable(Int32) NULL; -- { serverError ILLEGAL_SYNTAX_FOR_DATA_TYPE }
 
+-- A type that cannot be nested inside Nullable is rejected, the same way as in CREATE TABLE.
+ALTER TABLE t_alter_null ADD COLUMN g Array(Int32) NULL; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+ALTER TABLE t_alter_null MODIFY COLUMN a Array(Int32) NULL; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
 DROP TABLE t_alter_null;

--- a/tests/queries/0_stateless/04299_alter_column_null_modifier.sql
+++ b/tests/queries/0_stateless/04299_alter_column_null_modifier.sql
@@ -1,0 +1,28 @@
+-- Tests that ALTER TABLE ADD/MODIFY COLUMN supports the trailing NULL / NOT NULL
+-- modifier, the same way CREATE TABLE does.
+-- See https://github.com/ClickHouse/ClickHouse/issues/44752
+
+DROP TABLE IF EXISTS t_alter_null;
+
+CREATE TABLE t_alter_null (a Int32) ENGINE = Memory;
+
+-- ADD COLUMN with the postfix NULL / NOT NULL modifier, for single-word and multiword types.
+ALTER TABLE t_alter_null ADD COLUMN b Int32 NULL;
+ALTER TABLE t_alter_null ADD COLUMN c Int32 NOT NULL;
+ALTER TABLE t_alter_null ADD COLUMN d TINYINT UNSIGNED NULL;
+ALTER TABLE t_alter_null ADD COLUMN e DOUBLE PRECISION NOT NULL;
+
+SELECT name, type FROM system.columns
+WHERE database = currentDatabase() AND table = 't_alter_null'
+ORDER BY name;
+
+-- MODIFY COLUMN with the postfix NULL modifier turns a non-nullable column nullable.
+ALTER TABLE t_alter_null MODIFY COLUMN c Int32 NULL;
+
+SELECT type FROM system.columns
+WHERE database = currentDatabase() AND table = 't_alter_null' AND name = 'c';
+
+-- A [NOT] NULL modifier on an already-Nullable type is rejected, the same way as in CREATE TABLE.
+ALTER TABLE t_alter_null ADD COLUMN f Nullable(Int32) NULL; -- { serverError ILLEGAL_SYNTAX_FOR_DATA_TYPE }
+
+DROP TABLE t_alter_null;

--- a/tests/queries/0_stateless/04299_alter_column_null_modifier.sql
+++ b/tests/queries/0_stateless/04299_alter_column_null_modifier.sql
@@ -1,5 +1,8 @@
--- Tests that ALTER TABLE ADD/MODIFY COLUMN supports the trailing NULL / NOT NULL
--- modifier, the same way CREATE TABLE does.
+-- Tests that ALTER TABLE ADD / MODIFY / ALTER COLUMN supports the trailing NULL / NOT NULL
+-- modifier, the same way CREATE TABLE does, for single-word and multiword types.
+-- The modifier needs an explicit column type to apply to, so ADD COLUMN, MODIFY COLUMN
+-- and ALTER COLUMN ... TYPE all accept it; only a type-less MODIFY / ALTER COLUMN keeps
+-- rejecting it at parse time (covered by 02302_column_decl_null_before_defaul_value).
 -- See https://github.com/ClickHouse/ClickHouse/issues/44752
 
 DROP TABLE IF EXISTS t_alter_null;
@@ -12,17 +15,30 @@ ALTER TABLE t_alter_null ADD COLUMN c Int32 NOT NULL;
 ALTER TABLE t_alter_null ADD COLUMN d TINYINT UNSIGNED NULL;
 ALTER TABLE t_alter_null ADD COLUMN e DOUBLE PRECISION NOT NULL;
 
+SELECT 'add';
 SELECT name, type FROM system.columns
 WHERE database = currentDatabase() AND table = 't_alter_null'
 ORDER BY name;
 
--- MODIFY COLUMN with the postfix NULL modifier turns a non-nullable column nullable.
-ALTER TABLE t_alter_null MODIFY COLUMN c Int32 NULL;
+-- MODIFY COLUMN with the postfix modifier, single-word and multiword types, both directions.
+ALTER TABLE t_alter_null MODIFY COLUMN c Int32 NULL;            -- Int32 -> Nullable(Int32)
+ALTER TABLE t_alter_null MODIFY COLUMN b Int32 NOT NULL;        -- Nullable(Int32) -> Int32
+ALTER TABLE t_alter_null MODIFY COLUMN e DOUBLE PRECISION NULL; -- Float64 -> Nullable(Float64)
 
+SELECT 'modify';
+SELECT name, type FROM system.columns
+WHERE database = currentDatabase() AND table = 't_alter_null'
+ORDER BY name;
+
+-- ALTER COLUMN ... TYPE ... NULL is supported too (same effect as MODIFY COLUMN ... NULL).
+ALTER TABLE t_alter_null ALTER COLUMN a TYPE Int32 NULL;
+
+SELECT 'alter_column';
 SELECT type FROM system.columns
-WHERE database = currentDatabase() AND table = 't_alter_null' AND name = 'c';
+WHERE database = currentDatabase() AND table = 't_alter_null' AND name = 'a';
 
 -- A [NOT] NULL modifier on an already-Nullable type is rejected, the same way as in CREATE TABLE.
 ALTER TABLE t_alter_null ADD COLUMN f Nullable(Int32) NULL; -- { serverError ILLEGAL_SYNTAX_FOR_DATA_TYPE }
+ALTER TABLE t_alter_null MODIFY COLUMN c Nullable(Int32) NULL; -- { serverError ILLEGAL_SYNTAX_FOR_DATA_TYPE }
 
 DROP TABLE t_alter_null;


### PR DESCRIPTION
CREATE TABLE accepts a trailing NULL / NOT NULL column modifier, but ALTER TABLE ADD/MODIFY COLUMN rejected it with a syntax error for any type (e.g. `ALTER TABLE t ADD COLUMN c Int32 NULL`). Enable allow_null_modifiers in the ALTER column-declaration parsers and apply the modifier in AlterCommands, mirroring InterpreterCreateQuery (rejecting a [NOT] NULL modifier on an already-Nullable type).

Closes #44752.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Support a trailing `NULL` / `NOT NULL` modifier in `ALTER TABLE ... ADD/MODIFY COLUMN`, mirroring `CREATE TABLE`. 