### PR TITLE
Fix flaky 03652_threads_count_insert: tighten query_log filter

### DIFF
--- a/tests/queries/0_stateless/03652_threads_count_insert.sh
+++ b/tests/queries/0_stateless/03652_threads_count_insert.sh
@@ -45,7 +45,9 @@ select
     if(peak_threads_usage >= 6, 7, peak_threads_usage),
 from system.query_log where event_date >= yesterday() AND event_time >= now() - 600 AND
     current_database = currentDatabase() and
-    type != 'QueryStart' and
+    type = 'QueryFinish' and
+    is_initial_query = 1 and
+    query_kind = 'Insert' and
     query_id = '$QUERY_ID'
 order by ALL;
 EOF


### PR DESCRIPTION
The flaky-test pattern was an extra `1` row appearing before the expected `7` in the
`max_threads = 7` iterations of `tests/queries/0_stateless/03652_threads_count_insert.sh`,
seen across multiple unrelated PRs and on `master` over the last ~3 months
(observed under at least `amd_msan + WasmEdge`, `arm_binary`, `amd_asan_ubsan db disk
distributed plan`, and `amd_debug` sequential variants).

The per-iteration query against `system.query_log` was filtering only by
`current_database = currentDatabase() AND type != 'QueryStart' AND query_id = '$QUERY_ID'`.
Under CI's randomized settings, a second `query_log` row can match the same `query_id`
(a subquery, a distributed sub-fragment, or a non-`Insert` follow-up running with the
same id), so the test sometimes saw two rows instead of the expected one and printed
an extra entry whose `peak_threads_usage` was small (typically mapped to `1` by the
`if(peak_threads_usage >= 6, 7, peak_threads_usage)` bucketing).

Tighten the filter to match only the successful initial `INSERT` log row:

```
type = 'QueryFinish' AND is_initial_query = 1 AND query_kind = 'Insert'
```

This is the same shape used by the sibling test `02871_peak_threads_usage`
(which filters on `type = 'QueryFinish'`).

Verified locally that the new filter correctly suppresses a duplicate `query_log` row
sharing the same `query_id` while still returning exactly one row for the real INSERT.

CI report (one of the recent failures):
https://s3.amazonaws.com/clickhouse-test-reports/101143/

No related open issue found.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)