### PR TITLE
Correct no-random-settings rationale in 04103_user_network_bandwidth_throttler

### DIFF
--- a/tests/queries/0_stateless/04103_user_network_bandwidth_throttler.sh
+++ b/tests/queries/0_stateless/04103_user_network_bandwidth_throttler.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Tags: no-fasttest, long, no-random-settings
 # no-fasttest: needs S3, and the test is slow (exercises throttling)
-# no-random-settings: S3 prefetch settings affect read throughput; disabling prefetch can make
-# the natural read rate drop close to the throttle limit, causing the throttler to never sleep
+# no-random-settings: various randomized settings (read-buffer sizes, prefetch, thread counts,
+# etc.) perturb the S3 read throughput; pinning them keeps the read rate stable relative to the
+# throttle limit so the throttler reliably sleeps and the assertion is deterministic. The primary
+# robustness comes from the conservative throttle limit below (well under the natural read rate).
 
 CUR_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh


### PR DESCRIPTION
Follow-up to #103586. Corrects the `no-random-settings` rationale comment in `04103_user_network_bandwidth_throttler` — it attributed the flakiness specifically to S3 prefetch, but as @azat pointed out in the review thread, the test fails with prefetching enabled too, so prefetch was not the cause.

The real fragility was the throttle limit sitting just below the natural S3 read rate, which has since been addressed by lowering the limit to 200 KB/s (well under the natural rate). This change only rewords the stale comment to say that various randomized settings perturb read throughput and that the conservative limit is the primary robustness. The `no-random-settings` tag is kept and test behavior is unchanged.

(Whether the tag is now redundant given the 200 KB/s limit could not be determined from CI history, since the two mitigations have only ever coexisted on master; this PR deliberately keeps the tag.)

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):


### Documentation entry for user-facing changes

- [ ] Documentation is written (mandatory for new features)
