### PR TITLE
Fix validation of named collection keys in HTTP Dictionary

### DIFF
--- a/src/Dictionaries/HTTPDictionarySource.cpp
+++ b/src/Dictionaries/HTTPDictionarySource.cpp
@@ -26,7 +26,7 @@ namespace ErrorCodes
 
 static const UInt64 max_block_size = 8192;
 
-static const std::unordered_set<std::string_view> optional_configuration_keys = {
+static const std::unordered_set<std::string_view> optional_configuration_keys = { // STYLE_CHECK_ALLOW_STD_CONTAINERS
     "url",
     "endpoint",
     "user",
@@ -252,7 +252,7 @@ void registerDictionarySourceHTTP(DictionarySourceFactory & factory)
         {
             /// Headers in config file will have structure "headers.header.name" and "headers.header.value".
             /// But Poco::AbstractConfiguration converts them into "header", "header[1]", "header[2]".
-            static const std::vector<std::shared_ptr<re2::RE2>> optional_regex_keys
+            static const std::vector<std::shared_ptr<re2::RE2>> optional_regex_keys // STYLE_CHECK_ALLOW_STD_CONTAINERS
             {
                 std::make_shared<re2::RE2>(R"(headers.header\[[0-9]*\].name)"),
                 std::make_shared<re2::RE2>(R"(headers.header\[[0-9]*\].value)"),

--- a/src/Dictionaries/HTTPDictionarySource.cpp
+++ b/src/Dictionaries/HTTPDictionarySource.cpp
@@ -26,6 +26,21 @@ namespace ErrorCodes
 
 static const UInt64 max_block_size = 8192;
 
+static const std::unordered_set<std::string_view> optional_configuration_keys = {
+    "url",
+    "endpoint",
+    "user",
+    "credentials.user",
+    "password",
+    "credentials.password",
+    "format",
+    "compression_method",
+    "structure",
+    "name",
+    "headers.header.name",
+    "headers.header.value",
+};
+
 
 HTTPDictionarySource::HTTPDictionarySource(
     const DictionaryStructure & dict_struct_,
@@ -235,11 +250,19 @@ void registerDictionarySourceHTTP(DictionarySourceFactory & factory)
         auto named_collection = created_from_ddl ? tryGetNamedCollectionWithOverrides(config, settings_config_prefix, global_context) : nullptr;
         if (named_collection)
         {
+            /// Headers in config file will have structure "headers.header.name" and "headers.header.value".
+            /// But Poco::AbstractConfiguration converts them into "header", "header[1]", "header[2]".
+            static const std::vector<std::shared_ptr<re2::RE2>> optional_regex_keys
+            {
+                std::make_shared<re2::RE2>(R"(headers.header\[[0-9]*\].name)"),
+                std::make_shared<re2::RE2>(R"(headers.header\[[0-9]*\].value)"),
+            };
+
             validateNamedCollection(
                 *named_collection,
-                /* required_keys */{},
-                /* optional_keys */ValidateKeysMultiset<ExternalDatabaseEqualKeysSet>{
-                "url", "endpoint", "user", "credentials.user", "password", "credentials.password", "format", "compression_method", "structure", "name"});
+                /* required_keys */ {},
+                /* optional_keys */ optional_configuration_keys,
+                optional_regex_keys);
 
             url = named_collection->getOrDefault<String>("url", "");
             endpoint = named_collection->getOrDefault<String>("endpoint", "");

--- a/tests/integration/test_http_dictionary_named_collection/configs/named_collections.xml
+++ b/tests/integration/test_http_dictionary_named_collection/configs/named_collections.xml
@@ -1,0 +1,19 @@
+<clickhouse>
+    <named_collections>
+        <http_dictionary_collection>
+            <url>http://localhost:8000</url>
+            <endpoint>/dict-data</endpoint>
+            <format>TabSeparated</format>
+            <headers>
+                <header>
+                    <name>X-First-Header</name>
+                    <value>first-value</value>
+                </header>
+                <header>
+                    <name>X-Second-Header</name>
+                    <value>second-value</value>
+                </header>
+            </headers>
+        </http_dictionary_collection>
+    </named_collections>
+</clickhouse>

--- a/tests/integration/test_http_dictionary_named_collection/http_dictionary_server.py
+++ b/tests/integration/test_http_dictionary_named_collection/http_dictionary_server.py
@@ -1,0 +1,40 @@
+import http.server
+import sys
+
+RESULT_PATH = "/headers.txt"
+
+
+class RequestHandler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass
+
+    def do_GET(self):
+        if self.path == "/":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b'{"status":"ok"}')
+        if self.path == "/dict-data":
+            with open(RESULT_PATH, "w") as f:
+                f.write(self.headers.as_string())
+            self.send_response(200)
+            self.send_header("Content-Type", "text/tab-separated-values")
+            self.end_headers()
+            self.wfile.write(b"1\tfirst\n2\tsecond\n")
+
+
+if __name__ == "__main__":
+    host = sys.argv[1]
+    port = int(sys.argv[2])
+    httpd = http.server.ThreadingHTTPServer(
+        (
+            host,
+            port,
+        ),
+        RequestHandler,
+    )
+
+    try:
+        httpd.serve_forever()
+    finally:
+        httpd.server_close()

--- a/tests/integration/test_http_dictionary_named_collection/test.py
+++ b/tests/integration/test_http_dictionary_named_collection/test.py
@@ -1,0 +1,96 @@
+import os
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.test_tools import wait_condition
+
+from . import http_dictionary_server
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node", main_configs=["configs/named_collections.xml"])
+
+
+def run_server():
+    container_id = cluster.get_container_id("node")
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    file_name = "http_dictionary_server.py"
+
+    cluster.copy_file_to_container(
+        container_id,
+        os.path.join(script_dir, file_name),
+        f"/{file_name}",
+    )
+
+    cluster.exec_in_container(
+        container_id,
+        [
+            "bash",
+            "-c",
+            f"python3 /{file_name} localhost 8000 > {file_name}.log 2>&1",
+        ],
+        detach=True,
+        user="root",
+    )
+
+    def check_server():
+        return cluster.exec_in_container(
+            container_id,
+            ["curl", "-s", "http://localhost:8000/"],
+            nothrow=True,
+        )
+
+    wait_condition(
+        check_server,
+        lambda response: '{"status":"ok"}' in response,
+        max_attempts=20,
+        delay=0.5,
+    )
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        run_server()
+        node.query("CREATE DATABASE IF NOT EXISTS test")
+
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def test_http_dictionary_with_headers_in_named_collection(started_cluster):
+    node.query(
+        """
+        CREATE DICTIONARY test.http_dictionary_with_headers (
+            id UInt64,
+            value String
+        )
+        PRIMARY KEY id
+        LAYOUT(FLAT())
+        SOURCE(HTTP(NAME http_dictionary_collection))
+        LIFETIME(MIN 0 MAX 0)
+        """
+    )
+
+    assert (
+        node.query(
+            "SELECT dictGetString('test.http_dictionary_with_headers', 'value', toUInt64(1))"
+        )
+        == "first\n"
+    )
+    assert (
+        node.query(
+            "SELECT dictGetString('test.http_dictionary_with_headers', 'value', toUInt64(2))"
+        )
+        == "second\n"
+    )
+
+    headers = node.exec_in_container(
+        ["cat", http_dictionary_server.RESULT_PATH], user="root"
+    )
+    assert "X-First-Header: first-value" in headers
+    assert "X-Second-Header: second-value" in headers
+
+    node.query("DROP DICTIONARY test.http_dictionary_with_headers")


### PR DESCRIPTION
Fix validation of named collection keys in HTTP Dictionary to allow setting header values. 
The code for getting header values from named collection was already there, it was just rejected by validation 

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Allows user to specify headers for `HTTPDictionary` using named collections

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.406`
<!-- ch-version-info:end -->