### PR TITLE
Fix flaky test 02881_system_detached_parts_modification_time

### DIFF
--- a/tests/queries/0_stateless/02881_system_detached_parts_modification_time.sql.j2
+++ b/tests/queries/0_stateless/02881_system_detached_parts_modification_time.sql.j2
@@ -1,5 +1,12 @@
 set mutations_sync=1;
 
+-- Bracket each part's modification_time between client-side now() timestamps
+-- captured immediately before and after that table's own DETACH.
+drop table if exists detach_started;
+drop table if exists detach_finished;
+create table detach_started (tbl String, started_at DateTime) engine = Memory;
+create table detach_finished (tbl String, finished_at DateTime) engine = Memory;
+
 {% for id, settings in [
     ("wide",    "min_bytes_for_wide_part=0, min_rows_for_wide_part=0"),
     ("compact", "min_bytes_for_wide_part=1000, min_rows_for_wide_part=100"),
@@ -8,18 +15,16 @@ set mutations_sync=1;
 drop table if exists data_{{ id }};
 create table data_{{ id }} (key Int) engine=MergeTree() order by tuple() settings {{ settings }};
 insert into data_{{ id }} values (1);
-select 'before detach', modification_time from system.detached_parts where database = currentDatabase() and table = 'data_{{ id }}';
+insert into detach_started values ('data_{{ id }}', now());
 alter table data_{{ id }} detach partition all;
+insert into detach_finished values ('data_{{ id }}', now());
 {% endfor %}
-
-system flush logs query_log;
 
 select
   parts.table,
-  -- make sure that the modification_time is within (query_start_time; query_finish_time) of ALTER query
-  abs(dateDiff('seconds', modification_time, query_finish_time)) <= ceil(query_duration_ms/1e3),
+  parts.modification_time between (started.started_at - 1) and (finished.finished_at + 1)
 from system.detached_parts parts
-left join (select tables[1] as table, event_time query_finish_time, query_duration_ms from system.query_log where event_date >= yesterday() AND event_time >= now() - 600 AND current_database = currentDatabase() and type = 'QueryFinish' and query_kind = 'Alter') query_log
-  on (query_log.table = database || '.' || parts.table)
-where database = currentDatabase()
+inner join detach_started started on started.tbl = parts.table
+inner join detach_finished finished on finished.tbl = parts.table
+where parts.database = currentDatabase()
 order by parts.table;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/92974
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: #92974

The test compared each detached part's `modification_time` to the `ALTER ... DETACH` finish time from `system.query_log`, with a tolerance of `ceil(query_duration_ms/1e3)`. DETACH runs instantly so it logs `query_duration_ms = 0`, and the tolerance collapses to 0. The check then requires `modification_time` and `query_finish_time` to be in the same second; when those two second-resolution timestamps straddle a second boundary the assertion returns 0, which is the flaky failure.

Fix: drop the `query_log` dependency. For each table capture `now()` immediately before and after its own `ALTER ... DETACH` into a `Memory` table, then assert `modification_time BETWEEN started_at - 1 AND finished_at + 1` per table. The per-table bracket keeps the upper bound tight, the `+/-1s` absorbs DateTime second truncation, and an out-of-window value (e.g. epoch 0) is still rejected. Reference output is unchanged.

Found by CI: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=105045&sha=48ab80fd074599c63f967f624435e0a2e7f166ed&name_0=PR&name_1=Stateless%20tests%20%28amd_debug%2C%20parallel%29

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.673`
<!-- ch-version-info:end -->