### PR TITLE
Surface the function-fuzzer SQL repro in Praktika gtest crash reports

### DIFF
--- a/ci/praktika/result.py
+++ b/ci/praktika/result.py
@@ -781,12 +781,24 @@ class Result(MetaClasses.Serializable):
             # Covers sanitizer reports ("SUMMARY:") and ClickHouse logical errors.
             _ERROR_PREFIXES = ("SUMMARY:", "Logical error:", "Code: ", "Signal description:")
             crash_info = ""
+            # Some gtests (e.g. the function property fuzzer, gtest_functions_stress) log the
+            # offending call as a runnable SQL query right before crashing, via
+            # logCurrentOperation: "(while executing: SELECT f(...);)". Surface it next to the
+            # error so the report shows a copy-pasteable repro instead of just the message.
+            repro_info = ""
+            _REPRO_MAX_LEN = 8192
             if result.files:
                 log_content = Shell.get_output(f"cat {result.files[0]}", verbose=False)
                 for line in log_content.splitlines():
-                    if any(line.startswith(p) for p in _ERROR_PREFIXES):
+                    if not crash_info and any(line.startswith(p) for p in _ERROR_PREFIXES):
                         crash_info = line
+                    if not repro_info and line.startswith("(while ") and "SELECT " in line:
+                        repro_info = line
+                        if len(repro_info) > _REPRO_MAX_LEN:
+                            repro_info = repro_info[:_REPRO_MAX_LEN] + " ... (truncated, see log)"
+                    if crash_info and repro_info:
                         break
+            crash_info = "\n".join(p for p in (crash_info, repro_info) if p)
             result.info = crash_info or info
             # Synthesize a failed sub-result so the job summary is not empty.
             crashed_test = gtest_filter.rstrip(".*") or "unknown"


### PR DESCRIPTION
When a unit-test (gtest) binary is killed before it can write its JSON results — e.g. a `LOGICAL_ERROR` aborts the process under a sanitizer — `Result.from_gtest_run` extracted only the first error line from the log, so the report card showed just the message (for example `Logical error: 'Unsupported argument types for function geohashesInBox : Float32, Float32, Float32, Float32.'`) with no way to reproduce it.

The function property fuzzer (`gtest_functions_stress`) already logs the offending call as a runnable query via `logCurrentOperation`, e.g. `(while executing: SELECT geohashesInBox(...);)`, but that line was buried in the job log and never surfaced on the report.

This also captures that `(while ... SELECT ...)` line and shows it next to the error, so the report card carries a copy-pasteable repro. The behavior is unchanged for all other gtests (they emit no such line), and the repro is capped at 8 KB to keep the card readable.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.556`
<!-- ch-version-info:end -->