### PR TITLE
Fix flaky test 04103_user_network_bandwidth_throttler

### DIFF
--- a/tests/queries/0_stateless/04103_user_network_bandwidth_throttler.sh
+++ b/tests/queries/0_stateless/04103_user_network_bandwidth_throttler.sh
@@ -2,7 +2,7 @@
 # Tags: no-fasttest, long, no-random-settings
 # no-fasttest: needs S3, and the test is slow (exercises throttling)
 # no-random-settings: S3 prefetch settings affect read throughput; disabling prefetch can make
-# natural read rate drop below the 1 MB/s throttle limit, causing the throttler to never sleep
+# the natural read rate drop close to the throttle limit, causing the throttler to never sleep
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
@@ -19,22 +19,27 @@ $CLICKHOUSE_CLIENT -m -q "
     DROP TABLE IF EXISTS data_04103;
     CREATE TABLE data_04103 (key UInt64 CODEC(NONE)) ENGINE=MergeTree() ORDER BY key
         SETTINGS min_bytes_for_wide_part=1e9, disk='s3_disk';
-    INSERT INTO data_04103 SELECT * FROM numbers(1e6);
+    INSERT INTO data_04103 SELECT * FROM numbers(2e5);
     GRANT SELECT, INSERT ON ${CLICKHOUSE_DATABASE}.data_04103 TO $READ_USER, $WRITE_USER;
 "
 
 write_query_id="04103_w_$CLICKHOUSE_DATABASE"
 read_query_id="04103_r_$CLICKHOUSE_DATABASE"
 
-# Writing/reading ~1e6*8 bytes with a 1M/s cap should each take ~7 seconds.
-# They run in parallel (~7s wall-clock) because each user has its own throttler.
+# Writing/reading ~2e5*8 bytes with a 200 KB/s cap should each take ~8 seconds.
+# They run in parallel (~8s wall-clock) because each user has its own throttler.
+# The throttle limit is intentionally well below the natural S3 read rate observed on
+# loaded TSAN parallel runners (~0.9 MB/s) so the throttler reliably enters its sleep
+# path. With a 1 MB/s limit (the previous value), heavy contention occasionally let
+# the natural rate drop near the limit, the throttler did not need to sleep, and the
+# `UserThrottlerSleepMicroseconds` assertion flapped (issue #103422).
 $CLICKHOUSE_CLIENT --user "$WRITE_USER" --query_id "$write_query_id" -q "
-    INSERT INTO ${CLICKHOUSE_DATABASE}.data_04103 SELECT number+1e6 FROM numbers(1e6)
-    SETTINGS max_network_bandwidth_for_user = 1000000
+    INSERT INTO ${CLICKHOUSE_DATABASE}.data_04103 SELECT number+2e5 FROM numbers(2e5)
+    SETTINGS max_network_bandwidth_for_user = 200000
 " &
 $CLICKHOUSE_CLIENT --user "$READ_USER" --query_id "$read_query_id" -q "
-    SELECT * FROM ${CLICKHOUSE_DATABASE}.data_04103 WHERE key < 1e6 FORMAT Null
-    SETTINGS max_network_bandwidth_for_user = 1000000
+    SELECT * FROM ${CLICKHOUSE_DATABASE}.data_04103 WHERE key < 2e5 FORMAT Null
+    SETTINGS max_network_bandwidth_for_user = 200000
 " &
 wait
 
@@ -44,7 +49,7 @@ $CLICKHOUSE_CLIENT --serialize_query_plan=0 -m -q "
     SELECT
         if(query_id = '$write_query_id', 'write', 'read') AS q,
         query_duration_ms >= 7e3,
-        ProfileEvents['UserThrottlerBytes'] > 8e6,
+        ProfileEvents['UserThrottlerBytes'] > 1.6e6,
         ProfileEvents['UserThrottlerSleepMicroseconds'] > 7e6 * 0.5
     FROM system.query_log
     WHERE event_date >= yesterday() AND event_time >= now() - 600


### PR DESCRIPTION
The test asserts `ProfileEvents['UserThrottlerSleepMicroseconds']` is greater than half the throttled query duration. The throttler only enters its sleep path when the natural read rate exceeds the configured limit; when the natural rate drops close to the limit, the token bucket never goes negative and the assertion flaps.

PR #103586 added `no-random-settings` to remove S3-prefetch settings as one source of slow natural rate. Post-merge CIDB shows 4 sightings on `Stateless tests (amd_tsan, parallel, 2/2)` (PRs #106222, #102039, #49966, #106184), all with the `read 1 1 0` shape (duration ok, bytes ok, sleep below threshold). All four already carry the `no-random-settings` tag, so the residual flakiness is contention-driven, not random-settings driven.

Drop the throttle limit and dataset 5x (1 MB/s -> 200 KB/s, 1e6 -> 2e5 rows). Wall-clock stays at ~8s. The 200 KB/s limit is well below the worst observed natural S3 read rate on contended TSAN parallel runners (~0.9 MB/s), giving a 4.5x safety margin. Local 10/10 iterations on an S3 disk produced `sleep_us` between 16.8s and 17.3s, comfortably above the 3.5s threshold.

Closes: https://github.com/ClickHouse/ClickHouse/issues/103422
Related: https://github.com/ClickHouse/ClickHouse/pull/103586
Related: https://github.com/ClickHouse/ClickHouse/pull/106184

CI report (post-merge sighting on PR #106184): https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=106184&sha=31a83e8fe57d67ba3f402133ba620f7b99a63ebd&name_0=PR&name_1=Stateless%20tests%20%28amd_tsan%2C%20parallel%2C%202%2F2%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not required.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.481`
<!-- ch-version-info:end -->