### PR TITLE
Add test: Out-of-range index throw in refactored `vectorConstant` (non-const haystack + const index) is untested

### DIFF
--- a/tests/queries/0_stateless/04308_regexp_extract_vector_constant_oob.reference
+++ b/tests/queries/0_stateless/04308_regexp_extract_vector_constant_oob.reference
@@ -1,0 +1,11 @@
+-- { echoOn }
+-- Out-of-range index through the vectorConstant path: non-const haystack + const index.
+-- (The const-haystack form folds into a different internal path via default-impl-for-constants.)
+select regexpExtract(materialize('100-200'), '\\d+', 1); -- { serverError INDEX_OF_POSITIONAL_ARGUMENT_IS_OUT_OF_RANGE }
+select regexpExtract(materialize('100-200'), '\\d+', -1); -- { serverError INDEX_OF_POSITIONAL_ARGUMENT_IS_OUT_OF_RANGE }
+select regexpExtract(materialize('100-200'), '(\\d+)-(\\d+)', 3); -- { serverError INDEX_OF_POSITIONAL_ARGUMENT_IS_OUT_OF_RANGE }
+-- A valid in-range index on the same path still returns the match.
+select regexpExtract(materialize('100-200'), '(\\d+)-(\\d+)', 0);
+100-200
+select regexpExtract(materialize('100-200'), '\\d+', 0);
+100

--- a/tests/queries/0_stateless/04308_regexp_extract_vector_constant_oob.sql
+++ b/tests/queries/0_stateless/04308_regexp_extract_vector_constant_oob.sql
@@ -1,0 +1,10 @@
+-- { echoOn }
+-- Out-of-range index through the vectorConstant path: non-const haystack + const index.
+-- (The const-haystack form folds into a different internal path via default-impl-for-constants.)
+select regexpExtract(materialize('100-200'), '\\d+', 1); -- { serverError INDEX_OF_POSITIONAL_ARGUMENT_IS_OUT_OF_RANGE }
+select regexpExtract(materialize('100-200'), '\\d+', -1); -- { serverError INDEX_OF_POSITIONAL_ARGUMENT_IS_OUT_OF_RANGE }
+select regexpExtract(materialize('100-200'), '(\\d+)-(\\d+)', 3); -- { serverError INDEX_OF_POSITIONAL_ARGUMENT_IS_OUT_OF_RANGE }
+-- A valid in-range index on the same path still returns the match.
+select regexpExtract(materialize('100-200'), '(\\d+)-(\\d+)', 0);
+select regexpExtract(materialize('100-200'), '\\d+', 0);
+-- { echoOff }


### PR DESCRIPTION
_Found via ClickGap automated review. Please close or comment if this is incorrect or needs adjustment._

_This is a test-only PR — no source code changes. Please review: test quality, whether the claimed coverage gaps are real, and whether test output makes sense._

Adds test coverage for 1 untested code path(s), found during automated review of [PR #106374](https://github.com/ClickHouse/ClickHouse/pull/106374).
That PR (1) The PR makes `regexpExtract(haystack, pattern)` (two-arg form) default the group index to `0` (whole match) when `pattern` has no capturing group, instead of `1` (which was out-of-range and threw `INDEX_OF_POSITIONAL_ARGUMENT_IS_OUT_OF_RANGE`). The change is localized to `vectorConstant`, whose 

**1. Out-of-range index throw in refactored `vectorConstant` (non-const haystack + const index) is untested**
  `src/Functions/regexpExtract.cpp:144`
  **Risk:** Call chain: `executeImpl` (line 96, non-const haystack + const index, `isColumnConst` true) -> `vectorConstant` -> `index = index_arg.value_or(...)` (line 143, refactored) -> `if (index < 0 || index >= capture + 1) throw` (line 144). The PR refactored exactly this function but its out-of-range test uses a const haystack, which `useDefaultImplementationForConstants` folds into the `vectorVector` path instead. RISK: if the refactor regressed the bounds check, an explicit out-of-range index on …
  **What's unique vs PR tests:** The PR's out-of-range assertion `regexpExtract('100-200', '\d+', 1)` uses a const haystack, which `useDefaultImplementationForConstants` folds into the `vectorVector` path (throw at line 196). This test uses a materialized (non-const) haystack with a const index, the only input shape that reaches the `vectorConstant` throw at lines 144-146 — the function the PR actually refactored — which the LLVM report confirms is otherwise uncovered.
  [Try it on ClickHouse Fiddle](https://fiddle.clickhouse.com/53fa9834-e1ff-4781-8b7f-f4b791886f17)

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Not applicable — test-only change.

### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)