### PR TITLE
Harden `ThreadStatus::attachToGroupImpl` against partial attachment failures

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -202,6 +202,8 @@ static struct InitFiu
     REGULAR(wide_part_writer_fail_in_add_streams) \
     REGULAR(compact_part_writer_fail_in_add_streams) \
     REGULAR(transaction_force_unknown_state_after_commit) \
+    ONCE(thread_group_switcher_attach_failure) \
+    ONCE(thread_group_link_thread_failure) \
     PAUSEABLE(transaction_after_commit_pause) \
     REGULAR(mt_mutate_task_can_skip_conversion_to_nullable_force_null_column_desc) \
     REGULAR(tcp_handler_fail_connection_setup) \

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -202,7 +202,7 @@ static struct InitFiu
     REGULAR(wide_part_writer_fail_in_add_streams) \
     REGULAR(compact_part_writer_fail_in_add_streams) \
     REGULAR(transaction_force_unknown_state_after_commit) \
-    ONCE(thread_group_switcher_attach_failure) \
+    ONCE(attach_to_group_failure) \
     PAUSEABLE(transaction_after_commit_pause) \
     REGULAR(mt_mutate_task_can_skip_conversion_to_nullable_force_null_column_desc) \
     REGULAR(tcp_handler_fail_connection_setup) \

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -203,7 +203,6 @@ static struct InitFiu
     REGULAR(compact_part_writer_fail_in_add_streams) \
     REGULAR(transaction_force_unknown_state_after_commit) \
     ONCE(thread_group_switcher_attach_failure) \
-    ONCE(thread_group_link_thread_failure) \
     PAUSEABLE(transaction_after_commit_pause) \
     REGULAR(mt_mutate_task_can_skip_conversion_to_nullable_force_null_column_desc) \
     REGULAR(tcp_handler_fail_connection_setup) \

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -203,6 +203,7 @@ static struct InitFiu
     REGULAR(compact_part_writer_fail_in_add_streams) \
     REGULAR(transaction_force_unknown_state_after_commit) \
     ONCE(attach_to_group_failure) \
+    ONCE(thread_group_switcher_post_attach_failure) \
     PAUSEABLE(transaction_after_commit_pause) \
     REGULAR(mt_mutate_task_can_skip_conversion_to_nullable_force_null_column_desc) \
     REGULAR(tcp_handler_fail_connection_setup) \

--- a/src/Common/ThreadGroupSwitcher.cpp
+++ b/src/Common/ThreadGroupSwitcher.cpp
@@ -1,4 +1,5 @@
 #include <Common/Exception.h>
+#include <Common/FailPoint.h>
 #include <Common/LockMemoryExceptionInThread.h>
 #include <Common/ThreadGroupSwitcher.h>
 #include <Common/CurrentThread.h>
@@ -7,9 +8,15 @@
 namespace DB
 {
 
+namespace FailPoints
+{
+    extern const char thread_group_switcher_post_attach_failure[];
+}
+
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+    extern const int FAULT_INJECTED;
 }
 
 ThreadGroupPtr getCurrentThreadGroup()
@@ -50,22 +57,33 @@ ThreadGroupSwitcher::ThreadGroupSwitcher(ThreadGroupPtr thread_group_, ThreadNam
 
         CurrentThread::attachToGroup(thread_group);
         setThreadName(thread_name);
+
+        /// Simulate a failure after the attach succeeded (e.g. setThreadName throwing),
+        /// to verify the catch block detaches from the target group and restores the
+        /// previous one instead of leaving the thread attached to the failed target.
+        fiu_do_on(FailPoints::thread_group_switcher_post_attach_failure,
+        {
+            throw Exception(ErrorCodes::FAULT_INJECTED, "Injected failure after attachToGroup");
+        });
     }
     catch (...)
     {
         /// Unexpected. For caller's convenience avoid throwing exceptions.
         DB::tryLogCurrentException(__PRETTY_FUNCTION__);
-        if (prev_thread_group && !CurrentThread::getGroup())
+        try
         {
-            try
-            {
-                LockMemoryExceptionInThread lock_memory_tracker(VariableContext::Global);
+            LockMemoryExceptionInThread lock_memory_tracker(VariableContext::Global);
+            /// The attach may have succeeded before a later step (e.g. setThreadName) threw,
+            /// leaving the thread on the target group. Detach it first.
+            if (CurrentThread::getGroup() == thread_group)
+                CurrentThread::detachFromGroupIfNotDetached();
+            /// Restore the previous group for allow_existing_group=true callers.
+            if (prev_thread_group && !CurrentThread::getGroup())
                 CurrentThread::attachToGroup(prev_thread_group);
-            }
-            catch (...)
-            {
-                DB::tryLogCurrentException(__PRETTY_FUNCTION__);
-            }
+        }
+        catch (...)
+        {
+            DB::tryLogCurrentException(__PRETTY_FUNCTION__);
         }
         thread_group = nullptr;
         prev_thread_group = nullptr;

--- a/src/Common/ThreadGroupSwitcher.cpp
+++ b/src/Common/ThreadGroupSwitcher.cpp
@@ -55,7 +55,6 @@ ThreadGroupSwitcher::ThreadGroupSwitcher(ThreadGroupPtr thread_group_, ThreadNam
     {
         /// Unexpected. For caller's convenience avoid throwing exceptions.
         DB::tryLogCurrentException(__PRETTY_FUNCTION__);
-        /// Best-effort restore of prev_thread_group for allow_existing_group=true callers.
         if (prev_thread_group && !CurrentThread::getGroup())
         {
             try

--- a/src/Common/ThreadGroupSwitcher.cpp
+++ b/src/Common/ThreadGroupSwitcher.cpp
@@ -55,14 +55,7 @@ ThreadGroupSwitcher::ThreadGroupSwitcher(ThreadGroupPtr thread_group_, ThreadNam
     {
         /// Unexpected. For caller's convenience avoid throwing exceptions.
         DB::tryLogCurrentException(__PRETTY_FUNCTION__);
-        /// allow_existing_group=true callers (ExceptionKeepingTransform, merge/mutate
-        /// tasks) entered already attached to prev_thread_group. We detached them above
-        /// before calling attachToGroupImpl, which then failed and rolled back to a
-        /// detached state. Best-effort restore so the caller does not continue without
-        /// query/merge accounting, memory limits, and cancellation context.
-        /// If the restore itself throws (e.g. uniform OOM), log and leave the thread
-        /// detached — that is no worse than not attempting the restore at all, and
-        /// the noexcept contract is preserved by the inner try/catch.
+        /// Best-effort restore of prev_thread_group for allow_existing_group=true callers.
         if (prev_thread_group && !CurrentThread::getGroup())
         {
             try

--- a/src/Common/ThreadGroupSwitcher.cpp
+++ b/src/Common/ThreadGroupSwitcher.cpp
@@ -55,6 +55,26 @@ ThreadGroupSwitcher::ThreadGroupSwitcher(ThreadGroupPtr thread_group_, ThreadNam
     {
         /// Unexpected. For caller's convenience avoid throwing exceptions.
         DB::tryLogCurrentException(__PRETTY_FUNCTION__);
+        /// allow_existing_group=true callers (ExceptionKeepingTransform, merge/mutate
+        /// tasks) entered already attached to prev_thread_group. We detached them above
+        /// before calling attachToGroupImpl, which then failed and rolled back to a
+        /// detached state. Best-effort restore so the caller does not continue without
+        /// query/merge accounting, memory limits, and cancellation context.
+        /// If the restore itself throws (e.g. uniform OOM), log and leave the thread
+        /// detached — that is no worse than not attempting the restore at all, and
+        /// the noexcept contract is preserved by the inner try/catch.
+        if (prev_thread_group && !CurrentThread::getGroup())
+        {
+            try
+            {
+                LockMemoryExceptionInThread lock_memory_tracker(VariableContext::Global);
+                CurrentThread::attachToGroup(prev_thread_group);
+            }
+            catch (...)
+            {
+                DB::tryLogCurrentException(__PRETTY_FUNCTION__);
+            }
+        }
         thread_group = nullptr;
         prev_thread_group = nullptr;
     }

--- a/src/Common/tests/gtest_thread_group_switcher.cpp
+++ b/src/Common/tests/gtest_thread_group_switcher.cpp
@@ -26,7 +26,7 @@ TEST(ThreadGroupSwitcher, FailedConstructionRestoresPreviousState)
     auto G0 = std::make_shared<ThreadGroup>(context, 0);
     auto G1 = std::make_shared<ThreadGroup>(context, 0);
 
-    /// Thread was detached → must end detached after the failed switch.
+    /// Started detached → must end detached after the failed switch.
     FailPointInjection::enableFailPoint(FailPoints::thread_group_switcher_attach_failure);
     {
         ThreadGroupSwitcher switcher(G1, ThreadName::REMOTE_FS_READ_THREAD_POOL);
@@ -34,7 +34,7 @@ TEST(ThreadGroupSwitcher, FailedConstructionRestoresPreviousState)
             << "Failed switch from detached state must leave the thread detached";
     }
 
-    /// Thread was attached to G0 → must end attached to G0 after the failed switch.
+    /// Started attached to G0 → must end attached to G0 after the failed switch.
     CurrentThread::attachToGroupIfDetached(G0);
     FailPointInjection::enableFailPoint(FailPoints::thread_group_switcher_attach_failure);
     {

--- a/src/Common/tests/gtest_thread_group_switcher.cpp
+++ b/src/Common/tests/gtest_thread_group_switcher.cpp
@@ -1,5 +1,3 @@
-#include <thread>
-
 #include <gtest/gtest.h>
 
 #include <Common/CurrentThread.h>
@@ -16,180 +14,35 @@ namespace DB
 namespace FailPoints
 {
     extern const char thread_group_switcher_attach_failure[];
-    extern const char thread_group_link_thread_failure[];
 }
 
-/// Mid-attachment failure must leave ThreadStatus fully detached so the next switcher
-/// on the same thread can attach cleanly. Regression for incident #1682.
-TEST(ThreadGroupSwitcher, PartialAttachUndoneOnException)
+/// After a failed ThreadGroupSwitcher construction the thread must be left in the
+/// state it was in before construction started (detached or attached to the original
+/// group), so the next switcher on the same thread can attach cleanly.
+TEST(ThreadGroupSwitcher, FailedConstructionRestoresPreviousState)
 {
+    ThreadStatus ts;
     auto context = getContext().context;
+    auto G0 = std::make_shared<ThreadGroup>(context, 0);
+    auto G1 = std::make_shared<ThreadGroup>(context, 0);
 
-    std::exception_ptr ex;
-    bool second_switcher_succeeded = false;
-
-    std::thread t([&]
+    /// Thread was detached → must end detached after the failed switch.
+    FailPointInjection::enableFailPoint(FailPoints::thread_group_switcher_attach_failure);
     {
-        try
-        {
-            ThreadStatus ts;
+        ThreadGroupSwitcher switcher(G1, ThreadName::REMOTE_FS_READ_THREAD_POOL);
+        EXPECT_EQ(getCurrentThreadGroup(), nullptr)
+            << "Failed switch from detached state must leave the thread detached";
+    }
 
-            auto G1 = std::make_shared<ThreadGroup>(context, 0);
-            auto G2 = std::make_shared<ThreadGroup>(context, 0);
-
-            /// Enable the failpoint: attachToGroupImpl() will throw after all context
-            /// fields are set (performance_counters parent, memory_tracker parent,
-            /// query_context, local_data, …) but before initPerformanceCounters,
-            /// matching the 26.4 failure window.
-            FailPointInjection::enableFailPoint(FailPoints::thread_group_switcher_attach_failure);
-
-            {
-                /// ThreadGroupSwitcher is noexcept — the injected exception is caught
-                /// and logged internally. The SCOPE_EXIT_SAFE guard in attachToGroupImpl
-                /// calls detachFromGroup() to undo the full attachment before returning.
-                ThreadGroupSwitcher switcher(G1, ThreadName::REMOTE_FS_READ_THREAD_POOL);
-
-                /// Prove the failpoint actually fired: on success the thread would
-                /// be attached to G1 here. nullptr means the attach failed and the
-                /// rollback in attachToGroupImpl ran.
-                ASSERT_EQ(getCurrentThreadGroup(), nullptr);
-            }
-
-            /// Failpoint is ONCE — already consumed, no need to disable.
-
-            /// With the fix the thread is clean: the second attachment must succeed.
-            /// Without the fix the stale G1 is still set and this constructor throws
-            /// LOGICAL_ERROR "already attached" (caught internally, switcher is a no-op).
-            {
-                ThreadGroupSwitcher switcher(G2, ThreadName::REMOTE_FS_READ_THREAD_POOL);
-                second_switcher_succeeded = (getCurrentThreadGroup() == G2);
-            }
-
-            ASSERT_EQ(getCurrentThreadGroup(), nullptr);
-        }
-        catch (...)
-        {
-            ex = std::current_exception();
-        }
-    });
-    t.join();
-
-    if (ex)
-        std::rethrow_exception(ex);
-
-    EXPECT_TRUE(second_switcher_succeeded)
-        << "Second ThreadGroupSwitcher must attach successfully after the first one "
-           "cleaned up its partial attachment; without the fix the stale group from the "
-           "failed first attachment would block every subsequent task on this pool worker";
-}
-
-/// When linkThread() itself throws (e.g. bad_alloc from thread_ids.insert), active_thread_count
-/// was never incremented. The SCOPE_EXIT_SAFE rollback in attachToGroupImpl must NOT call
-/// unlinkThread() in that case, or it would corrupt the counter and hit the chassert.
-/// After the failure the thread must be clean and able to accept the next attachment.
-TEST(ThreadGroupSwitcher, LinkThreadFailureDoesNotCorruptCounter)
-{
-    auto context = getContext().context;
-
-    std::exception_ptr ex;
-    bool second_switcher_succeeded = false;
-
-    std::thread t([&]
+    /// Thread was attached to G0 → must end attached to G0 after the failed switch.
+    CurrentThread::attachToGroupIfDetached(G0);
+    FailPointInjection::enableFailPoint(FailPoints::thread_group_switcher_attach_failure);
     {
-        try
-        {
-            ThreadStatus ts;
-
-            auto G1 = std::make_shared<ThreadGroup>(context, 0);
-            auto G2 = std::make_shared<ThreadGroup>(context, 0);
-
-            FailPointInjection::enableFailPoint(FailPoints::thread_group_link_thread_failure);
-
-            {
-                /// linkThread throws before active_thread_count is incremented.
-                /// The SCOPE_EXIT rollback must skip unlinkThread (linked=false).
-                /// ThreadStatus::thread_group is never set, so the thread is immediately clean.
-                ThreadGroupSwitcher switcher(G1, ThreadName::REMOTE_FS_READ_THREAD_POOL);
-
-                /// Prove the failpoint actually fired: on success the thread would
-                /// be attached to G1 here. nullptr means linkThread threw and the
-                /// thread was never attached in the first place.
-                ASSERT_EQ(getCurrentThreadGroup(), nullptr);
-            }
-
-            /// Thread is clean — second attachment must succeed.
-            {
-                ThreadGroupSwitcher switcher(G2, ThreadName::REMOTE_FS_READ_THREAD_POOL);
-                second_switcher_succeeded = (getCurrentThreadGroup() == G2);
-            }
-
-            ASSERT_EQ(getCurrentThreadGroup(), nullptr);
-        }
-        catch (...)
-        {
-            ex = std::current_exception();
-        }
-    });
-    t.join();
-
-    if (ex)
-        std::rethrow_exception(ex);
-
-    EXPECT_TRUE(second_switcher_succeeded)
-        << "linkThread failure must not corrupt active_thread_count and must leave the "
-           "thread clean for the next attachment";
-}
-
-/// allow_existing_group=true callers (ExceptionKeepingTransform, merge/mutate tasks)
-/// start the switcher already attached to a group. If the new attachment fails, the
-/// constructor must best-effort restore the original group so the caller does not
-/// continue without query/merge accounting and cancellation context.
-TEST(ThreadGroupSwitcher, AllowExistingGroupRestoresOnFailure)
-{
-    auto context = getContext().context;
-
-    std::exception_ptr ex;
-    bool original_group_restored = false;
-
-    std::thread t([&]
-    {
-        try
-        {
-            ThreadStatus ts;
-
-            auto G0 = std::make_shared<ThreadGroup>(context, 0);
-            auto G1 = std::make_shared<ThreadGroup>(context, 0);
-
-            /// Start attached to G0, simulating a merge/pipeline executor thread.
-            CurrentThread::attachToGroupIfDetached(G0);
-            ASSERT_EQ(getCurrentThreadGroup(), G0);
-
-            FailPointInjection::enableFailPoint(FailPoints::thread_group_switcher_attach_failure);
-
-            {
-                /// allow_existing_group=true: constructor detaches G0, attachToGroupImpl
-                /// then throws (failpoint), its rollback detaches the partial G1 state.
-                /// The constructor catch block must restore G0.
-                ThreadGroupSwitcher switcher(G1, ThreadName::MERGE_MUTATE, /*allow_existing_group*/ true);
-            }
-
-            original_group_restored = (getCurrentThreadGroup() == G0);
-
-            CurrentThread::detachFromGroupIfNotDetached();
-        }
-        catch (...)
-        {
-            ex = std::current_exception();
-        }
-    });
-    t.join();
-
-    if (ex)
-        std::rethrow_exception(ex);
-
-    EXPECT_TRUE(original_group_restored)
-        << "Failed allow_existing_group switch must restore the original group; "
-           "otherwise the thread loses its query/merge accounting and cancellation context";
+        ThreadGroupSwitcher switcher(G1, ThreadName::MERGE_MUTATE, /*allow_existing_group*/ true);
+        EXPECT_EQ(getCurrentThreadGroup(), G0)
+            << "Failed allow_existing_group switch must restore the original group";
+    }
+    CurrentThread::detachFromGroupIfNotDetached();
 }
 
 } // namespace DB

--- a/src/Common/tests/gtest_thread_group_switcher.cpp
+++ b/src/Common/tests/gtest_thread_group_switcher.cpp
@@ -1,3 +1,5 @@
+#include <thread>
+
 #include <gtest/gtest.h>
 
 #include <Common/CurrentThread.h>
@@ -14,6 +16,7 @@ namespace DB
 namespace FailPoints
 {
     extern const char attach_to_group_failure[];
+    extern const char thread_group_switcher_post_attach_failure[];
 }
 
 /// After a failed ThreadGroupSwitcher construction the thread must be left in the
@@ -21,28 +24,53 @@ namespace FailPoints
 /// group), so the next switcher on the same thread can attach cleanly.
 TEST(ThreadGroupSwitcher, FailedConstructionRestoresPreviousState)
 {
-    ThreadStatus ts;
-    auto context = getContext().context;
-    auto G0 = std::make_shared<ThreadGroup>(context, 0);
-    auto G1 = std::make_shared<ThreadGroup>(context, 0);
-
-    /// Started detached → must end detached after the failed switch.
-    FailPointInjection::enableFailPoint(FailPoints::attach_to_group_failure);
+    /// Run in a dedicated thread so current_thread starts as nullptr, independent of
+    /// whatever ThreadStatus / thread group other gtests in unit_tests_dbms left behind.
+    std::thread t([&]
     {
-        ThreadGroupSwitcher switcher(G1, ThreadName::REMOTE_FS_READ_THREAD_POOL);
-        EXPECT_EQ(getCurrentThreadGroup(), nullptr)
-            << "Failed switch from detached state must leave the thread detached";
-    }
+        ThreadStatus ts;
+        auto context = getContext().context;
+        auto G0 = std::make_shared<ThreadGroup>(context, 0);
+        auto G1 = std::make_shared<ThreadGroup>(context, 0);
 
-    /// Started attached to G0 → must end attached to G0 after the failed switch.
-    CurrentThread::attachToGroupIfDetached(G0);
-    FailPointInjection::enableFailPoint(FailPoints::attach_to_group_failure);
-    {
-        ThreadGroupSwitcher switcher(G1, ThreadName::MERGE_MUTATE, /*allow_existing_group*/ true);
-        EXPECT_EQ(getCurrentThreadGroup(), G0)
-            << "Failed allow_existing_group switch must restore the original group";
-    }
-    CurrentThread::detachFromGroupIfNotDetached();
+        /// attach_to_group_failure throws inside attachToGroupImpl (the attach is rolled
+        /// back there); post_attach_failure throws after attachToGroup already succeeded.
+        /// Both must leave the thread in its pre-construction state.
+
+        /// --- Starting detached: every failed switch must end detached. ---
+        FailPointInjection::enableFailPoint(FailPoints::attach_to_group_failure);
+        {
+            ThreadGroupSwitcher switcher(G1, ThreadName::REMOTE_FS_READ_THREAD_POOL);
+            EXPECT_EQ(getCurrentThreadGroup(), nullptr)
+                << "Failed attach from detached state must leave the thread detached";
+        }
+
+        FailPointInjection::enableFailPoint(FailPoints::thread_group_switcher_post_attach_failure);
+        {
+            ThreadGroupSwitcher switcher(G1, ThreadName::REMOTE_FS_READ_THREAD_POOL);
+            EXPECT_EQ(getCurrentThreadGroup(), nullptr)
+                << "Post-attach failure from detached state must leave the thread detached";
+        }
+
+        /// --- Starting attached to G0: every failed switch must restore G0. ---
+        CurrentThread::attachToGroupIfDetached(G0);
+
+        FailPointInjection::enableFailPoint(FailPoints::attach_to_group_failure);
+        {
+            ThreadGroupSwitcher switcher(G1, ThreadName::MERGE_MUTATE, /*allow_existing_group*/ true);
+            EXPECT_EQ(getCurrentThreadGroup(), G0)
+                << "Failed allow_existing_group attach must restore the original group";
+        }
+
+        FailPointInjection::enableFailPoint(FailPoints::thread_group_switcher_post_attach_failure);
+        {
+            ThreadGroupSwitcher switcher(G1, ThreadName::MERGE_MUTATE, /*allow_existing_group*/ true);
+            EXPECT_EQ(getCurrentThreadGroup(), G0)
+                << "Post-attach failure must detach the target group and restore the original";
+        }
+        CurrentThread::detachFromGroupIfNotDetached();
+    });
+    t.join();
 }
 
 } // namespace DB

--- a/src/Common/tests/gtest_thread_group_switcher.cpp
+++ b/src/Common/tests/gtest_thread_group_switcher.cpp
@@ -1,0 +1,153 @@
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include <Common/CurrentThread.h>
+#include <Common/FailPoint.h>
+#include <Common/ThreadGroupSwitcher.h>
+#include <Common/ThreadStatus.h>
+#include <Common/setThreadName.h>
+#include <Common/tests/gtest_global_context.h>
+#include <Interpreters/Context.h>
+
+namespace DB
+{
+
+namespace FailPoints
+{
+    extern const char thread_group_switcher_attach_failure[];
+    extern const char thread_group_link_thread_failure[];
+}
+
+/// Regression test for https://github.com/ClickHouse/clickhouse-core-incidents/issues/1682
+///
+/// Root cause (confirmed from stack traces):
+///   In 26.4, TasksStatsCounters::reset() inside initPerformanceCounters() had no
+///   try/catch. When /proc/thread-self/schedstat returned errno=9 (EBADF), the
+///   ErrnoException escaped initPerformanceCounters and propagated up through
+///   attachToGroupImpl into the ThreadGroupSwitcher constructor's noexcept catch block.
+///   By that point all context fields (performance_counters parent, memory_tracker
+///   parent, query_context, local_data, …) were already pointing at the thread group.
+///   The catch block logged the error but left ThreadStatus fully attached to the stale
+///   group, so every subsequent task on that pool worker threw LOGICAL_ERROR:
+///     "Thread (REMOTE_FS_READ_THREAD_POOL) is already attached to a group (master_thread_id 1398)"
+///
+/// Fix: attachToGroupImpl now installs a SCOPE_EXIT_SAFE guard that calls
+/// detachFromGroup() on failure, undoing the full attachment (unlinkThread, all parent
+/// pointers, query_context, local_data, etc.). ThreadGroupSwitcher's catch block is
+/// unchanged — it just clears its own members; the ThreadStatus is already clean.
+///
+/// The failpoint thread_group_switcher_attach_failure fires after all context fields
+/// are set but before initPerformanceCounters, matching the 26.4 failure window.
+/// ThreadGroupSwitcher::ThreadGroupSwitcher is noexcept — the injected exception is
+/// swallowed internally and never reaches the test.
+TEST(ThreadGroupSwitcher, PartialAttachUndoneOnException)
+{
+    auto context = getContext().context;
+
+    std::exception_ptr ex;
+    bool second_switcher_succeeded = false;
+
+    std::thread t([&]
+    {
+        try
+        {
+            ThreadStatus ts;
+
+            auto G1 = std::make_shared<ThreadGroup>(context, 0);
+            auto G2 = std::make_shared<ThreadGroup>(context, 0);
+
+            /// Enable the failpoint: attachToGroupImpl() will throw after all context
+            /// fields are set (performance_counters parent, memory_tracker parent,
+            /// query_context, local_data, …) but before initPerformanceCounters,
+            /// matching the 26.4 failure window.
+            FailPointInjection::enableFailPoint(FailPoints::thread_group_switcher_attach_failure);
+
+            {
+                /// ThreadGroupSwitcher is noexcept — the injected exception is caught
+                /// and logged internally. The SCOPE_EXIT_SAFE guard in attachToGroupImpl
+                /// calls detachFromGroup() to undo the full attachment before returning.
+                ThreadGroupSwitcher switcher(G1, ThreadName::REMOTE_FS_READ_THREAD_POOL);
+            }
+
+            /// Failpoint is ONCE — already consumed, no need to disable.
+
+            /// With the fix the thread is clean: the second attachment must succeed.
+            /// Without the fix the stale G1 is still set and this constructor throws
+            /// LOGICAL_ERROR "already attached" (caught internally, switcher is a no-op).
+            {
+                ThreadGroupSwitcher switcher(G2, ThreadName::REMOTE_FS_READ_THREAD_POOL);
+                second_switcher_succeeded = (getCurrentThreadGroup() == G2);
+            }
+
+            ASSERT_EQ(getCurrentThreadGroup(), nullptr);
+        }
+        catch (...)
+        {
+            ex = std::current_exception();
+        }
+    });
+    t.join();
+
+    if (ex)
+        std::rethrow_exception(ex);
+
+    EXPECT_TRUE(second_switcher_succeeded)
+        << "Second ThreadGroupSwitcher must attach successfully after the first one "
+           "cleaned up its partial attachment; without the fix the stale group from the "
+           "failed first attachment would block every subsequent task on this pool worker";
+}
+
+/// When linkThread() itself throws (e.g. bad_alloc from thread_ids.insert), active_thread_count
+/// was never incremented. The SCOPE_EXIT_SAFE rollback in attachToGroupImpl must NOT call
+/// unlinkThread() in that case, or it would corrupt the counter and hit the chassert.
+/// After the failure the thread must be clean and able to accept the next attachment.
+TEST(ThreadGroupSwitcher, LinkThreadFailureDoesNotCorruptCounter)
+{
+    auto context = getContext().context;
+
+    std::exception_ptr ex;
+    bool second_switcher_succeeded = false;
+
+    std::thread t([&]
+    {
+        try
+        {
+            ThreadStatus ts;
+
+            auto G1 = std::make_shared<ThreadGroup>(context, 0);
+            auto G2 = std::make_shared<ThreadGroup>(context, 0);
+
+            FailPointInjection::enableFailPoint(FailPoints::thread_group_link_thread_failure);
+
+            {
+                /// linkThread throws before active_thread_count is incremented.
+                /// The SCOPE_EXIT rollback must skip unlinkThread (linked=false).
+                /// ThreadStatus::thread_group is never set, so the thread is immediately clean.
+                ThreadGroupSwitcher switcher(G1, ThreadName::REMOTE_FS_READ_THREAD_POOL);
+            }
+
+            /// Thread is clean — second attachment must succeed.
+            {
+                ThreadGroupSwitcher switcher(G2, ThreadName::REMOTE_FS_READ_THREAD_POOL);
+                second_switcher_succeeded = (getCurrentThreadGroup() == G2);
+            }
+
+            ASSERT_EQ(getCurrentThreadGroup(), nullptr);
+        }
+        catch (...)
+        {
+            ex = std::current_exception();
+        }
+    });
+    t.join();
+
+    if (ex)
+        std::rethrow_exception(ex);
+
+    EXPECT_TRUE(second_switcher_succeeded)
+        << "linkThread failure must not corrupt active_thread_count and must leave the "
+           "thread clean for the next attachment";
+}
+
+} // namespace DB

--- a/src/Common/tests/gtest_thread_group_switcher.cpp
+++ b/src/Common/tests/gtest_thread_group_switcher.cpp
@@ -160,4 +160,56 @@ TEST(ThreadGroupSwitcher, LinkThreadFailureDoesNotCorruptCounter)
            "thread clean for the next attachment";
 }
 
+/// allow_existing_group=true callers (ExceptionKeepingTransform, merge/mutate tasks)
+/// start the switcher already attached to a group. If the new attachment fails, the
+/// constructor must best-effort restore the original group so the caller does not
+/// continue without query/merge accounting and cancellation context.
+TEST(ThreadGroupSwitcher, AllowExistingGroupRestoresOnFailure)
+{
+    auto context = getContext().context;
+
+    std::exception_ptr ex;
+    bool original_group_restored = false;
+
+    std::thread t([&]
+    {
+        try
+        {
+            ThreadStatus ts;
+
+            auto G0 = std::make_shared<ThreadGroup>(context, 0);
+            auto G1 = std::make_shared<ThreadGroup>(context, 0);
+
+            /// Start attached to G0, simulating a merge/pipeline executor thread.
+            CurrentThread::attachToGroupIfDetached(G0);
+            ASSERT_EQ(getCurrentThreadGroup(), G0);
+
+            FailPointInjection::enableFailPoint(FailPoints::thread_group_switcher_attach_failure);
+
+            {
+                /// allow_existing_group=true: constructor detaches G0, attachToGroupImpl
+                /// then throws (failpoint), its rollback detaches the partial G1 state.
+                /// The constructor catch block must restore G0.
+                ThreadGroupSwitcher switcher(G1, ThreadName::MERGE_MUTATE, /*allow_existing_group*/ true);
+            }
+
+            original_group_restored = (getCurrentThreadGroup() == G0);
+
+            CurrentThread::detachFromGroupIfNotDetached();
+        }
+        catch (...)
+        {
+            ex = std::current_exception();
+        }
+    });
+    t.join();
+
+    if (ex)
+        std::rethrow_exception(ex);
+
+    EXPECT_TRUE(original_group_restored)
+        << "Failed allow_existing_group switch must restore the original group; "
+           "otherwise the thread loses its query/merge accounting and cancellation context";
+}
+
 } // namespace DB

--- a/src/Common/tests/gtest_thread_group_switcher.cpp
+++ b/src/Common/tests/gtest_thread_group_switcher.cpp
@@ -68,6 +68,11 @@ TEST(ThreadGroupSwitcher, PartialAttachUndoneOnException)
                 /// and logged internally. The SCOPE_EXIT_SAFE guard in attachToGroupImpl
                 /// calls detachFromGroup() to undo the full attachment before returning.
                 ThreadGroupSwitcher switcher(G1, ThreadName::REMOTE_FS_READ_THREAD_POOL);
+
+                /// Prove the failpoint actually fired: on success the thread would
+                /// be attached to G1 here. nullptr means the attach failed and the
+                /// rollback in attachToGroupImpl ran.
+                ASSERT_EQ(getCurrentThreadGroup(), nullptr);
             }
 
             /// Failpoint is ONCE — already consumed, no need to disable.
@@ -125,6 +130,11 @@ TEST(ThreadGroupSwitcher, LinkThreadFailureDoesNotCorruptCounter)
                 /// The SCOPE_EXIT rollback must skip unlinkThread (linked=false).
                 /// ThreadStatus::thread_group is never set, so the thread is immediately clean.
                 ThreadGroupSwitcher switcher(G1, ThreadName::REMOTE_FS_READ_THREAD_POOL);
+
+                /// Prove the failpoint actually fired: on success the thread would
+                /// be attached to G1 here. nullptr means linkThread threw and the
+                /// thread was never attached in the first place.
+                ASSERT_EQ(getCurrentThreadGroup(), nullptr);
             }
 
             /// Thread is clean — second attachment must succeed.

--- a/src/Common/tests/gtest_thread_group_switcher.cpp
+++ b/src/Common/tests/gtest_thread_group_switcher.cpp
@@ -19,28 +19,8 @@ namespace FailPoints
     extern const char thread_group_link_thread_failure[];
 }
 
-/// Regression test for https://github.com/ClickHouse/clickhouse-core-incidents/issues/1682
-///
-/// Root cause (confirmed from stack traces):
-///   In 26.4, TasksStatsCounters::reset() inside initPerformanceCounters() had no
-///   try/catch. When /proc/thread-self/schedstat returned errno=9 (EBADF), the
-///   ErrnoException escaped initPerformanceCounters and propagated up through
-///   attachToGroupImpl into the ThreadGroupSwitcher constructor's noexcept catch block.
-///   By that point all context fields (performance_counters parent, memory_tracker
-///   parent, query_context, local_data, …) were already pointing at the thread group.
-///   The catch block logged the error but left ThreadStatus fully attached to the stale
-///   group, so every subsequent task on that pool worker threw LOGICAL_ERROR:
-///     "Thread (REMOTE_FS_READ_THREAD_POOL) is already attached to a group (master_thread_id 1398)"
-///
-/// Fix: attachToGroupImpl now installs a SCOPE_EXIT_SAFE guard that calls
-/// detachFromGroup() on failure, undoing the full attachment (unlinkThread, all parent
-/// pointers, query_context, local_data, etc.). ThreadGroupSwitcher's catch block is
-/// unchanged — it just clears its own members; the ThreadStatus is already clean.
-///
-/// The failpoint thread_group_switcher_attach_failure fires after all context fields
-/// are set but before initPerformanceCounters, matching the 26.4 failure window.
-/// ThreadGroupSwitcher::ThreadGroupSwitcher is noexcept — the injected exception is
-/// swallowed internally and never reaches the test.
+/// Mid-attachment failure must leave ThreadStatus fully detached so the next switcher
+/// on the same thread can attach cleanly. Regression for incident #1682.
 TEST(ThreadGroupSwitcher, PartialAttachUndoneOnException)
 {
     auto context = getContext().context;

--- a/src/Common/tests/gtest_thread_group_switcher.cpp
+++ b/src/Common/tests/gtest_thread_group_switcher.cpp
@@ -13,7 +13,7 @@ namespace DB
 
 namespace FailPoints
 {
-    extern const char thread_group_switcher_attach_failure[];
+    extern const char attach_to_group_failure[];
 }
 
 /// After a failed ThreadGroupSwitcher construction the thread must be left in the
@@ -27,7 +27,7 @@ TEST(ThreadGroupSwitcher, FailedConstructionRestoresPreviousState)
     auto G1 = std::make_shared<ThreadGroup>(context, 0);
 
     /// Started detached → must end detached after the failed switch.
-    FailPointInjection::enableFailPoint(FailPoints::thread_group_switcher_attach_failure);
+    FailPointInjection::enableFailPoint(FailPoints::attach_to_group_failure);
     {
         ThreadGroupSwitcher switcher(G1, ThreadName::REMOTE_FS_READ_THREAD_POOL);
         EXPECT_EQ(getCurrentThreadGroup(), nullptr)
@@ -36,7 +36,7 @@ TEST(ThreadGroupSwitcher, FailedConstructionRestoresPreviousState)
 
     /// Started attached to G0 → must end attached to G0 after the failed switch.
     CurrentThread::attachToGroupIfDetached(G0);
-    FailPointInjection::enableFailPoint(FailPoints::thread_group_switcher_attach_failure);
+    FailPointInjection::enableFailPoint(FailPoints::attach_to_group_failure);
     {
         ThreadGroupSwitcher switcher(G1, ThreadName::MERGE_MUTATE, /*allow_existing_group*/ true);
         EXPECT_EQ(getCurrentThreadGroup(), G0)

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -374,15 +374,9 @@ void ThreadStatus::attachToGroupImpl(const ThreadGroupPtr & thread_group_)
         applyGlobalSettings();
         applyQuerySettings();
 
-        /// Failpoint fires here: all context fields are already populated
-        /// (performance_counters/memory_tracker parents, query_context, local_data, …)
-        /// but initPerformanceCounters has not run yet. This mirrors the 26.4 incident
-        /// where TasksStatsCounters::reset() threw at exactly this point in the call
-        /// stack without a try/catch, leaving the thread attached to a stale group.
-        /// The try-catch above calls detachFromGroup() which resets all those fields.
         fiu_do_on(FailPoints::thread_group_switcher_attach_failure,
         {
-            throw Exception(ErrorCodes::FAULT_INJECTED, "Injected failure in attachToGroupImpl after context fields set");
+            throw Exception(ErrorCodes::FAULT_INJECTED, "Injected failure in attachToGroupImpl");
         });
 
         initPerformanceCounters();

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -42,7 +42,7 @@ namespace DB
 {
 namespace FailPoints
 {
-    extern const char thread_group_switcher_attach_failure[];
+    extern const char attach_to_group_failure[];
 }
 
 namespace Setting
@@ -374,7 +374,7 @@ void ThreadStatus::attachToGroupImpl(const ThreadGroupPtr & thread_group_)
         applyGlobalSettings();
         applyQuerySettings();
 
-        fiu_do_on(FailPoints::thread_group_switcher_attach_failure,
+        fiu_do_on(FailPoints::attach_to_group_failure,
         {
             throw Exception(ErrorCodes::FAULT_INJECTED, "Injected failure in attachToGroupImpl");
         });

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -17,6 +17,7 @@
 #include <Common/CurrentThread.h>
 #include <Common/DateLUT.h>
 #include <Common/Exception.h>
+#include <Common/FailPoint.h>
 #include <Common/MemoryTracker.h>
 #include <Common/ProfileEvents.h>
 #include <Common/QueryProfiler.h>
@@ -39,6 +40,12 @@
 
 namespace DB
 {
+namespace FailPoints
+{
+    extern const char thread_group_switcher_attach_failure[];
+    extern const char thread_group_link_thread_failure[];
+}
+
 namespace Setting
 {
     extern const SettingsBool calculate_text_stack_trace;
@@ -74,6 +81,7 @@ namespace ServerSetting
 namespace ErrorCodes
 {
     extern const int LOGICAL_ERROR;
+    extern const int FAULT_INJECTED;
 }
 
 void configureMemoryTrackerFromSettings(bool has_trace_collector, MemoryTracker & memory_tracker, const Settings & settings)
@@ -176,6 +184,10 @@ UInt64 ThreadGroup::getGroupElapsedMs() const
 void ThreadGroup::linkThread(UInt64 thread_id)
 {
     std::lock_guard lock(mutex);
+    fiu_do_on(FailPoints::thread_group_link_thread_failure,
+    {
+        throw Exception(ErrorCodes::FAULT_INJECTED, "Injected failure in ThreadGroup::linkThread");
+    });
     thread_ids.insert(thread_id);
 
     if (active_thread_count == 0)
@@ -350,27 +362,45 @@ void ThreadStatus::attachToGroupImpl(const ThreadGroupPtr & thread_group_)
 {
     thread_attach_time.setUp();
 
-    /// Attach or init current thread to thread group and copy useful information from it
+    thread_group_->linkThread(thread_id);
     thread_group = thread_group_;
-    thread_group->linkThread(thread_id);
-
-    performance_counters.setParent(&thread_group->performance_counters);
-    memory_tracker.setParent(&thread_group->memory_tracker);
-
-    query_context = thread_group->query_context;
-    global_context = thread_group->global_context;
-
-    fatal_error_callback = thread_group->fatal_error_callback;
-
-    local_data = thread_group->getSharedData();
-
-    applyGlobalSettings();
-    applyQuerySettings();
-    initPerformanceCounters();
-
-    if (thread_group->os_threads_nice_value != 0)
+    try
     {
-        OSThreadNiceValue::set(thread_group->os_threads_nice_value);
+        performance_counters.setParent(&thread_group->performance_counters);
+        memory_tracker.setParent(&thread_group->memory_tracker);
+
+        query_context = thread_group->query_context;
+        global_context = thread_group->global_context;
+
+        fatal_error_callback = thread_group->fatal_error_callback;
+
+        local_data = thread_group->getSharedData();
+
+        applyGlobalSettings();
+        applyQuerySettings();
+
+        /// Failpoint fires here: all context fields are already populated
+        /// (performance_counters/memory_tracker parents, query_context, local_data, …)
+        /// but initPerformanceCounters has not run yet. This mirrors the 26.4 incident
+        /// where TasksStatsCounters::reset() threw at exactly this point in the call
+        /// stack without a try/catch, leaving the thread attached to a stale group.
+        /// The try-catch above calls detachFromGroup() which resets all those fields.
+        fiu_do_on(FailPoints::thread_group_switcher_attach_failure,
+        {
+            throw Exception(ErrorCodes::FAULT_INJECTED, "Injected failure in attachToGroupImpl after context fields set");
+        });
+
+        initPerformanceCounters();
+
+        if (thread_group->os_threads_nice_value != 0)
+        {
+            OSThreadNiceValue::set(thread_group->os_threads_nice_value);
+        }
+    }
+    catch (...)
+    {
+        detachFromGroup();
+        throw;
     }
 }
 

--- a/src/Interpreters/ThreadStatusExt.cpp
+++ b/src/Interpreters/ThreadStatusExt.cpp
@@ -43,7 +43,6 @@ namespace DB
 namespace FailPoints
 {
     extern const char thread_group_switcher_attach_failure[];
-    extern const char thread_group_link_thread_failure[];
 }
 
 namespace Setting
@@ -184,10 +183,6 @@ UInt64 ThreadGroup::getGroupElapsedMs() const
 void ThreadGroup::linkThread(UInt64 thread_id)
 {
     std::lock_guard lock(mutex);
-    fiu_do_on(FailPoints::thread_group_link_thread_failure,
-    {
-        throw Exception(ErrorCodes::FAULT_INJECTED, "Injected failure in ThreadGroup::linkThread");
-    });
     thread_ids.insert(thread_id);
 
     if (active_thread_count == 0)


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
<!-- End of fixes issue link part, do not remove -->

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a case where a worker thread could stay attached to a stale thread group after `CurrentThread::attachToGroup` failed part way through, causing later tasks on the same thread to fail with `Thread is already attached to a group`.