### PR TITLE
Fix Jepsen Keeper counter workload: coerce values to Long

### DIFF
--- a/tests/jepsen.clickhouse/src/jepsen/clickhouse/keeper/counter.clj
+++ b/tests/jepsen.clickhouse/src/jepsen/clickhouse/keeper/counter.clj
@@ -4,7 +4,8 @@
    [jepsen
     [checker :as checker]
     [client :as client]
-    [generator :as gen]]
+    [generator :as gen]
+    [history :as h]]
    [jepsen.clickhouse.keeper.utils :refer :all]
    [jepsen.clickhouse.utils :as chu]
    [zookeeper :as zk])
@@ -12,7 +13,7 @@
 
 (def root-path "/counter")
 (defn r   [_ _] {:type :invoke, :f :read})
-(defn add [_ _] {:type :invoke, :f :add, :value (rand-int 5)})
+(defn add [_ _] {:type :invoke, :f :add, :value (long (rand-int 5))})
 
 (defrecord CounterClient [conn nodename]
   client/Client
@@ -31,11 +32,11 @@
       :read (try
              (assoc op
                :type :ok
-               :value (count (zk-list conn root-path)))
+               :value (long (count (zk-list conn root-path))))
              (catch Exception _ (assoc op :type :info, :error :connect-error)))
       :final-read (chu/exec-with-retries 30 (fn [] (assoc op
                                                      :type :ok
-                                                     :value (count (zk-list conn root-path)))))
+                                                     :value (long (count (zk-list conn root-path))))))
       :add (try
              (do
                (zk-multi-create-many-seq-nodes conn (concat-path root-path "seq-") (:value op) :with-acl (:with-auth test))
@@ -47,12 +48,23 @@
   (close! [_ test]
     (zk/close conn)))
 
+(defn counter-checker
+  "jepsen 0.3.11's `checker/counter` asserts that every operation's `:value` is
+  `nil` or a `Long` (checker.clj:801), which trips on nemesis operations that
+  carry non-Long values (partition grudges, node lists, keywords). Restrict the
+  check to client operations so only counter reads and adds are inspected."
+  []
+  (let [c (checker/counter)]
+    (reify checker/Checker
+      (check [_ test history opts]
+        (checker/check c test (h/client-ops history) opts)))))
+
 (defn workload
   "A generator, client, and checker for a set test."
   [opts]
   {:client    (CounterClient. nil nil)
    :checker   (checker/compose
-                {:counter (checker/counter)
+                {:counter (counter-checker)
                  :perf    (checker/perf)})
    :generator (gen/mix [r add])
    :final-generator (gen/once {:type :invoke, :f :final-read, :value nil})})


### PR DESCRIPTION
Fixes the `counter` workload failures in the `NightlyJepsen` / `ClickHouse Keeper Jepsen` check.

The Jepsen `counter` checker (`jepsen.checker/counter`) asserts that every recorded value is `nil` or a `Long`. The Keeper counter workload emitted Java `Integer` values — `:read`/`:final-read` via `count` and `:add` via `rand-int` — so the checker raised `AssertionError: Assert failed: (or (nil? value) (instance? Long value))` and every `counter` test was reported as `:valid? :unknown` (the checker errored during analysis; Keeper itself did not violate linearizability — all other workloads `set`, `unique-ids`, `total-queue` passed). Coercing the values with `long` makes them `java.lang.Long` and satisfies the checker.

This is a test-harness incompatibility surfaced by the recent Jepsen dependency update, not a Keeper correctness issue.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=5218d12d727632bbb5d2691f126d9841ce11a0f0&name_0=NightlyJepsen&name_1=ClickHouse%20Keeper%20Jepsen

Related: https://github.com/ClickHouse/ClickHouse/pull/106392

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not required (CI fix).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.560`
<!-- ch-version-info:end -->