### PR TITLE
Mark caught LOGICAL_ERROR exception as logged in BackupDataFileNameGenerator gtest

### DIFF
--- a/src/Backups/tests/gtest_backup_data_file_name_generator.cpp
+++ b/src/Backups/tests/gtest_backup_data_file_name_generator.cpp
@@ -92,6 +92,14 @@ TEST(BackupDataFileNameGeneratorTest, ThrowsOnZeroChecksum)
     auto info = makeFileInfo("test.bin", checksum);
 
     auto prefix_length = 2;
-    EXPECT_THROW(getBackupDataFileName(info, BackupDataFileNameGeneratorType::Checksum, prefix_length), Exception);
+    try
+    {
+        getBackupDataFileName(info, BackupDataFileNameGeneratorType::Checksum, prefix_length);
+        FAIL() << "Expected DB::Exception with LOGICAL_ERROR for zero checksum";
+    }
+    catch (Exception & e)
+    {
+        e.markAsLogged();
+    }
 #endif
 }


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/100177

`BackupDataFileNameGeneratorTest.ThrowsOnZeroChecksum` deliberately throws `DB::Exception(LOGICAL_ERROR, ...)` from `getBackupDataFileName` to validate the zero-checksum guard. On non-debug, non-sanitizer builds (e.g. `Unit tests (amd_llvm_coverage)`) the test passes, but `Exception::~Exception` then logs the exception with a stack trace via `ForcedCriticalErrorsLogger` because `LOGICAL_ERROR` is "important" unless `markAsLogged` was called. The trace ends up on the gtest binary's stderr, after the test's `[ OK ]` line.

When an unrelated test in the same `unit_tests_dbms` binary later hangs and the `gdb -batch ... -ex run` runner times out and kills the binary mid-suite, `gtest.json` is never written. Praktika's `from_gtest` parser falls back to log-scraping, which then surfaces the stray `Backup checksum should not be zero (test.bin). (LOGICAL_ERROR)` trace as a fake `-FunctionsStress` failure in CIDB. 16 such hits across `Unit tests (amd_llvm_coverage)` on PRs #100177, #105784, #96100 in the last 60 days — all attributable to the underlying `SchedulerWorkloadResourceManager` / `FunctionsStress` chronic hang family, not the backup test.

Replace `EXPECT_THROW(..., Exception)` with an equivalent `try` block that calls `markAsLogged` on the caught exception, mirroring the pattern from commit `64a4caa39242` ("Mark fuzzer exceptions as logged to prevent `ForcedCriticalErrorsLogger`") in `src/Interpreters/executeQuery.cpp`. Verified locally with a release-mode `unit_tests_dbms` (`-O3 -DNDEBUG`, `ENABLE_TESTS=1`, no sanitizer): the pre-fix binary prints a 17-frame stack trace to stderr on this test, while the post-fix binary runs the test silently with `[ OK ]` and no trace.

CI report containing the trace: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=100177&sha=6e1a7cdc1170bb75bbcc76d5c46ba23c6cc38855&name_0=PR&name_1=Unit%20tests%20%28amd_llvm_coverage%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.406` (included in `26.7` and later)
<!-- ch-version-info:end -->