### PR TITLE
Exempt OOM in dmesg from flaky and targeted integration test checks

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -1059,11 +1059,13 @@ tar -czf ./ci/tmp/logs.tar.gz \
                 )
                 attached_files.append("./ci/tmp/dmesg.log")
 
-    # For targeted and flaky checks, session-timeout is an expected risk (because of
-    # `--count N` overloading on targeted, and the soft FLAKY_CHECK_TIME_LIMIT on flaky),
-    # so do not propagate the synthetic `Timeout` result as a failure.
+    # In targeted and flaky checks, `Timeout` and `OOM in dmesg` reflect intentional
+    # overload of the runner, not per-test regressions, so drop the synthetic results.
+    # The `dmesg.log` is still attached above for debugging.
     if is_targeted_check or is_flaky_check:
-        test_results = [r for r in test_results if r.name != "Timeout"]
+        test_results = [
+            r for r in test_results if r.name not in ("Timeout", OOM_IN_DMESG_TEST_NAME)
+        ]
 
     R = Result.create_from(results=test_results, stopwatch=sw, files=attached_files)
 


### PR DESCRIPTION
Mirror the existing `Timeout` exemption for `OOM in dmesg` in `ci/jobs/integration_test_job.py`. Targeted and flaky integration test checks deliberately overload the runner (`--count N` for targeted, `--dist=each` over all changed test modules for flaky), so a host-level OOM under that overload is not attributable to any individual changed test. The `dmesg.log` is still attached for debugging.

Reported by @alexey-milovidov on https://github.com/ClickHouse/ClickHouse/pull/105171#issuecomment-4641116003, referencing failing run https://github.com/ClickHouse/ClickHouse/actions/runs/26987765500/job/79643750220.

Related: https://github.com/ClickHouse/ClickHouse/pull/105819
Related: https://github.com/ClickHouse/ClickHouse/pull/105171

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...