### PR TITLE
Stabilize 02346_text_index_hits test

### DIFF
--- a/tests/queries/0_stateless/02346_text_index_hits.sql
+++ b/tests/queries/0_stateless/02346_text_index_hits.sql
@@ -12,9 +12,12 @@ CREATE TABLE hits_text
     `URL` String
 )
 ENGINE = MergeTree
-ORDER BY (CounterID, EventDate);
+ORDER BY (CounterID, EventDate)
+SETTINGS index_granularity = 8192;
 
 SET use_query_condition_cache = 0;
+SET max_threads = 4;
+SET min_bytes_to_use_direct_io = 10737418240;
 
 ALTER TABLE hits_text ADD INDEX idx_search_phrase SearchPhrase TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 8;
 ALTER TABLE hits_text ADD INDEX idx_url URL TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 8;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix CI failure here: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=0af404d2dbbb280aa74c7fce3450a2629b7579bb&name_0=MasterCI&name_1=Stateless+tests+%28amd_debug%2C+sequential%29&name_2=Tests by stabilizing relevant settings.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.419`
<!-- ch-version-info:end -->