### PR TITLE
Fix flaky test 00177_memory_bound_merging

### DIFF
--- a/tests/queries/0_stateless/00177_memory_bound_merging.sh
+++ b/tests/queries/0_stateless/00177_memory_bound_merging.sh
@@ -10,14 +10,22 @@ CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 check_replicas_read_in_order() {
     # NOTE: lack of "current_database = '$CLICKHOUSE_DATABASE'" filter is made on purpose
-    $CLICKHOUSE_CLIENT -q "
-        SYSTEM FLUSH LOGS query_log, text_log;
+    # Secondary parallel-replica queries push their query_log/text_log rows asynchronously
+    # after the initiator has already returned, so retry until they become visible.
+    local result="0"
+    for _ in $(seq 1 60); do
+        result=$($CLICKHOUSE_CLIENT -q "
+            SYSTEM FLUSH LOGS query_log, text_log;
 
-        SELECT COUNT() > 0
-        FROM system.text_log
-        WHERE query_id IN (SELECT query_id FROM system.query_log WHERE query_id != '$1' AND initial_query_id = '$1' AND event_date >= yesterday() AND event_time >= now() - 600)
-            AND event_date >= yesterday() AND message ILIKE '%Reading%ranges in order%'
-        SETTINGS max_rows_to_read=0"
+            SELECT COUNT() > 0
+            FROM system.text_log
+            WHERE query_id IN (SELECT query_id FROM system.query_log WHERE query_id != '$1' AND initial_query_id = '$1' AND event_date >= yesterday() AND event_time >= now() - 600)
+                AND event_date >= yesterday() AND message ILIKE '%Reading%ranges in order%'
+            SETTINGS max_rows_to_read=0")
+        [ "$result" = "1" ] && break
+        sleep 0.5
+    done
+    echo "$result"
 }
 
 # replicas should use reading in order following initiator's decision to execute aggregation in order.


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes a transient one-row result diff in `00177_memory_bound_merging`.

The `check_replicas_read_in_order` helper flushed `query_log`/`text_log` once
and immediately checked for the "Reading N ranges in order" message emitted by
the secondary parallel-replica queries. Those secondary queries push their
log rows asynchronously, after the initiator has already returned the result
to the client. When the rows had not landed yet at check time, the inner
subquery returned no query_ids and `COUNT() > 0` evaluated to `0` instead of
`1`, producing the flaky diff (33/33 CI reruns passed, confirming a timing
race rather than a regression).

The check is now wrapped in a bounded flush-and-retry loop (up to 60 attempts,
0.5s apart), mirroring the established idiom in
`02841_parallel_replicas_summary.sh` which handles the same race between the
response being sent and the query_log entry being written. Prior fixes (#96261,
#100823) only pinned query settings and did not address this async-log race.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.660`
<!-- ch-version-info:end -->