### PR TITLE
Fix -Wlifetime-safety-use-after-scope-moved in ProfileEvents under clang 23

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -1574,12 +1574,11 @@ void Counters::setTraceProfileEvent(Event event)
     {
         /// It is very unlikely that it will be allocated twice, since we set it at the beginning of the query
         auto fresh = std::make_unique<std::atomic_bool[]>(num_counters);
-        auto * fresh_raw = fresh.get();
         std::atomic_bool * expected = nullptr;
-        if (should_trace_array.compare_exchange_strong(expected, fresh_raw, std::memory_order_release, std::memory_order_relaxed))
+        if (should_trace_array.compare_exchange_strong(expected, fresh.get(), std::memory_order_release, std::memory_order_relaxed))
         {
             should_trace_holder = std::move(fresh);
-            trace_array = fresh_raw;
+            trace_array = should_trace_holder.get();
         }
         else
             trace_array = expected;


### PR DESCRIPTION
clang 23:

    /home/ubuntu/ch/ClickHouse/src/Common/ProfileEvents.cpp:1577:28: error: object whose reference is captured may not live long enough. This could be false positive as the storage may have been moved later [-Werror,-Wlifetime-safety-use-after-scope-moved]
     1577 |         auto * fresh_raw = fresh.get();
          |                            ^~~~~
    /home/ubuntu/ch/ClickHouse/src/Common/ProfileEvents.cpp:1581:35: note: potentially moved here
     1581 |             should_trace_holder = std::move(fresh);
          |                                   ^~~~~~~~~~~~~~~~
    /home/ubuntu/ch/ClickHouse/src/Common/ProfileEvents.cpp:1586:5: note: destroyed here
     1586 |     }
          |     ^
    /home/ubuntu/ch/ClickHouse/src/Common/ProfileEvents.cpp:1587:5: note: later used here
     1587 |     trace_array[event].store(true, std::memory_order_relaxed);
          |     ^~~~~~~~~~~
    1 error generated.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
