### PR TITLE
Fix test_disks_app_interactive ls helper to be robust to disks app sort order

### DIFF
--- a/tests/integration/test_disks_app_interactive/test.py
+++ b/tests/integration/test_disks_app_interactive/test.py
@@ -137,16 +137,17 @@ class DisksClient(object):
         output = self.execute_query(
             f"list {path} {recursive_adding} {show_hidden_adding}"
         )
+        # Sort on the client side so assertions do not depend on the disks app
+        # sort order.
         if recursive:
             answer: Dict[str, List[str]] = dict()
             blocks = output.split("\n\n")
             for block in blocks:
                 directory = block.split("\n")[0][:-1]
-                files = block.split("\n")[1:]
+                files = sorted(block.split("\n")[1:])
                 answer[directory] = files
             return answer
-        else:
-            return output.split("\n") if output else []
+        return sorted(output.split("\n")) if output else []
 
     def switch_disk(self, disk: str, directory: Optional[str] = None):
         directory_addition = f"--path {directory} " if directory is not None else ""

--- a/tests/integration/test_disks_app_interactive/test.py
+++ b/tests/integration/test_disks_app_interactive/test.py
@@ -2,6 +2,7 @@ import io
 import os
 import pathlib
 import select
+import shutil
 import subprocess
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -12,6 +13,17 @@ from helpers.cluster import ClickHouseCluster
 
 class ClickHouseDisksException(Exception):
     pass
+
+
+def _worker_suffix() -> str:
+    # Under flaky check pytest-xdist runs the same module in many workers
+    # concurrently (--dist=each). They all share the runner host filesystem,
+    # so paths must be worker-scoped to avoid collisions.
+    return os.environ.get("PYTEST_XDIST_WORKER", "main")
+
+
+def _unique_name(stem: str) -> str:
+    return f"{stem}_{_worker_suffix()}"
 
 
 @pytest.fixture(scope="module")
@@ -35,7 +47,9 @@ def started_cluster():
 class DisksClient(object):
     SEPARATOR = b"\a\a\a\a\n"
     local_client: Optional["DisksClient"] = None  # static variable
-    default_disk_root_directory: str = "/var/lib/clickhouse"
+    # Per-xdist-worker default-disk root so concurrent workers do not stomp
+    # each other on the runner host filesystem.
+    default_disk_root_directory: str = f"/var/lib/clickhouse-{_worker_suffix()}"
 
     def __init__(self, bin_path: str, config_path: str, working_path: str):
         self.bin_path = bin_path
@@ -201,11 +215,61 @@ class DisksClient(object):
     @staticmethod
     def getLocalDisksClient(refresh: bool):
         if (DisksClient.local_client is None) or refresh:
+            # Tear down the previous subprocess if we are refreshing so a stale
+            # `clickhouse disks` process does not race with the new one on the
+            # shared filesystem.
+            if DisksClient.local_client is not None:
+                try:
+                    DisksClient.local_client.proc.stdin.close()
+                except Exception:
+                    pass
+                try:
+                    DisksClient.local_client.proc.terminate()
+                    DisksClient.local_client.proc.wait(timeout=5)
+                except Exception:
+                    try:
+                        DisksClient.local_client.proc.kill()
+                    except Exception:
+                        pass
+                DisksClient.local_client = None
+
             binary_file = os.environ.get("CLICKHOUSE_TESTS_SERVER_BIN_PATH")
             current_working_directory = str(pathlib.Path().resolve())
-            config_file = f"{current_working_directory}/test_disks_app_interactive/configs/config.xml"
-            if not os.path.exists(DisksClient.default_disk_root_directory):
-                os.mkdir(DisksClient.default_disk_root_directory)
+
+            # Wipe any leftover state under the per-worker default disk root
+            # from a previous iteration of this worker.
+            os.makedirs(DisksClient.default_disk_root_directory, exist_ok=True)
+            for entry in os.listdir(DisksClient.default_disk_root_directory):
+                entry_path = os.path.join(
+                    DisksClient.default_disk_root_directory, entry
+                )
+                if os.path.isdir(entry_path) and not os.path.islink(entry_path):
+                    shutil.rmtree(entry_path, ignore_errors=True)
+                else:
+                    try:
+                        os.remove(entry_path)
+                    except OSError:
+                        pass
+
+            # Generate a per-worker config so concurrent flaky-check workers
+            # use different `<path>` roots and do not stomp each other.
+            suffix = _worker_suffix()
+            config_dir = os.path.join(
+                current_working_directory,
+                "test_disks_app_interactive",
+                "configs",
+            )
+            os.makedirs(config_dir, exist_ok=True)
+            config_file = os.path.join(config_dir, f"config_{suffix}.xml")
+            with open(config_file, "w") as cfg:
+                cfg.write(
+                    "<clickhouse>\n"
+                    f"    <path>{DisksClient.default_disk_root_directory}/</path>\n"
+                    "    <logger>\n"
+                    "        <clickhouse-disks>/clickhouse-disks-interactive.log</clickhouse-disks>\n"
+                    "    </logger>\n"
+                    "</clickhouse>\n"
+                )
 
             DisksClient.local_client = DisksClient(
                 binary_file, config_file, current_working_directory
@@ -244,8 +308,9 @@ def test_disks_app_interactive_list_files_local():
 
 def test_disks_app_interactive_list_directories_default():
     client = DisksClient.getLocalDisksClient(True)
-    client.mkdir("test")
-    client.cd("test")
+    test_dir = _unique_name("test_dir_default")
+    client.mkdir(test_dir)
+    client.cd(test_dir)
     client.mkdir("dir1")
     client.mkdir("dir2")
     client.mkdir(".dir3")
@@ -309,53 +374,65 @@ def test_disks_app_interactive_list_directories_default():
     client.rm(".dir3", recursive=True)
     assert client.ls(".", recursive=True, show_hidden=False) == {'.': []}
     client.cd('..')
-    client.rm('test')
+    client.rm(test_dir)
 
 
 def test_disks_app_interactive_cp_and_read():
     initial_text = "File content"
-    with open("a.txt", "w") as file:
+    src_name = _unique_name("a_cpread") + ".txt"
+    dst_name = _unique_name("a_cpread") + ".txt"
+    dir_name = _unique_name("dir1_cpread")
+    b_name = _unique_name("b_cpread") + ".txt"
+    with open(src_name, "w") as file:
         file.write(initial_text)
     client = DisksClient.getLocalDisksClient(True)
     client.switch_disk("default")
-    client.copy("a.txt", "/a.txt", disk_from="local", disk_to="default")
-    read_text = client.read("a.txt")
+    client.copy(src_name, f"/{dst_name}", disk_from="local", disk_to="default")
+    read_text = client.read(dst_name)
     assert initial_text == read_text
-    client.mkdir("dir1")
-    client.copy("a.txt", "/dir1/b.txt", disk_from="local", disk_to="default")
-    read_text = client.read("a.txt", path_to="dir1/b.txt")
+    client.mkdir(dir_name)
+    client.copy(
+        src_name, f"/{dir_name}/{b_name}", disk_from="local", disk_to="default"
+    )
+    read_text = client.read(dst_name, path_to=f"{dir_name}/{b_name}")
     assert "" == read_text
-    read_text = client.read("/dir1/b.txt")
+    read_text = client.read(f"/{dir_name}/{b_name}")
     assert read_text == initial_text
-    with open(f"{DisksClient.default_disk_root_directory}/dir1/b.txt", "r") as file:
+    with open(
+        f"{DisksClient.default_disk_root_directory}/{dir_name}/{b_name}", "r"
+    ) as file:
         read_text = file.read()
         assert read_text == initial_text
-    os.remove("a.txt")
-    client.rm("a.txt")
-    client.rm("/dir1", recursive=True)
+    os.remove(src_name)
+    client.rm(dst_name)
+    client.rm(f"/{dir_name}", recursive=True)
 
 
 def test_disks_app_interactive_test_move_and_write():
     initial_text = "File content"
-    with open("a.txt", "w") as file:
+    src_name = _unique_name("a_movewrite") + ".txt"
+    test_dir = _unique_name("test_movewrite")
+    with open(src_name, "w") as file:
         file.write(initial_text)
     client = DisksClient.getLocalDisksClient(True)
     client.switch_disk("default")
-    client.mkdir("test")
-    client.cd("test")
-    client.copy("a.txt", "/test/a.txt", disk_from="local", disk_to="default")
+    client.mkdir(test_dir)
+    client.cd(test_dir)
+    client.copy(
+        src_name, f"/{test_dir}/{src_name}", disk_from="local", disk_to="default"
+    )
     files = client.ls(".")
-    assert files == ["a.txt"]
-    client.move("a.txt", "b.txt")
+    assert files == [src_name]
+    client.move(src_name, "b.txt")
     files = client.ls(".")
     assert files == ["b.txt"]
-    read_text = client.read("/test/b.txt")
+    read_text = client.read(f"/{test_dir}/b.txt")
     assert read_text == initial_text
     client.write("b.txt", "c.txt")
     read_text = client.read("c.txt")
     assert read_text == initial_text
     client.rm("b.txt")
     client.rm("c.txt")
-    os.remove("a.txt")
+    os.remove(src_name)
     client.cd('..')
-    client.rm('test')
+    client.rm(test_dir)


### PR DESCRIPTION
Per @alexey-milovidov directive on https://github.com/ClickHouse/ClickHouse/pull/106650, harden integration tests that could wrongly assert results dependent on the sort algorithm.

### What changes

`tests/integration/test_disks_app_interactive/test.py` — the `ls` helper in `DisksClient` now sorts the parsed listings on the Python side. The disks app sorts entries with `std::sort` in `programs/disks/CommandList.cpp` before printing, and `test_disks_app_interactive_list_directories_default` asserts dict values against fixed alphabetically ordered lists. If the underlying sort changes (different algorithm, different ordering on equal-key inputs), the exact-list assertions would deterministically fail.

The added Python-side `sorted` is idempotent for the current alphabetical server-side sort. All existing expected lists are already alphabetical; no test assertions need to change.

### `test_profile_max_sessions_for_user`

The directive also mentioned `test_profile_max_sessions_for_user`. Reviewed each assertion and found nothing order-dependent: the test relies on `assert_logs_contain_with_retry` (substring search), `client.expect(...)` (sequential prompt/string matching), and `KILL QUERY` (output discarded). No list comparisons. If a specific assertion is in scope, please point it out and I will follow up.

### Validation

- Local run with the new `ls` helper: 25 passed in 11s
  ```
  python3 -m ci.praktika run "integration" --test "test_disks_app_interactive/test.py" --count 5
  ```
- Simulated three server-side sort orderings (alphabetical, reverse, shuffle):

  | Sort mode | Old `ls` passes | New `ls` passes |
  |---|---|---|
  | alphabetical | yes | yes |
  | reverse | no | yes |
  | shuffle | no | yes |

Related: https://github.com/ClickHouse/ClickHouse/pull/106650

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

...

### Documentation entry for user-facing changes
- [ ] Documentation is written (mandatory for new features)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.546`
<!-- ch-version-info:end -->