### PR TITLE
Update TPC-DS Q75 references to the correct blocking issue

### DIFF
--- a/tests/benchmarks/tpc-ds/README.md
+++ b/tests/benchmarks/tpc-ds/README.md
@@ -415,7 +415,7 @@ LIMIT 100;
 ```
 
 ## Q75
-The query doesn't work out-of-the-box due to https://github.com/ClickHouse/ClickHouse/issues/94671. The alternative formulation with a minor fix works.
+The query doesn't work out-of-the-box due to https://github.com/ClickHouse/ClickHouse/issues/106707. The alternative formulation with a minor fix works.
 
 Original:
 ```sql

--- a/tests/benchmarks/tpc-ds/queries/query_75.sql
+++ b/tests/benchmarks/tpc-ds/queries/query_75.sql
@@ -1,5 +1,4 @@
---  "0." -> CAST('0.0', 'Decimal(7, 2)') as "0." parsed as Float and did not convert to Decimal.
--- Needs to be fixed: https://github.com/ClickHouse/ClickHouse/issues/94671
+--  "0." -> CAST('0.0', 'Decimal(7, 2)'). Needs to be fixed: https://github.com/ClickHouse/ClickHouse/issues/106707
 WITH
     all_sales AS
     (

--- a/tests/queries/0_stateless/04033_tpc_ds_q75.sh
+++ b/tests/queries/0_stateless/04033_tpc_ds_q75.sh
@@ -4,7 +4,7 @@
 # no-random-settings: random session_timezone, query_plan_join_swap_table, etc. change query results.
 # no-replicated-database: the `tpcds` database is not created in DatabaseReplicated mode.
 # no-flaky-check: TPC-DS queries are too expensive for thread fuzzer.
-# Known issue: the original query doesn't work, uses alternative formulation (https://github.com/ClickHouse/ClickHouse/issues/94671).
+# Known issue: the original query doesn't work, uses alternative formulation (https://github.com/ClickHouse/ClickHouse/issues/106707).
 # Once the issue is fixed, switch to the original query from tests/benchmarks/tpc-ds/README.md.
 
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)


### PR DESCRIPTION
The non-working Q75 of TPC-DS now doesn't work for another reason. Updated it from https://github.com/ClickHouse/ClickHouse/issues/94671 to https://github.com/ClickHouse/ClickHouse/issues/106707.


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.554`
<!-- ch-version-info:end -->