### PR TITLE
Reimplement `getMetadataStorage()` for DiskEncrypted

### DIFF
--- a/src/Disks/DiskEncrypted.h
+++ b/src/Disks/DiskEncrypted.h
@@ -3,6 +3,8 @@
 #include "config.h"
 
 #if USE_SSL
+#include <mutex>
+
 #include <Disks/IDisk.h>
 #include <Common/MultiVersion.h>
 #include <Disks/FakeDiskTransaction.h>
@@ -373,7 +375,14 @@ public:
 
     MetadataStoragePtr getMetadataStorage() override
     {
-        return std::make_shared<MetadataStorageWithPathWrapper>(delegate->getMetadataStorage(), disk_path);
+        /// Cache the wrapper so that the metadata storage pointer is stable across calls (like `DiskObjectStorage`),
+        /// which code such as `isStoredOnTheSameDisk` relies on to hardlink parts instead of copying them; lazily,
+        /// because a non-object-storage delegate does not implement `getMetadataStorage`.
+        std::call_once(metadata_storage_init_flag, [this]
+        {
+            metadata_storage = std::make_shared<MetadataStorageWithPathWrapper>(delegate->getMetadataStorage(), disk_path);
+        });
+        return metadata_storage;
     }
 
     std::unordered_map<String, String> getSerializedMetadata(const std::vector<String> & paths) const override;
@@ -413,6 +422,10 @@ private:
     const String disk_absolute_path;
     MultiVersion<DiskEncryptedSettings> current_settings;
     bool use_fake_transaction;
+
+    /// Lazily-initialized stable wrapper returned by getMetadataStorage(); see the comment there.
+    std::once_flag metadata_storage_init_flag;
+    MetadataStoragePtr metadata_storage;
 };
 
 }


### PR DESCRIPTION
Cache the `MetadataStorageWithPathWrapper` in `DiskEncrypted` so that `getMetadataStorage` returns a stable instance instead of allocating a fresh wrapper on every call. The clone path (`isStoredOnTheSameDisk`) compares metadata-storage pointers to decide whether to hardlink or copy parts; the fresh-wrapper behavior made that comparison always fail for encrypted disks, forcing a full copy (e.g. a slow `CREATE TABLE ... CLONE AS` that doubled stored data). The cache is initialized lazily via `std::call_once` since a non-object-storage delegate does not implement `getMetadataStorage`.

### Changelog category (leave one):
- Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `CREATE TABLE ... CLONE AS (and REPLACE / ATTACH PARTITION ... FROM)` on encrypted disks copying data instead of hardlinking it.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.574`
- Backported to: `26.5.3.24`, `26.4.5.31`, `26.3.14.24`
<!-- ch-version-info:end -->