### PR TITLE
Allowlist `system.metric_log` flush DEADLOCK_AVOIDED in upgrade-check log scrub

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -368,6 +368,15 @@ cp /var/log/clickhouse-server/clickhouse-server.upgrade.log /test_output/clickho
 #       this regex covers the other variant (peer wins, read returns EOF or another transient socket error).
 #       Filtered via regex in the secondary pipe below to require all three substrings together, so unrelated
 #       RaftInstance errors are not masked.
+# `Failed to flush system log system.metric_log` + `DEADLOCK_AVOIDED` is a transient lock-timeout emitted by
+#       `SystemLog<MetricLogElement>::flushImpl` when the background `MetricLog` flush loop races with the
+#       ongoing upgrade-test shutdown sequence. Another worker (DROP/RENAME/DETACH on `system.metric_log`,
+#       or a parallel mutation/merge) holds the table-level write lock, the flush blocks for the 60s timeout,
+#       and then aborts with code 473 (`DEADLOCK_AVOIDED`). Losing a few `MetricLogElement` samples during
+#       shutdown is harmless; the upgrade-check stage is not asserting on metric continuity. Filtered via
+#       regex in the secondary pipe below to require BOTH the `SystemLog` flush wrapper for `metric_log` AND
+#       the `DEADLOCK_AVOIDED` error code together, so unrelated lock-timeout errors and unrelated
+#       `metric_log` errors are not masked.
 echo "Check for Error messages in server log:"
 rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "Code: 236. DB::Exception: Cancelled mutating parts" \
@@ -449,6 +458,7 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
     | grep -av -e "rdk:FAIL.*Connect to.*failed: Connection refused" \
     | grep -av -e "wrong_metadata.*Detaching broken part.*backward incompatibility" \
     | grep -av -e "RaftInstance: session.*failed to read rpc header from socket.*due to error" \
+    | grep -av -e "SystemLog.*Failed to flush system log system\.metric_log.*DEADLOCK_AVOIDED" \
     | grep -Fa "<Error>" > /test_output/upgrade_error_messages.txt || true
 
 if [ -s /test_output/upgrade_error_messages.txt ]; then


### PR DESCRIPTION
### Changelog category (leave one):

- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...

### Documentation entry for user-facing changes

- [ ] Documentation is unchanged.

### Modify your CI run

(default settings, no labels)

---

The upgrade-check post-restart `<Error>` log scrub catches a transient lock-timeout emitted by `SystemLog<MetricLogElement>::flushImpl` when the background `MetricLog` flush loop races with shutdown work on `system.metric_log` during the upgrade restart sequence. The signature, from CIDB:

```
<Error> void DB::SystemLog<DB::MetricLogElement>::flushImpl(...) [LogElement = DB::MetricLogElement]: Failed to flush system log system.metric_log with N entries up to offset M: Code: 473. DB::Exception: WRITE locking attempt on "system.metric_log" has timed out! (60000ms) Possible deadlock avoided. Client should retry. Owner query ids: . (DEADLOCK_AVOIDED), Stack trace ...
```

Another worker (DROP/RENAME/DETACH on `system.metric_log`, or a parallel mutation/merge) holds the table-level write lock during the upgrade-test restart, the flush blocks for the 60s timeout, and then aborts with code 473 (`DEADLOCK_AVOIDED`). Code 473 is the engine's own "I gave up to avoid a deadlock, not a crash" signal — losing a few `MetricLogElement` samples during shutdown is harmless; the upgrade-check stage is not asserting on metric continuity.

CIDB confirms this is chronic CI noise, not a code regression:

- 4 hits across 4 distinct PRs in the last 30 days, **0 master**, 100% on `Upgrade check (amd_release)`
- Reported by @ alexey-milovidov on https://github.com/ClickHouse/ClickHouse/pull/102017 (cited PRs #106425, #104561, #106202)

The added regex requires BOTH the `SystemLog` flush wrapper for `metric_log` AND the `DEADLOCK_AVOIDED` error code together, mirroring the narrowing approach of the existing `rdk:FAIL.*Connect to.*failed: Connection refused` and `StorageKafka2.*Broker transport failure` filters. Real `metric_log` regressions (other flush errors) and unrelated `DEADLOCK_AVOIDED` hits on other system_log tables (`query_log`, `text_log`, etc.) still surface.

Related: https://github.com/ClickHouse/ClickHouse/pull/102017
Related: https://github.com/ClickHouse/ClickHouse/pull/106563
Related: https://github.com/ClickHouse/ClickHouse/pull/101576

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.461`
<!-- ch-version-info:end -->