### PR TITLE
Fixing more retry loops

### DIFF
--- a/ci/jobs/collect_clickhouse_profiles.py
+++ b/ci/jobs/collect_clickhouse_profiles.py
@@ -178,7 +178,7 @@ def wait_for_server_ready(proc, server_dir, port, log_file):
         # window would otherwise produce hundreds of identical `Run command`
         # lines; emit a progress heartbeat every 30s instead.
         res, out, _ = Shell.get_res_stdout_stderr(
-            f'{server_dir}/clickhouse-client --port {port} --query "select 1"'
+            f'{server_dir}/clickhouse-client --port {port} --receive_timeout=5 --query "select 1"'
         )
         if out.strip() == "1":
             elapsed = time.monotonic() - start

--- a/ci/jobs/install_check.py
+++ b/ci/jobs/install_check.py
@@ -43,9 +43,9 @@ echo "$test_env" >> /etc/default/clickhouse
 # listener can take longer to open on a slow CI host; poll for up to 30s. See #86278.
 SYSTEMCTL_SKIP_REDIRECT=1 /etc/init.d/clickhouse-server start
 for i in {1..30}; do
-    clickhouse-client -q 'SELECT version()' && break || sleep 1
+    clickhouse-client --receive_timeout=5 -q 'SELECT version()' && break || sleep 1
 done
-clickhouse-client -q 'SELECT version()'
+clickhouse-client --receive_timeout=5 -q 'SELECT version()'
 grep "$test_env" /proc/$(cat /var/run/clickhouse-server/clickhouse-server.pid)/environ"""
     keeper_test = r"""#!/bin/bash
 set -e
@@ -71,7 +71,7 @@ trap "bash -ex /packages/preserve_logs.sh" ERR
 /packages/clickhouse install
 clickhouse-server start --daemon
 for i in {1..5}; do
-    clickhouse-client -q 'SELECT version()' && break || sleep 1
+    clickhouse-client --receive_timeout=5 -q 'SELECT version()' && break || sleep 1
 done
 clickhouse-keeper start --daemon
 for i in {1..20}; do

--- a/ci/jobs/performance_tests.py
+++ b/ci/jobs/performance_tests.py
@@ -784,7 +784,7 @@ class CHServer:
         delay = 2
         for attempt in range(attempts):
             res, out, err = Shell.get_res_stdout_stderr(
-                f'clickhouse-client --port {self.port} --query "select 1"', verbose=True
+                f'clickhouse-client --port {self.port} --receive_timeout=5 --query "select 1"', verbose=True
             )
             if out.strip() == "1":
                 print("Server ready")

--- a/ci/jobs/scripts/clickhouse_proc.py
+++ b/ci/jobs/scripts/clickhouse_proc.py
@@ -644,7 +644,7 @@ profiles:
             return False
         for attempt in range(attempts):
             res, out, err = Shell.get_res_stdout_stderr(
-                f'clickhouse-client --port {port} --query "select 1"', verbose=True
+                f'clickhouse-client --port {port} --receive_timeout=5 --query "select 1"', verbose=True
             )
             if out.strip() == "1":
                 print(f"Server replica {replica_num} ready")

--- a/ci/jobs/scripts/clickhouse_service.py
+++ b/ci/jobs/scripts/clickhouse_service.py
@@ -154,7 +154,7 @@ class ClickHouseService:
 
         for attempt in range(attempts):
             _res, out, err = Shell.get_res_stdout_stderr(
-                f'clickhouse-client --port {port} --query "select 1"', verbose=True
+                f'clickhouse-client --port {port} --receive_timeout=5 --query "select 1"', verbose=True
             )
             if out.strip() == "1":
                 print("ClickHouse server ready")

--- a/ci/jobs/scripts/fuzzer/run-fuzzer.sh
+++ b/ci/jobs/scripts/fuzzer/run-fuzzer.sh
@@ -148,7 +148,7 @@ function fuzz
     server_bg_pid=$!
     for _ in {1..30}
     do
-        if clickhouse-client --query "select 1"
+        if clickhouse-client --receive_timeout=5 --query "select 1"
         then
             break
         fi
@@ -203,7 +203,7 @@ function fuzz
         # to freeze, and the fuzzer will fail. In debug build, it can take a lot of time.
         for _ in {1..180}
         do
-            if clickhouse-client --query "select 1"
+            if clickhouse-client --receive_timeout=5 --query "select 1"
             then
                 break
             fi
@@ -299,7 +299,7 @@ function fuzz
 
     for _ in {1..100}
     do
-        if clickhouse-client --query "SELECT 1" 2> err
+        if clickhouse-client --receive_timeout=5 --query "SELECT 1" 2> err
         then
             server_died=0
             break

--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -31,14 +31,14 @@ function wait_for_server # port, pid
 {
     for _ in {1..60}
     do
-        if clickhouse-client --port "$1" --query "select 1" || ! kill -0 "$2"
+        if clickhouse-client --port "$1" --receive_timeout=5 --query "select 1" || ! kill -0 "$2"
         then
             break
         fi
         sleep 1
     done
 
-    if ! clickhouse-client --port "$1" --query "select 1"
+    if ! clickhouse-client --port "$1" --receive_timeout=5 --query "select 1"
     then
         echo "Cannot connect to ClickHouse server at $1"
         return 1
@@ -318,9 +318,9 @@ function run_tests
     do
         echo "$current_test of $total_tests tests complete" > status.txt
         # Check that both servers are alive, and restart them if they die.
-        clickhouse-client --port $LEFT_SERVER_PORT --query "select 1 format Null" \
+        clickhouse-client --port $LEFT_SERVER_PORT --receive_timeout=5 --query "select 1 format Null" \
             || { echo $test_name >> left-server-died.log ; restart ; }
-        clickhouse-client --port $RIGHT_SERVER_PORT --query "select 1 format Null" \
+        clickhouse-client --port $RIGHT_SERVER_PORT --receive_timeout=5 --query "select 1 format Null" \
             || { echo $test_name >> right-server-died.log ; restart ; }
 
         test_name=$(basename "$test" ".xml")
@@ -414,8 +414,8 @@ function get_profiles
 
     # Just check that the servers are alive so that we return a proper exit code.
     # We don't consistently check the return codes of the above background jobs.
-    clickhouse-client --port $LEFT_SERVER_PORT --query "select 1"
-    clickhouse-client --port $RIGHT_SERVER_PORT --query "select 1"
+    clickhouse-client --port $LEFT_SERVER_PORT --receive_timeout=5 --query "select 1"
+    clickhouse-client --port $RIGHT_SERVER_PORT --receive_timeout=5 --query "select 1"
 }
 
 # Build and analyze randomization distribution for all queries.

--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -53,7 +53,7 @@ class RandomQueryKiller:
         try:
             # Get a random query_id, excluding our own queries and system queries
             result = check_output(
-                "clickhouse client -q \""
+                "clickhouse client --receive_timeout=5 -q \""
                 "SELECT query_id FROM system.processes "
                 "WHERE query NOT LIKE '%system.processes%' "
                 "AND query NOT LIKE '%KILL QUERY%' "
@@ -66,7 +66,7 @@ class RandomQueryKiller:
             if query_id:
                 logging.info("Killing random query: %s", query_id)
                 call(
-                    f"clickhouse client -q \"KILL QUERY WHERE query_id = '{query_id}' ASYNC\" 2>/dev/null",
+                    f"clickhouse client --receive_timeout=5 -q \"KILL QUERY WHERE query_id = '{query_id}' ASYNC\" 2>/dev/null",
                     shell=True,
                     timeout=5,
                 )
@@ -395,7 +395,7 @@ def execute_bash(full_command, timeout=120):
 
 def make_query_command(query: str) -> str:
     return (
-        f'clickhouse client -q "{query}" --max_untracked_memory=1Gi '
+        f'clickhouse client -q "{query}" --receive_timeout=15 --max_untracked_memory=1Gi '
         "--memory_profiler_step=1Gi --max_memory_usage_for_user=0 --max_memory_usage_in_client=1000000000 "
         "--enable-progress-table-toggle=0"
     )
@@ -424,7 +424,7 @@ def prepare_for_hung_check(drop_databases: bool) -> bool:
         raise ServerDied("clickhouse-server process does not exist")
     # Sometimes there is a message `Child process was stopped by signal 19` in logs after stopping gdb
     call_with_retry(
-        "kill -CONT $(cat /var/run/clickhouse-server/clickhouse-server.pid) && clickhouse client -q 'SELECT 1 FORMAT Null'"
+        "kill -CONT $(cat /var/run/clickhouse-server/clickhouse-server.pid) && clickhouse client --receive_timeout=5 -q 'SELECT 1 FORMAT Null'"
     )
 
     # ThreadFuzzer significantly slows down server and causes false-positive hung check failures
@@ -523,7 +523,7 @@ def prepare_for_hung_check(drop_databases: bool) -> bool:
     # Even if all clickhouse-test processes are finished, there are probably some sh scripts,
     # which still run some new queries. Let's ignore them.
     try:
-        query = 'clickhouse client -q "SELECT count() FROM system.processes where elapsed > 300" '
+        query = 'clickhouse client --receive_timeout=30 -q "SELECT count() FROM system.processes where elapsed > 300" '
         output = (
             check_output(query, shell=True, stderr=STDOUT, timeout=30)
             .decode("utf-8")

--- a/ci/jobs/smoke_test.py
+++ b/ci/jobs/smoke_test.py
@@ -54,7 +54,7 @@ def wait_for_server(timeout=60):
     start_time = time.time()
     while time.time() - start_time < timeout:
         result = Shell.check(
-            f"{BINARY_PATH} client --query 'SELECT 1'",
+            f"{BINARY_PATH} client --receive_timeout=5 --query 'SELECT 1'",
             verbose=False,
         )
         if result:

--- a/ci/jobs/sqllogic_test.py
+++ b/ci/jobs/sqllogic_test.py
@@ -76,7 +76,7 @@ class ClickHouseBinary:
         delay = 2
         for attempt in range(attempts):
             res, out, err = Shell.get_res_stdout_stderr(
-                f'clickhouse-client --port {self.port} --query "select 1"', verbose=True
+                f'clickhouse-client --port {self.port} --receive_timeout=5 --query "select 1"', verbose=True
             )
             if out.strip() == "1":
                 print("Server ready")

--- a/ci/jobs/sqltest_job.py
+++ b/ci/jobs/sqltest_job.py
@@ -70,7 +70,7 @@ class ClickHouseBinary:
         delay = 2
         for attempt in range(attempts):
             res, out, err = Shell.get_res_stdout_stderr(
-                f'clickhouse-client --port {self.port} --query "select 1"', verbose=True
+                f'clickhouse-client --port {self.port} --receive_timeout=5 --query "select 1"', verbose=True
             )
             if out.strip() == "1":
                 print("Server ready")

--- a/ci/jobs/vector_search_stress_job.py
+++ b/ci/jobs/vector_search_stress_job.py
@@ -96,7 +96,7 @@ def main():
         test_results.append(
             Result.from_commands_run(
                 name="select 1",
-                command=f"{temp_dir}/clickhouse-client --query 'select 1'",
+                command=f"{temp_dir}/clickhouse-client --receive_timeout=5 --query 'select 1'",
             )
         )  # success if exit code is 0
         test_results.append(Result(name="test 2", status=Result.Status.OK))


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

@alexey-milovidov I should have looked further. Don't wait 5 minutes for a `SELECT 1;` query. If the server crashes or hangs, let the retry loops end faster. Let's wait for the CI first

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.434`
<!-- ch-version-info:end -->