### PR TITLE
Propagate OpenTelemetry context to S3 and Azure

### DIFF
--- a/src/IO/AzureBlobStorage/PocoHTTPClient.cpp
+++ b/src/IO/AzureBlobStorage/PocoHTTPClient.cpp
@@ -6,6 +6,7 @@
 
 #include <IO/HTTPCommon.h>  // Add this include at the top
 #include <Common/NetException.h>
+#include <Common/OpenTelemetryTraceContext.h>
 #include <Common/Throttler.h>
 #include <Common/VectorWithMemoryTracking.h>
 #include <Common/logger_useful.h>
@@ -129,6 +130,20 @@ private:
         return static_cast<size_t>(stream.gcount());
     }
 };
+
+void addOpenTelemetryTraceContextHeaders(Poco::Net::HTTPRequest & request)
+{
+    const auto & current_trace_context = OpenTelemetry::CurrentContext();
+    if (!current_trace_context.isTraceEnabled())
+        return;
+
+    request.set("traceparent", current_trace_context.composeTraceparentHeader());
+
+    if (!current_trace_context.tracestate.empty())
+        request.set("tracestate", current_trace_context.tracestate);
+    else
+        request.erase("tracestate");
+}
 
 }
 
@@ -347,6 +362,7 @@ std::unique_ptr<Azure::Core::Http::RawResponse> PocoAzureHTTPClient::makeRequest
             if (!header.value.empty())  // Skip empty headers
                 poco_request.set(header.name, header.value);
         }
+        addOpenTelemetryTraceContextHeaders(poco_request);
 
         if (method == "GET" || method == "HEAD")
             request_throttler.throttleHTTPGet();

--- a/src/IO/AzureBlobStorage/PocoHTTPClient.cpp
+++ b/src/IO/AzureBlobStorage/PocoHTTPClient.cpp
@@ -139,7 +139,11 @@ void addOpenTelemetryTraceContextHeaders(Poco::Net::HTTPRequest & request)
 
     request.set("traceparent", current_trace_context.composeTraceparentHeader());
 
-    if (!current_trace_context.tracestate.empty())
+    /// Client-provided tracestate may be kept for internal span logging even if
+    /// it is not safe as an HTTP header.
+    if (!current_trace_context.tracestate.empty()
+        && current_trace_context.tracestate.find('\r') == String::npos
+        && current_trace_context.tracestate.find('\n') == String::npos)
         request.set("tracestate", current_trace_context.tracestate);
     else
         request.erase("tracestate");

--- a/src/IO/AzureBlobStorage/tests/gtest_azure_http_client.cpp
+++ b/src/IO/AzureBlobStorage/tests/gtest_azure_http_client.cpp
@@ -1,0 +1,129 @@
+#include <gtest/gtest.h>
+
+#include "config.h"
+
+#if USE_AZURE_BLOB_STORAGE
+
+#include <memory>
+#include <string>
+
+#include <Common/OpenTelemetryTraceContext.h>
+#include <Common/RemoteHostFilter.h>
+#include <IO/AzureBlobStorage/PocoHTTPClient.h>
+#include <IO/S3/tests/TestPocoHTTPServer.h>
+
+#include <azure/core/context.hpp>
+#include <azure/core/http/http.hpp>
+#include <azure/core/http/http_status_code.hpp>
+#include <azure/core/url.hpp>
+
+namespace
+{
+
+Azure::Core::Http::HttpStatusCode sendAzureRequest(DB::PocoAzureHTTPClient & client, const std::string & url)
+{
+    Azure::Core::Http::Request request(Azure::Core::Http::HttpMethod::Get, Azure::Core::Url(url));
+    auto response = client.Send(request, Azure::Core::Context{});
+    if (!response)
+        return Azure::Core::Http::HttpStatusCode::None;
+    return response->GetStatusCode();
+}
+
+}
+
+TEST(IOTestAzureHTTPClient, PropagatesOpenTelemetryTraceContext)
+{
+    TestPocoHTTPServer http;
+
+    DB::RemoteHostFilter remote_host_filter;
+    DB::PocoAzureHTTPClientConfiguration configuration{
+        .remote_host_filter = remote_host_filter,
+        .max_redirects = 0,
+        .for_disk_azure = false,
+        .request_throttler = {},
+        .extra_headers = {},
+    };
+    DB::PocoAzureHTTPClient client(configuration);
+
+    DB::OpenTelemetry::TracingContext tracing_context;
+    String error;
+    ASSERT_TRUE(tracing_context.parseTraceparentHeader("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", error)) << error;
+    tracing_context.tracestate = "congo=t61rcWkgMzE";
+
+    {
+        DB::OpenTelemetry::TracingContextHolder tracing_context_holder(
+            "IOTestAzureHTTPClient::PropagatesOpenTelemetryTraceContext",
+            tracing_context,
+            std::weak_ptr<DB::OpenTelemetrySpanLog>{});
+
+        const auto expected_traceparent = DB::OpenTelemetry::CurrentContext().composeTraceparentHeader();
+        ASSERT_EQ(sendAzureRequest(client, http.getUrl()), Azure::Core::Http::HttpStatusCode::Ok);
+
+        const auto & headers = http.getLastRequestHeader();
+        ASSERT_TRUE(headers.has("traceparent"));
+        EXPECT_EQ(headers.get("traceparent"), expected_traceparent);
+        ASSERT_TRUE(headers.has("tracestate"));
+        EXPECT_EQ(headers.get("tracestate"), tracing_context.tracestate);
+    }
+}
+
+TEST(IOTestAzureHTTPClient, DoesNotPropagateOpenTelemetryTraceContextWithoutCurrentContext)
+{
+    TestPocoHTTPServer http;
+
+    DB::RemoteHostFilter remote_host_filter;
+    DB::PocoAzureHTTPClientConfiguration configuration{
+        .remote_host_filter = remote_host_filter,
+        .max_redirects = 0,
+        .for_disk_azure = false,
+        .request_throttler = {},
+        .extra_headers = {},
+    };
+    DB::PocoAzureHTTPClient client(configuration);
+
+    ASSERT_FALSE(DB::OpenTelemetry::CurrentContext().isTraceEnabled());
+    ASSERT_EQ(sendAzureRequest(client, http.getUrl()), Azure::Core::Http::HttpStatusCode::Ok);
+
+    const auto & headers = http.getLastRequestHeader();
+    EXPECT_FALSE(headers.has("traceparent"));
+    EXPECT_FALSE(headers.has("tracestate"));
+}
+
+TEST(IOTestAzureHTTPClient, OpenTelemetryTraceContextOverridesExistingTraceHeaders)
+{
+    TestPocoHTTPServer http;
+
+    DB::RemoteHostFilter remote_host_filter;
+    DB::PocoAzureHTTPClientConfiguration configuration{
+        .remote_host_filter = remote_host_filter,
+        .max_redirects = 0,
+        .for_disk_azure = false,
+        .request_throttler = {},
+        .extra_headers = {
+            {"traceparent", "00-00000000000000000000000000000001-0000000000000001-01"},
+            {"tracestate", "stale=value"},
+        },
+    };
+    DB::PocoAzureHTTPClient client(configuration);
+
+    DB::OpenTelemetry::TracingContext tracing_context;
+    String error;
+    ASSERT_TRUE(tracing_context.parseTraceparentHeader("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", error)) << error;
+
+    {
+        DB::OpenTelemetry::TracingContextHolder tracing_context_holder(
+            "IOTestAzureHTTPClient::OpenTelemetryTraceContextOverridesExistingTraceHeaders",
+            tracing_context,
+            std::weak_ptr<DB::OpenTelemetrySpanLog>{});
+
+        const auto expected_traceparent = DB::OpenTelemetry::CurrentContext().composeTraceparentHeader();
+        ASSERT_EQ(sendAzureRequest(client, http.getUrl()), Azure::Core::Http::HttpStatusCode::Ok);
+
+        const auto & headers = http.getLastRequestHeader();
+        ASSERT_TRUE(headers.has("traceparent"));
+        EXPECT_EQ(headers.get("traceparent"), expected_traceparent);
+        EXPECT_FALSE(headers.has("tracestate"));
+    }
+}
+
+#endif

--- a/src/IO/AzureBlobStorage/tests/gtest_azure_http_client.cpp
+++ b/src/IO/AzureBlobStorage/tests/gtest_azure_http_client.cpp
@@ -126,4 +126,41 @@ TEST(IOTestAzureHTTPClient, OpenTelemetryTraceContextOverridesExistingTraceHeade
     }
 }
 
+TEST(IOTestAzureHTTPClient, SkipsInvalidOpenTelemetryTracestate)
+{
+    TestPocoHTTPServer http;
+
+    DB::RemoteHostFilter remote_host_filter;
+    DB::PocoAzureHTTPClientConfiguration configuration{
+        .remote_host_filter = remote_host_filter,
+        .max_redirects = 0,
+        .for_disk_azure = false,
+        .request_throttler = {},
+        .extra_headers = {
+            {"tracestate", "stale=value"},
+        },
+    };
+    DB::PocoAzureHTTPClient client(configuration);
+
+    DB::OpenTelemetry::TracingContext tracing_context;
+    String error;
+    ASSERT_TRUE(tracing_context.parseTraceparentHeader("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", error)) << error;
+    tracing_context.tracestate = "a\nb cd";
+
+    {
+        DB::OpenTelemetry::TracingContextHolder tracing_context_holder(
+            "IOTestAzureHTTPClient::SkipsInvalidOpenTelemetryTracestate",
+            tracing_context,
+            std::weak_ptr<DB::OpenTelemetrySpanLog>{});
+
+        const auto expected_traceparent = DB::OpenTelemetry::CurrentContext().composeTraceparentHeader();
+        ASSERT_EQ(sendAzureRequest(client, http.getUrl()), Azure::Core::Http::HttpStatusCode::Ok);
+
+        const auto & headers = http.getLastRequestHeader();
+        ASSERT_TRUE(headers.has("traceparent"));
+        EXPECT_EQ(headers.get("traceparent"), expected_traceparent);
+        EXPECT_FALSE(headers.has("tracestate"));
+    }
+}
+
 #endif

--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -123,7 +123,11 @@ void addOpenTelemetryTraceContextHeaders(Poco::Net::HTTPRequest & request)
 
     request.set("traceparent", current_trace_context.composeTraceparentHeader());
 
-    if (!current_trace_context.tracestate.empty())
+    /// Client-provided tracestate may be kept for internal span logging even if
+    /// it is not safe as an HTTP header.
+    if (!current_trace_context.tracestate.empty()
+        && current_trace_context.tracestate.find('\r') == String::npos
+        && current_trace_context.tracestate.find('\n') == String::npos)
         request.set("tracestate", current_trace_context.tracestate);
     else
         request.erase("tracestate");

--- a/src/IO/S3/PocoHTTPClient.cpp
+++ b/src/IO/S3/PocoHTTPClient.cpp
@@ -1,6 +1,7 @@
 #include <Poco/Timespan.h>
 #include <Poco/Net/NetException.h>
 #include <Common/NetException.h>
+#include <Common/OpenTelemetryTraceContext.h>
 #include <Common/config_version.h>
 #include "config.h"
 
@@ -109,6 +110,25 @@ bool isS3WrongSigningRegionBadRequest(int status_code, const Poco::Net::HTTPMess
     if (!response.has("x-amz-bucket-region"))
         return false;
     return !response.get("x-amz-bucket-region").empty();
+}
+
+namespace
+{
+
+void addOpenTelemetryTraceContextHeaders(Poco::Net::HTTPRequest & request)
+{
+    const auto & current_trace_context = OpenTelemetry::CurrentContext();
+    if (!current_trace_context.isTraceEnabled())
+        return;
+
+    request.set("traceparent", current_trace_context.composeTraceparentHeader());
+
+    if (!current_trace_context.tracestate.empty())
+        request.set("tracestate", current_trace_context.tracestate);
+    else
+        request.erase("tracestate");
+}
+
 }
 
 PocoHTTPClientConfiguration::PocoHTTPClientConfiguration(
@@ -609,6 +629,7 @@ void PocoHTTPClient::makeRequestInternalImpl(
                     poco_request.set(boost::algorithm::to_lower_copy(header_name), header_value);
                 }
             }
+            addOpenTelemetryTraceContextHeaders(poco_request);
 
             Poco::Net::HTTPResponse poco_response;
             poco_response.setFieldLimit(static_cast<int>(http_max_fields));

--- a/src/IO/S3/tests/gtest_aws_s3_client.cpp
+++ b/src/IO/S3/tests/gtest_aws_s3_client.cpp
@@ -14,6 +14,7 @@
 
 #include <boost/algorithm/string/split.hpp>
 
+#include <Common/OpenTelemetryTraceContext.h>
 #include <Poco/Net/HTTPResponse.h>
 #include <Poco/URI.h>
 
@@ -124,6 +125,50 @@ static void doWriteRequest(std::shared_ptr<const DB::S3::Client> client, const D
 
     write_buffer.write('\0'); // doesn't matter what we write here, just needs to be something
     write_buffer.finalize();
+}
+
+static std::shared_ptr<DB::S3::Client> createTestS3Client(const DB::S3::URI & uri, DB::HTTPHeaderEntries headers = {})
+{
+    static DB::RemoteHostFilter remote_host_filter;
+    unsigned int s3_max_redirects = 100;
+    unsigned int s3_retry_attempts = 0;
+    bool s3_slow_all_threads_after_network_error = true;
+    bool s3_slow_all_threads_after_retryable_error = true;
+    String access_key_id = "ACCESS_KEY_ID";
+    String secret_access_key = "SECRET_ACCESS_KEY";
+    String region = "us-east-1";
+    bool enable_s3_requests_logging = false;
+
+    DB::S3::PocoHTTPClientConfiguration client_configuration = DB::S3::ClientFactory::instance().createClientConfiguration(
+        region,
+        remote_host_filter,
+        s3_max_redirects,
+        DB::S3::PocoHTTPClientConfiguration::RetryStrategy{.max_retries = s3_retry_attempts},
+        s3_slow_all_threads_after_network_error,
+        s3_slow_all_threads_after_retryable_error,
+        enable_s3_requests_logging,
+        /* for_disk_s3 = */ false,
+        /* opt_disk_name = */ {},
+        /* request_throttler = */ {},
+        uri.uri.getScheme());
+
+    client_configuration.endpointOverride = uri.endpoint;
+
+    DB::S3::ClientSettings client_settings{
+        .use_virtual_addressing = uri.is_virtual_hosted_style,
+        .disable_checksum = false,
+        .gcs_issue_compose_request = false,
+    };
+
+    return DB::S3::ClientFactory::instance().create(
+        client_configuration,
+        client_settings,
+        access_key_id,
+        secret_access_key,
+        /* server_side_encryption_customer_key_base64 = */ "",
+        {},
+        headers,
+        DB::S3::CredentialsConfiguration{});
 }
 
 using RequestFn = std::function<void(std::shared_ptr<const DB::S3::Client>, const DB::S3::URI &)>;
@@ -344,6 +389,82 @@ TEST(IOTestAwsS3Client, ChecksumHeaderIsPresentForS3Express)
         "x-amz-date;"
         "x-amz-sdk-checksum-algorithm, ...\n",
         /*is_s3express_bucket=*/true);
+}
+
+TEST(IOTestAwsS3Client, PropagatesOpenTelemetryTraceContext)
+{
+    TestPocoHTTPServer http;
+    DB::S3::URI uri(http.getUrl() + "/IOTestAwsS3ClientOpenTelemetryTraceContext/test.txt");
+    auto client = createTestS3Client(uri);
+    ASSERT_TRUE(client);
+
+    DB::OpenTelemetry::TracingContext tracing_context;
+    String error;
+    ASSERT_TRUE(tracing_context.parseTraceparentHeader("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", error)) << error;
+    tracing_context.tracestate = "congo=t61rcWkgMzE";
+
+    {
+        DB::OpenTelemetry::TracingContextHolder tracing_context_holder(
+            "IOTestAwsS3Client::PropagatesOpenTelemetryTraceContext",
+            tracing_context,
+            std::weak_ptr<DB::OpenTelemetrySpanLog>{});
+
+        const auto expected_traceparent = DB::OpenTelemetry::CurrentContext().composeTraceparentHeader();
+        doReadRequest(client, uri);
+
+        const auto & headers = http.getLastRequestHeader();
+        ASSERT_TRUE(headers.has("traceparent"));
+        EXPECT_EQ(headers.get("traceparent"), expected_traceparent);
+        ASSERT_TRUE(headers.has("tracestate"));
+        EXPECT_EQ(headers.get("tracestate"), tracing_context.tracestate);
+    }
+}
+
+TEST(IOTestAwsS3Client, DoesNotPropagateOpenTelemetryTraceContextWithoutCurrentContext)
+{
+    TestPocoHTTPServer http;
+    DB::S3::URI uri(http.getUrl() + "/IOTestAwsS3ClientOpenTelemetryTraceContext/test.txt");
+    auto client = createTestS3Client(uri);
+    ASSERT_TRUE(client);
+
+    ASSERT_FALSE(DB::OpenTelemetry::CurrentContext().isTraceEnabled());
+    doReadRequest(client, uri);
+
+    const auto & headers = http.getLastRequestHeader();
+    EXPECT_FALSE(headers.has("traceparent"));
+    EXPECT_FALSE(headers.has("tracestate"));
+}
+
+TEST(IOTestAwsS3Client, OpenTelemetryTraceContextOverridesExistingTraceHeaders)
+{
+    TestPocoHTTPServer http;
+    DB::S3::URI uri(http.getUrl() + "/IOTestAwsS3ClientOpenTelemetryTraceContext/test.txt");
+    auto client = createTestS3Client(
+        uri,
+        {
+            {"traceparent", "00-00000000000000000000000000000001-0000000000000001-01"},
+            {"tracestate", "stale=value"},
+        });
+    ASSERT_TRUE(client);
+
+    DB::OpenTelemetry::TracingContext tracing_context;
+    String error;
+    ASSERT_TRUE(tracing_context.parseTraceparentHeader("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", error)) << error;
+
+    {
+        DB::OpenTelemetry::TracingContextHolder tracing_context_holder(
+            "IOTestAwsS3Client::OpenTelemetryTraceContextOverridesExistingTraceHeaders",
+            tracing_context,
+            std::weak_ptr<DB::OpenTelemetrySpanLog>{});
+
+        const auto expected_traceparent = DB::OpenTelemetry::CurrentContext().composeTraceparentHeader();
+        doReadRequest(client, uri);
+
+        const auto & headers = http.getLastRequestHeader();
+        ASSERT_TRUE(headers.has("traceparent"));
+        EXPECT_EQ(headers.get("traceparent"), expected_traceparent);
+        EXPECT_FALSE(headers.has("tracestate"));
+    }
 }
 
 TEST(IOTestAwsS3Client, DetectRegionFromS3ExpressEndpoint)

--- a/src/IO/S3/tests/gtest_aws_s3_client.cpp
+++ b/src/IO/S3/tests/gtest_aws_s3_client.cpp
@@ -467,6 +467,38 @@ TEST(IOTestAwsS3Client, OpenTelemetryTraceContextOverridesExistingTraceHeaders)
     }
 }
 
+TEST(IOTestAwsS3Client, SkipsInvalidOpenTelemetryTracestate)
+{
+    TestPocoHTTPServer http;
+    DB::S3::URI uri(http.getUrl() + "/IOTestAwsS3ClientOpenTelemetryTraceContext/test.txt");
+    auto client = createTestS3Client(
+        uri,
+        {
+            {"tracestate", "stale=value"},
+        });
+    ASSERT_TRUE(client);
+
+    DB::OpenTelemetry::TracingContext tracing_context;
+    String error;
+    ASSERT_TRUE(tracing_context.parseTraceparentHeader("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01", error)) << error;
+    tracing_context.tracestate = "a\nb cd";
+
+    {
+        DB::OpenTelemetry::TracingContextHolder tracing_context_holder(
+            "IOTestAwsS3Client::SkipsInvalidOpenTelemetryTracestate",
+            tracing_context,
+            std::weak_ptr<DB::OpenTelemetrySpanLog>{});
+
+        const auto expected_traceparent = DB::OpenTelemetry::CurrentContext().composeTraceparentHeader();
+        doReadRequest(client, uri);
+
+        const auto & headers = http.getLastRequestHeader();
+        ASSERT_TRUE(headers.has("traceparent"));
+        EXPECT_EQ(headers.get("traceparent"), expected_traceparent);
+        EXPECT_FALSE(headers.has("tracestate"));
+    }
+}
+
 TEST(IOTestAwsS3Client, DetectRegionFromS3ExpressEndpoint)
 {
     DB::RemoteHostFilter remote_host_filter;


### PR DESCRIPTION
### Changelog category (leave one):
Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Propagates OpenTelemetry W3C trace context (`traceparent` and `tracestate`) from ClickHouse queries to outbound S3 and Azure Blob Storage requests, making distributed traces continue across object storage access.

Closes #77470.

### Tests
- `git diff --check`
- `env -u HTTP_PROXY -u HTTPS_PROXY -u http_proxy -u https_proxy NO_PROXY='127.0.0.1,localhost,::1,0.0.0.0' no_proxy='127.0.0.1,localhost,::1,0.0.0.0' ./build-s3-azure-otel-min-codex/src/unit_tests_s3_azure_otel_chmain --gtest_filter='IOTestAwsS3Client.*OpenTelemetry*:IOTestAzureHTTPClient.*OpenTelemetry*'`
- Full local E2E with patched ClickHouse server, Docker MinIO, Docker Azurite, and header-capturing proxies. S3 captured traced `HEAD` and `GET`; Azure captured traced `HEAD`, `HEAD`, and ranged `GET`; both queries returned `6`.
