### PR TITLE
Specify default precision value for DateTime64

### DIFF
--- a/docs/en/sql-reference/data-types/datetime64.md
+++ b/docs/en/sql-reference/data-types/datetime64.md
@@ -13,6 +13,8 @@ Allows to store an instant in time, that can be expressed as a calendar date and
 Tick size (precision): 10<sup>-precision</sup> seconds. Valid range: [ 0 : 9 ].
 Typically, are used - 3 (milliseconds), 6 (microseconds), 9 (nanoseconds).
 
+Default value: 3 (milliseconds).
+
 **Syntax:**
 
 ```sql


### PR DESCRIPTION
Added default value for precision in DateTime64.


### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.432`
<!-- ch-version-info:end -->