### PR TITLE
Fix segfault due to use-after-free in NATS

### DIFF
--- a/src/Storages/NATS/INATSConsumer.cpp
+++ b/src/Storages/NATS/INATSConsumer.cpp
@@ -86,15 +86,24 @@ void INATSConsumer::onMsg(natsConnection *, natsSubscription *, natsMsg * msg, v
                 .subject = subject,
             };
             if (!nats_consumer->received.push(std::move(data)))
+            {
                 LOG_DEBUG(nats_consumer->log, "Consumer {} is shutting down, dropping a message", static_cast<void *>(nats_consumer));
+                nats_consumer->nackMessage(msg);
+            }
         }
     }
     catch (...)
     {
         tryLogCurrentException(nats_consumer->log, "Could not push to received queue");
+        nats_consumer->nackMessage(msg);
     }
 
     natsMsg_Destroy(msg);
+}
+
+void INATSConsumer::nackMessage(natsMsg *)
+{
+    /// Core NATS has no acknowledgements. Nothing to do.
 }
 
 }

--- a/src/Storages/NATS/INATSConsumer.cpp
+++ b/src/Storages/NATS/INATSConsumer.cpp
@@ -5,15 +5,13 @@
 #include <Storages/NATS/INATSConsumer.h>
 #include <IO/ReadBufferFromMemory.h>
 #include <Poco/Timer.h>
+#include <Common/Exception.h>
 #include <Common/logger_useful.h>
 
 namespace DB
 {
 
-namespace ErrorCodes
-{
-    extern const int INVALID_STATE;
-}
+static const int64_t DRAIN_TIMEOUT_MS = 5000;
 
 INATSConsumer::INATSConsumer(
     NATSConnectionPtr connection_,
@@ -37,6 +35,27 @@ bool INATSConsumer::isSubscribed() const
 }
 void INATSConsumer::unsubscribe()
 {
+    if (stopped)
+    {
+        received.finish();
+
+        for (auto & subscription : subscriptions)
+        {
+            auto status = natsSubscription_DrainTimeout(subscription.get(), DRAIN_TIMEOUT_MS);
+            if (status != NATS_OK)
+            {
+                LOG_WARNING(log, "Failed to start draining a subscription of consumer {}: {}",
+                    static_cast<void *>(this), natsStatus_GetText(status));
+                continue;
+            }
+
+            status = natsSubscription_WaitForDrainCompletion(subscription.get(), DRAIN_TIMEOUT_MS);
+            if (status != NATS_OK)
+                LOG_WARNING(log, "A subscription of consumer {} did not finish draining: {}",
+                    static_cast<void *>(this), natsStatus_GetText(status));
+        }
+    }
+
     subscriptions.clear();
 
     LOG_DEBUG(log, "Consumer {} unsubscribed", static_cast<void*>(this));
@@ -53,19 +72,26 @@ ReadBufferPtr INATSConsumer::consume()
 void INATSConsumer::onMsg(natsConnection *, natsSubscription *, natsMsg * msg, void * consumer)
 {
     auto * nats_consumer = static_cast<INATSConsumer *>(consumer);
-    const int msg_length = natsMsg_GetDataLength(msg);
 
-    if (msg_length)
+    try
     {
-        String message_received = std::string(natsMsg_GetData(msg), msg_length);
-        String subject = natsMsg_GetSubject(msg);
+        const int msg_length = natsMsg_GetDataLength(msg);
+        if (msg_length)
+        {
+            String message_received = std::string(natsMsg_GetData(msg), msg_length);
+            String subject = natsMsg_GetSubject(msg);
 
-        MessageData data = {
-            .message = message_received,
-            .subject = subject,
-        };
-        if (!nats_consumer->received.push(std::move(data)))
-            throw Exception(ErrorCodes::INVALID_STATE, "Could not push to received queue");
+            MessageData data = {
+                .message = message_received,
+                .subject = subject,
+            };
+            if (!nats_consumer->received.push(std::move(data)))
+                LOG_DEBUG(nats_consumer->log, "Consumer {} is shutting down, dropping a message", static_cast<void *>(nats_consumer));
+        }
+    }
+    catch (...)
+    {
+        tryLogCurrentException(nats_consumer->log, "Could not push to received queue");
     }
 
     natsMsg_Destroy(msg);

--- a/src/Storages/NATS/INATSConsumer.h
+++ b/src/Storages/NATS/INATSConsumer.h
@@ -67,6 +67,8 @@ protected:
 
     static void onMsg(natsConnection * nc, natsSubscription * sub, natsMsg * msg, void * consumer);
 
+    virtual void nackMessage(natsMsg * msg);
+
 private:
     NATSConnectionPtr connection;
     std::vector<NATSSubscriptionPtr> subscriptions;

--- a/src/Storages/NATS/NATSJetStreamConsumer.cpp
+++ b/src/Storages/NATS/NATSJetStreamConsumer.cpp
@@ -9,6 +9,11 @@ namespace ErrorCodes
     extern const int INVALID_STATE;
 }
 
+void NATSJetStreamConsumer::nackMessage(natsMsg * msg)
+{
+    natsMsg_Nak(msg, nullptr);
+}
+
 NATSJetStreamConsumer::NATSJetStreamConsumer(
     NATSConnectionPtr connection,
     String stream_name_,

--- a/src/Storages/NATS/NATSJetStreamConsumer.h
+++ b/src/Storages/NATS/NATSJetStreamConsumer.h
@@ -26,6 +26,8 @@ public:
     void subscribe() override;
 
 protected:
+    void nackMessage(natsMsg * msg) override;
+
     NATSSubscriptionPtr subscribeToSubject(const String & subject);
 
     const String stream_name;

--- a/src/Storages/NATS/StorageNATS.cpp
+++ b/src/Storages/NATS/StorageNATS.cpp
@@ -481,8 +481,7 @@ void StorageNATS::shutdown(bool /* is_drop */)
     /// Just a paranoid try catch, it is not actually needed.
     try
     {
-        if (drop_table)
-            unsubscribeConsumers();
+        unsubscribeConsumers();
 
         if (consumers_connection)
         {


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1861
<!-- End of fixes issue link part, do not remove -->

<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


Fix a race between destroying `INATSConsumer` objects and calling `INATSConsumer::onMsg` on them via callbacks in the NATS library. Make sure that there are no `INATSConsumer::onMsg` calls after `INATSConsumer::unsubscribe` is called on shutdown by synchronously draining the subscription.

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a race between destroying `INATSConsumer` objects and calling `INATSConsumer::onMsg` on them via callbacks in the NATS library.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.579`
- Backported to: `26.5.3.11`, `26.4.5.12`, `26.3.14.12`
<!-- ch-version-info:end -->