### PR TITLE
Ignore irrelevant errors in upgrade check

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -437,6 +437,7 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "Tuple element name 'null' is reserved" \
            -e "No stream (column1_renamedcolumn1.bin) file checksum for column column1_renamed" \
            -e "No stream (ba1.bin) file checksum for column b" \
+           -e "Exception during get topic partitions from Kafka: Local: Broker transport failure" \
     /test_output/clickhouse-server.upgrade.log \
     | grep -av -e "_repl_01111_.*Mapping for table with UUID" \
     | grep -av -e "Azure::Storage::StorageException.*Not found address of host" \


### PR DESCRIPTION
When Kafka is not available, Kafka2 can log these errors, e.g. [here](https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=99980&sha=2766a93faa4d06c88f34acc00fbc313811df9f29&name_0=PR&name_1=Upgrade+check+%28amd_release%29)


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

