### PR TITLE
Add test coverage and docs for force_add_bucket DataLake catalog setting

### DIFF
--- a/docs/en/engines/database-engines/datalake.md
+++ b/docs/en/engines/database-engines/datalake.md
@@ -59,6 +59,7 @@ The following settings are supported:
 | `region`                | AWS region for the service (e.g., `us-east-1`)                                          |
 | `dlf_access_key_id`     | Access key ID for DLF access                                                            |
 | `dlf_access_key_secret` | Access key Secret for DLF access                                                        |
+| `force_add_bucket`      | When constructing object-storage URLs from the catalog-provided table location and `storage_endpoint`, prepend the bucket/container name even if the endpoint already contains it. Default: `false`. Set to `true` for catalogs that hand back paths without the bucket and require it to be added at the URL-construction step (Polaris-style paths). |
 
 ## Examples {#examples}
 

--- a/src/Databases/DataLake/DatabaseDataLakeSettings.cpp
+++ b/src/Databases/DataLake/DatabaseDataLakeSettings.cpp
@@ -45,7 +45,7 @@ namespace ErrorCodes
     DECLARE(String, google_adc_credentials_file, "", "Deprecated setting, will throw an exception if used", 0) \
     DECLARE(String, dlf_access_key_id, "", "Access id of DLF token for Paimon REST Catalog", 0) \
     DECLARE(String, dlf_access_key_secret, "", "Access secret of DLF token for Paimon REST Catalog", 0) \
-    DECLARE(Bool, force_add_bucket, false, "Add bucket name to the metadata path", 0) \
+    DECLARE(Bool, force_add_bucket, false, "When constructing object-storage URLs from the catalog-provided table location and storage_endpoint, prepend the bucket/container name even if the endpoint already contains it. Useful for catalogs that hand back paths without the bucket and expect it to be added at URL construction (Polaris-style paths).", 0) \
 
 #define LIST_OF_DATABASE_ICEBERG_SETTINGS(M, ALIAS) \
     DATABASE_ICEBERG_RELATED_SETTINGS(M, ALIAS) \

--- a/src/Databases/DataLake/tests/gtest_azure_abfss_parsing.cpp
+++ b/src/Databases/DataLake/tests/gtest_azure_abfss_parsing.cpp
@@ -240,4 +240,48 @@ TEST_F(AzureAbfssParsingTest, TableMetadataGetLocationWithEndpointVirtualHostedD
     EXPECT_EQ(location, "https://my.dotted.bucket.s3.mycompany.com/path/to/table/");
 }
 
+TEST_F(AzureAbfssParsingTest, TableMetadataAbfssEndpointAlreadyContainsContainerDefault)
+{
+    TableMetadata metadata;
+    metadata.withLocation();
+    metadata.setLocation("abfss://mycontainer@mystorageaccount.dfs.core.windows.net/mycontainer/actual/path");
+    metadata.setEndpoint("https://mystorageaccount.dfs.core.windows.net/mycontainer");
+
+    EXPECT_EQ(
+        metadata.getLocation(),
+        "https://mystorageaccount.dfs.core.windows.net/mycontainer/mycontainer/actual/path/");
+}
+
+TEST_F(AzureAbfssParsingTest, TableMetadataAbfssEndpointAlreadyContainsContainerForceAddBucket)
+{
+    TableMetadata metadata;
+    metadata.withLocation().withForceAddBucket();
+    metadata.setLocation("abfss://mycontainer@mystorageaccount.dfs.core.windows.net/mycontainer/actual/path");
+    metadata.setEndpoint("https://mystorageaccount.dfs.core.windows.net/mycontainer");
+
+    EXPECT_EQ(
+        metadata.getLocation(),
+        "https://mystorageaccount.dfs.core.windows.net/mycontainer/mycontainer/mycontainer/actual/path/");
+}
+
+TEST_F(AzureAbfssParsingTest, TableMetadataS3EndpointAlreadyEndsWithBucketDefault)
+{
+    TableMetadata metadata;
+    metadata.withLocation();
+    metadata.setLocation("s3://warehouse-rest/data/testns/testtable");
+    metadata.setEndpoint("http://minio:9000/warehouse-rest");
+
+    EXPECT_EQ(metadata.getLocation(), "http://minio:9000/warehouse-rest/data/testns/testtable/");
+}
+
+TEST_F(AzureAbfssParsingTest, TableMetadataS3EndpointAlreadyEndsWithBucketForceAddBucket)
+{
+    TableMetadata metadata;
+    metadata.withLocation().withForceAddBucket();
+    metadata.setLocation("s3://warehouse-rest/data/testns/testtable");
+    metadata.setEndpoint("http://minio:9000/warehouse-rest");
+
+    EXPECT_EQ(metadata.getLocation(), "http://minio:9000/warehouse-rest/warehouse-rest/data/testns/testtable/");
+}
+
 }


### PR DESCRIPTION
Follow-up to #104120 per @alexbakharew's request on https://github.com/ClickHouse/ClickHouse/pull/104120#issuecomment-4626805935.

PR #104120 renamed the catalog Polaris-style flag to `force_add_bucket` and rewrote the `gtest_azure_abfss_parsing.cpp` suite. The two surviving references to the new flag in that suite (`TableMetadataSetLocationPolarisStyle` and `TableMetadataGetMetadataLocationEqualStrings`) do not actually exercise its behavior: the first calls `getLocation` without an endpoint set (so `constructLocation` is never reached), and the second does not call `withForceAddBucket` at all. Endpoint-bearing tests that previously exercised the flag (`TableMetadataSetLocationPolarisStyleWithEndpoint`, `TableMetadataSetLocationNonPolarisContainerInPathWithEndpoint`, `TableMetadataGetMetadataLocationS3WithHttpEndpoint`) were dropped by the rewrite.

Adds four targeted unit tests that distinguish the flag's behavior on the only two callers in `constructLocation`: the Azure-with-endpoint path and the S3-with-endpoint path. Each pair fixes the same location and an endpoint that already embeds the bucket/container, so the flag is the only difference and its effect on the constructed URL is observable.

Also adds a `force_add_bucket` row to the DataLakeCatalog settings table in the docs and tightens the in-source description.

Related: https://github.com/ClickHouse/ClickHouse/pull/104120

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add unit tests and documentation for the `force_add_bucket` DataLake catalog setting introduced by #104120.


### Documentation entry for user-facing changes
- [x] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.130`
<!-- ch-version-info:end -->