### PR TITLE
Fix constant filter conjunct pushed to non-preserved side of OUTER JOIN

### DIFF
--- a/src/Interpreters/ActionsDAG.cpp
+++ b/src/Interpreters/ActionsDAG.cpp
@@ -2711,6 +2711,34 @@ ConjunctionNodes getConjunctionNodes(ActionsDAG::Node * predicate, std::unordere
     return conjunction;
 }
 
+/// Returns true if the conjunct's sub-DAG reaches at least one node from allowed_nodes.
+/// Used to detect a conjunct that depends on no allowed input of a JOIN side (e.g. a pure
+/// constant like `1` or a folded `NULL`). Such a conjunct must not be pushed to a disabled
+/// (non-preserved) side: it would be evaluated on that side's input before the join, and the
+/// non-matched rows the OUTER join fabricates would not be constrained by it.
+bool conjunctDependsOnAllowedInput(const ActionsDAG::Node * conjunct, const std::unordered_set<const ActionsDAG::Node *> & allowed_nodes)
+{
+    std::stack<const ActionsDAG::Node *> stack;
+    std::unordered_set<const ActionsDAG::Node *> visited;
+    stack.push(conjunct);
+    visited.insert(conjunct);
+    while (!stack.empty())
+    {
+        const auto * node = stack.top();
+        stack.pop();
+
+        if (allowed_nodes.contains(node))
+            return true;
+
+        for (const auto * child : node->children)
+        {
+            if (visited.insert(child).second)
+                stack.push(child);
+        }
+    }
+    return false;
+}
+
 ColumnsWithTypeAndName prepareFunctionArguments(const ActionsDAG::NodeRawConstPtrs & nodes)
 {
     ColumnsWithTypeAndName arguments;
@@ -2965,6 +2993,43 @@ ActionsDAG::ActionsForJOINFilterPushDown ActionsDAG::splitActionsForJOINFilterPu
     auto left_stream_push_down_conjunctions = getConjunctionNodes(predicate, left_stream_allowed_nodes, false);
     auto right_stream_push_down_conjunctions = getConjunctionNodes(predicate, right_stream_allowed_nodes, false);
     auto both_streams_push_down_conjunctions = getConjunctionNodes(predicate, both_streams_allowed_nodes, false);
+
+    /// getConjunctionNodes() classifies a conjunct as pushable to a side when all of its inputs are
+    /// allowed inputs of that side. A conjunct with no inputs (a pure constant such as a literal `1`
+    /// or a folded `NULL`) satisfies this trivially, so it is classified as pushable to EVERY side,
+    /// including a side that is disabled for push-down. A side is disabled exactly when its allowed
+    /// input set is empty, which is how the non-preserved side of an OUTER join is modeled. Pushing a
+    /// constant to a non-preserved side and dropping it from the post-join filter is wrong: a falsy or
+    /// NULL constant filters out that side's input, the OUTER join then fabricates non-matched rows
+    /// with the side's columns defaulted, and those rows escape the now constant-free post-join filter.
+    /// Move such no-input conjuncts back to the post-join filter, where they correctly constrain every
+    /// output row. This is applied only to a disabled side: pushing a constant to an enabled (preserved)
+    /// side is equivalent to keeping it in the post-join filter and is the intended push-down behaviour,
+    /// so the classification for enabled sides is left intact.
+    auto keep_conjuncts_depending_on_allowed_input = [](ConjunctionNodes & conjunctions, const std::unordered_set<const Node *> & allowed_nodes)
+    {
+        NodeRawConstPtrs kept;
+        for (const auto * conjunct : conjunctions.allowed)
+        {
+            if (conjunctDependsOnAllowedInput(conjunct, allowed_nodes))
+                kept.push_back(conjunct);
+            else
+                conjunctions.rejected.push_back(conjunct);
+        }
+        conjunctions.allowed = std::move(kept);
+    };
+
+    const bool left_stream_push_down_enabled = !left_stream_allowed_nodes.empty();
+    const bool right_stream_push_down_enabled = !right_stream_allowed_nodes.empty();
+
+    if (!left_stream_push_down_enabled)
+        keep_conjuncts_depending_on_allowed_input(left_stream_push_down_conjunctions, left_stream_allowed_nodes);
+    if (!right_stream_push_down_enabled)
+        keep_conjuncts_depending_on_allowed_input(right_stream_push_down_conjunctions, right_stream_allowed_nodes);
+    /// A both-streams conjunct is pushed to BOTH sides, so a no-input conjunct here is unsafe if
+    /// EITHER side is disabled.
+    if (!left_stream_push_down_enabled || !right_stream_push_down_enabled)
+        keep_conjuncts_depending_on_allowed_input(both_streams_push_down_conjunctions, both_streams_allowed_nodes);
 
     NodeRawConstPtrs left_stream_allowed_conjunctions = std::move(left_stream_push_down_conjunctions.allowed);
     NodeRawConstPtrs right_stream_allowed_conjunctions = std::move(right_stream_push_down_conjunctions.allowed);

--- a/tests/queries/0_stateless/04335_storage_join_right_join_const_conjunct_pushdown.reference
+++ b/tests/queries/0_stateless/04335_storage_join_right_join_const_conjunct_pushdown.reference
@@ -1,0 +1,5 @@
+bare predicate, QUALIFY NULL
+no-op AND constant, QUALIFY NULL
+baseline, no WHERE keeps both right rows
+2	-2	2	-2
+0	0	6	-6

--- a/tests/queries/0_stateless/04335_storage_join_right_join_const_conjunct_pushdown.sql
+++ b/tests/queries/0_stateless/04335_storage_join_right_join_const_conjunct_pushdown.sql
@@ -1,0 +1,34 @@
+SET enable_analyzer = 1;
+
+DROP TABLE IF EXISTS t_left_04335;
+DROP TABLE IF EXISTS t_join_04335;
+
+CREATE TABLE t_left_04335 (key2 UInt64, key1 Int64) ENGINE = Memory;
+INSERT INTO t_left_04335 VALUES (2, -2), (3, -3);
+
+CREATE TABLE t_join_04335 (key2 UInt64, key1 Int64) ENGINE = Join(ALL, RIGHT, key1, key2);
+INSERT INTO t_join_04335 VALUES (2, -2), (6, -6);
+
+-- A constant conjunct must not be pushed to the non-preserved (left) side of a RIGHT JOIN
+-- and dropped from the post-join filter. Otherwise a NULL/falsy constant filters out the
+-- left input, the join fabricates non-matched rows, and they escape the post-join filter.
+
+SELECT 'bare predicate, QUALIFY NULL';
+SELECT * FROM t_left_04335 ALL RIGHT JOIN t_join_04335
+    ON t_join_04335.key2 = t_left_04335.key2 AND t_join_04335.key1 = t_left_04335.key1
+WHERE (t_left_04335.key2 <=> t_join_04335.key2) = t_left_04335.key2
+QUALIFY NULL;
+
+SELECT 'no-op AND constant, QUALIFY NULL';
+SELECT * FROM t_left_04335 ALL RIGHT JOIN t_join_04335
+    ON t_join_04335.key2 = t_left_04335.key2 AND t_join_04335.key1 = t_left_04335.key1
+WHERE and((t_left_04335.key2 <=> t_join_04335.key2) = t_left_04335.key2, 1)
+QUALIFY NULL;
+
+SELECT 'baseline, no WHERE keeps both right rows';
+SELECT * FROM t_left_04335 ALL RIGHT JOIN t_join_04335
+    ON t_join_04335.key2 = t_left_04335.key2 AND t_join_04335.key1 = t_left_04335.key1
+ORDER BY t_join_04335.key2;
+
+DROP TABLE t_left_04335;
+DROP TABLE t_join_04335;


### PR DESCRIPTION
<!--
Closes: https://github.com/ClickHouse/ClickHouse/issues/106949
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a wrong result in an OUTER JOIN when the `WHERE` filter is a conjunction that contains a constant term (for example `p AND 1`, or `WHERE p QUALIFY NULL` where `QUALIFY NULL` is merged into `WHERE`). The constant conjunct could be pushed into the non-preserved side of the join and removed from the post-join filter, so the join produced non-matched rows with the side columns defaulted and those rows incorrectly passed the filter.


### Description

Reported by SQLancer (#106949).

Reproducer (`tjmin` is a `Join(ALL, RIGHT, ...)` engine table):

```sql
SELECT * FROM tmin ALL RIGHT JOIN tjmin ON tjmin.key2 = tmin.key2 AND tjmin.key1 = tmin.key1
WHERE and((tmin.key2 <=> tjmin.key2) = tmin.key2, 1)
QUALIFY NULL;
```

Without the extra `AND 1` the query returns 0 rows (correct). With it, the
same query returns all right-side rows with the left columns defaulted.

Root cause: `getConjunctionNodes()` (used by
`ActionsDAG::splitActionsForJOINFilterPushDown`) classifies a conjunct as
pushable to a join side when all of its children are allowed inputs of that
side. A conjunct with no inputs (a pure constant such as `1` or a folded
`NULL` literal) satisfies this trivially, so constant conjuncts were treated
as pushable to any side, including a side that is disabled for push-down. For
an OUTER join the non-preserved side is disabled (its allowed-input set is
empty), yet the constant conjunct was still pushed into that side input and
dropped from the post-join filter. A falsy/`NULL` constant then filtered out
the side input, the join fabricated non-matched rows with the side columns
defaulted, and those rows escaped the now constant-free post-join filter.

Fix: push a conjunct to a join side only if it actually depends on at least
one allowed input of that side. Constant conjuncts now stay in the post-join
filter, where they are applied to the join output and correctly constrain all
rows (matched and non-matched).

Regression test added in
`tests/queries/0_stateless/04335_storage_join_right_join_const_conjunct_pushdown.sql`.
It returns 2 wrong rows on current master and 0 rows with this fix.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.378` (included in `26.7` and later)
<!-- ch-version-info:end -->