### PR TITLE
Fix LOGICAL_ERROR in function execution over Dynamic with same type in shared and regular variant

### DIFF
--- a/src/Functions/FunctionDynamicAdaptor.cpp
+++ b/src/Functions/FunctionDynamicAdaptor.cpp
@@ -399,8 +399,11 @@ ColumnPtr ExecutableFunctionDynamicAdaptor::executeImpl(const ColumnsWithTypeAnd
     /// variants we have in Dynamic column (shared variant can contain unknown amount of new variant types).
     /// So, we allocate 0 index for rows with NULL values.
     variants.emplace_back();
-    /// Remember indexes in selector for each variant type.
-    UnorderedMapWithMemoryTracking<String, size_t> variant_indexes;
+    /// Remember indexes in selector for each variant type. The same type can be present both in the
+    /// shared variant and as a regular variant, and these two storages need separate selector indexes
+    /// (shared values are deserialized into a fresh column, regular values reference the existing one).
+    UnorderedMapWithMemoryTracking<String, size_t> shared_variant_indexes;
+    UnorderedMapWithMemoryTracking<String, size_t> non_shared_variant_indexes;
     const auto & local_discriminators = variant_column.getLocalDiscriminators();
     const auto & offsets = variant_column.getOffsets();
     auto shared_variant_local_discr = variant_column.localDiscriminatorByGlobal(dynamic_column.getSharedVariantDiscriminator());
@@ -424,12 +427,12 @@ ColumnPtr ExecutableFunctionDynamicAdaptor::executeImpl(const ColumnsWithTypeAnd
             auto type = decodeDataType(buf);
             auto type_name = type->getName();
 
-            /// Check if we already allocated selector index for this variant type.
+            /// Check if we already allocated selector index for this variant type in the shared variant.
             /// If not, append it to list of variants and remember its index.
-            auto indexes_it = variant_indexes.find(type_name);
-            if (indexes_it == variant_indexes.end())
+            auto indexes_it = shared_variant_indexes.find(type_name);
+            if (indexes_it == shared_variant_indexes.end())
             {
-                indexes_it = variant_indexes.emplace(type_name, variants.size()).first;
+                indexes_it = shared_variant_indexes.emplace(type_name, variants.size()).first;
                 variants.emplace_back(type->createColumn(), type, "");
             }
 
@@ -445,12 +448,12 @@ ColumnPtr ExecutableFunctionDynamicAdaptor::executeImpl(const ColumnsWithTypeAnd
         else
         {
             auto global_discr = variant_column.globalDiscriminatorByLocal(local_discr);
-            /// Check if we already allocated selector index for this variant type.
+            /// Check if we already allocated selector index for this non-shared variant type.
             /// If not, append it to list of variants and remember its index.
-            auto it = variant_indexes.find(variant_info.variant_names[global_discr]);
-            if (it == variant_indexes.end())
+            auto it = non_shared_variant_indexes.find(variant_info.variant_names[global_discr]);
+            if (it == non_shared_variant_indexes.end())
             {
-                it = variant_indexes.emplace(variant_info.variant_names[global_discr], variants.size()).first;
+                it = non_shared_variant_indexes.emplace(variant_info.variant_names[global_discr], variants.size()).first;
                 variants.emplace_back(variant_column.getVariantPtrByLocalDiscriminator(local_discr), variant_types[global_discr], "");
             }
 

--- a/src/Functions/tests/gtest_function_dynamic_adaptor_shared_variant.cpp
+++ b/src/Functions/tests/gtest_function_dynamic_adaptor_shared_variant.cpp
@@ -1,0 +1,62 @@
+#include <gtest/gtest.h>
+
+#include <Common/tests/gtest_global_context.h>
+#include <Common/tests/gtest_global_register.h>
+
+#include <Functions/FunctionFactory.h>
+#include <Interpreters/Context.h>
+#include <DataTypes/DataTypeDynamic.h>
+#include <DataTypes/DataTypesNumber.h>
+#include <Columns/ColumnDynamic.h>
+#include <Columns/ColumnString.h>
+#include <Columns/ColumnsNumber.h>
+#include <Core/Field.h>
+
+using namespace DB;
+
+/// A Dynamic column can hold the same logical type both as a regular variant and inside the shared
+/// variant at the same time. Applying a function over such a column must keep separate selector slots
+/// for the two storages, otherwise the per-variant column sizes stop matching the scattered arguments.
+TEST(FunctionDynamicAdaptor, SameTypeInSharedAndRegularVariant)
+{
+    tryRegisterFunctions();
+    auto context = getContext().context;
+
+    auto dyn_type = std::make_shared<DataTypeDynamic>(2);
+    auto column = ColumnDynamic::create(2);
+
+    /// Put several Int8 values into the shared variant.
+    auto int8_type = std::make_shared<DataTypeInt8>();
+    auto shared_src = int8_type->createColumn();
+    shared_src->insert(Field(Int8(20)));
+    shared_src->insert(Field(Int8(21)));
+    shared_src->insert(Field(Int8(22)));
+    column->insertValueIntoSharedVariant(*shared_src, int8_type, int8_type->getName(), 0);
+    column->insertValueIntoSharedVariant(*shared_src, int8_type, int8_type->getName(), 1);
+    column->insertValueIntoSharedVariant(*shared_src, int8_type, int8_type->getName(), 2);
+
+    /// Add regular Int8 values: same type, non-shared variant.
+    column->insert(Field(Int8(10)));
+    column->insert(Field(Int8(11)));
+
+    const size_t n = column->size();
+    ASSERT_EQ(n, 5u);
+    ASSERT_EQ(column->getSharedVariant().size(), 3u);
+
+    /// A binary function with a non-const second argument routes through FunctionDynamicAdaptor and
+    /// scatters the second argument per variant.
+    auto rhs_type = std::make_shared<DataTypeInt64>();
+    auto rhs = rhs_type->createColumn();
+    for (size_t i = 0; i < n; ++i)
+        rhs->insert(Field(Int64(100)));
+
+    auto resolver = FunctionFactory::instance().get("plus", context);
+    ColumnsWithTypeAndName args;
+    args.emplace_back(ColumnWithTypeAndName{std::move(column), dyn_type, "d"});
+    args.emplace_back(ColumnWithTypeAndName{std::move(rhs), rhs_type, "rhs"});
+    auto func = resolver->build(args);
+
+    ColumnPtr result;
+    ASSERT_NO_THROW(result = func->execute(args, func->getResultType(), n, false));
+    ASSERT_EQ(result->size(), n);
+}


### PR DESCRIPTION
Fixes a `LOGICAL_ERROR` when a function is applied over a `Dynamic` column that holds the same logical type both as a regular variant and inside the shared variant.

`ExecutableFunctionDynamicAdaptor::executeImpl` built the per-variant selector using one `name -> index` map shared between the shared-variant branch and the regular-variant branch. When the same type appeared in both storages the branches collided on a single selector index, so the per-variant column row count stopped matching the scattered arguments and `checkFunctionArgumentSizes` aborted with `Expected the argument N to have X rows, but it has Y`. The fix keeps separate maps for the two storages.

Found by the AST fuzzer (rare, depends on parallel block layout). Mirrors the approach of #106589 (closed); adds a deterministic unit test that builds such a column and runs a function through the adaptor (aborts before the fix, passes after).

No related open issue found.

### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a user-readable short description of the changes that goes into CHANGELOG.md):
Fix a `LOGICAL_ERROR` (`Expected the argument N to have X rows, but it has Y`) when applying a function to a `Dynamic` column that contains the same type both as a regular variant and in the shared variant.
