### PR TITLE
Adjust 04299_deltalake_invalid_utf8_credentials for FIPS build

### DIFF
--- a/tests/queries/0_stateless/04299_deltalake_invalid_utf8_credentials.sh
+++ b/tests/queries/0_stateless/04299_deltalake_invalid_utf8_credentials.sh
@@ -21,5 +21,5 @@ CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CUR_DIR"/../shell_config.sh
 
-$CLICKHOUSE_LOCAL --query "SELECT * FROM deltaLakeAzure('\0', MD5('')) SETTINGS allow_experimental_delta_kernel_rs = 1" 2>&1 \
+$CLICKHOUSE_LOCAL --query "SELECT * FROM deltaLakeAzure('\0', UNHEX('D41D8CD98F00B204E9800998ECF8427E')) SETTINGS allow_experimental_delta_kernel_rs = 1" 2>&1 \
     | grep -o -m1 BAD_ARGUMENTS


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.305`
<!-- ch-version-info:end -->