### PR TITLE
Reduce Spark JVM heap in delta-lake integration tests to fix OOM under flaky-check --dist=each

### DIFF
--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -84,8 +84,8 @@ def get_spark(log_dir=None):
             "spark.sql.catalog.spark_catalog.warehouse",
             "/var/lib/clickhouse/user_files/test_storage_delta",
         )
-        .config("spark.driver.memory", "8g")
-        .config("spark.executor.memory", "8g")
+        .config("spark.driver.memory", "2g")
+        .config("spark.executor.memory", "2g")
         .master("local")
     )
 

--- a/tests/integration/test_storage_delta/test_cdf.py
+++ b/tests/integration/test_storage_delta/test_cdf.py
@@ -72,8 +72,8 @@ def get_spark(log_dir=None):
             "spark.sql.catalog.spark_catalog.warehouse",
             "/var/lib/clickhouse/user_files",
         )
-        .config("spark.driver.memory", "8g")
-        .config("spark.executor.memory", "8g")
+        .config("spark.driver.memory", "2g")
+        .config("spark.executor.memory", "2g")
         .master("local")
     )
 

--- a/tests/integration/test_storage_delta_disks/test.py
+++ b/tests/integration/test_storage_delta_disks/test.py
@@ -50,8 +50,8 @@ def get_spark(log_dir=None):
             "spark.sql.catalog.spark_catalog.warehouse",
             "/var/lib/clickhouse/user_files",
         )
-        .config("spark.driver.memory", "8g")
-        .config("spark.executor.memory", "8g")
+        .config("spark.driver.memory", "2g")
+        .config("spark.executor.memory", "2g")
         .master("local")
     )
 


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/105171

Under integration `flaky` and `targeted` checks, pytest is launched with `--dist=each`, which spawns N xdist workers (typically 12 on the CI runner) each running its own isolated Docker cluster with a fresh PySpark JVM. With the three delta-lake `get_spark` builders previously pinning `spark.driver.memory` and `spark.executor.memory` to `8g` (16 GiB heap per worker), 12 workers × 16 GiB plus ASan/UBSan overhead in the ClickHouse processes themselves saturates host memory and the kernel kills the JVMs, after which every subsequent Spark call from `generate_data` fails (`spark._sc._jvm` AttributeError) and the runner records an `OOM in dmesg` synthetic failure.

That is what happened on PR #105171's flaky check (https://github.com/ClickHouse/ClickHouse/actions/runs/26987765500/job/79643750220): 19 `test_storage_delta/*` failures all sharing the dead-JVM signature plus the synthetic `OOM in dmesg`.

The data the tests feed Spark is tiny (`generate_data` calls top out at `spark.range(0, 1300)`, most use 100 rows or fewer). 4 GiB total per JVM (`2g` driver + `2g` executor) leaves comfortable headroom above the 1g/1g Spark default while making 12-worker `--dist=each` fit (12 × 4 GiB = 48 GiB, well under the ~256 GiB host).

Applied symmetrically to all three delta-lake test files that share the 8g/8g pattern - `tests/integration/test_storage_delta/test.py`, `tests/integration/test_storage_delta/test_cdf.py`, `tests/integration/test_storage_delta_disks/test.py` - so the same OOM does not surface on any future PR touching a sibling file. `test_storage_iceberg/test.py` and `test_storage_iceberg_disks/test.py` already use Spark defaults and do not need a similar change.

The previous 8g/8g value was added in `0302eb0c3af` (2025-08-29, "Try fix spark out of memory") to address per-process OOM on a different path; 2g/2g still gives 4× the Spark default, preserving that intent while removing the multi-process pressure.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.497`
<!-- ch-version-info:end -->