### PR TITLE
Fix flaky test_cluster_discovery_macros

### DIFF
--- a/tests/integration/test_cluster_discovery/test.py
+++ b/tests/integration/test_cluster_discovery/test.py
@@ -191,6 +191,7 @@ def test_cluster_discovery_macros(start_cluster):
     # single read can flake. Retry (tolerating transient errors) until it converges.
     expected = str(total_nodes)
     res = None
+    last_exception = None
     for _ in range(30):
         try:
             res = nodes["node_observer"].query(
@@ -198,7 +199,9 @@ def test_cluster_discovery_macros(start_cluster):
             ).strip()
             if res == expected:
                 break
-        except Exception:
-            pass
+        except Exception as e:
+            last_exception = e
         time.sleep(2)
-    assert res == expected, f"Wrong macro result: {res}, expected {expected}"
+    assert res == expected, (
+        f"Wrong macro result: {res}, expected {expected}, last exception: {last_exception!r}"
+    )

--- a/tests/integration/test_cluster_discovery/test.py
+++ b/tests/integration/test_cluster_discovery/test.py
@@ -1,4 +1,5 @@
 import functools
+import time
 
 import pytest
 
@@ -183,10 +184,21 @@ def test_cluster_discovery_macros(start_cluster):
         check_on_cluster, what="count()", msg="Wrong nodes count in cluster"
     )
     total_nodes = len(nodes) - 1
-    check_nodes_count([nodes["node_observer"]], total_nodes)
+    check_nodes_count([nodes["node_observer"]], total_nodes, retries=6)
 
-    # check macros
-    res = nodes["node_observer"].query(
-        "SELECT sum(number) FROM clusterAllReplicas('{autocluster}', system.numbers) WHERE number=1"
-    )
-    assert res.strip() == "5"
+    # Poll the distributed query instead of asserting once: it needs every replica
+    # reachable, and the cluster may still be settling when this test starts, so a
+    # single read can flake. Retry (tolerating transient errors) until it converges.
+    expected = str(total_nodes)
+    res = None
+    for _ in range(30):
+        try:
+            res = nodes["node_observer"].query(
+                "SELECT sum(number) FROM clusterAllReplicas('{autocluster}', system.numbers) WHERE number=1"
+            ).strip()
+            if res == expected:
+                break
+        except Exception:
+            pass
+        time.sleep(2)
+    assert res == expected, f"Wrong macro result: {res}, expected {expected}"


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/106114
-->

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

None required (CI Fix or Improvement — flaky integration test stabilization).

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

----

#### Problem

`test_cluster_discovery/test.py::test_cluster_discovery_macros` is flaky: when it starts it can read `0` (or fewer than all) nodes from the observer, or the distributed macro query can transiently fail, and the test fails (e.g. `Wrong nodes count in cluster: {'node_observer': 0}, expected: 5`). The test has a flaky history (`dac342bbfeb Stabilize flapping test for autodiscovery macros`); it was observed again on a flaky CI lane (1 of 3 runs of the same commit).

#### Root cause

The test assumes the discovery cluster is already fully formed:

- the node-count pre-check uses the default `check_on_cluster` budget (`retries=5`, ~30s) and returns on the **first** matching read (a single instant);
- the `clusterAllReplicas('{autocluster}', system.numbers)` macro query — which needs **every** replica reachable — is asserted on a **single** read.

When the cluster is still settling at test start (slow discovery, or a replica briefly unreachable), the count is transiently below the expected value or the distributed query errors / returns the wrong value, so the single read flakes. The earlier `dac342bbfeb` fix added the count pre-check but kept both the single-instant count and the single macro assertion, so the fragility remained.

#### Fix

- Give the node-count pre-check the full retry budget (`retries=6`).
- Poll the macro query (tolerating transient errors) until it converges to the expected value, instead of asserting on a single read. The asserted invariant is unchanged (`sum == total_nodes`).

Test-only change; it only widens the retry budgets and adds a convergence poll, so it cannot weaken the assertion.

