### PR TITLE
Make regexpExtract return the whole match for patterns without a capturing group

### DIFF
--- a/src/Functions/regexpExtract.cpp
+++ b/src/Functions/regexpExtract.cpp
@@ -94,8 +94,9 @@ public:
         else if (!column_index || isColumnConst(*column_index))
         {
             const auto * col_const_index = typeid_cast<const ColumnConst *>(column_index.get());
+            const bool index_omitted = !column_index;
             ssize_t index = !col_const_index ? 1 : col_const_index->getInt(0);
-            vectorConstant(col->getChars(), col->getOffsets(), col_pattern->getValue<String>(), index, vec_res, offsets_res);
+            vectorConstant(col->getChars(), col->getOffsets(), col_pattern->getValue<String>(), index, index_omitted, vec_res, offsets_res);
         }
         else
             vectorVector(col->getChars(), col->getOffsets(), col_pattern->getValue<String>(), column_index, vec_res, offsets_res);
@@ -130,11 +131,15 @@ private:
         const ColumnString::Offsets & offsets,
         const std::string & pattern,
         ssize_t index,
+        bool index_omitted,
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets) const
     {
         const OptimizedRegularExpression regexp = Regexps::createRegexp<false, false, false>(pattern);
         unsigned capture = regexp.getNumberOfSubpatterns();
+        /// A pattern with no capturing group only has group 0, so the default index 1 falls back to it.
+        if (index_omitted && capture == 0)
+            index = 0;
         if (index < 0 || index >= capture + 1)
             throw Exception(
                 ErrorCodes::INDEX_OF_POSITIONAL_ARGUMENT_IS_OUT_OF_RANGE,

--- a/src/Functions/regexpExtract.cpp
+++ b/src/Functions/regexpExtract.cpp
@@ -261,8 +261,8 @@ Extracts the first string in `haystack` that matches the regexp pattern and corr
     FunctionDocumentation::Syntax syntax = "regexpExtract(haystack, pattern[, index])";
     FunctionDocumentation::Arguments arguments = {
         {"haystack", "String, in which regexp pattern will be matched.", {"String"}},
-        {"pattern", "String, regexp expression. `pattern` may contain multiple regexp groups, `index` indicates which regex group to extract. An index of 0 means matching the entire regular expression.", {"const String"}},
-        {"index", "Optional. An integer number greater or equal 0 with default 1. It represents which regex group to extract.", {"(U)Int*"}},
+        {"pattern", "String, regexp expression. `pattern` may contain multiple regexp groups, `index` indicates which regex group to extract. An index of `0` means matching the entire regular expression.", {"const String"}},
+        {"index", "Optional. A non-negative integer indicating which regex group to extract. The default is `1` if `pattern` contains at least one capturing group, and `0` (the whole match) if `pattern` has no capturing group.", {"(U)Int*"}},
     };
     FunctionDocumentation::ReturnedValue returned_value = {
         "Returns a string match",
@@ -277,12 +277,13 @@ SELECT
     regexpExtract('100-200', '(\\d+)-(\\d+)', 1),
     regexpExtract('100-200', '(\\d+)-(\\d+)', 2),
     regexpExtract('100-200', '(\\d+)-(\\d+)', 0),
-    regexpExtract('100-200', '(\\d+)-(\\d+)');
+    regexpExtract('100-200', '(\\d+)-(\\d+)'),
+    regexpExtract('100-200', '\\d+');
         )",
         R"(
-┌─regexpExtract('100-200', '(\\d+)-(\\d+)', 1)─┬─regexpExtract('100-200', '(\\d+)-(\\d+)', 2)─┬─regexpExtract('100-200', '(\\d+)-(\\d+)', 0)─┬─regexpExtract('100-200', '(\\d+)-(\\d+)')─┐
-│ 100                                          │ 200                                          │ 100-200                                      │ 100                                       │
-└──────────────────────────────────────────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┴───────────────────────────────────────────┘
+┌─regexpExtract('100-200', '(\\d+)-(\\d+)', 1)─┬─regexpExtract('100-200', '(\\d+)-(\\d+)', 2)─┬─regexpExtract('100-200', '(\\d+)-(\\d+)', 0)─┬─regexpExtract('100-200', '(\\d+)-(\\d+)')─┬─regexpExtract('100-200', '\\d+')─┐
+│ 100                                          │ 200                                          │ 100-200                                      │ 100                                       │ 100                              │
+└──────────────────────────────────────────────┴──────────────────────────────────────────────┴──────────────────────────────────────────────┴───────────────────────────────────────────┴──────────────────────────────────┘
         )"
     }
     };

--- a/src/Functions/regexpExtract.cpp
+++ b/src/Functions/regexpExtract.cpp
@@ -1,3 +1,5 @@
+#include <optional>
+
 #include <Columns/ColumnConst.h>
 #include <Columns/ColumnString.h>
 #include <DataTypes/DataTypeString.h>
@@ -94,9 +96,10 @@ public:
         else if (!column_index || isColumnConst(*column_index))
         {
             const auto * col_const_index = typeid_cast<const ColumnConst *>(column_index.get());
-            const bool index_omitted = !column_index;
-            ssize_t index = !col_const_index ? 1 : col_const_index->getInt(0);
-            vectorConstant(col->getChars(), col->getOffsets(), col_pattern->getValue<String>(), index, index_omitted, vec_res, offsets_res);
+            std::optional<ssize_t> index_arg;
+            if (col_const_index)
+                index_arg = col_const_index->getInt(0);
+            vectorConstant(col->getChars(), col->getOffsets(), col_pattern->getValue<String>(), index_arg, vec_res, offsets_res);
         }
         else
             vectorVector(col->getChars(), col->getOffsets(), col_pattern->getValue<String>(), column_index, vec_res, offsets_res);
@@ -130,16 +133,14 @@ private:
         const ColumnString::Chars & data,
         const ColumnString::Offsets & offsets,
         const std::string & pattern,
-        ssize_t index,
-        bool index_omitted,
+        std::optional<ssize_t> index_arg,
         ColumnString::Chars & res_data,
         ColumnString::Offsets & res_offsets) const
     {
         const OptimizedRegularExpression regexp = Regexps::createRegexp<false, false, false>(pattern);
         unsigned capture = regexp.getNumberOfSubpatterns();
-        /// A pattern with no capturing group only has group 0, so the default index 1 falls back to it.
-        if (index_omitted && capture == 0)
-            index = 0;
+        /// Default index: `1` when capture groups exist, `0` (whole match) otherwise.
+        ssize_t index = index_arg.value_or(capture == 0 ? 0 : 1);
         if (index < 0 || index >= capture + 1)
             throw Exception(
                 ErrorCodes::INDEX_OF_POSITIONAL_ARGUMENT_IS_OUT_OF_RANGE,

--- a/tests/queries/0_stateless/04305_regexp_extract_no_capture_group.reference
+++ b/tests/queries/0_stateless/04305_regexp_extract_no_capture_group.reference
@@ -1,0 +1,24 @@
+-- { echoOn }
+-- Two-argument form with a pattern that has no capturing group returns the whole match (group 0)
+-- instead of throwing INDEX_OF_POSITIONAL_ARGUMENT_IS_OUT_OF_RANGE.
+select regexpExtract('100-200', '');
+
+select regexpExtract('100-200', '\\d+');
+100
+select regexpExtract('100-200', '\\d+-\\d+');
+100-200
+select regexpExtract(materialize('100-200'), '\\d+');
+100
+select regexpExtract(materialize('100-200'), '');
+
+select regexpExtract(number::String, '\\d+') from numbers(3);
+0
+1
+2
+-- Explicit index is still honored: a pattern with no group only has group 0, index 1 is out of range.
+select regexpExtract('100-200', '\\d+', 0);
+100
+select regexpExtract('100-200', '\\d+', 1); -- { serverError INDEX_OF_POSITIONAL_ARGUMENT_IS_OUT_OF_RANGE }
+-- A pattern with a capturing group keeps the default index 1 (first group).
+select regexpExtract('100-200', '(\\d+)-(\\d+)');
+100

--- a/tests/queries/0_stateless/04305_regexp_extract_no_capture_group.sql
+++ b/tests/queries/0_stateless/04305_regexp_extract_no_capture_group.sql
@@ -1,0 +1,17 @@
+-- { echoOn }
+-- Two-argument form with a pattern that has no capturing group returns the whole match (group 0)
+-- instead of throwing INDEX_OF_POSITIONAL_ARGUMENT_IS_OUT_OF_RANGE.
+select regexpExtract('100-200', '');
+select regexpExtract('100-200', '\\d+');
+select regexpExtract('100-200', '\\d+-\\d+');
+select regexpExtract(materialize('100-200'), '\\d+');
+select regexpExtract(materialize('100-200'), '');
+select regexpExtract(number::String, '\\d+') from numbers(3);
+
+-- Explicit index is still honored: a pattern with no group only has group 0, index 1 is out of range.
+select regexpExtract('100-200', '\\d+', 0);
+select regexpExtract('100-200', '\\d+', 1); -- { serverError INDEX_OF_POSITIONAL_ARGUMENT_IS_OUT_OF_RANGE }
+
+-- A pattern with a capturing group keeps the default index 1 (first group).
+select regexpExtract('100-200', '(\\d+)-(\\d+)');
+-- { echoOff }


### PR DESCRIPTION
The two-argument form `regexpExtract(haystack, pattern)` defaults the group index to 1. A pattern with no capturing group only has group 0 (the whole match), so the default index 1 was out of range and the function threw `INDEX_OF_POSITIONAL_ARGUMENT_IS_OUT_OF_RANGE` instead of returning anything useful. For example `regexpExtract('100-200', '\d+')` failed.

Now, when the index is omitted and the pattern has no capturing group, the function falls back to group 0 and returns the whole match. An explicitly supplied out-of-range index still throws, and patterns with at least one capturing group keep the default index 1.

Closes: https://github.com/ClickHouse/ClickHouse/issues/56393

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix `regexpExtract(haystack, pattern)` so that patterns without a capturing group return the whole match instead of throwing `INDEX_OF_POSITIONAL_ARGUMENT_IS_OUT_OF_RANGE`.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.537`
<!-- ch-version-info:end -->