### PR TITLE
Fix server crash on DeltaLake write with mismatched columns

### DIFF
--- a/src/Storages/ObjectStorage/DataLakes/DeltaLake/WriteTransaction.cpp
+++ b/src/Storages/ObjectStorage/DataLakes/DeltaLake/WriteTransaction.cpp
@@ -33,6 +33,7 @@ namespace DB::ErrorCodes
     extern const int LOGICAL_ERROR;
     extern const int UNKNOWN_EXCEPTION;
     extern const int NOT_IMPLEMENTED;
+    extern const int INCOMPATIBLE_COLUMNS;
 }
 
 namespace DeltaLake
@@ -217,9 +218,11 @@ void WriteTransaction::validateSchema(const DB::Block & header) const
     auto header_column_names = header.getNamesAndTypesList().getNameSet();
     if (write_column_names != header_column_names)
     {
+        /// Reachable from user input (e.g. Nested subcolumns, explicit column subsets),
+        /// so this is a user error, not an internal invariant violation.
         throw DB::Exception(
-            DB::ErrorCodes::LOGICAL_ERROR,
-            "Header does not match write schema. Expected: {}, got: {}",
+            DB::ErrorCodes::INCOMPATIBLE_COLUMNS,
+            "Inserted columns do not match the DeltaLake table schema. Expected: {}, got: {}",
             fmt::join(write_column_names, ", "), fmt::join(header_column_names, ", "));
     }
 }

--- a/tests/integration/test_storage_delta/test.py
+++ b/tests/integration/test_storage_delta/test.py
@@ -4055,6 +4055,63 @@ def test_write_column_order(started_cluster):
     assert num_rows * 2 == int(instance.query(f"SELECT count() FROM {table_name}"))
 
 
+def test_write_schema_mismatch_raises_user_error(started_cluster):
+    instance = started_cluster.instances["node1"]
+    table_name = randomize_table_name("test_write_schema_mismatch")
+
+    # Case 1: a Nested column declared in the table definition flattens to
+    # subcolumns (c0.c1), which do not match the table-level write schema (c0).
+    nested_file = f"/var/lib/clickhouse/user_files/{table_name}_nested"
+    nested_type = pa.list_(pa.struct([("c1", pa.int32())]))
+    nested_schema = pa.schema([("c0", nested_type)])
+    write_deltalake(
+        f"file:///{nested_file}",
+        pa.Table.from_arrays([pa.array([], type=nested_type)], schema=nested_schema),
+        mode="overwrite",
+    )
+    LocalUploader(instance).upload_directory(f"/{nested_file}/", f"/{nested_file}/")
+
+    nested_table = randomize_table_name("nested")
+    instance.query(
+        f"CREATE TABLE {nested_table} (c0 Nested(c1 Int32)) "
+        f"ENGINE = DeltaLakeLocal('/{nested_file}') "
+        f"SETTINGS output_format_parquet_compression_method = 'none'"
+    )
+    error = instance.query_and_get_error(
+        f"INSERT INTO {nested_table} (c0.c1) SELECT [1, 2, 3]"
+    )
+    assert "INCOMPATIBLE_COLUMNS" in error
+    assert "do not match" in error
+
+    # Case 2: explicit structure inserts a subset of the table's columns.
+    subset_file = f"/var/lib/clickhouse/user_files/{table_name}_subset"
+    subset_schema = pa.schema([("c1", pa.int32()), ("c0", pa.int32())])
+    write_deltalake(
+        f"file:///{subset_file}",
+        pa.Table.from_arrays(
+            [pa.array([], type=pa.int32()), pa.array([], type=pa.int32())],
+            schema=subset_schema,
+        ),
+        mode="overwrite",
+    )
+    LocalUploader(instance).upload_directory(f"/{subset_file}/", f"/{subset_file}/")
+
+    error = instance.query_and_get_error(
+        f"INSERT INTO TABLE FUNCTION deltaLakeLocal('/{subset_file}', 'Parquet', 'c0 Int32') (c0) "
+        f"VALUES (1)"
+    )
+    assert "INCOMPATIBLE_COLUMNS" in error
+    assert "do not match" in error
+
+    # Server stays alive: a well-formed write to the same table still works.
+    instance.query(
+        f"INSERT INTO TABLE FUNCTION deltaLakeLocal('/{subset_file}') (c1, c0) VALUES (1, 2)"
+    )
+    assert "1\t2" == instance.query(
+        f"SELECT c1, c0 FROM deltaLakeLocal('/{subset_file}')"
+    ).strip()
+
+
 @pytest.mark.parametrize("column_mapping", ["", "name"])
 def test_type_from_storage_def(started_cluster, column_mapping):
     instance = started_cluster.instances["node1"]


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/87402
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fixed a server crash (`LOGICAL_ERROR`) when inserting into a DeltaLake table with columns that do not match its write schema (for example a `Nested` column that flattens to subcolumns, or a table function with an explicit column subset). Such inserts now fail with a user-facing `INCOMPATIBLE_COLUMNS` error instead. resolves #https://github.com/ClickHouse/ClickHouse/issues/87402


### Description

`DeltaLake::WriteTransaction::validateSchema` rejected a column-name mismatch with `LOGICAL_ERROR`, which aborts the server in debug and sanitizer builds. The mismatch is reachable from ordinary user SQL, so it is a user error, not an internal invariant violation:

- `c0 Nested(c1 Int32)` in the table definition flattens to header column `c0.c1`, which does not match the Delta schema column `c0`;
- a table function with `structure = 'c0 Int32'` lists a subset of a `c1, c0` table's columns.

The write must still be rejected (the schema genuinely differs); only the error class was wrong. It is now `INCOMPATIBLE_COLUMNS`, matching `StorageFile`, `StorageTableFunction` and `MergeTreeData`. Both the plain and partitioned DeltaLake sinks call `validateSchema`, so the single change covers both. Added an integration test for both shapes plus a well-formed write that still succeeds.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.808`
<!-- ch-version-info:end -->