### PR TITLE
Make classification perf test deterministic to reduce noise

### DIFF
--- a/tests/performance/classification.xml
+++ b/tests/performance/classification.xml
@@ -3,13 +3,19 @@
         <allow_experimental_nlp_functions>1</allow_experimental_nlp_functions>
     </settings>
 
-    <query>SELECT detectLanguage(SearchPhrase) FROM hits_100m_single LIMIT 10000000 FORMAT Null</query>
-    <query>SELECT detectLanguageMixed(SearchPhrase) FROM hits_100m_single LIMIT 10000000 FORMAT Null</query>
+    <!-- A plain LIMIT without ORDER BY returns a different set of rows on each server (the read race between
+         parts and threads decides which rows win), and because the detect* functions' cost depends on the input,
+         the two servers ended up with different workloads and the comparison was reported as noisy. Sampling on
+         cityHash64(WatchID) is reproducible: it depends only on the row contents, so both servers process exactly
+         the same rows. The modulus keeps roughly the original row counts (LIMIT 10000000 -> % 10, 500000 -> % 200). -->
+
+    <query>SELECT detectLanguage(SearchPhrase) FROM hits_100m_single WHERE cityHash64(WatchID) % 10 = 0 FORMAT Null</query>
+    <query>SELECT detectLanguageMixed(SearchPhrase) FROM hits_100m_single WHERE cityHash64(WatchID) % 10 = 0 FORMAT Null</query>
     <query>SELECT detectTonality(SearchPhrase) FROM hits_100m_single FORMAT Null</query>
 
     <!-- Input is not really correct for these functions,
     but at least it gives us some idea about their performance -->
-    <query>SELECT detectLanguageUnknown(SearchPhrase) FROM hits_100m_single LIMIT 500000 FORMAT Null</query>
-    <query>SELECT detectCharset(SearchPhrase) FROM hits_100m_single LIMIT 500000 FORMAT Null</query>
+    <query>SELECT detectLanguageUnknown(SearchPhrase) FROM hits_100m_single WHERE cityHash64(WatchID) % 200 = 0 FORMAT Null</query>
+    <query>SELECT detectCharset(SearchPhrase) FROM hits_100m_single WHERE cityHash64(WatchID) % 200 = 0 FORMAT Null</query>
 
 </test>


### PR DESCRIPTION
`classification` is one of the noisy tests tracked in #100759 (`classification #1`, arm 14% / amd 10%).

Root cause is the same as #106249 (`reading_from_file`): the queries select a row subset with `LIMIT` and no `ORDER BY`, so when the parts are read by multiple threads each of the two compared servers ends up processing a different set of rows. Because the `detect*` functions' cost depends on the input phrases, one server is persistently slower than the other within a run and the verdict flips randomly across runs.

Per-run CI data for `classification #1` confirms the signature: within each server the runs are stable, but the two servers diverge by up to ~3x (e.g. baseline 3.08s/3.14s vs candidate 9.12s/9.22s on the same master commit), with the slow side alternating.

`cityHash64(WatchID) % K = 0` is a reproducible sample that depends only on row contents, so both servers process exactly the same rows. The modulus keeps roughly the original row counts (`% 10` for the `LIMIT 10000000` queries, `% 200` for the `LIMIT 500000` ones) and preserves the natural distribution, so the runtime is unchanged. `detectTonality` already scans the whole table and is not affected, so it is left as is.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.334`
<!-- ch-version-info:end -->