### PR TITLE
Fix flaky test_s3_aws_sdk_has_slightly_unreliable_behaviour::test_dataloss

### DIFF
--- a/tests/integration/test_s3_aws_sdk_has_slightly_unreliable_behaviour/configs/storage_conf.xml
+++ b/tests/integration/test_s3_aws_sdk_has_slightly_unreliable_behaviour/configs/storage_conf.xml
@@ -15,7 +15,8 @@
                 <skip_access_check>true</skip_access_check>
                 <!-- Avoid extra retries to speed up tests -->
                 <!-- never set retry_attempts to 0, as it disables retries on all errors including sporadic timeouts -->
-                <retry_attempts>2</retry_attempts>
+                <!-- disk request settings need the s3_ prefix; the bare key is ignored -->
+                <s3_retry_attempts>2</s3_retry_attempts>
                 <skip_access_check>true</skip_access_check>
             </s3>
         </disks>

--- a/tests/integration/test_s3_aws_sdk_has_slightly_unreliable_behaviour/test.py
+++ b/tests/integration/test_s3_aws_sdk_has_slightly_unreliable_behaviour/test.py
@@ -83,9 +83,15 @@ def test_dataloss(cluster):
     )
 
     # Must throw an exception because we use proxy which always fail
-    # CompleteMultipartUpload requests
+    # CompleteMultipartUpload requests.
+    # async_insert is disabled so the write fails synchronously: otherwise the
+    # insert returns after the async timeout while a background flush keeps
+    # retrying against the always-failing proxy, racing the cleanup DROP below.
     try:
         with pytest.raises(Exception):
-            node.query("INSERT INTO s3_failover_test VALUES (1, 'Hello')")
+            node.query(
+                "INSERT INTO s3_failover_test VALUES (1, 'Hello')",
+                settings={"async_insert": 0},
+            )
     finally:
         node.query("DROP TABLE IF EXISTS s3_failover_test")


### PR DESCRIPTION
The integration test `test_s3_aws_sdk_has_slightly_unreliable_behaviour/test.py::test_dataloss` is flaky and slow in CI. It times out at the cleanup `DROP` under the 600s client timeout, e.g. on `Integration tests (amd_asan_ubsan, db disk, old analyzer)`.

The test asserts that an `INSERT` into an S3-backed table throws when the S3 proxy always fails `CompleteMultipartUpload`. Two independent causes broke it:

1. `async_insert` defaults to `true`, so the `INSERT` was routed through the async queue. The client returned after the `WaitForAsyncInsert` timeout (satisfying `pytest.raises`), while a background flush kept retry-storming the always-failing proxy and raced the cleanup `DROP`. The test was written for the synchronous S3 write-failure path, so this disables `async_insert` on the `INSERT`.

2. The disk config set `retry_attempts`, but S3 disk request settings are read with the `s3_` prefix (`loadFromConfigForObjectStorage` passes `setting_name_prefix = "s3_"`), so the bare key was silently ignored and the 500-attempt default stayed active. Even synchronously this made the `INSERT` take about 300s. The key is renamed to `s3_retry_attempts` so the intended cap of 2 takes effect.

With both fixes the test fails synchronously in about 6s. Validated with 6/6 passing runs locally on the `amd_tsan` integration image, each call phase 5.5-6.8s.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)