### PR TITLE
Enable GitHub auth for nightly clickhousectl upload job

### DIFF
--- a/ci/workflows/nightly_upload.py
+++ b/ci/workflows/nightly_upload.py
@@ -11,6 +11,7 @@ workflow = Workflow.Config(
             name="Upload clickhousectl",
             command="python3 ./ci/jobs/upload_clickhousectl.py",
             runs_on=RunnerLabels.STYLE_CHECK_ARM,
+            enable_gh_auth=True,
         )
     ],
     secrets=SECRETS,


### PR DESCRIPTION
Add `enable_gh_auth=True` to the "Upload clickhousectl" job in the nightly upload workflow so it can authenticate to GitHub via the GH App when running the upload.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.337`
<!-- ch-version-info:end -->