### PR TITLE
Fix `clickhouse local --query_id` handling

### DIFF
--- a/programs/local/LocalServer.cpp
+++ b/programs/local/LocalServer.cpp
@@ -744,6 +744,8 @@ try
     /// After this point the global context must be stayed almost unchanged till shutdown,
     /// and all necessary changes must be made to the client context instead.
     initClientContext(Context::createCopy(global_context));
+    if (!query_id.empty())
+        client_context->setCurrentQueryId(query_id);
     /// Note, QueryScope will be initialized in the LocalConnection
 
     if (is_interactive)
@@ -820,6 +822,8 @@ void LocalServer::processConfig()
     {
         echo_queries = getClientConfiguration().hasOption("echo") || getClientConfiguration().hasOption("verbose");
         ignore_error = getClientConfiguration().getBool("ignore-error", false);
+
+        query_id = getClientConfiguration().getString("query_id", "");
     }
 
     print_stack_trace = getClientConfiguration().getBool("stacktrace", false);

--- a/tests/queries/0_stateless/04301_clickhouse_local_query_id.reference
+++ b/tests/queries/0_stateless/04301_clickhouse_local_query_id.reference
@@ -1,0 +1,1 @@
+clickhouse_local_custom_query_id

--- a/tests/queries/0_stateless/04301_clickhouse_local_query_id.sh
+++ b/tests/queries/0_stateless/04301_clickhouse_local_query_id.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+${CLICKHOUSE_LOCAL} --query_id='clickhouse_local_custom_query_id' --query "SELECT queryID() FORMAT TSV"


### PR DESCRIPTION
This PR closes https://github.com/ClickHouse/ClickHouse/issues/106201

### Changelog category:
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry:
- Fix clickhouse local's `--query_id` parameter to allow it to specify custom query id

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.292`
<!-- ch-version-info:end -->