### PR TITLE
Fix clang 23 -Wlifetime-safety errors

### DIFF
--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -49,6 +49,11 @@ no_warning(missing-noreturn) # too aggressive with no clear benefit, see https:/
 if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 23)
     no_warning(lifetime-safety-intra-tu-suggestions)
     no_warning(lifetime-safety-cross-tu-suggestions)
+    # Too many false positives: it treats mutation of a container captured by
+    # reference in a lambda (e.g. `push_back`, `clear`, `+=`) as invalidating the
+    # captured reference to the container variable itself, while in reality only
+    # references to the container's elements would be invalidated.
+    no_warning(lifetime-safety-invalidation)
 endif ()
 if (ARCH_E2K)
     # disable "use of GNU statement expression extension from macro expansion" warning

--- a/programs/keeper/keeper_main.cpp
+++ b/programs/keeper/keeper_main.cpp
@@ -170,7 +170,7 @@ static __attribute__((constructor(202))) void init_ssl()
 ///
 /// extern bool inside_main;
 /// class C { C() { assert(inside_main); } };
-static bool inside_main = false;
+bool inside_main = false;
 
 int main(int argc_, char ** argv_)
 {

--- a/src/Backups/BackupsWorker.cpp
+++ b/src/Backups/BackupsWorker.cpp
@@ -285,9 +285,8 @@ public:
         size_t max_free_threads = 0;
         size_t queue_size = use_queue ? 0 : max_threads;
         auto thread_pool = std::make_unique<ThreadPool>(metric_threads, metric_active_threads, metric_scheduled_threads, max_threads, max_free_threads, queue_size);
-        auto * thread_pool_ptr = thread_pool.get();
-        thread_pools.emplace(thread_pool_id, std::move(thread_pool));
-        return *thread_pool_ptr;
+        it = thread_pools.emplace(thread_pool_id, std::move(thread_pool)).first;
+        return *it->second;
     }
 
     /// Waits for all threads to finish.

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -1599,12 +1599,11 @@ void Counters::setTraceProfileEvent(Event event)
     {
         /// It is very unlikely that it will be allocated twice, since we set it at the beginning of the query
         auto fresh = std::make_unique<std::atomic_bool[]>(num_counters);
-        auto * fresh_raw = fresh.get();
         std::atomic_bool * expected = nullptr;
-        if (should_trace_array.compare_exchange_strong(expected, fresh_raw, std::memory_order_release, std::memory_order_relaxed))
+        if (should_trace_array.compare_exchange_strong(expected, fresh.get(), std::memory_order_release, std::memory_order_relaxed))
         {
             should_trace_holder = std::move(fresh);
-            trace_array = fresh_raw;
+            trace_array = should_trace_holder.get();
         }
         else
             trace_array = expected;

--- a/src/Common/ReplicasReconnector.cpp
+++ b/src/Common/ReplicasReconnector.cpp
@@ -23,6 +23,7 @@ ReplicasReconnector::ReplicasReconnector(ContextPtr context)
     : task_handle(context->getSchedulePool().createTask(StorageID::createEmpty(), "ReplicasReconnector", [this]{ run(); }))
     , log(getLogger("ReplicasReconnector"))
 {
+    instance_ptr = this;
 }
 
 ReplicasReconnector::~ReplicasReconnector()
@@ -37,9 +38,7 @@ std::unique_ptr<ReplicasReconnector> ReplicasReconnector::init(ContextPtr contex
     if (instance_ptr)
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Replicas reconnector is already initialized.");
 
-    std::unique_ptr<ReplicasReconnector> ret(new ReplicasReconnector(context));
-    instance_ptr = ret.get();
-    return ret;
+    return std::unique_ptr<ReplicasReconnector>(new ReplicasReconnector(context));
 }
 
 ReplicasReconnector & ReplicasReconnector::instance()

--- a/src/Processors/Transforms/TTLTransform.cpp
+++ b/src/Processors/Transforms/TTLTransform.cpp
@@ -76,8 +76,8 @@ TTLTransform::TTLTransform(
         if (algorithm->isMaxTTLExpired() && !rows_ttl.where_expression_ast)
             all_data_dropped = true;
 
-        delete_algorithm = algorithm.get();
         algorithms.emplace_back(std::move(algorithm));
+        delete_algorithm = static_cast<const TTLDeleteAlgorithm *>(algorithms.back().get());
     }
 
     for (const auto & where_ttl : metadata_snapshot_->getRowsWhereTTLs())

--- a/src/Storages/MergeTree/MergeTreeReaderStream.cpp
+++ b/src/Storages/MergeTree/MergeTreeReaderStream.cpp
@@ -98,9 +98,9 @@ void MergeTreeReaderStream::init()
         if (profile_callback)
             buffer->setProfileCallback(profile_callback, clock_type);
 
-        data_buffer = buffer.get();
-        plain_file_buffer = buffer.get();
         read_buffer_holder = std::move(buffer);
+        data_buffer = read_buffer_holder.get();
+        plain_file_buffer = static_cast<ReadBufferFromFileBase *>(read_buffer_holder.get());
     }
     else if (uncompressed_cache)
     {
@@ -128,9 +128,9 @@ void MergeTreeReaderStream::init()
         if (!settings.checksum_on_read)
             buffer->disableChecksumming();
 
-        data_buffer = buffer.get();
-        compressed_data_buffer = buffer.get();
         read_buffer_holder = std::move(buffer);
+        data_buffer = read_buffer_holder.get();
+        compressed_data_buffer = static_cast<CachedCompressedReadBuffer *>(read_buffer_holder.get());
     }
     else
     {
@@ -143,9 +143,9 @@ void MergeTreeReaderStream::init()
         if (!settings.checksum_on_read)
             buffer->disableChecksumming();
 
-        data_buffer = buffer.get();
-        compressed_data_buffer = buffer.get();
         read_buffer_holder = std::move(buffer);
+        data_buffer = read_buffer_holder.get();
+        compressed_data_buffer = static_cast<CompressedReadBufferFromFile *>(read_buffer_holder.get());
     }
 
     initialized = true;


### PR DESCRIPTION
Fix:
- -Wlifetime-safety-dangling-global-moved in `ReplicasReconnector`,
- -Wlifetime-safety-dangling-field-moved in `MergeTreeReaderStream` and `TTLTransform`
- -Wlifetime-safety-return-stack-addr-moved in `BackupsWorker` (move first, alias later)
- -Wunused-but-set-variable for `inside_main` in keeper.
- -Wlifetime-safety-use-after-scope-moved in ProfileEvents

Disable -Wlifetime-safety-invalidation: too many false positives, it treats mutation of a container captured by reference in a lambda as invalidating the reference to the container variable itself.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.581`
<!-- ch-version-info:end -->