### PR TITLE
Support CREATE OR REPLACE TEMPORARY VIEW

### DIFF
--- a/src/Interpreters/InterpreterCreateQuery.cpp
+++ b/src/Interpreters/InterpreterCreateQuery.cpp
@@ -1831,7 +1831,7 @@ BlockIO InterpreterCreateQuery::createTable(ASTCreateQuery & create)
     if (need_add_to_database && !database)
         throw Exception(ErrorCodes::UNKNOWN_DATABASE, "Database {} does not exist", backQuoteIfNeed(database_name));
 
-    if (create.isTemporary() && create.replace_table)
+    if (create.isTemporary() && (create.replace_table || create.replace_view))
     {
         chassert(!ddl_guard);
         return doCreateOrReplaceTemporaryTable(create, properties, mode);

--- a/src/Parsers/ParserCreateQuery.cpp
+++ b/src/Parsers/ParserCreateQuery.cpp
@@ -1596,7 +1596,7 @@ bool ParserCreateViewQuery::parseImpl(Pos & pos, ASTPtr & node, Expected & expec
     else
         is_ordinary_view = true;
 
-    if (!replace_view && !is_materialized_view && s_temporary.ignore(pos, expected))
+    if ( !is_materialized_view && s_temporary.ignore(pos, expected))
     {
         is_temporary = true;
     }


### PR DESCRIPTION
Allow TEMPORARY to be used together with OR REPLACE in CREATE VIEW statements and route temporary view replacement through the existing temporary object replacement path.

Temporary views are stored in the same session-scoped external table mapping as temporary tables, so the existing replacement infrastructure can be reused safely.

Closes: https://github.com/ClickHouse/ClickHouse/issues/106660

### Changelog category (leave one):

* Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry
...
Support `CREATE OR REPLACE TEMPORARY VIEW` by allowing the parser to recognize `TEMPORARY` together with `OR REPLACE` and handling temporary view replacement through the existing temporary object replacement mechanism.

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

