### PR TITLE
Fix `std::bad_alloc` in Darwin `CHJIT` arena routing

### DIFF
--- a/src/Common/JemallocJITArena.cpp
+++ b/src/Common/JemallocJITArena.cpp
@@ -22,10 +22,13 @@ namespace ProfileEvents
 namespace DB::JemallocJITArena
 {
 
+/// The arena only has JIT callers when `USE_EMBEDDED_COMPILER` is enabled. On Darwin, jemalloc
+/// goes through the zone allocator; switching `thread.arena` while LLVM creates AArch64 `CHJIT`
+/// target-machine state can throw `std::bad_alloc`, so keep JIT allocations on the default arena.
+#if USE_EMBEDDED_COMPILER && !defined(OS_DARWIN)
+
 namespace
 {
-
-#if USE_EMBEDDED_COMPILER && !defined(OS_DARWIN)
 
 struct ArenaState
 {
@@ -63,34 +66,31 @@ const ArenaState & state()
     return s;
 }
 
-#endif
-
 }
 
 unsigned getArenaIndex()
 {
-#if USE_EMBEDDED_COMPILER && !defined(OS_DARWIN)
     return state().index;
-#else
-    return 0;
-#endif
 }
 
 bool isEnabled()
 {
-    /// The arena only has callers when JIT is built in. Without USE_EMBEDDED_COMPILER, nothing
-    /// allocates here; reporting `enabled` would create a useless empty arena and expose a
-    /// permanently-zero metric. Pair the runtime jemalloc check with the compile-time JIT check.
-    ///
-    /// macOS uses jemalloc through the zone allocator. Switching `thread.arena` around LLVM
-    /// target-machine construction currently makes AArch64 `CHJIT` initialization throw
-    /// `std::bad_alloc`, so keep JIT allocations on the default arena there.
-#if USE_EMBEDDED_COMPILER && !defined(OS_DARWIN)
     return state().created;
-#else
-    return false;
-#endif
 }
+
+#else
+
+unsigned getArenaIndex()
+{
+    return 0;
+}
+
+bool isEnabled()
+{
+    return false;
+}
+
+#endif
 
 void purge()
 {

--- a/src/Common/JemallocJITArena.cpp
+++ b/src/Common/JemallocJITArena.cpp
@@ -25,6 +25,8 @@ namespace DB::JemallocJITArena
 namespace
 {
 
+#if USE_EMBEDDED_COMPILER && !defined(OS_DARWIN)
+
 struct ArenaState
 {
     unsigned index;
@@ -61,11 +63,17 @@ const ArenaState & state()
     return s;
 }
 
+#endif
+
 }
 
 unsigned getArenaIndex()
 {
+#if USE_EMBEDDED_COMPILER && !defined(OS_DARWIN)
     return state().index;
+#else
+    return 0;
+#endif
 }
 
 bool isEnabled()
@@ -73,7 +81,11 @@ bool isEnabled()
     /// The arena only has callers when JIT is built in. Without USE_EMBEDDED_COMPILER, nothing
     /// allocates here; reporting `enabled` would create a useless empty arena and expose a
     /// permanently-zero metric. Pair the runtime jemalloc check with the compile-time JIT check.
-#if USE_EMBEDDED_COMPILER
+    ///
+    /// macOS uses jemalloc through the zone allocator. Switching `thread.arena` around LLVM
+    /// target-machine construction currently makes AArch64 `CHJIT` initialization throw
+    /// `std::bad_alloc`, so keep JIT allocations on the default arena there.
+#if USE_EMBEDDED_COMPILER && !defined(OS_DARWIN)
     return state().created;
 #else
     return false;

--- a/src/Common/JemallocJITArena.h
+++ b/src/Common/JemallocJITArena.h
@@ -5,10 +5,11 @@ namespace DB::JemallocJITArena
 
 /// Returns the jemalloc arena index dedicated to LLVM/JIT allocations.
 /// Creates the arena on first call (thread-safe via Meyers singleton).
-/// Returns 0 (meaning "use default arena selection") if jemalloc is not available, or if
-/// `mallctl("arenas.create", ...)` failed at first call — in which case an error is logged
-/// and `isEnabled` returns false. Passing 0 to `ScopedJemallocThreadArena` is a documented
-/// no-op, so callers do not need to branch on availability.
+/// Returns 0 (meaning "use default arena selection") if jemalloc is not available, if the
+/// platform disables the dedicated arena, or if `mallctl("arenas.create", ...)` failed at
+/// first call — in which case an error is logged and `isEnabled` returns false. Passing 0 to
+/// `ScopedJemallocThreadArena` is a documented no-op, so callers do not need to branch on
+/// availability.
 ///
 /// LLVM allocates via global `operator new`, so we cannot route its allocations
 /// through a custom allocator template parameter the way we do for `JemallocCacheAllocator`.
@@ -18,7 +19,7 @@ namespace DB::JemallocJITArena
 unsigned getArenaIndex();
 
 /// Whether the dedicated JIT arena is available (jemalloc compiled in, embedded compiler
-/// enabled, and `arenas.create` succeeded on first call).
+/// enabled, the platform supports it, and `arenas.create` succeeded on first call).
 bool isEnabled();
 
 /// Purge dirty pages only in the JIT arena, returning memory to the OS.

--- a/src/Common/JemallocJITArena.h
+++ b/src/Common/JemallocJITArena.h
@@ -6,9 +6,9 @@ namespace DB::JemallocJITArena
 /// Returns the jemalloc arena index dedicated to LLVM/JIT allocations.
 /// Creates the arena on first call (thread-safe via Meyers singleton).
 /// Returns 0 (meaning "use default arena selection") if jemalloc is not available, if the
-/// platform disables the dedicated arena, or if `mallctl("arenas.create", ...)` failed at
-/// first call — in which case an error is logged and `isEnabled` returns false. Passing 0 to
-/// `ScopedJemallocThreadArena` is a documented no-op, so callers do not need to branch on
+/// dedicated arena is disabled on the platform, or if `mallctl("arenas.create", ...)` failed
+/// at first call; in the latter case an error is logged and `isEnabled` returns false. Passing
+/// 0 to `ScopedJemallocThreadArena` is a documented no-op, so callers do not need to branch on
 /// availability.
 ///
 /// LLVM allocates via global `operator new`, so we cannot route its allocations
@@ -23,7 +23,7 @@ unsigned getArenaIndex();
 bool isEnabled();
 
 /// Purge dirty pages only in the JIT arena, returning memory to the OS.
-/// No-op if the arena is not available (`isEnabled()` returns false).
+/// No-op if the arena is not available (`isEnabled` returns false).
 void purge();
 
 }

--- a/tests/queries/0_stateless/04202_jemalloc_jit_arena_metrics.sql
+++ b/tests/queries/0_stateless/04202_jemalloc_jit_arena_metrics.sql
@@ -2,14 +2,15 @@
 -- limits are exposed in `system.asynchronous_metrics`. Both sets of metrics are gated on build
 -- options, so the test compares "metric is exposed" against the build options it depends on.
 
--- The JIT arena is only meaningful when both jemalloc AND the embedded compiler are built in;
--- `JemallocJITArena::isEnabled` requires both, and `system.asynchronous_metrics` only emits
--- `jemalloc.jit_arena.*` when `isEnabled` returns true.
+-- The JIT arena is only meaningful when jemalloc and the embedded compiler are built in on a
+-- supported platform; `JemallocJITArena::isEnabled` requires all three, and
+-- `system.asynchronous_metrics` only emits `jemalloc.jit_arena.*` when `isEnabled` returns true.
 WITH
     (SELECT value IN ('ON', '1') FROM system.build_options WHERE name = 'USE_JEMALLOC') AS jemalloc_on,
-    (SELECT value IN ('ON', '1') FROM system.build_options WHERE name = 'USE_EMBEDDED_COMPILER') AS jit_on
+    (SELECT value IN ('ON', '1') FROM system.build_options WHERE name = 'USE_EMBEDDED_COMPILER') AS jit_on,
+    (SELECT value = 'Darwin' FROM system.build_options WHERE name = 'SYSTEM') AS is_darwin
 SELECT
-    (count() > 0) = (jemalloc_on AND jit_on)
+    (count() > 0) = (jemalloc_on AND jit_on AND NOT is_darwin)
 FROM system.asynchronous_metrics
 WHERE metric LIKE 'jemalloc.jit_arena%';
 

--- a/tests/queries/0_stateless/04202_jemalloc_jit_arena_metrics.sql
+++ b/tests/queries/0_stateless/04202_jemalloc_jit_arena_metrics.sql
@@ -2,9 +2,8 @@
 -- limits are exposed in `system.asynchronous_metrics`. Both sets of metrics are gated on build
 -- options, so the test compares "metric is exposed" against the build options it depends on.
 
--- The JIT arena is only meaningful when jemalloc and the embedded compiler are built in on a
--- supported platform; `JemallocJITArena::isEnabled` requires all three, and
--- `system.asynchronous_metrics` only emits `jemalloc.jit_arena.*` when `isEnabled` returns true.
+-- Dedicated JIT arena metrics exist only when jemalloc and the embedded compiler are built in
+-- and the platform supports `thread.arena` routing for `CHJIT`.
 WITH
     (SELECT value IN ('ON', '1') FROM system.build_options WHERE name = 'USE_JEMALLOC') AS jemalloc_on,
     (SELECT value IN ('ON', '1') FROM system.build_options WHERE name = 'USE_EMBEDDED_COMPILER') AS jit_on,

--- a/tests/queries/0_stateless/04203_jit_arena_drop_compiled.sh
+++ b/tests/queries/0_stateless/04203_jit_arena_drop_compiled.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
-# Tags: no-parallel, no-fasttest, use_jemalloc
+# Tags: no-parallel, no-fasttest, use_jemalloc, no-darwin
 # no-parallel: this test issues `SYSTEM DROP COMPILED EXPRESSION CACHE`, which is process-wide.
 #              Running in parallel with other JIT-using tests would flap their assertions and ours.
 # no-fasttest: requires USE_EMBEDDED_COMPILER, which the fast-test image disables.
 # use_jemalloc: this test asserts on `jemalloc.jit_arena.*` async metrics, which are only
 #               registered when the build has jemalloc.
+# no-darwin: the dedicated JIT arena is disabled on Darwin because switching `thread.arena`
+#            around `CHJIT` currently makes AArch64 target-machine initialization throw
+#            `std::bad_alloc`.
 #
 # Test that JIT compilation populates the dedicated jemalloc JIT arena and the compiled-expression
 # cache, and that `SYSTEM DROP COMPILED EXPRESSION CACHE` reaches its purge path. The cache count

--- a/tests/queries/0_stateless/04203_jit_arena_drop_compiled.sh
+++ b/tests/queries/0_stateless/04203_jit_arena_drop_compiled.sh
@@ -5,9 +5,8 @@
 # no-fasttest: requires USE_EMBEDDED_COMPILER, which the fast-test image disables.
 # use_jemalloc: this test asserts on `jemalloc.jit_arena.*` async metrics, which are only
 #               registered when the build has jemalloc.
-# no-darwin: the dedicated JIT arena is disabled on Darwin because switching `thread.arena`
-#            around `CHJIT` currently makes AArch64 target-machine initialization throw
-#            `std::bad_alloc`.
+# no-darwin: Darwin disables the dedicated JIT arena because `thread.arena` routing can make
+#            AArch64 `CHJIT` target-machine initialization throw `std::bad_alloc`.
 #
 # Test that JIT compilation populates the dedicated jemalloc JIT arena and the compiled-expression
 # cache, and that `SYSTEM DROP COMPILED EXPRESSION CACHE` reaches its purge path. The cache count
@@ -45,7 +44,7 @@ echo "cache_count_after_compile $($CLICKHOUSE_CLIENT -q "
 
 # Drop the cache. We do NOT assert here that `CompiledExpressionCacheCount` returns to zero,
 # nor that `jemalloc.jit_arena.active_bytes` returns to its pre-compile value:
-#  - The arena footprint is dominated by the CHJIT singleton's persistent state (`TargetMachine`,
+#  - The arena footprint is dominated by the `CHJIT` singleton's persistent state (`TargetMachine`,
 #    `Subtarget`, `LLVMContext`-uniqued types/constants), held alive via `shared_ptr<CHJIT>` by
 #    every cache entry that compiled against it. A concurrent in-flight compile that lands a
 #    fresh holder between `cache->clear()` and the singleton-slot reset will pin the old

--- a/tests/queries/0_stateless/04319_jit_sort_window_empty_macos_bad_alloc.sql
+++ b/tests/queries/0_stateless/04319_jit_sort_window_empty_macos_bad_alloc.sql
@@ -1,0 +1,4 @@
+SET compile_sort_description = 1;
+SET min_count_to_compile_sort_description = 0;
+
+SELECT row_number() OVER (PARTITION BY number ORDER BY number) FROM numbers(0) FORMAT Null;


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/106646

Disable the dedicated jemalloc JIT arena on Darwin because routing LLVM target-machine allocations through `thread.arena` can make `CHJIT` throw `std::bad_alloc` on macOS arm64. Add a stateless regression test that forces sort-description JIT for an empty `row_number` window query.


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `std::bad_alloc` from forced or repeated sort-description JIT compilation on macOS.


### Documentation entry:
- [x] Documentation is not required for this change.
