### PR TITLE
Fix UBSan signed integer overflow in arrayLevenshteinDistanceWeighted

### DIFF
--- a/src/Common/levenshteinDistance.h
+++ b/src/Common/levenshteinDistance.h
@@ -50,11 +50,15 @@ size_t levenshteinDistance(std::span<const Element> lhs, std::span<const Element
     return v0[n];
 };
 
-/// Accumulator type for the weighted distance. Integral weights are summed in a wide integer so the
-/// arithmetic stays exact and never overflows (wide::integer has defined wraparound, not signed UB);
-/// floating weights are summed in Float64. The result is converted to Float64 once at the end.
+/// Accumulator type for the weighted distance. Integral weights are summed in a wide integer twice as
+/// wide as the weight (at least 256-bit), so any feasible array sum stays exact and cannot overflow:
+/// overflowing would need more than 2^(weight bits) elements. 256-bit weights therefore accumulate in
+/// 512 bits. Floating weights are summed in Float64. The result is converted to Float64 once at the end.
 template <class Weight>
-using LevenshteinWeightAccumulator = std::conditional_t<is_integer<Weight>, std::conditional_t<is_unsigned_v<Weight>, UInt256, Int256>, Float64>;
+using LevenshteinWeightAccumulator = std::conditional_t<
+    is_integer<Weight>,
+    wide::integer<std::max<size_t>(256, sizeof(Weight) * 8 * 2), std::conditional_t<is_unsigned_v<Weight>, unsigned, signed>>,
+    Float64>;
 
 /// Levenshtein Distance with weights, is used to calculate custom distance from lhs to rhs.
 /// The result is Float64 (the SQL functions return Float64). To avoid overflow/UB on weights near the

--- a/src/Common/levenshteinDistance.h
+++ b/src/Common/levenshteinDistance.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include <base/types.h>
+#include <base/extended_types.h>
 #include <Common/PODArray.h>
 #include <Common/iota.h>
 #include <span>
 
 #include <algorithm>
+#include <type_traits>
 
 namespace DB
 {
@@ -48,12 +50,22 @@ size_t levenshteinDistance(std::span<const Element> lhs, std::span<const Element
     return v0[n];
 };
 
+/// Accumulator type for the weighted distance. Integral weights are summed in a wide integer so the
+/// arithmetic stays exact and never overflows (wide::integer has defined wraparound, not signed UB);
+/// floating weights are summed in Float64. The result is converted to Float64 once at the end.
+template <class Weight>
+using LevenshteinWeightAccumulator = std::conditional_t<is_integer<Weight>, std::conditional_t<is_unsigned_v<Weight>, UInt256, Int256>, Float64>;
+
 /// Levenshtein Distance with weights, is used to calculate custom distance from lhs to rhs.
-/// All callers consume the result as Float64, so sums are accumulated in Float64 to avoid integer overflow.
+/// The result is Float64 (the SQL functions return Float64). To avoid overflow/UB on weights near the
+/// type maximum, the dynamic-programming sums use a wide internal accumulator (see above): integral
+/// weights stay exact, then the final value is cast to Float64 only once.
 template <class Element, class Weight>
 Float64 levenshteinDistanceWeighted(std::span<const Element> lhs, std::span<const Element> rhs,
                                     std::span<const Weight> lhs_weights, std::span<const Weight> rhs_weights)
 {
+    using Acc = LevenshteinWeightAccumulator<Weight>;
+
     if (lhs.size() != lhs_weights.size() || rhs.size() != rhs_weights.size())
         throw Exception(
             ErrorCodes::SIZES_OF_ARRAYS_DONT_MATCH,
@@ -63,16 +75,16 @@ Float64 levenshteinDistanceWeighted(std::span<const Element> lhs, std::span<cons
             rhs.size(),
             rhs_weights.size());
 
-    auto sum_span = [](const std::span<const Weight> & span) -> Float64
+    auto sum_span = [](const std::span<const Weight> & span) -> Acc
     {
-        Float64 sum = 0;
+        Acc sum = 0;
         for (const auto & weight : span)
-            sum += static_cast<Float64>(weight);
+            sum += static_cast<Acc>(weight);
         return sum;
     };
     if (lhs.empty() || rhs.empty())
     {
-        return sum_span(lhs_weights) + sum_span(rhs_weights);
+        return static_cast<Float64>(sum_span(lhs_weights) + sum_span(rhs_weights));
     }
 
     // Consume minimum memory by allocating sliding vector for min `m`
@@ -85,19 +97,19 @@ Float64 levenshteinDistanceWeighted(std::span<const Element> lhs, std::span<cons
     const size_t m = lhs.size();
     const size_t n = rhs.size();
 
-    PODArray<Float64> row(m + 1);
+    PODArray<Acc> row(m + 1);
 
     row[0] = 0;
     for (size_t i = 1; i <= m; ++i)
-        row[i] = row[i - 1] + static_cast<Float64>(lhs_weights[i - 1]);
+        row[i] = row[i - 1] + static_cast<Acc>(lhs_weights[i - 1]);
 
     for (size_t j = 1; j <= n; ++j)
     {
-        Float64 prev = row[0];
-        row[0] += static_cast<Float64>(rhs_weights[j - 1]);
+        Acc prev = row[0];
+        row[0] += static_cast<Acc>(rhs_weights[j - 1]);
         for (size_t i = 1; i <= m; ++i)
         {
-            Float64 old = row[i];
+            Acc old = row[i];
             if (lhs[i - 1] == rhs[j - 1])
             {
                 row[i] = prev;
@@ -106,14 +118,14 @@ Float64 levenshteinDistanceWeighted(std::span<const Element> lhs, std::span<cons
             }
 
             row[i] = std::min(
-                {old + static_cast<Float64>(rhs_weights[j - 1]), // deletion
-                 row[i - 1] + static_cast<Float64>(lhs_weights[i - 1]), // insertion
-                 prev + static_cast<Float64>(lhs_weights[i - 1]) + static_cast<Float64>(rhs_weights[j - 1])}); // substitution
+                {old + static_cast<Acc>(rhs_weights[j - 1]), // deletion
+                 row[i - 1] + static_cast<Acc>(lhs_weights[i - 1]), // insertion
+                 prev + static_cast<Acc>(lhs_weights[i - 1]) + static_cast<Acc>(rhs_weights[j - 1])}); // substitution
             prev = old;
         }
     }
 
-    return row[m];
+    return static_cast<Float64>(row[m]);
 };
 
 }

--- a/src/Common/levenshteinDistance.h
+++ b/src/Common/levenshteinDistance.h
@@ -5,7 +5,7 @@
 #include <Common/iota.h>
 #include <span>
 
-#include <numeric>
+#include <algorithm>
 
 namespace DB
 {
@@ -48,10 +48,11 @@ size_t levenshteinDistance(std::span<const Element> lhs, std::span<const Element
     return v0[n];
 };
 
-/// Levenshtein Distance with weights, is used to calculate custom distance from lhs to rhs
+/// Levenshtein Distance with weights, is used to calculate custom distance from lhs to rhs.
+/// All callers consume the result as Float64, so sums are accumulated in Float64 to avoid integer overflow.
 template <class Element, class Weight>
-Weight levenshteinDistanceWeighted(std::span<const Element> lhs, std::span<const Element> rhs,
-                                   std::span<const Weight> lhs_weights, std::span<const Weight> rhs_weights)
+Float64 levenshteinDistanceWeighted(std::span<const Element> lhs, std::span<const Element> rhs,
+                                    std::span<const Weight> lhs_weights, std::span<const Weight> rhs_weights)
 {
     if (lhs.size() != lhs_weights.size() || rhs.size() != rhs_weights.size())
         throw Exception(
@@ -62,9 +63,12 @@ Weight levenshteinDistanceWeighted(std::span<const Element> lhs, std::span<const
             rhs.size(),
             rhs_weights.size());
 
-    auto sum_span = [](const std::span<const Weight> & span) -> Weight
+    auto sum_span = [](const std::span<const Weight> & span) -> Float64
     {
-        return std::accumulate(span.begin(), span.end(), Weight{});
+        Float64 sum = 0;
+        for (const auto & weight : span)
+            sum += static_cast<Float64>(weight);
+        return sum;
     };
     if (lhs.empty() || rhs.empty())
     {
@@ -81,18 +85,19 @@ Weight levenshteinDistanceWeighted(std::span<const Element> lhs, std::span<const
     const size_t m = lhs.size();
     const size_t n = rhs.size();
 
-    PODArray<Weight> row(m + 1);
+    PODArray<Float64> row(m + 1);
 
     row[0] = 0;
-    std::partial_sum(lhs_weights.begin(), lhs_weights.end(), row.begin() + 1);
+    for (size_t i = 1; i <= m; ++i)
+        row[i] = row[i - 1] + static_cast<Float64>(lhs_weights[i - 1]);
 
     for (size_t j = 1; j <= n; ++j)
     {
-        Weight prev = row[0];
-        row[0] += rhs_weights[j - 1];
+        Float64 prev = row[0];
+        row[0] += static_cast<Float64>(rhs_weights[j - 1]);
         for (size_t i = 1; i <= m; ++i)
         {
-            Weight old = row[i];
+            Float64 old = row[i];
             if (lhs[i - 1] == rhs[j - 1])
             {
                 row[i] = prev;
@@ -100,10 +105,10 @@ Weight levenshteinDistanceWeighted(std::span<const Element> lhs, std::span<const
                 continue;
             }
 
-            row[i] = static_cast<Weight>(std::min(
-                {old + rhs_weights[j - 1], // deletion
-                 row[i - 1] + lhs_weights[i - 1], // insertion
-                 prev + lhs_weights[i - 1] + rhs_weights[j - 1]})); // substitution
+            row[i] = std::min(
+                {old + static_cast<Float64>(rhs_weights[j - 1]), // deletion
+                 row[i - 1] + static_cast<Float64>(lhs_weights[i - 1]), // insertion
+                 prev + static_cast<Float64>(lhs_weights[i - 1]) + static_cast<Float64>(rhs_weights[j - 1])}); // substitution
             prev = old;
         }
     }

--- a/src/Functions/array/arrayLevenshtein.cpp
+++ b/src/Functions/array/arrayLevenshtein.cpp
@@ -528,14 +528,18 @@ private:
                 res_values[row] = 1.0;
                 continue;
             }
-            W weights_sum = std::accumulate(from_weights.begin(), from_weights.end(), W{}) +
-                            std::accumulate(to_weights.begin(), to_weights.end(), W{});
+            // Accumulate in Float64 to match the distance domain and avoid overflow in the weight type.
+            Float64 weights_sum = 0;
+            for (const auto & weight : from_weights)
+                weights_sum += static_cast<Float64>(weight);
+            for (const auto & weight : to_weights)
+                weights_sum += static_cast<Float64>(weight);
             if (weights_sum == 0)
             {
                 res_values[row] = 1.0;
                 continue;
             }
-            res_values[row] = 1.0 - (distance->getFloat64(row) / static_cast<Float64>(weights_sum));
+            res_values[row] = 1.0 - (distance->getFloat64(row) / weights_sum);
         }
         return true;
     }

--- a/src/Functions/array/arrayLevenshtein.cpp
+++ b/src/Functions/array/arrayLevenshtein.cpp
@@ -528,12 +528,15 @@ private:
                 res_values[row] = 1.0;
                 continue;
             }
-            // Accumulate in Float64 to match the distance domain and avoid overflow in the weight type.
-            Float64 weights_sum = 0;
+            // Sum the weights in a wide accumulator (exact for integral weights, no overflow/UB), then
+            // convert once to Float64 to match the distance domain. Mirrors levenshteinDistanceWeighted.
+            using Acc = LevenshteinWeightAccumulator<W>;
+            Acc weights_acc = 0;
             for (const auto & weight : from_weights)
-                weights_sum += static_cast<Float64>(weight);
+                weights_acc += static_cast<Acc>(weight);
             for (const auto & weight : to_weights)
-                weights_sum += static_cast<Float64>(weight);
+                weights_acc += static_cast<Acc>(weight);
+            const Float64 weights_sum = static_cast<Float64>(weights_acc);
             if (weights_sum == 0)
             {
                 res_values[row] = 1.0;

--- a/tests/queries/0_stateless/04327_array_levenshtein_weighted_overflow.reference
+++ b/tests/queries/0_stateless/04327_array_levenshtein_weighted_overflow.reference
@@ -12,3 +12,9 @@
 9007199254740994
 9007199254740994
 9007199254740994
+--- widest (256-bit) weights do not wrap the accumulator ---
+1
+0
+1
+1
+1

--- a/tests/queries/0_stateless/04327_array_levenshtein_weighted_overflow.reference
+++ b/tests/queries/0_stateless/04327_array_levenshtein_weighted_overflow.reference
@@ -8,3 +8,7 @@
 --- results stay finite ---
 1
 1
+--- large integer weights stay exact (sum accumulated without rounding) ---
+9007199254740994
+9007199254740994
+9007199254740994

--- a/tests/queries/0_stateless/04327_array_levenshtein_weighted_overflow.reference
+++ b/tests/queries/0_stateless/04327_array_levenshtein_weighted_overflow.reference
@@ -1,0 +1,10 @@
+--- large integer weights do not overflow ---
+36893488147419103000
+18446744073709552000
+18446744073709552000
+73786976294838210000
+--- arraySimilarity weights_sum does not overflow ---
+0
+--- results stay finite ---
+1
+1

--- a/tests/queries/0_stateless/04327_array_levenshtein_weighted_overflow.sql
+++ b/tests/queries/0_stateless/04327_array_levenshtein_weighted_overflow.sql
@@ -10,3 +10,13 @@ SELECT arraySimilarity(['a', 'b'], ['c', 'd'], [9223372036854775807, 92233720368
 SELECT '--- results stay finite ---';
 SELECT isFinite(arrayLevenshteinDistanceWeighted(['a', 'b'], ['c', 'd'], [9223372036854775807, 9223372036854775807]::Array(Int64), [9223372036854775807, 9223372036854775807]::Array(Int64)));
 SELECT isFinite(arraySimilarity(['a', 'b'], ['c', 'd'], [9223372036854775807, 9223372036854775807]::Array(Int64), [9223372036854775807, 9223372036854775807]::Array(Int64)));
+
+SELECT '--- large integer weights stay exact (sum accumulated without rounding) ---';
+-- Empty-side shortcut: 9007199254740992 + 1 + 1 must accumulate exactly to 9007199254740994
+-- (representable in Float64), not collapse to 9007199254740992 as plain Float64 adds would.
+SELECT toUInt64(arrayLevenshteinDistanceWeighted([]::Array(UInt8), [1, 2, 3]::Array(UInt8), []::Array(Int64), [9007199254740992, 1, 1]::Array(Int64)));
+-- Same exactness on the DP path: cost accumulates 9007199254740992 + 1 + 1 = 9007199254740994,
+-- which plain Float64 adds would round back down to 9007199254740992.
+SELECT toUInt64(arrayLevenshteinDistanceWeighted(['a'], ['b', 'c'], [9007199254740992]::Array(Int64), [1, 1]::Array(Int64)));
+-- Unsigned wide accumulator stays exact too: 2^53 + 2 over two UInt64 weights.
+SELECT toUInt64(arrayLevenshteinDistanceWeighted([]::Array(UInt8), [1, 2, 3]::Array(UInt8), []::Array(UInt64), [9007199254740992, 1, 1]::Array(UInt64)));

--- a/tests/queries/0_stateless/04327_array_levenshtein_weighted_overflow.sql
+++ b/tests/queries/0_stateless/04327_array_levenshtein_weighted_overflow.sql
@@ -20,3 +20,14 @@ SELECT toUInt64(arrayLevenshteinDistanceWeighted([]::Array(UInt8), [1, 2, 3]::Ar
 SELECT toUInt64(arrayLevenshteinDistanceWeighted(['a'], ['b', 'c'], [9007199254740992]::Array(Int64), [1, 1]::Array(Int64)));
 -- Unsigned wide accumulator stays exact too: 2^53 + 2 over two UInt64 weights.
 SELECT toUInt64(arrayLevenshteinDistanceWeighted([]::Array(UInt8), [1, 2, 3]::Array(UInt8), []::Array(UInt64), [9007199254740992, 1, 1]::Array(UInt64)));
+
+SELECT '--- widest (256-bit) weights do not wrap the accumulator ---';
+-- UInt256::max() + 1 + 1 must stay a large positive distance, not wrap the accumulator to 0.
+SELECT arrayLevenshteinDistanceWeighted([]::Array(UInt8), [1, 2, 3]::Array(UInt8), []::Array(UInt256), [toUInt256('115792089237316195423570985008687907853269984665640564039457584007913129639935'), 1, 1]::Array(UInt256)) > 0;
+-- arraySimilarity must not report perfect similarity (1) for a total mismatch with such weights.
+SELECT arraySimilarity([]::Array(UInt8), [1, 2, 3]::Array(UInt8), []::Array(UInt256), [toUInt256('115792089237316195423570985008687907853269984665640564039457584007913129639935'), 1, 1]::Array(UInt256));
+-- The same large UInt256 weight on the DP (insertion) path stays positive.
+SELECT arrayLevenshteinDistanceWeighted(['a'], ['b', 'c'], [toUInt256('115792089237316195423570985008687907853269984665640564039457584007913129639935')]::Array(UInt256), [1, 1]::Array(UInt256)) > 0;
+-- Signed Int256::max() summed twice must stay positive (no signed wrap to a negative value).
+SELECT arrayLevenshteinDistanceWeighted([]::Array(UInt8), [1, 2]::Array(UInt8), []::Array(Int256), [toInt256('57896044618658097711785492504343953926634992332820282019728792003956564819967'), toInt256('57896044618658097711785492504343953926634992332820282019728792003956564819967')]::Array(Int256)) > 0;
+SELECT isFinite(arrayLevenshteinDistanceWeighted([]::Array(UInt8), [1, 2, 3]::Array(UInt8), []::Array(UInt256), [toUInt256('115792089237316195423570985008687907853269984665640564039457584007913129639935'), 1, 1]::Array(UInt256)));

--- a/tests/queries/0_stateless/04327_array_levenshtein_weighted_overflow.sql
+++ b/tests/queries/0_stateless/04327_array_levenshtein_weighted_overflow.sql
@@ -1,0 +1,12 @@
+SELECT '--- large integer weights do not overflow ---';
+SELECT arrayLevenshteinDistanceWeighted(['a', 'b'], ['c', 'd'], [9223372036854775807, 9223372036854775807]::Array(Int64), [9223372036854775807, 9223372036854775807]::Array(Int64));
+SELECT arrayLevenshteinDistanceWeighted(['a', 'b', 'c'], ['x'], [9223372036854775807, 9223372036854775807, 1]::Array(Int64), [5]::Array(Int64));
+SELECT arrayLevenshteinDistanceWeighted([]::Array(String), ['a', 'b'], []::Array(Int64), [9223372036854775807, 9223372036854775807]::Array(Int64));
+SELECT arrayLevenshteinDistanceWeighted([1, 2], [3, 4], [18446744073709551615, 18446744073709551615]::Array(UInt64), [18446744073709551615, 18446744073709551615]::Array(UInt64));
+
+SELECT '--- arraySimilarity weights_sum does not overflow ---';
+SELECT arraySimilarity(['a', 'b'], ['c', 'd'], [9223372036854775807, 9223372036854775807]::Array(Int64), [9223372036854775807, 9223372036854775807]::Array(Int64));
+
+SELECT '--- results stay finite ---';
+SELECT isFinite(arrayLevenshteinDistanceWeighted(['a', 'b'], ['c', 'd'], [9223372036854775807, 9223372036854775807]::Array(Int64), [9223372036854775807, 9223372036854775807]::Array(Int64)));
+SELECT isFinite(arraySimilarity(['a', 'b'], ['c', 'd'], [9223372036854775807, 9223372036854775807]::Array(Int64), [9223372036854775807, 9223372036854775807]::Array(Int64)));


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a signed integer overflow (undefined behavior) in `arrayLevenshteinDistanceWeighted` and `arraySimilarity` when the weight arrays contain large integer values. The weighted distance is now accumulated in a wide integer for integral weights, so large integer weights no longer overflow and stay exact.

## Description

`levenshteinDistanceWeighted<Element, Weight>` did all of its DP arithmetic in the template `Weight` type (the SQL weight array element type). Integer weights near the type maximum (e.g. `Int64` `LLONG_MAX`) overflowed at every accumulation: the `partial_sum` seeding the row, the `row[0]` prefix, the three adds inside `min{}`, the empty-side `sum_span`, and the separate `weights_sum` in `arraySimilarity`. UBSan reported `1 + LLONG_MAX cannot be represented in type 'long'`; in release the result was undefined.

The functions return `Float64`, so the sums are now accumulated in `LevenshteinWeightAccumulator<Weight>` and cast to `Float64` once at the end. For integral weights the accumulator is a `wide::integer` twice as wide as the weight (at least 256-bit, 512-bit for `Int256`/`UInt256` weights), so a sum can overflow only with more than `2^(weight bits)` elements (not representable); integral results therefore stay exact for any feasible input, and `wide::integer` keeps defined wraparound rather than signed-overflow UB. Floating weights accumulate in `Float64` as before. The unweighted `size_t levenshteinDistance` is unaffected.

Reproduced under ASan+UBSan: pre-fix master overflows in `partial_sum.h:34`; post-fix the same queries return finite results with no UBSan report. Existing tests `03369_function_arrayLevenshtein` and `04125_array_levenshtein_types` pass unchanged. New test `04327_array_levenshtein_weighted_overflow` covers the overflow, the exact-integer, and the 256-bit-weight boundary cases.

Fuzzer-surfaced (AST fuzzer arm_asan_ubsan, STID 3067-370b). No related open issue found.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.712`
<!-- ch-version-info:end -->