### PR TITLE
Remove per-thread (VariableContext::Thread) MemoryTracker

### DIFF
--- a/src/AggregateFunctions/fuzzers/aggregate_function_state_deserialization_fuzzer.cpp
+++ b/src/AggregateFunctions/fuzzers/aggregate_function_state_deserialization_fuzzer.cpp
@@ -152,8 +152,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
     {
         total_memory_tracker.resetCounters();
         total_memory_tracker.setHardLimit(128_MiB);
-        CurrentThread::get().memory_tracker.resetCounters();
-        CurrentThread::get().memory_tracker.setHardLimit(128_MiB);
+        CurrentThread::get().memory_tracker->resetCounters();
+        CurrentThread::get().memory_tracker->setHardLimit(128_MiB);
 
         /// The input format is as follows:
         /// - the aggregate function name on the first line, possible with parameters, then data types of the arguments,

--- a/src/Common/CurrentMemoryTracker.cpp
+++ b/src/Common/CurrentMemoryTracker.cpp
@@ -85,7 +85,9 @@ AllocationTrace CurrentMemoryTracker::allocImpl(Int64 size, bool enforce_memory_
 
             try
             {
-                return memory_tracker->allocImpl(current_untracked_memory, enforce_memory_limit);
+                auto trace = memory_tracker->allocImpl(current_untracked_memory, enforce_memory_limit);
+                current_thread->adjustThreadMemoryUsage(current_untracked_memory);
+                return trace;
             }
             catch (...)
             {
@@ -156,6 +158,7 @@ AllocationTrace CurrentMemoryTracker::free(Int64 size)
         {
             Int64 untracked_memory = current_thread->untracked_memory;
             current_thread->untracked_memory = 0;
+            current_thread->adjustThreadMemoryUsage(untracked_memory);
             return memory_tracker->free(-untracked_memory);
         }
 

--- a/src/Common/CurrentThread.cpp
+++ b/src/Common/CurrentThread.cpp
@@ -55,7 +55,7 @@ MemoryTracker * CurrentThread::getMemoryTracker()
 {
     if (!current_thread) [[unlikely]]
         return nullptr;
-    return &current_thread->memory_tracker;
+    return current_thread->memory_tracker;
 }
 
 void CurrentThread::updateProgressIn(const Progress & value)
@@ -227,11 +227,18 @@ MemoryTracker * CurrentThread::getUserMemoryTracker()
     if (unlikely(!current_thread))
         return nullptr;
 
-    auto * tracker = current_thread->memory_tracker.getParent();
+    auto * tracker = current_thread->memory_tracker;
     while (tracker && tracker->level != VariableContext::User)
         tracker = tracker->getParent();
 
     return tracker;
+}
+
+Int64 CurrentThread::getThreadMemoryUsage()
+{
+    if (unlikely(!current_thread))
+        return 0;
+    return current_thread->getThreadMemoryUsage();
 }
 
 void CurrentThread::flushUntrackedMemory()

--- a/src/Common/CurrentThread.h
+++ b/src/Common/CurrentThread.h
@@ -82,7 +82,10 @@ public:
     static void updatePerformanceCountersIfNeeded();
 
     static ProfileEvents::Counters & getProfileEvents();
+    /// The tracker this thread's allocations are accounted to (Process-level group tracker or total).
     static MemoryTracker * getMemoryTracker();
+    /// Current memory consumed by this thread (the thread "delta", may be negative).
+    static Int64 getThreadMemoryUsage();
 
     /// Update read and write rows (bytes) statistics (used in system.query_thread_log)
     static void updateProgressIn(const Progress & value);

--- a/src/Common/MemoryTracker.cpp
+++ b/src/Common/MemoryTracker.cpp
@@ -627,11 +627,6 @@ AllocationTrace MemoryTracker::free(Int64 size, double _sample_probability)
         amount.fetch_sub(accounted_size, std::memory_order_relaxed);
         rss.fetch_sub(accounted_size, std::memory_order_relaxed);
     }
-    else if (level == VariableContext::Thread)
-    {
-        /// Could become negative if memory allocated in this thread is freed in another one
-        amount.fetch_sub(accounted_size, std::memory_order_relaxed);
-    }
     else
     {
         Int64 new_amount = amount.fetch_sub(accounted_size, std::memory_order_relaxed) - accounted_size;
@@ -767,11 +762,6 @@ bool MemoryTracker::isSizeOkForSampling(UInt64 size) const
 
 void MemoryTracker::setParent(MemoryTracker * elem)
 {
-    /// Untracked memory shouldn't be accounted to a query or a user if it was allocated before the thread was attached
-    /// to a query thread group or a user group, because this memory will be (🤞) freed outside of these scopes.
-    if (level == VariableContext::Thread && DB::current_thread)
-        DB::current_thread->flushUntrackedMemory();
-
     parent.store(elem, std::memory_order_relaxed);
 
 #ifdef DEBUG_OR_SANITIZER_BUILD

--- a/src/Common/MemoryTracker.h
+++ b/src/Common/MemoryTracker.h
@@ -150,8 +150,8 @@ public:
     static constexpr auto USAGE_EVENT_NAME = "MemoryTrackerUsage";
     static constexpr auto PEAK_USAGE_EVENT_NAME = "MemoryTrackerPeakUsage";
 
-    explicit MemoryTracker(VariableContext level_ = VariableContext::Thread);
-    explicit MemoryTracker(MemoryTracker * parent_, VariableContext level_ = VariableContext::Thread);
+    explicit MemoryTracker(VariableContext level_ = VariableContext::Process);
+    explicit MemoryTracker(MemoryTracker * parent_, VariableContext level_ = VariableContext::Process);
     MemoryTracker(MemoryTracker * parent_, VariableContext level_, bool log_peak_memory_usage_in_destructor_);
 
     ~MemoryTracker();

--- a/src/Common/MemoryTrackerSwitcher.cpp
+++ b/src/Common/MemoryTrackerSwitcher.cpp
@@ -16,6 +16,7 @@ MemoryTrackerSwitcher::MemoryTrackerSwitcher(MemoryTracker * new_tracker)
     prev_memory_tracker = current_thread->memory_tracker;
 
     current_thread->untracked_memory = 0;
+    chassert(new_tracker);
     current_thread->memory_tracker = new_tracker;
 }
 

--- a/src/Common/MemoryTrackerSwitcher.cpp
+++ b/src/Common/MemoryTrackerSwitcher.cpp
@@ -11,14 +11,12 @@ MemoryTrackerSwitcher::MemoryTrackerSwitcher(MemoryTracker * new_tracker)
     if (!current_thread)
         return;
 
-    auto * thread_tracker = CurrentThread::getMemoryTracker();
-
     prev_untracked_memory = current_thread->untracked_memory;
     prev_untracked_memory_blocker_level = current_thread->untracked_memory_blocker_level;
-    prev_memory_tracker_parent = thread_tracker->getParent();
+    prev_memory_tracker = current_thread->memory_tracker;
 
     current_thread->untracked_memory = 0;
-    thread_tracker->setParent(new_tracker);
+    current_thread->memory_tracker = new_tracker;
 }
 
 MemoryTrackerSwitcher::~MemoryTrackerSwitcher()
@@ -28,11 +26,10 @@ MemoryTrackerSwitcher::~MemoryTrackerSwitcher()
         return;
 
     CurrentThread::flushUntrackedMemory();
-    auto * thread_tracker = CurrentThread::getMemoryTracker();
 
-    /// It is important to set untracked memory after the call of
-    /// 'setParent' because it may flush untracked memory to the wrong parent.
-    thread_tracker->setParent(prev_memory_tracker_parent);
+    /// It is important to restore untracked memory after repointing the tracker,
+    /// otherwise flushUntrackedMemory() above would account it to the wrong tracker.
+    current_thread->memory_tracker = prev_memory_tracker;
     current_thread->untracked_memory = prev_untracked_memory;
     current_thread->untracked_memory_blocker_level = prev_untracked_memory_blocker_level;
 }

--- a/src/Common/MemoryTrackerSwitcher.h
+++ b/src/Common/MemoryTrackerSwitcher.h
@@ -11,7 +11,7 @@ struct MemoryTrackerSwitcher
     ~MemoryTrackerSwitcher();
 
 private:
-    MemoryTracker * prev_memory_tracker_parent = nullptr;
+    MemoryTracker * prev_memory_tracker = nullptr;
     Int64 prev_untracked_memory = 0;
     VariableContext prev_untracked_memory_blocker_level = VariableContext::Max;
 };

--- a/src/Common/MemoryTrackerUtils.cpp
+++ b/src/Common/MemoryTrackerUtils.cpp
@@ -6,11 +6,9 @@
 
 std::optional<UInt64> getMostStrictAvailableSystemMemory()
 {
-    MemoryTracker * query_memory_tracker;
-    if (query_memory_tracker = DB::CurrentThread::getMemoryTracker(); !query_memory_tracker)
-        return {};
     /// query-level memory tracker
-    if (query_memory_tracker = query_memory_tracker->getParent(); !query_memory_tracker)
+    MemoryTracker * query_memory_tracker = DB::CurrentThread::getMemoryTracker();
+    if (!query_memory_tracker)
         return {};
 
     Int64 available = std::numeric_limits<Int64>::max();
@@ -51,11 +49,7 @@ std::optional<UInt64> getCurrentQueryHardLimit()
 Int64 getCurrentQueryMemoryUsage()
 {
     /// Use query-level memory tracker
-    auto * thread_memory_tracker = DB::CurrentThread::getMemoryTracker();
-    if (!thread_memory_tracker || thread_memory_tracker->level != VariableContext::Thread)
-        return 0;
-
-    auto * query_process_memory_tracker = thread_memory_tracker->getParent();
+    auto * query_process_memory_tracker = DB::CurrentThread::getMemoryTracker();
     if (!query_process_memory_tracker || query_process_memory_tracker->level != VariableContext::Process)
         return 0;
 

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -113,7 +113,6 @@ ThreadStatus::ThreadStatus()
 
     last_rusage = std::make_unique<RUsageCounters>();
 
-    memory_tracker.setDescription("Thread");
     log = getLogger("ThreadStatus");
 
     current_thread = this;
@@ -239,7 +238,8 @@ void ThreadStatus::flushUntrackedMemory()
     MemoryTrackerBlockerInThread blocker(untracked_memory_blocker_level);
     Int64 current_untracked_memory = untracked_memory;
     untracked_memory = 0;
-    memory_tracker.adjustWithUntrackedMemory(current_untracked_memory);
+    memory_tracker->adjustWithUntrackedMemory(current_untracked_memory);
+    adjustThreadMemoryUsage(current_untracked_memory);
 }
 
 bool ThreadStatus::isQueryCanceled() const

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -174,7 +174,18 @@ public:
     /// Could be changed to point to another object to calculate performance counters for some narrow scope.
     ProfileEvents::Counters * current_performance_counters{&performance_counters};
 
-    MemoryTracker memory_tracker{VariableContext::Thread};
+    /// Tracker into which this thread's allocations are flushed: the Process-level group
+    /// tracker while attached to a thread group, total_memory_tracker otherwise.
+    /// There is no per-thread MemoryTracker anymore; MemoryTrackerSwitcher just repoints this.
+    MemoryTracker * memory_tracker = &total_memory_tracker;
+
+    /// Per-thread memory accounting (the "delta" of memory consumed by this thread).
+    /// Accumulated on every untracked_memory flush; used for query_thread_log and as a
+    /// thread-local memory-growth signal (e.g. AggregatingInOrderTransform). Allocations
+    /// passed to other threads may drive memory_tracker_amount negative.
+    Int64 memory_tracker_amount = 0;
+    Int64 memory_tracker_peak = 0;
+
     /// Small amount of untracked memory (per thread atomic-less counter)
     Int64 untracked_memory = 0;
     /// MemoryTrackerBlockerInThread state corresponding to untracked_memory.
@@ -296,6 +307,21 @@ public:
     void logToQueryViewsLog(const ViewRuntimeData & vinfo);
 
     void flushUntrackedMemory();
+
+    /// Current/peak memory consumed by this thread (delta of allocations minus deallocations).
+    Int64 getThreadMemoryUsage() const { return memory_tracker_amount + untracked_memory; }
+    Int64 getThreadPeakMemoryUsage() const { return memory_tracker_peak; }
+    void resetThreadMemoryTracker()
+    {
+        memory_tracker_amount = 0;
+        memory_tracker_peak = 0;
+    }
+    /// Move `delta` from the untracked buffer into the per-thread accumulator (called on every flush).
+    void adjustThreadMemoryUsage(Int64 delta)
+    {
+        memory_tracker_amount += delta;
+        memory_tracker_peak = std::max(memory_tracker_amount, memory_tracker_peak);
+    }
 
     void initGlobalProfiler(UInt64 global_profiler_real_time_period, UInt64 global_profiler_cpu_time_period);
 

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -317,8 +317,12 @@ public:
         memory_tracker_peak = 0;
     }
     /// Move `delta` from the untracked buffer into the per-thread accumulator (called on every flush).
+    /// Skip bytes accumulated under a MemoryTrackerBlockerInThread: the removed Thread-level tracker
+    /// was blocked alongside user/query, so such allocations never showed up in the per-thread delta.
     void adjustThreadMemoryUsage(Int64 delta)
     {
+        if (untracked_memory_blocker_level != VariableContext::Max)
+            return;
         memory_tracker_amount += delta;
         memory_tracker_peak = std::max(memory_tracker_amount, memory_tracker_peak);
     }

--- a/src/Common/tests/gtest_allocation_interceptors.cpp
+++ b/src/Common/tests/gtest_allocation_interceptors.cpp
@@ -31,16 +31,16 @@ void checkMemory(auto allocation_callback, auto deallocation_callback)
 {
     MainThreadStatus::getInstance();
     total_memory_tracker.resetCounters();
-    CurrentThread::get().memory_tracker.resetCounters();
+    CurrentThread::get().memory_tracker->resetCounters();
     CurrentThread::flushUntrackedMemory();
 
-    const auto before_thread = CurrentThread::get().memory_tracker.get();
+    const auto before_thread = CurrentThread::get().memory_tracker->get();
     const auto before_global = total_memory_tracker.get();
 
     auto ptr = allocation_callback();
     CurrentThread::flushUntrackedMemory();
 
-    const auto after_thread = CurrentThread::get().memory_tracker.get();
+    const auto after_thread = CurrentThread::get().memory_tracker->get();
     const auto after_global = total_memory_tracker.get();
 
     /// The allocation should be tracked (no under-counting) without double-accounting.
@@ -52,7 +52,7 @@ void checkMemory(auto allocation_callback, auto deallocation_callback)
     deallocation_callback(ptr);
     CurrentThread::flushUntrackedMemory();
 
-    const auto freed_thread = after_thread - CurrentThread::get().memory_tracker.get();
+    const auto freed_thread = after_thread - CurrentThread::get().memory_tracker->get();
     const auto freed_global = after_global - total_memory_tracker.get();
 
     /// The deallocation should be tracked without double-accounting.
@@ -90,10 +90,10 @@ TEST(AllocationInterceptors, FailedReallocPreservesOldAllocationAccounting)
 {
     MainThreadStatus::getInstance();
     total_memory_tracker.resetCounters();
-    CurrentThread::get().memory_tracker.resetCounters();
+    CurrentThread::get().memory_tracker->resetCounters();
     CurrentThread::flushUntrackedMemory();
 
-    const Int64 before_alloc_thread = CurrentThread::get().memory_tracker.get();
+    const Int64 before_alloc_thread = CurrentThread::get().memory_tracker->get();
     const Int64 before_alloc_global = total_memory_tracker.get();
 
     void * ptr = malloc(allocation_size);
@@ -102,7 +102,7 @@ TEST(AllocationInterceptors, FailedReallocPreservesOldAllocationAccounting)
     *reinterpret_cast<char *>(ptr) = 'a';
     CurrentThread::flushUntrackedMemory();
 
-    const auto after_alloc_thread = CurrentThread::get().memory_tracker.get();
+    const auto after_alloc_thread = CurrentThread::get().memory_tracker->get();
     const auto after_alloc_global = total_memory_tracker.get();
 
     ASSERT_GE(after_alloc_thread - before_alloc_thread, allocation_size);
@@ -115,7 +115,7 @@ TEST(AllocationInterceptors, FailedReallocPreservesOldAllocationAccounting)
     ASSERT_EQ(failed_realloc, nullptr);
     CurrentThread::flushUntrackedMemory();
 
-    const auto thread_after_realloc = CurrentThread::get().memory_tracker.get();
+    const auto thread_after_realloc = CurrentThread::get().memory_tracker->get();
     const auto global_after_realloc = total_memory_tracker.get();
 
     EXPECT_GE(static_cast<double>(thread_after_realloc), static_cast<double>(after_alloc_thread) * 0.95);
@@ -126,7 +126,7 @@ TEST(AllocationInterceptors, FailedReallocPreservesOldAllocationAccounting)
     free(ptr);
     CurrentThread::flushUntrackedMemory();
 
-    const auto freed_thread = after_alloc_thread - CurrentThread::get().memory_tracker.get();
+    const auto freed_thread = after_alloc_thread - CurrentThread::get().memory_tracker->get();
     const auto freed_global = after_alloc_global - total_memory_tracker.get();
 
     EXPECT_GE(static_cast<double>(freed_thread), static_cast<double>(allocation_size) * 0.95);
@@ -139,9 +139,9 @@ TEST(AllocationInterceptors, MallocZeroFreeDoesNotCauseNegativeDrift)
 {
     MainThreadStatus::getInstance();
     total_memory_tracker.resetCounters();
-    CurrentThread::get().memory_tracker.resetCounters();
+    CurrentThread::get().memory_tracker->resetCounters();
 
-    const Int64 before_thread = CurrentThread::get().memory_tracker.get();
+    const Int64 before_thread = CurrentThread::get().memory_tracker->get();
     const Int64 before_global = total_memory_tracker.get();
 
     constexpr size_t iterations = 100000;
@@ -151,7 +151,7 @@ TEST(AllocationInterceptors, MallocZeroFreeDoesNotCauseNegativeDrift)
         free(ptr);
     }
 
-    EXPECT_GE(CurrentThread::get().memory_tracker.get() - before_thread, -64 * 1024);
+    EXPECT_GE(CurrentThread::get().memory_tracker->get() - before_thread, -64 * 1024);
     EXPECT_GE(total_memory_tracker.get() - before_global, -64 * 1024);
 }
 

--- a/src/Compression/fuzzers/compressed_buffer_fuzzer.cpp
+++ b/src/Compression/fuzzers/compressed_buffer_fuzzer.cpp
@@ -29,8 +29,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
     {
         total_memory_tracker.resetCounters();
         total_memory_tracker.setHardLimit(1_GiB);
-        CurrentThread::get().memory_tracker.resetCounters();
-        CurrentThread::get().memory_tracker.setHardLimit(1_GiB);
+        CurrentThread::get().memory_tracker->resetCounters();
+        CurrentThread::get().memory_tracker->setHardLimit(1_GiB);
 
         DB::ReadBufferFromMemory from(data, size);
         DB::CompressedReadBuffer in{from};

--- a/src/Compression/fuzzers/delta_decompress_fuzzer.cpp
+++ b/src/Compression/fuzzers/delta_decompress_fuzzer.cpp
@@ -40,8 +40,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
     {
         total_memory_tracker.resetCounters();
         total_memory_tracker.setHardLimit(1_GiB);
-        CurrentThread::get().memory_tracker.resetCounters();
-        CurrentThread::get().memory_tracker.setHardLimit(1_GiB);
+        CurrentThread::get().memory_tracker->resetCounters();
+        CurrentThread::get().memory_tracker->setHardLimit(1_GiB);
 
         if (size < sizeof(AuxiliaryRandomData))
             return 0;

--- a/src/Compression/fuzzers/double_delta_decompress_fuzzer.cpp
+++ b/src/Compression/fuzzers/double_delta_decompress_fuzzer.cpp
@@ -44,8 +44,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
     {
         total_memory_tracker.resetCounters();
         total_memory_tracker.setHardLimit(1_GiB);
-        CurrentThread::get().memory_tracker.resetCounters();
-        CurrentThread::get().memory_tracker.setHardLimit(1_GiB);
+        CurrentThread::get().memory_tracker->resetCounters();
+        CurrentThread::get().memory_tracker->setHardLimit(1_GiB);
 
         if (size < sizeof(AuxiliaryRandomData))
             return 0;

--- a/src/Compression/fuzzers/encrypted_decompress_fuzzer.cpp
+++ b/src/Compression/fuzzers/encrypted_decompress_fuzzer.cpp
@@ -299,8 +299,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
     {
         total_memory_tracker.resetCounters();
         total_memory_tracker.setHardLimit(1_GiB);
-        CurrentThread::get().memory_tracker.resetCounters();
-        CurrentThread::get().memory_tracker.setHardLimit(1_GiB);
+        CurrentThread::get().memory_tracker->resetCounters();
+        CurrentThread::get().memory_tracker->setHardLimit(1_GiB);
 
         XMLGenerator generator(data, size);
 

--- a/src/Compression/fuzzers/gcd_decompress_fuzzer.cpp
+++ b/src/Compression/fuzzers/gcd_decompress_fuzzer.cpp
@@ -42,8 +42,8 @@ try
 {
     total_memory_tracker.resetCounters();
     total_memory_tracker.setHardLimit(1_GiB);
-    CurrentThread::get().memory_tracker.resetCounters();
-    CurrentThread::get().memory_tracker.setHardLimit(1_GiB);
+    CurrentThread::get().memory_tracker->resetCounters();
+    CurrentThread::get().memory_tracker->setHardLimit(1_GiB);
 
     if (size < sizeof(AuxiliaryRandomData))
         return 0;

--- a/src/Compression/fuzzers/lz4_decompress_fuzzer.cpp
+++ b/src/Compression/fuzzers/lz4_decompress_fuzzer.cpp
@@ -43,8 +43,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
     {
         total_memory_tracker.resetCounters();
         total_memory_tracker.setHardLimit(1_GiB);
-        CurrentThread::get().memory_tracker.resetCounters();
-        CurrentThread::get().memory_tracker.setHardLimit(1_GiB);
+        CurrentThread::get().memory_tracker->resetCounters();
+        CurrentThread::get().memory_tracker->setHardLimit(1_GiB);
 
         if (size < sizeof(AuxiliaryRandomData) + LZ4::ADDITIONAL_BYTES_AT_END_OF_BUFFER)
             return 0;

--- a/src/DataTypes/fuzzers/data_type_deserialization_fuzzer.cpp
+++ b/src/DataTypes/fuzzers/data_type_deserialization_fuzzer.cpp
@@ -147,8 +147,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
     {
         total_memory_tracker.resetCounters();
         total_memory_tracker.setHardLimit(1_GiB);
-        CurrentThread::get().memory_tracker.resetCounters();
-        CurrentThread::get().memory_tracker.setHardLimit(1_GiB);
+        CurrentThread::get().memory_tracker->resetCounters();
+        CurrentThread::get().memory_tracker->setHardLimit(1_GiB);
 
         /// The input format is as follows:
         /// - data type name on the first line,

--- a/src/Formats/fuzzers/format_fuzzer.cpp
+++ b/src/Formats/fuzzers/format_fuzzer.cpp
@@ -135,8 +135,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
     {
         total_memory_tracker.resetCounters();
         total_memory_tracker.setHardLimit(1_GiB);
-        CurrentThread::get().memory_tracker.resetCounters();
-        CurrentThread::get().memory_tracker.setHardLimit(1_GiB);
+        CurrentThread::get().memory_tracker->resetCounters();
+        CurrentThread::get().memory_tracker->setHardLimit(1_GiB);
 
         /// The input format is as follows:
         /// - format name on the first line,

--- a/src/Functions/tests/gtest_functions_stress.cpp
+++ b/src/Functions/tests/gtest_functions_stress.cpp
@@ -1302,8 +1302,10 @@ struct FunctionsStressTestThread
                 operation.step = Operation::Step::GeneratingArguments;
             }
 
-            thread_status->memory_tracker.resetCounters(); // reset the peak
-            thread_status->memory_tracker.setHardLimit(MEMORY_LIMIT_BYTES_PER_THREAD);
+            /// One thread group per worker thread, so the Process tracker doubles as the per-thread one.
+            thread_status->memory_tracker->resetCounters(); // reset the peak
+            thread_status->memory_tracker->setHardLimit(MEMORY_LIMIT_BYTES_PER_THREAD);
+            thread_status->resetThreadMemoryTracker();
             thread_status->untracked_memory = 0;
 
             randomizeSettings();
@@ -1433,8 +1435,8 @@ struct FunctionsStressTestThread
             }
             stats.max(S_TIME_MAX_NS, ns);
 
-            Int64 memory_balance = thread_status->memory_tracker.get() + thread_status->untracked_memory;
-            Int64 memory_peak = thread_status->memory_tracker.getPeak();
+            Int64 memory_balance = thread_status->getThreadMemoryUsage();
+            Int64 memory_peak = thread_status->getThreadPeakMemoryUsage();
 
             stats.add(S_MEMORY_BALANCE, memory_balance);
             stats.max(S_MEMORY_PEAK, memory_peak);

--- a/src/Interpreters/HashJoin/HashJoin.cpp
+++ b/src/Interpreters/HashJoin/HashJoin.cpp
@@ -78,10 +78,9 @@ namespace
 
 Int64 getCurrentQueryMemoryUsage()
 {
-    /// Use query-level memory tracker
-    if (auto * memory_tracker_child = CurrentThread::getMemoryTracker())
-        if (auto * memory_tracker = memory_tracker_child->getParent())
-            return memory_tracker->get();
+    /// Use query-level memory tracker (CurrentThread::getMemoryTracker() is the Process-level tracker)
+    if (auto * memory_tracker = CurrentThread::getMemoryTracker(); memory_tracker && memory_tracker->level == VariableContext::Process)
+        return memory_tracker->get();
     return 0;
 }
 

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -325,7 +325,7 @@ void ThreadStatus::applyQuerySettings()
     /// (we cannot do this for all threads, even though it is no-op, since it is a data-race)
     if (thread_group->master_thread_id == thread_id)
         configureMemoryTrackerFromSettings(query_context_ptr->hasTraceCollector(), thread_group->memory_tracker, settings);
-    auto sample_config = memory_tracker.getResolvedSampleConfig();
+    auto sample_config = memory_tracker->getResolvedSampleConfig();
     sample_probability = sample_config.probability;
     sample_min_allocation_size = sample_config.min_allocation_size;
     sample_max_allocation_size = sample_config.max_allocation_size;
@@ -351,7 +351,12 @@ void ThreadStatus::attachToGroupImpl(const ThreadGroupPtr & thread_group_)
     thread_group->linkThread(thread_id);
 
     performance_counters.setParent(&thread_group->performance_counters);
-    memory_tracker.setParent(&thread_group->memory_tracker);
+
+    /// Untracked memory shouldn't be accounted to a query or a user if it was allocated before the
+    /// thread was attached to the group, because it will be (🤞) freed outside of these scopes.
+    /// Flush it to the previous tracker before repointing.
+    flushUntrackedMemory();
+    memory_tracker = &thread_group->memory_tracker;
 
     query_context = thread_group->query_context;
     global_context = thread_group->global_context;
@@ -377,7 +382,7 @@ void ThreadStatus::detachFromGroup()
 
     LockMemoryExceptionInThread lock_memory_tracker(VariableContext::Global);
 
-    /// flush untracked memory before resetting memory_tracker parent
+    /// flush untracked memory before repointing memory_tracker to the total tracker
     flushUntrackedMemory();
 
     finalizeQueryProfiler();
@@ -385,9 +390,9 @@ void ThreadStatus::detachFromGroup()
 
     performance_counters.setParent(&ProfileEvents::global_counters);
 
-    memory_tracker.reset();
-    /// Extract MemoryTracker out from query and user context
-    memory_tracker.setParent(&total_memory_tracker);
+    resetThreadMemoryTracker();
+    /// Detach from the query/user context: account this thread's allocations to the total again.
+    memory_tracker = &total_memory_tracker;
 
     thread_group->unlinkThread();
 
@@ -491,8 +496,7 @@ void ThreadStatus::initPerformanceCounters()
     /// Clear stats from previous query if a new query is started
     /// TODO: make separate query_thread_performance_counters and thread_performance_counters
     performance_counters.resetCounters();
-    memory_tracker.resetCounters();
-    memory_tracker.setDescription("Thread");
+    resetThreadMemoryTracker();
 
     // query_start_time.nanoseconds cannot be used here since RUsageCounters expect CLOCK_MONOTONIC
     *last_rusage = RUsageCounters::current();
@@ -699,8 +703,8 @@ void ThreadStatus::logToQueryThreadLog(QueryThreadLog & thread_log, const String
 
     elem.written_rows = progress_out.written_rows.load(std::memory_order_relaxed);
     elem.written_bytes = progress_out.written_bytes.load(std::memory_order_relaxed);
-    elem.memory_usage = memory_tracker.get();
-    elem.peak_memory_usage = memory_tracker.getPeak();
+    elem.memory_usage = getThreadMemoryUsage();
+    elem.peak_memory_usage = getThreadPeakMemoryUsage();
 
     elem.thread_name = getThreadName();
     elem.thread_id = thread_id;

--- a/src/Interpreters/fuzzers/execute_query_fuzzer.cpp
+++ b/src/Interpreters/fuzzers/execute_query_fuzzer.cpp
@@ -165,8 +165,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size)
     {
         total_memory_tracker.resetCounters();
         total_memory_tracker.setHardLimit(1_GiB);
-        CurrentThread::get().memory_tracker.resetCounters();
-        CurrentThread::get().memory_tracker.setHardLimit(1_GiB);
+        CurrentThread::get().memory_tracker->resetCounters();
+        CurrentThread::get().memory_tracker->setHardLimit(1_GiB);
 
         std::string input = std::string(reinterpret_cast<const char*>(data), size);
 

--- a/src/Interpreters/tests/gtest_mark_ranges_memory_tracking.cpp
+++ b/src/Interpreters/tests/gtest_mark_ranges_memory_tracking.cpp
@@ -15,13 +15,13 @@ TEST(MarkRanges, MemoryTracking)
 {
     MainThreadStatus::getInstance();
     total_memory_tracker.resetCounters();
-    CurrentThread::get().memory_tracker.resetCounters();
+    CurrentThread::get().memory_tracker->resetCounters();
 
     total_memory_tracker.setHardLimit(1_KiB);
-    CurrentThread::get().memory_tracker.setHardLimit(1_KiB);
+    CurrentThread::get().memory_tracker->setHardLimit(1_KiB);
 
     SCOPE_EXIT_SAFE(total_memory_tracker.setHardLimit(0));
-    SCOPE_EXIT_SAFE(CurrentThread::get().memory_tracker.setHardLimit(0));
+    SCOPE_EXIT_SAFE(CurrentThread::get().memory_tracker->setHardLimit(0));
 
     constexpr size_t num_ranges = 1'000'000;
     std::uniform_int_distribution<size_t> dist(0, 1'000'000);

--- a/src/Processors/Transforms/AggregatingInOrderTransform.cpp
+++ b/src/Processors/Transforms/AggregatingInOrderTransform.cpp
@@ -68,10 +68,8 @@ AggregatingInOrderTransform::~AggregatingInOrderTransform() = default;
 
 static Int64 getCurrentMemoryUsage()
 {
-    Int64 current_memory_usage = 0;
-    if (auto * memory_tracker = CurrentThread::getMemoryTracker())
-        current_memory_usage = memory_tracker->get();
-    return current_memory_usage;
+    /// Per-thread memory growth signal (this transform runs single-threaded over its chunk).
+    return CurrentThread::getThreadMemoryUsage();
 }
 
 void AggregatingInOrderTransform::consume(Chunk chunk)


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
TBD