### PR TITLE
Avoid quoting a fatal error string in a test comment (serverfuzz false positive)

### DIFF
--- a/tests/queries/0_stateless/04100_summing_merge_tree_sort_order_float_nan.sql
+++ b/tests/queries/0_stateless/04100_summing_merge_tree_sort_order_float_nan.sql
@@ -29,8 +29,9 @@ INSERT INTO TABLE t_float_nan_sort (c1, c0)
 INSERT INTO TABLE t_float_nan_sort (c1, c0)
     SELECT c1, c0 FROM generateRandom('c1 Float32, c0 Int32', 14156128262908154975, 2463, 2) LIMIT 10;
 
--- This OPTIMIZE triggers a merge. Before the fix, debug builds crashed here with:
--- "Logical error: Sort order of blocks violated for column number ..."
+-- This OPTIMIZE triggers the merge. Before the fix, debug builds aborted here
+-- when CheckSortedTransform saw the merge output regress on the hash sort key;
+-- release builds silently wrote a part with a corrupt primary-key index.
 OPTIMIZE TABLE t_float_nan_sort FINAL;
 
 SELECT count() > 0 FROM t_float_nan_sort;


### PR DESCRIPTION
The comment above the `OPTIMIZE` in `04100_summing_merge_tree_sort_order_float_nan` quoted the historical error verbatim:

```
-- "Logical error: Sort order of blocks violated for column number ..."
```

During serverfuzz/stress runs the merge of this table can be cancelled by the CancellationChecker timeout. The resulting `Code: 236 ... Cancelled merging parts (ABORTED)` log line echoes the cancelled query back into the server log, including that comment. The fuzzer log scraper (`ci/jobs/scripts/log_parser.py`, `FuzzerLogParser.parse_failure`) greps the server log with `rg --text -o 'Logical error.*'` and lifts the quoted comment fragment as the failure name, producing a spurious `Logical error: Sort order of blocks violated ...` result.

This surfaced once on master (2026-06-01, `Stress test (experimental, serverfuzz, arm_tsan)`) even though the actual fix from #102791 is present and correct. Verified locally on a debug build: base seed + merge-tree-setting variants + type/engine variants + 300 AST-fuzzer runs all pass; the only real log event in that CI run was the `ABORTED` merge cancellation.

Reword the comment to keep the explanation without the literal trigger string. No test logic changes; output is unchanged (`1 / 1 / 1`).

Note: the scraper weakness is general (20+ stateless tests quote such strings in comments). A parser-side fix that ignores matches inside echoed-query/comment lines — mirroring the filter `get_failed_query` already applies — would cover all of them, but it touches shared crash-detection infra and is left as a separate change.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.606`
<!-- ch-version-info:end -->