### PR TITLE
Add receive_timeout to client stress scripts

### DIFF
--- a/tests/docker_scripts/stress_runner.sh
+++ b/tests/docker_scripts/stress_runner.sh
@@ -304,7 +304,7 @@ rm -f /etc/clickhouse-server/config.d/fail_points_active.xml
 
 # Use a larger timeout for the post-stress restart: under sanitizers with
 # async_load_databases=false the server may need minutes to load all tables.
-start_server 15 || { echo "Failed to start server"; exit 1; }
+start_server 10 || { echo "Failed to start server"; exit 1; }
 
 check_server_start
 

--- a/tests/docker_scripts/stress_runner.sh
+++ b/tests/docker_scripts/stress_runner.sh
@@ -304,7 +304,7 @@ rm -f /etc/clickhouse-server/config.d/fail_points_active.xml
 
 # Use a larger timeout for the post-stress restart: under sanitizers with
 # async_load_databases=false the server may need minutes to load all tables.
-start_server 30 || { echo "Failed to start server"; exit 1; }
+start_server 15 || { echo "Failed to start server"; exit 1; }
 
 check_server_start
 

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -286,7 +286,7 @@ function start_server()
 
     counter=0
     max_attempt=${1:-6}
-    until clickhouse-client --query "SELECT 1"
+    until clickhouse-client --receive_timeout 30 --query "SELECT 1"
     do
         if [ "$counter" -gt "$max_attempt" ]
         then
@@ -307,7 +307,7 @@ function start_server()
 
 function check_server_start()
 {
-    clickhouse-client --query "SELECT 'Server successfully started', 'OK', NULL, ''" >> /test_output/test_results.tsv \
+    clickhouse-client --receive_timeout 30 --query "SELECT 'Server successfully started', 'OK', NULL, ''" >> /test_output/test_results.tsv \
         || (rg --text "<Error>.*Application" /var/log/clickhouse-server/clickhouse-server.log > /test_output/application_errors.txt \
         && echo -e "Server failed to start (see application_errors.txt and clickhouse-server.clean.log)$FAIL$(trim_server_logs application_errors.txt)" \
         >> /test_output/test_results.tsv)

--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -107,7 +107,7 @@ sudo chgrp clickhouse /etc/clickhouse-server/config.d/s3_storage_policy_by_defau
 
 start_server || (echo "Failed to start server" && exit 1)
 
-clickhouse-client --query="SELECT 'Server version: ', version()"
+clickhouse-client --receive_timeout 30 --query="SELECT 'Server version: ', version()"
 
 mkdir tmp_stress_output
 
@@ -286,7 +286,7 @@ check_allow_list() {
 
 start_server || check_allow_list || (echo "Failed to start server" && exit 1)
 
-clickhouse-client --query "SELECT 'Server successfully started', 'OK', NULL, ''" >> /test_output/test_results.tsv \
+clickhouse-client --receive_timeout 30 --query "SELECT 'Server successfully started', 'OK', NULL, ''" >> /test_output/test_results.tsv \
     || (rg --text "<Error>.*Application" /var/log/clickhouse-server/clickhouse-server.log > /test_output/application_errors.txt \
     && echo -e "Server failed to start (see application_errors.txt and clickhouse-server.clean.log)$FAIL$(trim_server_logs application_errors.txt)" \
     >> /test_output/test_results.tsv)
@@ -294,7 +294,7 @@ clickhouse-client --query "SELECT 'Server successfully started', 'OK', NULL, ''"
 # Remove file application_errors.txt if it's empty
 [ -s /test_output/application_errors.txt ] || rm -f /test_output/application_errors.txt
 
-clickhouse-client --query="SELECT 'Server version: ', version()"
+clickhouse-client --receive_timeout 30 --query="SELECT 'Server version: ', version()"
 
 # Let the server run for a while before checking log.
 sleep 60


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Add `--receive_timeout 30` to `clickhouse-client` health checks in stress and upgrade test scripts. When the server accepts TCP connections but hangs on queries (common under sanitizers), the default 300s socket timeout caused each retry to block for 5 minutes, exhausting the CI job timeout before log collection could run. Also, reduce post-stress restart retries from 30 to 10.

With this fix, tests results such as this one https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=106495&sha=990f8d0925c86dd3135ddaa75af72475220e758e&name_0=PR&name_1=Stress+test+%28amd_tsan%29 will have time to upload server artifacts.

cc @maxknv 

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.427`
<!-- ch-version-info:end -->