### PR TITLE
(storage) OneLake: use blob endpoint instead of dfs

### DIFF
--- a/src/Storages/ObjectStorage/Azure/Configuration.cpp
+++ b/src/Storages/ObjectStorage/Azure/Configuration.cpp
@@ -354,7 +354,7 @@ void AzureStorageParsedArguments::initializeForOneLake(ASTs & args, ContextPtr c
 
     String connection_url = checkAndGetLiteralArgument<String>(args[0], "connection_string/storage_account_url");
 
-    fillBlobsFromURLCommon(connection_url, ".com", ".dfs.fabric.microsoft.com");
+    fillBlobsFromURLCommon(connection_url, ".com", ".blob.fabric.microsoft.com");
 
     connection_params.endpoint.container_already_exists = true;
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

  (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->
Closes: https://github.com/ClickHouse/ClickHouse/issues/106344


### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Improve `DataLakeCatalog` initialization for `onelake`: use OneLake blob endpoint (`.blob.fabric.microsoft.com`).

### Explanation of changes
- `initializeForOneLake` now maps OneLake to `.blob.fabric.microsoft.com` instead of `.dfs.fabric.microsoft.com`.
	This is necessary because the table metadata and object access path uses Azure Blob operations; using a DFS endpoint can lead to partial behavior where catalog listing succeeds but metadata/table operations fail.


Verified and tested the fix manually with OneLake account. 