### PR TITLE
fix(docs): readWKTMultiLineString example uses wrong function name

### DIFF
--- a/src/Functions/readWkt.cpp
+++ b/src/Functions/readWkt.cpp
@@ -338,9 +338,9 @@ Parses a Well-Known Text (WKT) representation of a MultiLineString geometry and 
     },
     {
         "MultiLineString example",
-        "SELECT toTypeName(readWKTLineString('MULTILINESTRING ((1 1, 2 2, 3 3, 1 1))'));",
+        "SELECT toTypeName(readWKTMultiLineString('MULTILINESTRING ((1 1, 2 2, 3 3, 1 1))'));",
         R"(
-┌─toTypeName(readWKTLineString('MULTILINESTRING ((1 1, 2 2, 3 3, 1 1))'))─┐
+┌─toTypeName(readWKTMultiLineString('MULTILINESTRING ((1 1, 2 2, 3 3, 1 1))'))─┐
 │ MultiLineString                                                         │
 └─────────────────────────────────────────────────────────────────────────┘
         )"


### PR DESCRIPTION
## Description

The documentation example for `readWKTMultiLineString` incorrectly uses `readWKTLineString` in the example query, which throws an error when executed instead of producing the documented output.

## Changes

- Changed `readWKTLineString` → `readWKTMultiLineString` in the example query
- Updated the output header to match the corrected function name

## References

Closes #104974

## Checklist
- [x] User-facing changes have a documentation update
- [x] The `changelog/` entry was created (documentation-only fix, no changelog needed)