### PR TITLE
Client: keep pasted multi-line query under a single prompt with `--highlight 0`

### DIFF
--- a/src/Client/ReplxxLineReader.cpp
+++ b/src/Client/ReplxxLineReader.cpp
@@ -379,8 +379,11 @@ ReplxxLineReader::ReplxxLineReader(ReplxxLineReader::Options && options)
         /// paste support), fold the embedded newline into the same edit buffer instead of
         /// committing a partial query and switching to the continuation prompt. This way the
         /// whole paste lives in a single replxx edit buffer and arrow keys navigate across it.
-        /// NOTE: Lexer is only available if we use highlighter.
-        if (highlighter && !replxx_last_is_delimiter && (multiline || hasInputData()))
+        /// The paste case does not depend on the highlighter: the `NEW_LINE` action only inserts
+        /// a newline into the edit buffer and does not use the lexer, so the paste stays under a
+        /// single prompt even with `--highlight 0`. The explicit `--multiline` continuation still
+        /// requires the highlighter, preserving the previous behavior.
+        if (!replxx_last_is_delimiter && ((highlighter && multiline) || hasInputData()))
             return rx.invoke(Replxx::ACTION::NEW_LINE, code);
         replxx_last_is_delimiter = false;
         return rx.invoke(Replxx::ACTION::COMMIT_LINE, code);


### PR DESCRIPTION
Follow-up to #104299.

The paste-folding behavior added in #104299 keeps a pasted multi-line query under a single prompt (instead of switching to the `:-]` continuation prompt for every embedded newline) when the terminal does not support bracketed paste. However, that code path was gated on the `highlighter` callback being present:

```cpp
if (highlighter && !replxx_last_is_delimiter && (multiline || hasInputData()))
    return rx.invoke(Replxx::ACTION::NEW_LINE, code);
```

With `clickhouse-client --highlight 0` the `highlighter` is empty, so the whole condition short-circuits to `false`, every embedded newline of a non-bracketed paste takes `COMMIT_LINE`, and the old continuation loop is used again. That made the single-prompt promise from the changelog hold only in the default highlighted mode, even though `--highlight` is documented as a display option.

The `NEW_LINE` action in `replxx` is implemented as `insert_character('\n')` and does not use the lexer, so the paste case does not actually need the highlighter. This change decouples them: the `hasInputData()` paste path now folds embedded newlines regardless of the highlighter, while the explicit `--multiline` continuation keeps requiring the highlighter, preserving the previous behavior.

This addresses the remaining unresolved review thread on #104299.

Related: https://github.com/ClickHouse/ClickHouse/pull/104299

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

In `clickhouse-client`, keeping a pasted multi-line query under a single prompt (when the terminal does not support bracketed paste) now also works with syntax highlighting disabled (`--highlight 0`).

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.478`
<!-- ch-version-info:end -->