### PR TITLE
CI: pin Jepsen docker images to digest tags

### DIFF
--- a/ci/jobs/jepsen_check.py
+++ b/ci/jobs/jepsen_check.py
@@ -178,58 +178,81 @@ def main():
         logging.info("Not jepsen test label in labels list, skipping")
         sys.exit(0)
 
+    image_name = KEEPER_IMAGE_NAME if args.program == "keeper" else SERVER_IMAGE_NAME
+    # Pull by the immutable praktika digest tag instead of mutable ":latest".
+    # Jepsen runs docker directly, so use the architecture-specific tag built by praktika.
+    docker_tag = info.docker_tag(image_name)
+    if docker_tag:
+        if Utils.is_arm():
+            docker_tag += "_arm"
+        elif Utils.is_amd():
+            docker_tag += "_amd"
+        else:
+            raise RuntimeError("Unsupported CPU architecture")
+        docker_image = f"{image_name}:{docker_tag}"
+    else:
+        if not info.is_local_run:
+            raise RuntimeError(
+                f"No praktika digest tag for image [{image_name}] "
+                f"in workflow [{info.workflow_name}]"
+            )
+        logging.warning(
+            "No praktika digest tag for %s in local run; falling back to mutable ':latest' "
+            "(may be served stale through the pull-through cache)",
+            image_name,
+        )
+        docker_image = image_name
+
     temp_path.mkdir(parents=True, exist_ok=True)
 
     result_path = temp_path / "result_path"
     result_path.mkdir(parents=True, exist_ok=True)
 
-    instances = prepare_autoscaling_group_and_get_hostnames(
-        KEEPER_DESIRED_INSTANCE_COUNT
-        if args.program == "keeper"
-        else SERVER_DESIRED_INSTANCE_COUNT
-    )
-    nodes_path = save_nodes_to_file(
-        instances[:KEEPER_DESIRED_INSTANCE_COUNT], temp_path
-    )
-
-    # always use latest
-    docker_image = KEEPER_IMAGE_NAME if args.program == "keeper" else SERVER_IMAGE_NAME
-
-    # build amd_binary assumed to be always ready on the master as it's part of the merge queue workflow
-    urls = read_build_urls(temp_path, "amd_binary")
-    build_url = None
-    for url in urls:
-        if url.endswith("clickhouse"):
-            build_url = url
-    assert build_url, "No build url found in the report"
-
-    extra_args = ""
-    if args.program == "server":
-        extra_args = f"-e KEEPER_NODE={instances[-1]}"
-
-    ssh_key_secret = Secret.Config(
-        name="jepsen_ssh_key", type=Secret.Type.AWS_SSM_PARAMETER
-    )
-    with SSHKey(key_value=ssh_key_secret.get_value() + "\n"):
-        ssh_auth_sock = os.environ["SSH_AUTH_SOCK"]
-        auth_sock_dir = os.path.dirname(ssh_auth_sock)
-        cmd = get_run_command(
-            ssh_auth_sock,
-            auth_sock_dir,
-            info,
-            nodes_path,
-            Utils.cwd(),
-            build_url,
-            result_path,
-            extra_args,
-            docker_image,
+    try:
+        instances = prepare_autoscaling_group_and_get_hostnames(
+            KEEPER_DESIRED_INSTANCE_COUNT
+            if args.program == "keeper"
+            else SERVER_DESIRED_INSTANCE_COUNT
         )
-        logging.info("Going to run jepsen: %s", cmd)
+        nodes_path = save_nodes_to_file(
+            instances[:KEEPER_DESIRED_INSTANCE_COUNT], temp_path
+        )
 
-        if Shell.run(cmd) != 0:
-            logging.error("Jepsen run command failed")
+        # build amd_binary assumed to be always ready on the master as it's part of the merge queue workflow
+        urls = read_build_urls(temp_path, "amd_binary")
+        build_url = None
+        for url in urls:
+            if url.endswith("clickhouse"):
+                build_url = url
+        assert build_url, "No build url found in the report"
 
-    clear_autoscaling_group()
+        extra_args = ""
+        if args.program == "server":
+            extra_args = f"-e KEEPER_NODE={instances[-1]}"
+
+        ssh_key_secret = Secret.Config(
+            name="jepsen_ssh_key", type=Secret.Type.AWS_SSM_PARAMETER
+        )
+        with SSHKey(key_value=ssh_key_secret.get_value() + "\n"):
+            ssh_auth_sock = os.environ["SSH_AUTH_SOCK"]
+            auth_sock_dir = os.path.dirname(ssh_auth_sock)
+            cmd = get_run_command(
+                ssh_auth_sock,
+                auth_sock_dir,
+                info,
+                nodes_path,
+                Utils.cwd(),
+                build_url,
+                result_path,
+                extra_args,
+                docker_image,
+            )
+            logging.info("Going to run jepsen: %s", cmd)
+
+            if Shell.run(cmd) != 0:
+                logging.error("Jepsen run command failed")
+    finally:
+        clear_autoscaling_group()
 
     status = Result.Status.OK
     description = "No invalid analysis found ヽ(‘ー`)ノ"


### PR DESCRIPTION
Pin the Jepsen docker images to their immutable praktika digest tags instead of the mutable `:latest` tag.

The Jepsen jobs run `docker run` against `:latest`, which the CI registry mirror can serve stale after a rebuild — so the job runs an outdated image. Resolve the image by its digest tag via `Info.docker_tag` plus the runner architecture suffix (`<image>:<digest>_amd` / `_arm`), the same way `run_in_docker` jobs do. Fail closed in CI when no digest tag is available instead of silently using `:latest`; keep the bare-name fallback only for local runs.

Also move `clear_autoscaling_group` into a `finally` block so the autoscaling group is torn down on every exit path, not only on success.

CI report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=5218d12d727632bbb5d2691f126d9841ce11a0f0&name_0=NightlyJepsen&name_1=ClickHouse%20Keeper%20Jepsen

Related: https://github.com/ClickHouse/ClickHouse/pull/106834

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Not required (CI fix).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.567`
<!-- ch-version-info:end -->