### PR TITLE
Stop merges in 03394_distributed_shuffle_join_early_close_sink to fix flakiness

### DIFF
--- a/tests/queries/0_stateless/03394_distributed_shuffle_join_early_close_sink.sql
+++ b/tests/queries/0_stateless/03394_distributed_shuffle_join_early_close_sink.sql
@@ -6,6 +6,9 @@ SET max_rows_to_group_by = 0;
 
 CREATE TABLE test(id UInt64, data String) ENGINE=MergeTree() ORDER BY id SETTINGS index_granularity=10000;
 
+-- Temporary fix: keep the part set stable, a merge could replace the parts pinned in the distributed plan.
+SYSTEM STOP MERGES test;
+
 INSERT INTO test SELECT number, '' FROM numbers(10000000);
 
 -- Joining on a.id%1 so that only one bucket is not empty


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/106020

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

The test flakes in the "distributed plan" stateless flavor with `Distributed read: part all_1_1_0 selected by the coordinator is not available on this replica (diverged by merge or replication lag); retry the query` ([CI report](https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=fc73f46fae655b1fb5e5dc447c121c844a8a6295&name_0=MasterCI&name_1=Stateless%20tests%20%28amd_debug%2C%20distributed%20plan%2C%20s3%20storage%2C%20parallel%29)).

The 10M-row insert lands as multiple parts whose names the coordinator pins in the serialized plan, and the deliberately slow read (`sleepEachRow`) gives background merges time to replace the pinned parts before a late worker task takes its storage snapshot. Stopping merges before the insert keeps the part set stable, so the retryable `NO_SUCH_DATA_PART` error cannot fire.

This is a temporary test-level fix. The proper fix is for the worker to resolve the pinned part names including Outdated parts instead of taking a fresh active-only snapshot, making bucketed distributed reads immune to concurrent merges and mutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.608`
<!-- ch-version-info:end -->