### PR TITLE
Require explicit interlinking between pull requests and issues

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,6 +2,13 @@ When working with a branch, do not use rebase or amend - add new commits instead
 
 Do not commit to the master branch. Create a new branch for every task.
 
+Link related pull requests and issues explicitly, using full GitHub URLs, one relationship per line:
+- When a pull request fixes an issue, put `Closes: <full link to the issue>` on its own line in the pull request description. GitHub renders this as `Closes: #<number>` and closes the issue automatically when the pull request is merged into the default branch (auto-close only fires when targeting the default branch).
+- When an issue was caused by a pull request (a regression), put `Caused by: <full link to the pull request>` on its own line in the issue.
+- For any other relevant pull request or issue, put `Related: <full link>` on its own line.
+
+Use the keyword `Closes` (not `Fixes` or `Resolves`) for consistency. Only `Closes` triggers GitHub's automatic closing; `Caused by` and `Related` are conventions for humans and tooling. Issues never close pull requests, so the issue side uses only `Caused by` and `Related`.
+
 When writing text such as documentation, comments, or commit messages, wrap literal names from ClickHouse SQL language, classes and functions, or literal excerpts from log messages inside inline code blocks, such as: `MergeTree`.
 
 When adding headers to documentation files under `docs/`, every header must include an explicit anchor in the form `{#kebab-case-anchor}` at the end of the header line, e.g. `## My Section {#my-section}`. This is mandatory for all heading levels. New documentation files must also include a frontmatter block at the top (before the first heading) with `description`, `sidebar_label`, `sidebar_position`, `slug`, `title`, and `doc_type` fields, modelled on existing files such as `docs/en/development/continuous-integration.md`.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,13 +2,6 @@ When working with a branch, do not use rebase or amend - add new commits instead
 
 Do not commit to the master branch. Create a new branch for every task.
 
-Link related pull requests and issues explicitly, using full GitHub URLs, one relationship per line:
-- When a pull request fixes an issue, put `Closes: <full link to the issue>` on its own line in the pull request description. GitHub renders this as `Closes: #<number>` and closes the issue automatically when the pull request is merged into the default branch (auto-close only fires when targeting the default branch).
-- When an issue was caused by a pull request (a regression), put `Caused by: <full link to the pull request>` on its own line in the issue.
-- For any other relevant pull request or issue, put `Related: <full link>` on its own line.
-
-Use the keyword `Closes` (not `Fixes` or `Resolves`) for consistency. Only `Closes` triggers GitHub's automatic closing; `Caused by` and `Related` are conventions for humans and tooling. Issues never close pull requests, so the issue side uses only `Caused by` and `Related`.
-
 When writing text such as documentation, comments, or commit messages, wrap literal names from ClickHouse SQL language, classes and functions, or literal excerpts from log messages inside inline code blocks, such as: `MergeTree`.
 
 When adding headers to documentation files under `docs/`, every header must include an explicit anchor in the form `{#kebab-case-anchor}` at the end of the header line, e.g. `## My Section {#my-section}`. This is mandatory for all heading levels. New documentation files must also include a frontmatter block at the top (before the first heading) with `description`, `sidebar_label`, `sidebar_position`, `slug`, `title`, and `doc_type` fields, modelled on existing files such as `docs/en/development/continuous-integration.md`.
@@ -168,6 +161,13 @@ When running tests, always redirect output to a log file in the build directory 
 If I provided a URL with the CI report, logs, or examples, include it in the commit message. If the link has `PR=...`, also add a link to the corresponding PR.
 
 When creating or updating a pull request, use `.github/PULL_REQUEST_TEMPLATE.md` as the PR body template. The body should contain: a short description of the change and motivation, then the Changelog category (leave one from the list), then the Changelog entry, then the Documentation entry checkbox. Do not invent a custom "## Summary" or "## Test plan" structure — follow the template exactly. The "Bug Fix" category should be used only for real bug fixes, while for fixing CI reports you can use the "CI Fix or improvement" category. Include the URL to CI report I provided if any. If the PR is about a CI failure, search for the corresponding open issues and provide a link in the PR description.
+
+Link related pull requests and issues explicitly, using full GitHub URLs, one relationship per line:
+- When a pull request fixes an issue, put `Closes: <full link to the issue>` on its own line in the pull request description. GitHub renders this as `Closes: #<number>` and closes the issue automatically when the pull request is merged into the default branch (auto-close only fires when targeting the default branch).
+- When an issue was caused by a pull request (a regression), put `Caused by: <full link to the pull request>` on its own line in the issue.
+- For any other relevant pull request or issue, put `Related: <full link>` on its own line.
+
+Use the keyword `Closes` (not `Fixes` or `Resolves`) for consistency. Only `Closes` triggers GitHub's automatic closing; `Caused by` and `Related` are conventions for humans and tooling. Issues never close pull requests, so the issue side uses only `Caused by` and `Related`.
 
 ARM machines in CI are not slow. They are similar to x86 in performance.
 

--- a/.github/ISSUE_TEMPLATE/30_unexpected-behaviour.yaml
+++ b/.github/ISSUE_TEMPLATE/30_unexpected-behaviour.yaml
@@ -49,6 +49,15 @@ body:
       required: false
   - type: textarea
     attributes:
+      label: Related issues and pull requests
+      description: |
+        Use full GitHub URLs, one relationship per line.
+        * If a pull request caused this (a regression): `Caused by: <full pull request URL>`
+        * For any related issue or pull request: `Related: <full URL>`
+    validations:
+      required: false
+  - type: textarea
+    attributes:
       label: Additional context
       description: Add any other context about the problem here.
     validations:

--- a/.github/ISSUE_TEMPLATE/70_performance-issue.yaml
+++ b/.github/ISSUE_TEMPLATE/70_performance-issue.yaml
@@ -42,6 +42,15 @@ body:
       required: false
   - type: textarea
     attributes:
+      label: Related issues and pull requests
+      description: |
+        Use full GitHub URLs, one relationship per line.
+        * If a pull request caused this (a regression): `Caused by: <full pull request URL>`
+        * For any related issue or pull request: `Related: <full URL>`
+    validations:
+      required: false
+  - type: textarea
+    attributes:
       label: Additional context
       description: Add any other context about the problem here.
     validations:

--- a/.github/ISSUE_TEMPLATE/80_backward-compatibility.yaml
+++ b/.github/ISSUE_TEMPLATE/80_backward-compatibility.yaml
@@ -42,6 +42,15 @@ body:
       required: false
   - type: textarea
     attributes:
+      label: Related issues and pull requests
+      description: |
+        Use full GitHub URLs, one relationship per line.
+        * If a pull request caused this (a regression): `Caused by: <full pull request URL>`
+        * For any related issue or pull request: `Related: <full URL>`
+    validations:
+      required: false
+  - type: textarea
+    attributes:
       label: Additional context
       description: Add any other context about the problem here.
     validations:

--- a/.github/ISSUE_TEMPLATE/85_bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/85_bug-report.yaml
@@ -70,6 +70,15 @@ body:
       required: false
   - type: textarea
     attributes:
+      label: Related issues and pull requests
+      description: |
+        Use full GitHub URLs, one relationship per line.
+        * If a pull request caused this (a regression): `Caused by: <full pull request URL>`
+        * For any related issue or pull request: `Related: <full URL>`
+    validations:
+      required: false
+  - type: textarea
+    attributes:
       label: Additional context
       description: Add any other context about the problem here.
     validations:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,11 @@
+<!--
+Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
+
+Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
+Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
+-->
+
+
 ### Changelog category (leave one):
 - New Feature
 - Experimental Feature


### PR DESCRIPTION
Adds a strict, uniform convention for linking related pull requests and issues so the relationships are explicit and machine-greppable. One relationship per line, using full GitHub URLs:

- `Closes: <issue URL>` in a pull request that fixes an issue. GitHub auto-closes the issue when the pull request is merged into the default branch.
- `Caused by: <pull request URL>` in an issue that is a regression introduced by a pull request.
- `Related: <URL>` for any other relevant pull request or issue.

Changes:
- `.claude/CLAUDE.md` — documents the convention for agents (keyword `Closes` only, directionality, default-branch caveat).
- `.github/PULL_REQUEST_TEMPLATE.md` — adds a `Closes:`/`Related:` block at the top.
- `.github/ISSUE_TEMPLATE/{85_bug-report,30_unexpected-behaviour,70_performance-issue,80_backward-compatibility}.yaml` — add a "Related issues and pull requests" field for `Caused by:`/`Related:`.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.319`
<!-- ch-version-info:end -->