### PR TITLE
Fix logical error in `parseDateTime` with non-ASCII input bytes

### DIFF
--- a/src/Functions/parseDateTime.cpp
+++ b/src/Functions/parseDateTime.cpp
@@ -1014,8 +1014,8 @@ namespace
                         "Unable to parse fragment {} from {} because char {} is expected but {} provided",
                         fragment,
                         std::string_view(cur, end - cur),
-                        String(expected, 1),
-                        String(*cur, 1))
+                        String(1, expected),
+                        String(1, *cur))
 
                 ++cur;
                 return cur;
@@ -1034,7 +1034,7 @@ namespace
                         "Unable to parse fragment {} from {} because {} is not a number",
                         fragment,
                         std::string_view(cur, end - cur),
-                        String(*cur, 1))
+                        String(1, *cur))
 
                 ++cur;
                 return cur;

--- a/tests/queries/0_stateless/04324_parse_datetime_non_ascii.sql
+++ b/tests/queries/0_stateless/04324_parse_datetime_non_ascii.sql
@@ -1,0 +1,7 @@
+-- Regression test: parseDateTime with non-ASCII bytes in input/format must not cause
+-- a logical error (std::length_error) from String(char, 1) where a high-bit char
+-- is implicitly converted to a huge size_t count.
+
+SELECT parseDateTime(CAST('\xaed\xc6\xefwvA\xe6' AS String), CAST('%r2f\x820' AS String)); -- { serverError CANNOT_PARSE_DATETIME }
+SELECT parseDateTime('\x80', '%H'); -- { serverError CANNOT_PARSE_DATETIME }
+SELECT parseDateTime('12:\xff', '%H:%i'); -- { serverError CANNOT_PARSE_DATETIME }


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix logical error in `parseDateTime` with non-ASCII input bytes.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.812`
<!-- ch-version-info:end -->