### PR TITLE
Fix LOGICAL_ERROR in decorrelated correlated subquery join with duplicate columns

### DIFF
--- a/src/Processors/QueryPlan/JoinStepLogical.cpp
+++ b/src/Processors/QueryPlan/JoinStepLogical.cpp
@@ -1310,16 +1310,22 @@ static QueryPlanNode buildPhysicalJoinImpl(
         {
             auto input_it = name_to_nodes.find(column.name);
 
-            if (input_it == name_to_nodes.end() || input_it->second.empty())
+            if (input_it == name_to_nodes.end())
                 throw Exception(ErrorCodes::LOGICAL_ERROR,
                     "Cannot find input column {} on its position in inputs of expression actions DAG, expected inputs {} in\n{}",
                     column.name,
                     fmt::join(children | std::views::transform([](const auto & c) { return fmt::format("[{}]", c->step->getOutputHeader()->dumpNames()); }), ", "),
                     expression_actions.getActionsDAG()->dumpDAG());
 
+            /// The child step may return more same-named columns than the DAG has inputs for, when an
+            /// unreferenced duplicate input was pruned from the DAG while the child still produces it (e.g. a
+            /// decorrelated correlated subquery over a source that projects the same identifier twice). Keep
+            /// the last remaining node when the deque is exhausted; duplicate references are dropped right below.
+            const auto * input_node = input_it->second.front();
+            if (input_it->second.size() > 1)
+                input_it->second.pop_front();
 
-            used_expressions.emplace_back(input_it->second.front(), expression_actions);
-            input_it->second.pop_front();
+            used_expressions.emplace_back(input_node, expression_actions);
         }
     }
 

--- a/tests/queries/0_stateless/04327_correlated_subquery_duplicate_column_join.reference
+++ b/tests/queries/0_stateless/04327_correlated_subquery_duplicate_column_join.reference
@@ -1,0 +1,11 @@
+-- minimal
+-- left
+0	0	0
+1	1	1
+2	2	2
+-- right
+0	0	0
+1	1	1
+2	2	2
+-- fuzzer query runs
+-- ok

--- a/tests/queries/0_stateless/04327_correlated_subquery_duplicate_column_join.sql
+++ b/tests/queries/0_stateless/04327_correlated_subquery_duplicate_column_join.sql
@@ -1,5 +1,3 @@
--- Tags: no-parallel-replicas
-
 -- Regression test for a LOGICAL_ERROR "Cannot find input column ... on its position in inputs of
 -- expression actions DAG" thrown from buildPhysicalJoinImpl, which aborted the server. A correlated
 -- scalar subquery is decorrelated into a JOIN; when the input side projects the same identifier twice

--- a/tests/queries/0_stateless/04327_correlated_subquery_duplicate_column_join.sql
+++ b/tests/queries/0_stateless/04327_correlated_subquery_duplicate_column_join.sql
@@ -1,5 +1,5 @@
 -- Regression test for a LOGICAL_ERROR "Cannot find input column ... on its position in inputs of
--- expression actions DAG" thrown from buildPhysicalJoinImpl, which aborted the server. A correlated
+-- expression actions DAG" thrown from buildPhysicalJoinImpl. A correlated
 -- scalar subquery is decorrelated into a JOIN; when the input side projects the same identifier twice
 -- (SELECT number, *) and correlated_subqueries_default_join_kind = 'left' swaps that side onto the left
 -- join child, the join's ActionsDAG had a single input for the duplicated name while the child step
@@ -8,9 +8,9 @@
 SET enable_analyzer = 1;
 SET allow_experimental_correlated_subqueries = 1;
 
--- Minimal case that previously aborted the server: the duplicated column is NOT projected to the
+-- Minimal case that previously threw: the duplicated column is NOT projected to the
 -- output, so the unreferenced duplicate input was pruned from the join DAG while the left child still
--- produced it. Result is discarded; the test only verifies the query no longer crashes.
+-- produced it. Result is discarded; the test only verifies the query no longer throws.
 SELECT '-- minimal';
 WITH t AS (SELECT number, * FROM numbers(3))
 SELECT (SELECT number) FROM t
@@ -31,7 +31,7 @@ SELECT *, (SELECT t.number WHERE t.number >= 0) AS r FROM t
 ORDER BY 1
 SETTINGS correlated_subqueries_default_join_kind = 'right';
 
--- The original AST-fuzzer query: previously aborted the server under left decorrelation.
+-- The original AST-fuzzer query: previously threw under left decorrelation.
 SELECT '-- fuzzer query runs';
 WITH RECURSIVE
     alias2 AS (

--- a/tests/queries/0_stateless/04327_correlated_subquery_duplicate_column_join.sql
+++ b/tests/queries/0_stateless/04327_correlated_subquery_duplicate_column_join.sql
@@ -1,0 +1,54 @@
+-- Tags: no-parallel-replicas
+
+-- Regression test for a LOGICAL_ERROR "Cannot find input column ... on its position in inputs of
+-- expression actions DAG" thrown from buildPhysicalJoinImpl, which aborted the server. A correlated
+-- scalar subquery is decorrelated into a JOIN; when the input side projects the same identifier twice
+-- (SELECT number, *) and correlated_subqueries_default_join_kind = 'left' swaps that side onto the left
+-- join child, the join's ActionsDAG had a single input for the duplicated name while the child step
+-- still produced two. See STID 2409-5283 (AST fuzzer).
+
+SET enable_analyzer = 1;
+SET allow_experimental_correlated_subqueries = 1;
+
+-- Minimal case that previously aborted the server: the duplicated column is NOT projected to the
+-- output, so the unreferenced duplicate input was pruned from the join DAG while the left child still
+-- produced it. Result is discarded; the test only verifies the query no longer crashes.
+SELECT '-- minimal';
+WITH t AS (SELECT number, * FROM numbers(3))
+SELECT (SELECT number) FROM t
+FORMAT Null
+SETTINGS correlated_subqueries_default_join_kind = 'left';
+
+-- The duplicated column flows to the output: both 'number' columns must be preserved and the result
+-- must be identical for both decorrelation join kinds.
+SELECT '-- left';
+WITH t AS (SELECT number, * FROM numbers(3))
+SELECT *, (SELECT t.number WHERE t.number >= 0) AS r FROM t
+ORDER BY 1
+SETTINGS correlated_subqueries_default_join_kind = 'left';
+
+SELECT '-- right';
+WITH t AS (SELECT number, * FROM numbers(3))
+SELECT *, (SELECT t.number WHERE t.number >= 0) AS r FROM t
+ORDER BY 1
+SETTINGS correlated_subqueries_default_join_kind = 'right';
+
+-- The original AST-fuzzer query: previously aborted the server under left decorrelation.
+SELECT '-- fuzzer query runs';
+WITH RECURSIVE
+    alias2 AS (
+        SELECT DISTINCT number FROM test_aliases LIMIT 255, -2147483649
+        UNION DISTINCT SELECT number FROM test_aliases LIMIT 10, -2
+        UNION DISTINCT SELECT number FROM test_aliases LIMIT 548, 1048576
+        UNION DISTINCT SELECT (SELECT number) FROM test_aliases WHERE 2147483648 LIMIT -886, 2
+    ),
+    test_aliases AS (
+        SELECT toFixedString('(', 4), number, isNullable(65537), isNullable(65537), *
+        FROM numbers(1025) WHERE 1024 QUALIFY isZeroOrNull(NULL)
+    )
+SELECT DISTINCT number, toFixedString(materialize('('), 65536), isNullable(1)
+FROM alias2
+FORMAT Null
+SETTINGS correlated_subqueries_default_join_kind = 'left';
+
+SELECT '-- ok';


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):

Fix a `LOGICAL_ERROR` ("Cannot find input column ... on its position in inputs of expression actions DAG") that aborted the server for a correlated scalar subquery over a source projecting the same column identifier twice (e.g. `SELECT number, *`) when `correlated_subqueries_default_join_kind = 'left'`.


### Description

A correlated scalar subquery is decorrelated into a JOIN. When its input side projects the same column identifier twice (e.g. `SELECT number, * FROM numbers(...)`) and `correlated_subqueries_default_join_kind = 'left'` swaps that side onto the left join child, the join's `ActionsDAG` ends up with a single input node for the duplicated name (the unreferenced duplicate input is pruned), while the child step still produces two same-named columns. `buildPhysicalJoinImpl` matched each child output column to a DAG input by popping from a per-name deque, underflowed on the second column, and threw the `LOGICAL_ERROR`, aborting the server. The default (`'right'`) decorrelation join kind already tolerated this; only the swapped layout underflowed.

Fix: keep the last remaining DAG input node for a name when the deque is exhausted instead of throwing. Duplicate references are deduplicated immediately afterwards, so the per-side actions are unchanged for the well-formed case.

Minimal reproducer (aborts the server on current master):

```sql
SET allow_experimental_correlated_subqueries = 1;
WITH t AS (SELECT number, * FROM numbers(10))
SELECT (SELECT number) FROM t
SETTINGS correlated_subqueries_default_join_kind = 'left';
```

Found by the AST fuzzer (STID 2409-5283, `AST fuzzer (arm_asan_ubsan)`):
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104119&sha=2aecdb1750a7377fbd72828bea243716535dc8bb&name_0=PR&name_1=AST%20fuzzer%20%28arm_asan_ubsan%29

No related open issue found.


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.7.1.377` (included in `26.7` and later)
<!-- ch-version-info:end -->