### PR TITLE
MaterializedPostgreSQL: prevent exported snapshot expiration during initial sync

### DIFF
--- a/src/Storages/PostgreSQL/PostgreSQLReplicationHandler.cpp
+++ b/src/Storages/PostgreSQL/PostgreSQLReplicationHandler.cpp
@@ -307,6 +307,13 @@ void PostgreSQLReplicationHandler::startSynchronization(bool throw_on_error)
 {
     postgres::Connection replication_connection(connection_info, /* replication */true);
     pqxx::nontransaction tx(replication_connection.getRef());
+
+    /// Disable idle transaction timeouts for the snapshot holder connection.
+    /// This connection must remain idle while data is synchronized through
+    /// a separate PostgreSQL connection. If PostgreSQL terminates this
+    /// session due to idle_in_transaction_session_timeout, the exported
+    /// snapshot becomes invalid.
+    tx.exec("SET idle_in_transaction_session_timeout = 0");
     createPublicationIfNeeded(tx);
 
     /// List of nested tables (table_name -> nested_storage), which is passed to replication consumer.

--- a/tests/integration/test_postgresql_replica_database_engine/test_idle_timeout.py
+++ b/tests/integration/test_postgresql_replica_database_engine/test_idle_timeout.py
@@ -1,0 +1,83 @@
+import time
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+from helpers.postgres_utility import (
+    PostgresManager,
+    check_tables_are_synchronized,
+)
+
+cluster = ClickHouseCluster(__file__)
+instance = cluster.add_instance(
+    "instance",
+    main_configs=["configs/log_conf.xml"],
+    user_configs=["configs/users.xml"],
+    with_postgres=True,
+    stay_alive=True,
+)
+
+pg_manager = PostgresManager()
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        pg_manager.init(
+            instance,
+            cluster.postgres_ip,
+            cluster.postgres_port,
+            default_database="postgres_database",
+        )
+        yield cluster
+
+    finally:
+        cluster.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def setup_teardown():
+    print("PostgreSQL is available - running test")
+    yield  # run test
+    pg_manager.restart()
+
+
+def test_idle_in_transaction_session_timeout(started_cluster):
+    """
+    Regression test for #80724: idle_in_transaction_session_timeout
+    must not kill the snapshot-holder connection during initial sync.
+    """
+
+    # 1. Set aggressive timeout on PostgreSQL
+    pg_manager.execute(
+        "ALTER SYSTEM SET idle_in_transaction_session_timeout = '2s';"
+    )
+    pg_manager.execute("SELECT pg_reload_conf();")
+
+    # 2. Create a table with enough data to make sync take >2 seconds
+    pg_manager.create_postgres_table("test_timeout_table")
+    instance.query(
+        "INSERT INTO postgres_database.test_timeout_table "
+        "SELECT number, number FROM numbers(10000000)"
+    )
+
+    # 3. Create the materialized database. 
+    # Without the fix, this would fail with "invalid snapshot identifier"
+    # because PostgreSQL would kill the idle exported-snapshot session before
+    # the 1M rows finish copying.
+    pg_manager.create_materialized_db(
+        ip=started_cluster.postgres_ip,
+        port=started_cluster.postgres_port,
+        settings=[
+            "materialized_postgresql_tables_list = 'test_timeout_table'"
+        ],
+    )
+
+    # 4. If we reach here, the snapshot survived the timeout
+    check_tables_are_synchronized(instance, "test_timeout_table")
+
+    # Cleanup: restore default timeout
+    pg_manager.execute(
+        "ALTER SYSTEM RESET idle_in_transaction_session_timeout;"
+    )
+    pg_manager.execute("SELECT pg_reload_conf();")


### PR DESCRIPTION
Fixes #80724.

This PR addresses a failure mode during MaterializedPostgreSQL initial synchronization that can result in an invalid snapshot identifier error.

During initial synchronization, ClickHouse creates an exported snapshot using a dedicated PostgreSQL replication session and then copies table data through a separate temporary connection. The replication session remains open to keep the exported snapshot alive while the data copy is in progress.

If PostgreSQL is configured with idle_in_transaction_session_timeout, the snapshot-owning session may remain idle long enough to be terminated by PostgreSQL while synchronization is still running. Once that session exits, the exported snapshot becomes invalid and subsequent snapshot usage can fail with invalid snapshot identifier.

To prevent this, this change disables idle_in_transaction_session_timeout only for the snapshot-owning replication session before the replication slot and exported snapshot are created.

Scope of the change:

- Applies only to the snapshot-holder session used during MaterializedPostgreSQL initial synchronization.
- Does not modify generic PostgreSQL connection behavior.
- Does not change other PostgreSQL timeout settings or administrator-configured policies.

A regression test has been added to verify synchronization behavior under a low idle_in_transaction_session_timeout configuration.
