### PR TITLE
CI: do not fail Build Post Hooks when build profile artifacts are absent

### DIFF
--- a/ci/jobs/scripts/job_hooks/build_profile_hook.py
+++ b/ci/jobs/scripts/job_hooks/build_profile_hook.py
@@ -11,6 +11,27 @@ temp_dir = "./ci/tmp"
 build_dir = "./ci/tmp/build"
 
 
+def _has_data(file):
+    """Whether prepare-time-trace.sh actually produced this artifact.
+
+    Not every build emits every artifact: binary_symbols.txt is skipped for
+    LTO builds (nm does not work with LTO) and cross-arch/non-Linux builds
+    produce no readable objects at all (#84159). A missing or empty file means
+    there is nothing to upload, not that the job failed.
+    """
+    file = Path(file)
+    return file.exists() and file.stat().st_size > 0
+
+
+def _upload_profile_artifacts(build_type, start_time, artifacts):
+    """Upload each (insert, file) pair that was produced; skip the rest."""
+    for insert, file in artifacts:
+        if not _has_data(file):
+            print(f"No build profile data in [{file}], skipping upload")
+            continue
+        insert(build_name=build_type, start_time=start_time, file=file)
+
+
 def check():
     print("Prepare build profile data")
     profiles_dir = Path("./ci/tmp") / "profiles_source"
@@ -23,6 +44,8 @@ def check():
             verbose=True,
         )
         profile_data_file = Path(temp_dir) / "profile.json"
+        build_size_file = profiles_dir / "binary_sizes.txt"
+        binary_symbol_file = profiles_dir / "binary_symbols.txt"
         with open(profile_data_file, "wb") as profile_fd:
             for profile_source in profiles_dir.iterdir():
                 if profile_source.name not in (
@@ -36,20 +59,15 @@ def check():
         )
         build_type = Info().job_name.split("(")[1].rstrip(")")
         assert build_type
-        LogClusterBuildProfileQueries().insert_profile_data(
-            build_name=build_type,
-            start_time=check_start_time,
-            file=profile_data_file,
-        )
-        LogClusterBuildProfileQueries().insert_build_size_data(
-            build_name=build_type,
-            start_time=check_start_time,
-            file=profiles_dir / "binary_sizes.txt",
-        )
-        LogClusterBuildProfileQueries().insert_binary_symbol_data(
-            build_name=build_type,
-            start_time=check_start_time,
-            file=profiles_dir / "binary_symbols.txt",
+        queries = LogClusterBuildProfileQueries()
+        _upload_profile_artifacts(
+            build_type,
+            check_start_time,
+            [
+                (queries.insert_profile_data, profile_data_file),
+                (queries.insert_build_size_data, build_size_file),
+                (queries.insert_binary_symbol_data, binary_symbol_file),
+            ],
         )
     except Exception as e:
         print(f"ERROR: Failed to upload build profile data:")

--- a/ci/jobs/scripts/job_hooks/build_profile_hook.py
+++ b/ci/jobs/scripts/job_hooks/build_profile_hook.py
@@ -16,15 +16,22 @@ def _has_data(file):
 
     Not every build emits every artifact: binary_symbols.txt is skipped for
     LTO builds (nm does not work with LTO) and cross-arch/non-Linux builds
-    produce no readable objects at all (#84159). A missing or empty file means
-    there is nothing to upload, not that the job failed.
+    produce no readable objects at all (#84159). prepare-time-trace.sh uses
+    `xargs -r`, so for those builds the artifact is left empty rather than
+    holding a junk row. An absent or empty file therefore means "this build
+    has no such profile data to upload", not that the job failed.
     """
     file = Path(file)
     return file.exists() and file.stat().st_size > 0
 
 
 def _upload_profile_artifacts(build_type, start_time, artifacts):
-    """Upload each (insert, file) pair that was produced; skip the rest."""
+    """No-op for builds without profile data; upload it for builds that have it.
+
+    Skips only artifacts that are genuinely empty (no data for this build).
+    A non-empty artifact is always uploaded, and any failure uploading it
+    propagates so the caller can fail loudly: we never swallow a real error.
+    """
     for insert, file in artifacts:
         if not _has_data(file):
             print(f"No build profile data in [{file}], skipping upload")
@@ -69,8 +76,10 @@ def check():
                 (queries.insert_binary_symbol_data, binary_symbol_file),
             ],
         )
-    except Exception as e:
-        print(f"ERROR: Failed to upload build profile data:")
+    except Exception:
+        # Fail loudly on any genuine error (producer crashed, upload rejected,
+        # malformed data): never let the post-hook pass silently.
+        print("ERROR: Failed to upload build profile data:")
         traceback.print_exc()
         sys.exit(1)
 

--- a/ci/tests/test_build_profile_hook.py
+++ b/ci/tests/test_build_profile_hook.py
@@ -1,10 +1,22 @@
-"""Regression tests for the build profile post-hook artifact selection.
+"""Regression tests for the build profile post-hook and its producer.
 
 See ClickHouse/ClickHouse#84159.
+
+Two layers are covered:
+
+* The producer (``utils/prepare-time-trace/prepare-time-trace.sh``): for a build
+  with no readable objects (cross-arch/non-Linux) it must leave
+  ``binary_sizes.txt`` empty, not write a junk ``0`` row that no consumer can
+  parse.
+* The hook artifact selection (``_has_data`` / ``_upload_profile_artifacts``):
+  no-op for builds without profile data, upload for builds that have it, and
+  propagate any genuine upload error so the caller fails loudly.
 """
 
 import os
+import subprocess
 import sys
+from pathlib import Path
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
 
@@ -13,12 +25,44 @@ from ci.jobs.scripts.job_hooks.build_profile_hook import (
     _upload_profile_artifacts,
 )
 
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_PRODUCER = _REPO_ROOT / "utils" / "prepare-time-trace" / "prepare-time-trace.sh"
+
 
 def _record_inserts(recorded):
     def insert(build_name, start_time, file):
         recorded.append(str(file))
 
     return insert
+
+
+# --- producer: empty build dir must not emit a junk row -------------------
+
+
+def test_producer_no_objects_leaves_binary_sizes_empty(tmp_path):
+    """Cross-arch build: no objects -> binary_sizes.txt empty, not '0\\n'.
+
+    Without ``xargs -r`` GNU xargs runs ``wc -c`` once with no args and writes a
+    bare ``0`` row, which fails the binary_sizes FORMAT Regexp and aborts the
+    upload. The producer must instead leave the file empty.
+    """
+    build_dir = tmp_path / "build"
+    build_dir.mkdir()
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    subprocess.run(
+        ["bash", str(_PRODUCER), str(build_dir), str(out_dir)],
+        check=True,
+        capture_output=True,
+    )
+
+    binary_sizes = out_dir / "binary_sizes.txt"
+    assert binary_sizes.exists()
+    assert binary_sizes.read_bytes() == b""
+
+
+# --- hook artifact selection ----------------------------------------------
 
 
 def test_has_data_false_for_missing(tmp_path):
@@ -56,8 +100,19 @@ def test_lto_build_missing_symbols_uploads_rest(tmp_path):
     assert recorded == [str(profile), str(sizes)]
 
 
-def test_cross_arch_build_no_artifacts_is_noop(tmp_path):
-    """Cross-arch build: no readable objects, nothing produced, no failure."""
+def test_cross_arch_build_no_data_is_noop(tmp_path):
+    """Cross-arch build models the real producer output: empty files, no upload.
+
+    profile.json is absent (the hook never opens what was not produced) and
+    binary_sizes.txt / binary_symbols.txt are present-but-empty, exactly what
+    ``prepare-time-trace.sh`` (with ``xargs -r``) leaves for a build with no
+    readable objects. The hook must no-op without failing.
+    """
+    sizes = tmp_path / "binary_sizes.txt"
+    sizes.write_text("")  # real producer output for no objects, not absent
+    symbols = tmp_path / "binary_symbols.txt"
+    symbols.write_text("")
+
     recorded = []
     insert = _record_inserts(recorded)
     _upload_profile_artifacts(
@@ -65,8 +120,8 @@ def test_cross_arch_build_no_artifacts_is_noop(tmp_path):
         "2026-06-11 00:00:00",
         [
             (insert, tmp_path / "profile.json"),
-            (insert, tmp_path / "binary_sizes.txt"),
-            (insert, tmp_path / "binary_symbols.txt"),
+            (insert, sizes),
+            (insert, symbols),
         ],
     )
 
@@ -90,3 +145,20 @@ def test_native_build_uploads_all(tmp_path):
     )
 
     assert recorded == [str(f) for f in files]
+
+
+def test_upload_error_propagates(tmp_path):
+    """A genuine upload failure must not be swallowed by the selector."""
+    f = tmp_path / "binary_sizes.txt"
+    f.write_text("1 a.o")
+
+    def failing_insert(build_name, start_time, file):
+        raise AssertionError("upload rejected")
+
+    try:
+        _upload_profile_artifacts(
+            "amd_debug", "2026-06-11 00:00:00", [(failing_insert, f)]
+        )
+    except AssertionError:
+        return
+    raise AssertionError("expected the upload error to propagate")

--- a/ci/tests/test_build_profile_hook.py
+++ b/ci/tests/test_build_profile_hook.py
@@ -1,0 +1,92 @@
+"""Regression tests for the build profile post-hook artifact selection.
+
+See ClickHouse/ClickHouse#84159.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+
+from ci.jobs.scripts.job_hooks.build_profile_hook import (
+    _has_data,
+    _upload_profile_artifacts,
+)
+
+
+def _record_inserts(recorded):
+    def insert(build_name, start_time, file):
+        recorded.append(str(file))
+
+    return insert
+
+
+def test_has_data_false_for_missing(tmp_path):
+    assert not _has_data(tmp_path / "absent.txt")
+
+
+def test_has_data_false_for_empty(tmp_path):
+    empty = tmp_path / "empty.txt"
+    empty.write_text("")
+    assert not _has_data(empty)
+
+
+def test_has_data_true_for_nonempty(tmp_path):
+    f = tmp_path / "data.txt"
+    f.write_text("x")
+    assert _has_data(f)
+
+
+def test_lto_build_missing_symbols_uploads_rest(tmp_path):
+    """LTO build: binary_symbols.txt absent must not abort the upload."""
+    profile = tmp_path / "profile.json"
+    profile.write_text("[]")
+    sizes = tmp_path / "binary_sizes.txt"
+    sizes.write_text("1 a.o")
+    symbols = tmp_path / "binary_symbols.txt"  # never created for LTO builds
+
+    recorded = []
+    insert = _record_inserts(recorded)
+    _upload_profile_artifacts(
+        "arm_release",
+        "2026-06-11 00:00:00",
+        [(insert, profile), (insert, sizes), (insert, symbols)],
+    )
+
+    assert recorded == [str(profile), str(sizes)]
+
+
+def test_cross_arch_build_no_artifacts_is_noop(tmp_path):
+    """Cross-arch build: no readable objects, nothing produced, no failure."""
+    recorded = []
+    insert = _record_inserts(recorded)
+    _upload_profile_artifacts(
+        "amd_darwin",
+        "2026-06-11 00:00:00",
+        [
+            (insert, tmp_path / "profile.json"),
+            (insert, tmp_path / "binary_sizes.txt"),
+            (insert, tmp_path / "binary_symbols.txt"),
+        ],
+    )
+
+    assert recorded == []
+
+
+def test_native_build_uploads_all(tmp_path):
+    """Non-LTO native build: all three artifacts present and uploaded."""
+    files = []
+    for name in ("profile.json", "binary_sizes.txt", "binary_symbols.txt"):
+        f = tmp_path / name
+        f.write_text("x")
+        files.append(f)
+
+    recorded = []
+    insert = _record_inserts(recorded)
+    _upload_profile_artifacts(
+        "amd_debug",
+        "2026-06-11 00:00:00",
+        [(insert, f) for f in files],
+    )
+
+    assert recorded == [str(f) for f in files]

--- a/utils/prepare-time-trace/prepare-time-trace.sh
+++ b/utils/prepare-time-trace/prepare-time-trace.sh
@@ -81,7 +81,9 @@ ENGINE = MergeTree
 ORDER BY (date, file, pull_request_number, commit_sha, check_name);
 ///
 
-find "$INPUT_DIR" -type f -executable -or -name '*.o' -or -name '*.a' | grep -v cargo | xargs wc -c | grep -v 'total' > "${OUTPUT_DIR}/binary_sizes.txt"
+# xargs -r: with no matching objects (cross-arch/non-Linux builds) emit no row at
+# all, instead of GNU xargs running 'wc -c' once with no args and writing '0'.
+find "$INPUT_DIR" -type f -executable -or -name '*.o' -or -name '*.a' | grep -v cargo | xargs -r wc -c | grep -v 'total' > "${OUTPUT_DIR}/binary_sizes.txt"
 
 # Additionally, collect information about the symbols inside translation units
 true<<///
@@ -123,5 +125,6 @@ then
       ${NM} --demangle --defined-only --print-size '{}' | grep -v -P '[0-9a-zA-Z] r ' | sed 's@^@{} @' > '{}.symbols'
     "
 
-    find "$INPUT_DIR" -type f -name '*.o.symbols' | xargs cat > "${OUTPUT_DIR}/binary_symbols.txt"
+    # xargs -r: with no '*.o.symbols' files emit nothing rather than running cat once.
+    find "$INPUT_DIR" -type f -name '*.o.symbols' | xargs -r cat > "${OUTPUT_DIR}/binary_symbols.txt"
 fi


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/84159
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

The `build_profile_hook` post-hook runs on every master Build job and uploads three artifacts that `utils/prepare-time-trace/prepare-time-trace.sh` produces: the time-trace profile, `binary_sizes.txt`, and `binary_symbols.txt`.

`prepare-time-trace.sh` does not emit every artifact for every build:
- `binary_symbols.txt` is produced only for non-LTO builds (the script guards `nm` with `if ! grep -q -- '-flto'`, since `nm` does not work with LTO). Release builds use ThinLTO, so the file is never created.
- Cross-arch and non-Linux builds produce no readable objects at all (issue #84159).

The hook opened all three files unconditionally, so on LTO release builds and cross-arch builds the missing file raised `FileNotFoundError`, which the broad `except` turned into `sys.exit(1)`, failing the `Post Hooks` check. This has failed on master across all such Build variants for months (top variants `arm_release` and `amd_release` are LTO builds).

The fix uploads whatever `prepare-time-trace.sh` actually produced and skips artifacts that are absent or empty, instead of failing the whole post-hook. Added `ci/tests` regression coverage for the LTO, cross-arch, and native-build cases.

Reproduced on master HEAD (Build (arm_release)): https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=fc73f46fae655b1fb5e5dc447c121c844a8a6295&name_0=MasterCI&name_1=Build%20(arm_release)
```
ERROR: Failed to upload build profile data:
  ...
  File "ci/jobs/scripts/log_cluster.py", line 135, in insert_binary_symbol_data
    with open(file, "rb") as data_fd:
FileNotFoundError: [Errno 2] No such file or directory: 'ci/tmp/profiles_source/binary_symbols.txt'
```

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.973`
<!-- ch-version-info:end -->