### PR TITLE
SipHash::update: avoid forming an out-of-range pointer in the unrolled loop

### DIFF
--- a/src/Common/SipHash.h
+++ b/src/Common/SipHash.h
@@ -107,10 +107,6 @@ public:
 
     ALWAYS_INLINE void update(const char * data, UInt64 size)
     {
-        /// Avoid UB from `data + 8` arithmetic below when `data == nullptr`.
-        if (size == 0)
-            return;
-
         const char * end = data + size;
 
         /// We'll finish to process the remainder of the previous update, if any.
@@ -135,7 +131,9 @@ public:
 
         cnt += end - data;
 
-        while (data + 8 <= end)
+        /// Use pointer subtraction, not `data + 8 <= end`: forming `data + 8` when fewer than
+        /// 8 bytes remain points past `end`, which is undefined behavior ([expr.add]/4).
+        while (end - data >= 8)
         {
             current_word = unalignedLoadLittleEndian<UInt64>(data);
 

--- a/src/Common/tests/gtest_sip_hash.cpp
+++ b/src/Common/tests/gtest_sip_hash.cpp
@@ -1,6 +1,9 @@
 #include <Common/SipHash.h>
 
+#include <cstdlib>
+#include <string>
 #include <string_view>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -30,4 +33,53 @@ TEST(SipHash, UpdateWithEmptyStringViewIsNoOp)
     UInt128 with_empty_value = with_empty.get128();
 
     EXPECT_EQ(baseline_value, with_empty_value);
+}
+
+namespace
+{
+UInt128 hashWhole(const char * data, size_t size)
+{
+    SipHash hash;
+    hash.update(data, size);
+    return hash.get128();
+}
+
+UInt128 hashByteByByte(const char * data, size_t size)
+{
+    SipHash hash;
+    for (size_t i = 0; i < size; ++i)
+        hash.update(data + i, 1);
+    return hash.get128();
+}
+}
+
+/// Buffers are allocated at exactly their length, so a 1-7 byte tail sits at the allocation end:
+/// the unrolled loop must read it without forming a pointer past end (ASan catches an over-read).
+TEST(SipHash, UpdateBoundaryLengths)
+{
+    for (size_t size = 0; size <= 64; ++size)
+    {
+        std::vector<char> buffer(size == 0 ? 1 : size);
+        for (size_t i = 0; i < size; ++i)
+            buffer[i] = static_cast<char>(i * 31 + 7);
+
+        /// Streaming one byte at a time must equal hashing the whole buffer in one update.
+        EXPECT_EQ(hashWhole(buffer.data(), size), hashByteByByte(buffer.data(), size))
+            << "size=" << size;
+    }
+}
+
+/// Splitting an update at every chunk size drives the cnt&7 remainder path into the loop.
+TEST(SipHash, UpdateChunkedMatchesWhole)
+{
+    const std::string payload = "The quick brown fox jumps over the lazy dog 0123456789";
+    const UInt128 whole = hashWhole(payload.data(), payload.size());
+
+    for (size_t chunk = 1; chunk <= payload.size(); ++chunk)
+    {
+        SipHash hash;
+        for (size_t offset = 0; offset < payload.size(); offset += chunk)
+            hash.update(payload.data() + offset, std::min(chunk, payload.size() - offset));
+        EXPECT_EQ(whole, hash.get128()) << "chunk=" << chunk;
+    }
 }


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/pull/106469
-->

Related: #106469


### Changelog category (leave one):
- Not for changelog (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Follow-up to #106469, addressing the clickhouse-gh[bot] inline review on that PR.

The unrolled 8-byte loop in `SipHash::update(const char *, UInt64)` used `while (data + 8 <= end)`. When fewer than 8 bytes remain (a 1-7 byte input, or the tail iteration after the last full chunk where `data == end`), `data + 8` points past the one-past-the-end pointer `end`. Forming such a pointer is undefined behavior under [expr.add]/4, regardless of whether it is dereferenced.

This is the general form of the defect fixed narrowly in #106469: there `data` was `nullptr` and `data + 8` triggered UBSan's "applying non-zero offset to null pointer"; here `data` is a valid non-null pointer but the formed pointer still leaves the `[base, base + size]` range.

The fix rewrites the condition as `while (end - data >= 8)`, which only ever evaluates pointer subtraction and never forms a pointer outside the buffer. The loop body is unchanged, so the hash is byte-identical for every input length.

The `size == 0` early return added in #106469 is now redundant and is removed (per review feedback). After the rewrite the empty-input path forms no out-of-range pointer: `end = data + 0` is well-defined, and the only remaining pointer arithmetic is `end - data` subtractions (all `nullptr - nullptr`, i.e. 0), so the loop body and the tail switch never run, exactly as for a zero-length valid buffer.

Verification (clang-21, `-fsanitize=address,undefined -fno-sanitize-recover=all`, matching `amd_asan_ubsan`): with the guard removed, the existing empty-string-view tests from #106469 (`UpdateWithEmptyStringViewDoesNotInvokeUB`, `UpdateWithEmptyStringViewIsNoOp`, which drive the exact `nullptr, 0` path) and the new `UpdateBoundaryLengths` / `UpdateChunkedMatchesWhole` cases all pass and produce byte-identical hashes.
