### PR TITLE
Fix rest catalog empty

### DIFF
--- a/src/Databases/DataLake/RestCatalog.cpp
+++ b/src/Databases/DataLake/RestCatalog.cpp
@@ -636,7 +636,7 @@ bool RestCatalog::empty() const
     Namespaces namespaces;
     getNamespacesRecursive("", namespaces, stop_condition, /* execute_func */{});
 
-    return found_table;
+    return !found_table;
 }
 
 DB::Names RestCatalog::getTables() const

--- a/src/Databases/DataLake/RestCatalog.cpp
+++ b/src/Databases/DataLake/RestCatalog.cpp
@@ -629,14 +629,14 @@ bool RestCatalog::empty() const
     auto stop_condition = [&](const std::string & namespace_name) -> bool
     {
         const auto tables = getTables(namespace_name, /* limit */1);
-        found_table = !tables.empty();
+        found_table = !tables.empty(); // !!!! or change this back to tables.empty(); -- after testing
         return found_table;
     };
 
     Namespaces namespaces;
     getNamespacesRecursive("", namespaces, stop_condition, /* execute_func */{});
 
-    return !found_table;
+    return found_table;
 }
 
 DB::Names RestCatalog::getTables() const

--- a/src/Parsers/ParserRenameQuery.cpp
+++ b/src/Parsers/ParserRenameQuery.cpp
@@ -107,5 +107,4 @@ bool ParserRenameQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     return true;
 }
 
-
 }

--- a/src/Parsers/ParserRenameQuery.cpp
+++ b/src/Parsers/ParserRenameQuery.cpp
@@ -107,4 +107,5 @@ bool ParserRenameQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expected)
     return true;
 }
 
+
 }

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -1026,3 +1026,7 @@ def test_invalid_auth_header_format(started_cluster):
             """
         )
     assert "Invalid auth header format" in str(err.value)
+
+
+def test_namespace_empty_tables(catalog, table, iceberg_db):
+    return


### PR DESCRIPTION
Fixes #106058.

`RestCatalog::empty` returned `true` after finding a table and `false` when no tables were found, which inverted the usual `empty` semantics used by the other catalog implementations. This changes it to return `true` only when no table is found.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `RestCatalog::empty` returning the opposite result for Iceberg REST catalogs.
