### PR TITLE
CI (docs): Reusable Mintlify docs checks for integrations repos

### DIFF
--- a/ci/defs/job_configs.py
+++ b/ci/defs/job_configs.py
@@ -1378,6 +1378,7 @@ class JobConfigs:
             include_paths=[
                 "./docs",
                 "./ci/jobs/docs_job_mintlify.py",
+                "./ci/jobs/scripts/docs",
             ],
             # Exclude everything currently in ./docs so that this job runs only
             # on files that are NOT part of the legacy docs tree (i.e. the new

--- a/ci/jobs/docs_job_mintlify.py
+++ b/ci/jobs/docs_job_mintlify.py
@@ -1,33 +1,35 @@
-import os
-
+from ci.jobs.scripts.docs.check_readonly_copies import check_readonly_copies
+from ci.jobs.scripts.docs.mintlify_docs_check import DEFAULT_CHECKS
+from ci.praktika.info import Info
 from ci.praktika.result import Result
-from ci.praktika.utils import Shell, Utils
+from ci.praktika.utils import Utils
+
+
+def _readonly_copies_guard():
+    # One-way sync: fail edits to docs folders whose canonical source lives in
+    # another repo (declared in ci/jobs/scripts/docs/readonly_copies.json). This
+    # is aggregator-only -- the consuming repos are the source of truth, so this
+    # is deliberately not part of the shared DEFAULT_CHECKS.
+    return check_readonly_copies(Info().get_changed_files() or [])
+
 
 if __name__ == "__main__":
 
-    results = []
-    stop_watch = Utils.Stopwatch()
-    temp_dir = f"{Utils.cwd()}/ci/tmp/"
-
     docs_dir = f"{Utils.cwd()}/docs"
 
-    results.append(
-        Result.from_commands_run(
-            name="Verify Mintlify docs.json file is valid",
-            command=[
-                "mint validate",
-            ],
-            workdir=docs_dir,
-        )
-    )
+    # The mint check definitions are shared with the standalone driver
+    # (ci/jobs/scripts/docs/mintlify_docs_check.py). This job already runs inside
+    # the docs-builder image with the docs present natively, so it runs them
+    # directly; add new checks to DEFAULT_CHECKS, not here.
+    results = [
+        Result.from_commands_run(name=name, command=command, workdir=docs_dir)
+        for name, command in DEFAULT_CHECKS
+    ]
 
     results.append(
         Result.from_commands_run(
-            name="Check for broken links",
-            command=[
-                "mint broken-links",
-            ],
-            workdir=docs_dir,
+            name="No direct edits to read-only copied docs",
+            command=_readonly_copies_guard,
         )
     )
 

--- a/ci/jobs/docs_job_mintlify.py
+++ b/ci/jobs/docs_job_mintlify.py
@@ -10,7 +10,13 @@ def _readonly_copies_guard():
     # another repo (declared in ci/jobs/scripts/docs/readonly_copies.json). This
     # is aggregator-only -- the consuming repos are the source of truth, so this
     # is deliberately not part of the shared DEFAULT_CHECKS.
-    return check_readonly_copies(Info().get_changed_files() or [])
+    changed_files = Info().get_changed_files()
+    if changed_files is None:
+        # Fail close: without the changed-file list we cannot prove the PR does
+        # not touch read-only copies, so do not report success.
+        print("Error: the changed-file list is unavailable, cannot run the check.")
+        return False
+    return check_readonly_copies(changed_files)
 
 
 if __name__ == "__main__":

--- a/ci/jobs/scripts/docs/check_readonly_copies.py
+++ b/ci/jobs/scripts/docs/check_readonly_copies.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Guard for one-way-synced docs folders.
+
+Some docs folders in this repo are *copies* whose canonical source lives in
+another repository (e.g. ``docs/integrations/language-clients/python`` is owned
+by ``clickhouse-connect``). Editing the copy here is almost always a mistake --
+the next sync overwrites it. This check fails such edits and points the
+contributor at the canonical source.
+
+The protected folders and their owning repos are declared in
+``readonly_copies.json`` next to this file. The check matches a list of changed
+files (repo-relative paths, as they appear in the PR diff) against those
+folders.
+
+It has no CI-framework dependency: the Praktika job feeds it
+``Info().get_changed_files()``; standalone you can pipe ``git diff --name-only``.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+CONFIG_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "readonly_copies.json"
+)
+
+
+def load_sources(config_path):
+    with open(config_path, encoding="utf-8") as f:
+        return json.load(f)["sources"]
+
+
+def _normalize(path):
+    return path.strip().removeprefix("./")
+
+
+def find_violations(changed_files, sources):
+    """Return [(source, [offending files])] for every source that was touched."""
+    normalized = [_normalize(f) for f in changed_files]
+    violations = []
+    for src in sources:
+        prefix = src["path"].rstrip("/")
+        hit = [f for f in normalized if f == prefix or f.startswith(prefix + "/")]
+        if hit:
+            violations.append((src, sorted(hit)))
+    return violations
+
+
+def format_message(violations):
+    lines = []
+    for src, files in violations:
+        owner = src.get("repo") or src.get("url", "")
+        subdir = src.get("subdir")
+        where = f" (in its `{subdir}` folder)" if subdir else ""
+        lines.append(f"'{src['path']}' is a one-way copy from {owner}{where}.")
+        if src.get("url"):
+            lines.append(f"  Canonical source: {src['url']}")
+        lines.append(
+            "  Edit it there -- changes made directly here are overwritten by the "
+            "next sync."
+        )
+        lines.append("  Offending files:")
+        lines.extend(f"    {f}" for f in files)
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def check_readonly_copies(changed_files, config_path=CONFIG_PATH):
+    """Return True if no read-only copied docs were edited, else False."""
+    sources = load_sources(config_path)
+    violations = find_violations(changed_files, sources)
+    if not violations:
+        print("OK: no edits to read-only copied docs.")
+        return True
+    print("Edits to read-only copied docs detected:\n")
+    print(format_message(violations))
+    return False
+
+
+def _read_changed_files(args):
+    if args.changed_file:
+        return args.changed_file
+    return [line.strip() for line in sys.stdin.read().splitlines() if line.strip()]
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--config", default=CONFIG_PATH, help="Path to readonly_copies.json.")
+    p.add_argument(
+        "--changed-file",
+        action="append",
+        default=[],
+        help="A changed file path (repeatable). If omitted, newline-separated "
+        "paths are read from stdin.",
+    )
+    args = p.parse_args(argv)
+    return 0 if check_readonly_copies(_read_changed_files(args), args.config) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/jobs/scripts/docs/check_readonly_copies.py
+++ b/ci/jobs/scripts/docs/check_readonly_copies.py
@@ -13,8 +13,12 @@ The protected folders and their owning repos are declared in
 files (repo-relative paths, as they appear in the PR diff) against those
 folders.
 
-It has no CI-framework dependency: the Praktika job feeds it
-``Info().get_changed_files()``; standalone you can pipe ``git diff --name-only``.
+The input must cover *both* sides of renames: a rename out of a protected
+folder is an edit to it (a deletion), and only the source path falls under the
+protected prefix. ``Info().get_changed_files()``, which the Praktika job feeds
+in, includes rename sources; standalone, pipe ``git diff --name-only
+--no-renames`` (with rename detection disabled a rename is listed as a
+deletion plus an addition, so both paths appear).
 """
 
 import argparse

--- a/ci/jobs/scripts/docs/mintlify_docs_check.py
+++ b/ci/jobs/scripts/docs/mintlify_docs_check.py
@@ -10,9 +10,12 @@ Steps:
   1. Pull the docs image (``clickhouse/docs-builder`` by default).
   2. Shallow + sparse clone the aggregator docs repo (``docs`` and the docs CI
      scripts at ``ci/jobs/scripts/docs``).
-  3. Overlay one or more local folders onto it (e.g. drop the locally edited
-     Python client docs over ``integrations/language-clients/python``).
-  4. Run the checks inside the image against the overlaid docs.
+  3. Replace one or more folders in it with local folders (e.g. drop the
+     locally edited Python client docs over
+     ``integrations/language-clients/python``). The destination is wiped first,
+     so deletions and renames in the local source are reflected -- the docs sync
+     is one-way, so the checks see exactly what the next sync would produce.
+  4. Run the checks inside the image against the resulting docs.
 
 The check definitions live in ``DEFAULT_CHECKS`` so they are declared once and
 shared: this driver runs them via ``docker run``, while the Praktika job
@@ -61,15 +64,19 @@ def clone_aggregator(repo, ref, sparse, dest):
     run(["git", "-C", dest, "checkout", "FETCH_HEAD"], check=True)
 
 
-def overlay(src, dest, mirror):
+def replace(src, dest):
     src = os.path.abspath(src)
     if not os.path.isdir(src):
-        raise FileNotFoundError(f"Overlay source is not a directory: {src}")
-    print(f"Overlay {src} -> {dest} ({'mirror' if mirror else 'merge'})", flush=True)
-    if mirror and os.path.exists(dest):
+        raise FileNotFoundError(f"Replace source is not a directory: {src}")
+    print(f"Replace {dest} with {src}", flush=True)
+    # Wipe dest first: the docs sync is one-way (the consuming repo is the source
+    # of truth), so the checks must see exactly what the next sync produces. A
+    # merge would leave stale files from the cloned aggregator behind, hiding
+    # deletions and renames in the source repo.
+    if os.path.exists(dest):
         shutil.rmtree(dest)
     os.makedirs(os.path.dirname(dest) or ".", exist_ok=True)
-    shutil.copytree(src, dest, dirs_exist_ok=True)
+    shutil.copytree(src, dest)
 
 
 def check_in_image(image, mount_root, workdir, name, command):
@@ -96,9 +103,9 @@ def main(argv=None):
                         "plus ci/jobs/scripts/docs).")
     p.add_argument("--docs-root", default="docs",
                    help="Dir containing docs.json within the clone (default: docs).")
-    p.add_argument("--overlay", action="append", default=[], metavar="SRC:DEST[:mirror]",
-                   help="Overlay a local folder onto DEST (relative to docs root); "
-                        "repeatable.")
+    p.add_argument("--replace", action="append", default=[], metavar="SRC:DEST",
+                   help="Replace DEST (relative to docs root) with the local folder "
+                        "SRC, wiping DEST first; repeatable.")
     p.add_argument("--workdir", help="Where to clone (default: a temp dir).")
     args = p.parse_args(argv)
 
@@ -114,12 +121,11 @@ def main(argv=None):
     if not os.path.isfile(os.path.join(docs_root, "docs.json")):
         raise FileNotFoundError(f"No docs.json in docs root: {docs_root}")
 
-    for spec in args.overlay:
+    for spec in args.replace:
         parts = spec.split(":")
-        if len(parts) < 2:
-            raise ValueError(f"Invalid --overlay '{spec}'. Expected SRC:DEST[:mirror].")
-        mirror = len(parts) >= 3 and parts[2].lower() in ("1", "true", "mirror", "yes")
-        overlay(parts[0], os.path.join(docs_root, parts[1]), mirror)
+        if len(parts) != 2:
+            raise ValueError(f"Invalid --replace '{spec}'. Expected SRC:DEST.")
+        replace(parts[0], os.path.join(docs_root, parts[1]))
 
     results = [(name, check_in_image(args.image, clone_dir, args.docs_root, name, command))
                for name, command in DEFAULT_CHECKS]

--- a/ci/jobs/scripts/docs/mintlify_docs_check.py
+++ b/ci/jobs/scripts/docs/mintlify_docs_check.py
@@ -57,10 +57,19 @@ def run(cmd, **kw):
 
 
 def clone_aggregator(repo, ref, sparse, dest):
-    run(["git", "clone", "--filter=blob:none", "--no-checkout", repo, dest], check=True)
+    # Fetch only what the checks need: the tip of `ref` with no history
+    # (--depth 1), only the trees/blobs under the sparse paths (blob:none filter
+    # + sparse-checkout), and nothing else. `git clone` without --depth would
+    # download the aggregator's entire commit history -- enormous for a repo like
+    # ClickHouse -- so build the repo with `git init` + a single shallow fetch
+    # instead, which never materialises history or out-of-slice files.
+    run(["git", "init", "-q", dest], check=True)
+    run(["git", "-C", dest, "remote", "add", "origin", repo], check=True)
+    run(["git", "-C", dest, "config", "remote.origin.promisor", "true"], check=True)
+    run(["git", "-C", dest, "config", "remote.origin.partialclonefilter", "blob:none"], check=True)
     run(["git", "-C", dest, "sparse-checkout", "init", "--cone"], check=True)
     run(["git", "-C", dest, "sparse-checkout", "set", *sparse], check=True)
-    run(["git", "-C", dest, "fetch", "--depth", "1", "origin", ref], check=True)
+    run(["git", "-C", dest, "fetch", "--depth", "1", "--filter=blob:none", "origin", ref], check=True)
     run(["git", "-C", dest, "checkout", "FETCH_HEAD"], check=True)
 
 

--- a/ci/jobs/scripts/docs/mintlify_docs_check.py
+++ b/ci/jobs/scripts/docs/mintlify_docs_check.py
@@ -2,32 +2,32 @@
 """
 Run the Mintlify docs checks for a slice of a larger docs site.
 
-Self-contained: a consuming repo vendors only this file. The host needs
-``docker``, ``git`` and ``python3`` -- ``mint`` is provided by the docs image,
-never installed locally.
+Run this inside the docs image (``clickhouse/docs-builder``), which provides
+``mint`` along with ``git`` and ``python3``; nothing is installed locally. A
+consuming repo vendors nothing -- its CI runs the image as the job container,
+fetches this one file from the aggregator, and runs it.
 
 Steps:
-  1. Pull the docs image (``clickhouse/docs-builder`` by default).
-  2. Shallow + sparse clone the aggregator docs repo (``docs`` and the docs CI
-     scripts at ``ci/jobs/scripts/docs``).
-  3. Replace one or more folders in it with local folders (e.g. drop the
+  1. Shallow + sparse clone the aggregator docs repo (the docs root and the
+     docs CI scripts at ``ci/jobs/scripts/docs``).
+  2. Replace one or more folders in it with local folders (e.g. drop the
      locally edited Python client docs over
      ``integrations/language-clients/python``). The destination is wiped first,
      so deletions and renames in the local source are reflected -- the docs sync
      is one-way, so the checks see exactly what the next sync would produce.
-  4. Run the checks inside the image against the resulting docs.
+  3. Run the checks from the docs root against the resulting docs.
 
 The check definitions live in ``DEFAULT_CHECKS`` so they are declared once and
-shared: this driver runs them via ``docker run``, while the Praktika job
-(``ci/jobs/docs_job_mintlify.py``) imports the same list and runs them natively
-inside the container. Add a new check here and both pick it up.
+shared: this driver runs them directly, as does the Praktika job
+(``ci/jobs/docs_job_mintlify.py``), which imports the same list. Add a new check
+here and both pick it up.
 
-A check can be any shell command, including ``python3 <script>``. The clone
-root is mounted into the container and checks run from the docs root, so a
-Python check script committed at ``ci/jobs/scripts/docs`` is referenced relative
-to the docs root -- ``python3 ../ci/jobs/scripts/docs/foo.py`` -- which resolves
-identically here and in the Praktika job. A consuming repo therefore gets those
-scripts for free from the clone; it never needs to vendor them.
+A check can be any shell command, including ``python3 <script>``. Checks run
+from the docs root, so a Python check script committed at
+``ci/jobs/scripts/docs`` is referenced relative to the docs root --
+``python3 ../ci/jobs/scripts/docs/foo.py`` -- which resolves because the sparse
+clone includes that directory. A consuming repo therefore gets those scripts
+for free from the clone; it never needs to vendor them.
 """
 
 import argparse
@@ -38,9 +38,9 @@ import subprocess
 import sys
 import tempfile
 
-# The checks to run (name, shell command), executed from the docs root inside
-# the image. Kept here, independent of any CI framework, as the single source
-# of truth shared with the Praktika job.
+# The checks to run (name, shell command), executed from the docs root. Kept
+# here, independent of any CI framework, as the single source of truth shared
+# with the Praktika job.
 #
 # A command may invoke a Python check script committed at ci/jobs/scripts/docs,
 # referenced relative to the docs root, e.g.:
@@ -88,22 +88,17 @@ def replace(src, dest):
     shutil.copytree(src, dest)
 
 
-def check_in_image(image, mount_root, workdir, name, command):
-    # Mount the whole clone root (not just the docs root) so check commands can
-    # reach sibling CI scripts (e.g. ../ci/jobs/scripts/docs) the same way the
-    # native Praktika run does. Checks still run from the docs root.
+def run_check(docs_root, name, command):
+    # Checks run from the docs root. A command may reach a sibling CI script via
+    # the docs root (e.g. ../ci/jobs/scripts/docs/foo.py); that path resolves
+    # because the sparse clone includes ci/jobs/scripts/docs. `mint` and friends
+    # come from the docs image this script is expected to run inside.
     print(f"\n=== {name} ===", flush=True)
-    return run(
-        ["docker", "run", "--rm", "-v", f"{mount_root}:/work", "-w", f"/work/{workdir}",
-         image, "sh", "-lc", command]
-    ).returncode == 0
+    return run(["sh", "-lc", command], cwd=docs_root).returncode == 0
 
 
 def main(argv=None):
     p = argparse.ArgumentParser(description=__doc__)
-    p.add_argument("--image", default="clickhouse/docs-builder",
-                   help="Docker image providing mint (default: %(default)s).")
-    p.add_argument("--no-pull", action="store_true", help="Skip docker pull.")
     p.add_argument("--repo", required=True,
                    help="Aggregator docs repo to shallow/sparse clone.")
     p.add_argument("--ref", default="HEAD", help="Branch/tag/sha (default: HEAD).")
@@ -117,9 +112,6 @@ def main(argv=None):
                         "SRC, wiping DEST first; repeatable.")
     p.add_argument("--workdir", help="Where to clone (default: a temp dir).")
     args = p.parse_args(argv)
-
-    if not args.no_pull:
-        run(["docker", "pull", args.image], check=True)
 
     base = args.workdir or tempfile.mkdtemp(prefix="docs-check-")
     clone_dir = os.path.abspath(os.path.join(base, "aggregator"))
@@ -136,7 +128,7 @@ def main(argv=None):
             raise ValueError(f"Invalid --replace '{spec}'. Expected SRC:DEST.")
         replace(parts[0], os.path.join(docs_root, parts[1]))
 
-    results = [(name, check_in_image(args.image, clone_dir, args.docs_root, name, command))
+    results = [(name, run_check(docs_root, name, command))
                for name, command in DEFAULT_CHECKS]
 
     print("\n=== Summary ===", flush=True)

--- a/ci/jobs/scripts/docs/mintlify_docs_check.py
+++ b/ci/jobs/scripts/docs/mintlify_docs_check.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+Run the Mintlify docs checks for a slice of a larger docs site.
+
+Self-contained: a consuming repo vendors only this file. The host needs
+``docker``, ``git`` and ``python3`` -- ``mint`` is provided by the docs image,
+never installed locally.
+
+Steps:
+  1. Pull the docs image (``clickhouse/docs-builder`` by default).
+  2. Shallow + sparse clone the aggregator docs repo (``docs`` and the docs CI
+     scripts at ``ci/jobs/scripts/docs``).
+  3. Overlay one or more local folders onto it (e.g. drop the locally edited
+     Python client docs over ``integrations/language-clients/python``).
+  4. Run the checks inside the image against the overlaid docs.
+
+The check definitions live in ``DEFAULT_CHECKS`` so they are declared once and
+shared: this driver runs them via ``docker run``, while the Praktika job
+(``ci/jobs/docs_job_mintlify.py``) imports the same list and runs them natively
+inside the container. Add a new check here and both pick it up.
+
+A check can be any shell command, including ``python3 <script>``. The clone
+root is mounted into the container and checks run from the docs root, so a
+Python check script committed at ``ci/jobs/scripts/docs`` is referenced relative
+to the docs root -- ``python3 ../ci/jobs/scripts/docs/foo.py`` -- which resolves
+identically here and in the Praktika job. A consuming repo therefore gets those
+scripts for free from the clone; it never needs to vendor them.
+"""
+
+import argparse
+import os
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+
+# The checks to run (name, shell command), executed from the docs root inside
+# the image. Kept here, independent of any CI framework, as the single source
+# of truth shared with the Praktika job.
+#
+# A command may invoke a Python check script committed at ci/jobs/scripts/docs,
+# referenced relative to the docs root, e.g.:
+#     ("Frontmatter lint", "python3 ../ci/jobs/scripts/docs/frontmatter_lint.py ."),
+DEFAULT_CHECKS = [
+    ("Validate docs.json", "mint validate"),
+    ("Check for broken links", "mint broken-links"),
+]
+
+
+def run(cmd, **kw):
+    print("+ " + " ".join(shlex.quote(c) for c in cmd), flush=True)
+    return subprocess.run(cmd, **kw)
+
+
+def clone_aggregator(repo, ref, sparse, dest):
+    run(["git", "clone", "--filter=blob:none", "--no-checkout", repo, dest], check=True)
+    run(["git", "-C", dest, "sparse-checkout", "init", "--cone"], check=True)
+    run(["git", "-C", dest, "sparse-checkout", "set", *sparse], check=True)
+    run(["git", "-C", dest, "fetch", "--depth", "1", "origin", ref], check=True)
+    run(["git", "-C", dest, "checkout", "FETCH_HEAD"], check=True)
+
+
+def overlay(src, dest, mirror):
+    src = os.path.abspath(src)
+    if not os.path.isdir(src):
+        raise FileNotFoundError(f"Overlay source is not a directory: {src}")
+    print(f"Overlay {src} -> {dest} ({'mirror' if mirror else 'merge'})", flush=True)
+    if mirror and os.path.exists(dest):
+        shutil.rmtree(dest)
+    os.makedirs(os.path.dirname(dest) or ".", exist_ok=True)
+    shutil.copytree(src, dest, dirs_exist_ok=True)
+
+
+def check_in_image(image, mount_root, workdir, name, command):
+    # Mount the whole clone root (not just the docs root) so check commands can
+    # reach sibling CI scripts (e.g. ../ci/jobs/scripts/docs) the same way the
+    # native Praktika run does. Checks still run from the docs root.
+    print(f"\n=== {name} ===", flush=True)
+    return run(
+        ["docker", "run", "--rm", "-v", f"{mount_root}:/work", "-w", f"/work/{workdir}",
+         image, "sh", "-lc", command]
+    ).returncode == 0
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--image", default="clickhouse/docs-builder",
+                   help="Docker image providing mint (default: %(default)s).")
+    p.add_argument("--no-pull", action="store_true", help="Skip docker pull.")
+    p.add_argument("--repo", required=True,
+                   help="Aggregator docs repo to shallow/sparse clone.")
+    p.add_argument("--ref", default="HEAD", help="Branch/tag/sha (default: HEAD).")
+    p.add_argument("--sparse", action="append", default=None,
+                   help="Sparse-checkout path (repeatable; default: the docs root "
+                        "plus ci/jobs/scripts/docs).")
+    p.add_argument("--docs-root", default="docs",
+                   help="Dir containing docs.json within the clone (default: docs).")
+    p.add_argument("--overlay", action="append", default=[], metavar="SRC:DEST[:mirror]",
+                   help="Overlay a local folder onto DEST (relative to docs root); "
+                        "repeatable.")
+    p.add_argument("--workdir", help="Where to clone (default: a temp dir).")
+    args = p.parse_args(argv)
+
+    if not args.no_pull:
+        run(["docker", "pull", args.image], check=True)
+
+    base = args.workdir or tempfile.mkdtemp(prefix="docs-check-")
+    clone_dir = os.path.abspath(os.path.join(base, "aggregator"))
+    sparse = args.sparse or [args.docs_root, "ci/jobs/scripts/docs"]
+    clone_aggregator(args.repo, args.ref, sparse, clone_dir)
+
+    docs_root = os.path.join(clone_dir, args.docs_root)
+    if not os.path.isfile(os.path.join(docs_root, "docs.json")):
+        raise FileNotFoundError(f"No docs.json in docs root: {docs_root}")
+
+    for spec in args.overlay:
+        parts = spec.split(":")
+        if len(parts) < 2:
+            raise ValueError(f"Invalid --overlay '{spec}'. Expected SRC:DEST[:mirror].")
+        mirror = len(parts) >= 3 and parts[2].lower() in ("1", "true", "mirror", "yes")
+        overlay(parts[0], os.path.join(docs_root, parts[1]), mirror)
+
+    results = [(name, check_in_image(args.image, clone_dir, args.docs_root, name, command))
+               for name, command in DEFAULT_CHECKS]
+
+    print("\n=== Summary ===", flush=True)
+    for name, ok in results:
+        print(f"[{'PASS' if ok else 'FAIL'}] {name}", flush=True)
+    return 0 if all(ok for _, ok in results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/jobs/scripts/docs/mintlify_docs_check.py
+++ b/ci/jobs/scripts/docs/mintlify_docs_check.py
@@ -88,6 +88,26 @@ def replace(src, dest):
     shutil.copytree(src, dest)
 
 
+def resolve_replace_dest(docs_root, dest):
+    # `replace` wipes its destination with rmtree, so a DEST that escapes the
+    # cloned docs tree (absolute, `..`, or a symlink pointing out) would delete
+    # an unrelated directory on the host. Resolve it against the docs root and
+    # refuse anything that lands outside, including the docs root itself.
+    if not dest or os.path.isabs(dest):
+        raise ValueError(
+            f"--replace destination must be a relative path inside the docs "
+            f"root: '{dest}'"
+        )
+    root = os.path.realpath(docs_root)
+    resolved = os.path.realpath(os.path.join(root, dest))
+    if not resolved.startswith(root + os.sep):
+        raise ValueError(
+            f"--replace destination '{dest}' resolves to '{resolved}', "
+            f"outside the docs root '{root}'"
+        )
+    return resolved
+
+
 def run_check(docs_root, name, command):
     # Checks run from the docs root. A command may reach a sibling CI script via
     # the docs root (e.g. ../ci/jobs/scripts/docs/foo.py); that path resolves
@@ -126,7 +146,7 @@ def main(argv=None):
         parts = spec.split(":")
         if len(parts) != 2:
             raise ValueError(f"Invalid --replace '{spec}'. Expected SRC:DEST.")
-        replace(parts[0], os.path.join(docs_root, parts[1]))
+        replace(parts[0], resolve_replace_dest(docs_root, parts[1]))
 
     results = [(name, run_check(docs_root, name, command))
                for name, command in DEFAULT_CHECKS]

--- a/ci/jobs/scripts/docs/readonly_copies.json
+++ b/ci/jobs/scripts/docs/readonly_copies.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Docs folders in this repo that are one-way copies of a canonical source living in another repository. Editing them here is overwritten by the next sync; the readonly-copies guard fails such edits and points contributors at the source. 'path' is repo-relative (as it appears in the PR diff).",
+  "sources": [
+    {
+      "path": "docs/integrations/language-clients/python",
+      "repo": "ClickHouse/clickhouse-connect",
+      "url": "https://github.com/ClickHouse/clickhouse-connect",
+      "subdir": "docs"
+    }
+  ]
+}

--- a/ci/praktika/gh.py
+++ b/ci/praktika/gh.py
@@ -83,20 +83,32 @@ class GH:
         assert repo_name
         print(repo_name)
 
+        # Include both sides of renames: .filename is the destination path and
+        # .previous_filename (REST API only, absent for non-renames) is the
+        # source path. Without the source path a rename out of a watched
+        # directory is invisible to consumers such as job filtering and the
+        # read-only docs guard. Rename sources do not exist in the checkout at
+        # HEAD, same as deleted files, which were always included.
+        jq_both_sides = ".filename, (.previous_filename // empty)"
+
         for attempt in range(3):
             # store changed files
             if info.pr_number > 0:
                 exit_code, changed_files_str, err = Shell.get_res_stdout_stderr(
-                    f"gh pr view {info.pr_number} --repo {repo_name} --json files --jq '.files[].path'",
+                    f"gh api repos/{repo_name}/pulls/{info.pr_number}/files --paginate --jq '.[] | {jq_both_sides}'",
                 )
                 assert exit_code == 0, "Failed to retrieve changed files list"
             else:
                 exit_code, changed_files_str, err = Shell.get_res_stdout_stderr(
-                    f"gh api repos/{repo_name}/commits/{sha} | jq -r '.files[].filename'",
+                    f"gh api repos/{repo_name}/commits/{sha} --jq '.files[] | {jq_both_sides}'",
                 )
 
             if exit_code == 0:
-                res = changed_files_str.split("\n") if changed_files_str else []
+                res = (
+                    list(dict.fromkeys(changed_files_str.split("\n")))
+                    if changed_files_str
+                    else []
+                )
                 break
             else:
                 print(


### PR DESCRIPTION
Structures the Mintlify docs check such that it can be easily run standalone without Praktika in other repos. The motivation for this is to enable us to easily run the same Mintlify docs checks that will run in this repo in any of the language client repositories.

**Context**

Our integrations team would like to keep docs close to the source code so they can make docs updates alongside code changes. Currently the docs are kept in clickhouse-docs repo and it's necessary to context switch to make docs updates.

With the Mintlify migration, beginning with clickhouse-connect: https://github.com/ClickHouse/clickhouse-connect/pull/768, we will move language client docs back into their own repositories.

1. Language client docs live in the local repo
2. As part of the language client CI we will run the docs check via https://github.com/ClickHouse/clickhouse-connect/pull/778
  - Runs the check using the `docs_builder` image
  - Shallows clones the docs and any necessary scripts from ClickHouse/ClickHouse
  - Unifies the local docs together with the complete docs
  - Runs the docs check
3. If all checks pass, then the PR merges
4. GitHub version releases of the language client will trigger a workflow which will make a versioned copy in this repo for publication

We want the sync to be unidirectional, so there is a check added to this repository to fail the docs check with an error message pointing to the canonical source if someone tries to make the updates to the copies in ClickHouse/ClickHouse docs folder.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.597`
<!-- ch-version-info:end -->