### PR TITLE
Delay creating column readers with use_skip_indexes_on_data_read=1

### DIFF
--- a/src/Processors/QueryPlan/ReadFromMergeTree.cpp
+++ b/src/Processors/QueryPlan/ReadFromMergeTree.cpp
@@ -496,6 +496,9 @@ Pipe ReadFromMergeTree::readFromPoolParallelReplicas(
     Names required_columns,
     PoolSettings pool_settings)
 {
+    pool_settings.defer_reader_creation = static_cast<bool>(index_build_context);
+    pool_settings.deferred_index_build_context = index_build_context;
+
     const auto & client_info = context->getClientInfo();
 
     auto extension = ParallelReadingExtension{
@@ -552,6 +555,9 @@ Pipe ReadFromMergeTree::readFromPool(
     Names required_columns,
     PoolSettings pool_settings)
 {
+    pool_settings.defer_reader_creation = static_cast<bool>(index_build_context);
+    pool_settings.deferred_index_build_context = index_build_context;
+
     size_t total_rows = parts_with_range.getRowsCountAllParts();
 
     if (query_info.trivial_limit > 0 && query_info.trivial_limit < total_rows)
@@ -670,6 +676,9 @@ Pipe ReadFromMergeTree::readInOrder(
     ReadType read_type,
     UInt64 read_limit)
 {
+    pool_settings.defer_reader_creation = static_cast<bool>(index_build_context);
+    pool_settings.deferred_index_build_context = index_build_context;
+
     /// For reading in order it makes sense to read only
     /// one range per task to reduce number of read rows.
     const bool has_hard_limit_below_one_block = read_type != ReadType::Default && read_limit && read_limit < block_size.max_block_size_rows;
@@ -870,6 +879,7 @@ Pipe ReadFromMergeTree::read(
         .preferred_block_size_bytes = settings[Setting::preferred_block_size_bytes],
         .use_uncompressed_cache = use_uncompressed_cache,
         .use_const_size_tasks_for_remote_reading = settings[Setting::merge_tree_use_const_size_tasks_for_remote_reading],
+        .deferred_index_build_context = {},
         .total_query_nodes = total_query_nodes,
     };
 
@@ -1344,6 +1354,7 @@ Pipe ReadFromMergeTree::spreadMarkRangesAmongStreamsWithOrder(
         .min_marks_for_concurrent_read = info.min_marks_for_concurrent_read,
         .preferred_block_size_bytes = settings[Setting::preferred_block_size_bytes],
         .use_uncompressed_cache = info.use_uncompressed_cache,
+        .deferred_index_build_context = {},
         .total_query_nodes = total_query_nodes,
     };
 
@@ -3715,6 +3726,7 @@ void ReadFromMergeTree::initializePipeline(QueryPipelineBuilder & pipeline, cons
             .preferred_block_size_bytes = query_settings[Setting::preferred_block_size_bytes],
             .use_uncompressed_cache = info.use_uncompressed_cache,
             .use_const_size_tasks_for_remote_reading = query_settings[Setting::merge_tree_use_const_size_tasks_for_remote_reading],
+            .deferred_index_build_context = {},
             .total_query_nodes = 1,
         };
 

--- a/src/Processors/Sources/LazyReadFromMergeTreeSource.cpp
+++ b/src/Processors/Sources/LazyReadFromMergeTreeSource.cpp
@@ -232,6 +232,7 @@ Processors LazyReadFromMergeTreeSource::buildReaders()
         .preferred_block_size_bytes = ctx_settings[Setting::preferred_block_size_bytes],
         .use_uncompressed_cache = ctx_settings[Setting::use_uncompressed_cache],
         .use_const_size_tasks_for_remote_reading = ctx_settings[Setting::merge_tree_use_const_size_tasks_for_remote_reading],
+        .deferred_index_build_context = {},
         .total_query_nodes = 1,
     };
 

--- a/src/Storages/MergeTree/IMergeTreeReadPool.h
+++ b/src/Storages/MergeTree/IMergeTreeReadPool.h
@@ -17,6 +17,7 @@ public:
     virtual ~IMergeTreeReadPool() = default;
     virtual String getName() const = 0;
     virtual Block getHeader() const = 0;
+    virtual MergeTreeReadTask::Extras getReaderExtras() const = 0;
 
     /// Returns true if tasks are returned in the same order as the order of ranges passed to pool
     virtual bool preservesOrderOfRanges() const = 0;

--- a/src/Storages/MergeTree/MergeTreeIndexReadResultPool.cpp
+++ b/src/Storages/MergeTree/MergeTreeIndexReadResultPool.cpp
@@ -117,6 +117,14 @@ SkipIndexReadResultPtr MergeTreeSkipIndexReader::read(const RangesInDataPart & p
 
     auto res = std::make_shared<SkipIndexReadResult>();
     res->granules_selected.resize(part.data_part->index_granularity->getMarksCountWithoutFinal(), false);
+
+    if (ranges.empty())
+    {
+        res->has_selected_granules = false;
+        return res;
+    }
+
+    res->has_selected_granules = true;
     for (const auto & range : ranges)
     {
         for (auto i = range.begin; i < range.end; ++i)
@@ -425,6 +433,8 @@ ProjectionIndexBitmapPtr SingleProjectionIndexReader::read(const RangesInDataPar
     /// If the read was cancelled, return nullptr to avoid using an incomplete index bitmap.
     if (processor->is_cancelled)
         res = nullptr;
+    else if (res)
+        res->has_selected_granules = !res->empty();
 
     return res;
 }
@@ -461,6 +471,8 @@ ProjectionIndexBitmapPtr MergeTreeProjectionIndexReader::read(const RangesInData
         projection_index_bitmap = std::move(bitmaps[0]);
         for (size_t i = 1; i < bitmaps.size(); ++i)
             projection_index_bitmap->intersectWith(*bitmaps[i]);
+
+        projection_index_bitmap->has_selected_granules = !projection_index_bitmap->empty();
     }
 
     return projection_index_bitmap;
@@ -512,6 +524,16 @@ MergeTreeIndexReadResultPool::getOrBuildIndexReadResult(const RangesInDataPart &
                         res = std::make_shared<MergeTreeIndexReadResult>();
                     res->projection_index_read_result = std::move(projection_index_res);
                 }
+            }
+
+            if (res)
+            {
+                bool has_selected_granules = true;
+                if (res->skip_index_read_result)
+                    has_selected_granules = res->skip_index_read_result->has_selected_granules;
+                if (has_selected_granules && res->projection_index_read_result)
+                    has_selected_granules = res->projection_index_read_result->has_selected_granules;
+                res->has_selected_granules = has_selected_granules;
             }
 
             promise->set_value(res);

--- a/src/Storages/MergeTree/MergeTreeIndexReadResultPool.h
+++ b/src/Storages/MergeTree/MergeTreeIndexReadResultPool.h
@@ -15,6 +15,7 @@ using DataPartPtr = std::shared_ptr<const IMergeTreeDataPart>;
 
 struct SkipIndexReadResult
 {
+    bool has_selected_granules = true;
     std::vector<bool> granules_selected; /// granules selected by skip index(es) at read time
     std::shared_ptr<MergeTreeIndexBulkGranulesMinMax> min_max_index_for_top_k;
     TopKThresholdTrackerPtr threshold_tracker;
@@ -93,6 +94,8 @@ struct ProjectionIndexBitmap
     size_t cardinality() const;
     bool empty() const;
 
+    bool has_selected_granules = true;
+
     template <typename Offset>
     bool contains(std::type_identity_t<Offset> value);
 
@@ -159,6 +162,7 @@ using MergeTreeProjectionIndexReaderPtr = std::shared_ptr<MergeTreeProjectionInd
 
 struct MergeTreeIndexReadResult
 {
+    bool has_selected_granules = true;
     SkipIndexReadResultPtr skip_index_read_result;
     ProjectionIndexBitmapPtr projection_index_read_result;
 };

--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
@@ -210,12 +210,16 @@ void MergeTreePrefetchedReadPool::createPrefetchedReadersForTask(ThreadTask & ta
     task.readers_future = buildReadersForTask(task, /*on_warmup_thread=*/false);
 }
 
-void MergeTreePrefetchedReadPool::startPrefetches()
+std::vector<MergeTreePrefetchedReadPool::TaskHolder> MergeTreePrefetchedReadPool::startPrefetches()
 {
     OpenTelemetry::SpanHolder span("MergeTreePrefetchedReadPool::startPrefetches");
 
+    /// Deferred (use_skip_indexes_on_data_read) tasks are collected here and their warmup jobs are
+    /// scheduled by the caller AFTER `mutex` is released (see getTask / schedulePrefetchWarmupJobs).
+    std::vector<TaskHolder> tasks_to_warm_up;
+
     if (prefetch_queue.empty())
-        return;
+        return tasks_to_warm_up;
 
     [[maybe_unused]] TaskHolder prev;
     [[maybe_unused]] const Priority highest_priority{reader_settings.read_settings.priority.value + 1};
@@ -233,32 +237,10 @@ void MergeTreePrefetchedReadPool::startPrefetches()
             /// filtering (partHasSelectedGranules), which is expensive and may read from remote
             /// storage. Doing it inline here would serialize filtering across all parts while
             /// holding `mutex`, blocking every reader thread until the slowest part finishes
-            /// filtering. Instead schedule one warmup job per part: filtering then runs
-            /// concurrently and each selected part starts prefetching as soon as its own filtering
-            /// completes. getOrBuildIndexReadResult dedupes per part via a promise/future registry,
-            /// so concurrent jobs are safe. The task is shared_ptr-owned so it outlives this job
-            /// even if a reader thread takes it from per_thread_tasks first; the result is stored
-            /// back under `mutex` so it cannot race getTask()/createTask().
-            auto task = top.task;
-            prefetch_warmup_runner.enqueueAndKeepTrack(
-                [this, task]
-                {
-                    std::unique_ptr<PrefetchedReaders> readers_future;
-                    std::exception_ptr warmup_exception;
-                    try
-                    {
-                        readers_future = buildReadersForTask(*task, /*on_warmup_thread=*/true);
-                    }
-                    catch (...)
-                    {
-                        warmup_exception = std::current_exception();
-                    }
-
-                    std::lock_guard lock(mutex);
-                    task->readers_future = std::move(readers_future);
-                    task->warmup_exception = std::move(warmup_exception);
-                },
-                top.task->priority);
+            /// filtering. Instead collect the task and let the caller schedule one warmup job per
+            /// part once `mutex` is released; filtering then runs concurrently and each selected
+            /// part starts prefetching as soon as its own filtering completes.
+            tasks_to_warm_up.push_back(top);
         }
         else
         {
@@ -275,37 +257,90 @@ void MergeTreePrefetchedReadPool::startPrefetches()
 #endif
         prefetch_queue.pop();
     }
+
+    return tasks_to_warm_up;
+}
+
+void MergeTreePrefetchedReadPool::schedulePrefetchWarmupJobs(const std::vector<TaskHolder> & tasks_to_warm_up)
+{
+    /// MUST be called WITHOUT holding `mutex`. Each warmup job acquires `mutex` to publish its
+    /// result, and `prefetch_threadpool` has a bounded queue (prefetch_threadpool_queue_size).
+    /// Scheduling while holding `mutex` would deadlock once there are more warmup jobs than the
+    /// queue can hold: scheduleOrThrowOnError blocks waiting for a free queue slot while the
+    /// already-running jobs block on `mutex` at their publish step, so no job can finish to free a slot.
+    for (const auto & holder : tasks_to_warm_up)
+    {
+        auto task = holder.task;
+        prefetch_warmup_runner.enqueueAndKeepTrack(
+            [this, task]
+            {
+                /// getOrBuildIndexReadResult dedupes per part via a promise/future registry, so
+                /// concurrent jobs over the same part are safe. The task is shared_ptr-owned so it
+                /// outlives this job even if a reader thread takes it from per_thread_tasks first;
+                /// the result is published under `mutex` so it cannot race getTask()/createTask().
+                std::unique_ptr<PrefetchedReaders> readers_future;
+                std::exception_ptr warmup_exception;
+                try
+                {
+                    readers_future = buildReadersForTask(*task, /*on_warmup_thread=*/true);
+                }
+                catch (...)
+                {
+                    warmup_exception = std::current_exception();
+                }
+
+                std::lock_guard lock(mutex);
+                task->readers_future = std::move(readers_future);
+                task->warmup_exception = std::move(warmup_exception);
+            },
+            task->priority);
+    }
 }
 
 MergeTreeReadTaskPtr MergeTreePrefetchedReadPool::getTask(size_t task_idx, MergeTreeReadTask * previous_task)
 {
     OpenTelemetry::SpanHolder span("MergeTreePrefetchedReadPool::getTask");
 
-    std::lock_guard lock(mutex);
-
-    if (per_thread_tasks.empty())
-        return nullptr;
-
-    if (!started_prefetches)
+    std::vector<TaskHolder> tasks_to_warm_up;
+    MergeTreeReadTaskPtr result;
     {
-        started_prefetches = true;
-        startPrefetches();
+        std::lock_guard lock(mutex);
+
+        if (per_thread_tasks.empty())
+            return nullptr;
+
+        if (!started_prefetches)
+        {
+            started_prefetches = true;
+            tasks_to_warm_up = startPrefetches();
+        }
+
+        auto it = per_thread_tasks.find(task_idx);
+        if (it == per_thread_tasks.end())
+        {
+            result = stealTask(task_idx, previous_task);
+        }
+        else
+        {
+            auto & thread_tasks = it->second;
+            chassert(!thread_tasks.empty());
+
+            auto thread_task = std::move(thread_tasks.front());
+            thread_tasks.pop_front();
+
+            if (thread_tasks.empty())
+                per_thread_tasks.erase(it);
+
+            result = createTask(*thread_task, previous_task);
+        }
     }
 
-    auto it = per_thread_tasks.find(task_idx);
-    if (it == per_thread_tasks.end())
-        return stealTask(task_idx, previous_task);
+    /// Schedule the deferred warmup jobs only after `mutex` is released: they acquire `mutex` to
+    /// publish their results and run on the bounded `prefetch_threadpool`, so scheduling under the
+    /// lock could deadlock (see schedulePrefetchWarmupJobs).
+    schedulePrefetchWarmupJobs(tasks_to_warm_up);
 
-    auto & thread_tasks = it->second;
-    chassert(!thread_tasks.empty());
-
-    auto thread_task = std::move(thread_tasks.front());
-    thread_tasks.pop_front();
-
-    if (thread_tasks.empty())
-        per_thread_tasks.erase(it);
-
-    return createTask(*thread_task, previous_task);
+    return result;
 }
 
 MergeTreeReadTaskPtr MergeTreePrefetchedReadPool::stealTask(size_t thread, MergeTreeReadTask * previous_task)

--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
@@ -66,18 +66,32 @@ MergeTreePrefetchedReadPool::PrefetchedReaders::PrefetchedReaders(
     ThreadPool & pool,
     MergeTreeReadTask::Readers readers_,
     Priority priority_,
-    MergeTreePrefetchedReadPool & read_prefetch)
+    MergeTreePrefetchedReadPool & read_prefetch,
+    bool issue_prefetch_synchronously)
     : is_valid(true)
     , readers(std::move(readers_))
     , prefetch_runner(pool, ThreadName::PREFETCH_READER)
 {
-    prefetch_runner.enqueueAndKeepTrack(read_prefetch.createPrefetchedTask(readers.main.get(), priority_));
-
+    /// Collect all readers that need a prefetch, then either schedule them on `pool` (default
+    /// path: called from a reader thread, so prefetching is offloaded) or issue them inline
+    /// (deferred warmup path: already running on `pool`, so scheduling onto the same pool again
+    /// could self-deadlock when its queue is full). Both paths run the same task closure (which
+    /// keeps the PrefetchIncrement / async-read metrics accounting identical).
+    std::vector<IMergeTreeReader *> readers_to_prefetch;
+    readers_to_prefetch.push_back(readers.main.get());
     for (const auto & reader : readers.prewhere)
-        prefetch_runner.enqueueAndKeepTrack(read_prefetch.createPrefetchedTask(reader.get(), priority_));
-
+        readers_to_prefetch.push_back(reader.get());
     for (const auto & patch_reader : readers.patches)
-        prefetch_runner.enqueueAndKeepTrack(read_prefetch.createPrefetchedTask(patch_reader->getReader(), priority_));
+        readers_to_prefetch.push_back(patch_reader->getReader());
+
+    for (auto * reader : readers_to_prefetch)
+    {
+        auto prefetch_task = read_prefetch.createPrefetchedTask(reader, priority_);
+        if (issue_prefetch_synchronously)
+            prefetch_task();
+        else
+            prefetch_runner.enqueueAndKeepTrack(std::move(prefetch_task));
+    }
 
     fiu_do_on(FailPoints::prefetched_reader_pool_failpoint,
     {
@@ -139,6 +153,7 @@ MergeTreePrefetchedReadPool::MergeTreePrefetchedReadPool(
     , log(getLogger(
           "MergeTreePrefetchedReadPool("
           + (parts_ranges.empty() ? "" : parts_ranges.front().data_part->storage.getStorageID().getNameForLogs()) + ")"))
+    , prefetch_warmup_runner(prefetch_threadpool, ThreadName::PREFETCH_READER)
 {
     /// Tasks creation might also create a lost of readers - check they do not
     /// do any time consuming operations in ctor.
@@ -164,11 +179,9 @@ std::function<void()> MergeTreePrefetchedReadPool::createPrefetchedTask(IMergeTr
     };
 }
 
-void MergeTreePrefetchedReadPool::createPrefetchedReadersForTask(ThreadTask & task)
+std::unique_ptr<MergeTreePrefetchedReadPool::PrefetchedReaders>
+MergeTreePrefetchedReadPool::buildReadersForTask(const ThreadTask & task, bool on_warmup_thread)
 {
-    if (task.isValidReadersFuture())
-        throw Exception(ErrorCodes::LOGICAL_ERROR, "Task already has a reader");
-
     if (pool_settings.defer_reader_creation)
     {
         const auto & read_info = *task.read_info;
@@ -176,12 +189,25 @@ void MergeTreePrefetchedReadPool::createPrefetchedReadersForTask(ThreadTask & ta
                 read_info.part_index_in_query,
                 storage_snapshot->metadata,
                 read_info.alter_conversions->getAllUpdatedColumns()))
-            return;
+            return nullptr;
     }
 
     auto extras = getExtras();
     auto readers = MergeTreeReadTask::createReaders(task.read_info, extras, task.ranges, task.patches_ranges);
-    task.readers_future = std::make_unique<PrefetchedReaders>(prefetch_threadpool, std::move(readers), task.priority, *this);
+    /// When already running on the prefetch threadpool (deferred warmup path), issue the prefetch
+    /// inline instead of scheduling it onto the same pool again, to avoid a self-deadlock.
+    return std::make_unique<PrefetchedReaders>(
+        prefetch_threadpool, std::move(readers), task.priority, *this, /*issue_prefetch_synchronously=*/on_warmup_thread);
+}
+
+void MergeTreePrefetchedReadPool::createPrefetchedReadersForTask(ThreadTask & task)
+{
+    if (task.isValidReadersFuture())
+        throw Exception(ErrorCodes::LOGICAL_ERROR, "Task already has a reader");
+
+    /// Synchronous path: invoked from startPrefetches() while holding `mutex`, so the result can be
+    /// stored directly. The async (deferred) path schedules buildReadersForTask on the warmup runner.
+    task.readers_future = buildReadersForTask(task, /*on_warmup_thread=*/false);
 }
 
 void MergeTreePrefetchedReadPool::startPrefetches()
@@ -200,7 +226,44 @@ void MergeTreePrefetchedReadPool::startPrefetches()
     while (!prefetch_queue.empty())
     {
         const auto & top = prefetch_queue.top();
-        createPrefetchedReadersForTask(*top.task);
+
+        if (pool_settings.defer_reader_creation)
+        {
+            /// With `use_skip_indexes_on_data_read`, reader creation is gated on skip-index
+            /// filtering (partHasSelectedGranules), which is expensive and may read from remote
+            /// storage. Doing it inline here would serialize filtering across all parts while
+            /// holding `mutex`, blocking every reader thread until the slowest part finishes
+            /// filtering. Instead schedule one warmup job per part: filtering then runs
+            /// concurrently and each selected part starts prefetching as soon as its own filtering
+            /// completes. getOrBuildIndexReadResult dedupes per part via a promise/future registry,
+            /// so concurrent jobs are safe. The task is shared_ptr-owned so it outlives this job
+            /// even if a reader thread takes it from per_thread_tasks first; the result is stored
+            /// back under `mutex` so it cannot race getTask()/createTask().
+            auto task = top.task;
+            prefetch_warmup_runner.enqueueAndKeepTrack(
+                [this, task]
+                {
+                    std::unique_ptr<PrefetchedReaders> readers_future;
+                    std::exception_ptr warmup_exception;
+                    try
+                    {
+                        readers_future = buildReadersForTask(*task, /*on_warmup_thread=*/true);
+                    }
+                    catch (...)
+                    {
+                        warmup_exception = std::current_exception();
+                    }
+
+                    std::lock_guard lock(mutex);
+                    task->readers_future = std::move(readers_future);
+                    task->warmup_exception = std::move(warmup_exception);
+                },
+                top.task->priority);
+        }
+        else
+        {
+            createPrefetchedReadersForTask(*top.task);
+        }
 #ifndef NDEBUG
         if (prev.task)
         {
@@ -342,10 +405,21 @@ MergeTreeReadTaskPtr MergeTreePrefetchedReadPool::stealTask(size_t thread, Merge
 
 MergeTreeReadTaskPtr MergeTreePrefetchedReadPool::createTask(ThreadTask & task, MergeTreeReadTask * previous_task)
 {
+    /// Called under `mutex` (from getTask/stealTask), the same lock the async warmup job uses to
+    /// publish its result, so reading these fields here is race-free. If the warmup job threw
+    /// while filtering or creating readers, rethrow so the error reaches the query instead of
+    /// being silently swallowed (the synchronous path propagates such errors directly).
+    if (task.warmup_exception)
+        std::rethrow_exception(task.warmup_exception);
+
     if (task.isValidReadersFuture())
         return MergeTreeReadPoolBase::createTask(task.read_info, task.readers_future->get(), task.ranges, task.patches_ranges, updater);
-    else
-        return MergeTreeReadPoolBase::createTask(task.read_info, task.ranges, task.patches_ranges, previous_task, updater);
+
+    /// No prefetched readers: either the part was fully filtered out by the warmup job, or a reader
+    /// thread reached this task before its warmup job ran. Fall through to the base pool, which (in
+    /// the deferred path) defers reader creation to MergeTreeReadTask::initializeReadersChain ->
+    /// createColumnReadersIfNeeded, where skip-index filtering is re-checked (cached) on this thread.
+    return MergeTreeReadPoolBase::createTask(task.read_info, task.ranges, task.patches_ranges, previous_task, updater);
 }
 
 void MergeTreePrefetchedReadPool::fillPerPartStatistics()
@@ -573,10 +647,10 @@ void MergeTreePrefetchedReadPool::fillPerThreadTasks(size_t threads, size_t sum_
 
             const auto & read_info = per_part_infos[part_idx];
             auto patch_ranges = ranges_in_patch_parts.getRanges(read_info->data_part, read_info->patch_parts, ranges_to_get_from_part);
-            auto thread_task = std::make_unique<ThreadTask>(read_info, ranges_to_get_from_part, std::move(patch_ranges), priority);
+            auto thread_task = std::make_shared<ThreadTask>(read_info, ranges_to_get_from_part, std::move(patch_ranges), priority);
 
             if (allow_prefetch)
-                prefetch_queue.emplace(TaskHolder{thread_task.get(), i});
+                prefetch_queue.emplace(TaskHolder{thread_task, i});
 
             per_thread_tasks[i].push_back(std::move(thread_task));
 

--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.cpp
@@ -5,6 +5,7 @@
 #include <Storages/MergeTree/MarkRange.h>
 #include <Storages/MergeTree/MergeTreeBlockReadUtils.h>
 #include <Storages/MergeTree/MergeTreePrefetchedReadPool.h>
+#include <Storages/MergeTree/MergeTreeSelectProcessor.h>
 #include <Storages/MergeTree/MergeTreeRangeReader.h>
 #include <Storages/MergeTree/RangesInDataPart.h>
 #include <Common/ElapsedTimeProfileEventIncrement.h>
@@ -167,6 +168,16 @@ void MergeTreePrefetchedReadPool::createPrefetchedReadersForTask(ThreadTask & ta
 {
     if (task.isValidReadersFuture())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Task already has a reader");
+
+    if (pool_settings.defer_reader_creation)
+    {
+        const auto & read_info = *task.read_info;
+        if (!pool_settings.deferred_index_build_context->partHasSelectedGranules(
+                read_info.part_index_in_query,
+                storage_snapshot->metadata,
+                read_info.alter_conversions->getAllUpdatedColumns()))
+            return;
+    }
 
     auto extras = getExtras();
     auto readers = MergeTreeReadTask::createReaders(task.read_info, extras, task.ranges, task.patches_ranges);

--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.h
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.h
@@ -124,7 +124,14 @@ private:
     void fillPerPartStatistics();
     void fillPerThreadTasks(size_t threads, size_t sum_marks);
 
-    void startPrefetches();
+    /// Drains `prefetch_queue` under `mutex`. For the deferred (use_skip_indexes_on_data_read) path
+    /// it does NOT schedule anything; it returns the tasks whose warmup jobs the caller must
+    /// schedule via schedulePrefetchWarmupJobs() AFTER releasing `mutex`.
+    std::vector<TaskHolder> startPrefetches();
+    /// Schedules the per-part warmup jobs returned by startPrefetches(). MUST be called without
+    /// holding `mutex`: the jobs acquire `mutex` to publish and run on the bounded
+    /// `prefetch_threadpool`, so scheduling under the lock would deadlock.
+    void schedulePrefetchWarmupJobs(const std::vector<TaskHolder> & tasks_to_warm_up);
     void createPrefetchedReadersForTask(ThreadTask & task);
     /// Does the expensive part of reader creation for a single task WITHOUT holding `mutex`:
     /// skip-index filtering (deferred path) and reader construction + prefetch issuing. Returns

--- a/src/Storages/MergeTree/MergeTreePrefetchedReadPool.h
+++ b/src/Storages/MergeTree/MergeTreePrefetchedReadPool.h
@@ -60,8 +60,13 @@ private:
     class PrefetchedReaders
     {
     public:
+        /// When `issue_prefetch_synchronously` is true, prefetches are issued inline in the
+        /// constructor instead of being scheduled on `pool`. Used by the deferred warmup path,
+        /// which already runs on a background thread, so it must not recursively enqueue onto the
+        /// same prefetch threadpool (that could self-deadlock when the pool queue is full).
         PrefetchedReaders(
-            ThreadPool & pool, MergeTreeReadTask::Readers readers_, Priority priority_, MergeTreePrefetchedReadPool & read_prefetch);
+            ThreadPool & pool, MergeTreeReadTask::Readers readers_, Priority priority_, MergeTreePrefetchedReadPool & read_prefetch,
+            bool issue_prefetch_synchronously = false);
 
         void wait();
         MergeTreeReadTask::Readers get();
@@ -96,16 +101,22 @@ private:
         std::vector<MarkRanges> patches_ranges;
         Priority priority;
         std::unique_ptr<PrefetchedReaders> readers_future;
+        /// Set by the asynchronous warmup job (deferred path) when skip-index filtering or reader
+        /// creation throws. Rethrown by the reader thread in createTask() so the error is not lost
+        /// (the synchronous path propagates such errors directly).
+        std::exception_ptr warmup_exception;
     };
 
     struct TaskHolder
     {
-        ThreadTask * task = nullptr;
+        std::shared_ptr<ThreadTask> task;
         size_t thread_id = 0;
         bool operator<(const TaskHolder & other) const;
     };
 
-    using ThreadTaskPtr = std::unique_ptr<ThreadTask>;
+    /// Shared so an in-flight asynchronous warmup job (deferred path) can co-own the task and keep
+    /// it alive even after a reader thread takes it from per_thread_tasks via getTask().
+    using ThreadTaskPtr = std::shared_ptr<ThreadTask>;
     using ThreadTasks = std::deque<ThreadTaskPtr>;
     using TasksPerThread = std::map<size_t, ThreadTasks>;
     using PartStatistics = std::vector<PartStatistic>;
@@ -115,6 +126,13 @@ private:
 
     void startPrefetches();
     void createPrefetchedReadersForTask(ThreadTask & task);
+    /// Does the expensive part of reader creation for a single task WITHOUT holding `mutex`:
+    /// skip-index filtering (deferred path) and reader construction + prefetch issuing. Returns
+    /// nullptr when the part is fully filtered out. The caller stores the result into
+    /// `task.readers_future` (under `mutex` in the async path; already-locked in the sync path).
+    /// `on_warmup_thread` is true when invoked from a prefetch_warmup_runner job, in which case
+    /// prefetches are issued inline rather than scheduled onto the same threadpool.
+    std::unique_ptr<PrefetchedReaders> buildReadersForTask(const ThreadTask & task, bool on_warmup_thread);
     std::function<void()> createPrefetchedTask(IMergeTreeReader * reader, Priority priority);
 
     MergeTreeReadTaskPtr stealTask(size_t thread, MergeTreeReadTask * previous_task);
@@ -132,6 +150,12 @@ private:
     std::priority_queue<TaskHolder> prefetch_queue; /// the smallest on top
     bool started_prefetches = false;
     LoggerPtr log;
+
+    /// Runs per-task skip-index filtering + reader creation concurrently across parts on
+    /// `prefetch_threadpool` (deferred path only). Declared after every member its jobs touch
+    /// (mutex, prefetch_threadpool, per_thread_tasks, ...) so it is destroyed FIRST: its
+    /// destructor drains all in-flight jobs while everything they reference is still alive.
+    ThreadPoolCallbackRunnerLocal<void> prefetch_warmup_runner;
 
     /// A struct which allows to track max number of tasks which were in the
     /// threadpool simultaneously (similar to CurrentMetrics, but the result

--- a/src/Storages/MergeTree/MergeTreeReadPoolBase.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadPoolBase.cpp
@@ -387,6 +387,17 @@ MergeTreeReadTaskPtr MergeTreeReadPoolBase::createTask(
     auto extras = getExtras();
     MergeTreeReadTask::Readers task_readers;
 
+    if (pool_settings.defer_reader_creation)
+    {
+        if (previous_task && previous_task->hasReaders() && get_part_name(previous_task->getInfo()) == get_part_name(*read_info))
+        {
+            task_readers = previous_task->releaseReaders();
+            task_readers.updateAllMarkRanges(ranges);
+        }
+
+        return createTask(read_info, std::move(task_readers), std::move(ranges), std::move(patches_ranges), updater);
+    }
+
     if (!previous_task)
     {
         task_readers = MergeTreeReadTask::createReaders(read_info, extras, ranges, patches_ranges);

--- a/src/Storages/MergeTree/MergeTreeReadPoolBase.h
+++ b/src/Storages/MergeTree/MergeTreeReadPoolBase.h
@@ -8,6 +8,9 @@
 namespace DB
 {
 
+struct MergeTreeIndexBuildContext;
+using MergeTreeIndexBuildContextPtr = std::shared_ptr<MergeTreeIndexBuildContext>;
+
 class UncompressedCache;
 using UncompressedCachePtr = std::shared_ptr<UncompressedCache>;
 
@@ -26,6 +29,11 @@ public:
         bool use_uncompressed_cache = false;
         bool do_not_steal_tasks = false;
         bool use_const_size_tasks_for_remote_reading = false;
+
+        /// When set, column readers are created in `MergeTreeReadTask::initializeReadersChain`
+        /// after skip-index filtering instead of in `createTask`.
+        bool defer_reader_creation = false;
+        MergeTreeIndexBuildContextPtr deferred_index_build_context;
 
         // Not the same as the similar field in `ParallelReadingExtension`. Accounts for `max_parallel_replicas`.
         const size_t total_query_nodes{};
@@ -59,6 +67,7 @@ public:
         const ContextPtr & context_);
 
     Block getHeader() const override { return header; }
+    MergeTreeReadTask::Extras getReaderExtras() const override { return getExtras(); }
 
 protected:
     /// Initialized in constructor

--- a/src/Storages/MergeTree/MergeTreeReadTask.cpp
+++ b/src/Storages/MergeTree/MergeTreeReadTask.cpp
@@ -291,10 +291,18 @@ void MergeTreeReadTask::initializeReadersChain(
     const PrewhereExprInfo & prewhere_actions,
     MergeTreeIndexBuildContextPtr index_build_context,
     LazyMaterializingRowsPtr lazy_materializing_rows,
-    const ReadStepsPerformanceCounters & read_steps_performance_counters)
+    const ReadStepsPerformanceCounters & read_steps_performance_counters,
+    const Extras & reader_extras)
 {
     if (readers_chain.isInitialized())
         throw Exception(ErrorCodes::LOGICAL_ERROR, "Range readers chain is already initialized");
+
+    if (!createColumnReadersIfNeeded(reader_extras, index_build_context))
+    {
+        mark_ranges.clear();
+        patches_mark_ranges.clear();
+        return;
+    }
 
     PrewhereExprInfo all_prewhere_actions;
 
@@ -308,6 +316,25 @@ void MergeTreeReadTask::initializeReadersChain(
         all_prewhere_actions.steps.push_back(step);
 
     readers_chain = createReadersChain(readers, all_prewhere_actions, read_steps_performance_counters);
+}
+
+bool MergeTreeReadTask::createColumnReadersIfNeeded(
+    const Extras & reader_extras, MergeTreeIndexBuildContextPtr index_build_context)
+{
+    if (readers.main)
+        return true;
+
+    if (index_build_context)
+    {
+        if (!index_build_context->partHasSelectedGranules(
+                info->part_index_in_query,
+                reader_extras.storage_snapshot->metadata,
+                info->alter_conversions->getAllUpdatedColumns()))
+            return false;
+    }
+
+    readers = createReaders(info, reader_extras, mark_ranges, patches_mark_ranges);
+    return true;
 }
 
 void MergeTreeReadTask::initializeIndexReader(const MergeTreeIndexBuildContextPtr & index_build_context, const LazyMaterializingRowsPtr & lazy_materializing_rows)
@@ -387,6 +414,9 @@ UInt64 MergeTreeReadTask::estimateNumRows() const
 MergeTreeReadTask::BlockAndProgress MergeTreeReadTask::read()
 {
     auto component_guard = Coordination::setCurrentComponent("MergeTreeReadTask::read");
+    if (!readers.main)
+        return {};
+
     if (size_predictor)
         size_predictor->startBlock();
 

--- a/src/Storages/MergeTree/MergeTreeReadTask.h
+++ b/src/Storages/MergeTree/MergeTreeReadTask.h
@@ -193,7 +193,8 @@ public:
         const PrewhereExprInfo & prewhere_actions,
         MergeTreeIndexBuildContextPtr index_build_context,
         LazyMaterializingRowsPtr lazy_materializing_rows,
-        const ReadStepsPerformanceCounters & read_steps_performance_counters);
+        const ReadStepsPerformanceCounters & read_steps_performance_counters,
+        const Extras & reader_extras);
 
     void initializeIndexReader(const MergeTreeIndexBuildContextPtr & index_build_context, const LazyMaterializingRowsPtr & lazy_materializing_rows);
 
@@ -203,6 +204,9 @@ public:
     const MergeTreeReadTaskInfo & getInfo() const { return *info; }
     const MergeTreeReadersChain & getReadersChain() const { return readers_chain; }
     const IMergeTreeReader & getMainReader() const { return *readers.main; }
+    bool hasReaders() const { return readers.main != nullptr; }
+
+    bool createColumnReadersIfNeeded(const Extras & reader_extras, MergeTreeIndexBuildContextPtr index_build_context);
 
     void addPrewhereUnmatchedMarks(const MarkRanges & mark_ranges_);
     const MarkRanges & getPrewhereUnmatchedMarks() { return prewhere_unmatched_marks; }

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.cpp
@@ -118,6 +118,45 @@ MergeTreeIndexBuildContext::MergeTreeIndexBuildContext(
     chassert(index_reader_pool);
 }
 
+bool MergeTreeIndexBuildContext::partHasSelectedGranules(
+    size_t part_index_in_query,
+    const StorageMetadataPtr & metadata,
+    const NameSet & all_updated_columns) const
+{
+    {
+        std::lock_guard lock(part_selection_cache_mutex);
+        if (auto it = part_selection_cache.find(part_index_in_query); it != part_selection_cache.end())
+            return it->second;
+    }
+
+    const auto & part_ranges = read_ranges.at(part_index_in_query);
+    auto projection_it = projection_read_ranges.find(part_index_in_query);
+    static const RangesInDataParts empty_projection_ranges;
+    const auto & projection_parts_ranges = projection_it != projection_read_ranges.end() ? projection_it->second : empty_projection_ranges;
+
+    auto index_read_result = index_reader_pool->getOrBuildIndexReadResult(
+        part_ranges, projection_parts_ranges, metadata, all_updated_columns);
+
+    const bool has_selected_granules = !index_read_result || index_read_result->has_selected_granules;
+
+    if (!has_selected_granules)
+        markPartFullySkipped(part_index_in_query);
+
+    {
+        std::lock_guard lock(part_selection_cache_mutex);
+        part_selection_cache[part_index_in_query] = has_selected_granules;
+    }
+
+    return has_selected_granules;
+}
+
+void MergeTreeIndexBuildContext::markPartFullySkipped(size_t part_index_in_query) const
+{
+    const auto & part_ranges = read_ranges.at(part_index_in_query);
+    part_remaining_marks.at(part_index_in_query).value.store(0, std::memory_order_relaxed);
+    index_reader_pool->clear(part_ranges.data_part);
+}
+
 MergeTreeIndexReadResultPtr MergeTreeIndexBuildContext::getPreparedIndexReadResult(const MergeTreeReadTask & task) const
 {
     const auto & part_ranges = read_ranges.at(task.getInfo().part_index_in_query);
@@ -246,7 +285,12 @@ ChunkAndProgress
 MergeTreeSelectProcessor::readCurrentTask(MergeTreeReadTask & current_task, IMergeTreeSelectAlgorithm & task_algorithm) const
 {
     if (!current_task.getReadersChain().isInitialized())
-        current_task.initializeReadersChain(prewhere_actions, merge_tree_index_build_context, lazy_materializing_rows, read_steps_performance_counters);
+        current_task.initializeReadersChain(
+            prewhere_actions,
+            merge_tree_index_build_context,
+            lazy_materializing_rows,
+            read_steps_performance_counters,
+            pool->getReaderExtras());
 
     auto res = task_algorithm.readFromTask(current_task);
 

--- a/src/Storages/MergeTree/MergeTreeSelectProcessor.h
+++ b/src/Storages/MergeTree/MergeTreeSelectProcessor.h
@@ -7,6 +7,8 @@
 #include <Storages/MergeTree/RangesInDataPart.h>
 #include <Storages/MergeTree/RequestResponse.h>
 #include <Processors/Chunk.h>
+#include <mutex>
+#include <unordered_map>
 
 namespace DB
 {
@@ -91,7 +93,18 @@ struct MergeTreeIndexBuildContext
         MergeTreeIndexReadResultPoolPtr index_reader_pool_,
         PartRemainingMarks part_remaining_marks_);
 
+    bool partHasSelectedGranules(
+        size_t part_index_in_query,
+        const StorageMetadataPtr & metadata,
+        const NameSet & all_updated_columns) const;
+
+    void markPartFullySkipped(size_t part_index_in_query) const;
+
     MergeTreeIndexReadResultPtr getPreparedIndexReadResult(const MergeTreeReadTask & task) const;
+
+private:
+    mutable std::mutex part_selection_cache_mutex;
+    mutable std::unordered_map<size_t, bool> part_selection_cache;
 };
 
 using MergeTreeIndexBuildContextPtr = std::shared_ptr<MergeTreeIndexBuildContext>;


### PR DESCRIPTION
**Change**  : With `use_skip_indexes_on_data_read = 1`, evaluate skip indexes before instantiating `MergeTree` readers so that fully filtered `parts` do not load column marks  (or prefetch column data), while keeping skip index checks parallel across read threads. 

Note that the essential identity of `use_skip_indexes_on_data_read = 1` is still maintained. Data read of a selected `part` will begin immediately when it's skip index filtering is complete.

Currently, take a case where PK filtering has resulted in 1000 parts and skip index filtering is deferred to read time with `use_skip_indexes_on_data_read = 1`. The column readers of the 1000 parts will immediately start reading their marks etc and cause significant load on the thread pool / storage.  Skip Index filtering may finally find only 20 `parts` to be read.

### Changelog category (leave one):
- Not for changelog (changelog entry is not required)
