### PR TITLE
Allow short `case` labels on a single line

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -60,7 +60,7 @@ AlignConsecutiveAssignments: false
 AlignOperands: false
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
-AllowShortCaseLabelsOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: true
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None


### PR DESCRIPTION
Currently `.clang-format` forces every `case` label onto a separate line from its statement. In practice the rule is ignored across the codebase: spreading each short case over two lines hurts readability, so contributors keep the compact form and avoid running clang-format on those files. A rough count finds roughly 2k single-line `case` labels in `src/`. For example, `src/Core/Joins.cpp` has

```cpp
const char * toString(JoinKind kind)
{
    switch (kind)
    {
        case JoinKind::Inner: return "INNER";
        case JoinKind::Left: return "LEFT";
        case JoinKind::Right: return "RIGHT";
        case JoinKind::Full: return "FULL";
        case JoinKind::Cross: return "CROSS";
        case JoinKind::Comma: return "COMMA";
        case JoinKind::Paste: return "PASTE";
    }
};
```

even though clang-format with the current config would expand it to

```cpp
const char * toString(JoinKind kind)
{
    switch (kind)
    {
        case JoinKind::Inner:
            return "INNER";
        case JoinKind::Left:
            return "LEFT";
        case JoinKind::Right:
            return "RIGHT";
        case JoinKind::Full:
            return "FULL";
        case JoinKind::Cross:
            return "CROSS";
        case JoinKind::Comma:
            return "COMMA";
        case JoinKind::Paste:
            return "PASTE";
    }
};
```


Our [style guide](https://clickhouse.com/docs/development/style) favours brevity: "Write as little code as possible" and "Code simplification is encouraged. Reduce the size of your code where possible." 

Permitting the compact form makes clang-format agree with what we already write, so we can apply it to these files again instead of skipping it.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.383`
<!-- ch-version-info:end -->