### PR TITLE
Fix flaky 00377_shard_group_uniq_array_of_string_array under shared-runner memory pressure

### DIFF
--- a/tests/queries/0_stateless/00377_shard_group_uniq_array_of_string_array.sql
+++ b/tests/queries/0_stateless/00377_shard_group_uniq_array_of_string_array.sql
@@ -1,5 +1,7 @@
 -- Tags: shard, long
 SET max_rows_to_read = '55M';
+-- Bound this query's memory so it is not the OvercommitTracker victim under shared-runner pressure.
+SET max_threads = 4;
 
 DROP TABLE IF EXISTS group_uniq_arr_str;
 CREATE TABLE group_uniq_arr_str ENGINE = Memory AS


### PR DESCRIPTION
<!--
Related: https://github.com/ClickHouse/ClickHouse/pull/106733
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

`00377_shard_group_uniq_array_of_string_array` fails intermittently on `Stateless tests (arm_asan_ubsan, azure, parallel)` with `Code: 241 (total) memory limit exceeded`.

The failing query is not over its own limit. The server total RSS is already at the host cap (53.68 / 53.69 GiB) from other concurrent queries on the shared azure-parallel runner, and the `OvercommitTracker` selects this query's `AggregatingTransform` as the victim to stop. CIDB shows 3 hits in 30 days across 3 unrelated PRs (#106733, #98472, #106808), 0 on master, all on the same azure-parallel check.

The fix bounds the test's thread count (`SET max_threads = 4`) so its peak memory footprint is lower and it is far less likely to be the `OvercommitTracker` victim. The tracker picks the victim by overcommit ratio (query memory / soft limit), so a smaller query is less exposed under shared-runner pressure.

Measured locally on a debug build (10M-row Memory table, 4-way `remote()` fan-out): peak memory of the heavy fan-out query drops from ~1.1-1.3 GiB at the default thread count to ~0.57-0.67 GiB with `max_threads = 4` (roughly halved). Output is unchanged and matches the reference exactly.

Same approach and precedent as #106667. Reported by alexey-milovidov on #106733.
