### PR TITLE
Make reading_from_file perf test deterministic to reduce noise

### DIFF
--- a/tests/performance/reading_from_file.xml
+++ b/tests/performance/reading_from_file.xml
@@ -1,6 +1,9 @@
 <test>
 
-<fill_query>INSERT INTO function file(reading_from_file.parquet) SELECT URL FROM test.hits LIMIT 100000 SETTINGS engine_file_truncate_on_insert=1</fill_query>
+<!-- ORDER BY URL makes the selected subset deterministic. Without it, LIMIT returns a different 100000 rows on each
+     server (the read race between parts/threads decides which rows win), and since base58Encode cost is super-linear
+     in string length, the two servers get persistently different workloads and the comparison is reported as noisy. -->
+<fill_query>INSERT INTO function file(reading_from_file.parquet) SELECT URL FROM test.hits ORDER BY URL LIMIT 100000 SETTINGS engine_file_truncate_on_insert=1</fill_query>
 
 <query>SELECT sum(length(base58Encode(URL))) FROM file(reading_from_file.parquet) FORMAT Null</query>
 


### PR DESCRIPTION
The `reading_from_file` performance test is one of the noisiest tests tracked in #100759 (arm 67% / amd 59% noisy in master runs).

Root cause: the fill query `SELECT URL FROM test.hits LIMIT 100000` has no `ORDER BY`, so when the parts are read by multiple threads the `LIMIT` returns whichever 100000 rows win the read race, and each of the two compared servers ends up with a different subset of URLs in its parquet file. Because `base58Encode` cost is super-linear in string length, a slightly different (heavier-tailed) subset costs disproportionately more, so one server is persistently slower than the other within a run and the verdict flips randomly across runs.

Evidence from a master self-comparison (`old_sha == new_sha`): same `SelectedRows` on both sides, `SelectedBytes` differs by 9%, but `UserTimeMicroseconds` and `client_time` differ by ~2x. Reproduced locally against `test.hits`: independent runs of the old fill produce 2.53-5.00 MB of URL data and 0.036-0.167s query time, a 4.6x swing; with `ORDER BY URL` the fill is byte-for-byte identical and the time is constant at ~0.137s.

This is the same class of issue as the `apply_patch_parts_join` fix in #105527.

`ORDER BY URL` makes both servers encode the same deterministic subset. The fill query is not measured, so the sort cost is irrelevant.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.314`
<!-- ch-version-info:end -->