### PR TITLE
Fix test_library_bridge/test.py::test_server_restart_bridge_might_be_still_alive test

### DIFF
--- a/tests/integration/test_library_bridge/test.py
+++ b/tests/integration/test_library_bridge/test.py
@@ -303,6 +303,9 @@ def test_server_restart_bridge_might_be_still_alive(ch_cluster):
     assert result.strip() == "101"
 
     instance.restart_clickhouse()
+    # Force the server to re-establish the bridge connection; the old bridge process
+    # may still be alive with stale state, causing "Connection reset by peer" on first dictGet.
+    instance.query("SYSTEM RELOAD DICTIONARY lib_dict_c")
 
     result = instance.query("""select dictGet(lib_dict_c, 'value1', toUInt64(1));""")
     assert result.strip() == "101"
@@ -311,6 +314,7 @@ def test_server_restart_bridge_might_be_still_alive(ch_cluster):
         ["bash", "-c", "kill -9 `pidof clickhouse-library-bridge`"], user="root"
     )
     instance.restart_clickhouse()
+    instance.query("SYSTEM RELOAD DICTIONARY lib_dict_c")
 
     result = instance.query("""select dictGet(lib_dict_c, 'value1', toUInt64(1));""")
     assert result.strip() == "101"


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Reload the dictionary after a server restart, so the bridge connection is re-established. Closes https://github.com/ClickHouse/ClickHouse/issues/106151

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.276`
<!-- ch-version-info:end -->