### PR TITLE
Use subcolumn skip indexes and primary key for predicates through views

### DIFF
--- a/src/Storages/MergeTree/KeyCondition.cpp
+++ b/src/Storages/MergeTree/KeyCondition.cpp
@@ -948,6 +948,53 @@ static const ActionsDAG::Node * tryRewriteCoalesceComparison(
     return &inverted_dag.addFunction(or_func, std::move(or_children), "");
 }
 
+/// Fold `getSubcolumn(<input>, '<subname>')` into a single INPUT named `<input>.<subname>`, the
+/// canonical subcolumn name an index/primary key is registered under. The cloned DAG is used only
+/// for index/PK granule pruning (never for filter execution), so substituting the equivalent
+/// subcolumn input is faithful. Returns nullptr for any non-foldable shape, so the caller falls
+/// back to generic cloning. See issue #107038.
+static const ActionsDAG::Node * tryFoldGetSubcolumnToInput(
+    const ActionsDAG::Node & node,
+    ActionsDAG & inverted_dag,
+    std::unordered_map<const ActionsDAG::Node *, const ActionsDAG::Node *> & inputs_mapping)
+{
+    if (node.children.size() != 2)
+        return nullptr;
+
+    /// Second argument must be a constant String with the subcolumn name.
+    const auto & subname_node = *node.children[1];
+    if (subname_node.type != ActionsDAG::ActionType::COLUMN || !subname_node.column || !isColumnConst(*subname_node.column))
+        return nullptr;
+    Field subname_field = assert_cast<const ColumnConst &>(*subname_node.column).getField();
+    if (subname_field.getType() != Field::Types::String)
+        return nullptr;
+    const String & subname = subname_field.safeGet<String>();
+    if (subname.empty())
+        return nullptr;
+
+    /// First argument must resolve (through aliases) to a plain INPUT - the base column read.
+    /// A nested subcolumn read is itself a foldable getSubcolumn and is handled recursively below.
+    const ActionsDAG::Node * base = node.children[0];
+    while (base->type == ActionsDAG::ActionType::ALIAS)
+        base = base->children.front();
+
+    const ActionsDAG::Node * folded_base = nullptr;
+    if (base->type == ActionsDAG::ActionType::INPUT)
+        folded_base = base;
+    else if (base->type == ActionsDAG::ActionType::FUNCTION && base->function_base->getName() == "getSubcolumn")
+        folded_base = tryFoldGetSubcolumnToInput(*base, inverted_dag, inputs_mapping);
+
+    if (!folded_base)
+        return nullptr;
+
+    /// Build (and dedup) the canonical subcolumn input `<base>.<subname>`, typed as the
+    /// getSubcolumn result (i.e. the subcolumn type).
+    auto & mapped = inputs_mapping[&node];
+    if (mapped == nullptr)
+        mapped = &inverted_dag.addInput(folded_base->result_name + "." + subname, node.result_type);
+    return mapped;
+}
+
 static const ActionsDAG::Node & cloneDAGWithInversionPushDown(
     const ActionsDAG::Node & node,
     ActionsDAG & inverted_dag,
@@ -1034,6 +1081,13 @@ static const ActionsDAG::Node & cloneDAGWithInversionPushDown(
                 /// `need_inversion` was already pushed into the child; avoid adding an extra `not()` wrapper
                 /// Without this, we could add an extra `not()` here (double inversion), e.g. `NOT materialize(x = 0)` -> `not(notEquals(x, 0))`.
                 handled_inversion = true;
+            }
+            else if (!need_inversion && name == "getSubcolumn"
+                && (res = tryFoldGetSubcolumnToInput(node, inverted_dag, inputs_mapping)) != nullptr)
+            {
+                /// Folded `getSubcolumn(col, 'name')` (produced for subcolumn reads through views) into the
+                /// canonical subcolumn input `col.name`, so index/primary-key name matching works the same
+                /// as for a direct table read. `res` is a leaf input; fall through to the inversion wrapper.
             }
             else if (isTrivialCast(node))
             {

--- a/tests/queries/0_stateless/04322_subcolumn_skip_index_through_view.reference
+++ b/tests/queries/0_stateless/04322_subcolumn_skip_index_through_view.reference
@@ -1,0 +1,12 @@
+1
+1
+1
+Skip
+Name: idx_text
+Skip
+Name: idx_text
+Condition: (t.inner.x in [100, 100])
+Granules: 2/64
+Condition: (t.inner.x in [100, 100])
+Granules: 2/64
+1

--- a/tests/queries/0_stateless/04322_subcolumn_skip_index_through_view.sql
+++ b/tests/queries/0_stateless/04322_subcolumn_skip_index_through_view.sql
@@ -1,0 +1,64 @@
+-- Tags: no-random-merge-tree-settings
+-- Subcolumn skip indexes and primary key must be used for subcolumn predicates that arrive through a view,
+-- the same as for the base table. Through a view the analyzer rewrites `col.sub` into
+-- `getSubcolumn(col, 'sub')`; index analysis must fold that back to the canonical subcolumn name.
+-- https://github.com/ClickHouse/ClickHouse/issues/107038
+
+SET use_query_condition_cache = 0;
+SET parallel_replicas_index_analysis_only_on_coordinator = 0;
+
+DROP TABLE IF EXISTS tab;
+DROP VIEW IF EXISTS v;
+
+CREATE TABLE tab
+(
+    id UInt64,
+    arr Array(Tuple(role String, text String)),
+    tup Tuple(role String, text String),
+    INDEX idx_text arr.text TYPE text(tokenizer = splitByNonAlpha) GRANULARITY 1,
+    INDEX idx_arr_bf arr.text TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_tup_bf tup.text TYPE bloom_filter GRANULARITY 1
+)
+ENGINE = MergeTree ORDER BY id SETTINGS index_granularity = 4;
+
+INSERT INTO tab SELECT number, [('user', 'lorem ipsum filler ' || toString(number))], ('user', 'tup filler ' || toString(number)) FROM numbers(64);
+INSERT INTO tab VALUES (64, [('user', 'the needle token')], ('user', 'tup needle'));
+
+CREATE VIEW v AS SELECT * FROM tab;
+
+-- text index on Array(Tuple).text subcolumn, through the view: index must be used (query errors otherwise),
+-- and the result must be correct.
+SELECT count() FROM v WHERE hasAnyTokens(arr.text, ['needle']) SETTINGS force_data_skipping_indices = 'idx_text';
+
+-- generic bloom_filter on the same Array(Tuple).text subcolumn, through the view.
+SELECT count() FROM v WHERE has(arr.text, 'the needle token') SETTINGS force_data_skipping_indices = 'idx_arr_bf';
+
+-- generic bloom_filter on a plain Tuple subcolumn, through the view.
+SELECT count() FROM v WHERE tup.text = 'tup needle' SETTINGS force_data_skipping_indices = 'idx_tup_bf';
+
+-- The skip section must be present (and prune) in the plan when querying through the view,
+-- matching the direct-table behaviour.
+SELECT trimLeft(explain) FROM (EXPLAIN indexes = 1 SELECT count() FROM tab WHERE hasAnyTokens(arr.text, ['needle'])) WHERE explain LIKE '%Name:%' OR explain LIKE '%Skip%';
+SELECT trimLeft(explain) FROM (EXPLAIN indexes = 1 SELECT count() FROM v   WHERE hasAnyTokens(arr.text, ['needle'])) WHERE explain LIKE '%Name:%' OR explain LIKE '%Skip%';
+
+DROP VIEW v;
+DROP TABLE tab;
+
+-- Primary key on a (nested) Tuple subcolumn must also prune through a view.
+DROP TABLE IF EXISTS tab_pk;
+DROP VIEW IF EXISTS v_pk;
+
+CREATE TABLE tab_pk (id UInt64, t Tuple(inner Tuple(x UInt64, y String)))
+ENGINE = MergeTree ORDER BY t.inner.x SETTINGS index_granularity = 4;
+
+INSERT INTO tab_pk SELECT number, tuple(tuple(number, toString(number))) FROM numbers(256);
+
+CREATE VIEW v_pk AS SELECT * FROM tab_pk;
+
+-- Same primary-key condition and granule pruning whether read directly or through the view.
+SELECT trimLeft(explain) FROM (EXPLAIN indexes = 1 SELECT count() FROM tab_pk WHERE t.inner.x = 100) WHERE explain LIKE '%Condition:%' OR explain LIKE '%Granules:%';
+SELECT trimLeft(explain) FROM (EXPLAIN indexes = 1 SELECT count() FROM v_pk   WHERE t.inner.x = 100) WHERE explain LIKE '%Condition:%' OR explain LIKE '%Granules:%';
+SELECT count() FROM v_pk WHERE t.inner.x = 100;
+
+DROP VIEW v_pk;
+DROP TABLE tab_pk;

--- a/tests/queries/0_stateless/04322_subcolumn_skip_index_through_view.sql
+++ b/tests/queries/0_stateless/04322_subcolumn_skip_index_through_view.sql
@@ -1,11 +1,14 @@
--- Tags: no-random-merge-tree-settings
+-- Tags: no-random-merge-tree-settings, no-parallel-replicas, no-old-analyzer
+-- no-old-analyzer: a subcolumn predicate through a view only resolves on the analyzer.
+-- no-parallel-replicas: through a view the filter stays on the coordinator and is not pushed into the
+--                       per-replica MergeTree read, so the index is not consulted there (true for
+--                       top-level columns too); force_data_skipping_indices would then wrongly error.
 -- Subcolumn skip indexes and primary key must be used for subcolumn predicates that arrive through a view,
 -- the same as for the base table. Through a view the analyzer rewrites `col.sub` into
 -- `getSubcolumn(col, 'sub')`; index analysis must fold that back to the canonical subcolumn name.
 -- https://github.com/ClickHouse/ClickHouse/issues/107038
 
 SET use_query_condition_cache = 0;
-SET parallel_replicas_index_analysis_only_on_coordinator = 0;
 
 DROP TABLE IF EXISTS tab;
 DROP VIEW IF EXISTS v;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/107038
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Skip indexes (text and generic, e.g. `bloom_filter`) and the primary key are now used for `WHERE` predicates on a subcolumn (e.g. `t.a` of a `Tuple`, or `arr.field` of an `Array(Tuple(...))`) when the query reads through a view, the same as when reading the base table directly. Previously such predicates read all granules through a view, causing large read amplification.


### Description

Through a view (even a trivial `CREATE VIEW v AS SELECT * FROM tab`), a `WHERE` predicate on a subcolumn was not pruned by the subcolumn's skip index or primary key, so the query read every granule. The base table read pruned correctly. Results were always correct; only index usage (read amplification) was affected. This matters in practice for `SQL SECURITY DEFINER` views used as a multi-tenant enforcement layer, where the user has no grants on the base table and so cannot rewrite the query to read it directly.

Root cause: for a direct table read the analyzer emits a direct subcolumn read named like `turns.text`, which matches the canonical name the index or primary key is registered under. Through a view the source is a query (not the storage), so it does not advertise subcolumn support and the analyzer instead emits `getSubcolumn(turns, 'text')`. MergeTree index analysis matches predicate atoms by column name, so the `getSubcolumn(...)` form never matched the indexed subcolumn name and the index was skipped. Top-level column predicates were unaffected because the shared index-analysis canonicalizer already strips the `materialize()` wrapper that views add.

Fix: in `cloneDAGWithInversionPushDown` (the canonicalizer that feeds `KeyCondition` and every skip-index condition) fold `getSubcolumn(<input>, '<const subname>')` into a single `INPUT` named `<input>.<subname>`. This is applied only to the cloned DAG used for index/PK granule pruning, never to filter execution, and falls back to generic cloning for any non-foldable shape, so it cannot change query results. One change fixes the text skip index, generic skip indexes, the primary key, and minmax indexes, and it composes for nested subcolumns.

Added a stateless regression test `04322_subcolumn_skip_index_through_view` that asserts, through a view, the index is used (via `force_data_skipping_indices`, which errors otherwise) and that the plan prunes granules for the text index, a generic `bloom_filter` on both an `Array(Tuple).text` and a plain `Tuple` subcolumn, and the primary key on a nested `Tuple` subcolumn. The test fails on master (`INDEX_NOT_USED`) and passes with this fix.

Closes https://github.com/ClickHouse/ClickHouse/issues/107038