### PR TITLE
Fix clang 23 -Wlifetime-safety errors

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -1574,12 +1574,11 @@ void Counters::setTraceProfileEvent(Event event)
     {
         /// It is very unlikely that it will be allocated twice, since we set it at the beginning of the query
         auto fresh = std::make_unique<std::atomic_bool[]>(num_counters);
-        auto * fresh_raw = fresh.get();
         std::atomic_bool * expected = nullptr;
-        if (should_trace_array.compare_exchange_strong(expected, fresh_raw, std::memory_order_release, std::memory_order_relaxed))
+        if (should_trace_array.compare_exchange_strong(expected, fresh.get(), std::memory_order_release, std::memory_order_relaxed))
         {
             should_trace_holder = std::move(fresh);
-            trace_array = fresh_raw;
+            trace_array = should_trace_holder.get();
         }
         else
             trace_array = expected;


### PR DESCRIPTION
Fix:
- -Wlifetime-safety-dangling-global-moved in `ReplicasReconnector`,
- -Wlifetime-safety-dangling-field-moved in `MergeTreeReaderStream` and `TTLTransform`
- -Wlifetime-safety-return-stack-addr-moved in `BackupsWorker` (move first, alias later)
- -Wunused-but-set-variable for `inside_main` in keeper.
- -Wlifetime-safety-use-after-scope-moved in ProfileEvents

Disable -Wlifetime-safety-invalidation: too many false positives, it treats
mutation of a container captured by reference in a lambda as invalidating the
reference to the container variable itself.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)