### PR TITLE
Add per-disk BlobKiller queue-depth metric for object-storage removal…

### DIFF
--- a/src/Disks/DiskObjectStorage/MetadataStorages/IMetadataStorage.h
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/IMetadataStorage.h
@@ -293,6 +293,7 @@ public:
     virtual BlobsToRemove getBlobsToRemove(const ClusterConfigurationPtr & /*cluster*/, int64_t /*max_count*/) { return {}; }
     virtual int64_t recordAsRemoved(const StoredObjects & /*blobs*/) { return 0; }
     virtual bool hasPendingRemovalBlobs(const StoredObjects & /*blobs*/) const { return false; }
+    virtual size_t getRemovalQueueSize() const { return 0; }
 
     struct BlobsReplication
     {

--- a/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDisk.cpp
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDisk.cpp
@@ -325,6 +325,12 @@ bool MetadataStorageFromDisk::hasPendingRemovalBlobs(const StoredObjects & blobs
     return objects_to_remove.containsAny(blobs);
 }
 
+size_t MetadataStorageFromDisk::getRemovalQueueSize() const
+{
+    std::lock_guard guard(removed_objects_mutex);
+    return objects_to_remove.size();
+}
+
 MetadataStorageFromDiskTransaction::MetadataStorageFromDiskTransaction(MetadataStorageFromDisk & metadata_storage_)
     : metadata_storage(metadata_storage_)
 {

--- a/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDisk.h
+++ b/src/Disks/DiskObjectStorage/MetadataStorages/Local/MetadataStorageFromDisk.h
@@ -120,6 +120,7 @@ public:
     BlobsToRemove getBlobsToRemove(const ClusterConfigurationPtr & cluster, int64_t max_count) override;
     int64_t recordAsRemoved(const StoredObjects & blobs) override;
     bool hasPendingRemovalBlobs(const StoredObjects & blobs) const override;
+    size_t getRemovalQueueSize() const override;
 };
 
 class MetadataStorageFromDiskTransaction final : public IMetadataTransaction

--- a/src/Disks/tests/gtest_metadata_local_disk.cpp
+++ b/src/Disks/tests/gtest_metadata_local_disk.cpp
@@ -1464,3 +1464,41 @@ TEST_F(MetadataLocalDiskTest, TestNonExistingObjectsInTransaction)
             });
     }
 }
+
+TEST_F(MetadataLocalDiskTest, TestGetRemovalQueueSize)
+{
+    auto metadata = getMetadataStorage("/TestGetRemovalQueueSize");
+    metadata->startup();
+
+    {
+        auto tx = metadata->createTransaction();
+        tx->createDirectoryRecursive("queue-size");
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    EXPECT_EQ(metadata->getRemovalQueueSize(), 0);
+
+    auto stored = [](const std::string & blob_key, const std::string & file)
+    {
+        return DB::StoredObject(DB::ObjectStorageKey::createAsAbsolute(blob_key).serialize(), file, 1);
+    };
+
+    {
+        auto tx = metadata->createTransaction();
+        for (const auto & key : {"a-1", "a-2", "a-3"})
+        {
+            const std::string file = std::string("queue-size/f-") + key;
+            tx->createMetadataFile(file, {stored(key, file)});
+            tx->unlinkFile(file, /*if_exists=*/false, /*should_remove_objects=*/true);
+        }
+        tx->commit(DB::NoCommitOptions{});
+    }
+
+    EXPECT_EQ(metadata->getRemovalQueueSize(), 3);
+
+    EXPECT_EQ(metadata->recordAsRemoved({stored("a-1", "queue-size/f-a-1")}), 1);
+    EXPECT_EQ(metadata->getRemovalQueueSize(), 2);
+
+    EXPECT_EQ(metadata->recordAsRemoved({stored("a-2", "queue-size/f-a-2"), stored("a-3", "queue-size/f-a-3")}), 2);
+    EXPECT_EQ(metadata->getRemovalQueueSize(), 0);
+}

--- a/src/Interpreters/ServerAsynchronousMetrics.cpp
+++ b/src/Interpreters/ServerAsynchronousMetrics.cpp
@@ -11,6 +11,8 @@
 
 #include <Databases/IDatabase.h>
 
+#include <Disks/DiskObjectStorage/MetadataStorages/IMetadataStorage.h>
+
 #include <IO/UncompressedCache.h>
 #include <IO/MMappedFileCache.h>
 #include <Common/PageCache.h>
@@ -267,6 +269,18 @@ void ServerAsynchronousMetrics::updateImpl(TimePoint update_time, TimePoint curr
                 if (unreserved)
                     new_values[fmt::format("DiskUnreserved_{}", name)] = { *unreserved,
                         "Available bytes on the disk (virtual filesystem) without the reservations for merges, fetches, and moves. Remote filesystems may not provide this information and can show a large value like 16 EiB." };
+            }
+
+            try
+            {
+                if (auto metadata_storage = disk->getMetadataStorage())
+                {
+                    new_values[fmt::format("BlobKillerObjectsToRemove_{}", name)] = { metadata_storage->getRemovalQueueSize(),
+                        "Number of object-storage blobs queued for background removal by `BlobKillerThread` for this disk. Sustained growth indicates the drain rate is below the producer rate and `metadata_request_size` should be increased." };
+                }
+            }
+            catch (...)
+            {
             }
 
 #if USE_AWS_S3


### PR DESCRIPTION
### Why

While investigating a slow memory creep, I eventually traced it to retired object-storage blobs piling up in `MetadataStorageFromDisk::objects_to_remove`. After the cleanup work was moved to `BlobKillerThread`, the drainer was running behind producers, but nothing surfaced that. The existing `BlobKillerThread*` counters measure drain throughput, not queue depth, so a too-small `metadata_request_size` falls behind silently while memory grows. Having this metric earlier would have pointed at the cause directly instead of working backward from RSS.

### What

Adds `BlobKillerObjectsToRemove_<disk>` in `system.asynchronous_metrics`, one row per object-storage disk, reading `objects_to_remove.size()` from the disk's `MetadataStorageFromDisk`. Disks that don't implement `getMetadataStorage` are silently skipped. Sustained growth of this gauge is the signal to raise `metadata_request_size` for the affected disk.

Verification on an aarch64 build with `metadata_request_size = 1` and 8 parallel writers churning small parts: the gauge climbed steadily from 36k to 61k under load, held at ~70k after producers stopped, and collapsed to 0 within 5s of `SYSTEM RELOAD CONFIG` restoring a healthy drain rate.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add a per-disk `BlobKillerObjectsToRemove_<disk>` asynchronous metric exposing the number of object-storage blobs queued for background removal. Sustained growth of this gauge means the drainer is falling behind producers and `metadata_request_size` should be increased.
