### PR TITLE
Fix LocalObjectStorage with cache 

### DIFF
--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -308,7 +308,7 @@ std::shared_ptr<ReadBufferFromFileBase> getRemoteReadBuffer(
 {
     ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::CachedReadBufferCreateBufferMicroseconds);
 
-    auto create_remote_read_buffer = [&]()
+    auto create_remote_read_buffer = [&]() -> std::unique_ptr<ReadBufferFromFileBase>
     {
         auto impl = info.implementation_buffer_creator();
         if (impl->supportsRightBoundedReads())

--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -308,6 +308,14 @@ std::shared_ptr<ReadBufferFromFileBase> getRemoteReadBuffer(
 {
     ProfileEventTimeIncrement<Microseconds> watch(ProfileEvents::CachedReadBufferCreateBufferMicroseconds);
 
+    auto create_remote_read_buffer = [&]()
+    {
+        auto impl = info.implementation_buffer_creator();
+        if (impl->supportsRightBoundedReads())
+            return impl;
+        return std::make_unique<BoundedReadBuffer>(std::move(impl));
+    };
+
     switch (read_type)
     {
         case ReadType::REMOTE_FS_READ_AND_PUT_IN_CACHE:
@@ -332,12 +340,7 @@ std::shared_ptr<ReadBufferFromFileBase> getRemoteReadBuffer(
 
             if (!remote_fs_segment_reader)
             {
-                auto impl = info.implementation_buffer_creator();
-                if (impl->supportsRightBoundedReads())
-                    remote_fs_segment_reader = std::move(impl);
-                else
-                    remote_fs_segment_reader = std::make_unique<BoundedReadBuffer>(std::move(impl));
-
+                remote_fs_segment_reader = create_remote_read_buffer();
                 file_segment.setRemoteFileReader(remote_fs_segment_reader);
             }
             else
@@ -356,9 +359,13 @@ std::shared_ptr<ReadBufferFromFileBase> getRemoteReadBuffer(
             /// We cannot directly check info.remote_file_reader because of a possible race with background downloader.
             auto reader = file_segment.extractRemoteFileReader();
             if (reader && offset == reader->getFileOffsetOfBufferEnd())
+            {
                 info.remote_file_reader = reader;
+            }
             else
-                info.remote_file_reader = info.implementation_buffer_creator();
+            {
+                info.remote_file_reader = create_remote_read_buffer();
+            }
 
             return info.remote_file_reader;
         }

--- a/tests/integration/test_filesystem_cache/test.py
+++ b/tests/integration/test_filesystem_cache/test.py
@@ -190,6 +190,83 @@ def test_parallel_cache_loading_on_startup(cluster, node_name):
 
 
 @pytest.mark.parametrize("node_name", ["node"])
+def test_bypass_cache_does_not_overread_non_last_segment(cluster, node_name):
+    """
+    Regression test for an over-read on the `REMOTE_FS_READ_BYPASS_CACHE` path.
+
+    A non-last file segment read in bypass mode relies on the buffer being
+    right-bounded (the read size is clamped to the range only for a single held
+    segment). For readers without right-bounded support (local object storage)
+    the bypass buffer must be wrapped into `BoundedReadBuffer`, otherwise it
+    reads past the segment and trips a logical error in
+    `CachedOnDiskReadBufferFromFile`.
+
+    The `cache_filesystem_failure` failpoint with `skip_cache_on_disk_failure`
+    leaves segments in `PARTIALLY_DOWNLOADED_NO_CONTINUATION`, so concurrent
+    readers read the front segment in bypass mode while holding the next ones.
+    """
+    node = cluster.instances[node_name]
+    cache_name = f"bypass_overread_{uuid.uuid4().hex[:8]}"
+    table_name = f"bypass_overread_{uuid.uuid4().hex[:8]}"
+    try:
+        node.query(
+            f"""
+            DROP TABLE IF EXISTS {table_name} SYNC;
+            CREATE TABLE {table_name} (key UInt32, value String)
+            ENGINE = MergeTree() ORDER BY key
+            SETTINGS disk = disk(
+                type = cache,
+                name = '{cache_name}',
+                path = '{cache_name}/',
+                max_size = '1Gi',
+                max_file_segment_size = 32768,
+                boundary_alignment = 32768,
+                skip_cache_on_disk_failure = true,
+                disk = 'hdd_blob'
+            );
+            INSERT INTO {table_name} SELECT number, randomString(100) FROM numbers(100000);
+            SYSTEM DROP FILESYSTEM CACHE;
+            """
+        )
+
+        test_start = node.query("SELECT now()").strip()
+
+        # Force every download write to fail so segments stay in
+        # PARTIALLY_DOWNLOADED_NO_CONTINUATION and reads fall back to bypass.
+        node.query("SYSTEM ENABLE FAILPOINT cache_filesystem_failure")
+        try:
+            # Concurrent readers: while one query leaves the front segment in a
+            # bypass state, others read it together with the following segments.
+            node.exec_in_container(
+                [
+                    "/usr/bin/clickhouse",
+                    "benchmark",
+                    "--iterations",
+                    "200",
+                    "--concurrency",
+                    "50",
+                    "--query",
+                    f"SELECT * FROM {table_name} FORMAT Null",
+                ]
+            )
+        finally:
+            node.query("SYSTEM DISABLE FAILPOINT cache_filesystem_failure")
+
+        # If the over-read aborted the server, the queries above raise a
+        # connection error (and the cluster teardown reports the crash).
+        # Otherwise make sure no logical error was recorded.
+        node.query("SELECT 1")
+        errors = int(
+            node.query(
+                f"SELECT count() FROM system.errors WHERE name = 'LOGICAL_ERROR' AND last_error_time >= '{test_start}'"
+            ).strip()
+        )
+        assert errors == 0, f"LOGICAL_ERROR occurred on {node.name}"
+    finally:
+        node.query(f"DROP TABLE IF EXISTS {table_name} SYNC")
+
+
+@pytest.mark.parametrize("node_name", ["node"])
 def test_caches_with_the_same_configuration(cluster, node_name):
     node = cluster.instances[node_name]
     cache_path = "cache1"


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Not for changelog because LocalObjectStorage is used only for test, not a real feature.



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.347` (included in `26.6` and later)
- Backported to: `26.3.33.42`
<!-- ch-version-info:end -->