### PR TITLE
Vectorize `arrayNorm` with runtime CPU dispatch

### DIFF
--- a/src/Functions/array/CMakeLists.txt
+++ b/src/Functions/array/CMakeLists.txt
@@ -39,9 +39,12 @@ endif()
 # generating `vfmadd*` from `a*b + c` patterns in their hot inner loops. The per-file `COMPILE_FLAGS` are
 # appended after `CMAKE_CXX_FLAGS`, so this override wins over the global `-ffp-contract=off`.
 set_source_files_properties(arrayDotProduct.cpp PROPERTIES COMPILE_FLAGS "-ffp-contract=fast")
-# Append so the conditional `-march=x86-64-v2` set above for arrayDistance.cpp is preserved
+# Append so the conditional `-march=x86-64-v2` set above for arrayDistance.cpp / arrayNorm.cpp is preserved
 # (`set_source_files_properties` has no APPEND form; use `set_property ... APPEND_STRING`).
 set_property(SOURCE arrayDistance.cpp APPEND_STRING PROPERTY COMPILE_FLAGS " -ffp-contract=fast")
+# `arrayNorm.cpp` carries an `x86_64_v4` (AVX-512) specialisation that fuses `a*b + c` into FMA on the
+# `L2`/`L2Squared` paths; re-enable contraction here too (the default reduction stays at `v2`/128-bit).
+set_property(SOURCE arrayNorm.cpp APPEND_STRING PROPERTY COMPILE_FLAGS " -ffp-contract=fast")
 
 if (OMIT_HEAVY_DEBUG_SYMBOLS)
     target_compile_options(clickhouse_functions_array PRIVATE "-g1")

--- a/src/Functions/array/arrayNorm.cpp
+++ b/src/Functions/array/arrayNorm.cpp
@@ -6,6 +6,7 @@
 #include <DataTypes/IDataType.h>
 #include <Functions/FunctionFactory.h>
 #include <Functions/FunctionHelpers.h>
+#include <Common/TargetSpecific.h>
 
 namespace DB
 {
@@ -134,6 +135,35 @@ struct LinfNorm
 };
 
 
+/// Auto-vectorized single-array norm reduction kernel, modeled after the `arrayDotProduct` kernel.
+/// Manual unrolling with independent accumulators breaks the FP dependency chain so the compiler can
+/// keep several SIMD registers in flight and (for `L2`/`L2Squared`) fuse `a*b + c` into FMA. The macro
+/// emits an `x86_64_v4` (AVX-512) variant and a default (SSE2/NEON) variant; the caller dispatches on the
+/// running CPU. Returns the pre-`finalize` reduction (e.g. the sum of squares for `L2`).
+MULTITARGET_FUNCTION_X86_V4(
+    MULTITARGET_FUNCTION_HEADER(template <typename Kernel, typename ResultType> static ResultType NO_SANITIZE_UNDEFINED NO_INLINE),
+    normImpl,
+    MULTITARGET_FUNCTION_BODY((const ResultType * __restrict data, size_t count, const typename Kernel::ConstParams & params) {
+        constexpr size_t unroll_count = 16;
+        ResultType partial_results[unroll_count]{};
+
+        size_t i = 0;
+        const size_t unrolled_end = count / unroll_count * unroll_count;
+        for (; i < unrolled_end; i += unroll_count)
+            for (size_t s = 0; s < unroll_count; ++s)
+                partial_results[s] = Kernel::template accumulate<ResultType>(partial_results[s], data[i + s], params);
+
+        ResultType result = 0;
+        for (size_t s = 0; s < unroll_count; ++s)
+            result = Kernel::template combine<ResultType>(result, partial_results[s], params);
+
+        for (; i < count; ++i)
+            result = Kernel::template accumulate<ResultType>(result, data[i], params);
+
+        return result;
+    }))
+
+
 template <class Kernel>
 class FunctionArrayNorm final : public IFunction
 {
@@ -245,29 +275,45 @@ private:
         const typename Kernel::ConstParams kernel_params = initConstParams(arguments);
 
         ColumnArray::Offset prev = 0;
-        size_t row = 0;
-        for (auto off : offsets)
+        for (size_t row = 0; row < input_rows_count; ++row)
         {
-            /// Process chunks in vectorized manner
-            static constexpr size_t VEC_SIZE = 4;
-            ResultType results[VEC_SIZE] = {0};
-            for (; prev + VEC_SIZE < off; prev += VEC_SIZE)
-            {
-                for (size_t s = 0; s < VEC_SIZE; ++s)
-                    results[s] = Kernel::template accumulate<ResultType>(results[s], static_cast<ResultType>(data[prev + s]), kernel_params);
-            }
+            const auto off = offsets[row];
+            const size_t array_size = off - prev;
 
-            ResultType result = 0;
-            for (const auto & other_state : results)
-                result = Kernel::template combine<ResultType>(result, other_state, kernel_params);
-
-            /// Process the tail
-            for (; prev < off; ++prev)
+            if constexpr (std::is_same_v<ResultType, ArgumentType>
+                && (std::is_same_v<ResultType, Float32> || std::is_same_v<ResultType, Float64>))
             {
-                result = Kernel::template accumulate<ResultType>(result, static_cast<ResultType>(data[prev]), kernel_params);
+                /// SIMD-optimized path for same-type floating point: runtime-dispatched to AVX-512 when
+                /// available, else the baseline variant. This is where `L2`/`L2Squared` pick up FMA.
+                ResultType result;
+#if USE_MULTITARGET_CODE
+                if (isArchSupported(TargetArch::x86_64_v4))
+                    result = normImpl_x86_64_v4<Kernel, ResultType>(data.data() + prev, array_size, kernel_params);
+                else
+#endif
+                    result = normImpl<Kernel, ResultType>(data.data() + prev, array_size, kernel_params);
+                result_data[row] = Kernel::finalize(result, kernel_params);
             }
-            result_data[row] = Kernel::finalize(result, kernel_params);
-            row++;
+            else
+            {
+                /// Scalar path for widened types (integers cast up to Float64, BFloat16 cast to Float32).
+                static constexpr size_t VEC_SIZE = 4;
+                ResultType results[VEC_SIZE] = {0};
+                size_t i = 0;
+                for (; i + VEC_SIZE < array_size; i += VEC_SIZE)
+                    for (size_t s = 0; s < VEC_SIZE; ++s)
+                        results[s] = Kernel::template accumulate<ResultType>(results[s], static_cast<ResultType>(data[prev + i + s]), kernel_params);
+
+                ResultType result = 0;
+                for (const auto & other_state : results)
+                    result = Kernel::template combine<ResultType>(result, other_state, kernel_params);
+
+                for (; i < array_size; ++i)
+                    result = Kernel::template accumulate<ResultType>(result, static_cast<ResultType>(data[prev + i]), kernel_params);
+
+                result_data[row] = Kernel::finalize(result, kernel_params);
+            }
+            prev = off;
         }
         return result_col;
     }

--- a/src/Functions/array/arrayNorm.cpp
+++ b/src/Functions/array/arrayNorm.cpp
@@ -154,8 +154,8 @@ MULTITARGET_FUNCTION_X86_V4(
                 partial_results[s] = Kernel::template accumulate<ResultType>(partial_results[s], data[i + s], params);
 
         ResultType result = 0;
-        for (size_t s = 0; s < unroll_count; ++s)
-            result = Kernel::template combine<ResultType>(result, partial_results[s], params);
+        for (auto & partial_result : partial_results)
+            result = Kernel::template combine<ResultType>(result, partial_result, params);
 
         for (; i < count; ++i)
             result = Kernel::template accumulate<ResultType>(result, data[i], params);

--- a/src/Functions/array/arrayNorm.cpp
+++ b/src/Functions/array/arrayNorm.cpp
@@ -135,32 +135,47 @@ struct LinfNorm
 };
 
 
-/// Auto-vectorized single-array norm reduction kernel, modeled after the `arrayDotProduct` kernel.
-/// Manual unrolling with independent accumulators breaks the FP dependency chain so the compiler can
-/// keep several SIMD registers in flight and (for `L2`/`L2Squared`) fuse `a*b + c` into FMA. The macro
-/// emits an `x86_64_v4` (AVX-512) variant and a default (SSE2/NEON) variant; the caller dispatches on the
-/// running CPU. Returns the pre-`finalize` reduction (e.g. the sum of squares for `L2`).
+/// Auto-vectorized norm reduction kernel, modeled after the `arrayDotProduct` kernel. Manual unrolling
+/// with independent accumulators breaks the FP dependency chain so the compiler can keep several SIMD
+/// registers in flight and (for `L2`/`L2Squared`) fuse `a*b + c` into FMA.
+///
+/// The whole row loop lives inside this single multitarget call: an `x86_64_v4` (AVX-512) specialisation
+/// cannot be inlined into the `v2`-baseline caller, so a per-row call would impose a hard boundary every
+/// ~150 elements that interrupts the hardware prefetcher's stream. Batching all rows into one call keeps
+/// the load stream continuous across row boundaries, which matters for the bandwidth-bound `Float64` paths.
 MULTITARGET_FUNCTION_X86_V4(
-    MULTITARGET_FUNCTION_HEADER(template <typename Kernel, typename ResultType> static ResultType NO_SANITIZE_UNDEFINED NO_INLINE),
-    normImpl,
-    MULTITARGET_FUNCTION_BODY((const ResultType * __restrict data, size_t count, const typename Kernel::ConstParams & params) {
+    MULTITARGET_FUNCTION_HEADER(template <typename Kernel, typename ResultType> static void NO_SANITIZE_UNDEFINED NO_INLINE),
+    normBatchImpl,
+    MULTITARGET_FUNCTION_BODY((
+        const ResultType * __restrict data,
+        const ColumnArray::Offset * __restrict offsets,
+        ResultType * __restrict result_data,
+        size_t input_rows_count,
+        const typename Kernel::ConstParams & params) {
         constexpr size_t unroll_count = 16;
-        ResultType partial_results[unroll_count]{};
+        ColumnArray::Offset prev = 0;
+        for (size_t row = 0; row < input_rows_count; ++row)
+        {
+            const size_t count = offsets[row] - prev;
+            const ResultType * __restrict row_data = data + prev;
 
-        size_t i = 0;
-        const size_t unrolled_end = count / unroll_count * unroll_count;
-        for (; i < unrolled_end; i += unroll_count)
+            ResultType partial_results[unroll_count]{};
+            size_t i = 0;
+            const size_t unrolled_end = count / unroll_count * unroll_count;
+            for (; i < unrolled_end; i += unroll_count)
+                for (size_t s = 0; s < unroll_count; ++s)
+                    partial_results[s] = Kernel::template accumulate<ResultType>(partial_results[s], row_data[i + s], params);
+
+            ResultType result = 0;
             for (size_t s = 0; s < unroll_count; ++s)
-                partial_results[s] = Kernel::template accumulate<ResultType>(partial_results[s], data[i + s], params);
+                result = Kernel::template combine<ResultType>(result, partial_results[s], params);
 
-        ResultType result = 0;
-        for (auto & partial_result : partial_results)
-            result = Kernel::template combine<ResultType>(result, partial_result, params);
+            for (; i < count; ++i)
+                result = Kernel::template accumulate<ResultType>(result, row_data[i], params);
 
-        for (; i < count; ++i)
-            result = Kernel::template accumulate<ResultType>(result, data[i], params);
-
-        return result;
+            result_data[row] = Kernel::finalize(result, params);
+            prev = offsets[row];
+        }
     }))
 
 
@@ -274,29 +289,28 @@ private:
 
         const typename Kernel::ConstParams kernel_params = initConstParams(arguments);
 
-        ColumnArray::Offset prev = 0;
-        for (size_t row = 0; row < input_rows_count; ++row)
+        if constexpr (std::is_same_v<ResultType, ArgumentType>
+            && (std::is_same_v<ResultType, Float32> || std::is_same_v<ResultType, Float64>))
         {
-            const auto off = offsets[row];
-            const size_t array_size = off - prev;
-
-            if constexpr (std::is_same_v<ResultType, ArgumentType>
-                && (std::is_same_v<ResultType, Float32> || std::is_same_v<ResultType, Float64>))
-            {
-                /// SIMD-optimized path for same-type floating point: runtime-dispatched to AVX-512 when
-                /// available, else the baseline variant. This is where `L2`/`L2Squared` pick up FMA.
-                ResultType result;
+            /// SIMD-optimized path for same-type floating point: the entire row loop is handled in a single
+            /// multitarget call, runtime-dispatched to AVX-512 when available, else the baseline variant.
+            /// This keeps the load stream continuous across rows (see `normBatchImpl`).
 #if USE_MULTITARGET_CODE
-                if (isArchSupported(TargetArch::x86_64_v4))
-                    result = normImpl_x86_64_v4<Kernel, ResultType>(data.data() + prev, array_size, kernel_params);
-                else
-#endif
-                    result = normImpl<Kernel, ResultType>(data.data() + prev, array_size, kernel_params);
-                result_data[row] = Kernel::finalize(result, kernel_params);
-            }
+            if (isArchSupported(TargetArch::x86_64_v4))
+                normBatchImpl_x86_64_v4<Kernel, ResultType>(data.data(), offsets.data(), result_data.data(), input_rows_count, kernel_params);
             else
+#endif
+                normBatchImpl<Kernel, ResultType>(data.data(), offsets.data(), result_data.data(), input_rows_count, kernel_params);
+        }
+        else
+        {
+            /// Scalar path for widened types (integers cast up to Float64, BFloat16 cast to Float32).
+            ColumnArray::Offset prev = 0;
+            for (size_t row = 0; row < input_rows_count; ++row)
             {
-                /// Scalar path for widened types (integers cast up to Float64, BFloat16 cast to Float32).
+                const auto off = offsets[row];
+                const size_t array_size = off - prev;
+
                 static constexpr size_t VEC_SIZE = 4;
                 ResultType results[VEC_SIZE] = {0};
                 size_t i = 0;
@@ -312,8 +326,8 @@ private:
                     result = Kernel::template accumulate<ResultType>(result, static_cast<ResultType>(data[prev + i]), kernel_params);
 
                 result_data[row] = Kernel::finalize(result, kernel_params);
+                prev = off;
             }
-            prev = off;
         }
         return result_col;
     }

--- a/src/Functions/array/arrayNorm.cpp
+++ b/src/Functions/array/arrayNorm.cpp
@@ -167,8 +167,8 @@ MULTITARGET_FUNCTION_X86_V4(
                     partial_results[s] = Kernel::template accumulate<ResultType>(partial_results[s], row_data[i + s], params);
 
             ResultType result = 0;
-            for (size_t s = 0; s < unroll_count; ++s)
-                result = Kernel::template combine<ResultType>(result, partial_results[s], params);
+            for (auto & partial_result : partial_results)
+                result = Kernel::template combine<ResultType>(result, partial_result, params);
 
             for (; i < count; ++i)
                 result = Kernel::template accumulate<ResultType>(result, row_data[i], params);

--- a/src/Functions/array/arrayNorm.cpp
+++ b/src/Functions/array/arrayNorm.cpp
@@ -144,10 +144,10 @@ struct LinfNorm
 /// ~150 elements that interrupts the hardware prefetcher's stream. Batching all rows into one call keeps
 /// the load stream continuous across row boundaries, which matters for the bandwidth-bound `Float64` paths.
 MULTITARGET_FUNCTION_X86_V4(
-    MULTITARGET_FUNCTION_HEADER(template <typename Kernel, typename ResultType> static void NO_SANITIZE_UNDEFINED NO_INLINE),
+    MULTITARGET_FUNCTION_HEADER(template <typename Kernel, typename ResultType, typename ArgumentType> static void NO_SANITIZE_UNDEFINED NO_INLINE),
     normBatchImpl,
     MULTITARGET_FUNCTION_BODY((
-        const ResultType * __restrict data,
+        const ArgumentType * __restrict data,
         const ColumnArray::Offset * __restrict offsets,
         ResultType * __restrict result_data,
         size_t input_rows_count,
@@ -158,21 +158,21 @@ MULTITARGET_FUNCTION_X86_V4(
         for (size_t row = 0; row < input_rows_count; ++row)
         {
             const size_t count = offsets[row] - prev;
-            const ResultType * __restrict row_data = data + prev;
+            const ArgumentType * __restrict row_data = data + prev;
 
             ResultType partial_results[unroll_count]{};
             size_t i = 0;
             const size_t unrolled_end = count / unroll_count * unroll_count;
             for (; i < unrolled_end; i += unroll_count)
                 for (size_t s = 0; s < unroll_count; ++s)
-                    partial_results[s] = Kernel::template accumulate<ResultType>(partial_results[s], row_data[i + s], params);
+                    partial_results[s] = Kernel::template accumulate<ResultType>(partial_results[s], static_cast<ResultType>(row_data[i + s]), params);
 
             ResultType result = 0;
             for (auto & partial_result : partial_results)
                 result = Kernel::template combine<ResultType>(result, partial_result, params);
 
             for (; i < count; ++i)
-                result = Kernel::template accumulate<ResultType>(result, row_data[i], params);
+                result = Kernel::template accumulate<ResultType>(result, static_cast<ResultType>(row_data[i]), params);
 
             result_data[row] = Kernel::finalize(result, params);
             prev = offsets[row];
@@ -290,46 +290,16 @@ private:
 
         const typename Kernel::ConstParams kernel_params = initConstParams(arguments);
 
-        if constexpr (std::is_same_v<ResultType, ArgumentType>
-            && (std::is_same_v<ResultType, Float32> || std::is_same_v<ResultType, Float64>))
-        {
-            /// SIMD-optimized path for same-type floating point: the entire row loop is handled in a single
-            /// multitarget call, runtime-dispatched to AVX-512 when available, else the baseline variant.
-            /// This keeps the load stream continuous across rows (see `normBatchImpl`).
+        /// The entire row loop is handled in a single multitarget call (runtime-dispatched to AVX-512 when
+        /// available, else the baseline variant), keeping the load stream continuous across rows. The kernel
+        /// widens each element to `ResultType` internally, so `BFloat16` (-> Float32) and integers (-> Float64)
+        /// take the same vectorized path as `Float32`/`Float64` (see `normBatchImpl`).
 #if USE_MULTITARGET_CODE
-            if (isArchSupported(TargetArch::x86_64_v4))
-                normBatchImpl_x86_64_v4<Kernel, ResultType>(data.data(), offsets.data(), result_data.data(), input_rows_count, kernel_params);
-            else
-#endif
-                normBatchImpl<Kernel, ResultType>(data.data(), offsets.data(), result_data.data(), input_rows_count, kernel_params);
-        }
+        if (isArchSupported(TargetArch::x86_64_v4))
+            normBatchImpl_x86_64_v4<Kernel, ResultType, ArgumentType>(data.data(), offsets.data(), result_data.data(), input_rows_count, kernel_params);
         else
-        {
-            /// Scalar path for widened types (integers cast up to Float64, BFloat16 cast to Float32).
-            ColumnArray::Offset prev = 0;
-            for (size_t row = 0; row < input_rows_count; ++row)
-            {
-                const auto off = offsets[row];
-                const size_t array_size = off - prev;
-
-                static constexpr size_t VEC_SIZE = 4;
-                ResultType results[VEC_SIZE] = {0};
-                size_t i = 0;
-                for (; i + VEC_SIZE < array_size; i += VEC_SIZE)
-                    for (size_t s = 0; s < VEC_SIZE; ++s)
-                        results[s] = Kernel::template accumulate<ResultType>(results[s], static_cast<ResultType>(data[prev + i + s]), kernel_params);
-
-                ResultType result = 0;
-                for (const auto & other_state : results)
-                    result = Kernel::template combine<ResultType>(result, other_state, kernel_params);
-
-                for (; i < array_size; ++i)
-                    result = Kernel::template accumulate<ResultType>(result, static_cast<ResultType>(data[prev + i]), kernel_params);
-
-                result_data[row] = Kernel::finalize(result, kernel_params);
-                prev = off;
-            }
-        }
+#endif
+            normBatchImpl<Kernel, ResultType, ArgumentType>(data.data(), offsets.data(), result_data.data(), input_rows_count, kernel_params);
         return result_col;
     }
 

--- a/src/Functions/array/arrayNorm.cpp
+++ b/src/Functions/array/arrayNorm.cpp
@@ -151,7 +151,8 @@ MULTITARGET_FUNCTION_X86_V4(
         const ColumnArray::Offset * __restrict offsets,
         ResultType * __restrict result_data,
         size_t input_rows_count,
-        const typename Kernel::ConstParams & params) {
+        const typename Kernel::ConstParams & params)
+    {
         constexpr size_t unroll_count = 16;
         ColumnArray::Offset prev = 0;
         for (size_t row = 0; row < input_rows_count; ++row)


### PR DESCRIPTION
### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improved performance of the `arrayNorm` function.

---
<img width="1056" height="168" alt="Screenshot 2026-06-04 at 10 23 13" src="https://github.com/user-attachments/assets/209c94cc-0b4d-4497-92a8-11e54b0abda7" />

<img width="962" height="64" alt="Screenshot 2026-06-04 at 10 23 26" src="https://github.com/user-attachments/assets/9c1ae106-c50f-4ea7-b2c9-c57266d94094" />

New situation:

```  ┌──────────────────────┬──────────────────┬──────────────────────────┬──────────────────────────────┐
  │        Metric        │    Input type    │          master          │         this branch          │
  ├──────────────────────┼──────────────────┼──────────────────────────┼──────────────────────────────┤
  │ L1/L2/L2Squared/Linf │ Float32, Float64 │ scalar (VEC_SIZE=4 loop) │ v4 batched kernel            │
  ├──────────────────────┼──────────────────┼──────────────────────────┼──────────────────────────────┤
  │ L1/L2/L2Squared/Linf │ BFloat16         │ scalar                   │ v4 batched (widened→Float32) │
  ├──────────────────────┼──────────────────┼──────────────────────────┼──────────────────────────────┤
  │ L1/L2/L2Squared/Linf │ integers         │ scalar                   │ v4 batched (widened→Float64) │
  ├──────────────────────┼──────────────────┼──────────────────────────┼──────────────────────────────┤
  │ Lp                   │ any              │ scalar (pow)             │ scalar (pow)                 │
  └──────────────────────┴──────────────────┴──────────────────────────┴──────────────────────────────┘
```

I will upload changes to `arrayDistance` with a separate PR.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.457`
<!-- ch-version-info:end -->