### PR TITLE
Implement SYSTEM RESTART DISK for plain_rewritable readonly replicas

### DIFF
--- a/src/Interpreters/InterpreterSystemQuery.cpp
+++ b/src/Interpreters/InterpreterSystemQuery.cpp
@@ -996,6 +996,11 @@ BlockIO InterpreterSystemQuery::execute()
 
             break;
         }
+        case Type::RESTART_DISK:
+        {
+            restartDisk(query.disk);
+            break;
+        }
         case Type::FLUSH_LOGS:
         {
             getContext()->checkAccess(AccessType::SYSTEM_FLUSH_LOGS);
@@ -2080,6 +2085,58 @@ void InterpreterSystemQuery::waitLoadingParts()
     }
 }
 
+void InterpreterSystemQuery::restartDisk(const String & disk_name)
+{
+    getContext()->checkAccess(AccessType::SYSTEM_RESTART_DISK);
+
+    auto disk = getContext()->getDisk(disk_name);
+
+    /// A loaded `MergeTree` caches its set of active parts and never re-scans it on its own, so
+    /// reloading the disk alone would not surface new parts until the table is re-attached. For
+    /// every already-loaded table that uses this disk and whose data is entirely on readonly disks
+    /// (i.e. a readonly replica of data written elsewhere), re-scan the data directory -- the same
+    /// work the background `refresh_parts_interval` task performs. `refreshDataPartsOnce` reloads
+    /// the disk metadata first (for a `plain_rewritable` object-storage disk this re-reads the path
+    /// map, so directories written by another writer process become visible), passing 0 to bypass
+    /// the time-based refresh throttle. Tables with a writable disk own their part set and must not
+    /// have it rebuilt here.
+    bool disk_refreshed = false;
+    for (auto & elem : DatabaseCatalog::instance().getDatabases(GetDatabasesOptions{.with_remote_databases = false}))
+    {
+        /// skip_not_loaded: act only on already-loaded tables, do not block on async loading.
+        for (auto it = elem.second->getTablesIterator(getContext(), {}, /*skip_not_loaded=*/ true); it->isValid(); it->next())
+        {
+            auto * merge_tree = dynamic_cast<MergeTreeData *>(it->table().get());
+            if (!merge_tree)
+                continue;
+
+            auto policy = merge_tree->getStoragePolicy();
+            if (!policy->tryGetDiskByName(disk_name))
+                continue;
+
+            bool all_disks_are_readonly = true;
+            for (const auto & table_disk : policy->getDisks())
+            {
+                if (!table_disk->isReadOnly())
+                {
+                    all_disks_are_readonly = false;
+                    break;
+                }
+            }
+            if (!all_disks_are_readonly)
+                continue;
+
+            merge_tree->refreshDataPartsOnce(/*interval_milliseconds=*/ 0);
+            disk_refreshed = true;
+        }
+    }
+
+    /// No readonly table re-scanned this disk above, but the user still asked to restart it, so
+    /// reload its in-memory metadata directly. Passing 0 bypasses the time-based refresh throttle.
+    if (!disk_refreshed)
+        disk->refresh(/*not_sooner_than_milliseconds=*/ 0);
+}
+
 namespace
 {
 
@@ -2699,6 +2756,10 @@ AccessRightsElements InterpreterSystemQuery::getRequiredAccessForDDLOnCluster() 
             break;
         }
         case Type::RESTART_DISK:
+        {
+            required_access.emplace_back(AccessType::SYSTEM_RESTART_DISK);
+            break;
+        }
         case Type::WAIT_BLOBS_CLEANUP:
         {
             required_access.emplace_back(AccessType::SYSTEM_WAIT_BLOBS_CLEANUP);

--- a/src/Interpreters/InterpreterSystemQuery.h
+++ b/src/Interpreters/InterpreterSystemQuery.h
@@ -69,6 +69,8 @@ private:
     void setReplicaReadiness(bool ready);
     void waitLoadingParts();
 
+    void restartDisk(const String & disk_name);
+
     void scheduleMerge(ASTSystemQuery & query);
     void syncMerges();
 

--- a/src/Storages/MergeTree/MergeTreeData.cpp
+++ b/src/Storages/MergeTree/MergeTreeData.cpp
@@ -2620,6 +2620,23 @@ void MergeTreeData::startStatisticsCache()
 void MergeTreeData::refreshDataParts(UInt64 interval_milliseconds)
 try
 {
+    refreshDataPartsOnce(interval_milliseconds);
+    refresh_parts_task->scheduleAfter(interval_milliseconds);
+}
+catch (...)
+{
+    tryLogCurrentException(log, "Failed to refresh parts");
+}
+
+/// Re-scan the data directory once: reload disk metadata and add parts that appeared since the
+/// last scan (it does not detect parts that vanished from disk; `grabOldParts` only cleans up
+/// parts already marked outdated). Shared by the background refresh task (which reschedules
+/// itself afterwards) and by `SYSTEM RESTART DISK` (an explicit, one-shot refresh). The two
+/// callers are serialized so they cannot load the same new part concurrently.
+void MergeTreeData::refreshDataPartsOnce(UInt64 interval_milliseconds)
+{
+    std::lock_guard refresh_lock(refresh_parts_mutex);
+
     for (auto & disk : getStoragePolicy()->getDisks())
         disk->refresh(interval_milliseconds);
 
@@ -2637,7 +2654,7 @@ try
         if (disk_ptr->isBroken())
             continue;
         if (!disk_ptr->isReadOnly())
-            throw Exception(ErrorCodes::LOGICAL_ERROR, "MergeTreeData::refreshDataParts should only be called if all disks are readonly");
+            throw Exception(ErrorCodes::LOGICAL_ERROR, "MergeTreeData::refreshDataPartsOnce should only be called if all disks are readonly");
 
         for (auto it = disk_ptr->iterateDirectory(relative_data_path); it->isValid(); it->next())
         {
@@ -2710,12 +2727,6 @@ try
 
     ProfileEvents::increment(ProfileEvents::LoadedDataParts, parts_to_add.size());
     ProfileEvents::increment(ProfileEvents::LoadedDataPartsMicroseconds, watch.elapsedMicroseconds());
-
-    refresh_parts_task->scheduleAfter(interval_milliseconds);
-}
-catch (...)
-{
-    tryLogCurrentException(log, "Failed to refresh parts");
 }
 
 void MergeTreeData::refreshStatistics(UInt64 interval_seconds)

--- a/src/Storages/MergeTree/MergeTreeData.h
+++ b/src/Storages/MergeTree/MergeTreeData.h
@@ -643,7 +643,10 @@ public:
 
     /// Check the set of data parts on disk and load if needed, assuming the data on disk can change under the hood.
     /// This method allows read-only replicas of tables on a shared storage.
+    /// `refreshDataParts` is the background-task entry point: it reschedules itself afterwards.
+    /// `refreshDataPartsOnce` performs a single refresh and is also used by `SYSTEM RESTART DISK`.
     void refreshDataParts(UInt64 interval_milliseconds);
+    void refreshDataPartsOnce(UInt64 interval_milliseconds);
 
     /// Returns a pointer to primary index cache if it is enabled.
     PrimaryIndexCachePtr getPrimaryIndexCache() const;
@@ -1888,6 +1891,12 @@ protected:
     void stopOutdatedAndUnexpectedDataPartsLoadingTask();
 
     BackgroundSchedulePoolTaskHolder refresh_parts_task;
+
+    /// Serializes refreshDataPartsOnce so the background refresh task and SYSTEM RESTART DISK
+    /// cannot scan and load the same new part concurrently (which would throw a duplicate-part
+    /// LOGICAL_ERROR, because the "is this part already present" check and the actual load are
+    /// not done under a single lock).
+    std::mutex refresh_parts_mutex;
 
     BackgroundSchedulePoolTaskHolder refresh_stats_task;
 

--- a/tests/queries/0_stateless/04318_system_restart_disk_plain_rewritable.reference
+++ b/tests/queries/0_stateless/04318_system_restart_disk_plain_rewritable.reference
@@ -1,0 +1,4 @@
+before restart:
+0
+after restart:
+1

--- a/tests/queries/0_stateless/04318_system_restart_disk_plain_rewritable.sh
+++ b/tests/queries/0_stateless/04318_system_restart_disk_plain_rewritable.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Tags: no-random-settings, no-object-storage, no-replicated-database, no-shared-merge-tree
+# Tag no-replicated-database: plain rewritable should not be shared between replicas
+
+# Two tables share a single plain_rewritable backing path: `writer` on a read-write disk,
+# `reader` on a readonly disk. The reader caches both the disk namespace and its part list
+# in memory, so it does not observe the writer's new part on its own. A single
+# `SYSTEM RESTART DISK` reloads the disk namespace and re-scans the part list of readonly
+# tables on that disk, so the reader observes the row without DETACH/ATTACH or a restart.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS writer SYNC"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE IF EXISTS reader SYNC"
+
+${CLICKHOUSE_CLIENT} --query "
+CREATE TABLE writer (s String) ORDER BY ()
+SETTINGS table_disk = true,
+  disk = disk(
+      name = restart_disk_writer_${CLICKHOUSE_DATABASE},
+      type = object_storage,
+      object_storage_type = local,
+      metadata_type = plain_rewritable,
+      path = 'disks/04318/${CLICKHOUSE_DATABASE}/')
+"
+
+# Same backing path, but readonly and WITHOUT refresh_parts_interval, so the only way for
+# this replica to notice external writes is an explicit SYSTEM RESTART DISK.
+${CLICKHOUSE_CLIENT} --query "
+CREATE TABLE reader (s String) ORDER BY ()
+SETTINGS table_disk = true,
+  disk = disk(
+      readonly = true,
+      name = restart_disk_reader_${CLICKHOUSE_DATABASE},
+      type = object_storage,
+      object_storage_type = local,
+      metadata_type = plain_rewritable,
+      path = 'disks/04318/${CLICKHOUSE_DATABASE}/')
+"
+
+${CLICKHOUSE_CLIENT} --query "INSERT INTO writer VALUES ('Hello')"
+
+# The reader has not reloaded its disk yet, so it does not see the new row.
+echo "before restart:"
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM reader"
+
+# One command reloads the disk namespace and re-scans the readonly table's parts.
+${CLICKHOUSE_CLIENT} --query "SYSTEM RESTART DISK restart_disk_reader_${CLICKHOUSE_DATABASE}"
+echo "after restart:"
+${CLICKHOUSE_CLIENT} --query "SELECT count() FROM reader"
+
+${CLICKHOUSE_CLIENT} --query "DROP TABLE reader SYNC"
+${CLICKHOUSE_CLIENT} --query "DROP TABLE writer SYNC"


### PR DESCRIPTION
<!--
Closes:
Related:
-->

## Description

`SYSTEM RESTART DISK <name>` was accepted by the parser and had access-control wiring, but its execution case was never implemented, so it failed with `Unknown type of SYSTEM query`. This implements it for the shared-storage reader scenario, where a `plain_rewritable` disk is written by one process and read by another (a readonly replica, the same setup served by the `refresh_parts_interval` setting).

A readonly reader caches two things in memory that go stale when another process writes: the disk's `plain_rewritable` namespace (the path map) and each table's active part list. `SYSTEM RESTART DISK` now refreshes both:

- it reloads the disk's in-memory metadata via `IDisk::refresh`, so directories written by another process become visible;
- it re-scans the part list of every loaded table on that disk whose data is entirely on readonly disks, so a single command yields read-your-writes without `DETACH`/`ATTACH` or a server restart.

To share the part-refresh logic with the background `refresh_parts_interval` task, `MergeTreeData::refreshDataPartsOnce` is split out of `refreshDataParts`: the latter wraps it and reschedules the background task (calling `refreshDataParts` directly would dereference the null background-task handle). The two callers are serialized by a mutex so they cannot load the same new part concurrently. The required-access wiring is also corrected: `RESTART_DISK` now requires `SYSTEM_RESTART_DISK` instead of sharing `SYSTEM_WAIT_BLOBS_CLEANUP`.

A stateless test (`04318_system_restart_disk_plain_rewritable`) covers a writer plus a readonly reader over a single shared `plain_rewritable` path.

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Implemented `SYSTEM RESTART DISK <name>`: it now reloads a disk's in-memory metadata and re-scans the data parts of readonly-replica tables located on it. This lets a readonly replica of a table on shared `plain_rewritable` storage observe data written by another server on demand, without waiting for `refresh_parts_interval` or restarting the server.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.470`
<!-- ch-version-info:end -->