### PR TITLE
Fix flaky test test_kafka_read_consumers_in_parallel on slow builds

### DIFF
--- a/tests/integration/test_storage_kafka/test_batch_fast.py
+++ b/tests/integration/test_storage_kafka/test_batch_fast.py
@@ -587,10 +587,23 @@ def test_kafka_read_consumers_in_parallel(kafka_cluster):
         """
     )
 
+    # Parallel reading of 8 consumers reaches 64 polls in ~8s; sequential reading
+    # is gated by kafka_poll_timeout_ms=1000 to ~1 poll/sec, so it cannot reach 64
+    # polls in under ~64s on any build. Slow builds (sanitizer/coverage/debug)
+    # inflate the parallel path's wall-clock well past 30s under CI batch load, so
+    # use a larger timeout there while staying below the ~64s sequential floor that
+    # would catch a regression to sequential reads.
+    poll_timeout = (
+        60
+        if instance.is_built_with_sanitizer()
+        or instance.is_built_with_llvm_coverage()
+        or instance.is_debug_build()
+        else 30
+    )
     instance.wait_for_log_line(
         f"{kafka_table}.*Polled batch of [0-9]+.*read_consumers_in_parallel",
         repetitions=64,
-        timeout=30,  # we should get 64 polls in ~8 seconds, but when read sequentially it will take more than 64 sec
+        timeout=poll_timeout,
     )
 
     cancel.set()


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

No related open issue found.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Fixes the chronic flaky integration test
`test_storage_kafka/test_batch_fast.py::test_kafka_read_consumers_in_parallel`.

The test verifies that 8 Kafka consumers with `kafka_thread_per_consumer=0`
read in parallel rather than sequentially. It does so by timing: it waits for
64 "Polled batch" log lines. With parallel reads they appear in ~8s; with
sequential reads each poll is gated by `kafka_poll_timeout_ms=1000` so 64 polls
take >64s. The fixed `timeout=30` sits between these.

That 30s budget was calibrated for fast (binary/debug) builds. On slow builds
(sanitizer/coverage) under CI batch load the parallel path's wall-clock for 64
polls exceeds 30s, so the wait times out mid-accumulation and the test fails
with "Not enough repetitions: 49 found, while 64 expected". All observed
failures are on slow builds (msan/asan/tsan/coverage); none on binary/debug.

Fix: scale the timeout to 60s on sanitizer/coverage/debug builds, keeping it
below the ~64s sequential floor so a regression to sequential reads is still
caught.

Measured locally (ASAN): parallel 8 consumers reach 64 polls in ~16.6s;
sequential 1 consumer takes ~77.5s. Validated both directions under ASAN: the
test passes with 8 consumers (60s branch) and still fails when forced to a
single consumer (53/64 in 60s).

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.956`
<!-- ch-version-info:end -->