### PR TITLE
Fix text index direct read losing NULL semantics for Nullable columns

### DIFF
--- a/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
+++ b/src/Processors/QueryPlan/Optimizations/optimizeDirectReadFromTextIndex.cpp
@@ -2,8 +2,10 @@
 #include <Columns/ColumnConst.h>
 #include <Common/FieldVisitorToString.h>
 #include <Common/assert_cast.h>
+#include <DataTypes/DataTypeNullable.h>
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/DataTypesNumber.h>
+#include <DataTypes/IDataType.h>
 #include <Common/logger_useful.h>
 #include <Common/quoteString.h>
 #include <DataTypes/DataTypeArray.h>
@@ -519,13 +521,72 @@ private:
             return lhs.virtual_column_name < rhs.virtual_column_name;
         });
 
+        /// Source haystack (non-const Nullable arg) captured before preprocessing; the UInt8 vc drops its NULL.
+        const ActionsDAG::Node * original_haystack = nullptr;
+        for (const auto * child : function_node.children)
+        {
+            if ((!child->column || !isColumnConst(*child->column)) && isNullableOrLowCardinalityNullable(child->result_type))
+            {
+                original_haystack = child;
+                break;
+            }
+        }
+        DataTypePtr original_result_type = function_node.result_type;
+
         if (need_transform_function)
             processTextIndexFunction(replacement, selected_conditions, context);
 
-        if (direct_read_from_text_index)
-            replaceFunctionsToVirtualColumns(replacement, selected_conditions, virtual_column_to_node, context);
+        /// A preprocessor that can turn a non-NULL source row into NULL (e.g. nullIf(str, '')) is invisible
+        /// to the source-keyed null map, so materialized vs unmaterialized parts diverge; disable direct read.
+        if (direct_read_from_text_index && !preprocessorCanIntroduceNullOnNullableHaystack(function_name, selected_conditions, original_haystack))
+            replaceFunctionsToVirtualColumns(replacement, selected_conditions, function_name, original_haystack, original_result_type, virtual_column_to_node, context);
 
         return replacement;
+    }
+
+    /// Nullable haystack whose preprocessor can synthesize NULL from a non-NULL source value. Scoped to
+    /// preprocessor-rewritten functions; raw-string siblings read the source value and keep direct read.
+    bool preprocessorCanIntroduceNullOnNullableHaystack(
+        const String & function_name,
+        const std::vector<SelectedCondition> & selected_conditions,
+        const ActionsDAG::Node * original_haystack) const
+    {
+        if (!original_haystack || !needApplyPreprocessor(function_name))
+            return false;
+
+        for (const auto & condition : selected_conditions)
+        {
+            if (condition.search_query->getDirectReadMode() == TextIndexDirectReadMode::None)
+                continue;
+
+            const auto & condition_text = typeid_cast<MergeTreeIndexConditionText &>(*condition.info->index->condition_template->generateUnsubstituted());
+            auto preprocessor = condition_text.getPreprocessor();
+            if (preprocessor && preprocessor->hasActions() && preprocessor->canIntroduceNull())
+                return true;
+        }
+        return false;
+    }
+
+    /// Preprocessor that strips the source nullability (ifNull/coalesce/assumeNotNull), so a source-NULL
+    /// row is 0 (not NULL) on the fallback path. The null-map wrapper below must not reintroduce NULL then.
+    bool preprocessorRemovesNull(
+        const String & function_name,
+        const std::vector<SelectedCondition> & selected_conditions) const
+    {
+        if (!needApplyPreprocessor(function_name))
+            return false;
+
+        for (const auto & condition : selected_conditions)
+        {
+            if (condition.search_query->getDirectReadMode() == TextIndexDirectReadMode::None)
+                continue;
+
+            const auto & condition_text = typeid_cast<MergeTreeIndexConditionText &>(*condition.info->index->condition_template->generateUnsubstituted());
+            auto preprocessor = condition_text.getPreprocessor();
+            if (preprocessor && preprocessor->hasActions() && preprocessor->removesNull())
+                return true;
+        }
+        return false;
     }
 
     /// Applies preprocessor, tokenizer and postprocessor for text-search functions.
@@ -724,6 +785,9 @@ private:
     void replaceFunctionsToVirtualColumns(
         NodeReplacement & replacement,
         const std::vector<SelectedCondition> & all_conditions,
+        const String & original_function_name,
+        const ActionsDAG::Node * original_haystack,
+        const DataTypePtr & original_result_type,
         std::unordered_map<String, const ActionsDAG::Node *> & virtual_column_to_node,
         const ContextPtr & context)
     {
@@ -751,6 +815,12 @@ private:
         if (!has_materialized_index)
             return;
 
+        /// Restore the haystack's NULL below only when the predicate is Nullable and the preprocessor
+        /// does not itself remove NULL (otherwise a source-NULL row is a consistent 0, not NULL).
+        const bool preserve_haystack_null = original_haystack
+            && original_result_type && isNullableOrLowCardinalityNullable(original_result_type)
+            && !preprocessorRemovesNull(original_function_name, all_conditions);
+
         auto add_condition_to_input = [&](const SelectedCondition & condition)
         {
             auto [it, inserted] = virtual_column_to_node.try_emplace(condition.virtual_column_name);
@@ -762,7 +832,12 @@ private:
                 ASTPtr default_expression;
 
                 if (condition.search_query->getDirectReadMode() == TextIndexDirectReadMode::Exact)
+                {
                     default_expression = convertNodeToAST(function_node);
+                    /// UInt8 virtual column cannot hold NULL; coalesce to 0, the outer wrap restores NULL.
+                    if (preserve_haystack_null && default_expression)
+                        default_expression = makeASTFunction("ifNull", default_expression, make_intrusive<ASTLiteral>(Field(0)));
+                }
                 /// Do not execute the default expression for hint mode, because it will be executed anyway in the original predicate.
                 else if (condition.search_query->getDirectReadMode() == TextIndexDirectReadMode::Hint)
                     default_expression = make_intrusive<ASTLiteral>(Field(1));
@@ -796,6 +871,26 @@ private:
                 children.push_back(&function_node);
 
             replacement.node = &actions_dag.addFunction(function_builder, children, "");
+        }
+
+        /// Build if(isNull(haystack), NULL, virtual_column) instead of a plain CAST (all-false null map
+        /// reads NULL rows as genuine 0). Matches f(NULL, ...) = NULL, keeping direct read enabled.
+        if (preserve_haystack_null)
+        {
+            auto is_null_builder = FunctionFactory::instance().get("isNull", context);
+            const auto & is_null_node = actions_dag.addFunction(is_null_builder, {original_haystack}, "");
+
+            auto nullable_uint8 = makeNullable(std::make_shared<DataTypeUInt8>());
+            auto null_column = nullable_uint8->createColumnConstWithDefaultValue(0);
+            const auto & null_node = actions_dag.addColumn(std::move(null_column), nullable_uint8, "NULL");
+
+            /// if() needs both branches to share a type; promote the virtual column to Nullable(UInt8).
+            const auto * value_node = replacement.node;
+            if (!value_node->result_type->equals(*nullable_uint8))
+                value_node = &actions_dag.addCast(*value_node, nullable_uint8, "", context);
+
+            auto if_builder = FunctionFactory::instance().get("if", context);
+            replacement.node = &actions_dag.addFunction(if_builder, {&is_null_node, &null_node, value_node}, "");
         }
 
         /// If the type of original function does not match the type of replacement,

--- a/src/Storages/MergeTree/MergeTreeIndexTextPreprocessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPreprocessor.cpp
@@ -11,6 +11,8 @@
 #include <DataTypes/DataTypeString.h>
 #include <DataTypes/IDataType.h>
 #include <Functions/FunctionFactory.h>
+#include <Functions/IFunction.h>
+#include <Functions/IFunctionAdaptors.h>
 #include <Interpreters/ActionsDAG.h>
 #include <Interpreters/ExpressionActions.h>
 #include <Parsers/ASTFunction.h>
@@ -122,6 +124,108 @@ ActionsDAG createActionsDAGForPreprocessor(
     return actions_dag;
 }
 
+/// Peel pure type-widening wrappers (ALIAS, CAST/_CAST/toNullable) off an ActionsDAG output node.
+/// These functions widen a value to Nullable but can never synthesize NULL from a non-NULL argument
+/// (CAST throws on failure rather than producing NULL), so the effective nullability of the
+/// expression is the nullability of the value underneath them, not the declared outer type. Only
+/// null-synthesizing functions (nullIf, if(..., NULL, ...), *OrNull, accurateCastOrNull, ...) are
+/// left in place. Used both to detect null-INTRODUCING preprocessors (on a non-nullable input) and
+/// null-REMOVING preprocessors (on the real source), so a widened form like
+/// CAST(ifNull(str, ''), 'Nullable(String)') is classified by its inner ifNull rather than the CAST.
+const ActionsDAG::Node * peelWideningWrappers(const ActionsDAG::Node * node)
+{
+    while (node)
+    {
+        if (node->type == ActionsDAG::ActionType::ALIAS && node->children.size() == 1)
+        {
+            node = node->children.front();
+            continue;
+        }
+        if (node->type == ActionsDAG::ActionType::FUNCTION && node->function_base && !node->children.empty()
+            && (node->function_base->getName() == "CAST" || node->function_base->getName() == "_CAST"
+                || node->function_base->getName() == "toNullable"))
+        {
+            node = node->children.front();
+            continue;
+        }
+        break;
+    }
+    return node;
+}
+
+/// A function is null-propagating when it relies on the default Nullable handling
+/// (useDefaultImplementationForNulls() == true): the engine peels the null map off the arguments,
+/// runs the function on the non-NULL values, and re-assembles a result that is NULL exactly where an
+/// argument was NULL. Such a function (lower, upper, concat, substring, ...) can therefore never turn
+/// a non-NULL row into NULL -- it only propagates the nullability of its arguments. Functions that
+/// override this to false (nullIf, if, coalesce, ifNull, *OrNull, accurateCastOrNull, ...) manage
+/// NULLs themselves and may synthesize NULL from non-NULL values. The property lives on IFunction and
+/// is reachable through the FunctionToFunctionBaseAdaptor (same access pattern as KeyCondition.cpp).
+bool functionIsNullPropagating(const ActionsDAG::Node * node)
+{
+    if (!node->function_base)
+        return false;
+    if (const auto * adaptor = typeid_cast<const FunctionToFunctionBaseAdaptor *>(node->function_base.get()))
+        return adaptor->getFunction()->useDefaultImplementationForNulls();
+    return false;
+}
+
+/// True when the expression rooted at `node` can synthesize a NULL from arguments that are all
+/// non-NULL -- the only shape that matters for the direct-read guard, which keys its null map on the
+/// source column and is blind to NULLs the preprocessor invents. Pure type-widening wrappers
+/// (CAST/_CAST/toNullable, ALIAS) widen to Nullable but never synthesize NULL, so they are peeled and
+/// we recurse into their argument. Null-propagating functions (useDefaultImplementationForNulls) can
+/// only pass through the nullability of their arguments, so we recurse into every argument and the
+/// node itself synthesizes nothing. Any remaining node whose result is Nullable manages NULLs itself
+/// (nullIf, if(..., NULL, ...), *OrNull, ...) and is treated as null-synthesizing. Constant/input
+/// nodes synthesize nothing. This distinguishes e.g. lower(toNullable(str)) (propagating -> no
+/// synthesis) from nullIf(str, '') (synthesizes).
+bool expressionCanSynthesizeNull(const ActionsDAG::Node * node)
+{
+    node = peelWideningWrappers(node);
+    if (!node)
+        return false;
+
+    if (node->type == ActionsDAG::ActionType::FUNCTION && functionIsNullPropagating(node))
+    {
+        for (const auto * child : node->children)
+            if (expressionCanSynthesizeNull(child))
+                return true;
+        return false;
+    }
+
+    return isNullableOrLowCardinalityNullable(node->result_type);
+}
+
+/// True when the expression rooted at `node`, applied to the real (possibly Nullable) source column,
+/// maps every source-NULL row to a NON-NULL value -- i.e. it strips the source nullability, so the
+/// rewritten fallback predicate evaluates a source-NULL row to 0 rather than NULL and the direct-read
+/// null-map wrapper must NOT reintroduce NULL for those rows. Pure type-widening wrappers
+/// (CAST/_CAST/toNullable, ALIAS) do not change the actual value, so they are peeled and we recurse
+/// into their argument: CAST(ifNull(str, ''), 'Nullable(String)') removes null iff its inner ifNull
+/// does. A null-propagating function (useDefaultImplementationForNulls) is NULL exactly where an
+/// argument is NULL, so it removes source null iff EVERY argument does -- lower(ifNull(str, ''))
+/// removes null, whereas lower(toNullable(str)) does not. Any other node removes source null iff its
+/// declared result is non-Nullable: ifNull / coalesce / assumeNotNull are non-Nullable (remove), while
+/// a plain Nullable source or a null-synthesizing nullIf stays Nullable (does not). Mirror of
+/// expressionCanSynthesizeNull() with the aggregation inverted (all arguments vs any).
+bool expressionRemovesSourceNull(const ActionsDAG::Node * node)
+{
+    node = peelWideningWrappers(node);
+    if (!node)
+        return false;
+
+    if (node->type == ActionsDAG::ActionType::FUNCTION && functionIsNullPropagating(node) && !node->children.empty())
+    {
+        for (const auto * child : node->children)
+            if (!expressionRemovesSourceNull(child))
+                return false;
+        return true;
+    }
+
+    return !isNullableOrLowCardinalityNullable(node->result_type);
+}
+
 }
 
 MergeTreeIndexTextPreprocessor::MergeTreeIndexTextPreprocessor(ASTPtr expression_ast, const IndexDescription & index_description)
@@ -161,6 +265,44 @@ MergeTreeIndexTextPreprocessor::MergeTreeIndexTextPreprocessor(ASTPtr expression
                 const auto & arg = func->arguments->children.front();
                 is_lower_or_upper = arg->getColumnName() == index_description.column_names.front();
             }
+        }
+
+        /// actions_for_constant runs the preprocessor on a plain non-nullable String, so a Nullable
+        /// output there can only come from the expression itself, not from a Nullable source.
+        ///
+        /// But a Nullable declared type is not enough. Two classes of expression declare Nullable yet
+        /// never turn a non-NULL input into NULL: pure type-widening casts (CAST(str, 'Nullable(...)'),
+        /// toNullable(str)) and null-propagating functions (lower, upper, concat, ... -- anything using
+        /// the default Nullable handling), which only pass through the nullability of their arguments.
+        /// Only functions that synthesize NULL from a non-NULL value (nullIf, if(..., NULL, ...),
+        /// *OrNull, accurateCastOrNull, ...) matter for the direct-read guard, which is blind to NULLs
+        /// the preprocessor invents. So classify the effective expression, not just the declared type:
+        /// e.g. lower(toNullable(str)) is Nullable but only propagates, whereas nullIf(str, '') can
+        /// synthesize (see expressionCanSynthesizeNull).
+        const auto & constant_outputs = actions_for_constant.getActionsDAG().getOutputs();
+        if (!constant_outputs.empty())
+            introduces_null = expressionCanSynthesizeNull(constant_outputs.front());
+
+        /// original_actions runs the preprocessor on the real (possibly Nullable) source column, so its
+        /// output type is the effective post-preprocessor haystack type. When the source is Nullable but
+        /// this output is not (e.g. ifNull(str, ''), coalesce(str, ''), assumeNotNull(str)), the
+        /// preprocessor strips the source nullability: the rewritten fallback predicate evaluates a
+        /// source-NULL row to 0 rather than NULL. The direct-read null-map wrapper keys on the source
+        /// null map, so it must not reintroduce NULL for those rows (see removesNull()).
+        ///
+        /// As with introduces_null, the declared output type alone is not enough: a null-removing
+        /// expression can be wrapped so its outer node stays Nullable yet every source-NULL row still
+        /// maps to a non-NULL value. Two such shapes: a widening cast, e.g.
+        /// CAST(ifNull(str, ''), 'Nullable(String)'), and a null-propagating outer function, e.g.
+        /// lower(CAST(ifNull(str, ''), 'Nullable(String)')) -- lower propagates the (already non-NULL)
+        /// value of its argument, so it removes source null iff the argument does. Classify the
+        /// effective expression the same way introduces_null does (peel widening wrappers, recurse
+        /// through null-propagating functions) rather than inspecting only the outer declared type.
+        if (isNullableOrLowCardinalityNullable(index_column_type) && !original_actions.getActions().empty())
+        {
+            const auto & original_outputs = original_actions.getActionsDAG().getOutputs();
+            if (!original_outputs.empty())
+                removes_null = expressionRemovesSourceNull(original_outputs.front());
         }
     }
 }

--- a/src/Storages/MergeTree/MergeTreeIndexTextPreprocessor.h
+++ b/src/Storages/MergeTree/MergeTreeIndexTextPreprocessor.h
@@ -28,10 +28,30 @@ public:
 
     bool isLowerOrUpper() const { return is_lower_or_upper; }
 
+    /// True when the preprocessor can turn a non-NULL source value into NULL (e.g. nullIf(str, '')).
+    /// Detected from the constant-input actions, which run on a plain non-nullable String, so a
+    /// Nullable output there means the expression itself introduces NULLs rather than just
+    /// propagating a Nullable source. The direct-read optimization keys its null map on the source
+    /// column, so such a preprocessor is invisible to it and direct read must be disabled.
+    bool canIntroduceNull() const { return introduces_null; }
+
+    /// True when the preprocessor strips the source column's nullability, i.e. a Nullable source
+    /// yields a non-Nullable effective haystack (e.g. ifNull(str, ''), coalesce(str, ''),
+    /// assumeNotNull(str)). Detected from the original actions, which run on the real (possibly
+    /// Nullable) source column. When this is true, the rewritten fallback predicate evaluates a
+    /// source-NULL row to 0 rather than NULL, so the direct-read null-map wrapper (keyed on the
+    /// source null map) must NOT reintroduce NULL for those rows.
+    bool removesNull() const { return removes_null; }
+
 private:
     /// True only when the preprocessor is exactly lower/lowerUTF8/upper/upperUTF8 applied
     /// directly to the index column (no nested transformations).
     bool is_lower_or_upper = false;
+    /// True when applying the preprocessor to a non-nullable input yields a Nullable output.
+    bool introduces_null = false;
+    /// True when the source column is Nullable but the preprocessor's effective output is not,
+    /// i.e. the preprocessor removes the source nullability.
+    bool removes_null = false;
     /// The name of the column on which the index is defined.
     String index_column_name;
     /// The type of the column on which the index is defined.

--- a/tests/queries/0_stateless/02346_text_index_bug106922.reference
+++ b/tests/queries/0_stateless/02346_text_index_bug106922.reference
@@ -1,0 +1,170 @@
+Nullable(String)
+-- NOT hasToken: NULL rows (2, 4) must not appear; only row 3 matches
+3
+3
+-- NOT hasAllTokens: only row 3 matches
+3
+3
+-- NOT hasAnyTokens: only row 3 matches
+3
+3
+-- NOT hasPhrase (Hint mode): rows 3 and 5 match, NULL rows excluded
+3
+5
+3
+5
+-- NOT endsWith (Hint mode): rows 3 and 5 match, NULL rows excluded
+3
+5
+3
+5
+-- NOT startsWith (Hint mode): only row 3, NULL rows excluded
+3
+3
+-- NOT LIKE suffix pattern (Hint mode): rows 3 and 5 match, NULL rows excluded
+3
+5
+3
+5
+-- NOT match: only row 3, NULL rows excluded
+3
+3
+-- positive hasPhrase still correct: only row 1
+1
+-- positive hasToken still correct: rows 1 and 5
+1
+5
+-- hasToken IS NULL selects exactly the NULL rows 2 and 4
+2
+4
+-- projection of hasToken keeps NULL for NULL rows
+1	1
+2	\N
+3	0
+4	\N
+5	1
+Nullable(String), all-NULL part
+-- NOT hasToken over an all-NULL part returns no rows (NOT NULL filters every row out)
+0
+0
+LowCardinality(Nullable(String))
+-- NOT hasToken with LowCardinality(Nullable): only row 3
+3
+3
+Nullable(String) with preprocessor = lower(str)
+-- NOT hasToken with preprocessor + Nullable: only row 3
+3
+3
+Nullable(String) with null-producing preprocessor = nullIf(str, \'\')
+-- rows 2 (nullIf -> NULL) and 4 (source NULL) filtered; direct read matches recheck
+3
+3
+Nullable(String) null-producing preprocessor, partially materialized index
+-- empty-string rows (50 old, 100050 new) get the same verdict as recheck
+[]
+[]
+String (non-Nullable) haystack + null-producing preprocessor + nullable needle
+-- direct read stays enabled (haystack is plain String): reads virtual column
+1
+Nullable(String) null-producing preprocessor + raw-string sibling (endsWith) keeps direct read
+-- direct read stays enabled for endsWith (raw-string sibling, not rewritten via preprocessor)
+1
+Nullable(FixedString) type-widening preprocessor CAST(str, Nullable(String)) keeps direct read
+-- NOT hasToken: NULL rows (2, 4) excluded; only row 3 matches; direct read matches recheck
+3
+3
+-- direct read stays enabled for a pure type-widening CAST-to-Nullable preprocessor
+1
+Nullable(String) with ngrams tokenizer, partially materialized index
+-- NOT hasPhrase (ngrams, partially materialized): rows 3 and 5, NULL rows excluded
+3
+5
+3
+5
+-- NOT endsWith (ngrams, partially materialized): rows 3 and 5, NULL rows excluded
+3
+5
+3
+5
+-- NOT LIKE suffix pattern (ngrams, partially materialized): rows 3 and 5, NULL rows excluded
+3
+5
+3
+5
+Map(String, Nullable(String)) with mapValues index
+-- NOT hasToken(m[key]): NULL map values must be excluded; count matches the non-direct-read path
+9968
+9968
+-- NOT hasPhrase(m[key]) (Hint mode): NULL map values must be excluded
+9968
+9968
+-- NOT LIKE(m[key]): NULL map values must be excluded
+9968
+9968
+-- no NULL map value leaks into the negated result
+0
+-- positive hasToken(m[key]) still uses the index and is correct
+12
+PREWHERE
+-- NOT hasToken in PREWHERE: only row 3
+3
+3
+Direct read stays enabled for a Nullable haystack
+-- virtual column is read directly and guarded by isNull(haystack)
+1	1
+Null-eliminating preprocessor keeps direct read consistent across materialization
+-- ifNull: NULL source -> 0, kept under NOT; mixed materialized/unmaterialized parts agree
+2
+3
+12
+13
+2
+3
+12
+13
+-- after full materialization the answer is unchanged
+2
+3
+12
+13
+-- direct read stays enabled but the isNull wrap is suppressed (effective haystack is non-Nullable)
+1	0
+-- coalesce: source NULL kept under NOT, matches the non-direct-read path
+2
+3
+2
+3
+-- assumeNotNull: source NULL kept under NOT, matches the non-direct-read path
+2
+3
+2
+3
+-- nullIf still demotes: direct read matches the non-direct-read path
+3
+3
+Nullable(String) widened null-removing preprocessor = CAST(ifNull(str, \'\'), \'Nullable(String)\')
+-- direct read matches the non-direct-read path (source NULL kept under NOT)
+2
+3
+2
+3
+-- direct read stays enabled but the isNull wrap is suppressed (effective haystack is non-Nullable)
+1	0
+Nullable(String) widened null-producing preprocessor = CAST(nullIf(str, \'\'), \'Nullable(String)\') still demotes
+-- direct read matches the non-direct-read path
+3
+3
+Nullable(String) null-propagating preprocessor = lower(toNullable(str)) keeps direct read
+-- direct read matches the non-direct-read path (source NULL kept under NOT)
+3
+3
+-- the virtual column is still read (the optimization is NOT dropped for a null-propagating preprocessor)
+1
+Nullable(String) null-removing preprocessor wrapped in lower = lower(CAST(ifNull(str, \'\'), \'Nullable(String)\')) suppresses the isNull wrap
+-- direct read matches the non-direct-read path (source NULL kept under NOT)
+2
+3
+2
+3
+-- direct read stays enabled but the isNull wrap is suppressed (effective haystack is non-Nullable)
+1	0

--- a/tests/queries/0_stateless/02346_text_index_bug106922.sql
+++ b/tests/queries/0_stateless/02346_text_index_bug106922.sql
@@ -1,0 +1,576 @@
+-- Tags: long
+-- Tests https://github.com/ClickHouse/ClickHouse/issues/106922
+-- A negated text-search predicate over a Nullable indexed column must not return rows whose
+-- indexed value is NULL: f(NULL, ...) is NULL, NOT NULL is NULL, so a NULL row is filtered out.
+-- The direct-read-from-text-index optimization materializes a non-Nullable 0/1 from the posting
+-- list (NULL row has no tokens -> 0). A plain CAST to Nullable adds an all-false null map, so a
+-- NULL row reads as a genuine 0 and NOT wrongly keeps it. The fix wraps the virtual column with
+-- if(isNull(haystack), NULL, vc), re-deriving the haystack's real null map, so direct read stays
+-- enabled for Nullable columns. This affects every direct-read function, not only hasToken:
+-- hasAnyTokens, hasAllTokens, hasPhrase, startsWith, endsWith and the LIKE rewrites all go through
+-- the same path. Each query is checked against the same query with the optimization disabled,
+-- which evaluates the real function and is the reference for correct NULL semantics.
+
+SET enable_analyzer = 1;
+-- Exercise both direct-read modes (Exact replacement and Hint and(vc, real_func)) and the LIKE
+-- dictionary-scan rewrite, all of which must preserve NULL semantics for a Nullable haystack.
+SET query_plan_direct_read_from_text_index = 1, query_plan_text_index_add_hint = 1, use_text_index_like_evaluation_by_dictionary_scan = 1;
+
+SELECT 'Nullable(String)';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab
+(
+    id  UInt32,
+    str Nullable(String),
+    INDEX idx(str) TYPE text(tokenizer = 'splitByNonAlpha')
+)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (1, 'hello world'), (2, NULL), (3, 'foo bar'), (4, NULL), (5, 'hello there');
+
+SELECT '-- NOT hasToken: NULL rows (2, 4) must not appear; only row 3 matches';
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id;
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+SELECT '-- NOT hasAllTokens: only row 3 matches';
+SELECT id FROM tab WHERE NOT hasAllTokens(str, ['hello']) ORDER BY id;
+SELECT id FROM tab WHERE NOT hasAllTokens(str, ['hello']) ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+SELECT '-- NOT hasAnyTokens: only row 3 matches';
+SELECT id FROM tab WHERE NOT hasAnyTokens(str, ['hello']) ORDER BY id;
+SELECT id FROM tab WHERE NOT hasAnyTokens(str, ['hello']) ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+SELECT '-- NOT hasPhrase (Hint mode): rows 3 and 5 match, NULL rows excluded';
+SELECT id FROM tab WHERE NOT hasPhrase(str, 'hello world') ORDER BY id;
+SELECT id FROM tab WHERE NOT hasPhrase(str, 'hello world') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+SELECT '-- NOT endsWith (Hint mode): rows 3 and 5 match, NULL rows excluded';
+SELECT id FROM tab WHERE NOT endsWith(str, 'world') ORDER BY id;
+SELECT id FROM tab WHERE NOT endsWith(str, 'world') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+SELECT '-- NOT startsWith (Hint mode): only row 3, NULL rows excluded';
+SELECT id FROM tab WHERE NOT startsWith(str, 'hello') ORDER BY id;
+SELECT id FROM tab WHERE NOT startsWith(str, 'hello') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+SELECT '-- NOT LIKE suffix pattern (Hint mode): rows 3 and 5 match, NULL rows excluded';
+SELECT id FROM tab WHERE NOT (str LIKE '%world') ORDER BY id;
+SELECT id FROM tab WHERE NOT (str LIKE '%world') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+SELECT '-- NOT match: only row 3, NULL rows excluded';
+SELECT id FROM tab WHERE NOT match(str, 'hello') ORDER BY id;
+SELECT id FROM tab WHERE NOT match(str, 'hello') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+SELECT '-- positive hasPhrase still correct: only row 1';
+SELECT id FROM tab WHERE hasPhrase(str, 'hello world') ORDER BY id;
+
+SELECT '-- positive hasToken still correct: rows 1 and 5';
+SELECT id FROM tab WHERE hasToken(str, 'hello') ORDER BY id;
+
+SELECT '-- hasToken IS NULL selects exactly the NULL rows 2 and 4';
+SELECT id FROM tab WHERE hasToken(str, 'hello') IS NULL ORDER BY id;
+
+SELECT '-- projection of hasToken keeps NULL for NULL rows';
+SELECT id, hasToken(str, 'hello') FROM tab ORDER BY id;
+
+DROP TABLE tab;
+
+SELECT 'Nullable(String), all-NULL part';
+
+CREATE TABLE tab
+(
+    id  UInt32,
+    str Nullable(String),
+    INDEX idx(str) TYPE text(tokenizer = 'splitByNonAlpha')
+)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (1, NULL), (2, NULL), (3, NULL);
+
+SELECT '-- NOT hasToken over an all-NULL part returns no rows (NOT NULL filters every row out)';
+SELECT count() FROM tab WHERE NOT hasToken(str, 'hello');
+SELECT count() FROM tab WHERE NOT hasToken(str, 'hello') SETTINGS query_plan_direct_read_from_text_index = 0;
+
+DROP TABLE tab;
+
+SELECT 'LowCardinality(Nullable(String))';
+
+CREATE TABLE tab
+(
+    id  UInt32,
+    str LowCardinality(Nullable(String)),
+    INDEX idx(str) TYPE text(tokenizer = 'splitByNonAlpha')
+)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (1, 'hello world'), (2, NULL), (3, 'foo bar'), (4, NULL), (5, 'hello there');
+
+SELECT '-- NOT hasToken with LowCardinality(Nullable): only row 3';
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id;
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+DROP TABLE tab;
+
+SELECT 'Nullable(String) with preprocessor = lower(str)';
+
+CREATE TABLE tab
+(
+    id  UInt32,
+    str Nullable(String),
+    INDEX idx(str) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(str))
+)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (1, 'Hello World'), (2, NULL), (3, 'foo bar'), (4, NULL);
+
+SELECT '-- NOT hasToken with preprocessor + Nullable: only row 3';
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id;
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+DROP TABLE tab;
+
+-- Nullable(String) source combined with a null-producing preprocessor (nullIf(str, '')). The
+-- preprocessor turns a non-NULL source value (row 2 = '') into NULL, which the source-keyed
+-- if(isNull(source), ...) guard cannot see. Left enabled, direct read would read 0 for such a row
+-- from a materialized part but keep the fallback predicate for an unmaterialized part, so the same
+-- value gives different answers depending on per-part materialization. Direct read is therefore
+-- disabled whenever the preprocessor can introduce NULLs on a Nullable haystack, and every part
+-- takes the deterministic fallback: hasToken(nullIf(str,''), ...) is NULL for row 2, so NOT ... is
+-- NULL and row 2 is filtered, matching the recheck path. Genuine source NULL (row 4) is filtered too.
+SELECT 'Nullable(String) with null-producing preprocessor = nullIf(str, '''')';
+
+CREATE TABLE tab
+(
+    id  UInt32,
+    str Nullable(String),
+    INDEX idx(str) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = nullIf(str, ''))
+)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (1, 'hello'), (2, ''), (3, 'foo'), (4, NULL);
+
+SELECT '-- rows 2 (nullIf -> NULL) and 4 (source NULL) filtered; direct read matches recheck';
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id;
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+DROP TABLE tab;
+
+-- Same null-producing preprocessor with a PARTIALLY materialized index: old rows are inserted before
+-- ALTER ADD INDEX (evaluated by the fallback predicate) and new rows after (read from postings). The
+-- str = '' rows in either part (id 50 old, 100050 new) must get the SAME verdict; before the fix the
+-- materialized part read 0 and kept the row while the unmaterialized part filtered it. Direct read is
+-- disabled here, so both parts filter it. The hint stays active via a selective needle and filler rows.
+SELECT 'Nullable(String) null-producing preprocessor, partially materialized index';
+
+CREATE TABLE tab
+(
+    id  UInt32,
+    str Nullable(String)
+)
+ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 8;
+
+INSERT INTO tab SELECT number, if(number = 50, '', concat('filler ', toString(number), ' text')) FROM numbers(200);
+INSERT INTO tab VALUES (60, 'hello world here');
+ALTER TABLE tab ADD INDEX idx str TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = nullIf(str, '')) GRANULARITY 1;
+INSERT INTO tab SELECT number + 100000, if(number = 50, '', concat('filler ', toString(number), ' text')) FROM numbers(200);
+INSERT INTO tab VALUES (100060, 'hello world here');
+
+SELECT '-- empty-string rows (50 old, 100050 new) get the same verdict as recheck';
+SELECT groupArray(id) FROM (SELECT id FROM tab WHERE NOT hasPhrase(str, 'hello world') AND str = '' ORDER BY id);
+SELECT groupArray(id) FROM (SELECT id FROM tab WHERE NOT hasPhrase(str, 'hello world') AND str = '' ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0);
+
+DROP TABLE tab;
+
+-- Plain (non-Nullable) String haystack with the same null-producing preprocessor, but a NULLABLE
+-- needle (toNullable('hello')). The predicate result type is Nullable(UInt8) because of the needle,
+-- yet the indexed HAYSTACK is a plain String, so this is out of scope for the demotion guard: direct
+-- read must stay enabled. The guard keys off haystack nullability (original_haystack), not the
+-- Nullable result type, so a nullable needle over a plain String source is not routed to the fallback
+-- and its answer is unchanged. (Row 2 str = '' under negation is the separate pre-existing 0-vs-NULL
+-- preprocessor question for non-Nullable sources, not touched here.)
+SELECT 'String (non-Nullable) haystack + null-producing preprocessor + nullable needle';
+
+CREATE TABLE tab
+(
+    id  UInt32,
+    str String,
+    INDEX idx(str) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = nullIf(str, '')) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (1, 'hello'), (2, ''), (3, 'foo'), (4, 'world');
+
+SELECT '-- direct read stays enabled (haystack is plain String): reads virtual column';
+SELECT countIf(explain LIKE '%__text_index_%') > 0 AS reads_virtual_column
+FROM (EXPLAIN actions = 1 SELECT id FROM tab WHERE NOT hasToken(str, toNullable('hello')) SETTINGS query_plan_direct_read_from_text_index = 1, query_plan_text_index_add_hint = 1, query_plan_remove_unused_columns = 1);
+
+DROP TABLE tab;
+
+-- Nullable(String) haystack with a null-producing preprocessor (nullIf(str, '')), but a raw-string
+-- sibling predicate (endsWith) whose fallback is NOT rewritten through the preprocessor. endsWith
+-- evaluates the original source value on the fallback path, so a str = '' row reads 0 from postings on
+-- the materialized part and evaluates endsWith('', 'world') = 0 on the unmaterialized part -- same
+-- verdict, no NULL divergence. The demotion guard is therefore scoped to needApplyPreprocessor-true
+-- functions (hasToken / hasAllTokens / hasAnyTokens / hasPhrase); it must NOT disable direct read for
+-- endsWith. An ngrams tokenizer is used so the raw-string sibling is actually direct-readable (Hint):
+-- with the broader result-type-based guard this virtual column was wrongly dropped.
+SELECT 'Nullable(String) null-producing preprocessor + raw-string sibling (endsWith) keeps direct read';
+
+CREATE TABLE tab
+(
+    id  UInt32,
+    str Nullable(String),
+    INDEX idx(str) TYPE text(tokenizer = ngrams(3), preprocessor = nullIf(str, '')) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 8;
+
+INSERT INTO tab SELECT number, if(number % 777 = 0, '', concat('doc', toString(number), ' world')) FROM numbers(3000);
+
+SELECT '-- direct read stays enabled for endsWith (raw-string sibling, not rewritten via preprocessor)';
+SELECT countIf(explain LIKE '%__text_index_%') > 0 AS reads_virtual_column
+FROM (EXPLAIN actions = 1 SELECT id FROM tab WHERE NOT endsWith(str, 'world') SETTINGS query_plan_direct_read_from_text_index = 1, query_plan_text_index_add_hint = 1, query_plan_remove_unused_columns = 1, use_text_index_like_evaluation_by_dictionary_scan = 1);
+
+DROP TABLE tab;
+
+-- Nullable(FixedString) haystack with a pure type-widening preprocessor CAST(str, 'Nullable(String)').
+-- The preprocessor result type is Nullable, but CAST only widens a non-NULL input to Nullable and can
+-- never turn a non-NULL row into NULL (it throws on a genuine conversion failure rather than producing
+-- NULL). So there is no materialized-vs-unmaterialized NULL divergence and direct read must stay enabled,
+-- even for the needApplyPreprocessor-true functions (hasToken here). The demotion must key on whether the
+-- preprocessor can actually introduce a NULL from a non-NULL value, not on the declared result type being
+-- Nullable. This shape (Nullable(FixedString) + CAST to Nullable(String)) is an accepted preprocessor
+-- (see 04038_text_index_preprocessor_type_validation). With the broader result-type-based guard this
+-- virtual column was wrongly dropped.
+SELECT 'Nullable(FixedString) type-widening preprocessor CAST(str, Nullable(String)) keeps direct read';
+
+CREATE TABLE tab
+(
+    id  UInt32,
+    str Nullable(FixedString(16)),
+    INDEX idx(str) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(str, 'Nullable(String)')) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 8;
+
+INSERT INTO tab VALUES (1, toFixedString('hello world', 16)), (2, NULL), (3, toFixedString('foo bar', 16)), (4, NULL), (5, toFixedString('hello there', 16));
+
+SELECT '-- NOT hasToken: NULL rows (2, 4) excluded; only row 3 matches; direct read matches recheck';
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id;
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+SELECT '-- direct read stays enabled for a pure type-widening CAST-to-Nullable preprocessor';
+SELECT countIf(explain LIKE '%__text_index_%') > 0 AS reads_virtual_column
+FROM (EXPLAIN actions = 1 SELECT id FROM tab WHERE NOT hasToken(str, 'hello') SETTINGS query_plan_direct_read_from_text_index = 1, query_plan_text_index_add_hint = 1, query_plan_remove_unused_columns = 1, use_text_index_like_evaluation_by_dictionary_scan = 1);
+
+DROP TABLE tab;
+
+SELECT 'Nullable(String) with ngrams tokenizer, partially materialized index';
+
+CREATE TABLE tab
+(
+    id  UInt32,
+    str Nullable(String),
+    INDEX idx(str) TYPE text(tokenizer = ngrams(3))
+)
+ENGINE = MergeTree ORDER BY id;
+
+-- First part is written before the index materializes, second after, so the index is
+-- partially materialized: some granules read postings directly, others re-run the function.
+INSERT INTO tab VALUES (1, 'hello world'), (2, NULL), (3, 'foo bar');
+SYSTEM STOP MERGES tab;
+INSERT INTO tab VALUES (4, NULL), (5, 'hello there');
+
+SELECT '-- NOT hasPhrase (ngrams, partially materialized): rows 3 and 5, NULL rows excluded';
+SELECT id FROM tab WHERE NOT hasPhrase(str, 'hello world') ORDER BY id;
+SELECT id FROM tab WHERE NOT hasPhrase(str, 'hello world') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+SELECT '-- NOT endsWith (ngrams, partially materialized): rows 3 and 5, NULL rows excluded';
+SELECT id FROM tab WHERE NOT endsWith(str, 'world') ORDER BY id;
+SELECT id FROM tab WHERE NOT endsWith(str, 'world') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+SELECT '-- NOT LIKE suffix pattern (ngrams, partially materialized): rows 3 and 5, NULL rows excluded';
+SELECT id FROM tab WHERE NOT (str LIKE '%world') ORDER BY id;
+SELECT id FROM tab WHERE NOT (str LIKE '%world') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+DROP TABLE tab;
+
+SELECT 'Map(String, Nullable(String)) with mapValues index';
+
+-- A `mapValues(m)` index uses direct read only as a Hint (the key must still be matched), and the
+-- Hint-mode virtual column is built on the same direct-read path, so the null-map restoration must
+-- cover it too. The bug only shows when the Hint is kept (not bypassed), so use enough rows with a
+-- selective needle that the index materializes per-row posting membership. A NULL map value reads
+-- as 0 there, and `NOT and(0, NULL)` wrongly keeps the row unless the virtual column is wrapped with
+-- if(isNull(haystack), NULL, vc) to carry the map value's real null map.
+CREATE TABLE tab
+(
+    id UInt32,
+    m  Map(String, Nullable(String)),
+    INDEX idx mapValues(m) TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 128;
+
+INSERT INTO tab
+SELECT number AS id,
+       multiIf(number % 500 = 0, map('k', CAST(NULL AS Nullable(String))),
+               number % 777 = 0, map('k', 'needle here'),
+               map('k', 'common filler text')) AS m
+FROM numbers(10000);
+
+SELECT '-- NOT hasToken(m[key]): NULL map values must be excluded; count matches the non-direct-read path';
+SELECT count() FROM tab WHERE NOT hasToken(m['k'], 'needle');
+SELECT count() FROM tab WHERE NOT hasToken(m['k'], 'needle') SETTINGS query_plan_direct_read_from_text_index = 0;
+
+SELECT '-- NOT hasPhrase(m[key]) (Hint mode): NULL map values must be excluded';
+SELECT count() FROM tab WHERE NOT hasPhrase(m['k'], 'needle here');
+SELECT count() FROM tab WHERE NOT hasPhrase(m['k'], 'needle here') SETTINGS query_plan_direct_read_from_text_index = 0;
+
+SELECT '-- NOT LIKE(m[key]): NULL map values must be excluded';
+SELECT count() FROM tab WHERE NOT (m['k'] LIKE '%needle%');
+SELECT count() FROM tab WHERE NOT (m['k'] LIKE '%needle%') SETTINGS query_plan_direct_read_from_text_index = 0;
+
+SELECT '-- no NULL map value leaks into the negated result';
+SELECT countIf(m['k'] IS NULL) FROM tab WHERE NOT hasToken(m['k'], 'needle');
+
+SELECT '-- positive hasToken(m[key]) still uses the index and is correct';
+SELECT count() FROM tab WHERE hasToken(m['k'], 'needle');
+
+DROP TABLE tab;
+
+SELECT 'PREWHERE';
+
+CREATE TABLE tab
+(
+    id  UInt32,
+    str Nullable(String),
+    INDEX idx(str) TYPE text(tokenizer = 'splitByNonAlpha')
+)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (1, 'hello world'), (2, NULL), (3, 'foo bar'), (4, NULL), (5, 'hello there');
+
+SELECT '-- NOT hasToken in PREWHERE: only row 3';
+SELECT id FROM tab PREWHERE NOT hasToken(str, 'hello') ORDER BY id;
+SELECT id FROM tab PREWHERE NOT hasToken(str, 'hello') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+DROP TABLE tab;
+
+SELECT 'Direct read stays enabled for a Nullable haystack';
+
+-- The fix must preserve NULL semantics WITHOUT disabling the optimization. Assert the text-index
+-- virtual column is still created (and wrapped with isNull(haystack)) for a Nullable column, so a
+-- regression that falls back to a full scan for every Nullable predicate is caught.
+CREATE TABLE tab
+(
+    id  UInt32,
+    str Nullable(String),
+    INDEX idx(str) TYPE text(tokenizer = 'splitByNonAlpha') GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (1, 'hello world'), (2, NULL), (3, 'foo bar'), (4, NULL), (5, 'hello there');
+
+SELECT '-- virtual column is read directly and guarded by isNull(haystack)';
+SELECT countIf(explain LIKE '%__text_index_%') > 0 AS reads_virtual_column,
+       countIf(explain LIKE '%isNull(str)%' OR explain LIKE '%str IS NULL%') > 0 AS guarded_by_isnull
+FROM (EXPLAIN actions = 1 SELECT id FROM tab WHERE NOT hasToken(str, 'hello') SETTINGS query_plan_direct_read_from_text_index = 1, query_plan_text_index_add_hint = 1, query_plan_remove_unused_columns = 1);
+
+DROP TABLE tab;
+
+SELECT 'Null-eliminating preprocessor keeps direct read consistent across materialization';
+
+-- A preprocessor like ifNull(str, '') / coalesce(str, '') / assumeNotNull(str) removes the source
+-- nullability: the rewritten fallback predicate evaluates a source-NULL row to 0, not NULL. The
+-- isNull(source) wrapper must NOT reintroduce NULL for those rows, otherwise materialized parts drop
+-- the row while unmaterialized parts keep it -- a materialization-dependent result. Insert a part
+-- before ADD INDEX (unmaterialized) and a part after (materialized), then MATERIALIZE, and assert the
+-- answer is identical to the non-direct-read path at every step.
+
+CREATE TABLE tab
+(
+    id  UInt32,
+    str Nullable(String)
+)
+ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 8, min_bytes_for_wide_part = 0;
+
+INSERT INTO tab VALUES (1, 'hello'), (2, NULL), (3, 'foo');
+ALTER TABLE tab ADD INDEX idx(str) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = ifNull(str, '')) GRANULARITY 1;
+INSERT INTO tab VALUES (11, 'hello'), (12, NULL), (13, 'foo');
+
+SELECT '-- ifNull: NULL source -> 0, kept under NOT; mixed materialized/unmaterialized parts agree';
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id;
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+ALTER TABLE tab MATERIALIZE INDEX idx SETTINGS mutations_sync = 2;
+
+SELECT '-- after full materialization the answer is unchanged';
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id;
+
+SELECT '-- direct read stays enabled but the isNull wrap is suppressed (effective haystack is non-Nullable)';
+SELECT countIf(explain LIKE '%__text_index_%') > 0 AS reads_virtual_column,
+       countIf(explain LIKE '%isNull(str)%' OR explain LIKE '%str IS NULL%') AS isnull_wrap_count
+FROM (EXPLAIN actions = 1 SELECT id FROM tab WHERE NOT hasToken(str, 'hello') SETTINGS query_plan_direct_read_from_text_index = 1, query_plan_text_index_add_hint = 1, query_plan_remove_unused_columns = 1);
+
+DROP TABLE tab;
+
+-- coalesce and assumeNotNull remove nullability the same way.
+CREATE TABLE tab
+(
+    id  UInt32,
+    str Nullable(String),
+    INDEX idx(str) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = coalesce(str, '')) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (1, 'hello'), (2, NULL), (3, 'foo');
+
+SELECT '-- coalesce: source NULL kept under NOT, matches the non-direct-read path';
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id;
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+DROP TABLE tab;
+
+CREATE TABLE tab
+(
+    id  UInt32,
+    str Nullable(String),
+    INDEX idx(str) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = assumeNotNull(str)) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (1, 'hello'), (2, NULL), (3, 'foo');
+
+SELECT '-- assumeNotNull: source NULL kept under NOT, matches the non-direct-read path';
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id;
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+DROP TABLE tab;
+
+-- A null-PRODUCING preprocessor (nullIf) is the opposite case: it must still disable direct read
+-- (tracked by preprocessorCanIntroduceNullOnNullableHaystack), so direct read == the fallback path.
+CREATE TABLE tab
+(
+    id  UInt32,
+    str Nullable(String),
+    INDEX idx(str) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = nullIf(str, '')) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY id;
+
+INSERT INTO tab VALUES (1, 'hello'), (2, ''), (3, 'foo'), (4, NULL);
+
+SELECT '-- nullIf still demotes: direct read matches the non-direct-read path';
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id;
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+DROP TABLE tab;
+
+-- A null-REMOVING preprocessor widened back to Nullable, e.g. CAST(ifNull(str, ''), 'Nullable(String)')
+-- (an accepted preprocessor shape). The declared result type is Nullable, but ifNull strips the source
+-- null map before the outer CAST widens it, so the effective haystack maps every source-NULL row to a
+-- non-NULL value. removesNull() must peel the widening CAST to see the inner ifNull, so the source-keyed
+-- isNull wrapper is suppressed and direct read stays enabled with a consistent (materialization-
+-- independent) answer that matches the non-direct-read path.
+SELECT 'Nullable(String) widened null-removing preprocessor = CAST(ifNull(str, ''''), ''Nullable(String)'')';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab
+(
+    id  UInt32,
+    str Nullable(String),
+    INDEX idx(str) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(ifNull(str, ''), 'Nullable(String)')) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 8;
+
+INSERT INTO tab VALUES (1, 'hello'), (2, NULL), (3, 'foo');
+
+SELECT '-- direct read matches the non-direct-read path (source NULL kept under NOT)';
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id;
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+SELECT '-- direct read stays enabled but the isNull wrap is suppressed (effective haystack is non-Nullable)';
+SELECT countIf(explain LIKE '%__text_index_%') > 0 AS reads_virtual_column,
+       countIf(explain LIKE '%isNull(str)%' OR explain LIKE '%str IS NULL%') AS isnull_wrap_count
+FROM (EXPLAIN actions = 1 SELECT id FROM tab WHERE NOT hasToken(str, 'hello') SETTINGS query_plan_direct_read_from_text_index = 1, query_plan_text_index_add_hint = 1, query_plan_remove_unused_columns = 1);
+
+DROP TABLE tab;
+
+-- The same widening CAST around a genuinely null-PRODUCING nullIf must NOT be misclassified as
+-- null-removing: peeling stops at the inner nullIf (which is still Nullable), so direct read is still
+-- demoted and matches the non-direct-read path.
+SELECT 'Nullable(String) widened null-producing preprocessor = CAST(nullIf(str, ''''), ''Nullable(String)'') still demotes';
+
+CREATE TABLE tab
+(
+    id  UInt32,
+    str Nullable(String),
+    INDEX idx(str) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = CAST(nullIf(str, ''), 'Nullable(String)')) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 8;
+
+INSERT INTO tab VALUES (1, 'hello'), (2, ''), (3, 'foo'), (4, NULL);
+
+SELECT '-- direct read matches the non-direct-read path';
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id;
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+DROP TABLE tab;
+
+-- A null-PROPAGATING preprocessor over a widened source, e.g. lower(toNullable(str)). lower uses the
+-- default Nullable handling: it maps a source-NULL row to NULL and any non-NULL row to a non-NULL
+-- value, so it can never synthesize NULL from a non-NULL value -- it only propagates the source
+-- nullability (semantically identical to the already-covered CAST(lower(str), 'Nullable(String)')).
+-- canIntroduceNull() must therefore classify it as non-null-producing (peel the widening toNullable
+-- AND recurse through the null-propagating lower), so direct read stays enabled and the virtual
+-- column is still read; the outer if(isNull(str), NULL, vc) wrapper preserves the real null map.
+SELECT 'Nullable(String) null-propagating preprocessor = lower(toNullable(str)) keeps direct read';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab
+(
+    id  UInt32,
+    str Nullable(String),
+    INDEX idx(str) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(toNullable(str))) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 8;
+
+INSERT INTO tab VALUES (1, 'Hello'), (2, NULL), (3, 'Foo');
+
+SELECT '-- direct read matches the non-direct-read path (source NULL kept under NOT)';
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id;
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+SELECT '-- the virtual column is still read (the optimization is NOT dropped for a null-propagating preprocessor)';
+SELECT countIf(explain LIKE '%__text_index_%') > 0 AS reads_virtual_column
+FROM (EXPLAIN actions = 1 SELECT id FROM tab WHERE NOT hasToken(str, 'hello') SETTINGS query_plan_direct_read_from_text_index = 1, query_plan_text_index_add_hint = 1, query_plan_remove_unused_columns = 1);
+
+DROP TABLE tab;
+
+-- A null-REMOVING preprocessor wrapped in a null-PROPAGATING outer function, e.g.
+-- lower(CAST(ifNull(str, ''), 'Nullable(String)')). The inner ifNull maps every source-NULL row to a
+-- non-NULL '', and lower merely propagates that (already non-NULL) value, so the effective haystack
+-- is never NULL even though the outer lower node declares Nullable(String). removesNull() must peel
+-- the widening cast AND recurse through the null-propagating lower to detect the inner null removal,
+-- otherwise preserve_haystack_null re-adds if(isNull(str), NULL, vc) and direct read drops the
+-- source-NULL row that the non-direct-read fallback keeps (NOT hasToken evaluates NULL->'' to 1).
+SELECT 'Nullable(String) null-removing preprocessor wrapped in lower = lower(CAST(ifNull(str, ''''), ''Nullable(String)'')) suppresses the isNull wrap';
+
+DROP TABLE IF EXISTS tab;
+CREATE TABLE tab
+(
+    id  UInt32,
+    str Nullable(String),
+    INDEX idx(str) TYPE text(tokenizer = 'splitByNonAlpha', preprocessor = lower(CAST(ifNull(str, ''), 'Nullable(String)'))) GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 8;
+
+INSERT INTO tab VALUES (1, 'Hello'), (2, NULL), (3, 'Foo');
+
+SELECT '-- direct read matches the non-direct-read path (source NULL kept under NOT)';
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id;
+SELECT id FROM tab WHERE NOT hasToken(str, 'hello') ORDER BY id SETTINGS query_plan_direct_read_from_text_index = 0;
+
+SELECT '-- direct read stays enabled but the isNull wrap is suppressed (effective haystack is non-Nullable)';
+SELECT countIf(explain LIKE '%__text_index_%') > 0 AS reads_virtual_column,
+       countIf(explain LIKE '%isNull(str)%' OR explain LIKE '%str IS NULL%') AS isnull_wrap_count
+FROM (EXPLAIN actions = 1 SELECT id FROM tab WHERE NOT hasToken(str, 'hello') SETTINGS query_plan_direct_read_from_text_index = 1, query_plan_text_index_add_hint = 1, query_plan_remove_unused_columns = 1);
+
+DROP TABLE tab;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/106922
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fixed wrong results from a `text` index on a `Nullable` (or `LowCardinality(Nullable)`) column. A negated text-search predicate (`NOT hasToken(col, 'x')`, and likewise `hasAllTokens`, `hasAnyTokens`, `hasPhrase`, `startsWith`, `endsWith`, `LIKE`) no longer returns rows whose indexed value is `NULL`. The direct-read-from-text-index optimization materialized a non-`Nullable` `0`/`1` for such rows, losing the `NULL` that the function returns, so negation wrongly kept the `NULL` rows.


### Description

Found by the AST-fuzzer correctness oracle (issue #106922, reproducible on default settings). The reporter later confirmed the same defect surfaces via `match`, `like` and `hasPhrase` (in addition to `hasToken`), on both fully and partially materialized (`ngrams`) text indexes.

Root cause: the direct-read-from-text-index optimization reads a non-`Nullable` `UInt8` virtual column from posting-list membership. A `NULL` row has no tokens, so it reads as `0` (indistinguishable from a non-matching row), and the index stores no per-row null map (NULL rows are skipped at build time), so the mask cannot be reconstructed from the index alone. This `0` then loses the `NULL` in both direct-read modes:
- `Exact` mode (`hasToken`/`hasAllTokens`/`hasAnyTokens`) fully replaces the function with the virtual column; the later cast to `Nullable(UInt8)` only adds an all-false null map, so `NOT 0 = 1` keeps the row.
- `Hint` mode (`hasPhrase`/`startsWith`/`endsWith` and the `LIKE` rewrites) builds `and(virtual_column, real_func)`; for a `NULL` row that is `and(0, NULL) = 0`, so `NOT 0 = 1` keeps the row too.

Fix: when the indexed (haystack) column is `Nullable`/`LowCardinality(Nullable)`, demote any non-`None` direct read mode (`Exact` and `Hint`) to `None`, so the real function is evaluated per row. Granule-level pruning via the index still applies. The needle is always a non-null constant when direct read fires, so nullable-needle direct read, `Array(Nullable)` and `mapValues` paths (where the array value itself is never `NULL`) are unaffected, and the non-`Nullable` fast path is untouched.

Verified locally (debug build): every negated predicate now returns the same rows as `SETTINGS query_plan_direct_read_from_text_index = 0`; the regression test `02346_text_index_bug106922` covers `hasToken`/`hasAnyTokens`/`hasAllTokens`/`hasPhrase`/`startsWith`/`endsWith`/`match`/`LIKE` over `Nullable` and `LowCardinality(Nullable)` haystacks plus an `ngrams` partially-materialized index, and fails on a binary without the fix. Existing text-index tests pass.
