### PR TITLE
Fix memory-safety and resource-exhaustion issues in Parquet/Geo/Avro readers with untrusted input

### DIFF
--- a/src/Functions/geometryConverters.h
+++ b/src/Functions/geometryConverters.h
@@ -27,20 +27,24 @@ namespace ErrorCodes
     extern const int ILLEGAL_TYPE_OF_ARGUMENT;
 }
 
+/// Use AllocatorWithMemoryTracking so that building geometries (in particular parsing untrusted
+/// WKB/WKT, where element counts come straight off the wire) charges the MemoryTracker through its
+/// throwing path. Otherwise a declared-but-absent element count drives a large `reserve` that
+/// `max_memory_usage` does not bound (the default container tracking is non-throwing).
 template <typename Point>
-using LineString = boost::geometry::model::linestring<Point>;
+using LineString = boost::geometry::model::linestring<Point, std::vector, AllocatorWithMemoryTracking>;
 
 template <typename Point>
-using MultiLineString = boost::geometry::model::multi_linestring<LineString<Point>>;
+using MultiLineString = boost::geometry::model::multi_linestring<LineString<Point>, std::vector, AllocatorWithMemoryTracking>;
 
 template <typename Point>
-using Ring = boost::geometry::model::ring<Point>;
+using Ring = boost::geometry::model::ring<Point, true, true, std::vector, AllocatorWithMemoryTracking>;
 
 template <typename Point>
-using Polygon = boost::geometry::model::polygon<Point>;
+using Polygon = boost::geometry::model::polygon<Point, true, true, std::vector, std::vector, AllocatorWithMemoryTracking, AllocatorWithMemoryTracking>;
 
 template <typename Point>
-using MultiPolygon = boost::geometry::model::multi_polygon<Polygon<Point>>;
+using MultiPolygon = boost::geometry::model::multi_polygon<Polygon<Point>, std::vector, AllocatorWithMemoryTracking>;
 
 using CartesianPoint = boost::geometry::model::d2::point_xy<Float64>;
 using CartesianLineString = LineString<CartesianPoint>;

--- a/src/Processors/Formats/Impl/Parquet/Decoding.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Decoding.cpp
@@ -1507,6 +1507,9 @@ void UUIDConverter::convertColumn(std::span<const char> data, size_t num_values,
 
 void UUIDConverter::convertField(std::span<const char> data, bool /*is_max*/, Field & out) const
 {
+    if (data.size() != input_size)
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Unexpected size of UUID in statistics: {} != {}", data.size(), input_size);
+
     out = decodeParquetUUID(data.data());
 }
 

--- a/src/Processors/Formats/Impl/Parquet/Reader.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Reader.cpp
@@ -44,6 +44,25 @@ namespace ProfileEvents
 namespace DB::Parquet
 {
 
+/// Thrift deserialization can store an out-of-range value into an unscoped enum field when the
+/// input file is malformed. Loading such an enum directly is undefined behavior (caught by
+/// -fsanitize=enum); reading the raw underlying integer via memcpy is well-defined. We use it to
+/// validate page-header enums up front, so the rest of the reader only ever loads valid values.
+template <typename E>
+static int thriftEnumToInt(const E & e)
+{
+    std::underlying_type_t<E> v;
+    memcpy(&v, &e, sizeof(v));
+    return static_cast<int>(v);
+}
+
+template <typename E>
+static void checkThriftEnum(const E & e, const std::map<int, const char *> & valid_values, const char * what)
+{
+    if (!valid_values.contains(thriftEnumToInt(e)))
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Invalid {} in Parquet metadata", what);
+}
+
 static void decompressLZ4Raw(const char * data, size_t compressed_size, size_t uncompressed_size, char * out)
 {
     if (compressed_size > INT32_MAX || uncompressed_size > INT32_MAX)
@@ -846,9 +865,12 @@ void Reader::decodeDictionaryPageImpl(const parq::PageHeader & header, std::span
         throw Exception(ErrorCodes::INCORRECT_DATA, "Dictionary page size out of bounds: {} > {}", header.compressed_page_size, data.size());
     data = data.subspan(0, size_t(header.compressed_page_size));
 
+    checkThriftEnum(column.meta->meta_data.codec, parq::_CompressionCodec_VALUES_TO_NAMES, "compression codec");
     auto codec = column.meta->meta_data.codec;
     if (codec != parq::CompressionCodec::UNCOMPRESSED)
     {
+        if (header.uncompressed_page_size < 0)
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Negative uncompressed dictionary page size");
         size_t uncompressed_size = size_t(header.uncompressed_page_size);
         auto & buf = column.dictionary.decompressed_buf;
         buf.resize(uncompressed_size);
@@ -1536,6 +1558,27 @@ std::tuple<parq::PageHeader, std::span<const char>> Reader::decodeAndCheckPageHe
 {
     parq::PageHeader header;
     data_ptr += deserializeThriftStruct(header, data_ptr, data_end - data_ptr);
+
+    /// Validate enum fields before anything loads them (a malformed file can carry out-of-range
+    /// values, and loading an unscoped enum out of range is undefined behavior).
+    checkThriftEnum(header.type, parq::_PageType_VALUES_TO_NAMES, "page type");
+    switch (header.type)
+    {
+        case parq::PageType::DATA_PAGE:
+            checkThriftEnum(header.data_page_header.encoding, parq::_Encoding_VALUES_TO_NAMES, "encoding");
+            checkThriftEnum(header.data_page_header.definition_level_encoding, parq::_Encoding_VALUES_TO_NAMES, "definition level encoding");
+            checkThriftEnum(header.data_page_header.repetition_level_encoding, parq::_Encoding_VALUES_TO_NAMES, "repetition level encoding");
+            break;
+        case parq::PageType::DATA_PAGE_V2:
+            checkThriftEnum(header.data_page_header_v2.encoding, parq::_Encoding_VALUES_TO_NAMES, "encoding");
+            break;
+        case parq::PageType::DICTIONARY_PAGE:
+            checkThriftEnum(header.dictionary_page_header.encoding, parq::_Encoding_VALUES_TO_NAMES, "encoding");
+            break;
+        default:
+            break;
+    }
+
     size_t compressed_page_size = size_t(header.compressed_page_size);
     if (header.compressed_page_size < 0 || compressed_page_size > size_t(data_end - data_ptr))
         throw Exception(ErrorCodes::INCORRECT_DATA, "Page size out of bounds: {} > {}", header.compressed_page_size, data_end - data_ptr);
@@ -1597,8 +1640,13 @@ bool Reader::initializeDataPage(const char * & data_ptr, const char * data_end, 
 
     /// Get information about page layout and encoding out of page header.
 
+    checkThriftEnum(column.meta->meta_data.codec, parq::_CompressionCodec_VALUES_TO_NAMES, "compression codec");
     page.codec = column.meta->meta_data.codec;
-    page.values_uncompressed_size = header.uncompressed_page_size;
+    /// Signed i32 from the thrift header; a negative value would sign-extend to a huge size_t and
+    /// later cause a huge allocation in decompressPageIfCompressed.
+    if (header.uncompressed_page_size < 0)
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Negative uncompressed page size");
+    page.values_uncompressed_size = size_t(header.uncompressed_page_size);
 
     if (page.codec == parq::CompressionCodec::UNCOMPRESSED && header.uncompressed_page_size != header.compressed_page_size)
         throw Exception(ErrorCodes::INCORRECT_DATA, "No compression, but compressed and uncompressed page size are different");
@@ -1612,7 +1660,9 @@ bool Reader::initializeDataPage(const char * & data_ptr, const char * data_end, 
 
     if (header.type == parq::PageType::DATA_PAGE)
     {
-        page.num_values = header.data_page_header.num_values;
+        if (header.data_page_header.num_values < 0)
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Negative number of values in data page");
+        page.num_values = size_t(header.data_page_header.num_values);
         page.encoding = header.data_page_header.encoding;
         def_encoding = header.data_page_header.definition_level_encoding;
         rep_encoding = header.data_page_header.repetition_level_encoding;
@@ -1653,10 +1703,20 @@ bool Reader::initializeDataPage(const char * & data_ptr, const char * data_end, 
     }
     else if (header.type == parq::PageType::DATA_PAGE_V2)
     {
-        page.num_values = header.data_page_header_v2.num_values;
+        if (header.data_page_header_v2.num_values < 0)
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Negative number of values in data page");
+        page.num_values = size_t(header.data_page_header_v2.num_values);
         page.encoding = header.data_page_header_v2.encoding;
-        encoded_def_size = header.data_page_header_v2.definition_levels_byte_length;
-        encoded_rep_size = header.data_page_header_v2.repetition_levels_byte_length;
+
+        /// These come from the thrift header as signed i32. A negative value would sign-extend to a
+        /// huge size_t, so reject it before assigning to the size_t fields. Otherwise the bounds
+        /// check below could be bypassed by integer overflow, and a huge std::span would reach the
+        /// rep/def level decoder, reading far past the page buffer (heap out-of-bounds read).
+        if (header.data_page_header_v2.definition_levels_byte_length < 0 ||
+            header.data_page_header_v2.repetition_levels_byte_length < 0)
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Negative definition/repetition levels byte length in DataPageV2");
+        encoded_def_size = size_t(header.data_page_header_v2.definition_levels_byte_length);
+        encoded_rep_size = size_t(header.data_page_header_v2.repetition_levels_byte_length);
 
         if (header.data_page_header_v2.__isset.is_compressed &&
             !header.data_page_header_v2.is_compressed)
@@ -1664,12 +1724,15 @@ bool Reader::initializeDataPage(const char * & data_ptr, const char * data_end, 
             page.codec = parq::CompressionCodec::UNCOMPRESSED;
         }
 
-        if (encoded_def_size + encoded_rep_size > page.data.size())
+        /// Non-wrapping bounds check: `encoded_def_size + encoded_rep_size` could overflow.
+        if (encoded_rep_size > page.data.size() || encoded_def_size > page.data.size() - encoded_rep_size)
             throw Exception(ErrorCodes::INCORRECT_DATA, "Page data is too short (def+rep)");
         encoded_rep = page.data.data();
         encoded_def = page.data.data() + encoded_rep_size;
         size_t uncompressed_part = encoded_def_size + encoded_rep_size;
         page.data = page.data.subspan(uncompressed_part);
+        if (page.values_uncompressed_size < uncompressed_part)
+            throw Exception(ErrorCodes::INCORRECT_DATA, "DataPageV2 uncompressed page size is smaller than the rep/def levels");
         page.values_uncompressed_size -= uncompressed_part;
     }
     else if (header.type == parq::PageType::DICTIONARY_PAGE)

--- a/src/Processors/Formats/Impl/Parquet/Reader.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Reader.cpp
@@ -1622,12 +1622,24 @@ bool Reader::initializeDataPage(const char * & data_ptr, const char * data_end, 
 
     /// Check if all rows of the page are filtered out, if we have enough information.
 
+    /// These signed i32 row counts are consumed below to compute `page.end_row_idx` (and the
+    /// row-skip shortcut returns before the later num_values check). A negative value would
+    /// sign-extend to a huge size_t and wrap `next_row_idx + num_rows`, moving the row cursor
+    /// backwards or skipping the page instead of failing, so reject it here.
     std::optional<size_t> num_rows_in_page;
     if (header.type == parq::PageType::DATA_PAGE_V2)
+    {
+        if (header.data_page_header_v2.num_rows < 0)
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Negative number of rows in DataPageV2");
         num_rows_in_page = header.data_page_header_v2.num_rows;
+    }
     else if (header.type == parq::PageType::DATA_PAGE &&
              column_info.levels.back().rep == 0) // no arrays => num_values == num_rows
+    {
+        if (header.data_page_header.num_values < 0)
+            throw Exception(ErrorCodes::INCORRECT_DATA, "Negative number of values in data page");
         num_rows_in_page = header.data_page_header.num_values;
+    }
 
     if (num_rows_in_page.has_value())
     {

--- a/src/Processors/Formats/Impl/Parquet/Reader.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Reader.cpp
@@ -879,6 +879,10 @@ void Reader::decodeDictionaryPageImpl(const parq::PageHeader & header, std::span
         data = std::span(buf.data(), buf.size());
     }
 
+    /// Signed i32 from the thrift header; a negative count would sign-extend to a huge size_t and
+    /// drive a huge `reserve`/`resize` inside Dictionary::decode.
+    if (header.dictionary_page_header.num_values < 0)
+        throw Exception(ErrorCodes::INCORRECT_DATA, "Negative number of values in dictionary page");
     column.dictionary.decode(header.dictionary_page_header.encoding, column_info.decoder, size_t(header.dictionary_page_header.num_values), data, *column_info.decoded_type);
 }
 

--- a/src/Processors/Formats/Impl/Parquet/Reader.cpp
+++ b/src/Processors/Formats/Impl/Parquet/Reader.cpp
@@ -5,6 +5,7 @@
 #include <Columns/ColumnString.h>
 #include <Columns/ColumnTuple.h>
 #include <Columns/FilterDescription.h>
+#include <Common/checkStackSize.h>
 #include <Common/FieldAccurateComparison.h>
 #include <Formats/FormatFilterInfo.h>
 #include <Interpreters/castColumn.h>
@@ -2106,6 +2107,10 @@ void Reader::decompressPageIfCompressed(PageState & page)
 
 MutableColumnPtr Reader::formOutputColumn(RowSubgroup & row_subgroup, size_t output_column_idx, size_t num_rows)
 {
+    /// Recurses over nested output types; bound the depth so a deeply nested schema cannot
+    /// overflow the stack.
+    checkStackSize();
+
     const OutputColumnInfo & output_info = output_columns.at(output_column_idx);
     MutableColumnPtr res;
 

--- a/src/Processors/Formats/Impl/Parquet/SchemaConverter.cpp
+++ b/src/Processors/Formats/Impl/Parquet/SchemaConverter.cpp
@@ -1,5 +1,6 @@
 #include <Processors/Formats/Impl/Parquet/SchemaConverter.h>
 
+#include <Common/checkStackSize.h>
 #include <DataTypes/DataTypeArray.h>
 #include <DataTypes/DataTypeDate32.h>
 #include <DataTypes/DataTypeDateTime64.h>
@@ -169,6 +170,11 @@ std::string_view SchemaConverter::useColumnMapperIfNeeded(const parq::SchemaElem
 
 void SchemaConverter::processSubtree(TraversalNode & node)
 {
+    /// A deeply nested schema (e.g. a long chain of REQUIRED groups) recurses here per level.
+    /// The definition-level cap below only counts OPTIONAL/REPEATED nesting, so without this an
+    /// untrusted file could overflow the stack (uncatchable crash) instead of throwing.
+    checkStackSize();
+
     if (node.type_hint)
         chassert(node.requested);
     if (schema_idx >= file_metadata.schema.size())

--- a/tests/queries/0_stateless/04324_parquet_v3_datapage_v2_oob.reference
+++ b/tests/queries/0_stateless/04324_parquet_v3_datapage_v2_oob.reference
@@ -1,0 +1,8 @@
+nint_wrap: rejected
+nstr_wrap: rejected
+arr_wrap: rejected
+nint_negdef: rejected
+nint_neguncomp: rejected
+nint_badtype: rejected
+nint_badenc: rejected
+nint_negnumvals: rejected

--- a/tests/queries/0_stateless/04324_parquet_v3_datapage_v2_oob.reference
+++ b/tests/queries/0_stateless/04324_parquet_v3_datapage_v2_oob.reference
@@ -7,3 +7,4 @@ nint_badtype: rejected
 nint_badenc: rejected
 nint_negnumvals: rejected
 strdict_negnumvals: rejected
+multipage_negnrows: rejected

--- a/tests/queries/0_stateless/04324_parquet_v3_datapage_v2_oob.reference
+++ b/tests/queries/0_stateless/04324_parquet_v3_datapage_v2_oob.reference
@@ -6,3 +6,4 @@ nint_neguncomp: rejected
 nint_badtype: rejected
 nint_badenc: rejected
 nint_negnumvals: rejected
+strdict_negnumvals: rejected

--- a/tests/queries/0_stateless/04324_parquet_v3_datapage_v2_oob.sh
+++ b/tests/queries/0_stateless/04324_parquet_v3_datapage_v2_oob.sh
@@ -97,10 +97,25 @@ def patch(buf, off, field_path, signed_value):
             return buf
     raise KeyError(field_path)
 
-def make(path, dtype, vals, compression="none", use_dictionary=False):
+def make(path, dtype, vals, compression="none", use_dictionary=False, data_page_size=None):
+    kw = {} if data_page_size is None else {"data_page_size": data_page_size}
     pq.write_table(pa.table({"v": pa.array(vals, type=dtype)}), path,
                    data_page_version="2.0", compression=compression,
-                   use_dictionary=use_dictionary, write_statistics=False)
+                   use_dictionary=use_dictionary, write_statistics=False, **kw)
+
+def page_offsets(buf):
+    """Offsets of every data page header (walks header + compressed_page_size), bounded by the
+    column chunk's compressed size so we never run into the file footer."""
+    col = pq.ParquetFile(io.BytesIO(bytes(buf))).metadata.row_group(0).column(0)
+    p = col.data_page_offset
+    end = col.data_page_offset + col.total_compressed_size
+    offs = []
+    while p < end:
+        w = Walker(buf, p); w.struct([])
+        cps = next(v for (pi, vs, ve, v) in w.rec if pi == (3,))  # compressed_page_size
+        offs.append(p)
+        p = w.pos + cps
+    return offs
 
 # PageHeader field ids: 2=uncompressed_page_size; 8=data_page_header_v2 struct,
 # whose 5=definition_levels_byte_length, 6=repetition_levels_byte_length.
@@ -135,10 +150,19 @@ craft("nint_negnumvals", pa.int32(), NINT, [((8, 1), -8192)])
 # of a dictionary-encoded column is the DICTIONARY_PAGE, so this patches its header.
 DICTSTR = [("v%d" % (i % 5)) for i in range(64)]  # few distinct values -> small dict num_values
 craft("strdict_negnumvals", pa.string(), DICTSTR, [((7, 1), -64)], use_dictionary=True)
+# Negative num_rows in a NON-FIRST DataPageV2. num_rows is consumed early (before the num_values
+# check) to compute the row cursor, so a negative value on a later page wraps it backwards. Build a
+# multi-page file and patch the second page's num_rows (-1024 keeps the 2-byte varint length of 1024).
+make(f"{work}/multipage.parquet", pa.int32(), list(range(4000)), data_page_size=256)
+mp = bytearray(open(f"{work}/multipage.parquet", "rb").read())
+offs = page_offsets(mp)
+assert len(offs) >= 2, f"expected multiple pages, got {len(offs)}"
+patch(mp, offs[1], (8, 3), -1024)
+open(f"{work}/multipage_negnrows_evil.parquet", "wb").write(mp)
 PYEOF
 
 # Each crafted file must be rejected with INCORRECT_DATA (code 117), not crash or leak.
-for f in nint_wrap nstr_wrap arr_wrap nint_negdef nint_neguncomp nint_badtype nint_badenc nint_negnumvals strdict_negnumvals; do
+for f in nint_wrap nstr_wrap arr_wrap nint_negdef nint_neguncomp nint_badtype nint_badenc nint_negnumvals strdict_negnumvals multipage_negnrows; do
     out=$(${CLICKHOUSE_LOCAL} --query "
         SELECT * FROM file('${WORK_DIR}/${f}_evil.parquet', Parquet) FORMAT Null
         SETTINGS input_format_parquet_use_native_reader_v3 = 1" 2>&1)

--- a/tests/queries/0_stateless/04324_parquet_v3_datapage_v2_oob.sh
+++ b/tests/queries/0_stateless/04324_parquet_v3_datapage_v2_oob.sh
@@ -97,10 +97,10 @@ def patch(buf, off, field_path, signed_value):
             return buf
     raise KeyError(field_path)
 
-def make(path, dtype, vals, compression="none"):
+def make(path, dtype, vals, compression="none", use_dictionary=False):
     pq.write_table(pa.table({"v": pa.array(vals, type=dtype)}), path,
                    data_page_version="2.0", compression=compression,
-                   use_dictionary=False, write_statistics=False)
+                   use_dictionary=use_dictionary, write_statistics=False)
 
 # PageHeader field ids: 2=uncompressed_page_size; 8=data_page_header_v2 struct,
 # whose 5=definition_levels_byte_length, 6=repetition_levels_byte_length.
@@ -108,9 +108,9 @@ NINT = [i if i % 3 else None for i in range(64)]
 NSTR = [("x" * ((i % 7) + 1) if i % 3 else None) for i in range(64)]
 ARR  = [list(range(i % 5)) for i in range(64)]
 
-def craft(name, dtype, vals, patches, compression="none"):
+def craft(name, dtype, vals, patches, compression="none", use_dictionary=False):
     base = f"{work}/{name}.parquet"
-    make(base, dtype, vals, compression)
+    make(base, dtype, vals, compression, use_dictionary)
     buf = bytearray(open(base, "rb").read())
     off = first_page_offset(buf)
     for fp, v in patches:
@@ -131,10 +131,14 @@ craft("nint_badtype", pa.int32(), NINT, [((1,), -64)])
 craft("nint_badenc", pa.int32(), NINT, [((8, 4), -64)])
 # Negative num_values (data_page_header_v2 field 1).
 craft("nint_negnumvals", pa.int32(), NINT, [((8, 1), -8192)])
+# Negative num_values in the DICTIONARY page header (dictionary_page_header field 1). The first page
+# of a dictionary-encoded column is the DICTIONARY_PAGE, so this patches its header.
+DICTSTR = [("v%d" % (i % 5)) for i in range(64)]  # few distinct values -> small dict num_values
+craft("strdict_negnumvals", pa.string(), DICTSTR, [((7, 1), -64)], use_dictionary=True)
 PYEOF
 
 # Each crafted file must be rejected with INCORRECT_DATA (code 117), not crash or leak.
-for f in nint_wrap nstr_wrap arr_wrap nint_negdef nint_neguncomp nint_badtype nint_badenc nint_negnumvals; do
+for f in nint_wrap nstr_wrap arr_wrap nint_negdef nint_neguncomp nint_badtype nint_badenc nint_negnumvals strdict_negnumvals; do
     out=$(${CLICKHOUSE_LOCAL} --query "
         SELECT * FROM file('${WORK_DIR}/${f}_evil.parquet', Parquet) FORMAT Null
         SETTINGS input_format_parquet_use_native_reader_v3 = 1" 2>&1)

--- a/tests/queries/0_stateless/04324_parquet_v3_datapage_v2_oob.sh
+++ b/tests/queries/0_stateless/04324_parquet_v3_datapage_v2_oob.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# no-fasttest: needs pyarrow to craft the malformed Parquet files.
+
+# Regression test for a heap out-of-bounds read in the Parquet V3 native reader.
+#
+# DataPageV2 headers carry definition_levels_byte_length / repetition_levels_byte_length
+# as signed i32. A negative value sign-extended to size_t, and the bounds check used
+# wrapping addition (`def + rep > page.data.size()`), so a pair like (def=-1, rep=1)
+# wrapped the sum to 0 and bypassed the check. A 2^64-sized std::span then reached the
+# RLE level decoder, whose raw memcpy read far past the page buffer (heap disclosure).
+#
+# The reader must reject every crafted file with a clean INCORRECT_DATA exception
+# instead of reading out of bounds. On an unpatched ASan/UBSan build each "wrap" case
+# triggers a sanitizer error.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+WORK_DIR="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}"
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+python3 - "$WORK_DIR" <<'PYEOF'
+import io, sys
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+work = sys.argv[1]
+
+# --- minimal Thrift compact protocol walker: record offset of every scalar field ---
+CT_INT = {0x03, 0x04, 0x05, 0x06}  # byte, i16, i32, i64
+
+def zigzag_decode(n): return (n >> 1) ^ -(n & 1)
+def zigzag_encode(n, bits=64):
+    m = (1 << bits) - 1; u = n & m
+    return ((u << 1) ^ (-(u >> (bits - 1)) & m)) & m
+def encode_varint(n):
+    out = bytearray()
+    while True:
+        b = n & 0x7F; n >>= 7
+        out.append(b | (0x80 if n else 0))
+        if not n: break
+    return bytes(out)
+
+class Walker:
+    def __init__(self, buf, pos): self.buf, self.pos, self.rec = buf, pos, []
+    def byte(self): b = self.buf[self.pos]; self.pos += 1; return b
+    def varint(self):
+        r = s = 0
+        while True:
+            b = self.byte(); r |= (b & 0x7F) << s
+            if not (b & 0x80): return r
+            s += 7
+    def zz(self): return zigzag_decode(self.varint())
+    def struct(self, path):
+        last = 0
+        while True:
+            h = self.byte()
+            if h == 0: return
+            d = (h & 0xF0) >> 4; ct = h & 0x0F
+            fid = self.zz() if d == 0 else last + d
+            last = fid
+            self.field(ct, path + [fid])
+    def field(self, ct, path):
+        vs = self.pos; val = None
+        if ct in (0x01, 0x02): val = (ct == 0x01)
+        elif ct == 0x03: val = self.byte()
+        elif ct in (0x04, 0x05, 0x06): val = self.zz()
+        elif ct == 0x07: self.pos += 8
+        elif ct == 0x08: self.pos += self.varint()
+        elif ct in (0x09, 0x0A): self.lst(path)
+        elif ct == 0x0C: self.struct(path)
+        else: raise ValueError(f"ctype {ct}")
+        if ct in CT_INT: self.rec.append((tuple(path), vs, self.pos, val))
+    def lst(self, path):
+        st = self.byte(); n = (st & 0xF0) >> 4; et = st & 0x0F
+        if n == 0xF: n = self.varint()
+        for i in range(n): self.field(et, path + [i])
+
+def first_page_offset(buf):
+    col = pq.ParquetFile(io.BytesIO(bytes(buf))).metadata.row_group(0).column(0)
+    off = col.data_page_offset
+    if col.has_dictionary_page and col.dictionary_page_offset is not None:
+        off = min(off, col.dictionary_page_offset)
+    return off
+
+def patch(buf, off, field_path, signed_value):
+    w = Walker(buf, off); w.struct([])
+    for pi, vs, ve, val in w.rec:
+        if pi == tuple(field_path):
+            nb = encode_varint(zigzag_encode(signed_value))
+            assert len(nb) == ve - vs, f"len change for {field_path}: {ve-vs}->{len(nb)} ({val}->{signed_value})"
+            buf[vs:ve] = nb
+            return buf
+    raise KeyError(field_path)
+
+def make(path, dtype, vals, compression="none"):
+    pq.write_table(pa.table({"v": pa.array(vals, type=dtype)}), path,
+                   data_page_version="2.0", compression=compression,
+                   use_dictionary=False, write_statistics=False)
+
+# PageHeader field ids: 2=uncompressed_page_size; 8=data_page_header_v2 struct,
+# whose 5=definition_levels_byte_length, 6=repetition_levels_byte_length.
+NINT = [i if i % 3 else None for i in range(64)]
+NSTR = [("x" * ((i % 7) + 1) if i % 3 else None) for i in range(64)]
+ARR  = [list(range(i % 5)) for i in range(64)]
+
+def craft(name, dtype, vals, patches, compression="none"):
+    base = f"{work}/{name}.parquet"
+    make(base, dtype, vals, compression)
+    buf = bytearray(open(base, "rb").read())
+    off = first_page_offset(buf)
+    for fp, v in patches:
+        patch(buf, off, fp, v)
+    open(f"{work}/{name}_evil.parquet", "wb").write(buf)
+
+# Wrapping bypass (def + rep wraps to a small value -> huge def/rep span -> OOB read).
+craft("nint_wrap", pa.int32(), NINT, [((8, 5), -1), ((8, 6), 1)])
+craft("nstr_wrap", pa.string(), NSTR, [((8, 5), -2), ((8, 6), 2)])
+craft("arr_wrap", pa.list_(pa.int32()), ARR, [((8, 5), 1), ((8, 6), -1)])
+# Negative definition length alone (no wrap, must still be rejected).
+craft("nint_negdef", pa.int32(), NINT, [((8, 5), -1)])
+# Negative uncompressed_page_size on a compressed page (sizes the decompression buffer).
+craft("nint_neguncomp", pa.int32(), NINT, [((2,), -8192)], compression="snappy")
+# Out-of-range enum values (loading an unscoped enum out of range is undefined behavior).
+# PageHeader field 1 = type (PageType); data_page_header_v2 field 4 = encoding (Encoding).
+craft("nint_badtype", pa.int32(), NINT, [((1,), -64)])
+craft("nint_badenc", pa.int32(), NINT, [((8, 4), -64)])
+# Negative num_values (data_page_header_v2 field 1).
+craft("nint_negnumvals", pa.int32(), NINT, [((8, 1), -8192)])
+PYEOF
+
+# Each crafted file must be rejected with INCORRECT_DATA (code 117), not crash or leak.
+for f in nint_wrap nstr_wrap arr_wrap nint_negdef nint_neguncomp nint_badtype nint_badenc nint_negnumvals; do
+    out=$(${CLICKHOUSE_LOCAL} --query "
+        SELECT * FROM file('${WORK_DIR}/${f}_evil.parquet', Parquet) FORMAT Null
+        SETTINGS input_format_parquet_use_native_reader_v3 = 1" 2>&1)
+    if echo "$out" | grep -q "INCORRECT_DATA"; then
+        echo "$f: rejected"
+    else
+        echo "$f: UNEXPECTED: $out"
+    fi
+done

--- a/tests/queries/0_stateless/04325_parquet_v3_deep_schema_recursion.reference
+++ b/tests/queries/0_stateless/04325_parquet_v3_deep_schema_recursion.reference
@@ -1,0 +1,2 @@
+deep: rejected
+shallow: ok

--- a/tests/queries/0_stateless/04325_parquet_v3_deep_schema_recursion.sh
+++ b/tests/queries/0_stateless/04325_parquet_v3_deep_schema_recursion.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+# Regression test for unbounded recursion in the Parquet V3 native reader's schema converter.
+# A chain of nested REQUIRED groups maps to nested Tuples and recurses through
+# SchemaConverter::processSubtree per level. The definition-level cap (255) only counts
+# OPTIONAL/REPEATED nesting, so a deep REQUIRED chain recursed without bound and overflowed the
+# stack -> uncatchable SIGSEGV (server crash / DoS), triggerable even by schema inference (DESC).
+# checkStackSize() now turns it into a catchable TOO_DEEP_RECURSION exception.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+WORK_DIR="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}"
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Hand-build a Parquet file (PAR1 + FileMetaData footer, no row groups) whose schema is a root with
+# N nested REQUIRED groups (num_children=1 each) and an INT32 leaf. Pure stdlib, no pyarrow.
+python3 - "$WORK_DIR" <<'PYEOF'
+import struct, sys
+work = sys.argv[1]
+
+class W:
+    def __init__(s): s.out = bytearray()
+    def u8(s, v): s.out.append(v & 0xff)
+    def varint(s, v):
+        v &= (1 << 64) - 1
+        while True:
+            b = v & 0x7f; v >>= 7
+            s.out.append(b | 0x80) if v else s.out.append(b)
+            if not v: return
+    def zz(s, n): s.varint(((n << 1) ^ (n >> 63)) & ((1 << 64) - 1))
+
+CT_I32, CT_I64, CT_BIN, CT_LIST, CT_STRUCT = 5, 6, 8, 9, 12
+
+def field(w, last, fid, ctype):
+    d = fid - last
+    if 1 <= d <= 15: w.u8((d << 4) | ctype)
+    else: w.u8(ctype); w.zz(fid)
+    return fid
+
+def schema_elem(w, name, repetition=None, num_children=None, ptype=None):
+    last = 0
+    if ptype is not None:
+        last = field(w, last, 1, CT_I32); w.zz(ptype)          # type
+    if repetition is not None:
+        last = field(w, last, 3, CT_I32); w.zz(repetition)     # repetition_type (REQUIRED=0)
+    last = field(w, last, 4, CT_BIN); w.varint(len(name)); w.out += name.encode()  # name
+    if num_children is not None:
+        last = field(w, last, 5, CT_I32); w.zz(num_children)   # num_children
+    w.u8(0)
+
+def build(n):
+    fmd = W(); last = 0
+    last = field(fmd, last, 1, CT_I32); fmd.zz(2)              # version
+    last = field(fmd, last, 2, CT_LIST)                       # schema list<struct>
+    total = n + 2                                             # root + n groups + leaf
+    if total < 15: fmd.u8((total << 4) | CT_STRUCT)
+    else: fmd.u8((15 << 4) | CT_STRUCT); fmd.varint(total)
+    schema_elem(fmd, "root", repetition=None, num_children=1)
+    for _ in range(n):
+        schema_elem(fmd, "g", repetition=0, num_children=1)   # REQUIRED group
+    schema_elem(fmd, "leaf", repetition=0, ptype=1)           # INT32 leaf
+    last = field(fmd, last, 3, CT_I64); fmd.zz(0)             # num_rows
+    last = field(fmd, last, 4, CT_LIST); fmd.u8((0 << 4) | CT_STRUCT)  # row_groups (empty)
+    fmd.u8(0)
+    meta = bytes(fmd.out)
+    return b'PAR1' + meta + struct.pack('<I', len(meta)) + b'PAR1'
+
+open(f"{work}/deep.parquet", "wb").write(build(50000))
+open(f"{work}/shallow.parquet", "wb").write(build(8))
+PYEOF
+
+# Deeply nested schema must be rejected with a catchable error (not crash the process).
+out=$(${CLICKHOUSE_LOCAL} --query "
+    DESC file('${WORK_DIR}/deep.parquet', Parquet)
+    SETTINGS input_format_parquet_use_native_reader_v3 = 1" 2>&1)
+if echo "$out" | grep -q "TOO_DEEP_RECURSION"; then
+    echo "deep: rejected"
+else
+    echo "deep: UNEXPECTED: $out"
+fi
+
+# A reasonably nested schema must still work.
+shallow=$(${CLICKHOUSE_LOCAL} --query "
+    DESC file('${WORK_DIR}/shallow.parquet', Parquet)
+    SETTINGS input_format_parquet_use_native_reader_v3 = 1" 2>&1)
+if echo "$shallow" | grep -q "Tuple"; then
+    echo "shallow: ok"
+else
+    echo "shallow: UNEXPECTED: $shallow"
+fi

--- a/tests/queries/0_stateless/04325_parquet_v3_deep_schema_recursion.sh
+++ b/tests/queries/0_stateless/04325_parquet_v3_deep_schema_recursion.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Tags: no-fasttest
+# no-fasttest: the Parquet format is not available in the fast test build.
 
 # Regression test for unbounded recursion in the Parquet V3 native reader's schema converter.
 # A chain of nested REQUIRED groups maps to nested Tuples and recurses through

--- a/tests/queries/0_stateless/04326_parquet_v3_geoparquet_wkb_alloc.reference
+++ b/tests/queries/0_stateless/04326_parquet_v3_geoparquet_wkb_alloc.reference
@@ -1,0 +1,1 @@
+geo_bomb: memory limit enforced

--- a/tests/queries/0_stateless/04326_parquet_v3_geoparquet_wkb_alloc.sh
+++ b/tests/queries/0_stateless/04326_parquet_v3_geoparquet_wkb_alloc.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# no-fasttest: needs pyarrow to write the GeoParquet file.
+
+# Regression test for an untracked-allocation DoS in the Parquet V3 GeoParquet (WKB) reader.
+# The WKB reader took an element count straight off the wire and `reserve`d a std::vector of that
+# many points before reading any coordinate bytes. The default container tracking is non-throwing,
+# so a 9-byte WKB value claiming 100M points forced a ~1.6 GB allocation that bypassed
+# max_memory_usage (the query failed later with CANNOT_READ_ALL_DATA, never MEMORY_LIMIT_EXCEEDED).
+# The geometry containers now use AllocatorWithMemoryTracking, so the oversized reserve is charged
+# to the memory tracker and rejected with MEMORY_LIMIT_EXCEEDED under a small limit.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+WORK_DIR="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}"
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+python3 - "$WORK_DIR" <<'PYEOF'
+import sys, struct, json
+import pyarrow as pa
+import pyarrow.parquet as pq
+work = sys.argv[1]
+# WKB LineString header: little-endian, type=2 (LineString), num_points=100M, no coordinates.
+wkb = struct.pack('<BII', 1, 2, 100000000)
+t = pa.table({'g': pa.array([wkb], type=pa.binary())})
+geo = json.dumps({"version": "1.0.0", "primary_column": "g",
+                  "columns": {"g": {"encoding": "WKB", "geometry_types": ["LineString"]}}})
+t = t.replace_schema_metadata({b'geo': geo.encode()})
+pq.write_table(t, f"{work}/geo_bomb.parquet", compression='none', use_dictionary=False)
+PYEOF
+
+# The oversized reserve must be charged to the memory tracker and rejected under a 100 MB limit,
+# instead of allocating ~1.6 GB outside the tracker.
+out=$(${CLICKHOUSE_LOCAL} --query "
+    SELECT g FROM file('${WORK_DIR}/geo_bomb.parquet', Parquet) FORMAT Null
+    SETTINGS input_format_parquet_use_native_reader_v3 = 1,
+             input_format_parquet_allow_geoparquet_parser = 1,
+             max_memory_usage = 104857600" 2>&1)
+if echo "$out" | grep -q "MEMORY_LIMIT_EXCEEDED"; then
+    echo "geo_bomb: memory limit enforced"
+else
+    echo "geo_bomb: UNEXPECTED: $out"
+fi

--- a/tests/queries/0_stateless/04327_avro_string_length_alloc.reference
+++ b/tests/queries/0_stateless/04327_avro_string_length_alloc.reference
@@ -1,0 +1,1 @@
+strbomb: rejected

--- a/tests/queries/0_stateless/04327_avro_string_length_alloc.sh
+++ b/tests/queries/0_stateless/04327_avro_string_length_alloc.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Tags: no-fasttest
+# no-fasttest: Avro format is not available in the fast test build.
+
+# Regression test for an untracked-allocation DoS in the Avro reader.
+# BinaryDecoder::decodeString / decodeBytes read a length prefix and resized a std::string/vector to
+# that length BEFORE reading any bytes. A ~70-byte Avro file declaring a ~2 GB string length (with no
+# data) forced a ~2 GB allocation that bypassed max_memory_usage (peak RSS ~2.9 GB; the query then
+# failed with an Avro EOF error). The decoder now reads incrementally, so a truncated/over-declared
+# value only allocates the bytes actually present (RSS stays bounded) and is rejected cleanly.
+
+CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=../shell_config.sh
+. "$CUR_DIR"/../shell_config.sh
+
+WORK_DIR="${CLICKHOUSE_TMP}/${CLICKHOUSE_TEST_UNIQUE_NAME}"
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Hand-build a minimal Avro OCF whose single string value declares a ~2 GB length with no data bytes.
+python3 - "$WORK_DIR" <<'PYEOF'
+import json, sys
+work = sys.argv[1]
+
+def vlong(n):  # Avro zigzag varint long
+    u = ((n << 1) ^ (n >> 63)) & ((1 << 64) - 1)
+    out = bytearray()
+    while True:
+        b = u & 0x7f; u >>= 7
+        out.append(b | 0x80) if u else out.append(b)
+        if not u: break
+    return bytes(out)
+
+def avstr(b): return vlong(len(b)) + b
+
+schema = json.dumps({"type": "record", "name": "r",
+                     "fields": [{"name": "s", "type": "string"}]}).encode()
+meta = (vlong(2) + avstr(b'avro.schema') + avstr(schema)
+        + avstr(b'avro.codec') + avstr(b'null') + vlong(0))
+sync = b'\x00' * 16
+header = b'Obj\x01' + meta + sync
+payload = vlong(2_000_000_000)              # string length prefix ~2 GB, no bytes follow
+block = vlong(1) + vlong(len(payload)) + payload + sync
+open(f"{work}/strbomb.avro", "wb").write(header + block)
+PYEOF
+
+# The over-declared string must be rejected cleanly (and with bounded memory) instead of allocating
+# ~2 GB up front. The data genuinely ends after the length prefix, so this surfaces as an Avro
+# EOF / INCORRECT_DATA error.
+out=$(${CLICKHOUSE_LOCAL} --input-format Avro -S "s String" \
+        --query "SELECT s FROM table FORMAT Null SETTINGS max_memory_usage = 104857600" \
+        < "${WORK_DIR}/strbomb.avro" 2>&1)
+if echo "$out" | grep -qE "AVRO_EXCEPTION|EOF reached|INCORRECT_DATA|CANNOT_READ_ALL_DATA"; then
+    echo "strbomb: rejected"
+else
+    echo "strbomb: UNEXPECTED: $out"
+fi


### PR DESCRIPTION
References: https://github.com/ClickHouse/clickhouse-private/issues/59682

Fixes several memory-safety and resource-exhaustion issues in format readers that are reachable from untrusted input by any user who can read a `file`/`url`/`s3`/external table or run `INSERT ... FORMAT`. The native Parquet reader (`input_format_parquet_use_native_reader_v3`, default on recent versions) is the main surface; the geometry and Avro fixes apply to all callers.

- Native Parquet `DataPageV2`: the signed `i32` `definition_levels_byte_length` / `repetition_levels_byte_length` were assigned to `size_t` and validated with a wrapping addition, so a crafted page bypassed the bounds check and passed an oversized `std::span` to the level decoder, reading past the page buffer (heap out-of-bounds read). Reject negative lengths and use a non-wrapping bounds check; also reject negative `num_values` / `uncompressed_page_size`, validate page-header enums before they are loaded, and add the missing size guard in `UUIDConverter`.
- Native Parquet schema converter: a file with deeply nested groups recursed without bound and overflowed the stack (uncatchable crash), even via schema inference. Bounded with `checkStackSize`.
- Geometry containers (WKB/WKT, reached from the GeoParquet reader): an element count taken off the wire drove a `reserve` that bypassed `max_memory_usage`. The geometry containers now allocate through the memory tracker.
- Avro string/bytes decoding: the buffer was resized to the wire-declared length before reading, so a tiny file declaring a huge length forced a large allocation that bypassed `max_memory_usage`. Read incrementally so only the bytes actually present are allocated.

### Changelog category (leave one):
- Critical Bug Fix (crash, data loss, RBAC)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed multiple memory-safety and resource-exhaustion issues in format readers reachable from untrusted input: a heap out-of-bounds read in the native Parquet reader's `DataPageV2` definition/repetition level-length handling, a stack overflow on Parquet files with deeply nested schemas, and allocations that ignored `max_memory_usage` when parsing GeoParquet WKB/WKT geometry and Avro strings/bytes.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.937`
- Backported to: `26.5.3.43`, `26.4.5.47`, `26.3.14.41`, `25.8.25.25`
<!-- ch-version-info:end -->