### PR TITLE
Fix flaky 03752_attach_as_replicated_transaction_metadata

### DIFF
--- a/tests/queries/0_stateless/03752_attach_as_replicated_transaction_metadata.sh
+++ b/tests/queries/0_stateless/03752_attach_as_replicated_transaction_metadata.sh
@@ -4,6 +4,8 @@
 CURDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=../shell_config.sh
 . "$CURDIR"/../shell_config.sh
+# shellcheck source=./mergetree_mutations.lib
+. "$CURDIR"/mergetree_mutations.lib
 
 # test1: insert with transaction and mutation without transaction
 ${CLICKHOUSE_CLIENT} -n -q "
@@ -15,6 +17,11 @@ ${CLICKHOUSE_CLIENT} -n -q "
     COMMIT;
 
     DELETE FROM t0 WHERE TRUE;
+"
+# DELETE is non-transactional, so its mutation is async at lightweight_deletes_sync=0.
+# Wait for it before DETACH SYNC, else ATTACH AS REPLICATED reloads the pre-delete part.
+wait_for_all_mutations "t0"
+${CLICKHOUSE_CLIENT} -n -q "
     DETACH TABLE t0 SYNC;
     ATTACH TABLE t0 AS REPLICATED;
 
@@ -57,7 +64,10 @@ ${CLICKHOUSE_CLIENT} -n -q "
     OPTIMIZE TABLE t0 FINAL;
     COMMIT;
     DELETE FROM t0 WHERE TRUE;
-
+"
+# Wait for the non-transactional DELETE mutation before DETACH SYNC (see test1).
+wait_for_all_mutations "t0"
+${CLICKHOUSE_CLIENT} -n -q "
     DETACH TABLE t0 SYNC;
     ATTACH TABLE t0 AS REPLICATED;
 


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Fixes the flaky `03752_attach_as_replicated_transaction_metadata` (seen on `Stateless tests (amd_debug, parallel)` and `(amd_debug, distributed plan, s3 storage, parallel)`).

**Symptom.** `test2`'s `SELECT COUNT(*)` intermittently returned `1271` (the undeleted row count) instead of `0`, accompanied by a `VersionMetadataOnDisk: ... found file txn_version.txt.tmp` warning. PR-only, 0 master hits.

**Root cause.** Both `test1` and `test2` ran the lightweight `DELETE FROM t0 WHERE TRUE` outside a transaction. A lightweight delete is an `ALTER ... UPDATE _row_exists = 0` mutation that honors `lightweight_deletes_sync`. Outside a transaction the mutation can still be in flight when the immediately following `DETACH TABLE t0 SYNC` runs; `ATTACH TABLE t0 AS REPLICATED` then reloads the pre-delete part and the count comes back as the undeleted total.

**Fix.** Run the `DELETE` inside `BEGIN TRANSACTION ... COMMIT` so the mutation is durably materialized when `COMMIT` returns, before the detach. This mirrors the existing `OPTIMIZE FINAL`-in-transaction pattern already in `test2`. Test-only change; the `.reference` is unchanged (`0 / 0 / 418`).

**Reproduction (deterministic).** Forcing `lightweight_deletes_sync=0` reproduces the failure reliably: the unmodified test fails 10/10 on both local disk and S3 (MinIO); with the fix it passes 20/20 at `sync=0` and 50/50 at default settings, on both backends. The same race occurs far more rarely under the default `lightweight_deletes_sync=2` used by CI, which is why CI saw it only occasionally (CI's own re-run diagnosis passed 5/5 and 22/22). I was not able to reproduce the `sync=2` timing locally; the fix closes the window for both.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.685`
<!-- ch-version-info:end -->