### PR TITLE
Cap smoke check global_time_limit to avoid orphaned clickhouse-test

### DIFF
--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -124,14 +124,9 @@ class RandomQueryKiller:
         self._thread = None
 
 
-def get_options(
-    i: int,
-    upgrade_check: bool,
-    encrypted_storage: bool,
-    extra_client_options: Optional[List[str]] = None,
-) -> str:
+def get_options(i: int, upgrade_check: bool, encrypted_storage: bool) -> str:
     options = []
-    client_options = list(extra_client_options or [])
+    client_options = []
 
     if upgrade_check:
         # Disable settings randomization for upgrade checks to prevent test failures caused by missing settings in old version
@@ -284,22 +279,18 @@ def run_func_test(
         # Validate that simple tests work across all randomizations.
         # IF THIS FAILS, THE STRESS TESTS ARE BROKEN
         options = get_options(i, upgrade_check, encrypted_storage)
-        full_command = (
-            f"{cmd} --stress-tests {options} {global_time_limit_option} "
+        base_command = (
+            f"{cmd} --stress-tests {options} "
             f"{skip_tests_option} {upgrade_check_option} {encrypted_storage_option} "
         )
+        full_command = f"{base_command} {global_time_limit_option} "
         commands.append(full_command)
         # Smoke check: disable AST fuzzer (fuzzed queries produce expected
         # errors in stderr) and cap global_time_limit so clickhouse-test
         # exits on its own within the execute_bash timeout.
-        smoke_options = get_options(
-            i, upgrade_check, encrypted_storage,
-            extra_client_options=["ast_fuzzer_runs=0"],
-        )
-        smoke_command = (
-            f"{cmd} --stress-tests {smoke_options} {smoke_time_limit_option} "
-            f"{skip_tests_option} {upgrade_check_option} {encrypted_storage_option} "
-        )
+        smoke_command = base_command.replace(
+            "--client-option ", "--client-option ast_fuzzer_runs=0 ", 1
+        ) + f" {smoke_time_limit_option} "
         check_command = (
             smoke_command
             + "--server-logs-level fatal --jobs 1 00001_select_1 00234_disjunctive_equality_chains_optimization"

--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -264,6 +264,9 @@ def run_func_test(
     global_time_limit_option = (
         f"--global_time_limit={global_time_limit}" if global_time_limit else ""
     )
+    # --stress-tests loops until global_time_limit; cap the smoke check so
+    # clickhouse-test exits on its own within the execute_bash timeout (180s).
+    smoke_time_limit_option = "--global_time_limit=120"
 
     output_paths = [
         output_prefix / f"stress_test_run_{i}.txt" for i in range(num_processes)
@@ -283,7 +286,7 @@ def run_func_test(
         # produce expected errors in stderr, which would fail these tests.
         smoke_command = full_command.replace(
             "--client-option ", "--client-option ast_fuzzer_runs=0 ", 1
-        )
+        ).replace(global_time_limit_option, smoke_time_limit_option)
         check_command = (
             smoke_command
             + "--server-logs-level fatal --jobs 1 00001_select_1 00234_disjunctive_equality_chains_optimization"
@@ -291,18 +294,6 @@ def run_func_test(
         logging.info(check_command)
         try:
             execute_bash(check_command, timeout=180)
-        except subprocess.TimeoutExpired as e:
-            output = str(e.stdout or "")
-            if "tests passed" in output and "FAIL" not in output:
-                logging.warning(
-                    "Smoke check timed out after 180s (--stress-tests loops until global_time_limit). "
-                    "Tests passed. Partial output:\n%s",
-                    output,
-                )
-            else:
-                raise RuntimeError(
-                    f"Smoke check timed out and tests did not pass:\n{output}"
-                ) from e
         except subprocess.CalledProcessError as e:
             logging.info("Smoke check stdout:\n%s", e.stdout)
             logging.info("Smoke check stderr:\n%s", e.stderr)

--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -266,7 +266,8 @@ def run_func_test(
     )
     # --stress-tests loops until global_time_limit; cap the smoke check so
     # clickhouse-test exits on its own within the execute_bash timeout (180s).
-    smoke_time_limit_option = "--global_time_limit=120"
+    smoke_time_limit = min(global_time_limit, 120) if global_time_limit else 120
+    smoke_time_limit_option = f"--global_time_limit={smoke_time_limit}"
 
     output_paths = [
         output_prefix / f"stress_test_run_{i}.txt" for i in range(num_processes)
@@ -286,7 +287,13 @@ def run_func_test(
         # produce expected errors in stderr, which would fail these tests.
         smoke_command = full_command.replace(
             "--client-option ", "--client-option ast_fuzzer_runs=0 ", 1
-        ).replace(global_time_limit_option, smoke_time_limit_option)
+        )
+        if global_time_limit_option:
+            smoke_command = smoke_command.replace(
+                global_time_limit_option, smoke_time_limit_option
+            )
+        else:
+            smoke_command += f" {smoke_time_limit_option} "
         check_command = (
             smoke_command
             + "--server-logs-level fatal --jobs 1 00001_select_1 00234_disjunctive_equality_chains_optimization"

--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -124,9 +124,14 @@ class RandomQueryKiller:
         self._thread = None
 
 
-def get_options(i: int, upgrade_check: bool, encrypted_storage: bool) -> str:
+def get_options(
+    i: int,
+    upgrade_check: bool,
+    encrypted_storage: bool,
+    extra_client_options: Optional[List[str]] = None,
+) -> str:
     options = []
-    client_options = []
+    client_options = list(extra_client_options or [])
 
     if upgrade_check:
         # Disable settings randomization for upgrade checks to prevent test failures caused by missing settings in old version
@@ -287,10 +292,13 @@ def run_func_test(
         # Smoke check: disable AST fuzzer (fuzzed queries produce expected
         # errors in stderr) and cap global_time_limit so clickhouse-test
         # exits on its own within the execute_bash timeout.
+        smoke_options = get_options(
+            i, upgrade_check, encrypted_storage,
+            extra_client_options=["ast_fuzzer_runs=0"],
+        )
         smoke_command = (
-            f"{cmd} --stress-tests {options} {smoke_time_limit_option} "
+            f"{cmd} --stress-tests {smoke_options} {smoke_time_limit_option} "
             f"{skip_tests_option} {upgrade_check_option} {encrypted_storage_option} "
-            f"--client-option ast_fuzzer_runs=0 "
         )
         check_command = (
             smoke_command

--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -278,22 +278,20 @@ def run_func_test(
     for i, path in enumerate(output_paths):
         # Validate that simple tests work across all randomizations.
         # IF THIS FAILS, THE STRESS TESTS ARE BROKEN
+        options = get_options(i, upgrade_check, encrypted_storage)
         full_command = (
-            f"{cmd} --stress-tests {get_options(i, upgrade_check, encrypted_storage)} {global_time_limit_option} "
+            f"{cmd} --stress-tests {options} {global_time_limit_option} "
             f"{skip_tests_option} {upgrade_check_option} {encrypted_storage_option} "
         )
         commands.append(full_command)
-        # Disable server-side AST fuzzer for the smoke check: fuzzed queries
-        # produce expected errors in stderr, which would fail these tests.
-        smoke_command = full_command.replace(
-            "--client-option ", "--client-option ast_fuzzer_runs=0 ", 1
+        # Smoke check: disable AST fuzzer (fuzzed queries produce expected
+        # errors in stderr) and cap global_time_limit so clickhouse-test
+        # exits on its own within the execute_bash timeout.
+        smoke_command = (
+            f"{cmd} --stress-tests {options} {smoke_time_limit_option} "
+            f"{skip_tests_option} {upgrade_check_option} {encrypted_storage_option} "
+            f"--client-option ast_fuzzer_runs=0 "
         )
-        if global_time_limit_option:
-            smoke_command = smoke_command.replace(
-                global_time_limit_option, smoke_time_limit_option
-            )
-        else:
-            smoke_command += f" {smoke_time_limit_option} "
         check_command = (
             smoke_command
             + "--server-logs-level fatal --jobs 1 00001_select_1 00234_disjunctive_equality_chains_optimization"

--- a/ci/jobs/scripts/stress/stress.py
+++ b/ci/jobs/scripts/stress/stress.py
@@ -291,6 +291,18 @@ def run_func_test(
         logging.info(check_command)
         try:
             execute_bash(check_command, timeout=180)
+        except subprocess.TimeoutExpired as e:
+            output = str(e.stdout or "")
+            if "tests passed" in output and "FAIL" not in output:
+                logging.warning(
+                    "Smoke check timed out after 180s (--stress-tests loops until global_time_limit). "
+                    "Tests passed. Partial output:\n%s",
+                    output,
+                )
+            else:
+                raise RuntimeError(
+                    f"Smoke check timed out and tests did not pass:\n{output}"
+                ) from e
         except subprocess.CalledProcessError as e:
             logging.info("Smoke check stdout:\n%s", e.stdout)
             logging.info("Smoke check stderr:\n%s", e.stderr)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

With --stress-tests, clickhouse-test loops until --global_time_limit expires. The smoke check inherited the full limit (e.g. 1200s) but execute_bash kills after 180s — only killing the shell, not clickhouse-test (which sets its own process group). Cap the smoke check at 120s so it exits cleanly on its own.

Fixes CI failure like this one here: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=106385&sha=latest&name_0=PR&name_1=Stress+test+%28arm_debug%29 cc @alexey-milovidov @leshikus @maxknv 

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.501`
<!-- ch-version-info:end -->