### PR TITLE
Fix .null subcolumn extraction from Nullable(JSON) returning nullmap

### DIFF
--- a/src/DataTypes/IDataType.cpp
+++ b/src/DataTypes/IDataType.cpp
@@ -138,14 +138,13 @@ void IDataType::forEachSubcolumn(
             {
                 auto name = ISerialization::getSubcolumnNameForStream(subpath, prefix_len);
 
-                /// Skip the outer `Nullable` null-map static subcolumn (named `null`)
-                /// only when the IMMEDIATE inner type is a direct dynamic carrier
-                /// (`JSON` / `Dynamic`) that owns the colliding name as a dynamic key.
-                /// Do NOT skip for delegating types like `Array` or `Map` where the
-                /// dynamic resolution would only succeed via delegation: the user-visible
-                /// `Nullable(Array(JSON)).null` must still return the outer null-map.
-                /// The outer null-map remains reachable via `isNull(x)` / `x IS NULL`.
+                /// Skip the outer `Nullable` null-map subcolumn (literal name `null`)
+                /// when the inner type is `JSON` / `Dynamic` and owns the same name
+                /// as a dynamic key. `name == "null"` keeps typed-path null-maps
+                /// (e.g. `c.null`) enumerating normally; the direct-carrier check
+                /// keeps `Nullable(Array(JSON)).null` returning the outer null-map.
                 if (subpath[i].type == ISerialization::Substream::NullMap
+                    && name == "null"
                     && data.type
                     && data.type->isNullable())
                 {

--- a/src/DataTypes/IDataType.cpp
+++ b/src/DataTypes/IDataType.cpp
@@ -13,6 +13,7 @@
 
 #include <DataTypes/IDataType.h>
 #include <DataTypes/DataTypeCustom.h>
+#include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/NestedUtils.h>
 #include <DataTypes/Serializations/SerializationSparse.h>
 #include <DataTypes/Serializations/SerializationReplicated.h>
@@ -138,21 +139,23 @@ void IDataType::forEachSubcolumn(
                 auto name = ISerialization::getSubcolumnNameForStream(subpath, prefix_len);
 
                 /// Skip the outer `Nullable` null-map static subcolumn (named `null`)
-                /// when the inner type can resolve the same name as a dynamic subcolumn
-                /// (e.g. `Nullable(JSON)` with a JSON key literally named `null`). In
-                /// that case `getSubcolumnData` returns the JSON value, but if we still
-                /// register the static UInt8 null-map subcolumn here, the planner picks
-                /// it up first (it has priority over dynamic) and the storage's column
-                /// extraction returns the JSON-key value — a type mismatch. The outer
-                /// null-map remains reachable via `isNull(x)` / `x IS NULL`.
+                /// only when the IMMEDIATE inner type is a direct dynamic carrier
+                /// (`JSON` / `Dynamic`) that owns the colliding name as a dynamic key.
+                /// Do NOT skip for delegating types like `Array` or `Map` where the
+                /// dynamic resolution would only succeed via delegation: the user-visible
+                /// `Nullable(Array(JSON)).null` must still return the outer null-map.
+                /// The outer null-map remains reachable via `isNull(x)` / `x IS NULL`.
                 if (subpath[i].type == ISerialization::Substream::NullMap
                     && data.type
-                    && data.type->isNullable()
-                    && data.type->hasDynamicSubcolumnsData()
-                    && data.type->getDynamicSubcolumnData(name, data, /*initial_array_level=*/0, /*throw_if_null=*/false))
+                    && data.type->isNullable())
                 {
-                    subpath[i].visited = true;
-                    continue;
+                    const auto & inner = assert_cast<const DataTypeNullable &>(*data.type).getNestedType();
+                    if (inner && (isObject(inner) || isDynamic(inner))
+                        && data.type->getDynamicSubcolumnData(name, data, /*initial_array_level=*/0, /*throw_if_null=*/false))
+                    {
+                        subpath[i].visited = true;
+                        continue;
+                    }
                 }
 
                 auto subdata = ISerialization::createFromPath(subpath, prefix_len);
@@ -176,20 +179,25 @@ std::unique_ptr<IDataType::SubstreamData> IDataType::getSubcolumnData(
     size_t initial_array_level,
     bool throw_if_null)
 {
-    /// When `data.type` is `Nullable(T)` and `T` has dynamic subcolumns (e.g. `JSON`),
-    /// the `Nullable` serialization registers a `null` substream (the null-map of the
-    /// outer `Nullable`) that would otherwise shadow a `null` key inside `T`. So a
-    /// query like `SELECT data.null FROM t (data Nullable(JSON))` would return the
-    /// outer null-map byte instead of the `JSON` value at key `null`. Try the inner
-    /// type's dynamic resolution first; if it can resolve the requested name, return
-    /// that result (wrapped via `NullableSubcolumnCreator` so outer-row nulls still
-    /// propagate). The outer null-map is still reachable via `data IS NULL` /
-    /// `isNull(data)`. This is a no-op for `Nullable(T)` where `T` has no dynamic
-    /// subcolumns (e.g. `Nullable(Int32).null` still returns the null-map).
-    if (data.type->isNullable() && data.type->hasDynamicSubcolumnsData())
+    /// When `data.type` is `Nullable(T)` and `T` is a direct dynamic carrier (`JSON`
+    /// or `Dynamic`), the `Nullable` serialization registers a `null` substream (the
+    /// null-map of the outer `Nullable`) that would otherwise shadow a `null` key
+    /// inside `T`. So `SELECT data.null FROM t (data Nullable(JSON))` would return
+    /// the outer null-map byte instead of the `JSON` value at key `null`. Try the
+    /// inner type's dynamic resolution first; if it can resolve the requested name,
+    /// return that result (wrapped via `NullableSubcolumnCreator` so outer-row nulls
+    /// still propagate). The outer null-map is still reachable via `data IS NULL` /
+    /// `isNull(data)`. Restricted to direct dynamic carriers so delegating wrappers
+    /// (e.g. `Nullable(Array(JSON)).null`, `Nullable(Map(K, JSON)).null`) still return
+    /// the outer null-map. No-op when `T` has no dynamic subcolumns at all.
+    if (data.type->isNullable())
     {
-        if (auto dynamic_res = data.type->getDynamicSubcolumnData(subcolumn_name, data, initial_array_level, /*throw_if_null=*/false))
-            return dynamic_res;
+        const auto & inner = assert_cast<const DataTypeNullable &>(*data.type).getNestedType();
+        if (inner && (isObject(inner) || isDynamic(inner)))
+        {
+            if (auto dynamic_res = data.type->getDynamicSubcolumnData(subcolumn_name, data, initial_array_level, /*throw_if_null=*/false))
+                return dynamic_res;
+        }
     }
 
     std::unique_ptr<IDataType::SubstreamData> res;

--- a/src/DataTypes/IDataType.cpp
+++ b/src/DataTypes/IDataType.cpp
@@ -136,6 +136,25 @@ void IDataType::forEachSubcolumn(
             if (!subpath[i].visited && ISerialization::hasSubcolumnForPath(subpath, prefix_len))
             {
                 auto name = ISerialization::getSubcolumnNameForStream(subpath, prefix_len);
+
+                /// Skip the outer `Nullable` null-map static subcolumn (named `null`)
+                /// when the inner type can resolve the same name as a dynamic subcolumn
+                /// (e.g. `Nullable(JSON)` with a JSON key literally named `null`). In
+                /// that case `getSubcolumnData` returns the JSON value, but if we still
+                /// register the static UInt8 null-map subcolumn here, the planner picks
+                /// it up first (it has priority over dynamic) and the storage's column
+                /// extraction returns the JSON-key value — a type mismatch. The outer
+                /// null-map remains reachable via `isNull(x)` / `x IS NULL`.
+                if (subpath[i].type == ISerialization::Substream::NullMap
+                    && data.type
+                    && data.type->isNullable()
+                    && data.type->hasDynamicSubcolumnsData()
+                    && data.type->getDynamicSubcolumnData(name, data, /*initial_array_level=*/0, /*throw_if_null=*/false))
+                {
+                    subpath[i].visited = true;
+                    continue;
+                }
+
                 auto subdata = ISerialization::createFromPath(subpath, prefix_len);
                 auto path_copy = subpath;
                 path_copy.resize(prefix_len);
@@ -157,6 +176,22 @@ std::unique_ptr<IDataType::SubstreamData> IDataType::getSubcolumnData(
     size_t initial_array_level,
     bool throw_if_null)
 {
+    /// When `data.type` is `Nullable(T)` and `T` has dynamic subcolumns (e.g. `JSON`),
+    /// the `Nullable` serialization registers a `null` substream (the null-map of the
+    /// outer `Nullable`) that would otherwise shadow a `null` key inside `T`. So a
+    /// query like `SELECT data.null FROM t (data Nullable(JSON))` would return the
+    /// outer null-map byte instead of the `JSON` value at key `null`. Try the inner
+    /// type's dynamic resolution first; if it can resolve the requested name, return
+    /// that result (wrapped via `NullableSubcolumnCreator` so outer-row nulls still
+    /// propagate). The outer null-map is still reachable via `data IS NULL` /
+    /// `isNull(data)`. This is a no-op for `Nullable(T)` where `T` has no dynamic
+    /// subcolumns (e.g. `Nullable(Int32).null` still returns the null-map).
+    if (data.type->isNullable() && data.type->hasDynamicSubcolumnsData())
+    {
+        if (auto dynamic_res = data.type->getDynamicSubcolumnData(subcolumn_name, data, initial_array_level, /*throw_if_null=*/false))
+            return dynamic_res;
+    }
+
     std::unique_ptr<IDataType::SubstreamData> res;
     /// Track whether res was set by an exact name match, so that exact matches
     /// always take priority over prefix (dynamic subcolumn) matches.

--- a/tests/queries/0_stateless/04306_106085_nullable_json_null_subcolumn.reference
+++ b/tests/queries/0_stateless/04306_106085_nullable_json_null_subcolumn.reference
@@ -1,0 +1,12 @@
+nullable_json_null:	1	xx	Dynamic
+nullable_json_null:	2	yy	Dynamic
+nullable_json_null:	3	\N	Dynamic
+nullable_json_foo:	1	\N	Dynamic
+nullable_json_foo:	2	bar	Dynamic
+nullable_json_foo:	3	\N	Dynamic
+isNull:	1	0	0
+isNull:	2	0	0
+isNull:	3	1	1
+plain_json_null:	xx	Dynamic
+nullable_int_null:	\N	1	UInt8
+nullable_int_null:	42	0	UInt8

--- a/tests/queries/0_stateless/04306_106085_nullable_json_null_subcolumn.reference
+++ b/tests/queries/0_stateless/04306_106085_nullable_json_null_subcolumn.reference
@@ -10,3 +10,14 @@ isNull:	3	1	1
 plain_json_null:	xx	Dynamic
 nullable_int_null:	\N	1	UInt8
 nullable_int_null:	42	0	UInt8
+typed_path_c:	1	42	Nullable(UInt32)
+typed_path_c:	2	\N	Nullable(UInt32)
+typed_path_c:	3	\N	Nullable(UInt32)
+typed_path_c_null:	1	0	Nullable(UInt8)
+typed_path_c_null:	2	1	Nullable(UInt8)
+typed_path_c_null:	3	\N	Nullable(UInt8)
+describe_typed:
+id	UInt32						0
+data	Nullable(JSON(c Nullable(UInt32)))						0
+data.c	Nullable(UInt32)						1
+data.c.null	Nullable(UInt8)						1

--- a/tests/queries/0_stateless/04306_106085_nullable_json_null_subcolumn.sql
+++ b/tests/queries/0_stateless/04306_106085_nullable_json_null_subcolumn.sql
@@ -42,6 +42,14 @@ CREATE TABLE t_106085_int (data Nullable(Int32)) ENGINE = Memory;
 INSERT INTO t_106085_int VALUES (NULL), (42);
 SELECT 'nullable_int_null:', data, data.null, toTypeName(data.null) FROM t_106085_int ORDER BY data NULLS FIRST SETTINGS allow_suspicious_types_in_order_by = 0;
 
+-- The precedence rewrite in `IDataType::getSubcolumnData` is restricted to direct
+-- dynamic carriers (`JSON` / `Dynamic`) wrapped by `Nullable`. The type system also
+-- rejects `Nullable(Array(JSON))` / `Nullable(Map(K, JSON))` at construction time,
+-- so no SQL-reachable column can hit the over-broad branch; assert this here so
+-- the narrow contract stays meaningful if the type rules change.
+CREATE TABLE t_106085_reject_array (data Nullable(Array(JSON))) ENGINE = Memory; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+CREATE TABLE t_106085_reject_map (data Nullable(Map(String, JSON))) ENGINE = Memory; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+
 DROP TABLE t_106085;
 DROP TABLE t_106085_plain;
 DROP TABLE t_106085_int;

--- a/tests/queries/0_stateless/04306_106085_nullable_json_null_subcolumn.sql
+++ b/tests/queries/0_stateless/04306_106085_nullable_json_null_subcolumn.sql
@@ -50,6 +50,31 @@ SELECT 'nullable_int_null:', data, data.null, toTypeName(data.null) FROM t_10608
 CREATE TABLE t_106085_reject_array (data Nullable(Array(JSON))) ENGINE = Memory; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 CREATE TABLE t_106085_reject_map (data Nullable(Map(String, JSON))) ENGINE = Memory; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
 
+-- The `forEachSubcolumn` skip applies only when the substream name is literally
+-- `"null"` (the outer Nullable null-map). A typed-path null-map inside `JSON`
+-- is named `"<path>.null"` and must still enumerate as a regular subcolumn,
+-- otherwise lookup (`tryGetSubcolumnType` -> `getSubcolumnData`) and enumeration
+-- (`forEachSubcolumn` -> `DESCRIBE TABLE ... describe_include_subcolumns = 1`,
+-- `system.columns`) diverge for the same name.
+DROP TABLE IF EXISTS t_106085_typed;
+CREATE TABLE t_106085_typed (id UInt32, data Nullable(JSON(c Nullable(UInt32)))) ENGINE = Memory;
+INSERT INTO t_106085_typed VALUES (1, '{"c": 42}'), (2, '{"c": null}'), (3, NULL);
+
+-- Lookup: `data.c` is the typed `Nullable(UInt32)` path; `data.c.null` is its
+-- inner UInt8 null-map (1 when the typed path value is null OR when the outer
+-- Nullable row is null, 0 when the typed path holds a value).
+SELECT 'typed_path_c:', id, data.c, toTypeName(data.c) FROM t_106085_typed ORDER BY id;
+SELECT 'typed_path_c_null:', id, data.c.null, toTypeName(data.c.null) FROM t_106085_typed ORDER BY id;
+
+-- Enumeration: the typed-path null-map must show up in `DESCRIBE TABLE ...
+-- describe_include_subcolumns = 1` next to the typed path itself. Without the
+-- `name == "null"` predicate the enumeration would also skip `c.null` (dynamic
+-- JSON path can resolve it), so it would be absent from the description while
+-- the lookup still finds it.
+SELECT 'describe_typed:';
+DESCRIBE TABLE t_106085_typed SETTINGS describe_include_subcolumns = 1 FORMAT TSVRaw;
+
 DROP TABLE t_106085;
 DROP TABLE t_106085_plain;
 DROP TABLE t_106085_int;
+DROP TABLE t_106085_typed;

--- a/tests/queries/0_stateless/04306_106085_nullable_json_null_subcolumn.sql
+++ b/tests/queries/0_stateless/04306_106085_nullable_json_null_subcolumn.sql
@@ -1,0 +1,47 @@
+-- Tags: no-fasttest
+-- ^ JSON data type is not enabled in fast-test image.
+--
+-- Regression test for https://github.com/ClickHouse/ClickHouse/issues/106085 :
+-- reading the `.null` subcolumn from a `Nullable(JSON)` column returned the
+-- outer Nullable's null-map byte instead of the value at the JSON key `null`.
+-- The outer null-map of `Nullable(T)` registers a substream literally named
+-- `null`, which shadows any `null` key inside the inner type `T` when `T` has
+-- dynamic subcolumns (`JSON`). The fix is in `IDataType::getSubcolumnData`:
+-- when `data.type` is `Nullable` and the inner type has dynamic subcolumns,
+-- try the inner type's dynamic resolution first. The outer null-map remains
+-- reachable via `isNull(data)` / `data IS NULL`.
+
+SET enable_json_type = 1;
+SET allow_suspicious_types_in_order_by = 1;
+
+DROP TABLE IF EXISTS t_106085;
+CREATE TABLE t_106085 (id UInt32, data Nullable(JSON)) ENGINE = Memory;
+INSERT INTO t_106085 VALUES (1, '{"null":"xx"}'), (2, '{"foo":"bar","null":"yy"}'), (3, NULL);
+
+-- Bug case: `.null` previously returned the outer null-map byte (0 / UInt8).
+-- After the fix it returns the JSON value at key `null` wrapped in `Nullable`,
+-- and NULL for rows where the outer Nullable is NULL.
+SELECT 'nullable_json_null:', id, data.null, toTypeName(data.null) FROM t_106085 ORDER BY id;
+
+-- Other keys must keep working as before.
+SELECT 'nullable_json_foo:', id, data.foo, toTypeName(data.foo) FROM t_106085 ORDER BY id;
+
+-- Outer-row NULL state is still reachable via the standard ClickHouse pattern.
+SELECT 'isNull:', id, isNull(data), data IS NULL FROM t_106085 ORDER BY id;
+
+-- Sanity: plain `JSON` (no `Nullable` wrapper) was never affected by the bug.
+DROP TABLE IF EXISTS t_106085_plain;
+CREATE TABLE t_106085_plain (data JSON) ENGINE = Memory;
+INSERT INTO t_106085_plain VALUES ('{"null":"xx"}');
+SELECT 'plain_json_null:', data.null, toTypeName(data.null) FROM t_106085_plain;
+
+-- Sanity: `Nullable(T)` for non-dynamic `T` must keep returning the null-map
+-- under `.null` (e.g. `Nullable(Int32).null` is the UInt8 null-map column).
+DROP TABLE IF EXISTS t_106085_int;
+CREATE TABLE t_106085_int (data Nullable(Int32)) ENGINE = Memory;
+INSERT INTO t_106085_int VALUES (NULL), (42);
+SELECT 'nullable_int_null:', data, data.null, toTypeName(data.null) FROM t_106085_int ORDER BY data NULLS FIRST SETTINGS allow_suspicious_types_in_order_by = 0;
+
+DROP TABLE t_106085;
+DROP TABLE t_106085_plain;
+DROP TABLE t_106085_int;

--- a/tests/queries/0_stateless/04308_nullable_json_optimizer_tradeoff.reference
+++ b/tests/queries/0_stateless/04308_nullable_json_optimizer_tradeoff.reference
@@ -1,0 +1,13 @@
+int:count	2
+int:isNull	1
+int:isNotNull	2
+int:count_rewritten	1
+int:isNull_rewritten	1
+int:isNotNull_rewritten	1
+json:count	2
+json:isNull	1
+json:isNotNull	2
+json:count_not_rewritten	1
+json:isNull_not_rewritten	1
+json:isNotNull_not_rewritten	1
+json:data.null_returns_json_value	xx

--- a/tests/queries/0_stateless/04308_nullable_json_optimizer_tradeoff.sql
+++ b/tests/queries/0_stateless/04308_nullable_json_optimizer_tradeoff.sql
@@ -1,5 +1,7 @@
--- Tags: no-fasttest
--- ^ JSON data type is not enabled in fast-test image.
+-- Tags: no-fasttest, no-old-analyzer
+-- ^ JSON data type is not enabled in fast-test image; `FunctionToSubcolumnsPass`
+--   is a new-analyzer pass with no old-analyzer equivalent, so the A2 rewrite
+--   assertions cannot fire under the old analyzer (EXPLAIN reads `data` directly).
 --
 -- Companion test for https://github.com/ClickHouse/ClickHouse/issues/106085 fix
 -- in `IDataType::forEachSubcolumn`. The fix hides the static `.null` substream

--- a/tests/queries/0_stateless/04308_nullable_json_optimizer_tradeoff.sql
+++ b/tests/queries/0_stateless/04308_nullable_json_optimizer_tradeoff.sql
@@ -1,0 +1,66 @@
+-- Tags: no-fasttest
+-- ^ JSON data type is not enabled in fast-test image.
+--
+-- Companion test for https://github.com/ClickHouse/ClickHouse/issues/106085 fix
+-- in `IDataType::forEachSubcolumn`. The fix hides the static `.null` substream
+-- of `Nullable(T)` when `T` has dynamic subcolumns and `T` can resolve the
+-- subcolumn name dynamically (e.g. `Nullable(JSON)` where `JSON` has a key
+-- named `null`). This is needed for `SELECT data.null FROM (data Nullable(JSON))`
+-- to return the JSON value at key `null` rather than the outer null-map byte.
+--
+-- Side effect: for `Nullable(JSON)` (and other `Nullable(T-with-dynamic)`),
+-- `FunctionToSubcolumnsPass` no longer rewrites `count(x)`, `isNull(x)`, and
+-- `isNotNull(x)` to read the `.null` UInt8 subcolumn -- it now reads the full
+-- `Nullable(JSON)` column. The result is still correct.
+--
+-- This test pins down both halves of the trade-off:
+--   A) `Nullable(Int)` still gets the rewrite (sanity).
+--   B) `Nullable(JSON)` does NOT get the rewrite (documented regression).
+
+SET enable_json_type = 1;
+SET optimize_functions_to_subcolumns = 1;
+
+DROP TABLE IF EXISTS t_04308_int;
+CREATE TABLE t_04308_int (data Nullable(Int32)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_04308_int VALUES (1), (NULL), (3);
+
+-- A1. Result correctness (Nullable(Int)).
+SELECT 'int:count', count(data) FROM t_04308_int;
+SELECT 'int:isNull', sum(isNull(data)) FROM t_04308_int;
+SELECT 'int:isNotNull', sum(isNotNull(data)) FROM t_04308_int;
+
+-- A2. Rewrite is applied: `data.null` UInt8 appears in the pipeline.
+SELECT 'int:count_rewritten', countIf(position(explain, 'data.null') > 0) > 0
+FROM (EXPLAIN actions=1 SELECT count(data) FROM t_04308_int);
+SELECT 'int:isNull_rewritten', countIf(position(explain, 'data.null') > 0) > 0
+FROM (EXPLAIN actions=1 SELECT isNull(data) FROM t_04308_int);
+SELECT 'int:isNotNull_rewritten', countIf(position(explain, 'data.null') > 0) > 0
+FROM (EXPLAIN actions=1 SELECT isNotNull(data) FROM t_04308_int);
+
+DROP TABLE IF EXISTS t_04308_json;
+CREATE TABLE t_04308_json (data Nullable(JSON)) ENGINE = MergeTree ORDER BY tuple();
+INSERT INTO t_04308_json VALUES ('{"foo":1}'), (NULL), ('{"null":"xx"}');
+
+-- B1. Result correctness (Nullable(JSON)) -- rewrite is gone but result is the same.
+SELECT 'json:count', count(data) FROM t_04308_json;
+SELECT 'json:isNull', sum(isNull(data)) FROM t_04308_json;
+SELECT 'json:isNotNull', sum(isNotNull(data)) FROM t_04308_json;
+
+-- B2. Rewrite is NOT applied: `data.null` UInt8 does not appear -- the planner
+-- reads the full `Nullable(JSON)` column instead. This is the documented cost
+-- of fixing the `.null` JSON-key collision in #106085.
+SELECT 'json:count_not_rewritten', countIf(position(explain, 'data.null') > 0) = 0
+FROM (EXPLAIN actions=1 SELECT count(data) FROM t_04308_json);
+SELECT 'json:isNull_not_rewritten', countIf(position(explain, 'data.null') > 0) = 0
+FROM (EXPLAIN actions=1 SELECT isNull(data) FROM t_04308_json);
+SELECT 'json:isNotNull_not_rewritten', countIf(position(explain, 'data.null') > 0) = 0
+FROM (EXPLAIN actions=1 SELECT isNotNull(data) FROM t_04308_json);
+
+-- B3. The `.null` JSON-key user-visible value is preserved (the bug fix from
+-- #106085 -- duplicated here so this test self-contains the trade-off summary).
+SELECT 'json:data.null_returns_json_value', data.null
+FROM t_04308_json
+WHERE data IS NOT NULL AND data.null IS NOT NULL;
+
+DROP TABLE t_04308_int;
+DROP TABLE t_04308_json;


### PR DESCRIPTION
Fix a user-visible correctness bug: reading the `.null` subcolumn from a `Nullable(JSON)` column returned the outer `Nullable` null-map byte (0 / `UInt8`) instead of the value at the JSON key `null`. Reported by @wangtZJU, assigned to @groeneai by @PedroTadim with @Avogar pre-arranged as reviewer.

`SerializationNullable::enumerateStreams` registers a substream literally named `null` for the outer null-map. That substream becomes a static subcolumn that shadows the inner `JSON`'s dynamic resolution of the same key. Reproducer (from #106085):

```sql
CREATE TABLE t (data Nullable(JSON)) ENGINE = Memory;
INSERT INTO t VALUES ('{"null":"xx"}');
SELECT data.null FROM t;  -- before: 0, after: "xx"
```

The fix is in `src/DataTypes/IDataType.cpp`, two hooks:

1. `getSubcolumnData`: when `data.type` is `Nullable(T)` and `T` has dynamic subcolumns, try the inner type's dynamic resolution first. If it succeeds for the requested name, return that (wrapped via `NullableSubcolumnCreator` inside `DataTypeNullable::getDynamicSubcolumnData`, so outer-row nulls still propagate).
2. `forEachSubcolumn`: skip the outer `Nullable` null-map static subcolumn when the inner type can resolve the same name dynamically. Otherwise the planner picks the static `UInt8` null-map first (static has priority over dynamic in `ColumnsDescription::tryGetColumn`), and storage extraction then returns the JSON value -- a type mismatch at read time.

Behaviour matrix (covers all `Nullable(...)` shapes I could enumerate):
- `Nullable(JSON).null` -> JSON value at key `null` (was `UInt8` null-map). Fixes #106085.
- `Nullable(JSON).foo` -> unchanged (was already going through the dynamic path via the fall-through at the bottom of `getSubcolumnData`).
- `Nullable(Int32).null` -> unchanged (`Int32` has no dynamic subcolumns, top check skipped).
- `Nullable(Tuple(j JSON)).null` -> unchanged (`Tuple` rejects element name `null` at create time, dynamic resolution returns null, fall-through emits the static null-map).
- `Nullable(Array(JSON)).null` / `Nullable(Map(K, JSON)).null` -> unchanged (these inner types have `hasDynamicSubcolumnsData() = false` themselves; the dynamic check at the top short-circuits).

`isNull(data)` and `data IS NULL` still report the outer-row null state for all `Nullable(T)`.

Regression test: `tests/queries/0_stateless/04306_106085_nullable_json_null_subcolumn.sql`. Covers the bug case, two other keys, outer-NULL row, plain `JSON` (no `Nullable` wrapper, untouched), and `Nullable(Int32)` (untouched). Tagged `no-fasttest` because `JSON` is not enabled in the fast-test image. Verified locally (20/20 deterministic) and a spot-check of 11 existing `Nullable(JSON)` tests still passes.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix reading the `.null` subcolumn from a `Nullable(JSON)` column: it now returns the JSON value at the key `null` instead of the outer `Nullable` null-map byte. The outer null state remains reachable via `isNull(x)` / `x IS NULL`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
