### PR TITLE
Backport version-specific labels to the named release even when end-of-life

### DIFF
--- a/docs/en/development/backports.md
+++ b/docs/en/development/backports.md
@@ -66,6 +66,8 @@ A version-specific label sets the *oldest* release the PR must reach: it is back
 
 The named release does not have to be active itself. A label for an end-of-life release (one with no open release PR) still pulls the fix forward into every active release after it, so upgrading from that release never silently loses the fix. For example, `v25.12-must-backport` on a PR keeps backporting to `26.1`, `26.2`, … even after `25.12` itself has reached end-of-life.
 
+In addition, the **named release itself is backported to whenever its branch still exists in the repository**, even when that release is no longer active — so a fix can be delivered to an end-of-life release line on request. So `v25.12-must-backport` backports to `25.12` (if the `25.12` branch is still present) plus every newer active release. Only when the named branch has been deleted is it skipped. The newer-release fan-out is still limited to *active* releases; an inactive label does not resurrect every old branch between it and the active set.
+
 ## Implementation {#implementation}
 
 ### Overview {#overview}
@@ -86,7 +88,7 @@ Labels on the original PR control whether and where backporting happens.
 | `pr-must-backport` | Backport to all active release branches (skipping branches marked `rolling-out`) |
 | `pr-must-backport-force` | Backport to all active release branches, ignoring `rolling-out` restrictions |
 | `pr-critical-bugfix` | Triggers `pr-must-backport` automatically (via `AUTO_BACKPORT` in `pr_labels_and_category.py`) |
-| `v{VER}-must-backport` (e.g. `v25.3-must-backport`) | Backport to that release branch **and every newer active release branch** — the version marks the *oldest* release the PR must reach, even when the named release is itself end-of-life. With several such labels, the lowest version wins. Overrides the `rolling-out` skip for those branches |
+| `v{VER}-must-backport` (e.g. `v25.3-must-backport`) | Backport to that release branch (whenever its branch still exists, even when end-of-life) **and to every newer active release branch** — the version marks the *oldest* release the PR must reach. With several such labels, the lowest version wins. Overrides the `rolling-out` skip for those branches |
 | `pr-backports-created` | Set by the bot when all required backport PRs have been created; cleared if a cherry-pick PR is reopened |
 | `pr-cherrypick` | Applied to cherry-pick PRs created by the bot |
 | `pr-backport` | Applied to backport PRs created by the bot |
@@ -162,7 +164,7 @@ Before starting any work on a PR, `ReleaseBranch.pre_check` runs `git merge-base
 
 The `CherryPickPRs` class runs at the start of each hourly execution and handles two scenarios:
 
-- **Orphaned cherry-pick PRs**: If a cherry-pick PR's release branch no longer has an open release PR (i.e. the release is closed), the cherry-pick PR is closed automatically.
+- **Orphaned cherry-pick PRs**: If a cherry-pick PR's release branch no longer has an open release PR (i.e. the release is closed), the cherry-pick PR is closed automatically — **unless** the original PR still carries the matching `v{VER}-must-backport` label, which explicitly targets that release line and keeps the cherry-pick open even after the release is end-of-life.
 - **Reopened cherry-pick PRs**: If an original PR already has `pr-backports-created` but a cherry-pick PR for it is still open, the `pr-backports-created` label is removed from the original PR so it can be reprocessed.
 
 For cherry-pick PRs waiting for manual conflict resolution:

--- a/tests/ci/cherry_pick.py
+++ b/tests/ci/cherry_pick.py
@@ -34,7 +34,7 @@ import os
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from subprocess import CalledProcessError
-from typing import Iterable, List, Optional
+from typing import Iterable, List, Optional, Tuple
 
 from github.GithubException import GithubException
 
@@ -799,6 +799,57 @@ class BackportPRs:
             )
             open_pr.edit(state="closed")
 
+    def _release_branch_name(self, version: Tuple[int, int]) -> str:
+        """
+        Build a release branch name in this repository's convention from a
+        version tuple, e.g. `(26, 2)` -> `release/26.2` (private fork) or `26.2`
+        (public repo). The convention is inferred from the active release
+        branches so it matches whatever the repo uses.
+        """
+        prefix = (
+            "release/"
+            if any(branch.startswith("release/") for branch in self.release_branches)
+            else ""
+        )
+        return f"{prefix}{version[0]}.{version[1]}"
+
+    def _branch_exists(self, branch: str) -> bool:
+        """Whether `branch` exists in the repository (a single GitHub lookup)."""
+        try:
+            self.repo.get_branch(branch)
+            return True
+        except GithubException as e:
+            if e.status == 404:
+                return False
+            raise
+
+    def _explicit_named_branches(self, pr_labels: List[str]) -> List[str]:
+        """
+        Release branches explicitly named by a `vX.Y-must-backport` label on the
+        PR that are not active (have no open `release` PR) but still exist in the
+        repository. Such branches are backported to as well, so a fix can reach
+        an end-of-life release line on request. Active branches are handled by
+        the floor fan-out in `select_backport_branches`, so they are skipped here.
+        """
+        active_versions = {branch_version(branch) for branch in self.release_branches}
+        named = []  # type: List[str]
+        for label in pr_labels:
+            version = label_version(label)
+            if version is None or version in active_versions:
+                continue
+            branch = self._release_branch_name(version)
+            if branch in named:
+                continue
+            if self._branch_exists(branch):
+                named.append(branch)
+            else:
+                logging.info(
+                    "PR carries %r but branch %s does not exist, skipping it",
+                    label,
+                    branch,
+                )
+        return named
+
     def process_pr(self, pr: PullRequest) -> None:
         pr_labels = [label.name for label in pr.labels]
 
@@ -808,6 +859,9 @@ class BackportPRs:
         # the PR is backported to that release and every newer active release
         # branch; the lowest such label wins. `skipped` are rolling-out branches
         # excluded for a general backport that no version-specific label covers.
+        # `explicit_branches` are non-active branches explicitly named by a
+        # version label that still exist in the repo, so a fix can be backported
+        # to an end-of-life release line on request.
         rolling_out = set(self._rolling_out_branches())
         branch_names, skipped = select_backport_branches(
             pr_labels,
@@ -816,6 +870,7 @@ class BackportPRs:
             general_backport_labels={Labels.MUST_BACKPORT, Labels.MUST_BACKPORT_FORCE}
             | Labels.AUTO_BACKPORT,
             force_backport_label=Labels.MUST_BACKPORT_FORCE,
+            explicit_branches=self._explicit_named_branches(pr_labels),
         )
 
         if skipped:
@@ -972,6 +1027,21 @@ class CherryPickPRs:
             # The release branch is opened, so we can continue
             return True
         release_name = cpp.head.ref.split("/", maxsplit=1)[1].rsplit("/", maxsplit=1)[0]
+        # A version-specific label on the original PR explicitly targets this
+        # release line, so keep the cherry-pick even though the line is
+        # end-of-life (no open `release` PR). This mirrors the explicit-branch
+        # selection in `BackportPRs._explicit_named_branches`.
+        explicit_label = f"v{release_name.replace('release/', '')}-must-backport"
+        original_pr = self.gh.get_pull_cached(self.repo, original_pr_number)
+        if explicit_label in {label.name for label in original_pr.labels}:
+            logging.info(
+                "Cherry-pick PR %s kept: PR #%s explicitly targets `%s` (`%s`)",
+                cpp.html_url,
+                original_pr_number,
+                release_name,
+                explicit_label,
+            )
+            return True
         logging.info(
             "An opened release PR `%s` for cherry-pick PR %s is not found, going to close it",
             release_name,

--- a/tests/ci/cherry_pick_branches.py
+++ b/tests/ci/cherry_pick_branches.py
@@ -67,14 +67,22 @@ def select_backport_branches(
     *,
     general_backport_labels: Set[str],
     force_backport_label: str,
+    explicit_branches: Sequence[str] = (),
 ) -> Tuple[List[str], List[str]]:
     """
     Decide which release branches a PR should be backported to.
 
-    Returns `(branches, skipped)`, both in `release_branches` order:
-    - `branches`: release branches the PR should be backported to.
+    Returns `(branches, skipped)`:
+    - `branches`: release branches the PR should be backported to, ordered by
+      version (oldest first).
     - `skipped`: rolling-out branches that were excluded, so the caller can
       close any stale cherry-pick / backport PRs for them.
+
+    `explicit_branches` are branches explicitly named by a `vX.Y-must-backport`
+    label that exist in the repository but are not necessarily active (have no
+    open `release` PR). They are always backported to, so a fix can reach an
+    end-of-life release line on request. The caller resolves which named
+    branches actually exist (this module stays free of GitHub access).
 
     Rules:
     - `force_backport_label` -> all release branches, ignoring `rolling_out`.
@@ -84,6 +92,7 @@ def select_backport_branches(
     - otherwise (version-specific labels only) -> the floor release and every
       newer active release branch. `rolling_out` does not apply here: an explicit
       version request always proceeds.
+    In every case the explicitly named existing branches are added to the result.
     """
     labels = set(pr_labels)
     floor = backport_floor(pr_labels)
@@ -95,30 +104,35 @@ def select_backport_branches(
         for branch in release_branches
         if floor is not None and branch_version(branch) >= floor
     }
+    explicit = set(explicit_branches)
+
+    def ordered(branches: Set[str]) -> List[str]:
+        return sorted(branches, key=branch_version)
 
     if force_backport_label in labels:
-        return list(release_branches), []
+        return ordered(set(release_branches) | explicit), []
 
     if labels & general_backport_labels:
-        branches = [
+        selected = {
             branch
             for branch in release_branches
             if branch not in rolling_out or branch in covered_by_floor
-        ]
+        }
         skipped = [
             branch
             for branch in release_branches
             if branch in rolling_out and branch not in covered_by_floor
         ]
-        return branches, skipped
+        return ordered(selected | explicit), skipped
 
     # Version-specific labels only. `covered_by_floor` is the floor release and
-    # every newer active branch. It is normally non-empty -- the search that
-    # feeds this function only selects PRs whose floor is not newer than the
-    # newest active release -- but it may be empty if a PR carries only a label
-    # newer than every active release; the caller skips such PRs gracefully.
-    assert floor is not None, (
+    # every newer active branch; together with the explicitly named existing
+    # branches it is normally non-empty -- the search that feeds this function
+    # only selects PRs whose floor is not newer than the newest active release.
+    # It may still be empty if a PR carries only a label newer than every active
+    # release whose branch does not exist; the caller skips such PRs gracefully.
+    assert floor is not None or explicit, (
         "select_backport_branches called without a general backport label and "
         f"without a version-specific label; labels: {sorted(labels)}"
     )
-    return [branch for branch in release_branches if branch in covered_by_floor], []
+    return ordered(covered_by_floor | explicit), []

--- a/tests/ci/test_cherry_pick_branches.py
+++ b/tests/ci/test_cherry_pick_branches.py
@@ -31,13 +31,14 @@ RB = ["release/25.12", "release/26.1", "release/26.2", "release/26.3"]
 RB_PUBLIC = ["25.12", "26.1", "26.2", "26.3"]
 
 
-def select(pr_labels, release_branches, rolling_out=None):
+def select(pr_labels, release_branches, rolling_out=None, explicit_branches=()):
     return select_backport_branches(
         pr_labels,
         release_branches,
         set(rolling_out or []),
         general_backport_labels=GENERAL_BACKPORT_LABELS,
         force_backport_label=MUST_BACKPORT_FORCE,
+        explicit_branches=explicit_branches,
     )
 
 
@@ -155,6 +156,67 @@ class TestSelectVersionSpecific(unittest.TestCase):
     def test_no_backport_label_raises(self):
         with self.assertRaises(AssertionError):
             select(["pr-feature"], RB)
+
+
+class TestExplicitNamedBranches(unittest.TestCase):
+    # The #106466 scenario: the named release 26.2 is end-of-life (not in the
+    # active set) but its branch still exists. The caller resolves that and
+    # passes it as an explicit branch, so it is backported to in addition to the
+    # floor fan-out over the newer active releases.
+    ACTIVE = ["25.8", "26.3", "26.4", "26.5"]
+
+    def test_eol_named_branch_added_to_floor_fanout(self):
+        branches, skipped = select(
+            ["v26.2-must-backport"], self.ACTIVE, explicit_branches=["26.2"]
+        )
+        # Ordered by version: the explicit EOL branch sorts in among the active.
+        self.assertEqual(branches, ["26.2", "26.3", "26.4", "26.5"])
+        self.assertEqual(skipped, [])
+
+    def test_eol_branch_below_active_set(self):
+        # Only the explicitly named existing branch is older than every active
+        # release; the floor (24.3) fans out to all active and 24.3 is added.
+        branches, _ = select(
+            ["v24.3-must-backport"], self.ACTIVE, explicit_branches=["24.3"]
+        )
+        self.assertEqual(branches, ["24.3", "25.8", "26.3", "26.4", "26.5"])
+
+    def test_explicit_branch_with_general_label(self):
+        branches, skipped = select(
+            ["pr-must-backport", "v26.2-must-backport"],
+            self.ACTIVE,
+            explicit_branches=["26.2"],
+        )
+        self.assertEqual(branches, ["25.8", "26.2", "26.3", "26.4", "26.5"])
+        self.assertEqual(skipped, [])
+
+    def test_explicit_branch_with_force_label(self):
+        branches, _ = select(
+            ["pr-must-backport-force", "v26.2-must-backport"],
+            self.ACTIVE,
+            explicit_branches=["26.2"],
+        )
+        self.assertEqual(branches, ["25.8", "26.2", "26.3", "26.4", "26.5"])
+
+    def test_no_duplicate_when_explicit_also_active(self):
+        # Defensive: even if an active branch is passed as explicit, it appears
+        # once. (The caller filters active versions out, so this is belt-and-braces.)
+        branches, _ = select(
+            ["v26.3-must-backport"], self.ACTIVE, explicit_branches=["26.3"]
+        )
+        self.assertEqual(branches, ["26.3", "26.4", "26.5"])
+
+    def test_only_eol_named_branch_no_newer_active(self):
+        # Floor newer than every active release, but the named branch exists:
+        # back-port only to it (the fan-out is empty).
+        branches, _ = select(
+            ["v26.6-must-backport"], ["25.8", "26.3"], explicit_branches=["26.6"]
+        )
+        self.assertEqual(branches, ["26.6"])
+
+    def test_no_explicit_branches_is_unchanged(self):
+        branches, _ = select(["v26.3-must-backport"], self.ACTIVE)
+        self.assertEqual(branches, ["26.3", "26.4", "26.5"])
 
 
 class TestSelectGeneral(unittest.TestCase):


### PR DESCRIPTION
Make a `vX.Y-must-backport` label also back-port to **`X.Y` itself whenever that branch still exists** in the repository — even when the release is end-of-life (its `release` PR is closed). This gives the ability to deliver a fix to an end-of-life release line on request.

### Motivation

Today a version-specific label only fans out to newer **active** releases; the named release is dropped once it leaves the active set. So a fix explicitly requested for e.g. `26.2` via `v26.2-must-backport` produces backports to the newer active releases (`26.3`, `26.4`, `26.5`) but **not** to `26.2` itself once `26.2`'s `release` PR has closed — see [#106466](https://github.com/ClickHouse/ClickHouse/pull/106466), where the `26.2` backport was silently never created. This matters mainly for setups that keep older releases alive longer than the public support window.

### What changed

- `BackportPRs._explicit_named_branches` resolves the existing-but-inactive branches named by the PR's version labels (one `get_branch` lookup per non-active label) and passes them to `select_backport_branches`, which now adds them to the targets in every path.
- The newer-release fan-out is still limited to **active** releases, so an inactive label does not resurrect every old branch between it and the active set — only the branch it literally names. If the named branch has been deleted, it is skipped (logged).
- `CherryPickPRs._check_opened_release` is updated to match: a cherry-pick for an end-of-life release branch is no longer auto-closed as "orphaned" while the original PR still carries the matching `vX.Y-must-backport` label.
- Branch-selection stays pure and unit-tested; `test_cherry_pick_branches.py` gains cases for the named end-of-life branch (added to the fan-out, below the active set, with general/force labels, dedup, and a named branch with no newer active release).

`docs/en/development/backports.md` is updated.

### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)

### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
A `vX.Y-must-backport` label now also creates a backport to the named release `X.Y` itself when that branch still exists, even after the release has reached end-of-life.

### Documentation entry for user-facing changes
- [x] Documentation updated — `docs/en/development/backports.md`.

Related: https://github.com/ClickHouse/ClickHouse/pull/106466
