### PR TITLE
Try to do something about TSAN error in NonblockingBoundedQueue

### DIFF
--- a/src/Common/NonblockingBoundedQueue.h
+++ b/src/Common/NonblockingBoundedQueue.h
@@ -85,7 +85,8 @@ public:
         size_t pos = enqueue_pos.load(std::memory_order_relaxed);
         while (true)
         {
-            Slot & slot = slots[pos & mask];
+            size_t slot_idx = pos & mask;
+            Slot & slot = slots[slot_idx];
             size_t slot_pos = slot.pos.load(std::memory_order_acquire);
             if (slot_pos < pos)
             {
@@ -104,6 +105,28 @@ public:
                 continue;
             }
 
+            /// We're seeing very rare TSAN error saying there's data race between the slot.value
+            /// write in tryPush and slot.value read in tryPop. For the life of me I can't see how
+            /// this is possible. The code is isomorphic to dvykov's original implementation.
+            /// Best guess is TSAN false positive of some kind.
+            /// So here's a desperate hack that re-loads slot.pos in hopes it would un-confuse TSAN.
+            ///
+            /// Appendix:
+            /// Reasoning for why that tryPush and tryPop can't race on slot.value:
+            ///  * Let i be slot's index in `slots`, i.e. pos & mask.
+            ///    Notice that i has the same parity as pos.
+            ///  * If (slot.pos - i) is even, slot.value may be written to.
+            ///    If (slot.pos - i) is odd, slot.value may be read from.
+            ///  * tryPush does slot.pos.load(acquire), then effectively checks that (slot.pos - i)
+            ///    is even (by checking slot_pos == pos; pos has same parity as i), then
+            ///    writes slot.value, then does slot.pos.store(release) that flips the
+            ///    (slot.pos - i) parity to odd.
+            ///  * tryPop symmetrically does slot.pos.load(acquire), checks that parity is odd,
+            ///    does the read, does slot.pos.store(release) that flips parity back to even.
+            size_t slot_pos_again = slot.pos.load(std::memory_order_acquire);
+            if (slot_pos_again != pos || (slot_pos_again - slot_idx) % 2 != 0)
+                std::abort();
+
             slot.value = std::move(value);
             slot.pos.store(pos + 1, std::memory_order_release);
             return true;
@@ -116,7 +139,8 @@ public:
         size_t pos = dequeue_pos.load(std::memory_order_relaxed);
         while (true)
         {
-            Slot & slot = slots[pos & mask];
+            size_t slot_idx = pos & mask;
+            Slot & slot = slots[slot_idx];
             size_t slot_pos = slot.pos.load(std::memory_order_acquire);
             if (slot_pos < pos + 1)
             {
@@ -134,6 +158,11 @@ public:
                 /// Another consumer won a different race.
                 continue;
             }
+
+            /// Same hack as in tryPush.
+            size_t slot_pos_again = slot.pos.load(std::memory_order_acquire);
+            if (slot_pos_again != pos + 1 || (slot_pos_again - slot_idx) % 2 != 1)
+                std::abort();
 
             out_value = std::move(slot.value);
             slot.pos.store(pos + mask + 1, std::memory_order_release);


### PR DESCRIPTION
### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

A perplexing TSAN error. I didn't figure out the cause. Happened ~6 times over 2 weeks, in different integration tests.

https://play.clickhouse.com/play?user=play#U0VMRUNUIGNoZWNrX3N0YXJ0X3RpbWUsIHRlc3RfbmFtZSwgcHVsbF9yZXF1ZXN0X251bWJlciwgcmVwb3J0X3VybApGUk9NIGNoZWNrcwpXSEVSRSBjaGVja19zdGFydF90aW1lID49IG5vdygpIC0gSU5URVJWQUwgMzAgREFZCiAgQU5EIGNoZWNrX25hbWUgSUxJS0UgJyVJbnRlZ3JhdGlvbiUnCiAgQU5EIHRlc3RfY29udGV4dF9yYXcgTElLRSAnJVNhbml0aXplciBhc3NlcnQgZm91bmQgZm9yIGluc3RhbmNlIHpvbyUnCiAgYW5kIGJhc2VfcmVmID0gJ21hc3RlcicKICBhbmQgcHVsbF9yZXF1ZXN0X251bWJlciAhPSAxMDE3NTcKT1JERVIgQlkgY2hlY2tfc3RhcnRfdGltZSBERVND

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=106185&sha=fb27559f055b68972384718352e7c41b809441b3&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%206%2F6%29&name_1=Integration%20tests%20%28amd_tsan%2C%206%2F6%29

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=106178&sha=413c4041a85f2652834a98bfbbc57e163673601b&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%204%2F6%29&name_1=Integration%20tests%20%28amd_tsan%2C%204%2F6%29

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=105891&sha=775580d0e4e076b016a615cd1fee61e5fc640d17&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%201%2F6%29&name_1=Integration%20tests%20%28amd_tsan%2C%201%2F6%29

https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=97676&sha=8e774bd9e9054aaae7708ffad555f15c570c77ae&name_0=PR&name_1=Integration%20tests%20%28amd_tsan%2C%205%2F6%29&name_1=Integration%20tests%20%28amd_tsan%2C%205%2F6%29

(etc)

TSAN says data race in NonblockingBoundedQueue between writing `slot.value` in `tryPush` and reading `slot.value` in `tryPop` from another thread. I.e. exactly the normal usage of the queue, exactly the race the queue's fancy atomics with fancy memory_orders are meant to prevent.
 * Neither I nor claude found any significant difference between this code and Vykov's original code, which seems very unlikely to be incorrect.
 * I think I have a proof that this particular race can't happen.
 * Claude failed to find or reproduce known TSAN problems that lead to such blatant false positives on spinlock-like things. It guessed it may have something to do with pushing to the queue from lots of threads (one KeeperTCPHandler thread per client connection) or with those threads exiting between the enqueue and dequeue.

So, I'm confused and ran out of plausible hypotheses. Maybe I'm just being silly and there's an obvious bug.

Here's a desperate PR that adds another atomic load to (a) explicitly re-check the invariant and possibly crash if the code is actually wrong, (b) possibly work around TSAN problem.