### PR TITLE
Make url_base_setting test more stable

### DIFF
--- a/tests/queries/0_stateless/04070_url_base_setting.sh
+++ b/tests/queries/0_stateless/04070_url_base_setting.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Tags: no-replicated-database
 
 # Test url_base setting for resolving relative URLs.
 # The queries will fail with connection errors, but the debug-level log from
@@ -88,7 +89,7 @@ run_and_check "SELECT * FROM url('../a.csv?foo=bar', CSV, 'c String') SETTINGS u
 
 # URL engine: path-relative URL with url_base should resolve correctly
 $CLICKHOUSE_CLIENT --send_logs_level=debug -n -q "
-SET url_base = 'http://base.invalid/dir/', http_connection_timeout = 1, http_max_tries = 1;
+SET url_base = 'http://base.invalid/dir/', $FAST;
 CREATE TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_url (c String) ENGINE = URL('data.csv', CSV);
 SELECT * FROM ${CLICKHOUSE_TEST_UNIQUE_NAME}_url;
 " 2>&1 | grep -oF 'http://base.invalid/dir/data.csv' | head -1
@@ -101,7 +102,7 @@ run_and_check "SELECT * FROM url('', CSV, 'c String') SETTINGS url_base = 'http:
 # DETACH/ATTACH (and server restart) after url_base is unset or changed.
 # Use FORMAT TabSeparatedRaw so single quotes are not escaped in the output.
 $CLICKHOUSE_CLIENT -n -q "
-SET url_base = 'http://base.invalid/dir/';
+SET url_base = 'http://base.invalid/dir/', $FAST;
 DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_url_persist;
 CREATE TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_url_persist (c String) ENGINE = URL('persist.csv', CSV);
 SET url_base = '';
@@ -120,7 +121,7 @@ run_and_check "SELECT * FROM url('//other.invalid/a/../b.csv', CSV, 'c String') 
 $CLICKHOUSE_CLIENT -n -q "
 DROP NAMED COLLECTION IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_nc;
 CREATE NAMED COLLECTION ${CLICKHOUSE_TEST_UNIQUE_NAME}_nc AS url='persist.csv', format='CSV';
-SET url_base = 'http://base.invalid/dir/';
+SET url_base = 'http://base.invalid/dir/', $FAST;
 DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_url_nc_persist;
 CREATE TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_url_nc_persist (c String) ENGINE = URL(${CLICKHOUSE_TEST_UNIQUE_NAME}_nc);
 SET url_base = '';
@@ -137,7 +138,7 @@ DROP NAMED COLLECTION IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_nc;
 $CLICKHOUSE_CLIENT -n -q "
 DROP NAMED COLLECTION IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_nc_secret;
 CREATE NAMED COLLECTION ${CLICKHOUSE_TEST_UNIQUE_NAME}_nc_secret AS url='http://abs.invalid/data.csv', format='CSV';
-SET url_base = 'http://base.invalid/dir/';
+SET url_base = 'http://base.invalid/dir/', $FAST;
 DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_url_nc_secret;
 CREATE TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_url_nc_secret (c String) ENGINE = URL(${CLICKHOUSE_TEST_UNIQUE_NAME}_nc_secret);
 SHOW CREATE TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_url_nc_secret FORMAT TabSeparatedRaw;
@@ -152,7 +153,7 @@ DROP NAMED COLLECTION IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_nc_secret;
 $CLICKHOUSE_CLIENT -n -q "
 DROP NAMED COLLECTION IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_nc_creds;
 CREATE NAMED COLLECTION ${CLICKHOUSE_TEST_UNIQUE_NAME}_nc_creds AS url='persist.csv', format='CSV';
-SET url_base = 'http://user:pass@base.invalid/dir/';
+SET url_base = 'http://user:pass@base.invalid/dir/', $FAST;
 DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_url_nc_creds;
 CREATE TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_url_nc_creds (c String) ENGINE = URL(${CLICKHOUSE_TEST_UNIQUE_NAME}_nc_creds);
 SHOW CREATE TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_url_nc_creds FORMAT TabSeparatedRaw;
@@ -162,7 +163,7 @@ DROP NAMED COLLECTION IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_nc_creds;
 
 # URL engine: credentials introduced by url_base must also NOT leak into positional engine args.
 $CLICKHOUSE_CLIENT -n -q "
-SET url_base = 'http://user:pass@base.invalid/dir/';
+SET url_base = 'http://user:pass@base.invalid/dir/', $FAST;
 DROP TABLE IF EXISTS ${CLICKHOUSE_TEST_UNIQUE_NAME}_url_pos_creds;
 CREATE TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_url_pos_creds (c String) ENGINE = URL('persist.csv', CSV);
 SHOW CREATE TABLE ${CLICKHOUSE_TEST_UNIQUE_NAME}_url_pos_creds FORMAT TabSeparatedRaw;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Attempts to fix the CI failure here: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=106235&sha=3ad1cde50f70f233cf36d22fc54d0fce5c7bd635&name_0=PR&name_1=Stateless+tests+%28amd_llvm_coverage%2C+old+analyzer%2C+s3+storage%2C+DatabaseReplicated%2C+WasmEdge%2C+parallel%29

From Claude:
```
Session-level SET url_base does not propagate through Keeper's DDL queue, 
so CREATE TABLE on the replica never sees the setting.
Add no-replicated-database tag and fast HTTP timeout settings to all multi-statement blocks.
```

cc @alexey-milovidov can you review this?

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.389`
<!-- ch-version-info:end -->