### PR TITLE
Remove live crash signature from 04256 test comment

### DIFF
--- a/tests/queries/0_stateless/04256_extremes_transform_partial_populate_on_exception.sql
+++ b/tests/queries/0_stateless/04256_extremes_transform_partial_populate_on_exception.sql
@@ -1,15 +1,7 @@
--- Regression for ExtremesTransform partial-population abort (STID 2286-2cea).
--- Pre-fix, `extremes_columns` was resized to N null entries then filled
--- column-by-column. A throw mid-loop left the vector partially populated;
--- the next `work()` call ran `Chunk::setColumns` on the broken vector and the
--- row-count diagnostic dereferenced one of the still-null intrusive pointers
--- via `Chunk::dumpStructure`, aborting the server with
--- `Assertion 'px != 0' failed`. The fix builds into a local vector and moves
--- it on success, so a mid-loop throw leaves `extremes_columns` empty.
---
--- The exact memory budget that triggers the throw inside the partial-population
--- loop varies by build (debug/release/sanitizer), so run several variants:
--- at least one will hit the bug path on each environment.
+-- Regression for the ExtremesTransform partial-population abort (STID 2286-2cea).
+-- Each variant uses a different memory budget so that at least one trips the
+-- mid-population throw on every build flavor (debug/release/sanitizer); the
+-- expected outcome is a clean MEMORY_LIMIT_EXCEEDED, not a server abort.
 
 SELECT DISTINCT 1025, toFixedString('%', 1048576), 100 UNION ALL
 SELECT 9223372036854775807, '\0', materialize(toLowCardinality(1025))


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

The comment block of `04256_extremes_transform_partial_populate_on_exception.sql` contained the literal string `` `Assertion 'px != 0' failed` `` to explain the bug the test guards against. That string is logged verbatim as the query text every time the test runs.

The stress/fuzzer log parser `ci/jobs/scripts/log_parser.py::parse_failure` scans the whole server log with `rg --text -o 'Logical error.*|Assertion.*failed|...'` and uses the **first** match as the failure's result name. So when an unrelated crash happens elsewhere in the same stress run, the parser picks up this test's comment text and reports the crash as `Assertion 'px != 0' failed`, glued to the unrelated crash's stack-trace id.

This produced a phantom finding on the `Stress test (arm_release)` job (`STID 2354-2d76`). Evidence from that run's `clickhouse-server.err.log`:
- The only real crash was a fault-injected `MEMORY_LIMIT_EXCEEDED` escaping `QueryPlan::unitePlans` / `QueryPlanResourceHolder::append` (query `02151_hash_table_sizes_stats.sh`) — a separate issue, already fixed on master by the non-`noexcept` change to `QueryPlanResourceHolder` move-assignment.
- No `px != 0` assertion ever fired; the only occurrence of that string in the log is this test's comment, logged at `<Error>` level as query context ~14 min before the crash.

This change rewords the comment so it no longer contains a matchable crash signature, while keeping the test's intent clear. The four SQL statements and their expected `serverError MEMORY_LIMIT_EXCEEDED` markers are unchanged, so test behavior is identical.

Note: `log_parser.py::parse_failure` taking the first whole-log regex match is the general weakness here (its sibling `get_failed_query` already filters out SQL-comment continuation lines, but `parse_failure` does not). A handful of other `.sql` tests embed `Logical error:` / `Segmentation fault` strings in comments and carry the same latent risk. Left for maintainers to decide whether to harden the parser centrally.

Validation: running the exact `log_parser.py` regex against this file matches `Assertion 'px != 0' failed` before the change and matches nothing after. This is a comment-only change to a SQL test (no source change), so no rebuild is required; a ClickHouse build is orthogonal to a CI-log-parser false match.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.630`
<!-- ch-version-info:end -->