### PR TITLE
Fix logical error 'analyzed_join.oneDisjunct()' for JOIN ON without keys

### DIFF
--- a/src/Interpreters/TreeRewriter.cpp
+++ b/src/Interpreters/TreeRewriter.cpp
@@ -756,7 +756,10 @@ void collectJoinedColumns(TableJoin & analyzed_join, ASTTableJoin & table_join,
         {
             analyzed_join.addDisjunct();
             CollectJoinOnKeysVisitor(data).visit(table_join.on_expression);
-            chassert(analyzed_join.oneDisjunct());
+            /// Exactly one disjunct is added here. The clause may still be empty (e.g. an ASOF inequality
+            /// without an equality key, or a single-table condition); that case is reported below as a
+            /// proper exception, so we only assert the number of clauses, not their non-emptiness.
+            chassert(analyzed_join.getClauses().size() == 1);
         }
 
         auto check_keys_empty = [] (auto e) { return e.key_names_left.empty(); };

--- a/tests/queries/0_stateless/04303_asof_join_on_single_inequality.sql
+++ b/tests/queries/0_stateless/04303_asof_join_on_single_inequality.sql
@@ -1,0 +1,17 @@
+-- Regression test: an ASOF JOIN whose ON section yields no equality key (here a single
+-- inequality, optionally wrapped in a redundant one-argument `and`) must report a proper
+-- exception instead of failing the `analyzed_join.oneDisjunct()` assertion in a debug build.
+
+SET enable_analyzer = 0;
+
+DROP TABLE IF EXISTS t0_04303;
+DROP TABLE IF EXISTS t1_04303;
+
+CREATE TABLE t0_04303 (x Int32, y Int32) ENGINE = Memory;
+CREATE TABLE t1_04303 (x Int32, y Int32) ENGINE = Memory;
+
+SELECT * FROM t0_04303 ASOF LEFT JOIN t1_04303 ON and((t0_04303.y > t1_04303.y)); -- { serverError INVALID_JOIN_ON_EXPRESSION }
+SELECT * FROM t0_04303 ASOF LEFT JOIN t1_04303 ON (t0_04303.y > t1_04303.y); -- { serverError INVALID_JOIN_ON_EXPRESSION }
+
+DROP TABLE t0_04303;
+DROP TABLE t1_04303;


### PR DESCRIPTION
Fixes a logical error `'analyzed_join.oneDisjunct()'` found by the AST fuzzer (`amd_debug`) on the query (with `enable_analyzer = 0`):

```sql
SELECT * FROM t0 ASOF LEFT JOIN t1 ON and((t0.y > t1.y))
```

In `collectJoinedColumns`, when the `JOIN ON` expression is not a top-level `or`, exactly one disjunct is added and the expression is visited, then `chassert(analyzed_join.oneDisjunct())` was checked. `oneDisjunct` additionally requires the single clause to be non-empty, but the clause can legitimately be empty at this point — for an `ASOF` inequality without an equality key the keys are only materialized later via `asofToJoinKeys`, and a single-table condition adds no keys either. Such cases are reported right below as a proper `INVALID_JOIN_ON_EXPRESSION` exception, but in a debug build the assertion fired first.

The redundant one-argument `and` in the fuzzed query is not the cause: the plain `ON (t0.y > t1.y)` triggers the same assertion. The fix asserts only the number of clauses, mirroring the sibling `or`-branch assertion.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=13a9b8ea79c017e7e34c4b6065660398647e35f7&name_0=MasterCI&name_1=AST%20fuzzer%20%28amd_debug%29

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a logical error when a `JOIN ON` section (with the old analyzer) produces no join keys, such as an `ASOF JOIN` with only an inequality condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
