### PR TITLE
Fix RestCatalog empty result for non-empty catalogs

### DIFF
--- a/src/Databases/DataLake/RestCatalog.cpp
+++ b/src/Databases/DataLake/RestCatalog.cpp
@@ -624,19 +624,23 @@ DB::ReadWriteBufferFromHTTPPtr RestCatalog::createReadBuffer(
 
 bool RestCatalog::empty() const
 {
-    /// TODO: add a test with empty namespaces and zero namespaces.
     bool found_table = false;
     auto stop_condition = [&](const std::string & namespace_name) -> bool
     {
+        if (found_table)
+            return true;
+
         const auto tables = getTables(namespace_name, /* limit */1);
-        found_table = !tables.empty();
+        if (!tables.empty())
+            found_table = true;
+
         return found_table;
     };
 
     Namespaces namespaces;
     getNamespacesRecursive("", namespaces, stop_condition, /* execute_func */{});
 
-    return found_table;
+    return !found_table;
 }
 
 DB::Names RestCatalog::getTables() const

--- a/src/Databases/DataLake/tests/gtest_rest_catalog.cpp
+++ b/src/Databases/DataLake/tests/gtest_rest_catalog.cpp
@@ -1,0 +1,215 @@
+#include "config.h"
+
+#if USE_AVRO
+
+#include <gtest/gtest.h>
+
+#include <Common/tests/gtest_global_context.h>
+#include <Databases/DataLake/RestCatalog.h>
+#include <Interpreters/Context.h>
+
+#include <Poco/AutoPtr.h>
+#include <Poco/Net/HTTPRequestHandler.h>
+#include <Poco/Net/HTTPRequestHandlerFactory.h>
+#include <Poco/Net/HTTPServer.h>
+#include <Poco/Net/HTTPServerParams.h>
+#include <Poco/Net/HTTPServerRequest.h>
+#include <Poco/Net/HTTPServerResponse.h>
+#include <Poco/Net/ServerSocket.h>
+#include <Poco/Net/SocketAddress.h>
+#include <Poco/SharedPtr.h>
+#include <Poco/URI.h>
+
+#include <memory>
+#include <string>
+
+using namespace DataLake;
+
+namespace
+{
+
+enum class CatalogShape
+{
+    TopLevelTable,
+    NestedTableThenEmptySibling,
+    Empty,
+};
+
+void writeJSON(Poco::Net::HTTPServerResponse & response, const std::string & body)
+{
+    response.setStatus(Poco::Net::HTTPResponse::HTTP_OK);
+    response.setContentType("application/json");
+    response.setContentLength(body.size());
+    response.send() << body;
+}
+
+std::string getRawPath(const std::string & uri)
+{
+    const auto query_pos = uri.find('?');
+    if (query_pos == std::string::npos)
+        return uri;
+    return uri.substr(0, query_pos);
+}
+
+class RestCatalogRequestHandler final : public Poco::Net::HTTPRequestHandler
+{
+public:
+    explicit RestCatalogRequestHandler(CatalogShape shape_)
+        : shape(shape_)
+    {
+    }
+
+    void handleRequest(Poco::Net::HTTPServerRequest & request, Poco::Net::HTTPServerResponse & response) override
+    {
+        Poco::URI uri(request.getURI());
+        const auto path = getRawPath(request.getURI());
+        const auto params = uri.getQueryParameters();
+
+        if (path == "/v1/config")
+        {
+            writeJSON(response, R"({"defaults":{},"overrides":{}})");
+            return;
+        }
+
+        if (path == "/v1/namespaces")
+        {
+            const auto parent = getParent(params);
+            if (parent.empty())
+            {
+                if (shape == CatalogShape::NestedTableThenEmptySibling)
+                    writeJSON(response, R"({"namespaces":[["parent"],["empty_later"]]})");
+                else
+                    writeJSON(response, R"({"namespaces":[["namespace"]]})");
+                return;
+            }
+
+            if (shape == CatalogShape::NestedTableThenEmptySibling && parent == "parent")
+                writeJSON(response, R"({"namespaces":[["leaf_with_table"]]})");
+            else
+                writeJSON(response, R"({"namespaces":[]})");
+            return;
+        }
+
+        if (path == "/v1/namespaces/namespace/tables")
+        {
+            if (shape == CatalogShape::TopLevelTable)
+                writeJSON(response, R"({"identifiers":[{"name":"table_a"}]})");
+            else
+                writeJSON(response, R"({"identifiers":[]})");
+            return;
+        }
+
+        if (path == "/v1/namespaces/parent/tables"
+            || path == "/v1/namespaces/empty_later/tables")
+        {
+            writeJSON(response, R"({"identifiers":[]})");
+            return;
+        }
+
+        if (path == "/v1/namespaces/parent%1Fleaf_with_table/tables")
+        {
+            writeJSON(response, R"({"identifiers":[{"name":"table_a"}]})");
+            return;
+        }
+
+        response.setStatus(Poco::Net::HTTPResponse::HTTP_NOT_FOUND);
+        response.send();
+    }
+
+private:
+    static std::string getParent(const Poco::URI::QueryParameters & params)
+    {
+        for (const auto & [key, value] : params)
+        {
+            if (key == "parent")
+                return value;
+        }
+        return {};
+    }
+
+    CatalogShape shape;
+};
+
+class RestCatalogRequestHandlerFactory final : public Poco::Net::HTTPRequestHandlerFactory
+{
+public:
+    explicit RestCatalogRequestHandlerFactory(CatalogShape shape_)
+        : shape(shape_)
+    {
+    }
+
+    Poco::Net::HTTPRequestHandler * createRequestHandler(const Poco::Net::HTTPServerRequest &) override
+    {
+        return new RestCatalogRequestHandler(shape);
+    }
+
+private:
+    CatalogShape shape;
+};
+
+class RestCatalogTestServer
+{
+public:
+    explicit RestCatalogTestServer(CatalogShape shape)
+        : server_socket(std::make_unique<Poco::Net::ServerSocket>(Poco::Net::SocketAddress("127.0.0.1", 0)))
+        , handler_factory(new RestCatalogRequestHandlerFactory(shape))
+        , server_params(new Poco::Net::HTTPServerParams())
+        , server(std::make_unique<Poco::Net::HTTPServer>(handler_factory, *server_socket, server_params))
+    {
+        server->start();
+    }
+
+    ~RestCatalogTestServer()
+    {
+        server->stop();
+    }
+
+    std::string getUrl() const
+    {
+        return "http://" + server_socket->address().toString();
+    }
+
+private:
+    std::unique_ptr<Poco::Net::ServerSocket> server_socket;
+    Poco::SharedPtr<RestCatalogRequestHandlerFactory> handler_factory;
+    Poco::AutoPtr<Poco::Net::HTTPServerParams> server_params;
+    std::unique_ptr<Poco::Net::HTTPServer> server;
+};
+
+bool restCatalogEmpty(CatalogShape shape)
+{
+    RestCatalogTestServer server(shape);
+    auto context = DB::Context::createCopy(getContext().context);
+    context->makeQueryContext();
+
+    RestCatalog catalog(
+        "warehouse",
+        server.getUrl(),
+        /* catalog_credential */"",
+        /* auth_scope */"",
+        /* auth_header */"",
+        /* oauth_server_uri */"",
+        /* oauth_server_use_request_body */false,
+        context);
+
+    return catalog.empty();
+}
+
+}
+
+TEST(RestCatalog, EmptyReturnsFalseForTopLevelTable)
+{
+    EXPECT_FALSE(restCatalogEmpty(CatalogShape::TopLevelTable));
+}
+
+TEST(RestCatalog, EmptyKeepsFoundTableStateSticky)
+{
+    EXPECT_FALSE(restCatalogEmpty(CatalogShape::NestedTableThenEmptySibling));
+}
+
+TEST(RestCatalog, EmptyReturnsTrueWhenNoTablesExist)
+{
+    EXPECT_TRUE(restCatalogEmpty(CatalogShape::Empty));
+}
+
+#endif

--- a/src/Databases/DataLake/tests/gtest_rest_catalog.cpp
+++ b/src/Databases/DataLake/tests/gtest_rest_catalog.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include <Common/Exception.h>
 #include <Common/tests/gtest_global_context.h>
 #include <Databases/DataLake/RestCatalog.h>
 #include <Interpreters/Context.h>
@@ -24,6 +25,14 @@
 #include <string>
 
 using namespace DataLake;
+
+namespace DB
+{
+namespace ErrorCodes
+{
+    extern const int LOGICAL_ERROR;
+}
+}
 
 namespace
 {
@@ -112,8 +121,7 @@ public:
             return;
         }
 
-        response.setStatus(Poco::Net::HTTPResponse::HTTP_NOT_FOUND);
-        response.send();
+        throw DB::Exception(DB::ErrorCodes::LOGICAL_ERROR, "Unexpected request to fake Iceberg REST catalog: {}", request.getURI());
     }
 
 private:

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -286,25 +286,6 @@ def test_list_tables(started_cluster):
     )
 
 
-def test_rest_catalog_empty_returns_false_when_table_exists(started_cluster):
-    node = started_cluster.instances["node1"]
-
-    database_name = f"rest_catalog_empty_{uuid.uuid4().hex}"
-    root_namespace = f"clickhouse_{uuid.uuid4().hex}"
-    namespace_with_table = f"{root_namespace}.a_has_table"
-    empty_namespace = f"{root_namespace}.z_empty_namespace"
-
-    catalog = load_catalog_impl(started_cluster)
-    catalog.create_namespace(namespace_with_table)
-    create_table(catalog, namespace_with_table, "table_a")
-    catalog.create_namespace(empty_namespace)
-
-    create_clickhouse_iceberg_database(started_cluster, node, database_name)
-
-    error = node.query_and_get_error(f"DETACH DATABASE {database_name}")
-    assert "DATABASE_NOT_EMPTY" in error
-
-
 def test_check_database(started_cluster):
     node = started_cluster.instances["node1"]
 

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -286,6 +286,25 @@ def test_list_tables(started_cluster):
     )
 
 
+def test_rest_catalog_empty_returns_false_when_table_exists(started_cluster):
+    node = started_cluster.instances["node1"]
+
+    database_name = f"rest_catalog_empty_{uuid.uuid4().hex}"
+    root_namespace = f"clickhouse_{uuid.uuid4().hex}"
+    namespace_with_table = f"{root_namespace}.a_has_table"
+    empty_namespace = f"{root_namespace}.z_empty_namespace"
+
+    catalog = load_catalog_impl(started_cluster)
+    catalog.create_namespace(namespace_with_table)
+    create_table(catalog, namespace_with_table, "table_a")
+    catalog.create_namespace(empty_namespace)
+
+    create_clickhouse_iceberg_database(started_cluster, node, database_name)
+
+    error = node.query_and_get_error(f"DROP DATABASE {database_name}")
+    assert "DATABASE_NOT_EMPTY" in error
+
+
 def test_check_database(started_cluster):
     node = started_cluster.instances["node1"]
 

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -133,10 +133,9 @@ def create_clickhouse_iceberg_database(
 
     settings.update(additional_settings)
 
-    drop_clickhouse_iceberg_database_if_exists(node, name)
-
     node.query(
         f"""
+DROP DATABASE IF EXISTS {name};
 CREATE DATABASE {name} ENGINE = DataLakeCatalog('{BASE_URL}', 'minio', '{minio_secret_key}')
 SETTINGS {",".join((k+"="+repr(v) for k, v in settings.items()))}
     """,
@@ -148,16 +147,6 @@ SETTINGS {",".join((k+"="+repr(v) for k, v in settings.items()))}
     show_result = node.query(f"SHOW DATABASE {name}")
     assert minio_secret_key not in show_result
     assert "HIDDEN" in show_result
-
-def drop_clickhouse_iceberg_database_if_exists(node, name):
-    if node.query(f"EXISTS DATABASE {name}").strip() != "1":
-        return
-
-    tables = node.query(f"SHOW TABLES FROM {name}").strip().splitlines()
-    for table in tables:
-        node.query(f"DROP TABLE IF EXISTS {name}.`{table}`")
-
-    node.query(f"DROP DATABASE IF EXISTS {name}")
 
 def create_clickhouse_iceberg_table(
     started_cluster, node, database_name, table_name, schema, additional_settings={}
@@ -312,7 +301,7 @@ def test_rest_catalog_empty_returns_false_when_table_exists(started_cluster):
 
     create_clickhouse_iceberg_database(started_cluster, node, database_name)
 
-    error = node.query_and_get_error(f"DROP DATABASE {database_name}")
+    error = node.query_and_get_error(f"DETACH DATABASE {database_name}")
     assert "DATABASE_NOT_EMPTY" in error
 
 
@@ -873,9 +862,9 @@ def test_not_specified_catalog_type(started_cluster):
         "storage_endpoint": "http://minio1:9001/warehouse-rest",
     }
 
-    drop_clickhouse_iceberg_database_if_exists(node, CATALOG_NAME)
     node.query(
         f"""
+    DROP DATABASE IF EXISTS {CATALOG_NAME};
     CREATE DATABASE {CATALOG_NAME} ENGINE = DataLakeCatalog('{BASE_URL}', 'minio', '{minio_secret_key}')
     SETTINGS {",".join((k+"="+repr(v) for k, v in settings.items()))}
     """,
@@ -969,7 +958,7 @@ def test_system_tables_with_nullptr_table(started_cluster):
     )
     assert int(result.strip()) > 0
 
-    drop_clickhouse_iceberg_database_if_exists(node, CATALOG_NAME)
+    node.query(f"DROP DATABASE IF EXISTS {CATALOG_NAME}")
 
 def test_delete_on_lazy_initialized_table(started_cluster):
     """
@@ -1022,8 +1011,8 @@ def test_delete_on_lazy_initialized_table(started_cluster):
 def test_gcs(started_cluster):
     node = started_cluster.instances["node1"]
 
-    drop_clickhouse_iceberg_database_if_exists(node, CATALOG_NAME)
     node.query("SYSTEM ENABLE FAILPOINT database_iceberg_gcs")
+    node.query(f"DROP DATABASE IF EXISTS {CATALOG_NAME};")
 
     with pytest.raises(Exception) as err:
         node.query(
@@ -1042,7 +1031,7 @@ def test_gcs(started_cluster):
 def test_invalid_auth_header_format(started_cluster):
     node = started_cluster.instances["node1"]
 
-    drop_clickhouse_iceberg_database_if_exists(node, CATALOG_NAME)
+    node.query(f"DROP DATABASE IF EXISTS {CATALOG_NAME};")
     with pytest.raises(Exception) as err:
         node.query(
             f"""

--- a/tests/integration/test_database_iceberg/test.py
+++ b/tests/integration/test_database_iceberg/test.py
@@ -133,9 +133,10 @@ def create_clickhouse_iceberg_database(
 
     settings.update(additional_settings)
 
+    drop_clickhouse_iceberg_database_if_exists(node, name)
+
     node.query(
         f"""
-DROP DATABASE IF EXISTS {name};
 CREATE DATABASE {name} ENGINE = DataLakeCatalog('{BASE_URL}', 'minio', '{minio_secret_key}')
 SETTINGS {",".join((k+"="+repr(v) for k, v in settings.items()))}
     """,
@@ -147,6 +148,16 @@ SETTINGS {",".join((k+"="+repr(v) for k, v in settings.items()))}
     show_result = node.query(f"SHOW DATABASE {name}")
     assert minio_secret_key not in show_result
     assert "HIDDEN" in show_result
+
+def drop_clickhouse_iceberg_database_if_exists(node, name):
+    if node.query(f"EXISTS DATABASE {name}").strip() != "1":
+        return
+
+    tables = node.query(f"SHOW TABLES FROM {name}").strip().splitlines()
+    for table in tables:
+        node.query(f"DROP TABLE IF EXISTS {name}.`{table}`")
+
+    node.query(f"DROP DATABASE IF EXISTS {name}")
 
 def create_clickhouse_iceberg_table(
     started_cluster, node, database_name, table_name, schema, additional_settings={}
@@ -862,9 +873,9 @@ def test_not_specified_catalog_type(started_cluster):
         "storage_endpoint": "http://minio1:9001/warehouse-rest",
     }
 
+    drop_clickhouse_iceberg_database_if_exists(node, CATALOG_NAME)
     node.query(
         f"""
-    DROP DATABASE IF EXISTS {CATALOG_NAME};
     CREATE DATABASE {CATALOG_NAME} ENGINE = DataLakeCatalog('{BASE_URL}', 'minio', '{minio_secret_key}')
     SETTINGS {",".join((k+"="+repr(v) for k, v in settings.items()))}
     """,
@@ -958,7 +969,7 @@ def test_system_tables_with_nullptr_table(started_cluster):
     )
     assert int(result.strip()) > 0
 
-    node.query(f"DROP DATABASE IF EXISTS {CATALOG_NAME}")
+    drop_clickhouse_iceberg_database_if_exists(node, CATALOG_NAME)
 
 def test_delete_on_lazy_initialized_table(started_cluster):
     """
@@ -1011,8 +1022,8 @@ def test_delete_on_lazy_initialized_table(started_cluster):
 def test_gcs(started_cluster):
     node = started_cluster.instances["node1"]
 
+    drop_clickhouse_iceberg_database_if_exists(node, CATALOG_NAME)
     node.query("SYSTEM ENABLE FAILPOINT database_iceberg_gcs")
-    node.query(f"DROP DATABASE IF EXISTS {CATALOG_NAME};")
 
     with pytest.raises(Exception) as err:
         node.query(
@@ -1031,7 +1042,7 @@ def test_gcs(started_cluster):
 def test_invalid_auth_header_format(started_cluster):
     node = started_cluster.instances["node1"]
 
-    node.query(f"DROP DATABASE IF EXISTS {CATALOG_NAME};")
+    drop_clickhouse_iceberg_database_if_exists(node, CATALOG_NAME)
     with pytest.raises(Exception) as err:
         node.query(
             f"""


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/106058

`RestCatalog::empty` returned whether a table was found instead of whether the catalog was empty. The fix keeps the table-found state sticky while walking namespaces, and returns `false` when any table exists.

The regression test uses `DETACH DATABASE` rather than `DROP DATABASE`: `DROP DATABASE` processes catalog tables first and only calls `DatabaseDataLake::empty` as a final guard, while `DETACH DATABASE` exercises the `empty` result without dropping the catalog tables first.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `RestCatalog::empty` returning the wrong result when an Iceberg REST catalog contains tables.


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.5.6.47`, `26.4.5.135`
<!-- ch-version-info:end -->