### PR TITLE
Fix flaky test 02865_tcp_proxy_query_packet_validation

### DIFF
--- a/tests/queries/0_stateless/02865_tcp_proxy_query_packet_validation.sh
+++ b/tests/queries/0_stateless/02865_tcp_proxy_query_packet_validation.sh
@@ -6,5 +6,24 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
 
-printf "PROXY TCP4 255.255.255.255 255.255.255.255 65535 65535\r\n\0\21ClickHouse client\24\r\253\251\3\0\7default\0\4\1\0\1\0\0\t0.0.0.0:0\1\6hacker\16hacker-desktop\15Hacker client\24\r\253\251\3\0\1\0\0\0\2\1\25SELECT 'Hello, world'\2\0\247\203\254l\325\\z|\265\254F\275\333\206\342\24\202\24\0\0\0\n\0\0\0\240\1\0\2\377\377\377\377\0\0\0" | nc "${CLICKHOUSE_HOST}" "${CLICKHOUSE_PORT_TCP_WITH_PROXY}" | head -c250 | grep --text -o -F 'client_name does not match'
-printf "PROXY TCP4 255.255.255.255 255.255.255.255 65535 65535\r\n\0\21ClickHouse client\24\r\253\251\3\0\7default\0\4\1\0\1\0\0\t0.0.0.0:0\1\6hacker\16hacker-desktop\21ClickHouse client\20\r\253\251\3\0\1\0\0\0\2\1\25SELECT 'Hello, world'\2\0\247\203\254l\325\\z|\265\254F\275\333\206\342\24\202\24\0\0\0\n\0\0\0\240\1\0\2\377\377\377\377\0\0\0" | nc "${CLICKHOUSE_HOST}" "${CLICKHOUSE_PORT_TCP_WITH_PROXY}" | head -c250 | grep --text -o -F 'version does not match'
+# The server closes the connection right after rejecting these malformed Hello
+# packets; the resulting TCP RST can race ahead of nc reading the buffered error,
+# so a single attempt occasionally yields no output. Retry until it appears; a
+# genuine breakage still fails the diff because every attempt stays empty.
+function expect_rejection() {
+    local expected="$1"
+    local payload="$2"
+    local i result
+    for i in {1..30}; do
+        result=$(printf "$payload" | nc "${CLICKHOUSE_HOST}" "${CLICKHOUSE_PORT_TCP_WITH_PROXY}" | head -c250 | grep --text -o -F "$expected")
+        if [ -n "$result" ]; then
+            echo "$result"
+            return 0
+        fi
+        sleep 0.3
+    done
+    return 1
+}
+
+expect_rejection 'client_name does not match' "PROXY TCP4 255.255.255.255 255.255.255.255 65535 65535\r\n\0\21ClickHouse client\24\r\253\251\3\0\7default\0\4\1\0\1\0\0\t0.0.0.0:0\1\6hacker\16hacker-desktop\15Hacker client\24\r\253\251\3\0\1\0\0\0\2\1\25SELECT 'Hello, world'\2\0\247\203\254l\325\\z|\265\254F\275\333\206\342\24\202\24\0\0\0\n\0\0\0\240\1\0\2\377\377\377\377\0\0\0"
+expect_rejection 'version does not match' "PROXY TCP4 255.255.255.255 255.255.255.255 65535 65535\r\n\0\21ClickHouse client\24\r\253\251\3\0\7default\0\4\1\0\1\0\0\t0.0.0.0:0\1\6hacker\16hacker-desktop\21ClickHouse client\20\r\253\251\3\0\1\0\0\0\2\1\25SELECT 'Hello, world'\2\0\247\203\254l\325\\z|\265\254F\275\333\206\342\24\202\24\0\0\0\n\0\0\0\240\1\0\2\377\377\377\377\0\0\0"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/106222
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Fixes a rare flaky failure of `02865_tcp_proxy_query_packet_validation`, reported by @ alexey-milovidov on #106222 ("return code: 1" while the expected output was otherwise produced; 104/104 re-runs with the same randomized settings passed). The failure is unrelated to that PR.

Root cause: the test sends malformed Hello packets to the proxy TCP port and expects the server to reject them. When `validate_tcp_client_information` is on (set in the CI test config), the server rejects the malformed Query packet during parsing, before a query context exists. Per `TCPHandler.cpp` it sends the exception and then closes the connection, because it consumed only part of the packet and the trailing client bytes would be misinterpreted as the next packet. The client (`printf`) has already written those trailing bytes, which the server never reads, so the close produces a TCP RST. The RST can race ahead of `nc` reading the buffered exception, so a single attempt occasionally yields no output, and the last `grep` then exits 1 with the expected line missing.

Fix: wrap each probe in a bounded retry loop that re-sends until the expected rejection message appears. A genuine breakage still fails, because every attempt yields empty output and the diff against the reference does not match. The reference file and the assertions are unchanged; the fix is in the test only.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.648`
<!-- ch-version-info:end -->