### PR TITLE
Forbid large BuzzHouse queries being sent to the server

### DIFF
--- a/ci/jobs/buzzhouse_job.py
+++ b/ci/jobs/buzzhouse_job.py
@@ -166,7 +166,7 @@ def main():
 
     allow_hardcoded_inserts = random.choice([True, False])
     min_nested_rows = random.randint(0, 5)
-    max_nested_rows = min_nested_rows + (5 if allow_hardcoded_inserts else 100)
+    max_nested_rows = min_nested_rows + (5 if allow_hardcoded_inserts else 30)
     min_insert_rows = random.randint(1, 100)
     max_insert_rows = min_insert_rows + (10 if allow_hardcoded_inserts else 3000)
     min_string_length = random.randint(0, 100)

--- a/programs/client/FuzzLoop.cpp
+++ b/programs/client/FuzzLoop.cpp
@@ -495,11 +495,18 @@ bool Client::processWithASTFuzzer(std::string_view full_query)
 
 bool Client::processBuzzHouseQuery(const String & full_query)
 {
+    static constexpr size_t max_query_bytes = 1 << 20;
     bool server_up = true;
 
     have_error = false;
     error_code = 0;
-    if (!processQueryText(full_query))
+    if (full_query.size() > max_query_bytes)
+    {
+        have_error = true;
+        error_code = ErrorCodes::CANNOT_PARSE_TEXT;
+        LOG_WARNING(fuzz_config->log, "Skipping oversized query ({} bytes, limit {})", full_query.size(), max_query_bytes);
+    }
+    else if (!processQueryText(full_query))
     {
         have_error = true;
         error_code = ErrorCodes::CANNOT_PARSE_TEXT;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Also, reduce the max number of nested rows being generated. Fixes this CI failure: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=f95eeea66d09a3bddb48df51b6e317cbe3c2325c&name_0=MasterCI&name_1=BuzzHouse+%28experimental%2C+serverfuzz%2C+arm_asan_ubsan%29

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.557`
<!-- ch-version-info:end -->