### PR TITLE
Add test: Non-`Array` sibling column skip in `tryResolveIdentifierAsNestedPrefix` is untested

### DIFF
--- a/tests/queries/0_stateless/04316_array_join_nested_prefix_non_array_sibling.reference
+++ b/tests/queries/0_stateless/04316_array_join_nested_prefix_non_array_sibling.reference
@@ -1,0 +1,4 @@
+x1	y1
+x2	y2
+x1	scalar
+x2	scalar

--- a/tests/queries/0_stateless/04316_array_join_nested_prefix_non_array_sibling.sql
+++ b/tests/queries/0_stateless/04316_array_join_nested_prefix_non_array_sibling.sql
@@ -1,0 +1,23 @@
+-- Test ARRAY JOIN over a Nested prefix where a same-prefixed column is NOT an Array:
+-- the scalar sibling must be skipped and only the Array per-field columns expanded.
+
+DROP TABLE IF EXISTS t_nested_prefix_non_array SYNC;
+
+CREATE TABLE t_nested_prefix_non_array
+(
+    id String,
+    `loc.x` Array(String),
+    `loc.y` Array(String),
+    `loc.z` String
+) ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO t_nested_prefix_non_array (id, `loc.x`, `loc.y`, `loc.z`)
+VALUES ('a', ['x1', 'x2'], ['y1', 'y2'], 'scalar');
+
+SELECT loc.x, loc.y FROM t_nested_prefix_non_array ARRAY JOIN loc ORDER BY loc.x
+SETTINGS enable_analyzer = 1;
+
+SELECT loc.x, loc.z FROM t_nested_prefix_non_array ARRAY JOIN loc ORDER BY loc.x
+SETTINGS enable_analyzer = 1;
+
+DROP TABLE t_nested_prefix_non_array SYNC;


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #106069](https://github.com/ClickHouse/ClickHouse/pull/106069).
That PR The PR fixes a regression in the new analyzer: `ARRAY JOIN <name>` over a Nested prefix failed with `TYPE_MISMATCH` when a same-named `ALIAS` column resolved to a non-`Array`/`Map` expression (e.g. a `Tuple`). It hoists the Nested-prefix expansion logic out of `IdentifierResolver::tryResolveIdentifi

**1. Non-`Array` sibling column skip in `tryResolveIdentifierAsNestedPrefix` is untested**
  `src/Analyzer/Resolve/IdentifierResolver.cpp:245`, `src/Analyzer/Resolve/IdentifierResolver.cpp:249`
  **Risk:** `IdentifierResolver::tryResolveIdentifierAsNestedPrefix` computes `column_type` for each prefix-matching column and at `IdentifierResolver.cpp:245` sets `column_type = nullptr` when the column is not an `Array`, then at `:249` skips it via `continue`. Risk: if this `typeid_cast<DataTypeArray>`/`!column_type` guard is broken, a scalar sibling column (`loc.z String`) would be pushed into the `nested(...)` FunctionNode as a non-`Array` argument, producing a wrong-type expansion or an exception …
  **What's unique vs PR tests:** The PR's own test (04279) and the existing 03285 only use tables whose nested-prefix family columns are ALL `Array`; this test is the only one where a non-`Array` sibling column shares the prefix, exercising the skip branch at :245/:249 that all existing tests miss.
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/87e63006-df2b-47d7-b8b3-a4f2a885cfd1)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.930`
<!-- ch-version-info:end -->