### PR TITLE
fix(docs): correct output values in multiSearchFirstPositionUTF8 examples

### DIFF
--- a/src/Functions/multiSearchFirstPositionCaseInsensitiveUTF8.cpp
+++ b/src/Functions/multiSearchFirstPositionCaseInsensitiveUTF8.cpp
@@ -35,8 +35,8 @@ Like [multiSearchFirstPosition](#multiSearchFirstPosition) but assumes `haystack
         "Find the leftmost offset in UTF-8 string 'Здравствуй, мир' ('Hello, world') which matches any of the given needles",
         "SELECT multiSearchFirstPositionCaseInsensitiveUTF8('Здравствуй, мир', ['МИР', 'вст', 'Здра'])",
         R"(
-┌─multiSearchFirstPositionCaseInsensitiveUTF8('Здравствуй, мир', ['мир', 'вст', 'Здра'])─┐
-│                                                                                      3 │
+┌─multiSearchFirstPositionCaseInsensitiveUTF8('Здравствуй, мир', ['МИР', 'вст', 'Здра'])─┐
+│                                                                                      1 │
 └────────────────────────────────────────────────────────────────────────────────────────┘
         )"
     }

--- a/src/Functions/multiSearchFirstPositionUTF8.cpp
+++ b/src/Functions/multiSearchFirstPositionUTF8.cpp
@@ -36,7 +36,7 @@ Like [multiSearchFirstPosition](#multiSearchFirstPosition) but assumes `haystack
         "SELECT multiSearchFirstPositionUTF8('Здравствуй, мир',['мир', 'вст', 'авст'])",
         R"(
 ┌─multiSearchFirstPositionUTF8('Здравствуй, мир', ['мир', 'вст', 'авст'])─┐
-│                                                                       3 │
+│                                                                       4 │
 └─────────────────────────────────────────────────────────────────────────┘
         )"
     }


### PR DESCRIPTION
## Description

The documentation examples for `multiSearchFirstPositionUTF8` and `multiSearchFirstPositionCaseInsensitiveUTF8` contain incorrect expected output values.

## Changes

### `multiSearchFirstPositionUTF8.cpp`
- Changed example output from `3` to `4` (correct 1-based position of leftmost match "авст" in "Здравствуй, мир": З(1) д(2) р(3) а(4))

### `multiSearchFirstPositionCaseInsensitiveUTF8.cpp`
- Changed example output from `3` to `1` (correct 1-based position of leftmost match "Здра" at character 1)
- Fixed the output header to use uppercase `МИР` matching the actual query needles (was incorrectly showing lowercase `мир`)

## References

Closes #102662

## Checklist
- [x] User-facing changes have a documentation update
- [x] The `changelog/` entry was created (documentation-only fix, no changelog needed)