### PR TITLE
Backport version-specific labels to all newer releases

### DIFF
--- a/docs/en/development/backports.md
+++ b/docs/en/development/backports.md
@@ -62,6 +62,8 @@ An active release branch is any branch whose corresponding release PR (carrying 
 
 A release branch can be in a **rolling-out** state (its release PR carries the `rolling-out` label) during the period when a new release is being deployed. General backports are paused for rolling-out branches to avoid complicating the rollout. Version-specific labels (e.g. `v25.3-must-backport`) override this and force backporting even during a rollout.
 
+A version-specific label sets the *oldest* release the PR must reach: it is backported to that release **and to every newer active release branch**, not only to the named one. For example, `v25.3-must-backport` on a PR merged into the development branch backports to `25.3` and to every active release after it (`25.4`, `25.5`, …). If multiple version-specific labels are present, the lowest version wins, since it already covers the newer ones.
+
 ## Implementation {#implementation}
 
 ### Overview {#overview}
@@ -82,7 +84,7 @@ Labels on the original PR control whether and where backporting happens.
 | `pr-must-backport` | Backport to all active release branches (skipping branches marked `rolling-out`) |
 | `pr-must-backport-force` | Backport to all active release branches, ignoring `rolling-out` restrictions |
 | `pr-critical-bugfix` | Triggers `pr-must-backport` automatically (via `AUTO_BACKPORT` in `pr_labels_and_category.py`) |
-| `v{VER}-must-backport` (e.g. `v25.3-must-backport`) | Backport only to that specific release branch; overrides `rolling-out` skip for that branch |
+| `v{VER}-must-backport` (e.g. `v25.3-must-backport`) | Backport to that release branch **and every newer active release branch** — the version marks the *oldest* release the PR must reach. With several such labels, the lowest version wins. Overrides the `rolling-out` skip for those branches |
 | `pr-backports-created` | Set by the bot when all required backport PRs have been created; cleared if a cherry-pick PR is reopened |
 | `pr-cherrypick` | Applied to cherry-pick PRs created by the bot |
 | `pr-backport` | Applied to backport PRs created by the bot |
@@ -114,7 +116,7 @@ For each original PR number `N` and release branch `release/X.Y`:
 
 #### 3. Rolling-out branch handling {#rolling-out-branch-handling}
 
-When a release PR carries the `rolling-out` label, general backport labels (`pr-must-backport`, `pr-critical-bugfix`) skip that branch. The bot closes any previously created cherry-pick or backport PRs for that branch with an explanatory comment. A version-specific label (e.g. `v25.3-must-backport`) always overrides this. `pr-must-backport-force` bypasses the `rolling-out` check for all branches.
+When a release PR carries the `rolling-out` label, general backport labels (`pr-must-backport`, `pr-critical-bugfix`) skip that branch. The bot closes any previously created cherry-pick or backport PRs for that branch with an explanatory comment. A version-specific label (e.g. `v25.3-must-backport`) always overrides this — for the named release and for every newer active release branch it expands to. `pr-must-backport-force` bypasses the `rolling-out` check for all branches.
 
 #### 4. Cherry-pick stage (`ReleaseBranch.create_cherrypick`) {#cherry-pick-stage}
 

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -15,8 +15,10 @@ A plan:
             stage, if mergable) and create backport-PRs
             - If successful, set pr-backported label on the PR
 
-        - for version-specific labels:
-            - the same, check, cherry-pick, backport, pr-backported
+        - for version-specific labels (e.g. v25.12-must-backport):
+            - the label marks the OLDEST release the PR must reach. Backport to
+            that release AND to every newer active release branch, then the same
+            check, cherry-pick, backport, pr-backported
 
 Cherry-pick stage:
     - From time to time the cherry-pick fails, if it was done manually. In the
@@ -37,6 +39,7 @@ from typing import Iterable, List, Optional
 from github.GithubException import GithubException
 
 from cache_utils import GitHubCache
+from cherry_pick_branches import select_backport_branches
 from ci_buddy import CIBuddy
 from ci_utils import Shell
 from env_helper import (
@@ -785,82 +788,43 @@ class BackportPRs:
     def process_pr(self, pr: PullRequest) -> None:
         pr_labels = [label.name for label in pr.labels]
 
-        is_force_backport = Labels.MUST_BACKPORT_FORCE in pr_labels
-        is_general_backport = (
-            is_force_backport
-            or Labels.MUST_BACKPORT in pr_labels
-            or bool(Labels.AUTO_BACKPORT & set(pr_labels))
+        # Decide the target release branches (pure logic, unit-tested in
+        # `test_cherry_pick_branches.py`). A version-specific label
+        # (`vX.Y-must-backport`) marks the OLDEST release the PR must reach, so
+        # the PR is backported to that release and every newer active release
+        # branch; the lowest such label wins. `skipped` are rolling-out branches
+        # excluded for a general backport that no version-specific label covers.
+        rolling_out = set(self._rolling_out_branches())
+        branch_names, skipped = select_backport_branches(
+            pr_labels,
+            self.release_branches,
+            rolling_out,
+            general_backport_labels={Labels.MUST_BACKPORT, Labels.MUST_BACKPORT_FORCE}
+            | Labels.AUTO_BACKPORT,
+            force_backport_label=Labels.MUST_BACKPORT_FORCE,
         )
-        if is_general_backport:
-            if is_force_backport:
-                # pr-must-backport-force: backport to all release branches,
-                # ignoring the rolling-out restriction entirely.
-                logging.info(
-                    "PR #%s: label %r present, ignoring rolling-out branches",
-                    pr.number,
-                    Labels.MUST_BACKPORT_FORCE,
-                )
-                branches = [
-                    ReleaseBranch(br, pr, self.repo) for br in self.release_branches
-                ]  # type: List[ReleaseBranch]
-            else:
-                # For general backports (pr-must-backport / critical bugfix), skip
-                # release branches that are currently rolling out, unless the PR
-                # carries an explicit version-specific label for that branch.
-                rolling_out = set(self._rolling_out_branches())
-                # Build a per-branch version-specific label so we can honour explicit
-                # overrides (e.g. the PR has both pr-must-backport AND
-                # v25.10-must-backport: the 25.10 branch must be included even if it
-                # is marked rolling-out).
-                branch_specific_label = {
-                    branch: f"v{branch.replace('release/', '')}-must-backport"
-                    for branch in self.release_branches
-                }
-                skipped = [
-                    br
-                    for br in self.release_branches
-                    if br in rolling_out and branch_specific_label[br] not in pr_labels
-                ]
-                if skipped:
-                    logging.info(
-                        "PR #%s: skipping rolling-out release branches for general "
-                        "backport: %s",
-                        pr.number,
-                        ", ".join(skipped),
-                    )
-                    for br in skipped:
-                        self._close_prs_for_rolling_out_branch(pr, br)
-                branches = [
-                    ReleaseBranch(br, pr, self.repo)
-                    for br in self.release_branches
-                    if br not in rolling_out or branch_specific_label[br] in pr_labels
-                ]
-                if not branches:
-                    logging.info(
-                        "PR #%s: all release branches are rolling-out, skipping backport",
-                        pr.number,
-                    )
-                    return
-        else:
-            branches = [
-                ReleaseBranch(
-                    (
-                        br
-                        if self._repo_name == "ClickHouse/ClickHouse"
-                        else f"release/{br}"
-                    ),
-                    pr,
-                    self.repo,
-                )
-                for br in [
-                    label.split("-", 1)[0][1:]  # v21.8-must-backport
-                    for label in pr_labels
-                    if label in self.labels_to_backport
-                ]
-            ]
-        assert (
-            branches
-        ), f"Unable to determine branches for PR {pr.html_url}, check its labels"
+
+        if skipped:
+            logging.info(
+                "PR #%s: skipping rolling-out release branches for general "
+                "backport: %s",
+                pr.number,
+                ", ".join(skipped),
+            )
+            for br in skipped:
+                self._close_prs_for_rolling_out_branch(pr, br)
+
+        if not branch_names:
+            logging.info(
+                "PR #%s: all candidate release branches are rolling-out, "
+                "skipping backport",
+                pr.number,
+            )
+            return
+
+        branches = [
+            ReleaseBranch(br, pr, self.repo) for br in branch_names
+        ]  # type: List[ReleaseBranch]
 
         logging.info(
             "  PR #%s is supposed to be backported to %s",

--- a/tests/ci/cherry_pick_branches.py
+++ b/tests/ci/cherry_pick_branches.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+Pure branch-selection logic for the backport automation (`cherry_pick.py`).
+
+This module is intentionally free of GitHub / git / CI dependencies so the
+branch-selection contract can be unit-tested directly (see
+`test_cherry_pick_branches.py`). The label name constants live with `Labels`
+in `cherry_pick.py` / `pr_info.py` and are passed in by the caller, so this
+module stays the single source of truth for *which branches* a PR reaches
+without duplicating *what the labels are called*.
+"""
+from typing import List, Optional, Sequence, Set, Tuple
+
+
+def version_key(version: str) -> Tuple[int, ...]:
+    """
+    Turn a release version (e.g. `25.12`, `26.1`) into a tuple of integers so
+    that versions compare numerically: `(25, 12) < (26, 1) < (26, 2) < (26, 10)`.
+    Plain string comparison would order `26.10` before `26.2`, which is wrong.
+    """
+    return tuple(int(part) for part in version.split("."))
+
+
+def branch_version(branch: str) -> Tuple[int, ...]:
+    """Release branch name to a comparable version: `release/25.12` -> `(25, 12)`."""
+    return version_key(branch.replace("release/", ""))
+
+
+def must_backport_label(branch: str) -> str:
+    """The version-specific backport label for a release branch."""
+    return f"v{branch.replace('release/', '')}-must-backport"
+
+
+def backport_floor(
+    pr_labels: Sequence[str], release_branches: Sequence[str]
+) -> Optional[Tuple[int, ...]]:
+    """
+    The lowest version among the PR's *active* version-specific backport labels
+    (`v<MAJOR>.<MINOR>-must-backport`), or `None` if there are none.
+
+    A version-specific label marks the OLDEST release the PR must reach, so the
+    minimum of them is the floor: the PR is backported to that release and to
+    every newer active release branch. Only labels that match an active release
+    branch are considered, so a stale label for an end-of-life release can never
+    widen the floor.
+    """
+    floors = [
+        branch_version(branch)
+        for branch in release_branches
+        if must_backport_label(branch) in pr_labels
+    ]
+    return min(floors) if floors else None
+
+
+def select_backport_branches(
+    pr_labels: Sequence[str],
+    release_branches: Sequence[str],
+    rolling_out: Set[str],
+    *,
+    general_backport_labels: Set[str],
+    force_backport_label: str,
+) -> Tuple[List[str], List[str]]:
+    """
+    Decide which release branches a PR should be backported to.
+
+    Returns `(branches, skipped)`, both in `release_branches` order:
+    - `branches`: release branches the PR should be backported to.
+    - `skipped`: rolling-out branches that were excluded, so the caller can
+      close any stale cherry-pick / backport PRs for them.
+
+    Rules:
+    - `force_backport_label` -> all release branches, ignoring `rolling_out`.
+    - any of `general_backport_labels` (`pr-must-backport`, `pr-critical-bugfix`,
+      ...) -> all release branches, but a `rolling_out` branch is skipped unless
+      a version-specific label covers it (its version is `>= floor`).
+    - otherwise (version-specific labels only) -> the floor release and every
+      newer active release branch. `rolling_out` does not apply here: an explicit
+      version request always proceeds.
+    """
+    labels = set(pr_labels)
+    floor = backport_floor(pr_labels, release_branches)
+    # The branches a version-specific label expands to: the floor release and
+    # every newer active branch. Such a label overrides the `rolling_out` skip
+    # for exactly these branches.
+    covered_by_floor = {
+        branch
+        for branch in release_branches
+        if floor is not None and branch_version(branch) >= floor
+    }
+
+    if force_backport_label in labels:
+        return list(release_branches), []
+
+    if labels & general_backport_labels:
+        branches = [
+            branch
+            for branch in release_branches
+            if branch not in rolling_out or branch in covered_by_floor
+        ]
+        skipped = [
+            branch
+            for branch in release_branches
+            if branch in rolling_out and branch not in covered_by_floor
+        ]
+        return branches, skipped
+
+    # Version-specific labels only. The floor is one of the active release
+    # branches, so `covered_by_floor` is never empty here.
+    assert floor is not None, (
+        "select_backport_branches called without a general backport label and "
+        f"without an active version-specific label; labels: {sorted(labels)}"
+    )
+    return [branch for branch in release_branches if branch in covered_by_floor], []

--- a/tests/ci/test_cherry_pick_branches.py
+++ b/tests/ci/test_cherry_pick_branches.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""
+Unit tests for the backport branch-selection contract in
+`cherry_pick_branches.py`. Run with `python -m unittest` from `tests/ci/`, or
+with `pytest tests/ci/test_cherry_pick_branches.py` from the repo root.
+
+The module under test has no GitHub / git / CI dependencies, so these tests run
+anywhere. Label constants mirror `pr_info.Labels` and are kept local to avoid
+importing the heavyweight `cherry_pick` module.
+"""
+import unittest
+from typing import List, Set
+
+from cherry_pick_branches import (
+    backport_floor,
+    branch_version,
+    select_backport_branches,
+    version_key,
+)
+
+# Mirror of the label constants used by `cherry_pick.process_pr`.
+MUST_BACKPORT = "pr-must-backport"
+MUST_BACKPORT_FORCE = "pr-must-backport-force"
+CRITICAL_BUGFIX = "pr-critical-bugfix"  # member of Labels.AUTO_BACKPORT
+GENERAL_BACKPORT_LABELS = {MUST_BACKPORT, MUST_BACKPORT_FORCE, CRITICAL_BUGFIX}
+
+# Active release branches as `cherry_pick.py` sees them (private fork uses the
+# `release/` prefix; the public repo uses bare names -- both are exercised).
+RB = ["release/25.12", "release/26.1", "release/26.2", "release/26.3"]
+RB_PUBLIC = ["25.12", "26.1", "26.2", "26.3"]
+
+
+def select(pr_labels, release_branches, rolling_out=None):
+    return select_backport_branches(
+        pr_labels,
+        release_branches,
+        set(rolling_out or []),
+        general_backport_labels=GENERAL_BACKPORT_LABELS,
+        force_backport_label=MUST_BACKPORT_FORCE,
+    )
+
+
+class TestVersionKey(unittest.TestCase):
+    def test_numeric_ordering(self):
+        # The whole point of tuple keys: 26.10 must sort *after* 26.2 and 26.9,
+        # which naive string comparison ("26.10" < "26.2") gets wrong.
+        self.assertEqual(version_key("26.2"), (26, 2))
+        self.assertLess(version_key("26.2"), version_key("26.9"))
+        self.assertLess(version_key("26.9"), version_key("26.10"))
+        self.assertLess(version_key("25.12"), version_key("26.1"))
+
+    def test_branch_version_strips_prefix(self):
+        self.assertEqual(branch_version("release/25.12"), (25, 12))
+        self.assertEqual(branch_version("26.1"), (26, 1))
+
+
+class TestBackportFloor(unittest.TestCase):
+    def test_single_active_label(self):
+        self.assertEqual(backport_floor(["v25.12-must-backport"], RB), (25, 12))
+
+    def test_lowest_of_multiple_labels_wins(self):
+        self.assertEqual(
+            backport_floor(["v26.2-must-backport", "v25.12-must-backport"], RB),
+            (25, 12),
+        )
+
+    def test_stale_inactive_label_does_not_lower_floor(self):
+        # v25.8 is not an active release branch -> it must be ignored, so the
+        # floor stays at the lowest *active* label (26.2), not 25.8.
+        self.assertEqual(
+            backport_floor(["v25.8-must-backport", "v26.2-must-backport"], RB),
+            (26, 2),
+        )
+
+    def test_no_version_label(self):
+        self.assertIsNone(backport_floor(["pr-must-backport"], RB))
+
+
+class TestSelectVersionSpecific(unittest.TestCase):
+    def test_floor_fans_out_to_all_newer_releases(self):
+        # The headline scenario: a PR merged into the development branch with
+        # only v25.12-must-backport must reach 25.12, 26.1, 26.2, 26.3.
+        branches, skipped = select(["v25.12-must-backport"], RB)
+        self.assertEqual(branches, RB)
+        self.assertEqual(skipped, [])
+
+    def test_floor_fans_out_public_repo(self):
+        branches, skipped = select(["v25.12-must-backport"], RB_PUBLIC)
+        self.assertEqual(branches, RB_PUBLIC)
+        self.assertEqual(skipped, [])
+
+    def test_mid_floor(self):
+        branches, _ = select(["v26.2-must-backport"], RB)
+        self.assertEqual(branches, ["release/26.2", "release/26.3"])
+
+    def test_multiple_labels_lowest_wins(self):
+        branches, _ = select(["v26.2-must-backport", "v25.12-must-backport"], RB)
+        self.assertEqual(branches, RB)
+
+    def test_numeric_ordering_in_selection(self):
+        rb = ["release/26.2", "release/26.9", "release/26.10"]
+        branches, _ = select(["v26.9-must-backport"], rb)
+        # 26.10 must be included (>= 26.9); a string comparison would drop it.
+        self.assertEqual(branches, ["release/26.9", "release/26.10"])
+
+    def test_stale_label_does_not_widen_selection(self):
+        branches, _ = select(["v25.8-must-backport", "v26.2-must-backport"], RB)
+        self.assertEqual(branches, ["release/26.2", "release/26.3"])
+
+    def test_rolling_out_ignored_for_version_specific(self):
+        # A pure version-specific request always proceeds, even for a
+        # rolling-out branch.
+        branches, skipped = select(
+            ["v25.12-must-backport"], RB, rolling_out={"release/26.2"}
+        )
+        self.assertEqual(branches, RB)
+        self.assertEqual(skipped, [])
+
+    def test_floor_is_always_an_active_branch_so_never_empty(self):
+        branches, _ = select(["v26.3-must-backport"], RB)
+        self.assertEqual(branches, ["release/26.3"])
+
+    def test_no_backport_label_raises(self):
+        with self.assertRaises(AssertionError):
+            select(["pr-feature"], RB)
+
+
+class TestSelectGeneral(unittest.TestCase):
+    def test_all_branches_no_rolling_out(self):
+        branches, skipped = select(["pr-must-backport"], RB)
+        self.assertEqual(branches, RB)
+        self.assertEqual(skipped, [])
+
+    def test_critical_bugfix_is_general(self):
+        branches, _ = select(["pr-critical-bugfix"], RB)
+        self.assertEqual(branches, RB)
+
+    def test_rolling_out_skipped_without_version_label(self):
+        branches, skipped = select(
+            ["pr-must-backport"], RB, rolling_out={"release/26.2"}
+        )
+        self.assertEqual(
+            branches, ["release/25.12", "release/26.1", "release/26.3"]
+        )
+        self.assertEqual(skipped, ["release/26.2"])
+
+    def test_rolling_out_overridden_by_lower_floor(self):
+        # pr-must-backport + v25.12-must-backport: the version label covers
+        # 26.2 (>= 25.12), so the rolling-out skip is overridden and nothing is
+        # skipped. This is the case the docs promise and the general path must
+        # honour.
+        branches, skipped = select(
+            ["pr-must-backport", "v25.12-must-backport"],
+            RB,
+            rolling_out={"release/26.2"},
+        )
+        self.assertEqual(branches, RB)
+        self.assertEqual(skipped, [])
+
+    def test_rolling_out_partial_override_by_floor(self):
+        # Floor 26.3 covers only 26.3; the rolling-out 26.1/26.2 are not covered
+        # and stay skipped.
+        branches, skipped = select(
+            ["pr-must-backport", "v26.3-must-backport"],
+            RB,
+            rolling_out={"release/26.1", "release/26.2"},
+        )
+        self.assertEqual(branches, ["release/25.12", "release/26.3"])
+        self.assertEqual(skipped, ["release/26.1", "release/26.2"])
+
+    def test_force_ignores_rolling_out(self):
+        branches, skipped = select(
+            ["pr-must-backport-force"],
+            RB,
+            rolling_out={"release/26.1", "release/26.2"},
+        )
+        self.assertEqual(branches, RB)
+        self.assertEqual(skipped, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Make version-specific backport labels (`vX.Y-must-backport`) in `cherry_pick.py` mark the **oldest** release a PR must reach: the backport now targets that release **and every newer active release branch**, instead of only the named one.

### Motivation

Today `v25.12-must-backport` on a PR merged into the development branch creates a backport only to `25.12`; intermediate releases (`26.1`, `26.2`, ...) are skipped unless every version label is added by hand. This is a footgun: a fix can land in an old release but not in a newer one, so a user upgrading from the old release silently loses the fix. With this change a single `v25.12-must-backport` fans out to every active release `>= 25.12`. When several version-specific labels are present, the lowest version wins.

Version comparison is numeric (so `26.10` correctly sorts after `26.2`), and a version-specific label keeps overriding the `rolling-out` skip for the whole expanded range — including in the general-backport path, where a lower-version label now covers every newer rolling-out branch (previously only an exact per-branch label did).

The branch-selection logic is extracted into a dependency-free `cherry_pick_branches.py` with unit tests in `test_cherry_pick_branches.py` (numeric ordering, floor from multiple labels, stale-label handling, and rolling-out branches covered or not by a lower floor). `docs/en/development/backports.md` is updated to match.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
A version-specific backport label (e.g. `v25.12-must-backport`) now backports the PR to the named release and every newer active release branch, treating the label as the oldest release the PR must reach.

### Documentation entry for user-facing changes
- [x] Documentation updated — `docs/en/development/backports.md` reflects the new version-specific label semantics.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.540`
<!-- ch-version-info:end -->