### PR TITLE
fix sub second display in praktika report

### DIFF
--- a/ci/jobs/scripts/perf/compare.sh
+++ b/ci/jobs/scripts/perf/compare.sh
@@ -1178,7 +1178,7 @@ create table ci_checks engine File(TSVWithNamesAndTypes, 'ci-checks.tsv')
         fromUnixTimestamp($CHPC_CHECK_START_TIMESTAMP) check_start_time,
         test_name :: LowCardinality(String) AS test_name ,
         test_status :: LowCardinality(String) AS test_status,
-        test_duration_ms :: UInt64 AS test_duration_ms,
+        test_duration_ms :: Float64 AS test_duration_ms,
         report_url,
         $PR_TO_TEST = 0
             ? 'https://github.com/ClickHouse/ClickHouse/commit/$SHA_TO_TEST'

--- a/ci/praktika/json.html
+++ b/ci/praktika/json.html
@@ -691,16 +691,20 @@
     }
 
     function formatDuration(durationInSeconds, detailed = false) {
-        // Check if the duration is empty, null, or not a number
-        if (!durationInSeconds || isNaN(durationInSeconds)) {
+        // Treat null/undefined/non-numeric as "unknown"; a literal 0 is a
+        // real measurement and flows through the precision ladder below
+        // (otherwise sub-millisecond perf-comparison rows showed up as the
+        // misleading placeholder "00s").
+        if (durationInSeconds === null || durationInSeconds === undefined) {
+            return '00s';
+        }
+        const duration = parseFloat(durationInSeconds);
+        if (isNaN(duration)) {
             return '00s';
         }
 
-        // Ensure duration is a floating-point number
-        const duration = parseFloat(durationInSeconds);
-
-        if (detailed) {
-            // Format in the detailed format with hours, minutes, and seconds
+        if (detailed && duration >= 1) {
+            // H/M/S format for job-level totals (e.g. "1h 23m 45s").
             const hours = Math.floor(duration / 3600);
             const minutes = Math.floor((duration % 3600) / 60);
             const seconds = Math.floor(duration % 60);
@@ -710,20 +714,31 @@
             const formattedSeconds = `${String(seconds).padStart(2, '0')}s`;
 
             return `${formattedHours}${formattedMinutes}${formattedSeconds}`.trim();
-        } else {
-            if (duration < 1) {
-                // Sub-second durations: show milliseconds
-                return `${Math.floor(duration * 1000)}ms`;
-            }
-            // Format in the default format with seconds and milliseconds
-            const seconds = Math.floor(duration);
-            const milliseconds = Math.floor((duration % 1) * 1000);
-
-            const formattedSeconds = String(seconds);
-            const formattedMilliseconds = String(milliseconds).padStart(2, 0).slice(-2);
-
-            return `${formattedSeconds}.${formattedMilliseconds}`;
         }
+
+        // Sub-second precision ladder: drop to a smaller unit when the
+        // next-coarser one would round to zero. Covers true zero too.
+        if (duration < 0.00001) {
+            // < 0.01ms — integer nanoseconds.
+            return `${Math.round(duration * 1e9)}ns`;
+        }
+        if (duration < 0.001) {
+            // < 1ms but >= 0.01ms — two decimals in ms.
+            return `${(duration * 1000).toFixed(2)}ms`;
+        }
+        if (duration < 1) {
+            // Sub-second: integer milliseconds.
+            return `${Math.floor(duration * 1000)}ms`;
+        }
+
+        // >= 1s and not detailed: seconds with two-digit milliseconds.
+        const seconds = Math.floor(duration);
+        const milliseconds = Math.floor((duration % 1) * 1000);
+
+        const formattedSeconds = String(seconds);
+        const formattedMilliseconds = String(milliseconds).padStart(2, 0).slice(-2);
+
+        return `${formattedSeconds}.${formattedMilliseconds}`;
     }
 
     // Function to determine status class based on value


### PR DESCRIPTION
### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

fix sub second values display in praktika report, fixes performance comparison results to correctly show query duration

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.587`
<!-- ch-version-info:end -->