### PR TITLE
Check CREATE TEMPORARY TABLE grant lazily in InverseDictionaryLookupPass

### DIFF
--- a/src/Analyzer/Passes/InverseDictionaryLookupPass.cpp
+++ b/src/Analyzer/Passes/InverseDictionaryLookupPass.cpp
@@ -290,6 +290,15 @@ public:
             return;
         }
 
+        /// The rewrite produces `IN (SELECT ... FROM dictionary(...))`, and the `dictionary()`
+        /// table function requires the `CREATE TEMPORARY TABLE` grant; if it is missing, skip the
+        /// optimization to avoid `ACCESS_DENIED`. Checked only after a rewrite candidate is found:
+        /// getAccess touches the access storage, and query analysis must not depend on it for
+        /// queries without `dictGet` predicates (in particular internal queries, which otherwise
+        /// block whenever the replicated access storage is being refreshed).
+        if (!isCreateTemporaryTableGranted())
+            return;
+
         /// Type of the attribute and key columns are not present in the query. So, we have to fetch dictionary and get the column types.
         auto helper = FunctionDictHelper(getContext());
         const String dict_name = dictget_function_info.dict_name_node->getValue().safeGet<String>();
@@ -418,18 +427,22 @@ public:
 
         node = std::move(replacement_node);
     }
+
+private:
+    bool isCreateTemporaryTableGranted()
+    {
+        if (!create_temporary_table_granted.has_value())
+            create_temporary_table_granted = getContext()->getAccess()->isGranted(AccessType::CREATE_TEMPORARY_TABLE);
+        return *create_temporary_table_granted;
+    }
+
+    std::optional<bool> create_temporary_table_granted;
 };
 
 }
 
 void InverseDictionaryLookupPass::run(QueryTreeNodePtr & query_tree_node, ContextPtr context)
 {
-    /// This rewrite turns `dictGet(...)` predicates into `IN (SELECT ... FROM dictionary(...))`.
-    /// The `dictionary()` table function requires `CREATE TEMPORARY TABLE`; if that grant is missing,
-    /// skip the optimization to avoid `ACCESS_DENIED`.
-    if (!context->getAccess()->isGranted(AccessType::CREATE_TEMPORARY_TABLE))
-        return;
-
     InverseDictionaryLookupVisitor visitor(std::move(context));
     visitor.visit(query_tree_node);
 }


### PR DESCRIPTION
### Changelog category (leave one):
- Improvement

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Check CREATE TEMPORARY TABLE grant lazily in InverseDictionaryLookupPass

The grant check (added in d871de78d4a, hoisted to once-per-pass in 6d49cde18b0) ran unconditionally at the start of the pass, so the analysis of every single query called Context::getAccess, including queries with no dictGet predicate at all. For internal queries (dictionary source loads, metrics exporter queries) this was the only access-storage dependency in their lifetime: getAccess resolves the user via MultipleAccessStorage::findImpl, which blocks on the ZooKeeperReplicator mutex whenever the replicated access storage is refreshing its entities list. During a slow refresh this stalled all query analysis server-side for the whole refresh duration (observed in production: 693 seconds between executeQuery and Planner log lines of an internal query stuck in this pass).

Defer the check until a rewrite candidate (dictGet <op> const) is actually found, and cache the result for the rest of the pass. Queries without such predicates no longer touch the access storage here.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.629`
<!-- ch-version-info:end -->