### PR TITLE
Remove the `no-stress` test tag and reject its use

### DIFF
--- a/docs/en/development/tests.md
+++ b/docs/en/development/tests.md
@@ -205,7 +205,7 @@ List of available tags:
 | `no-release` | Disables tests in Release builds ||
 | `no-darwin` | Disables test on macOS (Darwin) | Test relies on Linux-specific features such as distributed queries, `procfs`, or HTTP server |
 
-The following options are also supported: `no-stress`, `no-polymorphic-parts`, `no-random-settings`, `no-random-merge-tree-settings`, `no-backward-compatibility-check`, `no-cpu-x86_64`, `no-cpu-aarch64`, `no-cpu-ppc64le`, `no-s3-storage`.
+The following options are also supported: `no-polymorphic-parts`, `no-random-settings`, `no-random-merge-tree-settings`, `no-backward-compatibility-check`, `no-cpu-x86_64`, `no-cpu-aarch64`, `no-cpu-ppc64le`, `no-s3-storage`.
 
 In addition to above settings, you can use `USE_*` flags from `system.build_options` to define usage of particular ClickHouse features.
 For example, if your test uses a MySQL table, you should add a tag `use-mysql`.

--- a/tests/clickhouse-test
+++ b/tests/clickhouse-test
@@ -3813,6 +3813,11 @@ class TestSuite:
             tags_str = tags_str[len(tags_prefix) :]  # noqa: ignore E203
             tags = tags_str.split(",")
             tags = {tag.strip() for tag in tags}
+            if "no-stress" in tags:
+                raise ValueError(
+                    "The 'no-stress' tag is not supported: stress tests must be "
+                    "able to run every test. Remove it from the test."
+                )
             return tags
 
         def parse_memory_limits_from_line(

--- a/tests/queries/0_stateless/02310_clickhouse_local_INSERT_progress_profile_events.expect
+++ b/tests/queries/0_stateless/02310_clickhouse_local_INSERT_progress_profile_events.expect
@@ -1,5 +1,5 @@
 #!/usr/bin/expect -f
-# Tags: no-debug, no-tsan, no-msan, no-asan, no-ubsan, no-object-storage, no-cpu-aarch64, no-parallel, no-random-settings, no-stress
+# Tags: no-debug, no-tsan, no-msan, no-asan, no-ubsan, no-object-storage, no-cpu-aarch64, no-parallel, no-random-settings
 # ^ it can be slower than 60 seconds
 
 # This is the regression for the concurrent access in ProgressIndication,


### PR DESCRIPTION
The `no-stress` tag had no effect: support for it was reverted long ago in `bddead1ea21` ("Revert ... azat/no-stress"). Stress tests are expected to run every test, so this tag should never be used. It lingered only in one test and in the documentation.

This change removes the only remaining use of the tag, drops it from the docs, and makes `clickhouse-test` raise an error if any test declares it, so it is impossible to use again.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.473`
<!-- ch-version-info:end -->