### PR TITLE
Fix inconsistent columns on exception (i.e. MEMORY_LIMIT_EXCEEDED) during parsing

### DIFF
--- a/src/Columns/ColumnNullable.h
+++ b/src/Columns/ColumnNullable.h
@@ -95,7 +95,17 @@ public:
     void insertDefault() override
     {
         getNestedColumn().insertDefault();
-        getNullMapData().push_back(true);
+        /// Keep the nested column and the null map in sync even if appending to the
+        /// null map throws (e.g. on a memory limit).
+        try
+        {
+            getNullMapData().push_back(true);
+        }
+        catch (...)
+        {
+            getNestedColumn().popBack(1);
+            throw;
+        }
     }
 
     void popBack(size_t n) override;

--- a/src/Columns/ColumnObject.cpp
+++ b/src/Columns/ColumnObject.cpp
@@ -833,20 +833,55 @@ void ColumnObject::deserializeValueFromSharedData(const ColumnString * shared_da
 
 void ColumnObject::insertDefault()
 {
-    for (auto & [_, column] : typed_paths)
-        column->insertDefault();
-    for (auto & [_, column] : dynamic_paths_ptrs)
-        column->insertDefault();
-    shared_data->insertDefault();
+    /// Exception-safe: if some sub-column's insertDefault throws (e.g. on a memory limit),
+    /// roll back the sub-columns that were already modified, otherwise the object is left
+    /// with sub-columns of different sizes and popBack would over-pop the shorter ones.
+    size_t prev_size = size();
+    try
+    {
+        for (auto & [_, column] : typed_paths)
+            column->insertDefault();
+        for (auto & [_, column] : dynamic_paths_ptrs)
+            column->insertDefault();
+        shared_data->insertDefault();
+    }
+    catch (...)
+    {
+        for (auto & [_, column] : typed_paths)
+            if (column->size() > prev_size)
+                column->popBack(column->size() - prev_size);
+        for (auto & [_, column] : dynamic_paths_ptrs)
+            if (column->size() > prev_size)
+                column->popBack(column->size() - prev_size);
+        if (shared_data->size() > prev_size)
+            shared_data->popBack(shared_data->size() - prev_size);
+        throw;
+    }
 }
 
 void ColumnObject::insertManyDefaults(size_t length)
 {
-    for (auto & [_, column] : typed_paths)
-        column->insertManyDefaults(length);
-    for (auto & [_, column] : dynamic_paths_ptrs)
-        column->insertManyDefaults(length);
-    shared_data->insertManyDefaults(length);
+    size_t prev_size = size();
+    try
+    {
+        for (auto & [_, column] : typed_paths)
+            column->insertManyDefaults(length);
+        for (auto & [_, column] : dynamic_paths_ptrs)
+            column->insertManyDefaults(length);
+        shared_data->insertManyDefaults(length);
+    }
+    catch (...)
+    {
+        for (auto & [_, column] : typed_paths)
+            if (column->size() > prev_size)
+                column->popBack(column->size() - prev_size);
+        for (auto & [_, column] : dynamic_paths_ptrs)
+            if (column->size() > prev_size)
+                column->popBack(column->size() - prev_size);
+        if (shared_data->size() > prev_size)
+            shared_data->popBack(shared_data->size() - prev_size);
+        throw;
+    }
 }
 
 void ColumnObject::popBack(size_t n)

--- a/src/Columns/ColumnTuple.cpp
+++ b/src/Columns/ColumnTuple.cpp
@@ -279,9 +279,24 @@ void ColumnTuple::doInsertManyFrom(const IColumn & src, size_t position, size_t 
 
 void ColumnTuple::insertDefault()
 {
+    /// Must be exception-safe: if some nested column throws (e.g. on a memory limit),
+    /// the already modified nested columns have to be rolled back, otherwise the tuple
+    /// is left with nested columns of different sizes, which later leads to over-popping
+    /// in popBack during rollback of a partially read row.
+    size_t i = 0;
+    try
+    {
+        for (; i < columns.size(); ++i)
+            columns[i]->insertDefault();
+    }
+    catch (...)
+    {
+        for (size_t rollback = 0; rollback < i; ++rollback)
+            columns[rollback]->popBack(1);
+        throw;
+    }
+
     ++column_length;
-    for (auto & column : columns)
-        column->insertDefault();
 }
 
 void ColumnTuple::popBack(size_t n)

--- a/src/Columns/ColumnVariant.cpp
+++ b/src/Columns/ColumnVariant.cpp
@@ -718,14 +718,32 @@ void ColumnVariant::deserializeBinaryIntoVariant(ColumnVariant::Discriminator gl
 void ColumnVariant::insertDefault()
 {
     getLocalDiscriminators().push_back(NULL_DISCRIMINATOR);
-    getOffsets().emplace_back();
+    /// Keep local_discriminators and offsets in sync even if appending to offsets throws
+    /// (e.g. on a memory limit), otherwise popBack would over-pop the shorter one.
+    try
+    {
+        getOffsets().emplace_back();
+    }
+    catch (...)
+    {
+        getLocalDiscriminators().pop_back();
+        throw;
+    }
 }
 
 void ColumnVariant::insertManyDefaults(size_t length)
 {
-    size_t size = local_discriminators->size();
-    getLocalDiscriminators().resize_fill(size + length, NULL_DISCRIMINATOR);
-    getOffsets().resize_fill(size + length);
+    size_t prev_size = local_discriminators->size();
+    getLocalDiscriminators().resize_fill(prev_size + length, NULL_DISCRIMINATOR);
+    try
+    {
+        getOffsets().resize_fill(prev_size + length);
+    }
+    catch (...)
+    {
+        getLocalDiscriminators().resize_assume_reserved(prev_size);
+        throw;
+    }
 }
 
 void ColumnVariant::popBack(size_t n)

--- a/src/Columns/tests/gtest_column_tuple.cpp
+++ b/src/Columns/tests/gtest_column_tuple.cpp
@@ -1,8 +1,15 @@
 #include <Columns/ColumnTuple.h>
 #include <Columns/ColumnsNumber.h>
+#include <Columns/ColumnFixedString.h>
 
 #include <gtest/gtest.h>
+#include <base/types.h>
+#include <Common/CurrentThread.h>
 #include <Common/Exception.h>
+#include <Common/MemoryTracker.h>
+#include <Common/ThreadStatus.h>
+#include <Common/assert_cast.h>
+#include <Common/scope_guard_safe.h>
 
 using namespace DB;
 
@@ -75,6 +82,39 @@ TEST(ColumnTuple, EmptyTupleExpand)
     expanded_inv->expand(mask, true);
 
     ASSERT_EQ(expanded_inv->size(), mask.size());
+}
+
+TEST(ColumnTuple, InsertDefaultIsExceptionSafe)
+{
+    /// First element is plain: its insertDefault succeeds.
+    /// Second element is a wide FixedString: its insertDefault triggers a large allocation
+    /// that overshoots a clamped memory limit and throws MEMORY_LIMIT_EXCEEDED - the same
+    /// way a real query hits a memory limit in the middle of a default insert.
+    static constexpr size_t huge = 64 * 1024 * 1024;
+
+    auto first = ColumnFloat64::create();
+    first->reserve(1);
+    MutableColumns elements;
+    elements.push_back(std::move(first));
+    elements.push_back(ColumnFixedString::create(huge));
+    auto tuple = ColumnTuple::create(std::move(elements));
+
+    {
+        MainThreadStatus::getInstance();
+        CurrentThread::flushUntrackedMemory();
+        const Int64 prev_hard_limit = total_memory_tracker.getHardLimit();
+        SCOPE_EXIT_SAFE(total_memory_tracker.setHardLimit(prev_hard_limit));
+        total_memory_tracker.setHardLimit(total_memory_tracker.get() + 1024);
+
+        ASSERT_THROW(tuple->insertDefault(), Exception);
+    }
+
+    /// The first element must have been rolled back so that all nested columns stay in sync,
+    /// otherwise a later popBack would over-pop the shorter element.
+    const auto & tuple_concrete = assert_cast<const ColumnTuple &>(*tuple);
+    ASSERT_EQ(tuple_concrete.getColumn(0).size(), 0);
+    ASSERT_EQ(tuple_concrete.getColumn(1).size(), 0);
+    ASSERT_EQ(tuple->size(), 0);
 }
 
 TEST(ColumnTuple, EmptyTuplePermute)


### PR DESCRIPTION
<!-- Fixes issue link part, do not remove -->
## Linked issues
- fixes https://github.com/ClickHouse/clickhouse-core-incidents/issues/1842
<!-- End of fixes issue link part, do not remove -->

Composite columns grow several nested structures in sequence inside `insertDefault` with no rollback. If one of them throws (for example on a memory limit [1]) the already-grown structures are left ahead of the rest, so the column's nested structures end up with different sizes.

  [1]: https://pastila.nl/?0005eb6b/e1cd0ca11139b61c65264e368f8e6150#BjWwSA/197t3/SuuGCsqdg==GCM

This is reachable during deserialization default-filling: a missing named-tuple element (`input_format_json_defaults_for_missing_elements_in_named_tuple`) or a null with `input_format_null_as_default` calls `insertDefault` on a nested column. When an allocation throws in the middle, the column is left desynchronized; the exception then unwinds into a serialization-level restore (`SerializationTuple::addElementSafe` and friends) which calls `popBack` to undo the partial row, and `popBack` over-pops the shorter nested structure:

    Cannot pop 1 rows from String: there are only 0 rows

Per type:
- `Tuple`: `size` is `columns[0]->size` and `columns[0]` grows first, so any later element that throws leaves `size` ahead - roll back the grown elements.
- `Nullable`: the nested column grows before the null map - roll back the nested column if appending to the null map throws.
- `Variant`: `local_discriminators` grows before `offsets` - roll it back if appending to `offsets` throws.
- `Object`: typed/dynamic paths and `shared_data` grow in sequence - roll each back to the previous size.

This should be sufficient (i.e. we do not need to fix IColumn::insert() and others) because usually if some method of IColumn throws, we discard the column, there are only few exceptions:

- checkpoint-based rollback (`getCheckpoint`/`rollback`) - should be safe already
- manual handling of parsing errors and reverting the state via popBack() - usually safe, but not safe when filling defaults via insertDefault() -- this patch

Note `insertManyDefaults` is not on this path (parsing fills defaults one row at a time via `insertDefault`), but the `Variant`/`Object` overrides were made exception-safe too, since they do a bulk fill and may be reused elsewhere.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix inconsistent columns (that leads to LOGICAL_ERROR later) on exception (i.e. MEMORY_LIMIT_EXCEEDED) during parsing

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.578`
- Backported to: `26.5.3.19`, `26.4.5.11`, `26.3.14.11`
<!-- ch-version-info:end -->