### PR TITLE
Fix spurious ZooKeeper session recreation on config reload

### DIFF
--- a/src/Common/ZooKeeper/ZooKeeper.cpp
+++ b/src/Common/ZooKeeper/ZooKeeper.cpp
@@ -377,6 +377,11 @@ bool ZooKeeper::configChanged(const Poco::Util::AbstractConfiguration & config, 
     new_args.enforce_component_tracking = args.enforce_component_tracking;
     new_args.send_receive_os_threads_nice_value = args.send_receive_os_threads_nice_value;
 
+    /// last_zxid_seen is runtime session state propagated by startNewSession, not configuration,
+    /// so it is always 0 in new_args. Without this, the first config reload after any
+    /// expiry-driven session replacement recreates the session even if the config is unchanged.
+    new_args.last_zxid_seen = args.last_zxid_seen;
+
     return args != new_args;
 }
 

--- a/src/Common/ZooKeeper/ZooKeeperArgs.h
+++ b/src/Common/ZooKeeper/ZooKeeperArgs.h
@@ -29,6 +29,10 @@ struct ZooKeeperArgs
     /// hosts_string -- comma separated [secure://]host:port list
     ZooKeeperArgs(const String & hosts_string); /// NOLINT(google-explicit-constructor)
     ZooKeeperArgs() = default;
+    /// Memberwise comparison. ZooKeeper::configChanged uses it to compare args parsed from
+    /// config; any field below that is set out-of-band (server settings, runtime session state
+    /// such as last_zxid_seen) must be excluded from the comparison there, otherwise every
+    /// config reload spuriously recreates the session.
     bool operator == (const ZooKeeperArgs &) const = default;
 
     String zookeeper_name = "zookeeper";

--- a/tests/integration/test_zookeeper_session_on_config_reload/test.py
+++ b/tests/integration/test_zookeeper_session_on_config_reload/test.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+import pytest
+
+from helpers.cluster import ClickHouseCluster
+
+cluster = ClickHouseCluster(__file__)
+node = cluster.add_instance("node", with_zookeeper=True)
+
+
+@pytest.fixture(scope="module")
+def started_cluster():
+    try:
+        cluster.start()
+        yield cluster
+    finally:
+        cluster.shutdown()
+
+
+def get_session_id():
+    return int(
+        node.query(
+            "SELECT client_id FROM system.zookeeper_connection WHERE name = 'default'"
+        ).strip()
+    )
+
+
+def test_zookeeper_session_on_config_reload(started_cluster):
+    # Make the session observe some non-zero zxid.
+    node.query(
+        "CREATE TABLE t (key UInt64) "
+        "ENGINE = ReplicatedMergeTree('/clickhouse/tables/t', 'r1') ORDER BY key"
+    )
+
+    # Reloading an unchanged config must keep the session.
+    session_id = get_session_id()
+    node.query("SYSTEM RELOAD CONFIG")
+    assert get_session_id() == session_id
+
+    # Expire the session and touch ZooKeeper to establish a new one. The new
+    # session remembers the last zxid seen by the expired one (to refuse
+    # connecting to a Keeper node that is behind).
+    node.query("SYSTEM RECONNECT ZOOKEEPER")
+    node.query("SELECT * FROM system.zookeeper WHERE path = '/'")
+
+    new_session_id = get_session_id()
+    assert new_session_id != session_id
+    assert (
+        int(
+            node.query(
+                "SELECT last_zxid_seen FROM system.zookeeper_connection WHERE name = 'default'"
+            ).strip()
+        )
+        > 0
+    )
+
+    # Reloading an unchanged config must keep the session even after the
+    # replacement (the remembered zxid is session state, not configuration).
+    node.query("SYSTEM RELOAD CONFIG")
+    assert get_session_id() == new_session_id


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix spurious ZooKeeper session recreation on config reload

ZooKeeperArgs::operator== is defaulted and compares all fields, including last_zxid_seen, which is runtime session state rather than configuration: startNewSession copies the last zxid seen by the expired session into the new session's args (to refuse connecting to a Keeper node that is behind), so after the first expiry-driven session replacement the live args always carry a non-zero last_zxid_seen.

Same class of bug as the earlier fix for enforce_component_tracking and send_receive_os_threads_nice_value in faa405352dd; extend the same copy-over block.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.647`
- Backported to: `26.5.3.21`, `26.4.5.28`, `26.3.14.22`
<!-- ch-version-info:end -->