### PR TITLE
Fix arm_tidy: initialize variables in Iceberg::alter (caused by #106102)

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/Iceberg/Mutations.cpp
@@ -728,9 +728,9 @@ void alter(
     {
         auto log = getLogger("IcebergMutations");
 
-        int last_version;
+        int last_version = 0;
         String metadata_path;
-        CompressionMethod compression_method;
+        CompressionMethod compression_method = CompressionMethod::None;
         if (!catalog)
         {
             auto last_version_info = getLatestOrExplicitMetadataFileAndVersion(


### PR DESCRIPTION
Caused by: https://github.com/ClickHouse/ClickHouse/pull/106102

PR #106102 (`scanhex12/fix_alter_catalog`, merged 2026-06-05 17:43 UTC) refactored `Iceberg::alter` to declare `last_version` and `compression_method` outside an `if`/`else` that assigns them in both branches. Clang-tidy `cppcoreguidelines-init-variables` flags the bare declarations and `Build (arm_tidy)` is built with `-warnings-as-errors`, so the build fails for every PR whose CI ran on master after this commit.

CIDB shows 30+ unrelated PRs hitting this in the last 2 days (sample of `Build (arm_tidy)` failures in last 2d):

```
pull_request_number   head_ref                                cnt
89360                 feature-6476                             5
106404                cursor/fix-distributed-duplicate...      3
103540                totals-by-order-by-combinators           3
106386                untracked-memory-race                    3
106522                native-arrow-ipc-format                  2
106120                icolumn-shuffle-primitives               2
105102                groeneai/fix-99495-limit-with-ties...    2
106590                groeneai/fix-issue-106573-...            1
...
```

The fix initializes both variables to safe defaults at declaration. They are unconditionally overwritten in both `if` and `else` branches before use, so behavior is unchanged. The new defaults are only relevant if a future code path skips both assignments, in which case `last_version=0` and `compression_method=CompressionMethod::None` are sane no-op values (the same values the old structured-binding form would produce through default-construction of the destructured aggregate).

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...
