### PR TITLE
Remove note about not releasing a C library

### DIFF
--- a/docs/en/development/architecture.md
+++ b/docs/en/development/architecture.md
@@ -166,7 +166,7 @@ The server initializes the `Context` class with the necessary environment for qu
 We maintain full backward and forward compatibility for the server TCP protocol: old clients can talk to new servers, and new clients can talk to old servers. But we do not want to maintain it eternally, and we are removing support for old versions after about one year.
 
 :::note
-For most external applications, we recommend using the HTTP interface because it is simple and easy to use. The TCP protocol is more tightly linked to internal data structures: it uses an internal format for passing blocks of data, and it uses custom framing for compressed data. We haven't released a C library for that protocol because it requires linking most of the ClickHouse codebase, which is not practical.
+For most external applications, we recommend using the HTTP interface because it is simple and easy to use. The TCP protocol is more tightly linked to internal data structures: it uses an internal format for passing blocks of data, and it uses custom framing for compressed data.
 :::
 
 ## Configuration {#configuration}


### PR DESCRIPTION
There's [clickhouse-cpp](https://github.com/ClickHouse/clickhouse-cpp), [ch-go](https://github.com/ClickHouse/ch-go), & most recently [clickhouse-c](https://github.com/ClickHouse/clickhouse-c) all implementing partial support for native protocol

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Documentation (changelog entry is not required)