### PR TITLE
Add max_concurrent_queries_for_normalized_query_hash setting

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -2102,7 +2102,20 @@ Possible values:
 <max_concurrent_queries_for_user>5</max_concurrent_queries_for_user>
 ```
 )", 0) \
-\
+    DECLARE(UInt64, max_concurrent_queries_for_normalized_query_hash, 0, R"(
+The maximum number of simultaneously processed queries with the same normalized query hash (i.e. structurally identical queries).
+
+Possible values:
+- Positive integer.
+- 0 — No limit.
+)", 0) \
+    DECLARE(UInt64, queue_max_wait_ms_for_normalized_query_hash, 0, R"(
+Wait time in milliseconds for a query to start executing when max_concurrent_queries_for_normalized_query_hash limit is reached.
+
+Possible values:
+- Positive integer.
+- 0 — Throw immediately without waiting.
+)", 0) \
     DECLARE(DeduplicateInsertMode, deduplicate_insert, DeduplicateInsertMode::ENABLE, R"(
 Enables or disables block deduplication of  `INSERT INTO` (for Replicated\* tables).
 The setting overrides `insert_deduplicate` and `async_insert_deduplicate` settings.

--- a/src/Interpreters/ProcessList.cpp
+++ b/src/Interpreters/ProcessList.cpp
@@ -41,6 +41,8 @@ namespace Setting
 {
     extern const SettingsUInt64 max_concurrent_queries_for_all_users;
     extern const SettingsUInt64 max_concurrent_queries_for_user;
+    extern const SettingsUInt64 max_concurrent_queries_for_normalized_query_hash;
+    extern const SettingsUInt64 queue_max_wait_ms_for_normalized_query_hash;
     extern const SettingsSeconds max_execution_time;
     extern const SettingsUInt64 max_memory_usage;
     extern const SettingsUInt64 max_memory_usage_for_user;
@@ -253,6 +255,34 @@ ProcessList::EntryPtr ProcessList::insert(
             }
         }
 
+        /// Limit concurrent queries with the same normalized query hash
+        if (!is_unlimited_query && settings[Setting::max_concurrent_queries_for_normalized_query_hash])
+        {
+            UInt64 max_for_hash = settings[Setting::max_concurrent_queries_for_normalized_query_hash];
+            UInt64 wait_ms = settings[Setting::queue_max_wait_ms_for_normalized_query_hash];
+            auto it = queries_per_normalized_hash.find(normalized_query_hash);
+            size_t current_count = (it != queries_per_normalized_hash.end()) ? it->second : 0;
+
+            if (current_count >= max_for_hash)
+            {
+                if (wait_ms)
+                    LOG_WARNING(getLogger("ProcessList"),
+                        "Too many simultaneous queries with the same structure, will wait {} ms.", wait_ms);
+                if (!wait_ms || !have_space.wait_for(lock, std::chrono::milliseconds(wait_ms),
+                    [&]
+                    {
+                        auto it2 = queries_per_normalized_hash.find(normalized_query_hash);
+                        return it2 == queries_per_normalized_hash.end() || it2->second < max_for_hash;
+                    }))
+                    throw Exception(
+                        ErrorCodes::TOO_MANY_SIMULTANEOUS_QUERIES,
+                        "Too many simultaneous queries with the same query structure. "
+                        "Current: {}, maximum: {}",
+                        current_count,
+                        max_for_hash);
+            }
+        }
+
         /// Check other users running query with our query_id
         if (auto query_user = queries_to_user.find(client_info.current_query_id); query_user != queries_to_user.end() && query_user->second != client_info.current_user)
         {
@@ -345,6 +375,7 @@ ProcessList::EntryPtr ProcessList::insert(
         {
             ++non_internal_processes;
             increaseQueryKindAmount(query_kind);
+            ++queries_per_normalized_hash[normalized_query_hash];
         }
 
         bool registered_in_cancellation_checker = CancellationChecker::getInstance().appendTask(query, query_context->getSettingsRef()[Setting::max_execution_time].totalMilliseconds(), query_context->getSettingsRef()[Setting::timeout_overflow_mode]);
@@ -447,6 +478,14 @@ ProcessListEntry::~ProcessListEntry()
     {
         --parent.non_internal_processes;
         parent.decreaseQueryKindAmount(query_kind);
+        auto hash_it = parent.queries_per_normalized_hash.find((*it)->normalized_query_hash);
+        if (hash_it != parent.queries_per_normalized_hash.end())
+        {
+            if (hash_it->second <= 1)
+                parent.queries_per_normalized_hash.erase(hash_it);
+            else
+                --hash_it->second;
+        }
     }
 
     if (!found)

--- a/src/Interpreters/ProcessList.h
+++ b/src/Interpreters/ProcessList.h
@@ -403,6 +403,9 @@ protected:
     mutable std::condition_variable cancelled_cv;
 
     size_t max_size = 0;        /// 0 means no limit. Otherwise, when limit exceeded, an exception is thrown.
+    
+    /// Count of currently running queries per normalized query hash
+    std::unordered_map<UInt64, size_t> queries_per_normalized_hash;
 
     /// Stores per-user info: queries, statistics and limits
     UserToQueries user_to_queries;


### PR DESCRIPTION
Implements control on the number of concurrent similar queries per the request in #106408.

Structurally identical queries (same normalized query hash) can now be limited using two new settings:

- `max_concurrent_queries_for_normalized_query_hash` - maximum number of concurrent queries with the same structure. 0 means no limit.
- `queue_max_wait_ms_for_normalized_query_hash` - how long to wait in milliseconds before throwing. 0 means throw immediately.

Only the simplest variant is implemented as requested.

Closes https://github.com/ClickHouse/ClickHouse/issues/106408

### Changelog category :
- New Feature

### Changelog entry :
Added `max_concurrent_queries_for_normalized_query_hash` and `queue_max_wait_ms_for_normalized_query_hash` settings to limit the number of concurrent structurally identical queries.