### PR TITLE
Fix flaky UniqueKeyIndexCache.InsertLookupAndHitMissCounters

### DIFF
--- a/src/Storages/MergeTree/tests/gtest_unique_key_index_cache.cpp
+++ b/src/Storages/MergeTree/tests/gtest_unique_key_index_cache.cpp
@@ -3,6 +3,7 @@
 #include "config.h"
 
 #include <Storages/MergeTree/UniqueKey/UniqueKeyIndexCache.h>
+#include <Common/CurrentThread.h>
 #include <Common/ProfileEvents.h>
 
 #include <atomic>
@@ -54,8 +55,9 @@ TEST(UniqueKeyIndexCache, InsertLookupAndHitMissCounters)
 {
     UniqueKeyIndexCache cache = makeCache(1 << 20);
 
-    const auto hits_before = ProfileEvents::global_counters[ProfileEvents::UniqueKeyIndexCacheHits].load();
-    const auto misses_before = ProfileEvents::global_counters[ProfileEvents::UniqueKeyIndexCacheMisses].load();
+    auto & counters = CurrentThread::getProfileEvents();
+    const auto hits_before = counters[ProfileEvents::UniqueKeyIndexCacheHits].load();
+    const auto misses_before = counters[ProfileEvents::UniqueKeyIndexCacheMisses].load();
 
     auto * obj = new FakeObject{nullptr, 42};
     rocksdb::Slice key("key-1");
@@ -74,15 +76,8 @@ TEST(UniqueKeyIndexCache, InsertLookupAndHitMissCounters)
                                rocksdb::Cache::Priority::LOW, nullptr);
     EXPECT_EQ(miss, nullptr);
 
-    /// Coverage build's ProfileEvents propagate into a thread-local subtree
-    /// that doesn't reach `global_counters`; deltas read 0 there only.
-#if !WITH_COVERAGE
-    EXPECT_EQ(ProfileEvents::global_counters[ProfileEvents::UniqueKeyIndexCacheHits].load() - hits_before, 1u);
-    EXPECT_EQ(ProfileEvents::global_counters[ProfileEvents::UniqueKeyIndexCacheMisses].load() - misses_before, 1u);
-#else
-    (void)hits_before;
-    (void)misses_before;
-#endif
+    EXPECT_EQ(counters[ProfileEvents::UniqueKeyIndexCacheHits].load() - hits_before, 1u);
+    EXPECT_EQ(counters[ProfileEvents::UniqueKeyIndexCacheMisses].load() - misses_before, 1u);
 
     cache.Release(lh, /*erase_if_last_ref=*/false);
     cache.Release(ih, /*erase_if_last_ref=*/false);


### PR DESCRIPTION
Caused by: https://github.com/ClickHouse/ClickHouse/pull/104282

Fixes the flaky test `UniqueKeyIndexCache.InsertLookupAndHitMissCounters`.

### Root cause

The test reads hit/miss deltas from `ProfileEvents::global_counters`, but `ProfileEvents::increment` (called inside `UniqueKeyIndexCache::Lookup`) routes through `CurrentThread::getProfileEvents`:

```cpp
return current_thread ? *current_thread->current_performance_counters : ProfileEvents::global_counters;
```

The increment reaches `global_counters` only when no `ThreadStatus` is attached to the current thread.

All gtests in `unit_tests_dbms` run on a single main thread, and some tests attach a `ThreadStatus` to it that persists for the rest of the binary - for example `gtest_filecache` sets `current_thread = MainThreadStatus::get()` and never clears it. Once that has happened, the `UniqueKeyIndexCache` increments land in that thread's `current_performance_counters` subtree, which does not propagate to `global_counters`, so the deltas the test reads are `0` instead of `1` and the assertions fail.

Whether this happens depends purely on gtest execution order, and CI runs with `--gtest_shuffle`, which is why the failure is flaky. The pre-existing `WITH_COVERAGE` guard in the test was a partial workaround for the same underlying issue (coverage builds always set up a thread-local subtree).

### Fix

Read the deltas from `CurrentThread::getProfileEvents` - the exact `Counters` object the increment targets - so the assertion is correct whether or not a `ThreadStatus` is attached to the main thread. This also makes the `WITH_COVERAGE` special case unnecessary, so it is removed.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Documentation entry for user-facing changes
- [ ] No documentation needed.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.573`
<!-- ch-version-info:end -->