### PR TITLE
Make the setting `allow_experimental_reverse_key` obsolete

### DIFF
--- a/ci/jobs/buzzhouse_job.py
+++ b/ci/jobs/buzzhouse_job.py
@@ -270,7 +270,6 @@ def main():
         "hot_table_settings": [
             "allow_coalescing_columns_in_partition_or_order_key",
             # "allow_experimental_replacing_merge_with_cleanup",
-            "allow_experimental_reverse_key",
             "allow_floating_point_partition_key",
             "allow_nullable_key",
             "allow_summing_columns_in_partition_or_order_key",

--- a/src/Client/BuzzHouse/Generator/TableSettings.cpp
+++ b/src/Client/BuzzHouse/Generator/TableSettings.cpp
@@ -54,7 +54,6 @@ static std::unordered_map<String, CHSetting> mergeTreeTableSettings = {
     {"allow_coalescing_columns_in_partition_or_order_key", trueOrFalseSetting},
     {"allow_commit_order_projection", trueOrFalseSetting},
     {"allow_experimental_replacing_merge_with_cleanup", trueOrFalseSetting},
-    {"allow_experimental_reverse_key", trueOrFalseSetting},
     {"allow_floating_point_partition_key", trueOrFalseSetting},
     {"allow_nullable_key", trueOrFalseSetting},
     {"allow_part_offset_column_in_projections", trueOrFalseSetting},

--- a/src/Common/QueryFuzzer.cpp
+++ b/src/Common/QueryFuzzer.cpp
@@ -961,7 +961,6 @@ void QueryFuzzer::fuzzCreateQuery(ASTCreateQuery & create)
                "add_minmax_index_for_string_columns",
                "add_minmax_index_for_temporal_columns",
                "allow_coalescing_columns_in_partition_or_order_key",
-               "allow_experimental_reverse_key",
                "allow_floating_point_partition_key",
                "allow_nullable_key",
                "allow_summing_columns_in_partition_or_order_key",

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -1227,7 +1227,6 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
         addSettingsChanges(merge_tree_settings_changes_history, "26.6",
         {
             {"shared_merge_tree_try_fetch_part_in_memory_data_from_replicas_on_startup", false, false, "New setting which allows SMT download parts data from replicas instead of S3 on startup"},
-            {"allow_experimental_reverse_key", false, false, "Obsolete setting, descending sort order in MergeTree sorting keys is now always supported."},
         });
         addSettingsChanges(merge_tree_settings_changes_history, "26.5",
         {

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -1227,6 +1227,7 @@ const VersionToSettingsChangesMap & getMergeTreeSettingsChangesHistory()
         addSettingsChanges(merge_tree_settings_changes_history, "26.6",
         {
             {"shared_merge_tree_try_fetch_part_in_memory_data_from_replicas_on_startup", false, false, "New setting which allows SMT download parts data from replicas instead of S3 on startup"},
+            {"allow_experimental_reverse_key", false, false, "Obsolete setting, descending sort order in MergeTree sorting keys is now always supported."},
         });
         addSettingsChanges(merge_tree_settings_changes_history, "26.5",
         {

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -238,7 +238,6 @@ namespace Setting
 
 namespace MergeTreeSetting
 {
-    extern const MergeTreeSettingsBool allow_experimental_reverse_key;
     extern const MergeTreeSettingsBool allow_nullable_key;
     extern const MergeTreeSettingsBool allow_remote_fs_zero_copy_replication;
     extern const MergeTreeSettingsBool allow_suspicious_indices;
@@ -711,7 +710,6 @@ MergeTreeData::MergeTreeData(
     bool sanity_checks = mode <= LoadingStrictnessLevel::CREATE;
 
     allow_nullable_key = !sanity_checks || (*settings)[MergeTreeSetting::allow_nullable_key];
-    allow_reverse_key = !sanity_checks || (*settings)[MergeTreeSetting::allow_experimental_reverse_key];
 
     /// Check sanity of MergeTreeSettings. Only when table is created.
     if (sanity_checks)
@@ -934,27 +932,11 @@ void MergeTreeData::checkProperties(
     const StorageInMemoryMetadata & old_metadata,
     bool attach,
     bool allow_empty_sorting_key,
-    bool allow_reverse_sorting_key,
     bool allow_nullable_key_,
     ContextPtr local_context) const
 {
     if (!new_metadata.sorting_key.definition_ast && !allow_empty_sorting_key)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "ORDER BY cannot be empty");
-
-    if (!allow_reverse_sorting_key)
-    {
-        size_t num_sorting_keys = new_metadata.sorting_key.column_names.size();
-        for (size_t i = 0; i < num_sorting_keys; ++i)
-        {
-            if (!new_metadata.sorting_key.reverse_flags.empty() && new_metadata.sorting_key.reverse_flags[i])
-            {
-                throw Exception(
-                    ErrorCodes::ILLEGAL_COLUMN,
-                    "Sorting key {} is reversed, but merge tree setting `allow_experimental_reverse_key` is disabled",
-                    new_metadata.sorting_key.column_names[i]);
-            }
-        }
-    }
 
     KeyDescription new_sorting_key = new_metadata.sorting_key;
     KeyDescription new_primary_key = new_metadata.primary_key;
@@ -1123,7 +1105,6 @@ void MergeTreeData::checkProperties(
                 *projection.metadata,
                 attach,
                 is_aggregate,
-                allow_reverse_key,
                 true /* allow_nullable_key */,
                 local_context);
 
@@ -1230,7 +1211,6 @@ void MergeTreeData::setProperties(
         old_metadata,
         attach,
         false,
-        allow_reverse_key,
         allow_nullable_key,
         local_context);
 
@@ -4795,7 +4775,7 @@ void MergeTreeData::checkAlterIsPossible(const AlterCommands & commands, Context
     }
 
     checkColumnFilenamesForCollision(new_metadata, /*throw_on_error=*/ true);
-    checkProperties(new_metadata, old_metadata, false, false, allow_reverse_key, allow_nullable_key, local_context);
+    checkProperties(new_metadata, old_metadata, false, false, allow_nullable_key, local_context);
     checkTTLExpressions(new_metadata, old_metadata);
 
     if (!columns_to_check_conversion.empty())

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -1642,7 +1642,6 @@ protected:
         const StorageInMemoryMetadata & old_metadata,
         bool attach,
         bool allow_empty_sorting_key,
-        bool allow_reverse_sorting_key,
         bool allow_nullable_key_,
         ContextPtr local_context) const;
 
@@ -1960,7 +1959,6 @@ private:
     virtual void startBackgroundMovesIfNeeded() = 0;
 
     bool allow_nullable_key = false;
-    bool allow_reverse_key = false;
 
     void addPartContributionToDataVolume(const DataPartPtr & part);
     void removePartContributionToDataVolume(const DataPartPtr & part);

--- a/src/Storages/MergeTree/MergeTreeSettings.cpp
+++ b/src/Storages/MergeTree/MergeTreeSettings.cpp
@@ -2015,36 +2015,6 @@ namespace ErrorCodes
     - `true`
     - `false`
     )", EXPERIMENTAL) \
-    DECLARE(Bool, allow_experimental_reverse_key, false, R"(
-    Enables support for descending sort order in MergeTree sorting keys. This
-    setting is particularly useful for time series analysis and Top-N queries,
-    allowing data to be stored in reverse chronological order to optimize query
-    performance.
-
-    With `allow_experimental_reverse_key` enabled, you can define descending sort
-    orders within the `ORDER BY` clause of a MergeTree table. This enables the
-    use of more efficient `ReadInOrder` optimizations instead of `ReadInReverseOrder`
-    for descending queries.
-
-    **Example**
-
-    ```sql
-    CREATE TABLE example
-    (
-    time DateTime,
-    key Int32,
-    value String
-    ) ENGINE = MergeTree
-    ORDER BY (time DESC, key)  -- Descending order on 'time' field
-    SETTINGS allow_experimental_reverse_key = 1;
-
-    SELECT * FROM example WHERE key = 'xxx' ORDER BY time DESC LIMIT 10;
-    ```
-
-    By using `ORDER BY time DESC` in the query, `ReadInOrder` is applied.
-
-    **Default Value:** false
-    )", EXPERIMENTAL) \
     DECLARE(Bool, allow_commit_order_projection, false, R"(
     Enables commit-order projections that store `_block_number` and `_block_offset` virtual columns, preserving original insertion order through merges.
     Requires `enable_block_number_column` and `enable_block_offset_column` to be enabled.
@@ -2235,6 +2205,7 @@ namespace ErrorCodes
     MAKE_OBSOLETE_MERGE_TREE_SETTING(M, UInt64, kill_delay_period_random_add, 10) \
     MAKE_OBSOLETE_MERGE_TREE_SETTING(M, UInt64, kill_threads, 128) \
     MAKE_OBSOLETE_MERGE_TREE_SETTING(M, UInt64, cleanup_threads, 128) \
+    MAKE_OBSOLETE_MERGE_TREE_SETTING(M, Bool, allow_experimental_reverse_key, false) \
 
     /// Settings that should not change after the creation of a table.
     /// NOLINTNEXTLINE

--- a/tests/integration/test_allow_feature_tier/configs/users.d/users.xml
+++ b/tests/integration/test_allow_feature_tier/configs/users.d/users.xml
@@ -2,8 +2,8 @@
     <profiles>
         <default>
             <!-- To verify it works with compatibility values too (as long as they don't change tiers)
-                In 24.10 allow_experimental_reverse_key was introduced as experimental and it's added to compatibility
-                but it's disabled in all cases
+                allow_experimental_reverse_key was introduced as experimental and added to compatibility,
+                but it's disabled in all cases. It has since been made obsolete, which does not affect this test.
             -->
             <compatibility>24.10</compatibility>
 

--- a/tests/queries/0_stateless/04312_reverse_key_obsolete_setting.reference
+++ b/tests/queries/0_stateless/04312_reverse_key_obsolete_setting.reference
@@ -1,0 +1,7 @@
+3	30
+2	20
+1	10
+3	30
+2	20
+1	10
+allow_experimental_reverse_key	Obsolete	1

--- a/tests/queries/0_stateless/04312_reverse_key_obsolete_setting.sql
+++ b/tests/queries/0_stateless/04312_reverse_key_obsolete_setting.sql
@@ -1,0 +1,26 @@
+-- Descending sort order in MergeTree sorting keys used to be gated by the experimental
+-- setting `allow_experimental_reverse_key`. The feature is now always supported and the
+-- setting is obsolete. This test checks that:
+--   1. a descending sort key works without any setting,
+--   2. the obsolete setting is still accepted (does nothing) for backward compatibility,
+--   3. the setting is reported as obsolete in `system.merge_tree_settings`.
+
+DROP TABLE IF EXISTS t_reverse_key;
+
+-- A descending sort key is now always allowed, no setting required.
+CREATE TABLE t_reverse_key (a Int32, b Int32) ENGINE = MergeTree ORDER BY (a DESC, b);
+INSERT INTO t_reverse_key VALUES (1, 10), (3, 30), (2, 20);
+SELECT a, b FROM t_reverse_key ORDER BY a DESC, b;
+
+DROP TABLE t_reverse_key;
+
+-- The obsolete setting is still accepted (does nothing) for backward compatibility.
+CREATE TABLE t_reverse_key (a Int32, b Int32) ENGINE = MergeTree ORDER BY (a DESC, b)
+SETTINGS allow_experimental_reverse_key = 1;
+INSERT INTO t_reverse_key VALUES (1, 10), (3, 30), (2, 20);
+SELECT a, b FROM t_reverse_key ORDER BY a DESC, b;
+
+DROP TABLE t_reverse_key;
+
+-- The setting is reported as obsolete.
+SELECT name, tier, is_obsolete FROM system.merge_tree_settings WHERE name = 'allow_experimental_reverse_key';


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/103677

Descending sort order in `MergeTree` sorting keys (`ORDER BY` with `DESC`, e.g. `ORDER BY (time DESC, key)`) used to be gated behind the experimental table-level setting `allow_experimental_reverse_key`. The feature has been available and covered by tests for a while, so this PR graduates it to always-on and makes the setting obsolete.

The obsolete setting is kept as a no-op for backward compatibility, so existing DDL and table metadata that set `allow_experimental_reverse_key = 1` keep working. The now-dead gating code is removed: the `allow_reverse_key` member, the `allow_reverse_sorting_key` parameter of `checkProperties`, and the validation branch that rejected reversed sorting keys. The setting is also no longer randomized by the query fuzzer and BuzzHouse.

No `SettingsChangesHistory` entry is added: the setting's default value does not change (`false`), and the `MergeTree` settings history records new settings and value changes rather than tier-only obsolescence (consistent with existing obsolete `MergeTree` settings such as `write_final_mark` or `cleanup_threads`).

A new stateless test (`04312_reverse_key_obsolete_setting`) verifies that a descending sort key works without any setting, that the obsolete setting is still accepted, and that it is reported as obsolete in `system.merge_tree_settings`.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Descending sort order in `MergeTree` sorting keys (e.g. `ORDER BY (time DESC, key)`) is now always supported and no longer requires the experimental setting `allow_experimental_reverse_key`, which became obsolete.

### Documentation entry for user-facing changes
- [x] Documentation is not required: the `MergeTree` settings reference is generated from the source, and the feature itself is already documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.553`
<!-- ch-version-info:end -->