### PR TITLE
Add test: dateTrunc 3-argument timezone form for sub-second units

### DIFF
--- a/tests/queries/0_stateless/04201_date_trunc_subsecond_with_timezone.reference
+++ b/tests/queries/0_stateless/04201_date_trunc_subsecond_with_timezone.reference
@@ -1,0 +1,9 @@
+DateTime64(3)
+DateTime64(6)
+DateTime64(9)
+DateTime64(3, \'Asia/Tokyo\')
+DateTime64(6, \'Asia/Tokyo\')
+DateTime64(9, \'Asia/Tokyo\')
+2022-03-01 21:12:12.012
+2022-03-01 21:12:12.012346
+2022-03-01 21:12:12.012345678

--- a/tests/queries/0_stateless/04201_date_trunc_subsecond_with_timezone.sql
+++ b/tests/queries/0_stateless/04201_date_trunc_subsecond_with_timezone.sql
@@ -1,0 +1,23 @@
+-- Test: exercises `dateTrunc` 3-argument form (with timezone) for sub-second
+-- units (millisecond, microsecond, nanosecond). Also verifies the return
+-- type scale (3, 6, 9). The PR that added these units only tested the
+-- 2-argument form; the 3-argument timezone path and scale-selection logic
+-- are unexercised across the test suite.
+-- Covers: src/Functions/date_trunc.cpp:209-216 — DateTime64 result branch
+-- with timezone extraction and scale selection (3 / 6 / 9).
+SET session_timezone = 'UTC';
+
+-- Scale verification for the 2-argument form (output type only)
+SELECT toTypeName(dateTrunc('millisecond', toDateTime64('2022-03-01 12:12:12.012345678', 9)));
+SELECT toTypeName(dateTrunc('microsecond', toDateTime64('2022-03-01 12:12:12.012345678', 9)));
+SELECT toTypeName(dateTrunc('nanosecond',  toDateTime64('2022-03-01 12:12:12.012345678', 9)));
+
+-- 3-argument form: timezone propagation into the DateTime64 result type
+SELECT toTypeName(dateTrunc('millisecond', toDateTime64('2022-03-01 12:12:12.012345678', 9, 'UTC'), 'Asia/Tokyo'));
+SELECT toTypeName(dateTrunc('microsecond', toDateTime64('2022-03-01 12:12:12.012345678', 9, 'UTC'), 'Asia/Tokyo'));
+SELECT toTypeName(dateTrunc('nanosecond',  toDateTime64('2022-03-01 12:12:12.012345678', 9, 'UTC'), 'Asia/Tokyo'));
+
+-- 3-argument form: timezone shifts the displayed value (UTC -> JST is +09:00)
+SELECT dateTrunc('millisecond', toDateTime64('2022-03-01 12:12:12.012345678', 9, 'UTC'), 'Asia/Tokyo');
+SELECT dateTrunc('microsecond', toDateTime64('2022-03-01 12:12:12.012345678', 9, 'UTC'), 'Asia/Tokyo');
+SELECT dateTrunc('nanosecond',  toDateTime64('2022-03-01 12:12:12.012345678', 9, 'UTC'), 'Asia/Tokyo');


### PR DESCRIPTION
Adds a stateless test covering the `dateTrunc` 3-argument (timezone) form for sub-second units (`millisecond` / `microsecond` / `nanosecond`) and the `DateTime64` result-type scale selection (3 / 6 / 9).

The PR that introduced these units (#62335) only exercised the 2-argument form; the 3-argument timezone path and the scale-selection logic in `src/Functions/date_trunc.cpp` were unexercised across the test suite. The test is deterministic and matches actual server output on the current build.

This supersedes #104012, whose branch ended up with an empty diff.

_Found via ClickGap automated review._

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.413`
<!-- ch-version-info:end -->