### PR TITLE
Fix flaky 04239_streaming_combinations: wait for both UNION ALL sides

### DIFF
--- a/tests/queries/0_stateless/04239_streaming_combinations.sh
+++ b/tests/queries/0_stateless/04239_streaming_combinations.sh
@@ -29,7 +29,10 @@ $STREAMING_CLIENT -q "TRUNCATE t_streaming_test"
 $STREAMING_CLIENT -q "INSERT INTO t_streaming_test VALUES ('started', 0)"
 
 read -r fifo_1 pid_1 < <(spawn $STREAMING_CLIENT -q "SELECT a FROM t_streaming_test UNION ALL SELECT a FROM t_streaming_test STREAM")
-read_until "$fifo_1" "started"
+# Both UNION ALL sides each emit one 'started' row from the pre-existing data;
+# wait until both have produced theirs before triggering inserts to keep
+# downstream output ordering deterministic.
+read_until "$fifo_1" "started" 2
 
 $STREAMING_CLIENT -q "INSERT INTO t_streaming_test select number, number from numbers(1)"
 $STREAMING_CLIENT -q "INSERT INTO t_streaming_test select number, number from numbers(2)"

--- a/tests/queries/0_stateless/streaming.lib
+++ b/tests/queries/0_stateless/streaming.lib
@@ -32,6 +32,7 @@ read_until()
 {
     local fifo="$1"
     local stop_string="$2"
+    local target_count="${3:-1}"
 
     # Check if the FIFO file exists
     if [[ ! -p "$fifo" ]]; then
@@ -39,11 +40,15 @@ read_until()
         return 1
     fi
 
+    local seen=0
     while IFS= read -r line; do
         echo $line
 
         if [[ "$line" == *"$stop_string"* ]]; then
-            break
+            seen=$((seen + 1))
+            if (( seen >= target_count )); then
+                break
+            fi
         fi
     done <"$fifo"
 }


### PR DESCRIPTION
The `Test Regular Union Stream` subtest of `04239_streaming_combinations` spawns:

```sql
SELECT a FROM t_streaming_test UNION ALL SELECT a FROM t_streaming_test STREAM
```

against a table that already contains one row (`'started'`, `0`). Both `UNION ALL` sources scan that row and emit one `started` line each, so the expected reference begins with two `started` lines before any post-INSERT data.

The test synchronized with `read_until "$fifo_1" "started"`, which returns after the FIRST `started` line. `UNION ALL` provides no ordering between sources, so the regular side's `started` could still be in flight when the test issues `INSERT`s. When that happens the streaming side emits a post-INSERT row (`0`) into the FIFO before the regular side's `started` reaches stdout, producing `started\n0\nstarted\n0\n1` instead of the reference `started\nstarted\n0\n0\n1`. The race widens under `distributed plan` + `s3 storage` because of higher and more variable scheduling latency, which matches where CI saw the failures.

This patch extends `read_until` in `streaming.lib` with an optional target-count argument (defaults to 1, preserving existing callers) and updates the `Test Regular Union Stream` subtest to wait for **both** `started` markers before issuing the INSERTs. Post-INSERT rows are then appended at a deterministic position relative to both source rows.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=106423&sha=c63e3b252e8a6bd504220f99031f9ba16a95ce09&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20distributed%20plan%2C%20s3%20storage%2C%20parallel%29

Verified locally: 20/20 passes with random settings disabled, 1/1 with default randomization. The race is timing-sensitive in CI; the fix removes the synchronization gap that allowed it.

Related: https://github.com/ClickHouse/ClickHouse/pull/106423
Caused by: https://github.com/ClickHouse/ClickHouse/pull/96130

### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...

### Documentation entry for user-facing changes

- [x] Documentation entry is not required.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.459`
<!-- ch-version-info:end -->