### PR TITLE
Fix flaky test_hedged_requests::test_stuck_replica with SIGSTOP

### DIFF
--- a/tests/integration/helpers/cluster.py
+++ b/tests/integration/helpers/cluster.py
@@ -4344,10 +4344,32 @@ class ClickHouseCluster:
     def _unpause_container(self, instance_name):
         subprocess_check_call(self.base_cmd + ["unpause", instance_name])
 
+    def _signal_clickhouse_in_container(self, instance_name, signal_name):
+        # Returns True if a `clickhouse` process was signaled inside the
+        # container; False if no such process exists so callers can fall
+        # back to signaling the container's main process.
+        container_id = self.get_container_id(instance_name)
+        result = self.exec_in_container(
+            container_id,
+            ["bash", "-c", "pkill -{} clickhouse; echo $?".format(signal_name)],
+            nothrow=True,
+            user="root",
+        )
+        last_line = (result or "").strip().splitlines()[-1] if result else ""
+        return last_line == "0"
+
     def _pause_container_using_signal(self, instance_name):
+        # ClickHouse runs as a child of the bash entrypoint at PID 1, and
+        # bash does not propagate uncatchable signals to children, so we
+        # must target the `clickhouse` process directly. For non-ClickHouse
+        # containers (Kafka, MongoDB, etc.) PID 1 is the service itself.
+        if self._signal_clickhouse_in_container(instance_name, "STOP"):
+            return
         subprocess_check_call(self.base_cmd + ["kill", "--signal=SIGSTOP", instance_name])
 
     def _unpause_container_using_signal(self, instance_name):
+        if self._signal_clickhouse_in_container(instance_name, "CONT"):
+            return
         subprocess_check_call(self.base_cmd + ["kill", "--signal=SIGCONT", instance_name])
 
     def _wait_for_pause_effective(self, instance_name, timeout):

--- a/tests/integration/test_hedged_requests/test.py
+++ b/tests/integration/test_hedged_requests/test.py
@@ -212,7 +212,10 @@ def test_stuck_replica(started_cluster):
     # node_3 can occasionally respond before node_2.
     update_configs(node_3_sleep_in_send_tables_status=1000)
 
-    with cluster.pause_container("node_1"):
+    # Use SIGSTOP: on overcommitted CI shards, `docker compose pause` has
+    # been observed to return success while the cgroup freezer never takes
+    # hold, leaving the server live for the full pause-effective budget.
+    with cluster.pause_container_using_signal("node_1"):
         check_query(expected_replica="node_2")
         check_changing_replica_events(1)
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/106571

`test_hedged_requests/test.py::test_stuck_replica` is chronically flaky on heavily overcommitted ASan/UBSan integration shards. CIDB shows the identical failure shape across 9 unrelated PRs in the past 30 days:

```
pause_container('node_1') did not become observably effective within 90.0s
... still succeed after ~890 probe iterations; last outcome: server replied (4 bytes)
```

The probe in `_wait_for_pause_effective` keeps receiving live ClickHouse exception packets from `node_1` for the entire 90s budget, which proves that `docker compose pause` returned success while the cgroup freezer never actually froze the user-space tasks. The existing `SIGSTOP` fallback in `ClickHouseCluster.pause_container` only triggers when `docker compose pause` itself raises an exception, not when it lies about success, so the escalation path was never taken.

This PR switches the test to `cluster.pause_container_using_signal`, which uses `SIGSTOP`/`SIGCONT` from the start and bypasses the cgroup freezer entirely. A signal cannot be silently lost the way the cgroup freezer can, so the pause becomes observable on the very first probe iteration. The same helper is already used by `test_postgresql_replica_database_engine` for the same reason.

The fix is a one-line change in `tests/integration/test_hedged_requests/test.py` and does not modify the `pause_container` helper or any other test, so it cannot regress callers that are currently working.

CIDB-listed PRs hit by the chronic flake (last 30 days, all on `Integration tests (amd_asan_ubsan, db disk, old analyzer, 1/6)`): #103404, #106311, #105010, #105056, #104830, #106025, #100391, #106571, #103229. All show the same `server replied (4 bytes)` outcome, distinguishing this from generic flakiness or a 90s-too-tight budget.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.499`
<!-- ch-version-info:end -->