### PR TITLE
Bound listFilesWithRegexpMatchingImpl recursion depth in StorageFile

### DIFF
--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -53,6 +53,7 @@
 #include <Processors/QueryPlan/SourceStepWithFilter.h>
 
 #include <Common/CurrentThread.h>
+#include <Common/checkStackSize.h>
 #include <Common/escapeForFileName.h>
 #include <Common/typeid_cast.h>
 #include <Common/parseGlobs.h>
@@ -164,6 +165,11 @@ void listFilesWithRegexpMatchingImpl(
         throw Exception(ErrorCodes::TOO_DEEP_RECURSION,
             "Maximum recursion depth ({}) exceeded while listing files for pattern '{}'.",
             MAX_LIST_FILES_RECURSION_DEPTH, for_match);
+
+    /// On systems with small stacks (e.g., Musl) the depth cap above is not enough on its own,
+    /// because each recursion frame can be large. Probe the remaining stack periodically.
+    if (depth % 16 == 0)
+        checkStackSize();
 
     const size_t first_glob_pos = for_match.find_first_of("*?{");
 

--- a/src/Storages/StorageFile.cpp
+++ b/src/Storages/StorageFile.cpp
@@ -139,12 +139,16 @@ namespace ErrorCodes
     extern const int CANNOT_DETECT_FORMAT;
     extern const int CANNOT_COMPILE_REGEXP;
     extern const int UNSUPPORTED_METHOD;
+    extern const int TOO_DEEP_RECURSION;
 }
 
 using String = std::string;
 
 namespace
 {
+/// Bound on the recursion depth of `listFilesWithRegexpMatchingImpl`.
+constexpr size_t MAX_LIST_FILES_RECURSION_DEPTH = 1000;
+
 /* Recursive directory listing with matched paths as a result.
  * Have the same method in StorageHDFS.
  */
@@ -153,8 +157,14 @@ void listFilesWithRegexpMatchingImpl(
     const std::string & for_match,
     size_t & total_bytes_to_read,
     std::vector<std::string> & result,
-    bool recursive)
+    bool recursive,
+    size_t depth)
 {
+    if (depth > MAX_LIST_FILES_RECURSION_DEPTH)
+        throw Exception(ErrorCodes::TOO_DEEP_RECURSION,
+            "Maximum recursion depth ({}) exceeded while listing files for pattern '{}'.",
+            MAX_LIST_FILES_RECURSION_DEPTH, for_match);
+
     const size_t first_glob_pos = for_match.find_first_of("*?{");
 
     if (first_glob_pos == std::string::npos)
@@ -236,12 +246,11 @@ void listFilesWithRegexpMatchingImpl(
             {
                 listFilesWithRegexpMatchingImpl(fs::path(full_path).append(it->path().string()) / "",
                                                 looking_for_directory ? suffix_with_globs.substr(next_slash_after_glob_pos) : current_glob,
-                                                total_bytes_to_read, result, recursive);
+                                                total_bytes_to_read, result, recursive, depth + 1);
             }
             else if (looking_for_directory && re2::RE2::FullMatch(file_name, matcher))
-                /// Recursion depth is limited by pattern. '*' works only for depth = 1, for depth = 2 pattern path is '*/*'. So we do not need additional check.
                 listFilesWithRegexpMatchingImpl(fs::path(full_path) / "", suffix_with_globs.substr(next_slash_after_glob_pos),
-                                                total_bytes_to_read, result, false);
+                                                total_bytes_to_read, result, false, depth + 1);
         }
     }
 }
@@ -255,7 +264,7 @@ std::vector<std::string> listFilesWithRegexpMatching(
     Strings for_match_paths_expanded = expandSelectionGlob(for_match);
 
     for (const auto & for_match_expanded : for_match_paths_expanded)
-        listFilesWithRegexpMatchingImpl("/", for_match_expanded, total_bytes_to_read, result, false);
+        listFilesWithRegexpMatchingImpl("/", for_match_expanded, total_bytes_to_read, result, false, 0);
 
     return result;
 }

--- a/tests/queries/0_stateless/04323_test_storage_file_glob_recursion_depth.reference
+++ b/tests/queries/0_stateless/04323_test_storage_file_glob_recursion_depth.reference
@@ -1,0 +1,2 @@
+TOO_DEEP_RECURSION
+alive

--- a/tests/queries/0_stateless/04323_test_storage_file_glob_recursion_depth.sh
+++ b/tests/queries/0_stateless/04323_test_storage_file_glob_recursion_depth.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest, no-parallel
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+USER_FILES_PATH=$($CLICKHOUSE_CLIENT_BINARY --query "select _path,_file from file('nonexist.txt', 'CSV', 'val1 char')" 2>&1 \
+    | grep Exception | awk '{gsub("/nonexist.txt","",$9); print $9}')
+
+DEEP_DIR_NAME="$CLICKHOUSE_TEST_UNIQUE_NAME-deep"
+DEEP_DIR_ABS="$USER_FILES_PATH/$DEEP_DIR_NAME"
+
+mkdir -p "$DEEP_DIR_ABS"
+trap 'rm -rf "$DEEP_DIR_ABS"' EXIT
+
+# Build a chain of >1000 nested directories. A trailing `/**` glob walks every
+# level, so the listing depth equals the chain length and must trip the guard.
+NESTED="$DEEP_DIR_ABS"
+for _ in $(seq 1 1100); do
+    NESTED="$NESTED/x"
+done
+mkdir -p "$NESTED"
+
+$CLICKHOUSE_CLIENT --query "SELECT count() FROM file('$DEEP_DIR_NAME/**')" 2>&1 \
+    | grep -oF "TOO_DEEP_RECURSION" | head -n 1
+
+$CLICKHOUSE_CLIENT --query "SELECT 'alive'"

--- a/tests/queries/0_stateless/04323_test_storage_file_glob_recursion_depth.sh
+++ b/tests/queries/0_stateless/04323_test_storage_file_glob_recursion_depth.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Tags: no-fasttest, no-parallel
+# Tags: no-fasttest
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
<!--
Linked issues and pull requests.
-->
Related: https://github.com/ClickHouse/ClickHouse/pull/106255

`listFilesWithRegexpMatchingImpl` in `src/Storages/StorageFile.cpp` recurses while expanding a `file` glob. The recursion had no bound: a pathological pattern (e.g. dozens of `/**/` segments piped through `concat`/`toFixedString`) or a trailing `/**` over a deep on-disk tree could keep recursing until the C++ stack was exhausted, taking the server with it.

The AST fuzzer surfaced this on PR #106255 as a debug-build segmentation fault inside `libunwind` while `MemoryTracker::allocImpl` was capturing a stack trace from a `std::string` allocation in `fs::path::append` called from `listFilesWithRegexpMatchingImpl`. The fuzzer query was:

```
SELECT DISTINCT 3 FROM file(concat(decodeURLFormComponent(concat(toFixedString('/**/', 9), ...
```

Add a `depth` parameter and reject the call with `TOO_DEEP_RECURSION` once it exceeds `MAX_LIST_FILES_RECURSION_DEPTH = 1000`. Both recursive call sites (the `**` recursive descent and the per-component descent through nested globs) increment `depth`. The cap is comfortably above any realistic legitimate use of `file` glob expansion while still protecting the stack. Includes a regression test that builds a >1000 deep directory chain under `user_files_path` and verifies that `SELECT count() FROM file('.../**')` returns `TOO_DEEP_RECURSION` and the server stays alive.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=106255&sha=a473c40b4708c54e0d3e4d0c04dbf3014374cbab&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%2C%20targeted%29

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Reject pathological `file` glob patterns that would cause unbounded recursion in directory listing. A maximum recursion depth of 1000 is now enforced; queries that exceed it raise `TOO_DEEP_RECURSION` instead of crashing the server with a stack overflow.


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)

<!---
Directly edit documentation source files in the "docs" folder with the same pull-request as code changes
-->

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.507`
<!-- ch-version-info:end -->