### PR TITLE
Fix abort on malformed uniqTheta state in ThetaSketchData::read

### DIFF
--- a/src/AggregateFunctions/ThetaSketchData.h
+++ b/src/AggregateFunctions/ThetaSketchData.h
@@ -187,6 +187,12 @@ public:
         {
             throw;
         }
+        catch (const std::bad_alloc &)
+        {
+            /// Memory pressure on `compact_theta_sketch::deserialize`, `getSkUnion`,
+            /// or `theta_union.update` is not data corruption; let it propagate.
+            throw;
+        }
         catch (const std::exception & e)
         {
             /// `datasketches` throws `std::invalid_argument` / `std::out_of_range` on

--- a/src/AggregateFunctions/ThetaSketchData.h
+++ b/src/AggregateFunctions/ThetaSketchData.h
@@ -11,9 +11,16 @@
 #include <theta_intersection.hpp>
 #include <theta_a_not_b.hpp>
 
+#include <Common/Exception.h>
+
 
 namespace DB
 {
+
+namespace ErrorCodes
+{
+    extern const int CORRUPTED_DATA;
+}
 
 
 template <typename Key>
@@ -168,10 +175,30 @@ public:
     {
         datasketches::compact_theta_sketch::vector_bytes bytes;
         readVectorBinary(bytes, in);
-        if (!bytes.empty())
+        if (bytes.empty())
+            return;
+
+        try
         {
             auto sk = datasketches::compact_theta_sketch::deserialize(bytes.data(), bytes.size());
             getSkUnion()->update(sk);
+        }
+        catch (const DB::Exception &)
+        {
+            throw;
+        }
+        catch (const std::exception & e)
+        {
+            /// `datasketches` throws `std::invalid_argument` / `std::out_of_range` on
+            /// malformed input. These are not `DB::Exception`, so without translation
+            /// they escape `SerializationAggregateFunction`'s `catch (...)` block, reach
+            /// the top level as `LOGICAL_ERROR` (code 1001), and abort the process via
+            /// `abortOnFailedAssertion`. Translate to `CORRUPTED_DATA` so the bad input
+            /// is rejected cleanly.
+            throw Exception(
+                ErrorCodes::CORRUPTED_DATA,
+                "Cannot deserialize Theta sketch state: {}",
+                e.what());
         }
     }
 

--- a/tests/queries/0_stateless/04307_uniqTheta_corrupted_state_106259.reference
+++ b/tests/queries/0_stateless/04307_uniqTheta_corrupted_state_106259.reference
@@ -1,0 +1,2 @@
+OK rowbinary
+OK param

--- a/tests/queries/0_stateless/04307_uniqTheta_corrupted_state_106259.sh
+++ b/tests/queries/0_stateless/04307_uniqTheta_corrupted_state_106259.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# no-fasttest -- compiled w/o datasketches
+
+# Regression test for https://github.com/ClickHouse/ClickHouse/issues/106259
+#
+# Deserializing a malformed `AggregateFunction(uniqTheta, ...)` state used to
+# trigger a `std::out_of_range` / `std::invalid_argument` from the
+# `datasketches` library. Those are not `DB::Exception`, so they escaped
+# `SerializationAggregateFunction`'s `catch (...)` block and were treated as
+# `LOGICAL_ERROR` (code 1001) at the top level, aborting the process via
+# `abortOnFailedAssertion`. The fix in `ThetaSketchData::read` translates the
+# bare `std::exception` from the third-party library into
+# `DB::Exception(CORRUPTED_DATA)` so the bad input is rejected cleanly.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+# RowBinary path. The 24 bytes encode one row: first byte 0x03 is a varint
+# saying the sketch payload is 3 bytes long, which is shorter than the Theta
+# sketch minimum, so `check_memory_size` throws `std::out_of_range` from inside
+# `datasketches::compact_theta_sketch::deserialize`. Before the fix this
+# aborted with SIGABRT (exit 134); after the fix it must produce
+# `CORRUPTED_DATA`.
+printf '\x03\x03\x03\x30\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' \
+    | $CLICKHOUSE_LOCAL --input-format=RowBinary \
+        --structure='x AggregateFunction(uniqTheta, IPv6)' \
+        --query='SELECT x FROM table' 2>&1 \
+    | grep -q -F 'CORRUPTED_DATA' && echo 'OK rowbinary' || echo 'FAIL rowbinary'
+
+# Query-parameter path: deserialised via `deserializeTextEscaped` rather than
+# `deserializeBinary`, but the eventual call into `ThetaSketchData::read` is
+# the same. This is the original fuzzer-found code path.
+$CLICKHOUSE_LOCAL \
+    --param_p=$'\x03\x03\x03\x30\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' \
+    --query='SELECT count() FROM numbers(1) WHERE {p:AggregateFunction(uniqTheta, IPv6)} IS NOT NULL' \
+    2>&1 \
+    | grep -q -F 'CORRUPTED_DATA' && echo 'OK param' || echo 'FAIL param'


### PR DESCRIPTION
The `datasketches` library throws `std::out_of_range` / `std::invalid_argument` when deserialising malformed Theta sketch bytes. Those are not `DB::Exception`, so they escape `SerializationAggregateFunction`'s `catch (...)` block (which rethrows by type) and `ReplaceQueryParameterVisitor` (`catch (Exception &)`). At the top level a bare `std::logic_error` subclass triggers an unconditional `abortOnFailedAssertion` and `SIGABRT`, in both debug and release builds.

Wrap the `datasketches::compact_theta_sketch::deserialize` call at the library boundary in `ThetaSketchData::read` with a `try` / `catch` block that rethrows `DB::Exception` unchanged and translates bare `std::exception` to `DB::Exception(CORRUPTED_DATA)`. Both the `RowBinary` `deserializeBinary` path and the query-parameter `deserializeTextEscaped` path go through this `read`, so a single boundary catches both fuzzer-found code paths.

Adds stateless regression test `04307_uniqTheta_corrupted_state_106259` covering both code paths with the 24-byte payload from the issue.

Closes #106259

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed an abort when deserialising a malformed `AggregateFunction(uniqTheta, ...)` state from `RowBinary` input or a query parameter. The bad input is now rejected with `CORRUPTED_DATA` instead of escaping as a `std::exception` and aborting the process via `abortOnFailedAssertion`.


### Documentation entry for user-facing changes
- [x] Documentation is not required: the change only converts an internal abort into a user-facing exception.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.495`
<!-- ch-version-info:end -->