### PR TITLE
Allowlist `StorageKafka2 Broker transport failure` upgrade-check shutdown noise

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -344,6 +344,13 @@ cp /var/log/clickhouse-server/clickhouse-server.upgrade.log /test_output/clickho
 #       via regex in the secondary pipe below to require the `rdk:FAIL` tag AND the specific connection-refused
 #       message together, so real Kafka regressions (auth, protocol, config) that also emit `rdk:FAIL` are
 #       not masked.
+# `StorageKafka2` + `Exception during get topic partitions from Kafka: Local: Broker transport failure` is
+#       the wrapper-exception variant of the same class of error: the `KafkaConsumer2` background poll loop
+#       (`KafkaConsumer2::getAllTopicPartitionOffsets` -> `cppkafka::HandleException`) keeps polling while the
+#       Redpanda broker is in transition during the upgrade restart sequence and logs `<Error>` for each retry.
+#       Filtered via regex in the secondary pipe below to require both the `StorageKafka2` engine context AND
+#       the `Broker transport failure` symptom together, so real `StorageKafka2` regressions (auth errors,
+#       timeouts, protocol errors, other broker errors) still surface.
 # `No stream (column1_renamedcolumn1.bin) file checksum for column column1_renamed` is the unique signature of
 #       issue #102259 (`getFileNameForRenamedColumnStream` uses `substr(0, N)` instead of `substr(N)`, producing
 #       `<renamed><original>.bin` instead of `<renamed>.bin`). The fix is in PR #102689; until it lands, the
@@ -444,6 +451,7 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
     | grep -av -e "TraceCollector.*CANNOT_READ_FROM_FILE_DESCRIPTOR" \
     | grep -av -e "while loading statistics.*ILLEGAL_STATISTICS" \
     | grep -av -e "rdk:FAIL.*Connect to.*failed: Connection refused" \
+    | grep -av -e "StorageKafka2.*Exception during get topic partitions from Kafka: Local: Broker transport failure" \
     | grep -av -e "wrong_metadata.*Detaching broken part.*backward incompatibility" \
     | grep -av -e "RaftInstance: session.*failed to read rpc header from socket.*due to error" \
     | grep -Fa "<Error>" > /test_output/upgrade_error_messages.txt || true


### PR DESCRIPTION
The `Upgrade check (amd_release)` post-restart `<Error>` scrub catches a chronic shutdown-time log line emitted by `StorageKafka2`'s background `KafkaConsumer2::getAllTopicPartitionOffsets` poll loop when the Redpanda broker is in transition during the upgrade restart sequence:

```
<Error> StorageKafka2 (test_X.`03923_kafka2_keeper_offsets_test_X_kafka` (uuid)): Exception during get topic partitions from Kafka: Local: Broker transport failure
```

The line is produced by `LOG_ERROR` at `KafkaConsumer2.cpp:317` from the `cppkafka::HandleException` catch branch; the only call site is the background poll path in `KeeperHandlingConsumer.cpp:174`. The existing `[rdk:FAIL]`-prefix allowlist filter only matches raw librdkafka tagged log lines and does not cover this wrapper-exception variant.

CIDB confirms this is widespread chronic environmental noise, not a code regression: 38 hits across 38 distinct PRs in the last 14 days (8 / 16 / 14 on 2026-06-02 / 06-03 / 06-04), 0 master hits, 100% on `Upgrade check (amd_release)`, 100% involve `03923_kafka2_keeper_offsets`. The pattern has been visible in CIDB since 2026-03-05 (the test was added on 2026-02-15). Reported on PR #99647 (recent spike since 2026-06-02).

The added regex requires BOTH the `StorageKafka2` engine context AND the `Broker transport failure` symptom together, mirroring the narrowing approach used by the existing `rdk:FAIL.*Connect to.*failed: Connection refused` filter. Real `StorageKafka2` regressions (authentication failures, timeouts, protocol errors, other broker errors raised on this same code path) still surface.

Related: https://github.com/ClickHouse/ClickHouse/pull/99647
Related: https://github.com/ClickHouse/ClickHouse/pull/101576

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Documentation entry for user-facing changes
- [x] Documentation is unchanged.