### PR TITLE
Fix data race on reading query id from signal handles while being written on the same thread

### DIFF
--- a/src/Common/SignalUnsafeMutationGuard.cpp
+++ b/src/Common/SignalUnsafeMutationGuard.cpp
@@ -1,0 +1,19 @@
+#include <Common/SignalUnsafeMutationGuard.h>
+
+namespace DB
+{
+
+SignalUnsafeMutationGuard::SignalUnsafeMutationGuard(std::atomic<bool> & is_usable_)
+    : is_usable(is_usable_)
+{
+    is_usable.store(false, std::memory_order_relaxed);
+    std::atomic_signal_fence(std::memory_order_seq_cst);
+}
+
+SignalUnsafeMutationGuard::~SignalUnsafeMutationGuard()
+{
+    std::atomic_signal_fence(std::memory_order_seq_cst);
+    is_usable.store(true, std::memory_order_relaxed);
+}
+
+}

--- a/src/Common/SignalUnsafeMutationGuard.h
+++ b/src/Common/SignalUnsafeMutationGuard.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <atomic>
+
+namespace DB
+{
+
+/// Marks signal-observed data unusable during mutation and usable again on destruction.
+class SignalUnsafeMutationGuard
+{
+public:
+    explicit SignalUnsafeMutationGuard(std::atomic<bool> & is_usable_);
+    ~SignalUnsafeMutationGuard();
+
+private:
+    std::atomic<bool> & is_usable;
+};
+
+}

--- a/src/Common/ThreadStatus.cpp
+++ b/src/Common/ThreadStatus.cpp
@@ -1,16 +1,18 @@
-#include <Common/Exception.h>
-#include <Common/ErrnoException.h>
-#include <Common/ThreadProfileEvents.h>
-#include <Common/QueryProfiler.h>
 #include <Common/ThreadStatus.h>
-#include <Common/CurrentThread.h>
-#include <Common/logger_useful.h>
-#include <Common/setThreadName.h>
-#include <Common/memory.h>
-#include <Common/MemoryTrackerBlockerInThread.h>
+
 #include <Core/Settings.h>
-#include <base/getPageSize.h>
 #include <Interpreters/Context.h>
+#include <base/getPageSize.h>
+#include <Common/CurrentThread.h>
+#include <Common/ErrnoException.h>
+#include <Common/Exception.h>
+#include <Common/MemoryTrackerBlockerInThread.h>
+#include <Common/QueryProfiler.h>
+#include <Common/SignalUnsafeMutationGuard.h>
+#include <Common/ThreadProfileEvents.h>
+#include <Common/logger_useful.h>
+#include <Common/memory.h>
+#include <Common/setThreadName.h>
 
 #include <Poco/Logger.h>
 
@@ -171,16 +173,22 @@ ThreadGroupPtr ThreadStatus::getThreadGroup() const
 void ThreadStatus::setQueryId(std::string && new_query_id) noexcept
 {
     chassert(query_id.empty());
+    SignalUnsafeMutationGuard guard(is_query_id_usable);
     query_id = std::move(new_query_id);
 }
 
 void ThreadStatus::clearQueryId() noexcept
 {
+    SignalUnsafeMutationGuard guard(is_query_id_usable);
     query_id.clear();
 }
 
-const String & ThreadStatus::getQueryId() const
+std::string_view ThreadStatus::getQueryId() const
 {
+    if (!is_query_id_usable.load(std::memory_order_acquire))
+        return "";
+
+    std::atomic_signal_fence(std::memory_order_seq_cst);
     return query_id;
 }
 

--- a/src/Common/ThreadStatus.h
+++ b/src/Common/ThreadStatus.h
@@ -210,6 +210,10 @@ protected:
     bool performance_counters_finalized = false;
 
     String query_id;
+    /// The query_id can be read by signal handlers. If the signal interrupts the thread while it is updating the query_id, it can lead to a race.
+    std::atomic<bool> is_query_id_usable{true};
+    /// is_query_id_usable is used in signal handlers, so ensure it is lock-free to avoid undefined behavior in signal handlers.
+    static_assert(std::atomic<bool>::is_always_lock_free);
 
     [[maybe_unused]] bool jemalloc_profiler_enabled = false;
 
@@ -252,7 +256,7 @@ public:
 
     void setQueryId(std::string && new_query_id) noexcept;
     void clearQueryId() noexcept;
-    const String & getQueryId() const;
+    std::string_view getQueryId() const;
 
     ContextPtr tryGetQueryContext() const;
     ContextPtr getGlobalContext() const;

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -4,6 +4,8 @@
 #include <Common/Jemalloc.h>
 #include <Common/ThreadStatus.h>
 
+#include <Core/ServerSettings.h>
+#include <Core/Settings.h>
 #include <Interpreters/Context.h>
 #include <Interpreters/OpenTelemetrySpanLog.h>
 #include <Interpreters/ProcessList.h>
@@ -11,21 +13,20 @@
 #include <Interpreters/QueryViewsLog.h>
 #include <Interpreters/TraceCollector.h>
 #include <Parsers/queryNormalization.h>
-#include <Common/MemoryTracker.h>
-#include <Common/VariableContext.h>
+#include <base/errnoToString.h>
 #include <Common/CurrentThread.h>
+#include <Common/DateLUT.h>
 #include <Common/Exception.h>
+#include <Common/MemoryTracker.h>
 #include <Common/ProfileEvents.h>
 #include <Common/QueryProfiler.h>
 #include <Common/SensitiveDataMasker.h>
+#include <Common/SignalUnsafeMutationGuard.h>
 #include <Common/ThreadProfileEvents.h>
-#include <Common/setThreadName.h>
-#include <Common/noexcept_scope.h>
-#include <Common/DateLUT.h>
+#include <Common/VariableContext.h>
 #include <Common/logger_useful.h>
-#include <Core/Settings.h>
-#include <base/errnoToString.h>
-#include <Core/ServerSettings.h>
+#include <Common/noexcept_scope.h>
+#include <Common/setThreadName.h>
 
 #if defined(OS_LINUX)
 #   include <sys/time.h>
@@ -314,7 +315,10 @@ void ThreadStatus::applyQuerySettings()
 
     DB::Exception::enable_job_stack_trace = settings[Setting::enable_job_stack_trace];
 
-    query_id = query_context_ptr->getCurrentQueryId();
+    {
+        SignalUnsafeMutationGuard guard(is_query_id_usable);
+        query_id = query_context_ptr->getCurrentQueryId();
+    }
     initQueryProfiler();
 
     untracked_memory_limit = settings[Setting::max_untracked_memory];
@@ -411,7 +415,7 @@ void ThreadStatus::detachFromGroup()
     Jemalloc::setCollectLocalProfileSamplesInTraceLog(false);
 #endif
 
-    query_id.clear();
+    clearQueryId();
     query_context.reset();
 
     local_data = {};


### PR DESCRIPTION
I cannot write a deterministic test to reproduce the bug, but [here](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=44e2e1596f6d9d8e1d18b24586997feabf3e8978&name_0=MasterCI&name_1=Integration%20tests%20%28amd_tsan%2C%202%2F6%29&name_1=Integration%20tests%20%28amd_tsan%2C%202%2F6%29) is the CI run that caused the issue 
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)



<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.355`
<!-- ch-version-info:end -->