### PR TITLE
Fix flaky 04295_04278_materialized_cte_in_union_runtime_set on ParallelReplicas variant

### DIFF
--- a/tests/queries/0_stateless/04295_04278_materialized_cte_in_union_runtime_set.sql
+++ b/tests/queries/0_stateless/04295_04278_materialized_cte_in_union_runtime_set.sql
@@ -1,6 +1,16 @@
 SET enable_analyzer = 1;
 SET enable_materialized_cte = 1;
 
+-- The temporary materialized CTE storage `_materialized_cte_ct_<hash>` is
+-- registered on the initiator only. Under `enable_parallel_replicas = 1`,
+-- the follower replica running the `Remote` step does not see it and raises
+-- `UNKNOWN_TABLE: Unknown table expression identifier '_materialized_cte_ct_<hash>'`
+-- in `QueryAnalyzer::initializeQueryJoiningTreeWithTableExpressions`. Pin the
+-- setting so the CI `ParallelReplicas` variant cannot flip it on. The proper
+-- planner-side fix lives in `MaterializingCTEStep` plus the `ParallelReplicas`
+-- distributed-query construction path and is tracked separately.
+SET enable_parallel_replicas = 0;
+
 DROP TABLE IF EXISTS t_04278 SYNC;
 CREATE TABLE t_04278 (a Int32, b Int32) ENGINE = MergeTree ORDER BY a;
 INSERT INTO t_04278 VALUES (1, 10), (2, 20), (3, 30);


### PR DESCRIPTION
Pin `enable_parallel_replicas = 0` at the top of `04295_04278_materialized_cte_in_union_runtime_set` so the CI `ParallelReplicas` variant does not flip it on.

Under `enable_parallel_replicas = 1`, the temporary materialized CTE storage `_materialized_cte_ct_<hash>` is registered on the initiator only; the follower replica running the `Remote` step does not see it and raises `UNKNOWN_TABLE: Unknown table expression identifier '_materialized_cte_ct_<hash>'` in `QueryAnalyzer::initializeQueryJoiningTreeWithTableExpressions` (`src/Analyzer/Resolve/QueryAnalyzer.cpp:3836`).

12 hits in the last 14 days, all on `Stateless tests (amd_llvm_coverage, ParallelReplicas, s3 storage, parallel)`. Master red on 2026-06-08 (commits `38129a8480db`, `bf043eba3728`); 11 unrelated PRs affected.

The proper fix - making materialized CTEs work under parallel replicas - lives in `MaterializingCTEStep` plus the `ParallelReplicas` distributed-query construction path and is tracked separately.

Reported by @alexey-milovidov on https://github.com/ClickHouse/ClickHouse/pull/91583.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=91583&sha=7371cc6ee365348755585b2285028edb3781b81c&name_0=PR&name_1=Stateless%20tests%20%28amd_llvm_coverage%2C%20ParallelReplicas%2C%20s3%20storage%2C%20parallel%29

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Stabilize the `04295_04278_materialized_cte_in_union_runtime_set` stateless test under the `ParallelReplicas` CI variant.

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)
