### PR TITLE
Handle truncated S3 objects in predownloadForFileSegment and readBigAt

### DIFF
--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -811,6 +811,18 @@ bool CachedOnDiskReadBufferFromFile::predownloadForFileSegment(
                             file_segment.getInfoForLog());
 
                         state.bytes_to_predownload = 0;
+
+                        /// Mark the segment as not-to-be-continued before resetting the
+                        /// downloader, matching the readFromFileSegment EOF handling. Otherwise
+                        /// completePartAndResetDownloader leaves the segment PARTIALLY_DOWNLOADED
+                        /// (downloaded size is the real, truncated object size, which is less than
+                        /// the stale range size). On completion that would enqueue a background
+                        /// download (filesystem_cache_allow_background_download is on by default)
+                        /// or let a later reader become downloader and retry past the real EOF.
+                        /// PARTIALLY_DOWNLOADED_NO_CONTINUATION instead shrinks the segment to the
+                        /// downloaded size and never continues. completePartAndResetDownloader
+                        /// accepts this state and only resets the downloader, preserving it.
+                        file_segment.setDownloadFinishedWithoutContinuation();
                         file_segment.completePartAndResetDownloader();
                         state.read_type = ReadType::REMOTE_FS_READ_BYPASS_CACHE;
 

--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -826,13 +826,18 @@ bool CachedOnDiskReadBufferFromFile::predownloadForFileSegment(
                         file_segment.completePartAndResetDownloader();
                         state.read_type = ReadType::REMOTE_FS_READ_BYPASS_CACHE;
 
-                        /// Adjust read_until_position to the actual object size so
-                        /// the caller knows the real data boundary. Without this,
-                        /// the caller would seek to `offset` (beyond the truncated
-                        /// object), get zero bytes, and the existing truncation guard
-                        /// (`object_size == offset`) would fail because
-                        /// object_size < offset by construction.
-                        info.read_until_position = *object_size;
+                        /// Move the read boundary down to the current offset so the
+                        /// caller treats this position as EOF (the `offset >=
+                        /// read_until_position` guards below and in readBigAt then fire).
+                        /// Set it to `offset`, NOT to `*object_size`: `offset` equals
+                        /// `file_offset_of_buffer_end` here and `*object_size < offset`
+                        /// by construction, so using `*object_size` would push the
+                        /// boundary behind the buffer end and violate the
+                        /// `file_offset_of_buffer_end <= read_until_position` invariant
+                        /// (chassert in nextImplStep / throw in getRemainingSizeToRead).
+                        /// This matches the readFromFileSegment EOF path, which likewise
+                        /// sets `info.read_until_position = offset`.
+                        info.read_until_position = offset;
 
                         return false;
                     }

--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -46,6 +46,7 @@ namespace ErrorCodes
     extern const int ARGUMENT_OUT_OF_BOUND;
     extern const int UNKNOWN_FILE_SIZE;
     extern const int CACHE_CANNOT_WRITE_TO_CACHE_DISK;
+    extern const int CANNOT_READ_ALL_DATA;
 }
 
 CachedOnDiskReadBufferFromFile::ReadInfo::ReadInfo(
@@ -794,52 +795,32 @@ bool CachedOnDiskReadBufferFromFile::predownloadForFileSegment(
                 if (state.bytes_to_predownload)
                 {
                     /// The remote object may have been overwritten with shorter content
-                    /// between listing and reading. Check the actual remote file size
-                    /// before throwing an error (same logic as in readFromFileSegment).
+                    /// between listing and reading. Check the actual remote file size to
+                    /// distinguish that from a genuine logic error.
                     auto object_size = state.buf->getRemoteFileSize();
                     if (object_size.has_value()
                         && *object_size == file_segment.getCurrentWriteOffset())
                     {
-                        LOG_WARNING(
-                            log,
-                            "Remote object is smaller than expected during predownload. "
-                            "Remaining bytes to predownload: {}, current write offset: {}, "
-                            "actual object size: {}, file segment: {}. Treating as truncated object.",
-                            state.bytes_to_predownload,
-                            file_segment.getCurrentWriteOffset(),
+                        /// We reached the real end of the (now shorter) object while
+                        /// predownloading, before reaching the bytes the reader actually
+                        /// needs: those lie beyond the truncated object, because
+                        /// offset == current_write_offset + bytes_to_predownload > *object_size.
+                        ///
+                        /// There is no valid data to return for `offset`. We must NOT treat
+                        /// this as EOF (return a short/zero read): the caller would then
+                        /// consume buffer bytes that were never written -- a
+                        /// use-of-uninitialized-value under MSan, and silent garbage in
+                        /// release. Fail with a regular CANNOT_READ_ALL_DATA instead of a
+                        /// LOGICAL_ERROR: it does not alert as a server bug and is retryable
+                        /// while the object is being concurrently replaced.
+                        throw Exception(
+                            ErrorCodes::CANNOT_READ_ALL_DATA,
+                            "Remote object was truncated between listing and reading: "
+                            "actual object size {}, but need to read until offset {}. "
+                            "Current file segment: {}",
                             *object_size,
+                            offset,
                             file_segment.getInfoForLog());
-
-                        state.bytes_to_predownload = 0;
-
-                        /// Mark the segment as not-to-be-continued before resetting the
-                        /// downloader, matching the readFromFileSegment EOF handling. Otherwise
-                        /// completePartAndResetDownloader leaves the segment PARTIALLY_DOWNLOADED
-                        /// (downloaded size is the real, truncated object size, which is less than
-                        /// the stale range size). On completion that would enqueue a background
-                        /// download (filesystem_cache_allow_background_download is on by default)
-                        /// or let a later reader become downloader and retry past the real EOF.
-                        /// PARTIALLY_DOWNLOADED_NO_CONTINUATION instead shrinks the segment to the
-                        /// downloaded size and never continues. completePartAndResetDownloader
-                        /// accepts this state and only resets the downloader, preserving it.
-                        file_segment.setDownloadFinishedWithoutContinuation();
-                        file_segment.completePartAndResetDownloader();
-                        state.read_type = ReadType::REMOTE_FS_READ_BYPASS_CACHE;
-
-                        /// Move the read boundary down to the current offset so the
-                        /// caller treats this position as EOF (the `offset >=
-                        /// read_until_position` guards below and in readBigAt then fire).
-                        /// Set it to `offset`, NOT to `*object_size`: `offset` equals
-                        /// `file_offset_of_buffer_end` here and `*object_size < offset`
-                        /// by construction, so using `*object_size` would push the
-                        /// boundary behind the buffer end and violate the
-                        /// `file_offset_of_buffer_end <= read_until_position` invariant
-                        /// (chassert in nextImplStep / throw in getRemainingSizeToRead).
-                        /// This matches the readFromFileSegment EOF path, which likewise
-                        /// sets `info.read_until_position = offset`.
-                        info.read_until_position = offset;
-
-                        return false;
                     }
 
                     throw Exception(
@@ -1243,13 +1224,6 @@ size_t CachedOnDiskReadBufferFromFile::readFromFileSegment(
         {
             chassert(!state.buf->available());
             chassert(state.read_type == ReadType::REMOTE_FS_READ_BYPASS_CACHE);
-
-            /// If predownload detected a truncated remote object, it adjusts
-            /// info.read_until_position to the actual object size, which may be
-            /// less than our current offset. In that case there is nothing left
-            /// to read — return 0 so the caller treats it as EOF.
-            if (offset >= info.read_until_position)
-                return 0;
 
             auto buf = getRemoteReadBuffer(file_segment, offset, ReadType::REMOTE_FS_READ_BYPASS_CACHE, info);
             buf->setReadUntilPosition(file_segment.range().right + 1); /// [..., range.right]

--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -251,6 +251,28 @@ namespace
 using ReadType = CachedOnDiskReadBufferFromFile::ReadType;
 using ReadInfo = CachedOnDiskReadBufferFromFile::ReadInfo;
 
+/// Fetch the remote object's last modification time for diagnostics, alongside its size: a recent
+/// timestamp confirms the object was overwritten between listing and reading. Best-effort -- a
+/// failed metadata request must never mask the diagnostic we are building, so fall back to "None".
+String getRemoteFileLastModifiedForLog(ReadBufferFromFileBase & buf)
+{
+    std::optional<time_t> last_modified;
+    try
+    {
+        last_modified = buf.getRemoteFileLastModificationTime();
+    }
+    catch (...) // NOLINT(bugprone-empty-catch)
+    {
+    }
+
+    if (!last_modified.has_value())
+        return "None";
+
+    WriteBufferFromOwnString out;
+    writeDateTimeText(*last_modified, out);
+    return fmt::format("{} (unix time {})", out.str(), *last_modified);
+}
+
 std::shared_ptr<ReadBufferFromFileBase> getCacheReadBuffer(
     const FileSegment & file_segment,
     ReadInfo & info)
@@ -816,9 +838,10 @@ bool CachedOnDiskReadBufferFromFile::predownloadForFileSegment(
                         throw Exception(
                             ErrorCodes::CANNOT_READ_ALL_DATA,
                             "Remote object was truncated between listing and reading: "
-                            "actual object size {}, but need to read until offset {}. "
+                            "actual object size {}, last modified {}, but need to read until offset {}. "
                             "Current file segment: {}",
                             *object_size,
+                            getRemoteFileLastModifiedForLog(*state.buf),
                             offset,
                             file_segment.getInfoForLog());
                     }
@@ -827,14 +850,15 @@ bool CachedOnDiskReadBufferFromFile::predownloadForFileSegment(
                         ErrorCodes::LOGICAL_ERROR,
                         "Failed to predownload remaining {} bytes. Current file segment: {}, "
                         "current download offset: {}, expected: {}, eof: {}, "
-                        "internal buffer size: {}, remote object size: {}",
+                        "internal buffer size: {}, remote object size: {}, remote object last modified: {}",
                         state.bytes_to_predownload,
                         file_segment.range().toString(),
                         file_segment.getCurrentWriteOffset(),
                         offset,
                         state.buf->eof(),
                         state.buf->internalBuffer().size(),
-                        object_size ? std::to_string(*object_size) : "None");
+                        object_size ? std::to_string(*object_size) : "None",
+                        getRemoteFileLastModifiedForLog(*state.buf));
                 }
 
                 chassert(!state.buf->hasPendingData());
@@ -1430,8 +1454,8 @@ size_t CachedOnDiskReadBufferFromFile::readFromFileSegment(
             LOG_WARNING(
                 log,
                 "Remote object is smaller than expected: read {} bytes but expected to read until position {}. "
-                "Actual object size: {}, expected size: {}, stop reason: {}. Treating as EOF.",
-                offset, info.read_until_position, *object_size, file_size_,
+                "Actual object size: {}, last modified: {}, expected size: {}, stop reason: {}. Treating as EOF.",
+                offset, info.read_until_position, *object_size, getRemoteFileLastModifiedForLog(*state.buf), file_size_,
                 impl_read_stop_reason ? *impl_read_stop_reason : "None");
             if (file_segment.isDownloader())
                 file_segment.setDownloadFinishedWithoutContinuation();
@@ -1445,6 +1469,7 @@ size_t CachedOnDiskReadBufferFromFile::readFromFileSegment(
             "file offset: {}, "
             "read bytes: {}, "
             "object size: {}, "
+            "object last modified: {}, "
             "expected object size: {}, "
             "reading until: {}, "
             "read type: {}, "
@@ -1463,6 +1488,7 @@ size_t CachedOnDiskReadBufferFromFile::readFromFileSegment(
             offset + size,
             size,
             object_size ? std::to_string(*object_size) : "None",
+            getRemoteFileLastModifiedForLog(*state.buf),
             file_size_,
             info.read_until_position,
             toString(state.read_type),
@@ -1628,8 +1654,10 @@ size_t CachedOnDiskReadBufferFromFile::readBigAt(
                 LOG_WARNING(
                     log,
                     "ReadBigAt() stopped early due to truncated remote object. "
-                    "Read {} bytes instead of requested {}. Offset: {}, read_until_position: {}",
-                    read_bytes, n, offset, current_info.read_until_position);
+                    "Read {} bytes instead of requested {}. Offset: {}, read_until_position: {}, "
+                    "remote object last modified: {}",
+                    read_bytes, n, offset, current_info.read_until_position,
+                    getRemoteFileLastModifiedForLog(*current_state->buf));
                 break;
             }
 

--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -272,8 +272,9 @@ std::optional<RemoteFileMetadata> tryGetRemoteFileMetadata(ReadBufferFromFileBas
     {
         return buf.getRemoteFileMetadata();
     }
-    catch (...) // NOLINT(bugprone-empty-catch)
+    catch (...)
     {
+        /// Ok: best-effort diagnostics -- a failed metadata lookup must not mask the message being built.
         return std::nullopt;
     }
 }

--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -251,26 +251,31 @@ namespace
 using ReadType = CachedOnDiskReadBufferFromFile::ReadType;
 using ReadInfo = CachedOnDiskReadBufferFromFile::ReadInfo;
 
-/// Fetch the remote object's last modification time for diagnostics, alongside its size: a recent
-/// timestamp confirms the object was overwritten between listing and reading. Best-effort -- a
-/// failed metadata request must never mask the diagnostic we are building, so fall back to "None".
-String getRemoteFileLastModifiedForLog(ReadBufferFromFileBase & buf)
+/// Format the remote object's last modification time for diagnostics, alongside its size: a recent
+/// timestamp confirms the object was overwritten between listing and reading. Returns "None" when the
+/// metadata is unavailable (e.g. a non-remote buffer).
+String formatRemoteFileLastModified(const std::optional<RemoteFileMetadata> & metadata)
 {
-    std::optional<time_t> last_modified;
-    try
-    {
-        last_modified = buf.getRemoteFileLastModificationTime();
-    }
-    catch (...) // NOLINT(bugprone-empty-catch)
-    {
-    }
-
-    if (!last_modified.has_value())
+    if (!metadata.has_value())
         return "None";
 
     WriteBufferFromOwnString out;
-    writeDateTimeText(*last_modified, out);
-    return fmt::format("{} (unix time {})", out.str(), *last_modified);
+    writeDateTimeText(metadata->last_modification_time, out);
+    return fmt::format("{} (unix time {})", out.str(), metadata->last_modification_time);
+}
+
+/// Best-effort metadata lookup for log-only diagnostics: a failed metadata request must never mask
+/// the message being built, so fall back to std::nullopt (rendered as "None").
+std::optional<RemoteFileMetadata> tryGetRemoteFileMetadata(ReadBufferFromFileBase & buf)
+{
+    try
+    {
+        return buf.getRemoteFileMetadata();
+    }
+    catch (...) // NOLINT(bugprone-empty-catch)
+    {
+        return std::nullopt;
+    }
 }
 
 std::shared_ptr<ReadBufferFromFileBase> getCacheReadBuffer(
@@ -817,16 +822,17 @@ bool CachedOnDiskReadBufferFromFile::predownloadForFileSegment(
                 if (state.bytes_to_predownload)
                 {
                     /// The remote object may have been overwritten with shorter content
-                    /// between listing and reading. Check the actual remote file size to
-                    /// distinguish that from a genuine logic error.
-                    auto object_size = state.buf->getRemoteFileSize();
-                    if (object_size.has_value()
-                        && *object_size == file_segment.getCurrentWriteOffset())
+                    /// between listing and reading. Check the actual remote file metadata (size and
+                    /// last modification time, fetched in a single request) to distinguish that from
+                    /// a genuine logic error.
+                    const auto remote_metadata = state.buf->getRemoteFileMetadata();
+                    if (remote_metadata.has_value()
+                        && remote_metadata->size == file_segment.getCurrentWriteOffset())
                     {
                         /// We reached the real end of the (now shorter) object while
                         /// predownloading, before reaching the bytes the reader actually
                         /// needs: those lie beyond the truncated object, because
-                        /// offset == current_write_offset + bytes_to_predownload > *object_size.
+                        /// offset == current_write_offset + bytes_to_predownload > remote_metadata->size.
                         ///
                         /// There is no valid data to return for `offset`. We must NOT treat
                         /// this as EOF (return a short/zero read): the caller would then
@@ -840,8 +846,8 @@ bool CachedOnDiskReadBufferFromFile::predownloadForFileSegment(
                             "Remote object was truncated between listing and reading: "
                             "actual object size {}, last modified {}, but need to read until offset {}. "
                             "Current file segment: {}",
-                            *object_size,
-                            getRemoteFileLastModifiedForLog(*state.buf),
+                            remote_metadata->size,
+                            formatRemoteFileLastModified(remote_metadata),
                             offset,
                             file_segment.getInfoForLog());
                     }
@@ -857,8 +863,8 @@ bool CachedOnDiskReadBufferFromFile::predownloadForFileSegment(
                         offset,
                         state.buf->eof(),
                         state.buf->internalBuffer().size(),
-                        object_size ? std::to_string(*object_size) : "None",
-                        getRemoteFileLastModifiedForLog(*state.buf));
+                        remote_metadata ? std::to_string(remote_metadata->size) : "None",
+                        formatRemoteFileLastModified(remote_metadata));
                 }
 
                 chassert(!state.buf->hasPendingData());
@@ -1430,12 +1436,12 @@ size_t CachedOnDiskReadBufferFromFile::readFromFileSegment(
         else
             download_finished_time = "None";
 
-        std::optional<size_t> object_size;
+        std::optional<RemoteFileMetadata> remote_metadata;
         std::optional<size_t> impl_read_until_position;
         std::optional<std::string> impl_read_stop_reason;
         if (state.read_type != ReadType::CACHED)
         {
-            object_size = state.buf->getRemoteFileSize();
+            remote_metadata = state.buf->getRemoteFileMetadata();
 
 #if USE_AWS_S3
             if (const auto * s3_buf = dynamic_cast<const ReadBufferFromS3 *>(state.buf.get()))
@@ -1446,7 +1452,7 @@ size_t CachedOnDiskReadBufferFromFile::readFromFileSegment(
 #endif
         }
 
-        if (object_size.has_value() && *object_size == offset)
+        if (remote_metadata.has_value() && remote_metadata->size == offset)
         {
             /// The remote object is smaller than file_size_ indicated, e.g. the object was
             /// overwritten with shorter content between listing and reading.
@@ -1455,7 +1461,7 @@ size_t CachedOnDiskReadBufferFromFile::readFromFileSegment(
                 log,
                 "Remote object is smaller than expected: read {} bytes but expected to read until position {}. "
                 "Actual object size: {}, last modified: {}, expected size: {}, stop reason: {}. Treating as EOF.",
-                offset, info.read_until_position, *object_size, getRemoteFileLastModifiedForLog(*state.buf), file_size_,
+                offset, info.read_until_position, remote_metadata->size, formatRemoteFileLastModified(remote_metadata), file_size_,
                 impl_read_stop_reason ? *impl_read_stop_reason : "None");
             if (file_segment.isDownloader())
                 file_segment.setDownloadFinishedWithoutContinuation();
@@ -1487,8 +1493,8 @@ size_t CachedOnDiskReadBufferFromFile::readFromFileSegment(
             "current file segment: {}",
             offset + size,
             size,
-            object_size ? std::to_string(*object_size) : "None",
-            getRemoteFileLastModifiedForLog(*state.buf),
+            remote_metadata ? std::to_string(remote_metadata->size) : "None",
+            formatRemoteFileLastModified(remote_metadata),
             file_size_,
             info.read_until_position,
             toString(state.read_type),
@@ -1657,7 +1663,7 @@ size_t CachedOnDiskReadBufferFromFile::readBigAt(
                     "Read {} bytes instead of requested {}. Offset: {}, read_until_position: {}, "
                     "remote object last modified: {}",
                     read_bytes, n, offset, current_info.read_until_position,
-                    getRemoteFileLastModifiedForLog(*current_state->buf));
+                    formatRemoteFileLastModified(tryGetRemoteFileMetadata(*current_state->buf)));
                 break;
             }
 

--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -792,16 +792,52 @@ bool CachedOnDiskReadBufferFromFile::predownloadForFileSegment(
             if (!state.bytes_to_predownload || !has_more_data)
             {
                 if (state.bytes_to_predownload)
+                {
+                    /// The remote object may have been overwritten with shorter content
+                    /// between listing and reading. Check the actual remote file size
+                    /// before throwing an error (same logic as in readFromFileSegment).
+                    auto object_size = state.buf->getRemoteFileSize();
+                    if (object_size.has_value()
+                        && *object_size == file_segment.getCurrentWriteOffset())
+                    {
+                        LOG_WARNING(
+                            log,
+                            "Remote object is smaller than expected during predownload. "
+                            "Remaining bytes to predownload: {}, current write offset: {}, "
+                            "actual object size: {}, file segment: {}. Treating as truncated object.",
+                            state.bytes_to_predownload,
+                            file_segment.getCurrentWriteOffset(),
+                            *object_size,
+                            file_segment.getInfoForLog());
+
+                        state.bytes_to_predownload = 0;
+                        file_segment.completePartAndResetDownloader();
+                        state.read_type = ReadType::REMOTE_FS_READ_BYPASS_CACHE;
+
+                        /// Adjust read_until_position to the actual object size so
+                        /// the caller knows the real data boundary. Without this,
+                        /// the caller would seek to `offset` (beyond the truncated
+                        /// object), get zero bytes, and the existing truncation guard
+                        /// (`object_size == offset`) would fail because
+                        /// object_size < offset by construction.
+                        info.read_until_position = *object_size;
+
+                        return false;
+                    }
+
                     throw Exception(
                         ErrorCodes::LOGICAL_ERROR,
                         "Failed to predownload remaining {} bytes. Current file segment: {}, "
-                        "current download offset: {}, expected: {}, eof: {}, internal buffer size: {}",
+                        "current download offset: {}, expected: {}, eof: {}, "
+                        "internal buffer size: {}, remote object size: {}",
                         state.bytes_to_predownload,
                         file_segment.range().toString(),
                         file_segment.getCurrentWriteOffset(),
                         offset,
                         state.buf->eof(),
-                        state.buf->internalBuffer().size());
+                        state.buf->internalBuffer().size(),
+                        object_size ? std::to_string(*object_size) : "None");
+                }
 
                 chassert(!state.buf->hasPendingData());
                 auto result = state.buf->hasPendingData();
@@ -1190,6 +1226,13 @@ size_t CachedOnDiskReadBufferFromFile::readFromFileSegment(
         {
             chassert(!state.buf->available());
             chassert(state.read_type == ReadType::REMOTE_FS_READ_BYPASS_CACHE);
+
+            /// If predownload detected a truncated remote object, it adjusts
+            /// info.read_until_position to the actual object size, which may be
+            /// less than our current offset. In that case there is nothing left
+            /// to read — return 0 so the caller treats it as EOF.
+            if (offset >= info.read_until_position)
+                return 0;
 
             auto buf = getRemoteReadBuffer(file_segment, offset, ReadType::REMOTE_FS_READ_BYPASS_CACHE, info);
             buf->setReadUntilPosition(file_segment.range().right + 1); /// [..., range.right]
@@ -1585,6 +1628,20 @@ size_t CachedOnDiskReadBufferFromFile::readBigAt(
 
         if (!size)
         {
+            /// readFromFileSegment may return 0 if the remote object was truncated
+            /// (overwritten with shorter content between listing and reading).
+            /// In that case, read_until_position was adjusted to the actual object size.
+            /// Return what we have instead of throwing.
+            if (offset >= current_info.read_until_position)
+            {
+                LOG_WARNING(
+                    log,
+                    "ReadBigAt() stopped early due to truncated remote object. "
+                    "Read {} bytes instead of requested {}. Offset: {}, read_until_position: {}",
+                    read_bytes, n, offset, current_info.read_until_position);
+                break;
+            }
+
             throw Exception(
                 ErrorCodes::LOGICAL_ERROR,
                 "Cannot read all data. Offset: {} (initial offset: {}), read bytes {}/{}",

--- a/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
+++ b/src/Disks/IO/CachedOnDiskReadBufferFromFile.cpp
@@ -264,21 +264,6 @@ String formatRemoteFileLastModified(const std::optional<RemoteFileMetadata> & me
     return fmt::format("{} (unix time {})", out.str(), metadata->last_modification_time);
 }
 
-/// Best-effort metadata lookup for log-only diagnostics: a failed metadata request must never mask
-/// the message being built, so fall back to std::nullopt (rendered as "None").
-std::optional<RemoteFileMetadata> tryGetRemoteFileMetadata(ReadBufferFromFileBase & buf)
-{
-    try
-    {
-        return buf.getRemoteFileMetadata();
-    }
-    catch (...)
-    {
-        /// Ok: best-effort diagnostics -- a failed metadata lookup must not mask the message being built.
-        return std::nullopt;
-    }
-}
-
 std::shared_ptr<ReadBufferFromFileBase> getCacheReadBuffer(
     const FileSegment & file_segment,
     ReadInfo & info)
@@ -822,11 +807,22 @@ bool CachedOnDiskReadBufferFromFile::predownloadForFileSegment(
             {
                 if (state.bytes_to_predownload)
                 {
+                    /// We failed to predownload all the bytes that were needed, so this downloader
+                    /// will not continue. Release the segment (transition it to
+                    /// PARTIALLY_DOWNLOADED_NO_CONTINUATION) before throwing, so that other readers
+                    /// waiting on this segment can take over instead of waiting for a download that
+                    /// will never finish. This mirrors the EOF handling in readFromFileSegment.
+                    if (file_segment.isDownloader())
+                        file_segment.setDownloadFinishedWithoutContinuation();
+
                     /// The remote object may have been overwritten with shorter content
                     /// between listing and reading. Check the actual remote file metadata (size and
                     /// last modification time, fetched in a single request) to distinguish that from
                     /// a genuine logic error.
                     const auto remote_metadata = state.buf->getRemoteFileMetadata();
+                    /// The object size known at buffer creation time (from listing). Logged alongside
+                    /// the actual size so a truncation is immediately visible in diagnostics.
+                    const auto expected_object_size = state.buf->tryGetFileSize();
                     if (remote_metadata.has_value()
                         && remote_metadata->size == file_segment.getCurrentWriteOffset())
                     {
@@ -845,9 +841,10 @@ bool CachedOnDiskReadBufferFromFile::predownloadForFileSegment(
                         throw Exception(
                             ErrorCodes::CANNOT_READ_ALL_DATA,
                             "Remote object was truncated between listing and reading: "
-                            "actual object size {}, last modified {}, but need to read until offset {}. "
-                            "Current file segment: {}",
+                            "actual object size {}, expected object size {}, last modified {}, "
+                            "but need to read until offset {}. Current file segment: {}",
                             remote_metadata->size,
+                            expected_object_size ? std::to_string(*expected_object_size) : "None",
                             formatRemoteFileLastModified(remote_metadata),
                             offset,
                             file_segment.getInfoForLog());
@@ -857,7 +854,8 @@ bool CachedOnDiskReadBufferFromFile::predownloadForFileSegment(
                         ErrorCodes::LOGICAL_ERROR,
                         "Failed to predownload remaining {} bytes. Current file segment: {}, "
                         "current download offset: {}, expected: {}, eof: {}, "
-                        "internal buffer size: {}, remote object size: {}, remote object last modified: {}",
+                        "internal buffer size: {}, remote object size: {}, "
+                        "expected object size: {}, remote object last modified: {}",
                         state.bytes_to_predownload,
                         file_segment.range().toString(),
                         file_segment.getCurrentWriteOffset(),
@@ -865,6 +863,7 @@ bool CachedOnDiskReadBufferFromFile::predownloadForFileSegment(
                         state.buf->eof(),
                         state.buf->internalBuffer().size(),
                         remote_metadata ? std::to_string(remote_metadata->size) : "None",
+                        expected_object_size ? std::to_string(*expected_object_size) : "None",
                         formatRemoteFileLastModified(remote_metadata));
                 }
 
@@ -1456,18 +1455,23 @@ size_t CachedOnDiskReadBufferFromFile::readFromFileSegment(
         if (remote_metadata.has_value() && remote_metadata->size == offset)
         {
             /// The remote object is smaller than file_size_ indicated, e.g. the object was
-            /// overwritten with shorter content between listing and reading.
-            /// Treat this as a legitimate EOF rather than a logic error.
-            LOG_WARNING(
-                log,
-                "Remote object is smaller than expected: read {} bytes but expected to read until position {}. "
-                "Actual object size: {}, last modified: {}, expected size: {}, stop reason: {}. Treating as EOF.",
-                offset, info.read_until_position, remote_metadata->size, formatRemoteFileLastModified(remote_metadata), file_size_,
-                impl_read_stop_reason ? *impl_read_stop_reason : "None");
+            /// overwritten with shorter content between listing and reading. This downloader
+            /// will not continue: release the segment so other readers waiting on it can take
+            /// over, then fail with a regular CANNOT_READ_ALL_DATA -- retryable while the object
+            /// is being concurrently replaced, and (unlike a LOGICAL_ERROR) it does not alert as a
+            /// server bug. The predownloadForFileSegment and readBigAt paths fail the same way.
             if (file_segment.isDownloader())
                 file_segment.setDownloadFinishedWithoutContinuation();
-            info.read_until_position = offset;
-            return 0;
+            throw Exception(
+                ErrorCodes::CANNOT_READ_ALL_DATA,
+                "Remote object was truncated between listing and reading: "
+                "read until offset {} but expected to read until position {}. "
+                "Actual object size {}, expected object size {}, last modified {}, stop reason: {}. "
+                "Current file segment: {}",
+                offset, info.read_until_position, remote_metadata->size, file_size_,
+                formatRemoteFileLastModified(remote_metadata),
+                impl_read_stop_reason ? *impl_read_stop_reason : "None",
+                file_segment.getInfoForLog());
         }
 
         throw Exception(
@@ -1652,22 +1656,9 @@ size_t CachedOnDiskReadBufferFromFile::readBigAt(
 
         if (!size)
         {
-            /// readFromFileSegment may return 0 if the remote object was truncated
-            /// (overwritten with shorter content between listing and reading).
-            /// In that case, read_until_position was adjusted to the actual object size.
-            /// Return what we have instead of throwing.
-            if (offset >= current_info.read_until_position)
-            {
-                LOG_WARNING(
-                    log,
-                    "ReadBigAt() stopped early due to truncated remote object. "
-                    "Read {} bytes instead of requested {}. Offset: {}, read_until_position: {}, "
-                    "remote object last modified: {}",
-                    read_bytes, n, offset, current_info.read_until_position,
-                    formatRemoteFileLastModified(tryGetRemoteFileMetadata(*current_state->buf)));
-                break;
-            }
-
+            /// A truncated remote object (overwritten with shorter content between listing and
+            /// reading) is handled in readFromFileSegment, which throws CANNOT_READ_ALL_DATA before
+            /// returning here. Reaching this point with a zero-sized read is therefore unexpected.
             throw Exception(
                 ErrorCodes::LOGICAL_ERROR,
                 "Cannot read all data. Offset: {} (initial offset: {}), read bytes {}/{}",

--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
@@ -349,6 +349,15 @@ std::optional<size_t> ReadBufferFromAzureBlobStorage::getRemoteFileSize() const
     return static_cast<size_t>(blob_container_client->GetBlobClient(path).GetProperties().Value.BlobSize);
 }
 
+std::optional<time_t> ReadBufferFromAzureBlobStorage::getRemoteFileLastModificationTime() const
+{
+    const auto last_modified = blob_container_client->GetBlobClient(path).GetProperties().Value.LastModified;
+    return static_cast<time_t>(
+        std::chrono::duration_cast<std::chrono::seconds>(
+            static_cast<std::chrono::system_clock::time_point>(last_modified).time_since_epoch())
+            .count());
+}
+
 size_t ReadBufferFromAzureBlobStorage::readBigAt(char * to, size_t n, size_t range_begin, const std::function<bool(size_t)> & /*progress_callback*/) const
 {
     size_t initial_n = n;

--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.cpp
@@ -344,18 +344,15 @@ std::optional<size_t> ReadBufferFromAzureBlobStorage::tryGetFileSize()
     return file_size;
 }
 
-std::optional<size_t> ReadBufferFromAzureBlobStorage::getRemoteFileSize() const
+std::optional<RemoteFileMetadata> ReadBufferFromAzureBlobStorage::getRemoteFileMetadata() const
 {
-    return static_cast<size_t>(blob_container_client->GetBlobClient(path).GetProperties().Value.BlobSize);
-}
-
-std::optional<time_t> ReadBufferFromAzureBlobStorage::getRemoteFileLastModificationTime() const
-{
-    const auto last_modified = blob_container_client->GetBlobClient(path).GetProperties().Value.LastModified;
-    return static_cast<time_t>(
-        std::chrono::duration_cast<std::chrono::seconds>(
-            static_cast<std::chrono::system_clock::time_point>(last_modified).time_since_epoch())
-            .count());
+    const auto properties = blob_container_client->GetBlobClient(path).GetProperties().Value;
+    const auto last_modification_time = std::chrono::duration_cast<std::chrono::seconds>(
+        static_cast<std::chrono::system_clock::time_point>(properties.LastModified).time_since_epoch())
+        .count();
+    return RemoteFileMetadata{
+        .size = static_cast<size_t>(properties.BlobSize),
+        .last_modification_time = static_cast<time_t>(last_modification_time)};
 }
 
 size_t ReadBufferFromAzureBlobStorage::readBigAt(char * to, size_t n, size_t range_begin, const std::function<bool(size_t)> & /*progress_callback*/) const

--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.h
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.h
@@ -55,6 +55,8 @@ public:
 
     std::optional<size_t> getRemoteFileSize() const override;
 
+    std::optional<time_t> getRemoteFileLastModificationTime() const override;
+
     size_t readBigAt(char * to, size_t n, size_t range_begin, const std::function<bool(size_t)> & progress_callback) const override;
 
     bool supportsReadAt() override { return true; }

--- a/src/Disks/IO/ReadBufferFromAzureBlobStorage.h
+++ b/src/Disks/IO/ReadBufferFromAzureBlobStorage.h
@@ -53,9 +53,7 @@ public:
 
     std::optional<size_t> tryGetFileSize() override;
 
-    std::optional<size_t> getRemoteFileSize() const override;
-
-    std::optional<time_t> getRemoteFileLastModificationTime() const override;
+    std::optional<RemoteFileMetadata> getRemoteFileMetadata() const override;
 
     size_t readBigAt(char * to, size_t n, size_t range_begin, const std::function<bool(size_t)> & progress_callback) const override;
 

--- a/src/IO/ReadBufferFromFileBase.h
+++ b/src/IO/ReadBufferFromFileBase.h
@@ -22,6 +22,13 @@
 namespace DB
 {
 
+/// A consistent snapshot of a remote object's metadata, fetched in a single request.
+struct RemoteFileMetadata
+{
+    size_t size = 0;
+    time_t last_modification_time = 0;
+};
+
 class ReadBufferFromFileBase : public BufferWithOwnMemory<SeekableReadBuffer>, public WithFileName, public WithFileSize
 {
 public:
@@ -62,19 +69,14 @@ public:
 
     virtual bool isCached() const { return false; }
 
-    /// Query the actual object size directly from remote storage.
+    /// Query the actual object's size and last modification time directly from remote storage.
     /// Unlike tryGetFileSize(), which typically returns a pre-known cached value passed at construction time,
     /// this method issues a real metadata request (e.g. S3 HeadObject, Azure GetProperties) and reflects
-    /// the current state of the object. Useful for detecting mismatches between the expected and actual size.
+    /// the current state of the object. Both fields come from a single request, so they form a consistent
+    /// snapshot -- useful for detecting (and confirming, via the timestamp) that an object was overwritten
+    /// between listing and reading.
     /// Returns std::nullopt for non-remote or local file buffers.
-    virtual std::optional<size_t> getRemoteFileSize() const { return std::nullopt; }
-
-    /// Query the actual object's last modification time directly from remote storage.
-    /// Like getRemoteFileSize(), this issues a real metadata request and reflects the current
-    /// state of the object. Useful, together with the size, to confirm that an object was
-    /// concurrently overwritten between listing and reading.
-    /// Returns std::nullopt for non-remote or local file buffers.
-    virtual std::optional<time_t> getRemoteFileLastModificationTime() const { return std::nullopt; }
+    virtual std::optional<RemoteFileMetadata> getRemoteFileMetadata() const { return std::nullopt; }
 
 protected:
     std::optional<size_t> file_size;

--- a/src/IO/ReadBufferFromFileBase.h
+++ b/src/IO/ReadBufferFromFileBase.h
@@ -69,6 +69,13 @@ public:
     /// Returns std::nullopt for non-remote or local file buffers.
     virtual std::optional<size_t> getRemoteFileSize() const { return std::nullopt; }
 
+    /// Query the actual object's last modification time directly from remote storage.
+    /// Like getRemoteFileSize(), this issues a real metadata request and reflects the current
+    /// state of the object. Useful, together with the size, to confirm that an object was
+    /// concurrently overwritten between listing and reading.
+    /// Returns std::nullopt for non-remote or local file buffers.
+    virtual std::optional<time_t> getRemoteFileLastModificationTime() const { return std::nullopt; }
+
 protected:
     std::optional<size_t> file_size;
     ProfileCallback profile_callback;

--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -429,14 +429,10 @@ size_t ReadBufferFromS3::getObjectSizeFromS3() const
     return S3::getObjectSize(*client_ptr, bucket, key, version_id);
 }
 
-std::optional<size_t> ReadBufferFromS3::getRemoteFileSize() const
+std::optional<RemoteFileMetadata> ReadBufferFromS3::getRemoteFileMetadata() const
 {
-    return getObjectSizeFromS3();
-}
-
-std::optional<time_t> ReadBufferFromS3::getRemoteFileLastModificationTime() const
-{
-    return S3::getObjectInfo(*client_ptr, bucket, key, version_id).last_modification_time;
+    const auto object_info = S3::getObjectInfo(*client_ptr, bucket, key, version_id);
+    return RemoteFileMetadata{.size = object_info.size, .last_modification_time = object_info.last_modification_time};
 }
 
 off_t ReadBufferFromS3::getPosition()

--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -434,6 +434,11 @@ std::optional<size_t> ReadBufferFromS3::getRemoteFileSize() const
     return getObjectSizeFromS3();
 }
 
+std::optional<time_t> ReadBufferFromS3::getRemoteFileLastModificationTime() const
+{
+    return S3::getObjectInfo(*client_ptr, bucket, key, version_id).last_modification_time;
+}
+
 off_t ReadBufferFromS3::getPosition()
 {
     return offset - available();

--- a/src/IO/ReadBufferFromS3.h
+++ b/src/IO/ReadBufferFromS3.h
@@ -95,9 +95,7 @@ public:
 
     std::string getStopReason() const { return stop_reason; }
 
-    std::optional<size_t> getRemoteFileSize() const override;
-
-    std::optional<time_t> getRemoteFileLastModificationTime() const override;
+    std::optional<RemoteFileMetadata> getRemoteFileMetadata() const override;
 
 private:
     std::unique_ptr<S3::ReadBufferFromGetObjectResult> initialize(size_t attempt);

--- a/src/IO/ReadBufferFromS3.h
+++ b/src/IO/ReadBufferFromS3.h
@@ -97,6 +97,8 @@ public:
 
     std::optional<size_t> getRemoteFileSize() const override;
 
+    std::optional<time_t> getRemoteFileLastModificationTime() const override;
+
 private:
     std::unique_ptr<S3::ReadBufferFromGetObjectResult> initialize(size_t attempt);
 

--- a/tests/integration/test_cache_s3_object_truncation/config.d/storage.xml
+++ b/tests/integration/test_cache_s3_object_truncation/config.d/storage.xml
@@ -1,0 +1,29 @@
+<clickhouse>
+    <storage_configuration>
+        <disks>
+            <s3_disk>
+                <type>object_storage</type>
+                <object_storage_type>s3</object_storage_type>
+                <metadata_type>plain_rewritable</metadata_type>
+                <endpoint>http://minio1:9001/root/data/</endpoint>
+                <access_key_id>minio</access_key_id>
+                <secret_access_key>ClickHouse_Minio_P@ssw0rd</secret_access_key>
+            </s3_disk>
+            <s3_cache>
+                <type>cache</type>
+                <disk>s3_disk</disk>
+                <path>/var/lib/clickhouse/cache/</path>
+                <max_size>10Gi</max_size>
+            </s3_cache>
+        </disks>
+        <policies>
+            <s3_cache>
+                <volumes>
+                    <main>
+                        <disk>s3_cache</disk>
+                    </main>
+                </volumes>
+            </s3_cache>
+        </policies>
+    </storage_configuration>
+</clickhouse>

--- a/tests/integration/test_cache_s3_object_truncation/test.py
+++ b/tests/integration/test_cache_s3_object_truncation/test.py
@@ -1,19 +1,31 @@
 """
-Regression tests for graceful handling of truncated S3 objects during cached reads.
+Regression test for graceful handling of truncated S3 objects during cached reads.
 
 When an S3 object is overwritten with shorter content between listing and
-reading, the cache layer must NOT throw LOGICAL_ERROR. Instead it should
-detect the truncation and either:
-  - switch to bypass-cache mode (predownloadForFileSegment path), or
-  - return a short read (readBigAt path), or
-  - treat it as legitimate EOF (readFromFileSegment path).
+reading, the cache layer must NOT throw LOGICAL_ERROR. Instead it should detect
+the truncation and treat it as a legitimate EOF / bypass-cache, in:
+  - predownloadForFileSegment (catch-up download before a mid-segment read), and
+  - readFromFileSegment (the sibling EOF path).
 
-NOTE: the MergeTree-based tests below exercise the sequential cached-read
-paths (predownloadForFileSegment / readFromFileSegment). `readBigAt` is the
-random-access path used by Parquet over object storage; it is NOT reached by
-a MergeTree SELECT and would need a separate test reading a Parquet file via
-the s3() table function. The `Cannot read all data` assertion below is kept
-as a guard but is not actually exercised by these queries.
+Two conditions are required to actually exercise the predownload path, both
+discovered empirically (a naive test passes on the buggy code too):
+
+1. The object must be truncated to a VALID PREFIX of its real content, not
+   overwritten with zeros. Zero-filled content fails decompression on the first
+   block (UNKNOWN_CODEC) before the predownload path is reached.
+
+2. The query must SEEK to a granule located beyond the truncation offset (a
+   point query on the primary key), so the cache must predownload past the real
+   EOF. A full-scan instead fails earlier in the compression layer
+   (CANNOT_READ_ALL_DATA) and never reaches the predownload path.
+
+NOTE on readBigAt: readBigAt is the random-access path used by the Parquet
+reader over object storage, and is not reached by a MergeTree SELECT. It cannot
+be exercised deterministically from a single-node query, because reading a
+truncated object via the s3() table function re-fetches the object size (a fresh
+HEAD returns the new, smaller size) and so never over-reads — it surfaces as a
+plain INCORRECT_DATA "Not a Parquet file" error instead. The readBigAt guard in
+the fix mirrors the readFromFileSegment EOF logic that this test does cover.
 """
 
 import io
@@ -35,7 +47,6 @@ node = cluster.add_instance(
 )
 
 BUCKET = "root"
-S3_PREFIX = "data/"
 
 
 @pytest.fixture(scope="module")
@@ -47,156 +58,115 @@ def started_cluster():
         cluster.shutdown()
 
 
-def _drop_cache(node):
-    node.query("SYSTEM DROP FILESYSTEM CACHE")
-
-
 def _get_data_objects(minio_client, prefix="data/"):
-    """Return list of (object_name, size) tuples for all S3 data objects."""
+    """Return list of (object_name, size) tuples for all non-empty S3 data objects."""
     objects = list(minio_client.list_objects(BUCKET, prefix=prefix, recursive=True))
     return [(obj.object_name, obj.size) for obj in objects if obj.size > 0]
 
 
-def _truncate_s3_object(minio_client, object_name, original_size, keep_fraction=0.5):
+def _read_s3_object(minio_client, object_name):
+    response = minio_client.get_object(BUCKET, object_name)
+    try:
+        return response.read()
+    finally:
+        response.close()
+        response.release_conn()
+
+
+def _truncate_to_valid_prefix(minio_client, object_name, keep_fraction=0.5):
     """
-    Replace an S3 object with shorter content (zeros), simulating
-    the object being overwritten with a smaller version.
+    Replace an S3 object with a VALID PREFIX of its real content: the same
+    leading bytes, just shorter. This simulates the object being overwritten
+    with shorter content while the leading data is still readable — the
+    condition that makes the cache predownload run past the real EOF.
+
+    Replacing with zeros instead would fail decompression on the very first
+    block (UNKNOWN_CODEC) before the predownload path is ever reached.
     """
-    truncated_size = max(1, int(original_size * keep_fraction))
-    truncated_data = b"\x00" * truncated_size
-    buf = io.BytesIO(truncated_data)
-    minio_client.put_object(BUCKET, object_name, buf, len(truncated_data))
+    data = _read_s3_object(minio_client, object_name)
+    truncated = data[: max(1, int(len(data) * keep_fraction))]
+    minio_client.put_object(BUCKET, object_name, io.BytesIO(truncated), len(truncated))
     logger.info(
-        "Truncated %s from %d to %d bytes", object_name, original_size, truncated_size
+        "Truncated %s to a valid prefix: %d -> %d bytes",
+        object_name,
+        len(data),
+        len(truncated),
     )
-    return truncated_size
+    return len(data), len(truncated)
 
 
-def test_truncated_object_no_logical_error(started_cluster):
+# Substrings of the three LOGICAL_ERROR messages that the fix prevents. The
+# readBigAt message is matched on its specific "Offset:" phrasing so it is not
+# confused with the benign compression-layer "Cannot read all data. Bytes read:"
+# (CANNOT_READ_ALL_DATA), which is an acceptable error for a truncated object.
+FORBIDDEN_LOGICAL_ERRORS = [
+    "Failed to predownload remaining",  # predownloadForFileSegment
+    "Cannot read all data. Offset:",  # readBigAt
+    "Having zero bytes, but range is not finished",  # readFromFileSegment
+]
+
+
+def _assert_no_forbidden_logical_error(error_msg):
+    for needle in FORBIDDEN_LOGICAL_ERRORS:
+        assert needle not in error_msg, (
+            f"Bug: pre-fix LOGICAL_ERROR resurfaced ({needle!r}): {error_msg}"
+        )
+
+
+def test_truncated_object_predownload_no_logical_error(started_cluster):
     """
-    After truncating an S3 data object, a SELECT must NOT produce
-    LOGICAL_ERROR about failed predownload or readBigAt.
-    Any other error (checksum mismatch, broken part, etc.) is acceptable.
+    Truncate the column data object to a valid prefix, then seek (via a point
+    query on the primary key) to a granule located beyond the truncation. On the
+    unpatched code this throws `Failed to predownload remaining ... bytes`
+    (LOGICAL_ERROR); the fix treats it as EOF and returns no/partial data.
+    Any non-LOGICAL_ERROR (e.g. CANNOT_READ_ALL_DATA, broken part) is acceptable.
     """
     minio = started_cluster.minio_client
+    node.query("DROP TABLE IF EXISTS t_trunc SYNC")
     node.query(
         """
         CREATE TABLE t_trunc (x UInt64, s String)
         ENGINE = MergeTree ORDER BY x
         SETTINGS storage_policy = 's3_cache',
-                 min_bytes_for_wide_part = 0
+                 min_bytes_for_wide_part = 0,
+                 index_granularity = 8192
         """
     )
     try:
-        # Insert enough rows to produce non-trivial S3 objects
+        # A single INSERT well under max_insert_block_size produces one part, so
+        # the largest object is unambiguously that part's `s` column data.
         node.query(
             "INSERT INTO t_trunc SELECT number, repeat(toString(number), 100) "
-            "FROM numbers(10000)"
+            "FROM numbers(100000)"
         )
-        # Force data to be flushed to S3
-        node.query("OPTIMIZE TABLE t_trunc FINAL")
+        active_parts = node.query(
+            "SELECT count() FROM system.parts WHERE table = 't_trunc' AND active"
+        ).strip()
+        assert active_parts == "1", f"expected a single part, got {active_parts}"
 
-        # Find the largest data object. With wide parts (min_bytes_for_wide_part = 0)
-        # every column is a separate .bin object, and the largest one is the data
-        # for the `s` String column — by far bigger than the UInt64 `x` column.
         objects = _get_data_objects(minio)
-        assert len(objects) > 0, "No S3 objects found for the table"
-
         objects.sort(key=lambda x: x[1], reverse=True)
         target_name, target_size = objects[0]
-        logger.info(
-            "Target object for truncation: %s (%d bytes)", target_name, target_size
-        )
-        assert target_size > 100, f"Target object too small: {target_size}"
+        logger.info("Truncating largest object %s (%d bytes)", target_name, target_size)
+        # Must be large enough that a late granule sits beyond the 50% cut.
+        assert target_size > 100000, f"target object too small: {target_size}"
 
-        # Drop filesystem cache so the next read must go through S3
-        _drop_cache(node)
+        node.query("SYSTEM DROP FILESYSTEM CACHE")
+        _truncate_to_valid_prefix(minio, target_name, keep_fraction=0.5)
 
-        # Truncate the S3 object to 50% of its original size
-        _truncate_s3_object(minio, target_name, target_size, keep_fraction=0.5)
-
-        # Read the data. The query MUST read the `s` column so it actually hits
-        # the truncated object (the largest one) — reading only `x`/count() would
-        # never touch it and the test would pass even on the unpatched code.
-        # This should NOT throw LOGICAL_ERROR about predownload. Other errors are
-        # acceptable (broken part, checksum mismatch, etc.).
+        # Point query on the PK seeks to a granule near the end of the column,
+        # forcing the cache to predownload past the real (truncated) EOF.
         try:
-            node.query("SELECT sum(cityHash64(s)), count() FROM t_trunc")
-            logger.info("Query succeeded despite truncated object (bypass-cache worked)")
+            node.query(
+                "SELECT s FROM t_trunc WHERE x = 99000 "
+                "SETTINGS enable_filesystem_cache = 1, max_threads = 1"
+            )
+            logger.info("Query returned without error (truncation handled as EOF)")
         except Exception as e:
-            error_msg = str(e)
-            # These are the specific LOGICAL_ERROR messages our fix prevents:
-            assert "Failed to predownload remaining" not in error_msg, (
-                f"Bug: LOGICAL_ERROR from predownloadForFileSegment: {error_msg}"
-            )
-            assert "Cannot read all data" not in error_msg, (
-                f"Bug: LOGICAL_ERROR from readBigAt: {error_msg}"
-            )
-            assert "Having zero bytes, but range is not finished" not in error_msg, (
-                f"Bug: LOGICAL_ERROR from readFromFileSegment: {error_msg}"
-            )
-            # Any other error is fine — checksum failure, broken part, etc.
-            logger.info("Query raised non-LOGICAL_ERROR exception (expected): %s", error_msg[:200])
+            _assert_no_forbidden_logical_error(str(e))
+            logger.info("Query raised acceptable non-LOGICAL_ERROR: %s", str(e)[:200])
+
+        # Server must stay alive.
+        assert node.query("SELECT 1").strip() == "1"
     finally:
         node.query("DROP TABLE IF EXISTS t_trunc SYNC")
-
-
-def test_truncated_object_during_merge_read(started_cluster):
-    """
-    Truncating an S3 object during a merge-related read must not
-    produce a LOGICAL_ERROR. The merge may fail, but the server must
-    stay alive.
-    """
-    minio = started_cluster.minio_client
-    node.query(
-        """
-        CREATE TABLE t_trunc_merge (x UInt64, s String)
-        ENGINE = MergeTree ORDER BY x
-        SETTINGS storage_policy = 's3_cache',
-                 min_bytes_for_wide_part = 0
-        """
-    )
-    try:
-        # Insert multiple parts
-        for i in range(3):
-            node.query(
-                f"INSERT INTO t_trunc_merge SELECT number + {i * 5000}, "
-                f"repeat(toString(number + {i * 5000}), 50) "
-                "FROM numbers(5000)"
-            )
-
-        # Find objects before merge
-        objects_before = _get_data_objects(minio)
-        assert len(objects_before) > 0
-
-        # Drop cache
-        _drop_cache(node)
-
-        # Truncate the largest object (the `s` String column data).
-        objects_before.sort(key=lambda x: x[1], reverse=True)
-        target_name, target_size = objects_before[0]
-        _truncate_s3_object(minio, target_name, target_size, keep_fraction=0.3)
-
-        # Try reading the `s` column so the read actually touches the truncated
-        # object — a bare count() reads only metadata and would never hit it.
-        # Same assertion: no LOGICAL_ERROR from predownload.
-        try:
-            result = node.query("SELECT sum(cityHash64(s)) FROM t_trunc_merge")
-            logger.info("Read succeeded: %s", result.strip())
-        except Exception as e:
-            error_msg = str(e)
-            assert "Failed to predownload remaining" not in error_msg, (
-                f"Bug: LOGICAL_ERROR from predownloadForFileSegment: {error_msg}"
-            )
-            assert "Cannot read all data" not in error_msg, (
-                f"Bug: LOGICAL_ERROR from readBigAt: {error_msg}"
-            )
-            assert "Having zero bytes, but range is not finished" not in error_msg, (
-                f"Bug: LOGICAL_ERROR from readFromFileSegment: {error_msg}"
-            )
-            logger.info("Query raised acceptable exception: %s", error_msg[:200])
-
-        # Verify the server is still alive
-        assert node.query("SELECT 1").strip() == "1", "Server should be alive after truncated read"
-    finally:
-        node.query("DROP TABLE IF EXISTS t_trunc_merge SYNC")

--- a/tests/integration/test_cache_s3_object_truncation/test.py
+++ b/tests/integration/test_cache_s3_object_truncation/test.py
@@ -1,0 +1,190 @@
+"""
+Regression tests for graceful handling of truncated S3 objects during cached reads.
+
+When an S3 object is overwritten with shorter content between listing and
+reading, the cache layer must NOT throw LOGICAL_ERROR. Instead it should
+detect the truncation and either:
+  - switch to bypass-cache mode (predownloadForFileSegment path), or
+  - return a short read (readBigAt path), or
+  - treat it as legitimate EOF (readFromFileSegment path).
+"""
+
+import io
+import logging
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+logger = logging.getLogger(__name__)
+
+cluster = ClickHouseCluster(__file__)
+
+node = cluster.add_instance(
+    "node",
+    main_configs=["config.d/storage.xml"],
+    with_minio=True,
+    stay_alive=True,
+)
+
+BUCKET = "root"
+S3_PREFIX = "data/"
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def _drop_cache(node):
+    node.query("SYSTEM DROP FILESYSTEM CACHE")
+
+
+def _get_data_objects(minio_client, prefix="data/"):
+    """Return list of (object_name, size) tuples for all S3 data objects."""
+    objects = list(minio_client.list_objects(BUCKET, prefix=prefix, recursive=True))
+    return [(obj.object_name, obj.size) for obj in objects if obj.size > 0]
+
+
+def _truncate_s3_object(minio_client, object_name, original_size, keep_fraction=0.5):
+    """
+    Replace an S3 object with shorter content (zeros), simulating
+    the object being overwritten with a smaller version.
+    """
+    truncated_size = max(1, int(original_size * keep_fraction))
+    truncated_data = b"\x00" * truncated_size
+    buf = io.BytesIO(truncated_data)
+    minio_client.put_object(BUCKET, object_name, buf, len(truncated_data))
+    logger.info(
+        "Truncated %s from %d to %d bytes", object_name, original_size, truncated_size
+    )
+    return truncated_size
+
+
+def test_truncated_object_no_logical_error(started_cluster):
+    """
+    After truncating an S3 data object, a SELECT must NOT produce
+    LOGICAL_ERROR about failed predownload or readBigAt.
+    Any other error (checksum mismatch, broken part, etc.) is acceptable.
+    """
+    minio = started_cluster.minio_client
+    node.query(
+        """
+        CREATE TABLE t_trunc (x UInt64, s String)
+        ENGINE = MergeTree ORDER BY x
+        SETTINGS storage_policy = 's3_cache',
+                 min_bytes_for_wide_part = 0
+        """
+    )
+    try:
+        # Insert enough rows to produce non-trivial S3 objects
+        node.query(
+            "INSERT INTO t_trunc SELECT number, repeat(toString(number), 100) "
+            "FROM numbers(10000)"
+        )
+        # Force data to be flushed to S3
+        node.query("OPTIMIZE TABLE t_trunc FINAL")
+
+        # Find the largest data object — most likely to trigger predownload
+        objects = _get_data_objects(minio)
+        assert len(objects) > 0, "No S3 objects found for the table"
+
+        # Pick the largest object (most likely a column data file)
+        objects.sort(key=lambda x: x[1], reverse=True)
+        target_name, target_size = objects[0]
+        logger.info(
+            "Target object for truncation: %s (%d bytes)", target_name, target_size
+        )
+        assert target_size > 100, f"Target object too small: {target_size}"
+
+        # Drop filesystem cache so the next read must go through S3
+        _drop_cache(node)
+
+        # Truncate the S3 object to 50% of its original size
+        _truncate_s3_object(minio, target_name, target_size, keep_fraction=0.5)
+
+        # Read the data — this should NOT throw LOGICAL_ERROR about
+        # predownload or readBigAt. Other errors are acceptable (broken part,
+        # checksum mismatch, etc.)
+        try:
+            node.query("SELECT sum(x), count() FROM t_trunc")
+            logger.info("Query succeeded despite truncated object (bypass-cache worked)")
+        except Exception as e:
+            error_msg = str(e)
+            # These are the specific LOGICAL_ERROR messages our fix prevents:
+            assert "Failed to predownload remaining" not in error_msg, (
+                f"Bug: LOGICAL_ERROR from predownloadForFileSegment: {error_msg}"
+            )
+            assert "Cannot read all data" not in error_msg, (
+                f"Bug: LOGICAL_ERROR from readBigAt: {error_msg}"
+            )
+            assert "Having zero bytes, but range is not finished" not in error_msg, (
+                f"Bug: LOGICAL_ERROR from readFromFileSegment: {error_msg}"
+            )
+            # Any other error is fine — checksum failure, broken part, etc.
+            logger.info("Query raised non-LOGICAL_ERROR exception (expected): %s", error_msg[:200])
+    finally:
+        node.query("DROP TABLE IF EXISTS t_trunc SYNC")
+
+
+def test_truncated_object_during_merge_read(started_cluster):
+    """
+    Truncating an S3 object during a merge-related read must not
+    produce a LOGICAL_ERROR. The merge may fail, but the server must
+    stay alive.
+    """
+    minio = started_cluster.minio_client
+    node.query(
+        """
+        CREATE TABLE t_trunc_merge (x UInt64, s String)
+        ENGINE = MergeTree ORDER BY x
+        SETTINGS storage_policy = 's3_cache',
+                 min_bytes_for_wide_part = 0
+        """
+    )
+    try:
+        # Insert multiple parts
+        for i in range(3):
+            node.query(
+                f"INSERT INTO t_trunc_merge SELECT number + {i * 5000}, "
+                f"repeat(toString(number + {i * 5000}), 50) "
+                "FROM numbers(5000)"
+            )
+
+        # Find objects before merge
+        objects_before = _get_data_objects(minio)
+        assert len(objects_before) > 0
+
+        # Drop cache
+        _drop_cache(node)
+
+        # Truncate the largest object
+        objects_before.sort(key=lambda x: x[1], reverse=True)
+        target_name, target_size = objects_before[0]
+        _truncate_s3_object(minio, target_name, target_size, keep_fraction=0.3)
+
+        # Try reading — same assertion: no LOGICAL_ERROR from predownload/readBigAt
+        try:
+            result = node.query("SELECT count() FROM t_trunc_merge")
+            logger.info("Read succeeded: %s rows", result.strip())
+        except Exception as e:
+            error_msg = str(e)
+            assert "Failed to predownload remaining" not in error_msg, (
+                f"Bug: LOGICAL_ERROR from predownloadForFileSegment: {error_msg}"
+            )
+            assert "Cannot read all data" not in error_msg, (
+                f"Bug: LOGICAL_ERROR from readBigAt: {error_msg}"
+            )
+            assert "Having zero bytes, but range is not finished" not in error_msg, (
+                f"Bug: LOGICAL_ERROR from readFromFileSegment: {error_msg}"
+            )
+            logger.info("Query raised acceptable exception: %s", error_msg[:200])
+
+        # Verify the server is still alive
+        assert node.query("SELECT 1").strip() == "1", "Server should be alive after truncated read"
+    finally:
+        node.query("DROP TABLE IF EXISTS t_trunc_merge SYNC")

--- a/tests/integration/test_cache_s3_object_truncation/test.py
+++ b/tests/integration/test_cache_s3_object_truncation/test.py
@@ -2,10 +2,12 @@
 Regression test for graceful handling of truncated S3 objects during cached reads.
 
 When an S3 object is overwritten with shorter content between listing and
-reading, the cache layer must NOT throw LOGICAL_ERROR. Instead it should detect
-the truncation and treat it as a legitimate EOF / bypass-cache, in:
-  - predownloadForFileSegment (catch-up download before a mid-segment read), and
-  - readFromFileSegment (the sibling EOF path).
+reading, the cache layer must NOT throw LOGICAL_ERROR and must NOT crash the
+server. In predownloadForFileSegment, when the bytes the reader needs lie beyond
+the truncated object there is no valid data to return, so the read fails with a
+regular CANNOT_READ_ALL_DATA error -- not a LOGICAL_ERROR, and not a fabricated
+EOF (a short/zero read there makes the caller consume uninitialized memory,
+which aborts under MemorySanitizer and returns silent garbage in release).
 
 Two conditions are required to actually exercise the predownload path, both
 discovered empirically (a naive test passes on the buggy code too):
@@ -118,8 +120,10 @@ def test_truncated_object_predownload_no_logical_error(started_cluster):
     Truncate the column data object to a valid prefix, then seek (via a point
     query on the primary key) to a granule located beyond the truncation. On the
     unpatched code this throws `Failed to predownload remaining ... bytes`
-    (LOGICAL_ERROR); the fix treats it as EOF and returns no/partial data.
-    Any non-LOGICAL_ERROR (e.g. CANNOT_READ_ALL_DATA, broken part) is acceptable.
+    (LOGICAL_ERROR); the fix fails with a regular CANNOT_READ_ALL_DATA and the
+    server stays up. Any non-LOGICAL_ERROR (CANNOT_READ_ALL_DATA, broken part,
+    etc.) is acceptable; what matters is no forbidden LOGICAL_ERROR and that the
+    server survives (no use-of-uninitialized-value crash).
     """
     minio = started_cluster.minio_client
     node.query("DROP TABLE IF EXISTS t_trunc SYNC")

--- a/tests/integration/test_cache_s3_object_truncation/test.py
+++ b/tests/integration/test_cache_s3_object_truncation/test.py
@@ -7,6 +7,13 @@ detect the truncation and either:
   - switch to bypass-cache mode (predownloadForFileSegment path), or
   - return a short read (readBigAt path), or
   - treat it as legitimate EOF (readFromFileSegment path).
+
+NOTE: the MergeTree-based tests below exercise the sequential cached-read
+paths (predownloadForFileSegment / readFromFileSegment). `readBigAt` is the
+random-access path used by Parquet over object storage; it is NOT reached by
+a MergeTree SELECT and would need a separate test reading a Parquet file via
+the s3() table function. The `Cannot read all data` assertion below is kept
+as a guard but is not actually exercised by these queries.
 """
 
 import io
@@ -89,11 +96,12 @@ def test_truncated_object_no_logical_error(started_cluster):
         # Force data to be flushed to S3
         node.query("OPTIMIZE TABLE t_trunc FINAL")
 
-        # Find the largest data object — most likely to trigger predownload
+        # Find the largest data object. With wide parts (min_bytes_for_wide_part = 0)
+        # every column is a separate .bin object, and the largest one is the data
+        # for the `s` String column — by far bigger than the UInt64 `x` column.
         objects = _get_data_objects(minio)
         assert len(objects) > 0, "No S3 objects found for the table"
 
-        # Pick the largest object (most likely a column data file)
         objects.sort(key=lambda x: x[1], reverse=True)
         target_name, target_size = objects[0]
         logger.info(
@@ -107,11 +115,13 @@ def test_truncated_object_no_logical_error(started_cluster):
         # Truncate the S3 object to 50% of its original size
         _truncate_s3_object(minio, target_name, target_size, keep_fraction=0.5)
 
-        # Read the data — this should NOT throw LOGICAL_ERROR about
-        # predownload or readBigAt. Other errors are acceptable (broken part,
-        # checksum mismatch, etc.)
+        # Read the data. The query MUST read the `s` column so it actually hits
+        # the truncated object (the largest one) — reading only `x`/count() would
+        # never touch it and the test would pass even on the unpatched code.
+        # This should NOT throw LOGICAL_ERROR about predownload. Other errors are
+        # acceptable (broken part, checksum mismatch, etc.).
         try:
-            node.query("SELECT sum(x), count() FROM t_trunc")
+            node.query("SELECT sum(cityHash64(s)), count() FROM t_trunc")
             logger.info("Query succeeded despite truncated object (bypass-cache worked)")
         except Exception as e:
             error_msg = str(e)
@@ -162,15 +172,17 @@ def test_truncated_object_during_merge_read(started_cluster):
         # Drop cache
         _drop_cache(node)
 
-        # Truncate the largest object
+        # Truncate the largest object (the `s` String column data).
         objects_before.sort(key=lambda x: x[1], reverse=True)
         target_name, target_size = objects_before[0]
         _truncate_s3_object(minio, target_name, target_size, keep_fraction=0.3)
 
-        # Try reading — same assertion: no LOGICAL_ERROR from predownload/readBigAt
+        # Try reading the `s` column so the read actually touches the truncated
+        # object — a bare count() reads only metadata and would never hit it.
+        # Same assertion: no LOGICAL_ERROR from predownload.
         try:
-            result = node.query("SELECT count() FROM t_trunc_merge")
-            logger.info("Read succeeded: %s rows", result.strip())
+            result = node.query("SELECT sum(cityHash64(s)) FROM t_trunc_merge")
+            logger.info("Read succeeded: %s", result.strip())
         except Exception as e:
             error_msg = str(e)
             assert "Failed to predownload remaining" not in error_msg, (

--- a/tests/integration/test_cache_s3_object_truncation/test.py
+++ b/tests/integration/test_cache_s3_object_truncation/test.py
@@ -21,13 +21,16 @@ discovered empirically (a naive test passes on the buggy code too):
    EOF. A full-scan instead fails earlier in the compression layer
    (CANNOT_READ_ALL_DATA) and never reaches the predownload path.
 
+All three cache read paths -- predownloadForFileSegment, readFromFileSegment and
+readBigAt -- fail a truncated read the same way: a regular CANNOT_READ_ALL_DATA,
+never a LOGICAL_ERROR and never a fabricated EOF.
+
 NOTE on readBigAt: readBigAt is the random-access path used by the Parquet
 reader over object storage, and is not reached by a MergeTree SELECT. It cannot
 be exercised deterministically from a single-node query, because reading a
 truncated object via the s3() table function re-fetches the object size (a fresh
 HEAD returns the new, smaller size) and so never over-reads — it surfaces as a
-plain INCORRECT_DATA "Not a Parquet file" error instead. The readBigAt guard in
-the fix mirrors the readFromFileSegment EOF logic that this test does cover.
+plain INCORRECT_DATA "Not a Parquet file" error instead.
 """
 
 import io
@@ -165,7 +168,7 @@ def test_truncated_object_predownload_no_logical_error(started_cluster):
                 "SELECT s FROM t_trunc WHERE x = 99000 "
                 "SETTINGS enable_filesystem_cache = 1, max_threads = 1"
             )
-            logger.info("Query returned without error (truncation handled as EOF)")
+            logger.info("Query returned without error")
         except Exception as e:
             _assert_no_forbidden_logical_error(str(e))
             logger.info("Query raised acceptable non-LOGICAL_ERROR: %s", str(e)[:200])


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/clickhouse-core-incidents/issues/1736
Related: https://github.com/ClickHouse/clickhouse-core-incidents/issues/763
Related: https://github.com/ClickHouse/clickhouse-core-incidents/issues/717
Related: https://github.com/ClickHouse/clickhouse-core-incidents/issues/1010
Related: https://github.com/ClickHouse/clickhouse-core-incidents/issues/598
Related: https://github.com/ClickHouse/ClickHouse/pull/101219

PR #101219 fixed a `LOGICAL_ERROR` in `readFromFileSegment` that occurred when a remote S3 object was overwritten with shorter content between listing and reading. However, the same error handling was not applied to `predownloadForFileSegment` or `readBigAt`, which use the same underlying read buffer and encounter the same EOF condition.

This applies the same graceful truncation handling to both paths:

1. **`predownloadForFileSegment`** — When EOF is hit during predownload with bytes still remaining, checks `getRemoteFileSize`. If the object was truncated (actual size matches current write offset), completes the segment and falls back to bypass-cache mode instead of throwing `LOGICAL_ERROR`.

2. **`readBigAt`** — When `readFromFileSegment` returns 0 after adjusting `read_until_position` for a truncated object, returns the partial read instead of throwing `LOGICAL_ERROR: Cannot read all data`.

Also adds the remote object size to the error message for remaining cases to aid debugging.

A new integration test (`test_cache_s3_object_truncation`) truncates an S3 data object via minio and verifies that none of the three `LOGICAL_ERROR` messages from the pre-fix code paths appear when reading the table.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `LOGICAL_ERROR` exception during cache predownload when a remote S3 object is overwritten with shorter content between listing and reading.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.544`
- Backported to: `26.5.3.9`, `26.4.5.9`
<!-- ch-version-info:end -->