### PR TITLE
Docs: add missing format docs

### DIFF
--- a/docs/en/interfaces/formats/Arrow/Arrow.md
+++ b/docs/en/interfaces/formats/Arrow/Arrow.md
@@ -15,8 +15,9 @@ doc_type: 'reference'
 
 ## Description {#description}
 
-[Apache Arrow](https://arrow.apache.org/) comes with two built-in columnar storage formats. ClickHouse supports read and write operations for these formats.
-`Arrow` is Apache Arrow's "file mode" format. It is designed for in-memory random access.
+[Apache Arrow](https://arrow.apache.org/) comes with two built-in columnar storage formats.
+ClickHouse supports read and write operations for these formats.
+`Arrow` is Apache Arrow's "file mode" format, designed for in-memory random access.
 
 ## Data types matching {#data-types-matching}
 
@@ -65,20 +66,66 @@ The data types of ClickHouse table columns do not have to match the correspondin
 
 ## Example usage {#example-usage}
 
-### Inserting data {#inserting-data}
-
-You can insert Arrow data from a file into ClickHouse table using the following command:
-
-```bash
-$ cat filename.arrow | clickhouse-client --query="INSERT INTO some_table FORMAT Arrow"
-```
+In the example below we use the `forex` dataset available in the
+[ClickHouse SQL playground](https://sql.clickhouse.com).
 
 ### Selecting data {#selecting-data}
 
-You can select data from a ClickHouse table and save it into some file in the Arrow format using the following command:
+We select one day of `EUR/USD` exchange rates from the playground and save it
+into a local `forex_eurusd.arrow` file. We query the playground over the HTTP
+interface, where the host is `sql-clickhouse.clickhouse.com` and the user is
+`demo` (which has no password):
 
 ```bash
-$ clickhouse-client --query="SELECT * FROM {some_table} FORMAT Arrow" > {filename.arrow}
+curl "https://sql-clickhouse.clickhouse.com:8443/?user=demo&database=forex" \
+    --data-binary "
+        SELECT
+            concat(base, '.', quote) AS base_quote,
+            datetime AS last_update,
+            CAST(bid, 'Float32') AS bid,
+            CAST(ask, 'Float32') AS ask,
+            ask - bid AS spread
+        FROM forex
+        WHERE base = 'EUR' AND quote = 'USD'
+            AND datetime >= '2020-01-01' AND datetime < '2020-01-02'
+        ORDER BY datetime ASC
+        FORMAT Arrow
+        SETTINGS output_format_arrow_compression_method='zstd'" > forex_eurusd.arrow
+```
+
+### Reading the file back {#reading-data}
+
+We can now read the local Arrow file back with
+[`clickhouse-local`](/operations/utilities/clickhouse-local) using the
+[`file`](/sql-reference/table-functions/file) table function. The file is
+self-describing, so the `Arrow` format infers the schema automatically:
+
+```bash
+clickhouse-local --query "
+    SELECT *
+    FROM file('forex_eurusd.arrow', Arrow)
+    ORDER BY last_update ASC
+    LIMIT 5
+    FORMAT PrettyCompact"
+```
+
+```response title="Response"
+   ┌─base_quote─┬─────────────last_update─┬─────bid─┬─────ask─┬────────────────spread─┐
+1. │ EUR.USD    │ 2020-01-01 17:00:00.065 │  1.1212 │ 1.12172 │ 0.0005199909210205078 │
+2. │ EUR.USD    │ 2020-01-01 17:00:10.447 │  1.1212 │ 1.12192 │ 0.0007200241088867188 │
+3. │ EUR.USD    │ 2020-01-01 17:00:10.498 │ 1.12117 │ 1.12161 │ 0.0004400014877319336 │
+4. │ EUR.USD    │ 2020-01-01 17:00:12.579 │  1.1212 │ 1.12161 │ 0.0004100799560546875 │
+5. │ EUR.USD    │ 2020-01-01 17:00:12.630 │  1.1212 │ 1.12172 │ 0.0005199909210205078 │
+   └────────────┴─────────────────────────┴─────────┴─────────┴───────────────────────┘
+```
+
+### Inserting data {#inserting-data}
+
+To load an Arrow file into a ClickHouse table, pipe it into `clickhouse-client`
+with `FORMAT Arrow`:
+
+```bash
+cat forex_eurusd.arrow | clickhouse-client --query="INSERT INTO some_table FORMAT Arrow"
 ```
 
 ## Format settings {#format-settings}

--- a/docs/en/interfaces/formats/Arrow/ArrowStream.md
+++ b/docs/en/interfaces/formats/Arrow/ArrowStream.md
@@ -66,7 +66,9 @@ The `ArrowStream` output is raw binary, so rather than printing it to the
 terminal we pipe it into a consumer. The stream is self-describing (it carries
 its own schema), so here we pipe it straight into
 [`clickhouse-local`](/operations/utilities/clickhouse-local), which reads the
-incoming batches with `--input-format ArrowStream` and queries them as a table:
+incoming batches with `--input-format ArrowStream` and queries them as a table.
+The `forex` table is large, so we bound the remote query with a `WHERE`
+predicate and a `LIMIT` to keep this example small:
 
 ```bash
 curl "https://sql-clickhouse.clickhouse.com:8443/?user=demo&database=forex" \
@@ -78,11 +80,13 @@ curl "https://sql-clickhouse.clickhouse.com:8443/?user=demo&database=forex" \
             CAST(ask, 'Float32') AS ask,
             ask - bid AS spread
         FROM forex
+        WHERE base = 'USD' AND quote = 'CHF'
         ORDER BY datetime ASC
+        LIMIT 5
         FORMAT ArrowStream
         SETTINGS output_format_arrow_compression_method='none'" \
   | clickhouse-local --input-format ArrowStream \
-      --query "SELECT * FROM table ORDER BY last_update ASC LIMIT 5 FORMAT PrettyCompact"
+      --query "SELECT * FROM table ORDER BY last_update ASC FORMAT PrettyCompact"
 ```
 
 ```response title="Response"

--- a/docs/en/interfaces/formats/Arrow/ArrowStream.md
+++ b/docs/en/interfaces/formats/Arrow/ArrowStream.md
@@ -19,4 +19,119 @@ doc_type: 'reference'
 
 ## Example usage {#example-usage}
 
+In the example below we use the `forex` dataset which is available in the
+[ClickHouse SQL playground](https://sql.clickhouse.com). You can connect to it
+remotely with `clickhouse-client` using the host `sql-clickhouse.clickhouse.com`
+and the user `demo` (which has no password). The `forex` table lives in the
+`forex` database, so we select it as the default database:
+
+```bash
+clickhouse-client --secure --host sql-clickhouse.clickhouse.com --user demo --database forex
+```
+
+The `forex` table stores currency exchange rates. We can inspect its size and
+how well it compresses on disk by querying [`system.columns`](/operations/system-tables/columns):
+
+```sql title="Query"
+SELECT
+    table,
+    formatReadableSize(sum(data_compressed_bytes)) AS compressed_size,
+    formatReadableSize(sum(data_uncompressed_bytes)) AS uncompressed_size,
+    sum(data_compressed_bytes) / sum(data_uncompressed_bytes) AS compression_ratio
+FROM system.columns
+WHERE (database = 'forex') AND (table = 'forex')
+GROUP BY table
+ORDER BY table ASC
+```
+
+```response title="Response"
+   ┌─table─┬─compressed_size─┬─uncompressed_size─┬───compression_ratio─┐
+1. │ forex │ 63.69 GiB       │ 280.48 GiB        │ 0.22708227109363446 │
+   └───────┴─────────────────┴───────────────────┴─────────────────────┘
+```
+
+Unlike the [`Arrow`](/interfaces/formats/Arrow) "file mode" format, which
+requires the whole result before it can be read, `ArrowStream` is delivered as a
+sequence of record batches that a consumer can read incrementally as they
+arrive. This makes it well suited to streaming a query result straight into a
+visualization or analytics tool without first materializing the entire dataset.
+
+To stream the result, send the query over ClickHouse's HTTP interface with a
+`POST` request and read the response as an Arrow stream. We disable compression
+of the Arrow output via the
+[`output_format_arrow_compression_method`](/operations/settings/formats#output_format_arrow_compression_method)
+setting so that consumers can decode batches directly as they are received.
+
+The `ArrowStream` output is raw binary, so rather than printing it to the
+terminal we pipe it into a consumer. The stream is self-describing (it carries
+its own schema), so here we pipe it straight into
+[`clickhouse-local`](/operations/utilities/clickhouse-local), which reads the
+incoming batches with `--input-format ArrowStream` and queries them as a table:
+
+```bash
+curl "https://sql-clickhouse.clickhouse.com:8443/?user=demo&database=forex" \
+    --data-binary "
+        SELECT
+            concat(base, '.', quote) AS base_quote,
+            datetime AS last_update,
+            CAST(bid, 'Float32') AS bid,
+            CAST(ask, 'Float32') AS ask,
+            ask - bid AS spread
+        FROM forex
+        ORDER BY datetime ASC
+        FORMAT ArrowStream
+        SETTINGS output_format_arrow_compression_method='none'" \
+  | clickhouse-local --input-format ArrowStream \
+      --query "SELECT * FROM table ORDER BY last_update ASC LIMIT 5 FORMAT PrettyCompact"
+```
+
+```response title="Response"
+   ┌─base_quote─┬─────────────last_update─┬────bid─┬────ask─┬────────────────spread─┐
+1. │ USD.CHF    │ 2000-05-30 17:23:44.000 │  1.688 │ 1.6885 │ 0.0005000829696655273 │
+2. │ USD.CHF    │ 2000-05-30 17:23:46.000 │ 1.6885 │  1.689 │ 0.0004999637603759766 │
+3. │ USD.CHF    │ 2000-05-30 17:23:48.000 │ 1.6886 │ 1.6891 │ 0.0005000829696655273 │
+4. │ USD.CHF    │ 2000-05-30 17:23:49.000 │ 1.6888 │ 1.6893 │ 0.0004999637603759766 │
+5. │ USD.CHF    │ 2000-05-30 17:24:45.000 │  1.689 │ 1.6895 │ 0.0004999637603759766 │
+   └────────────┴─────────────────────────┴────────┴────────┴───────────────────────┘
+```
+
+The same stream can be consumed incrementally by any Arrow-aware client, which
+reads it batch-by-batch rather than buffering the result in full. For example,
+using the [Apache Arrow JavaScript library](https://arrow.apache.org/docs/js/), a
+`RecordBatchReader` yields each record batch as soon as it is streamed from the
+server:
+
+```js
+const reader = await RecordBatchReader.from(response);
+await reader.open();
+for await (const recordBatch of reader) {
+    const batchTable = new Table(recordBatch);
+    const ipcStream = tableToIPC(batchTable, 'stream');
+    const bytes = new Uint8Array(ipcStream);
+    table.update(bytes);
+}
+```
+
+For a full walkthrough of streaming `ArrowStream` data from ClickHouse into a
+real-time visualization with [Perspective](https://perspective.finos.org/), see
+the blog post
+[Streaming real-time visualizations with ClickHouse, Apache Arrow and Perspective](https://clickhouse.com/blog/streaming-real-time-visualizations-clickhouse-apache-arrow-perpsective).
+
 ## Format settings {#format-settings}
+
+`ArrowStream` shares the same format settings as the [`Arrow`](/interfaces/formats/Arrow) format.
+
+| Setting                                                                      | Description                                                                                                                                | Default     |
+|------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+| `input_format_arrow_allow_missing_columns`                                   | Allow missing columns while reading Arrow input formats                                                                                    | `1`         |
+| `input_format_arrow_case_insensitive_column_matching`                        | Ignore case when matching Arrow columns with CH columns.                                                                                   | `0`         |
+| `input_format_arrow_import_nested`                                           | Obsolete setting, does nothing.                                                                                                            | `0`         |
+| `input_format_arrow_skip_columns_with_unsupported_types_in_schema_inference` | Skip columns with unsupported types while schema inference for format Arrow                                                                | `0`         |
+| `output_format_arrow_compression_method`                                     | Compression method for Arrow output format. Supported codecs: lz4_frame, zstd, none (uncompressed)                                         | `lz4_frame` |
+| `output_format_arrow_date_as_uint16`                                         | Write Date values as plain 16-bit numbers (read back as UInt16), instead of converting to a 32-bit Arrow DATE32 type (read back as Date32). | `0`         |
+| `output_format_arrow_fixed_string_as_fixed_byte_array`                       | Use Arrow FIXED_SIZE_BINARY type instead of Binary for FixedString columns.                                                                | `1`         |
+| `output_format_arrow_low_cardinality_as_dictionary`                          | Enable output LowCardinality type as Dictionary Arrow type                                                                                 | `0`         |
+| `output_format_arrow_string_as_string`                                       | Use Arrow String type instead of Binary for String columns                                                                                 | `1`         |
+| `output_format_arrow_unsupported_types_as_binary`                            | Output types having no conversion as raw binary data. If false - such types would raise UNKNOWN_TYPE exception.                             | `1`         |
+| `output_format_arrow_use_64_bit_indexes_for_dictionary`                      | Always use 64 bit integers for dictionary indexes in Arrow format                                                                          | `0`         |
+| `output_format_arrow_use_signed_indexes_for_dictionary`                      | Use signed integers for dictionary indexes in Arrow format                                                                                 | `1`         |

--- a/docs/en/interfaces/formats/HiveText.md
+++ b/docs/en/interfaces/formats/HiveText.md
@@ -17,12 +17,9 @@ doc_type: 'reference'
 
 `HiveText` reads the text serialization format used by [Apache Hive](https://hive.apache.org/)
 tables (the format produced by Hive's `LazySimpleSerDe`). It is a delimited text
-format, similar to [`CSV`](/interfaces/formats/CSV), but with the
-non-printable delimiters Hive uses by default:
-
-- fields are separated by `\x01` (Ctrl-A),
-- items of a collection (an array or a map) are separated by `\x02`,
-- key/value pairs of a map are separated by `\x03`.
+format, similar to [`CSV`](/interfaces/formats/CSV), in which fields are
+separated by the Hive default `\x01` (Ctrl-A) delimiter. The field delimiter is
+configurable via [`input_format_hive_text_fields_delimiter`](#format-settings).
 
 `HiveText` is an input-only format. The data has no header row: values are
 mapped positionally onto the columns of the destination table, so the column
@@ -31,6 +28,18 @@ structure) rather than inferred from the data. While reading, ClickHouse parses
 dates and times in best-effort mode (see [`date_time_input_format`](/operations/settings/settings-formats#date_time_input_format)),
 fills omitted trailing fields with column defaults, and skips fields it does not
 recognize.
+
+Within a field, values are parsed using the same escaping rules as `CSV` rather
+than Hive's nested delimiters. In particular, a column of type
+[`Array`](/sql-reference/data-types/array) is read from the bracketed
+representation (for example, `"['a','b','c']"`), not from values separated by
+the Hive collection delimiter `\x02`.
+
+:::note Nested delimiter settings have no effect
+The [`input_format_hive_text_collection_items_delimiter`](#format-settings) and
+[`input_format_hive_text_map_keys_delimiter`](#format-settings) settings are
+accepted for compatibility but are currently not used during parsing.
+:::
 
 By default, rows are allowed to have a variable number of fields (see
 [`input_format_hive_text_allow_variable_number_of_columns`](#format-settings)):
@@ -112,6 +121,6 @@ a parsing exception.
 | Setting                                                | Description                                                                                                                           | Default |
 |--------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|---------|
 | `input_format_hive_text_fields_delimiter`              | Delimiter between fields in Hive Text File                                                                                             | `\x01`  |
-| `input_format_hive_text_collection_items_delimiter`    | Delimiter between collection (array or map) items in Hive Text File                                                                    | `\x02`  |
-| `input_format_hive_text_map_keys_delimiter`            | Delimiter between a pair of map key/values in Hive Text File                                                                           | `\x03`  |
+| `input_format_hive_text_collection_items_delimiter`    | Delimiter between collection (array or map) items in Hive Text File. Accepted but currently not used during parsing.                   | `\x02`  |
+| `input_format_hive_text_map_keys_delimiter`            | Delimiter between a pair of map key/values in Hive Text File. Accepted but currently not used during parsing.                          | `\x03`  |
 | `input_format_hive_text_allow_variable_number_of_columns` | Ignore extra columns in Hive Text input (if file has more columns than expected) and treat missing fields as default values        | `1`     |

--- a/docs/en/interfaces/formats/HiveText.md
+++ b/docs/en/interfaces/formats/HiveText.md
@@ -25,7 +25,7 @@ configurable via [`input_format_hive_text_fields_delimiter`](#format-settings).
 mapped positionally onto the columns of the destination table, so the column
 names and types are taken from the table (or from an explicitly provided
 structure) rather than inferred from the data. While reading, ClickHouse parses
-dates and times in best-effort mode (see [`date_time_input_format`](/operations/settings/settings-formats#date_time_input_format)),
+dates and times in best-effort mode (see [`date_time_input_format`](/operations/settings/formats#date_time_input_format)),
 fills omitted trailing fields with column defaults, and skips fields it does not
 recognize.
 

--- a/docs/en/interfaces/formats/HiveText.md
+++ b/docs/en/interfaces/formats/HiveText.md
@@ -1,13 +1,117 @@
 ---
+alias: []
 description: 'Documentation for the HiveText format'
+input_format: true
 keywords: ['HiveText']
+output_format: false
 slug: /interfaces/formats/HiveText
 title: 'HiveText'
 doc_type: 'reference'
 ---
 
+| Input | Output | Alias |
+|-------|--------|-------|
+| ✔     | ✗      |       |
+
 ## Description {#description}
+
+`HiveText` reads the text serialization format used by [Apache Hive](https://hive.apache.org/)
+tables (the format produced by Hive's `LazySimpleSerDe`). It is a delimited text
+format, similar to [`CSV`](/interfaces/formats/CSV), but with the
+non-printable delimiters Hive uses by default:
+
+- fields are separated by `\x01` (Ctrl-A),
+- items of a collection (an array or a map) are separated by `\x02`,
+- key/value pairs of a map are separated by `\x03`.
+
+`HiveText` is an input-only format. The data has no header row: values are
+mapped positionally onto the columns of the destination table, so the column
+names and types are taken from the table (or from an explicitly provided
+structure) rather than inferred from the data. While reading, ClickHouse parses
+dates and times in best-effort mode (see [`date_time_input_format`](/operations/settings/settings-formats#date_time_input_format)),
+fills omitted trailing fields with column defaults, and skips fields it does not
+recognize.
+
+By default, rows are allowed to have a variable number of fields (see
+[`input_format_hive_text_allow_variable_number_of_columns`](#format-settings)):
+rows with fewer fields than the table have the missing columns filled with
+default values, and rows with extra trailing fields have the extras skipped.
 
 ## Example usage {#example-usage}
 
+The examples below override the default field delimiter with a comma (`,`) using
+[`input_format_hive_text_fields_delimiter`](#format-settings) so that the input
+files are easy to read.
+
+### Reading a HiveText file {#reading-data}
+
+Given a file `hive_data.txt` with comma-separated fields:
+
+```text title="hive_data.txt"
+1,3
+3,5,9
+```
+
+We create a table that defines the column names and types, and insert the file
+into it with `FORMAT HiveText`:
+
+```sql title="Query"
+CREATE TABLE test_tbl (a UInt16, b UInt32, c UInt32) ENGINE = MergeTree ORDER BY a;
+
+INSERT INTO test_tbl FROM INFILE 'hive_data.txt'
+SETTINGS input_format_hive_text_fields_delimiter = ','
+FORMAT HiveText;
+
+SELECT * FROM test_tbl;
+```
+
+```response title="Response"
+┌─a─┬─b─┬─c─┐
+│ 1 │ 3 │ 0 │
+│ 3 │ 5 │ 9 │
+└───┴───┴───┘
+```
+
+Note that the first row, `1,3`, has only two fields, so the missing column `c`
+is filled with its default value `0`.
+
+### Variable number of columns {#variable-number-of-columns}
+
+With the default `input_format_hive_text_allow_variable_number_of_columns = 1`,
+rows that have more fields than the table simply have the extra trailing fields
+skipped:
+
+```text title="hive_extras.txt"
+1,2,3,4,5
+6,7,8
+```
+
+```sql title="Query"
+CREATE TABLE test_extras (a UInt16, b UInt32, c UInt32) ENGINE = MergeTree ORDER BY a;
+
+INSERT INTO test_extras FROM INFILE 'hive_extras.txt'
+SETTINGS input_format_hive_text_fields_delimiter = ','
+FORMAT HiveText;
+
+SELECT * FROM test_extras ORDER BY a;
+```
+
+```response title="Response"
+┌─a─┬─b─┬─c─┐
+│ 1 │ 2 │ 3 │
+│ 6 │ 7 │ 8 │
+└───┴───┴───┘
+```
+
+Setting `input_format_hive_text_allow_variable_number_of_columns = 0` instead
+enforces a strict field count, and a row with fewer fields than the table raises
+a parsing exception.
+
 ## Format settings {#format-settings}
+
+| Setting                                                | Description                                                                                                                           | Default |
+|--------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `input_format_hive_text_fields_delimiter`              | Delimiter between fields in Hive Text File                                                                                             | `\x01`  |
+| `input_format_hive_text_collection_items_delimiter`    | Delimiter between collection (array or map) items in Hive Text File                                                                    | `\x02`  |
+| `input_format_hive_text_map_keys_delimiter`            | Delimiter between a pair of map key/values in Hive Text File                                                                           | `\x03`  |
+| `input_format_hive_text_allow_variable_number_of_columns` | Ignore extra columns in Hive Text input (if file has more columns than expected) and treat missing fields as default values        | `1`     |

--- a/docs/en/interfaces/formats/Values.md
+++ b/docs/en/interfaces/formats/Values.md
@@ -35,6 +35,66 @@ This is the format that is used in `INSERT INTO t VALUES ...`, but you can also 
 
 ## Example usage {#example-usage}
 
+### Inserting data {#inserting-data}
+
+The `Values` format is what `INSERT` uses, so any `INSERT ... VALUES` statement
+is already using it. The `FORMAT Values` clause can be stated explicitly, and the
+rows can be supplied from a stream or a file. Each row is a bracketed,
+comma-separated tuple, with the tuples themselves separated by commas:
+
+```sql title="Query"
+CREATE TABLE t (id UInt32, name String, values Array(UInt32)) ENGINE = Memory;
+
+INSERT INTO t FORMAT Values (1, 'a', [10, 20]), (2, 'b', [30]);
+
+SELECT * FROM t ORDER BY id;
+```
+
+```response title="Response"
+┌─id─┬─name─┬─values──┐
+│  1 │ a    │ [10,20] │
+│  2 │ b    │ [30]    │
+└────┴──────┴─────────┘
+```
+
+### Using expressions on input {#using-expressions}
+
+Unlike most input formats, `Values` can evaluate SQL expressions in each field
+rather than only accepting literals. This is controlled by
+[`input_format_values_interpret_expressions`](#format-settings) (enabled by
+default): when a field cannot be read by the fast streaming parser, ClickHouse
+falls back to the SQL parser and interprets the field as an expression.
+
+```sql title="Query"
+CREATE TABLE prices (item String, total UInt32) ENGINE = Memory;
+
+INSERT INTO prices FORMAT Values ('apple', 3 * 4), ('pear', length('hello') + 10);
+
+SELECT * FROM prices ORDER BY total;
+```
+
+```response title="Response"
+┌─item──┬─total─┐
+│ apple │    12 │
+│ pear  │    15 │
+└───────┴───────┘
+```
+
+### Selecting data {#selecting-data}
+
+The `Values` format can also be used to format query results. Numbers are
+written without quotes, arrays in `[]`, and strings and dates in single quotes;
+single quotes and backslashes inside strings are escaped with a backslash, and
+[`NULL`](/sql-reference/syntax.md) is written as `NULL`:
+
+```sql title="Query"
+SELECT 1 AS a, 'O''Reilly' AS b, NULL::Nullable(String) AS c FORMAT Values;
+```
+
+```response title="Response"
+(1,'O\'Reilly',NULL)
+```
+
 ## Format settings {#format-settings}
 
 | Setting                                                                                                                                                     | Description                                                                                                                                                                                   | Default |


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->
Adds documentation for the following formats:
- `Arrow` (example updated)
- `ArrowStream`
- `HiveText`
- Values (example missing)

### Changelog category (leave one):
- Documentation (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.559`
<!-- ch-version-info:end -->