### PR TITLE
Wait for more ports to be free before starting server

### DIFF
--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -276,13 +276,28 @@ function wait_server_port_free()
     fi
 }
 
+function wait_server_ports_free()
+{
+    # Wait for all ClickHouse listen ports to become available.
+    # In debug+ThreadFuzzer builds, shutdown is slow and the kernel
+    # may still hold sockets from the previous server instance.
+    #   8123  HTTP               9010  TCP with proxy protocol
+    #   8443  HTTPS              9022  SSH
+    #   9000  Native TCP         9100  gRPC
+    #   9004  MySQL compat       9181  Keeper
+    #   9005  PostgreSQL compat  9234  Keeper Raft
+    #   9009  Interserver HTTP   9440  Native TCP TLS
+    #                            9988  Prometheus
+    for port in 8123 8443 9000 9004 9005 9009 9010 9022 9100 9181 9234 9440 9988; do
+        wait_server_port_free "$port"
+    done
+}
+
 function start_server()
 {
     # After safeExit (forceful shutdown), the kernel may still be cleaning up sockets,
     # especially under sanitizer builds. Wait for the server ports to become available.
-    wait_server_port_free 9000
-    wait_server_port_free 9009
-    wait_server_port_free 9181
+    wait_server_ports_free
 
     counter=0
     max_attempt=${1:-6}
@@ -298,9 +313,15 @@ function start_server()
             tail -n100000 /var/log/clickhouse-server/clickhouse-server.log | rg -F -v -e '<Warning> RaftInstance:' -e '<Information> RaftInstance' | tail -n100
             return 1
         fi
+        # Wait for ports before each retry, not just the first attempt.
+        # In debug+ThreadFuzzer builds, the previous `clickhouse start` may
+        # have spawned a server that is still binding ports or crashing.
+        if [ "$counter" -gt 0 ]; then
+            wait_server_ports_free
+        fi
         # use root to match with current uid
         clickhouse start --user root >/var/log/clickhouse-server/stdout.log 2>>/var/log/clickhouse-server/stderr.log
-        sleep 20
+        sleep 10
         counter=$((counter + 1))
     done
 }

--- a/tests/docker_scripts/stress_tests.lib
+++ b/tests/docker_scripts/stress_tests.lib
@@ -313,14 +313,13 @@ function start_server()
             tail -n100000 /var/log/clickhouse-server/clickhouse-server.log | rg -F -v -e '<Warning> RaftInstance:' -e '<Information> RaftInstance' | tail -n100
             return 1
         fi
-        # Wait for ports before each retry, not just the first attempt.
-        # In debug+ThreadFuzzer builds, the previous `clickhouse start` may
-        # have spawned a server that is still binding ports or crashing.
-        if [ "$counter" -gt 0 ]; then
-            wait_server_ports_free
+        # Only wait for ports and restart if the previous daemon actually exited.
+        # If the process is still alive, the ports are bound by a healthy but
+        # slow-starting server — just retry the readiness check.
+        if [ "$counter" -eq 0 ] || ! pgrep -x clickhouse-serv > /dev/null 2>&1; then
+            [ "$counter" -gt 0 ] && wait_server_ports_free
+            clickhouse start --user root >/var/log/clickhouse-server/stdout.log 2>>/var/log/clickhouse-server/stderr.log
         fi
-        # use root to match with current uid
-        clickhouse start --user root >/var/log/clickhouse-server/stdout.log 2>>/var/log/clickhouse-server/stderr.log
         sleep 10
         counter=$((counter + 1))
     done


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

in stress tests. Fixes CI failures such as this one: https://d1k2gkhrlfqv31.cloudfront.net/clickhouse-test-reports-private/json.html?PR=59667&sha=latest&name_0=PR&name_1=Stress+test+%28amd_debug%2C+meta+in+keeper%29

Reduce sleep time after restart, because the wait before start is going to be longer. 40 seconds waiting for the server to start should be enough.

cc @maxknv @leshikus 

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.547`
<!-- ch-version-info:end -->