### PR TITLE
Disable use_iceberg_metadata_files_cache by default

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -5461,7 +5461,7 @@ Threshold for compaction data files in iceberg.
     DECLARE(UInt64, iceberg_max_number_datafiles_to_compact, 1000, R"(
 Threshold for compaction data files in iceberg.
 )", 0) \
-    DECLARE(Bool, use_iceberg_metadata_files_cache, true, R"(
+    DECLARE(Bool, use_iceberg_metadata_files_cache, false, R"(
 If turned on, iceberg table function and iceberg storage may utilize the iceberg metadata files cache.
 
 Possible values:

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -54,6 +54,9 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"optimize_rewrite_has_to_in", false, true, "New setting"},
             {"query_plan_push_limit_by_into_sort", false, true, "New setting that pushes a per-stream LIMIT BY into the sort pipeline when LIMIT BY's columns are a prefix of ORDER BY, reducing rows flowing through the final merge."},
             {"query_plan_max_set_size_for_projection_match", 0, 10000, "Added new setting that bounds the cost of content-hashing IN-clause sets in the projection matcher (today: aggregate projection). Sets larger than the limit are treated as non-matching. Zero disables content-hash comparison entirely (compatibility value: projection match never succeeds for nodes with IN-sets)."},
+            {"query_plan_min_columns_for_join_lazy_indexing", 0, 3, "Control the minimum number of payload columns from the left side required for enabling lazy indexing optimization in JOIN"},
+            {"query_plan_max_limit_for_join_lazy_indexing", 1000, 1000, "Added new setting to control maximum limit value that allows to use query plan for lazy join indexing optimization. If zero, there is no limit"},
+            {"use_iceberg_metadata_files_cache", true, false, "Disabled the iceberg metadata files cache by default to avoid serving stale metadata."},
         });
         addSettingsChanges(settings_changes_history, "26.5",
         {

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -54,8 +54,6 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"optimize_rewrite_has_to_in", false, true, "New setting"},
             {"query_plan_push_limit_by_into_sort", false, true, "New setting that pushes a per-stream LIMIT BY into the sort pipeline when LIMIT BY's columns are a prefix of ORDER BY, reducing rows flowing through the final merge."},
             {"query_plan_max_set_size_for_projection_match", 0, 10000, "Added new setting that bounds the cost of content-hashing IN-clause sets in the projection matcher (today: aggregate projection). Sets larger than the limit are treated as non-matching. Zero disables content-hash comparison entirely (compatibility value: projection match never succeeds for nodes with IN-sets)."},
-            {"query_plan_min_columns_for_join_lazy_indexing", 0, 3, "Control the minimum number of payload columns from the left side required for enabling lazy indexing optimization in JOIN"},
-            {"query_plan_max_limit_for_join_lazy_indexing", 1000, 1000, "Added new setting to control maximum limit value that allows to use query plan for lazy join indexing optimization. If zero, there is no limit"},
             {"use_iceberg_metadata_files_cache", true, false, "Disabled the iceberg metadata files cache by default to avoid serving stale metadata."},
         });
         addSettingsChanges(settings_changes_history, "26.5",

--- a/tests/integration/test_storage_iceberg_with_spark/configs/users.d/users.xml
+++ b/tests/integration/test_storage_iceberg_with_spark/configs/users.d/users.xml
@@ -1,4 +1,9 @@
 <clickhouse>
+    <profiles>
+        <default>
+            <use_iceberg_metadata_files_cache>1</use_iceberg_metadata_files_cache>
+        </default>
+    </profiles>
     <users>
         <default>
             <password></password>

--- a/tests/integration/test_storage_iceberg_with_spark/test_async_metadata_refresh.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_async_metadata_refresh.py
@@ -41,9 +41,7 @@ def test_selecting_with_stale_vs_latest_metadata(started_cluster_iceberg_with_sp
         additional_settings = [
             f"iceberg_metadata_async_prefetch_period_ms=0"
     ])
-    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}", settings={
-                              "use_iceberg_metadata_files_cache":1
-                              })) == 100
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}")) == 100
 
     # 1. Validating that SELECT will pull the latest metadata by default
     write_iceberg_from_df(
@@ -62,7 +60,6 @@ def test_selecting_with_stale_vs_latest_metadata(started_cluster_iceberg_with_sp
     # Now we will SELECT data with accepting a stale metadata - the expectation is that no call to remote catalog will occur and the cached metadata to be used
     assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}", settings={
                               "iceberg_metadata_staleness_ms":600_000,
-                              "use_iceberg_metadata_files_cache":1,
                               "log_comment":f"{TABLE_NAME}_01"
                               })) == 100
 
@@ -93,7 +90,6 @@ def test_selecting_with_stale_vs_latest_metadata(started_cluster_iceberg_with_sp
 
     # by default, SELECT will query remote catalog for the latest metadata
     assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}", settings={
-                              "use_iceberg_metadata_files_cache":1,
                               "log_comment":f"{TABLE_NAME}_02"
                               })) == 200
 
@@ -139,7 +135,6 @@ def test_selecting_with_stale_vs_latest_metadata(started_cluster_iceberg_with_sp
     # then, we accept really stale metadata at SELECT - no call to remote catalog
     assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}", settings={
                               "iceberg_metadata_staleness_ms":600_000,
-                              "use_iceberg_metadata_files_cache":1,
                               "log_comment":f"{TABLE_NAME}_03"
                               })) == 200
 
@@ -153,7 +148,6 @@ def test_selecting_with_stale_vs_latest_metadata(started_cluster_iceberg_with_sp
     # lastly, we SELECT with tiny tolerance to stale metadata - latest metadata will be fetched from s3
     assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}", settings={
                               "iceberg_metadata_staleness_ms":4_000,
-                              "use_iceberg_metadata_files_cache":1,
                               "log_comment":f"{TABLE_NAME}_04"
                               })) == 300
     # latest metadata was fetched from s3
@@ -206,9 +200,7 @@ def test_default_async_metadata_refresh(started_cluster_iceberg_with_spark, stor
 
     # The expectation is that async metadata fetcher is disabled by default
     create_iceberg_table(storage_type, instance, TABLE_NAME, started_cluster_iceberg_with_spark)
-    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}", settings={
-                              "use_iceberg_metadata_files_cache":1
-                              })) == 100
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}")) == 100
 
     write_iceberg_from_df(
         spark,
@@ -224,11 +216,11 @@ def test_default_async_metadata_refresh(started_cluster_iceberg_with_spark, stor
     )
 
     # the fresh metadata won't get pulled at SELECT, so we see stale data
-    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME} SETTINGS iceberg_metadata_staleness_ms=600000, use_iceberg_metadata_files_cache=1")) == 100
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME} SETTINGS iceberg_metadata_staleness_ms=600000")) == 100
     # sleeping a little bit
     time.sleep(10)
     # the metadata is not updated after sleep
-    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME} SETTINGS iceberg_metadata_staleness_ms=600000, use_iceberg_metadata_files_cache=1")) == 100
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME} SETTINGS iceberg_metadata_staleness_ms=600000")) == 100
 
 
 @pytest.mark.parametrize("storage_type", ["s3"])
@@ -261,9 +253,7 @@ def test_async_metadata_refresh(started_cluster_iceberg_with_spark, storage_type
         additional_settings = [
             f"iceberg_metadata_async_prefetch_period_ms={ASYNC_METADATA_REFRESH_PERIOD_MS}"
     ])
-    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}", settings={
-                              "use_iceberg_metadata_files_cache":1
-                              })) == 100
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}")) == 100
 
     # In order to track background activity against S3, let's remember current metric
     s3_reads_before = int(instance.query(
@@ -283,7 +273,7 @@ def test_async_metadata_refresh(started_cluster_iceberg_with_spark, storage_type
         "",
     )
     # the fresh metadata won't get pulled at SELECT, so we see stale data
-    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME} SETTINGS iceberg_metadata_staleness_ms=600000, use_iceberg_metadata_files_cache=1")) == 100
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME} SETTINGS iceberg_metadata_staleness_ms=600000")) == 100
     # Wait for the background async refresher to pick up the new metadata (2 periods of ASYNC_METADATA_REFRESH_PERIOD_MS)
     time.sleep(ASYNC_METADATA_REFRESH_PERIOD_MS/1000 * 2)
 
@@ -293,7 +283,7 @@ def test_async_metadata_refresh(started_cluster_iceberg_with_spark, storage_type
     ))
     assert s3_reads_after > s3_reads_before
     # we don't pull fresh metadata at SELECT, but the data is up to date because of the async refresh
-    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME} SETTINGS iceberg_metadata_staleness_ms=600000, use_iceberg_metadata_files_cache=1")) == 200
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME} SETTINGS iceberg_metadata_staleness_ms=600000")) == 200
 
 
 @pytest.mark.parametrize("storage_type", ["s3"])
@@ -320,7 +310,6 @@ def test_insert_updates_metadata_cache(started_cluster_iceberg_with_spark, stora
 
     assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}", settings={
                               "iceberg_metadata_staleness_ms":600_000,
-                              "use_iceberg_metadata_files_cache":1,
                               "log_comment":f"{TABLE_NAME}_40"
                               })) == 100
 

--- a/tests/integration/test_storage_iceberg_with_spark/test_async_metadata_refresh.py
+++ b/tests/integration/test_storage_iceberg_with_spark/test_async_metadata_refresh.py
@@ -41,7 +41,9 @@ def test_selecting_with_stale_vs_latest_metadata(started_cluster_iceberg_with_sp
         additional_settings = [
             f"iceberg_metadata_async_prefetch_period_ms=0"
     ])
-    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}")) == 100
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}", settings={
+                              "use_iceberg_metadata_files_cache":1
+                              })) == 100
 
     # 1. Validating that SELECT will pull the latest metadata by default
     write_iceberg_from_df(
@@ -60,6 +62,7 @@ def test_selecting_with_stale_vs_latest_metadata(started_cluster_iceberg_with_sp
     # Now we will SELECT data with accepting a stale metadata - the expectation is that no call to remote catalog will occur and the cached metadata to be used
     assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}", settings={
                               "iceberg_metadata_staleness_ms":600_000,
+                              "use_iceberg_metadata_files_cache":1,
                               "log_comment":f"{TABLE_NAME}_01"
                               })) == 100
 
@@ -90,6 +93,7 @@ def test_selecting_with_stale_vs_latest_metadata(started_cluster_iceberg_with_sp
 
     # by default, SELECT will query remote catalog for the latest metadata
     assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}", settings={
+                              "use_iceberg_metadata_files_cache":1,
                               "log_comment":f"{TABLE_NAME}_02"
                               })) == 200
 
@@ -135,6 +139,7 @@ def test_selecting_with_stale_vs_latest_metadata(started_cluster_iceberg_with_sp
     # then, we accept really stale metadata at SELECT - no call to remote catalog
     assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}", settings={
                               "iceberg_metadata_staleness_ms":600_000,
+                              "use_iceberg_metadata_files_cache":1,
                               "log_comment":f"{TABLE_NAME}_03"
                               })) == 200
 
@@ -148,6 +153,7 @@ def test_selecting_with_stale_vs_latest_metadata(started_cluster_iceberg_with_sp
     # lastly, we SELECT with tiny tolerance to stale metadata - latest metadata will be fetched from s3
     assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}", settings={
                               "iceberg_metadata_staleness_ms":4_000,
+                              "use_iceberg_metadata_files_cache":1,
                               "log_comment":f"{TABLE_NAME}_04"
                               })) == 300
     # latest metadata was fetched from s3
@@ -200,7 +206,9 @@ def test_default_async_metadata_refresh(started_cluster_iceberg_with_spark, stor
 
     # The expectation is that async metadata fetcher is disabled by default
     create_iceberg_table(storage_type, instance, TABLE_NAME, started_cluster_iceberg_with_spark)
-    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}")) == 100
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}", settings={
+                              "use_iceberg_metadata_files_cache":1
+                              })) == 100
 
     write_iceberg_from_df(
         spark,
@@ -216,11 +224,11 @@ def test_default_async_metadata_refresh(started_cluster_iceberg_with_spark, stor
     )
 
     # the fresh metadata won't get pulled at SELECT, so we see stale data
-    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME} SETTINGS iceberg_metadata_staleness_ms=600000")) == 100
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME} SETTINGS iceberg_metadata_staleness_ms=600000, use_iceberg_metadata_files_cache=1")) == 100
     # sleeping a little bit
     time.sleep(10)
     # the metadata is not updated after sleep
-    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME} SETTINGS iceberg_metadata_staleness_ms=600000")) == 100
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME} SETTINGS iceberg_metadata_staleness_ms=600000, use_iceberg_metadata_files_cache=1")) == 100
 
 
 @pytest.mark.parametrize("storage_type", ["s3"])
@@ -253,7 +261,9 @@ def test_async_metadata_refresh(started_cluster_iceberg_with_spark, storage_type
         additional_settings = [
             f"iceberg_metadata_async_prefetch_period_ms={ASYNC_METADATA_REFRESH_PERIOD_MS}"
     ])
-    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}")) == 100
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}", settings={
+                              "use_iceberg_metadata_files_cache":1
+                              })) == 100
 
     # In order to track background activity against S3, let's remember current metric
     s3_reads_before = int(instance.query(
@@ -273,7 +283,7 @@ def test_async_metadata_refresh(started_cluster_iceberg_with_spark, storage_type
         "",
     )
     # the fresh metadata won't get pulled at SELECT, so we see stale data
-    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME} SETTINGS iceberg_metadata_staleness_ms=600000")) == 100
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME} SETTINGS iceberg_metadata_staleness_ms=600000, use_iceberg_metadata_files_cache=1")) == 100
     # Wait for the background async refresher to pick up the new metadata (2 periods of ASYNC_METADATA_REFRESH_PERIOD_MS)
     time.sleep(ASYNC_METADATA_REFRESH_PERIOD_MS/1000 * 2)
 
@@ -283,7 +293,7 @@ def test_async_metadata_refresh(started_cluster_iceberg_with_spark, storage_type
     ))
     assert s3_reads_after > s3_reads_before
     # we don't pull fresh metadata at SELECT, but the data is up to date because of the async refresh
-    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME} SETTINGS iceberg_metadata_staleness_ms=600000")) == 200
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME} SETTINGS iceberg_metadata_staleness_ms=600000, use_iceberg_metadata_files_cache=1")) == 200
 
 
 @pytest.mark.parametrize("storage_type", ["s3"])
@@ -310,6 +320,7 @@ def test_insert_updates_metadata_cache(started_cluster_iceberg_with_spark, stora
 
     assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}", settings={
                               "iceberg_metadata_staleness_ms":600_000,
+                              "use_iceberg_metadata_files_cache":1,
                               "log_comment":f"{TABLE_NAME}_40"
                               })) == 100
 

--- a/tests/integration/test_storage_iceberg_with_spark_cache/configs/users.d/users.xml
+++ b/tests/integration/test_storage_iceberg_with_spark_cache/configs/users.d/users.xml
@@ -1,4 +1,9 @@
 <clickhouse>
+    <profiles>
+        <default>
+            <use_iceberg_metadata_files_cache>1</use_iceberg_metadata_files_cache>
+        </default>
+    </profiles>
     <users>
         <default>
             <password></password>

--- a/tests/integration/test_storage_iceberg_with_spark_cache/test_metadata_cache.py
+++ b/tests/integration/test_storage_iceberg_with_spark_cache/test_metadata_cache.py
@@ -88,7 +88,6 @@ def test_metadata_cache(started_cluster_iceberg_with_spark, storage_type):
     instance.query(
         f"SELECT * FROM {table_expr}",
         query_id=query_id,
-        settings={"use_iceberg_metadata_files_cache":"0"},
     )
 
     instance.query("SYSTEM FLUSH LOGS")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
