### PR TITLE
Propagate S3Queue streaming task query_id to dependent table inserts

### DIFF
--- a/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
+++ b/src/Storages/ObjectStorageQueue/StorageObjectStorageQueue.cpp
@@ -36,6 +36,7 @@
 #include <Storages/VirtualColumnUtils.h>
 #include <Storages/prepareReadingFromFormat.h>
 #include <Storages/HivePartitioningUtils.h>
+#include <Common/CurrentThread.h>
 #include <Common/FailPoint.h>
 #include <Common/Macros.h>
 #include <Common/ProfileEvents.h>
@@ -834,6 +835,13 @@ bool StorageObjectStorageQueue::streamToViews(size_t streaming_tasks_index)
     auto storage_snapshot = getStorageSnapshot(getInMemoryMetadataPtr(getContext(), false), getContext());
     auto queue_context = Context::createCopy(getContext());
     queue_context->makeQueryContext();
+
+    /// Propagate the background schedule pool task's query_id (e.g. `BgSchPool::<uuid>`) to the
+    /// insert into dependent tables. Without this, the insert pipeline runs with an empty query_id,
+    /// so the parts it writes are recorded with an empty query_id in `system.part_log` and the
+    /// part-writing messages in `system.text_log` cannot be correlated with the streaming task.
+    if (auto query_id = CurrentThread::getQueryId(); !query_id.empty())
+        queue_context->setCurrentQueryId(String(query_id));
 
     size_t min_insert_block_size_rows = 0;
     size_t min_insert_block_size_bytes = 0;

--- a/tests/integration/test_storage_s3_queue/test_0.py
+++ b/tests/integration/test_storage_s3_queue/test_0.py
@@ -812,6 +812,63 @@ def test_streaming_to_view(started_cluster, mode):
 
 
 @pytest.mark.parametrize("mode", AVAILABLE_MODES)
+def test_streaming_query_id_propagation(started_cluster, mode):
+    node = started_cluster.instances["instance"]
+    table_name = f"streaming_query_id_{mode}"
+    dst_table_name = f"{table_name}_dst"
+    files_path = f"{table_name}_data"
+    # A unique path is necessary for repeatable tests
+    keeper_path = f"/clickhouse/test_{table_name}_{generate_random_string()}"
+
+    total_values = generate_random_files(started_cluster, files_path, 5)
+    create_table(
+        started_cluster,
+        node,
+        table_name,
+        mode,
+        files_path,
+        additional_settings={"keeper_path": keeper_path},
+    )
+    create_mv(node, table_name, dst_table_name)
+
+    expected_values = set([tuple(i) for i in total_values])
+    for _ in range(20):
+        selected_values = {
+            tuple(map(int, l.split()))
+            for l in node.query(
+                f"SELECT column1, column2, column3 FROM {dst_table_name} ORDER BY all"
+            ).splitlines()
+        }
+        if selected_values == expected_values:
+            break
+        time.sleep(1)
+    assert selected_values == expected_values
+
+    node.query("SYSTEM FLUSH LOGS")
+
+    # The streaming task runs in the BackgroundSchedulePool, which assigns a
+    # query_id of the form `BgSchPool::<uuid>` to the task thread. This id is
+    # propagated to the insert into dependent tables, so the parts written for
+    # the destination table must carry it in system.part_log. Before the
+    # propagation the query_id of these parts was empty.
+    query_ids = (
+        node.query(
+            f"""
+            SELECT DISTINCT query_id FROM system.part_log
+            WHERE database = 'default' AND table = '{dst_table_name}'
+                AND event_type = 'NewPart'
+            """
+        )
+        .strip()
+        .splitlines()
+    )
+
+    assert len(query_ids) > 0
+    for query_id in query_ids:
+        assert query_id.startswith("BgSchPool::"), query_id
+
+
+@pytest.mark.parametrize("mode", AVAILABLE_MODES)
 def test_streaming_to_many_views(started_cluster, mode):
     node = started_cluster.instances["instance"]
     table_name = f"streaming_to_many_views_{mode}"


### PR DESCRIPTION
The S3Queue (and other `ObjectStorageQueue`) streaming task runs in the `BackgroundSchedulePool`, which assigns a per-run `query_id` of the form `BgSchPool::<uuid>` to the pool thread. This id shows up in `system.query_views_log`, but the insert into dependent tables built by `streamToViews` ran with an empty `query_id` because `makeQueryContext` does not inherit the pool thread's id.

As a result, the parts written by that insert were recorded with an empty `query_id` in `system.part_log`, and the part-writing messages in `system.text_log` could not be correlated with the streaming task.

Propagate `CurrentThread::getQueryId` onto the queue context after `makeQueryContext` so the insert, its `system.part_log` rows, and the part-writing `system.text_log` lines all carry the same `BgSchPool::<uuid>` id that already appears in `system.query_views_log`.

It's a very small change, and its purpose is just to populate an existing column in some system tables, so I didn't add a test or changelog entry.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.543`
<!-- ch-version-info:end -->