### PR TITLE
Fix race between quorum failure cleanup and GET_PART queue entries.

### DIFF
--- a/src/Common/FailPoint.cpp
+++ b/src/Common/FailPoint.cpp
@@ -99,6 +99,7 @@ static struct InitFiu
     PAUSEABLE_ONCE(replicated_merge_tree_insert_retry_pause) \
     ONCE(replicated_merge_tree_restore_attach_retry) \
     PAUSEABLE_ONCE(finish_set_quorum_failed_parts) \
+    PAUSEABLE_ONCE(replicated_merge_tree_pause_before_mark_quorum_failed_try_multi) \
     PAUSEABLE_ONCE(finish_clean_quorum_failed_parts) \
     PAUSEABLE_ONCE(smt_wait_next_mutation) \
     PAUSEABLE_ONCE(delta_lake_metadata_iterate_pause) \

--- a/src/Storages/MergeTree/ReplicatedMergeTreePartCheckThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreePartCheckThread.cpp
@@ -544,6 +544,25 @@ bool ReplicatedMergeTreePartCheckThread::onPartIsLostForever(const String & part
         }
     }
 
+    if (lost_part_info.level == 0 && lost_part_info.mutation == 0)
+    {
+        auto zookeeper = storage.getZooKeeper();
+
+        if (storage.isQuorumFailedForPart(part_name, zookeeper))
+        {
+            LOG_INFO(log, "Part {} has failed quorum, will not create empty part.", part_name);
+            storage.queue.removeFailedQuorumPart(lost_part_info);
+            return true;
+        }
+
+        if (storage.isQuorumWritePendingForPart(part_name, zookeeper))
+        {
+            LOG_INFO(log, "Quorum write for part {} is still pending, will recheck later.", part_name);
+            enqueuePart(part_name, 30);
+            return true;
+        }
+    }
+
     ThreadFuzzer::maybeInjectSleep();
 
     if (storage.createEmptyPartInsteadOfLost(storage.getZooKeeper(), part_name))

--- a/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
+++ b/src/Storages/MergeTree/ReplicatedMergeTreeRestartingThread.cpp
@@ -286,6 +286,9 @@ void ReplicatedMergeTreeRestartingThread::removeFailedQuorumParts()
 
     for (const auto & part_name : failed_parts)
     {
+        auto part_info = MergeTreePartInfo::fromPartName(part_name, storage.format_version);
+        storage.queue.removeFailedQuorumPart(part_info);
+
         auto part = storage.getPartIfExists(
             part_name, {MergeTreeDataPartState::PreActive, MergeTreeDataPartState::Active, MergeTreeDataPartState::Outdated});
 
@@ -293,9 +296,10 @@ void ReplicatedMergeTreeRestartingThread::removeFailedQuorumParts()
         {
             LOG_DEBUG(log, "Found part {} with failed quorum. Moving to detached. This shouldn't happen often.", part_name);
             storage.forcefullyMovePartToDetachedAndRemoveFromMemory(part, "noquorum");
-            storage.queue.removeFailedQuorumPart(part->info);
         }
     }
+
+    storage.background_operations_assignee.trigger();
     FailPointInjection::disableFailPoint(FailPoints::finish_clean_quorum_failed_parts);
 }
 

--- a/src/Storages/StorageReplicatedMergeTree.cpp
+++ b/src/Storages/StorageReplicatedMergeTree.cpp
@@ -249,6 +249,7 @@ namespace FailPoints
     extern const char replicated_queue_fail_next_entry[];
     extern const char replicated_queue_unfail_entries[];
     extern const char finish_set_quorum_failed_parts[];
+    extern const char replicated_merge_tree_pause_before_mark_quorum_failed_try_multi[];
     extern const char zero_copy_lock_zk_fail_before_op[];
     extern const char zero_copy_lock_zk_fail_after_op[];
     extern const char zero_copy_unlock_zk_fail_before_op[];
@@ -2575,10 +2576,11 @@ bool StorageReplicatedMergeTree::executeLogEntry(LogEntry & entry)
 
     /// Perhaps we don't need this part, because during write with quorum, the quorum has failed
     /// (see below about `/quorum/failed_parts`).
-    if (entry.quorum && getZooKeeper()->exists(fs::path(zookeeper_path) / "quorum" / "failed_parts" / entry.new_part_name))
+    if (entry.quorum && isQuorumFailedForPart(entry.new_part_name, getZooKeeper()))
     {
         LOG_DEBUG(log, "Skipping action for part {} because quorum for that part was failed.", entry.new_part_name);
-        return true;    /// NOTE Deletion from `virtual_parts` is not done, but it is only necessary for merge.
+        queue.removeFailedQuorumPart(MergeTreePartInfo::fromPartName(entry.new_part_name, format_version));
+        return true;
     }
 
     switch (entry.type)
@@ -2708,6 +2710,7 @@ bool StorageReplicatedMergeTree::executeFetch(LogEntry & entry, bool need_to_che
                         }
 
                         Coordination::Responses responses;
+                        FailPointInjection::pauseFailPoint(FailPoints::replicated_merge_tree_pause_before_mark_quorum_failed_try_multi);
                         auto code = zookeeper->tryMulti(ops, responses);
 
                         if (code == Coordination::Error::ZOK)
@@ -2725,6 +2728,15 @@ bool StorageReplicatedMergeTree::executeFetch(LogEntry & entry, bool need_to_che
                                 "State was changed or isn't expected when trying to mark quorum for part {} as failed. Code: {}",
                                 entry.new_part_name,
                                 code);
+
+                            if ((code == Coordination::Error::ZNODEEXISTS || code == Coordination::Error::ZNONODE)
+                                && isQuorumFailedForPart(entry.new_part_name, zookeeper))
+                            {
+                                LOG_DEBUG(log, "Quorum for part {} was marked as failed by another replica.", entry.new_part_name);
+                                FailPointInjection::disableFailPoint(FailPoints::finish_set_quorum_failed_parts);
+                                queue.removeFailedQuorumPart(part_info);
+                                return true;
+                            }
                         }
                         else
                             throw Coordination::Exception(code);
@@ -11157,6 +11169,33 @@ bool StorageReplicatedMergeTree::checkIfDetachedPartitionExists(const String & p
                 return true;
         }
     }
+    return false;
+}
+
+
+bool StorageReplicatedMergeTree::isQuorumFailedForPart(const String & part_name, const zkutil::ZooKeeperPtr & zookeeper) const
+{
+    return zookeeper->exists(fs::path(zookeeper_path) / "quorum" / "failed_parts" / part_name);
+}
+
+bool StorageReplicatedMergeTree::isQuorumWritePendingForPart(const String & part_name, const zkutil::ZooKeeperPtr & zookeeper) const
+{
+    String quorum_str;
+    const String quorum_unparallel_path = fs::path(zookeeper_path) / "quorum" / "status";
+    const String quorum_parallel_path = fs::path(zookeeper_path) / "quorum" / "parallel" / part_name;
+
+    if (zookeeper->tryGet(quorum_unparallel_path, quorum_str))
+    {
+        ReplicatedMergeTreeQuorumEntry quorum_entry(quorum_str);
+        return quorum_entry.part_name == part_name;
+    }
+
+    if (zookeeper->tryGet(quorum_parallel_path, quorum_str))
+    {
+        ReplicatedMergeTreeQuorumEntry quorum_entry(quorum_str);
+        return quorum_entry.part_name == part_name;
+    }
+
     return false;
 }
 

--- a/src/Storages/StorageReplicatedMergeTree.h
+++ b/src/Storages/StorageReplicatedMergeTree.h
@@ -339,6 +339,9 @@ public:
 
     bool createEmptyPartInsteadOfLost(zkutil::ZooKeeperPtr zookeeper, const String & lost_part_name);
 
+    bool isQuorumFailedForPart(const String & part_name, const zkutil::ZooKeeperPtr & zookeeper) const;
+    bool isQuorumWritePendingForPart(const String & part_name, const zkutil::ZooKeeperPtr & zookeeper) const;
+
     // Return default or custom zookeeper name for table
     const String & getZooKeeperName() const { return zookeeper_info.zookeeper_name; }
     const String & getZooKeeperPath() const { return zookeeper_info.path; }

--- a/tests/integration/test_quorum_inserts/test.py
+++ b/tests/integration/test_quorum_inserts/test.py
@@ -475,3 +475,127 @@ def test_insert_quorum_with_keeper_loss_connection(started_cluster):
             assert zero.contains_in_log(
                 "fails to commit and will not retry or clean garbage"
             )
+
+
+def test_failed_quorum_cleans_replication_queue(started_cluster):
+    table_name = "test_failed_quorum_cleans_queue_" + uuid.uuid4().hex
+    zk_table_path = f"/clickhouse/tables/{table_name}"
+    pause_failpoint = "replicated_merge_tree_pause_before_mark_quorum_failed_try_multi"
+    create_query = (
+        f"CREATE TABLE {table_name} "
+        "(a Int8, d Date) "
+        "Engine = ReplicatedMergeTree('/clickhouse/tables/{table}', '{replica}') "
+        "ORDER BY a "
+    )
+
+    zero.query(create_query)
+    first.query(create_query)
+    second.query(create_query)
+
+    first.query(f"SYSTEM STOP FETCHES {table_name}")
+    second.query(f"SYSTEM STOP FETCHES {table_name}")
+
+    zero.query("SYSTEM ENABLE FAILPOINT replicated_merge_tree_commit_zk_fail_after_op")
+    zero.query("SYSTEM ENABLE FAILPOINT replicated_merge_tree_insert_retry_pause")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+        insert_future = executor.submit(
+            lambda: zero.query(
+                f"INSERT INTO {table_name}(a,d) VALUES(1, '2011-01-01')",
+                settings={"insert_quorum_timeout": 150000},
+            )
+        )
+
+        zk = cluster.get_kazoo_client("zoo1")
+
+        retries = 0
+        while True:
+            if zk.exists(f"{zk_table_path}/replicas/zero/parts/all_0_0_0"):
+                break
+            time.sleep(1)
+            retries += 1
+            if retries == 120:
+                raise Exception("Can not wait for all_0_0_0 part")
+
+        with PartitionManager() as pm:
+            pm.drop_instance_zk_connections(zero)
+
+            retries = 0
+            while True:
+                if zk.exists(f"{zk_table_path}/replicas/zero/is_active") is None:
+                    break
+                time.sleep(1)
+                retries += 1
+                if retries == 120:
+                    raise Exception("Can not wait cluster replica inactive")
+
+            # Part is not visible in ZooKeeper anymore, but quorum is still pending.
+            zk.delete(f"{zk_table_path}/replicas/zero/parts/all_0_0_0", recursive=True)
+
+            # Pause the second replica right before tryMulti, then let the first replica
+            # win the race and verify that the second replica handles ZNODEEXISTS.
+            second.query(f"SYSTEM ENABLE FAILPOINT {pause_failpoint}")
+            second_pause_future = executor.submit(
+                lambda: second.query(
+                    f"SYSTEM WAIT FAILPOINT {pause_failpoint} PAUSE",
+                    timeout=300,
+                )
+            )
+            second_start_fetch_future = executor.submit(
+                lambda: second.query(f"SYSTEM START FETCHES {table_name}")
+            )
+
+            concurrent.futures.wait([second_pause_future])
+            assert second_pause_future.exception() is None
+
+            first.query(f"SYSTEM START FETCHES {table_name}")
+            second.query(f"SYSTEM NOTIFY FAILPOINT {pause_failpoint}")
+            concurrent.futures.wait([second_start_fetch_future])
+            assert second_start_fetch_future.exception() is None
+
+            # Without the fix, the losing replica keeps GET_PART in the queue after ZNODEEXISTS.
+            for node in (first, second):
+                for _ in range(60):
+                    if TSV("0") == TSV(
+                        node.query(
+                            f"SELECT count() FROM system.replication_queue WHERE database = currentDatabase() AND table = '{table_name}'"
+                        )
+                    ):
+                        break
+                    time.sleep(0.5)
+                else:
+                    raise Exception(f"replication queue is not empty on {node.name}")
+
+            assert first.contains_in_log(
+                "Quorum for part all_0_0_0 was marked as failed by another replica"
+            ) or second.contains_in_log(
+                "Quorum for part all_0_0_0 was marked as failed by another replica"
+            )
+
+            zero.query("SYSTEM ENABLE FAILPOINT finish_clean_quorum_failed_parts")
+            clean_quorum_fail_parts_future = executor.submit(
+                lambda: zero.query(
+                    "SYSTEM WAIT FAILPOINT finish_clean_quorum_failed_parts",
+                    timeout=300,
+                )
+            )
+            pm.restore_instance_zk_connections(zero)
+            concurrent.futures.wait([clean_quorum_fail_parts_future])
+            assert clean_quorum_fail_parts_future.exception() is None
+
+            zero.query(
+                "SYSTEM DISABLE FAILPOINT replicated_merge_tree_insert_retry_pause"
+            )
+            concurrent.futures.wait([insert_future])
+            assert insert_future.exception() is not None
+
+            for node in (zero, first, second):
+                node.query(f"SYSTEM SYNC REPLICA {table_name}", timeout=120)
+                assert TSV("0") == TSV(
+                    node.query(
+                        f"SELECT count() FROM system.replication_queue WHERE database = currentDatabase() AND table = '{table_name}'"
+                    )
+                )
+
+            second.query(f"SYSTEM START FETCHES {table_name}")
+    zero.query(f"DROP TABLE IF EXISTS {table_name} ON CLUSTER cluster")


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

When several replicas mark a failed quorum concurrently, the losing replica must drop its GET_PART queue entry on ZNODEEXISTS instead of retrying forever. Also clean virtual_parts consistently and add an integration test with a dedicated failpoint for the race.

Closes: https://github.com/ClickHouse/ClickHouse/issues/54545

AI assisted by Cursor.

