### PR TITLE
Slow down `use_skip_indexes_on_data_read = 1`

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -519,7 +519,8 @@ Pipe ReadFromMergeTree::readFromPoolParallelReplicas(
         required_columns,
         pool_settings,
         block_size,
-        context);
+        context,
+        index_build_context);
 
     Pipes pipes;
 
@@ -609,7 +610,8 @@ Pipe ReadFromMergeTree::readFromPool(
             pool_settings,
             block_size,
             context,
-            dataflow_cache_updater);
+            dataflow_cache_updater,
+            index_build_context);
     }
     else
     {
@@ -627,7 +629,8 @@ Pipe ReadFromMergeTree::readFromPool(
             pool_settings,
             block_size,
             context,
-            dataflow_cache_updater);
+            dataflow_cache_updater,
+            index_build_context);
     }
 
     LOG_DEBUG(log, "Reading approx. {} rows with {} streams", total_rows, pool_settings.threads);
@@ -714,7 +717,8 @@ Pipe ReadFromMergeTree::readInOrder(
             required_columns,
             pool_settings,
             block_size,
-            context);
+            context,
+            index_build_context);
     }
     else
     {
@@ -735,7 +739,8 @@ Pipe ReadFromMergeTree::readInOrder(
             pool_settings,
             block_size,
             context,
-            dataflow_cache_updater);
+            dataflow_cache_updater,
+            index_build_context);
     }
 
     /// If parallel replicas enabled, set total rows in progress here only on initiator with local plan

--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
@@ -164,9 +164,29 @@ void MergeTreePrefetchedReadPool::createPrefetchedReadersForTask(ThreadTask & ta
     if (shouldSkipPartRead(*task.read_info))
         return;
 
+    if (!task.allow_prefetch || !tryAcquirePrefetchBudget(task.prefetch_memory_cost, task.prefetch_readers_cost))
+        return;
+
     auto extras = getExtras();
     auto readers = MergeTreeReadTask::createReaders(task.read_info, extras, task.ranges, task.patches_ranges);
     task.readers_future = std::make_unique<PrefetchedReaders>(prefetch_threadpool, std::move(readers), task.priority, *this);
+}
+
+bool MergeTreePrefetchedReadPool::tryAcquirePrefetchBudget(size_t memory_cost, size_t readers_cost)
+{
+    std::lock_guard lock(mutex);
+
+    if (memory_cost > remaining_prefetch_memory)
+        return false;
+
+    if (remaining_prefetch_readers_num.has_value() && readers_cost > remaining_prefetch_readers_num.value())
+        return false;
+
+    remaining_prefetch_memory -= memory_cost;
+    if (remaining_prefetch_readers_num.has_value())
+        *remaining_prefetch_readers_num -= readers_cost;
+
+    return true;
 }
 
 void MergeTreePrefetchedReadPool::preparePrefetchedReadersIfNeeded(ThreadTask & task)
@@ -433,6 +453,9 @@ void MergeTreePrefetchedReadPool::fillPerThreadTasks(size_t threads, size_t sum_
     std::optional<size_t> allowed_prefetches_num
         = reader_settings.filesystem_prefetches_limit ? std::optional<size_t>(reader_settings.filesystem_prefetches_limit) : std::nullopt;
 
+    remaining_prefetch_memory = allowed_memory_usage;
+    remaining_prefetch_readers_num = allowed_prefetches_num;
+
     per_thread_tasks.clear();
     size_t total_tasks = 0;
 
@@ -530,19 +553,14 @@ void MergeTreePrefetchedReadPool::fillPerThreadTasks(size_t threads, size_t sum_
             {
                 allow_prefetch = part_stat.estimated_memory_usage_for_single_prefetch <= allowed_memory_usage
                     && (!allowed_prefetches_num.has_value() || part_stat.required_readers_num <= allowed_prefetches_num.value());
-
-                if (allow_prefetch)
-                {
-                    allowed_memory_usage -= part_stat.estimated_memory_usage_for_single_prefetch;
-                    if (allowed_prefetches_num.has_value())
-                        *allowed_prefetches_num -= part_stat.required_readers_num;
-                }
             }
 
             const auto & read_info = per_part_infos[part_idx];
             auto patch_ranges = ranges_in_patch_parts.getRanges(read_info->data_part, read_info->patch_parts, ranges_to_get_from_part);
             auto thread_task = std::make_unique<ThreadTask>(read_info, ranges_to_get_from_part, std::move(patch_ranges), priority);
             thread_task->allow_prefetch = allow_prefetch;
+            thread_task->prefetch_memory_cost = part_stat.estimated_memory_usage_for_single_prefetch;
+            thread_task->prefetch_readers_cost = part_stat.required_readers_num;
 
             per_thread_tasks[i].push_back(std::move(thread_task));
 

--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
@@ -179,32 +179,41 @@ MergeTreeReadTaskPtr MergeTreePrefetchedReadPool::getTask(size_t task_idx, Merge
 {
     OpenTelemetry::SpanHolder span("MergeTreePrefetchedReadPool::getTask");
 
-    std::lock_guard lock(mutex);
+    ThreadTaskPtr thread_task;
+    {
+        std::lock_guard lock(mutex);
 
-    if (per_thread_tasks.empty())
+        if (per_thread_tasks.empty())
+            return nullptr;
+
+        auto it = per_thread_tasks.find(task_idx);
+        if (it == per_thread_tasks.end())
+            thread_task = stealTaskLocked(task_idx);
+        else
+        {
+            auto & thread_tasks = it->second;
+            chassert(!thread_tasks.empty());
+
+            thread_task = std::move(thread_tasks.front());
+            thread_tasks.pop_front();
+
+            if (thread_tasks.empty())
+                per_thread_tasks.erase(it);
+        }
+    }
+
+    if (!thread_task)
         return nullptr;
-
-    auto it = per_thread_tasks.find(task_idx);
-    if (it == per_thread_tasks.end())
-        return stealTask(task_idx, previous_task);
-
-    auto & thread_tasks = it->second;
-    chassert(!thread_tasks.empty());
-
-    auto thread_task = std::move(thread_tasks.front());
-    thread_tasks.pop_front();
-
-    if (thread_tasks.empty())
-        per_thread_tasks.erase(it);
 
     preparePrefetchedReadersIfNeeded(*thread_task);
     return createTask(*thread_task, previous_task);
 }
 
-MergeTreeReadTaskPtr MergeTreePrefetchedReadPool::stealTask(size_t thread, MergeTreeReadTask * previous_task)
+MergeTreePrefetchedReadPool::ThreadTaskPtr MergeTreePrefetchedReadPool::stealTaskLocked(size_t thread)
 {
     auto non_prefetched_tasks_to_steal = per_thread_tasks.end();
     auto prefetched_tasks_to_steal = per_thread_tasks.end();
+    ThreadTasks::iterator prefetched_task_it;
     int64_t best_prefetched_task_priority = -1;
 
     /// There is no point stealing in order (like in MergeTreeReadPool, where tasks can be stolen
@@ -223,13 +232,9 @@ MergeTreeReadTaskPtr MergeTreePrefetchedReadPool::stealTask(size_t thread, Merge
 
         auto task_it = std::find_if(
             thread_tasks.begin(), thread_tasks.end(),
-            [this](const auto & task)
+            [](const auto & task)
             {
-                if (!task->allow_prefetch)
-                    return false;
-
-                preparePrefetchedReadersIfNeeded(*task);
-                return task->isValidReadersFuture();
+                return task->allow_prefetch && task->isValidReadersFuture();
             });
 
         if (task_it == thread_tasks.end())
@@ -247,6 +252,7 @@ MergeTreeReadTaskPtr MergeTreePrefetchedReadPool::stealTask(size_t thread, Merge
             best_prefetched_task_priority = (*task_it)->priority;
             chassert(best_prefetched_task_priority >= 0);
             prefetched_tasks_to_steal = thread_tasks_it;
+            prefetched_task_it = task_it;
         }
     }
 
@@ -254,27 +260,15 @@ MergeTreeReadTaskPtr MergeTreePrefetchedReadPool::stealTask(size_t thread, Merge
     {
         auto & thread_tasks = prefetched_tasks_to_steal->second;
         chassert(!thread_tasks.empty());
+        chassert(prefetched_task_it != thread_tasks.end());
 
-        auto task_it = std::find_if(
-            thread_tasks.begin(), thread_tasks.end(),
-            [this](const auto & task)
-            {
-                if (!task->allow_prefetch)
-                    return false;
-
-                preparePrefetchedReadersIfNeeded(*task);
-                return task->isValidReadersFuture();
-            });
-
-        chassert(task_it != thread_tasks.end());
-        auto thread_task = std::move(*task_it);
-        thread_tasks.erase(task_it);
+        auto thread_task = std::move(*prefetched_task_it);
+        thread_tasks.erase(prefetched_task_it);
 
         if (thread_tasks.empty())
             per_thread_tasks.erase(prefetched_tasks_to_steal);
 
-        preparePrefetchedReadersIfNeeded(*thread_task);
-        return createTask(*thread_task, previous_task);
+        return thread_task;
     }
 
     /// TODO: it also makes sense to first try to steal from the next thread if it has ranges
@@ -305,8 +299,7 @@ MergeTreeReadTaskPtr MergeTreePrefetchedReadPool::stealTask(size_t thread, Merge
         if (current_thread_tasks.empty())
             per_thread_tasks.erase(thread);
 
-        preparePrefetchedReadersIfNeeded(*thread_task);
-        return createTask(*thread_task, previous_task);
+        return thread_task;
     }
 
     return nullptr;

--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
@@ -44,15 +44,6 @@ namespace FailPoints
     extern const char prefetched_reader_pool_failpoint[];
 }
 
-bool MergeTreePrefetchedReadPool::TaskHolder::operator<(const TaskHolder & other) const
-{
-    chassert(task->priority >= 0);
-    chassert(other.task->priority >= 0);
-    /// With default std::priority_queue, top() returns largest element.
-    /// So closest to 0 will be on top with this comparator.
-    return task->priority > other.task->priority; /// Less is better.
-}
-
 MergeTreePrefetchedReadPool::ThreadTask::ThreadTask(InfoPtr read_info_, MarkRanges ranges_, std::vector<MarkRanges> patches_ranges_, Priority priority_)
     : read_info(std::move(read_info_))
     , ranges(std::move(ranges_))
@@ -118,7 +109,8 @@ MergeTreePrefetchedReadPool::MergeTreePrefetchedReadPool(
     const PoolSettings & settings_,
     const MergeTreeReadTask::BlockSizeParams & params_,
     const ContextPtr & context_,
-    RuntimeDataflowStatisticsCacheUpdaterPtr updater_)
+    RuntimeDataflowStatisticsCacheUpdaterPtr updater_,
+    MergeTreeIndexBuildContextPtr index_build_context_)
     : MergeTreeReadPoolBase(
           std::move(parts_),
           std::move(mutations_snapshot_),
@@ -132,7 +124,8 @@ MergeTreePrefetchedReadPool::MergeTreePrefetchedReadPool(
           column_names_,
           settings_,
           params_,
-          context_)
+          context_,
+          std::move(index_build_context_))
     , updater(std::move(updater_))
     , prefetch_threadpool(getContext()->getPrefetchThreadpool())
     , log(getLogger(
@@ -168,39 +161,18 @@ void MergeTreePrefetchedReadPool::createPrefetchedReadersForTask(ThreadTask & ta
     if (task.isValidReadersFuture())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Task already has a reader");
 
+    if (shouldSkipPartRead(*task.read_info))
+        return;
+
     auto extras = getExtras();
     auto readers = MergeTreeReadTask::createReaders(task.read_info, extras, task.ranges, task.patches_ranges);
     task.readers_future = std::make_unique<PrefetchedReaders>(prefetch_threadpool, std::move(readers), task.priority, *this);
 }
 
-void MergeTreePrefetchedReadPool::startPrefetches()
+void MergeTreePrefetchedReadPool::preparePrefetchedReadersIfNeeded(ThreadTask & task)
 {
-    OpenTelemetry::SpanHolder span("MergeTreePrefetchedReadPool::startPrefetches");
-
-    if (prefetch_queue.empty())
-        return;
-
-    [[maybe_unused]] TaskHolder prev;
-    [[maybe_unused]] const Priority highest_priority{reader_settings.read_settings.priority.value + 1};
-    /// Due to the difference in `estimated_memory_usage_for_single_prefetch` for different parts (column sizes might be different), it might happen that for the given thread, task number N won't fit in the prefetch memory limit, but the next task will.
-    /// So the top of the queue may have a priority higher than `highest_priority`.
-    chassert(prefetch_queue.top().task->priority >= highest_priority);
-
-    while (!prefetch_queue.empty())
-    {
-        const auto & top = prefetch_queue.top();
-        createPrefetchedReadersForTask(*top.task);
-#ifndef NDEBUG
-        if (prev.task)
-        {
-            chassert(top.task->priority >= highest_priority);
-            if (prev.thread_id == top.thread_id)
-                chassert(prev.task->priority < top.task->priority);
-        }
-        prev = top;
-#endif
-        prefetch_queue.pop();
-    }
+    if (task.allow_prefetch && !task.isValidReadersFuture())
+        createPrefetchedReadersForTask(task);
 }
 
 MergeTreeReadTaskPtr MergeTreePrefetchedReadPool::getTask(size_t task_idx, MergeTreeReadTask * previous_task)
@@ -211,12 +183,6 @@ MergeTreeReadTaskPtr MergeTreePrefetchedReadPool::getTask(size_t task_idx, Merge
 
     if (per_thread_tasks.empty())
         return nullptr;
-
-    if (!started_prefetches)
-    {
-        started_prefetches = true;
-        startPrefetches();
-    }
 
     auto it = per_thread_tasks.find(task_idx);
     if (it == per_thread_tasks.end())
@@ -231,6 +197,7 @@ MergeTreeReadTaskPtr MergeTreePrefetchedReadPool::getTask(size_t task_idx, Merge
     if (thread_tasks.empty())
         per_thread_tasks.erase(it);
 
+    preparePrefetchedReadersIfNeeded(*thread_task);
     return createTask(*thread_task, previous_task);
 }
 
@@ -256,7 +223,14 @@ MergeTreeReadTaskPtr MergeTreePrefetchedReadPool::stealTask(size_t thread, Merge
 
         auto task_it = std::find_if(
             thread_tasks.begin(), thread_tasks.end(),
-            [](const auto & task) { return task->isValidReadersFuture(); });
+            [this](const auto & task)
+            {
+                if (!task->allow_prefetch)
+                    return false;
+
+                preparePrefetchedReadersIfNeeded(*task);
+                return task->isValidReadersFuture();
+            });
 
         if (task_it == thread_tasks.end())
         {
@@ -283,7 +257,14 @@ MergeTreeReadTaskPtr MergeTreePrefetchedReadPool::stealTask(size_t thread, Merge
 
         auto task_it = std::find_if(
             thread_tasks.begin(), thread_tasks.end(),
-            [](const auto & task) { return task->isValidReadersFuture(); });
+            [this](const auto & task)
+            {
+                if (!task->allow_prefetch)
+                    return false;
+
+                preparePrefetchedReadersIfNeeded(*task);
+                return task->isValidReadersFuture();
+            });
 
         chassert(task_it != thread_tasks.end());
         auto thread_task = std::move(*task_it);
@@ -292,6 +273,7 @@ MergeTreeReadTaskPtr MergeTreePrefetchedReadPool::stealTask(size_t thread, Merge
         if (thread_tasks.empty())
             per_thread_tasks.erase(prefetched_tasks_to_steal);
 
+        preparePrefetchedReadersIfNeeded(*thread_task);
         return createTask(*thread_task, previous_task);
     }
 
@@ -323,6 +305,7 @@ MergeTreeReadTaskPtr MergeTreePrefetchedReadPool::stealTask(size_t thread, Merge
         if (current_thread_tasks.empty())
             per_thread_tasks.erase(thread);
 
+        preparePrefetchedReadersIfNeeded(*thread_task);
         return createTask(*thread_task, previous_task);
     }
 
@@ -331,6 +314,9 @@ MergeTreeReadTaskPtr MergeTreePrefetchedReadPool::stealTask(size_t thread, Merge
 
 MergeTreeReadTaskPtr MergeTreePrefetchedReadPool::createTask(ThreadTask & task, MergeTreeReadTask * previous_task)
 {
+    if (shouldSkipPartRead(*task.read_info))
+        return MergeTreeReadPoolBase::createTask(task.read_info, MergeTreeReadTask::Readers{}, MarkRanges{}, {}, updater);
+
     if (task.isValidReadersFuture())
         return MergeTreeReadPoolBase::createTask(task.read_info, task.readers_future->get(), task.ranges, task.patches_ranges, updater);
     else
@@ -563,9 +549,7 @@ void MergeTreePrefetchedReadPool::fillPerThreadTasks(size_t threads, size_t sum_
             const auto & read_info = per_part_infos[part_idx];
             auto patch_ranges = ranges_in_patch_parts.getRanges(read_info->data_part, read_info->patch_parts, ranges_to_get_from_part);
             auto thread_task = std::make_unique<ThreadTask>(read_info, ranges_to_get_from_part, std::move(patch_ranges), priority);
-
-            if (allow_prefetch)
-                prefetch_queue.emplace(TaskHolder{thread_task.get(), i});
+            thread_task->allow_prefetch = allow_prefetch;
 
             per_thread_tasks[i].push_back(std::move(thread_task));
 

--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.h
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.h
@@ -96,6 +96,8 @@ private:
         std::vector<MarkRanges> patches_ranges;
         Priority priority;
         bool allow_prefetch = false;
+        size_t prefetch_memory_cost = 0;
+        size_t prefetch_readers_cost = 0;
         std::unique_ptr<PrefetchedReaders> readers_future;
     };
 
@@ -112,6 +114,8 @@ private:
 
     void preparePrefetchedReadersIfNeeded(ThreadTask & task);
 
+    bool tryAcquirePrefetchBudget(size_t memory_cost, size_t readers_cost);
+
     /// Must be called with `mutex` held. Returns a task to prepare outside the lock.
     ThreadTaskPtr stealTaskLocked(size_t thread);
     MergeTreeReadTaskPtr createTask(ThreadTask & thread_task, MergeTreeReadTask * previous_task);
@@ -125,6 +129,8 @@ private:
 
     PartStatistics per_part_statistics;
     TasksPerThread per_thread_tasks;
+    size_t remaining_prefetch_memory = 0;
+    std::optional<size_t> remaining_prefetch_readers_num;
     LoggerPtr log;
 
     /// A struct which allows to track max number of tasks which were in the

--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.h
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.h
@@ -112,7 +112,8 @@ private:
 
     void preparePrefetchedReadersIfNeeded(ThreadTask & task);
 
-    MergeTreeReadTaskPtr stealTask(size_t thread, MergeTreeReadTask * previous_task);
+    /// Must be called with `mutex` held. Returns a task to prepare outside the lock.
+    ThreadTaskPtr stealTaskLocked(size_t thread);
     MergeTreeReadTaskPtr createTask(ThreadTask & thread_task, MergeTreeReadTask * previous_task);
 
     static std::string dumpTasks(const TasksPerThread & tasks);

--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.h
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.h
@@ -3,7 +3,6 @@
 #include <Common/threadPoolCallbackRunner.h>
 #include <Common/ThreadPool_fwd.h>
 #include <IO/AsyncReadCounters.h>
-#include <boost/heap/priority_queue.hpp>
 #include <queue>
 
 namespace DB
@@ -34,7 +33,8 @@ public:
         const PoolSettings & settings_,
         const MergeTreeReadTask::BlockSizeParams & params_,
         const ContextPtr & context_,
-        RuntimeDataflowStatisticsCacheUpdaterPtr updater_);
+        RuntimeDataflowStatisticsCacheUpdaterPtr updater_,
+        MergeTreeIndexBuildContextPtr index_build_context_ = {});
 
     String getName() const override { return "PrefetchedReadPool"; }
     bool preservesOrderOfRanges() const override { return false; }
@@ -95,14 +95,8 @@ private:
         MarkRanges ranges;
         std::vector<MarkRanges> patches_ranges;
         Priority priority;
+        bool allow_prefetch = false;
         std::unique_ptr<PrefetchedReaders> readers_future;
-    };
-
-    struct TaskHolder
-    {
-        ThreadTask * task = nullptr;
-        size_t thread_id = 0;
-        bool operator<(const TaskHolder & other) const;
     };
 
     using ThreadTaskPtr = std::unique_ptr<ThreadTask>;
@@ -113,9 +107,10 @@ private:
     void fillPerPartStatistics();
     void fillPerThreadTasks(size_t threads, size_t sum_marks);
 
-    void startPrefetches();
     void createPrefetchedReadersForTask(ThreadTask & task);
     std::function<void()> createPrefetchedTask(IMergeTreeReader * reader, Priority priority);
+
+    void preparePrefetchedReadersIfNeeded(ThreadTask & task);
 
     MergeTreeReadTaskPtr stealTask(size_t thread, MergeTreeReadTask * previous_task);
     MergeTreeReadTaskPtr createTask(ThreadTask & thread_task, MergeTreeReadTask * previous_task);
@@ -129,8 +124,6 @@ private:
 
     PartStatistics per_part_statistics;
     TasksPerThread per_thread_tasks;
-    std::priority_queue<TaskHolder> prefetch_queue; /// the smallest on top
-    bool started_prefetches = false;
     LoggerPtr log;
 
     /// A struct which allows to track max number of tasks which were in the

--- a/src/Storages/MergeTree/MergeTreeReadPool.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadPool.cpp
@@ -49,7 +49,8 @@ MergeTreeReadPool::MergeTreeReadPool(
     const PoolSettings & settings_,
     const MergeTreeReadTask::BlockSizeParams & params_,
     const ContextPtr & context_,
-    RuntimeDataflowStatisticsCacheUpdaterPtr updater_)
+    RuntimeDataflowStatisticsCacheUpdaterPtr updater_,
+    MergeTreeIndexBuildContextPtr index_build_context_)
     : MergeTreeReadPoolBase(
           std::move(parts_),
           std::move(mutations_snapshot_),
@@ -63,7 +64,8 @@ MergeTreeReadPool::MergeTreeReadPool(
           column_names_,
           settings_,
           params_,
-          context_)
+          context_,
+          std::move(index_build_context_))
     , updater(std::move(updater_))
     , backoff_settings{context_->getSettingsRef()}
     , backoff_state{pool_settings.threads}

--- a/src/Storages/MergeTree/MergeTreeReadPool.h
+++ b/src/Storages/MergeTree/MergeTreeReadPool.h
@@ -37,7 +37,8 @@ public:
         const PoolSettings & settings_,
         const MergeTreeReadTask::BlockSizeParams & params_,
         const ContextPtr & context_,
-        RuntimeDataflowStatisticsCacheUpdaterPtr updater_);
+        RuntimeDataflowStatisticsCacheUpdaterPtr updater_,
+        MergeTreeIndexBuildContextPtr index_build_context_ = {});
 
     ~MergeTreeReadPool() override = default;
 

--- a/src/Storages/MergeTree/MergeTreeReadPoolBase.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadPoolBase.cpp
@@ -40,7 +40,8 @@ MergeTreeReadPoolBase::MergeTreeReadPoolBase(
     const Names & column_names_,
     const PoolSettings & pool_settings_,
     const MergeTreeReadTask::BlockSizeParams & block_size_params_,
-    const ContextPtr & context_)
+    const ContextPtr & context_,
+    MergeTreeIndexBuildContextPtr index_build_context_)
     : WithContext(context_)
     , storage_snapshot(storage_snapshot_)
     , parts_ranges(std::move(parts_))
@@ -59,6 +60,7 @@ MergeTreeReadPoolBase::MergeTreeReadPoolBase(
     , patch_join_cache(std::make_shared<PatchJoinCache>(context_->getSettingsRef()[Setting::apply_patch_parts_join_cache_buckets]))
     , header(storage_snapshot->getSampleBlockForColumns(column_names))
     , ranges_in_patch_parts(context_->getSettingsRef()[Setting::merge_tree_min_read_task_size])
+    , index_build_context(std::move(index_build_context_))
     , profile_callback([this](ReadBufferFromFileBase::ProfileInfo info_) { profileFeedback(info_); })
 {
     fillPerPartInfos(context_->getSettingsRef());
@@ -335,6 +337,17 @@ std::vector<size_t> MergeTreeReadPoolBase::getPerPartSumMarks() const
     return per_part_sum_marks;
 }
 
+bool MergeTreeReadPoolBase::shouldSkipPartRead(const MergeTreeReadTaskInfo & read_info) const
+{
+    if (!index_build_context)
+        return false;
+
+    return !index_build_context->partHasSelectedGranules(
+        read_info.part_index_in_query,
+        storage_snapshot->metadata,
+        read_info.alter_conversions->getAllUpdatedColumns());
+}
+
 MergeTreeReadTaskPtr MergeTreeReadPoolBase::createTask(
     MergeTreeReadTaskInfoPtr read_info,
     MergeTreeReadTask::Readers task_readers,
@@ -387,7 +400,12 @@ MergeTreeReadTaskPtr MergeTreeReadPoolBase::createTask(
     auto extras = getExtras();
     MergeTreeReadTask::Readers task_readers;
 
-    if (!previous_task)
+    if (shouldSkipPartRead(*read_info))
+        return createTask(read_info, std::move(task_readers), MarkRanges{}, {}, updater);
+
+    const bool can_reuse_previous_readers = previous_task && previous_task->hasReaders();
+
+    if (!can_reuse_previous_readers)
     {
         task_readers = MergeTreeReadTask::createReaders(read_info, extras, ranges, patches_ranges);
     }

--- a/src/Storages/MergeTree/MergeTreeReadPoolBase.h
+++ b/src/Storages/MergeTree/MergeTreeReadPoolBase.h
@@ -4,6 +4,7 @@
 #include <Storages/MergeTree/IMergeTreeReadPool.h>
 #include <Storages/MergeTree/PatchParts/RangesInPatchParts.h>
 #include <Storages/MergeTree/MergeTreeData.h>
+#include <Storages/MergeTree/MergeTreeSelectProcessor.h>
 
 namespace DB
 {
@@ -44,7 +45,8 @@ public:
         const Names & column_names_,
         const PoolSettings & settings_,
         const MergeTreeReadTask::BlockSizeParams & params_,
-        const ContextPtr & context_);
+        const ContextPtr & context_,
+        MergeTreeIndexBuildContextPtr index_build_context_ = {});
 
     /// Simplified c'tor for MergeTreeReadPoolProjectionIndex
     MergeTreeReadPoolBase(
@@ -61,6 +63,8 @@ public:
     Block getHeader() const override { return header; }
 
 protected:
+    bool shouldSkipPartRead(const MergeTreeReadTaskInfo & read_info) const;
+
     /// Initialized in constructor
     const StorageSnapshotPtr storage_snapshot;
     const RangesInDataParts parts_ranges;
@@ -110,6 +114,7 @@ protected:
     RangesInPatchParts ranges_in_patch_parts;
     std::vector<bool> is_part_on_remote_disk;
 
+    MergeTreeIndexBuildContextPtr index_build_context;
     ReadBufferFromFileBase::ProfileCallback profile_callback;
 };
 

--- a/src/Storages/MergeTree/MergeTreeReadPoolInOrder.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadPoolInOrder.cpp
@@ -25,7 +25,8 @@ MergeTreeReadPoolInOrder::MergeTreeReadPoolInOrder(
     const PoolSettings & settings_,
     const MergeTreeReadTask::BlockSizeParams & params_,
     const ContextPtr & context_,
-    RuntimeDataflowStatisticsCacheUpdaterPtr updater_)
+    RuntimeDataflowStatisticsCacheUpdaterPtr updater_,
+    MergeTreeIndexBuildContextPtr index_build_context_)
     : MergeTreeReadPoolBase(
         std::move(parts_),
         std::move(mutations_snapshot_),
@@ -39,7 +40,8 @@ MergeTreeReadPoolInOrder::MergeTreeReadPoolInOrder(
         column_names_,
         settings_,
         params_,
-        context_)
+        context_,
+        std::move(index_build_context_))
     , has_hard_limit_below_one_block(has_hard_limit_below_one_block_)
     , has_soft_limit_below_one_block(has_soft_limit_below_one_block_)
     , read_type(read_type_)

--- a/src/Storages/MergeTree/MergeTreeReadPoolInOrder.h
+++ b/src/Storages/MergeTree/MergeTreeReadPoolInOrder.h
@@ -24,7 +24,8 @@ public:
         const PoolSettings & settings_,
         const MergeTreeReadTask::BlockSizeParams & params_,
         const ContextPtr & context_,
-        RuntimeDataflowStatisticsCacheUpdaterPtr updater_);
+        RuntimeDataflowStatisticsCacheUpdaterPtr updater_,
+        MergeTreeIndexBuildContextPtr index_build_context_ = {});
 
     String getName() const override { return "ReadPoolInOrder"; }
     bool preservesOrderOfRanges() const override { return true; }

--- a/src/Storages/MergeTree/MergeTreeReadPoolParallelReplicas.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadPoolParallelReplicas.cpp
@@ -120,7 +120,8 @@ MergeTreeReadPoolParallelReplicas::MergeTreeReadPoolParallelReplicas(
     const Names & column_names_,
     const PoolSettings & settings_,
     const MergeTreeReadTask::BlockSizeParams & params_,
-    const ContextPtr & context_)
+    const ContextPtr & context_,
+    MergeTreeIndexBuildContextPtr index_build_context_)
     : MergeTreeReadPoolBase(
         std::move(parts_),
         std::move(mutations_snapshot_),
@@ -134,7 +135,8 @@ MergeTreeReadPoolParallelReplicas::MergeTreeReadPoolParallelReplicas(
         column_names_,
         settings_,
         params_,
-        context_)
+        context_,
+        std::move(index_build_context_))
     , extension(std::move(extension_))
     , coordination_mode(CoordinationMode::Default)
 {

--- a/src/Storages/MergeTree/MergeTreeReadPoolParallelReplicas.h
+++ b/src/Storages/MergeTree/MergeTreeReadPoolParallelReplicas.h
@@ -22,7 +22,8 @@ public:
         const Names & column_names_,
         const PoolSettings & settings_,
         const MergeTreeReadTask::BlockSizeParams & params_,
-        const ContextPtr & context_);
+        const ContextPtr & context_,
+        MergeTreeIndexBuildContextPtr index_build_context_ = {});
 
     ~MergeTreeReadPoolParallelReplicas() override = default;
 

--- a/src/Storages/MergeTree/MergeTreeReadPoolParallelReplicasInOrder.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadPoolParallelReplicasInOrder.cpp
@@ -37,7 +37,8 @@ MergeTreeReadPoolParallelReplicasInOrder::MergeTreeReadPoolParallelReplicasInOrd
     const Names & column_names_,
     const PoolSettings & settings_,
     const MergeTreeReadTask::BlockSizeParams & params_,
-    const ContextPtr & context_)
+    const ContextPtr & context_,
+    MergeTreeIndexBuildContextPtr index_build_context_)
     : MergeTreeReadPoolBase(
         std::move(parts_),
         std::move(mutations_snapshot_),
@@ -51,7 +52,8 @@ MergeTreeReadPoolParallelReplicasInOrder::MergeTreeReadPoolParallelReplicasInOrd
         column_names_,
         settings_,
         params_,
-        context_)
+        context_,
+        std::move(index_build_context_))
     , extension(std::move(extension_))
     , mode(mode_)
     , has_hard_limit_below_one_block(has_hard_limit_below_one_block_)

--- a/src/Storages/MergeTree/MergeTreeReadPoolParallelReplicasInOrder.h
+++ b/src/Storages/MergeTree/MergeTreeReadPoolParallelReplicasInOrder.h
@@ -25,7 +25,8 @@ public:
         const Names & column_names_,
         const PoolSettings & settings_,
         const MergeTreeReadTask::BlockSizeParams & params_,
-        const ContextPtr & context_);
+        const ContextPtr & context_,
+        MergeTreeIndexBuildContextPtr index_build_context_ = {});
 
     String getName() const override { return "ReadPoolParallelReplicasInOrder"; }
     bool preservesOrderOfRanges() const override { return true; }

--- a/src/Storages/MergeTree/MergeTreeReadTask.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadTask.cpp
@@ -296,6 +296,9 @@ void MergeTreeReadTask::initializeReadersChain(
     if (readers_chain.isInitialized())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Range readers chain is already initialized");
 
+    if (!readers.main)
+        return;
+
     PrewhereExprInfo all_prewhere_actions;
 
     if (index_build_context || lazy_materializing_rows)
@@ -387,6 +390,9 @@ UInt64 MergeTreeReadTask::estimateNumRows() const
 MergeTreeReadTask::BlockAndProgress MergeTreeReadTask::read()
 {
     auto component_guard = Coordination::setCurrentComponent("MergeTreeReadTask::read");
+    if (!readers.main)
+        return {};
+
     if (size_predictor)
         size_predictor->startBlock();
 

--- a/src/Storages/MergeTree/MergeTreeReadTask.h
+++ b/src/Storages/MergeTree/MergeTreeReadTask.h
@@ -202,6 +202,7 @@ public:
 
     const MergeTreeReadTaskInfo & getInfo() const { return *info; }
     const MergeTreeReadersChain & getReadersChain() const { return readers_chain; }
+    bool hasReaders() const { return readers.main != nullptr; }
     const IMergeTreeReader & getMainReader() const { return *readers.main; }
 
     void addPrewhereUnmatchedMarks(const MarkRanges & mark_ranges_);

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
@@ -1,5 +1,4 @@
 #include <Storages/MergeTree/MergeTreeSelectProcessor.h>
-
 #include <Columns/ColumnLazy.h>
 #include <Columns/FilterDescription.h>
 #include <DataTypes/DataTypeArray.h>
@@ -116,6 +115,57 @@ MergeTreeIndexBuildContext::MergeTreeIndexBuildContext(
     , part_remaining_marks(std::move(part_remaining_marks_))
 {
     chassert(index_reader_pool);
+}
+
+bool MergeTreeIndexBuildContext::partHasSelectedGranules(
+    size_t part_index_in_query,
+    const StorageMetadataPtr & metadata,
+    const NameSet & all_updated_columns) const
+{
+    {
+        std::lock_guard lock(part_selection_cache_mutex);
+        if (auto it = part_selection_cache.find(part_index_in_query); it != part_selection_cache.end())
+            return it->second;
+    }
+
+    const auto & part_ranges = read_ranges.at(part_index_in_query);
+    auto projection_it = projection_read_ranges.find(part_index_in_query);
+    static const RangesInDataParts empty_projection_ranges;
+    const auto & projection_parts_ranges = projection_it != projection_read_ranges.end() ? projection_it->second : empty_projection_ranges;
+
+    auto index_read_result = index_reader_pool->getOrBuildIndexReadResult(
+        part_ranges, projection_parts_ranges, metadata, all_updated_columns);
+
+    bool has_selected_granules = true;
+
+    if (index_read_result)
+    {
+        if (index_read_result->skip_index_read_result)
+        {
+            const auto & granules = index_read_result->skip_index_read_result->granules_selected;
+            has_selected_granules = std::any_of(granules.begin(), granules.end(), [](bool selected) { return selected; });
+        }
+
+        if (has_selected_granules && index_read_result->projection_index_read_result)
+            has_selected_granules = !index_read_result->projection_index_read_result->empty();
+    }
+
+    if (!has_selected_granules)
+        markPartFullySkipped(part_index_in_query);
+
+    {
+        std::lock_guard lock(part_selection_cache_mutex);
+        part_selection_cache[part_index_in_query] = has_selected_granules;
+    }
+
+    return has_selected_granules;
+}
+
+void MergeTreeIndexBuildContext::markPartFullySkipped(size_t part_index_in_query) const
+{
+    const auto & part_ranges = read_ranges.at(part_index_in_query);
+    part_remaining_marks.at(part_index_in_query).value.store(0, std::memory_order_relaxed);
+    index_reader_pool->clear(part_ranges.data_part);
 }
 
 MergeTreeIndexReadResultPtr MergeTreeIndexBuildContext::getPreparedIndexReadResult(const MergeTreeReadTask & task) const

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.h
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.h
@@ -8,6 +8,9 @@
 #include <Storages/MergeTree/RequestResponse.h>
 #include <Processors/Chunk.h>
 
+#include <mutex>
+#include <unordered_map>
+
 namespace DB
 {
 
@@ -91,7 +94,20 @@ struct MergeTreeIndexBuildContext
         MergeTreeIndexReadResultPoolPtr index_reader_pool_,
         PartRemainingMarks part_remaining_marks_);
 
+    /// Returns true if skip or projection indexes leave at least one granule to read in the part.
+    /// Builds the index read result on first call and caches the answer per part.
+    bool partHasSelectedGranules(
+        size_t part_index_in_query,
+        const StorageMetadataPtr & metadata,
+        const NameSet & all_updated_columns) const;
+
     MergeTreeIndexReadResultPtr getPreparedIndexReadResult(const MergeTreeReadTask & task) const;
+
+private:
+    void markPartFullySkipped(size_t part_index_in_query) const;
+
+    mutable std::unordered_map<size_t, bool> part_selection_cache;
+    mutable std::mutex part_selection_cache_mutex;
 };
 
 using MergeTreeIndexBuildContextPtr = std::shared_ptr<MergeTreeIndexBuildContext>;


### PR DESCRIPTION
**Change**  : With `use_skip_indexes_on_data_read = 1`, evaluate skip indexes before instantiating `MergeTree` readers so that fully filtered `parts` do not load column marks  (or prefetch column data), while keeping skip index checks parallel across read threads. 

Note that the essential identity of `use_skip_indexes_on_data_read = 1` is still maintained. Data read of a selected `part` will begin immediately when it's skip index filtering is complete.

Currently, take a case where PK filtering has resulted in 1000 parts and skip index filtering is deferred to read time with `use_skip_indexes_on_data_read = 1`. The column readers of the 1000 parts will immediately start reading their marks etc and cause significant load on the thread pool / storage.  Skip Index filtering may finally find only 20 `parts` to be read.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
