### PR TITLE
Do not swallow fatal errors (e.g. MEMORY_LIMIT_EXCEEDED) in tryDeserialize

### DIFF
--- a/src/DataTypes/Serializations/ISerialization.cpp
+++ b/src/DataTypes/Serializations/ISerialization.cpp
@@ -7,6 +7,7 @@
 #include <DataTypes/NestedUtils.h>
 #include <DataTypes/Serializations/ISerialization.h>
 #include <DataTypes/Serializations/SerializationObjectPool.h>
+#include <Formats/ParseError.h>
 #include <IO/Operators.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/WriteHelpers.h>
@@ -573,6 +574,7 @@ bool tryDeserializeText(const F deserialize, DB::IColumn & column)
     {
         if (column.size() > prev_size)
             column.popBack(column.size() - prev_size);
+        rethrowIfNotParseError();
         return false;
     }
 }

--- a/src/DataTypes/Serializations/SerializationArray.cpp
+++ b/src/DataTypes/Serializations/SerializationArray.cpp
@@ -15,6 +15,7 @@
 
 #include <Formats/FormatSettings.h>
 #include <Formats/JSONUtils.h>
+#include <Formats/ParseError.h>
 
 #include <algorithm>
 
@@ -655,6 +656,8 @@ static ReturnType deserializeTextImpl(IColumn & column, ReadBuffer & istr, Reade
             nested_column.popBack(size);
         if constexpr (throw_exception)
             throw;
+        /// Other errors (e.g. MEMORY_LIMIT_EXCEEDED) must propagate, not be reported as a failed parse.
+        rethrowIfNotParseError();
         return ReturnType(false);
     }
 

--- a/src/DataTypes/Serializations/SerializationCustomSimpleText.cpp
+++ b/src/DataTypes/Serializations/SerializationCustomSimpleText.cpp
@@ -1,5 +1,6 @@
 #include <DataTypes/Serializations/SerializationCustomSimpleText.h>
 
+#include <Formats/ParseError.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteBufferFromString.h>
@@ -49,6 +50,8 @@ bool SerializationCustomSimpleText::tryDeserializeText(DB::IColumn & column, DB:
     }
     catch (...) // Ok: tryDeserializeText is a try-pattern
     {
+        /// Other errors (e.g. MEMORY_LIMIT_EXCEEDED) must propagate, not be reported as a failed parse.
+        rethrowIfNotParseError();
         return false;
     }
 }

--- a/src/DataTypes/Serializations/SerializationFixedString.cpp
+++ b/src/DataTypes/Serializations/SerializationFixedString.cpp
@@ -5,6 +5,7 @@
 #include <Columns/ColumnConst.h>
 
 #include <Formats/FormatSettings.h>
+#include <Formats/ParseError.h>
 
 #include <IO/WriteBuffer.h>
 #include <IO/ReadHelpers.h>
@@ -211,6 +212,8 @@ static inline bool tryRead(const SerializationFixedString & self, IColumn & colu
     catch (...) // Ok: tryRead is a try-pattern
     {
         data.resize_assume_reserved(prev_size);
+        /// Other errors (e.g. MEMORY_LIMIT_EXCEEDED) must propagate, not be reported as a failed parse.
+        rethrowIfNotParseError();
         return false;
     }
 }

--- a/src/DataTypes/Serializations/SerializationMap.cpp
+++ b/src/DataTypes/Serializations/SerializationMap.cpp
@@ -17,6 +17,7 @@
 #include <Core/Field.h>
 #include <Formats/FormatSettings.h>
 #include <Formats/JSONUtils.h>
+#include <Formats/ParseError.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteBufferFromString.h>
@@ -284,6 +285,8 @@ ReturnType SerializationMap::deserializeTextImpl(IColumn & column, ReadBuffer & 
 
         if constexpr (throw_exception)
             throw;
+        /// Other errors (e.g. MEMORY_LIMIT_EXCEEDED) must propagate, not be reported as a failed parse.
+        rethrowIfNotParseError();
         return ReturnType(false);
     }
 

--- a/src/DataTypes/Serializations/SerializationNullable.cpp
+++ b/src/DataTypes/Serializations/SerializationNullable.cpp
@@ -8,6 +8,7 @@
 
 #include <Columns/ColumnNullable.h>
 #include <Core/Field.h>
+#include <Formats/ParseError.h>
 #include <IO/ReadBuffer.h>
 #include <IO/ReadHelpers.h>
 #include <IO/WriteBuffer.h>
@@ -237,6 +238,8 @@ ReturnType safeAppendToNullMap(ColumnNullable & column, bool is_null)
         column.getNestedColumn().popBack(1);
         if constexpr (std::is_same_v<ReturnType, void>)
             throw;
+        /// Other errors (e.g. MEMORY_LIMIT_EXCEEDED) must propagate, not be reported as a failed parse.
+        rethrowIfNotParseError();
         return ReturnType(false);
     }
 

--- a/src/DataTypes/Serializations/SerializationQBit.cpp
+++ b/src/DataTypes/Serializations/SerializationQBit.cpp
@@ -6,6 +6,7 @@
 #include <DataTypes/DataTypeQBit.h>
 #include <Common/SipHash.h>
 #include <DataTypes/Serializations/SerializationQBit.h>
+#include <Formats/ParseError.h>
 
 #include <IO/ReadBuffer.h>
 #include <IO/ReadHelpers.h>
@@ -118,6 +119,8 @@ static ReturnType addElementSafe(size_t num_elems, IColumn & column, F && impl)
         restore_elements();
         if constexpr (throw_exception)
             throw;
+        /// Other errors (e.g. MEMORY_LIMIT_EXCEEDED) must propagate, not be reported as a failed parse.
+        rethrowIfNotParseError();
         return ReturnType(false);
     }
 

--- a/src/DataTypes/Serializations/SerializationString.cpp
+++ b/src/DataTypes/Serializations/SerializationString.cpp
@@ -9,6 +9,7 @@
 #include <DataTypes/Serializations/SerializationNumber.h>
 #include <DataTypes/Serializations/SerializationStringSize.h>
 #include <Formats/FormatSettings.h>
+#include <Formats/ParseError.h>
 #include <IO/ReadBufferFromString.h>
 #include <IO/ReadHelpers.h>
 #include <IO/VarInt.h>
@@ -433,7 +434,9 @@ static inline ReturnType read(IColumn & column, Reader && reader)
         restore_column();
         if constexpr (throw_exception)
             throw;
-        else
+        /// Other errors (e.g. MEMORY_LIMIT_EXCEEDED) must propagate, not be reported as a failed parse.
+        rethrowIfNotParseError();
+        if constexpr (!throw_exception)
             return false;
     }
 }

--- a/src/DataTypes/Serializations/SerializationTuple.cpp
+++ b/src/DataTypes/Serializations/SerializationTuple.cpp
@@ -7,6 +7,7 @@
 #include <Columns/ColumnTuple.h>
 #include <Common/assert_cast.h>
 #include <Formats/JSONUtils.h>
+#include <Formats/ParseError.h>
 #include <IO/WriteHelpers.h>
 #include <IO/ReadHelpers.h>
 #include <IO/ReadBufferFromString.h>
@@ -146,6 +147,10 @@ static ReturnType addElementSafe(size_t num_elems, IColumn & column, F && impl)
         restore_elements();
         if constexpr (throw_exception)
             throw;
+        /// Only a genuine parse failure means "this value did not parse"; other errors
+        /// (e.g. MEMORY_LIMIT_EXCEEDED) must propagate instead of being reported as a
+        /// failed parse and silently turned into a default/skip.
+        rethrowIfNotParseError();
         return ReturnType(false);
     }
 

--- a/src/DataTypes/Serializations/SimpleTextSerialization.h
+++ b/src/DataTypes/Serializations/SimpleTextSerialization.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <DataTypes/Serializations/ISerialization.h>
+#include <Formats/ParseError.h>
 
 namespace DB
 {
@@ -94,6 +95,7 @@ protected:
         }
         catch (...) // Ok: tryDeserializeText is a try-pattern
         {
+            rethrowIfNotParseError();
             return false;
         }
     }

--- a/src/DataTypes/Serializations/tests/gtest_serialization_try_deserialize.cpp
+++ b/src/DataTypes/Serializations/tests/gtest_serialization_try_deserialize.cpp
@@ -1,0 +1,113 @@
+#include <DataTypes/Serializations/SimpleTextSerialization.h>
+#include <DataTypes/Serializations/SerializationArray.h>
+#include <Columns/ColumnArray.h>
+#include <Columns/ColumnsNumber.h>
+#include <Formats/FormatSettings.h>
+#include <IO/ReadBufferFromMemory.h>
+#include <Common/Exception.h>
+
+#include <gtest/gtest.h>
+
+using namespace DB;
+
+namespace DB::ErrorCodes
+{
+    extern const int MEMORY_LIMIT_EXCEEDED;
+    extern const int CANNOT_PARSE_NUMBER;
+    extern const int NOT_IMPLEMENTED;
+}
+
+namespace
+{
+
+/// A serialization whose deserializeText always throws the configured error code.
+/// Used to check that the tryDeserializeText "try-pattern" only swallows parse errors
+/// and rethrows everything else (e.g. MEMORY_LIMIT_EXCEEDED).
+class ThrowingSerialization : public SimpleTextSerialization
+{
+public:
+    explicit ThrowingSerialization(int code_) : code(code_) {}
+
+    /// Opt out of pooling so it can be wrapped without a precomputed hash.
+    bool supportsPooling() const override { return false; }
+
+    void deserializeText(IColumn &, ReadBuffer &, const FormatSettings &, bool) const override
+    {
+        throw Exception(code, "injected by ThrowingSerialization");
+    }
+
+    void serializeText(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override {}
+
+    void serializeBinary(const Field &, WriteBuffer &, const FormatSettings &) const override { notImplemented(); }
+    void deserializeBinary(Field &, ReadBuffer &, const FormatSettings &) const override { notImplemented(); }
+    void serializeBinary(const IColumn &, size_t, WriteBuffer &, const FormatSettings &) const override { notImplemented(); }
+    void deserializeBinary(IColumn &, ReadBuffer &, const FormatSettings &) const override { notImplemented(); }
+
+private:
+    int code;
+
+    [[noreturn]] static void notImplemented()
+    {
+        throw Exception(ErrorCodes::NOT_IMPLEMENTED, "Not implemented in ThrowingSerialization");
+    }
+};
+
+}
+
+/// A parse error means "this value did not parse" -> tryDeserialize returns false.
+/// Any other error (here MEMORY_LIMIT_EXCEEDED) is fatal and must propagate.
+TEST(SerializationTryDeserialize, RethrowsNonParseErrors)
+{
+    FormatSettings settings;
+
+    {
+        SerializationPtr serialization = std::make_shared<ThrowingSerialization>(ErrorCodes::CANNOT_PARSE_NUMBER);
+        auto column = ColumnUInt8::create();
+        ReadBufferFromMemory istr("x");
+        ASSERT_FALSE(serialization->tryDeserializeTextQuoted(*column, istr, settings));
+    }
+
+    {
+        SerializationPtr serialization = std::make_shared<ThrowingSerialization>(ErrorCodes::MEMORY_LIMIT_EXCEEDED);
+        auto column = ColumnUInt8::create();
+        ReadBufferFromMemory istr("x");
+        try
+        {
+            serialization->tryDeserializeTextQuoted(*column, istr, settings);
+            FAIL() << "tryDeserialize swallowed MEMORY_LIMIT_EXCEEDED";
+        }
+        catch (const Exception & e)
+        {
+            ASSERT_EQ(e.code(), ErrorCodes::MEMORY_LIMIT_EXCEEDED);
+        }
+    }
+}
+
+/// Same contract through a composite serialization, whose restore-on-failure catch must
+/// also rethrow fatal errors raised while deserializing a nested element.
+TEST(SerializationTryDeserialize, RethrowsNonParseErrorsFromNested)
+{
+    FormatSettings settings;
+
+    {
+        SerializationPtr serialization = SerializationArray::create(std::make_shared<ThrowingSerialization>(ErrorCodes::CANNOT_PARSE_NUMBER));
+        auto column = ColumnArray::create(ColumnUInt8::create());
+        ReadBufferFromMemory istr("[1]");
+        ASSERT_FALSE(serialization->tryDeserializeTextQuoted(*column, istr, settings));
+    }
+
+    {
+        SerializationPtr serialization = SerializationArray::create(std::make_shared<ThrowingSerialization>(ErrorCodes::MEMORY_LIMIT_EXCEEDED));
+        auto column = ColumnArray::create(ColumnUInt8::create());
+        ReadBufferFromMemory istr("[1]");
+        try
+        {
+            serialization->tryDeserializeTextQuoted(*column, istr, settings);
+            FAIL() << "tryDeserialize swallowed MEMORY_LIMIT_EXCEEDED from a nested element";
+        }
+        catch (const Exception & e)
+        {
+            ASSERT_EQ(e.code(), ErrorCodes::MEMORY_LIMIT_EXCEEDED);
+        }
+    }
+}

--- a/src/Formats/ParseError.cpp
+++ b/src/Formats/ParseError.cpp
@@ -1,0 +1,60 @@
+#include <Formats/ParseError.h>
+
+#include <Common/Exception.h>
+
+namespace DB
+{
+
+namespace ErrorCodes
+{
+    extern const int CANNOT_PARSE_INPUT_ASSERTION_FAILED;
+    extern const int CANNOT_PARSE_QUOTED_STRING;
+    extern const int CANNOT_PARSE_DATE;
+    extern const int CANNOT_PARSE_DATETIME;
+    extern const int CANNOT_PARSE_NUMBER;
+    extern const int CANNOT_PARSE_BOOL;
+    extern const int CANNOT_PARSE_UUID;
+    extern const int CANNOT_READ_ARRAY_FROM_TEXT;
+    extern const int CANNOT_READ_MAP_FROM_TEXT;
+    extern const int CANNOT_READ_ALL_DATA;
+    extern const int TOO_LARGE_STRING_SIZE;
+    extern const int ARGUMENT_OUT_OF_BOUND;
+    extern const int INCORRECT_DATA;
+    extern const int CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING;
+    extern const int CANNOT_PARSE_IPV4;
+    extern const int CANNOT_PARSE_IPV6;
+    extern const int UNKNOWN_ELEMENT_OF_ENUM;
+    extern const int CANNOT_PARSE_ESCAPE_SEQUENCE;
+    extern const int UNEXPECTED_DATA_AFTER_PARSED_VALUE;
+}
+
+bool isParseError(int code)
+{
+    return code == ErrorCodes::CANNOT_PARSE_INPUT_ASSERTION_FAILED
+        || code == ErrorCodes::CANNOT_PARSE_QUOTED_STRING
+        || code == ErrorCodes::CANNOT_PARSE_DATE
+        || code == ErrorCodes::CANNOT_PARSE_DATETIME
+        || code == ErrorCodes::CANNOT_PARSE_NUMBER
+        || code == ErrorCodes::CANNOT_PARSE_UUID
+        || code == ErrorCodes::CANNOT_PARSE_BOOL
+        || code == ErrorCodes::CANNOT_READ_ARRAY_FROM_TEXT
+        || code == ErrorCodes::CANNOT_READ_MAP_FROM_TEXT
+        || code == ErrorCodes::CANNOT_READ_ALL_DATA
+        || code == ErrorCodes::TOO_LARGE_STRING_SIZE
+        || code == ErrorCodes::ARGUMENT_OUT_OF_BOUND       /// For Decimals
+        || code == ErrorCodes::INCORRECT_DATA              /// For some ReadHelpers
+        || code == ErrorCodes::CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING
+        || code == ErrorCodes::CANNOT_PARSE_IPV4
+        || code == ErrorCodes::CANNOT_PARSE_IPV6
+        || code == ErrorCodes::UNKNOWN_ELEMENT_OF_ENUM
+        || code == ErrorCodes::CANNOT_PARSE_ESCAPE_SEQUENCE
+        || code == ErrorCodes::UNEXPECTED_DATA_AFTER_PARSED_VALUE;
+}
+
+void rethrowIfNotParseError()
+{
+    if (!isParseError(getCurrentExceptionCode()))
+        throw;
+}
+
+}

--- a/src/Formats/ParseError.h
+++ b/src/Formats/ParseError.h
@@ -1,0 +1,21 @@
+#pragma once
+
+namespace DB
+{
+
+/// Returns true if the error code corresponds to a recoverable error in the input data
+/// (a parsing error) rather than a fatal one (e.g. MEMORY_LIMIT_EXCEEDED).
+///
+/// It is used to decide whether a value can be treated as not parsed (skipped, replaced
+/// with a default, etc.) or whether the exception must propagate. In particular the
+/// deserialization code that restores a column after a failed read must rethrow
+/// non-parse errors instead of swallowing them.
+bool isParseError(int code);
+
+/// To be called from a `catch (...)` block of a `tryDeserialize` "try-pattern": if the
+/// currently handled exception is not a parse error (e.g. it is MEMORY_LIMIT_EXCEEDED),
+/// rethrow it, so that only genuine parse failures are reported as a not-parsed value.
+/// Must be called only while an exception is being handled.
+void rethrowIfNotParseError();
+
+}

--- a/src/Processors/Formats/IRowInputFormat.cpp
+++ b/src/Processors/Formats/IRowInputFormat.cpp
@@ -3,6 +3,7 @@
 #include <IO/WithFileSize.h>
 #include <IO/WriteHelpers.h> // toString
 #include <Processors/Formats/IRowInputFormat.h>
+#include <Formats/ParseError.h>
 #include <Common/logger_useful.h>
 
 
@@ -12,26 +13,7 @@ namespace DB
 namespace ErrorCodes
 {
     extern const int NOT_IMPLEMENTED;
-    extern const int CANNOT_PARSE_INPUT_ASSERTION_FAILED;
-    extern const int CANNOT_PARSE_QUOTED_STRING;
-    extern const int CANNOT_PARSE_DATE;
-    extern const int CANNOT_PARSE_DATETIME;
-    extern const int CANNOT_PARSE_NUMBER;
-    extern const int CANNOT_PARSE_BOOL;
-    extern const int CANNOT_PARSE_UUID;
-    extern const int CANNOT_READ_ARRAY_FROM_TEXT;
-    extern const int CANNOT_READ_MAP_FROM_TEXT;
-    extern const int CANNOT_READ_ALL_DATA;
-    extern const int TOO_LARGE_STRING_SIZE;
     extern const int INCORRECT_NUMBER_OF_COLUMNS;
-    extern const int ARGUMENT_OUT_OF_BOUND;
-    extern const int INCORRECT_DATA;
-    extern const int CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING;
-    extern const int CANNOT_PARSE_IPV4;
-    extern const int CANNOT_PARSE_IPV6;
-    extern const int UNKNOWN_ELEMENT_OF_ENUM;
-    extern const int CANNOT_PARSE_ESCAPE_SEQUENCE;
-    extern const int UNEXPECTED_DATA_AFTER_PARSED_VALUE;
     extern const int SOCKET_TIMEOUT;
     extern const int NETWORK_ERROR;
     extern const int CANNOT_READ_FROM_SOCKET;
@@ -39,29 +21,6 @@ namespace ErrorCodes
     extern const int UNEXPECTED_END_OF_FILE;
 }
 
-
-bool isParseError(int code)
-{
-    return code == ErrorCodes::CANNOT_PARSE_INPUT_ASSERTION_FAILED
-        || code == ErrorCodes::CANNOT_PARSE_QUOTED_STRING
-        || code == ErrorCodes::CANNOT_PARSE_DATE
-        || code == ErrorCodes::CANNOT_PARSE_DATETIME
-        || code == ErrorCodes::CANNOT_PARSE_NUMBER
-        || code == ErrorCodes::CANNOT_PARSE_UUID
-        || code == ErrorCodes::CANNOT_PARSE_BOOL
-        || code == ErrorCodes::CANNOT_READ_ARRAY_FROM_TEXT
-        || code == ErrorCodes::CANNOT_READ_MAP_FROM_TEXT
-        || code == ErrorCodes::CANNOT_READ_ALL_DATA
-        || code == ErrorCodes::TOO_LARGE_STRING_SIZE
-        || code == ErrorCodes::ARGUMENT_OUT_OF_BOUND       /// For Decimals
-        || code == ErrorCodes::INCORRECT_DATA              /// For some ReadHelpers
-        || code == ErrorCodes::CANNOT_PARSE_DOMAIN_VALUE_FROM_STRING
-        || code == ErrorCodes::CANNOT_PARSE_IPV4
-        || code == ErrorCodes::CANNOT_PARSE_IPV6
-        || code == ErrorCodes::UNKNOWN_ELEMENT_OF_ENUM
-        || code == ErrorCodes::CANNOT_PARSE_ESCAPE_SEQUENCE
-        || code == ErrorCodes::UNEXPECTED_DATA_AFTER_PARSED_VALUE;
-}
 
 static bool isConnectionError(int code)
 {

--- a/src/Processors/Formats/IRowInputFormat.h
+++ b/src/Processors/Formats/IRowInputFormat.h
@@ -37,7 +37,6 @@ struct RowInputFormatParams
     OverflowMode timeout_overflow_mode = OverflowMode::THROW;
 };
 
-bool isParseError(int code);
 bool checkTimeLimit(const RowInputFormatParams & params, const Stopwatch & stopwatch);
 
 /// Row oriented input format: reads data row by row.

--- a/src/Processors/Formats/Impl/ConstantExpressionTemplate.cpp
+++ b/src/Processors/Formats/Impl/ConstantExpressionTemplate.cpp
@@ -3,7 +3,9 @@
 #include <Columns/ColumnMap.h>
 #include <Columns/ColumnsNumber.h>
 #include <Common/SipHash.h>
+#include <Core/BlockMissingValues.h>
 #include <Formats/FormatSettings.h>
+#include <Formats/ParseError.h>
 #include <Core/Settings.h>
 #include <DataTypes/DataTypesNumber.h>
 #include <DataTypes/DataTypeNullable.h>
@@ -12,7 +14,6 @@
 #include <DataTypes/DataTypeTuple.h>
 #include <DataTypes/DataTypeMap.h>
 #include <DataTypes/FieldToDataType.h>
-#include <Processors/Formats/IRowInputFormat.h>
 #include <Functions/FunctionFactory.h>
 #include <Interpreters/ExpressionAnalyzer.h>
 #include <Interpreters/ExpressionActions.h>

--- a/src/Processors/Formats/Impl/ConstantExpressionTemplate.h
+++ b/src/Processors/Formats/Impl/ConstantExpressionTemplate.h
@@ -19,6 +19,8 @@ using ExpressionActionsPtr = std::shared_ptr<ExpressionActions>;
 struct FormatSettings;
 struct Settings;
 
+class BlockMissingValues;
+
 /// Deduces template of an expression by replacing literals with dummy columns.
 /// It allows to parse and evaluate similar expressions without using heavy IParsers and ExpressionAnalyzer.
 /// Using ConstantExpressionTemplate for one expression is slower then evaluateConstantExpression(...),

--- a/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
+++ b/src/Processors/Formats/Impl/ValuesBlockInputFormat.cpp
@@ -8,6 +8,7 @@
 #include <Processors/Formats/Impl/ValuesBlockInputFormat.h>
 #include <Formats/FormatFactory.h>
 #include <Formats/EscapingRuleUtils.h>
+#include <Formats/ParseError.h>
 #include <Core/Block.h>
 #include <base/find_symbols.h>
 #include <Common/typeid_cast.h>

--- a/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
+++ b/src/Storages/Statistics/ConditionSelectivityEstimator.cpp
@@ -17,7 +17,7 @@
 #include <Storages/StorageInMemoryMetadata.h>
 #include <Storages/MergeTree/RPNBuilder.h>
 #include <Storages/MergeTree/IMergeTreeDataPart.h>
-#include <Processors/Formats/IRowInputFormat.h>
+#include <Formats/ParseError.h>
 
 
 namespace DB


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Do not swallow fatal errors (e.g. MEMORY_LIMIT_EXCEEDED) in tryDeserialize
