### PR TITLE
Fix arm_tidy build

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
@@ -728,9 +728,9 @@ void alter(
     {
         auto log = getLogger("IcebergMutations");
 
-        int last_version;
+        int last_version = 0;
         String metadata_path;
-        CompressionMethod compression_method;
+        CompressionMethod compression_method = CompressionMethod::None;
         if (!catalog)
         {
             auto last_version_info = getLatestOrExplicitMetadataFileAndVersion(


### PR DESCRIPTION
https://s3.amazonaws.com/clickhouse-test-reports/PRs/106020/dcf1fe52292ff9a3425075ba79ee36b2b8767d73/build_arm_tidy/build_clickhouse/build_clickhouse.log
```
/ClickHouse/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp:731:13: error: variable 'last_version' is not initialized [cppcoreguidelines-init-variables,-warnings-as-errors]
  731 |         int last_version;
      |             ^           
      |                          = 0
/ClickHouse/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp:733:27: error: variable 'compression_method' is not initialized [cppcoreguidelines-init-variables,-warnings-as-errors]
  733 |         CompressionMethod compression_method;
      |    
```


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.440`
<!-- ch-version-info:end -->