### PR TITLE
Bump mariadb-connector-c to 3.1.29

### DIFF
--- a/contrib/mariadb-connector-c-cmake/CMakeLists.txt
+++ b/contrib/mariadb-connector-c-cmake/CMakeLists.txt
@@ -43,6 +43,14 @@ MATH(EXPR MARIADB_VERSION_ID "${MARIADB_CLIENT_VERSION_MAJOR} * 10000 +
                               ${MARIADB_CLIENT_VERSION_MINOR} * 100   +
                               ${MARIADB_CLIENT_VERSION_PATCH}")
 
+set(CPACK_PACKAGE_VERSION_MAJOR 3)
+set(CPACK_PACKAGE_VERSION_MINOR 1)
+set(CPACK_PACKAGE_VERSION_PATCH 29)
+set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
+MATH(EXPR MARIADB_PACKAGE_VERSION_ID "${CPACK_PACKAGE_VERSION_MAJOR} * 10000 +
+                                      ${CPACK_PACKAGE_VERSION_MINOR} * 100   +
+                                      ${CPACK_PACKAGE_VERSION_PATCH}")
+
 IF (NOT MARIADB_PORT)
   set(MARIADB_PORT 3306)
 ENDIF ()
@@ -207,7 +215,7 @@ set(LIBMARIADB_SOURCES ${LIBMARIADB_SOURCES}
 ${CC_SOURCE_DIR}/plugins/auth/my_auth.c
 ${CC_SOURCE_DIR}/libmariadb/ma_array.c
 ${CC_SOURCE_DIR}/libmariadb/ma_charset.c
-${CC_SOURCE_DIR}/libmariadb/ma_hash.c
+${CC_SOURCE_DIR}/libmariadb/ma_hashtbl.c
 ${CC_SOURCE_DIR}/libmariadb/ma_net.c
 ${CC_SOURCE_DIR}/libmariadb/mariadb_charset.c
 ${CC_SOURCE_DIR}/libmariadb/ma_time.c

--- a/tests/integration/helpers/port_forward.py
+++ b/tests/integration/helpers/port_forward.py
@@ -70,6 +70,10 @@ class PortForward:
     def start(self, address, listen_port=0):
         self._address = address
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        # Allow rebinding to the same fixed port immediately after stop(): the
+        # previously accepted connection lingers in TIME_WAIT on this port, so
+        # without SO_REUSEADDR bind() fails with "Address already in use".
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self._sock.bind(("", listen_port))
         self._sock.listen()
         self._sock.settimeout(1)


### PR DESCRIPTION
### Changelog category (leave one):
- Build/Testing/Packaging Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Bumped `mariadb-connector-c` to 3.1.29. All the ClickHouse-relevant patches preserved. 

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.381`
- Backported to: `26.5.2.33`, `26.4.5.2`, `26.3.14.2`, `25.8.25.15`
<!-- ch-version-info:end -->