### PR TITLE
CI: Fix log parser 

### DIFF
--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -9,6 +9,11 @@ from ci.praktika.utils import Shell
 class FuzzerLogParser:
     UNKNOWN_ERROR = "Unknown error"
     MAX_INLINE_REPRODUCE_COMMANDS = 20
+    SANITIZER_ERROR_PATTERN = (
+        r"(SUMMARY|ERROR|WARNING): [a-zA-Z]+Sanitizer:.*|"
+        r".*[a-zA-Z]+Sanitizer: CHECK failed:.*"
+    )
+    RUNTIME_ERROR_PATTERN = r".*runtime error: .*|.*is located.*"
     SQL_COMMANDS = [
         "SELECT",
         "INSERT",
@@ -63,7 +68,7 @@ class FuzzerLogParser:
             (
                 "Sanitizer",
                 "is_sanitizer_error",
-                r"(SUMMARY|ERROR|WARNING): [a-zA-Z]+Sanitizer:.*",
+                self.SANITIZER_ERROR_PATTERN,
             ),
             ("Logical error", "is_logical_error", r"Logical error.*"),
             (
@@ -74,7 +79,7 @@ class FuzzerLogParser:
             (
                 "Runtime error",
                 "is_sanitizer_error",
-                r".*runtime error: .*|.*is located.*",
+                self.RUNTIME_ERROR_PATTERN,
             ),
             ("SegFault", "is_segfault", r"Segmentation fault.*"),
             (
@@ -294,7 +299,8 @@ class FuzzerLogParser:
         def _extract_sanitizer_trace(log_file):
             ansi_escape = re.compile(r"\x1b\[[0-9;]*m")
             sanitizer_start = re.compile(
-                r"(==\d+==\s*)?(ERROR|WARNING): \w+Sanitizer:|: runtime error: "
+                r"(==\d+==\s*)?(ERROR|WARNING): \w+Sanitizer:|"
+                r"\b\w+Sanitizer: CHECK failed:|: runtime error: "
             )
             summary_pattern = re.compile(r"SUMMARY: \w+Sanitizer:")
             # ClickHouse log line: "2024.01.15 12:34:56.789 [ 123 ] {id} <Level>"
@@ -308,6 +314,7 @@ class FuzzerLogParser:
             result_lines = []
             in_report = False
             is_runtime_error = False
+            is_check_failed_report = False
             consecutive_blank = 0
 
             for line in all_lines:
@@ -318,11 +325,16 @@ class FuzzerLogParser:
                     if sanitizer_start.search(clean_line):
                         in_report = True
                         is_runtime_error = ": runtime error: " in clean_line
+                        is_check_failed_report = (
+                            "Sanitizer: CHECK failed:" in clean_line
+                        )
                         result_lines.append(stripped)
                         consecutive_blank = 0
                 else:
                     if summary_pattern.search(stripped):
                         result_lines.append(stripped)
+                        break
+                    elif is_check_failed_report and not stripped:
                         break
                     elif not stripped:
                         consecutive_blank += 1

--- a/ci/jobs/scripts/log_parser.py
+++ b/ci/jobs/scripts/log_parser.py
@@ -152,10 +152,17 @@ class FuzzerLogParser:
                     substring = substring.strip().rstrip(".").strip("'\"")
                     format_message = substring
                 break
+        is_check_failed = bool(
+            error_lines and re.search(r"\w+Sanitizer: CHECK failed:", error_lines[0])
+        )
         # keep all lines before next log line
         for i, line in enumerate(error_lines):
             if "] {" in line and "} <" in line or line.startswith("    #"):
                 # it's a new log line or sanitizer frame - break
+                error_lines = error_lines[:i]
+                break
+            elif is_check_failed and not line.strip():
+                # CHECK failed reports end at the first blank line
                 error_lines = error_lines[:i]
                 break
         error_output = "\n".join(error_lines)

--- a/ci/tests/test_log_parser.py
+++ b/ci/tests/test_log_parser.py
@@ -1,0 +1,39 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.jobs.scripts.log_parser import FuzzerLogParser
+
+
+def test_parse_failure_prefers_asan_check_failed_over_server_assertion(tmp_path):
+    server_log = tmp_path / "clickhouse-server.err.log"
+    stderr_log = tmp_path / "stderr.log"
+
+    server_log.write_text(
+        "2026.06.09 00:00:00.000000 [ 1 ] {} <Fatal> Application: "
+        "Assertion 'px != 0' failed.\n",
+        encoding="utf-8",
+    )
+    stderr_log.write_text(
+        "AddressSanitizer: CHECK failed: sanitizer_allocator_secondary.h:200 "
+        "\"((nearest_chunk)) < ((h->map_beg + h->map_size))\" "
+        "(0x7b44c2461000, 0x0) (tid=3005)\n"
+        "    <empty stack>\n"
+        "\n"
+        "dpkg: error processing package clickhouse-server (--install):\n",
+        encoding="utf-8",
+    )
+
+    parser = FuzzerLogParser(
+        server_log=str(server_log),
+        stderr_log=str(stderr_log),
+        fuzzer_log="",
+    )
+
+    result_name, info, files = parser.parse_failure()
+
+    assert result_name == "AddressSanitizer (STID: None)"
+    assert "AddressSanitizer: CHECK failed:" in info
+    assert "Assertion 'px != 0' failed" not in info
+    assert files == []

--- a/ci/tests/test_log_parser.py
+++ b/ci/tests/test_log_parser.py
@@ -5,6 +5,22 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
 from ci.jobs.scripts.log_parser import FuzzerLogParser
 
+_ASAN_CHECK_FAILED_STDERR = """\
+==2138==WARNING: ASan doesn't fully support makecontext/swapcontext functions and may produce false positives in some cases!
+AddressSanitizer: CHECK failed: sanitizer_allocator_secondary.h:200 "((nearest_chunk)) < ((h->map_beg + h->map_size))" (0x7b44c2461000, 0x0) (tid=3005)
+    #0 0x55b9822b6021 in __asan::CheckUnwind() asan_rtl.cpp
+    #1 0x55b9822cedcb in __sanitizer::CheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) sanitizer_termination.cpp
+    #2 0x55b9b8db9bc7 in DB::ExceptionKeepingTransform::work() src/Processors/Transforms/ExceptionKeepingTransform.cpp:189:42
+    #3 0x55b9b85a724d in DB::executeJob(DB::ExecutingGraph::Node*, DB::ReadProgressCallback*) src/Processors/Executors/ExecutionThreadContext.cpp:54:28
+    #4 0x55b9b85a724d in DB::ExecutionThreadContext::executeTask() src/Processors/Executors/ExecutionThreadContext.cpp:103:9
+    #5 0x55b9b85728d8 in DB::PipelineExecutor::executeStepImpl(unsigned long, DB::IAcquiredSlot*, std::__1::atomic<bool>*) src/Processors/Executors/PipelineExecutor.cpp:363:26
+    #6 0x55b9b8571ae1 in DB::PipelineExecutor::executeStep(std::__1::atomic<bool>*) src/Processors/Executors/PipelineExecutor.cpp:191:5
+    #7 0x55b9b85cb318 in DB::PushingPipelineExecutor::finish() src/Processors/Executors/PushingPipelineExecutor.cpp:131:47
+    #8 0x7f4ae1fdb8cf  misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
+
+dpkg: error processing package clickhouse-server (--install):
+"""
+
 
 def test_parse_failure_prefers_asan_check_failed_over_server_assertion(tmp_path):
     server_log = tmp_path / "clickhouse-server.err.log"
@@ -36,4 +52,31 @@ def test_parse_failure_prefers_asan_check_failed_over_server_assertion(tmp_path)
     assert result_name == "AddressSanitizer (STID: None)"
     assert "AddressSanitizer: CHECK failed:" in info
     assert "Assertion 'px != 0' failed" not in info
+    assert "dpkg" not in info
+    assert files == []
+
+
+def test_parse_failure_asan_check_failed_with_stack_trace(tmp_path):
+    server_log = tmp_path / "clickhouse-server.err.log"
+    stderr_log = tmp_path / "stderr.log"
+
+    server_log.write_text(
+        "2026.06.09 00:00:00.000000 [ 1 ] {} <Fatal> Application: "
+        "Assertion 'px != 0' failed.\n",
+        encoding="utf-8",
+    )
+    stderr_log.write_text(_ASAN_CHECK_FAILED_STDERR, encoding="utf-8")
+
+    parser = FuzzerLogParser(
+        server_log=str(server_log),
+        stderr_log=str(stderr_log),
+        fuzzer_log="",
+    )
+
+    result_name, info, files = parser.parse_failure()
+
+    assert result_name == "AddressSanitizer (STID: 1288-3bd5)"
+    assert "AddressSanitizer: CHECK failed:" in info
+    assert "Assertion 'px != 0' failed" not in info
+    assert "dpkg" not in info
     assert files == []


### PR DESCRIPTION
When a fuzzer run produces a log where the server emits an `AddressSanitizer: CHECK failed: `error but also logs a generic server assertion failure, FuzzerLogParser was reporting the assertion as the failure type instead of the sanitizer error.

**Root cause:** the SANITIZER_ERROR_PATTERN regex only matched lines starting with (SUMMARY|ERROR|WARNING): \w+Sanitizer:, missing the \w+Sanitizer: CHECK failed: form that has no prefix keyword. Similarly, _extract_sanitizer_trace did not recognize CHECK failed: as a sanitizer report start marker.

Changes:

Extended SANITIZER_ERROR_PATTERN to also match \w+Sanitizer: CHECK failed: lines.
Updated _extract_sanitizer_trace to start a new report block on CHECK failed: lines.
Added is_check_failed_report flag: CHECK failed: reports end at the first blank line (no SUMMARY: trailer), so the extractor now terminates correctly.
Extracted both regex strings to named class constants (SANITIZER_ERROR_PATTERN, RUNTIME_ERROR_PATTERN) to eliminate duplication between the pattern table and _extract_sanitizer_trace.
Added a regression test in ci/tests/test_log_parser.py covering the mixed assertion + ASan CHECK failed case.


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.576`
<!-- ch-version-info:end -->