### PR TITLE
Fix flaky 00906_low_cardinality_cache and 00945_bloom_filter_index on Azure parallel runner

### DIFF
--- a/tests/queries/0_stateless/00906_low_cardinality_cache.sql
+++ b/tests/queries/0_stateless/00906_low_cardinality_cache.sql
@@ -4,5 +4,8 @@ SET max_rows_to_read = '100M', max_execution_time = 600;
 drop table if exists lc_00906;
 create table lc_00906 (b LowCardinality(String)) engine=MergeTree order by b SETTINGS index_granularity = 8192, index_granularity_bytes = '10Mi', vertical_merge_algorithm_min_rows_to_activate=100000000;
 insert into lc_00906 select '0123456789' from numbers(100000000) SETTINGS max_insert_threads=6, max_threads=4;
-select count(), b from lc_00906 group by b;
+-- Aggregating a single `LowCardinality` group produces one row, so a single thread is enough.
+-- Pinning `max_threads = 1` avoids per-thread aggregation-state allocations that, combined with
+-- randomized parallel replicas, can push the runner over its memory budget under shared load.
+select count(), b from lc_00906 group by b SETTINGS max_threads = 1, enable_parallel_replicas = 0;
 drop table if exists lc_00906;

--- a/tests/queries/0_stateless/00945_bloom_filter_index.sql
+++ b/tests/queries/0_stateless/00945_bloom_filter_index.sql
@@ -6,6 +6,13 @@ SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injectio
 -- Prevent remote replicas from skipping index analysis in Parallel Replicas. Otherwise, they may return full ranges and trigger max_rows_to_read validation failures.
 SET parallel_replicas_index_analysis_only_on_coordinator = 0;
 
+-- All tables in this test are tiny (a few hundred rows). The randomized-settings diagnoser
+-- (issue #104873) identified the parallel-replicas cluster as the reproducing trigger, and
+-- single-threaded execution is sufficient for verifying bloom-filter index behaviour. Pinning
+-- both keeps the test light enough to coexist with heavier sibling tests on shared CI runners.
+SET max_threads = 1;
+SET enable_parallel_replicas = 0;
+
 DROP TABLE IF EXISTS single_column_bloom_filter;
 
 CREATE TABLE single_column_bloom_filter (u64 UInt64, i32 Int32, i64 UInt64, INDEX idx (i32) TYPE bloom_filter GRANULARITY 1) ENGINE = MergeTree() ORDER BY u64 SETTINGS index_granularity = 6, index_granularity_bytes = '10Mi';


### PR DESCRIPTION
Both tests intermittently fail on `Stateless tests (arm_asan_ubsan, azure, parallel)` with `MEMORY_LIMIT_EXCEEDED` from the global tracker, with `Failed 0 out of 3 reruns` (transient runner-wide pressure, not per-test bugs). Reported on PR #74691 (alexey-milovidov asked us to fix and send a PR).

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=74691&sha=ae085e998b212b496c9ad6166c2f5dd64625b65c&name_0=PR&name_1=Stateless%20tests%20%28arm_asan_ubsan%2C%20azure%2C%20parallel%29

**Failure shape (both at 15:39:56 UTC, same run, RSS = 50.39 GiB / 53.69 GiB max):**

- `00906_low_cardinality_cache` fails inside `AggregatingTransform::consume` on the `GROUP BY b` query (1-row result, but spawns per-thread aggregation state under default `max_threads`).
- `00945_bloom_filter_index` fails inside `MergeTreeSelect` on a tiny IN-set lookup. Issue #104873's randomized-settings diagnoser identified the parallel-replicas cluster (`enable_parallel_replicas`/`cluster_for_parallel_replicas`/`parallel_replicas_for_non_replicated_merge_tree`) as the trigger.

**Fix:** pin the minimum settings to keep these tests light enough to coexist with heavier siblings on shared runners.

- `00906`: `max_threads = 1, enable_parallel_replicas = 0` on the GROUP BY. Local measurement: tracked memory drops from 3.16 MiB to 478 KiB (6.6x reduction).
- `00945`: `max_threads = 1` and `enable_parallel_replicas = 0` at the top. All tables are <= a few hundred rows; single-threaded execution is sufficient to verify bloom-filter index behaviour.

Test intent is preserved in both cases: the `LowCardinality` cache and bloom filter index assertions are unchanged.

Related: https://github.com/ClickHouse/ClickHouse/pull/74691
Related: https://github.com/ClickHouse/ClickHouse/issues/104873
Related: https://github.com/ClickHouse/ClickHouse/issues/91024

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [x] Documentation is written (mandatory for new features)