### PR TITLE
Add missing Jepsen project dependencies

### DIFF
--- a/tests/jepsen.clickhouse/project.clj
+++ b/tests/jepsen.clickhouse/project.clj
@@ -18,7 +18,6 @@
                  [net.java.dev.jna/jna "5.14.0"]
                  [net.java.dev.jna/jna-platform "5.14.0"]
                  [com.clickhouse/clickhouse-jdbc "0.3.2-patch11"]
-                 [org.clojure/data.generators "0.1.0"]
                  [clojure-interop/java.util.concurrent "1.0.5"]
                  [org.apache.zookeeper/zookeeper "3.6.1"
                   :exclusions [org.slf4j/slf4j-log4j12

--- a/tests/jepsen.clickhouse/project.clj
+++ b/tests/jepsen.clickhouse/project.clj
@@ -18,6 +18,8 @@
                  [net.java.dev.jna/jna "5.14.0"]
                  [net.java.dev.jna/jna-platform "5.14.0"]
                  [com.clickhouse/clickhouse-jdbc "0.3.2-patch11"]
+                 [org.clojure/data.generators "0.1.0"]
+                 [clojure-interop/java.util.concurrent "1.0.5"]
                  [org.apache.zookeeper/zookeeper "3.6.1"
                   :exclusions [org.slf4j/slf4j-log4j12
                                org.slf4j/slf4j-api]]]


### PR DESCRIPTION
Adds the missing Jepsen dependency declarations needed by the `tests/jepsen.clickhouse` project.

This keeps `project.clj` aligned with the Jepsen code that uses these libraries.

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Added missing Jepsen dependency declarations to `tests/jepsen.clickhouse/project.clj`.


### Documentation entry:
- [x] Documentation is not required.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.356`
<!-- ch-version-info:end -->