### PR TITLE
 Chore : In ClickHouseDisk read function , the line for getting info uses while loop for a single row, changed it to if statement for better clarity

### DIFF
--- a/rust/chcache/src/disks/clickhouse.rs
+++ b/rust/chcache/src/disks/clickhouse.rs
@@ -70,7 +70,7 @@ impl ClickHouseDisk {
             .fetch::<CacheLine>()
             .unwrap();
 
-        while let Some(row) = cursor.next().await? {
+        if let Some(row) = cursor.next().await? {
             return Ok(row.blob);
         }
 


### PR DESCRIPTION

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


In the current rust file ClickHouse/rust/chcache/src/disks/clickhouse.rs :
<img width="1442" height="493" alt="image" src="https://github.com/user-attachments/assets/a9786b05-06e8-442e-9d48-9f6d7c9c569e" />

According to query it only return a single row and even the lsp showing error the loop return after the first iteration. So for this it's better to use if condition rather than while since ,we only have one iteration / step for this.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1114`
<!-- ch-version-info:end -->