### PR TITLE
Do not report test-runner abortions and per-test timeouts as Server died

### DIFF
--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -257,16 +257,25 @@ class FTResultsProcessor:
         elif runner_exit_code in RUNNER_ABORTED_EXIT_CODES:
             # `clickhouse-test` was terminated by a signal (job-level timeout,
             # runner shutdown, or the worker -> parent SIGTERM feedback loop) -
-            # not a server death. Do NOT demote the per-test results: the ones
-            # that completed before the kill are authoritative. Report it under
-            # the same `clickhouse-test` leaf the end-of-run path uses for other
-            # non-zero exits, so the failure reads as "the runner did not finish"
-            # rather than "Server died".
-            state = Result.Status.FAIL
+            # not a server death. This is the same condition as `not
+            # s.success_finish` below (the runner did not finish), so it gets
+            # the same `ERROR` status, plus an explicit `clickhouse-test` leaf
+            # carrying the exit code. `ERROR`, not `FAIL`: the run is
+            # inconclusive (we never reached the finish marker), it is not a
+            # test producing a wrong answer. We do NOT demote the per-test
+            # results - the ones that completed before the kill are
+            # authoritative and stay visible.
+            #
+            # The `ERROR` status also drives the bugfix-validation inverter
+            # down its "preserve, do not invert" path: an abort while
+            # exercising the regression test is reported as inconclusive rather
+            # than silently claimed as "bug reproduced" (a wall-clock timeout
+            # does not prove this particular bug reproduced).
+            state = Result.Status.ERROR
             test_results.append(
                 Result(
                     "clickhouse-test",
-                    Result.Status.FAIL,
+                    Result.Status.ERROR,
                     info=f"clickhouse-test was terminated before finishing (exit code {runner_exit_code})",
                 )
             )
@@ -326,15 +335,18 @@ class FTResultsProcessor:
         )
 
         if not result.is_ok():
+            # Sort the leaves so the most actionable ones come first. Keys are
+            # the actual `Result.Status` values the parser assigns - the former
+            # `SERVER_DIED`/`Timeout`/`BROKEN` keys never matched anything (the
+            # synthetic "Server died" leaf has status FAIL, not "SERVER_DIED")
+            # and `ERROR` was missing, so it silently sorted to the front.
             order = {
                 "FAIL": 0,
-                "SERVER_DIED": 1,
-                "Timeout": 2,
-                "NOT_FAILED": 3,
-                "BROKEN": 4,
-                "UNKNOWN": 5,
-                "OK": 6,
-                "SKIPPED": 7,
+                "ERROR": 1,
+                "NOT_FAILED": 2,
+                "UNKNOWN": 3,
+                "OK": 4,
+                "SKIPPED": 5,
             }
             result.results.sort(key=lambda x: order.get(x.status, -1))
 

--- a/ci/jobs/scripts/functional_tests_results.py
+++ b/ci/jobs/scripts/functional_tests_results.py
@@ -23,37 +23,53 @@ _clickhouse_test_globals = runpy.run_path(str(_clickhouse_test))
 STOP_TESTING_EXIT_CODE = _clickhouse_test_globals["STOP_TESTING_EXIT_CODE"]
 GLOBAL_TIME_LIMIT_EXIT_CODE = _clickhouse_test_globals["GLOBAL_TIME_LIMIT_EXIT_CODE"]
 
-# Exit codes that mean the run was aborted mid-flight, so per-test results
-# (if any) are incomplete and we cannot trust which test "caused" the
-# failure. `STOP_TESTING_EXIT_CODE` is the in-band signal — the parent
-# raised `StopTesting` and reached the outer handler. The kill-by-signal
-# variants cover the out-of-band cases where the parent was killed before
-# it could exit through that handler (currently reachable via the
-# worker -> parent SIGTERM feedback loop in `stop_tests`: each worker the
-# parent terminates re-broadcasts SIGTERM to the whole process group via
-# `killpg`, hitting the parent before it can `sys.exit(STOP_TESTING_EXIT_CODE)`;
-# also covers external kills like job-level timeouts and runner shutdown).
+# Exit codes that mean the run was aborted mid-flight, so it never reached
+# the "All tests have finished" marker. They split into two kinds with
+# very different meanings, and conflating them is what made every external
+# kill show up as a spurious "Server died" (see PR #105643 follow-up).
 #
-# Both `128 + N` (bash's convention when its child died from signal N) and
-# the negative form `-N` are included: `Shell.run` wraps the command in
-# `bash -c`, so most kills surface as `128 + N` via bash's exit status, but
-# `Shell._check_timeout` calls `os.killpg` on the whole group, so the
-# wrapper bash can itself die from the signal — and Python's
-# `subprocess.Popen.returncode` reports that as `-N`, not `128 + N`.
+# `SERVER_DIED_EXIT_CODES` — the server really died. `clickhouse-test`
+# itself detected it (a dead server or a tripped hung-check), raised
+# `StopTesting`, reached its outer handler and exited with
+# `STOP_TESTING_EXIT_CODE`. The partial per-test results are untrustworthy
+# (the crash may have caused them), so they are demoted, and a "Server
+# died" leaf is the honest summary.
 #
-# Exit code 1 is deliberately NOT in this set: it is set by end-of-run
+# `RUNNER_ABORTED_EXIT_CODES` — `clickhouse-test` was terminated by a
+# signal, NOT because the server died. This is a plain "the test runner did
+# not finish" and must not be reported as a server death:
+#   * 143 = 128 + SIGTERM is `clickhouse-test`'s OWN exit code: its
+#     `signal_handler` turns SIGTERM into a `Terminated` exception and
+#     `__main__` exits `128 + e.signal` (see `tests/clickhouse-test`). The
+#     SIGTERM comes from a job-level wall-clock timeout (`Shell.run`'s
+#     safety-net `os.killpg`), a runner shutdown, or the worker -> parent
+#     feedback loop in `stop_tests` (terminating a worker re-broadcasts
+#     SIGTERM to the whole process group, hitting the parent).
+#   * 137 = 128 + SIGKILL is bash's convention for a child killed by an
+#     uncatchable SIGKILL (e.g. `_check_timeout` escalating after SIGTERM).
+#   * -15 / -9 are the negative form: `Shell._check_timeout` `killpg`s the
+#     whole group, so the wrapper `bash -c` itself can die from the signal,
+#     and Python's `subprocess.Popen.returncode` reports that as `-N`.
+# The per-test results that completed before the kill are authoritative and
+# are kept as-is — a real failure that happened before the abort stays
+# visible.
+#
+# Exit code 1 is deliberately NOT in either set: it is set by end-of-run
 # checks (final hung-check, `runner_process_killed`, `total_tests_run == 0`)
 # that run AFTER all tests have finished. Per-test results in that case are
 # complete and authoritative and must not be demoted.
-ABORTED_RUN_EXIT_CODES = frozenset(
+SERVER_DIED_EXIT_CODES = frozenset({STOP_TESTING_EXIT_CODE})
+
+RUNNER_ABORTED_EXIT_CODES = frozenset(
     {
-        STOP_TESTING_EXIT_CODE,
         128 + signal.SIGTERM,  # 143
         128 + signal.SIGKILL,  # 137
         -signal.SIGTERM,  # -15
         -signal.SIGKILL,  # -9
     }
 )
+
+ABORTED_RUN_EXIT_CODES = SERVER_DIED_EXIT_CODES | RUNNER_ABORTED_EXIT_CODES
 
 SUCCESS_FINISH_SIGNS = ["All tests have finished", "No tests were run"]
 
@@ -223,7 +239,7 @@ class FTResultsProcessor:
             test_results.append(
                 Result("Some queries hung", Result.Status.FAIL, info="Some queries hung")
             )
-        elif runner_exit_code in ABORTED_RUN_EXIT_CODES:
+        elif runner_exit_code in SERVER_DIED_EXIT_CODES:
             state = Result.Status.FAIL
             failed_results = [r for r in test_results if r.is_failure()]
             if len(failed_results) > 1:
@@ -238,6 +254,22 @@ class FTResultsProcessor:
                 # Single test failed - sequential run, this test is the culprit.
                 failed_results[0].status = Result.Status.ERROR
             test_results.append(Result("Server died", Result.Status.FAIL, info="Server died"))
+        elif runner_exit_code in RUNNER_ABORTED_EXIT_CODES:
+            # `clickhouse-test` was terminated by a signal (job-level timeout,
+            # runner shutdown, or the worker -> parent SIGTERM feedback loop) -
+            # not a server death. Do NOT demote the per-test results: the ones
+            # that completed before the kill are authoritative. Report it under
+            # the same `clickhouse-test` leaf the end-of-run path uses for other
+            # non-zero exits, so the failure reads as "the runner did not finish"
+            # rather than "Server died".
+            state = Result.Status.FAIL
+            test_results.append(
+                Result(
+                    "clickhouse-test",
+                    Result.Status.FAIL,
+                    info=f"clickhouse-test was terminated before finishing (exit code {runner_exit_code})",
+                )
+            )
         elif runner_exit_code == GLOBAL_TIME_LIMIT_EXIT_CODE:
             # The run stopped gracefully because the global time limit was
             # reached. This is the *expected* stop condition for the flaky and

--- a/ci/tests/test_bugfix_validation_inverter.py
+++ b/ci/tests/test_bugfix_validation_inverter.py
@@ -75,10 +75,32 @@ def test_mixed_fail_and_ok_treats_any_fail_as_bug_reproduced():
 
 def test_server_died_synthetic_fail_leaf_treated_as_bug_reproduced():
     """Mirrors the leshikus PR #105643 flow: parser synthesises a `Server
-    died` FAIL leaf for `runner_exit_code in {STOP_TESTING_EXIT_CODE, 137,
-    143}`. The inverter must flip it to OK so the bugfix check passes.
+    died` FAIL leaf for `runner_exit_code in SERVER_DIED_EXIT_CODES`
+    (`STOP_TESTING_EXIT_CODE`). The inverter must flip it to OK so the
+    bugfix check passes.
     """
     leaf = _make_leaf("Server died", Result.Status.FAIL, info="Server died")
+    outer = _make_outer(Result.Status.FAIL, [leaf])
+
+    invert_bugfix_validation_status(outer)
+
+    assert leaf.status == Result.Status.OK
+    assert outer.status == Result.Status.OK
+
+
+def test_runner_aborted_synthetic_fail_leaf_treated_as_bug_reproduced():
+    """A run killed by SIGTERM/SIGKILL (exit codes 143/137/-15/-9) now
+    synthesises a `clickhouse-test` FAIL leaf instead of `Server died` - the
+    runner did not finish, but the server did not necessarily die. During
+    bugfix validation the runner being killed while exercising the new test
+    still means the bug reproduced, so the inverter must flip this leaf to OK
+    just as it does for `Server died`.
+    """
+    leaf = _make_leaf(
+        "clickhouse-test",
+        Result.Status.FAIL,
+        info="clickhouse-test was terminated before finishing (exit code 143)",
+    )
     outer = _make_outer(Result.Status.FAIL, [leaf])
 
     invert_bugfix_validation_status(outer)

--- a/ci/tests/test_bugfix_validation_inverter.py
+++ b/ci/tests/test_bugfix_validation_inverter.py
@@ -88,25 +88,27 @@ def test_server_died_synthetic_fail_leaf_treated_as_bug_reproduced():
     assert outer.status == Result.Status.OK
 
 
-def test_runner_aborted_synthetic_fail_leaf_treated_as_bug_reproduced():
+def test_runner_aborted_error_is_preserved_as_inconclusive():
     """A run killed by SIGTERM/SIGKILL (exit codes 143/137/-15/-9) now
-    synthesises a `clickhouse-test` FAIL leaf instead of `Server died` - the
-    runner did not finish, but the server did not necessarily die. During
-    bugfix validation the runner being killed while exercising the new test
-    still means the bug reproduced, so the inverter must flip this leaf to OK
-    just as it does for `Server died`.
+    surfaces as `ERROR` with a `clickhouse-test` leaf - the runner did not
+    finish, but the server did not necessarily die. Unlike the old `Server
+    died` FAIL leaf (which the inverter flipped to "bug reproduced"), an
+    aborted run is inconclusive: a wall-clock abort does not prove this
+    particular bug reproduced. The inverter must preserve the `ERROR` rather
+    than claim a reproduction.
     """
     leaf = _make_leaf(
         "clickhouse-test",
-        Result.Status.FAIL,
+        Result.Status.ERROR,
         info="clickhouse-test was terminated before finishing (exit code 143)",
     )
-    outer = _make_outer(Result.Status.FAIL, [leaf])
+    outer = _make_outer(Result.Status.ERROR, [leaf])
 
     invert_bugfix_validation_status(outer)
 
-    assert leaf.status == Result.Status.OK
-    assert outer.status == Result.Status.OK
+    assert outer.status == Result.Status.ERROR
+    # The leaf is labelled XFAIL (bugfix-validation marker) but not flipped.
+    assert leaf.status == Result.Status.ERROR
 
 
 def test_error_status_with_empty_results_preserves_error():

--- a/ci/tests/test_functional_tests_results.py
+++ b/ci/tests/test_functional_tests_results.py
@@ -1,0 +1,95 @@
+"""
+Tests for `FTResultsProcessor.run` exit-code classification in
+`ci/jobs/scripts/functional_tests_results.py`.
+
+The parser maps `clickhouse-test`'s exit code to a synthetic summary leaf.
+The crucial distinction is between a genuine server death and the runner
+merely being killed by a signal:
+
+  * `STOP_TESTING_EXIT_CODE` (2) is the in-band signal that the server died
+    or the hung-check tripped -> "Server died", partial per-test results are
+    demoted because the crash may have caused them.
+  * 143 / 137 / -15 / -9 mean `clickhouse-test` was terminated by a signal
+    (job-level timeout, runner shutdown, the worker -> parent SIGTERM
+    feedback loop) -> the runner did not finish, but the server did not
+    necessarily die. These get a `clickhouse-test` leaf and the completed
+    per-test results stay authoritative.
+
+This split is the follow-up to ClickHouse/ClickHouse#105643, which had
+folded every kill code into a single "Server died" branch and so produced
+hundreds of spurious "Server died" rows from ordinary timeouts.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+# Importing `ci.praktika` first runs its package `__init__`, which appends
+# `ci/` to `sys.path` - the parser module imports `from praktika.result`
+# (bare, not `ci.praktika.result`), so that path entry must exist first.
+from ci.praktika.result import Result
+from ci.jobs.scripts.functional_tests_results import (  # noqa: E402
+    FTResultsProcessor,
+    RUNNER_ABORTED_EXIT_CODES,
+    SERVER_DIED_EXIT_CODES,
+)
+
+
+def _processor(tmp_path, lines):
+    (tmp_path / "test_result.txt").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return FTResultsProcessor(wd=str(tmp_path))
+
+
+def _leaf(result, name):
+    return next((r for r in result.results if r.name == name), None)
+
+
+def test_server_died_demotes_multiple_failures_and_adds_server_died_leaf(tmp_path):
+    lines = [
+        "00001_a: [ FAIL ] 1.00 sec.",
+        "00002_b: [ FAIL ] 1.00 sec.",
+    ]
+    (exit_code,) = tuple(SERVER_DIED_EXIT_CODES)
+    result = _processor(tmp_path, lines).run(runner_exit_code=exit_code)
+
+    assert result.status == Result.Status.FAIL
+    assert _leaf(result, "Server died") is not None
+    # We cannot tell which test crashed the server: both are demoted to UNKNOWN.
+    assert _leaf(result, "00001_a").status == Result.Status.UNKNOWN
+    assert _leaf(result, "00002_b").status == Result.Status.UNKNOWN
+    assert _leaf(result, "clickhouse-test") is None
+
+
+def test_runner_aborted_keeps_results_and_does_not_report_server_died(tmp_path):
+    lines = [
+        "00001_a: [ OK ] 1.00 sec.",
+        "00002_b: [ FAIL ] 1.00 sec.",
+    ]
+    for exit_code in sorted(RUNNER_ABORTED_EXIT_CODES):
+        result = _processor(tmp_path, lines).run(runner_exit_code=exit_code)
+
+        assert result.status == Result.Status.FAIL, exit_code
+        # Not a server death.
+        assert _leaf(result, "Server died") is None, exit_code
+        # The runner-did-not-finish summary leaf is present.
+        aborted_leaf = _leaf(result, "clickhouse-test")
+        assert aborted_leaf is not None, exit_code
+        assert aborted_leaf.status == Result.Status.FAIL, exit_code
+        assert str(exit_code) in aborted_leaf.info, exit_code
+        # Completed per-test results stay authoritative - the FAIL that
+        # happened before the kill is NOT demoted to UNKNOWN.
+        assert _leaf(result, "00001_a").status == Result.Status.OK, exit_code
+        assert _leaf(result, "00002_b").status == Result.Status.FAIL, exit_code
+
+
+def test_clean_finish_reports_ok(tmp_path):
+    lines = [
+        "00001_a: [ OK ] 1.00 sec.",
+        "All tests have finished",
+    ]
+    result = _processor(tmp_path, lines).run(runner_exit_code=0)
+
+    assert result.status == Result.Status.OK
+    assert _leaf(result, "Server died") is None
+    assert _leaf(result, "clickhouse-test") is None

--- a/ci/tests/test_functional_tests_results.py
+++ b/ci/tests/test_functional_tests_results.py
@@ -69,13 +69,15 @@ def test_runner_aborted_keeps_results_and_does_not_report_server_died(tmp_path):
     for exit_code in sorted(RUNNER_ABORTED_EXIT_CODES):
         result = _processor(tmp_path, lines).run(runner_exit_code=exit_code)
 
-        assert result.status == Result.Status.FAIL, exit_code
+        # The run did not finish, so it is inconclusive (ERROR), not a test
+        # producing a wrong answer (FAIL).
+        assert result.status == Result.Status.ERROR, exit_code
         # Not a server death.
         assert _leaf(result, "Server died") is None, exit_code
         # The runner-did-not-finish summary leaf is present.
         aborted_leaf = _leaf(result, "clickhouse-test")
         assert aborted_leaf is not None, exit_code
-        assert aborted_leaf.status == Result.Status.FAIL, exit_code
+        assert aborted_leaf.status == Result.Status.ERROR, exit_code
         assert str(exit_code) in aborted_leaf.info, exit_code
         # Completed per-test results stay authoritative - the FAIL that
         # happened before the kill is NOT demoted to UNKNOWN.

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -4429,17 +4429,23 @@ def run_tests_array(
                 # It helps with completely frozen processes, like in case of lldb errors
                 def timeout_handler(_signum, _frame):
                     with redirect_stdout(cleanup_output):
-                        # Dump stacktraces *before* stop_tests() kills the
-                        # client connections.  This is the only moment
-                        # the offending user query is still wedged on the
-                        # server with its query_id — once the TCP
-                        # connection drops, the server typically cancels
-                        # the query and its threads go away.  BG threads
-                        # stay around either way and can be captured at
-                        # end-of-run.
+                        # Dump stacktraces while the offending query is still
+                        # wedged on the server with its query_id — once the
+                        # client connection drops, the server typically cancels
+                        # the query and its threads go away. BG threads stay
+                        # around either way and can be captured at end-of-run.
+                        #
+                        # Deliberately NOT calling stop_tests() here: its
+                        # `killpg` would SIGTERM this runner's own process group,
+                        # which surfaces as exit code 143 and is misreported as
+                        # an aborted run ("Server died"). The timed-out test is
+                        # instead reported as a normal per-test FAIL below (see
+                        # the `except TimeoutError`); the test's client runs in
+                        # its own session (`start_new_session=True` in
+                        # `TestCase.run`), so it is reaped by `--cleanup` rather
+                        # than by this killpg.
                         print_sql_stacktraces(args)
                         print_c_stacktraces(args)
-                        stop_tests()
                     raise TimeoutError("Test execution timed out")
 
                 signal.signal(signal.SIGALRM, timeout_handler)
@@ -4449,6 +4455,21 @@ def run_tests_array(
                     test_result = test_case.run(args, test_suite, client_options)
                     test_result = test_case.process_result(test_result, MESSAGES)
                 except TimeoutError:
+                    # The per-test wall-clock backstop fired. Treat it like the
+                    # query-level timeout paths: a FAIL with reason TIMEOUT,
+                    # recorded through the normal per-test result path so it
+                    # shows up as a `[ FAIL ]` line (`Reason: Timeout!`) rather
+                    # than aborting the whole run with exit code 143.
+                    test_result = test_case.process_result(
+                        TestResult(
+                            test_case.name,
+                            TestStatus.FAIL,
+                            FailureReason.TIMEOUT,
+                            float(int(args.timeout * 1.1) + 60),
+                            "",
+                        ),
+                        MESSAGES,
+                    )
                     break
                 finally:
                     signal.alarm(0)


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/105643
Related: https://github.com/ClickHouse/ClickHouse/pull/106228
-->

## Motivation

Follow-up to #105643, which folded every mid-flight abort exit code into a
single `ABORTED_RUN_EXIT_CODES` set and attached a synthetic `Server died`
leaf to all of them. That conflated unrelated conditions and produced
hundreds of spurious `Server died` rows from ordinary job-level timeouts and
flaky/targeted checks, where the server was healthy and shut down cleanly
(reported by @Algunenano; see e.g. the targeted run on #105019 and the flaky
check on #104965, and the alternative #106228).

Working through where each "timeout" actually originates showed there is no
single signal to fix - the cases are genuinely different and should be
reported differently.

## Changes

`tests/clickhouse-test` — the per-test SIGALRM backstop (the watchdog for
completely frozen tests, armed at `int(args.timeout * 1.1) + 60`) used to
call `stop_tests` from inside the signal handler. That `killpg` SIGTERMs the
runner's own process group, so the run exits `143`, which the job side then
misreports as an aborted run / `Server died`. The timed-out test is now
recorded as a normal per-test `TestResult(FAIL, FailureReason.TIMEOUT)`
through the usual `process_result` path - exactly like the existing
query-level and `socket.timeout` paths already do - so it surfaces as a plain
`[ FAIL ]` line with `Reason: Timeout!`. No exit-code-based reclassification
is needed on the job side. The test's client runs in its own session
(`start_new_session=True`), so it is still reaped by `--cleanup`, not by the
removed `killpg`.

`ci/jobs/scripts/functional_tests_results.py`:
- `STOP_TESTING_EXIT_CODE` (the in-band signal that the server actually died
  or the hung-check tripped) keeps the `Server died` leaf and the demotion of
  partial per-test results.
- An external kill - `143` / `137` / `-15` / `-9` (job-level timeout, runner
  shutdown, the worker→parent SIGTERM feedback loop) - is now reported as
  `ERROR` with a `clickhouse-test` leaf, not `Server died`. It is the same
  "the runner did not finish" condition as the existing `not s.success_finish`
  branch, and the per-test results that completed before the kill are kept
  authoritative (no `UNKNOWN` demotion). As `ERROR` it also routes the
  bugfix-validation inverter down its "preserve, do not invert" path: an abort
  is reported as inconclusive rather than silently claimed as "bug reproduced"
  (a kill does not prove the bug reproduced).
- Removed the dead `order` keys `SERVER_DIED` / `Timeout` / `BROKEN` (no leaf
  ever has those statuses) and added the real `ERROR` status, which was
  missing and silently sorted to the front.

## Caveat

Dropping `stop_tests` from the SIGALRM handler means a single frozen test no
longer aborts the whole run via `killpg` - it is a `FAIL` and the run
continues, bounded by `--max-failures-chain`. This is strictly more resilient
than before (previously one frozen test killed the entire run with `143`). The
outer `Shell.run` safety-net timeout still backstops a genuinely stuck run.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)
