### PR TITLE
Fix flakiness due to ColumnTuple test leaking MainThreadStatus

### DIFF
--- a/src/Columns/tests/gtest_column_tuple.cpp
+++ b/src/Columns/tests/gtest_column_tuple.cpp
@@ -100,8 +100,7 @@ TEST(ColumnTuple, InsertDefaultIsExceptionSafe)
     auto tuple = ColumnTuple::create(std::move(elements));
 
     {
-        MainThreadStatus::getInstance();
-        CurrentThread::flushUntrackedMemory();
+        ThreadStatus thread_status;
         const Int64 prev_hard_limit = total_memory_tracker.getHardLimit();
         SCOPE_EXIT_SAFE(total_memory_tracker.setHardLimit(prev_hard_limit));
         total_memory_tracker.setHardLimit(total_memory_tracker.get() + 1024);


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
`ColumnTuple.InsertDefaultIsExceptionSafe` calls `MainThreadStatus::getInstance()` — a process-lifetime singleton that permanently redirects `ProfileEvents::increment` to thread-local counters. This breaks other tests relying on `global_counters`.

Fix: scoped `ThreadStatus` instead of singleton.

Related: https://github.com/ClickHouse/ClickHouse/pull/106802
