### PR TITLE
Restore test_tuple_evolved_simple for Iceberg struct schema evolution

### DIFF
--- a/tests/integration/test_storage_iceberg_schema_evolution/test_tuple_evolved_simple.py
+++ b/tests/integration/test_storage_iceberg_schema_evolution/test_tuple_evolved_simple.py
@@ -43,7 +43,7 @@ def test_tuple_evolved_simple(
             c struct<c : int, d: int>
         )
         USING iceberg
-        OPTIONS ('format-version'='2')
+        OPTIONS ('format-version'='{format_version}')
     """)
 
     execute_spark_query(f"INSERT INTO {TABLE_NAME} VALUES (1, named_struct('a', 1.23, 'b', 'ABBA'), named_struct('c', 1, 'd', 2))")

--- a/tests/integration/test_storage_iceberg_schema_evolution/test_tuple_evolved_simple.py
+++ b/tests/integration/test_storage_iceberg_schema_evolution/test_tuple_evolved_simple.py
@@ -1,0 +1,259 @@
+import pytest
+
+from helpers.iceberg_utils import (
+    default_upload_directory,
+    get_uuid_str,
+    get_creation_expression,
+    check_schema_and_data
+)
+
+
+@pytest.mark.parametrize("format_version", ["1", "2"])
+@pytest.mark.parametrize("storage_type", ["s3", "azure", "local"])
+@pytest.mark.parametrize("is_table_function", [False, True])
+def test_tuple_evolved_simple(
+    started_cluster_iceberg_schema_evolution, format_version, storage_type, is_table_function
+):
+    instance = started_cluster_iceberg_schema_evolution.instances["node1"]
+    spark = started_cluster_iceberg_schema_evolution.spark_session
+    TABLE_NAME = (
+        "test_tuple_evolved_simple_"
+        + format_version
+        + "_"
+        + storage_type
+        + "_"
+        + get_uuid_str()
+    )
+
+    def execute_spark_query(query: str):
+        spark.sql(query)
+        default_upload_directory(
+            started_cluster_iceberg_schema_evolution,
+            storage_type,
+            f"/iceberg_data/default/{TABLE_NAME}/",
+            f"/iceberg_data/default/{TABLE_NAME}/",
+        )
+        return
+
+    execute_spark_query(f"DROP TABLE IF EXISTS {TABLE_NAME}")
+    execute_spark_query(f"""
+        CREATE TABLE IF NOT EXISTS {TABLE_NAME} (
+            a int NOT NULL,
+            b struct<a: float, b: string>,
+            c struct<c : int, d: int>
+        )
+        USING iceberg
+        OPTIONS ('format-version'='2')
+    """)
+
+    execute_spark_query(f"INSERT INTO {TABLE_NAME} VALUES (1, named_struct('a', 1.23, 'b', 'ABBA'), named_struct('c', 1, 'd', 2))")
+
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} RENAME COLUMN b.a TO e")
+
+    table_creation_expression = get_creation_expression(
+        storage_type,
+        TABLE_NAME,
+        started_cluster_iceberg_schema_evolution,
+        table_function=is_table_function,
+    )
+
+    table_select_expression = (
+        TABLE_NAME if not is_table_function else table_creation_expression
+    )
+
+    if not is_table_function:
+        instance.query(table_creation_expression)
+
+
+    check_schema_and_data(
+        instance,
+        table_select_expression,
+        [
+            ['a', 'Int32'],
+            ['b', 'Tuple(\\n    e Nullable(Float32),\\n    b Nullable(String))'],
+            ['c', 'Tuple(\\n    c Nullable(Int32),\\n    d Nullable(Int32))']
+        ],
+        [
+            ['1', "(1.23,'ABBA')", '(1,2)']
+        ],
+    )
+
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} ALTER COLUMN c.d TYPE long;")
+
+    check_schema_and_data(
+        instance,
+        table_select_expression,
+        [
+            ['a', 'Int32'],
+            ['b', 'Tuple(\\n    e Nullable(Float32),\\n    b Nullable(String))'],
+            ['c', 'Tuple(\\n    c Nullable(Int32),\\n    d Nullable(Int64))']
+        ],
+        [
+            ['1', "(1.23,'ABBA')", '(1,2)']
+        ],
+    )
+
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} DROP COLUMN c.c")
+
+    check_schema_and_data(
+        instance,
+        table_select_expression,
+        [
+            ['a', 'Int32'],
+            ['b', 'Tuple(\\n    e Nullable(Float32),\\n    b Nullable(String))'],
+            ['c', 'Tuple(\\n    d Nullable(Int64))']
+        ],
+        [
+            ['1', "(1.23,'ABBA')", '(2)']
+        ],
+    )
+
+    execute_spark_query(
+        f"""
+            ALTER TABLE {TABLE_NAME} ADD COLUMN b.g int;
+        """
+    )
+
+    check_schema_and_data(
+        instance,
+        table_select_expression,
+        [
+            ['a', 'Int32'],
+            ['b', 'Tuple(\\n    e Nullable(Float32),\\n    b Nullable(String),\\n    g Nullable(Int32))'],
+            ['c', 'Tuple(\\n    d Nullable(Int64))']
+        ],
+        [
+            ['1', "(1.23,'ABBA',NULL)", '(2)']
+        ],
+    )
+
+    execute_spark_query(
+        f"""
+            ALTER TABLE {TABLE_NAME} ALTER COLUMN b.g FIRST;
+        """
+    )
+
+    check_schema_and_data(
+        instance,
+        table_select_expression,
+        [
+            ['a', 'Int32'],
+            ['b', 'Tuple(\\n    g Nullable(Int32),\\n    e Nullable(Float32),\\n    b Nullable(String))'],
+            ['c', 'Tuple(\\n    d Nullable(Int64))']
+        ],
+        [
+            ['1', "(NULL,1.23,'ABBA')", '(2)']
+        ],
+    )
+
+    execute_spark_query(f"INSERT INTO {TABLE_NAME} VALUES (2, named_struct('g', 5, 'e', 1.23, 'b', 'BACCARA'), named_struct('d', 3))")
+
+    check_schema_and_data(
+        instance,
+        table_select_expression,
+        [
+            ['a', 'Int32'],
+            ['b', 'Tuple(\\n    g Nullable(Int32),\\n    e Nullable(Float32),\\n    b Nullable(String))'],
+            ['c', 'Tuple(\\n    d Nullable(Int64))']
+        ],
+        [
+            ['1', "(NULL,1.23,'ABBA')", '(2)'],
+            ['2', "(5,1.23,'BACCARA')", '(3)']
+        ],
+    )
+
+    execute_spark_query(
+        f"""
+            ALTER TABLE {TABLE_NAME} RENAME COLUMN b.g TO a;
+        """
+    )
+
+    check_schema_and_data(
+        instance,
+        table_select_expression,
+        [
+            ['a', 'Int32'],
+            ['b', 'Tuple(\\n    a Nullable(Int32),\\n    e Nullable(Float32),\\n    b Nullable(String))'],
+            ['c', 'Tuple(\\n    d Nullable(Int64))']
+        ],
+        [
+            ['1', "(NULL,1.23,'ABBA')", '(2)'],
+            ['2', "(5,1.23,'BACCARA')", '(3)']
+        ],
+    )
+
+    execute_spark_query(f"ALTER TABLE {TABLE_NAME} DROP COLUMN b.a")
+
+    check_schema_and_data(
+        instance,
+        table_select_expression,
+        [
+            ['a', 'Int32'],
+            ['b', 'Tuple(\\n    e Nullable(Float32),\\n    b Nullable(String))'],
+            ['c', 'Tuple(\\n    d Nullable(Int64))']
+        ],
+        [
+            ['1', "(1.23,'ABBA')", '(2)'],
+            ['2', "(1.23,'BACCARA')", '(3)']
+        ],
+    )
+
+    execute_spark_query(
+        f"""
+            ALTER TABLE {TABLE_NAME} RENAME COLUMN b.b TO a;
+        """
+    )
+
+    check_schema_and_data(
+        instance,
+        table_select_expression,
+        [
+            ['a', 'Int32'],
+            ['b', 'Tuple(\\n    e Nullable(Float32),\\n    a Nullable(String))'],
+            ['c', 'Tuple(\\n    d Nullable(Int64))']
+        ],
+        [
+            ['1', "(1.23,'ABBA')", '(2)'],
+            ['2', "(1.23,'BACCARA')", '(3)']
+        ],
+    )
+
+    execute_spark_query(
+        f"""
+            ALTER TABLE {TABLE_NAME} RENAME COLUMN b.e TO b;
+        """
+    )
+
+    check_schema_and_data(
+        instance,
+        table_select_expression,
+        [
+            ['a', 'Int32'],
+            ['b', 'Tuple(\\n    b Nullable(Float32),\\n    a Nullable(String))'],
+            ['c', 'Tuple(\\n    d Nullable(Int64))']
+        ],
+        [
+            ['1', "(1.23,'ABBA')", '(2)'],
+            ['2', "(1.23,'BACCARA')", '(3)']
+        ],
+    )
+
+    execute_spark_query(
+        f"""
+            ALTER TABLE {TABLE_NAME} ALTER COLUMN b.a FIRST;
+        """
+    )
+
+    check_schema_and_data(
+        instance,
+        table_select_expression,
+        [
+            ['a', 'Int32'],
+            ['b', 'Tuple(\\n    a Nullable(String),\\n    b Nullable(Float32))'],
+            ['c', 'Tuple(\\n    d Nullable(Int64))']
+        ],
+        [
+            ['1', "('ABBA',1.23)", '(2)'],
+            ['2', "('BACCARA',1.23)", '(3)']
+        ],
+    )


### PR DESCRIPTION
Restores the `test_tuple_evolved_simple` integration test that was removed in commit `6c9568b` (part of PR #84821, "Fix iceberg reading by field ids for complex types") so that the fix could be delivered quickly, with the intent to restore it later.

The test exercises schema evolution of `Tuple` (struct) columns in Iceberg: renaming, type promotion, dropping, adding, and reordering of nested fields, including sequences that reuse previously-used field names. The name-reuse sequences (rename `b.g`→`a`, drop `b.a`, rename `b.b`→`a`, rename `b.e`→`b`) verify that nested struct fields are resolved by Iceberg field id rather than by name.

Since the original deletion, the test directory was split into per-feature files and the native Parquet reader gained a field-id `ColumnMapper`. The restored test (modelled on `test_tuple_evolved_nested.py`, dropping the now-obsolete `allow_dynamic_metadata_for_data_lakes` argument) passes on current master across all 12 parametrizations (`s3`/`azure`/`local`, format versions `1`/`2`, table and table-function), so the behavior is already correct and only the test needed to be returned.

Closes #85954

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.309`
<!-- ch-version-info:end -->