### PR TITLE
Reduce arrayDotProduct unroll from 128/sizeof to a fixed 16

### DIFF
--- a/src/Functions/array/arrayDotProduct.cpp
+++ b/src/Functions/array/arrayDotProduct.cpp
@@ -47,8 +47,8 @@ MULTITARGET_FUNCTION_X86_V4_V3(
 
         /// Reduce partial sums
         ResultType sum = 0;
-        for (size_t s = 0; s < unroll_count; ++s)
-            sum += partial_sums[s];
+        for (auto & partial_sum : partial_sums)
+            sum += partial_sum;
 
         /// Tail: process remaining elements that don't fill a full unroll block
         for (; i < count; ++i)

--- a/src/Functions/array/arrayDotProduct.cpp
+++ b/src/Functions/array/arrayDotProduct.cpp
@@ -30,9 +30,11 @@ MULTITARGET_FUNCTION_X86_V4_V3(
     MULTITARGET_FUNCTION_BODY((const ResultType * __restrict data_x, const ResultType * __restrict data_y, size_t count) {
         /// Manual unrolling with independent accumulators to break FP dependency chains.
         /// With FMA latency ~4 cycles and throughput 1/cycle, we need >= 4 independent
-        /// chains to saturate the pipeline. We use more (32 for Float32, 16 for Float64)
-        /// so the compiler can map them to multiple SIMD registers across all targets.
-        constexpr size_t unroll_count = 128 / sizeof(ResultType);
+        /// chains to saturate the pipeline. 16 accumulators is enough to do that while
+        /// keeping the per-row reduction and scalar remainder small: a wider unroll
+        /// (e.g. 128/sizeof = 32 for Float32) only pays off for very long arrays and
+        /// noticeably regresses the short (~150-element) arrays typical of vector search.
+        constexpr size_t unroll_count = 16;
         ResultType partial_sums[unroll_count]{};
 
         size_t i = 0;


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
The performance of `dotProduct` improved in some cases.

---

<img width="627" height="69" alt="Screenshot 2026-06-01 at 10 17 04" src="https://github.com/user-attachments/assets/773e02b1-d46d-4daa-b5ee-74a901a45015" />

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.350`
<!-- ch-version-info:end -->