### PR TITLE
Revert "Shrink idle thread pools of the distributed query infrastructure"

### DIFF
--- a/programs/server/Server.cpp
+++ b/programs/server/Server.cpp
@@ -2044,14 +2044,7 @@ try
     if (config().getBool("stateless_worker_server.enabled", false))
     {
         String stateless_worker_endpoint = config().getString("stateless_worker_server.endpoint", "localhost");
-        size_t stateless_worker_max_threads = config().getUInt64("stateless_worker_server.max_threads", 1000);
-        if (stateless_worker_max_threads == 0)
-            throw Exception(ErrorCodes::INVALID_CONFIG_PARAMETER,
-                "`stateless_worker_server.max_threads` must be at least 1");
-        stateless_worker_endpoint_ptr = std::make_shared<StatelessWorkerEndpoint>(
-            stateless_worker_max_threads,
-            config().getUInt64("stateless_worker_server.max_free_threads", 0),
-            config().getUInt64("stateless_worker_server.queue_size", 3000));
+        stateless_worker_endpoint_ptr = std::make_shared<StatelessWorkerEndpoint>();
         stateless_worker_endpoint_name = stateless_worker_endpoint_ptr->getId(stateless_worker_endpoint);
         global_context->getInterserverIOHandler().addEndpoint(stateless_worker_endpoint_name, stateless_worker_endpoint_ptr);
         LOG_DEBUG(log, "Added stateless worker endpoint '{}'.", stateless_worker_endpoint_name);

--- a/src/Server/DistributedQuery/ExchangeServer.cpp
+++ b/src/Server/DistributedQuery/ExchangeServer.cpp
@@ -31,10 +31,9 @@ namespace ErrorCodes
 }
 
 /// Bounds the handshake thread pool: enough threads to absorb bursts of concurrent connections
-/// without serializing on the accept thread, while staying bounded. Handshakes are short-lived,
-/// so idle threads are not retained.
+/// without serializing on the accept thread, while staying bounded.
 static constexpr size_t HANDSHAKE_POOL_MAX_THREADS = 64;
-static constexpr size_t HANDSHAKE_POOL_MAX_FREE_THREADS = 0;
+static constexpr size_t HANDSHAKE_POOL_MAX_FREE_THREADS = 8;
 static constexpr size_t HANDSHAKE_POOL_QUEUE_SIZE = 10000;
 
 ExchangeServer::ExchangeServer(const String & listen_host, UInt16 port, ExchangeConnectionsPtr connections_)

--- a/src/Server/StatelessWorker/StatelessTaskExecutor.cpp
+++ b/src/Server/StatelessWorker/StatelessTaskExecutor.cpp
@@ -28,12 +28,12 @@ namespace DB
 /// TODO: move
 std::pair<ObjectStoragePtr, String> getObjectStorageForTemporaryFiles(const String & unique_temp_file_path, ContextPtr context);
 
-StatelessTaskExecutor::StatelessTaskExecutor(size_t max_threads, size_t max_free_threads, size_t queue_size)
+StatelessTaskExecutor::StatelessTaskExecutor()
     : thread_pool(
         CurrentMetrics::StatelessWorkerThreads,
         CurrentMetrics::StatelessWorkerThreadsActive,
         CurrentMetrics::StatelessWorkerThreadsScheduled,
-        max_threads, max_free_threads, queue_size)
+        1000, 100, 3000)
 {
 }
 

--- a/src/Server/StatelessWorker/StatelessTaskExecutor.h
+++ b/src/Server/StatelessWorker/StatelessTaskExecutor.h
@@ -18,7 +18,7 @@ namespace DB
 class StatelessTaskExecutor
 {
 public:
-    StatelessTaskExecutor(size_t max_threads, size_t max_free_threads, size_t queue_size);
+    StatelessTaskExecutor();
     virtual ~StatelessTaskExecutor() = default;
 
     enum Result

--- a/src/Server/StatelessWorker/StatelessWorkerEndpoint.cpp
+++ b/src/Server/StatelessWorker/StatelessWorkerEndpoint.cpp
@@ -19,10 +19,10 @@ namespace ErrorCodes
     extern const int NOT_IMPLEMENTED;
 }
 
-StatelessWorkerEndpoint::StatelessWorkerEndpoint(size_t max_threads, size_t max_free_threads, size_t queue_size)
+StatelessWorkerEndpoint::StatelessWorkerEndpoint()
     : endpoint_name("stateless_worker/")
     , log(Poco::Logger::getShared("StatelessWorkerEndpoint"))
-    , task_runner(std::make_shared<StatelessTaskExecutor>(max_threads, max_free_threads, queue_size))
+    , task_runner(std::make_shared<StatelessTaskExecutor>())
 {
 }
 

--- a/src/Server/StatelessWorker/StatelessWorkerEndpoint.h
+++ b/src/Server/StatelessWorker/StatelessWorkerEndpoint.h
@@ -12,7 +12,7 @@ class StatelessTaskExecutor;
 class StatelessWorkerEndpoint final : public InterserverIOEndpoint, private boost::noncopyable
 {
 public:
-    StatelessWorkerEndpoint(size_t max_threads, size_t max_free_threads, size_t queue_size);
+    StatelessWorkerEndpoint();
     ~StatelessWorkerEndpoint() override;
 
     std::string getId(const std::string & path) const override;

--- a/tests/config/config.d/thread_pool_trim.xml
+++ b/tests/config/config.d/thread_pool_trim.xml
@@ -1,6 +1,0 @@
-<clickhouse>
-    <!-- Trim idle global pool threads after concurrency bursts. The default of 1000 is above the
-         idle thread count typically reached in tests, so the pool would never shrink and each
-         thread would keep its stack resident, which is expensive under sanitizers. -->
-    <max_thread_pool_free_size>128</max_thread_pool_free_size>
-</clickhouse>

--- a/tests/config/install.sh
+++ b/tests/config/install.sh
@@ -173,7 +173,6 @@ function is_sanitizer_build()
 }
 if is_sanitizer_build; then
     ln -sf $SRC_PATH/config.d/trace_log_no_symbolize.xml $DEST_SERVER_PATH/config.d/
-    ln -sf $SRC_PATH/config.d/thread_pool_trim.xml $DEST_SERVER_PATH/config.d/
 fi
 ln -sf $SRC_PATH/config.d/memory_profiler.yaml $DEST_SERVER_PATH/config.d/
 ln -sf $SRC_PATH/config.d/rocksdb.xml $DEST_SERVER_PATH/config.d/


### PR DESCRIPTION
Reverts ClickHouse/ClickHouse#106978
See https://s3.amazonaws.com/clickhouse-test-reports/json.html?REF=master&sha=b825a23a5cb63137a94dc0971fd4cf1ef73f789b&name_0=MasterCI&name_1=Stateless%20tests%20%28arm_asan_ubsan%2C%20azure%2C%20sequential%29&name_1=Stateless%20tests%20%28arm_asan_ubsan%2C%20azure%2C%20sequential%29

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.619`
<!-- ch-version-info:end -->