### PR TITLE
Allowlist rdb_test_ DDLWorker UUID-collision upgrade-check restart noise

### DIFF
--- a/tests/docker_scripts/upgrade_runner.sh
+++ b/tests/docker_scripts/upgrade_runner.sh
@@ -435,6 +435,22 @@ cp /var/log/clickhouse-server/clickhouse-server.upgrade.log /test_output/clickho
 #       restart the engine probes the server while loading the persisted object and logs `<Error>` for the
 #       expected connection failure. Filtered to require the MySQL component AND the connection-failure
 #       symptom together, so real MySQL regressions (auth, protocol, query errors) are not masked.
+# `DDLWorker(rdb_test_...)` + `Error on initialization of rdb_test_...` + `Mapping for table with UUID=... already
+#       exists` + `TABLE_ALREADY_EXISTS` is benign noise from the `--replicated-database` test wrapper during the
+#       upgrade restart. `clickhouse-test --replicated-database` creates each test's database as
+#       `ENGINE=Replicated(...)` named `rdb_test_<rnd>_<shard>`. On the upgrade restart the database's DDLWorker
+#       runs `DatabaseReplicatedDDLWorker::initializeReplication` -> `recoverLostReplica`, which re-creates tables
+#       from the ZooKeeper metadata snapshot. If a stale local table still owns a table's UUID (e.g. a leftover
+#       `_tmp_replace_*` from `CREATE OR REPLACE`, or a table not yet finally dropped), `addUUIDMapping` reports the
+#       collision as a non-fatal `TABLE_ALREADY_EXISTS` (code 57). The DDLWorker main loop catches it, logs this
+#       `<Error> ... Error on initialization of ...` line, waits 5s and retries; recovery self-heals (after enough
+#       retries `max_retries_before_automatic_recovery` forces a digest reset). The server stays up - every other
+#       upgrade-check sub-test (incl. "Server successfully started") passes; only the post-restart `<Error>` scrub
+#       trips. Filtered via regex in the secondary pipe below to require ALL of: `Error on initialization of`
+#       (logged at exactly one site, the DDLWorker recovery retry), the `rdb_test_` test-DB prefix, the UUID mapping
+#       message, AND the `TABLE_ALREADY_EXISTS` code together. So a real `LOGICAL_ERROR` UUID-mapping crash, the same
+#       collision on a non-test database, a different init failure on an `rdb_test_` DB, and unrelated
+#       `TABLE_ALREADY_EXISTS` errors all still surface.
 echo "Check for Error messages in server log:"
 rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "Code: 236. DB::Exception: Cancelled mutating parts" \
@@ -511,6 +527,7 @@ rg -Fav -e "Code: 236. DB::Exception: Cancelled merging parts" \
            -e "Exception during get topic partitions from Kafka: Local: Broker transport failure" \
     /test_output/clickhouse-server.upgrade.log \
     | grep -av -e "_repl_01111_.*Mapping for table with UUID" \
+    | grep -av -e "Error on initialization of rdb_test_.*Mapping for table with UUID=.*already exists.*TABLE_ALREADY_EXISTS" \
     | grep -av -e "Azure::Storage::StorageException.*Not found address of host" \
     | grep -av -e "SystemLogQueue.*Queue had been full" \
     | grep -av -e "TraceCollector.*CANNOT_READ_FROM_FILE_DESCRIPTOR" \


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Closes: https://github.com/ClickHouse/ClickHouse/issues/NNNNN   (auto-closes the issue when this PR is merged into the default branch)
Related: https://github.com/ClickHouse/ClickHouse/pull/NNNNN
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Allowlists a benign, self-healing error from the `--replicated-database` test wrapper that trips the upgrade-check post-restart `<Error>` scrub. Chronic CI noise on `Upgrade check (amd_release)`, not a code regression.

The failing line (repeated every ~5s as the DDLWorker retries):

```
<Error> DDLWorker(rdb_test_mur4ipro_2): Error on initialization of rdb_test_mur4ipro_2: Code: 57. DB::Exception: Mapping for table with UUID=69047a76-6be0-4eef-8696-576514388289 already exists. It happened due to UUID collision, most likely because some not random UUIDs were manually specified in CREATE queries. (TABLE_ALREADY_EXISTS), Stack trace ...
```

`clickhouse-test --replicated-database` names each test DB `rdb_test_<rnd>_<shard>` with `ENGINE=Replicated(...)`. On the upgrade restart its DDLWorker runs `DatabaseReplicatedDDLWorker::initializeReplication` -> `recoverLostReplica`, re-creating tables from the ZooKeeper metadata snapshot. If a stale local table still owns a table's UUID (a leftover `_tmp_replace_*` from `CREATE OR REPLACE`, or a table not yet finally dropped), `DatabaseCatalog::addUUIDMapping` reports the collision as a non-fatal `TABLE_ALREADY_EXISTS` (code 57), not a `LOGICAL_ERROR`. `initializeMainThread` catches it, logs this line, waits 5s and retries; recovery self-heals (after `max_retries_before_automatic_recovery` retries it forces a digest reset). The server stays up - every other upgrade-check sub-test passes, including "Server successfully started"; only the `<Error>` scrub trips.

The two existing UUID-mapping masks do not cover this case: one hardcodes a single UUID (useless, UUIDs are random), the other matches only `_repl_01111_` databases. The added regex requires ALL of `Error on initialization of` (logged at exactly one site, the DDLWorker recovery retry), the `rdb_test_` test-DB prefix, the UUID mapping message, AND the `TABLE_ALREADY_EXISTS` code together. So a real `LOGICAL_ERROR` UUID-mapping crash, the same collision on a non-test database, a different init failure on an `rdb_test_` DB, and unrelated `TABLE_ALREADY_EXISTS` errors all still surface. This mirrors the narrowing approach of the existing multi-substring filters in the same scrub.

**Provenance:** `Upgrade check (amd_release)` on PR #106107, commit 942a72f5e14987e3d86f7011d1b688ed4a11e9ea, sub-test "Error message in clickhouse-server.log".
Report: https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=106107&sha=942a72f5e14987e3d86f7011d1b688ed4a11e9ea&name_0=PR&name_1=Upgrade%20check%20%28amd_release%29
Chronic across many unrelated PRs in the last 30 days (e.g. #101757, #103952, #101033, #106230).


<!-- ch-version-info:start -->
### Version info
- Merged into: `26.8.1.143` (included in `26.8` and later)
<!-- ch-version-info:end -->