### PR TITLE
Fix Bad cast crash for qualified asterisk over a JOIN USING key

### DIFF
--- a/src/Analyzer/Resolve/QueryAnalyzer.cpp
+++ b/src/Analyzer/Resolve/QueryAnalyzer.cpp
@@ -1792,10 +1792,16 @@ QueryAnalyzer::QueryTreeNodesWithNames QueryAnalyzer::getMatchedColumnNodesWithN
 
 /// Columns that resolved from matcher can also match columns from JOIN USING.
 /// In that case we update type to type of column in USING section.
-/// TODO: It's not completely correct for qualified matchers, so t1.* should be resolved to left table column type.
-/// But in planner we do not distinguish such cases.
+///
+/// Unqualified matcher (`*`): the matched column IS the merged USING key, so it takes the
+/// key type as-is. Qualified matcher (`t.*`): the matched column is `t`'s own column, so its
+/// type must equal what the explicit reference `t.col` resolves to. The merged key's type is
+/// not correct here: in a nested JOIN it reflects the outer join's other side, while `t.col`
+/// only follows the joins `t` participates in.
 void QueryAnalyzer::updateMatchedColumnsFromJoinUsing(
     QueryTreeNodesWithNames & result_matched_column_nodes_with_names,
+    bool is_qualified_matcher,
+    const Identifier & matched_qualified_identifier,
     IdentifierResolveScope & scope)
 {
     auto * nearest_query_scope = scope.getNearestQueryScope();
@@ -1846,12 +1852,32 @@ void QueryAnalyzer::updateMatchedColumnsFromJoinUsing(
                     }
                 }
 
+                auto using_column_type = join_using_column_node.getResultType();
+
+                /// Qualified matcher: the matched column is `t.col`, NOT the merged USING key.
+                /// Resolve the explicit identifier `t.col` and adopt its type, exactly matching
+                /// how an explicit reference is typed (IdentifierResolver::tryResolveIdentifierFromJoin).
+                /// The merged key's type is wrong here: in a nested JOIN it reflects the OUTER
+                /// join's siblings, while `t.col` only follows the joins `t` participates in.
+                if (is_qualified_matcher)
+                {
+                    Identifier explicit_identifier = matched_qualified_identifier;
+                    explicit_identifier.push_back(matched_column_name);
+                    auto explicit_lookup = IdentifierLookup{explicit_identifier, IdentifierLookupContext::EXPRESSION};
+                    IdentifierResolveContext explicit_resolve_settings;
+                    explicit_resolve_settings.allow_to_check_cte = false;
+                    explicit_resolve_settings.allow_to_check_database_catalog = false;
+                    auto explicit_resolve_result = tryResolveIdentifier(explicit_lookup, scope, explicit_resolve_settings);
+                    if (explicit_resolve_result.resolved_identifier)
+                        using_column_type = explicit_resolve_result.resolved_identifier->getResultType();
+                }
+
                 auto it = node_to_projection_name.find(matched_column_node);
                 matched_column_node = matched_column_node->clone();
                 if (it != node_to_projection_name.end())
                     node_to_projection_name.emplace(matched_column_node, it->second);
 
-                matched_column_node->as<ColumnNode &>().setColumnType(join_using_column_node.getResultType());
+                matched_column_node->as<ColumnNode &>().setColumnType(using_column_type);
                 correctColumnExpressionType(matched_column_node->as<ColumnNode &>(), scope.context);
                 if (!matched_column_node->isEqual(*join_using_column_nodes.at(0)))
                     scope.join_columns_with_changed_types[matched_column_node] = join_using_column_nodes.at(0);
@@ -2012,7 +2038,8 @@ QueryAnalyzer::QueryTreeNodesWithNames QueryAnalyzer::resolveQualifiedMatcher(Qu
         matched_columns,
         scope);
 
-    updateMatchedColumnsFromJoinUsing(result_matched_column_nodes_with_names, scope);
+    updateMatchedColumnsFromJoinUsing(
+        result_matched_column_nodes_with_names, /*is_qualified_matcher=*/ true, matcher_node_typed.getQualifiedIdentifier(), scope);
 
     return result_matched_column_nodes_with_names;
 }
@@ -2267,7 +2294,7 @@ QueryAnalyzer::QueryTreeNodesWithNames QueryAnalyzer::resolveUnqualifiedMatcher(
             table_expression_columns,
             scope);
 
-        updateMatchedColumnsFromJoinUsing(matched_column_nodes_with_names, scope);
+        updateMatchedColumnsFromJoinUsing(matched_column_nodes_with_names, /*is_qualified_matcher=*/ false, {}, scope);
 
         table_expressions_column_nodes_with_names_stack.push_back(std::move(matched_column_nodes_with_names));
     }

--- a/src/Analyzer/Resolve/QueryAnalyzer.h
+++ b/src/Analyzer/Resolve/QueryAnalyzer.h
@@ -230,7 +230,7 @@ private:
         const NamesAndTypes & matched_columns,
         IdentifierResolveScope & scope);
 
-    void updateMatchedColumnsFromJoinUsing(QueryTreeNodesWithNames & result_matched_column_nodes_with_names, IdentifierResolveScope & scope);
+    void updateMatchedColumnsFromJoinUsing(QueryTreeNodesWithNames & result_matched_column_nodes_with_names, bool is_qualified_matcher, const Identifier & matched_qualified_identifier, IdentifierResolveScope & scope);
 
     QueryTreeNodesWithNames resolveQualifiedMatcher(QueryTreeNodePtr & matcher_node, IdentifierResolveScope & scope);
 

--- a/tests/queries/0_stateless/04329_qualified_asterisk_join_using_nullable_key.reference
+++ b/tests/queries/0_stateless/04329_qualified_asterisk_join_using_nullable_key.reference
@@ -1,0 +1,13 @@
+1
+1
+UInt64
+Int64
+Nullable(Int64)
+Int64
+1
+1
+1
+1
+1
+Nullable(UInt64)
+1

--- a/tests/queries/0_stateless/04329_qualified_asterisk_join_using_nullable_key.sql
+++ b/tests/queries/0_stateless/04329_qualified_asterisk_join_using_nullable_key.sql
@@ -1,0 +1,116 @@
+-- A qualified matcher (`t.*`) over a JOIN USING key must keep the matched column's own
+-- type, not the merged key's. Otherwise it can wrongly become Nullable (join_use_nulls = 0,
+-- outer JOIN against a Nullable key) and an aggregate over it aborts with
+-- "Bad cast from type DB::IColumn const* to DB::ColumnNullable const*".
+
+DROP TABLE IF EXISTS t_jn1;
+DROP TABLE IF EXISTS t_jn2;
+DROP TABLE IF EXISTS t_jn3;
+
+CREATE TABLE t_jn1 (id UInt64, value String) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t_jn2 (id UInt64, value String) ENGINE = MergeTree ORDER BY tuple();
+CREATE TABLE t_jn3 (id Nullable(UInt64), value String) ENGINE = MergeTree ORDER BY tuple() SETTINGS allow_nullable_key = 1;
+
+INSERT INTO t_jn1 VALUES (0, 'a'), (1, 'b'), (2, 'c');
+INSERT INTO t_jn2 VALUES (0, 'd'), (1, 'e'), (3, 'f');
+INSERT INTO t_jn3 VALUES (0, 'g'), (2, 'h'), (4, 'i');
+
+SET enable_analyzer = 1;
+
+-- The aggregation over the qualified matcher used to crash the server.
+SELECT count() FROM
+(
+    SELECT anyHeavy(sipHash64(t2.*))
+    FROM t_jn1 LEFT JOIN t_jn2 AS t2 USING (id) GLOBAL RIGHT JOIN t_jn3 USING (id)
+)
+SETTINGS join_use_nulls = 0;
+
+-- With join_use_nulls = 0 the qualified-matcher column must have the same type as the
+-- explicit reference: the join does not make the data Nullable, so neither must the type.
+SELECT toTypeName(sipHash64(t2.*)) = toTypeName(sipHash64(t2.id, t2.value))
+FROM t_jn1 LEFT JOIN t_jn2 AS t2 USING (id) RIGHT JOIN t_jn3 USING (id)
+LIMIT 1
+SETTINGS join_use_nulls = 0;
+
+SELECT toTypeName(t2.id)
+FROM t_jn1 LEFT JOIN t_jn2 AS t2 USING (id) RIGHT JOIN t_jn3 USING (id)
+LIMIT 1
+SETTINGS join_use_nulls = 0;
+
+-- The qualified matcher still adopts the common supertype of the USING key, and still
+-- becomes Nullable when the join does make the data Nullable.
+SELECT toTypeName(t1.a)
+FROM (SELECT 1 :: Int32 AS a) AS t1 INNER JOIN (SELECT 1 :: UInt32 AS a) AS t2 USING (a)
+SETTINGS join_use_nulls = 0;
+
+SELECT toTypeName(t2.a)
+FROM (SELECT 1 :: Int32 AS a) AS t1 LEFT JOIN (SELECT 2 :: UInt32 AS a) AS t2 USING (a)
+SETTINGS join_use_nulls = 1;
+
+SELECT toTypeName(t1.a)
+FROM (SELECT 1 :: Int32 AS a) AS t1 RIGHT JOIN (SELECT 2 :: UInt32 AS a) AS t2 USING (a)
+SETTINGS join_use_nulls = 0;
+
+-- USING can widen the value type along axes other than nullability (e.g. UInt8 -> Int64 or
+-- Decimal(9,2) -> Decimal(18,4)). The qualified matcher must take that supertype for the
+-- value, exactly like the explicit reference does, so these equalities must hold.
+SELECT toTypeName(sipHash64(t1.*)) = toTypeName(sipHash64(t1.a))
+FROM (SELECT 1 :: UInt8 AS a) AS t1 LEFT JOIN (SELECT 1 :: Int64 AS a) AS t2 USING (a)
+LIMIT 1
+SETTINGS join_use_nulls = 0;
+
+SELECT toTypeName(sipHash64(t1.*)) = toTypeName(sipHash64(t1.a))
+FROM (SELECT 1 :: UInt8 AS a) AS t1 RIGHT JOIN (SELECT 1 :: Int64 AS a) AS t2 USING (a)
+LIMIT 1
+SETTINGS join_use_nulls = 1;
+
+SELECT toTypeName(sipHash64(t1.*)) = toTypeName(sipHash64(t1.a))
+FROM (SELECT 1 :: Decimal(9, 2) AS a) AS t1 LEFT JOIN (SELECT 1 :: Decimal(18, 4) AS a) AS t2 USING (a)
+LIMIT 1
+SETTINGS join_use_nulls = 0;
+
+-- Aggregating over a qualified matcher whose USING key both widens (UInt8 -> Int64) and
+-- gains nullability on the other side must not crash with join_use_nulls = 0.
+SELECT count() FROM
+(
+    SELECT anyHeavy(sipHash64(t1.*))
+    FROM (SELECT 1 :: UInt8 AS a, 'x' AS v) AS t1 GLOBAL RIGHT JOIN (SELECT 1 :: Int64 AS a) AS t2 USING (a)
+)
+SETTINGS join_use_nulls = 0;
+
+-- The qualified-matcher column belongs to the inner JOIN it participates in, not the outer
+-- USING key. When a sibling USING table is Nullable, the inner-merged key (and the runtime
+-- column) is Nullable, so the matcher type must be Nullable too, matching the explicit
+-- reference. The matcher used to wrongly take the matched column's own (non-Nullable) type,
+-- and an `-OrNull` aggregate over it aborted with the opposite Bad cast
+-- "from type DB::ColumnNullable to DB::ColumnVector<unsigned long>".
+DROP TABLE IF EXISTS t_jn1_nullable;
+DROP TABLE IF EXISTS t_jn3_nullable;
+CREATE TABLE t_jn1_nullable (id Nullable(UInt64), value String) ENGINE = MergeTree ORDER BY tuple() SETTINGS allow_nullable_key = 1;
+CREATE TABLE t_jn3_nullable (id Nullable(UInt64), value String) ENGINE = MergeTree ORDER BY tuple() SETTINGS allow_nullable_key = 1;
+INSERT INTO t_jn1_nullable VALUES (0, 'a'), (1, 'b'), (2, 'c');
+INSERT INTO t_jn3_nullable VALUES (0, 'g'), (2, 'h'), (4, 'i');
+
+SELECT toTypeName(sipHash64(t2.*)) = toTypeName(sipHash64(t2.id, t2.value))
+FROM t_jn1_nullable LEFT JOIN t_jn2 AS t2 USING (id) RIGHT JOIN t_jn3_nullable USING (id)
+LIMIT 1
+SETTINGS join_use_nulls = 0;
+
+SELECT toTypeName(t2.id)
+FROM t_jn1_nullable LEFT JOIN t_jn2 AS t2 USING (id) RIGHT JOIN t_jn3_nullable USING (id)
+LIMIT 1
+SETTINGS join_use_nulls = 0;
+
+SELECT count() FROM
+(
+    SELECT anyHeavyOrNull(sipHash64(t2.*))
+    FROM t_jn1_nullable LEFT JOIN t_jn2 AS t2 USING (id) GLOBAL RIGHT JOIN t_jn3_nullable USING (id)
+)
+SETTINGS join_use_nulls = 0;
+
+DROP TABLE t_jn1_nullable;
+DROP TABLE t_jn3_nullable;
+
+DROP TABLE t_jn1;
+DROP TABLE t_jn2;
+DROP TABLE t_jn3;


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

-->


### Changelog category (leave one):
- Bug Fix (user-visible misbehavior in an official stable release)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
Fix a `Bad cast from type DB::IColumn const* to DB::ColumnNullable const*` logical error / crash when a qualified asterisk (`t.*`) over a `JOIN ... USING` key is passed to an aggregate function and the other side of an outer JOIN has a `Nullable` key (with `join_use_nulls = 0`).


### Description

Found by the AST fuzzer: `AST fuzzer (amd_debug)`, STID `3524-3f17`, report
https://s3.amazonaws.com/clickhouse-test-reports/json.html?PR=104625&sha=79737e37a9f5cc4c525fbadef72b35ce8349c871&name_0=PR&name_1=AST%20fuzzer%20%28amd_debug%29

Reproducer:

```sql
CREATE TABLE j1 (id UInt64, value String) ENGINE = MergeTree ORDER BY tuple();
CREATE TABLE j2 (id UInt64, value String) ENGINE = MergeTree ORDER BY tuple();
CREATE TABLE j3 (id Nullable(UInt64), value String) ENGINE = MergeTree ORDER BY tuple() SETTINGS allow_nullable_key = 1;

SELECT anyHeavy(sipHash64(t2.*))
FROM j1 LEFT JOIN j2 AS t2 USING (id) RIGHT JOIN j3 USING (id)
SETTINGS join_use_nulls = 0;  -- aborts: Bad cast from type DB::IColumn const* to DB::ColumnNullable const*
```

Crash path: `AggregateFunctionNullUnary<true, true>::addBatchSinglePlace`
(`AggregateFunctionNull.h:442`) <- `Aggregator::executeWithoutKeyImpl`
(`Aggregator.cpp`) <- `AggregatingTransform::consume`.

Root cause is in the analyzer. When a qualified matcher (`t2.*`) matches a
`JOIN USING` key, `updateMatchedColumnsFromJoinUsing` overrode the matched
column's type with the merged USING-key type. That type is the common
supertype of the joined keys and, for an outer JOIN, can be `Nullable`
because the other side's key is natively `Nullable`. With `join_use_nulls = 0`
the data the planner produces for `t2.id` stays plain (non-`Nullable`), so the
query tree typed `sipHash64(t2.*)` as `Nullable(UInt64)` while the actual
column is plain `UInt64`. The aggregate function `anyHeavy` was therefore built
with the `Null` combinator (expecting a `ColumnNullable` argument) but received
the plain column at runtime, and `assert_cast<const ColumnNullable *>` aborted.
The existing code carried a `TODO` noting this was "not completely correct for
qualified matchers".

Fix: for a qualified matcher keep the USING-key supertype but preserve the
matched column's own nullability (do not declare a column `Nullable` that the
planner keeps plain). Unqualified matcher (`*`) behaviour, where the matched
column genuinely is the merged key, is unchanged. Added a stateless regression
test that crashes on master and passes with the fix, and that also checks the
supertype-coalescing and `join_use_nulls = 1` cases still resolve as before.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.1074`
<!-- ch-version-info:end -->