### PR TITLE
Fix flaky test 04023_rollup_totals_memory_limit

### DIFF
--- a/tests/queries/0_stateless/04023_rollup_totals_memory_limit.sql
+++ b/tests/queries/0_stateless/04023_rollup_totals_memory_limit.sql
@@ -1,5 +1,8 @@
 -- Tags: no-parallel-replicas
 -- https://github.com/ClickHouse/ClickHouse/issues/93465
+-- `max_memory_usage` is set well below observed aggregator memory so the
+-- expected `MEMORY_LIMIT_EXCEEDED` is reached deterministically across all
+-- randomized settings combinations.
 CREATE TABLE t0 (c0 Int, c1 Int128) ENGINE = MergeTree ORDER BY tuple();
 INSERT INTO t0 SELECT 1, number FROM numbers(40000);
-SELECT countDistinct(c1) FROM t0 GROUP BY c0 WITH ROLLUP WITH TOTALS SETTINGS max_memory_usage = 10000000, max_bytes_before_external_group_by = 0, max_bytes_ratio_before_external_group_by = 0; -- { serverError MEMORY_LIMIT_EXCEEDED }
+SELECT countDistinct(c1) FROM t0 GROUP BY c0 WITH ROLLUP WITH TOTALS SETTINGS max_memory_usage = 1000000, max_bytes_before_external_group_by = 0, max_bytes_ratio_before_external_group_by = 0; -- { serverError MEMORY_LIMIT_EXCEEDED }


### PR DESCRIPTION
Lower `max_memory_usage` from 10 MB to 1 MB so the expected `MEMORY_LIMIT_EXCEEDED` exception is hit deterministically across all randomized settings combinations.

The previous limit (10 MB) sat just below the observed aggregator footprint of ~12 MiB. The 1.2x margin is too thin: certain randomized settings on `Stateless tests (amd_debug, distributed plan, s3 storage, parallel)` and `Fast test` runs shave off 2-3 MiB and let the query slip under the limit, so `MEMORY_LIMIT_EXCEEDED` is never thrown and the test fails with "query succeeded but server error 241 was expected" (22/88 reruns failed on PR #106187).

With a 1 MB limit the aggregator footprint (5-6 MiB observed locally across 50 random setting combinations) is firmly above the threshold, so the exception fires deterministically.

The regression target from issue #93465 (server crash inside ROLLUP+TOTALS memory-limit handling) is still exercised: any `MEMORY_LIMIT_EXCEEDED` thrown cleanly proves the crash path is not reached.

Requested by @ alexey-milovidov on https://github.com/ClickHouse/ClickHouse/pull/106187

Related: https://github.com/ClickHouse/ClickHouse/issues/93465

CI report (the run that prompted this fix): https://github.com/ClickHouse/ClickHouse/pull/106187

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...