### PR TITLE
Fix xdist race in Azure backup integration config

### DIFF
--- a/tests/integration/test_backup_restore_azure_blob_storage/test.py
+++ b/tests/integration/test_backup_restore_azure_blob_storage/test.py
@@ -11,9 +11,11 @@ from helpers.cluster import ClickHouseCluster
 
 
 def generate_cluster_def(port):
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER", "")
+    suffix = f"_{worker_id}" if worker_id else ""
     path = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
-        "./_gen/named_collections.xml",
+        f"./_gen/named_collections{suffix}.xml",
     )
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, "w") as f:


### PR DESCRIPTION
When `test_backup_restore_azure_blob_storage/test.py` runs under `pytest-xdist`, every worker calls `generate_cluster_def`, which wrote the generated config to a single shared path `./_gen/named_collections.xml`. Concurrent workers write to the same file at the same time, so a worker can read a partially written config, and the server then fails to start.

This is observed in `Integration tests (amd_asan_ubsan, flaky)`, where the job fails (and the worker effectively hangs) in `cluster.start()`:

```
Fail [test_backup_restore_azure_blob_storage/test.py::test_backup_restore_on_merge_tree_with_checksum_data_file_name]
  | File: test_backup_restore_azure_blob_storage/test.py:85 - in cluster
  |     cluster.start()
  | File: helpers/cluster.py:5911 - in wait_until_port_is_ready
  |     raise Exception(
  | E   Exception: Instance `node' failed to start. Container status: exited
```

This change gives each worker its own config path by appending the `PYTEST_XDIST_WORKER` id as a suffix, so parallel workers no longer share the same file.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.360`
<!-- ch-version-info:end -->