### PR TITLE
Fix flaky test_lost_part by disabling failed-fetch/merge backoff

### DIFF
--- a/tests/integration/test_lost_part/test.py
+++ b/tests/integration/test_lost_part/test.py
@@ -45,7 +45,8 @@ def test_lost_part_same_replica(start_cluster):
             node.query(
                 f"CREATE TABLE mt0 (id UInt64, date Date) ENGINE ReplicatedMergeTree('/clickhouse/tables/t', '{node.name}') ORDER BY tuple() PARTITION BY date "
                 "SETTINGS cleanup_delay_period=1, cleanup_delay_period_random_add=1, cleanup_thread_preferred_points_per_iteration=0,"
-                "merge_selecting_sleep_ms=100, max_merge_selecting_sleep_ms=1000"
+                "merge_selecting_sleep_ms=100, max_merge_selecting_sleep_ms=1000,"
+                "max_postpone_time_for_failed_replicated_fetches_ms=0, max_postpone_time_for_failed_replicated_merges_ms=0"
             )
 
         node1.query("SYSTEM STOP MERGES mt0")
@@ -114,7 +115,8 @@ def test_lost_part_other_replica(start_cluster):
             node.query(
                 f"CREATE TABLE mt1 (id UInt64) ENGINE ReplicatedMergeTree('/clickhouse/tables/t1', '{node.name}') ORDER BY tuple() "
                 "SETTINGS cleanup_delay_period=1, cleanup_delay_period_random_add=1, cleanup_thread_preferred_points_per_iteration=0,"
-                "merge_selecting_sleep_ms=100, max_merge_selecting_sleep_ms=1000"
+                "merge_selecting_sleep_ms=100, max_merge_selecting_sleep_ms=1000,"
+                "max_postpone_time_for_failed_replicated_fetches_ms=0, max_postpone_time_for_failed_replicated_merges_ms=0"
             )
 
         node1.query("SYSTEM STOP MERGES mt1")
@@ -188,7 +190,8 @@ def test_lost_part_mutation(start_cluster):
             node.query(
                 f"CREATE TABLE mt2 (id UInt64) ENGINE ReplicatedMergeTree('/clickhouse/tables/t2', '{node.name}') ORDER BY tuple() "
                 "SETTINGS cleanup_delay_period=1, cleanup_delay_period_random_add=1, cleanup_thread_preferred_points_per_iteration=0,"
-                "merge_selecting_sleep_ms=100, max_merge_selecting_sleep_ms=1000, max_postpone_time_for_failed_mutations_ms = 0"
+                "merge_selecting_sleep_ms=100, max_merge_selecting_sleep_ms=1000, max_postpone_time_for_failed_mutations_ms = 0,"
+                "max_postpone_time_for_failed_replicated_fetches_ms=0, max_postpone_time_for_failed_replicated_merges_ms=0"
             )
 
         node1.query("SYSTEM STOP MERGES mt2")


### PR DESCRIPTION
`test_lost_part_other_replica` (and siblings `test_lost_part_same_replica`, `test_lost_part_mutation`) drain the replication queue with a tight 10x1s poll loop after lost-part recovery. Recovery produces queue entries that fail transiently: a `GET_PART` for the recovered part can hit `PART_IS_TEMPORARILY_LOCKED` while the outdated duplicate is cleaned up, and the dependent `MERGE_PARTS` hits `NO_REPLICA_HAS_PART` until the fetch lands. Each failure increments `num_tries`, and `ReplicatedMergeTreeQueue::getPostponeTimeMsForEntry` parks the entry for `1 << num_tries` ms capped at `max_postpone_time_for_failed_replicated_{fetches,merges}_ms` (default 60000). After ~14 retries the backoff exceeds the 10s window, the queue is still non-empty, and the test fails with "Still have something in replication queue" (seen in CI with `num_postponed=156`, 29s backoff).

Fix: set `max_postpone_time_for_failed_replicated_fetches_ms=0` and `max_postpone_time_for_failed_replicated_merges_ms=0` in these tests, mirroring the existing `max_postpone_time_for_failed_mutations_ms=0` in `test_lost_part_mutation`. Entries then retry immediately and the queue drains in time. `test_lost_last_part` is unchanged (it tolerates pending entries, 50s wait).

Reproduced deterministically with the `replicated_queue_fail_next_entry` failpoint: forcing `num_tries>=14` leaves the queue non-empty after 10s without the setting and empty with it. Fixed suite: 12/12 (4 tests x 3 runs).

No related open issue found.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)
