### PR TITLE
Backport version-specific labels even when the named release is end-of-life

### DIFF
--- a/docs/en/development/backports.md
+++ b/docs/en/development/backports.md
@@ -64,6 +64,8 @@ A release branch can be in a **rolling-out** state (its release PR carries the `
 
 A version-specific label sets the *oldest* release the PR must reach: it is backported to that release **and to every newer active release branch**, not only to the named one. For example, `v25.3-must-backport` on a PR merged into the development branch backports to `25.3` and to every active release after it (`25.4`, `25.5`, …). If multiple version-specific labels are present, the lowest version wins, since it already covers the newer ones.
 
+The named release does not have to be active itself. A label for an end-of-life release (one with no open release PR) still pulls the fix forward into every active release after it, so upgrading from that release never silently loses the fix. For example, `v25.12-must-backport` on a PR keeps backporting to `26.1`, `26.2`, … even after `25.12` itself has reached end-of-life.
+
 ## Implementation {#implementation}
 
 ### Overview {#overview}
@@ -84,7 +86,7 @@ Labels on the original PR control whether and where backporting happens.
 | `pr-must-backport` | Backport to all active release branches (skipping branches marked `rolling-out`) |
 | `pr-must-backport-force` | Backport to all active release branches, ignoring `rolling-out` restrictions |
 | `pr-critical-bugfix` | Triggers `pr-must-backport` automatically (via `AUTO_BACKPORT` in `pr_labels_and_category.py`) |
-| `v{VER}-must-backport` (e.g. `v25.3-must-backport`) | Backport to that release branch **and every newer active release branch** — the version marks the *oldest* release the PR must reach. With several such labels, the lowest version wins. Overrides the `rolling-out` skip for those branches |
+| `v{VER}-must-backport` (e.g. `v25.3-must-backport`) | Backport to that release branch **and every newer active release branch** — the version marks the *oldest* release the PR must reach, even when the named release is itself end-of-life. With several such labels, the lowest version wins. Overrides the `rolling-out` skip for those branches |
 | `pr-backports-created` | Set by the bot when all required backport PRs have been created; cleared if a cherry-pick PR is reopened |
 | `pr-cherrypick` | Applied to cherry-pick PRs created by the bot |
 | `pr-backport` | Applied to backport PRs created by the bot |
@@ -104,7 +106,7 @@ For each original PR number `N` and release branch `release/X.Y`:
 
 #### 1. Discover active releases {#discover-active-releases}
 
-`BackportPRs.receive_release_prs` queries GitHub for all open PRs with the `release` label. The head refs of these PRs are the release branch names (e.g. `release/25.3`). A compatibility label set is derived from them: `v25.3-must-backport`, etc.
+`BackportPRs.receive_release_prs` queries GitHub for all open PRs with the `release` label. The head refs of these PRs are the release branch names (e.g. `release/25.3`). From these it derives the set of version-specific labels to search for: every `v{VER}-must-backport` label that exists in the repository whose version is not newer than the newest active release. Older labels are included even when their release is no longer active (a label newer than every active release is skipped, since it could not expand to any active branch), so a PR labelled for an end-of-life release is still found as long as a newer release is active.
 
 #### 2. Find PRs to backport {#find-prs-to-backport}
 

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -39,7 +39,11 @@ from typing import Iterable, List, Optional
 from github.GithubException import GithubException
 
 from cache_utils import GitHubCache
-from cherry_pick_branches import select_backport_branches
+from cherry_pick_branches import (
+    branch_version,
+    label_version,
+    select_backport_branches,
+)
 from ci_buddy import CIBuddy
 from ci_utils import Shell
 from env_helper import (
@@ -641,13 +645,23 @@ class BackportPRs:
         self.release_prs = self.gh.get_release_pulls(self._repo_name)
         self.release_branches = [pr.head.ref for pr in self.release_prs]
 
-        self.labels_to_backport = [
-            # compatibility labels for the cloud and public release branches
-            f"v{branch.replace('release/', '')}-must-backport"
-            for branch in self.release_branches
-        ]
+        # A version-specific label `vX.Y-must-backport` is backported to X.Y and
+        # to every newer active release (see `select_backport_branches`). The
+        # named release need not be active itself, so the search must also pick
+        # up PRs labelled for an end-of-life release as long as a newer release
+        # is still active. Include every version-specific label that exists in
+        # the repo whose version is not newer than the newest active release --
+        # a newer label could not expand to any active branch.
+        newest_active = max(branch_version(branch) for branch in self.release_branches)
+        self.labels_to_backport = sorted(
+            label.name
+            for label in self.repo.get_labels()
+            if label_version(label.name) is not None
+            and label_version(label.name) <= newest_active
+        )
 
         logging.info("Active releases: %s", ", ".join(self.release_branches))
+        logging.info("Labels to backport: %s", ", ".join(self.labels_to_backport))
 
     def update_local_release_branches(self):
         logging.info("Update local release branches")

--- a/tests/ci/cherry_pick_branches.py
+++ b/tests/ci/cherry_pick_branches.py
@@ -9,7 +9,11 @@ in `cherry_pick.py` / `pr_info.py` and are passed in by the caller, so this
 module stays the single source of truth for *which branches* a PR reaches
 without duplicating *what the labels are called*.
 """
+import re
 from typing import List, Optional, Sequence, Set, Tuple
+
+# Version-specific backport label, e.g. `v25.12-must-backport`.
+VERSION_LABEL_RE = re.compile(r"^v(\d+)\.(\d+)-must-backport$")
 
 
 def version_key(version: str) -> Tuple[int, ...]:
@@ -26,28 +30,32 @@ def branch_version(branch: str) -> Tuple[int, ...]:
     return version_key(branch.replace("release/", ""))
 
 
-def must_backport_label(branch: str) -> str:
-    """The version-specific backport label for a release branch."""
-    return f"v{branch.replace('release/', '')}-must-backport"
+def label_version(label: str) -> Optional[Tuple[int, ...]]:
+    """A version-specific backport label to its version: `v25.12-must-backport`
+    -> `(25, 12)`. Returns `None` for any other label."""
+    match = VERSION_LABEL_RE.fullmatch(label)
+    if match is None:
+        return None
+    return (int(match.group(1)), int(match.group(2)))
 
 
-def backport_floor(
-    pr_labels: Sequence[str], release_branches: Sequence[str]
-) -> Optional[Tuple[int, ...]]:
+def backport_floor(pr_labels: Sequence[str]) -> Optional[Tuple[int, ...]]:
     """
-    The lowest version among the PR's *active* version-specific backport labels
+    The lowest version among the PR's version-specific backport labels
     (`v<MAJOR>.<MINOR>-must-backport`), or `None` if there are none.
 
     A version-specific label marks the OLDEST release the PR must reach, so the
     minimum of them is the floor: the PR is backported to that release and to
-    every newer active release branch. Only labels that match an active release
-    branch are considered, so a stale label for an end-of-life release can never
-    widen the floor.
+    every newer active release branch. The named release does NOT need to be
+    active itself -- a label for an end-of-life release (e.g. `v25.12` when only
+    the 26.x line and the 25.8 LTS are active) still pulls the fix forward into
+    every active release after it, so upgrading from that release never silently
+    loses the fix.
     """
     floors = [
-        branch_version(branch)
-        for branch in release_branches
-        if must_backport_label(branch) in pr_labels
+        version
+        for version in (label_version(label) for label in pr_labels)
+        if version is not None
     ]
     return min(floors) if floors else None
 
@@ -78,7 +86,7 @@ def select_backport_branches(
       version request always proceeds.
     """
     labels = set(pr_labels)
-    floor = backport_floor(pr_labels, release_branches)
+    floor = backport_floor(pr_labels)
     # The branches a version-specific label expands to: the floor release and
     # every newer active branch. Such a label overrides the `rolling_out` skip
     # for exactly these branches.
@@ -104,10 +112,13 @@ def select_backport_branches(
         ]
         return branches, skipped
 
-    # Version-specific labels only. The floor is one of the active release
-    # branches, so `covered_by_floor` is never empty here.
+    # Version-specific labels only. `covered_by_floor` is the floor release and
+    # every newer active branch. It is normally non-empty -- the search that
+    # feeds this function only selects PRs whose floor is not newer than the
+    # newest active release -- but it may be empty if a PR carries only a label
+    # newer than every active release; the caller skips such PRs gracefully.
     assert floor is not None, (
         "select_backport_branches called without a general backport label and "
-        f"without an active version-specific label; labels: {sorted(labels)}"
+        f"without a version-specific label; labels: {sorted(labels)}"
     )
     return [branch for branch in release_branches if branch in covered_by_floor], []

--- a/tests/ci/test_cherry_pick_branches.py
+++ b/tests/ci/test_cherry_pick_branches.py
@@ -14,6 +14,7 @@ from typing import List, Set
 from cherry_pick_branches import (
     backport_floor,
     branch_version,
+    label_version,
     select_backport_branches,
     version_key,
 )
@@ -54,26 +55,38 @@ class TestVersionKey(unittest.TestCase):
         self.assertEqual(branch_version("26.1"), (26, 1))
 
 
+class TestLabelVersion(unittest.TestCase):
+    def test_parses_version_specific_label(self):
+        self.assertEqual(label_version("v25.12-must-backport"), (25, 12))
+        self.assertEqual(label_version("v26.1-must-backport"), (26, 1))
+
+    def test_rejects_other_labels(self):
+        self.assertIsNone(label_version("pr-must-backport"))
+        # A longer label must not match the version prefix.
+        self.assertIsNone(label_version("v25.12-must-backport-synced"))
+
+
 class TestBackportFloor(unittest.TestCase):
-    def test_single_active_label(self):
-        self.assertEqual(backport_floor(["v25.12-must-backport"], RB), (25, 12))
+    def test_single_label(self):
+        self.assertEqual(backport_floor(["v25.12-must-backport"]), (25, 12))
 
     def test_lowest_of_multiple_labels_wins(self):
         self.assertEqual(
-            backport_floor(["v26.2-must-backport", "v25.12-must-backport"], RB),
+            backport_floor(["v26.2-must-backport", "v25.12-must-backport"]),
             (25, 12),
         )
 
-    def test_stale_inactive_label_does_not_lower_floor(self):
-        # v25.8 is not an active release branch -> it must be ignored, so the
-        # floor stays at the lowest *active* label (26.2), not 25.8.
+    def test_inactive_label_still_sets_floor(self):
+        # A version label is honoured by its literal version regardless of
+        # whether that release is still active. 25.8 lowers the floor below
+        # 26.2 so the fix is pulled forward into every newer active release.
         self.assertEqual(
-            backport_floor(["v25.8-must-backport", "v26.2-must-backport"], RB),
-            (26, 2),
+            backport_floor(["v25.8-must-backport", "v26.2-must-backport"]),
+            (25, 8),
         )
 
     def test_no_version_label(self):
-        self.assertIsNone(backport_floor(["pr-must-backport"], RB))
+        self.assertIsNone(backport_floor(["pr-must-backport"]))
 
 
 class TestSelectVersionSpecific(unittest.TestCase):
@@ -103,9 +116,28 @@ class TestSelectVersionSpecific(unittest.TestCase):
         # 26.10 must be included (>= 26.9); a string comparison would drop it.
         self.assertEqual(branches, ["release/26.9", "release/26.10"])
 
-    def test_stale_label_does_not_widen_selection(self):
+    def test_inactive_label_widens_selection(self):
+        # 25.8 is older than every branch in RB and not active here, but its
+        # label still sets the floor, so the fix fans out to all of RB.
         branches, _ = select(["v25.8-must-backport", "v26.2-must-backport"], RB)
+        self.assertEqual(branches, RB)
+
+    def test_eol_named_release_fans_out_to_newer_active(self):
+        # The #101644 scenario: the named release (25.12) is end-of-life and not
+        # in the active set, yet the fix must still reach every newer active
+        # release (here 26.2, 26.3 -- e.g. the private fork keeps them alive).
+        branches, skipped = select(
+            ["v25.12-must-backport"], ["release/26.2", "release/26.3"]
+        )
         self.assertEqual(branches, ["release/26.2", "release/26.3"])
+        self.assertEqual(skipped, [])
+
+    def test_floor_newer_than_all_active_yields_no_branches(self):
+        # A label newer than every active release expands to nothing; the
+        # function returns an empty list rather than raising.
+        branches, skipped = select(["v27.1-must-backport"], RB)
+        self.assertEqual(branches, [])
+        self.assertEqual(skipped, [])
 
     def test_rolling_out_ignored_for_version_specific(self):
         # A pure version-specific request always proceeds, even for a
@@ -116,7 +148,7 @@ class TestSelectVersionSpecific(unittest.TestCase):
         self.assertEqual(branches, RB)
         self.assertEqual(skipped, [])
 
-    def test_floor_is_always_an_active_branch_so_never_empty(self):
+    def test_floor_at_newest_branch_selects_only_it(self):
         branches, _ = select(["v26.3-must-backport"], RB)
         self.assertEqual(branches, ["release/26.3"])
 


### PR DESCRIPTION
The fan-out behaviour for version-specific backport labels (added in `ec91c467f9b`, "Backport version-specific labels to all newer releases") only worked while the *named* release was still active. Both guards in `cherry_pick.py` keyed off the active release branches:

- `BackportPRs.receive_release_prs` built the GitHub search label set solely from active-branch labels, so a PR carrying a label for an end-of-life release was never selected.
- `backport_floor` derived the floor from active branches only, so even if such a PR were found, the floor would be `None`.

As a result, a PR labelled `v25.12-must-backport` after `25.12` reached end-of-life was dropped entirely — it was not backported to the newer releases (`26.2`, `26.3`, …) that still need the fix. That is the footgun the original change set out to prevent: a fix present in an old release but missing from a newer one, so upgrading silently loses it. See `https://github.com/ClickHouse/ClickHouse/pull/101644`, which carries `v25.12-must-backport` and received no backport.

## Approach

A version-specific label is now honoured by its literal version, regardless of whether the named release is still active:

- `backport_floor` parses the version from the label itself (new `label_version` helper) instead of matching it against active branches. The floor still fans out to every active release `>=` it.
- `receive_release_prs` now searches every `vX.Y-must-backport` label that exists in the repository whose version is not newer than the newest active release. End-of-life labels such as `v25.12` are included; a label newer than every active release is skipped, since it could not expand to any active branch. Only a handful of these labels exist (old ones are deleted), so the search query stays small.

The end-of-life release itself is never a target — it has no active branch — but every active release after it is. This matters mainly for the private fork, where releases such as `26.2` stay active longer: a `v25.12-must-backport` PR now backports to `26.2` as expected.

The branch-selection contract lives in `cherry_pick_branches.py` (no GitHub/git/CI deps) with unit tests in `test_cherry_pick_branches.py`. The two "stale label" tests are updated to the new contract (an inactive label sets the floor and widens selection), and new cases cover the end-of-life named release fanning out and a floor newer than every active release yielding no branches. `docs/en/development/backports.md` is updated accordingly.

Related: https://github.com/ClickHouse/ClickHouse/pull/101644

### Changelog category (leave one):
- CI Fix or Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.600`
<!-- ch-version-info:end -->