### PR TITLE
Fix `DateLUT` atexit `heap-use-after-free` vs asynchronous logger

### DIFF
--- a/src/Common/DateLUT.cpp
+++ b/src/Common/DateLUT.cpp
@@ -206,8 +206,10 @@ const DateLUTImpl & DateLUT::getImplementation(std::string_view time_zone) const
 
 DateLUT & DateLUT::getInstance()
 {
-    static DateLUT ret;
-    return ret;
+    /// Intentionally leaked: must outlive the asynchronous logger threads that may still
+    /// be formatting `LocalDateTime` values when other static destructors run.
+    static DateLUT * ret = new DateLUT;
+    return *ret;
 }
 
 ExtendedDayNum makeDayNum(const DateLUTImpl & date_lut, Int16 year, UInt8 month, UInt8 day_of_month, Int32 default_error_day_num)


### PR DESCRIPTION
Fix `heap-use-after-free` at `clickhouse-local` shutdown reported as `Scraping system tables` in CI ASan jobs.

**Failure mode** (CIDB, 30 days, 9 hits across 6 unrelated PRs; `arm_asan_ubsan azure/targeted`, `amd_asan_ubsan flaky check/distributed plan`):

```
==NNNN==ERROR: AddressSanitizer: heap-use-after-free
READ of size 8 at 0x... thread T3 (AsyncLogger)
    #0 findIndex                                src/Common/DateLUTImpl.h:245
    #1 DateLUTImpl::toDateTimeComponents        src/Common/DateLUTImpl.h:1314
    #2 LocalDateTime::init                      src/Common/LocalDateTime.cpp:6
    ...
    #5 OwnPatternFormatter::formatExtended      src/Loggers/OwnPatternFormatter.cpp:23
    ...
    #8 OwnAsyncSplitChannel::runChannel         src/Loggers/OwnSplitChannel.cpp:529

freed by thread T0 here:
    #0 operator delete(...)
    ...
    #3 ~unique_ptr<DateLUTImpl>                 contrib/llvm-project/libcxx/include/__memory/unique_ptr.h:258
    #4 ~pair                                    contrib/llvm-project/libcxx/include/__utility/pair.h:88
    ...
    DateLUT::~DateLUT
```

**Root cause** is a cross-translation-unit static-destructor-order race. `DateLUT::getInstance` returned a function-local `static DateLUT ret;`. Poco's `auto_logger_shutdown` static (in `base/poco/Foundation/src/Logger.cpp`) is what ultimately joins the asynchronous logger threads via `~OwnAsyncSplitChannel::close`. The order between these two static destructors across translation units is unspecified, so a `clickhouse-local` exit can free the timezone map while a logger thread is still formatting a queued log message that contains a timestamp.

**Fix** is to deliberately leak the `DateLUT` instance so it outlives every other static. The pointer remains reachable from the function-local static, so LeakSanitizer does not report it. The OS reclaims the memory at process exit. This is the standard idiom for static-init-order destruction races and matches the comment in `Common/ThreadPool.h` ("order of destructors of global static objects and callbacks added by `atexit` is undefined for different translation units").

**Local verification** on `build-asan` (clang-21, `-DSANITIZE=address,undefined`):

| Binary | Iterations | ASan reports |
|---|---|---|
| Master (`static DateLUT ret;`) | 400 (50 batches x 8 parallel `clickhouse local` invocations with the asynchronous logger at trace level) | 4 (~1.0%, captured stacks match the CI signature: `T2/T3 AsyncLogger` reading freed memory allocated by `T0`) |
| With fix (`static DateLUT * ret = new DateLUT;`) | 400 (same harness) | 0 |

CI report referenced by `@alexey-milovidov`: https://github.com/ClickHouse/ClickHouse/pull/105375

Related: https://github.com/ClickHouse/ClickHouse/pull/105375

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.447`
<!-- ch-version-info:end -->