### PR TITLE
CI: report a budget timeout as Timeout, not Server died

### DIFF
--- a/ci/jobs/functional_tests.py
+++ b/ci/jobs/functional_tests.py
@@ -104,9 +104,18 @@ def run_tests(
                 | tee -a \"{test_output_file}\""
     if Path(test_output_file).exists():
         Path(test_output_file).unlink()
-    return Shell.run(
-        command, verbose=True, timeout=global_time_limit if global_time_limit > 0 else None
+    # `timeout_status` is populated by `Shell._check_timeout` only when the
+    # wall-clock budget elapsed and it killed a still-running runner. That lets
+    # us report a timeout instead of a (false) server death, since both arrive
+    # as a SIGTERM exit code.
+    timeout_status: list = []
+    exit_code = Shell.run(
+        command,
+        verbose=True,
+        timeout=global_time_limit if global_time_limit > 0 else None,
+        timeout_status=timeout_status,
     )
+    return exit_code, bool(timeout_status)
 
 
 OPTIONS_TO_INSTALL_ARGUMENTS = {
@@ -585,6 +594,7 @@ def main():
         ft_res_processor = FTResultsProcessor(wd=temp_dir)
 
         global_time_limit = 0
+        runner_timed_out = False
         if is_flaky_check:
             FLAKY_CHECK_TIME_LIMIT = 45 * 60  # 45 min
             global_time_limit = max(
@@ -596,7 +606,7 @@ def main():
                 f" remaining: {global_time_limit}s)"
             )
 
-            runner_exit_code = run_tests(
+            runner_exit_code, runner_timed_out = run_tests(
                 batch_num=0,
                 batch_total=0,
                 tests=list(tests) if tests else tests,
@@ -617,7 +627,7 @@ def main():
                 f" remaining: {global_time_limit}s)"
             )
 
-            runner_exit_code = run_tests(
+            runner_exit_code, runner_timed_out = run_tests(
                 batch_num=0,
                 batch_total=0,
                 tests=list(tests) if tests else tests,
@@ -628,7 +638,7 @@ def main():
             )
 
         else:
-            runner_exit_code = run_tests(
+            runner_exit_code, runner_timed_out = run_tests(
                 batch_num=batch_num,
                 batch_total=total_batches,
                 tests=list(tests) if tests else tests,
@@ -638,7 +648,9 @@ def main():
                 global_time_limit=global_time_limit,
             )
 
-        test_result = ft_res_processor.run(runner_exit_code=runner_exit_code)
+        test_result = ft_res_processor.run(
+            runner_exit_code=runner_exit_code, timed_out=runner_timed_out
+        )
 
         if not info.is_local_run:
             CH.stop_log_exports()

--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -30,7 +30,13 @@ STOP_TESTING_EXIT_CODE = runpy.run_path(str(_clickhouse_test))["STOP_TESTING_EXI
 # worker -> parent SIGTERM feedback loop in `stop_tests`: each worker the
 # parent terminates re-broadcasts SIGTERM to the whole process group via
 # `killpg`, hitting the parent before it can `sys.exit(STOP_TESTING_EXIT_CODE)`;
-# also covers external kills like job-level timeouts and runner shutdown).
+# also covers runner shutdown).
+#
+# A job-level wall-clock timeout also kills the runner with SIGTERM, but the
+# server is healthy in that case and the completed per-test results are
+# authoritative. That is handled separately via the `timed_out` flag in `run`
+# (reported as a `Timeout`, not `Server died`), which takes precedence over
+# this set.
 #
 # Both `128 + N` (bash's convention when its child died from signal N) and
 # the negative form `-N` are included: `Shell.run` wraps the command in
@@ -207,7 +213,12 @@ class FTResultsProcessor:
 
         return s
 
-    def run(self, task_name="Tests", runner_exit_code: Optional[int] = None):
+    def run(
+        self,
+        task_name="Tests",
+        runner_exit_code: Optional[int] = None,
+        timed_out: bool = False,
+    ):
         state = Result.Status.OK
         s = self._process_test_output()
         test_results = s.test_results
@@ -220,6 +231,21 @@ class FTResultsProcessor:
             state = Result.Status.FAIL
             test_results.append(
                 Result("Some queries hung", Result.Status.FAIL, info="Some queries hung")
+            )
+        elif timed_out:
+            # The runner was killed by the job-level wall-clock budget (SIGTERM
+            # from `Shell._check_timeout`), not by a crash. The server is healthy
+            # and the per-test results that completed are authoritative, so keep
+            # them as-is (no UNKNOWN demotion) and report a timeout rather than a
+            # spurious `Server died`. Both arrive as a SIGTERM exit code, so this
+            # branch must precede the `ABORTED_RUN_EXIT_CODES` one.
+            state = Result.Status.FAIL
+            test_results.append(
+                Result(
+                    "Timeout",
+                    Result.Status.FAIL,
+                    info="The test run exceeded its time budget and was terminated",
+                )
             )
         elif runner_exit_code in ABORTED_RUN_EXIT_CODES:
             state = Result.Status.FAIL

--- a/ci/praktika/utils.py
+++ b/ci/praktika/utils.py
@@ -280,13 +280,23 @@ class Shell:
         return not failed
 
     @classmethod
-    def _check_timeout(cls, timeout, process) -> None:
+    def _check_timeout(cls, timeout, process, timeout_status=None) -> None:
         if not timeout:
             return
         time.sleep(timeout)
+        if process.poll() is not None:
+            # The process finished on its own within the budget; nothing to kill.
+            return
         print(
             f"WARNING: Timeout exceeded [{timeout}], sending SIGTERM to process group [{process.pid}]"
         )
+        # The process group was alive when the budget elapsed: this kill is a
+        # wall-clock timeout, not a crash. Record it before signalling so callers
+        # can tell a budget timeout apart from a genuine abort (both surface as
+        # SIGTERM in the exit code). Set before `killpg` to avoid racing the
+        # caller's `proc.wait()`.
+        if timeout_status is not None:
+            timeout_status.append(True)
         try:
             os.killpg(process.pid, signal.SIGTERM)
         except ProcessLookupError:
@@ -322,6 +332,7 @@ class Shell:
         timeout=None,
         retries=1,
         retry_errors: Union[List[str], str] = "",
+        timeout_status=None,
         **kwargs,
     ):
         if retry_errors and retries < 2:
@@ -368,7 +379,10 @@ class Shell:
 
                     # Start the timeout thread if specified
                     if timeout:
-                        t = Thread(target=cls._check_timeout, args=(timeout, proc))
+                        t = Thread(
+                            target=cls._check_timeout,
+                            args=(timeout, proc, timeout_status),
+                        )
                         t.daemon = True
                         t.start()
 

--- a/ci/tests/test_functional_tests_results_timeout.py
+++ b/ci/tests/test_functional_tests_results_timeout.py
@@ -1,0 +1,104 @@
+"""
+Tests for `FTResultsProcessor.run` distinguishing a wall-clock budget timeout
+from a server death.
+
+Both a job-level budget timeout and a genuine mid-flight abort kill the runner
+with SIGTERM, so they share the same exit code. Only the timeout case carries
+`timed_out=True` (set by `Shell._check_timeout`). In that case the server is
+healthy and the completed per-test results are authoritative, so the processor
+must report a `Timeout` leaf and keep per-test results intact, rather than a
+`Server died` leaf with the failures demoted to `UNKNOWN`.
+"""
+
+import os
+import signal
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.jobs.scripts.functional_tests_results import FTResultsProcessor
+from ci.praktika.result import Result
+
+
+def _processor(tmp_path, lines):
+    output_file = tmp_path / "test_result.txt"
+    output_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return FTResultsProcessor(wd=str(tmp_path))
+
+
+def _names(result):
+    return [r.name for r in result.results]
+
+
+def _by_name(result, name):
+    return next(r for r in result.results if r.name == name)
+
+
+def test_budget_timeout_reports_timeout_not_server_died(tmp_path):
+    """A budget timeout (SIGTERM, `timed_out=True`) must surface as `Timeout`,
+    never `Server died`, and must keep a genuine per-test failure visible.
+    """
+    proc = _processor(
+        tmp_path,
+        [
+            "2026-06-01 10:00:00 00001_passing_test: [ OK ] 1.00 sec.",
+            "2026-06-01 10:00:01 03748_join_on_complex_condition_result_memory: [ FAIL ] 1.23 sec.",
+            "2026-06-01 10:00:01 Code: 241. MEMORY_LIMIT_EXCEEDED",
+        ],
+    )
+
+    result = proc.run(runner_exit_code=-signal.SIGTERM, timed_out=True)
+
+    assert "Timeout" in _names(result)
+    assert "Server died" not in _names(result)
+    assert result.status == Result.Status.FAIL
+    # The genuine failure stays a FAIL (authoritative), not demoted to UNKNOWN.
+    assert _by_name(result, "03748_join_on_complex_condition_result_memory").status == (
+        Result.Status.FAIL
+    )
+
+
+def test_budget_timeout_with_no_failures_still_fails_as_timeout(tmp_path):
+    """A timeout with only passing tests must not read as OK; it is a `Timeout`
+    FAIL so the job is flagged and re-run.
+    """
+    proc = _processor(
+        tmp_path,
+        ["2026-06-01 10:00:00 00001_passing_test: [ OK ] 1.00 sec."],
+    )
+
+    result = proc.run(runner_exit_code=-signal.SIGTERM, timed_out=True)
+
+    assert "Timeout" in _names(result)
+    assert "Server died" not in _names(result)
+    assert result.status == Result.Status.FAIL
+    assert _by_name(result, "00001_passing_test").status == Result.Status.OK
+
+
+def test_sigterm_without_timeout_still_reports_server_died(tmp_path):
+    """A SIGTERM that is not a budget timeout (`timed_out=False`) keeps the
+    existing abort behavior: a `Server died` leaf and ambiguous parallel
+    failures demoted to `UNKNOWN`.
+    """
+    proc = _processor(
+        tmp_path,
+        [
+            "2026-06-01 10:00:00 00001_test_a: [ FAIL ] 1.00 sec.",
+            "2026-06-01 10:00:01 00002_test_b: [ FAIL ] 1.00 sec.",
+        ],
+    )
+
+    result = proc.run(runner_exit_code=-signal.SIGTERM, timed_out=False)
+
+    assert "Server died" in _names(result)
+    assert "Timeout" not in _names(result)
+    assert result.status == Result.Status.FAIL
+    # Two failures during an abort are ambiguous -> demoted to UNKNOWN.
+    assert _by_name(result, "00001_test_a").status == Result.Status.UNKNOWN
+    assert _by_name(result, "00002_test_b").status == Result.Status.UNKNOWN
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
A job-level wall-clock budget timeout in the flaky and targeted stateless checks is currently reported as `Server died`, even though the server is healthy and shuts down cleanly. When a run exceeds its budget, `Shell._check_timeout` kills the runner with SIGTERM, and the result parser treats any SIGTERM exit code (`-15` / `143`) as an aborted run and attaches a synthetic `Server died` leaf. A timeout is not a crash, so this is misleading and triggers spurious server-death alerts.

The behavior was introduced by `8536a678354` and `07778ae4699`, which intentionally folded job-level timeouts into `ABORTED_RUN_EXIT_CODES`. cc @leshikus

The fix threads a real signal from the only place that knows the kill was a timeout: `Shell._check_timeout` records into an optional `timeout_status` list right before sending SIGTERM, and only when the process was still alive, so a runner that finished on its own within the budget is not misreported. `run_tests` returns whether the budget timeout fired, and `FTResultsProcessor.run` reports a `Timeout` leaf instead of `Server died`. The completed per-test results stay authoritative (no demotion to `UNKNOWN`), so a genuine failure that happened before the timeout stays visible. A genuine mid-flight abort (worker to parent SIGTERM feedback loop, runner shutdown, real server death) still has `timed_out=False` and keeps the existing `Server died` behavior.

Observed on:
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=105019&sha=latest&name_0=PR&name_1=Stateless+tests+%28arm_asan_ubsan%2C+targeted%29 (targeted)
- https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104965&sha=b8200879b832ff77f5a82d8d8e5c77efe10d0353&name_0=PR&name_1=Stateless%20tests%20%28amd_asan_ubsan%2C%20flaky%20check%29 (flaky check)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Report a stateless-check budget timeout as `Timeout` instead of `Server died`.
