### PR TITLE
Fix flaky test 02346_text_index_queries

### DIFF
--- a/tests/queries/0_stateless/02346_text_index_queries.reference
+++ b/tests/queries/0_stateless/02346_text_index_queries.reference
@@ -17,6 +17,7 @@ af	text
 106	x Alick a06 y
 111	x Alick b01 y
 116	x Alick b06 y
+1
 101	x Alick a01 y
 106	x Alick a06 y
 1

--- a/tests/queries/0_stateless/02346_text_index_queries.sql
+++ b/tests/queries/0_stateless/02346_text_index_queries.sql
@@ -1,7 +1,8 @@
-SET log_queries = 1;
+-- Tags: no-parallel-replicas
+
 SET merge_tree_read_split_ranges_into_intersecting_and_non_intersecting_injection_probability = 0.0;
 
--- Affects the number of read rows.
+-- Affects the number of estimated rows.
 SET use_skip_indexes_on_data_read = 0;
 
 ----------------------------------------------------
@@ -23,42 +24,18 @@ CHECK TABLE tab SETTINGS check_query_single_value_result = 1;
 
 -- search text index with ==
 SELECT * FROM tab WHERE s == 'Alick a01';
-
--- check the query only read 1 granules (2 rows total; each granule has 2 rows)
-SYSTEM FLUSH LOGS query_log;
-SELECT read_rows==2 from system.query_log
-        WHERE event_date >= yesterday() AND event_time >= now() - 600 AND query_kind ='Select'
-            AND current_database = currentDatabase()
-            AND endsWith(trimRight(query), 'SELECT * FROM tab WHERE s == \'Alick a01\';')
-            AND type='QueryFinish'
-            AND result_rows==1
-        LIMIT 1;
+-- check the query only read 1 granule (2 rows total; each granule has 2 rows)
+SELECT sum(rows) == 2 FROM (EXPLAIN ESTIMATE SELECT * FROM tab WHERE s == 'Alick a01');
 
 -- search text index with LIKE
 SELECT * FROM tab WHERE s LIKE '%01%' ORDER BY k;
-
 -- check the query only read 2 granules (4 rows total; each granule has 2 rows)
-SYSTEM FLUSH LOGS query_log;
-SELECT read_rows==4 from system.query_log
-        WHERE event_date >= yesterday() AND event_time >= now() - 600 AND query_kind ='Select'
-            AND current_database = currentDatabase()
-            AND endsWith(trimRight(query), 'SELECT * FROM tab WHERE s LIKE \'%01%\' ORDER BY k;')
-            AND type='QueryFinish'
-            AND result_rows==2
-        LIMIT 1;
+SELECT sum(rows) == 4 FROM (EXPLAIN ESTIMATE SELECT * FROM tab WHERE s LIKE '%01%' ORDER BY k);
 
 -- search text index with hasToken
 SELECT * FROM tab WHERE hasToken(s, 'Click') ORDER BY k;
-
 -- check the query only read 4 granules (8 rows total; each granule has 2 rows)
-SYSTEM FLUSH LOGS query_log;
-SELECT read_rows==8 from system.query_log
-        WHERE event_date >= yesterday() AND event_time >= now() - 600 AND query_kind ='Select'
-            AND current_database = currentDatabase()
-            AND endsWith(trimRight(query), 'SELECT * FROM tab WHERE hasToken(s, \'Click\') ORDER BY k;')
-            AND type='QueryFinish'
-            AND result_rows==4
-        LIMIT 1;
+SELECT sum(rows) == 8 FROM (EXPLAIN ESTIMATE SELECT * FROM tab WHERE hasToken(s, 'Click') ORDER BY k);
 
 ----------------------------------------------------
 SELECT 'Test text(tokenizer = "splitByNonAlpha")';
@@ -76,29 +53,13 @@ SELECT name, type FROM system.data_skipping_indices WHERE table == 'tab_x' AND d
 
 -- search text index with hasToken
 SELECT * FROM tab_x WHERE hasToken(s, 'Alick') ORDER BY k;
-
 -- check the query only read 4 granules (8 rows total; each granule has 2 rows)
-SYSTEM FLUSH LOGS query_log;
-SELECT read_rows==8 from system.query_log
-    WHERE event_date >= yesterday() AND event_time >= now() - 600 AND query_kind ='Select'
-        AND current_database = currentDatabase()
-        AND endsWith(trimRight(query), 'SELECT * FROM tab_x WHERE hasToken(s, \'Alick\');')
-        AND type='QueryFinish'
-        AND result_rows==4
-    LIMIT 1;
+SELECT sum(rows) == 8 FROM (EXPLAIN ESTIMATE SELECT * FROM tab_x WHERE hasToken(s, 'Alick') ORDER BY k);
 
 -- search text index with IN operator
 SELECT * FROM tab_x WHERE s IN ('x Alick a01 y', 'x Alick a06 y') ORDER BY k;
-
 -- check the query only read 2 granules (4 rows total; each granule has 2 rows)
-SYSTEM FLUSH LOGS query_log;
-SELECT read_rows==4 from system.query_log
-    WHERE event_date >= yesterday() AND event_time >= now() - 600 AND query_kind ='Select'
-        AND current_database = currentDatabase()
-        AND endsWith(trimRight(query), 'SELECT * FROM tab_x WHERE s IN (\'x Alick a01 y\', \'x Alick a06 y\') ORDER BY k;')
-        AND type='QueryFinish'
-        AND result_rows==2
-    LIMIT 1;
+SELECT sum(rows) == 4 FROM (EXPLAIN ESTIMATE SELECT * FROM tab_x WHERE s IN ('x Alick a01 y', 'x Alick a06 y') ORDER BY k);
 
 ----------------------------------------------------
 SELECT 'Test text(tokenizer = ngrams(2)) on a column with two parts';
@@ -121,16 +82,8 @@ SELECT name, type FROM system.data_skipping_indices WHERE table == 'tab' AND dat
 
 -- search text index
 SELECT * FROM tab WHERE s LIKE '%01%' ORDER BY k;
-
 -- check the query only read 3 granules (6 rows total; each granule has 2 rows)
-SYSTEM FLUSH LOGS query_log;
-SELECT read_rows==6 from system.query_log
-    WHERE event_date >= yesterday() AND event_time >= now() - 600 AND query_kind ='Select'
-        AND current_database = currentDatabase()
-        AND endsWith(trimRight(query), 'SELECT * FROM tab WHERE s LIKE \'%01%\' ORDER BY k;')
-        AND type='QueryFinish'
-        AND result_rows==3
-    LIMIT 1;
+SELECT sum(rows) == 6 FROM (EXPLAIN ESTIMATE SELECT * FROM tab WHERE s LIKE '%01%' ORDER BY k);
 
 ----------------------------------------------------
 SELECT 'Test text(tokenizer = ngrams(2)) on UTF-8 data';
@@ -149,16 +102,8 @@ SELECT name, type FROM system.data_skipping_indices WHERE table == 'tab' AND dat
 
 -- search text index
 SELECT * FROM tab WHERE s LIKE '%你好%' ORDER BY k;
-
 -- check the query only read 1 granule (2 rows total; each granule has 2 rows)
-SYSTEM FLUSH LOGS query_log;
-SELECT read_rows==2 from system.query_log
-    WHERE event_date >= yesterday() AND event_time >= now() - 600 AND query_kind ='Select'
-        AND current_database = currentDatabase()
-        AND endsWith(trimRight(query), 'SELECT * FROM tab WHERE s LIKE \'%你好%\' ORDER BY k;')
-        AND type='QueryFinish'
-        AND result_rows==1
-    LIMIT 1;
+SELECT sum(rows) == 2 FROM (EXPLAIN ESTIMATE SELECT * FROM tab WHERE s LIKE '%你好%' ORDER BY k);
 
 ----------------------------------------------------
 SELECT 'Test text(tokenizer = sparseGrams(3, 100)) on UTF-8 data';
@@ -177,16 +122,8 @@ SELECT name, type FROM system.data_skipping_indices WHERE table == 'tab' AND dat
 
 -- search text index
 SELECT * FROM tab WHERE s LIKE '%house你好%' ORDER BY k;
-
 -- check the query only read 1 granule (2 rows total; each granule has 2 rows)
-SYSTEM FLUSH LOGS query_log;
-SELECT read_rows==2 from system.query_log
-    WHERE event_date >= yesterday() AND event_time >= now() - 600 AND query_kind ='Select'
-        AND current_database = currentDatabase()
-        AND endsWith(trimRight(query), 'SELECT * FROM tab WHERE s LIKE \'%你好%\' ORDER BY k;')
-        AND type='QueryFinish'
-        AND result_rows==1
-    LIMIT 1;
+SELECT sum(rows) == 2 FROM (EXPLAIN ESTIMATE SELECT * FROM tab WHERE s LIKE '%house你好%' ORDER BY k);
 
 ----------------------------------------------------
 SELECT 'Test text(tokenizer = sparseGrams(3, 100, 4)) on UTF-8 data';
@@ -205,13 +142,5 @@ SELECT name, type FROM system.data_skipping_indices WHERE table == 'tab' AND dat
 
 -- search text index
 SELECT * FROM tab WHERE s LIKE '%house你好%' ORDER BY k;
-
 -- check the query only read 1 granule (2 rows total; each granule has 2 rows)
-SYSTEM FLUSH LOGS query_log;
-SELECT read_rows==2 from system.query_log
-    WHERE event_date >= yesterday() AND event_time >= now() - 600 AND query_kind ='Select'
-        AND current_database = currentDatabase()
-        AND endsWith(trimRight(query), 'SELECT * FROM tab WHERE s LIKE \'%你好%\' ORDER BY k;')
-        AND type='QueryFinish'
-        AND result_rows==1
-    LIMIT 1;
+SELECT sum(rows) == 2 FROM (EXPLAIN ESTIMATE SELECT * FROM tab WHERE s LIKE '%house你好%' ORDER BY k);


### PR DESCRIPTION
<!--
Linked issues and pull requests. Use full GitHub URLs, one relationship per line; delete the lines you don't need.

Related: https://github.com/ClickHouse/ClickHouse/issues/104923
-->


### Changelog category (leave one):
- CI Fix or Improvement (changelog entry is not required)


### Changelog entry (a [user-readable short description](https://github.com/ClickHouse/ClickHouse/blob/master/docs/changelog_entry_guidelines.md) of the changes that goes into CHANGELOG.md):
...

### Description

Related: #104923

`02346_text_index_queries` was flaky (timeout on the slow `amd_msan, WasmEdge, parallel` lane) because it ran 9 `SYSTEM FLUSH LOGS query_log` calls plus 9 full `system.query_log` scans to read `read_rows` per query.

Replace each `query_log` probe with `EXPLAIN ESTIMATE` on the same query and assert the estimated rows. `EXPLAIN ESTIMATE` reports the granule count the index analysis selects (it honors `use_skip_indexes_on_data_read = 0`, already pinned), so the per-tokenizer pruning contract is still verified, but with no log flush and no full scan. Each assertion now targets its own query.

This also fixes 3 probes whose predicate did not match their own query, per the bot review:
- the `splitByNonAlpha` `hasToken('Alick')` probe filtered the query without `ORDER BY k`, so it matched no log row and never ran (the reference gains the missing `1`);
- both `sparseGrams` probes filtered `%你好%` while executing `%house你好%`, so they could pass by reading the earlier `ngrams` query's log row.

Dropped `no-parallel` (no global flush/scan cost remains to move to the sequential pool); kept `no-parallel-replicas` since the granule estimate is single-node.

Verified locally: assertion returns `1` with pruning and `0` when pruning is forced off (regression caught); 50/50 runs pass with randomized settings, ~0.5s each.

<!-- ch-version-info:start -->
### Version info
- Merged into: `26.6.1.680`
<!-- ch-version-info:end -->