### PR TITLE
Fix `LIMIT` with `TIES` and fractional `LIMIT` with `TIES` ignoring collation

### DIFF
--- a/src/Columns/ColumnConst.h
+++ b/src/Columns/ColumnConst.h
@@ -243,6 +243,11 @@ public:
         return data->compareAt(0, 0, *assert_cast<const ColumnConst &>(rhs).data, nan_direction_hint);
     }
 
+    int compareAtWithCollation(size_t, size_t, const IColumn & rhs, int nan_direction_hint, const Collator & collator) const override
+    {
+        return data->compareAtWithCollation(0, 0, *assert_cast<const ColumnConst &>(rhs).data, nan_direction_hint, collator);
+    }
+
     void compareColumn(const IColumn & rhs, size_t rhs_row_num,
                        PaddedPODArray<UInt64> * row_indexes, PaddedPODArray<Int8> & compare_results,
                        int direction, int nan_direction_hint) const override;

--- a/src/Processors/FractionalLimitTransform.cpp
+++ b/src/Processors/FractionalLimitTransform.cpp
@@ -483,8 +483,22 @@ bool FractionalLimitTransform::sortColumnsEqualAt(const ColumnRawPtrs & current_
     const size_t num_sort_columns = current_chunk_sort_columns.size();
     const auto & ties_last_row_sort_columns = ties_last_row.getColumns();
     for (size_t i = 0; i < num_sort_columns; ++i)
-        if (0 != current_chunk_sort_columns[i]->compareAt(current_chunk_row_num, 0, *ties_last_row_sort_columns[i], 1))
+    {
+        const auto & column = *current_chunk_sort_columns[i];
+        const auto & ties_last_row_column = *ties_last_row_sort_columns[i];
+
+        /// Compare ties using the same collation as ORDER BY, otherwise rows that are equal
+        /// according to the collation (for example '1' and '01' under numeric collation) would
+        /// be treated as distinct and wrongly dropped from the result.
+        int res = 0;
+        if (limit_with_ties_sort_description[i].collator && column.isCollationSupported())
+            res = column.compareAtWithCollation(current_chunk_row_num, 0, ties_last_row_column, 1, *limit_with_ties_sort_description[i].collator);
+        else
+            res = column.compareAt(current_chunk_row_num, 0, ties_last_row_column, 1);
+
+        if (res != 0)
             return false;
+    }
     return true;
 }
 

--- a/src/Processors/LimitTransform.cpp
+++ b/src/Processors/LimitTransform.cpp
@@ -381,8 +381,22 @@ bool LimitTransform::sortColumnsEqualAt(const ColumnRawPtrs & current_chunk_sort
     size_t size = current_chunk_sort_columns.size();
     const auto & previous_row_sort_columns = previous_row_chunk.getColumns();
     for (size_t i = 0; i < size; ++i)
-        if (0 != current_chunk_sort_columns[i]->compareAt(current_chunk_row_num, 0, *previous_row_sort_columns[i], 1))
+    {
+        const auto & column = *current_chunk_sort_columns[i];
+        const auto & previous_column = *previous_row_sort_columns[i];
+
+        /// Compare ties using the same collation as ORDER BY, otherwise rows that are equal
+        /// according to the collation (for example '1' and '01' under numeric collation) would
+        /// be treated as distinct and wrongly dropped from the result.
+        int res = 0;
+        if (description[i].collator && column.isCollationSupported())
+            res = column.compareAtWithCollation(current_chunk_row_num, 0, previous_column, 1, *description[i].collator);
+        else
+            res = column.compareAt(current_chunk_row_num, 0, previous_column, 1);
+
+        if (res != 0)
             return false;
+    }
     return true;
 }
 

--- a/tests/queries/0_stateless/04312_limit_with_ties_collation.reference
+++ b/tests/queries/0_stateless/04312_limit_with_ties_collation.reference
@@ -25,6 +25,6 @@ SELECT x FROM (SELECT x FROM (SELECT arrayJoin(['1', '01', '2', '02', '3', '03']
 02
 2
 -- Negative LIMIT WITH TIES is not supported yet.
-SELECT x FROM (SELECT x FROM (SELECT arrayJoin(['1', '01', '001', '2', '02', '3']) AS x) ORDER BY x COLLATE 'en-u-kn-true' LIMIT -1 WITH TIES) ORDER BY x; -- { serverError NOT_IMPLEMENTED }
-SELECT k, x FROM (SELECT k, x FROM (SELECT arrayJoin([(0, '1'), (0, '01'), (1, '2')]) AS t, t.1 AS k, t.2 AS x) ORDER BY k, x COLLATE 'en-u-kn-true' LIMIT -1 WITH TIES) ORDER BY k, x; -- { serverError NOT_IMPLEMENTED }
+SELECT x FROM (SELECT x FROM (SELECT arrayJoin(['3', '03', '003', '2', '02', '1']) AS x) ORDER BY x COLLATE 'en-u-kn-true' LIMIT -1 WITH TIES) ORDER BY x; -- { serverError NOT_IMPLEMENTED }
+SELECT k, x FROM (SELECT k, x FROM (SELECT arrayJoin([(0, '1'), (1, '3'), (1, '03'), (1, '003')]) AS t, t.1 AS k, t.2 AS x) ORDER BY k, x COLLATE 'en-u-kn-true' LIMIT -1 WITH TIES) ORDER BY k, x; -- { serverError NOT_IMPLEMENTED }
 DROP TABLE test;

--- a/tests/queries/0_stateless/04312_limit_with_ties_collation.reference
+++ b/tests/queries/0_stateless/04312_limit_with_ties_collation.reference
@@ -16,6 +16,10 @@ SELECT x FROM (SELECT x FROM (SELECT arrayJoin(['1', '01', '001', '2', '02', '3'
 SELECT k, x FROM (SELECT k, x FROM (SELECT arrayJoin([(0, '1'), (0, '01'), (1, '2')]) AS t, t.1 AS k, t.2 AS x) ORDER BY k, x COLLATE 'en-u-kn-true' LIMIT 1 WITH TIES) ORDER BY k, x;
 0	01
 0	1
+-- constant collated sort key
+SELECT x FROM (SELECT x FROM test ORDER BY 'k' COLLATE 'en-u-kn-true', x COLLATE 'en-u-kn-true' LIMIT 1 WITH TIES) ORDER BY x;
+01
+1
 -- fractional limit, numeric collation
 SELECT x FROM (SELECT x FROM test ORDER BY x COLLATE 'en-u-kn-true' LIMIT 0.2 WITH TIES) ORDER BY x;
 01
@@ -24,7 +28,12 @@ SELECT x FROM (SELECT x FROM test ORDER BY x COLLATE 'en-u-kn-true' LIMIT 0.2 WI
 SELECT x FROM (SELECT x FROM (SELECT arrayJoin(['1', '01', '2', '02', '3', '03']) AS x) ORDER BY x COLLATE 'en-u-kn-true' LIMIT 2, 0.2 WITH TIES) ORDER BY x;
 02
 2
+-- fractional limit, constant collated sort key
+SELECT x FROM (SELECT x FROM test ORDER BY 'k' COLLATE 'en-u-kn-true', x COLLATE 'en-u-kn-true' LIMIT 0.2 WITH TIES) ORDER BY x;
+01
+1
 -- Negative LIMIT WITH TIES is not supported yet.
 SELECT x FROM (SELECT x FROM (SELECT arrayJoin(['3', '03', '003', '2', '02', '1']) AS x) ORDER BY x COLLATE 'en-u-kn-true' LIMIT -1 WITH TIES) ORDER BY x; -- { serverError NOT_IMPLEMENTED }
 SELECT k, x FROM (SELECT k, x FROM (SELECT arrayJoin([(0, '1'), (1, '3'), (1, '03'), (1, '003')]) AS t, t.1 AS k, t.2 AS x) ORDER BY k, x COLLATE 'en-u-kn-true' LIMIT -1 WITH TIES) ORDER BY k, x; -- { serverError NOT_IMPLEMENTED }
+SELECT x FROM (SELECT x FROM test ORDER BY 'k' COLLATE 'en-u-kn-true', x COLLATE 'en-u-kn-true' LIMIT -1 WITH TIES) ORDER BY x; -- { serverError NOT_IMPLEMENTED }
 DROP TABLE test;

--- a/tests/queries/0_stateless/04312_limit_with_ties_collation.reference
+++ b/tests/queries/0_stateless/04312_limit_with_ties_collation.reference
@@ -1,0 +1,30 @@
+-- { echo }
+
+DROP TABLE IF EXISTS test;
+CREATE TABLE test (x String) ENGINE = Memory;
+INSERT INTO test VALUES ('1'), ('01'), ('2'), ('10'), ('9');
+-- numeric collation, single sort column
+SELECT x FROM (SELECT x FROM test ORDER BY x COLLATE 'en-u-kn-true' LIMIT 1 WITH TIES) ORDER BY x;
+01
+1
+-- numeric collation, larger tie group
+SELECT x FROM (SELECT x FROM (SELECT arrayJoin(['1', '01', '001', '2', '02', '3']) AS x) ORDER BY x COLLATE 'en-u-kn-true' LIMIT 1 WITH TIES) ORDER BY x;
+001
+01
+1
+-- collation as a secondary sort key
+SELECT k, x FROM (SELECT k, x FROM (SELECT arrayJoin([(0, '1'), (0, '01'), (1, '2')]) AS t, t.1 AS k, t.2 AS x) ORDER BY k, x COLLATE 'en-u-kn-true' LIMIT 1 WITH TIES) ORDER BY k, x;
+0	01
+0	1
+-- fractional limit, numeric collation
+SELECT x FROM (SELECT x FROM test ORDER BY x COLLATE 'en-u-kn-true' LIMIT 0.2 WITH TIES) ORDER BY x;
+01
+1
+-- fractional limit with offset, numeric collation
+SELECT x FROM (SELECT x FROM (SELECT arrayJoin(['1', '01', '2', '02', '3', '03']) AS x) ORDER BY x COLLATE 'en-u-kn-true' LIMIT 2, 0.2 WITH TIES) ORDER BY x;
+02
+2
+-- Negative LIMIT WITH TIES is not supported yet.
+SELECT x FROM (SELECT x FROM (SELECT arrayJoin(['1', '01', '001', '2', '02', '3']) AS x) ORDER BY x COLLATE 'en-u-kn-true' LIMIT -1 WITH TIES) ORDER BY x; -- { serverError NOT_IMPLEMENTED }
+SELECT k, x FROM (SELECT k, x FROM (SELECT arrayJoin([(0, '1'), (0, '01'), (1, '2')]) AS t, t.1 AS k, t.2 AS x) ORDER BY k, x COLLATE 'en-u-kn-true' LIMIT -1 WITH TIES) ORDER BY k, x; -- { serverError NOT_IMPLEMENTED }
+DROP TABLE test;

--- a/tests/queries/0_stateless/04312_limit_with_ties_collation.sql
+++ b/tests/queries/0_stateless/04312_limit_with_ties_collation.sql
@@ -1,0 +1,30 @@
+-- Tags: no-fasttest
+-- no-fasttest: requires ICU for collation support.
+
+-- { echo }
+
+DROP TABLE IF EXISTS test;
+CREATE TABLE test (x String) ENGINE = Memory;
+INSERT INTO test VALUES ('1'), ('01'), ('2'), ('10'), ('9');
+
+-- numeric collation, single sort column
+SELECT x FROM (SELECT x FROM test ORDER BY x COLLATE 'en-u-kn-true' LIMIT 1 WITH TIES) ORDER BY x;
+
+-- numeric collation, larger tie group
+SELECT x FROM (SELECT x FROM (SELECT arrayJoin(['1', '01', '001', '2', '02', '3']) AS x) ORDER BY x COLLATE 'en-u-kn-true' LIMIT 1 WITH TIES) ORDER BY x;
+
+-- collation as a secondary sort key
+SELECT k, x FROM (SELECT k, x FROM (SELECT arrayJoin([(0, '1'), (0, '01'), (1, '2')]) AS t, t.1 AS k, t.2 AS x) ORDER BY k, x COLLATE 'en-u-kn-true' LIMIT 1 WITH TIES) ORDER BY k, x;
+
+-- fractional limit, numeric collation
+SELECT x FROM (SELECT x FROM test ORDER BY x COLLATE 'en-u-kn-true' LIMIT 0.2 WITH TIES) ORDER BY x;
+
+-- fractional limit with offset, numeric collation
+SELECT x FROM (SELECT x FROM (SELECT arrayJoin(['1', '01', '2', '02', '3', '03']) AS x) ORDER BY x COLLATE 'en-u-kn-true' LIMIT 2, 0.2 WITH TIES) ORDER BY x;
+
+-- Negative LIMIT WITH TIES is not supported yet.
+SELECT x FROM (SELECT x FROM (SELECT arrayJoin(['1', '01', '001', '2', '02', '3']) AS x) ORDER BY x COLLATE 'en-u-kn-true' LIMIT -1 WITH TIES) ORDER BY x; -- { serverError NOT_IMPLEMENTED }
+
+SELECT k, x FROM (SELECT k, x FROM (SELECT arrayJoin([(0, '1'), (0, '01'), (1, '2')]) AS t, t.1 AS k, t.2 AS x) ORDER BY k, x COLLATE 'en-u-kn-true' LIMIT -1 WITH TIES) ORDER BY k, x; -- { serverError NOT_IMPLEMENTED }
+
+DROP TABLE test;

--- a/tests/queries/0_stateless/04312_limit_with_ties_collation.sql
+++ b/tests/queries/0_stateless/04312_limit_with_ties_collation.sql
@@ -16,15 +16,23 @@ SELECT x FROM (SELECT x FROM (SELECT arrayJoin(['1', '01', '001', '2', '02', '3'
 -- collation as a secondary sort key
 SELECT k, x FROM (SELECT k, x FROM (SELECT arrayJoin([(0, '1'), (0, '01'), (1, '2')]) AS t, t.1 AS k, t.2 AS x) ORDER BY k, x COLLATE 'en-u-kn-true' LIMIT 1 WITH TIES) ORDER BY k, x;
 
+-- constant collated sort key
+SELECT x FROM (SELECT x FROM test ORDER BY 'k' COLLATE 'en-u-kn-true', x COLLATE 'en-u-kn-true' LIMIT 1 WITH TIES) ORDER BY x;
+
 -- fractional limit, numeric collation
 SELECT x FROM (SELECT x FROM test ORDER BY x COLLATE 'en-u-kn-true' LIMIT 0.2 WITH TIES) ORDER BY x;
 
 -- fractional limit with offset, numeric collation
 SELECT x FROM (SELECT x FROM (SELECT arrayJoin(['1', '01', '2', '02', '3', '03']) AS x) ORDER BY x COLLATE 'en-u-kn-true' LIMIT 2, 0.2 WITH TIES) ORDER BY x;
 
+-- fractional limit, constant collated sort key
+SELECT x FROM (SELECT x FROM test ORDER BY 'k' COLLATE 'en-u-kn-true', x COLLATE 'en-u-kn-true' LIMIT 0.2 WITH TIES) ORDER BY x;
+
 -- Negative LIMIT WITH TIES is not supported yet.
 SELECT x FROM (SELECT x FROM (SELECT arrayJoin(['3', '03', '003', '2', '02', '1']) AS x) ORDER BY x COLLATE 'en-u-kn-true' LIMIT -1 WITH TIES) ORDER BY x; -- { serverError NOT_IMPLEMENTED }
 
 SELECT k, x FROM (SELECT k, x FROM (SELECT arrayJoin([(0, '1'), (1, '3'), (1, '03'), (1, '003')]) AS t, t.1 AS k, t.2 AS x) ORDER BY k, x COLLATE 'en-u-kn-true' LIMIT -1 WITH TIES) ORDER BY k, x; -- { serverError NOT_IMPLEMENTED }
+
+SELECT x FROM (SELECT x FROM test ORDER BY 'k' COLLATE 'en-u-kn-true', x COLLATE 'en-u-kn-true' LIMIT -1 WITH TIES) ORDER BY x; -- { serverError NOT_IMPLEMENTED }
 
 DROP TABLE test;

--- a/tests/queries/0_stateless/04312_limit_with_ties_collation.sql
+++ b/tests/queries/0_stateless/04312_limit_with_ties_collation.sql
@@ -23,8 +23,8 @@ SELECT x FROM (SELECT x FROM test ORDER BY x COLLATE 'en-u-kn-true' LIMIT 0.2 WI
 SELECT x FROM (SELECT x FROM (SELECT arrayJoin(['1', '01', '2', '02', '3', '03']) AS x) ORDER BY x COLLATE 'en-u-kn-true' LIMIT 2, 0.2 WITH TIES) ORDER BY x;
 
 -- Negative LIMIT WITH TIES is not supported yet.
-SELECT x FROM (SELECT x FROM (SELECT arrayJoin(['1', '01', '001', '2', '02', '3']) AS x) ORDER BY x COLLATE 'en-u-kn-true' LIMIT -1 WITH TIES) ORDER BY x; -- { serverError NOT_IMPLEMENTED }
+SELECT x FROM (SELECT x FROM (SELECT arrayJoin(['3', '03', '003', '2', '02', '1']) AS x) ORDER BY x COLLATE 'en-u-kn-true' LIMIT -1 WITH TIES) ORDER BY x; -- { serverError NOT_IMPLEMENTED }
 
-SELECT k, x FROM (SELECT k, x FROM (SELECT arrayJoin([(0, '1'), (0, '01'), (1, '2')]) AS t, t.1 AS k, t.2 AS x) ORDER BY k, x COLLATE 'en-u-kn-true' LIMIT -1 WITH TIES) ORDER BY k, x; -- { serverError NOT_IMPLEMENTED }
+SELECT k, x FROM (SELECT k, x FROM (SELECT arrayJoin([(0, '1'), (1, '3'), (1, '03'), (1, '003')]) AS t, t.1 AS k, t.2 AS x) ORDER BY k, x COLLATE 'en-u-kn-true' LIMIT -1 WITH TIES) ORDER BY k, x; -- { serverError NOT_IMPLEMENTED }
 
 DROP TABLE test;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

`LIMIT with TIES`:

```sql
SELECT x FROM (SELECT arrayJoin(['1', '01', '001', '2', '02', '3']) AS x) ORDER BY x COLLATE 'en-u-kn-true' LIMIT 1 WITH TIES;

-- returns 1 but should be 1, 01, 001
```

Fractional `LIMIT` with `TIES`:

```sql
SELECT x FROM (SELECT arrayJoin(['1', '01', '001', '2', '02', '3']) AS x) ORDER BY x COLLATE 'en-u-kn-true' LIMIT 0.1 WITH TIES; 

-- returns 1 but should be 1, 01, 001
```

Related
- https://github.com/ClickHouse/ClickHouse/pull/100930

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `LIMIT WITH TIES` and fractional `LIMIT WITH TIES` not respecting the collation from `ORDER BY ... COLLATE` when determining ties. Rows that are equal according to the collation (for example `'1'` and `'01'` under numeric collation) were compared byte-wise, so some tied rows were wrongly dropped from the result.
