### PR TITLE
CI: standalone update_userdata.py to reconcile macOS runner user_data

### DIFF
--- a/ci/infra/scripts/update_userdata.py
+++ b/ci/infra/scripts/update_userdata.py
@@ -80,6 +80,22 @@ def get_live_user_data(ec2, instance_id) -> str:
     return base64.b64decode(encoded).decode("utf-8") if encoded else ""
 
 
+def strip_comments(text) -> str:
+    """Drop full-line `#` comments so the match ignores comment-only edits.
+
+    Comments do not affect the booted runner, and pushing a comment-only change
+    would cycle the whole Mac fleet through multi-hour Dedicated Host scrubs for
+    nothing. The shebang (`#!`) is kept - it is functional. Only lines whose
+    first non-blank character is `#` are dropped, so a `#` inside a string or
+    heredoc is left untouched.
+    """
+    return "\n".join(
+        line
+        for line in text.splitlines()
+        if not line.lstrip().startswith("#") or line.lstrip().startswith("#!")
+    )
+
+
 def install_user_data(ec2, instance_id, state, user_data):
     """Stop the instance (waiting until fully stopped) and install `user_data` via
     `ModifyInstanceAttribute`, which requires the instance to be stopped (otherwise
@@ -212,9 +228,12 @@ def reconcile_instance(ec2, instance_id, state, user_data, update, show_diff):
     user_data differs, print a unified diff of live vs configured first. Returns
     True if a diff was printed, so the caller can show it only for the first
     mismatch.
+
+    Comments are ignored when matching (see `strip_comments`), so a comment-only
+    edit does not trigger a fleet-wide stop/start.
     """
     live = get_live_user_data(ec2, instance_id)
-    if live == user_data:
+    if strip_comments(live) == strip_comments(user_data):
         print(f"{instance_id}: user_data already up to date - skip")
         return False
 

--- a/ci/infra/scripts/update_userdata.py
+++ b/ci/infra/scripts/update_userdata.py
@@ -22,19 +22,21 @@ instance found under a config it uses that config's `region` and
 
 Instances are reconciled one at a time so the whole fleet is never stopped at
 once. Only the instance ids you pass are touched; with no `--instance` every
-live instance of every config is scanned. `--dry-run` prints the update plan
-without changing anything.
+live instance of every config is scanned. By default the script only reports
+the plan and prints a diff for the first mismatched instance - pass `--update`
+to actually stop, install, and start.
 
 Examples:
 
-    update_userdata.py --instance i-0123456789abcdef0
-    update_userdata.py --instance i-0123456789abcdef0 i-0fedcba9876543210
-    update_userdata.py                 # scan and reconcile the whole fleet
-    update_userdata.py --dry-run       # show what would change
+    update_userdata.py                                  # report the fleet plan + diff
+    update_userdata.py --instance i-0123456789abcdef0   # report one instance
+    update_userdata.py --update                         # apply to the whole fleet
+    update_userdata.py --instance i-0123456789abcdef0 --update
 """
 
 import argparse
 import base64
+import difflib
 import importlib.util
 import os
 import sys
@@ -67,16 +69,15 @@ def load_ec2_configs():
     return {config.name: config for config in module.CLOUD.ec2_instances}
 
 
-def user_data_matches(ec2, instance_id, user_data) -> bool:
-    """Return True if the instance's live `user_data` already equals `user_data`."""
+def get_live_user_data(ec2, instance_id) -> str:
+    """Return the instance's current `user_data`, decoded to text."""
     resp = ec2.describe_instance_attribute(
         InstanceId=instance_id, Attribute="userData"
     )
     encoded = (resp.get("UserData") or {}).get("Value") or ""
     if isinstance(encoded, bytes):
         encoded = encoded.decode("ascii")
-    current = base64.b64decode(encoded).decode("utf-8") if encoded else ""
-    return current == user_data
+    return base64.b64decode(encoded).decode("utf-8") if encoded else ""
 
 
 def install_user_data(ec2, instance_id, state, user_data):
@@ -203,24 +204,44 @@ def start_instances(ec2, instance_ids):
     ec2.get_waiter("instance_running").wait(InstanceIds=started)
 
 
-def reconcile_instance(ec2, instance_id, state, user_data, start, dry_run=False):
+def reconcile_instance(ec2, instance_id, state, user_data, update, show_diff):
     """Reconcile one instance: skip when the live user_data already matches,
-    otherwise stop, reinstall, and (when `start`) start it again.
+    otherwise (when `update`) stop, reinstall, and start it again.
 
-    With `dry_run`, only print whether the instance would be updated; make no
-    changes.
+    Without `update`, make no changes - only report. When `show_diff` and the
+    user_data differs, print a unified diff of live vs configured first. Returns
+    True if a diff was printed, so the caller can show it only for the first
+    mismatch.
     """
-    if user_data_matches(ec2, instance_id, user_data):
+    live = get_live_user_data(ec2, instance_id)
+    if live == user_data:
         print(f"{instance_id}: user_data already up to date - skip")
-        return
+        return False
 
-    if dry_run:
-        print(f"{instance_id}: user_data differs - would update (state={state})")
-        return
+    printed = False
+    if show_diff:
+        print(f"{instance_id}: user_data differs (state={state}):")
+        sys.stdout.writelines(
+            difflib.unified_diff(
+                live.splitlines(keepends=True),
+                user_data.splitlines(keepends=True),
+                fromfile=f"{instance_id} (live)",
+                tofile="configured",
+            )
+        )
+        if not live.endswith("\n") or not user_data.endswith("\n"):
+            print()  # keep the next log line on its own row
+        printed = True
+
+    if not update:
+        print(
+            f"{instance_id}: would update (state={state}) - pass --update to apply"
+        )
+        return printed
 
     install_user_data(ec2, instance_id, state, user_data)
-    if start:
-        start_instances(ec2, [instance_id])
+    start_instances(ec2, [instance_id])
+    return printed
 
 
 def load_user_data(config):
@@ -241,7 +262,7 @@ def load_user_data(config):
     return user_data
 
 
-def reconcile_instances(configs, requested_ids, dry_run=False):
+def reconcile_instances(configs, requested_ids, update=False):
     """Reconcile instances, sourcing each one's `region` and `user_data_file`
     from the `ci/infra/cloud.py` config that owns it.
 
@@ -251,10 +272,11 @@ def reconcile_instances(configs, requested_ids, dry_run=False):
 
     Each config's live instances are discovered with praktika's own tag-based
     lookup (`_find_existing_instances`), so the standalone update matches what
-    praktika `deploy` would launch. With `dry_run`, print the update plan
-    without changing anything.
+    praktika `deploy` would launch. Without `update`, report the plan and print
+    a diff for the first mismatched instance without changing anything.
     """
     pending = None if requested_ids is None else set(requested_ids)
+    diff_printed = False
     for config in configs.values():
         if pending is not None and not pending:
             break
@@ -275,8 +297,15 @@ def reconcile_instances(configs, requested_ids, dry_run=False):
         for inst in matched:
             instance_id = inst.get("InstanceId")
             state = (inst.get("State") or {}).get("Name")
-            reconcile_instance(
-                ec2, instance_id, state, user_data, start=True, dry_run=dry_run
+            # Show the diff only for the first mismatched instance - the
+            # configured user_data is the same for every instance of a config.
+            diff_printed |= reconcile_instance(
+                ec2,
+                instance_id,
+                state,
+                user_data,
+                update=update,
+                show_diff=not diff_printed,
             )
             if pending is not None:
                 pending.discard(instance_id)
@@ -309,19 +338,19 @@ def main():
         ),
     )
     parser.add_argument(
-        "--dry-run",
+        "--update",
         action="store_true",
         help=(
-            "Report which instances would be updated (live user_data differs "
-            "from the configured file) without stopping, updating, or starting "
-            "anything."
+            "Actually perform the update (stop, install user_data, start). "
+            "Without it the script only reports the plan and prints a diff for "
+            "the first mismatched instance, making no changes."
         ),
     )
     args = parser.parse_args()
 
-    if args.dry_run:
-        print("dry run - update plan only, no changes will be made")
-    reconcile_instances(configs, args.instance, dry_run=args.dry_run)
+    if not args.update:
+        print("report only - pass --update to apply changes")
+    reconcile_instances(configs, args.instance, update=args.update)
 
 
 if __name__ == "__main__":

--- a/ci/infra/scripts/update_userdata.py
+++ b/ci/infra/scripts/update_userdata.py
@@ -10,12 +10,15 @@ Mac instance puts its host into a multi-hour scrub (host state `pending`), so
 This script encapsulates that whole user_data update workflow so it lives apart
 from the praktika `deploy` path. It runs in two phases:
 
-  1. `build_plan` reads the live state (read-only) and produces a `Plan`. For
-     every instance it decides one action: `update` (live user_data differs -
-     stop, install, start), `start` (user_data is current but the instance is
-     stopped), or `none`.
-  2. `Plan.apply` carries the plan out, one instance at a time, blocking on the
-     Dedicated Host scrub.
+  1. `build_plan` reads the live state (read-only) and produces a list of
+     `PlanItem`s. An instance gets an `update` item when its live user_data
+     differs (stop, install, start) or a `start` item when its user_data is
+     current but it is stopped. A running, up-to-date instance needs no action
+     and is left out of the plan (logged as skipped).
+  2. Applying loops the items, one at a time, blocking on the Dedicated Host
+     scrub. Already-stopped instances are started first, before any update -
+     an update stops its instance and triggers a host scrub that would block
+     those starts.
 
 The plan is always printed. By default that is all that happens - pass
 `--apply` to execute it.
@@ -223,17 +226,18 @@ def start_instances(ec2, instance_ids):
     ec2.get_waiter("instance_running").wait(InstanceIds=started)
 
 
-# Plan item actions.
-UPDATE = "update"  # live user_data differs - stop, install, start
+# Plan item actions. Running instances with current user_data need no action
+# and are not added to the plan at all.
+UPDATE = "update"  # live user_data differs - stop, install, then start
 START = "start"  # user_data current but instance stopped - just start
-NONE = "none"  # running and current - nothing to do
 
 
 @dataclass
 class PlanItem:
     """One planned action for one instance, self-contained enough to `apply`.
 
-    `build_plan` fills these in read-only; `apply` carries a single item out.
+    `build_plan` fills these in read-only; `apply` carries a single item out,
+    waiting out the Dedicated Host scrub as part of the start.
     """
 
     config: str
@@ -249,16 +253,16 @@ class PlanItem:
         unified diff of live vs configured first; return True if it did, so the
         caller shows the diff only for the first mismatch.
         """
-        if self.action == NONE:
-            print(f"  {self.instance_id}: up to date, {self.state} - no action")
-            return False
         if self.action == START:
-            print(f"  {self.instance_id}: up to date but {self.state} - start")
+            print(
+                f"  {self.instance_id} [{self.config}] {self.state}: "
+                f"start (wait for host scrub, then start)"
+            )
             return False
 
         printed = False
         if show_diff:
-            print(f"  {self.instance_id}: user_data diff (live -> configured):")
+            print(f"  {self.instance_id} [{self.config}] user_data diff (live -> configured):")
             sys.stdout.writelines(
                 difflib.unified_diff(
                     self.live.splitlines(keepends=True),
@@ -271,41 +275,34 @@ class PlanItem:
                 print()  # keep the next log line on its own row
             printed = True
         print(
-            f"  {self.instance_id}: user_data differs ({self.state}) - "
-            f"stop, install, start"
+            f"  {self.instance_id} [{self.config}] {self.state}: "
+            f"update (stop, install, wait for host scrub, then start)"
         )
         return printed
 
     def apply(self):
-        """Carry out this item: update (stop, install, start) or start a stopped
-        instance, blocking on the Dedicated Host scrub. A NONE item is a no-op.
+        """Carry out this item. For an UPDATE: stop, install user_data, then
+        start. For a START: just start a stopped instance. Either way the start
+        blocks on the Dedicated Host scrub (see `start_instances`).
         """
-        if self.action == NONE:
-            return
         ec2 = boto3.client("ec2", region_name=self.region)
         if self.action == UPDATE:
             install_user_data(ec2, self.instance_id, self.state, self.user_data)
-            start_instances(ec2, [self.instance_id])
-        elif self.action == START:
-            if self.state == "stopping":
-                # `start_instances` needs a fully stopped instance.
-                ec2.get_waiter("instance_stopped").wait(
-                    InstanceIds=[self.instance_id],
-                    WaiterConfig={"Delay": 30, "MaxAttempts": 80},
-                )
-            start_instances(ec2, [self.instance_id])
+        elif self.action == START and self.state == "stopping":
+            # `start_instances` needs a fully stopped instance.
+            ec2.get_waiter("instance_stopped").wait(
+                InstanceIds=[self.instance_id],
+                WaiterConfig={"Delay": 30, "MaxAttempts": 80},
+            )
+        start_instances(ec2, [self.instance_id])
 
 
 def print_plan(plan):
-    """Print every item in `plan`, grouped by config, with a diff for the first
-    instance that needs an update.
+    """Print every item in `plan`, with a diff for the first instance that needs
+    an update.
     """
     diff_shown = False
-    current_config = None
     for item in plan:
-        if item.config != current_config:
-            current_config = item.config
-            print(f"[{item.config}] region={item.region}")
         diff_shown = item.describe(show_diff=not diff_shown) or diff_shown
 
 
@@ -336,7 +333,8 @@ def build_plan(configs, requested_ids) -> List[PlanItem]:
     `strip_comments`), so a comment-only edit plans no update.
     """
     pending = None if requested_ids is None else set(requested_ids)
-    plan: List[PlanItem] = []
+    starts: List[PlanItem] = []
+    updates: List[PlanItem] = []
     for config in configs.values():
         if pending is not None and not pending:
             break
@@ -358,23 +356,24 @@ def build_plan(configs, requested_ids) -> List[PlanItem]:
             instance_id = inst.get("InstanceId")
             state = (inst.get("State") or {}).get("Name")
             live = get_live_user_data(ec2, instance_id)
-            if strip_comments(live) != strip_comments(user_data):
-                action = UPDATE
-            elif state in ("stopped", "stopping"):
-                action = START
-            else:
-                action = NONE
-            plan.append(
-                PlanItem(
-                    config=config.name,
-                    region=config.region,
-                    instance_id=instance_id,
-                    state=state,
-                    action=action,
-                    user_data=user_data,
-                    live=live,
-                )
+            item = PlanItem(
+                config=config.name,
+                region=config.region,
+                instance_id=instance_id,
+                state=state,
+                action="",
+                user_data=user_data,
+                live=live,
             )
+            if strip_comments(live) != strip_comments(user_data):
+                item.action = UPDATE
+                updates.append(item)
+            elif state in ("stopped", "stopping"):
+                item.action = START
+                starts.append(item)
+            else:
+                # Running with current user_data - nothing to do; not planned.
+                print(f"  {instance_id} [{config.name}] {state}: up to date - skip")
             if pending is not None:
                 pending.discard(instance_id)
 
@@ -383,7 +382,11 @@ def build_plan(configs, requested_ids) -> List[PlanItem]:
             f"instance(s) {sorted(pending)} not found under any EC2Instance "
             f"config in ci/infra/cloud.py"
         )
-    return plan
+
+    # Start already-stopped instances before any update: an update stops its
+    # instance, which puts the Dedicated Host into a multi-hour scrub that would
+    # then block these starts.
+    return starts + updates
 
 
 def main():
@@ -417,16 +420,15 @@ def main():
     plan = build_plan(configs, args.instance)
     print_plan(plan)
 
-    changes = [item for item in plan if item.action != NONE]
-    if not changes:
-        print("nothing to do")
+    if not plan:
+        print("nothing to do - every instance is up to date and running")
         return
     if not args.apply:
-        print(f"{len(changes)} change(s) planned - pass --apply to execute")
+        print(f"{len(plan)} change(s) planned - pass --apply to execute")
         return
 
-    print(f"applying {len(changes)} change(s)...")
-    for item in changes:
+    print(f"applying {len(plan)} change(s)...")
+    for item in plan:
         item.apply()
 
 

--- a/ci/infra/scripts/update_userdata.py
+++ b/ci/infra/scripts/update_userdata.py
@@ -8,30 +8,31 @@ Mac instance puts its host into a multi-hour scrub (host state `pending`), so
 `available` again.
 
 This script encapsulates that whole user_data update workflow so it lives apart
-from the praktika `deploy` path. You pass the EC2 instance ids to touch via
-`--instance`; the `EC2Instance.Config` entries in `ci/infra/cloud.py` are the
-source of truth for everything else. The script discovers each config's live
-instances (matching praktika's own tag-based lookup), and for every requested
-instance found under a config it uses that config's `region` and
-`user_data_file` to:
+from the praktika `deploy` path. It runs in two phases:
 
-  1. Compare the live `user_data` with the configured file; skip the instance
-     when it already matches.
-  2. Otherwise stop the instance, install the new `user_data`, and start it
-     again, blocking on the Dedicated Host scrub.
+  1. `build_plan` reads the live state (read-only) and produces a `Plan`. For
+     every instance it decides one action: `update` (live user_data differs -
+     stop, install, start), `start` (user_data is current but the instance is
+     stopped), or `none`.
+  2. `Plan.apply` carries the plan out, one instance at a time, blocking on the
+     Dedicated Host scrub.
 
-Instances are reconciled one at a time so the whole fleet is never stopped at
-once. Only the instance ids you pass are touched; with no `--instance` every
-live instance of every config is scanned. By default the script only reports
-the plan and prints a diff for the first mismatched instance - pass `--update`
-to actually stop, install, and start.
+The plan is always printed. By default that is all that happens - pass
+`--apply` to execute it.
+
+The `EC2Instance.Config` entries in `ci/infra/cloud.py` are the source of truth:
+each config supplies the `region` and `user_data_file`, and its live instances
+are discovered with praktika's own tag-based lookup. You pass the EC2 instance
+ids to touch via `--instance`; with no `--instance` every live instance of every
+config is scanned. Comments are ignored when matching user_data, so a
+comment-only edit plans no update.
 
 Examples:
 
-    update_userdata.py                                  # report the fleet plan + diff
-    update_userdata.py --instance i-0123456789abcdef0   # report one instance
-    update_userdata.py --update                         # apply to the whole fleet
-    update_userdata.py --instance i-0123456789abcdef0 --update
+    update_userdata.py                                  # print the fleet plan
+    update_userdata.py --instance i-0123456789abcdef0   # plan one instance
+    update_userdata.py --apply                          # apply to the whole fleet
+    update_userdata.py --instance i-0123456789abcdef0 --apply
 """
 
 import argparse
@@ -41,6 +42,8 @@ import importlib.util
 import os
 import sys
 import time
+from dataclasses import dataclass
+from typing import List
 
 import boto3
 from botocore.exceptions import ClientError
@@ -220,47 +223,90 @@ def start_instances(ec2, instance_ids):
     ec2.get_waiter("instance_running").wait(InstanceIds=started)
 
 
-def reconcile_instance(ec2, instance_id, state, user_data, update, show_diff):
-    """Reconcile one instance: skip when the live user_data already matches,
-    otherwise (when `update`) stop, reinstall, and start it again.
+# Plan item actions.
+UPDATE = "update"  # live user_data differs - stop, install, start
+START = "start"  # user_data current but instance stopped - just start
+NONE = "none"  # running and current - nothing to do
 
-    Without `update`, make no changes - only report. When `show_diff` and the
-    user_data differs, print a unified diff of live vs configured first. Returns
-    True if a diff was printed, so the caller can show it only for the first
-    mismatch.
 
-    Comments are ignored when matching (see `strip_comments`), so a comment-only
-    edit does not trigger a fleet-wide stop/start.
+@dataclass
+class PlanItem:
+    """One planned action for one instance, self-contained enough to `apply`.
+
+    `build_plan` fills these in read-only; `apply` carries a single item out.
     """
-    live = get_live_user_data(ec2, instance_id)
-    if strip_comments(live) == strip_comments(user_data):
-        print(f"{instance_id}: user_data already up to date - skip")
-        return False
 
-    printed = False
-    if show_diff:
-        print(f"{instance_id}: user_data differs (state={state}):")
-        sys.stdout.writelines(
-            difflib.unified_diff(
-                live.splitlines(keepends=True),
-                user_data.splitlines(keepends=True),
-                fromfile=f"{instance_id} (live)",
-                tofile="configured",
+    config: str
+    region: str
+    instance_id: str
+    state: str
+    action: str
+    user_data: str  # configured content, installed on UPDATE
+    live: str  # live content, for the diff on UPDATE
+
+    def describe(self, show_diff):
+        """Print this item's plan line. On an UPDATE, when `show_diff`, print a
+        unified diff of live vs configured first; return True if it did, so the
+        caller shows the diff only for the first mismatch.
+        """
+        if self.action == NONE:
+            print(f"  {self.instance_id}: up to date, {self.state} - no action")
+            return False
+        if self.action == START:
+            print(f"  {self.instance_id}: up to date but {self.state} - start")
+            return False
+
+        printed = False
+        if show_diff:
+            print(f"  {self.instance_id}: user_data diff (live -> configured):")
+            sys.stdout.writelines(
+                difflib.unified_diff(
+                    self.live.splitlines(keepends=True),
+                    self.user_data.splitlines(keepends=True),
+                    fromfile=f"{self.instance_id} (live)",
+                    tofile="configured",
+                )
             )
-        )
-        if not live.endswith("\n") or not user_data.endswith("\n"):
-            print()  # keep the next log line on its own row
-        printed = True
-
-    if not update:
+            if not self.live.endswith("\n") or not self.user_data.endswith("\n"):
+                print()  # keep the next log line on its own row
+            printed = True
         print(
-            f"{instance_id}: would update (state={state}) - pass --update to apply"
+            f"  {self.instance_id}: user_data differs ({self.state}) - "
+            f"stop, install, start"
         )
         return printed
 
-    install_user_data(ec2, instance_id, state, user_data)
-    start_instances(ec2, [instance_id])
-    return printed
+    def apply(self):
+        """Carry out this item: update (stop, install, start) or start a stopped
+        instance, blocking on the Dedicated Host scrub. A NONE item is a no-op.
+        """
+        if self.action == NONE:
+            return
+        ec2 = boto3.client("ec2", region_name=self.region)
+        if self.action == UPDATE:
+            install_user_data(ec2, self.instance_id, self.state, self.user_data)
+            start_instances(ec2, [self.instance_id])
+        elif self.action == START:
+            if self.state == "stopping":
+                # `start_instances` needs a fully stopped instance.
+                ec2.get_waiter("instance_stopped").wait(
+                    InstanceIds=[self.instance_id],
+                    WaiterConfig={"Delay": 30, "MaxAttempts": 80},
+                )
+            start_instances(ec2, [self.instance_id])
+
+
+def print_plan(plan):
+    """Print every item in `plan`, grouped by config, with a diff for the first
+    instance that needs an update.
+    """
+    diff_shown = False
+    current_config = None
+    for item in plan:
+        if item.config != current_config:
+            current_config = item.config
+            print(f"[{item.config}] region={item.region}")
+        diff_shown = item.describe(show_diff=not diff_shown) or diff_shown
 
 
 def load_user_data(config):
@@ -273,29 +319,24 @@ def load_user_data(config):
     if not os.path.isabs(user_data_file):
         user_data_file = os.path.join(REPO_ROOT, user_data_file)
     with open(user_data_file, "r") as f:
-        user_data = f.read()
-    print(
-        f"[{config.name}] region={config.region}, user_data='{user_data_file}' "
-        f"({len(user_data)} bytes)"
-    )
-    return user_data
+        return f.read()
 
 
-def reconcile_instances(configs, requested_ids, update=False):
-    """Reconcile instances, sourcing each one's `region` and `user_data_file`
-    from the `ci/infra/cloud.py` config that owns it.
+def build_plan(configs, requested_ids) -> List[PlanItem]:
+    """Read live state (read-only) and return the list of `PlanItem`s.
 
-    With `requested_ids` set, only those ids are touched and an id that belongs
-    to no config is an error. With `requested_ids` None, every live instance of
-    every config is scanned and reconciled.
+    Each one's `region` and `user_data_file` come from the `ci/infra/cloud.py`
+    config that owns it. With `requested_ids` set, only those ids are planned
+    and an id that belongs to no config is an error. With `requested_ids` None,
+    every live instance of every config is planned.
 
     Each config's live instances are discovered with praktika's own tag-based
-    lookup (`_find_existing_instances`), so the standalone update matches what
-    praktika `deploy` would launch. Without `update`, report the plan and print
-    a diff for the first mismatched instance without changing anything.
+    lookup (`_find_existing_instances`), so the plan matches what praktika
+    `deploy` would launch. Comments are ignored when matching user_data (see
+    `strip_comments`), so a comment-only edit plans no update.
     """
     pending = None if requested_ids is None else set(requested_ids)
-    diff_printed = False
+    plan: List[PlanItem] = []
     for config in configs.values():
         if pending is not None and not pending:
             break
@@ -316,15 +357,23 @@ def reconcile_instances(configs, requested_ids, update=False):
         for inst in matched:
             instance_id = inst.get("InstanceId")
             state = (inst.get("State") or {}).get("Name")
-            # Show the diff only for the first mismatched instance - the
-            # configured user_data is the same for every instance of a config.
-            diff_printed |= reconcile_instance(
-                ec2,
-                instance_id,
-                state,
-                user_data,
-                update=update,
-                show_diff=not diff_printed,
+            live = get_live_user_data(ec2, instance_id)
+            if strip_comments(live) != strip_comments(user_data):
+                action = UPDATE
+            elif state in ("stopped", "stopping"):
+                action = START
+            else:
+                action = NONE
+            plan.append(
+                PlanItem(
+                    config=config.name,
+                    region=config.region,
+                    instance_id=instance_id,
+                    state=state,
+                    action=action,
+                    user_data=user_data,
+                    live=live,
+                )
             )
             if pending is not None:
                 pending.discard(instance_id)
@@ -334,6 +383,7 @@ def reconcile_instances(configs, requested_ids, update=False):
             f"instance(s) {sorted(pending)} not found under any EC2Instance "
             f"config in ci/infra/cloud.py"
         )
+    return plan
 
 
 def main():
@@ -348,28 +398,36 @@ def main():
         nargs="+",
         metavar="INSTANCE_ID",
         help=(
-            "EC2 instance ids to reconcile (e.g. i-0123456789abcdef0). Each id "
-            "is matched to its ci/infra/cloud.py config to source the region "
-            "and user_data file, then the instance is stopped, has the "
-            "configured user_data installed, and is started again. Other "
-            "instances are left untouched. When omitted, every live instance of "
-            "every config is scanned and reconciled."
+            "EC2 instance ids to plan (e.g. i-0123456789abcdef0). Each id is "
+            "matched to its ci/infra/cloud.py config to source the region and "
+            "user_data file. When omitted, every live instance of every config "
+            "is planned."
         ),
     )
     parser.add_argument(
-        "--update",
+        "--apply",
         action="store_true",
         help=(
-            "Actually perform the update (stop, install user_data, start). "
-            "Without it the script only reports the plan and prints a diff for "
-            "the first mismatched instance, making no changes."
+            "Execute the plan (stop/install/start updates, start stopped "
+            "instances). Without it the plan is only printed, making no changes."
         ),
     )
     args = parser.parse_args()
 
-    if not args.update:
-        print("report only - pass --update to apply changes")
-    reconcile_instances(configs, args.instance, update=args.update)
+    plan = build_plan(configs, args.instance)
+    print_plan(plan)
+
+    changes = [item for item in plan if item.action != NONE]
+    if not changes:
+        print("nothing to do")
+        return
+    if not args.apply:
+        print(f"{len(changes)} change(s) planned - pass --apply to execute")
+        return
+
+    print(f"applying {len(changes)} change(s)...")
+    for item in changes:
+        item.apply()
 
 
 if __name__ == "__main__":

--- a/ci/infra/scripts/update_userdata.py
+++ b/ci/infra/scripts/update_userdata.py
@@ -8,33 +8,58 @@ Mac instance puts its host into a multi-hour scrub (host state `pending`), so
 `available` again.
 
 This script encapsulates that whole user_data update workflow so it lives apart
-from the praktika `deploy` path:
+from the praktika `deploy` path. It reuses the `EC2Instance.Config` entries from
+`ci/infra/cloud.py` as the source of truth: each named config supplies the
+`region`, the `user_data_file`, and the tags used to discover the live
+instances. For every instance of a selected config it:
 
-  1. For each named instance, compare the live `user_data` with the configured
-     file; skip the instance when it already matches.
-  2. Otherwise stop the instance, install the new `user_data`, and (unless
-     `--no-start`) start it again, blocking on the Dedicated Host scrub.
+  1. Compares the live `user_data` with the configured file; skips the instance
+     when it already matches.
+  2. Otherwise stops the instance, installs the new `user_data`, and starts it
+     again, blocking on the Dedicated Host scrub.
 
 Instances are reconciled one at a time so the whole fleet is never stopped at
-once. The whole operation is restricted to the instance ids you pass, so other
-instances are left untouched.
+once. Only the configs named with `--instance` are touched; all others are left
+alone.
 
 Examples:
 
-    update_userdata.py --user-data-file ci/infra/scripts/user_data_macos.txt \\
-        --instance i-0123456789abcdef0
-    update_userdata.py --user-data-file ci/infra/scripts/user_data_macos.txt \\
-        --instance i-0123456789abcdef0 i-0fedcba9876543210 --region us-east-1
+    update_userdata.py --instance macos_m2
+    update_userdata.py --instance amd_macos_m1 macos_m2
 """
 
 import argparse
 import base64
+import importlib.util
+import os
 import sys
 import time
 
 import boto3
 from botocore.exceptions import ClientError
 from botocore.waiter import WaiterModel, create_waiter_with_client
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+CLOUD_CONFIG_PATH = os.path.join(REPO_ROOT, "ci", "infra", "cloud.py")
+
+# Empty `region` in a config means "the default" — match the AWS SDK default
+# region used throughout praktika.
+DEFAULT_REGION = "us-east-1"
+
+
+def load_ec2_configs():
+    """Load `ci/infra/cloud.py` and return its `EC2Instance.Config`s keyed by name.
+
+    `cloud.py` imports `from praktika import ...` and `from ci.defs.defs import
+    ...`, so both the repo root and `ci/` must be importable before it loads.
+    """
+    for path in (REPO_ROOT, os.path.join(REPO_ROOT, "ci")):
+        if path not in sys.path:
+            sys.path.insert(0, path)
+    spec = importlib.util.spec_from_file_location("cloud", CLOUD_CONFIG_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return {config.name: config for config in module.CLOUD.ec2_instances}
 
 
 def user_data_matches(ec2, instance_id, user_data) -> bool:
@@ -173,7 +198,7 @@ def start_instances(ec2, instance_ids):
     ec2.get_waiter("instance_running").wait(InstanceIds=started)
 
 
-def reconcile_instance(ec2, instance_id, user_data, start):
+def reconcile_instance(ec2, instance_id, state, user_data, start):
     """Reconcile one instance: skip when the live user_data already matches,
     otherwise stop, reinstall, and (when `start`) start it again.
     """
@@ -181,63 +206,71 @@ def reconcile_instance(ec2, instance_id, user_data, start):
         print(f"{instance_id}: user_data already up to date - skip")
         return
 
-    resp = ec2.describe_instances(InstanceIds=[instance_id])
-    instances = [
-        inst
-        for r in resp.get("Reservations", [])
-        for inst in r.get("Instances", [])
-    ]
-    if not instances:
-        raise Exception(f"instance {instance_id} not found")
-    state = (instances[0].get("State") or {}).get("Name")
-
     install_user_data(ec2, instance_id, state, user_data)
     if start:
         start_instances(ec2, [instance_id])
 
 
+def reconcile_config(config, start):
+    """Reconcile every live instance of one `EC2Instance.Config`.
+
+    Reuses the config's `region`, `user_data_file`, and tag-based discovery
+    (`_find_existing_instances`) so the standalone update matches what praktika
+    `deploy` would launch.
+    """
+    region = config.region or DEFAULT_REGION
+    # `_find_existing_instances` builds its own boto3 client from `config.region`,
+    # so pin the default region on the config before discovery.
+    config.region = region
+
+    user_data_file = config.user_data_file
+    if not user_data_file:
+        raise Exception(f"config '{config.name}' has no user_data_file")
+    if not os.path.isabs(user_data_file):
+        user_data_file = os.path.join(REPO_ROOT, user_data_file)
+    with open(user_data_file, "r") as f:
+        user_data = f.read()
+    print(
+        f"[{config.name}] region={region}, user_data='{user_data_file}' "
+        f"({len(user_data)} bytes)"
+    )
+
+    instances = config._find_existing_instances()
+    if not instances:
+        print(f"[{config.name}] no instances found - skip")
+        return
+
+    ec2 = boto3.client("ec2", region_name=region)
+    for inst in instances:
+        instance_id = inst.get("InstanceId")
+        state = (inst.get("State") or {}).get("Name")
+        reconcile_instance(ec2, instance_id, state, user_data, start)
+
+
 def main():
+    configs = load_ec2_configs()
+
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
-        "--user-data-file",
-        required=True,
-        help="Path to the user_data script to install (e.g. user_data_macos.txt).",
-    )
-    parser.add_argument(
         "--instance",
         required=True,
         nargs="+",
-        metavar="INSTANCE_ID",
+        metavar="NAME",
+        choices=sorted(configs),
         help=(
-            "EC2 instance ids to reconcile (e.g. i-0123456789abcdef0). Each named "
-            "instance is stopped, has the configured user_data installed, and is "
-            "started again. Other instances are left untouched."
+            "EC2Instance config name(s) from ci/infra/cloud.py to reconcile "
+            "(e.g. macos_m2). Every live instance of each named config is "
+            "stopped, has its configured user_data installed, and is started "
+            "again. Configs not named here are left untouched."
         ),
-    )
-    parser.add_argument(
-        "--region",
-        default="us-east-1",
-        help="AWS region of the instances (default: us-east-1).",
-    )
-    parser.add_argument(
-        "--no-start",
-        action="store_true",
-        help="Stop and update user_data but leave the instances stopped.",
     )
     args = parser.parse_args()
 
-    with open(args.user_data_file, "r") as f:
-        user_data = f.read()
-    print(
-        f"loaded user_data from '{args.user_data_file}' ({len(user_data)} bytes)"
-    )
-
-    ec2 = boto3.client("ec2", region_name=args.region)
-    for instance_id in args.instance:
-        reconcile_instance(ec2, instance_id, user_data, start=not args.no_start)
+    for name in args.instance:
+        reconcile_config(configs[name], start=True)
 
 
 if __name__ == "__main__":

--- a/ci/infra/scripts/update_userdata.py
+++ b/ci/infra/scripts/update_userdata.py
@@ -8,24 +8,25 @@ Mac instance puts its host into a multi-hour scrub (host state `pending`), so
 `available` again.
 
 This script encapsulates that whole user_data update workflow so it lives apart
-from the praktika `deploy` path. It reuses the `EC2Instance.Config` entries from
-`ci/infra/cloud.py` as the source of truth: each named config supplies the
-`region`, the `user_data_file`, and the tags used to discover the live
-instances. For every instance of a selected config it:
+from the praktika `deploy` path. You pass the EC2 instance ids to touch via
+`--instance`; the `EC2Instance.Config` entries in `ci/infra/cloud.py` are the
+source of truth for everything else. The script discovers each config's live
+instances (matching praktika's own tag-based lookup), and for every requested
+instance found under a config it uses that config's `region` and
+`user_data_file` to:
 
-  1. Compares the live `user_data` with the configured file; skips the instance
+  1. Compare the live `user_data` with the configured file; skip the instance
      when it already matches.
-  2. Otherwise stops the instance, installs the new `user_data`, and starts it
+  2. Otherwise stop the instance, install the new `user_data`, and start it
      again, blocking on the Dedicated Host scrub.
 
 Instances are reconciled one at a time so the whole fleet is never stopped at
-once. Only the configs named with `--instance` are touched; all others are left
-alone.
+once. Only the instance ids you pass are touched; all others are left alone.
 
 Examples:
 
-    update_userdata.py --instance macos_m2
-    update_userdata.py --instance amd_macos_m1 macos_m2
+    update_userdata.py --instance i-0123456789abcdef0
+    update_userdata.py --instance i-0123456789abcdef0 i-0fedcba9876543210
 """
 
 import argparse
@@ -211,18 +212,10 @@ def reconcile_instance(ec2, instance_id, state, user_data, start):
         start_instances(ec2, [instance_id])
 
 
-def reconcile_config(config, start):
-    """Reconcile every live instance of one `EC2Instance.Config`.
-
-    Reuses the config's `region`, `user_data_file`, and tag-based discovery
-    (`_find_existing_instances`) so the standalone update matches what praktika
-    `deploy` would launch.
+def load_user_data(config):
+    """Read the `user_data` file configured for `config`, resolving a relative
+    path against the repo root.
     """
-    region = config.region or DEFAULT_REGION
-    # `_find_existing_instances` builds its own boto3 client from `config.region`,
-    # so pin the default region on the config before discovery.
-    config.region = region
-
     user_data_file = config.user_data_file
     if not user_data_file:
         raise Exception(f"config '{config.name}' has no user_data_file")
@@ -231,20 +224,49 @@ def reconcile_config(config, start):
     with open(user_data_file, "r") as f:
         user_data = f.read()
     print(
-        f"[{config.name}] region={region}, user_data='{user_data_file}' "
+        f"[{config.name}] region={config.region}, user_data='{user_data_file}' "
         f"({len(user_data)} bytes)"
     )
+    return user_data
 
-    instances = config._find_existing_instances()
-    if not instances:
-        print(f"[{config.name}] no instances found - skip")
-        return
 
-    ec2 = boto3.client("ec2", region_name=region)
-    for inst in instances:
-        instance_id = inst.get("InstanceId")
-        state = (inst.get("State") or {}).get("Name")
-        reconcile_instance(ec2, instance_id, state, user_data, start)
+def reconcile_instances(configs, requested_ids):
+    """Reconcile the requested instance ids, sourcing each one's `region` and
+    `user_data_file` from the `ci/infra/cloud.py` config that owns it.
+
+    Each config's live instances are discovered with praktika's own tag-based
+    lookup (`_find_existing_instances`), so the standalone update matches what
+    praktika `deploy` would launch. An id that belongs to no config is an error.
+    """
+    pending = set(requested_ids)
+    for config in configs.values():
+        if not pending:
+            break
+        # `_find_existing_instances` builds its own boto3 client from
+        # `config.region`, so pin the default region on the config first.
+        config.region = config.region or DEFAULT_REGION
+
+        matched = [
+            inst
+            for inst in config._find_existing_instances()
+            if inst.get("InstanceId") in pending
+        ]
+        if not matched:
+            continue
+
+        user_data = load_user_data(config)
+        ec2 = boto3.client("ec2", region_name=config.region)
+        for inst in matched:
+            instance_id = inst.get("InstanceId")
+            state = (inst.get("State") or {}).get("Name")
+            reconcile_instance(ec2, instance_id, state, user_data, start=True)
+            pending.discard(instance_id)
+
+    if pending:
+        raise Exception(
+            f"instance(s) {sorted(pending)} not found under any EC2Instance "
+            f"config in ci/infra/cloud.py"
+        )
 
 
 def main():
@@ -258,19 +280,18 @@ def main():
         "--instance",
         required=True,
         nargs="+",
-        metavar="NAME",
-        choices=sorted(configs),
+        metavar="INSTANCE_ID",
         help=(
-            "EC2Instance config name(s) from ci/infra/cloud.py to reconcile "
-            "(e.g. macos_m2). Every live instance of each named config is "
-            "stopped, has its configured user_data installed, and is started "
-            "again. Configs not named here are left untouched."
+            "EC2 instance ids to reconcile (e.g. i-0123456789abcdef0). Each id "
+            "is matched to its ci/infra/cloud.py config to source the region "
+            "and user_data file, then the instance is stopped, has the "
+            "configured user_data installed, and is started again. Other "
+            "instances are left untouched."
         ),
     )
     args = parser.parse_args()
 
-    for name in args.instance:
-        reconcile_config(configs[name], start=True)
+    reconcile_instances(configs, args.instance)
 
 
 if __name__ == "__main__":

--- a/ci/infra/scripts/update_userdata.py
+++ b/ci/infra/scripts/update_userdata.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Reconcile the EC2 `user_data` of running macOS GitHub Actions runners.
+
+EC2 only accepts a `ModifyInstanceAttribute` for `userData` while the instance
+is stopped, and a macOS instance can only run on a Dedicated Host. Stopping a
+Mac instance puts its host into a multi-hour scrub (host state `pending`), so
+`StartInstances` is rejected with `InsufficientHostCapacity` until the host is
+`available` again.
+
+This script encapsulates that whole user_data update workflow so it lives apart
+from the praktika `deploy` path:
+
+  1. For each named instance, compare the live `user_data` with the configured
+     file; skip the instance when it already matches.
+  2. Otherwise stop the instance, install the new `user_data`, and (unless
+     `--no-start`) start it again, blocking on the Dedicated Host scrub.
+
+Instances are reconciled one at a time so the whole fleet is never stopped at
+once. The whole operation is restricted to the instance ids you pass, so other
+instances are left untouched.
+
+Examples:
+
+    update_userdata.py --user-data-file ci/infra/scripts/user_data_macos.txt \\
+        --instance i-0123456789abcdef0
+    update_userdata.py --user-data-file ci/infra/scripts/user_data_macos.txt \\
+        --instance i-0123456789abcdef0 i-0fedcba9876543210 --region us-east-1
+"""
+
+import argparse
+import base64
+import sys
+import time
+
+import boto3
+from botocore.exceptions import ClientError
+from botocore.waiter import WaiterModel, create_waiter_with_client
+
+
+def user_data_matches(ec2, instance_id, user_data) -> bool:
+    """Return True if the instance's live `user_data` already equals `user_data`."""
+    resp = ec2.describe_instance_attribute(
+        InstanceId=instance_id, Attribute="userData"
+    )
+    encoded = (resp.get("UserData") or {}).get("Value") or ""
+    if isinstance(encoded, bytes):
+        encoded = encoded.decode("ascii")
+    current = base64.b64decode(encoded).decode("utf-8") if encoded else ""
+    return current == user_data
+
+
+def install_user_data(ec2, instance_id, state, user_data):
+    """Stop the instance (waiting until fully stopped) and install `user_data` via
+    `ModifyInstanceAttribute`, which requires the instance to be stopped (otherwise
+    it returns `IncorrectInstanceState`).
+    """
+    if state in ("pending", "running"):
+        print(f"stopping {instance_id} to update user_data")
+        ec2.stop_instances(InstanceIds=[instance_id])
+    if state != "stopped":
+        # A Mac instance stop can exceed the waiter's 10-min default (15s x 40)
+        # once the host starts scrubbing, so wait up to 40 min.
+        ec2.get_waiter("instance_stopped").wait(
+            InstanceIds=[instance_id],
+            WaiterConfig={"Delay": 30, "MaxAttempts": 80},
+        )
+
+    # UserData.Value is a blob; boto3 base64-encodes it for the API call, so pass
+    # the raw script bytes here. Pre-encoding would double-encode and store base64
+    # text as the boot script.
+    ec2.modify_instance_attribute(
+        InstanceId=instance_id,
+        UserData={"Value": user_data.encode("utf-8")},
+    )
+    print(f"updated user_data on {instance_id}")
+
+
+def wait_for_hosts_available(ec2, instance_ids, require_all=True):
+    """Block until the Dedicated Host(s) backing `instance_ids` finish the EC2 Mac
+    scrub workflow and become `available`. boto3 has no built-in host waiter, so
+    define one over `DescribeHosts` (poll every 60s for up to 3h, the worst-case
+    Mac scrub window). With `require_all=False` it returns as soon as any one of
+    the hosts is available.
+    """
+    resp = ec2.describe_instances(InstanceIds=instance_ids)
+    host_ids = sorted(
+        {
+            inst.get("Placement", {}).get("HostId")
+            for r in resp.get("Reservations", [])
+            for inst in r.get("Instances", [])
+            if inst.get("Placement", {}).get("HostId")
+        }
+    )
+    if not host_ids:
+        raise Exception(
+            f"cannot wait for host capacity - no dedicated host associated with "
+            f"{instance_ids}"
+        )
+
+    print(
+        f"waiting for dedicated host(s) {host_ids} to finish scrubbing; "
+        f"press Ctrl+C to abort waiting"
+    )
+    model = WaiterModel(
+        {
+            "version": 2,
+            "waiters": {
+                "HostAvailable": {
+                    "operation": "DescribeHosts",
+                    "delay": 60,
+                    "maxAttempts": 180,
+                    "acceptors": [
+                        {
+                            "state": "success",
+                            "matcher": "pathAll" if require_all else "pathAny",
+                            "argument": "Hosts[].State",
+                            "expected": "available",
+                        },
+                        {
+                            "state": "failure",
+                            "matcher": "pathAny",
+                            "argument": "Hosts[].State",
+                            "expected": "permanent-failure",
+                        },
+                    ],
+                }
+            },
+        }
+    )
+    waiter = create_waiter_with_client("HostAvailable", model, ec2)
+    waiter.wait(HostIds=host_ids)
+
+
+def start_instances(ec2, instance_ids):
+    """Start the given (stopped) instances, each as soon as its EC2 Mac dedicated
+    host finishes scrubbing. We try every instance up front, then wait for a
+    blocked host to recover and retry - so a ready instance never waits behind a
+    still-scrubbing one.
+    """
+    pending = [i for i in instance_ids if i]
+    if not pending:
+        return
+
+    started = []
+    while pending:
+        blocked = []
+        for instance_id in pending:
+            try:
+                ec2.start_instances(InstanceIds=[instance_id])
+            except ClientError as e:
+                if (
+                    e.response.get("Error", {}).get("Code")
+                    == "InsufficientHostCapacity"
+                ):
+                    blocked.append(instance_id)
+                    continue
+                raise
+            print(f"starting {instance_id}")
+            started.append(instance_id)
+
+        if not blocked:
+            break
+
+        # Wait until at least one blocked host becomes available, then retry all
+        # blocked instances (the recovered one(s) start, the rest loop).
+        wait_for_hosts_available(ec2, blocked, require_all=False)
+        # A host can report `available` a moment before StartInstances will accept
+        # it; sleep briefly so a transient rejection paces the retry instead of
+        # spinning the loop.
+        time.sleep(10)
+        pending = blocked
+
+    ec2.get_waiter("instance_running").wait(InstanceIds=started)
+
+
+def reconcile_instance(ec2, instance_id, user_data, start):
+    """Reconcile one instance: skip when the live user_data already matches,
+    otherwise stop, reinstall, and (when `start`) start it again.
+    """
+    if user_data_matches(ec2, instance_id, user_data):
+        print(f"{instance_id}: user_data already up to date - skip")
+        return
+
+    resp = ec2.describe_instances(InstanceIds=[instance_id])
+    instances = [
+        inst
+        for r in resp.get("Reservations", [])
+        for inst in r.get("Instances", [])
+    ]
+    if not instances:
+        raise Exception(f"instance {instance_id} not found")
+    state = (instances[0].get("State") or {}).get("Name")
+
+    install_user_data(ec2, instance_id, state, user_data)
+    if start:
+        start_instances(ec2, [instance_id])
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--user-data-file",
+        required=True,
+        help="Path to the user_data script to install (e.g. user_data_macos.txt).",
+    )
+    parser.add_argument(
+        "--instance",
+        required=True,
+        nargs="+",
+        metavar="INSTANCE_ID",
+        help=(
+            "EC2 instance ids to reconcile (e.g. i-0123456789abcdef0). Each named "
+            "instance is stopped, has the configured user_data installed, and is "
+            "started again. Other instances are left untouched."
+        ),
+    )
+    parser.add_argument(
+        "--region",
+        default="us-east-1",
+        help="AWS region of the instances (default: us-east-1).",
+    )
+    parser.add_argument(
+        "--no-start",
+        action="store_true",
+        help="Stop and update user_data but leave the instances stopped.",
+    )
+    args = parser.parse_args()
+
+    with open(args.user_data_file, "r") as f:
+        user_data = f.read()
+    print(
+        f"loaded user_data from '{args.user_data_file}' ({len(user_data)} bytes)"
+    )
+
+    ec2 = boto3.client("ec2", region_name=args.region)
+    for instance_id in args.instance:
+        reconcile_instance(ec2, instance_id, user_data, start=not args.no_start)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/infra/scripts/update_userdata.py
+++ b/ci/infra/scripts/update_userdata.py
@@ -21,12 +21,16 @@ instance found under a config it uses that config's `region` and
      again, blocking on the Dedicated Host scrub.
 
 Instances are reconciled one at a time so the whole fleet is never stopped at
-once. Only the instance ids you pass are touched; all others are left alone.
+once. Only the instance ids you pass are touched; with no `--instance` every
+live instance of every config is scanned. `--dry-run` prints the update plan
+without changing anything.
 
 Examples:
 
     update_userdata.py --instance i-0123456789abcdef0
     update_userdata.py --instance i-0123456789abcdef0 i-0fedcba9876543210
+    update_userdata.py                 # scan and reconcile the whole fleet
+    update_userdata.py --dry-run       # show what would change
 """
 
 import argparse
@@ -199,12 +203,19 @@ def start_instances(ec2, instance_ids):
     ec2.get_waiter("instance_running").wait(InstanceIds=started)
 
 
-def reconcile_instance(ec2, instance_id, state, user_data, start):
+def reconcile_instance(ec2, instance_id, state, user_data, start, dry_run=False):
     """Reconcile one instance: skip when the live user_data already matches,
     otherwise stop, reinstall, and (when `start`) start it again.
+
+    With `dry_run`, only print whether the instance would be updated; make no
+    changes.
     """
     if user_data_matches(ec2, instance_id, user_data):
         print(f"{instance_id}: user_data already up to date - skip")
+        return
+
+    if dry_run:
+        print(f"{instance_id}: user_data differs - would update (state={state})")
         return
 
     install_user_data(ec2, instance_id, state, user_data)
@@ -230,17 +241,22 @@ def load_user_data(config):
     return user_data
 
 
-def reconcile_instances(configs, requested_ids):
-    """Reconcile the requested instance ids, sourcing each one's `region` and
-    `user_data_file` from the `ci/infra/cloud.py` config that owns it.
+def reconcile_instances(configs, requested_ids, dry_run=False):
+    """Reconcile instances, sourcing each one's `region` and `user_data_file`
+    from the `ci/infra/cloud.py` config that owns it.
+
+    With `requested_ids` set, only those ids are touched and an id that belongs
+    to no config is an error. With `requested_ids` None, every live instance of
+    every config is scanned and reconciled.
 
     Each config's live instances are discovered with praktika's own tag-based
     lookup (`_find_existing_instances`), so the standalone update matches what
-    praktika `deploy` would launch. An id that belongs to no config is an error.
+    praktika `deploy` would launch. With `dry_run`, print the update plan
+    without changing anything.
     """
-    pending = set(requested_ids)
+    pending = None if requested_ids is None else set(requested_ids)
     for config in configs.values():
-        if not pending:
+        if pending is not None and not pending:
             break
         # `_find_existing_instances` builds its own boto3 client from
         # `config.region`, so pin the default region on the config first.
@@ -249,7 +265,7 @@ def reconcile_instances(configs, requested_ids):
         matched = [
             inst
             for inst in config._find_existing_instances()
-            if inst.get("InstanceId") in pending
+            if pending is None or inst.get("InstanceId") in pending
         ]
         if not matched:
             continue
@@ -259,8 +275,11 @@ def reconcile_instances(configs, requested_ids):
         for inst in matched:
             instance_id = inst.get("InstanceId")
             state = (inst.get("State") or {}).get("Name")
-            reconcile_instance(ec2, instance_id, state, user_data, start=True)
-            pending.discard(instance_id)
+            reconcile_instance(
+                ec2, instance_id, state, user_data, start=True, dry_run=dry_run
+            )
+            if pending is not None:
+                pending.discard(instance_id)
 
     if pending:
         raise Exception(
@@ -278,7 +297,6 @@ def main():
     )
     parser.add_argument(
         "--instance",
-        required=True,
         nargs="+",
         metavar="INSTANCE_ID",
         help=(
@@ -286,12 +304,24 @@ def main():
             "is matched to its ci/infra/cloud.py config to source the region "
             "and user_data file, then the instance is stopped, has the "
             "configured user_data installed, and is started again. Other "
-            "instances are left untouched."
+            "instances are left untouched. When omitted, every live instance of "
+            "every config is scanned and reconciled."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Report which instances would be updated (live user_data differs "
+            "from the configured file) without stopping, updating, or starting "
+            "anything."
         ),
     )
     args = parser.parse_args()
 
-    reconcile_instances(configs, args.instance)
+    if args.dry_run:
+        print("dry run - update plan only, no changes will be made")
+    reconcile_instances(configs, args.instance, dry_run=args.dry_run)
 
 
 if __name__ == "__main__":

--- a/ci/infra/scripts/update_userdata.py
+++ b/ci/infra/scripts/update_userdata.py
@@ -87,13 +87,18 @@ def get_live_user_data(ec2, instance_id) -> str:
 
 
 def strip_comments(text) -> str:
-    """Drop full-line `#` comments so the match ignores comment-only edits.
+    """Drop every line whose first non-blank character is `#` so the match
+    ignores comment-only edits. The shebang (`#!`) is kept - it is functional.
 
     Comments do not affect the booted runner, and pushing a comment-only change
     would cycle the whole Mac fleet through multi-hour Dedicated Host scrubs for
-    nothing. The shebang (`#!`) is kept - it is functional. Only lines whose
-    first non-blank character is `#` are dropped, so a `#` inside a string or
-    heredoc is left untouched.
+    nothing.
+
+    This is a line-level strip, not a shell parser: a `#`-leading line inside a
+    heredoc or quoted string would also be dropped, which would wrongly equate
+    two functionally different scripts. That is acceptable here because the
+    `user_data` bootstrap is a flat script with no such lines; do not reuse this
+    on arbitrary scripts without revisiting that assumption.
     """
     return "\n".join(
         line

--- a/ci/infra/scripts/user_data_macos.txt
+++ b/ci/infra/scripts/user_data_macos.txt
@@ -1,138 +1,44 @@
 #!/usr/bin/env bash
-# Script to prepare a clean macOS machine as a GitHub Actions runner
-# Based on prepare-ci-ami.sh but adapted for macOS
+# Bootstrap script for macOS GitHub Actions runners.
+# Bootstraps Homebrew + Python, then hands off to the runner-init script
+# fetched from S3 for the rest of provisioning (CloudWatch agent,
+# actions-runner install, etc.). After changing this file, push it to the
+# running fleet with `ci/infra/scripts/update_userdata.py`, which stops each
+# instance, installs the new user_data, and starts it again.
 
 set -xeuo pipefail
 trap reboot EXIT
 
-echo "Running macOS runner prepare script"
+USER=ec2-user
+export HOME="${HOME:-/Users/$USER}"
+cd "$HOME"
 
-# Set HOME if not already set (EC2 user_data context may not have it)
-export HOME="${HOME:-/Users/ec2-user}"
-cd $HOME
+# Install Homebrew if not already installed
+if ! sudo -u "$USER" -i command -v brew &> /dev/null; then
+  echo "Installing Homebrew..."
+  sudo -u "$USER" -i bash -c 'NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
 
-# If running as root, run brew/pip commands as ec2-user
-export USER="${SUDO_USER:-$(whoami)}"
-if [ "$EUID" -eq 0 ]; then
-  export USER="ec2-user"
-fi
-
-runner_arch() {
-  case $(uname -m) in
-    x86_64 )
-      echo x64;;
-    arm64 )
-      echo arm64;;
-  esac
-}
-
-cloudwatch_arch() {
-  case $(uname -m) in
-    x86_64 )
-      echo amd64;;
-    arm64 )
-      echo arm64;;
-  esac
-}
-
-export RUNNER_HOME="${HOME}/actions-runner"
-
-# Check if already installed - if success marker exists, skip to cloud-init
-if [ -f /tmp/clickhouse-ci-macos-runner.success ]; then
-  echo "Success marker found - skipping installation steps"
-  echo "Jumping directly to cloud-init..."
-else
-  echo "No success marker found - proceeding with installation"
-
-  # Disable greedy system service
-  launchctl disable system/com.apple.bluetoothd
-
-  # Install Homebrew if not already installed
-  if ! sudo -u "$USER" -i command -v brew &> /dev/null; then
-    echo "Installing Homebrew..."
-    sudo -u "$USER" -i bash -c 'NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
-
-    # Add Homebrew to PATH for Apple Silicon Macs
-    if [[ $(uname -m) == "arm64" ]]; then
-      sudo -u "$USER" -i bash -c "echo 'eval \"\$(/opt/homebrew/bin/brew shellenv)\"' >> ~/.zprofile"
-    fi
-  else
-    echo "Homebrew already installed"
-    sudo -u "$USER" -i brew update
+  # Add Homebrew to PATH for Apple Silicon Macs
+  if [[ $(uname -m) == "arm64" ]]; then
+    sudo -u "$USER" -i bash -c "echo 'eval \"\$(/opt/homebrew/bin/brew shellenv)\"' >> ~/.zprofile"
   fi
-
-  # Install essential tools
-  echo "Installing essential tools..."
-  sudo -u "$USER" -i brew install \
-    ca-certificates \
-    curl \
-    gh \
-    jq \
-    pigz \
-    ripgrep \
-    zstd \
-    python@3 \
-    wget \
-    unzip \
-    gnu-sed \
-    grep \
-    bash \
-    coreutils
-
-  # Install Python packages into a virtual environment using Homebrew Python
-  echo "Installing Python packages into venv..."
-  sudo -u "$USER" -i bash -c '$(brew --prefix python@3)/bin/python3 -m venv ~/venv && ~/venv/bin/pip install boto3 pygithub requests urllib3 unidiff dohq-artifactory pyjwt'
-
-  # Add venv/bin and GNU tools to PATH for both bash and zsh login shells
-  GNU_COREUTILS_BIN=$(sudo -u "$USER" -i brew --prefix coreutils)/libexec/gnubin
-  GNU_SED_BIN=$(sudo -u "$USER" -i brew --prefix gnu-sed)/libexec/gnubin
-  GNU_GREP_BIN=$(sudo -u "$USER" -i brew --prefix grep)/libexec/gnubin
-  sudo -u "$USER" -i bash -c "echo 'export PATH=\"\$HOME/venv/bin:${GNU_COREUTILS_BIN}:${GNU_SED_BIN}:${GNU_GREP_BIN}:\$PATH\"' >> ~/.bash_profile"
-  sudo -u "$USER" -i bash -c "echo 'export PATH=\"\$HOME/venv/bin:${GNU_COREUTILS_BIN}:${GNU_SED_BIN}:${GNU_GREP_BIN}:\$PATH\"' >> ~/.zprofile"
-
-  # Download and install CloudWatch agent
-  echo "Installing Amazon CloudWatch agent..."
-  CLOUDWATCH_ARCH=$(cloudwatch_arch)
-  wget --directory-prefix=/tmp "https://s3.amazonaws.com/amazoncloudwatch-agent/darwin/${CLOUDWATCH_ARCH}/latest/amazon-cloudwatch-agent.pkg"
-  sudo installer -pkg /tmp/amazon-cloudwatch-agent.pkg -target /
-
-  # Download and configure CloudWatch agent config, replacing Linux log path with macOS equivalent
-  aws ssm get-parameter --region us-east-1 --name AmazonCloudWatch-github-runners --query 'Parameter.Value' --output text \
-    | jq 'walk(if type == "object" and .file_path == "/var/log/cloud-init-output.log" then .file_path = "/var/log/amazon/ec2/ec2-macos-init.log" else . end)' \
-    | sudo tee /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json > /dev/null
-
-  # Start CloudWatch agent service
-  sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
-    -a fetch-config \
-    -m ec2 \
-    -s \
-    -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
-
-  # Download and install GitHub Actions runner
-  export RUNNER_VERSION=$(curl -fsSL "https://api.github.com/repos/actions/runner/releases/latest" | jq -r '.tag_name | ltrimstr("v")')
-  echo "Installing GitHub Actions runner..."
-  rm -rf "$RUNNER_HOME"  # if it's a reinstall
-  mkdir -p "$RUNNER_HOME" && cd "$RUNNER_HOME"
-
-  RUNNER_ARCHIVE="actions-runner-osx-$(runner_arch)-$RUNNER_VERSION.tar.gz"
-
-  curl -O -L "https://github.com/actions/runner/releases/download/v$RUNNER_VERSION/$RUNNER_ARCHIVE"
-
-  tar xzf "./$RUNNER_ARCHIVE"
-  rm -f "./$RUNNER_ARCHIVE"
-
-  # Note: installdependencies.sh is Linux-only, macOS dependencies are handled via Homebrew above
-
-  echo "GitHub Actions runner installed at: $RUNNER_HOME"
-  echo "See https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/adding-self-hosted-runners for configuration instructions."
-
-  # Create a success marker
-  touch /tmp/clickhouse-ci-macos-runner.success
-  echo "Setup completed successfully!"
+else
+  echo "Homebrew already installed"
+  sudo -u "$USER" -i brew update
 fi
 
-# Download and execute cloud-init script
+# Install Python. `brew update` above (or a fresh Homebrew install) means this
+# resolves to the latest formula, so a separate `brew upgrade` is unnecessary.
+echo "Installing python@3..."
+sudo -u "$USER" -i brew install python@3
+
+# Install / upgrade boto3 — the only third-party dependency of runner-init.py.
+# `--upgrade` keeps it at the latest version on re-runs triggered by a
+# user_data change.
+echo "Installing Python packages into venv..."
+sudo -u "$USER" -i bash -c '$(brew --prefix python@3)/bin/python3 -m venv --upgrade ~/venv && ~/venv/bin/pip install --upgrade boto3'
+
 INIT_ENVIRONMENT=${INIT_ENVIRONMENT:-macos}
 aws s3 cp "s3://github-runners-data/cloud-init/${INIT_ENVIRONMENT}.py" /tmp/runner-init.py
-rm -rf "$RUNNER_HOME/_work"
-sudo -u ec2-user -i bash -c "/Users/ec2-user/venv/bin/python /tmp/runner-init.py --environment \"$INIT_ENVIRONMENT\""
+rm -rf "$HOME/actions-runner/_work"
+sudo -u "$USER" -i bash -c "$HOME/venv/bin/python /tmp/runner-init.py --environment \"$INIT_ENVIRONMENT\""

--- a/ci/infra/scripts/user_data_macos.txt
+++ b/ci/infra/scripts/user_data_macos.txt
@@ -2,9 +2,9 @@
 # Bootstrap script for macOS GitHub Actions runners.
 # Bootstraps Homebrew + Python, then hands off to the runner-init script
 # fetched from S3 for the rest of provisioning (CloudWatch agent,
-# actions-runner install, etc.). After changing this file, push it to the
-# running fleet with `ci/infra/scripts/update_userdata.py`, which stops each
-# instance, installs the new user_data, and starts it again.
+# actions-runner install, etc.). `deploy` reconciles user_data on every run, so
+# changes to this file stop the instance, install the new user_data, and start
+# it again.
 
 set -xeuo pipefail
 trap reboot EXIT

--- a/ci/infra/scripts/user_data_macos.txt
+++ b/ci/infra/scripts/user_data_macos.txt
@@ -2,15 +2,18 @@
 # Bootstrap script for macOS GitHub Actions runners.
 # Bootstraps Homebrew + Python, then hands off to the runner-init script
 # fetched from S3 for the rest of provisioning (CloudWatch agent,
-# actions-runner install, etc.). `deploy` reconciles user_data on every run, so
-# changes to this file stop the instance, install the new user_data, and start
-# it again.
+# actions-runner install, etc.). After changing this file, push it to the
+# running fleet with `ci/infra/scripts/update_userdata.py`, which stops each
+# instance, installs the new user_data, and starts it again.
 
 set -xeuo pipefail
 trap reboot EXIT
 
 USER=ec2-user
-export HOME="${HOME:-/Users/$USER}"
+# Pin HOME to the target user. In the EC2 user_data context this script runs as
+# root, where HOME may be /var/root; the venv created below (and the runner-init
+# handoff that runs `$HOME/venv/bin/python`) must resolve under /Users/$USER.
+export HOME="/Users/$USER"
 cd "$HOME"
 
 # Install Homebrew if not already installed
@@ -27,10 +30,13 @@ else
   sudo -u "$USER" -i brew update
 fi
 
-# Install Python. `brew update` above (or a fresh Homebrew install) means this
-# resolves to the latest formula, so a separate `brew upgrade` is unnecessary.
+# Install Python, then upgrade it: `brew install` is a no-op on an already
+# installed (even outdated) python@3, so a separate `brew upgrade` is needed for
+# interpreter bumps to propagate on existing hosts. `brew upgrade` is a no-op
+# when python@3 is already current (e.g. right after a fresh install).
 echo "Installing python@3..."
 sudo -u "$USER" -i brew install python@3
+sudo -u "$USER" -i brew upgrade python@3
 
 # Install / upgrade boto3 — the only third-party dependency of runner-init.py.
 # `--upgrade` keeps it at the latest version on re-runs triggered by a


### PR DESCRIPTION
Follow-up to https://github.com/ClickHouse/ClickHouse/pull/105202.

That PR taught the praktika `deploy` path to reconcile macOS `user_data` in place (`EC2Instance.Config.update_user_data_on_change`). This moves all of that reconciliation logic out of praktika and into a standalone `ci/infra/scripts/update_userdata.py`, so it is an explicit operator action rather than a side effect of every `deploy`.

`ModifyInstanceAttribute` only accepts a `userData` change while the instance is stopped, and stopping a Mac instance puts its Dedicated Host into a multi-hour scrub that rejects `StartInstances` with `InsufficientHostCapacity` until the host is `available`. The script handles that whole workflow one instance at a time.

The script runs in two phases:

- `build_plan` reads live state (read-only) and returns a list of `PlanItem`s. An instance gets an `update` item when its live `user_data` differs (stop, install, start) or a `start` item when its `user_data` is current but it is stopped. A running, up-to-date instance is logged as skipped and left out of the plan. Comments are ignored when comparing `user_data` (they do not affect the booted runner), so a comment-only edit plans no update - avoiding a pointless fleet-wide stop/start.
- Applying loops the items, blocking on the host scrub. Already-stopped instances are started first, before any update, because an update stops its instance and triggers a scrub that would otherwise block those starts.

The plan is always printed (with a unified diff for the first instance that needs an update); `--apply` then executes it. The `EC2Instance.Config` entries in `ci/infra/cloud.py` are the source of truth: each config supplies the `region` and `user_data_file`, and its live instances are discovered with praktika's own tag-based lookup. Pass instance ids with `--instance`, or omit it to scan every live instance of every config.

`user_data_macos.txt` is trimmed back to the Homebrew + Python + venv bootstrap that hands off to the S3-hosted `runner-init.py`; the venv uses `python3 -m venv --upgrade` and `pip install --upgrade boto3` so interpreter and dependency bumps propagate on each re-run. Its content is identical to PR #105202.

Related: https://github.com/ClickHouse/ClickHouse/pull/105202

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.641`
<!-- ch-version-info:end -->