### PR TITLE
Fix flaky test_attach_partition_using_copy

### DIFF
--- a/tests/integration/test_attach_partition_using_copy/test.py
+++ b/tests/integration/test_attach_partition_using_copy/test.py
@@ -24,10 +24,27 @@ def start_cluster():
         cluster.shutdown()
 
 
+# Retry parameters for queries that read from a `web` disk backed by
+# `raw.githubusercontent.com`. The endpoint occasionally returns
+# `Poco::TimeoutException: connect timed out` under CI network load,
+# so all queries that touch the source table or its data are wrapped
+# in `query_with_retry`.
+WEB_RETRY_COUNT = 5
+WEB_RETRY_SLEEP = 10
+
+
 def cleanup(nodes):
     for node in nodes:
-        node.query("DROP TABLE IF EXISTS source SYNC")
-        node.query("DROP TABLE IF EXISTS destination SYNC")
+        node.query_with_retry(
+            "DROP TABLE IF EXISTS source SYNC",
+            retry_count=WEB_RETRY_COUNT,
+            sleep_time=WEB_RETRY_SLEEP,
+        )
+        node.query_with_retry(
+            "DROP TABLE IF EXISTS destination SYNC",
+            retry_count=WEB_RETRY_COUNT,
+            sleep_time=WEB_RETRY_SLEEP,
+        )
 
 
 def create_source_table(node, table_name, replicated):
@@ -91,7 +108,7 @@ def create_destination_table(node, table_name, replicated):
         district LowCardinality(String),
         county LowCardinality(String)
         )
-        ENGINE = {engine} 
+        ENGINE = {engine}
         ORDER BY (postcode1, postcode2, addr1, addr2)
         """.format(
             table_name=table_name, engine=engine
@@ -104,18 +121,27 @@ def test_both_mergetree(start_cluster):
     create_source_table(replica1, "source", False)
     create_destination_table(replica1, "destination", False)
 
-    replica1.query(f"ALTER TABLE destination ATTACH PARTITION tuple() FROM source")
+    replica1.query_with_retry(
+        "ALTER TABLE destination ATTACH PARTITION tuple() FROM source",
+        retry_count=WEB_RETRY_COUNT,
+        sleep_time=WEB_RETRY_SLEEP,
+    )
 
+    expected = replica1.query_with_retry(
+        "SELECT toYear(date) AS year,round(avg(price)) AS price,"
+        "bar(price, 0, 1000000, 80) FROM source GROUP BY year ORDER BY year ASC",
+        retry_count=WEB_RETRY_COUNT,
+        sleep_time=WEB_RETRY_SLEEP,
+    )
     assert_eq_with_retry(
         replica1,
-        f"SELECT toYear(date) AS year,round(avg(price)) AS price,bar(price, 0, 1000000, 80) FROM destination GROUP BY year ORDER BY year ASC",
-        replica1.query(
-            f"SELECT toYear(date) AS year,round(avg(price)) AS price,bar(price, 0, 1000000, 80) FROM source GROUP BY year ORDER BY year ASC"
-        ),
+        "SELECT toYear(date) AS year,round(avg(price)) AS price,"
+        "bar(price, 0, 1000000, 80) FROM destination GROUP BY year ORDER BY year ASC",
+        expected,
     )
 
     assert_eq_with_retry(
-        replica1, f"SELECT town from destination LIMIT 1", "SCARBOROUGH"
+        replica1, "SELECT town from destination LIMIT 1", "SCARBOROUGH"
     )
 
     cleanup([replica1])
@@ -127,30 +153,38 @@ def test_all_replicated(start_cluster):
     create_destination_table(replica1, "destination", True)
     create_destination_table(replica2, "destination", True)
 
-    replica1.query(f"ALTER TABLE destination ATTACH PARTITION tuple() FROM source")
+    replica1.query_with_retry(
+        "ALTER TABLE destination ATTACH PARTITION tuple() FROM source",
+        retry_count=WEB_RETRY_COUNT,
+        sleep_time=WEB_RETRY_SLEEP,
+    )
     replica2.query("SYSTEM SYNC REPLICA destination")
 
-    assert_eq_with_retry(
-        replica1,
-        f"SELECT toYear(date) AS year,round(avg(price)) AS price,bar(price, 0, 1000000, 80) FROM destination GROUP BY year ORDER BY year ASC",
-        replica1.query(
-            f"SELECT toYear(date) AS year,round(avg(price)) AS price,bar(price, 0, 1000000, 80) FROM source GROUP BY year ORDER BY year ASC"
-        ),
+    expected = replica1.query_with_retry(
+        "SELECT toYear(date) AS year,round(avg(price)) AS price,"
+        "bar(price, 0, 1000000, 80) FROM source GROUP BY year ORDER BY year ASC",
+        retry_count=WEB_RETRY_COUNT,
+        sleep_time=WEB_RETRY_SLEEP,
     )
     assert_eq_with_retry(
         replica1,
-        f"SELECT toYear(date) AS year,round(avg(price)) AS price,bar(price, 0, 1000000, 80) FROM source GROUP BY year ORDER BY year ASC",
-        replica2.query(
-            f"SELECT toYear(date) AS year,round(avg(price)) AS price,bar(price, 0, 1000000, 80) FROM destination GROUP BY year ORDER BY year ASC"
-        ),
+        "SELECT toYear(date) AS year,round(avg(price)) AS price,"
+        "bar(price, 0, 1000000, 80) FROM destination GROUP BY year ORDER BY year ASC",
+        expected,
+    )
+    assert_eq_with_retry(
+        replica2,
+        "SELECT toYear(date) AS year,round(avg(price)) AS price,"
+        "bar(price, 0, 1000000, 80) FROM destination GROUP BY year ORDER BY year ASC",
+        expected,
     )
 
     assert_eq_with_retry(
-        replica1, f"SELECT town from destination LIMIT 1", "SCARBOROUGH"
+        replica1, "SELECT town from destination LIMIT 1", "SCARBOROUGH"
     )
 
     assert_eq_with_retry(
-        replica2, f"SELECT town from destination LIMIT 1", "SCARBOROUGH"
+        replica2, "SELECT town from destination LIMIT 1", "SCARBOROUGH"
     )
 
     cleanup([replica1, replica2])
@@ -162,30 +196,38 @@ def test_only_destination_replicated(start_cluster):
     create_destination_table(replica1, "destination", True)
     create_destination_table(replica2, "destination", True)
 
-    replica1.query(f"ALTER TABLE destination ATTACH PARTITION tuple() FROM source")
+    replica1.query_with_retry(
+        "ALTER TABLE destination ATTACH PARTITION tuple() FROM source",
+        retry_count=WEB_RETRY_COUNT,
+        sleep_time=WEB_RETRY_SLEEP,
+    )
     replica2.query("SYSTEM SYNC REPLICA destination")
 
-    assert_eq_with_retry(
-        replica1,
-        f"SELECT toYear(date) AS year,round(avg(price)) AS price,bar(price, 0, 1000000, 80) FROM destination GROUP BY year ORDER BY year ASC",
-        replica1.query(
-            f"SELECT toYear(date) AS year,round(avg(price)) AS price,bar(price, 0, 1000000, 80) FROM source GROUP BY year ORDER BY year ASC"
-        ),
+    expected = replica1.query_with_retry(
+        "SELECT toYear(date) AS year,round(avg(price)) AS price,"
+        "bar(price, 0, 1000000, 80) FROM source GROUP BY year ORDER BY year ASC",
+        retry_count=WEB_RETRY_COUNT,
+        sleep_time=WEB_RETRY_SLEEP,
     )
     assert_eq_with_retry(
         replica1,
-        f"SELECT toYear(date) AS year,round(avg(price)) AS price,bar(price, 0, 1000000, 80) FROM source GROUP BY year ORDER BY year ASC",
-        replica2.query(
-            f"SELECT toYear(date) AS year,round(avg(price)) AS price,bar(price, 0, 1000000, 80) FROM destination GROUP BY year ORDER BY year ASC"
-        ),
+        "SELECT toYear(date) AS year,round(avg(price)) AS price,"
+        "bar(price, 0, 1000000, 80) FROM destination GROUP BY year ORDER BY year ASC",
+        expected,
+    )
+    assert_eq_with_retry(
+        replica2,
+        "SELECT toYear(date) AS year,round(avg(price)) AS price,"
+        "bar(price, 0, 1000000, 80) FROM destination GROUP BY year ORDER BY year ASC",
+        expected,
     )
 
     assert_eq_with_retry(
-        replica1, f"SELECT town from destination LIMIT 1", "SCARBOROUGH"
+        replica1, "SELECT town from destination LIMIT 1", "SCARBOROUGH"
     )
 
     assert_eq_with_retry(
-        replica2, f"SELECT town from destination LIMIT 1", "SCARBOROUGH"
+        replica2, "SELECT town from destination LIMIT 1", "SCARBOROUGH"
     )
 
     cleanup([replica1, replica2])


### PR DESCRIPTION
The integration test `test_attach_partition_using_copy` creates a `source` table backed by a `web` disk pointing at `https://raw.githubusercontent.com/ClickHouse/web-tables-demo/main/web/`. Every operation that touches data through that table (`ALTER TABLE ... ATTACH PARTITION`, `SELECT FROM source`, `DROP TABLE source SYNC`) goes through `DiskObjectStorage::copyFile` -> `ReadWriteBufferFromHTTP::callImpl` -> `Poco::Net::SocketImpl::connect` and can fail with `Poco::TimeoutException: connect timed out` when the GitHub Pages endpoint (`185.199.110.x:443`) is slow under CI network load.

`create_source_table` and `create_destination_table` already use `query_with_retry` for exactly this reason (see PR #64977). This PR extends the same pattern to the remaining queries that touch the web-backed source table:

- `cleanup`: `DROP TABLE source SYNC` and `DROP TABLE destination SYNC`
- `test_both_mergetree`, `test_all_replicated`, `test_only_destination_replicated`: the `ALTER TABLE destination ATTACH PARTITION tuple() FROM source` and the `SELECT ... FROM source` snapshot used as the expected value for `assert_eq_with_retry`.

In the replicated tests, the second `assert_eq_with_retry` previously took a one-shot `replica2.query(...)` snapshot of `destination` and polled `replica1.SELECT FROM source` against it. The same comparison is now expressed by polling `replica2.SELECT FROM destination` against `expected` (the retry-fetched source snapshot), which is logically equivalent and resilient to transient web-disk timeouts.

Per @alexey-milovidov directive on https://github.com/ClickHouse/ClickHouse/pull/103559#issuecomment-4640862015

CIDB sighting: https://play.clickhouse.com/ - PR #103559, `Integration tests (arm_binary, distributed plan, 2/4)`, 2026-06-04 19:55:18, full stack ending in `Poco::TimeoutException` from `Poco::Net::SocketImpl::connect`.

No related open issue found.

Related: https://github.com/ClickHouse/ClickHouse/pull/103559
Related: https://github.com/ClickHouse/ClickHouse/pull/64977

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.727`
<!-- ch-version-info:end -->