### PR TITLE
Fix flaky test_refreshable_mv_in_replicated_db

### DIFF
--- a/tests/integration/test_refreshable_mv/test.py
+++ b/tests/integration/test_refreshable_mv/test.py
@@ -42,6 +42,17 @@ nodes = [node1, node2]
 test_idx = 0
 
 
+def wait_until_view_registered(node, name):
+    # `system sync database replica` doesn't wait for the replicated view's startup() to
+    # register its refresh task, so the SYSTEM *VIEW commands below can race with it.
+    assert_eq_with_retry(
+        node,
+        f"select count() from system.view_refreshes where database = 're' and view = '{name}'",
+        "1\n",
+        retry_count=60,
+    )
+
+
 @pytest.fixture(scope="module")
 def started_cluster():
     try:
@@ -83,6 +94,7 @@ def test_refreshable_mv_in_replicated_db(started_cluster, cleanup):
     )
     node1.query("system sync database replica re")
     for node in nodes:
+        wait_until_view_registered(node, "a")
         node.query("system wait view re.a")
         assert node.query("select * from re.a order by all") == "0\n10\n"
         assert (
@@ -101,8 +113,10 @@ def test_refreshable_mv_in_replicated_db(started_cluster, cleanup):
         )
         # Stop the clocks.
         for node in nodes:
+            node.query("system sync database replica re")
+            wait_until_view_registered(node, name)
             node.query(
-                f"system sync database replica re; system test view re.{name} set fake time '2040-01-01 00:00:01'"
+                f"system test view re.{name} set fake time '2040-01-01 00:00:01'"
             )
         # Wait for quiescence.
         for node in nodes:
@@ -140,6 +154,7 @@ def test_refreshable_mv_in_replicated_db(started_cluster, cleanup):
     )
     node2.query("system sync database replica re")
     for node in nodes:
+        wait_until_view_registered(node, "unreplicated_uncoordinated")
         node.query("system wait view re.unreplicated_uncoordinated")
         assert (
             node.query("select distinct x from re.unreplicated_uncoordinated") == "1\n"


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...


### Description

Fixes chronic flakiness of `test_refreshable_mv/test.py::test_refreshable_mv_in_replicated_db`.

The test fails intermittently with:

```
Code: 36. DB::Exception: Refreshable view re.<name> (<uuid>) doesn't exist.
  InterpreterSystemQuery::getRefreshTasks()
```

right after a `SYSTEM SYNC DATABASE REPLICA re`, on `SYSTEM WAIT VIEW` / `SYSTEM TEST VIEW`.

Root cause: when a Replicated database replica applies the replicated `CREATE MATERIALIZED VIEW` log entry, the ZooKeeper `log_ptr` node is written as part of the metadata transaction that is committed inside `database->createTable()`, before `IStorage::startup()` runs. The refresh task is only registered into the `RefreshSet` later, in `StorageMaterializedView::startup()` -> `RefreshTask::startup()`. `SYSTEM SYNC DATABASE REPLICA` waits only for the log pointer, so it can return before the refresh task is registered. A following `SYSTEM WAIT/TEST/REFRESH VIEW` then calls `getRefreshTasks()`, finds nothing in the `RefreshSet`, and throws `BAD_ARGUMENTS`. The same file already documents this (`system sync database replica` does not guarantee a replicated object is fully initialized).

Fix is test-side only: after `SYSTEM SYNC DATABASE REPLICA`, wait until the view is registered (visible in `system.view_refreshes`) before issuing `SYSTEM *VIEW` commands. `system.view_refreshes` lists whatever is in the `RefreshSet` and never throws for a missing view, so it is a safe barrier. No assertions are weakened and no settings are pinned.

Reproduced deterministically by setting the existing debug server setting `startup_mv_delay_ms` high (it sleeps in `StorageMaterializedView::startup()` before registering the refresh task): the test fails reliably without this change and passes with it. Validated with the default config as well.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.684`
<!-- ch-version-info:end -->