### PR TITLE
Fix Variant statistics merge using local instead of global discriminator

### DIFF
--- a/src/Columns/ColumnVariant.cpp
+++ b/src/Columns/ColumnVariant.cpp
@@ -1984,13 +1984,15 @@ bool ColumnVariant::hasStatistics() const
 
 void ColumnVariant::takeOrCalculateStatisticsFrom(const VectorWithMemoryTracking<ColumnPtr> & source_columns)
 {
+    /// Iterate by global discriminator: source columns are addressed by global discriminator,
+    /// so the destination variant must be too (local order may differ from global order).
     for (size_t i = 0; i != variants.size(); ++i)
     {
         VectorWithMemoryTracking<ColumnPtr> variant_source_columns;
         variant_source_columns.reserve(source_columns.size());
         for (const auto & source_column : source_columns)
             variant_source_columns.push_back(assert_cast<const ColumnVariant &>(*source_column).getVariantPtrByGlobalDiscriminator(i));
-        variants[i]->takeOrCalculateStatisticsFrom(variant_source_columns);
+        getVariantByGlobalDiscriminator(i).takeOrCalculateStatisticsFrom(variant_source_columns);
     }
 }
 

--- a/tests/queries/0_stateless/04327_variant_map_statistics_merge_discriminator.sql
+++ b/tests/queries/0_stateless/04327_variant_map_statistics_merge_discriminator.sql
@@ -1,0 +1,17 @@
+-- A Variant column whose local variant order differs from its global order, with one
+-- variant being Map, would feed a non-Map source column into ColumnMap statistics during
+-- a sorted merge and abort with "Source column is not Map". The query must not crash.
+SELECT * FROM
+(
+    SELECT n, m FROM
+    (
+        (SELECT 2 AS n, map('z', 'a') AS m FROM numbers(2))
+        EXCEPT ALL
+        (SELECT map(toFixedString('z', 1), 'a') AS m, 2 AS n FROM numbers(2))
+    )
+    UNION ALL
+    SELECT toLowCardinality(1) AS n, map('-1', 'b') AS m FROM numbers(2)
+)
+ORDER BY n
+SETTINGS allow_suspicious_types_in_order_by = 1
+FORMAT Null;

--- a/tests/queries/0_stateless/04327_variant_map_statistics_merge_discriminator.sql
+++ b/tests/queries/0_stateless/04327_variant_map_statistics_merge_discriminator.sql
@@ -1,3 +1,7 @@
+-- The crash path only exists in the new analyzer; the old analyzer rejects this query
+-- earlier with NO_COMMON_TYPE, so it cannot exercise the regression.
+SET enable_analyzer = 1;
+
 -- A Variant column whose local variant order differs from its global order, with one
 -- variant being Map, would feed a non-Map source column into ColumnMap statistics during
 -- a sorted merge and abort with "Source column is not Map". The query must not crash.


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/102390
Related: https://github.com/ClickHouse/ClickHouse/pull/102406
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a crash (`Source column is not Map` / `SIGSEGV`) when merging sorted blocks that contain a `Variant` column with a `Map` variant whose local storage order differs from its global order.


### Description

`ColumnVariant::takeOrCalculateStatisticsFrom` addressed the source columns by global discriminator (`getVariantPtrByGlobalDiscriminator(i)`) but addressed the destination variant by local discriminator (`variants[i]`). When a `Variant` column's local storage order differs from its global order and one of the variants is a `Map`, the `Map` destination variant was handed a non-`Map` source column, aborting in `ColumnMap::takeOrCalculateStatisticsFrom` with `Source column is not Map, but X` (`X` seen as `LowCardinality(UInt8)`, `UInt32`, `UInt64`).

The `Map` statistics path comes from #99200. The assertion was added by #102406 to turn the original `SIGSEGV` reported in #102390 into a diagnosable `LOGICAL_ERROR`; the discriminator mismatch itself was never fixed. The AST fuzzer reached it on a query that builds `Variant(LowCardinality(UInt8), Map(FixedString(1), String), UInt8)` together with a sibling `Map` column followed by `ORDER BY`, which triggers a sorted merge and the per-variant statistics merge.

The fix addresses the destination by global discriminator as well, matching the sibling functions (`prepareForSquashing`, `chooseDynamicStructureForMerge`, `takeExactDynamicStructureFrom`) which already use `getVariantByGlobalDiscriminator` on both sides. Added a stateless regression test.

Closes https://github.com/ClickHouse/ClickHouse/issues/107024

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.706`
- Backported to: `26.5.4.7`, `26.4.5.53`
<!-- ch-version-info:end -->