### PR TITLE
Fix logical error when table is dropped before distributed plan task deserialization

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -269,6 +269,7 @@ namespace ErrorCodes
     extern const int TOO_MANY_PARTITIONS;
     extern const int NO_SUCH_DATA_PART;
     extern const int SUPPORT_IS_DISABLED;
+    extern const int UNKNOWN_TABLE;
 }
 
 static bool checkAllPartsOnRemoteFS(const RangesInDataParts & parts)
@@ -4898,12 +4899,17 @@ std::unique_ptr<IQueryPlanStep> ReadFromMergeTree::deserialize(Deserialization &
         }
     }
 
+    /// The table could be dropped concurrently after the plan was serialized,
+    /// so a failed lookup is a regular error, not a logical one.
     StorageID table_id(database_name, table_name);
-    auto storage_ptr = DatabaseCatalog::instance().tryGetTable(table_id, ctx.context);
-    if (!storage_ptr)
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Table {}.{} not found in catalog", database_name, table_name);
+    auto storage_ptr = DatabaseCatalog::instance().getTable(table_id, ctx.context);
 
-    MergeTreeData & table = dynamic_cast<MergeTreeData &>(*storage_ptr);
+    auto * merge_tree = dynamic_cast<MergeTreeData *>(storage_ptr.get());
+    if (!merge_tree)
+        throw Exception(ErrorCodes::UNKNOWN_TABLE,
+            "Table {} is not a MergeTree table", table_id.getNameForLogs());
+
+    MergeTreeData & table = *merge_tree;
     MergeTreeDataSelectExecutor executor(table);
 
     StorageSnapshotPtr storage_snapshot = table.getStorageSnapshot(table.getInMemoryMetadataPtr(ctx.context, false), ctx.context);


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/ClickHouse/issues/106906
Related: https://github.com/ClickHouse/ClickHouse/pull/106020

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

With `make_distributed_plan = 1`, a table can be dropped concurrently between the coordinator serializing the query plan and a worker deserializing it. This is a reachable runtime condition, not an invariant violation, but the worker threw `LOGICAL_ERROR`, aborting the server in debug and sanitizer builds and bringing down stress tests since #106020.

Now such a query fails with a regular `UNKNOWN_TABLE` error — the same behavior as parallel replicas with ReplicatedMergeTree, where a replica that receives a query for a concurrently dropped table returns `UNKNOWN_TABLE` to the initiator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.602`
<!-- ch-version-info:end -->