### PR TITLE
Fix filesystem cache memory leak from zombie LRU queue entries

### DIFF
--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -845,6 +845,7 @@ The server successfully detected this situation and will download merged part fr
     M(FilesystemCacheUnusedHoldFileSegments, "Filesystem cache file segments count, which were hold, but not used (because of seek or LIMIT n, etc)", ValueType::Number) \
     M(FilesystemCacheFreeSpaceKeepingThreadRun, "Number of times background thread executed free space keeping job", ValueType::Number) \
     M(FilesystemCacheFreeSpaceKeepingThreadWorkMilliseconds, "Time for which background thread executed free space keeping job", ValueType::Milliseconds) \
+    M(FilesystemCacheInvalidatedEntries, "Number of invalidated (zombie) entries removed from filesystem cache LRU queue by background sweep", ValueType::Number) \
     M(FilesystemCacheFailedEvictionCandidates, "Number of file segments which unexpectedly failed to be evicted during dynamic filesystem cache eviction", ValueType::Number) \
     \
     M(RemoteFSSeeks, "Total number of seeks for async buffer", ValueType::Number) \

--- a/src/Interpreters/FileCache/FileCache.cpp
+++ b/src/Interpreters/FileCache/FileCache.cpp
@@ -51,6 +51,7 @@ namespace ProfileEvents
     extern const Event FilesystemCacheFailToReserveSpaceBecauseOfCacheResize;
     extern const Event FilesystemCacheBackgroundEvictedFileSegments;
     extern const Event FilesystemCacheBackgroundEvictedBytes;
+    extern const Event FilesystemCacheInvalidatedEntries;
     extern const Event FilesystemCacheCheckCorrectness;
     extern const Event FilesystemCacheCheckCorrectnessMicroseconds;
 }
@@ -447,11 +448,14 @@ void FileCache::initializeImpl(bool load_metadata)
         throw;
     }
 
-    if (keep_current_size_to_max_ratio != 1 || keep_current_elements_to_max_ratio != 1)
-    {
-        keep_up_free_space_ratio_task = Context::getGlobalContextInstance()->getSchedulePool().createTask(StorageID::createEmpty(), log->name(), [this] { freeSpaceRatioKeepingThreadFunc(); });
-        keep_up_free_space_ratio_task->schedule();
-    }
+    /// Always start the background task: even when keep_free_space_*_ratio is 0
+    /// (the default), the task is needed to sweep invalidated (zombie) entries
+    /// from the LRU queue. Without this, zombie entries accumulate indefinitely
+    /// because iterateImpl uses a read lock and cannot remove entries inline.
+    keep_up_free_space_ratio_task = Context::getGlobalContextInstance()->getSchedulePool().createTask(StorageID::createEmpty(), log->name(), [this] { freeSpaceRatioKeepingThreadFunc(); });
+    keep_up_free_space_ratio_task->schedule();
+    LOG_INFO(log, "Background cache cleanup task started (zombie sweep enabled, batch size: {})",
+             keep_up_free_space_remove_batch);
 
     is_initialized = true;
     LOG_TEST(log, "Initialized cache from {}", metadata.getBaseDirectory());
@@ -1448,8 +1452,37 @@ void FileCache::freeSpaceRatioKeepingThreadFunc()
 
         if (!size_to_evict && !elements_to_evict)
         {
-            /// Nothing to free - all limits are satisfied.
-            keep_up_free_space_ratio_task->scheduleAfter(space_ratio_satisfied_reschedule_ms);
+            /// Release cache_state_guard before taking priority guard locks,
+            /// respecting the lock ordering documented in Guards.h:
+            /// CachePriorityGuard must be acquired before CacheStateGuard.
+            lock.unlock();
+
+            /// Size/element limits are satisfied, but there may still be
+            /// invalidated (zombie) entries in the queue that need cleanup.
+            /// These entries have size=0 and are excluded from State counters,
+            /// so they are invisible to the checks above. We must still sweep
+            /// the queue to remove them, otherwise they leak memory by keeping
+            /// KeyMetadata objects alive via shared_ptr in Entry.
+            IFileCachePriority::InvalidatedEntriesInfos invalidated_entries;
+            bool has_more = main_priority->collectInvalidatedEntries(
+                invalidated_entries, keep_up_free_space_remove_batch, cache_guard);
+
+            if (!invalidated_entries.empty())
+            {
+                LOG_TRACE(
+                    log, "No eviction needed, but sweeping {} invalidated queue entries{}",
+                    invalidated_entries.size(), has_more ? " (more remain)" : "");
+
+                auto wlock = cache_guard.writeLock();
+                IFileCachePriority::removeEntries(invalidated_entries, wlock);
+
+                ProfileEvents::increment(ProfileEvents::FilesystemCacheInvalidatedEntries, invalidated_entries.size());
+            }
+
+            if (has_more)
+                keep_up_free_space_ratio_task->schedule();
+            else
+                keep_up_free_space_ratio_task->scheduleAfter(space_ratio_satisfied_reschedule_ms);
             return;
         }
 
@@ -2153,6 +2186,11 @@ size_t FileCache::getFileSegmentsNum() const
 {
     /// We use this method for metrics, so it is ok to get approximate result.
     return main_priority->getElementsCountApprox();
+}
+
+size_t FileCache::getQueueSize() const
+{
+    return main_priority->getQueueSize();
 }
 
 void FileCache::assertCacheCorrectnessWithProbability()

--- a/src/Interpreters/FileCache/FileCache.h
+++ b/src/Interpreters/FileCache/FileCache.h
@@ -207,6 +207,8 @@ public:
 
     size_t getFileSegmentsNum() const;
 
+    size_t getQueueSize() const;
+
     size_t getMaxFileSegmentSize() const { return max_file_segment_size; }
 
     size_t getBackgroundDownloadMaxFileSegmentSize() const { return background_download_max_file_segment_size.load(); }

--- a/src/Interpreters/FileCache/FileCacheSettings.cpp
+++ b/src/Interpreters/FileCache/FileCacheSettings.cpp
@@ -132,6 +132,11 @@ ColumnsDescription FileCacheSettings::getColumnsDescription()
     result.add(
         ColumnDescription(
             "current_elements_num", std::make_shared<DataTypeUInt64>(), "Current cache elements (file segments) number"));
+    result.add(
+        ColumnDescription(
+            "current_queue_size", std::make_shared<DataTypeUInt64>(),
+            "Actual LRU queue size including invalidated entries. "
+            "Delta with current_elements_num indicates zombie entry count."));
 
     return result;
 }
@@ -151,6 +156,7 @@ void FileCacheSettings::dumpToSystemSettingsColumns(
     res_columns[i++]->insert(cache->isInitialized());
     res_columns[i++]->insert(cache->getUsedCacheSize());
     res_columns[i++]->insert(cache->getFileSegmentsNum());
+    res_columns[i++]->insert(cache->getQueueSize());
 }
 
 void FileCacheSettings::loadFromConfig(

--- a/src/Interpreters/FileCache/IFileCachePriority.h
+++ b/src/Interpreters/FileCache/IFileCachePriority.h
@@ -196,6 +196,10 @@ public:
     virtual size_t getElementsCount(const CacheStateGuard::Lock &) const = 0;
     virtual size_t getElementsCountApprox() const = 0;
 
+    /** Total queue entries including invalidated (zombie) entries.
+      * The difference between this and getElementsCount is the zombie count. */
+    virtual size_t getQueueSize() const = 0;
+
     virtual bool isOvercommitEviction() const { return false; }
     virtual double getSLRUSizeRatio() const { return 0; }
 
@@ -322,6 +326,14 @@ public:
         const CacheStateGuard::Lock & lock) = 0;
 
     virtual void resetEvictionPos() = 0;
+
+    /** Sweep the queue under a read lock and collect up to `limit` invalidated
+      * (zombie) entries. Invalidated entries have size=0 and are excluded from
+      * State counters, so they are invisible to size/element-based eviction
+      * checks. Collected entries can be removed via removeEntries under a
+      * subsequent write lock. Returns true if the sweep was truncated by the
+      * limit (i.e. there may be more zombies to collect). */
+    virtual bool collectInvalidatedEntries(InvalidatedEntriesInfos & invalidated_entries, size_t limit, CachePriorityGuard & cache_guard) = 0;
 
     /// Remove given queue entries for the queue.
     /// Used to cleanup invalidated queue entries.

--- a/src/Interpreters/FileCache/LRUFileCachePriority.cpp
+++ b/src/Interpreters/FileCache/LRUFileCachePriority.cpp
@@ -553,6 +553,25 @@ IFileCachePriority::PriorityDumpPtr LRUFileCachePriority::dump(const CachePriori
     return std::make_shared<IPriorityDump>(res);
 }
 
+bool LRUFileCachePriority::collectInvalidatedEntries(
+    InvalidatedEntriesInfos & invalidated_entries,
+    size_t limit,
+    CachePriorityGuard & cache_guard)
+{
+    auto lock = cache_guard.readLock();
+    for (auto it = queue.begin(); it != queue.end(); ++it)
+    {
+        const auto & entry = **it;
+        if (entry.getState() == Entry::State::Invalidated)
+        {
+            invalidated_entries.emplace_back(*it, std::make_shared<LRUIterator>(this, it));
+            if (invalidated_entries.size() >= limit)
+                return true;
+        }
+    }
+    return false;
+}
+
 bool LRUFileCachePriority::modifySizeLimits(
     size_t max_size_, size_t max_elements_, double /* size_ratio_ */, const CacheStateGuard::Lock & lock)
 {

--- a/src/Interpreters/FileCache/LRUFileCachePriority.h
+++ b/src/Interpreters/FileCache/LRUFileCachePriority.h
@@ -51,6 +51,8 @@ public:
     size_t getElementsCount(const CacheStateGuard::Lock & lock) const override { return state->getElementsCount(lock); }
     size_t getElementsCountApprox() const override { return state->getElementsCountApprox(); }
 
+    size_t getQueueSize() const override { return queue.size(); }
+
     size_t getQueueID() const { return queue_id; }
 
     std::string getStateInfoForLog(const CacheStateGuard::Lock & lock) const override;
@@ -97,6 +99,8 @@ public:
         const OriginInfo & origin_info,
         CachePriorityGuard &,
         CacheStateGuard &) override;
+
+    bool collectInvalidatedEntries(InvalidatedEntriesInfos & invalidated_entries, size_t limit, CachePriorityGuard & cache_guard) override;
 
     bool tryIncreasePriority(
         Iterator & iterator,

--- a/src/Interpreters/FileCache/SLRUFileCachePriority.cpp
+++ b/src/Interpreters/FileCache/SLRUFileCachePriority.cpp
@@ -190,6 +190,16 @@ void SLRUFileCachePriority::iterate(
     probationary_queue.iterate(func, stat, lock);
 }
 
+bool SLRUFileCachePriority::collectInvalidatedEntries(
+    InvalidatedEntriesInfos & invalidated_entries,
+    size_t limit,
+    CachePriorityGuard & cache_guard)
+{
+    if (protected_queue.collectInvalidatedEntries(invalidated_entries, limit, cache_guard))
+        return true;
+    return probationary_queue.collectInvalidatedEntries(invalidated_entries, limit, cache_guard);
+}
+
 void SLRUFileCachePriority::resetEvictionPos()
 {
     protected_queue.resetEvictionPos();

--- a/src/Interpreters/FileCache/SLRUFileCachePriority.h
+++ b/src/Interpreters/FileCache/SLRUFileCachePriority.h
@@ -32,6 +32,8 @@ public:
     size_t getElementsCount(const CacheStateGuard::Lock &) const override;
     size_t getElementsCountApprox() const override;
 
+    size_t getQueueSize() const override { return protected_queue.getQueueSize() + probationary_queue.getQueueSize(); }
+
     size_t getProtectedSize(const CacheStateGuard::Lock & lock) const { return protected_queue.getSize(lock); }
     size_t getProtectedElementsCount(const CacheStateGuard::Lock & lock) const { return protected_queue.getElementsCount(lock); }
     size_t getProbationarySize(const CacheStateGuard::Lock & lock) const { return probationary_queue.getSize(lock); }
@@ -91,6 +93,8 @@ public:
         IterateFunc func,
         FileCacheReserveStat & stat,
         const CachePriorityGuard::ReadLock &) override;
+
+    bool collectInvalidatedEntries(InvalidatedEntriesInfos & invalidated_entries, size_t limit, CachePriorityGuard & cache_guard) override;
 
     bool tryIncreasePriority(
         Iterator & iterator_,

--- a/src/Interpreters/FileCache/SplitFileCachePriority.cpp
+++ b/src/Interpreters/FileCache/SplitFileCachePriority.cpp
@@ -82,6 +82,12 @@ size_t SplitFileCachePriority::getElementsCountApprox() const
         + getPriority(SegmentType::System).getElementsCountApprox();
 }
 
+size_t SplitFileCachePriority::getQueueSize() const
+{
+    return getPriority(SegmentType::Data).getQueueSize()
+        + getPriority(SegmentType::System).getQueueSize();
+}
+
 std::string SplitFileCachePriority::getStateInfoForLog(const CacheStateGuard::Lock & lock) const
 {
     return "DataPriority: " + getPriority(SegmentType::Data).getStateInfoForLog(lock)
@@ -110,6 +116,16 @@ void SplitFileCachePriority::iterate(
 {
     getPriority(SegmentType::Data).iterate(func, stat, lock);
     getPriority(SegmentType::System).iterate(func, stat, lock);
+}
+
+bool SplitFileCachePriority::collectInvalidatedEntries(
+    InvalidatedEntriesInfos & invalidated_entries,
+    size_t limit,
+    CachePriorityGuard & cache_guard)
+{
+    if (getPriority(SegmentType::Data).collectInvalidatedEntries(invalidated_entries, limit, cache_guard))
+        return true;
+    return getPriority(SegmentType::System).collectInvalidatedEntries(invalidated_entries, limit, cache_guard);
 }
 
 bool SplitFileCachePriority::modifySizeLimits(

--- a/src/Interpreters/FileCache/SplitFileCachePriority.h
+++ b/src/Interpreters/FileCache/SplitFileCachePriority.h
@@ -41,6 +41,8 @@ public:
     size_t getElementsCount(const CacheStateGuard::Lock &) const override;
     size_t getElementsCountApprox() const override;
 
+    size_t getQueueSize() const override;
+
     std::string getStateInfoForLog(const CacheStateGuard::Lock & lock) const override;
 
     bool canFit( /// NOLINT
@@ -98,6 +100,8 @@ public:
         IterateFunc func,
         FileCacheReserveStat & stat,
         const CachePriorityGuard::ReadLock & lock) override;
+
+    bool collectInvalidatedEntries(InvalidatedEntriesInfos & invalidated_entries, size_t limit, CachePriorityGuard & cache_guard) override;
 
     void shuffle(const CachePriorityGuard::WriteLock &) override;
 

--- a/src/Interpreters/tests/gtest_filecache.cpp
+++ b/src/Interpreters/tests/gtest_filecache.cpp
@@ -2142,3 +2142,91 @@ TEST_F(FileCacheTest, FailedEvictionRestorePreservesInvariants)
         ASSERT_LE(cache->getUsedCacheSize(), 4u);
     }
 }
+
+TEST_F(FileCacheTest, CollectInvalidatedEntries)
+{
+    /// Regression for the zombie-leak bug:
+    /// `iterate` runs under a `ReadLock` and cannot remove invalidated
+    /// entries from the underlying `std::list`. They must be drained by
+    /// `collectInvalidatedEntries` (read-locked walk) followed by
+    /// `removeEntries` (write-locked drain).
+
+    ServerUUID::setRandomForUnitTests();
+
+    size_t max_size = 1000;
+    size_t max_elements = 100;
+
+    LRUFileCachePriority priority(max_size, max_elements);
+
+    std::string cache_path = std::filesystem::path(caches_dir) / "test_invalidated_sweep";
+    CacheMetadata cache_metadata(cache_path, 0, 0, false);
+
+    auto key = DB::FileCacheKey::fromPath("zombie_key");
+    auto origin = FileCache::getCommonOrigin();
+
+    CacheStateGuard state_guard;
+    CachePriorityGuard cache_guard;
+    auto key_metadata = std::make_shared<KeyMetadata>(key, origin, &cache_metadata);
+
+    auto add_entry = [&](size_t offset, size_t size)
+    {
+        auto write_lock = cache_guard.writeLock();
+        auto state_lock = state_guard.lock();
+        return priority.add(key_metadata, offset, size, write_lock, &state_lock);
+    };
+
+    auto it1 = add_entry(0, 10);
+    auto it2 = add_entry(10, 10);
+    auto it3 = add_entry(20, 10);
+
+    ASSERT_EQ(priority.getQueueSize(), 3u);
+    ASSERT_EQ(priority.getElementsCount(state_guard.lock()), 3u);
+
+    /// Invalidate two entries. State counters drop, but `queue.size()` does
+    /// not change — these are the zombies.
+    it1->invalidate();
+    it3->invalidate();
+
+    ASSERT_EQ(priority.getQueueSize(), 3u);                                /// list unchanged
+    ASSERT_EQ(priority.getElementsCount(state_guard.lock()), 1u);          /// counters did drop
+    ASSERT_EQ(priority.getQueueSize() - priority.getElementsCount(state_guard.lock()), 2u);
+
+    /// Sweep: collect under ReadLock, drain under WriteLock.
+    IFileCachePriority::InvalidatedEntriesInfos invalidated;
+    bool has_more = priority.collectInvalidatedEntries(invalidated, /* limit */ 100, cache_guard);
+    ASSERT_FALSE(has_more);
+    ASSERT_EQ(invalidated.size(), 2u);
+
+    IFileCachePriority::removeEntries(invalidated, cache_guard.writeLock());
+
+    ASSERT_EQ(priority.getQueueSize(), 1u);                                /// zombies drained
+    ASSERT_EQ(priority.getElementsCount(state_guard.lock()), 1u);
+
+    /// Batch limit is respected: invalidate one more, ask for limit=1, expect has_more=false
+    /// because there is exactly one zombie. Then invalidate another and verify limit truncation.
+    it2->invalidate();
+    auto it4 = add_entry(30, 10);
+    auto it5 = add_entry(40, 10);
+    it4->invalidate();
+    it5->invalidate();
+
+    ASSERT_EQ(priority.getQueueSize(), 3u);
+    ASSERT_EQ(priority.getElementsCount(state_guard.lock()), 0u);
+
+    invalidated.clear();
+    has_more = priority.collectInvalidatedEntries(invalidated, /* limit */ 2, cache_guard);
+    ASSERT_TRUE(has_more);                                                 /// truncated by limit
+    ASSERT_EQ(invalidated.size(), 2u);
+
+    IFileCachePriority::removeEntries(invalidated, cache_guard.writeLock());
+    ASSERT_EQ(priority.getQueueSize(), 1u);
+
+    invalidated.clear();
+    has_more = priority.collectInvalidatedEntries(invalidated, /* limit */ 100, cache_guard);
+    ASSERT_FALSE(has_more);
+    ASSERT_EQ(invalidated.size(), 1u);
+    IFileCachePriority::removeEntries(invalidated, cache_guard.writeLock());
+
+    ASSERT_EQ(priority.getQueueSize(), 0u);
+    ASSERT_EQ(priority.getElementsCount(state_guard.lock()), 0u);
+}


### PR DESCRIPTION
The filesystem cache leaks ~224-byte `KeyMetadata` objects and ~96-byte LRU entry nodes when invalidated queue entries are never removed from the underlying `std::list`. The condition arises because `iterate` runs under a `ReadLock` and cannot remove entries inline, while the background cleanup task that could remove them was only started when `keep_free_space_*_ratio != 0` (default: 0). Observed unbounded linear growth (~0.82 GiB/hr) in production.

This PR makes the background task always run and adds a `collectInvalidatedEntries` sweep that drains zombie entries under the proper read-lock-then-write-lock discipline. New `system.events` row `FilesystemCacheInvalidatedEntries` and a `current_queue_size` column in `system.filesystem_cache_settings` provide observability.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix unbounded memory growth in the filesystem cache caused by invalidated LRU queue entries that were never removed when both `keep_free_space_size_ratio` and `keep_free_space_elements_ratio` are 0 (the default).
