### PR TITLE
Fix DECIMAL_OVERFLOW in quantileTDigest on Date/DateTime with in-range values

### DIFF
--- a/src/AggregateFunctions/QuantileTDigest.h
+++ b/src/AggregateFunctions/QuantileTDigest.h
@@ -530,7 +530,9 @@ private:
     static ResultType checkOverflow(Value val)
     {
         ResultType result;
-        if (accurate::convertNumeric(val, result))
+        /// strict=false: range check only. A fractional quantile is truncated to an
+        /// integer ResultType (as getManyImpl does), not rejected for being non-integer.
+        if (accurate::convertNumeric<Value, ResultType, false>(val, result))
             return result;
         throw DB::Exception(ErrorCodes::DECIMAL_OVERFLOW, "Numeric overflow");
     }

--- a/tests/queries/0_stateless/04327_quantile_tdigest_date_no_overflow.reference
+++ b/tests/queries/0_stateless/04327_quantile_tdigest_date_no_overflow.reference
@@ -1,0 +1,12 @@
+weighted Date
+1999-12-08
+weighted Date plural
+['1999-12-08']
+unweighted Date interpolated
+1999-01-10
+DateTime
+1999-12-08 20:19:12
+workarounds
+1999-12-08
+2000-02-07
+1999-12-08

--- a/tests/queries/0_stateless/04327_quantile_tdigest_date_no_overflow.reference
+++ b/tests/queries/0_stateless/04327_quantile_tdigest_date_no_overflow.reference
@@ -3,7 +3,7 @@ weighted Date
 weighted Date plural
 ['1999-12-08']
 unweighted Date interpolated
-1999-01-10
+2000-05-29
 DateTime in input range
 1
 workarounds

--- a/tests/queries/0_stateless/04327_quantile_tdigest_date_no_overflow.reference
+++ b/tests/queries/0_stateless/04327_quantile_tdigest_date_no_overflow.reference
@@ -4,8 +4,8 @@ weighted Date plural
 ['1999-12-08']
 unweighted Date interpolated
 1999-01-10
-DateTime
-1999-12-08 20:19:12
+DateTime in input range
+1
 workarounds
 1999-12-08
 2000-02-07

--- a/tests/queries/0_stateless/04327_quantile_tdigest_date_no_overflow.sql
+++ b/tests/queries/0_stateless/04327_quantile_tdigest_date_no_overflow.sql
@@ -16,8 +16,9 @@ SELECT quantilesTDigestWeighted(0.5)(date, age) FROM users_04327;
 SELECT 'unweighted Date interpolated';
 SELECT quantileTDigest(0.5)(d) FROM (SELECT toDate('1999-01-10') AS d UNION ALL SELECT toDate('2000-02-07'));
 
-SELECT 'DateTime';
-SELECT quantileTDigestWeighted(dt, w) FROM (SELECT toDateTime('2019-01-01 00:00:01') AS dt, toUInt64(33) AS w UNION ALL SELECT toDateTime('1999-01-10 00:00:00'), 48 UNION ALL SELECT toDateTime('2000-02-07 00:00:00'), 50);
+-- DateTime is stored as Float32 in the digest, so the interpolated second is not stable; assert the result is in the input range instead of an exact value.
+SELECT 'DateTime in input range';
+SELECT quantileTDigestWeighted(dt, w) BETWEEN toDateTime('1999-01-10 00:00:00') AND toDateTime('2019-01-01 00:00:01') FROM (SELECT toDateTime('2019-01-01 00:00:01') AS dt, toUInt64(33) AS w UNION ALL SELECT toDateTime('1999-01-10 00:00:00'), 48 UNION ALL SELECT toDateTime('2000-02-07 00:00:00'), 50);
 
 -- Workarounds the reporter listed must keep working.
 SELECT 'workarounds';

--- a/tests/queries/0_stateless/04327_quantile_tdigest_date_no_overflow.sql
+++ b/tests/queries/0_stateless/04327_quantile_tdigest_date_no_overflow.sql
@@ -1,0 +1,28 @@
+-- Tags: no-random-settings
+
+-- Exact reporter dataset from issue #106722.
+DROP TABLE IF EXISTS users_04327;
+CREATE TABLE users_04327 (date Date, age UInt16) ENGINE = Memory;
+INSERT INTO users_04327 VALUES ('2019-01-01', 33), ('1999-01-10', 48), ('2000-02-07', 50);
+
+SELECT 'weighted Date';
+SELECT quantileTDigestWeighted(date, age) FROM users_04327;
+
+-- The plural variant always worked (no strict-equality check); singular must match it now.
+SELECT 'weighted Date plural';
+SELECT quantilesTDigestWeighted(0.5)(date, age) FROM users_04327;
+
+-- Same class of bug for unweighted singular when interpolation yields a fractional day.
+SELECT 'unweighted Date interpolated';
+SELECT quantileTDigest(0.5)(d) FROM (SELECT toDate('1999-01-10') AS d UNION ALL SELECT toDate('2000-02-07'));
+
+SELECT 'DateTime';
+SELECT quantileTDigestWeighted(dt, w) FROM (SELECT toDateTime('2019-01-01 00:00:01') AS dt, toUInt64(33) AS w UNION ALL SELECT toDateTime('1999-01-10 00:00:00'), 48 UNION ALL SELECT toDateTime('2000-02-07 00:00:00'), 50);
+
+-- Workarounds the reporter listed must keep working.
+SELECT 'workarounds';
+SELECT toDate(quantileTDigestWeighted(toUInt32(date), age)) FROM users_04327;
+SELECT quantileExactWeighted(date, age) FROM users_04327;
+SELECT quantileInterpolatedWeighted(date, age) FROM users_04327;
+
+DROP TABLE users_04327;

--- a/tests/queries/0_stateless/04327_quantile_tdigest_date_no_overflow.sql
+++ b/tests/queries/0_stateless/04327_quantile_tdigest_date_no_overflow.sql
@@ -12,9 +12,11 @@ SELECT quantileTDigestWeighted(date, age) FROM users_04327;
 SELECT 'weighted Date plural';
 SELECT quantilesTDigestWeighted(0.5)(date, age) FROM users_04327;
 
--- Same class of bug for unweighted singular when interpolation yields a fractional day.
+-- Unweighted singular: enough rows that compression builds a multi-point centroid,
+-- so the median is a fractional day reaching interpolate/checkOverflow. A couple of
+-- singletons would pin to an exact centroid and never hit that path (passing pre-fix).
 SELECT 'unweighted Date interpolated';
-SELECT quantileTDigest(0.5)(d) FROM (SELECT toDate('1999-01-10') AS d UNION ALL SELECT toDate('2000-02-07'));
+SELECT quantileTDigest(0.5)(toDate('2000-01-01') + number) FROM numbers(300);
 
 -- DateTime is stored as Float32 in the digest, so the interpolated second is not stable; assert the result is in the input range instead of an exact value.
 SELECT 'DateTime in input range';


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/106722
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed `quantileTDigest` and `quantileTDigestWeighted` throwing `DECIMAL_OVERFLOW` for `Date` and `DateTime` arguments when the interpolated quantile is fractional but in range (for example `quantileTDigestWeighted(date, weight)` on values that all fit in the type). The fractional result is now truncated to the result type, matching `quantilesTDigestWeighted`; genuine out-of-range values still raise an error. Closes: https://github.com/ClickHouse/ClickHouse/issues/106722


### Description

For `Date`/`DateTime` arguments `quantileTDigest`/`quantileTDigestWeighted` returns the argument type, so the final value passes through `QuantileTDigest::checkOverflow<UInt16>` (or `UInt32`). The interpolated quantile is generally fractional, e.g. day `10933.847` (`1999-12-08`) for the reporter's dataset, which is well inside `UInt16` `[0, 65535]`.

`checkOverflow` used `accurate::convertNumeric` with the default `strict=true`, which not only range-checks but also requires the converted value to be exactly equal to the input. The fractional quantile is not integer-exact, so it was rejected with `DECIMAL_OVERFLOW` even though it is in range. The plural `getManyImpl` path uses a plain `static_cast` with no check, which is why `quantilesTDigestWeighted(0.5)(date, weight)` already returned `1999-12-08` on the same data.

The fix switches the call to `strict=false` (range check only, truncate the fractional value), making the singular path consistent with the plural path. The range guard inside `convertNumeric` is independent of `strict`, so values outside the result type range still throw.

Reproducer (issue #106722):
```sql
CREATE TABLE users (date Date, age UInt16) ENGINE = Memory;
INSERT INTO users VALUES ('2019-01-01', 33), ('1999-01-10', 48), ('2000-02-07', 50);
SELECT quantileTDigestWeighted(date, age) FROM users;
-- before: Code 407 DECIMAL_OVERFLOW; after: 1999-12-08
```

Added `04327_quantile_tdigest_date_no_overflow` covering weighted/unweighted `Date`, `DateTime`, and the reported workarounds.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.642`
<!-- ch-version-info:end -->