### PR TITLE
Fix PREWHERE IN-subquery primary key pruning regression

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -2270,18 +2270,18 @@ void ReadFromMergeTree::applyFilters(ActionDAGNodes added_filter_nodes)
                 deferred_prewhere_info != nullptr);
         }
 
-        /// Build sets for PREWHERE and row_level_filter synchronously during applyFilters.
-        /// PREWHERE is evaluated at the storage level during data reading, before the
-        /// pipeline-level CreatingSetsStep has a chance to execute. Although CreatingSetsStep
-        /// uses DelayedPortsProcessor to ensure sets are built before the main query starts,
-        /// there is a race condition: if a downstream processor (e.g. JoiningTransform with
-        /// an empty right side) closes its inputs early, DelayedPortsProcessor may terminate
-        /// the set-building pipeline before the set is ready.
-        /// Building sets synchronously here eliminates this race condition entirely.
+        /// Build PREWHERE/row-level-filter sets before buildIndexes. Ordered build first so the
+        /// IN-subquery set keeps explicit elements for primary-key pruning; the unordered build
+        /// is a fallback for sets the ordered pass skips (use_index_for_in_with_subqueries=0).
+        auto build_prewhere_sets = [&](const ActionsDAG & filter_dag)
+        {
+            VirtualColumnUtils::buildOrderedSetsForDAG(filter_dag, context);
+            VirtualColumnUtils::buildSetsForDAG(filter_dag, context);
+        };
         if (query_info.prewhere_info)
-            VirtualColumnUtils::buildSetsForDAG(query_info.prewhere_info->prewhere_actions, context);
+            build_prewhere_sets(query_info.prewhere_info->prewhere_actions);
         if (query_info.row_level_filter)
-            VirtualColumnUtils::buildSetsForDAG(query_info.row_level_filter->actions, context);
+            build_prewhere_sets(query_info.row_level_filter->actions);
 
         buildIndexes(
             indexes,

--- a/tests/queries/0_stateless/04304_prewhere_in_subquery_pk_pruning.reference
+++ b/tests/queries/0_stateless/04304_prewhere_in_subquery_pk_pruning.reference
@@ -1,0 +1,1 @@
+Condition: (client_id in 1-element set)

--- a/tests/queries/0_stateless/04304_prewhere_in_subquery_pk_pruning.sql
+++ b/tests/queries/0_stateless/04304_prewhere_in_subquery_pk_pruning.sql
@@ -1,0 +1,33 @@
+-- Tags: no-parallel-replicas
+DROP TABLE IF EXISTS t_04304 SYNC;
+
+CREATE TABLE t_04304
+(
+    client_id UInt32,
+    request_time DateTime64(3, 'UTC'),
+    payload String
+)
+ENGINE = MergeTree
+ORDER BY (client_id, request_time)
+SETTINGS index_granularity = 8192;
+
+INSERT INTO t_04304
+SELECT number % 100, now() - toIntervalSecond(number % 604800), 'x'
+FROM numbers(200000);
+
+SET optimize_move_to_prewhere = 1;
+SET query_plan_optimize_prewhere = 1;
+SET use_index_for_in_with_subqueries = 1;
+
+-- The PrimaryKey condition for PREWHERE col IN (subquery) must reference the key set,
+-- not collapse to "true" (issue #106336).
+SELECT trim(explain) FROM
+(
+    EXPLAIN indexes = 1
+    SELECT count()
+    FROM t_04304
+    PREWHERE client_id IN (SELECT client_id FROM t_04304 LIMIT 10)
+)
+WHERE explain LIKE '%Condition:%';
+
+DROP TABLE t_04304 SYNC;


### PR DESCRIPTION
Closes #106336

Since 26.2, `SELECT ... FROM t PREWHERE key_col IN (SELECT ...)` stopped using the primary key for granule pruning. `EXPLAIN indexes = 1` shows the PrimaryKey condition collapse to `true` and all granules being read.

Root cause: PR #98522 began building PREWHERE/row-level-filter sets in `ReadFromMergeTree::applyFilters` before `buildIndexes`, using the unordered `buildSetsForDAG`. The unordered build marks the shared `FutureSetFromSubquery` as created without explicit set elements. `KeyCondition::tryPrepareSetIndexForIn` then calls `buildOrderedSetInplace` on the already-created set, sees `hasExplicitSetElements() == false`, and returns nullptr, so the PrimaryKey condition for the IN expression degrades to `true`.

Fix: build the ordered set first (so the set keeps explicit elements usable for primary-key pruning), then run the unordered build as a fallback for the sets the ordered pass skips (`use_index_for_in_with_subqueries = 0`).

Verified with `EXPLAIN indexes = 1`: without the fix `Condition: true` (all granules read); with the fix `Condition: (client_id in N-element set)` and granules pruned. Added regression test `04304_prewhere_in_subquery_pk_pruning`.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a regression where `PREWHERE col IN (subquery)` stopped using the primary key for index pruning, causing full scans of all granules.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)