### PR TITLE
DeltaLake: retry snapshot init on ExpiredToken; fix STS refresh

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -64,6 +64,7 @@ static struct InitFiu
     ONCE(s3_read_buffer_throw_expired_token) \
     ONCE(s3_send_request_throw_expired_token) \
     ONCE(delta_kernel_throw_expired_token) \
+    ONCE(delta_kernel_throw_expired_token_on_scan) \
     ONCE(distributed_cache_fail_request_in_the_middle_of_request) \
     ONCE(object_storage_queue_fail_commit_once) \
     ONCE(object_storage_queue_fail_commit_after_success) \

--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -63,6 +63,7 @@ static struct InitFiu
     ONCE(rmt_merge_task_sleep_in_prepare) \
     ONCE(s3_read_buffer_throw_expired_token) \
     ONCE(s3_send_request_throw_expired_token) \
+    ONCE(delta_kernel_throw_expired_token) \
     ONCE(distributed_cache_fail_request_in_the_middle_of_request) \
     ONCE(object_storage_queue_fail_commit_once) \
     ONCE(object_storage_queue_fail_commit_after_success) \

--- a/src/IO/S3/Client.cpp
+++ b/src/IO/S3/Client.cpp
@@ -349,6 +349,11 @@ Aws::Auth::AWSCredentials Client::getCredentials() const
     return credentials_provider->GetAWSCredentials();
 }
 
+void Client::setCredentialsProviderNeedRefresh() const
+{
+    credentials_provider->SetNeedRefresh();
+}
+
 bool Client::checkIfCredentialsChanged(const Aws::S3::S3Error & error) const
 {
     return (error.GetExceptionName() == "AuthenticationRequired");

--- a/src/IO/S3/Client.h
+++ b/src/IO/S3/Client.h
@@ -148,6 +148,14 @@ public:
 
     Aws::Auth::AWSCredentials getCredentials() const;
 
+    /// Marks the underlying credentials provider so that the next `getCredentials()` call
+    /// forces a `Reload()`. Used to recover from `ExpiredToken` errors that bypass the
+    /// client's own retry loop (e.g. the Rust delta-kernel `object_store` S3 path, which
+    /// is handed static credentials at engine-build time).
+    /// `const` because, like `getCredentials() const`, this only delegates to the
+    /// credentials provider; it does not mutate the client itself.
+    void setCredentialsProviderNeedRefresh() const;
+
     /// We want to manually handle permanent moves (status code 301) because:
     /// - redirect location is written in XML format inside the response body something that doesn't exist for HEAD
     ///   requests so we need to manually find the correct location

--- a/src/IO/S3/Credentials.cpp
+++ b/src/IO/S3/Credentials.cpp
@@ -1292,12 +1292,9 @@ void AwsAuthSTSAssumeRoleCredentialsProvider::Reload()
 
     AssumeRoleRequest request(role_arn, session_name);
     auto outcome = client->assumeRole(request);
-    /// Reset the base provider's `m_needsRefresh` flag so an external `SetNeedRefresh()`
-    /// signal isn't latched indefinitely. Mirrors the WebIdentity and SSO providers above
-    /// (see `AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider::Reload`).
-    AWSCredentialsProvider::Reload();
     if (!outcome.IsSuccess())
     {
+        /// Keep `m_needsRefresh` and cached `credentials` so the next call retries STS.
         LOG_WARNING(logger, "Failed to get credentials using AssumeRule. Error: {}", outcome.GetError().GetMessage());
         return;
     }
@@ -1307,6 +1304,9 @@ void AwsAuthSTSAssumeRoleCredentialsProvider::Reload()
     credentials.SetAWSSecretKey(result.getSecretAccessKey());
     credentials.SetSessionToken(result.getSessionToken());
     credentials.SetExpiration(result.getExpiration());
+
+    /// Clear `m_needsRefresh` so an external `SetNeedRefresh()` isn't latched.
+    AWSCredentialsProvider::Reload();
 
     LOG_TRACE(logger, "Successfully retrieved credentials");
 }

--- a/src/IO/S3/Credentials.cpp
+++ b/src/IO/S3/Credentials.cpp
@@ -1270,12 +1270,16 @@ AwsAuthSTSAssumeRoleCredentialsProvider::AwsAuthSTSAssumeRoleCredentialsProvider
 
 Aws::Auth::AWSCredentials AwsAuthSTSAssumeRoleCredentialsProvider::GetAWSCredentials()
 {
+    /// Honor `SetNeedRefresh()` like sibling providers (Web-Identity, SSO) do.
+    /// Without this, external callers (e.g. `S3::Client` on auth retries, or the
+    /// delta-kernel `ExpiredToken` retry path) can't force a re-AssumeRole even
+    /// after explicitly signalling the cached token is stale.
     Aws::Utils::Threading::ReaderLockGuard guard(m_reloadLock);
-    if (!areCredentialsEmptyOrExpired(credentials, expiration_window_seconds))
+    if (!IsSetNeedRefresh() && !areCredentialsEmptyOrExpired(credentials, expiration_window_seconds))
         return credentials;
 
     guard.UpgradeToWriterLock();
-    if (!areCredentialsEmptyOrExpired(credentials, expiration_window_seconds)) // double-checked lock to avoid refreshing twice
+    if (!IsSetNeedRefresh() && !areCredentialsEmptyOrExpired(credentials, expiration_window_seconds)) // double-checked lock to avoid refreshing twice
         return credentials;
 
     Reload();
@@ -1288,6 +1292,10 @@ void AwsAuthSTSAssumeRoleCredentialsProvider::Reload()
 
     AssumeRoleRequest request(role_arn, session_name);
     auto outcome = client->assumeRole(request);
+    /// Reset the base provider's `m_needsRefresh` flag so an external `SetNeedRefresh()`
+    /// signal isn't latched indefinitely. Mirrors the WebIdentity and SSO providers above
+    /// (see `AwsAuthSTSAssumeRoleWebIdentityCredentialsProvider::Reload`).
+    AWSCredentialsProvider::Reload();
     if (!outcome.IsSuccess())
     {
         LOG_WARNING(logger, "Failed to get credentials using AssumeRule. Error: {}", outcome.GetError().GetMessage());

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.cpp
@@ -101,6 +101,14 @@ public:
 
     const std::string & getDataPath() const override { return url.key; }
 
+    /// Force the next `client->getCredentials()` call (in `createBuilder` below) to bypass the
+    /// provider's cached snapshot and do a real `Reload()`. Used by the snapshot-init retry path
+    /// after the kernel reports `ExpiredToken`.
+    void refreshCredentials() override
+    {
+        client->setCredentialsProviderNeedRefresh();
+    }
+
     ffi::EngineBuilder * createBuilder() const override
     {
         ffi::EngineBuilder * builder = KernelUtils::unwrapResult(

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.h
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/KernelHelper.h
@@ -34,6 +34,13 @@ public:
     /// delta-kernel-rs ffi api and performs all interactions
     /// with object storage layer.
     virtual ffi::EngineBuilder * createBuilder() const = 0;
+
+    /// Invalidate any cached credentials so that the next `createBuilder()` call pulls
+    /// freshly-rotated values from the underlying provider. Used by the snapshot-init
+    /// retry path to recover from `ExpiredToken` errors that the Rust delta-kernel
+    /// `object_store` client cannot self-heal (it gets static creds at build time).
+    /// Default is a noop for backends without rotating credentials.
+    virtual void refreshCredentials() {}
 };
 
 using KernelHelperPtr = std::shared_ptr<IKernelHelper>;

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -46,6 +46,7 @@ namespace DB::ErrorCodes
 namespace DB::FailPoints
 {
     extern const char delta_kernel_throw_expired_token[];
+    extern const char delta_kernel_throw_expired_token_on_scan[];
 }
 
 namespace DB::Setting
@@ -205,65 +206,140 @@ public:
             "scan_metadata_iter_init");
     }
 
+    /// One-shot retry for stale-credentials errors surfaced from `scan_metadata_next`.
+    /// Returns true if the caller should re-enter the scan loop; false otherwise.
+    /// Safe only when no data files have been enqueued yet — once consumers may have
+    /// observed paths via `next()`, restarting the listing would emit duplicates.
+    bool tryRefreshAndRetryScanState(const DB::Exception & e)
+    {
+        if (e.code() != DB::ErrorCodes::DELTA_KERNEL_ERROR)
+            return false;
+        const auto & msg = e.message();
+        const bool credentials_error =
+            msg.find("ExpiredToken") != std::string::npos
+            || msg.find("InvalidToken") != std::string::npos
+            || msg.find("TokenRefreshRequired") != std::string::npos;
+        if (!credentials_error)
+            return false;
+
+        {
+            std::lock_guard lock(next_mutex);
+            if (total_data_files > 0)
+            {
+                LOG_INFO(
+                    log,
+                    "Cannot safely retry DeltaLake scan iteration after stale-credentials error: "
+                    "{} data file(s) already enqueued for the consumer. Propagating exception.",
+                    total_data_files);
+                return false;
+            }
+        }
+
+        LOG_INFO(
+            log,
+            "DeltaLake kernel iteration failed with a stale-credentials error; "
+            "rebuilding kernel engine + snapshot + scan iterator with fresh credentials. "
+            "Original error: {}",
+            msg);
+
+        helper->refreshCredentials();
+        kernel_snapshot_state = std::make_shared<KernelSnapshotState>(
+            *helper,
+            std::optional<size_t>(kernel_snapshot_state->snapshot_version));
+        /// Drop the old kernel scan + iterator handles; `initScanState()` rebuilds them
+        /// against the freshly-credentialed engine on the next loop entry.
+        scan = KernelScan();
+        scan_data_iterator = KernelScanDataIterator();
+        return true;
+    }
+
     void scanDataFunc()
     {
+        bool retried = false;
         try
         {
-            initScanState();
-
-            LOG_TEST(log, "Starting iterator loop (predicate exception: {})", bool(engine_predicate_exception));
-
-            while (!shutdown.load())
+            while (true)
             {
-                bool have_scan_data_res = KernelUtils::unwrapResult(
-                    ffi::scan_metadata_next(scan_data_iterator.get(), this, visitData),
-                    "scan_metadata_next");
-
-                if (have_scan_data_res)
+                try
                 {
-                    std::unique_lock lock(next_mutex);
-                    LOG_TEST(
-                        log, "List batch size is {}/{}, shutdown: {}",
-                        data_files.size(),
-                        list_batch_size ? DB::toString(list_batch_size) : "Unlimitted",
-                        shutdown.load());
+                    initScanState();
 
-                    if (!shutdown.load() && list_batch_size && data_files.size() >= list_batch_size)
-                    {
-                        schedule_next_batch_cv.wait(
-                            lock,
-                            [&]() { return (data_files.size() < list_batch_size) || shutdown.load(); });
-                    }
-                }
-                else
-                {
-                    {
-                        std::lock_guard lock(next_mutex);
-                        iterator_finished = true;
-                        LOG_TEST(log, "Set finished");
-                    }
-                    data_files_cv.notify_all();
+                    LOG_TEST(log, "Starting iterator loop (predicate exception: {})", bool(engine_predicate_exception));
 
-                    LOG_TRACE(
-                        log, "All data files at version {} were listed "
-                        "(scan exception: {}, total data files: {}, total rows: {}, total bytes: {})",
-                        kernel_snapshot_state->snapshot_version,
-                        bool(scan_exception),
-                        total_data_files,
-                        total_rows ? DB::toString(*total_rows) : "Unknown",
-                        total_bytes);
-
-                    if (update_stats_func
-                        && !scan_exception
-                        && (!filter.has_value() || !enable_engine_predicate))
+                    while (!shutdown.load())
                     {
-                        update_stats_func(SnapshotStats{
-                            .total_bytes = total_bytes,
-                            /// total_rows is an optional statistic, but total_bytes is obligatory.
-                            .total_rows = total_rows
+                        /// Mirrors the same error shape `delta-kernel-rs` surfaces when its embedded
+                        /// session token is rejected by S3 mid-iteration. Wired here, just before the
+                        /// `ffi::scan_metadata_next` call, so the failpoint reaches the post-snapshot
+                        /// path that the snapshot-init failpoint can't.
+                        fiu_do_on(DB::FailPoints::delta_kernel_throw_expired_token_on_scan,
+                        {
+                            throw DB::Exception(
+                                DB::ErrorCodes::DELTA_KERNEL_ERROR,
+                                "Received DeltaLake kernel error ObjectStoreError: Error interacting with object store: "
+                                "Generic S3 error: Server returned non-2xx status code: 400 Bad Request: "
+                                "<Code>ExpiredToken</Code><Message>The provided token has expired.</Message> "
+                                "(in scan_metadata_next): While executing ReadFromObjectStorage");
                         });
+
+                        bool have_scan_data_res = KernelUtils::unwrapResult(
+                            ffi::scan_metadata_next(scan_data_iterator.get(), this, visitData),
+                            "scan_metadata_next");
+
+                        if (have_scan_data_res)
+                        {
+                            std::unique_lock lock(next_mutex);
+                            LOG_TEST(
+                                log, "List batch size is {}/{}, shutdown: {}",
+                                data_files.size(),
+                                list_batch_size ? DB::toString(list_batch_size) : "Unlimitted",
+                                shutdown.load());
+
+                            if (!shutdown.load() && list_batch_size && data_files.size() >= list_batch_size)
+                            {
+                                schedule_next_batch_cv.wait(
+                                    lock,
+                                    [&]() { return (data_files.size() < list_batch_size) || shutdown.load(); });
+                            }
+                        }
+                        else
+                        {
+                            {
+                                std::lock_guard lock(next_mutex);
+                                iterator_finished = true;
+                                LOG_TEST(log, "Set finished");
+                            }
+                            data_files_cv.notify_all();
+
+                            LOG_TRACE(
+                                log, "All data files at version {} were listed "
+                                "(scan exception: {}, total data files: {}, total rows: {}, total bytes: {})",
+                                kernel_snapshot_state->snapshot_version,
+                                bool(scan_exception),
+                                total_data_files,
+                                total_rows ? DB::toString(*total_rows) : "Unknown",
+                                total_bytes);
+
+                            if (update_stats_func
+                                && !scan_exception
+                                && (!filter.has_value() || !enable_engine_predicate))
+                            {
+                                update_stats_func(SnapshotStats{
+                                    .total_bytes = total_bytes,
+                                    /// total_rows is an optional statistic, but total_bytes is obligatory.
+                                    .total_rows = total_rows
+                                });
+                            }
+                            return;
+                        }
                     }
                     return;
+                }
+                catch (const DB::Exception & e)
+                {
+                    if (retried || !tryRefreshAndRetryScanState(e))
+                        throw;
+                    retried = true;
                 }
             }
         }

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/TableSnapshot.cpp
@@ -14,6 +14,7 @@
 
 #include <Columns/IColumn.h>
 #include <Common/Exception.h>
+#include <Common/FailPoint.h>
 #include <Common/logger_useful.h>
 #include <Common/ThreadPool.h>
 #include <Common/ThreadStatus.h>
@@ -39,6 +40,12 @@
 namespace DB::ErrorCodes
 {
     extern const int BAD_ARGUMENTS;
+    extern const int DELTA_KERNEL_ERROR;
+}
+
+namespace DB::FailPoints
+{
+    extern const char delta_kernel_throw_expired_token[];
 }
 
 namespace DB::Setting
@@ -710,7 +717,38 @@ void TableSnapshot::initOrUpdateSnapshot() const
 
     LOG_TEST(log, "Initializing snapshot");
 
-    kernel_snapshot_state = std::make_shared<KernelSnapshotState>(*helper, snapshot_version_to_read);
+    try
+    {
+        kernel_snapshot_state = std::make_shared<KernelSnapshotState>(*helper, snapshot_version_to_read);
+    }
+    catch (const DB::Exception & e)
+    {
+        /// The Rust delta-kernel `object_store` S3 client receives static credentials at
+        /// engine-build time and can't refresh them on its own. If S3 rejects the token as
+        /// expired (e.g. STS provider silently failed to `Reload()`, or clock-skew put the
+        /// cached creds outside the safety window), invalidate the C++ provider cache and
+        /// retry the snapshot once. The second attempt's `createBuilder()` will pull
+        /// freshly-rotated credentials. A single retry is enough — if those also fail,
+        /// the original exception will resurface unchanged.
+        const bool is_kernel_error = e.code() == DB::ErrorCodes::DELTA_KERNEL_ERROR;
+        const auto & msg = e.message();
+        const bool is_credentials_error =
+            msg.find("ExpiredToken") != std::string::npos
+            || msg.find("InvalidToken") != std::string::npos
+            || msg.find("TokenRefreshRequired") != std::string::npos;
+        if (!is_kernel_error || !is_credentials_error)
+            throw;
+
+        LOG_INFO(
+            log,
+            "DeltaLake kernel call failed with a stale-credentials error, "
+            "refreshing the S3 client's credentials provider and retrying snapshot init once. "
+            "Original error: {}",
+            msg);
+
+        helper->refreshCredentials();
+        kernel_snapshot_state = std::make_shared<KernelSnapshotState>(*helper, snapshot_version_to_read);
+    }
 
     LOG_TRACE(
         log, "Initialized snapshot. Snapshot version: {}",
@@ -727,6 +765,20 @@ TableSnapshot::KernelSnapshotState::KernelSnapshotState(const IKernelHelper & he
 {
     auto * engine_builder = helper_.createBuilder();
     engine = KernelUtils::unwrapResult(ffi::builder_build(engine_builder), "builder_build");
+
+    /// Mirrors the exact error shape that `delta-kernel-rs` surfaces when the Rust
+    /// `object_store` S3 client is handed a session token that AWS already rejected.
+    /// The kernel bypasses `ReadBufferFromS3`, so the `s3_*_throw_expired_token` failpoints
+    /// can't reach this path — hence a dedicated failpoint.
+    fiu_do_on(DB::FailPoints::delta_kernel_throw_expired_token,
+    {
+        throw DB::Exception(
+            DB::ErrorCodes::DELTA_KERNEL_ERROR,
+            "Received DeltaLake kernel error ObjectStoreError: Error interacting with object store: "
+            "Generic S3 error: Server returned non-2xx status code: 400 Bad Request: "
+            "<Code>ExpiredToken</Code><Message>The provided token has expired.</Message> (in snapshot)");
+    });
+
     if (snapshot_version_.has_value())
     {
         snapshot = KernelUtils::unwrapResult(

--- a/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLakeMetadataDeltaKernel.cpp
@@ -259,7 +259,16 @@ void DeltaLakeMetadataDeltaKernel::update(const ContextPtr & context)
                 log);
 
         size_t version = latest_snapshot->getVersion();
-        snapshots.getOrSet(version, [&]() { return latest_snapshot; });
+        /// Always replace the cached snapshot for this version with the freshly-built
+        /// `latest_snapshot`. `S3KernelHelper::createBuilder` embeds the C++ S3 client's
+        /// current credentials as static options into the Rust delta-kernel-rs engine, and
+        /// the engine cannot refresh them on its own. A snapshot cached longer than the
+        /// STS session TTL (~1 h) holds expired credentials, so the next kernel S3 call
+        /// surfaces `DELTA_KERNEL_ERROR` (`ExpiredToken`). The fresh `latest_snapshot` we
+        /// just built captured the provider's *current* credentials inside `getVersion()`,
+        /// so dropping the stale entry here keeps subsequent kernel operations on
+        /// freshly-credentialed engines without adding any extra S3 / STS round-trips.
+        snapshots.set(version, latest_snapshot);
 
         LOG_TEST(
             log, "Updating latest snapshot version from {} to {}",

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -5469,3 +5469,66 @@ def test_delta_kernel_expired_token_on_snapshot_init(started_cluster):
 
     # Sanity check: subsequent queries work without the failpoint as well.
     assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}")) == 100
+
+
+def test_delta_kernel_expired_token_on_scan(started_cluster):
+    """Verify scanDataFunc recovers from ExpiredToken thrown by `scan_metadata_next`.
+
+    The customer's production stack traces a credentials failure to the iteration loop,
+    not to snapshot init (`Iterator::scanDataFunc` -> `scan_metadata_next` reading later
+    `_delta_log/*.json` segments). The `ONCE(delta_kernel_throw_expired_token_on_scan)`
+    failpoint fires there once; the retry rebuilds engine + snapshot + scan iterator
+    with fresh credentials and resumes listing. Safe only when no data files have been
+    exposed to the consumer yet — which is the common case at the start of iteration.
+
+    Uses `SELECT sum(a)` rather than `SELECT count()` because `count()` is served by
+    `DeltaLakeMetadataDeltaKernel::totalRows` -> `TableSnapshot::getSnapshotStatsImpl`,
+    which calls `ffi::scan_metadata_next` in a separate code path that bypasses the
+    `Iterator::scanDataFunc` failpoint entirely.
+    """
+    instance = started_cluster.instances["node1"]
+    spark = started_cluster.spark_session
+    minio_client = started_cluster.minio_client
+    bucket = started_cluster.minio_bucket
+    TABLE_NAME = randomize_table_name("test_delta_kernel_expired_token_on_scan")
+
+    write_delta_from_df(
+        spark, generate_data(spark, 0, 100), f"/{TABLE_NAME}", mode="overwrite"
+    )
+    upload_directory(minio_client, bucket, f"/{TABLE_NAME}", "")
+    create_delta_table(instance, "s3", TABLE_NAME, started_cluster)
+
+    expected_sum = sum(range(0, 100))  # 4950
+
+    # Baseline: query succeeds before the failpoint is armed.
+    assert int(instance.query(f"SELECT sum(a) FROM {TABLE_NAME}")) == expected_sum
+
+    armed_query_id = f"{TABLE_NAME}_armed"
+    instance.query("SYSTEM ENABLE FAILPOINT delta_kernel_throw_expired_token_on_scan")
+    try:
+        # First `scan_metadata_next` call inside `Iterator::scanDataFunc` throws (ONCE
+        # failpoint). The retry rebuilds engine + snapshot + scan iterator with fresh
+        # creds and resumes; the second attempt succeeds because the ONCE failpoint is
+        # now disarmed.
+        assert int(instance.query(
+            f"SELECT sum(a) FROM {TABLE_NAME}",
+            query_id=armed_query_id,
+        )) == expected_sum
+    finally:
+        instance.query("SYSTEM DISABLE FAILPOINT delta_kernel_throw_expired_token_on_scan")
+
+    # Positive evidence the retry path actually fired (not just that the failpoint
+    # silently failed to arm and the baseline path passed through).
+    instance.query("SYSTEM FLUSH LOGS")
+    retry_log_hits = int(instance.query(
+        "SELECT count() FROM system.text_log "
+        f"WHERE query_id = '{armed_query_id}' "
+        "  AND message ILIKE '%rebuilding kernel engine%scan iterator%fresh credentials%'"
+    ).strip())
+    assert retry_log_hits >= 1, (
+        f"Expected the scan-iteration retry log line to fire for query {armed_query_id}, "
+        f"found {retry_log_hits} hits."
+    )
+
+    # Sanity check: subsequent queries work without the failpoint as well.
+    assert int(instance.query(f"SELECT sum(a) FROM {TABLE_NAME}")) == expected_sum

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -5409,3 +5409,63 @@ def test_azure_empty_blob_path(started_cluster, use_delta_kernel):
     assert instance.query(f"SELECT * FROM {TABLE_NAME}") == instance.query(
         inserted_data
     )
+
+
+def test_delta_kernel_expired_token_on_snapshot_init(started_cluster):
+    """Verify that DeltaLake snapshot init recovers from a stale STS session token.
+
+    The Rust `delta-kernel-rs` / `object_store` S3 client receives static credentials
+    captured at `S3KernelHelper::createBuilder` time and cannot refresh them. When the
+    underlying STS / instance-profile cache hands out a stale session token (e.g. after
+    a silent `Reload()` failure), the kernel call surfaces as `DELTA_KERNEL_ERROR` (742)
+    with `ExpiredToken` in the message.
+
+    The fix invalidates the C++ S3 client's credentials provider and retries the
+    snapshot once. We simulate the kernel-side rejection with a `ONCE` failpoint that
+    fires inside `KernelSnapshotState`'s constructor: the first attempt throws, the
+    retry uses a fresh build (failpoint disarmed) and succeeds.
+    """
+    instance = started_cluster.instances["node1"]
+    spark = started_cluster.spark_session
+    minio_client = started_cluster.minio_client
+    bucket = started_cluster.minio_bucket
+    TABLE_NAME = randomize_table_name("test_delta_kernel_expired_token")
+
+    write_delta_from_df(
+        spark, generate_data(spark, 0, 100), f"/{TABLE_NAME}", mode="overwrite"
+    )
+    upload_directory(minio_client, bucket, f"/{TABLE_NAME}", "")
+    create_delta_table(instance, "s3", TABLE_NAME, started_cluster)
+
+    # Baseline: query succeeds before the failpoint is armed.
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}")) == 100
+
+    armed_query_id = f"{TABLE_NAME}_armed"
+    instance.query("SYSTEM ENABLE FAILPOINT delta_kernel_throw_expired_token")
+    try:
+        # With the retry-on-ExpiredToken fix in place, the ONCE failpoint fires on the
+        # first KernelSnapshotState build, the retry uses real credentials, and the
+        # query succeeds end-to-end.
+        assert int(instance.query(
+            f"SELECT count() FROM {TABLE_NAME}",
+            query_id=armed_query_id,
+        )) == 100
+    finally:
+        instance.query("SYSTEM DISABLE FAILPOINT delta_kernel_throw_expired_token")
+
+    # Positive evidence that the retry path actually fired (not just that the failpoint
+    # silently failed to arm and the baseline path passed through). Without this check
+    # the test would still pass even if the registration didn't take effect.
+    instance.query("SYSTEM FLUSH LOGS")
+    retry_log_hits = int(instance.query(
+        "SELECT count() FROM system.text_log "
+        f"WHERE query_id = '{armed_query_id}' "
+        "  AND message ILIKE '%stale-credentials%retrying snapshot init%'"
+    ).strip())
+    assert retry_log_hits >= 1, (
+        f"Expected the snapshot-init retry log line to fire for query {armed_query_id}, "
+        f"found {retry_log_hits} hits."
+    )
+
+    # Sanity check: subsequent queries work without the failpoint as well.
+    assert int(instance.query(f"SELECT count() FROM {TABLE_NAME}")) == 100


### PR DESCRIPTION
### Changelog category (leave one):

- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix `DELTA_KERNEL_ERROR` (`ExpiredToken`) when reading a DeltaLake table that uses `extra_credentials(role_arn = ...)` and the cached STS session token gets stale; the S3 credentials provider is now correctly invalidated and the snapshot init is retried once.
