### PR TITLE
Allow experimental MergeTree settings from the global config under allow_feature_tier

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -2936,14 +2936,13 @@ try
     /// It is important to initialize MergeTreeSettings after Settings, to support compatibility for MergeTreeSettings.
     sanityChecks(*this, server_settings);
 
-    /// Check sanity of MergeTreeSettings on server startup
+    /// Check sanity of MergeTreeSettings on server startup.
+    /// `allow_feature_tier` is intentionally not enforced for the global `<merge_tree>` config: any setting
+    /// (including EXPERIMENTAL/BETA) may be changed there, the same way it may be set in the default profile.
     {
-        /// All settings can be changed in the global config
-        bool allowed_experimental = true;
-        bool allowed_beta = true;
         size_t background_pool_tasks = global_context->getMergeMutateExecutor()->getMaxTasksCount();
-        global_context->getMergeTreeSettings().sanityCheck(background_pool_tasks, allowed_experimental, allowed_beta, global_context->wasBackgroundPoolAutoLowered());
-        global_context->getReplicatedMergeTreeSettings().sanityCheck(background_pool_tasks, allowed_experimental, allowed_beta, global_context->wasBackgroundPoolAutoLowered());
+        global_context->getMergeTreeSettings().sanityCheck(background_pool_tasks, global_context->wasBackgroundPoolAutoLowered());
+        global_context->getReplicatedMergeTreeSettings().sanityCheck(background_pool_tasks, global_context->wasBackgroundPoolAutoLowered());
     }
     /// try set up encryption. There are some errors in config, error will be printed and server wouldn't start.
     CompressionCodecEncrypted::Configuration::instance().load(config(), "encryption_codecs");

--- a/src/Access/SettingsConstraints.cpp
+++ b/src/Access/SettingsConstraints.cpp
@@ -337,6 +337,42 @@ bool SettingsConstraints::checkImpl(const MergeTreeSettings & current_settings, 
     Field new_value = getNewValueToCheck(current_settings, change, /*ignore_unchanged_settings=*/false, reaction == THROW_ON_VIOLATION);
     if (new_value.isNull())
         return false;
+
+    /// Enforce `allow_feature_tier` for MergeTree settings, mirroring `getChecker` for regular settings.
+    /// This is intentionally delta-based: `getNewValueToCheck` above already returned Null (skipped) for
+    /// settings whose value equals the baseline `current_settings`. When the baseline is the server
+    /// `<merge_tree>` config (on CREATE) or the table's current settings (on ALTER), an EXPERIMENTAL/BETA
+    /// value inherited from that trusted source is exempt, while a value introduced by the query is rejected.
+    /// This matches how an experimental setting placed in the default profile is allowed for regular settings.
+    if (access_control)
+    {
+        bool allowed_experimental = access_control->getAllowExperimentalTierSettings();
+        bool allowed_beta = access_control->getAllowBetaTierSettings();
+        if (!allowed_experimental || !allowed_beta)
+        {
+            auto setting_tier = current_settings.getTier(setting_name);
+            if (setting_tier == SettingsTierType::EXPERIMENTAL && !allowed_experimental)
+            {
+                if (reaction == THROW_ON_VIOLATION)
+                    throw Exception(
+                        ErrorCodes::READONLY,
+                        "Cannot modify setting '{}'. Changes to EXPERIMENTAL settings are disabled in the server config "
+                        "('allow_feature_tier')",
+                        setting_name);
+                return false;
+            }
+            if (setting_tier == SettingsTierType::BETA && !allowed_beta)
+            {
+                if (reaction == THROW_ON_VIOLATION)
+                    throw Exception(
+                        ErrorCodes::READONLY,
+                        "Cannot modify setting '{}'. Changes to BETA settings are disabled in the server config ('allow_feature_tier')",
+                        setting_name);
+                return false;
+            }
+        }
+    }
+
     return getMergeTreeChecker(setting_name).check(change, new_value, reaction, SettingSource::QUERY);
 }
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -714,15 +714,12 @@ MergeTreeData::MergeTreeData(
     allow_reverse_key = !sanity_checks || (*settings)[MergeTreeSetting::allow_experimental_reverse_key];
 
     /// Check sanity of MergeTreeSettings. Only when table is created.
+    /// `allow_feature_tier` enforcement happens earlier, in the delta-based settings-constraints check
+    /// (`checkMergeTreeSettingsConstraints`) run by the storage factory / ALTER, so it is not repeated here.
     if (sanity_checks)
     {
-        const auto & ac = getContext()->getAccessControl();
-        bool allow_experimental = ac.getAllowExperimentalTierSettings();
-        bool allow_beta = ac.getAllowBetaTierSettings();
         settings->sanityCheck(
             getContext()->getMergeMutateExecutor()->getMaxTasksCount(),
-            allow_experimental,
-            allow_beta,
             getContext()->wasBackgroundPoolAutoLowered());
     }
 
@@ -4804,11 +4801,21 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
         performRequiredConversions(old_header, columns_to_check_conversion, local_context, new_metadata.getColumns().getDefaults(), true);
     }
 
+    /// Validate settings constraints (min/max/readonly and `allow_feature_tier`) for any settings the
+    /// ALTER introduces. Done unconditionally - not only when the table already had a SETTINGS clause - so
+    /// that a newly added EXPERIMENTAL/BETA setting is rejected under `allow_feature_tier`. The check is
+    /// delta-based against the table's current settings, so values carried over unchanged are exempt; this
+    /// is the enforcement point for the tier on ALTER (`MergeTreeSettings::sanityCheck` no longer checks it).
+    if (new_metadata.settings_changes)
+    {
+        const auto & new_changes = new_metadata.settings_changes->as<const ASTSetQuery &>().changes;
+        local_context->checkMergeTreeSettingsConstraints(*settings_from_storage, new_changes);
+    }
+
     if (old_metadata.hasSettingsChanges())
     {
         const auto current_changes = old_metadata.getSettingsChanges()->as<const ASTSetQuery &>().changes;
         const auto & new_changes = new_metadata.settings_changes->as<const ASTSetQuery &>().changes;
-        local_context->checkMergeTreeSettingsConstraints(*settings_from_storage, new_changes);
 
         bool found_disk_setting = false;
         bool found_storage_policy_setting = false;
@@ -5072,15 +5079,13 @@ void MergeTreeData::changeSettings(
         }
 
         /// Reset to default settings before applying existing.
+        /// `allow_feature_tier` is enforced earlier, during ALTER validation in `checkAlterIsPossible`
+        /// (delta-based), so it is not re-checked here - this would also run on rollback paths that
+        /// re-apply previously-valid settings.
         auto copy = getDefaultSettings();
         copy->applyChanges(new_changes);
-        const auto & ac = getContext()->getAccessControl();
-        bool allow_experimental = ac.getAllowExperimentalTierSettings();
-        bool allow_beta = ac.getAllowBetaTierSettings();
         copy->sanityCheck(
             getContext()->getMergeMutateExecutor()->getMaxTasksCount(),
-            allow_experimental,
-            allow_beta,
             getContext()->wasBackgroundPoolAutoLowered());
 
         bool has_escape_index_filenames_changed

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -43,7 +43,6 @@ namespace ErrorCodes
     extern const int UNKNOWN_SETTING;
     extern const int BAD_ARGUMENTS;
     extern const int LOGICAL_ERROR;
-    extern const int READONLY;
 }
 
 // clang-format off
@@ -2258,7 +2257,7 @@ struct MergeTreeSettingsImpl : public BaseSettings<MergeTreeSettingsTraits>
     void loadFromQuery(ASTStorage & storage_def, ContextPtr context, bool is_loading_from_existing_metadata);
 
     /// Check that the values are sane taking also query-level settings into account.
-    void sanityCheck(size_t background_pool_tasks, bool allow_experimental, bool allow_beta, bool background_pool_auto_lowered) const;
+    void sanityCheck(size_t background_pool_tasks, bool background_pool_auto_lowered) const;
 
     /// Subscript operators so that MergeTreeSetting::NAME can be used inside Impl methods.
     /// Delegate to `BaseSettings::operator[]` so the Impl->Data subobject offset is handled
@@ -2368,33 +2367,15 @@ void MergeTreeSettingsImpl::loadFromQuery(ASTStorage & storage_def, ContextPtr c
 #undef ADD_IF_ABSENT
 }
 
-void MergeTreeSettingsImpl::sanityCheck(size_t background_pool_tasks, bool allow_experimental, bool allow_beta, bool background_pool_auto_lowered) const
+void MergeTreeSettingsImpl::sanityCheck(size_t background_pool_tasks, bool background_pool_auto_lowered) const
 {
-    if (!allow_experimental || !allow_beta)
-    {
-        for (const auto & setting : all())
-        {
-            if (!setting.isValueChanged())
-                continue;
-
-            auto tier = setting.getTier();
-            if (!allow_experimental && tier == EXPERIMENTAL)
-            {
-                throw Exception(
-                    ErrorCodes::READONLY,
-                    "Cannot modify setting '{}'. Changes to EXPERIMENTAL settings are disabled in the server config "
-                    "('allow_feature_tier')",
-                    setting.getName());
-            }
-            if (!allow_beta && tier == BETA)
-            {
-                throw Exception(
-                    ErrorCodes::READONLY,
-                    "Cannot modify setting '{}'. Changes to BETA settings are disabled in the server config ('allow_feature_tier')",
-                    setting.getName());
-            }
-        }
-    }
+    /// NOTE: `allow_feature_tier` enforcement for MergeTree settings is intentionally NOT done here.
+    /// A state-based check (rejecting any setting whose value differs from the compiled-in default)
+    /// would also reject EXPERIMENTAL/BETA values inherited from the server `<merge_tree>` config,
+    /// breaking creation of every table on such a server. Tier enforcement is instead delta-based and
+    /// lives in `SettingsConstraints::checkImpl` (invoked on CREATE/ALTER), so that only values
+    /// introduced by the query are rejected, while values inherited from the trusted server config are
+    /// allowed - mirroring how experimental settings placed in the default profile work for regular settings.
 
 
     /// Skip these checks when the background pool was auto-lowered by the low-memory heuristic
@@ -2609,6 +2590,11 @@ Field MergeTreeSettings::get(std::string_view name) const
     return impl->get(name);
 }
 
+SettingsTierType MergeTreeSettings::getTier(std::string_view name) const
+{
+    return impl->getTier(name);
+}
+
 void MergeTreeSettings::set(std::string_view name, const Field & value)
 {
     impl->set(name, value);
@@ -2703,9 +2689,9 @@ bool MergeTreeSettings::needSyncPart(size_t input_rows, size_t input_bytes) cons
         || ((*this)[MergeTreeSetting::min_compressed_bytes_to_fsync_after_merge] && input_bytes >= (*this)[MergeTreeSetting::min_compressed_bytes_to_fsync_after_merge]));
 }
 
-void MergeTreeSettings::sanityCheck(size_t background_pool_tasks, bool allow_experimental, bool allow_beta, bool background_pool_auto_lowered) const
+void MergeTreeSettings::sanityCheck(size_t background_pool_tasks, bool background_pool_auto_lowered) const
 {
-    impl->sanityCheck(background_pool_tasks, allow_experimental, allow_beta, background_pool_auto_lowered);
+    impl->sanityCheck(background_pool_tasks, background_pool_auto_lowered);
 }
 
 void MergeTreeSettings::dumpToSystemMergeTreeSettingsColumns(MutableColumnsAndConstraints & params) const

--- a/src/Storages/MergeTree/MergeTreeSettings.h
+++ b/src/Storages/MergeTree/MergeTreeSettings.h
@@ -4,6 +4,7 @@
 #include <Core/Field.h>
 #include <Core/SettingsEnums.h>
 #include <Core/SettingsFields.h>
+#include <Core/SettingsTierType.h>
 #include <base/types.h>
 #include <Common/SettingsChanges.h>
 #include <Columns/IColumn_fwd.h>
@@ -79,6 +80,8 @@ struct MergeTreeSettings
     bool tryGet(std::string_view name, Field & value) const;
     Field get(std::string_view name) const;
 
+    SettingsTierType getTier(std::string_view name) const;
+
     void set(std::string_view name, const Field & value);
 
     SettingsChanges changes() const;
@@ -92,7 +95,7 @@ struct MergeTreeSettings
     void loadFromConfig(const String & config_elem, const Poco::Util::AbstractConfiguration & config);
 
     bool needSyncPart(size_t input_rows, size_t input_bytes) const;
-    void sanityCheck(size_t background_pool_tasks, bool allow_experimental, bool allow_beta, bool background_pool_auto_lowered) const;
+    void sanityCheck(size_t background_pool_tasks, bool background_pool_auto_lowered) const;
 
     void dumpToSystemMergeTreeSettingsColumns(MutableColumnsAndConstraints & params) const;
     void dumpToSystemCompletionsColumns(MutableColumns & columns) const;

--- a/src/Storages/ProjectionsDescription.cpp
+++ b/src/Storages/ProjectionsDescription.cpp
@@ -328,14 +328,11 @@ ProjectionDescription ProjectionDescription::getProjectionFromAST(
                 throw Exception(ErrorCodes::BAD_ARGUMENTS, "Setting {} is not allowed for projections", change.name);
         }
 
-        const auto & ac = query_context->getAccessControl();
-        bool allow_experimental = ac.getAllowExperimentalTierSettings();
-        bool allow_beta = ac.getAllowBetaTierSettings();
+        /// Projections only allow PRODUCTION-tier settings (see ALLOWED_PROJECTION_SETTINGS above), so
+        /// `allow_feature_tier` enforcement is not applicable here.
         query_context->getGlobalContext()->initializeBackgroundExecutorsIfNeeded();
         merge_tree_settings->sanityCheck(
             query_context->getMergeMutateExecutor()->getMaxTasksCount(),
-            allow_experimental,
-            allow_beta,
             query_context->wasBackgroundPoolAutoLowered());
     }
 

--- a/tests/integration/test_allow_feature_tier/configs/feature_tier_mergetree.xml
+++ b/tests/integration/test_allow_feature_tier/configs/feature_tier_mergetree.xml
@@ -1,0 +1,9 @@
+<clickhouse>
+    <!-- allow_feature_tier=1 forbids changing EXPERIMENTAL settings, but an EXPERIMENTAL MergeTree
+         setting placed in the global <merge_tree> config is a trusted source and must not break the
+         server or table creation. -->
+    <allow_feature_tier>1</allow_feature_tier>
+    <merge_tree>
+        <allow_experimental_reverse_key>1</allow_experimental_reverse_key>
+    </merge_tree>
+</clickhouse>

--- a/tests/integration/test_allow_feature_tier/test.py
+++ b/tests/integration/test_allow_feature_tier/test.py
@@ -12,6 +12,14 @@ instance = cluster.add_instance(
     stay_alive=True,
 )
 
+# A separate instance that boots with allow_feature_tier=1 and an EXPERIMENTAL MergeTree setting
+# (allow_experimental_reverse_key) defined in the global <merge_tree> config.
+instance_mergetree_config = cluster.add_instance(
+    "instance_mergetree_config",
+    main_configs=["configs/feature_tier_mergetree.xml"],
+    stay_alive=True,
+)
+
 feature_tier_path = "/etc/clickhouse-server/config.d/allow_feature_tier.xml"
 
 
@@ -318,3 +326,54 @@ def test_it_is_possible_to_enable_experimental_settings_in_default_profile(
 
     instance.query("SYSTEM RELOAD CONFIG")
     assert "0" == get_current_tier_value(instance)
+
+
+def test_experimental_mergetree_setting_in_global_config_is_allowed(start_cluster):
+    # An EXPERIMENTAL MergeTree setting defined in the global <merge_tree> config is a trusted source,
+    # just like an experimental setting placed in the default profile. With allow_feature_tier=1 the
+    # server must boot and table creation must keep working, while a query that introduces an
+    # experimental setting itself must still be rejected.
+    node = instance_mergetree_config
+    assert "1" == get_current_tier_value(node)
+
+    # The experimental MergeTree setting from the global config is in effect.
+    assert (
+        "1"
+        == node.query(
+            "SELECT value FROM system.merge_tree_settings WHERE name = 'allow_experimental_reverse_key'"
+        ).strip()
+    )
+
+    node.query("DROP TABLE IF EXISTS t_plain")
+    node.query("DROP TABLE IF EXISTS t_reverse")
+
+    # A plain table must be creatable even though an experimental value is inherited from the config.
+    output, error = node.query_and_get_answer_with_error(
+        "CREATE TABLE t_plain (x UInt64) ENGINE = MergeTree ORDER BY x"
+    )
+    assert error == "", error
+
+    # A table that actually uses the experimental feature (reverse key) must be creatable too,
+    # because the setting comes from the trusted global config and not from the query.
+    output, error = node.query_and_get_answer_with_error(
+        "CREATE TABLE t_reverse (x UInt64) ENGINE = MergeTree ORDER BY (x DESC)"
+    )
+    assert error == "", error
+
+    # But introducing the experimental setting via the query SETTINGS clause must still be rejected.
+    output, error = node.query_and_get_answer_with_error(
+        "CREATE TABLE t_explicit (x UInt64) ENGINE = MergeTree ORDER BY x "
+        "SETTINGS allow_remote_fs_zero_copy_replication = 1"
+    )
+    assert output == ""
+    assert "Changes to EXPERIMENTAL settings are disabled" in error
+
+    # And ALTER ... MODIFY SETTING that introduces an experimental setting must still be rejected.
+    output, error = node.query_and_get_answer_with_error(
+        "ALTER TABLE t_plain MODIFY SETTING allow_remote_fs_zero_copy_replication = 1"
+    )
+    assert output == ""
+    assert "Changes to EXPERIMENTAL settings are disabled" in error
+
+    node.query("DROP TABLE IF EXISTS t_plain")
+    node.query("DROP TABLE IF EXISTS t_reverse")


### PR DESCRIPTION
With `allow_feature_tier` set to `1` (allow beta+production) or `2` (production only), the server rejected changes to `EXPERIMENTAL`/`BETA` MergeTree settings. The enforcement lived in `MergeTreeSettingsImpl::sanityCheck` and was **state-based**: it rejected any setting whose value differed from the compiled-in default — which also rejected values inherited from the global `<merge_tree>` config section, even though the operator (not an end user) put them there.

### The problem

An experimental MergeTree setting placed in `<merge_tree>` (e.g. `allow_experimental_reverse_key`, `allow_remote_fs_zero_copy_replication`) made the server **boot normally but fail every `CREATE TABLE`** — including plain tables that don't use the feature — because the inherited changed value tripped the tier check:

```xml
<allow_feature_tier>1</allow_feature_tier>
<merge_tree>
    <allow_experimental_reverse_key>1</allow_experimental_reverse_key>
</merge_tree>
```

```sql
CREATE TABLE t (x UInt64) ENGINE = MergeTree ORDER BY x;
-- Code: 164. DB::Exception: Cannot modify setting 'allow_experimental_reverse_key'.
-- Changes to EXPERIMENTAL settings are disabled in the server config ('allow_feature_tier'). (READONLY)
```

This is the worst failure mode for a managed deployment: silent at boot, broken on the first DDL. It blocks rolling out feature tiers to any service that needs an experimental MergeTree setting.

### The fix

Regular query settings already behave correctly: an experimental setting placed in the default profile is applied as a trusted default, and only a query that *actively changes* it is rejected. This makes MergeTree settings match that model:

- Tier enforcement is removed from `MergeTreeSettingsImpl::sanityCheck` (state-based) and moved to the **delta-based** `SettingsConstraints::checkImpl` for MergeTree settings, which already skips values equal to the baseline. On `CREATE` the baseline is the server `<merge_tree>` config; on `ALTER` it is the table's current settings. A value inherited from the trusted config is exempt; a value introduced by the query is still rejected.
- `MergeTreeData::checkAlterIsPossible` now validates settings constraints for any settings an `ALTER` introduces, not only when the table already had a `SETTINGS` clause, so a newly added experimental setting is still rejected.
- `MergeTreeSettings::sanityCheck` loses its now-unused `allow_experimental` / `allow_beta` parameters; callers in `Server.cpp`, `MergeTreeData` and `ProjectionsDescription` are updated.

Behavior after the fix (verified against a 26.6 server for the broken cases):

| Config | Plain `CREATE TABLE` | `CREATE` using the experimental feature | Query introducing the setting (`SETTINGS …=1` / `ALTER MODIFY SETTING`) |
|---|---|---|---|
| `allow_feature_tier=1`, experimental setting in `<merge_tree>` | ✅ allowed (was ❌) | ✅ allowed (was ❌) | ❌ still rejected |
| `allow_feature_tier=1`, setting only in query | ✅ allowed | n/a | ❌ rejected |

Existing tables that already carry an experimental setting in their metadata continue to attach and work after a restart into `allow_feature_tier=1` (attach does not run the constraints check) — unchanged behavior.

`ServerSettings` (such as `allow_experimental_webterminal`) are not affected: they have never been tier-enforced and are already allowed from the config.

### Test

Adds `test_experimental_mergetree_setting_in_global_config_is_allowed` to `test_allow_feature_tier`: a node boots with `allow_feature_tier=1` and `allow_experimental_reverse_key=1` in `<merge_tree>`, then asserts plain table creation and reverse-key table creation succeed, while a query-introduced experimental setting (via `SETTINGS` and via `ALTER MODIFY SETTING`) is still rejected.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `allow_feature_tier` so that experimental/beta MergeTree settings defined in the global `<merge_tree>` config no longer break table creation. Previously, with `allow_feature_tier` set to `1` or `2`, having such a setting in the config caused every `CREATE TABLE` to fail. Settings introduced by a query are still rejected, matching how experimental settings in the default profile behave.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)