### PR TITLE
Re-merge TaskTracker::addFinal

### DIFF
--- a/src/Common/ThreadPoolTaskTracker.cpp
+++ b/src/Common/ThreadPoolTaskTracker.cpp
@@ -104,6 +104,12 @@ void TaskTracker::waitIfAny()
 
 void TaskTracker::add(Callback && func)
 {
+    {
+        std::lock_guard lock(mutex);
+        chassert(!final_task_added && "add must not be called after addFinal");
+        ++tasks_added;
+    }
+
     /// All this fuzz is about 2 things. This is the most critical place of TaskTracker.
     /// The first is not to fail insertion in the list `futures`.
     /// In order to face it, the element is allocated at the end of the list `futures` in advance.
@@ -118,14 +124,33 @@ void TaskTracker::add(Callback && func)
     /// preallocation for the second issue
     FinishedList pre_allocated_finished {future_placeholder};
 
-    Callback func_with_notification = [&, my_func = std::move(func), my_pre_allocated_finished = std::move(pre_allocated_finished)]() mutable
+    Callback func_with_notification = [this, my_func = std::move(func), my_pre_allocated_finished = std::move(pre_allocated_finished)]() mutable
     {
         SCOPE_EXIT({
-            DENY_ALLOCATIONS_IN_SCOPE;
-
-            std::lock_guard lock(mutex);
-            finished_futures.splice(finished_futures.end(), my_pre_allocated_finished);
-            has_finished.notify_one();
+            std::shared_ptr<std::packaged_task<void()>> maybe_final_task;
+            {
+                DENY_ALLOCATIONS_IN_SCOPE;
+                std::lock_guard lock(mutex);
+                finished_futures.splice(finished_futures.end(), my_pre_allocated_finished);
+                ++tasks_finished;
+                if (final_task && tasks_finished == tasks_added)
+                {
+                    maybe_final_task = std::move(final_task);
+                }
+                has_finished.notify_one();
+            }
+            if (maybe_final_task)
+            {
+                try
+                {
+                    scheduler([pt = std::move(maybe_final_task)]() mutable { (*pt)(); }, Priority{});
+                }
+                catch (...)
+                {
+                    /// SCOPE_EXIT is noexcept; let the final task's future report broken_promise.
+                    tryLogCurrentException(__PRETTY_FUNCTION__);
+                }
+            }
         });
 
         my_func();
@@ -135,6 +160,33 @@ void TaskTracker::add(Callback && func)
     *future_placeholder = scheduler(std::move(func_with_notification), Priority{});
 
     waitTilInflightShrink();
+}
+
+void TaskTracker::addFinal(Callback && func)
+{
+    auto pt = std::make_shared<std::packaged_task<void()>>(std::move(func));
+    futures.emplace_back(pt->get_future());
+
+    bool run_final_task_now = false;
+    {
+        std::lock_guard lock(mutex);
+        chassert(!final_task_added && "addFinal must be called at most once");
+        final_task_added = true;
+        if (tasks_finished == tasks_added)
+        {
+            /// Every previously added task has already finished.
+            /// There will be no SCOPE_EXIT to trigger the final callback, so run it here.
+            run_final_task_now = true;
+        }
+        else
+        {
+            final_task = pt;
+        }
+    }
+    if (run_final_task_now)
+    {
+        scheduler([p = std::move(pt)]() mutable { (*p)(); }, Priority{});
+    }
 }
 
 void TaskTracker::waitTilInflightShrink()

--- a/src/Common/ThreadPoolTaskTracker.h
+++ b/src/Common/ThreadPoolTaskTracker.h
@@ -39,6 +39,11 @@ public:
 
     void add(Callback && func);
 
+    /// Must be called at most once, after all `add()` calls.
+    /// The callback runs on a worker thread once every previously-added task has completed.
+    /// May or may not run if prior tasks threw.
+    void addFinal(Callback && func);
+
 private:
     /// waitTilInflightShrink waits til the number of in-flight tasks beyond the limit `max_tasks_inflight`.
     void waitTilInflightShrink() TSA_NO_THREAD_SAFETY_ANALYSIS;
@@ -57,6 +62,18 @@ private:
     std::condition_variable has_finished TSA_GUARDED_BY(mutex);
     using FinishedList = std::list<FutureList::iterator>;
     FinishedList finished_futures TSA_GUARDED_BY(mutex);
+
+    /// Monotonic counters of regular tasks submitted via add (excludes the final task).
+    /// Worker threads compare these to decide when the final task is ready, so they
+    /// never need to read `futures`.
+    size_t tasks_added TSA_GUARDED_BY(mutex) = 0;
+    size_t tasks_finished TSA_GUARDED_BY(mutex) = 0;
+
+    /// A packaged task for the callback added by addFinal. A non-null value means
+    /// the callback has been added, but not yet scheduled.
+    std::shared_ptr<std::packaged_task<void()>> final_task TSA_GUARDED_BY(mutex);
+
+    bool final_task_added = false;
 };
 
 }

--- a/src/Common/tests/gtest_thread_pool_task_tracker.cpp
+++ b/src/Common/tests/gtest_thread_pool_task_tracker.cpp
@@ -1,0 +1,203 @@
+#include <Common/ThreadPoolTaskTracker.h>
+#include <Common/setThreadName.h>
+
+#include <gtest/gtest.h>
+
+namespace CurrentMetrics
+{
+    extern const Metric LocalThread;
+    extern const Metric LocalThreadActive;
+    extern const Metric LocalThreadScheduled;
+}
+
+using namespace DB;
+
+namespace
+{
+
+LogSeriesLimiterPtr makeTestLogger()
+{
+    return std::make_shared<LogSeriesLimiter>(getLogger("TaskTrackerTest"), 1, 5);
+}
+
+struct AsyncTracker
+{
+    ThreadPool pool;
+    TaskTracker tracker;
+
+    explicit AsyncTracker(size_t threads, size_t max_inflight = 0)
+        : pool(CurrentMetrics::LocalThread, CurrentMetrics::LocalThreadActive, CurrentMetrics::LocalThreadScheduled, threads)
+        , tracker(threadPoolCallbackRunnerUnsafe<void>(pool, ThreadName::UNKNOWN), max_inflight, makeTestLogger())
+    {}
+};
+
+}
+
+TEST(TaskTrackerAddFinal, AsyncHappyPathRunsFinalAfterAllPriors)
+{
+    AsyncTracker t{/*threads=*/4};
+    constexpr size_t N = 16;
+    std::atomic<size_t> ran{0};
+    std::atomic<bool> final_ran{false};
+    std::atomic<size_t> count_observed_by_final{0};
+
+    for (size_t i = 0; i < N; ++i)
+        t.tracker.add([&] {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            ran.fetch_add(1);
+        });
+
+    t.tracker.addFinal([&] {
+        count_observed_by_final = ran.load();
+        final_ran = true;
+    });
+
+    t.tracker.waitAll();
+
+    EXPECT_EQ(ran.load(), N);
+    EXPECT_TRUE(final_ran.load());
+    EXPECT_EQ(count_observed_by_final.load(), N);
+}
+
+TEST(TaskTrackerAddFinal, AsyncZeroPriorsStillRunsFinal)
+{
+    AsyncTracker t{/*threads=*/2};
+    std::atomic<bool> final_ran{false};
+
+    t.tracker.addFinal([&] { final_ran = true; });
+    t.tracker.waitAll();
+
+    EXPECT_TRUE(final_ran.load());
+}
+
+TEST(TaskTrackerAddFinal, AsyncAllPriorsAlreadyDoneBeforeAddFinal)
+{
+    AsyncTracker t{/*threads=*/2};
+    constexpr size_t N = 4;
+    std::atomic<size_t> ran{0};
+    std::atomic<bool> final_ran{false};
+
+    for (size_t i = 0; i < N; ++i)
+        t.tracker.add([&] { ran.fetch_add(1); });
+
+    /// Give workers a chance to finish before we call addFinal — exercises the path where
+    /// `finished_futures.size() == futures.size()` is already true at the time addFinal is called.
+    while (ran.load() != N)
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+    t.tracker.addFinal([&] { final_ran = true; });
+    t.tracker.waitAll();
+
+    EXPECT_TRUE(final_ran.load());
+}
+
+TEST(TaskTrackerAddFinal, AsyncPriorFailureDoesNotDeadlock)
+{
+    AsyncTracker t{/*threads=*/2};
+
+    t.tracker.add([] { /* ok */ });
+    t.tracker.add([] { throw std::runtime_error("boom"); });
+    t.tracker.add([] { /* ok */ });
+    t.tracker.addFinal([] {});
+
+    EXPECT_THROW(t.tracker.waitAll(), std::runtime_error);
+    /// The final callback is best-effort on failures — we only assert no deadlock and clean shutdown.
+    t.tracker.safeWaitAll();
+}
+
+TEST(TaskTrackerAddFinal, AsyncFinalCallbackException)
+{
+    AsyncTracker t{/*threads=*/2};
+    t.tracker.add([] { /* ok */ });
+    t.tracker.addFinal([] { throw std::runtime_error("final boom"); });
+
+    EXPECT_THROW(t.tracker.waitAll(), std::runtime_error);
+    t.tracker.safeWaitAll();
+}
+
+TEST(TaskTrackerAddFinal, WaitIfAnyBeforeFinalTask)
+{
+    TaskTracker tracker(/*scheduler_=*/{}, /*max_tasks_inflight=*/0, makeTestLogger());
+    ASSERT_FALSE(tracker.isAsync());
+
+    constexpr size_t N = 2;
+    std::atomic<size_t> ran{0};
+    std::atomic<bool> final_ran{false};
+
+    for (size_t i = 0; i < N; ++i)
+        tracker.add([&] { ran.fetch_add(1); });
+
+    /// Sync runner has already run every task body and populated `finished_futures`.
+    ASSERT_EQ(ran.load(), N);
+
+    tracker.waitIfAny();
+
+    tracker.addFinal([&] { final_ran = true; });
+
+    tracker.waitAll();
+
+    EXPECT_EQ(ran.load(), N);
+    EXPECT_TRUE(final_ran.load());
+}
+
+TEST(TaskTrackerAddFinal, AsyncWithInflightLimit)
+{
+    /// Exercise the path where `waitTilInflightShrink` is hit on the owner thread between adds.
+    AsyncTracker t{/*threads=*/4, /*max_inflight=*/3};
+    constexpr size_t N = 32;
+    std::atomic<size_t> ran{0};
+    std::atomic<bool> final_ran{false};
+
+    for (size_t i = 0; i < N; ++i)
+        t.tracker.add([&] {
+            std::this_thread::sleep_for(std::chrono::milliseconds(2));
+            ran.fetch_add(1);
+        });
+
+    size_t observed_in_final = 0;
+    t.tracker.addFinal([&] {
+        observed_in_final = ran.load();
+        final_ran = true;
+    });
+    t.tracker.waitAll();
+
+    EXPECT_EQ(ran.load(), N);
+    EXPECT_TRUE(final_ran.load());
+    EXPECT_EQ(observed_in_final, N);
+}
+
+TEST(TaskTrackerAddFinal, SyncRunnerHappyPath)
+{
+    TaskTracker tracker(/*scheduler_=*/{}, /*max_tasks_inflight=*/0, makeTestLogger());
+    ASSERT_FALSE(tracker.isAsync());
+
+    constexpr size_t N = 5;
+    std::atomic<size_t> ran{0};
+    std::atomic<bool> final_ran{false};
+    size_t observed_in_final = 0;
+
+    for (size_t i = 0; i < N; ++i)
+        tracker.add([&] { ran.fetch_add(1); });
+
+    tracker.addFinal([&] {
+        observed_in_final = ran.load();
+        final_ran = true;
+    });
+    tracker.waitAll();
+
+    EXPECT_EQ(ran.load(), N);
+    EXPECT_TRUE(final_ran.load());
+    EXPECT_EQ(observed_in_final, N);
+}
+
+TEST(TaskTrackerAddFinal, SyncRunnerPriorFailureDoesNotDeadlock)
+{
+    TaskTracker tracker(/*scheduler_=*/{}, /*max_tasks_inflight=*/0, makeTestLogger());
+
+    tracker.add([] { /* ok */ });
+    tracker.add([] { throw std::runtime_error("boom"); });
+    tracker.addFinal([] {});
+
+    EXPECT_THROW(tracker.waitAll(), std::runtime_error);
+    tracker.safeWaitAll();
+}

--- a/src/IO/WriteBufferFromS3.cpp
+++ b/src/IO/WriteBufferFromS3.cpp
@@ -195,6 +195,11 @@ void WriteBufferFromS3::preFinalize()
     else
     {
         writeMultipartUpload();
+        task_tracker->addFinal([this]()
+        {
+            if (completeMultipartUpload())
+                multipart_upload_finished = true;
+        });
     }
 }
 
@@ -218,12 +223,6 @@ void WriteBufferFromS3::finalizeImpl()
     task_tracker->waitAll();
 
     span.addAttributeIfNotZero("clickhouse.multipart_upload_parts", multipart_tags.size());
-
-    if (!multipart_upload_id.empty())
-    {
-        completeMultipartUpload();
-        multipart_upload_finished = true;
-    }
 
     if (request_settings[S3RequestSetting::check_objects_after_upload])
     {
@@ -618,7 +617,7 @@ void WriteBufferFromS3::writePart(WriteBufferFromS3::PartData && data)
     task_tracker->add(std::move(upload_worker));
 }
 
-void WriteBufferFromS3::completeMultipartUpload()
+bool WriteBufferFromS3::completeMultipartUpload()
 {
     LOG_TEST(limited_log, "Completing multipart upload. {}, Parts: {}", getShortLogDetails(), multipart_tags.size());
 
@@ -627,13 +626,13 @@ void WriteBufferFromS3::completeMultipartUpload()
                 ErrorCodes::LOGICAL_ERROR,
                 "Failed to complete multipart upload. No parts have uploaded");
 
-    for (size_t i = 0; i < multipart_tags.size(); ++i)
+    for (const auto & tag : multipart_tags)
     {
-        const auto tag = multipart_tags.at(i);
         if (tag.empty())
-            throw Exception(
-                    ErrorCodes::LOGICAL_ERROR,
-                    "Failed to complete multipart upload. Part {} haven't been uploaded.", i);
+        {
+            // One of the earlier uploads failed.
+            return false;
+        }
     }
 
     S3::CompleteMultipartUploadRequest req;
@@ -680,7 +679,7 @@ void WriteBufferFromS3::completeMultipartUpload()
         if (outcome.IsSuccess())
         {
             LOG_TRACE(limited_log, "Multipart upload has completed. {}, Parts: {}", getShortLogDetails(), multipart_tags.size());
-            return;
+            return true;
         }
 
         ProfileEvents::increment(ProfileEvents::WriteBufferFromS3RequestsErrors, 1);

--- a/src/IO/WriteBufferFromS3.h
+++ b/src/IO/WriteBufferFromS3.h
@@ -72,7 +72,7 @@ private:
     void writePart(PartData && data);
     void writeMultipartUpload();
     void createMultipartUpload();
-    void completeMultipartUpload();
+    bool completeMultipartUpload();
     void abortMultipartUpload();
     void tryToAbortMultipartUpload() noexcept;
 

--- a/tests/integration/test_s3_aws_sdk_has_slightly_unreliable_behaviour/configs/storage_conf.xml
+++ b/tests/integration/test_s3_aws_sdk_has_slightly_unreliable_behaviour/configs/storage_conf.xml
@@ -15,7 +15,7 @@
                 <skip_access_check>true</skip_access_check>
                 <!-- Avoid extra retries to speed up tests -->
                 <!-- never set retry_attempts to 0, as it disables retries on all errors including sporadic timeouts -->
-                <retry_attempts>2</retry_attempts>
+                <s3_retry_attempts>2</s3_retry_attempts>
                 <skip_access_check>true</skip_access_check>
                 <persistent_removal_log>true</persistent_removal_log>
             </s3>

--- a/tests/integration/test_s3_aws_sdk_has_slightly_unreliable_behaviour/test.py
+++ b/tests/integration/test_s3_aws_sdk_has_slightly_unreliable_behaviour/test.py
@@ -70,8 +70,8 @@ def cluster():
 
 def test_dataloss(cluster):
     node = cluster.instances["node"]
-
     node.query("DROP TABLE IF EXISTS s3_failover_test")
+
     node.query(
         """
         CREATE TABLE s3_failover_test (
@@ -85,7 +85,8 @@ def test_dataloss(cluster):
     # Must throw an exception because we use proxy which always fail
     # CompleteMultipartUpload requests
     try:
-        with pytest.raises(Exception):
+        with pytest.raises(Exception) as exc_info:
             node.query("INSERT INTO s3_failover_test VALUES (1, 'Hello')")
+        assert "completeMultipartUpload" in str(exc_info.value)
     finally:
         node.query("DROP TABLE IF EXISTS s3_failover_test")


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Summary

Remerging PR #105487 after it initally broke CI. Here is why.

The test `test_aws_s3_sdk_has_slightly_unreliable_behavior` uses an endpoint that always returns a retriable error for completeMultiPartUpload . The test intended to pin retry_attempts to 2, but used the wrong value, causing it to run the full 500 retries. Since async inserts are on by default and time out after two minutes, the test would fail by hitting this client-side timeout. After it failed, the insert would continue running on the server.

Why did the `TaskTracker::addFinal()` PR cause problems? It moved `completeMultiPartUpload` to run on a separate thread, taken from `threadpool_writer_pool` (size = 100), rather than the global thread pool (size = 10k). As the inserts continued running for a long time, this caused thread pool starvation for subsequent tests trying to write to object storage.

I don't believe this is a bug in the code itself -- it is a fairly contrived example, and I assume the upload pool is intentionally small. I verified that query cancellation still works correctly with `completeMultiPartUpload` running on a separate thread, so if needed, we would be able to cancel such queries.

The fix is test-only -- correcting the retry count from 500 to 2, and adding an assert that the test fails due to completeMultiPartUpload failing, rather than async timeouts.

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.577`
<!-- ch-version-info:end -->