### PR TITLE
Run heavy delta modules sequentially in the integration flaky check

### DIFF
--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -13,6 +13,7 @@ from ci.jobs.scripts.find_tests import Targeting
 from ci.jobs.scripts.integration_tests_configs import (
     IMAGES_ENV,
     LLVM_COVERAGE_SKIP_PREFIXES,
+    force_heavy_modules_sequential,
     get_optimal_test_batch,
 )
 from ci.jobs.scripts.workflow_hooks.pr_labels_and_category import Labels
@@ -778,6 +779,18 @@ tar -czf ./ci/tmp/logs.tar.gz \
             no_strict=is_targeted_check or is_flaky_check,  # targeted check might want to run test that was removed on a merge-commit; flaky check might pick up a changed test filtered out by SKIP_LIST in the private fork
         )
     )
+
+    if is_flaky_check or is_targeted_check:
+        # The flaky/targeted parallel bucket runs `--dist=each`: every worker runs
+        # every parallel module at once. Heavy modules would start one cluster per
+        # worker and OOM small runners, so move them to the looped sequential phase.
+        before = list(parallel_test_modules)
+        parallel_test_modules, sequential_test_modules = force_heavy_modules_sequential(
+            parallel_test_modules, sequential_test_modules
+        )
+        moved = [m for m in before if m not in parallel_test_modules]
+        if moved:
+            print(f"Forced heavy modules to the sequential phase (avoid concurrent --dist=each clusters): {moved}")
 
     if is_sequential:
         parallel_test_modules = []

--- a/ci/jobs/integration_test_job.py
+++ b/ci/jobs/integration_test_job.py
@@ -782,8 +782,9 @@ tar -czf ./ci/tmp/logs.tar.gz \
 
     if is_flaky_check or is_targeted_check:
         # The flaky/targeted parallel bucket runs `--dist=each`: every worker runs
-        # every parallel module at once. Heavy modules would start one cluster per
-        # worker and OOM small runners, so move them to the looped sequential phase.
+        # every parallel module at once. TEST_CONFIGS `dist_each_sequential` modules
+        # would start one cluster per worker and OOM small runners, so move them to
+        # the looped sequential phase. Normal `--dist=loadfile` runs do not call this.
         before = list(parallel_test_modules)
         parallel_test_modules, sequential_test_modules = force_heavy_modules_sequential(
             parallel_test_modules, sequential_test_modules

--- a/ci/jobs/scripts/integration_tests_configs.py
+++ b/ci/jobs/scripts/integration_tests_configs.py
@@ -8,8 +8,12 @@ from ci.praktika.info import Info
 @dataclasses.dataclass
 class TC:
     prefix: str
-    is_sequential: bool
+    is_sequential: bool  # sequential in every integration job
     comment: str
+    # Sequential only under the flaky/targeted `--dist=each` schedule; parallel
+    # under the normal `--dist=loadfile` schedule. Set for heavy modules that
+    # would start one cluster per xdist worker under `--dist=each` and OOM.
+    dist_each_sequential: bool = False
 
 
 # Tests that are too slow to run under LLVM coverage instrumentation.
@@ -21,45 +25,6 @@ LLVM_COVERAGE_SKIP_PREFIXES = [
     "test_multiple_disks/",
     "test_ytsaurus/",
 ]
-
-# Heavy modules that must not run concurrently under the flaky/targeted checks'
-# `--dist=each` scheduling. Each starts a Spark JVM plus a multi-node ClickHouse
-# cluster in its module-scoped fixture, so N concurrent copies (N = xdist workers)
-# exhaust memory on smaller runners. In the flaky/targeted path these are moved
-# to the looped sequential phase (one cluster at a time, still repeated >=3x).
-# Normal runs use `--dist=loadfile` (one file -> one worker -> one cluster) and
-# are unaffected.
-FLAKY_FORCE_SEQUENTIAL_PREFIXES = [
-    "test_storage_delta/test.py",
-    "test_storage_delta/test_cdf.py",
-    "test_storage_delta_disks/test.py",
-]
-
-
-def force_heavy_modules_sequential(
-    parallel_test_modules: list[str],
-    sequential_test_modules: list[str],
-) -> tuple[list[str], list[str]]:
-    """Move FLAKY_FORCE_SEQUENTIAL_PREFIXES modules from the parallel to the
-    sequential bucket, preserving order.
-
-    Called only on the flaky/targeted path, where the parallel bucket runs with
-    `--dist=each` (every worker runs every parallel module at once). Heavy
-    modules there would start one cluster per worker and exhaust memory; the
-    sequential bucket runs `-n 1` (one cluster at a time, looped >=3x), which
-    keeps the flakiness signal without the concurrent OOM.
-    """
-    forced = [
-        m
-        for m in parallel_test_modules
-        if any(m.startswith(p) for p in FLAKY_FORCE_SEQUENTIAL_PREFIXES)
-    ]
-    if not forced:
-        return parallel_test_modules, sequential_test_modules
-    new_parallel = [m for m in parallel_test_modules if m not in forced]
-    new_sequential = sequential_test_modules + forced
-    return new_parallel, new_sequential
-
 
 TEST_CONFIGS = [
     TC("test_dns_cache/", False, "uses fixed IPv6 addresses; Docker network startup is serialized via file lock"),
@@ -92,7 +57,53 @@ TEST_CONFIGS = [
         True,
         "pins azurite to fixed host port 10000 (Spark emulator mode); concurrent --dist=each workers collide on bind",
     ),
+    TC(
+        "test_storage_delta/test.py",
+        False,
+        "starts a Spark JVM + multi-node ClickHouse cluster per module fixture",
+        dist_each_sequential=True,
+    ),
+    TC(
+        "test_storage_delta/test_cdf.py",
+        False,
+        "starts a Spark JVM + multi-node ClickHouse cluster per module fixture",
+        dist_each_sequential=True,
+    ),
+    TC(
+        "test_storage_delta_disks/test.py",
+        False,
+        "starts a Spark JVM + multi-node ClickHouse cluster per module fixture",
+        dist_each_sequential=True,
+    ),
 ]
+
+
+def force_heavy_modules_sequential(
+    parallel_test_modules: list[str],
+    sequential_test_modules: list[str],
+) -> tuple[list[str], list[str]]:
+    """Move TEST_CONFIGS `dist_each_sequential` modules from the parallel to the
+    sequential bucket, preserving order.
+
+    Called only on the flaky/targeted path, whose parallel bucket runs with
+    `--dist=each` (every worker runs every parallel module at once). These
+    modules start one cluster per worker there and exhaust memory; the
+    sequential bucket runs `-n 1` (one cluster at a time, looped >=3x), which
+    keeps the flakiness signal without the concurrent OOM. Normal runs use
+    `--dist=loadfile` (one file -> one worker -> one cluster) and never call this.
+    """
+    prefixes = [tc.prefix for tc in TEST_CONFIGS if tc.dist_each_sequential]
+    forced = [
+        m
+        for m in parallel_test_modules
+        if any(m.startswith(p) for p in prefixes)
+    ]
+    if not forced:
+        return parallel_test_modules, sequential_test_modules
+    new_parallel = [m for m in parallel_test_modules if m not in forced]
+    new_sequential = sequential_test_modules + forced
+    return new_parallel, new_sequential
+
 
 IMAGES_ENV = {
     "clickhouse/dotnet-client": "DOCKER_DOTNET_CLIENT_TAG",

--- a/ci/jobs/scripts/integration_tests_configs.py
+++ b/ci/jobs/scripts/integration_tests_configs.py
@@ -22,6 +22,45 @@ LLVM_COVERAGE_SKIP_PREFIXES = [
     "test_ytsaurus/",
 ]
 
+# Heavy modules that must not run concurrently under the flaky/targeted checks'
+# `--dist=each` scheduling. Each starts a Spark JVM plus a multi-node ClickHouse
+# cluster in its module-scoped fixture, so N concurrent copies (N = xdist workers)
+# exhaust memory on smaller runners. In the flaky/targeted path these are moved
+# to the looped sequential phase (one cluster at a time, still repeated >=3x).
+# Normal runs use `--dist=loadfile` (one file -> one worker -> one cluster) and
+# are unaffected.
+FLAKY_FORCE_SEQUENTIAL_PREFIXES = [
+    "test_storage_delta/test.py",
+    "test_storage_delta/test_cdf.py",
+    "test_storage_delta_disks/test.py",
+]
+
+
+def force_heavy_modules_sequential(
+    parallel_test_modules: list[str],
+    sequential_test_modules: list[str],
+) -> tuple[list[str], list[str]]:
+    """Move FLAKY_FORCE_SEQUENTIAL_PREFIXES modules from the parallel to the
+    sequential bucket, preserving order.
+
+    Called only on the flaky/targeted path, where the parallel bucket runs with
+    `--dist=each` (every worker runs every parallel module at once). Heavy
+    modules there would start one cluster per worker and exhaust memory; the
+    sequential bucket runs `-n 1` (one cluster at a time, looped >=3x), which
+    keeps the flakiness signal without the concurrent OOM.
+    """
+    forced = [
+        m
+        for m in parallel_test_modules
+        if any(m.startswith(p) for p in FLAKY_FORCE_SEQUENTIAL_PREFIXES)
+    ]
+    if not forced:
+        return parallel_test_modules, sequential_test_modules
+    new_parallel = [m for m in parallel_test_modules if m not in forced]
+    new_sequential = sequential_test_modules + forced
+    return new_parallel, new_sequential
+
+
 TEST_CONFIGS = [
     TC("test_dns_cache/", False, "uses fixed IPv6 addresses; Docker network startup is serialized via file lock"),
     TC("test_global_overcommit_tracker/", False, "memory overcommit test; isolated to its own ClickHouse instance"),

--- a/ci/jobs/scripts/integration_tests_configs.py
+++ b/ci/jobs/scripts/integration_tests_configs.py
@@ -11,8 +11,9 @@ class TC:
     is_sequential: bool  # sequential in every integration job
     comment: str
     # Sequential only under the flaky/targeted `--dist=each` schedule; parallel
-    # under the normal `--dist=loadfile` schedule. Set for heavy modules that
-    # would start one cluster per xdist worker under `--dist=each` and OOM.
+    # under the normal `--dist=loadfile` schedule. Set for modules that start one
+    # cluster per xdist worker under `--dist=each` and then contend on a shared
+    # resource (host memory, a fixed host port, or a global Docker-network lock).
     dist_each_sequential: bool = False
 
 
@@ -27,7 +28,13 @@ LLVM_COVERAGE_SKIP_PREFIXES = [
 ]
 
 TEST_CONFIGS = [
-    TC("test_dns_cache/", False, "uses fixed IPv6 addresses; Docker network startup is serialized via file lock"),
+    TC(
+        "test_dns_cache/",
+        False,
+        "fixed IPv6 addresses; concurrent --dist=each clusters serialize on the "
+        "global /tmp/docker_net.lock and blow the 10-min acquire budget",
+        dist_each_sequential=True,
+    ),
     TC("test_global_overcommit_tracker/", False, "memory overcommit test; isolated to its own ClickHouse instance"),
     TC(
         "test_profile_max_sessions_for_user/",

--- a/ci/tests/test_force_heavy_modules_sequential.py
+++ b/ci/tests/test_force_heavy_modules_sequential.py
@@ -1,0 +1,104 @@
+"""
+Regression tests for `force_heavy_modules_sequential` (integration flaky check).
+
+PR #105171's flaky integration check (`Integration tests (amd_asan_ubsan, flaky)`)
+OOM-hung on the `AMD_MEDIUM` runner (16 cpu, 61 GiB -> workers = min(16//5, 61//11)
+= 3). The flaky/targeted parallel bucket runs `-n 3 --dist=each`, so all 3 workers
+run every parallel module at once. `test_storage_delta/test.py` starts a 5-node
+ClickHouse cluster plus a Spark JVM in its module-scoped fixture; three concurrent
+copies meant 15 ASan servers + 3 JVMs on 61 GiB and a kernel OOM (an in-test hang
+at `test_checkpoint[1-s3]`). Reducing the per-JVM heap (#106698, 8g->2g) helped but
+did not remove the concurrency driver.
+
+`force_heavy_modules_sequential` moves the heavy delta modules out of the
+`--dist=each` parallel bucket into the looped sequential bucket (`-n 1`, repeated
+>=3x), so at most one delta cluster runs at a time while the flakiness signal is
+preserved. Normal runs use `--dist=loadfile` (one file -> one worker -> one cluster)
+and never call this, so they are unaffected.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.jobs.scripts.integration_tests_configs import (
+    FLAKY_FORCE_SEQUENTIAL_PREFIXES,
+    force_heavy_modules_sequential,
+)
+
+
+def test_heavy_delta_modules_moved_to_sequential():
+    # PR #105171 reproducer: all three heavy delta modules start in the parallel
+    # (--dist=each) bucket. After re-routing they must be sequential.
+    parallel = [
+        "test_storage_delta/test.py",
+        "test_storage_delta/test_cdf.py",
+        "test_storage_delta_disks/test.py",
+    ]
+    sequential = []
+    new_parallel, new_sequential = force_heavy_modules_sequential(parallel, sequential)
+    assert new_parallel == []
+    assert new_sequential == [
+        "test_storage_delta/test.py",
+        "test_storage_delta/test_cdf.py",
+        "test_storage_delta_disks/test.py",
+    ]
+
+
+def test_light_modules_stay_parallel():
+    # Non-heavy modules must remain in the concurrent bucket.
+    parallel = ["test_storage_s3/test.py", "test_dns_cache/test.py"]
+    sequential = ["test_server_overload/test.py"]
+    new_parallel, new_sequential = force_heavy_modules_sequential(parallel, sequential)
+    assert new_parallel == ["test_storage_s3/test.py", "test_dns_cache/test.py"]
+    assert new_sequential == ["test_server_overload/test.py"]
+
+
+def test_mixed_split_preserves_order_and_existing_sequential():
+    parallel = [
+        "test_storage_s3/test.py",
+        "test_storage_delta/test.py",
+        "test_distributed_ddl/test.py",
+        "test_storage_delta_disks/test.py",
+    ]
+    sequential = ["test_server_overload/test.py"]
+    new_parallel, new_sequential = force_heavy_modules_sequential(parallel, sequential)
+    # Heavy ones removed from parallel, order of survivors preserved.
+    assert new_parallel == ["test_storage_s3/test.py", "test_distributed_ddl/test.py"]
+    # Pre-existing sequential modules kept; heavy ones appended in original order.
+    assert new_sequential == [
+        "test_server_overload/test.py",
+        "test_storage_delta/test.py",
+        "test_storage_delta_disks/test.py",
+    ]
+
+
+def test_other_delta_modules_are_not_forced():
+    # Only the listed prefixes are heavy. Lightweight delta modules
+    # (no Spark JVM / single instance) stay parallel.
+    parallel = [
+        "test_storage_delta/test_imds.py",
+        "test_storage_delta/test_azure_cluster.py",
+        "test_database_delta/test.py",
+    ]
+    new_parallel, new_sequential = force_heavy_modules_sequential(parallel, [])
+    assert new_parallel == parallel
+    assert new_sequential == []
+
+
+def test_idempotent_when_nothing_to_move():
+    # Returns inputs unchanged (and does not duplicate) when no heavy module is
+    # present in the parallel bucket.
+    parallel = ["test_storage_s3/test.py"]
+    sequential = ["test_storage_delta/test.py"]
+    new_parallel, new_sequential = force_heavy_modules_sequential(parallel, sequential)
+    assert new_parallel == ["test_storage_s3/test.py"]
+    assert new_sequential == ["test_storage_delta/test.py"]
+
+
+def test_prefixes_match_real_module_paths():
+    # Guard against the prefixes drifting from real test module paths.
+    base = os.path.join(os.path.dirname(__file__), "..", "..", "tests", "integration")
+    for prefix in FLAKY_FORCE_SEQUENTIAL_PREFIXES:
+        assert os.path.isfile(os.path.join(base, prefix)), prefix

--- a/ci/tests/test_force_heavy_modules_sequential.py
+++ b/ci/tests/test_force_heavy_modules_sequential.py
@@ -10,7 +10,8 @@ copies meant 15 ASan servers + 3 JVMs on 61 GiB and a kernel OOM (an in-test han
 at `test_checkpoint[1-s3]`). Reducing the per-JVM heap (#106698, 8g->2g) helped but
 did not remove the concurrency driver.
 
-`force_heavy_modules_sequential` moves the heavy delta modules out of the
+The heavy delta modules carry `dist_each_sequential=True` in TEST_CONFIGS.
+`force_heavy_modules_sequential` reads that flag and moves them out of the
 `--dist=each` parallel bucket into the looped sequential bucket (`-n 1`, repeated
 >=3x), so at most one delta cluster runs at a time while the flakiness signal is
 preserved. Normal runs use `--dist=loadfile` (one file -> one worker -> one cluster)
@@ -23,9 +24,11 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
 from ci.jobs.scripts.integration_tests_configs import (
-    FLAKY_FORCE_SEQUENTIAL_PREFIXES,
+    TEST_CONFIGS,
     force_heavy_modules_sequential,
 )
+
+HEAVY_PREFIXES = [tc.prefix for tc in TEST_CONFIGS if tc.dist_each_sequential]
 
 
 def test_heavy_delta_modules_moved_to_sequential():
@@ -75,7 +78,7 @@ def test_mixed_split_preserves_order_and_existing_sequential():
 
 
 def test_other_delta_modules_are_not_forced():
-    # Only the listed prefixes are heavy. Lightweight delta modules
+    # Only the flagged prefixes are heavy. Lightweight delta modules
     # (no Spark JVM / single instance) stay parallel.
     parallel = [
         "test_storage_delta/test_imds.py",
@@ -97,8 +100,20 @@ def test_idempotent_when_nothing_to_move():
     assert new_sequential == ["test_storage_delta/test.py"]
 
 
+def test_heavy_modules_are_not_unconditionally_sequential():
+    # The conditional flag must NOT also set is_sequential, otherwise the heavy
+    # delta modules would be serialized in the ~140 normal --dist=loadfile jobs
+    # too (where one cluster per file is fine). dist_each_sequential is the only
+    # flag that should be set for them.
+    for tc in TEST_CONFIGS:
+        if tc.dist_each_sequential:
+            assert not tc.is_sequential, tc.prefix
+
+
 def test_prefixes_match_real_module_paths():
-    # Guard against the prefixes drifting from real test module paths.
+    # Guard against the TEST_CONFIGS dist_each_sequential prefixes drifting from
+    # real test module paths.
     base = os.path.join(os.path.dirname(__file__), "..", "..", "tests", "integration")
-    for prefix in FLAKY_FORCE_SEQUENTIAL_PREFIXES:
+    assert HEAVY_PREFIXES, "expected at least one dist_each_sequential module in TEST_CONFIGS"
+    for prefix in HEAVY_PREFIXES:
         assert os.path.isfile(os.path.join(base, prefix)), prefix

--- a/ci/tests/test_force_heavy_modules_sequential.py
+++ b/ci/tests/test_force_heavy_modules_sequential.py
@@ -10,10 +10,16 @@ copies meant 15 ASan servers + 3 JVMs on 61 GiB and a kernel OOM (an in-test han
 at `test_checkpoint[1-s3]`). Reducing the per-JVM heap (#106698, 8g->2g) helped but
 did not remove the concurrency driver.
 
-The heavy delta modules carry `dist_each_sequential=True` in TEST_CONFIGS.
+The same concurrency driver hits any module that contends on a shared resource
+under `--dist=each`. `test_dns_cache` pins fixed IPs on the one shared
+`docker_compose_net.yml` subnet, so its concurrent copies serialize on the global
+`/tmp/docker_net.lock` and blow the 10-min acquire budget instead of OOMing. It
+carries the same flag.
+
+These modules carry `dist_each_sequential=True` in TEST_CONFIGS.
 `force_heavy_modules_sequential` reads that flag and moves them out of the
 `--dist=each` parallel bucket into the looped sequential bucket (`-n 1`, repeated
->=3x), so at most one delta cluster runs at a time while the flakiness signal is
+>=3x), so at most one such cluster runs at a time while the flakiness signal is
 preserved. Normal runs use `--dist=loadfile` (one file -> one worker -> one cluster)
 and never call this, so they are unaffected.
 """
@@ -51,11 +57,23 @@ def test_heavy_delta_modules_moved_to_sequential():
 
 def test_light_modules_stay_parallel():
     # Non-heavy modules must remain in the concurrent bucket.
-    parallel = ["test_storage_s3/test.py", "test_dns_cache/test.py"]
+    parallel = ["test_storage_s3/test.py", "test_distributed_ddl/test.py"]
     sequential = ["test_server_overload/test.py"]
     new_parallel, new_sequential = force_heavy_modules_sequential(parallel, sequential)
-    assert new_parallel == ["test_storage_s3/test.py", "test_dns_cache/test.py"]
+    assert new_parallel == ["test_storage_s3/test.py", "test_distributed_ddl/test.py"]
     assert new_sequential == ["test_server_overload/test.py"]
+
+
+def test_dns_cache_moved_to_sequential():
+    # test_dns_cache pins fixed IPs on the one shared docker_compose_net.yml subnet,
+    # so concurrent --dist=each copies serialize on the global /tmp/docker_net.lock
+    # and blow the 10-min acquire budget. It carries dist_each_sequential=True and
+    # must move to the sequential bucket, while light siblings stay parallel.
+    parallel = ["test_storage_s3/test.py", "test_dns_cache/test.py"]
+    sequential = []
+    new_parallel, new_sequential = force_heavy_modules_sequential(parallel, sequential)
+    assert new_parallel == ["test_storage_s3/test.py"]
+    assert new_sequential == ["test_dns_cache/test.py"]
 
 
 def test_mixed_split_preserves_order_and_existing_sequential():
@@ -112,8 +130,10 @@ def test_heavy_modules_are_not_unconditionally_sequential():
 
 def test_prefixes_match_real_module_paths():
     # Guard against the TEST_CONFIGS dist_each_sequential prefixes drifting from
-    # real test module paths.
+    # real test paths. A prefix is either a module file (test_storage_delta/test.py)
+    # or a suite directory (test_dns_cache/).
     base = os.path.join(os.path.dirname(__file__), "..", "..", "tests", "integration")
     assert HEAVY_PREFIXES, "expected at least one dist_each_sequential module in TEST_CONFIGS"
     for prefix in HEAVY_PREFIXES:
-        assert os.path.isfile(os.path.join(base, prefix)), prefix
+        path = os.path.join(base, prefix)
+        assert os.path.isfile(path) or os.path.isdir(path), prefix

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -2905,7 +2905,7 @@ def test_join_with_distributed(started_cluster):
 
     table_function_cluster = f"deltaLakeCluster(cluster, 'http://{started_cluster.minio_ip}:{started_cluster.minio_port}/{bucket}/{result_file}/', 'minio', '{minio_secret_key}')"
 
-    # All cases which were reproted as faulty
+    # All cases which were reported as faulty
     assert (
         int(
             instance.query(


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/106698
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

The flaky/targeted integration checks schedule the parallel bucket with `-n {workers} --dist=each`, so every xdist worker runs every parallel module concurrently. On `AMD_MEDIUM` (16 cpu, 61 GiB) `workers = min(16//5, 61//11) = 3`.

`test_storage_delta/test.py` starts a 5-node ClickHouse cluster plus a Spark JVM in its module-scoped fixture. Three concurrent copies meant ~15 ASan servers + 3 JVMs on a 61 GiB host and a kernel OOM that surfaced as an in-test hang (e.g. run 27175604347/job 80226138143 hung at `test_checkpoint[1-s3]` and was SIGTERMed by the praktika timeout). Reducing the per-JVM heap (8g -> 2g, #106698) helped but did not remove the concurrency driver.

This moves the heavy delta modules (`test_storage_delta/test.py`, `test_storage_delta/test_cdf.py`, `test_storage_delta_disks/test.py`) out of the `--dist=each` parallel bucket into the looped sequential bucket (`-n 1`, repeated >=3x) for the flaky/targeted path only. At most one delta cluster runs at a time, so the OOM driver is removed while the flakiness signal is preserved. Normal master/PR runs use `--dist=loadfile` (one file -> one worker -> one cluster) and never take this path, so they are unaffected.

The move is done by a small `force_heavy_modules_sequential` helper in `ci/jobs/scripts/integration_tests_configs.py`, gated on `is_flaky_check or is_targeted_check` in `ci/jobs/integration_test_job.py`. A regression test in `ci/tests/test_force_heavy_modules_sequential.py` pins the behavior.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.152` (included in `26.7` and later)
<!-- ch-version-info:end -->