### PR TITLE
Fix logical error "Inconsistent AST formatting" on a function name containing query parameters

### DIFF
--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -518,7 +518,18 @@ namespace
         bool parseImpl(Pos & pos, ASTPtr & node, Expected & expected) override
         {
             ParserCompoundIdentifier parser(false, true, Highlight::function);
-            return parser.parse(pos, node, expected);
+            if (!parser.parse(pos, node, expected))
+                return false;
+
+            /// Function names containing query parameters (for example, `{x:Identifier}(...)`)
+            /// are not supported.
+            if (node->as<ASTIdentifier>()->isParam())
+            {
+                node = nullptr;
+                return false;
+            }
+
+            return true;
         }
     };
 }
@@ -2996,6 +3007,7 @@ static std::unique_ptr<Layer> getFunctionLayer(ASTPtr identifier, bool is_table_
     /// OVERLAY(x PLACING y FROM a FOR b)
 
     String function_name = getIdentifierName(identifier);
+    chassert(!function_name.empty());
     String function_name_lowercase = Poco::toLower(function_name);
 
     if (is_table_function)

--- a/tests/queries/0_stateless/04319_query_parameter_as_function_name.sql
+++ b/tests/queries/0_stateless/04319_query_parameter_as_function_name.sql
@@ -1,0 +1,6 @@
+-- A query parameter cannot be a function name or a part of a function name.
+SELECT {f:Identifier}(x); -- { clientError SYNTAX_ERROR }
+SELECT {f:Identifier}.g(x); -- { clientError SYNTAX_ERROR }
+
+-- The original fuzzer reproducer.
+DESCRIBE TABLE (SELECT {db:Identifier}.test_table.COLUMNS(plus(id, toInt256(x))) FROM test_table); -- { clientError SYNTAX_ERROR }


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix logical error "Inconsistent AST formatting" on a function name containing query parameters

Closes https://github.com/ClickHouse/ClickHouse/issues/106358

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.474`
<!-- ch-version-info:end -->