### PR TITLE
Enable independent per-partition DISTINCT when partition key matches DISTINCT columns

### DIFF
--- a/src/Client/BuzzHouse/Generator/SessionSettings.cpp
+++ b/src/Client/BuzzHouse/Generator/SessionSettings.cpp
@@ -271,6 +271,7 @@ std::unordered_map<String, CHSetting> performanceSettings
        {"allow_experimental_join_right_table_sorting", trueOrFalseSetting},
        {"allow_experimental_text_index_lazy_apply", trueOrFalseSetting},
        {"allow_limit_by_partitions_independently", trueOrFalseSetting},
+       {"allow_distinct_partitions_independently", trueOrFalseSetting},
        {"allow_push_predicate_ast_for_distributed_subqueries", trueOrFalseSetting},
        {"allow_push_predicate_when_subquery_contains_with", trueOrFalseSetting},
        {"allow_reorder_prewhere_conditions", trueOrFalseSetting},

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -5780,6 +5780,9 @@ Force the use of optimization when it is applicable, but heuristics decided not 
     DECLARE(Bool, allow_limit_by_partitions_independently, true, R"(
 Enable independent `LIMIT BY` evaluation per partition on separate threads when the partition expression is a deterministic function of the `LIMIT BY` columns.
 )", 0) \
+    DECLARE(Bool, allow_distinct_partitions_independently, true, R"(
+Enable independent `DISTINCT` evaluation per partition on separate threads when the partition expression is a deterministic function of the `DISTINCT` columns.
+)", 0) \
     DECLARE(UInt64, max_number_of_partitions_for_independent_aggregation, 128, R"(
 Maximal number of partitions in table to apply optimization
 )", 0) \

--- a/src/Core/SettingsChangesHistory.cpp
+++ b/src/Core/SettingsChangesHistory.cpp
@@ -53,6 +53,7 @@ const VersionToSettingsChangesMap & getSettingsChangesHistory()
             {"output_format_float_precision", 0, 0, "A new setting to control decimal digits in float output"},
             {"file_like_engine_default_partition_strategy", "wildcard", "hive", "Change the default partition strategy for file-like table engines (S3, AzureBlobStorage, etc.) from `wildcard` to `hive` when no `partition_strategy` is provided."},
             {"allow_limit_by_partitions_independently", false, true, "New setting to enable independent per-partition evaluation of `LIMIT BY` when the partition expression is a deterministic function of the `LIMIT BY` columns."},
+            {"allow_distinct_partitions_independently", false, true, "New setting to enable independent per-partition evaluation of `DISTINCT` when the partition expression is a deterministic function of the `DISTINCT` columns."},
             {"optimize_rewrite_has_to_in", false, true, "New setting"},
             {"unique_key_max_encoded_size", 256, 256, "New setting: maximum size (bytes) of the order-preserving binary encoding of a single UNIQUE KEY row"},
             {"query_plan_push_limit_by_into_sort", false, true, "New setting that pushes a per-stream LIMIT BY into the sort pipeline when LIMIT BY's columns are a prefix of ORDER BY, reducing rows flowing through the final merge."},

--- a/src/Processors/QueryPlan/DistinctStep.cpp
+++ b/src/Processors/QueryPlan/DistinctStep.cpp
@@ -72,7 +72,7 @@ void DistinctStep::updateLimitHint(UInt64 hint)
 
 void DistinctStep::transformPipeline(QueryPipelineBuilder & pipeline, const BuildQueryPipelineSettings &)
 {
-    if (!pre_distinct)
+    if (!pre_distinct && !skip_stream_merging)
         pipeline.resize(1);
 
     {
@@ -164,6 +164,9 @@ void DistinctStep::describeActions(FormatSettings & settings) const
     }
 
     settings.out << '\n';
+
+    if (skip_stream_merging)
+        settings.out << prefix << "Skip stream merging: 1\n";
 }
 
 void DistinctStep::describeActions(JSONBuilder::JSONMap & map) const
@@ -173,6 +176,8 @@ void DistinctStep::describeActions(JSONBuilder::JSONMap & map) const
         columns_array->add(column);
 
     map.add("Columns", std::move(columns_array));
+    if (skip_stream_merging)
+        map.add("Skip stream merging", true);
 }
 
 void DistinctStep::updateOutputHeader()

--- a/src/Processors/QueryPlan/DistinctStep.h
+++ b/src/Processors/QueryPlan/DistinctStep.h
@@ -45,6 +45,11 @@ public:
     void applyOrder(SortDescription sort_desc) { distinct_sort_desc = std::move(sort_desc); }
     const SortDescription & getSortDescription() const override { return distinct_sort_desc; }
 
+    /// Skip the resize-to-one-stream and run one `DistinctTransform` per input stream.
+    /// Set by `optimizeDistinctPerPartition`; assumes upstream streams carry disjoint
+    /// partition sets so no `DISTINCT` key spans two streams.
+    void skipStreamMerging() { skip_stream_merging = true; }
+
 private:
     void updateOutputHeader() override;
 
@@ -53,6 +58,7 @@ private:
     const Names columns;
     bool pre_distinct;
     SortDescription distinct_sort_desc;
+    bool skip_stream_merging = false;
 };
 
 }

--- a/src/Processors/QueryPlan/Optimizations/Optimizations.h
+++ b/src/Processors/QueryPlan/Optimizations/Optimizations.h
@@ -208,6 +208,7 @@ void optimizeDistinctInOrder(QueryPlan::Node & node, QueryPlan::Nodes &, const Q
 void pushLimitByIntoSort(QueryPlan::Node & node);
 void optimizeAggregationPerPartition(QueryPlan::Node & node, QueryPlan::Nodes &, const QueryPlanOptimizationSettings &);
 void optimizeLimitByPerPartition(QueryPlan::Node & node, QueryPlan::Nodes &, const QueryPlanOptimizationSettings &);
+void optimizeDistinctPerPartition(QueryPlan::Node & node, QueryPlan::Nodes &, const QueryPlanOptimizationSettings &);
 void updateQueryConditionCache(const Stack & stack, const QueryPlanOptimizationSettings & optimization_settings);
 bool optimizeVectorSearchSecondPass(QueryPlan::Node & root, Stack & stack, QueryPlan::Nodes & nodes, const Optimization::ExtraSettings &);
 void materializeQueryPlanReferences(QueryPlan::Node & node, QueryPlan::Nodes & nodes);

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.cpp
@@ -16,6 +16,7 @@ namespace DB
 namespace Setting
 {
     extern const SettingsBool allow_aggregate_partitions_independently;
+    extern const SettingsBool allow_distinct_partitions_independently;
     extern const SettingsBool allow_limit_by_partitions_independently;
     extern const SettingsBool allow_experimental_analyzer;
     extern const SettingsBool collect_hash_table_stats_during_joins;
@@ -187,6 +188,7 @@ QueryPlanOptimizationSettings::QueryPlanOptimizationSettings(
     read_in_order = from[Setting::query_plan_enable_optimizations] && from[Setting::optimize_read_in_order] && from[Setting::query_plan_read_in_order];
     distinct_in_order = from[Setting::query_plan_enable_optimizations] && from[Setting::optimize_distinct_in_order];
     limit_by_partitions_independently = from[Setting::query_plan_enable_optimizations] && from[Setting::allow_limit_by_partitions_independently];
+    distinct_partitions_independently = from[Setting::query_plan_enable_optimizations] && from[Setting::allow_distinct_partitions_independently];
     optimize_sorting_by_input_stream_properties = from[Setting::query_plan_enable_optimizations] && from[Setting::optimize_sorting_by_input_stream_properties];
     aggregation_in_order = from[Setting::query_plan_enable_optimizations] && from[Setting::optimize_aggregation_in_order] && from[Setting::query_plan_aggregation_in_order];
     optimize_projection = from[Setting::optimize_use_projections];

--- a/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
+++ b/src/Processors/QueryPlan/Optimizations/QueryPlanOptimizationSettings.h
@@ -57,6 +57,7 @@ struct QueryPlanOptimizationSettings
     bool lift_up_union;
     bool aggregate_partitions_independently;
     bool limit_by_partitions_independently;
+    bool distinct_partitions_independently;
     bool remove_redundant_distinct;
     bool try_use_vector_search;
     bool convert_join_to_in;

--- a/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeTree.cpp
@@ -392,6 +392,9 @@ void optimizeTreeSecondPass(
             if (optimization_settings.limit_by_partitions_independently)
                 optimizeLimitByPerPartition(frame_node, nodes, optimization_settings);
 
+            if (optimization_settings.distinct_partitions_independently)
+                optimizeDistinctPerPartition(frame_node, nodes, optimization_settings);
+
             if (optimization_settings.read_in_order)
                 optimizeReadInOrder(frame_node, nodes, optimization_settings);
 

--- a/src/Processors/QueryPlan/Optimizations/useDataParallelAggregation.cpp
+++ b/src/Processors/QueryPlan/Optimizations/useDataParallelAggregation.cpp
@@ -6,6 +6,7 @@
 #include <Processors/QueryPlan/AggregatingStep.h>
 #include <Processors/QueryPlan/ExpressionStep.h>
 #include <Processors/QueryPlan/FilterStep.h>
+#include <Processors/QueryPlan/DistinctStep.h>
 #include <Processors/QueryPlan/LimitByStep.h>
 #include <Processors/QueryPlan/Optimizations/actionsDAGUtils.h>
 #include <Processors/QueryPlan/ReadFromMergeTree.h>
@@ -28,6 +29,9 @@ ReadFromMergeTree * findReadingStep(QueryPlan::Node & node)
     if (typeid_cast<ExpressionStep *>(step) || typeid_cast<FilterStep *>(step))
         return findReadingStep(*node.children.front());
 
+    if (const auto * distinct = typeid_cast<DistinctStep *>(step); distinct && distinct->isPreliminary())
+        return findReadingStep(*node.children.front());
+
     return nullptr;
 }
 
@@ -45,6 +49,13 @@ void buildKeyDAG(const QueryPlan::Node & node, std::optional<ActionsDAG> & dag)
         return;
 
     auto * step = node.step.get();
+
+    if (const auto * distinct = typeid_cast<const DistinctStep *>(step); distinct && distinct->isPreliminary())
+    {
+        buildKeyDAG(*node.children.front(), dag);
+        return;
+    }
+
     const ActionsDAG * step_dag = nullptr;
     if (const auto * expression = typeid_cast<const ExpressionStep *>(step))
         step_dag = &expression->getExpression();
@@ -161,6 +172,32 @@ void optimizeLimitByPerPartition(QueryPlan::Node & node, QueryPlan::Nodes &, con
     {
         if (reading->requestOutputEachPartitionThroughSeparatePortForLimitBy())
             limit_by_step->skipStreamMerging();
+    }
+}
+
+void optimizeDistinctPerPartition(QueryPlan::Node & node, QueryPlan::Nodes &, const QueryPlanOptimizationSettings & /*optimization_settings*/)
+{
+    if (node.children.size() != 1)
+        return;
+
+    auto * distinct_step = typeid_cast<DistinctStep *>(node.step.get());
+    if (!distinct_step || distinct_step->isPreliminary())
+        return;
+
+    auto * reading = findReadingStep(*node.children.front());
+    if (!reading)
+        return;
+
+    std::optional<ActionsDAG> dag;
+    buildKeyDAG(*node.children.front(), dag);
+    if (!dag)
+        return;
+
+    if (!reading->willOutputEachPartitionThroughSeparatePort()
+        && isPartitionKeyFunctionOfKeys(*reading, *dag, distinct_step->getColumnNames()))
+    {
+        if (reading->requestOutputEachPartitionThroughSeparatePortForDistinct())
+            distinct_step->skipStreamMerging();
     }
 }
 }

--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -3096,6 +3096,11 @@ bool ReadFromMergeTree::requestOutputEachPartitionThroughSeparatePortForLimitBy(
     return output_each_partition_through_separate_port = true;
 }
 
+bool ReadFromMergeTree::requestOutputEachPartitionThroughSeparatePortForDistinct()
+{
+    return requestOutputEachPartitionThroughSeparatePortForLimitBy();
+}
+
 ReadFromMergeTree::AnalysisResult & ReadFromMergeTree::getAnalysisResultImpl() const
 {
     if (!analyzed_result_ptr)

--- a/src/Processors/QueryPlan/ReadFromMergeTree.h
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.h
@@ -339,6 +339,7 @@ public:
     /// Returns true if the optimization is applicable (and applies it then).
     bool requestOutputEachPartitionThroughSeparatePortForAggregation();
     bool requestOutputEachPartitionThroughSeparatePortForLimitBy();
+    bool requestOutputEachPartitionThroughSeparatePortForDistinct();
 
     bool willOutputEachPartitionThroughSeparatePort() const { return output_each_partition_through_separate_port; }
 

--- a/tests/queries/0_stateless/04327_distinct_partitions_independently.reference
+++ b/tests/queries/0_stateless/04327_distinct_partitions_independently.reference
@@ -1,0 +1,101 @@
+-- { echo }
+
+DROP TABLE IF EXISTS test_partition_eq_key;
+CREATE TABLE test_partition_eq_key (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY tuple() PARTITION BY a % 8;
+SYSTEM STOP MERGES test_partition_eq_key;
+INSERT INTO test_partition_eq_key SELECT number, number FROM numbers_mt(1e3);
+INSERT INTO test_partition_eq_key SELECT number, number FROM numbers_mt(1e3);
+EXPLAIN PIPELINE SELECT DISTINCT a FROM test_partition_eq_key SETTINGS allow_distinct_partitions_independently = 1;
+(Expression)
+ExpressionTransform × 8
+  (Distinct)
+  DistinctTransform × 8
+    (Distinct)
+    DistinctTransform × 8
+      (Expression)
+      ExpressionTransform × 8
+        (ReadFromMergeTree)
+        Resize 2 → 1
+          MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 2 0 → 1
+            Resize 2 → 1
+              MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 2 0 → 1
+                Resize 2 → 1
+                  MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 2 0 → 1
+                    Resize 2 → 1
+                      MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 2 0 → 1
+                        Resize 2 → 1
+                          MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 2 0 → 1
+                            Resize 2 → 1
+                              MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 2 0 → 1
+                                Resize 2 → 1
+                                  MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 2 0 → 1
+                                    Resize 2 → 1
+                                      MergeTreeSelect(pool: ReadPool, algorithm: Thread) × 2 0 → 1
+SELECT replaceRegexpOne(explain, '^[ ]*(.*)', '\\1') FROM (EXPLAIN actions = 1 SELECT DISTINCT a FROM test_partition_eq_key SETTINGS allow_distinct_partitions_independently = 1) WHERE explain LIKE '%Skip stream merging%' OR explain LIKE '%Read each partition through separate port%';
+Skip stream merging: 1
+Read each partition through separate port: 1
+SELECT (SELECT count() FROM (SELECT DISTINCT a FROM test_partition_eq_key SETTINGS allow_distinct_partitions_independently = 0)) = (SELECT count() FROM (SELECT DISTINCT a FROM test_partition_eq_key SETTINGS allow_distinct_partitions_independently = 1));
+1
+DROP TABLE test_partition_eq_key;
+DROP TABLE IF EXISTS test_partition_func_of_key;
+CREATE TABLE test_partition_func_of_key (d Date, x UInt32) ENGINE = MergeTree ORDER BY d PARTITION BY toYYYYMM(d);
+SYSTEM STOP MERGES test_partition_func_of_key;
+INSERT INTO test_partition_func_of_key SELECT toDate('2024-01-01') + (number % 240), number FROM numbers_mt(1e3);
+INSERT INTO test_partition_func_of_key SELECT toDate('2024-01-01') + (number % 240), number + 1 FROM numbers_mt(1e3);
+SELECT replaceRegexpOne(explain, '^[ ]*(.*)', '\\1') FROM (EXPLAIN actions = 1 SELECT DISTINCT d FROM test_partition_func_of_key SETTINGS allow_distinct_partitions_independently = 1) WHERE explain LIKE '%Skip stream merging%' OR explain LIKE '%Read each partition through separate port%';
+Skip stream merging: 1
+Read each partition through separate port: 1
+SELECT (SELECT count() FROM (SELECT DISTINCT d FROM test_partition_func_of_key SETTINGS allow_distinct_partitions_independently = 0)) = (SELECT count() FROM (SELECT DISTINCT d FROM test_partition_func_of_key SETTINGS allow_distinct_partitions_independently = 1));
+1
+DROP TABLE test_partition_func_of_key;
+DROP TABLE IF EXISTS test_complex_expr_both_sides;
+CREATE TABLE test_complex_expr_both_sides (a UInt32) ENGINE = MergeTree ORDER BY a PARTITION BY intDiv(a, 2) * 2 + 1;
+INSERT INTO test_complex_expr_both_sides SELECT number FROM numbers_mt(100);
+SELECT replaceRegexpOne(explain, '^[ ]*(.*)', '\\1') FROM (EXPLAIN actions = 1 SELECT DISTINCT intDiv(a, 2) + 1 AS a1 FROM test_complex_expr_both_sides SETTINGS allow_distinct_partitions_independently = 1) WHERE explain LIKE '%Skip stream merging%' OR explain LIKE '%Read each partition through separate port%';
+Skip stream merging: 1
+Read each partition through separate port: 1
+SELECT (SELECT count() FROM (SELECT DISTINCT intDiv(a, 2) + 1 AS a1 FROM test_complex_expr_both_sides SETTINGS allow_distinct_partitions_independently = 0)) = (SELECT count() FROM (SELECT DISTINCT intDiv(a, 2) + 1 AS a1 FROM test_complex_expr_both_sides SETTINGS allow_distinct_partitions_independently = 1));
+1
+DROP TABLE test_complex_expr_both_sides;
+DROP TABLE IF EXISTS test_with_where_filter;
+CREATE TABLE test_with_where_filter (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY b PARTITION BY a % 8;
+SYSTEM STOP MERGES test_with_where_filter;
+INSERT INTO test_with_where_filter SELECT number, number FROM numbers_mt(1e3);
+INSERT INTO test_with_where_filter SELECT number, number + 1 FROM numbers_mt(1e3);
+SELECT replaceRegexpOne(explain, '^[ ]*(.*)', '\\1') FROM (EXPLAIN actions = 1 SELECT DISTINCT a FROM test_with_where_filter WHERE b > 0 SETTINGS allow_distinct_partitions_independently = 1) WHERE explain LIKE '%Skip stream merging%' OR explain LIKE '%Read each partition through separate port%';
+Skip stream merging: 1
+Read each partition through separate port: 1
+SELECT (SELECT count() FROM (SELECT DISTINCT a FROM test_with_where_filter WHERE b > 0 SETTINGS allow_distinct_partitions_independently = 0)) = (SELECT count() FROM (SELECT DISTINCT a FROM test_with_where_filter WHERE b > 0 SETTINGS allow_distinct_partitions_independently = 1));
+1
+DROP TABLE test_with_where_filter;
+DROP TABLE IF EXISTS test_with_filter_step;
+CREATE TABLE test_with_filter_step (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY b PARTITION BY a % 8;
+SYSTEM STOP MERGES test_with_filter_step;
+INSERT INTO test_with_filter_step SELECT number, number FROM numbers_mt(1e3);
+INSERT INTO test_with_filter_step SELECT number, number + 1 FROM numbers_mt(1e3);
+SELECT replaceRegexpOne(explain, '^[ ]*(.*)', '\\1') FROM (EXPLAIN actions = 1 SELECT DISTINCT a FROM test_with_filter_step WHERE b > 0 SETTINGS allow_distinct_partitions_independently = 1, optimize_move_to_prewhere = 0) WHERE explain LIKE '%Skip stream merging%' OR explain LIKE '%Read each partition through separate port%';
+Skip stream merging: 1
+Read each partition through separate port: 1
+SELECT (SELECT count() FROM (SELECT DISTINCT a FROM test_with_filter_step WHERE b > 0 SETTINGS allow_distinct_partitions_independently = 0, optimize_move_to_prewhere = 0)) = (SELECT count() FROM (SELECT DISTINCT a FROM test_with_filter_step WHERE b > 0 SETTINGS allow_distinct_partitions_independently = 1, optimize_move_to_prewhere = 0));
+1
+DROP TABLE test_with_filter_step;
+DROP TABLE IF EXISTS test_key_noninjective_of_partition;
+CREATE TABLE test_key_noninjective_of_partition (a UInt32) ENGINE = MergeTree ORDER BY tuple() PARTITION BY a;
+INSERT INTO test_key_noninjective_of_partition SELECT number % 8 FROM numbers_mt(1e3);
+SELECT replaceRegexpOne(explain, '^[ ]*(.*)', '\\1') FROM (EXPLAIN actions = 1 SELECT DISTINCT (a % 4) FROM test_key_noninjective_of_partition SETTINGS allow_distinct_partitions_independently = 1) WHERE explain LIKE '%Skip stream merging%' OR explain LIKE '%Read each partition through separate port%';
+DROP TABLE test_key_noninjective_of_partition;
+DROP TABLE IF EXISTS test_key_coarser_than_partition;
+CREATE TABLE test_key_coarser_than_partition (a UInt32) ENGINE = MergeTree ORDER BY tuple() PARTITION BY a;
+INSERT INTO test_key_coarser_than_partition SELECT number % 16 FROM numbers_mt(1e3);
+SELECT replaceRegexpOne(explain, '^[ ]*(.*)', '\\1') FROM (EXPLAIN actions = 1 SELECT DISTINCT intDiv(a, 2) AS a1 FROM test_key_coarser_than_partition SETTINGS allow_distinct_partitions_independently = 1) WHERE explain LIKE '%Skip stream merging%' OR explain LIKE '%Read each partition through separate port%';
+DROP TABLE test_key_coarser_than_partition;
+DROP TABLE IF EXISTS test_with_final;
+CREATE TABLE test_with_final (a UInt32, ver UInt32) ENGINE = ReplacingMergeTree(ver) ORDER BY a PARTITION BY a % 8;
+INSERT INTO test_with_final SELECT number, 1 FROM numbers_mt(1e3);
+SELECT replaceRegexpOne(explain, '^[ ]*(.*)', '\\1') FROM (EXPLAIN actions = 1 SELECT DISTINCT a FROM test_with_final FINAL SETTINGS allow_distinct_partitions_independently = 1) WHERE explain LIKE '%Skip stream merging%' OR explain LIKE '%Read each partition through separate port%';
+DROP TABLE test_with_final;
+DROP TABLE IF EXISTS test_no_partition_by;
+CREATE TABLE test_no_partition_by (a UInt32) ENGINE = MergeTree ORDER BY a;
+INSERT INTO test_no_partition_by SELECT number FROM numbers_mt(1e3);
+SELECT replaceRegexpOne(explain, '^[ ]*(.*)', '\\1') FROM (EXPLAIN actions = 1 SELECT DISTINCT a FROM test_no_partition_by SETTINGS allow_distinct_partitions_independently = 1) WHERE explain LIKE '%Skip stream merging%' OR explain LIKE '%Read each partition through separate port%';
+DROP TABLE test_no_partition_by;

--- a/tests/queries/0_stateless/04327_distinct_partitions_independently.sql
+++ b/tests/queries/0_stateless/04327_distinct_partitions_independently.sql
@@ -1,0 +1,75 @@
+-- Tags: long, no-tsan, no-asan, no-msan, no-s3-storage, no-random-settings, no-random-merge-tree-settings
+-- no-tsan, no-asan, no-msan, no-s3-storage: multiple scenarios with INSERT + EXPLAIN; the slowdown blows past the test timeout
+-- no-random-settings, no-random-merge-tree-settings: Explain output may differ
+
+SET max_threads = 16;
+
+-- { echo }
+
+DROP TABLE IF EXISTS test_partition_eq_key;
+CREATE TABLE test_partition_eq_key (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY tuple() PARTITION BY a % 8;
+SYSTEM STOP MERGES test_partition_eq_key;
+INSERT INTO test_partition_eq_key SELECT number, number FROM numbers_mt(1e3);
+INSERT INTO test_partition_eq_key SELECT number, number FROM numbers_mt(1e3);
+EXPLAIN PIPELINE SELECT DISTINCT a FROM test_partition_eq_key SETTINGS allow_distinct_partitions_independently = 1;
+SELECT replaceRegexpOne(explain, '^[ ]*(.*)', '\\1') FROM (EXPLAIN actions = 1 SELECT DISTINCT a FROM test_partition_eq_key SETTINGS allow_distinct_partitions_independently = 1) WHERE explain LIKE '%Skip stream merging%' OR explain LIKE '%Read each partition through separate port%';
+SELECT (SELECT count() FROM (SELECT DISTINCT a FROM test_partition_eq_key SETTINGS allow_distinct_partitions_independently = 0)) = (SELECT count() FROM (SELECT DISTINCT a FROM test_partition_eq_key SETTINGS allow_distinct_partitions_independently = 1));
+DROP TABLE test_partition_eq_key;
+
+DROP TABLE IF EXISTS test_partition_func_of_key;
+CREATE TABLE test_partition_func_of_key (d Date, x UInt32) ENGINE = MergeTree ORDER BY d PARTITION BY toYYYYMM(d);
+SYSTEM STOP MERGES test_partition_func_of_key;
+INSERT INTO test_partition_func_of_key SELECT toDate('2024-01-01') + (number % 240), number FROM numbers_mt(1e3);
+INSERT INTO test_partition_func_of_key SELECT toDate('2024-01-01') + (number % 240), number + 1 FROM numbers_mt(1e3);
+SELECT replaceRegexpOne(explain, '^[ ]*(.*)', '\\1') FROM (EXPLAIN actions = 1 SELECT DISTINCT d FROM test_partition_func_of_key SETTINGS allow_distinct_partitions_independently = 1) WHERE explain LIKE '%Skip stream merging%' OR explain LIKE '%Read each partition through separate port%';
+SELECT (SELECT count() FROM (SELECT DISTINCT d FROM test_partition_func_of_key SETTINGS allow_distinct_partitions_independently = 0)) = (SELECT count() FROM (SELECT DISTINCT d FROM test_partition_func_of_key SETTINGS allow_distinct_partitions_independently = 1));
+DROP TABLE test_partition_func_of_key;
+
+DROP TABLE IF EXISTS test_complex_expr_both_sides;
+CREATE TABLE test_complex_expr_both_sides (a UInt32) ENGINE = MergeTree ORDER BY a PARTITION BY intDiv(a, 2) * 2 + 1;
+INSERT INTO test_complex_expr_both_sides SELECT number FROM numbers_mt(100);
+SELECT replaceRegexpOne(explain, '^[ ]*(.*)', '\\1') FROM (EXPLAIN actions = 1 SELECT DISTINCT intDiv(a, 2) + 1 AS a1 FROM test_complex_expr_both_sides SETTINGS allow_distinct_partitions_independently = 1) WHERE explain LIKE '%Skip stream merging%' OR explain LIKE '%Read each partition through separate port%';
+SELECT (SELECT count() FROM (SELECT DISTINCT intDiv(a, 2) + 1 AS a1 FROM test_complex_expr_both_sides SETTINGS allow_distinct_partitions_independently = 0)) = (SELECT count() FROM (SELECT DISTINCT intDiv(a, 2) + 1 AS a1 FROM test_complex_expr_both_sides SETTINGS allow_distinct_partitions_independently = 1));
+DROP TABLE test_complex_expr_both_sides;
+
+DROP TABLE IF EXISTS test_with_where_filter;
+CREATE TABLE test_with_where_filter (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY b PARTITION BY a % 8;
+SYSTEM STOP MERGES test_with_where_filter;
+INSERT INTO test_with_where_filter SELECT number, number FROM numbers_mt(1e3);
+INSERT INTO test_with_where_filter SELECT number, number + 1 FROM numbers_mt(1e3);
+SELECT replaceRegexpOne(explain, '^[ ]*(.*)', '\\1') FROM (EXPLAIN actions = 1 SELECT DISTINCT a FROM test_with_where_filter WHERE b > 0 SETTINGS allow_distinct_partitions_independently = 1) WHERE explain LIKE '%Skip stream merging%' OR explain LIKE '%Read each partition through separate port%';
+SELECT (SELECT count() FROM (SELECT DISTINCT a FROM test_with_where_filter WHERE b > 0 SETTINGS allow_distinct_partitions_independently = 0)) = (SELECT count() FROM (SELECT DISTINCT a FROM test_with_where_filter WHERE b > 0 SETTINGS allow_distinct_partitions_independently = 1));
+DROP TABLE test_with_where_filter;
+
+DROP TABLE IF EXISTS test_with_filter_step;
+CREATE TABLE test_with_filter_step (a UInt32, b UInt32) ENGINE = MergeTree ORDER BY b PARTITION BY a % 8;
+SYSTEM STOP MERGES test_with_filter_step;
+INSERT INTO test_with_filter_step SELECT number, number FROM numbers_mt(1e3);
+INSERT INTO test_with_filter_step SELECT number, number + 1 FROM numbers_mt(1e3);
+SELECT replaceRegexpOne(explain, '^[ ]*(.*)', '\\1') FROM (EXPLAIN actions = 1 SELECT DISTINCT a FROM test_with_filter_step WHERE b > 0 SETTINGS allow_distinct_partitions_independently = 1, optimize_move_to_prewhere = 0) WHERE explain LIKE '%Skip stream merging%' OR explain LIKE '%Read each partition through separate port%';
+SELECT (SELECT count() FROM (SELECT DISTINCT a FROM test_with_filter_step WHERE b > 0 SETTINGS allow_distinct_partitions_independently = 0, optimize_move_to_prewhere = 0)) = (SELECT count() FROM (SELECT DISTINCT a FROM test_with_filter_step WHERE b > 0 SETTINGS allow_distinct_partitions_independently = 1, optimize_move_to_prewhere = 0));
+DROP TABLE test_with_filter_step;
+
+DROP TABLE IF EXISTS test_key_noninjective_of_partition;
+CREATE TABLE test_key_noninjective_of_partition (a UInt32) ENGINE = MergeTree ORDER BY tuple() PARTITION BY a;
+INSERT INTO test_key_noninjective_of_partition SELECT number % 8 FROM numbers_mt(1e3);
+SELECT replaceRegexpOne(explain, '^[ ]*(.*)', '\\1') FROM (EXPLAIN actions = 1 SELECT DISTINCT (a % 4) FROM test_key_noninjective_of_partition SETTINGS allow_distinct_partitions_independently = 1) WHERE explain LIKE '%Skip stream merging%' OR explain LIKE '%Read each partition through separate port%';
+DROP TABLE test_key_noninjective_of_partition;
+
+DROP TABLE IF EXISTS test_key_coarser_than_partition;
+CREATE TABLE test_key_coarser_than_partition (a UInt32) ENGINE = MergeTree ORDER BY tuple() PARTITION BY a;
+INSERT INTO test_key_coarser_than_partition SELECT number % 16 FROM numbers_mt(1e3);
+SELECT replaceRegexpOne(explain, '^[ ]*(.*)', '\\1') FROM (EXPLAIN actions = 1 SELECT DISTINCT intDiv(a, 2) AS a1 FROM test_key_coarser_than_partition SETTINGS allow_distinct_partitions_independently = 1) WHERE explain LIKE '%Skip stream merging%' OR explain LIKE '%Read each partition through separate port%';
+DROP TABLE test_key_coarser_than_partition;
+
+DROP TABLE IF EXISTS test_with_final;
+CREATE TABLE test_with_final (a UInt32, ver UInt32) ENGINE = ReplacingMergeTree(ver) ORDER BY a PARTITION BY a % 8;
+INSERT INTO test_with_final SELECT number, 1 FROM numbers_mt(1e3);
+SELECT replaceRegexpOne(explain, '^[ ]*(.*)', '\\1') FROM (EXPLAIN actions = 1 SELECT DISTINCT a FROM test_with_final FINAL SETTINGS allow_distinct_partitions_independently = 1) WHERE explain LIKE '%Skip stream merging%' OR explain LIKE '%Read each partition through separate port%';
+DROP TABLE test_with_final;
+
+DROP TABLE IF EXISTS test_no_partition_by;
+CREATE TABLE test_no_partition_by (a UInt32) ENGINE = MergeTree ORDER BY a;
+INSERT INTO test_no_partition_by SELECT number FROM numbers_mt(1e3);
+SELECT replaceRegexpOne(explain, '^[ ]*(.*)', '\\1') FROM (EXPLAIN actions = 1 SELECT DISTINCT a FROM test_no_partition_by SETTINGS allow_distinct_partitions_independently = 1) WHERE explain LIKE '%Skip stream merging%' OR explain LIKE '%Read each partition through separate port%';
+DROP TABLE test_no_partition_by;


### PR DESCRIPTION
## Enable independent per-partition `DISTINCT` when partition key matches `DISTINCT` columns

When a `MergeTree` partition expression is a deterministic injective function of the `DISTINCT` columns, the same logical key cannot appear in two partitions. In that case, `DISTINCT` can be evaluated independently on each partition stream without a final cross-stream merge.

This PR adds a query-plan optimization, following the same framework as the existing per-partition `LIMIT BY` and `GROUP BY` optimizations:

- New setting `allow_distinct_partitions_independently` (default: `true`)
- `optimizeDistinctPerPartition` reuses `isPartitionKeyFunctionOfKeys` to check applicability
- `ReadFromMergeTree` outputs each partition through a separate port via `groupStreamsByPartition`
- Final `DistinctStep` skips `pipeline.resize(1)` through `skipStreamMerging()`, running one `DistinctTransform` per partition stream

The optimization is not applied for `FINAL`, parallel replicas, single-partition tables, or non-injective key expressions (same constraints as other per-partition optimizations).

### Performance

Setup:

```sql
DROP TABLE IF EXISTS bench_distinct_partition;

CREATE TABLE bench_distinct_partition
(
    user_id UInt64,
    payload String
)
ENGINE = MergeTree
ORDER BY tuple()
PARTITION BY user_id % 32;

INSERT INTO bench_distinct_partition
SELECT
    number AS user_id,
    repeat('x', 20) AS payload
FROM numbers(20000000);
```

Query comparison (`max_threads = 16`, `FORMAT Null`):

```sql
SELECT DISTINCT user_id
FROM bench_distinct_partition
SETTINGS allow_distinct_partitions_independently = 0,
         max_threads = 16,
         log_comment = 'distinct_no_opt'
FORMAT Null;

SELECT DISTINCT user_id
FROM bench_distinct_partition
SETTINGS allow_distinct_partitions_independently = 1,
         max_threads = 16,
         log_comment = 'distinct_with_opt'
FORMAT Null;

SELECT
    log_comment,
    count() AS runs,
    round(quantile(0.5)(query_duration_ms)) AS p50_ms,
    round(quantile(0.9)(query_duration_ms)) AS p90_ms,
    round(avg(query_duration_ms)) AS avg_ms
FROM system.query_log
WHERE type = 'QueryFinish'
  AND current_database = currentDatabase()
  AND log_comment IN ('distinct_no_opt', 'distinct_with_opt')
  AND event_time > now() - 600
GROUP BY log_comment
ORDER BY log_comment;
```

Results:

| Setting | p50 (ms) | p90 (ms) | avg (ms) |
|---------|----------|----------|----------|
| `allow_distinct_partitions_independently = 0` | 757 | 786 | 757 |
| `allow_distinct_partitions_independently = 1` | 315 | 320 | 310 |

Roughly **2.4×** faster median latency. The gain comes from avoiding the single-stream final `DistinctTransform` bottleneck (one global hash set over all rows) and using smaller per-partition hash sets in parallel.

### Changelog category (leave one):
- Performance Improvement


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Add `allow_distinct_partitions_independently` setting (enabled by default). When the partition key is a deterministic function of the `DISTINCT` columns, `DISTINCT` is evaluated independently per partition on separate threads, avoiding the final stream merge and improving performance on multi-partition tables.
