### PR TITLE
backfill_distroless: also tag with floating major.minor and minor refs

### DIFF
--- a/.github/workflows/backfill_distroless.yml
+++ b/.github/workflows/backfill_distroless.yml
@@ -72,8 +72,15 @@ jobs:
               DOCKERFILE=${rest%%:*}
               CONTEXT=${rest#*:}
 
-              echo "--- ${IMAGE_NAME}:${VERSION}-distroless ---"
+              echo "--- ${IMAGE_NAME}:${VERSION}-distroless (also tagging ${VERSION_MINOR}, ${VERSION_MAJOR}) ---"
 
+              # Tag with all three precisions so the floating
+              # major.minor and minor refs (e.g. `:26.4-distroless`,
+              # `:26.4.3-distroless`) point at the rebuilt image too.
+              # Without this, a backfill rebuilds `:X.Y.Z.N-distroless`
+              # only — `:X.Y-distroless` keeps pointing at the prior
+              # vulnerable image, so consumers tracking the floating
+              # tag never pick up the patch.
               docker buildx build \
                 --platform=linux/amd64,linux/arm64 \
                 --provenance=true \
@@ -83,12 +90,14 @@ jobs:
                 --label="com.clickhouse.build.githash=${SHA}" \
                 --label="com.clickhouse.build.version=${VERSION}-distroless" \
                 --tag="${IMAGE_NAME}:${VERSION}-distroless" \
+                --tag="${IMAGE_NAME}:${VERSION_MINOR}-distroless" \
+                --tag="${IMAGE_NAME}:${VERSION_MAJOR}-distroless" \
                 --build-arg=VERSION="${VERSION}" \
                 --progress=plain \
                 --file="${DOCKERFILE}" \
                 "${CONTEXT}"
 
-              echo "Done: ${IMAGE_NAME}:${VERSION}-distroless"
+              echo "Done: ${IMAGE_NAME}:${VERSION}-distroless (+ ${VERSION_MINOR}, ${VERSION_MAJOR})"
             done
           done
 

--- a/.github/workflows/backfill_distroless.yml
+++ b/.github/workflows/backfill_distroless.yml
@@ -49,19 +49,56 @@ jobs:
           GITHUB_RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           SHA=$(git rev-parse HEAD)
 
+          # Validate every input version before doing anything. We want to
+          # bail loudly on the first bad version rather than rebuild some
+          # of the multi-version input and then fail halfway through.
           for VERSION in $INPUT_VERSIONS; do
-            echo "============================================"
-            echo "Building distroless images for ${VERSION}"
-            echo "============================================"
-
-            # Validate version format
             if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo "ERROR: Invalid version format: ${VERSION}"
               exit 1
             fi
+          done
+
+          # Sort versions descending so that within any X.Y or X.Y.Z group
+          # the HIGHEST patch is processed first. We use that ordering to
+          # decide which version "owns" the floating refs: only the first
+          # version seen for a given X.Y / X.Y.Z gets to update those
+          # floating tags. Without this, an input like
+          # `versions="26.4.4.10 26.4.3.37"` would publish the floating
+          # `:26.4-distroless` ref pointing at the older 26.4.3.37 image
+          # because the lower version is processed last.
+          SORTED_VERSIONS=$(printf '%s\n' $INPUT_VERSIONS | sort -rV)
+
+          SEEN_MINOR=""
+          SEEN_MAJOR=""
+
+          for VERSION in $SORTED_VERSIONS; do
+            echo "============================================"
+            echo "Building distroless images for ${VERSION}"
+            echo "============================================"
 
             VERSION_MINOR=${VERSION%.*}
             VERSION_MAJOR=${VERSION_MINOR%.*}
+
+            # Decide which floating tags THIS version is allowed to write.
+            # First time we see a given X.Y.Z or X.Y in this run, we let
+            # this build update that floating ref. Subsequent (lower)
+            # versions in the same group skip it.
+            FLOATING_TAGS=""
+            case " $SEEN_MINOR " in
+              *" $VERSION_MINOR "*)
+                echo "skipping :${VERSION_MINOR}-distroless — already updated by a higher patch in this run" ;;
+              *)
+                FLOATING_TAGS="$FLOATING_TAGS:${VERSION_MINOR}"
+                SEEN_MINOR="$SEEN_MINOR $VERSION_MINOR" ;;
+            esac
+            case " $SEEN_MAJOR " in
+              *" $VERSION_MAJOR "*)
+                echo "skipping :${VERSION_MAJOR}-distroless — already updated by a higher patch in this run" ;;
+              *)
+                FLOATING_TAGS="$FLOATING_TAGS:${VERSION_MAJOR}"
+                SEEN_MAJOR="$SEEN_MAJOR $VERSION_MAJOR" ;;
+            esac
 
             for image_config in \
               "clickhouse/clickhouse-server:docker/server/Dockerfile.distroless:docker/server" \
@@ -72,15 +109,19 @@ jobs:
               DOCKERFILE=${rest%%:*}
               CONTEXT=${rest#*:}
 
-              echo "--- ${IMAGE_NAME}:${VERSION}-distroless (also tagging ${VERSION_MINOR}, ${VERSION_MAJOR}) ---"
+              # Build the --tag args. Full-version tag always written;
+              # floating tags only for versions that won the descending-
+              # sort race above.
+              TAG_ARGS="--tag=${IMAGE_NAME}:${VERSION}-distroless"
+              IFS=':' read -ra _floats <<<"${FLOATING_TAGS}"
+              for _f in "${_floats[@]}"; do
+                if [ -n "$_f" ]; then
+                  TAG_ARGS="${TAG_ARGS} --tag=${IMAGE_NAME}:${_f}-distroless"
+                fi
+              done
 
-              # Tag with all three precisions so the floating
-              # major.minor and minor refs (e.g. `:26.4-distroless`,
-              # `:26.4.3-distroless`) point at the rebuilt image too.
-              # Without this, a backfill rebuilds `:X.Y.Z.N-distroless`
-              # only — `:X.Y-distroless` keeps pointing at the prior
-              # vulnerable image, so consumers tracking the floating
-              # tag never pick up the patch.
+              echo "--- ${IMAGE_NAME}:${VERSION}-distroless${FLOATING_TAGS:+ (also${FLOATING_TAGS//:/ +})} ---"
+
               docker buildx build \
                 --platform=linux/amd64,linux/arm64 \
                 --provenance=true \
@@ -89,15 +130,13 @@ jobs:
                 --label="build-url=${GITHUB_RUN_URL}" \
                 --label="com.clickhouse.build.githash=${SHA}" \
                 --label="com.clickhouse.build.version=${VERSION}-distroless" \
-                --tag="${IMAGE_NAME}:${VERSION}-distroless" \
-                --tag="${IMAGE_NAME}:${VERSION_MINOR}-distroless" \
-                --tag="${IMAGE_NAME}:${VERSION_MAJOR}-distroless" \
+                ${TAG_ARGS} \
                 --build-arg=VERSION="${VERSION}" \
                 --progress=plain \
                 --file="${DOCKERFILE}" \
                 "${CONTEXT}"
 
-              echo "Done: ${IMAGE_NAME}:${VERSION}-distroless (+ ${VERSION_MINOR}, ${VERSION_MAJOR})"
+              echo "Done: ${IMAGE_NAME}:${VERSION}-distroless"
             done
           done
 

--- a/.github/workflows/backfill_distroless.yml
+++ b/.github/workflows/backfill_distroless.yml
@@ -59,6 +59,52 @@ jobs:
             fi
           done
 
+          # Read the currently-published com.clickhouse.build.version label
+          # from a floating tag. Echoes the X.Y.Z.N version, or empty if the
+          # tag does not exist yet. Returns non-zero on any other failure so
+          # the caller can bail rather than silently overwrite.
+          read_published_version() {
+            local image="$1"
+            local tag="$2"
+            local manifest_raw
+            local err
+
+            manifest_raw=$(docker buildx imagetools inspect "${image}:${tag}" --format '{{json .}}' 2>/dev/null) || {
+              err=$(docker buildx imagetools inspect "${image}:${tag}" 2>&1 1>/dev/null || true)
+              if echo "$err" | grep -qiE "not found|manifest unknown|no such manifest|does not exist"; then
+                return 0
+              fi
+              echo "ERROR: failed to inspect ${image}:${tag}: ${err}" >&2
+              return 1
+            }
+
+            local label
+            label=$(echo "$manifest_raw" | jq -r '
+              (.image // {}) as $img |
+              if ($img | has("config")) then
+                $img.config.Labels["com.clickhouse.build.version"] // ""
+              else
+                ($img | to_entries[]? | .value.config.Labels["com.clickhouse.build.version"]) // ""
+              end' 2>/dev/null | grep -v '^$' | head -1)
+
+            if [ -z "$label" ]; then
+              echo "ERROR: ${image}:${tag} has no com.clickhouse.build.version label" >&2
+              return 1
+            fi
+
+            local version="${label%-distroless}"
+            if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "ERROR: ${image}:${tag} label '${label}' is not X.Y.Z.N-distroless" >&2
+              return 1
+            fi
+            echo "$version"
+          }
+
+          # Returns 0 if $1 >= $2 (semver-ish via sort -V), 1 otherwise.
+          version_ge() {
+            [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n 1)" = "$1" ]
+          }
+
           # Sort versions descending so that within any X.Y or X.Y.Z group
           # the HIGHEST patch is processed first. We use that ordering to
           # decide which version "owns" the floating refs: only the first
@@ -111,16 +157,36 @@ jobs:
 
               # Build the --tag args. Full-version tag always written;
               # floating tags only for versions that won the descending-
-              # sort race above.
+              # sort race above AND are >= whatever is currently published
+              # at the floating ref. The cross-run check guards against a
+              # later partial backfill of an older patch silently moving
+              # the floating tag backwards. Anyone tracking :X.Y-distroless
+              # would otherwise see a downgrade with no warning.
               TAG_ARGS="--tag=${IMAGE_NAME}:${VERSION}-distroless"
+              EFFECTIVE_FLOATS=""
               IFS=':' read -ra _floats <<<"${FLOATING_TAGS}"
               for _f in "${_floats[@]}"; do
-                if [ -n "$_f" ]; then
+                if [ -z "$_f" ]; then
+                  continue
+                fi
+                if ! PUBLISHED=$(read_published_version "${IMAGE_NAME}" "${_f}-distroless"); then
+                  echo "ERROR: cannot read currently-published version for ${IMAGE_NAME}:${_f}-distroless — refusing to overwrite floating tag" >&2
+                  exit 1
+                fi
+                if [ -z "$PUBLISHED" ]; then
+                  echo "  ${IMAGE_NAME}:${_f}-distroless does not exist yet, will publish ${VERSION}"
                   TAG_ARGS="${TAG_ARGS} --tag=${IMAGE_NAME}:${_f}-distroless"
+                  EFFECTIVE_FLOATS="${EFFECTIVE_FLOATS}:${_f}"
+                elif version_ge "${VERSION}" "${PUBLISHED}"; then
+                  echo "  ${IMAGE_NAME}:${_f}-distroless currently at ${PUBLISHED}, will overwrite with ${VERSION}"
+                  TAG_ARGS="${TAG_ARGS} --tag=${IMAGE_NAME}:${_f}-distroless"
+                  EFFECTIVE_FLOATS="${EFFECTIVE_FLOATS}:${_f}"
+                else
+                  echo "  skipping ${IMAGE_NAME}:${_f}-distroless — published ${PUBLISHED} is newer than candidate ${VERSION}"
                 fi
               done
 
-              echo "--- ${IMAGE_NAME}:${VERSION}-distroless${FLOATING_TAGS:+ (also${FLOATING_TAGS//:/ +})} ---"
+              echo "--- ${IMAGE_NAME}:${VERSION}-distroless${EFFECTIVE_FLOATS:+ (also${EFFECTIVE_FLOATS//:/ +})} ---"
 
               docker buildx build \
                 --platform=linux/amd64,linux/arm64 \


### PR DESCRIPTION
BackfillDistroless only writes the full-version `:X.Y.Z.N-distroless` tag right now. Floating refs like `:X.Y-distroless` and `:X.Y.Z-distroless` keep pointing at the old vulnerable image, so the rebuild silently doesn't help anyone tracking those.

Hit this for real on 2026-06-08 — ran a backfill for 26.4.3.37, it built and pushed the patched image fine, but `:26.4-distroless` stayed on the old digest. Our CVE scanner kept flagging the same libssl3t64 CVEs the next morning.

Adds two extra `--tag` lines for the `VERSION_MINOR` and `VERSION_MAJOR` values the script was already computing but not using.


### Changelog category (leave one):
- Build/Testing/Packaging Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

`BackfillDistroless` now also updates the `:X.Y-distroless` and `:X.Y.Z-distroless` floating tags, not just the full-version tag.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.610`
<!-- ch-version-info:end -->