### PR TITLE
fix(docs): correct h3Distance example output value

### DIFF
--- a/src/Functions/h3Distance.cpp
+++ b/src/Functions/h3Distance.cpp
@@ -141,7 +141,7 @@ This function calculates the minimum number of grid cells between the start and 
             "SELECT h3Distance(590080540275638271, 590103561300344831) AS distance",
             R"(
 ┌─distance─┐
-│        7 │
+│        6 │
 └──────────┘
             )"
         }


### PR DESCRIPTION
## Description

The `h3Distance` documentation example claims `h3Distance(590080540275638271, 590103561300344831)` returns `7`, but the H3 library actually returns `6` for these inputs.

## Changes

- Changed example output from `7` to `6` in `src/Functions/h3Distance.cpp`

## References

Closes #102844

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):