### PR TITLE
Do not hold mutex across ZooKeeper reads in access entities refresh

### DIFF
--- a/src/Access/ZooKeeperReplicator.cpp
+++ b/src/Access/ZooKeeperReplicator.cpp
@@ -310,6 +310,7 @@ bool ZooKeeperReplicator::removeEntity(const UUID & id, bool throw_if_not_exists
     if (!ok)
         return false;
 
+    std::lock_guard refresh_lock{refresh_mutex};
     std::lock_guard lock{mutex};
     removeEntityNoLock(id);
     return true;
@@ -569,6 +570,13 @@ void ZooKeeperReplicator::refreshEntities(const zkutil::ZooKeeperPtr & zookeeper
 {
     LOG_DEBUG(&Poco::Logger::get(storage_name), "Refreshing entities list");
 
+    /// Reading from ZooKeeper is one synchronous round trip per entity and must not happen under
+    /// `mutex`: findEntity (authentication, Context::getAccess) blocks on it, so holding it across
+    /// a slow refresh stalls every query on the server. `refresh_mutex` keeps the reads and the
+    /// publication of their results atomic with respect to other read->publish sequences, so this
+    /// snapshot can never overwrite the result of a newer read.
+    std::lock_guard refresh_lock{refresh_mutex};
+
     if (all)
     {
         /// It doesn't make sense to keep the queue because we will reread everything in this function.
@@ -586,11 +594,6 @@ void ZooKeeperReplicator::refreshEntities(const zkutil::ZooKeeperPtr & zookeeper
     entity_uuids.reserve(entity_uuid_strs.size());
     for (const String & entity_uuid_str : entity_uuid_strs)
         entity_uuids.emplace_back(parseUUID(entity_uuid_str));
-
-    /// Reading entities is one synchronous ZooKeeper round trip per entity and must not happen
-    /// under `mutex`: findEntity (authentication, Context::getAccess) blocks on it, so holding it
-    /// across a slow refresh stalls every query on the server. Entities changed concurrently while
-    /// we read without the lock are caught up via the watches these reads register.
 
     if (all)
     {
@@ -619,13 +622,19 @@ void ZooKeeperReplicator::refreshEntities(const zkutil::ZooKeeperPtr & zookeeper
             }
         }
         for (const auto & uuid : new_uuids)
-            refreshEntity(zookeeper, uuid);
+            refreshEntityImpl(zookeeper, uuid);
     }
 
     LOG_DEBUG(&Poco::Logger::get(storage_name), "Refreshing entities list finished");
 }
 
 void ZooKeeperReplicator::refreshEntity(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id)
+{
+    std::lock_guard refresh_lock{refresh_mutex};
+    refreshEntityImpl(zookeeper, id);
+}
+
+void ZooKeeperReplicator::refreshEntityImpl(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id)
 {
     LOG_DEBUG(&Poco::Logger::get(storage_name), "Refreshing entity {}", toString(id));
 

--- a/src/Access/ZooKeeperReplicator.cpp
+++ b/src/Access/ZooKeeperReplicator.cpp
@@ -587,7 +587,10 @@ void ZooKeeperReplicator::refreshEntities(const zkutil::ZooKeeperPtr & zookeeper
     for (const String & entity_uuid_str : entity_uuid_strs)
         entity_uuids.emplace_back(parseUUID(entity_uuid_str));
 
-    std::lock_guard lock{mutex};
+    /// Reading entities is one synchronous ZooKeeper round trip per entity and must not happen
+    /// under `mutex`: findEntity (authentication, Context::getAccess) blocks on it, so holding it
+    /// across a slow refresh stalls every query on the server. Entities changed concurrently while
+    /// we read without the lock are caught up via the watches these reads register.
 
     if (all)
     {
@@ -598,17 +601,25 @@ void ZooKeeperReplicator::refreshEntities(const zkutil::ZooKeeperPtr & zookeeper
             if (auto entity = tryReadEntityFromZooKeeper(zookeeper, uuid))
                 entities.emplace_back(uuid, entity);
         }
+
+        std::lock_guard lock{mutex};
         memory_storage.setAll(entities);
     }
     else
     {
         /// all=false means we read & parse only new access entities from ZooKeeper.
-        memory_storage.removeAllExcept(entity_uuids);
-        for (const auto & uuid : entity_uuids)
+        std::vector<UUID> new_uuids;
         {
-            if (!memory_storage.exists(uuid))
-                refreshEntityNoLock(zookeeper, uuid);
+            std::lock_guard lock{mutex};
+            memory_storage.removeAllExcept(entity_uuids);
+            for (const auto & uuid : entity_uuids)
+            {
+                if (!memory_storage.exists(uuid))
+                    new_uuids.push_back(uuid);
+            }
         }
+        for (const auto & uuid : new_uuids)
+            refreshEntity(zookeeper, uuid);
     }
 
     LOG_DEBUG(&Poco::Logger::get(storage_name), "Refreshing entities list finished");
@@ -622,17 +633,6 @@ void ZooKeeperReplicator::refreshEntity(const zkutil::ZooKeeperPtr & zookeeper, 
 
     std::lock_guard lock{mutex};
 
-    if (entity)
-        setEntityNoLock(id, entity);
-    else
-        removeEntityNoLock(id);
-}
-
-void ZooKeeperReplicator::refreshEntityNoLock(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id)
-{
-    LOG_DEBUG(&Poco::Logger::get(storage_name), "Refreshing entity {}", toString(id));
-
-    auto entity = tryReadEntityFromZooKeeper(zookeeper, id);
     if (entity)
         setEntityNoLock(id, entity);
     else

--- a/src/Access/ZooKeeperReplicator.h
+++ b/src/Access/ZooKeeperReplicator.h
@@ -91,7 +91,6 @@ private:
     bool refresh();
     void refreshEntities(const zkutil::ZooKeeperPtr & zookeeper, bool all);
     void refreshEntity(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id);
-    void refreshEntityNoLock(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id) TSA_REQUIRES(mutex);
 
     AccessEntityPtr tryReadEntityFromZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id) const;
     void setEntityNoLock(const UUID & id, const AccessEntityPtr & entity)  TSA_REQUIRES(mutex);

--- a/src/Access/ZooKeeperReplicator.h
+++ b/src/Access/ZooKeeperReplicator.h
@@ -91,11 +91,20 @@ private:
     bool refresh();
     void refreshEntities(const zkutil::ZooKeeperPtr & zookeeper, bool all);
     void refreshEntity(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id);
+    void refreshEntityImpl(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id) TSA_REQUIRES(refresh_mutex);
 
     AccessEntityPtr tryReadEntityFromZooKeeper(const zkutil::ZooKeeperPtr & zookeeper, const UUID & id) const;
     void setEntityNoLock(const UUID & id, const AccessEntityPtr & entity)  TSA_REQUIRES(mutex);
     void removeEntityNoLock(const UUID & id) TSA_REQUIRES(mutex);
 
+    /// Serializes every "read from ZooKeeper -> publish into memory_storage" sequence (entity
+    /// refreshes and the cache updates of local writes), so that a publish based on an older
+    /// ZooKeeper read can never overwrite a publish based on a newer one. Held across ZooKeeper
+    /// round trips, therefore never taken by the read-only methods (findEntity etc.).
+    /// Lock order: cached_zookeeper_mutex -> refresh_mutex -> mutex.
+    std::mutex refresh_mutex;
+
+    /// Guards memory_storage; held only for in-memory operations, never across ZooKeeper requests.
     mutable std::mutex mutex;
 };
 


### PR DESCRIPTION
### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Do not hold mutex across ZooKeeper reads in access entities refresh

ZooKeeperReplicator::refreshEntities held `mutex` across one synchronous ZooKeeper round trip per access entity. The same mutex is taken by findEntity, which sits on the hot path of authentication (AccessControl::authenticate -> MultipleAccessStorage::findImpl) and of Context::getAccess during query analysis. A full refresh (all=true) runs on every session expiry and on config-driven session recreation; when Keeper round trips are slow (e.g. right after a Keeper rolling restart, when every component reconnects through the freshly created shared session), the refresh holds the mutex for N * latency, during which the server accepts no new connections and query analysis stalls. **Observed in production as a 693-second hold that blocked all queries for the whole window**.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.689`
- Backported to: `26.5.3.22`, `26.4.5.29`, `26.3.14.23`, `25.8.25.22`
<!-- ch-version-info:end -->