### PR TITLE
Common: mask sensitive data on Exception::addMessage

### DIFF
--- a/src/Common/Exception.h
+++ b/src/Common/Exception.h
@@ -152,15 +152,17 @@ protected:
     static thread_local ThreadFramePointers thread_frame_pointers;
     static const ThreadFramePointersBase dummy_frame_pointers;
 
-    // used to remove the sensitive information from exceptions if query_masking_rules is configured
+    // Used to remove the sensitive information from exceptions if `query_masking_rules` is configured.
+    // Both constructors run `SensitiveDataMasker::wipeSensitiveData` on `msg_` when a masker is registered.
+    // There is intentionally no constructor that skips the masker - every code path that builds a
+    // `MessageMasked` (initial `Exception` construction or `addMessage` extension) must mask consistently,
+    // otherwise `query_masking_rules` cannot cover the appended portion (see issue #106441).
     struct MessageMasked
     {
         std::string msg;
         std::string format_string;
         explicit MessageMasked(const std::string & msg_, std::string format_string_);
         explicit MessageMasked(std::string && msg_, std::string format_string_);
-        explicit MessageMasked(const std::string & msg_) : msg(msg_) {}
-        explicit MessageMasked(std::string && msg_) : msg(msg_) {}
     };
 
     Exception(const MessageMasked & msg_masked, int code, bool remote_);
@@ -206,9 +208,13 @@ public:
         addMessage(fmt::format(format, std::forward<Args>(args)...));
     }
 
-    void addMessage(const std::string& message)
+    void addMessage(const std::string & message)
     {
-        addMessage(MessageMasked(message));
+        // Use the 2-argument `MessageMasked` constructor so the masker is invoked on the appended
+        // portion. Without this `query_masking_rules` cannot cover content added via `addMessage`,
+        // e.g. the `(in file/uri ...)` suffix in `IInputFormat::generate` for jdbc/odbc table functions
+        // can leak connection strings (issue #106441).
+        addMessage(MessageMasked(message, ""));
     }
 
     void addMessage(const MessageMasked & msg_masked);

--- a/src/Common/tests/gtest_sensitive_data_masker.cpp
+++ b/src/Common/tests/gtest_sensitive_data_masker.cpp
@@ -8,6 +8,10 @@
 #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
 #pragma clang diagnostic ignored "-Wundef"
 
+#include <memory>
+#include <sstream>
+#include <string>
+
 #include <gtest/gtest.h>
 
 
@@ -18,6 +22,7 @@ namespace ErrorCodes
 extern const int CANNOT_COMPILE_REGEXP;
 extern const int NO_ELEMENTS_IN_CONFIG;
 extern const int INVALID_CONFIG_PARAMETER;
+extern const int LOGICAL_ERROR;
 }
 }
 
@@ -203,4 +208,61 @@ TEST(Common, SensitiveDataMasker)
         masker_xml_based.printStats();
 #endif
     }
+}
+
+
+// Regression test for issue #106441: `Exception::addMessage` must run the appended
+// message through `SensitiveDataMasker::wipeSensitiveData`. Before the fix the
+// 1-argument `MessageMasked` constructor bypassed the masker, so anything appended
+// via `addMessage` (e.g. the `(in file/uri ...)` suffix added by
+// `IInputFormat::generate` for jdbc/odbc table functions) was never masked even
+// when `query_masking_rules` were configured.
+TEST(Common, ExceptionAddMessageMasked)
+{
+    using namespace DB;
+
+    // Build a masker with one rule that masks an URL-encoded password parameter,
+    // matching the security-sensitive case described in issue #106441.
+    std::istringstream      // STYLE_CHECK_ALLOW_STD_STRING_STREAM
+        xml_isteam(R"END(<clickhouse>
+    <query_masking_rules>
+        <rule>
+            <name>mask URL-encoded password</name>
+            <regexp>password%3D[^%&amp;\s'"]+</regexp>
+            <replace>password%3D***</replace>
+        </rule>
+    </query_masking_rules>
+</clickhouse>)END");
+
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> xml_config = new Poco::Util::XMLConfiguration(xml_isteam);
+    auto masker = std::make_unique<SensitiveDataMasker>(*xml_config, "query_masking_rules");
+    SensitiveDataMasker::setInstance(std::move(masker));
+
+    // The initial exception message goes through the 2-argument MessageMasked ctor
+    // (via the delegating Exception ctor) and was already masked before the fix.
+    std::string sensitive_url = "http://host:9019/?connection_string=jdbc%3Apostgresql%3A%2F%2Fdb%26password%3Ds3cr3t";
+
+    try
+    {
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "boom");
+    }
+    catch (Exception & e)
+    {
+        // Mimic IInputFormat::generate appending `(in file/uri <url>)` to the
+        // existing exception. With the fix this string flows through wipeSensitiveData;
+        // before the fix it did not.
+        e.addMessage(fmt::format("(in file/uri {})", sensitive_url));
+
+        const std::string what = e.what();
+        EXPECT_EQ(what.find("password%3Ds3cr3t"), std::string::npos)
+            << "raw secret leaked through addMessage: " << what;
+        EXPECT_NE(what.find("password%3D***"), std::string::npos)
+            << "expected masked replacement not present: " << what;
+    }
+
+    // Restore the global masker to a no-op so other gtests in this binary
+    // see the same state they would without this test.
+    Poco::AutoPtr<Poco::Util::XMLConfiguration> empty_xml_config = new Poco::Util::XMLConfiguration();
+    auto empty_masker = std::make_unique<SensitiveDataMasker>(*empty_xml_config, "");
+    SensitiveDataMasker::setInstance(std::move(empty_masker));
 }

--- a/src/Common/tests/gtest_sensitive_data_masker.cpp
+++ b/src/Common/tests/gtest_sensitive_data_masker.cpp
@@ -244,7 +244,10 @@ TEST(Common, ExceptionAddMessageMasked)
 
     try
     {
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "boom");
+        // Use a non-fatal error code here: constructing a LOGICAL_ERROR exception
+        // aborts the process in debug/sanitizer builds, so the specific code is
+        // incidental -- this test only needs an Exception to exercise addMessage() masking.
+        throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER, "boom");
     }
     catch (Exception & e)
     {


### PR DESCRIPTION
`Exception::addMessage(const std::string &)` constructed a `MessageMasked`
through the 1-argument constructor in `src/Common/Exception.h`, which was a
plain initializer that did not call `SensitiveDataMasker::wipeSensitiveData`.
As a result, anything appended to an existing exception via `addMessage`
(and the `fmt::format_string` variadic overload that delegates to it) was
never subject to `query_masking_rules`, even when rules were configured.

The motivating case is `jdbc()`/`odbc()` table functions: when the JDBC bridge
returns a 4xx error during data reading, `IInputFormat::generate` catches
the exception and appends `(in file/uri <URL>)` via `addMessage`. The URL
contains the percent-encoded connection string including the password,
and no masking rule could ever remove it because the masker was not
invoked on this path. The same gap existed in
`src/Formats/ReadSchemaUtils.cpp` and in every other call site that uses
`addMessage(string)` with content that could carry secrets.

This PR routes `addMessage` through the 2-argument `MessageMasked` constructor
(empty `format_string`), which is the same path that
`Exception(const std::string &, ...)` already takes. The unmasking 1-argument
`MessageMasked` constructors are deleted so the masker cannot be skipped
again by accident; the `addMessage` call site was the only caller of those
overloads. A regression test in
`src/Common/tests/gtest_sensitive_data_masker.cpp` installs a masker with a
URL-encoded password rule, throws an exception, appends a sensitive URL via
`addMessage`, and asserts the secret is replaced with the masked form.

Closes: https://github.com/ClickHouse/ClickHouse/issues/106441


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Apply `query_masking_rules` to messages appended via `Exception::addMessage` so URL-encoded credentials in `(in file/uri ...)` suffixes from `jdbc()`/`odbc()` errors are not leaked when masking rules are configured.


### Documentation entry for user-facing changes
- [x] Not applicable (no user-facing API change; only a behavior fix for existing `query_masking_rules` configuration).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.1144` (included in `26.7` and later)
<!-- ch-version-info:end -->