### PR TITLE
Shrink idle thread pools of the distributed query infrastructure

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -2041,8 +2041,12 @@ try
     if (config().getBool("stateless_worker_server.enabled", false))
     {
         String stateless_worker_endpoint = config().getString("stateless_worker_server.endpoint", "localhost");
+        size_t stateless_worker_max_threads = config().getUInt64("stateless_worker_server.max_threads", 1000);
+        if (stateless_worker_max_threads == 0)
+            throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER,
+                "`stateless_worker_server.max_threads` must be at least 1");
         stateless_worker_endpoint_ptr = std::make_shared<StatelessWorkerEndpoint>(
-            config().getUInt64("stateless_worker_server.max_threads", 1000),
+            stateless_worker_max_threads,
             config().getUInt64("stateless_worker_server.max_free_threads", 0),
             config().getUInt64("stateless_worker_server.queue_size", 3000));
         stateless_worker_endpoint_name = stateless_worker_endpoint_ptr->getId(stateless_worker_endpoint);

--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -2041,7 +2041,10 @@ try
     if (config().getBool("stateless_worker_server.enabled", false))
     {
         String stateless_worker_endpoint = config().getString("stateless_worker_server.endpoint", "localhost");
-        stateless_worker_endpoint_ptr = std::make_shared<StatelessWorkerEndpoint>();
+        stateless_worker_endpoint_ptr = std::make_shared<StatelessWorkerEndpoint>(
+            config().getUInt64("stateless_worker_server.max_threads", 1000),
+            config().getUInt64("stateless_worker_server.max_free_threads", 0),
+            config().getUInt64("stateless_worker_server.queue_size", 3000));
         stateless_worker_endpoint_name = stateless_worker_endpoint_ptr->getId(stateless_worker_endpoint);
         global_context->getInterserverIOHandler().addEndpoint(stateless_worker_endpoint_name, stateless_worker_endpoint_ptr);
         LOG_DEBUG(log, "Added stateless worker endpoint '{}'.", stateless_worker_endpoint_name);

--- a/src/Server/DistributedQuery/ExchangeServer.cpp
+++ b/src/Server/DistributedQuery/ExchangeServer.cpp
@@ -31,9 +31,10 @@ namespace ErrorCodes
 }
 
 /// Bounds the handshake thread pool: enough threads to absorb bursts of concurrent connections
-/// without serializing on the accept thread, while staying bounded.
+/// without serializing on the accept thread, while staying bounded. Handshakes are short-lived,
+/// so idle threads are not retained.
 static constexpr size_t HANDSHAKE_POOL_MAX_THREADS = 64;
-static constexpr size_t HANDSHAKE_POOL_MAX_FREE_THREADS = 8;
+static constexpr size_t HANDSHAKE_POOL_MAX_FREE_THREADS = 0;
 static constexpr size_t HANDSHAKE_POOL_QUEUE_SIZE = 10000;
 
 ExchangeServer::ExchangeServer(const String & listen_host, UInt16 port, ExchangeConnectionsPtr connections_)

--- a/src/Server/StatelessWorker/StatelessTaskExecutor.cpp
+++ b/src/Server/StatelessWorker/StatelessTaskExecutor.cpp
@@ -28,12 +28,12 @@ namespace DB
 /// TODO: move
 std::pair<ObjectStoragePtr, String> getObjectStorageForTemporaryFiles(const String & unique_temp_file_path, ContextPtr context);
 
-StatelessTaskExecutor::StatelessTaskExecutor()
+StatelessTaskExecutor::StatelessTaskExecutor(size_t max_threads, size_t max_free_threads, size_t queue_size)
     : thread_pool(
         CurrentMetrics::StatelessWorkerThreads,
         CurrentMetrics::StatelessWorkerThreadsActive,
         CurrentMetrics::StatelessWorkerThreadsScheduled,
-        1000, 100, 3000)
+        max_threads, max_free_threads, queue_size)
 {
 }
 

--- a/src/Server/StatelessWorker/StatelessTaskExecutor.h
+++ b/src/Server/StatelessWorker/StatelessTaskExecutor.h
@@ -18,7 +18,7 @@ namespace DB
 class StatelessTaskExecutor
 {
 public:
-    StatelessTaskExecutor();
+    StatelessTaskExecutor(size_t max_threads, size_t max_free_threads, size_t queue_size);
     virtual ~StatelessTaskExecutor() = default;
 
     enum Result

--- a/src/Server/StatelessWorker/StatelessWorkerEndpoint.cpp
+++ b/src/Server/StatelessWorker/StatelessWorkerEndpoint.cpp
@@ -19,10 +19,10 @@ namespace ErrorCodes
     extern const int NOT_IMPLEMENTED;
 }
 
-StatelessWorkerEndpoint::StatelessWorkerEndpoint()
+StatelessWorkerEndpoint::StatelessWorkerEndpoint(size_t max_threads, size_t max_free_threads, size_t queue_size)
     : endpoint_name("stateless_worker/")
     , log(Poco::Logger::getShared("StatelessWorkerEndpoint"))
-    , task_runner(std::make_shared<StatelessTaskExecutor>())
+    , task_runner(std::make_shared<StatelessTaskExecutor>(max_threads, max_free_threads, queue_size))
 {
 }
 

--- a/src/Server/StatelessWorker/StatelessWorkerEndpoint.h
+++ b/src/Server/StatelessWorker/StatelessWorkerEndpoint.h
@@ -12,7 +12,7 @@ class StatelessTaskExecutor;
 class StatelessWorkerEndpoint final : public InterserverIOEndpoint, private boost::noncopyable
 {
 public:
-    StatelessWorkerEndpoint();
+    StatelessWorkerEndpoint(size_t max_threads, size_t max_free_threads, size_t queue_size);
     ~StatelessWorkerEndpoint() override;
 
     std::string getId(const std::string & path) const override;

--- a/tests/config/config.d/thread_pool_trim.xml
+++ b/tests/config/config.d/thread_pool_trim.xml
@@ -1,0 +1,6 @@
+<clickhouse>
+    <!-- Trim idle global pool threads after concurrency bursts. The default of 1000 is above the
+         idle thread count typically reached in tests, so the pool would never shrink and each
+         thread would keep its stack resident, which is expensive under sanitizers. -->
+    <max_thread_pool_free_size>128</max_thread_pool_free_size>
+</clickhouse>

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -173,6 +173,7 @@ function is_sanitizer_build()
 }
 if is_sanitizer_build; then
     ln -sf $SRC_PATH/config.d/trace_log_no_symbolize.xml $DEST_SERVER_PATH/config.d/
+    ln -sf $SRC_PATH/config.d/thread_pool_trim.xml $DEST_SERVER_PATH/config.d/
 fi
 ln -sf $SRC_PATH/config.d/memory_profiler.yaml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/rocksdb.xml $DEST_SERVER_PATH/config.d/


### PR DESCRIPTION
Related: https://github.com/ClickHouse/ClickHouse/pull/106020

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)

Since the stateless worker endpoint and streaming exchange server were enabled in every stateless CI run, sanitizer jobs idle closer to their memory cap and OOM more often. The infrastructure retains idle threads for the server's lifetime, and under ASan each parked thread is expensive (instrumented stack pages, fake stack, allocator cache, shadow memory), none of it visible to the memory tracker.

Three sources of retained threads, addressed individually:
- `StatelessTaskExecutor` kept up to 100 idle pool threads (observed: 35 parked for the whole run at ~0.1% utilization). The pool parameters are now configurable via `stateless_worker_server.max_threads/max_free_threads/queue_size`, and idle threads are not retained by default. Since `ThreadPool` spawns threads on demand, this has no startup or steady-state cost.
- The `ExchangeServer` handshake pool kept 8 idle threads; handshakes are short-lived, so it now retains none.
- The global thread pool only trims when idle threads exceed `max_thread_pool_free_size` (default 1000). Idle counts in stateless runs peak at ~400-500, so the pool never shrank and every concurrency burst permanently ratcheted up the thread count and resident stack memory. Sanitizer test configs now set the threshold to 128.

Verified locally: after running the `03394_distributed_*` worker-path tests, `StatelessWorkerThreads` and `ExchangeServerThreads` drain to 0 instead of parking at their high-water marks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.607`
<!-- ch-version-info:end -->