### PR TITLE
Fix flaky test 02813_optimize_lazy_materialization

### DIFF
--- a/tests/queries/0_stateless/02813_optimize_lazy_materialization.reference
+++ b/tests/queries/0_stateless/02813_optimize_lazy_materialization.reference
@@ -320,7 +320,7 @@ SELECT * FROM optimize_lazy_materialization_with_tuple_data_type ORDER BY b LIMI
 16	16	(16,'32')
 18	18	(18,'36')
 -- { echoOn }
-SELECT * FROM optimize_lazy_materialization_with_map_data_type ORDER BY b LIMIT 10;
+SELECT a, b, mapSort(c) FROM optimize_lazy_materialization_with_map_data_type ORDER BY b LIMIT 10;
 0	0	{'key1':1,'key2':2}
 2	2	{'key1':3,'key2':4}
 4	4	{'key1':5,'key2':6}

--- a/tests/queries/0_stateless/02813_optimize_lazy_materialization.sql
+++ b/tests/queries/0_stateless/02813_optimize_lazy_materialization.sql
@@ -385,7 +385,7 @@ SELECT
     map('key1', number + 1, 'key2', number + 2)
 FROM numbers(0, 1000);
 -- { echoOn }
-SELECT * FROM optimize_lazy_materialization_with_map_data_type ORDER BY b LIMIT 10;
+SELECT a, b, mapSort(c) FROM optimize_lazy_materialization_with_map_data_type ORDER BY b LIMIT 10;
 SELECT a, b, c['key1'] FROM optimize_lazy_materialization_with_map_data_type ORDER BY b LIMIT 10;
 -- { echoOff }
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Fixes flaky `02813_optimize_lazy_materialization` (`Stateless tests`).

The `map data type` subtest did `SELECT * FROM ...with_map_data_type ORDER BY b LIMIT 10` and compared the whole `Map(String, UInt64)` column against a reference assuming insertion key order. CI randomizes `map_serialization_version` to `with_buckets`, which stores map keys in hash-bucket order, not insertion order (keys are distributed by `hash(key) % num_buckets` and read back bucket-by-bucket). The query then returns `{'key2':2,'key1':1}` and diverges from the reference.

Deterministic reproducer (table SETTINGS): `map_serialization_version='with_buckets', map_serialization_version_for_zero_level_parts='with_buckets', map_buckets_strategy='linear', map_buckets_coefficient=1.87, map_buckets_min_avg_size=1`.

Key reordering is an intended property of bucketed map serialization and is independent of lazy materialization: it reproduces with `query_plan_optimize_lazy_materialization=0` and with a plain `SELECT c`.

Wrap the Map column with `mapSort()` to normalize key order, matching the fix already used for other map-bucket flaky tests (02169, 01872, 04060). This keeps the bucketed serialization path exercised under CI randomization instead of pinning the setting.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.668`
<!-- ch-version-info:end -->