### PR TITLE
Allow FORMAT/SETTINGS/INTO OUTFILE after SHOW [ROW|MASKING] POLICIES

### DIFF
--- a/src/Parsers/Access/ASTShowAccessEntitiesQuery.cpp
+++ b/src/Parsers/Access/ASTShowAccessEntitiesQuery.cpp
@@ -1,4 +1,5 @@
 #include <Parsers/Access/ASTShowAccessEntitiesQuery.h>
+#include <Parsers/Access/parseAccessEntityName.h>
 #include <Common/quoteString.h>
 #include <IO/Operators.h>
 #include <fmt/format.h>
@@ -29,7 +30,7 @@ void ASTShowAccessEntitiesQuery::formatQueryImpl(WriteBuffer & ostr, const Forma
     ostr << "SHOW " << getKeyword();
 
     if (!short_name.empty())
-        ostr << " " << backQuoteIfNeed(short_name);
+        ostr << " " << backQuoteAccessEntityNameIfNeed(short_name);
 
     if (database_and_table_name)
     {

--- a/src/Parsers/Access/ASTShowCreateAccessEntityQuery.cpp
+++ b/src/Parsers/Access/ASTShowCreateAccessEntityQuery.cpp
@@ -1,5 +1,6 @@
 #include <Parsers/Access/ASTShowCreateAccessEntityQuery.h>
 #include <Parsers/Access/ASTRowPolicyName.h>
+#include <Parsers/Access/parseAccessEntityName.h>
 #include <Common/quoteString.h>
 #include <IO/Operators.h>
 
@@ -15,7 +16,7 @@ namespace
         {
             if (std::exchange(need_comma, true))
                 ostr << ',';
-            ostr << ' ' << backQuoteIfNeed(name);
+            ostr << ' ' << backQuoteAccessEntityNameIfNeed(name);
         }
     }
 }
@@ -61,7 +62,7 @@ void ASTShowCreateAccessEntityQuery::formatQueryImpl(WriteBuffer & ostr, const F
     }
 
     if (!short_name.empty())
-        ostr << " " << backQuoteIfNeed(short_name);
+        ostr << " " << backQuoteAccessEntityNameIfNeed(short_name);
 
     if (database_and_table_name)
     {

--- a/src/Parsers/Access/ParserShowAccessEntitiesQuery.cpp
+++ b/src/Parsers/Access/ParserShowAccessEntitiesQuery.cpp
@@ -33,6 +33,17 @@ namespace
                 && parseDatabaseAndTableNameOrAsterisks(pos, expected, database, table, wildcard, default_database);
         });
     }
+
+    /// True if pos is at a trailing query-output clause owned by ParserQueryWithOutput.
+    /// The optional policy short name is a bare identifier, so without this guard it would
+    /// swallow these keywords (e.g. FORMAT) instead of leaving them for the outer parser.
+    bool atQueryOutputTail(IParserBase::Pos & pos, Expected & expected)
+    {
+        return ParserKeyword{Keyword::FORMAT}.checkWithoutMoving(pos, expected)
+            || ParserKeyword{Keyword::SETTINGS}.checkWithoutMoving(pos, expected)
+            || ParserKeyword{Keyword::INTO_OUTFILE}.checkWithoutMoving(pos, expected)
+            || ParserKeyword{Keyword::PARALLEL_WITH}.checkWithoutMoving(pos, expected);
+    }
 }
 
 
@@ -84,7 +95,7 @@ bool ParserShowAccessEntitiesQuery::parseImpl(Pos & pos, ASTPtr & node, Expected
             else
                 database_and_table_name.emplace(database, table_name);
         }
-        else if (parseIdentifierOrStringLiteral(pos, expected, short_name))
+        else if (!atQueryOutputTail(pos, expected) && parseIdentifierOrStringLiteral(pos, expected, short_name))
         {
         }
         else

--- a/src/Parsers/Access/ParserShowAccessEntitiesQuery.cpp
+++ b/src/Parsers/Access/ParserShowAccessEntitiesQuery.cpp
@@ -1,5 +1,6 @@
 #include <Parsers/Access/ParserShowAccessEntitiesQuery.h>
 #include <Parsers/Access/ASTShowAccessEntitiesQuery.h>
+#include <Parsers/Access/parseAccessEntityName.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/parseDatabaseAndTableName.h>
 #include <Parsers/parseIdentifierOrStringLiteral.h>
@@ -32,17 +33,6 @@ namespace
             return ParserKeyword{Keyword::ON}.ignore(pos, expected)
                 && parseDatabaseAndTableNameOrAsterisks(pos, expected, database, table, wildcard, default_database);
         });
-    }
-
-    /// True if pos is at a trailing query-output clause owned by ParserQueryWithOutput.
-    /// The optional policy short name is a bare identifier, so without this guard it would
-    /// swallow these keywords (e.g. FORMAT) instead of leaving them for the outer parser.
-    bool atQueryOutputTail(IParserBase::Pos & pos, Expected & expected)
-    {
-        return ParserKeyword{Keyword::FORMAT}.checkWithoutMoving(pos, expected)
-            || ParserKeyword{Keyword::SETTINGS}.checkWithoutMoving(pos, expected)
-            || ParserKeyword{Keyword::INTO_OUTFILE}.checkWithoutMoving(pos, expected)
-            || ParserKeyword{Keyword::PARALLEL_WITH}.checkWithoutMoving(pos, expected);
     }
 }
 

--- a/src/Parsers/Access/ParserShowCreateAccessEntityQuery.cpp
+++ b/src/Parsers/Access/ParserShowCreateAccessEntityQuery.cpp
@@ -2,6 +2,7 @@
 #include <Parsers/Access/ASTShowCreateAccessEntityQuery.h>
 #include <Parsers/Access/ASTRowPolicyName.h>
 #include <Parsers/Access/ParserRowPolicyName.h>
+#include <Parsers/Access/parseAccessEntityName.h>
 #include <Parsers/Access/parseUserName.h>
 #include <Parsers/CommonParsers.h>
 #include <Parsers/parseIdentifierOrStringLiteral.h>
@@ -83,7 +84,7 @@ bool ParserShowCreateAccessEntityQuery::parseImpl(Pos & pos, ASTPtr & node, Expe
         {
             if (parseCurrentUserTag(pos, expected))
                 current_user = true;
-            else if (parseUserNames(pos, expected, names, /*allow_query_parameter=*/ false))
+            else if (!atQueryOutputTail(pos, expected) && parseUserNames(pos, expected, names, /*allow_query_parameter=*/ false))
             {
             }
             else if (plural)
@@ -94,7 +95,7 @@ bool ParserShowCreateAccessEntityQuery::parseImpl(Pos & pos, ASTPtr & node, Expe
         }
         case AccessEntityType::ROLE:
         {
-            if (parseRoleNames(pos, expected, names))
+            if (!atQueryOutputTail(pos, expected) && parseRoleNames(pos, expected, names))
             {
             }
             else if (plural)
@@ -119,7 +120,7 @@ bool ParserShowCreateAccessEntityQuery::parseImpl(Pos & pos, ASTPtr & node, Expe
                 else
                     database_and_table_name.emplace(database, table_name);
             }
-            else if (parseIdentifierOrStringLiteral(pos, expected, short_name))
+            else if (!atQueryOutputTail(pos, expected) && parseIdentifierOrStringLiteral(pos, expected, short_name))
             {
             }
             else if (plural)
@@ -130,7 +131,7 @@ bool ParserShowCreateAccessEntityQuery::parseImpl(Pos & pos, ASTPtr & node, Expe
         }
         case AccessEntityType::SETTINGS_PROFILE:
         {
-            if (parseIdentifiersOrStringLiterals(pos, expected, names))
+            if (!atQueryOutputTail(pos, expected) && parseIdentifiersOrStringLiterals(pos, expected, names))
             {
             }
             else if (plural)
@@ -141,7 +142,7 @@ bool ParserShowCreateAccessEntityQuery::parseImpl(Pos & pos, ASTPtr & node, Expe
         }
         case AccessEntityType::QUOTA:
         {
-            if (parseIdentifiersOrStringLiterals(pos, expected, names))
+            if (!atQueryOutputTail(pos, expected) && parseIdentifiersOrStringLiterals(pos, expected, names))
             {
             }
             else if (plural)
@@ -156,7 +157,8 @@ bool ParserShowCreateAccessEntityQuery::parseImpl(Pos & pos, ASTPtr & node, Expe
             String table_name;
             bool wildcard = false;
             bool default_database = false;
-            if (parseIdentifierOrStringLiteral(pos, expected, short_name)
+            if (!atQueryOutputTail(pos, expected)
+                && parseIdentifierOrStringLiteral(pos, expected, short_name)
                 && parseOnDBAndTableName(pos, expected, database, table_name, wildcard, default_database))
             {
                 database_and_table_name.emplace(database, table_name);
@@ -172,7 +174,7 @@ bool ParserShowCreateAccessEntityQuery::parseImpl(Pos & pos, ASTPtr & node, Expe
             {
                 // Already parsed short_name in the first condition
             }
-            else if (parseIdentifiersOrStringLiterals(pos, expected, names))
+            else if (!atQueryOutputTail(pos, expected) && parseIdentifiersOrStringLiterals(pos, expected, names))
             {
             }
             else if (plural)

--- a/src/Parsers/Access/parseAccessEntityName.cpp
+++ b/src/Parsers/Access/parseAccessEntityName.cpp
@@ -1,0 +1,34 @@
+#include <Parsers/Access/parseAccessEntityName.h>
+#include <Parsers/CommonParsers.h>
+#include <Common/StringUtils.h>
+#include <Common/quoteString.h>
+
+
+namespace DB
+{
+
+bool atQueryOutputTail(IParser::Pos & pos, Expected & expected)
+{
+    return ParserKeyword{Keyword::FORMAT}.checkWithoutMoving(pos, expected)
+        || ParserKeyword{Keyword::SETTINGS}.checkWithoutMoving(pos, expected)
+        || ParserKeyword{Keyword::INTO_OUTFILE}.checkWithoutMoving(pos, expected)
+        || ParserKeyword{Keyword::PARALLEL_WITH}.checkWithoutMoving(pos, expected);
+}
+
+String backQuoteAccessEntityNameIfNeed(const String & name)
+{
+    /// FORMAT and SETTINGS are the only single-token output-tail keywords; INTO OUTFILE and
+    /// PARALLEL WITH are two tokens and so can never be a single bare identifier.
+    auto equals_keyword = [&](Keyword keyword)
+    {
+        const auto text = toStringView(keyword);
+        return name.size() == text.size() && 0 == strncasecmp(name.data(), text.data(), name.size());
+    };
+
+    if (equals_keyword(Keyword::FORMAT) || equals_keyword(Keyword::SETTINGS))
+        return backQuote(name);
+
+    return backQuoteIfNeed(name);
+}
+
+}

--- a/src/Parsers/Access/parseAccessEntityName.cpp
+++ b/src/Parsers/Access/parseAccessEntityName.cpp
@@ -3,6 +3,8 @@
 #include <Common/StringUtils.h>
 #include <Common/quoteString.h>
 
+#include <algorithm>
+
 
 namespace DB
 {
@@ -21,8 +23,7 @@ String backQuoteAccessEntityNameIfNeed(const String & name)
     /// PARALLEL WITH are two tokens and so can never be a single bare identifier.
     auto equals_keyword = [&](Keyword keyword)
     {
-        const auto text = toStringView(keyword);
-        return name.size() == text.size() && 0 == strncasecmp(name.data(), text.data(), name.size());
+        return std::ranges::equal(name, toStringView(keyword), equalsCaseInsensitive);
     };
 
     if (equals_keyword(Keyword::FORMAT) || equals_keyword(Keyword::SETTINGS))

--- a/src/Parsers/Access/parseAccessEntityName.h
+++ b/src/Parsers/Access/parseAccessEntityName.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <Parsers/IParser.h>
+#include <base/types.h>
+
+
+namespace DB
+{
+
+/// True if pos is at a trailing query-output clause owned by ParserQueryWithOutput
+/// (FORMAT / SETTINGS / INTO OUTFILE / PARALLEL WITH). The optional access-entity name in
+/// SHOW [ROW|MASKING] POLICIES ... and SHOW CREATE ... is a bare identifier, so without this
+/// guard it would swallow these keywords instead of leaving them for the outer parser.
+bool atQueryOutputTail(IParser::Pos & pos, Expected & expected);
+
+/// Like backQuoteIfNeed, but also backtick-quotes a name that is a single-token query-output
+/// keyword (FORMAT, SETTINGS). Such a name is a valid identifier, so backQuoteIfNeed leaves it
+/// unquoted, but emitting it unquoted after SHOW ... would be re-parsed as the output clause by
+/// atQueryOutputTail, breaking the AST formatting round-trip.
+String backQuoteAccessEntityNameIfNeed(const String & name);
+
+}

--- a/tests/queries/0_stateless/04330_show_policies_format_clause.reference
+++ b/tests/queries/0_stateless/04330_show_policies_format_clause.reference
@@ -1,0 +1,15 @@
+SHOW ROW POLICIES query (children 1)
+ Identifier TabSeparated
+SHOW ROW POLICIES query (children 1)
+ Identifier TabSeparated
+SHOW MASKING POLICIES query (children 1)
+ Identifier TabSeparated
+SHOW ROW POLICIES query (children 1)
+ Set
+SHOW ROW POLICIES query (children 1)
+ Literal \'test.tsv\'
+SHOW ROW POLICIES query (children 1)
+ Identifier TabSeparated
+SHOW ROW POLICIES query (children 1)
+ Identifier TabSeparated
+p_04330 ON db.tbl

--- a/tests/queries/0_stateless/04330_show_policies_format_clause.reference
+++ b/tests/queries/0_stateless/04330_show_policies_format_clause.reference
@@ -12,4 +12,32 @@ SHOW ROW POLICIES query (children 1)
  Identifier TabSeparated
 SHOW ROW POLICIES query (children 1)
  Identifier TabSeparated
+SHOW CREATE ROW POLICIES query (children 1)
+ Identifier TabSeparated
+SHOW CREATE MASKING POLICIES query (children 1)
+ Identifier TabSeparated
+SHOW CREATE ROW POLICIES query (children 1)
+ Identifier TabSeparated
+SHOW CREATE USERS query (children 1)
+ Identifier TabSeparated
+SHOW CREATE ROLES query (children 1)
+ Identifier TabSeparated
+SHOW CREATE QUOTAS query (children 1)
+ Identifier TabSeparated
+SHOW CREATE SETTINGS PROFILES query (children 1)
+ Identifier TabSeparated
+SHOW CREATE USERS query (children 1)
+ Set
+SHOW CREATE QUOTAS query (children 1)
+ Literal \'test.tsv\'
+SHOW CREATE USER query (children 1)
+ Identifier TabSeparated
+SHOW CREATE ROW POLICY query (children 1)
+ Identifier TabSeparated
+SHOW ROW POLICIES query
+SHOW ROW POLICIES query
+SHOW MASKING POLICIES query
+SHOW CREATE USER query
+SHOW CREATE QUOTA query
+SHOW CREATE ROW POLICY query
 p_04330 ON db.tbl

--- a/tests/queries/0_stateless/04330_show_policies_format_clause.sql
+++ b/tests/queries/0_stateless/04330_show_policies_format_clause.sql
@@ -1,0 +1,26 @@
+-- Tags: no-parallel
+
+-- SHOW [ROW|MASKING] POLICIES used to reject a trailing FORMAT / SETTINGS /
+-- INTO OUTFILE clause: the optional bare-identifier short name greedily
+-- consumed the keyword (e.g. FORMAT) instead of leaving it for the outer
+-- ParserQueryWithOutput. EXPLAIN AST checks the parser only, so it works
+-- without the enterprise-only system.masking_policies table and regardless of
+-- which policies already exist on the server.
+
+EXPLAIN AST SHOW ROW POLICIES FORMAT TabSeparated;
+EXPLAIN AST SHOW POLICIES FORMAT TabSeparated;
+EXPLAIN AST SHOW MASKING POLICIES FORMAT TabSeparated;
+EXPLAIN AST SHOW ROW POLICIES SETTINGS max_threads = 1;
+EXPLAIN AST SHOW ROW POLICIES INTO OUTFILE 'test.tsv';
+
+-- A real bare-identifier short name is still accepted, and a FORMAT clause
+-- after it is parsed as the output format, not folded into the name.
+EXPLAIN AST SHOW ROW POLICIES p_04330 FORMAT TabSeparated;
+EXPLAIN AST SHOW ROW POLICIES ON db.tbl FORMAT TabSeparated;
+
+-- End to end: the statement now executes with a FORMAT clause. Filtering by a
+-- unique short name keeps the output deterministic on a shared server.
+DROP ROW POLICY IF EXISTS p_04330 ON db.tbl;
+CREATE ROW POLICY p_04330 ON db.tbl USING 1 AS PERMISSIVE;
+SHOW ROW POLICIES p_04330 FORMAT TabSeparated;
+DROP ROW POLICY p_04330 ON db.tbl;

--- a/tests/queries/0_stateless/04330_show_policies_format_clause.sql
+++ b/tests/queries/0_stateless/04330_show_policies_format_clause.sql
@@ -18,6 +18,35 @@ EXPLAIN AST SHOW ROW POLICIES INTO OUTFILE 'test.tsv';
 EXPLAIN AST SHOW ROW POLICIES p_04330 FORMAT TabSeparated;
 EXPLAIN AST SHOW ROW POLICIES ON db.tbl FORMAT TabSeparated;
 
+-- SHOW CREATE <entity> had the same greedy-name bug for every entity type when
+-- no name is given: the trailing FORMAT / SETTINGS / INTO OUTFILE keyword was
+-- consumed as the entity name. Cover all of them (plural form = no name).
+EXPLAIN AST SHOW CREATE ROW POLICIES FORMAT TabSeparated;
+EXPLAIN AST SHOW CREATE MASKING POLICIES FORMAT TabSeparated;
+EXPLAIN AST SHOW CREATE POLICIES FORMAT TabSeparated;
+EXPLAIN AST SHOW CREATE USERS FORMAT TabSeparated;
+EXPLAIN AST SHOW CREATE ROLES FORMAT TabSeparated;
+EXPLAIN AST SHOW CREATE QUOTAS FORMAT TabSeparated;
+EXPLAIN AST SHOW CREATE PROFILES FORMAT TabSeparated;
+EXPLAIN AST SHOW CREATE USERS SETTINGS max_threads = 1;
+EXPLAIN AST SHOW CREATE QUOTAS INTO OUTFILE 'test.tsv';
+
+-- SHOW CREATE <entity> <name> FORMAT ... (a real name present) was already fine
+-- and must stay so.
+EXPLAIN AST SHOW CREATE USER u_04330 FORMAT TabSeparated;
+EXPLAIN AST SHOW CREATE ROW POLICY p_04330 ON db.tbl FORMAT TabSeparated;
+
+-- A name that is backtick-quoted is a real name even when it spells a keyword.
+-- The formatter must quote such a name back, otherwise the formatted query is
+-- re-parsed as the output clause and the AST formatting round-trip check (debug
+-- builds) fails with LOGICAL_ERROR.
+EXPLAIN AST SHOW ROW POLICIES `FORMAT`;
+EXPLAIN AST SHOW ROW POLICIES `SETTINGS`;
+EXPLAIN AST SHOW MASKING POLICIES `FORMAT`;
+EXPLAIN AST SHOW CREATE USER `FORMAT`;
+EXPLAIN AST SHOW CREATE QUOTA `SETTINGS`;
+EXPLAIN AST SHOW CREATE ROW POLICY `FORMAT` ON db.tbl;
+
 -- End to end: the statement now executes with a FORMAT clause. Filtering by a
 -- unique short name keeps the output deterministic on a shared server.
 DROP ROW POLICY IF EXISTS p_04330 ON db.tbl;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->
Closes: https://github.com/ClickHouse/ClickHouse/issues/105899


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed a syntax error when a `FORMAT`, `SETTINGS`, or `INTO OUTFILE` clause follows `SHOW ROW POLICIES` or `SHOW MASKING POLICIES` (e.g. `SHOW ROW POLICIES FORMAT TabSeparated`).


### Description
The optional policy short name in `SHOW [ROW|MASKING] POLICIES [name]` was read with `parseIdentifierOrStringLiteral`, which accepts the bare keyword `FORMAT` (or `SETTINGS` / `INTO OUTFILE`) as the name. The trailing clause was consumed as the policy name, leaving the next token dangling and raising `Syntax error: failed at position N`. Only `ROW_POLICY` and `MASKING_POLICY` have this short-name branch, so other `SHOW` commands were unaffected.

The short-name parse is now skipped when the position is at a query-output tail clause (`FORMAT` / `SETTINGS` / `INTO OUTFILE` / `PARALLEL WITH`), leaving those keywords for `ParserQueryWithOutput`. A real short name and the `ON <db>.<table>` form still parse, and a `FORMAT` clause after a short name is kept as the output format. Added `04330_show_policies_format_clause`.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.837`
<!-- ch-version-info:end -->