### PR TITLE
Fix STID 1941-1bfa: stop mutating call-syntax arrayElement on kql_array_sort_*

### DIFF
--- a/src/Parsers/ExpressionListParsers.cpp
+++ b/src/Parsers/ExpressionListParsers.cpp
@@ -773,20 +773,24 @@ public:
             }
             else
             {
-                /// enable using subscript operator for kql_array_sort
+                /// Treat `[i]` on a `kql_array_sort_*` result as tuple-element access (these
+                /// functions return `Tuple(Array, ...)`). Only mutate the sibling
+                /// `arrayElement` when it was built via operator syntax; mutating a
+                /// call-syntax node breaks the format/parse/format round-trip check.
                 if (cur_op.function_name == "arrayElement" && !operands.empty())
                 {
-                    auto* first_arg_as_node = operands.front()->as<ASTFunction>();
-                    if (first_arg_as_node)
+                    if (auto * first_arg_as_node = operands.front()->as<ASTFunction>())
                     {
                         if (first_arg_as_node->name == "kql_array_sort_asc" || first_arg_as_node->name == "kql_array_sort_desc")
                         {
                             cur_op.function_name = "tupleElement";
                             cur_op.type = OperatorType::TupleElement;
                         }
-                        else if (first_arg_as_node->name == "arrayElement" && !first_arg_as_node->arguments->children.empty())
+                        else if (first_arg_as_node->isOperator()
+                            && first_arg_as_node->name == "arrayElement"
+                            && !first_arg_as_node->arguments->children.empty())
                         {
-                            auto *arg_inside = first_arg_as_node->arguments->children[0]->as<ASTFunction>();
+                            auto * arg_inside = first_arg_as_node->arguments->children[0]->as<ASTFunction>();
                             if (arg_inside && (arg_inside->name == "kql_array_sort_asc" || arg_inside->name == "kql_array_sort_desc"))
                                 first_arg_as_node->name = "tupleElement";
                         }

--- a/tests/queries/0_stateless/04325_stid_1941_1bfa_kql_array_sort_arrayelement_roundtrip.reference
+++ b/tests/queries/0_stateless/04325_stid_1941_1bfa_kql_array_sort_arrayelement_roundtrip.reference
@@ -1,0 +1,12 @@
+SELECT (kql_array_sort_asc([3, 1, 2])).1
+SELECT (kql_array_sort_desc([3, 1, 2])).1
+SELECT ((kql_array_sort_asc([3, 1, 2])).1)[2]
+SELECT ((kql_array_sort_desc([3, 1, 2])).1)[2]
+SELECT arrayElement(kql_array_sort_asc([(1, 2)]), 1)
+SELECT arrayElement(kql_array_sort_desc([(1, 2)]), 1)
+SELECT arrayElement(arrayElement(kql_array_sort_asc([(1, 2)]), 1), 2)
+SELECT arrayElement(arrayElement(kql_array_sort_desc([(1, 2)]), 1), 2)
+SELECT arrayElement(kql_array_sort_asc([(1, 2)]), 1)[2]
+SELECT arrayElement(kql_array_sort_desc([(1, 2)]), 1)[2]
+[1,2,3]
+2

--- a/tests/queries/0_stateless/04325_stid_1941_1bfa_kql_array_sort_arrayelement_roundtrip.sql
+++ b/tests/queries/0_stateless/04325_stid_1941_1bfa_kql_array_sort_arrayelement_roundtrip.sql
@@ -1,0 +1,44 @@
+-- The bracket subscript on `kql_array_sort_asc` / `kql_array_sort_desc` was implemented by
+-- an in-place rename of a sibling `arrayElement` operand to `tupleElement` inside the
+-- operator-folding code. That rewrite also fired against an `arrayElement(kql_array_sort_*, ...)`
+-- node built via call syntax, destroying the user-built shape and causing the format /
+-- parse / format round-trip check to raise `Inconsistent AST formatting` (STID 1941-1bfa).
+--
+-- The fix only rewrites a sibling whose `is_operator` flag is set, so call-syntax
+-- arrayElement nodes are preserved verbatim.
+
+-- 1. Existing `kql_array_sort_*([...])[i]` syntax must still produce `tupleElement(kql, i)`.
+SELECT formatQuery('SELECT kql_array_sort_asc([3, 1, 2])[1]');
+SELECT formatQuery('SELECT kql_array_sort_desc([3, 1, 2])[1]');
+
+-- 2. Existing `kql_array_sort_*([...])[i][j]` chained syntax must still produce
+--    `arrayElement(tupleElement(kql, i), j)`.
+SELECT formatQuery('SELECT kql_array_sort_asc([3, 1, 2])[1][2]');
+SELECT formatQuery('SELECT kql_array_sort_desc([3, 1, 2])[1][2]');
+
+-- 3. Call-syntax `arrayElement(kql_array_sort_*([...]), i)` must round-trip unchanged
+--    (the inner `arrayElement` must NOT be silently rewritten to `tupleElement`).
+SELECT formatQuery('SELECT arrayElement(kql_array_sort_asc([(1, 2)]), 1)');
+SELECT formatQuery('SELECT arrayElement(kql_array_sort_desc([(1, 2)]), 1)');
+
+-- 4. Call-syntax `arrayElement(arrayElement(kql_array_sort_*([...]), x), y)` must round-trip
+--    unchanged. This was the BuzzHouse-failing shape.
+SELECT formatQuery('SELECT arrayElement(arrayElement(kql_array_sort_asc([(1, 2)]), 1), 2)');
+SELECT formatQuery('SELECT arrayElement(arrayElement(kql_array_sort_desc([(1, 2)]), 1), 2)');
+
+-- 5. Mixed call-syntax inner + bracket outer: `arrayElement(kql_array_sort_*([...]), i)[j]`.
+--    Pre-fix this triggered `Inconsistent AST formatting` because the outer bracket-fold
+--    silently mutated the inner call-syntax `arrayElement` to `tupleElement`.
+SELECT formatQuery('SELECT arrayElement(kql_array_sort_asc([(1, 2)]), 1)[2]');
+SELECT formatQuery('SELECT arrayElement(kql_array_sort_desc([(1, 2)]), 1)[2]');
+
+-- 6. KQL evaluation semantics: single bracket returns the array, double bracket the scalar.
+SELECT kql_array_sort_asc([3, 1, 2])[1];
+SELECT kql_array_sort_asc([3, 1, 2])[1][2];
+
+-- 7. Force the format/parse/format round-trip check to run on the BuzzHouse-failing shape.
+--    Pre-fix this raised LOGICAL_ERROR `Inconsistent AST formatting (STID: 1941-1bfa)`.
+--    Post-fix the parser preserves the original shape and the type checker reports the
+--    semantic error instead.
+SELECT 1 WHERE (arrayElement(kql_array_sort_asc([(1, 2)]), 1)[2]).1 = 1; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }
+SELECT 1 WHERE (arrayElement(arrayElement(kql_array_sort_asc([(1, 2)]), 1), 2)).1 = 1; -- { serverError ILLEGAL_TYPE_OF_ARGUMENT }


### PR DESCRIPTION
The bracket subscript on `kql_array_sort_asc` / `kql_array_sort_desc` was implemented by an in-place rename of a sibling `arrayElement` operand to `tupleElement` inside the operator-folding code in `ParserExpression`. The rewrite also fired against `arrayElement` nodes built via call syntax (`arrayElement(kql_array_sort_*(...), i)`), which destroyed the user-built AST and broke the format/parse/format round-trip check executed in debug builds.

The original AST stored `arrayElement(arrayElement(kql_array_sort_*, i), j)` because the inner was constructed by call syntax (`is_operator = false`). Formatting wrote `arrayElement(kql_array_sort_*, i)[j]`, and the re-parse of that string went through the same code path and renamed the inner to `tupleElement`. The resulting AST had a different tree hash than the original and `executeQueryImpl` raised `LOGICAL_ERROR` `Inconsistent AST formatting (STID: 1941-1bfa)` across many BuzzHouse runs.

The fix restricts the inner rewrite to siblings whose `is_operator` flag is set. Operator-syntax `kql_array_sort_*(...)[i][j]` still folds to `arrayElement(tupleElement(kql, i), j)`. Call-syntax shapes are kept verbatim and survive the round-trip; the type checker reports the semantic mismatch instead of an internal `LOGICAL_ERROR`.

Reproducer (debug build):
```
SELECT 1 WHERE (arrayElement(kql_array_sort_asc([(1, 2)]), 1)[2]).1 = 1;
```

Pre-fix raises `LOGICAL_ERROR` `Inconsistent AST formatting (STID: 1941-1bfa)`. Post-fix raises `ILLEGAL_TYPE_OF_ARGUMENT` (the round-trip check passes; the call-syntax `arrayElement` applied to a Tuple is correctly rejected by type analysis).

Closes: https://github.com/ClickHouse/ClickHouse/issues/105396
Related: https://github.com/ClickHouse/ClickHouse/pull/91164

Latest CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=91164&sha=1102a6dbcb0f2cd3788e5c04bbdc1b1a78b76121&name_0=PR&name_1=BuzzHouse%20%28amd_debug%29

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a server-side `LOGICAL_ERROR` `Inconsistent AST formatting: ... (STID: 1941-1bfa)` raised by the AST round-trip check in debug builds when an `arrayElement(kql_array_sort_asc(...), i)` or `arrayElement(kql_array_sort_desc(...), i)` was constructed via call syntax and a further `[j]` was applied. The parser no longer destructively renames a call-syntax sibling `arrayElement`, preserving the user-supplied shape across format/parse/format.

Documentation entry for user-facing changes
- [x] Documentation is unchanged