### PR TITLE
Add diagnostic bounds asserts in threadpool remote-fs metadata read path (#104692)

### DIFF
--- a/src/Disks/IO/AsynchronousBoundedReadBuffer.cpp
+++ b/src/Disks/IO/AsynchronousBoundedReadBuffer.cpp
@@ -278,6 +278,20 @@ bool AsynchronousBoundedReadBuffer::nextImpl()
 
     chassert(use_page_cache || !result.page_cache_cell);
 
+    /// Diagnostic asserts for the bounds-corruption class of bug tracked in
+    /// `https://github.com/ClickHouse/ClickHouse/issues/104692`. The
+    /// `working_buffer` we hand back to the caller MUST be a sub-range of the
+    /// `Memory<>` we own (`memory.data()`, `memory.size()`), or, when the page
+    /// cache is in use, a sub-range of the cache cell that backs `result.buf`.
+    /// Anything else means an inner buffer (`ReadBufferFromS3`,
+    /// `ReadBufferFromRemoteFSGather`) returned a corrupt range.
+    chassert(result.offset <= result.size);
+    if (!use_page_cache)
+    {
+        chassert(result.size <= memory.size());
+        chassert(result.size == 0 || result.buf == memory.data());
+    }
+
     size_t bytes_read = result.size - result.offset;
     if (bytes_read)
     {

--- a/src/Disks/IO/ReadBufferFromRemoteFSGather.cpp
+++ b/src/Disks/IO/ReadBufferFromRemoteFSGather.cpp
@@ -135,18 +135,14 @@ bool ReadBufferFromRemoteFSGather::readImpl()
                 file_offset_of_buffer_end, current_buf->getFileOffsetOfBufferEnd(),
                 current_buf->available(), nextimpl_working_buffer_offset));
 
-        /// Diagnostic asserts for the bounds-corruption class of bug tracked in
-        /// `https://github.com/ClickHouse/ClickHouse/issues/104692`. While the
-        /// `SwapHelper` is in scope, `current_buf->buffer()` is the buffer view
-        /// our caller will see after the swap is undone. When
-        /// `use_external_buffer` is set, that range MUST lie inside
-        /// `internal_buffer` (the external buffer the caller handed us). If it
-        /// doesn't, the caller's owned `Memory<>` ends up silently extended
-        /// with bytes from somewhere else.
+        /// While the `SwapHelper` is in scope our external buffer lives on
+        /// `current_buf->internalBuffer`, not on `this->internal_buffer`.
+        /// The asserts must run on the same side of the swap as the working
+        /// buffer they validate.
         if (use_external_buffer)
         {
-            chassert(current_buf->buffer().begin() >= internal_buffer.begin());
-            chassert(current_buf->buffer().begin() + current_buf->buffer().size() <= internal_buffer.end());
+            chassert(current_buf->buffer().begin() >= current_buf->internalBuffer().begin());
+            chassert(current_buf->buffer().begin() + current_buf->buffer().size() <= current_buf->internalBuffer().end());
         }
     }
 

--- a/src/Disks/IO/ReadBufferFromRemoteFSGather.cpp
+++ b/src/Disks/IO/ReadBufferFromRemoteFSGather.cpp
@@ -134,6 +134,20 @@ bool ReadBufferFromRemoteFSGather::readImpl()
                 "offset: {}, buf offset: {}, available: {}, nextimpl offset: {}",
                 file_offset_of_buffer_end, current_buf->getFileOffsetOfBufferEnd(),
                 current_buf->available(), nextimpl_working_buffer_offset));
+
+        /// Diagnostic asserts for the bounds-corruption class of bug tracked in
+        /// `https://github.com/ClickHouse/ClickHouse/issues/104692`. While the
+        /// `SwapHelper` is in scope, `current_buf->buffer()` is the buffer view
+        /// our caller will see after the swap is undone. When
+        /// `use_external_buffer` is set, that range MUST lie inside
+        /// `internal_buffer` (the external buffer the caller handed us). If it
+        /// doesn't, the caller's owned `Memory<>` ends up silently extended
+        /// with bytes from somewhere else.
+        if (use_external_buffer)
+        {
+            chassert(current_buf->buffer().begin() >= internal_buffer.begin());
+            chassert(current_buf->buffer().begin() + current_buf->buffer().size() <= internal_buffer.end());
+        }
     }
 
     return result;

--- a/src/Disks/IO/ReadBufferFromRemoteFSGather.cpp
+++ b/src/Disks/IO/ReadBufferFromRemoteFSGather.cpp
@@ -10,6 +10,8 @@
 #include <Interpreters/FilesystemCacheLog.h>
 #include <Common/logger_useful.h>
 
+#include <cstdint>
+
 using namespace DB;
 
 namespace DB
@@ -18,6 +20,29 @@ namespace ErrorCodes
 {
     extern const int CANNOT_SEEK_THROUGH_FILE;
     extern const int LOGICAL_ERROR;
+
+}
+
+namespace
+{
+
+/// Diagnostic predicate for the bounds-corruption class of bug tracked in
+/// `https://github.com/ClickHouse/ClickHouse/issues/104692`. Validates that
+/// `inner` is fully contained in `outer` WITHOUT touching `Buffer::size` or
+/// `begin + size` arithmetic on `inner`. If `inner` is corrupt (inverted, or
+/// `begin`/`end` from different allocations), `Buffer::size` would be a huge
+/// unsigned and `begin + size` would overflow before `chassert` ever reports
+/// anything. Compare the four stored pointers as integer addresses instead.
+void assertWorkingBufferContainedIn(BufferBase::Buffer inner, BufferBase::Buffer outer)
+{
+    auto inner_begin = reinterpret_cast<std::uintptr_t>(inner.begin());
+    auto inner_end = reinterpret_cast<std::uintptr_t>(inner.end());
+    auto outer_begin = reinterpret_cast<std::uintptr_t>(outer.begin());
+    auto outer_end = reinterpret_cast<std::uintptr_t>(outer.end());
+    chassert(inner_begin <= inner_end);
+    chassert(inner_begin >= outer_begin);
+    chassert(inner_end <= outer_end);
+}
 
 }
 
@@ -140,10 +165,7 @@ bool ReadBufferFromRemoteFSGather::readImpl()
         /// The asserts must run on the same side of the swap as the working
         /// buffer they validate.
         if (use_external_buffer)
-        {
-            chassert(current_buf->buffer().begin() >= current_buf->internalBuffer().begin());
-            chassert(current_buf->buffer().begin() + current_buf->buffer().size() <= current_buf->internalBuffer().end());
-        }
+            assertWorkingBufferContainedIn(current_buf->buffer(), current_buf->internalBuffer());
     }
 
     return result;

--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -210,6 +210,18 @@ bool ReadBufferFromS3::nextImpl()
         return false;
     }
 
+    /// Diagnostic asserts for the bounds-corruption class of bug tracked in
+    /// `https://github.com/ClickHouse/ClickHouse/issues/104692`. When
+    /// `use_external_buffer` is set, the inner `impl` was told to fill our
+    /// caller-provided `internal_buffer`. If the populated range escapes that
+    /// external buffer, every consumer up the chain
+    /// (`ReadBufferFromRemoteFSGather`, `AsynchronousBoundedReadBuffer`,
+    /// `readMetadataFile`) inherits the corrupt bounds.
+    if (use_external_buffer)
+    {
+        chassert(impl->buffer().begin() >= internal_buffer.begin());
+        chassert(impl->buffer().begin() + impl->buffer().size() <= internal_buffer.end());
+    }
     BufferBase::set(impl->buffer().begin(), impl->buffer().size(), impl->offset());
 
     ProfileEvents::increment(ProfileEvents::ReadBufferFromS3Bytes, working_buffer.size());

--- a/src/IO/ReadBufferFromS3.cpp
+++ b/src/IO/ReadBufferFromS3.cpp
@@ -16,6 +16,7 @@
 #include <Common/CurrentThread.h>
 #include <base/sleep.h>
 
+#include <cstdint>
 #include <utility>
 
 
@@ -51,6 +52,29 @@ namespace ErrorCodes
     extern const int LOGICAL_ERROR;
     extern const int CANNOT_ALLOCATE_MEMORY;
     extern const int NOT_INITIALIZED;
+}
+
+namespace
+{
+
+/// Diagnostic predicate for the bounds-corruption class of bug tracked in
+/// `https://github.com/ClickHouse/ClickHouse/issues/104692`. Validates that
+/// `inner` is fully contained in `outer` WITHOUT touching `Buffer::size` or
+/// `begin + size` arithmetic on `inner`. If `inner` is corrupt (inverted, or
+/// `begin`/`end` from different allocations), `Buffer::size` would be a huge
+/// unsigned and `begin + size` would overflow before `chassert` ever reports
+/// anything. Compare the four stored pointers as integer addresses instead.
+void assertWorkingBufferContainedIn(BufferBase::Buffer inner, BufferBase::Buffer outer)
+{
+    auto inner_begin = reinterpret_cast<std::uintptr_t>(inner.begin());
+    auto inner_end = reinterpret_cast<std::uintptr_t>(inner.end());
+    auto outer_begin = reinterpret_cast<std::uintptr_t>(outer.begin());
+    auto outer_end = reinterpret_cast<std::uintptr_t>(outer.end());
+    chassert(inner_begin <= inner_end);
+    chassert(inner_begin >= outer_begin);
+    chassert(inner_end <= outer_end);
+}
+
 }
 
 
@@ -218,10 +242,7 @@ bool ReadBufferFromS3::nextImpl()
     /// (`ReadBufferFromRemoteFSGather`, `AsynchronousBoundedReadBuffer`,
     /// `readMetadataFile`) inherits the corrupt bounds.
     if (use_external_buffer)
-    {
-        chassert(impl->buffer().begin() >= internal_buffer.begin());
-        chassert(impl->buffer().begin() + impl->buffer().size() <= internal_buffer.end());
-    }
+        assertWorkingBufferContainedIn(impl->buffer(), internal_buffer);
     BufferBase::set(impl->buffer().begin(), impl->buffer().size(), impl->offset());
 
     ProfileEvents::increment(ProfileEvents::ReadBufferFromS3Bytes, working_buffer.size());

--- a/src/IO/ReadHelpers.cpp
+++ b/src/IO/ReadHelpers.cpp
@@ -10,6 +10,7 @@
 #include <IO/PeekableReadBuffer.h>
 #include <IO/readFloatText.h>
 #include <IO/Operators.h>
+#include <cstdint>
 #include <cstdlib>
 #include <bit>
 #include <utility>
@@ -177,6 +178,28 @@ bool checkStringByFirstCharacterAndAssertTheRestCaseInsensitive(const char * s, 
 }
 
 
+/// Diagnostic predicate for the bounds-corruption class of bug tracked in
+/// `https://github.com/ClickHouse/ClickHouse/issues/104692`. Validates the
+/// caller-supplied `[rb.position(), end)` source range against the working
+/// buffer `[rb.buffer().begin(), rb.buffer().end())` WITHOUT performing
+/// relational pointer comparisons on the untrusted range. C++ relational
+/// comparisons between pointers from different allocations are UB; if
+/// `working_buffer` is corrupt and its begin/end / `end` come from different
+/// allocations, the predicates `end >= rb.position()`, `end <= rb.buffer().end()`,
+/// and `rb.position() >= rb.buffer().begin()` could trigger UB before
+/// `chassert` ever reports the bug. Compare the four pointers as integer
+/// addresses instead.
+static void assertReadBufferRangeForAppend(ReadBuffer & rb, const char * end)
+{
+    auto pos_addr = reinterpret_cast<std::uintptr_t>(rb.position());
+    auto end_addr = reinterpret_cast<std::uintptr_t>(end);
+    auto wb_begin_addr = reinterpret_cast<std::uintptr_t>(rb.buffer().begin());
+    auto wb_end_addr = reinterpret_cast<std::uintptr_t>(rb.buffer().end());
+    chassert(pos_addr <= end_addr);
+    chassert(end_addr <= wb_end_addr);
+    chassert(pos_addr >= wb_begin_addr);
+}
+
 template <typename T>
 static void appendToStringOrVector(T & s, ReadBuffer & rb, const char * end)
 {
@@ -184,21 +207,17 @@ static void appendToStringOrVector(T & s, ReadBuffer & rb, const char * end)
     /// `https://github.com/ClickHouse/ClickHouse/issues/104692`. If
     /// `working_buffer` becomes inverted or extends past the underlying owned
     /// `Memory<>`, the `s.append` below memcpys an arbitrary span and corrupts
-    /// the destination `String`'s heap arena. The crash then surfaces either at
-    /// the memcpy itself (unmapped source) or much later when the oversized
-    /// `String` is freed.
-    chassert(end >= rb.position());
-    chassert(end <= rb.buffer().end());
-    chassert(rb.position() >= rb.buffer().begin());
+    /// the destination `String`'s heap arena. The exception then surfaces
+    /// either at the memcpy itself (unmapped source) or much later when the
+    /// oversized `String` is freed.
+    assertReadBufferRangeForAppend(rb, end);
     s.append(rb.position(), end - rb.position());
 }
 
 template <>
 inline void appendToStringOrVector(PaddedPODArray<UInt8> & s, ReadBuffer & rb, const char * end)
 {
-    chassert(end >= rb.position());
-    chassert(end <= rb.buffer().end());
-    chassert(rb.position() >= rb.buffer().begin());
+    assertReadBufferRangeForAppend(rb, end);
     if (rb.isPadded())
         s.insertSmallAllowReadWriteOverflow15(rb.position(), end);
     else
@@ -208,9 +227,7 @@ inline void appendToStringOrVector(PaddedPODArray<UInt8> & s, ReadBuffer & rb, c
 template <>
 inline void appendToStringOrVector(PODArray<char> & s, ReadBuffer & rb, const char * end)
 {
-    chassert(end >= rb.position());
-    chassert(end <= rb.buffer().end());
-    chassert(rb.position() >= rb.buffer().begin());
+    assertReadBufferRangeForAppend(rb, end);
     s.insert(rb.position(), end);
 }
 

--- a/src/IO/ReadHelpers.cpp
+++ b/src/IO/ReadHelpers.cpp
@@ -180,12 +180,25 @@ bool checkStringByFirstCharacterAndAssertTheRestCaseInsensitive(const char * s, 
 template <typename T>
 static void appendToStringOrVector(T & s, ReadBuffer & rb, const char * end)
 {
+    /// Diagnostic asserts for the bounds-corruption class of bug tracked in
+    /// `https://github.com/ClickHouse/ClickHouse/issues/104692`. If
+    /// `working_buffer` becomes inverted or extends past the underlying owned
+    /// `Memory<>`, the `s.append` below memcpys an arbitrary span and corrupts
+    /// the destination `String`'s heap arena. The crash then surfaces either at
+    /// the memcpy itself (unmapped source) or much later when the oversized
+    /// `String` is freed.
+    chassert(end >= rb.position());
+    chassert(end <= rb.buffer().end());
+    chassert(rb.position() >= rb.buffer().begin());
     s.append(rb.position(), end - rb.position());
 }
 
 template <>
 inline void appendToStringOrVector(PaddedPODArray<UInt8> & s, ReadBuffer & rb, const char * end)
 {
+    chassert(end >= rb.position());
+    chassert(end <= rb.buffer().end());
+    chassert(rb.position() >= rb.buffer().begin());
     if (rb.isPadded())
         s.insertSmallAllowReadWriteOverflow15(rb.position(), end);
     else
@@ -195,6 +208,9 @@ inline void appendToStringOrVector(PaddedPODArray<UInt8> & s, ReadBuffer & rb, c
 template <>
 inline void appendToStringOrVector(PODArray<char> & s, ReadBuffer & rb, const char * end)
 {
+    chassert(end >= rb.position());
+    chassert(end <= rb.buffer().end());
+    chassert(rb.position() >= rb.buffer().begin());
     s.insert(rb.position(), end);
 }
 


### PR DESCRIPTION
The flaky test `03710_parallel_alter_comment_rename_selects` fails intermittently with `server died` while a `SELECT * FROM system.tables` worker thread reads table metadata via `readMetadataFile`. The two known surfacings look different but are both consistent with one underlying bug class.

* In one occurrence the crash is in the memcpy inside `appendToStringOrVector`, with `Address not mapped to object` / `SEGV_MAPERR` -- the source pointer of the memcpy is unmapped.
* In another occurrence (PR #105640, 2026-05-25, aarch64 ASan+UBSan, decoded core), the live frames are `LargeMmapAllocator::Deallocate` from `Quarantine::Recycle` from `operator delete` from `TablesBlockSource::generate` (`StorageSystemTables.cpp:959`) -- the per-table `String` returned for one `CREATE` query has a corrupt large-allocation header by the time the loop iteration frees it.

Both fit one mechanism: somewhere in the threadpool remote-fs read chain (`ReadBufferFromS3` -> `ReadBufferFromRemoteFSGather` -> `AsynchronousBoundedReadBuffer`), `working_buffer` ends up either inverted (`end < position`) or extended past the owned `Memory<>`. Then `appendToStringOrVector`'s `s.append(rb.position(), end - rb.position())` memcpys an arbitrary span and corrupts the destination `String`. The crash surfaces either at the memcpy (unmapped source) or much later when the oversized `String` is freed.

A core dump at the FREE site cannot reveal the WRITE site, and we have not been able to reproduce the failure locally despite several heavy MinIO+plain_rewritable+ASan stress runs.

Per @alexey-milovidov's request on https://github.com/ClickHouse/ClickHouse/issues/104692#issuecomment-4641207058 (\"yes, let's add more asserts\"), this PR adds targeted `chassert` calls along the threadpool remote-fs metadata read chain. They are no-ops in release builds. They should fire on the WRITE site of the corruption with a deterministic stack trace next time CI hits this in a debug or sanitizer build, so we can identify the exact mechanism instead of guessing.

Asserts added:

* `src/IO/ReadHelpers.cpp` -- in all three `appendToStringOrVector` overloads, assert `end >= rb.position()`, `end <= rb.buffer().end()`, and `rb.position() >= rb.buffer().begin()`. Catches an inverted or escaped `working_buffer` at the consumer side regardless of which inner buffer produced it.
* `src/Disks/IO/AsynchronousBoundedReadBuffer.cpp` -- in `nextImpl`, where `working_buffer` is set from the `IAsynchronousReader::Result`, assert `result.offset <= result.size` and (when the page cache is not in use) `result.size <= memory.size()` and `result.buf == memory.data()`. Catches the case where the inner Gather/S3 chain returned a range that exceeds or doesn't match the owned `Memory<>`.
* `src/Disks/IO/ReadBufferFromRemoteFSGather.cpp` -- in `readImpl`, after `current_buf->next()` succeeds, assert (when `use_external_buffer` is set) that `current_buf->buffer()` lies inside our `internal_buffer`.
* `src/IO/ReadBufferFromS3.cpp` -- in `nextImpl`, before `BufferBase::set(impl->buffer()...)`, assert (when `use_external_buffer` is set) that `impl->buffer()` lies inside our `internal_buffer`.

Closes: https://github.com/ClickHouse/ClickHouse/issues/104692

Related CI report: https://s3.amazonaws.com/clickhouse-test-reports/PRs/105640/9f1efa05d97b0c6bc1c652857999eded33b5d671/stateless_tests_arm_asan_ubsan_azure_sequential/

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.603`
<!-- ch-version-info:end -->