### PR TITLE
Add debug virtual row assertions to MergingSortedAlgorithm

### DIFF
--- a/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.cpp
+++ b/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.cpp
@@ -1,6 +1,8 @@
 #include <Processors/Merges/Algorithms/MergeTreeReadInfo.h>
 #include <Processors/Merges/Algorithms/MergingSortedAlgorithm.h>
 #include <Processors/Transforms/ColumnGathererTransform.h>
+#include <Columns/IColumn.h>
+#include <Common/FieldVisitorDump.h>
 #include <IO/WriteBuffer.h>
 #include <IO/WriteHelpers.h>
 #include <IO/WriteBufferFromString.h>
@@ -11,7 +13,47 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int ILLEGAL_TYPE_OF_COLUMN_FOR_FILTER;
+    extern const int LOGICAL_ERROR;
 }
+
+static void rememberVirtualRowBoundary(const SortCursorImpl & cursor, Columns & virtual_row_boundary)
+{
+    virtual_row_boundary.clear();
+    if (cursor.rows == 0)
+        return;
+
+    /// A virtual row announces the boundary of the source's next output: remember its sort key.
+    for (const auto * sort_column : cursor.sort_columns)
+        virtual_row_boundary.push_back(sort_column->cut(cursor.getRow(), 1));
+}
+
+static void checkVirtualRowBoundary(const SortCursorImpl & cursor, Columns & virtual_row_boundary, const SortDescription & description, size_t source_num)
+{
+    if (virtual_row_boundary.empty() || cursor.rows == 0)
+        return;
+
+    size_t row = cursor.getRow();
+    for (size_t i = 0; i < description.size(); ++i)
+    {
+        int cmp = description[i].direction * virtual_row_boundary[i]->compareAt(0, row, *cursor.sort_columns[i], description[i].nulls_direction);
+        if (cmp == 0)
+            continue;
+
+        if (cmp < 0)
+            break;
+
+        throw Exception(
+            ErrorCodes::LOGICAL_ERROR,
+            "Virtual row boundary violated in MergingSortedAlgorithm for input {} on sort column '{}' {}: "
+            "the virtual row announced {} but the source then produced {}, which would mis-order the merge",
+            source_num, description[i].column_name, description[i].direction > 0 ? "ASC" : "DESC",
+            applyVisitor(FieldVisitorDump(), (*virtual_row_boundary[i])[0]),
+            applyVisitor(FieldVisitorDump(), (*cursor.sort_columns[i])[row]));
+    }
+
+    virtual_row_boundary.clear();
+}
+
 
 MergingSortedAlgorithm::MergingSortedAlgorithm(
     SharedHeader header_,
@@ -63,6 +105,7 @@ void MergingSortedAlgorithm::addInput()
 {
     current_inputs.emplace_back();
     cursors.emplace_back();
+    virtual_row_boundary.emplace_back();
 }
 
 void MergingSortedAlgorithm::initialize(Inputs inputs)
@@ -80,6 +123,7 @@ void MergingSortedAlgorithm::initialize(Inputs inputs)
     removeConstAndSparse(inputs);
     merged_data.initialize(*header, inputs);
     current_inputs = std::move(inputs);
+    virtual_row_boundary.assign(current_inputs.size(), {});
 
     for (size_t source_num = 0; source_num < current_inputs.size(); ++source_num)
     {
@@ -89,6 +133,14 @@ void MergingSortedAlgorithm::initialize(Inputs inputs)
 
         cursors[source_num] = SortCursorImpl(*header, chunk.getColumns(), chunk.getNumRows(), description, source_num);
     }
+
+#ifndef NDEBUG
+    for (size_t source_num = 0; source_num < current_inputs.size(); ++source_num)
+    {
+        if (current_inputs[source_num].skip_last_row && !has_collation)
+            rememberVirtualRowBoundary(cursors[source_num], virtual_row_boundary[source_num]);
+    }
+#endif
 
     if (sorting_queue_strategy == SortingQueueStrategy::Default)
     {
@@ -110,7 +162,8 @@ void MergingSortedAlgorithm::initialize(Inputs inputs)
 
 void MergingSortedAlgorithm::consume(Input & input, size_t source_num)
 {
-    if (isVirtualRow(input.chunk))
+    bool is_virtual_row = isVirtualRow(input.chunk);
+    if (is_virtual_row)
     {
         setVirtualRow(input.chunk, *header, apply_virtual_row_conversions);
         input.skip_last_row = true;
@@ -120,6 +173,16 @@ void MergingSortedAlgorithm::consume(Input & input, size_t source_num)
     removeConstAndSparse(input);
     current_inputs[source_num].swap(input);
     cursors[source_num].reset(current_inputs[source_num].chunk.getColumns(), *header, current_inputs[source_num].chunk.getNumRows());
+
+#ifndef NDEBUG
+    if (is_virtual_row && !has_collation)
+        rememberVirtualRowBoundary(cursors[source_num], virtual_row_boundary[source_num]);
+    else
+        checkVirtualRowBoundary(cursors[source_num], virtual_row_boundary[source_num], description, source_num);
+#else
+    UNUSED(rememberVirtualRowBoundary);
+    UNUSED(checkVirtualRowBoundary);
+#endif
 
     if (sorting_queue_strategy == SortingQueueStrategy::Default)
     {

--- a/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.h
+++ b/src/Processors/Merges/Algorithms/MergingSortedAlgorithm.h
@@ -75,6 +75,9 @@ private:
     void insertRow(const SortCursorImpl & current);
     void insertRows(const SortCursorImpl & current, size_t num_rows);
     void insertChunk(size_t source_num);
+
+    /// Per-input pending virtual-row boundary (empty when none), used for debug checks to ensure virtual rows are placed correctly.
+    std::vector<Columns> virtual_row_boundary;
 };
 
 }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):

- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
* Add debug virtual row assertions to MergingSortedAlgorithm

Followup for https://github.com/ClickHouse/ClickHouse/pull/106429 submitting separately so it's easier to backport prev PR with actual fix