### PR TITLE
ci: set least-privilege permissions on workflow token

### DIFF
--- a/.github/workflows/backfill_distroless.yml
+++ b/.github/workflows/backfill_distroless.yml
@@ -19,6 +19,9 @@ concurrency:
 env:
   PYTHONUNBUFFERED: 1
 
+permissions:
+  contents: read
+
 jobs:
   BackfillDistroless:
     runs-on: [self-hosted, release-maker]

--- a/.github/workflows/cherry_pick.yml
+++ b/.github/workflows/cherry_pick.yml
@@ -11,6 +11,9 @@ on: # yamllint disable-line rule:truthy
     - cron: '0 * * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   CherryPick:
     runs-on: [self-hosted, style-checker-aarch64]

--- a/.github/workflows/nightly_coverage.yml
+++ b/.github/workflows/nightly_coverage.yml
@@ -14,6 +14,9 @@ env:
   CHECKOUT_REF: ""
 
 
+permissions:
+  contents: read
+
 jobs:
 
   config_workflow:

--- a/.github/workflows/nightly_fuzzers.yml
+++ b/.github/workflows/nightly_fuzzers.yml
@@ -14,6 +14,9 @@ env:
   CHECKOUT_REF: ""
 
 
+permissions:
+  contents: read
+
 jobs:
 
   config_workflow:


### PR DESCRIPTION
I work on software supply chain security and have been hardening GitHub Actions workflows across OSS projects.

Each of these workflows runs without a top-level `permissions:` block, so its `GITHUB_TOKEN` inherits the repository (or org) default, which is frequently read/write for all scopes. This PR sets `permissions: contents: read` at the workflow level for `.github/workflows/backfill_distroless.yml`, `.github/workflows/cherry_pick.yml`, `.github/workflows/nightly_coverage.yml`, `.github/workflows/nightly_fuzzers.yml`, which is all these jobs need (checkout plus the build/test steps). Scoping the token to read-only shrinks what a compromised step or dependency can do, a concern made concrete by the March 2025 `tj-actions/changed-files` compromise (CVE-2025-30066), where a leaked write-scoped `GITHUB_TOKEN` was the blast radius.

No job behavior changes; the steps already only read the repository.