### PR TITLE
Setting to use blob endpoint instead of dfs

### DIFF
--- a/src/Databases/DataLake/DatabaseDataLake.cpp
+++ b/src/Databases/DataLake/DatabaseDataLake.cpp
@@ -71,6 +71,7 @@ namespace DatabaseDataLakeSetting
     extern const DatabaseDataLakeSettingsString onelake_tenant_id;
     extern const DatabaseDataLakeSettingsString onelake_client_id;
     extern const DatabaseDataLakeSettingsString onelake_client_secret;
+    extern const DatabaseDataLakeSettingsBool onelake_use_blob_endpoint;
     extern const DatabaseDataLakeSettingsString dlf_access_key_id;
     extern const DatabaseDataLakeSettingsString dlf_access_key_secret;
     extern const DatabaseDataLakeSettingsString google_project_id;
@@ -630,7 +631,8 @@ StoragePtr DatabaseDataLake::tryGetTableImpl(const String & name, ContextPtr con
         azure_configuration->setInitializationAsOneLake(
             rest_catalog->getClientId(),
             rest_catalog->getClientSecret(),
-            rest_catalog->getTenantId()
+            rest_catalog->getTenantId(),
+            settings[DatabaseDataLakeSetting::onelake_use_blob_endpoint].value
         );
 #else
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Server does not contain support for storage type Azure for Iceberg OneLake catalog");

--- a/src/Databases/DataLake/DatabaseDataLakeSettings.cpp
+++ b/src/Databases/DataLake/DatabaseDataLakeSettings.cpp
@@ -35,6 +35,7 @@ namespace ErrorCodes
     DECLARE(String, onelake_tenant_id, "", "Tenant id from azure", 0) \
     DECLARE(String, onelake_client_id, "", "Client id from azure", 0) \
     DECLARE(String, onelake_client_secret, "", "Client secret from azure", 0) \
+    DECLARE(Bool, onelake_use_blob_endpoint, true, "Use the Blob endpoint (.blob.fabric.microsoft.com) for OneLake. When disabled, the DFS endpoint (.dfs.fabric.microsoft.com) is used instead", 0) \
     DECLARE(String, google_project_id, "", "Google Cloud project ID for BigLake. Required for BigLake catalog. Used in x-goog-user-project header. If not set and google_adc_quota_project_id is provided, it latter will be used", 0) \
     DECLARE(String, google_service_account, "", "Google Cloud service account email for metadata service authentication. Default: 'default'. Only used when ADC credentials are not provided", 0) \
     DECLARE(String, google_metadata_service, "", "Google Cloud metadata service endpoint for token retrieval. Default: 'metadata.google.internal'. Only used when ADC credentials are not provided", 0) \

--- a/src/Storages/ObjectStorage/Azure/Configuration.cpp
+++ b/src/Storages/ObjectStorage/Azure/Configuration.cpp
@@ -347,14 +347,15 @@ void AzureStorageParsedArguments::fromDisk(DiskPtr disk, ASTs & args, ContextPtr
         structure = *parsing_result.structure;
 }
 
-void AzureStorageParsedArguments::initializeForOneLake(ASTs & args, ContextPtr context)
+void AzureStorageParsedArguments::initializeForOneLake(ASTs & args, ContextPtr context, bool use_blob_endpoint)
 {
     if (args.size() != 1)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "Only one argument should be provided in OneLake catalog");
 
     String connection_url = checkAndGetLiteralArgument<String>(args[0], "connection_string/storage_account_url");
 
-    fillBlobsFromURLCommon(connection_url, ".com", ".dfs.fabric.microsoft.com");
+    const String full_suffix = use_blob_endpoint ? ".blob.fabric.microsoft.com" : ".dfs.fabric.microsoft.com";
+    fillBlobsFromURLCommon(connection_url, ".com", full_suffix);
 
     connection_params.endpoint.container_already_exists = true;
 
@@ -870,7 +871,7 @@ void StorageAzureConfiguration::fromAST(ASTs & engine_args, ContextPtr context, 
     AzureStorageParsedArguments parsed_arguments;
     if (!onelake_client_id.empty())
     {
-        parsed_arguments.initializeForOneLake(engine_args, context);
+        parsed_arguments.initializeForOneLake(engine_args, context, onelake_use_blob_endpoint);
         parsed_arguments.connection_params.auth_method = std::make_shared<Azure::Identity::ClientSecretCredential>(
             onelake_tenant_id,
             onelake_client_id,

--- a/src/Storages/ObjectStorage/Azure/Configuration.h
+++ b/src/Storages/ObjectStorage/Azure/Configuration.h
@@ -73,7 +73,7 @@ struct AzureStorageParsedArguments : private StorageParsedArguments
     void initializeForOneLake(
         ASTs & args,
         ContextPtr context,
-        bool use_blob_endpoint = true);
+        bool use_blob_endpoint);
 
     Path blob_path;
     AzureBlobStorage::ConnectionParams connection_params;

--- a/src/Storages/ObjectStorage/Azure/Configuration.h
+++ b/src/Storages/ObjectStorage/Azure/Configuration.h
@@ -72,7 +72,8 @@ struct AzureStorageParsedArguments : private StorageParsedArguments
     void fromAST(ASTs & args, ContextPtr context, bool with_structure);
     void initializeForOneLake(
         ASTs & args,
-        ContextPtr context);
+        ContextPtr context,
+        bool use_blob_endpoint = true);
 
     Path blob_path;
     AzureBlobStorage::ConnectionParams connection_params;
@@ -124,11 +125,12 @@ public:
         ContextPtr context,
         bool with_structure) override;
 
-    void setInitializationAsOneLake(const String & client_id_, const String & client_secret_, const String & tenant_id_)
+    void setInitializationAsOneLake(const String & client_id_, const String & client_secret_, const String & tenant_id_, bool use_blob_endpoint_)
     {
         onelake_client_id = client_id_;
         onelake_client_secret = client_secret_;
         onelake_tenant_id = tenant_id_;
+        onelake_use_blob_endpoint = use_blob_endpoint_;
     }
 
 protected:
@@ -146,6 +148,7 @@ private:
     String onelake_client_id;
     String onelake_client_secret;
     String onelake_tenant_id;
+    bool onelake_use_blob_endpoint = true;
 
     void initializeFromParsedArguments(const AzureStorageParsedArguments & parsed_arguments);
 };


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix `DataLakeCatalog` databases with `catalog_type = 'onelake'` reading table data by using the OneLake Blob endpoint (`.blob.fabric.microsoft.com`) by default. Set `onelake_use_blob_endpoint = false` to keep the previous DFS endpoint (`.dfs.fabric.microsoft.com`) behavior.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.591` (included in `26.6` and later)
- Backported to: `26.5.6.17`, `26.4.5.104`, `26.3.17.23`
<!-- ch-version-info:end -->