### PR TITLE
Fix flaky `test_e2e` test

### DIFF
--- a/ci/praktika/utils.py
+++ b/ci/praktika/utils.py
@@ -803,7 +803,7 @@ class Utils:
     def encrypt(cls, path: str, key_path: str, aes_key_path: str) -> str:
         if not Path(f"{aes_key_path}.rsa").exists():
             Shell.run(f"""
-openssl rand 32 >{aes_key_path}
+openssl rand -base64 32 >{aes_key_path}
 openssl pkeyutl -encrypt -pubin -inkey {key_path} -in {aes_key_path} -out {aes_key_path}.rsa \
     -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:sha256
 """)

--- a/ci/praktika/utils.py
+++ b/ci/praktika/utils.py
@@ -801,6 +801,7 @@ class Utils:
 
     @classmethod
     def encrypt(cls, path: str, key_path: str, aes_key_path: str) -> str:
+        # -base64: raw bytes can contain \0 which breaks openssl enc -pass file:
         if not Path(f"{aes_key_path}.rsa").exists():
             Shell.run(f"""
 openssl rand -base64 32 >{aes_key_path}


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

`openssl rand 32` may produce the null character in the password, thus making it shorter. Later on, the password can't be read, and the test fails. The solution is to use base64 encoding to always print ASCII chars.

Closes https://github.com/ClickHouse/ClickHouse/issues/106302

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.333`
<!-- ch-version-info:end -->