### PR TITLE
Fix flaky test test_multiple_disks::test_jbod_overflow

### DIFF
--- a/tests/integration/test_multiple_disks/test.py
+++ b/tests/integration/test_multiple_disks/test.py
@@ -678,9 +678,16 @@ def test_jbod_overflow(start_cluster, name, engine):
             )
         )
 
-        used_disks = get_used_disks_for_table(node1, name)
+        # The last (10MB) part cannot fit on the nearly-full jbod1 and must go to `external`.
+        # Find it by the highest block number instead of relying on `get_used_disks_for_table`,
+        # which orders by `modification_time`: all inserts happen within the same second, so the
+        # last jbod1 part and the external part tie and order arbitrarily, making this flaky.
+        overflow_part_disk = node1.query(
+            "SELECT disk_name FROM system.parts WHERE table == '{}' AND active = 1 "
+            "ORDER BY max_block_number DESC LIMIT 1".format(name)
+        ).strip()
 
-        assert used_disks[-1] == "external"
+        assert overflow_part_disk == "external"
 
         node1.query(f"SYSTEM START MERGES {name}")
         node1.query(f"SYSTEM START MOVES {name}")


### PR DESCRIPTION
`test_multiple_disks::test_jbod_overflow` fills the 40 MB `jbod1` disk with seven 5 MB parts and then inserts a 10 MB part that must overflow to the `external` disk.

The overflow itself is deterministic: by the time of the last insert `jbod1` has only ~4.6 MB free, so the 10 MB reservation cannot fit and is placed on `external`. This is confirmed by the reservation trace in the server logs of the failing run:

```
insert 1-7 (5 MiB each): Reserved on jbod1   (unreserved 40.0 -> 34.9 -> ... -> 9.67 MiB)
insert 8  (10 MiB):       Reserved on external      (jbod1 had only ~4.6 MiB free)
```

The flakiness is in the assertion, not the behavior. The test used `get_used_disks_for_table`, which orders parts by `modification_time` — a `DateTime` with one-second resolution. All eight inserts complete within the same second (the test body runs in ~1.2 s), so the last `jbod1` part and the `external` part tie on `modification_time` and are returned in an arbitrary order. As a result `used_disks[-1]` is sometimes the `jbod1` part, and `assert used_disks[-1] == "external"` fails with `assert 'jbod1' == 'external'`.

The fix identifies the overflow part by the highest block number instead, which is unique and monotonic with insertion order, so the check no longer depends on `modification_time` tie-breaking:

```python
overflow_part_disk = node1.query(
    "SELECT disk_name FROM system.parts WHERE table == '{}' AND active = 1 "
    "ORDER BY max_block_number DESC LIMIT 1".format(name)
).strip()
assert overflow_part_disk == "external"
```

Verified locally that several parts inserted in quick succession share a single `modification_time` second (so the old ordering is ambiguous), while `ORDER BY max_block_number DESC LIMIT 1` deterministically returns the last-inserted part.

This is a pre-existing flake unrelated to any product change; it was observed in an unrelated PR's CI run:
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=106618&sha=1d4dfae4ff763d2bfe72452de05445a9326a3057&name_0=PR&name_1=Integration%20tests%20%28amd_binary_excluded_from_llvm%29

### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not for changelog.


### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.450`
<!-- ch-version-info:end -->