### PR TITLE
Web UI: lay out bottom menu icons horizontally when the panel is expanded

### DIFF
--- a/programs/server/play.html
+++ b/programs/server/play.html
@@ -193,6 +193,20 @@
             overflow-y: clip;
         }
 
+        /* When the databases list is expanded, lay out the bottom icons (Web
+           Terminal, GitHub) side by side instead of stacked, so the list of
+           databases/tables gets more vertical space. */
+        #menu.databases-opened
+        {
+            grid-template-columns: auto 1fr;
+            grid-template-areas: "databases-icon databases-icon" "contents contents" "terminal-icon github-icon";
+        }
+
+        #menu.databases-opened #github-icon
+        {
+            justify-self: start;
+        }
+
         #main
         {
             overflow: auto;
@@ -2695,11 +2709,13 @@ function toggleDatabases() {
             if (ok !== false) {
                 databases_toggle.dataset['opened'] = 1;
                 menu_elem.style.cursor = 'w-resize';
+                menu_elem.classList.add('databases-opened');
             }
         });
     } else {
         delete databases_toggle.dataset['opened'];
         menu_elem.style.cursor = 'e-resize';
+        menu_elem.classList.remove('databases-opened');
         let databases_elem = document.getElementById('databases');
         while (databases_elem.firstChild) databases_elem.removeChild(databases_elem.firstChild);
     }


### PR DESCRIPTION
In the Web UI (`play.html`), the left menu stacked the bottom icons (Web Terminal and GitHub) vertically below the list of databases and tables. When the panel is expanded, this wasted a row of vertical space.

Now, when the databases list is expanded, the bottom icons are laid out horizontally on a single row, giving the list of databases/tables more vertical space. The collapsed state keeps the original stacked layout, since the narrow menu has no room for a horizontal arrangement.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
In the Web UI, lay out the bottom menu icons (Web Terminal and GitHub) horizontally when the left panel is expanded, giving the list of databases and tables more vertical space.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.396`
<!-- ch-version-info:end -->