### PR TITLE
Reject CREATE INDEX with GRANULARITY 0

### DIFF
--- a/src/Parsers/ASTIndexDeclaration.cpp
+++ b/src/Parsers/ASTIndexDeclaration.cpp
@@ -97,11 +97,8 @@ void ASTIndexDeclaration::formatImpl(WriteBuffer & ostr, const FormatSettings & 
         type->format(ostr, s, state, frame);
     }
 
-    if (granularity)
-    {
-        ostr << " GRANULARITY ";
-        ostr << granularity;
-    }
+    /// Always emit so AST round-trip is invariant for every granularity (zero included).
+    ostr << " GRANULARITY " << granularity;
 }
 
 UInt64 getSecondaryIndexGranularity(const boost::intrusive_ptr<ASTFunction> & type, const ASTPtr & granularity)

--- a/src/Storages/IndicesDescription.cpp
+++ b/src/Storages/IndicesDescription.cpp
@@ -101,6 +101,9 @@ IndexDescription IndexDescription::getIndexFromAST(
     if (index_type->parameters && !index_type->parameters->children.empty())
         throw Exception(ErrorCodes::INCORRECT_QUERY, "Index type cannot have parameters");
 
+    if (index_definition->granularity == 0)
+        throw Exception(ErrorCodes::BAD_ARGUMENTS, "Index GRANULARITY must be a positive integer");
+
     IndexDescription result;
     result.definition_ast = index_definition->clone();
     result.name = index_definition->name;

--- a/tests/queries/0_stateless/04326_reject_create_index_granularity_zero.sql
+++ b/tests/queries/0_stateless/04326_reject_create_index_granularity_zero.sql
@@ -1,0 +1,14 @@
+DROP TABLE IF EXISTS t_granularity_zero_create;
+DROP TABLE IF EXISTS t_granularity_zero_alter;
+DROP TABLE IF EXISTS t_granularity_zero_create_index;
+
+CREATE TABLE t_granularity_zero_create (a Int32, INDEX idx a TYPE minmax GRANULARITY 0) ENGINE = MergeTree ORDER BY a; -- { serverError BAD_ARGUMENTS }
+
+CREATE TABLE t_granularity_zero_alter (a Int32) ENGINE = MergeTree ORDER BY a;
+ALTER TABLE t_granularity_zero_alter ADD INDEX idx a TYPE minmax GRANULARITY 0; -- { serverError BAD_ARGUMENTS }
+
+CREATE TABLE t_granularity_zero_create_index (a Int32) ENGINE = MergeTree ORDER BY a;
+CREATE INDEX idx ON t_granularity_zero_create_index a TYPE minmax GRANULARITY 0; -- { serverError BAD_ARGUMENTS }
+
+DROP TABLE t_granularity_zero_alter;
+DROP TABLE t_granularity_zero_create_index;


### PR DESCRIPTION
Creating a skipping index with `GRANULARITY 0` raises an `Inconsistent AST formatting` exception in debug builds and is semantically invalid (the skip-index writer at `MergeTreeDataPartWriterOnDisk:224` would match every accumulated mark immediately on `granularity == 0`).

`ASTIndexDeclaration::formatImpl` had `if (granularity) { ostr << " GRANULARITY " << granularity; }`, so a stored zero was silently dropped from formatted output. The parser falls back to `DEFAULT_INDEX_GRANULARITY` (1) when the clause is absent, so format then parse produced a different AST and `executeQueryImpl::queryRoundTrip` raised `Inconsistent AST formatting`.

Two changes:
1. The formatter unconditionally emits `GRANULARITY <n>` so AST round-trip is invariant for every value (the implicit-minmax path and the field default both use `DEFAULT_INDEX_GRANULARITY`, so no existing call site changes its formatted output).
2. `IndexDescription::getIndexFromAST` rejects `granularity == 0` with `BAD_ARGUMENTS`, mirroring `registerStorageMergeTree`'s existing check for the table-level `index_granularity` setting. This is the canonical interpretation point invoked by `CREATE TABLE`, `ALTER TABLE ADD INDEX`, and `CREATE INDEX`.

Reproducer (before this PR raised `Inconsistent AST formatting` and aborted in debug):
```sql
CREATE TABLE t (a Int32, INDEX idx a TYPE minmax GRANULARITY 0) ENGINE = MergeTree ORDER BY a;
-- Code: 36. DB::Exception: Index GRANULARITY must be a positive integer. (BAD_ARGUMENTS)
```

Regression test: `tests/queries/0_stateless/04326_reject_create_index_granularity_zero.sql` covers all three entry points.

Closes: https://github.com/ClickHouse/ClickHouse/issues/106719

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Reject `CREATE TABLE`, `ALTER TABLE ADD INDEX`, and `CREATE INDEX` with `GRANULARITY 0` for skipping indexes with a clear `BAD_ARGUMENTS` error. Previously this triggered an `Inconsistent AST formatting` exception in debug builds.


### Documentation entry for user-facing changes

- [x] Documentation is unnecessary or follows from the existing behavior of the new validation.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.575`
<!-- ch-version-info:end -->