### PR TITLE
Keep Dynamic invariant when inserting from shared variant

### DIFF
--- a/src/Columns/ColumnDynamic.cpp
+++ b/src/Columns/ColumnDynamic.cpp
@@ -452,6 +452,27 @@ void ColumnDynamic::doInsertRangeFrom(const IColumn & src_, size_t start, size_t
         const auto & src_offsets = src_variant_column.getOffsets();
         const auto & src_shared_variant = assert_cast<const ColumnString &>(src_variant_column.getVariantByLocalDiscriminator(src_shared_variant_local_discr));
 
+        /// Some rows from the src shared variant may carry a type that is not a regular variant here yet.
+        /// Promote such types to regular variants up front while we still have room, otherwise the loop
+        /// below would copy them into our shared variant even though they can later become a regular
+        /// variant, leaving the type in both storages (see deserializeAndInsertFromArena which follows the
+        /// same logic). This must happen before caching the destination column references below, because
+        /// addNewVariant reallocates them.
+        for (size_t i = 0; i != length && canAddNewVariant(); ++i)
+        {
+            if (src_local_discriminators[start + i] != src_shared_variant_local_discr)
+                continue;
+            ReadBufferFromMemory type_buf(src_shared_variant.getDataAt(src_offsets[start + i]));
+            auto promoted_type = decodeDataType(type_buf);
+            auto promoted_type_name = promoted_type->getName();
+            if (!variant_info.variant_name_to_discriminator.contains(promoted_type_name))
+                addNewVariant(promoted_type, promoted_type_name);
+        }
+
+        /// addNewVariant above reassigns global discriminators (DataTypeVariant sorts its nested types),
+        /// so the shared variant discriminator captured before the promotion pass may now be stale.
+        shared_variant_discr = getSharedVariantDiscriminator();
+
         auto & local_discriminators = variant_col.getLocalDiscriminators();
         auto & offsets = variant_col.getOffsets();
         const auto shared_variant_local_discr = variant_col.localDiscriminatorByGlobal(shared_variant_discr);

--- a/src/Columns/ColumnDynamic.cpp
+++ b/src/Columns/ColumnDynamic.cpp
@@ -364,6 +364,10 @@ void ColumnDynamic::doInsertFrom(const IColumn & src_, size_t n)
         /// Check if we have this variant and deserialize value into variant from shared variant data.
         if (auto it = variant_info.variant_name_to_discriminator.find(type_name); it != variant_info.variant_name_to_discriminator.end())
             variant_col.deserializeBinaryIntoVariant(it->second, getVariantSerialization(type, type_name), buf, getFormatSettings());
+        /// Try to add it as a regular variant. We must not leave a type both in the shared variant and
+        /// as a regular variant (see deserializeAndInsertFromArena which follows the same logic).
+        else if (addNewVariant(type, type_name))
+            variant_col.deserializeBinaryIntoVariant(variant_info.variant_name_to_discriminator[type_name], getVariantSerialization(type, type_name), buf, getFormatSettings());
         /// Otherwise just insert it into our shared variant.
         else
             variant_col.insertIntoVariantFrom(getSharedVariantDiscriminator(), src_shared_variant, src_offset);
@@ -661,6 +665,15 @@ void ColumnDynamic::doInsertManyFrom(const IColumn & src_, size_t position, size
             tmp_column->reserve(1);
             getVariantSerialization(type, type_name)->deserializeBinary(*tmp_column, buf, getFormatSettings());
             variant_col.insertManyIntoVariantFrom(it->second, *tmp_column, 0, length);
+        }
+        /// Try to add it as a regular variant. We must not leave a type both in the shared variant and
+        /// as a regular variant (see deserializeAndInsertFromArena which follows the same logic).
+        else if (addNewVariant(type, type_name))
+        {
+            auto tmp_column = type->createColumn();
+            tmp_column->reserve(1);
+            getVariantSerialization(type, type_name)->deserializeBinary(*tmp_column, buf, getFormatSettings());
+            variant_col.insertManyIntoVariantFrom(variant_info.variant_name_to_discriminator[type_name], *tmp_column, 0, length);
         }
         /// Otherwise just insert it into our shared variant.
         else

--- a/src/Columns/ColumnDynamic.cpp
+++ b/src/Columns/ColumnDynamic.cpp
@@ -364,8 +364,7 @@ void ColumnDynamic::doInsertFrom(const IColumn & src_, size_t n)
         /// Check if we have this variant and deserialize value into variant from shared variant data.
         if (auto it = variant_info.variant_name_to_discriminator.find(type_name); it != variant_info.variant_name_to_discriminator.end())
             variant_col.deserializeBinaryIntoVariant(it->second, getVariantSerialization(type, type_name), buf, getFormatSettings());
-        /// Try to add it as a regular variant. We must not leave a type both in the shared variant and
-        /// as a regular variant (see deserializeAndInsertFromArena which follows the same logic).
+        /// Try to add a new variant if there are available slots.
         else if (addNewVariant(type, type_name))
             variant_col.deserializeBinaryIntoVariant(variant_info.variant_name_to_discriminator[type_name], getVariantSerialization(type, type_name), buf, getFormatSettings());
         /// Otherwise just insert it into our shared variant.
@@ -452,27 +451,6 @@ void ColumnDynamic::doInsertRangeFrom(const IColumn & src_, size_t start, size_t
         const auto & src_offsets = src_variant_column.getOffsets();
         const auto & src_shared_variant = assert_cast<const ColumnString &>(src_variant_column.getVariantByLocalDiscriminator(src_shared_variant_local_discr));
 
-        /// Some rows from the src shared variant may carry a type that is not a regular variant here yet.
-        /// Promote such types to regular variants up front while we still have room, otherwise the loop
-        /// below would copy them into our shared variant even though they can later become a regular
-        /// variant, leaving the type in both storages (see deserializeAndInsertFromArena which follows the
-        /// same logic). This must happen before caching the destination column references below, because
-        /// addNewVariant reallocates them.
-        for (size_t i = 0; i != length && canAddNewVariant(); ++i)
-        {
-            if (src_local_discriminators[start + i] != src_shared_variant_local_discr)
-                continue;
-            ReadBufferFromMemory type_buf(src_shared_variant.getDataAt(src_offsets[start + i]));
-            auto promoted_type = decodeDataType(type_buf);
-            auto promoted_type_name = promoted_type->getName();
-            if (!variant_info.variant_name_to_discriminator.contains(promoted_type_name))
-                addNewVariant(promoted_type, promoted_type_name);
-        }
-
-        /// addNewVariant above reassigns global discriminators (DataTypeVariant sorts its nested types),
-        /// so the shared variant discriminator captured before the promotion pass may now be stale.
-        shared_variant_discr = getSharedVariantDiscriminator();
-
         auto & local_discriminators = variant_col.getLocalDiscriminators();
         auto & offsets = variant_col.getOffsets();
         const auto shared_variant_local_discr = variant_col.localDiscriminatorByGlobal(shared_variant_discr);
@@ -495,6 +473,16 @@ void ColumnDynamic::doInsertRangeFrom(const IColumn & src_, size_t start, size_t
                     getVariantSerialization(type, type_name)->deserializeBinary(variant, buf, getFormatSettings());
                     /// Local discriminators were already filled in ColumnVariant::insertRangeFrom and this row should contain
                     /// shared_variant_local_discr. Change it to local discriminator of the found variant and update offsets.
+                    local_discriminators[prev_size + i] = local_discr;
+                    offsets[prev_size + i] = variant.size() - 1;
+                }
+                /// Try to add a new variant if there are available slots. addNewVariant only reassigns global
+                /// discriminators, so shared_variant_local_discr and the cached references stay valid.
+                else if (addNewVariant(type, type_name))
+                {
+                    auto local_discr = variant_col.localDiscriminatorByGlobal(variant_info.variant_name_to_discriminator[type_name]);
+                    auto & variant = variant_col.getVariantByLocalDiscriminator(local_discr);
+                    getVariantSerialization(type, type_name)->deserializeBinary(variant, buf, getFormatSettings());
                     local_discriminators[prev_size + i] = local_discr;
                     offsets[prev_size + i] = variant.size() - 1;
                 }
@@ -687,8 +675,7 @@ void ColumnDynamic::doInsertManyFrom(const IColumn & src_, size_t position, size
             getVariantSerialization(type, type_name)->deserializeBinary(*tmp_column, buf, getFormatSettings());
             variant_col.insertManyIntoVariantFrom(it->second, *tmp_column, 0, length);
         }
-        /// Try to add it as a regular variant. We must not leave a type both in the shared variant and
-        /// as a regular variant (see deserializeAndInsertFromArena which follows the same logic).
+        /// Try to add a new variant if there are available slots.
         else if (addNewVariant(type, type_name))
         {
             auto tmp_column = type->createColumn();

--- a/src/Columns/ColumnDynamic.cpp
+++ b/src/Columns/ColumnDynamic.cpp
@@ -340,8 +340,11 @@ void ColumnDynamic::doInsertFrom(const IColumn & src_, size_t n)
 {
     const auto & dynamic_src = assert_cast<const ColumnDynamic &>(src_);
 
-    /// Check if we have the same variants in both columns.
-    if (variant_info.variant_name == dynamic_src.variant_info.variant_name)
+    /// Same variants: copy the Variant column directly. Skip this fast path when the source has values in
+    /// its shared variant and we still have room, so those types get promoted to regular variants below
+    /// instead of ending up in both storages.
+    if (variant_info.variant_name == dynamic_src.variant_info.variant_name
+        && (dynamic_src.getSharedVariant().empty() || !canAddNewVariant()))
     {
         variant_column_ptr->insertFrom(*dynamic_src.variant_column, n);
         return;
@@ -421,8 +424,11 @@ void ColumnDynamic::doInsertRangeFrom(const IColumn & src_, size_t start, size_t
     const auto & dynamic_src = assert_cast<const ColumnDynamic &>(src_);
     auto & variant_col = getVariantColumn();
 
-    /// Check if we have the same variants in both columns.
-    if (variant_info.variant_names == dynamic_src.variant_info.variant_names)
+    /// Same variants: copy the Variant range directly. Skip this fast path when the source has values in
+    /// its shared variant and we still have room, so those types get promoted to regular variants in the
+    /// combine path below instead of ending up in both storages.
+    if (variant_info.variant_names == dynamic_src.variant_info.variant_names
+        && (dynamic_src.getSharedVariant().empty() || !canAddNewVariant()))
     {
         variant_col.insertRangeFrom(*dynamic_src.variant_column, start, length);
         return;
@@ -646,8 +652,11 @@ void ColumnDynamic::doInsertManyFrom(const IColumn & src_, size_t position, size
     const auto & dynamic_src = assert_cast<const ColumnDynamic &>(src_);
     auto & variant_col = getVariantColumn();
 
-    /// Check if we have the same variants in both columns.
-    if (variant_info.variant_names == dynamic_src.variant_info.variant_names)
+    /// Same variants: copy the Variant value directly. Skip this fast path when the source has values in
+    /// its shared variant and we still have room, so a type living in the source shared variant gets
+    /// promoted to a regular variant below instead of ending up in both storages.
+    if (variant_info.variant_names == dynamic_src.variant_info.variant_names
+        && (dynamic_src.getSharedVariant().empty() || !canAddNewVariant()))
     {
         variant_col.insertManyFrom(*dynamic_src.variant_column, position, length);
         return;

--- a/src/Columns/tests/gtest_column_dynamic.cpp
+++ b/src/Columns/tests/gtest_column_dynamic.cpp
@@ -488,6 +488,40 @@ TEST(ColumnDynamic, InsertFromSharedVariantKeepsInvariant)
     check(/*many=*/ true);
 }
 
+/// Same invariant as above, exercised through the public range-copy path. insertRangeFrom has its own
+/// shared-variant source loops that used to copy a type from the source shared variant into the
+/// destination shared variant without trying to add it as a regular variant first, even when there was
+/// room. A subsequent range copy could then add the same type as a regular variant, leaving it in both
+/// storages.
+TEST(ColumnDynamic, InsertRangeFromSharedVariantKeepsInvariant)
+{
+    /// src_shared: String lives only inside its shared variant (Int8 is the single regular variant).
+    auto src_shared = ColumnDynamic::create(1);
+    src_shared->insert(Field(1));
+    src_shared->insert(Field("from_shared"));
+    ASSERT_EQ(getTypeNamesInSharedVariant(*src_shared), (std::set<String>{"String"}));
+
+    /// src_regular: String is a regular variant.
+    auto src_regular = ColumnDynamic::create(10);
+    src_regular->insert(Field("from_regular"));
+    ASSERT_TRUE(src_regular->getVariantInfo().variant_name_to_discriminator.contains("String"));
+
+    /// Copy the shared-variant String row first (column_to has no String regular variant yet but has
+    /// room), then copy the regular-variant String row.
+    auto column_to = ColumnDynamic::create(10);
+    column_to->insertRangeFrom(*src_shared, 1, 1);
+    column_to->insertRangeFrom(*src_regular, 0, 1);
+
+    /// Invariant: String must not be present both as a regular variant and inside the shared variant.
+    const bool string_is_regular = column_to->getVariantInfo().variant_name_to_discriminator.contains("String");
+    const bool string_in_shared = getTypeNamesInSharedVariant(*column_to).contains("String");
+    ASSERT_FALSE(string_is_regular && string_in_shared);
+
+    /// Both values must read back correctly regardless of which storage holds them.
+    ASSERT_EQ((*column_to)[0], Field("from_shared"));
+    ASSERT_EQ((*column_to)[1], Field("from_regular"));
+}
+
 static void checkInsertRangeFrom(const ColumnDynamic::MutablePtr & column_from, ColumnDynamic::MutablePtr & column_to, const std::string & expected_variant, const Names & expected_names, const UnorderedMapWithMemoryTracking<String, UInt8> & expected_variant_name_to_discriminator)
 {
     column_to->insertRangeFrom(*column_from, 0, 3);
@@ -708,12 +742,16 @@ TEST(ColumnDynamic, InsertRangeFromOverflow7)
     column_to->insert(Field(42));
 
     column_to->insertRangeFrom(*column_from, 0, 8);
-    ASSERT_EQ(column_to->getVariantInfo().variant_names.size(), 4);
+    /// column_to has plenty of room (max_dynamic_types=254), so every type coming from column_from's
+    /// shared variant (Int8 and Array(Int8)) is promoted to a regular variant rather than left in the
+    /// shared variant. This keeps the invariant that a type lives in exactly one storage and matches the
+    /// row-by-row insertFrom path and deserializeAndInsertFromArena.
+    ASSERT_EQ(column_to->getVariantInfo().variant_names.size(), 5);
     ASSERT_TRUE(column_to->getVariantInfo().variant_name_to_discriminator.contains("Float64"));
     ASSERT_TRUE(column_to->getVariantInfo().variant_name_to_discriminator.contains("String"));
     ASSERT_TRUE(column_to->getVariantInfo().variant_name_to_discriminator.contains("Int8"));
-    ASSERT_FALSE(column_to->getVariantInfo().variant_name_to_discriminator.contains("Array(Int8)"));
-    ASSERT_EQ(column_to->getSharedVariant().size(), 2);
+    ASSERT_TRUE(column_to->getVariantInfo().variant_name_to_discriminator.contains("Array(Int8)"));
+    ASSERT_EQ(column_to->getSharedVariant().size(), 0);
     auto field = (*column_to)[column_to->size() - 8];
     ASSERT_EQ(field, Field(42.42));
     field = (*column_to)[column_to->size() - 7];

--- a/src/Columns/tests/gtest_column_dynamic.cpp
+++ b/src/Columns/tests/gtest_column_dynamic.cpp
@@ -1,8 +1,12 @@
 #include <Columns/ColumnDynamic.h>
 #include <Columns/ColumnString.h>
+#include <DataTypes/DataTypesBinaryEncoding.h>
+#include <IO/ReadBufferFromMemory.h>
 #include <IO/ReadBufferFromString.h>
 #include <gtest/gtest.h>
 #include <Common/Arena.h>
+
+#include <set>
 
 using namespace DB;
 
@@ -412,6 +416,76 @@ TEST(ColumnDynamic, InsertManyFromOverflow3)
     ASSERT_EQ(field, 42.42);
     field = (*column_to)[column_to->size() - 1];
     ASSERT_EQ(field, 42.42);
+}
+
+/// Helper for the regression test below: returns the set of type names that are physically present
+/// in the shared variant of a ColumnDynamic (decoded from the binary-encoded shared variant rows).
+static std::set<String> getTypeNamesInSharedVariant(const ColumnDynamic & column)
+{
+    std::set<String> names;
+    const auto & shared_variant = column.getSharedVariant();
+    for (size_t i = 0; i != shared_variant.size(); ++i)
+    {
+        auto value = shared_variant.getDataAt(i);
+        ReadBufferFromMemory buf(value);
+        names.insert(decodeDataType(buf)->getName());
+    }
+    return names;
+}
+
+/// A type must never be present both as a regular variant and inside the shared variant of the same
+/// ColumnDynamic. doInsertFrom/doInsertManyFrom used to break this when a value coming from the source
+/// shared variant was inserted into a column that still had room for a new regular variant while the
+/// same type was already accumulated in the destination shared variant. The resulting column had the
+/// type in both storages, which later crashed function execution over Dynamic with a row-count
+/// LOGICAL_ERROR in checkFunctionArgumentSizes.
+TEST(ColumnDynamic, InsertFromSharedVariantKeepsInvariant)
+{
+    auto check = [](bool many)
+    {
+        /// src_shared: holds String inside its shared variant (Int8 is the single regular variant,
+        /// String overflowed into shared). Inserting its String row goes through the shared-variant
+        /// branch of (do)insertFrom.
+        auto src_shared = ColumnDynamic::create(1);
+        src_shared->insert(Field(1));
+        src_shared->insert(Field("from_shared"));
+        ASSERT_EQ(getTypeNamesInSharedVariant(*src_shared), (std::set<String>{"String"}));
+        const size_t shared_string_row = src_shared->size() - 1;
+
+        /// src_regular: holds String as a regular variant.
+        auto src_regular = ColumnDynamic::create(10);
+        src_regular->insert(Field("from_regular"));
+        ASSERT_TRUE(src_regular->getVariantInfo().variant_name_to_discriminator.contains("String"));
+
+        /// Build column_to the way the join non-joined-rows gather does: a fresh Dynamic with room,
+        /// filled row by row by insertFrom from sources with different internal layouts. First take the
+        /// String value that lives in src_shared's shared variant (no String regular variant in
+        /// column_to yet, but there is room), then take a String value that is a regular variant in
+        /// src_regular.
+        auto column_to = ColumnDynamic::create(10);
+        if (many)
+        {
+            column_to->insertManyFrom(*src_shared, shared_string_row, 2);
+            column_to->insertManyFrom(*src_regular, 0, 2);
+        }
+        else
+        {
+            column_to->insertFrom(*src_shared, shared_string_row);
+            column_to->insertFrom(*src_regular, 0);
+        }
+
+        /// Invariant: String must not be present both as a regular variant and inside the shared variant.
+        const bool string_is_regular = column_to->getVariantInfo().variant_name_to_discriminator.contains("String");
+        const bool string_in_shared = getTypeNamesInSharedVariant(*column_to).contains("String");
+        ASSERT_FALSE(string_is_regular && string_in_shared);
+
+        /// And every inserted value must read back correctly regardless of which storage holds it.
+        ASSERT_EQ((*column_to)[0], Field("from_shared"));
+        ASSERT_EQ((*column_to)[column_to->size() - 1], Field("from_regular"));
+    };
+
+    check(/*many=*/ false);
+    check(/*many=*/ true);
 }
 
 static void checkInsertRangeFrom(const ColumnDynamic::MutablePtr & column_from, ColumnDynamic::MutablePtr & column_to, const std::string & expected_variant, const Names & expected_names, const UnorderedMapWithMemoryTracking<String, UInt8> & expected_variant_name_to_discriminator)

--- a/src/Columns/tests/gtest_column_dynamic.cpp
+++ b/src/Columns/tests/gtest_column_dynamic.cpp
@@ -265,9 +265,12 @@ TEST(ColumnDynamic, InsertFromOverflow3)
     auto field = (*column_to)[column_to->size() - 1];
     ASSERT_EQ(field, 42);
 
+    /// column_from and column_to share the same variant layout, but column_to has room (max_dynamic_types=254),
+    /// so the Float64 value coming from column_from's shared variant is promoted to a regular variant instead
+    /// of being left in the shared variant. This keeps the invariant that a type lives in exactly one storage.
     column_to->insertFrom(*column_from, 1);
-    ASSERT_FALSE(column_to->getVariantInfo().variant_name_to_discriminator.contains("Float64"));
-    ASSERT_EQ(column_to->getSharedVariant().size(), 1);
+    ASSERT_TRUE(column_to->getVariantInfo().variant_name_to_discriminator.contains("Float64"));
+    ASSERT_EQ(column_to->getSharedVariant().size(), 0);
     field = (*column_to)[column_to->size() - 1];
     ASSERT_EQ(field, 42.42);
 }
@@ -409,9 +412,12 @@ TEST(ColumnDynamic, InsertManyFromOverflow3)
     field = (*column_to)[column_to->size() - 1];
     ASSERT_EQ(field, 42);
 
+    /// column_from and column_to share the same variant layout, but column_to has room (max_dynamic_types=254),
+    /// so the Float64 value coming from column_from's shared variant is promoted to a regular variant instead
+    /// of being left in the shared variant. This keeps the invariant that a type lives in exactly one storage.
     column_to->insertManyFrom(*column_from, 1, 2);
-    ASSERT_FALSE(column_to->getVariantInfo().variant_name_to_discriminator.contains("Float64"));
-    ASSERT_EQ(column_to->getSharedVariant().size(), 2);
+    ASSERT_TRUE(column_to->getVariantInfo().variant_name_to_discriminator.contains("Float64"));
+    ASSERT_EQ(column_to->getSharedVariant().size(), 0);
     field = (*column_to)[column_to->size() - 2];
     ASSERT_EQ(field, 42.42);
     field = (*column_to)[column_to->size() - 1];
@@ -520,6 +526,69 @@ TEST(ColumnDynamic, InsertRangeFromSharedVariantKeepsInvariant)
     /// Both values must read back correctly regardless of which storage holds them.
     ASSERT_EQ((*column_to)[0], Field("from_shared"));
     ASSERT_EQ((*column_to)[1], Field("from_regular"));
+}
+
+/// Same invariant, but exercised through the same-variants fast path at the top of
+/// insertFrom/insertManyFrom/insertRangeFrom. Two Dynamic columns can share the same variant_names while
+/// having different max_dynamic_types: a low-limit source overflows a type into its shared variant, while
+/// a high-limit destination with the same layout still has room for it as a regular variant. The fast path
+/// used to copy the source shared-variant row straight into the destination shared variant, so a later
+/// insert could add the same type as a regular variant and leave it in both storages.
+TEST(ColumnDynamic, SameLayoutSharedVariantKeepsInvariant)
+{
+    enum Mode { One, Many, Range };
+    auto check = [](Mode mode)
+    {
+        /// src_shared: Int8 is the single regular variant (max_dynamic_types=1), String overflowed into
+        /// the shared variant. Its row 1 (String) lives in the shared variant.
+        auto src_shared = ColumnDynamic::create(1);
+        src_shared->insert(Field(1));
+        src_shared->insert(Field("from_shared"));
+        ASSERT_EQ(getTypeNamesInSharedVariant(*src_shared), (std::set<String>{"String"}));
+
+        /// src_regular: String is a regular variant.
+        auto src_regular = ColumnDynamic::create(10);
+        src_regular->insert(Field("from_regular"));
+        ASSERT_TRUE(src_regular->getVariantInfo().variant_name_to_discriminator.contains("String"));
+
+        /// column_to has the SAME variant_names as src_shared (Int8 + SharedVariant) but a higher limit,
+        /// so it still has room to add String as a regular variant.
+        auto column_to = ColumnDynamic::create(10);
+        column_to->insert(Field(2));
+        ASSERT_EQ(column_to->getVariantInfo().variant_names, src_shared->getVariantInfo().variant_names);
+
+        /// First copy the shared-variant String row (same-layout fast path), then copy the regular-variant
+        /// String row (different layout).
+        if (mode == Many)
+        {
+            column_to->insertManyFrom(*src_shared, 1, 2);
+            column_to->insertManyFrom(*src_regular, 0, 2);
+        }
+        else if (mode == Range)
+        {
+            column_to->insertRangeFrom(*src_shared, 1, 1);
+            column_to->insertRangeFrom(*src_regular, 0, 1);
+        }
+        else
+        {
+            column_to->insertFrom(*src_shared, 1);
+            column_to->insertFrom(*src_regular, 0);
+        }
+
+        /// Invariant: String must not be present both as a regular variant and inside the shared variant.
+        const bool string_is_regular = column_to->getVariantInfo().variant_name_to_discriminator.contains("String");
+        const bool string_in_shared = getTypeNamesInSharedVariant(*column_to).contains("String");
+        ASSERT_FALSE(string_is_regular && string_in_shared);
+
+        /// Values must read back correctly regardless of which storage holds them.
+        ASSERT_EQ((*column_to)[0], Field(2));
+        ASSERT_EQ((*column_to)[1], Field("from_shared"));
+        ASSERT_EQ((*column_to)[column_to->size() - 1], Field("from_regular"));
+    };
+
+    check(One);
+    check(Many);
+    check(Range);
 }
 
 static void checkInsertRangeFrom(const ColumnDynamic::MutablePtr & column_from, ColumnDynamic::MutablePtr & column_to, const std::string & expected_variant, const Names & expected_names, const UnorderedMapWithMemoryTracking<String, UInt8> & expected_variant_name_to_discriminator)


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/106953
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a `LOGICAL_ERROR` (`Expected the argument N to have X rows, but it has Y`) when executing a function over a `Dynamic` column built by a JOIN over `Dynamic` (for example the non-joined rows of a `RIGHT`/`FULL JOIN`, or a correlated `EXISTS` subquery decorrelated into a join).

### Description

`ColumnDynamic` keeps an invariant that a logical type is stored either as a regular variant or inside the shared variant, never both. `doInsertFrom`/`doInsertManyFrom` could break it: when a value coming from the source shared variant was inserted into a destination that still had room for a new regular variant, the type was always appended to the destination shared variant; during a row-by-row gather the same type could also become a regular variant for other rows, leaving it in both storages. Such a column then crashed `ExecutableFunctionDynamicAdaptor::executeImpl` with the row-count `LOGICAL_ERROR` above.

The fix makes the shared-variant branch of `doInsertFrom`/`doInsertManyFrom` try `addNewVariant` first (falling back to the shared variant only when no regular variant can be added), matching `deserializeAndInsertFromArena`. Found by the AST fuzzer (STID 2959-51fd). Added a `ColumnDynamic` unit test that reproduces the broken invariant through the public insert API.


<!-- ch-version-info:start -->
### Version info
- Backported to: `26.3.33.29`
<!-- ch-version-info:end -->