### PR TITLE
Fix flaky timeout in test_profile_max_sessions_for_user (postgres)

### DIFF
--- a/tests/integration/test_profile_max_sessions_for_user/test.py
+++ b/tests/integration/test_profile_max_sessions_for_user/test.py
@@ -104,8 +104,9 @@ def threaded_run_test(sessions):
         if not any(thread.is_alive() for thread in thread_list):
             break
 
-    for thread in thread_list:
-        thread.join()
+    # Bounded: never fall through to an unbounded join (would hang to the pytest timeout).
+    if any(thread.is_alive() for thread in thread_list):
+        pytest.fail("Timed out waiting for session threads to finish after KILL QUERY")
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_profile_max_sessions_for_user/test.py
+++ b/tests/integration/test_profile_max_sessions_for_user/test.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import threading
+import time
 
 import grpc
 import psycopg2 as py_psql
@@ -92,7 +93,16 @@ def threaded_run_test(sessions):
             instance, "overflown session count", retry_count=120
         )
 
-    instance.query(f"KILL QUERY WHERE user='{TEST_USER}' SYNC")
+    # A single KILL snapshots system.processes once. An accepted session whose
+    # query has not registered yet (slow under sanitizers) survives and its
+    # thread blocks forever. Re-issue KILL until every worker thread has exited.
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline:
+        instance.query(f"KILL QUERY WHERE user='{TEST_USER}' SYNC")
+        for thread in thread_list:
+            thread.join(timeout=1)
+        if not any(thread.is_alive() for thread in thread_list):
+            break
 
     for thread in thread_list:
         thread.join()


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/106175
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes a recurring 900s pytest timeout in `test_profile_max_sessions_for_user/test.py::test_profile_max_sessions_for_user_postgres`, almost exclusively on the `amd_msan` integration shard. Reported by @alexey-milovidov on #106175 (the failure is unrelated to that docs PR).

`threaded_run_test` starts the session threads, waits for the `overflown session count` log (emitted at session acquisition, not at query execution), then issues a single `KILL QUERY WHERE user='test_user' SYNC` and joins the threads with no timeout. The single KILL snapshots `system.processes` once; an accepted session whose infinite `SELECT ... COUNT(*) FROM system.numbers` has not registered yet is not killed and runs forever, so its thread blocks until the pytest limit. The postgres worker uses psycopg2 with no client-side query timeout (native variants have the 600s timeout from `helpers/client.py` that masks the same race), and MSan widens the connect-to-execute window. CIDB over 30 days: 14 timeouts on the postgres variant across 13 distinct PRs and master (11 of 14 on amd_msan) vs 1 each for tcp/http/mysql/grpc, all with the identical `thread.join()` stack.

Fix: re-issue the KILL in a bounded loop until every worker thread has exited, so a late-registering query is caught by a later iteration. The loop is driven by thread liveness rather than `system.processes` being empty, because a process-count loop can break early on a transient gap and reintroduces the same hang. The overflow assertion is unchanged.

Reproduced locally against a debug server: the current code hangs deterministically when an accepted session's query registers after the KILL; the patched code joins all threads within seconds.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.661`
<!-- ch-version-info:end -->