### PR TITLE
Fix flaky test_async_load_databases::test_materialized_views_replicated

### DIFF
--- a/tests/integration/test_async_load_databases/test.py
+++ b/tests/integration/test_async_load_databases/test.py
@@ -6,7 +6,7 @@ from multiprocessing.dummy import Pool
 
 import pytest
 
-from helpers.client import QueryRuntimeException
+from helpers.client import QueryRuntimeException, QueryTimeoutExceedException
 from helpers.cluster import ClickHouseCluster
 from helpers.test_tools import assert_eq_with_retry
 
@@ -407,21 +407,25 @@ def test_materialized_views_replicated(started_cluster):
     # start INSERTS when CH is not started yet
     for i in range(100, 130):
         try:
+            # timeout: a connect to a half-restarted server can otherwise block ~600s
             node1.query(
-                f"INSERT INTO test_mv.test_table_H VALUES({i})"
+                f"INSERT INTO test_mv.test_table_H VALUES({i})", timeout=60
             )
             logging.debug(f"{i} inserted")
-        except QueryRuntimeException as e:
+        except (QueryRuntimeException, QueryTimeoutExceedException) as e:
             # CH is not started yet
             logging.debug(f"{i} is not inserted - skip")
             time.sleep(0.2)
 
 
-    disconnect_event.wait(90)
+    # assert: a bare wait(90) ignored its timeout, racing the loop below against a
+    # still-restarting server on slow builds
+    assert disconnect_event.wait(180), "restart_clickhouse() did not finish within 180s"
 
     for i in range(2000, 2100):
+        # timeout: bound a hung insert so it can't exhaust the 900s session timeout
         node1.query(
-            f"INSERT INTO test_mv.test_table_H VALUES({i})"
+            f"INSERT INTO test_mv.test_table_H VALUES({i})", timeout=60
         )
 
     src_rows = node1.query("select count(*) from test_mv.test_table_H Format CSV")

--- a/tests/integration/test_async_load_databases/test.py
+++ b/tests/integration/test_async_load_databases/test.py
@@ -404,10 +404,14 @@ def test_materialized_views_replicated(started_cluster):
         )
     )
 
-    # start INSERTS when CH is not started yet
+    # Fire INSERTs while CH is restarting. Stop as soon as the restart finishes
+    # (event set) or its budget elapses, so repeated half-up-server hangs (each
+    # bounded by `timeout`) can't accumulate past the 900s pytest session timeout.
+    insert_phase_deadline = time.monotonic() + 180
     for i in range(100, 130):
+        if disconnect_event.is_set() or time.monotonic() >= insert_phase_deadline:
+            break
         try:
-            # timeout: a connect to a half-restarted server can otherwise block ~600s
             node1.query(
                 f"INSERT INTO test_mv.test_table_H VALUES({i})", timeout=60
             )
@@ -417,9 +421,7 @@ def test_materialized_views_replicated(started_cluster):
             logging.debug(f"{i} is not inserted - skip")
             time.sleep(0.2)
 
-
-    # assert: a bare wait(90) ignored its timeout, racing the loop below against a
-    # still-restarting server on slow builds
+    # restart must finish within budget; assert loudly instead of session-timeout
     assert disconnect_event.wait(180), "restart_clickhouse() did not finish within 180s"
 
     for i in range(2000, 2100):


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes flaky `test_async_load_databases::test_materialized_views_replicated`. 13 distinct PR groups hit it in the last 30 days (most recent 2026-06-10); the dominant signature is an empty `test_context_raw` (the 900s pytest session timeout), and when the session is killed it takes the sibling `test_materialized_views_cascaded_multiple` down too (shared module fixture).

Root cause (two cooperating timing assumptions that break on slow sanitizer builds):

1. `disconnect_event.wait(90)` ignored its return value. When `restart_clickhouse()` takes longer than 90s (its stop+start budget alone is ~120s, and startup is much slower under TSan/ASan), the main thread fell through while the server was still restarting.
2. The INSERT loops used `node1.query(...)` with no per-query timeout. A query to a half-restarted server (TCP port open but not yet serving) makes `clickhouse-client` connect and then block on the response. With `DEFAULT_QUERY_TIMEOUT=600s`, one such query exhausts the 900s session timeout.

Fix (test-only, assertions unchanged):

- `assert disconnect_event.wait(180)` so a too-slow restart fails loudly instead of silently racing ahead (180s gives sanitizer builds headroom over the original 90s).
- `timeout=60` on the INSERTs in both loops, so a connection to a not-yet-ready server fails fast and attributably instead of hanging up to 600s.
- the pre-restart guarded loop also catches `QueryTimeoutExceedException` (the new fast-fail path).

Reproduced and validated locally (native integration runner, debug build): unmodified test passes on a fast build (race doesn't trigger); with an injected slow restart, an unguarded `query(timeout=None)` against a half-up server blocks indefinitely while `timeout=60` fails in seconds; the fixed test passes 3/3 repeated runs.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.955` (included in `26.6` and later)
- Backported to: `25.8.26.9`
<!-- ch-version-info:end -->