### PR TITLE
Explain rejected skip indexes

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -2107,11 +2107,11 @@ void ReadFromMergeTree::buildIndexes(
         if (condition && !condition->alwaysUnknownOrTrue())
             skip_indexes.useful_indices.emplace_back(index_helper, condition);
         else
-            rejected_indexes.rejected_indices.push_back({
+            rejected_indexes.rejected_indices.emplace_back(
                 index.name,
                 index.type,
                 index.granularity,
-                condition ? condition->rejectionReason() : "no condition could be created from the query predicate"});
+                condition ? condition->rejectionReason() : "no condition could be created from the query predicate");
 
         auto can_skip_index_be_used_for_top_k_filtering = [top_k_filter_info](const MergeTreeIndexPtr & skip_index)
         {
@@ -4161,6 +4161,7 @@ void ReadFromMergeTree::describeIndexes(FormatSettings & format_settings) const
         && !(index_stats.size() == 1 && index_stats.front().type == IndexType::None);
     bool has_rejected_indexes = !result.rejected_skip_indexes.empty();
 
+    /// No indexes to describe at all — nothing to print.
     if (!has_applied_indexes && !has_rejected_indexes)
         return;
 
@@ -4245,6 +4246,7 @@ void ReadFromMergeTree::describeIndexes(JSONBuilder::JSONMap & map) const
         && !(index_stats.size() == 1 && index_stats.front().type == IndexType::None);
     bool has_rejected_indexes = !result.rejected_skip_indexes.empty();
 
+    /// No indexes to describe at all — nothing to print.
     if (!has_applied_indexes && !has_rejected_indexes)
         return;
 

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -2107,7 +2107,11 @@ void ReadFromMergeTree::buildIndexes(
         if (condition && !condition->alwaysUnknownOrTrue())
             skip_indexes.useful_indices.emplace_back(index_helper, condition);
         else
-            rejected_indexes.rejected_indices.push_back({index_helper, condition ? condition->rejectionReason() : "no condition could be created from the query predicate"});
+            rejected_indexes.rejected_indices.push_back({
+                index.name,
+                index.type,
+                index.granularity,
+                condition ? condition->rejectionReason() : "no condition could be created from the query predicate"});
 
         auto can_skip_index_be_used_for_top_k_filtering = [top_k_filter_info](const MergeTreeIndexPtr & skip_index)
         {
@@ -4151,6 +4155,8 @@ void ReadFromMergeTree::describeIndexes(FormatSettings & format_settings) const
 
     const std::string & prefix = format_settings.detail_prefix;
 
+    /// index_stats always contains at least a None entry (the baseline parts/granules count
+    /// before any filtering). A lone None entry means no actual index was applied.
     bool has_applied_indexes = !index_stats.empty()
         && !(index_stats.size() == 1 && index_stats.front().type == IndexType::None);
     bool has_rejected_indexes = !result.rejected_skip_indexes.empty();
@@ -4221,9 +4227,9 @@ void ReadFromMergeTree::describeIndexes(FormatSettings & format_settings) const
     for (const auto & rejected : result.rejected_skip_indexes.rejected_indices)
     {
         format_settings.out << prefix << indent << "Skip" << '\n';
-        format_settings.out << prefix << indent << indent << "Name: " << rejected.index->index.name << '\n';
+        format_settings.out << prefix << indent << indent << "Name: " << rejected.name << '\n';
         format_settings.out << prefix << indent << indent << "Description: "
-            << rejected.index->index.type << " GRANULARITY " << rejected.index->index.granularity << '\n';
+            << rejected.index_type << " GRANULARITY " << rejected.granularity << '\n';
         format_settings.out << prefix << indent << indent << "Status: NOT APPLIED" << '\n';
         format_settings.out << prefix << indent << indent << "Reason: " << rejected.rejection_reason << '\n';
     }
@@ -4234,6 +4240,7 @@ void ReadFromMergeTree::describeIndexes(JSONBuilder::JSONMap & map) const
     const auto & result = getAnalysisResult();
     const auto & index_stats = result.index_stats;
 
+    /// See comment in the text-format overload above.
     bool has_applied_indexes = !index_stats.empty()
         && !(index_stats.size() == 1 && index_stats.front().type == IndexType::None);
     bool has_rejected_indexes = !result.rejected_skip_indexes.empty();
@@ -4312,9 +4319,9 @@ void ReadFromMergeTree::describeIndexes(JSONBuilder::JSONMap & map) const
     {
         auto rejected_map = std::make_unique<JSONBuilder::JSONMap>();
         rejected_map->add("Type", "Skip");
-        rejected_map->add("Name", rejected.index->index.name);
+        rejected_map->add("Name", rejected.name);
         rejected_map->add("Description",
-            rejected.index->index.type + " GRANULARITY " + std::to_string(rejected.index->index.granularity));
+            rejected.index_type + " GRANULARITY " + std::to_string(rejected.granularity));
         rejected_map->add("Status", "NOT APPLIED");
         rejected_map->add("Reason", rejected.rejection_reason);
         indexes_array->add(std::move(rejected_map));

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -2079,6 +2079,7 @@ void ReadFromMergeTree::buildIndexes(
     }
 
     UsefulSkipIndexes skip_indexes;
+    RejectedSkipIndexes rejected_indexes;
 
     for (const auto & index : all_indexes)
     {
@@ -2105,6 +2106,8 @@ void ReadFromMergeTree::buildIndexes(
 
         if (condition && !condition->alwaysUnknownOrTrue())
             skip_indexes.useful_indices.emplace_back(index_helper, condition);
+        else
+            rejected_indexes.rejected_indices.push_back({index_helper, condition ? condition->rejectionReason() : "no condition could be created from the query predicate"});
 
         auto can_skip_index_be_used_for_top_k_filtering = [top_k_filter_info](const MergeTreeIndexPtr & skip_index)
         {
@@ -2212,6 +2215,7 @@ void ReadFromMergeTree::buildIndexes(
     }
 
     indexes->skip_indexes = std::move(skip_indexes);
+    indexes->rejected_skip_indexes = std::move(rejected_indexes);
 }
 
 void ReadFromMergeTree::deferFiltersAfterFinalIfNeeded()
@@ -2852,6 +2856,9 @@ ReadFromMergeTree::AnalysisResultPtr ReadFromMergeTree::selectRangesToRead(
             .num_parts_after = result.parts_with_ranges.size(),
             .num_granules_after = sum_marks});
     }
+
+    if (indexes)
+        result.rejected_skip_indexes = indexes->rejected_skip_indexes;
 
     result.total_parts = total_parts;
     result.parts_before_pk = parts_before_pk;
@@ -4143,15 +4150,19 @@ void ReadFromMergeTree::describeIndexes(FormatSettings & format_settings) const
     const auto & index_stats = result.index_stats;
 
     const std::string & prefix = format_settings.detail_prefix;
-    if (!index_stats.empty())
+
+    bool has_applied_indexes = !index_stats.empty()
+        && !(index_stats.size() == 1 && index_stats.front().type == IndexType::None);
+    bool has_rejected_indexes = !result.rejected_skip_indexes.empty();
+
+    if (!has_applied_indexes && !has_rejected_indexes)
+        return;
+
+    std::string indent(format_settings.base_indent, format_settings.indent_char);
+    format_settings.out << prefix << "Indexes:\n";
+
+    if (has_applied_indexes)
     {
-        /// Do not print anything if no indexes is applied.
-        if (index_stats.size() == 1 && index_stats.front().type == IndexType::None)
-            return;
-
-        std::string indent(format_settings.base_indent, format_settings.indent_char);
-        format_settings.out << prefix << "Indexes:\n";
-
         for (size_t i = 0; i < index_stats.size(); ++i)
         {
             const auto & stat = index_stats[i];
@@ -4206,6 +4217,16 @@ void ReadFromMergeTree::describeIndexes(FormatSettings & format_settings) const
 
         format_settings.out << prefix << indent << "Ranges: " << result.selected_ranges << '\n';
     }
+
+    for (const auto & rejected : result.rejected_skip_indexes.rejected_indices)
+    {
+        format_settings.out << prefix << indent << "Skip" << '\n';
+        format_settings.out << prefix << indent << indent << "Name: " << rejected.index->index.name << '\n';
+        format_settings.out << prefix << indent << indent << "Description: "
+            << rejected.index->index.type << " GRANULARITY " << rejected.index->index.granularity << '\n';
+        format_settings.out << prefix << indent << indent << "Status: NOT APPLIED" << '\n';
+        format_settings.out << prefix << indent << indent << "Reason: " << rejected.rejection_reason << '\n';
+    }
 }
 
 void ReadFromMergeTree::describeIndexes(JSONBuilder::JSONMap & map) const
@@ -4213,14 +4234,17 @@ void ReadFromMergeTree::describeIndexes(JSONBuilder::JSONMap & map) const
     const auto & result = getAnalysisResult();
     const auto & index_stats = result.index_stats;
 
-    if (!index_stats.empty())
+    bool has_applied_indexes = !index_stats.empty()
+        && !(index_stats.size() == 1 && index_stats.front().type == IndexType::None);
+    bool has_rejected_indexes = !result.rejected_skip_indexes.empty();
+
+    if (!has_applied_indexes && !has_rejected_indexes)
+        return;
+
+    auto indexes_array = std::make_unique<JSONBuilder::JSONArray>();
+
+    if (has_applied_indexes)
     {
-        /// Do not print anything if no indexes is applied.
-        if (index_stats.size() == 1 && index_stats.front().type == IndexType::None)
-            return;
-
-        auto indexes_array = std::make_unique<JSONBuilder::JSONArray>();
-
         for (size_t i = 0; i < index_stats.size(); ++i)
         {
             const auto & stat = index_stats[i];
@@ -4282,9 +4306,21 @@ void ReadFromMergeTree::describeIndexes(JSONBuilder::JSONMap & map) const
 
             indexes_array->add(std::move(index_map));
         }
-
-        map.add("Indexes", std::move(indexes_array));
     }
+
+    for (const auto & rejected : result.rejected_skip_indexes.rejected_indices)
+    {
+        auto rejected_map = std::make_unique<JSONBuilder::JSONMap>();
+        rejected_map->add("Type", "Skip");
+        rejected_map->add("Name", rejected.index->index.name);
+        rejected_map->add("Description",
+            rejected.index->index.type + " GRANULARITY " + std::to_string(rejected.index->index.granularity));
+        rejected_map->add("Status", "NOT APPLIED");
+        rejected_map->add("Reason", rejected.rejection_reason);
+        indexes_array->add(std::move(rejected_map));
+    }
+
+    map.add("Indexes", std::move(indexes_array));
 }
 
 void ReadFromMergeTree::describeProjections(FormatSettings & format_settings) const

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -45,6 +45,19 @@ struct UsefulSkipIndexes
     TopKThresholdTrackerPtr threshold_tracker{nullptr};
 };
 
+struct RejectedSkipIndex
+{
+    MergeTreeIndexPtr index;
+    std::string rejection_reason;
+};
+
+struct RejectedSkipIndexes
+{
+    bool empty() const { return rejected_indices.empty(); }
+
+    std::vector<RejectedSkipIndex> rejected_indices;
+};
+
 /// Contains parts each from different projection index
 using ProjectionIndexReadRangesByIndex = std::unordered_map<size_t, RangesInDataParts>;
 
@@ -150,6 +163,7 @@ public:
         SplitPartsByRanges split_parts;
         MergeTreeDataSelectSamplingData sampling;
         IndexStats index_stats;
+        RejectedSkipIndexes rejected_skip_indexes;
         ProjectionStats projection_stats;
         Names column_names_to_read;
         ReadType read_type = ReadType::Default;
@@ -171,6 +185,7 @@ public:
             , split_parts(other.split_parts)
             , sampling(other.sampling)
             , index_stats(other.index_stats)
+            , rejected_skip_indexes(other.rejected_skip_indexes)
             , projection_stats(other.projection_stats)
             , column_names_to_read(other.column_names_to_read)
             , read_type(other.read_type)
@@ -191,6 +206,7 @@ public:
             , split_parts(std::move(other.split_parts))
             , sampling(std::move(other.sampling))
             , index_stats(std::move(other.index_stats))
+            , rejected_skip_indexes(std::move(other.rejected_skip_indexes))
             , projection_stats(std::move(other.projection_stats))
             , column_names_to_read(std::move(other.column_names_to_read))
             , read_type(other.read_type)
@@ -286,6 +302,7 @@ public:
         std::optional<KeyCondition> part_offset_condition;
         std::optional<KeyCondition> total_offset_condition;
         UsefulSkipIndexes skip_indexes;
+        RejectedSkipIndexes rejected_skip_indexes;
         bool use_skip_indexes;
         bool use_skip_indexes_for_disjunctions;
         bool use_skip_indexes_if_final_exact_mode;

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -45,9 +45,11 @@ struct UsefulSkipIndexes
     TopKThresholdTrackerPtr threshold_tracker{nullptr};
 };
 
-struct RejectedSkipIndex
+struct RejectedSkipIndexStat
 {
-    MergeTreeIndexPtr index;
+    std::string name;
+    std::string index_type;
+    size_t granularity;
     std::string rejection_reason;
 };
 
@@ -55,7 +57,7 @@ struct RejectedSkipIndexes
 {
     bool empty() const { return rejected_indices.empty(); }
 
-    std::vector<RejectedSkipIndex> rejected_indices;
+    std::vector<RejectedSkipIndexStat> rejected_indices;
 };
 
 /// Contains parts each from different projection index

--- a/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.cpp
@@ -537,6 +537,22 @@ bool MergeTreeIndexConditionVectorSimilarity::alwaysUnknownOrTrue() const
     return false;
 }
 
+std::string MergeTreeIndexConditionVectorSimilarity::rejectionReason() const
+{
+    if (!parameters)
+        return "query is not a vector search query (requires ORDER BY <distance_function>(column, reference_vector) ASC LIMIT N)";
+
+    if (parameters->column != index_column)
+        return fmt::format("query searches column '{}' but index is built on column '{}'", parameters->column, index_column);
+
+    if ((parameters->distance_function == "L2Distance" && metric_kind != unum::usearch::metric_kind_t::l2sq_k)
+        || (parameters->distance_function == "cosineDistance" && metric_kind != unum::usearch::metric_kind_t::cos_k && metric_kind != unum::usearch::metric_kind_t::hamming_k)
+        || (parameters->distance_function == "dotProduct" && metric_kind != unum::usearch::metric_kind_t::ip_k))
+        return fmt::format("query uses distance function '{}' but index was built for a different metric", parameters->distance_function);
+
+    return "";
+}
+
 NearestNeighbours MergeTreeIndexConditionVectorSimilarity::calculateApproximateNearestNeighbors(MergeTreeIndexGranulePtr granule_) const
 {
     if (!parameters)

--- a/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.h
+++ b/src/Storages/MergeTree/MergeTreeIndexVectorSimilarity.h
@@ -151,6 +151,7 @@ public:
     ~MergeTreeIndexConditionVectorSimilarity() override = default;
 
     bool alwaysUnknownOrTrue() const override;
+    std::string rejectionReason() const override;
     bool mayBeTrueOnGranule(MergeTreeIndexGranulePtr granule, const UpdatePartialDisjunctionResultFn & update_partial_disjunction_result_fn) const override;
     NearestNeighbours calculateApproximateNearestNeighbors(MergeTreeIndexGranulePtr granule) const override;
     std::string getDescription() const override { return ""; }

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -160,6 +160,7 @@ public:
 
     /// Returns a human-readable reason why the index condition is not useful.
     /// Only meaningful when alwaysUnknownOrTrue() returns true.
+    /// Used by EXPLAIN indexes=1 to show why a skip index was not applied.
     virtual std::string rejectionReason() const { return "condition is always unknown or true"; }
 
     using UpdatePartialDisjunctionResultFn = KeyCondition::UpdatePartialDisjunctionResultFn;

--- a/src/Storages/MergeTree/MergeTreeIndices.h
+++ b/src/Storages/MergeTree/MergeTreeIndices.h
@@ -158,6 +158,10 @@ public:
     /// Checks if this index is useful for query.
     virtual bool alwaysUnknownOrTrue() const = 0;
 
+    /// Returns a human-readable reason why the index condition is not useful.
+    /// Only meaningful when alwaysUnknownOrTrue() returns true.
+    virtual std::string rejectionReason() const { return "condition is always unknown or true"; }
+
     using UpdatePartialDisjunctionResultFn = KeyCondition::UpdatePartialDisjunctionResultFn;
     virtual bool mayBeTrueOnGranule(MergeTreeIndexGranulePtr granule, const UpdatePartialDisjunctionResultFn & update_partial_disjunction_result_fn) const = 0;
 

--- a/tests/queries/0_stateless/04324_explain_rejected_skip_indexes.reference
+++ b/tests/queries/0_stateless/04324_explain_rejected_skip_indexes.reference
@@ -1,4 +1,4 @@
-Full EXPLAIN indexes output with rejected indexes
+Both indexes rejected
 Expression ((Project names + Projection))
   Filter ((WHERE + Change column names to column identifiers))
     ReadFromMergeTree (default.tab)
@@ -21,20 +21,29 @@ Expression ((Project names + Projection))
         Description: bloom_filter GRANULARITY 1
         Status: NOT APPLIED
         Reason: condition is always unknown or true
-Both skip indexes rejected when query does not match either
-Name: idx_vec
-Status: NOT APPLIED
-Reason: query is not a vector search query (requires ORDER BY <distance_function>(column, reference_vector) ASC LIMIT N)
-Name: idx_bloom
-Status: NOT APPLIED
-Reason: condition is always unknown or true
-vector_similarity applied, bloom_filter rejected (no predicate)
-Name: idx_vec
-Name: idx_bloom
-Status: NOT APPLIED
-Reason: no condition could be created from the query predicate
-bloom_filter applied, vector_similarity rejected (no ORDER BY LIMIT)
-Name: idx_bloom
-Name: idx_vec
-Status: NOT APPLIED
-Reason: query is not a vector search query (requires ORDER BY <distance_function>(column, reference_vector) ASC LIMIT N)
+Both indexes applied
+Expression (Project names)
+  Expression
+    JoinLazyColumnsStep
+      Limit (preliminary LIMIT)
+        Sorting (Sorting for ORDER BY)
+          Expression
+            Filter
+              ReadFromMergeTree (default.tab)
+              Indexes:
+                PrimaryKey
+                  Condition: true
+                  Parts: 1/1
+                  Granules: 1/1
+                Skip
+                  Name: idx_vec
+                  Description: vector_similarity GRANULARITY 10000
+                  Parts: 1/1
+                  Granules: 1/1
+                Skip
+                  Name: idx_bloom
+                  Description: bloom_filter GRANULARITY 1
+                  Parts: 1/1
+                  Granules: 1/1
+                Ranges: 1
+      LazilyReadFromMergeTree

--- a/tests/queries/0_stateless/04324_explain_rejected_skip_indexes.reference
+++ b/tests/queries/0_stateless/04324_explain_rejected_skip_indexes.reference
@@ -1,3 +1,22 @@
+Full EXPLAIN indexes output with rejected indexes
+Indexes:
+PrimaryKey
+Keys:
+Condition: (id in [1, +Inf))
+Parts: 1/1
+Granules: 1/1
+Search Algorithm: binary search
+Ranges: 1
+Skip
+Name: idx_vec
+Description: vector_similarity GRANULARITY 10000
+Status: NOT APPLIED
+Reason: query is not a vector search query (requires ORDER BY <distance_function>(column, reference_vector) ASC LIMIT N)
+Skip
+Name: idx_bloom
+Description: bloom_filter GRANULARITY 1
+Status: NOT APPLIED
+Reason: condition is always unknown or true
 Both skip indexes rejected when query does not match either
 Name: idx_vec
 Status: NOT APPLIED

--- a/tests/queries/0_stateless/04324_explain_rejected_skip_indexes.reference
+++ b/tests/queries/0_stateless/04324_explain_rejected_skip_indexes.reference
@@ -1,22 +1,26 @@
 Full EXPLAIN indexes output with rejected indexes
-Indexes:
-PrimaryKey
-Keys:
-Condition: (id in [1, +Inf))
-Parts: 1/1
-Granules: 1/1
-Search Algorithm: binary search
-Ranges: 1
-Skip
-Name: idx_vec
-Description: vector_similarity GRANULARITY 10000
-Status: NOT APPLIED
-Reason: query is not a vector search query (requires ORDER BY <distance_function>(column, reference_vector) ASC LIMIT N)
-Skip
-Name: idx_bloom
-Description: bloom_filter GRANULARITY 1
-Status: NOT APPLIED
-Reason: condition is always unknown or true
+Expression ((Project names + Projection))
+  Filter ((WHERE + Change column names to column identifiers))
+    ReadFromMergeTree (default.tab)
+    Indexes:
+      PrimaryKey
+        Keys:
+          id
+        Condition: (id in [1, +Inf))
+        Parts: 1/1
+        Granules: 1/1
+        Search Algorithm: binary search
+      Ranges: 1
+      Skip
+        Name: idx_vec
+        Description: vector_similarity GRANULARITY 10000
+        Status: NOT APPLIED
+        Reason: query is not a vector search query (requires ORDER BY <distance_function>(column, reference_vector) ASC LIMIT N)
+      Skip
+        Name: idx_bloom
+        Description: bloom_filter GRANULARITY 1
+        Status: NOT APPLIED
+        Reason: condition is always unknown or true
 Both skip indexes rejected when query does not match either
 Name: idx_vec
 Status: NOT APPLIED

--- a/tests/queries/0_stateless/04324_explain_rejected_skip_indexes.reference
+++ b/tests/queries/0_stateless/04324_explain_rejected_skip_indexes.reference
@@ -1,0 +1,17 @@
+Both skip indexes rejected when query does not match either
+Name: idx_vec
+Status: NOT APPLIED
+Reason: query is not a vector search query (requires ORDER BY <distance_function>(column, reference_vector) ASC LIMIT N)
+Name: idx_bloom
+Status: NOT APPLIED
+Reason: condition is always unknown or true
+vector_similarity applied, bloom_filter rejected (no predicate)
+Name: idx_vec
+Name: idx_bloom
+Status: NOT APPLIED
+Reason: no condition could be created from the query predicate
+bloom_filter applied, vector_similarity rejected (no ORDER BY LIMIT)
+Name: idx_bloom
+Name: idx_vec
+Status: NOT APPLIED
+Reason: query is not a vector search query (requires ORDER BY <distance_function>(column, reference_vector) ASC LIMIT N)

--- a/tests/queries/0_stateless/04324_explain_rejected_skip_indexes.sql
+++ b/tests/queries/0_stateless/04324_explain_rejected_skip_indexes.sql
@@ -21,29 +21,13 @@ SETTINGS index_granularity = 3;
 
 INSERT INTO tab VALUES (1, [1.0, 0.0], 'a'), (2, [1.1, 0.0], 'b'), (3, [1.2, 0.0], 'c');
 
-SELECT 'Full EXPLAIN indexes output with rejected indexes';
+SELECT 'Both indexes rejected';
 EXPLAIN indexes = 1
     SELECT id FROM tab WHERE id > 0;
 
-SELECT 'Both skip indexes rejected when query does not match either';
-SELECT trimLeft(explain) FROM (
-    EXPLAIN indexes = 1
-    SELECT id FROM tab WHERE id > 0
-)
-WHERE explain LIKE '%Name:%' OR explain LIKE '%Status:%' OR explain LIKE '%Reason:%';
-
-SELECT 'vector_similarity applied, bloom_filter rejected (no predicate)';
-SELECT trimLeft(explain) FROM (
-    EXPLAIN indexes = 1
-    SELECT id FROM tab ORDER BY L2Distance(vec, [0.0, 0.0]) LIMIT 3
-)
-WHERE explain LIKE '%Name:%' OR explain LIKE '%Status:%' OR explain LIKE '%Reason:%';
-
-SELECT 'bloom_filter applied, vector_similarity rejected (no ORDER BY LIMIT)';
-SELECT trimLeft(explain) FROM (
-    EXPLAIN indexes = 1
-    SELECT id FROM tab WHERE attr1 = 'a'
-)
-WHERE explain LIKE '%Name:%' OR explain LIKE '%Status:%' OR explain LIKE '%Reason:%';
+SELECT 'Both indexes applied';
+EXPLAIN indexes = 1
+    SELECT id FROM tab WHERE attr1 = 'a' ORDER BY L2Distance(vec, [0.0, 0.0]) LIMIT 3
+    SETTINGS vector_search_filter_strategy = 'postfilter';
 
 DROP TABLE tab;

--- a/tests/queries/0_stateless/04324_explain_rejected_skip_indexes.sql
+++ b/tests/queries/0_stateless/04324_explain_rejected_skip_indexes.sql
@@ -1,0 +1,45 @@
+-- Tags: no-fasttest, no-ordinary-database
+
+-- Tests that EXPLAIN indexes=1 shows rejected (not applied) skip indexes with reasons.
+
+SET enable_analyzer = 1;
+SET parallel_replicas_local_plan = 1;
+
+DROP TABLE IF EXISTS tab;
+
+CREATE TABLE tab
+(
+    id Int32,
+    vec Array(Float32),
+    attr1 String,
+    INDEX idx_vec vec TYPE vector_similarity('hnsw', 'L2Distance', 2) GRANULARITY 10000,
+    INDEX idx_bloom attr1 TYPE bloom_filter() GRANULARITY 1
+)
+ENGINE = MergeTree
+ORDER BY id
+SETTINGS index_granularity = 3;
+
+INSERT INTO tab VALUES (1, [1.0, 0.0], 'a'), (2, [1.1, 0.0], 'b'), (3, [1.2, 0.0], 'c');
+
+SELECT 'Both skip indexes rejected when query does not match either';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN indexes = 1
+    SELECT id FROM tab WHERE id > 0
+)
+WHERE explain LIKE '%Name:%' OR explain LIKE '%Status:%' OR explain LIKE '%Reason:%';
+
+SELECT 'vector_similarity applied, bloom_filter rejected (no predicate)';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN indexes = 1
+    SELECT id FROM tab ORDER BY L2Distance(vec, [0.0, 0.0]) LIMIT 3
+)
+WHERE explain LIKE '%Name:%' OR explain LIKE '%Status:%' OR explain LIKE '%Reason:%';
+
+SELECT 'bloom_filter applied, vector_similarity rejected (no ORDER BY LIMIT)';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN indexes = 1
+    SELECT id FROM tab WHERE attr1 = 'a'
+)
+WHERE explain LIKE '%Name:%' OR explain LIKE '%Status:%' OR explain LIKE '%Reason:%';
+
+DROP TABLE tab;

--- a/tests/queries/0_stateless/04324_explain_rejected_skip_indexes.sql
+++ b/tests/queries/0_stateless/04324_explain_rejected_skip_indexes.sql
@@ -21,6 +21,17 @@ SETTINGS index_granularity = 3;
 
 INSERT INTO tab VALUES (1, [1.0, 0.0], 'a'), (2, [1.1, 0.0], 'b'), (3, [1.2, 0.0], 'c');
 
+SELECT 'Full EXPLAIN indexes output with rejected indexes';
+SELECT trimLeft(explain) FROM (
+    EXPLAIN indexes = 1
+    SELECT id FROM tab WHERE id > 0
+)
+WHERE explain LIKE '%Indexes%' OR explain LIKE '%PrimaryKey%' OR explain LIKE '%Keys%'
+    OR explain LIKE '%Condition%' OR explain LIKE '%Parts%' OR explain LIKE '%Granules%'
+    OR explain LIKE '%Search Algorithm%' OR explain LIKE '%Ranges%'
+    OR explain LIKE '%Skip%' OR explain LIKE '%Name:%' OR explain LIKE '%Description%'
+    OR explain LIKE '%Status%' OR explain LIKE '%Reason%';
+
 SELECT 'Both skip indexes rejected when query does not match either';
 SELECT trimLeft(explain) FROM (
     EXPLAIN indexes = 1

--- a/tests/queries/0_stateless/04324_explain_rejected_skip_indexes.sql
+++ b/tests/queries/0_stateless/04324_explain_rejected_skip_indexes.sql
@@ -22,15 +22,8 @@ SETTINGS index_granularity = 3;
 INSERT INTO tab VALUES (1, [1.0, 0.0], 'a'), (2, [1.1, 0.0], 'b'), (3, [1.2, 0.0], 'c');
 
 SELECT 'Full EXPLAIN indexes output with rejected indexes';
-SELECT trimLeft(explain) FROM (
-    EXPLAIN indexes = 1
-    SELECT id FROM tab WHERE id > 0
-)
-WHERE explain LIKE '%Indexes%' OR explain LIKE '%PrimaryKey%' OR explain LIKE '%Keys%'
-    OR explain LIKE '%Condition%' OR explain LIKE '%Parts%' OR explain LIKE '%Granules%'
-    OR explain LIKE '%Search Algorithm%' OR explain LIKE '%Ranges%'
-    OR explain LIKE '%Skip%' OR explain LIKE '%Name:%' OR explain LIKE '%Description%'
-    OR explain LIKE '%Status%' OR explain LIKE '%Reason%';
+EXPLAIN indexes = 1
+    SELECT id FROM tab WHERE id > 0;
 
 SELECT 'Both skip indexes rejected when query does not match either';
 SELECT trimLeft(explain) FROM (


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->

Add Rejected Indices in the ReadFromMergeTree analysis output. This is used to keep track of which indices where skipped due to the `alwaysUnknownOrTrue` condition being true. If true the index can't be applied.

For Vector indexes this actually checks whether the query contains the correct format & the correct distance function, meaning we can expand on the condition & add meaningful output to Explain

As stated on  https://github.com/ClickHouse/ClickHouse/issues/105516 there are a few points worth discussing:

- Should this be behind a toggle (e.g. EXPLAIN rejected_indices = 1) or a setting?
- Should we add more of a rejection reason for the indices using rpnEvaluatesAlwaysUnknownOrTrue? Right now I use a default value for it.

It is also very possible we need to customise the rejectionReason for more indices, I would be grateful for input there.

Closes: https://github.com/ClickHouse/ClickHouse/issues/105516

### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Add rejected indices in Explain output: If an index would be potentially applicable but is skipped due to query layout (e.g. filtering on the wrong condition) the reason for rejection will now be included.
